### PR TITLE
Stats connection leak

### DIFF
--- a/agent/engine/docker_container_engine.go
+++ b/agent/engine/docker_container_engine.go
@@ -722,7 +722,7 @@ func (dg *dockerGoClient) Stats(id string, ctx context.Context) (<-chan *docker.
 	statsComplete := make(chan struct{})
 	go func() {
 		statsErr := client.Stats(options)
-		if statsErr != nil {
+		if err != nil {
 			seelog.Warnf("Error retrieving stats for container %s: %v", id, statsErr)
 		}
 		close(statsComplete)

--- a/agent/stats/container.go
+++ b/agent/stats/container.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	ecsengine "github.com/aws/amazon-ecs-agent/agent/engine"
-	"github.com/aws/amazon-ecs-agent/agent/utils"
 	"github.com/cihub/seelog"
 	"golang.org/x/net/context"
 )
@@ -29,13 +28,6 @@ const (
 	// ContainerStatsBufferLength is the number of usage metrics stored in memory for a container. It is calculated as
 	// Number of usage metrics gathered in a second (1) * 60 * Time duration in minutes to store the data for (2)
 	ContainerStatsBufferLength = 120
-
-	// dockerStatsReconnectTimeout is the initial timeout for disconnecting and reconnecting to `docker stats`
-	// channel
-	dockerStatsReconnectTimeout = 10 * time.Minute
-
-	// dockerStatsReconnectTimeoutJitter is the jitter to add to the timeout for reconnecting to `docker stats`
-	dockerStatsReconnectTimeoutJitter = 10 * time.Minute
 )
 
 func newStatsContainer(dockerID string, client ecsengine.DockerClient) *StatsContainer {
@@ -54,14 +46,14 @@ func (container *StatsContainer) StartStatsCollection() {
 	// Create the queue to store utilization data from docker stats
 	container.statsQueue = NewQueue(ContainerStatsBufferLength)
 
-	go container.collect(dockerStatsReconnectTimeout, dockerStatsReconnectTimeoutJitter)
+	go container.collect()
 }
 
 func (container *StatsContainer) StopStatsCollection() {
 	container.cancel()
 }
 
-func (container *StatsContainer) collect(statsReconnectTimeout, statsReconnectTimeoutJitter time.Duration) {
+func (container *StatsContainer) collect() {
 	dockerID := container.containerMetadata.DockerID
 	for {
 		select {
@@ -69,30 +61,21 @@ func (container *StatsContainer) collect(statsReconnectTimeout, statsReconnectTi
 			seelog.Debugf("Stopping stats collection for container %s", dockerID)
 			return
 		default:
-			// invoke collectDockerStats with a context that has timeout set to
-			// dockerStatsReconnectTimeout + jitter
-			dockerStatsJitter := utils.AddJitter(statsReconnectTimeout, statsReconnectTimeoutJitter)
-			dockerStatsCtx, _ := context.WithTimeout(container.ctx, dockerStatsJitter)
-			container.collectDockerStats(dockerStatsCtx)
+			seelog.Debugf("Collecting stats for container %s", dockerID)
+			dockerStats, err := container.client.Stats(dockerID, container.ctx)
+			if err != nil {
+				seelog.Warnf("Error retrieving stats for container %s: %v", dockerID, err)
+				continue
+			}
+			for rawStat := range dockerStats {
+				stat, err := dockerStatsToContainerStats(rawStat)
+				if err == nil {
+					container.statsQueue.Add(stat)
+				} else {
+					seelog.Warnf("Error converting stats for container %s: %v", dockerID, err)
+				}
+			}
+			seelog.Debugf("Disconnected from docker stats for container %s", dockerID)
 		}
 	}
-}
-
-func (container *StatsContainer) collectDockerStats(ctx context.Context) {
-	dockerID := container.containerMetadata.DockerID
-	seelog.Debugf("Collecting stats for container %s", dockerID)
-	dockerStats, err := container.client.Stats(dockerID, ctx)
-	if err != nil {
-		seelog.Warnf("Error retrieving stats for container %s: %v", dockerID, err)
-		return
-	}
-	for rawStat := range dockerStats {
-		stat, err := dockerStatsToContainerStats(rawStat)
-		if err == nil {
-			container.statsQueue.Add(stat)
-		} else {
-			seelog.Warnf("Error converting stats for container %s: %v", dockerID, err)
-		}
-	}
-	seelog.Debugf("Disconnected from docker stats for container %s", dockerID)
 }

--- a/agent/stats/queue.go
+++ b/agent/stats/queue.go
@@ -73,7 +73,7 @@ func (queue *Queue) Add(rawStat *ContainerStats) {
 			// Ignore the stat if the current timestamp is same as the last one. This
 			// results in the value being set as +infinity
 			// float32(1) / float32(0) = +Inf
-			seelog.Debug("Time since last stat is zero. Ignoring cpu stat")
+			seelog.Debugf("time since last stat is zero. Ignoring cpu stat")
 		}
 		if queue.maxSize == queueLength {
 			// Remove first element if queue is full.

--- a/agent/tcs/client/client.go
+++ b/agent/tcs/client/client.go
@@ -91,7 +91,7 @@ func (cs *clientServer) MakeRequest(input interface{}) error {
 		return err
 	}
 
-	seelog.Debugf("TCS client sending payload: %s", string(payload))
+	seelog.Debug("TCS client sending payload: %s", string(payload))
 	data := cs.signRequest(payload)
 
 	// Over the wire we send something like


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Fixes #488

https://github.com/aws/amazon-ecs-agent/commit/95239bff045932cd1d13569ba35a1546f59d9bc0 was intended to help reduce the possibility that a connection to `docker stats` would become non-responsive leading to loss of metric data.  However, the version of go-dockerclient we have vendored does not correctly disconnect from the stats stream when we attempt to close our connection through the client.  Failing to properly disconnect leaks connections, which can ultimately lead to exhausting the open file limit inside the agent container.

This behavior is fixed in the latest version of go-dockerclient, which we are not yet using.  I will open a separate issue to track the upgrade.

### Implementation details
<!-- How are the changes implemented? -->

This pull request reverts https://github.com/aws/amazon-ecs-agent/commit/95239bff045932cd1d13569ba35a1546f59d9bc0 and also adds an inactivity timeout to the options we use when invoking go-dockerclient's `Stats` method.  The inactivity timeout does actually close the underlying dialer when activity has ceased across the connection.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make short-test` and `make test` can run anywhere in a development environment
like your laptop.  Please ensure both of these pass before opening the pull
request.  `make run-functional-tests` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` may incur charges to your AWS account; if you're
unable or unwilling to run these tests in your own account, we can run the tests
and provide test results.
-->
- [x] Builds (`make release`)
- [x] Unit tests (`make short-test`) pass
- [x] Integration tests (`make test`) pass
- [x] Functional tests (`make run-functional-tests`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
> Bug - Fixed an issue that could lead to exhausting the open file limit

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: yes, Amazon author

r? @aaithal @juanrhenals @richardpen 