### PR TITLE
Add flag to print capabilities

### DIFF
--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -71,6 +71,9 @@ var (
 type agent interface {
 	// printVersion prints the Agent version string
 	printVersion() int
+	// printECSAttributes prints the Agent's capabilities based on
+	// its environment
+	printECSAttributes() int
 	// start starts the Agent execution
 	start() int
 }
@@ -160,6 +163,15 @@ func newAgent(
 // printVersion prints the ECS Agent version string
 func (agent *ecsAgent) printVersion() int {
 	version.PrintVersion(agent.dockerClient)
+	return exitcodes.ExitSuccess
+}
+
+// printECSAttributes prints the Agent's ECS Attributes based on its
+// environment
+func (agent *ecsAgent) printECSAttributes() int {
+	for _, attr := range agent.capabilities() {
+		fmt.Printf("%s\t%s\n", aws.StringValue(attr.Name), aws.StringValue(attr.Value))
+	}
 	return exitcodes.ExitSuccess
 }
 

--- a/agent/app/args/flag.go
+++ b/agent/app/args/flag.go
@@ -21,9 +21,11 @@ const (
 	acceptInsecureCertUsage  = "Disable SSL certificate verification. We do not recommend setting this option"
 	licenseUsage             = "Print the LICENSE and NOTICE files and exit"
 	blacholeEC2MetadataUsage = "Blackhole the EC2 Metadata requests. Setting this option can cause the ECS Agent to fail to work properly.  We do not recommend setting this option"
+	ecsAttributesUsage       = "Print the Agent's ECS Attributes based on its environment"
 
 	versionFlagName              = "version"
 	logLevelFlagName             = "loglevel"
+	ecsAttributesFlagName        = "ecs-attributes"
 	acceptInsecureCertFlagName   = "k"
 	licenseFlagName              = "license"
 	blackholeEC2MetadataFlagName = "blackhole-ec2-metadata"
@@ -35,14 +37,16 @@ type Args struct {
 	Version *bool
 	// LogLevel represents the ECS Agent's log level
 	LogLevel *string
-	// AcceptInsecureCert indicates if SSL certificate verification shoule be
-	// disabled
+	// AcceptInsecureCert indicates if SSL certificate verification
+	// should be disabled
 	AcceptInsecureCert *bool
 	// License indicates if the license information should be printed
 	License *bool
 	// BlackholeEC2Metadata indicates if EC2 Metadata requests should be
 	// blackholed
 	BlackholeEC2Metadata *bool
+	// ECSAttributes indicates that the agent should print its attributes
+	ECSAttributes *bool
 }
 
 // New creates a new Args object from the argument list
@@ -55,6 +59,7 @@ func New(arguments []string) (*Args, error) {
 		AcceptInsecureCert:   flagset.Bool(acceptInsecureCertFlagName, false, acceptInsecureCertUsage),
 		License:              flagset.Bool(licenseFlagName, false, licenseUsage),
 		BlackholeEC2Metadata: flagset.Bool(blackholeEC2MetadataFlagName, false, blacholeEC2MetadataUsage),
+		ECSAttributes:        flagset.Bool(ecsAttributesFlagName, false, ecsAttributesUsage),
 	}
 
 	err := flagset.Parse(arguments)

--- a/agent/app/run.go
+++ b/agent/app/run.go
@@ -49,11 +49,15 @@ func Run(arguments []string) int {
 		return exitcodes.ExitError
 	}
 
-	if *parsedArgs.Version {
-		// Print version and exit
+	switch {
+	case *parsedArgs.Version:
+		// Print Agent's version and exit
 		return agent.printVersion()
+	case *parsedArgs.ECSAttributes:
+		// Print agent's ecs attributes based on its environment and exit
+		return agent.printECSAttributes()
+	default:
+		// Start the agent
+		return agent.start()
 	}
-
-	// Start the agent execution
-	return agent.start()
 }


### PR DESCRIPTION
### Summary
Print the Agent's capabilities without having to connect it to ECS.

### Implementation details
This uses the Agent's existing capability discovery mechanism and prints the values without starting the Agent.

### Testing
This was run on an ec2 instance with the added flag.

- [ ] Builds on Linux (`make release`)
- [ ] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [ ] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
Agent offline capability discovery

### Licensing
This contribution is under the terms of the Apache 2.0 License: yes
