### PR TITLE
make the task cleanup wait time configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ configure them as something other than the defaults.
 | `ECS_DISABLE_PRIVILEGED` | `true` | Whether launching privileged containers is disabled on the Container Instance. | `false` |
 | `ECS_SELINUX_CAPABLE` | `true` | Whether SELinux is available on the Container Instance. | `false` |
 | `ECS_APPARMOR_CAPABLE` | `true` | Whether AppArmor is available on the Container Instance. | `false` |
-| `ECS_ENGINE_CLEANUP_WAIT_MINUTES` | 3 hours | Time to wait from when a task is stopped until the docker container is removed |
+| `ECS_ENGINE_CLEANUP_WAIT_DURATION` | 3 hours | Time to wait from when a task is stopped until the docker container is removed |
 
 ### Persistence
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ configure them as something other than the defaults.
 | `ECS_DISABLE_PRIVILEGED` | `true` | Whether launching privileged containers is disabled on the Container Instance. | `false` |
 | `ECS_SELINUX_CAPABLE` | `true` | Whether SELinux is available on the Container Instance. | `false` |
 | `ECS_APPARMOR_CAPABLE` | `true` | Whether AppArmor is available on the Container Instance. | `false` |
+| `ECS_ENGINE_CLEANUP_WAIT_MINUTES` | 3 hours | Time to wait from when a task is stopped until the docker container is removed |
 
 ### Persistence
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ configure them as something other than the defaults.
 | `ECS_DISABLE_PRIVILEGED` | `true` | Whether launching privileged containers is disabled on the Container Instance. | `false` |
 | `ECS_SELINUX_CAPABLE` | `true` | Whether SELinux is available on the Container Instance. | `false` |
 | `ECS_APPARMOR_CAPABLE` | `true` | Whether AppArmor is available on the Container Instance. | `false` |
-| `ECS_ENGINE_CLEANUP_WAIT_DURATION` | 3 hours | Time to wait from when a task is stopped until the docker container is removed |
+| `ECS_ENGINE_CLEANUP_WAIT_DURATION` | 3h | Time duration to wait from when a task is stopped until the docker container is removed |
 
 ### Persistence
 

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -189,7 +189,7 @@ func parseEnvVariableInt(envVar string, defaultValue uint16) (uint16) {
 	if envVal == "" {
 			var16 = defaultValue
 	} else {
-    var64, err := strconv.ParseUint(envVal, 10, 16)
+		var64, err := strconv.ParseUint(envVal, 10, 16)
 		if err != nil {
 			log.Warn("Invalid format for \"" + envVar + "\" environment variable; expected unsigned integer.", "err", err)
 			var16 = defaultValue
@@ -197,7 +197,7 @@ func parseEnvVariableInt(envVar string, defaultValue uint16) (uint16) {
 			var16 = uint16(var64)
 		}
 	}
-  return var16
+	return var16
 }
 
 func parseEnvVariableDuration(envVar string, defaultValue time.Duration) (time.Duration) {

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -268,7 +268,7 @@ func EnvironmentConfig() Config {
 	disableMetrics := utils.ParseBool(os.Getenv("ECS_DISABLE_METRICS"), false)
 	dockerGraphPath := os.Getenv("ECS_DOCKER_GRAPHPATH")
 
-	reservedMemory := parseEnvVariableInt("ECS_RESERVED_MEMORY", DefaultConfig().ReservedMemory)
+	reservedMemory := parseEnvVariableInt("ECS_RESERVED_MEMORY", 0)
 
 	cleanupWaitDuration := parseEnvVariableDuration("ECS_ENGINE_CLEANUP_WAIT_DURATION", DefaultConfig().CleanupWaitDuration)
 

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -200,6 +200,22 @@ func parseEnvVariableInt(envVar string, defaultValue uint16) (uint16) {
   return var16
 }
 
+func parseEnvVariableDuration(envVar string, defaultValue time.Duration) (time.Duration) {
+	envVal := os.Getenv(envVar)
+	if envVal == "" {
+		log.Debug("Environment variable empty: " + envVar + " using default.")
+		return defaultValue
+	} else {
+		envDuration, durErr := time.ParseDuration(envVal)
+		if durErr != nil {
+			log.Warn("Could not parse duration value: " + envVal + " for Env Var " + envVar + " using default. ", durErr)
+			return defaultValue
+		} else {
+			return envDuration
+		}
+	}
+}
+
 // EnvironmentConfig reads the given configs from the environment and attempts
 // to convert them to the given type
 func EnvironmentConfig() Config {
@@ -254,11 +270,7 @@ func EnvironmentConfig() Config {
 
 	reservedMemory := parseEnvVariableInt("ECS_RESERVED_MEMORY", DefaultConfig().ReservedMemory)
 
-	cleanupWaitDuration := DefaultConfig().CleanupWaitDuration
-	cleanupWaitDurationEnv, cwsErr := time.ParseDuration(os.Getenv("ECS_ENGINE_CLEANUP_WAIT_DURATION"))
-  if cwsErr != nil {
-    cleanupWaitDuration = cleanupWaitDurationEnv
-  }
+	cleanupWaitDuration := parseEnvVariableDuration("ECS_ENGINE_CLEANUP_WAIT_DURATION", DefaultConfig().CleanupWaitDuration)
 
 	availableLoggingDriversEnv := os.Getenv("ECS_AVAILABLE_LOGGING_DRIVERS")
 	loggingDriverDecoder := json.NewDecoder(strings.NewReader(availableLoggingDriversEnv))
@@ -295,7 +307,7 @@ func EnvironmentConfig() Config {
 		PrivilegedDisabled:      privilegedDisabled,
 		SELinuxCapable:          seLinuxCapable,
 		AppArmorCapable:         appArmorCapable,
-		CleanupWaitDuration:      cleanupWaitDuration,
+		CleanupWaitDuration:     cleanupWaitDuration,
 	}
 }
 

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -255,7 +255,7 @@ func EnvironmentConfig() Config {
 	reservedMemory := parseEnvVariableInt("ECS_RESERVED_MEMORY", DefaultConfig().ReservedMemory)
 
 	cleanupWaitDuration := DefaultConfig().CleanupWaitDuration
-	cleanupWaitDurationEnv, cwsErr := time.ParseDuration(os.Getenv("ECS_ENGINE_CLEANUP_WAIT_SECONDS"))
+	cleanupWaitDurationEnv, cwsErr := time.ParseDuration(os.Getenv("ECS_ENGINE_CLEANUP_WAIT_DURATION"))
   if cwsErr != nil {
     cleanupWaitDuration = cleanupWaitDurationEnv
   }

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/ec2"
 	"github.com/aws/amazon-ecs-agent/agent/ec2/mocks"
@@ -84,6 +85,7 @@ func TestEnvironmentConfig(t *testing.T) {
 	os.Setenv("ECS_SELINUX_CAPABLE", "true")
 	os.Setenv("ECS_APPARMOR_CAPABLE", "true")
 	os.Setenv("ECS_DISABLE_PRIVILEGED", "true")
+	os.Setenv("ECS_ENGINE_CLEANUP_WAIT_DURATION", "20s")
 
 	conf := EnvironmentConfig()
 	if conf.Cluster != "myCluster" {
@@ -109,6 +111,9 @@ func TestEnvironmentConfig(t *testing.T) {
 	}
 	if !conf.AppArmorCapable {
 		t.Error("Wrong value for AppArmorCapable")
+	}
+	if conf.CleanupWaitDuration != (20 * time.Second) {
+		t.Error("Wrong value for CleanupWaitDuration")
 	}
 }
 

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -15,6 +15,7 @@ package config
 
 import (
 	"encoding/json"
+	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerclient"
 )
@@ -98,6 +99,10 @@ type Config struct {
 	// AppArmorCapable specifies whether the Agent is capable of using AppArmor
 	// security options
 	AppArmorCapable bool
+
+	// CleanupWaitDuration specifies the time to wait after a task is stopped
+	// until cleanup of task resources is started.
+	CleanupWaitDuration time.Duration
 }
 
 // SensitiveRawMessage is a struct to store some data that should not be logged

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -394,6 +394,7 @@ func TestCapabilities(t *testing.T) {
 		PrivilegedDisabled: false,
 		SELinuxCapable:     true,
 		AppArmorCapable:    true,
+		CleanupWaitDuration: config.DefaultConfig().CleanupWaitDuration,
 	}
 	ctrl, client, taskEngine := mocks(t, conf)
 	defer ctrl.Finish()

--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -24,7 +24,6 @@ import (
 )
 
 const (
-	taskStoppedDuration           = 3 * time.Hour
 	steadyStateTaskVerifyInterval = 10 * time.Minute
 )
 
@@ -161,7 +160,7 @@ func (task *managedTask) overseeTask() {
 		llog.Debug("Marking done for this sequence", "seqnum", task.StopSequenceNumber)
 		task.engine.taskStopGroup.Done(task.StopSequenceNumber)
 	}
-	task.cleanupTask()
+	task.cleanupTask(task.engine.cfg.CleanupWaitDuration)
 }
 
 func (mtask *managedTask) emitCurrentStatus() {
@@ -415,7 +414,7 @@ func (task *managedTask) progressContainers() {
 	task.UpdateStatus()
 }
 
-func (task *managedTask) cleanupTask() {
+func (task *managedTask) cleanupTask(taskStoppedDuration time.Duration) {
 	cleanupTime := ttime.After(task.KnownStatusTime.Add(taskStoppedDuration).Sub(ttime.Now()))
 	cleanupTimeBool := make(chan bool)
 	go func() {


### PR DESCRIPTION
resolves #70

I have not yet tested this in any manual or automated way. How can I start running this forked version on my ECS cluster?