### PR TITLE
Build with patched Go binary for multiple CVEs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,9 +26,13 @@ static: gogenerate
 	@cd agent && CGO_ENABLED=0 godep go build -installsuffix cgo -a -ldflags '-s' -o ../out/amazon-ecs-agent .
 	@git checkout -- agent/version/version.go
 
+# 'golang-base' builds a Go binary patched for CVE-2015-5739, CVE-2015-5740, and CVE-2015-5741
+golang-base:
+	@docker build -f scripts/dockerfiles/Dockerfile.golang -t "amazon/amazon-ecs-agent-build:golang" .
+
 # 'build-in-docker' builds the agent within a dockerfile and saves it to the ./out
 # directory
-build-in-docker:
+build-in-docker: golang-base
 	@docker build -f scripts/dockerfiles/Dockerfile.build -t "amazon/amazon-ecs-agent-build:make" .
 	@docker run -v "$(shell pwd)/out:/out" -v "$(shell pwd):/go/src/github.com/aws/amazon-ecs-agent" "amazon/amazon-ecs-agent-build:make"
 
@@ -41,7 +45,7 @@ docker: certs build-in-docker
 
 # 'docker-release' builds the agent from a clean snapshot of the git repo in
 # 'RELEASE' mode
-docker-release:
+docker-release: golang-base
 	@docker build -f scripts/dockerfiles/Dockerfile.cleanbuild -t "amazon/amazon-ecs-agent-cleanbuild:make" .
 	@docker run -v "$(shell pwd)/out:/out" -v "$(shell pwd):/src/amazon-ecs-agent" "amazon/amazon-ecs-agent-cleanbuild:make"
 

--- a/scripts/dockerfiles/Dockerfile.build
+++ b/scripts/dockerfiles/Dockerfile.build
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-FROM golang:1.4
+FROM amazon/amazon-ecs-agent-build:golang
 MAINTAINER Amazon Web Services, Inc.
 
 RUN mkdir /out

--- a/scripts/dockerfiles/Dockerfile.cleanbuild
+++ b/scripts/dockerfiles/Dockerfile.cleanbuild
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-FROM golang:1.4
+FROM amazon/amazon-ecs-agent-build:golang
 MAINTAINER Amazon Web Services, Inc.
 
 RUN mkdir /out

--- a/scripts/dockerfiles/Dockerfile.golang
+++ b/scripts/dockerfiles/Dockerfile.golang
@@ -1,0 +1,39 @@
+# Copyright 2014-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# A Dockerfile for a Go binary with patches applied for CVE-2015-5739,
+# CVE-2015-5740, and CVE-2015-5741.  Uses golang:1.4 as a base for existing
+# environment setup and scripts.
+FROM golang:1.4
+MAINTAINER Amazon Web Services, Inc.
+
+# CVE-2015-5739 117ddcb83d7f42d6aa72241240af99ded81118e9
+# CVE-2015-5740 300d9a21583e7cf0149a778a0611e76ff7c6680f
+# CVE-2015-5741 300d9a21583e7cf0149a778a0611e76ff7c6680f
+#
+# 143822585e32449860e624cace9d2e521deee62e reverts part of
+# 300d9a21583e7cf0149a778a0611e76ff7c6680f.
+
+RUN mkdir -p /usr/src \
+	&& rm -rf /usr/src/go \
+	&& cd /usr/src \
+	&& git clone https://github.com/golang/go.git \
+	&& cd go \
+	&& git config user.email "no-reply@localhost" \
+	&& git config user.name "Amazon ECS Agent builder" \
+	&& git checkout -b patch-go go1.4.2 \
+	&& git cherry-pick --strategy=recursive -X theirs 300d9a21583e7cf0149a778a0611e76ff7c6680f \
+	&& git cherry-pick --strategy=recursive -X theirs 117ddcb83d7f42d6aa72241240af99ded81118e9 \
+	&& git cherry-pick --strategy=recursive -X theirs 143822585e32449860e624cace9d2e521deee62e \
+	&& cd src \
+	&& ./make.bash --no-clean 2>&1


### PR DESCRIPTION
CVE-2015-5739 117ddcb83d7f42d6aa72241240af99ded81118e9
CVE-2015-5740 300d9a21583e7cf0149a778a0611e76ff7c6680f
CVE-2015-5741 300d9a21583e7cf0149a778a0611e76ff7c6680f

143822585e32449860e624cace9d2e521deee62e reverts part of
300d9a21583e7cf0149a778a0611e76ff7c6680f.

Based on my reading of the CVEs, I do not believe that we are affected (we have no auth on the locally-exposed http server and are not part of a reverse-proxying setup).  However, it's good to patch the underlying compiler anyway.

r? @aaithal @euank 