### PR TITLE
Adding support for Docker API version 1.30 in Windows

### DIFF
--- a/agent/engine/dockerclient/dockerclientfactory_windows_test.go
+++ b/agent/engine/dockerclient/dockerclientfactory_windows_test.go
@@ -53,6 +53,18 @@ func TestFindClientAPIVersion(t *testing.T) {
 	for _, version := range getAgentVersions() {
 		client, err := factory.GetClient(version)
 		assert.NoError(t, err)
-		assert.Equal(t, Version_1_24, factory.FindClientAPIVersion(client))
+		if isWindowsReplaceableVersion(version) {
+			version = minDockerAPIVersion
+		}
+		assert.Equal(t, version, factory.FindClientAPIVersion(client))
 	}
+}
+
+func isWindowsReplaceableVersion(version DockerVersion) bool {
+	for _, v := range getWindowsReplaceableVersions() {
+		if v == version {
+			return true
+		}
+	}
+	return false
 }

--- a/agent/engine/dockerclient/versionsupport_unix.go
+++ b/agent/engine/dockerclient/versionsupport_unix.go
@@ -40,6 +40,10 @@ func getAgentVersions() []DockerVersion {
 		Version_1_23,
 		Version_1_24,
 		Version_1_25,
+		Version_1_26,
+		Version_1_27,
+		Version_1_28,
+		Version_1_29,
 		Version_1_30,
 	}
 }

--- a/agent/engine/dockerclient/versionsupport_windows.go
+++ b/agent/engine/dockerclient/versionsupport_windows.go
@@ -46,9 +46,23 @@ func getWindowsReplaceableVersions() []DockerVersion {
 	}
 }
 
-// getAgentVersions for Windows should return all of the replaceable versions plus additional versions
+// getWindowsSupportedVersions returns the set of remote api versions that are
+// supported by agent in windows
+func getWindowsSupportedVersions() []DockerVersion {
+	return []DockerVersion{
+		Version_1_24,
+		Version_1_25,
+		Version_1_26,
+		Version_1_27,
+		Version_1_28,
+		Version_1_29,
+		Version_1_30,
+	}
+}
+
+// getAgentVersions for Windows should return all of the replaceable versions plus supported versions
 func getAgentVersions() []DockerVersion {
-	return append(getWindowsReplaceableVersions(), minDockerAPIVersion)
+	return append(getWindowsReplaceableVersions(), getWindowsSupportedVersions()...)
 }
 
 // getDefaultVersion returns agent's default version of the Docker API


### PR DESCRIPTION
### Summary
Currently, agent only supports Docker remote API version 1.24 in Windows. Extending this to support other versions such as 1.30.

### Testing
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes

### Licensing
This contribution is under the terms of the Apache 2.0 License: yes
