### PR TITLE
Fix type assertion bug

### DIFF
--- a/agent/engine/docker_container_engine.go
+++ b/agent/engine/docker_container_engine.go
@@ -552,7 +552,7 @@ func (dg *dockerGoClient) StopContainer(dockerID string, timeout time.Duration) 
 		if err == context.DeadlineExceeded {
 			return DockerContainerMetadata{Error: &DockerTimeoutError{timeout, "stopped"}}
 		}
-		return DockerContainerMetadata{Error: &CannotStopContainerError{err}}
+		return DockerContainerMetadata{Error: CannotStopContainerError{err}}
 	}
 }
 

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -901,7 +901,7 @@ func TestTaskTransitionWhenStopContainerReturnsTransientErrorBeforeSucceeding(t 
 	client.EXPECT().ContainerEvents(gomock.Any()).Return(eventStream, nil)
 	mockTime.EXPECT().After(gomock.Any()).AnyTimes()
 	containerStoppingError := DockerContainerMetadata{
-		Error: &CannotStopContainerError{errors.New("Error stopping container")},
+		Error: CannotStopContainerError{errors.New("Error stopping container")},
 	}
 	for _, container := range sleepTask.Containers {
 		gomock.InOrder(

--- a/agent/engine/errors.go
+++ b/agent/engine/errors.go
@@ -30,6 +30,11 @@ type engineError interface {
 	ErrorName() string
 }
 
+type cannotStopContainerError interface {
+	engineError
+	IsUnretriableError() bool
+}
+
 // impossibleTransitionError is an error that occurs when an event causes a
 // container to try and transition to a state that it cannot be moved to
 type impossibleTransitionError struct {

--- a/agent/engine/errors.go
+++ b/agent/engine/errors.go
@@ -32,7 +32,7 @@ type engineError interface {
 
 type cannotStopContainerError interface {
 	engineError
-	IsUnretriableError() bool
+	IsRetriableError() bool
 }
 
 // impossibleTransitionError is an error that occurs when an event causes a
@@ -159,15 +159,21 @@ func (err CannotStopContainerError) ErrorName() string {
 	return "CannotStopContainerError"
 }
 
-func (err CannotStopContainerError) IsUnretriableError() bool {
+// IsRetriableError returns a boolean indicating whether the call that
+// generated the error can be retried.
+// When stopping a container, most errors that we can get should be
+// considered retriable. However, in the case where the container is
+// already stopped or doesn't exist at all, there's no sense in
+// retrying.
+func (err CannotStopContainerError) IsRetriableError() bool {
 	if _, ok := err.fromError.(*docker.NoSuchContainer); ok {
-		return true
+		return false
 	}
 	if _, ok := err.fromError.(*docker.ContainerNotRunning); ok {
-		return true
+		return false
 	}
 
-	return false
+	return true
 }
 
 // CannotPullContainerError indicates any error when trying to pull

--- a/agent/engine/errors_test.go
+++ b/agent/engine/errors_test.go
@@ -22,17 +22,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestUnretriableErrorReturnsTrueForNoSuchContainer(t *testing.T) {
+func TestRetriableErrorReturnsFalseForNoSuchContainer(t *testing.T) {
 	err := CannotStopContainerError{&docker.NoSuchContainer{}}
-	assert.True(t, err.IsUnretriableError(), "No such container error should be treated as unretriable docker error")
+	assert.False(t, err.IsRetriableError(), "No such container error should be treated as unretriable docker error")
 }
 
-func TestUnretriableErrorReturnsTrueForContainerNotRunning(t *testing.T) {
+func TestRetriableErrorReturnsFalseForContainerNotRunning(t *testing.T) {
 	err := CannotStopContainerError{&docker.ContainerNotRunning{}}
-	assert.True(t, err.IsUnretriableError(), "ContainerNotRunning error should be treated as unretriable docker error")
+	assert.False(t, err.IsRetriableError(), "ContainerNotRunning error should be treated as unretriable docker error")
 }
 
-func TestUnretriableErrorReturnsFalse(t *testing.T) {
+func TestRetriableErrorReturnsTrue(t *testing.T) {
 	err := CannotStopContainerError{errors.New("error")}
-	assert.False(t, err.IsUnretriableError(), "Non unretriable error treated as unretriable docker error")
+	assert.True(t, err.IsRetriableError(), "Non unretriable error treated as unretriable docker error")
 }

--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -255,7 +255,7 @@ func (mtask *managedTask) handleContainerChange(containerChange dockerContainerC
 			// If docker returned a transient error while trying to stop a container,
 			// reset the known status to the current status and return
 			cannotStopContainerError, ok := event.Error.(cannotStopContainerError)
-			if ok && !cannotStopContainerError.IsUnretriableError() {
+			if ok && cannotStopContainerError.IsRetriableError() {
 				seelog.Infof("Error stopping the container, ignoring state change; error: %s, task: %v",
 					cannotStopContainerError.Error(), mtask.Task)
 				container.SetKnownStatus(currentKnownStatus)

--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -254,7 +254,7 @@ func (mtask *managedTask) handleContainerChange(containerChange dockerContainerC
 			}
 			// If docker returned a transient error while trying to stop a container,
 			// reset the known status to the current status and return
-			cannotStopContainerError, ok := event.Error.(*CannotStopContainerError)
+			cannotStopContainerError, ok := event.Error.(cannotStopContainerError)
 			if ok && !cannotStopContainerError.IsUnretriableError() {
 				seelog.Infof("Error stopping the container, ignoring state change; error: %s, task: %v",
 					cannotStopContainerError.Error(), mtask.Task)
@@ -266,8 +266,9 @@ func (mtask *managedTask) handleContainerChange(containerChange dockerContainerC
 			// clearly can't just continue trying to transition it to stopped
 			// again and again... In this case, assume it's stopped (or close
 			// enough) and get on with it
-			// This actually happens a lot for the case of stopping something that was not running.
-			llog.Info("Error for 'docker stop' of container; assuming it's stopped anyways", "err", event.Error)
+			// This can happen in cases where the container we tried to stop
+			// was already stopped or did not exist at all.
+			seelog.Warnf("'docker stop' returned %s: %s", event.Error.ErrorName(), event.Error.Error())
 			container.SetKnownStatus(api.ContainerStopped)
 			container.SetDesiredStatus(api.ContainerStopped)
 		} else if event.Status == api.ContainerPulled {


### PR DESCRIPTION
A type assertion of event.Error assumed that the variable being tested was a
reference, when we actually weren't consistent in how we assigned that
variable. This caused the assertion to fail in places where it should have
passed, ultimately causing us to leak containers in the case where docker
returned an API error in response to the 'stop' call.

### Summary
Fix a bug in which containers can be leaked in the event that docker returns an error in response to a `stop` API call.

### Implementation details

This is a minimal fix that ensures that we're performing assertions of the same type that we're actually assigning. It additionally makes a minor change to log output to add some additional detail.

### Testing

Using a custom build of Docker to force the `stop` API call to return a 500 error. Verify that without this change, agent logs `Error while pulling container; will try to run anyways` and leaks a container. (Leak, in this case, means that it has indicated to the ECS service that the task has successfully transitioned to `STOPPED` even though at least one associated container was still running, and no further efforts would be made to terminate the container.)

With the change, Agent exhibits the expected behavior, which is that it retries the `stop` call indefinitely and does not signal that the task has transitioned to `STOPPED`.

- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes:

### Description for the changelog

Bug -- Fix a situation in which containers may be falsely reported as STOPPED in the case of a Docker "stop" API failure.

### Licensing

This contribution is under the terms of the Apache 2.0 License: yes
