### PR TITLE
RawConfig: Avoid panicing on null labels

### DIFF
--- a/agent/api/task.go
+++ b/agent/api/task.go
@@ -220,7 +220,6 @@ func (task *Task) dockerConfig(container *Container) (*docker.Config, *DockerCli
 		Env:          dockerEnv,
 		Memory:       dockerMem,
 		CPUShares:    task.dockerCpuShares(container.Cpu),
-		Labels:       map[string]string{},
 	}
 
 	if container.DockerConfig.Config != nil {
@@ -228,6 +227,9 @@ func (task *Task) dockerConfig(container *Container) (*docker.Config, *DockerCli
 		if err != nil {
 			return nil, &DockerClientConfigError{"Unable decode given docker config: " + err.Error()}
 		}
+	}
+	if config.Labels == nil {
+		config.Labels = make(map[string]string)
 	}
 
 	// Augment labels with some metadata from the agent. Explicitly do this last

--- a/agent/api/task_test.go
+++ b/agent/api/task_test.go
@@ -415,6 +415,32 @@ func TestDockerConfigRawConfig(t *testing.T) {
 	assertSetStructFieldsEqual(t, expectedOutput, *config)
 }
 
+func TestDockerConfigRawConfigNilLabel(t *testing.T) {
+	rawConfig, err := json.Marshal(&struct{ Labels map[string]string }{nil})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testTask := &Task{
+		Arn:     "arn:aws:ecs:us-east-1:012345678910:task/c09f0188-7f87-4b0f-bfc3-16296622b6fe",
+		Family:  "myFamily",
+		Version: "1",
+		Containers: []*Container{
+			&Container{
+				Name: "c1",
+				DockerConfig: DockerConfig{
+					Config: strptr(string(rawConfig)),
+				},
+			},
+		},
+	}
+
+	_, configErr := testTask.DockerConfig(testTask.Containers[0])
+	if configErr != nil {
+		t.Fatal(configErr)
+	}
+}
+
 func TestDockerConfigRawConfigMerging(t *testing.T) {
 	// Use a struct that will marshal to the actual message we expect; not
 	// docker.Config which will include a lot of zero values.


### PR DESCRIPTION
Per the title, this fixes a possible panic. It wouldn't happen if `labels` was omitted, but it would if it was explicitly null.

r? @samuelkarp @marcelvr 