### PR TITLE
windows: Report functional test failure correctly

### DIFF
--- a/scripts/run-functional-tests.ps1
+++ b/scripts/run-functional-tests.ps1
@@ -34,11 +34,16 @@ $cwd = (pwd).Path
 try {
   cd "${PSScriptRoot}"
   go test -tags functional -timeout=30m -v ../agent/functional_tests/tests
+  $handwrittenExitCode = $LastExitCode
+  echo "Handwritten functional tests exited with ${handwrittenExitCode}"
   go test -tags functional -timeout=30m -v ../agent/functional_tests/tests/generated/simpletests_windows
-  $testsExitCode = $LastExitCode
+  $simpletestExitCode = $LastExitCode
+  echo "Simple functional tests exited with ${simpletestExitCode}"
 } finally {
   cd "$cwd"
   docker stop ecs-cred-proxy
 }
-
-exit $testsExitCode
+if (${handwrittenExitCode} -ne 0) {
+  exit $handwrittenExitCode
+}
+exit $simpletestExitCode


### PR DESCRIPTION
@aaithal @khannag 

### Summary
Fixes the `run-functional-tests.ps1` script to properly report failures when they occur in the handwritten functional tests.

### Implementation details
Preserve exit codes from separate runs and ensure that we return non-zero if a failure occurs.

### Testing
- [x] Manually forced tests to fail in each part (handwritten and simple) and observed that `$LastExitCode` was non-zero
- [ ] Builds on Linux (`make release`)
- [ ] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [ ] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: no

### Description for the changelog
none

### Licensing
This contribution is under the terms of the Apache 2.0 License: yes (Amazon employee)
