### PR TITLE
taskmetadata: bump throttles

### DIFF
--- a/agent/handlers/taskmetadata/handler.go
+++ b/agent/handlers/taskmetadata/handler.go
@@ -41,9 +41,20 @@ const (
 	apiVersion1 = 1
 	apiVersion2 = 2
 
-	// Rate limits for the metadata endpoint(s) and APIs by request ip addresses
-	rateLimitPerSecond      = 3
-	rateLimitBurstPerSecond = 6
+	// Rate limits for the metadata endpoint(s) and APIs by request ip addresses. Today, we
+	// support the following endpoints:
+	// 1. /v2/credentials: For serving IAM role credentials
+	// 2. /v2/metadata: For serving task and container metadata information (for "awsvpc" tasks)
+	// 3. /v2/stats: For serving task and container stats information (for "awsvpc" tasks)
+
+	// rateLimitPerSecond specifies the steady state throttle for the task metadata endpoint.
+	// Because all containers in a task share the same IP address in an "awsvpc" task, and a
+	// task can be constituted of up to 10 containers, the steady state rate is set at 10
+	// per second
+	rateLimitPerSecond = 10
+
+	// rateLimitBurstPerSecond specifies the burst rate throttle for the task metadata endpoint.
+	rateLimitBurstPerSecond = 15
 )
 
 // ServeHTTP serves IAM Role Credentials for Tasks being managed by the agent.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Because all containers in a task share the same IP address in an
"awsvpc" task, and a task can be constituted of up to 10 containers, the
steady state rate is set at 10 rps. Burst rate is set to 15 rps.

### Implementation details
<!-- How are the changes implemented? -->
NA

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
NA

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: yes
