### PR TITLE
ftests: Increase CPU limits for Windows

### DIFF
--- a/agent/functional_tests/testdata/taskdefinitions/awslogs-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/awslogs-windows/task-definition.json
@@ -4,7 +4,7 @@
     "essential": true,
     "memory": 256,
     "name": "awslogs",
-    "cpu": 10,
+    "cpu": 512,
     "image": "microsoft/windowsservercore:latest",
     "logConfiguration": {
         "logDriver": "awslogs",

--- a/agent/functional_tests/testdata/taskdefinitions/cleanup-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/cleanup-windows/task-definition.json
@@ -3,7 +3,7 @@
   "containerDefinitions": [{
     "image": "microsoft/windowsservercore:latest",
     "name": "cleanup-windows",
-    "cpu": 10,
+    "cpu": 512,
     "memory": 256,
     "portBindings": [{
       "containerPort": 80

--- a/agent/functional_tests/testdata/taskdefinitions/datavolume-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/datavolume-windows/task-definition.json
@@ -7,7 +7,7 @@
   "containerDefinitions": [{
     "image": "microsoft/windowsservercore:latest",
     "name": "exit",
-    "cpu": 10,
+    "cpu": 512,
     "memory": 256,
     "essential": true,
     "volumesFrom": [{
@@ -17,7 +17,7 @@
   }, {
     "image": "microsoft/windowsservercore:latest",
     "name": "dataSource",
-    "cpu": 10,
+    "cpu": 512,
     "memory": 256,
     "essential": false,
     "volumesFrom": [{
@@ -27,7 +27,7 @@
   }, {
     "image": "microsoft/windowsservercore:latest",
     "name": "data-volume-source",
-    "cpu": 10,
+    "cpu": 512,
     "memory": 256,
     "essential": false,
     "mountPoints": [{

--- a/agent/functional_tests/testdata/taskdefinitions/hostname-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/hostname-windows/task-definition.json
@@ -3,7 +3,7 @@
   "containerDefinitions": [{
     "image": "microsoft/windowsservercore:latest",
     "name": "exit",
-    "cpu": 10,
+    "cpu": 512,
     "memory": 256,
     "hostname": "foobarbaz",
     "command": ["powershell", "-c",  "if ((hostname) -eq \"foobarbaz\") { exit 42 } ; exit 1"]

--- a/agent/functional_tests/testdata/taskdefinitions/logdriver-jsonfile-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/logdriver-jsonfile-windows/task-definition.json
@@ -4,7 +4,7 @@
     "image": "microsoft/windowsservercore:latest",
     "name": "exit",
     "memory": 256,
-    "cpu": 10,
+    "cpu": 512,
     "logConfiguration": {
       "logDriver": "json-file",
       "options": {

--- a/agent/functional_tests/testdata/taskdefinitions/network-mode-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/network-mode-windows/task-definition.json
@@ -6,6 +6,7 @@
     "entryPoint": ["powershell"],
     "command": ["sleep", "60"],
     "name": "network-$$$$NETWORK_MODE$$$$",
-    "memory": 256
+    "memory": 256,
+    "cpu": 512
   }]
 }

--- a/agent/functional_tests/testdata/taskdefinitions/oom-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/oom-windows/task-definition.json
@@ -2,9 +2,9 @@
   "family": "ecsftest-oom-container-windows",
   "containerDefinitions": [{
     "essential": true,
-    "memory": 100,
+    "memory": 256,
     "name": "memory-overcommit",
-    "cpu": 256,
+    "cpu": 512,
     "image": "amazon/amazon-ecs-windows-python:make",
     "command": ["python", "-c", "import time; time.sleep(30); foo=' '*1024*1024*1024;"]
   }]

--- a/agent/functional_tests/testdata/taskdefinitions/port-80-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/port-80-windows/task-definition.json
@@ -8,6 +8,7 @@
       "hostPort": 5180
     }],
     "memory": 256,
+    "cpu": 512,
     "command": ["powershell", "\\listen80.exe"]
   }]
 }

--- a/agent/functional_tests/testdata/taskdefinitions/savedstate-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/savedstate-windows/task-definition.json
@@ -3,7 +3,7 @@
   "containerDefinitions": [{
     "image": "microsoft/windowsservercore:latest",
     "name": "savedstate-windows",
-    "cpu": 10,
+    "cpu": 512,
     "memory": 256,
     "entryPoint": ["powershell"],
     "command": ["sleep", "500"]

--- a/agent/functional_tests/testdata/taskdefinitions/simple-exit-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/simple-exit-windows/task-definition.json
@@ -3,7 +3,7 @@
   "containerDefinitions": [{
     "image": "microsoft/windowsservercore:latest",
     "name": "exit",
-    "cpu": 10,
+    "cpu": 512,
     "memory": 256,
     "essential": true,
     "entryPoint": ["powershell"],

--- a/agent/functional_tests/testdata/taskdefinitions/working-dir-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/working-dir-windows/task-definition.json
@@ -3,7 +3,7 @@
   "containerDefinitions": [{
     "image": "microsoft/windowsservercore:latest",
     "name": "exit",
-    "cpu": 10,
+    "cpu": 512,
     "memory": 256,
     "workingDirectory": "C:/windows/system32",
     "command": ["powershell", "-c", "if ((pwd).Path -eq \"C:\\windows\\system32\") { exit 42 } ; exit 1"]


### PR DESCRIPTION
### Summary
Windows functional tests are failing because the small CPU limit is slowing the container launch.  This commit increases CPU limits.

### Implementation details
Increases CPU limits for Windows functional tests

### Testing
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: no

### Description for the changelog
none

### Licensing
This contribution is under the terms of the Apache 2.0 License: yes
