### PR TITLE
Adding integration test for container health check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of
@@ -133,7 +133,7 @@ cni-plugins: get-cni-sources
 		"amazon/amazon-ecs-build-cniplugins:make"
 	@echo "Built amazon-ecs-cni-plugins successfully."
 
-run-integ-tests: test-registry gremlin
+run-integ-tests: test-registry gremlin container-health-check-image
 	. ./scripts/shared_env && go test -race -tags integration -timeout=5m -v ./agent/engine/... ./agent/stats/... ./agent/app/...
 
 netkitten:
@@ -144,7 +144,7 @@ volumes-test:
 
 # TODO, replace this with a build on dockerhub or a mechanism for the
 # functional tests themselves to build this
-.PHONY: squid awscli fluentd gremlin taskmetadata-validator image-cleanup-test-images ecr-execution-role-image
+.PHONY: squid awscli fluentd gremlin taskmetadata-validator image-cleanup-test-images ecr-execution-role-image container-health-check-image
 squid:
 	$(MAKE) -C misc/squid $(MFLAGS)
 
@@ -164,6 +164,9 @@ taskmetadata-validator:
 	$(MAKE) -C misc/taskmetadata-validator $(MFLAGS)
 ecr-execution-role-image:
 	$(MAKE) -C misc/ecr $(MFLAGS)
+
+container-health-check-image:
+	$(MAKE) -C misc/container-health $(MFLAGS)
 
 .get-deps-stamp:
 	go get golang.org/x/tools/cmd/cover
@@ -185,4 +188,5 @@ clean:
 	-$(MAKE) -C misc/testnnp $(MFLAGS) clean
 	-$(MAKE) -C misc/image-cleanup-test-images $(MFLAGS) clean
 	-$(MAKE) -C misc/taskmetadata-validator $(MFLAGS) clean
+	-$(MAKE) -C misc/container-health $(MFLAGS) clean
 	-rm -f .get-deps-stamp

--- a/agent/stats/common_test.go
+++ b/agent/stats/common_test.go
@@ -131,7 +131,7 @@ func validateInstanceMetrics(t *testing.T, engine *DockerStatsEngine) {
 
 	taskMetric := taskMetrics[0]
 	assert.Equal(t, aws.StringValue(taskMetric.TaskDefinitionFamily), taskDefinitionFamily, "unexpected task definition family")
-	assert.Equal(t, aws.StringValue(taskMetric.TaskDefinitionVersion), taskDefinitionVersion, "unexcpected task definition version")
+	assert.Equal(t, aws.StringValue(taskMetric.TaskDefinitionVersion), taskDefinitionVersion, "unexpected task definition version")
 	assert.NoError(t, validateContainerMetrics(taskMetric.ContainerMetrics, 1), "validating container metrics failed")
 }
 
@@ -231,6 +231,8 @@ func validateTaskHealthMetrics(t *testing.T, engine *DockerStatsEngine) {
 }
 
 func validateEmptyTaskHealthMetrics(t *testing.T, engine *DockerStatsEngine) {
+	// If the metrics is empty, no health metrics will be send, the metadata won't be used
+	// no need to check the metadata here
 	_, healthMetrics, err := engine.GetTaskHealthMetrics()
 	assert.NoError(t, err, "getting task health failed")
 	assert.Len(t, healthMetrics, 0, "no health metrics was expected")

--- a/agent/stats/common_test.go
+++ b/agent/stats/common_test.go
@@ -15,20 +15,16 @@ package stats
 
 import (
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
-	ecsengine "github.com/aws/amazon-ecs-agent/agent/engine"
-	"github.com/aws/amazon-ecs-agent/agent/engine/dockerclient"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
 	"github.com/aws/amazon-ecs-agent/agent/statechange"
 	"github.com/aws/amazon-ecs-agent/agent/statemanager"
 	"github.com/aws/amazon-ecs-agent/agent/tcs/model/ecstcs"
-	"github.com/aws/amazon-ecs-agent/agent/utils"
 
 	"github.com/aws/aws-sdk-go/aws"
 	docker "github.com/fsouza/go-dockerclient"
@@ -41,7 +37,6 @@ const (
 	// checkPointSleep is the sleep duration in milliseconds between
 	// starting/stopping containers in the test code.
 	checkPointSleep              = 5 * SleepBetweenUsageDataCollection
-	testImageName                = "amazon/amazon-ecs-gremlin:make"
 	testContainerHealthImageName = "amazon/amazon-ecs-containerhealthcheck:make"
 
 	// defaultDockerTimeoutSeconds is the timeout for dialing the docker remote API.
@@ -57,14 +52,11 @@ const (
 	containerName         = "gremlin-container"
 )
 
-var endpoint = utils.DefaultIfBlank(os.Getenv(ecsengine.DockerEndpointEnvVariable), ecsengine.DockerDefaultEndpoint)
-
-var client, _ = docker.NewClient(endpoint)
-var clientFactory = dockerclient.NewFactory(endpoint)
-var cfg = config.DefaultConfig()
-
-var defaultCluster = "default"
-var defaultContainerInstance = "ci"
+var (
+	cfg                      = config.DefaultConfig()
+	defaultCluster           = "default"
+	defaultContainerInstance = "ci"
+)
 
 func init() {
 	cfg.EngineAuthData = config.NewSensitiveRawMessage([]byte{})

--- a/agent/stats/common_unix_test.go
+++ b/agent/stats/common_unix_test.go
@@ -1,0 +1,33 @@
+//+build !windows
+
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package stats
+
+import (
+	"os"
+
+	ecsengine "github.com/aws/amazon-ecs-agent/agent/engine"
+	"github.com/aws/amazon-ecs-agent/agent/utils"
+
+	"github.com/aws/amazon-ecs-agent/agent/engine/dockerclient"
+	docker "github.com/fsouza/go-dockerclient"
+)
+
+var (
+	testImageName = "amazon/amazon-ecs-gremlin:make"
+	endpoint      = utils.DefaultIfBlank(os.Getenv(ecsengine.DockerEndpointEnvVariable), ecsengine.DockerDefaultEndpoint)
+	client, _     = docker.NewClient(endpoint)
+	clientFactory = dockerclient.NewFactory(endpoint)
+)

--- a/agent/stats/common_windows_test.go
+++ b/agent/stats/common_windows_test.go
@@ -1,0 +1,33 @@
+//+build windows
+
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package stats
+
+import (
+	"os"
+
+	ecsengine "github.com/aws/amazon-ecs-agent/agent/engine"
+	"github.com/aws/amazon-ecs-agent/agent/utils"
+
+	"github.com/aws/amazon-ecs-agent/agent/engine/dockerclient"
+	docker "github.com/fsouza/go-dockerclient"
+)
+
+var (
+	testImageName = "amazon/amazon-ecs-stats:make"
+	endpoint      = utils.DefaultIfBlank(os.Getenv(ecsengine.DockerEndpointEnvVariable), "npipe:////./pipe/docker_engine")
+	client, _     = docker.NewClient(endpoint)
+	clientFactory = dockerclient.NewFactory(endpoint)
+)

--- a/agent/stats/engine.go
+++ b/agent/stats/engine.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/stats/engine.go
+++ b/agent/stats/engine.go
@@ -390,7 +390,7 @@ func (engine *DockerStatsEngine) containerHealthsToMonitor() bool {
 	return len(engine.tasksToHealthCheckContainers) != 0
 }
 
-// stopTrackingContainerUnsafe remove the StatsContaine from stats engine and
+// stopTrackingContainerUnsafe removes the StatsContainer from stats engine and
 // returns true if the container is stopped or no longer tracked in agent. Otherwise
 // it does nothing and return false
 func (engine *DockerStatsEngine) stopTrackingContainerUnsafe(container *StatsContainer, taskARN string) bool {

--- a/agent/stats/engine_integ_test.go
+++ b/agent/stats/engine_integ_test.go
@@ -1,5 +1,5 @@
-//+build !windows,integration
-// Disabled on Windows until Stats are actually supported
+//+build integration
+
 // Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/stats/engine_test.go
+++ b/agent/stats/engine_test.go
@@ -151,18 +151,12 @@ func TestStatsEngineAddRemoveContainers(t *testing.T) {
 	// Should get an error while adding this container due to unmapped
 	// container to task.
 	engine.addAndStartStatsContainer("c4")
-	err = validateIdleContainerMetrics(engine)
-	if err != nil {
-		t.Fatalf("Error validating metadata: %v", err)
-	}
+	validateIdleContainerMetrics(t, engine)
 
 	// Should get an error while adding this container due to unmapped
 	// task arn to task definition family.
 	engine.addAndStartStatsContainer("c6")
-	err = validateIdleContainerMetrics(engine)
-	if err != nil {
-		t.Fatalf("Error validating metadata: %v", err)
-	}
+	validateIdleContainerMetrics(t, engine)
 }
 
 func TestStatsEngineMetadataInStatsSets(t *testing.T) {
@@ -228,10 +222,7 @@ func TestStatsEngineMetadataInStatsSets(t *testing.T) {
 	assert.Equal(t, ts2, dockerStat.Read)
 
 	engine.removeContainer("c1")
-	err = validateIdleContainerMetrics(engine)
-	if err != nil {
-		t.Fatalf("Error validating metadata: %v", err)
-	}
+	validateIdleContainerMetrics(t, engine)
 }
 
 func TestStatsEngineInvalidTaskEngine(t *testing.T) {
@@ -251,10 +242,7 @@ func TestStatsEngineUninitialized(t *testing.T) {
 	engine.cluster = defaultCluster
 	engine.containerInstanceArn = defaultContainerInstance
 	engine.addAndStartStatsContainer("c1")
-	err := validateIdleContainerMetrics(engine)
-	if err != nil {
-		t.Fatalf("Error validating metadata: %v", err)
-	}
+	validateIdleContainerMetrics(t, engine)
 }
 
 func TestStatsEngineTerminalTask(t *testing.T) {
@@ -274,10 +262,7 @@ func TestStatsEngineTerminalTask(t *testing.T) {
 	engine.resolver = resolver
 
 	engine.addAndStartStatsContainer("c1")
-	err := validateIdleContainerMetrics(engine)
-	if err != nil {
-		t.Fatalf("Error validating metadata: %v", err)
-	}
+	validateIdleContainerMetrics(t, engine)
 }
 
 func TestGetTaskHealthMetrics(t *testing.T) {
@@ -350,7 +335,7 @@ func TestGetTaskHealthMetricsStoppedContainer(t *testing.T) {
 
 	engine.resolver = resolver
 	_, _, err := engine.GetTaskHealthMetrics()
-	assert.Error(t, err, "empty metrics should causing error")
+	assert.Error(t, err, "empty metrics should cause an error")
 }
 
 // TestMetricsDisabled tests container won't call docker api to collect stats

--- a/agent/stats/engine_test.go
+++ b/agent/stats/engine_test.go
@@ -1,5 +1,5 @@
 //+build !integration
-// Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/misc/container-health-windows/build.ps1
+++ b/misc/container-health-windows/build.ps1
@@ -1,0 +1,15 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+
+docker build -t "amazon/amazon-ecs-containerhealthcheck:make" -f "${PSScriptRoot}/windows.dockerfile" ${PSScriptRoot}

--- a/misc/container-health-windows/windows.dockerfile
+++ b/misc/container-health-windows/windows.dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+FROM microsoft/windowsservercore:latest
+
+MAINTAINER Amazon Web Services, Inc.
+
+SHELL ["powershell", "-command"]
+
+HEALTHCHECK --interval=1s --timeout=1s --retries=3 CMD echo hello
+
+ENTRYPOINT ["powershell","-command"]
+CMD ["Start-Sleep -s 2000"]

--- a/misc/container-health/Dockerfile
+++ b/misc/container-health/Dockerfile
@@ -1,0 +1,17 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+FROM busybox@sha256:5551dbdfc48d66734d0f01cafee0952cb6e8eeecd1e2492240bf2fd9640c2279
+
+HEALTHCHECK --interval=1s --timeout=1s --retries=3 CMD echo hello
+
+CMD ["sh", "-c", "sleep 30m"]

--- a/misc/container-health/Makefile
+++ b/misc/container-health/Makefile
@@ -1,0 +1,18 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+.PHONY: all clean
+all:
+	docker build -t amazon/amazon-ecs-containerhealthcheck:make .
+
+clean:
+	-docker rmi -f "amazon/amazon-ecs-containerhealthcheck:make"

--- a/misc/stats-windows/build.ps1
+++ b/misc/stats-windows/build.ps1
@@ -1,0 +1,15 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+
+docker build -t "amazon/amazon-ecs-stats:make" -f "${PSScriptRoot}/windows.dockerfile" ${PSScriptRoot}

--- a/misc/stats-windows/windows.dockerfile
+++ b/misc/stats-windows/windows.dockerfile
@@ -1,0 +1,19 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+FROM microsoft/windowsservercore:latest
+
+MAINTAINER Amazon Web Services, Inc.
+
+SHELL ["powershell", "-command"]
+ENTRYPOINT ["powershell","-command"]
+CMD ["Start-Sleep -s 2000"]

--- a/scripts/run-integ-tests.ps1
+++ b/scripts/run-integ-tests.ps1
@@ -14,6 +14,8 @@
 # Prepare dependencies
 Invoke-Expression "${PSScriptRoot}\..\misc\volumes-test\build.ps1"
 Invoke-Expression "${PSScriptRoot}\..\misc\image-cleanup-test-images\build.ps1"
+Invoke-Expression "${PSScriptRoot}\..\misc\stats-windows\build.ps1"
+Invoke-Expression "${PSScriptRoot}\..\misc\container-health-windows\build.ps1"
 
 # Run the tests
 $cwd = (pwd).Path


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Adding integration tests to cover the code path in `agent/stats` for container health check metrics.
### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->
yes
### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
yes