### PR TITLE
Added splunk as logging driver option, now supported in v1.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ configure them as something other than the defaults.
 | `ECS_DISABLE_METRICS`     | &lt;true &#124; false&gt;  | Whether to disable metrics gathering for tasks. | false |
 | `AWS_SESSION_TOKEN` |                         | The [Session Token](http://docs.aws.amazon.com/STS/latest/UsingSTS/Welcome.html) used for temporary credentials. | Taken from EC2 Instance Metadata |
 | `ECS_RESERVED_MEMORY` | 32 | Memory, in MB, to reserve for use by things other than containers managed by ECS. | 0 |
-| `ECS_AVAILABLE_LOGGING_DRIVERS` | `["json-file","syslog"]` | Which logging drivers are available on the Container Instance. | `["json-file"]` |
+| `ECS_AVAILABLE_LOGGING_DRIVERS` | `["json-file","splunk","syslog"]` | Which logging drivers are available on the Container Instance. | `["json-file"]` |
 | `ECS_DISABLE_PRIVILEGED` | `true` | Whether launching privileged containers is disabled on the Container Instance. | `false` |
 | `ECS_SELINUX_CAPABLE` | `true` | Whether SELinux is available on the Container Instance. | `false` |
 | `ECS_APPARMOR_CAPABLE` | `true` | Whether AppArmor is available on the Container Instance. | `false` |


### PR DESCRIPTION
This just adds the splunk logging driver option (merged in v1.11.0 release) to the README.