### PR TITLE
Discard task events during cleanup period

### DIFF
--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -376,13 +376,13 @@ func (engine *DockerTaskEngine) handleDockerEvents(ctx context.Context) {
 			}
 			engine.processTasks.RLock()
 			managedTask, ok := engine.managedTasks[task.Arn]
+			engine.processTasks.RUnlock()
 			if !ok {
 				log.Crit("Could not find managed task corresponding to a docker event", "event", event, "task", task)
 			}
 			log.Debug("Writing docker event to the associated task", "task", task, "event", event)
 			managedTask.dockerMessages <- dockerContainerChange{container: cont.Container, event: event}
 			log.Debug("Wrote docker event to the associated task", "task", task, "event", event)
-			engine.processTasks.RUnlock()
 		}
 	}
 }

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -379,6 +379,7 @@ func (engine *DockerTaskEngine) handleDockerEvents(ctx context.Context) {
 			engine.processTasks.RUnlock()
 			if !ok {
 				log.Crit("Could not find managed task corresponding to a docker event", "event", event, "task", task)
+				continue
 			}
 			log.Debug("Writing docker event to the associated task", "task", task, "event", event)
 			managedTask.dockerMessages <- dockerContainerChange{container: cont.Container, event: event}

--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -443,7 +443,7 @@ func (task *managedTask) cleanupTask(taskStoppedDuration time.Duration) {
 		handleCleanupDone <- struct{}{}
 	}()
 	task.discardEventsUntil(handleCleanupDone)
-	log.Debug("Finished removing task data; removing from state and quitting")
+	log.Debug("Finished removing task data; removing from state no longer managing", "task", task.Task)
 	// Now remove ourselves from the global state and cleanup channels
 	task.engine.processTasks.Lock()
 	delete(task.engine.managedTasks, task.Arn)


### PR DESCRIPTION
Relates to #313

This fixes a deadlock that could occur during the period of time between
when a container waited for cleanup and when the actual cleanup finished
(removes and state management changes).

During that period of time, the task_manager would not accept any new
events and, immediately after that period of time, the task_manager
needed to take the processTasks lock to complete removing itself.

Due to another issue, the scope of that lock when sending events was
overly broad, leading to a deadlock.

This fixes that deadlock by appropriately reducing the scope of the
processTasks lock when handling events.

It also speeds up the processing of multiple tasks by continuing to read
task events during the cleanup actions. Prior to this, while a task's
container's were being removed, no other task could process new events.

-----------------------------

The test I added ends up testing more the improved performance than the actual deadlock unfortunately. The timing is fairly subtle once you fix the performance issue, so it's tricky to test properly.

I made sure the integ and functional tests all still pass.

r? @samuelkarp 