### PR TITLE
windows: Updated setup scripts

### DIFF
--- a/misc/windows-deploy/containersetup.ps1
+++ b/misc/windows-deploy/containersetup.ps1
@@ -1,0 +1,27 @@
+# Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+$CREDENTIAL_ADDRESS = "169.254.170.2"
+$EC2_METADATA_ADDRESS = "169.254.169.254"
+
+# Clear pre-existing routes that may conflict
+Get-NetRoute -DestinationPrefix "$($CREDENTIAL_ADDRESS)/32" -PolicyStore PersistentStore -Erroraction:Ignore | Remove-NetRoute -Confirm:$false -Erroraction:Ignore
+Get-NetRoute -DestinationPrefix "$($CREDENTIAL_ADDRESS)/32" -PolicyStore ActiveStore -Erroraction:Ignore | Remove-NetRoute -Confirm:$false -Erroraction:Ignore
+Get-NetRoute -DestinationPrefix "$($EC2_METADATA_ADDRESS)/32" -PolicyStore PersistentStore -Erroraction:Ignore | Remove-NetRoute -Confirm:$false -Erroraction:Ignore
+Get-NetRoute -DestinationPrefix "$($EC2_METADATA_ADDRESS)/32" -PolicyStore ActiveStore -Erroraction:Ignore | Remove-NetRoute -Confirm:$false -Erroraction:Ignore
+
+# Update routes
+[string]$gateway = (Get-WMIObject -Class Win32_IP4RouteTable | Where { $_.Destination -eq '0.0.0.0' -and $_.Mask -eq '0.0.0.0' } | Sort-Object Metric1 | Select NextHop).NextHop
+[int]$ifIndex = (Get-NetAdapter -InterfaceDescription "Hyper-V Virtual Ethernet*" | Sort-Object | Select -First 1).ifIndex
+New-NetRoute -DestinationPrefix "$($CREDENTIAL_ADDRESS)/32" -InterfaceIndex $ifindex -NextHop $gateway
+New-NetRoute -DestinationPrefix "$($EC2_METADATA_ADDRESS)/32" -InterfaceIndex $ifindex -NextHop $gateway

--- a/misc/windows-deploy/hostsetup.ps1
+++ b/misc/windows-deploy/hostsetup.ps1
@@ -1,4 +1,4 @@
-# Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved
+# Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may
 # not use this file except in compliance with the License. A copy of the
@@ -11,41 +11,236 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+# This setup script is required in order to enable task IAM roles on windows instances.
+$CREDENTIAL_ADDRESS = "169.254.170.2"
+$CREDENTIAL_LISTEN_PORT = "80"
+$CREDENTIAL_CONNECT_PORT = "51679"
+
 $oldActionPref = $ErrorActionPreference
 $ErrorActionPreference = 'Continue'
 
-# This setup script is required in order to enable task IAM roles on windows instances.
-
-# 169.254.170.2:51679 is the IP address used for task IAM roles.
-$credentialAddress = "169.254.170.2"
-$credentialPort = "51679"
-
-$adapter = (Get-NetAdapter -Name "*APIPA*")
-if(!($adapter)) {
-	# APIPA nat adapter controls IP range 169.254.x.x on windows.
-	Add-VMNetworkAdapter -VMNetworkAdapterName "APIPA" -SwitchName nat -ManagementOS
+LogMsg "Checking VMNetwork adapter"
+$VMNetParams = @{
+    SwitchName = 'nat';
+    ManagementOS = 1;
+    Name = "*APIPA*";
+}
+if(!(Get-VMNetworkAdapter @VMNetParams -ErrorAction:Ignore | Select -First 1)) {
+    # APIPA nat adapter controls IP range 169.254.x.x on windows.
+    Add-VMNetworkAdapter -VMNetworkAdapterName "APIPA" -SwitchName nat -ManagementOS
+}
+[int]$delay = 1
+[int]$maxTries = 10
+[bool]$available = $false
+While ($available -eq $false -and $maxTries -ge 0) {
+    try {
+        $vmNetAdapter = Get-VMNetworkAdapter @VMNetParams -ErrorAction:Ignore | Select -First 1
+        if ($vmNetAdapter) {
+            $available = $true
+            break;
+        }
+    } catch {
+        # VM Net Adapter not available yet
+    } finally {
+        LogMsg "VMNetwork adapter not found. Retrying after sleeping $($delay)sec"
+        sleep $delay
+        $maxTries--
+    }
+}
+if ($available -eq $false) {
+    [string]$msg = "There was a problem getting the VMNetwork adapter"
+    LogMsg "ERROR: $msg"
+    throw $msg
+    return
+} else {
+    [string]$vmNetAdapterMac = $vmNetAdapter.MacAddress
+    LogMsg "VMNetwork adapter found with mac: $($vmNetAdapterMac)"
 }
 
-$ifIndex = (Get-NetAdapter -Name "*APIPA*" | Sort-Object | Select ifIndex).ifIndex
-
-$dockerSubnet = (docker network inspect nat | ConvertFrom-Json).IPAM.Config.Subnet
-
-# This address will only exist on systems that have already set up the routes.
-$ip = (Get-NetRoute -InterfaceIndex $ifIndex -DestinationPrefix $dockerSubnet)
-if(!($ip)) {
-
-	# This command tells the APIPA interface that this IP exists.
-	New-NetIPAddress -InterfaceIndex $ifIndex -IPAddress $credentialAddress -PrefixLength 32
-
-	# Enable the default docker IP range to be routable by the APIPA interface.
-	New-NetRoute -DestinationPrefix $dockerSubnet -ifIndex $ifindex
-
-	# Exposes credential port for local windows firewall
-	New-NetFirewallRule -DisplayName "Allow Inbound Port $credentialPort" -Direction Inbound -LocalPort $credentialPort -Protocol TCP -Action Allow
-
-	# This forwards traffic from port 80 and listens on the IAM role IP address.
-	# 'portproxy' doesn't have a powershell module equivalent, but we could move if it becomes available.
-	netsh interface portproxy add v4tov4 listenaddress=$credentialAddress listenport=80 connectaddress=$credentialAddress connectport=$credentialPort
+LogMsg "Checking for network adatper with mac: $($vmNetAdapterMac)"
+[int]$delay = 2
+[int]$maxTries = 30
+[bool]$available = $false
+While (-not $available -and $maxTries -ge 0) {
+    try {
+        $netAdapter = Get-NetAdapter | Where {$_.MacAddress.Replace('-','') -eq $vmNetAdapterMac}
+        if ($netAdapter) {
+            $available = $true
+            LogMsg "Network adapter found."
+            Break;
+        }
+    } catch {
+        # Net Adapter not available yet
+    } finally {
+        LogMsg "Network adapter not found. Retrying after sleeping $($delay)sec"
+        sleep $delay
+        $maxTries--
+    }
 }
+if ($available -eq $false) {
+    [string]$msg = "There was a problem getting the local network adapter adapter associated with mac: $($vmNetAdapterMac)"
+    LogMsg "ERROR: $msg"
+    throw $msg
+    return
+} else {
+    [int]$InterfaceIndex = $netAdapter.InterfaceIndex
+    LogMsg "Network adapter found with mac $($vmNetAdapterMac) on interface $($InterfaceIndex)"
+}
+
+LogMsg "Getting subnet info from docker..."
+try {
+    $dockerCmd = "docker network inspect nat"
+    $dockerNatConfigOutput = Invoke-Expression -Command $dockerCmd
+    $dockerNatConfig = $dockerNatConfigOutput | ConvertFrom-Json
+    $dockerSubnet = $dockerNatConfig.IPAM.Config.Subnet
+    LogMsg "Docker subnet found: $($dockerSubnet)"
+} catch {
+    [string]$msg = "There was a problem getting the docker output. Command: $($dockerCmd), CommandOutput: $($dockerNatConfigOutput), Subnet: $($dockerSubnet), Exception: $($_.Exception.Message)"
+    LogMsg "ERROR: $msg"
+    throw $msg
+    return
+}
+
+LogMsg "Getting net ip address"
+$IPAddrParams = @{
+    InterfaceIndex = $InterfaceIndex;
+    IPAddress = $CREDENTIAL_ADDRESS;
+    PrefixLength = 32;
+}
+if(!(Get-NetIPAddress @IPAddrParams -ErrorAction:Ignore)) {
+    LogMsg "IP address not found. $($IPAddrParams | Out-String)"
+    # This command creates a virtual ip for the APIPA interface
+    LogMsg "Creating new virtual network adapter ip..."
+    $newIpOutput = New-NetIPAddress @IPAddrParams
+    LogMsg "Virtual network adapter ip created: $($newIpOutput)"
+    LogMsg "Waiting for it to become available on the device..."
+
+    [int]$delay = 1
+    [int]$maxTries = 10
+    [bool]$available = $false
+    While (-not $available -and $maxTries -ge 0) {
+        try {
+            $IPAddr = Get-NetIPAddress @IPAddrParams
+            if ($IPAddr) {
+                $available = $true
+                Break;
+            }
+        } catch {
+            # Prevent race condition where the adapter has multiple addresses before our new ip is assigned
+            # Note: Allowing this race condition can cause the netsh interface portproxy setup to  result
+            #       in the network adapter in an unrecoverable bad state where the proxy is unable to
+            #       listen on port 80 because the port is in use by a non-functional proxy rule.
+        } finally {
+            LogMsg "Waiting for ip $($CREDENTIAL_ADDRESS) to become available on interface index $($InterfaceIndex)... (sleeping $($delay))"
+            sleep $delay
+            $maxTries--
+        }
+    }
+    
+}
+if ($available -eq $false) {
+    [string]$msg = "There was a problem getting the net ip address for the virtual adapter"
+    LogMsg "ERROR: $msg"
+    throw $msg
+    return
+} else {
+    LogMsg "IP address available. $($IPAddrParams | Out-String)"
+}
+
+$NetRouteParams = @{
+    DestinationPrefix = $dockerSubnet;
+    InterfaceIndex = $InterfaceIndex;
+}
+if (-not (Get-NetRoute @NetRouteParams)) {
+    LogMsg "Route not found. $($NetRouteParams  | Out-String)"
+    # Enable the default docker IP range to be routable by the APIPA interface.
+    LogMsg "Setting up new route for $($dockerSubnet) on adapter $($InterfaceIndex)..."
+    $newRouteOutput = New-NetRoute @NetRouteParams
+    LogMsg "Route setup complete: $($newRouteOutput)"
+}
+if (-not (Get-NetRoute @NetRouteParams)) {
+    [string]$msg = "Route not found. $($NetRouteParams  | Out-String)"
+    LogMsg "ERROR: $msg"
+    throw $msg
+    return
+}
+
+$NewRuleParam = @{
+    Action = 'Allow';
+    DisplayName = "Allow Inbound Port $CREDENTIAL_CONNECT_PORT";
+    Direction = 'Inbound';
+    LocalPort = $CREDENTIAL_CONNECT_PORT;
+    Protocol = 'TCP';
+}
+if (-not (Get-NetFirewallRule | ?{   $_.Action -eq $NewRuleParam.Action `
+                                -and $_.Direction -eq $NewRuleParam.Direction `
+                                -and $_.DisplayName -eq $NewRuleParam.DisplayName})) {
+    LogMsg "Route not found.  $($NewRuleParam  | Out-String)"
+    # Exposes credential port for local windows firewall
+    LogMsg "Setting up new inbound firewall rule to allow $($NewRuleParam.Protocol) $($NewRuleParam.LocalPort)..."
+    $newFWOutput = New-NetFirewallRule @NewRuleParam
+    LogMsg "Firewall rule setup complete: $($newFWOutput)"
+}
+if (-not (Get-NetFirewallRule | ?{   $_.Action -eq $NewRuleParam.Action `
+                                -and $_.Direction -eq $NewRuleParam.Direction `
+                                -and $_.DisplayName -eq $NewRuleParam.DisplayName})) {
+    [string]$msg = "Firewall Rule not found. $($NewRuleParam  | Out-String)"
+    LogMsg "ERROR: $msg"
+    throw $msg
+    return
+}
+
+# This forwards traffic from port 80 and listens on the IAM role IP address.
+# TODO: Convert this to powershell shouyld 'netsh interface portproxy' have a powershell cmdlet/module equivalent.
+$netshShowAllCmd = "netsh interface portproxy show all"
+$netshReturn = Invoke-Expression -Command $netshShowAllCmd
+LogMsg $netshShowAllCmd
+Foreach ($line in $netshReturn) {
+    LogMsg $line
+}
+
+LogMsg "Setting up new ipv4 interface proxy to forward traffic"
+LogMsg "  from $($CREDENTIAL_ADDRESS):$($CREDENTIAL_LISTEN_PORT)"
+LogMsg "  to $($CREDENTIAL_ADDRESS):$($CREDENTIAL_CONNECT_PORT)"
+try {
+    [string]$netshPortProxyCmd = "netsh interface portproxy add v4tov4 listenaddress=$CREDENTIAL_ADDRESS " + `
+                                                                      "listenport=$CREDENTIAL_LISTEN_PORT " + `
+                                                                      "connectaddress=$CREDENTIAL_ADDRESS " + `
+                                                                      "connectport=$CREDENTIAL_CONNECT_PORT"
+    $netshReturn = Invoke-Expression -Command $netshPortProxyCmd
+} catch {
+    [string]$msg = "There was a problem setting up the traffic forwarding. Exception: $($_.Exception.Message)"
+    LogMsg "ERROR: $msg"
+    throw $msg
+    return
+}
+Foreach ($line in $netshReturn) {
+    LogMsg $line
+}
+
+LogMsg "Checking port forwarding..."
+try {
+    $result = Test-NetConnection -ComputerName $CREDENTIAL_ADDRESS -Port $CREDENTIAL_LISTEN_PORT
+} catch {
+    [string]$msg = "There was a problem validating TPC port forwarding on $($CREDENTIAL_ADDRESS):$($CREDENTIAL_LISTEN_PORT). Exception: $($_.Exception.Message)"    
+    LogMsg "ERROR: $msg"
+    throw $msg
+} finally {
+    $netshReturn = Invoke-Expression -Command $netshShowAllCmd
+    LogMsg $netshShowAllCmd
+    Foreach ($line in $netshReturn) {
+        LogMsg $line
+    }
+}
+if (-Not $result -or $result.TcpTestSucceeded -ne "True") {
+    [string]$msg = "There was a problem validating TPC port forwarding on $($CREDENTIAL_ADDRESS):$($CREDENTIAL_LISTEN_PORT)"
+    LogMsg "ERROR: $msg"
+    throw $msg
+    return
+} else {
+    LogMsg "TcpTestSucceeded: $($result.TcpTestSucceeded)"
+}
+LogMsg "Port forwarding setup complete."
 
 $ErrorActionPreference=$oldActionPref
+LogMsg "Host setup complete."

--- a/misc/windows-deploy/user-data.ps1
+++ b/misc/windows-deploy/user-data.ps1
@@ -5,6 +5,7 @@
 [Environment]::SetEnvironmentVariable("ECS_CLUSTER", "windows", "Machine")
 [Environment]::SetEnvironmentVariable("ECS_ENABLE_TASK_IAM_ROLE", "false", "Machine")
 $agentVersion = 'v1.14.5'
+
 $agentZipUri = "https://s3.amazonaws.com/amazon-ecs-agent/ecs-agent-windows-$agentVersion.zip"
 $agentZipMD5Uri = "$agentZipUri.md5"
 

--- a/misc/windows-iam/application.ps1
+++ b/misc/windows-iam/application.ps1
@@ -11,7 +11,9 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-$gateway = (Get-WMIObject -Class Win32_IP4RouteTable | Where { $_.Destination -eq '0.0.0.0' -and $_.Mask -eq '0.0.0.0' } | Sort-Object Metric1 | Select NextHop).NextHop
-$ifIndex = (Get-NetAdapter -InterfaceDescription "Hyper-V Virtual Ethernet*" | Sort-Object | Select ifIndex).ifIndex
-route -p add 169.254.170.2 mask 255.255.255.255 0.0.0.0
-New-NetRoute -DestinationPrefix 169.254.169.254/32 -InterfaceIndex $ifindex -NextHop $gateway
+$CREDENTIAL_ADDRESS = "169.254.170.2"
+$EC2_METADATA_ADDRESS = "169.254.169.254"
+[string]$gateway = (Get-WMIObject -Class Win32_IP4RouteTable | Where { $_.Destination -eq '0.0.0.0' -and $_.Mask -eq '0.0.0.0' } | Sort-Object Metric1 | Select NextHop).NextHop
+[int]$ifIndex = (Get-NetAdapter -InterfaceDescription "Hyper-V Virtual Ethernet*" | Sort-Object | Select -First 1).ifIndex
+New-NetRoute -DestinationPrefix "$($CREDENTIAL_ADDRESS)/32" -InterfaceIndex $ifindex -NextHop $gateway
+New-NetRoute -DestinationPrefix "$($EC2_METADATA_ADDRESS)/32" -InterfaceIndex $ifindex -NextHop $gateway


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
- Improved reliability and maintainability of hostsetup.ps1
- New containersetup.ps1 to configure windows container routes
- Improved maintainability and readabilty of application.ps1

### Implementation details
<!-- How are the changes implemented? -->
- Fixes/refactoring to hostsetup.ps1 that adds a more robust way of setting up the required host routes and virtual network adapters such that it is both idempotent, and avoids the breaking race-condition where the adapter is created, the ip address is assigned, and the port proxy is created before the adapter has completed assigning the ip address resulting in a non-removable "ghost port proxy" that prevents new port proxies from being created with that port. Also pulled hard coded values out to variables for readability and maintainability.
- New containersetup.ps1 for users to execute within a windows container to setup network routes withing the container to allow EC2 meta-data and AWS IAM roles to work correctly.
- Updates to application.ps1 to replace cmd commands with powershell commandlets, and pulled hard coded values out to variables for readability and maintainability.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [ ] Testing in progress...
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
windows: Updates to ps1 setup scripts

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: yes <!-- yes -->
