### PR TITLE
Bugfix: Handle known StopContainer errors

### DIFF
--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -650,7 +650,7 @@ func (engine *DockerTaskEngine) applyContainerState(task *api.Task, container *a
 
 	metadata := tryApplyTransition(task, container, nextState, transitionFunction)
 	if metadata.Error != nil {
-		clog.Info("Error transitioning container", "state", nextState.String())
+		clog.Info("Error transitioning container", "state", nextState.String(), "error", metadata.Error)
 	} else {
 		clog.Debug("Transitioned container", "state", nextState.String())
 		engine.saver.Save()

--- a/agent/engine/errors.go
+++ b/agent/engine/errors.go
@@ -20,7 +20,11 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerclient"
 )
 
-const dockerTimeoutErrorName = "DockerTimeoutError"
+const (
+	dockerTimeoutErrorName     = "DockerTimeoutError"
+	unretriableDockerErrorName = "UnretriableDockerError"
+	dockerStateErrorName       = "DockerStateError"
+)
 
 // engineError wraps the error interface with an identifier method that
 // is used to classify the error type
@@ -93,7 +97,7 @@ func NewDockerStateError(err string) DockerStateError {
 	// Add stringmatching logic as needed to provide better output than docker
 	return DockerStateError{
 		dockerError: err,
-		name:        "DockerStateError",
+		name:        dockerStateErrorName,
 	}
 }
 
@@ -136,4 +140,16 @@ func (err TaskStoppedBeforePullBeginError) Error() string {
 // ErrorName returns the name of the error
 func (TaskStoppedBeforePullBeginError) ErrorName() string {
 	return "TaskStoppedBeforePullBeginError"
+}
+
+type UnretriableDockerError struct {
+	dockerError error
+}
+
+func (err UnretriableDockerError) Error() string {
+	return err.dockerError.Error()
+}
+
+func (UnretriableDockerError) ErrorName() string {
+	return unretriableDockerErrorName
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->
### Summary

<!-- What does this pull request do? -->

The Task Engine silently consumes all error from StopContainer API except
the time out error. Modify this so that only known non-retriable errors
are silently consumed and force reconciliation for other error types.
### Implementation details

<!-- How are the changes implemented? -->

The Task Engine silently consumes all error from StopContainer API except
the time out error. Modify this so that only known non-retriable errors
are silently consumed and force reconciliation for other error types.

These errors include:
1. Container Not Running
2. Unknwon Container ID
3. Docker State Errors from Inspect (Example: invalid command in container
   config)

This should fix the bug where the transient StopContainer errors result
in the Task being prematurely marked as STOPPED.
### Testing

<!-- How was this tested? -->

<!--
Note for external contributors:
`make short-test` and `make test` can run anywhere in a development environment
like your laptop.  Please ensure both of these pass before opening the pull
request.  `make run-functional-tests` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` may incur charges to your AWS account; if you're
unable or unwilling to run these tests in your own account, we can run the tests
and provide test results.
-->
- [X] Builds (`make release`)
- [X] Unit tests (`make short-test`) pass
- [X] Integration tests (`make test` and `make run-integ-tests`) pass
- [X] Functional tests (`make run-functional-tests`) pass

New tests cover the changes: yes
### Description for the changelog

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Bug - Resolved a bug where a Task could prematurely transition to STOPPED
### Licensing

<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->

This contribution is under the terms of the Apache 2.0 License: yes
