### PR TITLE
Bugfix: Stats engine reconciliation for missed remove events.

### DIFF
--- a/agent/api/container.go
+++ b/agent/api/container.go
@@ -28,9 +28,37 @@ func (c *Container) Overridden() *Container {
 }
 
 func (c *Container) KnownTerminal() bool {
-	return c.KnownStatus.Terminal()
+	return c.GetKnownStatus().Terminal()
 }
 
 func (c *Container) DesiredTerminal() bool {
-	return c.DesiredStatus.Terminal()
+	return c.GetDesiredStatus().Terminal()
+}
+
+func (c *Container) GetKnownStatus() ContainerStatus {
+	c.knownStatusLock.RLock()
+	defer c.knownStatusLock.RUnlock()
+
+	return c.KnownStatus
+}
+
+func (c *Container) SetKnownStatus(status ContainerStatus) {
+	c.knownStatusLock.Lock()
+	defer c.knownStatusLock.Unlock()
+
+	c.KnownStatus = status
+}
+
+func (c *Container) GetDesiredStatus() ContainerStatus {
+	c.desiredStatusLock.RLock()
+	defer c.desiredStatusLock.RUnlock()
+
+	return c.DesiredStatus
+}
+
+func (c *Container) SetDesiredStatus(status ContainerStatus) {
+	c.desiredStatusLock.Lock()
+	defer c.desiredStatusLock.Unlock()
+
+	c.DesiredStatus = status
 }

--- a/agent/api/task.go
+++ b/agent/api/task.go
@@ -176,8 +176,8 @@ func (task *Task) UpdateMountPoints(cont *Container, vols map[string]string) {
 // task's desired status
 func (task *Task) updateContainerDesiredStatus() {
 	for _, c := range task.Containers {
-		if c.DesiredStatus < task.DesiredStatus.ContainerStatus() {
-			c.DesiredStatus = task.DesiredStatus.ContainerStatus()
+		if c.GetDesiredStatus() < task.DesiredStatus.ContainerStatus() {
+			c.SetDesiredStatus(task.DesiredStatus.ContainerStatus())
 		}
 	}
 }
@@ -193,8 +193,9 @@ func (task *Task) updateTaskKnownStatus() (newStatus TaskStatus) {
 	// Set to a large 'impossible' status that can't be the min
 	earliestStatus := ContainerZombie
 	for _, cont := range task.Containers {
-		if cont.KnownStatus < earliestStatus {
-			earliestStatus = cont.KnownStatus
+		contKnownStatus := cont.GetKnownStatus()
+		if contKnownStatus < earliestStatus {
+			earliestStatus = contKnownStatus
 		}
 	}
 
@@ -475,7 +476,7 @@ func (task *Task) updateTaskDesiredStatus() {
 	// A task's desired status is stopped if any essential container is stopped
 	// Otherwise, the task's desired status is unchanged (typically running, but no need to change)
 	for _, cont := range task.Containers {
-		if cont.Essential && (cont.KnownStatus.Terminal() || cont.DesiredStatus.Terminal()) {
+		if cont.Essential && (cont.KnownTerminal() || cont.DesiredTerminal()) {
 			llog.Debug("Updating task desired status to stopped", "container", cont.Name)
 			task.DesiredStatus = TaskStopped
 		}

--- a/agent/api/types.go
+++ b/agent/api/types.go
@@ -211,7 +211,7 @@ func (t *Task) String() string {
 	res := fmt.Sprintf("%s:%s %s, Status: (%s->%s)", t.Family, t.Version, t.Arn, t.GetKnownStatus().String(), t.DesiredStatus.String())
 	res += " Containers: ["
 	for _, c := range t.Containers {
-		res += fmt.Sprintf("%s (%s->%s),", c.Name, c.KnownStatus.String(), c.DesiredStatus.String())
+		res += fmt.Sprintf("%s (%s->%s),", c.Name, c.GetKnownStatus().String(), c.GetDesiredStatus().String())
 	}
 	return res + "]"
 }
@@ -237,8 +237,11 @@ type Container struct {
 	DockerConfig           DockerConfig                `json:"dockerConfig"`
 	RegistryAuthentication *RegistryAuthenticationData `json:"registryAuthentication"`
 
-	DesiredStatus ContainerStatus `json:"desiredStatus"`
-	KnownStatus   ContainerStatus
+	DesiredStatus     ContainerStatus `json:"desiredStatus"`
+	desiredStatusLock sync.RWMutex
+
+	KnownStatus     ContainerStatus
+	knownStatusLock sync.RWMutex
 
 	// RunDependencies is a list of containers that must be run before
 	// this one is created
@@ -287,7 +290,7 @@ type ECRAuthData struct {
 }
 
 func (c *Container) String() string {
-	ret := fmt.Sprintf("%s(%s) (%s->%s)", c.Name, c.Image, c.KnownStatus.String(), c.DesiredStatus.String())
+	ret := fmt.Sprintf("%s(%s) (%s->%s)", c.Name, c.Image, c.GetKnownStatus().String(), c.GetDesiredStatus().String())
 	if c.KnownExitCode != nil {
 		ret += " - Exit: " + strconv.Itoa(*c.KnownExitCode)
 	}

--- a/agent/engine/docker_container_engine.go
+++ b/agent/engine/docker_container_engine.go
@@ -726,7 +726,7 @@ func (dg *dockerGoClient) Stats(id string, ctx context.Context) (<-chan *docker.
 	go func() {
 		statsErr := client.Stats(options)
 		if statsErr != nil {
-			seelog.Warnf("Error retrieving stats for container %s: %v", id, statsErr)
+			seelog.Infof("Error retrieving stats for container %s: %v", id, statsErr)
 		}
 	}()
 

--- a/agent/stats/engine_test.go
+++ b/agent/stats/engine_test.go
@@ -151,6 +151,9 @@ func TestStatsEngineAddRemoveContainers(t *testing.T) {
 	resolver.EXPECT().ResolveTask("c4").AnyTimes().Return(nil, fmt.Errorf("unmapped container"))
 	resolver.EXPECT().ResolveTask("c5").AnyTimes().Return(t2, nil)
 	resolver.EXPECT().ResolveTask("c6").AnyTimes().Return(t3, nil)
+	resolver.EXPECT().ResolveContainer(gomock.Any()).AnyTimes().Return(&api.DockerContainer{
+		Container: &api.Container{},
+	}, nil)
 	mockStatsChannel := make(chan *docker.Stats)
 	defer close(mockStatsChannel)
 	mockDockerClient.EXPECT().Stats(gomock.Any(), gomock.Any()).Return(mockStatsChannel, nil).AnyTimes()
@@ -275,6 +278,9 @@ func TestStatsEngineMetadataInStatsSets(t *testing.T) {
 	resolver := mock_resolver.NewMockContainerMetadataResolver(mockCtrl)
 	t1 := &api.Task{Arn: "t1", Family: "f1"}
 	resolver.EXPECT().ResolveTask("c1").AnyTimes().Return(t1, nil)
+	resolver.EXPECT().ResolveContainer(gomock.Any()).AnyTimes().Return(&api.DockerContainer{
+		Container: &api.Container{},
+	}, nil)
 
 	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestStatsEngineMetadataInStatsSets"))
 	engine.resolver = resolver

--- a/agent/stats/resolver/mock/resolver.go
+++ b/agent/stats/resolver/mock/resolver.go
@@ -42,6 +42,17 @@ func (_m *MockContainerMetadataResolver) EXPECT() *_MockContainerMetadataResolve
 	return _m.recorder
 }
 
+func (_m *MockContainerMetadataResolver) ResolveContainer(_param0 string) (*api.DockerContainer, error) {
+	ret := _m.ctrl.Call(_m, "ResolveContainer", _param0)
+	ret0, _ := ret[0].(*api.DockerContainer)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockContainerMetadataResolverRecorder) ResolveContainer(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ResolveContainer", arg0)
+}
+
 func (_m *MockContainerMetadataResolver) ResolveTask(_param0 string) (*api.Task, error) {
 	ret := _m.ctrl.Call(_m, "ResolveTask", _param0)
 	ret0, _ := ret[0].(*api.Task)

--- a/agent/stats/resolver/resolver.go
+++ b/agent/stats/resolver/resolver.go
@@ -20,4 +20,5 @@ import "github.com/aws/amazon-ecs-agent/agent/api"
 // ContainerMetadataResolver defines methods to resolve meta-data.
 type ContainerMetadataResolver interface {
 	ResolveTask(string) (*api.Task, error)
+	ResolveContainer(string) (*api.DockerContainer, error)
 }

--- a/agent/stats/types.go
+++ b/agent/stats/types.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	ecsengine "github.com/aws/amazon-ecs-agent/agent/engine"
+	"github.com/aws/amazon-ecs-agent/agent/stats/resolver"
 	"golang.org/x/net/context"
 )
 
@@ -47,6 +48,7 @@ type StatsContainer struct {
 	cancel            context.CancelFunc
 	client            ecsengine.DockerClient
 	statsQueue        *Queue
+	resolver          resolver.ContainerMetadataResolver
 }
 
 // taskDefinition encapsulates family and version strings for a task definition


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This is a quick fix for cases where stats engine might miss
'container removed' event from the docker task engine
event stream.

Without this fix, the stats engine will spin on
'docker stats' api until the container is removed.

This is mentioned as a quick fix because this is not addressing the
root-cause of why an event is sometimes being missed by the
stats engine.

There's also the case of 'container added' event being missed
which could cause metrics to be misrepresented.

This is also proposed as a fix for the issue #515.

There's a minor refactor of the task engine code where locks have been
added to protect api.Container status'es

### Implementation details
<!-- How are the changes implemented? -->

* `engine.GetInstanceMetrics()` is used to trigger a state reconciliation in stats engine
* `container.collect()` is used to check if the container is terminal when disconnected from `docker stats`

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make short-test` and `make test` can run anywhere in a development environment
like your laptop.  Please ensure both of these pass before opening the pull
request.  `make run-functional-tests` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` may incur charges to your AWS account; if you're
unable or unwilling to run these tests in your own account, we can run the tests
and provide test results.
-->
- [X] Builds (`make release`)
- [X] Unit tests (`make short-test`) pass
- [X] Integration tests (`make test`) pass
- [X] Functional tests (`make run-functional-tests`) pass
- Manual tests
 - [X] Built an agent, where 'stats engine' would deliberately ignore 'container removed' events and verified that it's still reconcile and not spin as it used to before this fix.

New tests cover the changes: Yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Fixes an issue where stats engine could miss 'remove' events and indefinitely query stats for stopped containers
### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: Yes (AWS employee)


