### PR TITLE
Fixing misspells reported by goreportcard

### DIFF
--- a/agent/acs/handler/acs_handler.go
+++ b/agent/acs/handler/acs_handler.go
@@ -74,7 +74,7 @@ type Session interface {
 }
 
 // session encapsulates all arguments needed by the handler to connect to ACS
-// and to handle messages recieved by ACS. The Session.Start() method can be used
+// and to handle messages received by ACS. The Session.Start() method can be used
 // to start processing messages from ACS.
 type session struct {
 	containerInstanceARN            string

--- a/agent/acs/handler/acs_handler_test.go
+++ b/agent/acs/handler/acs_handler_test.go
@@ -954,7 +954,7 @@ func TestStartSessionHandlesRefreshCredentialsMessages(t *testing.T) {
 		// Return a task from the engine for GetTaskByArn
 		taskEngine.EXPECT().GetTaskByArn("t1").Return(taskFromEngine, true),
 		// The last invocation of SetCredentials is to update
-		// credentials when a refresh message is recieved by the handler
+		// credentials when a refresh message is received by the handler
 		credentialsManager.EXPECT().SetTaskCredentials(gomock.Any()).Do(func(creds rolecredentials.TaskIAMRoleCredentials) {
 			updatedCredentials = creds
 			// Validate parsed credentials after the update
@@ -981,7 +981,7 @@ func TestStartSessionHandlesRefreshCredentialsMessages(t *testing.T) {
 	case err := <-errChan:
 		t.Fatal("Error should not have been returned from server", err)
 	case <-ctx.Done():
-		// Context is canceled when requestsChan recieves an ack
+		// Context is canceled when requestsChan receives an ack
 	}
 
 	// Validate that the correct credentialsId is set for the task

--- a/agent/acs/handler/payload_handler.go
+++ b/agent/acs/handler/payload_handler.go
@@ -179,7 +179,7 @@ func (payloadHandler *payloadRequestHandler) addPayloadTasks(payload *ecsacs.Pay
 	validTasks := make([]*api.Task, 0, len(payload.Tasks))
 	for _, task := range payload.Tasks {
 		if task == nil {
-			seelog.Criticalf("Recieved nil task for messageId: %s", *payload.MessageId)
+			seelog.Criticalf("Received nil task for messageId: %s", *payload.MessageId)
 			allTasksOK = false
 			continue
 		}
@@ -279,7 +279,7 @@ func (payloadHandler *payloadRequestHandler) addTasks(payload *ecsacs.PayloadMes
 		}
 
 		// Generate an ack request for the credentials in the task, if the
-		// task is associated with an IAM role or the exectuion role
+		// task is associated with an IAM role or the execution role
 		taskCredentialsID := task.GetCredentialsID()
 		if taskCredentialsID != "" {
 			ackCredentials(taskCredentialsID, "task iam role")
@@ -324,7 +324,7 @@ func isTaskStatusNotStopped(status api.TaskStatus) bool {
 // a suitable reason to the backend
 func (payloadHandler *payloadRequestHandler) handleUnrecognizedTask(task *ecsacs.Task, err error, payload *ecsacs.PayloadMessage) {
 	if task.Arn == nil {
-		seelog.Criticalf("Recieved task with no arn, messageId: %s, task: %v", *payload.MessageId, task)
+		seelog.Criticalf("Received task with no arn, messageId: %s, task: %v", *payload.MessageId, task)
 		return
 	}
 

--- a/agent/api/container.go
+++ b/agent/api/container.go
@@ -120,7 +120,7 @@ type Container struct {
 	// AppliedStatus is the status that has been "applied" (e.g., we've called Pull,
 	// Create, Start, or Stop) but we don't yet know that the application was successful.
 	AppliedStatus ContainerStatus
-	// ApplyingError is an error that occured trying to transition the container
+	// ApplyingError is an error that occurred trying to transition the container
 	// to its desired state. It is propagated to the backend in the form
 	// 'Name: ErrorString' as the 'reason' field.
 	ApplyingError *DefaultNamedError

--- a/agent/api/task.go
+++ b/agent/api/task.go
@@ -310,7 +310,7 @@ func (task *Task) ContainerByName(name string) (*Container, bool) {
 }
 
 // HostVolumeByName returns the task Volume for the given a volume name in that
-// task. The second return value indicates the presense of that volume
+// task. The second return value indicates the presence of that volume
 func (task *Task) HostVolumeByName(name string) (HostVolume, bool) {
 	for _, v := range task.Volumes {
 		if v.Name == name {
@@ -557,7 +557,7 @@ func (task *Task) DockerHostConfig(container *Container, dockerContainerMap map[
 	return task.dockerHostConfig(container, dockerContainerMap, apiVersion)
 }
 
-// ApplyExecutionRoleLogsAuth will check whether the task has excecution role
+// ApplyExecutionRoleLogsAuth will check whether the task has execution role
 // credentials, and add the genereated credentials endpoint to the associated HostConfig
 func (task *Task) ApplyExecutionRoleLogsAuth(hostConfig *docker.HostConfig, credentialsManager credentials.Manager) *HostConfigError {
 	id := task.GetExecutionCredentialsID()
@@ -789,7 +789,7 @@ func (task *Task) dockerHostBinds(container *Container) ([]string, error) {
 	return binds, nil
 }
 
-// TaskFromACS translates ecsacs.Task to api.Task by first marshaling the recieved
+// TaskFromACS translates ecsacs.Task to api.Task by first marshaling the received
 // ecsacs.Task to json and unmrashaling it as api.Task
 func TaskFromACS(acsTask *ecsacs.Task, envelope *ecsacs.PayloadMessage) (*Task, error) {
 	data, err := jsonutil.BuildJSON(acsTask)

--- a/agent/api/task_test.go
+++ b/agent/api/task_test.go
@@ -858,7 +858,7 @@ func TestTaskUpdateKnownStatusToPendingWithEssentialContainerStoppedWhenSteadySt
 
 // TestGetEarliestTaskStatusForContainersEmptyTask verifies that
 // `getEarliestKnownTaskStatusForContainers` returns TaskStatusNone when invoked on
-// a task with no contianers
+// a task with no containers
 func TestGetEarliestTaskStatusForContainersEmptyTask(t *testing.T) {
 	testTask := &Task{}
 	assert.Equal(t, testTask.getEarliestKnownTaskStatusForContainers(), TaskStatusNone)
@@ -866,7 +866,7 @@ func TestGetEarliestTaskStatusForContainersEmptyTask(t *testing.T) {
 
 // TestGetEarliestTaskStatusForContainersWhenKnownStatusIsNotSetForContainers verifies that
 // `getEarliestKnownTaskStatusForContainers` returns TaskStatusNone when invoked on
-// a task with contianers that do not have the `KnownStatusUnsafe` field set
+// a task with containers that do not have the `KnownStatusUnsafe` field set
 func TestGetEarliestTaskStatusForContainersWhenKnownStatusIsNotSetForContainers(t *testing.T) {
 	testTask := &Task{
 		KnownStatusUnsafe: TaskStatusNone,
@@ -1009,7 +1009,7 @@ func TestTaskUpdateKnownStatusChecksSteadyStateWhenSetToResourceProvisioned(t *t
 func assertSetStructFieldsEqual(t *testing.T, expected, actual interface{}) {
 	for i := 0; i < reflect.TypeOf(expected).NumField(); i++ {
 		expectedValue := reflect.ValueOf(expected).Field(i)
-		// All the values we actaully expect to see are valid and non-nil
+		// All the values we actually expect to see are valid and non-nil
 		if !expectedValue.IsValid() || ((expectedValue.Kind() == reflect.Map || expectedValue.Kind() == reflect.Slice) && expectedValue.IsNil()) {
 			continue
 		}

--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -173,7 +173,7 @@ func newAgent(
 func (agent *ecsAgent) printECSAttributes() int {
 	capabilities, err := agent.capabilities()
 	if err != nil {
-		seelog.Warnf("Unable to obtain capabilit: %v", err)
+		seelog.Warnf("Unable to obtain capabilities: %v", err)
 		return exitcodes.ExitError
 	}
 	for _, attr := range capabilities {

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -535,7 +535,7 @@ func (cfg *Config) validateAndOverrideBounds() error {
 	}
 
 	if cfg.NumImagesToDeletePerCycle < minimumNumImagesToDeletePerCycle {
-		seelog.Warnf("Invalid value for number of images to delete for image cleanup, will be overriden with the default value: %d. Parsed value: %d, minimum value: %d.", DefaultImageDeletionAge, cfg.NumImagesToDeletePerCycle, minimumNumImagesToDeletePerCycle)
+		seelog.Warnf("Invalid value for number of images to delete for image cleanup, will be overridden with the default value: %d. Parsed value: %d, minimum value: %d.", DefaultImageDeletionAge, cfg.NumImagesToDeletePerCycle, minimumNumImagesToDeletePerCycle)
 		cfg.NumImagesToDeletePerCycle = DefaultNumImagesToDeletePerCycle
 	}
 

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -227,7 +227,7 @@ func TestInvalidTaskCleanupTimeoutOverridesToThreeHours(t *testing.T) {
 
 	// If an invalid value is set, the config should pick up the default value for
 	// cleaning up the task.
-	assert.Equal(t, cfg.TaskCleanupWaitDuration, 3*time.Hour, "Defualt task cleanup wait duration set incorrectly")
+	assert.Equal(t, cfg.TaskCleanupWaitDuration, 3*time.Hour, "Default task cleanup wait duration set incorrectly")
 }
 
 func TestTaskCleanupTimeout(t *testing.T) {

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -43,7 +43,7 @@ type Config struct {
 	// will be fatal.
 	AWSRegion string `missing:"fatal" trim:"true"`
 
-	// ReservedPorts is an array of ports which should be registerd as
+	// ReservedPorts is an array of ports which should be registered as
 	// unavailable. If not set, they default to [22,2375,2376,51678].
 	ReservedPorts []uint16
 	// ReservedPortsUDP is an array of UDP ports which should be registered as

--- a/agent/containermetadata/manager.go
+++ b/agent/containermetadata/manager.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	// metadataEnvironmentVariable is the enviornment variable passed to the
+	// metadataEnvironmentVariable is the environment variable passed to the
 	// container for the metadata file path.
 	metadataEnvironmentVariable = "ECS_CONTAINER_METADATA_FILE"
 	inspectContainerTimeout     = 30 * time.Second

--- a/agent/ecr/client_test.go
+++ b/agent/ecr/client_test.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-// ecr_test packge to avoid test dependency cycle on ecr/mocks
+// ecr_test package to avoid test dependency cycle on ecr/mocks
 package ecr_test
 
 import (

--- a/agent/engine/docker_container_engine_test.go
+++ b/agent/engine/docker_container_engine_test.go
@@ -1079,7 +1079,7 @@ func TestECRAuthCacheForDifferentRegistry(t *testing.T) {
 }
 
 // TestECRAuthCacheWithExecutionRole tests the client will use the cached docker auth
-// for ecr when pull from the same registery with same execution role
+// for ecr when pull from the same registry with same execution role
 func TestECRAuthCacheWithSameExecutionRole(t *testing.T) {
 	mockDocker, client, mockTime, ctrl, ecrClientFactory, done := dockerClientSetup(t)
 	defer done()
@@ -1129,7 +1129,7 @@ func TestECRAuthCacheWithSameExecutionRole(t *testing.T) {
 }
 
 // TestECRAuthCacheWithDifferentExecutionRole tests client will call ecr client to get
-// docker auth credentails for different execution role
+// docker auth credentials for different execution role
 func TestECRAuthCacheWithDifferentExecutionRole(t *testing.T) {
 	mockDocker, client, mockTime, ctrl, ecrClientFactory, done := dockerClientSetup(t)
 	defer done()

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -88,9 +88,9 @@ type DockerTaskEngine struct {
 
 	stopEngine context.CancelFunc
 
-	// processTasks is a mutex that the task engine must aquire before changing
+	// processTasks is a mutex that the task engine must acquire before changing
 	// any task's state which it manages. Since this is a lock that encompasses
-	// all tasks, it must not aquire it for any significant duration
+	// all tasks, it must not acquire it for any significant duration
 	// The write mutex should be taken when adding and removing tasks from managedTasks.
 	processTasks sync.RWMutex
 
@@ -829,7 +829,7 @@ func (engine *DockerTaskEngine) provisionContainerResources(task *api.Task, cont
 	}
 }
 
-// releaseIPInIPAM marks the ip avaialble in the ipam db
+// releaseIPInIPAM marks the ip available in the ipam db
 func (engine *DockerTaskEngine) releaseIPInIPAM(task *api.Task) error {
 	seelog.Infof("Releasing ip in the ipam, task: %s", task.Arn)
 	cfg, err := task.BuildCNIConfig()

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -1264,7 +1264,7 @@ func TestCreateContainerMergesLabels(t *testing.T) {
 }
 
 // TestTaskTransitionWhenStopContainerTimesout tests that task transitions to stopped
-// only when terminal events are recieved from docker event stream when
+// only when terminal events are received from docker event stream when
 // StopContainer times out
 func TestTaskTransitionWhenStopContainerTimesout(t *testing.T) {
 	ctrl, client, mockTime, taskEngine, _, imageManager, _ := mocks(t, &defaultConfig)

--- a/agent/engine/dockerauth/dockerauth.go
+++ b/agent/engine/dockerauth/dockerauth.go
@@ -141,7 +141,7 @@ func parseAuthData(authType string, authData json.RawMessage) dockerAuths {
 	return output
 }
 
-// stripRegistrySchema normalizes the registy url by removing http/https from it.
+// stripRegistrySchema normalizes the registry url by removing http/https from it.
 // because registries only support those two schemas, this function can be quite naive.
 func stripRegistrySchema(registry string) string {
 	if strings.HasPrefix(registry, "http://") {

--- a/agent/engine/dockerstate/docker_task_engine_state.go
+++ b/agent/engine/dockerstate/docker_task_engine_state.go
@@ -77,7 +77,7 @@ type TaskEngineState interface {
 // accessed before an update comes and to ensure multiple goroutines can safely
 // work with it.
 //
-// The methods on it will aquire the read lock, but not all aquire the write
+// The methods on it will acquire the read lock, but not all acquire the write
 // lock (sometimes it is up to the caller). This is because the write lock for
 // containers should encapsulate the creation of the resource as well as adding,
 // and creating the resource (docker container) is outside the scope of this

--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -558,7 +558,7 @@ type containerTransitionFunc func(container *api.Container, nextStatus api.Conta
 // It returns a transition struct including the information:
 // * container state it should transition to,
 // * a bool indicating whether any action is required
-// * an error indicate why this transition can't happend
+// * an error indicating why this transition can't happen
 //
 // 'Stopped, false, ""' -> "You can move it to known stopped, but you don't have to call a transition function"
 // 'Running, true, ""' -> "You can move it to running and you need to call the transition function"

--- a/agent/engine/task_manager_test.go
+++ b/agent/engine/task_manager_test.go
@@ -694,7 +694,7 @@ func TestWaitForContainerTransitionsForNonTerminalTask(t *testing.T) {
 		transitionChangeContainer <- firstContainerName
 	}()
 
-	// waitForContainerTransitions will block until it recieves events
+	// waitForContainerTransitions will block until it receives events
 	// sent by the go routine defined above
 	task.waitForContainerTransitions(transitions, transitionChange, transitionChangeContainer)
 }
@@ -726,7 +726,7 @@ func TestWaitForContainerTransitionsForTerminalTask(t *testing.T) {
 
 	// Event though there are two keys in the transitions map, send
 	// only one event. This tests that `waitForContainerTransitions` doesn't
-	// block to recieve two events and will still progress
+	// block to receive two events and will still progress
 	go func() {
 		transitionChange <- true
 		transitionChangeContainer <- secondContainerName
@@ -830,7 +830,7 @@ func TestHandleStoppedToSteadyStateTransition(t *testing.T) {
 		api.ContainerStopped: transitionFunction,
 	}
 
-	// Recieved RUNNING event, known status is not STOPPED, expect this to
+	// Received RUNNING event, known status is not STOPPED, expect this to
 	// be a noop. Assertions in transitionFunction asserts that as well
 	mTask.handleStoppedToRunningContainerTransition(
 		api.ContainerRunning, secondContainer)
@@ -854,7 +854,7 @@ func TestHandleStoppedToSteadyStateTransition(t *testing.T) {
 			"Mismatch in container reference in event")
 		waitForDockerMessageAssertions.Done()
 	}()
-	// Recieved RUNNING, known status is STOPPED, expect this to invoke
+	// Received RUNNING, known status is STOPPED, expect this to invoke
 	// transition function once
 	mTask.handleStoppedToRunningContainerTransition(
 		api.ContainerRunning, firstContainer)

--- a/agent/eventhandler/task_handler.go
+++ b/agent/eventhandler/task_handler.go
@@ -314,11 +314,11 @@ func (taskEvents *taskSendableEvents) sendChange(change *sendableEvent,
 // to ECS. The error is used by the backoff handler to backoff before retrying the
 // state change submission for the first event
 func (taskEvents *taskSendableEvents) submitFirstEvent(handler *TaskHandler, backoff utils.Backoff) (bool, error) {
-	seelog.Debug("TaskHandler: Aquiring lock for sending event...")
+	seelog.Debug("TaskHandler: Acquiring lock for sending event...")
 	taskEvents.lock.Lock()
 	defer taskEvents.lock.Unlock()
 
-	seelog.Debugf("TaskHandler: Aquired lock, processing event list: : %s", taskEvents.toStringUnsafe())
+	seelog.Debugf("TaskHandler: Acquired lock, processing event list: : %s", taskEvents.toStringUnsafe())
 
 	if taskEvents.events.Len() == 0 {
 		seelog.Debug("TaskHandler: No events left; not retrying more")

--- a/agent/functional_tests/tests/functionaltests_unix_test.go
+++ b/agent/functional_tests/tests/functionaltests_unix_test.go
@@ -157,7 +157,7 @@ func TestDockerAuth(t *testing.T) {
 			gobytes := fmt.Sprintf("%#v", []byte(badstring))
 			// format is []byte{0x12, 0x34}
 			// if it were json.RawMessage or another alias, it would print as json.RawMessage ... in the log
-			// Because of this, strip down to just the comma-seperated hex and look for that
+			// Because of this, strip down to just the comma-separated hex and look for that
 			if strings.Contains(string(data), gobytes[len(`[]byte{`):len(gobytes)-1]) {
 				t.Fatalf("log data contained byte-hex representation of bad string: %v, %v", string(data), badstring)
 			}
@@ -507,7 +507,7 @@ func taskIAMRoles(networkMode string, agent *TestAgent, t *testing.T) {
 	}
 	if !iamRoleEnabled {
 		task.Stop()
-		t.Fatalf("Could not found AWS_CONTAINER_CREDENTIALS_RELATIVE_URI in the container envrionment variable")
+		t.Fatalf("Could not found AWS_CONTAINER_CREDENTIALS_RELATIVE_URI in the container environment variable")
 	}
 
 	// Task will only run one command "aws ec2 describe-regions"

--- a/agent/functional_tests/tests/functionaltests_windows_test.go
+++ b/agent/functional_tests/tests/functionaltests_windows_test.go
@@ -173,7 +173,7 @@ func taskIamRolesTest(networkMode string, agent *TestAgent, t *testing.T) {
 	}
 	if !iamRoleEnabled {
 		task.Stop()
-		t.Fatalf("Could not found AWS_CONTAINER_CREDENTIALS_RELATIVE_URI in the container envrionment variable")
+		t.Fatalf("Could not found AWS_CONTAINER_CREDENTIALS_RELATIVE_URI in the container environment variable")
 	}
 
 	// Task will only run one command "aws ec2 describe-regions"

--- a/agent/functional_tests/util/utils.go
+++ b/agent/functional_tests/util/utils.go
@@ -642,7 +642,7 @@ func GetInstanceIAMRole() (*iam.Role, error) {
 	return instanceRole.Role, nil
 }
 
-// SearchStrInDir searches the files in direcotry for specific content
+// SearchStrInDir searches the files in directory for specific content
 func SearchStrInDir(dir, filePrefix, content string) error {
 	logfiles, err := ioutil.ReadDir(dir)
 	if err != nil {

--- a/agent/httpclient/httpclient.go
+++ b/agent/httpclient/httpclient.go
@@ -84,7 +84,7 @@ type OverridableTransport interface {
 }
 
 // SetTransport allows you to set the transport. It is exposed so tests may
-// override it. It fulfills an interface to allow calling thsi function via
+// override it. It fulfills an interface to allow calling this function via
 // assertion to the exported interface
 func (client *ecsRoundTripper) SetTransport(transport http.RoundTripper) {
 	client.transport = transport

--- a/agent/sighandlers/exitcodes/exitcodes.go
+++ b/agent/sighandlers/exitcodes/exitcodes.go
@@ -19,7 +19,7 @@ const (
 	// is okay
 	ExitSuccess = 0
 	// ExitError (as well as unspecified exit codes) indicate a fatal error
-	// occured, but the agent should be restarted
+	// occurred, but the agent should be restarted
 	ExitError = 1
 	// ExitTerminal indicates the agent has exited unsuccessfully, but should
 	// not be restarted

--- a/agent/statemanager/state_manager.go
+++ b/agent/statemanager/state_manager.go
@@ -93,7 +93,7 @@ type intermediateSaveableState map[string]json.RawMessage
 // Note, changing this to work with BinaryMarshaler or another more compact
 // format would be fine, but everything already needs a json representation
 // since that's our wire format and the extra space taken / IO-time is expected
-// to be fairly negligable.
+// to be fairly negligible.
 type state struct {
 	Data saveableState
 

--- a/agent/statemanager/state_manager_unix_test.go
+++ b/agent/statemanager/state_manager_unix_test.go
@@ -39,7 +39,7 @@ func TestStateManager(t *testing.T) {
 	assert.Nil(t, err, "Error loading manager")
 
 	err = manager.Load()
-	assert.Nil(t, err, "Expected loading a non-existant file to not be an error")
+	assert.Nil(t, err, "Expected loading a non-existent file to not be an error")
 
 	// Now let's make some state to save
 	containerInstanceArn := ""

--- a/agent/statemanager/state_manager_windows_test.go
+++ b/agent/statemanager/state_manager_windows_test.go
@@ -67,7 +67,7 @@ func TestStateManagerLoadNoRegistryKey(t *testing.T) {
 	mockRegistry.EXPECT().OpenKey(ecsDataFileRootKey, ecsDataFileKeyPath, gomock.Any()).Return(nil, registry.ErrNotExist)
 
 	err := manager.Load()
-	assert.Nil(t, err, "Expected loading a non-existant file to not be an error")
+	assert.Nil(t, err, "Expected loading a non-existent file to not be an error")
 }
 
 func TestStateManagerLoadNoFile(t *testing.T) {
@@ -82,7 +82,7 @@ func TestStateManagerLoadNoFile(t *testing.T) {
 	mockFS.EXPECT().IsNotExist(gomock.Any()).Return(true)
 
 	err := manager.Load()
-	assert.Nil(t, err, "Expected loading a non-existant file to not be an error")
+	assert.Nil(t, err, "Expected loading a non-existent file to not be an error")
 }
 
 func TestStateManagerLoadError(t *testing.T) {

--- a/agent/stats/container.go
+++ b/agent/stats/container.go
@@ -66,7 +66,7 @@ func (container *StatsContainer) collect() {
 		default:
 			err := container.processStatsStream()
 			if err != nil {
-				// Currenlty, the only error that we get here is if go-dockerclient is unable
+				// Currently, the only error that we get here is if go-dockerclient is unable
 				// to decode the stats payload properly. Other errors such as
 				// 'NoSuchContainer', 'InactivityTimeoutExceeded' etc are silently consumed.
 				// We rely on state reconciliation with docker task engine at this point of

--- a/agent/stats/engine.go
+++ b/agent/stats/engine.go
@@ -68,7 +68,7 @@ type DockerStatsEngine struct {
 	resolver                   resolver.ContainerMetadataResolver
 	// tasksToContainers maps task arns to a map of container ids to StatsContainer objects.
 	tasksToContainers map[string]map[string]*StatsContainer
-	// tasksToDefinitions maps task arns to task definiton name and family metadata objects.
+	// tasksToDefinitions maps task arns to task definition name and family metadata objects.
 	tasksToDefinitions map[string]*taskDefinition
 }
 

--- a/agent/utils/json.go
+++ b/agent/utils/json.go
@@ -42,7 +42,7 @@ func JsonKeys(b []byte) ([]string, error) {
 // CompleteJsonUnmarshal determines if a given struct has members corresponding
 // to every key of a json object (passed as the json string).
 // By default, Go ignores fields in an object which have no corresponding struct
-// member and this can be used to determine if this ignoring has occured
+// member and this can be used to determine if this ignoring has occurred
 // Errors will result in "false" as a return value
 func CompleteJsonUnmarshal(b []byte, iface interface{}) error {
 	keys, err := JsonKeys(b)

--- a/agent/wsclient/errors.go
+++ b/agent/wsclient/errors.go
@@ -37,7 +37,7 @@ type NotMarshallableWSRequest struct {
 	Err error
 }
 
-// Retry implementes Retriable
+// Retry implements Retriable
 func (u *NotMarshallableWSRequest) Retry() bool {
 	return false
 }

--- a/agent/wsclient/mock/utils/utils.go
+++ b/agent/wsclient/mock/utils/utils.go
@@ -21,7 +21,7 @@ import (
 	"github.com/gorilla/websocket"
 )
 
-// GetMockServer retuns a mock websocket server that can be started up as TLS or not.
+// GetMockServer returns a mock websocket server that can be started up as TLS or not.
 // TODO replace with gomock
 func GetMockServer(closeWS <-chan []byte) (*httptest.Server, chan<- string, <-chan string, <-chan error, error) {
 	serverChan := make(chan string)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Fixing misspells as reported by https://goreportcard.com/report/github.com/aws/amazon-ecs-agent#misspell

### Implementation details
Misspells are mostly within comments, and few error log entries.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: N/A
Note: functional tests on Linux is likely to be failing due to flakey test, unable to find more information from the run log.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Didn't update changelog since this isn't a bug fix or implementation of a new feature. 

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
