### PR TITLE
Cache the ECR  authorizationToken

### DIFF
--- a/agent/engine/docker_container_engine_test.go
+++ b/agent/engine/docker_container_engine_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/ecr/mocks"
 	ecrapi "github.com/aws/amazon-ecs-agent/agent/ecr/model/ecr"
+	"github.com/aws/amazon-ecs-agent/agent/engine/dockerauth"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerclient"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerclient/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockeriface/mocks"
@@ -52,7 +53,7 @@ func dockerclientSetup(t *testing.T) (*mock_dockeriface.MockClient, *dockerGoCli
 	client, _ := NewDockerGoClient(factory, false, &conf)
 	goClient, _ := client.(*dockerGoClient)
 	ecrClientFactory := mock_ecr.NewMockECRFactory(ctrl)
-	goClient.ecrClientFactory = ecrClientFactory
+	goClient.ecrAuth = dockerauth.NewECRAuthProvider(ecrClientFactory)
 	goClient._time = mockTime
 	return mockDocker, goClient, mockTime, ctrl.Finish
 }
@@ -230,7 +231,7 @@ func TestPullImageECRSuccess(t *testing.T) {
 	ecrClientFactory := mock_ecr.NewMockECRFactory(ctrl)
 	ecrClient := mock_ecr.NewMockECRSDK(ctrl)
 	mockTime := mock_ttime.NewMockTime(ctrl)
-	goClient.ecrClientFactory = ecrClientFactory
+	goClient.ecrAuth = dockerauth.NewECRAuthProvider(ecrClientFactory)
 	goClient._time = mockTime
 
 	mockTime.EXPECT().After(gomock.Any()).AnyTimes()
@@ -293,7 +294,7 @@ func TestPullImageECRAuthFail(t *testing.T) {
 	ecrClientFactory := mock_ecr.NewMockECRFactory(ctrl)
 	ecrClient := mock_ecr.NewMockECRSDK(ctrl)
 	mockTime := mock_ttime.NewMockTime(ctrl)
-	goClient.ecrClientFactory = ecrClientFactory
+	goClient.ecrAuth = dockerauth.NewECRAuthProvider(ecrClientFactory)
 	goClient._time = mockTime
 
 	mockTime.EXPECT().After(gomock.Any()).AnyTimes()

--- a/agent/engine/dockerauth/ecr.go
+++ b/agent/engine/dockerauth/ecr.go
@@ -59,6 +59,7 @@ func (authProvider *EcrAuthProvider) GetAuthconfig(image string, authData *api.E
 
 	cachedAuthData := authProvider.authorizationDatas[registryId]
 	if cachedAuthData != nil {
+
 		allowTime := time.Now().Add(authDataTimeout)
 
 		if cachedAuthData.ExpiresAt != nil && cachedAuthData.ExpiresAt.After(allowTime) {

--- a/agent/engine/dockerauth/ecr.go
+++ b/agent/engine/dockerauth/ecr.go
@@ -17,6 +17,8 @@ import (
 	"encoding/base64"
 	"fmt"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
 	"github.com/aws/amazon-ecs-agent/agent/ecr"
@@ -26,47 +28,74 @@ import (
 	docker "github.com/fsouza/go-dockerclient"
 )
 
-type ecrAuthProvider struct {
-	authData *api.ECRAuthData
-	client   ecr.ECRSDK
+type EcrAuthProvider struct {
+	clientFactory          ecr.ECRFactory
+	authorizationDatasLock sync.Mutex
+	authorizationDatas     map[string]*ecrapi.AuthorizationData
 }
 
-const proxyEndpointScheme = "https://"
+const (
+	proxyEndpointScheme = "https://"
+	authDataTimeout     = 5 * time.Minute
+)
 
 // NewECRAuthProvider returns a DockerAuthProvider that can handle retrieve
 // credentials for pulling from Amazon EC2 Container Registry
-func NewECRAuthProvider(authData *api.ECRAuthData, clientFactory ecr.ECRFactory) DockerAuthProvider {
-	if authData == nil {
-		return &ecrAuthProvider{}
-	}
-	log.Tracef("Getting client in %s with endpoint %s", authData.Region, authData.EndpointOverride)
-	return &ecrAuthProvider{
-		authData: authData,
-		client:   clientFactory.GetClient(authData.Region, authData.EndpointOverride),
+func NewECRAuthProvider(clientFactory ecr.ECRFactory) EcrAuthProvider {
+	return EcrAuthProvider{
+		authorizationDatas: make(map[string]*ecrapi.AuthorizationData),
+		clientFactory:      clientFactory,
 	}
 }
 
 // GetAuthconfig retrieves the correct auth configuration for the given repository
-func (authProvider *ecrAuthProvider) GetAuthconfig(image string) (docker.AuthConfiguration, error) {
-	if authProvider.authData == nil {
-		return docker.AuthConfiguration{}, fmt.Errorf("ecrAuthProvider cannot be used without AuthData")
+func (authProvider *EcrAuthProvider) GetAuthconfig(image string, authData *api.ECRAuthData) (docker.AuthConfiguration, error) {
+	if authData == nil {
+		return docker.AuthConfiguration{}, fmt.Errorf("EcrAuthProvider cannot be used without AuthData")
 	}
+
 	log.Debugf("Calling ECR.GetAuthorizationToken for %s", image)
-	input := &ecrapi.GetAuthorizationTokenInput{
-		RegistryIds: []*string{aws.String(authProvider.authData.RegistryId)},
+	registryId := authData.RegistryId
+
+	cachedAuthData := authProvider.authorizationDatas[registryId]
+	if cachedAuthData != nil {
+		allowTime := time.Now().Add(authDataTimeout)
+
+		if cachedAuthData.ExpiresAt != nil && cachedAuthData.ExpiresAt.After(allowTime) {
+			log.Infof("Use cached token ", authData.Region, authData.EndpointOverride)
+			return extractToken(cachedAuthData)
+		} else {
+			authProvider.authorizationDatasLock.Lock()
+			delete(authProvider.authorizationDatas, registryId)
+			authProvider.authorizationDatasLock.Unlock()
+		}
 	}
-	output, err := authProvider.client.GetAuthorizationToken(input)
+
+	input := &ecrapi.GetAuthorizationTokenInput{
+		RegistryIds: []*string{aws.String(registryId)},
+	}
+
+	log.Infof("Getting client in %s with endpoint %s", authData.Region, authData.EndpointOverride)
+	client := authProvider.clientFactory.GetClient(authData.Region, authData.EndpointOverride)
+	output, err := client.GetAuthorizationToken(input)
+
 	if err != nil {
 		return docker.AuthConfiguration{}, err
 	}
+
 	if output == nil {
 		return docker.AuthConfiguration{}, fmt.Errorf("Missing AuthorizationData in ECR response for %s", image)
 	}
-	for _, authData := range output.AuthorizationData {
-		if authData.ProxyEndpoint != nil &&
-			strings.HasPrefix(proxyEndpointScheme+image, aws.StringValue(authData.ProxyEndpoint)) &&
-			authData.AuthorizationToken != nil {
-			return extractToken(authData)
+
+	for _, outputAuthData := range output.AuthorizationData {
+		if outputAuthData.ProxyEndpoint != nil &&
+			strings.HasPrefix(proxyEndpointScheme+image, aws.StringValue(outputAuthData.ProxyEndpoint)) &&
+			outputAuthData.AuthorizationToken != nil {
+
+			authProvider.authorizationDatasLock.Lock()
+			authProvider.authorizationDatas[registryId] = outputAuthData
+			authProvider.authorizationDatasLock.Unlock()
+			return extractToken(outputAuthData)
 		}
 	}
 	return docker.AuthConfiguration{}, fmt.Errorf("No AuthorizationToken found for %s", image)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This could fix #498.
Following the https://github.com/aws/amazon-ecs-agent/issues/498#issuecomment-243203690,
the reason of #498 is that `ecs-agent` call `GetAuthorizationToken` every task deployment.
This pull request will cache the tokenData and recycle it.

I'm newbie for golang. Any comment and suggestion are welcome. 

### Implementation details
This will delete `DockerAuthProvider` interface from `EcrAuthProvider` to add `api.ECRAuthData`
arg to `GetAuthconfig`. If you would like to keep the using DockerAuthProvider interface, 
I'll add the `authdata` argument to interface.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make short-test` and `make test` can run anywhere in a development environment
like your laptop.  Please ensure both of these pass before opening the pull
request.  `make run-functional-tests` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` may incur charges to your AWS account; if you're
unable or unwilling to run these tests in your own account, we can run the tests
and provide test results.
-->
- [x] Builds (`make release`)
- [x] Unit tests (`make short-test`) pass
- [x] Integration tests (`make test`) pass
- [ ] Functional tests (`make run-functional-tests`) pass

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: 
yes