### PR TITLE
Log Task Arn in credentials access log.

### DIFF
--- a/agent/acs/handler/acs_handler_test.go
+++ b/agent/acs/handler/acs_handler_test.go
@@ -508,7 +508,7 @@ func TestStartSessionHandlesRefreshCredentialsMessages(t *testing.T) {
 		ended <- true
 	}()
 
-	updatedCredentials := rolecredentials.IAMRoleCredentials{}
+	updatedCredentials := rolecredentials.TaskIAMRoleCredentials{}
 	taskFromEngine := &api.Task{}
 	credentialsIdInRefreshMessage := "credsId"
 	// Ensure that credentials manager interface methods are invoked in the
@@ -518,16 +518,19 @@ func TestStartSessionHandlesRefreshCredentialsMessages(t *testing.T) {
 		taskEngine.EXPECT().GetTaskByArn("t1").Return(taskFromEngine, true),
 		// The last invocation of SetCredentials is to update
 		// credentials when a refresh message is recieved by the handler
-		credentialsManager.EXPECT().SetCredentials(gomock.Any()).Do(func(creds rolecredentials.IAMRoleCredentials) {
+		credentialsManager.EXPECT().SetTaskCredentials(gomock.Any()).Do(func(creds rolecredentials.TaskIAMRoleCredentials) {
 			updatedCredentials = creds
 			// Validate parsed credentials after the update
-			expectedCreds := rolecredentials.IAMRoleCredentials{
-				RoleArn:         "r1",
-				AccessKeyId:     "newakid",
-				SecretAccessKey: "newskid",
-				SessionToken:    "newstkn",
-				Expiration:      "later",
-				CredentialsId:   credentialsIdInRefreshMessage,
+			expectedCreds := rolecredentials.TaskIAMRoleCredentials{
+				ARN: "t1",
+				IAMRoleCredentials: rolecredentials.IAMRoleCredentials{
+					RoleArn:         "r1",
+					AccessKeyId:     "newakid",
+					SecretAccessKey: "newskid",
+					SessionToken:    "newstkn",
+					Expiration:      "later",
+					CredentialsId:   credentialsIdInRefreshMessage,
+				},
 			}
 			if !reflect.DeepEqual(updatedCredentials, expectedCreds) {
 				t.Errorf("Mismatch between expected and credentials expected: %v, added: %v", expectedCreds, updatedCredentials)

--- a/agent/acs/handler/refresh_credentials_handler.go
+++ b/agent/acs/handler/refresh_credentials_handler.go
@@ -127,7 +127,11 @@ func (refreshHandler *refreshCredentialsHandler) handleSingleMessage(message *ec
 		seelog.Errorf("Task not found in the engine for the arn in credentials message, arn: %s, messageId: %s", taskArn, messageId)
 		return fmt.Errorf("Task not found in the engine for the arn in credentials message, arn: %s", taskArn)
 	}
-	err = refreshHandler.credentialsManager.SetCredentials(credentials.IAMRoleCredentialsFromACS(message.RoleCredentials))
+	taskCredentials := credentials.TaskIAMRoleCredentials{
+		ARN:                taskArn,
+		IAMRoleCredentials: credentials.IAMRoleCredentialsFromACS(message.RoleCredentials),
+	}
+	err = refreshHandler.credentialsManager.SetTaskCredentials(taskCredentials)
 	if err != nil {
 		seelog.Errorf("Error updating credentials, err: %v messageId: %s", err, messageId)
 		return fmt.Errorf("Error updating credentials %v", err)

--- a/agent/acs/handler/refresh_credentials_handler_test.go
+++ b/agent/acs/handler/refresh_credentials_handler_test.go
@@ -45,13 +45,16 @@ var expectedAck = &ecsacs.IAMRoleCredentialsAckRequest{
 	CredentialsId: aws.String(credentialsId),
 }
 
-var expectedCredentials = &credentials.IAMRoleCredentials{
-	RoleArn:         roleArn,
-	AccessKeyId:     accessKey,
-	SecretAccessKey: secretKey,
-	SessionToken:    sessionToken,
-	Expiration:      expiration,
-	CredentialsId:   credentialsId,
+var expectedCredentials = &credentials.TaskIAMRoleCredentials{
+	ARN: taskArn,
+	IAMRoleCredentials: credentials.IAMRoleCredentials{
+		RoleArn:         roleArn,
+		AccessKeyId:     accessKey,
+		SecretAccessKey: secretKey,
+		SessionToken:    sessionToken,
+		Expiration:      expiration,
+		CredentialsId:   credentialsId,
+	},
 }
 
 var message = &ecsacs.IAMRoleCredentialsMessage{
@@ -258,7 +261,7 @@ func TestHandleRefreshMessageAckedWhenCredentialsUpdated(t *testing.T) {
 		t.Errorf("Message between expected and requested ack. Expected: %v, Requested: %v", expectedAck, ackRequested)
 	}
 
-	creds, exist := credentialsManager.GetCredentials(credentialsId)
+	creds, exist := credentialsManager.GetTaskCredentials(credentialsId)
 	if !exist {
 		t.Errorf("Expected credentials to exist for the task")
 	}
@@ -299,7 +302,7 @@ func TestRefreshCredentialsHandler(t *testing.T) {
 		t.Errorf("Message between expected and requested ack. Expected: %v, Requested: %v", expectedAck, ackRequested)
 	}
 
-	creds, exist := credentialsManager.GetCredentials(credentialsId)
+	creds, exist := credentialsManager.GetTaskCredentials(credentialsId)
 	if !exist {
 		t.Errorf("Expected credentials to exist for the task")
 	}

--- a/agent/api/task.go
+++ b/agent/api/task.go
@@ -102,7 +102,7 @@ func (task *Task) initializeCredentialsEndpoint(credentialsManager credentials.M
 		// No credentials set for the task. Do not inject the endpoint environment variable.
 		return
 	}
-	roleCredentials, ok := credentialsManager.GetCredentials(id)
+	taskCredentials, ok := credentialsManager.GetTaskCredentials(id)
 	if !ok {
 		// Task has credentials id set, but credentials manager is unaware of
 		// the id. This should never happen as the payload handler sets
@@ -112,7 +112,7 @@ func (task *Task) initializeCredentialsEndpoint(credentialsManager credentials.M
 		return
 	}
 
-	credentialsEndpointRelativeURI := roleCredentials.GenerateCredentialsEndpointRelativeURI()
+	credentialsEndpointRelativeURI := taskCredentials.IAMRoleCredentials.GenerateCredentialsEndpointRelativeURI()
 	for _, container := range task.Containers {
 		// container.Environment map would not be initialized if there are
 		// no environment variables to be set or overridden in the container

--- a/agent/api/task_test.go
+++ b/agent/api/task_test.go
@@ -473,7 +473,10 @@ func TestGetCredentialsEndpointWhenCredentialsAreSet(t *testing.T) {
 		credentialsId: credentialsIdInTask,
 	}
 
-	credentialsManager.EXPECT().GetCredentials(credentialsIdInTask).Return(&credentials.IAMRoleCredentials{CredentialsId: "credsid"}, true)
+	taskCredentials := &credentials.TaskIAMRoleCredentials{
+		IAMRoleCredentials: credentials.IAMRoleCredentials{CredentialsId: "credsid"},
+	}
+	credentialsManager.EXPECT().GetTaskCredentials(credentialsIdInTask).Return(taskCredentials, true)
 	task.initializeCredentialsEndpoint(credentialsManager)
 
 	// Test if all containers in the task have the environment variable for

--- a/agent/credentials/manager_test.go
+++ b/agent/credentials/manager_test.go
@@ -47,65 +47,92 @@ func TestIAMRoleCredentialsFromACS(t *testing.T) {
 	}
 }
 
-// TestGetCredentialsUnknownId tests if GetCredentials returns a false value
+// TestGetTaskCredentialsUnknownId tests if GetTaskCredentials returns a false value
 // when credentials for a given id are not be found in the engine
-func TestGetCredentialsUnknownId(t *testing.T) {
+func TestGetTaskCredentialsUnknownId(t *testing.T) {
 	manager := NewManager()
-	_, ok := manager.GetCredentials("id")
+	_, ok := manager.GetTaskCredentials("id")
 	if ok {
-		t.Error("GetCredentials should return false for non existing id")
+		t.Error("GetTaskCredentials should return false for non existing id")
 	}
 }
 
-// TestSetCredentialsInvalidCredentials tests if credentials manager returns an
+// TestSetTaskCredentialsEmptyTaskCredentials tests if credentials manager returns an
 // error when invalid credentials are used to set credentials
-func TestSetCredentialsInvalidCredentials(t *testing.T) {
+func TestSetTaskCredentialsEmptyTaskCredentials(t *testing.T) {
 	manager := NewManager()
-	err := manager.SetCredentials(IAMRoleCredentials{})
+	err := manager.SetTaskCredentials(TaskIAMRoleCredentials{})
+	if err == nil {
+		t.Error("Expected error adding empty task credentials")
+	}
+}
+
+// TestSetTaskCredentialsNoCredentialsId tests if credentials manager returns an
+// error when credentials object with no credentials id is used to set credentials
+func TestSetTaskCredentialsNoCredentialsId(t *testing.T) {
+	manager := NewManager()
+	err := manager.SetTaskCredentials(TaskIAMRoleCredentials{ARN: "t1", IAMRoleCredentials: IAMRoleCredentials{}})
 	if err == nil {
 		t.Error("Expected error adding credentials payload without credential id")
 	}
 }
 
-// TestSetAndGetCredentialsHappyPath tests the happy path workflow for setting
-// and getting credentials
-func TestSetAndGetCredentialsHappyPath(t *testing.T) {
+// TestSetTaskCredentialsNoTaskArn tests if credentials manager returns an
+// error when credentials object with no task arn used to set credentials
+func TestSetTaskCredentialsNoTaskArn(t *testing.T) {
 	manager := NewManager()
-	credentials := IAMRoleCredentials{
-		RoleArn:         "r1",
-		AccessKeyId:     "akid1",
-		SecretAccessKey: "skid1",
-		SessionToken:    "stkn",
-		Expiration:      "ts",
-		CredentialsId:   "cid1",
+	err := manager.SetTaskCredentials(TaskIAMRoleCredentials{IAMRoleCredentials: IAMRoleCredentials{CredentialsId: "id"}})
+	if err == nil {
+		t.Error("Expected error adding credentials payload without credential id")
 	}
-	err := manager.SetCredentials(credentials)
+}
+
+// TestSetAndGetTaskCredentialsHappyPath tests the happy path workflow for setting
+// and getting credentials
+func TestSetAndGetTaskCredentialsHappyPath(t *testing.T) {
+	manager := NewManager()
+	credentials := TaskIAMRoleCredentials{
+		ARN: "t1",
+		IAMRoleCredentials: IAMRoleCredentials{
+			RoleArn:         "r1",
+			AccessKeyId:     "akid1",
+			SecretAccessKey: "skid1",
+			SessionToken:    "stkn",
+			Expiration:      "ts",
+			CredentialsId:   "cid1",
+		},
+	}
+
+	err := manager.SetTaskCredentials(credentials)
 	if err != nil {
 		t.Errorf("Error adding credentials: %v", err)
 	}
-	credentialsFromManager, ok := manager.GetCredentials("cid1")
+	credentialsFromManager, ok := manager.GetTaskCredentials("cid1")
 	if !ok {
-		t.Error("GetCredentials returned false for existing credentials")
+		t.Error("GetTaskCredentials returned false for existing credentials")
 	}
 	if !reflect.DeepEqual(credentials, *credentialsFromManager) {
 		t.Error("Mismatch between added and retrieved credentials")
 	}
 
-	updatedCredentials := IAMRoleCredentials{
-		RoleArn:         "r1",
-		AccessKeyId:     "akid2",
-		SecretAccessKey: "skid2",
-		SessionToken:    "stkn2",
-		Expiration:      "ts2",
-		CredentialsId:   "cid1",
+	updatedCredentials := TaskIAMRoleCredentials{
+		ARN: "t1",
+		IAMRoleCredentials: IAMRoleCredentials{
+			RoleArn:         "r1",
+			AccessKeyId:     "akid2",
+			SecretAccessKey: "skid2",
+			SessionToken:    "stkn2",
+			Expiration:      "ts2",
+			CredentialsId:   "cid1",
+		},
 	}
-	err = manager.SetCredentials(updatedCredentials)
+	err = manager.SetTaskCredentials(updatedCredentials)
 	if err != nil {
 		t.Errorf("Error updating credentials: %v", err)
 	}
-	credentialsFromManager, ok = manager.GetCredentials("cid1")
+	credentialsFromManager, ok = manager.GetTaskCredentials("cid1")
 	if !ok {
-		t.Error("GetCredentials returned false for existing credentials")
+		t.Error("GetTaskCredentials returned false for existing credentials")
 	}
 	if !reflect.DeepEqual(updatedCredentials, *credentialsFromManager) {
 		t.Error("Mismatch between added and retrieved credentials")
@@ -139,33 +166,36 @@ func TestGenerateCredentialsEndpointRelativeURI(t *testing.T) {
 	}
 }
 
-// TestRemoveExistingCredentials tests that GetCredentials returns false when
+// TestRemoveExistingCredentials tests that GetTaskCredentials returns false when
 // credentials are removed from the credentials manager
 func TestRemoveExistingCredentials(t *testing.T) {
 	manager := NewManager()
-	credentials := IAMRoleCredentials{
-		RoleArn:         "r1",
-		AccessKeyId:     "akid1",
-		SecretAccessKey: "skid1",
-		SessionToken:    "stkn",
-		Expiration:      "ts",
-		CredentialsId:   "cid1",
+	credentials := TaskIAMRoleCredentials{
+		ARN: "t1",
+		IAMRoleCredentials: IAMRoleCredentials{
+			RoleArn:         "r1",
+			AccessKeyId:     "akid1",
+			SecretAccessKey: "skid1",
+			SessionToken:    "stkn",
+			Expiration:      "ts",
+			CredentialsId:   "cid1",
+		},
 	}
-	err := manager.SetCredentials(credentials)
+	err := manager.SetTaskCredentials(credentials)
 	if err != nil {
 		t.Errorf("Error adding credentials: %v", err)
 	}
-	credentialsFromManager, ok := manager.GetCredentials("cid1")
+	credentialsFromManager, ok := manager.GetTaskCredentials("cid1")
 	if !ok {
-		t.Error("GetCredentials returned false for existing credentials")
+		t.Error("GetTaskCredentials returned false for existing credentials")
 	}
 	if !reflect.DeepEqual(credentials, *credentialsFromManager) {
 		t.Error("Mismatch between added and retrieved credentials")
 	}
 
 	manager.RemoveCredentials("cid1")
-	_, ok = manager.GetCredentials("cid1")
+	_, ok = manager.GetTaskCredentials("cid1")
 	if ok {
-		t.Error("Expected GetCredentials to return false for removed credentials")
+		t.Error("Expected GetTaskCredentials to return false for removed credentials")
 	}
 }

--- a/agent/credentials/mocks/credentials_mocks.go
+++ b/agent/credentials/mocks/credentials_mocks.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -42,15 +42,15 @@ func (_m *MockManager) EXPECT() *_MockManagerRecorder {
 	return _m.recorder
 }
 
-func (_m *MockManager) GetCredentials(_param0 string) (*credentials.IAMRoleCredentials, bool) {
-	ret := _m.ctrl.Call(_m, "GetCredentials", _param0)
-	ret0, _ := ret[0].(*credentials.IAMRoleCredentials)
+func (_m *MockManager) GetTaskCredentials(_param0 string) (*credentials.TaskIAMRoleCredentials, bool) {
+	ret := _m.ctrl.Call(_m, "GetTaskCredentials", _param0)
+	ret0, _ := ret[0].(*credentials.TaskIAMRoleCredentials)
 	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }
 
-func (_mr *_MockManagerRecorder) GetCredentials(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetCredentials", arg0)
+func (_mr *_MockManagerRecorder) GetTaskCredentials(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTaskCredentials", arg0)
 }
 
 func (_m *MockManager) RemoveCredentials(_param0 string) {
@@ -61,12 +61,12 @@ func (_mr *_MockManagerRecorder) RemoveCredentials(arg0 interface{}) *gomock.Cal
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveCredentials", arg0)
 }
 
-func (_m *MockManager) SetCredentials(_param0 credentials.IAMRoleCredentials) error {
-	ret := _m.ctrl.Call(_m, "SetCredentials", _param0)
+func (_m *MockManager) SetTaskCredentials(_param0 credentials.TaskIAMRoleCredentials) error {
+	ret := _m.ctrl.Call(_m, "SetTaskCredentials", _param0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockManagerRecorder) SetCredentials(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetCredentials", arg0)
+func (_mr *_MockManagerRecorder) SetTaskCredentials(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetTaskCredentials", arg0)
 }

--- a/agent/engine/engine_integ_test.go
+++ b/agent/engine/engine_integ_test.go
@@ -1172,7 +1172,10 @@ func TestStartStopWithCredentials(t *testing.T) {
 	defer done()
 
 	testTask := createTestTask("testStartWithCredentials")
-	credentialsManager.SetCredentials(credentials.IAMRoleCredentials{CredentialsId: credentialsId})
+	taskCredentials := credentials.TaskIAMRoleCredentials{
+		IAMRoleCredentials: credentials.IAMRoleCredentials{CredentialsId: credentialsId},
+	}
+	credentialsManager.SetTaskCredentials(taskCredentials)
 	testTask.SetCredentialsId(credentialsId)
 
 	taskEvents, contEvents := taskEngine.TaskEvents()
@@ -1193,7 +1196,7 @@ func TestStartStopWithCredentials(t *testing.T) {
 
 	// When task is stopped, credentials should have been removed for the
 	// credentials id set in the task
-	_, ok := credentialsManager.GetCredentials(credentialsId)
+	_, ok := credentialsManager.GetTaskCredentials(credentialsId)
 	if ok {
 		t.Error("Credentials not removed from credentials manager for stopped task")
 	}

--- a/agent/handlers/credentials/handler.go
+++ b/agent/handlers/credentials/handler.go
@@ -24,6 +24,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/credentials"
 	"github.com/aws/amazon-ecs-agent/agent/handlers"
 	"github.com/aws/amazon-ecs-agent/agent/logger/audit"
+	"github.com/aws/amazon-ecs-agent/agent/logger/audit/request"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 	log "github.com/cihub/seelog"
 )
@@ -103,24 +104,25 @@ func setupServer(credentialsManager credentials.Manager, auditLogger audit.Audit
 func credentialsV1RequestHandler(credentialsManager credentials.Manager, auditLogger audit.AuditLogger) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 
-		jsonResponse, errorMessage, err := processCredentialsV1Request(credentialsManager, r)
+		jsonResponse, arn, errorMessage, err := processCredentialsV1Request(credentialsManager, r)
 		if err != nil {
 			jsonMsg, _ := json.Marshal(errorMessage)
-			writeCredentialsV1RequestResponse(w, r, errorMessage.httpErrorCode, audit.GetCredentialsEventType(), auditLogger, jsonMsg)
+			writeCredentialsV1RequestResponse(w, r, errorMessage.httpErrorCode, audit.GetCredentialsEventType(), arn, auditLogger, jsonMsg)
 			return
 		}
 
-		writeCredentialsV1RequestResponse(w, r, http.StatusOK, audit.GetCredentialsEventType(), auditLogger, jsonResponse)
+		writeCredentialsV1RequestResponse(w, r, http.StatusOK, audit.GetCredentialsEventType(), arn, auditLogger, jsonResponse)
 	}
 }
 
-func writeCredentialsV1RequestResponse(w http.ResponseWriter, r *http.Request, httpStatusCode int, eventType string, auditLogger audit.AuditLogger, message []byte) {
-	auditLogger.Log(r, httpStatusCode, eventType)
+func writeCredentialsV1RequestResponse(w http.ResponseWriter, r *http.Request, httpStatusCode int, eventType string, arn string, auditLogger audit.AuditLogger, message []byte) {
+	auditLogger.Log(request.LogRequest{Request: r, ARN: arn}, httpStatusCode, eventType)
 
 	writeJsonToResponse(w, httpStatusCode, message)
 }
 
-func processCredentialsV1Request(credentialsManager credentials.Manager, r *http.Request) ([]byte, *errorMessage, error) {
+// processCredentialsV1Request returns the response json containing credentials for the credentials id in the request
+func processCredentialsV1Request(credentialsManager credentials.Manager, r *http.Request) ([]byte, string, *errorMessage, error) {
 	credentialsId, ok := handlers.ValueFromRequest(r, credentials.CredentialsIdQueryParameterName)
 
 	if !ok {
@@ -131,10 +133,10 @@ func processCredentialsV1Request(credentialsManager credentials.Manager, r *http
 			Message:       errText,
 			httpErrorCode: http.StatusBadRequest,
 		}
-		return nil, msg, errors.New(errText)
+		return nil, "", msg, errors.New(errText)
 	}
 
-	credentials, ok := credentialsManager.GetCredentials(credentialsId)
+	credentials, ok := credentialsManager.GetTaskCredentials(credentialsId)
 	if !ok {
 		errText := "CredentialsV1Request: ID not found"
 		log.Infof("%s. Request IP Address: %s", errText, r.RemoteAddr)
@@ -143,7 +145,7 @@ func processCredentialsV1Request(credentialsManager credentials.Manager, r *http
 			Message:       errText,
 			httpErrorCode: http.StatusBadRequest,
 		}
-		return nil, msg, errors.New(errText)
+		return nil, "", msg, errors.New(errText)
 	}
 
 	if credentials == nil {
@@ -155,10 +157,10 @@ func processCredentialsV1Request(credentialsManager credentials.Manager, r *http
 			Message:       errText,
 			httpErrorCode: http.StatusServiceUnavailable,
 		}
-		return nil, msg, errors.New(errText)
+		return nil, "", msg, errors.New(errText)
 	}
 
-	credentialsJSON, err := json.Marshal(credentials)
+	credentialsJSON, err := json.Marshal(credentials.IAMRoleCredentials)
 	if err != nil {
 		errText := "CredentialsV1Request: Error marshaling credentials"
 		log.Errorf("%s. Request IP Address: %s", errText, r.RemoteAddr)
@@ -167,11 +169,11 @@ func processCredentialsV1Request(credentialsManager credentials.Manager, r *http
 			Message:       "Internal server error",
 			httpErrorCode: http.StatusInternalServerError,
 		}
-		return nil, msg, errors.New(errText)
+		return nil, "", msg, errors.New(errText)
 	}
 
 	//Success
-	return credentialsJSON, nil, nil
+	return credentialsJSON, credentials.ARN, nil, nil
 }
 
 func writeJsonToResponse(w http.ResponseWriter, httpStatusCode int, jsonMessage []byte) {

--- a/agent/handlers/credentials/handler_test.go
+++ b/agent/handlers/credentials/handler_test.go
@@ -61,7 +61,7 @@ func TestCredentialsRequestWhenCredentialsIdNotFound(t *testing.T) {
 		httpErrorCode: http.StatusBadRequest,
 	}
 	_, err := getResponseForCredentialsRequestWithParameters(t, expectedErrorMessage.httpErrorCode,
-		expectedErrorMessage, credentialsId, func() (*credentials.IAMRoleCredentials, bool) { return nil, false })
+		expectedErrorMessage, credentialsId, func() (*credentials.TaskIAMRoleCredentials, bool) { return nil, false })
 	if err != nil {
 		t.Fatalf("Error getting response body: %v", err)
 	}
@@ -76,7 +76,7 @@ func TestCredentialsRequestWhenCredentialsUninitialized(t *testing.T) {
 		httpErrorCode: http.StatusServiceUnavailable,
 	}
 	_, err := getResponseForCredentialsRequestWithParameters(t, expectedErrorMessage.httpErrorCode,
-		expectedErrorMessage, credentialsId, func() (*credentials.IAMRoleCredentials, bool) { return nil, true })
+		expectedErrorMessage, credentialsId, func() (*credentials.TaskIAMRoleCredentials, bool) { return nil, true })
 	if err != nil {
 		t.Fatalf("Error getting response body: %v", err)
 	}
@@ -85,12 +85,14 @@ func TestCredentialsRequestWhenCredentialsUninitialized(t *testing.T) {
 // TestCredentialsRequestWhenCredentialsFound tests if HTTP status code 200 is returned when
 // the credentials manager contains the credentials id specified in the query.
 func TestCredentialsRequestWhenCredentialsFound(t *testing.T) {
-	creds := credentials.IAMRoleCredentials{
-		RoleArn:         roleArn,
-		AccessKeyId:     accessKeyID,
-		SecretAccessKey: secretAccessKey,
+	creds := credentials.TaskIAMRoleCredentials{
+		IAMRoleCredentials: credentials.IAMRoleCredentials{
+			RoleArn:         roleArn,
+			AccessKeyId:     accessKeyID,
+			SecretAccessKey: secretAccessKey,
+		},
 	}
-	body, err := getResponseForCredentialsRequestWithParameters(t, http.StatusOK, nil, credentialsId, func() (*credentials.IAMRoleCredentials, bool) { return &creds, true })
+	body, err := getResponseForCredentialsRequestWithParameters(t, http.StatusOK, nil, credentialsId, func() (*credentials.TaskIAMRoleCredentials, bool) { return &creds, true })
 	if err != nil {
 		t.Fatalf("Error retrieving credentials response: %v", err)
 	}
@@ -149,7 +151,7 @@ func testErrorResponsesFromServer(t *testing.T, path string, expectedErrorMessag
 // given id. The getCredentials function is used to simulate getting the
 // credentials object from the CredentialsManager
 func getResponseForCredentialsRequestWithParameters(t *testing.T, expectedStatus int,
-	expectedErrorMessage *errorMessage, id string, getCredentials func() (*credentials.IAMRoleCredentials, bool)) (*bytes.Buffer, error) {
+	expectedErrorMessage *errorMessage, id string, getCredentials func() (*credentials.TaskIAMRoleCredentials, bool)) (*bytes.Buffer, error) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	credentialsManager := mock_credentials.NewMockManager(ctrl)
@@ -158,7 +160,7 @@ func getResponseForCredentialsRequestWithParameters(t *testing.T, expectedStatus
 	recorder := httptest.NewRecorder()
 
 	creds, ok := getCredentials()
-	credentialsManager.EXPECT().GetCredentials(gomock.Any()).Return(creds, ok)
+	credentialsManager.EXPECT().GetTaskCredentials(gomock.Any()).Return(creds, ok)
 	auditLog.EXPECT().Log(gomock.Any(), gomock.Any(), gomock.Any())
 
 	params := make(url.Values)

--- a/agent/logger/audit/audit_log.go
+++ b/agent/logger/audit/audit_log.go
@@ -15,9 +15,9 @@ package audit
 
 import (
 	"fmt"
-	"net/http"
 
 	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/logger/audit/request"
 )
 
 type auditLog struct {
@@ -38,7 +38,7 @@ func NewAuditLog(containerInstanceArn string, cfg *config.Config, logger InfoLog
 
 // Log will construct an audit log entry log and log that entry to the audit log
 // using the underlying logger (which implements the audit.InfoLogger interface).
-func (a *auditLog) Log(r *http.Request, httpResponseCode int, eventType string) {
+func (a *auditLog) Log(r request.LogRequest, httpResponseCode int, eventType string) {
 	if !a.cfg.CredentialsAuditLogDisabled {
 		auditLogEntry := constructAuditLogEntry(r, httpResponseCode, eventType, a.GetCluster(),
 			a.GetContainerInstanceArn())
@@ -47,7 +47,7 @@ func (a *auditLog) Log(r *http.Request, httpResponseCode int, eventType string) 
 	}
 }
 
-func constructAuditLogEntry(r *http.Request, httpResponseCode int, eventType string,
+func constructAuditLogEntry(r request.LogRequest, httpResponseCode int, eventType string,
 	cluster string, containerInstanceArn string) string {
 	commonAuditLogFields := constructCommonAuditLogEntryFields(r, httpResponseCode)
 	auditLogTypeFields := constructAuditLogEntryByType(eventType, cluster, containerInstanceArn)

--- a/agent/logger/audit/interface.go
+++ b/agent/logger/audit/interface.go
@@ -13,10 +13,10 @@
 
 package audit
 
-import "net/http"
+import "github.com/aws/amazon-ecs-agent/agent/logger/audit/request"
 
 type AuditLogger interface {
-	Log(r *http.Request, httpResponseCode int, eventType string)
+	Log(r request.LogRequest, httpResponseCode int, eventType string)
 	GetContainerInstanceArn() string
 	GetCluster() string
 }

--- a/agent/logger/audit/mocks/audit_log_mocks.go
+++ b/agent/logger/audit/mocks/audit_log_mocks.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -17,8 +17,7 @@
 package mock_audit
 
 import (
-	http "net/http"
-
+	request "github.com/aws/amazon-ecs-agent/agent/logger/audit/request"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -63,7 +62,7 @@ func (_mr *_MockAuditLoggerRecorder) GetContainerInstanceArn() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetContainerInstanceArn")
 }
 
-func (_m *MockAuditLogger) Log(_param0 *http.Request, _param1 int, _param2 string) {
+func (_m *MockAuditLogger) Log(_param0 request.LogRequest, _param1 int, _param2 string) {
 	_m.ctrl.Call(_m, "Log", _param0, _param1, _param2)
 }
 

--- a/agent/logger/audit/request/request.go
+++ b/agent/logger/audit/request/request.go
@@ -11,13 +11,11 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package credentials
+package request
 
-// Manager is responsible for saving and retrieving credentials. A single
-// instance of the credentials manager is created in the agent, and shared
-// between the task engine, acs and credentials handlers
-type Manager interface {
-	SetTaskCredentials(TaskIAMRoleCredentials) error
-	GetTaskCredentials(string) (*TaskIAMRoleCredentials, bool)
-	RemoveCredentials(string)
+import "net/http"
+
+type LogRequest struct {
+	Request *http.Request
+	ARN     string
 }


### PR DESCRIPTION
* Modify credentials.Manager interface to set and get taks credentials. Task
  credentials include the IAMRoleCredentials object and the task arn.
* Modify audit logger interface to accept custom LogRequest type instead of
  http Requests. This is useful for passing additional metadata fields to
  the logger and wraps the http Request in a custom Request type. This is
  also used to log the arn that is associated with the credentials request
  in the access log.