### PR TITLE
Cleanup ACS Handler

### DIFF
--- a/agent/acs/handler/acs_handler_test.go
+++ b/agent/acs/handler/acs_handler_test.go
@@ -1,11 +1,25 @@
-package handler_test
+// Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+package handler
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"reflect"
 	"runtime"
 	"runtime/pprof"
 	"testing"
@@ -13,13 +27,16 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/aws/amazon-ecs-agent/agent/acs/handler"
+	"github.com/aws/amazon-ecs-agent/agent/acs/model/ecsacs"
+	"github.com/aws/amazon-ecs-agent/agent/api"
 	"github.com/aws/amazon-ecs-agent/agent/api/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/engine"
 	"github.com/aws/amazon-ecs-agent/agent/statemanager"
+	"github.com/aws/amazon-ecs-agent/agent/statemanager/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/utils/ttime"
 	"github.com/aws/amazon-ecs-agent/agent/version"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/gorilla/websocket"
 
@@ -35,7 +52,7 @@ func TestAcsWsUrl(t *testing.T) {
 
 	taskEngine.EXPECT().Version().Return("Docker version result", nil)
 
-	wsurl := handler.AcsWsUrl("http://endpoint.tld", "myCluster", "myContainerInstance", taskEngine)
+	wsurl := AcsWsUrl("http://endpoint.tld", "myCluster", "myContainerInstance", taskEngine)
 
 	parsed, err := url.Parse(wsurl)
 	if err != nil {
@@ -68,7 +85,7 @@ func TestHandlerReconnects(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	taskEngine := engine.NewMockTaskEngine(ctrl)
-	ecsclient := mock_api.NewMockECSClient(ctrl)
+	ecsClient := mock_api.NewMockECSClient(ctrl)
 	statemanager := statemanager.NewNoopStateManager()
 
 	closeWS := make(chan bool)
@@ -85,18 +102,18 @@ func TestHandlerReconnects(t *testing.T) {
 		}
 	}()
 
-	ecsclient.EXPECT().DiscoverPollEndpoint("myArn").Return(server.URL, nil).Times(10)
+	ecsClient.EXPECT().DiscoverPollEndpoint("myArn").Return(server.URL, nil).Times(10)
 	taskEngine.EXPECT().Version().Return("Docker: 1.5.0", nil).AnyTimes()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	ended := make(chan bool, 1)
 	go func() {
-		handler.StartSession(ctx, handler.StartSessionArguments{
+		StartSession(ctx, StartSessionArguments{
 			ContainerInstanceArn: "myArn",
 			CredentialProvider:   credentials.AnonymousCredentials,
 			Config:               &config.Config{Cluster: "someCluster"},
 			TaskEngine:           taskEngine,
-			ECSClient:            ecsclient,
+			ECSClient:            ecsClient,
 			StateManager:         statemanager,
 			AcceptInvalidCert:    true,
 		})
@@ -127,7 +144,7 @@ func TestHeartbeatOnlyWhenIdle(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	taskEngine := engine.NewMockTaskEngine(ctrl)
-	ecsclient := mock_api.NewMockECSClient(ctrl)
+	ecsClient := mock_api.NewMockECSClient(ctrl)
 	statemanager := statemanager.NewNoopStateManager()
 
 	closeWS := make(chan bool)
@@ -144,18 +161,18 @@ func TestHeartbeatOnlyWhenIdle(t *testing.T) {
 	}
 
 	// We're testing that it does not reconnect here; must be the case
-	ecsclient.EXPECT().DiscoverPollEndpoint("myArn").Return(server.URL, nil).Times(1)
+	ecsClient.EXPECT().DiscoverPollEndpoint("myArn").Return(server.URL, nil).Times(1)
 	taskEngine.EXPECT().Version().Return("Docker: 1.5.0", nil).AnyTimes()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	ended := make(chan bool, 1)
 	go func() {
-		handler.StartSession(ctx, handler.StartSessionArguments{
+		StartSession(ctx, StartSessionArguments{
 			ContainerInstanceArn: "myArn",
 			CredentialProvider:   credentials.AnonymousCredentials,
 			Config:               &config.Config{Cluster: "someCluster"},
 			TaskEngine:           taskEngine,
-			ECSClient:            ecsclient,
+			ECSClient:            ecsClient,
 			StateManager:         statemanager,
 			AcceptInvalidCert:    true,
 		})
@@ -182,6 +199,356 @@ func TestHeartbeatOnlyWhenIdle(t *testing.T) {
 	go server.Close()
 	cancel()
 	<-ended
+}
+
+func TestHandlerDoesntLeakGouroutines(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	taskEngine := engine.NewMockTaskEngine(ctrl)
+	ecsClient := mock_api.NewMockECSClient(ctrl)
+	statemanager := statemanager.NewNoopStateManager()
+	testTime := ttime.NewTestTime()
+	ttime.SetTime(testTime)
+
+	closeWS := make(chan bool)
+	server, serverIn, requests, errs, err := startMockAcsServer(t, closeWS)
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		for {
+			select {
+			case <-requests:
+			case <-errs:
+			}
+		}
+	}()
+
+	timesConnected := 0
+	ecsClient.EXPECT().DiscoverPollEndpoint("myArn").Return(server.URL, nil).AnyTimes().Do(func(_ interface{}) {
+		timesConnected++
+	})
+	taskEngine.EXPECT().Version().Return("Docker: 1.5.0", nil).AnyTimes()
+	taskEngine.EXPECT().AddTask(gomock.Any()).AnyTimes()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ended := make(chan bool, 1)
+	go func() {
+		StartSession(ctx, StartSessionArguments{"myArn", credentials.AnonymousCredentials, &config.Config{Cluster: "someCluster"}, taskEngine, ecsClient, statemanager, true})
+		ended <- true
+	}()
+	// Warm it up
+	serverIn <- `{"type":"HeartbeatMessage","message":{"healthy":true}}`
+	serverIn <- samplePayloadMessage
+
+	beforeGoroutines := runtime.NumGoroutine()
+	for i := 0; i < 100; i++ {
+		serverIn <- `{"type":"HeartbeatMessage","message":{"healthy":true}}`
+		serverIn <- samplePayloadMessage
+		closeWS <- true
+	}
+
+	cancel()
+	testTime.Cancel()
+	<-ended
+
+	afterGoroutines := runtime.NumGoroutine()
+
+	t.Logf("Gorutines after 1 and after 100 acs messages: %v and %v", beforeGoroutines, afterGoroutines)
+
+	if timesConnected < 50 {
+		t.Fatal("Expected times connected to be a large number, was ", timesConnected)
+	}
+	if afterGoroutines > beforeGoroutines+5 {
+		t.Error("Goroutine leak, oh no!")
+		pprof.Lookup("goroutine").WriteTo(os.Stdout, 1)
+	}
+
+}
+
+// TestHandlePayloadMessageWithNoMessageId tests that agent doesn't ack payload messages
+// that do not contain message ids
+func TestHandlePayloadMessageWithNoMessageId(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	taskEngine := engine.NewMockTaskEngine(ctrl)
+	ecsClient := mock_api.NewMockECSClient(ctrl)
+	stateManager := statemanager.NewNoopStateManager()
+
+	ackBuffer := make(chan string, payloadMessageBufferSize)
+
+	payloadMessage := &ecsacs.PayloadMessage{
+		Tasks: []*ecsacs.Task{
+			&ecsacs.Task{
+				Arn: aws.String("t1"),
+			},
+		},
+	}
+
+	// test adding a payload message without the MessageId field
+	err := handlePayloadMessage(ackBuffer, payloadMessage, taskEngine, ecsClient, stateManager)
+	if err == nil {
+		t.Error("Expected error while adding a task with no message id")
+	}
+
+	// test adding a payload message with blank MessageId
+	payloadMessage.MessageId = aws.String("")
+	err = handlePayloadMessage(ackBuffer, payloadMessage, taskEngine, ecsClient, stateManager)
+
+	if err == nil {
+		t.Error("Expected error while adding a task with no message id")
+	}
+
+}
+
+// TestHandlePayloadMessageAddTaskError tests that agent does not ack payload messages
+// when task engine fails to add tasks
+func TestHandlePayloadMessageAddTaskError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	taskEngine := engine.NewMockTaskEngine(ctrl)
+	ecsClient := mock_api.NewMockECSClient(ctrl)
+	stateManager := statemanager.NewNoopStateManager()
+
+	// Return error from AddTask
+	taskEngine.EXPECT().AddTask(gomock.Any()).Return(fmt.Errorf("oops")).Times(1)
+
+	ackBuffer := make(chan string, payloadMessageBufferSize)
+	payloadMessage := &ecsacs.PayloadMessage{
+		Tasks: []*ecsacs.Task{
+			&ecsacs.Task{
+				Arn: aws.String("t1"),
+			},
+		},
+		MessageId: aws.String("123"),
+	}
+	err := handlePayloadMessage(ackBuffer, payloadMessage, taskEngine, ecsClient, stateManager)
+
+	if err == nil {
+		t.Error("Expected error while adding the task")
+	}
+
+}
+
+// TestHandlePayloadMessageStateSaveError tests that agent does not ack payload messages
+// when state saver fails to save state
+func TestHandlePayloadMessageStateSaveError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	ecsClient := mock_api.NewMockECSClient(ctrl)
+
+	taskEngine := engine.NewMockTaskEngine(ctrl)
+
+	// Save added task in the addedTask variable
+	var addedTask *api.Task
+	taskEngine.EXPECT().AddTask(gomock.Any()).Do(func(task *api.Task) {
+		addedTask = task
+	}).Times(1)
+
+	// State manager returns error on save
+	stateManager := mock_statemanager.NewMockStateManager(ctrl)
+	stateManager.EXPECT().Save().Return(fmt.Errorf("oops"))
+
+	ackBuffer := make(chan string, payloadMessageBufferSize)
+	payloadMessage := &ecsacs.PayloadMessage{
+		Tasks: []*ecsacs.Task{
+			&ecsacs.Task{
+				Arn: aws.String("t1"),
+			},
+		},
+		MessageId: aws.String("123"),
+	}
+	err := handlePayloadMessage(ackBuffer, payloadMessage, taskEngine, ecsClient, stateManager)
+
+	if err == nil {
+		t.Error("Expected error while adding a task with no message id")
+	}
+
+	// We expect task to be added to the engine even though it hasn't been saved
+	expectedTask := &api.Task{
+		Arn: "t1",
+	}
+	if !reflect.DeepEqual(addedTask, expectedTask) {
+		t.Errorf("Mismatch between expected and added tasks, expected: %v, added: %v", expectedTask, addedTask)
+	}
+}
+
+// TestHandlePayloadMessageAckedWhenTaskAdded tests if the handler generates an ack
+// after processing a payload message.
+func TestHandlePayloadMessageAckedWhenTaskAdded(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	ecsClient := mock_api.NewMockECSClient(ctrl)
+	stateManager := statemanager.NewNoopStateManager()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	taskEngine := engine.NewMockTaskEngine(ctrl)
+	var addedTask *api.Task
+	taskEngine.EXPECT().AddTask(gomock.Any()).Do(func(task *api.Task) {
+		addedTask = task
+	}).Times(1)
+
+	// go routine to wait for message id ack from ackBuffer
+	ackBuffer := make(chan string, payloadMessageBufferSize)
+	var messageIdFromAck string
+	waitForAck := make(chan struct{})
+	go func() {
+	Loop:
+		for {
+			select {
+			case messageIdFromAck = <-ackBuffer:
+				cancel()
+			case <-ctx.Done():
+				break Loop
+			}
+		}
+		waitForAck <- struct{}{}
+	}()
+
+	// Send a payload message
+	messageId := "123"
+	payloadMessage := &ecsacs.PayloadMessage{
+		Tasks: []*ecsacs.Task{
+			&ecsacs.Task{
+				Arn: aws.String("t1"),
+			},
+		},
+		MessageId: aws.String(messageId),
+	}
+	err := handlePayloadMessage(ackBuffer, payloadMessage, taskEngine, ecsClient, stateManager)
+	if err != nil {
+		t.Errorf("Error handling payload message: %v", err)
+	}
+
+	// Wait till we get an ack from the ackBuffer
+	select {
+	case <-waitForAck:
+	}
+
+	// Verify the message id acked
+	if messageIdFromAck != messageId {
+		t.Errorf("Message Id mismatch. Expected: %s, got: %s", messageId, messageIdFromAck)
+	}
+
+	// Verify if task added == expected task
+	expectedTask := &api.Task{
+		Arn: "t1",
+	}
+	if !reflect.DeepEqual(addedTask, expectedTask) {
+		t.Errorf("Mismatch between expected and added tasks, expected: %v, added: %v", expectedTask, addedTask)
+	}
+}
+
+// TestAddPayloadTaskAddsNonStoppedTasksAfterStoppedTasks tests if tasks with desired status
+// 'RUNNING' are added after tasks with desired status 'STOPPED'
+func TestAddPayloadTaskAddsNonStoppedTasksAfterStoppedTasks(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	ecsClient := mock_api.NewMockECSClient(ctrl)
+	taskEngine := engine.NewMockTaskEngine(ctrl)
+
+	var tasksAddedToEngine []*api.Task
+	taskEngine.EXPECT().AddTask(gomock.Any()).Do(func(task *api.Task) {
+		tasksAddedToEngine = append(tasksAddedToEngine, task)
+	}).Times(2)
+
+	messageId := "123"
+	stoppedTaskArn := "stoppedTask"
+	runningTaskArn := "runningTask"
+	payloadMessage := &ecsacs.PayloadMessage{
+		Tasks: []*ecsacs.Task{
+			&ecsacs.Task{
+				Arn:           aws.String(runningTaskArn),
+				DesiredStatus: aws.String("RUNNING"),
+			},
+			&ecsacs.Task{
+				Arn:           aws.String(stoppedTaskArn),
+				DesiredStatus: aws.String("STOPPED"),
+			},
+		},
+		MessageId: aws.String(messageId),
+	}
+	ok := addPayloadTasks(ecsClient, payloadMessage, taskEngine)
+	if !ok {
+		t.Error("addPayloadTasks returned false")
+	}
+	if len(tasksAddedToEngine) != 2 {
+		t.Errorf("Incorrect number of tasks added to the engine. Expected: %d, got: %d", 2, len(tasksAddedToEngine))
+	}
+
+	// Verify if stopped task is added before running task
+	firstTaskAdded := tasksAddedToEngine[0]
+	if firstTaskAdded.Arn != stoppedTaskArn {
+		t.Errorf("Expected first task arn: %s, got: %s", stoppedTaskArn, firstTaskAdded.Arn)
+	}
+	if firstTaskAdded.DesiredStatus != api.TaskStopped {
+		t.Errorf("Expected first task state be be: %s , got: %s", "STOPPED", firstTaskAdded.DesiredStatus.String())
+	}
+
+	secondTaskAdded := tasksAddedToEngine[1]
+	if secondTaskAdded.Arn != runningTaskArn {
+		t.Errorf("Expected second task arn: %s, got: %s", runningTaskArn, secondTaskAdded.Arn)
+	}
+	if secondTaskAdded.DesiredStatus != api.TaskRunning {
+		t.Errorf("Expected second task state be be: %s , got: %s", "RUNNNING", secondTaskAdded.DesiredStatus.String())
+	}
+}
+
+// TestPayloadBufferHandler tests if the async payloadBufferHandler routine
+// acks messages after adding tasks
+func TestPayloadBufferHandler(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	taskEngine := engine.NewMockTaskEngine(ctrl)
+	ecsClient := mock_api.NewMockECSClient(ctrl)
+	stateManager := statemanager.NewNoopStateManager()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	payloadBuffer := make(chan *ecsacs.PayloadMessage, payloadMessageBufferSize)
+	ackBuffer := make(chan string, payloadMessageBufferSize)
+	var addedTask *api.Task
+	taskEngine.EXPECT().AddTask(gomock.Any()).Do(func(task *api.Task) {
+		addedTask = task
+	}).Times(1)
+	go payloadBufferHandler(payloadBuffer, ackBuffer, taskEngine, ecsClient, stateManager, ctx)
+
+	// Send a payload message to the payloadBufferChannel
+	messageId := "123"
+	taskArn := "t1"
+	payloadMessage := &ecsacs.PayloadMessage{
+		Tasks: []*ecsacs.Task{
+			&ecsacs.Task{
+				Arn: aws.String(taskArn),
+			},
+		},
+		MessageId: aws.String(messageId),
+	}
+	payloadBuffer <- payloadMessage
+
+	// Wait till we get an ack
+	var messageIdFromAck string
+Loop:
+	for {
+		select {
+		case messageIdFromAck = <-ackBuffer:
+			cancel()
+		case <-ctx.Done():
+			break Loop
+		}
+	}
+
+	// Verify if messageId read from the ack buffer is correct
+	if messageIdFromAck != messageId {
+		t.Errorf("Message Id mismatch. Expected: %s, got: %s", messageId, messageIdFromAck)
+	}
+
+	// Verify if the task added to the engine is correct
+	expectedTask := &api.Task{
+		Arn: taskArn,
+	}
+	if !reflect.DeepEqual(addedTask, expectedTask) {
+		t.Errorf("Mismatch between expected and added tasks, expected: %v, added: %v", expectedTask, addedTask)
+	}
 }
 
 func startMockAcsServer(t *testing.T, closeWS <-chan bool) (*httptest.Server, chan<- string, <-chan string, <-chan error, error) {
@@ -227,69 +594,4 @@ func startMockAcsServer(t *testing.T, closeWS <-chan bool) (*httptest.Server, ch
 
 	server := httptest.NewTLSServer(handler)
 	return server, serverChan, requestsChan, errChan, nil
-}
-
-func TestHandlerDoesntLeakGouroutines(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-	taskEngine := engine.NewMockTaskEngine(ctrl)
-	ecsclient := mock_api.NewMockECSClient(ctrl)
-	statemanager := statemanager.NewNoopStateManager()
-	testTime := ttime.NewTestTime()
-	ttime.SetTime(testTime)
-
-	closeWS := make(chan bool)
-	server, serverIn, requests, errs, err := startMockAcsServer(t, closeWS)
-	if err != nil {
-		t.Fatal(err)
-	}
-	go func() {
-		for {
-			select {
-			case <-requests:
-			case <-errs:
-			}
-		}
-	}()
-
-	timesConnected := 0
-	ecsclient.EXPECT().DiscoverPollEndpoint("myArn").Return(server.URL, nil).AnyTimes().Do(func(_ interface{}) {
-		timesConnected++
-	})
-	taskEngine.EXPECT().Version().Return("Docker: 1.5.0", nil).AnyTimes()
-	taskEngine.EXPECT().AddTask(gomock.Any()).AnyTimes()
-
-	ctx, cancel := context.WithCancel(context.Background())
-	ended := make(chan bool, 1)
-	go func() {
-		handler.StartSession(ctx, handler.StartSessionArguments{"myArn", credentials.AnonymousCredentials, &config.Config{Cluster: "someCluster"}, taskEngine, ecsclient, statemanager, true})
-		ended <- true
-	}()
-	// Warm it up
-	serverIn <- `{"type":"HeartbeatMessage","message":{"healthy":true}}`
-	serverIn <- samplePayloadMessage
-
-	beforeGoroutines := runtime.NumGoroutine()
-	for i := 0; i < 100; i++ {
-		serverIn <- `{"type":"HeartbeatMessage","message":{"healthy":true}}`
-		serverIn <- samplePayloadMessage
-		closeWS <- true
-	}
-
-	cancel()
-	testTime.Cancel()
-	<-ended
-
-	afterGoroutines := runtime.NumGoroutine()
-
-	t.Logf("Gorutines after 1 and after 100 acs messages: %v and %v", beforeGoroutines, afterGoroutines)
-
-	if timesConnected < 50 {
-		t.Fatal("Expected times connected to be a large number, was ", timesConnected)
-	}
-	if afterGoroutines > beforeGoroutines+5 {
-		t.Error("Goroutine leak, oh no!")
-		pprof.Lookup("goroutine").WriteTo(os.Stdout, 1)
-	}
-
 }

--- a/agent/acs/handler/acs_handler_test.go
+++ b/agent/acs/handler/acs_handler_test.go
@@ -19,7 +19,6 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
-	"reflect"
 	"runtime"
 	"runtime/pprof"
 	"testing"
@@ -27,16 +26,12 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/aws/amazon-ecs-agent/agent/acs/model/ecsacs"
-	"github.com/aws/amazon-ecs-agent/agent/api"
 	"github.com/aws/amazon-ecs-agent/agent/api/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/engine"
 	"github.com/aws/amazon-ecs-agent/agent/statemanager"
-	"github.com/aws/amazon-ecs-agent/agent/statemanager/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/utils/ttime"
 	"github.com/aws/amazon-ecs-agent/agent/version"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/gorilla/websocket"
 
@@ -117,7 +112,7 @@ func TestHandlerReconnects(t *testing.T) {
 			StateManager:         statemanager,
 			AcceptInvalidCert:    true,
 		})
-		// This should never return
+		// StartSession should never return unless the context is canceled
 		ended <- true
 	}()
 	start := time.Now()
@@ -127,6 +122,74 @@ func TestHandlerReconnects(t *testing.T) {
 	}
 	if time.Since(start) > 2*time.Second {
 		t.Error("Test took longer than expected; backoff should not have occured for EOF")
+	}
+
+	select {
+	case <-ended:
+		t.Fatal("Should not have stopped session")
+	default:
+	}
+	cancel()
+	<-ended
+}
+
+func TestHandlerReconnectsOnDiscoverPollEndpointError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	taskEngine := engine.NewMockTaskEngine(ctrl)
+	ecsClient := mock_api.NewMockECSClient(ctrl)
+	statemanager := statemanager.NewNoopStateManager()
+
+	closeWS := make(chan bool)
+	server, _, requests, errs, err := startMockAcsServer(t, closeWS)
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		for {
+			select {
+			case <-requests:
+			case <-errs:
+			}
+		}
+	}()
+
+	gomock.InOrder(
+		// DiscoverPollEndpoint returns an error on its first invocation
+		ecsClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return("", fmt.Errorf("oops")).Times(1),
+		// Second invocation returns a success
+		ecsClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(server.URL, nil).Times(1),
+	)
+	taskEngine.EXPECT().Version().Return("Docker: 1.5.0", nil).Times(1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ended := make(chan bool, 1)
+	go func() {
+		StartSession(ctx, StartSessionArguments{
+			ContainerInstanceArn: "myArn",
+			CredentialProvider:   credentials.AnonymousCredentials,
+			Config:               &config.Config{Cluster: "someCluster"},
+			TaskEngine:           taskEngine,
+			ECSClient:            ecsClient,
+			StateManager:         statemanager,
+			AcceptInvalidCert:    true,
+		})
+		// StartSession should never return unless the context is canceled
+		ended <- true
+	}()
+	start := time.Now()
+	closeWS <- true
+	timeSinceStart := time.Since(start)
+
+	if timeSinceStart < connectionBackoffMin {
+		t.Errorf("Duration since start is less than minimum threshold for backoff: %s", timeSinceStart.String())
+	}
+
+	// The upper limit here should really be connectionBackoffMin + (connectionBackoffMin * jitter)
+	// But, it can be off by a few milliseconds to account for execution of other instructions
+	// In any case, it should never be higher than 2*connectionBackoffMin
+	if timeSinceStart > 2*connectionBackoffMin {
+		t.Errorf("Duration since start is greater than maximum anticipated wait time: %v", timeSinceStart.String())
 	}
 
 	select {
@@ -176,6 +239,7 @@ func TestHeartbeatOnlyWhenIdle(t *testing.T) {
 			StateManager:         statemanager,
 			AcceptInvalidCert:    true,
 		})
+		// StartSession should never return unless the context is canceled
 		ended <- true
 	}()
 
@@ -264,291 +328,6 @@ func TestHandlerDoesntLeakGouroutines(t *testing.T) {
 		pprof.Lookup("goroutine").WriteTo(os.Stdout, 1)
 	}
 
-}
-
-// TestHandlePayloadMessageWithNoMessageId tests that agent doesn't ack payload messages
-// that do not contain message ids
-func TestHandlePayloadMessageWithNoMessageId(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-	taskEngine := engine.NewMockTaskEngine(ctrl)
-	ecsClient := mock_api.NewMockECSClient(ctrl)
-	stateManager := statemanager.NewNoopStateManager()
-
-	ackBuffer := make(chan string, payloadMessageBufferSize)
-
-	payloadMessage := &ecsacs.PayloadMessage{
-		Tasks: []*ecsacs.Task{
-			&ecsacs.Task{
-				Arn: aws.String("t1"),
-			},
-		},
-	}
-
-	// test adding a payload message without the MessageId field
-	err := handlePayloadMessage(ackBuffer, payloadMessage, taskEngine, ecsClient, stateManager)
-	if err == nil {
-		t.Error("Expected error while adding a task with no message id")
-	}
-
-	// test adding a payload message with blank MessageId
-	payloadMessage.MessageId = aws.String("")
-	err = handlePayloadMessage(ackBuffer, payloadMessage, taskEngine, ecsClient, stateManager)
-
-	if err == nil {
-		t.Error("Expected error while adding a task with no message id")
-	}
-
-}
-
-// TestHandlePayloadMessageAddTaskError tests that agent does not ack payload messages
-// when task engine fails to add tasks
-func TestHandlePayloadMessageAddTaskError(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-	taskEngine := engine.NewMockTaskEngine(ctrl)
-	ecsClient := mock_api.NewMockECSClient(ctrl)
-	stateManager := statemanager.NewNoopStateManager()
-
-	// Return error from AddTask
-	taskEngine.EXPECT().AddTask(gomock.Any()).Return(fmt.Errorf("oops")).Times(1)
-
-	ackBuffer := make(chan string, payloadMessageBufferSize)
-	payloadMessage := &ecsacs.PayloadMessage{
-		Tasks: []*ecsacs.Task{
-			&ecsacs.Task{
-				Arn: aws.String("t1"),
-			},
-		},
-		MessageId: aws.String("123"),
-	}
-	err := handlePayloadMessage(ackBuffer, payloadMessage, taskEngine, ecsClient, stateManager)
-
-	if err == nil {
-		t.Error("Expected error while adding the task")
-	}
-
-}
-
-// TestHandlePayloadMessageStateSaveError tests that agent does not ack payload messages
-// when state saver fails to save state
-func TestHandlePayloadMessageStateSaveError(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-	ecsClient := mock_api.NewMockECSClient(ctrl)
-
-	taskEngine := engine.NewMockTaskEngine(ctrl)
-
-	// Save added task in the addedTask variable
-	var addedTask *api.Task
-	taskEngine.EXPECT().AddTask(gomock.Any()).Do(func(task *api.Task) {
-		addedTask = task
-	}).Times(1)
-
-	// State manager returns error on save
-	stateManager := mock_statemanager.NewMockStateManager(ctrl)
-	stateManager.EXPECT().Save().Return(fmt.Errorf("oops"))
-
-	ackBuffer := make(chan string, payloadMessageBufferSize)
-	payloadMessage := &ecsacs.PayloadMessage{
-		Tasks: []*ecsacs.Task{
-			&ecsacs.Task{
-				Arn: aws.String("t1"),
-			},
-		},
-		MessageId: aws.String("123"),
-	}
-	err := handlePayloadMessage(ackBuffer, payloadMessage, taskEngine, ecsClient, stateManager)
-
-	if err == nil {
-		t.Error("Expected error while adding a task with no message id")
-	}
-
-	// We expect task to be added to the engine even though it hasn't been saved
-	expectedTask := &api.Task{
-		Arn: "t1",
-	}
-	if !reflect.DeepEqual(addedTask, expectedTask) {
-		t.Errorf("Mismatch between expected and added tasks, expected: %v, added: %v", expectedTask, addedTask)
-	}
-}
-
-// TestHandlePayloadMessageAckedWhenTaskAdded tests if the handler generates an ack
-// after processing a payload message.
-func TestHandlePayloadMessageAckedWhenTaskAdded(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-	ecsClient := mock_api.NewMockECSClient(ctrl)
-	stateManager := statemanager.NewNoopStateManager()
-	ctx, cancel := context.WithCancel(context.Background())
-
-	taskEngine := engine.NewMockTaskEngine(ctrl)
-	var addedTask *api.Task
-	taskEngine.EXPECT().AddTask(gomock.Any()).Do(func(task *api.Task) {
-		addedTask = task
-	}).Times(1)
-
-	// go routine to wait for message id ack from ackBuffer
-	ackBuffer := make(chan string, payloadMessageBufferSize)
-	var messageIdFromAck string
-	waitForAck := make(chan struct{})
-	go func() {
-	Loop:
-		for {
-			select {
-			case messageIdFromAck = <-ackBuffer:
-				cancel()
-			case <-ctx.Done():
-				break Loop
-			}
-		}
-		waitForAck <- struct{}{}
-	}()
-
-	// Send a payload message
-	messageId := "123"
-	payloadMessage := &ecsacs.PayloadMessage{
-		Tasks: []*ecsacs.Task{
-			&ecsacs.Task{
-				Arn: aws.String("t1"),
-			},
-		},
-		MessageId: aws.String(messageId),
-	}
-	err := handlePayloadMessage(ackBuffer, payloadMessage, taskEngine, ecsClient, stateManager)
-	if err != nil {
-		t.Errorf("Error handling payload message: %v", err)
-	}
-
-	// Wait till we get an ack from the ackBuffer
-	select {
-	case <-waitForAck:
-	}
-
-	// Verify the message id acked
-	if messageIdFromAck != messageId {
-		t.Errorf("Message Id mismatch. Expected: %s, got: %s", messageId, messageIdFromAck)
-	}
-
-	// Verify if task added == expected task
-	expectedTask := &api.Task{
-		Arn: "t1",
-	}
-	if !reflect.DeepEqual(addedTask, expectedTask) {
-		t.Errorf("Mismatch between expected and added tasks, expected: %v, added: %v", expectedTask, addedTask)
-	}
-}
-
-// TestAddPayloadTaskAddsNonStoppedTasksAfterStoppedTasks tests if tasks with desired status
-// 'RUNNING' are added after tasks with desired status 'STOPPED'
-func TestAddPayloadTaskAddsNonStoppedTasksAfterStoppedTasks(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-	ecsClient := mock_api.NewMockECSClient(ctrl)
-	taskEngine := engine.NewMockTaskEngine(ctrl)
-
-	var tasksAddedToEngine []*api.Task
-	taskEngine.EXPECT().AddTask(gomock.Any()).Do(func(task *api.Task) {
-		tasksAddedToEngine = append(tasksAddedToEngine, task)
-	}).Times(2)
-
-	messageId := "123"
-	stoppedTaskArn := "stoppedTask"
-	runningTaskArn := "runningTask"
-	payloadMessage := &ecsacs.PayloadMessage{
-		Tasks: []*ecsacs.Task{
-			&ecsacs.Task{
-				Arn:           aws.String(runningTaskArn),
-				DesiredStatus: aws.String("RUNNING"),
-			},
-			&ecsacs.Task{
-				Arn:           aws.String(stoppedTaskArn),
-				DesiredStatus: aws.String("STOPPED"),
-			},
-		},
-		MessageId: aws.String(messageId),
-	}
-	ok := addPayloadTasks(ecsClient, payloadMessage, taskEngine)
-	if !ok {
-		t.Error("addPayloadTasks returned false")
-	}
-	if len(tasksAddedToEngine) != 2 {
-		t.Errorf("Incorrect number of tasks added to the engine. Expected: %d, got: %d", 2, len(tasksAddedToEngine))
-	}
-
-	// Verify if stopped task is added before running task
-	firstTaskAdded := tasksAddedToEngine[0]
-	if firstTaskAdded.Arn != stoppedTaskArn {
-		t.Errorf("Expected first task arn: %s, got: %s", stoppedTaskArn, firstTaskAdded.Arn)
-	}
-	if firstTaskAdded.DesiredStatus != api.TaskStopped {
-		t.Errorf("Expected first task state be be: %s , got: %s", "STOPPED", firstTaskAdded.DesiredStatus.String())
-	}
-
-	secondTaskAdded := tasksAddedToEngine[1]
-	if secondTaskAdded.Arn != runningTaskArn {
-		t.Errorf("Expected second task arn: %s, got: %s", runningTaskArn, secondTaskAdded.Arn)
-	}
-	if secondTaskAdded.DesiredStatus != api.TaskRunning {
-		t.Errorf("Expected second task state be be: %s , got: %s", "RUNNNING", secondTaskAdded.DesiredStatus.String())
-	}
-}
-
-// TestPayloadBufferHandler tests if the async payloadBufferHandler routine
-// acks messages after adding tasks
-func TestPayloadBufferHandler(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-	taskEngine := engine.NewMockTaskEngine(ctrl)
-	ecsClient := mock_api.NewMockECSClient(ctrl)
-	stateManager := statemanager.NewNoopStateManager()
-	ctx, cancel := context.WithCancel(context.Background())
-
-	payloadBuffer := make(chan *ecsacs.PayloadMessage, payloadMessageBufferSize)
-	ackBuffer := make(chan string, payloadMessageBufferSize)
-	var addedTask *api.Task
-	taskEngine.EXPECT().AddTask(gomock.Any()).Do(func(task *api.Task) {
-		addedTask = task
-	}).Times(1)
-	go payloadBufferHandler(payloadBuffer, ackBuffer, taskEngine, ecsClient, stateManager, ctx)
-
-	// Send a payload message to the payloadBufferChannel
-	messageId := "123"
-	taskArn := "t1"
-	payloadMessage := &ecsacs.PayloadMessage{
-		Tasks: []*ecsacs.Task{
-			&ecsacs.Task{
-				Arn: aws.String(taskArn),
-			},
-		},
-		MessageId: aws.String(messageId),
-	}
-	payloadBuffer <- payloadMessage
-
-	// Wait till we get an ack
-	var messageIdFromAck string
-Loop:
-	for {
-		select {
-		case messageIdFromAck = <-ackBuffer:
-			cancel()
-		case <-ctx.Done():
-			break Loop
-		}
-	}
-
-	// Verify if messageId read from the ack buffer is correct
-	if messageIdFromAck != messageId {
-		t.Errorf("Message Id mismatch. Expected: %s, got: %s", messageId, messageIdFromAck)
-	}
-
-	// Verify if the task added to the engine is correct
-	expectedTask := &api.Task{
-		Arn: taskArn,
-	}
-	if !reflect.DeepEqual(addedTask, expectedTask) {
-		t.Errorf("Mismatch between expected and added tasks, expected: %v, added: %v", expectedTask, addedTask)
-	}
 }
 
 func startMockAcsServer(t *testing.T, closeWS <-chan bool) (*httptest.Server, chan<- string, <-chan string, <-chan error, error) {

--- a/agent/acs/handler/payload_handler.go
+++ b/agent/acs/handler/payload_handler.go
@@ -1,0 +1,245 @@
+// Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+package handler
+
+import (
+	"fmt"
+
+	"github.com/aws/amazon-ecs-agent/agent/acs/model/ecsacs"
+	"github.com/aws/amazon-ecs-agent/agent/api"
+	"github.com/aws/amazon-ecs-agent/agent/engine"
+	"github.com/aws/amazon-ecs-agent/agent/eventhandler"
+	"github.com/aws/amazon-ecs-agent/agent/statemanager"
+	"github.com/aws/amazon-ecs-agent/agent/wsclient"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/cihub/seelog"
+	"golang.org/x/net/context"
+)
+
+// payloadRequestHandler represents the payload operation for the ACS client
+type payloadRequestHandler struct {
+	// messageBuffer is used to process PayloadMessages received from the server
+	messageBuffer chan *ecsacs.PayloadMessage
+	// ackRequest is used to send acks to the backend
+	ackRequest chan string
+	ctx        context.Context
+	taskEngine engine.TaskEngine
+	ecsClient  api.ECSClient
+	saver      statemanager.Saver
+	// cancel is used to stop go routines started by start() method
+	cancel               context.CancelFunc
+	cluster              string
+	containerInstanceArn string
+	acsClient            wsclient.ClientServer
+}
+
+// newPayloadRequestHandler returns a new payloadRequestHandler object
+func newPayloadRequestHandler(taskEngine engine.TaskEngine, ecsClient api.ECSClient, cluster string, containerInstanceArn string, acsClient wsclient.ClientServer, saver statemanager.Saver, ctx context.Context) payloadRequestHandler {
+	// Create a cancelable context from the parent context
+	derivedContext, cancel := context.WithCancel(ctx)
+	return payloadRequestHandler{
+		messageBuffer:        make(chan *ecsacs.PayloadMessage, payloadMessageBufferSize),
+		ackRequest:           make(chan string, payloadMessageBufferSize),
+		taskEngine:           taskEngine,
+		ecsClient:            ecsClient,
+		saver:                saver,
+		ctx:                  derivedContext,
+		cancel:               cancel,
+		cluster:              cluster,
+		containerInstanceArn: containerInstanceArn,
+		acsClient:            acsClient,
+	}
+}
+
+// handlerFunc returns the request handler function for the ecsacs.PayloadMessage type
+func (payloadHandler *payloadRequestHandler) handlerFunc() func(payload *ecsacs.PayloadMessage) {
+	// return a function that just enqueues PayloadMessages into the message buffer
+	return func(payload *ecsacs.PayloadMessage) {
+		payloadHandler.messageBuffer <- payload
+	}
+}
+
+// start invokes go routines to:
+// 1. handle messages in the payload message buffer
+// 2. handle ack requests to be sent to ACS
+func (payloadHandler *payloadRequestHandler) start() {
+	go payloadHandler.handleMessages()
+	go payloadHandler.sendAcks()
+}
+
+// stop cancels the context being used by the payload handler. This is used
+// to stop the go routines started by 'start()'
+func (payloadHandler *payloadRequestHandler) stop() {
+	payloadHandler.cancel()
+}
+
+// sendAcks sends ack requests to ACS
+func (payloadHandler *payloadRequestHandler) sendAcks() {
+	for {
+		select {
+		case mid := <-payloadHandler.ackRequest:
+			payloadHandler.ackMessageId(mid)
+		case <-payloadHandler.ctx.Done():
+			return
+		}
+	}
+}
+
+// ackMessageId sends an AckRequest for a message id
+func (payloadHandler *payloadRequestHandler) ackMessageId(messageID string) {
+	err := payloadHandler.acsClient.MakeRequest(&ecsacs.AckRequest{
+		Cluster:           aws.String(payloadHandler.cluster),
+		ContainerInstance: aws.String(payloadHandler.containerInstanceArn),
+		MessageId:         aws.String(messageID),
+	})
+	if err != nil {
+		seelog.Warnf("Error 'ack'ing request with messageID: %s, error: %v", messageID, err)
+	}
+}
+
+// handleMessages processes payload messages in the payload message buffer in-order
+func (payloadHandler *payloadRequestHandler) handleMessages() {
+	for {
+		select {
+		case payload := <-payloadHandler.messageBuffer:
+			payloadHandler.handleSingleMessage(payload)
+		case <-payloadHandler.ctx.Done():
+			return
+		}
+	}
+}
+
+// handleSingleMessage processes a single payload message. It adds tasks in the message to the task engine
+// An error is returned if the message was not handled correctly. The error is being used only for testing
+// today. In the future, it could be used for doing more interesting things.
+func (payloadHandler *payloadRequestHandler) handleSingleMessage(payload *ecsacs.PayloadMessage) error {
+	if aws.StringValue(payload.MessageId) == "" {
+		seelog.Criticalf("Recieved a payload with no message id, payload: %v", payload)
+		return fmt.Errorf("Received a payload with no message id")
+	}
+	allTasksHandled := payloadHandler.addPayloadTasks(payload)
+	// save the state of tasks we know about after passing them to the task engine
+	err := payloadHandler.saver.Save()
+	if err != nil {
+		seelog.Errorf("Error saving state for payload message! err: %v, messageId: %s", err, *payload.MessageId)
+		// Don't ack; maybe we can save it in the future.
+		return fmt.Errorf("Error saving state for payload message, with messageId: %s", *payload.MessageId)
+	}
+	if !allTasksHandled {
+		return fmt.Errorf("All tasks not handled")
+	}
+
+	go func() {
+		// Throw the ack in async; it doesn't really matter all that much and this is blocking handling more tasks.
+		payloadHandler.ackRequest <- *payload.MessageId
+	}()
+	// Record the sequence number as well
+	if payload.SeqNum != nil {
+		SequenceNumber.Set(*payload.SeqNum)
+	}
+	return nil
+
+}
+
+// addPayloadTasks does validation on each task and, for all valid ones, adds
+// it to the task engine. It returns a bool indicating if it could add every
+// task to the taskEngine
+func (payloadHandler *payloadRequestHandler) addPayloadTasks(payload *ecsacs.PayloadMessage) bool {
+	// verify thatwe were able to work with all tasks in this payload so we know whether to ack the whole thing or not
+	allTasksOk := true
+
+	validTasks := make([]*api.Task, 0, len(payload.Tasks))
+	for _, task := range payload.Tasks {
+		if task == nil {
+			seelog.Criticalf("Recieved nil task for messageId: %s", *payload.MessageId)
+			allTasksOk = false
+			continue
+		}
+		apiTask, err := api.TaskFromACS(task, payload)
+		if err != nil {
+			payloadHandler.handleUnrecognizedTask(task, err, payload)
+			allTasksOk = false
+			continue
+		}
+		validTasks = append(validTasks, apiTask)
+	}
+	// Add 'stop' transitions first to allow seqnum ordering to work out
+	// Because a 'start' sequence number should only be proceeded if all 'stop's
+	// of the same sequence number have completed, the 'start' events need to be
+	// added after the 'stop' events are there to block them.
+	stoppedAddedOk := payloadHandler.addTasks(validTasks, isTaskStatusNotStopped)
+	nonstoppedAddedOk := payloadHandler.addTasks(validTasks, isTaskStatusStopped)
+	if !stoppedAddedOk || !nonstoppedAddedOk {
+		allTasksOk = false
+	}
+	return allTasksOk
+}
+
+// addTasks adds the tasks to the task engine based on the skipAddTask condition
+// This is used to add non-stopped tasks before adding stopped tasks
+func (payloadHandler *payloadRequestHandler) addTasks(tasks []*api.Task, skipAddTask skipAddTaskComparatorFunc) bool {
+	allTasksOk := true
+	for _, task := range tasks {
+		if skipAddTask(task.DesiredStatus) {
+			continue
+		}
+		err := payloadHandler.taskEngine.AddTask(task)
+		if err != nil {
+			seelog.Warnf("Could not add task; taskengine probably disabled, err: %v", err)
+			// Don't ack
+			allTasksOk = false
+		}
+	}
+	return allTasksOk
+}
+
+// skipAddTaskComparatorFunc defines the function pointer that accepts task status
+// and returns the boolean comparison result
+type skipAddTaskComparatorFunc func(api.TaskStatus) bool
+
+// isTaskStatusStopped returns true if the task status == STOPPTED
+func isTaskStatusStopped(status api.TaskStatus) bool {
+	return status == api.TaskStopped
+}
+
+// isTaskStatusNotStopped returns true if the task status != STOPPTED
+func isTaskStatusNotStopped(status api.TaskStatus) bool {
+	return status != api.TaskStopped
+}
+
+// handleUnrecognizedTask handles unrecognized tasks by sending 'stopped' with
+// a suitable reason to the backend
+func (payloadHandler *payloadRequestHandler) handleUnrecognizedTask(task *ecsacs.Task, err error, payload *ecsacs.PayloadMessage) {
+	if task.Arn == nil {
+		seelog.Criticalf("Recieved task with no arn, messageId: %s, task: %v", *payload.MessageId, task)
+		return
+	}
+
+	// Only need to stop the task; it brings down the containers too.
+	eventhandler.AddTaskEvent(api.TaskStateChange{
+		TaskArn: *task.Arn,
+		Status:  api.TaskStopped,
+		Reason:  UnrecognizedTaskError{err}.Error(),
+	}, payloadHandler.ecsClient)
+}
+
+// clearAcks drains the ack request channel
+func (payloadHandler *payloadRequestHandler) clearAcks() {
+	for {
+		select {
+		case <-payloadHandler.ackRequest:
+		default:
+			return
+		}
+	}
+}

--- a/agent/acs/handler/payload_handler_test.go
+++ b/agent/acs/handler/payload_handler_test.go
@@ -1,0 +1,329 @@
+// Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+package handler
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/aws/amazon-ecs-agent/agent/acs/model/ecsacs"
+	"github.com/aws/amazon-ecs-agent/agent/api"
+	"github.com/aws/amazon-ecs-agent/agent/api/mocks"
+	"github.com/aws/amazon-ecs-agent/agent/engine"
+	"github.com/aws/amazon-ecs-agent/agent/statemanager"
+	"github.com/aws/amazon-ecs-agent/agent/statemanager/mocks"
+	"github.com/aws/amazon-ecs-agent/agent/wsclient/mock"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/golang/mock/gomock"
+	"golang.org/x/net/context"
+)
+
+const (
+	clusterName          = "default"
+	containerInstanceArn = "instance"
+)
+
+// TestHandlePayloadMessageWithNoMessageId tests that agent doesn't ack payload messages
+// that do not contain message ids
+func TestHandlePayloadMessageWithNoMessageId(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	taskEngine := engine.NewMockTaskEngine(ctrl)
+	ecsClient := mock_api.NewMockECSClient(ctrl)
+	stateManager := statemanager.NewNoopStateManager()
+
+	ctx := context.Background()
+	buffer := newPayloadRequestHandler(taskEngine, ecsClient, clusterName, containerInstanceArn, nil, stateManager, ctx)
+
+	// test adding a payload message without the MessageId field
+	payloadMessage := &ecsacs.PayloadMessage{
+		Tasks: []*ecsacs.Task{
+			&ecsacs.Task{
+				Arn: aws.String("t1"),
+			},
+		},
+	}
+	err := buffer.handleSingleMessage(payloadMessage)
+	if err == nil {
+		t.Error("Expected error while adding a task with no message id")
+	}
+
+	// test adding a payload message with blank MessageId
+	payloadMessage.MessageId = aws.String("")
+	err = buffer.handleSingleMessage(payloadMessage)
+
+	if err == nil {
+		t.Error("Expected error while adding a task with no message id")
+	}
+
+}
+
+// TestHandlePayloadMessageAddTaskError tests that agent does not ack payload messages
+// when task engine fails to add tasks
+func TestHandlePayloadMessageAddTaskError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	taskEngine := engine.NewMockTaskEngine(ctrl)
+	ecsClient := mock_api.NewMockECSClient(ctrl)
+	stateManager := statemanager.NewNoopStateManager()
+
+	// Return error from AddTask
+	taskEngine.EXPECT().AddTask(gomock.Any()).Return(fmt.Errorf("oops")).Times(2)
+
+	ctx := context.Background()
+	buffer := newPayloadRequestHandler(taskEngine, ecsClient, clusterName, containerInstanceArn, nil, stateManager, ctx)
+
+	// Test AddTask error with RUNNING task
+	payloadMessage := &ecsacs.PayloadMessage{
+		Tasks: []*ecsacs.Task{
+			&ecsacs.Task{
+				Arn:           aws.String("t1"),
+				DesiredStatus: aws.String("RUNNING"),
+			},
+		},
+		MessageId: aws.String("123"),
+	}
+	err := buffer.handleSingleMessage(payloadMessage)
+	if err == nil {
+		t.Error("Expected error while adding the task")
+	}
+
+	payloadMessage = &ecsacs.PayloadMessage{
+		Tasks: []*ecsacs.Task{
+			&ecsacs.Task{
+				Arn:           aws.String("t1"),
+				DesiredStatus: aws.String("STOPPED"),
+			},
+		},
+		MessageId: aws.String("123"),
+	}
+	// Test AddTask error with STOPPED task
+	err = buffer.handleSingleMessage(payloadMessage)
+	if err == nil {
+		t.Error("Expected error while adding the task")
+	}
+}
+
+// TestHandlePayloadMessageStateSaveError tests that agent does not ack payload messages
+// when state saver fails to save state
+func TestHandlePayloadMessageStateSaveError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	ecsClient := mock_api.NewMockECSClient(ctrl)
+
+	taskEngine := engine.NewMockTaskEngine(ctrl)
+	// Save added task in the addedTask variable
+	var addedTask *api.Task
+	taskEngine.EXPECT().AddTask(gomock.Any()).Do(func(task *api.Task) {
+		addedTask = task
+	}).Times(1)
+
+	// State manager returns error on save
+	stateManager := mock_statemanager.NewMockStateManager(ctrl)
+	stateManager.EXPECT().Save().Return(fmt.Errorf("oops"))
+
+	ctx := context.Background()
+	buffer := newPayloadRequestHandler(taskEngine, ecsClient, clusterName, containerInstanceArn, nil, stateManager, ctx)
+
+	// Check if handleSingleMessage returns an error when state manager returns error on Save()
+	err := buffer.handleSingleMessage(&ecsacs.PayloadMessage{
+		Tasks: []*ecsacs.Task{
+			&ecsacs.Task{
+				Arn: aws.String("t1"),
+			},
+		},
+		MessageId: aws.String("123"),
+	})
+	if err == nil {
+		t.Error("Expected error while adding a task from statemanager")
+	}
+
+	// We expect task to be added to the engine even though it hasn't been saved
+	expectedTask := &api.Task{
+		Arn: "t1",
+	}
+	if !reflect.DeepEqual(addedTask, expectedTask) {
+		t.Errorf("Mismatch between expected and added tasks, expected: %v, added: %v", expectedTask, addedTask)
+	}
+}
+
+// TestHandlePayloadMessageAckedWhenTaskAdded tests if the handler generates an ack
+// after processing a payload message.
+func TestHandlePayloadMessageAckedWhenTaskAdded(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	ecsClient := mock_api.NewMockECSClient(ctrl)
+	stateManager := statemanager.NewNoopStateManager()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	taskEngine := engine.NewMockTaskEngine(ctrl)
+	var addedTask *api.Task
+	taskEngine.EXPECT().AddTask(gomock.Any()).Do(func(task *api.Task) {
+		addedTask = task
+	}).Times(1)
+
+	// Send a payload message
+	messageId := "123"
+	payloadMessage := &ecsacs.PayloadMessage{
+		Tasks: []*ecsacs.Task{
+			&ecsacs.Task{
+				Arn: aws.String("t1"),
+			},
+		},
+		MessageId: aws.String(messageId),
+	}
+	var ackRequested *ecsacs.AckRequest
+	mockWsClient := mock_wsclient.NewMockClientServer(ctrl)
+	mockWsClient.EXPECT().MakeRequest(gomock.Any()).Do(func(ackRequest *ecsacs.AckRequest) {
+		ackRequested = ackRequest
+		cancel()
+	}).Times(1)
+	buffer := newPayloadRequestHandler(taskEngine, ecsClient, clusterName, containerInstanceArn, mockWsClient, stateManager, ctx)
+	go buffer.start()
+	err := buffer.handleSingleMessage(payloadMessage)
+	if err != nil {
+		t.Errorf("Error handling payload message: %v", err)
+	}
+
+	// Wait till we get an ack from the ackBuffer
+	select {
+	case <-ctx.Done():
+	}
+	// Verify the message id acked
+	if aws.StringValue(ackRequested.MessageId) != messageId {
+		t.Errorf("Message Id mismatch. Expected: %s, got: %s", messageId, aws.StringValue(ackRequested.MessageId))
+	}
+
+	// Verify if task added == expected task
+	expectedTask := &api.Task{
+		Arn: "t1",
+	}
+	if !reflect.DeepEqual(addedTask, expectedTask) {
+		t.Errorf("Mismatch between expected and added tasks, expected: %v, added: %v", expectedTask, addedTask)
+	}
+}
+
+// TestAddPayloadTaskAddsNonStoppedTasksAfterStoppedTasks tests if tasks with desired status
+// 'RUNNING' are added after tasks with desired status 'STOPPED'
+func TestAddPayloadTaskAddsNonStoppedTasksAfterStoppedTasks(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	ecsClient := mock_api.NewMockECSClient(ctrl)
+	taskEngine := engine.NewMockTaskEngine(ctrl)
+
+	var tasksAddedToEngine []*api.Task
+	taskEngine.EXPECT().AddTask(gomock.Any()).Do(func(task *api.Task) {
+		tasksAddedToEngine = append(tasksAddedToEngine, task)
+	}).Times(2)
+
+	messageId := "123"
+	stoppedTaskArn := "stoppedTask"
+	runningTaskArn := "runningTask"
+	payloadMessage := &ecsacs.PayloadMessage{
+		Tasks: []*ecsacs.Task{
+			&ecsacs.Task{
+				Arn:           aws.String(runningTaskArn),
+				DesiredStatus: aws.String("RUNNING"),
+			},
+			&ecsacs.Task{
+				Arn:           aws.String(stoppedTaskArn),
+				DesiredStatus: aws.String("STOPPED"),
+			},
+		},
+		MessageId: aws.String(messageId),
+	}
+
+	ctx := context.Background()
+	stateManager := statemanager.NewNoopStateManager()
+	buffer := newPayloadRequestHandler(taskEngine, ecsClient, clusterName, containerInstanceArn, nil, stateManager, ctx)
+	ok := buffer.addPayloadTasks(payloadMessage)
+	if !ok {
+		t.Error("addPayloadTasks returned false")
+	}
+	if len(tasksAddedToEngine) != 2 {
+		t.Errorf("Incorrect number of tasks added to the engine. Expected: %d, got: %d", 2, len(tasksAddedToEngine))
+	}
+
+	// Verify if stopped task is added before running task
+	firstTaskAdded := tasksAddedToEngine[0]
+	if firstTaskAdded.Arn != stoppedTaskArn {
+		t.Errorf("Expected first task arn: %s, got: %s", stoppedTaskArn, firstTaskAdded.Arn)
+	}
+	if firstTaskAdded.DesiredStatus != api.TaskStopped {
+		t.Errorf("Expected first task state be be: %s , got: %s", "STOPPED", firstTaskAdded.DesiredStatus.String())
+	}
+
+	secondTaskAdded := tasksAddedToEngine[1]
+	if secondTaskAdded.Arn != runningTaskArn {
+		t.Errorf("Expected second task arn: %s, got: %s", runningTaskArn, secondTaskAdded.Arn)
+	}
+	if secondTaskAdded.DesiredStatus != api.TaskRunning {
+		t.Errorf("Expected second task state be be: %s , got: %s", "RUNNNING", secondTaskAdded.DesiredStatus.String())
+	}
+}
+
+// TestPayloadBufferHandler tests if the async payloadBufferHandler routine
+// acks messages after adding tasks
+func TestPayloadBufferHandler(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	taskEngine := engine.NewMockTaskEngine(ctrl)
+	ecsClient := mock_api.NewMockECSClient(ctrl)
+	stateManager := statemanager.NewNoopStateManager()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// payloadBuffer := make(chan *ecsacs.PayloadMessage, payloadMessageBufferSize)
+	var addedTask *api.Task
+	taskEngine.EXPECT().AddTask(gomock.Any()).Do(func(task *api.Task) {
+		addedTask = task
+	}).Times(1)
+
+	var ackRequested *ecsacs.AckRequest
+	mockWsClient := mock_wsclient.NewMockClientServer(ctrl)
+	mockWsClient.EXPECT().MakeRequest(gomock.Any()).Do(func(ackRequest *ecsacs.AckRequest) {
+		ackRequested = ackRequest
+		cancel()
+	}).Times(1)
+
+	buffer := newPayloadRequestHandler(taskEngine, ecsClient, clusterName, containerInstanceArn, mockWsClient, stateManager, ctx)
+	go buffer.start()
+	// Send a payload message to the payloadBufferChannel
+	messageId := "123"
+	taskArn := "t1"
+	buffer.messageBuffer <- &ecsacs.PayloadMessage{
+		Tasks: []*ecsacs.Task{
+			&ecsacs.Task{
+				Arn: aws.String(taskArn),
+			},
+		},
+		MessageId: aws.String(messageId),
+	}
+
+	// Wait till we get an ack
+	select {
+	case <-ctx.Done():
+	}
+	// Verify if messageId read from the ack buffer is correct
+	if aws.StringValue(ackRequested.MessageId) != messageId {
+		t.Errorf("Message Id mismatch. Expected: %s, got: %s", messageId, aws.StringValue(ackRequested.MessageId))
+	}
+
+	// Verify if the task added to the engine is correct
+	expectedTask := &api.Task{
+		Arn: taskArn,
+	}
+	if !reflect.DeepEqual(addedTask, expectedTask) {
+		t.Errorf("Mismatch between expected and added tasks, expected: %v, added: %v", expectedTask, addedTask)
+	}
+}


### PR DESCRIPTION
1. Remove unused cluster and containerInstanceArn parameters from addPayloadTasks
2. Move the async payload buffer handler go routine to a named function
3. Move handler tests to handler package from handler_test package
4. Add unit tests for various failure modes while adding a task and to test the order of tasks added to the engine
5. Fix bug with acking blank message ids

r? @samuelkarp @juanrhenals 