### PR TITLE
windows functional tests for awslogs multiline options

### DIFF
--- a/agent/functional_tests/testdata/taskdefinitions/awslogs-datetime-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/awslogs-datetime-windows/task-definition.json
@@ -1,0 +1,21 @@
+{
+  "family": "ecs-awslogs-datetime-windows-test",
+  "containerDefinitions": [{
+    "essential": true,
+    "memory": 512,
+    "name": "awslogs-datetime-windows",
+    "cpu": 1024,
+    "image": "microsoft/windowsservercore:latest",
+    "entryPoint": ["powershell"],
+    "command": ["echo", "\"May 01, 2017 19:00:01 ECS\nMay 01, 2017 19:00:04 Agent\nRunning\nin the instance\""],
+    "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+            "awslogs-group":"ecs-functional-tests",
+            "awslogs-region":"$$$TEST_REGION$$$",
+            "awslogs-stream-prefix":"ecs-functional-tests",
+            "awslogs-datetime-format":"%b %d, %Y %H:%M:%S"
+        }
+    }
+  }]
+}

--- a/agent/functional_tests/testdata/taskdefinitions/awslogs-multiline-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/awslogs-multiline-windows/task-definition.json
@@ -1,0 +1,21 @@
+{
+  "family": "ecs-awslogs-multiline-windows-test",
+  "containerDefinitions": [{
+    "essential": true,
+    "memory": 512,
+    "name": "awslogs-multiline-windows",
+    "cpu": 1024,
+    "image": "microsoft/windowsservercore:latest",
+    "entryPoint": ["powershell"],
+    "command": ["echo", "\"INFO: ECS Agent\nRunning\nINFO: Instance\""],
+    "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+            "awslogs-group":"ecs-functional-tests",
+            "awslogs-region":"$$$TEST_REGION$$$",
+            "awslogs-stream-prefix":"ecs-functional-tests",
+            "awslogs-multiline-pattern":"^INFO"
+        }
+    }
+  }]
+}

--- a/agent/functional_tests/util/utils.go
+++ b/agent/functional_tests/util/utils.go
@@ -614,6 +614,33 @@ func RequireDockerVersion(t *testing.T, selector string) {
 	}
 }
 
+func RequireDockerAPIVersion(t *testing.T, selector string) {
+	dockerClient, err := docker.NewClientFromEnv()
+	if err != nil {
+		t.Fatalf("Could not get docker client to check version: %v", err)
+	}
+	dockerVersion, err := dockerClient.Version()
+	if err != nil {
+		t.Fatalf("Could not get docker version: %v", err)
+	}
+
+	version := dockerVersion.Get("ApiVersion")
+
+	// adding zero patch to use semver comparator
+	// TODO: Implement non-semver comparator
+	version += ".0"
+	selector += ".0"
+
+	match, err := utils.Version(version).Matches(selector)
+	if err != nil {
+		t.Fatalf("Could not check docker api version to match required: %v", err)
+	}
+
+	if !match {
+		t.Skipf("Skipping test; requires %v, but api version is %v", selector, version)
+	}
+}
+
 // GetInstanceProfileName gets the instance profile name
 func GetInstanceMetadata(path string) (string, error) {
 	ec2MetadataClient := ec2metadata.New(session.New())


### PR DESCRIPTION
### Summary
Functional tests that verify logs from CloudWatch events for 'awslogs-multiline-pattern' and 'awslogs-datetime-format' options. This is for Windows.

### Implementation details
Test for awslogs option 'awslogs-datetime-format' verifies that multiple log lines with a certain pattern of timestamp are sent to a single CloudWatch log event.
Test for awslogs option 'awslogs-multiline-pattern' verifies that multiple log lines with a certain pattern are sent to a single CloudWatch log event.

### Testing
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes

### Licensing
This contribution is under the terms of the Apache 2.0 License: yes