### PR TITLE
adds support for lookup a task using the short docker Id

### DIFF
--- a/agent/engine/dockerstate/dockerstate_test.go
+++ b/agent/engine/dockerstate/dockerstate_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
 	"github.com/aws/amazon-ecs-agent/agent/engine/image"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCreateDockerTaskEngineState(t *testing.T) {
@@ -32,6 +33,10 @@ func TestCreateDockerTaskEngineState(t *testing.T) {
 		t.Error("Empty state should not have a test task")
 	}
 
+	if _, ok := state.TaskByShortID("test"); ok {
+		t.Error("Empty state should not have a test taskid")
+	}
+
 	if _, ok := state.TaskByID("test"); ok {
 		t.Error("Empty state should not have a test taskid")
 	}
@@ -43,6 +48,13 @@ func TestCreateDockerTaskEngineState(t *testing.T) {
 	if len(state.AllImageStates()) != 0 {
 		t.Error("Empty state should have no image states")
 	}
+
+	task, ok := state.TaskByShortID("test")
+	if assert.Empty(t, ok, "Empty state should have no tasks") {
+		assert.Empty(t, task, "Empty state should have no tasks")
+	}
+
+	assert.Empty(t, state.GetAllContainerIDs(), "Empty state should have no containers")
 }
 
 func TestAddTask(t *testing.T) {

--- a/agent/engine/dockerstate/mocks/dockerstate_mocks.go
+++ b/agent/engine/dockerstate/mocks/dockerstate_mocks.go
@@ -87,6 +87,16 @@ func (_mr *_MockTaskEngineStateRecorder) AllTasks() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "AllTasks")
 }
 
+func (_m *MockTaskEngineState) GetAllContainerIDs() []string {
+	ret := _m.ctrl.Call(_m, "GetAllContainerIDs")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+func (_mr *_MockTaskEngineStateRecorder) GetAllContainerIDs() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetAllContainerIDs")
+}
+
 func (_m *MockTaskEngineState) ContainerByID(_param0 string) (*api.DockerContainer, bool) {
 	ret := _m.ctrl.Call(_m, "ContainerByID", _param0)
 	ret0, _ := ret[0].(*api.DockerContainer)
@@ -156,6 +166,17 @@ func (_m *MockTaskEngineState) TaskByID(_param0 string) (*api.Task, bool) {
 
 func (_mr *_MockTaskEngineStateRecorder) TaskByID(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "TaskByID", arg0)
+}
+
+func (_mr *_MockTaskEngineStateRecorder) TaskByShortID(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "TaskByShortID", arg0)
+}
+
+func (_m *MockTaskEngineState) TaskByShortID(_param0 string) ([]*api.Task, bool) {
+	ret := _m.ctrl.Call(_m, "TaskByShortID", _param0)
+	ret0, _ := ret[0].([]*api.Task)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
 }
 
 func (_m *MockTaskEngineState) UnmarshalJSON(_param0 []byte) error {

--- a/agent/handlers/v1_handlers_test.go
+++ b/agent/handlers/v1_handlers_test.go
@@ -29,6 +29,8 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 	"github.com/aws/amazon-ecs-agent/agent/utils/mocks"
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const testContainerInstanceArn = "test_container_instance_arn"
@@ -76,6 +78,30 @@ func TestGetTaskByDockerID(t *testing.T) {
 	}
 
 	taskDiffHelper(t, []*api.Task{testTasks[1]}, TasksResponse{Tasks: []*TaskResponse{&taskResponse}})
+}
+
+func TestGetTaskByShortDockerIDMultiple(t *testing.T) {
+	recorder := performMockRequest(t, "/v1/tasks?dockerid=dockerid-tas")
+
+	assert.Equal(t, http.StatusBadRequest, recorder.Code, "Expected http 400 for dockerid with multiple matches")
+}
+
+func TestGetTaskShortByDockerID404(t *testing.T) {
+	recorder := performMockRequest(t, "/v1/tasks?dockerid=notfound")
+
+	assert.Equal(t, http.StatusNotFound, recorder.Code, "API did not return 404 for bad dockerid")
+}
+
+func TestGetTaskByShortDockerID(t *testing.T) {
+	// stateSetupHelper uses the convention of dockerid-$arn-$containerName; the
+	// first task has a container name prefix of dockerid-tas
+	recorder := performMockRequest(t, "/v1/tasks?dockerid=dockerid-by")
+
+	var taskResponse TaskResponse
+	err := json.Unmarshal(recorder.Body.Bytes(), &taskResponse)
+	require.NoError(t, err, "unmarshal failed for get task by short docker id")
+
+	taskDiffHelper(t, []*api.Task{testTasks[2]}, TasksResponse{Tasks: []*TaskResponse{&taskResponse}})
 }
 
 func TestGetTaskByDockerID404(t *testing.T) {
@@ -261,6 +287,18 @@ var testTasks = []*api.Task{
 		Containers: []*api.Container{
 			{
 				Name: "foo",
+			},
+		},
+	},
+	{
+		Arn:                 "byShortId",
+		DesiredStatusUnsafe: api.TaskRunning,
+		KnownStatusUnsafe:   api.TaskRunning,
+		Family:              "test",
+		Version:             "2",
+		Containers: []*api.Container{
+			{
+				Name: "shortId",
 			},
 		},
 	},


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Adds the ability to lookup a task via the introspection service using the short version of the docker Id. Use case is for a container to be able to discover this own task arn and other task related metadata

addresses feature-request #770

Supersedes PR #775  

### Implementation details
<!-- How are the changes implemented? -->
A function TaskByShortID and GetAllContainerIDs have been added to TaskEngineState interface to find the first matching Tasks who's container id started with the given short id. The tasksV1RequestHandlerMaker was then updated to call either the TaskByID or TaskByShortID depending on the length of the dockerId request param

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yesy <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Feature - Filter tasks returned by introspection API by short container ID

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: yes <!-- yes -->
