### PR TITLE
Log completion of image pulls.

### DIFF
--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -474,7 +474,7 @@ func (engine *DockerTaskEngine) GetTaskByArn(arn string) (*api.Task, bool) {
 
 func (engine *DockerTaskEngine) pullContainer(task *api.Task, container *api.Container) DockerContainerMetadata {
 	pullStart := time.Now()
-	defer seelog.Infof("Finished pulling container %v after %v.", container, time.Since(pullStart).String())
+	defer seelog.Infof("Finished pulling container %v. Lock acquisition and pull took %v.", container, time.Since(pullStart).String())
 	if engine.enableConcurrentPull {
 		seelog.Infof("Pulling container %v concurrently. Task: %v", container, task)
 		return engine.concurrentPull(task, container)

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -473,15 +473,18 @@ func (engine *DockerTaskEngine) GetTaskByArn(arn string) (*api.Task, bool) {
 }
 
 func (engine *DockerTaskEngine) pullContainer(task *api.Task, container *api.Container) DockerContainerMetadata {
+	pullStart := time.Now()
+	defer seelog.Infof("Finished pulling container %v after %v.", container, time.Since(pullStart).String())
 	if engine.enableConcurrentPull {
+		seelog.Infof("Pulling container %v concurrently. Task: %v", container, task)
 		return engine.concurrentPull(task, container)
 	} else {
+		seelog.Infof("Pulling container %v serially. Task: %v", container, task)
 		return engine.serialPull(task, container)
 	}
 }
 
 func (engine *DockerTaskEngine) concurrentPull(task *api.Task, container *api.Container) DockerContainerMetadata {
-	log.Info("Pulling container concurrently", "task", task, "container", container)
 	seelog.Debugf("Attempting to obtain ImagePullDeleteLock to pull image - %s", container.Image)
 
 	ImagePullDeleteLock.RLock()
@@ -492,7 +495,6 @@ func (engine *DockerTaskEngine) concurrentPull(task *api.Task, container *api.Co
 }
 
 func (engine *DockerTaskEngine) serialPull(task *api.Task, container *api.Container) DockerContainerMetadata {
-	log.Info("Pulling container serially", "task", task, "container", container)
 	seelog.Debugf("Attempting to obtain ImagePullDeleteLock to pull image - %s", container.Image)
 
 	ImagePullDeleteLock.Lock()


### PR DESCRIPTION
### Summary

This change adds an Info-level message upon completion of container image pull including the amount of time needed to complete the pull.

### Implementation details

Minor reorganization and conversion to seelog of some existing logging statements. time.Duration measures elapsed time for logging. Sample logs:
```
2017-02-20T19:25:15Z [INFO] Pulling container sleep(938878489526.dkr.ecr.us-west-2.amazonaws.com/sleep) (NONE->RUNNING) concurrently. Task: sleep:2 arn:aws:ecs:us-west-2:938878489526:task/75bfd2e7-d031-41ca-890e-75bb49491441, Status: (NONE->RUNNING) Containers: [sleep (NONE->RUNNING),~internal~ecs-emptyvolume-source (STOPPED->STOPPED),]
2017-02-20T19:25:16Z [INFO] Finished pulling container sleep(938878489526.dkr.ecr.us-west-2.amazonaws.com/sleep) (PULLED->RUNNING) after 232ns.
```

### Testing

- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: n/a

### Description for the changelog

Enhancement - Log completion of image pulls.

### Licensing

This contribution is under the terms of the Apache 2.0 License: yes
