### PR TITLE
Add functional test fof TaskIamRoles under net=host network mode

### DIFF
--- a/agent/functional_tests/README.md
+++ b/agent/functional_tests/README.md
@@ -31,15 +31,19 @@ The best way to run them is via the `make run-functional-tests` target.
 Thay may also be manually run with `go test -tags functional -v ./...`,
 
 ### Envrionment Variable
-In order to run Telemetry functional test in non Amazon Linux AMI environment, 
+In order to run Telemetry functional test in non Amazon Linux AMI environment,
 the following environment variables should be set:
   * CGROUP_PATH: cgroup path on the host, default value "/cgroup"
   * EXECDRIVER_PATH: execdriver path on the host, default value "/var/run/docker/execdriver"
+
 In order to run TaskIamRole functional test, the following steps should be done first:
-  * Run command: `sysctl -w net.ipv4.conf.all.route_localnet=1` and 
+  * Run command: `sysctl -w net.ipv4.conf.all.route_localnet=1` and
     `iptables -t nat -A PREROUTING -p tcp -d 169.254.170.2 --dport 80 -j DNAT --to-destination 127.0.0.1:51679`.
-  * Set the environment variable to enable the test: `export TEST_TASK_IAM_ROLE=true`.
+  * Set the environment variable to enable the test under default network mode: `export TEST_TASK_IAM_ROLE=true`.
   * Set the envrionment variable of IAM roles the test will use: `export TASK_IAM_ROLE_ARN="iam role arn"`,
   the role should have the `ec2:DescribeRegions` permission and have the trust relationship with "ecs-tasks.amazonaws.com".
   Or if the `TASK_IAM_ROLE_ARN` isn't set, it will use the IAM role attached to the instance profile. In this case,
   except the permissions required before, the IAM role should also have `iam:GetInstanceProfile` permission.
+  * Testing under net=host network mode requires additional command:
+    `iptables -t nat -A OUTPUT -d 169.254.170.2 -p tcp -m tcp --dport 80 -j REDIRECT --to-ports 51679` and
+    `export TEST_TASK_IAM_ROLE_NET_HOST=true`

--- a/agent/functional_tests/testdata/taskdefinitions/iam-roles/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/iam-roles/task-definition.json
@@ -1,6 +1,7 @@
 {
     "family": "ecsftest-iamrole-test",
     "taskRoleArn": "$$$TASK_ROLE$$$",
+    "networkMode": "$$$NETWORK_MODE$$$",
     "containerDefinitions": [{
         "memory": 100,
         "cpu": 100,

--- a/agent/functional_tests/tests/functionaltests_test.go
+++ b/agent/functional_tests/tests/functionaltests_test.go
@@ -740,11 +740,11 @@ func TestTaskIamRoles(t *testing.T) {
 	roleArn := os.Getenv("TASK_IAM_ROLE_ARN")
 	if utils.ZeroOrNil(roleArn) {
 		t.Logf("TASK_IAM_ROLE_ARN not set, will try to use the role attached to instance profile")
-		roles, err := GetInstanceIAMRole()
+		role, err := GetInstanceIAMRole()
 		if err != nil {
 			t.Fatalf("Error getting IAM Roles from instance profile, err: %v", err)
 		}
-		roleArn = *roles[0].Arn
+		roleArn = *role.Arn
 	}
 
 	agentOptions := &AgentOptions{

--- a/agent/functional_tests/util/utils.go
+++ b/agent/functional_tests/util/utils.go
@@ -754,27 +754,25 @@ func GetInstanceMetadata(path string) (string, error) {
 }
 
 // GetInstanceIAMRole gets the iam roles attached to the instance profile
-func GetInstanceIAMRole() ([]*iam.Role, error) {
-	instanceProfileName, err := GetInstanceMetadata("iam/security-credentials")
+func GetInstanceIAMRole() (*iam.Role, error) {
+	// This returns the name of the role
+	instanceRoleName, err := GetInstanceMetadata("iam/security-credentials")
 	if err != nil {
-		return nil, fmt.Errorf("Error getting instance profile name, err: %v", err)
+		return nil, fmt.Errorf("Error getting instance role name, err: %v", err)
 	}
-	if utils.ZeroOrNil(instanceProfileName) {
-		return nil, fmt.Errorf("Instance Profile name nil")
+	if utils.ZeroOrNil(instanceRoleName) {
+		return nil, fmt.Errorf("Instance Role name nil")
 	}
 
 	iamClient := iam.New(session.New())
-	instanceProfile, err := iamClient.GetInstanceProfile(&iam.GetInstanceProfileInput{
-		InstanceProfileName: aws.String(instanceProfileName),
+	instanceRole, err := iamClient.GetRole(&iam.GetRoleInput{
+		RoleName: aws.String(instanceRoleName),
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	if instanceProfile.InstanceProfile == nil || utils.ZeroOrNil(instanceProfile.InstanceProfile.Roles) {
-		return nil, fmt.Errorf("No roles found")
-	}
-	return instanceProfile.InstanceProfile.Roles, nil
+	return instanceRole.Role, nil
 }
 
 // SearchStrInDir searches the files in direcotry for specific content


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Add functional test fof TaskIamRoles under net=host network mode

### Implementation details
<!-- How are the changes implemented? -->
Using task definition with networkMode setting to host, launch the task and verify it can correctly get the credentials from agent.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make short-test` and `make test` can run anywhere in a development environment
like your laptop.  Please ensure both of these pass before opening the pull
request.  `make run-functional-tests` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` may incur charges to your AWS account; if you're
unable or unwilling to run these tests in your own account, we can run the tests
and provide test results.
-->
- [x] Builds (`make release`)
- [x] Unit tests (`make short-test`) pass
- [x] Integration tests (`make test`) pass
- [x] Functional tests (`make run-functional-tests`) pass

New tests cover the changes: <!-- yes|no -->
yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Added functional test for using Task IAM Role with net=host network mode.

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
r? @samuelkarp @aaithal @juanrhenals 