### PR TITLE
Fixes a CPUUtilization metrics calculation bug for Windows clusters.

### DIFF
--- a/agent/stats/utils_windows.go
+++ b/agent/stats/utils_windows.go
@@ -28,7 +28,7 @@ func dockerStatsToContainerStats(dockerStats *docker.Stats) (*ContainerStats, er
 		return nil, fmt.Errorf("invalid number of cpu cores acquired from the system")
 	}
 
-	cpuUsage := dockerStats.CPUStats.CPUUsage.TotalUsage / numCores
+	cpuUsage := (dockerStats.CPUStats.CPUUsage.TotalUsage * 100) / numCores
 	memoryUsage := dockerStats.MemoryStats.PrivateWorkingSet
 	return &ContainerStats{
 		cpuUsage:    cpuUsage,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR fixes a calculation error witnessed while collecting CPUUsage.TotalUsage on Windows.  The existing calculation resulted in an unusable value being sent back to AWS as 'CPUUtilization' and was impossible to derive scaling policies off of it.  Converting this value to a percentage during stat collection now results in accurate metrics.

### Implementation details
<!-- How are the changes implemented? -->
cpuUsage is converted to a percentage (* 100) then divided by numCores inside of the dockerStatsToContainerStats function.

### Testing
<!-- How was this tested? -->
This change was compiled and tested on a Windows ECS cluster running a number of different instance type configurations comprising of multiple vCPU counts in order to validate the new calculation. 
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [ ] Builds on Linux (`make release`)
- [X] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [ ] Unit tests on Linux (`make test`) pass
- [X] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [X] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [X] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
* Bug - Fixed a CPUUtilization metrics calculation bug for Windows clusters.

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: yes