### PR TITLE
[WIP] Fix an error case with task limits

### DIFF
--- a/agent/functional_tests/testdata/taskdefinitions/oom-task/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/oom-task/task-definition.json
@@ -1,0 +1,12 @@
+{
+  "family": "ecsftest-oom-task",
+  "memory": "256",
+  "containerDefinitions": [{
+    "essential": true,
+    "name": "error",
+    "cpu": 1,
+    "image": "127.0.0.1:51670/python:2",
+    "command": ["python", "-c", "foo=' '*1024*1024*1024; import time; time.sleep(10)"]
+  }]
+}
+

--- a/agent/functional_tests/tests/functionaltests_unix_test.go
+++ b/agent/functional_tests/tests/functionaltests_unix_test.go
@@ -98,6 +98,17 @@ func TestOOMContainer(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// TestOOMTask verifies that a task with a memory limit returns an error
+func TestOOMTask(t *testing.T) {
+	agent := RunAgent(t, nil)
+	defer agent.Cleanup()
+
+	testTask, err := agent.StartTask(t, "oom-task")
+	require.NoError(t, err, "Expected to start invalid-image task")
+	err = testTask.ExpectErrorType("error", "OutOfMemoryError", 1*time.Minute)
+	assert.NoError(t, err)
+}
+
 func strptr(s string) *string { return &s }
 
 func TestCommandOverrides(t *testing.T) {

--- a/agent/utils/ioutilwrapper/ioutil.go
+++ b/agent/utils/ioutilwrapper/ioutil.go
@@ -15,6 +15,7 @@ package ioutilwrapper
 
 import (
 	"io/ioutil"
+	"os"
 
 	"github.com/aws/amazon-ecs-agent/agent/utils/oswrapper"
 )
@@ -22,6 +23,7 @@ import (
 // IOUtil wraps 'io/util' methods for testing
 type IOUtil interface {
 	TempFile(string, string) (oswrapper.File, error)
+	WriteFile(string, []byte, os.FileMode) error
 }
 
 type ioUtil struct {
@@ -34,4 +36,8 @@ func NewIOUtil() IOUtil {
 
 func (*ioUtil) TempFile(dir string, prefix string) (oswrapper.File, error) {
 	return ioutil.TempFile(dir, prefix)
+}
+
+func (*ioUtil) WriteFile(filename string, data []byte, perm os.FileMode) error {
+	return ioutil.WriteFile(filename, data, perm)
 }

--- a/agent/utils/ioutilwrapper/mocks/ioutilwrapper_mocks.go
+++ b/agent/utils/ioutilwrapper/mocks/ioutilwrapper_mocks.go
@@ -17,6 +17,8 @@
 package mock_ioutilwrapper
 
 import (
+	os "os"
+
 	oswrapper "github.com/aws/amazon-ecs-agent/agent/utils/oswrapper"
 	gomock "github.com/golang/mock/gomock"
 )
@@ -51,4 +53,14 @@ func (_m *MockIOUtil) TempFile(_param0 string, _param1 string) (oswrapper.File, 
 
 func (_mr *_MockIOUtilRecorder) TempFile(arg0, arg1 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "TempFile", arg0, arg1)
+}
+
+func (_m *MockIOUtil) WriteFile(_param0 string, _param1 []byte, _param2 os.FileMode) error {
+	ret := _m.ctrl.Call(_m, "WriteFile", _param0, _param1, _param2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockIOUtilRecorder) WriteFile(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WriteFile", arg0, arg1, arg2)
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This fixes a bug with task limits

### Implementation details
If the host doesn't have hierarchical memory flag  (`use_hierarchy`) enabled, it can cause tasks to not enforce task limits correctly. This doesn't affect container size limits.

The agent will now manually set the `use_hierarchy` flag.

### Testing
<!-- How was this tested? -->
- [ ] Builds on Linux (`make release`)
- [ ] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [ ] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: indeed

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
* Bug - Task limit enforcement breaks in some conditions

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: yes
