### PR TITLE
Engine: Improve exitcode detection and logging

### DIFF
--- a/agent/api/status.go
+++ b/agent/api/status.go
@@ -20,9 +20,9 @@ var taskStatusMap = map[string]TaskStatus{
 	"STOPPED": TaskStopped,
 }
 
-func (ts *TaskStatus) String() string {
+func (ts TaskStatus) String() string {
 	for k, v := range taskStatusMap {
-		if v == *ts {
+		if v == ts {
 			return k
 		}
 	}
@@ -52,9 +52,9 @@ var containerStatusMap = map[string]ContainerStatus{
 	"STOPPED": ContainerStopped,
 }
 
-func (cs *ContainerStatus) String() string {
+func (cs ContainerStatus) String() string {
 	for k, v := range containerStatusMap {
-		if v == *cs {
+		if v == cs {
 			return k
 		}
 	}
@@ -93,16 +93,10 @@ func (cs *ContainerStatus) BackendRecognized() bool {
 	return *cs == ContainerRunning || *cs == ContainerStopped
 }
 
-func (cs *ContainerStatus) Terminal() bool {
-	if cs == nil {
-		return false
-	}
-	return *cs == ContainerStopped
+func (cs ContainerStatus) Terminal() bool {
+	return cs == ContainerStopped
 }
 
-func (ts *TaskStatus) Terminal() bool {
-	if ts == nil {
-		return false
-	}
-	return *ts == TaskStopped
+func (ts TaskStatus) Terminal() bool {
+	return ts == TaskStopped
 }

--- a/agent/api/types.go
+++ b/agent/api/types.go
@@ -199,7 +199,7 @@ func (t *TaskStateChange) String() string {
 }
 
 func (t *Task) String() string {
-	res := fmt.Sprintf("%s-%s %s, Status: (%s->%s)", t.Family, t.Version, t.Arn, t.KnownStatus.String(), t.DesiredStatus.String())
+	res := fmt.Sprintf("%s:%s %s, Status: (%s->%s)", t.Family, t.Version, t.Arn, t.KnownStatus.String(), t.DesiredStatus.String())
 	res += " Containers: ["
 	for _, c := range t.Containers {
 		res += fmt.Sprintf("%s (%s->%s),", c.Name, c.KnownStatus.String(), c.DesiredStatus.String())
@@ -266,7 +266,7 @@ type VolumeFrom struct {
 }
 
 func (c *Container) String() string {
-	ret := fmt.Sprintf("%s-%s (%s->%s)", c.Name, c.Image, c.KnownStatus.String(), c.DesiredStatus.String())
+	ret := fmt.Sprintf("%s(%s) (%s->%s)", c.Name, c.Image, c.KnownStatus.String(), c.DesiredStatus.String())
 	if c.KnownExitCode != nil {
 		ret += " - Exit: " + strconv.Itoa(*c.KnownExitCode)
 	}

--- a/agent/engine/docker_container_engine_test.go
+++ b/agent/engine/docker_container_engine_test.go
@@ -233,6 +233,9 @@ func TestCreateContainer(t *testing.T) {
 	if metadata.DockerId != "id" {
 		t.Error("Wrong id")
 	}
+	if metadata.ExitCode != nil {
+		t.Error("Expected a created container to not have an exit code")
+	}
 }
 
 func TestStartContainerTimeout(t *testing.T) {
@@ -407,7 +410,8 @@ func TestContainerEvents(t *testing.T) {
 		stoppedContainer := &docker.Container{
 			ID: "cid3" + strconv.Itoa(i),
 			State: docker.State{
-				ExitCode: 20,
+				FinishedAt: time.Now(),
+				ExitCode:   20,
 			},
 		}
 		mockDocker.EXPECT().InspectContainer("cid3"+strconv.Itoa(i)).Return(stoppedContainer, nil)

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -29,6 +29,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/statemanager"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 	utilsync "github.com/aws/amazon-ecs-agent/agent/utils/sync"
+	"github.com/cihub/seelog"
 )
 
 const (
@@ -466,6 +467,7 @@ func (engine *DockerTaskEngine) createContainer(task *api.Task, container *api.C
 	// we die before 'createContainer' returns because we can inspect by
 	// name
 	engine.state.AddContainer(&api.DockerContainer{DockerName: containerName, Container: container}, task)
+	seelog.Infof("Created container name mapping for task %s - %s -> %s", task, container, containerName)
 	engine.saver.ForceSave()
 
 	metadata := client.CreateContainer(config, hostConfig, containerName)
@@ -473,7 +475,7 @@ func (engine *DockerTaskEngine) createContainer(task *api.Task, container *api.C
 		return metadata
 	}
 	engine.state.AddContainer(&api.DockerContainer{DockerId: metadata.DockerId, DockerName: containerName, Container: container}, task)
-	log.Info("Created container successfully", "task", task, "container", container)
+	seelog.Infof("Created docker container for task %s: %s -> %s", task, container, metadata.DockerId)
 	return metadata
 }
 

--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -20,6 +20,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/api"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dependencygraph"
 	"github.com/aws/amazon-ecs-agent/agent/utils/ttime"
+	"github.com/cihub/seelog"
 )
 
 const (
@@ -176,7 +177,7 @@ func (mtask *managedTask) handleDesiredStatusChange(desiredStatus api.TaskStatus
 	// acs says it should be if it is compatible
 	llog.Debug("New acs transition", "status", desiredStatus.String(), "seqnum", seqnum, "taskSeqnum", mtask.StopSequenceNumber)
 	if desiredStatus <= mtask.DesiredStatus {
-		llog.Debug("Redundant transition; ignoring", "old", mtask.DesiredStatus.String(), "new", desiredStatus.String())
+		llog.Debug("Redundant task transition; ignoring", "old", mtask.DesiredStatus.String(), "new", desiredStatus.String())
 		return
 	}
 	if desiredStatus == api.TaskStopped && seqnum != 0 && mtask.StopSequenceNumber == 0 {
@@ -223,7 +224,7 @@ func (mtask *managedTask) handleContainerChange(containerChange dockerContainerC
 		}
 	}
 	if event.Status <= container.KnownStatus {
-		llog.Info("Redundant status change; ignoring", "current", container.KnownStatus.String(), "change", event.Status.String())
+		seelog.Infof("Redundant container state change for task %s: %s to %s, but already %s", mtask.Task, container, event.Status, container.KnownStatus)
 		return
 	}
 	container.KnownStatus = event.Status


### PR DESCRIPTION
Prior to this change, the 'exitcode' would be set in any case where the
container was not running, including created. This scopes it down to
only be after it exists. This also improves logging.

In addition, this ensures we log the DockerID and name explicitly at
info level since recovering that mapping from logs is often valuable

Example of the log lines showing name and ID:
```
2015-11-25T23:04:09Z [INFO] Created container name mapping for task sleep5:3 arn:aws:ecs:us-west-2:123:task/my-arn-uuid, Status: (NONE->RUNNING) Containers: [sleep5 (PULLED->RUNNING),] - sleep5(busybox) (PULLED->RUNNING) -> ecs-sleep5-3-sleep5-beb0a7b5ef9683ac6f00
2015-11-25T23:04:09Z [INFO] Created docker container for task sleep5:3 arn:aws:ecs:us-west-2:123:task/my-arn-uuid, Status: (NONE->RUNNING) Containers: [sleep5 (PULLED->RUNNING),]: sleep5(busybox) (PULLED->RUNNING) -> 2d3f2239d8f027cd244ca4f484872217b9edfed032b849828d80c3ae2d6b88e6
2015-11-25T23:04:09Z [INFO] Redundant container state change for task sleep5:3 arn:aws:ecs:us-west-2:123:task/my-arn-uuid, Status: (CREATED->RUNNING) Containers: [sleep5 (CREATED->RUNNING),]: sleep5(busybox) (CREATED->RUNNING) to CREATED, but already CREATED
```

I also verified functional tests are still passing with this.

r? @samuelkarp, @juanrhenals