### PR TITLE
Fix timing issue with hostsetup script

### DIFF
--- a/misc/windows-deploy/amazon-ecs-agent.ps1
+++ b/misc/windows-deploy/amazon-ecs-agent.ps1
@@ -61,7 +61,7 @@ try {
 
     LogMsg "Docker is running and ready."
 
-    if([System.Environment]::GetEnvironmentVariable("ECS_ENABLE_TASK_IAM_ROLE", "Machine") -eq "true") {
+    if([System.Environment]::GetEnvironmentVariable("ECS_ENABLE_TASK_IAM_ROLE") -eq "true") {
         LogMsg "IAM roles environment variable is set."
         .\hostsetup.ps1
     }

--- a/misc/windows-deploy/hostsetup.ps1
+++ b/misc/windows-deploy/hostsetup.ps1
@@ -28,7 +28,7 @@ if(!($adapter)) {
 
 $ifIndex = (Get-NetAdapter -Name "*APIPA*" | Sort-Object | Select ifIndex).ifIndex
 
-$dockerSubnet = (docker network inspect nat | ConvertFrom-Json).IPAM.Config.Subnet
+$dockerSubnet = (docker network inspect nat | Out-String | ConvertFrom-Json).IPAM.Config.Subnet
 
 # This address will only exist on systems that have already set up the routes.
 $ip = (Get-NetRoute -InterfaceIndex $ifIndex -DestinationPrefix $dockerSubnet)

--- a/misc/windows-deploy/hostsetup.ps1
+++ b/misc/windows-deploy/hostsetup.ps1
@@ -43,6 +43,13 @@ if(!($ip)) {
 	# Exposes credential port for local windows firewall
 	New-NetFirewallRule -DisplayName "Allow Inbound Port $credentialPort" -Direction Inbound -LocalPort $credentialPort -Protocol TCP -Action Allow
 
+	# Wait for Credential IP to become available
+	while(!(Test-Connection -ComputerName $credentialAddress))
+	{
+		Write-Output "Waiting for Credential IP to be up"
+		Start-Sleep 1
+	}
+	
 	# This forwards traffic from port 80 and listens on the IAM role IP address.
 	# 'portproxy' doesn't have a powershell module equivalent, but we could move if it becomes available.
 	netsh interface portproxy add v4tov4 listenaddress=$credentialAddress listenport=80 connectaddress=$credentialAddress connectport=$credentialPort


### PR DESCRIPTION
### Summary
I noticed that sometimes the port forwarding that we do using netsh doesn't work. The ECS agent does listen on port 51679, but we cannot connect to it using port 80, and hence IAM task roles don't work. I figured out that this happens when the netsh command is executed before the Credential IP is up. Maybe this is because we do the IP allocation in powershell, and then use netsh (cmd) to do the power forwarding. This change makes sure that the IP is up and responding before we try to set up port forwarding. And with this, I haven't noticed the issue anymore.

### Implementation details
Just wait for ping to succeed to the Credential IP before setting up port forwarding

### Testing
N/A

New tests cover the changes: no

### Description for the changelog
Fix timing issue with setting up port forwarding

### Licensing
This contribution is under the terms of the Apache 2.0 License: yes
