### PR TITLE
wsclient: Skip logging io.ErrUnexpectedEOF

### DIFF
--- a/agent/wsclient/client.go
+++ b/agent/wsclient/client.go
@@ -212,7 +212,7 @@ func (cs *ClientServerImpl) ConsumeMessages() error {
 		messageType, message, cerr := cs.Conn.ReadMessage()
 		err = cerr
 		if err != nil {
-			if err != io.EOF {
+			if err != io.EOF && err != io.ErrUnexpectedEOF {
 				if message != nil {
 					log.Error("Error getting message from ws backend", "err", err, "message", message)
 				} else {


### PR DESCRIPTION
`io.ErrUnexpectedEOF` is a mostly harmless error since we have retries around this and a reconnect will transmit data that hasn't yet been transmitted.  Other errors are still logged at `error` level.

Fixes #281

r? @aaithal