### PR TITLE
Reduce the acs inactivity timeout to 1 minute

### DIFF
--- a/agent/acs/handler/acs_handler.go
+++ b/agent/acs/handler/acs_handler.go
@@ -45,8 +45,8 @@ import (
 const (
 	// heartbeatTimeout is the maximum time to wait between heartbeats
 	// without disconnecting
-	heartbeatTimeout = 5 * time.Minute
-	heartbeatJitter  = 3 * time.Minute
+	heartbeatTimeout = 1 * time.Minute
+	heartbeatJitter  = 1 * time.Minute
 
 	inactiveInstanceReconnectDelay = 1 * time.Hour
 
@@ -298,7 +298,7 @@ func (acsSession *session) startACSSession(client wsclient.ClientServer, timer t
 	backoffResetTimer := time.AfterFunc(
 		utils.AddJitter(acsSession.heartbeatTimeout(), acsSession.heartbeatJitter()), func() {
 			// If we do not have an error connecting and remain connected for at
-			// least 5 or so minutes, reset the backoff. This prevents disconnect
+			// least 1 or so minutes, reset the backoff. This prevents disconnect
 			// errors that only happen infrequently from damaging the
 			// reconnectability as significantly.
 			acsSession.backoff.Reset()


### PR DESCRIPTION
  <!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This will reduce the acs disconnection period, the maximum disconnection period of acs would be 1 minute before agent try to connect to acs again. This should mitigate the issue #781.
### Implementation details
<!-- How are the changes implemented? -->
Change the default heartbeat timeout from 5 minute + random(3minutes) to 1 minute.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass
- [x] Run the agent for few hours, check the acs disconnection/connection period.
New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
* Enhancement - Reduce the disconnection period of agent to backend.

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
yes