### PR TITLE
wsclient: EOF is not an ERROR or WARN

### DIFF
--- a/agent/wsclient/client.go
+++ b/agent/wsclient/client.go
@@ -279,7 +279,7 @@ func (cs *ClientServerImpl) ConsumeMessages() error {
 			cs.handleMessage(message)
 
 		case permissibleCloseCode(err):
-			seelog.Warnf("Connection closed for a valid reason: %s", err)
+			seelog.Infof("Connection closed for a valid reason: %s", err)
 			return io.EOF
 
 		default:
@@ -344,5 +344,9 @@ func (cs *ClientServerImpl) handleMessage(data []byte) {
 
 // See https://github.com/gorilla/websocket/blob/87f6f6a22ebfbc3f89b9ccdc7fddd1b914c095f9/conn.go#L650
 func permissibleCloseCode(err error) bool {
-	return websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway, websocket.CloseInternalServerErr)
+	return websocket.IsCloseError(err,
+		websocket.CloseNormalClosure,
+		websocket.CloseAbnormalClosure,
+		websocket.CloseGoingAway,
+		websocket.CloseInternalServerErr)
 }


### PR DESCRIPTION
### Summary
`websocket.CloseAbnormalClosure` isn't really a problem unless we fail to reconnect.  Reconnection failures are already logged elsewhere.  This change logs at INFO level.

### Implementation details
`websocket.CloseAbnormalClosure` is added to the "allowed" list

### Testing
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: no

### Description for the changelog
none

### Licensing
This contribution is under the terms of the Apache 2.0 License: yes (Amazon employee)
