### PR TITLE
Fix warning message when ECS_NUM_IMAGES_DELETE_PER_CYCLE is not pr…

### DIFF
--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -314,8 +314,9 @@ func environmentConfig() Config {
 	imageCleanupDisabled := utils.ParseBool(os.Getenv("ECS_DISABLE_IMAGE_CLEANUP"), false)
 	minimumImageDeletionAge := parseEnvVariableDuration("ECS_IMAGE_MINIMUM_CLEANUP_AGE")
 	imageCleanupInterval := parseEnvVariableDuration("ECS_IMAGE_CLEANUP_INTERVAL")
-	numImagesToDeletePerCycle, err := strconv.Atoi(os.Getenv("ECS_NUM_IMAGES_DELETE_PER_CYCLE"))
-	if err != nil {
+	numImagesToDeletePerCycleEnvVal := os.Getenv("ECS_NUM_IMAGES_DELETE_PER_CYCLE")
+	numImagesToDeletePerCycle, err := strconv.Atoi(numImagesToDeletePerCycleEnvVal)
+	if numImagesToDeletePerCycleEnvVal != "" && err != nil {
 		seelog.Warnf("Invalid format for \"ECS_NUM_IMAGES_DELETE_PER_CYCLE\", expected an integer. err %v", err)
 	}
 


### PR DESCRIPTION
### Summary
Fix warning message when ECS_NUM_IMAGES_DELETE_PER_CYCLE is not provided. Related to #557 

### Implementation details
ECS_NUM_IMAGES_DELETE_PER_CYCLE already has a default value in config. Warning being printed is no-op.
### Testing
- [X] Builds (`make release`)
- [X] Unit tests (`make short-test`) pass
- [X] Integration tests (`make test` and `make run-integ-tests`) pass
- [ ] Functional tests (`make run-functional-tests`) 

New tests cover the changes: yes

### Licensing
This contribution is under the terms of the Apache 2.0 License: yes
