### PR TITLE
Remove backend host/port options

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,6 @@ configure them as something other than the defaults.
 | `ECS_DATADIR`      |   /data/                  | The container path where state is checkpointed for use across agent restarts. | /data/ |
 | `ECS_UPDATES_ENABLED` | &lt;true &#124; false&gt; | Whether to exit for an updater to apply updates when requested | false |
 | `ECS_UPDATE_DOWNLOAD_DIR` | /cache               | Where to place update tarballs within the container |  |
-| `ECS_BACKEND_HOST` | ecs.us-east-1.amazonaws.com | The host to make backend api calls against. | ecs.REGION.amazonaws.com |
-| `ECS_BACKEND_PORT` | 443                         | The associated port to make backend api calls with. | 443 |
 | `AWS_SESSION_TOKEN` |                         | The [Session Token](http://docs.aws.amazon.com/STS/latest/UsingSTS/Welcome.html) used for temporary credentials. | Taken from EC2 Instance Metadata |
 
 ### Flags

--- a/agent/acs/update_handler/os/mock/filesystem.go
+++ b/agent/acs/update_handler/os/mock/filesystem.go
@@ -17,9 +17,9 @@
 package mock_os
 
 import (
+	gomock "code.google.com/p/gomock/gomock"
 	io "io"
 	os "os"
-	gomock "code.google.com/p/gomock/gomock"
 )
 
 // Mock of FileSystem interface

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -20,7 +20,6 @@ import (
 	"io/ioutil"
 	"os"
 	"reflect"
-	"strconv"
 	"strings"
 
 	"github.com/aws/amazon-ecs-agent/agent/ec2"
@@ -110,7 +109,6 @@ func DefaultConfig() Config {
 	awsRegion := "us-west-2"
 	return Config{
 		APIEndpoint:    ecsEndpoint(awsRegion),
-		APIPort:        443,
 		DockerEndpoint: "unix:///var/run/docker.sock",
 		AWSRegion:      awsRegion,
 		ReservedPorts:  []uint16{SSH_PORT, DOCKER_RESERVED_PORT, DOCKER_RESERVED_SSL_PORT, AGENT_INTROSPECTION_PORT},
@@ -152,7 +150,6 @@ func FileConfig() Config {
 // to convert them to the given type
 func EnvironmentConfig() Config {
 	endpoint := os.Getenv("ECS_BACKEND_HOST")
-	port, _ := strconv.Atoi(os.Getenv("ECS_BACKEND_PORT"))
 
 	clusterRef := os.Getenv("ECS_CLUSTER")
 	awsRegion := os.Getenv("AWS_DEFAULT_REGION")
@@ -191,7 +188,6 @@ func EnvironmentConfig() Config {
 	return Config{
 		Cluster:           clusterRef,
 		APIEndpoint:       endpoint,
-		APIPort:           uint16(port),
 		AWSRegion:         awsRegion,
 		DockerEndpoint:    dockerEndpoint,
 		ReservedPorts:     reservedPorts,

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -18,7 +18,7 @@ import "testing"
 func TestMerge(t *testing.T) {
 	conf1 := &Config{Cluster: "Foo"}
 	conf2 := Config{Cluster: "ignored", APIEndpoint: "Bar"}
-	conf3 := Config{APIPort: 99}
+	conf3 := Config{AWSRegion: "us-west-2"}
 
 	conf1.Merge(conf2).Merge(conf3)
 
@@ -28,7 +28,7 @@ func TestMerge(t *testing.T) {
 	if conf1.APIEndpoint != "Bar" {
 		t.Error("The APIEndpoint should have been merged in")
 	}
-	if conf1.APIPort != 99 {
-		t.Error("The APIPort should have been 99")
+	if conf1.AWSRegion != "us-west-2" {
+		t.Error("Incorrect region")
 	}
 }

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -28,8 +28,6 @@ type Config struct {
 	// make calls against. If this value is not set, it will default to the
 	// endpoint for your current AWSRegion
 	APIEndpoint string
-	// APIPort is the port for the above APIEndpoint. It defaults to 443.
-	APIPort uint16
 	// DockerEndpoint is the address the agent will attempt to connect to the
 	// Docker daemon at. This should have the same value as "DOCKER_HOST"
 	// normally would to interact with the daemon. It defaults to

--- a/agent/engine/mocks/engine_mocks.go
+++ b/agent/engine/mocks/engine_mocks.go
@@ -17,11 +17,11 @@
 package mock_engine
 
 import (
-	gomock "code.google.com/p/gomock/gomock"
 	api "github.com/aws/amazon-ecs-agent/agent/api"
 	statemanager "github.com/aws/amazon-ecs-agent/agent/statemanager"
 	engine "github.com/aws/amazon-ecs-agent/agent/engine"
 	go_dockerclient "github.com/fsouza/go-dockerclient"
+	gomock "code.google.com/p/gomock/gomock"
 )
 
 // Mock of TaskEngine interface


### PR DESCRIPTION
Remove port entirely.
Leave the backend host option, but undocument it as it's not generally useful.

This is a backwards incompatible change, but should have little to no impact as this option should not have been used anyways.
The previous behavior can be reached by appending the port to the host.