### PR TITLE
Add a functional test for Task deadlock issue fixed in PR:320

### DIFF
--- a/agent/functional_tests/testdata/taskdefinitions/ten-containers/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/ten-containers/task-definition.json
@@ -1,0 +1,64 @@
+{
+  "family": "ten-containers",
+  "containerDefinitions": [{
+    "name": "1",
+    "image": "busybox",
+    "memory": 10,
+    "cpu": 0,
+    "command": ["sleep", "5"]
+  }, {
+    "name": "2",
+    "image": "busybox",
+    "memory": 10,
+    "cpu": 0,
+    "command": ["sleep", "5"]
+  }, {
+    "name": "3",
+    "image": "busybox",
+    "memory": 10,
+    "cpu": 0,
+    "command": ["sleep", "5"]
+  }, {
+    "name": "4",
+    "image": "busybox",
+    "memory": 10,
+    "cpu": 0,
+    "command": ["sleep", "5"]
+  }, {
+    "name": "5",
+    "image": "busybox",
+    "memory": 10,
+    "cpu": 0,
+    "command": ["sleep", "5"]
+  }, {
+    "name": "6",
+    "image": "busybox",
+    "memory": 10,
+    "cpu": 0,
+    "command": ["sleep", "5"]
+  }, {
+    "name": "7",
+    "image": "busybox",
+    "memory": 10,
+    "cpu": 0,
+    "command": ["sleep", "5"]
+  }, {
+    "name": "8",
+    "image": "busybox",
+    "memory": 10,
+    "cpu": 0,
+    "command": ["sleep", "5"]
+  }, {
+    "name": "9",
+    "image": "busybox",
+    "memory": 10,
+    "cpu": 0,
+    "command": ["sleep", "5"]
+  }, {
+    "name": "10",
+    "image": "busybox",
+    "memory": 10,
+    "cpu": 0,
+    "command": ["sleep", "5"]
+  }]
+}


### PR DESCRIPTION
This test attempts to reproduce the deadlock issue described in #313 and fixed in #320. This test is only run for agent versions >= v.1.8.1 that will successfully pass the test.

r? @aaithal @samuelkarp 