### PR TITLE
Generate Agent Manifest File

### DIFF
--- a/scripts/publish-staged
+++ b/scripts/publish-staged
@@ -5,7 +5,7 @@
 # "License"). You may not use this file except in compliance
 #  with the License. A copy of the License is located at
 #
-#     http://aws.amazon.com/apache2.0/
+# 		http://aws.amazon.com/apache2.0/
 #
 # or in the "license" file accompanying this file. This file is
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
@@ -59,9 +59,11 @@ publish_s3() {
 	for tag in ${IMAGE_TAG_VERSION} ${IMAGE_TAG_SHA} ${IMAGE_TAG_LATEST}; do
 		echo "Publishing as ${base_name}-${tag}.${suffix}"
 		dryval s3_cp "s3://${STAGE_S3_BUCKET}/${base_name}-${IMAGE_TAG_SHA}.${suffix}" \
-			   "s3://${PUBLISH_S3_BUCKET}/${base_name}-${tag}.${suffix}"
+			"s3://${PUBLISH_S3_BUCKET}/${base_name}-${tag}.${suffix}"
 		dryval s3_cp "s3://${STAGE_S3_BUCKET}/${base_name}-${IMAGE_TAG_SHA}.${suffix}.md5" \
-			   "s3://${PUBLISH_S3_BUCKET}/${base_name}-${tag}.${suffix}.md5"
+			"s3://${PUBLISH_S3_BUCKET}/${base_name}-${tag}.${suffix}.md5"
+		dryval s3_cp "s3://${STAGE_S3_BUCKET}/${base_name}-${IMAGE_TAG_SHA}.${suffix}.json" \
+			"s3://${PUBLISH_S3_BUCKET}/${base_name}-${tag}.${suffix}.json"
 	done
 }
 

--- a/scripts/stage
+++ b/scripts/stage
@@ -48,6 +48,11 @@ usage() {
 stage_s3() {
 	tarball="$(mktemp)"
 	tarball_md5="$(mktemp)"
+	tarball_manifest="$(mktemp)"
+
+	trap "rm -r \"${tarball}\" \"${tarball_md5}\" \"${tarball_manifest}\"" RETURN EXIT
+
+	generate_manifest ${IMAGE_TAG_VERSION} > "${tarball_manifest}"
 
 	docker save "amazon/amazon-ecs-agent:latest" > "${tarball}"
 	md5sum "${tarball}" | sed 's/ .*//' > "${tarball_md5}"
@@ -57,10 +62,12 @@ stage_s3() {
 		echo "Publishing as ecs-agent-${tag}"
 		dryval s3_cp "${tarball}" "s3://${S3_BUCKET}/ecs-agent-${tag}.tar"
 		dryval s3_cp "${tarball_md5}" "s3://${S3_BUCKET}/ecs-agent-${tag}.tar.md5"
+		dryval s3_cp "${tarball_manifest}" "s3://${S3_BUCKET}/ecs-agent-${tag}.tar.json"
 	done
 
 	rm "${tarball}"
 	rm "${tarball_md5}"
+	rm "${tarball_manifest}"
 }
 
 stage_windows_s3() {
@@ -68,7 +75,12 @@ stage_windows_s3() {
 	local ziptgtdir="$(mktemp -d)"
 	local zipfile="${ziptgtdir}/amazon-ecs-agent"
 	local zip_md5="$(mktemp)"
-	trap "rm -r \"${ziproot}\" \"${ziptgtdir}\" \"${zip_md5}\"" RETURN EXIT
+	local zip_manifest="$(mktemp)"
+
+	trap "rm -r \"${ziproot}\" \"${ziptgtdir}\" \"${zip_md5}\" \"${zip_manifest}\"" RETURN EXIT
+
+	generate_manifest ${IMAGE_TAG_VERSION} > "${zip_manifest}"
+
 	install_devcon "${ziproot}"
 	cp LICENSE "${ziproot}"
 	cp out/amazon-ecs-agent.exe "${ziproot}"
@@ -76,11 +88,19 @@ stage_windows_s3() {
 	pushd "${ziproot}"
 	zip "${zipfile}" *
 	md5sum "${zipfile}.zip" | sed 's/ .*//' > "${zip_md5}"
+	echo "Saved with md5sum $(cat ${zip_md5})"
+
 	for tag in ${IMAGE_TAG_VERSION} ${IMAGE_TAG_SHA} ${IMAGE_TAG_LATEST}; do
 		dryval s3_cp "${zipfile}.zip" "s3://${S3_BUCKET}/ecs-agent-windows-${tag}.zip"
 		dryval s3_cp "${zip_md5}" "s3://${S3_BUCKET}/ecs-agent-windows-${tag}.zip.md5"
+		dryval s3_cp "${zip_manifest}" "s3://${S3_BUCKET}/ecs-agent-windows-${tag}.zip.json"
 	done
 	popd
+
+	rm "${ziproot}"
+	rm "${ziptgtdir}"
+	rm "${zip_md5}"
+	rm "${zip_manifest}"
 }
 
 install_devcon() {
@@ -97,6 +117,12 @@ install_devcon() {
 	pushd "${ziproot}"
 	unzip "${zipfile}"
 	popd
+}
+
+generate_manifest() {
+	local version=$1
+
+	echo "{\"agentVersion\":\"${version}\"}"
 }
 
 while getopts ":d:p:b:i:a:o:sh" opt; do


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Adds a json file that contains the agent version giving users the ability to programmatically get information about the agent package contents without having to extract the tar/zip

### Implementation details
<!-- How are the changes implemented? -->
New "manifest" file that is just <agentTar/ZipName>.json that specifies the agent version.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass
- [x] Manually tested by running the staging scripts and checking artifact content
New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
New manifest.json that includes agent version
### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: yes
