### PR TITLE
eventhandler: Refactor to eliminate global state saver

### DIFF
--- a/agent/acs/handler/acs_handler_test.go
+++ b/agent/acs/handler/acs_handler_test.go
@@ -188,8 +188,8 @@ func TestHandlerReconnectsOnConnectErrors(t *testing.T) {
 	ecsClient := mock_api.NewMockECSClient(ctrl)
 	ecsClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(acsURL, nil).AnyTimes()
 
-	statemanager := statemanager.NewNoopStateManager()
-	taskHandler := eventhandler.NewTaskHandler()
+	stateManager := statemanager.NewNoopStateManager()
+	taskHandler := eventhandler.NewTaskHandler(stateManager)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	mockWsClient := mock_wsclient.NewMockClientServer(ctrl)
@@ -212,7 +212,7 @@ func TestHandlerReconnectsOnConnectErrors(t *testing.T) {
 		agentConfig:          testConfig,
 		taskEngine:           taskEngine,
 		ecsClient:            ecsClient,
-		stateManager:         statemanager,
+		stateManager:         stateManager,
 		taskHandler:          taskHandler,
 		backoff:              utils.NewSimpleBackoff(connectionBackoffMin, connectionBackoffMax, connectionBackoffJitter, connectionBackoffMultiplier),
 		ctx:                  ctx,
@@ -326,8 +326,8 @@ func TestHandlerReconnectsWithoutBackoffOnEOFError(t *testing.T) {
 	ecsClient := mock_api.NewMockECSClient(ctrl)
 	ecsClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(acsURL, nil).AnyTimes()
 
-	statemanager := statemanager.NewNoopStateManager()
-	taskHandler := eventhandler.NewTaskHandler()
+	stateManager := statemanager.NewNoopStateManager()
+	taskHandler := eventhandler.NewTaskHandler(stateManager)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	deregisterInstanceEventStream := eventstream.NewEventStream("DeregisterContainerInstance", ctx)
@@ -357,7 +357,7 @@ func TestHandlerReconnectsWithoutBackoffOnEOFError(t *testing.T) {
 		taskEngine:                      taskEngine,
 		ecsClient:                       ecsClient,
 		deregisterInstanceEventStream:   deregisterInstanceEventStream,
-		stateManager:                    statemanager,
+		stateManager:                    stateManager,
 		taskHandler:                     taskHandler,
 		backoff:                         mockBackoff,
 		ctx:                             ctx,
@@ -389,8 +389,8 @@ func TestHandlerReconnectsWithBackoffOnNonEOFError(t *testing.T) {
 	ecsClient := mock_api.NewMockECSClient(ctrl)
 	ecsClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(acsURL, nil).AnyTimes()
 
-	statemanager := statemanager.NewNoopStateManager()
-	taskHandler := eventhandler.NewTaskHandler()
+	stateManager := statemanager.NewNoopStateManager()
+	taskHandler := eventhandler.NewTaskHandler(stateManager)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	deregisterInstanceEventStream := eventstream.NewEventStream("DeregisterContainerInstance", ctx)
@@ -420,7 +420,7 @@ func TestHandlerReconnectsWithBackoffOnNonEOFError(t *testing.T) {
 		taskEngine:                    taskEngine,
 		ecsClient:                     ecsClient,
 		deregisterInstanceEventStream: deregisterInstanceEventStream,
-		stateManager:                  statemanager,
+		stateManager:                  stateManager,
 		taskHandler:                   taskHandler,
 		backoff:                       mockBackoff,
 		ctx:                           ctx,
@@ -451,8 +451,8 @@ func TestHandlerGeneratesDeregisteredInstanceEvent(t *testing.T) {
 	ecsClient := mock_api.NewMockECSClient(ctrl)
 	ecsClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(acsURL, nil).AnyTimes()
 
-	statemanager := statemanager.NewNoopStateManager()
-	taskHandler := eventhandler.NewTaskHandler()
+	stateManager := statemanager.NewNoopStateManager()
+	taskHandler := eventhandler.NewTaskHandler(stateManager)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	deregisterInstanceEventStream := eventstream.NewEventStream("DeregisterContainerInstance", ctx)
@@ -479,7 +479,7 @@ func TestHandlerGeneratesDeregisteredInstanceEvent(t *testing.T) {
 		taskEngine:                      taskEngine,
 		ecsClient:                       ecsClient,
 		deregisterInstanceEventStream:   deregisterInstanceEventStream,
-		stateManager:                    statemanager,
+		stateManager:                    stateManager,
 		taskHandler:                     taskHandler,
 		backoff:                         utils.NewSimpleBackoff(connectionBackoffMin, connectionBackoffMax, connectionBackoffJitter, connectionBackoffMultiplier),
 		ctx:                             ctx,
@@ -511,8 +511,8 @@ func TestHandlerReconnectDelayForInactiveInstanceError(t *testing.T) {
 	ecsClient := mock_api.NewMockECSClient(ctrl)
 	ecsClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(acsURL, nil).AnyTimes()
 
-	statemanager := statemanager.NewNoopStateManager()
-	taskHandler := eventhandler.NewTaskHandler()
+	stateManager := statemanager.NewNoopStateManager()
+	taskHandler := eventhandler.NewTaskHandler(stateManager)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	deregisterInstanceEventStream := eventstream.NewEventStream("DeregisterContainerInstance", ctx)
@@ -548,7 +548,7 @@ func TestHandlerReconnectDelayForInactiveInstanceError(t *testing.T) {
 		taskEngine:                      taskEngine,
 		ecsClient:                       ecsClient,
 		deregisterInstanceEventStream:   deregisterInstanceEventStream,
-		stateManager:                    statemanager,
+		stateManager:                    stateManager,
 		taskHandler:                     taskHandler,
 		backoff:                         utils.NewSimpleBackoff(connectionBackoffMin, connectionBackoffMax, connectionBackoffJitter, connectionBackoffMultiplier),
 		ctx:                             ctx,
@@ -579,8 +579,8 @@ func TestHandlerReconnectsOnServeErrors(t *testing.T) {
 	ecsClient := mock_api.NewMockECSClient(ctrl)
 	ecsClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(acsURL, nil).AnyTimes()
 
-	statemanager := statemanager.NewNoopStateManager()
-	taskHandler := eventhandler.NewTaskHandler()
+	stateManager := statemanager.NewNoopStateManager()
+	taskHandler := eventhandler.NewTaskHandler(stateManager)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	mockWsClient := mock_wsclient.NewMockClientServer(ctrl)
@@ -605,7 +605,7 @@ func TestHandlerReconnectsOnServeErrors(t *testing.T) {
 		agentConfig:          testConfig,
 		taskEngine:           taskEngine,
 		ecsClient:            ecsClient,
-		stateManager:         statemanager,
+		stateManager:         stateManager,
 		taskHandler:          taskHandler,
 		backoff:              utils.NewSimpleBackoff(connectionBackoffMin, connectionBackoffMax, connectionBackoffJitter, connectionBackoffMultiplier),
 		ctx:                  ctx,
@@ -635,8 +635,8 @@ func TestHandlerStopsWhenContextIsCancelled(t *testing.T) {
 	ecsClient := mock_api.NewMockECSClient(ctrl)
 	ecsClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(acsURL, nil).AnyTimes()
 
-	statemanager := statemanager.NewNoopStateManager()
-	taskHandler := eventhandler.NewTaskHandler()
+	stateManager := statemanager.NewNoopStateManager()
+	taskHandler := eventhandler.NewTaskHandler(stateManager)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	mockWsClient := mock_wsclient.NewMockClientServer(ctrl)
@@ -656,7 +656,7 @@ func TestHandlerStopsWhenContextIsCancelled(t *testing.T) {
 		agentConfig:          testConfig,
 		taskEngine:           taskEngine,
 		ecsClient:            ecsClient,
-		stateManager:         statemanager,
+		stateManager:         stateManager,
 		taskHandler:          taskHandler,
 		backoff:              utils.NewSimpleBackoff(connectionBackoffMin, connectionBackoffMax, connectionBackoffJitter, connectionBackoffMultiplier),
 		ctx:                  ctx,
@@ -684,8 +684,8 @@ func TestHandlerReconnectsOnDiscoverPollEndpointError(t *testing.T) {
 	taskEngine.EXPECT().Version().Return("Docker: 1.5.0", nil).AnyTimes()
 
 	ecsClient := mock_api.NewMockECSClient(ctrl)
-	statemanager := statemanager.NewNoopStateManager()
-	taskHandler := eventhandler.NewTaskHandler()
+	stateManager := statemanager.NewNoopStateManager()
+	taskHandler := eventhandler.NewTaskHandler(stateManager)
 
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -711,7 +711,7 @@ func TestHandlerReconnectsOnDiscoverPollEndpointError(t *testing.T) {
 		agentConfig:          testConfig,
 		taskEngine:           taskEngine,
 		ecsClient:            ecsClient,
-		stateManager:         statemanager,
+		stateManager:         stateManager,
 		taskHandler:          taskHandler,
 		backoff:              utils.NewSimpleBackoff(connectionBackoffMin, connectionBackoffMax, connectionBackoffJitter, connectionBackoffMultiplier),
 		ctx:                  ctx,
@@ -754,8 +754,8 @@ func TestConnectionIsClosedOnIdle(t *testing.T) {
 	taskEngine.EXPECT().Version().Return("Docker: 1.5.0", nil).AnyTimes()
 
 	ecsClient := mock_api.NewMockECSClient(ctrl)
-	statemanager := statemanager.NewNoopStateManager()
-	taskHandler := eventhandler.NewTaskHandler()
+	stateManager := statemanager.NewNoopStateManager()
+	taskHandler := eventhandler.NewTaskHandler(stateManager)
 
 	wait := sync.WaitGroup{}
 	wait.Add(1)
@@ -782,7 +782,7 @@ func TestConnectionIsClosedOnIdle(t *testing.T) {
 		agentConfig:          testConfig,
 		taskEngine:           taskEngine,
 		ecsClient:            ecsClient,
-		stateManager:         statemanager,
+		stateManager:         stateManager,
 		taskHandler:          taskHandler,
 		ctx:                  context.Background(),
 		backoff:              utils.NewSimpleBackoff(connectionBackoffMin, connectionBackoffMax, connectionBackoffJitter, connectionBackoffMultiplier),
@@ -806,8 +806,8 @@ func TestHandlerDoesntLeakGoroutines(t *testing.T) {
 	defer ctrl.Finish()
 	taskEngine := engine.NewMockTaskEngine(ctrl)
 	ecsClient := mock_api.NewMockECSClient(ctrl)
-	statemanager := statemanager.NewNoopStateManager()
-	taskHandler := eventhandler.NewTaskHandler()
+	stateManager := statemanager.NewNoopStateManager()
+	taskHandler := eventhandler.NewTaskHandler(stateManager)
 
 	closeWS := make(chan bool)
 	server, serverIn, requests, errs, err := startMockAcsServer(t, closeWS)
@@ -839,7 +839,7 @@ func TestHandlerDoesntLeakGoroutines(t *testing.T) {
 			agentConfig:          testConfig,
 			taskEngine:           taskEngine,
 			ecsClient:            ecsClient,
-			stateManager:         statemanager,
+			stateManager:         stateManager,
 			taskHandler:          taskHandler,
 			ctx:                  ctx,
 			_heartbeatTimeout:    1 * time.Second,
@@ -890,7 +890,7 @@ func TestStartSessionHandlesRefreshCredentialsMessages(t *testing.T) {
 	taskEngine := engine.NewMockTaskEngine(ctrl)
 	ecsClient := mock_api.NewMockECSClient(ctrl)
 	stateManager := statemanager.NewNoopStateManager()
-	taskHandler := eventhandler.NewTaskHandler()
+	taskHandler := eventhandler.NewTaskHandler(stateManager)
 	closeWS := make(chan bool)
 	server, serverIn, requestsChan, errChan, err := startMockAcsServer(t, closeWS)
 	if err != nil {
@@ -1008,8 +1008,8 @@ func TestHandlerReconnectsCorrectlySetsSendCredentialsURLParameter(t *testing.T)
 	defer ctrl.Finish()
 	taskEngine := engine.NewMockTaskEngine(ctrl)
 	ecsClient := mock_api.NewMockECSClient(ctrl)
-	statemanager := statemanager.NewNoopStateManager()
-	taskHandler := eventhandler.NewTaskHandler()
+	stateManager := statemanager.NewNoopStateManager()
+	taskHandler := eventhandler.NewTaskHandler(stateManager)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	mockWsClient := mock_wsclient.NewMockClientServer(ctrl)
@@ -1038,7 +1038,7 @@ func TestHandlerReconnectsCorrectlySetsSendCredentialsURLParameter(t *testing.T)
 		agentConfig:          testConfig,
 		taskEngine:           taskEngine,
 		ecsClient:            ecsClient,
-		stateManager:         statemanager,
+		stateManager:         stateManager,
 		taskHandler:          taskHandler,
 		ctx:                  ctx,
 		resources:            resources,

--- a/agent/acs/handler/payload_handler_test.go
+++ b/agent/acs/handler/payload_handler_test.go
@@ -47,7 +47,7 @@ func TestHandlePayloadMessageWithNoMessageId(t *testing.T) {
 	ecsClient := mock_api.NewMockECSClient(ctrl)
 	stateManager := statemanager.NewNoopStateManager()
 	credentialsManager := credentials.NewManager()
-	taskHandler := eventhandler.NewTaskHandler()
+	taskHandler := eventhandler.NewTaskHandler(stateManager)
 
 	ctx := context.Background()
 	buffer := newPayloadRequestHandler(
@@ -94,7 +94,7 @@ func TestHandlePayloadMessageAddTaskError(t *testing.T) {
 	ecsClient := mock_api.NewMockECSClient(ctrl)
 	stateManager := statemanager.NewNoopStateManager()
 	credentialsManager := credentials.NewManager()
-	taskHandler := eventhandler.NewTaskHandler()
+	taskHandler := eventhandler.NewTaskHandler(stateManager)
 
 	// Return error from AddTask
 	taskEngine.EXPECT().AddTask(gomock.Any()).Return(fmt.Errorf("oops")).Times(2)
@@ -150,7 +150,8 @@ func TestHandlePayloadMessageStateSaveError(t *testing.T) {
 	defer ctrl.Finish()
 	ecsClient := mock_api.NewMockECSClient(ctrl)
 	credentialsManager := credentials.NewManager()
-	taskHandler := eventhandler.NewTaskHandler()
+	stateManager := mock_statemanager.NewMockStateManager(ctrl)
+	taskHandler := eventhandler.NewTaskHandler(stateManager)
 
 	taskEngine := engine.NewMockTaskEngine(ctrl)
 	// Save added task in the addedTask variable
@@ -160,7 +161,6 @@ func TestHandlePayloadMessageStateSaveError(t *testing.T) {
 	}).Times(1)
 
 	// State manager returns error on save
-	stateManager := mock_statemanager.NewMockStateManager(ctrl)
 	stateManager.EXPECT().Save().Return(fmt.Errorf("oops"))
 
 	ctx := context.Background()
@@ -206,7 +206,7 @@ func TestHandlePayloadMessageAckedWhenTaskAdded(t *testing.T) {
 	ecsClient := mock_api.NewMockECSClient(ctrl)
 	stateManager := statemanager.NewNoopStateManager()
 	credentialsManager := credentials.NewManager()
-	taskHandler := eventhandler.NewTaskHandler()
+	taskHandler := eventhandler.NewTaskHandler(stateManager)
 	ctx, cancel := context.WithCancel(context.Background())
 
 	taskEngine := engine.NewMockTaskEngine(ctrl)
@@ -277,7 +277,7 @@ func TestHandlePayloadMessageCredentialsAckedWhenTaskAdded(t *testing.T) {
 	stateManager := statemanager.NewNoopStateManager()
 	ctx, cancel := context.WithCancel(context.Background())
 	credentialsManager := credentials.NewManager()
-	taskHandler := eventhandler.NewTaskHandler()
+	taskHandler := eventhandler.NewTaskHandler(stateManager)
 
 	taskEngine := engine.NewMockTaskEngine(ctrl)
 	var addedTask *api.Task
@@ -391,7 +391,8 @@ func TestAddPayloadTaskAddsNonStoppedTasksAfterStoppedTasks(t *testing.T) {
 	ecsClient := mock_api.NewMockECSClient(ctrl)
 	taskEngine := engine.NewMockTaskEngine(ctrl)
 	credentialsManager := credentials.NewManager()
-	taskHandler := eventhandler.NewTaskHandler()
+	stateManager := statemanager.NewNoopStateManager()
+	taskHandler := eventhandler.NewTaskHandler(stateManager)
 
 	var tasksAddedToEngine []*api.Task
 	taskEngine.EXPECT().AddTask(gomock.Any()).Do(func(task *api.Task) {
@@ -415,7 +416,6 @@ func TestAddPayloadTaskAddsNonStoppedTasksAfterStoppedTasks(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	stateManager := statemanager.NewNoopStateManager()
 	buffer := newPayloadRequestHandler(
 		ctx,
 		taskEngine,
@@ -451,7 +451,7 @@ func TestPayloadBufferHandler(t *testing.T) {
 	ecsClient := mock_api.NewMockECSClient(ctrl)
 	stateManager := statemanager.NewNoopStateManager()
 	credentialsManager := credentials.NewManager()
-	taskHandler := eventhandler.NewTaskHandler()
+	taskHandler := eventhandler.NewTaskHandler(stateManager)
 	ctx, cancel := context.WithCancel(context.Background())
 
 	var addedTask *api.Task
@@ -517,7 +517,7 @@ func TestPayloadBufferHandlerWithCredentials(t *testing.T) {
 	stateManager := statemanager.NewNoopStateManager()
 	ctx, cancel := context.WithCancel(context.Background())
 	credentialsManager := credentials.NewManager()
-	taskHandler := eventhandler.NewTaskHandler()
+	taskHandler := eventhandler.NewTaskHandler(stateManager)
 
 	// The payload message in the test consists of two tasks, record both of them in
 	// the order in which they were added

--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -186,7 +186,7 @@ func (agent *ecsAgent) doStart(containerChangeEventStream *eventstream.EventStre
 	deregisterInstanceEventStream := eventstream.NewEventStream(
 		deregisterContainerInstanceEventStreamName, agent.ctx)
 	deregisterInstanceEventStream.StartListening()
-	taskHandler := eventhandler.NewTaskHandler()
+	taskHandler := eventhandler.NewTaskHandler(stateManager)
 	agent.startAsyncRoutines(containerChangeEventStream, credentialsManager, imageManager,
 		taskEngine, stateManager, deregisterInstanceEventStream, client, taskHandler)
 

--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -393,7 +393,7 @@ func (agent *ecsAgent) startAsyncRoutines(
 	go credentialshandler.ServeHTTP(credentialsManager, agent.containerInstanceARN, agent.cfg)
 
 	// Start sending events to the backend
-	go eventhandler.HandleEngineEvents(taskEngine, client, stateManager, taskHandler)
+	go eventhandler.HandleEngineEvents(taskEngine, client, taskHandler)
 
 	telemetrySessionParams := tcshandler.TelemetrySessionParams{
 		CredentialProvider:            agent.credentialProvider,

--- a/agent/eventhandler/handler.go
+++ b/agent/eventhandler/handler.go
@@ -16,19 +16,10 @@ package eventhandler
 import (
 	"github.com/aws/amazon-ecs-agent/agent/api"
 	"github.com/aws/amazon-ecs-agent/agent/engine"
-	"github.com/aws/amazon-ecs-agent/agent/logger"
-	"github.com/aws/amazon-ecs-agent/agent/statemanager"
+	"github.com/cihub/seelog"
 )
 
-var log = logger.ForModule("eventhandler")
-
-// statesaver is a package-wise statemanager which may be used to save any
-// changes to a task or container's SentStatus
-var statesaver statemanager.Saver = statemanager.NewNoopStateManager()
-
-func HandleEngineEvents(taskEngine engine.TaskEngine, client api.ECSClient, saver statemanager.Saver, eventhandler *TaskHandler) {
-	statesaver = saver
-
+func HandleEngineEvents(taskEngine engine.TaskEngine, client api.ECSClient, eventhandler *TaskHandler) {
 	for {
 		stateChangeEvents := taskEngine.StateChangeEvents()
 
@@ -37,12 +28,12 @@ func HandleEngineEvents(taskEngine engine.TaskEngine, client api.ECSClient, save
 			case event, ok := <-stateChangeEvents:
 				if !ok {
 					stateChangeEvents = nil
-					log.Error("Unable to handle state change event. The events channel is closed")
+					seelog.Error("Unable to handle state change event. The events channel is closed")
 					break
 				}
 				err := eventhandler.AddStateChangeEvent(event, client)
 				if err != nil {
-					log.Error("Handler unable to add state change event", "err", err, "event", event)
+					seelog.Errorf("Handler unable to add state change event %v: %v", event, err)
 				}
 			}
 		}

--- a/agent/eventhandler/handler_test.go
+++ b/agent/eventhandler/handler_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/api"
 	"github.com/aws/amazon-ecs-agent/agent/api/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/statechange"
+	"github.com/aws/amazon-ecs-agent/agent/statemanager"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -31,8 +32,9 @@ func TestSendsEventsOneContainer(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	client := mock_api.NewMockECSClient(ctrl)
+	stateManager := statemanager.NewNoopStateManager()
 
-	handler := NewTaskHandler()
+	handler := NewTaskHandler(stateManager)
 	taskarn := "taskarn"
 
 	var wg sync.WaitGroup
@@ -61,8 +63,9 @@ func TestSendsEventsOneEventRetries(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	client := mock_api.NewMockECSClient(ctrl)
+	stateManager := statemanager.NewNoopStateManager()
 
-	handler := NewTaskHandler()
+	handler := NewTaskHandler(stateManager)
 	taskarn := "taskarn"
 
 	var wg sync.WaitGroup
@@ -85,8 +88,9 @@ func TestSendsEventsConcurrentLimit(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	client := mock_api.NewMockECSClient(ctrl)
+	stateManager := statemanager.NewNoopStateManager()
 
-	handler := NewTaskHandler()
+	handler := NewTaskHandler(stateManager)
 
 	completeStateChange := make(chan bool, concurrentEventCalls+1)
 	var wg sync.WaitGroup
@@ -121,8 +125,9 @@ func TestSendsEventsContainerDifferences(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	client := mock_api.NewMockECSClient(ctrl)
+	stateManager := statemanager.NewNoopStateManager()
 
-	handler := NewTaskHandler()
+	handler := NewTaskHandler(stateManager)
 	taskarn := "taskarn"
 
 	var wg sync.WaitGroup
@@ -153,8 +158,9 @@ func TestSendsEventsTaskDifferences(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	client := mock_api.NewMockECSClient(ctrl)
+	stateManager := statemanager.NewNoopStateManager()
 
-	handler := NewTaskHandler()
+	handler := NewTaskHandler(stateManager)
 	taskarnA := "taskarnA"
 	taskarnB := "taskarnB"
 
@@ -199,8 +205,9 @@ func TestSendsEventsDedupe(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	client := mock_api.NewMockECSClient(ctrl)
+	stateManager := statemanager.NewNoopStateManager()
 
-	handler := NewTaskHandler()
+	handler := NewTaskHandler(stateManager)
 	taskarnA := "taskarnA"
 	taskarnB := "taskarnB"
 

--- a/agent/eventhandler/handler_test.go
+++ b/agent/eventhandler/handler_test.go
@@ -27,22 +27,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func containerEvent(arn string) statechange.Event {
-	return api.ContainerStateChange{TaskArn: arn, ContainerName: "containerName", Status: api.ContainerRunning, Container: &api.Container{}}
-}
-
-func containerEventStopped(arn string) statechange.Event {
-	return api.ContainerStateChange{TaskArn: arn, ContainerName: "containerName", Status: api.ContainerStopped, Container: &api.Container{}}
-}
-
-func taskEvent(arn string) statechange.Event {
-	return api.TaskStateChange{TaskArn: arn, Status: api.TaskRunning, Task: &api.Task{}}
-}
-
-func taskEventStopped(arn string) statechange.Event {
-	return api.TaskStateChange{TaskArn: arn, Status: api.TaskStopped, Task: &api.Task{}}
-}
-
 func TestSendsEventsOneContainer(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -263,4 +247,20 @@ func TestShouldBeSent(t *testing.T) {
 	if !sendableEvent.containerShouldBeSent() {
 		t.Error("Container should be sent if it's the first try")
 	}
+}
+
+func containerEvent(arn string) statechange.Event {
+	return api.ContainerStateChange{TaskArn: arn, ContainerName: "containerName", Status: api.ContainerRunning, Container: &api.Container{}}
+}
+
+func containerEventStopped(arn string) statechange.Event {
+	return api.ContainerStateChange{TaskArn: arn, ContainerName: "containerName", Status: api.ContainerStopped, Container: &api.Container{}}
+}
+
+func taskEvent(arn string) statechange.Event {
+	return api.TaskStateChange{TaskArn: arn, Status: api.TaskRunning, Task: &api.Task{}}
+}
+
+func taskEventStopped(arn string) statechange.Event {
+	return api.TaskStateChange{TaskArn: arn, Status: api.TaskStopped, Task: &api.Task{}}
 }


### PR DESCRIPTION
Signed-off-by: Vinothkumar Siddharth <sidvin@amazon.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Removes global state saver from eventhandler

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no --> NO

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes --> YES
