### PR TITLE
Pause Container Packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,11 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-.PHONY: all gobuild static docker release certs test clean netkitten test-registry run-functional-tests gremlin benchmark-test gogenerate run-integ-tests image-cleanup-test-images
+PAUSE_CONTAINER_IMAGE = "amazon/amazon-ecs-pause"
+PAUSE_CONTAINER_TAG = "0.1.0"
+PAUSE_CONTAINER_TARBALL = "amazon-ecs-pause.tar"
+
+.PHONY: all gobuild static docker release certs test clean netkitten test-registry run-functional-tests gremlin benchmark-test gogenerate run-integ-tests image-cleanup-test-images pause-container
 
 all: docker
 
@@ -42,7 +46,7 @@ docker: certs build-in-docker
 
 # 'docker-release' builds the agent from a clean snapshot of the git repo in
 # 'RELEASE' mode
-docker-release:
+docker-release: pause-container-release
 	@docker build -f scripts/dockerfiles/Dockerfile.cleanbuild -t "amazon/amazon-ecs-agent-cleanbuild:make" .
 	@docker run --net=none -e TARGET_OS="${TARGET_OS}" -v "$(shell pwd)/out:/out" \
 	  -v "$(shell pwd):/src/amazon-ecs-agent" "amazon/amazon-ecs-agent-cleanbuild:make"
@@ -92,6 +96,9 @@ pause-container:
 
 	cd misc/pause-container; $(MAKE) $(MFLAGS)
 	@docker rmi -f "amazon/amazon-ecs-build-pause-bin:make"
+
+pause-container-release: pause-container
+	@docker save ${PAUSE_CONTAINER_IMAGE}:${PAUSE_CONTAINER_TAG} > out/${PAUSE_CONTAINER_TARBALL}
 
 run-integ-tests: test-registry gremlin
 	. ./scripts/shared_env && go test -tags integration -timeout=5m -v ./agent/engine/... ./agent/stats/...

--- a/scripts/create-amazon-ecs-scratch
+++ b/scripts/create-amazon-ecs-scratch
@@ -9,7 +9,9 @@
 
 mkdir amazon-ecs-scratch # include other directories that are needed here
 mkdir amazon-ecs-scratch/tmp
+mkdir amazon-ecs-scratch/images
+
 cd amazon-ecs-scratch
 tar -cv . | docker import - "amazon/amazon-ecs-scratch:make"
 cd ..
-rmdir amazon-ecs-scratch/tmp amazon-ecs-scratch
+rmdir amazon-ecs-scratch/tmp amazon-ecs-scratch/images amazon-ecs-scratch

--- a/scripts/dockerfiles/Dockerfile.release
+++ b/scripts/dockerfiles/Dockerfile.release
@@ -18,6 +18,8 @@ FROM amazon/amazon-ecs-scratch:make
 COPY out/amazon-ecs-agent /agent
 COPY ["LICENSE", "NOTICE", "/"]
 
+COPY out/amazon-ecs-pause.tar /images/amazon-ecs-pause.tar
+
 # Copy our bundled certs to the first place go will check: see
 # https://golang.org/src/pkg/crypto/x509/root_unix.go
 COPY misc/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Packaging Pause-Container

### Implementation details
<!-- How are the changes implemented? -->
The pause-container tarball is exported to the `out` directory.
This tarball is further stuck into the `/images` within the agent tarball. 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->
No

Changes were manually tested. 

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
* Packaging Pause Container for amazon-ecs-agent
### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes --> 
Yes
