### PR TITLE
Add task-arn and container-name labels.

### DIFF
--- a/agent/api/task.go
+++ b/agent/api/task.go
@@ -220,6 +220,10 @@ func (task *Task) dockerConfig(container *Container) (*docker.Config, *DockerCli
 		Env:          dockerEnv,
 		Memory:       dockerMem,
 		CPUShares:    int64(container.Cpu),
+		Labels: map[string]string{
+			"com.amazonaws.ecs.task-arn":       task.Arn,
+			"com.amazonaws.ecs.container-name": container.Name,
+		},
 	}
 	return config, nil
 }

--- a/agent/api/task.go
+++ b/agent/api/task.go
@@ -221,8 +221,10 @@ func (task *Task) dockerConfig(container *Container) (*docker.Config, *DockerCli
 		Memory:       dockerMem,
 		CPUShares:    int64(container.Cpu),
 		Labels: map[string]string{
-			"com.amazonaws.ecs.task-arn":       task.Arn,
-			"com.amazonaws.ecs.container-name": container.Name,
+			"com.amazonaws.ecs.task-arn":                task.Arn,
+			"com.amazonaws.ecs.container-name":          container.Name,
+			"com.amazonaws.ecs.task-definition-family":  task.Family,
+			"com.amazonaws.ecs.task-definition-version": task.Version,
 		},
 	}
 	return config, nil

--- a/agent/api/task_test.go
+++ b/agent/api/task_test.go
@@ -98,7 +98,9 @@ func TestDockerHostConfigVolumesFrom(t *testing.T) {
 
 func TestDockerConfigLabels(t *testing.T) {
 	testTask := &Task{
-		Arn: "arn:aws:ecs:us-east-1:012345678910:task/c09f0188-7f87-4b0f-bfc3-16296622b6fe",
+		Arn:     "arn:aws:ecs:us-east-1:012345678910:task/c09f0188-7f87-4b0f-bfc3-16296622b6fe",
+		Family:  "myFamily",
+		Version: "1",
 		Containers: []*Container{
 			&Container{
 				Name: "c1",
@@ -110,10 +112,14 @@ func TestDockerConfigLabels(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(config.Labels, map[string]string{
-		"com.amazonaws.ecs.task-arn":       "arn:aws:ecs:us-east-1:012345678910:task/c09f0188-7f87-4b0f-bfc3-16296622b6fe",
-		"com.amazonaws.ecs.container-name": "c1",
-	}) {
+
+	expected := map[string]string{
+		"com.amazonaws.ecs.task-arn":                "arn:aws:ecs:us-east-1:012345678910:task/c09f0188-7f87-4b0f-bfc3-16296622b6fe",
+		"com.amazonaws.ecs.container-name":          "c1",
+		"com.amazonaws.ecs.task-definition-family":  "myFamily",
+		"com.amazonaws.ecs.task-definition-version": "1",
+	}
+	if !reflect.DeepEqual(config.Labels, expected) {
 		t.Fatal("Expected default ecs labels to be set, was: ", config.Labels)
 	}
 }

--- a/agent/api/task_test.go
+++ b/agent/api/task_test.go
@@ -96,6 +96,28 @@ func TestDockerHostConfigVolumesFrom(t *testing.T) {
 	}
 }
 
+func TestDockerConfigLabels(t *testing.T) {
+	testTask := &Task{
+		Arn: "arn:aws:ecs:us-east-1:012345678910:task/c09f0188-7f87-4b0f-bfc3-16296622b6fe",
+		Containers: []*Container{
+			&Container{
+				Name: "c1",
+			},
+		},
+	}
+
+	config, err := testTask.DockerConfig(testTask.Containers[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(config.Labels, map[string]string{
+		"com.amazonaws.ecs.task-arn":       "arn:aws:ecs:us-east-1:012345678910:task/c09f0188-7f87-4b0f-bfc3-16296622b6fe",
+		"com.amazonaws.ecs.container-name": "c1",
+	}) {
+		t.Fatal("Expected default ecs labels to be set, was: ", config.Labels)
+	}
+}
+
 func TestTaskFromACS(t *testing.T) {
 	strptr := func(s string) *string {
 		return &s


### PR DESCRIPTION
This is in regards to https://github.com/aws/amazon-ecs-agent/issues. This adds the following labels to the docker container when it is run:

* `com.amazonaws.ecs.task-arn`: The task ARN associated with this container.
* `com.amazonaws.ecs.container-name`: The name of the container, from the task definition.

I've left out adding a `com.amazonaws.ecs.task-definition-arn` label because it seems like that information [isn't made available by the acs client](https://github.com/aws/amazon-ecs-agent/blob/a2fe6ba7e1dd58bcd518b8e91492f4630c067470/agent/acs/model/ecsacs/api.go#L272-L290).

Closes https://github.com/aws/amazon-ecs-agent/issues/82

/cc @samuelkarp 