### PR TITLE
Adding functional tests for Custom-Instance-Attributes

### DIFF
--- a/agent/functional_tests/tests/functionaltests_unix_test.go
+++ b/agent/functional_tests/tests/functionaltests_unix_test.go
@@ -27,7 +27,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
+	ecsapi "github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
 	. "github.com/aws/amazon-ecs-agent/agent/functional_tests/util"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 	"github.com/aws/aws-sdk-go/aws"
@@ -152,8 +152,8 @@ func TestCommandOverrides(t *testing.T) {
 	agent := RunAgent(t, nil)
 	defer agent.Cleanup()
 
-	task, err := agent.StartTaskWithOverrides(t, "simple-exit", []*ecs.ContainerOverride{
-		&ecs.ContainerOverride{
+	task, err := agent.StartTaskWithOverrides(t, "simple-exit", []*ecsapi.ContainerOverride{
+		&ecsapi.ContainerOverride{
 			Name:    strptr("exit"),
 			Command: []*string{strptr("sh"), strptr("-c"), strptr("exit 21")},
 		},
@@ -396,7 +396,7 @@ func TestAwslogsDriver(t *testing.T) {
 func TestTelemetry(t *testing.T) {
 	// Try to use a new cluster for this test, ensure no other task metrics for this cluster
 	newClusterName := "ecstest-telemetry-" + uuid.New()
-	_, err := ECS.CreateCluster(&ecs.CreateClusterInput{
+	_, err := ECS.CreateCluster(&ecsapi.CreateClusterInput{
 		ClusterName: aws.String(newClusterName),
 	})
 	require.NoError(t, err, "Failed to create cluster")

--- a/agent/functional_tests/util/utils.go
+++ b/agent/functional_tests/util/utils.go
@@ -646,3 +646,12 @@ func (agent *TestAgent) SweepTask(task *TestTask) error {
 
 	return nil
 }
+
+// AttributesToMap transforms a list of key, value attributes to return a map
+func AttributesToMap(attributes []*ecs.Attribute) map[string]string {
+	attributeMap := make(map[string]string)
+	for _, attribute := range attributes {
+		attributeMap[aws.StringValue(attribute.Name)] = aws.StringValue(attribute.Value)
+	}
+	return attributeMap
+}

--- a/agent/functional_tests/util/utils_unix.go
+++ b/agent/functional_tests/util/utils_unix.go
@@ -150,6 +150,11 @@ func (agent *TestAgent) StartAgent() error {
 		Cmd: strings.Split(os.Getenv("ECS_FTEST_AGENT_ARGS"), " "),
 	}
 
+	// Append ECS_INSTANCE_ATTRIBUTES to dockerConfig
+	if attr := os.Getenv("ECS_INSTANCE_ATTRIBUTES"); attr != "" {
+		dockerConfig.Env = append(dockerConfig.Env, "ECS_INSTANCE_ATTRIBUTES="+attr)
+	}
+
 	binds := agent.getBindMounts()
 
 	hostConfig := &docker.HostConfig{

--- a/agent/functional_tests/util/utils_windows.go
+++ b/agent/functional_tests/util/utils_windows.go
@@ -120,10 +120,14 @@ func (agent *TestAgent) StartAgent() error {
 	if TestDirectory := os.Getenv("ECS_WINDOWS_TEST_DIR"); TestDirectory != "" {
 		agentInvoke.Dir = TestDirectory
 	}
-	agentInvoke.Start()
+	err := agentInvoke.Start()
+	if err != nil {
+		agent.t.Logf("Agent start invocation failed with %s", err.Error())
+		return err
+	}
 	agent.Process = agentInvoke.Process
 	agent.IntrospectionURL = "http://localhost:51678"
-	err := agent.platformIndependentStartAgent()
+	err = agent.platformIndependentStartAgent()
 	return err
 }
 


### PR DESCRIPTION
* This patch tests the happy paths of the custom-instance-attribute
 feature. The `ECS_INSTANCE_ATTRIBUTE` holds a set of key=value pairs
 which are exposed via the DescribeContainerInstances API. Each key or value
 can contain upto 128 characters and we currently only support a maximum
 of 10 custom attributes per instance.

http://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_PutAttributes.html
describes more details about the limits for the attributes.

Signed-off-by: Vinothkumar Siddharth <sidvin@amazon.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
