### PR TITLE
Fix the docker auth configuration overrides problem in #732

### DIFF
--- a/agent/config/config_unix_test.go
+++ b/agent/config/config_unix_test.go
@@ -15,6 +15,8 @@
 package config
 
 import (
+	"fmt"
+	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -22,6 +24,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/ec2"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerclient"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestConfigDefault(t *testing.T) {
@@ -61,4 +64,87 @@ func TestConfigDefault(t *testing.T) {
 	assert.Equal(t, DefaultImageDeletionAge, cfg.MinimumImageDeletionAge, "MinimumImageDeletionAge default is set incorrectly")
 	assert.Equal(t, DefaultImageCleanupTimeInterval, cfg.ImageCleanupInterval, "ImageCleanupInterval default is set incorrectly")
 	assert.Equal(t, DefaultNumImagesToDeletePerCycle, cfg.NumImagesToDeletePerCycle, "NumImagesToDeletePerCycle default is set incorrectly")
+}
+
+// TestConfigFromFile tests the configuration can be read from file
+func TestConfigFromFile(t *testing.T) {
+	cluster := "TestCluster"
+	dockerAuthType := "dockercfg"
+	dockerAuth := `{
+  "https://index.docker.io/v1/":{
+    "auth":"admin",
+    "email":"email"
+  }
+}`
+	configContent := fmt.Sprintf(`{
+  "Cluster": "%s",
+  "EngineAuthType": "%s",
+  "EngineAuthData": %s,
+  "DataDir": "/var/run/ecs_agent",
+  "TaskIAMRoleEnabled": true,
+  "InstanceAttributes": {
+    "attribute1": "value1"
+  }
+}`, cluster, dockerAuthType, dockerAuth)
+
+	configFile := setupDockerAuthConfiguration(t, configContent)
+	defer os.Remove(configFile)
+
+	os.Setenv("ECS_AGENT_CONFIG_FILE_PATH", configFile)
+	defer os.Unsetenv("ECS_AGENT_CONFIG_FILE_PATH")
+
+	config, err := fileConfig()
+	assert.NoError(t, err, "reading configuration from file failed")
+
+	assert.Equal(t, cluster, config.Cluster, "cluster name not as expected from file")
+	assert.Equal(t, dockerAuthType, config.EngineAuthType, "docker auth type not as expected from file")
+	assert.Equal(t, dockerAuth, string(config.EngineAuthData.Contents()), "docker auth data not as expected from file")
+}
+
+// TestDockerAuthMergeFromFile tests docker auth read from file correctly after merge
+func TestDockerAuthMergeFromFile(t *testing.T) {
+	cluster := "myCluster"
+	dockerAuthType := "dockercfg"
+	dockerAuth := `{
+  "https://index.docker.io/v1/":{
+    "auth":"admin",
+    "email":"email"
+  }
+}`
+	configContent := fmt.Sprintf(`{
+  "Cluster": "TestCluster",
+  "EngineAuthType": "%s",
+  "EngineAuthData": %s,
+  "DataDir": "/var/run/ecs_agent",
+  "TaskIAMRoleEnabled": true,
+  "InstanceAttributes": {
+    "attribute1": "value1"
+  }
+}`, dockerAuthType, dockerAuth)
+
+	configFile := setupDockerAuthConfiguration(t, configContent)
+	defer os.Remove(configFile)
+
+	os.Setenv("ECS_CLUSTER", cluster)
+	os.Setenv("ECS_AGENT_CONFIG_FILE_PATH", configFile)
+	defer os.Unsetenv("ECS_CLUSTER")
+	defer os.Unsetenv("ECS_AGENT_CONFIG_FILE_PATH")
+
+	config, err := NewConfig(ec2.NewBlackholeEC2MetadataClient())
+	assert.NoError(t, err, "create configuration failed")
+
+	assert.Equal(t, cluster, config.Cluster, "cluster name not as expected from environment variable")
+	assert.Equal(t, dockerAuthType, config.EngineAuthType, "docker auth type not as expected from file")
+	assert.Equal(t, dockerAuth, string(config.EngineAuthData.Contents()), "docker auth data not as expected from file")
+}
+
+// setupDockerAuthConfiguration create a temp file store the configuration
+func setupDockerAuthConfiguration(t *testing.T, configContent string) string {
+	configFile, err := ioutil.TempFile("", "ecs-test")
+	require.NoError(t, err, "creating temp file for configuration failed")
+
+	_, err = configFile.Write([]byte(configContent))
+	require.NoError(t, err, "writing configuration to file failed")
+
+	return configFile.Name()
 }

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -154,9 +154,12 @@ type SensitiveRawMessage struct {
 	contents json.RawMessage
 }
 
-// NewSensitiveRawMessage returns a new encapsulated json.RawMessage that
-// cannot be accidentally logged via .String/.GoString/%v/%#v
+// NewSensitiveRawMessage returns a new encapsulated json.RawMessage or nil if
+// the data is empty. It cannot be accidentally logged via .String/.GoString/%v/%#v
 func NewSensitiveRawMessage(data json.RawMessage) *SensitiveRawMessage {
+	if len(data) == 0 {
+		return nil
+	}
 	return &SensitiveRawMessage{contents: data}
 }
 

--- a/agent/config/types_test.go
+++ b/agent/config/types_test.go
@@ -17,6 +17,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSensitiveRawMessageImplements(t *testing.T) {
@@ -29,15 +31,20 @@ func TestSensitiveRawMessageImplements(t *testing.T) {
 func TestSensitiveRawMessage(t *testing.T) {
 	sensitive := NewSensitiveRawMessage(json.RawMessage("secret"))
 
-	for i, str := range []string{
+	for _, str := range []string{
 		sensitive.String(),
 		sensitive.GoString(),
 		fmt.Sprintf("%v", sensitive),
 		fmt.Sprintf("%#v", sensitive),
 		fmt.Sprint(sensitive),
 	} {
-		if str != "[redacted]" {
-			t.Errorf("#%v: expected redacted, got %s", i, str)
-		}
+		assert.Equal(t, "[redacted]", str, "expected redacted")
 	}
+}
+
+// TestEmptySensitiveRawMessage tests the message content is empty
+func TestEmptySensitiveRawMessage(t *testing.T) {
+	sensitive := NewSensitiveRawMessage(json.RawMessage(""))
+
+	assert.Nil(t, sensitive, "empty message should return nil")
 }

--- a/agent/engine/docker_container_engine.go
+++ b/agent/engine/docker_container_engine.go
@@ -16,6 +16,7 @@ package engine
 import (
 	"archive/tar"
 	"bufio"
+	"encoding/json"
 	"io"
 	"strings"
 	"sync"
@@ -146,9 +147,13 @@ func NewDockerGoClient(clientFactory dockerclient.Factory, cfg *config.Config) (
 		return nil, err
 	}
 
+	var dockerAuthData json.RawMessage
+	if cfg.EngineAuthData != nil {
+		dockerAuthData = cfg.EngineAuthData.Contents()
+	}
 	return &dockerGoClient{
 		clientFactory:    clientFactory,
-		auth:             dockerauth.NewDockerAuthProvider(cfg.EngineAuthType, cfg.EngineAuthData.Contents()),
+		auth:             dockerauth.NewDockerAuthProvider(cfg.EngineAuthType, dockerAuthData),
 		ecrClientFactory: ecr.NewECRFactory(cfg.AcceptInsecureCert),
 		config:           cfg,
 	}, nil


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Fix issue #732 

### Implementation details
<!-- How are the changes implemented? -->
Return an nil instead of an empty object for dockerauth.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->
yes
### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Fix an issue where docker auth information can't be correctly read from file
### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
yes