### PR TITLE
Ignore "exec_create: /bin/bash" events from docker

### DIFF
--- a/agent/engine/docker_container_engine.go
+++ b/agent/engine/docker_container_engine.go
@@ -623,10 +623,10 @@ func (dg *dockerGoClient) ContainerEvents(ctx context.Context) (<-chan DockerCon
 				// No interest in image events
 				continue
 			default:
-				if len(event.Status) > 12 && event.Status[0:12] == "exec_create:" {
+				if len(event.Status) >= 12 && event.Status[0:12] == "exec_create:" {
 					continue
 				}
-				if len(event.Status) > 11 && event.Status[0:11] == "exec_start:" {
+				if len(event.Status) >= 11 && event.Status[0:11] == "exec_start:" {
 					continue
 				}
 

--- a/agent/engine/docker_container_engine.go
+++ b/agent/engine/docker_container_engine.go
@@ -623,10 +623,7 @@ func (dg *dockerGoClient) ContainerEvents(ctx context.Context) (<-chan DockerCon
 				// No interest in image events
 				continue
 			default:
-				if len(event.Status) >= 12 && event.Status[0:12] == "exec_create:" {
-					continue
-				}
-				if len(event.Status) >= 11 && event.Status[0:11] == "exec_start:" {
+				if strings.HasPrefix(event.Status, "exec_create:") || strings.HasPrefix(event.Status, "exec_start:") {
 					continue
 				}
 

--- a/agent/engine/docker_container_engine.go
+++ b/agent/engine/docker_container_engine.go
@@ -623,6 +623,13 @@ func (dg *dockerGoClient) ContainerEvents(ctx context.Context) (<-chan DockerCon
 				// No interest in image events
 				continue
 			default:
+				if len(event.Status) > 12 && event.Status[0:12] == "exec_create:" {
+					continue
+				}
+				if len(event.Status) > 11 && event.Status[0:11] == "exec_start:" {
+					continue
+				}
+
 				// Because docker emits new events even when you use an old event api
 				// version, it's not that big a deal
 				seelog.Debugf("Unknown status event from docker: %s", event.Status)

--- a/agent/engine/docker_container_engine_test.go
+++ b/agent/engine/docker_container_engine_test.go
@@ -565,7 +565,27 @@ func TestContainerEvents(t *testing.T) {
 	}
 
 	// Verify the following events do not translate into our event stream
-	for _, eventStatus := range []string{"pause", "export", "pull", "untag", "delete", "oom"} {
+	//
+	// Docker 1.8.3 sends the full command appended to exec_create and exec_start
+	// events. Test that we ignore there as well..
+	//
+	ignore := []string{
+		"pause",
+		"exec_create",
+		"exec_create: /bin/bash",
+		"exec_start",
+		"exec_start: /bin/bash",
+		"top",
+		"attach",
+		"export",
+		"pull",
+		"push",
+		"tag",
+		"untag",
+		"import",
+		"delete",
+	}
+	for _, eventStatus := range ignore {
 		events <- &docker.APIEvents{ID: "123", Status: eventStatus}
 		select {
 		case <-dockerEvents:


### PR DESCRIPTION
Docker 1.8.3 sends "exec_create: cmd" and "exec_start: cmd" events in response to a "docker exec". Update the event handling code to ignore these.