### PR TITLE
Capture stderr in ec2-stage

### DIFF
--- a/scripts/ec2-stage
+++ b/scripts/ec2-stage
@@ -162,7 +162,7 @@ userdata=$(cat << EOU
 #!/bin/bash
 
 mkdir -p ${ec2_work_root}
-exec > >(tee -a ${ec2_work_root}/userdata.log)
+exec > >(tee -a ${ec2_work_root}/userdata.log) 2>&1
 
 yum -y install docker golang git zip unzip
 service docker start


### PR DESCRIPTION
### Summary
This captures stderr output and includes this in the build log file.

### Implementation details
`2>&1`

### Testing
Ran `ec2-stage` and observed that the stderr output was present.

- [ ] Builds on Linux (`make release`)
- [ ] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [ ] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: no

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: yes