### PR TITLE
Replace ec2metadata with the official one from aws-sdk-go

### DIFF
--- a/agent/api/ecsclient/client.go
+++ b/agent/api/ecsclient/client.go
@@ -149,26 +149,24 @@ func (client *APIECSClient) registerContainerInstance(clusterRef string, contain
 		registrationAttributes = append(registrationAttributes, attribute)
 	}
 	registerRequest.Attributes = registrationAttributes
-	instanceIdentityDoc, err := client.ec2metadata.ReadResource(ec2.INSTANCE_IDENTITY_DOCUMENT_RESOURCE)
+	instanceIdentityDoc, err := client.ec2metadata.GetDynamicData(ec2.InstanceIdentityDocumentResource)
 	iidRetrieved := true
 	if err != nil {
 		log.Error("Unable to get instance identity document", "err", err)
 		iidRetrieved = false
-		instanceIdentityDoc = []byte{}
+		instanceIdentityDoc = ""
 	}
-	strIid := string(instanceIdentityDoc)
-	registerRequest.InstanceIdentityDocument = &strIid
+	registerRequest.InstanceIdentityDocument = &instanceIdentityDoc
 
-	instanceIdentitySignature := []byte{}
+	instanceIdentitySignature := ""
 	if iidRetrieved {
-		instanceIdentitySignature, err = client.ec2metadata.ReadResource(ec2.INSTANCE_IDENTITY_DOCUMENT_SIGNATURE_RESOURCE)
+		instanceIdentitySignature, err = client.ec2metadata.GetDynamicData(ec2.InstanceIdentityDocumentSignatureResource)
 		if err != nil {
 			log.Error("Unable to get instance identity signature", "err", err)
 		}
 	}
 
-	strIidSig := string(instanceIdentitySignature)
-	registerRequest.InstanceIdentityDocumentSignature = &strIidSig
+	registerRequest.InstanceIdentityDocumentSignature = &instanceIdentitySignature
 
 	// Micro-optimization, the pointer to this is used multiple times below
 	integerStr := "INTEGER"

--- a/agent/api/ecsclient/client_test.go
+++ b/agent/api/ecsclient/client_test.go
@@ -264,8 +264,8 @@ func TestReRegisterContainerInstance(t *testing.T) {
 		expectedAttributes[capabilities[i]] = ""
 	}
 
-	mockEC2Metadata.EXPECT().ReadResource(ec2.INSTANCE_IDENTITY_DOCUMENT_RESOURCE).Return([]byte("instanceIdentityDocument"), nil)
-	mockEC2Metadata.EXPECT().ReadResource(ec2.INSTANCE_IDENTITY_DOCUMENT_SIGNATURE_RESOURCE).Return([]byte("signature"), nil)
+	mockEC2Metadata.EXPECT().GetDynamicData(ec2.InstanceIdentityDocumentResource).Return("instanceIdentityDocument", nil)
+	mockEC2Metadata.EXPECT().GetDynamicData(ec2.InstanceIdentityDocumentSignatureResource).Return("signature", nil)
 	mc.EXPECT().RegisterContainerInstance(gomock.Any()).Do(func(req *ecs.RegisterContainerInstanceInput) {
 		assert.Equal(t, "arn:test", *req.ContainerInstanceArn, "Wrong container instance ARN")
 		assert.Equal(t, configuredCluster, *req.Cluster, "Wrong cluster")
@@ -319,8 +319,8 @@ func TestRegisterContainerInstance(t *testing.T) {
 		"my_other_custom_attribute": "Custom_Value2",
 	}
 
-	mockEC2Metadata.EXPECT().ReadResource(ec2.INSTANCE_IDENTITY_DOCUMENT_RESOURCE).Return([]byte("instanceIdentityDocument"), nil)
-	mockEC2Metadata.EXPECT().ReadResource(ec2.INSTANCE_IDENTITY_DOCUMENT_SIGNATURE_RESOURCE).Return([]byte("signature"), nil)
+	mockEC2Metadata.EXPECT().GetDynamicData(ec2.InstanceIdentityDocumentResource).Return("instanceIdentityDocument", nil)
+	mockEC2Metadata.EXPECT().GetDynamicData(ec2.InstanceIdentityDocumentSignatureResource).Return("signature", nil)
 	mc.EXPECT().RegisterContainerInstance(gomock.Any()).Do(func(req *ecs.RegisterContainerInstanceInput) {
 		assert.Nil(t, req.ContainerInstanceArn)
 		assert.Equal(t, configuredCluster, *req.Cluster, "Wrong cluster")
@@ -390,12 +390,12 @@ func TestRegisterBlankCluster(t *testing.T) {
 	}
 	defaultCluster := config.DefaultClusterName
 	gomock.InOrder(
-		mockEC2Metadata.EXPECT().ReadResource(ec2.INSTANCE_IDENTITY_DOCUMENT_RESOURCE).Return([]byte("instanceIdentityDocument"), nil),
-		mockEC2Metadata.EXPECT().ReadResource(ec2.INSTANCE_IDENTITY_DOCUMENT_SIGNATURE_RESOURCE).Return([]byte("signature"), nil),
+		mockEC2Metadata.EXPECT().GetDynamicData(ec2.InstanceIdentityDocumentResource).Return("instanceIdentityDocument", nil),
+		mockEC2Metadata.EXPECT().GetDynamicData(ec2.InstanceIdentityDocumentSignatureResource).Return("signature", nil),
 		mc.EXPECT().RegisterContainerInstance(gomock.Any()).Return(nil, awserr.New("ClientException", "No such cluster", errors.New("No such cluster"))),
 		mc.EXPECT().CreateCluster(&ecs.CreateClusterInput{ClusterName: &defaultCluster}).Return(&ecs.CreateClusterOutput{Cluster: &ecs.Cluster{ClusterName: &defaultCluster}}, nil),
-		mockEC2Metadata.EXPECT().ReadResource(ec2.INSTANCE_IDENTITY_DOCUMENT_RESOURCE).Return([]byte("instanceIdentityDocument"), nil),
-		mockEC2Metadata.EXPECT().ReadResource(ec2.INSTANCE_IDENTITY_DOCUMENT_SIGNATURE_RESOURCE).Return([]byte("signature"), nil),
+		mockEC2Metadata.EXPECT().GetDynamicData(ec2.InstanceIdentityDocumentResource).Return("instanceIdentityDocument", nil),
+		mockEC2Metadata.EXPECT().GetDynamicData(ec2.InstanceIdentityDocumentSignatureResource).Return("signature", nil),
 		mc.EXPECT().RegisterContainerInstance(gomock.Any()).Do(func(req *ecs.RegisterContainerInstanceInput) {
 			if *req.Cluster != config.DefaultClusterName {
 				t.Errorf("Wrong cluster: %v", *req.Cluster)

--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -279,7 +279,7 @@ func (agent *ecsAgent) getEC2InstanceID() string {
 			"Unable to access EC2 Metadata service to determine EC2 ID: %v", err)
 		return ""
 	}
-	return instanceIdentityDoc.InstanceId
+	return instanceIdentityDoc.InstanceID
 }
 
 // newStateManager creates a new state manager object for the task engine.

--- a/agent/app/agent_test.go
+++ b/agent/app/agent_test.go
@@ -26,7 +26,6 @@ import (
 	app_mocks "github.com/aws/amazon-ecs-agent/agent/app/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/credentials/mocks"
-	"github.com/aws/amazon-ecs-agent/agent/ec2"
 	"github.com/aws/amazon-ecs-agent/agent/ec2/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/engine"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate/mocks"
@@ -38,6 +37,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	aws_credentials "github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 )
@@ -108,8 +108,8 @@ func TestDoStartNewStateManagerError(t *testing.T) {
 
 	ec2MetadataClient := mock_ec2.NewMockEC2MetadataClient(ctrl)
 	expectedInstanceID := "inst-1"
-	iid := &ec2.InstanceIdentityDocument{
-		InstanceId: expectedInstanceID,
+	iid := ec2metadata.EC2InstanceIdentityDocument{
+		InstanceID: expectedInstanceID,
 		Region:     "us-west-2",
 	}
 	gomock.InOrder(
@@ -214,8 +214,8 @@ func TestNewTaskEngineRestoreFromCheckpointNoEC2InstanceIDToLoadHappyPath(t *tes
 	cfg := config.DefaultConfig()
 	cfg.Checkpoint = true
 	expectedInstanceID := "inst-1"
-	iid := &ec2.InstanceIdentityDocument{
-		InstanceId: expectedInstanceID,
+	iid := ec2metadata.EC2InstanceIdentityDocument{
+		InstanceID: expectedInstanceID,
 		Region:     "us-west-2",
 	}
 	gomock.InOrder(
@@ -262,8 +262,8 @@ func TestNewTaskEngineRestoreFromCheckpointPreviousEC2InstanceIDLoadedHappyPath(
 	cfg := config.DefaultConfig()
 	cfg.Checkpoint = true
 	expectedInstanceID := "inst-1"
-	iid := &ec2.InstanceIdentityDocument{
-		InstanceId: expectedInstanceID,
+	iid := ec2metadata.EC2InstanceIdentityDocument{
+		InstanceID: expectedInstanceID,
 		Region:     "us-west-2",
 	}
 
@@ -317,8 +317,8 @@ func TestNewTaskEngineRestoreFromCheckpointClusterIDMismatch(t *testing.T) {
 	cfg.Checkpoint = true
 	cfg.Cluster = "default"
 	ec2InstanceID := "inst-1"
-	iid := &ec2.InstanceIdentityDocument{
-		InstanceId: ec2InstanceID,
+	iid := ec2metadata.EC2InstanceIdentityDocument{
+		InstanceID: ec2InstanceID,
 		Region:     "us-west-2",
 	}
 
@@ -440,8 +440,8 @@ func TestNewTaskEngineRestoreFromCheckpoint(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.Checkpoint = true
 	expectedInstanceID := "inst-1"
-	iid := &ec2.InstanceIdentityDocument{
-		InstanceId: expectedInstanceID,
+	iid := ec2metadata.EC2InstanceIdentityDocument{
+		InstanceID: expectedInstanceID,
 		Region:     "us-west-2",
 	}
 	gomock.InOrder(
@@ -501,7 +501,7 @@ func TestGetEC2InstanceIDIIDError(t *testing.T) {
 	ec2MetadataClient := mock_ec2.NewMockEC2MetadataClient(ctrl)
 	agent := &ecsAgent{ec2MetadataClient: ec2MetadataClient}
 
-	ec2MetadataClient.EXPECT().InstanceIdentityDocument().Return(nil, errors.New("error"))
+	ec2MetadataClient.EXPECT().InstanceIdentityDocument().Return(ec2metadata.EC2InstanceIdentityDocument{}, errors.New("error"))
 	assert.Equal(t, "", agent.getEC2InstanceID())
 }
 

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/ec2"
 	"github.com/aws/amazon-ecs-agent/agent/ec2/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerclient"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -50,7 +51,7 @@ func TestBrokenEC2Metadata(t *testing.T) {
 	os.Clearenv()
 	ctrl := gomock.NewController(t)
 	mockEc2Metadata := mock_ec2.NewMockEC2MetadataClient(ctrl)
-	mockEc2Metadata.EXPECT().InstanceIdentityDocument().Return(nil, errors.New("err"))
+	mockEc2Metadata.EXPECT().InstanceIdentityDocument().Return(ec2metadata.EC2InstanceIdentityDocument{}, errors.New("err"))
 
 	_, err := NewConfig(mockEc2Metadata)
 	if err == nil {
@@ -63,7 +64,7 @@ func TestBrokenEC2MetadataEndpoint(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockEc2Metadata := mock_ec2.NewMockEC2MetadataClient(ctrl)
 
-	mockEc2Metadata.EXPECT().InstanceIdentityDocument().Return(nil, errors.New("err"))
+	mockEc2Metadata.EXPECT().InstanceIdentityDocument().Return(ec2metadata.EC2InstanceIdentityDocument{}, errors.New("err"))
 	os.Setenv("AWS_DEFAULT_REGION", "us-west-2")
 
 	config, err := NewConfig(mockEc2Metadata)

--- a/agent/ec2/blackhole_ec2_metadata_client.go
+++ b/agent/ec2/blackhole_ec2_metadata_client.go
@@ -13,7 +13,11 @@
 
 package ec2
 
-import "errors"
+import (
+	"errors"
+
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+)
 
 type blackholeMetadataClientImpl struct{}
 
@@ -25,10 +29,14 @@ func (blackholeMetadataClientImpl) DefaultCredentials() (*RoleCredentials, error
 	return nil, errors.New("blackholed")
 }
 
-func (blackholeMetadataClientImpl) InstanceIdentityDocument() (*InstanceIdentityDocument, error) {
-	return nil, errors.New("blackholed")
+func (blackholeMetadataClientImpl) InstanceIdentityDocument() (ec2metadata.EC2InstanceIdentityDocument, error) {
+	return ec2metadata.EC2InstanceIdentityDocument{}, errors.New("blackholed")
 }
 
-func (blackholeMetadataClientImpl) ReadResource(path string) ([]byte, error) {
-	return nil, errors.New("blackholed")
+func (blackholeMetadataClientImpl) GetMetadata(path string) (string, error) {
+	return "", errors.New("blackholed")
+}
+
+func (blackholeMetadataClientImpl) GetDynamicData(path string) (string, error) {
+	return "", errors.New("blackholed")
 }

--- a/agent/ec2/ec2_metadata_client_test.go
+++ b/agent/ec2/ec2_metadata_client_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/aws/amazon-ecs-agent/agent/ec2"
 	"github.com/aws/amazon-ecs-agent/agent/ec2/mocks"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/golang/mock/gomock"
 )
 
@@ -47,22 +48,19 @@ const (
 	testRoleName = "test-role"
 )
 
-var testInstanceIdentityDoc = `{
-  "privateIp" : "172.1.1.1",
-  "devpayProductCodes" : null,
-  "availabilityZone" : "us-east-1a",
-  "version" : "2010-08-31",
-  "region" : "us-east-1",
-  "accountId" : "012345678901",
-  "instanceId" : "i-01234567",
-  "billingProducts" : [ "bp-01234567" ],
-  "imageId" : "ami-12345678",
-  "instanceType" : "t2.micro",
-  "kernelId" : null,
-  "ramdiskId" : null,
-  "pendingTime" : "2015-06-04T22:16:06Z",
-  "architecture" : "x86_64"
-}`
+var testInstanceIdentityDoc = ec2metadata.EC2InstanceIdentityDocument{
+	PrivateIP:        "172.1.1.1",
+	AvailabilityZone: "us-east-1a",
+	Version:          "2010-08-31",
+	Region:           "us-east-1",
+	AccountID:        "012345678901",
+	InstanceID:       "i-01234567",
+	BillingProducts:  []string{"bp-01234567"},
+	ImageID:          "ami-12345678",
+	InstanceType:     "t2.micro",
+	PendingTime:      time.Now(),
+	Architecture:     "x86_64",
+}
 
 func testSuccessResponse(s string) (*http.Response, error) {
 	return &http.Response{
@@ -88,8 +86,8 @@ func TestDefaultCredentials(t *testing.T) {
 	mockGetter := mock_ec2.NewMockHttpClient(ctrl)
 	testClient := ec2.NewEC2MetadataClient(mockGetter)
 
-	mockGetter.EXPECT().Get(ec2.EC2_METADATA_SERVICE_URL + ec2.SECURITY_CREDENTIALS_RESOURCE).Return(testSuccessResponse(testRoleName))
-	mockGetter.EXPECT().Get(ec2.EC2_METADATA_SERVICE_URL + ec2.SECURITY_CREDENTIALS_RESOURCE + testRoleName).Return(testSuccessResponse(string(ignoreError(json.Marshal(makeTestRoleCredentials())).([]byte))))
+	mockGetter.EXPECT().GetMetadata(ec2.SecurityCrednetialsResource).Return(testRoleName, nil)
+	mockGetter.EXPECT().GetMetadata(ec2.SecurityCrednetialsResource+testRoleName).Return(string(ignoreError(json.Marshal(makeTestRoleCredentials())).([]byte)), nil)
 
 	credentials, err := testClient.DefaultCredentials()
 	if err != nil {
@@ -108,29 +106,7 @@ func TestGetInstanceIdentityDoc(t *testing.T) {
 	mockGetter := mock_ec2.NewMockHttpClient(ctrl)
 	testClient := ec2.NewEC2MetadataClient(mockGetter)
 
-	mockGetter.EXPECT().Get(ec2.EC2_METADATA_SERVICE_URL + ec2.INSTANCE_IDENTITY_DOCUMENT_RESOURCE).Return(testSuccessResponse(testInstanceIdentityDoc))
-
-	doc, err := testClient.InstanceIdentityDocument()
-	if err != nil {
-		t.Fatal("Expected to be able to get doc")
-	}
-	if doc.Region != "us-east-1" {
-		t.Error("Wrong region; expected us-east-1 but got " + doc.Region)
-	}
-}
-
-func TestRetriesOnError(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	mockGetter := mock_ec2.NewMockHttpClient(ctrl)
-	testClient := ec2.NewEC2MetadataClient(mockGetter)
-
-	gomock.InOrder(
-		mockGetter.EXPECT().Get(ec2.EC2_METADATA_SERVICE_URL+ec2.INSTANCE_IDENTITY_DOCUMENT_RESOURCE).Return(nil, errors.New("Something broke")),
-		mockGetter.EXPECT().Get(ec2.EC2_METADATA_SERVICE_URL+ec2.INSTANCE_IDENTITY_DOCUMENT_RESOURCE).Return(testErrorResponse()),
-		mockGetter.EXPECT().Get(ec2.EC2_METADATA_SERVICE_URL+ec2.INSTANCE_IDENTITY_DOCUMENT_RESOURCE).Return(testSuccessResponse(testInstanceIdentityDoc)),
-	)
+	mockGetter.EXPECT().GetInstanceIdentityDocument().Return(testInstanceIdentityDoc, nil)
 
 	doc, err := testClient.InstanceIdentityDocument()
 	if err != nil {
@@ -148,7 +124,7 @@ func TestErrorPropogatesUp(t *testing.T) {
 	mockGetter := mock_ec2.NewMockHttpClient(ctrl)
 	testClient := ec2.NewEC2MetadataClient(mockGetter)
 
-	mockGetter.EXPECT().Get(ec2.EC2_METADATA_SERVICE_URL+ec2.INSTANCE_IDENTITY_DOCUMENT_RESOURCE).Return(nil, errors.New("Something broke")).AnyTimes()
+	mockGetter.EXPECT().GetInstanceIdentityDocument().Return(ec2metadata.EC2InstanceIdentityDocument{}, errors.New("Something broke"))
 
 	_, err := testClient.InstanceIdentityDocument()
 	if err == nil {

--- a/agent/ec2/mocks/ec2_mocks.go
+++ b/agent/ec2/mocks/ec2_mocks.go
@@ -17,9 +17,8 @@
 package mock_ec2
 
 import (
-	http "net/http"
-
 	ec2 "github.com/aws/amazon-ecs-agent/agent/ec2"
+	ec2metadata "github.com/aws/aws-sdk-go/aws/ec2metadata"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -55,26 +54,37 @@ func (_mr *_MockEC2MetadataClientRecorder) DefaultCredentials() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DefaultCredentials")
 }
 
-func (_m *MockEC2MetadataClient) InstanceIdentityDocument() (*ec2.InstanceIdentityDocument, error) {
+func (_m *MockEC2MetadataClient) GetDynamicData(_param0 string) (string, error) {
+	ret := _m.ctrl.Call(_m, "GetDynamicData", _param0)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2MetadataClientRecorder) GetDynamicData(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetDynamicData", arg0)
+}
+
+func (_m *MockEC2MetadataClient) GetMetadata(_param0 string) (string, error) {
+	ret := _m.ctrl.Call(_m, "GetMetadata", _param0)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2MetadataClientRecorder) GetMetadata(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetMetadata", arg0)
+}
+
+func (_m *MockEC2MetadataClient) InstanceIdentityDocument() (ec2metadata.EC2InstanceIdentityDocument, error) {
 	ret := _m.ctrl.Call(_m, "InstanceIdentityDocument")
-	ret0, _ := ret[0].(*ec2.InstanceIdentityDocument)
+	ret0, _ := ret[0].(ec2metadata.EC2InstanceIdentityDocument)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 func (_mr *_MockEC2MetadataClientRecorder) InstanceIdentityDocument() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "InstanceIdentityDocument")
-}
-
-func (_m *MockEC2MetadataClient) ReadResource(_param0 string) ([]byte, error) {
-	ret := _m.ctrl.Call(_m, "ReadResource", _param0)
-	ret0, _ := ret[0].([]byte)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-func (_mr *_MockEC2MetadataClientRecorder) ReadResource(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReadResource", arg0)
 }
 
 // Mock of HttpClient interface
@@ -98,13 +108,35 @@ func (_m *MockHttpClient) EXPECT() *_MockHttpClientRecorder {
 	return _m.recorder
 }
 
-func (_m *MockHttpClient) Get(_param0 string) (*http.Response, error) {
-	ret := _m.ctrl.Call(_m, "Get", _param0)
-	ret0, _ := ret[0].(*http.Response)
+func (_m *MockHttpClient) GetDynamicData(_param0 string) (string, error) {
+	ret := _m.ctrl.Call(_m, "GetDynamicData", _param0)
+	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockHttpClientRecorder) Get(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Get", arg0)
+func (_mr *_MockHttpClientRecorder) GetDynamicData(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetDynamicData", arg0)
+}
+
+func (_m *MockHttpClient) GetInstanceIdentityDocument() (ec2metadata.EC2InstanceIdentityDocument, error) {
+	ret := _m.ctrl.Call(_m, "GetInstanceIdentityDocument")
+	ret0, _ := ret[0].(ec2metadata.EC2InstanceIdentityDocument)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockHttpClientRecorder) GetInstanceIdentityDocument() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetInstanceIdentityDocument")
+}
+
+func (_m *MockHttpClient) GetMetadata(_param0 string) (string, error) {
+	ret := _m.ctrl.Call(_m, "GetMetadata", _param0)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockHttpClientRecorder) GetMetadata(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetMetadata", arg0)
 }

--- a/agent/engine/dockerstate/mocks/dockerstate_mocks.go
+++ b/agent/engine/dockerstate/mocks/dockerstate_mocks.go
@@ -87,16 +87,6 @@ func (_mr *_MockTaskEngineStateRecorder) AllTasks() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "AllTasks")
 }
 
-func (_m *MockTaskEngineState) GetAllContainerIDs() []string {
-	ret := _m.ctrl.Call(_m, "GetAllContainerIDs")
-	ret0, _ := ret[0].([]string)
-	return ret0
-}
-
-func (_mr *_MockTaskEngineStateRecorder) GetAllContainerIDs() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetAllContainerIDs")
-}
-
 func (_m *MockTaskEngineState) ContainerByID(_param0 string) (*api.DockerContainer, bool) {
 	ret := _m.ctrl.Call(_m, "ContainerByID", _param0)
 	ret0, _ := ret[0].(*api.DockerContainer)
@@ -117,6 +107,16 @@ func (_m *MockTaskEngineState) ContainerMapByArn(_param0 string) (map[string]*ap
 
 func (_mr *_MockTaskEngineStateRecorder) ContainerMapByArn(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ContainerMapByArn", arg0)
+}
+
+func (_m *MockTaskEngineState) GetAllContainerIDs() []string {
+	ret := _m.ctrl.Call(_m, "GetAllContainerIDs")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+func (_mr *_MockTaskEngineStateRecorder) GetAllContainerIDs() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetAllContainerIDs")
 }
 
 func (_m *MockTaskEngineState) MarshalJSON() ([]byte, error) {
@@ -168,15 +168,15 @@ func (_mr *_MockTaskEngineStateRecorder) TaskByID(arg0 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "TaskByID", arg0)
 }
 
-func (_mr *_MockTaskEngineStateRecorder) TaskByShortID(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "TaskByShortID", arg0)
-}
-
 func (_m *MockTaskEngineState) TaskByShortID(_param0 string) ([]*api.Task, bool) {
 	ret := _m.ctrl.Call(_m, "TaskByShortID", _param0)
 	ret0, _ := ret[0].([]*api.Task)
 	ret1, _ := ret[1].(bool)
 	return ret0, ret1
+}
+
+func (_mr *_MockTaskEngineStateRecorder) TaskByShortID(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "TaskByShortID", arg0)
 }
 
 func (_m *MockTaskEngineState) UnmarshalJSON(_param0 []byte) error {

--- a/agent/functional_tests/util/utils_unix.go
+++ b/agent/functional_tests/util/utils_unix.go
@@ -55,7 +55,7 @@ func init() {
 		ecsconfig.Region = &region
 	}
 	if ecsconfig.Region == nil {
-		if iid, err := ec2.GetInstanceIdentityDocument(); err == nil {
+		if iid, err := ec2.NewEC2MetadataClient(nil).InstanceIdentityDocument(); err == nil {
 			ecsconfig.Region = &iid.Region
 		}
 	}

--- a/agent/functional_tests/util/utils_windows.go
+++ b/agent/functional_tests/util/utils_windows.go
@@ -44,7 +44,7 @@ func init() {
 		ecsconfig.Region = &region
 	}
 	if ecsconfig.Region == nil {
-		if iid, err := ec2.GetInstanceIdentityDocument(); err == nil {
+		if iid, err := ec2.NewEC2MetadataClient(nil).InstanceIdentityDocument(); err == nil {
 			ecsconfig.Region = &iid.Region
 		}
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Fix #869 

### Implementation details
<!-- How are the changes implemented? -->
Use the ec2metadata client from [aws-sdk-go](https://github.com/aws/aws-sdk-go/tree/master/aws/ec2metadata)

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
yes