### PR TITLE
CPU limits hack

### DIFF
--- a/agent/api/task.go
+++ b/agent/api/task.go
@@ -309,11 +309,36 @@ func (task *Task) dockerHostConfig(container *Container, dockerContainerMap map[
 		return nil, &HostConfigError{err.Error()}
 	}
 
+	// HACK: we get the CPU Quota and CPU Period from the environment, since
+	// there is no good way to propagate them in. If they are set in the
+	// container, initialize them, otherwise set them to the default value.
+	cpuPeriod := 100000 // 100ms, default value
+	cpuPeriodLabel := "_DOCKER_CPU_PERIOD"
+
+	cpuQuota := -1 // -1, default value to not set a quota
+	cpuQuotaLabel := "_DOCKER_CPU_QUOTA"
+
+	if container.Environment[cpuPeriodLabel] != "" && container.Environment[cpuQuotaLabel] != "" {
+		cpuQuota, err = strconv.Atoi(container.Environment[cpuQuotaLabel])
+		if err != nil {
+			return nil, &HostConfigError{err.Error()}
+		}
+		cpuPeriod, err = strconv.Atoi(container.Environment[cpuPeriodLabel])
+		if err != nil {
+			return nil, &HostConfigError{err.Error()}
+		}
+
+	}
+	delete(container.Environment, cpuPeriodLabel)
+	delete(container.Environment, cpuQuotaLabel)
+
 	hostConfig := &docker.HostConfig{
 		Links:        dockerLinkArr,
 		Binds:        binds,
 		PortBindings: dockerPortMap,
 		VolumesFrom:  volumesFrom,
+		CPUQuota:     int64(cpuQuota),
+		CPUPeriod:    int64(cpuPeriod),
 	}
 
 	if container.DockerConfig.HostConfig != nil {

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -531,7 +531,7 @@ func (engine *DockerTaskEngine) removeContainer(task *api.Task, container *api.C
 		return errors.New("No container named '" + container.Name + "' created in " + task.Arn)
 	}
 
-	return engine.client.RemoveContainer(dockerContainer.DockerId)
+	return engine.client.RemoveContainer(dockerContainer.DockerName)
 }
 
 // updateTask determines if a new transition needs to be applied to the


### PR DESCRIPTION
We don't have a good way to pass in CPUQuota and CPUPeriod, so pass those in through environment
variables set on the container (or resort to defaults if the variable is not specified).