### PR TITLE
Mention container name in OOM log message

### DIFF
--- a/agent/engine/docker_container_engine.go
+++ b/agent/engine/docker_container_engine.go
@@ -17,6 +17,7 @@ import (
 	"archive/tar"
 	"bufio"
 	"encoding/json"
+	"fmt"
 	"io"
 	"strings"
 	"sync"
@@ -679,7 +680,14 @@ func (dg *dockerGoClient) ContainerEvents(ctx context.Context) (<-chan DockerCon
 			// out of caution, some because it's a form of state change
 
 			case "oom":
-				seelog.Infof("process within container %v died due to OOM", event.ID)
+				containerInfo := event.ID
+				// events only contain the container's name in newer Docker API
+				// versions (starting with 1.22)
+				if containerName, ok := event.Actor.Attributes["name"]; ok {
+					containerInfo += fmt.Sprintf(" (name: %q)", containerName)
+				}
+
+				seelog.Infof("process within container %s died due to OOM", containerInfo)
 				// "oom" can either means any process got OOM'd, but doesn't always
 				// mean the container dies (non-init processes). If the container also
 				// dies, you see a "die" status as well; we'll update suitably there


### PR DESCRIPTION
### Summary
This PR adds the container's name to the log message that is written by the agent when a process in a container is killed by the OOM killer. This makes it easier to find containers with processes that run OOM.

As the code's comments mention, only OOM events that bring a container to stop are reported in the event stream. Therefore, we can only rely on the ECS agent's logs to find sub-processes in Docker containers that run OOM.

### Implementation details
According to the [the docs](https://docs.docker.com/engine/api/v1.22/), the Docker API started exposing more information about the container in question with version 1.22. 

The code adds the container's name only if it is available in the event.

### Testing
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: no

### Description for the changelog

Add container name to agent's OOM log message

### Licensing
This contribution is under the terms of the Apache 2.0 License: yes