### PR TITLE
CNIPlugins Packaging: Adding CNIPlugins to agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ _bin/
 .DS_Store
 /misc/windows-iam/devcon*
 /misc/pause-container/pause
+/amazon-ecs-cni-plugins

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,10 @@ PAUSE_CONTAINER_TARBALL = "amazon-ecs-pause.tar"
 # Variable to determine branch/tag of amazon-ecs-cni-plugins
 ECS_CNI_REPOSITORY_REVISION=master
 
+# Variable to override cni repository location
+ECS_CNI_REPOSITORY_SRC_DIR=$(shell pwd)/amazon-ecs-cni-plugins
+
+
 .PHONY: all gobuild static docker release certs test clean netkitten test-registry run-functional-tests gremlin benchmark-test gogenerate run-integ-tests image-cleanup-test-images pause-container get-cni-sources cni-plugins
 
 all: docker
@@ -122,7 +126,7 @@ cni-plugins:
 	@docker build -f scripts/dockerfiles/Dockerfile.buildCNIPlugins -t "amazon/amazon-ecs-build-cniplugins:make" .
 	@docker run --rm --net=none \
 		-v "$(shell pwd)/out/cni-plugins:/go/src/github.com/aws/amazon-ecs-cni-plugins/bin/plugins" \
-		-v "$(shell pwd)/amazon-ecs-cni-plugins:/go/src/github.com/aws/amazon-ecs-cni-plugins" \
+		-v "$(ECS_CNI_REPOSITORY_SRC_DIR):/go/src/github.com/aws/amazon-ecs-cni-plugins" \
 		"amazon/amazon-ecs-build-cniplugins:make"
 
 	@echo "Built amazon-ecs-cni-plugins successfully."

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ build-in-docker:
 
 # 'docker' builds the agent dockerfile from the current sourcecode tree, dirty
 # or not
-docker: certs build-in-docker pause-container-release
+docker: certs build-in-docker pause-container-release cni-plugins
 	@cd scripts && ./create-amazon-ecs-scratch
 	@docker build -f scripts/dockerfiles/Dockerfile.release -t "amazon/amazon-ecs-agent:make" .
 	@echo "Built Docker image \"amazon/amazon-ecs-agent:make\""
@@ -158,7 +158,7 @@ fluentd:
 image-cleanup-test-images:
 	cd misc/image-cleanup-test-images; $(MAKE) $(MFLAGS)
 
-get-deps:
+get-deps: get-cni-sources
 	go get github.com/tools/godep
 	go get golang.org/x/tools/cmd/cover
 	go get github.com/golang/mock/mockgen

--- a/scripts/create-amazon-ecs-scratch
+++ b/scripts/create-amazon-ecs-scratch
@@ -10,9 +10,9 @@
 mkdir amazon-ecs-scratch # include other directories that are needed here
 mkdir amazon-ecs-scratch/tmp
 mkdir amazon-ecs-scratch/images
-mkdir amazon-ecs-scratch/cni-plugins
+mkdir amazon-ecs-scratch/amazon-ecs-cni-plugins
 
 cd amazon-ecs-scratch
 tar -cv . | docker import - "amazon/amazon-ecs-scratch:make"
 cd ..
-rmdir amazon-ecs-scratch/tmp amazon-ecs-scratch/images amazon-ecs-scratch/cni-plugins amazon-ecs-scratch
+rmdir amazon-ecs-scratch/tmp amazon-ecs-scratch/images amazon-ecs-scratch/amazon-ecs-cni-plugins amazon-ecs-scratch

--- a/scripts/create-amazon-ecs-scratch
+++ b/scripts/create-amazon-ecs-scratch
@@ -10,8 +10,9 @@
 mkdir amazon-ecs-scratch # include other directories that are needed here
 mkdir amazon-ecs-scratch/tmp
 mkdir amazon-ecs-scratch/images
+mkdir amazon-ecs-scratch/cni-plugins
 
 cd amazon-ecs-scratch
 tar -cv . | docker import - "amazon/amazon-ecs-scratch:make"
 cd ..
-rmdir amazon-ecs-scratch/tmp amazon-ecs-scratch/images amazon-ecs-scratch
+rmdir amazon-ecs-scratch/tmp amazon-ecs-scratch/images amazon-ecs-scratch/cni-plugins amazon-ecs-scratch

--- a/scripts/dockerfiles/Dockerfile.buildCNIPlugins
+++ b/scripts/dockerfiles/Dockerfile.buildCNIPlugins
@@ -1,0 +1,21 @@
+# Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+FROM golang:1.7
+MAINTAINER Amazon Web Services, Inc.
+
+RUN mkdir -p /go/src/github.com/aws/
+
+WORKDIR /go/src/github.com/aws/amazon-ecs-cni-plugins
+
+CMD ["make", "plugins"]

--- a/scripts/dockerfiles/Dockerfile.buildCNIPlugins
+++ b/scripts/dockerfiles/Dockerfile.buildCNIPlugins
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may
 # not use this file except in compliance with the License. A copy of the

--- a/scripts/dockerfiles/Dockerfile.release
+++ b/scripts/dockerfiles/Dockerfile.release
@@ -1,4 +1,4 @@
-# Copyright 2014-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may
 # not use this file except in compliance with the License. A copy of the

--- a/scripts/dockerfiles/Dockerfile.release
+++ b/scripts/dockerfiles/Dockerfile.release
@@ -21,7 +21,7 @@ COPY ["LICENSE", "NOTICE", "/"]
 COPY out/amazon-ecs-pause.tar /images/amazon-ecs-pause.tar
 
 # Copy our cni plugins ecs-eni, ecs-ipam and ecs-bridge
-COPY out/cni-plugins /cni-plugins
+COPY out/cni-plugins /amazon-ecs-cni-plugins
 
 # Copy our bundled certs to the first place go will check: see
 # https://golang.org/src/pkg/crypto/x509/root_unix.go

--- a/scripts/dockerfiles/Dockerfile.release
+++ b/scripts/dockerfiles/Dockerfile.release
@@ -20,6 +20,9 @@ COPY ["LICENSE", "NOTICE", "/"]
 
 COPY out/amazon-ecs-pause.tar /images/amazon-ecs-pause.tar
 
+# Copy our cni plugins ecs-eni, ecs-ipam and ecs-bridge
+COPY out/cni-plugins /cni-plugins
+
 # Copy our bundled certs to the first place go will check: see
 # https://golang.org/src/pkg/crypto/x509/root_unix.go
 COPY misc/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt


### PR DESCRIPTION
Signed-off-by: Vinothkumar Siddharth <sidvin@amazon.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Packaging ecs-cni plugins for amazon/amazon-ecs-agent

### Implementation details

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no --> No

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
* Packaging cni plugins for amazon/amazon-ecs-agent

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes --> 
YES
