### PR TITLE
ftests: Fix Squid test to use versioned client

### DIFF
--- a/agent/functional_tests/tests/functionaltests_test.go
+++ b/agent/functional_tests/tests/functionaltests_test.go
@@ -376,7 +376,7 @@ func TestDockerAuth(t *testing.T) {
 
 func TestSquidProxy(t *testing.T) {
 	// Run a squid proxy manually, verify that the agent can connect through it
-	client, err := docker.NewClientFromEnv()
+	client, err := docker.NewVersionedClientFromEnv("1.17")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Using an unversioned client is causing test failures with Docker 1.11.0-rc4.

r? @aaithal 