### PR TITLE
Set the cpu percent to minimum 1 if cpu shares is too low on windows

### DIFF
--- a/agent/api/task_unix.go
+++ b/agent/api/task_unix.go
@@ -36,7 +36,8 @@ const (
 	// Reference: http://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ContainerDefinition.html
 	minimumCPUShare = 2
 
-	bytesPerMegabyte = 1024 * 1024
+	minimumCPUPercent = 0
+	bytesPerMegabyte  = 1024 * 1024
 )
 
 func (task *Task) adjustForPlatform(cfg *config.Config) {

--- a/agent/api/task_windows_test.go
+++ b/agent/api/task_windows_test.go
@@ -121,8 +121,8 @@ func TestWindowsPlatformHostConfigOverride(t *testing.T) {
 
 	hostConfig = &docker.HostConfig{CPUShares: 10}
 	task.platformHostConfigOverride(hostConfig)
-	assert.Equal(t, int64(0), hostConfig.CPUPercent)
-	assert.Equal(t, int64(10), hostConfig.CPUShares)
+	assert.Equal(t, int64(minimumCPUPercent), hostConfig.CPUPercent)
+	assert.Empty(t, hostConfig.CPUShares)
 }
 
 func TestWindowsMemorySwappinessOption(t *testing.T) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->


### Implementation details
<!-- How are the changes implemented? -->
When convert the cpu shares to cpu percent on windows, if the cpushares is too low the cpu percent will be 0, the commit will ensure the minimum cpu percent will be 1.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
