### PR TITLE
Add more logging during websocket connections.

### DIFF
--- a/agent/acs/handler/acs_handler.go
+++ b/agent/acs/handler/acs_handler.go
@@ -200,6 +200,7 @@ func (acsSession *session) Start() error {
 			if shouldReconnectWithoutBackoff(acsError) {
 				// If ACS closed the connection, there's no need to backoff,
 				// reconnect immediately
+				seelog.Info("ACS Websocket connection closed for a valid reason")
 				acsSession.backoff.Reset()
 				sendEmptyMessageOnChannel(connectToACS)
 			} else {
@@ -293,6 +294,8 @@ func (acsSession *session) startACSSession(client wsclient.ClientServer, timer t
 		seelog.Errorf("Error connecting to ACS: %v", err)
 		return err
 	}
+	seelog.Info("Connected to ACS endpoint")
+
 	acsSession.resources.connectedToACS()
 
 	backoffResetTimer := time.AfterFunc(

--- a/agent/acs/handler/acs_handler.go
+++ b/agent/acs/handler/acs_handler.go
@@ -383,11 +383,11 @@ func newSessionResources(credentialsProvider *credentials.Credentials) sessionRe
 
 // acsWsURL returns the websocket url for ACS given the endpoint
 func acsWsURL(endpoint, cluster, containerInstanceArn string, taskEngine engine.TaskEngine, acsSessionState sessionState) string {
-	acsUrl := endpoint
+	acsURL := endpoint
 	if endpoint[len(endpoint)-1] != '/' {
-		acsUrl += "/"
+		acsURL += "/"
 	}
-	acsUrl += "ws"
+	acsURL += "ws"
 	query := url.Values{}
 	query.Set("clusterArn", cluster)
 	query.Set("containerInstanceArn", containerInstanceArn)
@@ -398,7 +398,7 @@ func acsWsURL(endpoint, cluster, containerInstanceArn string, taskEngine engine.
 		query.Set("dockerVersion", "DockerVersion: "+dockerVersion)
 	}
 	query.Set(sendCredentialsURLParameterName, acsSessionState.getSendCredentialsURLParameter())
-	return acsUrl + "?" + query.Encode()
+	return acsURL + "?" + query.Encode()
 }
 
 // newDisconnectionTimer creates a new time object, with a callback to

--- a/agent/tcs/handler/handler.go
+++ b/agent/tcs/handler/handler.go
@@ -75,6 +75,7 @@ func StartSession(params TelemetrySessionParams, statsEngine stats.Engine) error
 	for {
 		tcsError := startTelemetrySession(params, statsEngine)
 		if tcsError == nil || tcsError == io.EOF {
+			seelog.Info("TCS Websocket connection closed for a valid reason")
 			backoff.Reset()
 		} else {
 			log.Infof("Error from tcs; backing off: %v", tcsError)
@@ -89,7 +90,6 @@ func startTelemetrySession(params TelemetrySessionParams, statsEngine stats.Engi
 		log.Errorf("Unable to discover poll endpoint: ", err)
 		return err
 	}
-	log.Debugf("Connecting to TCS endpoint %v", tcsEndpoint)
 	url := formatURL(tcsEndpoint, params.Cfg.Cluster, params.ContainerInstanceArn)
 	return startSession(url, params.Cfg, params.CredentialProvider, statsEngine, defaultHeartbeatTimeout, defaultHeartbeatJitter, defaultPublishMetricsInterval, params.DeregisterInstanceEventStream)
 }
@@ -123,6 +123,7 @@ func startSession(url string, cfg *config.Config, credentialProvider *credential
 		log.Errorf("Error connecting to TCS: %v", err.Error())
 		return err
 	}
+	log.Info("Connected to TCS endpoint")
 	return client.Serve()
 }
 

--- a/agent/wsclient/client.go
+++ b/agent/wsclient/client.go
@@ -132,6 +132,7 @@ type ClientServerImpl struct {
 // 'MakeRequest' can be made after calling this, but responss will not be
 // receivable until 'Serve' is also called.
 func (cs *ClientServerImpl) Connect() error {
+	seelog.Debugf("Establishing a Websocket connection to %s", cs.URL)
 	cs.writeLock.Lock()
 	defer cs.writeLock.Unlock()
 	parsedURL, err := url.Parse(cs.URL)
@@ -287,7 +288,7 @@ func (cs *ClientServerImpl) ConsumeMessages() error {
 			cs.handleMessage(message)
 
 		case permissibleCloseCode(err):
-			seelog.Infof("Connection closed for a valid reason: %s", err)
+			seelog.Debugf("Connection closed for a valid reason: %s", err)
 			return io.EOF
 
 		default:

--- a/agent/wsclient/client.go
+++ b/agent/wsclient/client.go
@@ -204,12 +204,15 @@ func (cs *ClientServerImpl) Connect() error {
 	return nil
 }
 
+// IsReady gives a boolean response that informs the caller if the websocket
+// connection is fully established.
 func (cs *ClientServerImpl) IsReady() bool {
 	cs.writeLock.Lock()
 	defer cs.writeLock.Unlock()
 	return cs.conn != nil
 }
 
+// SetConnection passes a websocket connection object into the client.
 func (cs *ClientServerImpl) SetConnection(conn WebsocketConn) {
 	cs.conn = conn
 }
@@ -247,6 +250,7 @@ func (cs *ClientServerImpl) AddRequestHandler(f RequestHandler) {
 	cs.RequestHandlers[firstArgTypeStr] = f
 }
 
+// SetAnyRequestHandler passes a RequestHandler object into the client.
 func (cs *ClientServerImpl) SetAnyRequestHandler(f RequestHandler) {
 	cs.AnyRequestHandler = f
 }


### PR DESCRIPTION
### Summary

There is frequent confusion regarding our logging of websocket disconnects. This adds logging for the subsequent reconnection.

### Implementation details
NA

### Testing
NA


- [ ] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [ ] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no --> no

### Description for the changelog

NA

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes --> yes
