### PR TITLE
fix issue1043

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,9 @@
 # Changelog
 
 ## Unreleased
-* Feature - Support a HTTP endpoint for `awsvpc` tasks to query metadata.
-* Feature - Support Docker health check.
+* Feature - Support a HTTP endpoint for `awsvpc` tasks to query metadata
+* Feature - Support Docker health check
 * Bug - Fixed a bug where `-version` fails due to its dependency on docker client. [#1118](https://github.com/aws/amazon-ecs-agent/pull/1118)
-* Bug - Persist container exit code in agent state file. [#1125](https://github.com/aws/amazon-ecs-agent/pull/1125)
 * Bug - Persist container exit code in agent state file [#1125](https://github.com/aws/amazon-ecs-agent/pull/1125)
 * Bug - Fixed a bug where the agent could lose track of running containers when Docker APIs timeout [#1217](https://github.com/aws/amazon-ecs-agent/pull/1217)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Feature - Support Docker health check.
 * Bug - Fixed a bug where `-version` fails due to its dependency on docker client. [#1118](https://github.com/aws/amazon-ecs-agent/pull/1118)
 * Bug - Persist container exit code in agent state file. [#1125](https://github.com/aws/amazon-ecs-agent/pull/1125)
+* Bug - Persist container exit code in agent state file [#1125](https://github.com/aws/amazon-ecs-agent/pull/1125)
+* Bug - Fixed a bug where the agent could lose track of running containers when Docker APIs timeout [#1217](https://github.com/aws/amazon-ecs-agent/pull/1217)
 
 ## 1.16.2
 * Bug - Fixed a bug where the ticker would submit empty container state change

--- a/agent/acs/handler/acs_handler_test.go
+++ b/agent/acs/handler/acs_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/acs/handler/acs_handler_test.go
+++ b/agent/acs/handler/acs_handler_test.go
@@ -218,7 +218,7 @@ func TestHandlerReconnectsOnConnectErrors(t *testing.T) {
 		// test  to time out as the context is never cancelled
 		mockWsClient.EXPECT().Connect().Do(func() {
 			cancel()
-		}).Return(io.EOF),
+		}).Return(io.EOF).MinTimes(1),
 	)
 	acsSession := session{
 		containerInstanceARN: "myArn",

--- a/agent/engine/docker_client.go
+++ b/agent/engine/docker_client.go
@@ -836,7 +836,12 @@ func (dg *dockerGoClient) handleContainerEvents(events <-chan *docker.APIEvents,
 		switch event.Status {
 		case "create":
 			status = api.ContainerCreated
-			// TODO no need to inspect containers here
+			// TODO no need to inspect containers here.
+			// There's no need to inspect containers after they are created when we
+			// adopt Docker's volume APIs. Today, that's the only information we need
+			// from the `inspect` API. Once we start injecting that ourselves,
+			// there's no need to `inspect` containers on `Create` anymore. This will
+			// save us a lot of `inspect` calls in the future.
 		case "start":
 			status = api.ContainerRunning
 		case "stop":
@@ -863,7 +868,7 @@ func (dg *dockerGoClient) handleContainerEvents(events <-chan *docker.APIEvents,
 		default:
 			// Because docker emits new events even when you use an old event api
 			// version, it's not that big a deal
-			seelog.Debugf("DockerGoClient: unknown status event from docker: %s", event.Status)
+			seelog.Debugf("DockerGoClient: unknown status event from docker: %v", event)
 		}
 
 		metadata := dg.containerMetadata(containerID)

--- a/agent/engine/docker_client_test.go
+++ b/agent/engine/docker_client_test.go
@@ -1,5 +1,5 @@
 // +build !integration
-// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/engine/docker_client_test.go
+++ b/agent/engine/docker_client_test.go
@@ -355,7 +355,9 @@ func TestCreateContainerTimeout(t *testing.T) {
 		warp <- time.Now()
 		wait.Wait()
 		// Don't return, verify timeout happens
-	})
+		// TODO remove the MaxTimes by cancel the context passed to CreateContainer
+		// when issue #1212 is resolved
+	}).MaxTimes(1)
 	metadata := client.CreateContainer(config.Config, nil, config.Name, xContainerShortTimeout)
 	assert.Error(t, metadata.Error, "expected error for pull timeout")
 	assert.Equal(t, "DockerTimeoutError", metadata.Error.(api.NamedError).ErrorName())

--- a/agent/engine/errors.go
+++ b/agent/engine/errors.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/engine/errors.go
+++ b/agent/engine/errors.go
@@ -21,7 +21,10 @@ import (
 	docker "github.com/fsouza/go-dockerclient"
 )
 
-const dockerTimeoutErrorName = "DockerTimeoutError"
+const (
+	dockerTimeoutErrorName          = "DockerTimeoutError"
+	cannotInspectContainerErrorName = "CannotInspectContainerError"
+)
 
 // engineError wraps the error interface with an identifier method that
 // is used to classify the error type
@@ -262,7 +265,7 @@ func (err CannotInspectContainerError) Error() string {
 }
 
 func (err CannotInspectContainerError) ErrorName() string {
-	return "CannotInspectContainerError"
+	return cannotInspectContainerErrorName
 }
 
 // CannotRemoveContainerError indicates any error when trying to remove a container

--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -505,7 +505,7 @@ func (mtask *managedTask) handleStoppedToRunningContainerTransition(status api.C
 		return
 	}
 	if containerKnownStatus != api.ContainerStopped {
-		// Container's known status is STOPPED. Nothing to do here.
+		// Container's known status is not STOPPED. Nothing to do here.
 		return
 	}
 	if !status.IsRunning() {
@@ -576,7 +576,7 @@ func (mtask *managedTask) handleEventError(containerChange dockerContainerChange
 }
 
 // handleContainerStoppedTransitionError handles an error when transitioning a container to
-// STOPPED. It returns a boolean indicating whethere the taks can continue with updating its
+// STOPPED. It returns a boolean indicating whether the tak can continue with updating its
 // state
 func (mtask *managedTask) handleContainerStoppedTransitionError(event DockerContainerChangeEvent,
 	container *api.Container,

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ clone_depth: 2
 clone_folder: c:\gopath\src\github.com\aws\amazon-ecs-agent
 environment:
   GOPATH: c:\gopath
-  GOVERSION: 1.7.4
+  GOVERSION: 1.9.3
 install:
   - set PATH=%GOPATH%\bin;c:\go\bin;%PATH%
   - rmdir c:\go /s /q


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass
- [X] Manual tests: 
  - [X] Simulated inspect error in start container and verified that other containers and the started container in a task with ephemeral volumes were stopped and cleaned up properly
  - [X] Simulated docker timeout error in start container and verified that other containers and the started container in a task with ephemeral volumes were stopped and cleaned up properly
New tests cover the changes: yes!

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
