### PR TITLE
Credentials v2 handler

### DIFF
--- a/agent/acs/handler/acs_handler_test.go
+++ b/agent/acs/handler/acs_handler_test.go
@@ -526,11 +526,11 @@ func TestStartSessionHandlesRefreshCredentialsMessages(t *testing.T) {
 				ARN: "t1",
 				IAMRoleCredentials: rolecredentials.IAMRoleCredentials{
 					RoleArn:         "r1",
-					AccessKeyId:     "newakid",
+					AccessKeyID:     "newakid",
 					SecretAccessKey: "newskid",
 					SessionToken:    "newstkn",
 					Expiration:      "later",
-					CredentialsId:   credentialsIdInRefreshMessage,
+					CredentialsID:   credentialsIdInRefreshMessage,
 				},
 			}
 			if !reflect.DeepEqual(updatedCredentials, expectedCreds) {

--- a/agent/acs/handler/payload_handler.go
+++ b/agent/acs/handler/payload_handler.go
@@ -191,7 +191,7 @@ func (payloadHandler *payloadRequestHandler) addPayloadTasks(payload *ecsacs.Pay
 				allTasksOK = false
 				continue
 			}
-			apiTask.SetCredentialsId(taskCredentials.IAMRoleCredentials.CredentialsId)
+			apiTask.SetCredentialsId(taskCredentials.IAMRoleCredentials.CredentialsID)
 		}
 		validTasks = append(validTasks, apiTask)
 	}
@@ -243,7 +243,7 @@ func (payloadHandler *payloadRequestHandler) addTasks(payload *ecsacs.PayloadMes
 			credentialsAcks = append(credentialsAcks, &ecsacs.IAMRoleCredentialsAckRequest{
 				MessageId:     payload.MessageId,
 				Expiration:    aws.String(creds.IAMRoleCredentials.Expiration),
-				CredentialsId: aws.String(creds.IAMRoleCredentials.CredentialsId),
+				CredentialsId: aws.String(creds.IAMRoleCredentials.CredentialsID),
 			})
 		}
 

--- a/agent/acs/handler/payload_handler_test.go
+++ b/agent/acs/handler/payload_handler_test.go
@@ -311,12 +311,12 @@ func TestHandlePayloadMessageCredentialsAckedWhenTaskAdded(t *testing.T) {
 		CredentialsId: aws.String(credentialsId),
 	}
 	expectedCredentials := credentials.IAMRoleCredentials{
-		AccessKeyId:     credentialsAccessKey,
+		AccessKeyID:     credentialsAccessKey,
 		Expiration:      credentialsExpiration,
 		RoleArn:         credentialsRoleArn,
 		SecretAccessKey: credentialsSecretKey,
 		SessionToken:    credentialsSessionToken,
-		CredentialsId:   credentialsId,
+		CredentialsID:   credentialsId,
 	}
 	err = validateTaskAndCredentials(taskCredentialsAckRequested, expectedCredentialsAck, addedTask, taskArn, expectedCredentials)
 	if err != nil {
@@ -553,12 +553,12 @@ func TestPayloadBufferHandlerWithCredentials(t *testing.T) {
 		CredentialsId: aws.String(firstTaskCredentialsId),
 	}
 	expectedCredentialsForFirstTask := credentials.IAMRoleCredentials{
-		AccessKeyId:     firstTaskCredentialsAccessKey,
+		AccessKeyID:     firstTaskCredentialsAccessKey,
 		Expiration:      firstTaskCredentialsExpiration,
 		RoleArn:         firstTaskCredentialsRoleArn,
 		SecretAccessKey: firstTaskCredentialsSecretKey,
 		SessionToken:    firstTaskCredentialsSessionToken,
-		CredentialsId:   firstTaskCredentialsId,
+		CredentialsID:   firstTaskCredentialsId,
 	}
 	err := validateTaskAndCredentials(firstTaskCredentialsAckRequested, expectedCredentialsAckForFirstTask, firstAddedTask, firstTaskArn, expectedCredentialsForFirstTask)
 	if err != nil {
@@ -573,12 +573,12 @@ func TestPayloadBufferHandlerWithCredentials(t *testing.T) {
 		CredentialsId: aws.String(secondTaskCredentialsId),
 	}
 	expectedCredentialsForSecondTask := credentials.IAMRoleCredentials{
-		AccessKeyId:     secondTaskCredentialsAccessKey,
+		AccessKeyID:     secondTaskCredentialsAccessKey,
 		Expiration:      secondTaskCredentialsExpiration,
 		RoleArn:         secondTaskCredentialsRoleArn,
 		SecretAccessKey: secondTaskCredentialsSecretKey,
 		SessionToken:    secondTaskCredentialsSessionToken,
-		CredentialsId:   secondTaskCredentialsId,
+		CredentialsID:   secondTaskCredentialsId,
 	}
 	err = validateTaskAndCredentials(secondTaskCredentialsAckRequested, expectedCredentialsAckForSecondTask, secondAddedTask, secondTaskArn, expectedCredentialsForSecondTask)
 	if err != nil {
@@ -597,7 +597,7 @@ func validateTaskAndCredentials(taskCredentialsAck, expectedCredentialsAckForTas
 	expectedTask := &api.Task{
 		Arn: expectedTaskArn,
 	}
-	expectedTask.SetCredentialsId(expectedTaskCredentials.CredentialsId)
+	expectedTask.SetCredentialsId(expectedTaskCredentials.CredentialsID)
 
 	if !reflect.DeepEqual(addedTask, expectedTask) {
 		return fmt.Errorf("Mismatch between expected and added tasks, expected: %v, added: %v", expectedTask, addedTask)

--- a/agent/acs/handler/refresh_credentials_handler_test.go
+++ b/agent/acs/handler/refresh_credentials_handler_test.go
@@ -49,11 +49,11 @@ var expectedCredentials = &credentials.TaskIAMRoleCredentials{
 	ARN: taskArn,
 	IAMRoleCredentials: credentials.IAMRoleCredentials{
 		RoleArn:         roleArn,
-		AccessKeyId:     accessKey,
+		AccessKeyID:     accessKey,
 		SecretAccessKey: secretKey,
 		SessionToken:    sessionToken,
 		Expiration:      expiration,
-		CredentialsId:   credentialsId,
+		CredentialsID:   credentialsId,
 	},
 }
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -247,7 +247,7 @@ func _main() int {
 	go handlers.ServeHttp(&containerInstanceArn, taskEngine, cfg)
 
 	// Start serving the endpoint to fetch IAM Role credentials
-	go credentialshandler.ServeHttp(credentialsManager, containerInstanceArn, cfg)
+	go credentialshandler.ServeHTTP(credentialsManager, containerInstanceArn, cfg)
 
 	// Start sending events to the backend
 	go eventhandler.HandleEngineEvents(taskEngine, client, stateManager)

--- a/agent/api/task_test.go
+++ b/agent/api/task_test.go
@@ -474,7 +474,7 @@ func TestGetCredentialsEndpointWhenCredentialsAreSet(t *testing.T) {
 	}
 
 	taskCredentials := &credentials.TaskIAMRoleCredentials{
-		IAMRoleCredentials: credentials.IAMRoleCredentials{CredentialsId: "credsid"},
+		IAMRoleCredentials: credentials.IAMRoleCredentials{CredentialsID: "credsid"},
 	}
 	credentialsManager.EXPECT().GetTaskCredentials(credentialsIdInTask).Return(taskCredentials, true)
 	task.initializeCredentialsEndpoint(credentialsManager)

--- a/agent/credentials/manager.go
+++ b/agent/credentials/manager.go
@@ -15,7 +15,6 @@ package credentials
 
 import (
 	"fmt"
-	"net/url"
 	"sync"
 
 	"github.com/aws/amazon-ecs-agent/agent/acs/model/ecsacs"
@@ -27,12 +26,18 @@ const (
 	CredentialsIDQueryParameterName = "id"
 
 	// CredentialsPath is the path to the credentials handler.
-	CredentialsPath = "/v1/credentials"
+	CredentialsPath = V2CredentialsPath
+
+	V1CredentialsPath = "/v1/credentials"
+	V2CredentialsPath = "/v2/credentials"
 
 	// credentialsEndpointRelativeURIFormat defines the relative URI format
 	// for the credentials endpoint. The place holders are the API Path and
-	// Query Parameters.
-	credentialsEndpointRelativeURIFormat = "%s?%s"
+	// credentials ID
+	credentialsEndpointRelativeURIFormat = v2CredentialsEndpointRelativeURIFormat
+
+	v1CredentialsEndpointRelativeURIFormat = "%s?" + CredentialsIDQueryParameterName + "=%s"
+	v2CredentialsEndpointRelativeURIFormat = "%s/%s"
 )
 
 // IAMRoleCredentials is used to save credentials sent by ACS
@@ -57,9 +62,7 @@ type TaskIAMRoleCredentials struct {
 // GenerateCredentialsEndpointRelativeURI generates the relative URI for the
 // credentials endpoint, for a given task id.
 func (roleCredentials *IAMRoleCredentials) GenerateCredentialsEndpointRelativeURI() string {
-	params := make(url.Values)
-	params[CredentialsIDQueryParameterName] = []string{roleCredentials.CredentialsID}
-	return fmt.Sprintf(credentialsEndpointRelativeURIFormat, CredentialsPath, params.Encode())
+	return fmt.Sprintf(credentialsEndpointRelativeURIFormat, CredentialsPath, roleCredentials.CredentialsID)
 }
 
 // credentialsManager implements the Manager interface. It is used to

--- a/agent/credentials/manager.go
+++ b/agent/credentials/manager.go
@@ -23,8 +23,8 @@ import (
 )
 
 const (
-	// CredentialsIdQueryParameterName is the name of GET query parameter for the task ID.
-	CredentialsIdQueryParameterName = "id"
+	// CredentialsIDQueryParameterName is the name of GET query parameter for the task ID.
+	CredentialsIDQueryParameterName = "id"
 
 	// CredentialsPath is the path to the credentials handler.
 	CredentialsPath = "/v1/credentials"
@@ -37,9 +37,9 @@ const (
 
 // IAMRoleCredentials is used to save credentials sent by ACS
 type IAMRoleCredentials struct {
-	CredentialsId   string `json:"-"`
+	CredentialsID   string `json:"-"`
 	RoleArn         string `json:"RoleArn"`
-	AccessKeyId     string `json:"AccessKeyId"`
+	AccessKeyID     string `json:"AccessKeyId"`
 	SecretAccessKey string `json:"SecretAccessKey"`
 	SessionToken    string `json:"Token"`
 	// Expiration is a string instead of a timestamp. This is to avoid any loss of context
@@ -58,7 +58,7 @@ type TaskIAMRoleCredentials struct {
 // credentials endpoint, for a given task id.
 func (roleCredentials *IAMRoleCredentials) GenerateCredentialsEndpointRelativeURI() string {
 	params := make(url.Values)
-	params[CredentialsIdQueryParameterName] = []string{roleCredentials.CredentialsId}
+	params[CredentialsIDQueryParameterName] = []string{roleCredentials.CredentialsID}
 	return fmt.Sprintf(credentialsEndpointRelativeURIFormat, CredentialsPath, params.Encode())
 }
 
@@ -75,10 +75,10 @@ type credentialsManager struct {
 // api.IAMRoleCredentials
 func IAMRoleCredentialsFromACS(roleCredentials *ecsacs.IAMRoleCredentials) IAMRoleCredentials {
 	return IAMRoleCredentials{
-		CredentialsId:   aws.StringValue(roleCredentials.CredentialsId),
+		CredentialsID:   aws.StringValue(roleCredentials.CredentialsId),
 		SessionToken:    aws.StringValue(roleCredentials.SessionToken),
 		RoleArn:         aws.StringValue(roleCredentials.RoleArn),
-		AccessKeyId:     aws.StringValue(roleCredentials.AccessKeyId),
+		AccessKeyID:     aws.StringValue(roleCredentials.AccessKeyId),
 		SecretAccessKey: aws.StringValue(roleCredentials.SecretAccessKey),
 		Expiration:      aws.StringValue(roleCredentials.Expiration),
 	}
@@ -98,7 +98,7 @@ func (manager *credentialsManager) SetTaskCredentials(taskCredentials TaskIAMRol
 
 	credentials := taskCredentials.IAMRoleCredentials
 	// Validate that credentials id is not empty
-	if credentials.CredentialsId == "" {
+	if credentials.CredentialsID == "" {
 		return fmt.Errorf("CredentialsId is empty")
 	}
 
@@ -108,13 +108,13 @@ func (manager *credentialsManager) SetTaskCredentials(taskCredentials TaskIAMRol
 	}
 
 	// Check if credentials exists for the given credentials id
-	taskCredentialsInMap, ok := manager.idToTaskCredentials[credentials.CredentialsId]
+	taskCredentialsInMap, ok := manager.idToTaskCredentials[credentials.CredentialsID]
 	if !ok {
 		// No existing credentials, create a new one
 		taskCredentialsInMap = &TaskIAMRoleCredentials{}
 	}
 	*taskCredentialsInMap = taskCredentials
-	manager.idToTaskCredentials[credentials.CredentialsId] = taskCredentialsInMap
+	manager.idToTaskCredentials[credentials.CredentialsID] = taskCredentialsInMap
 
 	return nil
 }

--- a/agent/credentials/manager_test.go
+++ b/agent/credentials/manager_test.go
@@ -35,8 +35,8 @@ func TestIAMRoleCredentialsFromACS(t *testing.T) {
 	}
 	credentials := IAMRoleCredentialsFromACS(acsCredentials)
 	expectedCredentials := IAMRoleCredentials{
-		CredentialsId:   "credsId",
-		AccessKeyId:     "keyId",
+		CredentialsID:   "credsId",
+		AccessKeyID:     "keyId",
 		Expiration:      "soon",
 		RoleArn:         "roleArn",
 		SecretAccessKey: "OhhSecret",
@@ -81,7 +81,7 @@ func TestSetTaskCredentialsNoCredentialsId(t *testing.T) {
 // error when credentials object with no task arn used to set credentials
 func TestSetTaskCredentialsNoTaskArn(t *testing.T) {
 	manager := NewManager()
-	err := manager.SetTaskCredentials(TaskIAMRoleCredentials{IAMRoleCredentials: IAMRoleCredentials{CredentialsId: "id"}})
+	err := manager.SetTaskCredentials(TaskIAMRoleCredentials{IAMRoleCredentials: IAMRoleCredentials{CredentialsID: "id"}})
 	if err == nil {
 		t.Error("Expected error adding credentials payload without credential id")
 	}
@@ -95,11 +95,11 @@ func TestSetAndGetTaskCredentialsHappyPath(t *testing.T) {
 		ARN: "t1",
 		IAMRoleCredentials: IAMRoleCredentials{
 			RoleArn:         "r1",
-			AccessKeyId:     "akid1",
+			AccessKeyID:     "akid1",
 			SecretAccessKey: "skid1",
 			SessionToken:    "stkn",
 			Expiration:      "ts",
-			CredentialsId:   "cid1",
+			CredentialsID:   "cid1",
 		},
 	}
 
@@ -119,11 +119,11 @@ func TestSetAndGetTaskCredentialsHappyPath(t *testing.T) {
 		ARN: "t1",
 		IAMRoleCredentials: IAMRoleCredentials{
 			RoleArn:         "r1",
-			AccessKeyId:     "akid2",
+			AccessKeyID:     "akid2",
 			SecretAccessKey: "skid2",
 			SessionToken:    "stkn2",
 			Expiration:      "ts2",
-			CredentialsId:   "cid1",
+			CredentialsID:   "cid1",
 		},
 	}
 	err = manager.SetTaskCredentials(updatedCredentials)
@@ -144,11 +144,11 @@ func TestSetAndGetTaskCredentialsHappyPath(t *testing.T) {
 func TestGenerateCredentialsEndpointRelativeURI(t *testing.T) {
 	credentials := IAMRoleCredentials{
 		RoleArn:         "r1",
-		AccessKeyId:     "akid1",
+		AccessKeyID:     "akid1",
 		SecretAccessKey: "skid1",
 		SessionToken:    "stkn",
 		Expiration:      "ts",
-		CredentialsId:   "cid1",
+		CredentialsID:   "cid1",
 	}
 	generatedURI := credentials.GenerateCredentialsEndpointRelativeURI()
 	url, err := url.Parse(generatedURI)
@@ -160,9 +160,9 @@ func TestGenerateCredentialsEndpointRelativeURI(t *testing.T) {
 		t.Errorf("Credentials Endpoint mismatch. Expected path: %s, got %s", CredentialsPath, url.Path)
 	}
 
-	id := url.Query().Get(CredentialsIdQueryParameterName)
+	id := url.Query().Get(CredentialsIDQueryParameterName)
 	if "cid1" != id {
-		t.Errorf("Credentials Endpoing mismatch. Expected value for %s: %s, got %s", CredentialsIdQueryParameterName, "cid1", id)
+		t.Errorf("Credentials Endpoing mismatch. Expected value for %s: %s, got %s", CredentialsIDQueryParameterName, "cid1", id)
 	}
 }
 
@@ -174,11 +174,11 @@ func TestRemoveExistingCredentials(t *testing.T) {
 		ARN: "t1",
 		IAMRoleCredentials: IAMRoleCredentials{
 			RoleArn:         "r1",
-			AccessKeyId:     "akid1",
+			AccessKeyID:     "akid1",
 			SecretAccessKey: "skid1",
 			SessionToken:    "stkn",
 			Expiration:      "ts",
-			CredentialsId:   "cid1",
+			CredentialsID:   "cid1",
 		},
 	}
 	err := manager.SetTaskCredentials(credentials)

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -62,7 +62,7 @@ func TestBatchContainerHappyPath(t *testing.T) {
 	defer ctrl.Finish()
 
 	roleCredentials := &credentials.TaskIAMRoleCredentials{
-		IAMRoleCredentials: credentials.IAMRoleCredentials{CredentialsId: "credsid"},
+		IAMRoleCredentials: credentials.IAMRoleCredentials{CredentialsID: "credsid"},
 	}
 	credentialsManager.EXPECT().GetTaskCredentials(credentialsId).Return(roleCredentials, true).AnyTimes()
 	credentialsManager.EXPECT().RemoveCredentials(credentialsId)

--- a/agent/engine/engine_integ_test.go
+++ b/agent/engine/engine_integ_test.go
@@ -1116,7 +1116,7 @@ func TestStartStopWithCredentials(t *testing.T) {
 
 	testTask := createTestTask("testStartWithCredentials")
 	taskCredentials := credentials.TaskIAMRoleCredentials{
-		IAMRoleCredentials: credentials.IAMRoleCredentials{CredentialsId: credentialsIdIntegTest},
+		IAMRoleCredentials: credentials.IAMRoleCredentials{CredentialsID: credentialsIdIntegTest},
 	}
 	credentialsManager.SetTaskCredentials(taskCredentials)
 	testTask.SetCredentialsId(credentialsIdIntegTest)

--- a/agent/handlers/credentials/handler.go
+++ b/agent/handlers/credentials/handler.go
@@ -140,7 +140,7 @@ func getV1CredentialsID(r *http.Request) string {
 }
 
 func getV2CredentialsID(r *http.Request) string {
-	if strings.HasPrefix(r.URL.String(), credentials.CredentialsPath+"/") {
+	if strings.HasPrefix(r.URL.Path, credentials.CredentialsPath+"/") {
 		return r.URL.String()[len(credentials.V2CredentialsPath+"/"):]
 	}
 	return ""

--- a/agent/handlers/credentials/handler.go
+++ b/agent/handlers/credentials/handler.go
@@ -112,7 +112,7 @@ func setupServer(credentialsManager credentials.Manager, auditLogger audit.Audit
 // containing credentials when found. The HTTP status code of 400 is returned otherwise.
 func credentialsV1RequestHandler(credentialsManager credentials.Manager, auditLogger audit.AuditLogger) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		credentialsID, ok := handlers.ValueFromRequest(r, credentials.CredentialsIdQueryParameterName)
+		credentialsID, ok := handlers.ValueFromRequest(r, credentials.CredentialsIDQueryParameterName)
 		if !ok {
 			credentialsID = ""
 		}

--- a/agent/handlers/credentials/handler_test.go
+++ b/agent/handlers/credentials/handler_test.go
@@ -33,7 +33,7 @@ const (
 	roleArn         = "r1"
 	accessKeyID     = "ak"
 	secretAccessKey = "sk"
-	credentialsId   = "credentialsId"
+	credentialsID   = "credentialsId"
 )
 
 // TestInvalidPath tests if HTTP status code 404 is returned when invalid path is queried.
@@ -45,7 +45,7 @@ func TestInvalidPath(t *testing.T) {
 // query parameters are not specified for the credentials endpoint.
 func TestCredentialsRequestWithNoArguments(t *testing.T) {
 	msg := &errorMessage{
-		Code:          NoIdInRequest,
+		Code:          NoIDInRequest,
 		Message:       "CredentialsV1Request: No ID in the request",
 		httpErrorCode: http.StatusBadRequest,
 	}
@@ -56,12 +56,12 @@ func TestCredentialsRequestWithNoArguments(t *testing.T) {
 // the credentials manager does not contain the credentials id specified in the query.
 func TestCredentialsRequestWhenCredentialsIdNotFound(t *testing.T) {
 	expectedErrorMessage := &errorMessage{
-		Code:          InvalidIdInRequest,
+		Code:          InvalidIDInRequest,
 		Message:       fmt.Sprintf("CredentialsV1Request: ID not found"),
 		httpErrorCode: http.StatusBadRequest,
 	}
 	_, err := getResponseForCredentialsRequestWithParameters(t, expectedErrorMessage.httpErrorCode,
-		expectedErrorMessage, credentialsId, func() (*credentials.TaskIAMRoleCredentials, bool) { return nil, false })
+		expectedErrorMessage, credentialsID, func() (*credentials.TaskIAMRoleCredentials, bool) { return nil, false })
 	if err != nil {
 		t.Fatalf("Error getting response body: %v", err)
 	}
@@ -76,7 +76,7 @@ func TestCredentialsRequestWhenCredentialsUninitialized(t *testing.T) {
 		httpErrorCode: http.StatusServiceUnavailable,
 	}
 	_, err := getResponseForCredentialsRequestWithParameters(t, expectedErrorMessage.httpErrorCode,
-		expectedErrorMessage, credentialsId, func() (*credentials.TaskIAMRoleCredentials, bool) { return nil, true })
+		expectedErrorMessage, credentialsID, func() (*credentials.TaskIAMRoleCredentials, bool) { return nil, true })
 	if err != nil {
 		t.Fatalf("Error getting response body: %v", err)
 	}
@@ -92,7 +92,7 @@ func TestCredentialsRequestWhenCredentialsFound(t *testing.T) {
 			SecretAccessKey: secretAccessKey,
 		},
 	}
-	body, err := getResponseForCredentialsRequestWithParameters(t, http.StatusOK, nil, credentialsId, func() (*credentials.TaskIAMRoleCredentials, bool) { return &creds, true })
+	body, err := getResponseForCredentialsRequestWithParameters(t, http.StatusOK, nil, credentialsID, func() (*credentials.TaskIAMRoleCredentials, bool) { return &creds, true })
 	if err != nil {
 		t.Fatalf("Error retrieving credentials response: %v", err)
 	}
@@ -164,7 +164,7 @@ func getResponseForCredentialsRequestWithParameters(t *testing.T, expectedStatus
 	auditLog.EXPECT().Log(gomock.Any(), gomock.Any(), gomock.Any())
 
 	params := make(url.Values)
-	params[credentials.CredentialsIdQueryParameterName] = []string{credentialsId}
+	params[credentials.CredentialsIdQueryParameterName] = []string{credentialsID}
 
 	req, _ := http.NewRequest("GET", credentials.CredentialsPath+"?"+params.Encode(), nil)
 	server.Handler.ServeHTTP(recorder, req)

--- a/agent/handlers/credentials/handler_test.go
+++ b/agent/handlers/credentials/handler_test.go
@@ -88,7 +88,7 @@ func TestCredentialsRequestWhenCredentialsFound(t *testing.T) {
 	creds := credentials.TaskIAMRoleCredentials{
 		IAMRoleCredentials: credentials.IAMRoleCredentials{
 			RoleArn:         roleArn,
-			AccessKeyId:     accessKeyID,
+			AccessKeyID:     accessKeyID,
 			SecretAccessKey: secretAccessKey,
 		},
 	}
@@ -105,8 +105,8 @@ func TestCredentialsRequestWhenCredentialsFound(t *testing.T) {
 	if roleArn != credentials.RoleArn {
 		t.Fatalf("Incorrect credentials received. Expected arn: %s, got: %s", roleArn, credentials.RoleArn)
 	}
-	if accessKeyID != credentials.AccessKeyId {
-		t.Fatalf("Incorrect credentials received. Expected Access Key: %s, got: %s", accessKeyID, credentials.AccessKeyId)
+	if accessKeyID != credentials.AccessKeyID {
+		t.Fatalf("Incorrect credentials received. Expected Access Key: %s, got: %s", accessKeyID, credentials.AccessKeyID)
 	}
 	if secretAccessKey != credentials.SecretAccessKey {
 		t.Fatalf("Incorrect credentials received. Expected Secret Key: %s, got: %s", secretAccessKey, credentials.SecretAccessKey)
@@ -164,7 +164,7 @@ func getResponseForCredentialsRequestWithParameters(t *testing.T, expectedStatus
 	auditLog.EXPECT().Log(gomock.Any(), gomock.Any(), gomock.Any())
 
 	params := make(url.Values)
-	params[credentials.CredentialsIdQueryParameterName] = []string{credentialsID}
+	params[credentials.CredentialsIDQueryParameterName] = []string{credentialsID}
 
 	req, _ := http.NewRequest("GET", credentials.CredentialsPath+"?"+params.Encode(), nil)
 	server.Handler.ServeHTTP(recorder, req)


### PR DESCRIPTION
### Summary
This pull request adds a new "V2" credentials handler that responds at `/v2/credentials/$id` in addition to the existing credentials handler that responds at `/v1/credentials?id=$id`.

### Implementation details
New handler + existing handler.  They share most code except for finding the credential ID.

I also fixed a bunch of warnings from gometalinter.

### Testing
- [x] Builds (`make release`)
- [x] Unit tests (`make short-test`) pass
- [x] Integration tests (`make test`) pass
- [x] Functional tests (`make run-functional-tests`) pass
- [x] Manually ran a task with a role, verified that the new route was passed in, verified that the task was able to use the role

New tests cover the changes: yes

### Description for the changelog
No changelog (no customer-facing change)

### Licensing
This contribution is under the terms of the Apache 2.0 License: yes (Amazon employee)

r? @aaithal @richardpen @nmeyerhans 
