### PR TITLE
Persist container exit code in agent state file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 * Bug - Fixed a bug where `-version` fails due to its dependency on docker client. [#1118](https://github.com/aws/amazon-ecs-agent/pull/1118)
+* Bug - Persist container exit code in agent state file [#1125](https://github.com/aws/amazon-ecs-agent/pull/1125)
 
 ## 1.16.0
 * Feature - Support pulling from Amazon ECR with specified IAM role in task definition

--- a/agent/api/container.go
+++ b/agent/api/container.go
@@ -135,7 +135,14 @@ type Container struct {
 	// metadata file
 	MetadataFileUpdated bool `json:"metadataFileUpdated"`
 
-	knownExitCode     *int
+	// KnownExitCodeUnsafe specifies the exit code for the container.
+	// It is exposed outside of the package so that it's marshalled/unmarshalled in
+	// the JSON body while saving the state.
+	// NOTE: Do not access KnownExitCodeUnsafe directly. Instead, use `GetKnownExitCode`
+	// and `SetKnownExitCode`.
+	KnownExitCodeUnsafe *int `json:"KnownExitCode"`
+
+	// KnownPortBindings is an array of port bindings for the container.
 	KnownPortBindings []PortBinding
 
 	// SteadyStateStatusUnsafe specifies the steady state status for the container
@@ -237,14 +244,16 @@ func (c *Container) SetSentStatus(status ContainerStatus) {
 func (c *Container) SetKnownExitCode(i *int) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	c.knownExitCode = i
+
+	c.KnownExitCodeUnsafe = i
 }
 
 // GetKnownExitCode returns the container exit code
 func (c *Container) GetKnownExitCode() *int {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.knownExitCode
+
+	return c.KnownExitCodeUnsafe
 }
 
 // SetRegistryAuthCredentials sets the credentials for pulling image from ECR
@@ -363,7 +372,7 @@ func (c *Container) IsEssential() bool {
 	return c.Essential
 }
 
-// LogAuthExecutionRole returns true if the auth is by exectution role
+// AWSLogAuthExecutionRole returns true if the auth is by execution role
 func (c *Container) AWSLogAuthExecutionRole() bool {
 	return c.LogsAuthStrategy == awslogsAuthExecutionRole
 }

--- a/agent/statemanager/state_manager_test.go
+++ b/agent/statemanager/state_manager_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/statemanager"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStateManagerNonexistantDirectory(t *testing.T) {
@@ -34,7 +35,7 @@ func TestStateManagerNonexistantDirectory(t *testing.T) {
 
 func TestLoadsV1DataCorrectly(t *testing.T) {
 	cleanup, err := setupWindowsTest(filepath.Join(".", "testdata", "v1", "1", "ecs_agent_data.json"))
-	assert.Nil(t, err, "Failed to set up test")
+	require.Nil(t, err, "Failed to set up test")
 	defer cleanup()
 	cfg := &config.Config{DataDir: filepath.Join(".", "testdata", "v1", "1")}
 
@@ -62,11 +63,17 @@ func TestLoadsV1DataCorrectly(t *testing.T) {
 			deadTask = task
 		}
 	}
-	assert.NotNil(t, deadTask)
+
+	require.NotNil(t, deadTask)
 	assert.Equal(t, deadTask.GetSentStatus(), api.TaskStopped)
 	assert.Equal(t, deadTask.Containers[0].SentStatusUnsafe, api.ContainerStopped)
 	assert.Equal(t, deadTask.Containers[0].DesiredStatusUnsafe, api.ContainerStopped)
 	assert.Equal(t, deadTask.Containers[0].KnownStatusUnsafe, api.ContainerStopped)
+
+	exitCode := deadTask.Containers[0].KnownExitCodeUnsafe
+	require.NotNil(t, exitCode)
+	assert.Equal(t, *exitCode, 128)
+
 	expected, _ := time.Parse(time.RFC3339, "2015-04-28T17:29:48.129140193Z")
 	assert.Equal(t, deadTask.GetKnownStatusTime(), expected)
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

Container exit code needs to be persisted in the agent state file so
that api.Container structs can be rebuilt after agent restarts. Go's
default JSON encoder marshals only public fields. This PR renames
and exports that field, updates access functions and adds a test case
for exercising the new logic.

Future work: We should write a custom marshaler for container class
so that we don't have to expose internal state. Since this improvement
is not specific to exit code, I chose to fix it first, and implement the
custom marshaler in a later commit.

### Implementation details
<!-- How are the changes implemented? -->

* Rename and export KnownExitCodeUnsafe with proper JSON marking.
* Add test to ensure exit code is persisted and catch any regressions.
* Fix existing test panics caused by continuing after fatal nil checks.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes
- [x] Confirmed the new test case fails before this commit, and succeeds after it.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Bug - Persist container exit code in agent state file

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: yes

Fixes #986 