### PR TITLE
Bug - Fixed a bug where -version fails due to its dependency on docker client 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 #Changelog
 
+## Unreleased
+* Bug - Fixed a bug where `-version` fails due to its dependency on docker client. [#1118](https://github.com/aws/amazon-ecs-agent/pull/1118)
+
 ## 1.16.0
 * Feature - Support pulling from Amazon ECR with specified IAM role in task definition
 * Feature - Enable support for task level CPU and memory constraints.

--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -44,7 +44,6 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/statemanager"
 	"github.com/aws/amazon-ecs-agent/agent/tcs/handler"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
-	"github.com/aws/amazon-ecs-agent/agent/version"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	aws_credentials "github.com/aws/aws-sdk-go/aws/credentials"
@@ -71,8 +70,6 @@ var (
 // object. Its purpose is to mostly demonstrate how to interact with the
 // ecsAgent type.
 type agent interface {
-	// printVersion prints the Agent version string
-	printVersion() int
 	// printECSAttributes prints the Agent's capabilities based on
 	// its environment
 	printECSAttributes() int
@@ -168,12 +165,6 @@ func newAgent(
 		resource:           resources.New(),
 		terminationHandler: sighandlers.StartDefaultTerminationHandler,
 	}, nil
-}
-
-// printVersion prints the ECS Agent version string
-func (agent *ecsAgent) printVersion() int {
-	version.PrintVersion(agent.dockerClient)
-	return exitcodes.ExitSuccess
 }
 
 // printECSAttributes prints the Agent's ECS Attributes based on its

--- a/agent/app/agent_integ_test.go
+++ b/agent/app/agent_integ_test.go
@@ -32,7 +32,7 @@ func TestNewAgent(t *testing.T) {
 	agent, err := newAgent(ctx, true, aws.Bool(true))
 
 	assert.NoError(t, err)
-	// printVersion should ensure that agent's cfg is set with
+	// printECSAttributes should ensure that agent's cfg is set with
 	// valid values and not panic
-	assert.Equal(t, exitcodes.ExitSuccess, agent.printVersion())
+	assert.Equal(t, exitcodes.ExitSuccess, agent.printECSAttributes())
 }

--- a/agent/app/agent_windows_test.go
+++ b/agent/app/agent_windows_test.go
@@ -40,7 +40,6 @@ func (m *mockAgent) start() int {
 func (m *mockAgent) setTerminationHandler(handler sighandlers.TerminationHandler) {
 	m.terminationHandler = handler
 }
-func (m *mockAgent) printVersion() int        { return 0 }
 func (m *mockAgent) printECSAttributes() int  { return 0 }
 func (m *mockAgent) startWindowsService() int { return 0 }
 

--- a/agent/app/run.go
+++ b/agent/app/run.go
@@ -19,6 +19,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/app/args"
 	"github.com/aws/amazon-ecs-agent/agent/logger"
 	"github.com/aws/amazon-ecs-agent/agent/sighandlers/exitcodes"
+	"github.com/aws/amazon-ecs-agent/agent/version"
 	"github.com/aws/aws-sdk-go/aws"
 	log "github.com/cihub/seelog"
 )
@@ -35,6 +36,8 @@ func Run(arguments []string) int {
 
 	if *parsedArgs.License {
 		return printLicense()
+	} else if *parsedArgs.Version {
+		return version.PrintVersion()
 	}
 
 	logger.SetLevel(*parsedArgs.LogLevel)
@@ -50,9 +53,6 @@ func Run(arguments []string) int {
 	}
 
 	switch {
-	case *parsedArgs.Version:
-		// Print Agent's version and exit
-		return agent.printVersion()
 	case *parsedArgs.ECSAttributes:
 		// Print agent's ecs attributes based on its environment and exit
 		return agent.printECSAttributes()

--- a/agent/version/formatting.go
+++ b/agent/version/formatting.go
@@ -13,11 +13,11 @@
 
 package version
 
-import "fmt"
+import (
+	"fmt"
 
-type Versioner interface {
-	Version() (string, error)
-}
+	"github.com/aws/amazon-ecs-agent/agent/sighandlers/exitcodes"
+)
 
 // PrintVersions prints the version information on stdout as a multi-line
 // string. The output will look similar to the following:
@@ -25,8 +25,7 @@ type Versioner interface {
 //    Amazon ECS Agent:
 //        Version: 0.0.3
 //        Commit: 4bdc7fc
-//        DockerVersion: 1.5.0
-func PrintVersion(extra ...Versioner) {
+func PrintVersion() int {
 	cleanliness := ""
 	if GitDirty {
 		cleanliness = "\tDirty: true\n"
@@ -37,12 +36,7 @@ func PrintVersion(extra ...Versioner) {
 	Commit: %v
 %v`, Version, GitShortHash, cleanliness)
 
-	for _, versioner := range extra {
-		if str, err := versioner.Version(); err == nil {
-			fmt.Printf("\t%v\n", str)
-		}
-	}
-
+	return exitcodes.ExitSuccess
 }
 
 // String produces a human-readable string showing the agent version.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Making -version flag for agent independent of docker client, and removing docker version from output.
% docker run --rm --env-file ~/env.txt amazon/amazon-ecs-agent:make -version
Amazon ECS Agent:
	Version: 1.16.0
	Commit: c2836d6
    	Dirty: true

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
