### PR TITLE
Reregistration: Don't ignore errors

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -170,11 +170,12 @@ func _main() int {
 		log.Infof("Restored from checkpoint file. I am running as '%v' in cluster '%v'", containerInstanceArn, cfg.Cluster)
 		_, err = client.RegisterContainerInstance(containerInstanceArn)
 		if err != nil {
-			log.Errorf("Error registering: %v", err)
+			log.Errorf("Error re-registering: %v", err)
 			if awserr, ok := err.(awserr.Error); ok && api.IsInstanceTypeChangedError(awserr) {
 				log.Criticalf("The current instance type does not match the registered instance type. Please revert the instance type change, or alternatively launch a new instance. Error: %v", err)
 				return exitcodes.ExitTerminal
 			}
+			return exitcodes.ExitError
 		}
 	}
 


### PR DESCRIPTION
Even if we've registered in the past and have a saved arn, avoid running
if we cannot do a re-register. This typically indicates a networking
error and we won't be able to do meaningful work in that state anyways.

This ensures better correctness with respect to registered resources and
so on as if they mutate, we won't receive work until we report that
successfully.

r? @samuelkarp 