### PR TITLE
readme: Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,19 +19,27 @@ On the [Amazon Linux AMI](https://aws.amazon.com/amazon-linux-ami/), we provide 
 The Amazon ECS Container Agent may also be run in a Docker container on an EC2 instance with a recent Docker version installed. A Docker image is available in our [Docker Hub Repository](https://registry.hub.docker.com/u/amazon/amazon-ecs-agent/).
 
 ```bash
+$ # Set up directories the agent uses
 $ mkdir -p /var/log/ecs /etc/ecs /var/lib/ecs/data
 $ touch /etc/ecs/ecs.config
+$ # Set up necessary rules to enable IAM roles for tasks
+$ sysctl -w net.ipv4.conf.all.route_localnet=1
+$ iptables -t nat -A PREROUTING -p tcp -d 169.254.170.2 --dport 80 -j DNAT --to-destination 127.0.0.1:51679
+$ iptables -t nat -A OUTPUT -d 169.254.170.2 -p tcp -m tcp --dport 80 -j REDIRECT --to-ports 51679
+$ # Run the agent
 $ docker run --name ecs-agent \
-    --restart on-failure:10 -d \
-    -v /var/run/docker.sock:/var/run/docker.sock \
-    -v /var/log/ecs:/log \
-    -v /var/lib/ecs/data:/data \
-    -v /var/lib/docker:/var/lib/docker \
-    -p 127.0.0.1:51678:51678 \
-    --env-file /etc/ecs/ecs.config \
-    -e ECS_LOGFILE=/log/ecs-agent.log \
-    -e ECS_DATADIR=/data/ \
-    amazon/amazon-ecs-agent
+    --detach=true \
+    --restart=on-failure:10 -d \
+    --volume=/var/run/docker.sock:/var/run/docker.sock \
+    --volume=/var/log/ecs:/log \
+    --volume=/var/lib/ecs/data:/data \
+    --net=host \
+    --env-file=/etc/ecs/ecs.config \
+    --env=ECS_LOGFILE=/log/ecs-agent.log \
+    --env=ECS_DATADIR=/data/ \
+    --env=ECS_ENABLE_TASK_IAM_ROLE=true \
+    --env=ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST=true \
+    amazon/amazon-ecs-agent:latest
 ```
 
 See also the Advanced Usage section below.


### PR DESCRIPTION
### Summary
Updates the installation instructions in the README to be in sync with [our documentation](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-install.html).  This should help address some confusion (like in https://github.com/aws/amazon-ecs-agent/issues/511).

### Implementation details
No implementation.

### Testing
Followed these instructions on an Ubuntu 14.04 instance.

### Description for the changelog
No changelog description

### Licensing
This contribution is under the terms of the Apache 2.0 License: yes (Amazon employee)

r? @aaithal @nrdlngr