### PR TITLE
ENI workflow bug fixes

### DIFF
--- a/agent/acs/handler/attach_eni_handler.go
+++ b/agent/acs/handler/attach_eni_handler.go
@@ -100,7 +100,7 @@ func (handler *attachENIHandler) handleSingleMessage(message *ecsacs.AttachTaskN
 	// Validate fields in the message
 	if err := validateAttachTaskNetworkInterfacesMessage(message); err != nil {
 		return errors.Wrapf(err,
-			"attach eni message handler: error validating AttachTaskNetworkInterfac message received from ECS")
+			"attach eni message handler: error validating AttachTaskNetworkInterface message received from ECS")
 	}
 	if err := handler.acsClient.MakeRequest(&ecsacs.AckRequest{
 		Cluster:           message.ClusterArn,

--- a/agent/acs/handler/attach_eni_handler.go
+++ b/agent/acs/handler/attach_eni_handler.go
@@ -142,7 +142,7 @@ func (handler *attachENIHandler) addENIAttachmentToState(message *ecsacs.AttachT
 	if err := eniAttachment.StartTimer(eniAckTimeoutHandler.handle); err != nil {
 		return err
 	}
-	seelog.Info("Adding eni info for task '%s' to state, attachment=%s mac=%s",
+	seelog.Infof("Adding eni info for task '%s' to state, attachment=%s mac=%s",
 		taskARN, attachmentARN, mac)
 	handler.state.AddENIAttachment(eniAttachment)
 	return nil

--- a/agent/acs/handler/attach_eni_handler_test.go
+++ b/agent/acs/handler/attach_eni_handler_test.go
@@ -28,9 +28,9 @@ import (
 )
 
 const (
-	eniMessageId = "123"
-	randomMAC    = "00:0a:95:9d:68:16"
-	waitTimeout  = 10
+	eniMessageId      = "123"
+	randomMAC         = "00:0a:95:9d:68:16"
+	waitTimeoutMillis = 10
 )
 
 // TestAttachENIMessageWithNoMessageId checks the validator against an
@@ -41,7 +41,7 @@ func TestAttachENIMessageWithNoMessageId(t *testing.T) {
 		ContainerInstanceArn:     aws.String(containerInstanceArn),
 		ElasticNetworkInterfaces: []*ecsacs.ElasticNetworkInterface{},
 		TaskArn:                  aws.String(taskArn),
-		WaitTimeoutMs:            aws.Int64(waitTimeout),
+		WaitTimeoutMs:            aws.Int64(waitTimeoutMillis),
 	}
 
 	err := validateAttachTaskNetworkInterfacesMessage(message)
@@ -56,7 +56,7 @@ func TestAttachENIMessageWithNoClusterArn(t *testing.T) {
 		ContainerInstanceArn:     aws.String(containerInstanceArn),
 		ElasticNetworkInterfaces: []*ecsacs.ElasticNetworkInterface{},
 		TaskArn:                  aws.String(taskArn),
-		WaitTimeoutMs:            aws.Int64(waitTimeout),
+		WaitTimeoutMs:            aws.Int64(waitTimeoutMillis),
 	}
 
 	err := validateAttachTaskNetworkInterfacesMessage(message)
@@ -71,7 +71,7 @@ func TestAttachENIMessageWithNoContainerInstanceArn(t *testing.T) {
 		ClusterArn:               aws.String(clusterName),
 		ElasticNetworkInterfaces: []*ecsacs.ElasticNetworkInterface{},
 		TaskArn:                  aws.String(taskArn),
-		WaitTimeoutMs:            aws.Int64(waitTimeout),
+		WaitTimeoutMs:            aws.Int64(waitTimeoutMillis),
 	}
 
 	err := validateAttachTaskNetworkInterfacesMessage(message)
@@ -85,7 +85,7 @@ func TestAttachENIMessageWithNoInterfaces(t *testing.T) {
 		MessageId:     aws.String(eniMessageId),
 		ClusterArn:    aws.String(clusterName),
 		TaskArn:       aws.String(taskArn),
-		WaitTimeoutMs: aws.Int64(waitTimeout),
+		WaitTimeoutMs: aws.Int64(waitTimeoutMillis),
 	}
 	err := validateAttachTaskNetworkInterfacesMessage(message)
 	assert.Error(t, err)
@@ -111,7 +111,7 @@ func TestAttachENIMessageWithMultipleInterfaces(t *testing.T) {
 			&mockNetInterface2,
 		},
 		TaskArn:       aws.String(taskArn),
-		WaitTimeoutMs: aws.Int64(waitTimeout),
+		WaitTimeoutMs: aws.Int64(waitTimeoutMillis),
 	}
 
 	err := validateAttachTaskNetworkInterfacesMessage(message)
@@ -131,7 +131,7 @@ func TestAttachENIMessageWithMissingNetworkDetails(t *testing.T) {
 			&mockNetInterface1,
 		},
 		TaskArn:       aws.String(taskArn),
-		WaitTimeoutMs: aws.Int64(waitTimeout),
+		WaitTimeoutMs: aws.Int64(waitTimeoutMillis),
 	}
 
 	err := validateAttachTaskNetworkInterfacesMessage(message)
@@ -152,7 +152,7 @@ func TestAttachENIMessageWithMissingMACAddress(t *testing.T) {
 			&mockNetInterface1,
 		},
 		TaskArn:       aws.String(taskArn),
-		WaitTimeoutMs: aws.Int64(waitTimeout),
+		WaitTimeoutMs: aws.Int64(waitTimeoutMillis),
 	}
 
 	err := validateAttachTaskNetworkInterfacesMessage(message)
@@ -176,7 +176,7 @@ func TestAttachENIMessageWithMissingTaskArn(t *testing.T) {
 		ElasticNetworkInterfaces: []*ecsacs.ElasticNetworkInterface{
 			&mockNetInterface1,
 		},
-		WaitTimeoutMs: aws.Int64(waitTimeout),
+		WaitTimeoutMs: aws.Int64(waitTimeoutMillis),
 	}
 
 	err := validateAttachTaskNetworkInterfacesMessage(message)
@@ -237,14 +237,14 @@ func TestENIAckSingleMessage(t *testing.T) {
 			&mockNetInterface1,
 		},
 		TaskArn:       aws.String(taskArn),
-		WaitTimeoutMs: aws.Int64(waitTimeout),
+		WaitTimeoutMs: aws.Int64(waitTimeoutMillis),
 	}
 
 	eniAttachHandler.handleSingleMessage(message)
 	assert.Len(t, taskEngineState.(*dockerstate.DockerTaskEngineState).AllENIAttachments(), 1)
 	eniattachment, ok := taskEngineState.ENIByMac(randomMAC)
 	assert.True(t, ok)
-	assert.Equal(t, taskArn, eniattachment.TaskArn)
+	assert.Equal(t, taskArn, eniattachment.TaskARN)
 
 	select {
 	case <-eniAttachHandler.ctx.Done():
@@ -289,7 +289,7 @@ func TestENIAckForMessageIdMismatch(t *testing.T) {
 			&mockNetInterface1,
 		},
 		TaskArn:       aws.String(taskArn),
-		WaitTimeoutMs: aws.Int64(waitTimeout),
+		WaitTimeoutMs: aws.Int64(waitTimeoutMillis),
 	}
 
 	eniAttachHandler.handleSingleMessage(message)
@@ -334,7 +334,7 @@ func TestENIAckHappyPath(t *testing.T) {
 			&mockNetInterface1,
 		},
 		TaskArn:       aws.String(taskArn),
-		WaitTimeoutMs: aws.Int64(waitTimeout),
+		WaitTimeoutMs: aws.Int64(waitTimeoutMillis),
 	}
 
 	eniAttachHandler.messageBuffer <- message
@@ -371,13 +371,13 @@ func TestENIAckTimeout(t *testing.T) {
 			&mockNetInterface1,
 		},
 		TaskArn:       aws.String(taskArn),
-		WaitTimeoutMs: aws.Int64(waitTimeout),
+		WaitTimeoutMs: aws.Int64(waitTimeoutMillis),
 	}
 
-	eniAttachHandler.addENIAttachmentToState(message)
+	eniAttachHandler.addENIAttachmentToState(message, time.Now())
 	assert.Len(t, taskEngineState.(*dockerstate.DockerTaskEngineState).AllENIAttachments(), 1)
 	for {
-		time.Sleep(time.Millisecond * waitTimeout)
+		time.Sleep(time.Millisecond * waitTimeoutMillis)
 		if len(taskEngineState.(*dockerstate.DockerTaskEngineState).AllENIAttachments()) == 0 {
 			break
 		}
@@ -408,16 +408,16 @@ func TestENIAckWithinTimeout(t *testing.T) {
 			&mockNetInterface1,
 		},
 		TaskArn:       aws.String(taskArn),
-		WaitTimeoutMs: aws.Int64(waitTimeout),
+		WaitTimeoutMs: aws.Int64(waitTimeoutMillis),
 	}
 
-	eniAttachHandler.addENIAttachmentToState(message)
+	eniAttachHandler.addENIAttachmentToState(message, time.Now())
 	assert.Len(t, taskEngineState.(*dockerstate.DockerTaskEngineState).AllENIAttachments(), 1)
 	eniAttachment, ok := taskEngineState.(*dockerstate.DockerTaskEngineState).ENIByMac(randomMAC)
 	assert.True(t, ok)
 	eniAttachment.SetSentStatus()
 
-	time.Sleep(time.Millisecond * waitTimeout)
+	time.Sleep(time.Millisecond * waitTimeoutMillis)
 
 	assert.Len(t, taskEngineState.(*dockerstate.DockerTaskEngineState).AllENIAttachments(), 1)
 }

--- a/agent/acs/handler/payload_handler.go
+++ b/agent/acs/handler/payload_handler.go
@@ -299,7 +299,7 @@ func (payloadHandler *payloadRequestHandler) handleUnrecognizedTask(task *ecsacs
 
 	// Only need to stop the task; it brings down the containers too.
 	taskEvent := api.TaskStateChange{
-		TaskArn: *task.Arn,
+		TaskARN: *task.Arn,
 		Status:  api.TaskStopped,
 		Reason:  UnrecognizedTaskError{err}.Error(),
 	}

--- a/agent/api/ecsclient/client.go
+++ b/agent/api/ecsclient/client.go
@@ -294,14 +294,14 @@ func (client *APIECSClient) SubmitTaskStateChange(change api.TaskStateChange) er
 		eniStatus := change.Attachment.Status.String()
 		attachments = []*ecs.AttachmentStateChange{
 			{
-				AttachmentArn: &change.Attachment.AttachmentARN,
-				Status:        &eniStatus,
+				AttachmentArn: aws.String(change.Attachment.AttachmentARN),
+				Status:        aws.String(eniStatus),
 			},
 		}
 
 		_, err := client.submitStateChangeClient.SubmitTaskStateChange(&ecs.SubmitTaskStateChangeInput{
-			Cluster:     &client.config.Cluster,
-			Task:        &change.TaskArn,
+			Cluster:     aws.String(client.config.Cluster),
+			Task:        aws.String(change.TaskARN),
 			Attachments: attachments,
 		})
 		if err != nil {
@@ -328,7 +328,7 @@ func (client *APIECSClient) SubmitTaskStateChange(change api.TaskStateChange) er
 
 	req := ecs.SubmitTaskStateChangeInput{
 		Cluster: aws.String(client.config.Cluster),
-		Task:    aws.String(change.TaskArn),
+		Task:    aws.String(change.TaskARN),
 		Status:  aws.String(status),
 		Reason:  aws.String(change.Reason),
 	}

--- a/agent/api/ecsclient/client.go
+++ b/agent/api/ecsclient/client.go
@@ -294,7 +294,7 @@ func (client *APIECSClient) SubmitTaskStateChange(change api.TaskStateChange) er
 		eniStatus := change.Attachments.Status.String()
 		attachments = []*ecs.AttachmentStateChange{
 			{
-				AttachmentArn: &change.Attachments.AttachmentArn,
+				AttachmentArn: &change.Attachments.AttachmentARN,
 				Status:        &eniStatus,
 			},
 		}

--- a/agent/api/ecsclient/client.go
+++ b/agent/api/ecsclient/client.go
@@ -288,13 +288,13 @@ func (client *APIECSClient) getCustomAttributes() []*ecs.Attribute {
 
 func (client *APIECSClient) SubmitTaskStateChange(change api.TaskStateChange) error {
 	// Submit attachment state change
-	if change.Attachments != nil {
+	if change.Attachment != nil {
 		var attachments []*ecs.AttachmentStateChange
 
-		eniStatus := change.Attachments.Status.String()
+		eniStatus := change.Attachment.Status.String()
 		attachments = []*ecs.AttachmentStateChange{
 			{
-				AttachmentArn: &change.Attachments.AttachmentARN,
+				AttachmentArn: &change.Attachment.AttachmentARN,
 				Status:        &eniStatus,
 			},
 		}

--- a/agent/api/ecsclient/client_test.go
+++ b/agent/api/ecsclient/client_test.go
@@ -668,7 +668,7 @@ func TestSubmitTaskStateChangeWithAttachments(t *testing.T) {
 	err := client.SubmitTaskStateChange(api.TaskStateChange{
 		TaskArn: "task_arn",
 		Attachments: &api.ENIAttachment{
-			AttachmentArn: "eni_arn",
+			AttachmentARN: "eni_arn",
 			Status:        api.ENIAttached,
 		},
 	})

--- a/agent/api/ecsclient/client_test.go
+++ b/agent/api/ecsclient/client_test.go
@@ -667,7 +667,7 @@ func TestSubmitTaskStateChangeWithAttachments(t *testing.T) {
 
 	err := client.SubmitTaskStateChange(api.TaskStateChange{
 		TaskArn: "task_arn",
-		Attachments: &api.ENIAttachment{
+		Attachment: &api.ENIAttachment{
 			AttachmentARN: "eni_arn",
 			Status:        api.ENIAttached,
 		},

--- a/agent/api/ecsclient/client_test.go
+++ b/agent/api/ecsclient/client_test.go
@@ -666,7 +666,7 @@ func TestSubmitTaskStateChangeWithAttachments(t *testing.T) {
 	})
 
 	err := client.SubmitTaskStateChange(api.TaskStateChange{
-		TaskArn: "task_arn",
+		TaskARN: "task_arn",
 		Attachment: &api.ENIAttachment{
 			AttachmentARN: "eni_arn",
 			Status:        api.ENIAttached,
@@ -691,7 +691,7 @@ func TestSubmitTaskStateChangeWithoutAttachments(t *testing.T) {
 	})
 
 	err := client.SubmitTaskStateChange(api.TaskStateChange{
-		TaskArn: "task_arn",
+		TaskARN: "task_arn",
 		Status:  api.TaskRunning,
 	})
 	assert.NoError(t, err, "Unable to submit task state change with no attachments")

--- a/agent/api/eni.go
+++ b/agent/api/eni.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -14,29 +14,10 @@
 package api
 
 import (
-	"sync"
-
 	"github.com/aws/amazon-ecs-agent/agent/acs/model/ecsacs"
-	"github.com/aws/amazon-ecs-agent/agent/utils/ttime"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/pkg/errors"
 )
-
-// ENIAttachment contains the information of the eni attachment
-type ENIAttachment struct {
-	// TaskArn is the task identifier from ecs
-	TaskArn string `json:"taskarn"`
-	// AttachmentArn is the identifier for the eni attachment
-	AttachmentArn string `json:"attachmentArn"`
-	// AttachStatusSent indicates whether the attached status has been sent to backend
-	AttachStatusSent bool `json:"attachSent"`
-	// MacAddress is the mac address of eni
-	MacAddress string `json:"macAddress"`
-	// Status is the status of the eni: none/attached/detached
-	Status         ENIAttachmentStatus `json:"status"`
-	sentStatusLock sync.RWMutex
-	AckTimer       ttime.Timer
-}
 
 // ENI contains information of the eni
 type ENI struct {
@@ -121,25 +102,4 @@ func ValidateTaskENI(acsenis []*ecsacs.ElasticNetworkInterface) error {
 	}
 
 	return nil
-}
-
-// IsSent checks if the eni attached status has been sent
-func (eni *ENIAttachment) IsSent() bool {
-	eni.sentStatusLock.RLock()
-	defer eni.sentStatusLock.RUnlock()
-
-	return eni.AttachStatusSent
-}
-
-// SetSentStatus marks the eni attached status has been sent
-func (eni *ENIAttachment) SetSentStatus() {
-	eni.sentStatusLock.Lock()
-	defer eni.sentStatusLock.Unlock()
-
-	eni.AttachStatusSent = true
-}
-
-// StopAckTimer stops the ack timer set on the ENI attachment
-func (eni *ENIAttachment) StopAckTimer() {
-	eni.AckTimer.Stop()
 }

--- a/agent/api/eniattachment.go
+++ b/agent/api/eniattachment.go
@@ -14,6 +14,7 @@
 package api
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
@@ -81,4 +82,14 @@ func (eni *ENIAttachment) SetSentStatus() {
 // StopAckTimer stops the ack timer set on the ENI attachment
 func (eni *ENIAttachment) StopAckTimer() {
 	eni.ackTimer.Stop()
+}
+
+// String returns a string representation of the ENI Attachment
+func (eni *ENIAttachment) String() string {
+	eni.sentStatusLock.RLock()
+	defer eni.sentStatusLock.RUnlock()
+
+	return fmt.Sprintf(
+		"ENI Attachment; task=%s;attachment=%s;attachmentSent=%t;mac=%s;status=%s;expiresAt=%s",
+		eni.TaskARN, eni.AttachmentARN, eni.AttachStatusSent, eni.MACAddress, eni.Status.String(), eni.ExpiresAt.String())
 }

--- a/agent/api/eniattachment.go
+++ b/agent/api/eniattachment.go
@@ -1,0 +1,84 @@
+// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package api
+
+import (
+	"sync"
+	"time"
+
+	"github.com/aws/amazon-ecs-agent/agent/utils/ttime"
+	"github.com/cihub/seelog"
+	"github.com/pkg/errors"
+)
+
+// ENIAttachment contains the information of the eni attachment
+type ENIAttachment struct {
+	// TaskARN is the task identifier from ecs
+	TaskARN string `json:"taskArn"`
+	// AttachmentARN is the identifier for the eni attachment
+	AttachmentARN string `json:"attachmentArn"`
+	// AttachStatusSent indicates whether the attached status has been sent to backend
+	AttachStatusSent bool `json:"attachSent"`
+	// MACAddress is the mac address of eni
+	MACAddress string `json:"macAddress"`
+	// Status is the status of the eni: none/attached/detached
+	Status         ENIAttachmentStatus `json:"status"`
+	sentStatusLock sync.RWMutex
+	// ExpiresAt is the timestamp past which the ENI Attachment is considered
+	// unsuccessful. The SubmitTaskStateChange API, with the attachment information
+	// should be invoked before this timestamp.
+	ExpiresAt time.Time `json:"expiresAt"`
+	// ackTimer is used to register the expirtation timeout callback for unsuccessful
+	// ENI attachments
+	ackTimer ttime.Timer
+}
+
+// StartTimer starts the ack timer to record the expiration of ENI attachment
+func (eni *ENIAttachment) StartTimer(timeoutFunc func()) error {
+	if eni.ackTimer != nil {
+		// The timer has already been initialized, do nothing
+		return nil
+	}
+	now := time.Now()
+	duration := eni.ExpiresAt.Sub(now)
+	if duration <= 0 {
+		return errors.Errorf("eni attachment: timer expiration is in the past; expiration [%s] < now [%s]",
+			eni.ExpiresAt.String(), now.String())
+	}
+	seelog.Infof("Starting ENI ack timer for task %s, with mac address %s, to expire at %s, with duration: %s",
+		eni.TaskARN, eni.MACAddress, eni.ExpiresAt, duration.String())
+	eni.ackTimer = time.AfterFunc(duration, timeoutFunc)
+	return nil
+}
+
+// IsSent checks if the eni attached status has been sent
+func (eni *ENIAttachment) IsSent() bool {
+	eni.sentStatusLock.RLock()
+	defer eni.sentStatusLock.RUnlock()
+
+	return eni.AttachStatusSent
+}
+
+// SetSentStatus marks the eni attached status has been sent
+func (eni *ENIAttachment) SetSentStatus() {
+	eni.sentStatusLock.Lock()
+	defer eni.sentStatusLock.Unlock()
+
+	eni.AttachStatusSent = true
+}
+
+// StopAckTimer stops the ack timer set on the ENI attachment
+func (eni *ENIAttachment) StopAckTimer() {
+	eni.ackTimer.Stop()
+}

--- a/agent/api/eniattachment.go
+++ b/agent/api/eniattachment.go
@@ -57,8 +57,7 @@ func (eni *ENIAttachment) StartTimer(timeoutFunc func()) error {
 		return errors.Errorf("eni attachment: timer expiration is in the past; expiration [%s] < now [%s]",
 			eni.ExpiresAt.String(), now.String())
 	}
-	seelog.Infof("Starting ENI ack timer for task %s, with mac address %s, to expire at %s, with duration: %s",
-		eni.TaskARN, eni.MACAddress, eni.ExpiresAt, duration.String())
+	seelog.Infof("Starting ENI ack timer with duration=%s, %s", duration.String(), eni.String())
 	eni.ackTimer = time.AfterFunc(duration, timeoutFunc)
 	return nil
 }

--- a/agent/api/eniattachment_test.go
+++ b/agent/api/eniattachment_test.go
@@ -25,7 +25,7 @@ const (
 	taskARN       = "t1"
 	attachmentARN = "att1"
 	mac           = "mac1"
-	attachSent    = false
+	attachSent    = true
 )
 
 func TestMarshalUnmarshal(t *testing.T) {
@@ -43,7 +43,17 @@ func TestMarshalUnmarshal(t *testing.T) {
 	var unmarshalledAttachment ENIAttachment
 	err = json.Unmarshal(bytes, &unmarshalledAttachment)
 	assert.NoError(t, err)
-	assert.Equal(t, attachment.String(), unmarshalledAttachment.String())
+	assert.Equal(t, attachment.TaskARN, unmarshalledAttachment.TaskARN)
+	assert.Equal(t, attachment.AttachmentARN, unmarshalledAttachment.AttachmentARN)
+	assert.Equal(t, attachment.AttachStatusSent, unmarshalledAttachment.AttachStatusSent)
+	assert.Equal(t, attachment.MACAddress, unmarshalledAttachment.MACAddress)
+	assert.Equal(t, attachment.Status, unmarshalledAttachment.Status)
+
+	expectedExpiresAtUTC, err := time.Parse(time.RFC3339, attachment.ExpiresAt.Format(time.RFC3339))
+	assert.NoError(t, err)
+	unmarshalledExpiresAtUTC, err := time.Parse(time.RFC3339, unmarshalledAttachment.ExpiresAt.Format(time.RFC3339))
+	assert.NoError(t, err)
+	assert.Equal(t, expectedExpiresAtUTC, unmarshalledExpiresAtUTC)
 }
 
 func TestStartTimerErrorWhenExpiresAtIsInThePast(t *testing.T) {

--- a/agent/api/eniattachment_test.go
+++ b/agent/api/eniattachment_test.go
@@ -1,0 +1,60 @@
+// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package api
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	taskARN       = "t1"
+	attachmentARN = "att1"
+	mac           = "mac1"
+	attachSent    = false
+)
+
+func TestMarshalUnmarshal(t *testing.T) {
+	expiresAt := time.Now()
+	attachment := &ENIAttachment{
+		TaskARN:          taskARN,
+		AttachmentARN:    attachmentARN,
+		AttachStatusSent: attachSent,
+		MACAddress:       mac,
+		Status:           ENIAttachmentNone,
+		ExpiresAt:        expiresAt,
+	}
+	bytes, err := json.Marshal(attachment)
+	assert.NoError(t, err)
+	var unmarshalledAttachment ENIAttachment
+	err = json.Unmarshal(bytes, &unmarshalledAttachment)
+	assert.NoError(t, err)
+	assert.Equal(t, *attachment, unmarshalledAttachment)
+}
+
+func TestStartTimerErrorWhenExpiresAtIsInThePast(t *testing.T) {
+	expiresAt := time.Now().Unix() - 1
+	attachment := &ENIAttachment{
+		TaskARN:          taskARN,
+		AttachmentARN:    attachmentARN,
+		AttachStatusSent: attachSent,
+		MACAddress:       mac,
+		Status:           ENIAttachmentNone,
+		ExpiresAt:        time.Unix(expiresAt, 0),
+	}
+	assert.Error(t, attachment.StartTimer(func() {}))
+}

--- a/agent/api/eniattachment_test.go
+++ b/agent/api/eniattachment_test.go
@@ -43,7 +43,7 @@ func TestMarshalUnmarshal(t *testing.T) {
 	var unmarshalledAttachment ENIAttachment
 	err = json.Unmarshal(bytes, &unmarshalledAttachment)
 	assert.NoError(t, err)
-	assert.Equal(t, *attachment, unmarshalledAttachment)
+	assert.Equal(t, attachment.String(), unmarshalledAttachment.String())
 }
 
 func TestStartTimerErrorWhenExpiresAtIsInThePast(t *testing.T) {

--- a/agent/api/statechange.go
+++ b/agent/api/statechange.go
@@ -49,7 +49,7 @@ type TaskStateChange struct {
 	// Attachment is the eni attachment object to send
 	Attachment *ENIAttachment
 	// TaskArn is the unique identifier for the task
-	TaskArn string
+	TaskARN string
 	// Status is the status to send
 	Status TaskStatus
 	// Reason may contain details of why the task stopped
@@ -82,7 +82,7 @@ func (c *ContainerStateChange) String() string {
 
 // String returns a human readable string representation of this object
 func (t *TaskStateChange) String() string {
-	res := fmt.Sprintf("%s -> %s", t.TaskArn, t.Status.String())
+	res := fmt.Sprintf("%s -> %s", t.TaskARN, t.Status.String())
 	if t.Task != nil {
 		res += ", Known Sent: " + t.Task.GetSentStatus().String()
 	}

--- a/agent/api/statechange.go
+++ b/agent/api/statechange.go
@@ -15,8 +15,9 @@ package api
 
 import (
 	"fmt"
-	"github.com/aws/amazon-ecs-agent/agent/statechange"
 	"strconv"
+
+	"github.com/aws/amazon-ecs-agent/agent/statechange"
 )
 
 // ContainerStateChange represents a state change that needs to be sent to the
@@ -45,7 +46,8 @@ type ContainerStateChange struct {
 // TaskStateChange represents a state change that needs to be sent to the
 // SubmitTaskStateChange API
 type TaskStateChange struct {
-	Attachments *ENIAttachment
+	// Attachment is the eni attachment object to send
+	Attachment *ENIAttachment
 	// TaskArn is the unique identifier for the task
 	TaskArn string
 	// Status is the status to send
@@ -83,6 +85,9 @@ func (t *TaskStateChange) String() string {
 	res := fmt.Sprintf("%s -> %s", t.TaskArn, t.Status.String())
 	if t.Task != nil {
 		res += ", Known Sent: " + t.Task.GetSentStatus().String()
+	}
+	if t.Attachment != nil {
+		res += ", " + t.Attachment.String()
 	}
 	return res
 }

--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -91,6 +91,7 @@ type ecsAgent struct {
 	os                    oswrapper.OS
 	vpc                   string
 	subnet                string
+	mac                   string
 }
 
 // newAgent returns a new ecsAgent object

--- a/agent/app/agent_unix.go
+++ b/agent/app/agent_unix.go
@@ -112,6 +112,7 @@ func (agent *ecsAgent) setVPCSubnet() (error, bool) {
 	}
 	agent.vpc = vpcID
 	agent.subnet = subnetID
+	agent.mac = mac
 	return nil, false
 }
 
@@ -157,7 +158,7 @@ func (agent *ecsAgent) startUdevWatcher(state dockerstate.TaskEngineState, state
 		return errors.Wrapf(err, "unable to create udev monitor")
 	}
 	// Create Watcher
-	eniWatcher := watcher.New(agent.ctx, udevMonitor, state, stateChangeEvents)
+	eniWatcher := watcher.New(agent.ctx, agent.mac, udevMonitor, state, stateChangeEvents)
 	if err := eniWatcher.Init(); err != nil {
 		return errors.Wrapf(err, "unable to initialize eni watcher")
 	}

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -338,7 +338,7 @@ func (engine *DockerTaskEngine) emitTaskEvent(task *api.Task, reason string) {
 		return
 	}
 	event := api.TaskStateChange{
-		TaskArn: task.Arn,
+		TaskARN: task.Arn,
 		Status:  taskKnownStatus,
 		Reason:  reason,
 		Task:    task,

--- a/agent/engine/dockerstate/docker_task_engine_state.go
+++ b/agent/engine/dockerstate/docker_task_engine_state.go
@@ -189,8 +189,8 @@ func (state *DockerTaskEngineState) AddENIAttachment(eniAttachment *api.ENIAttac
 	state.lock.Lock()
 	defer state.lock.Unlock()
 
-	if _, ok := state.eniAttachments[eniAttachment.MacAddress]; !ok {
-		state.eniAttachments[eniAttachment.MacAddress] = eniAttachment
+	if _, ok := state.eniAttachments[eniAttachment.MACAddress]; !ok {
+		state.eniAttachments[eniAttachment.MACAddress] = eniAttachment
 	} else {
 		seelog.Debugf("Duplicate eni attachment information: %v", eniAttachment)
 	}

--- a/agent/engine/dockerstate/dockerstate_test.go
+++ b/agent/engine/dockerstate/dockerstate_test.go
@@ -82,23 +82,23 @@ func TestAddRemoveENIAttachment(t *testing.T) {
 	state := NewTaskEngineState()
 
 	attachment := &api.ENIAttachment{
-		TaskArn:       "taskarn",
-		AttachmentArn: "eni1",
-		MacAddress:    "mac1",
+		TaskARN:       "taskarn",
+		AttachmentARN: "eni1",
+		MACAddress:    "mac1",
 	}
 
 	state.AddENIAttachment(attachment)
 	assert.Len(t, state.(*DockerTaskEngineState).AllENIAttachments(), 1)
 	eni, ok := state.ENIByMac("mac1")
 	assert.True(t, ok)
-	assert.Equal(t, eni.TaskArn, attachment.TaskArn)
+	assert.Equal(t, eni.TaskARN, attachment.TaskARN)
 
 	eni, ok = state.ENIByMac("non-mac")
 	assert.False(t, ok)
 	assert.Nil(t, eni)
 
 	// Remove the attachment from state
-	state.RemoveENIAttachment(attachment.MacAddress)
+	state.RemoveENIAttachment(attachment.MACAddress)
 	assert.Len(t, state.AllImageStates(), 0)
 	eni, ok = state.ENIByMac("mac1")
 	assert.False(t, ok)

--- a/agent/engine/test_common.go
+++ b/agent/engine/test_common.go
@@ -55,7 +55,7 @@ func verifyTaskIsRunning(stateChangeEvents <-chan statechange.Event, testTasks .
 			if event.GetEventType() == statechange.TaskEvent {
 				taskEvent := event.(api.TaskStateChange)
 				for i, task := range testTasks {
-					if taskEvent.TaskArn != task.Arn {
+					if taskEvent.TaskARN != task.Arn {
 						continue
 					}
 					if taskEvent.Status == api.TaskRunning {
@@ -79,7 +79,7 @@ func verifyTaskIsStopped(stateChangeEvents <-chan statechange.Event, testTasks .
 			if event.GetEventType() == statechange.TaskEvent {
 				taskEvent := event.(api.TaskStateChange)
 				for i, task := range testTasks {
-					if taskEvent.TaskArn == task.Arn && taskEvent.Status >= api.TaskStopped {
+					if taskEvent.TaskARN == task.Arn && taskEvent.Status >= api.TaskStopped {
 						if len(testTasks) == 1 {
 							return
 						}

--- a/agent/eni/watcher/watcher_linux.go
+++ b/agent/eni/watcher/watcher_linux.go
@@ -139,8 +139,8 @@ func (udevWatcher *UdevWatcher) sendENIStateChange(mac string) {
 			eni.Status = api.ENIAttached
 			log.Infof("Emitting ENI change event for: %v", eni)
 			udevWatcher.eniChangeEvent <- api.TaskStateChange{
-				TaskArn:     eni.TaskARN,
-				Attachments: eni,
+				TaskArn:    eni.TaskARN,
+				Attachment: eni,
 			}
 		}(eniAttachment)
 	}

--- a/agent/eni/watcher/watcher_linux.go
+++ b/agent/eni/watcher/watcher_linux.go
@@ -139,7 +139,7 @@ func (udevWatcher *UdevWatcher) sendENIStateChange(mac string) {
 			eni.Status = api.ENIAttached
 			log.Infof("Emitting ENI change event for: %v", eni)
 			udevWatcher.eniChangeEvent <- api.TaskStateChange{
-				TaskArn:     eni.TaskArn,
+				TaskArn:     eni.TaskARN,
 				Attachments: eni,
 			}
 		}(eniAttachment)

--- a/agent/eni/watcher/watcher_linux.go
+++ b/agent/eni/watcher/watcher_linux.go
@@ -139,7 +139,7 @@ func (udevWatcher *UdevWatcher) sendENIStateChange(mac string) {
 			eni.Status = api.ENIAttached
 			log.Infof("Emitting ENI change event for: %v", eni)
 			udevWatcher.eniChangeEvent <- api.TaskStateChange{
-				TaskArn:    eni.TaskARN,
+				TaskARN:    eni.TaskARN,
 				Attachment: eni,
 			}
 		}(eniAttachment)

--- a/agent/eni/watcher/watcher_linux_test.go
+++ b/agent/eni/watcher/watcher_linux_test.go
@@ -56,7 +56,7 @@ func TestWatcherInit(t *testing.T) {
 
 	taskEngineState := dockerstate.NewTaskEngineState()
 	taskEngineState.AddENIAttachment(&api.ENIAttachment{
-		MacAddress:       randomMAC,
+		MACAddress:       randomMAC,
 		AttachStatusSent: false,
 	})
 	eventChannel := make(chan statechange.Event)
@@ -79,8 +79,8 @@ func TestWatcherInit(t *testing.T) {
 	var event statechange.Event
 	go func() {
 		event = <-eventChannel
-		assert.NotNil(t, event.(api.TaskStateChange).Attachments)
-		assert.Equal(t, randomMAC, event.(api.TaskStateChange).Attachments.MacAddress)
+		assert.NotNil(t, event.(api.TaskStateChange).Attachment)
+		assert.Equal(t, randomMAC, event.(api.TaskStateChange).Attachment.MACAddress)
 		waitForEvents.Done()
 	}()
 	watcher.Init()
@@ -146,7 +146,7 @@ func TestReconcileENIs(t *testing.T) {
 	eventChannel := make(chan statechange.Event)
 
 	taskEngineState.AddENIAttachment(&api.ENIAttachment{
-		MacAddress:       randomMAC,
+		MACAddress:       randomMAC,
 		AttachStatusSent: false,
 	})
 
@@ -171,8 +171,8 @@ func TestReconcileENIs(t *testing.T) {
 	watcher.reconcileOnce()
 
 	<-done
-	assert.NotNil(t, event.(api.TaskStateChange).Attachments)
-	assert.Equal(t, randomMAC, event.(api.TaskStateChange).Attachments.MacAddress)
+	assert.NotNil(t, event.(api.TaskStateChange).Attachment)
+	assert.Equal(t, randomMAC, event.(api.TaskStateChange).Attachment.MACAddress)
 
 	select {
 	case <-eventChannel:
@@ -282,7 +282,7 @@ func TestUdevAddEvent(t *testing.T) {
 	eniChangeEvent := <-eventChannel
 	taskStateChange, ok := eniChangeEvent.(api.TaskStateChange)
 	require.True(t, ok)
-	assert.Equal(t, api.ENIAttached, taskStateChange.Attachments.Status)
+	assert.Equal(t, api.ENIAttached, taskStateChange.Attachment.Status)
 
 	var waitForClose sync.WaitGroup
 	waitForClose.Add(2)
@@ -436,7 +436,7 @@ func TestSendENIStateChange(t *testing.T) {
 	eniChangeEvent := <-eventChannel
 	taskStateChange, ok := eniChangeEvent.(api.TaskStateChange)
 	require.True(t, ok)
-	assert.Equal(t, api.ENIAttached, taskStateChange.Attachments.Status)
+	assert.Equal(t, api.ENIAttached, taskStateChange.Attachment.Status)
 }
 
 func TestShouldSendENIStateChange(t *testing.T) {

--- a/agent/eventhandler/handler_test.go
+++ b/agent/eventhandler/handler_test.go
@@ -38,11 +38,11 @@ func containerEventStopped(arn string) statechange.Event {
 }
 
 func taskEvent(arn string) statechange.Event {
-	return api.TaskStateChange{TaskArn: arn, Status: api.TaskRunning, Task: &api.Task{}}
+	return api.TaskStateChange{TaskARN: arn, Status: api.TaskRunning, Task: &api.Task{}}
 }
 
 func taskEventStopped(arn string) statechange.Event {
-	return api.TaskStateChange{TaskArn: arn, Status: api.TaskStopped, Task: &api.Task{}}
+	return api.TaskStateChange{TaskARN: arn, Status: api.TaskStopped, Task: &api.Task{}}
 }
 
 func TestSendsEventsOneContainer(t *testing.T) {
@@ -191,13 +191,13 @@ func TestSendsEventsTaskDifferences(t *testing.T) {
 	taskEventB := taskEventStopped(taskarnB)
 
 	client.EXPECT().SubmitTaskStateChange(gomock.Any()).Do(func(change api.TaskStateChange) {
-		assert.Equal(t, taskarnA, change.TaskArn)
+		assert.Equal(t, taskarnA, change.TaskARN)
 		wgAddEvent.Done()
 		wg.Done()
 	})
 
 	client.EXPECT().SubmitTaskStateChange(gomock.Any()).Do(func(change api.TaskStateChange) {
-		assert.Equal(t, taskarnB, change.TaskArn)
+		assert.Equal(t, taskarnB, change.TaskARN)
 		wg.Done()
 	})
 
@@ -243,7 +243,7 @@ func TestSendsEventsDedupe(t *testing.T) {
 	client.EXPECT().SubmitTaskStateChange(gomock.Any()).Do(func(change api.TaskStateChange) {
 		assert.Equal(t, 1, len(change.Containers))
 		assert.Equal(t, taskarnB, change.Containers[0].TaskArn)
-		assert.Equal(t, taskarnB, change.TaskArn)
+		assert.Equal(t, taskarnB, change.TaskARN)
 		wg.Done()
 	})
 
@@ -288,7 +288,7 @@ func TestENISentStatusChange(t *testing.T) {
 
 	sendableTaskEvent := newSendableTaskEvent(api.TaskStateChange{
 		Attachment: eniAttachment,
-		TaskArn:    "taskarn",
+		TaskARN:    "taskarn",
 		Status:     api.TaskStatusNone,
 		Task:       task,
 	})

--- a/agent/eventhandler/handler_test.go
+++ b/agent/eventhandler/handler_test.go
@@ -289,9 +289,8 @@ func TestENISentStatusChange(t *testing.T) {
 	sendableTaskEvent := newSendableTaskEvent(api.TaskStateChange{
 		Attachment: eniAttachment,
 		TaskArn:    "taskarn",
-		// TODO: This should be api.TaskStatusNone
-		Status: api.TaskStatusNone,
-		Task:   task,
+		Status:     api.TaskStatusNone,
+		Task:       task,
 	})
 
 	client.EXPECT().SubmitTaskStateChange(gomock.Any()).Return(nil)

--- a/agent/eventhandler/handler_test.go
+++ b/agent/eventhandler/handler_test.go
@@ -287,10 +287,10 @@ func TestENISentStatusChange(t *testing.T) {
 	assert.NoError(t, eniAttachment.StartTimer(timeoutFunc))
 
 	sendableTaskEvent := newSendableTaskEvent(api.TaskStateChange{
-		Attachments: eniAttachment,
-		TaskArn:     "taskarn",
+		Attachment: eniAttachment,
+		TaskArn:    "taskarn",
 		// TODO: This should be api.TaskStatusNone
-		Status: api.TaskRunning,
+		Status: api.TaskStatusNone,
 		Task:   task,
 	})
 
@@ -304,5 +304,4 @@ func TestENISentStatusChange(t *testing.T) {
 	}, client)
 
 	assert.True(t, eniAttachment.AttachStatusSent)
-	assert.Equal(t, api.TaskRunning, task.GetSentStatus())
 }

--- a/agent/eventhandler/task_handler.go
+++ b/agent/eventhandler/task_handler.go
@@ -104,8 +104,8 @@ func (handler *TaskHandler) flushBatch(event *api.TaskStateChange) {
 	handler.taskHandlerLock.Lock()
 	defer handler.taskHandlerLock.Unlock()
 
-	event.Containers = append(event.Containers, handler.tasksToContainerStates[event.TaskArn]...)
-	delete(handler.tasksToContainerStates, event.TaskArn)
+	event.Containers = append(event.Containers, handler.tasksToContainerStates[event.TaskARN]...)
+	delete(handler.tasksToContainerStates, event.TaskARN)
 }
 
 // Prepares a given event to be sent by adding it to the handler's appropriate

--- a/agent/eventhandler/task_handler.go
+++ b/agent/eventhandler/task_handler.go
@@ -182,7 +182,7 @@ func (handler *TaskHandler) SubmitTaskEvents(taskEvents *eventList, client api.E
 			event := eventToSubmit.Value.(*sendableEvent)
 
 			if event.containerShouldBeSent() {
-				seelog.Info("TaskHandler, Sending container change: ", event)
+				seelog.Infof("TaskHandler, Sending container change: %s", event.String())
 				err = client.SubmitContainerStateChange(event.containerChange)
 				if err == nil {
 					// submitted; ensure we don't retry it
@@ -191,35 +191,47 @@ func (handler *TaskHandler) SubmitTaskEvents(taskEvents *eventList, client api.E
 						event.containerChange.Container.SetSentStatus(event.containerChange.Status)
 					}
 					statesaver.Save()
-					seelog.Debug("TaskHandler, Submitted container state change")
+					seelog.Debugf("TaskHandler, Submitted container state change: %s", event.String())
 					backoff.Reset()
 					taskEvents.events.Remove(eventToSubmit)
 				} else {
-					seelog.Error("TaskHandler, Unretriable error submitting container state change ", err)
+					seelog.Errorf("TaskHandler, Unretriable error submitting container state change [%s]: %v",
+						event.String(), err)
 				}
 			} else if event.taskShouldBeSent() {
-				seelog.Info("TaskHandler, Sending task change: ", event)
+				seelog.Infof("TaskHandler, Sending task change: %s", event.String())
 				err = client.SubmitTaskStateChange(event.taskChange)
 				if err == nil {
 					// submitted or can't be retried; ensure we don't retry it
 					event.setSent()
-					if event.taskChange.Task != nil {
-						event.taskChange.Task.SetSentStatus(event.taskChange.Status)
-					}
-					if event.taskChange.Attachments != nil {
-						event.taskChange.Attachments.SetSentStatus()
-						event.taskChange.Attachments.StopAckTimer()
-					}
+					event.taskChange.Task.SetSentStatus(event.taskChange.Status)
 					statesaver.Save()
-					seelog.Debug("TaskHandler, Submitted task state change: ", event.taskChange)
+					seelog.Debugf("TaskHandler, Submitted task state change: %s", event.String())
 					backoff.Reset()
 					taskEvents.events.Remove(eventToSubmit)
 				} else {
-					seelog.Error("TaskHandler, Unretriable error submitting container state change: ", err)
+					seelog.Errorf("TaskHandler, Unretriable error submitting task state change[%s]: %v",
+						event.String(), err)
+				}
+			} else if event.taskAttachmentShouldBeSent() {
+				seelog.Infof("TaskHandler, Sending task attachment change: %s", event.String())
+				err = client.SubmitTaskStateChange(event.taskChange)
+				if err == nil {
+					// submitted or can't be retried; ensure we don't retry it
+					event.setSent()
+					event.taskChange.Attachment.SetSentStatus()
+					event.taskChange.Attachment.StopAckTimer()
+					statesaver.Save()
+					seelog.Debugf("TaskHandler, Submitted task attachment state change: %s", event.String())
+					backoff.Reset()
+					taskEvents.events.Remove(eventToSubmit)
+				} else {
+					seelog.Errorf("TaskHandler, Unretriable error submitting task attachment state change [%s]: %v",
+						event.String(), err)
 				}
 			} else {
 				// Shouldn't be sent as either a task or container change event; must have been already sent
-				seelog.Info("TaskHandler, Not submitting redundant event; just removing")
+				seelog.Infof("TaskHandler, Not submitting redundant event; just removing: %s", event.String())
 				taskEvents.events.Remove(eventToSubmit)
 			}
 

--- a/agent/eventhandler/task_handler_types.go
+++ b/agent/eventhandler/task_handler_types.go
@@ -65,7 +65,7 @@ func (event *sendableEvent) taskArn() string {
 	if event.isContainerEvent {
 		return event.containerChange.TaskArn
 	}
-	return event.taskChange.TaskArn
+	return event.taskChange.TaskARN
 }
 
 func (event *sendableEvent) taskShouldBeSent() bool {

--- a/agent/eventhandler/task_handler_types.go
+++ b/agent/eventhandler/task_handler_types.go
@@ -14,8 +14,9 @@
 package eventhandler
 
 import (
-	"github.com/aws/amazon-ecs-agent/agent/api"
 	"sync"
+
+	"github.com/aws/amazon-ecs-agent/agent/api"
 )
 
 // a state change that may have a container and, optionally, a task event to
@@ -81,6 +82,18 @@ func (event *sendableEvent) taskShouldBeSent() bool {
 		return false // redundant event
 	}
 	return true
+}
+
+func (event *sendableEvent) taskAttachmentShouldBeSent() bool {
+	event.lock.RLock()
+	defer event.lock.RUnlock()
+	if event.isContainerEvent {
+		return false
+	}
+	tevent := event.taskChange
+	return tevent.Status == api.TaskStatusNone && // Task Status is not set for attachments as task record has yet to be streamed down
+		tevent.Attachment != nil && // Task has attachment records
+		!tevent.Attachment.IsSent() // Task status hasn't already been sent
 }
 
 func (event *sendableEvent) containerShouldBeSent() bool {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Various bug fixes related to ENI attachment for a Task

### Implementation details
<!-- How are the changes implemented? -->
* 01e1707 agent/api: fix failing test in appveyor by using common time format for ENIAttachment.ExpiresAt
* 91d7095 agent/eventhandler: fix bug where eni attachment would not be submitted
* f8206d6 agent/api,agent/acs/handler: fix bug where eni attachment state could not be saved

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: Yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
None

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: Yes
