### PR TITLE
[wip] Metadata task definition fields

### DIFF
--- a/agent/containermetadata/manager.go
+++ b/agent/containermetadata/manager.go
@@ -24,6 +24,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/utils/oswrapper"
 
 	docker "github.com/fsouza/go-dockerclient"
+	"github.com/aws/amazon-ecs-agent/agent/api"
 )
 
 const (
@@ -39,8 +40,8 @@ const (
 // operations
 type Manager interface {
 	SetContainerInstanceARN(string)
-	Create(*docker.Config, *docker.HostConfig, string, string) error
-	Update(string, string, string) error
+	Create(*docker.Config, *docker.HostConfig, *api.Task, string) error
+	Update(string, *api.Task, string) error
 	Clean(string) error
 }
 
@@ -86,22 +87,22 @@ func (manager *metadataManager) SetContainerInstanceARN(containerInstanceARN str
 // Create creates the metadata file and adds the metadata directory to
 // the container's mounted host volumes
 // Pointer hostConfig is modified directly so there is risk of concurrency errors.
-func (manager *metadataManager) Create(config *docker.Config, hostConfig *docker.HostConfig, taskARN string, containerName string) error {
+func (manager *metadataManager) Create(config *docker.Config, hostConfig *docker.HostConfig, task *api.Task, containerName string) error {
 	// Create task and container directories if they do not yet exist
-	metadataDirectoryPath, err := getMetadataFilePath(taskARN, containerName, manager.dataDir)
+	metadataDirectoryPath, err := getMetadataFilePath(task.Arn, containerName, manager.dataDir)
 	// Stop metadata creation if path is malformed for any reason
 	if err != nil {
-		return fmt.Errorf("container metadata create for task %s container %s: %v", taskARN, containerName, err)
+		return fmt.Errorf("container metadata create for task %s container %s: %v", task.Arn, containerName, err)
 	}
 
 	err = manager.osWrap.MkdirAll(metadataDirectoryPath, os.ModePerm)
 	if err != nil {
-		return fmt.Errorf("creating metadata directory for task %s: %v", taskARN, err)
+		return fmt.Errorf("creating metadata directory for task %s: %v", task.Arn, err)
 	}
 
 	// Acquire the metadata then write it in JSON format to the file
-	metadata := manager.parseMetadataAtContainerCreate(taskARN, containerName)
-	err = manager.marshalAndWrite(metadata, taskARN, containerName)
+	metadata := manager.parseMetadataAtContainerCreate(task, containerName)
+	err = manager.marshalAndWrite(metadata, task.Arn, containerName)
 	if err != nil {
 		return err
 	}
@@ -115,7 +116,7 @@ func (manager *metadataManager) Create(config *docker.Config, hostConfig *docker
 }
 
 // Update updates the metadata file after container starts and dynamic metadata is available
-func (manager *metadataManager) Update(dockerID string, taskARN string, containerName string) error {
+func (manager *metadataManager) Update(dockerID string, task *api.Task, containerName string) error {
 	// Get docker container information through api call
 	dockerContainer, err := manager.client.InspectContainer(dockerID, inspectContainerTimeout)
 	if err != nil {
@@ -124,12 +125,12 @@ func (manager *metadataManager) Update(dockerID string, taskARN string, containe
 
 	// Ensure we do not update a container that is invalid or is not running
 	if dockerContainer == nil || !dockerContainer.State.Running {
-		return fmt.Errorf("container metadata update for contiainer %s in task %s: container not running or invalid", containerName, taskARN)
+		return fmt.Errorf("container metadata update for container %s in task %s: container not running or invalid", containerName, task.Arn)
 	}
 
 	// Acquire the metadata then write it in JSON format to the file
-	metadata := manager.parseMetadata(dockerContainer, taskARN, containerName)
-	return manager.marshalAndWrite(metadata, taskARN, containerName)
+	metadata := manager.parseMetadata(dockerContainer, task, containerName)
+	return manager.marshalAndWrite(metadata, task.Arn, containerName)
 }
 
 // Clean removes the metadata files of all containers associated with a task

--- a/agent/containermetadata/manager_unix_test.go
+++ b/agent/containermetadata/manager_unix_test.go
@@ -17,6 +17,8 @@ package containermetadata
 import (
 	"testing"
 
+	"github.com/aws/amazon-ecs-agent/agent/api"
+
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -28,6 +30,7 @@ func TestCreate(t *testing.T) {
 	defer done()
 
 	mockTaskARN := validTaskARN
+	mockTask := &api.Task{ Arn: mockTaskARN }
 	mockContainerName := containerName
 	mockConfig := &docker.Config{Env: make([]string, 0)}
 	mockHostConfig := &docker.HostConfig{Binds: make([]string, 0)}
@@ -46,7 +49,7 @@ func TestCreate(t *testing.T) {
 		osWrap:     mockOS,
 		ioutilWrap: mockIOUtil,
 	}
-	err := newManager.Create(mockConfig, mockHostConfig, mockTaskARN, mockContainerName)
+	err := newManager.Create(mockConfig, mockHostConfig, mockTask, mockContainerName)
 
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(mockConfig.Env), "Unexpected number of environment variables in config")
@@ -60,6 +63,7 @@ func TestUpdate(t *testing.T) {
 
 	mockDockerID := dockerID
 	mockTaskARN := validTaskARN
+	mockTask := &api.Task{ Arn: mockTaskARN }
 	mockContainerName := containerName
 	mockState := docker.State{
 		Running: true,
@@ -91,7 +95,7 @@ func TestUpdate(t *testing.T) {
 		mockOS.EXPECT().Rename(gomock.Any(), gomock.Any()).Return(nil),
 		mockFile.EXPECT().Close().Return(nil),
 	)
-	err := newManager.Update(mockDockerID, mockTaskARN, mockContainerName)
+	err := newManager.Update(mockDockerID, mockTask, mockContainerName)
 
 	assert.NoError(t, err)
 }

--- a/agent/containermetadata/manager_windows_test.go
+++ b/agent/containermetadata/manager_windows_test.go
@@ -17,6 +17,8 @@ package containermetadata
 import (
 	"testing"
 
+	"github.com/aws/amazon-ecs-agent/agent/api"
+
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -28,6 +30,7 @@ func TestCreate(t *testing.T) {
 	defer done()
 
 	mockTaskARN := validTaskARN
+	mockTask := &api.Task{ Arn: mockTaskARN }
 	mockContainerName := containerName
 	mockConfig := &docker.Config{Env: make([]string, 0)}
 	mockHostConfig := &docker.HostConfig{Binds: make([]string, 0)}
@@ -43,7 +46,7 @@ func TestCreate(t *testing.T) {
 	newManager := &metadataManager{
 		osWrap: mockOS,
 	}
-	err := newManager.Create(mockConfig, mockHostConfig, mockTaskARN, mockContainerName)
+	err := newManager.Create(mockConfig, mockHostConfig, mockTask, mockContainerName)
 
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(mockConfig.Env), "Unexpected number of environment variables in config")
@@ -57,6 +60,7 @@ func TestUpdate(t *testing.T) {
 
 	mockDockerID := dockerID
 	mockTaskARN := validTaskARN
+	mockTask := &api.Task{ Arn: mockTaskARN }
 	mockContainerName := containerName
 	mockState := docker.State{
 		Running: true,
@@ -85,7 +89,7 @@ func TestUpdate(t *testing.T) {
 		mockFile.EXPECT().Sync().Return(nil),
 		mockFile.EXPECT().Close().Return(nil),
 	)
-	err := newManager.Update(mockDockerID, mockTaskARN, mockContainerName)
+	err := newManager.Update(mockDockerID, mockTask, mockContainerName)
 
 	assert.NoError(t, err)
 }

--- a/agent/containermetadata/mocks/containermetadata_mocks.go
+++ b/agent/containermetadata/mocks/containermetadata_mocks.go
@@ -21,6 +21,7 @@ import (
 
 	go_dockerclient "github.com/fsouza/go-dockerclient"
 	gomock "github.com/golang/mock/gomock"
+	"github.com/aws/amazon-ecs-agent/agent/api"
 )
 
 // Mock of Manager interface
@@ -54,7 +55,7 @@ func (_mr *_MockManagerRecorder) Clean(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Clean", arg0)
 }
 
-func (_m *MockManager) Create(_param0 *go_dockerclient.Config, _param1 *go_dockerclient.HostConfig, _param2 string, _param3 string) error {
+func (_m *MockManager) Create(_param0 *go_dockerclient.Config, _param1 *go_dockerclient.HostConfig, _param2 *api.Task, _param3 string) error {
 	ret := _m.ctrl.Call(_m, "Create", _param0, _param1, _param2, _param3)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -72,7 +73,7 @@ func (_mr *_MockManagerRecorder) SetContainerInstanceARN(arg0 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetContainerInstanceARN", arg0)
 }
 
-func (_m *MockManager) Update(_param0 string, _param1 string, _param2 string) error {
+func (_m *MockManager) Update(_param0 string, _param1 *api.Task, _param2 string) error {
 	ret := _m.ctrl.Call(_m, "Update", _param0, _param1, _param2)
 	ret0, _ := ret[0].(error)
 	return ret0

--- a/agent/containermetadata/types.go
+++ b/agent/containermetadata/types.go
@@ -113,8 +113,10 @@ type DockerContainerMetadata struct {
 // TaskMetadata keeps track of all metadata associated with a task
 // provided by AWS, does not depend on the creation of the container
 type TaskMetadata struct {
-	containerName string
-	taskARN       string
+	containerName          string
+	taskARN                string
+	taskDefinitionFamily   string
+	taskDefinitionRevision int
 }
 
 // Metadata packages all acquired metadata and is used to format it
@@ -130,34 +132,38 @@ type Metadata struct {
 }
 
 // metadataSerializer is an intermediate struct that converts the information
-// in Metadata into information to encode into JSOn
+// in Metadata into information to encode into JSON
 type metadataSerializer struct {
-	Cluster              string            `json:"Cluster,omitempty"`
-	ContainerInstanceARN string            `json:"ContainerInstanceARN,omitempty"`
-	TaskARN              string            `json:"TaskARN,omitempty"`
-	ContainerID          string            `json:"ContainerID,omitempty"`
-	ContainerName        string            `json:"ContainerName,omitempty"`
-	DockerContainerName  string            `json:"DockerContainerName,omitempty"`
-	ImageID              string            `json:"ImageID,omitempty"`
-	ImageName            string            `json:"ImageName,omitempty"`
-	Ports                []api.PortBinding `json:"PortMappings,omitempty"`
-	Networks             []Network         `json:"Networks,omitempty"`
-	MetadataFileStatus   MetadataStatus    `json:"MetadataFileStatus,omitempty"`
+	Cluster                string            `json:"Cluster,omitempty"`
+	ContainerInstanceARN   string            `json:"ContainerInstanceARN,omitempty"`
+	TaskARN                string            `json:"TaskARN,omitempty"`
+	TaskDefinitionFamily   string            `json:"TaskDefinitionFamily,omitempty"`
+	TaskDefinitionRevision int             `json:"TaskDefinitionRevision,omitempty"`
+	ContainerID            string            `json:"ContainerID,omitempty"`
+	ContainerName          string            `json:"ContainerName,omitempty"`
+	DockerContainerName    string            `json:"DockerContainerName,omitempty"`
+	ImageID                string            `json:"ImageID,omitempty"`
+	ImageName              string            `json:"ImageName,omitempty"`
+	Ports                  []api.PortBinding `json:"PortMappings,omitempty"`
+	Networks               []Network         `json:"Networks,omitempty"`
+	MetadataFileStatus     MetadataStatus    `json:"MetadataFileStatus,omitempty"`
 }
 
 func (m Metadata) MarshalJSON() ([]byte, error) {
 	return json.Marshal(
 		metadataSerializer{
-			Cluster:              m.cluster,
-			ContainerInstanceARN: m.containerInstanceARN,
-			TaskARN:              m.taskMetadata.taskARN,
-			ContainerID:          m.dockerContainerMetadata.containerID,
-			ContainerName:        m.taskMetadata.containerName,
-			DockerContainerName:  m.dockerContainerMetadata.dockerContainerName,
-			ImageID:              m.dockerContainerMetadata.imageID,
-			ImageName:            m.dockerContainerMetadata.imageName,
-			Ports:                m.dockerContainerMetadata.ports,
-			Networks:             m.dockerContainerMetadata.networkInfo.networks,
-			MetadataFileStatus:   m.metadataStatus,
+			Cluster:                m.cluster,
+			ContainerInstanceARN:   m.containerInstanceARN,
+			TaskARN:                m.taskMetadata.taskARN,
+			TaskDefinitionFamily:   m.taskMetadata.taskDefinitionFamily,
+			TaskDefinitionRevision: m.taskMetadata.taskDefinitionRevision,
+			ContainerID:            m.dockerContainerMetadata.containerID,
+			ContainerName:          m.taskMetadata.containerName,
+			DockerContainerName:    m.dockerContainerMetadata.dockerContainerName,
+			ImageID:                m.dockerContainerMetadata.imageID,
+			ImageName:              m.dockerContainerMetadata.imageName,
+			Ports:                  m.dockerContainerMetadata.ports,
+			Networks:               m.dockerContainerMetadata.networkInfo.networks,
+			MetadataFileStatus:     m.metadataStatus,
 		})
 }

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -740,7 +740,7 @@ func (engine *DockerTaskEngine) createContainer(task *api.Task, container *api.C
 	// Create metadata directory and file then populate it with common metadata of all containers of this task
 	// Afterwards add this directory to the container's mounts if file creation was successful
 	if engine.cfg.ContainerMetadataEnabled && !container.IsInternal() {
-		mderr := engine.metadataManager.Create(config, hostConfig, task.Arn, container.Name)
+		mderr := engine.metadataManager.Create(config, hostConfig, task, container.Name)
 		if mderr != nil {
 			seelog.Warnf("Create metadata failed for container %s of task %s: %v", container.Name, task.Arn, mderr)
 		}
@@ -782,7 +782,7 @@ func (engine *DockerTaskEngine) startContainer(task *api.Task, container *api.Co
 	// add logic to engine state restoration to do a metadata update for containers that are running after the agent was restarted
 	if dockerContainerMD.Error == nil && engine.cfg.ContainerMetadataEnabled && !container.IsInternal() {
 		go func() {
-			err := engine.metadataManager.Update(dockerContainer.DockerID, task.Arn, container.Name)
+			err := engine.metadataManager.Update(dockerContainer.DockerID, task, container.Name)
 			if err != nil {
 				seelog.Warnf("Update metadata file failed for container %s of task %s: %v", container.Name, task.Arn, err)
 				return
@@ -1028,7 +1028,7 @@ func (engine *DockerTaskEngine) isParallelPullCompatible() bool {
 }
 
 func (engine *DockerTaskEngine) updateMetadataFile(task *api.Task, cont *api.DockerContainer) {
-	err := engine.metadataManager.Update(cont.DockerID, task.Arn, cont.Container.Name)
+	err := engine.metadataManager.Update(cont.DockerID, task, cont.Container.Name)
 	if err != nil {
 		seelog.Errorf("Update metadata file failed for container %s of task %s: %v", cont.Container.Name, task.Arn, err)
 	} else {

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -1978,8 +1978,8 @@ func TestMetadataFileUpdatedAgentRestart(t *testing.T) {
 	saver.EXPECT().Save().AnyTimes()
 	saver.EXPECT().ForceSave().AnyTimes()
 
-	metadataManager.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(dockerID string, taskARN string, containerName string) {
-		assert.Equal(t, expectedTaskARN, taskARN)
+	metadataManager.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(dockerID string, task *api.Task, containerName string) {
+		assert.Equal(t, expectedTaskARN, task.Arn)
 		assert.Equal(t, expectedContainerName, containerName)
 		assert.Equal(t, expectedDockerID, dockerID)
 		wg.Done()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Expose two more metadata fields, task definition family and task definition

### Implementation details
Retrieve the fields from the existing task struct, and copy them into the 
metadata JSON. 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [ ] Builds on Linux (`make release`)
- [ ] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes

### Description for the changelog
Enhancement -Expose two more metadata fields, task definition family and task definition

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: yes