### PR TITLE
dockerclient: Agent supported Docker versions from client min,API Versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,14 @@
 
 ## UNRELEASED
 * Feature - Support for provisioning Tasks with ENIs
+* Bug - Fixed a bug where unsupported Docker API client versions could be registered
+[#1014](https://github.com/aws/amazon-ecs-agent/pull/1014)
 
 ## 1.14.5
 * Enhancement - Retry failed container image pull operations [#975](https://github.com/aws/amazon-ecs-agent/pull/975)
 * Enhancement - Set read and write timeouts for websocket connectons [#993](https://github.com/aws/amazon-ecs-agent/pull/993)
 * Enhancement - Add support for the SumoLogic Docker log driver plugin
-  [#992](https://github.com/aws/amazon-ecs-agent/pull/992) 
+  [#992](https://github.com/aws/amazon-ecs-agent/pull/992)
 * Bug - Fixed a memory leak issue when submitting the task state change [#967](https://github.com/aws/amazon-ecs-agent/pull/967)
 * Bug - Fixed a race condition where a container can be created twice when agent restarts. [#939](https://github.com/aws/amazon-ecs-agent/pull/939)
 * Bug - Fixed an issue where `microsoft/windowsservercore:latest` was not

--- a/agent/engine/dockerclient/dockerclientfactory_unix_test.go
+++ b/agent/engine/dockerclient/dockerclientfactory_unix_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockeriface/mocks"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	docker "github.com/fsouza/go-dockerclient"
 )
 
 func TestGetClientCached(t *testing.T) {
@@ -29,7 +30,8 @@ func TestGetClientCached(t *testing.T) {
 
 	newVersionedClient = func(endpoint, version string) (dockeriface.Client, error) {
 		mockClient := mock_dockeriface.NewMockClient(ctrl)
-		mockClient.EXPECT().Ping()
+		mockClient.EXPECT().Version().Return(&docker.Env{}, nil).AnyTimes()
+		mockClient.EXPECT().Ping().AnyTimes()
 		return mockClient, nil
 	}
 

--- a/agent/engine/dockerclient/dockerclientfactory_windows_test.go
+++ b/agent/engine/dockerclient/dockerclientfactory_windows_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockeriface/mocks"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	docker "github.com/fsouza/go-dockerclient"
 )
 
 func TestGetClientMinimumVersion(t *testing.T) {
@@ -31,10 +32,11 @@ func TestGetClientMinimumVersion(t *testing.T) {
 
 	newVersionedClient = func(endpoint, version string) (dockeriface.Client, error) {
 		mockClient := mock_dockeriface.NewMockClient(ctrl)
-		if version == string(MinDockerAPIWindows) {
+		if version == string(minDockerAPIVersion) {
 			mockClient = expectedClient
 		}
-		mockClient.EXPECT().Ping()
+		mockClient.EXPECT().Version().Return(&docker.Env{}, nil).AnyTimes()
+		mockClient.EXPECT().Ping().AnyTimes()
 		return mockClient, nil
 	}
 

--- a/agent/engine/dockerclient/versionsupport_unix.go
+++ b/agent/engine/dockerclient/versionsupport_unix.go
@@ -18,6 +18,10 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockeriface"
 )
 
+const (
+	// minDockerAPIVersion is the min Docker API version supported by agent
+	minDockerAPIVersion = Version_1_17
+)
 // GetClient on linux will simply return the cached client from the map
 func (f *factory) GetClient(version DockerVersion) (dockeriface.Client, error) {
 	return f.getClient(version)

--- a/agent/engine/dockerclient/versionsupport_windows.go
+++ b/agent/engine/dockerclient/versionsupport_windows.go
@@ -18,14 +18,14 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockeriface"
 )
 
-const MinDockerAPIWindows = Version_1_24
+const minDockerAPIVersion = Version_1_24
 
 // GetClient will replace some versions of Docker on Windows. We need this because
 // agent assumes that it can always call older versions of the docker API.
 func (f *factory) GetClient(version DockerVersion) (dockeriface.Client, error) {
 	for _, v := range getWindowsReplaceableVersions() {
 		if v == version {
-			version = MinDockerAPIWindows
+			version = minDockerAPIVersion
 			break
 		}
 	}
@@ -48,10 +48,10 @@ func getWindowsReplaceableVersions() []DockerVersion {
 
 // getAgentVersions for Windows should return all of the replaceable versions plus additional versions
 func getAgentVersions() []DockerVersion {
-	return append(getWindowsReplaceableVersions(), MinDockerAPIWindows)
+	return append(getWindowsReplaceableVersions(), minDockerAPIVersion)
 }
 
 // getDefaultVersion returns agent's default version of the Docker API
 func getDefaultVersion() DockerVersion {
-	return MinDockerAPIWindows
+	return minDockerAPIVersion
 }


### PR DESCRIPTION
### Summary
Finds Agent supported Docker version clients from client version's min, API Versions returned

### Implementation details
dockerclient: Finding agent supported Docker versions by getting the default client version and if the min API version is present, add all the clients between min API version and API version supported, else follow current logic
utils: reuse the semantic version comparator to compare Docker API versions with only major and minor versions too

### Testing
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes|no

### Description for the changelog
Supported Docker version clients from default client's min supported API and API version returned

### Licensing
This contribution is under the terms of the Apache 2.0 License: yes
