### PR TITLE
scripts: fix usage string in ec2-stage

### DIFF
--- a/scripts/ec2-stage
+++ b/scripts/ec2-stage
@@ -30,7 +30,7 @@ source $(dirname "${0}")/publishing-common.sh
 TARGET_OS_LIST=${SUPPORTED_OSES[@]}
 
 usage() {
-	echo "Usage: ${0} -b BUCKET -k SSH_KEY -s SECURITY_GROUP -i IAM_ROLE [OPTIONS]"
+	echo "Usage: ${0} -a ARTIFACT_BUCKET -t SOURCE_BUCKET -k SSH_KEY -s SECURITY_GROUP -i IAM_ROLE [OPTIONS]"
 	echo
 	echo "This script stages a new version of the Amazon EC2 Container Agent"
 	echo "built on a freshly-launched EC2 instance."


### PR DESCRIPTION
### Summary
Fix usage output for the ec2-stage script. 

### Implementation details
String updated.

### Testing
`ec2-stage --help`, prints output.

- [ ] Builds on Linux (`make release`)
- [ ] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [ ] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: no

### Licensing
This contribution is under the terms of the Apache 2.0 License: yes
