### PR TITLE
engine: Clarify dependencygraph functionality

### DIFF
--- a/agent/api/container.go
+++ b/agent/api/container.go
@@ -87,7 +87,9 @@ type Container struct {
 	KnownStatusUnsafe ContainerStatus `json:"KnownStatus"`
 
 	// RunDependencies is a list of containers that must be run before
-	// this one is created
+	// this one is created.
+	// Note: Current logic requires that the containers specified here are run
+	// before this container can even be pulled.
 	RunDependencies []string
 	// 'Internal' containers are ones that are not directly specified by
 	// task definitions, but created by the agent

--- a/agent/api/task.go
+++ b/agent/api/task.go
@@ -248,7 +248,7 @@ func (task *Task) UpdateMountPoints(cont *Container, vols map[string]string) {
 // there was no change
 // Invariant: task known status is the minimum of container known status
 func (task *Task) updateTaskKnownStatus() (newStatus TaskStatus) {
-	seelog.Debug("Updating task: %s", task.String())
+	seelog.Debugf("Updating task: %s", task.String())
 
 	// Set to a large 'impossible' status that can't be the min
 	earliestStatus := ContainerZombie
@@ -269,7 +269,7 @@ func (task *Task) updateTaskKnownStatus() (newStatus TaskStatus) {
 		seelog.Debug("Essential container is stopped while other containers are running, not updating task status, task: %v", task)
 		return TaskStatusNone
 	}
-	seelog.Debug("Earliest status is %q for task %v", earliestStatus.String(), task)
+	seelog.Debugf("Earliest status is %q for task %v", earliestStatus.String(), task)
 	if task.GetKnownStatus() < earliestStatus.TaskStatus() {
 		task.SetKnownStatus(earliestStatus.TaskStatus())
 		return task.GetKnownStatus()
@@ -569,6 +569,7 @@ func (task *Task) updateTaskDesiredStatus() {
 // updateContainerDesiredStatus sets all container's desired status's to the
 // task's desired status
 // Invariant: container desired status is <= task desired status converted to container status
+// Note: task desired status and container desired status is typically only RUNNING or STOPPED
 func (task *Task) updateContainerDesiredStatus() {
 	for _, c := range task.Containers {
 		taskDesiredStatus := task.GetDesiredStatus()

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -476,13 +476,6 @@ func (engine *DockerTaskEngine) AddTask(task *api.Task) error {
 	return nil
 }
 
-type transitionApplyFunc (func(*api.Task, *api.Container) DockerContainerMetadata)
-
-// tryApplyTransition wraps the transitionApplyFunc provided
-func tryApplyTransition(task *api.Task, container *api.Container, to api.ContainerStatus, f transitionApplyFunc) DockerContainerMetadata {
-	return f(task, container)
-}
-
 // ListTasks returns the tasks currently managed by the DockerTaskEngine
 func (engine *DockerTaskEngine) ListTasks() ([]*api.Task, error) {
 	return engine.state.AllTasks(), nil
@@ -692,38 +685,6 @@ func (engine *DockerTaskEngine) updateTask(task *api.Task, update *api.Task) {
 	log.Debug("Update was taken off the acs channel", "task", task.Arn, "status", updateDesiredStatus)
 }
 
-// transitionFunctionMap provides the logic for the simple state machine of the
-// DockerTaskEngine. Each desired state maps to a function that can be called
-// to try and move the task to that desired state.
-func (engine *DockerTaskEngine) transitionFunctionMap() map[api.ContainerStatus]transitionApplyFunc {
-	return map[api.ContainerStatus]transitionApplyFunc{
-		api.ContainerPulled:  engine.pullContainer,
-		api.ContainerCreated: engine.createContainer,
-		api.ContainerRunning: engine.startContainer,
-		api.ContainerStopped: engine.stopContainer,
-	}
-}
-
-// applyContainerState moves the container to the given state by calling the
-// function defined in the transitionFunctionMap for the state
-func (engine *DockerTaskEngine) applyContainerState(task *api.Task, container *api.Container, nextState api.ContainerStatus) DockerContainerMetadata {
-	clog := log.New("task", task, "container", container)
-	transitionFunction, ok := engine.transitionFunctionMap()[nextState]
-	if !ok {
-		clog.Crit("Container desired to transition to an unsupported state", "state", nextState.String())
-		return DockerContainerMetadata{Error: &impossibleTransitionError{nextState}}
-	}
-
-	metadata := tryApplyTransition(task, container, nextState, transitionFunction)
-	if metadata.Error != nil {
-		clog.Info("Error transitioning container", "state", nextState.String(), "error", metadata.Error)
-	} else {
-		clog.Debug("Transitioned container", "state", nextState.String())
-		engine.saver.Save()
-	}
-	return metadata
-}
-
 // transitionContainer calls applyContainerState, and then notifies the managed
 // task of the change.  transitionContainer is called by progressContainers and
 // by handleStoppedToRunningContainerTransition.
@@ -745,6 +706,39 @@ func (engine *DockerTaskEngine) transitionContainer(task *api.Task, container *a
 	}
 	engine.processTasks.RUnlock()
 }
+
+// applyContainerState moves the container to the given state by calling the
+// function defined in the transitionFunctionMap for the state
+func (engine *DockerTaskEngine) applyContainerState(task *api.Task, container *api.Container, nextState api.ContainerStatus) DockerContainerMetadata {
+	clog := log.New("task", task, "container", container)
+	transitionFunction, ok := engine.transitionFunctionMap()[nextState]
+	if !ok {
+		clog.Crit("Container desired to transition to an unsupported state", "state", nextState.String())
+		return DockerContainerMetadata{Error: &impossibleTransitionError{nextState}}
+	}
+	metadata := transitionFunction(task, container)
+	if metadata.Error != nil {
+		clog.Info("Error transitioning container", "state", nextState.String(), "error", metadata.Error)
+	} else {
+		clog.Debug("Transitioned container", "state", nextState.String())
+		engine.saver.Save()
+	}
+	return metadata
+}
+
+// transitionFunctionMap provides the logic for the simple state machine of the
+// DockerTaskEngine. Each desired state maps to a function that can be called
+// to try and move the task to that desired state.
+func (engine *DockerTaskEngine) transitionFunctionMap() map[api.ContainerStatus]transitionApplyFunc {
+	return map[api.ContainerStatus]transitionApplyFunc{
+		api.ContainerPulled:  engine.pullContainer,
+		api.ContainerCreated: engine.createContainer,
+		api.ContainerRunning: engine.startContainer,
+		api.ContainerStopped: engine.stopContainer,
+	}
+}
+
+type transitionApplyFunc (func(*api.Task, *api.Container) DockerContainerMetadata)
 
 // State is a function primarily meant for testing usage; it is explicitly not
 // part of the TaskEngine interface and should not be relied upon.

--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -412,7 +412,7 @@ func (mtask *managedTask) steadyState() bool {
 // docker completes.
 // Container changes may also prompt the task status to change as well.
 func (mtask *managedTask) progressContainers() {
-	seelog.Debug("Progressing task: %s", mtask.Task.String())
+	seelog.Debugf("Progressing task: %s", mtask.Task.String())
 	// max number of transitions length to ensure writes will never block on
 	// these and if we exit early transitions can exit the goroutine and it'll
 	// get GC'd eventually
@@ -435,7 +435,7 @@ func (mtask *managedTask) progressContainers() {
 	// complete, but keep reading events as we do.. in fact, we have to for
 	// transitions to complete
 	mtask.waitForContainerTransitions(transitions, transitionChange, transitionChangeContainer)
-	seelog.Debug("Done transitioning all containers for task %v", mtask.Task)
+	seelog.Debugf("Done transitioning all containers for task %v", mtask.Task)
 
 	// update the task status
 	changed := mtask.UpdateStatus()


### PR DESCRIPTION
### Summary
Clarify how the dependencygraph functions and what transitions are allowed.

### Implementation details
Comments, reordering functions in a file

### Testing
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: no

### Description for the changelog
None

### Licensing
This contribution is under the terms of the Apache 2.0 License: yes (Amazon employee)
