### PR TITLE
Improve state-save lock scope

### DIFF
--- a/agent/engine/dockerstate/json.go
+++ b/agent/engine/dockerstate/json.go
@@ -30,16 +30,13 @@ type savedState struct {
 
 func (state *DockerTaskEngineState) MarshalJSON() ([]byte, error) {
 	var toSave savedState
-	func() {
-		// Lock scope
-		state.lock.RLock()
-		defer state.lock.RUnlock()
-		toSave = savedState{
-			Tasks:         state.AllTasks(),
-			IdToContainer: state.idToContainer,
-			IdToTask:      state.idToTask,
-		}
-	}()
+	state.lock.RLock()
+	defer state.lock.RUnlock()
+	toSave = savedState{
+		Tasks:         state.AllTasks(),
+		IdToContainer: state.idToContainer,
+		IdToTask:      state.idToTask,
+	}
 	return json.Marshal(toSave)
 }
 


### PR DESCRIPTION
The scope needs to encompass marshalling too since the toSave is not a deep copy.

It's possible this is what caused the second error in #31, but not certain.