### PR TITLE
engine: Disable OOM test for broken kernel configs

### DIFF
--- a/agent/engine/engine_integ_test.go
+++ b/agent/engine/engine_integ_test.go
@@ -942,7 +942,14 @@ func TestSweepContainer(t *testing.T) {
 // https://github.com/aws/amazon-ecs-agent/issues/261
 // Namely, this test verifies that Docker does emit a 'die' event after an OOM
 // event if the init dies.
+// Note: Your kernel must support swap limits in order for this test to run.
+// See https://github.com/docker/docker/pull/4251 about enabling swap limit
+// support, or set MY_KERNEL_DOES_NOT_SUPPORT_SWAP_LIMIT to non-empty to skip
+// this test.
 func TestInitOOMEvent(t *testing.T) {
+	if os.Getenv("MY_KERNEL_DOES_NOT_SUPPORT_SWAP_LIMIT") != "" {
+		t.Skip("Skipped because MY_KERNEL_DOES_NOT_SUPPORT_SWAP_LIMIT")
+	}
 	taskEngine, done, _ := setup(t)
 	defer done()
 


### PR DESCRIPTION
This test is only reliable when the kernel properly supports memory and
swap limits.  If you try to limit memory on a system where the kernel
does not support swap limits, the container can continue to use memory
in swap well beyond the expected timeout of the test.  If your system
does not support swap limits, you'll see a message like the following
when running a container with a memory limit:

WARNING: Your kernel does not support swap limit capabilities, memory limited without swap.

Note that you should not disable this test by default.

r? @aaithal @juanrhenals 