### PR TITLE
Add blackhole imds route for awsvpc network mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ configure them as something other than the defaults.
 | `ECS_INSTANCE_ATTRIBUTES` | `{"stack": "prod"}` | These attributes take effect only during initial registration. After the agent has joined an ECS cluster, use the PutAttributes API action to add additional attributes. For more information, see [Amazon ECS Container Agent Configuration](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-config.html) in the Amazon ECS Developer Guide.| `{}` | `{}` |
 | `ECS_ENABLE_TASK_ENI` | `false` | Whether to enable task networking for task to be launched with its own network interface | `false` | `false` |
 | `ECS_CNI_PLUGINS_PATH` | `/ecs/cni` | The path where the cni binary file is located | `/amazon-ecs-cni-plugins` | `/amazon-ecs-cni-plugins` |
-| `ECS_AWSVPC_BLOCK_IMDS` | `true` | Whether to block access to Instance Metdata for Tasks started with `awsvpc` network mode | `false` | `false`|
+| `ECS_AWSVPC_BLOCK_IMDS` | `true` | Whether to block access to [Instance Metdata](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) for Tasks started with `awsvpc` network mode | `false` | `false`|
 
 ### Persistence
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ configure them as something other than the defaults.
 | `ECS_INSTANCE_ATTRIBUTES` | `{"stack": "prod"}` | These attributes take effect only during initial registration. After the agent has joined an ECS cluster, use the PutAttributes API action to add additional attributes. For more information, see [Amazon ECS Container Agent Configuration](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-config.html) in the Amazon ECS Developer Guide.| `{}` | `{}` |
 | `ECS_ENABLE_TASK_ENI` | `false` | Whether to enable task networking for task to be launched with its own network interface | `false` | `false` |
 | `ECS_CNI_PLUGINS_PATH` | `/ecs/cni` | The path where the cni binary file is located | `/amazon-ecs-cni-plugins` | `/amazon-ecs-cni-plugins` |
+| `ECS_AWSVPC_BLOCK_IMDS` | `true` | Whether to block access to Instance Metdata for Tasks started with `awsvpc` network mode | `false` | `false`|
 
 ### Persistence
 

--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -23,12 +23,13 @@ import (
 )
 
 const (
-	capabilityPrefix             = "com.amazonaws.ecs.capability."
-	capabilityTaskIAMRole        = "task-iam-role"
-	capabilityTaskIAMRoleNetHost = "task-iam-role-network-host"
-	attributePrefix              = "ecs.capability."
-	taskENIAttributeSuffix       = "task-eni"
-	cniPluginVersionSuffix       = "cni-plugin-version"
+	capabilityPrefix                            = "com.amazonaws.ecs.capability."
+	capabilityTaskIAMRole                       = "task-iam-role"
+	capabilityTaskIAMRoleNetHost                = "task-iam-role-network-host"
+	attributePrefix                             = "ecs.capability."
+	taskENIAttributeSuffix                      = "task-eni"
+	taskENIBlockInstanceMetadataAttributeSuffix = "task-eni-block-instance-metadata"
+	cniPluginVersionSuffix                      = "cni-plugin-version"
 )
 
 // capabilities returns the supported capabilities of this agent / docker-client pair.
@@ -49,7 +50,8 @@ const (
 //    com.amazonaws.ecs.capability.ecr-auth
 //    com.amazonaws.ecs.capability.task-iam-role
 //    com.amazonaws.ecs.capability.task-iam-role-network-host
-//    ecs.capability.task-eni.0.1.0
+//    ecs.capability.task-eni
+//    ecs.capability.task-eni-block-instance-metadata
 func (agent *ecsAgent) capabilities() []*ecs.Attribute {
 	var capabilities []*ecs.Attribute
 
@@ -122,6 +124,14 @@ func (agent *ecsAgent) capabilities() []*ecs.Attribute {
 			return capabilities
 		}
 		capabilities = append(capabilities, taskENIVersionAttribute)
+	}
+
+	if agent.cfg.AWSVPCBlockInstanceMetdata {
+		// If the Block Instance Metadata flag is set for AWS VPC networking mode, register a capability
+		// indicating the same
+		capabilities = append(capabilities, &ecs.Attribute{
+			Name: aws.String(attributePrefix + taskENIBlockInstanceMetadataAttributeSuffix),
+		})
 	}
 
 	return capabilities

--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -124,14 +124,15 @@ func (agent *ecsAgent) capabilities() []*ecs.Attribute {
 			return capabilities
 		}
 		capabilities = append(capabilities, taskENIVersionAttribute)
-	}
+		// We only care about AWSVPCBlockInstanceMetdata if Task ENI is enabled
+		if agent.cfg.AWSVPCBlockInstanceMetdata {
+			// If the Block Instance Metadata flag is set for AWS VPC networking mode, register a capability
+			// indicating the same
+			capabilities = append(capabilities, &ecs.Attribute{
+				Name: aws.String(attributePrefix + taskENIBlockInstanceMetadataAttributeSuffix),
+			})
+		}
 
-	if agent.cfg.AWSVPCBlockInstanceMetdata {
-		// If the Block Instance Metadata flag is set for AWS VPC networking mode, register a capability
-		// indicating the same
-		capabilities = append(capabilities, &ecs.Attribute{
-			Name: aws.String(attributePrefix + taskENIBlockInstanceMetadataAttributeSuffix),
-		})
 	}
 
 	return capabilities

--- a/agent/app/agent_capability_test.go
+++ b/agent/app/agent_capability_test.go
@@ -47,11 +47,12 @@ func TestCapabilities(t *testing.T) {
 			dockerclient.GelfDriver,
 			dockerclient.FluentdDriver,
 		},
-		PrivilegedDisabled:      false,
-		SELinuxCapable:          true,
-		AppArmorCapable:         true,
-		TaskENIEnabled:          true,
-		TaskCleanupWaitDuration: config.DefaultConfig().TaskCleanupWaitDuration,
+		PrivilegedDisabled:         false,
+		SELinuxCapable:             true,
+		AppArmorCapable:            true,
+		TaskENIEnabled:             true,
+		AWSVPCBlockInstanceMetdata: true,
+		TaskCleanupWaitDuration:    config.DefaultConfig().TaskCleanupWaitDuration,
 	}
 
 	gomock.InOrder(
@@ -85,10 +86,15 @@ func TestCapabilities(t *testing.T) {
 			&ecs.Attribute{Name: aws.String(name)})
 	}
 	expectedCapabilities = append(expectedCapabilities,
-		&ecs.Attribute{
-			Name:  aws.String(attributePrefix + cniPluginVersionSuffix),
-			Value: aws.String("v1"),
-		})
+		[]*ecs.Attribute{
+			{
+				Name:  aws.String(attributePrefix + cniPluginVersionSuffix),
+				Value: aws.String("v1"),
+			},
+			{
+				Name: aws.String(attributePrefix + taskENIBlockInstanceMetadataAttributeSuffix),
+			},
+		}...)
 
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -325,6 +325,7 @@ func environmentConfig() (Config, error) {
 	}
 
 	cniPluginsPath := os.Getenv("ECS_CNI_PLUGINS_PATH")
+	awsVPCBlockInstanceMetadata := utils.ParseBool(os.Getenv("ECS_AWSVPC_BLOCK_IMDS"), false)
 
 	instanceAttributesEnv := os.Getenv("ECS_INSTANCE_ATTRIBUTES")
 	attributeDecoder := json.NewDecoder(strings.NewReader(instanceAttributesEnv))
@@ -377,6 +378,7 @@ func environmentConfig() (Config, error) {
 		NumImagesToDeletePerCycle:        numImagesToDeletePerCycle,
 		InstanceAttributes:               instanceAttributes,
 		CNIPluginsPath:                   cniPluginsPath,
+		AWSVPCBlockInstanceMetdata:       awsVPCBlockInstanceMetadata,
 	}, err
 }
 

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -380,3 +380,11 @@ func TestImageCleanupMinimumNumImagesToDeletePerCycle(t *testing.T) {
 		t.Errorf("Wrong value for NumImagesToDeletePerCycle: %v", cfg.NumImagesToDeletePerCycle)
 	}
 }
+
+func TestAWSVPCBlockInstanceMetadata(t *testing.T) {
+	os.Setenv("ECS_AWSVPC_BLOCK_IMDS", "true")
+	defer os.Unsetenv("ECS_AWSVPC_BLOCK_IMDS")
+	cfg, err := NewConfig(ec2.NewBlackholeEC2MetadataClient())
+	assert.NoError(t, err)
+	assert.True(t, cfg.AWSVPCBlockInstanceMetdata)
+}

--- a/agent/config/config_unix.go
+++ b/agent/config/config_unix.go
@@ -47,6 +47,7 @@ func DefaultConfig() Config {
 		PauseContainerTarballPath:   pauseContainerTarballPath,
 		PauseContainerImageName:     DefaultPauseContainerImageName,
 		PauseContainerTag:           DefaultPauseContainerTag,
+		AWSVPCBlockInstanceMetdata:  false,
 	}
 }
 

--- a/agent/config/config_unix_test.go
+++ b/agent/config/config_unix_test.go
@@ -45,6 +45,7 @@ func TestConfigDefault(t *testing.T) {
 	os.Unsetenv("ECS_IMAGE_CLEANUP_INTERVAL")
 	os.Unsetenv("ECS_ENABLE_TASK_ENI")
 	os.Unsetenv("ECS_CNI_PLUGINS_PATH")
+	os.Unsetenv("ECS_AWSVPC_BLOCK_IMDS")
 
 	cfg, err := NewConfig(ec2.NewBlackholeEC2MetadataClient())
 	assert.Nil(t, err)
@@ -68,6 +69,7 @@ func TestConfigDefault(t *testing.T) {
 	assert.Equal(t, DefaultImageCleanupTimeInterval, cfg.ImageCleanupInterval, "ImageCleanupInterval default is set incorrectly")
 	assert.Equal(t, DefaultNumImagesToDeletePerCycle, cfg.NumImagesToDeletePerCycle, "NumImagesToDeletePerCycle default is set incorrectly")
 	assert.Equal(t, defaultCNIPluginsPath, cfg.CNIPluginsPath, "CNIPluginsPath default is set incorrectly")
+	assert.False(t, cfg.AWSVPCBlockInstanceMetdata, "AWSVPCBlockInstanceMetdata default is incorrectly set")
 }
 
 // TestConfigFromFile tests the configuration can be read from file

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -163,6 +163,10 @@ type Config struct {
 	// Setting this value to be different from the default will disable loading
 	// the image from the tarball; the referenced image must already be loaded.
 	PauseContainerTag string
+
+	// AWSVPCBlockInstanceMetdata specifies if InstanceMetadata endpoint should be blocked
+	// for tasks that are launched with network mode "awsvpc" when ECS_AWSVPC_BLOCK_IMDS=true
+	AWSVPCBlockInstanceMetdata bool
 }
 
 // SensitiveRawMessage is a struct to store some data that should not be logged

--- a/agent/ecscni/plugin.go
+++ b/agent/ecscni/plugin.go
@@ -136,12 +136,13 @@ func (client *cniClient) constructNetworkConfig(cfg *Config) (*libcni.NetworkCon
 	}
 
 	eniConf := ENIConfig{
-		Type:        ECSENIPluginName,
-		CNIVersion:  client.cniVersion,
-		ENIID:       cfg.ENIID,
-		IPV4Address: cfg.ENIIPV4Address,
-		MACAddress:  cfg.ENIMACAddress,
-		IPV6Address: cfg.ENIIPV6Address,
+		Type:                 ECSENIPluginName,
+		CNIVersion:           client.cniVersion,
+		ENIID:                cfg.ENIID,
+		IPV4Address:          cfg.ENIIPV4Address,
+		MACAddress:           cfg.ENIMACAddress,
+		IPV6Address:          cfg.ENIIPV6Address,
+		BlockInstanceMetdata: cfg.BlockInstanceMetdata,
 	}
 
 	bridgeConfBytes, err := json.Marshal(bridgeConf)

--- a/agent/ecscni/plugin_test.go
+++ b/agent/ecscni/plugin_test.go
@@ -50,13 +50,14 @@ func TestConstructNetworkConfig(t *testing.T) {
 	ecscniClient := NewClient(&Config{})
 
 	config := &Config{
-		ENIID:          "eni-12345678",
-		ContainerID:    "containerid12",
-		ContainerPID:   "pid",
-		ENIIPV4Address: "172.31.21.40",
-		ENIIPV6Address: "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
-		ENIMACAddress:  "02:7b:64:49:b1:40",
-		BridgeName:     "bridge-test1",
+		ENIID:                "eni-12345678",
+		ContainerID:          "containerid12",
+		ContainerPID:         "pid",
+		ENIIPV4Address:       "172.31.21.40",
+		ENIIPV6Address:       "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+		ENIMACAddress:        "02:7b:64:49:b1:40",
+		BridgeName:           "bridge-test1",
+		BlockInstanceMetdata: true,
 	}
 
 	networkConfigList, err := ecscniClient.(*cniClient).constructNetworkConfig(config)
@@ -81,6 +82,7 @@ func TestConstructNetworkConfig(t *testing.T) {
 	assert.Equal(t, config.ENIIPV4Address, eniConfig.IPV4Address)
 	assert.Equal(t, config.ENIIPV6Address, eniConfig.IPV6Address)
 	assert.Equal(t, config.ENIMACAddress, eniConfig.MACAddress)
+	assert.True(t, eniConfig.BlockInstanceMetdata)
 }
 
 func TestCNIPluginVersion(t *testing.T) {

--- a/agent/ecscni/types.go
+++ b/agent/ecscni/types.go
@@ -107,6 +107,9 @@ type ENIConfig struct {
 	IPV6Address string `json:"ipv6-address, omitempty"`
 	// MacAddress is the mac address of eni
 	MACAddress string `json:"mac"`
+	// BlockInstanceMetdata specifies if InstanceMetadata endpoint should be
+	// blocked
+	BlockInstanceMetdata bool `json:"block-instance-metadata"`
 }
 
 // Config contains all the information to set up the container namespace using
@@ -134,4 +137,7 @@ type Config struct {
 	IPAMV4Address string
 	// ID is the information associate with ip in ipam
 	ID string
+	// BlockInstanceMetdata specifies if InstanceMetadata endpoint should be
+	// blocked
+	BlockInstanceMetdata bool
 }

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -712,6 +712,7 @@ func (engine *DockerTaskEngine) buildCNIConfigFromTaskContainer(task *api.Task, 
 
 	cfg.ContainerPID = strconv.Itoa(containerInspectOutput.State.Pid)
 	cfg.ContainerID = containerInspectOutput.ID
+	cfg.BlockInstanceMetdata = engine.cfg.AWSVPCBlockInstanceMetdata
 
 	return cfg, nil
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Add AWSVPCBlockInstanceMetdata config (`ECS_AWSVPC_BLOCK_IMDS`) for blocking access to instance metdata for awsvpc tasks

### Implementation details
<!-- How are the changes implemented? -->
* 5e8001c agent/app: register task-eni-block-instance-metadata capability when AWSVPCBlockInstanceMetdata config is enabled
* 63734d3 agent/ecscni,agent/engine: wire in AWSVPCBlockInstanceMetdata config to CNI config
* 5f0e4ed agent/config: add AWSVPCBlockInstanceMetdata config for blocking access to instance metdata for awsvpc tasks

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: Yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
None

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: Yes
