### PR TITLE
Improving a couple unit tests

### DIFF
--- a/agent/tcs/client/client_test.go
+++ b/agent/tcs/client/client_test.go
@@ -118,9 +118,10 @@ func newNonIdleStatsEngine(numTasks int) *nonIdleStatsEngine {
 func TestPayloadHandlerCalled(t *testing.T) {
 	cs, ml := testCS()
 
-	var handledPayload *ecstcs.AckPublishMetric
+	handledPayload := make(chan *ecstcs.AckPublishMetric)
+
 	reqHandler := func(payload *ecstcs.AckPublishMetric) {
-		handledPayload = payload
+		handledPayload <- payload
 	}
 	cs.AddRequestHandler(reqHandler)
 
@@ -134,11 +135,8 @@ func TestPayloadHandlerCalled(t *testing.T) {
 		}
 	}()
 
-	time.Sleep(1 * time.Millisecond)
-	if handledPayload == nil {
-		t.Fatal("Handler was not called")
-	}
-
+	t.Log("Waiting for handler to return payload.")
+	<-handledPayload
 	isClosed = true
 	cs.Close()
 }


### PR DESCRIPTION
### Summary
This improves unit tests that fail occasionally on windows.

### Implementation details
* This improves two tests by not relying on time.Sleep(..) exclusively. Let me know if there are better ways to tackle this.

### Testing
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: N/A

### Description for the changelog
* Bug - improving two unit test cases

### Licensing
This contribution is under the terms of the Apache 2.0 License: yes
