### PR TITLE
Handle default cluster when restoring state

### DIFF
--- a/scripts/dockerfiles/Dockerfile.test
+++ b/scripts/dockerfiles/Dockerfile.test
@@ -32,7 +32,7 @@ RUN apt-get update && apt-get install -y \
 		--no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*
 
-ENV GOLANG_VERSION 1.3.3
+ENV GOLANG_VERSION 1.4.2
 
 RUN curl -sSL https://golang.org/dl/go$GOLANG_VERSION.src.tar.gz \
 		| tar -v -C /usr/src -xz
@@ -54,7 +54,7 @@ WORKDIR /go
 # section.
 RUN mkdir -p /go/src/github.com/aws/
 RUN go get github.com/tools/godep
-RUN go get code.google.com/p/go.tools/cmd/cover
+RUN go get golang.org/x/tools/cmd/cover
 
 WORKDIR /go/src/github.com/aws/amazon-ecs-agent/agent
 


### PR DESCRIPTION
Prior to this change, agents without a configured cluster would fail to restore state as `""` does not match `"default"`.  This change allows state to be restored properly and saved back out.  There is still a TODO in here as we really need to think about handling the default cluster in a unified way across the codebase instead of special-casing it, but this fixes the bug for now.

I tested this on an EC2 Instance and ensured that state was persisted and restored correctly when things matched, the proper errors occurred when either the cluster was changed or the EC2 Instance ID was manually modified, the agent behaved properly with checkpointing disabled, and that tasks run and report events properly.

Note that I did need to modify Dockerfile.test to get the test-in-docker target to work properly.  The cover tool can no longer be pulled from the previous import path and the new import path does not work properly with Go 1.3.3.

r? @euank @jhspaybar 