### PR TITLE
Api client: Properly set default ec2 metadata impl

### DIFF
--- a/agent/api/api_client.go
+++ b/agent/api/api_client.go
@@ -104,7 +104,14 @@ func NewECSClient(credentialProvider aws.CredentialsProvider, config *config.Con
 		ecsConfig.Endpoint = config.APIEndpoint
 	}
 	client := ecs.New(ecsConfig)
-	return &ApiECSClient{credentialProvider: credentialProvider, config: config, insecureSkipVerify: insecureSkipVerify, c: client}
+	ec2metadataclient := ec2.DefaultClient
+	return &ApiECSClient{
+		credentialProvider: credentialProvider,
+		config:             config,
+		insecureSkipVerify: insecureSkipVerify,
+		c:                  client,
+		ec2metadata:        ec2metadataclient,
+	}
 }
 
 func getCpuAndMemory() (int64, int64) {


### PR DESCRIPTION
This fixes a bug introduced in c05a83c6ede777ba6b35946f1c884b632ab7d7aa when the client was interfaced out for testing, but a default implication was not set. This bug resulted in a 'dev' branch that builds, but was not able to register and thus was essentially unusable.

This was caught when I ran my functional tests against it (during rebasing #57 actually).

I think merging and automatically running those functional tests should be given a high priority as it ensures bugs of this magnitude don't end up on dev. I also share some fault for not dong manual testing of the sdk changes after my testing changes, only before.

r? @aaithal