### PR TITLE
Allow instance attributes to be provided from config file.

### DIFF
--- a/agent/config/config_unix_test.go
+++ b/agent/config/config_unix_test.go
@@ -99,6 +99,7 @@ func TestConfigFromFile(t *testing.T) {
 	assert.Equal(t, cluster, config.Cluster, "cluster name not as expected from file")
 	assert.Equal(t, dockerAuthType, config.EngineAuthType, "docker auth type not as expected from file")
 	assert.Equal(t, dockerAuth, string(config.EngineAuthData.Contents()), "docker auth data not as expected from file")
+	assert.Equal(t, map[string]string{"attribute1": "value1"}, config.InstanceAttributes)
 }
 
 // TestDockerAuthMergeFromFile tests docker auth read from file correctly after merge
@@ -136,6 +137,7 @@ func TestDockerAuthMergeFromFile(t *testing.T) {
 	assert.Equal(t, cluster, config.Cluster, "cluster name not as expected from environment variable")
 	assert.Equal(t, dockerAuthType, config.EngineAuthType, "docker auth type not as expected from file")
 	assert.Equal(t, dockerAuth, string(config.EngineAuthData.Contents()), "docker auth data not as expected from file")
+	assert.Equal(t, map[string]string{"attribute1": "value1"}, config.InstanceAttributes)
 }
 
 // setupDockerAuthConfiguration create a temp file store the configuration

--- a/agent/utils/utils.go
+++ b/agent/utils/utils.go
@@ -44,7 +44,8 @@ func ZeroOrNil(obj interface{}) bool {
 	if obj == nil {
 		return true
 	}
-	if value.Kind() == reflect.Slice || value.Kind() == reflect.Array {
+	switch value.Kind() {
+	case reflect.Slice, reflect.Array, reflect.Map:
 		return value.Len() == 0
 	}
 	zero := reflect.Zero(reflect.TypeOf(obj))

--- a/agent/utils/utils_test.go
+++ b/agent/utils/utils_test.go
@@ -87,6 +87,14 @@ func TestZeroOrNil(t *testing.T) {
 		t.Error("Uncomparable structs are never zero")
 	}
 
+	var strMap map[string]string
+	if !ZeroOrNil(strMap) {
+		t.Error("map[string]string is not zero or nil")
+	}
+
+	if ZeroOrNil(map[string]string{"foo": "bar"}) {
+		t.Error("map[string]string{foo:bar} is zero or nil")
+	}
 }
 
 func TestSlicesDeepEqual(t *testing.T) {


### PR DESCRIPTION
This is basically another case of https://github.com/aws/amazon-ecs-agent/issues/732, where instance attributes from the config file get overridden by the empty instance attributes from the environment.

I think the underlying problem was that `ZeroOrNil` in the `utils` package didn't handle map's, so I fixed the issue there. Based on `git grep ZeroOrNil` it looks like this wouldn't have any unintended side effects.

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: yes
