### PR TITLE
Add functional test for proxy support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ short-test:
 	. ./scripts/shared_env && go test -short -timeout=25s ./agent/...
 
 # Run our 'test' registry needed for integ and functional tests
-test-registry: netkitten volumes-test
+test-registry: netkitten volumes-test squid
 	@./scripts/setup-test-registry
 
 test: test-registry gremlin
@@ -85,6 +85,12 @@ netkitten:
 
 volumes-test:
 	cd misc/volumes-test; $(MAKE) $(MFLAGS)
+
+# TODO, replace this with a build on dockerhub or a mechanism for the
+# functional tests themselves to build this
+.PHONY: squid
+squid:
+	cd misc/squid; $(MAKE) $(MFLAGS)
 
 gremlin:
 	cd misc/gremlin; $(MAKE) $(MFLAGS)

--- a/misc/squid/Dockerfile
+++ b/misc/squid/Dockerfile
@@ -1,0 +1,4 @@
+FROM alpine@sha256:fb9f16730ac6316afa4d97caa5130219927bfcecf0b0ce35c01dcb612f449739
+RUN apk update && apk add squid
+EXPOSE 3128
+ENTRYPOINT ["squid", "-Nd", "1"]

--- a/misc/squid/Makefile
+++ b/misc/squid/Makefile
@@ -1,0 +1,5 @@
+
+.PHONY: all
+all:
+	docker build -t amazon/squid:make .
+

--- a/scripts/setup-test-registry
+++ b/scripts/setup-test-registry
@@ -64,7 +64,7 @@ mirror_local_image() {
   docker push $2
 }
 
-for image in "amazon/amazon-ecs-netkitten" "amazon/amazon-ecs-volumes-test"; do
+for image in "amazon/amazon-ecs-netkitten" "amazon/amazon-ecs-volumes-test" "amazon/squid"; do
   mirror_local_image "${image}:make" "127.0.0.1:51670/${image}:latest"
 done
 


### PR DESCRIPTION
This verifies that a squid3 proxy is at least connected to when the
appropriate environment variables are set.
There's certainly the possibility for improvement by adding iptable rules or using advanced docker networking features to ensure the Agent is unable to make connections except through the proxy link, but I think this is a reasonable initial test.

Related to #211 

r? @samuelkarp @abrgr