### PR TITLE
Makefile fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,4 @@ _bin/
 .DS_Store
 /misc/windows-iam/devcon*
 /misc/pause-container/pause
-/amazon-ecs-cni-plugins
 *-stamp

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ _bin/
 /misc/windows-iam/devcon*
 /misc/pause-container/pause
 /amazon-ecs-cni-plugins
+*-stamp

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "amazon-ecs-cni-plugins"]
+	path = amazon-ecs-cni-plugins
+	url = https://github.com/aws/amazon-ecs-cni-plugins.git

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ PAUSE_CONTAINER_TARBALL = "amazon-ecs-pause.tar"
 ECS_CNI_REPOSITORY_REVISION=master
 
 # Variable to override cni repository location
-ECS_CNI_REPOSITORY_SRC_DIR=$(shell pwd)/amazon-ecs-cni-plugins
+ECS_CNI_REPOSITORY_SRC_DIR=$(PWD)/amazon-ecs-cni-plugins
 
 
 .PHONY: all gobuild static docker release certs test clean netkitten test-registry run-functional-tests gremlin benchmark-test gogenerate run-integ-tests image-cleanup-test-images pause-container get-cni-sources cni-plugins
@@ -43,8 +43,8 @@ build-in-docker: get-deps
 	  -e TARGET_OS="${TARGET_OS}" \
 	  -e LDFLAGS="-X github.com/aws/amazon-ecs-agent/agent/config.DefaultPauseContainerTag=$(PAUSE_CONTAINER_TAG) \
 	  -X github.com/aws/amazon-ecs-agent/agent/config.DefaultPauseContainerImageName=$(PAUSE_CONTAINER_IMAGE)" \
-	  -v "$(shell pwd)/out:/out" \
-	  -v "$(shell pwd):/go/src/github.com/aws/amazon-ecs-agent" \
+	  -v "$(PWD)/out:/out" \
+	  -v "$(PWD):/go/src/github.com/aws/amazon-ecs-agent" \
 	  "amazon/amazon-ecs-agent-build:make"
 
 # 'docker' builds the agent dockerfile from the current sourcecode tree, dirty
@@ -60,10 +60,10 @@ docker-release: pause-container-release cni-plugins
 	@docker build -f scripts/dockerfiles/Dockerfile.cleanbuild -t "amazon/amazon-ecs-agent-cleanbuild:make" .
 	@docker run --net=none \
 	  -e TARGET_OS="${TARGET_OS}" \
-	  -v "$(shell pwd)/out:/out" \
+	  -v "$(PWD)/out:/out" \
 	  -e LDFLAGS="-X github.com/aws/amazon-ecs-agent/agent/config.DefaultPauseContainerTag=$(PAUSE_CONTAINER_TAG) \
 	  -X github.com/aws/amazon-ecs-agent/agent/config.DefaultPauseContainerImageName=$(PAUSE_CONTAINER_IMAGE)" \
-	  -v "$(shell pwd):/src/amazon-ecs-agent" \
+	  -v "$(PWD):/src/amazon-ecs-agent" \
 	  "amazon/amazon-ecs-agent-cleanbuild:make"
 
 # Release packages our agent into a "scratch" based dockerfile
@@ -97,7 +97,7 @@ test-registry: netkitten volumes-test squid awscli image-cleanup-test-images flu
 test-in-docker:
 	docker build -f scripts/dockerfiles/Dockerfile.test -t "amazon/amazon-ecs-agent-test:make" .
 	# Privileged needed for docker-in-docker so integ tests pass
-	docker run --net=none -v "$(shell pwd):/go/src/github.com/aws/amazon-ecs-agent" --privileged "amazon/amazon-ecs-agent-test:make"
+	docker run --net=none -v "$(PWD):/go/src/github.com/aws/amazon-ecs-agent" --privileged "amazon/amazon-ecs-agent-test:make"
 
 run-functional-tests: testnnp test-registry
 	. ./scripts/shared_env && go test -tags functional -timeout=30m -v ./agent/functional_tests/...
@@ -108,16 +108,16 @@ testnnp:
 pause-container:
 	@docker build -f scripts/dockerfiles/Dockerfile.buildPause -t "amazon/amazon-ecs-build-pause-bin:make" .
 	@docker run --net=none \
-		-v "$(shell pwd)/misc/pause-container:/out" \
-		-v "$(shell pwd)/misc/pause-container/buildPause:/usr/src/buildPause" \
+		-v "$(PWD)/misc/pause-container:/out" \
+		-v "$(PWD)/misc/pause-container/buildPause:/usr/src/buildPause" \
 		"amazon/amazon-ecs-build-pause-bin:make"
 
 	$(MAKE) -C misc/pause-container $(MFLAGS)
 	@docker rmi -f "amazon/amazon-ecs-build-pause-bin:make"
 
 pause-container-release: pause-container
-	mkdir -p "$(shell pwd)/out"
-	@docker save ${PAUSE_CONTAINER_IMAGE}:${PAUSE_CONTAINER_TAG} > "$(shell pwd)/out/${PAUSE_CONTAINER_TARBALL}"
+	mkdir -p "$(PWD)/out"
+	@docker save ${PAUSE_CONTAINER_IMAGE}:${PAUSE_CONTAINER_TAG} > "$(PWD)/out/${PAUSE_CONTAINER_TARBALL}"
 
 get-cni-sources: .cni-sources-stamp
 
@@ -132,7 +132,7 @@ get-cni-sources: .cni-sources-stamp
 cni-plugins: get-deps
 	@docker build -f scripts/dockerfiles/Dockerfile.buildCNIPlugins -t "amazon/amazon-ecs-build-cniplugins:make" .
 	@docker run --rm --net=none \
-		-v "$(shell pwd)/out/cni-plugins:/go/src/github.com/aws/amazon-ecs-cni-plugins/bin/plugins" \
+		-v "$(PWD)/out/cni-plugins:/go/src/github.com/aws/amazon-ecs-cni-plugins/bin/plugins" \
 		-v "$(ECS_CNI_REPOSITORY_SRC_DIR):/go/src/github.com/aws/amazon-ecs-cni-plugins" \
 		"amazon/amazon-ecs-build-cniplugins:make"
 
@@ -179,7 +179,7 @@ clean:
 	docker ps > /dev/null
 	rm -f misc/certs/ca-certificates.crt &> /dev/null
 	rm -rf out/*
-	rm -rf $(shell pwd)/amazon-ecs-cni-plugins
+	rm -rf $(PWD)/amazon-ecs-cni-plugins
 	rm -rf agent/Godeps/_workspace/pkg/
 	-$(MAKE) -C misc/netkitten $(MFLAGS) clean
 	-$(MAKE) -C misc/volumes-test $(MFLAGS) clean

--- a/Makefile
+++ b/Makefile
@@ -127,15 +127,16 @@ get-cni-sources: .cni-sources-stamp
 	else \
 		git clone https://github.com/aws/amazon-ecs-cni-plugins.git --branch $(ECS_CNI_REPOSITORY_REVISION) ; \
 	fi
+	mkdir -p amazon-ecs-cni-plugins/bin/plugins
 	touch .cni-sources-stamp
 
 cni-plugins: get-deps
 	@docker build -f scripts/dockerfiles/Dockerfile.buildCNIPlugins -t "amazon/amazon-ecs-build-cniplugins:make" .
-	@docker run --rm --net=none \
+	mkdir -p out/cni-plugins
+	docker run --rm --net=none \
 		-v "$(PWD)/out/cni-plugins:/go/src/github.com/aws/amazon-ecs-cni-plugins/bin/plugins" \
 		-v "$(ECS_CNI_REPOSITORY_SRC_DIR):/go/src/github.com/aws/amazon-ecs-cni-plugins" \
 		"amazon/amazon-ecs-build-cniplugins:make"
-
 	@echo "Built amazon-ecs-cni-plugins successfully."
 
 run-integ-tests: test-registry gremlin


### PR DESCRIPTION
### Summary

Makefile improvements to address #977 and #978 

### Implementation details

General makefile cleanup to provide better handling of dependencies.

### Testing

Multiple runs of `make clean`, `make get-deps`, etc. Confirm that subsequent runs don't do anything, e.g. 

```
ulap:amazon-ecs-agent‹makefile-fixes›$ make get-deps    
if [ -d amazon-ecs-cni-plugins/plugins ]; then \
        cd amazon-ecs-cni-plugins && git fetch && git checkout master ; \
else \
        git clone https://github.com/aws/amazon-ecs-cni-plugins.git --branch master ; \
fi
Cloning into 'amazon-ecs-cni-plugins'...
remote: Counting objects: 1867, done.
remote: Total 1867 (delta 0), reused 0 (delta 0), pack-reused 1867
Receiving objects: 100% (1867/1867), 2.91 MiB | 1.88 MiB/s, done.
Resolving deltas: 100% (808/808), done.
Checking connectivity... done.
mkdir -p amazon-ecs-cni-plugins/bin/plugins
touch .cni-sources-stamp
go get github.com/tools/godep
go get golang.org/x/tools/cmd/cover
go get github.com/golang/mock/mockgen
go get golang.org/x/tools/cmd/goimports
touch .get-deps-stamp
ulap:amazon-ecs-agent‹makefile-fixes›$ make get-deps  
make: Nothing to be done for 'get-deps'.
```

- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: There are no specific tests for the makefile.

### Description for the changelog
This change doesn't introduce any behavior changes into the agent and can be left out of the changelog.

### Licensing

This contribution is under the terms of the Apache 2.0 License: yes
