### PR TITLE
engine: add test for ContainerNextState with deps

### DIFF
--- a/agent/engine/task_manager_test.go
+++ b/agent/engine/task_manager_test.go
@@ -130,7 +130,7 @@ func TestContainerNextState(t *testing.T) {
 		expectedTransitionPossible   bool
 	}{
 		// NONE -> RUNNING transition is allowed and actionable, when desired is Running
-		// The exptected next status is Pulled
+		// The expected next status is Pulled
 		{api.ContainerStatusNone, api.ContainerRunning, api.ContainerPulled, true, true},
 		// NONE -> NONE transition is not be allowed and is not actionable,
 		// when desired is Running
@@ -151,7 +151,7 @@ func TestContainerNextState(t *testing.T) {
 		// actionable, when desired is STOPPED
 		{api.ContainerPulled, api.ContainerStopped, api.ContainerStopped, false, true},
 		// CREATED -> RUNNING transition is allowed and actionable, when desired is Running
-		// The exptected next status is Running
+		// The expected next status is Running
 		{api.ContainerCreated, api.ContainerRunning, api.ContainerRunning, true, true},
 		// CREATED -> CREATED transition is not allowed and not actionable,
 		// when desired is Running
@@ -166,7 +166,7 @@ func TestContainerNextState(t *testing.T) {
 		// actionable, when desired is STOPPED
 		{api.ContainerCreated, api.ContainerStopped, api.ContainerStopped, false, true},
 		// RUNNING -> STOPPED transition is allowed and actionable, when desired is Running
-		// The exptected next status is STOPPED
+		// The expected next status is STOPPED
 		{api.ContainerRunning, api.ContainerStopped, api.ContainerStopped, true, true},
 		// RUNNING -> RUNNING transition is not allowed and not actionable,
 		// when desired is Running
@@ -201,8 +201,61 @@ func TestContainerNextState(t *testing.T) {
 			assert.Equal(t, tc.expectedContainerStatus, nextStatus,
 				"Expected next state [%s] != Retrieved next state [%s]",
 				tc.expectedContainerStatus.String(), nextStatus.String())
-			assert.Equal(t, tc.expectedTransitionActionable, actionRequired)
-			assert.Equal(t, tc.expectedTransitionPossible, possible)
+			assert.Equal(t, tc.expectedTransitionActionable, actionRequired, "transition actionable")
+			assert.Equal(t, tc.expectedTransitionPossible, possible, "transition possible")
+		})
+	}
+}
+
+func TestContainerNextStateWithDependencies(t *testing.T) {
+	testCases := []struct {
+		containerCurrentStatus       api.ContainerStatus
+		containerDesiredStatus       api.ContainerStatus
+		dependencyCurrentStatus      api.ContainerStatus
+		expectedContainerStatus      api.ContainerStatus
+		expectedTransitionActionable bool
+		expectedTransitionPossible   bool
+	}{
+		// NONE -> RUNNING transition is not allowed and not actionable, when desired is Running and dependency is None
+		{api.ContainerStatusNone, api.ContainerRunning, api.ContainerStatusNone, api.ContainerStatusNone, false, false},
+		// NONE -> RUNNING transition is not allowed and not actionable, when desired is Running and dependency is Created
+		{api.ContainerStatusNone, api.ContainerRunning, api.ContainerCreated, api.ContainerStatusNone, false, false},
+		// NONE -> RUNNING transition is allowed and actionable, when desired is Running and dependency is Running
+		// The expected next status is Pulled
+		{api.ContainerStatusNone, api.ContainerRunning, api.ContainerRunning, api.ContainerPulled, true, true},
+		// NONE -> RUNNING transition is allowed and actionable, when desired is Running and dependency is Stopped
+		// The expected next status is Pulled
+		{api.ContainerStatusNone, api.ContainerRunning, api.ContainerStopped, api.ContainerPulled, true, true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%s to %s Transition",
+			tc.containerCurrentStatus.String(), tc.containerDesiredStatus.String()), func(t *testing.T) {
+			dependencyName := "dependency"
+			container := &api.Container{
+				DesiredStatusUnsafe: tc.containerDesiredStatus,
+				KnownStatusUnsafe:   tc.containerCurrentStatus,
+				RunDependencies:     []string{dependencyName},
+			}
+			dependency := &api.Container{
+				Name:              dependencyName,
+				KnownStatusUnsafe: tc.dependencyCurrentStatus,
+			}
+			task := &managedTask{
+				Task: &api.Task{
+					Containers: []*api.Container{
+						container,
+						dependency,
+					},
+					DesiredStatusUnsafe: api.TaskRunning,
+				},
+			}
+			nextStatus, actionRequired, possible := task.containerNextState(container)
+			assert.Equal(t, tc.expectedContainerStatus, nextStatus,
+				"Expected next state [%s] != Retrieved next state [%s]",
+				tc.expectedContainerStatus.String(), nextStatus.String())
+			assert.Equal(t, tc.expectedTransitionActionable, actionRequired, "transition actionable")
+			assert.Equal(t, tc.expectedTransitionPossible, possible, "transition possible")
 		})
 	}
 }


### PR DESCRIPTION
### Summary
Adds a test that specifically covers dependency states with `ContainerNextState`

### Implementation details
New test!

### Testing
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes!

### Description for the changelog
None

### Licensing
This contribution is under the terms of the Apache 2.0 License: yes, Amazon employee
