### PR TITLE
enable hierarchy memory limit,  config cgroup root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Bug - Fixed a bug where `-version` fails due to its dependency on docker client. [#1118](https://github.com/aws/amazon-ecs-agent/pull/1118)
 * Bug - Persist container exit code in agent state file [#1125](https://github.com/aws/amazon-ecs-agent/pull/1125)
 * Bug - Fixed a bug where the agent could lose track of running containers when Docker APIs timeout [#1217](https://github.com/aws/amazon-ecs-agent/pull/1217)
+* Bug - Task level memory.use_hierarchy was not being set and memory limits were not being enforced [#1195](https://github.com/aws/amazon-ecs-agent/pull/1195)
 
 ## 1.16.2
 * Bug - Fixed a bug where the ticker would submit empty container state change

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ additional details on each available environment variable.
 | `ECS_ENABLE_CONTAINER_METADATA` | `true` | When `true`, the agent will create a file describing the container's metadata and the file can be located and consumed by using the container enviornment variable `$ECS_CONTAINER_METADATA_FILE` | `false` | `false` |
 | `ECS_HOST_DATA_DIR` | `/var/lib/ecs` | The source directory on the host from which ECS_DATADIR is mounted. We use this to determine the source mount path for container metadata files in the case the ECS Agent is running as a container. We do not use this value in Windows because the ECS Agent is not running as container in Windows. | `/var/lib/ecs` | `Not used` |
 | `ECS_ENABLE_TASK_CPU_MEM_LIMIT` | `true` | Whether to enable task-level cpu and memory limits | `true` | `false` |
+| `ECS_CGROUP_MEMORY_SUBSYSTEM_PATH` | `/sys/fs/cgroup/memory/` | The root path of the cgroup memory subsystem  | `/sys/fs/cgroup/memory/` | Not applicable |
 
 ### Persistence
 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ additional details on each available environment variable.
 | `ECS_ENABLE_CONTAINER_METADATA` | `true` | When `true`, the agent will create a file describing the container's metadata and the file can be located and consumed by using the container enviornment variable `$ECS_CONTAINER_METADATA_FILE` | `false` | `false` |
 | `ECS_HOST_DATA_DIR` | `/var/lib/ecs` | The source directory on the host from which ECS_DATADIR is mounted. We use this to determine the source mount path for container metadata files in the case the ECS Agent is running as a container. We do not use this value in Windows because the ECS Agent is not running as container in Windows. | `/var/lib/ecs` | `Not used` |
 | `ECS_ENABLE_TASK_CPU_MEM_LIMIT` | `true` | Whether to enable task-level cpu and memory limits | `true` | `false` |
-| `ECS_CGROUP_MEMORY_SUBSYSTEM_PATH` | `/sys/fs/cgroup/memory/` | The root path of the cgroup memory subsystem  | `/sys/fs/cgroup/memory/` | Not applicable |
+| `ECS_CGROUP_PATH` | `/sys/fs/cgroup` | The root cgroup path that is expected by the ECS agent. This is the path that accessible from the agent mount. | `/sys/fs/cgroup` | Not applicable |
 
 ### Persistence
 

--- a/agent/acs/update_handler/updater_test.go
+++ b/agent/acs/update_handler/updater_test.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -105,7 +105,8 @@ func TestPerformUpdateWithUpdatesDisabled(t *testing.T) {
 		Reason:            ptr("Updates are disabled").(*string),
 	}})
 
-	u.performUpdateHandler(statemanager.NewNoopStateManager(), engine.NewTaskEngine(cfg, nil, nil, nil, nil, nil, nil, nil))(&ecsacs.PerformUpdateMessage{
+	taskEngine := engine.NewTaskEngine(cfg, nil, nil, nil, nil, nil, nil, nil)
+	msg := &ecsacs.PerformUpdateMessage{
 		ClusterArn:           ptr("cluster").(*string),
 		ContainerInstanceArn: ptr("containerInstance").(*string),
 		MessageId:            ptr("mid").(*string),
@@ -113,7 +114,9 @@ func TestPerformUpdateWithUpdatesDisabled(t *testing.T) {
 			Location:  ptr("https://s3.amazonaws.com/amazon-ecs-agent/update.tar").(*string),
 			Signature: ptr("c54518806ff4d14b680c35784113e1e7478491fe").(*string),
 		},
-	})
+	}
+
+	u.performUpdateHandler(statemanager.NewNoopStateManager(), taskEngine)(msg)
 }
 
 func TestFullUpdateFlow(t *testing.T) {
@@ -159,7 +162,8 @@ func TestFullUpdateFlow(t *testing.T) {
 
 			require.Equal(t, "update-tar-data", writtenFile.String(), "incorrect data written")
 
-			u.performUpdateHandler(statemanager.NewNoopStateManager(), engine.NewTaskEngine(cfg, nil, nil, nil, nil, nil, nil, nil))(&ecsacs.PerformUpdateMessage{
+			taskEngine := engine.NewTaskEngine(cfg, nil, nil, nil, nil, nil, nil, nil)
+			msg := &ecsacs.PerformUpdateMessage{
 				ClusterArn:           ptr("cluster").(*string),
 				ContainerInstanceArn: ptr("containerInstance").(*string),
 				MessageId:            ptr("mid2").(*string),
@@ -167,7 +171,9 @@ func TestFullUpdateFlow(t *testing.T) {
 					Location:  ptr("https://" + host + "/amazon-ecs-agent/update.tar").(*string),
 					Signature: ptr("c54518806ff4d14b680c35784113e1e7478491fe").(*string),
 				},
-			})
+			}
+
+			u.performUpdateHandler(statemanager.NewNoopStateManager(), taskEngine)(msg)
 		})
 	}
 }
@@ -224,11 +230,14 @@ func TestUndownloadedUpdate(t *testing.T) {
 		MessageId:         ptr("mid").(*string),
 	}})
 
-	u.performUpdateHandler(statemanager.NewNoopStateManager(), engine.NewTaskEngine(cfg, nil, nil, nil, nil, nil, nil, nil))(&ecsacs.PerformUpdateMessage{
+	taskEngine := engine.NewTaskEngine(cfg, nil, nil, nil, nil, nil, nil, nil)
+	msg := &ecsacs.PerformUpdateMessage{
 		ClusterArn:           ptr("cluster").(*string),
 		ContainerInstanceArn: ptr("containerInstance").(*string),
 		MessageId:            ptr("mid").(*string),
-	})
+	}
+
+	u.performUpdateHandler(statemanager.NewNoopStateManager(), taskEngine)(msg)
 }
 
 func TestDuplicateUpdateMessagesWithSuccess(t *testing.T) {
@@ -282,7 +291,8 @@ func TestDuplicateUpdateMessagesWithSuccess(t *testing.T) {
 
 	require.Equal(t, "update-tar-data", writtenFile.String(), "incorrect data written")
 
-	u.performUpdateHandler(statemanager.NewNoopStateManager(), engine.NewTaskEngine(cfg, nil, nil, nil, nil, nil, nil, nil))(&ecsacs.PerformUpdateMessage{
+	taskEngine := engine.NewTaskEngine(cfg, nil, nil, nil, nil, nil, nil, nil)
+	msg := &ecsacs.PerformUpdateMessage{
 		ClusterArn:           ptr("cluster").(*string),
 		ContainerInstanceArn: ptr("containerInstance").(*string),
 		MessageId:            ptr("mid3").(*string),
@@ -290,7 +300,9 @@ func TestDuplicateUpdateMessagesWithSuccess(t *testing.T) {
 			Location:  ptr("https://s3.amazonaws.com/amazon-ecs-agent/update.tar").(*string),
 			Signature: ptr("c54518806ff4d14b680c35784113e1e7478491fe").(*string),
 		},
-	})
+	}
+
+	u.performUpdateHandler(statemanager.NewNoopStateManager(), taskEngine)(msg)
 }
 
 func TestDuplicateUpdateMessagesWithFailure(t *testing.T) {
@@ -347,7 +359,8 @@ func TestDuplicateUpdateMessagesWithFailure(t *testing.T) {
 
 	require.Equal(t, "update-tar-data", writtenFile.String(), "incorrect data written")
 
-	u.performUpdateHandler(statemanager.NewNoopStateManager(), engine.NewTaskEngine(cfg, nil, nil, nil, nil, nil, nil, nil))(&ecsacs.PerformUpdateMessage{
+	taskEngine := engine.NewTaskEngine(cfg, nil, nil, nil, nil, nil, nil, nil)
+	msg := &ecsacs.PerformUpdateMessage{
 		ClusterArn:           ptr("cluster").(*string),
 		ContainerInstanceArn: ptr("containerInstance").(*string),
 		MessageId:            ptr("mid3").(*string),
@@ -355,7 +368,9 @@ func TestDuplicateUpdateMessagesWithFailure(t *testing.T) {
 			Location:  ptr("https://s3.amazonaws.com/amazon-ecs-agent/update.tar").(*string),
 			Signature: ptr("c54518806ff4d14b680c35784113e1e7478491fe").(*string),
 		},
-	})
+	}
+
+	u.performUpdateHandler(statemanager.NewNoopStateManager(), taskEngine)(msg)
 }
 
 func TestNewerUpdateMessages(t *testing.T) {
@@ -420,7 +435,8 @@ func TestNewerUpdateMessages(t *testing.T) {
 
 	require.Equal(t, "newer-update-tar-data", writtenFile.String(), "incorrect data written")
 
-	u.performUpdateHandler(statemanager.NewNoopStateManager(), engine.NewTaskEngine(cfg, nil, nil, nil, nil, nil, nil, nil))(&ecsacs.PerformUpdateMessage{
+	taskEngine := engine.NewTaskEngine(cfg, nil, nil, nil, nil, nil, nil, nil)
+	msg := &ecsacs.PerformUpdateMessage{
 		ClusterArn:           ptr("cluster").(*string),
 		ContainerInstanceArn: ptr("containerInstance").(*string),
 		MessageId:            ptr("mid2").(*string),
@@ -428,7 +444,9 @@ func TestNewerUpdateMessages(t *testing.T) {
 			Location:  ptr("https://s3.amazonaws.com/amazon-ecs-agent/update.tar").(*string),
 			Signature: ptr("c54518806ff4d14b680c35784113e1e7478491fe").(*string),
 		},
-	})
+	}
+
+	u.performUpdateHandler(statemanager.NewNoopStateManager(), taskEngine)(msg)
 }
 
 func TestValidationError(t *testing.T) {

--- a/agent/acs/update_handler/updater_test.go
+++ b/agent/acs/update_handler/updater_test.go
@@ -105,7 +105,7 @@ func TestPerformUpdateWithUpdatesDisabled(t *testing.T) {
 		Reason:            ptr("Updates are disabled").(*string),
 	}})
 
-	u.performUpdateHandler(statemanager.NewNoopStateManager(), engine.NewTaskEngine(cfg, nil, nil, nil, nil, nil, nil))(&ecsacs.PerformUpdateMessage{
+	u.performUpdateHandler(statemanager.NewNoopStateManager(), engine.NewTaskEngine(cfg, nil, nil, nil, nil, nil, nil, nil))(&ecsacs.PerformUpdateMessage{
 		ClusterArn:           ptr("cluster").(*string),
 		ContainerInstanceArn: ptr("containerInstance").(*string),
 		MessageId:            ptr("mid").(*string),
@@ -159,7 +159,7 @@ func TestFullUpdateFlow(t *testing.T) {
 
 			require.Equal(t, "update-tar-data", writtenFile.String(), "incorrect data written")
 
-			u.performUpdateHandler(statemanager.NewNoopStateManager(), engine.NewTaskEngine(cfg, nil, nil, nil, nil, nil, nil))(&ecsacs.PerformUpdateMessage{
+			u.performUpdateHandler(statemanager.NewNoopStateManager(), engine.NewTaskEngine(cfg, nil, nil, nil, nil, nil, nil, nil))(&ecsacs.PerformUpdateMessage{
 				ClusterArn:           ptr("cluster").(*string),
 				ContainerInstanceArn: ptr("containerInstance").(*string),
 				MessageId:            ptr("mid2").(*string),
@@ -224,7 +224,7 @@ func TestUndownloadedUpdate(t *testing.T) {
 		MessageId:         ptr("mid").(*string),
 	}})
 
-	u.performUpdateHandler(statemanager.NewNoopStateManager(), engine.NewTaskEngine(cfg, nil, nil, nil, nil, nil, nil))(&ecsacs.PerformUpdateMessage{
+	u.performUpdateHandler(statemanager.NewNoopStateManager(), engine.NewTaskEngine(cfg, nil, nil, nil, nil, nil, nil, nil))(&ecsacs.PerformUpdateMessage{
 		ClusterArn:           ptr("cluster").(*string),
 		ContainerInstanceArn: ptr("containerInstance").(*string),
 		MessageId:            ptr("mid").(*string),
@@ -282,7 +282,7 @@ func TestDuplicateUpdateMessagesWithSuccess(t *testing.T) {
 
 	require.Equal(t, "update-tar-data", writtenFile.String(), "incorrect data written")
 
-	u.performUpdateHandler(statemanager.NewNoopStateManager(), engine.NewTaskEngine(cfg, nil, nil, nil, nil, nil, nil))(&ecsacs.PerformUpdateMessage{
+	u.performUpdateHandler(statemanager.NewNoopStateManager(), engine.NewTaskEngine(cfg, nil, nil, nil, nil, nil, nil, nil))(&ecsacs.PerformUpdateMessage{
 		ClusterArn:           ptr("cluster").(*string),
 		ContainerInstanceArn: ptr("containerInstance").(*string),
 		MessageId:            ptr("mid3").(*string),
@@ -347,7 +347,7 @@ func TestDuplicateUpdateMessagesWithFailure(t *testing.T) {
 
 	require.Equal(t, "update-tar-data", writtenFile.String(), "incorrect data written")
 
-	u.performUpdateHandler(statemanager.NewNoopStateManager(), engine.NewTaskEngine(cfg, nil, nil, nil, nil, nil, nil))(&ecsacs.PerformUpdateMessage{
+	u.performUpdateHandler(statemanager.NewNoopStateManager(), engine.NewTaskEngine(cfg, nil, nil, nil, nil, nil, nil, nil))(&ecsacs.PerformUpdateMessage{
 		ClusterArn:           ptr("cluster").(*string),
 		ContainerInstanceArn: ptr("containerInstance").(*string),
 		MessageId:            ptr("mid3").(*string),
@@ -420,7 +420,7 @@ func TestNewerUpdateMessages(t *testing.T) {
 
 	require.Equal(t, "newer-update-tar-data", writtenFile.String(), "incorrect data written")
 
-	u.performUpdateHandler(statemanager.NewNoopStateManager(), engine.NewTaskEngine(cfg, nil, nil, nil, nil, nil, nil))(&ecsacs.PerformUpdateMessage{
+	u.performUpdateHandler(statemanager.NewNoopStateManager(), engine.NewTaskEngine(cfg, nil, nil, nil, nil, nil, nil, nil))(&ecsacs.PerformUpdateMessage{
 		ClusterArn:           ptr("cluster").(*string),
 		ContainerInstanceArn: ptr("containerInstance").(*string),
 		MessageId:            ptr("mid2").(*string),

--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -145,6 +145,9 @@ func newAgent(
 		metadataManager = containermetadata.NewManager(dockerClient, cfg)
 	}
 
+	resource := resources.New()
+	resource.ApplyConfigDependencies(cfg)
+
 	return &ecsAgent{
 		ctx:               ctx,
 		ec2MetadataClient: ec2MetadataClient,
@@ -163,7 +166,7 @@ func newAgent(
 		}),
 		os:                 oswrapper.New(),
 		metadataManager:    metadataManager,
-		resource:           resources.New(),
+		resource:           resource,
 		terminationHandler: sighandlers.StartDefaultTerminationHandler,
 	}, nil
 }

--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -311,13 +311,13 @@ func (agent *ecsAgent) newTaskEngine(containerChangeEventStream *eventstream.Eve
 	if !agent.cfg.Checkpoint {
 		seelog.Info("Checkpointing not enabled; a new container instance will be created each time the agent is run")
 		return engine.NewTaskEngine(agent.cfg, agent.dockerClient,
-			credentialsManager, containerChangeEventStream, imageManager, state, agent.metadataManager), "", nil
+			credentialsManager, containerChangeEventStream, imageManager, state, agent.metadataManager, agent.resource), "", nil
 	}
 
 	// We try to set these values by loading the existing state file first
 	var previousCluster, previousEC2InstanceID, previousContainerInstanceArn string
 	previousTaskEngine := engine.NewTaskEngine(agent.cfg, agent.dockerClient,
-		credentialsManager, containerChangeEventStream, imageManager, state, agent.metadataManager)
+		credentialsManager, containerChangeEventStream, imageManager, state, agent.metadataManager, agent.resource)
 
 	// previousStateManager is used to verify that our current runtime configuration is
 	// compatible with our past configuration as reflected by our state-file
@@ -349,7 +349,7 @@ func (agent *ecsAgent) newTaskEngine(containerChangeEventStream *eventstream.Eve
 		state.Reset()
 		// Reset taskEngine; all the other values are still default
 		return engine.NewTaskEngine(agent.cfg, agent.dockerClient, credentialsManager,
-			containerChangeEventStream, imageManager, state, agent.metadataManager), currentEC2InstanceID, nil
+			containerChangeEventStream, imageManager, state, agent.metadataManager, agent.resource), currentEC2InstanceID, nil
 	}
 
 	if previousCluster != "" {

--- a/agent/app/agent_test.go
+++ b/agent/app/agent_test.go
@@ -170,6 +170,8 @@ func TestDoStartTaskLimitsFail(t *testing.T) {
 		saveableOptionFactory.EXPECT().AddSaveable(gomock.Any(), gomock.Any()).AnyTimes(),
 		stateManagerFactory.EXPECT().NewStateManager(gomock.Any(), gomock.Any(), gomock.Any(),
 			gomock.Any(), gomock.Any()).Return(statemanager.NewNoopStateManager(), nil),
+
+		resource.EXPECT().ApplyConfigDependencies(gomock.Any()).AnyTimes(),
 		resource.EXPECT().Init().Return(errors.New("test error")),
 	)
 

--- a/agent/app/agent_test.go
+++ b/agent/app/agent_test.go
@@ -171,7 +171,7 @@ func TestDoStartTaskLimitsFail(t *testing.T) {
 		stateManagerFactory.EXPECT().NewStateManager(gomock.Any(), gomock.Any(), gomock.Any(),
 			gomock.Any(), gomock.Any()).Return(statemanager.NewNoopStateManager(), nil),
 
-		resource.EXPECT().ApplyConfigDependencies(gomock.Any()).AnyTimes(),
+		resource.EXPECT().ApplyConfigDependencies(gomock.Any()).MinTimes(1),
 		resource.EXPECT().Init().Return(errors.New("test error")),
 	)
 

--- a/agent/app/agent_unix_test.go
+++ b/agent/app/agent_unix_test.go
@@ -466,6 +466,7 @@ func TestDoStartCgroupInitHappyPath(t *testing.T) {
 	mockCredentialsProvider.EXPECT().IsExpired().Return(false).AnyTimes()
 
 	gomock.InOrder(
+		mockResource.EXPECT().ApplyConfigDependencies(gomock.Any()),
 		mockResource.EXPECT().Init().Return(nil),
 		mockCredentialsProvider.EXPECT().Retrieve().Return(credentials.Value{}, nil),
 		dockerClient.EXPECT().SupportedVersions().Return(nil),
@@ -527,6 +528,7 @@ func TestDoStartCgroupInitErrorPath(t *testing.T) {
 	imageManager.EXPECT().StartImageCleanupProcess(gomock.Any()).MaxTimes(1)
 	mockCredentialsProvider.EXPECT().IsExpired().Return(false).AnyTimes()
 
+	mockResource.EXPECT().ApplyConfigDependencies(gomock.Any())
 	mockResource.EXPECT().Init().Return(errors.New("cgroup init error"))
 
 	cfg := getTestConfig()

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -280,7 +280,7 @@ func environmentConfig() (Config, error) {
 
 	dockerStopTimeout := getDockerStopTimeout()
 
-	cgroupMemorySubsystemPath := os.Getenv("ECS_CGROUP_MEMORY_SUBSYSTEM_PATH")
+	cgroupPath := os.Getenv("ECS_CGROUP_PATH")
 
 	taskCleanupWaitDuration := parseEnvVariableDuration("ECS_ENGINE_TASK_CLEANUP_WAIT_DURATION")
 
@@ -390,7 +390,7 @@ func environmentConfig() (Config, error) {
 		ContainerMetadataEnabled:         containerMetadataEnabled,
 		DataDirOnHost:                    dataDirOnHost,
 		OverrideAWSLogsExecutionRole:     overrideAWSLogsExecutionRoleEnabled,
-		CgroupMemorySubsystemPath:        cgroupMemorySubsystemPath,
+		CgroupPath:                       cgroupPath,
 	}, err
 }
 

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -280,6 +280,8 @@ func environmentConfig() (Config, error) {
 
 	dockerStopTimeout := getDockerStopTimeout()
 
+	cgroupMemorySubsystemPath := os.Getenv("ECS_CGROUP_MEMORY_SUBSYSTEM_PATH")
+
 	taskCleanupWaitDuration := parseEnvVariableDuration("ECS_ENGINE_TASK_CLEANUP_WAIT_DURATION")
 
 	availableLoggingDriversEnv := os.Getenv("ECS_AVAILABLE_LOGGING_DRIVERS")
@@ -388,6 +390,7 @@ func environmentConfig() (Config, error) {
 		ContainerMetadataEnabled:         containerMetadataEnabled,
 		DataDirOnHost:                    dataDirOnHost,
 		OverrideAWSLogsExecutionRole:     overrideAWSLogsExecutionRoleEnabled,
+		CgroupMemorySubsystemPath:        cgroupMemorySubsystemPath,
 	}, err
 }
 

--- a/agent/config/config_unix.go
+++ b/agent/config/config_unix.go
@@ -1,5 +1,5 @@
 // +build !windows
-// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -29,8 +29,8 @@ const (
 	DefaultTaskCgroupPrefix = "/ecs"
 
 	// Default cgroup memory system root path, this is the default used if the
-	// path has not been configured through ECS_CGROUP_MEMORY_SUBSYSTEM_PATH
-	defaultCgroupMemorySubsystemPath = "/sys/fs/cgroup/memory/"
+	// path has not been configured through ECS_CGROUP_PATH
+	defaultCgroupPath = "/sys/fs/cgroup"
 )
 
 // DefaultConfig returns the default configuration for Linux
@@ -59,7 +59,7 @@ func DefaultConfig() Config {
 		AWSVPCBlockInstanceMetdata:  false,
 		ContainerMetadataEnabled:    false,
 		TaskCPUMemLimit:             DefaultEnabled,
-		CgroupMemorySubsystemPath:   defaultCgroupMemorySubsystemPath,
+		CgroupPath:                  defaultCgroupPath,
 	}
 }
 

--- a/agent/config/config_unix.go
+++ b/agent/config/config_unix.go
@@ -27,6 +27,8 @@ const (
 	defaultCredentialsAuditLogFile = "/log/audit.log"
 	// Default cgroup prefix for ECS tasks
 	DefaultTaskCgroupPrefix = "/ecs"
+
+	defaultCgroupMemorySubsystemPath = "/sys/fs/cgroup/memory/"
 )
 
 // DefaultConfig returns the default configuration for Linux
@@ -55,6 +57,7 @@ func DefaultConfig() Config {
 		AWSVPCBlockInstanceMetdata:  false,
 		ContainerMetadataEnabled:    false,
 		TaskCPUMemLimit:             DefaultEnabled,
+		CgroupMemorySubsystemPath:   defaultCgroupMemorySubsystemPath,
 	}
 }
 

--- a/agent/config/config_unix.go
+++ b/agent/config/config_unix.go
@@ -28,6 +28,8 @@ const (
 	// Default cgroup prefix for ECS tasks
 	DefaultTaskCgroupPrefix = "/ecs"
 
+	// Default cgroup memory system root path, this is the default used if the
+	// path has not been configured through ECS_CGROUP_MEMORY_SUBSYSTEM_PATH
 	defaultCgroupMemorySubsystemPath = "/sys/fs/cgroup/memory/"
 )
 

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -194,4 +194,6 @@ type Config struct {
 	// OverrideAWSLogsExecutionRole is config option used to enable awslogs
 	// driver authentication over the task's execution role
 	OverrideAWSLogsExecutionRole bool
+
+	CgroupMemorySubsystemPath string
 }

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -195,6 +195,7 @@ type Config struct {
 	// driver authentication over the task's execution role
 	OverrideAWSLogsExecutionRole bool
 
-	// The expected Cgroup root path in the agent
+	// CgroupPath is the path expected by the agent, defaults to
+	// '/sys/fs/cgroup'
 	CgroupPath string
 }

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -195,5 +195,6 @@ type Config struct {
 	// driver authentication over the task's execution role
 	OverrideAWSLogsExecutionRole bool
 
-	CgroupMemorySubsystemPath string
+	// The expected Cgroup root path in the agent
+	CgroupPath string
 }

--- a/agent/engine/default.go
+++ b/agent/engine/default.go
@@ -31,5 +31,10 @@ func NewTaskEngine(cfg *config.Config, client DockerClient,
 	imageManager ImageManager, state dockerstate.TaskEngineState,
 	metadataManager containermetadata.Manager,
 	resource resources.Resource) TaskEngine {
-	return NewDockerTaskEngine(cfg, client, credentialsManager, containerChangeEventStream, imageManager, state, metadataManager, resource)
+
+	taskEngine := NewDockerTaskEngine(cfg, client, credentialsManager,
+		containerChangeEventStream, imageManager,
+		state, metadataManager, resource)
+
+	return taskEngine
 }

--- a/agent/engine/default.go
+++ b/agent/engine/default.go
@@ -21,6 +21,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/credentials"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
+	"github.com/aws/amazon-ecs-agent/agent/resources"
 )
 
 // NewTaskEngine returns a default TaskEngine
@@ -28,6 +29,7 @@ func NewTaskEngine(cfg *config.Config, client DockerClient,
 	credentialsManager credentials.Manager,
 	containerChangeEventStream *eventstream.EventStream,
 	imageManager ImageManager, state dockerstate.TaskEngineState,
-	metadataManager containermetadata.Manager) TaskEngine {
-	return NewDockerTaskEngine(cfg, client, credentialsManager, containerChangeEventStream, imageManager, state, metadataManager)
+	metadataManager containermetadata.Manager,
+	resource resources.Resource) TaskEngine {
+	return NewDockerTaskEngine(cfg, client, credentialsManager, containerChangeEventStream, imageManager, state, metadataManager, resource)
 }

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -119,7 +119,8 @@ type DockerTaskEngine struct {
 func NewDockerTaskEngine(cfg *config.Config, client DockerClient,
 	credentialsManager credentials.Manager, containerChangeEventStream *eventstream.EventStream,
 	imageManager ImageManager, state dockerstate.TaskEngineState,
-	metadataManager containermetadata.Manager) *DockerTaskEngine {
+	metadataManager containermetadata.Manager,
+	resource resources.Resource) *DockerTaskEngine {
 	dockerTaskEngine := &DockerTaskEngine{
 		cfg:    cfg,
 		client: client,
@@ -142,7 +143,7 @@ func NewDockerTaskEngine(cfg *config.Config, client DockerClient,
 		}),
 
 		metadataManager: metadataManager,
-		resource:        resources.New(),
+		resource:        resource,
 	}
 
 	dockerTaskEngine.initializeContainerStatusToTransitionFunction()

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -470,6 +470,8 @@ func TestRemoveEvents(t *testing.T) {
 			eventStream <- createDockerEvent(api.ContainerStopped)
 			eventStream <- createDockerEvent(api.ContainerStopped)
 		}).Return(nil)
+
+	client.EXPECT().StopContainer(gomock.Any(), gomock.Any()).AnyTimes()
 	imageManager.EXPECT().RemoveContainerReferenceFromImageState(gomock.Any())
 
 	// This ensures that managedTask.waitForStopReported makes progress

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -105,8 +105,10 @@ func mocks(t *testing.T, ctx context.Context, cfg *config.Config) (*gomock.Contr
 	containerChangeEventStream.StartListening()
 	imageManager := NewMockImageManager(ctrl)
 	metadataManager := mock_containermetadata.NewMockManager(ctrl)
+	mockResource := mock_resources.NewMockResource(ctrl)
+
 	taskEngine := NewTaskEngine(cfg, client, credentialsManager, containerChangeEventStream,
-		imageManager, dockerstate.NewTaskEngineState(), metadataManager)
+		imageManager, dockerstate.NewTaskEngineState(), metadataManager, mockResource)
 	taskEngine.(*DockerTaskEngine)._time = mockTime
 
 	return ctrl, client, mockTime, taskEngine, credentialsManager, imageManager, metadataManager

--- a/agent/engine/engine_integ_test.go
+++ b/agent/engine/engine_integ_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerclient"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
+	"github.com/aws/amazon-ecs-agent/agent/resources"
 	"github.com/aws/amazon-ecs-agent/agent/statemanager"
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/stretchr/testify/assert"
@@ -84,9 +85,11 @@ func setup(cfg *config.Config, t *testing.T) (TaskEngine, func(), credentials.Ma
 	imageManager := NewImageManager(cfg, dockerClient, state)
 	imageManager.SetSaver(statemanager.NewNoopStateManager())
 	metadataManager := containermetadata.NewManager(dockerClient, cfg)
+	resource := resources.New()
+	resource.ApplyConfigDependencies(cfg)
 
 	taskEngine := NewDockerTaskEngine(cfg, dockerClient, credentialsManager,
-		eventstream.NewEventStream("ENGINEINTEGTEST", context.Background()), imageManager, state, metadataManager)
+		eventstream.NewEventStream("ENGINEINTEGTEST", context.Background()), imageManager, state, metadataManager, resource)
 	taskEngine.Init(context.TODO())
 	return taskEngine, func() {
 		taskEngine.Shutdown()

--- a/agent/functional_tests/testdata/taskdefinitions/oom-task/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/oom-task/task-definition.json
@@ -1,6 +1,6 @@
 {
   "family": "ecsftest-oom-task",
-  "memory": "256",
+  "memory": "64",
   "containerDefinitions": [{
     "essential": true,
     "name": "error",

--- a/agent/functional_tests/testdata/taskdefinitions/oom-task/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/oom-task/task-definition.json
@@ -1,0 +1,12 @@
+{
+  "family": "ecsftest-oom-task",
+  "memory": "256",
+  "containerDefinitions": [{
+    "essential": true,
+    "name": "error",
+    "cpu": 1,
+    "image": "127.0.0.1:51670/python:2",
+    "command": ["python", "-c", "foo=' '*1024*1024*1024; import time; time.sleep(10)"]
+  }]
+}
+

--- a/agent/functional_tests/tests/functionaltests_unix_test.go
+++ b/agent/functional_tests/tests/functionaltests_unix_test.go
@@ -98,6 +98,17 @@ func TestOOMContainer(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// TestOOMTask verifies that a task with a memory limit returns an error
+func TestOOMTask(t *testing.T) {
+	agent := RunAgent(t, nil)
+	defer agent.Cleanup()
+
+	testTask, err := agent.StartTask(t, "oom-task")
+	require.NoError(t, err, "Expected to start invalid-image task")
+	err = testTask.ExpectErrorType("error", "OutOfMemoryError", 1*time.Minute)
+	assert.NoError(t, err)
+}
+
 func strptr(s string) *string { return &s }
 
 func TestCommandOverrides(t *testing.T) {

--- a/agent/functional_tests/tests/functionaltests_unix_test.go
+++ b/agent/functional_tests/tests/functionaltests_unix_test.go
@@ -103,6 +103,8 @@ func TestOOMTask(t *testing.T) {
 	agent := RunAgent(t, nil)
 	defer agent.Cleanup()
 
+	agent.RequireVersion(">=1.16.0")
+
 	testTask, err := agent.StartTask(t, "oom-task")
 	require.NoError(t, err, "Expected to start invalid-image task")
 	err = testTask.ExpectErrorType("error", "OutOfMemoryError", 1*time.Minute)

--- a/agent/functional_tests/util/utils_unix.go
+++ b/agent/functional_tests/util/utils_unix.go
@@ -32,15 +32,16 @@ import (
 )
 
 const (
-	defaultExecDriverPath = "/var/run/docker/execdriver"
-	logdir                = "/log"
-	datadir               = "/data"
-	ExecDriverDir         = "/var/lib/docker/execdriver"
-	defaultCgroupPath     = "/cgroup"
-	cacheDirectory        = "/var/cache/ecs"
-	configDirectory       = "/etc/ecs"
-	readOnly              = ":ro"
-	dockerEndpoint        = "/var/run"
+	defaultExecDriverPath       = "/var/run/docker/execdriver"
+	logdir                      = "/log"
+	datadir                     = "/data"
+	ExecDriverDir               = "/var/lib/docker/execdriver"
+	defaultCgroupPath           = "/cgroup"
+	defaultCgroupPathAgentMount = "/sys/fs/cgroup"
+	cacheDirectory              = "/var/cache/ecs"
+	configDirectory             = "/etc/ecs"
+	readOnly                    = ":ro"
+	dockerEndpoint              = "/var/run"
 )
 
 var ECS *ecs.ECS
@@ -241,7 +242,7 @@ func (agent *TestAgent) StartAgent() error {
 func (agent *TestAgent) getBindMounts() []string {
 	var binds []string
 	cgroupPath := utils.DefaultIfBlank(os.Getenv("CGROUP_PATH"), defaultCgroupPath)
-	cgroupBind := cgroupPath + ":" + cgroupPath + readOnly
+	cgroupBind := cgroupPath + ":" + defaultCgroupPathAgentMount
 	binds = append(binds, cgroupBind)
 
 	execdriverPath := utils.DefaultIfBlank(os.Getenv("EXECDRIVER_PATH"), defaultExecDriverPath)

--- a/agent/resources/interface.go
+++ b/agent/resources/interface.go
@@ -27,6 +27,6 @@ type Resource interface {
 	Setup(task *api.Task) error
 	// Cleanup removes the resource
 	Cleanup(task *api.Task) error
-
+	// ApplyConfigDependencies applies config parameters for the resources
 	ApplyConfigDependencies(cfg *config.Config)
 }

--- a/agent/resources/interface.go
+++ b/agent/resources/interface.go
@@ -15,6 +15,7 @@ package resources
 
 import (
 	"github.com/aws/amazon-ecs-agent/agent/api"
+	"github.com/aws/amazon-ecs-agent/agent/config"
 )
 
 // Resource interface to interact with platform level resource constructs
@@ -26,4 +27,6 @@ type Resource interface {
 	Setup(task *api.Task) error
 	// Cleanup removes the resource
 	Cleanup(task *api.Task) error
+
+	ApplyConfigDependencies(cfg *config.Config)
 }

--- a/agent/resources/mock_resources/mock_resource.go
+++ b/agent/resources/mock_resources/mock_resource.go
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -18,6 +18,7 @@ package mock_resources
 
 import (
 	api "github.com/aws/amazon-ecs-agent/agent/api"
+	config "github.com/aws/amazon-ecs-agent/agent/config"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -40,6 +41,14 @@ func NewMockResource(ctrl *gomock.Controller) *MockResource {
 
 func (_m *MockResource) EXPECT() *_MockResourceRecorder {
 	return _m.recorder
+}
+
+func (_m *MockResource) ApplyConfigDependencies(_param0 *config.Config) {
+	_m.ctrl.Call(_m, "ApplyConfigDependencies", _param0)
+}
+
+func (_mr *_MockResourceRecorder) ApplyConfigDependencies(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ApplyConfigDependencies", arg0)
 }
 
 func (_m *MockResource) Cleanup(_param0 *api.Task) error {

--- a/agent/resources/resources_linux.go
+++ b/agent/resources/resources_linux.go
@@ -32,6 +32,7 @@ import (
 const (
 	memorySubsystem    = "/memory"
 	memoryUseHierarchy = "memory.use_hierarchy"
+	rootReadOnly       = 400
 )
 
 // cgroupWrapper implements the Resource interface
@@ -72,7 +73,8 @@ func (c *cgroupWrapper) ApplyConfigDependencies(cfg *config.Config) {
 	c.cgroupPath = cfg.CgroupPath
 }
 
-// cgroupInit is used to create the root '/ecs/ cgroup
+// cgroupInit is used to create the root '/ecs/ cgroup and enable
+// memory.use_hierarchy at the '/ecs/' level
 func (c *cgroupWrapper) cgroupInit() error {
 	if c.control.Exists(config.DefaultTaskCgroupPrefix) {
 		seelog.Debugf("Cgroup at %s already exists, skipping creation", config.DefaultTaskCgroupPrefix)

--- a/agent/resources/resources_linux_test.go
+++ b/agent/resources/resources_linux_test.go
@@ -17,7 +17,6 @@ package resources
 
 import (
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"

--- a/agent/resources/resources_linux_test.go
+++ b/agent/resources/resources_linux_test.go
@@ -91,9 +91,9 @@ func TestSetupHappyPath(t *testing.T) {
 	mockIO := mock_ioutilwrapper.NewMockIOUtil(ctrl)
 
 	task := testdata.LoadTask("sleep5TaskCgroup")
-	taskid, err := task.GetID()
+	taskID, err := task.GetID()
 	assert.NoError(t, err)
-	cgroupPath := fmt.Sprintf("/sys/fs/cgroup/memory/ecs/%s/memory.use_hierarchy", taskid)
+	cgroupPath := fmt.Sprintf("/sys/fs/cgroup/memory/ecs/%s/memory.use_hierarchy", taskID)
 
 	gomock.InOrder(
 		mockControl.EXPECT().Exists(gomock.Any()).Return(false),

--- a/agent/resources/resources_linux_test.go
+++ b/agent/resources/resources_linux_test.go
@@ -17,6 +17,7 @@ package resources
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"

--- a/agent/resources/resources_linux_test.go
+++ b/agent/resources/resources_linux_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
+	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/engine/testdata"
 	"github.com/aws/amazon-ecs-agent/agent/resources/cgroup/factory/mock"
 	"github.com/aws/amazon-ecs-agent/agent/resources/cgroup/mock_control"
@@ -100,7 +101,9 @@ func TestSetupHappyPath(t *testing.T) {
 		mockIO.EXPECT().WriteFile(cgroupPath, gomock.Any(), gomock.Any()).Return(nil),
 	)
 
+	cfg := config.DefaultConfig()
 	resource := newResources(mockControl, mockIO)
+	resource.ApplyConfigDependencies(&cfg)
 	assert.NoError(t, resource.Setup(task))
 }
 

--- a/agent/resources/resources_unsupported.go
+++ b/agent/resources/resources_unsupported.go
@@ -17,6 +17,7 @@ package resources
 
 import (
 	"github.com/aws/amazon-ecs-agent/agent/api"
+	"github.com/aws/amazon-ecs-agent/agent/config"
 )
 
 // unimplementedResource implements the Resource interface
@@ -40,4 +41,7 @@ func (r *unimplementedResource) Setup(task *api.Task) error {
 // Cleanup removes the resource
 func (r *unimplementedResource) Cleanup(task *api.Task) error {
 	return nil
+}
+
+func (r *unimplementedResource) ApplyConfigDependencies(cfg *config.Config) {
 }

--- a/agent/statemanager/state_manager_test.go
+++ b/agent/statemanager/state_manager_test.go
@@ -39,7 +39,7 @@ func TestLoadsV1DataCorrectly(t *testing.T) {
 	defer cleanup()
 	cfg := &config.Config{DataDir: filepath.Join(".", "testdata", "v1", "1")}
 
-	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil)
+	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil)
 	var containerInstanceArn, cluster, savedInstanceID string
 	var sequenceNumber int64
 

--- a/agent/statemanager/state_manager_unix_test.go
+++ b/agent/statemanager/state_manager_unix_test.go
@@ -43,7 +43,7 @@ func TestStateManager(t *testing.T) {
 
 	// Now let's make some state to save
 	containerInstanceArn := ""
-	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil)
+	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil)
 
 	manager, err = statemanager.NewStateManager(cfg, statemanager.AddSaveable("TaskEngine", taskEngine), statemanager.AddSaveable("ContainerInstanceArn", &containerInstanceArn))
 	require.Nil(t, err)
@@ -59,7 +59,7 @@ func TestStateManager(t *testing.T) {
 	assertFileMode(t, filepath.Join(tmpDir, "ecs_agent_data.json"))
 
 	// Now make sure we can load that state sanely
-	loadedTaskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil)
+	loadedTaskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil)
 	var loadedContainerInstanceArn string
 
 	manager, err = statemanager.NewStateManager(cfg, statemanager.AddSaveable("TaskEngine", &loadedTaskEngine), statemanager.AddSaveable("ContainerInstanceArn", &loadedContainerInstanceArn))

--- a/agent/stats/engine_integ_test.go
+++ b/agent/stats/engine_integ_test.go
@@ -325,7 +325,7 @@ func TestStatsEngineWithNewContainers(t *testing.T) {
 
 func TestStatsEngineWithDockerTaskEngine(t *testing.T) {
 	containerChangeEventStream := eventStream("TestStatsEngineWithDockerTaskEngine")
-	taskEngine := ecsengine.NewTaskEngine(&config.Config{}, nil, nil, containerChangeEventStream, nil, dockerstate.NewTaskEngineState(), nil)
+	taskEngine := ecsengine.NewTaskEngine(&config.Config{}, nil, nil, containerChangeEventStream, nil, dockerstate.NewTaskEngineState(), nil, nil)
 	container, err := createHealthContainer(client)
 	require.NoError(t, err, "creating container failed")
 
@@ -409,7 +409,7 @@ func TestStatsEngineWithDockerTaskEngine(t *testing.T) {
 
 func TestStatsEngineWithDockerTaskEngineMissingRemoveEvent(t *testing.T) {
 	containerChangeEventStream := eventStream("TestStatsEngineWithDockerTaskEngineMissingRemoveEvent")
-	taskEngine := ecsengine.NewTaskEngine(&config.Config{}, nil, nil, containerChangeEventStream, nil, dockerstate.NewTaskEngineState(), nil)
+	taskEngine := ecsengine.NewTaskEngine(&config.Config{}, nil, nil, containerChangeEventStream, nil, dockerstate.NewTaskEngineState(), nil, nil)
 
 	container, err := createHealthContainer(client)
 	require.NoError(t, err, "creating container failed")

--- a/agent/stats/engine_integ_test.go
+++ b/agent/stats/engine_integ_test.go
@@ -70,7 +70,8 @@ func TestStatsEngineWithExistingContainersWithoutHealth(t *testing.T) {
 	defer client.StopContainer(container.ID, defaultDockerTimeoutSeconds)
 
 	containerChangeEventStream := eventStream("TestStatsEngineWithExistingContainersWithoutHealth")
-	taskEngine := ecsengine.NewTaskEngine(&config.Config{}, nil, nil, containerChangeEventStream, nil, dockerstate.NewTaskEngineState(), nil)
+	taskEngine := ecsengine.NewTaskEngine(&config.Config{}, nil, nil, containerChangeEventStream,
+		nil, dockerstate.NewTaskEngineState(), nil, nil)
 	testTask := createRunningTask()
 	// Populate Tasks and Container map in the engine.
 	dockerTaskEngine := taskEngine.(*ecsengine.DockerTaskEngine)
@@ -128,7 +129,8 @@ func TestStatsEngineWithNewContainersWithoutHealth(t *testing.T) {
 	engine.containerInstanceArn = defaultContainerInstance
 
 	containerChangeEventStream := eventStream("TestStatsEngineWithNewContainers")
-	taskEngine := ecsengine.NewTaskEngine(&config.Config{}, nil, nil, containerChangeEventStream, nil, dockerstate.NewTaskEngineState(), nil)
+	taskEngine := ecsengine.NewTaskEngine(&config.Config{}, nil, nil, containerChangeEventStream,
+		nil, dockerstate.NewTaskEngineState(), nil, nil)
 	testTask := createRunningTask()
 	// Populate Tasks and Container map in the engine.
 	dockerTaskEngine := taskEngine.(*ecsengine.DockerTaskEngine)
@@ -201,7 +203,8 @@ func TestStatsEngineWithExistingContainers(t *testing.T) {
 	defer client.StopContainer(container.ID, defaultDockerTimeoutSeconds)
 
 	containerChangeEventStream := eventStream("TestStatsEngineWithExistingContainers")
-	taskEngine := ecsengine.NewTaskEngine(&config.Config{}, nil, nil, containerChangeEventStream, nil, dockerstate.NewTaskEngineState(), nil)
+	taskEngine := ecsengine.NewTaskEngine(&config.Config{}, nil, nil, containerChangeEventStream,
+		nil, dockerstate.NewTaskEngineState(), nil, nil)
 	testTask := createRunningTask()
 	// enable container health check for this container
 	testTask.Containers[0].HealthCheckType = "docker"
@@ -265,7 +268,8 @@ func TestStatsEngineWithNewContainers(t *testing.T) {
 	engine.containerInstanceArn = defaultContainerInstance
 
 	containerChangeEventStream := eventStream("TestStatsEngineWithNewContainers")
-	taskEngine := ecsengine.NewTaskEngine(&config.Config{}, nil, nil, containerChangeEventStream, nil, dockerstate.NewTaskEngineState(), nil)
+	taskEngine := ecsengine.NewTaskEngine(&config.Config{}, nil, nil, containerChangeEventStream,
+		nil, dockerstate.NewTaskEngineState(), nil, nil)
 
 	testTask := createRunningTask()
 	// enable health check of the container

--- a/agent/utils/ioutilwrapper/ioutil.go
+++ b/agent/utils/ioutilwrapper/ioutil.go
@@ -15,6 +15,7 @@ package ioutilwrapper
 
 import (
 	"io/ioutil"
+	"os"
 
 	"github.com/aws/amazon-ecs-agent/agent/utils/oswrapper"
 )
@@ -22,6 +23,7 @@ import (
 // IOUtil wraps 'io/util' methods for testing
 type IOUtil interface {
 	TempFile(string, string) (oswrapper.File, error)
+	WriteFile(string, []byte, os.FileMode) error
 }
 
 type ioUtil struct {
@@ -34,4 +36,8 @@ func NewIOUtil() IOUtil {
 
 func (*ioUtil) TempFile(dir string, prefix string) (oswrapper.File, error) {
 	return ioutil.TempFile(dir, prefix)
+}
+
+func (*ioUtil) WriteFile(filename string, data []byte, perm os.FileMode) error {
+	return ioutil.WriteFile(filename, data, perm)
 }

--- a/agent/utils/ioutilwrapper/mocks/ioutilwrapper_mocks.go
+++ b/agent/utils/ioutilwrapper/mocks/ioutilwrapper_mocks.go
@@ -17,6 +17,8 @@
 package mock_ioutilwrapper
 
 import (
+	os "os"
+
 	oswrapper "github.com/aws/amazon-ecs-agent/agent/utils/oswrapper"
 	gomock "github.com/golang/mock/gomock"
 )
@@ -51,4 +53,14 @@ func (_m *MockIOUtil) TempFile(_param0 string, _param1 string) (oswrapper.File, 
 
 func (_mr *_MockIOUtilRecorder) TempFile(arg0, arg1 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "TempFile", arg0, arg1)
+}
+
+func (_m *MockIOUtil) WriteFile(_param0 string, _param1 []byte, _param2 os.FileMode) error {
+	ret := _m.ctrl.Call(_m, "WriteFile", _param0, _param1, _param2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockIOUtilRecorder) WriteFile(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WriteFile", arg0, arg1, arg2)
 }


### PR DESCRIPTION
### Summary
<!-- What does this pull request do? -->
Includes the following changes:
1. enable `memory.use_hierarchy` scoped to the task's cgroup root
2. make the cgroup root path configurable through ecs.config and resolved at runtime, let default be `/sys/fs/cgroup/memory/`. this addresses https://github.com/aws/amazon-ecs-agent/pull/1147#pullrequestreview-85597853
3. refactored `DockerTaskEngine` to receive `agent.resource` instead of creating it's own instance.

We enforce the `memory.use_hierarchy` flag to the task level and not the `/ecs` root because the kernel does not allow modifications to anything under the `/ecs/` tree if child cgroups have already been created. This means that we will not be able to toggle the `memory.use_hierarchy` flag for existing ECS instances. Reports of this issue are also tracked here https://github.com/lxc/lxc/issues/236 and https://github.com/linuxkit/linuxkit/issues/373.



### Implementation details
<!-- How are the changes implemented? -->
1. echo 1 > memory.use_hierarchy scoped to task cgroup
2. added `ApplyConfigDependencies(cfg *config.Config)` to `type Resource interface` 
3. added `memorySubsystemPath string` to `type cgroupWrapper struct`
4. refactored function signatures for `NewTaskEngine` and `NewDockerTaskEngine`
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: yes
