### PR TITLE
Fix the issue where task does not wait for resource on restart

### DIFF
--- a/agent/api/task.go
+++ b/agent/api/task.go
@@ -884,6 +884,22 @@ func (task *Task) GetTaskENI() *ENI {
 	return task.ENI
 }
 
+// GetStopSequenceNumber returns the stop sequence number of a task
+func (task *Task) GetStopSequenceNumber() int64 {
+	task.desiredStatusLock.RLock()
+	defer task.desiredStatusLock.RUnlock()
+
+	return task.StopSequenceNumber
+}
+
+// SetStopSequenceNumber sets the stop seqence number of a task
+func (task *Task) SetStopSequenceNumber(seqnum int64) {
+	task.desiredStatusLock.Lock()
+	defer task.desiredStatusLock.Unlock()
+
+	task.StopSequenceNumber = seqnum
+}
+
 // String returns a human readable string representation of this object
 func (task *Task) String() string {
 	res := fmt.Sprintf("%s:%s %s, TaskStatus: (%s->%s)",

--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -261,9 +261,9 @@ func (mtask *managedTask) handleDesiredStatusChange(desiredStatus api.TaskStatus
 		llog.Debug("Redundant task transition; ignoring", "old", mtask.GetDesiredStatus().String(), "new", desiredStatus.String())
 		return
 	}
-	if desiredStatus == api.TaskStopped && seqnum != 0 && mtask.StopSequenceNumber == 0 {
+	if desiredStatus == api.TaskStopped && seqnum != 0 && mtask.GetStopSequenceNumber() == 0 {
 		llog.Debug("Task moving to stopped, adding to stopgroup", "seqnum", seqnum)
-		mtask.StopSequenceNumber = seqnum
+		mtask.SetStopSequenceNumber(seqnum)
 		mtask.engine.taskStopGroup.Add(seqnum, 1)
 	}
 	mtask.SetDesiredStatus(desiredStatus)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Initially agent should wait for instance resource(port, mem) to be
released by waiting for previous task to be stopped, but this will
broken when task is waiting and agent was restarted. This fix will add
task into waitgroup on restart.
### Implementation details
<!-- How are the changes implemented? -->
On agent restart, check if the task has the stop sequence number(which is set when agent receives payload message to stop a task), and add the stop sequence number into the waitStopGroup.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass
- [x] Manually tests with the scenario
New tests cover the changes: <!-- yes|no -->
yes
### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
yes