### PR TITLE
Adding gocyclo to travis config, excluding test and mock files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,5 @@ go_import_path: github.com/aws/amazon-ecs-agent
 install: make get-deps
 script:
   - make test
+  - make static-check
+  

--- a/Makefile
+++ b/Makefile
@@ -165,10 +165,21 @@ taskmetadata-validator:
 ecr-execution-role-image:
 	$(MAKE) -C misc/ecr $(MFLAGS)
 
+.PHONY: gocyclo
+gocyclo:
+	# Run gocyclo over all .go files in the agent, excluding vendor/ and testutils/ directories, and all *_test.go and *_mocks.go files
+	gocyclo -over 15 $(shell go list -f '{{$$p := .}}{{range $$f := .GoFiles}}{{$$p.Dir}}/{{$$f}} {{end}}' ./agent/... \
+		| grep -v /vendor/ | grep -v /testutils/ | grep -v _test\.go$ | grep -v _mocks\.go$)
+
+#TODO, create and add go vet target
+.PHONY: static-check
+static-check: gocyclo
+
 .get-deps-stamp:
 	go get golang.org/x/tools/cmd/cover
 	go get github.com/golang/mock/mockgen
 	go get golang.org/x/tools/cmd/goimports
+	go get github.com/fzipp/gocyclo
 	touch .get-deps-stamp
 
 get-deps: .get-deps-stamp


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Adding gocyclo to travis ci config, to run as a part of required checks for any commits. 
Previous PR got closed by mistake (https://github.com/aws/amazon-ecs-agent/pull/1172), this PR is a duplicate of that.

### Implementation details
Adding gocyclo installation and run of it to fail on any files with cyclomatic complexity over 15, excluding test and mock files, and vender/ testutils/ directories. 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

Tested on my forked repo:
```
$ make static-check
gocyclo -over 15 <go files as filtered by go list command>
The command "make static-check" exited with 0.
```

New tests cover the changes: N/A

### Description for the changelog
Did not update the changelog, not a feature implementation or bug fix that are customer facing.

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: yes
