### PR TITLE
ACS: Handle heartbeats vs idle correctly

### DIFF
--- a/agent/acs/handler/acs_handler.go
+++ b/agent/acs/handler/acs_handler.go
@@ -145,7 +145,7 @@ func StartSession(ctx context.Context, args StartSessionArguments) error {
 
 // anyMessageHandler handles any server message. Any server message means the
 // connection is active and thus the heartbeat disconnect should not occur
-func anyMessageHandler(timer *time.Timer) func(interface{}) {
+func anyMessageHandler(timer ttime.Timer) func(interface{}) {
 	return func(interface{}) {
 		log.Debug("ACS activity occured")
 		timer.Reset(utils.AddJitter(heartbeatTimeout, heartbeatJitter))

--- a/agent/utils/ttime/test_time.go
+++ b/agent/utils/ttime/test_time.go
@@ -54,6 +54,17 @@ func (t *TestTime) After(d time.Duration) <-chan time.Time {
 	return done
 }
 
+// AfterFunc returns a timer and calls a function after a given time
+// taking into account time-warping
+func (t *TestTime) AfterFunc(d time.Duration, f func()) *time.Timer {
+	timer := time.AfterFunc(d, f)
+	go func() {
+		t.Sleep(d)
+		timer.Reset(0)
+	}()
+	return timer
+}
+
 // Sleep sleeps the given duration in mock-time; that is to say that Warps will
 // reduce the amount of time slept and LudicrousSpeed will cause instant
 // success.

--- a/agent/utils/ttime/ttime.go
+++ b/agent/utils/ttime/ttime.go
@@ -8,7 +8,12 @@ type Time interface {
 	Now() time.Time
 	Sleep(d time.Duration)
 	After(d time.Duration) <-chan time.Time
-	AfterFunc(d time.Duration, f func()) *time.Timer
+	AfterFunc(d time.Duration, f func()) Timer
+}
+
+type Timer interface {
+	Reset(d time.Duration) bool
+	Stop() bool
 }
 
 // DefaultTime is a Time that behaves normally
@@ -34,7 +39,7 @@ func (*DefaultTime) After(d time.Duration) <-chan time.Time {
 // AfterFunc waits for the duration to elapse and then calls f in its own
 // goroutine. It returns a Timer that can be used to cancel the call using its
 // Stop method.
-func (*DefaultTime) AfterFunc(d time.Duration, f func()) *time.Timer {
+func (*DefaultTime) AfterFunc(d time.Duration, f func()) Timer {
 	return time.AfterFunc(d, f)
 }
 
@@ -65,6 +70,6 @@ func After(t time.Duration) <-chan time.Time {
 }
 
 // AfterFunc calls the implementations AfterFunc method
-func AfterFunc(d time.Duration, f func()) *time.Timer {
+func AfterFunc(d time.Duration, f func()) Timer {
 	return _time.AfterFunc(d, f)
 }

--- a/agent/utils/ttime/ttime.go
+++ b/agent/utils/ttime/ttime.go
@@ -8,6 +8,7 @@ type Time interface {
 	Now() time.Time
 	Sleep(d time.Duration)
 	After(d time.Duration) <-chan time.Time
+	AfterFunc(d time.Duration, f func()) *time.Timer
 }
 
 // DefaultTime is a Time that behaves normally
@@ -28,6 +29,13 @@ func (*DefaultTime) Sleep(d time.Duration) {
 // After sleeps for the given duration and then writes to to the returned channel
 func (*DefaultTime) After(d time.Duration) <-chan time.Time {
 	return time.After(d)
+}
+
+// AfterFunc waits for the duration to elapse and then calls f in its own
+// goroutine. It returns a Timer that can be used to cancel the call using its
+// Stop method.
+func (*DefaultTime) AfterFunc(d time.Duration, f func()) *time.Timer {
+	return time.AfterFunc(d, f)
 }
 
 // SetTime configures what 'Time' implementation to use for each of the
@@ -54,4 +62,9 @@ func Since(t time.Time) time.Duration {
 // After calls the implementations After method
 func After(t time.Duration) <-chan time.Time {
 	return _time.After(t)
+}
+
+// AfterFunc calls the implementations AfterFunc method
+func AfterFunc(d time.Duration, f func()) *time.Timer {
+	return _time.AfterFunc(d, f)
 }

--- a/agent/wsclient/mock/client.go
+++ b/agent/wsclient/mock/client.go
@@ -89,3 +89,11 @@ func (_m *MockClientServer) Serve() error {
 func (_mr *_MockClientServerRecorder) Serve() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Serve")
 }
+
+func (_m *MockClientServer) SetAnyRequestHandler(_param0 wsclient.RequestHandler) {
+	_m.ctrl.Call(_m, "SetAnyRequestHandler", _param0)
+}
+
+func (_mr *_MockClientServerRecorder) SetAnyRequestHandler(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetAnyRequestHandler", arg0)
+}


### PR DESCRIPTION
Previously a heartbeat message was required to consider the channel
active.
In reality, heartbeat messages were only sent when the channel was
inactive and no other messages were being sent.
This avoids treating a lack of heartbeats as an idle channel and closing
it unless there are also no other messages.

In addition, this tweaks how backoffs are handled (time, resets, etc) a
bit to be more forgiving to these sorts of issues (where the connection
is lost, but can be re-established).

I think this fixes the issue in #103.

r? @aaithal @samuelkarp 