### PR TITLE
ecscni: Re-implement removed AdditionalLocalRoutes

### DIFF
--- a/agent/ecscni/plugin_test.go
+++ b/agent/ecscni/plugin_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aws/amazon-ecs-agent/agent/ecscni/mocks_cnitypes"
 	"github.com/aws/amazon-ecs-agent/agent/ecscni/mocks_libcni"
+	"github.com/containernetworking/cni/libcni"
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -22,15 +23,24 @@ func TestSetupNS(t *testing.T) {
 
 	mockResult := mock_types.NewMockResult(ctrl)
 
-	gomock.InOrder(
-		libcniClient.EXPECT().AddNetworkList(gomock.Any(), gomock.Any()).Return(mockResult, nil),
-		mockResult.EXPECT().String().Return(""),
-	)
-
 	additionalRoutesJson := `["169.254.172.1/32", "10.11.12.13/32"]`
 	var additionalRoutes []cnitypes.IPNet
 	err := json.Unmarshal([]byte(additionalRoutesJson), &additionalRoutes)
 	assert.NoError(t, err)
+
+	gomock.InOrder(
+		libcniClient.EXPECT().AddNetworkList(gomock.Any(), gomock.Any()).Return(mockResult, nil).Do(func(net *libcni.NetworkConfigList, rt *libcni.RuntimeConf) {
+			assert.Len(t, net.Plugins, 2, "expected 2 plugins for SetupNS")
+			bridgePlugin := net.Plugins[0]
+			assert.Equal(t, ECSBridgePluginName, bridgePlugin.Network.Type, "first plugin should be bridge")
+			var bridgeConfig BridgeConfig
+			err := json.Unmarshal(bridgePlugin.Bytes, &bridgeConfig)
+			assert.NoError(t, err, "unmarshal BridgeConfig")
+			assert.Len(t, bridgeConfig.IPAM.IPV4Routes, 3, "default route plus two extra routes")
+		}),
+		mockResult.EXPECT().String().Return(""),
+	)
+
 	err = ecscniClient.SetupNS(&Config{AdditionalLocalRoutes: additionalRoutes})
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
### Summary
Code handling AdditionalLocalRoutes was inadvertently removed in 10fb083ad7cb23c64e822459a1562d72f58908b7.  This commit adds it back, and adjusts the TestSetupNS unit test to explicitly check for it.

### Implementation details
Added back the code that actually uses the field.  Checked the value in the mock implementation.

### Testing
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass
- [x] Observed additional routes being properly added to the network namespace

New tests cover the changes: yes

### Description for the changelog
None

### Licensing
This contribution is under the terms of the Apache 2.0 License: yes
