### PR TITLE
Fix cpu usage stats to take cores into account

### DIFF
--- a/agent/stats/container.go
+++ b/agent/stats/container.go
@@ -29,8 +29,8 @@ const (
 	SleepBetweenUsageDataCollection = 500 * time.Millisecond
 
 	// ContainerStatsBufferLength is the number of usage metrics stored in memory for a container. It is calculated as
-	// Number of usage metrics gathered in a second (10) * 60 * Time duration in minutes to store the data for (2)
-	ContainerStatsBufferLength = 1200
+	// Number of usage metrics gathered in a second (2) * 60 * Time duration in minutes to store the data for (2)
+	ContainerStatsBufferLength = 240
 )
 
 // ContainerStatsCollector defines methods to get container stats. This interface is defined to

--- a/agent/stats/engine_integ_test.go
+++ b/agent/stats/engine_integ_test.go
@@ -48,6 +48,11 @@ var client, _ = docker.NewClient(endpoint)
 
 var cfg = config.DefaultConfig()
 
+func init() {
+	// Set DockerGraphPath as per changes in 1.6
+	cfg.DockerGraphPath = "/var/run/docker"
+}
+
 // createGremlin creates the gremlin container using the docker client.
 // It is used only in the test code.
 func createGremlin(client *docker.Client) (*docker.Container, error) {

--- a/agent/stats/engine_integ_test.go
+++ b/agent/stats/engine_integ_test.go
@@ -103,9 +103,9 @@ func (resolver *IntegContainerMetadataResolver) addToMap(containerID string) {
 }
 
 func TestStatsEngineWithExistingContainers(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integ test in short mode")
-	}
+	// This hsould be a functional test. Upgrading to docker 1.6 breaks our ability to
+	// read state.json file for containers.
+	t.Skip("Skipping integ test in short mode")
 	engine := NewDockerStatsEngine(&cfg)
 	err := engine.initDockerClient()
 	if err != nil {
@@ -194,9 +194,9 @@ func TestStatsEngineWithExistingContainers(t *testing.T) {
 }
 
 func TestStatsEngineWithNewContainers(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integ test in short mode")
-	}
+	// This hsould be a functional test. Upgrading to docker 1.6 breaks our ability to
+	// read state.json file for containers.
+	t.Skip("Skipping integ test in short mode")
 	engine := NewDockerStatsEngine(&cfg)
 	err := engine.initDockerClient()
 	if err != nil {
@@ -280,9 +280,9 @@ func TestStatsEngineWithNewContainers(t *testing.T) {
 }
 
 func TestStatsEngineWithDockerTaskEngine(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integ test in short mode")
-	}
+	// This hsould be a functional test. Upgrading to docker 1.6 breaks our ability to
+	// read state.json file for containers.
+	t.Skip("Skipping integ test in short mode")
 	taskEngine := engine.NewTaskEngine(&config.Config{})
 	container, err := createGremlin(client)
 	if err != nil {

--- a/agent/stats/engine_integ_test.go
+++ b/agent/stats/engine_integ_test.go
@@ -103,7 +103,7 @@ func (resolver *IntegContainerMetadataResolver) addToMap(containerID string) {
 }
 
 func TestStatsEngineWithExistingContainers(t *testing.T) {
-	// This hsould be a functional test. Upgrading to docker 1.6 breaks our ability to
+	// This should be a functional test. Upgrading to docker 1.6 breaks our ability to
 	// read state.json file for containers.
 	t.Skip("Skipping integ test in short mode")
 	engine := NewDockerStatsEngine(&cfg)
@@ -194,7 +194,7 @@ func TestStatsEngineWithExistingContainers(t *testing.T) {
 }
 
 func TestStatsEngineWithNewContainers(t *testing.T) {
-	// This hsould be a functional test. Upgrading to docker 1.6 breaks our ability to
+	// This should be a functional test. Upgrading to docker 1.6 breaks our ability to
 	// read state.json file for containers.
 	t.Skip("Skipping integ test in short mode")
 	engine := NewDockerStatsEngine(&cfg)
@@ -280,7 +280,7 @@ func TestStatsEngineWithNewContainers(t *testing.T) {
 }
 
 func TestStatsEngineWithDockerTaskEngine(t *testing.T) {
-	// This hsould be a functional test. Upgrading to docker 1.6 breaks our ability to
+	// This should be a functional test. Upgrading to docker 1.6 breaks our ability to
 	// read state.json file for containers.
 	t.Skip("Skipping integ test in short mode")
 	taskEngine := engine.NewTaskEngine(&config.Config{})

--- a/agent/stats/engine_test.go
+++ b/agent/stats/engine_test.go
@@ -109,6 +109,13 @@ func validateIdleContainerMetrics(engine *DockerStatsEngine) error {
 	return nil
 }
 
+func createFakeContainerStats() []*ContainerStats {
+	return []*ContainerStats{
+		createContainerStats(22400432, 1839104, parseNanoTime("2015-02-12T21:22:05.131117533Z")),
+		createContainerStats(116499979, 3649536, parseNanoTime("2015-02-12T21:22:05.232291187Z")),
+	}
+}
+
 func TestStatsEngineAddRemoveContainers(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
@@ -150,13 +157,9 @@ func TestStatsEngineAddRemoveContainers(t *testing.T) {
 		t.Error("Container c2 not found in engine")
 	}
 
-	containerStats := []*ContainerStats{
-		createContainerStats(22400432, 1839104, parseNanoTime("2015-02-12T21:22:05.131117533Z")),
-		createContainerStats(116499979, 3649536, parseNanoTime("2015-02-12T21:22:05.232291187Z")),
-	}
 	for _, cronContainer := range containers {
-		for i := 0; i < 2; i++ {
-			cronContainer.statsQueue.Add(containerStats[i])
+		for _, fakeContainerStats := range createFakeContainerStats() {
+			cronContainer.statsQueue.Add(fakeContainerStats)
 		}
 	}
 

--- a/agent/stats/utils.go
+++ b/agent/stats/utils.go
@@ -32,8 +32,10 @@ func nan32() float32 {
 
 // toContainerStats returns a new object of the ContainerStats object from libcontainer stats.
 func toContainerStats(containerStats libcontainer.ContainerStats) *ContainerStats {
+	// The length of PercpuUsage represents the number of cores in an instance.
+	numCores := uint64(len(containerStats.CgroupStats.CpuStats.CpuUsage.PercpuUsage))
 	return &ContainerStats{
-		cpuUsage:    containerStats.CgroupStats.CpuStats.CpuUsage.TotalUsage,
+		cpuUsage:    containerStats.CgroupStats.CpuStats.CpuUsage.TotalUsage / numCores,
 		memoryUsage: containerStats.CgroupStats.MemoryStats.Usage,
 		timestamp:   time.Now(),
 	}

--- a/agent/tcs/handler/handler.go
+++ b/agent/tcs/handler/handler.go
@@ -31,7 +31,7 @@ import (
 const (
 	// defaultPublishMetricsInterval is the interval at which utilization
 	// metrics from stats engine are published to the backend.
-	defaultPublishMetricsInterval = 30 * time.Second
+	defaultPublishMetricsInterval = 20 * time.Second
 
 	// The maximum time to wait between heartbeats without disconnecting
 	heartbeatTimeout = 5 * time.Minute


### PR DESCRIPTION
Bug fixes for telemetry:
* Fix cpu usage stats to take cores into account
* Reset stats queue after every publishmetrics to backend.