### PR TITLE
register agent with "none" log driver capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 * Feature - Support for provisioning Tasks with ENIs
 * Enhancement - Support `init` process in containers by adding support for Docker remote API client version 1.25
   [#996](https://github.com/aws/amazon-ecs-agent/pull/996)
+* Enhancement - Enable 'none' logging driver capability by default 
+  [#1041](https://github.com/aws/amazon-ecs-agent/pull/1041) 
 * Bug - Fixed a bug where tasks that fail to pull containers can cause the
   agent to fail to restore properly after a restart.
   [#1033](https://github.com/aws/amazon-ecs-agent/pull/1033)

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ configure them as something other than the defaults.
 | `ECS_UPDATE_DOWNLOAD_DIR` | /cache               | Where to place update tarballs within the container. | | |
 | `ECS_DISABLE_METRICS`     | &lt;true &#124; false&gt;  | Whether to disable metrics gathering for tasks. | false | true |
 | `ECS_RESERVED_MEMORY` | 32 | Memory, in MB, to reserve for use by things other than containers managed by Amazon ECS. | 0 | 0 |
-| `ECS_AVAILABLE_LOGGING_DRIVERS` | `["awslogs","fluentd","gelf","json-file","journald","logentries","splunk","syslog"]` | Which logging drivers are available on the container instance. | `["json-file"]` | `["json-file"]` |
+| `ECS_AVAILABLE_LOGGING_DRIVERS` | `["awslogs","fluentd","gelf","json-file","journald","logentries","splunk","syslog"]` | Which logging drivers are available on the container instance. | `["json-file","none"]` | `["json-file","none"]` |
 | `ECS_DISABLE_PRIVILEGED` | `true` | Whether launching privileged containers is disabled on the container instance. | `false` | `false` |
 | `ECS_SELINUX_CAPABLE` | `true` | Whether SELinux is available on the container instance. | `false` | `false` |
 | `ECS_APPARMOR_CAPABLE` | `true` | Whether AppArmor is available on the container instance. | `false` | `false` |

--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -45,6 +45,7 @@ const (
 //    com.amazonaws.ecs.capability.logging-driver.fluentd
 //    com.amazonaws.ecs.capability.logging-driver.journald
 //    com.amazonaws.ecs.capability.logging-driver.gelf
+//    com.amazonaws.ecs.capability.logging-driver.none
 //    com.amazonaws.ecs.capability.selinux
 //    com.amazonaws.ecs.capability.apparmor
 //    com.amazonaws.ecs.capability.ecr-auth

--- a/agent/config/config_unix.go
+++ b/agent/config/config_unix.go
@@ -35,7 +35,7 @@ func DefaultConfig() Config {
 		DataDirOnHost:               "/var/lib/ecs",
 		DisableMetrics:              false,
 		ReservedMemory:              0,
-		AvailableLoggingDrivers:     []dockerclient.LoggingDriver{dockerclient.JSONFileDriver},
+		AvailableLoggingDrivers:     []dockerclient.LoggingDriver{dockerclient.JSONFileDriver, dockerclient.NoneDriver},
 		TaskCleanupWaitDuration:     DefaultTaskCleanupWaitDuration,
 		DockerStopTimeout:           DefaultDockerStopTimeout,
 		CredentialsAuditLogFile:     defaultCredentialsAuditLogFile,

--- a/agent/config/config_unix_test.go
+++ b/agent/config/config_unix_test.go
@@ -61,7 +61,8 @@ func TestConfigDefault(t *testing.T) {
 	assert.Equal(t, uint16(0), cfg.ReservedMemory, "Default reserved memory set incorrectly")
 	assert.Equal(t, 30*time.Second, cfg.DockerStopTimeout, "Default docker stop container timeout set incorrectly")
 	assert.False(t, cfg.PrivilegedDisabled, "Default PrivilegedDisabled set incorrectly")
-	assert.Equal(t, []dockerclient.LoggingDriver{dockerclient.JSONFileDriver}, cfg.AvailableLoggingDrivers, "Default logging drivers set incorrectly")
+	assert.Equal(t, []dockerclient.LoggingDriver{dockerclient.JSONFileDriver, dockerclient.NoneDriver},
+		cfg.AvailableLoggingDrivers, "Default logging drivers set incorrectly")
 	assert.Equal(t, 3*time.Hour, cfg.TaskCleanupWaitDuration, "Default task cleanup wait duration set incorrectly")
 	assert.False(t, cfg.TaskENIEnabled, "TaskENIEnabled set incorrectly")
 	assert.False(t, cfg.TaskIAMRoleEnabled, "TaskIAMRoleEnabled set incorrectly")

--- a/agent/config/config_windows.go
+++ b/agent/config/config_windows.go
@@ -67,7 +67,7 @@ func DefaultConfig() Config {
 		// DisableMetrics is set to true on Windows as docker stats does not work
 		DisableMetrics:              true,
 		ReservedMemory:              0,
-		AvailableLoggingDrivers:     []dockerclient.LoggingDriver{dockerclient.JSONFileDriver},
+		AvailableLoggingDrivers:     []dockerclient.LoggingDriver{dockerclient.JSONFileDriver, dockerclient.NoneDriver},
 		TaskCleanupWaitDuration:     DefaultTaskCleanupWaitDuration,
 		DockerStopTimeout:           DefaultDockerStopTimeout,
 		CredentialsAuditLogFile:     filepath.Join(ecsRoot, defaultCredentialsAuditLogFile),

--- a/agent/config/config_windows_test.go
+++ b/agent/config/config_windows_test.go
@@ -54,7 +54,8 @@ func TestConfigDefault(t *testing.T) {
 	assert.Equal(t, uint16(0), cfg.ReservedMemory, "Default reserved memory set incorrectly")
 	assert.Equal(t, 30*time.Second, cfg.DockerStopTimeout, "Default docker stop container timeout set incorrectly")
 	assert.False(t, cfg.PrivilegedDisabled, "Default PrivilegedDisabled set incorrectly")
-	assert.Equal(t, []dockerclient.LoggingDriver{dockerclient.JSONFileDriver}, cfg.AvailableLoggingDrivers, "Default logging drivers set incorrectly")
+	assert.Equal(t, []dockerclient.LoggingDriver{dockerclient.JSONFileDriver, dockerclient.NoneDriver},
+		cfg.AvailableLoggingDrivers, "Default logging drivers set incorrectly")
 	assert.Equal(t, 3*time.Hour, cfg.TaskCleanupWaitDuration, "Default task cleanup wait duration set incorrectly")
 	assert.False(t, cfg.TaskIAMRoleEnabled, "TaskIAMRoleEnabled set incorrectly")
 	assert.False(t, cfg.TaskIAMRoleEnabledForNetworkHost, "TaskIAMRoleEnabledForNetworkHost set incorrectly")

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -91,7 +91,7 @@ type Config struct {
 	DockerStopTimeout time.Duration
 
 	// AvailableLoggingDrivers specifies the logging drivers available for use
-	// with Docker.  If not set, it defaults to ["json-file"].
+	// with Docker.  If not set, it defaults to ["json-file","none"].
 	AvailableLoggingDrivers []dockerclient.LoggingDriver
 
 	// PrivilegedDisabled specified whether the Agent is capable of launching

--- a/agent/engine/dockerclient/logging_drivers.go
+++ b/agent/engine/dockerclient/logging_drivers.go
@@ -38,5 +38,5 @@ var LoggingDriverMinimumVersion = map[LoggingDriver]DockerVersion{
 	SplunklogsDriver: Version_1_22,
 	LogentriesDriver: Version_1_25,
 	SumoLogicDriver:  Version_1_29,
-	NoneDriver:       Version_1_18,
+	NoneDriver:       Version_1_19,
 }

--- a/agent/engine/dockerclient/logging_drivers.go
+++ b/agent/engine/dockerclient/logging_drivers.go
@@ -25,6 +25,7 @@ const (
 	SplunklogsDriver LoggingDriver = "splunk"
 	LogentriesDriver LoggingDriver = "logentries"
 	SumoLogicDriver  LoggingDriver = "sumologic"
+	NoneDriver       LoggingDriver = "none"
 )
 
 var LoggingDriverMinimumVersion = map[LoggingDriver]DockerVersion{
@@ -37,4 +38,5 @@ var LoggingDriverMinimumVersion = map[LoggingDriver]DockerVersion{
 	SplunklogsDriver: Version_1_22,
 	LogentriesDriver: Version_1_25,
 	SumoLogicDriver:  Version_1_29,
+	NoneDriver:       Version_1_18,
 }


### PR DESCRIPTION
Agent registers itself as being capable of placing containers
with "none" logging driver on start, without the need for
explicitly specifying this in the config

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
register agent with "none" log driver capability

### Implementation details
<!-- How are the changes implemented? -->
* Added an enum for "none" logging driver
* Added "none" to the default list of logging drivers registered

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: Yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
