### PR TITLE
api: Set cgroup memory in bytes instead of megabytes

### DIFF
--- a/agent/api/task_unix.go
+++ b/agent/api/task_unix.go
@@ -37,6 +37,8 @@ const (
 	maxTaskVCPULimit = 10
 	// Reference: http://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ContainerDefinition.html
 	minimumCPUShare = 2
+
+	bytesPerMegabyte = 1024 * 1024
 )
 
 func (task *Task) adjustForPlatform(cfg *config.Config) {
@@ -149,8 +151,11 @@ func (task *Task) buildLinuxMemorySpec() (specs.LinuxMemory, error) {
 					containerMemoryLimit, task.Memory)
 		}
 	}
+
+	// Kernel expects memory to be expressed in bytes
+	memoryBytes := task.Memory * bytesPerMegabyte
 	return specs.LinuxMemory{
-		Limit: &task.Memory,
+		Limit: &memoryBytes,
 	}, nil
 }
 

--- a/agent/api/task_unix_test.go
+++ b/agent/api/task_unix_test.go
@@ -122,13 +122,14 @@ func TestBuildLinuxResourceSpecCPUMem(t *testing.T) {
 
 	expectedTaskCPUPeriod := uint64(defaultCPUPeriod / time.Microsecond)
 	expectedTaskCPUQuota := int64(taskVCPULimit * float64(expectedTaskCPUPeriod))
+	expectedTaskMemory := taskMemoryLimit * bytesPerMegabyte
 	expectedLinuxResourceSpec := specs.LinuxResources{
 		CPU: &specs.LinuxCPU{
 			Quota:  &expectedTaskCPUQuota,
 			Period: &expectedTaskCPUPeriod,
 		},
 		Memory: &specs.LinuxMemory{
-			Limit: &taskMemoryLimit,
+			Limit: &expectedTaskMemory,
 		},
 	}
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This fixes a bug where we try to set memory using the wrong unit

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [ ] Builds on Linux (`make release`)
- [ ] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [ ] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: yes
