### PR TITLE
Bind credential listener to localhost

### DIFF
--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -45,9 +45,6 @@ const (
 	// AgentCredentialsPort is used to serve the credentials for tasks.
 	AgentCredentialsPort = 51679
 
-	// AgentCredentialsAddress is used to serve the credentials for tasks.
-	AgentCredentialsAddress = "127.0.0.1"
-
 	// defaultConfigFileName is the default (json-formatted) config file
 	defaultConfigFileName = "/etc/ecs_container_agent/config.json"
 

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -45,6 +45,9 @@ const (
 	// AgentCredentialsPort is used to serve the credentials for tasks.
 	AgentCredentialsPort = 51679
 
+	// AgentCredentialsAddress is used to serve the credentials for tasks.
+	AgentCredentialsAddress = "127.0.0.1"
+
 	// defaultConfigFileName is the default (json-formatted) config file
 	defaultConfigFileName = "/etc/ecs_container_agent/config.json"
 

--- a/agent/config/config_unix.go
+++ b/agent/config/config_unix.go
@@ -21,6 +21,8 @@ import (
 )
 
 const (
+	// AgentCredentialsAddress is used to serve the credentials for tasks.
+	AgentCredentialsAddress = "" // this is left blank right now for net=bridge
 	// defaultAuditLogFile specifies the default audit log filename
 	defaultCredentialsAuditLogFile = "/log/audit.log"
 	// Default cgroup prefix for ECS tasks

--- a/agent/config/config_windows.go
+++ b/agent/config/config_windows.go
@@ -23,6 +23,9 @@ import (
 )
 
 const (
+	// AgentCredentialsAddress is used to serve the credentials for tasks.
+	AgentCredentialsAddress = "127.0.0.1"
+	// defaultAuditLogFile specifies the default audit log filename
 	defaultCredentialsAuditLogFile = `log\audit.log`
 	// When using IAM roles for tasks on Windows, the credential proxy consumes port 80
 	httpPort = 80

--- a/agent/handlers/credentials/handler.go
+++ b/agent/handlers/credentials/handler.go
@@ -106,7 +106,7 @@ func setupServer(credentialsManager credentials.Manager, auditLogger audit.Audit
 	loggingServeMux.Handle("/", handlers.NewLoggingHandler(serverMux))
 
 	server := http.Server{
-		Addr:         ":" + strconv.Itoa(config.AgentCredentialsPort),
+		Addr:         config.AgentCredentialsAddress + ":" + strconv.Itoa(config.AgentCredentialsPort),
 		Handler:      loggingServeMux,
 		ReadTimeout:  readTimeout,
 		WriteTimeout: writeTimeout,

--- a/misc/windows-deploy/hostsetup.ps1
+++ b/misc/windows-deploy/hostsetup.ps1
@@ -19,6 +19,7 @@ $ErrorActionPreference = 'Continue'
 # 169.254.170.2:51679 is the IP address used for task IAM roles.
 $credentialAddress = "169.254.170.2"
 $credentialPort = "51679"
+$loopbackAddress = "127.0.0.1"
 
 $adapter = (Get-NetAdapter -Name "*APIPA*")
 if(!($adapter)) {
@@ -45,7 +46,7 @@ if(!($ip)) {
 
 	# This forwards traffic from port 80 and listens on the IAM role IP address.
 	# 'portproxy' doesn't have a powershell module equivalent, but we could move if it becomes available.
-	netsh interface portproxy add v4tov4 listenaddress=$credentialAddress listenport=80 connectaddress=$credentialAddress connectport=$credentialPort
+	netsh interface portproxy add v4tov4 listenaddress=$credentialAddress listenport=80 connectaddress=$loopbackAddress connectport=$credentialPort
 }
 
 $ErrorActionPreference=$oldActionPref


### PR DESCRIPTION
### Summary
Bind to 127.0.0.1 and set portproxy to 127.0.0.1 instead of 169.254.170.2

### Implementation details
Bind to 127.0.0.1 and set portproxy to 127.0.0.1 instead of 169.254.170.2

Existing behavior is preserved for Linux just because I haven't tested all possible configurations on Linux (especially the `net=bridge` configuration).

### Testing
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass
- [x] Manually tested that credentials endpoint could be reached from a container
- [x] Manually tested that credentials endpoint could be reached on the same host
- [x] Manually tested that credentials endpoint could not be reached from a host in the same subnet

New tests cover the changes: no

### Description for the changelog
none

### Licensing
This contribution is under the terms of the Apache 2.0 License: yes
