### PR TITLE
Fix container metadata information missing during agent restart

### DIFF
--- a/agent/api/task.go
+++ b/agent/api/task.go
@@ -1103,3 +1103,21 @@ func (task *Task) GetID() (string, error) {
 
 	return resourceSplit[1], nil
 }
+
+func (task *Task) RecordExecutionStoppedAt(container *Container) {
+	if !container.Essential {
+		return
+	}
+	if container.GetKnownStatus() != ContainerStopped {
+		return
+	}
+	// If the essential container is stopped, set the ExecutionStoppedAt timestamp
+	now := time.Now()
+	ok := task.SetExecutionStoppedAt(now)
+	if !ok {
+		// ExecutionStoppedAt was already recorded. Nothing to left to do here
+		return
+	}
+	seelog.Infof("Task [%s]: recording execution stopped time. Essential container [%s] stopped at: %s",
+		task.Arn, container.Name, now.String())
+}

--- a/agent/api/task.go
+++ b/agent/api/task.go
@@ -1104,6 +1104,8 @@ func (task *Task) GetID() (string, error) {
 	return resourceSplit[1], nil
 }
 
+// RecordExecutionStoppedAt checks if this is an essential container stopped
+// and set the task executionStoppedAt timestamps
 func (task *Task) RecordExecutionStoppedAt(container *Container) {
 	if !container.Essential {
 		return

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -37,7 +37,6 @@ import (
 	utilsync "github.com/aws/amazon-ecs-agent/agent/utils/sync"
 	"github.com/aws/amazon-ecs-agent/agent/utils/ttime"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/cihub/seelog"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
@@ -291,6 +290,7 @@ func (engine *DockerTaskEngine) synchronizeState() {
 	engine.saver.Save()
 }
 
+// updateContainerMetadata sets the container metadata from the docker inspect
 func updateContainerMetadata(metadata *DockerContainerMetadata, container *api.Container, task *api.Task) {
 	container.SetCreatedAt(metadata.CreatedAt)
 	container.SetStartedAt(metadata.StartedAt)
@@ -332,7 +332,7 @@ func (engine *DockerTaskEngine) synchronizeContainerStatus(container *api.Docker
 			seelog.Warnf("Task engine [%s]: could not find matching container for expected name [%s]: %v",
 				task.Arn, container.DockerName, err)
 		} else {
-			// update the container metadata in case the container status/metadata changed during agent restart
+			// update the container metadata in case the container was created during agent restart
 			metadata := metadataFromContainer(describedContainer)
 			updateContainerMetadata(&metadata, container.Container, task)
 			container.DockerID = describedContainer.ID

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -1720,3 +1720,170 @@ func TestHandleDockerHealthEvent(t *testing.T) {
 	})
 	assert.Equal(t, testContainer.Health.Status, api.ContainerHealthy)
 }
+
+func TestCreatedContainerMetadataUpdateOnRestart(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	ctrl, client, _, taskEngine, _, imageManager, _ := mocks(t, ctx, &defaultConfig)
+	defer ctrl.Finish()
+
+	dockerID := "dockerID"
+	dockerContainer := &api.DockerContainer{
+		DockerName: "c1",
+		Container: &api.Container{
+			MountPoints: []api.MountPoint{
+				{
+					SourceVolume:  "empty",
+					ContainerPath: "container",
+				},
+			},
+		},
+	}
+
+	labels := map[string]string{
+		"name": "metadata",
+	}
+	created := time.Now()
+	volumes := map[string]string{
+		"container": "tmp",
+	}
+	emptyVolume := &api.EmptyHostVolume{}
+	task := &api.Task{
+		Volumes: []api.TaskVolume{
+			{
+				Name:   "empty",
+				Volume: emptyVolume,
+			},
+		},
+	}
+
+	gomock.InOrder(
+		client.EXPECT().InspectContainer("c1", gomock.Any()).Return(&docker.Container{
+			ID: dockerID,
+			Config: &docker.Config{
+				Labels: labels,
+			},
+			Created: created,
+			Volumes: volumes,
+		}, nil),
+		imageManager.EXPECT().RecordContainerReference(dockerContainer.Container),
+	)
+	taskEngine.(*DockerTaskEngine).synchronizeContainerStatus(dockerContainer, task)
+	assert.Equal(t, dockerID, dockerContainer.DockerID)
+	assert.Equal(t, created, dockerContainer.Container.GetCreatedAt())
+	assert.Equal(t, labels, dockerContainer.Container.GetLabels())
+	assert.Equal(t, "tmp", task.Volumes[0].Volume.SourcePath())
+}
+
+func TestStartedContainerMetadataUpdateOnRestart(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	ctrl, client, _, taskEngine, _, imageManager, _ := mocks(t, ctx, &defaultConfig)
+	defer ctrl.Finish()
+
+	dockerID := "1234"
+	dockerContainer := &api.DockerContainer{
+		DockerID:   dockerID,
+		DockerName: "c1",
+		Container:  &api.Container{},
+	}
+
+	portBindings := []api.PortBinding{
+		{
+			ContainerPort: 80,
+			HostPort:      80,
+			BindIP:        "0.0.0.0/0",
+			Protocol:      api.TransportProtocolTCP,
+		},
+	}
+	labels := map[string]string{
+		"name": "metadata",
+	}
+	startedAt := time.Now()
+	gomock.InOrder(
+		client.EXPECT().DescribeContainer(dockerID).Return(api.ContainerRunning,
+			DockerContainerMetadata{
+				Labels:       labels,
+				DockerID:     dockerID,
+				StartedAt:    startedAt,
+				PortBindings: portBindings,
+			}),
+		imageManager.EXPECT().RecordContainerReference(dockerContainer.Container),
+	)
+	taskEngine.(*DockerTaskEngine).synchronizeContainerStatus(dockerContainer, nil)
+	assert.Equal(t, startedAt, dockerContainer.Container.GetStartedAt())
+	assert.Equal(t, labels, dockerContainer.Container.GetLabels())
+	assert.Equal(t, uint16(80), dockerContainer.Container.KnownPortBindings[0].ContainerPort)
+}
+
+func TestStoppedContainerMetadataUpdateOnRestart(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	ctrl, client, _, taskEngine, _, imageManager, _ := mocks(t, ctx, &defaultConfig)
+	defer ctrl.Finish()
+
+	dockerID := "1234"
+	dockerContainer := &api.DockerContainer{
+		DockerID:   dockerID,
+		DockerName: "c1",
+		Container: &api.Container{
+			Essential: true,
+		},
+	}
+	task := &api.Task{}
+
+	labels := map[string]string{
+		"name": "metadata",
+	}
+	finishedAt := time.Now()
+	gomock.InOrder(
+		client.EXPECT().DescribeContainer(dockerID).Return(api.ContainerStopped,
+			DockerContainerMetadata{
+				Labels:     labels,
+				DockerID:   dockerID,
+				FinishedAt: finishedAt,
+				ExitCode:   aws.Int(1),
+			}),
+		imageManager.EXPECT().RecordContainerReference(dockerContainer.Container),
+	)
+	taskEngine.(*DockerTaskEngine).synchronizeContainerStatus(dockerContainer, task)
+	assert.Equal(t, finishedAt, dockerContainer.Container.GetFinishedAt())
+	assert.Equal(t, labels, dockerContainer.Container.GetLabels())
+	assert.Equal(t, 1, aws.IntValue(dockerContainer.Container.GetKnownExitCode()))
+	assert.False(t, task.GetExecutionStoppedAt().IsZero())
+}
+
+func TestErroredContainerMetadataUpdateOnRestart(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	ctrl, client, _, taskEngine, _, _, _ := mocks(t, ctx, &defaultConfig)
+	defer ctrl.Finish()
+
+	dockerID := "1234"
+	dockerContainer := &api.DockerContainer{
+		DockerID:   dockerID,
+		DockerName: "c1",
+		Container:  &api.Container{},
+	}
+	task := &api.Task{}
+
+	labels := map[string]string{
+		"name": "metadata",
+	}
+	finishedAt := time.Now()
+	gomock.InOrder(
+		client.EXPECT().DescribeContainer(dockerID).Return(api.ContainerStopped,
+			DockerContainerMetadata{
+				Labels:     labels,
+				DockerID:   dockerID,
+				FinishedAt: finishedAt,
+				Error:      NewDockerStateError("failed"),
+				ExitCode:   aws.Int(1),
+			}),
+	)
+	taskEngine.(*DockerTaskEngine).synchronizeContainerStatus(dockerContainer, task)
+	assert.Equal(t, finishedAt, dockerContainer.Container.GetFinishedAt())
+	assert.Equal(t, labels, dockerContainer.Container.GetLabels())
+	assert.Equal(t, 1, aws.IntValue(dockerContainer.Container.GetKnownExitCode()))
+	assert.Error(t, dockerContainer.Container.ApplyingError)
+}

--- a/agent/engine/errors.go
+++ b/agent/engine/errors.go
@@ -24,6 +24,7 @@ import (
 const (
 	dockerTimeoutErrorName          = "DockerTimeoutError"
 	cannotInspectContainerErrorName = "CannotInspectContainerError"
+	cannotDescribeContainerError    = "CannotDescribeContainerError"
 )
 
 // engineError wraps the error interface with an identifier method that
@@ -291,7 +292,7 @@ func (err CannotDescribeContainerError) Error() string {
 }
 
 func (err CannotDescribeContainerError) ErrorName() string {
-	return "CannotDescribeContainerError"
+	return cannotDescribeContainerError
 }
 
 // CannotListContainersError indicates any error when trying to list containers

--- a/agent/functional_tests/tests/functionaltests_test.go
+++ b/agent/functional_tests/tests/functionaltests_test.go
@@ -27,6 +27,7 @@ import (
 	ecsapi "github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
 	. "github.com/aws/amazon-ecs-agent/agent/functional_tests/util"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/stretchr/testify/assert"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Fix the issue where agent could miss the container metadata information(portmapping/exitcode), if the container is started/stopped when the agent isn't running(eg: restart).

### Implementation details
<!-- How are the changes implemented? -->
Record the metadata information during the reconciliation on agent restart.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass
- [x] Manual test:
  - [x] Reproducible with the previous agent, but not with this fix.
  - [x] Container information(port mapping/exit code) correctly submitted to backend.
  - [x] Container information was updated correctly after agent restart while container is created/started/stopped when agent isn't running.

New tests cover the changes: <!-- yes|no -->
yes
### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
yes
