### PR TITLE
app: ensure that old tasks are compatible with TaskCPUMemLimits

### DIFF
--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -115,7 +115,6 @@ func (agent *ecsAgent) capabilities() ([]*ecs.Attribute, error) {
 		}
 	}
 
-	// TODO we also need to disable this if agent already managing older tasks
 	if agent.cfg.TaskCPUMemLimit.Enabled() {
 		if _, ok := supportedVersions[dockerclient.Version_1_22]; ok {
 			capabilities = appendNameOnlyAttribute(capabilities, attributePrefix+capabilityTaskCPUMemLimit)

--- a/agent/app/agent_compatibility_linux.go
+++ b/agent/app/agent_compatibility_linux.go
@@ -1,0 +1,63 @@
+// +build linux
+
+// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package app
+
+import (
+	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/engine"
+
+	"github.com/cihub/seelog"
+	"github.com/pkg/errors"
+)
+
+// checkCompatibility (for linux) ensures that the running task engine is capable for running with the TaskCPUMemLimit
+// flag enabled. It will disable the feature if it determines that it is incompatible and the feature isn't explicitly
+// enabled.
+func (agent *ecsAgent) checkCompatibility(engine engine.TaskEngine) error {
+
+	// We don't need to do these checks if CPUMemLimit is disabled
+	if !agent.cfg.TaskCPUMemLimit.Enabled() {
+		return nil
+	}
+
+	tasks, err := engine.ListTasks()
+	if err != nil {
+		return err
+	}
+
+	// Loop over each task to determine if the state is compatible with the running version of agent and its options
+	compatible := true
+	for _, task := range tasks {
+		if !task.MemoryCPULimitsEnabled {
+			seelog.Warnf("App: task from state file is not compatible with TaskCPUMemLimit setting, because it is not using ecs' cgroup hierarchy: %s", task.Arn)
+			compatible = false
+			break
+		}
+	}
+
+	if compatible {
+		return nil
+	}
+
+	if agent.cfg.TaskCPUMemLimit == config.ExplicitlyEnabled {
+		return errors.New("App: unable to load old tasks because TaskCPUMemLimits setting is incompatible with old state.")
+	}
+
+	seelog.Warn("App: disabling TaskCPUMemLimit.")
+	agent.cfg.TaskCPUMemLimit = config.ExplicitlyDisabled
+
+	return nil
+}

--- a/agent/app/agent_compatibility_linux_test.go
+++ b/agent/app/agent_compatibility_linux_test.go
@@ -1,0 +1,132 @@
+// +build linux
+
+// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package app
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/amazon-ecs-agent/agent/api"
+	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/ec2"
+	"github.com/aws/amazon-ecs-agent/agent/eventstream"
+	"github.com/aws/amazon-ecs-agent/agent/statemanager/mocks"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCompatibilityEnabledSuccess(t *testing.T) {
+	ctrl, creds, state, images, _, _, stateManagerFactory, saveableOptionFactory := setup(t)
+	defer ctrl.Finish()
+	stateManager := mock_statemanager.NewMockStateManager(ctrl)
+
+	cfg := getTestConfig()
+	cfg.Checkpoint = true
+	cfg.TaskCPUMemLimit = config.DefaultEnabled
+
+	agent := &ecsAgent{
+		cfg:                   &cfg,
+		stateManagerFactory:   stateManagerFactory,
+		saveableOptionFactory: saveableOptionFactory,
+		ec2MetadataClient:     ec2.NewBlackholeEC2MetadataClient(),
+	}
+
+	gomock.InOrder(
+		saveableOptionFactory.EXPECT().AddSaveable(gomock.Any(), gomock.Any()).AnyTimes(),
+		stateManagerFactory.EXPECT().NewStateManager(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(stateManager, nil),
+		stateManager.EXPECT().Load().AnyTimes(),
+		state.EXPECT().AllTasks().Return([]*api.Task{}),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	containerChangeEventStream := eventstream.NewEventStream("events", ctx)
+	_, _, err := agent.newTaskEngine(containerChangeEventStream, creds, state, images)
+
+	assert.NoError(t, err)
+	assert.True(t, cfg.TaskCPUMemLimit.Enabled())
+}
+
+func TestCompatibilityDefaultEnabledFail(t *testing.T) {
+	ctrl, creds, state, images, _, _, stateManagerFactory, saveableOptionFactory := setup(t)
+	defer ctrl.Finish()
+	stateManager := mock_statemanager.NewMockStateManager(ctrl)
+
+	cfg := getTestConfig()
+	cfg.Checkpoint = true
+	cfg.TaskCPUMemLimit = config.DefaultEnabled
+
+	agent := &ecsAgent{
+		cfg:                   &cfg,
+		stateManagerFactory:   stateManagerFactory,
+		saveableOptionFactory: saveableOptionFactory,
+		ec2MetadataClient:     ec2.NewBlackholeEC2MetadataClient(),
+	}
+	gomock.InOrder(
+		saveableOptionFactory.EXPECT().AddSaveable(gomock.Any(), gomock.Any()).AnyTimes(),
+		stateManagerFactory.EXPECT().NewStateManager(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(stateManager, nil),
+		stateManager.EXPECT().Load().AnyTimes(),
+		state.EXPECT().AllTasks().Return(getTaskListWithOneBadTask()),
+	)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	containerChangeEventStream := eventstream.NewEventStream("events", ctx)
+	_, _, err := agent.newTaskEngine(containerChangeEventStream, creds, state, images)
+
+	assert.NoError(t, err)
+	assert.False(t, cfg.TaskCPUMemLimit.Enabled())
+}
+
+func TestCompatibilityExplicitlyEnabledFail(t *testing.T) {
+	ctrl, creds, state, images, _, _, stateManagerFactory, saveableOptionFactory := setup(t)
+	defer ctrl.Finish()
+	stateManager := mock_statemanager.NewMockStateManager(ctrl)
+
+	cfg := getTestConfig()
+	cfg.Checkpoint = true
+	cfg.TaskCPUMemLimit = config.ExplicitlyEnabled
+
+	agent := &ecsAgent{
+		cfg:                   &cfg,
+		stateManagerFactory:   stateManagerFactory,
+		saveableOptionFactory: saveableOptionFactory,
+		ec2MetadataClient:     ec2.NewBlackholeEC2MetadataClient(),
+	}
+	gomock.InOrder(
+		saveableOptionFactory.EXPECT().AddSaveable(gomock.Any(), gomock.Any()).AnyTimes(),
+		stateManagerFactory.EXPECT().NewStateManager(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(stateManager, nil),
+		stateManager.EXPECT().Load().AnyTimes(),
+		state.EXPECT().AllTasks().Return(getTaskListWithOneBadTask()),
+	)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	containerChangeEventStream := eventstream.NewEventStream("events", ctx)
+	_, _, err := agent.newTaskEngine(containerChangeEventStream, creds, state, images)
+
+	assert.Error(t, err)
+}
+
+func getTaskListWithOneBadTask() []*api.Task {
+	oldtask := &api.Task{}
+	newtask := &api.Task{
+		MemoryCPULimitsEnabled: true,
+	}
+	return []*api.Task{oldtask, newtask}
+}

--- a/agent/app/agent_compatibility_unspecified.go
+++ b/agent/app/agent_compatibility_unspecified.go
@@ -1,0 +1,22 @@
+// +build !linux
+
+// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package app
+
+import "github.com/aws/amazon-ecs-agent/agent/engine"
+
+func (agent *ecsAgent) checkCompatibility(engine engine.TaskEngine) error {
+	return nil
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This ensures that we dont start old versions of agent with the cgroup hierarchy enabled.

### Implementation
Two main behavior paths:
* If the feature is explicitly enabled by the end user, we will throw an error on startup if old tasks exist in the state file
* If the feature is default enabled, we will degrade gracefully

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes


### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: yes 
