### PR TITLE
Fix container change not reported when task status is NONE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 #Changelog
 
+## Unreleased
+* Bug - Fixed a bug where container state information wasn't reported. [#1067](https://github.com/aws/amazon-ecs-agent/pull/1067)
+
 ## 1.15.1
 * Bug - Fixed a bug where container state information wasn't reported. [#1067](https://github.com/aws/amazon-ecs-agent/pull/1067)
 * Bug - Fixed a bug where a task can be blocked in creating state. [#1048](https://github.com/aws/amazon-ecs-agent/pull/1048)

--- a/agent/api/ecsclient/client.go
+++ b/agent/api/ecsclient/client.go
@@ -312,12 +312,6 @@ func (client *APIECSClient) SubmitTaskStateChange(change api.TaskStateChange) er
 		return nil
 	}
 
-	// Submit task state change
-	if change.Status == api.TaskStatusNone {
-		seelog.Warnf("SubmitTaskStateChange called with an invalid change: %s", change.String())
-		return errors.New("ecs api client: SubmitTaskStateChange called with an invalid change")
-	}
-
 	if change.Status != api.TaskRunning && change.Status != api.TaskStopped && len(change.Containers) == 0 {
 		seelog.Debugf("Not submitting unsupported upstream task state: %s", change.Status.String())
 		// Not really an error

--- a/agent/api/ecsclient/client.go
+++ b/agent/api/ecsclient/client.go
@@ -312,12 +312,6 @@ func (client *APIECSClient) SubmitTaskStateChange(change api.TaskStateChange) er
 		return nil
 	}
 
-	if change.Status != api.TaskRunning && change.Status != api.TaskStopped && len(change.Containers) == 0 {
-		seelog.Debugf("Not submitting unsupported upstream task state: %s", change.Status.String())
-		// Not really an error
-		return nil
-	}
-
 	status := change.Status.BackendStatus()
 
 	req := ecs.SubmitTaskStateChangeInput{


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Fix #1075 

### Implementation details
<!-- How are the changes implemented? -->
Task status with NONE is dropped in taskShouldBeSent, this commit makes the taskShouldBeSent more clear and stronger to handle both container  event and task event.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass
- [x] Manual test.

New tests cover the changes: <!-- yes|no -->
yes
### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
yes