### PR TITLE
Websocket timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## UNRELEASED
 * Feature - Support for provisioning Tasks with ENIs
-* Enhancement - Retry failed container image pull operations.
+* Enhancement - Retry failed container image pull operations [#975](https://github.com/aws/amazon-ecs-agent/pull/975)
+* Enhancement - Set read and write timeouts for websocket connectons [#993](https://github.com/aws/amazon-ecs-agent/pull/993) 
 * Bug - Fixed a memory leak issue when submitting the task state change [#967](https://github.com/aws/amazon-ecs-agent/pull/967)
 * Bug - Fixed a race condition where a container can be created twice when agent restarts. [#939](https://github.com/aws/amazon-ecs-agent/pull/939)
 * Bug - Fixed an issue where `microsoft/windowsservercore:latest` was not

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ cni-plugins: get-cni-sources
 	mkdir -p out/cni-plugins
 	docker run --rm --net=none \
 		-e GIT_SHORT_HASH=$(shell cd $(ECS_CNI_REPOSITORY_SRC_DIR) && git rev-parse --short HEAD) \
-		-e GIT_PORCELAIN=$(shell cd $(ECS_CNI_REPOSITORY_SRC_DIR) && git status --porcelain 2> /dev/null | wc -l) \
+		-e GIT_PORCELAIN=$(shell cd $(ECS_CNI_REPOSITORY_SRC_DIR) && git status --porcelain 2> /dev/null | wc -l | sed 's/^ *//') \
 		-v "$(PWD)/out/cni-plugins:/go/src/github.com/aws/amazon-ecs-cni-plugins/bin/plugins" \
 		-v "$(ECS_CNI_REPOSITORY_SRC_DIR):/go/src/github.com/aws/amazon-ecs-cni-plugins" \
 		"amazon/amazon-ecs-build-cniplugins:make"

--- a/agent/acs/handler/acs_handler.go
+++ b/agent/acs/handler/acs_handler.go
@@ -246,19 +246,13 @@ func (acsSession *session) startSessionOnce() error {
 	client := acsSession.resources.createACSClient(url, acsSession.agentConfig)
 	defer client.Close()
 
-	// Start inactivity timer for closing the connection
-	timer := newDisconnectionTimer(client, acsSession.heartbeatTimeout(), acsSession.heartbeatJitter())
-	defer timer.Stop()
-
-	return acsSession.startACSSession(client, timer)
+	return acsSession.startACSSession(client)
 }
 
 // startACSSession starts a session with ACS. It adds request handlers for various
 // kinds of messages expected from ACS. It returns on server disconnection or when
 // the context is cancelled
-func (acsSession *session) startACSSession(client wsclient.ClientServer, timer ttime.Timer) error {
-	// Any message from the server resets the disconnect timeout
-	client.SetAnyRequestHandler(anyMessageHandler(timer))
+func (acsSession *session) startACSSession(client wsclient.ClientServer) error {
 	cfg := acsSession.agentConfig
 
 	refreshCredsHandler := newRefreshCredentialsHandler(acsSession.ctx, cfg.Cluster, acsSession.containerInstanceARN,
@@ -313,6 +307,11 @@ func (acsSession *session) startACSSession(client wsclient.ClientServer, timer t
 		return err
 	}
 	seelog.Info("Connected to ACS endpoint")
+	// Start inactivity timer for closing the connection
+	timer := newDisconnectionTimer(client, acsSession.heartbeatTimeout(), acsSession.heartbeatJitter())
+	// Any message from the server resets the disconnect timeout
+	client.SetAnyRequestHandler(anyMessageHandler(timer, client))
+	defer timer.Stop()
 
 	acsSession.resources.connectedToACS()
 
@@ -377,7 +376,7 @@ func (acsSession *session) heartbeatJitter() time.Duration {
 
 // createACSClient creates the ACS Client using the specified URL
 func (acsResources *acsSessionResources) createACSClient(url string, cfg *config.Config) wsclient.ClientServer {
-	return acsclient.New(url, cfg, acsResources.credentialsProvider)
+	return acsclient.New(url, cfg, acsResources.credentialsProvider, heartbeatTimeout+heartbeatJitter)
 }
 
 // connectedToACS records a successful connection to ACS
@@ -424,9 +423,8 @@ func acsWsURL(endpoint, cluster, containerInstanceArn string, taskEngine engine.
 func newDisconnectionTimer(client wsclient.ClientServer, timeout time.Duration, jitter time.Duration) ttime.Timer {
 	timer := time.AfterFunc(utils.AddJitter(timeout, jitter), func() {
 		seelog.Warn("ACS Connection hasn't had any activity for too long; closing connection")
-		closeErr := client.Close()
-		if closeErr != nil {
-			seelog.Warnf("Error disconnecting: %v", closeErr)
+		if err := client.Close(); err != nil {
+			seelog.Warnf("Error disconnecting: %v", err)
 		}
 	})
 
@@ -435,9 +433,15 @@ func newDisconnectionTimer(client wsclient.ClientServer, timeout time.Duration, 
 
 // anyMessageHandler handles any server message. Any server message means the
 // connection is active and thus the heartbeat disconnect should not occur
-func anyMessageHandler(timer ttime.Timer) func(interface{}) {
+func anyMessageHandler(timer ttime.Timer, client wsclient.ClientServer) func(interface{}) {
 	return func(interface{}) {
-		seelog.Debug("ACS activity occured")
+		seelog.Debug("ACS activity occurred")
+		// Reset read deadline as there's activity on the channel
+		if err := client.SetReadDeadline(time.Now().Add(heartbeatTimeout + heartbeatJitter)); err != nil {
+			seelog.Warn("Unable to extend read deadline for ACS connection: %v", err)
+		}
+
+		// Reset heearbeat timer
 		timer.Reset(utils.AddJitter(heartbeatTimeout, heartbeatJitter))
 	}
 }

--- a/agent/acs/handler/acs_handler_test.go
+++ b/agent/acs/handler/acs_handler_test.go
@@ -804,9 +804,7 @@ func TestConnectionIsClosedOnIdle(t *testing.T) {
 		_heartbeatJitter:     10 * time.Millisecond,
 	}
 	go func() {
-		timer := newDisconnectionTimer(mockWsClient, acsSession.heartbeatTimeout(), acsSession.heartbeatJitter())
-		defer timer.Stop()
-		acsSession.startACSSession(mockWsClient, timer)
+		acsSession.startACSSession(mockWsClient)
 	}()
 
 	// Wait for connection to be closed. If the connection is not closed
@@ -1060,11 +1058,9 @@ func TestHandlerReconnectsCorrectlySetsSendCredentialsURLParameter(t *testing.T)
 		_heartbeatTimeout:    20 * time.Millisecond,
 		_heartbeatJitter:     10 * time.Millisecond,
 	}
-	timer := newDisconnectionTimer(mockWsClient, acsSession.heartbeatTimeout(), acsSession.heartbeatJitter())
-	defer timer.Stop()
 	go func() {
 		for i := 0; i < 10; i++ {
-			acsSession.startACSSession(mockWsClient, timer)
+			acsSession.startACSSession(mockWsClient)
 		}
 		cancel()
 	}()

--- a/agent/acs/handler/acs_handler_test.go
+++ b/agent/acs/handler/acs_handler_test.go
@@ -803,9 +803,7 @@ func TestConnectionIsClosedOnIdle(t *testing.T) {
 		_heartbeatTimeout:    20 * time.Millisecond,
 		_heartbeatJitter:     10 * time.Millisecond,
 	}
-	go func() {
-		acsSession.startACSSession(mockWsClient)
-	}()
+	go acsSession.startACSSession(mockWsClient)
 
 	// Wait for connection to be closed. If the connection is not closed
 	// due to inactivity, the test will time out

--- a/agent/tcs/handler/handler.go
+++ b/agent/tcs/handler/handler.go
@@ -25,6 +25,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/tcs/client"
 	"github.com/aws/amazon-ecs-agent/agent/tcs/model/ecstcs"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
+	"github.com/aws/amazon-ecs-agent/agent/wsclient"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/cihub/seelog"
 )
@@ -35,8 +36,8 @@ const (
 	defaultPublishMetricsInterval = 20 * time.Second
 
 	// The maximum time to wait between heartbeats without disconnecting
-	defaultHeartbeatTimeout            = 5 * time.Minute
-	defaultHeartbeatJitter             = 3 * time.Minute
+	defaultHeartbeatTimeout            = 1 * time.Minute
+	defaultHeartbeatJitter             = 1 * time.Minute
 	deregisterContainerInstanceHandler = "TCSDeregisterContainerInstanceHandler"
 )
 
@@ -94,10 +95,15 @@ func startTelemetrySession(params TelemetrySessionParams, statsEngine stats.Engi
 	return startSession(url, params.Cfg, params.CredentialProvider, statsEngine, defaultHeartbeatTimeout, defaultHeartbeatJitter, defaultPublishMetricsInterval, params.DeregisterInstanceEventStream)
 }
 
-func startSession(url string, cfg *config.Config, credentialProvider *credentials.Credentials,
-	statsEngine stats.Engine, heartbeatTimeout, heartbeatJitter, publishMetricsInterval time.Duration,
+func startSession(url string,
+	cfg *config.Config,
+	credentialProvider *credentials.Credentials,
+	statsEngine stats.Engine,
+	heartbeatTimeout, heartbeatJitter,
+	publishMetricsInterval time.Duration,
 	deregisterInstanceEventStream *eventstream.EventStream) error {
-	client := tcsclient.New(url, cfg, credentialProvider, statsEngine, publishMetricsInterval)
+	client := tcsclient.New(url, cfg, credentialProvider, statsEngine,
+		publishMetricsInterval, defaultHeartbeatTimeout+defaultHeartbeatJitter)
 	defer client.Close()
 
 	err := deregisterInstanceEventStream.Subscribe(deregisterContainerInstanceHandler, client.Disconnect)
@@ -112,7 +118,7 @@ func startSession(url string, cfg *config.Config, credentialProvider *credential
 	timer := time.AfterFunc(utils.AddJitter(heartbeatTimeout, heartbeatJitter), func() {
 		// Close the connection if there haven't been any messages received from backend
 		// for a long time.
-		seelog.Debug("TCS Connection hasn't had a heartbeat or an ack message in too long of a timeout; disconnecting")
+		seelog.Info("TCS Connection hasn't had a heartbeat or an ack message in too long of a timeout; disconnecting")
 		client.Disconnect()
 	})
 	defer timer.Stop()
@@ -124,6 +130,7 @@ func startSession(url string, cfg *config.Config, credentialProvider *credential
 		return err
 	}
 	seelog.Info("Connected to TCS endpoint")
+	client.SetAnyRequestHandler(anyMessageHandler(client))
 	return client.Serve()
 }
 
@@ -141,6 +148,18 @@ func ackPublishMetricHandler(timer *time.Timer) func(*ecstcs.AckPublishMetric) {
 	return func(*ecstcs.AckPublishMetric) {
 		seelog.Debug("Received AckPublishMetric from tcs")
 		timer.Reset(utils.AddJitter(defaultHeartbeatTimeout, defaultHeartbeatJitter))
+	}
+}
+
+// anyMessageHandler handles any server message. Any server message means the
+// connection is active
+func anyMessageHandler(client wsclient.ClientServer) func(interface{}) {
+	return func(interface{}) {
+		seelog.Trace("TCS activity occured")
+		// Reset read deadline as there's activity on the channel
+		if err := client.SetReadDeadline(time.Now().Add(defaultHeartbeatTimeout + defaultHeartbeatJitter)); err != nil {
+			seelog.Warnf("Unable to extend read deadline for TCS connection: %v", err)
+		}
 	}
 }
 

--- a/agent/tcs/handler/handler_test.go
+++ b/agent/tcs/handler/handler_test.go
@@ -82,7 +82,7 @@ func TestFormatURL(t *testing.T) {
 func TestStartSession(t *testing.T) {
 	// Start test server.
 	closeWS := make(chan []byte)
-	server, serverChan, requestChan, serverErr, err := wsmock.GetMockServer(t, closeWS)
+	server, serverChan, requestChan, serverErr, err := wsmock.GetMockServer(closeWS)
 	server.StartTLS()
 	defer server.Close()
 	if err != nil {
@@ -143,7 +143,7 @@ func TestStartSession(t *testing.T) {
 func TestSessionConnectionClosedByRemote(t *testing.T) {
 	// Start test server.
 	closeWS := make(chan []byte)
-	server, serverChan, _, serverErr, err := wsmock.GetMockServer(t, closeWS)
+	server, serverChan, _, serverErr, err := wsmock.GetMockServer(closeWS)
 	server.StartTLS()
 	defer server.Close()
 	if err != nil {
@@ -183,7 +183,7 @@ func TestSessionConnectionClosedByRemote(t *testing.T) {
 func TestConnectionInactiveTimeout(t *testing.T) {
 	// Start test server.
 	closeWS := make(chan []byte)
-	server, _, requestChan, serverErr, err := wsmock.GetMockServer(t, closeWS)
+	server, _, requestChan, serverErr, err := wsmock.GetMockServer(closeWS)
 	server.StartTLS()
 	defer server.Close()
 	if err != nil {

--- a/agent/wsclient/client.go
+++ b/agent/wsclient/client.go
@@ -305,7 +305,7 @@ func (cs *ClientServerImpl) WriteMessage(send []byte) error {
 
 	// This is just future proofing. Ignore the error as the gorilla websocket
 	// library returns 'nil' anyway for SetWriteDeadline
-	// https://github.com/gorilla/websocket/blob/master/conn.go#L761
+	// https://github.com/gorilla/websocket/blob/4201258b820c74ac8e6922fc9e6b52f71fe46f8d/conn.go#L761
 	if err := cs.conn.SetWriteDeadline(time.Now().Add(cs.RWTimeout)); err != nil {
 		seelog.Warnf("Unable to set write deadline for websocket connection: %v for %s", err, cs.URL)
 	}

--- a/agent/wsclient/mock/client.go
+++ b/agent/wsclient/mock/client.go
@@ -17,6 +17,8 @@
 package mock_wsclient
 
 import (
+	time "time"
+
 	wsclient "github.com/aws/amazon-ecs-agent/agent/wsclient"
 	gomock "github.com/golang/mock/gomock"
 )
@@ -130,6 +132,16 @@ func (_mr *_MockClientServerRecorder) SetConnection(arg0 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetConnection", arg0)
 }
 
+func (_m *MockClientServer) SetReadDeadline(_param0 time.Time) error {
+	ret := _m.ctrl.Call(_m, "SetReadDeadline", _param0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockClientServerRecorder) SetReadDeadline(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetReadDeadline", arg0)
+}
+
 func (_m *MockClientServer) WriteMessage(_param0 []byte) error {
 	ret := _m.ctrl.Call(_m, "WriteMessage", _param0)
 	ret0, _ := ret[0].(error)
@@ -181,6 +193,26 @@ func (_m *MockWebsocketConn) ReadMessage() (int, []byte, error) {
 
 func (_mr *_MockWebsocketConnRecorder) ReadMessage() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReadMessage")
+}
+
+func (_m *MockWebsocketConn) SetReadDeadline(_param0 time.Time) error {
+	ret := _m.ctrl.Call(_m, "SetReadDeadline", _param0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockWebsocketConnRecorder) SetReadDeadline(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetReadDeadline", arg0)
+}
+
+func (_m *MockWebsocketConn) SetWriteDeadline(_param0 time.Time) error {
+	ret := _m.ctrl.Call(_m, "SetWriteDeadline", _param0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockWebsocketConnRecorder) SetWriteDeadline(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetWriteDeadline", arg0)
 }
 
 func (_m *MockWebsocketConn) WriteMessage(_param0 int, _param1 []byte) error {

--- a/agent/wsclient/mock/utils/utils.go
+++ b/agent/wsclient/mock/utils/utils.go
@@ -16,7 +16,6 @@ package utils
 import (
 	"net/http"
 	"net/http/httptest"
-	"testing"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -24,7 +23,7 @@ import (
 
 // GetMockServer retuns a mock websocket server that can be started up as TLS or not.
 // TODO replace with gomock
-func GetMockServer(t *testing.T, closeWS <-chan []byte) (*httptest.Server, chan<- string, <-chan string, <-chan error, error) {
+func GetMockServer(closeWS <-chan []byte) (*httptest.Server, chan<- string, <-chan string, <-chan error, error) {
 	serverChan := make(chan string)
 	requestsChan := make(chan string)
 	errChan := make(chan error)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Implements some websocket connection management improvements. 

### Implementation details
<!-- How are the changes implemented? -->
1. Set read and write deadlines for websocket ReadMessage and
    WriteMessage operations. This is to ensure that these methods
    do not hang and result in io timeout if there's issues with
    the connection
2. Reduce the scope of the lock in the Connect() method. The
    lock was being held for the length of Connect() method, which
    meant that it wouldn't be relnquished if there was any delay
    in establishing the connection. The scope of the lock has now
    been reduced to just accessing the cs.conn variable
3. Start ACS heartbeat timer after the connection has been
    established. The timer was being started before a call to
    Connect, which meant that the connection could be prematurely
    terminated for being idle if there was a delay in establishing
    the connection

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass
- [x] Manual tests
  - [x] Reconnects to ACS and TCS work as expected when ACS/TCS initiate disconnect
  - [x] Reconnects to ACS and TCS work as expected when Agent initiates disconnect

New tests cover the changes: Yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Covered in changelog.md

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: Yes
