### PR TITLE
ACS inactive instance reconnect backoff

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,8 +20,8 @@ Any contributions should pass all tests, including those not run by our
 current CI system.
 
 You may run all test by either running the `make test` target (requires `go`,
-`godep`, and `go cover` to be installed), or by running the `make
-test-in-docker` target which requires only Docker to be installed.
+and `go cover` to be installed), or by running the `make test-in-docker`
+target which requires only Docker to be installed.
 
 ## Licensing
 

--- a/agent/acs/handler/acs_handler.go
+++ b/agent/acs/handler/acs_handler.go
@@ -61,64 +61,25 @@ const (
 	sendCredentialsURLParameterName = "sendCredentials"
 )
 
-// StartSessionArguments is a struct representing all the things this handler
-// needs... This is really a hack to get by-name instead of positional
-// arguments since there are too many for positional to be wieldy
-type StartSessionArguments struct {
-	ContainerInstanceArn          string
-	CredentialProvider            *credentials.Credentials
-	Config                        *config.Config
-	DeregisterInstanceEventStream *eventstream.EventStream
-	TaskEngine                    engine.TaskEngine
-	ECSClient                     api.ECSClient
+type Session struct {
+	containerInstanceARN          string
+	credentialsProvider           *credentials.Credentials
+	agentConfig                   *config.Config
+	deregisterInstanceEventStream *eventstream.EventStream
+	taskEngine                    engine.TaskEngine
+	ecsClient                     api.ECSClient
 	StateManager                  statemanager.StateManager
-	AcceptInvalidCert             bool
-	CredentialsManager            rolecredentials.Manager
+	acceptInsecureCert            bool
+	credentialsManager            rolecredentials.Manager
+	ctx                           context.Context
+	cancel                        context.CancelFunc
+	backoff                       *utils.SimpleBackoff
+	resources                     sessionResources
+	reconnectStoppedNotification  sync.Once
 	_time                         ttime.Time
 	_heartbeatTimeout             time.Duration
 	_heartbeatJitter              time.Duration
 	_timeOnce                     sync.Once
-}
-
-// sessionState defines state recorder interface for the
-// session established with ACS. It can be used to record and
-// retrieve data shared across multiple connections to ACS
-type sessionState interface {
-	// connectedToACS callback indicates that the client has
-	// connected to ACS
-	connectedToACS()
-	// getSendCredentialsURLParameter retrieves the value for
-	// the 'sendCredentials' URL parameter
-	getSendCredentialsURLParameter() string
-}
-
-func (a *StartSessionArguments) time() ttime.Time {
-	a.initTime()
-	return a._time
-}
-
-func (a *StartSessionArguments) heartbeatTimeout() time.Duration {
-	a.initTime()
-	return a._heartbeatTimeout
-}
-
-func (a *StartSessionArguments) heartbeatJitter() time.Duration {
-	a.initTime()
-	return a._heartbeatJitter
-}
-
-func (a *StartSessionArguments) initTime() {
-	a._timeOnce.Do(func() {
-		if a._time == nil {
-			a._time = &ttime.DefaultTime{}
-		}
-		if a._heartbeatTimeout == 0 {
-			a._heartbeatTimeout = heartbeatTimeout
-		}
-		if a._heartbeatJitter == 0 {
-			a._heartbeatJitter = heartbeatJitter
-		}
-	})
 }
 
 // sessionResources defines the resource creator interface for starting
@@ -138,7 +99,9 @@ type sessionResources interface {
 // to create resources needed to connect to ACS and to record session state
 // for the same
 type acsSessionResources struct {
-	startSessionArguments StartSessionArguments
+	region              string
+	credentialsProvider *credentials.Credentials
+	acceptInsecureCert  bool
 	// sendCredentials is used to set the 'sendCredentials' URL parameter
 	// used to connect to ACS
 	// It is set to 'true' for the very first successful connection on
@@ -146,67 +109,237 @@ type acsSessionResources struct {
 	sendCredentials bool
 }
 
-// StartSession creates a session with ACS and handles requests from ACS.
-// It creates resources required to invoke the package scoped 'startSession()'
-// method and invokes the same to repeatedly connect to ACS when disconnected
-func StartSession(ctx context.Context, args StartSessionArguments) error {
-	backoff := utils.NewSimpleBackoff(connectionBackoffMin, connectionBackoffMax, connectionBackoffJitter, connectionBackoffMultiplier)
-	session := newSessionResources(args)
-	return startSession(ctx, args, backoff, session)
+// sessionState defines state recorder interface for the
+// session established with ACS. It can be used to record and
+// retrieve data shared across multiple connections to ACS
+type sessionState interface {
+	// connectedToACS callback indicates that the client has
+	// connected to ACS
+	connectedToACS()
+	// getSendCredentialsURLParameter retrieves the value for
+	// the 'sendCredentials' URL parameter
+	getSendCredentialsURLParameter() string
 }
 
-func newSessionResources(args StartSessionArguments) sessionResources {
-	return &acsSessionResources{
-		startSessionArguments: args,
-		sendCredentials:       true,
+func NewSession(ctx context.Context,
+	acceptInsecureCert bool,
+	config *config.Config,
+	deregisterInstanceEventStream *eventstream.EventStream,
+	containerInstanceArn string,
+	credentialsProvider *credentials.Credentials,
+	ecsClient api.ECSClient,
+	stateManager statemanager.StateManager,
+	taskEngine engine.TaskEngine,
+	credentialsManager rolecredentials.Manager) *Session {
+	resources := newSessionResources(config.AWSRegion, credentialsProvider, acceptInsecureCert)
+	backoff := utils.NewSimpleBackoff(connectionBackoffMin, connectionBackoffMax,
+		connectionBackoffJitter, connectionBackoffMultiplier)
+	derivedContext, cancel := context.WithCancel(ctx)
+
+	return &Session{
+		acceptInsecureCert:            acceptInsecureCert,
+		agentConfig:                   config,
+		deregisterInstanceEventStream: deregisterInstanceEventStream,
+		containerInstanceARN:          containerInstanceArn,
+		credentialsProvider:           credentialsProvider,
+		ecsClient:                     ecsClient,
+		StateManager:                  stateManager,
+		taskEngine:                    taskEngine,
+		credentialsManager:            credentialsManager,
+		ctx:                           derivedContext,
+		cancel:                        cancel,
+		backoff:                       backoff,
+		resources:                     resources,
 	}
 }
 
-// startSession creates a session with ACS and handles requests from ACS
-// It also tries to repeatedly connect to ACS when disconnected
-func startSession(ctx context.Context, args StartSessionArguments, backoff *utils.SimpleBackoff, acsResources sessionResources) error {
+// Start starts the session. It'll forever keep trying to connect to ACS unless:
+// 1. The context is cancelled
+// 2. Instance is deregistered
+func (s *Session) Start() error {
+	connectToACS := true
 	for {
-		acsError := startSessionOnce(ctx, args, backoff, acsResources)
+		if connectToACS {
+			acsError := s.startSessionOnce()
+			connectToACS = s.handleACSError(acsError)
+		} else {
+			s.reconnectStoppedNotification.Do(func() {
+				seelog.Info("Stopping reconnect attempts to ACS")
+			})
+		}
 		select {
-		case <-ctx.Done():
-			return ctx.Err()
+		case <-s.ctx.Done():
+			return s.ctx.Err()
 		default:
 		}
 
-		if acsError == nil || acsError == io.EOF {
-			backoff.Reset()
-		} else if strings.HasPrefix(acsError.Error(), "InactiveInstanceException:") {
-			seelog.Debug("Container instance is deregistered, notifying listeners")
-			err := args.DeregisterInstanceEventStream.WriteToEventStream(struct{}{})
-			if err != nil {
-				seelog.Debugf("Failed to write to deregister container instance event stream, err: %v", err)
-			}
-		} else {
-			seelog.Infof("Error from acs; backing off, err: %v", acsError)
-			args.time().Sleep(backoff.Duration())
-		}
 	}
 }
 
 // startSessionOnce creates a session with ACS and handles requests using the passed
 // in arguments
-func startSessionOnce(ctx context.Context, args StartSessionArguments, backoff *utils.SimpleBackoff, acsResources sessionResources) error {
-	acsEndpoint, err := args.ECSClient.DiscoverPollEndpoint(args.ContainerInstanceArn)
+func (s *Session) startSessionOnce() error {
+	acsEndpoint, err := s.ecsClient.DiscoverPollEndpoint(s.containerInstanceARN)
 	if err != nil {
 		seelog.Errorf("Unable to discover poll endpoint, err: %v", err)
 		return err
 	}
 
-	cfg := args.Config
-	url := acsWsURL(acsEndpoint, cfg.Cluster, args.ContainerInstanceArn, args.TaskEngine, acsResources)
-	client := acsResources.createACSClient(url)
+	url := acsWsURL(acsEndpoint, s.agentConfig.Cluster, s.containerInstanceARN, s.taskEngine, s.resources)
+	client := s.resources.createACSClient(url)
 	defer client.Close()
 
 	// Start inactivity timer for closing the connection
-	timer := newDisconnectionTimer(client, args.time(), args.heartbeatTimeout(), args.heartbeatJitter())
+	timer := newDisconnectionTimer(client, s.time(), s.heartbeatTimeout(), s.heartbeatJitter())
 	defer timer.Stop()
 
-	return startACSSession(ctx, client, timer, args, backoff, acsResources)
+	return s.startACSSession(client, timer)
+}
+
+// startACSSession starts a session with ACS. It adds request handlers for various
+// kinds of messages expected from ACS. It returns on server disconnection or when
+// the context is cancelled
+func (s *Session) startACSSession(client wsclient.ClientServer, timer ttime.Timer) error {
+	// Any message from the server resets the disconnect timeout
+	client.SetAnyRequestHandler(anyMessageHandler(timer))
+	cfg := s.agentConfig
+
+	refreshCredsHandler := newRefreshCredentialsHandler(s.ctx, cfg.Cluster, s.containerInstanceARN,
+		client, s.credentialsManager, s.taskEngine)
+	defer refreshCredsHandler.clearAcks()
+	refreshCredsHandler.start()
+	defer refreshCredsHandler.stop()
+
+	client.AddRequestHandler(refreshCredsHandler.handlerFunc())
+
+	// Add request handler for handling payload messages from ACS
+	payloadHandler := newPayloadRequestHandler(s.ctx, s.taskEngine, s.ecsClient, cfg.Cluster,
+		s.containerInstanceARN, client, s.StateManager, refreshCredsHandler, s.credentialsManager)
+	// Clear the acks channel on return because acks of messageids don't have any value across sessions
+	defer payloadHandler.clearAcks()
+	payloadHandler.start()
+	defer payloadHandler.stop()
+
+	client.AddRequestHandler(payloadHandler.handlerFunc())
+
+	// Ignore heartbeat messages; anyMessageHandler gets 'em
+	client.AddRequestHandler(func(*ecsacs.HeartbeatMessage) {})
+
+	updater.AddAgentUpdateHandlers(client, cfg, s.StateManager, s.taskEngine)
+
+	err := client.Connect()
+	if err != nil {
+		seelog.Errorf("Error connecting to ACS: %v", err)
+		return err
+	}
+	s.resources.connectedToACS()
+
+	backoffResetTimer := s.time().AfterFunc(
+		utils.AddJitter(s.heartbeatTimeout(), s.heartbeatJitter()), func() {
+			// If we do not have an error connecting and remain connected for at
+			// least 5 or so minutes, reset the backoff. This prevents disconnect
+			// errors that only happen infrequently from damaging the
+			// reconnectability as significantly.
+			s.backoff.Reset()
+		})
+	defer backoffResetTimer.Stop()
+
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- client.Serve()
+	}()
+
+	for {
+		select {
+		case <-s.ctx.Done():
+			// Stop receiving and sending messages from and to ACS when
+			// the context received from the main function is canceled
+			return s.ctx.Err()
+		case err := <-serveErr:
+			// Stop receiving and sending messages from and to ACS when
+			// client.Serve returns an error. This can happen when the
+			// the connection is closed by ACS or the agent
+			return err
+		}
+	}
+}
+
+// handleACSError handles an error from ACS. It returns true if the session can reconnect
+// to ACS. Else, it returns false. It also applies the appropriate backoff policy for
+// errors which can result in the handler reconnecting to ACS. For an "InactiveInstance"
+// error, it emits an event to the deregister instance event stream.
+func (s *Session) handleACSError(acsError error) bool {
+	if acsError == nil || acsError == io.EOF {
+		s.backoff.Reset()
+	} else if strings.HasPrefix(acsError.Error(), "InactiveInstanceException:") {
+		seelog.Debug("Container instance is deregistered, notifying listeners")
+		err := s.deregisterInstanceEventStream.WriteToEventStream(struct{}{})
+		if err != nil {
+			seelog.Debugf("Failed to write to deregister container instance event stream, err: %v", err)
+		}
+		return false
+	} else {
+		seelog.Infof("Error from acs; backing off, err: %v", acsError)
+		s.time().Sleep(s.backoff.Duration())
+	}
+
+	return true
+}
+
+func (s *Session) time() ttime.Time {
+	s.initTime()
+	return s._time
+}
+
+func (s *Session) heartbeatTimeout() time.Duration {
+	s.initTime()
+	return s._heartbeatTimeout
+}
+
+func (s *Session) heartbeatJitter() time.Duration {
+	s.initTime()
+	return s._heartbeatJitter
+}
+
+func (s *Session) initTime() {
+	s._timeOnce.Do(func() {
+		if s._time == nil {
+			s._time = &ttime.DefaultTime{}
+		}
+		if s._heartbeatTimeout == 0 {
+			s._heartbeatTimeout = heartbeatTimeout
+		}
+		if s._heartbeatJitter == 0 {
+			s._heartbeatJitter = heartbeatJitter
+		}
+	})
+}
+
+// createACSClient creates the ACS Client using the specified URL
+func (acsResources *acsSessionResources) createACSClient(url string) wsclient.ClientServer {
+	return acsclient.New(
+		url, acsResources.region, acsResources.credentialsProvider, acsResources.acceptInsecureCert)
+}
+
+// connectedToACS records a successful connection to ACS
+// It sets sendCredentials to false on such an event
+func (acsResources *acsSessionResources) connectedToACS() {
+	acsResources.sendCredentials = false
+}
+
+// getSendCredentialsURLParameter gets the value to be set for the
+// 'sendCredentials' URL parameter
+func (acsResources *acsSessionResources) getSendCredentialsURLParameter() string {
+	return strconv.FormatBool(acsResources.sendCredentials)
+}
+
+func newSessionResources(region string, credentialsProvider *credentials.Credentials, acceptInsecureCert bool) sessionResources {
+	return &acsSessionResources{
+		region:              region,
+		credentialsProvider: credentialsProvider,
+		acceptInsecureCert:  acceptInsecureCert,
+		sendCredentials:     true,
+	}
 }
 
 // acsWsURL returns the websocket url for ACS given the endpoint
@@ -229,25 +362,6 @@ func acsWsURL(endpoint, cluster, containerInstanceArn string, taskEngine engine.
 	return acsUrl + "?" + query.Encode()
 }
 
-// createACSClient creates the ACS Client using the specified URL
-func (acsResources *acsSessionResources) createACSClient(url string) wsclient.ClientServer {
-	args := acsResources.startSessionArguments
-	cfg := args.Config
-	return acsclient.New(url, cfg.AWSRegion, args.CredentialProvider, args.AcceptInvalidCert)
-}
-
-// connectedToACS records a successful connection to ACS
-// It sets sendCredentials to false on such an event
-func (acsResources *acsSessionResources) connectedToACS() {
-	acsResources.sendCredentials = false
-}
-
-// getSendCredentialsURLParameter gets the value to be set for the
-// 'sendCredentials' URL parameter
-func (acsResources *acsSessionResources) getSendCredentialsURLParameter() string {
-	return strconv.FormatBool(acsResources.sendCredentials)
-}
-
 // newDisconnectionTimer creates a new time object, with a callback to
 // disconnect from ACS on inactivity
 func newDisconnectionTimer(client wsclient.ClientServer, _time ttime.Time, timeout time.Duration, jitter time.Duration) ttime.Timer {
@@ -260,71 +374,6 @@ func newDisconnectionTimer(client wsclient.ClientServer, _time ttime.Time, timeo
 	})
 
 	return timer
-}
-
-// startACSSession starts a session with ACS. It adds request handlers for various
-// kinds of messages expected from ACS. It returns on server disconnection or when
-// the context is cancelled
-func startACSSession(ctx context.Context, client wsclient.ClientServer, timer ttime.Timer, args StartSessionArguments, backoff *utils.SimpleBackoff, acsSessionState sessionState) error {
-	// Any message from the server resets the disconnect timeout
-	client.SetAnyRequestHandler(anyMessageHandler(timer))
-	cfg := args.Config
-
-	refreshCredsHandler := newRefreshCredentialsHandler(ctx, cfg.Cluster, args.ContainerInstanceArn, client, args.CredentialsManager, args.TaskEngine)
-	defer refreshCredsHandler.clearAcks()
-	refreshCredsHandler.start()
-	defer refreshCredsHandler.stop()
-
-	client.AddRequestHandler(refreshCredsHandler.handlerFunc())
-
-	// Add request handler for handling payload messages from ACS
-	payloadHandler := newPayloadRequestHandler(ctx, args.TaskEngine, args.ECSClient, cfg.Cluster, args.ContainerInstanceArn, client, args.StateManager, refreshCredsHandler, args.CredentialsManager)
-	// Clear the acks channel on return because acks of messageids don't have any value across sessions
-	defer payloadHandler.clearAcks()
-	payloadHandler.start()
-	defer payloadHandler.stop()
-
-	client.AddRequestHandler(payloadHandler.handlerFunc())
-
-	// Ignore heartbeat messages; anyMessageHandler gets 'em
-	client.AddRequestHandler(func(*ecsacs.HeartbeatMessage) {})
-
-	updater.AddAgentUpdateHandlers(client, cfg, args.StateManager, args.TaskEngine)
-
-	err := client.Connect()
-	if err != nil {
-		seelog.Errorf("Error connecting to ACS: %v", err)
-		return err
-	}
-	acsSessionState.connectedToACS()
-
-	backoffResetTimer := args.time().AfterFunc(utils.AddJitter(args.heartbeatTimeout(), args.heartbeatJitter()), func() {
-		// If we do not have an error connecting and remain connected for at
-		// least 5 or so minutes, reset the backoff. This prevents disconnect
-		// errors that only happen infrequently from damaging the
-		// reconnectability as significantly.
-		backoff.Reset()
-	})
-	defer backoffResetTimer.Stop()
-
-	serveErr := make(chan error, 1)
-	go func() {
-		serveErr <- client.Serve()
-	}()
-
-	for {
-		select {
-		case <-ctx.Done():
-			// Stop receiving and sending messages from and to ACS when
-			// the context received from the main function is canceled
-			return ctx.Err()
-		case err := <-serveErr:
-			// Stop receiving and sending messages from and to ACS when
-			// client.Serve returns an error. This can happen when the
-			// the connection is closed by ACS or the agent
-			return err
-		}
-	}
 }
 
 // anyMessageHandler handles any server message. Any server message means the

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -272,18 +272,20 @@ func _main() int {
 	// Start metrics session in a go routine
 	go tcshandler.StartMetricsSession(telemetrySessionParams)
 
+	acsSession := acshandler.NewSession(
+		ctx,
+		*acceptInsecureCert,
+		cfg,
+		deregisterInstanceEventStream,
+		containerInstanceArn,
+		credentialProvider,
+		client,
+		stateManager,
+		taskEngine,
+		credentialsManager,
+	)
 	log.Info("Beginning Polling for updates")
-	err = acshandler.StartSession(ctx, acshandler.StartSessionArguments{
-		AcceptInvalidCert: *acceptInsecureCert,
-		Config:            cfg,
-		DeregisterInstanceEventStream: deregisterInstanceEventStream,
-		ContainerInstanceArn:          containerInstanceArn,
-		CredentialProvider:            credentialProvider,
-		ECSClient:                     client,
-		StateManager:                  stateManager,
-		TaskEngine:                    taskEngine,
-		CredentialsManager:            credentialsManager,
-	})
+	err = acsSession.Start()
 	if err != nil {
 		log.Criticalf("Unretriable error starting communicating with ACS: %v", err)
 		return exitcodes.ExitTerminal

--- a/agent/stats/utils.go
+++ b/agent/stats/utils.go
@@ -44,9 +44,10 @@ func dockerStatsToContainerStats(dockerStats *docker.Stats) (*ContainerStats, er
 	}
 
 	cpuUsage := dockerStats.CPUStats.CPUUsage.TotalUsage / numCores
+	memoryUsage := dockerStats.MemoryStats.Usage - dockerStats.MemoryStats.Stats.Cache
 	return &ContainerStats{
 		cpuUsage:    cpuUsage,
-		memoryUsage: dockerStats.MemoryStats.Usage,
+		memoryUsage: memoryUsage,
 		timestamp:   dockerStats.Read,
 	}, nil
 }

--- a/agent/stats/utils_test.go
+++ b/agent/stats/utils_test.go
@@ -84,3 +84,35 @@ func TestDockerStatsToContainerStatsZeroCoresGeneratesError(t *testing.T) {
 		t.Error("Expected error converting container stats with empty PercpuUsage")
 	}
 }
+
+func TestDockerStatsToContainerStatsMemUsage(t *testing.T) {
+	jsonStat := fmt.Sprintf(`
+		{
+			"cpu_stats":{
+				"cpu_usage":{
+					"percpu_usage":[%d, %d, %d, %d],
+					"total_usage":%d
+				}
+			},
+			"memory_stats":{
+				"usage": %d,
+				"max_usage": %d,
+				"stats": {
+					"cache": %d,
+					"rss": %d
+				}
+			}
+		}`, 1, 2, 3, 4, 100, 30, 100, 20, 10)
+	dockerStat := &docker.Stats{}
+	json.Unmarshal([]byte(jsonStat), dockerStat)
+	containerStats, err := dockerStatsToContainerStats(dockerStat)
+	if err != nil {
+		t.Errorf("Error converting container stats: %v", err)
+	}
+	if containerStats == nil {
+		t.Fatal("containerStats should not be nil")
+	}
+	if containerStats.memoryUsage != 10 {
+		t.Error("Unexpected value for memoryUsage", containerStats.memoryUsage)
+	}
+}

--- a/scripts/dockerfiles/Dockerfile.test
+++ b/scripts/dockerfiles/Dockerfile.test
@@ -48,7 +48,6 @@ ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 WORKDIR $GOPATH
 
-COPY go-wrapper /usr/local/bin/
 # End docker-library/golang sourced data
 
 # Once https://github.com/docker/docker/issues/735 is resolved, this and

--- a/scripts/test
+++ b/scripts/test
@@ -19,6 +19,5 @@ sleep 2
 
 make get-deps
 cd agent
-export GOPATH=`godep path`:$GOPATH
 cd ..
 make test


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Stops ACS Handler from reconnecting to ACS when the instance is deregistered

### Implementation details
<!-- How are the changes implemented? -->
* The `InactiveInstanceException` is handled to set a boolean flag, which stopes the ACS Handler from invoking the `startSessionOnce()` method
* Also did some minor refactoring to get rid of the `StartSessionArgs` struct and merge it into a `Session` struct

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [X] Builds on Linux (`make release`)
- [ ] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [X] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [X] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [X] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: 
Yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
* Bug - Fixes an issue where ECS Agent would keep reconnecting to ACS without any backoff 
### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: Yes
