### PR TITLE
Filter tasks returned by introspection API by short container ID

### DIFF
--- a/agent/engine/dockerstate/dockerstate_test.go
+++ b/agent/engine/dockerstate/dockerstate_test.go
@@ -32,6 +32,10 @@ func TestCreateDockerTaskEngineState(t *testing.T) {
 		t.Error("Empty state should not have a test task")
 	}
 
+	if _, ok := state.TaskByShortID("test"); ok {
+		t.Error("Empty state should not have a test taskid")
+	}
+
 	if _, ok := state.TaskByID("test"); ok {
 		t.Error("Empty state should not have a test taskid")
 	}

--- a/agent/engine/dockerstate/mocks/dockerstate_mocks.go
+++ b/agent/engine/dockerstate/mocks/dockerstate_mocks.go
@@ -158,6 +158,17 @@ func (_mr *_MockTaskEngineStateRecorder) TaskByID(arg0 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "TaskByID", arg0)
 }
 
+func (_mr *_MockTaskEngineStateRecorder) TaskByShortID(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "TaskByShortID", arg0)
+}
+
+func (_m *MockTaskEngineState) TaskByShortID(_param0 string) (*api.Task, bool) {
+	ret := _m.ctrl.Call(_m, "TaskByShortID", _param0)
+	ret0, _ := ret[0].(*api.Task)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
 func (_m *MockTaskEngineState) UnmarshalJSON(_param0 []byte) error {
 	ret := _m.ctrl.Call(_m, "UnmarshalJSON", _param0)
 	ret0, _ := ret[0].(error)

--- a/agent/handlers/v1_handlers.go
+++ b/agent/handlers/v1_handlers.go
@@ -35,6 +35,7 @@ var log = logger.ForModule("Handlers")
 const (
 	dockerIdQueryField = "dockerid"
 	taskArnQueryField  = "taskarn"
+	dockerShortIdLen   = 12
 )
 
 type rootResponse struct {
@@ -134,7 +135,13 @@ func tasksV1RequestHandlerMaker(taskEngine DockerStateResolver) func(http.Respon
 		}
 		if dockerIdExists {
 			// Create TaskResponse for the docker id in the query.
-			task, found := dockerTaskEngineState.TaskByID(dockerId)
+			var task *api.Task
+			var found bool
+			if len(dockerId) > dockerShortIdLen {
+				task, found = dockerTaskEngineState.TaskByID(dockerId)
+			} else {
+				task, found = dockerTaskEngineState.TaskByShortID(dockerId)
+			}
 			responseJSON, status = createTaskJSONResponse(task, found, dockerId, dockerTaskEngineState)
 			w.WriteHeader(status)
 		} else if taskArnExists {

--- a/agent/handlers/v1_handlers_test.go
+++ b/agent/handlers/v1_handlers_test.go
@@ -78,6 +78,20 @@ func TestGetTaskByDockerID(t *testing.T) {
 	taskDiffHelper(t, []*api.Task{testTasks[1]}, TasksResponse{Tasks: []*TaskResponse{&taskResponse}})
 }
 
+func TestGetTaskByShortDockerID(t *testing.T) {
+	// stateSetupHelper uses the convention of dockerid-$arn-$containerName; the
+	// first task has a container name prefix of dockerid-tas
+	recorder := performMockRequest(t, "/v1/tasks?dockerid=dockerid-tas")
+
+	var taskResponse TaskResponse
+	err := json.Unmarshal(recorder.Body.Bytes(), &taskResponse)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	taskDiffHelper(t, []*api.Task{testTasks[0]}, TasksResponse{Tasks: []*TaskResponse{&taskResponse}})
+}
+
 func TestGetTaskByDockerID404(t *testing.T) {
 	recorder := performMockRequest(t, "/v1/tasks?dockerid=does-not-exist")
 


### PR DESCRIPTION
### Summary
Adds the ability to lookup a task via the introspection service using the short version of the docker Id. Use case is for a container to be able to discover this own task arn and other task related metadata 

addresses feature-request #770

### Implementation details
A function TaskByShortID was added to TaskEngineState interface to find the first matching Tasks who's container id started with the given short id. The tasksV1RequestHandlerMaker was then updated to call either the TaskByID or TaskByShortID depending on the length of the dockerId request param

### Testing
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes

### Description for the changelog
Feature - Filter tasks returned by introspection API by short container ID
### Licensing
This contribution is under the terms of the Apache 2.0 License: yes