### PR TITLE
Wait for docker socket to be active

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -e
+
+if [ "${1:0:1}" = '-' ]; then
+    set -- /agent "$@"
+fi
+
+if [ "$1" = '/agent' ]; then
+  if [ ! -S /var/run/docker.sock ]; then
+    echo 'Docker socket not found, exiting.'
+    exit 1
+  fi
+
+  # Guarantee that we can talk to docker or ecs-agent will start anyway
+  # but won't be able to do anything.
+  socat - UNIX-CONNECT:/var/run/docker.sock >/dev/null <<EOF
+GET /info HTTP/1.1
+
+EOF
+  if [ $? -ne 0 ]; then
+    echo 'Failed to connect to /var/run/docker.sock, exiting.'
+    exit 1
+  fi
+fi
+
+exec "$@"

--- a/scripts/dockerfiles/Dockerfile.release
+++ b/scripts/dockerfiles/Dockerfile.release
@@ -13,7 +13,9 @@
 
 # Not from scratch because we also want a little directory structure,
 # specifically /tmp
-FROM amazon/amazon-ecs-scratch:make
+FROM alpine:3.3
+
+RUN apk add --no-cache socat
 
 COPY out/amazon-ecs-agent /agent
 COPY ["LICENSE", "NOTICE", "/"]
@@ -23,4 +25,7 @@ COPY ["LICENSE", "NOTICE", "/"]
 COPY misc/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 EXPOSE 51678
-ENTRYPOINT ["/agent"]
+
+COPY scripts/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["/agent"]


### PR DESCRIPTION
It's not useful to have the agent start up without access to docker.  I've added an entrypoint that verifies that the docker socket exists and responds to a simple http request before starting.