### PR TITLE
Update cgroup root prefix to docker fixes #1119

### DIFF
--- a/agent/config/config_unix.go
+++ b/agent/config/config_unix.go
@@ -26,7 +26,7 @@ const (
 	// defaultAuditLogFile specifies the default audit log filename
 	defaultCredentialsAuditLogFile = "/log/audit.log"
 	// Default cgroup prefix for ECS tasks
-	DefaultTaskCgroupPrefix = "/ecs"
+	DefaultTaskCgroupPrefix = "/docker"
 )
 
 // DefaultConfig returns the default configuration for Linux

--- a/agent/resources/resources_linux.go
+++ b/agent/resources/resources_linux.go
@@ -66,10 +66,7 @@ func (c *cgroupWrapper) cgroupInit() error {
 
 // setupCgroup is used to create the task cgroup
 func (c *cgroupWrapper) setupCgroup(task *api.Task) error {
-	cgroupRoot, err := task.BuildCgroupRoot()
-	if err != nil {
-		return errors.Wrapf(err, "resource: setup cgroup: unable to determine cgroup root for task: %s", task.Arn)
-	}
+	var cgroupRoot = config.DefaultTaskCgroupPrefix
 
 	seelog.Debugf("Setting up cgroup at: %s for task: %s", cgroupRoot, task.Arn)
 
@@ -98,14 +95,11 @@ func (c *cgroupWrapper) setupCgroup(task *api.Task) error {
 
 // cleanupCgroup is used to remove the task cgroup
 func (c *cgroupWrapper) cleanupCgroup(task *api.Task) error {
-	cgroupRoot, err := task.BuildCgroupRoot()
-	if err != nil {
-		return errors.Wrapf(err, "resource: cleanup cgroup: unable to determine cgroup root for task: %s", task.Arn)
-	}
+	var cgroupRoot = config.DefaultTaskCgroupPrefix
 
 	seelog.Debugf("Cleaning up cgroup at: %s for task: %s", cgroupRoot, task.Arn)
 
-	err = c.control.Remove(cgroupRoot)
+	var err = c.control.Remove(cgroupRoot)
 	// Explicitly handle cgroup deleted error
 	if err != nil {
 		if err == cgroups.ErrCgroupDeleted {

--- a/agent/resources/resources_linux_test.go
+++ b/agent/resources/resources_linux_test.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/aws/amazon-ecs-agent/agent/api"
 	"github.com/aws/amazon-ecs-agent/agent/engine/testdata"
 	"github.com/aws/amazon-ecs-agent/agent/resources/cgroup/factory/mock"
 	"github.com/aws/amazon-ecs-agent/agent/resources/cgroup/mock_control"
@@ -94,20 +93,6 @@ func TestSetupHappyPath(t *testing.T) {
 	assert.NoError(t, resource.Setup(task))
 }
 
-func TestSetupInvalidTaskARN(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	mockControl := mock_cgroup.NewMockControl(ctrl)
-
-	task := &api.Task{
-		Arn: invalidTaskArn,
-	}
-
-	resource := newResources(mockControl)
-	assert.Error(t, resource.Setup(task))
-}
-
 func TestSetupCgroupExists(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -178,20 +163,6 @@ func TestCleanupRemoveError(t *testing.T) {
 	task := testdata.LoadTask("sleep5TaskCgroup")
 
 	mockControl.EXPECT().Remove(gomock.Any()).Return(errors.New("cgroup remove error"))
-
-	resource := newResources(mockControl)
-	assert.Error(t, resource.Cleanup(task))
-}
-
-func TestCleanupInvalidTaskARN(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	mockControl := mock_cgroup.NewMockControl(ctrl)
-
-	task := &api.Task{
-		Arn: invalidTaskArn,
-	}
 
 	resource := newResources(mockControl)
 	assert.Error(t, resource.Cleanup(task))


### PR DESCRIPTION
### Summary
Change the cgroup root prefix from ecs to docker. The default prefix for
a docker container is "docker" followed by the image name / sha. Several
libraries determine the container id by parsing /proc/self/cgroup and
expect "docker/container_id". This commit reverts part of a previous
commit (f09f0f56f21696cc) where the "ecs" prefix was introduced.

### Description of Changes
I updated the configuration for the cgroup prefix and the supporting
methods to remove the task arn. This should bring the naming convention
back to its previous default. The unit test were updated or removed
where necessary. Some checks for errors that no longer occur since we no
longer need to parse the task arn for the prefix.

### Testing
make test-in-docker

- [ ] Builds on Linux (`make release`)
- [ ] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes

Update cgroup root prefix to "docker" instead of "ecs"

This contribution is under the terms of the Apache 2.0 License: yes