### PR TITLE
Support HTTP Websocket Connections in wsclient

### DIFF
--- a/agent/tcs/handler/handler_test.go
+++ b/agent/tcs/handler/handler_test.go
@@ -82,7 +82,8 @@ func TestFormatURL(t *testing.T) {
 func TestStartSession(t *testing.T) {
 	// Start test server.
 	closeWS := make(chan []byte)
-	server, serverChan, requestChan, serverErr, err := wsmock.StartMockServer(t, closeWS)
+	server, serverChan, requestChan, serverErr, err := wsmock.GetMockServer(t, closeWS)
+	server.StartTLS()
 	defer server.Close()
 	if err != nil {
 		t.Fatal(err)
@@ -142,7 +143,8 @@ func TestStartSession(t *testing.T) {
 func TestSessionConnectionClosedByRemote(t *testing.T) {
 	// Start test server.
 	closeWS := make(chan []byte)
-	server, serverChan, _, serverErr, err := wsmock.StartMockServer(t, closeWS)
+	server, serverChan, _, serverErr, err := wsmock.GetMockServer(t, closeWS)
+	server.StartTLS()
 	defer server.Close()
 	if err != nil {
 		t.Fatal(err)
@@ -181,7 +183,8 @@ func TestSessionConnectionClosedByRemote(t *testing.T) {
 func TestConnectionInactiveTimeout(t *testing.T) {
 	// Start test server.
 	closeWS := make(chan []byte)
-	server, _, requestChan, serverErr, err := wsmock.StartMockServer(t, closeWS)
+	server, _, requestChan, serverErr, err := wsmock.GetMockServer(t, closeWS)
+	server.StartTLS()
 	defer server.Close()
 	if err != nil {
 		t.Fatal(err)

--- a/agent/wsclient/client.go
+++ b/agent/wsclient/client.go
@@ -54,9 +54,6 @@ const (
 	// writeBufSize is the size of the write buffer for the ws connection.
 	writeBufSize = 32768
 
-	// gorilla/websocket expects the websocket scheme (ws[s]://)
-	wsScheme = "wss"
-
 	// Default NO_PROXY env var IP addresses
 	defaultNoProxyIP = "169.254.169.254,169.254.170.2"
 )
@@ -142,6 +139,10 @@ func (cs *ClientServerImpl) Connect() error {
 		return err
 	}
 
+	wsScheme, err := websocketScheme(parsedURL.Scheme)
+	if err != nil {
+		return err
+	}
 	parsedURL.Scheme = wsScheme
 
 	// NewRequest never returns an error if the url parses and we just verified
@@ -347,6 +348,19 @@ func (cs *ClientServerImpl) handleMessage(data []byte) {
 	} else {
 		seelog.Infof("No handler for message type: %s", typeStr)
 	}
+}
+
+func websocketScheme(httpScheme string) (wsScheme string, err error) {
+	// gorilla/websocket expects the websocket scheme (ws[s]://)
+	switch httpScheme {
+	case "http":
+		wsScheme = "ws"
+	case "https":
+		wsScheme = "wss"
+	default:
+		err = fmt.Errorf("Unknown httpScheme %s", httpScheme)
+	}
+	return
 }
 
 // See https://github.com/gorilla/websocket/blob/87f6f6a22ebfbc3f89b9ccdc7fddd1b914c095f9/conn.go#L650

--- a/agent/wsclient/client_test.go
+++ b/agent/wsclient/client_test.go
@@ -16,6 +16,7 @@ package wsclient
 import (
 	"io"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/aws/amazon-ecs-agent/agent/acs/model/ecsacs"
@@ -39,7 +40,8 @@ func TestConcurrentWritesDontPanic(t *testing.T) {
 	closeWS := make(chan []byte)
 	defer close(closeWS)
 
-	mockServer, _, requests, _, _ := utils.StartMockServer(t, closeWS)
+	mockServer, _, requests, _, _ := utils.GetMockServer(t, closeWS)
+	mockServer.StartTLS()
 	defer mockServer.Close()
 
 	req := ecsacs.AckRequest{Cluster: aws.String("test"), ContainerInstance: aws.String("test"), MessageId: aws.String("test")}
@@ -70,7 +72,8 @@ func TestProxyVariableCustomValue(t *testing.T) {
 	closeWS := make(chan []byte)
 	defer close(closeWS)
 
-	mockServer, _, _, _, _ := utils.StartMockServer(t, closeWS)
+	mockServer, _, _, _, _ := utils.GetMockServer(t, closeWS)
+	mockServer.StartTLS()
 	defer mockServer.Close()
 
 	testString := "Custom no proxy string"
@@ -86,7 +89,8 @@ func TestProxyVariableDefaultValue(t *testing.T) {
 	closeWS := make(chan []byte)
 	defer close(closeWS)
 
-	mockServer, _, _, _, _ := utils.StartMockServer(t, closeWS)
+	mockServer, _, _, _, _ := utils.GetMockServer(t, closeWS)
+	mockServer.StartTLS()
 	defer mockServer.Close()
 
 	os.Unsetenv("NO_PROXY")
@@ -104,7 +108,8 @@ func TestHandleMessagePermissibleCloseCode(t *testing.T) {
 	defer close(closeWS)
 
 	messageError := make(chan error)
-	mockServer, _, _, _, _ := utils.StartMockServer(t, closeWS)
+	mockServer, _, _, _, _ := utils.GetMockServer(t, closeWS)
+	mockServer.StartTLS()
 	cs := getClientServer(mockServer.URL)
 	cs.Connect()
 
@@ -123,7 +128,8 @@ func TestHandleMessageUnexpectedCloseCode(t *testing.T) {
 	defer close(closeWS)
 
 	messageError := make(chan error)
-	mockServer, _, _, _, _ := utils.StartMockServer(t, closeWS)
+	mockServer, _, _, _, _ := utils.GetMockServer(t, closeWS)
+	mockServer.StartTLS()
 	cs := getClientServer(mockServer.URL)
 	cs.Connect()
 
@@ -133,6 +139,65 @@ func TestHandleMessageUnexpectedCloseCode(t *testing.T) {
 
 	closeWS <- websocket.FormatCloseMessage(websocket.CloseTryAgainLater, ":(")
 	assert.True(t, websocket.IsCloseError(<-messageError, websocket.CloseTryAgainLater), "Expected error from websocket library")
+}
+
+// TestHandlNonHTTPSEndpoint verifies that the wsclient can handle communication over
+// an HTTP (so WS) connection
+func TestHandleNonHTTPSEndpoint(t *testing.T) {
+	closeWS := make(chan []byte)
+	defer close(closeWS)
+
+	mockServer, _, requests, _, _ := utils.GetMockServer(t, closeWS)
+	mockServer.Start()
+	defer mockServer.Close()
+
+	cs := getClientServer(mockServer.URL)
+	cs.Connect()
+
+	req := ecsacs.AckRequest{Cluster: aws.String("test"), ContainerInstance: aws.String("test"), MessageId: aws.String("test")}
+	cs.MakeRequest(&req)
+
+	t.Log("Waiting for single request to be visible server-side")
+	<-requests
+}
+
+// TestHandleIncorrectHttpScheme checks that an incorrect URL scheme results in
+// an error
+func TestHandleIncorrectURLScheme(t *testing.T) {
+	closeWS := make(chan []byte)
+	defer close(closeWS)
+
+	mockServer, _, _, _, _ := utils.GetMockServer(t, closeWS)
+	mockServer.StartTLS()
+	defer mockServer.Close()
+
+	mockServerURL := strings.Replace(mockServer.URL, "https", "notaparticularlyrealscheme", 1)
+
+	cs := getClientServer(mockServerURL)
+	err := cs.Connect()
+
+	assert.Error(t, err, "Expected error for incorrect URL scheme")
+}
+
+// TestWebsocketScheme checks that websocketScheme handles valid and invalid mappings
+// correctly
+func TestWebsocketScheme(t *testing.T) {
+	// test valid schemes
+	validMappings := map[string]string{
+		"http":  "ws",
+		"https": "wss",
+	}
+
+	for input, expectedOutput := range validMappings {
+		actualOutput, err := websocketScheme(input)
+
+		assert.NoError(t, err, "Unexpected error for valid http scheme")
+		assert.Equal(t, actualOutput, expectedOutput, "Valid http schemes should map to a websocket scheme")
+	}
+
+	// test an invalid mapping
+	_, err := websocketScheme("highly-likely-to-be-junk")
+	assert.Error(t, err, "Expected error for invalid http scheme")
 }
 
 func getClientServer(url string) *ClientServerImpl {

--- a/agent/wsclient/client_test.go
+++ b/agent/wsclient/client_test.go
@@ -15,8 +15,8 @@ package wsclient
 
 import (
 	"io"
+	"net/url"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/aws/amazon-ecs-agent/agent/acs/model/ecsacs"
@@ -171,9 +171,10 @@ func TestHandleIncorrectURLScheme(t *testing.T) {
 	mockServer.StartTLS()
 	defer mockServer.Close()
 
-	mockServerURL := strings.Replace(mockServer.URL, "https", "notaparticularlyrealscheme", 1)
+	mockServerURL, _ := url.Parse(mockServer.URL)
+	mockServerURL.Scheme = "notaparticularlyrealscheme"
 
-	cs := getClientServer(mockServerURL)
+	cs := getClientServer(mockServerURL.String())
 	err := cs.Connect()
 
 	assert.Error(t, err, "Expected error for incorrect URL scheme")

--- a/agent/wsclient/mock/utils/utils.go
+++ b/agent/wsclient/mock/utils/utils.go
@@ -22,9 +22,9 @@ import (
 	"github.com/gorilla/websocket"
 )
 
-// StartMockServer starts a mock websocket server.
+// GetMockServer retuns a mock websocket server that can be started up as TLS or not.
 // TODO replace with gomock
-func StartMockServer(t *testing.T, closeWS <-chan []byte) (*httptest.Server, chan<- string, <-chan string, <-chan error, error) {
+func GetMockServer(t *testing.T, closeWS <-chan []byte) (*httptest.Server, chan<- string, <-chan string, <-chan error, error) {
 	serverChan := make(chan string)
 	requestsChan := make(chan string)
 	errChan := make(chan error)
@@ -63,6 +63,6 @@ func StartMockServer(t *testing.T, closeWS <-chan []byte) (*httptest.Server, cha
 		}
 	})
 
-	server := httptest.NewTLSServer(handler)
+	server := httptest.NewUnstartedServer(handler)
 	return server, serverChan, requestsChan, errChan, nil
 }


### PR DESCRIPTION
### Summary

This pull requests allows the wsclient (and therefore acs and tcs) to connect over http and upgrade to a plain websocket connection.

### Implementation details
wss (secure websocket) was hardcoded. This change makes a determination based on http or https. Maybe there will be some crazy httpX in the future so I made it a switch.

### Testing

- [X] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [X] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [X] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes

### Description for the changelog
Enhancement - Allow plain HTTP connections through wsclient

### Licensing
This contribution is under the terms of the Apache 2.0 License: yes
