### PR TITLE
engine: Integ test stability improvements

### DIFF
--- a/agent/utils/ttime/test_time.go
+++ b/agent/utils/ttime/test_time.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 	"time"
 
+	log "github.com/cihub/seelog"
 	"golang.org/x/net/context"
 )
 
@@ -36,6 +37,7 @@ func NewTestTime() *TestTime {
 // Warp moves the mock time forwards by the given duration.
 func (t *TestTime) Warp(d time.Duration) {
 	t.warped += d
+	log.Criticalf("WARPED TIME: %v", d)
 	t.timeChange.Broadcast()
 }
 


### PR DESCRIPTION
Sharing an instance of TestTime shares state across tests (things that
called Sleep() or AfterFunc()). Switching to a per-test instance
reduces shared state and seems to make TestSweepContainer more stable
(at least on my computer).

r? @aaithal @juanrhenals 