### PR TITLE
Go 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 sudo: false
 go:
-    - 1.6
+    - 1.7
 before_install: ./scripts/hack/symlink-gopath-travisci
 install: make get-deps
 script:

--- a/agent/engine/default.go
+++ b/agent/engine/default.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-// The 'engine' package contains code for interacting with container-running backends and handling events from them.
+// Package engine contains code for interacting with container-running backends and handling events from them.
 // It supports Docker as the sole task engine type.
 package engine
 

--- a/agent/engine/docker_container_engine_test.go
+++ b/agent/engine/docker_container_engine_test.go
@@ -251,13 +251,13 @@ func TestPullImageECRSuccess(t *testing.T) {
 
 	mockTime.EXPECT().After(gomock.Any()).AnyTimes()
 
-	registryId := "123456789012"
+	registryID := "123456789012"
 	region := "eu-west-1"
 	endpointOverride := "my.endpoint"
 	authData := &api.RegistryAuthenticationData{
 		Type: "ecr",
 		ECRAuthData: &api.ECRAuthData{
-			RegistryId:       registryId,
+			RegistryId:       registryID,
 			Region:           region,
 			EndpointOverride: endpointOverride,
 		},
@@ -273,7 +273,7 @@ func TestPullImageECRSuccess(t *testing.T) {
 	}
 
 	ecrClientFactory.EXPECT().GetClient(region, endpointOverride).Return(ecrClient)
-	ecrClient.EXPECT().GetAuthorizationToken(registryId).Return(
+	ecrClient.EXPECT().GetAuthorizationToken(registryID).Return(
 		&ecrapi.AuthorizationData{
 			ProxyEndpoint:      aws.String("https://" + imageEndpoint),
 			AuthorizationToken: aws.String(base64.StdEncoding.EncodeToString([]byte(username + ":" + password))),
@@ -307,13 +307,13 @@ func TestPullImageECRAuthFail(t *testing.T) {
 
 	mockTime.EXPECT().After(gomock.Any()).AnyTimes()
 
-	registryId := "123456789012"
+	registryID := "123456789012"
 	region := "eu-west-1"
 	endpointOverride := "my.endpoint"
 	authData := &api.RegistryAuthenticationData{
 		Type: "ecr",
 		ECRAuthData: &api.ECRAuthData{
-			RegistryId:       registryId,
+			RegistryId:       registryID,
 			Region:           region,
 			EndpointOverride: endpointOverride,
 		},
@@ -372,8 +372,8 @@ func TestCreateContainerInspectTimeout(t *testing.T) {
 		mockDocker.EXPECT().InspectContainerWithContext("id", gomock.Any()).Return(nil, &DockerTimeoutError{}),
 	)
 	metadata := client.CreateContainer(config.Config, nil, config.Name, 1*time.Second)
-	if metadata.DockerId != "id" {
-		t.Error("Expected ID to be set even if inspect failed; was " + metadata.DockerId)
+	if metadata.DockerID != "id" {
+		t.Error("Expected ID to be set even if inspect failed; was " + metadata.DockerID)
 	}
 	if metadata.Error == nil {
 		t.Error("Expected error for inspect timeout")
@@ -401,7 +401,7 @@ func TestCreateContainer(t *testing.T) {
 	if metadata.Error != nil {
 		t.Error("Did not expect error")
 	}
-	if metadata.DockerId != "id" {
+	if metadata.DockerID != "id" {
 		t.Error("Wrong id")
 	}
 	if metadata.ExitCode != nil {
@@ -440,7 +440,7 @@ func TestStartContainer(t *testing.T) {
 	if metadata.Error != nil {
 		t.Error("Did not expect error")
 	}
-	if metadata.DockerId != "id" {
+	if metadata.DockerID != "id" {
 		t.Error("Wrong id")
 	}
 }
@@ -481,7 +481,7 @@ func TestStopContainer(t *testing.T) {
 	if metadata.Error != nil {
 		t.Error("Did not expect error")
 	}
-	if metadata.DockerId != "id" {
+	if metadata.DockerID != "id" {
 		t.Error("Wrong id")
 	}
 }
@@ -549,7 +549,7 @@ func TestContainerEvents(t *testing.T) {
 	}()
 
 	event := <-dockerEvents
-	if event.DockerId != "containerId" {
+	if event.DockerID != "containerId" {
 		t.Error("Wrong docker id")
 	}
 	if event.Status != api.ContainerCreated {
@@ -570,7 +570,7 @@ func TestContainerEvents(t *testing.T) {
 		events <- &docker.APIEvents{Type: "container", ID: "cid2", Status: "start"}
 	}()
 	event = <-dockerEvents
-	if event.DockerId != "cid2" {
+	if event.DockerID != "cid2" {
 		t.Error("Wrong docker id")
 	}
 	if event.Status != api.ContainerRunning {
@@ -600,8 +600,8 @@ func TestContainerEvents(t *testing.T) {
 
 	for i := 0; i < 2; i++ {
 		anEvent := <-dockerEvents
-		if anEvent.DockerId != "cid3"+strconv.Itoa(i) {
-			t.Error("Wrong container id: " + anEvent.DockerId)
+		if anEvent.DockerID != "cid3"+strconv.Itoa(i) {
+			t.Error("Wrong container id: " + anEvent.DockerID)
 		}
 		if anEvent.Status != api.ContainerStopped {
 			t.Error("Should be stopped")
@@ -658,7 +658,7 @@ func TestContainerEvents(t *testing.T) {
 		events <- &docker.APIEvents{Type: eventType, ID: "123", Status: eventStatus}
 		select {
 		case <-dockerEvents:
-			t.Error("No event should be available for %v", eventType)
+			t.Errorf("No event should be available for %v", eventType)
 		default:
 		}
 	}
@@ -690,7 +690,7 @@ func TestListContainers(t *testing.T) {
 		t.Error("Did not expect error")
 	}
 
-	containerIds := response.DockerIds
+	containerIds := response.DockerIDs
 	if len(containerIds) != 1 {
 		t.Error("Unexpected number of containers in list: ", len(containerIds))
 	}

--- a/agent/engine/docker_image_manager.go
+++ b/agent/engine/docker_image_manager.go
@@ -61,6 +61,7 @@ type dockerImageManager struct {
 // ImageStatesForDeletion is used for implementing the sort interface
 type ImageStatesForDeletion []*image.ImageState
 
+// NewImageManager returns a new ImageManager
 func NewImageManager(cfg *config.Config, client DockerClient, state *dockerstate.DockerTaskEngineState) ImageManager {
 	return &dockerImageManager{
 		client: client,

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -939,6 +939,8 @@ func TestGetTaskByArn(t *testing.T) {
 	eventStream := make(chan DockerContainerChangeEvent)
 	client.EXPECT().ContainerEvents(gomock.Any()).Return(eventStream, nil)
 	imageManager.EXPECT().AddAllImageStates(gomock.Any()).AnyTimes()
+	imageManager.EXPECT().AddContainerReferenceToImageState(gomock.Any()).AnyTimes()
+	imageManager.EXPECT().GetImageStateFromImageName(gomock.Any()).AnyTimes()
 	client.EXPECT().PullImage(gomock.Any(), gomock.Any()).AnyTimes() // TODO change to MaxTimes(1)
 	err := taskEngine.Init()
 	if err != nil {

--- a/agent/engine/engine_integ_test.go
+++ b/agent/engine/engine_integ_test.go
@@ -165,10 +165,10 @@ func createImageCleanupTestTask(taskName string) *api.Task {
 	}
 }
 
-var endpoint = utils.DefaultIfBlank(os.Getenv(DOCKER_ENDPOINT_ENV_VARIABLE), DOCKER_DEFAULT_ENDPOINT)
+var endpoint = utils.DefaultIfBlank(os.Getenv(DockerEndpointEnvVariable), DockerDefaultEndpoint)
 
 func removeImage(img string) {
-	removeEndpoint := utils.DefaultIfBlank(os.Getenv(DOCKER_ENDPOINT_ENV_VARIABLE), DOCKER_DEFAULT_ENDPOINT)
+	removeEndpoint := utils.DefaultIfBlank(os.Getenv(DockerEndpointEnvVariable), DockerDefaultEndpoint)
 	client, _ := docker.NewClient(removeEndpoint)
 
 	client.RemoveImage(img)
@@ -203,18 +203,18 @@ func TestStartStopUnpulledImage(t *testing.T) {
 
 	go taskEngine.AddTask(testTask)
 
-	expected_events := []api.TaskStatus{api.TaskRunning, api.TaskStopped}
+	expectedEvents := []api.TaskStatus{api.TaskRunning, api.TaskStopped}
 
 	for taskEvent := range taskEvents {
 		if taskEvent.TaskArn != testTask.Arn {
 			continue
 		}
-		expected_event := expected_events[0]
-		expected_events = expected_events[1:]
-		if taskEvent.Status != expected_event {
-			t.Error("Got event " + taskEvent.Status.String() + " but expected " + expected_event.String())
+		expectedEvent := expectedEvents[0]
+		expectedEvents = expectedEvents[1:]
+		if taskEvent.Status != expectedEvent {
+			t.Error("Got event " + taskEvent.Status.String() + " but expected " + expectedEvent.String())
 		}
-		if len(expected_events) == 0 {
+		if len(expectedEvents) == 0 {
 			break
 		}
 	}
@@ -238,18 +238,18 @@ func TestStartStopUnpulledImageDigest(t *testing.T) {
 
 	go taskEngine.AddTask(testTask)
 
-	expected_events := []api.TaskStatus{api.TaskRunning, api.TaskStopped}
+	expectedEvents := []api.TaskStatus{api.TaskRunning, api.TaskStopped}
 
 	for taskEvent := range taskEvents {
 		if taskEvent.TaskArn != testTask.Arn {
 			continue
 		}
-		expected_event := expected_events[0]
-		expected_events = expected_events[1:]
-		if taskEvent.Status != expected_event {
-			t.Error("Got event " + taskEvent.Status.String() + " but expected " + expected_event.String())
+		expectedEvent := expectedEvents[0]
+		expectedEvents = expectedEvents[1:]
+		if taskEvent.Status != expectedEvent {
+			t.Error("Got event " + taskEvent.Status.String() + " but expected " + expectedEvent.String())
 		}
-		if len(expected_events) == 0 {
+		if len(expectedEvents) == 0 {
 			break
 		}
 	}
@@ -625,18 +625,18 @@ func TestDockerCfgAuth(t *testing.T) {
 
 	go taskEngine.AddTask(testTask)
 
-	expected_events := []api.TaskStatus{api.TaskRunning}
+	expectedEvents := []api.TaskStatus{api.TaskRunning}
 
 	for taskEvent := range taskEvents {
 		if taskEvent.TaskArn != testTask.Arn {
 			continue
 		}
-		expected_event := expected_events[0]
-		expected_events = expected_events[1:]
-		if taskEvent.Status != expected_event {
-			t.Error("Got event " + taskEvent.Status.String() + " but expected " + expected_event.String())
+		expectedEvent := expectedEvents[0]
+		expectedEvents = expectedEvents[1:]
+		if taskEvent.Status != expectedEvent {
+			t.Error("Got event " + taskEvent.Status.String() + " but expected " + expectedEvent.String())
 		}
-		if len(expected_events) == 0 {
+		if len(expectedEvents) == 0 {
 			break
 		}
 	}
@@ -676,18 +676,18 @@ func TestDockerAuth(t *testing.T) {
 
 	go taskEngine.AddTask(testTask)
 
-	expected_events := []api.TaskStatus{api.TaskRunning}
+	expectedEvents := []api.TaskStatus{api.TaskRunning}
 
 	for taskEvent := range taskEvents {
 		if taskEvent.TaskArn != testTask.Arn {
 			continue
 		}
-		expected_event := expected_events[0]
-		expected_events = expected_events[1:]
-		if taskEvent.Status != expected_event {
-			t.Error("Got event " + taskEvent.Status.String() + " but expected " + expected_event.String())
+		expectedEvent := expectedEvents[0]
+		expectedEvents = expectedEvents[1:]
+		if taskEvent.Status != expectedEvent {
+			t.Error("Got event " + taskEvent.Status.String() + " but expected " + expectedEvent.String())
 		}
-		if len(expected_events) == 0 {
+		if len(expectedEvents) == 0 {
 			break
 		}
 	}
@@ -861,18 +861,18 @@ func TestSweepContainer(t *testing.T) {
 
 	go taskEngine.AddTask(testTask)
 
-	expected_events := []api.TaskStatus{api.TaskRunning, api.TaskStopped}
+	expectedEvents := []api.TaskStatus{api.TaskRunning, api.TaskStopped}
 
 	for taskEvent := range taskEvents {
 		if taskEvent.TaskArn != testTask.Arn {
 			continue
 		}
-		expected_event := expected_events[0]
-		expected_events = expected_events[1:]
-		if taskEvent.Status != expected_event {
-			t.Error("Got event " + taskEvent.Status.String() + " but expected " + expected_event.String())
+		expectedEvent := expectedEvents[0]
+		expectedEvents = expectedEvents[1:]
+		if taskEvent.Status != expectedEvent {
+			t.Error("Got event " + taskEvent.Status.String() + " but expected " + expectedEvent.String())
 		}
-		if len(expected_events) == 0 {
+		if len(expectedEvents) == 0 {
 			break
 		}
 	}
@@ -923,7 +923,7 @@ func TestInitOOMEvent(t *testing.T) {
 
 	go taskEngine.AddTask(testTask)
 
-	expected_events := []api.ContainerStatus{api.ContainerRunning, api.ContainerStopped}
+	expectedEvents := []api.ContainerStatus{api.ContainerRunning, api.ContainerStopped}
 
 	var contEvent api.ContainerStateChange
 	for contEvent = range contEvents {
@@ -931,12 +931,12 @@ func TestInitOOMEvent(t *testing.T) {
 			continue
 		}
 
-		expected_event := expected_events[0]
-		expected_events = expected_events[1:]
-		if contEvent.Status != expected_event {
-			t.Error("Got event " + contEvent.Status.String() + " but expected " + expected_event.String())
+		expectedEvent := expectedEvents[0]
+		expectedEvents = expectedEvents[1:]
+		if contEvent.Status != expectedEvent {
+			t.Error("Got event " + contEvent.Status.String() + " but expected " + expectedEvent.String())
 		}
-		if len(expected_events) == 0 {
+		if len(expectedEvents) == 0 {
 			break
 		}
 	}
@@ -1116,10 +1116,10 @@ func TestStartStopWithCredentials(t *testing.T) {
 
 	testTask := createTestTask("testStartWithCredentials")
 	taskCredentials := credentials.TaskIAMRoleCredentials{
-		IAMRoleCredentials: credentials.IAMRoleCredentials{CredentialsID: credentialsIdIntegTest},
+		IAMRoleCredentials: credentials.IAMRoleCredentials{CredentialsID: credentialsIDIntegTest},
 	}
 	credentialsManager.SetTaskCredentials(taskCredentials)
-	testTask.SetCredentialsId(credentialsIdIntegTest)
+	testTask.SetCredentialsId(credentialsIDIntegTest)
 
 	taskEvents, contEvents := taskEngine.TaskEvents()
 
@@ -1131,7 +1131,7 @@ func TestStartStopWithCredentials(t *testing.T) {
 
 	// When task is stopped, credentials should have been removed for the
 	// credentials id set in the task
-	_, ok := credentialsManager.GetTaskCredentials(credentialsIdIntegTest)
+	_, ok := credentialsManager.GetTaskCredentials(credentialsIDIntegTest)
 	if ok {
 		t.Error("Credentials not removed from credentials manager for stopped task")
 	}

--- a/agent/engine/errors.go
+++ b/agent/engine/errors.go
@@ -40,6 +40,7 @@ func (err *impossibleTransitionError) Error() string {
 }
 func (err *impossibleTransitionError) ErrorName() string { return "ImpossibleStateTransitionError" }
 
+// DockerTimeoutError is an error type for describing timeouts
 type DockerTimeoutError struct {
 	duration   time.Duration
 	transition string
@@ -48,26 +49,37 @@ type DockerTimeoutError struct {
 func (err *DockerTimeoutError) Error() string {
 	return "Could not transition to " + err.transition + "; timed out after waiting " + err.duration.String()
 }
+
+// ErrorName returns the name of the error
 func (err *DockerTimeoutError) ErrorName() string { return dockerTimeoutErrorName }
 
+// ContainerVanishedError is a type for describing a container that does not exist
 type ContainerVanishedError struct{}
 
-func (err ContainerVanishedError) Error() string     { return "No container matching saved ID found" }
+func (err ContainerVanishedError) Error() string { return "No container matching saved ID found" }
+
+// ErrorName returns the name of the error
 func (err ContainerVanishedError) ErrorName() string { return "ContainerVanishedError" }
 
+// CannotXContainerError is a type for errors involving containers
 type CannotXContainerError struct {
 	transition string
 	msg        string
 }
 
 func (err CannotXContainerError) Error() string { return err.msg }
+
+// ErrorName returns the name of the error
 func (err CannotXContainerError) ErrorName() string {
 	return "Cannot" + err.transition + "ContainerError"
 }
 
+// OutOfMemoryError is a type for errors caused by running out of memory
 type OutOfMemoryError struct{}
 
-func (err OutOfMemoryError) Error() string     { return "Container killed due to memory usage" }
+func (err OutOfMemoryError) Error() string { return "Container killed due to memory usage" }
+
+// ErrorName returns the name of the error
 func (err OutOfMemoryError) ErrorName() string { return "OutOfMemoryError" }
 
 // DockerStateError is a wrapper around the error docker puts in the '.State.Error' field of its inspect output.
@@ -76,6 +88,7 @@ type DockerStateError struct {
 	name        string
 }
 
+// NewDockerStateError creates a DockerStateError
 func NewDockerStateError(err string) DockerStateError {
 	// Add stringmatching logic as needed to provide better output than docker
 	return DockerStateError{
@@ -87,10 +100,13 @@ func NewDockerStateError(err string) DockerStateError {
 func (err DockerStateError) Error() string {
 	return err.dockerError
 }
+
+// ErrorName returns the name of the error
 func (err DockerStateError) ErrorName() string {
 	return err.name
 }
 
+// CannotGetDockerClientError is a type for failing to get a specific Docker client
 type CannotGetDockerClientError struct {
 	version dockerclient.DockerVersion
 	err     error
@@ -103,10 +119,12 @@ func (c CannotGetDockerClientError) Error() string {
 	return c.err.Error()
 }
 
+// ErrorName returns the name of the error
 func (CannotGetDockerClientError) ErrorName() string {
 	return "CannotGetDockerclientError"
 }
 
+// TaskStoppedBeforePullBeginError is a type for task errors involving pull
 type TaskStoppedBeforePullBeginError struct {
 	taskArn string
 }
@@ -115,6 +133,7 @@ func (err TaskStoppedBeforePullBeginError) Error() string {
 	return "Task stopped before image pull could begin for task: " + err.taskArn
 }
 
+// ErrorName returns the name of the error
 func (TaskStoppedBeforePullBeginError) ErrorName() string {
 	return "TaskStoppedBeforePullBeginError"
 }

--- a/agent/engine/interface.go
+++ b/agent/engine/interface.go
@@ -20,6 +20,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/statemanager"
 )
 
+// TaskEngine is an interface for the DockerTaskEngine
 type TaskEngine interface {
 	Init() error
 	MustInit()

--- a/agent/engine/repotag.go
+++ b/agent/engine/repotag.go
@@ -7,6 +7,7 @@
 // license that can be found in the LICENSE file.
 //
 // Modifications are Copyright 2016 Amazon.com, Inc. or its affiliates. Licensed under the Apache License 2.0
+
 package engine
 
 import "strings"

--- a/agent/engine/testdata/test_tasks/sleep5.json
+++ b/agent/engine/testdata/test_tasks/sleep5.json
@@ -1,1 +1,38 @@
-{"Arn":"arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1","Family":"sleep5","Version":"2","Containers":[{"Name":"sleep5","Image":"busybox","Command":["sleep","5"],"Cpu":10,"Memory":10,"Links":null,"volumesFrom":[],"mountPoints":[],"portMappings":[],"Essential":true,"EntryPoint":null,"environment":{},"overrides":{"command":null},"desiredStatus":"NONE","KnownStatus":"NONE","RunDependencies":null,"IsInternal":false,"AppliedStatus":"NONE","ApplyingError":null,"SentStatus":"NONE","KnownExitCode":null,"KnownPortBindings":null,"StatusLock":{}}],"volumes":[],"DesiredStatus":"RUNNING","KnownStatus":"NONE","KnownTime":"0001-01-01T00:00:00Z","SentStatus":"NONE"}
+{
+  "Arn":"arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1",
+  "Family":"sleep5",
+  "Version":"2",
+  "Containers":
+  [
+    {
+      "Name":"sleep5",
+      "Image":"busybox",
+      "Command":["sleep","5"],
+      "Cpu":10,
+      "Memory":10,
+      "Links":null,
+      "volumesFrom":[],
+      "mountPoints":[],
+      "portMappings":[],
+      "Essential":true,
+      "EntryPoint":null,
+      "environment":{},
+      "overrides":{"command":null},
+      "desiredStatus":"NONE",
+      "KnownStatus":"NONE",
+      "RunDependencies":null,
+      "IsInternal":false,
+      "AppliedStatus":"NONE",
+      "ApplyingError":null,
+      "SentStatus":"NONE",
+      "KnownExitCode":null,
+      "KnownPortBindings":null,
+      "StatusLock":{}
+    }
+  ],
+  "volumes":[],
+  "DesiredStatus":"RUNNING",
+  "KnownStatus":"NONE",
+  "KnownTime":"0001-01-01T00:00:00Z",
+  "SentStatus":"NONE"
+}

--- a/agent/engine/types.go
+++ b/agent/engine/types.go
@@ -16,6 +16,7 @@ package engine
 import "fmt"
 import "github.com/aws/amazon-ecs-agent/agent/api"
 
+// ContainerNotFound is a type for a missing container
 type ContainerNotFound struct {
 	TaskArn       string
 	ContainerName string
@@ -25,14 +26,16 @@ func (cnferror ContainerNotFound) Error() string {
 	return fmt.Sprintf("Could not find container '%s' in task '%s'", cnferror.ContainerName, cnferror.TaskArn)
 }
 
+// DockerContainerChangeEvent is a type for container change events
 type DockerContainerChangeEvent struct {
 	Status api.ContainerStatus
 
 	DockerContainerMetadata
 }
 
+// DockerContainerMetadata is a type for metadata about Docker containers
 type DockerContainerMetadata struct {
-	DockerId     string
+	DockerID     string
 	ExitCode     *int
 	PortBindings []api.PortBinding
 	Error        engineError
@@ -42,6 +45,6 @@ type DockerContainerMetadata struct {
 // ListContainersResponse encapsulates the response from the docker client for the
 // ListContainers call.
 type ListContainersResponse struct {
-	DockerIds []string
+	DockerIDs []string
 	Error     error
 }

--- a/agent/stats/engine.go
+++ b/agent/stats/engine.go
@@ -179,7 +179,7 @@ func (engine *DockerStatsEngine) addExistingContainers() error {
 		return listContainersResponse.Error
 	}
 
-	for _, containerID := range listContainersResponse.DockerIds {
+	for _, containerID := range listContainersResponse.DockerIDs {
 		engine.addContainer(containerID)
 	}
 
@@ -258,11 +258,11 @@ func (engine *DockerStatsEngine) handleDockerEvents(events ...interface{}) error
 
 		switch dockerContainerChangeEvent.Status {
 		case api.ContainerRunning:
-			engine.addContainer(dockerContainerChangeEvent.DockerId)
+			engine.addContainer(dockerContainerChangeEvent.DockerID)
 		case api.ContainerStopped:
-			engine.removeContainer(dockerContainerChangeEvent.DockerId)
+			engine.removeContainer(dockerContainerChangeEvent.DockerID)
 		default:
-			seelog.Debugf("Ignoring event for container, id: %s, status: %d", dockerContainerChangeEvent.DockerId, dockerContainerChangeEvent.Status)
+			seelog.Debugf("Ignoring event for container, id: %s, status: %d", dockerContainerChangeEvent.DockerID, dockerContainerChangeEvent.Status)
 		}
 	}
 

--- a/agent/stats/engine_integ_test.go
+++ b/agent/stats/engine_integ_test.go
@@ -47,7 +47,7 @@ const (
 	containerName         = "gremlin-container"
 )
 
-var endpoint = utils.DefaultIfBlank(os.Getenv(ecsengine.DOCKER_ENDPOINT_ENV_VARIABLE), ecsengine.DOCKER_DEFAULT_ENDPOINT)
+var endpoint = utils.DefaultIfBlank(os.Getenv(ecsengine.DockerEndpointEnvVariable), ecsengine.DockerDefaultEndpoint)
 
 var client, _ = docker.NewClient(endpoint)
 var clientFactory = dockerclient.NewFactory(endpoint)
@@ -163,7 +163,7 @@ func TestStatsEngineWithExistingContainers(t *testing.T) {
 	err = engine.containerChangeEventStream.WriteToEventStream(ecsengine.DockerContainerChangeEvent{
 		Status: api.ContainerRunning,
 		DockerContainerMetadata: ecsengine.DockerContainerMetadata{
-			DockerId: container.ID,
+			DockerID: container.ID,
 		},
 	})
 	if err != nil {
@@ -214,7 +214,7 @@ func TestStatsEngineWithExistingContainers(t *testing.T) {
 	err = engine.containerChangeEventStream.WriteToEventStream(ecsengine.DockerContainerChangeEvent{
 		Status: api.ContainerStopped,
 		DockerContainerMetadata: ecsengine.DockerContainerMetadata{
-			DockerId: container.ID,
+			DockerID: container.ID,
 		},
 	})
 	if err != nil {
@@ -277,7 +277,7 @@ func TestStatsEngineWithNewContainers(t *testing.T) {
 	err = engine.containerChangeEventStream.WriteToEventStream(ecsengine.DockerContainerChangeEvent{
 		Status: api.ContainerRunning,
 		DockerContainerMetadata: ecsengine.DockerContainerMetadata{
-			DockerId: container.ID,
+			DockerID: container.ID,
 		},
 	})
 	if err != nil {
@@ -321,7 +321,7 @@ func TestStatsEngineWithNewContainers(t *testing.T) {
 	err = engine.containerChangeEventStream.WriteToEventStream(ecsengine.DockerContainerChangeEvent{
 		Status: api.ContainerStopped,
 		DockerContainerMetadata: ecsengine.DockerContainerMetadata{
-			DockerId: container.ID,
+			DockerID: container.ID,
 		},
 	})
 	if err != nil {
@@ -410,7 +410,7 @@ func TestStatsEngineWithDockerTaskEngine(t *testing.T) {
 	err = containerChangeEventStream.WriteToEventStream(ecsengine.DockerContainerChangeEvent{
 		Status: api.ContainerRunning,
 		DockerContainerMetadata: ecsengine.DockerContainerMetadata{
-			DockerId: container.ID,
+			DockerID: container.ID,
 		},
 	})
 	if err != nil {
@@ -420,7 +420,7 @@ func TestStatsEngineWithDockerTaskEngine(t *testing.T) {
 	err = containerChangeEventStream.WriteToEventStream(ecsengine.DockerContainerChangeEvent{
 		Status: api.ContainerRunning,
 		DockerContainerMetadata: ecsengine.DockerContainerMetadata{
-			DockerId: unmappedContainer.ID,
+			DockerID: unmappedContainer.ID,
 		},
 	})
 	if err != nil {
@@ -455,7 +455,7 @@ func TestStatsEngineWithDockerTaskEngine(t *testing.T) {
 	err = containerChangeEventStream.WriteToEventStream(ecsengine.DockerContainerChangeEvent{
 		Status: api.ContainerStopped,
 		DockerContainerMetadata: ecsengine.DockerContainerMetadata{
-			DockerId: container.ID,
+			DockerID: container.ID,
 		},
 	})
 	if err != nil {
@@ -532,7 +532,7 @@ func TestStatsEngineWithDockerTaskEngineMissingRemoveEvent(t *testing.T) {
 	err = containerChangeEventStream.WriteToEventStream(ecsengine.DockerContainerChangeEvent{
 		Status: api.ContainerRunning,
 		DockerContainerMetadata: ecsengine.DockerContainerMetadata{
-			DockerId: container.ID,
+			DockerID: container.ID,
 		},
 	})
 	if err != nil {

--- a/misc/gremlin/Makefile
+++ b/misc/gremlin/Makefile
@@ -15,7 +15,7 @@
 all: gremlin image
 
 gremlin: gremlin.go
-	docker run -v $(shell pwd):/out -v $(shell pwd)/gremlin.go:/in/gremlin.go -e CGO_ENABLED=0 golang:1.6 go build -a -x -ldflags '-s' -o /out/gremlin /in/gremlin.go
+	docker run -v $(shell pwd):/out -v $(shell pwd)/gremlin.go:/in/gremlin.go -e CGO_ENABLED=0 golang:1.7 go build -a -x -ldflags '-s' -o /out/gremlin /in/gremlin.go
 
 image: gremlin
 	@./docker-image

--- a/misc/gremlin/Makefile
+++ b/misc/gremlin/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2014-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may
 # not use this file except in compliance with the License. A copy of the

--- a/misc/netkitten/Makefile
+++ b/misc/netkitten/Makefile
@@ -15,7 +15,7 @@
 all: netkitten image
 
 netkitten:
-	docker run -v $(shell pwd):/out -v $(shell pwd)/netkitten.go:/in/netkitten.go -e CGO_ENABLED=0 golang:1.6 go build -a -installsuffix cgo -ldflags '-s' -o /out/netkitten /in/netkitten.go
+	docker run -v $(shell pwd):/out -v $(shell pwd)/netkitten.go:/in/netkitten.go -e CGO_ENABLED=0 golang:1.7 go build -a -installsuffix cgo -ldflags '-s' -o /out/netkitten /in/netkitten.go
 
 image: netkitten
 	@./docker-image

--- a/misc/netkitten/Makefile
+++ b/misc/netkitten/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2014-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may
 # not use this file except in compliance with the License. A copy of the

--- a/scripts/dockerfiles/Dockerfile.build
+++ b/scripts/dockerfiles/Dockerfile.build
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-FROM golang:1.6
+FROM golang:1.7
 MAINTAINER Amazon Web Services, Inc.
 
 RUN mkdir /out

--- a/scripts/dockerfiles/Dockerfile.build
+++ b/scripts/dockerfiles/Dockerfile.build
@@ -1,4 +1,4 @@
-# Copyright 2014-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may
 # not use this file except in compliance with the License. A copy of the

--- a/scripts/dockerfiles/Dockerfile.cleanbuild
+++ b/scripts/dockerfiles/Dockerfile.cleanbuild
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-FROM golang:1.6
+FROM golang:1.7
 MAINTAINER Amazon Web Services, Inc.
 
 RUN mkdir /out

--- a/scripts/dockerfiles/Dockerfile.cleanbuild
+++ b/scripts/dockerfiles/Dockerfile.cleanbuild
@@ -1,4 +1,4 @@
-# Copyright 2014-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may
 # not use this file except in compliance with the License. A copy of the

--- a/scripts/dockerfiles/Dockerfile.test
+++ b/scripts/dockerfiles/Dockerfile.test
@@ -32,9 +32,9 @@ RUN apt-get update && apt-get install -y \
 		--no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*
 
-ENV GOLANG_VERSION 1.6.2
+ENV GOLANG_VERSION 1.7.1
 ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-ENV GOLANG_DOWNLOAD_SHA256 e40c36ae71756198478624ed1bb4ce17597b3c19d243f3f0899bb5740d56212a
+ENV GOLANG_DOWNLOAD_SHA256 43ad621c9b014cde8db17393dc108378d37bc853aa351a6c74bf6432c1bbd182
 
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
   && echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \

--- a/scripts/dockerfiles/Dockerfile.test
+++ b/scripts/dockerfiles/Dockerfile.test
@@ -1,4 +1,4 @@
-# Copyright 2014-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may
 # not use this file except in compliance with the License. A copy of the


### PR DESCRIPTION
### Summary
Moves us to Go 1.7 and fixes broken tests
Fixes https://github.com/aws/amazon-ecs-agent/issues/485

### Implementation details
Go 1.7 started failing tests where a goroutine failed after the test ended.  Some of our tests were doing this; they've now been fixed.

### Testing
- [x] Builds (`make release`)
- [x] Unit tests (`make short-test`) pass
- [x] Integration tests (`make test` and `make run-integ-tests`) pass
- [ ] Functional tests (`make run-functional-tests`) pass

New tests cover the changes: no, but old ones are fixed

### Description for the changelog
No changelog impact

### Licensing
This contribution is under the terms of the Apache 2.0 License: yes (Amazon employee)
