### PR TITLE
Fix version extraction for SemVer prereleases and build metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Amazon ECS Container Agent
 
 [![Build Status](https://travis-ci.org/aws/amazon-ecs-agent.svg?branch=master)](https://travis-ci.org/aws/amazon-ecs-agent)
+[![Build status](https://ci.appveyor.com/api/projects/status/upkhbwf2oc0srglt?svg=true)](https://ci.appveyor.com/project/AmazonECS/amazon-ecs-agent)
+
 
 The Amazon ECS Container Agent is software developed for Amazon EC2 Container Service ([Amazon ECS](http://aws.amazon.com/ecs/)).
 

--- a/agent/functional_tests/util/compare_versions.go
+++ b/agent/functional_tests/util/compare_versions.go
@@ -15,6 +15,7 @@ package util
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 )
@@ -161,4 +162,14 @@ func compareSemver(lhs, rhs semver) int {
 		return 1
 	}
 	return 0
+}
+
+// extractVersion extracts a matching version from the version number string
+func extractVersion(input string) string {
+	versionNumberRegex := regexp.MustCompile(` v(\d+\.\d+\.\d+(\-[\S\.\-]+)?(\+[\S\.\-]+)?)`)
+	versionNumberStr := versionNumberRegex.FindStringSubmatch(input)
+	if len(versionNumberStr) >= 2 {
+		return string(versionNumberStr[1])
+	}
+	return "UNKNOWN"
 }

--- a/agent/functional_tests/util/compare_versions_test.go
+++ b/agent/functional_tests/util/compare_versions_test.go
@@ -14,7 +14,11 @@
 
 package util
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestParseSemver(t *testing.T) {
 	testCases := []struct {
@@ -63,6 +67,15 @@ func TestParseSemver(t *testing.T) {
 				patch:             0,
 				preReleaseVersion: "rc1",
 				buildMetadata:     "sha.xyz",
+			},
+		},
+		{
+			input: "1.14.0-1.windows.1",
+			output: semver{
+				major:             1,
+				minor:             14,
+				patch:             0,
+				preReleaseVersion: "1.windows.1",
 			},
 		},
 	}
@@ -167,6 +180,11 @@ func TestVersionMatches(t *testing.T) {
 			selector:       ">=1.9.0,<=1.9.1",
 			expectedOutput: true,
 		},
+		{
+			version:        "1.14.0-1.windows.1",
+			selector:       ">=1.5.0",
+			expectedOutput: true,
+		},
 	}
 
 	for i, testCase := range testCases {
@@ -177,5 +195,42 @@ func TestVersionMatches(t *testing.T) {
 		if result != testCase.expectedOutput {
 			t.Errorf("#%v: %v(%v) expected %v but got %v", i, testCase.version, testCase.selector, testCase.expectedOutput, result)
 		}
+	}
+}
+
+func TestExtractVersion(t *testing.T) {
+	testCases := []struct {
+		version        string
+		expectedOutput string
+	}{
+		{
+			version:        "Amazon ECS v1.0.0",
+			expectedOutput: "1.0.0",
+		},
+		{
+			version:        " v1.0.0-test",
+			expectedOutput: "1.0.0-test",
+		},
+		{
+			version:        "Amazon ECS v1.2.3-1.test.2",
+			expectedOutput: "1.2.3-1.test.2",
+		},
+		{
+			version:        " v1.2.3-1.test.2+build.123",
+			expectedOutput: "1.2.3-1.test.2+build.123",
+		},
+		{
+			version:        "",
+			expectedOutput: "UNKNOWN",
+		},
+		{
+			version:        " abcd",
+			expectedOutput: "UNKNOWN",
+		},
+	}
+
+	for i, testCase := range testCases {
+		result := extractVersion(testCase.version)
+		assert.Equal(t, testCase.expectedOutput, result, "Test case %d", i)
 	}
 }

--- a/agent/functional_tests/util/utils.go
+++ b/agent/functional_tests/util/utils.go
@@ -29,7 +29,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-	"regexp"
 
 	"github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
 	"github.com/aws/amazon-ecs-agent/agent/handlers"
@@ -92,7 +91,6 @@ func GetTaskDefinitionWithOverrides(name string, overrides map[string]string) (s
 	return fmt.Sprintf("%s:%d", *registered.TaskDefinition.Family, *registered.TaskDefinition.Revision), nil
 }
 
-
 type TestAgent struct {
 	Image                string
 	DockerID             string
@@ -145,20 +143,10 @@ func (agent *TestAgent) platformIndependentStartAgent() error {
 	agent.ContainerInstanceArn = *localMetadata.ContainerInstanceArn
 	fmt.Println("Container InstanceArn:", agent.ContainerInstanceArn)
 	agent.Cluster = localMetadata.Cluster
-	if localMetadata.Version != "" {
-		versionNumberRegex := regexp.MustCompile(` v(\d+\.\d+\.\d+) `)
-		versionNumberStr := versionNumberRegex.FindStringSubmatch(localMetadata.Version)
-		if len(versionNumberStr) == 2 {
-			agent.Version = string(versionNumberStr[1])
-		}
-	}
-	if agent.Version == "" {
-		agent.Version = "UNKNOWN"
-	}
+	agent.Version = extractVersion(localMetadata.Version)
 	agent.t.Logf("Found agent metadata: %+v", localMetadata)
 	return nil
 }
-
 
 // Platform Independent piece of Agent Cleanup. Gets executed on both linux and Windows.
 func (agent *TestAgent) platformIndependentCleanup() {


### PR DESCRIPTION
### Summary
Fixes version extraction to handle SemVer prereleases and build metadata.  Before this commit, any version that included a prerelease or build metadata component would be parsed as `UNKNOWN`.

### Implementation details
Fixed a regex, added some tests.

### Testing
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes

Before this change:
```
=== RUN   TestLabels
--- SKIP: TestLabels (0.58s)
        utils_windows.go:87: Registry location test_path_1479426396325122900
        utils_windows.go:97: datadir C:\Users\ADMINI~1\AppData\Local\Temp\2\ecs_integ_testdata610551524\data
        utils_windows.go:105: Created directory C:\Users\ADMINI~1\AppData\Local\Temp\2\ecs_integ_testdata610551524 to store test data in
        utils.go:158: Found agent metadata: {Cluster:ecs-functional-tests ContainerInstanceArn:0xc0421ee3d0 Version:Amazon ECS Agent - v1.14.0-1.windows.1 (*UNKNOWN)}
        utils.go:427: Skipping test requiring version >=1.5.0; agent version unknown
        utils.go:169: Removing test dir for passed test C:\Users\ADMINI~1\AppData\Local\Temp\2\ecs_integ_testdata610551524
```

After this change:
```
=== RUN   TestLabels
--- PASS: TestLabels (10.70s)
        utils_windows.go:87: Registry location test_path_1479428548137213300
        utils_windows.go:97: datadir C:\Users\ADMINI~1\AppData\Local\Temp\2\ecs_integ_testdata368142964\data
        utils_windows.go:105: Created directory C:\Users\ADMINI~1\AppData\Local\Temp\2\ecs_integ_testdata368142964 to store test data in
        utils.go:147: Found agent metadata: {Cluster:ecs-functional-tests ContainerInstanceArn:0xc0423e27e0 Version:Amazon ECS Agent - v1.14.0-1.windows.1 (*UNKNOWN)}
        utils.go:168: Task definition: ecsftest-labels-windows-075db6e80d2bf74251d3ea73614b107c:1
        utils.go:188: Started task: arn:aws:ecs:us-west-2:011483493243:task/a7de6ee5-cac1-4f66-ae4d-dd8d727b1faa
        utils.go:157: Removing test dir for passed test C:\Users\ADMINI~1\AppData\Local\Temp\2\ecs_integ_testdata368142964
```


### Description for the changelog
No changelog

### Licensing
This contribution is under the terms of the Apache 2.0 License: yes, Amazon employee

r? @richardpen @aaithal 
