### PR TITLE
Task cgroup config

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ configure them as something other than the defaults.
 | `ECS_ENABLE_TASK_ENI` | `false` | Whether to enable task networking for task to be launched with its own network interface | `false` | `false` |
 | `ECS_CNI_PLUGINS_PATH` | `/ecs/cni` | The path where the cni binary file is located | `/amazon-ecs-cni-plugins` | `/amazon-ecs-cni-plugins` |
 | `ECS_AWSVPC_BLOCK_IMDS` | `true` | Whether to block access to [Instance Metdata](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) for Tasks started with `awsvpc` network mode | `false` | `false`|
+| `ECS_ENABLE_TASK_CPU_MEM_LIMIT` | `true` | Whether to enable task-level cpu and memory limits | `true` | `false` |
 
 ### Persistence
 

--- a/agent/api/task_unix.go
+++ b/agent/api/task_unix.go
@@ -42,7 +42,7 @@ const (
 func (task *Task) adjustForPlatform(cfg *config.Config) {
 	task.memoryCPULimitsEnabledLock.Lock()
 	defer task.memoryCPULimitsEnabledLock.Unlock()
-	task.MemoryCPULimitsEnabled = cfg.TaskCPUMemLimit
+	task.MemoryCPULimitsEnabled = cfg.TaskCPUMemLimit.Enabled()
 }
 
 func getCanonicalPath(path string) string { return path }

--- a/agent/api/task_windows_test.go
+++ b/agent/api/task_windows_test.go
@@ -99,7 +99,7 @@ func TestPostUnmarshalWindowsCanonicalPaths(t *testing.T) {
 	seqNum := int64(42)
 	task, err := TaskFromACS(&taskFromAcs, &ecsacs.PayloadMessage{SeqNum: &seqNum})
 	assert.Nil(t, err, "Should be able to handle acs task")
-	cfg := config.Config{TaskCPUMemLimit: false}
+	cfg := config.Config{TaskCPUMemLimit: config.ExplicitlyDisabled}
 	task.PostUnmarshalTask(&cfg, nil)
 
 	assert.Equal(t, expectedTask.Containers, task.Containers, "Containers should be equal")

--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -195,7 +195,7 @@ func (agent *ecsAgent) doStart(containerChangeEventStream *eventstream.EventStre
 	// Conditionally create '/ecs' cgroup root
 	// TODO: Ensure that this feature is enabled only when
 	// the cgroup mountpoint is accessible to the agent
-	if agent.cfg.TaskCPUMemLimit {
+	if agent.cfg.TaskCPUMemLimit.Enabled() {
 		err = agent.resource.Init()
 		// When task CPU and memory limits are enabled, all tasks are placed
 		// under the '/ecs' cgroup root.
@@ -401,7 +401,12 @@ func (agent *ecsAgent) registerContainerInstance(
 	if preflightCreds, err := agent.credentialProvider.Get(); err != nil || preflightCreds.AccessKeyID == "" {
 		seelog.Warnf("Error getting valid credentials (AKID %s): %v", preflightCreds.AccessKeyID, err)
 	}
-	capabilities := append(agent.capabilities(), additionalAttributes...)
+
+	agentCapabilities, err := agent.capabilities()
+	if err != nil {
+		return err
+	}
+	capabilities := append(agentCapabilities, additionalAttributes...)
 
 	if agent.containerInstanceARN != "" {
 		seelog.Infof("Restored from checkpoint file. I am running as '%s' in cluster '%s'", agent.containerInstanceARN, agent.cfg.Cluster)

--- a/agent/app/agent_test.go
+++ b/agent/app/agent_test.go
@@ -87,7 +87,7 @@ func TestDoStartNewTaskEngineError(t *testing.T) {
 			nil, errors.New("error")),
 	)
 
-	cfg := config.DefaultConfig()
+	cfg := getTestConfig()
 	cfg.Checkpoint = true
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines
@@ -132,7 +132,7 @@ func TestDoStartNewStateManagerError(t *testing.T) {
 			nil, errors.New("error")),
 	)
 
-	cfg := config.DefaultConfig()
+	cfg := getTestConfig()
 	cfg.Checkpoint = true
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines
@@ -166,7 +166,8 @@ func TestDoStartRegisterContainerInstanceErrorTerminal(t *testing.T) {
 			"", utils.NewAttributeError("error")),
 	)
 
-	cfg := config.DefaultConfig()
+	cfg := getTestConfig()
+	cfg.TaskCPUMemLimit = config.ExplicitlyDisabled
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines
 	defer cancel()
@@ -196,7 +197,7 @@ func TestDoStartRegisterContainerInstanceErrorNonTerminal(t *testing.T) {
 			"", errors.New("error")),
 	)
 
-	cfg := config.DefaultConfig()
+	cfg := getTestConfig()
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines
 	defer cancel()
@@ -218,7 +219,7 @@ func TestNewTaskEngineRestoreFromCheckpointNoEC2InstanceIDToLoadHappyPath(t *tes
 	defer ctrl.Finish()
 
 	ec2MetadataClient := mock_ec2.NewMockEC2MetadataClient(ctrl)
-	cfg := config.DefaultConfig()
+	cfg := getTestConfig()
 	cfg.Checkpoint = true
 	expectedInstanceID := "inst-1"
 	iid := ec2metadata.EC2InstanceIdentityDocument{
@@ -265,7 +266,7 @@ func TestNewTaskEngineRestoreFromCheckpointPreviousEC2InstanceIDLoadedHappyPath(
 	defer ctrl.Finish()
 
 	ec2MetadataClient := mock_ec2.NewMockEC2MetadataClient(ctrl)
-	cfg := config.DefaultConfig()
+	cfg := getTestConfig()
 	cfg.Checkpoint = true
 	expectedInstanceID := "inst-1"
 	iid := ec2metadata.EC2InstanceIdentityDocument{
@@ -319,7 +320,7 @@ func TestNewTaskEngineRestoreFromCheckpointClusterIDMismatch(t *testing.T) {
 	defer ctrl.Finish()
 
 	ec2MetadataClient := mock_ec2.NewMockEC2MetadataClient(ctrl)
-	cfg := config.DefaultConfig()
+	cfg := getTestConfig()
 	cfg.Checkpoint = true
 	cfg.Cluster = "default"
 	ec2InstanceID := "inst-1"
@@ -371,7 +372,7 @@ func TestNewTaskEngineRestoreFromCheckpointNewStateManagerError(t *testing.T) {
 		dockerClient, stateManagerFactory, saveableOptionFactory := setup(t)
 	defer ctrl.Finish()
 
-	cfg := config.DefaultConfig()
+	cfg := getTestConfig()
 	cfg.Checkpoint = true
 	gomock.InOrder(
 		saveableOptionFactory.EXPECT().AddSaveable("ContainerInstanceArn", gomock.Any()).Return(nil),
@@ -405,7 +406,7 @@ func TestNewTaskEngineRestoreFromCheckpointStateLoadError(t *testing.T) {
 	defer ctrl.Finish()
 
 	stateManager := mock_statemanager.NewMockStateManager(ctrl)
-	cfg := config.DefaultConfig()
+	cfg := getTestConfig()
 	cfg.Checkpoint = true
 	gomock.InOrder(
 		saveableOptionFactory.EXPECT().AddSaveable("ContainerInstanceArn", gomock.Any()).Return(nil),
@@ -440,7 +441,7 @@ func TestNewTaskEngineRestoreFromCheckpoint(t *testing.T) {
 	defer ctrl.Finish()
 
 	ec2MetadataClient := mock_ec2.NewMockEC2MetadataClient(ctrl)
-	cfg := config.DefaultConfig()
+	cfg := getTestConfig()
 	cfg.Checkpoint = true
 	expectedInstanceID := "inst-1"
 	iid := ec2metadata.EC2InstanceIdentityDocument{
@@ -479,7 +480,7 @@ func TestSetClusterInConfigMismatch(t *testing.T) {
 	clusterNamesInConfig := []string{"", "foo"}
 	for _, clusterNameInConfig := range clusterNamesInConfig {
 		t.Run(fmt.Sprintf("cluster in config is '%s'", clusterNameInConfig), func(t *testing.T) {
-			cfg := config.DefaultConfig()
+			cfg := getTestConfig()
 			cfg.Cluster = ""
 			agent := &ecsAgent{cfg: &cfg}
 			err := agent.setClusterInConfig("bar")
@@ -489,7 +490,7 @@ func TestSetClusterInConfigMismatch(t *testing.T) {
 }
 
 func TestSetClusterInConfig(t *testing.T) {
-	cfg := config.DefaultConfig()
+	cfg := getTestConfig()
 	cfg.Cluster = clusterName
 	agent := &ecsAgent{cfg: &cfg}
 	err := agent.setClusterInConfig(clusterName)
@@ -522,7 +523,7 @@ func TestReregisterContainerInstanceHappyPath(t *testing.T) {
 		mockDockerClient.EXPECT().KnownVersions().Return(nil),
 		client.EXPECT().RegisterContainerInstance(containerInstanceARN, gomock.Any()).Return(containerInstanceARN, nil),
 	)
-	cfg := config.DefaultConfig()
+	cfg := getTestConfig()
 	cfg.Cluster = clusterName
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines
@@ -556,7 +557,7 @@ func TestReregisterContainerInstanceInstanceTypeChanged(t *testing.T) {
 			"", awserr.New("", api.InstanceTypeChangedErrorMessage, errors.New(""))),
 	)
 
-	cfg := config.DefaultConfig()
+	cfg := getTestConfig()
 	cfg.Cluster = clusterName
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines
@@ -591,7 +592,7 @@ func TestReregisterContainerInstanceAttributeError(t *testing.T) {
 			"", utils.NewAttributeError("error")),
 	)
 
-	cfg := config.DefaultConfig()
+	cfg := getTestConfig()
 	cfg.Cluster = clusterName
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines
@@ -626,7 +627,7 @@ func TestReregisterContainerInstanceNonTerminalError(t *testing.T) {
 			"", errors.New("error")),
 	)
 
-	cfg := config.DefaultConfig()
+	cfg := getTestConfig()
 	cfg.Cluster = clusterName
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines
@@ -661,7 +662,7 @@ func TestRegisterContainerInstanceWhenContainerInstanceARNIsNotSetHappyPath(t *t
 		stateManager.EXPECT().Save(),
 	)
 
-	cfg := config.DefaultConfig()
+	cfg := getTestConfig()
 	cfg.Cluster = clusterName
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines
@@ -695,7 +696,7 @@ func TestRegisterContainerInstanceWhenContainerInstanceARNIsNotSetCanRetryError(
 		client.EXPECT().RegisterContainerInstance("", gomock.Any()).Return("", retriableError),
 	)
 
-	cfg := config.DefaultConfig()
+	cfg := getTestConfig()
 	cfg.Cluster = clusterName
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines
@@ -729,7 +730,7 @@ func TestRegisterContainerInstanceWhenContainerInstanceARNIsNotSetCannotRetryErr
 		client.EXPECT().RegisterContainerInstance("", gomock.Any()).Return("", cannotRetryError),
 	)
 
-	cfg := config.DefaultConfig()
+	cfg := getTestConfig()
 	cfg.Cluster = clusterName
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines
@@ -763,7 +764,7 @@ func TestRegisterContainerInstanceWhenContainerInstanceARNIsNotSetAttributeError
 			"", utils.NewAttributeError("error")),
 	)
 
-	cfg := config.DefaultConfig()
+	cfg := getTestConfig()
 	cfg.Cluster = clusterName
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines
@@ -778,4 +779,10 @@ func TestRegisterContainerInstanceWhenContainerInstanceARNIsNotSetAttributeError
 	err := agent.registerContainerInstance(stateManager, client, nil)
 	assert.Error(t, err)
 	assert.False(t, isTranisent(err))
+}
+
+func getTestConfig() config.Config {
+	cfg := config.DefaultConfig()
+	cfg.TaskCPUMemLimit = config.ExplicitlyDisabled
+	return cfg
 }

--- a/agent/app/agent_unix_test.go
+++ b/agent/app/agent_unix_test.go
@@ -91,7 +91,7 @@ func TestDoStartHappyPath(t *testing.T) {
 		state.EXPECT().AllTasks().Return(nil),
 	)
 
-	cfg := config.DefaultConfig()
+	cfg := getTestConfig()
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines
 	defer cancel()
@@ -184,7 +184,7 @@ func TestDoStartTaskENIHappyPath(t *testing.T) {
 		state.EXPECT().AllTasks().Return(nil),
 	)
 
-	cfg := config.DefaultConfig()
+	cfg := getTestConfig()
 	cfg.TaskENIEnabled = true
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines
@@ -428,7 +428,7 @@ func TestInitializeTaskENIDependenciesPauseLoaderError(t *testing.T) {
 				cniClient.EXPECT().Capabilities(ecscni.ECSIPAMPluginName).Return(cniCapabilities, nil),
 				mockPauseLoader.EXPECT().LoadImage(gomock.Any(), gomock.Any()).Return(nil, loadErr),
 			)
-			cfg := config.DefaultConfig()
+			cfg := getTestConfig()
 			agent := &ecsAgent{
 				os:                mockOS,
 				ec2MetadataClient: mockMetadata,
@@ -452,7 +452,6 @@ func TestDoStartCgroupInitHappyPath(t *testing.T) {
 	ctrl, credentialsManager, state, imageManager, client,
 		dockerClient, _, _ := setup(t)
 	defer ctrl.Finish()
-
 	mockCredentialsProvider := app_mocks.NewMockProvider(ctrl)
 	mockResource := mock_resources.NewMockResource(ctrl)
 	var discoverEndpointsInvoked sync.WaitGroup
@@ -489,8 +488,6 @@ func TestDoStartCgroupInitHappyPath(t *testing.T) {
 	)
 
 	cfg := config.DefaultConfig()
-	cfg.TaskCPUMemLimit = true
-
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines
 	defer cancel()
@@ -508,6 +505,7 @@ func TestDoStartCgroupInitHappyPath(t *testing.T) {
 	// Wait for both DiscoverPollEndpointInput and DiscoverTelemetryEndpoint to be
 	// invoked. These are used as proxies to indicate that acs and tcs handlers'
 	// NewSession call has been invoked
+
 	discoverEndpointsInvoked.Wait()
 }
 
@@ -527,8 +525,8 @@ func TestDoStartCgroupInitErrorPath(t *testing.T) {
 
 	mockResource.EXPECT().Init().Return(errors.New("cgroup init error"))
 
-	cfg := config.DefaultConfig()
-	cfg.TaskCPUMemLimit = true
+	cfg := getTestConfig()
+	cfg.TaskCPUMemLimit = config.ExplicitlyEnabled
 
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines

--- a/agent/app/agent_windows_test.go
+++ b/agent/app/agent_windows_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	app_mocks "github.com/aws/amazon-ecs-agent/agent/app/mocks"
-	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/engine"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -63,7 +62,7 @@ func TestDoStartHappyPath(t *testing.T) {
 		state.EXPECT().AllTasks().Return(nil),
 	)
 
-	cfg := config.DefaultConfig()
+	cfg := getTestConfig()
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines
 	defer cancel()

--- a/agent/config/conditional.go
+++ b/agent/config/conditional.go
@@ -1,0 +1,64 @@
+// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+package config
+
+import (
+	"encoding/json"
+	"strconv"
+)
+
+// Conditional makes it possible to understand if a variable was set explicitly or relies on a default setting
+type Conditional int
+
+const (
+	_ Conditional = iota
+	ExplicitlyEnabled
+	ExplicitlyDisabled
+	DefaultEnabled
+)
+
+// Enabled is a convenience function for when consumers don't care if the value is implicit or explicit
+func (b Conditional) Enabled() bool {
+	return b == ExplicitlyEnabled || b == DefaultEnabled
+}
+
+// MarshalJSON is used to serialize the type to json, per the Marshaller interface
+func (b Conditional) MarshalJSON() ([]byte, error) {
+	switch b {
+	case ExplicitlyEnabled:
+		return json.Marshal(true)
+	case ExplicitlyDisabled:
+		return json.Marshal(false)
+	default:
+		return json.Marshal(nil)
+	}
+}
+
+// UnmarshalJSON is used to deserialize json types into Conditional, per the Unmarshaller interface
+func (b *Conditional) UnmarshalJSON(jsonData []byte) error {
+	jsonString := string(jsonData)
+	jsonBool, err := strconv.ParseBool(jsonString)
+	if err != nil && jsonString != "null" {
+		return err
+	}
+
+	if jsonString == "" || jsonString == "null" {
+		*b = DefaultEnabled
+	} else if jsonBool {
+		*b = ExplicitlyEnabled
+	} else {
+		*b = ExplicitlyDisabled
+	}
+
+	return nil
+}

--- a/agent/config/conditional_test.go
+++ b/agent/config/conditional_test.go
@@ -1,0 +1,67 @@
+// Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package config
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConditional(t *testing.T) {
+	x := DefaultEnabled
+	y := ExplicitlyEnabled
+	z := ExplicitlyDisabled
+
+	assert.True(t, x.Enabled(), "DefaultEnabled is enabled")
+	assert.True(t, y.Enabled(), "ExplicitlyEnabled is enabled")
+	assert.False(t, z.Enabled(), "ExplicitlyDisabled is not enabled")
+}
+
+func TestConditionalImplements(t *testing.T) {
+	assert.Implements(t, (*json.Marshaler)(nil), (Conditional)(1))
+	assert.Implements(t, (*json.Unmarshaler)(nil), (*Conditional)(nil))
+}
+
+// main conversion cases for Conditional marshalling
+var cases = []struct {
+	defaultBool Conditional
+	bytes       []byte
+}{
+	{ExplicitlyEnabled, []byte("true")},
+	{ExplicitlyDisabled, []byte("false")},
+	{DefaultEnabled, []byte("null")},
+}
+
+func TestConditionalMarshal(t *testing.T) {
+	for _, tc := range cases {
+		t.Run(string(tc.bytes), func(t *testing.T) {
+			m, err := json.Marshal(tc.defaultBool)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.bytes, m)
+		})
+	}
+}
+
+func TestConditionalUnmarshal(t *testing.T) {
+	for _, tc := range cases {
+		t.Run(string(tc.bytes), func(t *testing.T) {
+			var target Conditional
+			err := json.Unmarshal(tc.bytes, &target)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.defaultBool, target)
+		})
+	}
+}

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -311,7 +311,19 @@ func environmentConfig() (Config, error) {
 	taskENIEnabled := utils.ParseBool(os.Getenv("ECS_ENABLE_TASK_ENI"), false)
 	taskIAMRoleEnabled := utils.ParseBool(os.Getenv("ECS_ENABLE_TASK_IAM_ROLE"), false)
 	taskIAMRoleEnabledForNetworkHost := utils.ParseBool(os.Getenv("ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST"), false)
-	taskCPUMemLimitEnabled := utils.ParseBool(os.Getenv("ECS_ENABLE_TASK_CPU_MEM_LIMIT"), true)
+
+	var taskCPUMemLimitEnabled Conditional
+	taskCPUMemLimitConfigString := os.Getenv("ECS_ENABLE_TASK_CPU_MEM_LIMIT")
+
+	// We only want to set taskCPUMemLimit if it is explicitly set to true or false.
+	// We can do this by checking against the ParseBool default
+	if taskCPUMemLimitConfigString != "" {
+		if utils.ParseBool(taskCPUMemLimitConfigString, false) {
+			taskCPUMemLimitEnabled = ExplicitlyEnabled
+		} else {
+			taskCPUMemLimitEnabled = ExplicitlyDisabled
+		}
+	}
 
 	credentialsAuditLogFile := os.Getenv("ECS_AUDIT_LOGFILE")
 	credentialsAuditLogDisabled := utils.ParseBool(os.Getenv("ECS_AUDIT_LOGFILE_DISABLED"), false)

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -101,9 +101,8 @@ func TestEnvironmentConfig(t *testing.T) {
 	assert.True(t, conf.TaskIAMRoleEnabled, "Wrong value for TaskIAMRoleEnabled")
 	assert.True(t, conf.TaskIAMRoleEnabledForNetworkHost, "Wrong value for TaskIAMRoleEnabledForNetworkHost")
 	assert.True(t, conf.ImageCleanupDisabled, "Wrong value for ImageCleanupDisabled")
-	assert.True(t, conf.TaskCPUMemLimit, "Wrong value for TaskCPUMemLimit")
-	assert.True(t, conf.TaskENIEnabled, "Wrong value for TaskNetwork")
 
+	assert.True(t, conf.TaskENIEnabled, "Wrong value for TaskNetwork")
 	assert.Equal(t, (30 * time.Minute), conf.MinimumImageDeletionAge)
 	assert.Equal(t, (2 * time.Hour), conf.ImageCleanupInterval)
 	assert.Equal(t, 2, conf.NumImagesToDeletePerCycle)
@@ -305,7 +304,8 @@ func TestTaskResourceLimitsOverride(t *testing.T) {
 	defer setTestEnv("ECS_ENABLE_TASK_CPU_MEM_LIMIT", "false")()
 	cfg, err := NewConfig(ec2.NewBlackholeEC2MetadataClient())
 	assert.NoError(t, err)
-	assert.False(t, cfg.TaskCPUMemLimit, "Task resource limits should be overridden to false")
+	assert.False(t, cfg.TaskCPUMemLimit.Enabled(), "Task cpu and memory limits should be overridden to false")
+	assert.Equal(t, ExplicitlyDisabled, cfg.TaskCPUMemLimit, "Task cpu and memory limits should be explicitly set")
 }
 
 func TestAWSVPCBlockInstanceMetadata(t *testing.T) {

--- a/agent/config/config_unix.go
+++ b/agent/config/config_unix.go
@@ -50,6 +50,7 @@ func DefaultConfig() Config {
 		PauseContainerImageName:     DefaultPauseContainerImageName,
 		PauseContainerTag:           DefaultPauseContainerTag,
 		AWSVPCBlockInstanceMetdata:  false,
+		TaskCPUMemLimit:             DefaultEnabled,
 	}
 }
 

--- a/agent/config/config_unix_test.go
+++ b/agent/config/config_unix_test.go
@@ -45,6 +45,7 @@ func TestConfigDefault(t *testing.T) {
 	assert.False(t, cfg.TaskENIEnabled, "TaskENIEnabled set incorrectly")
 	assert.False(t, cfg.TaskIAMRoleEnabled, "TaskIAMRoleEnabled set incorrectly")
 	assert.False(t, cfg.TaskIAMRoleEnabledForNetworkHost, "TaskIAMRoleEnabledForNetworkHost set incorrectly")
+	assert.Equal(t, DefaultEnabled, cfg.TaskCPUMemLimit, "TaskCPUMemLimit should be DefaultEnabled")
 	assert.False(t, cfg.CredentialsAuditLogDisabled, "CredentialsAuditLogDisabled set incorrectly")
 	assert.Equal(t, defaultCredentialsAuditLogFile, cfg.CredentialsAuditLogFile, "CredentialsAuditLogFile is set incorrectly")
 	assert.False(t, cfg.ImageCleanupDisabled, "ImageCleanupDisabled default is set incorrectly")
@@ -73,6 +74,7 @@ func TestConfigFromFile(t *testing.T) {
   "EngineAuthData": %s,
   "DataDir": "/var/run/ecs_agent",
   "TaskIAMRoleEnabled": true,
+  "TaskCPUMemLimit": true,
   "InstanceAttributes": {
     "attribute1": "value1"
   },
@@ -95,6 +97,7 @@ func TestConfigFromFile(t *testing.T) {
 	assert.Equal(t, map[string]string{"attribute1": "value1"}, cfg.InstanceAttributes)
 	assert.Equal(t, testPauseImageName, cfg.PauseContainerImageName, "should read PauseContainerImageName")
 	assert.Equal(t, testPauseTag, cfg.PauseContainerTag, "should read PauseContainerTag")
+	assert.Equal(t, ExplicitlyEnabled, cfg.TaskCPUMemLimit, "TaskCPUMemLimit should be explicitly enabled")
 }
 
 // TestDockerAuthMergeFromFile tests docker auth read from file correctly after merge

--- a/agent/config/config_windows.go
+++ b/agent/config/config_windows.go
@@ -72,7 +72,7 @@ func DefaultConfig() Config {
 		MinimumImageDeletionAge:     DefaultImageDeletionAge,
 		ImageCleanupInterval:        DefaultImageCleanupTimeInterval,
 		NumImagesToDeletePerCycle:   DefaultNumImagesToDeletePerCycle,
-		TaskCPUMemLimit:             false,
+		TaskCPUMemLimit:             ExplicitlyDisabled,
 	}
 }
 
@@ -87,7 +87,7 @@ func (cfg *Config) platformOverrides() {
 	}
 
 	// ensure TaskResourceLimit is disabled
-	cfg.TaskCPUMemLimit = false
+	cfg.TaskCPUMemLimit = ExplicitlyDisabled
 }
 
 // platformString returns platform-specific config data that can be serialized

--- a/agent/config/config_windows_test.go
+++ b/agent/config/config_windows_test.go
@@ -47,6 +47,7 @@ func TestConfigDefault(t *testing.T) {
 	assert.Equal(t, DefaultImageDeletionAge, cfg.MinimumImageDeletionAge, "MinimumImageDeletionAge default is set incorrectly")
 	assert.Equal(t, DefaultImageCleanupTimeInterval, cfg.ImageCleanupInterval, "ImageCleanupInterval default is set incorrectly")
 	assert.Equal(t, DefaultNumImagesToDeletePerCycle, cfg.NumImagesToDeletePerCycle, "NumImagesToDeletePerCycle default is set incorrectly")
+	assert.False(t, cfg.TaskCPUMemLimit.Enabled())
 }
 
 func TestConfigIAMTaskRolesReserves80(t *testing.T) {
@@ -80,5 +81,5 @@ func TestTaskResourceLimitPlatformOverrideDisabled(t *testing.T) {
 	cfg, err := NewConfig(ec2.NewBlackholeEC2MetadataClient())
 	cfg.platformOverrides()
 	assert.NoError(t, err)
-	assert.False(t, cfg.TaskCPUMemLimit)
+	assert.False(t, cfg.TaskCPUMemLimit.Enabled())
 }

--- a/agent/config/sensitive.go
+++ b/agent/config/sensitive.go
@@ -1,0 +1,57 @@
+// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package config
+
+import (
+	"encoding/json"
+)
+
+// SensitiveRawMessage is a struct to store some data that should not be logged
+// or printed.
+// This struct is a Stringer which will not print its contents with 'String'.
+// It is a json.Marshaler and json.Unmarshaler and will present its actual
+// contents in plaintext when read/written from/to json.
+type SensitiveRawMessage struct {
+	contents json.RawMessage
+}
+
+// NewSensitiveRawMessage returns a new encapsulated json.RawMessage or nil if
+// the data is empty. It cannot be accidentally logged via .String/.GoString/%v/%#v
+func NewSensitiveRawMessage(data json.RawMessage) *SensitiveRawMessage {
+	if len(data) == 0 {
+		return nil
+	}
+	return &SensitiveRawMessage{contents: data}
+}
+
+func (data SensitiveRawMessage) String() string {
+	return "[redacted]"
+}
+
+func (data SensitiveRawMessage) GoString() string {
+	return "[redacted]"
+}
+
+func (data SensitiveRawMessage) Contents() json.RawMessage {
+	return data.contents
+}
+
+func (data SensitiveRawMessage) MarshalJSON() ([]byte, error) {
+	return data.contents, nil
+}
+
+func (data *SensitiveRawMessage) UnmarshalJSON(jsonData []byte) error {
+	data.contents = json.RawMessage(jsonData)
+	return nil
+}

--- a/agent/config/sensitive_test.go
+++ b/agent/config/sensitive_test.go
@@ -22,10 +22,10 @@ import (
 )
 
 func TestSensitiveRawMessageImplements(t *testing.T) {
-	var _ fmt.Stringer = SensitiveRawMessage{}
-	var _ fmt.GoStringer = SensitiveRawMessage{}
-	var _ json.Marshaler = SensitiveRawMessage{}
-	var _ json.Unmarshaler = &SensitiveRawMessage{}
+	assert.Implements(t, (*fmt.Stringer)(nil), SensitiveRawMessage{})
+	assert.Implements(t, (*fmt.GoStringer)(nil), SensitiveRawMessage{})
+	assert.Implements(t, (*json.Marshaler)(nil), SensitiveRawMessage{})
+	assert.Implements(t, (*json.Unmarshaler)(nil), &SensitiveRawMessage{})
 }
 
 func TestSensitiveRawMessage(t *testing.T) {

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -14,7 +14,6 @@
 package config
 
 import (
-	"encoding/json"
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerclient"
@@ -110,7 +109,7 @@ type Config struct {
 	TaskIAMRoleEnabled bool
 
 	// TaskCPUMemLimit specifies if Agent can launch a task with a hierarchical cgroup
-	TaskCPUMemLimit bool
+	TaskCPUMemLimit Conditional
 
 	// CredentialsAuditLogFile specifies the path/filename of the audit log.
 	CredentialsAuditLogFile string
@@ -170,43 +169,4 @@ type Config struct {
 	// AWSVPCBlockInstanceMetdata specifies if InstanceMetadata endpoint should be blocked
 	// for tasks that are launched with network mode "awsvpc" when ECS_AWSVPC_BLOCK_IMDS=true
 	AWSVPCBlockInstanceMetdata bool
-}
-
-// SensitiveRawMessage is a struct to store some data that should not be logged
-// or printed.
-// This struct is a Stringer which will not print its contents with 'String'.
-// It is a json.Marshaler and json.Unmarshaler and will present its actual
-// contents in plaintext when read/written from/to json.
-type SensitiveRawMessage struct {
-	contents json.RawMessage
-}
-
-// NewSensitiveRawMessage returns a new encapsulated json.RawMessage or nil if
-// the data is empty. It cannot be accidentally logged via .String/.GoString/%v/%#v
-func NewSensitiveRawMessage(data json.RawMessage) *SensitiveRawMessage {
-	if len(data) == 0 {
-		return nil
-	}
-	return &SensitiveRawMessage{contents: data}
-}
-
-func (data SensitiveRawMessage) String() string {
-	return "[redacted]"
-}
-
-func (data SensitiveRawMessage) GoString() string {
-	return "[redacted]"
-}
-
-func (data SensitiveRawMessage) Contents() json.RawMessage {
-	return data.contents
-}
-
-func (data SensitiveRawMessage) MarshalJSON() ([]byte, error) {
-	return data.contents, nil
-}
-
-func (data *SensitiveRawMessage) UnmarshalJSON(jsonData []byte) error {
-	data.contents = json.RawMessage(jsonData)
-	return nil
 }

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -76,6 +76,7 @@ func createDockerEvent(status api.ContainerStatus) DockerContainerChangeEvent {
 }
 
 func TestBatchContainerHappyPath(t *testing.T) {
+	defaultConfig.TaskCPUMemLimit = config.ExplicitlyDisabled
 	ctrl, client, mockTime, taskEngine, credentialsManager, imageManager := mocks(t, &defaultConfig)
 	defer ctrl.Finish()
 
@@ -1238,7 +1239,6 @@ func TestPauseContaienrHappyPath(t *testing.T) {
 
 	cniClient := mock_ecscni.NewMockCNIClient(ctrl)
 	taskEngine.(*DockerTaskEngine).cniClient = cniClient
-
 	eventStream := make(chan DockerContainerChangeEvent)
 	sleepTask := testdata.LoadTask("sleep5")
 

--- a/agent/engine/engine_integ_test.go
+++ b/agent/engine/engine_integ_test.go
@@ -56,6 +56,7 @@ func createTestTask(arn string) *api.Task {
 
 func defaultTestConfigIntegTest() *config.Config {
 	cfg, _ := config.NewConfig(ec2.NewBlackholeEC2MetadataClient())
+	cfg.TaskCPUMemLimit = config.ExplicitlyDisabled
 	return cfg
 }
 

--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -134,7 +134,7 @@ func (mtask *managedTask) overseeTask() {
 			llog.Debug("Task not steady state or terminal; progressing it")
 
 			// TODO: Add new resource provisioned state ?
-			if mtask.engine.cfg.TaskCPUMemLimit {
+			if mtask.engine.cfg.TaskCPUMemLimit.Enabled() {
 				err := mtask.resource.Setup(mtask.Task)
 				if err != nil {
 					seelog.Criticalf("Unable to setup platform resources for task %s: %v", mtask.Task.Arn, err)
@@ -618,7 +618,7 @@ func (mtask *managedTask) cleanupTask(taskStoppedDuration time.Duration) {
 	go mtask.discardEventsUntil(handleCleanupDone)
 	mtask.engine.sweepTask(mtask.Task)
 
-	if mtask.engine.cfg.TaskCPUMemLimit {
+	if mtask.engine.cfg.TaskCPUMemLimit.Enabled() {
 		err := mtask.resource.Cleanup(mtask.Task)
 		if err != nil {
 			seelog.Warnf("Unable to cleanup platform resources for task %s: %v", mtask.Task.Arn, err)

--- a/agent/engine/task_manager_test.go
+++ b/agent/engine/task_manager_test.go
@@ -698,7 +698,7 @@ func TestCleanupTask(t *testing.T) {
 	mockImageManager := NewMockImageManager(ctrl)
 	defer ctrl.Finish()
 
-	cfg := config.DefaultConfig()
+	cfg := getTestConfig()
 	taskEngine := &DockerTaskEngine{
 		cfg:          &cfg,
 		saver:        statemanager.NewNoopStateManager(),
@@ -746,7 +746,7 @@ func TestCleanupTaskWaitsForStoppedSent(t *testing.T) {
 	mockImageManager := NewMockImageManager(ctrl)
 	defer ctrl.Finish()
 
-	cfg := config.DefaultConfig()
+	cfg := getTestConfig()
 	taskEngine := &DockerTaskEngine{
 		cfg:          &cfg,
 		saver:        statemanager.NewNoopStateManager(),
@@ -806,7 +806,7 @@ func TestCleanupTaskGivesUpIfWaitingTooLong(t *testing.T) {
 	mockImageManager := NewMockImageManager(ctrl)
 	defer ctrl.Finish()
 
-	cfg := config.DefaultConfig()
+	cfg := getTestConfig()
 	taskEngine := &DockerTaskEngine{
 		cfg:          &cfg,
 		saver:        statemanager.NewNoopStateManager(),
@@ -854,7 +854,7 @@ func TestCleanupTaskENIs(t *testing.T) {
 	mockImageManager := NewMockImageManager(ctrl)
 	defer ctrl.Finish()
 
-	cfg := config.DefaultConfig()
+	cfg := getTestConfig()
 	taskEngine := &DockerTaskEngine{
 		cfg:          &cfg,
 		saver:        statemanager.NewNoopStateManager(),
@@ -919,7 +919,7 @@ func TestCleanupTaskWithInvalidInterval(t *testing.T) {
 	mockImageManager := NewMockImageManager(ctrl)
 	defer ctrl.Finish()
 
-	cfg := config.DefaultConfig()
+	cfg := getTestConfig()
 	taskEngine := &DockerTaskEngine{
 		cfg:          &cfg,
 		saver:        statemanager.NewNoopStateManager(),
@@ -969,8 +969,8 @@ func TestCleanupTaskWithResourceHappyPath(t *testing.T) {
 	mockResource := mock_resources.NewMockResource(ctrl)
 	defer ctrl.Finish()
 
-	cfg := config.DefaultConfig()
-	cfg.TaskCPUMemLimit = true
+	cfg := getTestConfig()
+	cfg.TaskCPUMemLimit = config.ExplicitlyEnabled
 
 	taskEngine := &DockerTaskEngine{
 		cfg:          &cfg,
@@ -1022,8 +1022,8 @@ func TestCleanupTaskWithResourceErrorPath(t *testing.T) {
 	mockResource := mock_resources.NewMockResource(ctrl)
 	defer ctrl.Finish()
 
-	cfg := config.DefaultConfig()
-	cfg.TaskCPUMemLimit = true
+	cfg := getTestConfig()
+	cfg.TaskCPUMemLimit = config.ExplicitlyEnabled
 
 	taskEngine := &DockerTaskEngine{
 		cfg:          &cfg,
@@ -1064,4 +1064,10 @@ func TestCleanupTaskWithResourceErrorPath(t *testing.T) {
 	mockState.EXPECT().RemoveTask(mTask.Task)
 	mockResource.EXPECT().Cleanup(gomock.Any()).Return(errors.New("resource cleanup error"))
 	mTask.cleanupTask(taskStoppedDuration)
+}
+
+func getTestConfig() config.Config {
+	cfg := config.DefaultConfig()
+	cfg.TaskCPUMemLimit = config.ExplicitlyDisabled
+	return cfg
 }


### PR DESCRIPTION
### Summary
<!-- What does this pull request do? -->
Agent will now fail when TaskCPUMemLimit is explicitly enabled.

### Implementation details
<!-- How are the changes implemented? -->
Agent is now aware of if the value was set by user or as a default. See change to config/types.go.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: yes
