### PR TITLE
Persist dockerID even in the case of errors

### DIFF
--- a/agent/engine/docker_container_engine.go
+++ b/agent/engine/docker_container_engine.go
@@ -502,7 +502,7 @@ func (dg *dockerGoClient) GetContainerName(id string) (string, error) {
 func (dg *dockerGoClient) containerMetadata(id string) DockerContainerMetadata {
 	dockerContainer, err := dg.InspectContainer(id)
 	if err != nil {
-		return DockerContainerMetadata{Error: CannotXContainerError{"Inspect", err.Error()}}
+		return DockerContainerMetadata{DockerId: id, Error: CannotXContainerError{"Inspect", err.Error()}}
 	}
 	return metadataFromContainer(dockerContainer)
 }

--- a/agent/engine/docker_container_engine_test.go
+++ b/agent/engine/docker_container_engine_test.go
@@ -322,6 +322,30 @@ func TestCreateContainerTimeout(t *testing.T) {
 	wait.Done()
 }
 
+func TestCreateContainerInspectTimeout(t *testing.T) {
+	mockDocker, client, testTime, done := dockerclientSetup(t)
+	defer done()
+
+	wait := &sync.WaitGroup{}
+	wait.Add(1)
+	config := docker.CreateContainerOptions{Config: &docker.Config{Memory: 100}, Name: "containerName"}
+	gomock.InOrder(
+		mockDocker.EXPECT().CreateContainer(config).Return(&docker.Container{ID: "id"}, nil),
+		mockDocker.EXPECT().InspectContainer("id").Do(func(x interface{}) {
+			testTime.Warp(inspectContainerTimeout)
+			wait.Wait()
+		}),
+	)
+	metadata := client.CreateContainer(config.Config, nil, config.Name)
+	if metadata.DockerId != "id" {
+		t.Error("Expected ID to be set even if inspect failed; was " + metadata.DockerId)
+	}
+	if metadata.Error == nil {
+		t.Error("Expected error for inspect timeout")
+	}
+	wait.Done()
+}
+
 func TestCreateContainer(t *testing.T) {
 	mockDocker, client, _, done := dockerclientSetup(t)
 	defer done()

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -472,10 +472,9 @@ func (engine *DockerTaskEngine) createContainer(task *api.Task, container *api.C
 	engine.saver.ForceSave()
 
 	metadata := client.CreateContainer(config, hostConfig, containerName)
-	if metadata.Error != nil {
-		return metadata
+	if metadata.DockerId != "" {
+		engine.state.AddContainer(&api.DockerContainer{DockerId: metadata.DockerId, DockerName: containerName, Container: container}, task)
 	}
-	engine.state.AddContainer(&api.DockerContainer{DockerId: metadata.DockerId, DockerName: containerName, Container: container}, task)
 	seelog.Infof("Created docker container for task %s: %s -> %s", task, container, metadata.DockerId)
 	return metadata
 }


### PR DESCRIPTION
For example, an inspect error prior to this change would have prevented
the ID from being persisted.

This could manifest in the form of a created container's ID being lost,
and thus never being removed.

r? @samuelkarp @juanrhenals 