### PR TITLE
Auth: ensure data can't be logged and add functional test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ misc/certs/ca-certificates.crt:
 short-test:
 	. ./scripts/shared_env && go test -short -timeout=25s ./agent/...
 
-# Run our 'test' registry needed for integ tests
+# Run our 'test' registry needed for integ and functional tests
 test-registry: netkitten volumes-test
 	@./scripts/setup-test-registry
 
@@ -83,7 +83,7 @@ test-in-docker:
 	# Privileged needed for docker-in-docker so integ tests pass
 	docker run -v "$(shell pwd):/go/src/github.com/aws/amazon-ecs-agent" --privileged "amazon/amazon-ecs-agent-test:make"
 
-run-functional-tests:
+run-functional-tests: test-registry
 	. ./scripts/shared_env && go test -tags functional -timeout=20m -v ./agent/functional_tests/...
 
 netkitten:

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ test-in-docker:
 	docker run -v "$(shell pwd):/go/src/github.com/aws/amazon-ecs-agent" --privileged "amazon/amazon-ecs-agent-test:make"
 
 run-functional-tests: test-registry
-	. ./scripts/shared_env && go test -tags functional -timeout=20m -v ./agent/functional_tests/...
+	. ./scripts/shared_env && go test -parallel 10 -tags functional -timeout=20m -v ./agent/functional_tests/...
 
 netkitten:
 	cd misc/netkitten; $(MAKE) $(MFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ misc/certs/ca-certificates.crt:
 	docker run "amazon/amazon-ecs-agent-cert-source:make" cat /etc/ssl/certs/ca-certificates.crt > misc/certs/ca-certificates.crt
 
 short-test:
-	. ./scripts/shared_env && go test -short -timeout=25s -v ./agent/...
+	. ./scripts/shared_env && go test -short -timeout=25s ./agent/...
 
 # Run our 'test' registry needed for integ tests
 test-registry: netkitten volumes-test

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -272,7 +272,7 @@ func EnvironmentConfig() Config {
 		DataDir:                 dataDir,
 		Checkpoint:              checkpoint,
 		EngineAuthType:          engineAuthType,
-		EngineAuthData:          []byte(engineAuthData),
+		EngineAuthData:          NewSensitiveRawMessage([]byte(engineAuthData)),
 		UpdatesEnabled:          updatesEnabled,
 		UpdateDownloadDir:       updateDownloadDir,
 		DisableMetrics:          disableMetrics,

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -62,7 +62,7 @@ type Config struct {
 	EngineAuthType string `trim:"true"`
 	// EngineAuthData contains authentication data. Please see the documentation
 	// for EngineAuthType for more information.
-	EngineAuthData json.RawMessage
+	EngineAuthData *SensitiveRawMessage
 
 	// UpdatesEnabled specifies whether updates should be applied to this agent.
 	// Default true
@@ -94,4 +94,38 @@ type Config struct {
 	// AppArmorCapable specifies whether the Agent is capable of using AppArmor
 	// security options
 	AppArmorCapable bool
+}
+
+// sensitiveData is a struct to store some data that should not be logged or
+// printed.
+// This struct is a Stringer which will not print its contents with 'String'.
+// It is a json.Marshaler and json.Unmarshaler and will present its actual
+// contents in plaintext when read/written from/to json.
+type SensitiveRawMessage struct {
+	contents json.RawMessage
+}
+
+func NewSensitiveRawMessage(data json.RawMessage) *SensitiveRawMessage {
+	return &SensitiveRawMessage{contents: data}
+}
+
+func (data SensitiveRawMessage) String() string {
+	return "[redacted]"
+}
+
+func (data SensitiveRawMessage) GoString() string {
+	return "[redacted]"
+}
+
+func (data SensitiveRawMessage) Contents() json.RawMessage {
+	return data.contents
+}
+
+func (data SensitiveRawMessage) MarshalJSON() ([]byte, error) {
+	return data.contents, nil
+}
+
+func (data *SensitiveRawMessage) UnmarshalJSON(jsonData []byte) error {
+	data.contents = json.RawMessage(jsonData)
+	return nil
 }

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -96,8 +96,8 @@ type Config struct {
 	AppArmorCapable bool
 }
 
-// sensitiveData is a struct to store some data that should not be logged or
-// printed.
+// SensitiveRawMessage is a struct to store some data that should not be logged
+// or printed.
 // This struct is a Stringer which will not print its contents with 'String'.
 // It is a json.Marshaler and json.Unmarshaler and will present its actual
 // contents in plaintext when read/written from/to json.
@@ -105,6 +105,8 @@ type SensitiveRawMessage struct {
 	contents json.RawMessage
 }
 
+// NewSensitiveRawMessage returns a new encapsulated json.RawMessage that
+// cannot be accidentally logged via .String/.GoString/%v/%#v
 func NewSensitiveRawMessage(data json.RawMessage) *SensitiveRawMessage {
 	return &SensitiveRawMessage{contents: data}
 }

--- a/agent/config/types_test.go
+++ b/agent/config/types_test.go
@@ -1,0 +1,27 @@
+// Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+)
+
+func TestSensitiveDataImplements(t *testing.T) {
+	var _ fmt.Stringer = SensitiveRawMessage{}
+	var _ fmt.GoStringer = SensitiveRawMessage{}
+	var _ json.Marshaler = SensitiveRawMessage{}
+	var _ json.Unmarshaler = &SensitiveRawMessage{}
+}

--- a/agent/config/types_test.go
+++ b/agent/config/types_test.go
@@ -19,9 +19,25 @@ import (
 	"testing"
 )
 
-func TestSensitiveDataImplements(t *testing.T) {
+func TestSensitiveRawMessageImplements(t *testing.T) {
 	var _ fmt.Stringer = SensitiveRawMessage{}
 	var _ fmt.GoStringer = SensitiveRawMessage{}
 	var _ json.Marshaler = SensitiveRawMessage{}
 	var _ json.Unmarshaler = &SensitiveRawMessage{}
+}
+
+func TestSensitiveRawMessage(t *testing.T) {
+	sensitive := NewSensitiveRawMessage(json.RawMessage("secret"))
+
+	for i, str := range []string{
+		sensitive.String(),
+		sensitive.GoString(),
+		fmt.Sprintf("%v", sensitive),
+		fmt.Sprintf("%#v", sensitive),
+		fmt.Sprint(sensitive),
+	} {
+		if str != "[redacted]" {
+			t.Errorf("#%v: expected redacted, got %s", i, str)
+		}
+	}
 }

--- a/agent/engine/dockerauth/dockerauth_test.go
+++ b/agent/engine/dockerauth/dockerauth_test.go
@@ -47,7 +47,7 @@ func TestDockerCfgAuth(t *testing.T) {
 		`}`), ""))
 	// Avoid accidentally loading the test-runner's .dockercfg
 	credentialprovider.SetPreferredDockercfgPath("/dev/null")
-	SetConfig(&config.Config{EngineAuthType: "dockercfg", EngineAuthData: authData})
+	SetConfig(&config.Config{EngineAuthType: "dockercfg", EngineAuthData: config.NewSensitiveRawMessage(authData)})
 
 	for ndx, pair := range expectedPairs {
 		authConfig := GetAuthconfig(pair.Image)

--- a/agent/engine/dockerauth/ecs/ecs_credentials.go
+++ b/agent/engine/dockerauth/ecs/ecs_credentials.go
@@ -52,9 +52,13 @@ func (creds *ecsCredentials) Provide() credentialprovider.DockerConfig {
 	case "dockercfg":
 		fallthrough
 	case "docker":
-		err := json.Unmarshal(creds.EngineAuthData, &providedCreds)
-		if err != nil {
-			log.Error("Unable to decode provided docker credentials", "type", creds.EngineAuthType)
+		if creds.EngineAuthData != nil {
+			err := json.Unmarshal(creds.EngineAuthData.Contents(), &providedCreds)
+			if err != nil {
+				log.Error("Unable to decode provided docker credentials", "type", creds.EngineAuthType)
+			}
+		} else {
+			log.Error("AuthType config specified, but AuthData not set")
 		}
 	case "":
 	default:

--- a/agent/engine/dockerauth/ecs/ecs_credentials_test.go
+++ b/agent/engine/dockerauth/ecs/ecs_credentials_test.go
@@ -31,7 +31,7 @@ var testPairs = []testPair{
 	testPair{
 		config.Config{
 			EngineAuthType: "docker",
-			EngineAuthData: []byte(`{"https://index.docker.io/v1/":{"username":"user","password":"swordfish","email":"user@email"}}`),
+			EngineAuthData: config.NewSensitiveRawMessage([]byte(`{"https://index.docker.io/v1/":{"username":"user","password":"swordfish","email":"user@email"}}`)),
 		},
 		credentialprovider.DockerConfig{
 			"https://index.docker.io/v1/": credentialprovider.DockerConfigEntry{
@@ -44,7 +44,7 @@ var testPairs = []testPair{
 	testPair{
 		config.Config{
 			EngineAuthType: "dockercfg",
-			EngineAuthData: []byte(`{"my.registry.tld":{"auth":"` + base64.StdEncoding.EncodeToString([]byte("test:dragon")) + `","email":"test@email"}}`),
+			EngineAuthData: config.NewSensitiveRawMessage([]byte(`{"my.registry.tld":{"auth":"` + base64.StdEncoding.EncodeToString([]byte("test:dragon")) + `","email":"test@email"}}`)),
 		},
 		credentialprovider.DockerConfig{
 			"my.registry.tld": credentialprovider.DockerConfigEntry{
@@ -57,8 +57,8 @@ var testPairs = []testPair{
 	testPair{
 		config.Config{
 			EngineAuthType: "dockercfg",
-			EngineAuthData: []byte(`{"my.registry.tld":{"auth":"` + base64.StdEncoding.EncodeToString([]byte("test:dragon")) + `","email":"test@email"},` +
-				`"my-other-registry.tld":{"auth":"` + base64.StdEncoding.EncodeToString([]byte("other:creds")) + `"}}`),
+			EngineAuthData: config.NewSensitiveRawMessage([]byte(`{"my.registry.tld":{"auth":"` + base64.StdEncoding.EncodeToString([]byte("test:dragon")) + `","email":"test@email"},` +
+				`"my-other-registry.tld":{"auth":"` + base64.StdEncoding.EncodeToString([]byte("other:creds")) + `"}}`)),
 		},
 		credentialprovider.DockerConfig{
 			"my.registry.tld": credentialprovider.DockerConfigEntry{
@@ -87,11 +87,11 @@ func TestProvide(t *testing.T) {
 var failingProvides = []config.Config{
 	config.Config{
 		EngineAuthType: "unknown",
-		EngineAuthData: []byte(`{"my.registry.tld":{"auth":"` + base64.StdEncoding.EncodeToString([]byte("test:dragon")) + `","email":"test@email"}}`),
+		EngineAuthData: config.NewSensitiveRawMessage([]byte(`{"my.registry.tld":{"auth":"` + base64.StdEncoding.EncodeToString([]byte("test:dragon")) + `","email":"test@email"}}`)),
 	},
 	config.Config{
 		EngineAuthType: "dockercfg",
-		EngineAuthData: []byte(`{"my.registry.tld":{"auth":"malformedbase64data"}}`),
+		EngineAuthData: config.NewSensitiveRawMessage([]byte(`{"my.registry.tld":{"auth":"malformedbase64data"}}`)),
 	},
 }
 

--- a/agent/engine/engine_integ_test.go
+++ b/agent/engine/engine_integ_test.go
@@ -655,10 +655,10 @@ func TestDockerCfgAuth(t *testing.T) {
 	removeImage(testAuthRegistryImage)
 
 	authString := base64.StdEncoding.EncodeToString([]byte(testAuthUser + ":" + testAuthPass))
-	cfg.EngineAuthData = []byte(`{"http://` + testAuthRegistryHost + `/v1/":{"auth":"` + authString + `"}}`)
+	cfg.EngineAuthData = config.NewSensitiveRawMessage([]byte(`{"http://` + testAuthRegistryHost + `/v1/":{"auth":"` + authString + `"}}`))
 	cfg.EngineAuthType = "dockercfg"
 	defer func() {
-		cfg.EngineAuthData = nil
+		cfg.EngineAuthData = config.NewSensitiveRawMessage(nil)
 		cfg.EngineAuthType = ""
 	}()
 
@@ -704,10 +704,10 @@ func TestDockerAuth(t *testing.T) {
 	taskEngine := setup(t)
 	removeImage(testAuthRegistryImage)
 
-	cfg.EngineAuthData = []byte(`{"http://` + testAuthRegistryHost + `":{"username":"` + testAuthUser + `","password":"` + testAuthPass + `"}}`)
+	cfg.EngineAuthData = config.NewSensitiveRawMessage([]byte(`{"http://` + testAuthRegistryHost + `":{"username":"` + testAuthUser + `","password":"` + testAuthPass + `"}}`))
 	cfg.EngineAuthType = "docker"
 	defer func() {
-		cfg.EngineAuthData = nil
+		cfg.EngineAuthData = config.NewSensitiveRawMessage(nil)
 		cfg.EngineAuthType = ""
 	}()
 

--- a/agent/functional_tests/testdata/taskdefinitions/simple-exit-authed/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/simple-exit-authed/task-definition.json
@@ -1,0 +1,11 @@
+{
+  "family": "ecsftest-simple-exit-authed",
+  "containerDefinitions": [{
+    "image": "127.0.0.1:51671/busybox:latest",
+    "name": "exit",
+    "cpu": 10,
+    "memory": 10,
+    "essential": true,
+    "command": ["sh", "-c", "exit 42"]
+  }]
+}

--- a/agent/utils/utils.go
+++ b/agent/utils/utils.go
@@ -48,6 +48,9 @@ func ZeroOrNil(obj interface{}) bool {
 		return value.Len() == 0
 	}
 	zero := reflect.Zero(reflect.TypeOf(obj))
+	if !value.Type().Comparable() {
+		return false
+	}
 	if obj == zero.Interface() {
 		return true
 	}

--- a/agent/utils/utils_test.go
+++ b/agent/utils/utils_test.go
@@ -77,6 +77,14 @@ func TestZeroOrNil(t *testing.T) {
 		t.Error("[] is Zero")
 	}
 
+	if ZeroOrNil(struct{ uncomparable []uint16 }{uncomparable: []uint16{1, 2, 3}}) {
+		t.Error("Uncomparable structs are never zero")
+	}
+
+	if ZeroOrNil(struct{ uncomparable []uint16 }{uncomparable: nil}) {
+		t.Error("Uncomparable structs are never zero")
+	}
+
 }
 
 func TestSlicesDeepEqual(t *testing.T) {

--- a/scripts/registry/nginx-auth/nginx.conf
+++ b/scripts/registry/nginx-auth/nginx.conf
@@ -1,0 +1,35 @@
+user  nginx;
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+  default_type  application/octet-stream;
+
+  log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+    '$status $body_bytes_sent "$http_referer" '
+    '"$http_user_agent" "$http_x_forwarded_for"';
+
+  access_log  /var/log/nginx/access.log  main;
+
+  sendfile        on;
+  keepalive_timeout  65;
+
+  upstream registrylink {
+    server registry:5000;
+  }
+  server {
+
+    add_header 'Docker-Distribution-Api-Version' 'registry/2.0' always;
+    location / {
+      auth_basic "private registry";
+      auth_basic_user_file registry.htpasswd;
+      proxy_pass http://registrylink;
+    }
+  }
+}

--- a/scripts/registry/nginx-auth/registry.htpasswd
+++ b/scripts/registry/nginx-auth/registry.htpasswd
@@ -1,0 +1,1 @@
+user:{PLAIN}swordfish

--- a/scripts/setup-test-registry
+++ b/scripts/setup-test-registry
@@ -15,6 +15,14 @@
 # Run a local registry on the 'well known' port 51670 if it is not running.
 # Also push images we will need to it.
 
+# registry:2 from 2015-09-15
+REGISTRY_IMAGE="registry@sha256:b7de4f6226df56d18f83296efa77dedf9bb72e79838167be0484a3078836fab2"
+# nginx:latest from  2015-09-15
+NGINX_IMAGE="nginx@sha256:0324afc5c8191616576f7b23b297d001609726a2f1b6561c90e229e54ab701cf"
+
+ROOT=$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )
+cd "${ROOT}"
+
 REGISTRY_CONTAINER_NAME=test-ecs-registry
 status=$(docker inspect -f "{{ .State.Running }}" "$REGISTRY_CONTAINER_NAME")
 if [[ "$status" == "false" ]]; then
@@ -24,7 +32,7 @@ fi
 # This will fail if we already have one running, but that's fine. We'll see it
 # running and push our image to it to make sure it's there
 if [[ "$status" != "true" ]]; then
-	docker run -d --name="$REGISTRY_CONTAINER_NAME" -e SETTINGS_FLAVOR=local -p 127.0.0.1:51670:5000 registry
+	docker run -d --name="$REGISTRY_CONTAINER_NAME" -e SETTINGS_FLAVOR=local -p "127.0.0.1:51670:5000" "${REGISTRY_IMAGE}"
 fi
 
 # Wait for it to be started which might include downloading the image
@@ -50,3 +58,20 @@ for image in "amazon/amazon-ecs-netkitten" "amazon/amazon-ecs-volumes-test"; do
 	docker tag -f "$image:make" "127.0.0.1:51670/$image:latest"
 	docker push "127.0.0.1:51670/$image:latest"
 done
+
+for image in "busybox"; do
+  docker pull ${image}
+  docker tag -f "${image}" "127.0.0.1:51670/${image}"
+  docker push "127.0.0.1:51670/${image}"
+done
+
+# Now setup a v2 registry with auth... aka nginx with basic auth in front of it
+REGISTRY_AUTH_CONTAINER_NAME="test-ecs-registry-auth"
+status=$(docker inspect -f "{{ .State.Running }}" "${REGISTRY_AUTH_CONTAINER_NAME}")
+if [[ "$status" == "false" ]]; then
+  docker rm -f "${REGISTRY_AUTH_CONTAINER_NAME}"
+fi
+
+if [[ "$status" != "true" ]]; then
+  docker run -d -p "127.0.0.1:51671:80" --link "${REGISTRY_CONTAINER_NAME}:registry" --name="${REGISTRY_AUTH_CONTAINER_NAME}" -v "${ROOT}/scripts/registry/nginx-auth:/etc/nginx" "${NGINX_IMAGE}"
+fi


### PR DESCRIPTION
When the v1.2.0 incident happened (see 2e002cd0672c9cdf923bf3a724904cba75e0d10d) we took an action item to add an encapsulation layer here just in case.

This commit does that, adds a functional test around it, and also includes several other minor testing improvements as well.

r? @samuelkarp 