### PR TITLE
engine: remove some dead code

### DIFF
--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -442,10 +442,7 @@ func (engine *DockerTaskEngine) handleDockerEvents(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case event := <-engine.events:
-			ok := engine.handleDockerEvent(event)
-			if !ok {
-				break
-			}
+			engine.handleDockerEvent(event)
 		}
 	}
 }


### PR DESCRIPTION
### Summary
Removes a bit of dead code

### Implementation details
Both branches of the conditional are the same, so why have the conditional in the first place?

### Testing
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: no

### Description for the changelog
None

### Licensing
This contribution is under the terms of the Apache 2.0 License: yes
