### PR TITLE
Add *StateChange stringer methods

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -20,8 +20,6 @@ import (
 	"runtime"
 	"time"
 
-	"golang.org/x/net/context"
-
 	acshandler "github.com/aws/amazon-ecs-agent/agent/acs/handler"
 	"github.com/aws/amazon-ecs-agent/agent/api"
 	"github.com/aws/amazon-ecs-agent/agent/config"
@@ -40,6 +38,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	log "github.com/cihub/seelog"
+	"golang.org/x/net/context"
 )
 
 func init() {

--- a/agent/api/types.go
+++ b/agent/api/types.go
@@ -161,6 +161,23 @@ type ContainerStateChange struct {
 	SentStatus *ContainerStatus
 }
 
+func (c *ContainerStateChange) String() string {
+	res := fmt.Sprintf("%s %s -> %s", c.TaskArn, c.ContainerName, c.Status.String())
+	if c.ExitCode != nil {
+		res += ", Exit " + strconv.Itoa(*c.ExitCode) + ", "
+	}
+	if c.Reason != "" {
+		res += ", Reason " + c.Reason
+	}
+	if len(c.PortBindings) != 0 {
+		res += fmt.Sprintf(", Ports %v", c.PortBindings)
+	}
+	if c.SentStatus != nil {
+		res += ", Known Sent: " + c.SentStatus.String()
+	}
+	return res
+}
+
 type TaskStateChange struct {
 	TaskArn string
 	Status  TaskStatus
@@ -171,6 +188,14 @@ type TaskStateChange struct {
 	// hook into storing metadata about the task on the task such that it follows
 	// the lifecycle of the task and so on.
 	SentStatus *TaskStatus
+}
+
+func (t *TaskStateChange) String() string {
+	res := fmt.Sprintf("%s -> %s", t.TaskArn, t.Status.String())
+	if t.SentStatus != nil {
+		res += ", Known Sent: " + t.SentStatus.String()
+	}
+	return res
 }
 
 func (t *Task) String() string {

--- a/agent/eventhandler/handler_test.go
+++ b/agent/eventhandler/handler_test.go
@@ -60,7 +60,7 @@ func mockClient(task taskChangeFn, cont containerChangeFn) api.ECSClient {
 }
 
 func contEvent(arn string) api.ContainerStateChange {
-	return api.ContainerStateChange{TaskArn: arn, Status: api.ContainerRunning}
+	return api.ContainerStateChange{TaskArn: arn, ContainerName: "containerName", Status: api.ContainerRunning}
 }
 func taskEvent(arn string) api.TaskStateChange {
 	return api.TaskStateChange{TaskArn: arn, Status: api.TaskRunning}

--- a/agent/eventhandler/task_handler.go
+++ b/agent/eventhandler/task_handler.go
@@ -109,7 +109,7 @@ func SubmitTaskEvents(events *eventList, client api.ECSClient) {
 			llog := log.New("event", event)
 
 			if event.containerShouldBeSent() {
-				llog.Info("Sending container change", "change", event.containerChange)
+				llog.Info("Sending container change", "change", event)
 				err = client.SubmitContainerStateChange(event.containerChange)
 				if err == nil {
 					// submitted; ensure we don't retry it
@@ -125,7 +125,7 @@ func SubmitTaskEvents(events *eventList, client api.ECSClient) {
 					llog.Error("Unretriable error submitting container state change", "err", err)
 				}
 			} else if event.taskShouldBeSent() {
-				llog.Info("Sending task change", "change", event.taskChange)
+				llog.Info("Sending task change", "change", event)
 				err = client.SubmitTaskStateChange(event.taskChange)
 				if err == nil {
 					// submitted or can't be retried; ensure we don't retry it

--- a/agent/eventhandler/task_handler_types.go
+++ b/agent/eventhandler/task_handler_types.go
@@ -37,6 +37,14 @@ type sendableEvent struct {
 	taskChange api.TaskStateChange
 }
 
+func (event sendableEvent) String() string {
+	if event.isContainerEvent {
+		return "ContainerChange: " + event.containerChange.String()
+	} else {
+		return "TaskChange: " + event.taskChange.String()
+	}
+}
+
 func newSendableContainerEvent(event api.ContainerStateChange) *sendableEvent {
 	return &sendableEvent{
 		isContainerEvent: true,


### PR DESCRIPTION
This is mostly logging improvements.

Example of what the output looks like from `go test -v -run=TestSendsEvents ./...`

`Adding event module="eventhandler" change="ContainerChange: concurrent_0 containerName -> RUNNING"`

A bit more readable than before.