### PR TITLE
Fix metrics drop when using CoreOS kernel >= 1122.2.0

### DIFF
--- a/agent/acs/handler/acs_handler_test.go
+++ b/agent/acs/handler/acs_handler_test.go
@@ -541,8 +541,6 @@ func TestStartSessionHandlesRefreshCredentialsMessages(t *testing.T) {
 	serverIn <- sampleRefreshCredentialsMessage
 
 	select {
-	case <-ended:
-		t.Fatal("Should not have stop session")
 	case err := <-errChan:
 		t.Fatal("Error should not have been returned from server", err)
 	case <-ctx.Done():
@@ -556,6 +554,7 @@ func TestStartSessionHandlesRefreshCredentialsMessages(t *testing.T) {
 	}
 
 	go server.Close()
+	// Cancel context should close the session
 	<-ended
 }
 

--- a/agent/stats/utils.go
+++ b/agent/stats/utils.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"math"
 	"regexp"
+	"runtime"
 	"time"
 
 	"github.com/cihub/seelog"
@@ -27,6 +28,8 @@ import (
 // if there's an error reading network stats.
 const networkStatsErrorPattern = "open /sys/class/net/veth.*: no such file or directory"
 
+var numCores = uint64(runtime.NumCPU())
+
 // nan32 returns a 32bit NaN.
 func nan32() float32 {
 	return (float32)(math.NaN())
@@ -35,9 +38,8 @@ func nan32() float32 {
 // dockerStatsToContainerStats returns a new object of the ContainerStats object from docker stats.
 func dockerStatsToContainerStats(dockerStats *docker.Stats) (*ContainerStats, error) {
 	// The length of PercpuUsage represents the number of cores in an instance.
-	numCores := uint64(len(dockerStats.CPUStats.CPUUsage.PercpuUsage))
-	if numCores == 0 {
-		seelog.Debug("Invalid container statitistics reported, got number of cores = 0")
+	if len(dockerStats.CPUStats.CPUUsage.PercpuUsage) == 0 {
+		seelog.Debug("Invalid container statistics reported, invalid stats payload from docker")
 		return nil, fmt.Errorf("Invalid container statistics reported")
 	}
 

--- a/agent/stats/utils_test.go
+++ b/agent/stats/utils_test.go
@@ -38,6 +38,10 @@ func TestIsNetworkStatsError(t *testing.T) {
 func TestDockerStatsToContainerStatsCpuUsage(t *testing.T) {
 	// doing this with json makes me sad, but is the easiest way to deal with
 	// the inner structs
+
+	// numCores is a global variable in package agent/stas
+	// whichdenotes the number of cpu cores
+	numCores = 4
 	jsonStat := fmt.Sprintf(`
 		{
 			"cpu_stats":{

--- a/test.log
+++ b/test.log
@@ -1,0 +1,2739 @@
+**********************************************************************
+* Please run brazil-build rather than make.  Your build might not work
+* correctly without running brazil-build.
+**********************************************************************
+cd misc/netkitten; /usr/bin/make 
+make[1]: Entering directory `/local/home/penyin/workspace/src/github.com/aws/amazon-ecs-agent/misc/netkitten'
+make[1]: Leaving directory `/local/home/penyin/workspace/src/github.com/aws/amazon-ecs-agent/misc/netkitten'
+cd misc/volumes-test; /usr/bin/make 
+make[1]: Entering directory `/local/home/penyin/workspace/src/github.com/aws/amazon-ecs-agent/misc/volumes-test'
+make[1]: Leaving directory `/local/home/penyin/workspace/src/github.com/aws/amazon-ecs-agent/misc/volumes-test'
+cd misc/squid; /usr/bin/make 
+make[1]: Entering directory `/local/home/penyin/workspace/src/github.com/aws/amazon-ecs-agent/misc/squid'
+docker build -t amazon/squid:make .
+Sending build context to Docker daemon 3.072 kB
+Step 1 : FROM alpine@sha256:fb9f16730ac6316afa4d97caa5130219927bfcecf0b0ce35c01dcb612f449739
+ ---> 558af09712a4
+Step 2 : RUN apk update && apk add squid
+ ---> Using cache
+ ---> 4338f12c9ac0
+Step 3 : EXPOSE 3128
+ ---> Using cache
+ ---> 74f9aa9de3b1
+Step 4 : ENTRYPOINT squid -Nd 1
+ ---> Using cache
+ ---> 5553612ff189
+Successfully built 5553612ff189
+make[1]: Leaving directory `/local/home/penyin/workspace/src/github.com/aws/amazon-ecs-agent/misc/squid'
+cd misc/awscli; /usr/bin/make 
+make[1]: Entering directory `/local/home/penyin/workspace/src/github.com/aws/amazon-ecs-agent/misc/awscli'
+docker build -t amazon/awscli:make .
+Sending build context to Docker daemon 3.072 kB
+Step 1 : FROM debian@sha256:8b1fc3a7a55c42e3445155b2f8f40c55de5f8bc8012992b26b570530c4bded9e
+ ---> 1b088884749b
+Step 2 : RUN apt-get update && apt-get install -y     python2.7 curl
+ ---> Using cache
+ ---> 93ebf2d2c568
+Step 3 : RUN curl -O https://bootstrap.pypa.io/get-pip.py
+ ---> Using cache
+ ---> 812c32c4d675
+Step 4 : RUN python2.7 get-pip.py && pip install awscli
+ ---> Using cache
+ ---> 89a2f563b528
+Successfully built 89a2f563b528
+make[1]: Leaving directory `/local/home/penyin/workspace/src/github.com/aws/amazon-ecs-agent/misc/awscli'
+cd misc/image-cleanup-test-images; /usr/bin/make 
+make[1]: Entering directory `/local/home/penyin/workspace/src/github.com/aws/amazon-ecs-agent/misc/image-cleanup-test-images'
+docker build -f "Dockerfile0" -t amazon/image-cleanup-test-image1:make .
+Sending build context to Docker daemon 7.168 kB
+Step 1 : FROM busybox@sha256:5551dbdfc48d66734d0f01cafee0952cb6e8eeecd1e2492240bf2fd9640c2279
+ ---> e4a4ff8a080d
+Step 2 : MAINTAINER Amazon Web Services, Inc.
+ ---> Using cache
+ ---> a5f461698d1b
+Step 3 : RUN date > boo.txt
+ ---> Using cache
+ ---> 2c141a3a59e8
+Step 4 : ENTRYPOINT sh -c
+ ---> Using cache
+ ---> 9e3364eff9a5
+Step 5 : CMD sleep 30
+ ---> Using cache
+ ---> 4e2ed2446906
+Successfully built 4e2ed2446906
+docker build -f "Dockerfile1" -t amazon/image-cleanup-test-image2:make .
+Sending build context to Docker daemon 7.168 kB
+Step 1 : FROM busybox@sha256:5551dbdfc48d66734d0f01cafee0952cb6e8eeecd1e2492240bf2fd9640c2279
+ ---> e4a4ff8a080d
+Step 2 : MAINTAINER Amazon Web Services, Inc.
+ ---> Using cache
+ ---> a5f461698d1b
+Step 3 : RUN date > foo.txt
+ ---> Using cache
+ ---> e8fcdeea2388
+Step 4 : ENTRYPOINT sh -c
+ ---> Using cache
+ ---> a79a263b4086
+Step 5 : CMD sleep 30
+ ---> Using cache
+ ---> e38ad5235b0e
+Successfully built e38ad5235b0e
+docker build -f "Dockerfile2" -t amazon/image-cleanup-test-image3:make .
+Sending build context to Docker daemon 7.168 kB
+Step 1 : FROM busybox@sha256:5551dbdfc48d66734d0f01cafee0952cb6e8eeecd1e2492240bf2fd9640c2279
+ ---> e4a4ff8a080d
+Step 2 : MAINTAINER Amazon Web Services, Inc.
+ ---> Using cache
+ ---> a5f461698d1b
+Step 3 : RUN date > roo.txt
+ ---> Using cache
+ ---> 0212d8e2b866
+Step 4 : ENTRYPOINT sh -c
+ ---> Using cache
+ ---> 4eb498d158e4
+Step 5 : CMD sleep 30
+ ---> Using cache
+ ---> db6e4d59b71c
+Successfully built db6e4d59b71c
+make[1]: Leaving directory `/local/home/penyin/workspace/src/github.com/aws/amazon-ecs-agent/misc/image-cleanup-test-images'
+The push refers to a repository [127.0.0.1:51670/amazon/amazon-ecs-netkitten]
+de1dceb9835c: Preparing
+de1dceb9835c: Layer already exists
+latest: digest: sha256:9f05be1df996234370999c82c3def0dce5b55372cfcf03fa8283c79717a27c18 size: 2586
+The push refers to a repository [127.0.0.1:51670/amazon/amazon-ecs-volumes-test]
+bb490e1d0ec2: Preparing
+c67770946097: Preparing
+5f70bf18a086: Preparing
+d7f400ce6d52: Preparing
+bb490e1d0ec2: Layer already exists
+d7f400ce6d52: Layer already exists
+c67770946097: Layer already exists
+5f70bf18a086: Layer already exists
+latest: digest: sha256:b382ea3eae09fb07a11990606e4234b4a056858caf836bc2ef0ffc2013c29742 size: 5066
+The push refers to a repository [127.0.0.1:51670/amazon/squid]
+82948c7495a5: Preparing
+65542ee6e3cb: Preparing
+65542ee6e3cb: Layer already exists
+82948c7495a5: Layer already exists
+latest: digest: sha256:be88f15ec1abf198fd11a1f0ce36632c2dedf0266ab8580acc1672dfe857b47b size: 3171
+The push refers to a repository [127.0.0.1:51670/amazon/awscli]
+2b13c3fbdafa: Preparing
+25c1f9e140f2: Preparing
+15dd7ef175ce: Preparing
+42755cf4ee95: Preparing
+2b13c3fbdafa: Layer already exists
+42755cf4ee95: Layer already exists
+15dd7ef175ce: Layer already exists
+25c1f9e140f2: Layer already exists
+latest: digest: sha256:fdec08d869cc5e1ca7fc2d28c657f665ea4450c8b608f21aee6a57a60296fb2c size: 3543
+The push refers to a repository [127.0.0.1:51670/amazon/image-cleanup-test-image1]
+558f49f1a467: Preparing
+5f70bf18a086: Preparing
+d7f400ce6d52: Preparing
+558f49f1a467: Layer already exists
+d7f400ce6d52: Layer already exists
+5f70bf18a086: Layer already exists
+latest: digest: sha256:fee156a56fec892d640463f5c77a2a4e4b4644ac2bb2bfc8427b1cf06af980f0 size: 4045
+The push refers to a repository [127.0.0.1:51670/amazon/image-cleanup-test-image2]
+621e946811c2: Preparing
+5f70bf18a086: Preparing
+d7f400ce6d52: Preparing
+621e946811c2: Layer already exists
+5f70bf18a086: Layer already exists
+d7f400ce6d52: Layer already exists
+latest: digest: sha256:1893364e86f5f19897e2fcc85e81ed5a655ac2661d68e7d95400158159e1a210 size: 4046
+The push refers to a repository [127.0.0.1:51670/amazon/image-cleanup-test-image3]
+b47a116211c2: Preparing
+5f70bf18a086: Preparing
+d7f400ce6d52: Preparing
+d7f400ce6d52: Layer already exists
+b47a116211c2: Layer already exists
+5f70bf18a086: Layer already exists
+latest: digest: sha256:5d9c6b93e4a1ea75d7be3ad7d632196bd4541653594e30df65e93654c45b72c3 size: 4046
+Untagged: amazon/image-cleanup-test-image1:make
+Untagged: amazon/image-cleanup-test-image2:make
+Untagged: amazon/image-cleanup-test-image3:make
+sha256:5551dbdfc48d66734d0f01cafee0952cb6e8eeecd1e2492240bf2fd9640c2279: Pulling from library/busybox
+1b373b69cd34: Already exists
+a3ed95caeb02: Already exists
+Digest: sha256:5551dbdfc48d66734d0f01cafee0952cb6e8eeecd1e2492240bf2fd9640c2279
+Status: Image is up to date for busybox@sha256:5551dbdfc48d66734d0f01cafee0952cb6e8eeecd1e2492240bf2fd9640c2279
+The push refers to a repository [127.0.0.1:51670/busybox]
+5f70bf18a086: Preparing
+d7f400ce6d52: Preparing
+5f70bf18a086: Layer already exists
+d7f400ce6d52: Layer already exists
+latest: digest: sha256:379f00da82c4b1afff083a74ce06042a50523ab67e9712183ad34e25500af5fa size: 1920
+sha256:0324afc5c8191616576f7b23b297d001609726a2f1b6561c90e229e54ab701cf: Pulling from library/nginx
+f8efbffe7b95: Already exists
+a3ed95caeb02: Already exists
+a3ed95caeb02: Already exists
+c2cdaa18ccc4: Already exists
+84756f2904cc: Already exists
+a3ed95caeb02: Already exists
+647f1544775d: Already exists
+8ef574356424: Already exists
+4fd310f87ecb: Already exists
+a3ed95caeb02: Already exists
+a3ed95caeb02: Already exists
+a3ed95caeb02: Already exists
+Digest: sha256:0324afc5c8191616576f7b23b297d001609726a2f1b6561c90e229e54ab701cf
+Status: Image is up to date for nginx@sha256:0324afc5c8191616576f7b23b297d001609726a2f1b6561c90e229e54ab701cf
+The push refers to a repository [127.0.0.1:51670/nginx]
+5f70bf18a086: Preparing
+5f70bf18a086: Preparing
+5f70bf18a086: Preparing
+3dea908133e8: Preparing
+aab58c11c55f: Preparing
+8ca6a143dbb2: Preparing
+5f70bf18a086: Preparing
+684caeadae73: Preparing
+ce00e171c01c: Preparing
+5f70bf18a086: Preparing
+5f70bf18a086: Preparing
+65f3b0435c42: Preparing
+ce00e171c01c: Waiting
+65f3b0435c42: Waiting
+5f70bf18a086: Layer already exists
+8ca6a143dbb2: Layer already exists
+3dea908133e8: Layer already exists
+684caeadae73: Layer already exists
+aab58c11c55f: Layer already exists
+ce00e171c01c: Layer already exists
+65f3b0435c42: Layer already exists
+latest: digest: sha256:2c32b2b74b6e825ca931fa947483a201cf441547b927bda44e7f6084774ac078 size: 7129
+sha256:3a1e82d95d0e75677cdac237b0174425d8ae94dd11d1ef14db73075f1e34c06c: Pulling from library/python
+f8efbffe7b95: Already exists
+a3ed95caeb02: Already exists
+b3010ec3eb21: Already exists
+a6f2dac3eb9c: Already exists
+f4f48828d97b: Already exists
+20cdbe5b7a6f: Already exists
+a3ed95caeb02: Already exists
+1fb2fc13fd7a: Already exists
+a3ed95caeb02: Already exists
+a3ed95caeb02: Already exists
+5f532de33fbc: Already exists
+96e342cb597d: Already exists
+a3ed95caeb02: Already exists
+Digest: sha256:3a1e82d95d0e75677cdac237b0174425d8ae94dd11d1ef14db73075f1e34c06c
+Status: Image is up to date for python@sha256:3a1e82d95d0e75677cdac237b0174425d8ae94dd11d1ef14db73075f1e34c06c
+The push refers to a repository [127.0.0.1:51670/python]
+5f70bf18a086: Preparing
+cb184317a3f7: Preparing
+08f3499a30f1: Preparing
+5f70bf18a086: Preparing
+5f70bf18a086: Preparing
+dc5aef0b699e: Preparing
+5f70bf18a086: Preparing
+dbd1909a8e8d: Preparing
+eb746b9c3e1e: Preparing
+f01e8626d61f: Preparing
+b734b7339275: Preparing
+5f70bf18a086: Preparing
+65f3b0435c42: Preparing
+eb746b9c3e1e: Waiting
+f01e8626d61f: Waiting
+b734b7339275: Waiting
+65f3b0435c42: Waiting
+dbd1909a8e8d: Layer already exists
+08f3499a30f1: Layer already exists
+5f70bf18a086: Layer already exists
+dc5aef0b699e: Layer already exists
+cb184317a3f7: Layer already exists
+eb746b9c3e1e: Layer already exists
+b734b7339275: Layer already exists
+f01e8626d61f: Layer already exists
+65f3b0435c42: Layer already exists
+2: digest: sha256:61690805e180faad642d54ee3b6e5637a24df0a5496914590c949c04f3bc83f5 size: 9125
+sha256:1bea66e185d3464fec1abda32ffaf2a11de69833cfcf81bd2b9a5be147776814: Pulling from library/ubuntu
+203137e8afd5: Already exists
+2ff1bbbe9310: Already exists
+933ae2486129: Already exists
+a3ed95caeb02: Already exists
+Digest: sha256:1bea66e185d3464fec1abda32ffaf2a11de69833cfcf81bd2b9a5be147776814
+Status: Image is up to date for ubuntu@sha256:1bea66e185d3464fec1abda32ffaf2a11de69833cfcf81bd2b9a5be147776814
+The push refers to a repository [127.0.0.1:51670/ubuntu]
+5f70bf18a086: Preparing
+1b82ce694c3b: Preparing
+db6b2d84f3c6: Preparing
+05b940eef08d: Preparing
+5f70bf18a086: Layer already exists
+1b82ce694c3b: Layer already exists
+db6b2d84f3c6: Layer already exists
+05b940eef08d: Layer already exists
+latest: digest: sha256:c38cf0d254a090e3db8b94232f239b01f58dea04bb8a765a8fde6cb838c06086 size: 4122
+cd misc/gremlin; /usr/bin/make 
+make[1]: Entering directory `/local/home/penyin/workspace/src/github.com/aws/amazon-ecs-agent/misc/gremlin'
+make[1]: Leaving directory `/local/home/penyin/workspace/src/github.com/aws/amazon-ecs-agent/misc/gremlin'
+. ./scripts/shared_env && go test -tags unit -timeout=180s -v -cover github.com/aws/amazon-ecs-agent/agent github.com/aws/amazon-ecs-agent/agent/acs/client github.com/aws/amazon-ecs-agent/agent/acs/handler github.com/aws/amazon-ecs-agent/agent/acs/model github.com/aws/amazon-ecs-agent/agent/acs/model/ecsacs github.com/aws/amazon-ecs-agent/agent/acs/update_handler github.com/aws/amazon-ecs-agent/agent/acs/update_handler/os github.com/aws/amazon-ecs-agent/agent/acs/update_handler/os/mock github.com/aws/amazon-ecs-agent/agent/api github.com/aws/amazon-ecs-agent/agent/api/mocks github.com/aws/amazon-ecs-agent/agent/api/testutils github.com/aws/amazon-ecs-agent/agent/async github.com/aws/amazon-ecs-agent/agent/async/mocks github.com/aws/amazon-ecs-agent/agent/config github.com/aws/amazon-ecs-agent/agent/credentials github.com/aws/amazon-ecs-agent/agent/credentials/mocks github.com/aws/amazon-ecs-agent/agent/ec2 github.com/aws/amazon-ecs-agent/agent/ec2/mocks github.com/aws/amazon-ecs-agent/agent/ecr github.com/aws/amazon-ecs-agent/agent/ecr/mocks github.com/aws/amazon-ecs-agent/agent/ecr/model github.com/aws/amazon-ecs-agent/agent/ecr/model/ecr github.com/aws/amazon-ecs-agent/agent/ecs_client/model github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs github.com/aws/amazon-ecs-agent/agent/engine github.com/aws/amazon-ecs-agent/agent/engine/dependencygraph github.com/aws/amazon-ecs-agent/agent/engine/dockerauth github.com/aws/amazon-ecs-agent/agent/engine/dockerclient github.com/aws/amazon-ecs-agent/agent/engine/dockerclient/mocks github.com/aws/amazon-ecs-agent/agent/engine/dockeriface github.com/aws/amazon-ecs-agent/agent/engine/dockeriface/mocks github.com/aws/amazon-ecs-agent/agent/engine/dockerstate github.com/aws/amazon-ecs-agent/agent/engine/dockerstate/testutils github.com/aws/amazon-ecs-agent/agent/engine/emptyvolume github.com/aws/amazon-ecs-agent/agent/engine/image github.com/aws/amazon-ecs-agent/agent/engine/testutils github.com/aws/amazon-ecs-agent/agent/eventhandler github.com/aws/amazon-ecs-agent/agent/eventstream github.com/aws/amazon-ecs-agent/agent/functional_tests/tests github.com/aws/amazon-ecs-agent/agent/functional_tests/tests/generated github.com/aws/amazon-ecs-agent/agent/functional_tests/tests/generated/simpletests github.com/aws/amazon-ecs-agent/agent/functional_tests/util github.com/aws/amazon-ecs-agent/agent/gogenerate github.com/aws/amazon-ecs-agent/agent/handlers github.com/aws/amazon-ecs-agent/agent/handlers/credentials github.com/aws/amazon-ecs-agent/agent/handlers/mocks github.com/aws/amazon-ecs-agent/agent/handlers/mocks/http github.com/aws/amazon-ecs-agent/agent/httpclient github.com/aws/amazon-ecs-agent/agent/httpclient/mock github.com/aws/amazon-ecs-agent/agent/logger github.com/aws/amazon-ecs-agent/agent/logger/audit github.com/aws/amazon-ecs-agent/agent/logger/audit/mocks github.com/aws/amazon-ecs-agent/agent/logger/audit/request github.com/aws/amazon-ecs-agent/agent/sighandlers github.com/aws/amazon-ecs-agent/agent/sighandlers/exitcodes github.com/aws/amazon-ecs-agent/agent/statemanager github.com/aws/amazon-ecs-agent/agent/statemanager/mocks github.com/aws/amazon-ecs-agent/agent/stats github.com/aws/amazon-ecs-agent/agent/stats/mock github.com/aws/amazon-ecs-agent/agent/stats/resolver github.com/aws/amazon-ecs-agent/agent/stats/resolver/mock github.com/aws/amazon-ecs-agent/agent/tcs/client github.com/aws/amazon-ecs-agent/agent/tcs/handler github.com/aws/amazon-ecs-agent/agent/tcs/model github.com/aws/amazon-ecs-agent/agent/tcs/model/ecstcs github.com/aws/amazon-ecs-agent/agent/utils github.com/aws/amazon-ecs-agent/agent/utils/atomic github.com/aws/amazon-ecs-agent/agent/utils/mocks github.com/aws/amazon-ecs-agent/agent/utils/sync github.com/aws/amazon-ecs-agent/agent/utils/ttime github.com/aws/amazon-ecs-agent/agent/utils/ttime/mocks github.com/aws/amazon-ecs-agent/agent/version github.com/aws/amazon-ecs-agent/agent/version/gen github.com/aws/amazon-ecs-agent/agent/wsclient github.com/aws/amazon-ecs-agent/agent/wsclient/mock github.com/aws/amazon-ecs-agent/agent/wsclient/mock/utils
+?   	github.com/aws/amazon-ecs-agent/agent	[no test files]
+=== RUN   TestMakeUnrecognizedRequest
+--- PASS: TestMakeUnrecognizedRequest (0.00s)
+=== RUN   TestWriteAckRequest
+--- PASS: TestWriteAckRequest (0.00s)
+=== RUN   TestPayloadHandlerCalled
+--- PASS: TestPayloadHandlerCalled (0.00s)
+=== RUN   TestRefreshCredentialsHandlerCalled
+2016-10-13T20:53:44Z [ERROR] Error getting message from ws backend: can't read from a closed websocket, message: 
+--- PASS: TestRefreshCredentialsHandlerCalled (0.00s)
+=== RUN   TestClosingConnection
+--- PASS: TestClosingConnection (0.00s)
+=== RUN   TestConnect
+2016-10-13T20:53:44Z [ERROR] Error getting message from ws backend: can't read from a closed websocket, message: 
+2016-10-13T20:53:44Z [INFO] Creating poll dialer, host: 127.0.0.1:41286
+2016-10-13T20:53:44Z [ERROR] Error getting message from ws backend: can't read from a closed websocket, message: 
+--- PASS: TestConnect (0.11s)
+=== RUN   TestConnectClientError
+2016-10-13T20:53:44Z [INFO] Creating poll dialer, host: 127.0.0.1:57109
+--- PASS: TestConnectClientError (0.00s)
+=== RUN   TestInvalidInstanceException
+--- PASS: TestInvalidInstanceException (0.00s)
+=== RUN   TestInvalidClusterException
+--- PASS: TestInvalidClusterException (0.00s)
+=== RUN   TestServerException
+--- PASS: TestServerException (0.00s)
+=== RUN   TestGenericErrorConversion
+--- PASS: TestGenericErrorConversion (0.00s)
+=== RUN   TestSomeRandomTypeConversion
+--- PASS: TestSomeRandomTypeConversion (0.00s)
+=== RUN   TestBadlyTypedMessage
+--- PASS: TestBadlyTypedMessage (0.00s)
+PASS
+coverage: 92.0% of statements
+ok  	github.com/aws/amazon-ecs-agent/agent/acs/client	0.160s	coverage: 92.0% of statements
+=== RUN   TestAcsWsUrl
+--- PASS: TestAcsWsUrl (0.00s)
+=== RUN   TestHandlerReconnectsOnConnectErrors
+--- PASS: TestHandlerReconnectsOnConnectErrors (0.00s)
+=== RUN   TestHandlerReconnectsOnServeErrors
+2016-10-13T20:53:59Z [ERROR] Error connecting to ACS: EOF
+2016-10-13T20:53:59Z [ERROR] Error connecting to ACS: EOF
+2016-10-13T20:53:59Z [ERROR] Error connecting to ACS: EOF
+2016-10-13T20:53:59Z [ERROR] Error connecting to ACS: EOF
+2016-10-13T20:53:59Z [ERROR] Error connecting to ACS: EOF
+2016-10-13T20:53:59Z [ERROR] Error connecting to ACS: EOF
+2016-10-13T20:53:59Z [ERROR] Error connecting to ACS: EOF
+2016-10-13T20:53:59Z [ERROR] Error connecting to ACS: EOF
+2016-10-13T20:53:59Z [ERROR] Error connecting to ACS: EOF
+2016-10-13T20:53:59Z [ERROR] Error connecting to ACS: EOF
+2016-10-13T20:53:59Z [ERROR] Error connecting to ACS: EOF
+--- PASS: TestHandlerReconnectsOnServeErrors (0.00s)
+=== RUN   TestHandlerReconnectsOnDiscoverPollEndpointError
+2016-10-13T20:53:59Z [ERROR] Unable to discover poll endpoint, err: oops
+2016-10-13T20:53:59Z [INFO] Error from acs; backing off, err: oops
+--- PASS: TestHandlerReconnectsOnDiscoverPollEndpointError (0.29s)
+=== RUN   TestConnectionIsClosedOnIdle
+--- PASS: TestConnectionIsClosedOnIdle (0.02s)
+=== RUN   TestHandlerDoesntLeakGouroutines
+2016-10-13T20:53:59Z [WARN] ACS Connection hasn't had any activity for too long; closing connection
+2016-10-13T20:53:59Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:53:59Z [WARN] ACS Connection hasn't had any activity for too long; closing connection
+2016-10-13T20:53:59Z [WARN] Error disconnecting: No Connection to close
+2016-10-13T20:53:59Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:53:59Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:53:59Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:53:59Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:53:59Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:53:59Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:53:59Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:53:59Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:53:59Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:53:59Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:53:59Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:53:59Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:53:59Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:53:59Z [WARN] ACS Connection hasn't had any activity for too long; closing connection
+2016-10-13T20:53:59Z [WARN] Error disconnecting: No Connection to close
+2016-10-13T20:53:59Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:53:59Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:53:59Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:53:59Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:53:59Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:53:59Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:53:59Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:53:59Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:53:59Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:53:59Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:53:59Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:53:59Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:53:59Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:53:59Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:53:59Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:53:59Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:53:59Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:53:59Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:53:59Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:53:59Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:53:59Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:53:59Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:53:59Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:53:59Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:53:59Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:53:59Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:53:59Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:53:59Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:53:59Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:53:59Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:53:59Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:53:59Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:53:59Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:53:59Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:53:59Z [ERROR] Error getting message from ws backend: websocket: unknown opcode 3
+2016-10-13T20:53:59Z [INFO] Error from acs; backing off, err: websocket: unknown opcode 3
+2016-10-13T20:53:59Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:53:59Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:53:59Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:53:59Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:53:59Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:53:59Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:53:59Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:53:59Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:53:59Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:53:59Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:53:59Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:53:59Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:53:59Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:53:59Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:53:59Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:53:59Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:53:59Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:53:59Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:53:59Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:53:59Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:53:59Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:53:59Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:53:59Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:53:59Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [WARN] ACS Connection hasn't had any activity for too long; closing connection
+2016-10-13T20:54:00Z [WARN] Error disconnecting: No Connection to close
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [ERROR] Error getting message from ws backend: websocket: unknown opcode 3
+2016-10-13T20:54:00Z [INFO] Error from acs; backing off, err: websocket: unknown opcode 3
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [ERROR] Error getting message from ws backend: websocket: unknown opcode 3
+2016-10-13T20:54:00Z [INFO] Error from acs; backing off, err: websocket: unknown opcode 3
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:58716
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+2016-10-13T20:54:00Z [WARN] Error 'ack'ing request with messageID: 123, error: websocket: close sent
+--- PASS: TestHandlerDoesntLeakGouroutines (1.48s)
+	acs_handler_test.go:452: Gorutines after 1 and after 100 acs messages: 17 and 10
+=== RUN   TestStartSessionHandlesRefreshCredentialsMessages
+2016-10-13T20:54:00Z [INFO] Creating poll dialer, host: 127.0.0.1:36705
+2016-10-13T20:54:00Z [ERROR] Error getting message from ws backend: read tcp 127.0.0.1:43568->127.0.0.1:58716: use of closed network connection
+--- PASS: TestStartSessionHandlesRefreshCredentialsMessages (0.00s)
+=== RUN   TestACSSessionResourcesCorrectlySetsSendCredentials
+--- PASS: TestACSSessionResourcesCorrectlySetsSendCredentials (0.00s)
+=== RUN   TestHandlerReconnectsCorrectlySetsSendCredentialsURLParameter
+--- PASS: TestHandlerReconnectsCorrectlySetsSendCredentialsURLParameter (0.00s)
+=== RUN   TestHandlePayloadMessageWithNoMessageId
+2016-10-13T20:54:00Z [CRITICAL] Recieved a payload with no message id, payload: {
+  Tasks: [{
+      Arn: "t1"
+    }]
+}
+2016-10-13T20:54:00Z [CRITICAL] Recieved a payload with no message id, payload: {
+  MessageId: "",
+  Tasks: [{
+      Arn: "t1"
+    }]
+}
+--- PASS: TestHandlePayloadMessageWithNoMessageId (0.00s)
+=== RUN   TestHandlePayloadMessageAddTaskError
+--- PASS: TestHandlePayloadMessageAddTaskError (0.00s)
+=== RUN   TestHandlePayloadMessageStateSaveError
+--- PASS: TestHandlePayloadMessageStateSaveError (0.00s)
+=== RUN   TestHandlePayloadMessageAckedWhenTaskAdded
+2016-10-13T20:54:00Z [WARN] Could not add task; taskengine probably disabled, err: oops
+2016-10-13T20:54:00Z [WARN] Could not add task; taskengine probably disabled, err: oops
+2016-10-13T20:54:00Z [ERROR] Error saving state for payload message! err: oops, messageId: 123
+2016-10-13T20:54:00Z [ERROR] Error getting message from ws backend: read tcp 127.0.0.1:49034->127.0.0.1:36705: use of closed network connection
+--- PASS: TestHandlePayloadMessageAckedWhenTaskAdded (0.00s)
+=== RUN   TestHandlePayloadMessageCredentialsAckedWhenTaskAdded
+--- PASS: TestHandlePayloadMessageCredentialsAckedWhenTaskAdded (0.00s)
+=== RUN   TestAddPayloadTaskAddsNonStoppedTasksAfterStoppedTasks
+--- PASS: TestAddPayloadTaskAddsNonStoppedTasksAfterStoppedTasks (0.00s)
+=== RUN   TestPayloadBufferHandler
+--- PASS: TestPayloadBufferHandler (0.00s)
+=== RUN   TestPayloadBufferHandlerWithCredentials
+--- PASS: TestPayloadBufferHandlerWithCredentials (0.00s)
+=== RUN   TestValidateRefreshMessageWithNilMessage
+--- PASS: TestValidateRefreshMessageWithNilMessage (0.00s)
+=== RUN   TestValidateRefreshMessageWithNoMessageId
+--- PASS: TestValidateRefreshMessageWithNoMessageId (0.00s)
+=== RUN   TestValidateRefreshMessageWithNoRoleCredentials
+--- PASS: TestValidateRefreshMessageWithNoRoleCredentials (0.00s)
+=== RUN   TestValidateRefreshMessageWithNoCredentialsId
+--- PASS: TestValidateRefreshMessageWithNoCredentialsId (0.00s)
+=== RUN   TestValidateRefreshMessageWithNoTaskArn
+--- PASS: TestValidateRefreshMessageWithNoTaskArn (0.00s)
+=== RUN   TestValidateRefreshMessageSuccess
+--- PASS: TestValidateRefreshMessageSuccess (0.00s)
+=== RUN   TestInvalidCredentialsMessageNotAcked
+--- PASS: TestInvalidCredentialsMessageNotAcked (0.00s)
+=== RUN   TestCredentialsMessageNotAckedWhenTaskNotFound
+2016-10-13T20:54:00Z [ERROR] Error validating credentials message: Message id not set in credentials message
+--- PASS: TestCredentialsMessageNotAckedWhenTaskNotFound (0.00s)
+=== RUN   TestHandleRefreshMessageAckedWhenCredentialsUpdated
+2016-10-13T20:54:00Z [ERROR] Task not found in the engine for the arn in credentials message, arn: task1, messageId: message1
+--- PASS: TestHandleRefreshMessageAckedWhenCredentialsUpdated (0.00s)
+=== RUN   TestRefreshCredentialsHandler
+--- PASS: TestRefreshCredentialsHandler (0.00s)
+PASS
+coverage: 90.2% of statements
+ok  	github.com/aws/amazon-ecs-agent/agent/acs/handler	1.851s	coverage: 90.2% of statements
+?   	github.com/aws/amazon-ecs-agent/agent/acs/model	[no test files]
+?   	github.com/aws/amazon-ecs-agent/agent/acs/model/ecsacs	[no test files]
+=== RUN   TestStageUpdateWithUpdatesDisabled
+--- PASS: TestStageUpdateWithUpdatesDisabled (0.00s)
+=== RUN   TestPerformUpdateWithUpdatesDisabled
+--- PASS: TestPerformUpdateWithUpdatesDisabled (0.00s)
+=== RUN   TestFullUpdateFlow
+--- PASS: TestFullUpdateFlow (0.00s)
+=== RUN   TestMissingUpdateInfo
+--- PASS: TestMissingUpdateInfo (0.00s)
+=== RUN   TestUndownloadedUpdate
+--- PASS: TestUndownloadedUpdate (0.00s)
+=== RUN   TestDuplicateUpdateMessagesWithSuccess
+--- PASS: TestDuplicateUpdateMessagesWithSuccess (0.00s)
+=== RUN   TestDuplicateUpdateMessagesWithFailure
+--- PASS: TestDuplicateUpdateMessagesWithFailure (0.00s)
+=== RUN   TestNewerUpdateMessages
+--- PASS: TestNewerUpdateMessages (0.00s)
+=== RUN   TestValidationError
+--- PASS: TestValidationError (0.00s)
+=== RUN   TestLocationBucketValidationError
+--- PASS: TestLocationBucketValidationError (0.00s)
+=== RUN   TestLocationHostValidationError
+--- PASS: TestLocationHostValidationError (0.00s)
+PASS
+coverage: 87.6% of statements
+ok  	github.com/aws/amazon-ecs-agent/agent/acs/update_handler	0.077s	coverage: 87.6% of statements
+?   	github.com/aws/amazon-ecs-agent/agent/acs/update_handler/os	[no test files]
+?   	github.com/aws/amazon-ecs-agent/agent/acs/update_handler/os/mock	[no test files]
+=== RUN   TestOverridden
+--- PASS: TestOverridden (0.00s)
+=== RUN   TestUnmarshalTaskStatus
+--- PASS: TestUnmarshalTaskStatus (0.00s)
+=== RUN   TestUnmarshalContainerStatus
+--- PASS: TestUnmarshalContainerStatus (0.00s)
+=== RUN   TestUnmarshalContainerOverrides
+--- PASS: TestUnmarshalContainerOverrides (0.00s)
+=== RUN   TestMarshalUnmarshalTaskVolumes
+--- PASS: TestMarshalUnmarshalTaskVolumes (0.00s)
+=== RUN   TestUnmarshalTransportProtocol_Null
+--- PASS: TestUnmarshalTransportProtocol_Null (0.00s)
+=== RUN   TestUnmarshalTransportProtocol_TCP
+--- PASS: TestUnmarshalTransportProtocol_TCP (0.00s)
+=== RUN   TestUnmarshalTransportProtocol_UDP
+--- PASS: TestUnmarshalTransportProtocol_UDP (0.00s)
+=== RUN   TestUnmarshalTransportProtocol_NullStruct
+--- PASS: TestUnmarshalTransportProtocol_NullStruct (0.00s)
+=== RUN   TestMarshalTransportProtocol_Unset
+--- PASS: TestMarshalTransportProtocol_Unset (0.00s)
+=== RUN   TestMarshalTransportProtocol_TCP
+--- PASS: TestMarshalTransportProtocol_TCP (0.00s)
+=== RUN   TestMarshalTransportProtocol_UDP
+--- PASS: TestMarshalTransportProtocol_UDP (0.00s)
+=== RUN   TestMarshalUnmarshalTransportProtocol
+--- PASS: TestMarshalUnmarshalTransportProtocol (0.00s)
+=== RUN   TestPortBindingFromDockerPortBinding
+--- PASS: TestPortBindingFromDockerPortBinding (0.00s)
+=== RUN   TestPortBindingErrors
+--- PASS: TestPortBindingErrors (0.00s)
+=== RUN   TestOneDayRetrier
+--- PASS: TestOneDayRetrier (0.00s)
+=== RUN   TestTaskOverridden
+--- PASS: TestTaskOverridden (0.00s)
+=== RUN   TestDockerConfigPortBinding
+--- PASS: TestDockerConfigPortBinding (0.00s)
+=== RUN   TestDockerConfigCPUShareZero
+--- PASS: TestDockerConfigCPUShareZero (0.00s)
+=== RUN   TestDockerConfigCPUShareMinimum
+--- PASS: TestDockerConfigCPUShareMinimum (0.00s)
+=== RUN   TestDockerConfigCPUShareUnchanged
+--- PASS: TestDockerConfigCPUShareUnchanged (0.00s)
+=== RUN   TestDockerHostConfigPortBinding
+--- PASS: TestDockerHostConfigPortBinding (0.00s)
+=== RUN   TestDockerHostConfigVolumesFrom
+--- PASS: TestDockerHostConfigVolumesFrom (0.00s)
+=== RUN   TestDockerHostConfigRawConfig
+--- PASS: TestDockerHostConfigRawConfig (0.00s)
+=== RUN   TestDockerHostConfigRawConfigMerging
+--- PASS: TestDockerHostConfigRawConfigMerging (0.00s)
+=== RUN   TestBadDockerHostConfigRawConfig
+--- PASS: TestBadDockerHostConfigRawConfig (0.00s)
+=== RUN   TestDockerConfigRawConfig
+--- PASS: TestDockerConfigRawConfig (0.00s)
+=== RUN   TestDockerConfigRawConfigNilLabel
+--- PASS: TestDockerConfigRawConfigNilLabel (0.00s)
+=== RUN   TestDockerConfigRawConfigMerging
+--- PASS: TestDockerConfigRawConfigMerging (0.00s)
+=== RUN   TestBadDockerConfigRawConfig
+--- PASS: TestBadDockerConfigRawConfig (0.00s)
+=== RUN   TestGetCredentialsEndpointWhenCredentialsAreSet
+--- PASS: TestGetCredentialsEndpointWhenCredentialsAreSet (0.00s)
+=== RUN   TestGetCredentialsEndpointWhenCredentialsAreNotSet
+--- PASS: TestGetCredentialsEndpointWhenCredentialsAreNotSet (0.00s)
+=== RUN   TestTaskFromACS
+--- PASS: TestTaskFromACS (0.00s)
+=== RUN   TestVolumesFromUnmarshal
+--- PASS: TestVolumesFromUnmarshal (0.00s)
+=== RUN   TestEmptyHostVolumeUnmarshal
+--- PASS: TestEmptyHostVolumeUnmarshal (0.00s)
+=== RUN   TestHostHostVolumeUnmarshal
+--- PASS: TestHostHostVolumeUnmarshal (0.00s)
+=== RUN   TestRemoveFromTaskArray
+--- PASS: TestRemoveFromTaskArray (0.00s)
+=== RUN   TestSubmitContainerStateChange
+--- PASS: TestSubmitContainerStateChange (0.00s)
+=== RUN   TestSubmitContainerStateChangeFull
+--- PASS: TestSubmitContainerStateChangeFull (0.00s)
+=== RUN   TestSubmitContainerStateChangeReason
+--- PASS: TestSubmitContainerStateChangeReason (0.00s)
+=== RUN   TestSubmitContainerStateChangeLongReason
+--- PASS: TestSubmitContainerStateChangeLongReason (0.00s)
+=== RUN   TestRegisterContainerInstance
+--- PASS: TestRegisterContainerInstance (0.00s)
+=== RUN   TestRegisterBlankCluster
+--- PASS: TestRegisterBlankCluster (0.00s)
+=== RUN   TestDiscoverTelemetryEndpoint
+--- PASS: TestDiscoverTelemetryEndpoint (0.00s)
+=== RUN   TestDiscoverNilTelemetryEndpoint
+--- PASS: TestDiscoverNilTelemetryEndpoint (0.00s)
+PASS
+coverage: 51.2% of statements
+ok  	github.com/aws/amazon-ecs-agent/agent/api	0.071s	coverage: 51.2% of statements
+?   	github.com/aws/amazon-ecs-agent/agent/api/mocks	[no test files]
+=== RUN   TestContainerEqual
+--- PASS: TestContainerEqual (0.00s)
+=== RUN   TestTaskEqual
+--- PASS: TestTaskEqual (0.00s)
+PASS
+coverage: 85.5% of statements
+ok  	github.com/aws/amazon-ecs-agent/agent/api/testutils	0.049s	coverage: 85.5% of statements
+=== RUN   TestLRUSimple
+--- PASS: TestLRUSimple (0.00s)
+=== RUN   TestLRUTTlPurge
+--- PASS: TestLRUTTlPurge (0.10s)
+=== RUN   TestLRUSizePurge
+--- PASS: TestLRUSizePurge (0.00s)
+=== RUN   TestLRUCacheConcurrency
+--- PASS: TestLRUCacheConcurrency (0.66s)
+PASS
+coverage: 100.0% of statements
+ok  	github.com/aws/amazon-ecs-agent/agent/async	0.796s	coverage: 100.0% of statements
+?   	github.com/aws/amazon-ecs-agent/agent/async/mocks	[no test files]
+=== RUN   TestMerge
+--- PASS: TestMerge (0.00s)
+=== RUN   TestBrokenEC2Metadata
+2016-10-13T20:53:48Z [WARN] Invalid format for "ECS_NUM_IMAGES_DELETE_PER_CYCLE", expected an integer. err strconv.ParseInt: parsing "": invalid syntax
+2016-10-13T20:53:48Z [CRITICAL] Unable to communicate with EC2 Metadata service to infer region: err
+2016-10-13T20:53:48Z [CRITICAL] Configuration key not set, key: AWSRegion
+--- PASS: TestBrokenEC2Metadata (0.00s)
+=== RUN   TestBrokenEC2MetadataEndpoint
+--- PASS: TestBrokenEC2MetadataEndpoint (0.00s)
+=== RUN   TestEnvironmentConfig
+--- PASS: TestEnvironmentConfig (0.00s)
+=== RUN   TestTrimWhitespace
+--- PASS: TestTrimWhitespace (0.00s)
+=== RUN   TestConfigBoolean
+--- PASS: TestConfigBoolean (0.00s)
+=== RUN   TestConfigDefault
+--- PASS: TestConfigDefault (0.00s)
+=== RUN   TestBadLoggingDriverSerialization
+--- PASS: TestBadLoggingDriverSerialization (0.00s)
+=== RUN   TestInvalidLoggingDriver
+--- PASS: TestInvalidLoggingDriver (0.00s)
+=== RUN   TestInvalidFormatDockerStopTimeout
+--- PASS: TestInvalidFormatDockerStopTimeout (0.00s)
+=== RUN   TestInvalideValueDockerStopTimeout
+--- PASS: TestInvalideValueDockerStopTimeout (0.00s)
+=== RUN   TestInvalideDockerStopTimeout
+2016-10-13T20:53:48Z [WARN] Invalid format for "ECS_NUM_IMAGES_DELETE_PER_CYCLE", expected an integer. err strconv.ParseInt: parsing "": invalid syntax
+2016-10-13T20:53:48Z [WARN] Invalid format for "ECS_NUM_IMAGES_DELETE_PER_CYCLE", expected an integer. err strconv.ParseInt: parsing "": invalid syntax
+2016-10-13T20:53:48Z [WARN] Invalid format for "ECS_AVAILABLE_LOGGING_DRIVERS" environment variable; expected a JSON array like ["json-file","syslog"]. err unexpected EOF
+2016-10-13T20:53:48Z [WARN] Invalid format for "ECS_NUM_IMAGES_DELETE_PER_CYCLE", expected an integer. err strconv.ParseInt: parsing "": invalid syntax
+2016-10-13T20:53:48Z [WARN] Could not parse duration value: invalid for Environment Variable ECS_CONTAINER_STOP_TIMEOUT : time: invalid duration invalid
+2016-10-13T20:53:48Z [WARN] Invalid format for "ECS_AVAILABLE_LOGGING_DRIVERS" environment variable; expected a JSON array like ["json-file","syslog"]. err unexpected EOF
+2016-10-13T20:53:48Z [WARN] Invalid format for "ECS_NUM_IMAGES_DELETE_PER_CYCLE", expected an integer. err strconv.ParseInt: parsing "": invalid syntax
+2016-10-13T20:53:48Z [WARN] Discarded invalid value for docker stop timeout, parsed as: -10s
+2016-10-13T20:53:48Z [WARN] Invalid format for "ECS_AVAILABLE_LOGGING_DRIVERS" environment variable; expected a JSON array like ["json-file","syslog"]. err unexpected EOF
+2016-10-13T20:53:48Z [WARN] Invalid format for "ECS_NUM_IMAGES_DELETE_PER_CYCLE", expected an integer. err strconv.ParseInt: parsing "": invalid syntax
+2016-10-13T20:53:48Z [CRITICAL] Configuration key not set, key: AWSRegion
+--- PASS: TestInvalideDockerStopTimeout (0.00s)
+=== RUN   TestInvalidFormatParseEnvVariableUint16
+--- PASS: TestInvalidFormatParseEnvVariableUint16 (0.00s)
+=== RUN   TestValidFormatParseEnvVariableUint16
+--- PASS: TestValidFormatParseEnvVariableUint16 (0.00s)
+=== RUN   TestInvalidFormatParseEnvVariableDuration
+--- PASS: TestInvalidFormatParseEnvVariableDuration (0.00s)
+=== RUN   TestValidFormatParseEnvVariableDuration
+--- PASS: TestValidFormatParseEnvVariableDuration (0.00s)
+=== RUN   TestInvalidTaskCleanupTimeout
+--- PASS: TestInvalidTaskCleanupTimeout (0.00s)
+=== RUN   TestTaskCleanupTimeout
+--- PASS: TestTaskCleanupTimeout (0.00s)
+=== RUN   TestInvalidReservedMemory
+--- PASS: TestInvalidReservedMemory (0.00s)
+2016-10-13T20:53:48Z [WARN] Invalid format for "FOO" environment variable; expected unsigned integer. err strconv.ParseUint: parsing "foo": invalid syntax
+2016-10-13T20:53:48Z [WARN] Could not parse duration value: foo for Environment Variable FOO : time: invalid duration foo
+2016-10-13T20:53:48Z [WARN] Discarded invalid value for docker stop timeout, parsed as: -10s
+2016-10-13T20:53:48Z [WARN] Invalid format for "ECS_AVAILABLE_LOGGING_DRIVERS" environment variable; expected a JSON array like ["json-file","syslog"]. err unexpected EOF
+=== RUN   TestReservedMemory
+2016-10-13T20:53:48Z [WARN] Invalid format for "ECS_NUM_IMAGES_DELETE_PER_CYCLE", expected an integer. err strconv.ParseInt: parsing "": invalid syntax
+2016-10-13T20:53:48Z [WARN] Invalid value for image cleanup duration, will be overridden with the default value: 3h0m0s. Parsed value: 1s, minimum value: 1m0s.
+2016-10-13T20:53:48Z [WARN] Discarded invalid value for docker stop timeout, parsed as: -10s
+2016-10-13T20:53:48Z [WARN] Invalid format for "ECS_AVAILABLE_LOGGING_DRIVERS" environment variable; expected a JSON array like ["json-file","syslog"]. err unexpected EOF
+2016-10-13T20:53:48Z [WARN] Invalid format for "ECS_NUM_IMAGES_DELETE_PER_CYCLE", expected an integer. err strconv.ParseInt: parsing "": invalid syntax
+2016-10-13T20:53:48Z [WARN] Invalid format for "ECS_RESERVED_MEMORY" environment variable; expected unsigned integer. err strconv.ParseUint: parsing "-1": invalid syntax
+2016-10-13T20:53:48Z [WARN] Discarded invalid value for docker stop timeout, parsed as: -10s
+2016-10-13T20:53:48Z [WARN] Invalid format for "ECS_AVAILABLE_LOGGING_DRIVERS" environment variable; expected a JSON array like ["json-file","syslog"]. err unexpected EOF
+2016-10-13T20:53:48Z [WARN] Invalid format for "ECS_NUM_IMAGES_DELETE_PER_CYCLE", expected an integer. err strconv.ParseInt: parsing "": invalid syntax
+--- PASS: TestReservedMemory (0.01s)
+=== RUN   TestTaskIAMRoleEnabled
+2016-10-13T20:53:48Z [WARN] Discarded invalid value for docker stop timeout, parsed as: -10s
+--- PASS: TestTaskIAMRoleEnabled (0.00s)
+=== RUN   TestTaskIAMRoleForHostNetworkEnabled
+2016-10-13T20:53:48Z [WARN] Invalid format for "ECS_AVAILABLE_LOGGING_DRIVERS" environment variable; expected a JSON array like ["json-file","syslog"]. err unexpected EOF
+2016-10-13T20:53:48Z [WARN] Invalid format for "ECS_NUM_IMAGES_DELETE_PER_CYCLE", expected an integer. err strconv.ParseInt: parsing "": invalid syntax
+2016-10-13T20:53:48Z [WARN] Discarded invalid value for docker stop timeout, parsed as: -10s
+2016-10-13T20:53:48Z [WARN] Invalid format for "ECS_AVAILABLE_LOGGING_DRIVERS" environment variable; expected a JSON array like ["json-file","syslog"]. err unexpected EOF
+2016-10-13T20:53:48Z [WARN] Invalid format for "ECS_NUM_IMAGES_DELETE_PER_CYCLE", expected an integer. err strconv.ParseInt: parsing "": invalid syntax
+--- PASS: TestTaskIAMRoleForHostNetworkEnabled (0.00s)
+=== RUN   TestCredentialsAuditLogFile
+2016-10-13T20:53:48Z [WARN] Discarded invalid value for docker stop timeout, parsed as: -10s
+2016-10-13T20:53:48Z [WARN] Invalid format for "ECS_AVAILABLE_LOGGING_DRIVERS" environment variable; expected a JSON array like ["json-file","syslog"]. err unexpected EOF
+2016-10-13T20:53:48Z [WARN] Invalid format for "ECS_NUM_IMAGES_DELETE_PER_CYCLE", expected an integer. err strconv.ParseInt: parsing "": invalid syntax
+2016-10-13T20:53:48Z [WARN] Discarded invalid value for docker stop timeout, parsed as: -10s
+2016-10-13T20:53:48Z [WARN] Invalid format for "ECS_AVAILABLE_LOGGING_DRIVERS" environment variable; expected a JSON array like ["json-file","syslog"]. err unexpected EOF
+2016-10-13T20:53:48Z [WARN] Invalid format for "ECS_NUM_IMAGES_DELETE_PER_CYCLE", expected an integer. err strconv.ParseInt: parsing "": invalid syntax
+--- PASS: TestCredentialsAuditLogFile (0.00s)
+=== RUN   TestCredentialsAuditLogDisabled
+--- PASS: TestCredentialsAuditLogDisabled (0.00s)
+=== RUN   TestImageCleanupMinimumInterval
+2016-10-13T20:53:48Z [WARN] Discarded invalid value for docker stop timeout, parsed as: -10s
+2016-10-13T20:53:48Z [WARN] Invalid format for "ECS_AVAILABLE_LOGGING_DRIVERS" environment variable; expected a JSON array like ["json-file","syslog"]. err unexpected EOF
+2016-10-13T20:53:48Z [WARN] Invalid format for "ECS_NUM_IMAGES_DELETE_PER_CYCLE", expected an integer. err strconv.ParseInt: parsing "": invalid syntax
+--- PASS: TestImageCleanupMinimumInterval (0.00s)
+=== RUN   TestImageCleanupMinimumNumImagesToDeletePerCycle
+2016-10-13T20:53:48Z [WARN] Discarded invalid value for docker stop timeout, parsed as: -10s
+2016-10-13T20:53:48Z [WARN] Invalid format for "ECS_AVAILABLE_LOGGING_DRIVERS" environment variable; expected a JSON array like ["json-file","syslog"]. err unexpected EOF
+2016-10-13T20:53:48Z [WARN] Invalid format for "ECS_NUM_IMAGES_DELETE_PER_CYCLE", expected an integer. err strconv.ParseInt: parsing "": invalid syntax
+2016-10-13T20:53:48Z [WARN] Invalid value for image cleanup duration, will be overridden with the default value: 30m0s. Parsed value: 1m0s, minimum value: 10m0s.
+2016-10-13T20:53:48Z [WARN] Discarded invalid value for docker stop timeout, parsed as: -10s
+--- PASS: TestImageCleanupMinimumNumImagesToDeletePerCycle (0.00s)
+=== RUN   TestSensitiveRawMessageImplements
+--- PASS: TestSensitiveRawMessageImplements (0.00s)
+=== RUN   TestSensitiveRawMessage
+--- PASS: TestSensitiveRawMessage (0.00s)
+PASS
+coverage: 83.1% of statements
+ok  	github.com/aws/amazon-ecs-agent/agent/config	0.111s	coverage: 83.1% of statements
+=== RUN   TestIAMRoleCredentialsFromACS
+--- PASS: TestIAMRoleCredentialsFromACS (0.00s)
+=== RUN   TestGetTaskCredentialsUnknownId
+--- PASS: TestGetTaskCredentialsUnknownId (0.00s)
+=== RUN   TestSetTaskCredentialsEmptyTaskCredentials
+--- PASS: TestSetTaskCredentialsEmptyTaskCredentials (0.00s)
+=== RUN   TestSetTaskCredentialsNoCredentialsId
+--- PASS: TestSetTaskCredentialsNoCredentialsId (0.00s)
+=== RUN   TestSetTaskCredentialsNoTaskArn
+--- PASS: TestSetTaskCredentialsNoTaskArn (0.00s)
+=== RUN   TestSetAndGetTaskCredentialsHappyPath
+--- PASS: TestSetAndGetTaskCredentialsHappyPath (0.00s)
+=== RUN   TestGenerateCredentialsEndpointRelativeURI
+--- PASS: TestGenerateCredentialsEndpointRelativeURI (0.00s)
+=== RUN   TestRemoveExistingCredentials
+--- PASS: TestRemoveExistingCredentials (0.00s)
+PASS
+coverage: 100.0% of statements
+ok  	github.com/aws/amazon-ecs-agent/agent/credentials	0.085s	coverage: 100.0% of statements
+?   	github.com/aws/amazon-ecs-agent/agent/credentials/mocks	[no test files]
+=== RUN   TestDefaultCredentials
+--- PASS: TestDefaultCredentials (0.00s)
+=== RUN   TestGetInstanceIdentityDoc
+--- PASS: TestGetInstanceIdentityDoc (0.00s)
+=== RUN   TestRetriesOnError
+2016-10-13T20:53:44Z [WARN] Error accessing the EC2 Metadata Service; retrying: Something broke
+2016-10-13T20:53:45Z [WARN] Error accessing the EC2 Metadata Service; non-200 response: 500
+--- PASS: TestRetriesOnError (0.83s)
+=== RUN   TestErrorPropogatesUp
+2016-10-13T20:53:45Z [WARN] Error accessing the EC2 Metadata Service; retrying: Something broke
+2016-10-13T20:53:45Z [WARN] Error accessing the EC2 Metadata Service; retrying: Something broke
+2016-10-13T20:53:45Z [WARN] Error accessing the EC2 Metadata Service; retrying: Something broke
+2016-10-13T20:53:45Z [WARN] Error accessing the EC2 Metadata Service; retrying: Something broke
+--- PASS: TestErrorPropogatesUp (0.53s)
+PASS
+coverage: 75.9% of statements
+ok  	github.com/aws/amazon-ecs-agent/agent/ec2	1.396s	coverage: 75.9% of statements
+?   	github.com/aws/amazon-ecs-agent/agent/ec2/mocks	[no test files]
+=== RUN   TestClientTokenCacheSet
+--- PASS: TestClientTokenCacheSet (0.00s)
+=== RUN   TestClientCachingSameClient
+--- PASS: TestClientCachingSameClient (0.00s)
+=== RUN   TestClientCachingDifferentClients
+--- PASS: TestClientCachingDifferentClients (0.00s)
+=== RUN   TestGetAuthorizationTokenSuite
+=== RUN   TestGetAuthorizationTokenCacheHit
+--- PASS: TestGetAuthorizationTokenCacheHit (0.00s)
+=== RUN   TestGetAuthorizationTokenCacheHitExpiredToken
+--- PASS: TestGetAuthorizationTokenCacheHitExpiredToken (0.00s)
+=== RUN   TestGetAuthorizationTokenCacheMiss
+--- PASS: TestGetAuthorizationTokenCacheMiss (0.00s)
+=== RUN   TestGetAuthorizationTokenError
+--- PASS: TestGetAuthorizationTokenError (0.00s)
+=== RUN   TestGetAuthorizationTokenMissingAuthData
+--- PASS: TestGetAuthorizationTokenMissingAuthData (0.00s)
+=== RUN   TestIsTokenValid
+--- PASS: TestIsTokenValid (0.00s)
+--- PASS: TestGetAuthorizationTokenSuite (0.00s)
+PASS
+coverage: 92.9% of statements
+ok  	github.com/aws/amazon-ecs-agent/agent/ecr	0.118s	coverage: 92.9% of statements
+?   	github.com/aws/amazon-ecs-agent/agent/ecr/mocks	[no test files]
+?   	github.com/aws/amazon-ecs-agent/agent/ecr/model	[no test files]
+?   	github.com/aws/amazon-ecs-agent/agent/ecr/model/ecr	[no test files]
+?   	github.com/aws/amazon-ecs-agent/agent/ecs_client/model	[no test files]
+?   	github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs	[no test files]
+=== RUN   TestPullImageOutputTimeout
+--- PASS: TestPullImageOutputTimeout (0.00s)
+=== RUN   TestPullImageGlobalTimeout
+--- PASS: TestPullImageGlobalTimeout (0.00s)
+=== RUN   TestPullImage
+--- PASS: TestPullImage (0.00s)
+=== RUN   TestPullImageTag
+--- PASS: TestPullImageTag (0.00s)
+=== RUN   TestPullImageDigest
+--- PASS: TestPullImageDigest (0.00s)
+=== RUN   TestPullEmptyvolumeImage
+--- PASS: TestPullEmptyvolumeImage (0.00s)
+=== RUN   TestPullExistingEmptyvolumeImage
+--- PASS: TestPullExistingEmptyvolumeImage (0.00s)
+=== RUN   TestPullImageECRSuccess
+2016-10-13T20:53:59Z [WARN] Invalid format for "ECS_NUM_IMAGES_DELETE_PER_CYCLE", expected an integer. err strconv.ParseInt: parsing "": invalid syntax
+2016-10-13T20:53:59Z [CRITICAL] Unable to communicate with EC2 Metadata service to infer region: blackholed
+2016-10-13T20:53:59Z [CRITICAL] Configuration key not set, key: AWSRegion
+--- PASS: TestPullImageECRSuccess (0.00s)
+=== RUN   TestPullImageECRAuthFail
+2016-10-13T20:53:59Z [WARN] Invalid format for "ECS_NUM_IMAGES_DELETE_PER_CYCLE", expected an integer. err strconv.ParseInt: parsing "": invalid syntax
+2016-10-13T20:53:59Z [CRITICAL] Unable to communicate with EC2 Metadata service to infer region: blackholed
+2016-10-13T20:53:59Z [CRITICAL] Configuration key not set, key: AWSRegion
+--- PASS: TestPullImageECRAuthFail (0.00s)
+=== RUN   TestCreateContainerTimeout
+--- PASS: TestCreateContainerTimeout (0.02s)
+=== RUN   TestCreateContainerInspectTimeout
+--- PASS: TestCreateContainerInspectTimeout (0.00s)
+=== RUN   TestCreateContainer
+--- PASS: TestCreateContainer (0.00s)
+=== RUN   TestStartContainerTimeout
+--- PASS: TestStartContainerTimeout (0.00s)
+=== RUN   TestStartContainer
+--- PASS: TestStartContainer (0.00s)
+=== RUN   TestStopContainerTimeout
+--- PASS: TestStopContainerTimeout (0.00s)
+=== RUN   TestStopContainer
+--- PASS: TestStopContainer (0.00s)
+=== RUN   TestInspectContainerTimeout
+--- PASS: TestInspectContainerTimeout (0.00s)
+=== RUN   TestInspectContainer
+--- PASS: TestInspectContainer (0.00s)
+=== RUN   TestContainerEvents
+2016-10-13T20:54:00Z [INFO] process within container 123 died due to OOM
+--- PASS: TestContainerEvents (0.00s)
+=== RUN   TestDockerVersion
+--- PASS: TestDockerVersion (0.00s)
+=== RUN   TestListContainers
+--- PASS: TestListContainers (0.00s)
+=== RUN   TestListContainersTimeout
+--- PASS: TestListContainersTimeout (0.00s)
+=== RUN   TestPingFailError
+2016-10-13T20:54:00Z [WARN] Invalid format for "ECS_NUM_IMAGES_DELETE_PER_CYCLE", expected an integer. err strconv.ParseInt: parsing "": invalid syntax
+2016-10-13T20:54:00Z [CRITICAL] Unable to communicate with EC2 Metadata service to infer region: blackholed
+2016-10-13T20:54:00Z [CRITICAL] Configuration key not set, key: AWSRegion
+--- PASS: TestPingFailError (0.00s)
+=== RUN   TestUsesVersionedClient
+2016-10-13T20:54:00Z [ERROR] Unable to ping docker daemon. Ensure docker is running. module="TaskEngine" err="err"
+2016-10-13T20:54:00Z [WARN] Invalid format for "ECS_NUM_IMAGES_DELETE_PER_CYCLE", expected an integer. err strconv.ParseInt: parsing "": invalid syntax
+2016-10-13T20:54:00Z [CRITICAL] Unable to communicate with EC2 Metadata service to infer region: blackholed
+2016-10-13T20:54:00Z [CRITICAL] Configuration key not set, key: AWSRegion
+--- PASS: TestUsesVersionedClient (0.00s)
+=== RUN   TestUnavailableVersionError
+2016-10-13T20:54:00Z [WARN] Invalid format for "ECS_NUM_IMAGES_DELETE_PER_CYCLE", expected an integer. err strconv.ParseInt: parsing "": invalid syntax
+2016-10-13T20:54:00Z [CRITICAL] Unable to communicate with EC2 Metadata service to infer region: blackholed
+2016-10-13T20:54:00Z [CRITICAL] Configuration key not set, key: AWSRegion
+--- PASS: TestUnavailableVersionError (0.00s)
+=== RUN   TestStatsNormalExit
+--- PASS: TestStatsNormalExit (0.00s)
+=== RUN   TestStatsClosed
+--- PASS: TestStatsClosed (0.00s)
+	docker_container_engine_test.go:847: Received cancel after 2 iterations
+=== RUN   TestStatsErrorReading
+--- PASS: TestStatsErrorReading (0.00s)
+=== RUN   TestStatsClientError
+--- PASS: TestStatsClientError (0.00s)
+=== RUN   TestRemoveImageTimeout
+--- PASS: TestRemoveImageTimeout (0.00s)
+=== RUN   TestRemoveImage
+--- PASS: TestRemoveImage (0.00s)
+=== RUN   TestAddAndRemoveContainerToImageStateReferenceHappyPath
+2016-10-13T20:54:00Z [WARN] Invalid format for "ECS_NUM_IMAGES_DELETE_PER_CYCLE", expected an integer. err strconv.ParseInt: parsing "": invalid syntax
+2016-10-13T20:54:00Z [CRITICAL] Unable to communicate with EC2 Metadata service to infer region: blackholed
+2016-10-13T20:54:00Z [CRITICAL] Configuration key not set, key: AWSRegion
+--- PASS: TestAddAndRemoveContainerToImageStateReferenceHappyPath (0.00s)
+=== RUN   TestAddContainerReferenceToImageStateInspectError
+--- PASS: TestAddContainerReferenceToImageStateInspectError (0.00s)
+=== RUN   TestAddContainerReferenceToImageStateWithNoImageName
+--- PASS: TestAddContainerReferenceToImageStateWithNoImageName (0.00s)
+=== RUN   TestAddInvalidContainerReferenceToImageState
+2016-10-13T20:54:00Z [INFO] Adding image name- testContainerImage to Image state- sha256:qwerty
+2016-10-13T20:54:00Z [INFO] Updating container reference testContainer in Image State - sha256:qwerty
+2016-10-13T20:54:00Z [INFO] Removing Container Reference: testContainer from Image State- sha256:qwerty
+2016-10-13T20:54:00Z [INFO] Adding image name- testContainerImage to Image state- sha256:qwerty
+2016-10-13T20:54:00Z [ERROR] Error inspecting image testContainerImage: error inspecting
+2016-10-13T20:54:00Z [INFO] Adding image name- testContainerImage to Image state- sha256:qwerty
+2016-10-13T20:54:00Z [INFO] Updating container reference testContainer in Image State - sha256:qwerty
+2016-10-13T20:54:00Z [WARN] Invalid format for "ECS_NUM_IMAGES_DELETE_PER_CYCLE", expected an integer. err strconv.ParseInt: parsing "": invalid syntax
+2016-10-13T20:54:00Z [CRITICAL] Unable to communicate with EC2 Metadata service to infer region: blackholed
+2016-10-13T20:54:00Z [CRITICAL] Configuration key not set, key: AWSRegion
+--- PASS: TestAddInvalidContainerReferenceToImageState (0.00s)
+=== RUN   TestAddContainerReferenceToExistingImageState
+--- PASS: TestAddContainerReferenceToExistingImageState (0.00s)
+=== RUN   TestAddContainerReferenceToExistingImageStateNoState
+--- PASS: TestAddContainerReferenceToExistingImageStateNoState (0.00s)
+=== RUN   TestAddContainerReferenceToNewImageState
+--- PASS: TestAddContainerReferenceToNewImageState (0.00s)
+=== RUN   TestAddContainerReferenceToNewImageStateAddedState
+--- PASS: TestAddContainerReferenceToNewImageStateAddedState (0.00s)
+=== RUN   TestRemoveContainerReferenceFromInvalidImageState
+2016-10-13T20:54:00Z [INFO] Adding image name- testContainerImage to Image state- sha256:asdfg
+2016-10-13T20:54:00Z [INFO] Adding image name- testContainerImage to Image state- sha256:qwerty
+2016-10-13T20:54:00Z [INFO] Updating container reference testContainer in Image State - sha256:qwerty
+2016-10-13T20:54:00Z [INFO] Adding image name- testContainerImage to Image state- sha256:qwerty
+2016-10-13T20:54:00Z [INFO] Updating container reference testContainer in Image State - sha256:qwerty
+2016-10-13T20:54:00Z [INFO] Adding image name- testContainerImage to Image state- sha256:asdfg
+2016-10-13T20:54:00Z [INFO] Adding image name- testContainerImage to Image state- sha256:qwerty
+2016-10-13T20:54:00Z [INFO] Updating container reference testContainer in Image State - sha256:qwerty
+2016-10-13T20:54:00Z [WARN] Invalid format for "ECS_NUM_IMAGES_DELETE_PER_CYCLE", expected an integer. err strconv.ParseInt: parsing "": invalid syntax
+2016-10-13T20:54:00Z [CRITICAL] Unable to communicate with EC2 Metadata service to infer region: blackholed
+2016-10-13T20:54:00Z [CRITICAL] Configuration key not set, key: AWSRegion
+--- PASS: TestRemoveContainerReferenceFromInvalidImageState (0.00s)
+=== RUN   TestRemoveInvalidContainerReferenceFromImageState
+2016-10-13T20:54:00Z [WARN] Invalid format for "ECS_NUM_IMAGES_DELETE_PER_CYCLE", expected an integer. err strconv.ParseInt: parsing "": invalid syntax
+2016-10-13T20:54:00Z [CRITICAL] Unable to communicate with EC2 Metadata service to infer region: blackholed
+2016-10-13T20:54:00Z [CRITICAL] Configuration key not set, key: AWSRegion
+--- PASS: TestRemoveInvalidContainerReferenceFromImageState (0.00s)
+=== RUN   TestRemoveContainerReferenceFromImageStateInspectError
+2016-10-13T20:54:00Z [WARN] Invalid format for "ECS_NUM_IMAGES_DELETE_PER_CYCLE", expected an integer. err strconv.ParseInt: parsing "": invalid syntax
+2016-10-13T20:54:00Z [CRITICAL] Unable to communicate with EC2 Metadata service to infer region: blackholed
+2016-10-13T20:54:00Z [CRITICAL] Configuration key not set, key: AWSRegion
+--- PASS: TestRemoveContainerReferenceFromImageStateInspectError (0.00s)
+=== RUN   TestRemoveContainerReferenceFromImageStateWithNoReference
+--- PASS: TestRemoveContainerReferenceFromImageStateWithNoReference (0.00s)
+=== RUN   TestGetCandidateImagesForDeletionImageNoImageState
+--- PASS: TestGetCandidateImagesForDeletionImageNoImageState (0.00s)
+=== RUN   TestGetCandidateImagesForDeletionImageJustPulled
+--- PASS: TestGetCandidateImagesForDeletionImageJustPulled (0.00s)
+=== RUN   TestGetCandidateImagesForDeletionImageHasContainerReference
+--- PASS: TestGetCandidateImagesForDeletionImageHasContainerReference (0.00s)
+=== RUN   TestGetCandidateImagesForDeletionImageHasMoreContainerReferences
+--- PASS: TestGetCandidateImagesForDeletionImageHasMoreContainerReferences (0.00s)
+=== RUN   TestGetLeastRecentlyUsedImages
+2016-10-13T20:54:00Z [ERROR] Error inspecting image myContainerImage: error inspecting
+2016-10-13T20:54:00Z [INFO] Updating container reference testContainer in Image State - sha256:qwerty
+2016-10-13T20:54:00Z [INFO] Updating container reference testContainer in Image State - sha256:qwerty
+2016-10-13T20:54:00Z [INFO] Updating container reference testContainer2 in Image State - sha256:qwerty
+2016-10-13T20:54:00Z [INFO] Removing Container Reference: testContainer from Image State- sha256:qwerty
+2016-10-13T20:54:00Z [WARN] Invalid format for "ECS_NUM_IMAGES_DELETE_PER_CYCLE", expected an integer. err strconv.ParseInt: parsing "": invalid syntax
+2016-10-13T20:54:00Z [CRITICAL] Unable to communicate with EC2 Metadata service to infer region: blackholed
+2016-10-13T20:54:00Z [CRITICAL] Configuration key not set, key: AWSRegion
+--- PASS: TestGetLeastRecentlyUsedImages (0.00s)
+=== RUN   TestGetLeastRecentlyUsedImagesLessThanFive
+--- PASS: TestGetLeastRecentlyUsedImagesLessThanFive (0.00s)
+=== RUN   TestRemoveAlreadyExistingImageNameWithDifferentID
+--- PASS: TestRemoveAlreadyExistingImageNameWithDifferentID (0.00s)
+=== RUN   TestImageCleanupHappyPath
+2016-10-13T20:54:00Z [INFO] Adding image name- testContainerImage to Image state- sha256:qwerty
+2016-10-13T20:54:00Z [INFO] Updating container reference testContainer in Image State - sha256:qwerty
+2016-10-13T20:54:00Z [INFO] Adding image name- testContainerImage to Image state- sha256:asdfg
+2016-10-13T20:54:00Z [INFO] Updating container reference testContainer1 in Image State - sha256:asdfg
+2016-10-13T20:54:00Z [INFO] Adding image name- testContainerImage to Image state- sha256:qwerty
+2016-10-13T20:54:00Z [INFO] Updating container reference testContainer in Image State - sha256:qwerty
+2016-10-13T20:54:00Z [INFO] Removing Container Reference: testContainer from Image State- sha256:qwerty
+2016-10-13T20:54:00Z [INFO] Adding image name- anotherImage to Image state- sha256:qwerty
+2016-10-13T20:54:00Z [INFO] Candidate image for deletion: &{Image:0xc8201bed80 Containers:[] PulledAt:2016-08-13 13:54:00.020895293 -0700 PDT LastUsedAt:2016-08-13 13:54:00.020896274 -0700 PDT updateLock:{w:{state:0 sema:0} writerSem:0 readerSem:0 readerCount:0 readerWait:0}}
+2016-10-13T20:54:00Z [INFO] Found 1 eligible images for deletion
+2016-10-13T20:54:00Z [INFO] Removing Image: testContainerImage
+2016-10-13T20:54:00Z [INFO] Image removed: testContainerImage
+2016-10-13T20:54:00Z [INFO] Removing Image: anotherImage
+2016-10-13T20:54:00Z [INFO] Image removed: anotherImage
+2016-10-13T20:54:00Z [INFO] Removing Image State: sha256:qwerty from Image Manager
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:00Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:00Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:01Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:01Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:01Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:01Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:01Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:01Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:01Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:01Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:01Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:01Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:01Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:01Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:01Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:01Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:01Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:01Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:01Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:01Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:01Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:01Z [INFO] End of eligible images for deletion
+--- PASS: TestImageCleanupHappyPath (1.00s)
+=== RUN   TestImageCleanupCannotRemoveImage
+--- PASS: TestImageCleanupCannotRemoveImage (0.00s)
+=== RUN   TestImageCleanupRemoveImageById
+--- PASS: TestImageCleanupRemoveImageById (0.00s)
+=== RUN   TestDeleteImage
+--- PASS: TestDeleteImage (0.00s)
+=== RUN   TestDeleteImageNotFoundError
+--- PASS: TestDeleteImageNotFoundError (0.00s)
+=== RUN   TestDeleteImageOtherRemoveImageErrors
+--- PASS: TestDeleteImageOtherRemoveImageErrors (0.00s)
+=== RUN   TestDeleteImageIDNull
+--- PASS: TestDeleteImageIDNull (0.00s)
+=== RUN   TestRemoveLeastRecentlyUsedImageNoImage
+--- PASS: TestRemoveLeastRecentlyUsedImageNoImage (0.00s)
+=== RUN   TestRemoveUnusedImagesNoImages
+--- PASS: TestRemoveUnusedImagesNoImages (0.00s)
+=== RUN   TestGetImageStateFromImageName
+--- PASS: TestGetImageStateFromImageName (0.00s)
+=== RUN   TestGetImageStateFromImageNameNoImageState
+--- PASS: TestGetImageStateFromImageNameNoImageState (0.00s)
+=== RUN   TestBatchContainerHappyPath
+2016-10-13T20:54:01Z [INFO] Adding image name- testContainerImage to Image state- sha256:qwerty
+2016-10-13T20:54:01Z [INFO] Updating container reference testContainer in Image State - sha256:qwerty
+2016-10-13T20:54:01Z [INFO] Removing Container Reference: testContainer from Image State- sha256:qwerty
+2016-10-13T20:54:01Z [INFO] Candidate image for deletion: &{Image:0xc8202a6ab0 Containers:[] PulledAt:2016-08-13 13:54:01.021239924 -0700 PDT LastUsedAt:2016-08-13 13:54:01.021241997 -0700 PDT updateLock:{w:{state:0 sema:0} writerSem:0 readerSem:0 readerCount:0 readerWait:0}}
+2016-10-13T20:54:01Z [INFO] Found 1 eligible images for deletion
+2016-10-13T20:54:01Z [INFO] Removing Image: testContainerImage
+2016-10-13T20:54:01Z [ERROR] Error removing Image testContainerImage - error removing image
+2016-10-13T20:54:01Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:01Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:01Z [INFO] Adding image name- testContainerImage to Image state- sha256:qwerty
+2016-10-13T20:54:01Z [INFO] Updating container reference testContainer in Image State - sha256:qwerty
+2016-10-13T20:54:01Z [INFO] Removing Container Reference: testContainer from Image State- sha256:qwerty
+2016-10-13T20:54:01Z [INFO] Candidate image for deletion: &{Image:0xc8202a71a0 Containers:[] PulledAt:2016-08-13 13:54:01.021384741 -0700 PDT LastUsedAt:2016-08-13 13:54:01.021385602 -0700 PDT updateLock:{w:{state:0 sema:0} writerSem:0 readerSem:0 readerCount:0 readerWait:0}}
+2016-10-13T20:54:01Z [INFO] Found 1 eligible images for deletion
+2016-10-13T20:54:01Z [INFO] Removing Image: sha256:qwerty
+2016-10-13T20:54:01Z [INFO] Image removed: sha256:qwerty
+2016-10-13T20:54:01Z [INFO] Removing Image State: sha256:qwerty from Image Manager
+2016-10-13T20:54:01Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:01Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:01Z [INFO] Adding image name- testContainerImage to Image state- sha256:qwerty
+2016-10-13T20:54:01Z [INFO] Updating container reference testContainer in Image State - sha256:qwerty
+2016-10-13T20:54:01Z [INFO] Removing Image: testContainerImage
+2016-10-13T20:54:01Z [INFO] Image removed: testContainerImage
+2016-10-13T20:54:01Z [INFO] Removing Image State: sha256:qwerty from Image Manager
+2016-10-13T20:54:01Z [INFO] Adding image name- testContainerImage to Image state- sha256:qwerty
+2016-10-13T20:54:01Z [INFO] Updating container reference testContainer in Image State - sha256:qwerty
+2016-10-13T20:54:01Z [INFO] Removing Image: testContainerImage
+2016-10-13T20:54:01Z [ERROR] Image already removed from the instance: no such image
+2016-10-13T20:54:01Z [INFO] Image removed: testContainerImage
+2016-10-13T20:54:01Z [INFO] Removing Image State: sha256:qwerty from Image Manager
+2016-10-13T20:54:01Z [INFO] Adding image name- testContainerImage to Image state- sha256:qwerty
+2016-10-13T20:54:01Z [INFO] Updating container reference testContainer in Image State - sha256:qwerty
+2016-10-13T20:54:01Z [INFO] Removing Image: testContainerImage
+2016-10-13T20:54:01Z [ERROR] Error removing Image testContainerImage - container for this image exists
+2016-10-13T20:54:01Z [ERROR] Image ID to be deleted is null
+2016-10-13T20:54:01Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:01Z [INFO] Adding image name- testContainerImage to Image state- sha256:qwerty
+2016-10-13T20:54:01Z [INFO] Updating container reference testContainer in Image State - sha256:qwerty
+2016-10-13T20:54:01Z [INFO] Adding image name- testContainerImage to Image state- sha256:qwerty
+2016-10-13T20:54:01Z [INFO] Updating container reference testContainer in Image State - sha256:qwerty
+2016-10-13T20:54:01Z [INFO] Pulling container module="TaskEngine" task="sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (NONE->RUNNING) Containers: [sleep5 (NONE->RUNNING),]" container="sleep5(busybox) (NONE->RUNNING)"
+2016-10-13T20:54:01Z [INFO] Creating container module="TaskEngine" task="sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (NONE->RUNNING) Containers: [sleep5 (PULLED->RUNNING),]" container="sleep5(busybox) (PULLED->RUNNING)"
+2016-10-13T20:54:01Z [INFO] Created container name mapping for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (NONE->RUNNING) Containers: [sleep5 (CREATED->RUNNING),] - sleep5(busybox) (CREATED->RUNNING) -> ecs-sleep5-2-sleep5-eec4e8bbb0a18fccf801
+2016-10-13T20:54:01Z [INFO] Created docker container for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (NONE->RUNNING) Containers: [sleep5 (CREATED->RUNNING),]: sleep5(busybox) (CREATED->RUNNING) -> containerId
+2016-10-13T20:54:01Z [INFO] Event stream TESTTASKENGINE start listening...
+2016-10-13T20:54:01Z [INFO] Starting container module="TaskEngine" task="sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (CREATED->RUNNING) Containers: [sleep5 (CREATED->RUNNING),]" container="sleep5(busybox) (CREATED->RUNNING)"
+2016-10-13T20:54:01Z [INFO] Task change event module="TaskEngine" event="{TaskArn:arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1 Status:RUNNING Reason: SentStatus:NONE}"
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (RUNNING->RUNNING) Containers: [sleep5 (RUNNING->RUNNING),]: sleep5(busybox) (RUNNING->RUNNING) to CREATED, but already RUNNING
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) - Exit: 0 to RUNNING, but already RUNNING
+2016-10-13T20:54:01Z [INFO] Task change event module="TaskEngine" event="{TaskArn:arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1 Status:STOPPED Reason: SentStatus:NONE}"
+2016-10-13T20:54:01Z [INFO] No eligible images for deletion for this cleanup cycle
+2016-10-13T20:54:01Z [INFO] End of eligible images for deletion
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) - Exit: 0 to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Cleaning up task's containers and data module="TaskEngine" task="sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]"
+2016-10-13T20:54:01Z [INFO] Removing container module="TaskEngine" task="sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]" container="sleep5(busybox) (STOPPED->STOPPED) - Exit: 0"
+--- PASS: TestBatchContainerHappyPath (0.01s)
+=== RUN   TestRemoveEvents
+2016-10-13T20:54:01Z [INFO] Pulling container module="TaskEngine" task="sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (NONE->RUNNING) Containers: [sleep5 (NONE->RUNNING),]" container="sleep5(busybox) (NONE->RUNNING)"
+2016-10-13T20:54:01Z [INFO] Creating container module="TaskEngine" task="sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (NONE->RUNNING) Containers: [sleep5 (PULLED->RUNNING),]" container="sleep5(busybox) (PULLED->RUNNING)"
+2016-10-13T20:54:01Z [INFO] Created container name mapping for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (RUNNING->RUNNING) Containers: [sleep5 (RUNNING->RUNNING),] - sleep5(busybox) (RUNNING->RUNNING) -> ecs-sleep5-2-sleep5-fcfcd9f7ded28ab1b601
+2016-10-13T20:54:01Z [INFO] Created docker container for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (RUNNING->RUNNING) Containers: [sleep5 (RUNNING->RUNNING),]: sleep5(busybox) (RUNNING->RUNNING) -> containerId
+2016-10-13T20:54:01Z [INFO] Event stream TESTTASKENGINE start listening...
+2016-10-13T20:54:01Z [INFO] Starting container module="TaskEngine" task="sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (CREATED->RUNNING) Containers: [sleep5 (CREATED->RUNNING),]" container="sleep5(busybox) (CREATED->RUNNING)"
+2016-10-13T20:54:01Z [INFO] Task change event module="TaskEngine" event="{TaskArn:arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1 Status:RUNNING Reason: SentStatus:NONE}"
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (RUNNING->RUNNING) Containers: [sleep5 (RUNNING->RUNNING),]: sleep5(busybox) (RUNNING->RUNNING) to CREATED, but already RUNNING
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) - Exit: 0 to RUNNING, but already RUNNING
+2016-10-13T20:54:01Z [INFO] Task change event module="TaskEngine" event="{TaskArn:arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1 Status:STOPPED Reason: SentStatus:NONE}"
+2016-10-13T20:54:01Z [INFO] Cleaning up task's containers and data module="TaskEngine" task="sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]"
+2016-10-13T20:54:01Z [INFO] Removing container module="TaskEngine" task="sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]" container="sleep5(busybox) (STOPPED->STOPPED) - Exit: 0"
+--- PASS: TestRemoveEvents (0.01s)
+=== RUN   TestStartTimeoutThenStart
+2016-10-13T20:54:01Z [INFO] Pulling container module="TaskEngine" task="sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (NONE->RUNNING) Containers: [sleep5 (NONE->RUNNING),]" container="sleep5(busybox) (NONE->RUNNING)"
+2016-10-13T20:54:01Z [INFO] Creating container module="TaskEngine" task="sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (NONE->RUNNING) Containers: [sleep5 (PULLED->RUNNING),]" container="sleep5(busybox) (PULLED->RUNNING)"
+2016-10-13T20:54:01Z [INFO] Created container name mapping for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),] - sleep5(busybox) (STOPPED->STOPPED) -> ecs-sleep5-2-sleep5-8acaa0cedacbd4834800
+2016-10-13T20:54:01Z [INFO] Created docker container for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) -> containerId
+2016-10-13T20:54:01Z [INFO] Event stream TESTTASKENGINE start listening...
+2016-10-13T20:54:01Z [INFO] Starting container module="TaskEngine" task="sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (CREATED->RUNNING) Containers: [sleep5 (CREATED->RUNNING),]" container="sleep5(busybox) (CREATED->RUNNING)"
+2016-10-13T20:54:01Z [INFO] Error transitioning container module="TaskEngine" task="sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (CREATED->RUNNING) Containers: [sleep5 (CREATED->RUNNING),]" container="sleep5(busybox) (CREATED->RUNNING)" state="RUNNING"
+2016-10-13T20:54:01Z [WARN] Error with docker; stopping container module="TaskEngine" task="sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (CREATED->RUNNING) Containers: [sleep5 (RUNNING->RUNNING),]" container="sleep5(busybox) (RUNNING->RUNNING)" err="Could not transition to ; timed out after waiting 0"
+2016-10-13T20:54:01Z [INFO] Stopping container module="TaskEngine" task="sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (RUNNING->STOPPED) Containers: [sleep5 (RUNNING->STOPPED),]" container="sleep5(busybox) (RUNNING->STOPPED)"
+2016-10-13T20:54:01Z [INFO] Error transitioning container module="TaskEngine" task="sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (RUNNING->STOPPED) Containers: [sleep5 (RUNNING->STOPPED),]" container="sleep5(busybox) (RUNNING->STOPPED)" state="STOPPED"
+2016-10-13T20:54:01Z [INFO] Error for 'docker stop' of container; assuming it's stopped anyways module="TaskEngine" task="sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (RUNNING->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]"
+2016-10-13T20:54:01Z [INFO] Task change event module="TaskEngine" event="{TaskArn:arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1 Status:STOPPED Reason: SentStatus:NONE}"
+2016-10-13T20:54:01Z [WARN] Container that we thought was stopped came back; re-stopping it once module="TaskEngine" task="sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]"
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to RUNNING, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Stopping container module="TaskEngine" task="sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]" container="sleep5(busybox) (STOPPED->STOPPED)"
+2016-10-13T20:54:01Z [INFO] Error transitioning container module="TaskEngine" task="sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]" container="sleep5(busybox) (STOPPED->STOPPED)" state="STOPPED"
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to CREATED, but already STOPPED
+--- PASS: TestStartTimeoutThenStart (0.00s)
+=== RUN   TestSteadyStatePoll
+2016-10-13T20:54:01Z [INFO] Pulling container module="TaskEngine" task="sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (NONE->RUNNING) Containers: [sleep5 (NONE->RUNNING),]" container="sleep5(busybox) (NONE->RUNNING)"
+2016-10-13T20:54:01Z [INFO] Creating container module="TaskEngine" task="sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (NONE->RUNNING) Containers: [sleep5 (PULLED->RUNNING),]" container="sleep5(busybox) (PULLED->RUNNING)"
+2016-10-13T20:54:01Z [INFO] Created container name mapping for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (RUNNING->RUNNING) Containers: [sleep5 (RUNNING->RUNNING),] - sleep5(busybox) (RUNNING->RUNNING) -> ecs-sleep5-2-sleep5-f4da8cb2b78d8eee0f00
+2016-10-13T20:54:01Z [INFO] Created docker container for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (RUNNING->RUNNING) Containers: [sleep5 (RUNNING->RUNNING),]: sleep5(busybox) (RUNNING->RUNNING) -> containerId
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to RUNNING, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to RUNNING, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Event stream TESTTASKENGINE start listening...
+2016-10-13T20:54:01Z [INFO] Starting container module="TaskEngine" task="sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (CREATED->RUNNING) Containers: [sleep5 (CREATED->RUNNING),]" container="sleep5(busybox) (CREATED->RUNNING)"
+2016-10-13T20:54:01Z [INFO] Task change event module="TaskEngine" event="{TaskArn:arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1 Status:RUNNING Reason: SentStatus:NONE}"
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (RUNNING->RUNNING) Containers: [sleep5 (RUNNING->RUNNING),]: sleep5(busybox) (RUNNING->RUNNING) to RUNNING, but already RUNNING
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (RUNNING->RUNNING) Containers: [sleep5 (RUNNING->RUNNING),]: sleep5(busybox) (RUNNING->RUNNING) to CREATED, but already RUNNING
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (RUNNING->RUNNING) Containers: [sleep5 (RUNNING->RUNNING),]: sleep5(busybox) (RUNNING->RUNNING) to RUNNING, but already RUNNING
+2016-10-13T20:54:01Z [INFO] Task change event module="TaskEngine" event="{TaskArn:arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1 Status:STOPPED Reason: SentStatus:NONE}"
+--- PASS: TestSteadyStatePoll (0.01s)
+=== RUN   TestStopWithPendingStops
+2016-10-13T20:54:01Z [INFO] Pulling container module="TaskEngine" task="sleep5:2 arn2, Status: (NONE->RUNNING) Containers: [sleep5 (NONE->RUNNING),]" container="sleep5(busybox) (NONE->RUNNING)"
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Event stream TESTTASKENGINE start listening...
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Task change event module="TaskEngine" event="{TaskArn:arn2 Status:STOPPED Reason: SentStatus:NONE}"
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+--- PASS: TestStopWithPendingStops (0.04s)
+=== RUN   TestCreateContainerForceSave
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [WARN] Container that we thought was stopped came back; re-stopping it once module="TaskEngine" task="sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]"
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to RUNNING, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Stopping container module="TaskEngine" task="sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]" container="sleep5(busybox) (STOPPED->STOPPED)"
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to STOPPED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Task change event module="TaskEngine" event="{TaskArn:arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1 Status:STOPPED Reason: SentStatus:NONE}"
+2016-10-13T20:54:01Z [INFO] Creating container module="TaskEngine" task="sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (NONE->RUNNING) Containers: [sleep5 (NONE->NONE),]" container="sleep5(busybox) (NONE->NONE)"
+--- PASS: TestCreateContainerForceSave (0.00s)
+=== RUN   TestCreateContainerMergesLabels
+2016-10-13T20:54:01Z [INFO] Created container name mapping for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (NONE->RUNNING) Containers: [sleep5 (NONE->NONE),] - sleep5(busybox) (NONE->NONE) -> ecs-sleep5-2-sleep5-faf8ecc49fdfbbbd7d00
+2016-10-13T20:54:01Z [INFO] Created docker container for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (NONE->RUNNING) Containers: [sleep5 (NONE->NONE),]: sleep5(busybox) (NONE->NONE) -> 
+2016-10-13T20:54:01Z [INFO] Event stream TESTTASKENGINE start listening...
+2016-10-13T20:54:01Z [INFO] Pulling container module="TaskEngine" task="sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]" container="sleep5(busybox) (STOPPED->STOPPED)"
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn2, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to PULLED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Task desired status is stopped, skip pull container: sleep5(busybox) (STOPPED->STOPPED), task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]
+2016-10-13T20:54:01Z [INFO] Error transitioning container module="TaskEngine" task="sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]" container="sleep5(busybox) (STOPPED->STOPPED)" state="PULLED"
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (STOPPED->STOPPED) Containers: [sleep5 (STOPPED->STOPPED),]: sleep5(busybox) (STOPPED->STOPPED) to PULLED, but already STOPPED
+2016-10-13T20:54:01Z [INFO] Event stream TESTTASKENGINE start listening...
+--- PASS: TestCreateContainerMergesLabels (0.00s)
+=== RUN   TestTaskTransitionWhenStopContainerTimesout
+2016-10-13T20:54:01Z [INFO] Creating container module="TaskEngine" task="myFamily:1 arn:aws:ecs:us-east-1:012345678910:task/c09f0188-7f87-4b0f-bfc3-16296622b6fe, Status: (NONE->NONE) Containers: [c1 (NONE->NONE),]" container="c1() (NONE->NONE)"
+2016-10-13T20:54:01Z [INFO] Created container name mapping for task myFamily:1 arn:aws:ecs:us-east-1:012345678910:task/c09f0188-7f87-4b0f-bfc3-16296622b6fe, Status: (NONE->NONE) Containers: [c1 (NONE->NONE),] - c1() (NONE->NONE) -> ecs-myFamily-1-c1-deaaf9bc93f1aabc2800
+2016-10-13T20:54:01Z [INFO] Created docker container for task myFamily:1 arn:aws:ecs:us-east-1:012345678910:task/c09f0188-7f87-4b0f-bfc3-16296622b6fe, Status: (NONE->NONE) Containers: [c1 (NONE->NONE),]: c1() (NONE->NONE) -> 
+2016-10-13T20:54:01Z [INFO] Event stream TESTTASKENGINE start listening...
+2016-10-13T20:54:01Z [INFO] Pulling container module="TaskEngine" task="sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (NONE->RUNNING) Containers: [sleep5 (NONE->RUNNING),]" container="sleep5(busybox) (NONE->RUNNING)"
+2016-10-13T20:54:01Z [INFO] Creating container module="TaskEngine" task="sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (NONE->RUNNING) Containers: [sleep5 (PULLED->RUNNING),]" container="sleep5(busybox) (PULLED->RUNNING)"
+2016-10-13T20:54:01Z [INFO] Created container name mapping for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (NONE->RUNNING) Containers: [sleep5 (PULLED->RUNNING),] - sleep5(busybox) (PULLED->RUNNING) -> ecs-sleep5-2-sleep5-84ee87a4d393afd63300
+2016-10-13T20:54:01Z [INFO] Created docker container for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (CREATED->RUNNING) Containers: [sleep5 (CREATED->RUNNING),]: sleep5(busybox) (CREATED->RUNNING) -> containerId
+2016-10-13T20:54:01Z [INFO] Redundant container state change for task sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (CREATED->RUNNING) Containers: [sleep5 (CREATED->RUNNING),]: sleep5(busybox) (CREATED->RUNNING) to CREATED, but already CREATED
+2016-10-13T20:54:01Z [INFO] Starting container module="TaskEngine" task="sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (CREATED->RUNNING) Containers: [sleep5 (CREATED->RUNNING),]" container="sleep5(busybox) (CREATED->RUNNING)"
+2016-10-13T20:54:01Z [INFO] Error transitioning container module="TaskEngine" task="sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (CREATED->RUNNING) Containers: [sleep5 (CREATED->RUNNING),]" container="sleep5(busybox) (CREATED->RUNNING)" state="RUNNING"
+2016-10-13T20:54:01Z [WARN] Error with docker; stopping container module="TaskEngine" task="sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (CREATED->RUNNING) Containers: [sleep5 (RUNNING->RUNNING),]" container="sleep5(busybox) (RUNNING->RUNNING)" err="Could not transition to ; timed out after waiting 0"
+2016-10-13T20:54:01Z [INFO] Stopping container module="TaskEngine" task="sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (RUNNING->STOPPED) Containers: [sleep5 (RUNNING->STOPPED),]" container="sleep5(busybox) (RUNNING->STOPPED)"
+2016-10-13T20:54:01Z [INFO] Error transitioning container module="TaskEngine" task="sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (RUNNING->STOPPED) Containers: [sleep5 (RUNNING->STOPPED),]" container="sleep5(busybox) (RUNNING->STOPPED)" state="STOPPED"
+2016-10-13T20:54:01Z [INFO] DockerTimeoutError for 'docker stop' of container; ignoring state change;  task: sleep5:2 arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1, Status: (RUNNING->STOPPED) Containers: [sleep5 (RUNNING->STOPPED),], container: sleep5(busybox) (RUNNING->STOPPED), error: Could not transition to stop; timed out after waiting 30s
+2016-10-13T20:54:01Z [INFO] Task change event module="TaskEngine" event="{TaskArn:arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1 Status:STOPPED Reason: SentStatus:NONE}"
+--- PASS: TestTaskTransitionWhenStopContainerTimesout (0.00s)
+=== RUN   TestCapabilities
+--- PASS: TestCapabilities (0.00s)
+=== RUN   TestCapabilitiesECR
+--- PASS: TestCapabilitiesECR (0.00s)
+=== RUN   TestCapabilitiesTaskIAMRoleForSupportedDockerVersion
+--- PASS: TestCapabilitiesTaskIAMRoleForSupportedDockerVersion (0.00s)
+=== RUN   TestCapabilitiesTaskIAMRoleForUnSupportedDockerVersion
+--- PASS: TestCapabilitiesTaskIAMRoleForUnSupportedDockerVersion (0.00s)
+=== RUN   TestCapabilitiesTaskIAMRoleNetworkHostForSupportedDockerVersion
+--- PASS: TestCapabilitiesTaskIAMRoleNetworkHostForSupportedDockerVersion (0.00s)
+=== RUN   TestCapabilitiesTaskIAMRoleNetworkHostForUnSupportedDockerVersion
+--- PASS: TestCapabilitiesTaskIAMRoleNetworkHostForUnSupportedDockerVersion (0.00s)
+=== RUN   TestGetTaskByArn
+--- PASS: TestGetTaskByArn (0.00s)
+PASS
+coverage: 76.3% of statements
+ok  	github.com/aws/amazon-ecs-agent/agent/engine	1.143s	coverage: 76.3% of statements
+=== RUN   TestValidDependencies
+--- PASS: TestValidDependencies (0.00s)
+=== RUN   TestDependenciesAreResolved
+--- PASS: TestDependenciesAreResolved (0.00s)
+=== RUN   TestRunningependsOnDependencies
+--- PASS: TestRunningependsOnDependencies (0.00s)
+PASS
+coverage: 83.3% of statements
+ok  	github.com/aws/amazon-ecs-agent/agent/engine/dependencygraph	0.074s	coverage: 83.3% of statements
+=== RUN   TestDockerCfgAuth
+--- PASS: TestDockerCfgAuth (0.00s)
+=== RUN   TestAuthAppliesToOnlyRegistry
+--- PASS: TestAuthAppliesToOnlyRegistry (0.00s)
+=== RUN   TestAuthErrors
+--- PASS: TestAuthErrors (0.00s)
+=== RUN   TestEmptyConfig
+--- PASS: TestEmptyConfig (0.00s)
+=== RUN   TestNewAuthProviderECRAuthNoAuth
+--- PASS: TestNewAuthProviderECRAuthNoAuth (0.00s)
+=== RUN   TestNewAuthProviderECRAuth
+--- PASS: TestNewAuthProviderECRAuth (0.00s)
+=== RUN   TestGetAuthConfigSuccess
+--- PASS: TestGetAuthConfigSuccess (0.00s)
+=== RUN   TestGetAuthConfigNoMatchAuthorizationToken
+--- PASS: TestGetAuthConfigNoMatchAuthorizationToken (0.00s)
+	ecr_test.go:129: No AuthorizationToken found for proxy/myimage
+=== RUN   TestGetAuthConfigBadBase64
+--- PASS: TestGetAuthConfigBadBase64 (0.00s)
+	ecr_test.go:163: No AuthorizationToken found for proxy/myimage
+=== RUN   TestGetAuthConfigMissingResponse
+--- PASS: TestGetAuthConfigMissingResponse (0.00s)
+	ecr_test.go:192: Missing AuthorizationData in ECR response for proxy/myimage
+=== RUN   TestGetAuthConfigECRError
+--- PASS: TestGetAuthConfigECRError (0.00s)
+	ecr_test.go:221: test error
+=== RUN   TestGetAuthConfigNoAuthData
+--- PASS: TestGetAuthConfigNoAuthData (0.00s)
+	ecr_test.go:243: ecrAuthProvider cannot be used without AuthData
+PASS
+coverage: 98.8% of statements
+ok  	github.com/aws/amazon-ecs-agent/agent/engine/dockerauth	0.055s	coverage: 98.8% of statements
+=== RUN   TestGetDefaultClientSuccess
+--- PASS: TestGetDefaultClientSuccess (0.00s)
+=== RUN   TestGetClientCached
+--- PASS: TestGetClientCached (0.00s)
+=== RUN   TestGetClientFailCreateNotCached
+--- PASS: TestGetClientFailCreateNotCached (0.00s)
+=== RUN   TestGetClientFailPingNotCached
+--- PASS: TestGetClientFailPingNotCached (0.00s)
+=== RUN   TestFindAvailableVersiosn
+--- PASS: TestFindAvailableVersiosn (0.00s)
+PASS
+coverage: 92.9% of statements
+ok  	github.com/aws/amazon-ecs-agent/agent/engine/dockerclient	0.027s	coverage: 92.9% of statements
+?   	github.com/aws/amazon-ecs-agent/agent/engine/dockerclient/mocks	[no test files]
+?   	github.com/aws/amazon-ecs-agent/agent/engine/dockeriface	[no test files]
+?   	github.com/aws/amazon-ecs-agent/agent/engine/dockeriface/mocks	[no test files]
+=== RUN   TestCreateDockerTaskEngineState
+--- PASS: TestCreateDockerTaskEngineState (0.00s)
+=== RUN   TestAddTask
+--- PASS: TestAddTask (0.00s)
+=== RUN   TestTwophaseAddContainer
+--- PASS: TestTwophaseAddContainer (0.00s)
+=== RUN   TestRemoveTask
+--- PASS: TestRemoveTask (0.00s)
+=== RUN   TestAddImageState
+--- PASS: TestAddImageState (0.00s)
+=== RUN   TestAddEmptyImageState
+--- PASS: TestAddEmptyImageState (0.00s)
+=== RUN   TestAddEmptyIdImageState
+--- PASS: TestAddEmptyIdImageState (0.00s)
+=== RUN   TestRemoveImageState
+--- PASS: TestRemoveImageState (0.00s)
+=== RUN   TestRemoveEmptyImageState
+--- PASS: TestRemoveEmptyImageState (0.00s)
+=== RUN   TestRemoveNonExistingImageState
+--- PASS: TestRemoveNonExistingImageState (0.00s)
+PASS
+coverage: 70.1% of statements
+ok  	github.com/aws/amazon-ecs-agent/agent/engine/dockerstate	0.040s	coverage: 70.1% of statements
+=== RUN   TestJsonEncoding
+--- PASS: TestJsonEncoding (0.00s)
+PASS
+coverage: 72.7% of statements
+ok  	github.com/aws/amazon-ecs-agent/agent/engine/dockerstate/testutils	0.080s	coverage: 72.7% of statements
+?   	github.com/aws/amazon-ecs-agent/agent/engine/emptyvolume	[no test files]
+?   	github.com/aws/amazon-ecs-agent/agent/engine/image	[no test files]
+?   	github.com/aws/amazon-ecs-agent/agent/engine/testutils	[no test files]
+=== RUN   TestSendsEventsOneContainer
+2016-10-13T20:54:06Z [INFO] Adding event module="eventhandler" change="ContainerChange: 1 containerName -> RUNNING"
+2016-10-13T20:54:06Z [INFO] Adding event module="eventhandler" change="ContainerChange: 2 containerName -> RUNNING"
+2016-10-13T20:54:06Z [INFO] Adding event module="eventhandler" change="TaskChange: 2 -> RUNNING"
+2016-10-13T20:54:06Z [INFO] Sending container change module="eventhandler" event="ContainerChange: 2 containerName -> RUNNING" change="ContainerChange: 2 containerName -> RUNNING"
+2016-10-13T20:54:06Z [INFO] Sending task change module="eventhandler" event="TaskChange: 2 -> RUNNING" change="TaskChange: 2 -> RUNNING"
+--- PASS: TestSendsEventsOneContainer (0.00s)
+=== RUN   TestSendsEventsOneEventRetries
+2016-10-13T20:54:06Z [INFO] Sending container change module="eventhandler" event="ContainerChange: 1 containerName -> RUNNING" change="ContainerChange: 1 containerName -> RUNNING"
+2016-10-13T20:54:06Z [INFO] Adding event module="eventhandler" change="ContainerChange: 1 containerName -> RUNNING"
+2016-10-13T20:54:06Z [INFO] Sending container change module="eventhandler" event="ContainerChange: 1 containerName -> RUNNING" change="ContainerChange: 1 containerName -> RUNNING"
+2016-10-13T20:54:06Z [ERROR] Unretriable error submitting container state change module="eventhandler" event="ContainerChange: 1 containerName -> RUNNING" err="test"
+--- PASS: TestSendsEventsOneEventRetries (1.15s)
+=== RUN   TestSendsEventsConcurrentLimit
+2016-10-13T20:54:07Z [INFO] Sending container change module="eventhandler" event="ContainerChange: 1 containerName -> RUNNING" change="ContainerChange: 1 containerName -> RUNNING"
+2016-10-13T20:54:07Z [INFO] Adding event module="eventhandler" change="ContainerChange: concurrent_0 containerName -> RUNNING"
+2016-10-13T20:54:07Z [INFO] Adding event module="eventhandler" change="ContainerChange: concurrent_1 containerName -> RUNNING"
+2016-10-13T20:54:07Z [INFO] Adding event module="eventhandler" change="ContainerChange: concurrent_2 containerName -> RUNNING"
+2016-10-13T20:54:07Z [INFO] Adding event module="eventhandler" change="ContainerChange: concurrent_3 containerName -> RUNNING"
+2016-10-13T20:54:07Z [INFO] Sending container change module="eventhandler" event="ContainerChange: concurrent_3 containerName -> RUNNING" change="ContainerChange: concurrent_3 containerName -> RUNNING"
+2016-10-13T20:54:07Z [INFO] Sending container change module="eventhandler" event="ContainerChange: concurrent_1 containerName -> RUNNING" change="ContainerChange: concurrent_1 containerName -> RUNNING"
+2016-10-13T20:54:07Z [INFO] Sending container change module="eventhandler" event="ContainerChange: concurrent_2 containerName -> RUNNING" change="ContainerChange: concurrent_2 containerName -> RUNNING"
+2016-10-13T20:54:07Z [INFO] Sending container change module="eventhandler" event="ContainerChange: concurrent_0 containerName -> RUNNING" change="ContainerChange: concurrent_0 containerName -> RUNNING"
+--- PASS: TestSendsEventsConcurrentLimit (0.03s)
+=== RUN   TestSendsEventsContainerDifferences
+--- PASS: TestSendsEventsContainerDifferences (0.00s)
+=== RUN   TestSendsEventsTaskDifferences
+2016-10-13T20:54:07Z [INFO] Adding event module="eventhandler" change="ContainerChange: notreplaced1 containerName -> RUNNING"
+2016-10-13T20:54:07Z [INFO] Adding event module="eventhandler" change="ContainerChange: notreplaced1 containerName -> STOPPED"
+2016-10-13T20:54:07Z [INFO] Sending container change module="eventhandler" event="ContainerChange: notreplaced1 containerName -> RUNNING" change="ContainerChange: notreplaced1 containerName -> RUNNING"
+2016-10-13T20:54:07Z [INFO] Sending container change module="eventhandler" event="ContainerChange: notreplaced1 containerName -> STOPPED" change="ContainerChange: notreplaced1 containerName -> STOPPED"
+2016-10-13T20:54:07Z [INFO] Adding event module="eventhandler" change="ContainerChange: notreplaced2 containerName -> RUNNING"
+2016-10-13T20:54:07Z [INFO] Adding event module="eventhandler" change="TaskChange: notreplaced -> RUNNING"
+2016-10-13T20:54:07Z [INFO] Adding event module="eventhandler" change="ContainerChange: notreplaced2 containerName -> STOPPED"
+2016-10-13T20:54:07Z [INFO] Adding event module="eventhandler" change="TaskChange: notreplaced2 -> STOPPED"
+2016-10-13T20:54:07Z [INFO] Sending task change module="eventhandler" event="TaskChange: notreplaced -> RUNNING" change="TaskChange: notreplaced -> RUNNING"
+--- PASS: TestSendsEventsTaskDifferences (0.00s)
+=== RUN   TestSendsEventsDedupe
+2016-10-13T20:54:07Z [INFO] Sending container change module="eventhandler" event="ContainerChange: notreplaced2 containerName -> RUNNING" change="ContainerChange: notreplaced2 containerName -> RUNNING"
+2016-10-13T20:54:07Z [INFO] Sending container change module="eventhandler" event="ContainerChange: notreplaced2 containerName -> STOPPED" change="ContainerChange: notreplaced2 containerName -> STOPPED"
+2016-10-13T20:54:07Z [INFO] Sending task change module="eventhandler" event="TaskChange: notreplaced2 -> STOPPED" change="TaskChange: notreplaced2 -> STOPPED"
+2016-10-13T20:54:07Z [INFO] Adding event module="eventhandler" change="ContainerChange: alreadySent containerName -> RUNNING, Known Sent: RUNNING"
+2016-10-13T20:54:07Z [INFO] Adding event module="eventhandler" change="TaskChange: alreadySent -> RUNNING, Known Sent: RUNNING"
+2016-10-13T20:54:07Z [INFO] Adding event module="eventhandler" change="ContainerChange: containerSent containerName -> RUNNING, Known Sent: RUNNING"
+2016-10-13T20:54:07Z [INFO] Adding event module="eventhandler" change="TaskChange: containerSent -> RUNNING, Known Sent: NONE"
+2016-10-13T20:54:07Z [INFO] Not submitting redundant event; just removing module="eventhandler" event="ContainerChange: containerSent containerName -> RUNNING, Known Sent: RUNNING"
+2016-10-13T20:54:07Z [INFO] Sending task change module="eventhandler" event="TaskChange: containerSent -> RUNNING, Known Sent: NONE" change="TaskChange: containerSent -> RUNNING, Known Sent: NONE"
+2016-10-13T20:54:07Z [INFO] Not submitting redundant event; just removing module="eventhandler" event="ContainerChange: alreadySent containerName -> RUNNING, Known Sent: RUNNING"
+2016-10-13T20:54:07Z [INFO] Not submitting redundant event; just removing module="eventhandler" event="TaskChange: alreadySent -> RUNNING, Known Sent: RUNNING"
+--- PASS: TestSendsEventsDedupe (0.01s)
+=== RUN   TestShouldBeSent
+--- PASS: TestShouldBeSent (0.00s)
+PASS
+coverage: 80.5% of statements
+ok  	github.com/aws/amazon-ecs-agent/agent/eventhandler	1.213s	coverage: 80.5% of statements
+=== RUN   TestSubscribe
+1476392037155995928 [Info] Event stream TestSubscribe start listening...
+1476392037156049268 [Debug] Event stream TestSubscribe received events, broadcasting to listeners...
+--- PASS: TestSubscribe (1.00s)
+=== RUN   TestUnsubscribe
+1476392038156325049 [Info] Event stream TestUnsubscribe start listening...
+1476392038156390052 [Debug] Event stream TestUnsubscribe received events, broadcasting to listeners...
+1476392038156403843 [Info] Event stream TestSubscribe stopped listening...
+1476392039156494670 [Debug] Unsbuscribe event handler listener1 from event stream TestUnsubscribe
+1476392039156546506 [Debug] Event stream TestUnsubscribe received events, broadcasting to listeners...
+--- PASS: TestUnsubscribe (2.00s)
+=== RUN   TestCancelEventStream
+1476392040156763057 [Info] Event stream TestCancelEventStream start listening...
+1476392040156797979 [Info] Event stream TestCancelEventStream stopped listening...
+1476392040156826922 [Info] Event stream TestUnsubscribe stopped listening...
+--- PASS: TestCancelEventStream (1.00s)
+PASS
+coverage: 95.0% of statements
+ok  	github.com/aws/amazon-ecs-agent/agent/eventstream	4.049s	coverage: 95.0% of statements
+=== RUN   TestTest
+--- PASS: TestTest (0.00s)
+PASS
+coverage: 0.0% of statements
+ok  	github.com/aws/amazon-ecs-agent/agent/functional_tests/tests	0.093s	coverage: 0.0% of statements
+?   	github.com/aws/amazon-ecs-agent/agent/functional_tests/tests/generated	[no test files]
+=== RUN   TestTest
+--- PASS: TestTest (0.00s)
+PASS
+coverage: 0.0% of statements
+ok  	github.com/aws/amazon-ecs-agent/agent/functional_tests/tests/generated/simpletests	0.027s	coverage: 0.0% of statements
+?   	github.com/aws/amazon-ecs-agent/agent/functional_tests/util	[no test files]
+?   	github.com/aws/amazon-ecs-agent/agent/gogenerate	[no test files]
+=== RUN   TestMetadataHandler
+--- PASS: TestMetadataHandler (0.00s)
+=== RUN   TestListMultipleTasks
+--- PASS: TestListMultipleTasks (0.00s)
+=== RUN   TestGetTaskByDockerID
+--- PASS: TestGetTaskByDockerID (0.00s)
+=== RUN   TestGetTaskByDockerID404
+--- PASS: TestGetTaskByDockerID404 (0.00s)
+=== RUN   TestGetTaskByTaskArn
+--- PASS: TestGetTaskByTaskArn (0.00s)
+=== RUN   TestGetTaskByTaskArnNotFound
+--- PASS: TestGetTaskByTaskArnNotFound (0.00s)
+=== RUN   TestGetTaskByTaskArnAndDockerIDBadRequest
+--- PASS: TestGetTaskByTaskArnAndDockerIDBadRequest (0.00s)
+=== RUN   TestBackendMismatchMapping
+--- PASS: TestBackendMismatchMapping (0.00s)
+=== RUN   TestLicenseHandler
+--- PASS: TestLicenseHandler (0.00s)
+=== RUN   TestLicenseHandlerError
+--- PASS: TestLicenseHandlerError (0.00s)
+PASS
+coverage: 86.2% of statements
+ok  	github.com/aws/amazon-ecs-agent/agent/handlers	0.027s	coverage: 86.2% of statements
+=== RUN   TestInvalidPath
+--- PASS: TestInvalidPath (0.00s)
+=== RUN   TestCredentialsV1RequestWithNoArguments
+--- PASS: TestCredentialsV1RequestWithNoArguments (0.00s)
+=== RUN   TestCredentialsV2RequestWithNoArguments
+--- PASS: TestCredentialsV2RequestWithNoArguments (0.00s)
+=== RUN   TestCredentialsV1RequestWhenCredentialsIdNotFound
+--- PASS: TestCredentialsV1RequestWhenCredentialsIdNotFound (0.00s)
+=== RUN   TestCredentialsV2RequestWhenCredentialsIdNotFound
+--- PASS: TestCredentialsV2RequestWhenCredentialsIdNotFound (0.00s)
+=== RUN   TestCredentialsV1RequestWhenCredentialsUninitialized
+--- PASS: TestCredentialsV1RequestWhenCredentialsUninitialized (0.00s)
+=== RUN   TestCredentialsV2RequestWhenCredentialsUninitialized
+--- PASS: TestCredentialsV2RequestWhenCredentialsUninitialized (0.00s)
+=== RUN   TestCredentialsV1RequestWhenCredentialsFound
+--- PASS: TestCredentialsV1RequestWhenCredentialsFound (0.00s)
+=== RUN   TestCredentialsV2RequestWhenCredentialsFound
+--- PASS: TestCredentialsV2RequestWhenCredentialsFound (0.00s)
+PASS
+coverage: 72.3% of statements
+ok  	github.com/aws/amazon-ecs-agent/agent/handlers/credentials	0.060s	coverage: 72.3% of statements
+?   	github.com/aws/amazon-ecs-agent/agent/handlers/mocks	[no test files]
+?   	github.com/aws/amazon-ecs-agent/agent/handlers/mocks/http	[no test files]
+?   	github.com/aws/amazon-ecs-agent/agent/httpclient	[no test files]
+?   	github.com/aws/amazon-ecs-agent/agent/httpclient/mock	[no test files]
+=== RUN   TestFormatMessage_NoCtx
+--- PASS: TestFormatMessage_NoCtx (0.00s)
+=== RUN   TestFormatMessage_UnevenCtx
+--- PASS: TestFormatMessage_UnevenCtx (0.00s)
+=== RUN   TestFormatMessage_SimpleCtx
+--- PASS: TestFormatMessage_SimpleCtx (0.00s)
+=== RUN   TestFormatMessage_Struct
+--- PASS: TestFormatMessage_Struct (0.00s)
+=== RUN   TestFormatMessage_TopCtx
+--- PASS: TestFormatMessage_TopCtx (0.00s)
+=== RUN   TestFormatMessage_NewCtx
+--- PASS: TestFormatMessage_NewCtx (0.00s)
+PASS
+coverage: 67.5% of statements
+ok  	github.com/aws/amazon-ecs-agent/agent/logger	0.048s	coverage: 67.5% of statements
+=== RUN   TestWritingToAuditLog
+--- PASS: TestWritingToAuditLog (0.00s)
+=== RUN   TestWritingToAuditLogV2
+--- PASS: TestWritingToAuditLogV2 (0.00s)
+=== RUN   TestWritingErrorsToAuditLog
+--- PASS: TestWritingErrorsToAuditLog (0.00s)
+=== RUN   TestWritingToAuditLogWhenDisabled
+--- PASS: TestWritingToAuditLogWhenDisabled (0.00s)
+=== RUN   TestConstructCommonAuditLogEntryFields
+--- PASS: TestConstructCommonAuditLogEntryFields (0.00s)
+=== RUN   TestConstructAuditLogEntryByTypeGetCredentials
+--- PASS: TestConstructAuditLogEntryByTypeGetCredentials (0.00s)
+=== RUN   TestConstructAuditLogEntryByTypeUnknownType
+--- PASS: TestConstructAuditLogEntryByTypeUnknownType (0.00s)
+PASS
+coverage: 83.9% of statements
+ok  	github.com/aws/amazon-ecs-agent/agent/logger/audit	0.050s	coverage: 83.9% of statements
+?   	github.com/aws/amazon-ecs-agent/agent/logger/audit/mocks	[no test files]
+?   	github.com/aws/amazon-ecs-agent/agent/logger/audit/request	[no test files]
+?   	github.com/aws/amazon-ecs-agent/agent/sighandlers	[no test files]
+?   	github.com/aws/amazon-ecs-agent/agent/sighandlers/exitcodes	[no test files]
+=== RUN   TestStateManager
+--- PASS: TestStateManager (0.00s)
+=== RUN   TestStateManagerNonexistantDirectory
+--- PASS: TestStateManagerNonexistantDirectory (0.00s)
+=== RUN   TestLoadsV1DataCorrectly
+--- PASS: TestLoadsV1DataCorrectly (0.00s)
+PASS
+coverage: 63.3% of statements
+ok  	github.com/aws/amazon-ecs-agent/agent/statemanager	0.070s	coverage: 63.3% of statements
+?   	github.com/aws/amazon-ecs-agent/agent/statemanager/mocks	[no test files]
+=== RUN   TestContainerStatsCollection
+--- PASS: TestContainerStatsCollection (5.00s)
+=== RUN   TestContainerStatsCollectionReconnection
+--- PASS: TestContainerStatsCollectionReconnection (5.00s)
+=== RUN   TestContainerStatsCollectionStopsIfContainerIsTerminal
+--- PASS: TestContainerStatsCollectionStopsIfContainerIsTerminal (0.00s)
+=== RUN   TestStatsEngineWithExistingContainers
+2016-10-13T20:54:27Z [WARN] Error determining if the container container1 is terminal, stopping stats collection: test error
+2016-10-13T20:54:27Z [INFO] Event stream TestStatsEngineWithExistingContainers start listening...
+2016-10-13T20:54:47Z [INFO] Error retrieving stats for container 3e26a97c3569c92c62d9b87ff45da518e4f64883558b0c0650aea924b5c92f11: context canceled
+--- PASS: TestStatsEngineWithExistingContainers (22.39s)
+=== RUN   TestStatsEngineWithNewContainers
+2016-10-13T20:54:50Z [INFO] Event stream TestStatsEngineWithNewContainers start listening...
+2016-10-13T20:55:09Z [INFO] Error retrieving stats for container d3d67bb45642d86b4c65e970846adf3943d2725220a7751cb557d3ca11e8263e: context canceled
+--- PASS: TestStatsEngineWithNewContainers (22.14s)
+=== RUN   TestStatsEngineWithDockerTaskEngine
+2016-10-13T20:55:12Z [INFO] Event stream TestStatsEngineWithDockerTaskEngine start listening...
+2016-10-13T20:55:13Z [INFO] Initializing stats engine
+2016-10-13T20:55:24Z [INFO] Error retrieving stats for container 163b550d86c9753e2f46fec610420c2fc2f71907d77f6d5fa153323333653c1b: context canceled
+--- PASS: TestStatsEngineWithDockerTaskEngine (19.23s)
+=== RUN   TestStatsEngineWithDockerTaskEngineMissingRemoveEvent
+2016-10-13T20:55:31Z [INFO] Event stream TestStatsEngineWithDockerTaskEngine start listening...
+2016-10-13T20:55:32Z [INFO] Initializing stats engine
+2016-10-13T20:55:40Z [INFO] Container 351ccfd2696e9c20c18e72e91bfaff54f8fd2b65e284811adbbe7b13252cab5b is terminal, stopping stats collection
+2016-10-13T20:55:48Z [INFO] Container 351ccfd2696e9c20c18e72e91bfaff54f8fd2b65e284811adbbe7b13252cab5b is terminal, cleaning up and skipping
+--- PASS: TestStatsEngineWithDockerTaskEngineMissingRemoveEvent (17.29s)
+=== RUN   TestStatsEngineAddRemoveContainers
+--- PASS: TestStatsEngineAddRemoveContainers (0.00s)
+=== RUN   TestStatsEngineMetadataInStatsSets
+--- PASS: TestStatsEngineMetadataInStatsSets (0.00s)
+=== RUN   TestStatsEngineInvalidTaskEngine
+--- PASS: TestStatsEngineInvalidTaskEngine (0.00s)
+=== RUN   TestStatsEngineUninitialized
+--- PASS: TestStatsEngineUninitialized (0.00s)
+=== RUN   TestStatsEngineTerminalTask
+--- PASS: TestStatsEngineTerminalTask (0.00s)
+=== RUN   TestQueueAddRemove
+--- PASS: TestQueueAddRemove (0.00s)
+=== RUN   TestQueueAddPredictableHighMemoryUtilization
+--- PASS: TestQueueAddPredictableHighMemoryUtilization (0.00s)
+=== RUN   TestCpuStatsSetNotSetToInfinity
+--- PASS: TestCpuStatsSetNotSetToInfinity (0.00s)
+=== RUN   TestIsNetworkStatsError
+--- PASS: TestIsNetworkStatsError (0.00s)
+=== RUN   TestDockerStatsToContainerStatsCpuUsage
+--- PASS: TestDockerStatsToContainerStatsCpuUsage (0.00s)
+=== RUN   TestDockerStatsToContainerStatsZeroCoresGeneratesError
+--- PASS: TestDockerStatsToContainerStatsZeroCoresGeneratesError (0.00s)
+PASS
+coverage: 86.5% of statements
+ok  	github.com/aws/amazon-ecs-agent/agent/stats	91.117s	coverage: 86.5% of statements
+?   	github.com/aws/amazon-ecs-agent/agent/stats/mock	[no test files]
+?   	github.com/aws/amazon-ecs-agent/agent/stats/resolver	[no test files]
+?   	github.com/aws/amazon-ecs-agent/agent/stats/resolver/mock	[no test files]
+=== RUN   TestPayloadHandlerCalled
+2016-10-13T20:54:17Z [WARN] Error getting instance metrics: uninitialized
+--- PASS: TestPayloadHandlerCalled (0.00s)
+=== RUN   TestPublishMetricsRequest
+--- PASS: TestPublishMetricsRequest (0.00s)
+=== RUN   TestPublishOnceIdleStatsEngine
+--- PASS: TestPublishOnceIdleStatsEngine (0.00s)
+=== RUN   TestPublishOnceNonIdleStatsEngine
+--- PASS: TestPublishOnceNonIdleStatsEngine (0.00s)
+=== RUN   TestDeregisterInstanceStream
+2016-10-13T20:54:17Z [INFO] Event stream TestDeregisterInstanceStream start listening...
+2016-10-13T20:54:17Z [ERROR] Error getting message from ws backend: can't read from a closed websocket, message: 
+--- PASS: TestDeregisterInstanceStream (1.00s)
+PASS
+coverage: 86.8% of statements
+ok  	github.com/aws/amazon-ecs-agent/agent/tcs/client	1.022s	coverage: 86.8% of statements
+=== RUN   TestFormatURL
+--- PASS: TestFormatURL (0.00s)
+=== RUN   TestStartSession
+2016-10-13T20:54:17Z [INFO] Creating poll dialer, host: 127.0.0.1:58135
+--- PASS: TestStartSession (0.08s)
+=== RUN   TestSessionConenctionClosedByRemote
+2016-10-13T20:54:17Z [INFO] Creating poll dialer, host: 127.0.0.1:46821
+2016-10-13T20:54:17Z [INFO] Event stream Deregister_Instance start listening...
+--- PASS: TestSessionConenctionClosedByRemote (0.01s)
+=== RUN   TestConnectionInactiveTimeout
+2016-10-13T20:54:17Z [WARN] Error publishing metrics: websocket: close sent. Request: {
+  Metadata: {
+    Cluster: "arn:aws:ecs:us-east-1:123:cluster/default",
+    ContainerInstance: "arn:aws:ecs:us-east-1:123:container-instance/abc",
+    Fin: true,
+    Idle: false,
+    MessageId: "testMessageId"
+  },
+  TaskMetrics: [{
+      ContainerMetrics: [{
+          CpuStatsSet: {
+            Max: 0.2065826619136986,
+            Min: 0.2065826619136986,
+            SampleCount: 8,
+            Sum: 0.2065826619136986
+          },
+          MemoryStatsSet: {
+            Max: 0.2065826619136986,
+            Min: 0.2065826619136986,
+            SampleCount: 8,
+            Sum: 0.2065826619136986
+          }
+        }],
+      TaskArn: "arn:aws:ecs:us-east-1:123:task/def",
+      TaskDefinitionFamily: "task-def"
+    }],
+  Timestamp: 2016-10-13 13:54:17.946440938 -0700 PDT
+}
+2016-10-13T20:54:17Z [INFO] Event stream Deregister_Instance stopped listening...
+2016-10-13T20:54:17Z [INFO] Creating poll dialer, host: 127.0.0.1:51065
+2016-10-13T20:54:17Z [INFO] Event stream Deregister_Instance start listening...
+2016-10-13T20:54:18Z [ERROR] Error getting message from ws backend: read tcp 127.0.0.1:53387->127.0.0.1:51065: use of closed network connection
+--- PASS: TestConnectionInactiveTimeout (0.06s)
+=== RUN   TestDiscoverEndpointAndStartSession
+--- PASS: TestDiscoverEndpointAndStartSession (0.00s)
+PASS
+coverage: 39.4% of statements
+ok  	github.com/aws/amazon-ecs-agent/agent/tcs/handler	0.185s	coverage: 39.4% of statements
+?   	github.com/aws/amazon-ecs-agent/agent/tcs/model	[no test files]
+?   	github.com/aws/amazon-ecs-agent/agent/tcs/model/ecstcs	[no test files]
+=== RUN   TestSimpleBackoff
+--- PASS: TestSimpleBackoff (0.00s)
+=== RUN   TestJitter
+--- PASS: TestJitter (0.00s)
+=== RUN   TestJsonKeys
+--- PASS: TestJsonKeys (0.00s)
+=== RUN   TestCompleteJsonUnmarshal
+--- PASS: TestCompleteJsonUnmarshal (0.00s)
+=== RUN   TestGetTextSuccess
+--- PASS: TestGetTextSuccess (0.00s)
+=== RUN   TestGetTextErrorLicense
+--- PASS: TestGetTextErrorLicense (0.00s)
+=== RUN   TestGetTextErrorNotice
+--- PASS: TestGetTextErrorNotice (0.00s)
+=== RUN   TestDefaultIfBlank
+--- PASS: TestDefaultIfBlank (0.00s)
+=== RUN   TestZeroOrNil
+--- PASS: TestZeroOrNil (0.00s)
+=== RUN   TestSlicesDeepEqual
+--- PASS: TestSlicesDeepEqual (0.00s)
+=== RUN   TestRetryWithBackoff
+--- PASS: TestRetryWithBackoff (0.00s)
+=== RUN   TestRetryNWithBackoff
+--- PASS: TestRetryNWithBackoff (0.00s)
+=== RUN   TestParseBool
+--- PASS: TestParseBool (0.00s)
+PASS
+coverage: 71.9% of statements
+ok  	github.com/aws/amazon-ecs-agent/agent/utils	0.030s	coverage: 71.9% of statements
+=== RUN   TestStrictlyIncreasing
+--- PASS: TestStrictlyIncreasing (0.00s)
+=== RUN   TestJSONMarshal
+--- PASS: TestJSONMarshal (0.00s)
+=== RUN   TestJSONUnmarshal
+--- PASS: TestJSONUnmarshal (0.00s)
+PASS
+coverage: 93.3% of statements
+ok  	github.com/aws/amazon-ecs-agent/agent/utils/atomic	0.071s	coverage: 93.3% of statements
+?   	github.com/aws/amazon-ecs-agent/agent/utils/mocks	[no test files]
+=== RUN   TestSequentialWaitgroup
+--- PASS: TestSequentialWaitgroup (0.00s)
+=== RUN   TestManyDones
+--- PASS: TestManyDones (0.62s)
+PASS
+coverage: 93.1% of statements
+ok  	github.com/aws/amazon-ecs-agent/agent/utils/sync	0.660s	coverage: 93.1% of statements
+?   	github.com/aws/amazon-ecs-agent/agent/utils/ttime	[no test files]
+?   	github.com/aws/amazon-ecs-agent/agent/utils/ttime/mocks	[no test files]
+?   	github.com/aws/amazon-ecs-agent/agent/version	[no test files]
+?   	github.com/aws/amazon-ecs-agent/agent/version/gen	[no test files]
+?   	github.com/aws/amazon-ecs-agent/agent/wsclient	[no test files]
+?   	github.com/aws/amazon-ecs-agent/agent/wsclient/mock	[no test files]
+?   	github.com/aws/amazon-ecs-agent/agent/wsclient/mock/utils	[no test files]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Fix an issue where agent get wrong cpu number for metrics when running on CoreOS with kernel version >= 1122.2.0
### Implementation details
<!-- How are the changes implemented? -->
Using runtime.NumCPU() to get the number of cpu cores instead of depending on entries of percpu_usage returned by docker stats
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make short-test` and `make test` can run anywhere in a development environment
like your laptop.  Please ensure both of these pass before opening the pull
request.  `make run-functional-tests` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` may incur charges to your AWS account; if you're
unable or unwilling to run these tests in your own account, we can run the tests
and provide test results.
-->
- [x] Builds (`make release`)
- [x] Unit tests (`make test`) pass
- [x] Integration tests (`make run-integ-tests`) pass
- [x] Functional tests (`make run-functional-tests`) pass
- [x] Manually test on CoreOS with both the kernel 1122.2.0 and 1068.9.0

New tests cover the changes: <!-- yes|no -->
yes
### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
no change log
### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
yes
