### PR TITLE
AWS logs multiline linux functional tests

### DIFF
--- a/agent/functional_tests/testdata/taskdefinitions/awslogs-datetime/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/awslogs-datetime/task-definition.json
@@ -1,0 +1,20 @@
+{
+  "family": "ecs-awslogs-datetime-test",
+  "containerDefinitions": [{
+    "essential": true,
+    "memory": 10,
+    "name": "awslogs-datetime",
+    "cpu": 10,
+    "image": "busybox:latest",
+    "command": ["sh", "-c", "echo \"May 01, 2017 19:00:01 ECS\nMay 01, 2017 19:00:04 Agent\nRunning\nin the instance\""],
+    "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+            "awslogs-group":"ecs-functional-tests",
+            "awslogs-region":"$$$TEST_REGION$$$",
+            "awslogs-stream-prefix":"ecs-functional-tests",
+            "awslogs-datetime-format":"%b %d, %Y %H:%M:%S"
+        }
+    }
+  }]
+}

--- a/agent/functional_tests/testdata/taskdefinitions/awslogs-multiline/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/awslogs-multiline/task-definition.json
@@ -1,0 +1,20 @@
+{
+  "family": "ecs-awslogs-multiline-test",
+  "containerDefinitions": [{
+    "essential": true,
+    "memory": 10,
+    "name": "awslogs-multiline",
+    "cpu": 10,
+    "image": "busybox:latest",
+    "command": ["sh", "-c", "echo \"INFO: ECS Agent\nRunning\nINFO: Instance\""],
+    "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+            "awslogs-group":"ecs-functional-tests",
+            "awslogs-region":"$$$TEST_REGION$$$",
+            "awslogs-stream-prefix":"ecs-functional-tests",
+            "awslogs-multiline-pattern":"^INFO"
+        }
+    }
+  }]
+}

--- a/agent/functional_tests/tests/functionaltests_unix_test.go
+++ b/agent/functional_tests/tests/functionaltests_unix_test.go
@@ -743,7 +743,7 @@ func TestExecutionRole(t *testing.T) {
 
 	// Wait for the container to start
 	testTask.WaitRunning(waitTaskStateChangeDuration)
-	taskID, err := GetTaskID(*testTask.TaskArn)
+	taskID, err := GetTaskID(aws.StringValue(testTask.TaskArn))
 	require.NoError(t, err)
 
 	// Delete the log stream after the test
@@ -765,4 +765,136 @@ func TestExecutionRole(t *testing.T) {
 	err = SearchStrInDir(filepath.Join(agent.TestDir, "log"), "audit.log.", "GetCredentialsExecutionRole")
 	err = SearchStrInDir(filepath.Join(agent.TestDir, "log"), "audit.log.", *testTask.TaskArn)
 	require.NoError(t, err, "Verify credential request failed")
+}
+
+// TestAWSLogsDriverMultilinePattern verifies that multiple log lines with a certain
+// pattern, specified using 'awslogs-multiline-pattern' option, are sent to a single
+// CloudWatch log event
+func TestAWSLogsDriverMultilinePattern(t *testing.T) {
+	RequireDockerVersion(t, ">=17.06.0-ce")
+	cwlClient := cloudwatchlogs.New(session.New(), aws.NewConfig().WithRegion(*ECS.Config.Region))
+	// Test whether the log group exists or not
+	respDescribeLogGroups, err := cwlClient.DescribeLogGroups(&cloudwatchlogs.DescribeLogGroupsInput{
+		LogGroupNamePrefix: aws.String(awslogsLogGroupName),
+	})
+	require.NoError(t, err, "CloudWatchLogs describe log groups failed")
+	logGroupExists := false
+	for i := 0; i < len(respDescribeLogGroups.LogGroups); i++ {
+		if *respDescribeLogGroups.LogGroups[i].LogGroupName == awslogsLogGroupName {
+			logGroupExists = true
+			break
+		}
+	}
+
+	if !logGroupExists {
+		_, err := cwlClient.CreateLogGroup(&cloudwatchlogs.CreateLogGroupInput{
+			LogGroupName: aws.String(awslogsLogGroupName),
+		})
+		require.NoError(t, err, fmt.Sprintf("Failed to create log group %s", awslogsLogGroupName))
+	}
+
+	agentOptions := AgentOptions{
+		ExtraEnvironment: map[string]string{
+			"ECS_AVAILABLE_LOGGING_DRIVERS": `["awslogs"]`,
+		},
+	}
+	agent := RunAgent(t, &agentOptions)
+	defer agent.Cleanup()
+
+	agent.RequireVersion(">=1.16.0") //Required for awslogs driver multiline pattern option
+
+	tdOverrides := make(map[string]string)
+	tdOverrides["$$$TEST_REGION$$$"] = *ECS.Config.Region
+
+	testTask, err := agent.StartTaskWithTaskDefinitionOverrides(t, "awslogs-multiline", tdOverrides)
+	require.NoError(t, err, "Expected to start task using awslogs driver failed")
+
+	// Wait for the container to start
+	testTask.WaitRunning(waitTaskStateChangeDuration)
+	taskID, err := GetTaskID(aws.StringValue(testTask.TaskArn))
+	require.NoError(t, err)
+
+	// Delete the log stream after the test
+	defer func() {
+		cwlClient.DeleteLogStream(&cloudwatchlogs.DeleteLogStreamInput{
+			LogGroupName:  aws.String(awslogsLogGroupName),
+			LogStreamName: aws.String(fmt.Sprintf("ecs-functional-tests/awslogs-multiline/%s", taskID)),
+		})
+	}()
+
+	params := &cloudwatchlogs.GetLogEventsInput{
+		LogGroupName:  aws.String(awslogsLogGroupName),
+		LogStreamName: aws.String(fmt.Sprintf("ecs-functional-tests/awslogs-multiline/%s", taskID)),
+	}
+	resp, err := waitCloudwatchLogs(cwlClient, params)
+	require.NoError(t, err, "CloudWatchLogs get log failed")
+	assert.Len(t, resp.Events, 2, fmt.Sprintf("Got unexpected number of log events: %d", len(resp.Events)))
+	assert.Equal(t, *resp.Events[0].Message, "INFO: ECS Agent\nRunning\n", fmt.Sprintf("Got log events message unexpected: %s", *resp.Events[0].Message))
+	assert.Equal(t, *resp.Events[1].Message, "INFO: Instance\n", fmt.Sprintf("Got log events message unexpected: %s", *resp.Events[1].Message))
+}
+
+// TestAWSLogsDriverDatetimeFormat verifies that multiple log lines with a certain
+// pattern of timestamp, specified using 'awslogs-datetime-format' option, are sent
+// to a single CloudWatch log event
+func TestAWSLogsDriverDatetimeFormat(t *testing.T) {
+	RequireDockerVersion(t, ">=17.06.0-ce")
+	cwlClient := cloudwatchlogs.New(session.New(), aws.NewConfig().WithRegion(*ECS.Config.Region))
+	// Test whether the log group exists or not
+	respDescribeLogGroups, err := cwlClient.DescribeLogGroups(&cloudwatchlogs.DescribeLogGroupsInput{
+		LogGroupNamePrefix: aws.String(awslogsLogGroupName),
+	})
+	require.NoError(t, err, "CloudWatchLogs describe log groups failed")
+	logGroupExists := false
+	for i := 0; i < len(respDescribeLogGroups.LogGroups); i++ {
+		if *respDescribeLogGroups.LogGroups[i].LogGroupName == awslogsLogGroupName {
+			logGroupExists = true
+			break
+		}
+	}
+
+	if !logGroupExists {
+		_, err := cwlClient.CreateLogGroup(&cloudwatchlogs.CreateLogGroupInput{
+			LogGroupName: aws.String(awslogsLogGroupName),
+		})
+		require.NoError(t, err, fmt.Sprintf("Failed to create log group %s", awslogsLogGroupName))
+	}
+
+	agentOptions := AgentOptions{
+		ExtraEnvironment: map[string]string{
+			"ECS_AVAILABLE_LOGGING_DRIVERS": `["awslogs"]`,
+		},
+	}
+	agent := RunAgent(t, &agentOptions)
+	defer agent.Cleanup()
+
+	agent.RequireVersion(">=1.16.0") //Required for awslogs driver datetime format option
+
+	tdOverrides := make(map[string]string)
+	tdOverrides["$$$TEST_REGION$$$"] = *ECS.Config.Region
+
+	testTask, err := agent.StartTaskWithTaskDefinitionOverrides(t, "awslogs-datetime", tdOverrides)
+	require.NoError(t, err, "Expected to start task using awslogs driver failed")
+
+	// Wait for the container to start
+	testTask.WaitRunning(waitTaskStateChangeDuration)
+	taskID, err := GetTaskID(aws.StringValue(testTask.TaskArn))
+	require.NoError(t, err)
+
+	// Delete the log stream after the test
+	defer func() {
+		cwlClient.DeleteLogStream(&cloudwatchlogs.DeleteLogStreamInput{
+			LogGroupName:  aws.String(awslogsLogGroupName),
+			LogStreamName: aws.String(fmt.Sprintf("ecs-functional-tests/awslogs-datetime/%s", taskID)),
+		})
+	}()
+
+	params := &cloudwatchlogs.GetLogEventsInput{
+		LogGroupName:  aws.String(awslogsLogGroupName),
+		LogStreamName: aws.String(fmt.Sprintf("ecs-functional-tests/awslogs-datetime/%s", taskID)),
+	}
+	resp, err := waitCloudwatchLogs(cwlClient, params)
+	require.NoError(t, err, "CloudWatchLogs get log failed")
+	assert.Len(t, resp.Events, 2, fmt.Sprintf("Got unexpected number of log events: %d", len(resp.Events)))
+	assert.Equal(t, *resp.Events[0].Message, "May 01, 2017 19:00:01 ECS\n", fmt.Sprintf("Got log events message unexpected: %s", *resp.Events[0].Message))
+	assert.Equal(t, *resp.Events[1].Message, "May 01, 2017 19:00:04 Agent\nRunning\nin the instance\n", fmt.Sprintf("Got log events message unexpected: %s", *resp.Events[1].Message))
 }


### PR DESCRIPTION
### Summary
Functional tests that verify logs from CloudWatch events for 'awslogs-multiline-pattern' and 'awslogs-datetime-format' awslogs driver options

### Test Results 
#### Multiline pattern 
<img width="1080" alt="multiline-support" src="https://user-images.githubusercontent.com/14119911/33050457-de99915c-ce19-11e7-9c62-983276e18bc8.png">

#### Date time format
<img width="1078" alt="datetime" src="https://user-images.githubusercontent.com/14119911/33050467-ef092e1c-ce19-11e7-89b9-d5d66b53dc4e.png">

### Testing
- [x] Manual testing
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes

### Description for the changelog

### Licensing
This contribution is under the terms of the Apache 2.0 License: yes
