### PR TITLE
Volumes: Properly serialize empty volumes

### DIFF
--- a/agent/api/json.go
+++ b/agent/api/json.go
@@ -163,7 +163,9 @@ func (tv *TaskVolume) UnmarshalJSON(b []byte) error {
 			return err
 		}
 		if hv.FSSourcePath == "" {
-			tv.Volume = &EmptyHostVolume{}
+			emptyVolume := &EmptyHostVolume{}
+			json.Unmarshal(host, emptyVolume)
+			tv.Volume = emptyVolume
 		} else {
 			tv.Volume = &hv
 		}

--- a/agent/api/json.go
+++ b/agent/api/json.go
@@ -143,6 +143,7 @@ func (overrides *ContainerOverrides) UnmarshalJSON(b []byte) error {
 // UnmarshalJSON for TaskVolume determines the name and volume type, and
 // unmarshals it into the appropriate HostVolume fulfilling interfaces
 func (tv *TaskVolume) UnmarshalJSON(b []byte) error {
+	// Format: {name: volumeName, host: emptyVolumeOrHostVolume}
 	intermediate := make(map[string]json.RawMessage)
 	if err := json.Unmarshal(b, &intermediate); err != nil {
 		return err
@@ -155,19 +156,22 @@ func (tv *TaskVolume) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	if host, ok := intermediate["host"]; ok {
-		// fs host type volume, unmarshal as such
-		var hv FSHostVolume
-		err := json.Unmarshal(host, &hv)
+	if rawhostdata, ok := intermediate["host"]; ok {
+		// Default to trying to unmarshal it as a FSHostVolume
+		var hostvolume FSHostVolume
+		err := json.Unmarshal(rawhostdata, &hostvolume)
 		if err != nil {
 			return err
 		}
-		if hv.FSSourcePath == "" {
+		if hostvolume.FSSourcePath == "" {
+			// If the FSSourcePath is empty, that must mean it was not an
+			// FSHostVolume (empty path is invalid for that type). The only other
+			// type is an empty volume, so unmarshal it as such.
 			emptyVolume := &EmptyHostVolume{}
-			json.Unmarshal(host, emptyVolume)
+			json.Unmarshal(rawhostdata, emptyVolume)
 			tv.Volume = emptyVolume
 		} else {
-			tv.Volume = &hv
+			tv.Volume = &hostvolume
 		}
 		return nil
 	}

--- a/agent/api/json_test.go
+++ b/agent/api/json_test.go
@@ -181,6 +181,9 @@ func TestMarshalUnmarshalTaskVolumes(t *testing.T) {
 		t.Error("Expected v1 to be an empty volume")
 	}
 
+	if v2.Volume.SourcePath() != "/path" {
+		t.Error("Expected v2 to have 'sourcepath' work correctly")
+	}
 	fs, ok := v2.Volume.(*FSHostVolume)
 	if !ok || fs.FSSourcePath != "/path" {
 		t.Error("Unmarshaled v2 didn't match marshalled v2")

--- a/agent/api/task.go
+++ b/agent/api/task.go
@@ -124,7 +124,7 @@ func (task *Task) UpdateMountPoints(cont *Container, vols map[string]string) {
 		if ok {
 			if hostVolume, exists := task.HostVolumeByName(mountPoint.SourceVolume); exists {
 				if empty, ok := hostVolume.(*EmptyHostVolume); ok {
-					empty.hostPath = hostPath
+					empty.HostPath = hostPath
 				}
 			}
 		}
@@ -359,7 +359,8 @@ func (task *Task) dockerHostBinds(container *Container) ([]string, error) {
 		}
 
 		if hv.SourcePath() == "" || mountPoint.ContainerPath == "" {
-			return []string{}, errors.New("Unable to resolve volume mounts; invalid path: " + hv.SourcePath() + " -> " + mountPoint.ContainerPath)
+			log.Error("Unable to resolve volume mounts; invalid path: " + container.Name + " " + mountPoint.SourceVolume + "; " + hv.SourcePath() + " -> " + mountPoint.ContainerPath)
+			return []string{}, errors.New("Unable to resolve volume mounts; invalid path: " + container.Name + " " + mountPoint.SourceVolume + "; " + hv.SourcePath() + " -> " + mountPoint.ContainerPath)
 		}
 
 		bind := hv.SourcePath() + ":" + mountPoint.ContainerPath

--- a/agent/api/types.go
+++ b/agent/api/types.go
@@ -103,11 +103,11 @@ func (fs *FSHostVolume) SourcePath() string {
 }
 
 type EmptyHostVolume struct {
-	hostPath string
+	HostPath string `json:"hostPath"`
 }
 
 func (e *EmptyHostVolume) SourcePath() string {
-	return e.hostPath
+	return e.HostPath
 }
 
 type ContainerStateChange struct {

--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -248,7 +248,6 @@ func (mtask *managedTask) handleContainerChange(containerChange dockerContainerC
 		container.KnownPortBindings = event.PortBindings
 	}
 	if event.Volumes != nil {
-		// No need to emit an event for this; this information is not propogated up yet
 		mtask.UpdateMountPoints(container, event.Volumes)
 	}
 


### PR DESCRIPTION
This handles the case where the agent is stopped after the empty volume
container reaches stopped but before something referencing it starts.