### PR TITLE
Avoid calling 'ShouldRetry' for nill response

### DIFF
--- a/agent/api/retry_handler.go
+++ b/agent/api/retry_handler.go
@@ -60,7 +60,10 @@ func ECSRetryHandler(r *aws.Request) {
 		r.RetryCount = 0
 	}
 
-	r.Retryable.Set(r.Service.ShouldRetry(r))
+	if !r.Retryable.IsSet() {
+		r.Retryable.Set(r.Service.ShouldRetry(r))
+	}
+
 	if r.WillRetry() {
 		r.RetryCount = realRetryCount
 		if r.RetryCount > 20 {


### PR DESCRIPTION
Avoids triggering the nil pointer dereference in #156 

The first test did not pass before making the code change. The second did.

r? @samuelkarp 