### PR TITLE
Add Docker client factory for versioned clients

### DIFF
--- a/agent/engine/dockerclient/interface.go
+++ b/agent/engine/dockerclient/interface.go
@@ -25,6 +25,7 @@ type Client interface {
 	InspectContainer(id string) (*docker.Container, error)
 	InspectImage(name string) (*docker.Image, error)
 	ListContainers(opts docker.ListContainersOptions) ([]docker.APIContainers, error)
+	Ping() error
 	PullImage(opts docker.PullImageOptions, auth docker.AuthConfiguration) error
 	RemoveContainer(opts docker.RemoveContainerOptions) error
 	RemoveEventListener(listener chan *docker.APIEvents) error

--- a/agent/engine/dockerclient/mocks/dockerclient_mocks.go
+++ b/agent/engine/dockerclient/mocks/dockerclient_mocks.go
@@ -106,6 +106,16 @@ func (_mr *_MockClientRecorder) ListContainers(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListContainers", arg0)
 }
 
+func (_m *MockClient) Ping() error {
+	ret := _m.ctrl.Call(_m, "Ping")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockClientRecorder) Ping() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Ping")
+}
+
 func (_m *MockClient) PullImage(_param0 go_dockerclient.PullImageOptions, _param1 go_dockerclient.AuthConfiguration) error {
 	ret := _m.ctrl.Call(_m, "PullImage", _param0, _param1)
 	ret0, _ := ret[0].(error)

--- a/agent/engine/dockerclient/versions.go
+++ b/agent/engine/dockerclient/versions.go
@@ -1,0 +1,121 @@
+// Copyright 2014-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package dockerclient
+
+import (
+	"sync"
+
+	log "github.com/cihub/seelog"
+	docker "github.com/fsouza/go-dockerclient"
+)
+
+type dockerVersion string
+
+const (
+	version_1_17 dockerVersion = "1.17"
+	version_1_18 dockerVersion = "1.18"
+	version_1_19 dockerVersion = "1.19"
+	version_1_20 dockerVersion = "1.20"
+
+	defaultVersion = version_1_17
+)
+
+var supportedVersions []dockerVersion
+
+func init() {
+	supportedVersions = []dockerVersion{
+		version_1_17,
+		version_1_18,
+		version_1_19,
+		version_1_20,
+	}
+}
+
+type Factory interface {
+	// GetDefaultClient returns a versioned client for the default version
+	GetDefaultClient() (Client, error)
+
+	// GetClient returns a client with the specified version
+	GetClient(version dockerVersion) (Client, error)
+
+	// FindAvailableVersions tests each supported version and returns a slice
+	// of available versions
+	FindAvailableVersions() []dockerVersion
+}
+
+type factory struct {
+	endpoint string
+	lock     sync.Mutex
+	clients  map[dockerVersion]Client
+}
+
+// newVersionedClient is a variable such that the implementation can be
+// swapped out for unit tests
+var newVersionedClient = func(endpoint, version string) (Client, error) {
+	return docker.NewVersionedClient(endpoint, version)
+}
+
+func NewFactory(endpoint string) *factory {
+	return &factory{
+		endpoint: endpoint,
+		clients:  make(map[dockerVersion]Client),
+	}
+}
+
+func (f *factory) GetDefaultClient() (Client, error) {
+	return f.GetClient(defaultVersion)
+}
+
+func (f *factory) GetClient(version dockerVersion) (Client, error) {
+	client, ok := f.clients[version]
+	if ok {
+		return client, nil
+	}
+
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	// double-check now that we're in a lock
+	client, ok = f.clients[version]
+	if ok {
+		return client, nil
+	}
+
+	client, err := newVersionedClient(f.endpoint, string(version))
+	if err != nil {
+		return nil, err
+	}
+
+	err = client.Ping()
+	if err != nil {
+		return nil, err
+	}
+
+	f.clients[version] = client
+	return client, nil
+}
+
+func (f *factory) FindAvailableVersions() []dockerVersion {
+	var availableVersions []dockerVersion
+	for _, version := range supportedVersions {
+		_, err := f.GetClient(version)
+		if err == nil {
+			availableVersions = append(availableVersions, version)
+		} else {
+			log.Debugf("Failed to ping with Docker version %s: %v", version, err)
+		}
+	}
+	log.Infof("Detected Docker versions %v", availableVersions)
+	return availableVersions
+}

--- a/agent/engine/dockerclient/versions_test.go
+++ b/agent/engine/dockerclient/versions_test.go
@@ -1,0 +1,205 @@
+// Copyright 2014-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package dockerclient
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/amazon-ecs-agent/agent/engine/dockerclient/mocks"
+	"github.com/golang/mock/gomock"
+)
+
+func TestGetDefaultClientSuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockClient := mock_dockerclient.NewMockClient(ctrl)
+	mockClient.EXPECT().Ping()
+
+	expectedEndpoint := "expectedEndpoint"
+
+	newVersionedClient = func(endpoint, version string) (Client, error) {
+		if endpoint != expectedEndpoint {
+			t.Errorf("Expected endpoint %s but was %s", expectedEndpoint, endpoint)
+		}
+		if version != string(defaultVersion) {
+			t.Errorf("Expected version %s but was %s", defaultVersion, version)
+		}
+		return mockClient, nil
+	}
+
+	factory := NewFactory(expectedEndpoint)
+	client, err := factory.GetDefaultClient()
+	if err != nil {
+		t.Fatal("err should be nil")
+	}
+	if client != mockClient {
+		t.Error("Client returned by GetDefaultClient differs from mockClient")
+	}
+}
+
+func TestGetClientCached(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockClient := mock_dockerclient.NewMockClient(ctrl)
+	mockClient.EXPECT().Ping()
+
+	expectedEndpoint := "expectedEndpoint"
+
+	newVersionedClient = func(endpoint, version string) (Client, error) {
+		if endpoint != expectedEndpoint {
+			t.Errorf("Expected endpoint %s but was %s", expectedEndpoint, endpoint)
+		}
+		if version != string(version_1_18) {
+			t.Errorf("Expected version %s but was %s", version_1_18, version)
+		}
+		return mockClient, nil
+	}
+
+	factory := NewFactory(expectedEndpoint)
+	client, err := factory.GetClient(version_1_18)
+	if err != nil {
+		t.Fatal("err should be nil")
+	}
+	if client != mockClient {
+		t.Error("Client returned by GetDefaultClient differs from mockClient")
+	}
+
+	client, err = factory.GetClient(version_1_18)
+	if err != nil {
+		t.Fatal("err should be nil")
+	}
+	if client != mockClient {
+		t.Error("Client returned by GetDefaultClient differs from mockClient")
+	}
+}
+
+func TestGetClientFailCreateNotCached(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockClient := mock_dockerclient.NewMockClient(ctrl)
+
+	calledOnce := false
+	newVersionedClient = func(endpoint, version string) (Client, error) {
+		if calledOnce {
+			return mockClient, nil
+		}
+		calledOnce = true
+		return mockClient, fmt.Errorf("Test error!")
+	}
+
+	factory := NewFactory("")
+	client, err := factory.GetClient(version_1_19)
+	if err == nil {
+		t.Fatal("err should not be nil")
+	}
+	if client != nil {
+		t.Error("client should be nil")
+	}
+
+	mockClient.EXPECT().Ping()
+
+	client, err = factory.GetClient(version_1_19)
+	if err != nil {
+		t.Fatal("err should be nil")
+	}
+	if client != mockClient {
+		t.Error("Client returned by GetDefaultClient differs from mockClient")
+	}
+}
+
+func TestGetClientFailPingNotCached(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockClient := mock_dockerclient.NewMockClient(ctrl)
+
+	newVersionedClient = func(endpoint, version string) (Client, error) {
+		return mockClient, nil
+	}
+
+	mockClient.EXPECT().Ping().Return(fmt.Errorf("Test error!"))
+
+	factory := NewFactory("")
+	client, err := factory.GetClient(version_1_20)
+	if err == nil {
+		t.Fatal("err should not be nil")
+	}
+	if client != nil {
+		t.Error("client should be nil")
+	}
+
+	mockClient.EXPECT().Ping()
+
+	client, err = factory.GetClient(version_1_20)
+	if err != nil {
+		t.Fatal("err should be nil")
+	}
+	if client != mockClient {
+		t.Error("Client returned by GetDefaultClient differs from mockClient")
+	}
+}
+
+func TestFindAvailableVersiosn(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockClient117 := mock_dockerclient.NewMockClient(ctrl)
+	mockClient118 := mock_dockerclient.NewMockClient(ctrl)
+	mockClient119 := mock_dockerclient.NewMockClient(ctrl)
+	mockClient120 := mock_dockerclient.NewMockClient(ctrl)
+
+	expectedEndpoint := "expectedEndpoint"
+
+	newVersionedClient = func(endpoint, version string) (Client, error) {
+		if endpoint != expectedEndpoint {
+			t.Errorf("Expected endpoint %s but was %s", expectedEndpoint, endpoint)
+		}
+
+		switch dockerVersion(version) {
+		case version_1_17:
+			return mockClient117, nil
+		case version_1_18:
+			return mockClient118, nil
+		case version_1_19:
+			return mockClient119, nil
+		case version_1_20:
+			return mockClient120, nil
+		default:
+			t.Fatal("Unrecognized version")
+		}
+		return nil, fmt.Errorf("This should not happen, update the test")
+	}
+
+	mockClient117.EXPECT().Ping()
+	mockClient118.EXPECT().Ping().Return(fmt.Errorf("Test error!"))
+	mockClient119.EXPECT().Ping()
+	mockClient120.EXPECT().Ping()
+
+	expectedVersions := []dockerVersion{version_1_17, version_1_19, version_1_20}
+
+	factory := NewFactory(expectedEndpoint)
+	versions := factory.FindAvailableVersions()
+	if len(versions) != len(expectedVersions) {
+		t.Errorf("Expected %d versions but got %d", len(expectedVersions), len(versions))
+	}
+	for i := 0; i < len(versions); i++ {
+		if versions[i] != expectedVersions[i] {
+			t.Errorf("Expected version %s but got version %s", expectedVersions[i], versions[i])
+		}
+	}
+}


### PR DESCRIPTION
None of this is yet hooked up to anything, but should help us detect and switch Remote API versions in the future.

r? @euank 