### PR TITLE
api: Set minimum memory limit by OS

### DIFF
--- a/agent/api/container.go
+++ b/agent/api/container.go
@@ -22,9 +22,6 @@ import (
 )
 
 const (
-	// DockerContainerMinimumMemoryInBytes is the minimum amount of
-	// memory to be allocated to a docker container
-	DockerContainerMinimumMemoryInBytes = 4 * 1024 * 1024 // 4MB
 	// defaultContainerSteadyStateStatus defines the container status at
 	// which the container is assumed to be in steady state. It is set
 	// to 'ContainerRunning' unless overridden

--- a/agent/api/container_unix.go
+++ b/agent/api/container_unix.go
@@ -1,0 +1,22 @@
+// +build !windows
+
+// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package api
+
+const (
+	// DockerContainerMinimumMemoryInBytes is the minimum amount of
+	// memory to be allocated to a docker container
+	DockerContainerMinimumMemoryInBytes = 4 * 1024 * 1024 // 4MB
+)

--- a/agent/api/container_windows.go
+++ b/agent/api/container_windows.go
@@ -1,0 +1,22 @@
+// +build windows
+
+// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package api
+
+const (
+	// DockerContainerMinimumMemoryInBytes is the minimum amount of
+	// memory to be allocated to a docker container
+	DockerContainerMinimumMemoryInBytes = 256 * 1024 * 1024 // 256MB
+)

--- a/agent/api/task.go
+++ b/agent/api/task.go
@@ -473,6 +473,7 @@ func (task *Task) SetConfigHostconfigBasedOnVersion(container *Container, config
 	// Convert MB to B
 	dockerMem := int64(container.Memory * 1024 * 1024)
 	if dockerMem != 0 && dockerMem < DockerContainerMinimumMemoryInBytes {
+		seelog.Warnf("Task %s container %s memory setting is too low, increasing to %d bytes", task.Arn, container.Name, DockerContainerMinimumMemoryInBytes)
 		dockerMem = DockerContainerMinimumMemoryInBytes
 	}
 	cpuShare := task.dockerCPUShares(container.CPU)

--- a/agent/api/task_test.go
+++ b/agent/api/task_test.go
@@ -1273,12 +1273,13 @@ func TestApplyExecutionRoleLogsAuthFailNoCredentialsForTask(t *testing.T) {
 
 // TestSetConfigHostconfigBasedOnAPIVersion tests the docker hostconfig was correctly set// based on the docker client version
 func TestSetConfigHostconfigBasedOnAPIVersion(t *testing.T) {
+	memoryMiB := 500
 	testTask := &Task{
 		Containers: []*Container{
 			{
 				Name:   "c1",
 				CPU:    uint(10),
-				Memory: uint(50),
+				Memory: uint(memoryMiB),
 			},
 		},
 	}
@@ -1289,7 +1290,7 @@ func TestSetConfigHostconfigBasedOnAPIVersion(t *testing.T) {
 	config, cerr := testTask.DockerConfig(testTask.Containers[0], defaultDockerClientAPIVersion)
 	assert.Nil(t, cerr)
 
-	assert.Equal(t, int64(50*1024*1024), config.Memory)
+	assert.Equal(t, int64(memoryMiB*1024*1024), config.Memory)
 	assert.Equal(t, int64(10), config.CPUShares)
 	assert.Empty(t, hostconfig.CPUShares)
 	assert.Empty(t, hostconfig.Memory)
@@ -1299,7 +1300,7 @@ func TestSetConfigHostconfigBasedOnAPIVersion(t *testing.T) {
 
 	config, cerr = testTask.DockerConfig(testTask.Containers[0], dockerclient.Version_1_18)
 	assert.Nil(t, err)
-	assert.Equal(t, int64(50*1024*1024), hostconfig.Memory)
+	assert.Equal(t, int64(memoryMiB*1024*1024), hostconfig.Memory)
 	assert.Equal(t, int64(10), hostconfig.CPUShares)
 	assert.Empty(t, config.CPUShares)
 	assert.Empty(t, config.Memory)

--- a/agent/api/task_test.go
+++ b/agent/api/task_test.go
@@ -432,7 +432,7 @@ func TestDockerConfigRawConfigMerging(t *testing.T) {
 				Name:   "c1",
 				Image:  "image",
 				CPU:    50,
-				Memory: 100,
+				Memory: 1000,
 				DockerConfig: DockerConfig{
 					Config: strptr(string(rawConfig)),
 				},
@@ -446,7 +446,7 @@ func TestDockerConfigRawConfigMerging(t *testing.T) {
 	}
 
 	expected := docker.Config{
-		Memory:    100 * 1024 * 1024,
+		Memory:    1000 * 1024 * 1024,
 		CPUShares: 50,
 		Image:     "image",
 		User:      "user",

--- a/agent/functional_tests/testdata/taskdefinitions/awslogs-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/awslogs-windows/task-definition.json
@@ -2,7 +2,7 @@
   "family": "ecs-awslogs-test",
   "containerDefinitions": [{
     "essential": true,
-    "memory": 10,
+    "memory": 256,
     "name": "awslogs",
     "cpu": 10,
     "image": "microsoft/windowsservercore:latest",

--- a/agent/functional_tests/testdata/taskdefinitions/cleanup-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/cleanup-windows/task-definition.json
@@ -4,7 +4,7 @@
     "image": "microsoft/windowsservercore:latest",
     "name": "cleanup-windows",
     "cpu": 10,
-    "memory": 10,
+    "memory": 256,
     "portBindings": [{
       "containerPort": 80
     }],

--- a/agent/functional_tests/testdata/taskdefinitions/datavolume-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/datavolume-windows/task-definition.json
@@ -8,7 +8,7 @@
     "image": "microsoft/windowsservercore:latest",
     "name": "exit",
     "cpu": 10,
-    "memory": 10,
+    "memory": 256,
     "essential": true,
     "volumesFrom": [{
       "sourceContainer": "data-volume-source"
@@ -18,7 +18,7 @@
     "image": "microsoft/windowsservercore:latest",
     "name": "dataSource",
     "cpu": 10,
-    "memory": 10,
+    "memory": 256,
     "essential": false,
     "volumesFrom": [{
       "sourceContainer": "data-volume-source"
@@ -28,7 +28,7 @@
     "image": "microsoft/windowsservercore:latest",
     "name": "data-volume-source",
     "cpu": 10,
-    "memory": 10,
+    "memory": 256,
     "essential": false,
     "mountPoints": [{
       "sourceVolume": "test",

--- a/agent/functional_tests/testdata/taskdefinitions/hostname-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/hostname-windows/task-definition.json
@@ -4,7 +4,7 @@
     "image": "microsoft/windowsservercore:latest",
     "name": "exit",
     "cpu": 10,
-    "memory": 10,
+    "memory": 256,
     "hostname": "foobarbaz",
     "command": ["powershell", "-c",  "if ((hostname) -eq \"foobarbaz\") { exit 42 } ; exit 1"]
   }]

--- a/agent/functional_tests/testdata/taskdefinitions/iam-roles-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/iam-roles-windows/task-definition.json
@@ -2,7 +2,7 @@
     "family": "ecsftest-iamrole-test",
     "taskRoleArn": "$$$TASK_ROLE$$$",
     "containerDefinitions": [{
-        "memory": 100,
+        "memory": 256,
         "cpu": 100,
         "name": "container-with-iamrole-windows",
         "image": "amazon/amazon-ecs-iamrolecontainer",

--- a/agent/functional_tests/testdata/taskdefinitions/labels-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/labels-windows/task-definition.json
@@ -4,7 +4,7 @@
     "image": "microsoft/windowsservercore:latest",
     "name": "labeled",
     "cpu": 10,
-    "memory": 10,
+    "memory": 256,
     "dockerLabels": {
       "label1": "",
       "com.foo.label2": "value"

--- a/agent/functional_tests/testdata/taskdefinitions/logdriver-jsonfile-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/logdriver-jsonfile-windows/task-definition.json
@@ -3,7 +3,7 @@
   "containerDefinitions": [{
     "image": "microsoft/windowsservercore:latest",
     "name": "exit",
-    "memory": 10,
+    "memory": 256,
     "cpu": 10,
     "logConfiguration": {
       "logDriver": "json-file",

--- a/agent/functional_tests/testdata/taskdefinitions/mdservice-validator-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/mdservice-validator-windows/task-definition.json
@@ -5,7 +5,7 @@
     "image": "microsoft/windowsservercore:latest",
     "name": "mdservice-validator-windows",
     "cpu": 100,
-    "memory": 100,
+    "memory": 256,
     "entryPoint": ["powershell"],
     "command": ["-c", "sleep 10; if($?){if(cat $env:ECS_CONTAINER_METADATA_FILE | Select-String -pattern READY){exit 42}else {exit 1}};"] 
   }]

--- a/agent/functional_tests/testdata/taskdefinitions/network-mode-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/network-mode-windows/task-definition.json
@@ -6,6 +6,6 @@
     "entryPoint": ["powershell"],
     "command": ["sleep", "60"],
     "name": "network-$$$$NETWORK_MODE$$$$",
-    "memory": 50
+    "memory": 256
   }]
 }

--- a/agent/functional_tests/testdata/taskdefinitions/oom-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/oom-windows/task-definition.json
@@ -4,9 +4,9 @@
     "essential": true,
     "memory": 100,
     "name": "memory-overcommit",
-    "cpu": 100,
+    "cpu": 256,
     "image": "python:3-windowsservercore",
-    "command": ["python", "-c", "import time; time.sleep(30); foo=' '*1024*1024*200;"]
+    "command": ["python", "-c", "import time; time.sleep(30); foo=' '*1024*1024*1024;"]
   }]
 }
 

--- a/agent/functional_tests/testdata/taskdefinitions/port-80-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/port-80-windows/task-definition.json
@@ -7,7 +7,7 @@
       "containerPort": 80,
       "hostPort": 5180
     }],
-    "memory": 50,
+    "memory": 256,
     "command": ["powershell", "\\listen80.exe"]
   }]
 }

--- a/agent/functional_tests/testdata/taskdefinitions/savedstate-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/savedstate-windows/task-definition.json
@@ -4,7 +4,7 @@
     "image": "microsoft/windowsservercore:latest",
     "name": "savedstate-windows",
     "cpu": 10,
-    "memory": 10,
+    "memory": 256,
     "entryPoint": ["powershell"],
     "command": ["sleep", "500"]
   }]

--- a/agent/functional_tests/testdata/taskdefinitions/simple-exit-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/simple-exit-windows/task-definition.json
@@ -4,7 +4,7 @@
     "image": "microsoft/windowsservercore:latest",
     "name": "exit",
     "cpu": 10,
-    "memory": 10,
+    "memory": 256,
     "essential": true,
     "entryPoint": ["powershell"],
     "command": ["exit", "42"]

--- a/agent/functional_tests/testdata/taskdefinitions/telemetry-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/telemetry-windows/task-definition.json
@@ -4,6 +4,6 @@
     "image": "amazon/amazon-ecs-windows-cpupercent-test:make",
     "name": "windows-cpu-percent",
     "cpu": $$$$CPUSHARE$$$$,
-    "memory": 500
+    "memory": 256
   }]
 }

--- a/agent/functional_tests/testdata/taskdefinitions/working-dir-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/working-dir-windows/task-definition.json
@@ -4,7 +4,7 @@
     "image": "microsoft/windowsservercore:latest",
     "name": "exit",
     "cpu": 10,
-    "memory": 10,
+    "memory": 256,
     "workingDirectory": "C:/windows/system32",
     "command": ["powershell", "-c", "if ((pwd).Path -eq \"C:\\windows\\system32\") { exit 42 } ; exit 1"]
   }]


### PR DESCRIPTION
### Summary
Enforces that the memory limit set for each container is at least the minimum required by the operating system.  For Linux this is 4MiB and Windows is 256MiB.

### Implementation details
`Config`/`HostConfig` adjusted to specify the proper limit in bytes.

### Testing
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes

### Description for the changelog
Bug: Ensure memory limit is at least 256MiB for Windows to avoid failing containers with too little memory.

### Licensing
This contribution is under the terms of the Apache 2.0 License: yes
