### PR TITLE
Ignore trailing whitespace in some config values

### DIFF
--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -23,11 +23,11 @@ type Config struct {
 	// Cluster can either be the Name or full ARN of a Cluster. This is the
 	// cluster the agent should register this ContainerInstance into. If this
 	// value is not set, it will default to "default"
-	Cluster string
+	Cluster string `trim:"true"`
 	// APIEndpoint is the endpoint, such as "ecs.us-east-1.amazonaws.com", to
 	// make calls against. If this value is not set, it will default to the
 	// endpoint for your current AWSRegion
-	APIEndpoint string
+	APIEndpoint string `trim:"true"`
 	// DockerEndpoint is the address the agent will attempt to connect to the
 	// Docker daemon at. This should have the same value as "DOCKER_HOST"
 	// normally would to interact with the daemon. It defaults to
@@ -35,7 +35,7 @@ type Config struct {
 	DockerEndpoint string
 	// AWSRegion is the region to run in (such as "us-east-1"). This value is
 	// used to determine the correct APIEndpoint.
-	AWSRegion string `missing:"warn"`
+	AWSRegion string `missing:"warn" trim:"true"`
 	// ReservedPorts is an array of ports which should be registerd as
 	// unavailable. If not set, they default to [22,2375,2376,51678].
 	ReservedPorts []uint16
@@ -50,7 +50,7 @@ type Config struct {
 
 	// EngineAuthType configures what type of data is in EngineAuthData.
 	// Supported types, right now, can be found in the dockerauth package: https://godoc.org/github.com/aws/amazon-ecs-agent/agent/engine/dockerauth
-	EngineAuthType string
+	EngineAuthType string `trim:"true"`
 	// EngineAuthData contains authentication data. Please see the documentation
 	// for EngineAuthType for more information.
 	EngineAuthData json.RawMessage

--- a/agent/utils/utils.go
+++ b/agent/utils/utils.go
@@ -21,6 +21,7 @@ import (
 	"math/big"
 	"reflect"
 	"strconv"
+	"strings"
 
 	"github.com/aws/amazon-ecs-agent/agent/logger"
 	"github.com/aws/amazon-ecs-agent/agent/utils/ttime"
@@ -159,7 +160,7 @@ func StrSliceEqual(s1, s2 []string) bool {
 }
 
 func ParseBool(str string, default_ bool) bool {
-	res, err := strconv.ParseBool(str)
+	res, err := strconv.ParseBool(strings.TrimSpace(str))
 	if err != nil {
 		return default_
 	}

--- a/agent/utils/utils_test.go
+++ b/agent/utils/utils_test.go
@@ -173,3 +173,37 @@ func TestRetryNWithBackoff(t *testing.T) {
 		t.Error("Retry didn't backoff for as long as expected: %v", testTime.Seconds())
 	}
 }
+
+func TestParseBool(t *testing.T) {
+
+	truthyStrings := []string{"true", "1", "t", "true\r", "true ", "true \r"}
+	falsyStrings := []string{"false", "0", "f", "false\r", "false ", "false \r"}
+	neitherStrings := []string{"apple", " ", "\r", "orange", "maybe"}
+
+	for ndx, str := range truthyStrings {
+		if !ParseBool(str, false) {
+			t.Fatal("Truthy string should be truthy: ", ndx)
+		}
+		if !ParseBool(str, true) {
+			t.Fatal("Truthy string should be truthy (regardless of default): ", ndx)
+		}
+	}
+
+	for ndx, str := range falsyStrings {
+		if ParseBool(str, false) {
+			t.Fatal("Falsy string should be falsy: ", ndx)
+		}
+		if ParseBool(str, true) {
+			t.Fatal("falsy string should be falsy (regardless of default): ", ndx)
+		}
+	}
+
+	for ndx, str := range neitherStrings {
+		if ParseBool(str, false) {
+			t.Fatal("Should default to false", ndx)
+		}
+		if !ParseBool(str, true) {
+			t.Fatal("Should default to true", ndx)
+		}
+	}
+}


### PR DESCRIPTION
It's easy to miss a trailing space in environment variables and there are several config values where that'll never be valid.

This commit removes whitespaces from those values and adds a little more testing around config (still room to improve of course).

r? @samuelkarp 