### PR TITLE
Small tweaks to Windows scripts

### DIFF
--- a/misc/windows-deploy/hostsetup.ps1
+++ b/misc/windows-deploy/hostsetup.ps1
@@ -24,5 +24,8 @@ $containerGateway = (Get-NetNat).InternalIPInterfaceAddressPrefix | %{ $_ -repla
 
 netsh interface portproxy add v4tov4 listenaddress=$containerGateway listenport=51679 connectaddress=127.0.0.1 connectport=51679 protocol=tcp
 
-route -p delete 169.254.170.2/32
+$existingRoute=route print 169.254.170.2 -4 | Sort-Object -Property "IPv4 Route Table"
+if ($existingRoute -Match "169.254.170.2") {
+   route -p delete 169.254.170.2/32
+}
 New-NetRoute -DestinationPrefix 169.254.170.2/32 -InterfaceIndex $ifIndex -NextHop $defaultGateway

--- a/misc/windows-iam/Setup_Iam.ps1
+++ b/misc/windows-iam/Setup_Iam.ps1
@@ -54,9 +54,12 @@ go build -o C:\IAM\ec2.exe C:\IAM\ec2.go
 cp C:\IAM\ec2.exe C:\ecs
 "@
 
+$buildimage="golang:1.7-windowsservercore"
+docker pull $buildimage
+
 docker run `
   --volume ${PSScriptRoot}:C:\ecs `
-  golang:1.7-windowsservercore `
+  $buildimage `
   powershell ${buildscript}
 
 Invoke-Expression "docker build -t amazon/amazon-ecs-iamrolecontainer --file ${PSScriptRoot}\iamroles.dockerfile ${PSScriptRoot}"


### PR DESCRIPTION
### Summary
Small tweaks to Windows scripts that made automated testing more reliable:
* Check for existing routes to 169.254.170.2 before removing them (this is an alternative to https://github.com/aws/amazon-ecs-agent/pull/633)
* Explicitly pull `golang:1.7-windowsservercore` before using it

### Implementation details
Route is checked in `hostsetup.ps1`
Pull occurs in `Setup_Iam.ps1`

### Testing
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

(see automated test coverage [here](https://github.com/samuelkarp/amazon-ecs-agent/commits/windows-tests))

New tests cover the changes: no

### Description for the changelog
None

### Licensing
This contribution is under the terms of the Apache 2.0 License: yes
