### PR TITLE
Move discover pollendpoint and start session into a function and hand…

### DIFF
--- a/agent/tcs/handler/handler.go
+++ b/agent/tcs/handler/handler.go
@@ -73,7 +73,7 @@ func StartMetricsSession(params TelemetrySessionParams) {
 func StartSession(params TelemetrySessionParams, statsEngine stats.Engine) error {
 	backoff := utils.NewSimpleBackoff(time.Second, 1*time.Minute, 0.2, 2)
 	for {
-		tcsError := discoverEndpointAndStartSession(params, statsEngine)
+		tcsError := startTelemetrySession(params, statsEngine)
 		if tcsError == nil || tcsError == io.EOF {
 			backoff.Reset()
 		} else {
@@ -83,7 +83,7 @@ func StartSession(params TelemetrySessionParams, statsEngine stats.Engine) error
 	}
 }
 
-func discoverEndpointAndStartSession(params TelemetrySessionParams, statsEngine stats.Engine) error {
+func startTelemetrySession(params TelemetrySessionParams, statsEngine stats.Engine) error {
 	tcsEndpoint, err := params.EcsClient.DiscoverTelemetryEndpoint(params.ContainerInstanceArn)
 	if err != nil {
 		log.Error("Unable to discover poll endpoint", "err", err)

--- a/agent/tcs/handler/handler.go
+++ b/agent/tcs/handler/handler.go
@@ -73,14 +73,7 @@ func StartMetricsSession(params TelemetrySessionParams) {
 func StartSession(params TelemetrySessionParams, statsEngine stats.Engine) error {
 	backoff := utils.NewSimpleBackoff(time.Second, 1*time.Minute, 0.2, 2)
 	for {
-		tcsEndpoint, err := params.EcsClient.DiscoverTelemetryEndpoint(params.ContainerInstanceArn)
-		if err != nil {
-			log.Error("Unable to discover poll endpoint", "err", err)
-			return err
-		}
-		log.Debug("Connecting to TCS endpoint " + tcsEndpoint)
-		url := formatURL(tcsEndpoint, params.Cfg.Cluster, params.ContainerInstanceArn)
-		tcsError := startSession(url, params.Cfg.AWSRegion, params.CredentialProvider, params.AcceptInvalidCert, statsEngine, defaultPublishMetricsInterval)
+		tcsError := discoverEndpointAndStartSession(params, statsEngine)
 		if tcsError == nil || tcsError == io.EOF {
 			backoff.Reset()
 		} else {
@@ -88,6 +81,17 @@ func StartSession(params TelemetrySessionParams, statsEngine stats.Engine) error
 			ttime.Sleep(backoff.Duration())
 		}
 	}
+}
+
+func discoverEndpointAndStartSession(params TelemetrySessionParams, statsEngine stats.Engine) error {
+	tcsEndpoint, err := params.EcsClient.DiscoverTelemetryEndpoint(params.ContainerInstanceArn)
+	if err != nil {
+		log.Error("Unable to discover poll endpoint", "err", err)
+		return err
+	}
+	log.Debug("Connecting to TCS endpoint " + tcsEndpoint)
+	url := formatURL(tcsEndpoint, params.Cfg.Cluster, params.ContainerInstanceArn)
+	return startSession(url, params.Cfg.AWSRegion, params.CredentialProvider, params.AcceptInvalidCert, statsEngine, defaultPublishMetricsInterval)
 }
 
 func startSession(url string, region string, credentialProvider *credentials.Credentials, acceptInvalidCert bool, statsEngine stats.Engine, publishMetricsInterval time.Duration) error {

--- a/agent/tcs/handler/handler_test.go
+++ b/agent/tcs/handler/handler_test.go
@@ -145,9 +145,9 @@ func TestDiscoverEndpointAndStartSession(t *testing.T) {
 	mockEcs := mock_api.NewMockECSClient(ctrl)
 	mockEcs.EXPECT().DiscoverTelemetryEndpoint(gomock.Any()).Return("", errors.New("error"))
 
-	err := discoverEndpointAndStartSession(TelemetrySessionParams{EcsClient: mockEcs}, nil)
+	err := startTelemetrySession(TelemetrySessionParams{EcsClient: mockEcs}, nil)
 	if err == nil {
-		t.Error("Expected error from discoverEndpointAndStartSession when DiscoverTelemetryEndpoint returns error")
+		t.Error("Expected error from startTelemetrySession when DiscoverTelemetryEndpoint returns error")
 	}
 }
 

--- a/agent/tcs/handler/handler_test.go
+++ b/agent/tcs/handler/handler_test.go
@@ -22,11 +22,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/amazon-ecs-agent/agent/api/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/tcs/client"
 	"github.com/aws/amazon-ecs-agent/agent/tcs/model/ecstcs"
 	"github.com/aws/amazon-ecs-agent/agent/wsclient"
 	"github.com/aws/amazon-ecs-agent/agent/wsclient/mock/utils"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/golang/mock/gomock"
 )
 
 const (
@@ -133,6 +135,19 @@ func TestSessionConenctionClosedByRemote(t *testing.T) {
 	}
 	if err != io.EOF {
 		t.Error("Expected io.EOF on closed connection, got: ", err)
+	}
+}
+
+func TestDiscoverEndpointAndStartSession(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockEcs := mock_api.NewMockECSClient(ctrl)
+	mockEcs.EXPECT().DiscoverTelemetryEndpoint(gomock.Any()).Return("", errors.New("error"))
+
+	err := discoverEndpointAndStartSession(TelemetrySessionParams{EcsClient: mockEcs}, nil)
+	if err == nil {
+		t.Error("Expected error from discoverEndpointAndStartSession when DiscoverTelemetryEndpoint returns error")
 	}
 }
 


### PR DESCRIPTION
Move discover pollendpoint and start session into a function and handler errors to properly backoff and retry on failure; Added a test; Hardcoded to overwrite the error returned to non null in discoverEndpointAndStartSession for DiscoverPollEndpoint and verified that agent retries

r? @euank 