### PR TITLE
Refactor the acs to use dockerstate directly

### DIFF
--- a/agent/acs/handler/acs_handler.go
+++ b/agent/acs/handler/acs_handler.go
@@ -31,6 +31,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	rolecredentials "github.com/aws/amazon-ecs-agent/agent/credentials"
 	"github.com/aws/amazon-ecs-agent/agent/engine"
+	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/eventhandler"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
 	"github.com/aws/amazon-ecs-agent/agent/statemanager"
@@ -79,6 +80,7 @@ type session struct {
 	deregisterInstanceEventStream   *eventstream.EventStream
 	taskEngine                      engine.TaskEngine
 	ecsClient                       api.ECSClient
+	state                           dockerstate.TaskEngineState
 	stateManager                    statemanager.StateManager
 	credentialsManager              rolecredentials.Manager
 	taskHandler                     *eventhandler.TaskHandler
@@ -135,6 +137,7 @@ func NewSession(ctx context.Context,
 	containerInstanceArn string,
 	credentialsProvider *credentials.Credentials,
 	ecsClient api.ECSClient,
+	taskEngineState dockerstate.TaskEngineState,
 	stateManager statemanager.StateManager,
 	taskEngine engine.TaskEngine,
 	credentialsManager rolecredentials.Manager,
@@ -150,6 +153,7 @@ func NewSession(ctx context.Context,
 		containerInstanceARN:            containerInstanceArn,
 		credentialsProvider:             credentialsProvider,
 		ecsClient:                       ecsClient,
+		state:                           taskEngineState,
 		stateManager:                    stateManager,
 		taskEngine:                      taskEngine,
 		credentialsManager:              credentialsManager,
@@ -270,7 +274,7 @@ func (acsSession *session) startACSSession(client wsclient.ClientServer, timer t
 		cfg.Cluster,
 		acsSession.containerInstanceARN,
 		client,
-		acsSession.taskEngine,
+		acsSession.state,
 		acsSession.stateManager,
 	)
 	eniAttachHandler.start()

--- a/agent/acs/handler/acs_handler_test.go
+++ b/agent/acs/handler/acs_handler_test.go
@@ -33,6 +33,7 @@ import (
 	rolecredentials "github.com/aws/amazon-ecs-agent/agent/credentials"
 	"github.com/aws/amazon-ecs-agent/agent/credentials/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/engine"
+	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/eventhandler"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
 	"github.com/aws/amazon-ecs-agent/agent/statemanager"
@@ -929,6 +930,7 @@ func TestStartSessionHandlesRefreshCredentialsMessages(t *testing.T) {
 			"myArn",
 			credentials.AnonymousCredentials,
 			ecsClient,
+			dockerstate.NewTaskEngineState(),
 			stateManager,
 			taskEngine,
 			credentialsManager,

--- a/agent/acs/handler/attach_eni_handler_test.go
+++ b/agent/acs/handler/attach_eni_handler_test.go
@@ -18,8 +18,6 @@ import (
 	"testing"
 
 	"github.com/aws/amazon-ecs-agent/agent/acs/model/ecsacs"
-	"github.com/aws/amazon-ecs-agent/agent/config"
-	"github.com/aws/amazon-ecs-agent/agent/engine"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/statemanager/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/wsclient/mock"
@@ -210,13 +208,11 @@ func TestENIAckSingleMessage(t *testing.T) {
 	defer ctrl.Finish()
 
 	taskEngineState := dockerstate.NewTaskEngineState()
-
-	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, taskEngineState)
 	manager := mock_statemanager.NewMockStateManager(ctrl)
 
 	ctx := context.TODO()
 	mockWsClient := mock_wsclient.NewMockClientServer(ctrl)
-	eniAttachHandler := newAttachENIHandler(ctx, clusterName, containerInstanceArn, mockWsClient, taskEngine, manager)
+	eniAttachHandler := newAttachENIHandler(ctx, clusterName, containerInstanceArn, mockWsClient, taskEngineState, manager)
 
 	var eniAckRequested *ecsacs.AckRequest
 	mockWsClient.EXPECT().MakeRequest(gomock.Any()).Do(func(ackRequest *ecsacs.AckRequest) {
@@ -262,12 +258,12 @@ func TestENIAckForMessageIdMismatch(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState())
+	taskEngineState := dockerstate.NewTaskEngineState()
 	manager := mock_statemanager.NewMockStateManager(ctrl)
 
 	ctx := context.TODO()
 	mockWsClient := mock_wsclient.NewMockClientServer(ctrl)
-	eniAttachHandler := newAttachENIHandler(ctx, clusterName, containerInstanceArn, mockWsClient, taskEngine, manager)
+	eniAttachHandler := newAttachENIHandler(ctx, clusterName, containerInstanceArn, mockWsClient, taskEngineState, manager)
 
 	var eniAckRequested *ecsacs.AckRequest
 	mockWsClient.EXPECT().MakeRequest(gomock.Any()).Do(func(ackRequest *ecsacs.AckRequest) {
@@ -310,11 +306,11 @@ func TestENIAckHappyPath(t *testing.T) {
 	defer ctrl.Finish()
 
 	ctx := context.TODO()
-	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState())
+	taskEngineState := dockerstate.NewTaskEngineState()
 	manager := mock_statemanager.NewMockStateManager(ctrl)
 
 	mockWsClient := mock_wsclient.NewMockClientServer(ctrl)
-	eniAttachHandler := newAttachENIHandler(ctx, clusterName, containerInstanceArn, mockWsClient, taskEngine, manager)
+	eniAttachHandler := newAttachENIHandler(ctx, clusterName, containerInstanceArn, mockWsClient, taskEngineState, manager)
 
 	var eniAckRequested *ecsacs.AckRequest
 	mockWsClient.EXPECT().MakeRequest(gomock.Any()).Do(func(ackRequest *ecsacs.AckRequest) {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -298,6 +298,7 @@ func _main() int {
 		containerInstanceArn,
 		credentialProvider,
 		client,
+		state,
 		stateManager,
 		taskEngine,
 		credentialsManager,

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -828,11 +828,6 @@ func (engine *DockerTaskEngine) State() dockerstate.TaskEngineState {
 	return engine.state
 }
 
-// AddENIAttachment adds an eni struct to the agent state
-func (engine *DockerTaskEngine) AddENIAttachment(eniAttachment *api.ENIAttachment) {
-	engine.state.AddENIAttachment(eniAttachment)
-}
-
 // Capabilities returns the supported capabilities of this agent / docker-client pair.
 // Currently, the following capabilities are possible:
 //

--- a/agent/engine/dockerstate/mocks/dockerstate_mocks.go
+++ b/agent/engine/dockerstate/mocks/dockerstate_mocks.go
@@ -95,16 +95,6 @@ func (_mr *_MockTaskEngineStateRecorder) AllTasks() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "AllTasks")
 }
 
-func (_m *MockTaskEngineState) GetAllContainerIDs() []string {
-	ret := _m.ctrl.Call(_m, "GetAllContainerIDs")
-	ret0, _ := ret[0].([]string)
-	return ret0
-}
-
-func (_mr *_MockTaskEngineStateRecorder) GetAllContainerIDs() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetAllContainerIDs")
-}
-
 func (_m *MockTaskEngineState) ContainerByID(_param0 string) (*api.DockerContainer, bool) {
 	ret := _m.ctrl.Call(_m, "ContainerByID", _param0)
 	ret0, _ := ret[0].(*api.DockerContainer)
@@ -136,6 +126,16 @@ func (_m *MockTaskEngineState) ENIByMac(_param0 string) (*api.ENIAttachment, boo
 
 func (_mr *_MockTaskEngineStateRecorder) ENIByMac(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ENIByMac", arg0)
+}
+
+func (_m *MockTaskEngineState) GetAllContainerIDs() []string {
+	ret := _m.ctrl.Call(_m, "GetAllContainerIDs")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+func (_mr *_MockTaskEngineStateRecorder) GetAllContainerIDs() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetAllContainerIDs")
 }
 
 func (_m *MockTaskEngineState) MarshalJSON() ([]byte, error) {
@@ -195,15 +195,15 @@ func (_mr *_MockTaskEngineStateRecorder) TaskByID(arg0 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "TaskByID", arg0)
 }
 
-func (_mr *_MockTaskEngineStateRecorder) TaskByShortID(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "TaskByShortID", arg0)
-}
-
 func (_m *MockTaskEngineState) TaskByShortID(_param0 string) ([]*api.Task, bool) {
 	ret := _m.ctrl.Call(_m, "TaskByShortID", _param0)
 	ret0, _ := ret[0].([]*api.Task)
 	ret1, _ := ret[1].(bool)
 	return ret0, ret1
+}
+
+func (_mr *_MockTaskEngineStateRecorder) TaskByShortID(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "TaskByShortID", arg0)
 }
 
 func (_m *MockTaskEngineState) UnmarshalJSON(_param0 []byte) error {

--- a/agent/engine/engine_mocks.go
+++ b/agent/engine/engine_mocks.go
@@ -51,14 +51,6 @@ func (_m *MockTaskEngine) EXPECT() *_MockTaskEngineRecorder {
 	return _m.recorder
 }
 
-func (_m *MockTaskEngine) AddENIAttachment(_param0 *api.ENIAttachment) {
-	_m.ctrl.Call(_m, "AddENIAttachment", _param0)
-}
-
-func (_mr *_MockTaskEngineRecorder) AddENIAttachment(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddENIAttachment", arg0)
-}
-
 func (_m *MockTaskEngine) AddTask(_param0 *api.Task) error {
 	ret := _m.ctrl.Call(_m, "AddTask", _param0)
 	ret0, _ := ret[0].(error)

--- a/agent/engine/interface.go
+++ b/agent/engine/interface.go
@@ -41,9 +41,6 @@ type TaskEngine interface {
 	// lifecycle. If it returns an error, the task was not added.
 	AddTask(*api.Task) error
 
-	// AddENIAttachment adds a new eni information to the state
-	AddENIAttachment(*api.ENIAttachment)
-
 	// ListTasks lists all the tasks being managed by the TaskEngine.
 	ListTasks() ([]*api.Task, error)
 

--- a/agent/stats/common_test.go
+++ b/agent/stats/common_test.go
@@ -203,9 +203,6 @@ func (engine *MockTaskEngine) AddTask(*api.Task) error {
 	return nil
 }
 
-func (engine *MockTaskEngine) AddENIAttachment(*api.ENIAttachment) {
-}
-
 func (engine *MockTaskEngine) ListTasks() ([]*api.Task, error) {
 	return nil, nil
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Added `dockerstate.TaskEngineState` into the acs, instead of relying on taskEngine to update the ENIAttachment information in the agent state.

### Implementation details
<!-- How are the changes implemented? -->
Added `dockerstate.TaskEngineState` to acs when create acs session in `agent.go`. Then pass to the ``attach_eni_handler` to update the `ENIAttachment` in agent state.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->
### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
yes