### PR TITLE
Don't log websocket messages if there are errors.

### DIFF
--- a/agent/acs/handler/acs_handler.go
+++ b/agent/acs/handler/acs_handler.go
@@ -214,7 +214,7 @@ func (acsSession *session) Start() error {
 				// Disconnected unexpectedly from ACS, compute backoff duration to
 				// reconnect
 				reconnectDelay := acsSession.computeReconnectDelay(isInactiveInstance)
-				seelog.Debugf("Reconnecting to ACS in: %v", reconnectDelay)
+				seelog.Infof("Reconnecting to ACS in: %s", reconnectDelay.String())
 				waitComplete := acsSession.waitForDuration(reconnectDelay)
 				if waitComplete {
 					// If the context was not cancelled and we've waited for the

--- a/agent/wsclient/client.go
+++ b/agent/wsclient/client.go
@@ -338,7 +338,7 @@ func (cs *ClientServerImpl) ConsumeMessages() error {
 
 		default:
 			// Unexpected error occurred
-			seelog.Errorf("Error getting message from ws backend: error: [%v], message: [%s], messageType: [%v] ", err, message, messageType)
+			seelog.Errorf("Error getting message from ws backend: error: [%v], messageType: [%v] ", err, messageType)
 			return err
 		}
 
@@ -413,8 +413,8 @@ func websocketScheme(httpScheme string) (string, error) {
 // See https://github.com/gorilla/websocket/blob/87f6f6a22ebfbc3f89b9ccdc7fddd1b914c095f9/conn.go#L650
 func permissibleCloseCode(err error) bool {
 	return websocket.IsCloseError(err,
-		websocket.CloseNormalClosure,
-		websocket.CloseAbnormalClosure,
-		websocket.CloseGoingAway,
-		websocket.CloseInternalServerErr)
+		websocket.CloseNormalClosure,     // websocket error code 1000
+		websocket.CloseAbnormalClosure,   // websocket error code 1006
+		websocket.CloseGoingAway,         // websocket error code 1001
+		websocket.CloseInternalServerErr) // websocket error code 1011
 }


### PR DESCRIPTION
The messages that come over the websockets can potentially contain sensitive
information that shouldn't be put in logs. Separately, if reading the message
results in an error, the content of the message is irrelevant and unreliable.


### Summary
When there is a websocket connection error, we shouldn't log the message because we have no way of knowing what it contains.

### Implementation details
Removed the `message` portion of the log line.

### Testing
- [ ] Builds on Linux (`make release`)
- [ ] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [ ] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: no

### Description for the changelog
NA

### Licensing
This contribution is under the terms of the Apache 2.0 License: yes
