### PR TITLE
Add Splunk logging driver

### DIFF
--- a/agent/engine/dockerclient/logging_drivers.go
+++ b/agent/engine/dockerclient/logging_drivers.go
@@ -22,6 +22,7 @@ const (
 	GelfDriver     LoggingDriver = "gelf"
 	FluentdDriver  LoggingDriver = "fluentd"
 	AwslogsDriver  LoggingDriver = "awslogs"
+	SplunklogsDriver  LoggingDriver = "splunk"
 )
 
 var LoggingDriverMinimumVersion = map[LoggingDriver]DockerVersion{
@@ -31,4 +32,5 @@ var LoggingDriverMinimumVersion = map[LoggingDriver]DockerVersion{
 	GelfDriver:     Version_1_20,
 	FluentdDriver:  Version_1_20,
 	AwslogsDriver:  Version_1_21,
+	SplunklogsDriver:  Version_1_22,
 }

--- a/agent/engine/dockerclient/versions.go
+++ b/agent/engine/dockerclient/versions.go
@@ -29,6 +29,7 @@ const (
 	Version_1_19 DockerVersion = "1.19"
 	Version_1_20 DockerVersion = "1.20"
 	Version_1_21 DockerVersion = "1.21"
+	Version_1_22 DockerVersion = "1.22"
 
 	defaultVersion = Version_1_17
 )
@@ -42,6 +43,7 @@ func init() {
 		Version_1_19,
 		Version_1_20,
 		Version_1_21,
+		Version_1_22,
 	}
 }
 

--- a/agent/engine/dockerclient/versions_test.go
+++ b/agent/engine/dockerclient/versions_test.go
@@ -197,7 +197,7 @@ func TestFindAvailableVersiosn(t *testing.T) {
 	mockClient119.EXPECT().Ping()
 	mockClient120.EXPECT().Ping()
 	mockClient121.EXPECT().Ping()
-	mockClient122EXPECT().Ping()
+	mockClient122.EXPECT().Ping()
 
 	expectedVersions := []DockerVersion{Version_1_17, Version_1_19, Version_1_20, Version_1_21, Version_1_22}
 

--- a/agent/engine/dockerclient/versions_test.go
+++ b/agent/engine/dockerclient/versions_test.go
@@ -164,6 +164,7 @@ func TestFindAvailableVersiosn(t *testing.T) {
 	mockClient119 := mock_dockeriface.NewMockClient(ctrl)
 	mockClient120 := mock_dockeriface.NewMockClient(ctrl)
 	mockClient121 := mock_dockeriface.NewMockClient(ctrl)
+	mockClient122 := mock_dockeriface.NewMockClient(ctrl)
 
 	expectedEndpoint := "expectedEndpoint"
 
@@ -183,6 +184,8 @@ func TestFindAvailableVersiosn(t *testing.T) {
 			return mockClient120, nil
 		case Version_1_21:
 			return mockClient121, nil
+		case Version_1_22:
+			return mockClient122, nil
 		default:
 			t.Fatal("Unrecognized version")
 		}
@@ -194,8 +197,9 @@ func TestFindAvailableVersiosn(t *testing.T) {
 	mockClient119.EXPECT().Ping()
 	mockClient120.EXPECT().Ping()
 	mockClient121.EXPECT().Ping()
+	mockClient122EXPECT().Ping()
 
-	expectedVersions := []DockerVersion{Version_1_17, Version_1_19, Version_1_20, Version_1_21}
+	expectedVersions := []DockerVersion{Version_1_17, Version_1_19, Version_1_20, Version_1_21, Version_1_22}
 
 	factory := NewFactory(expectedEndpoint)
 	versions := factory.FindAvailableVersions()


### PR DESCRIPTION
Updated dockerclient to now support the Splunk docker logging driver, https://docs.docker.com/engine/admin/logging/splunk/.