### PR TITLE
Task cgroup limit models and config

### DIFF
--- a/agent/api/task.go
+++ b/agent/api/task.go
@@ -69,7 +69,11 @@ type Task struct {
 	Containers []*Container
 	// Volumes are the volumes for the task
 	Volumes []TaskVolume `json:"volumes"`
-
+	// VCPULimit is a task-level limit for compute resources. A value of 1 means that
+	// the task may access 100% of 1 vCPU on the instance
+	VCPULimit float64 `json:"CPULimit,omitempty"`
+	// MemoryLimit is a task-level limit for memory resources in bytes
+	MemoryLimit int64 `json:"Memory,omitempty"`
 	// DesiredStatusUnsafe represents the state where the task should go. Generally,
 	// the desired status is informed by the ECS backend as a result of either
 	// API calls made to ECS or decisions made by the ECS service scheduler.

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -288,6 +288,7 @@ func environmentConfig() (Config, error) {
 	appArmorCapable := utils.ParseBool(os.Getenv("ECS_APPARMOR_CAPABLE"), false)
 	taskIAMRoleEnabled := utils.ParseBool(os.Getenv("ECS_ENABLE_TASK_IAM_ROLE"), false)
 	taskIAMRoleEnabledForNetworkHost := utils.ParseBool(os.Getenv("ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST"), false)
+	taskCPUMemLimitEnabled := utils.ParseBool(os.Getenv("ECS_ENABLE_TASK_CPU_MEM_LIMIT"), true)
 
 	credentialsAuditLogFile := os.Getenv("ECS_AUDIT_LOGFILE")
 	credentialsAuditLogDisabled := utils.ParseBool(os.Getenv("ECS_AUDIT_LOGFILE_DISABLED"), false)
@@ -341,6 +342,7 @@ func environmentConfig() (Config, error) {
 		AppArmorCapable:                  appArmorCapable,
 		TaskCleanupWaitDuration:          taskCleanupWaitDuration,
 		TaskIAMRoleEnabled:               taskIAMRoleEnabled,
+		TaskCPUMemLimit:                  taskCPUMemLimitEnabled,
 		DockerStopTimeout:                dockerStopTimeout,
 		CredentialsAuditLogFile:          credentialsAuditLogFile,
 		CredentialsAuditLogDisabled:      credentialsAuditLogDisabled,
@@ -484,5 +486,5 @@ func (config *Config) validateAndOverrideBounds() error {
 // String returns a lossy string representation of the config suitable for human readable display.
 // Consequently, it *should not* return any sensitive information.
 func (config *Config) String() string {
-	return fmt.Sprintf("Cluster: %v, Region: %v, DataDir: %v, Checkpoint: %v, AuthType: %v, UpdatesEnabled: %v, DisableMetrics: %v, ReservedMem: %v, TaskCleanupWaitDuration: %v, DockerStopTimeout: %v", config.Cluster, config.AWSRegion, config.DataDir, config.Checkpoint, config.EngineAuthType, config.UpdatesEnabled, config.DisableMetrics, config.ReservedMemory, config.TaskCleanupWaitDuration, config.DockerStopTimeout)
+	return fmt.Sprintf("Cluster: %v, Region: %v, DataDir: %v, Checkpoint: %v, AuthType: %v, UpdatesEnabled: %v, DisableMetrics: %v, ReservedMem: %v, TaskCleanupWaitDuration: %v, DockerStopTimeout: %v, TaskCPUMemLimit: %v", config.Cluster, config.AWSRegion, config.DataDir, config.Checkpoint, config.EngineAuthType, config.UpdatesEnabled, config.DisableMetrics, config.ReservedMemory, config.TaskCleanupWaitDuration, config.DockerStopTimeout, config.TaskCPUMemLimit)
 }

--- a/agent/config/config_windows.go
+++ b/agent/config/config_windows.go
@@ -72,6 +72,7 @@ func DefaultConfig() Config {
 		MinimumImageDeletionAge:     DefaultImageDeletionAge,
 		ImageCleanupInterval:        DefaultImageCleanupTimeInterval,
 		NumImagesToDeletePerCycle:   DefaultNumImagesToDeletePerCycle,
+		TaskCPUMemLimit:             false,
 	}
 }
 
@@ -84,4 +85,7 @@ func (config *Config) platformOverrides() {
 		}
 		config.ReservedPorts = append(config.ReservedPorts, httpPort)
 	}
+
+	// ensure TaskResourceLimit is disabled
+	config.TaskCPUMemLimit = false
 }

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -109,6 +109,9 @@ type Config struct {
 	// tasks with IAM Roles.
 	TaskIAMRoleEnabled bool
 
+	// TaskCPUMemLimit specifies if Agent can launch a task with a hierarchical cgroup
+	TaskCPUMemLimit bool
+
 	// CredentialsAuditLogFile specifies the path/filename of the audit log.
 	CredentialsAuditLogFile string
 


### PR DESCRIPTION

### Summary
<!-- What does this pull request do? -->
Adds model and config for task limits. 

### Implementation details
* Limit values set at task level
* Capabilities code enhanced to check for docker api 1.22
* Config enhanced to allow users to disable features

### Testing
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: yes
