### PR TITLE
resolves #126 Tune SIGKILL timeout with ENV_VAR : ECS_CONTAINER_STOP_…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ _bin/
 /misc/gremlin/gremlin
 .agignore
 *.sublime-*
+
+# Jetbrains files
+.idea/
+amazon-ecs-agent.iml

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -23,6 +23,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/ec2"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerclient"
@@ -147,7 +148,7 @@ func DefaultConfig() Config {
 		DisableMetrics:          	false,
 		DockerGraphPath:        	"/var/lib/docker",
 		ReservedMemory:          	0,
-		DockerStopTimeoutSeconds:	30,
+		DockerStopTimeoutSeconds:	time.Duration(30)*time.Second,
 		AvailableLoggingDrivers: 	[]dockerclient.LoggingDriver{dockerclient.JsonFileDriver},
 	}
 }
@@ -251,9 +252,7 @@ func EnvironmentConfig() Config {
 
 	dockerStopTimeoutSecondsEnv := os.Getenv("ECS_CONTAINER_STOP_TIMEOUT")
 	var dockerStopTimeoutSeconds uint64
-	if dockerStopTimeoutSecondsEnv == "" {
-		dockerStopTimeoutSeconds = 30
-	} else {
+	if dockerStopTimeoutSecondsEnv != "" {
 		dockerStopTimeoutSeconds, err = strconv.ParseUint(dockerStopTimeoutSecondsEnv, 10, 64)
 		if err != nil {
 			log.Warn("Invalid format for \"ECS_CONTAINER_STOP_TIMEOUT\" environment variable; expected unsigned integer.", "err", err)
@@ -294,7 +293,7 @@ func EnvironmentConfig() Config {
 		DisableMetrics:          	disableMetrics,
 		DockerGraphPath:         	dockerGraphPath,
 		ReservedMemory:          	reservedMemory,
-		DockerStopTimeoutSeconds: 	dockerStopTimeoutSeconds,
+		DockerStopTimeoutSeconds: 	(time.Duration(dockerStopTimeoutSeconds)*time.Second),
 		AvailableLoggingDrivers: 	availableLoggingDrivers,
 		PrivilegedDisabled:      	privilegedDisabled,
 		SELinuxCapable:          	seLinuxCapable,

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -16,6 +16,7 @@ package config
 import (
 	"errors"
 	"os"
+	"time"
 	"reflect"
 	"testing"
 
@@ -99,7 +100,8 @@ func TestEnvironmentConfig(t *testing.T) {
 	if conf.ReservedMemory != 20 {
 		t.Error("Wrong value for ReservedMemory", conf.ReservedMemory)
 	}
-	if conf.DockerStopTimeoutSeconds != 30 {
+	expectedDuration, _ := time.ParseDuration("30s")
+	if conf.DockerStopTimeoutSeconds != expectedDuration {
 		t.Error("Wrong value for DockerStopTimeoutSeconds", conf.DockerStopTimeoutSeconds)
 	}
 	if !reflect.DeepEqual(conf.AvailableLoggingDrivers, []dockerclient.LoggingDriver{dockerclient.SyslogDriver}) {
@@ -173,8 +175,9 @@ func TestConfigDefault(t *testing.T) {
 	if cfg.ReservedMemory != 0 {
 		t.Error("Default reserved memory set incorrectly")
 	}
-	if cfg.DockerStopTimeoutSeconds != 30 {
-		t.Error("Default docker stop container timeout set incorrectly")
+	expectedTimeout, _ := time.ParseDuration("30s")
+	if cfg.DockerStopTimeoutSeconds != expectedTimeout {
+		t.Error("Default docker stop container timeout set incorrectly", cfg.DockerStopTimeoutSeconds)
 	}
 	if cfg.PrivilegedDisabled {
 		t.Error("Default PrivilegedDisabled set incorrectly")

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -80,6 +80,7 @@ func TestEnvironmentConfig(t *testing.T) {
 	os.Setenv("ECS_CLUSTER", "myCluster")
 	os.Setenv("ECS_RESERVED_PORTS_UDP", "[42,99]")
 	os.Setenv("ECS_RESERVED_MEMORY", "20")
+	os.Setenv("ECS_CONTAINER_STOP_TIMEOUT", "30")
 	os.Setenv("ECS_AVAILABLE_LOGGING_DRIVERS", "[\""+string(dockerclient.SyslogDriver)+"\"]")
 	os.Setenv("ECS_SELINUX_CAPABLE", "true")
 	os.Setenv("ECS_APPARMOR_CAPABLE", "true")
@@ -97,6 +98,9 @@ func TestEnvironmentConfig(t *testing.T) {
 	}
 	if conf.ReservedMemory != 20 {
 		t.Error("Wrong value for ReservedMemory", conf.ReservedMemory)
+	}
+	if conf.DockerStopTimeoutSeconds != 30 {
+		t.Error("Wrong value for DockerStopTimeoutSeconds", conf.DockerStopTimeoutSeconds)
 	}
 	if !reflect.DeepEqual(conf.AvailableLoggingDrivers, []dockerclient.LoggingDriver{dockerclient.SyslogDriver}) {
 		t.Error("Wrong value for AvailableLoggingDrivers", conf.AvailableLoggingDrivers)
@@ -168,6 +172,9 @@ func TestConfigDefault(t *testing.T) {
 	}
 	if cfg.ReservedMemory != 0 {
 		t.Error("Default reserved memory set incorrectly")
+	}
+	if cfg.DockerStopTimeoutSeconds != 30 {
+		t.Error("Default docker stop container timeout set incorrectly")
 	}
 	if cfg.PrivilegedDisabled {
 		t.Error("Default PrivilegedDisabled set incorrectly")

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -14,6 +14,7 @@
 package config
 
 import (
+	"time"
 	"encoding/json"
 
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerclient"
@@ -85,7 +86,7 @@ type Config struct {
 
 	// ContainerTimeout specifies the amount time before a SIGKILL is issued to
 	// containers managed by ECS
-	DockerStopTimeoutSeconds uint64
+	DockerStopTimeoutSeconds time.Duration
 
 	// AvailableLoggingDrivers specifies the logging drivers available for use
 	// with Docker.  If not set, it defaults to ["json-file"].

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -83,6 +83,10 @@ type Config struct {
 	// other than containers managed by ECS
 	ReservedMemory uint16
 
+	// ContainerTimeout specifies the amount time before a SIGKILL is issued to
+	// containers managed by ECS
+	DockerStopTimeoutSeconds uint64
+
 	// AvailableLoggingDrivers specifies the logging drivers available for use
 	// with Docker.  If not set, it defaults to ["json-file"].
 	AvailableLoggingDrivers []dockerclient.LoggingDriver

--- a/agent/engine/docker_container_engine.go
+++ b/agent/engine/docker_container_engine.go
@@ -48,7 +48,7 @@ const (
 	pullImageTimeout        = 2 * time.Hour
 	createContainerTimeout  = 3 * time.Minute
 	startContainerTimeout   = 1 * time.Minute + 30*time.Second
-	stopContainerTimeout    = 1 * time.Minute
+	stopContainerTimeout    = 30 * time.Second
 	removeContainerTimeout  = 5 * time.Minute
 	inspectContainerTimeout = 30 * time.Second
 	listContainersTimeout   = 10 * time.Minute
@@ -434,8 +434,8 @@ func (dg *dockerGoClient) inspectContainer(dockerId string) (*docker.Container, 
 }
 
 func (dg *dockerGoClient) StopContainer(dockerId string) DockerContainerMetadata {
-	timeout := ttime.After(stopContainerTimeout + (time.Duration(dg.config.DockerStopTimeoutSeconds)*time.Second))
-
+	dockerStopTimeout := time.Duration(dg.config.DockerStopTimeoutSeconds)*time.Second
+	timeout := ttime.After(stopContainerTimeout + dockerStopTimeout)
 	ctx, cancelFunc := context.WithCancel(context.TODO()) // Could pass one through from engine
 	// Buffered channel so in the case of timeout it takes one write, never gets
 	// read, and can still be GC'd
@@ -446,7 +446,7 @@ func (dg *dockerGoClient) StopContainer(dockerId string) DockerContainerMetadata
 		return resp
 	case <-timeout:
 		cancelFunc()
-		return DockerContainerMetadata{Error: &DockerTimeoutError{stopContainerTimeout, "stopped"}}
+		return DockerContainerMetadata{Error: &DockerTimeoutError{stopContainerTimeout + dockerStopTimeout, "stopped"}}
 	}
 }
 

--- a/agent/engine/docker_container_engine.go
+++ b/agent/engine/docker_container_engine.go
@@ -4,7 +4,7 @@
 // not use this file except in compliance with the License. A copy of the
 // License is located at
 //
-//	http://aws.amazon.com/apache2.0/
+//      http://aws.amazon.com/apache2.0/
 //
 // or in the "license" file accompanying this file. This file is distributed
 // on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
@@ -40,22 +40,22 @@ import (
 )
 
 const (
-	dockerDefaultTag         = "latest"
+	dockerDefaultTag = "latest"
 )
 
 // Timelimits for docker operations enforced above docker
 const (
 	pullImageTimeout        = 2 * time.Hour
 	createContainerTimeout  = 3 * time.Minute
-	startContainerTimeout   = 1 * time.Minute + 30*time.Second
+	startContainerTimeout   = 1*time.Minute + 30*time.Second
 	stopContainerAPITimeout = 30 * time.Second
 	removeContainerTimeout  = 5 * time.Minute
 	inspectContainerTimeout = 30 * time.Second
 	listContainersTimeout   = 10 * time.Minute
 
-	// dockerPullBeginTimeout is the timeout from when a 'pull' is called to when
-	// we expect to see output on the pull progress stream. This is to work
-	// around a docker bug which sometimes results in pulls not progressing.
+// dockerPullBeginTimeout is the timeout from when a 'pull' is called to when
+// we expect to see output on the pull progress stream. This is to work
+// around a docker bug which sometimes results in pulls not progressing.
 	dockerPullBeginTimeout = 5 * time.Minute
 )
 
@@ -112,7 +112,7 @@ func (dg *dockerGoClient) WithVersion(version dockerclient.DockerVersion) Docker
 		clientFactory: dg.clientFactory,
 		version:       version,
 		auth:          dg.auth,
-		config:	       dg.config,
+		config:        dg.config,
 	}
 }
 
@@ -153,7 +153,7 @@ func NewDockerGoClient(clientFactory dockerclient.Factory, authType string, auth
 		clientFactory:    clientFactory,
 		auth:             dockerauth.NewDockerAuthProvider(authType, authData.Contents()),
 		ecrClientFactory: ecr.NewECRFactory(acceptInsecureCert),
-		config: 		  &cfg,
+		config:           &cfg,
 	}, nil
 }
 
@@ -344,7 +344,7 @@ func (dg *dockerGoClient) createContainer(ctx context.Context, config *docker.Co
 	dockerContainer, err := client.CreateContainer(containerOptions)
 	select {
 	case <-ctx.Done():
-		// Parent function already timed out; no need to get container metadata
+	// Parent function already timed out; no need to get container metadata
 		return DockerContainerMetadata{}
 	default:
 	}
@@ -378,7 +378,7 @@ func (dg *dockerGoClient) startContainer(ctx context.Context, id string) DockerC
 	err = client.StartContainer(id, nil)
 	select {
 	case <-ctx.Done():
-		// Parent function already timed out; no need to get container metadata
+	// Parent function already timed out; no need to get container metadata
 		return DockerContainerMetadata{}
 	default:
 	}
@@ -458,8 +458,8 @@ func (dg *dockerGoClient) stopContainer(ctx context.Context, dockerId string) Do
 	err = client.StopContainer(dockerId, uint(dg.config.DockerStopTimeoutSeconds))
 	select {
 	case <-ctx.Done():
-		// parent function has already timed out and returned; we're writing to a
-		// buffered channel that will never be read
+	// parent function has already timed out and returned; we're writing to a
+	// buffered channel that will never be read
 		return DockerContainerMetadata{}
 	default:
 	}
@@ -589,8 +589,8 @@ func (dg *dockerGoClient) ContainerEvents(ctx context.Context) (<-chan DockerCon
 			case "resize":
 			case "destroy":
 			case "unpause":
-				// These result in us falling through to inspect the container, some
-				// out of caution, some because it's a form of state change
+			// These result in us falling through to inspect the container, some
+			// out of caution, some because it's a form of state change
 
 			case "oom":
 				seelog.Infof("process within container %v died due to OOM", event.ID)

--- a/agent/engine/docker_container_engine_test.go
+++ b/agent/engine/docker_container_engine_test.go
@@ -322,30 +322,6 @@ func TestCreateContainerTimeout(t *testing.T) {
 	wait.Done()
 }
 
-func TestCreateContainerInspectTimeout(t *testing.T) {
-	mockDocker, client, testTime, done := dockerclientSetup(t)
-	defer done()
-
-	wait := &sync.WaitGroup{}
-	wait.Add(1)
-	config := docker.CreateContainerOptions{Config: &docker.Config{Memory: 100}, Name: "containerName"}
-	gomock.InOrder(
-		mockDocker.EXPECT().CreateContainer(config).Return(&docker.Container{ID: "id"}, nil),
-		mockDocker.EXPECT().InspectContainer("id").Do(func(x interface{}) {
-			testTime.Warp(inspectContainerTimeout)
-			wait.Wait()
-		}),
-	)
-	metadata := client.CreateContainer(config.Config, nil, config.Name)
-	if metadata.DockerId != "id" {
-		t.Error("Expected ID to be set even if inspect failed; was " + metadata.DockerId)
-	}
-	if metadata.Error == nil {
-		t.Error("Expected error for inspect timeout")
-	}
-	wait.Done()
-}
-
 func TestCreateContainer(t *testing.T) {
 	mockDocker, client, _, done := dockerclientSetup(t)
 	defer done()
@@ -409,10 +385,11 @@ func TestStopContainerTimeout(t *testing.T) {
 	mockDocker, client, testTime, done := dockerclientSetup(t)
 	defer done()
 
+	dockerStopTimeout := client.config.DockerStopTimeoutSeconds
 	wait := &sync.WaitGroup{}
 	wait.Add(1)
-	mockDocker.EXPECT().StopContainer("id", uint(client.config.DockerStopTimeoutSeconds)).Do(func(x, y interface{}) {
-		testTime.Warp(stopContainerTimeout + client.config.DockerStopTimeoutSeconds)
+	mockDocker.EXPECT().StopContainer("id", uint(dockerStopTimeout)).Do(func(x, y interface{}) {
+		testTime.Warp(stopContainerTimeout + time.Duration(dockerStopTimeout)*time.Second)
 		wait.Wait()
 		// Don't return, verify timeout happens
 	})

--- a/agent/engine/docker_container_engine_test.go
+++ b/agent/engine/docker_container_engine_test.go
@@ -411,8 +411,8 @@ func TestStopContainerTimeout(t *testing.T) {
 
 	wait := &sync.WaitGroup{}
 	wait.Add(1)
-	mockDocker.EXPECT().StopContainer("id", uint(dockerStopTimeoutSeconds)).Do(func(x, y interface{}) {
-		testTime.Warp(stopContainerTimeout)
+	mockDocker.EXPECT().StopContainer("id", uint(client.config.DockerStopTimeoutSeconds)).Do(func(x, y interface{}) {
+		testTime.Warp(stopContainerTimeout + client.config.DockerStopTimeoutSeconds)
 		wait.Wait()
 		// Don't return, verify timeout happens
 	})
@@ -431,7 +431,7 @@ func TestStopContainer(t *testing.T) {
 	defer done()
 
 	gomock.InOrder(
-		mockDocker.EXPECT().StopContainer("id", uint(dockerStopTimeoutSeconds)).Return(nil),
+		mockDocker.EXPECT().StopContainer("id", uint(client.config.DockerStopTimeoutSeconds)).Return(nil),
 		mockDocker.EXPECT().InspectContainer("id").Return(&docker.Container{ID: "id", State: docker.State{ExitCode: 10}}, nil),
 	)
 	metadata := client.StopContainer("id")


### PR DESCRIPTION
Adding an env variable for SIGKILL timeout #126 that defaults to current 30s constant