### PR TITLE
resources/cgroup: Adding 'Exists' to cgroup interface

### DIFF
--- a/agent/resources/cgroup/cgroup_controller_linux.go
+++ b/agent/resources/cgroup/cgroup_controller_linux.go
@@ -50,30 +50,42 @@ func (c *control) Create(cgroupSpec *Spec) (cgroups.Cgroup, error) {
 
 	// Create cgroup
 	seelog.Infof("Creating cgroup %s", cgroupSpec.Root)
-	control, err := c.New(cgroups.V1, cgroups.StaticPath(cgroupSpec.Root), cgroupSpec.Specs)
+	controller, err := c.New(cgroups.V1, cgroups.StaticPath(cgroupSpec.Root), cgroupSpec.Specs)
 
 	if err != nil {
 		return nil, errors.Wrapf(err, "cgroup create: unable to create controller")
 	}
 
-	return control, nil
+	return controller, nil
 }
 
 // Remove is used to delete the cgroup
 func (c *control) Remove(cgroupPath string) error {
 	seelog.Debugf("Removing cgroup %s", cgroupPath)
 
-	control, err := c.Load(cgroups.V1, cgroups.StaticPath(cgroupPath))
+	controller, err := c.Load(cgroups.V1, cgroups.StaticPath(cgroupPath))
 	if err != nil {
 		return errors.Wrapf(err, "cgroup remove: unable to obtain controller")
 	}
 
 	// Delete cgroup
-	err = control.Delete()
+	err = controller.Delete()
 	if err != nil {
 		return errors.Wrapf(err, "cgroup remove: unable to delete cgroup")
 	}
 	return nil
+}
+
+// Exists is used to verify the existence of a cgroup
+func (c *control) Exists(cgroupPath string) bool {
+	seelog.Debugf("Checking existence of cgroup: %s", cgroupPath)
+
+	controller, err := c.Load(cgroups.V1, cgroups.StaticPath(cgroupPath))
+	if err != nil || controller == nil {
+		return false
+	}
+
+	return true
 }
 
 // validateCgroupSpec checks the cgroup spec for valid path and specifications

--- a/agent/resources/cgroup/cgroup_controller_linux_test.go
+++ b/agent/resources/cgroup/cgroup_controller_linux_test.go
@@ -140,3 +140,43 @@ func TestRemoveErrorCase(t *testing.T) {
 
 	assert.Error(t, control.Remove(testCgroupRoot))
 }
+
+func TestExistsHappyPath(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockCgroup := mock_cgroups.NewMockCgroup(ctrl)
+	mockCgroupFactory := mock_factory.NewMockCgroupFactory(ctrl)
+
+	mockCgroupFactory.EXPECT().Load(gomock.Any(), gomock.Any()).Return(mockCgroup, nil)
+
+	control := newControl(mockCgroupFactory)
+
+	assert.True(t, control.Exists(testCgroupRoot))
+}
+
+func TestExistsErrorPath(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockCgroupFactory := mock_factory.NewMockCgroupFactory(ctrl)
+
+	mockCgroupFactory.EXPECT().Load(gomock.Any(), gomock.Any()).Return(nil, errors.New("cgroups error"))
+
+	control := newControl(mockCgroupFactory)
+
+	assert.False(t, control.Exists(testCgroupRoot))
+}
+
+func TestExistsErrorPathWithLoadError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockCgroupFactory := mock_factory.NewMockCgroupFactory(ctrl)
+
+	mockCgroupFactory.EXPECT().Load(gomock.Any(), gomock.Any()).Return(nil, nil)
+
+	control := newControl(mockCgroupFactory)
+
+	assert.False(t, control.Exists(testCgroupRoot))
+}

--- a/agent/resources/cgroup/mock_control/mock_cgroup_control_linux.go
+++ b/agent/resources/cgroup/mock_control/mock_cgroup_control_linux.go
@@ -54,6 +54,16 @@ func (_mr *_MockControlRecorder) Create(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Create", arg0)
 }
 
+func (_m *MockControl) Exists(_param0 string) bool {
+	ret := _m.ctrl.Call(_m, "Exists", _param0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+func (_mr *_MockControlRecorder) Exists(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Exists", arg0)
+}
+
 func (_m *MockControl) Init() error {
 	ret := _m.ctrl.Call(_m, "Init")
 	ret0, _ := ret[0].(error)

--- a/agent/resources/cgroup/types_linux.go
+++ b/agent/resources/cgroup/types_linux.go
@@ -32,5 +32,6 @@ type Spec struct {
 type Control interface {
 	Create(cgroupSpec *Spec) (cgroups.Cgroup, error)
 	Remove(cgroupPath string) error
+	Exists(cgroupPath string) bool
 	Init() error
 }


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Adding a new method to verify the existence of a cgroup at the given
root. This method accepts a cgroup root and returns a boolean.

Signed-off-by: Vinothkumar Siddharth <sidvin@amazon.com

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no --> YES

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes --> YES
