### PR TITLE
Fix tests and a race

### DIFF
--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -535,7 +535,7 @@ func TestCreateContainerForceSave(t *testing.T) {
 // only when terminal events are recieved from docker event stream when
 // StopContainer times out
 func TestTaskTransitionWhenStopContainerTimesout(t *testing.T) {
-	ctrl, client, _, taskEngine := mocks(t, &defaultConfig)
+	ctrl, client, mockTime, taskEngine := mocks(t, &defaultConfig)
 	defer ctrl.Finish()
 
 	sleepTask := testdata.LoadTask("sleep5")
@@ -550,6 +550,7 @@ func TestTaskTransitionWhenStopContainerTimesout(t *testing.T) {
 	}
 
 	client.EXPECT().ContainerEvents(gomock.Any()).Return(eventStream, nil)
+	mockTime.EXPECT().After(gomock.Any()).AnyTimes()
 	containerStopTimeoutError := DockerContainerMetadata{Error: &DockerTimeoutError{transition: "stop", duration: stopContainerTimeout}}
 	for _, container := range sleepTask.Containers {
 

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -398,6 +398,7 @@ func TestSteadyStatePoll(t *testing.T) {
 
 	steadyStateVerify := make(chan time.Time, 10)
 	testTime.EXPECT().After(steadyStateTaskVerifyInterval).Return(steadyStateVerify).AnyTimes()
+	testTime.EXPECT().After(gomock.Any()).AnyTimes()
 	err := taskEngine.Init()
 	taskEvents, contEvents := taskEngine.TaskEvents()
 	if err != nil {

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -681,10 +681,12 @@ func TestGetTaskByArn(t *testing.T) {
 	defer ctrl.Finish()
 	eventStream := make(chan DockerContainerChangeEvent)
 	client.EXPECT().ContainerEvents(gomock.Any()).Return(eventStream, nil)
+	client.EXPECT().PullImage(gomock.Any(), gomock.Any()).AnyTimes() // TODO change to MaxTimes(1)
 	err := taskEngine.Init()
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer taskEngine.Disable()
 
 	sleepTask := testdata.LoadTask("sleep5")
 	sleepTaskArn := sleepTask.Arn

--- a/agent/tcs/handler/handler_test.go
+++ b/agent/tcs/handler/handler_test.go
@@ -118,7 +118,10 @@ func TestSessionConenctionClosedByRemote(t *testing.T) {
 		t.Fatal(err)
 	}
 	go func() {
-		t.Error(<-serverErr)
+		serr := <-serverErr
+		if serr != io.EOF {
+			t.Error(serr)
+		}
 	}()
 	sleepBeforeClose := 10 * time.Millisecond
 	go func() {


### PR DESCRIPTION
After the Go 1.6 change, some tests have been a bit flaky due to broken assumptions and another test actually found a race condition in `engine`.  I saw one more test fail infrequently (`TestSendsEvents` in `eventhandler`) but I haven't reliably reproduced it yet.  Check individual commits for the tests that broke and how they were fixed.

r? @aaithal @juanrhenals @richardpen 