### PR TITLE
Add support for setting labels on container from task definition.

### DIFF
--- a/agent/api/task.go
+++ b/agent/api/task.go
@@ -211,6 +211,18 @@ func (task *Task) dockerConfig(container *Container) (*docker.Config, *DockerCli
 		entryPoint = *container.EntryPoint
 	}
 
+	labels := map[string]string{
+		"com.amazonaws.ecs.task-arn":                task.Arn,
+		"com.amazonaws.ecs.container-name":          container.Name,
+		"com.amazonaws.ecs.task-definition-family":  task.Family,
+		"com.amazonaws.ecs.task-definition-version": task.Version,
+	}
+	for k, v := range container.Labels {
+		if _, ok := labels[k]; !ok {
+			labels[k] = v
+		}
+	}
+
 	config := &docker.Config{
 		Image:        container.Image,
 		Cmd:          container.Command,
@@ -220,12 +232,7 @@ func (task *Task) dockerConfig(container *Container) (*docker.Config, *DockerCli
 		Env:          dockerEnv,
 		Memory:       dockerMem,
 		CPUShares:    task.dockerCpuShares(container.Cpu),
-		Labels: map[string]string{
-			"com.amazonaws.ecs.task-arn":                task.Arn,
-			"com.amazonaws.ecs.container-name":          container.Name,
-			"com.amazonaws.ecs.task-definition-family":  task.Family,
-			"com.amazonaws.ecs.task-definition-version": task.Version,
-		},
+		Labels:       labels,
 	}
 	return config, nil
 }

--- a/agent/api/task_test.go
+++ b/agent/api/task_test.go
@@ -202,6 +202,13 @@ func TestDockerConfigLabels(t *testing.T) {
 		Containers: []*Container{
 			&Container{
 				Name: "c1",
+				Labels: map[string]string{
+					"com.company.environment": "production",
+
+					// these labels are set explicitly by the agent
+					// and a task definition's labels will not be permitted to overwrite them
+					"com.amazonaws.ecs.task-arn": "thisshouldntbeallowedtobeset",
+				},
 			},
 		},
 	}
@@ -216,6 +223,7 @@ func TestDockerConfigLabels(t *testing.T) {
 		"com.amazonaws.ecs.container-name":          "c1",
 		"com.amazonaws.ecs.task-definition-family":  "myFamily",
 		"com.amazonaws.ecs.task-definition-version": "1",
+		"com.company.environment":                   "production",
 	}
 	if !reflect.DeepEqual(config.Labels, expected) {
 		t.Fatal("Expected default ecs labels to be set, was: ", config.Labels)

--- a/agent/api/types.go
+++ b/agent/api/types.go
@@ -200,6 +200,7 @@ type Container struct {
 	EntryPoint  *[]string
 	Environment map[string]string  `json:"environment"`
 	Overrides   ContainerOverrides `json:"overrides"`
+	Labels      map[string]string  `json:"labels"`
 
 	DesiredStatus ContainerStatus `json:"desiredStatus"`
 	KnownStatus   ContainerStatus


### PR DESCRIPTION
This change requires ECS to add support for a new field in the
containerDefinition object named *labels*. This allows users to
pass labels down to the Docker container.

This is useful for various reasons, but in particular, to be able
to tag containers with metadata and pick them up when inspecting
containers on the Docker host. For example if you are using 
https://github.com/digital-wonderland/docker-logstash-forwarder, 
your container's labels will get added as logstash fields automatically.

This relates to #82.