### PR TITLE
Save 'SentStatus' more reliably

### DIFF
--- a/agent/eventhandler/handler.go
+++ b/agent/eventhandler/handler.go
@@ -22,11 +22,9 @@ import (
 
 var log = logger.ForModule("eventhandler")
 
-// statemanager should always be set before calling AddTaskEvent
-// TODO, use statemanager to store whether or not we have sent an event and do a
-// limited cache of events we have sent so we know we don't need to send some
-// event again.
-var statesaver statemanager.Saver
+// statesaver is a package-wise statemanager which may be used to save any
+// changes to a task or container's SentStatus
+var statesaver statemanager.Saver = statemanager.NewNoopStateManager()
 
 func HandleEngineEvents(taskEngine engine.TaskEngine, client api.ECSClient, saver statemanager.Saver) {
 	statesaver = saver

--- a/agent/eventhandler/task_handler.go
+++ b/agent/eventhandler/task_handler.go
@@ -107,6 +107,7 @@ func SubmitTaskEvents(events *eventList, client api.ECSClient) {
 					// submitted or can't be retried; ensure we don't retry it
 					event.containerSent = true
 					event.Container.SentStatus = event.Status
+					statesaver.Save()
 					llog.Debug("Submitted container")
 				} else {
 					llog.Error("Unretriable error submitting container state change", "err", contErr)
@@ -119,6 +120,7 @@ func SubmitTaskEvents(events *eventList, client api.ECSClient) {
 					// submitted or can't be retried; ensure we don't retry it
 					event.taskSent = true
 					event.Task.SentStatus = event.TaskStatus
+					statesaver.Save()
 				} else {
 					llog.Error("Error submitting task state change", "err", taskErr)
 				}


### PR DESCRIPTION
Oversight this wasn't done in the first place.

This isn't as big a deal as it might seem because the data would be checkpointed regardless on sigterm and the effect of not saving this is simply to send redundant api requests.