### PR TITLE
Merge enis from dev 09012017

### DIFF
--- a/agent/acs/handler/acs_handler_test.go
+++ b/agent/acs/handler/acs_handler_test.go
@@ -201,8 +201,8 @@ func TestHandlerReconnectsOnConnectErrors(t *testing.T) {
 	ecsClient := mock_api.NewMockECSClient(ctrl)
 	ecsClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(acsURL, nil).AnyTimes()
 
-	statemanager := statemanager.NewNoopStateManager()
-	taskHandler := eventhandler.NewTaskHandler()
+	stateManager := statemanager.NewNoopStateManager()
+	taskHandler := eventhandler.NewTaskHandler(stateManager)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	mockWsClient := mock_wsclient.NewMockClientServer(ctrl)
@@ -225,7 +225,7 @@ func TestHandlerReconnectsOnConnectErrors(t *testing.T) {
 		agentConfig:          testConfig,
 		taskEngine:           taskEngine,
 		ecsClient:            ecsClient,
-		stateManager:         statemanager,
+		stateManager:         stateManager,
 		taskHandler:          taskHandler,
 		backoff:              utils.NewSimpleBackoff(connectionBackoffMin, connectionBackoffMax, connectionBackoffJitter, connectionBackoffMultiplier),
 		ctx:                  ctx,
@@ -339,8 +339,8 @@ func TestHandlerReconnectsWithoutBackoffOnEOFError(t *testing.T) {
 	ecsClient := mock_api.NewMockECSClient(ctrl)
 	ecsClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(acsURL, nil).AnyTimes()
 
-	statemanager := statemanager.NewNoopStateManager()
-	taskHandler := eventhandler.NewTaskHandler()
+	stateManager := statemanager.NewNoopStateManager()
+	taskHandler := eventhandler.NewTaskHandler(stateManager)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	deregisterInstanceEventStream := eventstream.NewEventStream("DeregisterContainerInstance", ctx)
@@ -370,7 +370,7 @@ func TestHandlerReconnectsWithoutBackoffOnEOFError(t *testing.T) {
 		taskEngine:                      taskEngine,
 		ecsClient:                       ecsClient,
 		deregisterInstanceEventStream:   deregisterInstanceEventStream,
-		stateManager:                    statemanager,
+		stateManager:                    stateManager,
 		taskHandler:                     taskHandler,
 		backoff:                         mockBackoff,
 		ctx:                             ctx,
@@ -402,8 +402,8 @@ func TestHandlerReconnectsWithBackoffOnNonEOFError(t *testing.T) {
 	ecsClient := mock_api.NewMockECSClient(ctrl)
 	ecsClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(acsURL, nil).AnyTimes()
 
-	statemanager := statemanager.NewNoopStateManager()
-	taskHandler := eventhandler.NewTaskHandler()
+	stateManager := statemanager.NewNoopStateManager()
+	taskHandler := eventhandler.NewTaskHandler(stateManager)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	deregisterInstanceEventStream := eventstream.NewEventStream("DeregisterContainerInstance", ctx)
@@ -433,7 +433,7 @@ func TestHandlerReconnectsWithBackoffOnNonEOFError(t *testing.T) {
 		taskEngine:                    taskEngine,
 		ecsClient:                     ecsClient,
 		deregisterInstanceEventStream: deregisterInstanceEventStream,
-		stateManager:                  statemanager,
+		stateManager:                  stateManager,
 		taskHandler:                   taskHandler,
 		backoff:                       mockBackoff,
 		ctx:                           ctx,
@@ -464,8 +464,8 @@ func TestHandlerGeneratesDeregisteredInstanceEvent(t *testing.T) {
 	ecsClient := mock_api.NewMockECSClient(ctrl)
 	ecsClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(acsURL, nil).AnyTimes()
 
-	statemanager := statemanager.NewNoopStateManager()
-	taskHandler := eventhandler.NewTaskHandler()
+	stateManager := statemanager.NewNoopStateManager()
+	taskHandler := eventhandler.NewTaskHandler(stateManager)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	deregisterInstanceEventStream := eventstream.NewEventStream("DeregisterContainerInstance", ctx)
@@ -492,7 +492,7 @@ func TestHandlerGeneratesDeregisteredInstanceEvent(t *testing.T) {
 		taskEngine:                      taskEngine,
 		ecsClient:                       ecsClient,
 		deregisterInstanceEventStream:   deregisterInstanceEventStream,
-		stateManager:                    statemanager,
+		stateManager:                    stateManager,
 		taskHandler:                     taskHandler,
 		backoff:                         utils.NewSimpleBackoff(connectionBackoffMin, connectionBackoffMax, connectionBackoffJitter, connectionBackoffMultiplier),
 		ctx:                             ctx,
@@ -524,8 +524,8 @@ func TestHandlerReconnectDelayForInactiveInstanceError(t *testing.T) {
 	ecsClient := mock_api.NewMockECSClient(ctrl)
 	ecsClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(acsURL, nil).AnyTimes()
 
-	statemanager := statemanager.NewNoopStateManager()
-	taskHandler := eventhandler.NewTaskHandler()
+	stateManager := statemanager.NewNoopStateManager()
+	taskHandler := eventhandler.NewTaskHandler(stateManager)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	deregisterInstanceEventStream := eventstream.NewEventStream("DeregisterContainerInstance", ctx)
@@ -561,7 +561,7 @@ func TestHandlerReconnectDelayForInactiveInstanceError(t *testing.T) {
 		taskEngine:                      taskEngine,
 		ecsClient:                       ecsClient,
 		deregisterInstanceEventStream:   deregisterInstanceEventStream,
-		stateManager:                    statemanager,
+		stateManager:                    stateManager,
 		taskHandler:                     taskHandler,
 		backoff:                         utils.NewSimpleBackoff(connectionBackoffMin, connectionBackoffMax, connectionBackoffJitter, connectionBackoffMultiplier),
 		ctx:                             ctx,
@@ -592,8 +592,8 @@ func TestHandlerReconnectsOnServeErrors(t *testing.T) {
 	ecsClient := mock_api.NewMockECSClient(ctrl)
 	ecsClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(acsURL, nil).AnyTimes()
 
-	statemanager := statemanager.NewNoopStateManager()
-	taskHandler := eventhandler.NewTaskHandler()
+	stateManager := statemanager.NewNoopStateManager()
+	taskHandler := eventhandler.NewTaskHandler(stateManager)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	mockWsClient := mock_wsclient.NewMockClientServer(ctrl)
@@ -618,7 +618,7 @@ func TestHandlerReconnectsOnServeErrors(t *testing.T) {
 		agentConfig:          testConfig,
 		taskEngine:           taskEngine,
 		ecsClient:            ecsClient,
-		stateManager:         statemanager,
+		stateManager:         stateManager,
 		taskHandler:          taskHandler,
 		backoff:              utils.NewSimpleBackoff(connectionBackoffMin, connectionBackoffMax, connectionBackoffJitter, connectionBackoffMultiplier),
 		ctx:                  ctx,
@@ -648,8 +648,8 @@ func TestHandlerStopsWhenContextIsCancelled(t *testing.T) {
 	ecsClient := mock_api.NewMockECSClient(ctrl)
 	ecsClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(acsURL, nil).AnyTimes()
 
-	statemanager := statemanager.NewNoopStateManager()
-	taskHandler := eventhandler.NewTaskHandler()
+	stateManager := statemanager.NewNoopStateManager()
+	taskHandler := eventhandler.NewTaskHandler(stateManager)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	mockWsClient := mock_wsclient.NewMockClientServer(ctrl)
@@ -669,7 +669,7 @@ func TestHandlerStopsWhenContextIsCancelled(t *testing.T) {
 		agentConfig:          testConfig,
 		taskEngine:           taskEngine,
 		ecsClient:            ecsClient,
-		stateManager:         statemanager,
+		stateManager:         stateManager,
 		taskHandler:          taskHandler,
 		backoff:              utils.NewSimpleBackoff(connectionBackoffMin, connectionBackoffMax, connectionBackoffJitter, connectionBackoffMultiplier),
 		ctx:                  ctx,
@@ -697,8 +697,8 @@ func TestHandlerReconnectsOnDiscoverPollEndpointError(t *testing.T) {
 	taskEngine.EXPECT().Version().Return("Docker: 1.5.0", nil).AnyTimes()
 
 	ecsClient := mock_api.NewMockECSClient(ctrl)
-	statemanager := statemanager.NewNoopStateManager()
-	taskHandler := eventhandler.NewTaskHandler()
+	stateManager := statemanager.NewNoopStateManager()
+	taskHandler := eventhandler.NewTaskHandler(stateManager)
 
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -724,7 +724,7 @@ func TestHandlerReconnectsOnDiscoverPollEndpointError(t *testing.T) {
 		agentConfig:          testConfig,
 		taskEngine:           taskEngine,
 		ecsClient:            ecsClient,
-		stateManager:         statemanager,
+		stateManager:         stateManager,
 		taskHandler:          taskHandler,
 		backoff:              utils.NewSimpleBackoff(connectionBackoffMin, connectionBackoffMax, connectionBackoffJitter, connectionBackoffMultiplier),
 		ctx:                  ctx,
@@ -767,8 +767,8 @@ func TestConnectionIsClosedOnIdle(t *testing.T) {
 	taskEngine.EXPECT().Version().Return("Docker: 1.5.0", nil).AnyTimes()
 
 	ecsClient := mock_api.NewMockECSClient(ctrl)
-	statemanager := statemanager.NewNoopStateManager()
-	taskHandler := eventhandler.NewTaskHandler()
+	stateManager := statemanager.NewNoopStateManager()
+	taskHandler := eventhandler.NewTaskHandler(stateManager)
 
 	wait := sync.WaitGroup{}
 	wait.Add(1)
@@ -795,7 +795,7 @@ func TestConnectionIsClosedOnIdle(t *testing.T) {
 		agentConfig:          testConfig,
 		taskEngine:           taskEngine,
 		ecsClient:            ecsClient,
-		stateManager:         statemanager,
+		stateManager:         stateManager,
 		taskHandler:          taskHandler,
 		ctx:                  context.Background(),
 		backoff:              utils.NewSimpleBackoff(connectionBackoffMin, connectionBackoffMax, connectionBackoffJitter, connectionBackoffMultiplier),
@@ -819,8 +819,8 @@ func TestHandlerDoesntLeakGoroutines(t *testing.T) {
 	defer ctrl.Finish()
 	taskEngine := engine.NewMockTaskEngine(ctrl)
 	ecsClient := mock_api.NewMockECSClient(ctrl)
-	statemanager := statemanager.NewNoopStateManager()
-	taskHandler := eventhandler.NewTaskHandler()
+	stateManager := statemanager.NewNoopStateManager()
+	taskHandler := eventhandler.NewTaskHandler(stateManager)
 
 	closeWS := make(chan bool)
 	server, serverIn, requests, errs, err := startMockAcsServer(t, closeWS)
@@ -852,7 +852,7 @@ func TestHandlerDoesntLeakGoroutines(t *testing.T) {
 			agentConfig:          testConfig,
 			taskEngine:           taskEngine,
 			ecsClient:            ecsClient,
-			stateManager:         statemanager,
+			stateManager:         stateManager,
 			taskHandler:          taskHandler,
 			ctx:                  ctx,
 			_heartbeatTimeout:    1 * time.Second,
@@ -903,7 +903,7 @@ func TestStartSessionHandlesRefreshCredentialsMessages(t *testing.T) {
 	taskEngine := engine.NewMockTaskEngine(ctrl)
 	ecsClient := mock_api.NewMockECSClient(ctrl)
 	stateManager := statemanager.NewNoopStateManager()
-	taskHandler := eventhandler.NewTaskHandler()
+	taskHandler := eventhandler.NewTaskHandler(stateManager)
 	closeWS := make(chan bool)
 	server, serverIn, requestsChan, errChan, err := startMockAcsServer(t, closeWS)
 	if err != nil {
@@ -1022,8 +1022,8 @@ func TestHandlerReconnectsCorrectlySetsSendCredentialsURLParameter(t *testing.T)
 	defer ctrl.Finish()
 	taskEngine := engine.NewMockTaskEngine(ctrl)
 	ecsClient := mock_api.NewMockECSClient(ctrl)
-	statemanager := statemanager.NewNoopStateManager()
-	taskHandler := eventhandler.NewTaskHandler()
+	stateManager := statemanager.NewNoopStateManager()
+	taskHandler := eventhandler.NewTaskHandler(stateManager)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	mockWsClient := mock_wsclient.NewMockClientServer(ctrl)
@@ -1052,7 +1052,7 @@ func TestHandlerReconnectsCorrectlySetsSendCredentialsURLParameter(t *testing.T)
 		agentConfig:          testConfig,
 		taskEngine:           taskEngine,
 		ecsClient:            ecsClient,
-		stateManager:         statemanager,
+		stateManager:         stateManager,
 		taskHandler:          taskHandler,
 		ctx:                  ctx,
 		resources:            resources,

--- a/agent/acs/handler/payload_handler_test.go
+++ b/agent/acs/handler/payload_handler_test.go
@@ -47,7 +47,7 @@ func TestHandlePayloadMessageWithNoMessageId(t *testing.T) {
 	ecsClient := mock_api.NewMockECSClient(ctrl)
 	stateManager := statemanager.NewNoopStateManager()
 	credentialsManager := credentials.NewManager()
-	taskHandler := eventhandler.NewTaskHandler()
+	taskHandler := eventhandler.NewTaskHandler(stateManager)
 
 	ctx := context.Background()
 	buffer := newPayloadRequestHandler(
@@ -94,7 +94,7 @@ func TestHandlePayloadMessageAddTaskError(t *testing.T) {
 	ecsClient := mock_api.NewMockECSClient(ctrl)
 	stateManager := statemanager.NewNoopStateManager()
 	credentialsManager := credentials.NewManager()
-	taskHandler := eventhandler.NewTaskHandler()
+	taskHandler := eventhandler.NewTaskHandler(stateManager)
 
 	// Return error from AddTask
 	taskEngine.EXPECT().AddTask(gomock.Any()).Return(fmt.Errorf("oops")).Times(2)
@@ -150,7 +150,8 @@ func TestHandlePayloadMessageStateSaveError(t *testing.T) {
 	defer ctrl.Finish()
 	ecsClient := mock_api.NewMockECSClient(ctrl)
 	credentialsManager := credentials.NewManager()
-	taskHandler := eventhandler.NewTaskHandler()
+	stateManager := mock_statemanager.NewMockStateManager(ctrl)
+	taskHandler := eventhandler.NewTaskHandler(stateManager)
 
 	taskEngine := engine.NewMockTaskEngine(ctrl)
 	// Save added task in the addedTask variable
@@ -160,7 +161,6 @@ func TestHandlePayloadMessageStateSaveError(t *testing.T) {
 	}).Times(1)
 
 	// State manager returns error on save
-	stateManager := mock_statemanager.NewMockStateManager(ctrl)
 	stateManager.EXPECT().Save().Return(fmt.Errorf("oops"))
 
 	ctx := context.Background()
@@ -206,7 +206,7 @@ func TestHandlePayloadMessageAckedWhenTaskAdded(t *testing.T) {
 	ecsClient := mock_api.NewMockECSClient(ctrl)
 	stateManager := statemanager.NewNoopStateManager()
 	credentialsManager := credentials.NewManager()
-	taskHandler := eventhandler.NewTaskHandler()
+	taskHandler := eventhandler.NewTaskHandler(stateManager)
 	ctx, cancel := context.WithCancel(context.Background())
 
 	taskEngine := engine.NewMockTaskEngine(ctrl)
@@ -277,7 +277,7 @@ func TestHandlePayloadMessageCredentialsAckedWhenTaskAdded(t *testing.T) {
 	stateManager := statemanager.NewNoopStateManager()
 	ctx, cancel := context.WithCancel(context.Background())
 	credentialsManager := credentials.NewManager()
-	taskHandler := eventhandler.NewTaskHandler()
+	taskHandler := eventhandler.NewTaskHandler(stateManager)
 
 	taskEngine := engine.NewMockTaskEngine(ctrl)
 	var addedTask *api.Task
@@ -391,7 +391,8 @@ func TestAddPayloadTaskAddsNonStoppedTasksAfterStoppedTasks(t *testing.T) {
 	ecsClient := mock_api.NewMockECSClient(ctrl)
 	taskEngine := engine.NewMockTaskEngine(ctrl)
 	credentialsManager := credentials.NewManager()
-	taskHandler := eventhandler.NewTaskHandler()
+	stateManager := statemanager.NewNoopStateManager()
+	taskHandler := eventhandler.NewTaskHandler(stateManager)
 
 	var tasksAddedToEngine []*api.Task
 	taskEngine.EXPECT().AddTask(gomock.Any()).Do(func(task *api.Task) {
@@ -415,7 +416,6 @@ func TestAddPayloadTaskAddsNonStoppedTasksAfterStoppedTasks(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	stateManager := statemanager.NewNoopStateManager()
 	buffer := newPayloadRequestHandler(
 		ctx,
 		taskEngine,
@@ -451,7 +451,7 @@ func TestPayloadBufferHandler(t *testing.T) {
 	ecsClient := mock_api.NewMockECSClient(ctrl)
 	stateManager := statemanager.NewNoopStateManager()
 	credentialsManager := credentials.NewManager()
-	taskHandler := eventhandler.NewTaskHandler()
+	taskHandler := eventhandler.NewTaskHandler(stateManager)
 	ctx, cancel := context.WithCancel(context.Background())
 
 	var addedTask *api.Task
@@ -517,7 +517,7 @@ func TestPayloadBufferHandlerWithCredentials(t *testing.T) {
 	stateManager := statemanager.NewNoopStateManager()
 	ctx, cancel := context.WithCancel(context.Background())
 	credentialsManager := credentials.NewManager()
-	taskHandler := eventhandler.NewTaskHandler()
+	taskHandler := eventhandler.NewTaskHandler(stateManager)
 
 	// The payload message in the test consists of two tasks, record both of them in
 	// the order in which they were added
@@ -696,7 +696,7 @@ func TestPayloadHandlerAddedENIToTask(t *testing.T) {
 	stateManager := statemanager.NewNoopStateManager()
 	ctx := context.Background()
 	credentialsManager := credentials.NewManager()
-	taskHandler := eventhandler.NewTaskHandler()
+	taskHandler := eventhandler.NewTaskHandler(stateManager)
 
 	taskEngine := engine.NewMockTaskEngine(ctrl)
 	var addedTask *api.Task

--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -234,8 +234,7 @@ func (agent *ecsAgent) doStart(containerChangeEventStream *eventstream.EventStre
 	deregisterInstanceEventStream := eventstream.NewEventStream(
 		deregisterContainerInstanceEventStreamName, agent.ctx)
 	deregisterInstanceEventStream.StartListening()
-	taskHandler := eventhandler.NewTaskHandler()
-
+	taskHandler := eventhandler.NewTaskHandler(stateManager)
 	agent.startAsyncRoutines(containerChangeEventStream, credentialsManager, imageManager,
 		taskEngine, stateManager, deregisterInstanceEventStream, client, taskHandler)
 
@@ -457,7 +456,7 @@ func (agent *ecsAgent) startAsyncRoutines(
 	go credentialshandler.ServeHTTP(credentialsManager, agent.containerInstanceARN, agent.cfg)
 
 	// Start sending events to the backend
-	go eventhandler.HandleEngineEvents(taskEngine, client, stateManager, taskHandler)
+	go eventhandler.HandleEngineEvents(taskEngine, client, taskHandler)
 
 	telemetrySessionParams := tcshandler.TelemetrySessionParams{
 		CredentialProvider:            agent.credentialProvider,

--- a/agent/engine/docker_container_engine.go
+++ b/agent/engine/docker_container_engine.go
@@ -715,11 +715,14 @@ func (dg *dockerGoClient) ContainerEvents(ctx context.Context) (<-chan DockerCon
 				continue
 			case "restart":
 			case "resize":
-			case "destroy":
 			case "unpause":
+			case "destroy":
+				// container remove events doesn't need to be handled by ecs agent
+				// as it has already moved to stopped before this event
+				continue
+
 			// These result in us falling through to inspect the container, some
 			// out of caution, some because it's a form of state change
-
 			case "oom":
 				seelog.Infof("process within container %v died due to OOM", event.ID)
 				// "oom" can either means any process got OOM'd, but doesn't always

--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -606,9 +606,9 @@ func (mtask *managedTask) cleanupTask(taskStoppedDuration time.Duration) {
 	mtask.engine.state.RemoveTask(mtask.Task)
 	eni := mtask.Task.GetTaskENI()
 	if eni == nil {
-		seelog.Debug("No eni associated with task: [%s]", mtask.Task.String())
+		seelog.Debugf("No eni associated with task: [%s]", mtask.Task.String())
 	} else {
-		seelog.Debug("Removing the eni from agent state, task: [%s]", mtask.Task.String())
+		seelog.Debugf("Removing the eni from agent state, task: [%s]", mtask.Task.String())
 		mtask.engine.state.RemoveENIAttachment(eni.MacAddress)
 	}
 	seelog.Debugf("Finished removing task data, removing task from managed tasks: %v", mtask.Task)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
One more rebase of enis branch

### Implementation details
<!-- How are the changes implemented? -->
NA

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes:  NA

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
NA

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: Yes
