### PR TITLE
ftests: Relax TestTaskCleanupDoesNotDeadlock time

### DIFF
--- a/agent/functional_tests/tests/functionaltests_test.go
+++ b/agent/functional_tests/tests/functionaltests_test.go
@@ -153,7 +153,7 @@ func TestTaskCleanupDoesNotDeadlock(t *testing.T) {
 		}
 
 		// Wait for the tasks to be cleaned up
-		time.Sleep(75 * time.Second)
+		time.Sleep(90 * time.Second)
 
 		// Ensure that tasks are cleaned up. WWe should not be able to describe the
 		// container now since it has been cleaned up.

--- a/agent/functional_tests/util/utils.go
+++ b/agent/functional_tests/util/utils.go
@@ -562,7 +562,7 @@ func (agent *TestAgent) waitRunningViaIntrospection(task *TestTask) (bool, error
 	var taskResp handlers.TaskResponse
 	err = json.Unmarshal(*rawResponse, &taskResp)
 
-	if taskResp.KnownStatus == "RUNNING" {
+	if taskResp.KnownStatus == "RUNNING" || taskResp.KnownStatus == "STOPPED" {
 		return true, nil
 	} else {
 		return false, errors.New("Task should be RUNNING but is " + taskResp.KnownStatus)


### PR DESCRIPTION
1. On systems where Docker is performing more slowly, 25 seconds may
not be enough time for the containers to get removed.
2. On systems where Docker is performing more quickly, the task may
move to STOPPED faster than we're inspecting.

r? @aaithal @juanrhenals 