### PR TITLE
engine: Windows integ test needs more CPU & memory

### DIFF
--- a/agent/engine/docker_image_manager_integ_test.go
+++ b/agent/engine/docker_image_manager_integ_test.go
@@ -352,7 +352,7 @@ func TestImageWithSameNameAndDifferentID(t *testing.T) {
 	err = renameImage(test3Image3Name, "testimagewithsamenameanddifferentid", "latest", goDockerClient)
 	require.NoError(t, err, "Renaming the image failed")
 
-	// Start and wiat for task3 to be running
+	// Start and wait for task3 to be running
 	go taskEngine.AddTask(task3)
 	err = verifyTaskIsRunning(stateChangeEvents, task3)
 	require.NoError(t, err, "task3")

--- a/agent/engine/engine_windows_integ_test.go
+++ b/agent/engine/engine_windows_integ_test.go
@@ -31,8 +31,8 @@ func createTestContainer() *api.Container {
 		Image:               "microsoft/windowsservercore:latest",
 		Essential:           true,
 		DesiredStatusUnsafe: api.ContainerRunning,
-		CPU:                 100,
-		Memory:              80,
+		CPU:                 512,
+		Memory:              256,
 	}
 }
 


### PR DESCRIPTION
### Summary
Increase CPU and memory limits for test containers.

Fixes one of the tests in https://github.com/aws/amazon-ecs-agent/issues/1096.

### Implementation details
Increase CPU and memory limits for test containers.

### Testing
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: no

### Description for the changelog
None

### Licensing
This contribution is under the terms of the Apache 2.0 License: yes
