### PR TITLE
Improve the error message when reserved memory is larger than the available memory

### DIFF
--- a/agent/api/ecsclient/client.go
+++ b/agent/api/ecsclient/client.go
@@ -15,6 +15,7 @@ package ecsclient
 
 import (
 	"errors"
+	"fmt"
 	"runtime"
 	"strings"
 	"time"
@@ -172,7 +173,12 @@ func (client *APIECSClient) registerContainerInstance(clusterRef string, contain
 	integerStr := "INTEGER"
 
 	cpu, mem := getCpuAndMemory()
-	mem = mem - int64(client.config.ReservedMemory)
+	remainingMem := mem - int64(client.config.ReservedMemory)
+	if remainingMem < 0 {
+		return "", fmt.Errorf(
+			"api register-container-instance: reserved memory is higher than available memory on the host, total memory: %d, reserved: %d",
+			mem, client.config.ReservedMemory)
+	}
 
 	cpuResource := ecs.Resource{
 		Name:         utils.Strptr("CPU"),
@@ -182,7 +188,7 @@ func (client *APIECSClient) registerContainerInstance(clusterRef string, contain
 	memResource := ecs.Resource{
 		Name:         utils.Strptr("MEMORY"),
 		Type:         &integerStr,
-		IntegerValue: &mem,
+		IntegerValue: &remainingMem,
 	}
 	portResource := ecs.Resource{
 		Name:           utils.Strptr("PORTS"),

--- a/agent/api/ecsclient/client_test.go
+++ b/agent/api/ecsclient/client_test.go
@@ -349,6 +349,30 @@ func TestRegisterContainerInstance(t *testing.T) {
 	assert.Equal(t, "registerArn", arn)
 }
 
+// TestRegisterContainerInstanceWithNegativeResource tests the registeration should fail with negative resource
+func TestRegisterContainerInstanceWithNegativeResource(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	_, mem := getCpuAndMemory()
+	mockEC2Metadata := mock_ec2.NewMockEC2MetadataClient(mockCtrl)
+	client := NewECSClient(credentials.AnonymousCredentials,
+		&config.Config{Cluster: configuredCluster,
+			AWSRegion:      "us-east-1",
+			ReservedMemory: uint16(mem) + 1,
+		}, mockEC2Metadata)
+	mockSDK := mock_api.NewMockECSSDK(mockCtrl)
+	mockSubmitStateSDK := mock_api.NewMockECSSubmitStateSDK(mockCtrl)
+	client.(*APIECSClient).SetSDK(mockSDK)
+	client.(*APIECSClient).SetSubmitStateChangeSDK(mockSubmitStateSDK)
+
+	mockEC2Metadata.EXPECT().GetDynamicData(ec2.InstanceIdentityDocumentResource).Return("instanceIdentityDocument", nil)
+	mockEC2Metadata.EXPECT().GetDynamicData(ec2.InstanceIdentityDocumentSignatureResource).Return("signature", nil)
+
+	_, err := client.RegisterContainerInstance("", nil)
+	assert.Error(t, err, "Register resource with negative value should cause registration fail")
+}
+
 func TestValidateRegisteredAttributes(t *testing.T) {
 	origAttributes := []*ecs.Attribute{
 		{Name: aws.String("foo"), Value: aws.String("bar")},

--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -341,7 +341,6 @@ func (agent *ecsAgent) registerContainerInstance(
 	// Save our shiny new containerInstanceArn
 	stateManager.Save()
 	return nil
-
 }
 
 // registerContainerInstance registers a container instance that has already been

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -605,16 +605,17 @@ func TestStopWithPendingStops(t *testing.T) {
 
 	taskEngine.AddTask(sleepTask2)
 	<-pullInvoked
-	stopSleep2 := *sleepTask2
+	stopSleep2 := testdata.LoadTask("sleep5")
+	stopSleep2.Arn = "arn2"
 	stopSleep2.SetDesiredStatus(api.TaskStopped)
 	stopSleep2.StopSequenceNumber = 4
-	taskEngine.AddTask(&stopSleep2)
+	taskEngine.AddTask(stopSleep2)
 
 	taskEngine.AddTask(sleepTask1)
-	stopSleep1 := *sleepTask1
+	stopSleep1 := testdata.LoadTask("sleep5")
 	stopSleep1.SetDesiredStatus(api.TaskStopped)
 	stopSleep1.StopSequenceNumber = 5
-	taskEngine.AddTask(&stopSleep1)
+	taskEngine.AddTask(stopSleep1)
 	pullDone <- true
 	// this means the PullImage is only called once due to the task is stopped before it
 	// gets the pull image lock
@@ -762,9 +763,9 @@ func TestTaskTransitionWhenStopContainerTimesout(t *testing.T) {
 	assert.Equal(t, event.(api.TaskStateChange).Status, api.TaskRunning, "Expected task to be RUNNING")
 
 	// Set the task desired status to be stopped and StopContainer will be called
-	updateSleepTask := *sleepTask
+	updateSleepTask := testdata.LoadTask("sleep5")
 	updateSleepTask.SetDesiredStatus(api.TaskStopped)
-	go taskEngine.AddTask(&updateSleepTask)
+	go taskEngine.AddTask(updateSleepTask)
 
 	// StopContainer timeout error shouldn't cause cantainer/task status change
 	// until receive stop event from docker event stream
@@ -867,9 +868,9 @@ func TestTaskTransitionWhenStopContainerReturnsUnretriableError(t *testing.T) {
 	eventsReported.Wait()
 
 	// Set the task desired status to be stopped and StopContainer will be called
-	updateSleepTask := *sleepTask
+	updateSleepTask := testdata.LoadTask("sleep5")
 	updateSleepTask.SetDesiredStatus(api.TaskStopped)
-	go taskEngine.AddTask(&updateSleepTask)
+	go taskEngine.AddTask(updateSleepTask)
 
 	// StopContainer was called again and received stop event from docker event stream
 	// Expect it to go to stopped
@@ -944,9 +945,9 @@ func TestTaskTransitionWhenStopContainerReturnsTransientErrorBeforeSucceeding(t 
 	}
 
 	// Set the task desired status to be stopped and StopContainer will be called
-	updateSleepTask := *sleepTask
+	updateSleepTask := testdata.LoadTask("sleep5")
 	updateSleepTask.SetDesiredStatus(api.TaskStopped)
-	go taskEngine.AddTask(&updateSleepTask)
+	go taskEngine.AddTask(updateSleepTask)
 
 	// StopContainer invocation should have caused it to stop eventually.
 	event = <-stateChangeEvents


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Fix #888 

### Implementation details
<!-- How are the changes implemented? -->
Check the value of memory trying to registered before calling ecs RegisterContainerInstance. And if the value is negative then just emit an error and exit the agent.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->
yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
yes