### PR TITLE
Fix the functional test TaskCleanupDoesNotDeadlock on windows

### DIFF
--- a/agent/functional_tests/testdata/taskdefinitions/ten-containers-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/ten-containers-windows/task-definition.json
@@ -6,69 +6,69 @@
     "memory": 10,
     "cpu": 0,
     "entryPoint": ["powershell"],
-    "command": ["sleep", "20"]
+    "command": ["sleep", "300"]
   }, {
     "name": "2",
     "image": "microsoft/windowsservercore:latest",
     "memory": 10,
     "cpu": 0,
     "entryPoint": ["powershell"],
-    "command": ["sleep", "20"]
+    "command": ["sleep", "300"]
   }, {
     "name": "3",
     "image": "microsoft/windowsservercore:latest",
     "memory": 10,
     "cpu": 0,
     "entryPoint": ["powershell"],
-    "command": ["sleep", "20"]
+    "command": ["sleep", "300"]
   }, {
     "name": "4",
     "image": "microsoft/windowsservercore:latest",
     "memory": 10,
     "cpu": 0,
     "entryPoint": ["powershell"],
-    "command": ["sleep", "20"]
+    "command": ["sleep", "300"]
   }, {
     "name": "5",
     "image": "microsoft/windowsservercore:latest",
     "memory": 10,
     "cpu": 0,
     "entryPoint": ["powershell"],
-    "command": ["sleep", "20"]
+    "command": ["sleep", "300"]
   }, {
     "name": "6",
     "image": "microsoft/windowsservercore:latest",
     "memory": 10,
     "cpu": 0,
     "entryPoint": ["powershell"],
-    "command": ["sleep", "20"]
+    "command": ["sleep", "300"]
   }, {
     "name": "7",
     "image": "microsoft/windowsservercore:latest",
     "memory": 10,
     "cpu": 0,
     "entryPoint": ["powershell"],
-    "command": ["sleep", "20"]
+    "command": ["sleep", "300"]
   }, {
     "name": "8",
     "image": "microsoft/windowsservercore:latest",
     "memory": 10,
     "cpu": 0,
     "entryPoint": ["powershell"],
-    "command": ["sleep", "20"]
+    "command": ["sleep", "300"]
   }, {
     "name": "9",
     "image": "microsoft/windowsservercore:latest",
     "memory": 10,
     "cpu": 0,
     "entryPoint": ["powershell"],
-    "command": ["sleep", "20"]
+    "command": ["sleep", "300"]
   }, {
     "name": "10",
     "image": "microsoft/windowsservercore:latest",
     "memory": 10,
     "cpu": 0,
     "entryPoint": ["powershell"],
-    "command": ["sleep", "20"]
+    "command": ["sleep", "300"]
   }]
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR fix the functional test TaskCleanupDoesNotDeadlock on windows

### Implementation details
<!-- How are the changes implemented? -->
This test starts 10 containers with each sleep 20s, which cause the problem when the first container already exit(after sleep 20s) while there is still some not be running. The task could go directly from pending to stopped. Increase the container sleep to 5 minutes, and stop the task explicitly after the task is running.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->
yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
No changelog

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
yes
