### PR TITLE
app: support Windows recovery actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ PS C:\> New-Service -Name "AmazonECS" `
         -Description "Amazon ECS service runs the Amazon ECS agent" `
         -DependsOn Docker `
         -StartupType Manual
-PS C:\> sc.exe failure AmazonECS reset=300 actions=restart/10000/restart/10000/restart/10000
+PS C:\> sc.exe failure AmazonECS reset=300 actions=restart/5000/restart/30000/restart/60000
 PS C:\> sc.exe failureflag AmazonECS 1
 ```
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ To install the service, you can do the following:
 PS C:\> # Set up directories the agent uses
 PS C:\> New-Item -Type directory -Path ${env:ProgramFiles}\Amazon\ECS -Force
 PS C:\> New-Item -Type directory -Path ${env:ProgramData}\Amazon\ECS -Force
+PS C:\> New-Item -Type directory -Path ${env:ProgramData}\Amazon\ECS\data -Force
 PS C:\> # Set up configuration
 PS C:\> $ecsExeDir = "${env:ProgramFiles}\Amazon\ECS"
 PS C:\> [Environment]::SetEnvironmentVariable("ECS_CLUSTER", "my-windows-cluster", "Machine")
@@ -86,6 +87,8 @@ PS C:\> New-Service -Name "AmazonECS" `
         -Description "Amazon ECS service runs the Amazon ECS agent" `
         -DependsOn Docker `
         -StartupType Manual
+PS C:\> sc.exe failure AmazonECS reset=300 actions=restart/10000/restart/10000/restart/10000
+PS C:\> sc.exe failureflag AmazonECS 1
 ```
 
 To run the service, you can do the following:
@@ -99,6 +102,7 @@ Start-Service AmazonECS
 PS C:\> # Set up directories the agent uses
 PS C:\> New-Item -Type directory -Path ${env:ProgramFiles}\Amazon\ECS -Force
 PS C:\> New-Item -Type directory -Path ${env:ProgramData}\Amazon\ECS -Force
+PS C:\> New-Item -Type directory -Path ${env:ProgramData}\Amazon\ECS\data -Force
 PS C:\> # Set up configuration
 PS C:\> $ecsExeDir = "${env:ProgramFiles}\Amazon\ECS"
 PS C:\> [Environment]::SetEnvironmentVariable("ECS_CLUSTER", "my-windows-cluster", "Machine")


### PR DESCRIPTION
### Summary
Support Windows recovery actions for failures

### Implementation details
Instructions added in the README for setting recovery policy with `sc.exe` (using `failure` and `failureflag`).  Propagated exit code so that agent reports exit code to Windows properly.  Suppressed the special `ExitTerminal` code to make it like `ExitSuccess` so that Windows does *not* restart the agent in terminal failure conditions.

### Testing
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass
- [x] Inserted fake failures and observed Windows properly restarting the service

New tests cover the changes: no

### Description for the changelog
none

### Licensing
This contribution is under the terms of the Apache 2.0 License: yes
