### PR TITLE
engine: single channel to propagate engine events

### DIFF
--- a/agent/acs/handler/payload_handler.go
+++ b/agent/acs/handler/payload_handler.go
@@ -286,13 +286,13 @@ func (payloadHandler *payloadRequestHandler) handleUnrecognizedTask(task *ecsacs
 	}
 
 	// Only need to stop the task; it brings down the containers too.
-	te := api.TaskStateChange{
+	taskEvent := api.TaskStateChange{
 		TaskArn: *task.Arn,
 		Status:  api.TaskStopped,
 		Reason:  UnrecognizedTaskError{err}.Error(),
 	}
 
-	payloadHandler.taskHandler.AddStateChangeEvent(te, payloadHandler.ecsClient)
+	payloadHandler.taskHandler.AddStateChangeEvent(taskEvent, payloadHandler.ecsClient)
 }
 
 // clearAcks drains the ack request channel

--- a/agent/acs/handler/payload_handler.go
+++ b/agent/acs/handler/payload_handler.go
@@ -20,7 +20,6 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/credentials"
 	"github.com/aws/amazon-ecs-agent/agent/engine"
 	"github.com/aws/amazon-ecs-agent/agent/eventhandler"
-	"github.com/aws/amazon-ecs-agent/agent/statechange"
 	"github.com/aws/amazon-ecs-agent/agent/statemanager"
 	"github.com/aws/amazon-ecs-agent/agent/wsclient"
 	"github.com/aws/aws-sdk-go/aws"
@@ -287,15 +286,13 @@ func (payloadHandler *payloadRequestHandler) handleUnrecognizedTask(task *ecsacs
 	}
 
 	// Only need to stop the task; it brings down the containers too.
-	te := &api.TaskStateChange{
+	te := api.TaskStateChange{
 		TaskArn: *task.Arn,
 		Status:  api.TaskStopped,
 		Reason:  UnrecognizedTaskError{err}.Error(),
 	}
 
-	payloadHandler.taskHandler.AddStateChangeEvent(statechange.StateChangeEvent{
-		TaskEvent: te,
-	}, payloadHandler.ecsClient)
+	payloadHandler.taskHandler.AddStateChangeEvent(te, payloadHandler.ecsClient)
 }
 
 // clearAcks drains the ack request channel

--- a/agent/acs/handler/payload_handler.go
+++ b/agent/acs/handler/payload_handler.go
@@ -20,6 +20,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/credentials"
 	"github.com/aws/amazon-ecs-agent/agent/engine"
 	"github.com/aws/amazon-ecs-agent/agent/eventhandler"
+	"github.com/aws/amazon-ecs-agent/agent/statechange"
 	"github.com/aws/amazon-ecs-agent/agent/statemanager"
 	"github.com/aws/amazon-ecs-agent/agent/wsclient"
 	"github.com/aws/aws-sdk-go/aws"
@@ -286,10 +287,14 @@ func (payloadHandler *payloadRequestHandler) handleUnrecognizedTask(task *ecsacs
 	}
 
 	// Only need to stop the task; it brings down the containers too.
-	payloadHandler.taskHandler.AddTaskEvent(api.TaskStateChange{
+	te := &api.TaskStateChange{
 		TaskArn: *task.Arn,
 		Status:  api.TaskStopped,
 		Reason:  UnrecognizedTaskError{err}.Error(),
+	}
+
+	payloadHandler.taskHandler.AddStateChangeEvent(statechange.StateChangeEvent{
+		TaskEvent: te,
 	}, payloadHandler.ecsClient)
 }
 

--- a/agent/api/statechange.go
+++ b/agent/api/statechange.go
@@ -85,11 +85,11 @@ func (t *TaskStateChange) String() string {
 }
 
 // GetEventType() returns an enum identifying the event type
-func (c ContainerStateChange) GetEventType() statechange.Event {
+func (c ContainerStateChange) GetEventType() statechange.EventType {
 	return statechange.ContainerEvent
 }
 
 // GetEventType() returns an enum identifying the event type
-func (t TaskStateChange) GetEventType() statechange.Event {
+func (t TaskStateChange) GetEventType() statechange.EventType {
 	return statechange.TaskEvent
 }

--- a/agent/api/statechange.go
+++ b/agent/api/statechange.go
@@ -15,6 +15,7 @@ package api
 
 import (
 	"fmt"
+	"github.com/aws/amazon-ecs-agent/agent/statechange"
 	"strconv"
 )
 
@@ -81,4 +82,12 @@ func (t *TaskStateChange) String() string {
 		res += ", Known Sent: " + t.Task.GetSentStatus().String()
 	}
 	return res
+}
+
+func (c ContainerStateChange) GetEventType() int {
+	return statechange.ContainerEvent
+}
+
+func (t TaskStateChange) GetEventType() int {
+	return statechange.TaskEvent
 }

--- a/agent/api/statechange.go
+++ b/agent/api/statechange.go
@@ -84,10 +84,12 @@ func (t *TaskStateChange) String() string {
 	return res
 }
 
+// GetEventType() returns an enum identifying the event type
 func (c ContainerStateChange) GetEventType() int {
 	return statechange.ContainerEvent
 }
 
+// GetEventType() returns an enum identifying the event type
 func (t TaskStateChange) GetEventType() int {
 	return statechange.TaskEvent
 }

--- a/agent/api/statechange.go
+++ b/agent/api/statechange.go
@@ -85,11 +85,11 @@ func (t *TaskStateChange) String() string {
 }
 
 // GetEventType() returns an enum identifying the event type
-func (c ContainerStateChange) GetEventType() int {
+func (c ContainerStateChange) GetEventType() statechange.Event {
 	return statechange.ContainerEvent
 }
 
 // GetEventType() returns an enum identifying the event type
-func (t TaskStateChange) GetEventType() int {
+func (t TaskStateChange) GetEventType() statechange.Event {
 	return statechange.TaskEvent
 }

--- a/agent/engine/docker_image_manager_integ_test.go
+++ b/agent/engine/docker_image_manager_integ_test.go
@@ -374,7 +374,7 @@ func TestImageWithSameNameAndDifferentID(t *testing.T) {
 	imageState2.PulledAt = imageState2.PulledAt.Add(-19 * time.Minute)
 	imageState3.PulledAt = imageState3.PulledAt.Add(-18 * time.Minute)
 
-	go discardEvents(taskEvents)
+	go discardEvents(stateChangeEvents)
 	// Wait for task to be stopped
 	waitForTaskStoppedByCheckStatus(task1)
 	waitForTaskStoppedByCheckStatus(task2)
@@ -503,7 +503,7 @@ func TestImageWithSameIDAndDifferentNames(t *testing.T) {
 	imageState1.LastUsedAt = imageState1.LastUsedAt.Add(-99995 * time.Hour)
 	imageState1.PulledAt = imageState1.PulledAt.Add(-20 * time.Minute)
 
-	go discardEvents(taskEvents)
+	go discardEvents(stateChangeEvents)
 	// Wait for the Task to be stopped
 	waitForTaskStoppedByCheckStatus(task1)
 	waitForTaskStoppedByCheckStatus(task2)

--- a/agent/engine/docker_image_manager_integ_test.go
+++ b/agent/engine/docker_image_manager_integ_test.go
@@ -65,9 +65,7 @@ func TestIntegImageCleanupHappyCase(t *testing.T) {
 		cleanupImagesHappy(imageManager)
 	}()
 
-	taskEvents, containerEvents := taskEngine.TaskEvents()
-
-	defer discardEvents(containerEvents)()
+	stateChangeEvents := taskEngine.StateChangeEvents()
 
 	// Create test Task
 	taskName := "imgClean"
@@ -76,7 +74,7 @@ func TestIntegImageCleanupHappyCase(t *testing.T) {
 	go taskEngine.AddTask(testTask)
 
 	// Verify that Task is running
-	err := verifyTaskIsRunning(taskEvents, testTask)
+	err := verifyTaskIsRunning(stateChangeEvents, testTask)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -111,7 +109,7 @@ func TestIntegImageCleanupHappyCase(t *testing.T) {
 	imageState3.LastUsedAt = imageState3.LastUsedAt.Add(-99993 * time.Hour)
 
 	// Verify Task is stopped.
-	verifyTaskIsStopped(taskEvents, testTask)
+	verifyTaskIsStopped(stateChangeEvents, testTask)
 	testTask.SetSentStatus(api.TaskStopped)
 
 	// Allow Task cleanup to occur
@@ -179,8 +177,7 @@ func TestIntegImageCleanupThreshold(t *testing.T) {
 		cleanupImagesThreshold(imageManager)
 	}()
 
-	taskEvents, containerEvents := taskEngine.TaskEvents()
-	defer discardEvents(containerEvents)()
+	stateChangeEvents := taskEngine.StateChangeEvents()
 
 	// Create test Task
 	taskName := "imgClean"
@@ -190,7 +187,7 @@ func TestIntegImageCleanupThreshold(t *testing.T) {
 	go taskEngine.AddTask(testTask)
 
 	// Verify that Task is running
-	err := verifyTaskIsRunning(taskEvents, testTask)
+	err := verifyTaskIsRunning(stateChangeEvents, testTask)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -230,7 +227,7 @@ func TestIntegImageCleanupThreshold(t *testing.T) {
 	imageState3.PulledAt = imageState3.PulledAt.Add(-25 * time.Minute)
 
 	// Verify Task is stopped
-	verifyTaskIsStopped(taskEvents, testTask)
+	verifyTaskIsStopped(stateChangeEvents, testTask)
 	testTask.SetSentStatus(api.TaskStopped)
 
 	// Allow Task cleanup to occur
@@ -295,8 +292,7 @@ func TestImageWithSameNameAndDifferentID(t *testing.T) {
 	imageManager := taskEngine.(*DockerTaskEngine).imageManager.(*dockerImageManager)
 	imageManager.SetSaver(statemanager.NewNoopStateManager())
 
-	taskEvents, containerEvents := taskEngine.TaskEvents()
-	defer discardEvents(containerEvents)()
+	stateChangeEvents := taskEngine.StateChangeEvents()
 
 	// Pull the images needed for the test
 	if _, err = dockerClient.InspectImage(test3Image1Name); err == docker.ErrNoSuchImage {
@@ -327,7 +323,7 @@ func TestImageWithSameNameAndDifferentID(t *testing.T) {
 
 	// start and wait for task1 to be running
 	go taskEngine.AddTask(task1)
-	err = verifyTaskIsRunning(taskEvents, task1)
+	err = verifyTaskIsRunning(stateChangeEvents, task1)
 	require.NoError(t, err, "task1")
 
 	// Verify image state is updated correctly
@@ -342,7 +338,7 @@ func TestImageWithSameNameAndDifferentID(t *testing.T) {
 
 	// Start and wait for task2 to be running
 	go taskEngine.AddTask(task2)
-	err = verifyTaskIsRunning(taskEvents, task2)
+	err = verifyTaskIsRunning(stateChangeEvents, task2)
 	require.NoError(t, err, "task2")
 
 	// Verify image state is updated correctly
@@ -358,7 +354,7 @@ func TestImageWithSameNameAndDifferentID(t *testing.T) {
 
 	// Start and wiat for task3 to be running
 	go taskEngine.AddTask(task3)
-	err = verifyTaskIsRunning(taskEvents, task3)
+	err = verifyTaskIsRunning(stateChangeEvents, task3)
 	require.NoError(t, err, "task3")
 
 	// Verify image state is updated correctly
@@ -434,8 +430,7 @@ func TestImageWithSameIDAndDifferentNames(t *testing.T) {
 	imageManager := taskEngine.(*DockerTaskEngine).imageManager.(*dockerImageManager)
 	imageManager.SetSaver(statemanager.NewNoopStateManager())
 
-	taskEvents, containerEvents := taskEngine.TaskEvents()
-	defer discardEvents(containerEvents)()
+	stateChangeEvents := taskEngine.StateChangeEvents()
 
 	// Start three tasks which using the image with same ID and different Name
 	task1 := createTestTask("task1")
@@ -457,7 +452,7 @@ func TestImageWithSameIDAndDifferentNames(t *testing.T) {
 
 	// Start and wait for task1 to be running
 	go taskEngine.AddTask(task1)
-	err = verifyTaskIsRunning(taskEvents, task1)
+	err = verifyTaskIsRunning(stateChangeEvents, task1)
 	require.NoError(t, err)
 
 	imageState1 := imageManager.GetImageStateFromImageName(task1.Containers[0].Image)
@@ -475,7 +470,7 @@ func TestImageWithSameIDAndDifferentNames(t *testing.T) {
 
 	// Start and wait for task2 to be running
 	go taskEngine.AddTask(task2)
-	err = verifyTaskIsRunning(taskEvents, task2)
+	err = verifyTaskIsRunning(stateChangeEvents, task2)
 	require.NoError(t, err)
 
 	imageState2 := imageManager.GetImageStateFromImageName(task2.Containers[0].Image)
@@ -494,7 +489,7 @@ func TestImageWithSameIDAndDifferentNames(t *testing.T) {
 
 	// Start and wait for task3 to be running
 	go taskEngine.AddTask(task3)
-	err = verifyTaskIsRunning(taskEvents, task3)
+	err = verifyTaskIsRunning(stateChangeEvents, task3)
 	assert.NoError(t, err)
 
 	imageState3 := imageManager.GetImageStateFromImageName(task3.Containers[0].Image)

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -314,14 +314,14 @@ func (engine *DockerTaskEngine) emitTaskEvent(task *api.Task, reason string) {
 		log.Debug("Already sent task event; no need to re-send", "task", task.Arn, "event", taskKnownStatus.String())
 		return
 	}
-	event := &api.TaskStateChange{
+	event := api.TaskStateChange{
 		TaskArn: task.Arn,
 		Status:  taskKnownStatus,
 		Reason:  reason,
 		Task:    task,
 	}
 	log.Info("Task change event", "event", event)
-	engine.stateChangeEvents <- statechange.StateChangeEvent{TaskEvent: event}
+	engine.stateChangeEvents <- event
 }
 
 // startTask creates a managedTask construct to track the task and then begins
@@ -366,7 +366,7 @@ func (engine *DockerTaskEngine) emitContainerEvent(task *api.Task, cont *api.Con
 	if reason == "" && cont.ApplyingError != nil {
 		reason = cont.ApplyingError.Error()
 	}
-	event := &api.ContainerStateChange{
+	event := api.ContainerStateChange{
 		TaskArn:       task.Arn,
 		ContainerName: cont.Name,
 		Status:        contKnownStatus,
@@ -376,7 +376,7 @@ func (engine *DockerTaskEngine) emitContainerEvent(task *api.Task, cont *api.Con
 		Container:     cont,
 	}
 	log.Debug("Container change event", "event", event)
-	engine.stateChangeEvents <- statechange.StateChangeEvent{ContainerEvent: event}
+	engine.stateChangeEvents <- event
 	log.Debug("Container change event passed on", "event", event)
 }
 

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -69,7 +69,7 @@ type DockerTaskEngine struct {
 	taskStopGroup *utilsync.SequentialWaitGroup
 
 	events            <-chan DockerContainerChangeEvent
-	stateChangeEvents chan statechange.StateChangeEvent
+	stateChangeEvents chan statechange.Event
 	saver             statemanager.Saver
 
 	client     DockerClient
@@ -106,7 +106,7 @@ func NewDockerTaskEngine(cfg *config.Config, client DockerClient, credentialsMan
 		managedTasks:  make(map[string]*managedTask),
 		taskStopGroup: utilsync.NewSequentialWaitGroup(),
 
-		stateChangeEvents: make(chan statechange.StateChangeEvent),
+		stateChangeEvents: make(chan statechange.Event),
 
 		enableConcurrentPull: false,
 		credentialsManager:   credentialsManager,
@@ -433,7 +433,7 @@ func (engine *DockerTaskEngine) handleDockerEvent(event DockerContainerChangeEve
 // StateChangeEvents returns channels to read task and container state changes. These
 // changes should be read as soon as possible as them not being read will block
 // processing the task referenced by the event.
-func (engine *DockerTaskEngine) StateChangeEvents() <-chan statechange.StateChangeEvent {
+func (engine *DockerTaskEngine) StateChangeEvents() <-chan statechange.Event {
 	return engine.stateChangeEvents
 }
 

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -152,10 +152,10 @@ func TestBatchContainerHappyPath(t *testing.T) {
 	taskEngine.AddTask(sleepTask)
 
 	event := <-stateChangeEvents
-	assert.Equal(t, event.ContainerEvent.Status, api.ContainerRunning, "Expected container to be RUNNING")
+	assert.Equal(t, event.(api.ContainerStateChange).Status, api.ContainerRunning, "Expected container to be RUNNING")
 
 	event = <-stateChangeEvents
-	assert.Equal(t, event.TaskEvent.Status, api.TaskRunning, "Expected task to be RUNNING")
+	assert.Equal(t, event.(api.TaskStateChange).Status, api.TaskRunning, "Expected task to be RUNNING")
 
 	select {
 	case <-stateChangeEvents:
@@ -185,13 +185,13 @@ func TestBatchContainerHappyPath(t *testing.T) {
 	}
 
 	event = <-stateChangeEvents
-	if cont := event.ContainerEvent; cont.Status != api.ContainerStopped {
+	if cont := event.(api.ContainerStateChange); cont.Status != api.ContainerStopped {
 		t.Fatal("Expected container to stop first")
 		assert.Equal(t, *cont.ExitCode, 0, "Exit code should be present")
 	}
 
 	event = <-stateChangeEvents
-	assert.Equal(t, event.TaskEvent.Status, api.TaskStopped, "Expected task to be STOPPED")
+	assert.Equal(t, event.(api.TaskStateChange).Status, api.TaskStopped, "Expected task to be STOPPED")
 	// This ensures that managedTask.waitForStopReported makes progress
 	sleepTask.SetSentStatus(api.TaskStopped)
 
@@ -291,10 +291,10 @@ func TestRemoveEvents(t *testing.T) {
 	taskEngine.AddTask(sleepTask)
 
 	event := <-stateChangeEvents
-	assert.Equal(t, event.ContainerEvent.Status, api.ContainerRunning, "Expected container to be RUNNING")
+	assert.Equal(t, event.(api.ContainerStateChange).Status, api.ContainerRunning, "Expected container to be RUNNING")
 
 	event = <-stateChangeEvents
-	assert.Equal(t, event.TaskEvent.Status, api.TaskRunning, "Expected task to be RUNNING")
+	assert.Equal(t, event.(api.TaskStateChange).Status, api.TaskRunning, "Expected task to be RUNNING")
 
 	select {
 	case <-stateChangeEvents:
@@ -324,13 +324,13 @@ func TestRemoveEvents(t *testing.T) {
 	}
 
 	event = <-stateChangeEvents
-	if cont := event.ContainerEvent; cont.Status != api.ContainerStopped {
+	if cont := event.(api.ContainerStateChange); cont.Status != api.ContainerStopped {
 		t.Fatal("Expected container to stop first")
 		assert.Equal(t, *cont.ExitCode, 0, "Exit code should be present")
 	}
 
 	event = <-stateChangeEvents
-	assert.Equal(t, event.TaskEvent.Status, api.TaskStopped, "Expected task to be STOPPED")
+	assert.Equal(t, event.(api.TaskStateChange).Status, api.TaskStopped, "Expected task to be STOPPED")
 
 	sleepTaskStop := testdata.LoadTask("sleep5")
 	sleepTaskStop.SetDesiredStatus(api.TaskStopped)
@@ -413,10 +413,10 @@ func TestStartTimeoutThenStart(t *testing.T) {
 
 	// Expect it to go to stopped
 	event := <-stateChangeEvents
-	assert.Equal(t, event.ContainerEvent.Status, api.ContainerStopped, "Expected container to timeout on start and stop")
+	assert.Equal(t, event.(api.ContainerStateChange).Status, api.ContainerStopped, "Expected container to timeout on start and stop")
 
 	event = <-stateChangeEvents
-	assert.Equal(t, event.TaskEvent.Status, api.TaskStopped, "Expected task to be STOPPED")
+	assert.Equal(t, event.(api.TaskStateChange).Status, api.TaskStopped, "Expected task to be STOPPED")
 
 	select {
 	case <-stateChangeEvents:
@@ -500,10 +500,10 @@ func TestSteadyStatePoll(t *testing.T) {
 
 	// verify that we get events for the container and task starting, but no other events
 	event := <-stateChangeEvents
-	assert.Equal(t, event.ContainerEvent.Status, api.ContainerRunning, "Expected container to be RUNNING")
+	assert.Equal(t, event.(api.ContainerStateChange).Status, api.ContainerRunning, "Expected container to be RUNNING")
 
 	event = <-stateChangeEvents
-	assert.Equal(t, event.TaskEvent.Status, api.TaskRunning, "Expected task to be RUNNING")
+	assert.Equal(t, event.(api.TaskStateChange).Status, api.TaskRunning, "Expected task to be RUNNING")
 
 	select {
 	case <-stateChangeEvents:
@@ -533,10 +533,10 @@ func TestSteadyStatePoll(t *testing.T) {
 	close(steadyStateVerify)
 
 	event = <-stateChangeEvents
-	assert.Equal(t, event.ContainerEvent.Status, api.ContainerStopped, "Expected container to be STOPPED")
+	assert.Equal(t, event.(api.ContainerStateChange).Status, api.ContainerStopped, "Expected container to be STOPPED")
 
 	event = <-stateChangeEvents
-	assert.Equal(t, event.TaskEvent.Status, api.TaskStopped, "Expected task to be STOPPED")
+	assert.Equal(t, event.(api.TaskStateChange).Status, api.TaskStopped, "Expected task to be STOPPED")
 
 	select {
 	case <-stateChangeEvents:
@@ -736,10 +736,10 @@ func TestTaskTransitionWhenStopContainerTimesout(t *testing.T) {
 	go taskEngine.AddTask(sleepTask)
 	// wait for task running
 	event := <-stateChangeEvents
-	assert.Equal(t, event.ContainerEvent.Status, api.ContainerRunning, "Expected container to be RUNNING")
+	assert.Equal(t, event.(api.ContainerStateChange).Status, api.ContainerRunning, "Expected container to be RUNNING")
 
 	event = <-stateChangeEvents
-	assert.Equal(t, event.TaskEvent.Status, api.TaskRunning, "Expected task to be RUNNING")
+	assert.Equal(t, event.(api.TaskStateChange).Status, api.TaskRunning, "Expected task to be RUNNING")
 
 	// Set the task desired status to be stopped and StopContainer will be called
 	updateSleepTask := *sleepTask
@@ -763,10 +763,10 @@ func TestTaskTransitionWhenStopContainerTimesout(t *testing.T) {
 	// StopContainer was called again and received stop event from docker event stream
 	// Expect it to go to stopped
 	event = <-stateChangeEvents
-	assert.Equal(t, event.ContainerEvent.Status, api.ContainerStopped, "Expected container to timeout on start and stop")
+	assert.Equal(t, event.(api.ContainerStateChange).Status, api.ContainerStopped, "Expected container to timeout on start and stop")
 
 	event = <-stateChangeEvents
-	assert.Equal(t, event.TaskEvent.Status, api.TaskStopped, "Expected task to be STOPPED")
+	assert.Equal(t, event.(api.TaskStateChange).Status, api.TaskStopped, "Expected task to be STOPPED")
 
 	select {
 	case <-stateChangeEvents:
@@ -834,10 +834,10 @@ func TestTaskTransitionWhenStopContainerReturnsUnretriableError(t *testing.T) {
 	go taskEngine.AddTask(sleepTask)
 	// wait for task running
 	event := <-stateChangeEvents
-	assert.Equal(t, event.ContainerEvent.Status, api.ContainerRunning, "Expected container to be RUNNING")
+	assert.Equal(t, event.(api.ContainerStateChange).Status, api.ContainerRunning, "Expected container to be RUNNING")
 
 	event = <-stateChangeEvents
-	assert.Equal(t, event.TaskEvent.Status, api.TaskRunning, "Expected task to be RUNNING")
+	assert.Equal(t, event.(api.TaskStateChange).Status, api.TaskRunning, "Expected task to be RUNNING")
 
 	select {
 	case <-stateChangeEvents:
@@ -854,10 +854,10 @@ func TestTaskTransitionWhenStopContainerReturnsUnretriableError(t *testing.T) {
 	// StopContainer was called again and received stop event from docker event stream
 	// Expect it to go to stopped
 	event = <-stateChangeEvents
-	assert.Equal(t, event.ContainerEvent.Status, api.ContainerStopped, "Expected container to be STOPPED")
+	assert.Equal(t, event.(api.ContainerStateChange).Status, api.ContainerStopped, "Expected container to be STOPPED")
 
 	event = <-stateChangeEvents
-	assert.Equal(t, event.TaskEvent.Status, api.TaskStopped, "Expected task to be STOPPED")
+	assert.Equal(t, event.(api.TaskStateChange).Status, api.TaskStopped, "Expected task to be STOPPED")
 
 	select {
 	case <-stateChangeEvents:
@@ -912,10 +912,10 @@ func TestTaskTransitionWhenStopContainerReturnsTransientErrorBeforeSucceeding(t 
 	// wait for task running
 
 	event := <-stateChangeEvents
-	assert.Equal(t, event.ContainerEvent.Status, api.ContainerRunning, "Expected container to be RUNNING")
+	assert.Equal(t, event.(api.ContainerStateChange).Status, api.ContainerRunning, "Expected container to be RUNNING")
 
 	event = <-stateChangeEvents
-	assert.Equal(t, event.TaskEvent.Status, api.TaskRunning, "Expected task to be RUNNING")
+	assert.Equal(t, event.(api.TaskStateChange).Status, api.TaskRunning, "Expected task to be RUNNING")
 
 	select {
 	case <-stateChangeEvents:
@@ -930,10 +930,10 @@ func TestTaskTransitionWhenStopContainerReturnsTransientErrorBeforeSucceeding(t 
 
 	// StopContainer invocation should have caused it to stop eventually.
 	event = <-stateChangeEvents
-	assert.Equal(t, event.ContainerEvent.Status, api.ContainerStopped, "Expected container to be STOPPED")
+	assert.Equal(t, event.(api.ContainerStateChange).Status, api.ContainerStopped, "Expected container to be STOPPED")
 
 	event = <-stateChangeEvents
-	assert.Equal(t, event.TaskEvent.Status, api.TaskStopped, "Expected task to be STOPPED")
+	assert.Equal(t, event.(api.TaskStateChange).Status, api.TaskStopped, "Expected task to be STOPPED")
 
 	select {
 	case <-stateChangeEvents:

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -185,10 +185,11 @@ func TestBatchContainerHappyPath(t *testing.T) {
 	}
 
 	event = <-stateChangeEvents
-	if cont := event.(api.ContainerStateChange); cont.Status != api.ContainerStopped {
-		t.Fatal("Expected container to stop first")
-		assert.Equal(t, *cont.ExitCode, 0, "Exit code should be present")
-	}
+	assert.Equal(t, event.(api.ContainerStateChange).Status, api.ContainerStopped, "Expected container to be STOPPED")
+
+	// hold on to container event to verify exit code
+	contEvent := event.(api.ContainerStateChange)
+	assert.Equal(t, *contEvent.ExitCode, 0, "Exit code should be present")
 
 	event = <-stateChangeEvents
 	assert.Equal(t, event.(api.TaskStateChange).Status, api.TaskStopped, "Expected task to be STOPPED")

--- a/agent/engine/engine_integ_test.go
+++ b/agent/engine/engine_integ_test.go
@@ -256,7 +256,7 @@ func TestStartStopWithCredentials(t *testing.T) {
 	assert.False(t, ok, "Credentials not removed from credentials manager for stopped task")
 }
 
-func verifyTaskIsRunning(stateChangeEvents <-chan statechange.StateChangeEvent, testTasks ...*api.Task) error {
+func verifyTaskIsRunning(stateChangeEvents <-chan statechange.Event, testTasks ...*api.Task) error {
 	for {
 		select {
 		case event := <-stateChangeEvents:
@@ -280,7 +280,7 @@ func verifyTaskIsRunning(stateChangeEvents <-chan statechange.StateChangeEvent, 
 	}
 }
 
-func verifyTaskIsStopped(stateChangeEvents <-chan statechange.StateChangeEvent, testTasks ...*api.Task) {
+func verifyTaskIsStopped(stateChangeEvents <-chan statechange.Event, testTasks ...*api.Task) {
 	for {
 		select {
 		case event := <-stateChangeEvents:

--- a/agent/engine/engine_integ_test.go
+++ b/agent/engine/engine_integ_test.go
@@ -170,8 +170,8 @@ func TestSweepContainer(t *testing.T) {
 	expectedEvents := []api.TaskStatus{api.TaskRunning, api.TaskStopped}
 
 	for event := range stateChangeEvents {
-		taskEvent := event.TaskEvent
-		if taskEvent != nil {
+		if event.GetEventType() == statechange.TaskEvent {
+			taskEvent := event.(api.TaskStateChange)
 			if taskEvent.TaskArn != testTask.Arn {
 				continue
 			}
@@ -228,8 +228,8 @@ func verifyTaskIsRunning(stateChangeEvents <-chan statechange.StateChangeEvent, 
 	for {
 		select {
 		case event := <-stateChangeEvents:
-			taskEvent := event.TaskEvent
-			if taskEvent != nil {
+			if event.GetEventType() == statechange.TaskEvent {
+				taskEvent := event.(api.TaskStateChange)
 				for i, task := range testTasks {
 					if taskEvent.TaskArn != task.Arn {
 						continue
@@ -252,8 +252,8 @@ func verifyTaskIsStopped(stateChangeEvents <-chan statechange.StateChangeEvent, 
 	for {
 		select {
 		case event := <-stateChangeEvents:
-			taskEvent := event.TaskEvent
-			if taskEvent != nil {
+			if event.GetEventType() == statechange.TaskEvent {
+				taskEvent := event.(api.TaskStateChange)
 				for i, task := range testTasks {
 					if taskEvent.TaskArn == task.Arn && taskEvent.Status >= api.TaskStopped {
 						if len(testTasks) == 1 {

--- a/agent/engine/engine_integ_test.go
+++ b/agent/engine/engine_integ_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerclient"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
+	"github.com/aws/amazon-ecs-agent/agent/statechange"
 	"github.com/aws/amazon-ecs-agent/agent/statemanager"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
@@ -118,9 +119,7 @@ func TestHostVolumeMount(t *testing.T) {
 	taskEngine, done, _ := setupWithDefaultConfig(t)
 	defer done()
 
-	taskEvents, contEvents := taskEngine.TaskEvents()
-
-	defer discardEvents(contEvents)()
+	stateChangeEvents := taskEngine.StateChangeEvents()
 
 	tmpPath, _ := ioutil.TempDir("", "ecs_volume_test")
 	defer os.RemoveAll(tmpPath)
@@ -130,7 +129,7 @@ func TestHostVolumeMount(t *testing.T) {
 
 	go taskEngine.AddTask(testTask)
 
-	verifyTaskIsStopped(taskEvents, testTask)
+	verifyTaskIsStopped(stateChangeEvents, testTask)
 
 	assert.NotNil(t, testTask.Containers[0].KnownExitCode, "No exit code found")
 	assert.Equal(t, 42, *testTask.Containers[0].KnownExitCode, "Wrong exit code")
@@ -144,14 +143,13 @@ func TestEmptyHostVolumeMount(t *testing.T) {
 	taskEngine, done, _ := setupWithDefaultConfig(t)
 	defer done()
 
-	taskEvents, contEvents := taskEngine.TaskEvents()
-
-	defer discardEvents(contEvents)()
+	stateChangeEvents := taskEngine.StateChangeEvents()
 
 	testTask := createTestEmptyHostVolumeMountTask()
+
 	go taskEngine.AddTask(testTask)
 
-	verifyTaskIsStopped(taskEvents, testTask)
+	verifyTaskIsStopped(stateChangeEvents, testTask)
 
 	assert.NotNil(t, testTask.Containers[0].KnownExitCode, "No exit code found")
 	assert.Equal(t, 42, *testTask.Containers[0].KnownExitCode, "Wrong exit code, file probably wasn't present")
@@ -163,9 +161,7 @@ func TestSweepContainer(t *testing.T) {
 	taskEngine, done, _ := setup(cfg, t)
 	defer done()
 
-	taskEvents, contEvents := taskEngine.TaskEvents()
-
-	defer discardEvents(contEvents)()
+	stateChangeEvents := taskEngine.StateChangeEvents()
 
 	testTask := createTestTask("testSweepContainer")
 
@@ -173,19 +169,20 @@ func TestSweepContainer(t *testing.T) {
 
 	expectedEvents := []api.TaskStatus{api.TaskRunning, api.TaskStopped}
 
-	for taskEvent := range taskEvents {
-		if taskEvent.TaskArn != testTask.Arn {
-			continue
-		}
-		expectedEvent := expectedEvents[0]
-		expectedEvents = expectedEvents[1:]
-		assert.Equal(t, expectedEvent, taskEvent.Status, "Got incorrect event")
-		if len(expectedEvents) == 0 {
-			break
+	for event := range stateChangeEvents {
+		taskEvent := event.TaskEvent
+		if taskEvent != nil {
+			if taskEvent.TaskArn != testTask.Arn {
+				continue
+			}
+			expectedEvent := expectedEvents[0]
+			expectedEvents = expectedEvents[1:]
+			assert.Equal(t, expectedEvent, taskEvent.Status, "Got incorrect event")
+			if len(expectedEvents) == 0 {
+				break
+			}
 		}
 	}
-
-	defer discardEvents(taskEvents)()
 
 	// Should be stopped, let's verify it's still listed...
 	task, ok := taskEngine.(*DockerTaskEngine).State().TaskByArn("testSweepContainer")
@@ -215,13 +212,11 @@ func TestStartStopWithCredentials(t *testing.T) {
 	credentialsManager.SetTaskCredentials(taskCredentials)
 	testTask.SetCredentialsID(credentialsIDIntegTest)
 
-	taskEvents, contEvents := taskEngine.TaskEvents()
-
-	defer discardEvents(contEvents)()
+	stateChangeEvents := taskEngine.StateChangeEvents()
 
 	go taskEngine.AddTask(testTask)
 
-	verifyTaskIsStopped(taskEvents, testTask)
+	verifyTaskIsStopped(stateChangeEvents, testTask)
 
 	// When task is stopped, credentials should have been removed for the
 	// credentials id set in the task
@@ -229,37 +224,43 @@ func TestStartStopWithCredentials(t *testing.T) {
 	assert.False(t, ok, "Credentials not removed from credentials manager for stopped task")
 }
 
-func verifyTaskIsRunning(taskEvents <-chan api.TaskStateChange, testTasks ...*api.Task) error {
+func verifyTaskIsRunning(stateChangeEvents <-chan statechange.StateChangeEvent, testTasks ...*api.Task) error {
 	for {
 		select {
-		case taskEvent := <-taskEvents:
-			for i, task := range testTasks {
-				if taskEvent.TaskArn != task.Arn {
-					continue
-				}
-				if taskEvent.Status == api.TaskRunning {
-					if len(testTasks) == 1 {
-						return nil
+		case event := <-stateChangeEvents:
+			taskEvent := event.TaskEvent
+			if taskEvent != nil {
+				for i, task := range testTasks {
+					if taskEvent.TaskArn != task.Arn {
+						continue
 					}
-					testTasks = append(testTasks[:i], testTasks[i+1:]...)
-				} else if taskEvent.Status > api.TaskRunning {
-					return fmt.Errorf("Task went straight to %s without running, task: %s", taskEvent.Status.String(), task.Arn)
+					if taskEvent.Status == api.TaskRunning {
+						if len(testTasks) == 1 {
+							return nil
+						}
+						testTasks = append(testTasks[:i], testTasks[i+1:]...)
+					} else if taskEvent.Status > api.TaskRunning {
+						return fmt.Errorf("Task went straight to %s without running, task: %s", taskEvent.Status.String(), task.Arn)
+					}
 				}
 			}
 		}
 	}
 }
 
-func verifyTaskIsStopped(taskEvents <-chan api.TaskStateChange, testTasks ...*api.Task) {
+func verifyTaskIsStopped(stateChangeEvents <-chan statechange.StateChangeEvent, testTasks ...*api.Task) {
 	for {
 		select {
-		case taskEvent := <-taskEvents:
-			for i, task := range testTasks {
-				if taskEvent.TaskArn == task.Arn && taskEvent.Status >= api.TaskStopped {
-					if len(testTasks) == 1 {
-						return
+		case event := <-stateChangeEvents:
+			taskEvent := event.TaskEvent
+			if taskEvent != nil {
+				for i, task := range testTasks {
+					if taskEvent.TaskArn == task.Arn && taskEvent.Status >= api.TaskStopped {
+						if len(testTasks) == 1 {
+							return
+						}
+						testTasks = append(testTasks[:i], testTasks[i+1:]...)
 					}
-					testTasks = append(testTasks[:i], testTasks[i+1:]...)
 				}
 			}
 		}

--- a/agent/engine/engine_mocks.go
+++ b/agent/engine/engine_mocks.go
@@ -137,9 +137,9 @@ func (_mr *_MockTaskEngineRecorder) SetSaver(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetSaver", arg0)
 }
 
-func (_m *MockTaskEngine) StateChangeEvents() <-chan statechange.StateChangeEvent {
+func (_m *MockTaskEngine) StateChangeEvents() <-chan statechange.Event {
 	ret := _m.ctrl.Call(_m, "StateChangeEvents")
-	ret0, _ := ret[0].(<-chan statechange.StateChangeEvent)
+	ret0, _ := ret[0].(<-chan statechange.Event)
 	return ret0
 }
 

--- a/agent/engine/engine_mocks.go
+++ b/agent/engine/engine_mocks.go
@@ -22,6 +22,7 @@ import (
 	api "github.com/aws/amazon-ecs-agent/agent/api"
 	dockerclient "github.com/aws/amazon-ecs-agent/agent/engine/dockerclient"
 	image "github.com/aws/amazon-ecs-agent/agent/engine/image"
+	statechange "github.com/aws/amazon-ecs-agent/agent/statechange"
 	statemanager "github.com/aws/amazon-ecs-agent/agent/statemanager"
 	go_dockerclient "github.com/fsouza/go-dockerclient"
 	gomock "github.com/golang/mock/gomock"
@@ -136,15 +137,14 @@ func (_mr *_MockTaskEngineRecorder) SetSaver(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetSaver", arg0)
 }
 
-func (_m *MockTaskEngine) TaskEvents() (<-chan api.TaskStateChange, <-chan api.ContainerStateChange) {
-	ret := _m.ctrl.Call(_m, "TaskEvents")
-	ret0, _ := ret[0].(<-chan api.TaskStateChange)
-	ret1, _ := ret[1].(<-chan api.ContainerStateChange)
-	return ret0, ret1
+func (_m *MockTaskEngine) StateChangeEvents() <-chan statechange.StateChangeEvent {
+	ret := _m.ctrl.Call(_m, "StateChangeEvents")
+	ret0, _ := ret[0].(<-chan statechange.StateChangeEvent)
+	return ret0
 }
 
-func (_mr *_MockTaskEngineRecorder) TaskEvents() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "TaskEvents")
+func (_mr *_MockTaskEngineRecorder) StateChangeEvents() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "StateChangeEvents")
 }
 
 func (_m *MockTaskEngine) UnmarshalJSON(_param0 []byte) error {

--- a/agent/engine/engine_unix_integ_test.go
+++ b/agent/engine/engine_unix_integ_test.go
@@ -104,24 +104,18 @@ func TestStartStopUnpulledImage(t *testing.T) {
 
 	go taskEngine.AddTask(testTask)
 
-	expectedEvents := []api.TaskStatus{api.TaskRunning, api.TaskStopped}
+	event := <-stateChangeEvents
+	assert.Equal(t, event.(api.ContainerStateChange).Status, api.ContainerRunning, "Expected container to be RUNNING")
 
-	for event := range stateChangeEvents {
-		if event.GetEventType() == statechange.TaskEvent {
-			taskEvent := event.(api.TaskStateChange)
-			if taskEvent.TaskArn != testTask.Arn {
-				continue
-			}
-			expectedEvent := expectedEvents[0]
-			expectedEvents = expectedEvents[1:]
-			if taskEvent.Status != expectedEvent {
-				t.Error("Got event " + taskEvent.Status.String() + " but expected " + expectedEvent.String())
-			}
-			if len(expectedEvents) == 0 {
-				break
-			}
-		}
-	}
+	event = <-stateChangeEvents
+	assert.Equal(t, event.(api.TaskStateChange).Status, api.TaskRunning, "Expected task to be RUNNING")
+
+	event = <-stateChangeEvents
+	assert.Equal(t, event.(api.ContainerStateChange).Status, api.ContainerStopped, "Expected container to be STOPPED")
+
+	event = <-stateChangeEvents
+	assert.Equal(t, event.(api.TaskStateChange).Status, api.TaskStopped, "Expected task to be STOPPED")
+
 }
 
 // TestStartStopUnpulledImageDigest ensures that an unpulled image with
@@ -140,24 +134,17 @@ func TestStartStopUnpulledImageDigest(t *testing.T) {
 
 	go taskEngine.AddTask(testTask)
 
-	expectedEvents := []api.TaskStatus{api.TaskRunning, api.TaskStopped}
+	event := <-stateChangeEvents
+	assert.Equal(t, event.(api.ContainerStateChange).Status, api.ContainerRunning, "Expected container to be RUNNING")
 
-	for event := range stateChangeEvents {
-		if event.GetEventType() == statechange.TaskEvent {
-			taskEvent := event.(api.TaskStateChange)
-			if taskEvent.TaskArn != testTask.Arn {
-				continue
-			}
-			expectedEvent := expectedEvents[0]
-			expectedEvents = expectedEvents[1:]
-			if taskEvent.Status != expectedEvent {
-				t.Error("Got event " + taskEvent.Status.String() + " but expected " + expectedEvent.String())
-			}
-			if len(expectedEvents) == 0 {
-				break
-			}
-		}
-	}
+	event = <-stateChangeEvents
+	assert.Equal(t, event.(api.TaskStateChange).Status, api.TaskRunning, "Expected task to be RUNNING")
+
+	event = <-stateChangeEvents
+	assert.Equal(t, event.(api.ContainerStateChange).Status, api.ContainerStopped, "Expected container to be STOPPED")
+
+	event = <-stateChangeEvents
+	assert.Equal(t, event.(api.TaskStateChange).Status, api.TaskStopped, "Expected task to be STOPPED")
 }
 
 // TestPortForward runs a container serving data on the randomly chosen port
@@ -385,7 +372,6 @@ func TestMultipleDynamicPortForward(t *testing.T) {
 	go taskEngine.AddTask(testTask)
 
 	var portBindings []api.PortBinding
-	// for contEvent := range contEvents {
 	for event := range stateChangeEvents {
 		if event.GetEventType() == statechange.ContainerEvent {
 			contEvent := event.(api.ContainerStateChange)
@@ -529,39 +515,21 @@ func TestDockerCfgAuth(t *testing.T) {
 
 	go taskEngine.AddTask(testTask)
 
-	expectedEvents := []api.TaskStatus{api.TaskRunning}
+	event := <-stateChangeEvents
+	assert.Equal(t, event.(api.ContainerStateChange).Status, api.ContainerRunning, "Expected container to be RUNNING")
 
-	for event := range stateChangeEvents {
-		if event.GetEventType() == statechange.TaskEvent {
-			taskEvent := event.(api.TaskStateChange)
-			if taskEvent.TaskArn != testTask.Arn {
-				continue
-			}
-			expectedEvent := expectedEvents[0]
-			expectedEvents = expectedEvents[1:]
-			if taskEvent.Status != expectedEvent {
-				t.Error("Got event " + taskEvent.Status.String() + " but expected " + expectedEvent.String())
-			}
-			if len(expectedEvents) == 0 {
-				break
-			}
-		}
-	}
+	event = <-stateChangeEvents
+	assert.Equal(t, event.(api.TaskStateChange).Status, api.TaskRunning, "Expected task to be RUNNING")
 
 	taskUpdate := *testTask
 	taskUpdate.SetDesiredStatus(api.TaskStopped)
 	go taskEngine.AddTask(&taskUpdate)
-	for event := range stateChangeEvents {
-		if event.GetEventType() == statechange.TaskEvent {
-			taskEvent := event.(api.TaskStateChange)
-			if taskEvent.TaskArn == testTask.Arn {
-				if !(taskEvent.Status >= api.TaskStopped) {
-					t.Error("Expected only terminal events; got " + taskEvent.Status.String())
-				}
-				break
-			}
-		}
-	}
+
+	event = <-stateChangeEvents
+	assert.Equal(t, event.(api.ContainerStateChange).Status, api.ContainerStopped, "Expected container to be STOPPED")
+
+	event = <-stateChangeEvents
+	assert.Equal(t, event.(api.TaskStateChange).Status, api.TaskStopped, "Expected task to be STOPPED")
 }
 
 func TestDockerAuth(t *testing.T) {
@@ -584,39 +552,21 @@ func TestDockerAuth(t *testing.T) {
 
 	go taskEngine.AddTask(testTask)
 
-	expectedEvents := []api.TaskStatus{api.TaskRunning}
+	event := <-stateChangeEvents
+	assert.Equal(t, event.(api.ContainerStateChange).Status, api.ContainerRunning, "Expected container to be RUNNING")
 
-	for event := range stateChangeEvents {
-		if event.GetEventType() == statechange.TaskEvent {
-			taskEvent := event.(api.TaskStateChange)
-			if taskEvent.TaskArn != testTask.Arn {
-				continue
-			}
-			expectedEvent := expectedEvents[0]
-			expectedEvents = expectedEvents[1:]
-			if taskEvent.Status != expectedEvent {
-				t.Error("Got event " + taskEvent.Status.String() + " but expected " + expectedEvent.String())
-			}
-			if len(expectedEvents) == 0 {
-				break
-			}
-		}
-	}
+	event = <-stateChangeEvents
+	assert.Equal(t, event.(api.TaskStateChange).Status, api.TaskRunning, "Expected task to be RUNNING")
 
 	taskUpdate := *testTask
 	taskUpdate.SetDesiredStatus(api.TaskStopped)
 	go taskEngine.AddTask(&taskUpdate)
-	for event := range stateChangeEvents {
-		if event.GetEventType() == statechange.TaskEvent {
-			taskEvent := event.(api.TaskStateChange)
-			if taskEvent.TaskArn == testTask.Arn {
-				if !(taskEvent.Status >= api.TaskStopped) {
-					t.Error("Expected only terminal events; got " + taskEvent.Status.String())
-				}
-				break
-			}
-		}
-	}
+
+	event = <-stateChangeEvents
+	assert.Equal(t, event.(api.ContainerStateChange).Status, api.ContainerStopped, "Expected container to be STOPPED")
+
+	event = <-stateChangeEvents
+	assert.Equal(t, event.(api.TaskStateChange).Status, api.TaskStopped, "Expected task to be STOPPED")
 }
 
 func TestVolumesFrom(t *testing.T) {
@@ -906,21 +856,19 @@ func TestStartStopWithSecurityOptionNoNewPrivileges(t *testing.T) {
 	go taskEngine.AddTask(testTask)
 
 	event := <-stateChangeEvents
-	assert.Equal(t, event.(api.ContainerStateChange).Status, api.ContainerRunning, "Expected container to be running")
+	assert.Equal(t, event.(api.ContainerStateChange).Status, api.ContainerRunning, "Expected container to be RUNNING")
+
+	event = <-stateChangeEvents
+	assert.Equal(t, event.(api.TaskStateChange).Status, api.TaskRunning, "Expected task to be RUNNING")
 
 	// Kill the existing container now
 	taskUpdate := *testTask
 	taskUpdate.SetDesiredStatus(api.TaskStopped)
 	go taskEngine.AddTask(&taskUpdate)
-	for event := range stateChangeEvents {
-		if event.GetEventType() == statechange.TaskEvent {
-			taskEvent := event.(api.TaskStateChange)
-			if taskEvent.TaskArn != testTask.Arn {
-				continue
-			}
-			if taskEvent.Status == api.TaskStopped {
-				break
-			}
-		}
-	}
+
+	event = <-stateChangeEvents
+	assert.Equal(t, event.(api.ContainerStateChange).Status, api.ContainerStopped, "Expected container to be STOPPED")
+
+	event = <-stateChangeEvents
+	assert.Equal(t, event.(api.TaskStateChange).Status, api.TaskStopped, "Expected task to be STOPPED")
 }

--- a/agent/engine/interface.go
+++ b/agent/engine/interface.go
@@ -17,6 +17,7 @@ import (
 	"encoding/json"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
+	"github.com/aws/amazon-ecs-agent/agent/statechange"
 	"github.com/aws/amazon-ecs-agent/agent/statemanager"
 )
 
@@ -29,10 +30,10 @@ type TaskEngine interface {
 	// this task engine from processing new tasks
 	Disable()
 
-	// TaskEvents will provide information about tasks that have been previously
+	// StateChangeEvents will provide information about tasks that have been previously
 	// executed. Specifically, it will provide information when they reach
 	// running or stopped, as well as providing portbinding and other metadata
-	TaskEvents() (<-chan api.TaskStateChange, <-chan api.ContainerStateChange)
+	StateChangeEvents() <-chan statechange.StateChangeEvent
 	SetSaver(statemanager.Saver)
 
 	// AddTask adds a new task to the task engine and manages its container's

--- a/agent/engine/interface.go
+++ b/agent/engine/interface.go
@@ -33,7 +33,7 @@ type TaskEngine interface {
 	// StateChangeEvents will provide information about tasks that have been previously
 	// executed. Specifically, it will provide information when they reach
 	// running or stopped, as well as providing portbinding and other metadata
-	StateChangeEvents() <-chan statechange.StateChangeEvent
+	StateChangeEvents() <-chan statechange.Event
 	SetSaver(statemanager.Saver)
 
 	// AddTask adds a new task to the task engine and manages its container's

--- a/agent/engine/task_manager_test.go
+++ b/agent/engine/task_manager_test.go
@@ -356,7 +356,7 @@ func TestOnContainersUnableToTransitionStateForDesiredStoppedTask(t *testing.T) 
 
 	go func() {
 		event := <-stateChangeEvents
-		assert.Equal(t, event.TaskEvent.Reason, taskUnableToTransitionToStoppedReason)
+		assert.Equal(t, event.(api.TaskStateChange).Reason, taskUnableToTransitionToStoppedReason)
 		eventsGenerated.Done()
 	}()
 

--- a/agent/engine/task_manager_test.go
+++ b/agent/engine/task_manager_test.go
@@ -234,7 +234,7 @@ func TestStartContainerTransitionsInvokesHandleContainerChange(t *testing.T) {
 	}
 
 	eventsGenerated := sync.WaitGroup{}
-	eventsGenerated.Add(3)
+	eventsGenerated.Add(2)
 	containerChangeEventStream.Subscribe(eventStreamName, func(events ...interface{}) error {
 		assert.NotNil(t, events)
 		assert.Len(t, events, 1)
@@ -247,12 +247,9 @@ func TestStartContainerTransitionsInvokesHandleContainerChange(t *testing.T) {
 	})
 	defer containerChangeEventStream.Unsubscribe(eventStreamName)
 
+	// account for container and task state change events for Submit* API
 	go func() {
 		<-stateChangeEvents
-		eventsGenerated.Done()
-	}()
-
-	go func() {
 		<-stateChangeEvents
 		eventsGenerated.Done()
 	}()

--- a/agent/engine/task_manager_test.go
+++ b/agent/engine/task_manager_test.go
@@ -218,7 +218,7 @@ func TestStartContainerTransitionsInvokesHandleContainerChange(t *testing.T) {
 	containerChangeEventStream := eventstream.NewEventStream(eventStreamName, context.Background())
 	containerChangeEventStream.StartListening()
 
-	stateChangeEvents := make(chan statechange.StateChangeEvent)
+	stateChangeEvents := make(chan statechange.Event)
 
 	task := &managedTask{
 		Task: &api.Task{
@@ -338,7 +338,7 @@ func TestWaitForContainerTransitionsForTerminalTask(t *testing.T) {
 }
 
 func TestOnContainersUnableToTransitionStateForDesiredStoppedTask(t *testing.T) {
-	stateChangeEvents := make(chan statechange.StateChangeEvent)
+	stateChangeEvents := make(chan statechange.Event)
 	task := &managedTask{
 		Task: &api.Task{
 			Containers:          []*api.Container{},

--- a/agent/eventhandler/handler.go
+++ b/agent/eventhandler/handler.go
@@ -30,27 +30,17 @@ func HandleEngineEvents(taskEngine engine.TaskEngine, client api.ECSClient, save
 	statesaver = saver
 
 	for {
-		taskEvents, containerEvents := taskEngine.TaskEvents()
+		stateChangeEvents := taskEngine.StateChangeEvents()
 
-		for taskEvents != nil && containerEvents != nil {
+		for stateChangeEvents != nil {
 			select {
-			case event, open := <-containerEvents:
-				if !open {
-					containerEvents = nil
-					log.Error("Container events closed")
+			case ev, ok := <-stateChangeEvents:
+				if !ok {
+					stateChangeEvents = nil
+					log.Error("stateChangeEvents closed")
 					break
 				}
-
-				eventhandler.AddContainerEvent(event, client)
-
-			case event, open := <-taskEvents:
-				if !open {
-					taskEvents = nil
-					log.Crit("Task events closed")
-					break
-				}
-
-				eventhandler.AddTaskEvent(event, client)
+				eventhandler.AddStateChangeEvent(ev, client)
 			}
 		}
 	}

--- a/agent/eventhandler/handler.go
+++ b/agent/eventhandler/handler.go
@@ -37,7 +37,7 @@ func HandleEngineEvents(taskEngine engine.TaskEngine, client api.ECSClient, save
 			case event, ok := <-stateChangeEvents:
 				if !ok {
 					stateChangeEvents = nil
-					log.Error("stateChangeEvents closed")
+					log.Error("Unable to handle state change event. The events channel is closed")
 					break
 				}
 				err := eventhandler.AddStateChangeEvent(event, client)

--- a/agent/eventhandler/handler.go
+++ b/agent/eventhandler/handler.go
@@ -34,13 +34,16 @@ func HandleEngineEvents(taskEngine engine.TaskEngine, client api.ECSClient, save
 
 		for stateChangeEvents != nil {
 			select {
-			case ev, ok := <-stateChangeEvents:
+			case event, ok := <-stateChangeEvents:
 				if !ok {
 					stateChangeEvents = nil
 					log.Error("stateChangeEvents closed")
 					break
 				}
-				eventhandler.AddStateChangeEvent(ev, client)
+				err := eventhandler.AddStateChangeEvent(event, client)
+				if err != nil {
+					log.Error("Handler unable to add state change event", "err", err, "event", event)
+				}
 			}
 		}
 	}

--- a/agent/eventhandler/handler_test.go
+++ b/agent/eventhandler/handler_test.go
@@ -28,19 +28,19 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func containerEvent(arn string) statechange.StateChangeEvent {
+func containerEvent(arn string) statechange.Event {
 	return api.ContainerStateChange{TaskArn: arn, ContainerName: "containerName", Status: api.ContainerRunning, Container: &api.Container{}}
 }
 
-func containerEventStopped(arn string) statechange.StateChangeEvent {
+func containerEventStopped(arn string) statechange.Event {
 	return api.ContainerStateChange{TaskArn: arn, ContainerName: "containerName", Status: api.ContainerStopped, Container: &api.Container{}}
 }
 
-func taskEvent(arn string) statechange.StateChangeEvent {
+func taskEvent(arn string) statechange.Event {
 	return api.TaskStateChange{TaskArn: arn, Status: api.TaskRunning, Task: &api.Task{}}
 }
 
-func taskEventStopped(arn string) statechange.StateChangeEvent {
+func taskEventStopped(arn string) statechange.Event {
 	return api.TaskStateChange{TaskArn: arn, Status: api.TaskStopped, Task: &api.Task{}}
 }
 
@@ -221,8 +221,6 @@ func TestSendsEventsDedupe(t *testing.T) {
 	handler.AddStateChangeEvent(task2, client)
 
 	wg.Wait()
-
-	time.Sleep(5 * time.Millisecond)
 }
 
 func TestShouldBeSent(t *testing.T) {

--- a/agent/eventhandler/task_handler.go
+++ b/agent/eventhandler/task_handler.go
@@ -58,12 +58,14 @@ func NewTaskHandler() *TaskHandler {
 
 // AddStateChangeEvent queues up a state change for sending using the given client.
 func (handler *TaskHandler) AddStateChangeEvent(change statechange.StateChangeEvent, client api.ECSClient) {
-	if change.TaskEvent != nil {
-		handler.addEvent(newSendableTaskEvent(*change.TaskEvent), client)
-	}
+	switch change.GetEventType() {
+	case statechange.TaskEvent:
+		se := newSendableTaskEvent(change.(api.TaskStateChange))
+		handler.addEvent(se, client)
 
-	if change.ContainerEvent != nil {
-		handler.addEvent(newSendableContainerEvent(*change.ContainerEvent), client)
+	case statechange.ContainerEvent:
+		se := newSendableContainerEvent(change.(api.ContainerStateChange))
+		handler.addEvent(se, client)
 	}
 }
 

--- a/agent/eventhandler/task_handler.go
+++ b/agent/eventhandler/task_handler.go
@@ -58,7 +58,7 @@ func NewTaskHandler() *TaskHandler {
 }
 
 // AddStateChangeEvent queues up a state change for sending using the given client.
-func (handler *TaskHandler) AddStateChangeEvent(change statechange.StateChangeEvent, client api.ECSClient) error {
+func (handler *TaskHandler) AddStateChangeEvent(change statechange.Event, client api.ECSClient) error {
 	switch change.GetEventType() {
 	case statechange.TaskEvent:
 		event, ok := change.(api.TaskStateChange)

--- a/agent/eventhandler/task_handler.go
+++ b/agent/eventhandler/task_handler.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
+	"github.com/aws/amazon-ecs-agent/agent/statechange"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 	"github.com/cihub/seelog"
 )
@@ -55,14 +56,15 @@ func NewTaskHandler() *TaskHandler {
 	}
 }
 
-// AddTaskEvent queues up a state change for sending using the given client.
-func (handler *TaskHandler) AddTaskEvent(change api.TaskStateChange, client api.ECSClient) {
-	handler.addEvent(newSendableTaskEvent(change), client)
-}
+// AddStateChangeEvent queues up a state change for sending using the given client.
+func (handler *TaskHandler) AddStateChangeEvent(change statechange.StateChangeEvent, client api.ECSClient) {
+	if change.TaskEvent != nil {
+		handler.addEvent(newSendableTaskEvent(*change.TaskEvent), client)
+	}
 
-// AddContainerEvent queues up a state change for sending using the given client.
-func (handler *TaskHandler) AddContainerEvent(change api.ContainerStateChange, client api.ECSClient) {
-	handler.addEvent(newSendableContainerEvent(change), client)
+	if change.ContainerEvent != nil {
+		handler.addEvent(newSendableContainerEvent(*change.ContainerEvent), client)
+	}
 }
 
 // Prepares a given event to be sent by adding it to the handler's appropriate

--- a/agent/statechange/statechange.go
+++ b/agent/statechange/statechange.go
@@ -1,3 +1,16 @@
+// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
 package statechange
 
 import (

--- a/agent/statechange/statechange.go
+++ b/agent/statechange/statechange.go
@@ -16,7 +16,7 @@ package statechange
 const (
 	// ContainerEvent is used to define the container state transition events
 	// emitted by the engine
-	ContainerEvent Event = iota
+	ContainerEvent EventType = iota
 
 	// TaskEvent is used to define the task state transition events emitted by
 	// the engine
@@ -24,13 +24,13 @@ const (
 )
 
 // Event defines the type of state change event
-type Event int32
+type EventType int32
 
-// StateChangeEvent is used to abstract away the two transition event types
+// Event is used to abstract away the two transition event types
 // passed up through a single channel from the the engine
-type StateChangeEvent interface {
+type Event interface {
 
 	// GetEventType implementations should return one the enums defined above to
 	// identify the type of event being emitted
-	GetEventType() Event
+	GetEventType() EventType
 }

--- a/agent/statechange/statechange.go
+++ b/agent/statechange/statechange.go
@@ -13,11 +13,11 @@
 
 package statechange
 
-import (
-	"github.com/aws/amazon-ecs-agent/agent/api"
+const (
+	ContainerEvent = iota
+	TaskEvent
 )
 
-type StateChangeEvent struct {
-	TaskEvent      *api.TaskStateChange
-	ContainerEvent *api.ContainerStateChange
+type StateChangeEvent interface {
+	GetEventType() int
 }

--- a/agent/statechange/statechange.go
+++ b/agent/statechange/statechange.go
@@ -14,9 +14,17 @@
 package statechange
 
 const (
-	ContainerEvent = iota
+	// ContainerEvent is used to define the container state transition events
+	// emitted by the engine
+	ContainerEvent Event = iota
+
+	// TaskEvent is used to define the task state transition events emitted by
+	// the engine
 	TaskEvent
 )
+
+// Event defines the type of state change event
+type Event int32
 
 // StateChangeEvent is used to abstract away the two transition event types
 // passed up through a single channel from the the engine
@@ -24,5 +32,5 @@ type StateChangeEvent interface {
 
 	// GetEventType implementations should return one the enums defined above to
 	// identify the type of event being emitted
-	GetEventType() int
+	GetEventType() Event
 }

--- a/agent/statechange/statechange.go
+++ b/agent/statechange/statechange.go
@@ -18,6 +18,11 @@ const (
 	TaskEvent
 )
 
+// StateChangeEvent is used to abstract away the two transition event types
+// passed up through a single channel from the the engine
 type StateChangeEvent interface {
+
+	// GetEventType implementations should return one the enums defined above to
+	// identify the type of event being emitted
 	GetEventType() int
 }

--- a/agent/statechange/statechange.go
+++ b/agent/statechange/statechange.go
@@ -1,0 +1,10 @@
+package statechange
+
+import (
+	"github.com/aws/amazon-ecs-agent/agent/api"
+)
+
+type StateChangeEvent struct {
+	TaskEvent      *api.TaskStateChange
+	ContainerEvent *api.ContainerStateChange
+}

--- a/agent/stats/common_test.go
+++ b/agent/stats/common_test.go
@@ -23,6 +23,7 @@ import (
 	ecsengine "github.com/aws/amazon-ecs-agent/agent/engine"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerclient"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
+	"github.com/aws/amazon-ecs-agent/agent/statechange"
 	"github.com/aws/amazon-ecs-agent/agent/statemanager"
 	"github.com/aws/amazon-ecs-agent/agent/tcs/model/ecstcs"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
@@ -186,8 +187,8 @@ func (engine *MockTaskEngine) Init() error {
 func (engine *MockTaskEngine) MustInit() {
 }
 
-func (engine *MockTaskEngine) TaskEvents() (<-chan api.TaskStateChange, <-chan api.ContainerStateChange) {
-	return make(chan api.TaskStateChange), make(chan api.ContainerStateChange)
+func (engine *MockTaskEngine) StateChangeEvents() <-chan statechange.StateChangeEvent {
+	return make(chan statechange.StateChangeEvent)
 }
 
 func (engine *MockTaskEngine) SetSaver(statemanager.Saver) {

--- a/agent/stats/common_test.go
+++ b/agent/stats/common_test.go
@@ -187,8 +187,8 @@ func (engine *MockTaskEngine) Init() error {
 func (engine *MockTaskEngine) MustInit() {
 }
 
-func (engine *MockTaskEngine) StateChangeEvents() <-chan statechange.StateChangeEvent {
-	return make(chan statechange.StateChangeEvent)
+func (engine *MockTaskEngine) StateChangeEvents() <-chan statechange.Event {
+	return make(chan statechange.Event)
 }
 
 func (engine *MockTaskEngine) SetSaver(statemanager.Saver) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This change uses a single channel to propagate task and container
transition events from the engine. Using a single channel forces
container events to preceed task events for a given task transition.

### Implementation details
<!-- How are the changes implemented? -->
* statechange: added new StateChangeEvent wrapper struct for api.ContainerStateChange and api.TaskStateChange

* engine: consolidated the two event channels into the single channel of statechange.StateChangeEvent structs. Modified all affected tests accordingly.

* acs: payloadRequestHandler's handleUnrecognizedTask is modified to use new StateChangeEvent struct to emit TaskStateChange event.

* eventhandler: modified to use single StateChangeEvent channel in this package and modified tests accordingly.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: yes <!-- yes -->
