### PR TITLE
Telemetry fix for eof

### DIFF
--- a/agent/tcs/client/client.go
+++ b/agent/tcs/client/client.go
@@ -15,6 +15,7 @@ package tcsclient
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -130,7 +131,7 @@ func (cs *clientServer) Close() error {
 	if cs.Conn != nil {
 		return cs.Conn.Close()
 	}
-	return nil
+	return errors.New("No connection to close")
 }
 
 // publishMetrics invokes the PublishMetricsRequest on the clientserver object.

--- a/agent/wsclient/client.go
+++ b/agent/wsclient/client.go
@@ -258,7 +258,7 @@ func (cs *ClientServerImpl) CreateRequestMessage(input interface{}) ([]byte, err
 func (cs *ClientServerImpl) handleMessage(data []byte) {
 	typedMessage, typeStr, err := DecodeData(data, cs.TypeDecoder)
 	if err != nil {
-		log.Warn("Unable to handle message from acs", "err", err)
+		log.Warn("Unable to handle message from backend", "err", err)
 		return
 	}
 

--- a/agent/wsclient/mock/utils/utils.go
+++ b/agent/wsclient/mock/utils/utils.go
@@ -17,6 +17,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gorilla/websocket"
 )
@@ -32,7 +33,7 @@ func StartMockServer(t *testing.T, closeWS <-chan bool) (*httptest.Server, chan<
 		ws, err := upgrader.Upgrade(w, r, nil)
 		go func() {
 			<-closeWS
-			ws.Close()
+			ws.WriteControl(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""), time.Now().Add(time.Second))
 		}()
 		if err != nil {
 			errChan <- err


### PR DESCRIPTION
… ack metric is received; This fixes the error of reading from a closed connection and getting the "connection closed" error message. The client correctly returns io.EOF when remote server closes connection.

r? @samuelkarp @euank 