### PR TITLE
416 telemetry json bug

### DIFF
--- a/agent/tcs/client/client.go
+++ b/agent/tcs/client/client.go
@@ -28,6 +28,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/wsclient"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/cihub/seelog"
 	"github.com/gorilla/websocket"
 )
 
@@ -164,6 +165,7 @@ func (cs *clientServer) publishMetricsOnce() {
 
 	// Make the publish metrics request to the backend.
 	for _, request := range requests {
+		seelog.Debugf("Trying to publish message: %v", request)
 		err = cs.MakeRequest(request)
 		if err != nil {
 			log.Warn("Error publishing metrics", "err", err)

--- a/agent/wsclient/client.go
+++ b/agent/wsclient/client.go
@@ -245,10 +245,12 @@ func (cs *ClientServerImpl) CreateRequestMessage(input interface{}) ([]byte, err
 	if msg.Type == "" {
 		return nil, &UnrecognizedWSRequestType{reflect.TypeOf(input).String()}
 	}
+	seelog.Debugf("Building JSON for: %v", input)
 	messageData, err := jsonutil.BuildJSON(input)
 	if err != nil {
 		return nil, &NotMarshallableWSRequest{msg.Type, err}
 	}
+	seelog.Debugf("Setting raw message: %v", string(messageData))
 	msg.Message = json.RawMessage(messageData)
 
 	send, err := json.Marshal(msg)

--- a/agent/wsclient/client.go
+++ b/agent/wsclient/client.go
@@ -245,12 +245,10 @@ func (cs *ClientServerImpl) CreateRequestMessage(input interface{}) ([]byte, err
 	if msg.Type == "" {
 		return nil, &UnrecognizedWSRequestType{reflect.TypeOf(input).String()}
 	}
-	seelog.Debugf("Building JSON for: %v", input)
 	messageData, err := jsonutil.BuildJSON(input)
 	if err != nil {
 		return nil, &NotMarshallableWSRequest{msg.Type, err}
 	}
-	seelog.Debugf("Setting raw message: %v", string(messageData))
 	msg.Message = json.RawMessage(messageData)
 
 	send, err := json.Marshal(msg)


### PR DESCRIPTION
From the commit:

This fixes the bug reported in #416. If the last and the current
timestamps in the queue are the same, the usage is computed as
+Inf. Such payloads are discarded with this change.

Also modified tcs client to log the metrics request on JSON
errors.

Verified that integ and functional tests pass. r? @samuelkarp @richardpen @juanrhenals 