### PR TITLE
engine: mtask wire in derived context

### DIFF
--- a/agent/engine/common_test.go
+++ b/agent/engine/common_test.go
@@ -182,7 +182,6 @@ func addTaskToEngine(t *testing.T,
 	sleepTask *api.Task,
 	mockTime *mock_ttime.MockTime,
 	createStartEventsReported sync.WaitGroup) {
-
 	// steadyStateCheckWait is used to force the test to wait until the steady-state check
 	// has been invoked at least once
 	steadyStateVerify := make(chan time.Time, 1)
@@ -248,5 +247,4 @@ func waitForStopEvents(t *testing.T, stateChangeEvents <-chan statechange.Event,
 		t.Fatal("Should be out of events")
 	default:
 	}
-
 }

--- a/agent/engine/common_test.go
+++ b/agent/engine/common_test.go
@@ -184,11 +184,7 @@ func addTaskToEngine(t *testing.T,
 	createStartEventsReported sync.WaitGroup) {
 	// steadyStateCheckWait is used to force the test to wait until the steady-state check
 	// has been invoked at least once
-	steadyStateVerify := make(chan time.Time, 1)
 	mockTime.EXPECT().Now().Return(time.Now()).AnyTimes()
-	gomock.InOrder(
-		mockTime.EXPECT().After(steadyStateTaskVerifyInterval).Return(steadyStateVerify).AnyTimes(),
-	)
 
 	err := taskEngine.Init(ctx)
 	assert.NoError(t, err)

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -213,11 +213,9 @@ func TestBatchContainerHappyPath(t *testing.T) {
 
 			addTaskToEngine(t, ctx, taskEngine, sleepTask, mockTime, containerEventsWG)
 			cleanup := make(chan time.Time, 1)
-
 			defer close(cleanup)
 			mockTime.EXPECT().After(gomock.Any()).Return(cleanup).MinTimes(1)
 			client.EXPECT().DescribeContainer(gomock.Any()).AnyTimes()
-
 			// Simulate a container stop event from docker
 			eventStream <- DockerContainerChangeEvent{
 				Status: api.ContainerStopped,
@@ -572,7 +570,6 @@ func TestSteadyStatePoll(t *testing.T) {
 
 	err := taskEngine.Init(ctx) // start the task engine
 	assert.NoError(t, err)
-
 	taskEngine.AddTask(sleepTask) // actually add the task we created
 	waitForRunningEvents(t, taskEngine.StateChangeEvents())
 	containerMap, ok := taskEngine.(*DockerTaskEngine).State().ContainerMapByArn(sleepTask.Arn)
@@ -614,14 +611,10 @@ func TestSteadyStatePoll(t *testing.T) {
 	// the cleanup phase. Account for that.
 	client.EXPECT().StopContainer(gomock.Any(), gomock.Any()).Return(
 		DockerContainerMetadata{DockerID: containerID}).AnyTimes()
-
 	waitForStopEvents(t, taskEngine.StateChangeEvents(), false)
-
 	// trigger cleanup, this ensures all the goroutines were finished
 	sleepTask.SetSentStatus(api.TaskStopped)
-
 	cleanup <- time.Now()
-
 	for {
 		tasks, _ := taskEngine.(*DockerTaskEngine).ListTasks()
 		if len(tasks) == 0 {
@@ -629,7 +622,6 @@ func TestSteadyStatePoll(t *testing.T) {
 		}
 		time.Sleep(5 * time.Millisecond)
 	}
-
 }
 
 func TestStopWithPendingStops(t *testing.T) {

--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -95,6 +95,7 @@ type containerTransition struct {
 type managedTask struct {
 	*api.Task
 	ctx                context.Context
+	cancel             context.CancelFunc
 	engine             *DockerTaskEngine
 	cfg                *config.Config
 	saver              statemanager.Saver
@@ -126,8 +127,10 @@ type managedTask struct {
 // This method must only be called when the engine.processTasks write lock is
 // already held.
 func (engine *DockerTaskEngine) newManagedTask(task *api.Task) *managedTask {
+	ctx, cancel := context.WithCancel(engine.ctx)
 	t := &managedTask{
-		ctx:                        engine.ctx,
+		ctx:                        ctx,
+		cancel:                     cancel,
 		Task:                       task,
 		acsMessages:                make(chan acsTransition),
 		dockerMessages:             make(chan dockerContainerChange),

--- a/agent/engine/task_manager_test.go
+++ b/agent/engine/task_manager_test.go
@@ -739,7 +739,7 @@ func TestWaitForContainerTransitionsForNonTerminalTask(t *testing.T) {
 		},
 	}
 
-	transitionChange := make(chan bool, 2)
+	transitionChange := make(chan struct{}, 2)
 	transitionChangeContainer := make(chan string, 2)
 
 	firstContainerName := "container1"
@@ -756,9 +756,9 @@ func TestWaitForContainerTransitionsForNonTerminalTask(t *testing.T) {
 		// Send "transitions completed" messages. These are being
 		// sent out of order for no particular reason. We should be
 		// resilient to the ordering of these messages anyway.
-		transitionChange <- true
+		transitionChange <- struct{}{}
 		transitionChangeContainer <- secondContainerName
-		transitionChange <- true
+		transitionChange <- struct{}{}
 		transitionChangeContainer <- firstContainerName
 	}()
 
@@ -786,7 +786,7 @@ func TestWaitForContainerTransitionsForTerminalTask(t *testing.T) {
 		ctx: ctx,
 	}
 
-	transitionChange := make(chan bool, 2)
+	transitionChange := make(chan struct{}, 2)
 	transitionChangeContainer := make(chan string, 2)
 
 	firstContainerName := "container1"
@@ -799,7 +799,7 @@ func TestWaitForContainerTransitionsForTerminalTask(t *testing.T) {
 	// only one event. This tests that `waitForContainerTransitions` doesn't
 	// block to receive two events and will still progress
 	go func() {
-		transitionChange <- true
+		transitionChange <- struct{}{}
 		transitionChangeContainer <- secondContainerName
 	}()
 	task.waitForContainerTransitions(transitions, transitionChange, transitionChangeContainer)

--- a/agent/engine/task_manager_test.go
+++ b/agent/engine/task_manager_test.go
@@ -1468,7 +1468,11 @@ func TestHandleContainerChangeUpdateContainerHealth(t *testing.T) {
 func TestWaitForHostResources(t *testing.T) {
 	taskStopWG := utilsync.NewSequentialWaitGroup()
 	taskStopWG.Add(1, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+
 	mtask := &managedTask{
+		ctx:        ctx,
+		cancel:     cancel,
 		taskStopWG: taskStopWG,
 		Task: &api.Task{
 			StartSequenceNumber: 1,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Wire in `context.Context` where possible for `mtask.waitEvent()` calls, else use `<-chan struct{}` signalling channel instead of `<-chan bool`
### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
