### PR TITLE
export port used for IAM credentials

### DIFF
--- a/scripts/dockerfiles/Dockerfile.release
+++ b/scripts/dockerfiles/Dockerfile.release
@@ -22,5 +22,5 @@ COPY ["LICENSE", "NOTICE", "/"]
 # https://golang.org/src/pkg/crypto/x509/root_unix.go
 COPY misc/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
-EXPOSE 51678
+EXPOSE 51678 51679
 ENTRYPOINT ["/agent"]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Exposes port 31679 so IAM credentials can be fetched

### Implementation details
added port to Dockerfile `EXPOSE` line

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make short-test` and `make test` can run anywhere in a development environment
like your laptop.  Please ensure both of these pass before opening the pull
request.  `make run-functional-tests` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` may incur charges to your AWS account; if you're
unable or unwilling to run these tests in your own account, we can run the tests
and provide test results.
-->
- [ ] Builds (`make release`)
- [ ] Unit tests (`make short-test`) pass
- [ ] Integration tests (`make test` and `make run-integ-tests`) pass
- [ ] Functional tests (`make run-functional-tests`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enhancement - Expose port 51679 so docker tasks can fetch IAM credentials

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: yes

The documentation for using IAM roles with docker tasks
states that when you are not using the amazon provided ECS OPTIMIZED
image, you need to fiddle with the iptables to route the special
IP 169.254.170.2 PORT 80 to 127.0.0.1:51679

https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html

However, this port is not listed as an exposable port via docker inspect
so it took me a sec to figure it out.  You can map the port manually anyway,
but this change makes things a little more obvious.

Now I'm not sure if this port isn't actually started in the event IAM
roles are not used, but this change shouldn't affect that since nothing
will be listening and the difference is zip.