### PR TITLE
exclude cache value from container memory utilization metric

### DIFF
--- a/agent/stats/utils.go
+++ b/agent/stats/utils.go
@@ -44,9 +44,10 @@ func dockerStatsToContainerStats(dockerStats *docker.Stats) (*ContainerStats, er
 	}
 
 	cpuUsage := dockerStats.CPUStats.CPUUsage.TotalUsage / numCores
+	memoryUsage := dockerStats.MemoryStats.Usage - dockerStats.MemoryStats.Stats.Cache
 	return &ContainerStats{
 		cpuUsage:    cpuUsage,
-		memoryUsage: dockerStats.MemoryStats.Usage,
+		memoryUsage: memoryUsage,
 		timestamp:   dockerStats.Read,
 	}, nil
 }

--- a/agent/stats/utils_test.go
+++ b/agent/stats/utils_test.go
@@ -84,3 +84,35 @@ func TestDockerStatsToContainerStatsZeroCoresGeneratesError(t *testing.T) {
 		t.Error("Expected error converting container stats with empty PercpuUsage")
 	}
 }
+
+func TestDockerStatsToContainerStatsMemUsage(t *testing.T) {
+	jsonStat := fmt.Sprintf(`
+		{
+			"cpu_stats":{
+				"cpu_usage":{
+					"percpu_usage":[%d, %d, %d, %d],
+					"total_usage":%d
+				}
+			},
+			"memory_stats":{
+				"usage": %d,
+				"max_usage": %d,
+				"stats": {
+					"cache": %d,
+					"rss": %d
+				}
+			}
+		}`, 1, 2, 3, 4, 100, 30, 100, 20, 10)
+	dockerStat := &docker.Stats{}
+	json.Unmarshal([]byte(jsonStat), dockerStat)
+	containerStats, err := dockerStatsToContainerStats(dockerStat)
+	if err != nil {
+		t.Errorf("Error converting container stats: %v", err)
+	}
+	if containerStats == nil {
+		t.Fatal("containerStats should not be nil")
+	}
+	if containerStats.memoryUsage != 10 {
+		t.Error("Unexpected value for memoryUsage", containerStats.memoryUsage)
+	}
+}


### PR DESCRIPTION
### Summary

Closes https://github.com/aws/amazon-ecs-agent/issues/280 by excluding cache usage from memory utilization stat.

### Implementation details

Subtract MemoryStats.Stats.Cache from MemoryStats.Usage and use the result as the memory stat.

### Testing

I have not been able to get the test suite to run successfully on master/dev or on the fork. I'm new to go, so guessing this is an issue with my local configuration 😅 A few things that I've been able to test successfully:

 - The unit test for the affected file.
 - Build an image from the fork + override the agent on a running container instance, confirm via Docker pseudo-files & CloudWatch that the actual usage metric is reported instead of the metric that includes the cache.

I'm happy to keep trying to get the suite to run if this is a prerequisite for a PR, but would really appreciate some pointers on how to get tests running in a fresh environment (any gotchas with versioning/dependencies?)


- [x] Builds (`make release`)
- [x] Unit tests (`make short-test`) pass
- [x] Integration tests (`make test` and `make run-integ-tests`) pass
- [ ] Functional tests (`make run-functional-tests`) pass

New tests cover the changes: Yes

### Description for the changelog

Fix memory metric to exclude cache value.

### Licensing

This contribution is under the terms of the Apache 2.0 License: Yes
