### PR TITLE
Trim untrusted cert from ca bundle

### DIFF
--- a/misc/certs/Dockerfile
+++ b/misc/certs/Dockerfile
@@ -4,4 +4,8 @@ RUN apt-get update &&  \
     apt-get install -y ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
+# If anyone has a better idea for how to trim undesired certs or a better ca list to use, I'm all ears
+RUN cp /etc/ca-certificates.conf /tmp/caconf && cat /tmp/caconf | \
+  grep -v "mozilla/CNNIC_ROOT\.crt" > /etc/ca-certificates.conf && \
+  update-ca-certificates --fresh
 


### PR DESCRIPTION
This removes CNNIC. See [this mozilla post](https://blog.mozilla.org/security/2015/04/02/distrusting-new-cnnic-certificates/) for why.

Note, updating to the latest Mozilla certificate bundle is not sufficient because the certificate has not been removed from it yet, merely revoked in OneCRL (which our tls clients don't use).