### PR TITLE
Explicitly removing the vendor directory from the mock imports

### DIFF
--- a/scripts/generate/mockgen.sh
+++ b/scripts/generate/mockgen.sh
@@ -19,6 +19,7 @@ set -e
 package=${1?Must provide package}
 interfaces=${2?Must provide interface names}
 outputfile=${3?Must provide an output file}
+PROJECT_VENDOR="github.com\/aws\/amazon-ecs-agent\/agent\/vendor\/"
 
 export PATH="${GOPATH//://bin:}/bin:$PATH"
 
@@ -44,4 +45,6 @@ EOF
 
 mkdir -p $(dirname ${outputfile})
 
-echo "$data" | goimports > "${outputfile}"
+# Explicitly removing the vendor directory from the mock imports
+# https://github.com/golang/mock/issues/30
+echo "$data" | sed -e "s/${PROJECT_VENDOR}//" | goimports > "${outputfile}"


### PR DESCRIPTION
See https://github.com/golang/mock/issues/30.

r? @samuelkarp @aaithal @sharanyad 