### PR TITLE
Automated Docker Image Cleanup by Agent

### DIFF
--- a/agent/acs/update_handler/updater_test.go
+++ b/agent/acs/update_handler/updater_test.go
@@ -102,7 +102,7 @@ func TestPerformUpdateWithUpdatesDisabled(t *testing.T) {
 		Reason:            ptr("Updates are disabled").(*string),
 	}})
 
-	u.performUpdateHandler(statemanager.NewNoopStateManager(), engine.NewTaskEngine(cfg, nil, nil, nil))(&ecsacs.PerformUpdateMessage{
+	u.performUpdateHandler(statemanager.NewNoopStateManager(), engine.NewTaskEngine(cfg, nil, nil, nil, nil, nil))(&ecsacs.PerformUpdateMessage{
 		ClusterArn:           ptr("cluster").(*string),
 		ContainerInstanceArn: ptr("containerInstance").(*string),
 		MessageId:            ptr("mid").(*string),
@@ -149,7 +149,7 @@ func TestFullUpdateFlow(t *testing.T) {
 		t.Error("Incorrect data written")
 	}
 
-	u.performUpdateHandler(statemanager.NewNoopStateManager(), engine.NewTaskEngine(cfg, nil, nil, nil))(&ecsacs.PerformUpdateMessage{
+	u.performUpdateHandler(statemanager.NewNoopStateManager(), engine.NewTaskEngine(cfg, nil, nil, nil, nil, nil))(&ecsacs.PerformUpdateMessage{
 		ClusterArn:           ptr("cluster").(*string),
 		ContainerInstanceArn: ptr("containerInstance").(*string),
 		MessageId:            ptr("mid2").(*string),
@@ -212,7 +212,7 @@ func TestUndownloadedUpdate(t *testing.T) {
 		MessageId:         ptr("mid").(*string),
 	}})
 
-	u.performUpdateHandler(statemanager.NewNoopStateManager(), engine.NewTaskEngine(cfg, nil, nil, nil))(&ecsacs.PerformUpdateMessage{
+	u.performUpdateHandler(statemanager.NewNoopStateManager(), engine.NewTaskEngine(cfg, nil, nil, nil, nil, nil))(&ecsacs.PerformUpdateMessage{
 		ClusterArn:           ptr("cluster").(*string),
 		ContainerInstanceArn: ptr("containerInstance").(*string),
 		MessageId:            ptr("mid").(*string),
@@ -272,7 +272,7 @@ func TestDuplicateUpdateMessagesWithSuccess(t *testing.T) {
 		t.Error("Incorrect data written")
 	}
 
-	u.performUpdateHandler(statemanager.NewNoopStateManager(), engine.NewTaskEngine(cfg, nil, nil, nil))(&ecsacs.PerformUpdateMessage{
+	u.performUpdateHandler(statemanager.NewNoopStateManager(), engine.NewTaskEngine(cfg, nil, nil, nil, nil, nil))(&ecsacs.PerformUpdateMessage{
 		ClusterArn:           ptr("cluster").(*string),
 		ContainerInstanceArn: ptr("containerInstance").(*string),
 		MessageId:            ptr("mid3").(*string),
@@ -339,7 +339,7 @@ func TestDuplicateUpdateMessagesWithFailure(t *testing.T) {
 		t.Error("Incorrect data written")
 	}
 
-	u.performUpdateHandler(statemanager.NewNoopStateManager(), engine.NewTaskEngine(cfg, nil, nil, nil))(&ecsacs.PerformUpdateMessage{
+	u.performUpdateHandler(statemanager.NewNoopStateManager(), engine.NewTaskEngine(cfg, nil, nil, nil, nil, nil))(&ecsacs.PerformUpdateMessage{
 		ClusterArn:           ptr("cluster").(*string),
 		ContainerInstanceArn: ptr("containerInstance").(*string),
 		MessageId:            ptr("mid3").(*string),
@@ -416,7 +416,7 @@ func TestNewerUpdateMessages(t *testing.T) {
 		t.Error("Incorrect data written")
 	}
 
-	u.performUpdateHandler(statemanager.NewNoopStateManager(), engine.NewTaskEngine(cfg, nil, nil, nil))(&ecsacs.PerformUpdateMessage{
+	u.performUpdateHandler(statemanager.NewNoopStateManager(), engine.NewTaskEngine(cfg, nil, nil, nil, nil, nil))(&ecsacs.PerformUpdateMessage{
 		ClusterArn:           ptr("cluster").(*string),
 		ContainerInstanceArn: ptr("containerInstance").(*string),
 		MessageId:            ptr("mid2").(*string),

--- a/agent/engine/default.go
+++ b/agent/engine/default.go
@@ -18,6 +18,7 @@ package engine
 import (
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/credentials"
+	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
 	"github.com/aws/amazon-ecs-agent/agent/logger"
 )
@@ -25,6 +26,6 @@ import (
 var log = logger.ForModule("TaskEngine")
 
 // NewTaskEngine returns a default TaskEngine
-func NewTaskEngine(cfg *config.Config, client DockerClient, credentialsManager credentials.Manager, containerChangeEventStream *eventstream.EventStream) TaskEngine {
-	return NewDockerTaskEngine(cfg, client, credentialsManager, containerChangeEventStream)
+func NewTaskEngine(cfg *config.Config, client DockerClient, credentialsManager credentials.Manager, containerChangeEventStream *eventstream.EventStream, imageManager ImageManager, state *dockerstate.DockerTaskEngineState) TaskEngine {
+	return NewDockerTaskEngine(cfg, client, credentialsManager, containerChangeEventStream, imageManager, state)
 }

--- a/agent/engine/docker_image_manager.go
+++ b/agent/engine/docker_image_manager.go
@@ -1,0 +1,354 @@
+// Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package engine
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/aws/amazon-ecs-agent/agent/api"
+	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
+	"github.com/aws/amazon-ecs-agent/agent/engine/image"
+	"github.com/aws/amazon-ecs-agent/agent/statemanager"
+	"github.com/cihub/seelog"
+	"golang.org/x/net/context"
+)
+
+const (
+	numImagesToDelete             = 5
+	minimumAgeBeforeDeletion      = 1 * time.Hour
+	imageCleanupTimeInterval      = 3 * time.Hour
+	imageNotFoundForDeletionError = "no such image"
+)
+
+// ImageManager is responsible for saving the Image states,
+// adding and removing container references to ImageStates
+type ImageManager interface {
+	AddContainerReferenceToImageState(container *api.Container) error
+	RemoveContainerReferenceFromImageState(container *api.Container) error
+	AddAllImageStates(imageStates []*image.ImageState)
+	GetImageStateFromImageName(containerImageName string) *image.ImageState
+	StartImageCleanupProcess(ctx context.Context)
+	SetSaver(stateManager statemanager.Saver)
+}
+
+// dockerImageManager accounts all the images and their states in the instance.
+// It also has the cleanup policy configuration.
+type dockerImageManager struct {
+	imageStates                      []*image.ImageState
+	client                           DockerClient
+	updateLock                       sync.RWMutex
+	imageCleanupTicker               *time.Ticker
+	state                            *dockerstate.DockerTaskEngineState
+	saver                            statemanager.Saver
+	imageStatesConsideredForDeletion map[string]*image.ImageState
+}
+
+// ImageStatesForDeletion is used for implementing the sort interface
+type ImageStatesForDeletion []*image.ImageState
+
+func NewImageManager(client DockerClient, state *dockerstate.DockerTaskEngineState) ImageManager {
+	return &dockerImageManager{
+		client: client,
+		state:  state,
+	}
+}
+
+func (imageManager *dockerImageManager) SetSaver(stateManager statemanager.Saver) {
+	imageManager.saver = stateManager
+}
+
+func (imageManager *dockerImageManager) AddAllImageStates(imageStates []*image.ImageState) {
+	imageManager.updateLock.Lock()
+	defer imageManager.updateLock.Unlock()
+	for _, imageState := range imageStates {
+		imageManager.addImageState(imageState)
+	}
+}
+
+// AddContainerReferenceToImageState adds container reference to the corresponding imageState object
+func (imageManager *dockerImageManager) AddContainerReferenceToImageState(container *api.Container) error {
+	if container.Image == "" {
+		return fmt.Errorf("Invalid container reference: Empty image name")
+	}
+	// Inspect image for obtaining Container's Image ID
+	imageInspected, err := imageManager.client.InspectImage(container.Image)
+	if err != nil {
+		seelog.Errorf("Error inspecting image %v: %v", container.Image, err)
+		return err
+	}
+	added := imageManager.addContainerReferenceToExistingImageState(container, imageInspected.ID)
+	if !added {
+		imageManager.addContainerReferenceToNewImageState(container, imageInspected.ID, imageInspected.Size)
+	}
+	return nil
+}
+
+func (imageManager *dockerImageManager) addContainerReferenceToExistingImageState(container *api.Container, imageID string) bool {
+	// this lock is used for reading the image states in the image manager
+	imageManager.updateLock.RLock()
+	defer imageManager.updateLock.RUnlock()
+	imageManager.removeExistingImageNameOfDifferentID(container.Image, imageID)
+	imageState, ok := imageManager.getImageState(imageID)
+	if ok {
+		imageState.UpdateImageState(container)
+	}
+	return ok
+}
+
+func (imageManager *dockerImageManager) addContainerReferenceToNewImageState(container *api.Container, imageID string, imageSize int64) {
+	// this lock is used while creating and adding new image state to image manager
+	imageManager.updateLock.Lock()
+	defer imageManager.updateLock.Unlock()
+	// check to see if a different thread added image state for same image ID
+	imageState, ok := imageManager.getImageState(imageID)
+	if ok {
+		imageManager.removeExistingImageNameOfDifferentID(container.Image, imageID)
+		imageState.UpdateImageState(container)
+	} else {
+		sourceImage := &image.Image{
+			ImageID: imageID,
+			Size:    imageSize,
+		}
+		sourceImageState := &image.ImageState{
+			Image:      sourceImage,
+			PulledAt:   time.Now(),
+			LastUsedAt: time.Now(),
+		}
+		sourceImageState.UpdateImageState(container)
+		imageManager.addImageState(sourceImageState)
+	}
+}
+
+// RemoveContainerReferenceFromImageState removes container reference from the corresponding imageState object
+func (imageManager *dockerImageManager) RemoveContainerReferenceFromImageState(container *api.Container) error {
+	// this lock is for reading image states and finding the one that the container belongs to
+	imageManager.updateLock.RLock()
+	defer imageManager.updateLock.RUnlock()
+	if container.Image == "" {
+		return fmt.Errorf("Invalid container reference: Empty image name")
+	}
+	// Inspect image for obtaining Container's Image ID
+	imageInspected, err := imageManager.client.InspectImage(container.Image)
+	if err != nil {
+		seelog.Errorf("Error inspecting image %v: %v", container.Image, err)
+		return err
+	}
+
+	// Find image state that this container is part of, and remove the reference
+	imageState, ok := imageManager.getImageState(imageInspected.ID)
+	if !ok {
+		return fmt.Errorf("Cannot find image state for the container to be removed")
+	}
+	// Found matching ImageState
+	return imageState.RemoveContainerReference(container)
+}
+
+func (imageManager *dockerImageManager) addImageState(imageState *image.ImageState) {
+	imageManager.imageStates = append(imageManager.imageStates, imageState)
+}
+
+// getAllImageStates returns the list of imageStates in the instance
+func (imageManager *dockerImageManager) getAllImageStates() []*image.ImageState {
+	return imageManager.imageStates
+}
+
+// getImageState returns the ImageState object that the container is referenced at
+func (imageManager *dockerImageManager) getImageState(containerImageID string) (*image.ImageState, bool) {
+	for _, imageState := range imageManager.getAllImageStates() {
+		if imageState.Image.ImageID == containerImageID {
+			return imageState, true
+		}
+	}
+	return nil, false
+}
+
+// removeImageState removes the imageState from the list of imageState objects in ImageManager
+func (imageManager *dockerImageManager) removeImageState(imageStateToBeRemoved *image.ImageState) {
+	imageManager.updateLock.Lock()
+	defer imageManager.updateLock.Unlock()
+	for i, imageState := range imageManager.imageStates {
+		if imageState.Image.ImageID == imageStateToBeRemoved.Image.ImageID {
+			// Image State found; hence remove it
+			seelog.Infof("Removing Image State: %v from Image Manager", imageState.Image.ImageID)
+			imageManager.imageStates = append(imageManager.imageStates[:i], imageManager.imageStates[i+1:]...)
+			return
+		}
+	}
+}
+
+func (imageManager *dockerImageManager) getCandidateImagesForDeletion() []*image.ImageState {
+	if len(imageManager.imageStatesConsideredForDeletion) < 1 {
+		// no image states present in image manager
+		return nil
+	}
+	var imagesForDeletion []*image.ImageState
+	for _, imageState := range imageManager.imageStatesConsideredForDeletion {
+		if imageManager.isImageOldEnough(imageState) && imageState.HasNoAssociatedContainers() {
+			seelog.Infof("Candidate image for deletion: %+v", imageState)
+			imagesForDeletion = append(imagesForDeletion, imageState)
+		}
+	}
+	return imagesForDeletion
+}
+
+func (imageManager *dockerImageManager) isImageOldEnough(imageState *image.ImageState) bool {
+	ageOfImage := time.Now().Sub(imageState.PulledAt)
+	return ageOfImage > minimumAgeBeforeDeletion
+}
+
+// Implementing sort interface based on last used times of the images
+func (imageStates ImageStatesForDeletion) Len() int {
+	return len(imageStates)
+}
+
+func (imageStates ImageStatesForDeletion) Less(i, j int) bool {
+	return imageStates[i].LastUsedAt.Before(imageStates[j].LastUsedAt)
+}
+
+func (imageStates ImageStatesForDeletion) Swap(i, j int) {
+	imageStates[i], imageStates[j] = imageStates[j], imageStates[i]
+}
+
+func (imageManager *dockerImageManager) getLeastRecentlyUsedImage(imagesForDeletion []*image.ImageState) *image.ImageState {
+	var candidateImages ImageStatesForDeletion
+	for _, imageState := range imagesForDeletion {
+		candidateImages = append(candidateImages, imageState)
+	}
+	// sort images in the order of last used times
+	sort.Sort(candidateImages)
+	// return only the top LRU image for deletion
+	return candidateImages[0]
+}
+
+func (imageManager *dockerImageManager) removeExistingImageNameOfDifferentID(containerImageName string, inspectedImageID string) {
+	for _, imageState := range imageManager.getAllImageStates() {
+		// image with same name pulled in the instance. Untag the already existing image name
+		if imageState.Image.ImageID != inspectedImageID {
+			imageState.RemoveImageName(containerImageName)
+		}
+	}
+}
+
+func (imageManager *dockerImageManager) StartImageCleanupProcess(ctx context.Context) {
+	// passing the cleanup interval as argument which would help during testing
+	imageManager.performPeriodicImageCleanup(ctx, imageCleanupTimeInterval)
+}
+
+func (imageManager *dockerImageManager) performPeriodicImageCleanup(ctx context.Context, imageCleanupInterval time.Duration) {
+	imageManager.imageCleanupTicker = time.NewTicker(imageCleanupInterval)
+	for {
+		select {
+		case <-imageManager.imageCleanupTicker.C:
+			go imageManager.removeUnusedImages()
+		case <-ctx.Done():
+			imageManager.imageCleanupTicker.Stop()
+			return
+		}
+	}
+}
+
+func (imageManager *dockerImageManager) removeUnusedImages() {
+	imageManager.imageStatesConsideredForDeletion = make(map[string]*image.ImageState)
+	for _, imageState := range imageManager.getAllImageStates() {
+		imageManager.imageStatesConsideredForDeletion[imageState.Image.ImageID] = imageState
+	}
+	for i := 0; i < numImagesToDelete; i++ {
+		err := imageManager.removeLeastRecentlyUsedImage()
+		if err != nil {
+			seelog.Infof("End of eligible images for deletion")
+			break
+		}
+	}
+}
+
+func (imageManager *dockerImageManager) removeLeastRecentlyUsedImage() error {
+	seelog.Debug("Attempting to obtain ImagePullDeleteLock for removing images")
+	ImagePullDeleteLock.Lock()
+	seelog.Debug("Obtained ImagePullDeleteLock for removing images")
+	defer seelog.Debug("Released ImagePullDeleteLock after removing images")
+	defer ImagePullDeleteLock.Unlock()
+	leastRecentlyUsedImage := imageManager.getUnusedImageForDeletion()
+	if leastRecentlyUsedImage == nil {
+		return fmt.Errorf("No more eligible images for deletion")
+	}
+	imageManager.removeImage(leastRecentlyUsedImage)
+	return nil
+}
+
+func (imageManager *dockerImageManager) getUnusedImageForDeletion() *image.ImageState {
+	imageManager.updateLock.RLock()
+	defer imageManager.updateLock.RUnlock()
+	candidateImageStatesForDeletion := imageManager.getCandidateImagesForDeletion()
+	if len(candidateImageStatesForDeletion) < 1 {
+		seelog.Infof("No eligible images for deletion for this cleanup cycle")
+		return nil
+	}
+	seelog.Infof("Found %d eligible images for deletion", len(candidateImageStatesForDeletion))
+	return imageManager.getLeastRecentlyUsedImage(candidateImageStatesForDeletion)
+}
+
+func (imageManager *dockerImageManager) removeImage(leastRecentlyUsedImage *image.ImageState) {
+	imageNames := leastRecentlyUsedImage.Image.Names
+	if len(imageNames) == 0 {
+		// potentially untagged image of format <none>:<none>; remove by ID
+		imageManager.deleteImage(leastRecentlyUsedImage.Image.ImageID, leastRecentlyUsedImage)
+	} else {
+		// Image has multiple tags/repos. Untag each name and delete the final reference to image
+		for _, imageName := range imageNames {
+			imageManager.deleteImage(imageName, leastRecentlyUsedImage)
+		}
+	}
+}
+
+func (imageManager *dockerImageManager) deleteImage(imageID string, imageState *image.ImageState) {
+	if imageID == "" {
+		seelog.Errorf("Image ID to be deleted is null")
+		return
+	}
+	seelog.Infof("Removing Image: %s", imageID)
+	err := imageManager.client.RemoveImage(imageID, removeImageTimeout)
+	if err != nil {
+		if err.Error() == imageNotFoundForDeletionError {
+			seelog.Errorf("Image already removed from the instance")
+		} else {
+			seelog.Errorf("Error removing Image %v - %v", imageID, err)
+			delete(imageManager.imageStatesConsideredForDeletion, imageState.Image.ImageID)
+			return
+		}
+	}
+	seelog.Infof("Image removed: %v", imageID)
+	imageState.RemoveImageName(imageID)
+	if len(imageState.Image.Names) == 0 {
+		delete(imageManager.imageStatesConsideredForDeletion, imageState.Image.ImageID)
+		imageManager.removeImageState(imageState)
+		imageManager.state.RemoveImageState(imageState)
+		imageManager.saver.Save()
+	}
+}
+
+func (imageManager *dockerImageManager) GetImageStateFromImageName(containerImageName string) *image.ImageState {
+	imageManager.updateLock.Lock()
+	defer imageManager.updateLock.Unlock()
+	for _, imageState := range imageManager.getAllImageStates() {
+		for _, imageName := range imageState.Image.Names {
+			if imageName == containerImageName {
+				return imageState
+			}
+		}
+	}
+	return nil
+}

--- a/agent/engine/docker_image_manager_test.go
+++ b/agent/engine/docker_image_manager_test.go
@@ -1,0 +1,829 @@
+// Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package engine
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/aws/amazon-ecs-agent/agent/api"
+	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
+	"github.com/aws/amazon-ecs-agent/agent/engine/image"
+	"github.com/aws/amazon-ecs-agent/agent/statemanager"
+	docker "github.com/fsouza/go-dockerclient"
+	"github.com/golang/mock/gomock"
+	"golang.org/x/net/context"
+)
+
+func TestAddAndRemoveContainerToImageStateReferenceHappyPath(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	client := NewMockDockerClient(ctrl)
+	imageManager := &dockerImageManager{client: client, state: dockerstate.NewDockerTaskEngineState()}
+	container := &api.Container{
+		Name:  "testContainer",
+		Image: "testContainerImage",
+	}
+	sourceImage := &image.Image{
+		ImageID: "sha256:qwerty",
+	}
+	sourceImageState := &image.ImageState{
+		Image:    sourceImage,
+		PulledAt: time.Now().AddDate(0, -2, 0),
+	}
+	sourceImageState.AddImageName(container.Image)
+	imageManager.addImageState(sourceImageState)
+	imageInspected := &docker.Image{
+		ID: "sha256:qwerty",
+	}
+	client.EXPECT().InspectImage(container.Image).Return(imageInspected, nil)
+	err := imageManager.AddContainerReferenceToImageState(container)
+	if err != nil {
+		t.Error("Error in adding container to an existing image state")
+	}
+	imageState, ok := imageManager.getImageState(imageInspected.ID)
+	if !ok {
+		t.Error("Error in retrieving existing Image State for the Container")
+	}
+	if !reflect.DeepEqual(sourceImageState, imageState) {
+		t.Error("Mismatch between added and retrieved image state")
+	}
+	client.EXPECT().InspectImage(container.Image).Return(imageInspected, nil)
+	err = imageManager.RemoveContainerReferenceFromImageState(container)
+	if err != nil {
+		t.Error("Error removing container reference from image state")
+	}
+	imageState, _ = imageManager.getImageState(imageInspected.ID)
+	if len(imageState.Containers) != 0 {
+		t.Error("Error removing container reference from image state")
+	}
+}
+
+func TestAddContainerReferenceToImageStateInspectError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	client := NewMockDockerClient(ctrl)
+	imageManager := &dockerImageManager{client: client, state: dockerstate.NewDockerTaskEngineState()}
+	container := &api.Container{
+		Name:  "testContainer",
+		Image: "testContainerImage",
+	}
+	sourceImage := &image.Image{
+		ImageID: "sha256:qwerty",
+	}
+	sourceImageState := &image.ImageState{
+		Image:    sourceImage,
+		PulledAt: time.Now(),
+	}
+	sourceImageState.AddImageName(container.Image)
+	imageManager.addImageState(sourceImageState)
+	client.EXPECT().InspectImage(container.Image).Return(nil, errors.New("error inspecting")).AnyTimes()
+	err := imageManager.AddContainerReferenceToImageState(container)
+	if err == nil {
+		t.Error("Expected error in inspecting image while adding container to image state")
+	}
+}
+
+func TestAddContainerReferenceToImageStateWithNoImageName(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	client := NewMockDockerClient(ctrl)
+	imageManager := &dockerImageManager{client: client, state: dockerstate.NewDockerTaskEngineState()}
+	container := &api.Container{
+		Name:  "testContainer",
+		Image: "testContainerImage",
+	}
+	sourceImage := &image.Image{
+		ImageID: "sha256:qwerty",
+	}
+	sourceImageState := &image.ImageState{
+		Image:    sourceImage,
+		PulledAt: time.Now(),
+	}
+	imageManager.addImageState(sourceImageState)
+	imageInspected := &docker.Image{
+		ID: "sha256:qwerty",
+	}
+	client.EXPECT().InspectImage(container.Image).Return(imageInspected, nil).AnyTimes()
+	err := imageManager.AddContainerReferenceToImageState(container)
+	if err != nil {
+		t.Error("Error in adding container to an existing image state")
+	}
+	imageState, ok := imageManager.getImageState(imageInspected.ID)
+	if !ok {
+		t.Error("Error in retrieving existing Image State for the Container")
+	}
+	for _, imageName := range imageState.Image.Names {
+		if imageName != container.Image {
+			t.Error("Error while adding image name to image state")
+		}
+	}
+}
+
+func TestAddInvalidContainerReferenceToImageState(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	client := NewMockDockerClient(ctrl)
+	imageManager := &dockerImageManager{client: client, state: dockerstate.NewDockerTaskEngineState()}
+	container := &api.Container{
+		Image: "",
+	}
+	err := imageManager.AddContainerReferenceToImageState(container)
+	if err == nil {
+		t.Error("Expected error adding container reference with no image name to image state")
+	}
+}
+
+func TestAddContainerReferenceToExistingImageState(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	client := NewMockDockerClient(ctrl)
+	imageManager := &dockerImageManager{client: client, state: dockerstate.NewDockerTaskEngineState()}
+	imageID := "sha256:qwerty"
+	container := &api.Container{
+		Name:  "testContainer",
+		Image: "testContainerImage",
+	}
+	sourceImage := &image.Image{
+		ImageID: imageID,
+	}
+	sourceImageState := &image.ImageState{
+		Image: sourceImage,
+	}
+	sourceImage1 := &image.Image{
+		ImageID: "sha256:asdfg",
+	}
+	sourceImageState1 := &image.ImageState{
+		Image: sourceImage1,
+	}
+	sourceImageState1.AddImageName("testContainerImage")
+	imageManager.addImageState(sourceImageState)
+	imageManager.addImageState(sourceImageState1)
+	if !imageManager.addContainerReferenceToExistingImageState(container, imageID) {
+		t.Error("Error in adding container to an already existing image state")
+	}
+	if !reflect.DeepEqual(sourceImageState.Containers[0], container) {
+		t.Error("Incorrect container added to an already existing image state")
+	}
+	if len(sourceImageState1.Image.Names) != 0 {
+		t.Error("Error removing existing image name of different ID")
+	}
+}
+
+func TestAddContainerReferenceToExistingImageStateNoState(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	client := NewMockDockerClient(ctrl)
+	imageManager := &dockerImageManager{client: client, state: dockerstate.NewDockerTaskEngineState()}
+	imageID := "sha256:qwerty"
+	container := &api.Container{
+		Name:  "testContainer",
+		Image: "testContainerImage",
+	}
+	if imageManager.addContainerReferenceToExistingImageState(container, imageID) {
+		t.Error("Error adding container to an incorrect existing image state")
+	}
+}
+
+func TestAddContainerReferenceToNewImageState(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	client := NewMockDockerClient(ctrl)
+	imageManager := &dockerImageManager{client: client, state: dockerstate.NewDockerTaskEngineState()}
+	imageID := "sha256:qwerty"
+	var imageSize int64
+	imageSize = 18767
+	container := &api.Container{
+		Name:  "testContainer",
+		Image: "testContainerImage",
+	}
+	imageManager.addContainerReferenceToNewImageState(container, imageID, imageSize)
+	_, ok := imageManager.getImageState(imageID)
+	if !ok {
+		t.Error("Error adding container reference to new image state")
+	}
+}
+
+func TestAddContainerReferenceToNewImageStateAddedState(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	client := NewMockDockerClient(ctrl)
+	imageManager := &dockerImageManager{client: client, state: dockerstate.NewDockerTaskEngineState()}
+	imageID := "sha256:qwerty"
+	var imageSize int64
+	imageSize = 18767
+	container := &api.Container{
+		Name:  "testContainer",
+		Image: "testContainerImage",
+	}
+	sourceImage := &image.Image{
+		ImageID: imageID,
+	}
+	sourceImageState := &image.ImageState{
+		Image: sourceImage,
+	}
+	sourceImage1 := &image.Image{
+		ImageID: "sha256:asdfg",
+	}
+	sourceImageState1 := &image.ImageState{
+		Image: sourceImage1,
+	}
+	sourceImageState1.AddImageName("testContainerImage")
+	imageManager.addImageState(sourceImageState)
+	imageManager.addImageState(sourceImageState1)
+	imageManager.addContainerReferenceToNewImageState(container, imageID, imageSize)
+	if !reflect.DeepEqual(sourceImageState.Containers[0], container) {
+		t.Error("Incorrect container added to an already existing image state")
+	}
+	if len(sourceImageState1.Image.Names) != 0 {
+		t.Error("Error removing existing image name of different ID")
+	}
+}
+
+func TestRemoveContainerReferenceFromInvalidImageState(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	client := NewMockDockerClient(ctrl)
+	imageManager := &dockerImageManager{client: client, state: dockerstate.NewDockerTaskEngineState()}
+	container := &api.Container{
+		Image: "myContainerImage",
+	}
+	imageInspected := &docker.Image{
+		ID: "sha256:qwerty",
+	}
+	client.EXPECT().InspectImage(container.Image).Return(imageInspected, nil).AnyTimes()
+	err := imageManager.RemoveContainerReferenceFromImageState(container)
+	if err == nil {
+		t.Error("Expected error while adding container to an invalid image state")
+	}
+}
+
+func TestRemoveInvalidContainerReferenceFromImageState(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	client := NewMockDockerClient(ctrl)
+	imageManager := &dockerImageManager{client: client, state: dockerstate.NewDockerTaskEngineState()}
+	container := &api.Container{
+		Image: "",
+	}
+	err := imageManager.RemoveContainerReferenceFromImageState(container)
+	if err == nil {
+		t.Error("Expected error removing container reference with no image name from image state")
+	}
+}
+
+func TestRemoveContainerReferenceFromImageStateInspectError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	client := NewMockDockerClient(ctrl)
+	imageManager := &dockerImageManager{client: client, state: dockerstate.NewDockerTaskEngineState()}
+	container := &api.Container{
+		Image: "myContainerImage",
+	}
+	client.EXPECT().InspectImage(container.Image).Return(nil, errors.New("error inspecting")).AnyTimes()
+	err := imageManager.RemoveContainerReferenceFromImageState(container)
+	if err == nil {
+		t.Error("Expected error in inspecting image while adding container to image state")
+	}
+}
+
+func TestRemoveContainerReferenceFromImageStateWithNoReference(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	client := NewMockDockerClient(ctrl)
+	imageManager := &dockerImageManager{client: client, state: dockerstate.NewDockerTaskEngineState()}
+	container := &api.Container{
+		Name:  "testContainer",
+		Image: "testContainerImage",
+	}
+	sourceImage := &image.Image{
+		ImageID: "sha256:qwerty",
+	}
+	sourceImageState := &image.ImageState{
+		Image:    sourceImage,
+		PulledAt: time.Now(),
+	}
+	imageManager.addImageState(sourceImageState)
+	imageInspected := &docker.Image{
+		ID: "sha256:qwerty",
+	}
+	client.EXPECT().InspectImage(container.Image).Return(imageInspected, nil).AnyTimes()
+	err := imageManager.RemoveContainerReferenceFromImageState(container)
+	if err == nil {
+		t.Error("Expected error removing non-existing container reference from image state")
+	}
+}
+
+func TestGetCandidateImagesForDeletionImageNoImageState(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	client := NewMockDockerClient(ctrl)
+	imageManager := &dockerImageManager{client: client, state: dockerstate.NewDockerTaskEngineState()}
+	imageStates := imageManager.getCandidateImagesForDeletion()
+	if imageStates != nil {
+		t.Error("Expected no image state to be returned for deletion")
+	}
+}
+
+func TestGetCandidateImagesForDeletionImageJustPulled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	client := NewMockDockerClient(ctrl)
+	imageManager := &dockerImageManager{client: client, state: dockerstate.NewDockerTaskEngineState()}
+	sourceImage := &image.Image{}
+	sourceImageState := &image.ImageState{
+		Image:    sourceImage,
+		PulledAt: time.Now(),
+	}
+	imageManager.addImageState(sourceImageState)
+	imageStates := imageManager.getCandidateImagesForDeletion()
+	if len(imageStates) > 0 {
+		t.Error("Expected no image state to be returned for deletion")
+	}
+}
+
+func TestGetCandidateImagesForDeletionImageHasContainerReference(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	client := NewMockDockerClient(ctrl)
+	imageManager := &dockerImageManager{client: client, state: dockerstate.NewDockerTaskEngineState()}
+	container := &api.Container{
+		Name:  "testContainer",
+		Image: "testContainerImage",
+	}
+	sourceImage := &image.Image{
+		ImageID: "sha256:qwerty",
+	}
+	sourceImage.Names = append(sourceImage.Names, container.Image)
+	sourceImageState := &image.ImageState{
+		Image:    sourceImage,
+		PulledAt: time.Now().AddDate(0, -2, 0),
+	}
+	imageManager.addImageState(sourceImageState)
+	imageInspected := &docker.Image{
+		ID: "sha256:qwerty",
+	}
+	client.EXPECT().InspectImage(container.Image).Return(imageInspected, nil).AnyTimes()
+	err := imageManager.AddContainerReferenceToImageState(container)
+	if err != nil {
+		t.Error("Error in adding container to an existing image state")
+	}
+	imageStates := imageManager.getCandidateImagesForDeletion()
+	if len(imageStates) > 0 {
+		t.Error("Expected no image state to be returned for deletion")
+	}
+}
+
+func TestGetCandidateImagesForDeletionImageHasMoreContainerReferences(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	client := NewMockDockerClient(ctrl)
+	imageManager := &dockerImageManager{client: client, state: dockerstate.NewDockerTaskEngineState()}
+	container := &api.Container{
+		Name:  "testContainer",
+		Image: "testContainerImage",
+	}
+	container2 := &api.Container{
+		Name:  "testContainer2",
+		Image: "testContainerImage",
+	}
+	sourceImage := &image.Image{
+		ImageID: "sha256:qwerty",
+	}
+	sourceImage.Names = append(sourceImage.Names, container.Image)
+	sourceImageState := &image.ImageState{
+		Image:    sourceImage,
+		PulledAt: time.Now().AddDate(0, -2, 0),
+	}
+	imageManager.addImageState(sourceImageState)
+	imageInspected := &docker.Image{
+		ID: "sha256:qwerty",
+	}
+	client.EXPECT().InspectImage(container.Image).Return(imageInspected, nil).AnyTimes()
+	err := imageManager.AddContainerReferenceToImageState(container)
+	if err != nil {
+		t.Error("Error in adding container to an existing image state")
+	}
+	client.EXPECT().InspectImage(container.Image).Return(imageInspected, nil).AnyTimes()
+	err = imageManager.AddContainerReferenceToImageState(container2)
+	if err != nil {
+		t.Error("Error in adding container2 to an existing image state")
+	}
+	client.EXPECT().InspectImage(container.Image).Return(imageInspected, nil).AnyTimes()
+	err = imageManager.RemoveContainerReferenceFromImageState(container)
+	if err != nil {
+		t.Error("Error removing container reference from image state")
+	}
+	imageStates := imageManager.getCandidateImagesForDeletion()
+	if len(imageStates) > 0 {
+		t.Error("Expected no image state to be returned for deletion")
+	}
+}
+
+func TestGetLeastRecentlyUsedImages(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	client := NewMockDockerClient(ctrl)
+	imageManager := &dockerImageManager{client: client, state: dockerstate.NewDockerTaskEngineState()}
+	imageStateA := &image.ImageState{
+		LastUsedAt: time.Now().AddDate(0, -5, 0),
+	}
+	imageStateB := &image.ImageState{
+		LastUsedAt: time.Now().AddDate(0, -3, 0),
+	}
+	imageStateC := &image.ImageState{
+		LastUsedAt: time.Now().AddDate(0, -2, 0),
+	}
+	imageStateD := &image.ImageState{
+		LastUsedAt: time.Now().AddDate(0, -6, 0),
+	}
+	imageStateE := &image.ImageState{
+		LastUsedAt: time.Now().AddDate(0, -4, 0),
+	}
+	imageStateF := &image.ImageState{
+		LastUsedAt: time.Now().AddDate(0, -1, 0),
+	}
+
+	candidateImagesForDeletion := []*image.ImageState{
+		imageStateA, imageStateB, imageStateC, imageStateD, imageStateE, imageStateF,
+	}
+	expectedLeastRecentlyUsedImages := []*image.ImageState{
+		imageStateD, imageStateA, imageStateE, imageStateB, imageStateC,
+	}
+	leastRecentlyUsedImage := imageManager.getLeastRecentlyUsedImage(candidateImagesForDeletion)
+	if !reflect.DeepEqual(leastRecentlyUsedImage, expectedLeastRecentlyUsedImages[0]) {
+		t.Error("Incorrect order of least recently used images")
+	}
+}
+
+func TestGetLeastRecentlyUsedImagesLessThanFive(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	client := NewMockDockerClient(ctrl)
+	imageManager := &dockerImageManager{client: client, state: dockerstate.NewDockerTaskEngineState()}
+	imageStateA := &image.ImageState{
+		LastUsedAt: time.Now().AddDate(0, -5, 0),
+	}
+	imageStateB := &image.ImageState{
+		LastUsedAt: time.Now().AddDate(0, -3, 0),
+	}
+	imageStateC := &image.ImageState{
+		LastUsedAt: time.Now().AddDate(0, -2, 0),
+	}
+	candidateImagesForDeletion := []*image.ImageState{
+		imageStateA, imageStateB, imageStateC,
+	}
+	expectedLeastRecentlyUsedImages := []*image.ImageState{
+		imageStateA, imageStateB, imageStateC,
+	}
+	leastRecentlyUsedImage := imageManager.getLeastRecentlyUsedImage(candidateImagesForDeletion)
+	if !reflect.DeepEqual(leastRecentlyUsedImage, expectedLeastRecentlyUsedImages[0]) {
+		t.Error("Incorrect order of least recently used images")
+	}
+}
+
+func TestRemoveAlreadyExistingImageNameWithDifferentID(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	client := NewMockDockerClient(ctrl)
+	imageManager := &dockerImageManager{client: client, state: dockerstate.NewDockerTaskEngineState()}
+	container := &api.Container{
+		Name:  "testContainer",
+		Image: "testContainerImage",
+	}
+	sourceImage := &image.Image{
+		ImageID: "sha256:qwerty",
+	}
+	sourceImage.Names = append(sourceImage.Names, container.Image)
+	imageInspected := &docker.Image{
+		ID: "sha256:qwerty",
+	}
+	client.EXPECT().InspectImage(container.Image).Return(imageInspected, nil)
+	err := imageManager.AddContainerReferenceToImageState(container)
+	if err != nil {
+		t.Error("Error in adding container to an existing image state")
+	}
+	container1 := &api.Container{
+		Name:  "testContainer1",
+		Image: "testContainerImage",
+	}
+	imageInspected1 := &docker.Image{
+		ID: "sha256:asdfg",
+	}
+	client.EXPECT().InspectImage(container.Image).Return(imageInspected1, nil)
+	err = imageManager.AddContainerReferenceToImageState(container1)
+	if err != nil {
+		t.Error("Error in adding container to an existing image state")
+	}
+	imageState, ok := imageManager.getImageState(imageInspected.ID)
+	if !ok {
+		t.Error("Error in retrieving existing Image State for the Container")
+	}
+	if len(imageState.Image.Names) != 0 {
+		t.Error("Error in removing already existing image name with different ID")
+	}
+}
+
+func TestImageCleanupHappyPath(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	client := NewMockDockerClient(ctrl)
+	imageManager := &dockerImageManager{client: client, state: dockerstate.NewDockerTaskEngineState()}
+	imageManager.SetSaver(statemanager.NewNoopStateManager())
+	container := &api.Container{
+		Name:  "testContainer",
+		Image: "testContainerImage",
+	}
+	imageInspected := &docker.Image{
+		ID: "sha256:qwerty",
+	}
+	client.EXPECT().InspectImage(container.Image).Return(imageInspected, nil).AnyTimes()
+	err := imageManager.AddContainerReferenceToImageState(container)
+	if err != nil {
+		t.Error("Error in adding container to an existing image state")
+	}
+
+	err = imageManager.RemoveContainerReferenceFromImageState(container)
+	if err != nil {
+		t.Error("Error removing container reference from image state")
+	}
+
+	imageState, _ := imageManager.getImageState(imageInspected.ID)
+	imageState.PulledAt = time.Now().AddDate(0, -2, 0)
+	imageState.LastUsedAt = time.Now().AddDate(0, -2, 0)
+	imageState.AddImageName("anotherImage")
+
+	client.EXPECT().RemoveImage(container.Image, removeImageTimeout).Return(nil)
+	client.EXPECT().RemoveImage("anotherImage", removeImageTimeout).Return(nil)
+	parent := context.Background()
+	ctx, cancel := context.WithCancel(parent)
+	go imageManager.performPeriodicImageCleanup(ctx, 2*time.Millisecond)
+	time.Sleep(3 * time.Millisecond)
+	cancel()
+	if len(imageState.Image.Names) != 0 {
+		t.Error("Error removing image name from state after the image is removed")
+	}
+	if len(imageManager.imageStates) != 0 {
+		t.Error("Error removing image state after the image is removed")
+	}
+}
+
+func TestImageCleanupCannotRemoveImage(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	client := NewMockDockerClient(ctrl)
+	imageManager := &dockerImageManager{client: client, state: dockerstate.NewDockerTaskEngineState()}
+	imageManager.SetSaver(statemanager.NewNoopStateManager())
+	container := &api.Container{
+		Name:  "testContainer",
+		Image: "testContainerImage",
+	}
+	sourceImage := &image.Image{
+		ImageID: "sha256:qwerty",
+	}
+	sourceImage.Names = append(sourceImage.Names, container.Image)
+	imageInspected := &docker.Image{
+		ID: "sha256:qwerty",
+	}
+	client.EXPECT().InspectImage(container.Image).Return(imageInspected, nil).AnyTimes()
+	err := imageManager.AddContainerReferenceToImageState(container)
+	if err != nil {
+		t.Error("Error in adding container to an existing image state")
+	}
+
+	err = imageManager.RemoveContainerReferenceFromImageState(container)
+	if err != nil {
+		t.Error("Error removing container reference from image state")
+	}
+
+	imageState, _ := imageManager.getImageState(imageInspected.ID)
+	imageState.PulledAt = time.Now().AddDate(0, -2, 0)
+	imageState.LastUsedAt = time.Now().AddDate(0, -2, 0)
+
+	client.EXPECT().RemoveImage(container.Image, removeImageTimeout).Return(errors.New("error removing image")).AnyTimes()
+	imageManager.removeUnusedImages()
+	if len(imageState.Image.Names) == 0 {
+		t.Error("Error: image name should not be removed")
+	}
+	if len(imageManager.imageStates) == 0 {
+		t.Error("Error: image state should not be removed")
+	}
+}
+
+func TestImageCleanupRemoveImageById(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	client := NewMockDockerClient(ctrl)
+	imageManager := &dockerImageManager{client: client, state: dockerstate.NewDockerTaskEngineState()}
+	imageManager.SetSaver(statemanager.NewNoopStateManager())
+	container := &api.Container{
+		Name:  "testContainer",
+		Image: "testContainerImage",
+	}
+	sourceImage := &image.Image{
+		ImageID: "sha256:qwerty",
+	}
+	sourceImage.Names = append(sourceImage.Names, container.Image)
+	imageInspected := &docker.Image{
+		ID: "sha256:qwerty",
+	}
+	client.EXPECT().InspectImage(container.Image).Return(imageInspected, nil).AnyTimes()
+	err := imageManager.AddContainerReferenceToImageState(container)
+	if err != nil {
+		t.Error("Error in adding container to an existing image state")
+	}
+
+	err = imageManager.RemoveContainerReferenceFromImageState(container)
+	if err != nil {
+		t.Error("Error removing container reference from image state")
+	}
+
+	imageState, _ := imageManager.getImageState(imageInspected.ID)
+	imageState.RemoveImageName(container.Image)
+	imageState.PulledAt = time.Now().AddDate(0, -2, 0)
+	imageState.LastUsedAt = time.Now().AddDate(0, -2, 0)
+
+	client.EXPECT().RemoveImage(sourceImage.ImageID, removeImageTimeout).Return(nil)
+	imageManager.removeUnusedImages()
+	if len(imageManager.imageStates) != 0 {
+		t.Error("Error removing image state after the image is removed")
+	}
+}
+
+func TestDeleteImage(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	client := NewMockDockerClient(ctrl)
+	imageManager := &dockerImageManager{client: client, state: dockerstate.NewDockerTaskEngineState()}
+	imageManager.SetSaver(statemanager.NewNoopStateManager())
+	container := &api.Container{
+		Name:  "testContainer",
+		Image: "testContainerImage",
+	}
+	imageInspected := &docker.Image{
+		ID: "sha256:qwerty",
+	}
+	client.EXPECT().InspectImage(container.Image).Return(imageInspected, nil).AnyTimes()
+	err := imageManager.AddContainerReferenceToImageState(container)
+	if err != nil {
+		t.Error("Error in adding container to an existing image state")
+	}
+	imageState, _ := imageManager.getImageState(imageInspected.ID)
+	client.EXPECT().RemoveImage(container.Image, removeImageTimeout).Return(nil)
+	imageManager.deleteImage(container.Image, imageState)
+	if len(imageState.Image.Names) != 0 {
+		t.Error("Error removing Image name from image state")
+	}
+	if len(imageManager.getAllImageStates()) != 0 {
+		t.Error("Error removing image state from image manager after deletion")
+	}
+}
+
+func TestDeleteImageNotFoundError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	client := NewMockDockerClient(ctrl)
+	imageManager := &dockerImageManager{client: client, state: dockerstate.NewDockerTaskEngineState()}
+	imageManager.SetSaver(statemanager.NewNoopStateManager())
+	container := &api.Container{
+		Name:  "testContainer",
+		Image: "testContainerImage",
+	}
+	imageInspected := &docker.Image{
+		ID: "sha256:qwerty",
+	}
+	client.EXPECT().InspectImage(container.Image).Return(imageInspected, nil).AnyTimes()
+	err := imageManager.AddContainerReferenceToImageState(container)
+	if err != nil {
+		t.Error("Error in adding container to an existing image state")
+	}
+	imageState, _ := imageManager.getImageState(imageInspected.ID)
+	client.EXPECT().RemoveImage(container.Image, removeImageTimeout).Return(errors.New("no such image"))
+	imageManager.deleteImage(container.Image, imageState)
+	if len(imageState.Image.Names) != 0 {
+		t.Error("Error removing Image name from image state")
+	}
+	if len(imageManager.getAllImageStates()) != 0 {
+		t.Error("Error removing image state from image manager")
+	}
+}
+
+func TestDeleteImageOtherRemoveImageErrors(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	client := NewMockDockerClient(ctrl)
+	imageManager := &dockerImageManager{client: client, state: dockerstate.NewDockerTaskEngineState()}
+	imageManager.SetSaver(statemanager.NewNoopStateManager())
+	container := &api.Container{
+		Name:  "testContainer",
+		Image: "testContainerImage",
+	}
+	imageInspected := &docker.Image{
+		ID: "sha256:qwerty",
+	}
+	client.EXPECT().InspectImage(container.Image).Return(imageInspected, nil).AnyTimes()
+	err := imageManager.AddContainerReferenceToImageState(container)
+	if err != nil {
+		t.Error("Error in adding container to an existing image state")
+	}
+	imageState, _ := imageManager.getImageState(imageInspected.ID)
+	client.EXPECT().RemoveImage(container.Image, removeImageTimeout).Return(errors.New("container for this image exists"))
+	imageManager.deleteImage(container.Image, imageState)
+	if len(imageState.Image.Names) == 0 {
+		t.Error("Incorrectly removed Image name from image state")
+	}
+	if len(imageManager.getAllImageStates()) == 0 {
+		t.Error("Incorrecting removed image state from image manager before deletion")
+	}
+}
+
+func TestDeleteImageIDNull(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	client := NewMockDockerClient(ctrl)
+	imageManager := &dockerImageManager{client: client, state: dockerstate.NewDockerTaskEngineState()}
+	imageManager.SetSaver(statemanager.NewNoopStateManager())
+	imageManager.deleteImage("", nil)
+}
+
+func TestRemoveLeastRecentlyUsedImageNoImage(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	client := NewMockDockerClient(ctrl)
+	imageManager := &dockerImageManager{client: client, state: dockerstate.NewDockerTaskEngineState()}
+	imageManager.SetSaver(statemanager.NewNoopStateManager())
+	err := imageManager.removeLeastRecentlyUsedImage()
+	if err == nil {
+		t.Error("Expected Error for no LRU image to remove")
+	}
+}
+
+func TestRemoveUnusedImagesNoImages(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	client := NewMockDockerClient(ctrl)
+	imageManager := &dockerImageManager{client: client, state: dockerstate.NewDockerTaskEngineState()}
+	imageManager.SetSaver(statemanager.NewNoopStateManager())
+	imageManager.removeUnusedImages()
+}
+
+func TestGetImageStateFromImageName(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	client := NewMockDockerClient(ctrl)
+	imageManager := &dockerImageManager{client: client, state: dockerstate.NewDockerTaskEngineState()}
+	imageManager.SetSaver(statemanager.NewNoopStateManager())
+	container := &api.Container{
+		Name:  "testContainer",
+		Image: "testContainerImage",
+	}
+	imageInspected := &docker.Image{
+		ID: "sha256:qwerty",
+	}
+	client.EXPECT().InspectImage(container.Image).Return(imageInspected, nil).AnyTimes()
+	err := imageManager.AddContainerReferenceToImageState(container)
+	if err != nil {
+		t.Error("Error in adding container to an existing image state")
+	}
+	imageState := imageManager.GetImageStateFromImageName(container.Image)
+	if imageState == nil {
+		t.Error("Error retrieving image state by image name")
+	}
+}
+
+func TestGetImageStateFromImageNameNoImageState(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	client := NewMockDockerClient(ctrl)
+	imageManager := &dockerImageManager{client: client, state: dockerstate.NewDockerTaskEngineState()}
+	imageManager.SetSaver(statemanager.NewNoopStateManager())
+	container := &api.Container{
+		Name:  "testContainer",
+		Image: "testContainerImage",
+	}
+	imageInspected := &docker.Image{
+		ID: "sha256:qwerty",
+	}
+	client.EXPECT().InspectImage(container.Image).Return(imageInspected, nil).AnyTimes()
+	err := imageManager.AddContainerReferenceToImageState(container)
+	if err != nil {
+		t.Error("Error in adding container to an existing image state")
+	}
+	imageState := imageManager.GetImageStateFromImageName("noSuchImage")
+	if imageState != nil {
+		t.Error("Incorrect image state retrieved by image name")
+	}
+}

--- a/agent/engine/dockeriface/interface.go
+++ b/agent/engine/dockeriface/interface.go
@@ -15,7 +15,7 @@
 // subset used by the agent
 package dockeriface
 
-import "github.com/fsouza/go-dockerclient"
+import docker "github.com/fsouza/go-dockerclient"
 
 // Client is an interface specifying the subset of
 // github.com/fsouza/go-dockerclient.Client that the agent uses.
@@ -34,4 +34,5 @@ type Client interface {
 	StopContainer(id string, timeout uint) error
 	Stats(opts docker.StatsOptions) error
 	Version() (*docker.Env, error)
+	RemoveImage(imageName string) error
 }

--- a/agent/engine/dockeriface/mocks/dockeriface_mocks.go
+++ b/agent/engine/dockeriface/mocks/dockeriface_mocks.go
@@ -186,3 +186,13 @@ func (_m *MockClient) Version() (*go_dockerclient.Env, error) {
 func (_mr *_MockClientRecorder) Version() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Version")
 }
+
+func (_m *MockClient) RemoveImage(_param0 string) error {
+	ret := _m.ctrl.Call(_m, "RemoveImage", _param0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockClientRecorder) RemoveImage(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveImage", arg0)
+}

--- a/agent/engine/dockerstate/dockerstate_test.go
+++ b/agent/engine/dockerstate/dockerstate_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
+	"github.com/aws/amazon-ecs-agent/agent/engine/image"
 )
 
 func TestCreateDockerTaskEngineState(t *testing.T) {
@@ -36,6 +37,10 @@ func TestCreateDockerTaskEngineState(t *testing.T) {
 
 	if len(state.AllTasks()) != 0 {
 		t.Error("Empty state should have no tasks")
+	}
+
+	if len(state.AllImageStates()) != 0 {
+		t.Error("Empty state should have no image states")
 	}
 }
 
@@ -149,5 +154,94 @@ func TestRemoveTask(t *testing.T) {
 	tasks = state.AllTasks()
 	if len(tasks) != 0 {
 		t.Error("Expected task to be removed")
+	}
+}
+
+func TestAddImageState(t *testing.T) {
+	state := NewDockerTaskEngineState()
+
+	testImage := &image.Image{ImageID: "sha256:imagedigest"}
+	testImageState := &image.ImageState{Image: testImage}
+	state.AddImageState(testImageState)
+
+	if len(state.AllImageStates()) != 1 {
+		t.Error("Error adding image state")
+	}
+
+	for _, imageState := range state.AllImageStates() {
+		if imageState.Image.ImageID != testImage.ImageID {
+			t.Error("Error in retrieving image state added")
+		}
+	}
+}
+
+func TestAddEmptyImageState(t *testing.T) {
+	state := NewDockerTaskEngineState()
+	state.AddImageState(nil)
+
+	if len(state.AllImageStates()) != 0 {
+		t.Error("Error adding empty image state")
+	}
+}
+
+func TestAddEmptyIdImageState(t *testing.T) {
+	state := NewDockerTaskEngineState()
+
+	testImage := &image.Image{ImageID: ""}
+	testImageState := &image.ImageState{Image: testImage}
+	state.AddImageState(testImageState)
+
+	if len(state.AllImageStates()) != 0 {
+		t.Error("Error adding image state with empty Image Id")
+	}
+}
+
+func TestRemoveImageState(t *testing.T) {
+	state := NewDockerTaskEngineState()
+
+	testImage := &image.Image{ImageID: "sha256:imagedigest"}
+	testImageState := &image.ImageState{Image: testImage}
+	state.AddImageState(testImageState)
+
+	if len(state.AllImageStates()) != 1 {
+		t.Error("Error adding image state")
+	}
+	state.RemoveImageState(testImageState)
+	if len(state.AllImageStates()) != 0 {
+		t.Error("Error removing image state")
+	}
+}
+
+func TestRemoveEmptyImageState(t *testing.T) {
+	state := NewDockerTaskEngineState()
+
+	testImage := &image.Image{ImageID: "sha256:imagedigest"}
+	testImageState := &image.ImageState{Image: testImage}
+	state.AddImageState(testImageState)
+
+	if len(state.AllImageStates()) != 1 {
+		t.Error("Error adding image state")
+	}
+	state.RemoveImageState(nil)
+	if len(state.AllImageStates()) == 0 {
+		t.Error("Error removing empty image state")
+	}
+}
+
+func TestRemoveNonExistingImageState(t *testing.T) {
+	state := NewDockerTaskEngineState()
+
+	testImage := &image.Image{ImageID: "sha256:imagedigest"}
+	testImageState := &image.ImageState{Image: testImage}
+	state.AddImageState(testImageState)
+
+	if len(state.AllImageStates()) != 1 {
+		t.Error("Error adding image state")
+	}
+	testImage1 := &image.Image{ImageID: "sha256:imagedigest1"}
+	testImageState1 := &image.ImageState{Image: testImage1}
+	state.RemoveImageState(testImageState1)
+	if len(state.AllImageStates()) == 0 {
+		t.Error("Error removing incorrect image state")
 	}
 }

--- a/agent/engine/engine_integ_test.go
+++ b/agent/engine/engine_integ_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/credentials"
 	"github.com/aws/amazon-ecs-agent/agent/ec2"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerclient"
+	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 	"github.com/aws/amazon-ecs-agent/agent/utils/ttime"
@@ -75,7 +76,9 @@ func setup(cfg *config.Config, t *testing.T) (TaskEngine, func(), credentials.Ma
 		t.Fatalf("Error creating Docker client: %v", err)
 	}
 	credentialsManager := credentials.NewManager()
-	taskEngine := NewDockerTaskEngine(cfg, dockerClient, credentialsManager, eventstream.NewEventStream("ENGINEINTEGTEST", context.Background()))
+	state := dockerstate.NewDockerTaskEngineState()
+	imageManager := NewImageManager(dockerClient, state)
+	taskEngine := NewDockerTaskEngine(cfg, dockerClient, credentialsManager, eventstream.NewEventStream("ENGINEINTEGTEST", context.Background()), imageManager, state)
 	taskEngine.Init()
 	return taskEngine, func() {
 		taskEngine.Shutdown()

--- a/agent/engine/engine_mocks.go
+++ b/agent/engine/engine_mocks.go
@@ -17,8 +17,11 @@
 package engine
 
 import (
+	"time"
+
 	api "github.com/aws/amazon-ecs-agent/agent/api"
 	dockerclient "github.com/aws/amazon-ecs-agent/agent/engine/dockerclient"
+	image "github.com/aws/amazon-ecs-agent/agent/engine/image"
 	statemanager "github.com/aws/amazon-ecs-agent/agent/statemanager"
 	go_dockerclient "github.com/fsouza/go-dockerclient"
 	gomock "github.com/golang/mock/gomock"
@@ -229,6 +232,17 @@ func (_mr *_MockDockerClientRecorder) InspectContainer(arg0 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "InspectContainer", arg0)
 }
 
+func (_m *MockDockerClient) InspectImage(_param0 string) (*go_dockerclient.Image, error) {
+	ret := _m.ctrl.Call(_m, "InspectImage", _param0)
+	ret0, _ := ret[0].(*go_dockerclient.Image)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockDockerClientRecorder) InspectImage(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "InspectImage", arg0)
+}
+
 func (_m *MockDockerClient) ListContainers(_param0 bool) ListContainersResponse {
 	ret := _m.ctrl.Call(_m, "ListContainers", _param0)
 	ret0, _ := ret[0].(ListContainersResponse)
@@ -319,4 +333,89 @@ func (_m *MockDockerClient) WithVersion(_param0 dockerclient.DockerVersion) Dock
 
 func (_mr *_MockDockerClientRecorder) WithVersion(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WithVersion", arg0)
+}
+
+func (_m *MockDockerClient) RemoveImage(_param0 string, _param1 time.Duration) error {
+	ret := _m.ctrl.Call(_m, "RemoveImage", _param0, _param1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockDockerClientRecorder) RemoveImage(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveImage", arg0, arg1)
+}
+
+// Mock of ImageManager interface
+type MockImageManager struct {
+	ctrl     *gomock.Controller
+	recorder *_MockImageManagerRecorder
+}
+
+// Recorder for MockDockerClient (not exported)
+type _MockImageManagerRecorder struct {
+	mock *MockImageManager
+}
+
+func NewMockImageManager(ctrl *gomock.Controller) *MockImageManager {
+	mock := &MockImageManager{ctrl: ctrl}
+	mock.recorder = &_MockImageManagerRecorder{mock}
+	return mock
+}
+
+func (_m *MockImageManager) EXPECT() *_MockImageManagerRecorder {
+	return _m.recorder
+}
+
+func (_m *MockImageManager) AddContainerReferenceToImageState(_param0 *api.Container) error {
+	ret := _m.ctrl.Call(_m, "AddContainerReferenceToImageState", _param0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockImageManagerRecorder) AddContainerReferenceToImageState(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddContainerReferenceToImageState", arg0)
+}
+
+func (_m *MockImageManager) RemoveContainerReferenceFromImageState(_param0 *api.Container) error {
+	ret := _m.ctrl.Call(_m, "RemoveContainerReferenceFromImageState", _param0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockImageManagerRecorder) RemoveContainerReferenceFromImageState(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveContainerReferenceFromImageState", arg0)
+}
+
+func (_m *MockImageManager) StartImageCleanupProcess(_param0 context.Context) {
+	_m.ctrl.Call(_m, "StartImageCleanupProcess", _param0)
+}
+
+func (_mr *_MockImageManagerRecorder) StartImageCleanupProcess(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "StartImageCleanupProcess", arg0)
+}
+
+func (_m *MockImageManager) AddAllImageStates(_param0 []*image.ImageState) {
+	_m.ctrl.Call(_m, "AddAllImageStates", _param0)
+}
+
+func (_mr *_MockImageManagerRecorder) AddAllImageStates(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddAllImageStates", arg0)
+}
+
+func (_m *MockImageManager) GetImageStateFromImageName(_param0 string) *image.ImageState {
+	ret := _m.ctrl.Call(_m, "GetImageStateFromImageName", _param0)
+	ret0, _ := ret[0].(*image.ImageState)
+	return ret0
+}
+
+func (_mr *_MockImageManagerRecorder) GetImageStateFromImageName(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetImageStateFromImageName", arg0)
+}
+
+func (_m *MockImageManager) SetSaver(_param0 statemanager.Saver) {
+	_m.ctrl.Call(_m, "SetSaver", _param0)
+}
+
+func (_mr *_MockImageManagerRecorder) SetSaver(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetSaver", arg0)
 }

--- a/agent/engine/image/types.go
+++ b/agent/engine/image/types.go
@@ -1,0 +1,100 @@
+// Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package image
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/aws/amazon-ecs-agent/agent/api"
+	"github.com/cihub/seelog"
+)
+
+type Image struct {
+	ImageID string
+	Names   []string
+	Size    int64
+}
+
+// ImageState represents a docker image
+// and its state information such as containers associated with it
+type ImageState struct {
+	Image      *Image
+	Containers []*api.Container `json:"-"`
+	PulledAt   time.Time
+	LastUsedAt time.Time
+	updateLock sync.RWMutex
+}
+
+func (imageState *ImageState) UpdateContainerReference(container *api.Container) {
+	imageState.updateLock.Lock()
+	defer imageState.updateLock.Unlock()
+	seelog.Infof("Updating container reference %v in Image State - %v", container.Name, imageState.Image.ImageID)
+	imageState.Containers = append(imageState.Containers, container)
+}
+
+func (imageState *ImageState) AddImageName(imageName string) {
+	imageState.updateLock.Lock()
+	defer imageState.updateLock.Unlock()
+	if !imageState.HasImageName(imageName) {
+		seelog.Infof("Adding image name- %v to Image state- %v", imageName, imageState.Image.ImageID)
+		imageState.Image.Names = append(imageState.Image.Names, imageName)
+	}
+}
+
+func (imageState *ImageState) HasNoAssociatedContainers() bool {
+	return len(imageState.Containers) == 0
+}
+
+func (imageState *ImageState) UpdateImageState(container *api.Container) {
+	imageState.AddImageName(container.Image)
+	imageState.UpdateContainerReference(container)
+}
+
+func (imageState *ImageState) RemoveImageName(containerImageName string) {
+	imageState.updateLock.Lock()
+	defer imageState.updateLock.Unlock()
+	for i, imageName := range imageState.Image.Names {
+		if imageName == containerImageName {
+			imageState.Image.Names = append(imageState.Image.Names[:i], imageState.Image.Names[i+1:]...)
+		}
+	}
+}
+
+func (imageState *ImageState) HasImageName(containerImageName string) bool {
+	for _, imageName := range imageState.Image.Names {
+		if imageName == containerImageName {
+			return true
+		}
+	}
+	return false
+}
+
+func (imageState *ImageState) RemoveContainerReference(container *api.Container) error {
+	// Get the image state write lock for updating container reference
+	imageState.updateLock.Lock()
+	defer imageState.updateLock.Unlock()
+	for i, _ := range imageState.Containers {
+		if imageState.Containers[i].Name == container.Name {
+			// Container reference found; hence remove it
+			seelog.Infof("Removing Container Reference: %v from Image State- %v", container.Name, imageState.Image.ImageID)
+			imageState.Containers = append(imageState.Containers[:i], imageState.Containers[i+1:]...)
+			// Update the last used time for the image
+			imageState.LastUsedAt = time.Now()
+			return nil
+		}
+	}
+	return fmt.Errorf("Container reference is not found in the image state")
+}

--- a/agent/statemanager/state_manager.go
+++ b/agent/statemanager/state_manager.go
@@ -43,7 +43,8 @@ import (
 //      forward compatible)
 // 3) Add 'Protocol' field to 'portMappings' and 'KnownPortBindings'
 // 4) Add 'DockerConfig' struct
-const EcsDataVersion = 4
+// 5) Add 'ImageStates' struct as part of ImageManager
+const EcsDataVersion = 5
 
 // Filename in the ECS_DATADIR
 const ecsDataFile = "ecs_agent_data.json"

--- a/agent/statemanager/state_manager_test.go
+++ b/agent/statemanager/state_manager_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/api"
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/engine"
+	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	engine_testutils "github.com/aws/amazon-ecs-agent/agent/engine/testutils"
 	"github.com/aws/amazon-ecs-agent/agent/statemanager"
 )
@@ -49,7 +50,7 @@ func TestStateManager(t *testing.T) {
 
 	// Now let's make some state to save
 	containerInstanceArn := ""
-	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil)
+	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewDockerTaskEngineState())
 
 	manager, err = statemanager.NewStateManager(cfg, statemanager.AddSaveable("TaskEngine", taskEngine), statemanager.AddSaveable("ContainerInstanceArn", &containerInstanceArn))
 	if err != nil {
@@ -67,7 +68,7 @@ func TestStateManager(t *testing.T) {
 	}
 
 	// Now make sure we can load that state sanely
-	loadedTaskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil)
+	loadedTaskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewDockerTaskEngineState())
 	var loadedContainerInstanceArn string
 
 	manager, err = statemanager.NewStateManager(cfg, statemanager.AddSaveable("TaskEngine", &loadedTaskEngine), statemanager.AddSaveable("ContainerInstanceArn", &loadedContainerInstanceArn))
@@ -113,7 +114,7 @@ func TestStateManagerNonexistantDirectory(t *testing.T) {
 func TestLoadsV1DataCorrectly(t *testing.T) {
 	cfg := &config.Config{DataDir: filepath.Join(".", "testdata", "v1", "1")}
 
-	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil)
+	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewDockerTaskEngineState())
 	var containerInstanceArn, cluster, savedInstanceID string
 	var sequenceNumber int64
 

--- a/agent/stats/engine_integ_test.go
+++ b/agent/stats/engine_integ_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	ecsengine "github.com/aws/amazon-ecs-agent/agent/engine"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerclient"
+	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 	docker "github.com/fsouza/go-dockerclient"
@@ -335,8 +336,7 @@ func TestStatsEngineWithDockerTaskEngine(t *testing.T) {
 	}
 
 	containerChangeEventStream := eventStream("TestStatsEngineWithDockerTaskEngine")
-	taskEngine := ecsengine.NewTaskEngine(&config.Config{}, nil, nil, containerChangeEventStream)
-
+	taskEngine := ecsengine.NewTaskEngine(&config.Config{}, nil, nil, containerChangeEventStream, nil, dockerstate.NewDockerTaskEngineState())
 	container, err := createGremlin(client)
 	if err != nil {
 		t.Fatalf("Error creating container: %v", err)


### PR DESCRIPTION
Adding Mock ImageManager and corresponding changes

Refactoring changes and adding InspectImage method in DockerClient interface

Adding unit tests for Accounting Images in ImageManager

Handling Image name with multiple Image IDs and image manager tests

Retrieving Images for cleanup

Handling Image name with multiple Image IDs and image manager tests

Remove existing image name with different ImageId

Periodic Image Cleanup

Added unit tests for periodic image removal

Using context.WithTimeout instead of timer for RemoveImage

Fine grained locking in Image Manager

saving image manager states

Locking for pull and delete image operations and merge changes

Image State Manager changes and fixing tests

Image Manager unit tests

Image State failed to be removed not chosen for deletion again