### PR TITLE
scripts: cleaning up windows scripts

### DIFF
--- a/scripts/run-functional-tests.ps1
+++ b/scripts/run-functional-tests.ps1
@@ -26,7 +26,6 @@ try {
   echo "Simple functional tests exited with ${simpletestExitCode}"
 } finally {
   cd "$cwd"
-  docker stop ecs-cred-proxy
 }
 if (${handwrittenExitCode} -ne 0) {
   exit $handwrittenExitCode

--- a/scripts/stage
+++ b/scripts/stage
@@ -73,7 +73,6 @@ stage_windows_s3() {
 	cp LICENSE "${ziproot}"
 	cp out/amazon-ecs-agent.exe "${ziproot}"
 	cp -v misc/windows-deploy/*.ps1 "${ziproot}"
-	cp -v misc/windows-deploy/credentialproxy.dockerfile "${ziproot}"
 	pushd "${ziproot}"
 	zip "${zipfile}" *
 	md5sum "${zipfile}.zip" | sed 's/ .*//' > "${zip_md5}"


### PR DESCRIPTION


### Summary
The credential proxy is no longer used, so I'm removing a couple leftover references
* Removing reference to credential proxy in functional tests
* Removing reference to credential proxy in stage script

### Testing
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: yes
