### PR TITLE
eni attachment state change: ignore expired

### DIFF
--- a/agent/api/eniattachment.go
+++ b/agent/api/eniattachment.go
@@ -90,6 +90,15 @@ func (eni *ENIAttachment) StopAckTimer() {
 	eni.ackTimer.Stop()
 }
 
+// HasExpired returns true if the ENI attachment object has exceeded the
+// threshold for notifying the backend of the attachment
+func (eni *ENIAttachment) HasExpired() bool {
+	eni.guard.RLock()
+	defer eni.guard.RUnlock()
+
+	return time.Now().After(eni.ExpiresAt)
+}
+
 // String returns a string representation of the ENI Attachment
 func (eni *ENIAttachment) String() string {
 	eni.guard.RLock()

--- a/agent/api/eniattachment_test.go
+++ b/agent/api/eniattachment_test.go
@@ -68,3 +68,26 @@ func TestStartTimerErrorWhenExpiresAtIsInThePast(t *testing.T) {
 	}
 	assert.Error(t, attachment.StartTimer(func() {}))
 }
+
+func TestHasExpired(t *testing.T) {
+	for _, tc := range []struct {
+		expiresAt int64
+		expected  bool
+		name      string
+	}{
+		{time.Now().Unix() - 1, true, "expiresAt in past returns true"},
+		{time.Now().Unix() + 10, false, "expiresAt in future returns false"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			attachment := &ENIAttachment{
+				TaskARN:          taskARN,
+				AttachmentARN:    attachmentARN,
+				AttachStatusSent: attachSent,
+				MACAddress:       mac,
+				Status:           ENIAttachmentNone,
+				ExpiresAt:        time.Unix(tc.expiresAt, 0),
+			}
+			assert.Equal(t, tc.expected, attachment.HasExpired())
+		})
+	}
+}

--- a/agent/ecscni/plugin.go
+++ b/agent/ecscni/plugin.go
@@ -124,7 +124,7 @@ func (client *cniClient) ReleaseIPResource(cfg *Config) error {
 		Plugins:    []*libcni.NetworkConfig{ipamConfig},
 	}
 
-	seelog.Debugf("Releasing the ip resource from ipam db, id: [%s], ip: [%s]", cfg.ID, cfg.IPAMV4Address)
+	seelog.Debugf("Releasing the ip resource from ipam db, id: [%s], ip: [%v]", cfg.ID, cfg.IPAMV4Address)
 	os.Setenv("ECS_CNI_LOGLEVEL", logger.GetLevel())
 	defer os.Unsetenv("ECS_CNI_LOGLEVEL")
 	return client.libcni.DelNetworkList(networkConfigList, cns)

--- a/agent/eventhandler/handler_test.go
+++ b/agent/eventhandler/handler_test.go
@@ -277,20 +277,6 @@ func TestCleanupTaskEventAfterSubmit(t *testing.T) {
 	assert.Len(t, handler.tasksToEvents, 0)
 }
 
-func TestShouldBeSent(t *testing.T) {
-	sendableEvent := newSendableContainerEvent(api.ContainerStateChange{
-		Status: api.ContainerStopped,
-	})
-
-	if sendableEvent.taskShouldBeSent() {
-		t.Error("Container event should not be sent as a task")
-	}
-
-	if !sendableEvent.containerShouldBeSent() {
-		t.Error("Container should be sent if it's the first try")
-	}
-}
-
 func containerEvent(arn string) statechange.Event {
 	return api.ContainerStateChange{TaskArn: arn, ContainerName: "containerName", Status: api.ContainerRunning, Container: &api.Container{}}
 }

--- a/agent/eventhandler/task_handler_types.go
+++ b/agent/eventhandler/task_handler_types.go
@@ -93,6 +93,7 @@ func (event *sendableEvent) taskAttachmentShouldBeSent() bool {
 	tevent := event.taskChange
 	return tevent.Status == api.TaskStatusNone && // Task Status is not set for attachments as task record has yet to be streamed down
 		tevent.Attachment != nil && // Task has attachment records
+		!tevent.Attachment.HasExpired() && // ENI attachment ack timestamp hasn't expired
 		!tevent.Attachment.IsSent() // Task status hasn't already been sent
 }
 

--- a/agent/eventhandler/task_handler_types_test.go
+++ b/agent/eventhandler/task_handler_types_test.go
@@ -1,0 +1,153 @@
+// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package eventhandler
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/aws/amazon-ecs-agent/agent/api"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShouldContainerEventBeSent(t *testing.T) {
+	event := newSendableContainerEvent(api.ContainerStateChange{
+		Status: api.ContainerStopped,
+	})
+	assert.Equal(t, true, event.containerShouldBeSent())
+	assert.Equal(t, false, event.taskShouldBeSent())
+}
+
+func TestShouldTaskEventBeSent(t *testing.T) {
+	for _, tc := range []struct {
+		event        *sendableEvent
+		shouldBeSent bool
+	}{
+		{
+			// We don't send a task event to backend if task status == NONE
+			event: newSendableTaskEvent(api.TaskStateChange{
+				Status: api.TaskStatusNone,
+			}),
+			shouldBeSent: false,
+		},
+		{
+			// task status == RUNNING should be sent to backend
+			event: newSendableTaskEvent(api.TaskStateChange{
+				Status: api.TaskRunning,
+			}),
+			shouldBeSent: true,
+		},
+		{
+			// task event will not be sent if sent status >= task status
+			event: newSendableTaskEvent(api.TaskStateChange{
+				Status: api.TaskRunning,
+				Task: &api.Task{
+					SentStatusUnsafe: api.TaskRunning,
+				},
+			}),
+			shouldBeSent: false,
+		},
+		{
+			// this is a valid event as task status >= sent status
+			event: newSendableTaskEvent(api.TaskStateChange{
+				Status: api.TaskStopped,
+				Task: &api.Task{
+					SentStatusUnsafe: api.TaskRunning,
+				},
+			}),
+			shouldBeSent: true,
+		},
+	} {
+		t.Run(fmt.Sprintf("Event[%s] should be sent[%t]", tc.event.String(), tc.shouldBeSent), func(t *testing.T) {
+			assert.Equal(t, tc.shouldBeSent, tc.event.taskShouldBeSent())
+			assert.Equal(t, false, tc.event.containerShouldBeSent())
+			assert.Equal(t, false, tc.event.taskAttachmentShouldBeSent())
+		})
+	}
+}
+
+func TestShouldTaskAttachmentEventBeSent(t *testing.T) {
+	for _, tc := range []struct {
+		event                  *sendableEvent
+		attachmentShouldBeSent bool
+		taskShouldBeSent       bool
+	}{
+		{
+			// ENI Attachment is only sent if task status == NONE
+			event: newSendableTaskEvent(api.TaskStateChange{
+				Status: api.TaskStopped,
+			}),
+			attachmentShouldBeSent: false,
+			taskShouldBeSent:       true,
+		},
+		{
+			// ENI Attachment is only sent if task status == NONE and if
+			// the event has a non nil attachment object
+			event: newSendableTaskEvent(api.TaskStateChange{
+				Status: api.TaskStatusNone,
+			}),
+			attachmentShouldBeSent: false,
+			taskShouldBeSent:       false,
+		},
+		{
+			// ENI Attachment is only sent if task status == NONE and if
+			// the event has a non nil attachment object and if expiration
+			// ack timeout is set for future
+			event: newSendableTaskEvent(api.TaskStateChange{
+				Status: api.TaskStatusNone,
+				Attachment: &api.ENIAttachment{
+					ExpiresAt:        time.Unix(time.Now().Unix()-1, 0),
+					AttachStatusSent: false,
+				},
+			}),
+			attachmentShouldBeSent: false,
+			taskShouldBeSent:       false,
+		},
+		{
+			// ENI Attachment is only sent if task status == NONE and if
+			// the event has a non nil attachment object and if expiration
+			// ack timeout is set for future and if attachment status hasn't
+			// already been sent
+			event: newSendableTaskEvent(api.TaskStateChange{
+				Status: api.TaskStatusNone,
+				Attachment: &api.ENIAttachment{
+					ExpiresAt:        time.Unix(time.Now().Unix()+10, 0),
+					AttachStatusSent: true,
+				},
+			}),
+			attachmentShouldBeSent: false,
+			taskShouldBeSent:       false,
+		},
+		{
+			// Valid attachment event, ensure that its sent
+			event: newSendableTaskEvent(api.TaskStateChange{
+				Status: api.TaskStatusNone,
+				Attachment: &api.ENIAttachment{
+					ExpiresAt:        time.Unix(time.Now().Unix()+10, 0),
+					AttachStatusSent: false,
+				},
+			}),
+			attachmentShouldBeSent: true,
+			taskShouldBeSent:       false,
+		},
+	} {
+		t.Run(fmt.Sprintf("Event[%s] should be sent[attachment=%t;task=%t]",
+			tc.event.String(), tc.attachmentShouldBeSent, tc.taskShouldBeSent), func(t *testing.T) {
+			assert.Equal(t, tc.attachmentShouldBeSent, tc.event.taskAttachmentShouldBeSent())
+			assert.Equal(t, tc.taskShouldBeSent, tc.event.taskShouldBeSent())
+			assert.Equal(t, false, tc.event.containerShouldBeSent())
+		})
+	}
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Ignore expired eni attachment state change events

### Implementation details
<!-- How are the changes implemented? -->

This change fixes a bug with the Agent's event submission
logic, where if the ENI attachment is ignored if the
ack time sent by the backend has expired. Not doing this
will result in the Agent forever trying to send the
attachment event to the backend as we can't reliably
distinguish between throttle errors and invalid input
errors from SubmitTaskStateChange response.


### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [X] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [X] Integration tests on Linux (`make run-integ-tests`) pass
- [X] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [X] Functional tests on Linux (`make run-functional-tests`) pass
- [X] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass
- [X] Manual Testing: Verified that Agent stops sending `SubmitTaskStateChange` events on by artificially introducing a delay to simulate timing out expiration time.

New tests cover the changes: Yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
None

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: Yes
