### PR TITLE
Adds support for security-opts=no-new-privileges

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,8 +76,11 @@ test-in-docker:
 	# Privileged needed for docker-in-docker so integ tests pass
 	docker run -v "$(shell pwd):/go/src/github.com/aws/amazon-ecs-agent" --privileged "amazon/amazon-ecs-agent-test:make"
 
-run-functional-tests: test-registry
+run-functional-tests: testnnp test-registry
 	. ./scripts/shared_env && go test -tags functional -timeout=30m -v ./agent/functional_tests/...
+
+testnnp:
+	cd misc/testnnp; $(MAKE) $(MFLAGS)
 
 netkitten:
 	cd misc/netkitten; $(MAKE) $(MFLAGS)
@@ -111,3 +114,4 @@ clean:
 	cd misc/netkitten; $(MAKE) $(MFLAGS) clean
 	cd misc/volumes-test; $(MAKE) $(MFLAGS) clean
 	cd misc/gremlin; $(MAKE) $(MFLAGS) clean
+	cd misc/testnnp; $(MAKE) $(MFLAGS) clean

--- a/agent/engine/dockerclient/versions.go
+++ b/agent/engine/dockerclient/versions.go
@@ -30,6 +30,7 @@ const (
 	Version_1_20 DockerVersion = "1.20"
 	Version_1_21 DockerVersion = "1.21"
 	Version_1_22 DockerVersion = "1.22"
+	Version_1_23 DockerVersion = "1.23"
 
 	defaultVersion = Version_1_17
 )
@@ -44,6 +45,7 @@ func init() {
 		Version_1_20,
 		Version_1_21,
 		Version_1_22,
+		Version_1_23,
 	}
 }
 

--- a/agent/engine/dockerclient/versions_test.go
+++ b/agent/engine/dockerclient/versions_test.go
@@ -165,6 +165,7 @@ func TestFindAvailableVersiosn(t *testing.T) {
 	mockClient120 := mock_dockeriface.NewMockClient(ctrl)
 	mockClient121 := mock_dockeriface.NewMockClient(ctrl)
 	mockClient122 := mock_dockeriface.NewMockClient(ctrl)
+	mockClient123 := mock_dockeriface.NewMockClient(ctrl)
 
 	expectedEndpoint := "expectedEndpoint"
 
@@ -185,7 +186,9 @@ func TestFindAvailableVersiosn(t *testing.T) {
 		case Version_1_21:
 			return mockClient121, nil
 		case Version_1_22:
-			return mockClient122, nil	
+			return mockClient122, nil
+		case Version_1_23:
+			return mockClient123, nil
 		default:
 			t.Fatal("Unrecognized version")
 		}
@@ -198,8 +201,9 @@ func TestFindAvailableVersiosn(t *testing.T) {
 	mockClient120.EXPECT().Ping()
 	mockClient121.EXPECT().Ping()
 	mockClient122.EXPECT().Ping()
+	mockClient123.EXPECT().Ping()
 
-	expectedVersions := []DockerVersion{Version_1_17, Version_1_19, Version_1_20, Version_1_21, Version_1_22}
+	expectedVersions := []DockerVersion{Version_1_17, Version_1_19, Version_1_20, Version_1_21, Version_1_22, Version_1_23}
 
 	factory := NewFactory(expectedEndpoint)
 	versions := factory.FindAvailableVersions()

--- a/agent/functional_tests/testdata/simpletests/security-opt-nonewprivileges.json
+++ b/agent/functional_tests/testdata/simpletests/security-opt-nonewprivileges.json
@@ -1,0 +1,10 @@
+{
+  "Name": "SecurityOptNoNewPrivileges",
+  "Description": "Check that security-opt=no-new-privileges works",
+  "TaskDefinition": "security-opt-nonewprivileges",
+  "Version": ">=1.12.1",
+  "Timeout": "2m",
+  "ExitCodes": {
+    "exit": 42
+  }
+}

--- a/agent/functional_tests/testdata/taskdefinitions/security-opt-nonewprivileges/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/security-opt-nonewprivileges/task-definition.json
@@ -1,0 +1,10 @@
+{
+  "family": "security-opt-nonewprivileges",
+  "containerDefinitions": [{
+    "image": "amazon/testnnp:make",
+    "name": "exit",
+    "portBindings": [],
+    "memory": 50,
+    "dockerSecurityOptions": ["no-new-privileges"]
+  }]
+}

--- a/misc/testnnp/Dockerfile
+++ b/misc/testnnp/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+FROM gcc:4.9
+COPY . /usr/src/
+WORKDIR /usr/src/
+RUN gcc -o testnnp testnnp.c
+RUN chmod +s ./testnnp
+# At the time of this writing:
+# ECS is not accepting --user=1000 (only accepts ^([a-z_][a-z0-9_-]{0,30})). 
+# So overriding USER here
+USER 1000
+CMD ["./testnnp"]

--- a/misc/testnnp/Makefile
+++ b/misc/testnnp/Makefile
@@ -1,0 +1,21 @@
+# Copyright 2014-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+.PHONY: all clean docker image
+
+all: image
+
+image:
+	docker build -f Dockerfile -t "amazon/testnnp:make" .
+
+clean:
+	docker rmi "amazon/testnnp:make"

--- a/misc/testnnp/testnnp.c
+++ b/misc/testnnp/testnnp.c
@@ -1,0 +1,26 @@
+/**
+Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"). You may
+not use this file except in compliance with the License. A copy of the
+License is located at
+
+http://aws.amazon.com/apache2.0/
+
+or in the "license" file accompanying this file. This file is distributed
+on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+express or implied. See the License for the specific language governing
+permissions and limitations under the License.
+*/
+
+#include <stdio.h>
+#include <unistd.h>
+#include <sys/types.h>
+
+int main(int argc, char *argv[])
+{
+	if(geteuid() == 0) {
+		return 1;
+	}
+	return 42;
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Adds support for security-opt=no-new-privileges

See https://github.com/docker/docker/issues/20329 for more information on support added by Docker around this.

### Testing
- [X] Builds (`make release`)
- [X] Unit tests (`make short-test`) pass
- [X] Integration tests (`make test`) pass
- [X] Functional tests (`make run-functional-tests`) pass

New tests cover the changes: yes, added new unit and functional tests around this feature

### Description for the changelog
Adds support for security-opts=no-new-privileges

### Licensing
This contribution is under the terms of the Apache 2.0 License: yes
