### PR TITLE
Fix the issue where agent could create the same container twice 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## UNRELEASED
 * Feature - Support for provisioning Tasks with ENIs
 * Bug - Fixed a memory leak issue when submitting the task state change [#967](https://github.com/aws/amazon-ecs-agent/pull/967)
+* Bug - Fix a race condition where a container can be created twice when agent restarts. [#939](https://github.com/aws/amazon-ecs-agent/pull/939)
 
 ## 1.14.4
 * Enhancement - Batch container state change events. [#867](https://github.com/aws/amazon-ecs-agent/pull/867)

--- a/agent/engine/docker_container_engine.go
+++ b/agent/engine/docker_container_engine.go
@@ -475,10 +475,21 @@ func (dg *dockerGoClient) startContainer(ctx context.Context, id string) DockerC
 	return metadata
 }
 
+// dockerStateToState converts the container status from docker to status recognized by the agent
+// Ref: https://github.com/fsouza/go-dockerclient/blob/fd53184a1439b6d7b82ca54c1cd9adac9a5278f2/container.go#L133
 func dockerStateToState(state docker.State) api.ContainerStatus {
 	if state.Running {
 		return api.ContainerRunning
 	}
+
+	if state.Dead {
+		return api.ContainerStopped
+	}
+
+	if state.StartedAt.IsZero() && state.Error == "" {
+		return api.ContainerCreated
+	}
+
 	return api.ContainerStopped
 }
 

--- a/agent/engine/dockerstate/docker_task_engine_state.go
+++ b/agent/engine/dockerstate/docker_task_engine_state.go
@@ -319,18 +319,25 @@ func (state *DockerTaskEngineState) AddContainer(container *api.DockerContainer,
 	}
 
 	if container.DockerID != "" {
+		// Update the container id to the state
+		state.idToContainer[container.DockerID] = container
 		state.idToTask[container.DockerID] = task.Arn
+
+		// Remove the previously added name mapping
+		delete(state.idToContainer, container.DockerName)
+		delete(state.idToTask, container.DockerName)
+	} else if container.DockerName != "" {
+		// Update the container name mapping to the state when the ID isn't available
+		state.idToContainer[container.DockerName] = container
+		state.idToTask[container.DockerName] = task.Arn
 	}
+
 	existingMap, exists := state.taskToID[task.Arn]
 	if !exists {
 		existingMap = make(map[string]*api.DockerContainer, len(task.Containers))
 		state.taskToID[task.Arn] = existingMap
 	}
 	existingMap[container.Container.Name] = container
-
-	if container.DockerID != "" {
-		state.idToContainer[container.DockerID] = container
-	}
 }
 
 // AddImageState adds an image.ImageState to be stored

--- a/agent/engine/dockerstate/dockerstate_test.go
+++ b/agent/engine/dockerstate/dockerstate_test.go
@@ -287,3 +287,44 @@ func TestRemoveNonExistingImageState(t *testing.T) {
 		t.Error("Error removing incorrect image state")
 	}
 }
+
+// TestAddContainer tests first add container with docker name and
+// then add the container with dockerID
+func TestAddContainerNameAndID(t *testing.T) {
+	state := NewTaskEngineState()
+
+	task := &api.Task{
+		Arn: "taskArn",
+	}
+	container := &api.DockerContainer{
+		DockerName: "ecs-test-container-1",
+		Container: &api.Container{
+			Name: "test",
+		},
+	}
+	state.AddTask(task)
+	state.AddContainer(container, task)
+	containerMap, ok := state.ContainerMapByArn(task.Arn)
+	assert.True(t, ok)
+	assert.Len(t, containerMap, 1)
+
+	assert.Len(t, state.GetAllContainerIDs(), 1)
+
+	_, ok = state.ContainerByID(container.DockerName)
+	assert.True(t, ok, "container with DockerName should be added to the state")
+
+	container = &api.DockerContainer{
+		DockerName: "ecs-test-container-1",
+		DockerID:   "dockerid",
+		Container: &api.Container{
+			Name: "test",
+		},
+	}
+	state.AddContainer(container, task)
+	assert.Len(t, containerMap, 1)
+	assert.Len(t, state.GetAllContainerIDs(), 1)
+	_, ok = state.ContainerByID(container.DockerID)
+	assert.True(t, ok, "container with DockerName should be added to the state")
+	_, ok = state.ContainerByID(container.DockerName)
+	assert.False(t, ok, "container with DockerName should be added to the state")
+}

--- a/agent/engine/engine_integ_test.go
+++ b/agent/engine/engine_integ_test.go
@@ -30,7 +30,9 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
 	"github.com/aws/amazon-ecs-agent/agent/statemanager"
+	docker "github.com/fsouza/go-dockerclient"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 )
 
@@ -85,6 +87,81 @@ func setup(cfg *config.Config, t *testing.T) (TaskEngine, func(), credentials.Ma
 	return taskEngine, func() {
 		taskEngine.Shutdown()
 	}, credentialsManager
+}
+
+func discardEvents(from interface{}) func() {
+	done := make(chan bool)
+
+	go func() {
+		for {
+			ndx, _, _ := reflect.Select([]reflect.SelectCase{
+				{
+					Dir:  reflect.SelectRecv,
+					Chan: reflect.ValueOf(from),
+				},
+				{
+					Dir:  reflect.SelectRecv,
+					Chan: reflect.ValueOf(done),
+				},
+			})
+			if ndx == 1 {
+				break
+			}
+		}
+	}()
+	return func() {
+		done <- true
+	}
+}
+
+// TestDockerStateToContainerState tests convert the container status from
+// docker inspect to the status defined in agent
+func TestDockerStateToContainerState(t *testing.T) {
+	taskEngine, done, _ := setupWithDefaultConfig(t)
+	defer done()
+
+	testTask := createTestTask("test_task")
+	container := testTask.Containers[0]
+
+	client, err := docker.NewClientFromEnv()
+	require.NoError(t, err, "Creating go docker client failed")
+
+	containerMetadata := taskEngine.(*DockerTaskEngine).pullContainer(testTask, container)
+	assert.NoError(t, containerMetadata.Error)
+
+	containerMetadata = taskEngine.(*DockerTaskEngine).createContainer(testTask, container)
+	assert.NoError(t, containerMetadata.Error)
+	state, _ := client.InspectContainer(containerMetadata.DockerID)
+	assert.Equal(t, api.ContainerCreated, dockerStateToState(state.State))
+
+	containerMetadata = taskEngine.(*DockerTaskEngine).startContainer(testTask, container)
+	assert.NoError(t, containerMetadata.Error)
+	state, _ = client.InspectContainer(containerMetadata.DockerID)
+	assert.Equal(t, api.ContainerRunning, dockerStateToState(state.State))
+
+	containerMetadata = taskEngine.(*DockerTaskEngine).stopContainer(testTask, container)
+	assert.NoError(t, containerMetadata.Error)
+	state, _ = client.InspectContainer(containerMetadata.DockerID)
+	assert.Equal(t, api.ContainerStopped, dockerStateToState(state.State))
+
+	// clean up the container
+	err = taskEngine.(*DockerTaskEngine).removeContainer(testTask, container)
+	assert.NoError(t, err, "remove the created container failed")
+
+	// Start the container failed
+	testTask = createTestTask("test_task2")
+	testTask.Containers[0].EntryPoint = &[]string{"non-existed"}
+	container = testTask.Containers[0]
+	containerMetadata = taskEngine.(*DockerTaskEngine).createContainer(testTask, container)
+	assert.NoError(t, containerMetadata.Error)
+	containerMetadata = taskEngine.(*DockerTaskEngine).startContainer(testTask, container)
+	assert.Error(t, containerMetadata.Error)
+	state, _ = client.InspectContainer(containerMetadata.DockerID)
+	assert.Equal(t, api.ContainerStopped, dockerStateToState(state.State))
+
+	// clean up the container
+	err = taskEngine.(*DockerTaskEngine).removeContainer(testTask, container)
+	assert.NoError(t, err, "remove the created container failed")
 }
 
 func TestHostVolumeMount(t *testing.T) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Fix the issue if agent was restarted before the docker create API returned, the agent could create duplicate containers for the task.

### Implementation details
<!-- How are the changes implemented? -->
Originally the agent stores the generated container name in memory before actually calling CreateContainer API, see [here](https://github.com/aws/amazon-ecs-agent/blob/master/agent/engine/docker_task_engine.go#L596). And this information was only stored in the taskToID struct, due to lacking of docker ID [here](https://github.com/aws/amazon-ecs-agent/blob/master/agent/engine/dockerstate/docker_task_engine_state.go#L236). But the `taskToID` struct wasn't stored in the [state file](https://github.com/aws/amazon-ecs-agent/blob/master/agent/engine/dockerstate/json.go#L26) by `statemanager`, so when the agent restart it will lose this information and then it will try to create the container with [another name](https://github.com/aws/amazon-ecs-agent/blob/master/agent/engine/docker_task_engine.go#L590) again.

This PR make sure the the generated container name can be restored from agent state file if agent restarted before the `CreateContainer` API returned.  Thus ensure the container won't be created twice. Also the agent would detect the container if it was created during the period of restarting, see [here](https://github.com/aws/amazon-ecs-agent/blob/master/agent/engine/docker_task_engine.go#L232).


### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass
- [x] Manually  verified the state when agent was restarted at the create.

New tests cover the changes: <!-- yes|no -->
yes
### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Bug - Fix an issue where a container could be created twice.
### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
yes