### PR TITLE
ftests: increase PortResourceContention timeout

### DIFF
--- a/agent/functional_tests/testdata/taskdefinitions/busybox-port-5180/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/busybox-port-5180/task-definition.json
@@ -1,7 +1,7 @@
 {
   "family": "ecsftest-busybox-port-5180",
   "containerDefinitions": [{
-    "image": "busybox:latest",
+    "image": "127.0.0.1:51670/busybox:latest",
     "name": "sleep",
     "portBindings": [{
       "containerPort": 80,

--- a/agent/functional_tests/tests/functionaltests_test.go
+++ b/agent/functional_tests/tests/functionaltests_test.go
@@ -132,7 +132,7 @@ func TestPortResourceContention(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = testTask.WaitRunning(1 * time.Minute)
+	err = testTask.WaitRunning(2 * time.Minute)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -145,7 +145,7 @@ func TestPortResourceContention(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = testTask2.WaitRunning(1 * time.Minute)
+	err = testTask2.WaitRunning(2 * time.Minute)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -153,7 +153,6 @@ func TestPortResourceContention(t *testing.T) {
 
 	go testTask.WaitStopped(2 * time.Minute)
 	testTask2.WaitStopped(2 * time.Minute)
-	// 30 seconds because this busybox ignores sigterm
 }
 
 func strptr(s string) *string { return &s }


### PR DESCRIPTION
I spent some time trying to figure out a better image / command so I could essentially do `trap "sleep 10; exit" 15` which would be a better solution, but it turns out to be less trivial than I hoped... so double the timeout it is.

r? @samuelkarp 