### PR TITLE
More go vet fixes, needed for adding to static check target

### DIFF
--- a/agent/api/eni.go
+++ b/agent/api/eni.go
@@ -34,10 +34,10 @@ type ENI struct {
 	MacAddress string
 	// DomainNameServers specifies the nameserver IP addresses for
 	// the eni
-	DomainNameServers []string `json:"omitempty"`
+	DomainNameServers []string `json:",omitempty"`
 	// DomainNameSearchList specifies the search list for the domain
 	// name lookup, for the eni
-	DomainNameSearchList []string `json:"omitempty"`
+	DomainNameSearchList []string `json:",omitempty"`
 }
 
 // GetIPV4Addresses returns a list of ipv4 addresses allocated to the ENI

--- a/agent/containermetadata/utils.go
+++ b/agent/containermetadata/utils.go
@@ -58,7 +58,7 @@ func getMetadataFilePath(taskARN string, containerName string, dataDir string) (
 func getTaskMetadataDir(taskARN string, dataDir string) (string, error) {
 	taskID, err := getTaskIDfromARN(taskARN)
 	if err != nil {
-		fmt.Errorf("get task metadata directory: %v", err)
+		return "", fmt.Errorf("get task metadata directory: %v", err)
 	}
 	return filepath.Join(dataDir, metadataJoinSuffix, taskID), err
 }

--- a/agent/containermetadata/utils_test.go
+++ b/agent/containermetadata/utils_test.go
@@ -16,8 +16,10 @@ package containermetadata
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
+	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const (
@@ -32,4 +34,51 @@ func TestGetTaskIDFailDueToInvalidID(t *testing.T) {
 	expectErrorMessage := fmt.Sprintf("get task ARN: cannot find TaskID for TaskARN %s", mockTaskARN)
 
 	assert.Equal(t, expectErrorMessage, err.Error())
+}
+
+func TestGetMetadataFilePathFailDueToInvalidID(t *testing.T) {
+	mockTaskARN := invalidSplitTaskARN
+	mockContainerName := containerName
+	mockDataDir := dataDir
+
+	_, err := getMetadataFilePath(mockTaskARN, mockContainerName, mockDataDir)
+	expectErrorMessage := fmt.Sprintf(
+		"get metdata file path of task %s container %s: get task ARN: cannot find TaskID for TaskARN %s",
+		mockTaskARN, mockContainerName, mockTaskARN)
+
+	assert.Equal(t, expectErrorMessage, err.Error())
+}
+
+func TestGetMetadataFilePathSuccess(t *testing.T) {
+	mockTaskARN := validTaskARN
+	mockContainerName := containerName
+	mockDataDir := dataDir
+
+	path, err := getMetadataFilePath(mockTaskARN, mockContainerName, mockDataDir)
+	expectedPath := filepath.Join(mockDataDir, metadataJoinSuffix, "task-id", mockContainerName)
+
+	assert.Equal(t, expectedPath, path)
+	assert.NoError(t, err)
+}
+
+func TestGetTaskMetadataDirFailDueToInvalidID(t *testing.T) {
+	mockTaskARN := invalidSplitTaskARN
+	mockDataDir := dataDir
+
+	_, err := getTaskMetadataDir(mockTaskARN, mockDataDir)
+	expectErrorMessage := fmt.Sprintf(
+		"get task metadata directory: get task ARN: cannot find TaskID for TaskARN %s", mockTaskARN)
+
+	assert.Equal(t, expectErrorMessage, err.Error())
+}
+
+func TestGetTaskMetadataDirSuccess(t *testing.T) {
+	mockTaskARN := validTaskARN
+	mockDataDir := dataDir
+
+	path, err := getTaskMetadataDir(mockTaskARN, mockDataDir)
+	expectedPath := filepath.Join(mockDataDir, metadataJoinSuffix, "task-id")
+
+	assert.Equal(t, expectedPath, path)
+	assert.NoError(t, err)
 }

--- a/agent/handlers/taskmetadata/helpers.go
+++ b/agent/handlers/taskmetadata/helpers.go
@@ -29,7 +29,7 @@ const (
 type errorMessage struct {
 	Code          string `json:"code"`
 	Message       string `json:"message"`
-	httpErrorCode int    `json:"-"`
+	httpErrorCode int
 }
 
 func writeJSONToResponse(w http.ResponseWriter, httpStatusCode int, jsonMessage []byte, requestType string) {

--- a/agent/handlers/v1_handlers.go
+++ b/agent/handlers/v1_handlers.go
@@ -70,7 +70,7 @@ func newTaskResponse(task *api.Task, containerMap map[string]*api.DockerContaine
 		if container.Container.IsInternal() {
 			continue
 		}
-		containers = append(containers, v1.ContainerResponse{container.DockerID, container.DockerName, containerName})
+		containers = append(containers, v1.ContainerResponse{DockerId: container.DockerID, DockerName: container.DockerName, Name: containerName})
 	}
 
 	knownStatus := task.GetKnownStatus()

--- a/misc/taskmetadata-validator/taskmetadata-validator.go
+++ b/misc/taskmetadata-validator/taskmetadata-validator.go
@@ -173,7 +173,7 @@ func metadataResponseOnce(client *http.Client, endpoint string, respType string)
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("task metadata: unable to read response body: %v", respType, err)
+		return nil, fmt.Errorf("task metadata: unable to read response body: %v", err)
 	}
 
 	return body, nil


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Fixes for go vet violations (there are more).

### Implementation details
Fixes for the following violations: 
- agent/api/eni.go:40: struct field DomainNameSearchList repeats json tag "omitempty" also at agent/api/eni.go:37  **<- see https://golang.org/pkg/encoding/json/#Marshal "note the leading comma"**
- agent/containermetadata/utils.go:61: result of fmt.Errorf call not used
- agent/handlers/taskmetadata/helpers.go:32: struct field httpErrorCode has json tag but is not exported  **<- I do not have context on why this field was not exported**
- agent/handlers/v1_handlers.go:73: github.com/aws/amazon-ecs-agent/agent/handlers/types/v1.ContainerResponse composite literal uses unkeyed fields

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: N/A

### Description for the changelog
Did not update changelog for this change

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: yes
