### PR TITLE
Fix memleak in ACS handler

### DIFF
--- a/agent/acs/handler/acs_handler.go
+++ b/agent/acs/handler/acs_handler.go
@@ -311,14 +311,14 @@ func clearStrChannel(c <-chan string) {
 	}
 }
 
-func ackMessageId(cs wsclient.ClientServer, cluster, containerInstanceArn, mid string) {
+func ackMessageId(cs wsclient.ClientServer, cluster, containerInstanceArn, messageID string) {
 	err := cs.MakeRequest(&ecsacs.AckRequest{
 		Cluster:           &cluster,
 		ContainerInstance: &containerInstanceArn,
-		MessageId:         &mid,
+		MessageId:         &messageID,
 	})
 	if err != nil {
-		log.Warn("Error 'ack'ing request", "MessageID", mid)
+		log.Warn("Error 'ack'ing request", "MessageID", messageID)
 	}
 }
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -73,6 +73,7 @@ func _main() int {
 		return exitcodes.ExitSuccess
 	}
 
+	sighandlers.StartDebugHandler()
 	ctx := context.Background()
 
 	if err != nil {

--- a/agent/sighandlers/debug_handler.go
+++ b/agent/sighandlers/debug_handler.go
@@ -1,0 +1,42 @@
+// Copyright 2014-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// sighandlers handle signals and behave appropriately. Currently, the only
+// supported signal is SIGTERM which causes state to be flushed to disk before
+// exiting.
+package sighandlers
+
+import (
+	"os"
+	"os/signal"
+	"runtime"
+	"syscall"
+	"time"
+
+	"github.com/cihub/seelog"
+)
+
+func StartDebugHandler() {
+	signalChannel := make(chan os.Signal, 1)
+	signal.Notify(signalChannel, syscall.SIGUSR1)
+	go func() {
+		for range signalChannel {
+			// "640 k ought to be enough for anybody." - Bill Gates, 1981
+			stackDump := make([]byte, 640*1024)
+			n := runtime.Stack(stackDump, true)
+			// Resize the buffer to the size of the actual stack
+			stackDump = stackDump[:n]
+			seelog.Criticalf("====== STACKTRACE ======\n%v\n%s\n====== /STACKTRACE ======", time.Now(), stackDump)
+		}
+	}()
+}

--- a/agent/sighandlers/debug_handler.go
+++ b/agent/sighandlers/debug_handler.go
@@ -11,9 +11,6 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-// sighandlers handle signals and behave appropriately. Currently, the only
-// supported signal is SIGTERM which causes state to be flushed to disk before
-// exiting.
 package sighandlers
 
 import (

--- a/agent/sighandlers/termination_handler.go
+++ b/agent/sighandlers/termination_handler.go
@@ -11,9 +11,11 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-// sighandlers handle signals and behave appropriately. Currently, the only
-// supported signal is SIGTERM which causes state to be flushed to disk before
-// exiting.
+// sighandlers handle signals and behave appropriately.
+// SIGTERM:
+//   Flush state to disk and exit
+// SIGUSR1:
+//   Print a dump of goroutines to the logger and DON'T exit
 package sighandlers
 
 import (

--- a/agent/wsclient/client.go
+++ b/agent/wsclient/client.go
@@ -150,6 +150,7 @@ func (cs *ClientServerImpl) Connect() error {
 		defer httpResponse.Body.Close()
 	}
 	if err != nil {
+		defer wsConn.Close()
 		var resp []byte
 		if httpResponse != nil {
 			var readErr error


### PR DESCRIPTION
This fixes a memory leak  :bomb:  that was caused by listening on dead payloadmessage channels for all past ACS connections forever and ever.
Specifically, [this line](https://github.com/aws/amazon-ecs-agent/blob/097e4aff2d33af4f6f7ef9e9fab5c8084beb598d/agent/acs/handler/acs_handler.go#L112) is the one at fault.
This bug was introduced in commit 6946a72379a831d484caf5dc6de5e3624b12cb89 (so it impacts every version since 1.0.0).

I've left a v1.3.0 and a bleeding edge with this fix runniing and would like to see what those look like tomorrow morning, but I do have a test showing there's a lot fewer goroutines at least. The test failed quite nicely before this code change.

I also added in the SIGUSR1 debug handler I've been meaning to stick in. I manually tested it.

r? @aaithal, @samuelkarp