### PR TITLE
Removed short-test target, use `make test` for unit test and `make run-integ-tests` for integration test

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,8 +24,8 @@ unable or unwilling to run these tests in your own account, we can run the tests
 and provide test results.
 -->
 - [ ] Builds (`make release`)
-- [ ] Unit tests (`make short-test`) pass
-- [ ] Integration tests (`make test` and `make run-integ-tests`) pass
+- [ ] Unit tests (`make test`) pass
+- [ ] Integration tests (`make run-integ-tests`) pass
 - [ ] Functional tests (`make run-functional-tests`) pass
 
 New tests cover the changes: <!-- yes|no -->

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ before_install: ./scripts/hack/symlink-gopath-travisci
 install: make get-deps
 script:
     # Full tests require building/running docker containers; short only for now
-    - cd $HOME/gopath/src/github.com/aws/amazon-ecs-agent; make short-test
+    - cd $HOME/gopath/src/github.com/aws/amazon-ecs-agent; make test

--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,8 @@ misc/certs/ca-certificates.crt:
 	docker build -t "amazon/amazon-ecs-agent-cert-source:make" misc/certs/
 	docker run "amazon/amazon-ecs-agent-cert-source:make" cat /etc/ssl/certs/ca-certificates.crt > misc/certs/ca-certificates.crt
 
-short-test:
-	. ./scripts/shared_env && go test -short -timeout=25s $(shell go list ./agent/... | grep -v /vendor/)
+test:
+	. ./scripts/shared_env && go test -timeout=25s -v -cover $(shell go list ./agent/... | grep -v /vendor/)
 
 benchmark-test:
 	. ./scripts/shared_env && go test -run=XX -bench=. $(shell go list ./agent/... | grep -v /vendor/)
@@ -67,9 +67,6 @@ benchmark-test:
 # Run our 'test' registry needed for integ and functional tests
 test-registry: netkitten volumes-test squid awscli image-cleanup-test-images
 	@./scripts/setup-test-registry
-
-test: test-registry gremlin
-	. ./scripts/shared_env && go test -tags unit -timeout=180s -v -cover $(shell go list ./agent/... | grep -v /vendor/)
 
 test-in-docker:
 	docker build -f scripts/dockerfiles/Dockerfile.test -t "amazon/amazon-ecs-agent-test:make" .
@@ -82,8 +79,8 @@ run-functional-tests: testnnp test-registry
 testnnp:
 	cd misc/testnnp; $(MAKE) $(MFLAGS)
 
-run-integ-tests: test-registry
-	. ./scripts/shared_env && go test -tags integration -timeout=5m -v ./agent/engine/...
+run-integ-tests: test-registry gremlin
+	. ./scripts/shared_env && go test -tags integration -timeout=5m -v ./agent/engine/... ./agent/stats/...
 
 netkitten:
 	cd misc/netkitten; $(MAKE) $(MFLAGS)

--- a/agent/engine/docker_image_manager_integ_test.go
+++ b/agent/engine/docker_image_manager_integ_test.go
@@ -1,4 +1,4 @@
-// +build integration !unit
+// +build integration
 // Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/engine/engine_integ_test.go
+++ b/agent/engine/engine_integ_test.go
@@ -1,4 +1,4 @@
-// +build integration !unit
+// +build integration
 // Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
@@ -57,9 +57,6 @@ func setupWithDefaultConfig(t *testing.T) (TaskEngine, func(), credentials.Manag
 }
 
 func setup(cfg *config.Config, t *testing.T) (TaskEngine, func(), credentials.Manager) {
-	if testing.Short() {
-		t.Skip("Skipping integ test in short mode")
-	}
 	if _, err := os.Stat("/var/run/docker.sock"); err != nil {
 		t.Skip("Docker not running")
 	}

--- a/agent/functional_tests/util/compare_versions_test.go
+++ b/agent/functional_tests/util/compare_versions_test.go
@@ -1,4 +1,4 @@
-// +build functional !unit
+// +build functional
 // Copyright 2014-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/stats/common_test.go
+++ b/agent/stats/common_test.go
@@ -1,0 +1,225 @@
+// Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package stats
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/aws/amazon-ecs-agent/agent/api"
+	"github.com/aws/amazon-ecs-agent/agent/config"
+	ecsengine "github.com/aws/amazon-ecs-agent/agent/engine"
+	"github.com/aws/amazon-ecs-agent/agent/engine/dockerclient"
+	"github.com/aws/amazon-ecs-agent/agent/eventstream"
+	"github.com/aws/amazon-ecs-agent/agent/statemanager"
+	"github.com/aws/amazon-ecs-agent/agent/tcs/model/ecstcs"
+	"github.com/aws/amazon-ecs-agent/agent/utils"
+	docker "github.com/fsouza/go-dockerclient"
+
+	"golang.org/x/net/context"
+)
+
+const (
+	// checkPointSleep is the sleep duration in milliseconds between
+	// starting/stopping containers in the test code.
+	checkPointSleep = 5 * SleepBetweenUsageDataCollection
+	testImageName   = "amazon/amazon-ecs-gremlin:make"
+
+	// defaultDockerTimeoutSeconds is the timeout for dialing the docker remote API.
+	defaultDockerTimeoutSeconds uint = 10
+
+	// waitForCleanupSleep is the sleep duration in milliseconds
+	// for the waiting after container cleanup before checking the state of the manager.
+	waitForCleanupSleep = 10 * time.Millisecond
+
+	taskArn               = "gremlin"
+	taskDefinitionFamily  = "docker-gremlin"
+	taskDefinitionVersion = "1"
+	containerName         = "gremlin-container"
+)
+
+var endpoint = utils.DefaultIfBlank(os.Getenv(ecsengine.DockerEndpointEnvVariable), ecsengine.DockerDefaultEndpoint)
+
+var client, _ = docker.NewClient(endpoint)
+var clientFactory = dockerclient.NewFactory(endpoint)
+var cfg = config.DefaultConfig()
+
+var dockerClient ecsengine.DockerClient
+var defaultCluster = "default"
+var defaultContainerInstance = "ci"
+
+func init() {
+	cfg.EngineAuthData = config.NewSensitiveRawMessage([]byte{})
+	dockerClient, _ = ecsengine.NewDockerGoClient(clientFactory, false, &cfg)
+}
+
+// eventStream returns the event stream used to receive container change events
+func eventStream(name string) *eventstream.EventStream {
+	eventStream := eventstream.NewEventStream(name, context.Background())
+	eventStream.StartListening()
+	return eventStream
+}
+
+// createGremlin creates the gremlin container using the docker client.
+// It is used only in the test code.
+func createGremlin(client *docker.Client) (*docker.Container, error) {
+	container, err := client.CreateContainer(docker.CreateContainerOptions{
+		Config: &docker.Config{
+			Image: testImageName,
+		},
+	})
+
+	return container, err
+}
+
+type IntegContainerMetadataResolver struct {
+	containerIDToTask            map[string]*api.Task
+	containerIDToDockerContainer map[string]*api.DockerContainer
+}
+
+func newIntegContainerMetadataResolver() *IntegContainerMetadataResolver {
+	resolver := IntegContainerMetadataResolver{
+		containerIDToTask:            make(map[string]*api.Task),
+		containerIDToDockerContainer: make(map[string]*api.DockerContainer),
+	}
+
+	return &resolver
+}
+
+func (resolver *IntegContainerMetadataResolver) ResolveTask(containerID string) (*api.Task, error) {
+	task, exists := resolver.containerIDToTask[containerID]
+	if !exists {
+		return nil, fmt.Errorf("unmapped container")
+	}
+
+	return task, nil
+}
+
+func (resolver *IntegContainerMetadataResolver) ResolveContainer(containerID string) (*api.DockerContainer, error) {
+	container, exists := resolver.containerIDToDockerContainer[containerID]
+	if !exists {
+		return nil, fmt.Errorf("unmapped container")
+	}
+
+	return container, nil
+}
+
+func validateContainerMetrics(containerMetrics []*ecstcs.ContainerMetric, expected int) error {
+	if len(containerMetrics) != expected {
+		return fmt.Errorf("Mismatch in number of ContainerStatsSet elements. Expected: %d, Got: %d", expected, len(containerMetrics))
+	}
+	for _, containerMetric := range containerMetrics {
+		if containerMetric.CpuStatsSet == nil {
+			return fmt.Errorf("CPUStatsSet is nil")
+		}
+		if containerMetric.MemoryStatsSet == nil {
+			return fmt.Errorf("MemoryStatsSet is nil")
+		}
+	}
+	return nil
+}
+
+func validateIdleContainerMetrics(engine *DockerStatsEngine) error {
+	metadata, taskMetrics, err := engine.GetInstanceMetrics()
+	if err != nil {
+		return err
+	}
+	err = validateMetricsMetadata(metadata)
+	if err != nil {
+		return err
+	}
+	if !*metadata.Idle {
+		return fmt.Errorf("Expected idle metadata to be true")
+	}
+	if !*metadata.Fin {
+		return fmt.Errorf("Fin not set to true when idle")
+	}
+	if len(taskMetrics) != 0 {
+		return fmt.Errorf("Expected empty task metrics, got a list of length: %d", len(taskMetrics))
+	}
+
+	return nil
+}
+
+func validateMetricsMetadata(metadata *ecstcs.MetricsMetadata) error {
+	if metadata == nil {
+		return fmt.Errorf("Metadata is nil")
+	}
+	if *metadata.Cluster != defaultCluster {
+		return fmt.Errorf("Expected cluster in metadata to be: %s, got %s", defaultCluster, *metadata.Cluster)
+	}
+	if *metadata.ContainerInstance != defaultContainerInstance {
+		return fmt.Errorf("Expected container instance in metadata to be %s, got %s", defaultContainerInstance, *metadata.ContainerInstance)
+	}
+	if len(*metadata.MessageId) == 0 {
+		return fmt.Errorf("Empty MessageId")
+	}
+
+	return nil
+}
+
+func createFakeContainerStats() []*ContainerStats {
+	return []*ContainerStats{
+		&ContainerStats{22400432, 1839104, parseNanoTime("2015-02-12T21:22:05.131117533Z")},
+		&ContainerStats{116499979, 3649536, parseNanoTime("2015-02-12T21:22:05.232291187Z")},
+	}
+}
+
+type MockTaskEngine struct {
+}
+
+func (engine *MockTaskEngine) Init() error {
+	return nil
+}
+func (engine *MockTaskEngine) MustInit() {
+}
+
+func (engine *MockTaskEngine) TaskEvents() (<-chan api.TaskStateChange, <-chan api.ContainerStateChange) {
+	return make(chan api.TaskStateChange), make(chan api.ContainerStateChange)
+}
+
+func (engine *MockTaskEngine) SetSaver(statemanager.Saver) {
+}
+
+func (engine *MockTaskEngine) AddTask(*api.Task) error {
+	return nil
+}
+
+func (engine *MockTaskEngine) ListTasks() ([]*api.Task, error) {
+	return nil, nil
+}
+
+func (engine *MockTaskEngine) GetTaskByArn(arn string) (*api.Task, bool) {
+	return nil, false
+}
+
+func (engine *MockTaskEngine) UnmarshalJSON([]byte) error {
+	return nil
+}
+
+func (engine *MockTaskEngine) MarshalJSON() ([]byte, error) {
+	return make([]byte, 0), nil
+}
+
+func (engine *MockTaskEngine) Version() (string, error) {
+	return "", nil
+}
+
+func (engine *MockTaskEngine) Capabilities() []string {
+	return []string{}
+}
+
+func (engine *MockTaskEngine) Disable() {
+}

--- a/agent/stats/container_test.go
+++ b/agent/stats/container_test.go
@@ -1,3 +1,4 @@
+//+build !integration
 // Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
@@ -27,10 +28,6 @@ import (
 	"github.com/golang/mock/gomock"
 	"golang.org/x/net/context"
 )
-
-// checkPointSleep is the sleep duration in milliseconds between
-// starting/stopping containers in the test code.
-const checkPointSleep = 5 * SleepBetweenUsageDataCollection
 
 type StatTestData struct {
 	timestamp time.Time

--- a/agent/stats/queue_test.go
+++ b/agent/stats/queue_test.go
@@ -1,3 +1,4 @@
+//+build !integration
 // Copyright 2014-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/stats/utils_test.go
+++ b/agent/stats/utils_test.go
@@ -1,3 +1,4 @@
+//+build !integration
 // Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Removed `short-test` target and using `test` and `run-integ-tests` to run all the tests in agent.
### Implementation details
<!-- How are the changes implemented? -->
Included integration test file in agent/stats/ to `run-integ-tests` target, so that `make run-integ-tests` will run all the integration test. And `make test` will run all the unit test.
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make short-test` and `make test` can run anywhere in a development environment
like your laptop.  Please ensure both of these pass before opening the pull
request.  `make run-functional-tests` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` may incur charges to your AWS account; if you're
unable or unwilling to run these tests in your own account, we can run the tests
and provide test results.
-->
- [x] Builds (`make release`)
- [x] Unit tests (`make test`) pass
- [x] Integration tests (`make run-integ-tests`) pass
- [x] Functional tests (`make run-functional-tests`) pass

New tests cover the changes: <!-- yes|no -->
yes
### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
no change log
### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
yes
