### PR TITLE
Tty and OpenStdin configuration flags

### DIFF
--- a/agent/acs/model/ecsacs/api.go
+++ b/agent/acs/model/ecsacs/api.go
@@ -84,6 +84,10 @@ type Container struct {
 
 	VolumesFrom []*VolumeFrom `locationName:"volumesFrom" type:"list"`
 
+	Tty *bool `locationName:"tty" type:"boolean"`
+
+	OpenStdin *bool `locationName:"openStdin" type:"boolean"`
+
 	metadataContainer `json:"-", xml:"-"`
 }
 

--- a/agent/api/task.go
+++ b/agent/api/task.go
@@ -214,6 +214,8 @@ func (task *Task) dockerConfig(container *Container) (*docker.Config, *DockerCli
 	config := &docker.Config{
 		Image:        container.Image,
 		Cmd:          container.Command,
+	        Tty:          container.Tty,
+     	        OpenStdin:    container.OpenStdin,
 		Entrypoint:   entryPoint,
 		ExposedPorts: task.dockerExposedPorts(container),
 		Volumes:      dockerVolumes,

--- a/agent/api/task_test.go
+++ b/agent/api/task_test.go
@@ -222,6 +222,29 @@ func TestDockerConfigLabels(t *testing.T) {
 	}
 }
 
+func TestDockerRunCommandFlags(t *testing.T) {
+	testTask := &Task{
+		Containers: []*Container{
+			&Container{
+				Name:  "c1",
+			        Tty: true,
+			        OpenStdin: true,
+			},
+		},
+	}
+	config, err := testTask.DockerConfig(testTask.Containers[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !config.Tty {
+		t.Fatal("Expected tty to be true, got false")
+	}
+	if !config.OpenStdin {
+		t.Fatal("Expected openStdin to be true, got false")
+	}
+}
+
 func TestTaskFromACS(t *testing.T) {
 	strptr := func(s string) *string {
 		return &s

--- a/agent/api/types.go
+++ b/agent/api/types.go
@@ -198,6 +198,8 @@ type Container struct {
 	Ports       []PortBinding `json:"portMappings"`
 	Essential   bool
 	EntryPoint  *[]string
+	Tty         bool
+	OpenStdin   bool
 	Environment map[string]string  `json:"environment"`
 	Overrides   ContainerOverrides `json:"overrides"`
 

--- a/agent/ecs_client/model/ecs/api.go
+++ b/agent/ecs_client/model/ecs/api.go
@@ -967,6 +967,14 @@ type ContainerDefinition struct {
 	// (https://docs.docker.com/reference/builder/#entrypoint).
 	EntryPoint []*string `locationName:"entryPoint" type:"list"`
 
+	// If the TTY parameter of a container is marked as true, the container will be started and a
+	// psuedo TTY will be allocated. This is equivalent to the command line option `docker run -t`.
+	Tty *bool `locationName:"tty" type:"boolean"`
+
+	// If the OPENSTDIN parameter of a container is marked as true, the container will keep stdin open
+	// even if the container is not attached. This is equivalent to the command line option `docker run -i`.
+	OpenStdin *bool `locationName:"openStdin" type:"boolean"`
+
 	// The environment variables to pass to a container.
 	Environment []*KeyValuePair `locationName:"environment" type:"list"`
 


### PR DESCRIPTION
I've added the two flags to the configuration in the agent and written a test that verifies they are at least set correctly.

However, I can't test that the flags will be passed in from the JSON since the task definition builder won't let me add the flags as far as I can tell. I'm also not quite sure if the documentation files are auto-generated, or any of the other files as well. I am happy to make changes, but I at least want to open the pull request to start a more concrete conversation about the issue.