### PR TITLE
Add dummy test to generated functional tests

### DIFF
--- a/agent/functional_tests/tests/generated/simpletests/dummy_test.go
+++ b/agent/functional_tests/tests/generated/simpletests/dummy_test.go
@@ -1,0 +1,22 @@
+// Copyright 2014-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package simpletest
+
+import (
+	"testing"
+)
+
+// go test seems to require at least one non-tagged test to exist even when
+// running with a build tag
+func TestTest(t *testing.T) {}


### PR DESCRIPTION
go test seems to require at least one non-tagged test to exist even when
running with a build tag

r? @aaithal @euank 