### PR TITLE
Temporary fix for #1127

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.17.1-dev
 * Bug - Fixed a bug that was causing a runtime panic by accessing negative index in the health check log slice. [#1239](https://github.com/aws/amazon-ecs-agent/pull/1239)
+* Bug - Workaround for an issue where CPU percent was set to 1 when CPU was not
+  set or set to zero(unbounded) in Windows [#1227](https://github.com/aws/amazon-ecs-agent/pull/1227)
 
 ## 1.17.0
 * Feature - Support a HTTP endpoint for `awsvpc` tasks to query metadata

--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ additional details on each available environment variable.
 | `ECS_HOST_DATA_DIR` | `/var/lib/ecs` | The source directory on the host from which ECS_DATADIR is mounted. We use this to determine the source mount path for container metadata files in the case the ECS Agent is running as a container. We do not use this value in Windows because the ECS Agent is not running as container in Windows. | `/var/lib/ecs` | `Not used` |
 | `ECS_ENABLE_TASK_CPU_MEM_LIMIT` | `true` | Whether to enable task-level cpu and memory limits | `true` | `false` |
 | `ECS_CGROUP_PATH` | `/sys/fs/cgroup` | The root cgroup path that is expected by the ECS agent. This is the path that accessible from the agent mount. | `/sys/fs/cgroup` | Not applicable |
+| `ECS_ENABLE_CPU_UNBOUNDED_WINDOWS_WORKAROUND` | `true` | When `true`, ECS will allow CPU unbounded(CPU=`0`) tasks to run along with CPU bounded tasks in Windows. | Not applicable | `false` |
 
 ### Persistence
 

--- a/agent/api/task.go
+++ b/agent/api/task.go
@@ -143,6 +143,9 @@ type Task struct {
 	// MemoryCPULimitsEnabled to determine if task supports CPU, memory limits
 	MemoryCPULimitsEnabled bool `json:"MemoryCPULimitsEnabled,omitempty"`
 
+	// platformFields consists of fields specific to linux/windows for a task
+	platformFields platformFields
+
 	// lock is for protecting all fields in the task struct
 	lock sync.RWMutex
 }
@@ -509,20 +512,6 @@ func (task *Task) SetConfigHostconfigBasedOnVersion(container *Container, config
 	}
 
 	return nil
-}
-
-// dockerCPUShares converts containerCPU shares if needed as per the logic stated below:
-// Docker silently converts 0 to 1024 CPU shares, which is probably not what we
-// want.  Instead, we convert 0 to 2 to be closer to expected behavior. The
-// reason for 2 over 1 is that 1 is an invalid value (Linux's choice, not Docker's).
-func (task *Task) dockerCPUShares(containerCPU uint) int64 {
-	if containerCPU <= 1 {
-		seelog.Debugf(
-			"Converting CPU shares to allowed minimum of 2 for task arn: [%s] and cpu shares: %d",
-			task.Arn, containerCPU)
-		return 2
-	}
-	return int64(containerCPU)
 }
 
 func (task *Task) dockerExposedPorts(container *Container) map[docker.Port]struct{} {

--- a/agent/api/task_unix_test.go
+++ b/agent/api/task_unix_test.go
@@ -1,6 +1,6 @@
 // +build !windows
 
-// Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -16,10 +16,12 @@
 package api
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/engine/dockerclient"
 
 	docker "github.com/fsouza/go-dockerclient"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -48,6 +50,7 @@ const (
 
 	taskVCPULimit   = 2.0
 	taskMemoryLimit = 512
+	minDockerClientAPIVersion = dockerclient.Version_1_17
 )
 
 func TestAddNetworkResourceProvisioningDependencyNop(t *testing.T) {
@@ -296,4 +299,92 @@ func TestPlatformHostConfigOverrideErrorPath(t *testing.T) {
 	dockerHostConfig, err := task.DockerHostConfig(task.Containers[0], dockerMap(task), defaultDockerClientAPIVersion)
 	assert.Error(t, err)
 	assert.Empty(t, dockerHostConfig)
+}
+
+func TestDockerHostConfigRawConfigMerging(t *testing.T) {
+	// Use a struct that will marshal to the actual message we expect; not
+	// docker.HostConfig which will include a lot of zero values.
+	rawHostConfigInput := struct {
+		Privileged  bool     `json:"Privileged,omitempty" yaml:"Privileged,omitempty"`
+		SecurityOpt []string `json:"SecurityOpt,omitempty" yaml:"SecurityOpt,omitempty"`
+	}{
+		Privileged:  true,
+		SecurityOpt: []string{"foo", "bar"},
+	}
+
+	rawHostConfig, err := json.Marshal(&rawHostConfigInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testTask := &Task{
+		Arn:     "arn:aws:ecs:us-east-1:012345678910:task/c09f0188-7f87-4b0f-bfc3-16296622b6fe",
+		Family:  "myFamily",
+		Version: "1",
+		Containers: []*Container{
+			{
+				Name:        "c1",
+				Image:       "image",
+				CPU:         50,
+				Memory:      100,
+				VolumesFrom: []VolumeFrom{{SourceContainer: "c2"}},
+				DockerConfig: DockerConfig{
+					HostConfig: strptr(string(rawHostConfig)),
+				},
+			},
+			{
+				Name: "c2",
+			},
+		},
+	}
+
+	hostConfig, configErr := testTask.DockerHostConfig(testTask.Containers[0], dockerMap(testTask), minDockerClientAPIVersion)
+	assert.Nil(t, configErr)
+
+	expected := docker.HostConfig{
+		Privileged:       true,
+		SecurityOpt:      []string{"foo", "bar"},
+		VolumesFrom:      []string{"dockername-c2"},
+		MemorySwappiness: memorySwappinessDefault,
+		CPUPercent:       minimumCPUPercent,
+	}
+
+	assertSetStructFieldsEqual(t, expected, *hostConfig)
+}
+
+// TestSetConfigHostconfigBasedOnAPIVersion tests the docker hostconfig was correctly
+// set based on the docker client version
+func TestSetConfigHostconfigBasedOnAPIVersion(t *testing.T) {
+	memoryMiB := 500
+	testTask := &Task{
+		Containers: []*Container{
+			{
+				Name:   "c1",
+				CPU:    uint(10),
+				Memory: uint(memoryMiB),
+			},
+		},
+	}
+
+	hostconfig, err := testTask.DockerHostConfig(testTask.Containers[0], dockerMap(testTask), minDockerClientAPIVersion)
+	assert.Nil(t, err)
+
+	config, cerr := testTask.DockerConfig(testTask.Containers[0], defaultDockerClientAPIVersion)
+	assert.Nil(t, cerr)
+
+	assert.Equal(t, int64(memoryMiB*1024*1024), config.Memory)
+	assert.Equal(t, int64(10), config.CPUShares)
+	assert.Empty(t, hostconfig.CPUShares)
+	assert.Empty(t, hostconfig.Memory)
+
+	hostconfig, err = testTask.DockerHostConfig(testTask.Containers[0], dockerMap(testTask), dockerclient.Version_1_18)
+	assert.Nil(t, err)
+
+	config, cerr = testTask.DockerConfig(testTask.Containers[0], dockerclient.Version_1_18)
+	assert.Nil(t, err)
+	assert.Equal(t, int64(memoryMiB*1024*1024), hostconfig.Memory)
+	assert.Equal(t, int64(10), hostconfig.CPUShares)
+
+	assert.Empty(t, config.CPUShares)
+	assert.Empty(t, config.Memory)
 }

--- a/agent/api/task_windows_test.go
+++ b/agent/api/task_windows_test.go
@@ -1,6 +1,6 @@
 // +build windows
 
-// Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -17,10 +17,14 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
+	"runtime"
 	"testing"
 
 	"github.com/aws/amazon-ecs-agent/agent/acs/model/ecsacs"
 	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/engine/dockerclient"
+
 	"github.com/fsouza/go-dockerclient"
 	"github.com/stretchr/testify/assert"
 )
@@ -39,6 +43,7 @@ const (
 	expectedEmptyVolumeContainerCmd   = "not-applicable"
 
 	expectedMemorySwappinessDefault = memorySwappinessDefault
+	minDockerClientAPIVersion = dockerclient.Version_1_24
 )
 
 func TestPostUnmarshalWindowsCanonicalPaths(t *testing.T) {
@@ -148,10 +153,150 @@ func TestWindowsMemorySwappinessOption(t *testing.T) {
 		},
 	}
 
-	config, configErr := testTask.DockerHostConfig(testTask.Containers[0], dockerMap(testTask), defaultDockerClientAPIVersion)
+	config, configErr := testTask.DockerHostConfig(testTask.Containers[0], dockerMap(testTask), minDockerClientAPIVersion)
 	if configErr != nil {
 		t.Fatal(configErr)
 	}
 
 	assert.EqualValues(t, expectedMemorySwappinessDefault, config.MemorySwappiness)
+}
+
+func TestDockerHostConfigRawConfigMerging(t *testing.T) {
+	// Use a struct that will marshal to the actual message we expect; not
+	// docker.HostConfig which will include a lot of zero values.
+	rawHostConfigInput := struct {
+		Privileged  bool     `json:"Privileged,omitempty" yaml:"Privileged,omitempty"`
+		SecurityOpt []string `json:"SecurityOpt,omitempty" yaml:"SecurityOpt,omitempty"`
+	}{
+		Privileged:  true,
+		SecurityOpt: []string{"foo", "bar"},
+	}
+
+	rawHostConfig, err := json.Marshal(&rawHostConfigInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testTask := &Task{
+		Arn:     "arn:aws:ecs:us-east-1:012345678910:task/c09f0188-7f87-4b0f-bfc3-16296622b6fe",
+		Family:  "myFamily",
+		Version: "1",
+		Containers: []*Container{
+			{
+				Name:        "c1",
+				Image:       "image",
+				CPU:         10,
+				Memory:      100,
+				VolumesFrom: []VolumeFrom{{SourceContainer: "c2"}},
+				DockerConfig: DockerConfig{
+					HostConfig: strptr(string(rawHostConfig)),
+				},
+			},
+			{
+				Name: "c2",
+			},
+		},
+	}
+
+	hostConfig, configErr := testTask.DockerHostConfig(testTask.Containers[0], dockerMap(testTask), minDockerClientAPIVersion)
+	assert.Nil(t, configErr)
+
+	expected := docker.HostConfig{
+		Memory:		  DockerContainerMinimumMemoryInBytes,
+		Privileged:       true,
+		SecurityOpt:      []string{"foo", "bar"},
+		VolumesFrom:      []string{"dockername-c2"},
+		MemorySwappiness: memorySwappinessDefault,
+		CPUPercent:       minimumCPUPercent,
+	}
+
+	assertSetStructFieldsEqual(t, expected, *hostConfig)
+}
+
+// TestSetConfigHostconfigBasedOnAPIVersion tests the docker hostconfig was correctly
+// set based on the docker client version
+func TestSetConfigHostconfigBasedOnAPIVersion(t *testing.T) {
+	memoryMiB := 500
+	testTask := &Task{
+		Containers: []*Container{
+			{
+				Name:   "c1",
+				CPU:    uint(10),
+				Memory: uint(memoryMiB),
+			},
+		},
+	}
+
+	hostconfig, err := testTask.DockerHostConfig(testTask.Containers[0], dockerMap(testTask), minDockerClientAPIVersion)
+	assert.Nil(t, err)
+
+	config, cerr := testTask.DockerConfig(testTask.Containers[0], minDockerClientAPIVersion)
+	assert.Nil(t, cerr)
+	assert.Equal(t, int64(memoryMiB*1024*1024), hostconfig.Memory)
+	assert.Empty(t, hostconfig.CPUShares)
+	assert.Equal(t, int64(minimumCPUPercent), hostconfig.CPUPercent)
+
+	assert.Empty(t, config.CPUShares)
+	assert.Empty(t, config.Memory)
+}
+
+func TestCPUPercentBasedOnUnboundedEnabled(t *testing.T) {
+	cpuShareScaleFactor := runtime.NumCPU() * cpuSharesPerCore
+	testcases := []struct {
+		cpu           int64
+		cpuUnbounded  bool
+		cpuPercent    int64
+	}{
+		{
+			cpu:          0,
+			cpuUnbounded: true,
+			cpuPercent:   0,
+		},
+		{
+			cpu:          1,
+			cpuUnbounded: true,
+			cpuPercent:   1,
+		},
+		{
+			cpu:          0,
+			cpuUnbounded: false,
+			cpuPercent:   1,
+		},
+		{
+			cpu:          1,
+			cpuUnbounded: false,
+			cpuPercent:   1,
+		},
+		{
+			cpu:          100,
+			cpuUnbounded: true,
+			cpuPercent:   100 * percentageFactor / int64(cpuShareScaleFactor),
+		},
+		{
+			cpu:          100,
+			cpuUnbounded: false,
+			cpuPercent:   100 * percentageFactor / int64(cpuShareScaleFactor),
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(fmt.Sprintf("container cpu-%d,cpu unbounded tasks enabled- %t,expected cpu percent-%d",
+			tc.cpu, tc.cpuUnbounded, tc.cpuPercent), func(t *testing.T) {
+			testTask := &Task{
+				Containers: []*Container{
+					{
+						Name:   "c1",
+						CPU:    uint(tc.cpu),
+					},
+				},
+				platformFields: platformFields{
+					cpuUnbounded: tc.cpuUnbounded,
+				},
+			}
+
+			hostconfig, err := testTask.DockerHostConfig(testTask.Containers[0], dockerMap(testTask), minDockerClientAPIVersion)
+			assert.Nil(t, err)
+			assert.Empty(t, hostconfig.CPUShares)
+			assert.Equal(t, tc.cpuPercent, hostconfig.CPUPercent)
+		})
+	}
 }

--- a/agent/config/config_windows.go
+++ b/agent/config/config_windows.go
@@ -48,6 +48,9 @@ func DefaultConfig() Config {
 	programData := utils.DefaultIfBlank(os.Getenv("ProgramData"), `C:\ProgramData`)
 	ecsRoot := filepath.Join(programData, "Amazon", "ECS")
 	dataDir := filepath.Join(ecsRoot, "data")
+	platformVariables := PlatformVariables{
+		CPUUnbounded: false,
+	}
 	return Config{
 		DockerEndpoint: "npipe:////./pipe/docker_engine",
 		ReservedPorts: []uint16{
@@ -79,6 +82,7 @@ func DefaultConfig() Config {
 		NumImagesToDeletePerCycle:   DefaultNumImagesToDeletePerCycle,
 		ContainerMetadataEnabled:    false,
 		TaskCPUMemLimit:             ExplicitlyDisabled,
+		PlatformVariables:           platformVariables,
 	}
 }
 
@@ -94,6 +98,12 @@ func (cfg *Config) platformOverrides() {
 
 	// ensure TaskResourceLimit is disabled
 	cfg.TaskCPUMemLimit = ExplicitlyDisabled
+
+	cpuUnbounded := utils.ParseBool(os.Getenv("ECS_ENABLE_CPU_UNBOUNDED_WINDOWS_WORKAROUND"), false)
+	platformVariables := PlatformVariables{
+		CPUUnbounded: cpuUnbounded,
+	}
+	cfg.PlatformVariables = platformVariables
 }
 
 // platformString returns platform-specific config data that can be serialized

--- a/agent/config/config_windows_test.go
+++ b/agent/config/config_windows_test.go
@@ -51,6 +51,7 @@ func TestConfigDefault(t *testing.T) {
 	assert.Equal(t, DefaultImageCleanupTimeInterval, cfg.ImageCleanupInterval, "ImageCleanupInterval default is set incorrectly")
 	assert.Equal(t, DefaultNumImagesToDeletePerCycle, cfg.NumImagesToDeletePerCycle, "NumImagesToDeletePerCycle default is set incorrectly")
 	assert.Equal(t, `C:\ProgramData\Amazon\ECS\data`, cfg.DataDirOnHost, "Default DataDirOnHost set incorrectly")
+	assert.False(t, cfg.PlatformVariables.CPUUnbounded, "CPUUnbounded should be false by default")
 }
 
 func TestConfigIAMTaskRolesReserves80(t *testing.T) {
@@ -86,4 +87,21 @@ func TestTaskResourceLimitPlatformOverrideDisabled(t *testing.T) {
 	cfg.platformOverrides()
 	assert.NoError(t, err)
 	assert.False(t, cfg.TaskCPUMemLimit.Enabled())
+}
+
+func TestCPUUnboundedSet(t *testing.T) {
+	defer setTestRegion()()
+	defer setTestEnv("ECS_ENABLE_CPU_UNBOUNDED_WINDOWS_WORKAROUND", "true")()
+	cfg, err := NewConfig(ec2.NewBlackholeEC2MetadataClient())
+	cfg.platformOverrides()
+	assert.NoError(t, err)
+	assert.True(t, cfg.PlatformVariables.CPUUnbounded)
+}
+
+func TestCPUUnboundedWindowsDisabled(t *testing.T) {
+	defer setTestRegion()()
+	cfg, err := NewConfig(ec2.NewBlackholeEC2MetadataClient())
+	cfg.platformOverrides()
+	assert.NoError(t, err)
+	assert.False(t, cfg.PlatformVariables.CPUUnbounded)
 }

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -198,4 +198,7 @@ type Config struct {
 	// CgroupPath is the path expected by the agent, defaults to
 	// '/sys/fs/cgroup'
 	CgroupPath string
+
+	// PlatformVariables consists of configuration variables specific to linux/windows
+	PlatformVariables PlatformVariables
 }

--- a/agent/config/types_unix.go
+++ b/agent/config/types_unix.go
@@ -1,0 +1,18 @@
+// +build !windows
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package config
+
+// PlatformVariables consists of configuration variables specific to Linux
+type PlatformVariables struct {}

--- a/agent/config/types_windows.go
+++ b/agent/config/types_windows.go
@@ -1,0 +1,22 @@
+// +build windows
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package config
+
+// PlatformVariables consists of configuration variables specific to Windows
+type PlatformVariables struct {
+	// CPUUnbounded specifies if agent can run a mix of CPU bounded and
+	// unbounded tasks for windows
+	CPUUnbounded bool
+}

--- a/agent/engine/dockerclient/versionsupport_windows.go
+++ b/agent/engine/dockerclient/versionsupport_windows.go
@@ -18,6 +18,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockeriface"
 )
 
+// minDockerAPIVersion is the min Docker API version supported by agent
 const minDockerAPIVersion = Version_1_24
 
 // GetClient will replace some versions of Docker on Windows. We need this because


### PR DESCRIPTION
### Summary
Allow a mix of CPU unbounded and bounded tasks for windows

### Implementation details
- Introduce an agent config variable to allow this behavior 
- if CPU is not set or set to zero, CPU percent and shares of the container will also be zero, else set to 1 if CPU percent calculates to zero 

### Testing
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing
This contribution is under the terms of the Apache 2.0 License: yes
