### PR TITLE
Make agent not try to remove non-existed container

### DIFF
--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -294,6 +294,9 @@ func (engine *DockerTaskEngine) CheckTaskState(task *api.Task) {
 // sweepTask deletes all the containers associated with a task
 func (engine *DockerTaskEngine) sweepTask(task *api.Task) {
 	for _, cont := range task.Containers {
+		if cont.ImageID == "" {
+			continue
+		}
 		err := engine.removeContainer(task, cont)
 		if err != nil {
 			log.Debug("Unable to remove old container", "err", err, "task", task, "cont", cont)

--- a/agent/engine/testdata/test_tasks/sleep5.json
+++ b/agent/engine/testdata/test_tasks/sleep5.json
@@ -8,6 +8,7 @@
       "Name":"sleep5",
       "Image":"busybox",
       "Command":["sleep","5"],
+      "ImageID": "dockerImageID",
       "Cpu":10,
       "Memory":10,
       "Links":null,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Fix an error where agent try to cleanup a container transitioned directly from NONE to STOPPED, like:
```
2017-06-05T21:20:19Z [DEBUG] Unable to remove old container module="TaskEngine" err="No container named 'nginx' created in arn:aws:ecs:us-west-2:807827109477:task/38039ea1-2384-43a1-b2b1-1d858bb1e1a0
github.com/aws/amazon-ecs-agent/agent/engine.(*DockerTaskEngine).removeContainer
	/go/src/github.com/aws/amazon-ecs-agent/agent/engine/docker_task_engine.go:744
github.com/aws/amazon-ecs-agent/agent/engine.(*DockerTaskEngine).sweepTask
	/go/src/github.com/aws/amazon-ecs-agent/agent/engine/docker_task_engine.go:324
github.com/aws/amazon-ecs-agent/agent/engine.(*managedTask).cleanupTask
	/go/src/github.com/aws/amazon-ecs-agent/agent/engine/task_manager.go:556
github.com/aws/amazon-ecs-agent/agent/engine.(*managedTask).overseeTask
	/go/src/github.com/aws/amazon-ecs-agent/agent/engine/task_manager.go:177
runtime.goexit
	/usr/local/go/src/runtime/asm_amd64.s:2086" task="task_networking_test:1 arn:aws:ecs:us-west-2:807827109477:task/38039ea1-2384-43a1-b2b1-1d858bb1e1a0, TaskStatus: (STOPPED->STOPPED) Containers: [nginx (STOPPED->STOPPED),~internal~ecs~pause (STOPPED->STOPPED),]" cont="nginx(nginx) (STOPPED->STOPPED)"
```

### Implementation details
<!-- How are the changes implemented? -->
Check if the container has been pulled before starting cleaning up the container.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->
yes
### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
yes