### PR TITLE
Pr 1148 for 1.16.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-#Changelog
+# Changelog
+
+## Unreleased
+* Bug - Fixed a bug where the agent could miss sending an ENI attachment to ECS because of address propagation delays [#1148](https://github.com/aws/amazon-ecs-agent/pull/1148)
 
 ## 1.16.0
 * Feature - Support pulling from Amazon ECR with specified IAM role in task definition

--- a/agent/eni/networkutils/utils_linux.go
+++ b/agent/eni/networkutils/utils_linux.go
@@ -17,22 +17,113 @@
 package networkutils
 
 import (
+	"context"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/eni/netlinkwrapper"
+	"github.com/aws/amazon-ecs-agent/agent/utils"
+	"github.com/pkg/errors"
 
-	log "github.com/cihub/seelog"
+	"github.com/cihub/seelog"
 )
 
+const (
+	// macAddressBackoffMin specifies the mimimum duration for the backoff
+	// when looking for an ENI's mac address on the host
+	macAddressBackoffMin = 2 * time.Millisecond
+
+	// macAddressBackoffMax specifies the maximum duration for the backoff
+	// when looking for an ENI's mac address on the host
+	macAddressBackoffMax = 200 * time.Millisecond
+
+	// macAddressBackoffJitter specifies the jitter multiple percentage when
+	// looking for an ENI's mac address on the host
+	macAddressBackoffJitter = 0.2
+
+	// macAddressBackoffMultiple specifies the backoff duration multiplier
+	// when looking for an ENI's mac address on the host
+	macAddressBackoffMultiple = 1.5
+)
+
+// macAddressRetriever is used to retrieve the mac address of a device. It collects
+// all the information necessary to start this operation and stores the result in
+// the 'macAddress' attribute
+type macAddressRetriever struct {
+	dev           string
+	netlinkClient netlinkwrapper.NetLink
+	macAddress    string
+	// timeout specifies the timeout duration before giving up when
+	// looking for an ENI's mac address on the host
+	timeout time.Duration
+	ctx     context.Context
+}
+
 // GetMACAddress retrieves the MAC address of a device using netlink
-func GetMACAddress(dev string, netlinkClient netlinkwrapper.NetLink) (string, error) {
-	dev = filepath.Base(dev)
-	link, err := netlinkClient.LinkByName(dev)
+func GetMACAddress(ctx context.Context,
+	timeout time.Duration,
+	dev string,
+	netlinkClient netlinkwrapper.NetLink) (string, error) {
+	retriever := &macAddressRetriever{
+		dev:           dev,
+		netlinkClient: netlinkClient,
+		ctx:           ctx,
+		timeout:       timeout,
+	}
+	return retriever.retrieve()
+}
+
+// retrieve retrives the mac address of a network device. If the retrieved mac
+// address is empty, it retries the operation with a timeout specified by the
+// caller
+func (retriever *macAddressRetriever) retrieve() (string, error) {
+	backoff := utils.NewSimpleBackoff(macAddressBackoffMin, macAddressBackoffMax,
+		macAddressBackoffJitter, macAddressBackoffMultiple)
+	ctx, cancel := context.WithTimeout(retriever.ctx, retriever.timeout)
+	defer cancel()
+
+	err := utils.RetryWithBackoffCtx(ctx, backoff, func() error {
+		retErr := retriever.retrieveOnce()
+		if retErr != nil {
+			seelog.Warnf("Unable to retrieve mac address for device '%s': %v",
+				retriever.dev, retErr)
+			return retErr
+		}
+
+		if retriever.macAddress == "" {
+			seelog.Debugf("Empty mac address for device '%s'", retriever.dev)
+			// Return a retriable error when mac address is empty. If the error
+			// is not wrapped with the RetriableError interface, RetryWithBackoffCtx
+			// treats them as retriable by default
+			return errors.Errorf("eni mac address: retrieved empty address for device %s",
+				retriever.dev)
+		}
+
+		return nil
+	})
 	if err != nil {
 		return "", err
 	}
-	return link.Attrs().HardwareAddr.String(), err
+	// RetryWithBackoffCtx returns nil when the context is cancelled. Check if there was
+	// a timeout here. TODO: Fix RetryWithBackoffCtx to return ctx.Err() on context Done()
+	if err = ctx.Err(); err != nil {
+		return "", errors.Wrapf(err, "eni mac address: timed out waiting for eni device '%s'",
+			retriever.dev)
+	}
+
+	return retriever.macAddress, nil
+}
+
+// retrieveOnce retrieves the MAC address of a device using netlink.LinkByName
+func (retriever *macAddressRetriever) retrieveOnce() error {
+	dev := filepath.Base(retriever.dev)
+	link, err := retriever.netlinkClient.LinkByName(dev)
+	if err != nil {
+		return utils.NewRetriableError(utils.NewRetriable(false), err)
+	}
+	retriever.macAddress = link.Attrs().HardwareAddr.String()
+	return nil
 }
 
 // IsValidNetworkDevice is used to differentiate virtual and physical devices
@@ -43,16 +134,16 @@ func IsValidNetworkDevice(devicePath string) bool {
 	* eth1 -> /devices/pci0000:00/0000:00:05.0/net/eth1
 	* eth0 -> ../../devices/pci0000:00/0000:00:03.0/net/eth0
 	* lo   -> ../../devices/virtual/net/lo
-	*/
+	 */
 	splitDevLink := strings.SplitN(devicePath, "devices/", 2)
 	if len(splitDevLink) != 2 {
-		log.Warnf("Cannot determine device validity: %s", devicePath)
+		seelog.Warnf("Cannot determine device validity: %s", devicePath)
 		return false
 	}
 	/*
 	* CoreOS typically employs the vif style for physical net interfaces
 	* Amazon Linux, Ubuntu, RHEL, Fedora, Suse use the traditional pci convention
-	*/
+	 */
 	if strings.HasPrefix(splitDevLink[1], pciDevicePrefix) || strings.HasPrefix(splitDevLink[1], vifDevicePrefix) {
 		return true
 	}
@@ -60,6 +151,6 @@ func IsValidNetworkDevice(devicePath string) bool {
 		return false
 	}
 	// NOTE: Should never reach here
-	log.Criticalf("Failed to validate device path: %s", devicePath)
+	seelog.Criticalf("Failed to validate device path: %s", devicePath)
 	return false
 }

--- a/agent/eni/networkutils/utils_linux_test.go
+++ b/agent/eni/networkutils/utils_linux_test.go
@@ -16,9 +16,11 @@
 package networkutils
 
 import (
+	"context"
 	"errors"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -49,7 +51,8 @@ func TestGetMACAddress(t *testing.T) {
 				Name:         randomDevice,
 			},
 		}, nil)
-	mac, err := GetMACAddress(randomDevice, mockNetlink)
+	ctx := context.TODO()
+	mac, err := GetMACAddress(ctx, time.Millisecond, randomDevice, mockNetlink)
 	assert.Nil(t, err)
 	assert.Equal(t, mac, validMAC)
 }
@@ -60,10 +63,57 @@ func TestGetMACAddressWithNetlinkError(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockNetlink := mock_netlinkwrapper.NewMockNetLink(mockCtrl)
+	// LinkByName returns an error. This will ensure that a non-retriable
+	// error is generated and halts the backoff-rety loop
 	mockNetlink.EXPECT().LinkByName(randomDevice).Return(
 		&netlink.Device{},
 		errors.New("Dummy Netlink Error"))
-	mac, err := GetMACAddress(randomDevice, mockNetlink)
+	ctx := context.TODO()
+	mac, err := GetMACAddress(ctx, 2*macAddressBackoffMax, randomDevice, mockNetlink)
+	assert.Error(t, err)
+	assert.Empty(t, mac)
+}
+
+// TestGetMACAddressNotFoundRetry tests if netlink.LinkByName gets invoked
+// multiple times if the mac address for a device is returned as empty string
+func TestGetMACAddressNotFoundRetry(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockNetlink := mock_netlinkwrapper.NewMockNetLink(mockCtrl)
+	pm, _ := net.ParseMAC(validMAC)
+	gomock.InOrder(
+		// Return empty mac address on first invocation
+		mockNetlink.EXPECT().LinkByName(randomDevice).Return(&netlink.Device{}, nil),
+		// Return a valid mac address on first invocation. Even though the first
+		// invocation did not result in an error, it did return an empty mac address.
+		// Hence, we expect it to be retried
+		mockNetlink.EXPECT().LinkByName(randomDevice).Return(&netlink.Device{
+			LinkAttrs: netlink.LinkAttrs{
+				HardwareAddr: pm,
+				Name:         randomDevice,
+			},
+		}, nil),
+	)
+	ctx := context.TODO()
+	// Set max retry duration to twice that of the min backoff to ensure that there's
+	// enough time to retry
+	mac, err := GetMACAddress(ctx, 2*macAddressBackoffMin, randomDevice, mockNetlink)
+	assert.NoError(t, err)
+	assert.Equal(t, mac, validMAC)
+}
+
+// TestGetMACAddressNotFoundRetryExpires tests if the backoff-retry logic for
+// retrieving mac address returns error on timeout
+func TestGetMACAddressNotFoundRetryExpires(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockNetlink := mock_netlinkwrapper.NewMockNetLink(mockCtrl)
+	// Return empty mac address everytime
+	mockNetlink.EXPECT().LinkByName(randomDevice).Return(&netlink.Device{}, nil).MinTimes(1)
+	ctx := context.TODO()
+	// Set max retry duration to twice that of the min backoff to ensure that there's
+	// enough time to retry
+	mac, err := GetMACAddress(ctx, 2*macAddressBackoffMin, randomDevice, mockNetlink)
 	assert.Error(t, err)
 	assert.Empty(t, mac)
 }

--- a/agent/utils/errors.go
+++ b/agent/utils/errors.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -18,34 +18,43 @@ import (
 	"strings"
 )
 
+// Retriable defines an interface for retriable methods
 type Retriable interface {
+	// Retry returns true if the operation can be retried
 	Retry() bool
 }
 
+// DefaultRetriable implements the Retriable interface with a boolean to
+// indicate if retry should occur
 type DefaultRetriable struct {
 	retry bool
 }
 
+// Retry returns true if the operation can be retried
 func (dr DefaultRetriable) Retry() bool {
 	return dr.retry
 }
 
+// NewRetriable creates a new DefaultRetriable object
 func NewRetriable(retry bool) Retriable {
 	return DefaultRetriable{
 		retry: retry,
 	}
 }
 
+// RetriableError defines an interface for a retriable error
 type RetriableError interface {
 	Retriable
 	error
 }
 
+// DefaultRetriableError is used to wrap a retriable error
 type DefaultRetriableError struct {
 	Retriable
 	error
 }
 
+// NewRetriableError creates a new DefaultRetriableError object
 func NewRetriableError(retriable Retriable, err error) RetriableError {
 	return &DefaultRetriableError{
 		retriable,
@@ -53,23 +62,28 @@ func NewRetriableError(retriable Retriable, err error) RetriableError {
 	}
 }
 
+// AttributeError defines an error type to indicate an error with an ECS
+// attribute
 type AttributeError struct {
 	err string
 }
 
+// Error returns the error string for AttributeError
 func (e AttributeError) Error() string {
 	return e.err
 }
 
+// NewAttributeError creates a new AttributeError object
 func NewAttributeError(err string) AttributeError {
 	return AttributeError{err}
 }
 
-// Implements error
+// MultiErr wraps multiple errors
 type MultiErr struct {
 	errors []error
 }
 
+// Error returns the error string for MultiErr
 func (me MultiErr) Error() string {
 	ret := make([]string, len(me.errors)+1)
 	ret[0] = "Multiple error:"
@@ -79,6 +93,7 @@ func (me MultiErr) Error() string {
 	return strings.Join(ret, "\n")
 }
 
+// NewMultiError creates a new MultErr object
 func NewMultiError(errs ...error) error {
 	errors := make([]error, 0, len(errs))
 	for _, err := range errs {


### PR DESCRIPTION
### Summary

This is a port of the changes from #1148 to the v1.16.x branch. It was generated with:
`git cherry-pick origin/dev..origin/pr/1148`

The merge completely cleanly with no conflicts except the expected CHANGELOG.md conflicts.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [ ] Builds on Linux (`make release`)
- [ ] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [ ] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
