### PR TITLE
Do not treat OOM events as a container stopping

### DIFF
--- a/agent/engine/docker_container_engine.go
+++ b/agent/engine/docker_container_engine.go
@@ -557,8 +557,6 @@ func (dg *DockerGoClient) ContainerEvents(ctx context.Context) (<-chan DockerCon
 				fallthrough
 			case "die":
 				fallthrough
-			case "oom":
-				fallthrough
 			case "kill":
 				status = api.ContainerStopped
 			case "rename":
@@ -573,6 +571,12 @@ func (dg *DockerGoClient) ContainerEvents(ctx context.Context) (<-chan DockerCon
 				// These result in us falling through to inspect the container, some
 				// out of caution, some because it's a form of state change
 
+			case "oom":
+				seelog.Infof("process within container %v died due to OOM", event.ID)
+				// "oom" can either means any process got OOM'd, but doesn't always
+				// mean the container dies (non-init processes). If the container also
+				// dies, you see a "die" status as well; we'll update suitably there
+				fallthrough
 			case "pause":
 				// non image events that aren't of interest currently
 				fallthrough

--- a/agent/engine/docker_container_engine_test.go
+++ b/agent/engine/docker_container_engine_test.go
@@ -436,7 +436,7 @@ func TestContainerEvents(t *testing.T) {
 	}
 
 	// Verify the following events do not translate into our event stream
-	for _, eventStatus := range []string{"pause", "export", "pull", "untag", "delete"} {
+	for _, eventStatus := range []string{"pause", "export", "pull", "untag", "delete", "oom"} {
 		events <- &docker.APIEvents{ID: "123", Status: eventStatus}
 		select {
 		case <-dockerEvents:


### PR DESCRIPTION
When a child process within a container dies, an OOM event is also
emitted, but the container could continue on.
If an OOM event is fatal, it will be followed by a 'die' event, which we
will handle appropriately.

Relates to #261, docker/docker#18433

I added an integ test to validate our assumption with Docker (I'll run it against more version of docker shortly and won't merge until I verify it passes on 1.5 - 1.9).

r? @samuelkarp @aaithal 