### PR TITLE
Add Stats api in metadata

### DIFF
--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -521,7 +521,7 @@ func (agent *ecsAgent) startAsyncRoutines(
 	go handlers.ServeHttp(&agent.containerInstanceARN, taskEngine, agent.cfg)
 
 	// Start serving the endpoint to fetch IAM Role credentials
-	go taskmetadata.ServeHTTP(credentialsManager, state, agent.containerInstanceARN, agent.cfg)
+	go taskmetadata.ServeHTTP(credentialsManager, state, agent.containerInstanceARN, agent.cfg, nil)
 
 	// Start sending events to the backend
 	go eventhandler.HandleEngineEvents(taskEngine, client, taskHandler)

--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -522,7 +522,8 @@ func (agent *ecsAgent) startAsyncRoutines(
 	go handlers.ServeHttp(&agent.containerInstanceARN, taskEngine, agent.cfg)
 
 	statsEngine := stats.NewDockerStatsEngine(agent.cfg, agent.dockerClient, containerChangeEventStream)
-	// Start serving the endpoint to fetch IAM Role credentials
+
+	// Start serving the endpoint to fetch IAM Role credentials and other task metadata
 	go taskmetadata.ServeHTTP(credentialsManager, state, agent.containerInstanceARN, agent.cfg, statsEngine)
 
 	// Start sending events to the backend

--- a/agent/handlers/taskmetadata/handler_test.go
+++ b/agent/handlers/taskmetadata/handler_test.go
@@ -174,7 +174,7 @@ func testErrorResponsesFromServer(t *testing.T, path string, expectedErrorMessag
 
 	credentialsManager := mock_credentials.NewMockManager(ctrl)
 	auditLog := mock_audit.NewMockAuditLogger(ctrl)
-	server := setupServer(credentialsManager, auditLog, nil, "")
+	server := setupServer(credentialsManager, auditLog, nil, "", nil)
 
 	recorder := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", path, nil)
@@ -207,7 +207,7 @@ func getResponseForCredentialsRequest(t *testing.T, expectedStatus int,
 	defer ctrl.Finish()
 	credentialsManager := mock_credentials.NewMockManager(ctrl)
 	auditLog := mock_audit.NewMockAuditLogger(ctrl)
-	server := setupServer(credentialsManager, auditLog, nil, "")
+	server := setupServer(credentialsManager, auditLog, nil, "", nil)
 	recorder := httptest.NewRecorder()
 
 	creds, ok := getCredentials()

--- a/agent/handlers/taskmetadata/taskinfo.go
+++ b/agent/handlers/taskmetadata/taskinfo.go
@@ -15,6 +15,7 @@ package taskmetadata
 
 import (
 	"encoding/json"
+	"fmt"
 	"net"
 	"net/http"
 	"net/url"
@@ -22,54 +23,72 @@ import (
 
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/handlers/types/v2"
+	"github.com/aws/amazon-ecs-agent/agent/stats"
 	"github.com/cihub/seelog"
+	"github.com/pkg/errors"
 )
 
 const (
 	// metadataPath specifies the relative URI path for serving task metadata
 	metadataPath = "/v2/metadata"
+	statsPath    = "/v2/stats"
 )
 
 // metadataV2Handler returns the handler method for handling task metadata requests
 func metadataV2Handler(state dockerstate.TaskEngineState, cluster string) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		// Get request's ip address
-		ip, _, err := net.SplitHostPort(r.RemoteAddr)
+		taskARN, err := getTaskARN(r, state)
 		if err != nil {
-			jsonMsg, _ := json.Marshal("Unable to get request's ip address")
+			jsonMsg, _ := json.Marshal(
+				fmt.Sprintf("Unable to get task arn from request: %s", err.Error()))
 			writeJSONToResponse(w, http.StatusBadRequest, jsonMsg, requestTypeMetadata)
 			return
 		}
-
-		// Get task arn for the request by looking up the ip address
-		taskARN, ok := state.GetTaskByIPAddress(ip)
-		if !ok {
-			jsonMsg, _ := json.Marshal("Unable to assoicate '" + ip + "' with a task")
-			writeJSONToResponse(w, http.StatusBadRequest, jsonMsg, requestTypeMetadata)
-			return
-		}
-
-		if containerID := getContainerID(r.URL); containerID != "" {
+		if containerID := getContainerID(r.URL, metadataPath); containerID != "" {
 			writeContainerResponse(w, containerID, state)
 			return
 		}
-		seelog.Infof("V2 metadata: handling request for task '%s'", taskARN)
-		// Generate a response for the task
-		taskResponse, err := v2.NewTaskResponse(taskARN, state, cluster)
-		if err != nil {
-			jsonMsg, _ := json.Marshal("Unable to generate metadata for '" + ip + "'")
-			writeJSONToResponse(w, http.StatusBadRequest, jsonMsg, requestTypeMetadata)
-			return
-		}
 
-		jsonMsg, _ := json.Marshal(taskResponse)
-		writeJSONToResponse(w, http.StatusOK, jsonMsg, requestTypeMetadata)
+		writeTaskResponse(w, taskARN, cluster, state)
 	}
 }
 
-func getContainerID(reqURL *url.URL) string {
-	if strings.HasPrefix(reqURL.Path, metadataPath+"/") {
-		return reqURL.String()[len(metadataPath+"/"):]
+func statsV2Handler(state dockerstate.TaskEngineState, statsEngine stats.Engine) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		taskARN, err := getTaskARN(r, state)
+		if err != nil {
+			jsonMsg, _ := json.Marshal(
+				fmt.Sprintf("Unable to get task arn from request: %s", err.Error()))
+			writeJSONToResponse(w, http.StatusBadRequest, jsonMsg, requestTypeMetadata)
+			return
+		}
+		if containerID := getContainerID(r.URL, statsPath); containerID != "" {
+			writeContainerStatsResponse(w, taskARN, containerID, statsEngine)
+			return
+		}
+
+		writeTaskStatsResponse(w, taskARN, state, statsEngine)
+	}
+}
+
+func getTaskARN(r *http.Request, state dockerstate.TaskEngineState) (string, error) {
+	ip, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return "", fmt.Errorf("v2 handler: unable to parse request's ip address: %v", err)
+	}
+
+	// Get task arn for the request by looking up the ip address
+	taskARN, ok := state.GetTaskByIPAddress(ip)
+	if !ok {
+		return "", errors.Errorf("v2 handler: unable to associate '%s' with task", ip)
+	}
+
+	return taskARN, nil
+}
+
+func getContainerID(reqURL *url.URL, prefix string) string {
+	if strings.HasPrefix(reqURL.Path, prefix+"/") {
+		return reqURL.String()[len(prefix+"/"):]
 	}
 
 	return ""
@@ -85,5 +104,52 @@ func writeContainerResponse(w http.ResponseWriter, containerID string, state doc
 	}
 
 	jsonMsg, _ := json.Marshal(containerResponse)
+	writeJSONToResponse(w, http.StatusOK, jsonMsg, requestTypeMetadata)
+}
+
+func writeTaskResponse(w http.ResponseWriter, taskARN string, cluster string, state dockerstate.TaskEngineState) {
+	seelog.Infof("V2 metadata: handling request for task '%s'", taskARN)
+	// Generate a response for the task
+	taskResponse, err := v2.NewTaskResponse(taskARN, state, cluster)
+	if err != nil {
+		jsonMsg, _ := json.Marshal("Unable to generate metadata for task: '" + taskARN + "'")
+		writeJSONToResponse(w, http.StatusBadRequest, jsonMsg, requestTypeMetadata)
+		return
+	}
+
+	jsonMsg, _ := json.Marshal(taskResponse)
+	writeJSONToResponse(w, http.StatusOK, jsonMsg, requestTypeMetadata)
+}
+
+func writeContainerStatsResponse(w http.ResponseWriter,
+	taskARN string,
+	containerID string,
+	statsEngine stats.Engine) {
+	dockerStats, err := statsEngine.ContainerDockerStats(taskARN, containerID)
+	if err != nil {
+		jsonMsg, _ := json.Marshal("Unable to get container stats for: " + containerID)
+		writeJSONToResponse(w, http.StatusBadRequest, jsonMsg, requestTypeMetadata)
+		return
+	}
+
+	jsonMsg, _ := json.Marshal(dockerStats)
+	writeJSONToResponse(w, http.StatusOK, jsonMsg, requestTypeMetadata)
+}
+
+func writeTaskStatsResponse(w http.ResponseWriter,
+	taskARN string,
+	state dockerstate.TaskEngineState,
+	statsEngine stats.Engine) {
+	fmt.Println("writeContainerResponse")
+
+	taskStatsResponse, err := v2.NewTaskStatsResponse(taskARN, state, statsEngine)
+	if err != nil {
+		seelog.Warnf("Unable to get task stats for task '%s': %v", taskARN, err)
+		jsonMsg, _ := json.Marshal("Unable to get task stats for: " + taskARN)
+		writeJSONToResponse(w, http.StatusBadRequest, jsonMsg, requestTypeMetadata)
+		return
+	}
+
+	jsonMsg, _ := json.Marshal(taskStatsResponse)
 	writeJSONToResponse(w, http.StatusOK, jsonMsg, requestTypeMetadata)
 }

--- a/agent/handlers/taskmetadata/taskinfo.go
+++ b/agent/handlers/taskmetadata/taskinfo.go
@@ -140,7 +140,6 @@ func writeTaskStatsResponse(w http.ResponseWriter,
 	taskARN string,
 	state dockerstate.TaskEngineState,
 	statsEngine stats.Engine) {
-	fmt.Println("writeContainerResponse")
 
 	taskStatsResponse, err := v2.NewTaskStatsResponse(taskARN, state, statsEngine)
 	if err != nil {

--- a/agent/handlers/types/v2/stats_response.go
+++ b/agent/handlers/types/v2/stats_response.go
@@ -1,0 +1,51 @@
+// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package v2
+
+import (
+	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
+	"github.com/aws/amazon-ecs-agent/agent/stats"
+	"github.com/cihub/seelog"
+	docker "github.com/fsouza/go-dockerclient"
+	"github.com/pkg/errors"
+)
+
+// NewTaskStatsResponse returns a new task stats response object
+func NewTaskStatsResponse(taskARN string,
+	state dockerstate.TaskEngineState,
+	statsEngine stats.Engine) (map[string]*docker.Stats, error) {
+
+	containerMap, ok := state.ContainerMapByArn(taskARN)
+	if !ok {
+		return nil, errors.Errorf(
+			"v2 task stats response: unable to lookup containers for task %s",
+			taskARN)
+	}
+
+	resp := make(map[string]*docker.Stats)
+	for _, dockerContainer := range containerMap {
+		containerID := dockerContainer.DockerID
+		dockerStats, err := statsEngine.ContainerDockerStats(taskARN, containerID)
+		if err != nil {
+			seelog.Warnf("V2 task stats response: Unable to get stats for container '%s' for task '%s': %v",
+				containerID, taskARN, err)
+			resp[containerID] = nil
+			continue
+		}
+
+		resp[containerID] = dockerStats
+	}
+
+	return resp, nil
+}

--- a/agent/handlers/types/v2/stats_response_test.go
+++ b/agent/handlers/types/v2/stats_response_test.go
@@ -1,0 +1,62 @@
+// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package v2
+
+import (
+	"testing"
+
+	"github.com/aws/amazon-ecs-agent/agent/api"
+	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate/mocks"
+	"github.com/aws/amazon-ecs-agent/agent/stats/mock"
+	docker "github.com/fsouza/go-dockerclient"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTaskStatsResponseSuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	state := mock_dockerstate.NewMockTaskEngineState(ctrl)
+	statsEngine := mock_stats.NewMockEngine(ctrl)
+
+	dockerStats := &docker.Stats{NumProcs: 2}
+	containerMap := map[string]*api.DockerContainer{
+		containerName: &api.DockerContainer{
+			DockerID: containerID,
+		},
+	}
+	gomock.InOrder(
+		state.EXPECT().ContainerMapByArn(taskARN).Return(containerMap, true),
+		statsEngine.EXPECT().ContainerDockerStats(taskARN, containerID).Return(dockerStats, nil),
+	)
+
+	resp, err := NewTaskStatsResponse(taskARN, state, statsEngine)
+	assert.NoError(t, err)
+	containerStats, ok := resp[containerID]
+	assert.True(t, ok)
+	assert.Equal(t, dockerStats.NumProcs, containerStats.NumProcs)
+}
+
+func TestTaskStatsResponseError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	state := mock_dockerstate.NewMockTaskEngineState(ctrl)
+	statsEngine := mock_stats.NewMockEngine(ctrl)
+
+	state.EXPECT().ContainerMapByArn(taskARN).Return(nil, false)
+	_, err := NewTaskStatsResponse(taskARN, state, statsEngine)
+	assert.Error(t, err)
+}

--- a/agent/stats/container.go
+++ b/agent/stats/container.go
@@ -105,10 +105,7 @@ func (container *StatsContainer) processStatsStream() error {
 		return err
 	}
 	for rawStat := range dockerStats {
-		stat, err := dockerStatsToContainerStats(rawStat)
-		if err == nil {
-			container.statsQueue.Add(stat)
-		} else {
+		if err := container.statsQueue.Add(rawStat); err != nil {
 			seelog.Warnf("Error converting stats for container %s: %v", dockerID, err)
 		}
 	}

--- a/agent/stats/engine.go
+++ b/agent/stats/engine.go
@@ -112,6 +112,7 @@ func NewDockerStatsEngine(cfg *config.Config, client ecsengine.DockerClient, con
 
 // MustInit initializes fields of the DockerStatsEngine object.
 func (engine *DockerStatsEngine) MustInit(taskEngine ecsengine.TaskEngine, cluster string, containerInstanceArn string) error {
+	// TODO ensure that this is done only once per engine object
 	seelog.Info("Initializing stats engine")
 	engine.cluster = cluster
 	engine.containerInstanceArn = containerInstanceArn

--- a/agent/stats/engine.go
+++ b/agent/stats/engine.go
@@ -463,7 +463,7 @@ func (engine *DockerStatsEngine) ContainerDockerStats(taskARN string, containerI
 
 	containerIDToStatsContainer, ok := engine.tasksToContainers[taskARN]
 	if !ok {
-		return nil, errors.Errorf("stats engine: task '%s' for container '%s' not found: %s",
+		return nil, errors.Errorf("stats engine: task '%s' for container '%s' not found",
 			taskARN, containerID)
 	}
 

--- a/agent/stats/engine_test.go
+++ b/agent/stats/engine_test.go
@@ -23,6 +23,7 @@ import (
 	mock_resolver "github.com/aws/amazon-ecs-agent/agent/stats/resolver/mock"
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestStatsEngineAddRemoveContainers(t *testing.T) {
@@ -178,14 +179,25 @@ func TestStatsEngineMetadataInStatsSets(t *testing.T) {
 	engine.containerInstanceArn = defaultContainerInstance
 	engine.client = mockDockerClient
 	engine.addContainer("c1")
+	ts1 := parseNanoTime("2015-02-12T21:22:05.131117533Z")
+	ts2 := parseNanoTime("2015-02-12T21:22:05.232291187Z")
 	containerStats := []*ContainerStats{
-		{22400432, 1839104, parseNanoTime("2015-02-12T21:22:05.131117533Z")},
-		{116499979, 3649536, parseNanoTime("2015-02-12T21:22:05.232291187Z")},
+		{22400432, 1839104, ts1},
+		{116499979, 3649536, ts2},
+	}
+	dockerStats := []*docker.Stats{
+		{
+			Read: ts1,
+		},
+		{
+			Read: ts2,
+		},
 	}
 	containers, _ := engine.tasksToContainers["t1"]
 	for _, statsContainer := range containers {
 		for i := 0; i < 2; i++ {
 			statsContainer.statsQueue.add(containerStats[i])
+			statsContainer.statsQueue.setLastStat(dockerStats[i])
 		}
 	}
 	metadata, taskMetrics, err := engine.GetInstanceMetrics()
@@ -206,6 +218,10 @@ func TestStatsEngineMetadataInStatsSets(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error validating metadata: %v", err)
 	}
+
+	dockerStat, err := engine.ContainerDockerStats("t1", "c1")
+	assert.NoError(t, err)
+	assert.Equal(t, ts2, dockerStat.Read)
 
 	engine.removeContainer("c1")
 	err = validateIdleContainerMetrics(engine)

--- a/agent/stats/engine_test.go
+++ b/agent/stats/engine_test.go
@@ -78,12 +78,12 @@ func TestStatsEngineAddRemoveContainers(t *testing.T) {
 
 	for _, statsContainer := range containers {
 		for _, fakeContainerStats := range createFakeContainerStats() {
-			statsContainer.statsQueue.Add(fakeContainerStats)
+			statsContainer.statsQueue.add(fakeContainerStats)
 		}
 	}
 
 	// Ensure task shows up in metrics.
-	containerMetrics, err := engine.getContainerMetricsForTask("t1")
+	containerMetrics, err := engine.taskContainerMetricsUnsafe("t1")
 	if err != nil {
 		t.Errorf("Error getting container metrics: %v", err)
 	}
@@ -113,7 +113,7 @@ func TestStatsEngineAddRemoveContainers(t *testing.T) {
 	}
 
 	// Ensure that only valid task shows up in metrics.
-	_, err = engine.getContainerMetricsForTask("t2")
+	_, err = engine.taskContainerMetricsUnsafe("t2")
 	if err == nil {
 		t.Error("Expected non-empty error for non existent task")
 	}
@@ -185,7 +185,7 @@ func TestStatsEngineMetadataInStatsSets(t *testing.T) {
 	containers, _ := engine.tasksToContainers["t1"]
 	for _, statsContainer := range containers {
 		for i := 0; i < 2; i++ {
-			statsContainer.statsQueue.Add(containerStats[i])
+			statsContainer.statsQueue.add(containerStats[i])
 		}
 	}
 	metadata, taskMetrics, err := engine.GetInstanceMetrics()

--- a/agent/stats/mock/engine.go
+++ b/agent/stats/mock/engine.go
@@ -18,6 +18,7 @@ package mock_stats
 
 import (
 	ecstcs "github.com/aws/amazon-ecs-agent/agent/tcs/model/ecstcs"
+	go_dockerclient "github.com/fsouza/go-dockerclient"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -40,6 +41,17 @@ func NewMockEngine(ctrl *gomock.Controller) *MockEngine {
 
 func (_m *MockEngine) EXPECT() *_MockEngineRecorder {
 	return _m.recorder
+}
+
+func (_m *MockEngine) ContainerDockerStats(_param0 string, _param1 string) (*go_dockerclient.Stats, error) {
+	ret := _m.ctrl.Call(_m, "ContainerDockerStats", _param0, _param1)
+	ret0, _ := ret[0].(*go_dockerclient.Stats)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockEngineRecorder) ContainerDockerStats(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ContainerDockerStats", arg0, arg1)
 }
 
 func (_m *MockEngine) GetInstanceMetrics() (*ecstcs.MetricsMetadata, []*ecstcs.TaskMetric, error) {

--- a/agent/stats/queue_test.go
+++ b/agent/stats/queue_test.go
@@ -132,7 +132,7 @@ func createQueue(size int, predictableHighMemoryUtilization bool) *Queue {
 	}
 	queue := NewQueue(size)
 	for i, time := range timestamps {
-		queue.Add(&ContainerStats{cpuUsage: cpuTimes[i], memoryUsage: memoryUtilizationInBytes[i], timestamp: time})
+		queue.add(&ContainerStats{cpuUsage: cpuTimes[i], memoryUsage: memoryUtilizationInBytes[i], timestamp: time})
 	}
 	return queue
 }
@@ -279,7 +279,7 @@ func TestCpuStatsSetNotSetToInfinity(t *testing.T) {
 	queueLength := 3
 	queue := NewQueue(queueLength)
 	for i, time := range timestamps {
-		queue.Add(&ContainerStats{cpuUsage: cpuTimes[i], memoryUsage: memoryUtilizationInBytes[i], timestamp: time})
+		queue.add(&ContainerStats{cpuUsage: cpuTimes[i], memoryUsage: memoryUtilizationInBytes[i], timestamp: time})
 	}
 	cpuStatsSet, err := queue.GetCPUStatsSet()
 	if err != nil {
@@ -352,7 +352,7 @@ func TestEnoughDatapointsInBuffer(t *testing.T) {
 	enoughDataPoints := queue.enoughDatapointsInBuffer()
 	assert.False(t, enoughDataPoints, "Queue is expected to not have enough data points right after creation")
 	for i, time := range timestamps {
-		queue.Add(&ContainerStats{cpuUsage: cpuTimes[i], memoryUsage: memoryUtilizationInBytes[i], timestamp: time})
+		queue.add(&ContainerStats{cpuUsage: cpuTimes[i], memoryUsage: memoryUtilizationInBytes[i], timestamp: time})
 	}
 
 	enoughDataPoints = queue.enoughDatapointsInBuffer()

--- a/agent/tcs/client/client_test.go
+++ b/agent/tcs/client/client_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/wsclient/mock"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	docker "github.com/fsouza/go-dockerclient"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 )
@@ -45,19 +46,27 @@ const (
 
 type mockStatsEngine struct{}
 
-func (engine *mockStatsEngine) GetInstanceMetrics() (*ecstcs.MetricsMetadata, []*ecstcs.TaskMetric, error) {
+func (*mockStatsEngine) GetInstanceMetrics() (*ecstcs.MetricsMetadata, []*ecstcs.TaskMetric, error) {
 	return nil, nil, fmt.Errorf("uninitialized")
+}
+
+func (*mockStatsEngine) ContainerDockerStats(taskARN string, id string) (*docker.Stats, error) {
+	return nil, fmt.Errorf("not implemented")
 }
 
 type emptyStatsEngine struct{}
 
-func (engine *emptyStatsEngine) GetInstanceMetrics() (*ecstcs.MetricsMetadata, []*ecstcs.TaskMetric, error) {
+func (*emptyStatsEngine) GetInstanceMetrics() (*ecstcs.MetricsMetadata, []*ecstcs.TaskMetric, error) {
 	return nil, nil, fmt.Errorf("empty stats")
+}
+
+func (*emptyStatsEngine) ContainerDockerStats(taskARN string, id string) (*docker.Stats, error) {
+	return nil, fmt.Errorf("not implemented")
 }
 
 type idleStatsEngine struct{}
 
-func (engine *idleStatsEngine) GetInstanceMetrics() (*ecstcs.MetricsMetadata, []*ecstcs.TaskMetric, error) {
+func (*idleStatsEngine) GetInstanceMetrics() (*ecstcs.MetricsMetadata, []*ecstcs.TaskMetric, error) {
 	metadata := &ecstcs.MetricsMetadata{
 		Cluster:           aws.String(testCluster),
 		ContainerInstance: aws.String(testContainerInstance),
@@ -65,6 +74,10 @@ func (engine *idleStatsEngine) GetInstanceMetrics() (*ecstcs.MetricsMetadata, []
 		MessageId:         aws.String(testMessageId),
 	}
 	return metadata, []*ecstcs.TaskMetric{}, nil
+}
+
+func (*idleStatsEngine) ContainerDockerStats(taskARN string, id string) (*docker.Stats, error) {
+	return nil, fmt.Errorf("not implemented")
 }
 
 type nonIdleStatsEngine struct {
@@ -85,6 +98,10 @@ func (engine *nonIdleStatsEngine) GetInstanceMetrics() (*ecstcs.MetricsMetadata,
 		taskMetrics = append(taskMetrics, &ecstcs.TaskMetric{TaskArn: &taskArn})
 	}
 	return metadata, taskMetrics, nil
+}
+
+func (*nonIdleStatsEngine) ContainerDockerStats(taskARN string, id string) (*docker.Stats, error) {
+	return nil, fmt.Errorf("not implemented")
 }
 
 func newNonIdleStatsEngine(numTasks int) *nonIdleStatsEngine {

--- a/agent/tcs/handler/handler_test.go
+++ b/agent/tcs/handler/handler_test.go
@@ -15,6 +15,7 @@ package tcshandler
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"math/rand"
 	"net/url"
@@ -31,6 +32,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/wsclient"
 	wsmock "github.com/aws/amazon-ecs-agent/agent/wsclient/mock/utils"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	docker "github.com/fsouza/go-dockerclient"
 	"github.com/golang/mock/gomock"
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
@@ -53,9 +55,13 @@ var testCfg = &config.Config{
 	AWSRegion:          "us-east-1",
 }
 
-func (engine *mockStatsEngine) GetInstanceMetrics() (*ecstcs.MetricsMetadata, []*ecstcs.TaskMetric, error) {
+func (*mockStatsEngine) GetInstanceMetrics() (*ecstcs.MetricsMetadata, []*ecstcs.TaskMetric, error) {
 	req := createPublishMetricsRequest()
 	return req.Metadata, req.TaskMetrics, nil
+}
+
+func (*mockStatsEngine) ContainerDockerStats(taskARN string, id string) (*docker.Stats, error) {
+	return nil, fmt.Errorf("not implemented")
 }
 
 func TestFormatURL(t *testing.T) {
@@ -106,7 +112,9 @@ func TestStartSession(t *testing.T) {
 
 	deregisterInstanceEventStream := eventstream.NewEventStream("Deregister_Instance", context.Background())
 	// Start a session with the test server.
-	go startSession(server.URL, testCfg, credentials.AnonymousCredentials, &mockStatsEngine{}, defaultHeartbeatTimeout, defaultHeartbeatJitter, testPublishMetricsInterval, deregisterInstanceEventStream)
+	go startSession(server.URL, testCfg, credentials.AnonymousCredentials, &mockStatsEngine{},
+		defaultHeartbeatTimeout, defaultHeartbeatJitter,
+		testPublishMetricsInterval, deregisterInstanceEventStream)
 
 	// startSession internally starts publishing metrics from the mockStatsEngine object.
 	time.Sleep(testPublishMetricsInterval)
@@ -168,7 +176,9 @@ func TestSessionConnectionClosedByRemote(t *testing.T) {
 	defer cancel()
 
 	// Start a session with the test server.
-	err = startSession(server.URL, testCfg, credentials.AnonymousCredentials, &mockStatsEngine{}, defaultHeartbeatTimeout, defaultHeartbeatJitter, testPublishMetricsInterval, deregisterInstanceEventStream)
+	err = startSession(server.URL, testCfg, credentials.AnonymousCredentials, &mockStatsEngine{},
+		defaultHeartbeatTimeout, defaultHeartbeatJitter,
+		testPublishMetricsInterval, deregisterInstanceEventStream)
 
 	if err == nil {
 		t.Error("Expected io.EOF on closed connection")
@@ -203,11 +213,14 @@ func TestConnectionInactiveTimeout(t *testing.T) {
 	deregisterInstanceEventStream.StartListening()
 	defer cancel()
 	// Start a session with the test server.
-	err = startSession(server.URL, testCfg, credentials.AnonymousCredentials, &mockStatsEngine{}, 50*time.Millisecond, 100*time.Millisecond, testPublishMetricsInterval, deregisterInstanceEventStream)
+	err = startSession(server.URL, testCfg, credentials.AnonymousCredentials, &mockStatsEngine{},
+		50*time.Millisecond, 100*time.Millisecond,
+		testPublishMetricsInterval, deregisterInstanceEventStream)
 	// if we are not blocked here, then the test pass as it will reconnect in StartSession
 	assert.Error(t, err, "Close the connection should cause the tcs client return error")
 
-	assert.True(t, websocket.IsCloseError(<-serverErr, websocket.CloseAbnormalClosure), "Read from closed connection should produce an io.EOF error")
+	assert.True(t, websocket.IsCloseError(<-serverErr, websocket.CloseAbnormalClosure),
+		"Read from closed connection should produce an io.EOF error")
 
 	closeSocket(closeWS)
 }

--- a/agent/tcs/handler/types.go
+++ b/agent/tcs/handler/types.go
@@ -14,36 +14,30 @@
 package tcshandler
 
 import (
-	"fmt"
 	"sync"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/engine"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
+	"github.com/aws/amazon-ecs-agent/agent/stats"
 	"github.com/aws/amazon-ecs-agent/agent/utils/ttime"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 )
 
+// TelemetrySessionParams contains all the parameters required to start a tcs
+// session
 type TelemetrySessionParams struct {
 	ContainerInstanceArn          string
 	CredentialProvider            *credentials.Credentials
 	Cfg                           *config.Config
 	DeregisterInstanceEventStream *eventstream.EventStream
-	ContainerChangeEventStream    *eventstream.EventStream
-	DockerClient                  engine.DockerClient
 	AcceptInvalidCert             bool
 	ECSClient                     api.ECSClient
 	TaskEngine                    engine.TaskEngine
+	StatsEngine                   *stats.DockerStatsEngine
 	_time                         ttime.Time
 	_timeOnce                     sync.Once
-}
-
-func (params *TelemetrySessionParams) isTelemetryDisabled() (bool, error) {
-	if params.Cfg != nil {
-		return params.Cfg.DisableMetrics, nil
-	}
-	return false, fmt.Errorf("Config is not initialized in session params")
 }
 
 func (params *TelemetrySessionParams) time() ttime.Time {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Adds `/v2/stats` api in metadata

### Implementation details
<!-- How are the changes implemented? -->

* fe6105c move stats engine creation to app
* 6950ce7 metadata handler: add a stats query endpoint
* 4ccc891 stats(engine): get docker stats for container
* 61f8339 stats(engine): refactor a bit to reorder locks
* 990611b stats(queue): store last retrieved raw docker stat

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [X] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [X] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: Yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: yes
