### PR TITLE
add handler for /v2/metadata/<container-id>

### DIFF
--- a/agent/ecscni/plugin.go
+++ b/agent/ecscni/plugin.go
@@ -92,7 +92,7 @@ func (client *cniClient) SetupNS(cfg *Config) (*current.Result, error) {
 
 	seelog.Debugf("Set up container namespace done: %s", result.String())
 	if _, err = result.GetAsVersion(currentCNISpec); err != nil {
-		seelog.Warnf("Unable to convert result to %s: %v: %s",
+		seelog.Warnf("Unable to convert result to %s; error: %v; result is of version: %s",
 			currentCNISpec, err, result.Version())
 		return nil, err
 	}

--- a/agent/handlers/taskmetadata/handler.go
+++ b/agent/handlers/taskmetadata/handler.go
@@ -82,6 +82,7 @@ func setupServer(credentialsManager credentials.Manager,
 	serverMux.HandleFunc(credentials.V2CredentialsPath+"/",
 		credentialsV1V2RequestHandler(
 			credentialsManager, auditLogger, getV2CredentialsID, apiVersion2))
+	serverMux.HandleFunc(metadataPath+"/", metadataV2Handler(state, cluster))
 	serverMux.HandleFunc(metadataPath, metadataV2Handler(state, cluster))
 
 	// Log all requests and then pass through to serverMux

--- a/agent/handlers/taskmetadata/helpers.go
+++ b/agent/handlers/taskmetadata/helpers.go
@@ -37,6 +37,8 @@ func writeJSONToResponse(w http.ResponseWriter, httpStatusCode int, jsonMessage 
 	w.WriteHeader(httpStatusCode)
 	_, err := w.Write(jsonMessage)
 	if err != nil {
-		seelog.Error("Task metadatda handler[%s]: Unable to write json error message to ResponseWriter")
+		seelog.Errorf(
+			"Task metadatda handler[%s]: Unable to write json error message to ResponseWriter",
+			requestType)
 	}
 }

--- a/agent/handlers/types/v2/response.go
+++ b/agent/handlers/types/v2/response.go
@@ -105,6 +105,24 @@ func NewTaskResponse(taskARN string,
 	return resp, nil
 }
 
+// NewContainerResponse creates a new container response based on container id
+func NewContainerResponse(containerID string,
+	state dockerstate.TaskEngineState) (*ContainerResponse, error) {
+	dockerContainer, ok := state.ContainerByID(containerID)
+	if !ok {
+		return nil, errors.Errorf(
+			"v2 container response: unable to find container '%s'", containerID)
+	}
+	task, ok := state.TaskByID(containerID)
+	if !ok {
+		return nil, errors.Errorf(
+			"v2 container response: unable to find task for container '%s'", containerID)
+	}
+
+	resp := newContainerResponse(dockerContainer, task.GetTaskENI(), state)
+	return &resp, nil
+}
+
 func newContainerResponse(dockerContainer *api.DockerContainer,
 	eni *api.ENI,
 	state dockerstate.TaskEngineState) ContainerResponse {


### PR DESCRIPTION
Added support for returning metadata information for a container by its
id.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Adds handler for /v2/metadata/<container-id>

### Implementation details
<!-- How are the changes implemented? -->
Parse container id from the url and use that to look up state

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: Yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: yes
