### PR TITLE
tcs: Fix payload log message

### DIFF
--- a/agent/tcs/client/client.go
+++ b/agent/tcs/client/client.go
@@ -91,7 +91,7 @@ func (cs *clientServer) MakeRequest(input interface{}) error {
 		return err
 	}
 
-	seelog.Debug("TCS client sending payload: %s", string(payload))
+	seelog.Debugf("TCS client sending payload: %s", string(payload))
 	data := cs.signRequest(payload)
 
 	// Over the wire we send something like


### PR DESCRIPTION
### Summary
Fix a log line that was incorrectly emitting `%s`.

### Implementation details
Changed `seelog.Debug` to `seelog.Debugf`

### Testing
- [x] Builds (`make release`)
- [x] Unit tests (`make short-test`) pass
- [ ] Integration tests (`make test`) pass
- [ ] Functional tests (`make run-functional-tests`) pass

New tests cover the changes: no

### Description for the changelog
No changelog

### Licensing
This contribution is under the terms of the Apache 2.0 License: yes (Amazon employee)

