### PR TITLE
Reset agent state if the instance id changed on agent restart

### DIFF
--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -232,6 +232,8 @@ func (agent *ecsAgent) newTaskEngine(containerChangeEventStream *eventstream.Eve
 		log.Warnf(instanceIDMismatchErrorFormat,
 			previousEC2InstanceID, currentEC2InstanceID)
 
+		// Reset agent state as a new container instance
+		state.Reset()
 		// Reset taskEngine; all the other values are still default
 		return engine.NewTaskEngine(agent.cfg, agent.dockerClient, credentialsManager,
 			containerChangeEventStream, imageManager, state), currentEC2InstanceID, nil

--- a/agent/app/agent_test.go
+++ b/agent/app/agent_test.go
@@ -287,6 +287,7 @@ func TestNewTaskEngineRestoreFromCheckpointPreviousEC2InstanceIDLoadedHappyPath(
 			gomock.Any(), gomock.Any(), gomock.Any()).Return(
 			statemanager.NewNoopStateManager(), nil),
 		ec2MetadataClient.EXPECT().InstanceIdentityDocument().Return(iid, nil),
+		state.EXPECT().Reset(),
 	)
 
 	ctx, cancel := context.WithCancel(context.TODO())

--- a/agent/engine/dockerstate/docker_task_engine_state.go
+++ b/agent/engine/dockerstate/docker_task_engine_state.go
@@ -52,6 +52,8 @@ type TaskEngineState interface {
 	AddImageState(imageState *image.ImageState)
 	// RemoveTask removes a task from the state
 	RemoveTask(task *api.Task)
+	// Reset resets all the fileds in the state
+	Reset()
 	// RemoveImageState removes an image.ImageState
 	RemoveImageState(imageState *image.ImageState)
 	json.Marshaler
@@ -87,13 +89,25 @@ func NewTaskEngineState() TaskEngineState {
 }
 
 func newDockerTaskEngineState() *DockerTaskEngineState {
-	return &DockerTaskEngineState{
-		tasks:         make(map[string]*api.Task),
-		idToTask:      make(map[string]string),
-		taskToID:      make(map[string]map[string]*api.DockerContainer),
-		idToContainer: make(map[string]*api.DockerContainer),
-		imageStates:   make(map[string]*image.ImageState),
-	}
+	state := &DockerTaskEngineState{}
+	state.initializeDockerTaskEngineState()
+	return state
+}
+
+func (state *DockerTaskEngineState) initializeDockerTaskEngineState() {
+	state.lock.Lock()
+	defer state.lock.Unlock()
+
+	state.tasks = make(map[string]*api.Task)
+	state.idToTask = make(map[string]string)
+	state.taskToID = make(map[string]map[string]*api.DockerContainer)
+	state.idToContainer = make(map[string]*api.DockerContainer)
+	state.imageStates = make(map[string]*image.ImageState)
+}
+
+// Reset resets all the states
+func (state *DockerTaskEngineState) Reset() {
+	state.initializeDockerTaskEngineState()
 }
 
 // AllTasks returns all of the tasks

--- a/agent/engine/dockerstate/mocks/dockerstate_mocks.go
+++ b/agent/engine/dockerstate/mocks/dockerstate_mocks.go
@@ -146,6 +146,14 @@ func (_mr *_MockTaskEngineStateRecorder) RemoveTask(arg0 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveTask", arg0)
 }
 
+func (_m *MockTaskEngineState) Reset() {
+	_m.ctrl.Call(_m, "Reset")
+}
+
+func (_mr *_MockTaskEngineStateRecorder) Reset() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Reset")
+}
+
 func (_m *MockTaskEngineState) TaskByArn(_param0 string) (*api.Task, bool) {
 	ret := _m.ctrl.Call(_m, "TaskByArn", _param0)
 	ret0, _ := ret[0].(*api.Task)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Fix #859 

### Implementation details
<!-- How are the changes implemented? -->
Rest the agent state when detected the instance id is different from the one stored in the agent state file.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass
- [x] Manually tested
New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
yes