### PR TITLE
fix race while accessing task's ENI object

### DIFF
--- a/agent/api/task.go
+++ b/agent/api/task.go
@@ -872,16 +872,18 @@ func (task *Task) GetTaskENI() *ENI {
 }
 
 // String returns a human readable string representation of this object
-func (t *Task) String() string {
+func (task *Task) String() string {
 	res := fmt.Sprintf("%s:%s %s, TaskStatus: (%s->%s)",
-		t.Family, t.Version, t.Arn,
-		t.GetKnownStatus().String(), t.GetDesiredStatus().String())
+		task.Family, task.Version, task.Arn,
+		task.GetKnownStatus().String(), task.GetDesiredStatus().String())
 	res += " Containers: ["
-	for _, c := range t.Containers {
+	for _, c := range task.Containers {
 		res += fmt.Sprintf("%s (%s->%s),", c.Name, c.GetKnownStatus().String(), c.GetDesiredStatus().String())
 	}
-	if t.ENI != nil {
-		res += fmt.Sprintf(" ENI: [%s]", t.ENI.String())
+	task.eniLock.Lock()
+	defer task.eniLock.Unlock()
+	if task.ENI != nil {
+		res += fmt.Sprintf(" ENI: [%s]", task.ENI.String())
 	}
 	return res + "]"
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
I introduced a race with `api.Task`'s `String` method with https://github.com/aws/amazon-ecs-agent/pull/1037/commits/78cb53cd0233b31e0d31488fed5b7a8555962d8f#diff-e008975819a900a8494cf91881a8304aR883. This fixes the same.

### Implementation details
<!-- How are the changes implemented? -->
Added required locks

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: Yes
