### PR TITLE
Preserve internal Docker images from deletion

### DIFF
--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -285,8 +285,6 @@ func TestTaskWithSteadyStateResourcesProvisioned(t *testing.T) {
 	imageManager.EXPECT().RecordContainerReference(sleepContainer).Return(nil)
 	imageManager.EXPECT().GetImageStateFromImageName(sleepContainer.Image).Return(nil)
 	client.EXPECT().PullImage(pauseContainer.Image, nil).Return(DockerContainerMetadata{})
-	imageManager.EXPECT().RecordContainerReference(pauseContainer).Return(nil)
-	imageManager.EXPECT().GetImageStateFromImageName(pauseContainer.Image).Return(nil)
 
 	gomock.InOrder(
 		// Ensure that the pause container is created first
@@ -1400,8 +1398,6 @@ func TestPauseContaienrHappyPath(t *testing.T) {
 	// Pause container will be launched first
 	gomock.InOrder(
 		dockerClient.EXPECT().PullImage(pauseContainerImage, nil).Return(DockerContainerMetadata{}),
-		imageManager.EXPECT().RecordContainerReference(gomock.Any()).Return(nil),
-		imageManager.EXPECT().GetImageStateFromImageName(pauseContainerImage).Return(nil),
 		dockerClient.EXPECT().CreateContainer(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(DockerContainerMetadata{DockerID: "pauseContainerID"}),
 		dockerClient.EXPECT().StartContainer(pauseContainerID, startContainerTimeout).Return(DockerContainerMetadata{DockerID: "pauseContainerID"}),
 		dockerClient.EXPECT().InspectContainer(gomock.Any(), gomock.Any()).Return(&docker.Container{
@@ -1445,7 +1441,7 @@ func TestPauseContaienrHappyPath(t *testing.T) {
 	cniClient.EXPECT().CleanupNS(gomock.Any()).Return(nil)
 	dockerClient.EXPECT().StopContainer(pauseContainerID, gomock.Any()).Return(DockerContainerMetadata{DockerID: pauseContainerID})
 	dockerClient.EXPECT().RemoveContainer(gomock.Any(), gomock.Any()).Return(nil).Times(2)
-	imageManager.EXPECT().RemoveContainerReferenceFromImageState(gomock.Any()).Return(nil).Times(2)
+	imageManager.EXPECT().RemoveContainerReferenceFromImageState(gomock.Any()).Return(nil)
 
 	exitCode := 0
 	eventStream <- DockerContainerChangeEvent{
@@ -1550,7 +1546,7 @@ func TestStopPauseContainerCleanupCalled(t *testing.T) {
 	testTask.Containers = append(testTask.Containers, pauseContainer)
 
 	testTask.SetTaskENI(&api.ENI{
-		ID: "TestTaskWithSteadyStateResourcesProvisioned",
+		ID: "TestStopPauseContainerCleanupCalled",
 		IPV4Addresses: []*api.ENIIPV4Address{
 			{
 				Primary: true,

--- a/agent/eni/pause/error.go
+++ b/agent/eni/pause/error.go
@@ -13,6 +13,9 @@
 
 package pause
 
+// https://golang.org/src/syscall/zerrors_linux_386.go#L1382
+const noSuchFile = "no such file or directory"
+
 // UnsupportedPlatformError indicates an error when loading pause container
 // image on an unsupported OS platform
 type UnsupportedPlatformError struct {
@@ -23,5 +26,14 @@ type UnsupportedPlatformError struct {
 // type
 func UnsupportedPlatform(err error) bool {
 	_, ok := err.(UnsupportedPlatformError)
+	return ok
+}
+
+type NoSuchFileError struct {
+	error
+}
+
+func IsNoSuchFileError(err error) bool {
+	_, ok := err.(NoSuchFileError)
 	return ok
 }

--- a/agent/eni/pause/error_test.go
+++ b/agent/eni/pause/error_test.go
@@ -34,3 +34,16 @@ func TestUnsupportedPlatform(t *testing.T) {
 		})
 	}
 }
+
+func TestIsNoSuchFileError(t *testing.T) {
+	testCases := map[error]bool{
+		errors.New("error"):                         false,
+		NoSuchFileError{errors.New("No such file")}: true,
+	}
+
+	for err, expected := range testCases {
+		t.Run(fmt.Sprintf("return %t for type %s", expected, reflect.TypeOf(err)), func(t *testing.T) {
+			assert.Equal(t, expected, IsNoSuchFileError(err))
+		})
+	}
+}

--- a/agent/eni/pause/pause_linux.go
+++ b/agent/eni/pause/pause_linux.go
@@ -41,6 +41,10 @@ func LoadImage(cfg *config.Config, dockerClient engine.DockerClient) (*docker.Im
 func loadFromFile(path string, dockerClient engine.DockerClient, fs os.FileSystem) error {
 	pauseContainerReader, err := fs.Open(path)
 	if err != nil {
+		if err.Error() == noSuchFile {
+			return NoSuchFileError{errors.Wrapf(err,
+				"pause container load: failed to read pause container image: %s", path)}
+		}
 		return errors.Wrapf(err,
 			"pause container load: failed to read pause container image: %s", path)
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Preserve the internal container images from being cleaned up by the agent.

### Implementation details
<!-- How are the changes implemented? -->
Check whether the container is internal when try to add the image state into the image manager.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->
yes
### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
yes