### PR TITLE
Reregister and remove state-file if it seems stale

### DIFF
--- a/agent/api/api_client.go
+++ b/agent/api/api_client.go
@@ -186,8 +186,7 @@ func (client *ApiECSClient) registerContainerInstance(clusterRef string) (string
 	svcRequest := svc.NewRegisterContainerInstanceRequest()
 	svcRequest.SetCluster(&clusterRef)
 
-	ec2MetadataClient := ec2.NewEC2MetadataClient()
-	instanceIdentityDoc, err := ec2MetadataClient.ReadResource(ec2.INSTANCE_IDENTITY_DOCUMENT_RESOURCE)
+	instanceIdentityDoc, err := ec2.ReadResource(ec2.INSTANCE_IDENTITY_DOCUMENT_RESOURCE)
 	iidRetrieved := true
 	if err != nil {
 		log.Error("Unable to get instance identity document", "err", err)
@@ -199,7 +198,7 @@ func (client *ApiECSClient) registerContainerInstance(clusterRef string) (string
 
 	instanceIdentitySignature := []byte{}
 	if iidRetrieved {
-		instanceIdentitySignature, err = ec2MetadataClient.ReadResource(ec2.INSTANCE_IDENTITY_DOCUMENT_SIGNATURE_RESOURCE)
+		instanceIdentitySignature, err = ec2.ReadResource(ec2.INSTANCE_IDENTITY_DOCUMENT_SIGNATURE_RESOURCE)
 		if err != nil {
 			log.Error("Unable to get instance identity signature", "err", err)
 		}

--- a/agent/auth/instance_metadata_provider.go
+++ b/agent/auth/instance_metadata_provider.go
@@ -31,17 +31,14 @@ const (
 )
 
 type InstanceMetadataCredentialProvider struct {
-	expiration     *time.Time
-	lastCheck      *time.Time
-	metadataClient *ec2.EC2MetadataClient
-	credentials    AWSCredentials
-	lock           sync.Mutex
+	expiration  *time.Time
+	lastCheck   *time.Time
+	credentials AWSCredentials
+	lock        sync.Mutex
 }
 
 func NewInstanceMetadataCredentialProvider() *InstanceMetadataCredentialProvider {
 	imcp := new(InstanceMetadataCredentialProvider)
-
-	imcp.metadataClient = ec2.NewEC2MetadataClient()
 	return imcp
 }
 
@@ -69,9 +66,9 @@ func (imcp *InstanceMetadataCredentialProvider) Credentials() (*AWSCredentials, 
 	defer imcp.lock.Unlock()
 
 	if imcp.shouldRefresh() {
-		now := time.Now() // can't &time.Now()
+		now := time.Now()
 		imcp.lastCheck = &now
-		credStruct, err := imcp.metadataClient.DefaultCredentials()
+		credStruct, err := ec2.DefaultCredentials()
 		if err != nil {
 			return &imcp.credentials, err
 		}

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -200,8 +200,7 @@ func EnvironmentConfig() Config {
 }
 
 func EC2MetadataConfig() Config {
-	metadataClient := ec2.NewEC2MetadataClient()
-	iid, err := metadataClient.InstanceIdentityDocument()
+	iid, err := ec2.GetInstanceIdentityDocument()
 	if err == nil {
 		return Config{AWSRegion: iid.Region, APIEndpoint: ecsEndpoint(iid.Region)}
 	}

--- a/agent/ec2/ec2_metadata_client.go
+++ b/agent/ec2/ec2_metadata_client.go
@@ -135,3 +135,24 @@ func (c EC2MetadataClient) ReadResource(path string) ([]byte, error) {
 
 	return ioutil.ReadAll(resp.Body)
 }
+
+// DefaultClient is the client used for package level methods.
+var DefaultClient = NewEC2MetadataClient()
+
+// ReadResource reads a given path from the EC2 metadata service using the
+// default client
+func ReadResource(path string) ([]byte, error) {
+	return DefaultClient.ReadResource(path)
+}
+
+// GetInstanceIdentityDocument returns an InstanceIdentityDocument read using
+// the default client
+func GetInstanceIdentityDocument() (*InstanceIdentityDocument, error) {
+	return DefaultClient.InstanceIdentityDocument()
+}
+
+// DefaultCredentials returns the instance's default role read using the default
+// client
+func DefaultCredentials() (*RoleCredentials, error) {
+	return DefaultClient.DefaultCredentials()
+}


### PR DESCRIPTION
Reset state instead of exiting for cluster.
Also explicitly save the ec2 instance id and if it changes ignore the loaded state since that indicates that datafile really belongs to a different agent.

r? @jhspaybar @samuelkarp