### PR TITLE
Build system cleanup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,8 +20,8 @@ Any contributions should pass all tests, including those not run by our
 current CI system.
 
 You may run all test by either running the `make test` target (requires `go`,
-`godep`, and `go cover` to be installed), or by running the `make
-test-in-docker` target which requires only Docker to be installed.
+and `go cover` to be installed), or by running the `make test-in-docker`
+target which requires only Docker to be installed.
 
 ## Licensing
 

--- a/scripts/dockerfiles/Dockerfile.test
+++ b/scripts/dockerfiles/Dockerfile.test
@@ -48,7 +48,6 @@ ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 WORKDIR $GOPATH
 
-COPY go-wrapper /usr/local/bin/
 # End docker-library/golang sourced data
 
 # Once https://github.com/docker/docker/issues/735 is resolved, this and

--- a/scripts/test
+++ b/scripts/test
@@ -19,6 +19,5 @@ sleep 2
 
 make get-deps
 cd agent
-export GOPATH=`godep path`:$GOPATH
 cd ..
 make test


### PR DESCRIPTION
### Summary

This change removes references to `godep` and stops trying to install it since we no longer use it. It also updates the dockerfile for the `test-in-docker` make rule to stop trying to install a file that's no longer distributed as part of go.

### Testing

`make build`
`make test-in-docker`
etc

- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: no, the build system does not have tests.

### Description for the changelog
Bug - Removed unnecessary references to `godep` and `go-wrapper` from `make test-in-docker` 

### Licensing

This contribution is under the terms of the Apache 2.0 License: yes
