### PR TITLE
Fixing copy lock violations from go vet run

### DIFF
--- a/agent/acs/handler/payload_handler.go
+++ b/agent/acs/handler/payload_handler.go
@@ -193,17 +193,18 @@ func (payloadHandler *payloadRequestHandler) addPayloadTasks(payload *ecsacs.Pay
 			// The payload from ACS for the task has credentials for the
 			// task. Add those to the credentials manager and set the
 			// credentials id for the task as well
-			taskCredentials := credentials.TaskIAMRoleCredentials{
-				ARN:                aws.StringValue(task.Arn),
-				IAMRoleCredentials: credentials.IAMRoleCredentialsFromACS(task.RoleCredentials, credentials.ApplicationRoleType),
-			}
-			err = payloadHandler.credentialsManager.SetTaskCredentials(taskCredentials)
+			taskIAMRoleCredentials := credentials.IAMRoleCredentialsFromACS(task.RoleCredentials, credentials.ApplicationRoleType)
+			err = payloadHandler.credentialsManager.SetTaskCredentials(
+				credentials.TaskIAMRoleCredentials{
+					ARN:                aws.StringValue(task.Arn),
+					IAMRoleCredentials: taskIAMRoleCredentials,
+				})
 			if err != nil {
 				payloadHandler.handleUnrecognizedTask(task, err, payload)
 				allTasksOK = false
 				continue
 			}
-			apiTask.SetCredentialsID(taskCredentials.IAMRoleCredentials.CredentialsID)
+			apiTask.SetCredentialsID(taskIAMRoleCredentials.CredentialsID)
 		}
 
 		// Adding the eni information to the task struct
@@ -221,17 +222,18 @@ func (payloadHandler *payloadRequestHandler) addPayloadTasks(payload *ecsacs.Pay
 			// The payload message contains execution credentials for the task.
 			// Add the credentials to the credentials manager and set the
 			// task executionCredentials id.
-			taskExecutionCredentials := credentials.TaskIAMRoleCredentials{
-				ARN:                aws.StringValue(task.Arn),
-				IAMRoleCredentials: credentials.IAMRoleCredentialsFromACS(task.ExecutionRoleCredentials, credentials.ExecutionRoleType),
-			}
-			err = payloadHandler.credentialsManager.SetTaskCredentials(taskExecutionCredentials)
+			taskExecutionIAMRoleCredentials := credentials.IAMRoleCredentialsFromACS(task.ExecutionRoleCredentials, credentials.ExecutionRoleType)
+			err = payloadHandler.credentialsManager.SetTaskCredentials(
+				credentials.TaskIAMRoleCredentials{
+					ARN:                aws.StringValue(task.Arn),
+					IAMRoleCredentials: taskExecutionIAMRoleCredentials,
+				})
 			if err != nil {
 				payloadHandler.handleUnrecognizedTask(task, err, payload)
 				allTasksOK = false
 				continue
 			}
-			apiTask.SetExecutionRoleCredentialsID(taskExecutionCredentials.IAMRoleCredentials.CredentialsID)
+			apiTask.SetExecutionRoleCredentialsID(taskExecutionIAMRoleCredentials.CredentialsID)
 		}
 
 		validTasks = append(validTasks, apiTask)

--- a/agent/acs/handler/refresh_credentials_handler.go
+++ b/agent/acs/handler/refresh_credentials_handler.go
@@ -132,12 +132,11 @@ func (refreshHandler *refreshCredentialsHandler) handleSingleMessage(message *ec
 	if !validRoleType(roleType) {
 		seelog.Errorf("Unknown RoleType for task in credentials message, roleType: %s arn: %s, messageId: %s", roleType, taskArn, messageId)
 	} else {
-
-		taskCredentials := credentials.TaskIAMRoleCredentials{
-			ARN:                taskArn,
-			IAMRoleCredentials: credentials.IAMRoleCredentialsFromACS(message.RoleCredentials, roleType),
-		}
-		err = refreshHandler.credentialsManager.SetTaskCredentials(taskCredentials)
+		err = refreshHandler.credentialsManager.SetTaskCredentials(
+			credentials.TaskIAMRoleCredentials{
+				ARN:                taskArn,
+				IAMRoleCredentials: credentials.IAMRoleCredentialsFromACS(message.RoleCredentials, roleType),
+			})
 		if err != nil {
 			seelog.Errorf("Unable to update credentials for task, err: %v messageId: %s", err, messageId)
 			return fmt.Errorf("unable to update credentials %v", err)

--- a/agent/credentials/manager.go
+++ b/agent/credentials/manager.go
@@ -132,13 +132,12 @@ func (manager *credentialsManager) SetTaskCredentials(taskCredentials TaskIAMRol
 	}
 
 	// Check if credentials exists for the given credentials id
-	taskCredentialsInMap, ok := manager.idToTaskCredentials[credentials.CredentialsID]
+	_, ok := manager.idToTaskCredentials[credentials.CredentialsID]
 	if !ok {
 		// No existing credentials, create a new one
-		taskCredentialsInMap = &TaskIAMRoleCredentials{}
+		manager.idToTaskCredentials[credentials.CredentialsID] = &TaskIAMRoleCredentials{}
 	}
-	*taskCredentialsInMap = taskCredentials
-	manager.idToTaskCredentials[credentials.CredentialsID] = taskCredentialsInMap
+	manager.idToTaskCredentials[credentials.CredentialsID] = &taskCredentials
 
 	return nil
 }
@@ -153,7 +152,10 @@ func (manager *credentialsManager) GetTaskCredentials(id string) (TaskIAMRoleCre
 	if !ok {
 		return TaskIAMRoleCredentials{}, ok
 	}
-	return *taskCredentials, ok
+	return TaskIAMRoleCredentials{
+		ARN:                taskCredentials.ARN,
+		IAMRoleCredentials: taskCredentials.GetIAMRoleCredentials(),
+	}, ok
 }
 
 // RemoveCredentials removes credentials from the credentials manager

--- a/agent/utils/utils.go
+++ b/agent/utils/utils.go
@@ -137,7 +137,6 @@ func RetryWithBackoffCtx(ctx context.Context, backoff Backoff, fn func() error) 
 
 		_time.Sleep(backoff.Duration())
 	}
-	return err
 }
 
 // RetryNWithBackoff takes a Backoff, a maximum number of tries 'n', and a


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Fixes copy lock via assignment or return statement, as reported by go vet tool ("return/assignment/calls to x copies lock value"). 

### Implementation details
Anonymous structs are used instead of creating a local variable of struct that contains mutex, for function calls and returns that result in a copy of the struct.The go vet tool may be on the strict side, for e.g. instance of a struct specifically created to return still violates the copylock test in the tool. I've screened out what I believe are clearly no-op copies, such as copies containing sync.Once.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [X] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: N/A
NOTE: Unable to find failing tests from Linux functional test output, suspecting flakey test or incorrect reporting?

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Did not update changelog as this is not a new feature or known bug fix.

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: yes
