### PR TITLE
Add test for submit eni state change and handle timeout of eni attachment

### DIFF
--- a/agent/acs/handler/attach_eni_handler_test.go
+++ b/agent/acs/handler/attach_eni_handler_test.go
@@ -376,9 +376,12 @@ func TestENIAckTimeout(t *testing.T) {
 
 	eniAttachHandler.addENIAttachmentToState(message)
 	assert.Len(t, taskEngineState.(*dockerstate.DockerTaskEngineState).AllENIAttachments(), 1)
-	time.Sleep(time.Millisecond * waitTimeout * 2)
-
-	assert.Len(t, taskEngineState.(*dockerstate.DockerTaskEngineState).AllENIAttachments(), 0)
+	for {
+		time.Sleep(time.Millisecond * waitTimeout)
+		if len(taskEngineState.(*dockerstate.DockerTaskEngineState).AllENIAttachments()) == 0 {
+			break
+		}
+	}
 }
 
 // TestENIAckWithinTimeout tests the eni state change was reported before the timeout

--- a/agent/api/ecsclient/client.go
+++ b/agent/api/ecsclient/client.go
@@ -303,7 +303,7 @@ func (client *APIECSClient) SubmitTaskStateChange(change api.TaskStateChange) er
 			Attachments: attachments,
 		})
 		if err != nil {
-			log.Warn("Could not submit an attachment state change", "err", err)
+			log.Warn("Could not submit an attachment state change", "err", err, "statechange", change)
 			return err
 		}
 
@@ -324,10 +324,10 @@ func (client *APIECSClient) SubmitTaskStateChange(change api.TaskStateChange) er
 
 	taskStatus := change.Status.String()
 	_, err := client.submitStateChangeClient.SubmitTaskStateChange(&ecs.SubmitTaskStateChangeInput{
-		Cluster: &client.config.Cluster,
-		Task:    &change.TaskArn,
-		Status:  &taskStatus,
-		Reason:  &change.Reason,
+		Cluster: aws.String(client.config.Cluster),
+		Task:    aws.String(change.TaskArn),
+		Status:  aws.String(taskStatus),
+		Reason:  aws.String(change.Reason),
 	})
 	if err != nil {
 		log.Warn("Could not submit a task state change", "err", err)

--- a/agent/api/ecsclient/client.go
+++ b/agent/api/ecsclient/client.go
@@ -285,6 +285,32 @@ func (client *APIECSClient) getCustomAttributes() []*ecs.Attribute {
 }
 
 func (client *APIECSClient) SubmitTaskStateChange(change api.TaskStateChange) error {
+	// Submit attachment state change
+	if change.Attachments != nil {
+		var attachments []*ecs.AttachmentStateChange
+
+		eniStatus := change.Attachments.Status.String()
+		attachments = []*ecs.AttachmentStateChange{
+			{
+				AttachmentArn: &change.Attachments.AttachmentArn,
+				Status:        &eniStatus,
+			},
+		}
+
+		_, err := client.submitStateChangeClient.SubmitTaskStateChange(&ecs.SubmitTaskStateChangeInput{
+			Cluster:     &client.config.Cluster,
+			Task:        &change.TaskArn,
+			Attachments: attachments,
+		})
+		if err != nil {
+			log.Warn("Could not submit an attachment state change", "err", err)
+			return err
+		}
+
+		return nil
+	}
+
+	// Submit task state change
 	if change.Status == api.TaskStatusNone {
 		log.Warn("SubmitTaskStateChange called with an invalid change", "change", change)
 		return errors.New("SubmitTaskStateChange called with an invalid change")
@@ -296,25 +322,12 @@ func (client *APIECSClient) SubmitTaskStateChange(change api.TaskStateChange) er
 		return nil
 	}
 
-	var attachments []*ecs.AttachmentStateChange
-
-	if change.Attachments != nil {
-		eniStatus := change.Attachments.Status.String()
-		attachments = []*ecs.AttachmentStateChange{
-			{
-				AttachmentArn: &change.Attachments.AttachmentArn,
-				Status:        &eniStatus,
-			},
-		}
-	}
-
 	taskStatus := change.Status.String()
 	_, err := client.submitStateChangeClient.SubmitTaskStateChange(&ecs.SubmitTaskStateChangeInput{
-		Cluster:     &client.config.Cluster,
-		Task:        &change.TaskArn,
-		Status:      &taskStatus,
-		Reason:      &change.Reason,
-		Attachments: attachments,
+		Cluster: &client.config.Cluster,
+		Task:    &change.TaskArn,
+		Status:  &taskStatus,
+		Reason:  &change.Reason,
 	})
 	if err != nil {
 		log.Warn("Could not submit a task state change", "err", err)

--- a/agent/api/eni.go
+++ b/agent/api/eni.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 
 	"github.com/aws/amazon-ecs-agent/agent/acs/model/ecsacs"
+	"github.com/aws/amazon-ecs-agent/agent/utils/ttime"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/pkg/errors"
 )
@@ -34,6 +35,7 @@ type ENIAttachment struct {
 	// Status is the status of the eni: none/attached/detached
 	Status         ENIAttachmentStatus `json:"status"`
 	sentStatusLock sync.RWMutex
+	AckTimer       ttime.Timer
 }
 
 // ENI contains information of the eni
@@ -121,8 +123,8 @@ func ValidateTaskENI(acsenis []*ecsacs.ElasticNetworkInterface) error {
 	return nil
 }
 
-// GetSentStatus checks if the eni attached status has been sent
-func (eni *ENIAttachment) GetSentStatus() bool {
+// IsSent checks if the eni attached status has been sent
+func (eni *ENIAttachment) IsSent() bool {
 	eni.sentStatusLock.RLock()
 	defer eni.sentStatusLock.RUnlock()
 
@@ -135,4 +137,9 @@ func (eni *ENIAttachment) SetSentStatus() {
 	defer eni.sentStatusLock.Unlock()
 
 	eni.AttachStatusSent = true
+}
+
+// StopAckTimer stops the ack timer set on the ENI attachment
+func (eni *ENIAttachment) StopAckTimer() {
+	eni.AckTimer.Stop()
 }

--- a/agent/eni/statemanager/statemanager_linux.go
+++ b/agent/eni/statemanager/statemanager_linux.go
@@ -66,7 +66,7 @@ func (statemanager *stateManager) ENIStateChangeShouldBeSent(macAddress string) 
 		return nil, false
 	}
 
-	if eni.GetSentStatus() {
+	if eni.IsSent() {
 		log.Infof("ENI state manager: eni attach status has already sent: %s", macAddress)
 		return eni, false
 	}

--- a/agent/eni/watcher_linux_test.go
+++ b/agent/eni/watcher_linux_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"sync"
 	"testing"
 
 	"github.com/deniswernert/udev"
@@ -75,10 +76,16 @@ func TestWatcherInit(t *testing.T) {
 		}, nil),
 	)
 
+	wait := sync.WaitGroup{}
+	wait.Add(1)
 	var event statechange.Event
-	go func() { event = <-eventChannel }()
+	go func() {
+		event = <-eventChannel
+		wait.Done()
+	}()
 	watcher.Init()
 
+	wait.Wait()
 	assert.NotNil(t, event.(api.TaskStateChange).Attachments)
 	assert.Equal(t, randomMAC, event.(api.TaskStateChange).Attachments.MacAddress)
 

--- a/agent/eventhandler/handler_test.go
+++ b/agent/eventhandler/handler_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/api/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/statechange"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
+	"github.com/aws/amazon-ecs-agent/agent/utils/ttime/mocks"
 	"github.com/golang/mock/gomock"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -242,6 +243,7 @@ func TestENISentStatusChange(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	client := mock_api.NewMockECSClient(ctrl)
+	timer := mock_ttime.NewMockTimer(ctrl)
 
 	task := &api.Task{
 		Arn: "taskarn",
@@ -250,6 +252,7 @@ func TestENISentStatusChange(t *testing.T) {
 	eniAttachment := &api.ENIAttachment{
 		TaskArn:          "taskarn",
 		AttachStatusSent: false,
+		AckTimer:         timer,
 	}
 
 	sendableTaskEvent := newSendableTaskEvent(api.TaskStateChange{
@@ -260,6 +263,7 @@ func TestENISentStatusChange(t *testing.T) {
 	})
 
 	client.EXPECT().SubmitTaskStateChange(gomock.Any()).Return(nil)
+	timer.EXPECT().Stop()
 
 	events := list.New()
 	events.PushBack(sendableTaskEvent)

--- a/agent/eventhandler/task_handler.go
+++ b/agent/eventhandler/task_handler.go
@@ -181,6 +181,7 @@ func (handler *TaskHandler) SubmitTaskEvents(taskEvents *eventList, client api.E
 					}
 					if event.taskChange.Attachments != nil {
 						event.taskChange.Attachments.SetSentStatus()
+						event.taskChange.Attachments.StopAckTimer()
 					}
 					statesaver.Save()
 					seelog.Debug("TaskHandler, Submitted task state change: ", event.taskChange)

--- a/agent/eventhandler/task_handler.go
+++ b/agent/eventhandler/task_handler.go
@@ -183,7 +183,7 @@ func (handler *TaskHandler) SubmitTaskEvents(taskEvents *eventList, client api.E
 						event.taskChange.Attachments.SetSentStatus()
 					}
 					statesaver.Save()
-					seelog.Debug("TaskHandler, Submitted task state change")
+					seelog.Debug("TaskHandler, Submitted task state change: ", event.taskChange)
 					backoff.Reset()
 					taskEvents.events.Remove(eventToSubmit)
 				} else {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
* Added test for submit eni attachment state change.
* Handle timeout for eni attachment.
### Implementation details
<!-- How are the changes implemented? -->
Added timer when received eni attachment message.
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->
yes
### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
yes