### PR TITLE
Add locks in api.Task struct for setting and getting KnownStatus and …

### DIFF
--- a/agent/api/testutils/task_equal.go
+++ b/agent/api/testutils/task_equal.go
@@ -42,7 +42,7 @@ func TasksEqual(lhs, rhs *api.Task) bool {
 	if lhs.DesiredStatus != rhs.DesiredStatus {
 		return false
 	}
-	if lhs.KnownStatus != rhs.KnownStatus {
+	if lhs.GetKnownStatus() != rhs.GetKnownStatus() {
 		return false
 	}
 	return true

--- a/agent/api/types.go
+++ b/agent/api/types.go
@@ -93,9 +93,12 @@ type Task struct {
 	Containers []*Container
 	Volumes    []TaskVolume `json:"volumes"`
 
-	DesiredStatus   TaskStatus
-	KnownStatus     TaskStatus
-	KnownStatusTime time.Time `json:"KnownTime"`
+	DesiredStatus TaskStatus
+
+	KnownStatus         TaskStatus
+	knownStatusLock     sync.RWMutex
+	KnownStatusTime     time.Time `json:"KnownTime"`
+	knownStatusTimeLock sync.RWMutex
 
 	SentStatus TaskStatus
 
@@ -199,7 +202,7 @@ func (t *TaskStateChange) String() string {
 }
 
 func (t *Task) String() string {
-	res := fmt.Sprintf("%s:%s %s, Status: (%s->%s)", t.Family, t.Version, t.Arn, t.KnownStatus.String(), t.DesiredStatus.String())
+	res := fmt.Sprintf("%s:%s %s, Status: (%s->%s)", t.Family, t.Version, t.Arn, t.GetKnownStatus().String(), t.DesiredStatus.String())
 	res += " Containers: ["
 	for _, c := range t.Containers {
 		res += fmt.Sprintf("%s (%s->%s),", c.Name, c.KnownStatus.String(), c.DesiredStatus.String())

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -286,16 +286,17 @@ func (engine *DockerTaskEngine) sweepTask(task *api.Task) {
 }
 
 func (engine *DockerTaskEngine) emitTaskEvent(task *api.Task, reason string) {
-	if !task.KnownStatus.BackendRecognized() {
+	taskKnownStatus := task.GetKnownStatus()
+	if !taskKnownStatus.BackendRecognized() {
 		return
 	}
-	if task.SentStatus >= task.KnownStatus {
-		log.Debug("Already sent task event; no need to re-send", "task", task.Arn, "event", task.KnownStatus.String())
+	if task.SentStatus >= taskKnownStatus {
+		log.Debug("Already sent task event; no need to re-send", "task", task.Arn, "event", taskKnownStatus.String())
 		return
 	}
 	event := api.TaskStateChange{
 		TaskArn:    task.Arn,
-		Status:     task.KnownStatus,
+		Status:     taskKnownStatus,
 		Reason:     reason,
 		SentStatus: &task.SentStatus,
 	}

--- a/agent/handlers/v1_handlers.go
+++ b/agent/handlers/v1_handlers.go
@@ -66,17 +66,18 @@ func newTaskResponse(task *api.Task, containerMap map[string]*api.DockerContaine
 		containers = append(containers, ContainerResponse{container.DockerId, container.DockerName, containerName})
 	}
 
-	knownStatus := task.KnownStatus.BackendStatus()
+	knownStatus := task.GetKnownStatus()
+	knownBackendStatus := knownStatus.BackendStatus()
 	desiredStatus := task.DesiredStatus.BackendStatus()
 
-	if (knownStatus == "STOPPED" && desiredStatus != "STOPPED") || (knownStatus == "RUNNING" && desiredStatus == "PENDING") {
+	if (knownBackendStatus == "STOPPED" && desiredStatus != "STOPPED") || (knownBackendStatus == "RUNNING" && desiredStatus == "PENDING") {
 		desiredStatus = ""
 	}
 
 	return &TaskResponse{
 		Arn:           task.Arn,
 		DesiredStatus: desiredStatus,
-		KnownStatus:   knownStatus,
+		KnownStatus:   knownBackendStatus,
 		Family:        task.Family,
 		Version:       task.Version,
 		Containers:    containers,

--- a/agent/handlers/v1_handlers_test.go
+++ b/agent/handlers/v1_handlers_test.go
@@ -211,8 +211,9 @@ func taskDiffHelper(t *testing.T, expected []*api.Task, actual TasksResponse) {
 		if respTask.DesiredStatus != task.DesiredStatus.String() {
 			t.Errorf("DesiredStatus mismatch: %v != %v", respTask.DesiredStatus, task.DesiredStatus)
 		}
-		if respTask.KnownStatus != task.KnownStatus.String() {
-			t.Errorf("KnownStatus mismatch: %v != %v", respTask.KnownStatus, task.KnownStatus)
+		taskKnownStatus := task.GetKnownStatus().String()
+		if respTask.KnownStatus != taskKnownStatus {
+			t.Errorf("KnownStatus mismatch: %v != %v", respTask.KnownStatus, taskKnownStatus)
 		}
 
 		if respTask.Family != task.Family || respTask.Version != task.Version {

--- a/agent/statemanager/state_manager_test.go
+++ b/agent/statemanager/state_manager_test.go
@@ -166,7 +166,7 @@ func TestLoadsV1DataCorrectly(t *testing.T) {
 		t.Fatal("container Dead should go to stopped")
 	}
 	expected, _ := time.Parse(time.RFC3339, "2015-04-28T17:29:48.129140193Z")
-	if deadTask.KnownStatusTime != expected {
+	if deadTask.GetKnownStatusTime() != expected {
 		t.Fatal("Time was not correct")
 	}
 }

--- a/agent/stats/engine.go
+++ b/agent/stats/engine.go
@@ -285,7 +285,7 @@ func (engine *DockerStatsEngine) addContainer(dockerID string) {
 		return
 	}
 
-	if task.KnownStatus.Terminal() {
+	if task.GetKnownStatus().Terminal() {
 		log.Debug("Task is terminal, ignoring", "id", dockerID)
 		return
 	}


### PR DESCRIPTION
…KnownStatusTime.

These variables are being used (mostly gets) outside the 'engine' package. Adding locks to
ensure that there's no race condition around these

Ensured that functional and integ tests [pass](https://github.com/aaithal/amazon-ecs-agent/compare/master...aaithal:APITaskKnownStatusLock).

r? @samuelkarp @juanrhenals @richardpen 