### PR TITLE
Add state transition unit tests

### DIFF
--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -25,9 +25,10 @@ import (
 )
 
 const (
-	steadyStateTaskVerifyInterval = 10 * time.Minute
-	stoppedSentWaitInterval       = 30 * time.Second
-	maxStoppedWaitTimes           = 72 * time.Hour / stoppedSentWaitInterval
+	steadyStateTaskVerifyInterval         = 10 * time.Minute
+	stoppedSentWaitInterval               = 30 * time.Second
+	maxStoppedWaitTimes                   = 72 * time.Hour / stoppedSentWaitInterval
+	taskUnableToTransitionToStoppedReason = "TaskStateError: Agent could not progress task's state to stopped"
 )
 
 type acsTaskUpdate struct {
@@ -224,22 +225,12 @@ func (mtask *managedTask) handleContainerChange(containerChange dockerContainerC
 	// If this is a backwards transition stopped->running, the first time set it
 	// to be known running so it will be stopped. Subsequently ignore these backward transitions
 	containerKnownStatus := container.GetKnownStatus()
-	if event.Status <= containerKnownStatus && containerKnownStatus == api.ContainerStopped {
-		if event.Status == api.ContainerRunning {
-			// If the container becomes running after we've stopped it (possibly
-			// because we got an error running it and it ran anyways), the first time
-			// update it to 'known running' so that it will be driven back to stopped
-			mtask.unexpectedStart.Do(func() {
-				llog.Warn("Container that we thought was stopped came back; re-stopping it once")
-				go mtask.engine.transitionContainer(mtask.Task, container, api.ContainerStopped)
-				// This will not proceed afterwards because status <= knownstatus below
-			})
-		}
-	}
+	mtask.handleStoppedToRunningContainerTransition(event.Status, container)
 	if event.Status <= containerKnownStatus {
 		seelog.Infof("Redundant container state change for task %s: %s to %s, but already %s", mtask.Task, container, event.Status, containerKnownStatus)
 		return
 	}
+
 	currentKnownStatus := containerKnownStatus
 	container.SetKnownStatus(event.Status)
 
@@ -318,6 +309,23 @@ func (mtask *managedTask) handleContainerChange(containerChange dockerContainerC
 	}
 }
 
+func (mtask *managedTask) handleStoppedToRunningContainerTransition(status api.ContainerStatus, container *api.Container) {
+	llog := log.New("task", mtask.Task)
+	containerKnownStatus := container.GetKnownStatus()
+	if status <= containerKnownStatus && containerKnownStatus == api.ContainerStopped {
+		if status == api.ContainerRunning {
+			// If the container becomes running after we've stopped it (possibly
+			// because we got an error running it and it ran anyways), the first time
+			// update it to 'known running' so that it will be driven back to stopped
+			mtask.unexpectedStart.Do(func() {
+				llog.Warn("Container that we thought was stopped came back; re-stopping it once")
+				go mtask.engine.transitionContainer(mtask.Task, container, api.ContainerStopped)
+				// This will not proceed afterwards because status <= knownstatus below
+			})
+		}
+	}
+}
+
 func (mtask *managedTask) steadyState() bool {
 	taskKnownStatus := mtask.GetKnownStatus()
 	return taskKnownStatus == api.TaskRunning && taskKnownStatus >= mtask.GetDesiredStatus()
@@ -380,6 +388,8 @@ func (mtask *managedTask) containerNextState(container *api.Container) (api.Cont
 	return nextState, true, true
 }
 
+type containerTransitionFunc func(container *api.Container, nextStatus api.ContainerStatus)
+
 // progressContainers tries to step forwards all containers that are able to be
 // transitioned in the task's current state.
 // It will continue listening to events from all channels while it does so, but
@@ -393,10 +403,34 @@ func (mtask *managedTask) progressContainers() {
 	transitionChange := make(chan bool, len(mtask.Containers))
 	transitionChangeContainer := make(chan string, len(mtask.Containers))
 
-	// Map of containerName -> applyingTransition
-	transitionsMap := make(map[string]api.ContainerStatus)
+	anyCanTransition, transitions := mtask.startContainerTransitions(
+		func(container *api.Container, nextStatus api.ContainerStatus) {
+			mtask.engine.transitionContainer(mtask.Task, container, nextStatus)
+			transitionChange <- true
+			transitionChangeContainer <- container.Name
+		})
 
+	if !anyCanTransition {
+		mtask.onContainersUnableToTransitionState()
+		return
+	}
+
+	// We've kicked off one or more transitions, wait for them to
+	// complete, but keep reading events as we do.. in fact, we have to for
+	// transitions to complete
+	mtask.waitForContainerTransitions(transitions, transitionChange, transitionChangeContainer)
+	log.Debug("Done transitioning all containers for task", "task", mtask.Task)
+
+	if mtask.UpdateStatus() {
+		log.Debug("Container change also resulted in task change")
+		// If knownStatus changed, let it be known
+		mtask.engine.emitTaskEvent(mtask.Task, "")
+	}
+}
+
+func (mtask *managedTask) startContainerTransitions(transitionFunc containerTransitionFunc) (bool, map[string]api.ContainerStatus) {
 	anyCanTransition := false
+	transitions := make(map[string]api.ContainerStatus)
 	for _, cont := range mtask.Containers {
 		nextState, shouldCallTransitionFunc, canTransition := mtask.containerNextState(cont)
 		if !canTransition {
@@ -409,42 +443,38 @@ func (mtask *managedTask) progressContainers() {
 			mtask.handleContainerChange(dockerContainerChange{cont, DockerContainerChangeEvent{Status: nextState}})
 			continue
 		}
-		transitionsMap[cont.Name] = nextState
-		go func(container *api.Container, nextStatus api.ContainerStatus) {
-			mtask.engine.transitionContainer(mtask.Task, container, nextStatus)
-			transitionChange <- true
-			transitionChangeContainer <- container.Name
-		}(cont, nextState)
+		transitions[cont.Name] = nextState
+		go transitionFunc(cont, nextState)
 	}
 
-	if !anyCanTransition {
-		log.Crit("Task in a bad state; it's not steadystate but no containers want to transition", "task", mtask.Task)
-		if mtask.GetDesiredStatus().Terminal() {
-			// Ack, really bad. We want it to stop but the containers don't think
-			// that's possible... let's just break out and hope for the best!
-			log.Crit("The state is so bad that we're just giving up on it")
-			mtask.SetKnownStatus(api.TaskStopped)
-			mtask.engine.emitTaskEvent(mtask.Task, "TaskStateError: Agent could not progress task's state to stopped")
-		} else {
-			log.Crit("Moving task to stopped due to bad state", "task", mtask.Task)
-			mtask.handleDesiredStatusChange(api.TaskStopped, 0)
-		}
-		return
-	}
+	return anyCanTransition, transitions
+}
 
-	// We've kicked off one or more transitions, wait for them to
-	// complete, but keep reading events as we do.. in fact, we have to for
-	// transitions to complete
-	for len(transitionsMap) > 0 {
+func (mtask *managedTask) onContainersUnableToTransitionState() {
+	log.Crit("Task in a bad state; it's not steadystate but no containers want to transition", "task", mtask.Task)
+	if mtask.GetDesiredStatus().Terminal() {
+		// Ack, really bad. We want it to stop but the containers don't think
+		// that's possible... let's just break out and hope for the best!
+		log.Crit("The state is so bad that we're just giving up on it")
+		mtask.SetKnownStatus(api.TaskStopped)
+		mtask.engine.emitTaskEvent(mtask.Task, taskUnableToTransitionToStoppedReason)
+	} else {
+		log.Crit("Moving task to stopped due to bad state", "task", mtask.Task)
+		mtask.handleDesiredStatusChange(api.TaskStopped, 0)
+	}
+}
+
+func (mtask *managedTask) waitForContainerTransitions(transitions map[string]api.ContainerStatus, transitionChange <-chan bool, transitionChangeContainer <-chan string) {
+	for len(transitions) > 0 {
 		if mtask.waitEvent(transitionChange) {
 			changedContainer := <-transitionChangeContainer
 			log.Debug("Transition for container finished", "task", mtask.Task, "container", changedContainer)
-			delete(transitionsMap, changedContainer)
-			log.Debug("Still waiting for", "map", transitionsMap)
+			delete(transitions, changedContainer)
+			log.Debug("Still waiting for", "map", transitions)
 		}
 		if mtask.GetDesiredStatus().Terminal() || mtask.GetKnownStatus().Terminal() {
 			allWaitingOnPulled := true
-			for _, desired := range transitionsMap {
+			for _, desired := range transitions {
 				if desired != api.ContainerPulled {
 					allWaitingOnPulled = false
 				}
@@ -453,17 +483,11 @@ func (mtask *managedTask) progressContainers() {
 				// We don't actually care to wait for 'pull' transitions to finish if
 				// we're just heading to stopped since those resources aren't
 				// inherently linked to this task anyways for e.g. gc and so on.
-				log.Debug("All waiting is for pulled transition; exiting early", "map", transitionsMap, "task", mtask.Task)
+				log.Debug("All waiting is for pulled transition; exiting early",
+					"map", transitions, "task", mtask.Task)
 				break
 			}
 		}
-	}
-	log.Debug("Done transitioning all containers for task", "task", mtask.Task)
-
-	if mtask.UpdateStatus() {
-		log.Debug("Container change also resulted in task change")
-		// If knownStatus changed, let it be known
-		mtask.engine.emitTaskEvent(mtask.Task, "")
 	}
 }
 

--- a/agent/engine/task_manager_test.go
+++ b/agent/engine/task_manager_test.go
@@ -15,154 +15,381 @@
 package engine
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/engine/testdata"
+	"github.com/aws/amazon-ecs-agent/agent/eventstream"
 	"github.com/aws/amazon-ecs-agent/agent/statemanager"
 	"github.com/aws/amazon-ecs-agent/agent/utils/ttime/mocks"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/golang/mock/gomock"
+	"golang.org/x/net/context"
 )
 
-func TestContainerNextStateFromNone(t *testing.T) {
-	// NONE -> RUNNING transition is allowed and actionable, when desired is Running
-	// The exptected next status is Pulled
-	testContainerNextStateAssertions(t,
-		api.ContainerStatusNone, api.ContainerRunning,
-		api.ContainerPulled, true, true)
+func TestContainerNextState(t *testing.T) {
+	testCases := []struct {
+		containerCurrentStatus       api.ContainerStatus
+		containerDesiredStatus       api.ContainerStatus
+		expectedContainerStatus      api.ContainerStatus
+		expectedTransitionActionable bool
+		expectedTransitionPossible   bool
+	}{
+		// NONE -> RUNNING transition is allowed and actionable, when desired is Running
+		// The exptected next status is Pulled
+		{api.ContainerStatusNone, api.ContainerRunning, api.ContainerPulled, true, true},
+		// NONE -> NONE transition is not be allowed and is not actionable,
+		// when desired is Running
+		{api.ContainerStatusNone, api.ContainerStatusNone, api.ContainerStatusNone, false, false},
+		// NONE -> STOPPED transition will result in STOPPED and is allowed, but not
+		// actionable, when desired is STOPPED
+		{api.ContainerStatusNone, api.ContainerStopped, api.ContainerStopped, false, true},
+		// PULLED -> RUNNING transition is allowed and actionable, when desired is Running
+		// The exptected next status is Created
+		{api.ContainerPulled, api.ContainerRunning, api.ContainerCreated, true, true},
+		// PULLED -> PULLED transition is not allowed and not actionable,
+		// when desired is Running
+		{api.ContainerPulled, api.ContainerPulled, api.ContainerStatusNone, false, false},
+		// PULLED -> NONE transition is not allowed and not actionable,
+		// when desired is Running
+		{api.ContainerPulled, api.ContainerStatusNone, api.ContainerStatusNone, false, false},
+		// PULLED -> STOPPED transition will result in STOPPED and is allowed, but not
+		// actionable, when desired is STOPPED
+		{api.ContainerPulled, api.ContainerStopped, api.ContainerStopped, false, true},
+		// CREATED -> RUNNING transition is allowed and actionable, when desired is Running
+		// The exptected next status is Running
+		{api.ContainerCreated, api.ContainerRunning, api.ContainerRunning, true, true},
+		// CREATED -> CREATED transition is not allowed and not actionable,
+		// when desired is Running
+		{api.ContainerCreated, api.ContainerCreated, api.ContainerStatusNone, false, false},
+		// CREATED -> NONE transition is not allowed and not actionable,
+		// when desired is Running
+		{api.ContainerCreated, api.ContainerStatusNone, api.ContainerStatusNone, false, false},
+		// CREATED -> PULLED transition is not allowed and not actionable,
+		// when desired is Running
+		{api.ContainerCreated, api.ContainerPulled, api.ContainerStatusNone, false, false},
+		// CREATED -> STOPPED transition will result in STOPPED and is allowed, but not
+		// actionable, when desired is STOPPED
+		{api.ContainerCreated, api.ContainerStopped, api.ContainerStopped, false, true},
+		// RUNNING -> STOPPED transition is allowed and actionable, when desired is Running
+		// The exptected next status is STOPPED
+		{api.ContainerRunning, api.ContainerStopped, api.ContainerStopped, true, true},
+		// RUNNING -> RUNNING transition is not allowed and not actionable,
+		// when desired is Running
+		{api.ContainerRunning, api.ContainerRunning, api.ContainerStatusNone, false, false},
+		// RUNNING -> NONE transition is not allowed and not actionable,
+		// when desired is Running
+		{api.ContainerRunning, api.ContainerStatusNone, api.ContainerStatusNone, false, false},
+		// RUNNING -> PULLED transition is not allowed and not actionable,
+		// when desired is Running
+		{api.ContainerRunning, api.ContainerPulled, api.ContainerStatusNone, false, false},
+		// RUNNING -> CREATED transition is not allowed and not actionable,
+		// when desired is Running
+		{api.ContainerRunning, api.ContainerCreated, api.ContainerStatusNone, false, false},
+	}
 
-	// NONE -> NONE transition is not be allowed and is not actionable,
-	// when desired is Running
-	testContainerNextStateAssertions(t,
-		api.ContainerStatusNone, api.ContainerStatusNone,
-		api.ContainerStatusNone, false, false)
-
-	// NONE -> STOPPED transition will result in STOPPED and is allowed, but not
-	// actionable, when desired is STOPPED
-	testContainerNextStateAssertions(t,
-		api.ContainerStatusNone, api.ContainerStopped,
-		api.ContainerStopped, false, true)
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%s to %s Transition",
+			tc.containerCurrentStatus.String(), tc.containerDesiredStatus.String()), func(t *testing.T) {
+			container := &api.Container{
+				DesiredStatusUnsafe: tc.containerDesiredStatus,
+				KnownStatusUnsafe:   tc.containerCurrentStatus,
+			}
+			task := &managedTask{
+				Task: &api.Task{
+					Containers: []*api.Container{
+						container,
+					},
+					DesiredStatusUnsafe: api.TaskRunning,
+				},
+			}
+			nextStatus, actionRequired, possible := task.containerNextState(container)
+			assert.Equal(t, tc.expectedContainerStatus, nextStatus,
+				"Expected next state [%s] != Retrieved next state [%s]",
+				tc.expectedContainerStatus.String(), nextStatus.String())
+			assert.Equal(t, tc.expectedTransitionActionable, actionRequired)
+			assert.Equal(t, tc.expectedTransitionPossible, possible)
+		})
+	}
 }
 
-func TestContainerNextStateFromPulled(t *testing.T) {
-	// PULLED -> RUNNING transition is allowed and actionable, when desired is Running
-	// The exptected next status is Created
-	testContainerNextStateAssertions(t,
-		api.ContainerPulled, api.ContainerRunning,
-		api.ContainerCreated, true, true)
-
-	// PULLED -> PULLED transition is not allowed and not actionable,
-	// when desired is Running
-	testContainerNextStateAssertions(t,
-		api.ContainerPulled, api.ContainerPulled,
-		api.ContainerStatusNone, false, false)
-
-	// PULLED -> NONE transition is not allowed and not actionable,
-	// when desired is Running
-	testContainerNextStateAssertions(t,
-		api.ContainerPulled, api.ContainerStatusNone,
-		api.ContainerStatusNone, false, false)
-
-	// PULLED -> STOPPED transition will result in STOPPED and is allowed, but not
-	// actionable, when desired is STOPPED
-	testContainerNextStateAssertions(t,
-		api.ContainerPulled, api.ContainerStopped,
-		api.ContainerStopped, false, true)
-}
-
-func TestContainerNextStateFromCreated(t *testing.T) {
-	// CREATED -> RUNNING transition is allowed and actionable, when desired is Running
-	// The exptected next status is Running
-	testContainerNextStateAssertions(t,
-		api.ContainerCreated, api.ContainerRunning,
-		api.ContainerRunning, true, true)
-
-	// CREATED -> CREATED transition is not allowed and not actionable,
-	// when desired is Running
-	testContainerNextStateAssertions(t,
-		api.ContainerCreated, api.ContainerCreated,
-		api.ContainerStatusNone, false, false)
-
-	// CREATED -> NONE transition is not allowed and not actionable,
-	// when desired is Running
-	testContainerNextStateAssertions(t,
-		api.ContainerCreated, api.ContainerStatusNone,
-		api.ContainerStatusNone, false, false)
-
-	// CREATED -> PULLED transition is not allowed and not actionable,
-	// when desired is Running
-	testContainerNextStateAssertions(t,
-		api.ContainerCreated, api.ContainerPulled,
-		api.ContainerStatusNone, false, false)
-
-	// CREATED -> STOPPED transition will result in STOPPED and is allowed, but not
-	// actionable, when desired is STOPPED
-	testContainerNextStateAssertions(t,
-		api.ContainerCreated, api.ContainerStopped,
-		api.ContainerStopped, false, true)
-}
-
-func TestContainerNextStateFromRunning(t *testing.T) {
-	// RUNNING -> STOPPED transition is allowed and actionable, when desired is Running
-	// The exptected next status is STOPPED
-	testContainerNextStateAssertions(t,
-		api.ContainerRunning, api.ContainerStopped,
-		api.ContainerStopped, true, true)
-
-	// RUNNING -> RUNNING transition is not allowed and not actionable,
-	// when desired is Running
-	testContainerNextStateAssertions(t,
-		api.ContainerRunning, api.ContainerRunning,
-		api.ContainerStatusNone, false, false)
-
-	// RUNNING -> NONE transition is not allowed and not actionable,
-	// when desired is Running
-	testContainerNextStateAssertions(t,
-		api.ContainerRunning, api.ContainerStatusNone,
-		api.ContainerStatusNone, false, false)
-
-	// RUNNING -> PULLED transition is not allowed and not actionable,
-	// when desired is Running
-	testContainerNextStateAssertions(t,
-		api.ContainerRunning, api.ContainerPulled,
-		api.ContainerStatusNone, false, false)
-
-	// RUNNING -> CREATED transition is not allowed and not actionable,
-	// when desired is Running
-	testContainerNextStateAssertions(t,
-		api.ContainerRunning, api.ContainerCreated,
-		api.ContainerStatusNone, false, false)
-}
-
-func testContainerNextStateAssertions(t *testing.T,
-	containerCurrentStatus api.ContainerStatus,
-	containerDesiredStatus api.ContainerStatus,
-	expectedContainerStatus api.ContainerStatus,
-	expectedTransitionActionable bool,
-	expectedTransitionPossible bool) {
-	container := &api.Container{
-		DesiredStatusUnsafe: containerDesiredStatus,
-		KnownStatusUnsafe:   containerCurrentStatus,
+func TestStartContainerTransitionsWhenForwardTransitionPossible(t *testing.T) {
+	firstContainerName := "container1"
+	firstContainer := &api.Container{
+		KnownStatusUnsafe:   api.ContainerCreated,
+		DesiredStatusUnsafe: api.ContainerRunning,
+		Name:                firstContainerName,
+	}
+	secondContainerName := "container2"
+	secondContainer := &api.Container{
+		KnownStatusUnsafe:   api.ContainerPulled,
+		DesiredStatusUnsafe: api.ContainerRunning,
+		Name:                secondContainerName,
 	}
 	task := &managedTask{
 		Task: &api.Task{
 			Containers: []*api.Container{
-				container,
+				firstContainer,
+				secondContainer,
+			},
+			DesiredStatusUnsafe: api.TaskRunning,
+		},
+		engine: &DockerTaskEngine{},
+	}
+
+	waitForAssertions := sync.WaitGroup{}
+	waitForAssertions.Add(2)
+	canTransition, transitions := task.startContainerTransitions(
+		func(cont *api.Container, nextStatus api.ContainerStatus) {
+			if cont.Name == firstContainerName {
+				assert.Equal(t, nextStatus, api.ContainerRunning)
+			} else if cont.Name == secondContainerName {
+				assert.Equal(t, nextStatus, api.ContainerCreated)
+			}
+			waitForAssertions.Done()
+		})
+	waitForAssertions.Wait()
+	assert.True(t, canTransition)
+	assert.NotEmpty(t, transitions)
+	assert.Len(t, transitions, 2)
+	firstContainerTransition, ok := transitions[firstContainerName]
+	assert.True(t, ok)
+	assert.Equal(t, firstContainerTransition, api.ContainerRunning)
+	secondContainerTransition, ok := transitions[secondContainerName]
+	assert.True(t, ok)
+	assert.Equal(t, secondContainerTransition, api.ContainerCreated)
+}
+
+func TestStartContainerTransitionsWhenForwardTransitionIsNotPossible(t *testing.T) {
+	firstContainerName := "container1"
+	firstContainer := &api.Container{
+		KnownStatusUnsafe:   api.ContainerRunning,
+		DesiredStatusUnsafe: api.ContainerRunning,
+		Name:                firstContainerName,
+	}
+	secondContainerName := "container2"
+	secondContainer := &api.Container{
+		KnownStatusUnsafe:   api.ContainerRunning,
+		DesiredStatusUnsafe: api.ContainerRunning,
+		Name:                secondContainerName,
+	}
+	task := &managedTask{
+		Task: &api.Task{
+			Containers: []*api.Container{
+				firstContainer,
+				secondContainer,
+			},
+			DesiredStatusUnsafe: api.TaskRunning,
+		},
+		engine: &DockerTaskEngine{},
+	}
+
+	canTransition, transitions := task.startContainerTransitions(
+		func(cont *api.Container, nextStatus api.ContainerStatus) {
+			t.Error("Transition function should not be called when no transitions are possible")
+		})
+	assert.False(t, canTransition)
+	assert.Empty(t, transitions)
+}
+
+func TestStartContainerTransitionsInvokesHandleContainerChange(t *testing.T) {
+	eventStreamName := "TESTTASKENGINE"
+
+	// Create a container with the intent to do
+	// CREATERD -> STOPPED transition. This triggers
+	// `managedTask.handleContainerChange()` and generates the following
+	// events:
+	// 1. container state change event for Submit* API
+	// 2. task state change event for Submit* API
+	// 3. container state change event for the internal event stream
+	firstContainerName := "container1"
+	firstContainer := &api.Container{
+		KnownStatusUnsafe:   api.ContainerCreated,
+		DesiredStatusUnsafe: api.ContainerStopped,
+		Name:                firstContainerName,
+	}
+
+	containerChangeEventStream := eventstream.NewEventStream(eventStreamName, context.Background())
+	containerChangeEventStream.StartListening()
+
+	containerEvents := make(chan api.ContainerStateChange)
+	taskEvents := make(chan api.TaskStateChange)
+
+	task := &managedTask{
+		Task: &api.Task{
+			Containers: []*api.Container{
+				firstContainer,
+			},
+			DesiredStatusUnsafe: api.TaskRunning,
+		},
+		engine: &DockerTaskEngine{
+			containerChangeEventStream: containerChangeEventStream,
+			containerEvents:            containerEvents,
+			taskEvents:                 taskEvents,
+		},
+	}
+
+	eventsGenerated := sync.WaitGroup{}
+	eventsGenerated.Add(3)
+	containerChangeEventStream.Subscribe(eventStreamName, func(events ...interface{}) error {
+		assert.NotNil(t, events)
+		assert.Len(t, events, 1)
+		event := events[0]
+		containerChangeEvent, ok := event.(DockerContainerChangeEvent)
+		assert.True(t, ok)
+		assert.Equal(t, containerChangeEvent.Status, api.ContainerStopped)
+		eventsGenerated.Done()
+		return nil
+	})
+	defer containerChangeEventStream.Unsubscribe(eventStreamName)
+
+	go func() {
+		<-containerEvents
+		eventsGenerated.Done()
+	}()
+
+	go func() {
+		<-taskEvents
+		eventsGenerated.Done()
+	}()
+
+	canTransition, transitions := task.startContainerTransitions(
+		func(cont *api.Container, nextStatus api.ContainerStatus) {
+			t.Error("Invalid code path. The transition function should not be invoked when transitioning container from CREATED -> STOPPED")
+		})
+	assert.True(t, canTransition)
+	assert.Empty(t, transitions)
+	eventsGenerated.Wait()
+}
+
+func TestWaitForContainerTransitionsForNonTerminalTask(t *testing.T) {
+	acsMessages := make(chan acsTransition)
+	dockerMessages := make(chan dockerContainerChange)
+	task := &managedTask{
+		acsMessages:    acsMessages,
+		dockerMessages: dockerMessages,
+		Task: &api.Task{
+			Containers: []*api.Container{},
+		},
+	}
+
+	transitionChange := make(chan bool, 2)
+	transitionChangeContainer := make(chan string, 2)
+
+	firstContainerName := "container1"
+	secondContainerName := "container2"
+
+	// populate the transitions map with transitions for two
+	// containers. We expect two sets of events to be consumed
+	// by `waitForContainerTransitions`
+	transitions := make(map[string]api.ContainerStatus)
+	transitions[firstContainerName] = api.ContainerRunning
+	transitions[secondContainerName] = api.ContainerRunning
+
+	go func() {
+		// Send "transitions completed" messages. These are being
+		// sent out of order for no particular reason. We should be
+		// resilient to the ordering of these messages anyway.
+		transitionChange <- true
+		transitionChangeContainer <- secondContainerName
+		transitionChange <- true
+		transitionChangeContainer <- firstContainerName
+	}()
+
+	// waitForContainerTransitions will block until it recieves events
+	// sent by the go routine defined above
+	task.waitForContainerTransitions(transitions, transitionChange, transitionChangeContainer)
+}
+
+// TestWaitForContainerTransitionsForTerminalTask verifies that the
+// `waitForContainerTransitions` method doesn't wait for any container
+// transitions when the task's desired status is STOPPED and if all
+// containers in the task are in PULLED state
+func TestWaitForContainerTransitionsForTerminalTask(t *testing.T) {
+	acsMessages := make(chan acsTransition)
+	dockerMessages := make(chan dockerContainerChange)
+	task := &managedTask{
+		acsMessages:    acsMessages,
+		dockerMessages: dockerMessages,
+		Task: &api.Task{
+			Containers:        []*api.Container{},
+			KnownStatusUnsafe: api.TaskStopped,
+		},
+	}
+
+	transitionChange := make(chan bool, 2)
+	transitionChangeContainer := make(chan string, 2)
+
+	firstContainerName := "container1"
+	secondContainerName := "container2"
+	transitions := make(map[string]api.ContainerStatus)
+	transitions[firstContainerName] = api.ContainerPulled
+	transitions[secondContainerName] = api.ContainerPulled
+
+	// Event though there are two keys in the transitions map, send
+	// only one event. This tests that `waitForContainerTransitions` doesn't
+	// block to recieve two events and will still progress
+	go func() {
+		transitionChange <- true
+		transitionChangeContainer <- secondContainerName
+	}()
+	task.waitForContainerTransitions(transitions, transitionChange, transitionChangeContainer)
+}
+
+func TestOnContainersUnableToTransitionStateForDesiredStoppedTask(t *testing.T) {
+	taskEvents := make(chan api.TaskStateChange)
+	task := &managedTask{
+		Task: &api.Task{
+			Containers:          []*api.Container{},
+			DesiredStatusUnsafe: api.TaskStopped,
+		},
+		engine: &DockerTaskEngine{
+			taskEvents: taskEvents,
+		},
+	}
+	eventsGenerated := sync.WaitGroup{}
+	eventsGenerated.Add(1)
+
+	go func() {
+		event := <-taskEvents
+		assert.Equal(t, event.Reason, taskUnableToTransitionToStoppedReason)
+		eventsGenerated.Done()
+	}()
+
+	task.onContainersUnableToTransitionState()
+	eventsGenerated.Wait()
+
+	assert.Equal(t, task.GetDesiredStatus(), api.TaskStopped)
+}
+
+func TestOnContainersUnableToTransitionStateForDesiredRunningTask(t *testing.T) {
+	firstContainerName := "container1"
+	firstContainer := &api.Container{
+		KnownStatusUnsafe:   api.ContainerCreated,
+		DesiredStatusUnsafe: api.ContainerRunning,
+		Name:                firstContainerName,
+	}
+	task := &managedTask{
+		Task: &api.Task{
+			Containers: []*api.Container{
+				firstContainer,
 			},
 			DesiredStatusUnsafe: api.TaskRunning,
 		},
 	}
-	nextStatus, actionRequired, possible := task.containerNextState(container)
-	assert.Equal(t, nextStatus, expectedContainerStatus,
-		"Retrieved next state [%s] != Expected next state [%s]",
-		nextStatus.String(), expectedContainerStatus.String())
-	assert.Equal(t, actionRequired, expectedTransitionActionable)
-	assert.Equal(t, possible, expectedTransitionPossible)
+
+	task.onContainersUnableToTransitionState()
+	assert.Equal(t, task.GetDesiredStatus(), api.TaskStopped)
+	assert.Equal(t, task.Containers[0].GetDesiredStatus(), api.ContainerStopped)
 }
+
+// TODO: Test progressContainers workflow
+// TODO: Test handleStoppedToRunningContainerTransition
 
 func TestCleanupTask(t *testing.T) {
 	ctrl := gomock.NewController(t)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Add state transition unit tests

### Implementation details
<!-- How are the changes implemented? -->
* engine: add tests for `managedTask.containerNextState`
* engine: break up `managedTask.progressContainers()` into multiple methods: This method has now been broken into:
    - startContainerTransitions
    - onContainersUnableToTransitionState and
    - waitForContainerTransitions
The main aim is to make this method more readable and testable. On that note,
multiple unit tests have also been added to test each method that constitutes
progressContainers()

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: Yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
None
### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: Yes
