### PR TITLE
Fix data race where a pointer was returned in Getter

### DIFF
--- a/agent/acs/handler/refresh_credentials_handler_test.go
+++ b/agent/acs/handler/refresh_credentials_handler_test.go
@@ -45,7 +45,7 @@ var expectedAck = &ecsacs.IAMRoleCredentialsAckRequest{
 	CredentialsId: aws.String(credentialsId),
 }
 
-var expectedCredentials = &credentials.TaskIAMRoleCredentials{
+var expectedCredentials = credentials.TaskIAMRoleCredentials{
 	ARN: taskArn,
 	IAMRoleCredentials: credentials.IAMRoleCredentials{
 		RoleArn:         roleArn,

--- a/agent/api/task_test.go
+++ b/agent/api/task_test.go
@@ -459,7 +459,7 @@ func TestGetCredentialsEndpointWhenCredentialsAreSet(t *testing.T) {
 		credentialsID: credentialsIDInTask,
 	}
 
-	taskCredentials := &credentials.TaskIAMRoleCredentials{
+	taskCredentials := credentials.TaskIAMRoleCredentials{
 		IAMRoleCredentials: credentials.IAMRoleCredentials{CredentialsID: "credsid"},
 	}
 	credentialsManager.EXPECT().GetTaskCredentials(credentialsIDInTask).Return(taskCredentials, true)

--- a/agent/credentials/interface.go
+++ b/agent/credentials/interface.go
@@ -18,6 +18,6 @@ package credentials
 // between the task engine, acs and credentials handlers
 type Manager interface {
 	SetTaskCredentials(TaskIAMRoleCredentials) error
-	GetTaskCredentials(string) (*TaskIAMRoleCredentials, bool)
+	GetTaskCredentials(string) (TaskIAMRoleCredentials, bool)
 	RemoveCredentials(string)
 }

--- a/agent/credentials/manager.go
+++ b/agent/credentials/manager.go
@@ -123,12 +123,16 @@ func (manager *credentialsManager) SetTaskCredentials(taskCredentials TaskIAMRol
 }
 
 // GetTaskCredentials retrieves credentials for a given credentials id
-func (manager *credentialsManager) GetTaskCredentials(id string) (*TaskIAMRoleCredentials, bool) {
+func (manager *credentialsManager) GetTaskCredentials(id string) (TaskIAMRoleCredentials, bool) {
 	manager.taskCredentialsLock.RLock()
 	defer manager.taskCredentialsLock.RUnlock()
 
 	taskCredentials, ok := manager.idToTaskCredentials[id]
-	return taskCredentials, ok
+
+	if !ok {
+		return TaskIAMRoleCredentials{}, ok
+	}
+	return *taskCredentials, ok
 }
 
 // RemoveCredentials removes credentials from the credentials manager

--- a/agent/credentials/manager_test.go
+++ b/agent/credentials/manager_test.go
@@ -15,7 +15,6 @@ package credentials
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
 
 	"github.com/aws/amazon-ecs-agent/agent/acs/model/ecsacs"
@@ -43,9 +42,7 @@ func TestIAMRoleCredentialsFromACS(t *testing.T) {
 		SecretAccessKey: "OhhSecret",
 		SessionToken:    "sessionToken",
 	}
-	if !reflect.DeepEqual(credentials, expectedCredentials) {
-		t.Error("Mismatch between expected and constructed credentials")
-	}
+	assert.Equal(t, credentials, expectedCredentials, "Mismatch between expected and constructed credentials")
 }
 
 // TestGetTaskCredentialsUnknownId tests if GetTaskCredentials returns a false value
@@ -102,12 +99,8 @@ func TestSetAndGetTaskCredentialsHappyPath(t *testing.T) {
 	assert.NoError(t, err, "Error adding credentials")
 
 	credentialsFromManager, ok := manager.GetTaskCredentials("cid1")
-	if !ok {
-		t.Error("GetTaskCredentials returned false for existing credentials")
-	}
-	if !reflect.DeepEqual(credentials, *credentialsFromManager) {
-		t.Error("Mismatch between added and retrieved credentials")
-	}
+	assert.True(t, ok, "GetTaskCredentials returned false for existing credentials")
+	assert.Equal(t, credentials, credentialsFromManager, "Mismatch between added and retrieved credentials")
 
 	updatedCredentials := TaskIAMRoleCredentials{
 		ARN: "t1",
@@ -123,12 +116,9 @@ func TestSetAndGetTaskCredentialsHappyPath(t *testing.T) {
 	err = manager.SetTaskCredentials(updatedCredentials)
 	assert.NoError(t, err, "Error updating credentials")
 	credentialsFromManager, ok = manager.GetTaskCredentials("cid1")
-	if !ok {
-		t.Error("GetTaskCredentials returned false for existing credentials")
-	}
-	if !reflect.DeepEqual(updatedCredentials, *credentialsFromManager) {
-		t.Error("Mismatch between added and retrieved credentials")
-	}
+
+	assert.True(t, ok, "GetTaskCredentials returned false for existing credentials")
+	assert.Equal(t, updatedCredentials, credentialsFromManager, "Mismatch between added and retrieved credentials")
 }
 
 // TestGenerateCredentialsEndpointRelativeURI tests if the relative credentials endpoint
@@ -166,12 +156,8 @@ func TestRemoveExistingCredentials(t *testing.T) {
 	assert.NoError(t, err, "Error adding credentials")
 
 	credentialsFromManager, ok := manager.GetTaskCredentials("cid1")
-	if !ok {
-		t.Error("GetTaskCredentials returned false for existing credentials")
-	}
-	if !reflect.DeepEqual(credentials, *credentialsFromManager) {
-		t.Error("Mismatch between added and retrieved credentials")
-	}
+	assert.True(t, ok, "GetTaskCredentials returned false for existing credentials")
+	assert.Equal(t, credentials, credentialsFromManager, "Mismatch between added and retrieved credentials")
 
 	manager.RemoveCredentials("cid1")
 	_, ok = manager.GetTaskCredentials("cid1")

--- a/agent/credentials/mocks/credentials_mocks.go
+++ b/agent/credentials/mocks/credentials_mocks.go
@@ -42,9 +42,9 @@ func (_m *MockManager) EXPECT() *_MockManagerRecorder {
 	return _m.recorder
 }
 
-func (_m *MockManager) GetTaskCredentials(_param0 string) (*credentials.TaskIAMRoleCredentials, bool) {
+func (_m *MockManager) GetTaskCredentials(_param0 string) (credentials.TaskIAMRoleCredentials, bool) {
 	ret := _m.ctrl.Call(_m, "GetTaskCredentials", _param0)
-	ret0, _ := ret[0].(*credentials.TaskIAMRoleCredentials)
+	ret0, _ := ret[0].(credentials.TaskIAMRoleCredentials)
 	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -69,7 +69,7 @@ func TestBatchContainerHappyPath(t *testing.T) {
 	ctrl, client, mockTime, taskEngine, credentialsManager, imageManager := mocks(t, &defaultConfig)
 	defer ctrl.Finish()
 
-	roleCredentials := &credentials.TaskIAMRoleCredentials{
+	roleCredentials := credentials.TaskIAMRoleCredentials{
 		IAMRoleCredentials: credentials.IAMRoleCredentials{CredentialsID: "credsid"},
 	}
 	credentialsManager.EXPECT().GetTaskCredentials(credentialsID).Return(roleCredentials, true).AnyTimes()

--- a/agent/handlers/credentials/handler.go
+++ b/agent/handlers/credentials/handler.go
@@ -178,7 +178,7 @@ func processCredentialsV1V2Request(credentialsManager credentials.Manager, r *ht
 		return nil, "", msg, errors.New(errText)
 	}
 
-	if credentials == nil {
+	if utils.ZeroOrNil(credentials) {
 		// This can happen when the agent is restarted and is reconciling its state.
 		errText := errPrefix + "Credentials uninitialized for ID"
 		log.Infof("%s. Request IP Address: %s", errText, r.RemoteAddr)

--- a/agent/handlers/credentials/handler_test.go
+++ b/agent/handlers/credentials/handler_test.go
@@ -74,7 +74,7 @@ func TestCredentialsV1RequestWhenCredentialsIdNotFound(t *testing.T) {
 	}
 	path := credentials.V1CredentialsPath + "?id=" + credentialsID
 	_, err := getResponseForCredentialsRequest(t, expectedErrorMessage.httpErrorCode,
-		expectedErrorMessage, path, func() (*credentials.TaskIAMRoleCredentials, bool) { return nil, false })
+		expectedErrorMessage, path, func() (credentials.TaskIAMRoleCredentials, bool) { return credentials.TaskIAMRoleCredentials{}, false })
 	assert.NoError(t, err, "Error getting response body")
 }
 
@@ -88,7 +88,7 @@ func TestCredentialsV2RequestWhenCredentialsIdNotFound(t *testing.T) {
 	}
 	path := credentials.V2CredentialsPath + "/" + credentialsID
 	_, err := getResponseForCredentialsRequest(t, expectedErrorMessage.httpErrorCode,
-		expectedErrorMessage, path, func() (*credentials.TaskIAMRoleCredentials, bool) { return nil, false })
+		expectedErrorMessage, path, func() (credentials.TaskIAMRoleCredentials, bool) { return credentials.TaskIAMRoleCredentials{}, false })
 	assert.NoError(t, err, "Error getting response body")
 }
 
@@ -102,7 +102,7 @@ func TestCredentialsV1RequestWhenCredentialsUninitialized(t *testing.T) {
 	}
 	path := credentials.V1CredentialsPath + "?id=" + credentialsID
 	_, err := getResponseForCredentialsRequest(t, expectedErrorMessage.httpErrorCode,
-		expectedErrorMessage, path, func() (*credentials.TaskIAMRoleCredentials, bool) { return nil, true })
+		expectedErrorMessage, path, func() (credentials.TaskIAMRoleCredentials, bool) { return credentials.TaskIAMRoleCredentials{}, true })
 	assert.NoError(t, err, "Error getting response body")
 }
 
@@ -116,7 +116,7 @@ func TestCredentialsV2RequestWhenCredentialsUninitialized(t *testing.T) {
 	}
 	path := credentials.V2CredentialsPath + "/" + credentialsID
 	_, err := getResponseForCredentialsRequest(t, expectedErrorMessage.httpErrorCode,
-		expectedErrorMessage, path, func() (*credentials.TaskIAMRoleCredentials, bool) { return nil, true })
+		expectedErrorMessage, path, func() (credentials.TaskIAMRoleCredentials, bool) { return credentials.TaskIAMRoleCredentials{}, true })
 	assert.NoError(t, err, "Error getting response body")
 }
 
@@ -124,6 +124,7 @@ func TestCredentialsV2RequestWhenCredentialsUninitialized(t *testing.T) {
 // the credentials manager contains the credentials id specified in the query.
 func TestCredentialsV1RequestWhenCredentialsFound(t *testing.T) {
 	creds := credentials.TaskIAMRoleCredentials{
+		ARN: "arn",
 		IAMRoleCredentials: credentials.IAMRoleCredentials{
 			RoleArn:         roleArn,
 			AccessKeyID:     accessKeyID,
@@ -131,7 +132,7 @@ func TestCredentialsV1RequestWhenCredentialsFound(t *testing.T) {
 		},
 	}
 	path := credentials.V1CredentialsPath + "?id=" + credentialsID
-	body, err := getResponseForCredentialsRequest(t, http.StatusOK, nil, path, func() (*credentials.TaskIAMRoleCredentials, bool) { return &creds, true })
+	body, err := getResponseForCredentialsRequest(t, http.StatusOK, nil, path, func() (credentials.TaskIAMRoleCredentials, bool) { return creds, true })
 	assert.NoError(t, err)
 
 	credentials, err := parseResponseBody(body)
@@ -146,6 +147,7 @@ func TestCredentialsV1RequestWhenCredentialsFound(t *testing.T) {
 // the credentials manager contains the credentials id specified in the query.
 func TestCredentialsV2RequestWhenCredentialsFound(t *testing.T) {
 	creds := credentials.TaskIAMRoleCredentials{
+		ARN: "arn",
 		IAMRoleCredentials: credentials.IAMRoleCredentials{
 			RoleArn:         roleArn,
 			AccessKeyID:     accessKeyID,
@@ -153,7 +155,7 @@ func TestCredentialsV2RequestWhenCredentialsFound(t *testing.T) {
 		},
 	}
 	path := credentials.V2CredentialsPath + "/" + credentialsID
-	body, err := getResponseForCredentialsRequest(t, http.StatusOK, nil, path, func() (*credentials.TaskIAMRoleCredentials, bool) { return &creds, true })
+	body, err := getResponseForCredentialsRequest(t, http.StatusOK, nil, path, func() (credentials.TaskIAMRoleCredentials, bool) { return creds, true })
 	if err != nil {
 		t.Fatalf("Error retrieving credentials response: %v", err)
 	}
@@ -200,7 +202,7 @@ func testErrorResponsesFromServer(t *testing.T, path string, expectedErrorMessag
 // given id. The getCredentials function is used to simulate getting the
 // credentials object from the CredentialsManager
 func getResponseForCredentialsRequest(t *testing.T, expectedStatus int,
-	expectedErrorMessage *errorMessage, path string, getCredentials func() (*credentials.TaskIAMRoleCredentials, bool)) (*bytes.Buffer, error) {
+	expectedErrorMessage *errorMessage, path string, getCredentials func() (credentials.TaskIAMRoleCredentials, bool)) (*bytes.Buffer, error) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	credentialsManager := mock_credentials.NewMockManager(ctrl)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Fix data race caught in test.

### Implementation details
<!-- How are the changes implemented? -->
Change the return value of Getter function to non-pointer value.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
yes