### PR TITLE
Enable Task IAM Role for containers launched with 'host' network mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ configure them as something other than the defaults.
 | `ECS_ENGINE_TASK_CLEANUP_WAIT_DURATION` | 10m | Time to wait to delete containers for a stopped task. If set to less than 1 minute, the value will be ignored.  | 3h |
 | `ECS_CONTAINER_STOP_TIMEOUT` | 10m | Time to wait for the container exit normally before being forcibly killed. | 30s |
 | `ECS_ENABLE_TASK_IAM_ROLE` | `true` | Whether to enable IAM Roles for Tasks on the Container Instance | `false` |
+| `ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST` | `true` | Whether to enable IAM Roles for Tasks when launched with `host` network mode on the Container Instance | `false` |
 
 ### Persistence
 

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -282,34 +282,36 @@ func environmentConfig() Config {
 	seLinuxCapable := utils.ParseBool(os.Getenv("ECS_SELINUX_CAPABLE"), false)
 	appArmorCapable := utils.ParseBool(os.Getenv("ECS_APPARMOR_CAPABLE"), false)
 	taskIAMRoleEnabled := utils.ParseBool(os.Getenv("ECS_ENABLE_TASK_IAM_ROLE"), false)
+	taskIAMRoleEnabledForNetworkHost := utils.ParseBool(os.Getenv("ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST"), false)
 
 	credentialsAuditLogFile := os.Getenv("ECS_AUDIT_LOGFILE")
 	credentialsAuditLogDisabled := utils.ParseBool(os.Getenv("ECS_AUDIT_LOGFILE_DISABLED"), false)
 
 	return Config{
-		Cluster:                     clusterRef,
-		APIEndpoint:                 endpoint,
-		AWSRegion:                   awsRegion,
-		DockerEndpoint:              dockerEndpoint,
-		ReservedPorts:               reservedPorts,
-		ReservedPortsUDP:            reservedPortsUDP,
-		DataDir:                     dataDir,
-		Checkpoint:                  checkpoint,
-		EngineAuthType:              engineAuthType,
-		EngineAuthData:              NewSensitiveRawMessage([]byte(engineAuthData)),
-		UpdatesEnabled:              updatesEnabled,
-		UpdateDownloadDir:           updateDownloadDir,
-		DisableMetrics:              disableMetrics,
-		ReservedMemory:              reservedMemory,
-		AvailableLoggingDrivers:     availableLoggingDrivers,
-		PrivilegedDisabled:          privilegedDisabled,
-		SELinuxCapable:              seLinuxCapable,
-		AppArmorCapable:             appArmorCapable,
-		TaskCleanupWaitDuration:     taskCleanupWaitDuration,
-		TaskIAMRoleEnabled:          taskIAMRoleEnabled,
-		DockerStopTimeout:           dockerStopTimeout,
-		CredentialsAuditLogFile:     credentialsAuditLogFile,
-		CredentialsAuditLogDisabled: credentialsAuditLogDisabled,
+		Cluster:                          clusterRef,
+		APIEndpoint:                      endpoint,
+		AWSRegion:                        awsRegion,
+		DockerEndpoint:                   dockerEndpoint,
+		ReservedPorts:                    reservedPorts,
+		ReservedPortsUDP:                 reservedPortsUDP,
+		DataDir:                          dataDir,
+		Checkpoint:                       checkpoint,
+		EngineAuthType:                   engineAuthType,
+		EngineAuthData:                   NewSensitiveRawMessage([]byte(engineAuthData)),
+		UpdatesEnabled:                   updatesEnabled,
+		UpdateDownloadDir:                updateDownloadDir,
+		DisableMetrics:                   disableMetrics,
+		ReservedMemory:                   reservedMemory,
+		AvailableLoggingDrivers:          availableLoggingDrivers,
+		PrivilegedDisabled:               privilegedDisabled,
+		SELinuxCapable:                   seLinuxCapable,
+		AppArmorCapable:                  appArmorCapable,
+		TaskCleanupWaitDuration:          taskCleanupWaitDuration,
+		TaskIAMRoleEnabled:               taskIAMRoleEnabled,
+		DockerStopTimeout:                dockerStopTimeout,
+		CredentialsAuditLogFile:          credentialsAuditLogFile,
+		CredentialsAuditLogDisabled:      credentialsAuditLogDisabled,
+		TaskIAMRoleEnabledForNetworkHost: taskIAMRoleEnabledForNetworkHost,
 	}
 }
 

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -88,6 +88,7 @@ func TestEnvironmentConfig(t *testing.T) {
 	os.Setenv("ECS_DISABLE_PRIVILEGED", "true")
 	os.Setenv("ECS_ENGINE_TASK_CLEANUP_WAIT_DURATION", "90s")
 	os.Setenv("ECS_ENABLE_TASK_IAM_ROLE", "true")
+	os.Setenv("ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST", "true")
 
 	conf := environmentConfig()
 	if conf.Cluster != "myCluster" {
@@ -124,6 +125,9 @@ func TestEnvironmentConfig(t *testing.T) {
 	}
 	if !conf.TaskIAMRoleEnabled {
 		t.Error("Wrong value for TaskIAMRoleEnabled")
+	}
+	if !conf.TaskIAMRoleEnabledForNetworkHost {
+		t.Error("Wrong value for TaskIAMRoleEnabledForNetworkHost")
 	}
 }
 
@@ -172,6 +176,7 @@ func TestConfigDefault(t *testing.T) {
 	os.Unsetenv("ECS_AVAILABLE_LOGGING_DRIVERS")
 	os.Unsetenv("ECS_ENGINE_TASK_CLEANUP_WAIT_DURATION")
 	os.Unsetenv("ECS_ENABLE_TASK_IAM_ROLE")
+	os.Unsetenv("ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST")
 	os.Unsetenv("ECS_CONTAINER_STOP_TIMEOUT")
 	os.Unsetenv("ECS_AUDIT_LOGFILE")
 	os.Unsetenv("ECS_AUDIT_LOGFILE_DISABLED")
@@ -209,6 +214,9 @@ func TestConfigDefault(t *testing.T) {
 	}
 	if cfg.TaskIAMRoleEnabled {
 		t.Error("TaskIAMRoleEnabled set incorrectly")
+	}
+	if cfg.TaskIAMRoleEnabledForNetworkHost {
+		t.Error("TaskIAMRoleEnabledForNetworkHost set incorrectly")
 	}
 	if cfg.CredentialsAuditLogDisabled {
 		t.Error("CredentialsAuditLogDisabled set incorrectly")
@@ -361,6 +369,18 @@ func TestTaskIAMRoleEnabled(t *testing.T) {
 
 	if !cfg.TaskIAMRoleEnabled {
 		t.Errorf("Wrong value for TaskIAMRoleEnabled: %v", cfg.TaskIAMRoleEnabled)
+	}
+}
+
+func TestTaskIAMRoleForHostNetworkEnabled(t *testing.T) {
+	os.Setenv("ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST", "true")
+	cfg, err := NewConfig(ec2.NewBlackholeEC2MetadataClient())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !cfg.TaskIAMRoleEnabledForNetworkHost {
+		t.Errorf("Wrong value for TaskIAMRoleEnabledForNetworkHost: %v", cfg.TaskIAMRoleEnabledForNetworkHost)
 	}
 }
 

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -114,6 +114,10 @@ type Config struct {
 
 	// CredentialsAuditLogEnabled specifies whether audit logging is disabled.
 	CredentialsAuditLogDisabled bool
+
+	// TaskIAMRoleEnabledForNetworkHost specifies if the Agent is capable of launching
+	// tasks with IAM Roles when networkMode is set to 'host'
+	TaskIAMRoleEnabledForNetworkHost bool
 }
 
 // SensitiveRawMessage is a struct to store some data that should not be logged

--- a/scripts/setup-test-registry
+++ b/scripts/setup-test-registry
@@ -60,7 +60,7 @@ mirror_image() {
 }
 
 mirror_local_image() {
-  docker tag -f $1 $2
+  docker tag $1 $2
   docker push $2
 }
 


### PR DESCRIPTION
#### Commits

##### Enable Task IAM Role for containers launched with 'host' network mode.

Register a new capability for the Container Instance to indicate if
it is capable of launching Tasks that need an IAM Role as well as
host network mode.

Create an env var config for the same as well.

##### Remove force tagging images when setting up test registry. 
Following the deprecation notice for docker tag -f, remove the
flag in the script. Refer https://docs.docker.com/engine/deprecated/#/f-flag-on-docker-tag
for details.

#### Testing
 - [x] `make test` passed
 - [x] `make run-functional-tests` passed
 - [x] Manually ran a task with IAM Role and host networking mode and ensured that it was able to retrieve credentials (Used the setup from [this ecs-init PR](https://github.com/aws/amazon-ecs-init/pull/52))


r? @samuelkarp @juanrhenals @richardpen 