### PR TITLE
Functional tests: Correct checks on container error strings

### DIFF
--- a/agent/functional_tests/tests/functionaltests_test.go
+++ b/agent/functional_tests/tests/functionaltests_test.go
@@ -74,7 +74,9 @@ func TestPullInvalidImage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Expected to start invalid-image task: %v", err)
 	}
-	testTask.ExpectErrorType("error", "CannotPullContainerError", 1*time.Minute)
+	if err = testTask.ExpectErrorType("error", "CannotPullContainerError", 1*time.Minute); err != nil {
+		t.Error(err)
+	}
 }
 
 // TestOOMContainer verifies that an OOM container returns an error
@@ -86,7 +88,9 @@ func TestOOMContainer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Expected to start invalid-image task: %v", err)
 	}
-	testTask.ExpectErrorType("error", "OutOfMemoryError", 1*time.Minute)
+	if err = testTask.ExpectErrorType("error", "OutOfMemoryError", 1*time.Minute); err != nil {
+		t.Error(err)
+	}
 }
 
 // TestSavedState verifies that stopping the agent, stopping a container under

--- a/agent/functional_tests/tests/functionaltests_test.go
+++ b/agent/functional_tests/tests/functionaltests_test.go
@@ -81,6 +81,7 @@ func TestPullInvalidImage(t *testing.T) {
 
 // TestOOMContainer verifies that an OOM container returns an error
 func TestOOMContainer(t *testing.T) {
+	RequireDockerVersion(t, "<1.9.0,>1.9.1") // https://github.com/docker/docker/issues/18510
 	agent := RunAgent(t, nil)
 	defer agent.Cleanup()
 

--- a/agent/functional_tests/util/compare_versions_test.go
+++ b/agent/functional_tests/util/compare_versions_test.go
@@ -151,6 +151,21 @@ func TestVersionMatches(t *testing.T) {
 			selector:       ">1.0.0",
 			expectedOutput: true,
 		},
+		{
+			version:        "1.1.0",
+			selector:       "2.1.0,1.1.0",
+			expectedOutput: true,
+		},
+		{
+			version:        "2.0.0",
+			selector:       "2.1.0,1.1.0",
+			expectedOutput: false,
+		},
+		{
+			version:        "1.9.1",
+			selector:       ">=1.9.0,<=1.9.1",
+			expectedOutput: true,
+		},
 	}
 
 	for i, testCase := range testCases {
@@ -159,7 +174,7 @@ func TestVersionMatches(t *testing.T) {
 			t.Errorf("#%v: Unexpected error %v", i, err)
 		}
 		if result != testCase.expectedOutput {
-			t.Errorf("#%v: expected %v but got %v", i, testCase.expectedOutput, result)
+			t.Errorf("#%v: %v(%v) expected %v but got %v", i, testCase.version, testCase.selector, testCase.expectedOutput, result)
 		}
 	}
 }

--- a/agent/functional_tests/util/utils.go
+++ b/agent/functional_tests/util/utils.go
@@ -515,3 +515,25 @@ func (task *TestTask) Stop() error {
 	})
 	return err
 }
+
+func RequireDockerVersion(t *testing.T, selector string) {
+	dockerClient, err := docker.NewClientFromEnv()
+	if err != nil {
+		t.Fatalf("Could not get docker client to check version: %v", err)
+	}
+	dockerVersion, err := dockerClient.Version()
+	if err != nil {
+		t.Fatalf("Could not get docker version: %v", err)
+	}
+
+	version := dockerVersion.Get("Version")
+
+	match, err := Version(version).Matches(selector)
+	if err != nil {
+		t.Fatalf("Could not check docker version to match required: %v", err)
+	}
+
+	if !match {
+		t.Skipf("Skipping test; requires %v, but version is %v", selector, version)
+	}
+}


### PR DESCRIPTION
This also skips the OOM message check for a pair of known broken versions of Docker.

r? @samuelkarp 