### PR TITLE
Do not explicitly set host IP to 0.0.0.0 for Linux, defer to Docker

### DIFF
--- a/agent/api/task.go
+++ b/agent/api/task.go
@@ -616,9 +616,9 @@ func (task *Task) dockerPortMap(container *Container) map[docker.Port][]docker.P
 		dockerPort := docker.Port(strconv.Itoa(int(portBinding.ContainerPort)) + "/" + portBinding.Protocol.String())
 		currentMappings, existing := dockerPortMap[dockerPort]
 		if existing {
-			dockerPortMap[dockerPort] = append(currentMappings, docker.PortBinding{HostIP: portBindingHostIP, HostPort: strconv.Itoa(int(portBinding.HostPort))})
+			dockerPortMap[dockerPort] = append(currentMappings, docker.PortBinding{HostPort: strconv.Itoa(int(portBinding.HostPort))})
 		} else {
-			dockerPortMap[dockerPort] = []docker.PortBinding{{HostIP: portBindingHostIP, HostPort: strconv.Itoa(int(portBinding.HostPort))}}
+			dockerPortMap[dockerPort] = []docker.PortBinding{{HostPort: strconv.Itoa(int(portBinding.HostPort))}}
 		}
 	}
 	return dockerPortMap

--- a/agent/api/task_test.go
+++ b/agent/api/task_test.go
@@ -158,13 +158,11 @@ func TestDockerHostConfigPortBinding(t *testing.T) {
 	assert.True(t, ok, "Could not get port bindings")
 	assert.Equal(t, 1, len(bindings), "Wrong number of bindings")
 	assert.Equal(t, "10", bindings[0].HostPort, "Wrong hostport")
-	assert.Equal(t, portBindingHostIP, bindings[0].HostIP, "Wrong hostIP")
 
 	bindings, ok = config.PortBindings["20/udp"]
 	assert.True(t, ok, "Could not get port bindings")
 	assert.Equal(t, 1, len(bindings), "Wrong number of bindings")
 	assert.Equal(t, "20", bindings[0].HostPort, "Wrong hostport")
-	assert.Equal(t, portBindingHostIP, bindings[0].HostIP, "Wrong hostIP")
 }
 
 func TestDockerHostConfigVolumesFrom(t *testing.T) {

--- a/agent/api/task_unix.go
+++ b/agent/api/task_unix.go
@@ -20,8 +20,6 @@ import (
 )
 
 const (
-	portBindingHostIP = "0.0.0.0"
-
 	//memorySwappinessDefault is the expected default value for this platform. This is used in task_windows.go
 	//and is maintained here for unix default. Also used for testing
 	memorySwappinessDefault = 0

--- a/agent/api/task_windows.go
+++ b/agent/api/task_windows.go
@@ -23,8 +23,6 @@ import (
 )
 
 const (
-	portBindingHostIP = ""
-
 	//memorySwappinessDefault is the expected default value for this platform
 	memorySwappinessDefault = -1
 )


### PR DESCRIPTION
### Summary

By hardcoding the host IP as 0.0.0.0, the agent is removing the ability for customers to specify specific host IP addresses (such as when there are multiple network interfaces). By default, the docker daemon defaults to 0.0.0.0, but this value may be overridden by launching the daemon with a --ip flag. [Reference](https://docs.docker.com/engine/reference/commandline/dockerd/)

This also has an implication for the CloudWatch Events published by ECS. Specifically, prior to this change the 'bindIP' field in the ECS Task Status events always contains '0.0.0.0'. By explicitly setting this value, customers can control the value that appears in these events, removing the need to query the ECS and/or EC2 control plane to obtain this value.

This change will benefit the following customer use cases:
[Issues-426](https://github.com/aws/amazon-ecs-agent/issues/426)
[AWS ECS Forum Thread 173250](https://forums.aws.amazon.com/thread.jspa?threadID=173250)
[Serverfault.com Question 695393](https://serverfault.com/questions/695393/amazon-ecs-docker-binding-container-to-specific-ip-address)

### Implementation details
Remove HostIP field when calling to the Docker daemon to create a container.

### Testing
Tests have been updated to no longer assert the host IP. Testing was performed by launching tasks against my personal EC2 hosts with this forked version of the agent, both with the default IP binding and an explicitly specified host binding IP set in the /etc/docker/daemon.json file.  Also verified that published ECS Task State events contain the new bound IP.

I have verified that:
* make release, make test, make run-integ-tests, and make run-functional-tests runs cleanly on 2017.03.f
* make release, make test, make run-integ-tests, and make run-functional-tests runs cleanly on 2015.09.d.  The tests do not build on versions of the AMI prior to this because the Debian image used by the test lives in a 2+ repository that is incompatible with older docker versions.
* Manually launched a server on 2017.03.f and verified that it correctly maintains the default behavior of binding to 0.0.0.0
* Manually launched a server on 2015.03.c and verified that it correctly maintains the default behavior of binding to 0.0.0.0. The agent certificates container does not build on versions of the AMI prior to this because the Debian repository related problems.
* Manually launched a server on 2017.03.f and verified that it uses the Docker –ip flag if specified.

<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [X] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [X] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: N/A - Tests have been updated to reflect change.

### Description for the changelog
* Enhancement - Stop explicitly binding containers to 0.0.0.0 and defer to Docker daemon

### Licensing
This contribution is under the terms of the Apache 2.0 License: Yes
