### PR TITLE
allow setting of Docker NetworkMode

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ configure them as something other than the defaults.
 | `ECS_UPDATES_ENABLED` | &lt;true &#124; false&gt; | Whether to exit for an updater to apply updates when requested | false |
 | `ECS_UPDATE_DOWNLOAD_DIR` | /cache               | Where to place update tarballs within the container |  |
 | `ECS_DISABLE_METRICS`     | &lt;true &#124; false&gt;  | Whether to disable metrics gathering for tasks. | false |
+| `ECS_DOCKER_NEWTORKMODE`  | &lt;bridge &#124; host&gt;  | Override the default `NetworkMode` setting for Docker tasks | blank |
 | `AWS_SESSION_TOKEN` |                         | The [Session Token](http://docs.aws.amazon.com/STS/latest/UsingSTS/Welcome.html) used for temporary credentials. | Taken from EC2 Instance Metadata |
 | `ECS_RESERVED_MEMORY` | 32 | Memory, in MB, to reserve for use by things other than containers managed by ECS. | 0 |
 | `ECS_AVAILABLE_LOGGING_DRIVERS` | `["json-file","syslog"]` | Which logging drivers are available on the Container Instance. | `["json-file"]` |

--- a/agent/api/task.go
+++ b/agent/api/task.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/acs/model/ecsacs"
+	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/engine/emptyvolume"
 	"github.com/aws/amazon-ecs-agent/agent/utils/ttime"
 	"github.com/aws/aws-sdk-go/private/protocol/json/jsonutil"
@@ -288,11 +289,11 @@ func (task *Task) dockerConfigVolumes(container *Container) (map[string]struct{}
 	return volumeMap, nil
 }
 
-func (task *Task) DockerHostConfig(container *Container, dockerContainerMap map[string]*DockerContainer) (*docker.HostConfig, *HostConfigError) {
-	return task.Overridden().dockerHostConfig(container.Overridden(), dockerContainerMap)
+func (task *Task) DockerHostConfig(container *Container, dockerContainerMap map[string]*DockerContainer, cfg *config.Config) (*docker.HostConfig, *HostConfigError) {
+	return task.Overridden().dockerHostConfig(container.Overridden(), dockerContainerMap, cfg)
 }
 
-func (task *Task) dockerHostConfig(container *Container, dockerContainerMap map[string]*DockerContainer) (*docker.HostConfig, *HostConfigError) {
+func (task *Task) dockerHostConfig(container *Container, dockerContainerMap map[string]*DockerContainer, cfg *config.Config) (*docker.HostConfig, *HostConfigError) {
 	dockerLinkArr, err := task.dockerLinks(container, dockerContainerMap)
 	if err != nil {
 		return nil, &HostConfigError{err.Error()}
@@ -315,6 +316,7 @@ func (task *Task) dockerHostConfig(container *Container, dockerContainerMap map[
 		Binds:        binds,
 		PortBindings: dockerPortMap,
 		VolumesFrom:  volumesFrom,
+		NetworkMode:  cfg.DockerNetworkMode,
 	}
 
 	if container.DockerConfig.HostConfig != nil {

--- a/agent/api/task_test.go
+++ b/agent/api/task_test.go
@@ -19,8 +19,14 @@ import (
 	"testing"
 
 	"github.com/aws/amazon-ecs-agent/agent/acs/model/ecsacs"
+	_config "github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/fsouza/go-dockerclient"
 )
+
+func cfg() *_config.Config {
+	c := _config.DefaultConfig()
+	return &c
+}
 
 func strptr(s string) *string { return &s }
 
@@ -143,7 +149,7 @@ func TestDockerHostConfigPortBinding(t *testing.T) {
 		},
 	}
 
-	config, err := testTask.DockerHostConfig(testTask.Containers[0], dockerMap(testTask))
+	config, err := testTask.DockerHostConfig(testTask.Containers[0], dockerMap(testTask), cfg())
 	if err != nil {
 		t.Error(err)
 	}
@@ -189,7 +195,7 @@ func TestDockerHostConfigVolumesFrom(t *testing.T) {
 		},
 	}
 
-	config, err := testTask.DockerHostConfig(testTask.Containers[1], dockerMap(testTask))
+	config, err := testTask.DockerHostConfig(testTask.Containers[1], dockerMap(testTask), cfg())
 	if err != nil {
 		t.Fatal("Error creating config: ", err)
 	}
@@ -232,7 +238,7 @@ func TestDockerHostConfigRawConfig(t *testing.T) {
 		},
 	}
 
-	config, configErr := testTask.DockerHostConfig(testTask.Containers[0], dockerMap(testTask))
+	config, configErr := testTask.DockerHostConfig(testTask.Containers[0], dockerMap(testTask), cfg())
 	if configErr != nil {
 		t.Fatal(configErr)
 	}
@@ -279,7 +285,7 @@ func TestDockerHostConfigRawConfigMerging(t *testing.T) {
 		},
 	}
 
-	hostConfig, configErr := testTask.DockerHostConfig(testTask.Containers[0], dockerMap(testTask))
+	hostConfig, configErr := testTask.DockerHostConfig(testTask.Containers[0], dockerMap(testTask), cfg())
 	if configErr != nil {
 		t.Fatal(configErr)
 	}
@@ -308,7 +314,8 @@ func TestBadDockerHostConfigRawConfig(t *testing.T) {
 				},
 			},
 		}
-		_, err := testTask.DockerHostConfig(testTask.Containers[0], dockerMap(&testTask))
+
+		_, err := testTask.DockerHostConfig(testTask.Containers[0], dockerMap(&testTask), cfg())
 		if err == nil {
 			t.Fatal("Expected error, was none for: " + badHostConfig)
 		}

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -240,6 +240,7 @@ func environmentConfig() Config {
 	updatesEnabled := utils.ParseBool(os.Getenv("ECS_UPDATES_ENABLED"), false)
 
 	disableMetrics := utils.ParseBool(os.Getenv("ECS_DISABLE_METRICS"), false)
+	dockerNetworkMode := os.Getenv("ECS_DOCKER_NETWORKMODE")
 
 	reservedMemory := parseEnvVariableUint16("ECS_RESERVED_MEMORY")
 
@@ -273,6 +274,7 @@ func environmentConfig() Config {
 		UpdatesEnabled:          updatesEnabled,
 		UpdateDownloadDir:       updateDownloadDir,
 		DisableMetrics:          disableMetrics,
+		DockerNetworkMode:       dockerNetworkMode,
 		ReservedMemory:          reservedMemory,
 		AvailableLoggingDrivers: availableLoggingDrivers,
 		PrivilegedDisabled:      privilegedDisabled,

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -77,6 +77,9 @@ type Config struct {
 	// sent to the ECS telemetry endpoint
 	DisableMetrics bool
 
+	// DockerNetworkMode specifies the type of network docker containers will use.
+	DockerNetworkMode string
+
 	// ReservedMemory specifies the amount of memory (in MB) to reserve for things
 	// other than containers managed by ECS
 	ReservedMemory uint16

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -422,7 +422,7 @@ func (engine *DockerTaskEngine) createContainer(task *api.Task, container *api.C
 		containerMap = make(map[string]*api.DockerContainer)
 	}
 
-	hostConfig, hcerr := task.DockerHostConfig(container, containerMap)
+	hostConfig, hcerr := task.DockerHostConfig(container, containerMap, engine.cfg)
 	if hcerr != nil {
 		return DockerContainerMetadata{Error: api.NamedError(hcerr)}
 	}


### PR DESCRIPTION
fixes #185.

`echo ECS_DOCKER_NETWORKMODE=host >> /etc/ecs/ecs.config`

Best I can tell the relevant tests are passing, but I'd appreciate a little guidance on how to test this on my live boxes.  When I run my own agent docker image that was built with `make release`, I ultimately get the following cert error in my logs:

```
2016-05-17T02:12:06Z [ERROR] Could not register module="api client" err="RequestError: send request failed
caused by: Post https://ecs.us-east-1.amazonaws.com/: x509: certificate signed by unknown authority"
```
