### PR TITLE
Over declare CPU and Memory

### DIFF
--- a/agent/api/api_client.go
+++ b/agent/api/api_client.go
@@ -14,10 +14,12 @@
 package api
 
 import (
+	"os"
 	"errors"
 	"net/http"
 	"runtime"
 	"time"
+	"strconv"
 
 	"github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
 	"github.com/aws/aws-sdk-go/aws"
@@ -206,6 +208,18 @@ func (client *ApiECSClient) registerContainerInstance(clusterRef string, contain
 
 	cpu, mem := getCpuAndMemory()
 	mem = mem - int64(client.config.ReservedMemory)
+
+	// Allows for extra over allocation of memory.
+	extraMem := os.Getenv("ECS_EXTRA_MEM")
+	if m, err := strconv.Atoi(extraMem); err == nil {
+		mem = mem + int64(m)
+	}
+
+	// Alows for extra over allocation of cpu.
+	extraCPU := os.Getenv("ECS_EXTRA_CPU")
+	if c, err := strconv.Atoi(extraCPU); err == nil {
+		cpu = cpu + int64(c)
+	}
 
 	cpuResource := ecs.Resource{
 		Name:         utils.Strptr("CPU"),


### PR DESCRIPTION
We all want to get the most value out of our ECS cluster instances, one method is to "over provision". The following is a proposal for 2 new environment variables that allow the administrator to simply declare more resources than the host actually has.

Here are some notes:
* Default - Nothing will change, instance gets declared with "1 for 1" resources.
* User can "opt in" by declaring ECS_EXTRA_CPU and/or ECS_EXTRA_MEM environment variables to "over declare" the resources of a single instance running the ecs-agent.
* User can declare 1024mb (ECS_EXTRA_MEM=1024) of extra RAM and supplement that with swap.

Where too from here:
* Can I get some guidance on if there is a better alternative to either 1) Declaring the env variables 2) Approach in general
* Discussion on naming/terminology of environment variables
* Docs for environment variables
* Test coverage