### PR TITLE
adding a 'awsvpc' functional test

### DIFF
--- a/agent/functional_tests/testdata/taskdefinitions/nginx-awsvpc/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/nginx-awsvpc/task-definition.json
@@ -1,0 +1,12 @@
+{
+  "family": "ecsftest-nginx-awsvpc",
+  "networkMode": "awsvpc",
+  "containerDefinitions": [{
+    "image": "127.0.0.1:51670/nginx:latest",
+    "name": "nginx",
+    "portBindings": [{
+      "containerPort": 80
+    }],
+    "memory": 50
+  }]
+}

--- a/agent/functional_tests/tests/functionaltests_unix_test.go
+++ b/agent/functional_tests/tests/functionaltests_unix_test.go
@@ -425,7 +425,7 @@ func TestTelemetry(t *testing.T) {
 	assert.NoError(t, err, "Task stopped, verify metrics for memory utilization failed")
 }
 
-func TestTaskIamRolesNetHostMode(t *testing.T) {
+func TestTaskIAMRolesNetHostMode(t *testing.T) {
 	// The test runs only when the environment TEST_IAM_ROLE was set
 	if os.Getenv("TEST_TASK_IAM_ROLE_NET_HOST") != "true" {
 		t.Skip("Skipping test TaskIamRole in host network mode, as TEST_TASK_IAM_ROLE_NET_HOST isn't set true")
@@ -445,10 +445,10 @@ func TestTaskIamRolesNetHostMode(t *testing.T) {
 	agent := RunAgent(t, agentOptions)
 	defer agent.Cleanup()
 
-	taskIamRolesTest("host", agent, t)
+	taskIAMRoles("host", agent, t)
 }
 
-func TestTaskIamRolesDefaultNetworkMode(t *testing.T) {
+func TestTaskIAMRolesDefaultNetworkMode(t *testing.T) {
 	// The test runs only when the environment TEST_IAM_ROLE was set
 	if os.Getenv("TEST_TASK_IAM_ROLE") != "true" {
 		t.Skip("Skipping test TaskIamRole in default network mode, as TEST_TASK_IAM_ROLE isn't set true")
@@ -468,10 +468,10 @@ func TestTaskIamRolesDefaultNetworkMode(t *testing.T) {
 	agent := RunAgent(t, agentOptions)
 	defer agent.Cleanup()
 
-	taskIamRolesTest("bridge", agent, t)
+	taskIAMRoles("bridge", agent, t)
 }
 
-func taskIamRolesTest(networkMode string, agent *TestAgent, t *testing.T) {
+func taskIAMRoles(networkMode string, agent *TestAgent, t *testing.T) {
 	RequireDockerVersion(t, ">=1.11.0") // TaskIamRole is available from agent 1.11.0
 	roleArn := os.Getenv("TASK_IAM_ROLE_ARN")
 	if utils.ZeroOrNil(roleArn) {
@@ -551,14 +551,14 @@ func TestMemoryOvercommit(t *testing.T) {
 			containerMetaData.HostConfig.MemoryReservation, memoryReservation*1024*1024))
 }
 
-// TestNetworkModeBridge tests the container network can be configured
+// TestNetworkModeHost tests the container network can be configured
 // as host mode in task definition
 func TestNetworkModeHost(t *testing.T) {
 	agent := RunAgent(t, nil)
 	defer agent.Cleanup()
 
 	err := networkModeTest(t, agent, "host")
-	require.NoError(t, err, "Networking mode host testing failed")
+	require.NoError(t, err, "Networking mode 'host' testing failed")
 }
 
 // TestNetworkModeBridge tests the container network can be configured
@@ -568,7 +568,16 @@ func TestNetworkModeBridge(t *testing.T) {
 	defer agent.Cleanup()
 
 	err := networkModeTest(t, agent, "bridge")
-	require.NoError(t, err, "Networking mode bridge testing failed")
+	require.NoError(t, err, "Networking mode 'bridge' testing failed")
+}
+
+func TestNetworkModeAWSVPC(t *testing.T) {
+	RequireDockerVersion(t, ">=17.06.0-ce")
+	agent := RunAgent(t, &AgentOptions{EnableTaskENI: true})
+	defer agent.Cleanup()
+
+	err := awsvpcNetworkModeTest(t, agent)
+	require.NoError(t, err, "Networking mode 'awsvpc' testing failed")
 }
 
 // TestFluentdTag tests the fluentd logging driver option "tag"

--- a/agent/functional_tests/util/utils.go
+++ b/agent/functional_tests/util/utils.go
@@ -18,7 +18,6 @@ package util
 import (
 	"crypto/md5"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -39,6 +38,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	"github.com/aws/aws-sdk-go/service/iam"
 	docker "github.com/fsouza/go-dockerclient"
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
 
@@ -112,6 +112,7 @@ type AgentOptions struct {
 	ExtraEnvironment map[string]string
 	ContainerLinks   []string
 	PortBindings     map[docker.Port]map[string]string
+	EnableTaskENI    bool
 }
 
 // verifyIntrospectionAPI verifies that we can talk to the agent's introspection http endpoint.
@@ -218,6 +219,48 @@ func (agent *TestAgent) StartTaskWithTaskDefinitionOverrides(t *testing.T, task 
 	}
 
 	return tasks[0], nil
+}
+
+// StartAWSVPCTask starts a task with "awsvpc" networking mode
+func (agent *TestAgent) StartAWSVPCTask(task string) (*TestTask, error) {
+	td, err := GetTaskDefinition(task)
+	if err != nil {
+		return nil, err
+	}
+
+	return agent.startAWSVPCTask(td)
+}
+
+func (agent *TestAgent) startAWSVPCTask(taskDefinition string) (*TestTask, error) {
+	agent.t.Logf("Task definition: %s", taskDefinition)
+	// Get the subnet ID, which is a required parameter for starting
+	// tasks in 'awsvpc' network mode
+	subnet, err := getSubnetID()
+	if err != nil {
+		return nil, err
+	}
+
+	agent.t.Logf("Starting 'awsvpc' task in subnet: %s", subnet)
+	resp, err := ECS.StartTask(&ecs.StartTaskInput{
+		Cluster:            &agent.Cluster,
+		ContainerInstances: []*string{&agent.ContainerInstanceArn},
+		TaskDefinition:     &taskDefinition,
+		NetworkConfiguration: &ecs.NetworkConfiguration{
+			AwsvpcConfiguration: &ecs.AwsVpcConfiguration{
+				Subnets: []*string{&subnet},
+			},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(resp.Failures) != 0 || len(resp.Tasks) == 0 {
+		return nil, errors.New("Failure starting task: " + *resp.Failures[0].Reason)
+	}
+
+	task := resp.Tasks[0]
+	agent.t.Logf("Started task: %s\n", *task.TaskArn)
+	return &TestTask{task}, nil
 }
 
 func (agent *TestAgent) StartTaskWithOverrides(t *testing.T, task string, overrides []*ecs.ContainerOverride) (*TestTask, error) {
@@ -480,7 +523,8 @@ func (task *TestTask) waitStatus(timeout time.Duration, status string) error {
 		return err
 	case <-timer.C:
 		cancelled = true
-		return errors.New("Timed out waiting for task to reach " + status + ": " + *task.TaskDefinitionArn + ", " + *task.TaskArn)
+		return errors.Errorf("Timed out waiting for task '%s' to reach '%s': '%s' ",
+			status, *task.TaskArn, task.GoString())
 	}
 }
 
@@ -531,6 +575,15 @@ func (task *TestTask) Stop() error {
 		Task:    task.TaskArn,
 	})
 	return err
+}
+
+// GetAttachmentInfo returns the task's attachment properties, as a list of key value pairs
+func (task *TestTask) GetAttachmentInfo() ([]*ecs.KeyValuePair, error) {
+	if len(task.Attachments) == 0 {
+		return nil, errors.New("attachments empty for task")
+	}
+
+	return task.Attachments[0].Details, nil
 }
 
 func RequireDockerVersion(t *testing.T, selector string) {
@@ -671,4 +724,19 @@ func AttributesToMap(attributes []*ecs.Attribute) map[string]string {
 		attributeMap[aws.StringValue(attribute.Name)] = aws.StringValue(attribute.Value)
 	}
 	return attributeMap
+}
+
+// getSubnetID gets the subnet id for the instance from ec2 instance metadata
+func getSubnetID() (string, error) {
+	ec2Metadata := ec2metadata.New(session.Must(session.NewSession()))
+	mac, err := ec2Metadata.GetMetadata("mac")
+	if err != nil {
+		return "", errors.Wrapf(err, "unable to get mac from ec2 metadata")
+	}
+	subnet, err := ec2Metadata.GetMetadata("network/interfaces/macs/" + mac + "/subnet-id")
+	if err != nil {
+		return "", errors.Wrapf(err, "unable to get subnet from ec2 metadata")
+	}
+
+	return subnet, nil
 }


### PR DESCRIPTION
The test starts a task with an 'nginx' container, gets the ip address of
the container by descrining the task and queries the ip address for a
response from the nginx container.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Adding a 'awsvpc' functional test

### Implementation details
<!-- How are the changes implemented? -->

The `TestNetworkModeAWSVPC ` test starts a task with an 'nginx' container, gets the ip address of the container by describing the task and queries the ip address for a response from the nginx container.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: Yes, the test is the test

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: Yes
