### PR TITLE
engine refactor: break up mtask and engine v1

### DIFF
--- a/agent/api/statechange.go
+++ b/agent/api/statechange.go
@@ -79,13 +79,13 @@ func NewTaskStateChangeEvent(task *Task, reason string) (TaskStateChange, error)
 	taskKnownStatus := task.GetKnownStatus()
 	if !taskKnownStatus.BackendRecognized() {
 		return event, errors.Errorf(
-			"create task state change event api: status not recognized by ECS: %v; task: %s",
-			taskKnownStatus, task.Arn)
+			"create task state change event api: status not recognized by ECS: %v",
+			taskKnownStatus)
 	}
 	if task.GetSentStatus() >= taskKnownStatus {
 		return event, errors.Errorf(
-			"create task state change event api: status [%s] already sent for task %s",
-			taskKnownStatus.String(), task.Arn)
+			"create task state change event api: status [%s] already sent",
+			taskKnownStatus.String())
 	}
 
 	event = TaskStateChange{
@@ -106,8 +106,8 @@ func NewContainerStateChangeEvent(task *Task, cont *Container, reason string) (C
 	contKnownStatus := cont.GetKnownStatus()
 	if !contKnownStatus.ShouldReportToBackend(cont.GetSteadyStateStatus()) {
 		return event, errors.Errorf(
-			"create container state change event api: status not recognized by ECS: %v; task: %s",
-			contKnownStatus, task.Arn)
+			"create container state change event api: status not recognized by ECS: %v",
+			contKnownStatus)
 	}
 	if cont.IsInternal() {
 		return event, errors.Errorf(

--- a/agent/engine/docker_container_engine.go
+++ b/agent/engine/docker_container_engine.go
@@ -250,14 +250,16 @@ func (dg *dockerGoClient) PullImage(image string, authData *api.RegistryAuthenti
 
 	response := make(chan DockerContainerMetadata, 1)
 	go func() {
-		imagePullBackoff := utils.NewSimpleBackoff(minimumPullRetryDelay, maximumPullRetryDelay, pullRetryJitterMultiplier, pullRetryDelayMultiplier)
-		err := utils.RetryNWithBackoffCtx(ctx, imagePullBackoff, maximumPullRetries, func() error {
-			err := dg.pullImage(image, authData)
-			if err != nil {
-				seelog.Warnf("Failed to pull image %s: %s", image, err.Error())
-			}
-			return err
-		})
+		imagePullBackoff := utils.NewSimpleBackoff(minimumPullRetryDelay,
+			maximumPullRetryDelay, pullRetryJitterMultiplier, pullRetryDelayMultiplier)
+		err := utils.RetryNWithBackoffCtx(ctx, imagePullBackoff, maximumPullRetries,
+			func() error {
+				err := dg.pullImage(image, authData)
+				if err != nil {
+					seelog.Warnf("Failed to pull image %s: %s", image, err.Error())
+				}
+				return err
+			})
 		response <- DockerContainerMetadata{Error: wrapPullErrorAsEngineError(err)}
 	}()
 	select {

--- a/agent/engine/docker_container_engine_test.go
+++ b/agent/engine/docker_container_engine_test.go
@@ -109,11 +109,12 @@ func TestPullImageOutputTimeout(t *testing.T) {
 	wait := sync.WaitGroup{}
 	wait.Add(1)
 	// multiple invocations will happen due to retries, but all should timeout
-	mockDocker.EXPECT().PullImage(&pullImageOptsMatcher{"image:latest"}, gomock.Any()).Do(func(x, y interface{}) {
-		pullBeginTimeout <- time.Now()
-		wait.Wait()
-		// Don't return, verify timeout happens
-	}).Times(maximumPullRetries) // expected number of retries
+	mockDocker.EXPECT().PullImage(&pullImageOptsMatcher{"image:latest"}, gomock.Any()).Do(
+		func(x, y interface{}) {
+			pullBeginTimeout <- time.Now()
+			wait.Wait()
+			// Don't return, verify timeout happens
+		}).Times(maximumPullRetries) // expected number of retries
 
 	metadata := client.PullImage("image", nil)
 	if metadata.Error == nil {

--- a/agent/engine/docker_events_buffer.go
+++ b/agent/engine/docker_events_buffer.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -14,8 +14,9 @@
 package engine
 
 import (
-	docker "github.com/fsouza/go-dockerclient"
 	"sync"
+
+	docker "github.com/fsouza/go-dockerclient"
 )
 
 const (
@@ -41,6 +42,7 @@ func NewInfiniteBuffer() *InfiniteBuffer {
 }
 
 // StartListening starts reading from the input channel and writes to the buffer
+// TODO: wire in ctx to stop listening
 func (buffer *InfiniteBuffer) StartListening(events chan *docker.APIEvents) {
 	for event := range events {
 		go buffer.CopyEvents(event)

--- a/agent/engine/docker_task_engine_unix_test.go
+++ b/agent/engine/docker_task_engine_unix_test.go
@@ -15,6 +15,7 @@
 package engine
 
 import (
+	"context"
 	"errors"
 	"sync"
 	"testing"
@@ -31,7 +32,9 @@ import (
 )
 
 func TestPullEmptyVolumeImage(t *testing.T) {
-	ctrl, client, _, privateTaskEngine, _, _, _ := mocks(t, &config.Config{})
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	ctrl, client, _, privateTaskEngine, _, _, _ := mocks(t, ctx, &config.Config{})
 	defer ctrl.Finish()
 	taskEngine, _ := privateTaskEngine.(*DockerTaskEngine)
 	saver := mock_statemanager.NewMockStateManager(ctrl)

--- a/agent/engine/docker_task_engine_windows_test.go
+++ b/agent/engine/docker_task_engine_windows_test.go
@@ -15,6 +15,7 @@
 package engine
 
 import (
+	"context"
 	"sync"
 	"testing"
 
@@ -29,7 +30,9 @@ import (
 )
 
 func TestPullEmptyVolumeImage(t *testing.T) {
-	ctrl, client, _, privateTaskEngine, _, _, _ := mocks(t, &config.Config{})
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	ctrl, client, _, privateTaskEngine, _, _, _ := mocks(t, ctx, &config.Config{})
 	defer ctrl.Finish()
 	taskEngine, _ := privateTaskEngine.(*DockerTaskEngine)
 	saver := mock_statemanager.NewMockStateManager(ctrl)
@@ -60,10 +63,13 @@ func TestDeleteTask(t *testing.T) {
 
 	mockState := mock_dockerstate.NewMockTaskEngineState(ctrl)
 	mockSaver := mock_statemanager.NewMockStateManager(ctrl)
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
 	taskEngine := &DockerTaskEngine{
 		state: mockState,
 		saver: mockSaver,
 		cfg:   &defaultConfig,
+		ctx:   ctx,
 	}
 
 	gomock.InOrder(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
 I have taken an initial stab at better populating and isolating `managedTask` and `DockerTaskEngine` classes. Also added unit tests for cgroup resource creation path.

### Implementation details
<!-- How are the changes implemented? -->

* 8709c96: This commit tries to remove references to fields in engine struct
from managedTask and vice versa. Instead, the relevant fields are
passed around and access to fields are removed.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: Yes


### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: yes
