### PR TITLE
Don't log entire config

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -74,7 +74,7 @@ func _main() int {
 		// All required config values can be inferred from EC2 Metadata, so this error could be transient.
 		return exitcodes.ExitError
 	}
-	log.Debugf("Loaded config: %+v", *cfg)
+	log.Debug("Loaded config: " + cfg.String())
 
 	var currentEc2InstanceID, containerInstanceArn string
 	var taskEngine engine.TaskEngine

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -16,6 +16,7 @@ package config
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -302,4 +303,10 @@ func NewConfig() (config *Config, err error) {
 	}
 
 	return config, err
+}
+
+// String returns a lossy string representation of the config suitable for human readable display.
+// Consequently, it *should not* return any sensitive information.
+func (config *Config) String() string {
+	return fmt.Sprintf("Cluster: %v, Region: %v, DataDir: %v, Checkpoint: %v, AuthType: %v, UpdatesEnabled: %v, DisableMetrics: %v, ReservedMem: %v")
 }


### PR DESCRIPTION
This was an unfortunate careless mistake; the config does include
sensitive information (auth data) and so only a safe subset should be
logged.

r? @sentientmonkey 