### PR TITLE
Make the IPAM cleanup at the end of the task

### DIFF
--- a/agent/ecscni/mocks/ecscni_mocks.go
+++ b/agent/ecscni/mocks/ecscni_mocks.go
@@ -63,6 +63,16 @@ func (_mr *_MockCNIClientRecorder) CleanupNS(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CleanupNS", arg0)
 }
 
+func (_m *MockCNIClient) ReleaseIPResource(_param0 *ecscni.Config) error {
+	ret := _m.ctrl.Call(_m, "ReleaseIPResource", _param0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockCNIClientRecorder) ReleaseIPResource(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReleaseIPResource", arg0)
+}
+
 func (_m *MockCNIClient) SetupNS(_param0 *ecscni.Config) error {
 	ret := _m.ctrl.Call(_m, "SetupNS", _param0)
 	ret0, _ := ret[0].(error)

--- a/agent/ecscni/plugin_test.go
+++ b/agent/ecscni/plugin_test.go
@@ -53,6 +53,60 @@ func TestCleanupNS(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestReleaseIPInIPAM(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ecscniClient := NewClient(&Config{})
+	libcniClient := mock_libcni.NewMockCNI(ctrl)
+	ecscniClient.(*cniClient).libcni = libcniClient
+
+	libcniClient.EXPECT().DelNetworkList(gomock.Any(), gomock.Any()).Return(nil)
+
+	err := ecscniClient.ReleaseIPResource(&Config{})
+	assert.NoError(t, err)
+}
+
+// TestConstructNetworkConfig tests constructNetworkConfig creates the correct
+// configuration for bridge/eni plugin
+func TestConstructNetworkConfigWithoutIPAM(t *testing.T) {
+	ecscniClient := NewClient(&Config{})
+
+	config := &Config{
+		ENIID:                "eni-12345678",
+		ContainerID:          "containerid12",
+		ContainerPID:         "pid",
+		ENIIPV4Address:       "172.31.21.40",
+		ENIIPV6Address:       "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+		ENIMACAddress:        "02:7b:64:49:b1:40",
+		BridgeName:           "bridge-test1",
+		BlockInstanceMetdata: true,
+	}
+
+	networkConfigList, err := ecscniClient.(*cniClient).createNetworkConfig(config, ecscniClient.(*cniClient).createBridgeNetworkConfigWithoutIPAM)
+	assert.NoError(t, err, "construct cni plugins configuration failed")
+
+	bridgeConfig := &BridgeConfig{}
+	eniConfig := &ENIConfig{}
+	for _, plugin := range networkConfigList.Plugins {
+		var err error
+		if plugin.Network.Type == ECSBridgePluginName {
+			err = json.Unmarshal(plugin.Bytes, bridgeConfig)
+		} else if plugin.Network.Type == ECSENIPluginName {
+			err = json.Unmarshal(plugin.Bytes, eniConfig)
+		}
+		assert.NoError(t, err, "unmarshal config from bytes failed")
+	}
+
+	assert.Equal(t, config.BridgeName, bridgeConfig.BridgeName)
+	assert.Equal(t, IPAMConfig{}, bridgeConfig.IPAM)
+	assert.Equal(t, config.ENIID, eniConfig.ENIID)
+	assert.Equal(t, config.ENIIPV4Address, eniConfig.IPV4Address)
+	assert.Equal(t, config.ENIIPV6Address, eniConfig.IPV6Address)
+	assert.Equal(t, config.ENIMACAddress, eniConfig.MACAddress)
+	assert.True(t, eniConfig.BlockInstanceMetdata)
+}
+
 // TestConstructNetworkConfig tests constructNetworkConfig creates the correct
 // configuration for bridge/eni/ipam plugin
 func TestConstructNetworkConfig(t *testing.T) {
@@ -75,7 +129,7 @@ func TestConstructNetworkConfig(t *testing.T) {
 		AdditionalLocalRoutes: additionalRoutes,
 	}
 
-	networkConfigList, err := ecscniClient.(*cniClient).constructNetworkConfig(config)
+	networkConfigList, err := ecscniClient.(*cniClient).createNetworkConfig(config, ecscniClient.(*cniClient).createBridgeNetworkConfigWithIPAM)
 	assert.NoError(t, err, "construct cni plugins configuration failed")
 
 	bridgeConfig := &BridgeConfig{}

--- a/agent/ecscni/types.go
+++ b/agent/ecscni/types.go
@@ -48,6 +48,13 @@ const (
 	CapabilityAWSVPCNetworkingMode = "awsvpc-network-mode"
 )
 
+//IPAMNetworkConfig is the config format accepted by the plugin
+type IPAMNetworkConfig struct {
+	Name       string     `json:"name,omitempty"`
+	CNIVersion string     `json:"cniVersion,omitempty"`
+	IPAM       IPAMConfig `json:"ipam"`
+}
+
 // IPAMConfig contains all the information needed to invoke the ipam plugin
 type IPAMConfig struct {
 	// Type is the cni plugin name

--- a/agent/engine/docker_container_engine.go
+++ b/agent/engine/docker_container_engine.go
@@ -18,6 +18,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"strings"
 	"sync"
@@ -39,6 +40,8 @@ import (
 
 const (
 	dockerDefaultTag = "latest"
+	// imageNameFormat is the name of a image may look like: repo:tag
+	imageNameFormat = "%s:%s"
 )
 
 // Timelimits for docker operations enforced above docker
@@ -271,7 +274,7 @@ func (dg *dockerGoClient) pullImage(image string, authData *api.RegistryAuthenti
 
 	// Special case; this image is not one that should be pulled, but rather
 	// should be created locally if necessary
-	if image == emptyvolume.Image+":"+emptyvolume.Tag {
+	if image == fmt.Sprintf(imageNameFormat, emptyvolume.Image, emptyvolume.Tag) {
 		scratchErr := dg.createScratchImageIfNotExists()
 		if scratchErr != nil {
 			return CreateEmptyVolumeError{scratchErr}

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -690,6 +690,17 @@ func (engine *DockerTaskEngine) provisionContainerResources(task *api.Task, cont
 	}
 }
 
+// releaseIPInIPAM marks the ip avaialble in the ipam db
+func (engine *DockerTaskEngine) releaseIPInIPAM(task *api.Task) error {
+	seelog.Infof("Releasing ip in the ipam, task: %s", task.Arn)
+	cfg, err := task.BuildCNIConfig()
+	if err != nil {
+		return errors.Wrapf(err, "engine: build cni configuration from task failed")
+	}
+
+	return engine.cniClient.ReleaseIPResource(cfg)
+}
+
 // cleanupPauseContainerNetwork will clean up the network namespace of pause container
 func (engine *DockerTaskEngine) cleanupPauseContainerNetwork(task *api.Task, container *api.Container) error {
 	seelog.Infof("Task [%s]: Cleaning up the network namespace", task.String())
@@ -705,7 +716,7 @@ func (engine *DockerTaskEngine) cleanupPauseContainerNetwork(task *api.Task, con
 func (engine *DockerTaskEngine) buildCNIConfigFromTaskContainer(task *api.Task, container *api.Container) (*ecscni.Config, error) {
 	cfg, err := task.BuildCNIConfig()
 	if err != nil {
-		return nil, errors.Wrapf(err, "engine: build cni configuration from taskfailed")
+		return nil, errors.Wrapf(err, "engine: build cni configuration from task failed")
 	}
 
 	if engine.cfg.OverrideAWSVPCLocalIPv4Address != nil &&

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -397,6 +397,7 @@ func TestTaskWithSteadyStateResourcesProvisioned(t *testing.T) {
 	}, nil)
 	mockCNIClient.EXPECT().CleanupNS(gomock.Any()).Return(nil)
 	client.EXPECT().StopContainer(containerID+":"+pauseContainer.Name, gomock.Any()).MinTimes(1)
+	mockCNIClient.EXPECT().ReleaseIPResource(gomock.Any()).Return(nil).MaxTimes(1)
 
 	exitCode := 0
 	// And then docker reports that sleep died, as sleep is wont to do
@@ -1315,6 +1316,7 @@ func TestPauseContaienrHappyPath(t *testing.T) {
 	cniClient.EXPECT().CleanupNS(gomock.Any()).Return(nil)
 	dockerClient.EXPECT().StopContainer(pauseContainerID, gomock.Any()).Return(
 		DockerContainerMetadata{DockerID: pauseContainerID})
+	cniClient.EXPECT().ReleaseIPResource(gomock.Any()).Return(nil)
 	dockerClient.EXPECT().RemoveContainer(gomock.Any(), gomock.Any()).Return(nil).Times(2)
 	imageManager.EXPECT().RemoveContainerReferenceFromImageState(gomock.Any()).Return(nil)
 

--- a/agent/engine/engine_integ_test.go
+++ b/agent/engine/engine_integ_test.go
@@ -89,6 +89,7 @@ func setup(cfg *config.Config, t *testing.T) (TaskEngine, func(), credentials.Ma
 	}, credentialsManager
 }
 
+/*
 func discardEvents(from interface{}) func() {
 	done := make(chan bool)
 
@@ -113,7 +114,7 @@ func discardEvents(from interface{}) func() {
 		done <- true
 	}
 }
-
+*/
 // TestDockerStateToContainerState tests convert the container status from
 // docker inspect to the status defined in agent
 func TestDockerStateToContainerState(t *testing.T) {

--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -151,6 +151,7 @@ func (mtask *managedTask) overseeTask() {
 		llog.Debug("Marking done for this sequence", "seqnum", mtask.StopSequenceNumber)
 		mtask.engine.taskStopGroup.Done(mtask.StopSequenceNumber)
 	}
+	// TODO: make this idempotent on agent restart
 	go mtask.releaseIPInIPAM()
 	mtask.cleanupTask(mtask.engine.cfg.TaskCleanupWaitDuration)
 }
@@ -333,7 +334,7 @@ func (mtask *managedTask) releaseIPInIPAM() {
 
 	err := mtask.engine.releaseIPInIPAM(mtask.Task)
 	if err != nil {
-		seelog.Infof("Releasing the ip in IPAM failed, task: [%s], err: %v", mtask.Task.Arn, err)
+		seelog.Warnf("Releasing the ip in IPAM failed, task: [%s], err: %v", mtask.Task.Arn, err)
 	}
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Fixing #970 

### Implementation details
<!-- How are the changes implemented? -->
Previously, the pause container namespace cleanup was invoked in `StopContainer` of task engine. This pr separate the cleanup into two process: clean up the network namespace and release the ip from ipam. Also this pr moves the ipam clean up out of the `StopContainer` to the end of a task life cycle. So that the `ipam del` command is always called when a task moved to stop.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass
- [x] Manual test the scenario where the pause container is killed outside agent

New tests cover the changes: <!-- yes|no -->
yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
yes