### PR TITLE
Remove task/container overridden in DockerHostConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-# Changelog
+#Changelog
+
+## Unreleased
+* Bug - Fixed a bug where a task can be blocked in creating state. [#1048](https://github.com/aws/amazon-ecs-agent/pull/1048)
 
 ## 1.15.0
 * Feature - Support for provisioning tasks with ENIs.

--- a/agent/api/container.go
+++ b/agent/api/container.go
@@ -167,19 +167,6 @@ func NewContainerWithSteadyState(steadyState ContainerStatus) *Container {
 	}
 }
 
-// Overriden applies the overridden command and returns the resulting
-// container object
-func (c *Container) Overridden() *Container {
-	result := *c
-
-	// We only support Command overrides at the moment
-	if result.Overrides.Command != nil {
-		result.Command = *c.Overrides.Command
-	}
-
-	return &result
-}
-
 // KnownTerminal returns true if the container's known status is STOPPED
 func (c *Container) KnownTerminal() bool {
 	return c.GetKnownStatus().Terminal()

--- a/agent/api/container_test.go
+++ b/agent/api/container_test.go
@@ -15,36 +15,12 @@ package api
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
 
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 	"github.com/fsouza/go-dockerclient"
 	"github.com/stretchr/testify/assert"
 )
-
-func TestOverridden(t *testing.T) {
-	container := &Container{
-		Name:                "name",
-		Image:               "image",
-		Command:             []string{"foo", "bar"},
-		CPU:                 1,
-		Memory:              1,
-		Links:               []string{},
-		Ports:               []PortBinding{{10, 10, "", TransportProtocolTCP}},
-		Overrides:           ContainerOverrides{},
-		DesiredStatusUnsafe: ContainerRunning,
-		AppliedStatus:       ContainerRunning,
-		KnownStatusUnsafe:   ContainerRunning,
-	}
-
-	overridden := container.Overridden()
-	// No overrides, should be identity
-	assert.True(t, reflect.DeepEqual(container, overridden))
-	assert.Equal(t, container, overridden)
-	overridden.Name = "mutated"
-	assert.Equal(t, container.Name, "name", "Should make a copy")
-}
 
 type configPair struct {
 	Container *Container


### PR DESCRIPTION
In task/container overridden, it's copying the task/container struct
which has a lock, this could cause deadlock if some other go routine
acquired the lock right before copying and released the lock after the
copy. This commit moved the overridden part to ACS when unmarshal the
task from payload message.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Fix #1047 

### Implementation details
<!-- How are the changes implemented? -->
Removed the Overridden function, and added the same in TaskFromACS.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->
yes
### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
