### PR TITLE
fix TestTaskCleanupDoesNotDeadlock unix test.

### DIFF
--- a/agent/functional_tests/testdata/taskdefinitions/ten-containers/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/ten-containers/task-definition.json
@@ -5,60 +5,60 @@
     "image": "busybox",
     "memory": 10,
     "cpu": 0,
-    "command": ["sleep", "5"]
+    "command": ["sleep", "300"]
   }, {
     "name": "2",
     "image": "busybox",
     "memory": 10,
     "cpu": 0,
-    "command": ["sleep", "5"]
+    "command": ["sleep", "300"]
   }, {
     "name": "3",
     "image": "busybox",
     "memory": 10,
     "cpu": 0,
-    "command": ["sleep", "5"]
+    "command": ["sleep", "300"]
   }, {
     "name": "4",
     "image": "busybox",
     "memory": 10,
     "cpu": 0,
-    "command": ["sleep", "5"]
+    "command": ["sleep", "300"]
   }, {
     "name": "5",
     "image": "busybox",
     "memory": 10,
     "cpu": 0,
-    "command": ["sleep", "5"]
+    "command": ["sleep", "300"]
   }, {
     "name": "6",
     "image": "busybox",
     "memory": 10,
     "cpu": 0,
-    "command": ["sleep", "5"]
+    "command": ["sleep", "300"]
   }, {
     "name": "7",
     "image": "busybox",
     "memory": 10,
     "cpu": 0,
-    "command": ["sleep", "5"]
+    "command": ["sleep", "300"]
   }, {
     "name": "8",
     "image": "busybox",
     "memory": 10,
     "cpu": 0,
-    "command": ["sleep", "5"]
+    "command": ["sleep", "300"]
   }, {
     "name": "9",
     "image": "busybox",
     "memory": 10,
     "cpu": 0,
-    "command": ["sleep", "5"]
+    "command": ["sleep", "300"]
   }, {
     "name": "10",
     "image": "busybox",
     "memory": 10,
     "cpu": 0,
-    "command": ["sleep", "5"]
+    "command": ["sleep", "300"]
   }]
 }


### PR DESCRIPTION
### Summary
This cleans up the TestTaskCleanupDoesNotDeadlock unix functional test similarly to what #680 did for the equivalent windows test.

### Testing

- [x] Builds on Linux (make release)
- [x] Builds on Windows (go build -out amazon-ecs-agent.exe ./agent)
- [x] Unit tests on Linux (make test) pass
- [x] Unit tests on Windows (go test -timeout=25s ./agent/...) pass
- [x] Integration tests on Linux (make run-integ-tests) pass
- [x] Integration tests on Windows (.\scripts\run-integ-tests.ps1) pass
- [x] Functional tests on Linux (make run-functional-tests) pass
- [x] Functional tests on Windows (.\scripts\run-functional-tests.ps1) pass


### Licensing
This contribution is under the terms of the Apache 2.0 License