### PR TITLE
Refactoring to reduce cyclomatic complexities in files that scored > 15

### DIFF
--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -169,6 +169,26 @@ func TestInvalidLoggingDriver(t *testing.T) {
 	assert.Error(t, conf.validateAndOverrideBounds(), "Should be error with invalid-logging-driver")
 }
 
+func TestDefaultCheckpointWithoutECSDataDir(t *testing.T) {
+	conf, err := environmentConfig()
+	assert.NoError(t, err)
+	assert.False(t, conf.Checkpoint)
+}
+
+func TestDefaultCheckpointWithECSDataDir(t *testing.T) {
+	defer setTestEnv("ECS_DATADIR", "/some/dir")()
+	conf, err := environmentConfig()
+	assert.NoError(t, err)
+	assert.True(t, conf.Checkpoint)
+}
+
+func TestCheckpointWithoutECSDataDir(t *testing.T) {
+	defer setTestEnv("ECS_CHECKPOINT", "true")()
+	conf, err := environmentConfig()
+	assert.NoError(t, err)
+	assert.True(t, conf.Checkpoint)
+}
+
 func TestInvalidFormatDockerStopTimeout(t *testing.T) {
 	defer setTestRegion()()
 	defer setTestEnv("ECS_CONTAINER_STOP_TIMEOUT", "invalid")()

--- a/agent/engine/docker_container_engine_test.go
+++ b/agent/engine/docker_container_engine_test.go
@@ -295,6 +295,20 @@ func TestPullImageECRAuthFail(t *testing.T) {
 	assert.Error(t, metadata.Error, "expected pull to fail")
 }
 
+func TestGetRepositoryWithTaggedImage(t *testing.T) {
+	image := "registry.endpoint/myimage:tag"
+	respository := getRepository(image)
+
+	assert.Equal(t, image, respository)
+}
+
+func TestGetRepositoryWithUntaggedImage(t *testing.T) {
+	image := "registry.endpoint/myimage"
+	respository := getRepository(image)
+
+	assert.Equal(t, image+":"+dockerDefaultTag, respository)
+}
+
 func TestImportLocalEmptyVolumeImage(t *testing.T) {
 	mockDocker, client, testTime, _, _, done := dockerClientSetup(t)
 	defer done()

--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -294,12 +294,7 @@ func (mtask *managedTask) handleContainerChange(containerChange dockerContainerC
 
 	// locate the container
 	container := containerChange.container
-	found := false
-	for _, c := range mtask.Containers {
-		if container == c {
-			found = true
-		}
-	}
+	found := mtask.isContainerFound(container)
 	if !found {
 		llog.Crit("State error; task manager called with another task's container!", "container", container)
 		return
@@ -363,6 +358,17 @@ func (mtask *managedTask) handleContainerChange(containerChange dockerContainerC
 		// If knownStatus changed, let it be known
 		mtask.engine.emitTaskEvent(mtask.Task, "")
 	}
+}
+
+func (mtask *managedTask) isContainerFound(container *api.Container) bool {
+	found := false
+	for _, c := range mtask.Containers {
+		if container == c {
+			found = true
+			break
+		}
+	}
+	return found
 }
 
 // releaseIPInIPAM releases the ip used by the task for awsvpc

--- a/agent/engine/types.go
+++ b/agent/engine/types.go
@@ -50,7 +50,7 @@ type DockerContainerMetadata struct {
 	ExitCode *int
 	// PortBindings is the list of port binding information of the container
 	PortBindings []api.PortBinding
-	// Error wraps vaioous container transition errors and is set if engine
+	// Error wraps various container transition errors and is set if engine
 	// is unable to perform any of the required container transitions
 	Error engineError
 	// Volumes contains volume informaton for the container


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Refactoring config, docker_container_engine, docker_task_engine, and task_manager to clean up and reduce cyclomatic complexities.

### Implementation details
Refactored logic that can be cleanly isolated from the main body of the function.

➜ gocyclo agent/config/config.go
Before:
20 config environmentConfig agent/config/config.go:235:1
After:
15 config environmentConfig agent/config/config.go:235:1
3 config getDockerStopTimeout agent/config/config.go:407:1
3 config getTaskCPUMemLimitEnabled agent/config/config.go:418:1
2 config getCheckpoint agent/config/config.go:394:1

➜ gocyclo agent/engine/docker_container_engine.go
Before:
16 engine (*dockerGoClient).pullImage agent/engine/docker_container_engine.go:284:1
After: 
8 engine (*dockerGoClient).pullImage agent/engine/docker_container_engine.go:284:1
8 engine (*dockerGoClient).filterDebugOutput agent/engine/docker_container_engine.go:339:1

➜ gocyclo agent/engine/docker_task_engine.go
Before:
23 engine (*DockerTaskEngine).createContainer agent/engine/docker_task_engine.go:669:1
After:
15 engine (*DockerTaskEngine).createContainer agent/engine/docker_task_engine.go:670:1

➜ gocyclo ./agent/engine/task_manager.go
Before:
16 engine (*managedTask).handleContainerChange ./agent/engine/task_manager.go:292:1
After: 
14 engine (*managedTask).handleContainerChange ./agent/engine/task_manager.go:292:1
3 engine (*managedTask).isContainerFound ./agent/engine/task_manager.go:363:1

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: N/A

### Description for the changelog
Did not update changelog, as this is a simple refactoring of existing logic, not a new feature or bug fix.

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: yes