### PR TITLE
Windows service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ out/
 coverage/
 _bin/
 *.exe
+*.exe~
 *.zip
 *.swp
 *.orig
@@ -15,3 +16,4 @@ _bin/
 /misc/windows-iam/devcon*
 /misc/pause-container/pause
 *-stamp
+/.idea/

--- a/README.md
+++ b/README.md
@@ -58,23 +58,27 @@ To install the service, you can do the following:
 
 ```powershell
 PS C:\> # Set up directories the agent uses
-PS C:\> New-Item -Type directory -Path $ProgramFiles\Amazon\ECS
-PS C:\> New-Item -Type directory -Path $ProgramData\Amazon\ECS
+PS C:\> New-Item -Type directory -Path ${env:ProgramFiles}\Amazon\ECS -Force
+PS C:\> New-Item -Type directory -Path ${env:ProgramData}\Amazon\ECS -Force
 PS C:\> # Set up configuration
-PS C:\> $ecsExeDir = "$env:ProgramFiles\Amazon\ECS"
+PS C:\> $ecsExeDir = "${env:ProgramFiles}\Amazon\ECS"
 PS C:\> [Environment]::SetEnvironmentVariable("ECS_CLUSTER", "my-windows-cluster", "Machine")
-PS C:\> [Environment]::SetEnvironmentVariable("ECS_LOGFILE", "$ProgramData\Amazon\ECS\log\ecs-agent.log", "Machine")
-PS C:\> [Environment]::SetEnvironmentVariable("ECS_DATADIR", "$ProgramData\Amazon\ECS\data", "Machine")
+PS C:\> [Environment]::SetEnvironmentVariable("ECS_LOGFILE", "${env:ProgramData}\Amazon\ECS\log\ecs-agent.log", "Machine")
+PS C:\> [Environment]::SetEnvironmentVariable("ECS_DATADIR", "${env:ProgramData}\Amazon\ECS\data", "Machine")
 PS C:\> # Download the agent
 PS C:\> $agentVersion = "latest"
 PS C:\> $agentZipUri = "https://s3.amazonaws.com/amazon-ecs-agent/ecs-agent-windows-$agentVersion.zip"
-PS C:\> $zipFile = "$env:TEMP\ecs-agent.zip"
+PS C:\> $zipFile = "${env:TEMP}\ecs-agent.zip"
 PS C:\> Invoke-RestMethod -OutFile $zipFile -Uri $agentZipUri
 PS C:\> # Put the executables in the executable directory.
 PS C:\> Expand-Archive -Path $zipFile -DestinationPath $ecsExeDir -Force
-PS C:\> # Uncomment the following line to enable task IAM roles.
+PS C:\> Set-Location ${ecsExeDir}
+PS C:\> # Set $EnableTaskIAMRoles to $true to enable task IAM roles
 PS C:\> # Note that enabling IAM roles will make port 80 unavailable for tasks.
-PS C:\> # cd '$ecsExeDir'; .\hostsetup.ps1
+PS C:\> [bool]$EnableTaskIAMRoles = $false
+PS C:\> if (${EnableTaskIAMRoles} {
+>> .\hostsetup.ps1
+>> }
 PS C:\> # Install the agent service
 PS C:\> New-Service -Name "AmazonECS" `
         -BinaryPathName "$ecsExeDir\amazon-ecs-agent.exe -windows-service" `
@@ -93,19 +97,19 @@ Start-Service AmazonECS
 
 ```powershell
 PS C:\> # Set up directories the agent uses
-PS C:\> New-Item -Type directory -Path $ProgramFiles\Amazon\ECS
-PS C:\> New-Item -Type directory -Path $ProgramData\Amazon\ECS
+PS C:\> New-Item -Type directory -Path ${env:ProgramFiles}\Amazon\ECS -Force
+PS C:\> New-Item -Type directory -Path ${env:ProgramData}\Amazon\ECS -Force
 PS C:\> # Set up configuration
-PS C:\> $ecsExeDir = "$env:ProgramFiles\Amazon\ECS"
+PS C:\> $ecsExeDir = "${env:ProgramFiles}\Amazon\ECS"
 PS C:\> [Environment]::SetEnvironmentVariable("ECS_CLUSTER", "my-windows-cluster", "Machine")
-PS C:\> [Environment]::SetEnvironmentVariable("ECS_LOGFILE", "$ProgramData\Amazon\ECS\log\ecs-agent.log", "Machine")
-PS C:\> [Environment]::SetEnvironmentVariable("ECS_DATADIR", "$ProgramData\Amazon\ECS\data", "Machine")
+PS C:\> [Environment]::SetEnvironmentVariable("ECS_LOGFILE", "${env:ProgramData}\Amazon\ECS\log\ecs-agent.log", "Machine")
+PS C:\> [Environment]::SetEnvironmentVariable("ECS_DATADIR", "${env:ProgramData}\Amazon\ECS\data", "Machine")
 PS C:\> # Set this environment variable to "true" to enable IAM roles.  Note that enabling IAM roles will make port 80 unavailable for tasks.
 PS C:\> [Environment]::SetEnvironmentVariable("ECS_ENABLE_TASK_IAM_ROLE", "false", "Machine")
 PS C:\> # Download the agent
 PS C:\> $agentVersion = "latest"
 PS C:\> $agentZipUri = "https://s3.amazonaws.com/amazon-ecs-agent/ecs-agent-windows-$agentVersion.zip"
-PS C:\> $zipFile = "$env:TEMP\ecs-agent.zip"
+PS C:\> $zipFile = "${env:TEMP}\ecs-agent.zip"
 PS C:\> Invoke-RestMethod -OutFile $zipFile -Uri $agentZipUri
 PS C:\> # Put the executables in the executable directory.
 PS C:\> Expand-Archive -Path $zipFile -DestinationPath $ecsExeDir -Force

--- a/README.md
+++ b/README.md
@@ -48,10 +48,48 @@ See also the Advanced Usage section below.
 
 ### On Windows Server 2016
 
-On Windows Server 2016, the Amazon ECS Container Agent runs as a process on the
-host. Unlike Linux, the agent may not run inside a container as it uses the
-host's registry and the named pipe at `\\.\pipe\docker_engine` to communicate
-with the Docker daemon.
+On Windows Server 2016, the Amazon ECS Container Agent runs as a process or
+service on the host. Unlike Linux, the agent may not run inside a container as
+it uses the host's registry and the named pipe at `\\.\pipe\docker_engine` to
+communicate with the Docker daemon.
+
+#### As a Service
+To install the service, you can do the following:
+
+```powershell
+PS C:\> # Set up directories the agent uses
+PS C:\> New-Item -Type directory -Path $ProgramFiles\Amazon\ECS
+PS C:\> New-Item -Type directory -Path $ProgramData\Amazon\ECS
+PS C:\> # Set up configuration
+PS C:\> $ecsExeDir = "$env:ProgramFiles\Amazon\ECS"
+PS C:\> [Environment]::SetEnvironmentVariable("ECS_CLUSTER", "my-windows-cluster", "Machine")
+PS C:\> [Environment]::SetEnvironmentVariable("ECS_LOGFILE", "$ProgramData\Amazon\ECS\log\ecs-agent.log", "Machine")
+PS C:\> [Environment]::SetEnvironmentVariable("ECS_DATADIR", "$ProgramData\Amazon\ECS\data", "Machine")
+PS C:\> # Download the agent
+PS C:\> $agentVersion = "latest"
+PS C:\> $agentZipUri = "https://s3.amazonaws.com/amazon-ecs-agent/ecs-agent-windows-$agentVersion.zip"
+PS C:\> $zipFile = "$env:TEMP\ecs-agent.zip"
+PS C:\> Invoke-RestMethod -OutFile $zipFile -Uri $agentZipUri
+PS C:\> # Put the executables in the executable directory.
+PS C:\> Expand-Archive -Path $zipFile -DestinationPath $ecsExeDir -Force
+PS C:\> # Uncomment the following line to enable task IAM roles.
+PS C:\> # Note that enabling IAM roles will make port 80 unavailable for tasks.
+PS C:\> # cd '$ecsExeDir'; .\hostsetup.ps1
+PS C:\> # Install the agent service
+PS C:\> New-Service -Name "AmazonECS" `
+        -BinaryPathName "$ecsExeDir\amazon-ecs-agent.exe -windows-service" `
+        -DisplayName "Amazon ECS" `
+        -Description "Amazon ECS service runs the Amazon ECS agent" `
+        -DependsOn Docker `
+        -StartupType Manual
+```
+
+To run the service, you can do the following:
+```powershell
+Start-Service AmazonECS
+```
+
+#### As a Process
 
 ```powershell
 PS C:\> # Set up directories the agent uses

--- a/agent/Gopkg.lock
+++ b/agent/Gopkg.lock
@@ -143,7 +143,7 @@
 
 [[projects]]
   name = "golang.org/x/sys"
-  packages = ["unix","windows","windows/registry"]
+  packages = ["unix","windows","windows/registry","windows/svc","windows/svc/eventlog"]
   revision = "afadfcc7779c1f4db0f6f6438afcb108d9c9c7cd"
 
 [[projects]]
@@ -154,6 +154,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "7622bf3f939a3ea183688145cbae7aee8a0513f27191096a17be1956d727ea36"
+  inputs-digest = "c09c3275be0ca13e00eca77147f1689e0d619e64b233e3dfdbda494c09215118"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -46,9 +46,9 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 	"github.com/aws/amazon-ecs-agent/agent/version"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	aws_credentials "github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/defaults"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/cihub/seelog"
 )
 
@@ -76,8 +76,12 @@ type agent interface {
 	// printECSAttributes prints the Agent's capabilities based on
 	// its environment
 	printECSAttributes() int
+	// startWindowsService starts the agent as a Windows Service
+	startWindowsService() int
 	// start starts the Agent execution
 	start() int
+	// setTerminationHandler sets the termination handler
+	setTerminationHandler(sighandlers.TerminationHandler)
 }
 
 // ecsAgent wraps all the entities needed to start the ECS Agent execution.
@@ -100,9 +104,10 @@ type ecsAgent struct {
 	mac                   string
 	metadataManager       containermetadata.Manager
 	resource              resources.Resource
+	terminationHandler    sighandlers.TerminationHandler
 }
 
-// newAgent returns a new ecsAgent object
+// newAgent returns a new ecsAgent object, but does not start anything
 func newAgent(
 	ctx context.Context,
 	blackholeEC2Metadata bool,
@@ -158,9 +163,10 @@ func newAgent(
 			PluginsPath:            cfg.CNIPluginsPath,
 			MinSupportedCNIVersion: config.DefaultMinSupportedCNIVersion,
 		}),
-		os:              oswrapper.New(),
-		metadataManager: metadataManager,
-		resource:        resources.New(),
+		os:                 oswrapper.New(),
+		metadataManager:    metadataManager,
+		resource:           resources.New(),
+		terminationHandler: sighandlers.StartDefaultTerminationHandler,
 	}, nil
 }
 
@@ -182,6 +188,10 @@ func (agent *ecsAgent) printECSAttributes() int {
 		fmt.Printf("%s\t%s\n", aws.StringValue(attr.Name), aws.StringValue(attr.Value))
 	}
 	return exitcodes.ExitSuccess
+}
+
+func (agent *ecsAgent) setTerminationHandler(handler sighandlers.TerminationHandler) {
+	agent.terminationHandler = handler
 }
 
 // start starts the ECS Agent
@@ -514,7 +524,7 @@ func (agent *ecsAgent) startAsyncRoutines(
 		go imageManager.StartImageCleanupProcess(agent.ctx)
 	}
 
-	go sighandlers.StartTerminationHandler(stateManager, taskEngine)
+	go agent.terminationHandler(stateManager, taskEngine)
 
 	// Agent introspection api
 	go handlers.ServeHttp(&agent.containerInstanceARN, taskEngine, agent.cfg)

--- a/agent/app/agent_unix.go
+++ b/agent/app/agent_unix.go
@@ -41,6 +41,12 @@ var awsVPCCNIPlugins = []string{ecscni.ECSENIPluginName,
 	ecscni.ECSIPAMPluginName,
 }
 
+// startWindowsService is not supported on Linux
+func (agent *ecsAgent) startWindowsService() int {
+	seelog.Error("Windows Services are not supported on Linux")
+	return 1
+}
+
 // initializeTaskENIDependencies initializes all of the dependencies required by
 // the Agent to support the 'awsvpc' networking mode. A non nil error is returned
 // if an error is encountered during this process. An additional boolean flag to

--- a/agent/app/agent_unix_test.go
+++ b/agent/app/agent_unix_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
 	"github.com/aws/amazon-ecs-agent/agent/resources/mock_resources"
 	"github.com/aws/amazon-ecs-agent/agent/sighandlers/exitcodes"
+	"github.com/aws/amazon-ecs-agent/agent/statemanager"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/golang/mock/gomock"
@@ -100,6 +101,7 @@ func TestDoStartHappyPath(t *testing.T) {
 		cfg:                &cfg,
 		credentialProvider: credentials.NewCredentials(mockCredentialsProvider),
 		dockerClient:       dockerClient,
+		terminationHandler: func(saver statemanager.Saver, taskEngine engine.TaskEngine) {},
 	}
 
 	go agent.doStart(eventstream.NewEventStream("events", ctx),
@@ -198,6 +200,7 @@ func TestDoStartTaskENIHappyPath(t *testing.T) {
 		cniClient:          cniClient,
 		os:                 mockOS,
 		ec2MetadataClient:  mockMetadata,
+		terminationHandler: func(saver statemanager.Saver, taskEngine engine.TaskEngine) {},
 	}
 
 	go agent.doStart(eventstream.NewEventStream("events", ctx),
@@ -497,6 +500,7 @@ func TestDoStartCgroupInitHappyPath(t *testing.T) {
 		credentialProvider: credentials.NewCredentials(mockCredentialsProvider),
 		dockerClient:       dockerClient,
 		resource:           mockResource,
+		terminationHandler: func(saver statemanager.Saver, taskEngine engine.TaskEngine) {},
 	}
 
 	go agent.doStart(eventstream.NewEventStream("events", ctx),
@@ -537,6 +541,7 @@ func TestDoStartCgroupInitErrorPath(t *testing.T) {
 		credentialProvider: credentials.NewCredentials(mockCredentialsProvider),
 		dockerClient:       dockerClient,
 		resource:           mockResource,
+		terminationHandler: func(saver statemanager.Saver, taskEngine engine.TaskEngine) {},
 	}
 
 	status := agent.doStart(eventstream.NewEventStream("events", ctx),

--- a/agent/app/agent_windows.go
+++ b/agent/app/agent_windows.go
@@ -175,14 +175,8 @@ func (h *handler) runAgent(ctx context.Context) {
 
 // sleepCtx provides a cancelable sleep
 func sleepCtx(ctx context.Context, duration time.Duration) {
-	done := make(chan struct{})
-	time.AfterFunc(duration, func() {
-		close(done)
-	})
-	select {
-	case <-ctx.Done():
-	case <-done:
-	}
+	derivedCtx, _ := context.WithDeadline(ctx, time.Now().Add(duration))
+	<-derivedCtx.Done()
 }
 
 type termHandlerIndicator struct {

--- a/agent/app/agent_windows.go
+++ b/agent/app/agent_windows.go
@@ -78,7 +78,8 @@ func (h *handler) Execute(args []string, requests <-chan svc.ChangeRequest, resp
 	select {
 	case <-windowsDone:
 		// Service was told to stop by the Windows API.  This happens either through manual intervention (i.e.,
-		// "Stop-Service ECS") or through system shutdown.  Regardless, this is a normal exit event and not an error.
+		// "Stop-Service AmazonECS") or through system shutdown.  Regardless, this is a normal exit event and not an
+		// error.
 		seelog.Info("Received normal signal from Windows to exit")
 	case <-agentDone:
 		// This means that the agent stopped on its own.  This is where it's appropriate to light the event log on fire

--- a/agent/app/agent_windows.go
+++ b/agent/app/agent_windows.go
@@ -1,0 +1,188 @@
+// +build windows
+
+// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package app
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/aws/amazon-ecs-agent/agent/engine"
+	"github.com/aws/amazon-ecs-agent/agent/sighandlers"
+	"github.com/aws/amazon-ecs-agent/agent/statemanager"
+	"github.com/cihub/seelog"
+	"golang.org/x/sys/windows/svc"
+)
+
+const (
+	//EcsSvcName is the name of the service
+	EcsSvcName = "AmazonECS"
+)
+
+// startWindowsService runs the ECS agent as a Windows Service
+func (agent *ecsAgent) startWindowsService() int {
+	svc.Run(EcsSvcName, newHandler(agent))
+	return 0
+}
+
+// handler implements https://godoc.org/golang.org/x/sys/windows/svc#Handler
+type handler struct {
+	ecsAgent agent
+}
+
+func newHandler(agent agent) *handler {
+	return &handler{agent}
+}
+
+// Execute implements https://godoc.org/golang.org/x/sys/windows/svc#Handler
+// The basic way that this implementation works is through two channels (representing the requests from Windows and the
+// responses we're sending to Windows) and two goroutines (one for message processing with Windows and the other to
+// actually run the agent).  Once we've set everything up and started both goroutines, we wait for either one to exit
+// (the Windows goroutine will exit based on messages from Windows while the agent goroutine exits if the agent exits)
+// and then cancel the other.  Once everything has stopped running, this function returns and the process exits.
+func (h *handler) Execute(args []string, requests <-chan svc.ChangeRequest, responses chan<- svc.Status) (bool, uint32) {
+	// channels for communication between goroutines
+	ctx, cancel := context.WithCancel(context.Background())
+	agentDone := make(chan struct{})
+	windowsDone := make(chan struct{})
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+
+	go func() {
+		defer close(windowsDone)
+		defer wg.Done()
+		h.handleWindowsRequests(ctx, requests, responses)
+	}()
+
+	go func() {
+		defer close(agentDone)
+		defer wg.Done()
+		h.runAgent(ctx)
+	}()
+
+	// Wait until one of the goroutines is either told to stop or fails spectacularly.  Under normal conditions we will
+	// be waiting here for a long time.
+	select {
+	case <-windowsDone:
+		// Service was told to stop by the Windows API.  This happens either through manual intervention (i.e.,
+		// "Stop-Service ECS") or through system shutdown.  Regardless, this is a normal exit event and not an error.
+		seelog.Info("Received normal signal from Windows to exit")
+	case <-agentDone:
+		// This means that the agent stopped on its own.  This is where it's appropriate to light the event log on fire
+		// and set off all the alarms.
+		seelog.Error("Exiting")
+	}
+	cancel()
+	wg.Wait()
+	return true, 0
+}
+
+// handleWindowsRequests is a loop intended to run in a goroutine.  It handles bidirectional communication with the
+// Windows service manager.  This function works by pretty much immediately moving to running and then waiting for a
+// stop or shut down message from Windows or to be canceled (which could happen if the agent exits by itself and the
+// calling function cancels the context).
+func (h *handler) handleWindowsRequests(ctx context.Context, requests <-chan svc.ChangeRequest, responses chan<- svc.Status) {
+	// Immediately tell Windows that we are pending service start.
+	responses <- svc.Status{State: svc.StartPending}
+	seelog.Info("Starting Windows service")
+
+	// TODO: Pre-start hooks go here (unclear if we need any yet)
+
+	// https://msdn.microsoft.com/en-us/library/windows/desktop/ms682108(v=vs.85).aspx
+	// Not sure if a better link exists to describe what these values mean
+	accepts := svc.AcceptStop | svc.AcceptShutdown
+
+	// Announce that we are running and we accept the above-mentioned commands
+	responses <- svc.Status{State: svc.Running, Accepts: accepts}
+
+	defer func() {
+		// Announce that we are stopping
+		seelog.Info("Stopping Windows service")
+		responses <- svc.Status{State: svc.StopPending}
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case r := <-requests:
+			switch r.Cmd {
+			case svc.Interrogate:
+				// Our status doesn't change unless we are told to stop or shutdown
+				responses <- r.CurrentStatus
+			case svc.Stop, svc.Shutdown:
+				return
+			default:
+				continue
+			}
+		}
+	}
+}
+
+// runAgent runs the ECS agent inside a goroutine and waits to be told to exit.
+func (h *handler) runAgent(ctx context.Context) {
+	agentCtx, cancel := context.WithCancel(ctx)
+	wg := sync.WaitGroup{}
+	running := true
+	terminationHandler := func(saver statemanager.Saver, taskEngine engine.TaskEngine) {
+		// We're using a waitgroup, a context, and a simple flag here.  The waitgroup gets added to as soon as this
+		// handler is invoked (agent.start() ultimately invokes it in a goroutine) so that at the end of the outer
+		// runAgent() function we know to wait for the handler to complete.  We then block on the context being
+		// canceled; this is our signal that the handler should actually run (happens either when the parent context is
+		// canceled because Windows told us to exit, or because the agent goroutine below exited unexpectedly).  The
+		// flag gets evaluated so that we know whether to actually save state; if the agent isn't properly running, we
+		// may not actually have any data to save.
+		wg.Add(1)
+		defer wg.Done()
+		<-agentCtx.Done()
+		if !running {
+			return
+		}
+
+		seelog.Info("Termination handler received signal to stop")
+		err := sighandlers.FinalSave(saver, taskEngine)
+		if err != nil {
+			seelog.Criticalf("Error saving state before final shutdown: %v", err)
+		}
+	}
+	h.ecsAgent.setTerminationHandler(terminationHandler)
+
+	go func() {
+		h.ecsAgent.start() // should block forever, unless there is an error
+		// TODO: distinguish between recoverable and unrecoverable errors
+		running = false
+		cancel()
+	}()
+
+	sleepCtx(agentCtx, time.Minute) // give the agent a minute to start and invoke terminationHandler
+
+	// wait for the termination handler to run.  Once the termination handler runs, we can safely exit.  If the agent
+	// exits by itself, the termination handler doesn't need to do anything and skips.  If the agent exits before the
+	// termination handler is invoked, we can exit immediately.
+	wg.Wait()
+}
+
+// sleepCtx provides a cancelable sleep
+func sleepCtx(ctx context.Context, duration time.Duration) {
+	done := make(chan struct{})
+	time.AfterFunc(duration, func() {
+		close(done)
+	})
+	select {
+	case <-ctx.Done():
+	case <-done:
+	}
+}

--- a/agent/app/args/flag.go
+++ b/agent/app/args/flag.go
@@ -18,10 +18,11 @@ import "flag"
 const (
 	versionUsage             = "Print the agent version information and exit"
 	logLevelUsage            = "Loglevel: [<crit>|<error>|<warn>|<info>|<debug>]"
+	ecsAttributesUsage       = "Print the Agent's ECS Attributes based on its environment"
 	acceptInsecureCertUsage  = "Disable SSL certificate verification. We do not recommend setting this option"
 	licenseUsage             = "Print the LICENSE and NOTICE files and exit"
 	blacholeEC2MetadataUsage = "Blackhole the EC2 Metadata requests. Setting this option can cause the ECS Agent to fail to work properly.  We do not recommend setting this option"
-	ecsAttributesUsage       = "Print the Agent's ECS Attributes based on its environment"
+	windowsServiceUsage      = "Run the ECS agent as a Windows Service"
 
 	versionFlagName              = "version"
 	logLevelFlagName             = "loglevel"
@@ -29,6 +30,7 @@ const (
 	acceptInsecureCertFlagName   = "k"
 	licenseFlagName              = "license"
 	blackholeEC2MetadataFlagName = "blackhole-ec2-metadata"
+	windowsServiceFlagName       = "windows-service"
 )
 
 // Args wraps various ECS Agent arguments
@@ -47,6 +49,8 @@ type Args struct {
 	BlackholeEC2Metadata *bool
 	// ECSAttributes indicates that the agent should print its attributes
 	ECSAttributes *bool
+	// WindowsService indicates that the agent should run as a Windows service
+	WindowsService *bool
 }
 
 // New creates a new Args object from the argument list
@@ -60,6 +64,7 @@ func New(arguments []string) (*Args, error) {
 		License:              flagset.Bool(licenseFlagName, false, licenseUsage),
 		BlackholeEC2Metadata: flagset.Bool(blackholeEC2MetadataFlagName, false, blacholeEC2MetadataUsage),
 		ECSAttributes:        flagset.Bool(ecsAttributesFlagName, false, ecsAttributesUsage),
+		WindowsService:       flagset.Bool(windowsServiceFlagName, false, windowsServiceUsage),
 	}
 
 	err := flagset.Parse(arguments)

--- a/agent/app/run.go
+++ b/agent/app/run.go
@@ -56,6 +56,9 @@ func Run(arguments []string) int {
 	case *parsedArgs.ECSAttributes:
 		// Print agent's ecs attributes based on its environment and exit
 		return agent.printECSAttributes()
+	case *parsedArgs.WindowsService:
+		// Enable Windows Service
+		return agent.startWindowsService()
 	default:
 		// Start the agent
 		return agent.start()

--- a/agent/logger/eventlog_windows.go
+++ b/agent/logger/eventlog_windows.go
@@ -1,0 +1,84 @@
+// +build windows
+
+// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package logger
+
+import (
+	"github.com/cihub/seelog"
+	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/svc/eventlog"
+)
+
+/*
+TODO: Make this whole thing better
+
+What's here right now is a stub just so that agent logs can appear in the Event Log.  Longer term, we should do a few
+things to make this better:
+
+1) Don't use init() and a package-global variable
+2) Conform to the MSDN guidelines about event log data.
+
+References to MSDN guidelines can be found here:
+* https://msdn.microsoft.com/en-us/library/windows/desktop/aa363632(v=vs.85).aspx
+* https://msdn.microsoft.com/en-us/library/windows/desktop/aa363648(v=vs.85).aspx
+* https://msdn.microsoft.com/en-us/library/windows/desktop/aa363661(v=vs.85).aspx
+* https://msdn.microsoft.com/en-us/library/windows/desktop/aa363669(v=vs.85).aspx
+*/
+
+const (
+	eventLogName = "AmazonECSAgent"
+	eventLogID   = 999
+)
+
+// eventLogReceiver fulfills the seelog.CustomReceiver interface
+type eventLogReceiver struct{}
+
+var eventLog *eventlog.Log
+
+func init() {
+	eventlog.InstallAsEventCreate(eventLogName, windows.EVENTLOG_INFORMATION_TYPE|windows.EVENTLOG_WARNING_TYPE|windows.EVENTLOG_ERROR_TYPE)
+	var err error
+	eventLog, err = eventlog.Open(eventLogName)
+	if err != nil {
+		panic(err)
+	}
+}
+
+// registerPlatformLogger registers the eventLogReceiver
+func registerPlatformLogger() {
+	seelog.RegisterReceiver("wineventlog", &eventLogReceiver{})
+}
+
+// platformLogConfig exposes log configuration for the event log receiver
+func platformLogConfig() string {
+	return `<custom name="wineventlog" formatid="windows" />`
+}
+
+// ReceiveMessage receives a log line from seelog and emits it to the Windows event log
+func (r *eventLogReceiver) ReceiveMessage(message string, level seelog.LogLevel, context seelog.LogContextInterface) error {
+	switch level {
+	case seelog.DebugLvl, seelog.InfoLvl:
+		return eventLog.Info(eventLogID, message)
+	case seelog.WarnLvl:
+		return eventLog.Warning(eventLogID, message)
+	case seelog.ErrorLvl, seelog.CriticalLvl:
+		return eventLog.Error(eventLogID, message)
+	}
+	return nil
+}
+
+func (r *eventLogReceiver) AfterParse(initArgs seelog.CustomReceiverInitArgs) error { return nil }
+func (r *eventLogReceiver) Flush()                                                  {}
+func (r *eventLogReceiver) Close() error                                            { return nil }

--- a/agent/logger/log.go
+++ b/agent/logger/log.go
@@ -59,6 +59,7 @@ func initLogger() {
 
 	logfile = os.Getenv(LOGFILE_ENV_VAR)
 	SetLevel(envLevel)
+	registerPlatformLogger()
 	reloadConfig()
 }
 
@@ -86,7 +87,7 @@ func SetLevel(logLevel string) {
 // GetLevel gets the log level
 func GetLevel() string {
 	levelLock.RLock()
-	defer levelLock.RLock()
+	defer levelLock.RUnlock()
 
 	return level
 }

--- a/agent/logger/platform_unix.go
+++ b/agent/logger/platform_unix.go
@@ -1,0 +1,22 @@
+// +build !windows
+
+// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package logger
+
+// registerPlatformLogger does nothing on Linux
+func registerPlatformLogger() {}
+
+// platformLogConfig does nothing on Linux
+func platformLogConfig() string { return "" }

--- a/agent/logger/seelog_config.go
+++ b/agent/logger/seelog_config.go
@@ -18,6 +18,7 @@ func loggerConfig() string {
 	<seelog type="asyncloop" minlevel="` + level + `">
 		<outputs formatid="main">
 			<console />`
+	config += platformLogConfig()
 	if logfile != "" {
 		config += `<rollingfile filename="` + logfile + `" type="date"
 			 datepattern="2006-01-02-15" archivetype="none" maxrolls="24" />`
@@ -26,6 +27,7 @@ func loggerConfig() string {
 		</outputs>
 		<formats>
 			<format id="main" format="%UTCDate(2006-01-02T15:04:05Z07:00) [%LEVEL] %Msg%n" />
+			<format id="windows" format="%Msg" />
 		</formats>
 	</seelog>
 `

--- a/agent/vendor/golang.org/x/sys/windows/svc/event.go
+++ b/agent/vendor/golang.org/x/sys/windows/svc/event.go
@@ -1,0 +1,48 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build windows
+
+package svc
+
+import (
+	"errors"
+
+	"golang.org/x/sys/windows"
+)
+
+// event represents auto-reset, initially non-signaled Windows event.
+// It is used to communicate between go and asm parts of this package.
+type event struct {
+	h windows.Handle
+}
+
+func newEvent() (*event, error) {
+	h, err := windows.CreateEvent(nil, 0, 0, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &event{h: h}, nil
+}
+
+func (e *event) Close() error {
+	return windows.CloseHandle(e.h)
+}
+
+func (e *event) Set() error {
+	return windows.SetEvent(e.h)
+}
+
+func (e *event) Wait() error {
+	s, err := windows.WaitForSingleObject(e.h, windows.INFINITE)
+	switch s {
+	case windows.WAIT_OBJECT_0:
+		break
+	case windows.WAIT_FAILED:
+		return err
+	default:
+		return errors.New("unexpected result from WaitForSingleObject")
+	}
+	return nil
+}

--- a/agent/vendor/golang.org/x/sys/windows/svc/eventlog/install.go
+++ b/agent/vendor/golang.org/x/sys/windows/svc/eventlog/install.go
@@ -1,0 +1,80 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build windows
+
+package eventlog
+
+import (
+	"errors"
+
+	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/registry"
+)
+
+const (
+	// Log levels.
+	Info    = windows.EVENTLOG_INFORMATION_TYPE
+	Warning = windows.EVENTLOG_WARNING_TYPE
+	Error   = windows.EVENTLOG_ERROR_TYPE
+)
+
+const addKeyName = `SYSTEM\CurrentControlSet\Services\EventLog\Application`
+
+// Install modifies PC registry to allow logging with an event source src.
+// It adds all required keys and values to the event log registry key.
+// Install uses msgFile as the event message file. If useExpandKey is true,
+// the event message file is installed as REG_EXPAND_SZ value,
+// otherwise as REG_SZ. Use bitwise of log.Error, log.Warning and
+// log.Info to specify events supported by the new event source.
+func Install(src, msgFile string, useExpandKey bool, eventsSupported uint32) error {
+	appkey, err := registry.OpenKey(registry.LOCAL_MACHINE, addKeyName, registry.CREATE_SUB_KEY)
+	if err != nil {
+		return err
+	}
+	defer appkey.Close()
+
+	sk, alreadyExist, err := registry.CreateKey(appkey, src, registry.SET_VALUE)
+	if err != nil {
+		return err
+	}
+	defer sk.Close()
+	if alreadyExist {
+		return errors.New(addKeyName + `\` + src + " registry key already exists")
+	}
+
+	err = sk.SetDWordValue("CustomSource", 1)
+	if err != nil {
+		return err
+	}
+	if useExpandKey {
+		err = sk.SetExpandStringValue("EventMessageFile", msgFile)
+	} else {
+		err = sk.SetStringValue("EventMessageFile", msgFile)
+	}
+	if err != nil {
+		return err
+	}
+	err = sk.SetDWordValue("TypesSupported", eventsSupported)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// InstallAsEventCreate is the same as Install, but uses
+// %SystemRoot%\System32\EventCreate.exe as the event message file.
+func InstallAsEventCreate(src string, eventsSupported uint32) error {
+	return Install(src, "%SystemRoot%\\System32\\EventCreate.exe", true, eventsSupported)
+}
+
+// Remove deletes all registry elements installed by the correspondent Install.
+func Remove(src string) error {
+	appkey, err := registry.OpenKey(registry.LOCAL_MACHINE, addKeyName, registry.SET_VALUE)
+	if err != nil {
+		return err
+	}
+	defer appkey.Close()
+	return registry.DeleteKey(appkey, src)
+}

--- a/agent/vendor/golang.org/x/sys/windows/svc/eventlog/log.go
+++ b/agent/vendor/golang.org/x/sys/windows/svc/eventlog/log.go
@@ -1,0 +1,70 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build windows
+
+// Package eventlog implements access to Windows event log.
+//
+package eventlog
+
+import (
+	"errors"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+// Log provides access to the system log.
+type Log struct {
+	Handle windows.Handle
+}
+
+// Open retrieves a handle to the specified event log.
+func Open(source string) (*Log, error) {
+	return OpenRemote("", source)
+}
+
+// OpenRemote does the same as Open, but on different computer host.
+func OpenRemote(host, source string) (*Log, error) {
+	if source == "" {
+		return nil, errors.New("Specify event log source")
+	}
+	var s *uint16
+	if host != "" {
+		s = syscall.StringToUTF16Ptr(host)
+	}
+	h, err := windows.RegisterEventSource(s, syscall.StringToUTF16Ptr(source))
+	if err != nil {
+		return nil, err
+	}
+	return &Log{Handle: h}, nil
+}
+
+// Close closes event log l.
+func (l *Log) Close() error {
+	return windows.DeregisterEventSource(l.Handle)
+}
+
+func (l *Log) report(etype uint16, eid uint32, msg string) error {
+	ss := []*uint16{syscall.StringToUTF16Ptr(msg)}
+	return windows.ReportEvent(l.Handle, etype, 0, eid, 0, 1, 0, &ss[0], nil)
+}
+
+// Info writes an information event msg with event id eid to the end of event log l.
+// When EventCreate.exe is used, eid must be between 1 and 1000.
+func (l *Log) Info(eid uint32, msg string) error {
+	return l.report(windows.EVENTLOG_INFORMATION_TYPE, eid, msg)
+}
+
+// Warning writes an warning event msg with event id eid to the end of event log l.
+// When EventCreate.exe is used, eid must be between 1 and 1000.
+func (l *Log) Warning(eid uint32, msg string) error {
+	return l.report(windows.EVENTLOG_WARNING_TYPE, eid, msg)
+}
+
+// Error writes an error event msg with event id eid to the end of event log l.
+// When EventCreate.exe is used, eid must be between 1 and 1000.
+func (l *Log) Error(eid uint32, msg string) error {
+	return l.report(windows.EVENTLOG_ERROR_TYPE, eid, msg)
+}

--- a/agent/vendor/golang.org/x/sys/windows/svc/eventlog/log_test.go
+++ b/agent/vendor/golang.org/x/sys/windows/svc/eventlog/log_test.go
@@ -1,0 +1,51 @@
+// Copyright 2012 The Go Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build windows
+
+package eventlog_test
+
+import (
+	"testing"
+
+	"golang.org/x/sys/windows/svc/eventlog"
+)
+
+func TestLog(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode - it modifies system logs")
+	}
+
+	const name = "mylog"
+	const supports = eventlog.Error | eventlog.Warning | eventlog.Info
+	err := eventlog.InstallAsEventCreate(name, supports)
+	if err != nil {
+		t.Fatalf("Install failed: %s", err)
+	}
+	defer func() {
+		err = eventlog.Remove(name)
+		if err != nil {
+			t.Fatalf("Remove failed: %s", err)
+		}
+	}()
+
+	l, err := eventlog.Open(name)
+	if err != nil {
+		t.Fatalf("Open failed: %s", err)
+	}
+	defer l.Close()
+
+	err = l.Info(1, "info")
+	if err != nil {
+		t.Fatalf("Info failed: %s", err)
+	}
+	err = l.Warning(2, "warning")
+	if err != nil {
+		t.Fatalf("Warning failed: %s", err)
+	}
+	err = l.Error(3, "error")
+	if err != nil {
+		t.Fatalf("Error failed: %s", err)
+	}
+}

--- a/agent/vendor/golang.org/x/sys/windows/svc/go12.c
+++ b/agent/vendor/golang.org/x/sys/windows/svc/go12.c
@@ -1,0 +1,24 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build windows
+// +build !go1.3
+
+// copied from pkg/runtime
+typedef	unsigned int	uint32;
+typedef	unsigned long long int	uint64;
+#ifdef _64BIT
+typedef	uint64		uintptr;
+#else
+typedef	uint32		uintptr;
+#endif
+
+// from sys_386.s or sys_amd64.s
+void ·servicemain(void);
+
+void
+·getServiceMain(uintptr *r)
+{
+	*r = (uintptr)·servicemain;
+}

--- a/agent/vendor/golang.org/x/sys/windows/svc/go12.go
+++ b/agent/vendor/golang.org/x/sys/windows/svc/go12.go
@@ -1,0 +1,11 @@
+// Copyright 2014 The Go Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build windows
+// +build !go1.3
+
+package svc
+
+// from go12.c
+func getServiceMain(r *uintptr)

--- a/agent/vendor/golang.org/x/sys/windows/svc/go13.go
+++ b/agent/vendor/golang.org/x/sys/windows/svc/go13.go
@@ -1,0 +1,31 @@
+// Copyright 2014 The Go Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build windows
+// +build go1.3
+
+package svc
+
+import "unsafe"
+
+const ptrSize = 4 << (^uintptr(0) >> 63) // unsafe.Sizeof(uintptr(0)) but an ideal const
+
+// Should be a built-in for unsafe.Pointer?
+func add(p unsafe.Pointer, x uintptr) unsafe.Pointer {
+	return unsafe.Pointer(uintptr(p) + x)
+}
+
+// funcPC returns the entry PC of the function f.
+// It assumes that f is a func value. Otherwise the behavior is undefined.
+func funcPC(f interface{}) uintptr {
+	return **(**uintptr)(add(unsafe.Pointer(&f), ptrSize))
+}
+
+// from sys_386.s and sys_amd64.s
+func servicectlhandler(ctl uint32) uintptr
+func servicemain(argc uint32, argv **uint16)
+
+func getServiceMain(r *uintptr) {
+	*r = funcPC(servicemain)
+}

--- a/agent/vendor/golang.org/x/sys/windows/svc/security.go
+++ b/agent/vendor/golang.org/x/sys/windows/svc/security.go
@@ -1,0 +1,62 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build windows
+
+package svc
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+func allocSid(subAuth0 uint32) (*windows.SID, error) {
+	var sid *windows.SID
+	err := windows.AllocateAndInitializeSid(&windows.SECURITY_NT_AUTHORITY,
+		1, subAuth0, 0, 0, 0, 0, 0, 0, 0, &sid)
+	if err != nil {
+		return nil, err
+	}
+	return sid, nil
+}
+
+// IsAnInteractiveSession determines if calling process is running interactively.
+// It queries the process token for membership in the Interactive group.
+// http://stackoverflow.com/questions/2668851/how-do-i-detect-that-my-application-is-running-as-service-or-in-an-interactive-s
+func IsAnInteractiveSession() (bool, error) {
+	interSid, err := allocSid(windows.SECURITY_INTERACTIVE_RID)
+	if err != nil {
+		return false, err
+	}
+	defer windows.FreeSid(interSid)
+
+	serviceSid, err := allocSid(windows.SECURITY_SERVICE_RID)
+	if err != nil {
+		return false, err
+	}
+	defer windows.FreeSid(serviceSid)
+
+	t, err := windows.OpenCurrentProcessToken()
+	if err != nil {
+		return false, err
+	}
+	defer t.Close()
+
+	gs, err := t.GetTokenGroups()
+	if err != nil {
+		return false, err
+	}
+	p := unsafe.Pointer(&gs.Groups[0])
+	groups := (*[2 << 20]windows.SIDAndAttributes)(p)[:gs.GroupCount]
+	for _, g := range groups {
+		if windows.EqualSid(g.Sid, interSid) {
+			return true, nil
+		}
+		if windows.EqualSid(g.Sid, serviceSid) {
+			return false, nil
+		}
+	}
+	return false, nil
+}

--- a/agent/vendor/golang.org/x/sys/windows/svc/service.go
+++ b/agent/vendor/golang.org/x/sys/windows/svc/service.go
@@ -1,0 +1,316 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build windows
+
+// Package svc provides everything required to build Windows service.
+//
+package svc
+
+import (
+	"errors"
+	"runtime"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// State describes service execution state (Stopped, Running and so on).
+type State uint32
+
+const (
+	Stopped         = State(windows.SERVICE_STOPPED)
+	StartPending    = State(windows.SERVICE_START_PENDING)
+	StopPending     = State(windows.SERVICE_STOP_PENDING)
+	Running         = State(windows.SERVICE_RUNNING)
+	ContinuePending = State(windows.SERVICE_CONTINUE_PENDING)
+	PausePending    = State(windows.SERVICE_PAUSE_PENDING)
+	Paused          = State(windows.SERVICE_PAUSED)
+)
+
+// Cmd represents service state change request. It is sent to a service
+// by the service manager, and should be actioned upon by the service.
+type Cmd uint32
+
+const (
+	Stop        = Cmd(windows.SERVICE_CONTROL_STOP)
+	Pause       = Cmd(windows.SERVICE_CONTROL_PAUSE)
+	Continue    = Cmd(windows.SERVICE_CONTROL_CONTINUE)
+	Interrogate = Cmd(windows.SERVICE_CONTROL_INTERROGATE)
+	Shutdown    = Cmd(windows.SERVICE_CONTROL_SHUTDOWN)
+)
+
+// Accepted is used to describe commands accepted by the service.
+// Note that Interrogate is always accepted.
+type Accepted uint32
+
+const (
+	AcceptStop             = Accepted(windows.SERVICE_ACCEPT_STOP)
+	AcceptShutdown         = Accepted(windows.SERVICE_ACCEPT_SHUTDOWN)
+	AcceptPauseAndContinue = Accepted(windows.SERVICE_ACCEPT_PAUSE_CONTINUE)
+)
+
+// Status combines State and Accepted commands to fully describe running service.
+type Status struct {
+	State      State
+	Accepts    Accepted
+	CheckPoint uint32 // used to report progress during a lengthy operation
+	WaitHint   uint32 // estimated time required for a pending operation, in milliseconds
+}
+
+// ChangeRequest is sent to the service Handler to request service status change.
+type ChangeRequest struct {
+	Cmd           Cmd
+	CurrentStatus Status
+}
+
+// Handler is the interface that must be implemented to build Windows service.
+type Handler interface {
+
+	// Execute will be called by the package code at the start of
+	// the service, and the service will exit once Execute completes.
+	// Inside Execute you must read service change requests from r and
+	// act accordingly. You must keep service control manager up to date
+	// about state of your service by writing into s as required.
+	// args contains service name followed by argument strings passed
+	// to the service.
+	// You can provide service exit code in exitCode return parameter,
+	// with 0 being "no error". You can also indicate if exit code,
+	// if any, is service specific or not by using svcSpecificEC
+	// parameter.
+	Execute(args []string, r <-chan ChangeRequest, s chan<- Status) (svcSpecificEC bool, exitCode uint32)
+}
+
+var (
+	// These are used by asm code.
+	goWaitsH                     uintptr
+	cWaitsH                      uintptr
+	ssHandle                     uintptr
+	sName                        *uint16
+	sArgc                        uintptr
+	sArgv                        **uint16
+	ctlHandlerProc               uintptr
+	cSetEvent                    uintptr
+	cWaitForSingleObject         uintptr
+	cRegisterServiceCtrlHandlerW uintptr
+)
+
+func init() {
+	k := syscall.MustLoadDLL("kernel32.dll")
+	cSetEvent = k.MustFindProc("SetEvent").Addr()
+	cWaitForSingleObject = k.MustFindProc("WaitForSingleObject").Addr()
+	a := syscall.MustLoadDLL("advapi32.dll")
+	cRegisterServiceCtrlHandlerW = a.MustFindProc("RegisterServiceCtrlHandlerW").Addr()
+}
+
+type ctlEvent struct {
+	cmd   Cmd
+	errno uint32
+}
+
+// service provides access to windows service api.
+type service struct {
+	name    string
+	h       windows.Handle
+	cWaits  *event
+	goWaits *event
+	c       chan ctlEvent
+	handler Handler
+}
+
+func newService(name string, handler Handler) (*service, error) {
+	var s service
+	var err error
+	s.name = name
+	s.c = make(chan ctlEvent)
+	s.handler = handler
+	s.cWaits, err = newEvent()
+	if err != nil {
+		return nil, err
+	}
+	s.goWaits, err = newEvent()
+	if err != nil {
+		s.cWaits.Close()
+		return nil, err
+	}
+	return &s, nil
+}
+
+func (s *service) close() error {
+	s.cWaits.Close()
+	s.goWaits.Close()
+	return nil
+}
+
+type exitCode struct {
+	isSvcSpecific bool
+	errno         uint32
+}
+
+func (s *service) updateStatus(status *Status, ec *exitCode) error {
+	if s.h == 0 {
+		return errors.New("updateStatus with no service status handle")
+	}
+	var t windows.SERVICE_STATUS
+	t.ServiceType = windows.SERVICE_WIN32_OWN_PROCESS
+	t.CurrentState = uint32(status.State)
+	if status.Accepts&AcceptStop != 0 {
+		t.ControlsAccepted |= windows.SERVICE_ACCEPT_STOP
+	}
+	if status.Accepts&AcceptShutdown != 0 {
+		t.ControlsAccepted |= windows.SERVICE_ACCEPT_SHUTDOWN
+	}
+	if status.Accepts&AcceptPauseAndContinue != 0 {
+		t.ControlsAccepted |= windows.SERVICE_ACCEPT_PAUSE_CONTINUE
+	}
+	if ec.errno == 0 {
+		t.Win32ExitCode = windows.NO_ERROR
+		t.ServiceSpecificExitCode = windows.NO_ERROR
+	} else if ec.isSvcSpecific {
+		t.Win32ExitCode = uint32(windows.ERROR_SERVICE_SPECIFIC_ERROR)
+		t.ServiceSpecificExitCode = ec.errno
+	} else {
+		t.Win32ExitCode = ec.errno
+		t.ServiceSpecificExitCode = windows.NO_ERROR
+	}
+	t.CheckPoint = status.CheckPoint
+	t.WaitHint = status.WaitHint
+	return windows.SetServiceStatus(s.h, &t)
+}
+
+const (
+	sysErrSetServiceStatusFailed = uint32(syscall.APPLICATION_ERROR) + iota
+	sysErrNewThreadInCallback
+)
+
+func (s *service) run() {
+	s.goWaits.Wait()
+	s.h = windows.Handle(ssHandle)
+	argv := (*[100]*int16)(unsafe.Pointer(sArgv))[:sArgc]
+	args := make([]string, len(argv))
+	for i, a := range argv {
+		args[i] = syscall.UTF16ToString((*[1 << 20]uint16)(unsafe.Pointer(a))[:])
+	}
+
+	cmdsToHandler := make(chan ChangeRequest)
+	changesFromHandler := make(chan Status)
+	exitFromHandler := make(chan exitCode)
+
+	go func() {
+		ss, errno := s.handler.Execute(args, cmdsToHandler, changesFromHandler)
+		exitFromHandler <- exitCode{ss, errno}
+	}()
+
+	status := Status{State: Stopped}
+	ec := exitCode{isSvcSpecific: true, errno: 0}
+	var outch chan ChangeRequest
+	inch := s.c
+	var cmd Cmd
+loop:
+	for {
+		select {
+		case r := <-inch:
+			if r.errno != 0 {
+				ec.errno = r.errno
+				break loop
+			}
+			inch = nil
+			outch = cmdsToHandler
+			cmd = r.cmd
+		case outch <- ChangeRequest{cmd, status}:
+			inch = s.c
+			outch = nil
+		case c := <-changesFromHandler:
+			err := s.updateStatus(&c, &ec)
+			if err != nil {
+				// best suitable error number
+				ec.errno = sysErrSetServiceStatusFailed
+				if err2, ok := err.(syscall.Errno); ok {
+					ec.errno = uint32(err2)
+				}
+				break loop
+			}
+			status = c
+		case ec = <-exitFromHandler:
+			break loop
+		}
+	}
+
+	s.updateStatus(&Status{State: Stopped}, &ec)
+	s.cWaits.Set()
+}
+
+func newCallback(fn interface{}) (cb uintptr, err error) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			return
+		}
+		cb = 0
+		switch v := r.(type) {
+		case string:
+			err = errors.New(v)
+		case error:
+			err = v
+		default:
+			err = errors.New("unexpected panic in syscall.NewCallback")
+		}
+	}()
+	return syscall.NewCallback(fn), nil
+}
+
+// BUG(brainman): There is no mechanism to run multiple services
+// inside one single executable. Perhaps, it can be overcome by
+// using RegisterServiceCtrlHandlerEx Windows api.
+
+// Run executes service name by calling appropriate handler function.
+func Run(name string, handler Handler) error {
+	runtime.LockOSThread()
+
+	tid := windows.GetCurrentThreadId()
+
+	s, err := newService(name, handler)
+	if err != nil {
+		return err
+	}
+
+	ctlHandler := func(ctl uint32) uintptr {
+		e := ctlEvent{cmd: Cmd(ctl)}
+		// We assume that this callback function is running on
+		// the same thread as Run. Nowhere in MS documentation
+		// I could find statement to guarantee that. So putting
+		// check here to verify, otherwise things will go bad
+		// quickly, if ignored.
+		i := windows.GetCurrentThreadId()
+		if i != tid {
+			e.errno = sysErrNewThreadInCallback
+		}
+		s.c <- e
+		return 0
+	}
+
+	var svcmain uintptr
+	getServiceMain(&svcmain)
+	t := []windows.SERVICE_TABLE_ENTRY{
+		{syscall.StringToUTF16Ptr(s.name), svcmain},
+		{nil, 0},
+	}
+
+	goWaitsH = uintptr(s.goWaits.h)
+	cWaitsH = uintptr(s.cWaits.h)
+	sName = t[0].ServiceName
+	ctlHandlerProc, err = newCallback(ctlHandler)
+	if err != nil {
+		return err
+	}
+
+	go s.run()
+
+	err = windows.StartServiceCtrlDispatcher(&t[0])
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/agent/vendor/golang.org/x/sys/windows/svc/svc_test.go
+++ b/agent/vendor/golang.org/x/sys/windows/svc/svc_test.go
@@ -1,0 +1,118 @@
+// Copyright 2012 The Go Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build windows
+
+package svc_test
+
+import (
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/windows/svc"
+	"golang.org/x/sys/windows/svc/mgr"
+)
+
+func getState(t *testing.T, s *mgr.Service) svc.State {
+	status, err := s.Query()
+	if err != nil {
+		t.Fatalf("Query(%s) failed: %s", s.Name, err)
+	}
+	return status.State
+}
+
+func testState(t *testing.T, s *mgr.Service, want svc.State) {
+	have := getState(t, s)
+	if have != want {
+		t.Fatalf("%s state is=%d want=%d", s.Name, have, want)
+	}
+}
+
+func waitState(t *testing.T, s *mgr.Service, want svc.State) {
+	for i := 0; ; i++ {
+		have := getState(t, s)
+		if have == want {
+			return
+		}
+		if i > 10 {
+			t.Fatalf("%s state is=%d, waiting timeout", s.Name, have)
+		}
+		time.Sleep(300 * time.Millisecond)
+	}
+}
+
+func TestExample(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode - it modifies system services")
+	}
+
+	const name = "myservice"
+
+	m, err := mgr.Connect()
+	if err != nil {
+		t.Fatalf("SCM connection failed: %s", err)
+	}
+	defer m.Disconnect()
+
+	dir, err := ioutil.TempDir("", "svc")
+	if err != nil {
+		t.Fatalf("failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	exepath := filepath.Join(dir, "a.exe")
+	o, err := exec.Command("go", "build", "-o", exepath, "golang.org/x/sys/windows/svc/example").CombinedOutput()
+	if err != nil {
+		t.Fatalf("failed to build service program: %v\n%v", err, string(o))
+	}
+
+	s, err := m.OpenService(name)
+	if err == nil {
+		err = s.Delete()
+		if err != nil {
+			s.Close()
+			t.Fatalf("Delete failed: %s", err)
+		}
+		s.Close()
+	}
+	s, err = m.CreateService(name, exepath, mgr.Config{DisplayName: "my service"}, "is", "auto-started")
+	if err != nil {
+		t.Fatalf("CreateService(%s) failed: %v", name, err)
+	}
+	defer s.Close()
+
+	testState(t, s, svc.Stopped)
+	err = s.Start("is", "manual-started")
+	if err != nil {
+		t.Fatalf("Start(%s) failed: %s", s.Name, err)
+	}
+	waitState(t, s, svc.Running)
+	time.Sleep(1 * time.Second)
+
+	// testing deadlock from issues 4.
+	_, err = s.Control(svc.Interrogate)
+	if err != nil {
+		t.Fatalf("Control(%s) failed: %s", s.Name, err)
+	}
+	_, err = s.Control(svc.Interrogate)
+	if err != nil {
+		t.Fatalf("Control(%s) failed: %s", s.Name, err)
+	}
+	time.Sleep(1 * time.Second)
+
+	_, err = s.Control(svc.Stop)
+	if err != nil {
+		t.Fatalf("Control(%s) failed: %s", s.Name, err)
+	}
+	waitState(t, s, svc.Stopped)
+
+	err = s.Delete()
+	if err != nil {
+		t.Fatalf("Delete failed: %s", err)
+	}
+}

--- a/agent/vendor/golang.org/x/sys/windows/svc/sys_386.s
+++ b/agent/vendor/golang.org/x/sys/windows/svc/sys_386.s
@@ -1,0 +1,67 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build windows
+
+// func servicemain(argc uint32, argv **uint16)
+TEXT ·servicemain(SB),7,$0
+	MOVL	argc+0(FP), AX
+	MOVL	AX, ·sArgc(SB)
+	MOVL	argv+4(FP), AX
+	MOVL	AX, ·sArgv(SB)
+
+	PUSHL	BP
+	PUSHL	BX
+	PUSHL	SI
+	PUSHL	DI
+
+	SUBL	$12, SP
+
+	MOVL	·sName(SB), AX
+	MOVL	AX, (SP)
+	MOVL	$·servicectlhandler(SB), AX
+	MOVL	AX, 4(SP)
+	MOVL	·cRegisterServiceCtrlHandlerW(SB), AX
+	MOVL	SP, BP
+	CALL	AX
+	MOVL	BP, SP
+	CMPL	AX, $0
+	JE	exit
+	MOVL	AX, ·ssHandle(SB)
+
+	MOVL	·goWaitsH(SB), AX
+	MOVL	AX, (SP)
+	MOVL	·cSetEvent(SB), AX
+	MOVL	SP, BP
+	CALL	AX
+	MOVL	BP, SP
+
+	MOVL	·cWaitsH(SB), AX
+	MOVL	AX, (SP)
+	MOVL	$-1, AX
+	MOVL	AX, 4(SP)
+	MOVL	·cWaitForSingleObject(SB), AX
+	MOVL	SP, BP
+	CALL	AX
+	MOVL	BP, SP
+
+exit:
+	ADDL	$12, SP
+
+	POPL	DI
+	POPL	SI
+	POPL	BX
+	POPL	BP
+
+	MOVL	0(SP), CX
+	ADDL	$12, SP
+	JMP	CX
+
+// I do not know why, but this seems to be the only way to call
+// ctlHandlerProc on Windows 7.
+
+// func servicectlhandler(ctl uint32) uintptr
+TEXT ·servicectlhandler(SB),7,$0
+	MOVL	·ctlHandlerProc(SB), CX
+	JMP	CX

--- a/agent/vendor/golang.org/x/sys/windows/svc/sys_amd64.s
+++ b/agent/vendor/golang.org/x/sys/windows/svc/sys_amd64.s
@@ -1,0 +1,41 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build windows
+
+// func servicemain(argc uint32, argv **uint16)
+TEXT ·servicemain(SB),7,$0
+	MOVL	CX, ·sArgc(SB)
+	MOVL	DX, ·sArgv(SB)
+
+	SUBQ	$32, SP		// stack for the first 4 syscall params
+
+	MOVQ	·sName(SB), CX
+	MOVQ	$·servicectlhandler(SB), DX
+	MOVQ	·cRegisterServiceCtrlHandlerW(SB), AX
+	CALL	AX
+	CMPQ	AX, $0
+	JE	exit
+	MOVQ	AX, ·ssHandle(SB)
+
+	MOVQ	·goWaitsH(SB), CX
+	MOVQ	·cSetEvent(SB), AX
+	CALL	AX
+
+	MOVQ	·cWaitsH(SB), CX
+	MOVQ	$4294967295, DX
+	MOVQ	·cWaitForSingleObject(SB), AX
+	CALL	AX
+
+exit:
+	ADDQ	$32, SP
+	RET
+
+// I do not know why, but this seems to be the only way to call
+// ctlHandlerProc on Windows 7.
+
+// func servicectlhandler(ctl uint32) uintptr
+TEXT ·servicectlhandler(SB),7,$0
+	MOVQ	·ctlHandlerProc(SB), AX
+	JMP	AX


### PR DESCRIPTION
### Summary
This set of commits enables the agent to be run as a Windows service and write logs into the Windows event log.

![amazon-ecs-agent-windows-scm](https://user-images.githubusercontent.com/737750/32695083-2bc92524-c707-11e7-850d-61d93abaf8e6.png)
![amazon-ecs-agent-windows-event-viewer](https://user-images.githubusercontent.com/737750/32695084-319cee4a-c707-11e7-8e64-ecd7045b246a.png)

~Note: This is marked WIP as it will fail to build because I haven't vendored the new dependencies (two more packages inside `golang.org/x/sys/windows`).  I'm waiting for https://github.com/aws/amazon-ecs-agent/pull/1009 to be merged so I can manage dependencies with dep.~

### Implementation details
* Added a new command-line argument to run as a Windows service
* Refactored the termination handler to use a function provided as part of the `agent` struct
* Implemented a new log receiver for seelog

### TODO
- [x] Vendor dependencies
- [ ] Set restart settings
- [x] Set dependency on Docker
- [ ] Determine correct recovery settings
- [ ] Determine if these need to be set in Go code or in PowerShell startup?

### Testing
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`) (as long as you have `golang.org/x/sys/windows on your `GOPATH)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass (as long as you have `golang.org/x/sys/windows on your `GOPATH)
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass
- [x] Starts the agent
- [x] Can be Started, Stopped, and Restarted from PowerShell and services.msc
- [x] Writes to Windows event log
- [x] Service stops gracefully on its own when Windows is shutting down or rebooting
- [x] Service starts correctly on boot when service is set to automatic startup or delayed start

New tests cover the changes: yes

### Description for the changelog
Feature - The Amazon ECS agent can now be installed as a Windows service

### Licensing
This contribution is under the terms of the Apache 2.0 License: yes
