### PR TITLE
stats: remove unused conditional

### DIFF
--- a/agent/stats/engine.go
+++ b/agent/stats/engine.go
@@ -292,11 +292,6 @@ func (engine *DockerStatsEngine) addContainer(dockerID string) {
 		return
 	}
 
-	if err != nil {
-		seelog.Debugf("Could not get name for container, ignoring, err: %v, id: %s", err, dockerID)
-		return
-	}
-
 	// Check if this container is already being watched.
 	_, taskExists := engine.tasksToContainers[task.Arn]
 	if taskExists {


### PR DESCRIPTION
### Summary
This conditional was used prior to a8d27bcd1a992f099cb339f032e3b5768a3bf46c, but looks like it was never actually removed afterward.

### Implementation details
Removed some lines

### Testing
- [x] Builds on Linux (`make release`)
- [ ] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: no

### Description for the changelog
None

### Licensing
This contribution is under the terms of the Apache 2.0 License: yes
