### PR TITLE
Fix code generation error for acs/tcs api

### DIFF
--- a/agent/acs/handler/acs_handler_test.go
+++ b/agent/acs/handler/acs_handler_test.go
@@ -842,6 +842,7 @@ func TestHandlerDoesntLeakGoroutines(t *testing.T) {
 			stateManager:         statemanager,
 			taskHandler:          taskHandler,
 			ctx:                  ctx,
+			_heartbeatTimeout:    1 * time.Second,
 			backoff:              utils.NewSimpleBackoff(connectionBackoffMin, connectionBackoffMax, connectionBackoffJitter, connectionBackoffMultiplier),
 			resources:            newSessionResources(credentials.AnonymousCredentials),
 			credentialsManager:   rolecredentials.NewManager(),

--- a/agent/acs/model/generate.go
+++ b/agent/acs/model/generate.go
@@ -1,3 +1,3 @@
 package model
 
-//go:generate go run ../../gogenerate/awssdk.go -typesOnly=true
+//go:generate go run -tags=codegen ../../gogenerate/awssdk.go -typesOnly=true

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -470,19 +470,19 @@ func TestSteadyStatePoll(t *testing.T) {
 		dockerConfig.Labels["com.amazonaws.ecs.task-definition-version"] = sleepTask.Version
 		dockerConfig.Labels["com.amazonaws.ecs.cluster"] = ""
 
+		wait.Add(1)
 		client.EXPECT().CreateContainer(dockerConfig, gomock.Any(), gomock.Any(), gomock.Any()).Do(
 			func(x, y, z, timeout interface{}) {
 				go func() {
-					wait.Add(1)
 					eventStream <- createDockerEvent(api.ContainerCreated)
 					wait.Done()
 				}()
 			}).Return(DockerContainerMetadata{DockerID: "containerId"})
 
+		wait.Add(1)
 		client.EXPECT().StartContainer("containerId", startContainerTimeout).Do(
 			func(id string, timeout time.Duration) {
 				go func() {
-					wait.Add(1)
 					eventStream <- createDockerEvent(api.ContainerRunning)
 					wait.Done()
 				}()

--- a/agent/gogenerate/awssdk.go
+++ b/agent/gogenerate/awssdk.go
@@ -37,8 +37,19 @@ func main() {
 	os.Exit(_main())
 }
 
-var typesOnlyTplAPI = template.Must(template.New("api").Parse(`
-{{ range $_, $s := .ShapeList }}
+func ShapeListWithErrors(a *api.API) []*api.Shape {
+	list := make([]*api.Shape, 0, len(a.Shapes))
+	for _, n := range a.ShapeNames() {
+		list = append(list, a.Shapes[n])
+	}
+	return list
+}
+
+var typesOnlyTplAPI = template.Must(template.New("api").Funcs(template.FuncMap{
+	"ShapeListWithErrors": ShapeListWithErrors,
+}).Parse(`
+{{ $shapeList := ShapeListWithErrors $ }}
+{{ range $_, $s := $shapeList }}
 {{ if eq $s.Type "structure"}}{{ $s.GoCode }}{{ end }}
 
 {{ end }}
@@ -83,8 +94,9 @@ func _main() int {
 
 func genTypesOnlyAPI(file string) error {
 	apiGen := &api.API{
-		NoRemoveUnusedShapes:   true,
-		NoRenameToplevelShapes: true,
+		NoRemoveUnusedShapes:      true,
+		NoRenameToplevelShapes:    true,
+		NoGenStructFieldAccessors: true,
 	}
 	apiGen.Attach(file)
 	apiGen.Setup()

--- a/agent/tcs/model/generate.go
+++ b/agent/tcs/model/generate.go
@@ -1,3 +1,3 @@
 package model
 
-//go:generate go run ../../gogenerate/awssdk.go -typesOnly=true
+//go:generate go run -tags=codegen ../../gogenerate/awssdk.go -typesOnly=true


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Fix issue #812 
### Implementation details
<!-- How are the changes implemented? -->
The [aws-sdk-go](https://github.com/aws/aws-sdk-go/blob/63041ae9ee94e32d0f2927f3cbc61f7ccea9b131/private/model/api/api.go#L191) ignore the `errors` type when generating the code. Implement a method that return all the shapes with error types to generate all the structure including the `errors` type.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass
- [x] `make gogenerate`

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
yes