### PR TITLE
Enforce minimum CPU shares of 2

### DIFF
--- a/agent/api/task.go
+++ b/agent/api/task.go
@@ -233,9 +233,9 @@ func (task *Task) dockerConfig(container *Container) (*docker.Config, *DockerCli
 // Docker silently converts 0 to 1024 CPU shares, which is probably not what we want.
 // Instead, we convert 0 to 1 to be closer to expected behavior.
 func (task *Task) dockerCpuShares(containerCpu uint) int64 {
-	if containerCpu <= 0 {
-		log.Debug("Converting CPU shares of 0 to 1", "task", task.Arn)
-		return 1
+	if containerCpu <= 1 {
+		log.Debug("Converting CPU shares to allowed minimum of 2", "task", task.Arn, "cpuShares", containerCpu)
+		return 2
 	}
 	return int64(containerCpu)
 }

--- a/agent/api/task_test.go
+++ b/agent/api/task_test.go
@@ -69,7 +69,7 @@ func TestDockerConfigPortBinding(t *testing.T) {
 	}
 }
 
-func TestDockerConfigCPUShareMinimum(t *testing.T) {
+func TestDockerConfigCPUShareZero(t *testing.T) {
 	testTask := &Task{
 		Containers: []*Container{
 			&Container{
@@ -84,8 +84,28 @@ func TestDockerConfigCPUShareMinimum(t *testing.T) {
 		t.Error(err)
 	}
 
-	if config.CPUShares != 1 {
-		t.Error("CPU shares of 0 did not get changed to 1")
+	if config.CPUShares != 2 {
+		t.Error("CPU shares of 0 did not get changed to 2")
+	}
+}
+
+func TestDockerConfigCPUShareMinimum(t *testing.T) {
+	testTask := &Task{
+		Containers: []*Container{
+			&Container{
+				Name: "c1",
+				Cpu:  1,
+			},
+		},
+	}
+
+	config, err := testTask.DockerConfig(testTask.Containers[0])
+	if err != nil {
+		t.Error(err)
+	}
+
+	if config.CPUShares != 2 {
+		t.Error("CPU shares of 1 did not get changed to 2")
 	}
 }
 


### PR DESCRIPTION
This works around docker/docker#13721.

r? @euank 