### PR TITLE
update_handler: remove unused global variable

### DIFF
--- a/agent/acs/update_handler/updater.go
+++ b/agent/acs/update_handler/updater.go
@@ -71,17 +71,13 @@ const (
 )
 
 const (
-	maxUpdateDuration     = 30 * time.Minute
 	updateDownloadTimeout = 15 * time.Minute
 )
-
-// Singleton updater
-var singleUpdater *updater
 
 // AddAgentUpdateHandlers adds the needed update handlers to perform agent
 // updates
 func AddAgentUpdateHandlers(cs wsclient.ClientServer, cfg *config.Config, saver statemanager.Saver, taskEngine engine.TaskEngine) {
-	singleUpdater = &updater{
+	singleUpdater := &updater{
 		acs:        cs,
 		config:     cfg,
 		fs:         os.Default,


### PR DESCRIPTION
### Summary
Remove an unused global variable (that is implicated in a data race) and an unused constant (since 53961c2bf3e1b5770b25c938bcff1c5f5bef1c82).

This change should resolve the following data race observed on the `enis` branch:

```
==================
WARNING: DATA RACE
Write at 0x00000112e728 by goroutine 51:
  github.com/aws/amazon-ecs-agent/agent/acs/update_handler.AddAgentUpdateHandlers()
      /opt/amazon-ecs-agent/go/src/github.com/aws/amazon-ecs-agent/agent/acs/update_handler/updater.go:88 +0x196
  github.com/aws/amazon-ecs-agent/agent/acs/handler.(*session).startACSSession()
      /opt/amazon-ecs-agent/go/src/github.com/aws/amazon-ecs-agent/agent/acs/handler/acs_handler.go:307 +0x976
  github.com/aws/amazon-ecs-agent/agent/acs/handler.(*session).startSessionOnce()
      /opt/amazon-ecs-agent/go/src/github.com/aws/amazon-ecs-agent/agent/acs/handler/acs_handler.go:252 +0x4d6
2017-08-24T18:56:42Z [ERROR] Error connecting to ACS: wsclient: unknown scheme 
  github.com/aws/amazon-ecs-agent/agent/acs/handler.(*session).Start()
      /opt/amazon-ecs-agent/go/src/github.com/aws/amazon-ecs-agent/agent/acs/handler/acs_handler.go:192 +0x188
  github.com/aws/amazon-ecs-agent/agent/app.(*ecsAgent).startACSSession()
      github.com/aws/amazon-ecs-agent/agent/app/_test/_obj_test/agent.go:553 +0x29e
  github.com/aws/amazon-ecs-agent/agent/app.(*ecsAgent).doStart()
      github.com/aws/amazon-ecs-agent/agent/app/_test/_obj_test/agent.go:259 +0xa1a
 
Previous write at 0x00000112e728 by goroutine 68:
  github.com/aws/amazon-ecs-agent/agent/acs/update_handler.AddAgentUpdateHandlers()
      /opt/amazon-ecs-agent/go/src/github.com/aws/amazon-ecs-agent/agent/acs/update_handler/updater.go:88 +0x196
  github.com/aws/amazon-ecs-agent/agent/acs/handler.(*session).startACSSession()
      /opt/amazon-ecs-agent/go/src/github.com/aws/amazon-ecs-agent/agent/acs/handler/acs_handler.go:307 +0x976
  github.com/aws/amazon-ecs-agent/agent/acs/handler.(*session).startSessionOnce()
      /opt/amazon-ecs-agent/go/src/github.com/aws/amazon-ecs-agent/agent/acs/handler/acs_handler.go:252 +0x4d6
2017-08-24T18:56:42Z [DEBUG] Reconnecting to ACS in: 287.113937ms
  github.com/aws/amazon-ecs-agent/agent/acs/handler.(*session).Start()
      /opt/amazon-ecs-agent/go/src/github.com/aws/amazon-ecs-agent/agent/acs/handler/acs_handler.go:192 +0x188
  github.com/aws/amazon-ecs-agent/agent/app.(*ecsAgent).startACSSession()
      github.com/aws/amazon-ecs-agent/agent/app/_test/_obj_test/agent.go:553 +0x29e
  github.com/aws/amazon-ecs-agent/agent/app.(*ecsAgent).doStart()
      github.com/aws/amazon-ecs-agent/agent/app/_test/_obj_test/agent.go:259 +0xa1a
 
Goroutine 51 (running) created at:
  github.com/aws/amazon-ecs-agent/agent/app.TestDoStartHappyPath()
      /opt/amazon-ecs-agent/go/src/github.com/aws/amazon-ecs-agent/agent/app/agent_unix_test.go:104 +0x2522
  testing.tRunner()
      /usr/lib/golang/src/testing/testing.go:610 +0xc9
 
Goroutine 68 (running) created at:
  github.com/aws/amazon-ecs-agent/agent/app.TestDoStartTaskENIHappyPath()
      /opt/amazon-ecs-agent/go/src/github.com/aws/amazon-ecs-agent/agent/app/agent_unix_test.go:202 +0x3cca
  testing.tRunner()
      /usr/lib/golang/src/testing/testing.go:610 +0xc9
==================
```

### Implementation details
Removed a few lines

### Testing
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: no

### Description for the changelog
None

### Licensing
This contribution is under the terms of the Apache 2.0 License: yes, Amazon employee
