### PR TITLE
Pull retries and configurable routes for `awsvpc` network mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## UNRELEASED
 * Feature - Support for provisioning Tasks with ENIs
+* Enhancement - Retry failed container image pull operations.
 * Bug - Fixed a memory leak issue when submitting the task state change [#967](https://github.com/aws/amazon-ecs-agent/pull/967)
 
 ## 1.14.4

--- a/README.md
+++ b/README.md
@@ -175,9 +175,10 @@ configure them as something other than the defaults.
 | `ECS_IMAGE_MINIMUM_CLEANUP_AGE` | 30m | The minimum time interval between when an image is pulled and when it can be considered for automated image cleanup. | 1h | 1h |
 | `ECS_NUM_IMAGES_DELETE_PER_CYCLE` | 5 | The maximum number of images to delete in a single automated image cleanup cycle. If set to less than 1, the value is ignored. | 5 | 5 |
 | `ECS_INSTANCE_ATTRIBUTES` | `{"stack": "prod"}` | These attributes take effect only during initial registration. After the agent has joined an ECS cluster, use the PutAttributes API action to add additional attributes. For more information, see [Amazon ECS Container Agent Configuration](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-config.html) in the Amazon ECS Developer Guide.| `{}` | `{}` |
-| `ECS_ENABLE_TASK_ENI` | `false` | Whether to enable task networking for task to be launched with its own network interface | `false` | `false` |
-| `ECS_CNI_PLUGINS_PATH` | `/ecs/cni` | The path where the cni binary file is located | `/amazon-ecs-cni-plugins` | `/amazon-ecs-cni-plugins` |
-| `ECS_AWSVPC_BLOCK_IMDS` | `true` | Whether to block access to [Instance Metdata](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) for Tasks started with `awsvpc` network mode | `false` | `false`|
+| `ECS_ENABLE_TASK_ENI` | `false` | Whether to enable task networking for task to be launched with its own network interface | `false` | Not applicable |
+| `ECS_CNI_PLUGINS_PATH` | `/ecs/cni` | The path where the cni binary file is located | `/amazon-ecs-cni-plugins` | Not applicable |
+| `ECS_AWSVPC_BLOCK_IMDS` | `true` | Whether to block access to [Instance Metdata](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) for Tasks started with `awsvpc` network mode | `false` | Not applicable |
+| `ECS_AWSVPC_ADDITIONAL_LOCAL_ROUTES` | `["10.0.15.0/24"]` | In `awsvpc` network mode, traffic to these prefixes will be routed via the host bridge instead of the task ENI | `[]` | Not applicable |
 
 ### Persistence
 

--- a/agent/acs/model/ecsacs/api.go
+++ b/agent/acs/model/ecsacs/api.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/api/errors.go
+++ b/agent/api/errors.go
@@ -46,7 +46,8 @@ type NamedError interface {
 	ErrorName() string
 }
 
-// NamedError is a wrapper type for 'error' which adds an optional name and provides a symetric marshal/unmarshal
+// DefaultNamedError is a wrapper type for 'error' which adds an optional name and provides a symmetric
+// marshal/unmarshal
 type DefaultNamedError struct {
 	Err  string `json:"error"`
 	Name string `json:"name"`

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -218,7 +218,8 @@ func fileConfig() (Config, error) {
 
 	err = json.Unmarshal(data, &cfg)
 	if err != nil {
-		seelog.Errorf("Error reading cfg json data, err %v", err)
+		seelog.Criticalf("Error reading cfg json data, err %v", err)
+		return cfg, err
 	}
 
 	// Handle any deprecated keys correctly here
@@ -293,6 +294,7 @@ func environmentConfig() (Config, error) {
 	}
 
 	taskCleanupWaitDuration := parseEnvVariableDuration("ECS_ENGINE_TASK_CLEANUP_WAIT_DURATION")
+
 	availableLoggingDriversEnv := os.Getenv("ECS_AVAILABLE_LOGGING_DRIVERS")
 	loggingDriverDecoder := json.NewDecoder(strings.NewReader(availableLoggingDriversEnv))
 	var availableLoggingDrivers []dockerclient.LoggingDriver

--- a/agent/config/config_unix_test.go
+++ b/agent/config/config_unix_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/aws/amazon-ecs-agent/agent/ec2"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerclient"
+	cnitypes "github.com/containernetworking/cni/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -85,6 +86,7 @@ func TestConfigFromFile(t *testing.T) {
 	testPauseImageName := "pause-image-name"
 	testPauseTag := "pause-image-tag"
 	content := fmt.Sprintf(`{
+  "AWSRegion": "not-real-1",
   "Cluster": "%s",
   "EngineAuthType": "%s",
   "EngineAuthData": %s,
@@ -94,13 +96,14 @@ func TestConfigFromFile(t *testing.T) {
     "attribute1": "value1"
   },
   "PauseContainerImageName":"%s",
-  "PauseContainerTag":"%s"
+  "PauseContainerTag":"%s",
+  "AWSVPCAdditionalLocalRoutes":["169.254.172.1/32"]
 }`, cluster, dockerAuthType, dockerAuth, testPauseImageName, testPauseTag)
 
-	configFile := setupDockerAuthConfiguration(t, content)
-	defer os.Remove(configFile)
+	filePath := setupFileConfiguration(t, content)
+	defer os.Remove(filePath)
 
-	os.Setenv("ECS_AGENT_CONFIG_FILE_PATH", configFile)
+	os.Setenv("ECS_AGENT_CONFIG_FILE_PATH", filePath)
 	defer os.Unsetenv("ECS_AGENT_CONFIG_FILE_PATH")
 
 	cfg, err := fileConfig()
@@ -112,6 +115,11 @@ func TestConfigFromFile(t *testing.T) {
 	assert.Equal(t, map[string]string{"attribute1": "value1"}, cfg.InstanceAttributes)
 	assert.Equal(t, testPauseImageName, cfg.PauseContainerImageName, "should read PauseContainerImageName")
 	assert.Equal(t, testPauseTag, cfg.PauseContainerTag, "should read PauseContainerTag")
+	assert.Equal(t, 1, len(cfg.AWSVPCAdditionalLocalRoutes), "should have one additional local route")
+	expectedLocalRoute, err := cnitypes.ParseCIDR("169.254.172.1/32")
+	assert.NoError(t, err)
+	assert.Equal(t, expectedLocalRoute.IP, cfg.AWSVPCAdditionalLocalRoutes[0].IP, "should match expected route IP")
+	assert.Equal(t, expectedLocalRoute.Mask, cfg.AWSVPCAdditionalLocalRoutes[0].Mask, "should match expected route Mask")
 }
 
 // TestDockerAuthMergeFromFile tests docker auth read from file correctly after merge
@@ -124,7 +132,8 @@ func TestDockerAuthMergeFromFile(t *testing.T) {
     "email":"email"
   }
 }`
-	configContent := fmt.Sprintf(`{
+	content := fmt.Sprintf(`{
+  "AWSRegion": "not-real-1",
   "Cluster": "TestCluster",
   "EngineAuthType": "%s",
   "EngineAuthData": %s,
@@ -135,21 +144,37 @@ func TestDockerAuthMergeFromFile(t *testing.T) {
   }
 }`, dockerAuthType, dockerAuth)
 
-	configFile := setupDockerAuthConfiguration(t, configContent)
-	defer os.Remove(configFile)
+	filePath := setupFileConfiguration(t, content)
+	defer os.Remove(filePath)
 
 	os.Setenv("ECS_CLUSTER", cluster)
-	os.Setenv("ECS_AGENT_CONFIG_FILE_PATH", configFile)
+	os.Setenv("ECS_AGENT_CONFIG_FILE_PATH", filePath)
 	defer os.Unsetenv("ECS_CLUSTER")
 	defer os.Unsetenv("ECS_AGENT_CONFIG_FILE_PATH")
 
-	config, err := NewConfig(ec2.NewBlackholeEC2MetadataClient())
+	cfg, err := NewConfig(ec2.NewBlackholeEC2MetadataClient())
 	assert.NoError(t, err, "create configuration failed")
 
-	assert.Equal(t, cluster, config.Cluster, "cluster name not as expected from environment variable")
-	assert.Equal(t, dockerAuthType, config.EngineAuthType, "docker auth type not as expected from file")
-	assert.Equal(t, dockerAuth, string(config.EngineAuthData.Contents()), "docker auth data not as expected from file")
-	assert.Equal(t, map[string]string{"attribute1": "value1"}, config.InstanceAttributes)
+	assert.Equal(t, cluster, cfg.Cluster, "cluster name not as expected from environment variable")
+	assert.Equal(t, dockerAuthType, cfg.EngineAuthType, "docker auth type not as expected from file")
+	assert.Equal(t, dockerAuth, string(cfg.EngineAuthData.Contents()), "docker auth data not as expected from file")
+	assert.Equal(t, map[string]string{"attribute1": "value1"}, cfg.InstanceAttributes)
+}
+
+func TestBadFileContent(t *testing.T) {
+	content := `{
+	"AWSRegion": "not-real-1",
+	"AWSVPCAdditionalLocalRoutes":["169.254.172.1/32", "300.300.300.300/32", "foo"]
+	}`
+
+	filePath := setupFileConfiguration(t, content)
+	defer os.Remove(filePath)
+
+	os.Setenv("ECS_AGENT_CONFIG_FILE_PATH", filePath)
+	defer os.Unsetenv("ECS_AGENT_CONFIG_FILE_PATH")
+
+	_, err := NewConfig(ec2.NewBlackholeEC2MetadataClient())
+	assert.Error(t, err, "create configuration should fail")
 }
 
 func TestShouldLoadPauseContainerTarball(t *testing.T) {
@@ -162,13 +187,13 @@ func TestShouldLoadPauseContainerTarball(t *testing.T) {
 	assert.False(t, cfg.ShouldLoadPauseContainerTarball(), "should not load tarball if image name differs")
 }
 
-// setupDockerAuthConfiguration create a temp file store the configuration
-func setupDockerAuthConfiguration(t *testing.T, configContent string) string {
-	configFile, err := ioutil.TempFile("", "ecs-test")
+// setupFileConfiguration create a temp file store the configuration
+func setupFileConfiguration(t *testing.T, configContent string) string {
+	file, err := ioutil.TempFile("", "ecs-test")
 	require.NoError(t, err, "creating temp file for configuration failed")
 
-	_, err = configFile.Write([]byte(configContent))
+	_, err = file.Write([]byte(configContent))
 	require.NoError(t, err, "writing configuration to file failed")
 
-	return configFile.Name()
+	return file.Name()
 }

--- a/agent/config/config_unix_test.go
+++ b/agent/config/config_unix_test.go
@@ -29,6 +29,8 @@ import (
 )
 
 func TestConfigDefault(t *testing.T) {
+	os.Setenv("AWS_DEFAULT_REGION", "foo-bar-1")
+	defer os.Unsetenv("AWS_DEFAULT_REGION")
 	os.Unsetenv("ECS_DISABLE_METRICS")
 	os.Unsetenv("ECS_RESERVED_PORTS")
 	os.Unsetenv("ECS_RESERVED_MEMORY")
@@ -49,7 +51,7 @@ func TestConfigDefault(t *testing.T) {
 	os.Unsetenv("ECS_AWSVPC_BLOCK_IMDS")
 
 	cfg, err := NewConfig(ec2.NewBlackholeEC2MetadataClient())
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, "unix:///var/run/docker.sock", cfg.DockerEndpoint, "Default docker endpoint set incorrectly")
 	assert.Equal(t, "/data/", cfg.DataDir, "Default datadir set incorrectly")

--- a/agent/config/config_windows_test.go
+++ b/agent/config/config_windows_test.go
@@ -25,6 +25,8 @@ import (
 )
 
 func TestConfigDefault(t *testing.T) {
+	os.Setenv("AWS_DEFAULT_REGION", "foo-bar-1")
+	defer os.Unsetenv("AWS_DEFAULT_REGION")
 	os.Unsetenv("ECS_DISABLE_METRICS")
 	os.Unsetenv("ECS_RESERVED_PORTS")
 	os.Unsetenv("ECS_RESERVED_MEMORY")
@@ -42,7 +44,7 @@ func TestConfigDefault(t *testing.T) {
 	os.Unsetenv("ECS_IMAGE_CLEANUP_INTERVAL")
 
 	cfg, err := NewConfig(ec2.NewBlackholeEC2MetadataClient())
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, "npipe:////./pipe/docker_engine", cfg.DockerEndpoint, "Default docker endpoint set incorrectly")
 	assert.Equal(t, `C:\ProgramData\Amazon\ECS\data`, cfg.DataDir, "Default datadir set incorrectly")
@@ -64,10 +66,12 @@ func TestConfigDefault(t *testing.T) {
 }
 
 func TestConfigIAMTaskRolesReserves80(t *testing.T) {
+	os.Setenv("AWS_DEFAULT_REGION", "foo-bar-1")
+	defer os.Unsetenv("AWS_DEFAULT_REGION")
 	os.Unsetenv("ECS_RESERVED_PORTS")
 	os.Setenv("ECS_ENABLE_TASK_IAM_ROLE", "true")
 	cfg, err := NewConfig(ec2.NewBlackholeEC2MetadataClient())
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, []uint16{
 		DockerReservedPort,
 		DockerReservedSSLPort,

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -167,6 +167,13 @@ type Config struct {
 	// AWSVPCBlockInstanceMetdata specifies if InstanceMetadata endpoint should be blocked
 	// for tasks that are launched with network mode "awsvpc" when ECS_AWSVPC_BLOCK_IMDS=true
 	AWSVPCBlockInstanceMetdata bool
+
+	// OverrideAWSVPCLocalIPv4Address overrides the local IPv4 address chosen
+	// for a task using the `awsvpc` networking mode. Using this configuration
+	// will limit you to running one `awsvpc` task at a time. IPv4 addresses
+	// must be specified in decimal-octet form and also specify the subnet
+	// size (e.g., "169.254.172.42/22").
+	OverrideAWSVPCLocalIPv4Address string
 }
 
 // SensitiveRawMessage is a struct to store some data that should not be logged

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -174,6 +174,11 @@ type Config struct {
 	// must be specified in decimal-octet form and also specify the subnet
 	// size (e.g., "169.254.172.42/22").
 	OverrideAWSVPCLocalIPv4Address string
+
+	// AWSVPCAdditionalLocalRoutes allows the specification of routing table
+	// entries that will be added in the task's network namespace via the
+	// instance bridge interface rather than via the ENI.
+	AWSVPCAdditionalLocalRoutes []string
 }
 
 // SensitiveRawMessage is a struct to store some data that should not be logged

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerclient"
+	cnitypes "github.com/containernetworking/cni/pkg/types"
 )
 
 type Config struct {
@@ -173,12 +174,12 @@ type Config struct {
 	// will limit you to running one `awsvpc` task at a time. IPv4 addresses
 	// must be specified in decimal-octet form and also specify the subnet
 	// size (e.g., "169.254.172.42/22").
-	OverrideAWSVPCLocalIPv4Address string
+	OverrideAWSVPCLocalIPv4Address *cnitypes.IPNet
 
 	// AWSVPCAdditionalLocalRoutes allows the specification of routing table
 	// entries that will be added in the task's network namespace via the
 	// instance bridge interface rather than via the ENI.
-	AWSVPCAdditionalLocalRoutes []string
+	AWSVPCAdditionalLocalRoutes []cnitypes.IPNet
 }
 
 // SensitiveRawMessage is a struct to store some data that should not be logged

--- a/agent/ecr/mocks/ecr_mocks.go
+++ b/agent/ecr/mocks/ecr_mocks.go
@@ -17,8 +17,8 @@
 package mock_ecr
 
 import (
-	ecr "github.com/aws/amazon-ecs-agent/agent/ecr"
-	ecr0 "github.com/aws/amazon-ecs-agent/agent/ecr/model/ecr"
+	ecr0 "github.com/aws/amazon-ecs-agent/agent/ecr"
+	ecr "github.com/aws/amazon-ecs-agent/agent/ecr/model/ecr"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -43,9 +43,9 @@ func (_m *MockECRSDK) EXPECT() *_MockECRSDKRecorder {
 	return _m.recorder
 }
 
-func (_m *MockECRSDK) GetAuthorizationToken(_param0 *ecr0.GetAuthorizationTokenInput) (*ecr0.GetAuthorizationTokenOutput, error) {
+func (_m *MockECRSDK) GetAuthorizationToken(_param0 *ecr.GetAuthorizationTokenInput) (*ecr.GetAuthorizationTokenOutput, error) {
 	ret := _m.ctrl.Call(_m, "GetAuthorizationToken", _param0)
-	ret0, _ := ret[0].(*ecr0.GetAuthorizationTokenOutput)
+	ret0, _ := ret[0].(*ecr.GetAuthorizationTokenOutput)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -75,9 +75,9 @@ func (_m *MockECRFactory) EXPECT() *_MockECRFactoryRecorder {
 	return _m.recorder
 }
 
-func (_m *MockECRFactory) GetClient(_param0 string, _param1 string) ecr.ECRClient {
+func (_m *MockECRFactory) GetClient(_param0 string, _param1 string) ecr0.ECRClient {
 	ret := _m.ctrl.Call(_m, "GetClient", _param0, _param1)
-	ret0, _ := ret[0].(ecr.ECRClient)
+	ret0, _ := ret[0].(ecr0.ECRClient)
 	return ret0
 }
 
@@ -106,9 +106,9 @@ func (_m *MockECRClient) EXPECT() *_MockECRClientRecorder {
 	return _m.recorder
 }
 
-func (_m *MockECRClient) GetAuthorizationToken(_param0 string) (*ecr0.AuthorizationData, error) {
+func (_m *MockECRClient) GetAuthorizationToken(_param0 string) (*ecr.AuthorizationData, error) {
 	ret := _m.ctrl.Call(_m, "GetAuthorizationToken", _param0)
-	ret0, _ := ret[0].(*ecr0.AuthorizationData)
+	ret0, _ := ret[0].(*ecr.AuthorizationData)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -117,7 +117,7 @@ func (_mr *_MockECRClientRecorder) GetAuthorizationToken(arg0 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetAuthorizationToken", arg0)
 }
 
-func (_m *MockECRClient) IsTokenValid(_param0 *ecr0.AuthorizationData) bool {
+func (_m *MockECRClient) IsTokenValid(_param0 *ecr.AuthorizationData) bool {
 	ret := _m.ctrl.Call(_m, "IsTokenValid", _param0)
 	ret0, _ := ret[0].(bool)
 	return ret0

--- a/agent/ecs_client/model/ecs/service.go
+++ b/agent/ecs_client/model/ecs/service.go
@@ -70,8 +70,8 @@ func New(p client.ConfigProvider, cfgs ...*aws.Config) *ECS {
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *ECS {
-	if signingName == "" {
-		signingName = ServiceName
+	if len(signingName) == 0 {
+		signingName = "ecs"
 	}
 	svc := &ECS{
 		Client: client.New(

--- a/agent/ecscni/mocks/ecscni_mocks.go
+++ b/agent/ecscni/mocks/ecscni_mocks.go
@@ -53,24 +53,24 @@ func (_mr *_MockCNIClientRecorder) Capabilities(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Capabilities", arg0)
 }
 
-func (_m *MockCNIClient) CleanupNS(_param0 *ecscni.Config) error {
-	ret := _m.ctrl.Call(_m, "CleanupNS", _param0)
+func (_m *MockCNIClient) CleanupNS(_param0 *ecscni.Config, _param1 []string) error {
+	ret := _m.ctrl.Call(_m, "CleanupNS", _param0, _param1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockCNIClientRecorder) CleanupNS(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CleanupNS", arg0)
+func (_mr *_MockCNIClientRecorder) CleanupNS(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CleanupNS", arg0, arg1)
 }
 
-func (_m *MockCNIClient) SetupNS(_param0 *ecscni.Config) error {
-	ret := _m.ctrl.Call(_m, "SetupNS", _param0)
+func (_m *MockCNIClient) SetupNS(_param0 *ecscni.Config, _param1 []string) error {
+	ret := _m.ctrl.Call(_m, "SetupNS", _param0, _param1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockCNIClientRecorder) SetupNS(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetupNS", arg0)
+func (_mr *_MockCNIClientRecorder) SetupNS(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetupNS", arg0, arg1)
 }
 
 func (_m *MockCNIClient) Version(_param0 string) (string, error) {

--- a/agent/ecscni/mocks/ecscni_mocks.go
+++ b/agent/ecscni/mocks/ecscni_mocks.go
@@ -53,24 +53,24 @@ func (_mr *_MockCNIClientRecorder) Capabilities(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Capabilities", arg0)
 }
 
-func (_m *MockCNIClient) CleanupNS(_param0 *ecscni.Config, _param1 []string) error {
-	ret := _m.ctrl.Call(_m, "CleanupNS", _param0, _param1)
+func (_m *MockCNIClient) CleanupNS(_param0 *ecscni.Config) error {
+	ret := _m.ctrl.Call(_m, "CleanupNS", _param0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockCNIClientRecorder) CleanupNS(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CleanupNS", arg0, arg1)
+func (_mr *_MockCNIClientRecorder) CleanupNS(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CleanupNS", arg0)
 }
 
-func (_m *MockCNIClient) SetupNS(_param0 *ecscni.Config, _param1 []string) error {
-	ret := _m.ctrl.Call(_m, "SetupNS", _param0, _param1)
+func (_m *MockCNIClient) SetupNS(_param0 *ecscni.Config) error {
+	ret := _m.ctrl.Call(_m, "SetupNS", _param0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockCNIClientRecorder) SetupNS(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetupNS", arg0, arg1)
+func (_mr *_MockCNIClientRecorder) SetupNS(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetupNS", arg0)
 }
 
 func (_m *MockCNIClient) Version(_param0 string) (string, error) {

--- a/agent/ecscni/plugin.go
+++ b/agent/ecscni/plugin.go
@@ -107,6 +107,7 @@ func (client *cniClient) CleanupNS(cfg *Config) error {
 // constructNetworkConfig creates configuration for eni, ipam and bridge plugin
 func (client *cniClient) constructNetworkConfig(cfg *Config) (*libcni.NetworkConfigList, error) {
 	_, dst, err := net.ParseCIDR(TaskIAMRoleEndpoint)
+	_, returnRoute, err := net.ParseCIDR(ecsSubnet)
 	if err != nil {
 		return nil, err
 	}
@@ -120,6 +121,9 @@ func (client *cniClient) constructNetworkConfig(cfg *Config) (*libcni.NetworkCon
 		IPV4Routes: []*types.Route{
 			{
 				Dst: *dst,
+			},
+			{
+				Dst: *returnRoute,
 			},
 		},
 	}

--- a/agent/ecscni/plugin_test.go
+++ b/agent/ecscni/plugin_test.go
@@ -26,7 +26,8 @@ func TestSetupNS(t *testing.T) {
 		mockResult.EXPECT().String().Return(""),
 	)
 
-	err := ecscniClient.SetupNS(&Config{})
+	additionalRoutes := []string{"169.254.172.1/32", "10.11.12.13/32"}
+	err := ecscniClient.SetupNS(&Config{}, additionalRoutes)
 	assert.NoError(t, err)
 }
 
@@ -40,7 +41,8 @@ func TestCleanupNS(t *testing.T) {
 
 	libcniClient.EXPECT().DelNetworkList(gomock.Any(), gomock.Any()).Return(nil)
 
-	err := ecscniClient.CleanupNS(&Config{})
+	additionalRoutes := []string{"169.254.172.1/32", "10.11.12.13/32"}
+	err := ecscniClient.CleanupNS(&Config{}, additionalRoutes)
 	assert.NoError(t, err)
 }
 
@@ -60,7 +62,8 @@ func TestConstructNetworkConfig(t *testing.T) {
 		BlockInstanceMetdata: true,
 	}
 
-	networkConfigList, err := ecscniClient.(*cniClient).constructNetworkConfig(config)
+	additionalRoutes := []string{"169.254.172.1/32", "10.11.12.13/32"}
+	networkConfigList, err := ecscniClient.(*cniClient).constructNetworkConfig(config, additionalRoutes)
 	assert.NoError(t, err, "construct cni plugins configuration failed")
 
 	bridgeConfig := &BridgeConfig{}

--- a/agent/ecscni/types.go
+++ b/agent/ecscni/types.go
@@ -14,7 +14,7 @@
 package ecscni
 
 import (
-	"github.com/containernetworking/cni/pkg/types"
+	cnitypes "github.com/containernetworking/cni/pkg/types"
 )
 
 const (
@@ -59,11 +59,11 @@ type IPAMConfig struct {
 	// IPV4Subnet is the ip address range managed by ipam
 	IPV4Subnet string `json:"ipv4-subnet,omitempty"`
 	// IPV4Address is the ip address to deal with(assign or release) in ipam
-	IPV4Address string `json:"ipv4-address,omitempty"`
+	IPV4Address *cnitypes.IPNet `json:"ipv4-address,omitempty"`
 	// IPV4Gateway is the gateway returned by ipam, defalut the '.1' in the subnet
 	IPV4Gateway string `json:"ipv4-gateway,omitempty"`
 	// IPV4Routes is the route to added in the containerr namespace
-	IPV4Routes []*types.Route `json:"ipv4-routes,omitempty"`
+	IPV4Routes []*cnitypes.Route `json:"ipv4-routes,omitempty"`
 }
 
 // BridgeConfig contains all the information needed to invoke the bridge plugin
@@ -134,10 +134,12 @@ type Config struct {
 	// BridgeName is the name used to create the bridge
 	BridgeName string
 	// IPAMV4Address is the ipv4 used to assign from ipam
-	IPAMV4Address string
+	IPAMV4Address *cnitypes.IPNet
 	// ID is the information associate with ip in ipam
 	ID string
 	// BlockInstanceMetdata specifies if InstanceMetadata endpoint should be
 	// blocked
 	BlockInstanceMetdata bool
+	// AdditionalLocalRoutes specifies additional routes to be added to the task namespace
+	AdditionalLocalRoutes []cnitypes.IPNet
 }

--- a/agent/engine/docker_container_engine.go
+++ b/agent/engine/docker_container_engine.go
@@ -274,7 +274,7 @@ func (dg *dockerGoClient) pullImage(image string, authData *api.RegistryAuthenti
 	if image == emptyvolume.Image+":"+emptyvolume.Tag {
 		scratchErr := dg.createScratchImageIfNotExists()
 		if scratchErr != nil {
-			return &api.DefaultNamedError{Name: "CreateEmptyVolumeError", Err: "Could not create empty volume " + scratchErr.Error()}
+			return CreateEmptyVolumeError{scratchErr}
 		}
 		return nil
 	}

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -680,7 +680,7 @@ func (engine *DockerTaskEngine) provisionContainerResources(task *api.Task, cont
 		}
 	}
 	// Invoke the libcni to config the network namespace for the container
-	err = engine.cniClient.SetupNS(cniConfig)
+	err = engine.cniClient.SetupNS(cniConfig, engine.cfg.AWSVPCAdditionalLocalRoutes)
 	if err != nil {
 		seelog.Errorf("Set up pause container namespace failed, err: %v, task: %s", err, task.String())
 		return DockerContainerMetadata{
@@ -703,7 +703,7 @@ func (engine *DockerTaskEngine) cleanupPauseContainerNetwork(task *api.Task, con
 		return errors.Wrapf(err, "engine: failed cleanup task network namespace, task: %s", task.String())
 	}
 
-	return engine.cniClient.CleanupNS(cniConfig)
+	return engine.cniClient.CleanupNS(cniConfig, engine.cfg.AWSVPCAdditionalLocalRoutes)
 }
 
 func (engine *DockerTaskEngine) buildCNIConfigFromTaskContainer(task *api.Task, container *api.Container) (*ecscni.Config, error) {

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -695,6 +695,11 @@ func (engine *DockerTaskEngine) buildCNIConfigFromTaskContainer(task *api.Task, 
 	if err != nil {
 		return nil, errors.Wrapf(err, "engine: build cni configuration from taskfailed")
 	}
+
+	if engine.cfg.OverrideAWSVPCLocalIPv4Address != "" {
+		cfg.IPAMV4Address = engine.cfg.OverrideAWSVPCLocalIPv4Address
+	}
+
 	// Get the pid of container
 	containers, ok := engine.state.ContainerMapByArn(task.Arn)
 	if !ok {

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -553,7 +553,23 @@ func (engine *DockerTaskEngine) pullAndUpdateContainerReference(task *api.Task, 
 		return DockerContainerMetadata{Error: TaskStoppedBeforePullBeginError{task.Arn}}
 	}
 
-	metadata := engine.client.PullImage(container.Image, container.RegistryAuthentication)
+	var metadata DockerContainerMetadata
+	imagePullBackoff := utils.NewSimpleBackoff(250*time.Millisecond, time.Second, 0.20, 1.5)
+	_ = utils.RetryNWithBackoff(imagePullBackoff, 10, func() error {
+		metadata = engine.client.PullImage(container.Image, container.RegistryAuthentication)
+		if container.IsInternal() {
+			// "internal" containers are created by the agent and we don't expect to actually pull them
+			return nil
+		}
+		if imagePullError, ok := metadata.Error.(CannotPullContainerError); ok {
+			seelog.Warnf("When pulling %s: %s", container.Image, imagePullError)
+			return imagePullError
+		} else {
+			// If the pull fails with something other than CannotPullContainerError, or if it is successful, we stop
+			// retrying
+			return nil
+		}
+	})
 
 	// Don't add internal images(created by ecs-agent) into imagemanger state
 	if container.IsInternal() {

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -328,7 +328,7 @@ func TestTaskWithSteadyStateResourcesProvisioned(t *testing.T) {
 			State: docker.State{Pid: 23},
 		}, nil),
 		// Then setting up the pause container network namespace
-		mockCNIClient.EXPECT().SetupNS(gomock.Any()).Return(nil),
+		mockCNIClient.EXPECT().SetupNS(gomock.Any(), gomock.Any()).Return(nil),
 
 		// Once the pause container is started, sleep container will be created
 		client.EXPECT().CreateContainer(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(
@@ -395,7 +395,7 @@ func TestTaskWithSteadyStateResourcesProvisioned(t *testing.T) {
 		ID:    containerID,
 		State: docker.State{Pid: 23},
 	}, nil)
-	mockCNIClient.EXPECT().CleanupNS(gomock.Any()).Return(nil)
+	mockCNIClient.EXPECT().CleanupNS(gomock.Any(), gomock.Any()).Return(nil)
 	client.EXPECT().StopContainer(containerID+":"+pauseContainer.Name, gomock.Any()).MinTimes(1)
 
 	exitCode := 0
@@ -1275,7 +1275,7 @@ func TestPauseContaienrHappyPath(t *testing.T) {
 				ID:    pauseContainerID,
 				State: docker.State{Pid: 123},
 			}, nil),
-		cniClient.EXPECT().SetupNS(gomock.Any()).Return(nil),
+		cniClient.EXPECT().SetupNS(gomock.Any(), gomock.Any()).Return(nil),
 	)
 
 	// For the other container
@@ -1312,7 +1312,7 @@ func TestPauseContaienrHappyPath(t *testing.T) {
 		ID:    pauseContainerID,
 		State: docker.State{Pid: 123},
 	}, nil)
-	cniClient.EXPECT().CleanupNS(gomock.Any()).Return(nil)
+	cniClient.EXPECT().CleanupNS(gomock.Any(), gomock.Any()).Return(nil)
 	dockerClient.EXPECT().StopContainer(pauseContainerID, gomock.Any()).Return(
 		DockerContainerMetadata{DockerID: pauseContainerID})
 	dockerClient.EXPECT().RemoveContainer(gomock.Any(), gomock.Any()).Return(nil).Times(2)
@@ -1453,7 +1453,7 @@ func TestStopPauseContainerCleanupCalled(t *testing.T) {
 			ID:    containerID,
 			State: docker.State{Pid: containerPid},
 		}, nil),
-		mockCNIClient.EXPECT().CleanupNS(gomock.Any()).Return(nil),
+		mockCNIClient.EXPECT().CleanupNS(gomock.Any(), gomock.Any()).Return(nil),
 		dockerClient.EXPECT().StopContainer(containerID, stopContainerTimeout).Return(DockerContainerMetadata{}),
 	)
 

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -328,7 +328,7 @@ func TestTaskWithSteadyStateResourcesProvisioned(t *testing.T) {
 			State: docker.State{Pid: 23},
 		}, nil),
 		// Then setting up the pause container network namespace
-		mockCNIClient.EXPECT().SetupNS(gomock.Any(), gomock.Any()).Return(nil),
+		mockCNIClient.EXPECT().SetupNS(gomock.Any()).Return(nil),
 
 		// Once the pause container is started, sleep container will be created
 		client.EXPECT().CreateContainer(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(
@@ -395,7 +395,7 @@ func TestTaskWithSteadyStateResourcesProvisioned(t *testing.T) {
 		ID:    containerID,
 		State: docker.State{Pid: 23},
 	}, nil)
-	mockCNIClient.EXPECT().CleanupNS(gomock.Any(), gomock.Any()).Return(nil)
+	mockCNIClient.EXPECT().CleanupNS(gomock.Any()).Return(nil)
 	client.EXPECT().StopContainer(containerID+":"+pauseContainer.Name, gomock.Any()).MinTimes(1)
 
 	exitCode := 0
@@ -1275,7 +1275,7 @@ func TestPauseContaienrHappyPath(t *testing.T) {
 				ID:    pauseContainerID,
 				State: docker.State{Pid: 123},
 			}, nil),
-		cniClient.EXPECT().SetupNS(gomock.Any(), gomock.Any()).Return(nil),
+		cniClient.EXPECT().SetupNS(gomock.Any()).Return(nil),
 	)
 
 	// For the other container
@@ -1312,7 +1312,7 @@ func TestPauseContaienrHappyPath(t *testing.T) {
 		ID:    pauseContainerID,
 		State: docker.State{Pid: 123},
 	}, nil)
-	cniClient.EXPECT().CleanupNS(gomock.Any(), gomock.Any()).Return(nil)
+	cniClient.EXPECT().CleanupNS(gomock.Any()).Return(nil)
 	dockerClient.EXPECT().StopContainer(pauseContainerID, gomock.Any()).Return(
 		DockerContainerMetadata{DockerID: pauseContainerID})
 	dockerClient.EXPECT().RemoveContainer(gomock.Any(), gomock.Any()).Return(nil).Times(2)
@@ -1453,7 +1453,7 @@ func TestStopPauseContainerCleanupCalled(t *testing.T) {
 			ID:    containerID,
 			State: docker.State{Pid: containerPid},
 		}, nil),
-		mockCNIClient.EXPECT().CleanupNS(gomock.Any(), gomock.Any()).Return(nil),
+		mockCNIClient.EXPECT().CleanupNS(gomock.Any()).Return(nil),
 		dockerClient.EXPECT().StopContainer(containerID, stopContainerTimeout).Return(DockerContainerMetadata{}),
 	)
 

--- a/agent/engine/engine_mocks.go
+++ b/agent/engine/engine_mocks.go
@@ -17,6 +17,7 @@
 package engine
 
 import (
+	context0 "context"
 	io "io"
 	time "time"
 
@@ -180,7 +181,7 @@ func (_m *MockDockerClient) EXPECT() *_MockDockerClientRecorder {
 	return _m.recorder
 }
 
-func (_m *MockDockerClient) ContainerEvents(_param0 context.Context) (<-chan DockerContainerChangeEvent, error) {
+func (_m *MockDockerClient) ContainerEvents(_param0 context0.Context) (<-chan DockerContainerChangeEvent, error) {
 	ret := _m.ctrl.Call(_m, "ContainerEvents", _param0)
 	ret0, _ := ret[0].(<-chan DockerContainerChangeEvent)
 	ret1, _ := ret[1].(error)
@@ -304,7 +305,7 @@ func (_mr *_MockDockerClientRecorder) StartContainer(arg0, arg1 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "StartContainer", arg0, arg1)
 }
 
-func (_m *MockDockerClient) Stats(_param0 string, _param1 context.Context) (<-chan *go_dockerclient.Stats, error) {
+func (_m *MockDockerClient) Stats(_param0 string, _param1 context0.Context) (<-chan *go_dockerclient.Stats, error) {
 	ret := _m.ctrl.Call(_m, "Stats", _param0, _param1)
 	ret0, _ := ret[0].(<-chan *go_dockerclient.Stats)
 	ret1, _ := ret[1].(error)

--- a/agent/engine/errors.go
+++ b/agent/engine/errors.go
@@ -204,6 +204,11 @@ func (err CannotPullECRContainerError) ErrorName() string {
 	return "CannotPullECRContainerError"
 }
 
+// Retry fulfills the utils.Retrier interface and allows retries to be skipped by utils.Retry* functions
+func (err CannotPullECRContainerError) Retry() bool {
+	return false
+}
+
 // CannotCreateContainerError indicates any error when trying to create a container
 type CannotCreateContainerError struct {
 	fromError error

--- a/agent/engine/errors.go
+++ b/agent/engine/errors.go
@@ -209,6 +209,23 @@ func (err CannotPullECRContainerError) Retry() bool {
 	return false
 }
 
+type CreateEmptyVolumeError struct {
+	fromError error
+}
+
+func (err CreateEmptyVolumeError) Error() string {
+	return err.fromError.Error()
+}
+
+func (err CreateEmptyVolumeError) ErrorName() string {
+	return "CreateEmptyVolumeError"
+}
+
+// Retry fulfills the utils.Retrier interface and allows retries to be skipped by utils.Retry* functions
+func (err CreateEmptyVolumeError) Retry() bool {
+	return false
+}
+
 // CannotCreateContainerError indicates any error when trying to create a container
 type CannotCreateContainerError struct {
 	fromError error

--- a/agent/eni/netlinkwrapper/mocks/mock_netlinkwrapper_linux.go
+++ b/agent/eni/netlinkwrapper/mocks/mock_netlinkwrapper_linux.go
@@ -18,7 +18,7 @@ package mock_netlinkwrapper
 
 import (
 	gomock "github.com/golang/mock/gomock"
-	"github.com/vishvananda/netlink"
+	netlink "github.com/vishvananda/netlink"
 )
 
 // Mock of NetLink interface

--- a/agent/eni/udevwrapper/mocks/mock_udevwrapper_linux.go
+++ b/agent/eni/udevwrapper/mocks/mock_udevwrapper_linux.go
@@ -17,7 +17,7 @@
 package mock_udevwrapper
 
 import (
-	"github.com/deniswernert/udev"
+	udev "github.com/deniswernert/udev"
 	gomock "github.com/golang/mock/gomock"
 )
 

--- a/agent/tcs/model/ecstcs/api.go
+++ b/agent/tcs/model/ecstcs/api.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/utils/utils_test.go
+++ b/agent/utils/utils_test.go
@@ -14,6 +14,7 @@
 package utils
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -97,21 +98,68 @@ func TestRetryWithBackoff(t *testing.T) {
 	_time = mocktime
 	defer func() { _time = &ttime.DefaultTime{} }()
 
-	mocktime.EXPECT().Sleep(100 * time.Millisecond).Times(3)
-	counter := 3
-	RetryWithBackoff(NewSimpleBackoff(100*time.Millisecond, 100*time.Millisecond, 0, 1), func() error {
-		if counter == 0 {
-			return nil
-		}
-		counter--
-		return errors.New("err")
+	t.Run("retries", func(t *testing.T) {
+		mocktime.EXPECT().Sleep(100 * time.Millisecond).Times(3)
+		counter := 3
+		RetryWithBackoff(NewSimpleBackoff(100*time.Millisecond, 100*time.Millisecond, 0, 1), func() error {
+			if counter == 0 {
+				return nil
+			}
+			counter--
+			return errors.New("err")
+		})
+		assert.Equal(t, 0, counter, "Counter didn't go to 0; didn't get retried enough")
 	})
-	assert.Equal(t, 0, counter, "Counter didn't go to 0; didn't get retried enough")
 
-	// no sleeps
-	RetryWithBackoff(NewSimpleBackoff(10*time.Second, 20*time.Second, 0, 2), func() error {
-		return NewRetriableError(NewRetriable(false), errors.New("can't retry"))
+	t.Run("no retries", func(t *testing.T) {
+		// no sleeps
+		RetryWithBackoff(NewSimpleBackoff(10*time.Second, 20*time.Second, 0, 2), func() error {
+			return NewRetriableError(NewRetriable(false), errors.New("can't retry"))
+		})
 	})
+}
+
+func TestRetryWithBackoffCtx(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mocktime := mock_ttime.NewMockTime(ctrl)
+	_time = mocktime
+	defer func() { _time = &ttime.DefaultTime{} }()
+
+	t.Run("retries", func(t *testing.T) {
+		mocktime.EXPECT().Sleep(100 * time.Millisecond).Times(3)
+		counter := 3
+		RetryWithBackoffCtx(context.TODO(), NewSimpleBackoff(100*time.Millisecond, 100*time.Millisecond, 0, 1), func() error {
+			if counter == 0 {
+				return nil
+			}
+			counter--
+			return errors.New("err")
+		})
+		assert.Equal(t, 0, counter, "Counter didn't go to 0; didn't get retried enough")
+	})
+
+	t.Run("no retries", func(t *testing.T) {
+		// no sleeps
+		RetryWithBackoffCtx(context.TODO(), NewSimpleBackoff(10*time.Second, 20*time.Second, 0, 2), func() error {
+			return NewRetriableError(NewRetriable(false), errors.New("can't retry"))
+		})
+	})
+
+	t.Run("cancel context", func(t *testing.T) {
+		mocktime.EXPECT().Sleep(100 * time.Millisecond).Times(2)
+		counter := 2
+		ctx, cancel := context.WithCancel(context.TODO())
+		RetryWithBackoffCtx(ctx, NewSimpleBackoff(100*time.Millisecond, 100*time.Millisecond, 0, 1), func() error {
+			counter--
+			if counter == 0 {
+				cancel()
+			}
+			return errors.New("err")
+		})
+		assert.Equal(t, 0, counter, "Counter not 0; went the wrong number of times")
+	})
+
 }
 
 func TestRetryNWithBackoff(t *testing.T) {
@@ -121,29 +169,83 @@ func TestRetryNWithBackoff(t *testing.T) {
 	_time = mocktime
 	defer func() { _time = &ttime.DefaultTime{} }()
 
-	// 2 tries, 1 sleep
-	mocktime.EXPECT().Sleep(100 * time.Millisecond).Times(1)
-	counter := 3
-	err := RetryNWithBackoff(NewSimpleBackoff(100*time.Millisecond, 100*time.Millisecond, 0, 1), 2, func() error {
-		counter--
-		return errors.New("err")
-	})
-	assert.Equal(t, 1, counter, "Should have stopped after two tries")
-	assert.Error(t, err)
-
-	// 3 tries, 2 sleeps
-	mocktime.EXPECT().Sleep(100 * time.Millisecond).Times(2)
-	counter = 3
-	err = RetryNWithBackoff(NewSimpleBackoff(100*time.Millisecond, 100*time.Millisecond, 0, 1), 5, func() error {
-		counter--
-		if counter == 0 {
-			return nil
-		}
-		return errors.New("err")
+	t.Run("count exceeded", func(t *testing.T) {
+		// 2 tries, 1 sleep
+		mocktime.EXPECT().Sleep(100 * time.Millisecond).Times(1)
+		counter := 3
+		err := RetryNWithBackoff(NewSimpleBackoff(100*time.Millisecond, 100*time.Millisecond, 0, 1), 2, func() error {
+			counter--
+			return errors.New("err")
+		})
+		assert.Equal(t, 1, counter, "Should have stopped after two tries")
+		assert.Error(t, err)
 	})
 
-	assert.Equal(t, 0, counter)
-	assert.Nil(t, err)
+	t.Run("retry succeeded", func(t *testing.T) {
+		// 3 tries, 2 sleeps
+		mocktime.EXPECT().Sleep(100 * time.Millisecond).Times(2)
+		counter := 3
+		err := RetryNWithBackoff(NewSimpleBackoff(100*time.Millisecond, 100*time.Millisecond, 0, 1), 5, func() error {
+			counter--
+			if counter == 0 {
+				return nil
+			}
+			return errors.New("err")
+		})
+		assert.Equal(t, 0, counter)
+		assert.NoError(t, err)
+	})
+}
+
+func TestRetryNWithBackoffCtx(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mocktime := mock_ttime.NewMockTime(ctrl)
+	_time = mocktime
+	defer func() { _time = &ttime.DefaultTime{} }()
+
+	t.Run("count exceeded", func(t *testing.T) {
+		// 2 tries, 1 sleep
+		mocktime.EXPECT().Sleep(100 * time.Millisecond).Times(1)
+		counter := 3
+		err := RetryNWithBackoffCtx(context.TODO(), NewSimpleBackoff(100*time.Millisecond, 100*time.Millisecond, 0, 1), 2, func() error {
+			counter--
+			return errors.New("err")
+		})
+		assert.Equal(t, 1, counter, "Should have stopped after two tries")
+		assert.Error(t, err)
+	})
+
+	t.Run("retry succeeded", func(t *testing.T) {
+		// 3 tries, 2 sleeps
+		mocktime.EXPECT().Sleep(100 * time.Millisecond).Times(2)
+		counter := 3
+		err := RetryNWithBackoffCtx(context.TODO(), NewSimpleBackoff(100*time.Millisecond, 100*time.Millisecond, 0, 1), 5, func() error {
+			counter--
+			if counter == 0 {
+				return nil
+			}
+			return errors.New("err")
+		})
+		assert.Equal(t, 0, counter)
+		assert.NoError(t, err)
+	})
+
+	t.Run("cancel context", func(t *testing.T) {
+		// 2 tries, 2 sleeps
+		mocktime.EXPECT().Sleep(100 * time.Millisecond).Times(2)
+		counter := 3
+		ctx, cancel := context.WithCancel(context.TODO())
+		err := RetryNWithBackoffCtx(ctx, NewSimpleBackoff(100*time.Millisecond, 100*time.Millisecond, 0, 1), 5, func() error {
+			counter--
+			if counter == 1 {
+				cancel()
+			}
+			return errors.New("err")
+		})
+		assert.Equal(t, 1, counter, "Should have stopped after two tries")
+		assert.Error(t, err)
+	})
 }
 
 func TestParseBool(t *testing.T) {


### PR DESCRIPTION
### Summary
This series of commits adds retries for failed pulls (compensating for transient network issues) and allows additional routes to be configured for tasks launched with the `awsvpc` network mode.

### Implementation details
Retries are implemented with the new `utils.RetryNWithBackoffCtx` (based on existing `utils.RetryNWithBackoff`) inside the `dockerGoClient` and excludes one expected non-transient error (missing IAM permissions to call `ecr:GetAuthorizationToken`).  Other non-transient errors could be excluded from retries by extending `CannotPullContainerError` to implement `utils.Retrier`, but has not been done yet (I have not assembled a list of expected non-transient error codes from Docker).

Configurable routes were added by depending on the `types.IPNet` type from `github.com/containernetworking/cni/pkg/types`, which wraps `net.IPNet` so it can be serialized and deserialized in CIDR notation.

### Testing
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

Ran in an environment with manually configured additional routes and with transient network failures.

New tests cover the changes: yes

### Description for the changelog
* Enhancement - Retry failed container image pull operations.

### Licensing
This contribution is under the terms of the Apache 2.0 License: yes
