### PR TITLE
Reset ACSSeqNum stored in state file when containerInstance …

### DIFF
--- a/agent/acs/handler/acs_handler.go
+++ b/agent/acs/handler/acs_handler.go
@@ -33,7 +33,6 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/engine"
 	"github.com/aws/amazon-ecs-agent/agent/statemanager"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
-	utilatomic "github.com/aws/amazon-ecs-agent/agent/utils/atomic"
 	"github.com/aws/amazon-ecs-agent/agent/utils/ttime"
 	"github.com/aws/amazon-ecs-agent/agent/version"
 	"github.com/aws/amazon-ecs-agent/agent/wsclient"
@@ -59,10 +58,6 @@ const (
 	// credentials for all tasks on establishing the connection
 	sendCredentialsURLParameterName = "sendCredentials"
 )
-
-// SequenceNumber is a number shared between all ACS clients which indicates
-// the last sequence number successfully handled.
-var SequenceNumber = utilatomic.NewIncreasingInt64(1)
 
 // StartSessionArguments is a struct representing all the things this handler
 // needs... This is really a hack to get by-name instead of positional
@@ -217,7 +212,7 @@ func acsWsURL(endpoint, cluster, containerInstanceArn string, taskEngine engine.
 	query.Set("containerInstanceArn", containerInstanceArn)
 	query.Set("agentHash", version.GitHashString())
 	query.Set("agentVersion", version.Version)
-	query.Set("seqNum", strconv.FormatInt(SequenceNumber.Get(), 10))
+	query.Set("seqNum", "1")
 	if dockerVersion, err := taskEngine.Version(); err == nil {
 		query.Set("dockerVersion", dockerVersion)
 	}

--- a/agent/acs/handler/acs_handler_test.go
+++ b/agent/acs/handler/acs_handler_test.go
@@ -154,14 +154,15 @@ func TestAcsWsUrl(t *testing.T) {
 	if parsed.Query().Get("agentHash") != version.GitHashString() {
 		t.Fatal("Wrong cluster")
 	}
-
 	if parsed.Query().Get("dockerVersion") != "Docker version result" {
 		t.Fatal("Wrong docker version")
 	}
 	if parsed.Query().Get(sendCredentialsURLParameterName) != "true" {
 		t.Fatalf("Wrong value set for: %s", sendCredentialsURLParameterName)
 	}
-
+	if parsed.Query().Get("seqNum") != "1" {
+		t.Fatal("Wrong seqNum")
+	}
 }
 
 // TestHandlerReconnectsOnConnectErrors tests if handler reconnects retries

--- a/agent/acs/handler/payload_handler.go
+++ b/agent/acs/handler/payload_handler.go
@@ -153,12 +153,8 @@ func (payloadHandler *payloadRequestHandler) handleSingleMessage(payload *ecsacs
 		}
 		payloadHandler.ackRequest <- *payload.MessageId
 	}()
-	// Record the sequence number as well
-	if payload.SeqNum != nil {
-		SequenceNumber.Set(*payload.SeqNum)
-	}
-	return nil
 
+	return nil
 }
 
 // addPayloadTasks does validation on each task and, for all valid ones, adds


### PR DESCRIPTION
…is reset

This fix will prevent from agents connecting using bad ACSSeqNum when agent is registered as new Container Instance.
This usually happens when EC2 instance (registered as Container Instance) is snapshotted and launched as a new EC2 instance i
(registered as new Container Instance). Before this fix the ACSSeqNum of the previous Container Instance is used for the new one.