### PR TITLE
functional_tests: shmsize and tmpfs fields support

### DIFF
--- a/agent/ecs_client/model/api/api-2.json
+++ b/agent/ecs_client/model/api/api-2.json
@@ -1024,7 +1024,9 @@
       "members":{
         "capabilities":{"shape":"KernelCapabilities"},
         "devices":{"shape":"DevicesList"},
-        "initProcessEnabled":{"shape":"BoxedBoolean"}
+        "initProcessEnabled":{"shape":"BoxedBoolean"},
+        "sharedMemorySize":{"shape":"BoxedInteger"},
+        "tmpfs":{"shape":"TmpfsList"}
       }
     },
     "ListAttributesRequest":{
@@ -1637,6 +1639,22 @@
       "member":{"shape":"Task"}
     },
     "Timestamp":{"type":"timestamp"},
+    "Tmpfs":{
+      "type":"structure",
+      "required":[
+        "containerPath",
+        "size"
+      ],
+      "members":{
+        "containerPath":{"shape":"String"},
+        "size":{"shape":"Integer"},
+        "mountOptions":{"shape":"StringList"}
+      }
+    },
+    "TmpfsList":{
+      "type":"list",
+      "member":{"shape":"Tmpfs"}
+    },
     "TransportProtocol":{
       "type":"string",
       "enum":[

--- a/agent/ecs_client/model/ecs/api.go
+++ b/agent/ecs_client/model/ecs/api.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -6075,6 +6075,10 @@ type LinuxParameters struct {
 	Devices []*Device `locationName:"devices" type:"list"`
 
 	InitProcessEnabled *bool `locationName:"initProcessEnabled" type:"boolean"`
+
+	SharedMemorySize *int64 `locationName:"sharedMemorySize" type:"integer"`
+
+	Tmpfs []*Tmpfs `locationName:"tmpfs" type:"list"`
 }
 
 // String returns the string representation
@@ -6100,6 +6104,16 @@ func (s *LinuxParameters) Validate() error {
 			}
 		}
 	}
+	if s.Tmpfs != nil {
+		for i, v := range s.Tmpfs {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Tmpfs", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -6122,6 +6136,18 @@ func (s *LinuxParameters) SetDevices(v []*Device) *LinuxParameters {
 // SetInitProcessEnabled sets the InitProcessEnabled field's value.
 func (s *LinuxParameters) SetInitProcessEnabled(v bool) *LinuxParameters {
 	s.InitProcessEnabled = &v
+	return s
+}
+
+// SetSharedMemorySize sets the SharedMemorySize field's value.
+func (s *LinuxParameters) SetSharedMemorySize(v int64) *LinuxParameters {
+	s.SharedMemorySize = &v
+	return s
+}
+
+// SetTmpfs sets the Tmpfs field's value.
+func (s *LinuxParameters) SetTmpfs(v []*Tmpfs) *LinuxParameters {
+	s.Tmpfs = v
 	return s
 }
 
@@ -9111,6 +9137,62 @@ func (s *TaskOverride) SetExecutionRoleArn(v string) *TaskOverride {
 // SetTaskRoleArn sets the TaskRoleArn field's value.
 func (s *TaskOverride) SetTaskRoleArn(v string) *TaskOverride {
 	s.TaskRoleArn = &v
+	return s
+}
+
+type Tmpfs struct {
+	_ struct{} `type:"structure"`
+
+	// ContainerPath is a required field
+	ContainerPath *string `locationName:"containerPath" type:"string" required:"true"`
+
+	MountOptions []*string `locationName:"mountOptions" type:"list"`
+
+	// Size is a required field
+	Size *int64 `locationName:"size" type:"integer" required:"true"`
+}
+
+// String returns the string representation
+func (s Tmpfs) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s Tmpfs) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Tmpfs) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Tmpfs"}
+	if s.ContainerPath == nil {
+		invalidParams.Add(request.NewErrParamRequired("ContainerPath"))
+	}
+	if s.Size == nil {
+		invalidParams.Add(request.NewErrParamRequired("Size"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetContainerPath sets the ContainerPath field's value.
+func (s *Tmpfs) SetContainerPath(v string) *Tmpfs {
+	s.ContainerPath = &v
+	return s
+}
+
+// SetMountOptions sets the MountOptions field's value.
+func (s *Tmpfs) SetMountOptions(v []*string) *Tmpfs {
+	s.MountOptions = v
+	return s
+}
+
+// SetSize sets the Size field's value.
+func (s *Tmpfs) SetSize(v int64) *Tmpfs {
+	s.Size = &v
 	return s
 }
 

--- a/agent/functional_tests/testdata/simpletests_unix/shmsize.json
+++ b/agent/functional_tests/testdata/simpletests_unix/shmsize.json
@@ -1,0 +1,10 @@
+{
+  "Name": "ShmSize",
+  "Description": "checks that setting size of shared memory volume works",
+  "TaskDefinition": "shmsize",
+  "Version": ">=1.11.0",
+  "Timeout": "2m",
+  "ExitCodes": {
+    "exit": 42
+  }
+}

--- a/agent/functional_tests/testdata/simpletests_unix/tmpfs.json
+++ b/agent/functional_tests/testdata/simpletests_unix/tmpfs.json
@@ -1,0 +1,10 @@
+{
+  "Name": "Tmpfs",
+  "Description": "checks that adding tmpfs volume works",
+  "TaskDefinition": "tmpfs",
+  "Version": ">=1.11.0",
+  "Timeout": "2m",
+  "ExitCodes": {
+    "exit": 42
+  }
+}

--- a/agent/functional_tests/testdata/taskdefinitions/shmsize/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/shmsize/task-definition.json
@@ -1,0 +1,13 @@
+{
+  "family": "ecsftest-shmsize",
+  "containerDefinitions": [{
+    "image": "127.0.0.1:51670/ubuntu:latest",
+    "name": "exit",
+    "cpu": 500,
+    "memory": 500,
+    "linuxParameters": {
+      "sharedMemorySize": 100
+    },
+    "command": ["sh", "-c", "if df -h /dev/shm | grep 100M; then exit 42; else exit 1; fi"]
+  }]
+}

--- a/agent/functional_tests/testdata/taskdefinitions/tmpfs/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/tmpfs/task-definition.json
@@ -1,0 +1,19 @@
+{
+  "family": "ecsftest-tmpfs",
+  "containerDefinitions": [{
+    "image": "127.0.0.1:51670/ubuntu:latest",
+    "name": "exit",
+    "cpu": 500,
+    "memory": 500,
+    "linuxParameters": {
+      "tmpfs": [
+        {
+          "containerPath": "/dev/tmpfs",
+          "size": 100,
+          "mountOptions": ["ro", "noexec"]
+        }
+      ]
+    },
+    "command": ["sh", "-c", "if mount | grep \"tmpfs on /dev/tmpfs type tmpfs (ro,nosuid,nodev,noexec,relatime,size=102400k)\"; then exit 42; else exit 1; fi"]
+  }]
+}

--- a/agent/functional_tests/tests/generated/simpletests_unix/simpletests_generated_unix_test.go
+++ b/agent/functional_tests/tests/generated/simpletests_unix/simpletests_generated_unix_test.go
@@ -682,6 +682,46 @@ func TestSecurityOptNoNewPrivileges(t *testing.T) {
 
 }
 
+// TestShmSize checks that setting size of shared memory volume works
+func TestShmSize(t *testing.T) {
+
+	// Parallel is opt in because resource constraints could cause test failures
+	// on smaller instances
+	if os.Getenv("ECS_FUNCTIONAL_PARALLEL") != "" {
+		t.Parallel()
+	}
+	agent := RunAgent(t, nil)
+	defer agent.Cleanup()
+	agent.RequireVersion(">=1.11.0")
+
+	td, err := GetTaskDefinition("shmsize")
+	if err != nil {
+		t.Fatalf("Could not register task definition: %v", err)
+	}
+	testTasks, err := agent.StartMultipleTasks(t, td, 1)
+	if err != nil {
+		t.Fatalf("Could not start task: %v", err)
+	}
+	timeout, err := time.ParseDuration("2m")
+	if err != nil {
+		t.Fatalf("Could not parse timeout: %#v", err)
+	}
+
+	for _, testTask := range testTasks {
+		err = testTask.WaitStopped(timeout)
+		if err != nil {
+			t.Fatalf("Timed out waiting for task to reach stopped. Error %#v, task %#v", err, testTask)
+		}
+
+		if exit, ok := testTask.ContainerExitcode("exit"); !ok || exit != 42 {
+			t.Errorf("Expected exit to exit with 42; actually exited (%v) with %v", ok, exit)
+		}
+
+		defer agent.SweepTask(testTask)
+	}
+
+}
+
 // TestSimpleExit Tests that the basic premis of this testing fromwork works (e.g. exit codes go through, etc)
 func TestSimpleExit(t *testing.T) {
 
@@ -695,6 +735,46 @@ func TestSimpleExit(t *testing.T) {
 	agent.RequireVersion(">=1.0.0")
 
 	td, err := GetTaskDefinition("simple-exit")
+	if err != nil {
+		t.Fatalf("Could not register task definition: %v", err)
+	}
+	testTasks, err := agent.StartMultipleTasks(t, td, 1)
+	if err != nil {
+		t.Fatalf("Could not start task: %v", err)
+	}
+	timeout, err := time.ParseDuration("2m")
+	if err != nil {
+		t.Fatalf("Could not parse timeout: %#v", err)
+	}
+
+	for _, testTask := range testTasks {
+		err = testTask.WaitStopped(timeout)
+		if err != nil {
+			t.Fatalf("Timed out waiting for task to reach stopped. Error %#v, task %#v", err, testTask)
+		}
+
+		if exit, ok := testTask.ContainerExitcode("exit"); !ok || exit != 42 {
+			t.Errorf("Expected exit to exit with 42; actually exited (%v) with %v", ok, exit)
+		}
+
+		defer agent.SweepTask(testTask)
+	}
+
+}
+
+// TestTmpfs checks that adding tmpfs volume works
+func TestTmpfs(t *testing.T) {
+
+	// Parallel is opt in because resource constraints could cause test failures
+	// on smaller instances
+	if os.Getenv("ECS_FUNCTIONAL_PARALLEL") != "" {
+		t.Parallel()
+	}
+	agent := RunAgent(t, nil)
+	defer agent.Cleanup()
+	agent.RequireVersion(">=1.11.0")
+
+	td, err := GetTaskDefinition("tmpfs")
 	if err != nil {
 		t.Fatalf("Could not register task definition: %v", err)
 	}


### PR DESCRIPTION
### Summary
This PR contains the model changes and functional tests for the new Task Definition fields for shmsize and tmpfs.

### Implementation details
Functional tests that verify:
* If shared memory volume of specified size is added to the container
* If tmpfs volume of the specified size and mount options is mounted at the provided container path

### Testing
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes

### Licensing
This contribution is under the terms of the Apache 2.0 License: yes