### PR TITLE
Config: Do not compute endpoint; make region fatal

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -59,16 +59,19 @@ func _main() int {
 
 	log.Info("Loading configuration")
 	cfg, err := config.NewConfig()
-	if err != nil {
-		log.Errorf("Error loading config: %v", err)
-		return exitcodes.ExitTerminal
-	}
-
+	// Load cfg before doing 'versionFlag' so that it has the DOCKER_HOST
+	// variable loaded if needed
 	if *versionFlag {
 		versionableEngine := engine.NewTaskEngine(cfg)
 		version.PrintVersion(versionableEngine)
 		return exitcodes.ExitSuccess
 	}
+
+	if err != nil {
+		log.Criticalf("Error loading config: %v", err)
+		return exitcodes.ExitTerminal
+	}
+	log.Debug("Loaded config: %+v", *cfg)
 
 	var currentEc2InstanceID, containerInstanceArn string
 	var taskEngine engine.TaskEngine

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -69,7 +69,8 @@ func _main() int {
 
 	if err != nil {
 		log.Criticalf("Error loading config: %v", err)
-		return exitcodes.ExitTerminal
+		// All required config values can be inferred from EC2 Metadata, so this error could be transient.
+		return exitcodes.ExitError
 	}
 	log.Debug("Loaded config: %+v", *cfg)
 

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -232,7 +232,7 @@ var ec2MetadataClient = ec2.DefaultClient
 func EC2MetadataConfig() Config {
 	iid, err := ec2MetadataClient.InstanceIdentityDocument()
 	if err != nil {
-		log.Crit("Unable to communicate with EC2 Metadata service to infer region and endpoint: " + err.Error())
+		log.Crit("Unable to communicate with EC2 Metadata service to infer region: " + err.Error())
 		return Config{}
 	}
 	return Config{AWSRegion: iid.Region}

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -15,7 +15,7 @@ package config
 
 import (
 	"encoding/json"
-	"fmt"
+	"errors"
 	"io"
 	"io/ioutil"
 	"os"
@@ -72,12 +72,13 @@ func (cfg *Config) Complete() bool {
 
 // CheckMissing checks all zero-valued fields for tags of the form
 // missing:STRING and acts based on that string. Current options are: fatal,
-// warn. Fatal will result in a fatal error, warn will result in a warning that
-// the field is missing being logged
-func (cfg *Config) CheckMissingAndDepreciated() {
+// warn. Fatal will result in an error being returned, warn will result in a
+// warning that the field is missing being logged.
+func (cfg *Config) CheckMissingAndDepreciated() error {
 	cfgElem := reflect.ValueOf(cfg).Elem()
 	cfgStructField := reflect.Indirect(reflect.ValueOf(cfg)).Type()
 
+	fatalFields := []string{}
 	for i := 0; i < cfgElem.NumField(); i++ {
 		cfgField := cfgElem.Field(i)
 		if utils.ZeroOrNil(cfgField.Interface()) {
@@ -90,7 +91,7 @@ func (cfg *Config) CheckMissingAndDepreciated() {
 				log.Warn("Configuration key not set", "key", cfgStructField.Field(i).Name)
 			case "fatal":
 				log.Crit("Configuration key not set", "key", cfgStructField.Field(i).Name)
-				os.Exit(1)
+				fatalFields = append(fatalFields, cfgStructField.Field(i).Name)
 			default:
 				log.Warn("Unexpected `missing` tag value", "tag", missingTag)
 			}
@@ -103,6 +104,10 @@ func (cfg *Config) CheckMissingAndDepreciated() {
 			log.Warn("Use of deprecated configuration key", "key", cfgStructField.Field(i).Name, "message", deprecatedTag)
 		}
 	}
+	if len(fatalFields) > 0 {
+		return errors.New("Missing required fields: " + strings.Join(fatalFields, ", "))
+	}
+	return nil
 }
 
 // TrimWhitespace trims whitespace from all string config values with the
@@ -131,11 +136,8 @@ func (cfg *Config) TrimWhitespace() {
 }
 
 func DefaultConfig() Config {
-	awsRegion := "us-west-2"
 	return Config{
-		APIEndpoint:    ecsEndpoint(awsRegion),
 		DockerEndpoint: "unix:///var/run/docker.sock",
-		AWSRegion:      awsRegion,
 		ReservedPorts:  []uint16{SSH_PORT, DOCKER_RESERVED_PORT, DOCKER_RESERVED_SSL_PORT, AGENT_INTROSPECTION_PORT},
 		DataDir:        "/data/",
 	}
@@ -225,26 +227,28 @@ func EnvironmentConfig() Config {
 	}
 }
 
+var ec2MetadataClient = ec2.DefaultClient
+
 func EC2MetadataConfig() Config {
-	iid, err := ec2.GetInstanceIdentityDocument()
+	iid, err := ec2MetadataClient.InstanceIdentityDocument()
 	if err != nil {
 		log.Crit("Unable to communicate with EC2 Metadata service to infer region and endpoint: " + err.Error())
 		return Config{}
 	}
-	return Config{AWSRegion: iid.Region, APIEndpoint: ecsEndpoint(iid.Region)}
+	return Config{AWSRegion: iid.Region}
 }
 
-func ecsEndpoint(awsRegion string) string {
-	endpoint := fmt.Sprintf("ecs.%s.amazonaws.com", awsRegion)
-	return endpoint
-}
-
-func NewConfig() (*Config, error) {
+// NewConfig returns a config struct created by merging environment variables,
+// a config file, and EC2 Metadata info.
+// The 'config' struct it returns can be used, even if an error is returned. An
+// error is returned, however, if the config is incomplete in some way that is
+// considered fatal.
+func NewConfig() (config *Config, err error) {
 	ctmp := EnvironmentConfig() //Environment overrides all else
-	config := &ctmp
+	config = &ctmp
 	defer func() {
 		config.TrimWhitespace()
-		config.CheckMissingAndDepreciated()
+		err = config.CheckMissingAndDepreciated()
 		config.Merge(DefaultConfig())
 	}()
 
@@ -255,10 +259,10 @@ func NewConfig() (*Config, error) {
 
 	config.Merge(FileConfig())
 
-	if config.AWSRegion == "" || config.APIEndpoint == "" {
+	if config.AWSRegion == "" {
 		// Get it from metadata only if we need to (network io)
 		config.Merge(EC2MetadataConfig())
 	}
 
-	return config, nil
+	return config, err
 }

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -33,9 +33,10 @@ type Config struct {
 	// normally would to interact with the daemon. It defaults to
 	// unix:///var/run/docker.sock
 	DockerEndpoint string
-	// AWSRegion is the region to run in (such as "us-east-1"). This value is
-	// used to determine the correct APIEndpoint.
-	AWSRegion string `missing:"warn" trim:"true"`
+	// AWSRegion is the region to run in (such as "us-east-1"). This value will
+	// be inferred from the EC2 metadata service, but if it cannot be found this
+	// will be fatal.
+	AWSRegion string `missing:"fatal" trim:"true"`
 	// ReservedPorts is an array of ports which should be registerd as
 	// unavailable. If not set, they default to [22,2375,2376,51678].
 	ReservedPorts []uint16


### PR DESCRIPTION
The SDK can handle setting the endpoint better than the Config code did;
the endpoint behavior before was a legacy from a time with no SDK.

The specific issue was that the endpoint would be set incorrectly if the
ec2 metadata service did not return any value.

In line with this, if no region can be determined it now is a fatal
error.

Possibly relates to #74, though I'm not certain.

r? @samuelkarp 