### PR TITLE
Fix issue #532

### DIFF
--- a/agent/wsclient/mock/utils/utils.go
+++ b/agent/wsclient/mock/utils/utils.go
@@ -39,11 +39,18 @@ func StartMockServer(t *testing.T, closeWS <-chan bool) (*httptest.Server, chan<
 			errChan <- err
 		}
 		go func() {
-			_, msg, err := ws.ReadMessage()
-			if err != nil {
-				errChan <- err
-			} else {
-				requestsChan <- string(msg)
+			for {
+				select {
+				case <-closeWS:
+					return
+				default:
+					_, msg, err := ws.ReadMessage()
+					if err != nil {
+						errChan <- err
+					} else {
+						requestsChan <- string(msg)
+					}
+				}
 			}
 		}()
 		for str := range serverChan {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Fix the issue #532 that tcs won't reconnect if the network connection is lost or inactive for long time.
### Implementation details
<!-- How are the changes implemented? -->
In tcs client Close() method, we need to send signal to the endPublish channel, which can only be able to send once. So change the Close() for timeout to Disconnect, as the Close will always be invoked in the defer.
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make short-test` and `make test` can run anywhere in a development environment
like your laptop.  Please ensure both of these pass before opening the pull
request.  `make run-functional-tests` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` may incur charges to your AWS account; if you're
unable or unwilling to run these tests in your own account, we can run the tests
and provide test results.
-->
- [x] Builds (`make release`)
- [x] Unit tests (`make short-test`) pass
- [x] Integration tests (`make test`) pass
- [x] Functional tests (`make run-functional-tests`) pass

New tests cover the changes: <!-- yes|no -->
yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Bug - Fixed an issue where Agent won't reconnect to the metrics endpoint if it loses network connectivity or if it's inactive for a long time.
### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
yes