### PR TITLE
Generate binaries and tests using AWS Codebuild

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,18 +11,9 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-PAUSE_CONTAINER_IMAGE = "amazon/amazon-ecs-pause"
-PAUSE_CONTAINER_TAG = "0.1.0"
-PAUSE_CONTAINER_TARBALL = "amazon-ecs-pause.tar"
+USERID=$(shell id -u)
 
-# Variable to determine branch/tag of amazon-ecs-cni-plugins
-ECS_CNI_REPOSITORY_REVISION=master
-
-# Variable to override cni repository location
-ECS_CNI_REPOSITORY_SRC_DIR=$(PWD)/amazon-ecs-cni-plugins
-
-
-.PHONY: all gobuild static docker release certs test clean netkitten test-registry run-functional-tests benchmark-test gogenerate run-integ-tests pause-container get-cni-sources cni-plugins
+.PHONY: all gobuild static docker release certs test clean netkitten test-registry run-functional-tests benchmark-test gogenerate run-integ-tests pause-container get-cni-sources cni-plugins test-artifacts
 
 all: docker
 
@@ -31,40 +22,55 @@ all: docker
 gobuild:
 	./scripts/build false
 
+# create output directories
+.out-stamp:
+	mkdir -p ./out/test-artifacts ./out/cni-plugins
+	touch .out-stamp
+
 # Basic go build
 static:
 	./scripts/build
 
+BUILDER_IMAGE="amazon/amazon-ecs-agent-build:make"
+.builder-image-stamp: scripts/dockerfiles/Dockerfile.build
+	@docker build -f scripts/dockerfiles/Dockerfile.build -t $(BUILDER_IMAGE) .
+	touch .builder-image-stamp
+
 # 'build-in-docker' builds the agent within a dockerfile and saves it to the ./out
 # directory
-build-in-docker:
-	@docker build -f scripts/dockerfiles/Dockerfile.build -t "amazon/amazon-ecs-agent-build:make" .
+# TODO: make this idempotent
+build-in-docker: .builder-image-stamp .out-stamp
 	@docker run --net=none \
-	  -e TARGET_OS="${TARGET_OS}" \
-	  -e LDFLAGS="-X github.com/aws/amazon-ecs-agent/agent/config.DefaultPauseContainerTag=$(PAUSE_CONTAINER_TAG) \
-	  -X github.com/aws/amazon-ecs-agent/agent/config.DefaultPauseContainerImageName=$(PAUSE_CONTAINER_IMAGE)" \
-	  -v "$(PWD)/out:/out" \
-	  -v "$(PWD):/go/src/github.com/aws/amazon-ecs-agent" \
-	  "amazon/amazon-ecs-agent-build:make"
+		--env TARGET_OS="${TARGET_OS}" \
+		--env LDFLAGS="-X github.com/aws/amazon-ecs-agent/agent/config.DefaultPauseContainerTag=$(PAUSE_CONTAINER_TAG) \
+			-X github.com/aws/amazon-ecs-agent/agent/config.DefaultPauseContainerImageName=$(PAUSE_CONTAINER_IMAGE)" \
+		--volume "$(PWD)/out:/out" \
+		--volume "$(PWD):/go/src/github.com/aws/amazon-ecs-agent" \
+		--user "$(USERID)" \
+		--rm \
+		$(BUILDER_IMAGE)
 
 # 'docker' builds the agent dockerfile from the current sourcecode tree, dirty
 # or not
-docker: certs build-in-docker pause-container-release cni-plugins
+docker: certs build-in-docker pause-container-release cni-plugins .out-stamp
 	@cd scripts && ./create-amazon-ecs-scratch
 	@docker build -f scripts/dockerfiles/Dockerfile.release -t "amazon/amazon-ecs-agent:make" .
 	@echo "Built Docker image \"amazon/amazon-ecs-agent:make\""
 
 # 'docker-release' builds the agent from a clean snapshot of the git repo in
 # 'RELEASE' mode
-docker-release: pause-container-release cni-plugins
+# TODO: make this idempotent
+docker-release: pause-container-release cni-plugins .out-stamp
 	@docker build -f scripts/dockerfiles/Dockerfile.cleanbuild -t "amazon/amazon-ecs-agent-cleanbuild:make" .
 	@docker run --net=none \
-	  -e TARGET_OS="${TARGET_OS}" \
-	  -v "$(PWD)/out:/out" \
-	  -e LDFLAGS="-X github.com/aws/amazon-ecs-agent/agent/config.DefaultPauseContainerTag=$(PAUSE_CONTAINER_TAG) \
-	  -X github.com/aws/amazon-ecs-agent/agent/config.DefaultPauseContainerImageName=$(PAUSE_CONTAINER_IMAGE)" \
-	  -v "$(PWD):/src/amazon-ecs-agent" \
-	  "amazon/amazon-ecs-agent-cleanbuild:make"
+		--env TARGET_OS="${TARGET_OS}" \
+		--env LDFLAGS="-X github.com/aws/amazon-ecs-agent/agent/config.DefaultPauseContainerTag=$(PAUSE_CONTAINER_TAG) \
+			-X github.com/aws/amazon-ecs-agent/agent/config.DefaultPauseContainerImageName=$(PAUSE_CONTAINER_IMAGE)" \
+		--user "$(USERID)" \
+		--volume "$(PWD)/out:/out" \
+		--volume "$(PWD):/src/amazon-ecs-agent" \
+		--rm \
+		"amazon/amazon-ecs-agent-cleanbuild:make"
 
 # Release packages our agent into a "scratch" based dockerfile
 release: certs docker-release
@@ -90,6 +96,80 @@ test-silent:
 benchmark-test:
 	. ./scripts/shared_env && go test -run=XX -bench=. $(shell go list ./agent/... | grep -v /vendor/)
 
+define dockerbuild
+	docker run \
+		--net none \
+		--user "$(USERID)" \
+		--volume "$(PWD)/out:/out" \
+		--volume "$(PWD):/go/src/github.com/aws/amazon-ecs-agent" \
+		--rm \
+		$(BUILDER_IMAGE) \
+		$(1)
+endef
+
+define win-cgo-dockerbuild
+	docker run --net=none \
+		--user "$(USERID)" \
+		--volume "$(PWD)/out:/out" \
+		--volume "$(PWD):/go/src/github.com/aws/amazon-ecs-agent" \
+		--env "GOOS=windows" \
+		--env "CGO_ENABLED=1" \
+		--env "CC=x86_64-w64-mingw32-gcc" \
+		--rm \
+		$(BUILDER_IMAGE) \
+		$(1)
+endef
+
+# TODO: use `go list -f` to target the test files more directly
+ALL_GO_FILES = $(shell find . -name "*.go" -print | tr "\n" " ")
+GO_INTEG_TEST = go test -race -tags integration -c -o
+out/test-artifacts/linux-engine-tests: $(ALL_GO_FILES) .out-stamp .builder-image-stamp
+	$(call dockerbuild,$(GO_INTEG_TEST) $@ ./agent/engine)
+
+out/test-artifacts/linux-app-tests: $(ALL_GO_FILES) .out-stamp .builder-image-stamp
+	$(call dockerbuild,$(GO_INTEG_TEST) $@ ./agent/app)
+
+out/test-artifacts/linux-stats-tests: $(ALL_GO_FILES) .out-stamp .builder-image-stamp
+	$(call dockerbuild,$(GO_INTEG_TEST) $@ ./agent/stats)
+
+out/test-artifacts/windows-engine-tests.exe: $(ALL_GO_FILES) .out-stamp .builder-image-stamp
+	$(call win-cgo-dockerbuild,$(GO_INTEG_TEST) $@ ./agent/engine)
+
+out/test-artifacts/windows-app-tests.exe: $(ALL_GO_FILES) .out-stamp .builder-image-stamp
+	$(call win-cgo-dockerbuild,$(GO_INTEG_TEST) $@ ./agent/app)
+
+out/test-artifacts/windows-stats-tests.exe: $(ALL_GO_FILES) .out-stamp .builder-image-stamp
+	$(call win-cgo-dockerbuild,$(GO_INTEG_TEST) $@ ./agent/stats)
+
+GO_FUNCTIONAL_TEST = go test -tags functional -c -o
+out/test-artifacts/linux-simple-tests: $(ALL_GO_FILES) .out-stamp .builder-image-stamp
+	$(call dockerbuild,$(GO_FUNCTIONAL_TEST) $@ ./agent/functional_tests/tests/generated/simpletests_unix)
+
+out/test-artifacts/linux-handwritten-tests: $(ALL_GO_FILES) .out-stamp .builder-image-stamp
+	$(call dockerbuild,$(GO_FUNCTIONAL_TEST) $@ ./agent/functional_tests/tests)
+
+out/test-artifacts/windows-simple-tests.exe: $(ALL_GO_FILES) .out-stamp .builder-image-stamp
+	$(call win-cgo-dockerbuild,$(GO_FUNCTIONAL_TEST) $@ ./agent/functional_tests/tests/generated/simpletests_windows)
+
+out/test-artifacts/windows-handwritten-tests.exe: $(ALL_GO_FILES) .out-stamp .builder-image-stamp
+	$(call win-cgo-dockerbuild,$(GO_FUNCTIONAL_TEST) $@ ./agent/functional_tests/tests)
+
+##.PHONY: test-artifacts-windows test-artifacts-linux test-artifacts
+
+WINDOWS_ARTIFACTS_TARGETS := out/test-artifacts/windows-engine-tests.exe out/test-artifacts/windows-stats-tests.exe
+WINDOWS_ARTIFACTS_TARGETS += out/test-artifacts/windows-app-tests.exe out/test-artifacts/windows-simple-tests.exe
+WINDOWS_ARTIFACTS_TARGETS += out/test-artifacts/windows-handwritten-tests.exe
+
+LINUX_ARTIFACTS_TARGETS := out/test-artifacts/linux-engine-tests out/test-artifacts/linux-stats-tests
+LINUX_ARTIFACTS_TARGETS += out/test-artifacts/linux-app-tests out/test-artifacts/linux-simple-tests
+LINUX_ARTIFACTS_TARGETS += out/test-artifacts/linux-handwritten-tests
+
+test-artifacts-windows: $(WINDOWS_ARTIFACTS_TARGETS)
+
+test-artifacts-linux: $(LINUX_ARTIFACTS_TARGETS)
+
+test-artifacts: test-artifacts-windows test-artifacts-linux
+
 # Run our 'test' registry needed for integ and functional tests
 test-registry: netkitten volumes-test squid awscli image-cleanup-test-images fluentd taskmetadata-validator
 	@./scripts/setup-test-registry
@@ -102,12 +182,14 @@ test-in-docker:
 run-functional-tests: testnnp test-registry ecr-execution-role-image
 	. ./scripts/shared_env && go test -tags functional -timeout=30m -v ./agent/functional_tests/...
 
-testnnp:
-	$(MAKE) -C misc/testnnp $(MFLAGS)
+PAUSE_CONTAINER_IMAGE = "amazon/amazon-ecs-pause"
+PAUSE_CONTAINER_TAG = "0.1.0"
+PAUSE_CONTAINER_TARBALL = "amazon-ecs-pause.tar"
 
-pause-container:
+pause-container: .out-stamp
 	@docker build -f scripts/dockerfiles/Dockerfile.buildPause -t "amazon/amazon-ecs-build-pause-bin:make" .
 	@docker run --net=none \
+		-u "$(USERID)" \
 		-v "$(PWD)/misc/pause-container:/out" \
 		-v "$(PWD)/misc/pause-container/buildPause:/usr/src/buildPause" \
 		"amazon/amazon-ecs-build-pause-bin:make"
@@ -116,18 +198,23 @@ pause-container:
 	@docker rmi -f "amazon/amazon-ecs-build-pause-bin:make"
 
 pause-container-release: pause-container
-	mkdir -p "$(PWD)/out"
 	@docker save ${PAUSE_CONTAINER_IMAGE}:${PAUSE_CONTAINER_TAG} > "$(PWD)/out/${PAUSE_CONTAINER_TARBALL}"
+
+# Variable to determine branch/tag of amazon-ecs-cni-plugins
+ECS_CNI_REPOSITORY_REVISION=master
+
+# Variable to override cni repository location
+ECS_CNI_REPOSITORY_SRC_DIR=$(PWD)/amazon-ecs-cni-plugins
 
 get-cni-sources:
 	git submodule update --init --checkout
 
-cni-plugins: get-cni-sources
+cni-plugins: get-cni-sources .out-stamp
 	@docker build -f scripts/dockerfiles/Dockerfile.buildCNIPlugins -t "amazon/amazon-ecs-build-cniplugins:make" .
-	mkdir -p out/cni-plugins
 	docker run --rm --net=none \
 		-e GIT_SHORT_HASH=$(shell cd $(ECS_CNI_REPOSITORY_SRC_DIR) && git rev-parse --short HEAD) \
 		-e GIT_PORCELAIN=$(shell cd $(ECS_CNI_REPOSITORY_SRC_DIR) && git status --porcelain 2> /dev/null | wc -l | sed 's/^ *//') \
+		-u "$(USERID)" \
 		-v "$(PWD)/out/cni-plugins:/go/src/github.com/aws/amazon-ecs-cni-plugins/bin/plugins" \
 		-v "$(ECS_CNI_REPOSITORY_SRC_DIR):/go/src/github.com/aws/amazon-ecs-cni-plugins" \
 		"amazon/amazon-ecs-build-cniplugins:make"
@@ -135,6 +222,13 @@ cni-plugins: get-cni-sources
 
 run-integ-tests: test-registry gremlin container-health-check-image
 	. ./scripts/shared_env && go test -race -tags integration -timeout=5m -v ./agent/engine/... ./agent/stats/... ./agent/app/...
+
+.PHONY: codebuild
+codebuild: get-deps test-artifacts .out-stamp
+	$(MAKE) release TARGET_OS="linux"
+	TARGET_OS="linux" ./scripts/local-save
+	$(MAKE) docker-release TARGET_OS="windows"
+	TARGET_OS="windows" ./scripts/local-save
 
 netkitten:
 	$(MAKE) -C misc/netkitten $(MFLAGS)
@@ -157,11 +251,15 @@ awscli:
 fluentd:
 	$(MAKE) -C misc/fluentd $(MFLAGS)
 
+testnnp:
+	$(MAKE) -C misc/testnnp $(MFLAGS)
+
 image-cleanup-test-images:
 	$(MAKE) -C misc/image-cleanup-test-images $(MFLAGS)
 
 taskmetadata-validator:
 	$(MAKE) -C misc/taskmetadata-validator $(MFLAGS)
+
 ecr-execution-role-image:
 	$(MAKE) -C misc/ecr $(MFLAGS)
 
@@ -190,8 +288,9 @@ get-deps: .get-deps-stamp
 clean:
 	# ensure docker is running and we can talk to it, abort if not:
 	docker ps > /dev/null
+	-docker rmi $(BUILDER_IMAGE) "amazon/amazon-ecs-agent-cleanbuild:make"
 	rm -f misc/certs/ca-certificates.crt &> /dev/null
-	rm -rf out/*
+	rm -rf out/
 	$(MAKE) -C $(ECS_CNI_REPOSITORY_SRC_DIR) clean
 	-$(MAKE) -C misc/netkitten $(MFLAGS) clean
 	-$(MAKE) -C misc/volumes-test $(MFLAGS) clean
@@ -201,3 +300,6 @@ clean:
 	-$(MAKE) -C misc/taskmetadata-validator $(MFLAGS) clean
 	-$(MAKE) -C misc/container-health $(MFLAGS) clean
 	-rm -f .get-deps-stamp
+	-rm -f .builder-image-stamp
+	-rm -f .out-stamp
+

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,0 +1,11 @@
+version: 0.2
+
+phases:
+  build:
+    commands:
+      - make codebuild
+artifacts:
+  files:
+      - 'out/**/*'
+      - 'agent/functional_tests/testdata/**/*'
+  discard-paths: no

--- a/scripts/build
+++ b/scripts/build
@@ -16,7 +16,7 @@
 # It exists to wrap go build and properly make a static binary, as well as to
 # correctly setup versioning before creating the binary
 
-set -e
+set -ex
 
 # Pass in whether you want to build a static binary (true|false) and whether
 # the resulting binary should be moved to an output directory

--- a/scripts/cleanbuild
+++ b/scripts/cleanbuild
@@ -14,6 +14,7 @@
 
 # This script is meant for use inside the clean build dockerfile and makes
 # assumptions related to that. It should not be run on its own.
+set -ex
 
 cd /src/amazon-ecs-agent
 DIRTY_WARNING=$(cat <<EOW
@@ -27,7 +28,9 @@ EOW
 [ ! -z "$(git status --porcelain)" ] && echo "$DIRTY_WARNING"
 
 # Fresh clone to ensure our build doesn't rely on anything outside of vcs
-git clone --quiet /src/amazon-ecs-agent /go/src/github.com/aws/amazon-ecs-agent
+# The config values 'user.name' and 'user.email' are used to make git-clone
+# happy when running in a container as a non-root user.
+git clone -c user.name="cleanbuild" -c user.email="cleanbuild" /src/amazon-ecs-agent /go/src/github.com/aws/amazon-ecs-agent
 
 # Allows the build to be marked as 'clean' so we can distinguish a properly
 # created build.

--- a/scripts/dockerfiles/Dockerfile.build
+++ b/scripts/dockerfiles/Dockerfile.build
@@ -14,8 +14,8 @@
 FROM golang:1.9
 MAINTAINER Amazon Web Services, Inc.
 
-RUN mkdir /out
-VOLUME ['/out']
+RUN apt-get update && \
+    apt-get install -y gcc-mingw-w64
 
 RUN mkdir -p /go/src/github.com/aws/
 

--- a/scripts/dockerfiles/Dockerfile.cleanbuild
+++ b/scripts/dockerfiles/Dockerfile.cleanbuild
@@ -14,12 +14,10 @@
 FROM golang:1.9
 MAINTAINER Amazon Web Services, Inc.
 
-RUN mkdir /out
-VOLUME ['/out']
-
-RUN mkdir -p /go/src/github.com/aws/
-
 COPY ./scripts/cleanbuild /scripts/cleanbuild
 WORKDIR /go/src/github.com/aws/amazon-ecs-agent
 
+# Set subfolder permissions to 777
+# https://github.com/docker-library/golang/blob/2f2f3b620d61f533484f24a568c2ca46e4fda91c/1.9/stretch/Dockerfile#L49
+RUN chmod -R 777 /go/src
 ENTRYPOINT /scripts/cleanbuild

--- a/scripts/local-save
+++ b/scripts/local-save
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the
+# "License"). You may not use this file except in compliance
+#  with the License. A copy of the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+IMAGE_NAME="amazon/amazon-ecs-agent:latest"
+
+stage() {
+	local tarball="./out/ecs-agent.tar"
+	docker save -o "${tarball}" "${IMAGE_NAME}"
+}
+
+stage_windows() {
+	local ziproot="$(mktemp -d)"
+	local ziptargetdir="$(mktemp -d)"
+	local zipfile="${ziptargetdir}/amazon-ecs-agent"
+	local buildroot="$(pwd)"
+
+	cp out/amazon-ecs-agent.exe "${ziproot}"
+	cp -v misc/windows-deploy/*.ps1 "${ziproot}"
+	pushd "${ziproot}"
+	zip "${zipfile}" *
+	cp "${zipfile}.zip" "${buildroot}/out/ecs-agent-windows.zip"
+	popd
+
+	rm -r "${ziptargetdir}" "${ziproot}"
+}
+
+if [ "${TARGET_OS}" == "windows" ]; then
+	stage_windows
+else
+	stage
+fi


### PR DESCRIPTION
### Summary 
Provides base layer of infrastructure for cross-compiling windows binaries on linux. This is only used in testing for now, but its in a good place where we could extend this to automate builds.

### Implementation
This provides the following:
- A makefile target that does the following:
  - compiles linux tarball and cni plugins
  - compiles windows zipfile
  - compiles all functional and integration test binaries
- A codebuild buildspec used to automate the compile step
- Some fixes to the build tooling to make sure that 'root' doesn't own the artifacts

When run with `make codebuild`, your out directory will result:

```
out
├── amazon-ecs-agent
├── amazon-ecs-agent.exe
├── amazon-ecs-pause.tar
├── cni-plugins
│   ├── ecs-bridge
│   ├── ecs-eni
│   └── ecs-ipam
├── ecs-agent.tar
├── ecs-agent-windows.zip
└── test-artifacts
    ├── unix-app-tests
    ├── unix-engine-tests
    ├── unix-handwritten-tests
    ├── unix-simple-tests
    ├── unix-stats-tests
    ├── windows-app-tests.exe
    ├── windows-engine-tests.exe
    ├── windows-handwritten-tests.exe
    ├── windows-simple-tests.exe
    └── windows-stats-tests.exe
```

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: yes
