### PR TITLE
Fixing windows cpu metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,16 @@
 ## Unreleased
 * Feature - Support a HTTP endpoint for `awsvpc` tasks to query metadata
 * Feature - Support Docker health check
-* Bug - Fixed a bug where `-version` fails due to its dependency on docker client. [#1118](https://github.com/aws/amazon-ecs-agent/pull/1118)
-* Bug - Persist container exit code in agent state file [#1125](https://github.com/aws/amazon-ecs-agent/pull/1125)
-* Bug - Fixed a bug where the agent could lose track of running containers when Docker APIs timeout [#1217](https://github.com/aws/amazon-ecs-agent/pull/1217)
-* Bug - Task level memory.use_hierarchy was not being set and memory limits were not being enforced [#1195](https://github.com/aws/amazon-ecs-agent/pull/1195)
+* Bug - Fixed a bug where `-version` fails due to its dependency on docker
+  client [#1118](https://github.com/aws/amazon-ecs-agent/pull/1118)
+* Bug - Persist container exit code in agent state file
+  [#1125](https://github.com/aws/amazon-ecs-agent/pull/1125)
+* Bug - Fixed a bug where the agent could lose track of running containers when
+  Docker APIs timeout [#1217](https://github.com/aws/amazon-ecs-agent/pull/1217)
+* Bug - Task level memory.use_hierarchy was not being set and memory limits
+  were not being enforced [#1195](https://github.com/aws/amazon-ecs-agent/pull/1195)
+* Bug - Fixed a bug where CPU utilization wasn't correctly reported on Windows
+  [@bboerst](https://github.com/bboerst) [#1219](https://github.com/aws/amazon-ecs-agent/pull/1219)
 
 ## 1.16.2
 * Bug - Fixed a bug where the ticker would submit empty container state change

--- a/agent/acs/handler/acs_handler_test.go
+++ b/agent/acs/handler/acs_handler_test.go
@@ -710,7 +710,7 @@ func TestHandlerReconnectsOnDiscoverPollEndpointError(t *testing.T) {
 	mockWsClient.EXPECT().Serve().Do(func() {
 		// Serve() cancels the context
 		cancel()
-	}).Return(io.EOF)
+	}).Return(io.EOF).MinTimes(1)
 
 	gomock.InOrder(
 		// DiscoverPollEndpoint returns an error on its first invocation

--- a/agent/functional_tests/tests/functionaltests_windows_test.go
+++ b/agent/functional_tests/tests/functionaltests_windows_test.go
@@ -290,7 +290,7 @@ func TestTelemetry(t *testing.T) {
 	metrics, err := VerifyMetrics(cwclient, params, false)
 	assert.NoError(t, err, "Task is running, verify metrics for CPU utilization failed")
 	// Also verify the cpu usage is around 25%
-	assert.InDelta(t, 0.25, *metrics.Average, 0.05)
+	assert.InDelta(t, 25, *metrics.Average, 5)
 
 	params.MetricName = aws.String("MemoryUtilization")
 	_, err = VerifyMetrics(cwclient, params, false)

--- a/agent/stats/utils_test.go
+++ b/agent/stats/utils_test.go
@@ -36,36 +36,6 @@ func TestIsNetworkStatsError(t *testing.T) {
 	}
 }
 
-func TestDockerStatsToContainerStatsCpuUsage(t *testing.T) {
-	// doing this with json makes me sad, but is the easiest way to deal with
-	// the inner structs
-
-	// numCores is a global variable in package agent/stas
-	// whichdenotes the number of cpu cores
-	numCores = 4
-	jsonStat := fmt.Sprintf(`
-		{
-			"cpu_stats":{
-				"cpu_usage":{
-					"percpu_usage":[%d, %d, %d, %d],
-					"total_usage":%d
-				}
-			}
-		}`, 1, 2, 3, 4, 100)
-	dockerStat := &docker.Stats{}
-	json.Unmarshal([]byte(jsonStat), dockerStat)
-	containerStats, err := dockerStatsToContainerStats(dockerStat)
-	if err != nil {
-		t.Errorf("Error converting container stats: %v", err)
-	}
-	if containerStats == nil {
-		t.Fatal("containerStats should not be nil")
-	}
-	if containerStats.cpuUsage != 25 {
-		t.Error("Unexpected value for cpuUsage", containerStats.cpuUsage)
-	}
-}
-
 func TestDockerStatsToContainerStatsMemUsage(t *testing.T) {
 	jsonStat := fmt.Sprintf(`
 		{

--- a/agent/stats/utils_windows.go
+++ b/agent/stats/utils_windows.go
@@ -28,7 +28,7 @@ func dockerStatsToContainerStats(dockerStats *docker.Stats) (*ContainerStats, er
 		return nil, fmt.Errorf("invalid number of cpu cores acquired from the system")
 	}
 
-	cpuUsage := dockerStats.CPUStats.CPUUsage.TotalUsage / numCores
+	cpuUsage := (dockerStats.CPUStats.CPUUsage.TotalUsage * 100) / numCores
 	memoryUsage := dockerStats.MemoryStats.PrivateWorkingSet
 	return &ContainerStats{
 		cpuUsage:    cpuUsage,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Fix the CPU metrics for windows by converting it to the percentage.

### Implementation details
<!-- How are the changes implemented? -->
Multiple 100 for the cpu usage on windows to convert it to percentage.
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->
yes
### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
yes