### PR TITLE
add awslogs driver and 1.21 api version

### DIFF
--- a/agent/engine/dockerclient/logging_drivers.go
+++ b/agent/engine/dockerclient/logging_drivers.go
@@ -21,6 +21,7 @@ const (
 	JournaldDriver LoggingDriver = "journald"
 	GelfDriver     LoggingDriver = "gelf"
 	FluentdDriver  LoggingDriver = "fluentd"
+	AwslogsDriver  LoggingDriver = "awslogs"
 )
 
 var LoggingDriverMinimumVersion = map[LoggingDriver]DockerVersion{
@@ -29,4 +30,5 @@ var LoggingDriverMinimumVersion = map[LoggingDriver]DockerVersion{
 	JournaldDriver: Version_1_19,
 	GelfDriver:     Version_1_20,
 	FluentdDriver:  Version_1_20,
+	AwslogsDriver:  Version_1_21,
 }

--- a/agent/engine/dockerclient/versions.go
+++ b/agent/engine/dockerclient/versions.go
@@ -28,6 +28,7 @@ const (
 	Version_1_18 DockerVersion = "1.18"
 	Version_1_19 DockerVersion = "1.19"
 	Version_1_20 DockerVersion = "1.20"
+	Version_1_21 DockerVersion = "1.21"
 
 	defaultVersion = Version_1_17
 )
@@ -40,6 +41,7 @@ func init() {
 		Version_1_18,
 		Version_1_19,
 		Version_1_20,
+		Version_1_21,
 	}
 }
 

--- a/agent/engine/dockerclient/versions_test.go
+++ b/agent/engine/dockerclient/versions_test.go
@@ -163,6 +163,7 @@ func TestFindAvailableVersiosn(t *testing.T) {
 	mockClient118 := mock_dockeriface.NewMockClient(ctrl)
 	mockClient119 := mock_dockeriface.NewMockClient(ctrl)
 	mockClient120 := mock_dockeriface.NewMockClient(ctrl)
+	mockClient121 := mock_dockeriface.NewMockClient(ctrl)
 
 	expectedEndpoint := "expectedEndpoint"
 
@@ -180,6 +181,8 @@ func TestFindAvailableVersiosn(t *testing.T) {
 			return mockClient119, nil
 		case Version_1_20:
 			return mockClient120, nil
+		case Version_1_21:
+			return mockClient121, nil
 		default:
 			t.Fatal("Unrecognized version")
 		}
@@ -190,8 +193,9 @@ func TestFindAvailableVersiosn(t *testing.T) {
 	mockClient118.EXPECT().Ping().Return(fmt.Errorf("Test error!"))
 	mockClient119.EXPECT().Ping()
 	mockClient120.EXPECT().Ping()
+	mockClient121.EXPECT().Ping()
 
-	expectedVersions := []DockerVersion{Version_1_17, Version_1_19, Version_1_20}
+	expectedVersions := []DockerVersion{Version_1_17, Version_1_19, Version_1_20, Version_1_21}
 
 	factory := NewFactory(expectedEndpoint)
 	versions := factory.FindAvailableVersions()


### PR DESCRIPTION
added the awslogs driver. this required adding the new 1.21 API version