### PR TITLE
Periodically disconnect and reconnect to the docker stats channel.

### DIFF
--- a/agent/engine/docker_container_engine.go
+++ b/agent/engine/docker_container_engine.go
@@ -722,7 +722,7 @@ func (dg *dockerGoClient) Stats(id string, ctx context.Context) (<-chan *docker.
 	statsComplete := make(chan struct{})
 	go func() {
 		statsErr := client.Stats(options)
-		if err != nil {
+		if statsErr != nil {
 			seelog.Warnf("Error retrieving stats for container %s: %v", id, statsErr)
 		}
 		close(statsComplete)

--- a/agent/stats/container_test.go
+++ b/agent/stats/container_test.go
@@ -55,7 +55,7 @@ func TestContainerStatsCollection(t *testing.T) {
 	dockerID := "container1"
 	ctx, cancel := context.WithCancel(context.TODO())
 	statChan := make(chan *docker.Stats)
-	mockDockerClient.EXPECT().Stats(dockerID, ctx).Return(statChan, nil)
+	mockDockerClient.EXPECT().Stats(dockerID, gomock.Any()).Return(statChan, nil)
 	go func() {
 		for _, stat := range statsData {
 			// doing this with json makes me sad, but is the easiest way to
@@ -136,9 +136,9 @@ func TestContainerStatsCollectionReconnection(t *testing.T) {
 	closedChan := make(chan *docker.Stats)
 	close(closedChan)
 	gomock.InOrder(
-		mockDockerClient.EXPECT().Stats(dockerID, ctx).Return(nil, statErr),
-		mockDockerClient.EXPECT().Stats(dockerID, ctx).Return(closedChan, nil),
-		mockDockerClient.EXPECT().Stats(dockerID, ctx).Return(statChan, nil),
+		mockDockerClient.EXPECT().Stats(dockerID, gomock.Any()).Return(nil, statErr),
+		mockDockerClient.EXPECT().Stats(dockerID, gomock.Any()).Return(closedChan, nil),
+		mockDockerClient.EXPECT().Stats(dockerID, gomock.Any()).Return(statChan, nil),
 	)
 
 	container := &StatsContainer{
@@ -150,6 +150,52 @@ func TestContainerStatsCollectionReconnection(t *testing.T) {
 		client: mockDockerClient,
 	}
 	container.StartStatsCollection()
+	time.Sleep(checkPointSleep)
+	container.StopStatsCollection()
+}
+
+func TestContainerStatsCollectionReconnectOnTimeout(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockDockerClient := ecsengine.NewMockDockerClient(ctrl)
+
+	dockerID := "container1"
+	ctx, cancel := context.WithCancel(context.TODO())
+
+	firstStatsChan := make(chan *docker.Stats)
+	secondStatsChan := make(chan *docker.Stats)
+	gomock.InOrder(
+		mockDockerClient.EXPECT().Stats(dockerID, gomock.Any()).Do(func(id string, statsCtx context.Context) {
+			// Close the stats channel when the context is done for the first invocation
+			// of Stats() API. This ensures that the successive calls to Stats()
+			// are made from container.collect()
+			go func() {
+				for {
+					select {
+					case <-statsCtx.Done():
+						close(firstStatsChan)
+						return
+					}
+				}
+			}()
+		}).Return(firstStatsChan, nil),
+		// If the reconnect logic is broken, container.collect() would not invoke
+		// Stats() for the second time
+		mockDockerClient.EXPECT().Stats(dockerID, gomock.Any()).Return(secondStatsChan, nil),
+		mockDockerClient.EXPECT().Stats(dockerID, gomock.Any()).Return(secondStatsChan, nil).AnyTimes(),
+	)
+
+	container := &StatsContainer{
+		containerMetadata: &ContainerMetadata{
+			DockerID: dockerID,
+		},
+		ctx:    ctx,
+		cancel: cancel,
+		client: mockDockerClient,
+	}
+
+	// Invoke container.collect() and sleep
+	go container.collect(SleepBetweenUsageDataCollection, 0)
 	time.Sleep(checkPointSleep)
 	container.StopStatsCollection()
 }

--- a/agent/stats/queue.go
+++ b/agent/stats/queue.go
@@ -73,7 +73,7 @@ func (queue *Queue) Add(rawStat *ContainerStats) {
 			// Ignore the stat if the current timestamp is same as the last one. This
 			// results in the value being set as +infinity
 			// float32(1) / float32(0) = +Inf
-			seelog.Debugf("time since last stat is zero. Ignoring cpu stat")
+			seelog.Debug("Time since last stat is zero. Ignoring cpu stat")
 		}
 		if queue.maxSize == queueLength {
 			// Remove first element if queue is full.

--- a/agent/tcs/client/client.go
+++ b/agent/tcs/client/client.go
@@ -92,7 +92,7 @@ func (cs *clientServer) MakeRequest(input interface{}) error {
 		return err
 	}
 
-	seelog.Debug("TCS client sending payload: %s", string(payload))
+	seelog.Debugf("TCS client sending payload: %s", string(payload))
 	data := cs.signRequest(payload)
 
 	// Over the wire we send something like


### PR DESCRIPTION
Long lived connections to the docker stats channel can sometimes turn
non-responsive. This commit modifies the behavior of querying stats
by periodically disconnecting and reconnecting to the
 channel.

I have tested this with 50 containers consuming 100% CPU and 50% memory of the host for ~2 hours and verified from logs that metrics are flowing through.

r? @samuelkarp @richardpen @juanrhenals 