### PR TITLE
Refactoring idToTaskCredentials map to contain objects not pointers

### DIFF
--- a/agent/credentials/manager.go
+++ b/agent/credentials/manager.go
@@ -90,7 +90,7 @@ func (roleCredentials *IAMRoleCredentials) GenerateCredentialsEndpointRelativeUR
 // the credentials endpoint
 type credentialsManager struct {
 	// idToTaskCredentials maps credentials id to its corresponding TaskIAMRoleCredentials object
-	idToTaskCredentials map[string]*TaskIAMRoleCredentials
+	idToTaskCredentials map[string]TaskIAMRoleCredentials
 	taskCredentialsLock sync.RWMutex
 }
 
@@ -111,7 +111,7 @@ func IAMRoleCredentialsFromACS(roleCredentials *ecsacs.IAMRoleCredentials, roleT
 // NewManager creates a new credentials manager object
 func NewManager() Manager {
 	return &credentialsManager{
-		idToTaskCredentials: make(map[string]*TaskIAMRoleCredentials),
+		idToTaskCredentials: make(map[string]TaskIAMRoleCredentials),
 	}
 }
 
@@ -131,13 +131,10 @@ func (manager *credentialsManager) SetTaskCredentials(taskCredentials TaskIAMRol
 		return fmt.Errorf("task ARN is empty")
 	}
 
-	// Check if credentials exists for the given credentials id
-	_, ok := manager.idToTaskCredentials[credentials.CredentialsID]
-	if !ok {
-		// No existing credentials, create a new one
-		manager.idToTaskCredentials[credentials.CredentialsID] = &TaskIAMRoleCredentials{}
+	manager.idToTaskCredentials[credentials.CredentialsID] = TaskIAMRoleCredentials{
+		ARN:                taskCredentials.ARN,
+		IAMRoleCredentials: taskCredentials.GetIAMRoleCredentials(),
 	}
-	manager.idToTaskCredentials[credentials.CredentialsID] = &taskCredentials
 
 	return nil
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Refactoring idToTaskCredentials map in credentials manager 

### Implementation details
Fixed idToTaskCredentials map to store TaskIAMRoleCredentials objects instead of pointers to them. There isn't any particular reason why we need to handle pointers in this map, and it allows for cleaner code (no npe handling for pointer).

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: N/A

### Description for the changelog
Change log not updated for this refactoring code change

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: yes
