### PR TITLE
refactor: Inject the Docker client

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2014-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License"). You
 may not use this file except in compliance with the License. A copy of

--- a/agent/acs/update_handler/updater_test.go
+++ b/agent/acs/update_handler/updater_test.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -100,7 +100,7 @@ func TestFullUpdateFlow(t *testing.T) {
 		t.Error("Incorrect data written")
 	}
 
-	u.performUpdateHandler(statemanager.NewNoopStateManager(), engine.NewTaskEngine(cfg, false))(&ecsacs.PerformUpdateMessage{
+	u.performUpdateHandler(statemanager.NewNoopStateManager(), engine.NewTaskEngine(cfg, nil))(&ecsacs.PerformUpdateMessage{
 		ClusterArn:           ptr("cluster").(*string),
 		ContainerInstanceArn: ptr("containerInstance").(*string),
 		MessageId:            ptr("mid2").(*string),
@@ -163,7 +163,7 @@ func TestUndownloadedUpdate(t *testing.T) {
 		MessageId:         ptr("mid").(*string),
 	}})
 
-	u.performUpdateHandler(statemanager.NewNoopStateManager(), engine.NewTaskEngine(cfg, false))(&ecsacs.PerformUpdateMessage{
+	u.performUpdateHandler(statemanager.NewNoopStateManager(), engine.NewTaskEngine(cfg, nil))(&ecsacs.PerformUpdateMessage{
 		ClusterArn:           ptr("cluster").(*string),
 		ContainerInstanceArn: ptr("containerInstance").(*string),
 		MessageId:            ptr("mid").(*string),
@@ -223,7 +223,7 @@ func TestDuplicateUpdateMessagesWithSuccess(t *testing.T) {
 		t.Error("Incorrect data written")
 	}
 
-	u.performUpdateHandler(statemanager.NewNoopStateManager(), engine.NewTaskEngine(cfg, false))(&ecsacs.PerformUpdateMessage{
+	u.performUpdateHandler(statemanager.NewNoopStateManager(), engine.NewTaskEngine(cfg, nil))(&ecsacs.PerformUpdateMessage{
 		ClusterArn:           ptr("cluster").(*string),
 		ContainerInstanceArn: ptr("containerInstance").(*string),
 		MessageId:            ptr("mid3").(*string),
@@ -290,7 +290,7 @@ func TestDuplicateUpdateMessagesWithFailure(t *testing.T) {
 		t.Error("Incorrect data written")
 	}
 
-	u.performUpdateHandler(statemanager.NewNoopStateManager(), engine.NewTaskEngine(cfg, false))(&ecsacs.PerformUpdateMessage{
+	u.performUpdateHandler(statemanager.NewNoopStateManager(), engine.NewTaskEngine(cfg, nil))(&ecsacs.PerformUpdateMessage{
 		ClusterArn:           ptr("cluster").(*string),
 		ContainerInstanceArn: ptr("containerInstance").(*string),
 		MessageId:            ptr("mid3").(*string),
@@ -367,7 +367,7 @@ func TestNewerUpdateMessages(t *testing.T) {
 		t.Error("Incorrect data written")
 	}
 
-	u.performUpdateHandler(statemanager.NewNoopStateManager(), engine.NewTaskEngine(cfg, false))(&ecsacs.PerformUpdateMessage{
+	u.performUpdateHandler(statemanager.NewNoopStateManager(), engine.NewTaskEngine(cfg, nil))(&ecsacs.PerformUpdateMessage{
 		ClusterArn:           ptr("cluster").(*string),
 		ContainerInstanceArn: ptr("containerInstance").(*string),
 		MessageId:            ptr("mid2").(*string),

--- a/agent/engine/default.go
+++ b/agent/engine/default.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -23,6 +23,6 @@ import (
 var log = logger.ForModule("TaskEngine")
 
 // NewTaskEngine returns a default TaskEngine
-func NewTaskEngine(cfg *config.Config, acceptInsecureCert bool) TaskEngine {
-	return NewDockerTaskEngine(cfg, acceptInsecureCert)
+func NewTaskEngine(cfg *config.Config, client DockerClient) TaskEngine {
+	return NewDockerTaskEngine(cfg, client)
 }

--- a/agent/engine/docker_container_engine.go
+++ b/agent/engine/docker_container_engine.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -17,7 +17,6 @@ import (
 	"archive/tar"
 	"bufio"
 	"io"
-	"os"
 	"strings"
 	"sync"
 	"time"
@@ -31,7 +30,6 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerclient"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockeriface"
 	"github.com/aws/amazon-ecs-agent/agent/engine/emptyvolume"
-	"github.com/aws/amazon-ecs-agent/agent/utils"
 	"github.com/aws/amazon-ecs-agent/agent/utils/ttime"
 	"github.com/cihub/seelog"
 	"github.com/docker/docker/pkg/parsers"
@@ -127,14 +125,9 @@ type DockerImageResponse struct {
 
 // NewDockerGoClient creates a new DockerGoClient
 func NewDockerGoClient(clientFactory dockerclient.Factory, authType string, authData *config.SensitiveRawMessage, acceptInsecureCert bool) (DockerClient, error) {
-	endpoint := utils.DefaultIfBlank(os.Getenv(DOCKER_ENDPOINT_ENV_VARIABLE), DOCKER_DEFAULT_ENDPOINT)
-	if clientFactory == nil {
-		clientFactory = dockerclient.NewFactory(endpoint)
-	}
-
 	client, err := clientFactory.GetDefaultClient()
 	if err != nil {
-		log.Error("Unable to connect to docker daemon . Ensure docker is running", "endpoint", endpoint, "err", err)
+		log.Error("Unable to connect to docker daemon. Ensure docker is running.", "err", err)
 		return nil, err
 	}
 
@@ -142,7 +135,7 @@ func NewDockerGoClient(clientFactory dockerclient.Factory, authType string, auth
 	// to ensure it's up.
 	err = client.Ping()
 	if err != nil {
-		log.Error("Unable to ping docker daemon. Ensure docker is running", "endpoint", endpoint, "err", err)
+		log.Error("Unable to ping docker daemon. Ensure docker is running.", "err", err)
 		return nil, err
 	}
 

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -35,8 +35,7 @@ var defaultConfig = config.DefaultConfig()
 func mocks(t *testing.T, cfg *config.Config) (*gomock.Controller, *MockDockerClient, TaskEngine) {
 	ctrl := gomock.NewController(t)
 	client := NewMockDockerClient(ctrl)
-	taskEngine := NewTaskEngine(cfg, false)
-	taskEngine.(*DockerTaskEngine).SetDockerClient(client)
+	taskEngine := NewTaskEngine(cfg, client)
 	return ctrl, client, taskEngine
 }
 

--- a/agent/engine/engine_integ_test.go
+++ b/agent/engine/engine_integ_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/api"
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/ec2"
+	"github.com/aws/amazon-ecs-agent/agent/engine/dockerclient"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 	"github.com/aws/amazon-ecs-agent/agent/utils/ttime"
 	docker "github.com/fsouza/go-dockerclient"
@@ -54,7 +55,12 @@ func setup(t *testing.T) (TaskEngine, func(), *ttime.TestTime) {
 	if os.Getenv("ECS_SKIP_ENGINE_INTEG_TEST") != "" {
 		t.Skip("ECS_SKIP_ENGINE_INTEG_TEST")
 	}
-	taskEngine := NewDockerTaskEngine(cfg, false)
+	clientFactory := dockerclient.NewFactory("unix:///var/run/docker.sock")
+	dockerClient, err := NewDockerGoClient(clientFactory, cfg.EngineAuthType, cfg.EngineAuthData, false)
+	if err != nil {
+		t.Fatalf("Error creating Docker client: %v", err)
+	}
+	taskEngine := NewDockerTaskEngine(cfg, dockerClient)
 	taskEngine.Init()
 	test_time := ttime.NewTestTime()
 	ttime.SetTime(test_time)

--- a/agent/statemanager/state_manager_test.go
+++ b/agent/statemanager/state_manager_test.go
@@ -49,7 +49,7 @@ func TestStateManager(t *testing.T) {
 
 	// Now let's make some state to save
 	containerInstanceArn := ""
-	taskEngine := engine.NewTaskEngine(&config.Config{}, false)
+	taskEngine := engine.NewTaskEngine(&config.Config{}, nil)
 
 	manager, err = statemanager.NewStateManager(cfg, statemanager.AddSaveable("TaskEngine", taskEngine), statemanager.AddSaveable("ContainerInstanceArn", &containerInstanceArn))
 	if err != nil {
@@ -67,7 +67,7 @@ func TestStateManager(t *testing.T) {
 	}
 
 	// Now make sure we can load that state sanely
-	loadedTaskEngine := engine.NewTaskEngine(&config.Config{}, false)
+	loadedTaskEngine := engine.NewTaskEngine(&config.Config{}, nil)
 	var loadedContainerInstanceArn string
 
 	manager, err = statemanager.NewStateManager(cfg, statemanager.AddSaveable("TaskEngine", &loadedTaskEngine), statemanager.AddSaveable("ContainerInstanceArn", &loadedContainerInstanceArn))
@@ -113,7 +113,7 @@ func TestStateManagerNonexistantDirectory(t *testing.T) {
 func TestLoadsV1DataCorrectly(t *testing.T) {
 	cfg := &config.Config{DataDir: filepath.Join(".", "testdata", "v1", "1")}
 
-	taskEngine := engine.NewTaskEngine(&config.Config{}, false)
+	taskEngine := engine.NewTaskEngine(&config.Config{}, nil)
 	var containerInstanceArn, cluster, savedInstanceID string
 	var sequenceNumber int64
 

--- a/agent/stats/engine_test.go
+++ b/agent/stats/engine_test.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -152,7 +152,7 @@ func TestStatsEngineAddRemoveContainers(t *testing.T) {
 	resolver.EXPECT().ResolveTask("c5").AnyTimes().Return(t2, nil)
 	resolver.EXPECT().ResolveTask("c6").AnyTimes().Return(t3, nil)
 
-	engine := NewDockerStatsEngine(&cfg)
+	engine := NewDockerStatsEngine(&cfg, nil)
 	engine.resolver = resolver
 	engine.cluster = defaultCluster
 	engine.containerInstanceArn = defaultContainerInstance
@@ -271,7 +271,7 @@ func TestStatsEngineMetadataInStatsSets(t *testing.T) {
 	t1 := &api.Task{Arn: "t1", Family: "f1"}
 	resolver.EXPECT().ResolveTask("c1").AnyTimes().Return(t1, nil)
 
-	engine := NewDockerStatsEngine(&cfg)
+	engine := NewDockerStatsEngine(&cfg, nil)
 	engine.resolver = resolver
 	engine.cluster = defaultCluster
 	engine.containerInstanceArn = defaultContainerInstance
@@ -313,7 +313,7 @@ func TestStatsEngineMetadataInStatsSets(t *testing.T) {
 }
 
 func TestStatsEngineInvalidTaskEngine(t *testing.T) {
-	statsEngine := NewDockerStatsEngine(&cfg)
+	statsEngine := NewDockerStatsEngine(&cfg, nil)
 	taskEngine := &MockTaskEngine{}
 	err := statsEngine.MustInit(taskEngine, "", "")
 	if err == nil {
@@ -322,7 +322,7 @@ func TestStatsEngineInvalidTaskEngine(t *testing.T) {
 }
 
 func TestStatsEngineUninitialized(t *testing.T) {
-	engine := NewDockerStatsEngine(&cfg)
+	engine := NewDockerStatsEngine(&cfg, nil)
 	engine.resolver = &DockerContainerMetadataResolver{}
 	engine.cluster = defaultCluster
 	engine.containerInstanceArn = defaultContainerInstance
@@ -338,7 +338,7 @@ func TestStatsEngineTerminalTask(t *testing.T) {
 	defer mockCtrl.Finish()
 	resolver := mock_resolver.NewMockContainerMetadataResolver(mockCtrl)
 	resolver.EXPECT().ResolveTask("c1").Return(&api.Task{Arn: "t1", KnownStatus: api.TaskStopped}, nil)
-	engine := NewDockerStatsEngine(&cfg)
+	engine := NewDockerStatsEngine(&cfg, nil)
 	engine.resolver = resolver
 
 	engine.addContainer("c1")
@@ -351,7 +351,7 @@ func TestStatsEngineTerminalTask(t *testing.T) {
 func TestStatsEngineClientErrorListingContainers(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
-	engine := NewDockerStatsEngine(&cfg)
+	engine := NewDockerStatsEngine(&cfg, nil)
 	mockDockerClient := ecsengine.NewMockDockerClient(mockCtrl)
 	// Mock client will return error while listing images.
 	mockDockerClient.EXPECT().ListContainers(false).Return(ecsengine.ListContainersResponse{DockerIds: nil, Error: fmt.Errorf("could not list containers")})

--- a/agent/tcs/handler/handler.go
+++ b/agent/tcs/handler/handler.go
@@ -50,7 +50,7 @@ func StartMetricsSession(params TelemetrySessionParams) {
 	}
 
 	if !disabled {
-		statsEngine := stats.NewDockerStatsEngine(params.Cfg)
+		statsEngine := stats.NewDockerStatsEngine(params.Cfg, params.DockerClient)
 		err := statsEngine.MustInit(params.TaskEngine, params.Cfg.Cluster, params.ContainerInstanceArn)
 		if err != nil {
 			log.Warn("Error initializing metrics engine", "err", err)

--- a/agent/tcs/handler/types.go
+++ b/agent/tcs/handler/types.go
@@ -26,6 +26,7 @@ type TelemetrySessionParams struct {
 	ContainerInstanceArn string
 	CredentialProvider   *credentials.Credentials
 	Cfg                  *config.Config
+	DockerClient         engine.DockerClient
 	AcceptInvalidCert    bool
 	EcsClient            api.ECSClient
 	TaskEngine           engine.TaskEngine


### PR DESCRIPTION
This commit moves the Docker client to an injection model instead of
each component creating its own copy.  We can also remove test-specific
methods and just mock using injection.

r? @aaithal @juanrhenals @richardpen 