### PR TITLE
Functional test for awslogs-stream name prefix

### DIFF
--- a/agent/functional_tests/testdata/taskdefinitions/awslogs/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/awslogs/task-definition.json
@@ -10,7 +10,8 @@
         "logDriver": "awslogs",
         "options": {
             "awslogs-group":"ecs-functional-tests",
-            "awslogs-region":"$$$TEST_REGION$$$"
+            "awslogs-region":"$$$TEST_REGION$$$",
+            "awslogs-stream-prefix":"ecs-functional-tests"
         }
     },
     "command": ["sh", "-c", "echo hello world"]

--- a/agent/functional_tests/tests/functionaltests_test.go
+++ b/agent/functional_tests/tests/functionaltests_test.go
@@ -567,9 +567,12 @@ func TestAwslogsDriver(t *testing.T) {
 		})
 	}()
 
+	strs := strings.Split(*testTask.TaskArn, "/")
+	taskId := strs[len(strs)-1]
+
 	params := &cloudwatchlogs.GetLogEventsInput{
 		LogGroupName:  aws.String(awslogsLogGroupName),
-		LogStreamName: aws.String(containerId),
+		LogStreamName: aws.String(fmt.Sprintf("ecs-functional-tests/awslogs/%s", taskId)),
 	}
 	resp, err := cwlClient.GetLogEvents(params)
 	if err != nil {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This pull request modified the functional test of awslogs driver to test 'awslogs-stream-prefix' option in task definition.

### Implementation details
<!-- How are the changes implemented? -->
Added the 'awslogs-stream-prefix' filed in task definition used to test. And verify the formatted stream name existed in cloudwatch logs with the expected content.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make short-test` and `make test` can run anywhere in a development environment
like your laptop.  Please ensure both of these pass before opening the pull
request.  `make run-functional-tests` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` may incur charges to your AWS account; if you're
unable or unwilling to run these tests in your own account, we can run the tests
and provide test results.
-->
- [x] Builds (`make release`)
- [x] Unit tests (`make short-test`) pass
- [x] Integration tests (`make test`) pass
- [x] Functional tests (`make run-functional-tests`) pass

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
No changelog

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: yes 