### PR TITLE
Docker: Pass HostConfig as part of Create instead of Start

### DIFF
--- a/agent/engine/docker_container_engine_test.go
+++ b/agent/engine/docker_container_engine_test.go
@@ -141,7 +141,7 @@ func TestCreateContainerTimeout(t *testing.T) {
 		wait.Wait()
 		// Don't return, verify timeout happens
 	})
-	metadata := client.CreateContainer(config.Config, config.Name)
+	metadata := client.CreateContainer(config.Config, nil, config.Name)
 	if metadata.Error == nil {
 		t.Error("Expected error for pull timeout")
 	}
@@ -160,7 +160,7 @@ func TestCreateContainer(t *testing.T) {
 		mockDocker.EXPECT().CreateContainer(config).Return(&docker.Container{ID: "id"}, nil),
 		mockDocker.EXPECT().InspectContainer("id").Return(&docker.Container{ID: "id"}, nil),
 	)
-	metadata := client.CreateContainer(config.Config, config.Name)
+	metadata := client.CreateContainer(config.Config, nil, config.Name)
 	if metadata.Error != nil {
 		t.Error("Did not expect error")
 	}
@@ -175,12 +175,12 @@ func TestStartContainerTimeout(t *testing.T) {
 
 	wait := &sync.WaitGroup{}
 	wait.Add(1)
-	mockDocker.EXPECT().StartContainer("id", &docker.HostConfig{}).Do(func(x, y interface{}) {
+	mockDocker.EXPECT().StartContainer("id", nil).Do(func(x, y interface{}) {
 		testTime.Warp(startContainerTimeout)
 		wait.Wait()
 		// Don't return, verify timeout happens
 	})
-	metadata := client.StartContainer("id", &docker.HostConfig{})
+	metadata := client.StartContainer("id")
 	if metadata.Error == nil {
 		t.Error("Expected error for pull timeout")
 	}
@@ -194,12 +194,11 @@ func TestStartContainer(t *testing.T) {
 	mockDocker, client, _, done := dockerclientSetup(t)
 	defer done()
 
-	hostConfig := &docker.HostConfig{}
 	gomock.InOrder(
-		mockDocker.EXPECT().StartContainer("id", hostConfig).Return(nil),
+		mockDocker.EXPECT().StartContainer("id", nil).Return(nil),
 		mockDocker.EXPECT().InspectContainer("id").Return(&docker.Container{ID: "id"}, nil),
 	)
-	metadata := client.StartContainer("id", hostConfig)
+	metadata := client.StartContainer("id")
 	if metadata.Error != nil {
 		t.Error("Did not expect error")
 	}

--- a/agent/engine/mocks/engine_mocks.go
+++ b/agent/engine/mocks/engine_mocks.go
@@ -176,14 +176,14 @@ func (_mr *_MockDockerClientRecorder) ContainerEvents(arg0 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ContainerEvents", arg0)
 }
 
-func (_m *MockDockerClient) CreateContainer(_param0 *go_dockerclient.Config, _param1 string) engine.DockerContainerMetadata {
-	ret := _m.ctrl.Call(_m, "CreateContainer", _param0, _param1)
+func (_m *MockDockerClient) CreateContainer(_param0 *go_dockerclient.Config, _param1 *go_dockerclient.HostConfig, _param2 string) engine.DockerContainerMetadata {
+	ret := _m.ctrl.Call(_m, "CreateContainer", _param0, _param1, _param2)
 	ret0, _ := ret[0].(engine.DockerContainerMetadata)
 	return ret0
 }
 
-func (_mr *_MockDockerClientRecorder) CreateContainer(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateContainer", arg0, arg1)
+func (_mr *_MockDockerClientRecorder) CreateContainer(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateContainer", arg0, arg1, arg2)
 }
 
 func (_m *MockDockerClient) DescribeContainer(_param0 string) (api.ContainerStatus, engine.DockerContainerMetadata) {
@@ -239,14 +239,14 @@ func (_mr *_MockDockerClientRecorder) RemoveContainer(arg0 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveContainer", arg0)
 }
 
-func (_m *MockDockerClient) StartContainer(_param0 string, _param1 *go_dockerclient.HostConfig) engine.DockerContainerMetadata {
-	ret := _m.ctrl.Call(_m, "StartContainer", _param0, _param1)
+func (_m *MockDockerClient) StartContainer(_param0 string) engine.DockerContainerMetadata {
+	ret := _m.ctrl.Call(_m, "StartContainer", _param0)
 	ret0, _ := ret[0].(engine.DockerContainerMetadata)
 	return ret0
 }
 
-func (_mr *_MockDockerClientRecorder) StartContainer(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "StartContainer", arg0, arg1)
+func (_mr *_MockDockerClientRecorder) StartContainer(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "StartContainer", arg0)
 }
 
 func (_m *MockDockerClient) StopContainer(_param0 string) engine.DockerContainerMetadata {


### PR DESCRIPTION
This is inline with the docker cli and other upstream recommendations, and what [other projects](https://github.com/docker/docker-py/issues/578#issuecomment-97651026) have found to be best as well.

The worrying thing about this change is the chance that it might break some dependency assumption related to create/start ordering (whereby a start could be ordered after a create before but now the create must be ordered after the create). I need to give a little more thought to that.