### PR TITLE
Set CPU/Memory in both config and hostconfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Feature - Enable support for task level CPU and memory constraints.
 * Bug - Fixed a bug where a task can be blocked in creating state. [#1048](https://github.com/aws/amazon-ecs-agent/pull/1048)
 * Bug - Fixed dynamic HostPort in container metadata. [#1052](https://github.com/aws/amazon-ecs-agent/pull/1052)
+* Bug - Fixed bug on Windows where container memory limits are not enforced. [#1069](https://github.com/aws/amazon-ecs-agent/pull/1069)
 
 ## 1.15.0
 * Feature - Support for provisioning tasks with ENIs.

--- a/agent/api/task.go
+++ b/agent/api/task.go
@@ -485,12 +485,7 @@ func (task *Task) SetConfigHostconfigBasedOnVersion(container *Container, config
 		return err
 	}
 
-	dockerAPIVersion_1_18, err := docker.NewAPIVersion("1.18")
-	if err != nil {
-		seelog.Errorf("Creating docker api version 1.18 failed, err: %v", err)
-		return err
-	}
-
+	dockerAPIVersion_1_18 := docker.APIVersion([]int{1, 18})
 	if dockerAPIVersion.GreaterThanOrEqualTo(dockerAPIVersion_1_18) {
 		// Set the memory and cpu in host config
 		if hc != nil {

--- a/agent/api/task_test.go
+++ b/agent/api/task_test.go
@@ -179,6 +179,7 @@ func TestDockerHostConfigRawConfig(t *testing.T) {
 		DNSSearch:      []string{"dns.search"},
 		ExtraHosts:     []string{"extra:hosts"},
 		SecurityOpt:    []string{"foo", "bar"},
+		CPUShares:      2,
 		LogConfig: docker.LogConfig{
 			Type:   "foo",
 			Config: map[string]string{"foo": "bar"},
@@ -257,6 +258,8 @@ func TestDockerHostConfigRawConfigMerging(t *testing.T) {
 		Privileged:       true,
 		SecurityOpt:      []string{"foo", "bar"},
 		VolumesFrom:      []string{"dockername-c2"},
+		Memory:           100 * 1024 * 1024,
+		CPUShares:        50,
 		MemorySwappiness: memorySwappinessDefault,
 	}
 

--- a/agent/api/task_unix_test.go
+++ b/agent/api/task_unix_test.go
@@ -293,7 +293,7 @@ func TestPlatformHostConfigOverrideErrorPath(t *testing.T) {
 		},
 	}
 
-	dockerHostConfig, err := task.DockerHostConfig(task.Containers[0], dockerMap(task))
+	dockerHostConfig, err := task.DockerHostConfig(task.Containers[0], dockerMap(task), defaultDockerClientAPIVersion)
 	assert.Error(t, err)
 	assert.Empty(t, dockerHostConfig)
 }

--- a/agent/api/task_windows.go
+++ b/agent/api/task_windows.go
@@ -29,7 +29,7 @@ const (
 	memorySwappinessDefault = -1
 )
 
-var cpus = runtime.NumCPU() * 1024
+var cpuShareScaleFactor = runtime.NumCPU() * 1024
 
 // adjustForPlatform makes Windows-specific changes to the task after unmarshal
 func (task *Task) adjustForPlatform(cfg *config.Config) {
@@ -62,7 +62,7 @@ func getCanonicalPath(path string) string {
 // passed to Docker API.
 func (task *Task) platformHostConfigOverride(hostConfig *docker.HostConfig) error {
 	task.overrideDefaultMemorySwappiness(hostConfig)
-	hostConfig.CPUPercent = hostConfig.CPUShares / int64(cpus)
+	hostConfig.CPUPercent = hostConfig.CPUShares / int64(cpuShareScaleFactor)
 	return nil
 }
 

--- a/agent/api/task_windows.go
+++ b/agent/api/task_windows.go
@@ -17,6 +17,7 @@ package api
 
 import (
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/aws/amazon-ecs-agent/agent/config"
@@ -27,6 +28,8 @@ const (
 	//memorySwappinessDefault is the expected default value for this platform
 	memorySwappinessDefault = -1
 )
+
+var cpus = runtime.NumCPU() * 1024
 
 // adjustForPlatform makes Windows-specific changes to the task after unmarshal
 func (task *Task) adjustForPlatform(cfg *config.Config) {
@@ -59,6 +62,7 @@ func getCanonicalPath(path string) string {
 // passed to Docker API.
 func (task *Task) platformHostConfigOverride(hostConfig *docker.HostConfig) error {
 	task.overrideDefaultMemorySwappiness(hostConfig)
+	hostConfig.CPUPercent = hostConfig.CPUShares / int64(cpus)
 	return nil
 }
 

--- a/agent/api/task_windows_test.go
+++ b/agent/api/task_windows_test.go
@@ -142,7 +142,7 @@ func TestWindowsMemorySwappinessOption(t *testing.T) {
 		},
 	}
 
-	config, configErr := testTask.DockerHostConfig(testTask.Containers[0], dockerMap(testTask))
+	config, configErr := testTask.DockerHostConfig(testTask.Containers[0], dockerMap(testTask), defaultDockerClientAPIVersion)
 	if configErr != nil {
 		t.Fatal(configErr)
 	}

--- a/agent/api/task_windows_test.go
+++ b/agent/api/task_windows_test.go
@@ -115,7 +115,7 @@ func TestWindowsPlatformHostConfigOverride(t *testing.T) {
 	hostConfig := &docker.HostConfig{CPUShares: 1024}
 
 	task.platformHostConfigOverride(hostConfig)
-	assert.Equal(t, int64(1024)/int64(cpus), hostConfig.CPUPercent)
+	assert.Equal(t, int64(1024)/int64(cpuShareScaleFactor), hostConfig.CPUPercent)
 	assert.EqualValues(t, expectedMemorySwappinessDefault, hostConfig.MemorySwappiness)
 }
 

--- a/agent/api/task_windows_test.go
+++ b/agent/api/task_windows_test.go
@@ -112,10 +112,10 @@ func TestWindowsPlatformHostConfigOverride(t *testing.T) {
 
 	task := &Task{}
 
-	hostConfig := &docker.HostConfig{}
+	hostConfig := &docker.HostConfig{CPUShares: 1024}
 
 	task.platformHostConfigOverride(hostConfig)
-
+	assert.Equal(t, int64(1024)/int64(cpus), hostConfig.CPUPercent)
 	assert.EqualValues(t, expectedMemorySwappinessDefault, hostConfig.MemorySwappiness)
 }
 

--- a/agent/engine/docker_container_engine.go
+++ b/agent/engine/docker_container_engine.go
@@ -146,6 +146,8 @@ type DockerClient interface {
 
 	// Version returns the version of the Docker daemon.
 	Version() (string, error)
+	// APIVersion returns the api version of the client
+	APIVersion() (dockerclient.DockerVersion, error)
 
 	// InspectImage returns information about the specified image.
 	InspectImage(string) (*docker.Image, error)
@@ -882,6 +884,15 @@ func (dg *dockerGoClient) Version() (string, error) {
 		return "", err
 	}
 	return info.Get("Version"), nil
+}
+
+// APIVersion returns the client api version
+func (dg *dockerGoClient) APIVersion() (dockerclient.DockerVersion, error) {
+	client, err := dg.dockerClient()
+	if err != nil {
+		return "", err
+	}
+	return dg.clientFactory.FindClientAPIVersion(client), nil
 }
 
 // Stats returns a channel of *docker.Stats entries for the container.

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -685,7 +685,12 @@ func (engine *DockerTaskEngine) createContainer(task *api.Task, container *api.C
 	// we have to do this in create, not start, because docker no longer handles
 	// merging create config with start hostconfig the same; e.g. memory limits
 	// get lost
-	hostConfig, hcerr := task.DockerHostConfig(container, containerMap)
+	dockerClientVersion, versionErr := client.APIVersion()
+	if versionErr != nil {
+		return DockerContainerMetadata{Error: CannotGetDockerClientVersionError{versionErr}}
+	}
+
+	hostConfig, hcerr := task.DockerHostConfig(container, containerMap, dockerClientVersion)
 	if hcerr != nil {
 		return DockerContainerMetadata{Error: api.NamedError(hcerr)}
 	}
@@ -697,7 +702,7 @@ func (engine *DockerTaskEngine) createContainer(task *api.Task, container *api.C
 		}
 	}
 
-	config, err := task.DockerConfig(container)
+	config, err := task.DockerConfig(container, dockerClientVersion)
 	if err != nil {
 		return DockerContainerMetadata{Error: api.NamedError(err)}
 	}

--- a/agent/engine/dockerclient/dockerclientfactory_test.go
+++ b/agent/engine/dockerclient/dockerclientfactory_test.go
@@ -19,9 +19,9 @@ import (
 
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockeriface"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockeriface/mocks"
+	docker "github.com/fsouza/go-dockerclient"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
-	docker "github.com/fsouza/go-dockerclient"
 )
 
 const expectedEndpoint = "expectedEndpoint"
@@ -109,7 +109,7 @@ func TestFindSupportedAPIVersionsFromMinAPIVersions(t *testing.T) {
 	// Ensure that agent pings all known versions of Docker API
 	for i := 0; i < len(allVersions); i++ {
 		mockClients[string(allVersions[i])] = mock_dockeriface.NewMockClient(ctrl)
-		mockClients[string(allVersions[i])].EXPECT().Version().Return(&docker.Env{"MinAPIVersion=1.12","ApiVersion=1.27"}, nil).AnyTimes()
+		mockClients[string(allVersions[i])].EXPECT().Version().Return(&docker.Env{"MinAPIVersion=1.12", "ApiVersion=1.27"}, nil).AnyTimes()
 		mockClients[string(allVersions[i])].EXPECT().Ping().AnyTimes()
 	}
 
@@ -138,7 +138,7 @@ func TestCompareDockerVersionsWithMinAPIVersion(t *testing.T) {
 
 	for _, version := range versions {
 		_, err := getDockerClientForVersion("endpoint", version, minAPIVersion, apiVersion)
-		assert.EqualError(t, err, "version detection using MinAPIVersion: unsupported version: " + version)
+		assert.EqualError(t, err, "version detection using MinAPIVersion: unsupported version: "+version)
 	}
 
 	mockClients := make(map[string]*mock_dockeriface.MockClient)

--- a/agent/engine/dockerclient/dockerclientfactory_unix_test.go
+++ b/agent/engine/dockerclient/dockerclientfactory_unix_test.go
@@ -19,9 +19,9 @@ import (
 
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockeriface"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockeriface/mocks"
+	docker "github.com/fsouza/go-dockerclient"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
-	docker "github.com/fsouza/go-dockerclient"
 )
 
 func TestGetClientCached(t *testing.T) {
@@ -43,4 +43,14 @@ func TestGetClientCached(t *testing.T) {
 	assert.Nil(t, errAgain)
 
 	assert.Equal(t, client, clientAgain)
+}
+
+func TestFindClientAPIVersion(t *testing.T) {
+	factory := NewFactory(expectedEndpoint)
+
+	for _, version := range getAgentVersions() {
+		client, err := factory.GetClient(version)
+		assert.NoError(t, err)
+		assert.Equal(t, version, factory.FindClientAPIVersion(client))
+	}
 }

--- a/agent/engine/dockerclient/dockerclientfactory_windows_test.go
+++ b/agent/engine/dockerclient/dockerclientfactory_windows_test.go
@@ -19,9 +19,9 @@ import (
 
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockeriface"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockeriface/mocks"
+	docker "github.com/fsouza/go-dockerclient"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
-	docker "github.com/fsouza/go-dockerclient"
 )
 
 func TestGetClientMinimumVersion(t *testing.T) {
@@ -45,4 +45,14 @@ func TestGetClientMinimumVersion(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, expectedClient, actualClient)
+}
+
+func TestFindClientAPIVersion(t *testing.T) {
+	factory := NewFactory(expectedEndpoint)
+
+	for _, version := range getAgentVersions() {
+		client, err := factory.GetClient(version)
+		assert.NoError(t, err)
+		assert.Equal(t, Version_1_24, factory.FindClientAPIVersion(client))
+	}
 }

--- a/agent/engine/dockerclient/mocks/dockerclient_mocks.go
+++ b/agent/engine/dockerclient/mocks/dockerclient_mocks.go
@@ -43,6 +43,16 @@ func (_m *MockFactory) EXPECT() *_MockFactoryRecorder {
 	return _m.recorder
 }
 
+func (_m *MockFactory) FindClientAPIVersion(_param0 dockeriface.Client) dockerclient.DockerVersion {
+	ret := _m.ctrl.Call(_m, "FindClientAPIVersion", _param0)
+	ret0, _ := ret[0].(dockerclient.DockerVersion)
+	return ret0
+}
+
+func (_mr *_MockFactoryRecorder) FindClientAPIVersion(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "FindClientAPIVersion", arg0)
+}
+
 func (_m *MockFactory) FindKnownAPIVersions() []dockerclient.DockerVersion {
 	ret := _m.ctrl.Call(_m, "FindKnownAPIVersions")
 	ret0, _ := ret[0].([]dockerclient.DockerVersion)

--- a/agent/engine/dockerclient/versionsupport_unix.go
+++ b/agent/engine/dockerclient/versionsupport_unix.go
@@ -22,6 +22,7 @@ const (
 	// minDockerAPIVersion is the min Docker API version supported by agent
 	minDockerAPIVersion = Version_1_17
 )
+
 // GetClient on linux will simply return the cached client from the map
 func (f *factory) GetClient(version DockerVersion) (dockeriface.Client, error) {
 	return f.getClient(version)

--- a/agent/engine/engine_mocks.go
+++ b/agent/engine/engine_mocks.go
@@ -181,6 +181,17 @@ func (_m *MockDockerClient) EXPECT() *_MockDockerClientRecorder {
 	return _m.recorder
 }
 
+func (_m *MockDockerClient) APIVersion() (dockerclient.DockerVersion, error) {
+	ret := _m.ctrl.Call(_m, "APIVersion")
+	ret0, _ := ret[0].(dockerclient.DockerVersion)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockDockerClientRecorder) APIVersion() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "APIVersion")
+}
+
 func (_m *MockDockerClient) ContainerEvents(_param0 context0.Context) (<-chan DockerContainerChangeEvent, error) {
 	ret := _m.ctrl.Call(_m, "ContainerEvents", _param0)
 	ret0, _ := ret[0].(<-chan DockerContainerChangeEvent)

--- a/agent/engine/engine_unix_integ_test.go
+++ b/agent/engine/engine_unix_integ_test.go
@@ -542,9 +542,9 @@ func TestDockerAuth(t *testing.T) {
 	event = <-stateChangeEvents
 	assert.Equal(t, event.(api.TaskStateChange).Status, api.TaskRunning, "Expected task to be RUNNING")
 
-	taskUpdate := *testTask
+	taskUpdate := createTestTask("testDockerAuth")
 	taskUpdate.SetDesiredStatus(api.TaskStopped)
-	go taskEngine.AddTask(&taskUpdate)
+	go taskEngine.AddTask(taskUpdate)
 
 	event = <-stateChangeEvents
 	assert.Equal(t, event.(api.ContainerStateChange).Status, api.ContainerStopped, "Expected container to be STOPPED")

--- a/agent/engine/errors.go
+++ b/agent/engine/errors.go
@@ -317,3 +317,16 @@ func (err ContainerNetworkingError) Error() string {
 func (err ContainerNetworkingError) ErrorName() string {
 	return "ContainerNetworkingError"
 }
+
+// CannotGetDockerClientVersionError indicates error when trying to get docker
+// client api version
+type CannotGetDockerClientVersionError struct {
+	fromError error
+}
+
+func (err CannotGetDockerClientVersionError) ErrorName() string {
+	return "CannotGetDockerClientVersionError"
+}
+func (err CannotGetDockerClientVersionError) Error() string {
+	return err.fromError.Error()
+}


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Fix #616 
### Implementation details
<!-- How are the changes implemented? -->
Set the CPU and memory in both Docker Config and HostConfig
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass
- [x] Manually tested on windows

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
