### PR TITLE
Fix an race condition in agent

### DIFF
--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -510,10 +510,10 @@ func (mtask *managedTask) cleanupTask(taskStoppedDuration time.Duration) {
 	// discard events while the task is being removed from engine state
 	go mtask.discardEventsUntil(handleCleanupDone)
 	mtask.engine.sweepTask(mtask.Task)
-	mtask.engine.state.RemoveTask(mtask.Task)
-	log.Debug("Finished removing task data; removing from state no longer managing", "task", mtask.Task)
 	// Now remove ourselves from the global state and cleanup channels
 	mtask.engine.processTasks.Lock()
+	mtask.engine.state.RemoveTask(mtask.Task)
+	seelog.Debug("Finished removing task data, removing task from managed tasks: %v", mtask.Task)
 	delete(mtask.engine.managedTasks, mtask.Arn)
 	handleCleanupDone <- struct{}{}
 	mtask.engine.processTasks.Unlock()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
There is a race condition when task is cleaning up, the [task state](https://github.com/aws/amazon-ecs-agent/blob/master/agent/engine/dockerstate/docker_task_engine_state.go) can get inconsistent with the [managed task](https://github.com/aws/amazon-ecs-agent/blob/master/agent/engine/task_manager.go) in some edge case. Because these two are updated one inside the [lock](https://github.com/aws/amazon-ecs-agent/blob/master/agent/engine/task_manager.go#L513) and one outside the [lock](https://github.com/aws/amazon-ecs-agent/blob/master/agent/engine/task_manager.go#L517) when clean up the task.
### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass
- [x] Manually modified the code to simulate the situation where race condition can happen without the change but not happened with this change.

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
Fixed a potential race condition in agent where could cause agent in corrupted state.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
yes