### PR TITLE
ecs_client/model, functional_tests: updated model, functional tests for devices and init fields

### DIFF
--- a/agent/ecs_client/model/api/api-2.json
+++ b/agent/ecs_client/model/api/api-2.json
@@ -552,6 +552,18 @@
       "type":"integer",
       "box":true
     },
+    "DeviceCgroupPermission":{
+      "type":"string",
+      "enum":[
+        "read",
+        "write",
+        "mknod"
+      ]
+    },
+    "DeviceCgroupPermissions":{
+      "type":"list",
+      "member":{"shape":"DeviceCgroupPermission"}
+    },
     "ClientException":{
       "type":"structure",
       "members":{
@@ -917,6 +929,19 @@
         "STOPPED"
       ]
     },
+    "Device":{
+      "type":"structure",
+      "required":["hostPath"],
+      "members":{
+        "hostPath":{"shape":"String"},
+        "containerPath":{"shape":"String"},
+        "permissions":{"shape":"DeviceCgroupPermissions"}
+      }
+    },
+    "DevicesList":{
+      "type":"list",
+      "member":{"shape":"Device"}
+    },
     "DiscoverPollEndpointRequest":{
       "type":"structure",
       "members":{
@@ -997,7 +1022,9 @@
     "LinuxParameters":{
       "type":"structure",
       "members":{
-        "capabilities":{"shape":"KernelCapabilities"}
+        "capabilities":{"shape":"KernelCapabilities"},
+        "devices":{"shape":"DevicesList"},
+        "initProcessEnabled":{"shape":"BoxedBoolean"}
       }
     },
     "ListAttributesRequest":{

--- a/agent/ecs_client/model/ecs/api.go
+++ b/agent/ecs_client/model/ecs/api.go
@@ -4180,6 +4180,11 @@ func (s *ContainerDefinition) Validate() error {
 			}
 		}
 	}
+	if s.LinuxParameters != nil {
+		if err := s.LinuxParameters.Validate(); err != nil {
+			invalidParams.AddNested("LinuxParameters", err.(request.ErrInvalidParams))
+		}
+	}
 	if s.LogConfiguration != nil {
 		if err := s.LogConfiguration.Validate(); err != nil {
 			invalidParams.AddNested("LogConfiguration", err.(request.ErrInvalidParams))
@@ -5790,6 +5795,58 @@ func (s *DescribeTasksOutput) SetTasks(v []*Task) *DescribeTasksOutput {
 	return s
 }
 
+type Device struct {
+	_ struct{} `type:"structure"`
+
+	ContainerPath *string `locationName:"containerPath" type:"string"`
+
+	// HostPath is a required field
+	HostPath *string `locationName:"hostPath" type:"string" required:"true"`
+
+	Permissions []*string `locationName:"permissions" type:"list"`
+}
+
+// String returns the string representation
+func (s Device) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s Device) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Device) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Device"}
+	if s.HostPath == nil {
+		invalidParams.Add(request.NewErrParamRequired("HostPath"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetContainerPath sets the ContainerPath field's value.
+func (s *Device) SetContainerPath(v string) *Device {
+	s.ContainerPath = &v
+	return s
+}
+
+// SetHostPath sets the HostPath field's value.
+func (s *Device) SetHostPath(v string) *Device {
+	s.HostPath = &v
+	return s
+}
+
+// SetPermissions sets the Permissions field's value.
+func (s *Device) SetPermissions(v []*string) *Device {
+	s.Permissions = v
+	return s
+}
+
 type DiscoverPollEndpointInput struct {
 	_ struct{} `type:"structure"`
 
@@ -6045,6 +6102,10 @@ type LinuxParameters struct {
 	_ struct{} `type:"structure"`
 
 	Capabilities *KernelCapabilities `locationName:"capabilities" type:"structure"`
+
+	Devices []*Device `locationName:"devices" type:"list"`
+
+	InitProcessEnabled *bool `locationName:"initProcessEnabled" type:"boolean"`
 }
 
 // String returns the string representation
@@ -6057,9 +6118,41 @@ func (s LinuxParameters) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *LinuxParameters) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "LinuxParameters"}
+	if s.Devices != nil {
+		for i, v := range s.Devices {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Devices", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // SetCapabilities sets the Capabilities field's value.
 func (s *LinuxParameters) SetCapabilities(v *KernelCapabilities) *LinuxParameters {
 	s.Capabilities = v
+	return s
+}
+
+// SetDevices sets the Devices field's value.
+func (s *LinuxParameters) SetDevices(v []*Device) *LinuxParameters {
+	s.Devices = v
+	return s
+}
+
+// SetInitProcessEnabled sets the InitProcessEnabled field's value.
+func (s *LinuxParameters) SetInitProcessEnabled(v bool) *LinuxParameters {
+	s.InitProcessEnabled = &v
 	return s
 }
 
@@ -9562,6 +9655,17 @@ const (
 
 	// DesiredStatusStopped is a DesiredStatus enum value
 	DesiredStatusStopped = "STOPPED"
+)
+
+const (
+	// DeviceCgroupPermissionRead is a DeviceCgroupPermission enum value
+	DeviceCgroupPermissionRead = "read"
+
+	// DeviceCgroupPermissionWrite is a DeviceCgroupPermission enum value
+	DeviceCgroupPermissionWrite = "write"
+
+	// DeviceCgroupPermissionMknod is a DeviceCgroupPermission enum value
+	DeviceCgroupPermissionMknod = "mknod"
 )
 
 const (

--- a/agent/functional_tests/testdata/simpletests_unix/devices.json
+++ b/agent/functional_tests/testdata/simpletests_unix/devices.json
@@ -1,0 +1,10 @@
+{
+  "Name": "Devices",
+  "Description": "checks that adding devices works",
+  "TaskDefinition": "devices",
+  "Version": ">=1.0.0",
+  "Timeout": "2m",
+  "ExitCodes": {
+    "exit": 42
+  }
+}

--- a/agent/functional_tests/testdata/simpletests_unix/init-process.json
+++ b/agent/functional_tests/testdata/simpletests_unix/init-process.json
@@ -1,0 +1,10 @@
+{
+  "Name": "InitProcessEnabled",
+  "Description": "checks that enabling init process works",
+  "TaskDefinition": "init-process",
+  "Version": ">=1.15.0",
+  "Timeout": "2m",
+  "ExitCodes": {
+    "exit": 42
+  }
+}

--- a/agent/functional_tests/testdata/taskdefinitions/devices/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/devices/task-definition.json
@@ -1,0 +1,19 @@
+{
+  "family": "ecsftest-devices",
+  "containerDefinitions": [{
+    "image": "127.0.0.1:51670/ubuntu:latest",
+    "name": "exit",
+    "cpu": 10,
+    "memory": 10,
+    "linuxParameters": {
+      "devices":[
+        {
+          "hostPath": "/dev/xvda",
+          "containerPath": "/dev/sda",
+          "permissions": ["read"]
+        }
+      ]
+    },
+    "command": ["sh", "-c", "if ls /dev/sda && ! fdisk /dev/sda; then exit 42; else exit 1; fi"]
+  }]
+}

--- a/agent/functional_tests/testdata/taskdefinitions/init-process/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/init-process/task-definition.json
@@ -1,0 +1,13 @@
+{
+  "family": "ecsftest-init-process",
+  "containerDefinitions": [{
+    "image": "127.0.0.1:51670/ubuntu:latest",
+    "name": "exit",
+    "cpu": 10,
+    "memory": 10,
+    "linuxParameters": {
+      "initProcessEnabled":true
+    },
+    "command": ["sh", "-c", "if pidof init == 1; then exit 42; else exit 1; fi"]
+  }]
+}

--- a/agent/functional_tests/tests/generated/simpletests_unix/simpletests_generated_unix_test.go
+++ b/agent/functional_tests/tests/generated/simpletests_unix/simpletests_generated_unix_test.go
@@ -147,6 +147,46 @@ func TestDataVolume2(t *testing.T) {
 
 }
 
+// TestDevices checks that adding devices works
+func TestDevices(t *testing.T) {
+
+	// Parallel is opt in because resource constraints could cause test failures
+	// on smaller instances
+	if os.Getenv("ECS_FUNCTIONAL_PARALLEL") != "" {
+		t.Parallel()
+	}
+	agent := RunAgent(t, nil)
+	defer agent.Cleanup()
+	agent.RequireVersion(">=1.0.0")
+
+	td, err := GetTaskDefinition("devices")
+	if err != nil {
+		t.Fatalf("Could not register task definition: %v", err)
+	}
+	testTasks, err := agent.StartMultipleTasks(t, td, 1)
+	if err != nil {
+		t.Fatalf("Could not start task: %v", err)
+	}
+	timeout, err := time.ParseDuration("2m")
+	if err != nil {
+		t.Fatalf("Could not parse timeout: %#v", err)
+	}
+
+	for _, testTask := range testTasks {
+		err = testTask.WaitStopped(timeout)
+		if err != nil {
+			t.Fatalf("Timed out waiting for task to reach stopped. Error %#v, task %#v", err, testTask)
+		}
+
+		if exit, ok := testTask.ContainerExitcode("exit"); !ok || exit != 42 {
+			t.Errorf("Expected exit to exit with 42; actually exited (%v) with %v", ok, exit)
+		}
+
+		defer agent.SweepTask(testTask)
+	}
+
+}
+
 // TestDisableNetworking Check that disable networking works
 func TestDisableNetworking(t *testing.T) {
 
@@ -320,6 +360,46 @@ func TestHostname(t *testing.T) {
 	agent.RequireVersion(">=1.5.0")
 
 	td, err := GetTaskDefinition("hostname")
+	if err != nil {
+		t.Fatalf("Could not register task definition: %v", err)
+	}
+	testTasks, err := agent.StartMultipleTasks(t, td, 1)
+	if err != nil {
+		t.Fatalf("Could not start task: %v", err)
+	}
+	timeout, err := time.ParseDuration("2m")
+	if err != nil {
+		t.Fatalf("Could not parse timeout: %#v", err)
+	}
+
+	for _, testTask := range testTasks {
+		err = testTask.WaitStopped(timeout)
+		if err != nil {
+			t.Fatalf("Timed out waiting for task to reach stopped. Error %#v, task %#v", err, testTask)
+		}
+
+		if exit, ok := testTask.ContainerExitcode("exit"); !ok || exit != 42 {
+			t.Errorf("Expected exit to exit with 42; actually exited (%v) with %v", ok, exit)
+		}
+
+		defer agent.SweepTask(testTask)
+	}
+
+}
+
+// TestInitProcessEnabled checks that enabling init process works
+func TestInitProcessEnabled(t *testing.T) {
+
+	// Parallel is opt in because resource constraints could cause test failures
+	// on smaller instances
+	if os.Getenv("ECS_FUNCTIONAL_PARALLEL") != "" {
+		t.Parallel()
+	}
+	agent := RunAgent(t, nil)
+	defer agent.Cleanup()
+	agent.RequireVersion(">=1.14.5")
+
+	td, err := GetTaskDefinition("init-process")
 	if err != nil {
 		t.Fatalf("Could not register task definition: %v", err)
 	}


### PR DESCRIPTION
### Summary
Model changes to Container Definition for enabling devices and init for Linux containers.
Functional tests

### Implementation details
Functional tests that verify:
* If device is added to the container with the right cgroup permissions
* If init flag is enabled, then init process is present in the container

### Testing
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes

### Description for the changelog

### Licensing
This contribution is under the terms of the Apache 2.0 License: yes
