### PR TITLE
Use docker name instead of docker id for cleaning up containers.

### DIFF
--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -532,7 +532,7 @@ func (engine *DockerTaskEngine) removeContainer(task *api.Task, container *api.C
 		return errors.New("No container named '" + container.Name + "' created in " + task.Arn)
 	}
 
-	return engine.client.RemoveContainer(dockerContainer.DockerId)
+	return engine.client.RemoveContainer(dockerContainer.DockerName)
 }
 
 // updateTask determines if a new transition needs to be applied to the


### PR DESCRIPTION
This should fix the issue where ECS Agent issues docker rm with no arguments (#364).
This should also fix the issue where ECS Agent does not clean up containers in
'created' state for tasks that fail during container creation.

r? @samuelkarp @juanrhenals @richardpen 