### PR TITLE
Load pause container on agent start

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,10 @@ static:
 # directory
 build-in-docker:
 	@docker build -f scripts/dockerfiles/Dockerfile.build -t "amazon/amazon-ecs-agent-build:make" .
-	@docker run --net=none -e TARGET_OS="${TARGET_OS}" \
+	@docker run --net=none \
+	  -e TARGET_OS="${TARGET_OS}" \
+	  -e LDFLAGS="-X github.com/aws/amazon-ecs-agent/agent/config.PauseContainerTag=$(PAUSE_CONTAINER_TAG) \
+	  -X github.com/aws/amazon-ecs-agent/agent/config.PauseContainerImageName=$(PAUSE_CONTAINER_IMAGE)" \
 	  -v "$(shell pwd)/out:/out" \
 	  -v "$(shell pwd):/go/src/github.com/aws/amazon-ecs-agent" \
 	  "amazon/amazon-ecs-agent-build:make"
@@ -48,8 +51,13 @@ docker: certs build-in-docker pause-container-release
 # 'RELEASE' mode
 docker-release: pause-container-release
 	@docker build -f scripts/dockerfiles/Dockerfile.cleanbuild -t "amazon/amazon-ecs-agent-cleanbuild:make" .
-	@docker run --net=none -e TARGET_OS="${TARGET_OS}" -v "$(shell pwd)/out:/out" \
-	  -v "$(shell pwd):/src/amazon-ecs-agent" "amazon/amazon-ecs-agent-cleanbuild:make"
+	@docker run --net=none \
+	  -e TARGET_OS="${TARGET_OS}" \
+	  -v "$(shell pwd)/out:/out" \
+	  -e LDFLAGS="-X github.com/aws/amazon-ecs-agent/agent/config.PauseContainerTag=$(PAUSE_CONTAINER_TAG) \
+	  -X github.com/aws/amazon-ecs-agent/agent/config.PauseContainerImageName=$(PAUSE_CONTAINER_IMAGE)" \
+	  -v "$(shell pwd):/src/amazon-ecs-agent" \
+	  "amazon/amazon-ecs-agent-cleanbuild:make"
 
 # Release packages our agent into a "scratch" based dockerfile
 release: certs docker-release

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ build-in-docker:
 
 # 'docker' builds the agent dockerfile from the current sourcecode tree, dirty
 # or not
-docker: certs build-in-docker
+docker: certs build-in-docker pause-container-release
 	@cd scripts && ./create-amazon-ecs-scratch
 	@docker build -f scripts/dockerfiles/Dockerfile.release -t "amazon/amazon-ecs-agent:make" .
 	@echo "Built Docker image \"amazon/amazon-ecs-agent:make\""

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -192,10 +192,15 @@ func _main() int {
 	}
 
 	// Load Pause Container Image
-	err = pause.Load(cfg, dockerClient)
+	err = pause.LoadImage(cfg, dockerClient)
 	if err != nil {
-		log.Criticalf("Error loading pause container image: %v", err)
-		return exitcodes.ExitError
+		if !pause.UnsupportedPlatform(err) {
+			log.Criticalf("Error loading pause container image: %v", err)
+			return exitcodes.ExitError
+		}
+		log.Debugf("Ignoring error loading pause container image: %v", err)
+	} else {
+		log.Infof("Successfully loaded pause container image")
 	}
 
 	stateManager, err := initializeStateManager(cfg, taskEngine, &cfg.Cluster, &containerInstanceArn, &currentEc2InstanceID)

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -192,7 +192,7 @@ func _main() int {
 	}
 
 	// Load Pause Container Image
-	err = pause.LoadImage(cfg, dockerClient)
+	_, err = pause.LoadImage(cfg, dockerClient)
 	if err != nil {
 		if !pause.UnsupportedPlatform(err) {
 			log.Criticalf("Error loading pause container image: %v", err)

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -29,6 +29,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/engine"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerclient"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
+	"github.com/aws/amazon-ecs-agent/agent/eni/pause"
 	eniwatchersetup "github.com/aws/amazon-ecs-agent/agent/eni/setup"
 	"github.com/aws/amazon-ecs-agent/agent/eventhandler"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
@@ -188,6 +189,13 @@ func _main() int {
 	} else {
 		log.Info("Checkpointing not enabled; a new container instance will be created each time the agent is run")
 		taskEngine = engine.NewTaskEngine(cfg, dockerClient, credentialsManager, containerChangeEventStream, imageManager, state)
+	}
+
+	// Load Pause Container Image
+	err = pause.Load(cfg, dockerClient)
+	if err != nil {
+		log.Criticalf("Error loading pause container image: %v", err)
+		return exitcodes.ExitError
 	}
 
 	stateManager, err := initializeStateManager(cfg, taskEngine, &cfg.Cluster, &containerInstanceArn, &currentEc2InstanceID)

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -200,7 +200,7 @@ func _main() int {
 		}
 		log.Debugf("Ignoring error loading pause container image: %v", err)
 	} else {
-		log.Infof("Successfully loaded pause container image")
+		log.Info("Successfully loaded pause container image")
 	}
 
 	stateManager, err := initializeStateManager(cfg, taskEngine, &cfg.Cluster, &containerInstanceArn, &currentEc2InstanceID)

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -367,8 +367,6 @@ func environmentConfig() (Config, error) {
 		NumImagesToDeletePerCycle:        numImagesToDeletePerCycle,
 		InstanceAttributes:               instanceAttributes,
 		CNIPluginsPath:                   cniPluginsPath,
-		PauseContainerTarballPath:        pauseContainerTarballPath,
-		PauseContainerTag:                pauseContainerTag,
 	}, err
 }
 

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -86,6 +86,12 @@ const (
 
 	// DefaultMinSupportedCNIVersion denotes the minimum version of cni spec required
 	DefaultMinSupportedCNIVersion = "0.3.0"
+
+	// Path to pause container tarball
+	pauseContainerTarballPath = "/images/amazon-ecs-pause.tar"
+
+	// Tag for pause container
+	pauseContainerTag = "0.1.0"
 )
 
 // Merge merges two config files, preferring the ones on the left. Any nil or
@@ -361,6 +367,8 @@ func environmentConfig() (Config, error) {
 		NumImagesToDeletePerCycle:        numImagesToDeletePerCycle,
 		InstanceAttributes:               instanceAttributes,
 		CNIPluginsPath:                   cniPluginsPath,
+		PauseContainerTarballPath:        pauseContainerTarballPath,
+		PauseContainerTag:                pauseContainerTag,
 	}, err
 }
 

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -89,9 +89,16 @@ const (
 
 	// pauseContainerTarball is the path to the pause container tarball
 	pauseContainerTarballPath = "/images/amazon-ecs-pause.tar"
+)
 
-	// pauseContainer is the Tag for the pause container image
-	pauseContainerTag = "0.1.0"
+var (
+	// PauseContainerTag is the tag for the pause container image. The linker's load
+	// flags are used to populate this value from the Makefile
+	PauseContainerTag = ""
+
+	// PauseContainerImageName is the name of the pause container image. The linker's
+	// load flags are used to populate this value from the Makefile
+	PauseContainerImageName = ""
 )
 
 // Merge merges two config files, preferring the ones on the left. Any nil or

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -87,10 +87,10 @@ const (
 	// DefaultMinSupportedCNIVersion denotes the minimum version of cni spec required
 	DefaultMinSupportedCNIVersion = "0.3.0"
 
-	// Path to pause container tarball
+	// pauseContainerTarball is the path to the pause container tarball
 	pauseContainerTarballPath = "/images/amazon-ecs-pause.tar"
 
-	// Tag for pause container
+	// pauseContainer is the Tag for the pause container image
 	pauseContainerTag = "0.1.0"
 )
 

--- a/agent/config/config_unix.go
+++ b/agent/config/config_unix.go
@@ -41,7 +41,7 @@ func DefaultConfig() Config {
 		NumImagesToDeletePerCycle:   DefaultNumImagesToDeletePerCycle,
 		CNIPluginsPath:              defaultCNIPluginsPath,
 		PauseContainerTarballPath:   pauseContainerTarballPath,
-		PauseContainerTag:           pauseContainerTag,
+		PauseContainerTag:           PauseContainerTag,
 	}
 }
 

--- a/agent/config/config_unix.go
+++ b/agent/config/config_unix.go
@@ -40,6 +40,8 @@ func DefaultConfig() Config {
 		ImageCleanupInterval:        DefaultImageCleanupTimeInterval,
 		NumImagesToDeletePerCycle:   DefaultNumImagesToDeletePerCycle,
 		CNIPluginsPath:              defaultCNIPluginsPath,
+		PauseContainerTarballPath:   pauseContainerTarballPath,
+		PauseContainerTag:           pauseContainerTag,
 	}
 }
 

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -150,6 +150,12 @@ type Config struct {
 
 	// CNIPluginsPath is the path for the cni plugins
 	CNIPluginsPath string
+
+	// Path to pause container tarball
+	PauseContainerTarballPath string
+
+	// Tag for pause container
+	PauseContainerTag string
 }
 
 // SensitiveRawMessage is a struct to store some data that should not be logged

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -151,10 +151,10 @@ type Config struct {
 	// CNIPluginsPath is the path for the cni plugins
 	CNIPluginsPath string
 
-	// Path to pause container tarball
+	// PauseContainerTarballPath is the path to the pause container tarball
 	PauseContainerTarballPath string
 
-	// Tag for pause container
+	// PauseContainer is the tag for the pause container image
 	PauseContainerTag string
 }
 

--- a/agent/engine/docker_container_engine.go
+++ b/agent/engine/docker_container_engine.go
@@ -91,6 +91,7 @@ type DockerClient interface {
 	Version() (string, error)
 	InspectImage(string) (*docker.Image, error)
 	RemoveImage(string, time.Duration) error
+	LoadImage(opts docker.LoadImageOptions) error
 }
 
 // DockerGoClient wraps the underlying go-dockerclient library.
@@ -847,4 +848,12 @@ func (dg *dockerGoClient) removeImage(imageName string) error {
 		return err
 	}
 	return client.RemoveImage(imageName)
+}
+
+func (dg *dockerGoClient) LoadImage(opts docker.LoadImageOptions) error {
+	client, err := dg.dockerClient()
+	if err != nil {
+		return err
+	}
+	return client.LoadImage(opts)
 }

--- a/agent/engine/docker_container_engine_test.go
+++ b/agent/engine/docker_container_engine_test.go
@@ -947,3 +947,13 @@ func TestContainerMetadataWorkaroundIssue27601(t *testing.T) {
 	metadata := client.containerMetadata("id")
 	assert.Equal(t, map[string]string{"destination1": "source1", "destination2": "source2"}, metadata.Volumes)
 }
+
+func TestLoadImage(t *testing.T) {
+	mockDocker, client, _, done := dockerClientSetup(t)
+	defer done()
+
+	mockDocker.EXPECT().LoadImage(gomock.Any()).Return(nil)
+
+	err := client.LoadImage(docker.LoadImageOptions{})
+	assert.NoError(t, err)
+}

--- a/agent/engine/docker_container_engine_test.go
+++ b/agent/engine/docker_container_engine_test.go
@@ -954,7 +954,7 @@ func TestLoadImageHappyPath(t *testing.T) {
 
 	mockDocker.EXPECT().LoadImage(gomock.Any()).Return(nil)
 
-	err := client.LoadImage(docker.LoadImageOptions{}, time.Second)
+	err := client.LoadImage(nil, time.Second)
 	assert.NoError(t, err)
 }
 
@@ -968,7 +968,7 @@ func TestLoadImageTimeoutError(t *testing.T) {
 		wait.Wait()
 	})
 
-	err := client.LoadImage(docker.LoadImageOptions{}, time.Millisecond)
+	err := client.LoadImage(nil, time.Millisecond)
 	assert.Error(t, err)
 	_, ok := err.(*DockerTimeoutError)
 	assert.True(t, ok)

--- a/agent/engine/dockeriface/interface.go
+++ b/agent/engine/dockeriface/interface.go
@@ -41,4 +41,5 @@ type Client interface {
 	Stats(opts docker.StatsOptions) error
 	Version() (*docker.Env, error)
 	RemoveImage(imageName string) error
+	LoadImage(opts docker.LoadImageOptions) error
 }

--- a/agent/engine/dockeriface/mocks/dockeriface_mocks.go
+++ b/agent/engine/dockeriface/mocks/dockeriface_mocks.go
@@ -118,6 +118,16 @@ func (_mr *_MockClientRecorder) ListContainers(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListContainers", arg0)
 }
 
+func (_m *MockClient) LoadImage(_param0 go_dockerclient.LoadImageOptions) error {
+	ret := _m.ctrl.Call(_m, "LoadImage", _param0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockClientRecorder) LoadImage(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "LoadImage", arg0)
+}
+
 func (_m *MockClient) Ping() error {
 	ret := _m.ctrl.Call(_m, "Ping")
 	ret0, _ := ret[0].(error)

--- a/agent/engine/engine_mocks.go
+++ b/agent/engine/engine_mocks.go
@@ -264,14 +264,14 @@ func (_mr *_MockDockerClientRecorder) ListContainers(arg0, arg1 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListContainers", arg0, arg1)
 }
 
-func (_m *MockDockerClient) LoadImage(_param0 go_dockerclient.LoadImageOptions) error {
-	ret := _m.ctrl.Call(_m, "LoadImage", _param0)
+func (_m *MockDockerClient) LoadImage(_param0 go_dockerclient.LoadImageOptions, _param1 time.Duration) error {
+	ret := _m.ctrl.Call(_m, "LoadImage", _param0, _param1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockDockerClientRecorder) LoadImage(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "LoadImage", arg0)
+func (_mr *_MockDockerClientRecorder) LoadImage(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "LoadImage", arg0, arg1)
 }
 
 func (_m *MockDockerClient) PullImage(_param0 string, _param1 *api.RegistryAuthenticationData) DockerContainerMetadata {

--- a/agent/engine/engine_mocks.go
+++ b/agent/engine/engine_mocks.go
@@ -264,6 +264,16 @@ func (_mr *_MockDockerClientRecorder) ListContainers(arg0, arg1 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListContainers", arg0, arg1)
 }
 
+func (_m *MockDockerClient) LoadImage(_param0 go_dockerclient.LoadImageOptions) error {
+	ret := _m.ctrl.Call(_m, "LoadImage", _param0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockDockerClientRecorder) LoadImage(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "LoadImage", arg0)
+}
+
 func (_m *MockDockerClient) PullImage(_param0 string, _param1 *api.RegistryAuthenticationData) DockerContainerMetadata {
 	ret := _m.ctrl.Call(_m, "PullImage", _param0, _param1)
 	ret0, _ := ret[0].(DockerContainerMetadata)

--- a/agent/engine/engine_mocks.go
+++ b/agent/engine/engine_mocks.go
@@ -17,6 +17,7 @@
 package engine
 
 import (
+	io "io"
 	time "time"
 
 	api "github.com/aws/amazon-ecs-agent/agent/api"
@@ -264,7 +265,7 @@ func (_mr *_MockDockerClientRecorder) ListContainers(arg0, arg1 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListContainers", arg0, arg1)
 }
 
-func (_m *MockDockerClient) LoadImage(_param0 go_dockerclient.LoadImageOptions, _param1 time.Duration) error {
+func (_m *MockDockerClient) LoadImage(_param0 io.Reader, _param1 time.Duration) error {
 	ret := _m.ctrl.Call(_m, "LoadImage", _param0, _param1)
 	ret0, _ := ret[0].(error)
 	return ret0

--- a/agent/eni/netlinkwrapper/mocks/mock_netlinkwrapper_linux.go
+++ b/agent/eni/netlinkwrapper/mocks/mock_netlinkwrapper_linux.go
@@ -18,7 +18,7 @@ package mock_netlinkwrapper
 
 import (
 	gomock "github.com/golang/mock/gomock"
-	netlink "github.com/vishvananda/netlink"
+	"github.com/vishvananda/netlink"
 )
 
 // Mock of NetLink interface

--- a/agent/eni/pause/error.go
+++ b/agent/eni/pause/error.go
@@ -1,5 +1,3 @@
-// +build !linux
-
 // Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
@@ -15,17 +13,15 @@
 
 package pause
 
-import (
-	"runtime"
+// UnsupportedPlatformError indicates an error when loading pause container
+// image on an unsupported OS platform
+type UnsupportedPlatformError struct {
+	error
+}
 
-	"github.com/aws/amazon-ecs-agent/agent/config"
-	"github.com/aws/amazon-ecs-agent/agent/engine"
-	"github.com/pkg/errors"
-)
-
-// LoadImage returns UnsupportedPlatformError on the unsupported platform
-func LoadImage(cfg *config.Config, dockerClient engine.DockerClient) error {
-	return UnsupportedPlatformError{errors.Errorf(
-		"pause container load: unsupported platform: %s/%s",
-		runtime.GOOS, runtime.GOARCH)}
+// UnsupportedPlatform returns true if the error is of UnsupportedPlatformError
+// type
+func UnsupportedPlatform(err error) bool {
+	_, ok := err.(UnsupportedPlatformError)
+	return ok
 }

--- a/agent/eni/pause/error_test.go
+++ b/agent/eni/pause/error_test.go
@@ -1,0 +1,23 @@
+package pause
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnsupportedPlatform(t *testing.T) {
+	testCases := map[error]bool{
+		errors.New("error"):                           false,
+		UnsupportedPlatformError{errors.New("error")}: true,
+	}
+
+	for err, expected := range testCases {
+		t.Run(fmt.Sprintf("returns %t for type %s", expected, reflect.TypeOf(err)), func(t *testing.T) {
+			assert.Equal(t, expected, UnsupportedPlatform(err))
+		})
+	}
+}

--- a/agent/eni/pause/error_test.go
+++ b/agent/eni/pause/error_test.go
@@ -1,3 +1,16 @@
+// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
 package pause
 
 import (

--- a/agent/eni/pause/pause_linux.go
+++ b/agent/eni/pause/pause_linux.go
@@ -1,0 +1,45 @@
+// +build linux
+
+// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package pause
+
+import (
+	"github.com/aws/amazon-ecs-agent/agent/acs/update_handler/os"
+	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/engine"
+
+	log "github.com/cihub/seelog"
+	docker "github.com/fsouza/go-dockerclient"
+	"github.com/pkg/errors"
+)
+
+// Load helps load the pause container image for the agent
+func Load(cfg *config.Config, dockerClient engine.DockerClient) error {
+	log.Debugf("Loading pause container tarball: %s:%s", cfg.PauseContainerTarballPath, cfg.PauseContainerTag)
+	return _load(cfg, dockerClient, os.Default)
+}
+
+func _load(cfg *config.Config, dockerClient engine.DockerClient, osi os.FileSystem) error {
+	pauseContainerReader, err := osi.Open(cfg.PauseContainerTarballPath)
+	if err != nil {
+		return errors.Wrapf(err, "pause container load: reading pause container image %s failed with error %v", cfg.PauseContainerTarballPath, err)
+	}
+	err = dockerClient.LoadImage(
+		docker.LoadImageOptions{
+			InputStream: pauseContainerReader,
+		},
+	)
+	return err
+}

--- a/agent/eni/pause/pause_linux_test.go
+++ b/agent/eni/pause/pause_linux_test.go
@@ -1,0 +1,92 @@
+// +build linux
+
+// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package pause
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/amazon-ecs-agent/agent/acs/update_handler/os/mock"
+	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/engine"
+	"github.com/aws/amazon-ecs-agent/agent/engine/dockerclient/mocks"
+	"github.com/aws/amazon-ecs-agent/agent/engine/dockeriface/mocks"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+)
+
+// Test _load with reader error
+func TestLoadWithReaderError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	conf := config.DefaultConfig()
+
+	mockDocker := mock_dockeriface.NewMockClient(ctrl)
+	mockDocker.EXPECT().Ping().AnyTimes().Return(nil)
+	factory := mock_dockerclient.NewMockFactory(ctrl)
+	factory.EXPECT().GetDefaultClient().AnyTimes().Return(mockDocker, nil)
+	client, _ := engine.NewDockerGoClient(factory, &conf)
+
+	mockfs := mock_os.NewMockFileSystem(ctrl)
+	mockfs.EXPECT().Open(gomock.Any()).Return(nil, errors.New("Dummy Reader Error"))
+
+	err := _load(&conf, client, mockfs)
+	assert.Error(t, err)
+}
+
+// Test _load against happy path
+func TestLoadHappyPath(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	conf := config.DefaultConfig()
+
+	mockDocker := mock_dockeriface.NewMockClient(ctrl)
+	mockDocker.EXPECT().Ping().AnyTimes().Return(nil)
+	factory := mock_dockerclient.NewMockFactory(ctrl)
+	factory.EXPECT().GetDefaultClient().AnyTimes().Return(mockDocker, nil)
+	client, _ := engine.NewDockerGoClient(factory, &conf)
+	mockDocker.EXPECT().LoadImage(gomock.Any()).Return(nil)
+
+	mockfs := mock_os.NewMockFileSystem(ctrl)
+	mockfs.EXPECT().Open(gomock.Any()).Return(nil, nil)
+
+	err := _load(&conf, client, mockfs)
+	assert.NoError(t, err)
+}
+
+// Test _load against error
+func TestLoadError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	conf := config.DefaultConfig()
+
+	mockDocker := mock_dockeriface.NewMockClient(ctrl)
+	mockDocker.EXPECT().Ping().AnyTimes().Return(nil)
+	factory := mock_dockerclient.NewMockFactory(ctrl)
+	factory.EXPECT().GetDefaultClient().AnyTimes().Return(mockDocker, nil)
+	client, _ := engine.NewDockerGoClient(factory, &conf)
+	mockDocker.EXPECT().LoadImage(gomock.Any()).Return(errors.New("Dummy Load Image Error"))
+
+	mockfs := mock_os.NewMockFileSystem(ctrl)
+	mockfs.EXPECT().Open(gomock.Any()).Return(nil, nil)
+
+	err := _load(&conf, client, mockfs)
+	assert.Error(t, err)
+}

--- a/agent/eni/pause/pause_linux_test.go
+++ b/agent/eni/pause/pause_linux_test.go
@@ -100,7 +100,7 @@ func TestLoadFromFileDockerLoadImageError(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestValidatePauseContainerImageInspectImageError(t *testing.T) {
+func TestGetPauseContainerImageInspectImageError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -114,11 +114,11 @@ func TestValidatePauseContainerImageInspectImageError(t *testing.T) {
 	mockDocker.EXPECT().InspectImage(pauseName+":"+pauseTag).Return(
 		nil, errors.New("error"))
 
-	err = validatePauseContainerImage(pauseName, pauseTag, client)
+	_, err = getPauseContainerImage(pauseName, pauseTag, client)
 	assert.Error(t, err)
 }
 
-func TestValidatePauseContainerHappyPath(t *testing.T) {
+func TestGetPauseContainerHappyPath(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -131,6 +131,6 @@ func TestValidatePauseContainerHappyPath(t *testing.T) {
 
 	mockDocker.EXPECT().InspectImage(pauseName+":"+pauseTag).Return(nil, nil)
 
-	err = validatePauseContainerImage(pauseName, pauseTag, client)
+	_, err = getPauseContainerImage(pauseName, pauseTag, client)
 	assert.NoError(t, err)
 }

--- a/agent/eni/pause/pause_linux_test.go
+++ b/agent/eni/pause/pause_linux_test.go
@@ -29,8 +29,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// Test _load with reader error
-func TestLoadWithReaderError(t *testing.T) {
+// TestLoadFromFileWithReaderError tests loadFromFile with reader error
+func TestLoadFromFileWithReaderError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -45,12 +45,12 @@ func TestLoadWithReaderError(t *testing.T) {
 	mockfs := mock_os.NewMockFileSystem(ctrl)
 	mockfs.EXPECT().Open(gomock.Any()).Return(nil, errors.New("Dummy Reader Error"))
 
-	err := _load(&conf, client, mockfs)
+	err := loadFromFile(&conf, client, mockfs)
 	assert.Error(t, err)
 }
 
-// Test _load against happy path
-func TestLoadHappyPath(t *testing.T) {
+// TestLoadFromFileHappyPath tests loadFromFile against happy path
+func TestLoadFromFileHappyPath(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -66,12 +66,13 @@ func TestLoadHappyPath(t *testing.T) {
 	mockfs := mock_os.NewMockFileSystem(ctrl)
 	mockfs.EXPECT().Open(gomock.Any()).Return(nil, nil)
 
-	err := _load(&conf, client, mockfs)
+	err := loadFromFile(&conf, client, mockfs)
 	assert.NoError(t, err)
 }
 
-// Test _load against error
-func TestLoadError(t *testing.T) {
+// TestLoadFromFileDockerLoadImageError tests loadFromFile against error
+// from Docker clients LoadImage
+func TestLoadFromFileDockerLoadImageError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -82,11 +83,12 @@ func TestLoadError(t *testing.T) {
 	factory := mock_dockerclient.NewMockFactory(ctrl)
 	factory.EXPECT().GetDefaultClient().AnyTimes().Return(mockDocker, nil)
 	client, _ := engine.NewDockerGoClient(factory, &conf)
-	mockDocker.EXPECT().LoadImage(gomock.Any()).Return(errors.New("Dummy Load Image Error"))
+	mockDocker.EXPECT().LoadImage(gomock.Any()).Return(
+		errors.New("Dummy Load Image Error"))
 
 	mockfs := mock_os.NewMockFileSystem(ctrl)
 	mockfs.EXPECT().Open(gomock.Any()).Return(nil, nil)
 
-	err := _load(&conf, client, mockfs)
+	err := loadFromFile(&conf, client, mockfs)
 	assert.Error(t, err)
 }

--- a/agent/eni/pause/pause_unsupported.go
+++ b/agent/eni/pause/pause_unsupported.go
@@ -20,12 +20,13 @@ import (
 
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/engine"
+	docker "github.com/fsouza/go-dockerclient"
 	"github.com/pkg/errors"
 )
 
 // LoadImage returns UnsupportedPlatformError on the unsupported platform
-func LoadImage(cfg *config.Config, dockerClient engine.DockerClient) error {
-	return UnsupportedPlatformError{errors.Errorf(
+func LoadImage(cfg *config.Config, dockerClient engine.DockerClient) (*docker.Image, error) {
+	return nil, UnsupportedPlatformError{errors.Errorf(
 		"pause container load: unsupported platform: %s/%s",
 		runtime.GOOS, runtime.GOARCH)}
 }

--- a/agent/eni/pause/pause_unsupported.go
+++ b/agent/eni/pause/pause_unsupported.go
@@ -1,0 +1,30 @@
+// +build !linux
+
+// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package pause
+
+import (
+	"runtime"
+
+	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/engine"
+
+	log "github.com/cihub/seelog"
+)
+
+func Load(cfg *config.Config, dockerClient engine.DockerClient) error {
+	log.Infof("pause container load: unsupported platform: %s/%s", runtime.GOOS, runtime.GOARCH)
+	return nil
+}

--- a/agent/eni/statemanager/mocks/mock_statemanager_linux.go
+++ b/agent/eni/statemanager/mocks/mock_statemanager_linux.go
@@ -18,7 +18,7 @@ package mock_statemanager
 
 import (
 	gomock "github.com/golang/mock/gomock"
-	netlink "github.com/vishvananda/netlink"
+	"github.com/vishvananda/netlink"
 )
 
 // Mock of StateManager interface

--- a/agent/eni/udevwrapper/mocks/mock_udevwrapper_linux.go
+++ b/agent/eni/udevwrapper/mocks/mock_udevwrapper_linux.go
@@ -17,7 +17,7 @@
 package mock_udevwrapper
 
 import (
-	udev "github.com/deniswernert/udev"
+	"github.com/deniswernert/udev"
 	gomock "github.com/golang/mock/gomock"
 )
 

--- a/scripts/build
+++ b/scripts/build
@@ -48,7 +48,7 @@ fi
 
 cd "${ROOT}"
 if [[ "${static}" == "true" ]]; then
-	CGO_ENABLED=0 go build -installsuffix cgo -a -ldflags "-s" -o $build_exe ./agent/
+	CGO_ENABLED=0 go build -installsuffix cgo -a -ldflags "${LDFLAGS} -s" -o $build_exe ./agent/
 else
 	go build -o $build_exe ./agent/
 fi

--- a/scripts/generate/mockgen_engine.sh
+++ b/scripts/generate/mockgen_engine.sh
@@ -18,7 +18,7 @@
 mockgen.sh github.com/aws/amazon-ecs-agent/agent/engine TaskEngine,DockerClient,ImageManager mocks/engine_mocks.go
 
 sed -e "s/engine\.//g" \
-	-e 's|\sengine "github.com/aws/amazon-ecs-agent/agent/engine"|REMOVETHISLINE|' \
+	-e 's|\s*engine "github.com/aws/amazon-ecs-agent/agent/engine"|REMOVETHISLINE|' \
 	-e "s/mock_engine/engine/" \
 	-e '/REMOVETHISLINE/d' \
 	mocks/engine_mocks.go > engine_mocks.go


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Update the Agent to load pause container on startup

### Implementation details
<!-- How are the changes implemented? -->
The `agent/eni/pause.LoadImage` method is invoked in `_main()` to load the pause container image (It returns an "unsupported platform error" for non linux platforms)

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [X] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [X] Unit tests on Linux (`make test`) pass
- [X] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass
- [X] Manual Testing: Verified that 'pause' container is loaded on Agent start up:
```
$ ./run-agent.sh
....
2017-06-13T23:09:01Z [DEBUG] Loading pause container tarball: /images/amazon-ecs-pause.tar
2017-06-13T23:09:02Z [DEBUG] Inspecting pause container image: amazon/amazon-ecs-pause:0.1.0
2017-06-13T23:09:02Z [INFO] Successfully loaded pause container image....
```
New tests cover the changes: Yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
None
### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: Yes
