### PR TITLE
Fix flaky tests in stats package

### DIFF
--- a/agent/stats/common_test.go
+++ b/agent/stats/common_test.go
@@ -58,13 +58,11 @@ var client, _ = docker.NewClient(endpoint)
 var clientFactory = dockerclient.NewFactory(endpoint)
 var cfg = config.DefaultConfig()
 
-var dockerClient ecsengine.DockerClient
 var defaultCluster = "default"
 var defaultContainerInstance = "ci"
 
 func init() {
 	cfg.EngineAuthData = config.NewSensitiveRawMessage([]byte{})
-	dockerClient, _ = ecsengine.NewDockerGoClient(clientFactory, &cfg)
 }
 
 // eventStream returns the event stream used to receive container change events

--- a/agent/stats/engine_integ_test.go
+++ b/agent/stats/engine_integ_test.go
@@ -26,6 +26,12 @@ import (
 	docker "github.com/fsouza/go-dockerclient"
 )
 
+var dockerClient ecsengine.DockerClient
+
+func init() {
+	dockerClient, _ = ecsengine.NewDockerGoClient(clientFactory, &cfg)
+}
+
 func (resolver *IntegContainerMetadataResolver) addToMap(containerID string) {
 	resolver.containerIDToTask[containerID] = &api.Task{
 		Arn:     taskArn,


### PR DESCRIPTION
### Summary
Fix flaky unit tests in `stats` package due to a call in `init()`
Fixes https://github.com/aws/amazon-ecs-agent/issues/1019

### Implementation details
Remove unnecessary `ecsengine.NewDockerGoClient` call in init method of unit tests and add to integ test

### Testing
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: 

### Description for the changelog

### Licensing
This contribution is under the terms of the Apache 2.0 License: yes
