### PR TITLE
engine/dockerclient: Add new DockerClient version support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 ## UNRELEASED
 * Feature - Support for provisioning Tasks with ENIs
 * Bug - Fixed a bug where unsupported Docker API client versions could be registered
-[#1014](https://github.com/aws/amazon-ecs-agent/pull/1014)
+  [#1014](https://github.com/aws/amazon-ecs-agent/pull/1014)
+* Enhancement - Support `init` process in containers by adding support for Docker remote API client version 1.25
+  [#996](https://github.com/aws/amazon-ecs-agent/pull/996)
 
 ## 1.14.5
 * Enhancement - Retry failed container image pull operations [#975](https://github.com/aws/amazon-ecs-agent/pull/975)

--- a/agent/engine/dockerclient/versionsupport_unix.go
+++ b/agent/engine/dockerclient/versionsupport_unix.go
@@ -38,6 +38,7 @@ func getAgentVersions() []DockerVersion {
 		Version_1_22,
 		Version_1_23,
 		Version_1_24,
+		Version_1_25,
 	}
 }
 


### PR DESCRIPTION
### Summary
Add new Docker API version 1.25 support

### Implementation details
Added 1.25 to supported agent version for init flag support.

### Testing
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
Support for Docker Client version 1.25

### Licensing
This contribution is under the terms of the Apache 2.0 License: yes
