### PR TITLE
Move to Go 1.4 and Docker 1.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ gobuild:
 
 # Basic go build
 static:
-	cd agent && CGO_ENABLED=0 godep go build -installsuffix cgo -a -x -ldflags '-s' -o ../out/amazon-ecs-agent .
+	cd agent && CGO_ENABLED=0 godep go build -installsuffix cgo -a -ldflags '-s' -o ../out/amazon-ecs-agent .
 
 docker:
 	docker build -f scripts/dockerfiles/Dockerfile.build -t "amazon/amazon-ecs-agent-build:make" .

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ gobuild:
 
 # Basic go build
 static:
-	cd agent && CGO_ENABLED=0 godep go build -a -x -ldflags '-s' -o ../out/amazon-ecs-agent .
+	cd agent && CGO_ENABLED=0 godep go build -installsuffix cgo -a -x -ldflags '-s' -o ../out/amazon-ecs-agent .
 
 # Phony target to make sure we never clobber someone's dockerfile. TODO, better
 # cleaning up of the dockerfile we ln so that this doesn't trigger incorrectly

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ See also the Advanced Usage section below.
 ### Docker Image
 
 The Amazon ECS Container Agent may be built by simply typing `make` with the [Docker
-daemon](https://docs.docker.com/installation/) running.
+daemon](https://docs.docker.com/installation/) (v1.5.0) running.
 
 This will produce an image tagged `amazon/ecs-container-agent:development` which
 you may run as described above.

--- a/misc/netkitten/Makefile
+++ b/misc/netkitten/Makefile
@@ -15,9 +15,7 @@
 all: netkitten image
 
 netkitten:
-	# Build in a go 1.3 container explicitly so static compiling works as
-	# expected
-	docker run -v $(shell pwd):/out -v $(shell pwd)/netkitten.go:/in/netkitten.go -e CGO_ENABLED=0 golang:1.3 go build -a -x -ldflags '-s' -o /out/netkitten /in/netkitten.go
+	docker run -v $(shell pwd):/out -v $(shell pwd)/netkitten.go:/in/netkitten.go -e CGO_ENABLED=0 golang:1.4 go build -a -installsuffix cgo -x -ldflags '-s' -o /out/netkitten /in/netkitten.go
 
 image: netkitten
 	@./docker-image

--- a/misc/netkitten/Makefile
+++ b/misc/netkitten/Makefile
@@ -15,7 +15,7 @@
 all: netkitten image
 
 netkitten:
-	docker run -v $(shell pwd):/out -v $(shell pwd)/netkitten.go:/in/netkitten.go -e CGO_ENABLED=0 golang:1.4 go build -a -installsuffix cgo -x -ldflags '-s' -o /out/netkitten /in/netkitten.go
+	docker run -v $(shell pwd):/out -v $(shell pwd)/netkitten.go:/in/netkitten.go -e CGO_ENABLED=0 golang:1.4 go build -a -installsuffix cgo -ldflags '-s' -o /out/netkitten /in/netkitten.go
 
 image: netkitten
 	@./docker-image

--- a/scripts/build
+++ b/scripts/build
@@ -15,7 +15,7 @@
 export GOPATH=`godep path`:$GOPATH
 
 # Statically link to ensure we can run in scratch
-CGO_ENABLED=0 go build -a -x -ldflags '-s' -o amazon-ecs-agent
+CGO_ENABLED=0 go build -a -installsuffix cgo -x -ldflags '-s' -o amazon-ecs-agent
 
 
 buildErr=$?

--- a/scripts/build
+++ b/scripts/build
@@ -15,7 +15,7 @@
 export GOPATH=`godep path`:$GOPATH
 
 # Statically link to ensure we can run in scratch
-CGO_ENABLED=0 go build -a -installsuffix cgo -x -ldflags '-s' -o amazon-ecs-agent
+CGO_ENABLED=0 go build -a -installsuffix cgo -ldflags '-s' -o amazon-ecs-agent
 
 
 buildErr=$?

--- a/scripts/dockerfiles/Dockerfile.build
+++ b/scripts/dockerfiles/Dockerfile.build
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-FROM golang:1.3
+FROM golang:1.4
 MAINTAINER Amazon Web Services, Inc.
 
 RUN mkdir /out


### PR DESCRIPTION
Using Docker 1.5's '-f' flag cleans up the Makefile nicely.
Go 1.4 is because I'm I've got some changes using `go generate` coming through soon and I'd like to only have one go version throughout.

r? @samuelkarp