### PR TITLE
Fixing flakey "TestManyDones" unit test from timing out

### DIFF
--- a/agent/utils/sync/sequential_waitgroup_test.go
+++ b/agent/utils/sync/sequential_waitgroup_test.go
@@ -39,11 +39,12 @@ func TestSequentialWaitgroup(t *testing.T) {
 func TestManyDones(t *testing.T) {
 	wg := NewSequentialWaitGroup()
 
-	for i := 1; i < 1000; i++ {
+	waitGroupCount := 10
+	for i := 1; i < waitGroupCount; i++ {
 		wg.Add(int64(i), i)
 	}
 
-	for i := 1; i < 1000; i++ {
+	for i := 1; i < waitGroupCount; i++ {
 		wg.Wait(int64(i - 1))
 
 		isAwake := make(chan bool)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Fixing flakey unit test (TestManyDones) which fails from timing out

### Implementation details
Reduced the number of waitgroups spawned in the test

### Testing
➜ go test ./agent/utils/sync/... -count 100 -run TestManyDones 
ok  	github.com/aws/amazon-ecs-agent/agent/utils/sync	0.024s
➜  go test ./agent/utils/sync/... -count 100000 -run TestManyDones 
ok  	github.com/aws/amazon-ecs-agent/agent/utils/sync	5.704s

- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
None - simple unit test fix, didn't update changelog

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
