### PR TITLE
Fix functional tests timeout

### DIFF
--- a/agent/functional_tests/testdata/taskdefinitions/iam-roles-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/iam-roles-windows/task-definition.json
@@ -2,8 +2,8 @@
     "family": "ecsftest-iamrole-test",
     "taskRoleArn": "$$$TASK_ROLE$$$",
     "containerDefinitions": [{
-        "memory": 256,
-        "cpu": 100,
+        "memory": 512,
+        "cpu": 1024,
         "name": "container-with-iamrole-windows",
         "image": "amazon/amazon-ecs-iamrolecontainer",
          "entryPoint": ["powershell"],

--- a/agent/functional_tests/testdata/taskdefinitions/mdservice-validator-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/mdservice-validator-windows/task-definition.json
@@ -4,8 +4,8 @@
   "containerDefinitions": [{
     "image": "microsoft/windowsservercore:latest",
     "name": "mdservice-validator-windows",
-    "cpu": 100,
-    "memory": 256,
+    "cpu": 1024,
+    "memory": 512,
     "entryPoint": ["powershell"],
     "command": ["-c", "sleep 10; if($?){if(cat $env:ECS_CONTAINER_METADATA_FILE | Select-String -pattern READY){exit 42}else {exit 1}};"] 
   }]

--- a/agent/functional_tests/testdata/taskdefinitions/oom-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/oom-windows/task-definition.json
@@ -5,7 +5,7 @@
     "memory": 100,
     "name": "memory-overcommit",
     "cpu": 256,
-    "image": "python:3-windowsservercore",
+    "image": "amazon/amazon-ecs-windows-python:make",
     "command": ["python", "-c", "import time; time.sleep(30); foo=' '*1024*1024*1024;"]
   }]
 }

--- a/agent/functional_tests/tests/functionaltests_windows_test.go
+++ b/agent/functional_tests/tests/functionaltests_windows_test.go
@@ -177,7 +177,7 @@ func taskIamRolesTest(networkMode string, agent *TestAgent, t *testing.T) {
 	}
 
 	// Task will only run one command "aws ec2 describe-regions"
-	err = task.WaitStopped(2 * time.Minute)
+	err = task.WaitStopped(waitTaskStateChangeDuration)
 	if err != nil {
 		t.Fatalf("Waiting task to stop error : %v", err)
 	}
@@ -215,7 +215,7 @@ func TestMetadataServiceValidator(t *testing.T) {
 	}
 
 	// clean up
-	err = task.WaitStopped(2 * time.Minute)
+	err = task.WaitStopped(waitTaskStateChangeDuration)
 	require.NoError(t, err, "Error waiting for task to transition to STOPPED")
 
 	containerID, err := agent.ResolveTaskDockerID(task, "mdservice-validator-windows")

--- a/misc/windows-python/build.ps1
+++ b/misc/windows-python/build.ps1
@@ -1,0 +1,15 @@
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+docker pull python:3-windowsservercore
+docker tag python:3-windowsservercore amazon/amazon-ecs-windows-python:make

--- a/scripts/run-functional-tests.ps1
+++ b/scripts/run-functional-tests.ps1
@@ -14,6 +14,8 @@
 Invoke-Expression "${PSScriptRoot}\..\misc\windows-iam\Setup_Iam.ps1"
 Invoke-Expression "${PSScriptRoot}\..\misc\windows-listen80\Setup_Listen80.ps1"
 Invoke-Expression "${PSScriptRoot}\..\misc\windows-cpupercent\build.ps1"
+Invoke-Expression "${PSScriptRoot}\..\misc\windows-python\build.ps1"
+
 
 # Run the tests
 $cwd = (pwd).Path


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Increase the cpu/memory for containers in the functional test

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
