### PR TITLE
vendor: seelog constrain to version 2.6

### DIFF
--- a/agent/Gopkg.lock
+++ b/agent/Gopkg.lock
@@ -4,7 +4,10 @@
 [[projects]]
   branch = "master"
   name = "github.com/Azure/go-ansiterm"
-  packages = [".","winterm"]
+  packages = [
+    ".",
+    "winterm"
+  ]
   revision = "d6e3b3328b783f23731bc4d058875b0371ff8109"
 
 [[projects]]
@@ -21,14 +24,47 @@
 
 [[projects]]
   name = "github.com/aws/aws-sdk-go"
-  packages = ["aws","aws/arn","aws/awserr","aws/awsutil","aws/client","aws/client/metadata","aws/corehandlers","aws/credentials","aws/credentials/ec2rolecreds","aws/credentials/endpointcreds","aws/credentials/stscreds","aws/defaults","aws/ec2metadata","aws/endpoints","aws/request","aws/session","aws/signer/v4","internal/shareddefaults","private/model/api","private/protocol","private/protocol/json/jsonutil","private/protocol/jsonrpc","private/protocol/query","private/protocol/query/queryutil","private/protocol/rest","private/protocol/xml/xmlutil","private/util","service/cloudwatch","service/cloudwatchlogs","service/iam","service/sts"]
+  packages = [
+    "aws",
+    "aws/arn",
+    "aws/awserr",
+    "aws/awsutil",
+    "aws/client",
+    "aws/client/metadata",
+    "aws/corehandlers",
+    "aws/credentials",
+    "aws/credentials/ec2rolecreds",
+    "aws/credentials/endpointcreds",
+    "aws/credentials/stscreds",
+    "aws/defaults",
+    "aws/ec2metadata",
+    "aws/endpoints",
+    "aws/request",
+    "aws/session",
+    "aws/signer/v4",
+    "internal/shareddefaults",
+    "private/model/api",
+    "private/protocol",
+    "private/protocol/json/jsonutil",
+    "private/protocol/jsonrpc",
+    "private/protocol/query",
+    "private/protocol/query/queryutil",
+    "private/protocol/rest",
+    "private/protocol/xml/xmlutil",
+    "private/util",
+    "service/cloudwatch",
+    "service/cloudwatchlogs",
+    "service/iam",
+    "service/sts"
+  ]
   revision = "decd990ddc5dcdf2f73309cbcab90d06b996ca28"
   version = "v1.12.67"
 
 [[projects]]
   name = "github.com/cihub/seelog"
   packages = ["."]
-  revision = "0fa7e41d2b9600ca6b7e1592478124e4f800f724"
+  revision = "d2c6e5aa9fbfdd1c624e140287063c7730654115"
+  version = "v2.6"
 
 [[projects]]
   name = "github.com/containerd/cgroups"
@@ -43,7 +79,14 @@
 
 [[projects]]
   name = "github.com/containernetworking/cni"
-  packages = ["libcni","pkg/invoke","pkg/types","pkg/types/020","pkg/types/current","pkg/version"]
+  packages = [
+    "libcni",
+    "pkg/invoke",
+    "pkg/types",
+    "pkg/types/020",
+    "pkg/types/current",
+    "pkg/version"
+  ]
   revision = "137b4975ecab6e1f0c24c1e3c228a50a3cfba75e"
   version = "v0.5.2"
 
@@ -66,14 +109,45 @@
 
 [[projects]]
   name = "github.com/didip/tollbooth"
-  packages = [".","errors","libstring","limiter"]
+  packages = [
+    ".",
+    "errors",
+    "libstring",
+    "limiter"
+  ]
   revision = "b65680a2d5f624ed528d36f8406f31535555828a"
   version = "v3.0.2"
 
 [[projects]]
   branch = "master"
   name = "github.com/docker/docker"
-  packages = ["api/types","api/types/blkiodev","api/types/container","api/types/filters","api/types/mount","api/types/network","api/types/registry","api/types/strslice","api/types/swarm","api/types/swarm/runtime","api/types/versions","opts","pkg/archive","pkg/fileutils","pkg/homedir","pkg/idtools","pkg/ioutils","pkg/jsonmessage","pkg/longpath","pkg/mount","pkg/pools","pkg/stdcopy","pkg/system","pkg/term","pkg/term/windows"]
+  packages = [
+    "api/types",
+    "api/types/blkiodev",
+    "api/types/container",
+    "api/types/filters",
+    "api/types/mount",
+    "api/types/network",
+    "api/types/registry",
+    "api/types/strslice",
+    "api/types/swarm",
+    "api/types/swarm/runtime",
+    "api/types/versions",
+    "opts",
+    "pkg/archive",
+    "pkg/fileutils",
+    "pkg/homedir",
+    "pkg/idtools",
+    "pkg/ioutils",
+    "pkg/jsonmessage",
+    "pkg/longpath",
+    "pkg/mount",
+    "pkg/pools",
+    "pkg/stdcopy",
+    "pkg/system",
+    "pkg/term",
+    "pkg/term/windows"
+  ]
   revision = "e4d0fe84f9ea88b0e0cfd847412c9f29442cc62d"
 
 [[projects]]
@@ -134,13 +208,19 @@
 
 [[projects]]
   name = "github.com/opencontainers/image-spec"
-  packages = ["specs-go","specs-go/v1"]
+  packages = [
+    "specs-go",
+    "specs-go/v1"
+  ]
   revision = "d60099175f88c47cd379c4738d158884749ed235"
   version = "v1.0.1"
 
 [[projects]]
   name = "github.com/opencontainers/runc"
-  packages = ["libcontainer/system","libcontainer/user"]
+  packages = [
+    "libcontainer/system",
+    "libcontainer/user"
+  ]
   revision = "baf6536d6259209c3edfa2b22237af82942d3dfa"
   version = "v0.1.1"
 
@@ -179,12 +259,19 @@
 
 [[projects]]
   name = "github.com/stretchr/testify"
-  packages = ["assert","require","suite"]
+  packages = [
+    "assert",
+    "require",
+    "suite"
+  ]
   revision = "d77da356e56a7428ad25149ca77381849a6a5232"
 
 [[projects]]
   name = "github.com/vishvananda/netlink"
-  packages = [".","nl"]
+  packages = [
+    ".",
+    "nl"
+  ]
   revision = "fe3b5664d23a11b52ba59bece4ff29c52772a56b"
 
 [[projects]]
@@ -202,13 +289,24 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
-  packages = ["context","context/ctxhttp","html","html/atom"]
+  packages = [
+    "context",
+    "context/ctxhttp",
+    "html",
+    "html/atom"
+  ]
   revision = "a337091b0525af65de94df2eb7e98bd9962dcbe2"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
-  packages = ["unix","windows","windows/registry","windows/svc","windows/svc/eventlog"]
+  packages = [
+    "unix",
+    "windows",
+    "windows/registry",
+    "windows/svc",
+    "windows/svc/eventlog"
+  ]
   revision = "bf42f188b9bc6f2cf5b8ee5a912ef1aedd0eba4c"
 
 [[projects]]
@@ -219,12 +317,15 @@
 
 [[projects]]
   name = "golang.org/x/tools"
-  packages = ["go/ast/astutil","imports"]
+  packages = [
+    "go/ast/astutil",
+    "imports"
+  ]
   revision = "bd4635fd25596cdd56c1fb399c53b351d1a81f2d"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "f3c3630bda365e370bc57e47aff0254d1c57e1c6788ac9a976264af7b0769369"
+  inputs-digest = "aa121c36f9f7f82cdfeba64e43e0987eb8f962e95f4539dbcdfead65d85aabe7"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/agent/Gopkg.toml
+++ b/agent/Gopkg.toml
@@ -27,7 +27,7 @@
 
 [[constraint]]
   name = "github.com/cihub/seelog"
-  revision ="0fa7e41d2b9600ca6b7e1592478124e4f800f724"
+  version ="2.6"
 
 [[constraint]]
   name = "github.com/containerd/cgroups"

--- a/agent/vendor/github.com/cihub/seelog/behavior_adaptivelogger.go
+++ b/agent/vendor/github.com/cihub/seelog/behavior_adaptivelogger.go
@@ -49,8 +49,8 @@ type asyncAdaptiveLogger struct {
 	maxInterval      time.Duration
 }
 
-// newAsyncLoopLogger creates a new asynchronous adaptive logger
-func newAsyncAdaptiveLogger(
+// NewAsyncLoopLogger creates a new asynchronous adaptive logger
+func NewAsyncAdaptiveLogger(
 	config *logConfig,
 	minInterval time.Duration,
 	maxInterval time.Duration,
@@ -90,11 +90,11 @@ func (asnAdaptiveLogger *asyncAdaptiveLogger) processItem() (closed bool, itemCo
 	asnAdaptiveLogger.queueHasElements.L.Lock()
 	defer asnAdaptiveLogger.queueHasElements.L.Unlock()
 
-	for asnAdaptiveLogger.msgQueue.Len() == 0 && !asnAdaptiveLogger.closed {
+	for asnAdaptiveLogger.msgQueue.Len() == 0 && !asnAdaptiveLogger.Closed() {
 		asnAdaptiveLogger.queueHasElements.Wait()
 	}
 
-	if asnAdaptiveLogger.closed {
+	if asnAdaptiveLogger.Closed() {
 		return true, asnAdaptiveLogger.msgQueue.Len()
 	}
 
@@ -115,7 +115,7 @@ func (asnAdaptiveLogger *asyncAdaptiveLogger) calcAdaptiveInterval(msgCount int)
 }
 
 func (asnAdaptiveLogger *asyncAdaptiveLogger) processQueue() {
-	for !asnAdaptiveLogger.closed {
+	for !asnAdaptiveLogger.Closed() {
 		closed, itemCount := asnAdaptiveLogger.processItem()
 
 		if closed {

--- a/agent/vendor/github.com/cihub/seelog/behavior_asynclogger.go
+++ b/agent/vendor/github.com/cihub/seelog/behavior_asynclogger.go
@@ -72,7 +72,7 @@ func (asnLogger *asyncLogger) Close() {
 	asnLogger.m.Lock()
 	defer asnLogger.m.Unlock()
 
-	if !asnLogger.closed {
+	if !asnLogger.Closed() {
 		asnLogger.flushQueue(true)
 		asnLogger.config.RootDispatcher.Flush()
 
@@ -80,6 +80,9 @@ func (asnLogger *asyncLogger) Close() {
 			reportInternalError(err)
 		}
 
+		asnLogger.closedM.Lock()
+		asnLogger.closed = true
+		asnLogger.closedM.Unlock()
 		asnLogger.queueHasElements.Broadcast()
 	}
 }
@@ -88,7 +91,7 @@ func (asnLogger *asyncLogger) Flush() {
 	asnLogger.m.Lock()
 	defer asnLogger.m.Unlock()
 
-	if !asnLogger.closed {
+	if !asnLogger.Closed() {
 		asnLogger.flushQueue(true)
 		asnLogger.config.RootDispatcher.Flush()
 	}
@@ -119,7 +122,7 @@ func (asnLogger *asyncLogger) addMsgToQueue(
 	context LogContextInterface,
 	message fmt.Stringer) {
 
-	if !asnLogger.closed {
+	if !asnLogger.Closed() {
 		asnLogger.queueHasElements.L.Lock()
 		defer asnLogger.queueHasElements.L.Unlock()
 

--- a/agent/vendor/github.com/cihub/seelog/behavior_asynclooplogger.go
+++ b/agent/vendor/github.com/cihub/seelog/behavior_asynclooplogger.go
@@ -30,8 +30,8 @@ type asyncLoopLogger struct {
 	asyncLogger
 }
 
-// newAsyncLoopLogger creates a new asynchronous loop logger
-func newAsyncLoopLogger(config *logConfig) *asyncLoopLogger {
+// NewAsyncLoopLogger creates a new asynchronous loop logger
+func NewAsyncLoopLogger(config *logConfig) *asyncLoopLogger {
 
 	asnLoopLogger := new(asyncLoopLogger)
 
@@ -46,11 +46,11 @@ func (asnLoopLogger *asyncLoopLogger) processItem() (closed bool) {
 	asnLoopLogger.queueHasElements.L.Lock()
 	defer asnLoopLogger.queueHasElements.L.Unlock()
 
-	for asnLoopLogger.msgQueue.Len() == 0 && !asnLoopLogger.closed {
+	for asnLoopLogger.msgQueue.Len() == 0 && !asnLoopLogger.Closed() {
 		asnLoopLogger.queueHasElements.Wait()
 	}
 
-	if asnLoopLogger.closed {
+	if asnLoopLogger.Closed() {
 		return true
 	}
 
@@ -59,7 +59,7 @@ func (asnLoopLogger *asyncLoopLogger) processItem() (closed bool) {
 }
 
 func (asnLoopLogger *asyncLoopLogger) processQueue() {
-	for !asnLoopLogger.closed {
+	for !asnLoopLogger.Closed() {
 		closed := asnLoopLogger.processItem()
 
 		if closed {

--- a/agent/vendor/github.com/cihub/seelog/behavior_asynctimerlogger.go
+++ b/agent/vendor/github.com/cihub/seelog/behavior_asynctimerlogger.go
@@ -36,8 +36,8 @@ type asyncTimerLogger struct {
 	interval time.Duration
 }
 
-// newAsyncLoopLogger creates a new asynchronous loop logger
-func newAsyncTimerLogger(config *logConfig, interval time.Duration) (*asyncTimerLogger, error) {
+// NewAsyncLoopLogger creates a new asynchronous loop logger
+func NewAsyncTimerLogger(config *logConfig, interval time.Duration) (*asyncTimerLogger, error) {
 
 	if interval <= 0 {
 		return nil, errors.New("async logger interval should be > 0")
@@ -57,11 +57,11 @@ func (asnTimerLogger *asyncTimerLogger) processItem() (closed bool) {
 	asnTimerLogger.queueHasElements.L.Lock()
 	defer asnTimerLogger.queueHasElements.L.Unlock()
 
-	for asnTimerLogger.msgQueue.Len() == 0 && !asnTimerLogger.closed {
+	for asnTimerLogger.msgQueue.Len() == 0 && !asnTimerLogger.Closed() {
 		asnTimerLogger.queueHasElements.Wait()
 	}
 
-	if asnTimerLogger.closed {
+	if asnTimerLogger.Closed() {
 		return true
 	}
 
@@ -70,7 +70,7 @@ func (asnTimerLogger *asyncTimerLogger) processItem() (closed bool) {
 }
 
 func (asnTimerLogger *asyncTimerLogger) processQueue() {
-	for !asnTimerLogger.closed {
+	for !asnTimerLogger.Closed() {
 		closed := asnTimerLogger.processItem()
 
 		if closed {

--- a/agent/vendor/github.com/cihub/seelog/behavior_synclogger.go
+++ b/agent/vendor/github.com/cihub/seelog/behavior_synclogger.go
@@ -34,8 +34,8 @@ type syncLogger struct {
 	commonLogger
 }
 
-// newSyncLogger creates a new synchronous logger
-func newSyncLogger(config *logConfig) *syncLogger {
+// NewSyncLogger creates a new synchronous logger
+func NewSyncLogger(config *logConfig) *syncLogger {
 	syncLogger := new(syncLogger)
 
 	syncLogger.commonLogger = *newCommonLogger(config, syncLogger)
@@ -55,10 +55,13 @@ func (syncLogger *syncLogger) Close() {
 	syncLogger.m.Lock()
 	defer syncLogger.m.Unlock()
 
-	if !syncLogger.closed {
+	if !syncLogger.Closed() {
 		if err := syncLogger.config.RootDispatcher.Close(); err != nil {
 			reportInternalError(err)
 		}
+		syncLogger.closedM.Lock()
+		syncLogger.closed = true
+		syncLogger.closedM.Unlock()
 	}
 }
 
@@ -66,7 +69,7 @@ func (syncLogger *syncLogger) Flush() {
 	syncLogger.m.Lock()
 	defer syncLogger.m.Unlock()
 
-	if !syncLogger.closed {
+	if !syncLogger.Closed() {
 		syncLogger.config.RootDispatcher.Flush()
 	}
 }

--- a/agent/vendor/github.com/cihub/seelog/cfg_config.go
+++ b/agent/vendor/github.com/cihub/seelog/cfg_config.go
@@ -44,7 +44,7 @@ func LoggerFromConfigAsFile(fileName string) (LoggerInterface, error) {
 		return nil, err
 	}
 
-	return createLoggerFromConfig(conf)
+	return createLoggerFromFullConfig(conf)
 }
 
 // LoggerFromConfigAsBytes creates a logger with config from bytes stream. Bytes should contain valid seelog xml.
@@ -54,7 +54,7 @@ func LoggerFromConfigAsBytes(data []byte) (LoggerInterface, error) {
 		return nil, err
 	}
 
-	return createLoggerFromConfig(conf)
+	return createLoggerFromFullConfig(conf)
 }
 
 // LoggerFromConfigAsString creates a logger with config from a string. String should contain valid seelog xml.
@@ -76,7 +76,7 @@ func LoggerFromParamConfigAsFile(fileName string, parserParams *CfgParseParams) 
 		return nil, err
 	}
 
-	return createLoggerFromConfig(conf)
+	return createLoggerFromFullConfig(conf)
 }
 
 // LoggerFromParamConfigAsBytes does the same as LoggerFromConfigAsBytes, but includes special parser options.
@@ -87,7 +87,7 @@ func LoggerFromParamConfigAsBytes(data []byte, parserParams *CfgParseParams) (Lo
 		return nil, err
 	}
 
-	return createLoggerFromConfig(conf)
+	return createLoggerFromFullConfig(conf)
 }
 
 // LoggerFromParamConfigAsString does the same as LoggerFromConfigAsString, but includes special parser options.
@@ -109,25 +109,25 @@ func LoggerFromWriterWithMinLevel(output io.Writer, minLevel LogLevel) (LoggerIn
 //
 // Can be called for usage with non-Seelog systems
 func LoggerFromWriterWithMinLevelAndFormat(output io.Writer, minLevel LogLevel, format string) (LoggerInterface, error) {
-	constraints, err := newMinMaxConstraints(minLevel, CriticalLvl)
+	constraints, err := NewMinMaxConstraints(minLevel, CriticalLvl)
 	if err != nil {
 		return nil, err
 	}
-	formatter, err := newFormatter(format)
+	formatter, err := NewFormatter(format)
 	if err != nil {
 		return nil, err
 	}
-	dispatcher, err := newSplitDispatcher(formatter, []interface{}{output})
-	if err != nil {
-		return nil, err
-	}
-
-	conf, err := newConfig(constraints, make([]*logLevelException, 0), dispatcher, syncloggerTypeFromString, nil, nil)
+	dispatcher, err := NewSplitDispatcher(formatter, []interface{}{output})
 	if err != nil {
 		return nil, err
 	}
 
-	return createLoggerFromConfig(conf)
+	conf, err := newFullLoggerConfig(constraints, make([]*LogLevelException, 0), dispatcher, syncloggerTypeFromString, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return createLoggerFromFullConfig(conf)
 }
 
 // LoggerFromXMLDecoder creates logger with config from a XML decoder starting from a specific node.
@@ -138,7 +138,7 @@ func LoggerFromXMLDecoder(xmlParser *xml.Decoder, rootNode xml.Token) (LoggerInt
 		return nil, err
 	}
 
-	return createLoggerFromConfig(conf)
+	return createLoggerFromFullConfig(conf)
 }
 
 // LoggerFromCustomReceiver creates a proxy logger that uses a CustomReceiver as the
@@ -165,24 +165,24 @@ func LoggerFromXMLDecoder(xmlParser *xml.Decoder, rootNode xml.Token) (LoggerInt
 // * LoggerFromCustomReceiver takes value and uses it without modification and
 // reinstantiation, directy passing it to the dispatcher tree.
 func LoggerFromCustomReceiver(receiver CustomReceiver) (LoggerInterface, error) {
-	constraints, err := newMinMaxConstraints(TraceLvl, CriticalLvl)
+	constraints, err := NewMinMaxConstraints(TraceLvl, CriticalLvl)
 	if err != nil {
 		return nil, err
 	}
 
-	output, err := newCustomReceiverDispatcherByValue(msgonlyformatter, receiver, "user-proxy", CustomReceiverInitArgs{})
+	output, err := NewCustomReceiverDispatcherByValue(msgonlyformatter, receiver, "user-proxy", CustomReceiverInitArgs{})
 	if err != nil {
 		return nil, err
 	}
-	dispatcher, err := newSplitDispatcher(msgonlyformatter, []interface{}{output})
-	if err != nil {
-		return nil, err
-	}
-
-	conf, err := newConfig(constraints, make([]*logLevelException, 0), dispatcher, syncloggerTypeFromString, nil, nil)
+	dispatcher, err := NewSplitDispatcher(msgonlyformatter, []interface{}{output})
 	if err != nil {
 		return nil, err
 	}
 
-	return createLoggerFromConfig(conf)
+	conf, err := newFullLoggerConfig(constraints, make([]*LogLevelException, 0), dispatcher, syncloggerTypeFromString, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return createLoggerFromFullConfig(conf)
 }

--- a/agent/vendor/github.com/cihub/seelog/cfg_logconfig_test.go
+++ b/agent/vendor/github.com/cihub/seelog/cfg_logconfig_test.go
@@ -46,7 +46,7 @@ func TestConfig(t *testing.T) {
 		return
 	}
 
-	context, err := currentContext()
+	context, err := currentContext(nil)
 	if err != nil {
 		t.Errorf("cannot get current context:" + err.Error())
 		return
@@ -91,9 +91,9 @@ func TestConfig(t *testing.T) {
 }
 
 func getFirstContext() (LogContextInterface, error) {
-	return currentContext()
+	return currentContext(nil)
 }
 
 func getSecondContext() (LogContextInterface, error) {
-	return currentContext()
+	return currentContext(nil)
 }

--- a/agent/vendor/github.com/cihub/seelog/cfg_parser.go
+++ b/agent/vendor/github.com/cihub/seelog/cfg_parser.go
@@ -180,7 +180,7 @@ func fillPredefinedFormats() error {
 	predefinedFormats = make(map[string]*formatter)
 
 	for formatKey, format := range predefinedFormatsWithoutPrefix {
-		formatter, err := newFormatter(format)
+		formatter, err := NewFormatter(format)
 		if err != nil {
 			return err
 		}
@@ -194,14 +194,14 @@ func fillPredefinedFormats() error {
 // configFromXMLDecoder parses data from a given XML decoder.
 // Returns parsed config which can be used to create logger in case no errors occured.
 // Returns error if format is incorrect or anything happened.
-func configFromXMLDecoder(xmlParser *xml.Decoder, rootNode xml.Token) (*logConfig, error) {
+func configFromXMLDecoder(xmlParser *xml.Decoder, rootNode xml.Token) (*configForParsing, error) {
 	return configFromXMLDecoderWithConfig(xmlParser, rootNode, nil)
 }
 
 // configFromXMLDecoderWithConfig parses data from a given XML decoder.
 // Returns parsed config which can be used to create logger in case no errors occured.
 // Returns error if format is incorrect or anything happened.
-func configFromXMLDecoderWithConfig(xmlParser *xml.Decoder, rootNode xml.Token, cfg *CfgParseParams) (*logConfig, error) {
+func configFromXMLDecoderWithConfig(xmlParser *xml.Decoder, rootNode xml.Token, cfg *CfgParseParams) (*configForParsing, error) {
 	_, ok := rootNode.(xml.StartElement)
 	if !ok {
 		return nil, errors.New("rootNode must be XML startElement")
@@ -221,14 +221,14 @@ func configFromXMLDecoderWithConfig(xmlParser *xml.Decoder, rootNode xml.Token, 
 // configFromReader parses data from a given reader.
 // Returns parsed config which can be used to create logger in case no errors occured.
 // Returns error if format is incorrect or anything happened.
-func configFromReader(reader io.Reader) (*logConfig, error) {
+func configFromReader(reader io.Reader) (*configForParsing, error) {
 	return configFromReaderWithConfig(reader, nil)
 }
 
 // configFromReaderWithConfig parses data from a given reader.
 // Returns parsed config which can be used to create logger in case no errors occured.
 // Returns error if format is incorrect or anything happened.
-func configFromReaderWithConfig(reader io.Reader, cfg *CfgParseParams) (*logConfig, error) {
+func configFromReaderWithConfig(reader io.Reader, cfg *CfgParseParams) (*configForParsing, error) {
 	config, err := unmarshalConfig(reader)
 	if err != nil {
 		return nil, err
@@ -241,7 +241,7 @@ func configFromReaderWithConfig(reader io.Reader, cfg *CfgParseParams) (*logConf
 	return configFromXMLNodeWithConfig(config, cfg)
 }
 
-func configFromXMLNodeWithConfig(config *xmlNode, cfg *CfgParseParams) (*logConfig, error) {
+func configFromXMLNodeWithConfig(config *xmlNode, cfg *CfgParseParams) (*configForParsing, error) {
 	err := checkUnexpectedAttribute(
 		config,
 		minLevelID,
@@ -297,7 +297,7 @@ func configFromXMLNodeWithConfig(config *xmlNode, cfg *CfgParseParams) (*logConf
 		return nil, err
 	}
 
-	return newConfig(constraints, exceptions, dispatcher, loggerType, logData, cfg)
+	return newFullLoggerConfig(constraints, exceptions, dispatcher, loggerType, logData, cfg)
 }
 
 func getConstraints(node *xmlNode) (logLevelConstraints, error) {
@@ -315,7 +315,7 @@ func getConstraints(node *xmlNode) (logLevelConstraints, error) {
 	if (isLevels && strings.TrimSpace(levelsStr) == offString) ||
 		(isMinLevel && !isMaxLevel && minLevelStr == offString) {
 
-		return newOffConstraints()
+		return NewOffConstraints()
 	}
 
 	if isLevels {
@@ -323,7 +323,7 @@ func getConstraints(node *xmlNode) (logLevelConstraints, error) {
 		if err != nil {
 			return nil, err
 		}
-		return newListConstraints(levels)
+		return NewListConstraints(levels)
 	}
 
 	var minLevel = LogLevel(TraceLvl)
@@ -344,7 +344,7 @@ func getConstraints(node *xmlNode) (logLevelConstraints, error) {
 		}
 	}
 
-	return newMinMaxConstraints(minLevel, maxLevel)
+	return NewMinMaxConstraints(minLevel, maxLevel)
 }
 
 func parseLevels(str string) ([]LogLevel, error) {
@@ -362,8 +362,8 @@ func parseLevels(str string) ([]LogLevel, error) {
 	return levels, nil
 }
 
-func getExceptions(config *xmlNode) ([]*logLevelException, error) {
-	var exceptions []*logLevelException
+func getExceptions(config *xmlNode) ([]*LogLevelException, error) {
+	var exceptions []*LogLevelException
 
 	var exceptionsNode *xmlNode
 	for _, child := range config.children {
@@ -411,7 +411,7 @@ func getExceptions(config *xmlNode) ([]*logLevelException, error) {
 			filePattern = "*"
 		}
 
-		exception, err := newLogLevelException(funcPattern, filePattern, constraints)
+		exception, err := NewLogLevelException(funcPattern, filePattern, constraints)
 		if err != nil {
 			return nil, errors.New("incorrect exception node: " + err.Error())
 		}
@@ -422,7 +422,7 @@ func getExceptions(config *xmlNode) ([]*logLevelException, error) {
 	return exceptions, nil
 }
 
-func checkDistinctExceptions(exceptions []*logLevelException) error {
+func checkDistinctExceptions(exceptions []*LogLevelException) error {
 	for i, exception := range exceptions {
 		for j, exception1 := range exceptions {
 			if i == j {
@@ -485,7 +485,7 @@ func getFormats(config *xmlNode) (map[string]*formatter, error) {
 			return nil, errors.New("format[" + id + "] has no '" + formatAttrID + "' attribute")
 		}
 
-		formatter, err := newFormatter(formatStr)
+		formatter, err := NewFormatter(formatStr)
 		if err != nil {
 			return nil, err
 		}
@@ -574,7 +574,7 @@ func getOutputsTree(config *xmlNode, formats map[string]*formatter, cfg *CfgPars
 			return nil, err
 		}
 
-		formatter, err := getCurrentFormat(outputsNode, defaultformatter, formats)
+		formatter, err := getCurrentFormat(outputsNode, DefaultFormatter, formats)
 		if err != nil {
 			return nil, err
 		}
@@ -590,11 +590,11 @@ func getOutputsTree(config *xmlNode, formats map[string]*formatter, cfg *CfgPars
 		}
 	}
 
-	console, err := newConsoleWriter()
+	console, err := NewConsoleWriter()
 	if err != nil {
 		return nil, err
 	}
-	return newSplitDispatcher(defaultformatter, []interface{}{console})
+	return NewSplitDispatcher(DefaultFormatter, []interface{}{console})
 }
 
 func getCurrentFormat(node *xmlNode, formatFromParent *formatter, formats map[string]*formatter) (*formatter, error) {
@@ -657,7 +657,7 @@ func createSplitter(node *xmlNode, formatFromParent *formatter, formats map[stri
 		return nil, err
 	}
 
-	return newSplitDispatcher(currentFormat, receivers)
+	return NewSplitDispatcher(currentFormat, receivers)
 }
 
 func createCustomReceiver(node *xmlNode, formatFromParent *formatter, formats map[string]*formatter, cfg *CfgParseParams) (interface{}, error) {
@@ -699,7 +699,7 @@ func createCustomReceiver(node *xmlNode, formatFromParent *formatter, formats ma
 			if err != nil {
 				return nil, err
 			}
-			creceiver, err := newCustomReceiverDispatcherByValue(currentFormat, rec, customName, args)
+			creceiver, err := NewCustomReceiverDispatcherByValue(currentFormat, rec, customName, args)
 			if err != nil {
 				return nil, err
 			}
@@ -711,7 +711,7 @@ func createCustomReceiver(node *xmlNode, formatFromParent *formatter, formats ma
 		}
 	}
 
-	return newCustomReceiverDispatcher(currentFormat, customName, args)
+	return NewCustomReceiverDispatcher(currentFormat, customName, args)
 }
 
 func createFilter(node *xmlNode, formatFromParent *formatter, formats map[string]*formatter, cfg *CfgParseParams) (interface{}, error) {
@@ -744,7 +744,7 @@ func createFilter(node *xmlNode, formatFromParent *formatter, formats map[string
 		return nil, err
 	}
 
-	return newFilterDispatcher(currentFormat, receivers, levels...)
+	return NewFilterDispatcher(currentFormat, receivers, levels...)
 }
 
 func createfileWriter(node *xmlNode, formatFromParent *formatter, formats map[string]*formatter, cfg *CfgParseParams) (interface{}, error) {
@@ -767,12 +767,12 @@ func createfileWriter(node *xmlNode, formatFromParent *formatter, formats map[st
 		return nil, newMissingArgumentError(node.name, pathID)
 	}
 
-	fileWriter, err := newFileWriter(path)
+	fileWriter, err := NewFileWriter(path)
 	if err != nil {
 		return nil, err
 	}
 
-	return newFormattedWriter(fileWriter, currentFormat)
+	return NewFormattedWriter(fileWriter, currentFormat)
 }
 
 // Creates new SMTP writer if encountered in the config file.
@@ -870,7 +870,7 @@ func createSMTPWriter(node *xmlNode, formatFromParent *formatter, formats map[st
 		subjectPhrase = subject
 	}
 
-	smtpWriter := newSMTPWriter(
+	smtpWriter := NewSMTPWriter(
 		senderAddress,
 		senderName,
 		recipientAddresses,
@@ -883,7 +883,7 @@ func createSMTPWriter(node *xmlNode, formatFromParent *formatter, formats map[st
 		mailHeaders,
 	)
 
-	return newFormattedWriter(smtpWriter, currentFormat)
+	return NewFormattedWriter(smtpWriter, currentFormat)
 }
 
 func createConsoleWriter(node *xmlNode, formatFromParent *formatter, formats map[string]*formatter, cfg *CfgParseParams) (interface{}, error) {
@@ -901,12 +901,12 @@ func createConsoleWriter(node *xmlNode, formatFromParent *formatter, formats map
 		return nil, err
 	}
 
-	consoleWriter, err := newConsoleWriter()
+	consoleWriter, err := NewConsoleWriter()
 	if err != nil {
 		return nil, err
 	}
 
-	return newFormattedWriter(consoleWriter, currentFormat)
+	return NewFormattedWriter(consoleWriter, currentFormat)
 }
 
 func createconnWriter(node *xmlNode, formatFromParent *formatter, formats map[string]*formatter, cfg *CfgParseParams) (interface{}, error) {
@@ -970,13 +970,13 @@ func createconnWriter(node *xmlNode, formatFromParent *formatter, formats map[st
 			}
 			config := tls.Config{InsecureSkipVerify: insecureSkipVerify}
 			connWriter := newTLSWriter(net, addr, reconnectOnMsg, &config)
-			return newFormattedWriter(connWriter, currentFormat)
+			return NewFormattedWriter(connWriter, currentFormat)
 		}
 	}
 
-	connWriter := newConnWriter(net, addr, reconnectOnMsg)
+	connWriter := NewConnWriter(net, addr, reconnectOnMsg)
 
-	return newFormattedWriter(connWriter, currentFormat)
+	return NewFormattedWriter(connWriter, currentFormat)
 }
 
 func createRollingFileWriter(node *xmlNode, formatFromParent *formatter, formats map[string]*formatter, cfg *CfgParseParams) (interface{}, error) {
@@ -1069,12 +1069,12 @@ func createRollingFileWriter(node *xmlNode, formatFromParent *formatter, formats
 			}
 		}
 
-		rollingWriter, err := newRollingFileWriterSize(path, rArchiveType, rArchivePath, maxSize, maxRolls, nameMode)
+		rollingWriter, err := NewRollingFileWriterSize(path, rArchiveType, rArchivePath, maxSize, maxRolls, nameMode)
 		if err != nil {
 			return nil, err
 		}
 
-		return newFormattedWriter(rollingWriter, currentFormat)
+		return NewFormattedWriter(rollingWriter, currentFormat)
 
 	} else if rollingType == rollingTypeTime {
 		err := checkUnexpectedAttribute(node, outputFormatID, rollingFileTypeAttr, rollingFilePathAttr,
@@ -1098,12 +1098,12 @@ func createRollingFileWriter(node *xmlNode, formatFromParent *formatter, formats
 			return nil, newMissingArgumentError(node.name, rollingFileDataPatternAttr)
 		}
 
-		rollingWriter, err := newRollingFileWriterTime(path, rArchiveType, rArchivePath, maxRolls, dataPattern, rollingIntervalAny, nameMode)
+		rollingWriter, err := NewRollingFileWriterTime(path, rArchiveType, rArchivePath, maxRolls, dataPattern, rollingIntervalAny, nameMode)
 		if err != nil {
 			return nil, err
 		}
 
-		return newFormattedWriter(rollingWriter, currentFormat)
+		return NewFormattedWriter(rollingWriter, currentFormat)
 	}
 
 	return nil, errors.New("incorrect rolling writer type " + rollingTypeStr)
@@ -1159,12 +1159,12 @@ func createbufferedWriter(node *xmlNode, formatFromParent *formatter, formats ma
 		return nil, errors.New("inner writer cannot have his own format")
 	}
 
-	bufferedWriter, err := newBufferedWriter(formattedWriter.Writer(), size, time.Duration(flushPeriod))
+	bufferedWriter, err := NewBufferedWriter(formattedWriter.Writer(), size, time.Duration(flushPeriod))
 	if err != nil {
 		return nil, err
 	}
 
-	return newFormattedWriter(bufferedWriter, currentFormat)
+	return NewFormattedWriter(bufferedWriter, currentFormat)
 }
 
 // Returns an error if node has any attributes not listed in expectedAttrs.

--- a/agent/vendor/github.com/cihub/seelog/cfg_parser_test.go
+++ b/agent/vendor/github.com/cihub/seelog/cfg_parser_test.go
@@ -82,7 +82,7 @@ var parserTests []parserTest
 type parserTest struct {
 	testName      string
 	config        string
-	expected      *logConfig //interface{}
+	expected      *configForParsing //interface{}
 	errorExpected bool
 	parserConfig  *CfgParseParams
 }
@@ -100,11 +100,11 @@ func getParserTests() []parserTest {
 			</outputs>
 		</seelog>
 		`
-		testExpected := new(logConfig)
-		testExpected.Constraints, _ = newMinMaxConstraints(TraceLvl, CriticalLvl)
+		testExpected := new(configForParsing)
+		testExpected.Constraints, _ = NewMinMaxConstraints(TraceLvl, CriticalLvl)
 		testExpected.Exceptions = nil
-		testfileWriter, _ := newFileWriter(testLogFileName)
-		testHeadSplitter, _ := newSplitDispatcher(defaultformatter, []interface{}{testfileWriter})
+		testfileWriter, _ := NewFileWriter(testLogFileName)
+		testHeadSplitter, _ := NewSplitDispatcher(DefaultFormatter, []interface{}{testfileWriter})
 		testExpected.LogType = asyncLooploggerTypeFromString
 		testExpected.RootDispatcher = testHeadSplitter
 		parserTests = append(parserTests, parserTest{testName, testConfig, testExpected, false, nil})
@@ -120,12 +120,12 @@ func getParserTests() []parserTest {
 			</outputs>
 		</seelog>
 		`
-		testExpected = new(logConfig)
-		testExpected.Constraints, _ = newMinMaxConstraints(TraceLvl, CriticalLvl)
+		testExpected = new(configForParsing)
+		testExpected.Constraints, _ = NewMinMaxConstraints(TraceLvl, CriticalLvl)
 		testExpected.Exceptions = nil
-		testfileWriter, _ = newFileWriter(testLogFileName)
-		testFilter, _ := newFilterDispatcher(defaultformatter, []interface{}{testfileWriter}, DebugLvl, InfoLvl, CriticalLvl)
-		testHeadSplitter, _ = newSplitDispatcher(defaultformatter, []interface{}{testFilter})
+		testfileWriter, _ = NewFileWriter(testLogFileName)
+		testFilter, _ := NewFilterDispatcher(DefaultFormatter, []interface{}{testfileWriter}, DebugLvl, InfoLvl, CriticalLvl)
+		testHeadSplitter, _ = NewSplitDispatcher(DefaultFormatter, []interface{}{testFilter})
 		testExpected.LogType = syncloggerTypeFromString
 		testExpected.RootDispatcher = testHeadSplitter
 		parserTests = append(parserTests, parserTest{testName, testConfig, testExpected, false, nil})
@@ -138,11 +138,11 @@ func getParserTests() []parserTest {
 			</outputs>
 		</seelog>
 		`
-		testExpected = new(logConfig)
-		testExpected.Constraints, _ = newMinMaxConstraints(TraceLvl, CriticalLvl)
+		testExpected = new(configForParsing)
+		testExpected.Constraints, _ = NewMinMaxConstraints(TraceLvl, CriticalLvl)
 		testExpected.Exceptions = nil
-		testconsoleWriter, _ := newConsoleWriter()
-		testHeadSplitter, _ = newSplitDispatcher(defaultformatter, []interface{}{testconsoleWriter})
+		testconsoleWriter, _ := NewConsoleWriter()
+		testHeadSplitter, _ = NewSplitDispatcher(DefaultFormatter, []interface{}{testconsoleWriter})
 		testExpected.LogType = syncloggerTypeFromString
 		testExpected.RootDispatcher = testHeadSplitter
 		parserTests = append(parserTests, parserTest{testName, testConfig, testExpected, false, nil})
@@ -162,10 +162,10 @@ func getParserTests() []parserTest {
 </seelog>
 		`
 
-		testExpected = new(logConfig)
-		testExpected.Constraints, _ = newMinMaxConstraints(TraceLvl, CriticalLvl)
+		testExpected = new(configForParsing)
+		testExpected.Constraints, _ = NewMinMaxConstraints(TraceLvl, CriticalLvl)
 		testExpected.Exceptions = nil
-		testSMTPWriter := newSMTPWriter(
+		testSMTPWriter := NewSMTPWriter(
 			"sa",
 			"sn",
 			[]string{"ra1", "ra2", "ra3"},
@@ -177,7 +177,7 @@ func getParserTests() []parserTest {
 			DefaultSubjectPhrase,
 			nil,
 		)
-		testHeadSplitter, _ = newSplitDispatcher(defaultformatter, []interface{}{testSMTPWriter})
+		testHeadSplitter, _ = NewSplitDispatcher(DefaultFormatter, []interface{}{testSMTPWriter})
 		testExpected.LogType = asyncLooploggerTypeFromString
 		testExpected.RootDispatcher = testHeadSplitter
 		parserTests = append(parserTests, parserTest{testName, testConfig, testExpected, false, nil})
@@ -197,10 +197,10 @@ func getParserTests() []parserTest {
 	</outputs>
 </seelog>
 		`
-		testExpected = new(logConfig)
-		testExpected.Constraints, _ = newMinMaxConstraints(TraceLvl, CriticalLvl)
+		testExpected = new(configForParsing)
+		testExpected.Constraints, _ = NewMinMaxConstraints(TraceLvl, CriticalLvl)
 		testExpected.Exceptions = nil
-		testSMTPWriter = newSMTPWriter(
+		testSMTPWriter = NewSMTPWriter(
 			"sa",
 			"sn",
 			[]string{"ra1"},
@@ -212,7 +212,7 @@ func getParserTests() []parserTest {
 			"ohlala",
 			[]string{"Priority: Urgent", "Importance: high", "Sensitivity: Company-Confidential", "Auto-Submitted: auto-generated"},
 		)
-		testHeadSplitter, _ = newSplitDispatcher(defaultformatter, []interface{}{testSMTPWriter})
+		testHeadSplitter, _ = NewSplitDispatcher(DefaultFormatter, []interface{}{testSMTPWriter})
 		testExpected.LogType = asyncLooploggerTypeFromString
 		testExpected.RootDispatcher = testHeadSplitter
 		parserTests = append(parserTests, parserTest{testName, testConfig, testExpected, false, nil})
@@ -221,11 +221,11 @@ func getParserTests() []parserTest {
 		testConfig = `
 		<seelog type="sync"/>
 		`
-		testExpected = new(logConfig)
-		testExpected.Constraints, _ = newMinMaxConstraints(TraceLvl, CriticalLvl)
+		testExpected = new(configForParsing)
+		testExpected.Constraints, _ = NewMinMaxConstraints(TraceLvl, CriticalLvl)
 		testExpected.Exceptions = nil
-		testconsoleWriter, _ = newConsoleWriter()
-		testHeadSplitter, _ = newSplitDispatcher(defaultformatter, []interface{}{testconsoleWriter})
+		testconsoleWriter, _ = NewConsoleWriter()
+		testHeadSplitter, _ = NewSplitDispatcher(DefaultFormatter, []interface{}{testconsoleWriter})
 		testExpected.LogType = syncloggerTypeFromString
 		testExpected.RootDispatcher = testHeadSplitter
 		parserTests = append(parserTests, parserTest{testName, testConfig, testExpected, false, nil})
@@ -234,11 +234,11 @@ func getParserTests() []parserTest {
 		testConfig = `
 		<seelog type="asyncloop"/>
 		`
-		testExpected = new(logConfig)
-		testExpected.Constraints, _ = newMinMaxConstraints(TraceLvl, CriticalLvl)
+		testExpected = new(configForParsing)
+		testExpected.Constraints, _ = NewMinMaxConstraints(TraceLvl, CriticalLvl)
 		testExpected.Exceptions = nil
-		testconsoleWriter, _ = newConsoleWriter()
-		testHeadSplitter, _ = newSplitDispatcher(defaultformatter, []interface{}{testconsoleWriter})
+		testconsoleWriter, _ = NewConsoleWriter()
+		testHeadSplitter, _ = NewSplitDispatcher(DefaultFormatter, []interface{}{testconsoleWriter})
 		testExpected.LogType = asyncLooploggerTypeFromString
 		testExpected.RootDispatcher = testHeadSplitter
 		parserTests = append(parserTests, parserTest{testName, testConfig, testExpected, false, nil})
@@ -247,11 +247,11 @@ func getParserTests() []parserTest {
 		testConfig = `
 		<seelog type="asynctimer" asyncinterval="101"/>
 		`
-		testExpected = new(logConfig)
-		testExpected.Constraints, _ = newMinMaxConstraints(TraceLvl, CriticalLvl)
+		testExpected = new(configForParsing)
+		testExpected.Constraints, _ = NewMinMaxConstraints(TraceLvl, CriticalLvl)
 		testExpected.Exceptions = nil
-		testconsoleWriter, _ = newConsoleWriter()
-		testHeadSplitter, _ = newSplitDispatcher(defaultformatter, []interface{}{testconsoleWriter})
+		testconsoleWriter, _ = NewConsoleWriter()
+		testHeadSplitter, _ = NewSplitDispatcher(DefaultFormatter, []interface{}{testconsoleWriter})
 		testExpected.LogType = asyncTimerloggerTypeFromString
 		testExpected.LoggerData = asyncTimerLoggerData{101}
 		testExpected.RootDispatcher = testHeadSplitter
@@ -266,11 +266,11 @@ func getParserTests() []parserTest {
 			</outputs>
 		</seelog>
 		`
-		testExpected = new(logConfig)
-		testExpected.Constraints, _ = newMinMaxConstraints(TraceLvl, CriticalLvl)
+		testExpected = new(configForParsing)
+		testExpected.Constraints, _ = NewMinMaxConstraints(TraceLvl, CriticalLvl)
 		testExpected.Exceptions = nil
-		testrollingFileWriter, _ := newRollingFileWriterSize(testLogFileName, rollingArchiveNone, "", 100, 5, rollingNameModePostfix)
-		testHeadSplitter, _ = newSplitDispatcher(defaultformatter, []interface{}{testrollingFileWriter})
+		testrollingFileWriter, _ := NewRollingFileWriterSize(testLogFileName, rollingArchiveNone, "", 100, 5, rollingNameModePostfix)
+		testHeadSplitter, _ = NewSplitDispatcher(DefaultFormatter, []interface{}{testrollingFileWriter})
 		testExpected.LogType = syncloggerTypeFromString
 		testExpected.RootDispatcher = testHeadSplitter
 		parserTests = append(parserTests, parserTest{testName, testConfig, testExpected, false, nil})
@@ -283,11 +283,11 @@ func getParserTests() []parserTest {
 				<rollingfile type="size" filename="` + testLogFileName + `" maxsize="100" maxrolls="5" archivetype="zip"/>
 			</outputs>
 		</seelog>`
-		testExpected = new(logConfig)
-		testExpected.Constraints, _ = newMinMaxConstraints(TraceLvl, CriticalLvl)
+		testExpected = new(configForParsing)
+		testExpected.Constraints, _ = NewMinMaxConstraints(TraceLvl, CriticalLvl)
 		testExpected.Exceptions = nil
-		testrollingFileWriter, _ = newRollingFileWriterSize(testLogFileName, rollingArchiveZip, "log.zip", 100, 5, rollingNameModePostfix)
-		testHeadSplitter, _ = newSplitDispatcher(defaultformatter, []interface{}{testrollingFileWriter})
+		testrollingFileWriter, _ = NewRollingFileWriterSize(testLogFileName, rollingArchiveZip, "log.zip", 100, 5, rollingNameModePostfix)
+		testHeadSplitter, _ = NewSplitDispatcher(DefaultFormatter, []interface{}{testrollingFileWriter})
 		testExpected.LogType = syncloggerTypeFromString
 		testExpected.RootDispatcher = testHeadSplitter
 		parserTests = append(parserTests, parserTest{testName, testConfig, testExpected, false, nil})
@@ -300,11 +300,11 @@ func getParserTests() []parserTest {
 				<rollingfile namemode="prefix" type="size" filename="` + testLogFileName + `" maxsize="100" maxrolls="5" archivetype="zip" archivepath="test.zip"/>
 			</outputs>
 		</seelog>`
-		testExpected = new(logConfig)
-		testExpected.Constraints, _ = newMinMaxConstraints(TraceLvl, CriticalLvl)
+		testExpected = new(configForParsing)
+		testExpected.Constraints, _ = NewMinMaxConstraints(TraceLvl, CriticalLvl)
 		testExpected.Exceptions = nil
-		testrollingFileWriter, _ = newRollingFileWriterSize(testLogFileName, rollingArchiveZip, "test.zip", 100, 5, rollingNameModePrefix)
-		testHeadSplitter, _ = newSplitDispatcher(defaultformatter, []interface{}{testrollingFileWriter})
+		testrollingFileWriter, _ = NewRollingFileWriterSize(testLogFileName, rollingArchiveZip, "test.zip", 100, 5, rollingNameModePrefix)
+		testHeadSplitter, _ = NewSplitDispatcher(DefaultFormatter, []interface{}{testrollingFileWriter})
 		testExpected.LogType = syncloggerTypeFromString
 		testExpected.RootDispatcher = testHeadSplitter
 		parserTests = append(parserTests, parserTest{testName, testConfig, testExpected, false, nil})
@@ -317,11 +317,11 @@ func getParserTests() []parserTest {
 				<rollingfile namemode="postfix" type="size" filename="` + testLogFileName + `" maxsize="100" maxrolls="5" archivetype="none"/>
 			</outputs>
 		</seelog>`
-		testExpected = new(logConfig)
-		testExpected.Constraints, _ = newMinMaxConstraints(TraceLvl, CriticalLvl)
+		testExpected = new(configForParsing)
+		testExpected.Constraints, _ = NewMinMaxConstraints(TraceLvl, CriticalLvl)
 		testExpected.Exceptions = nil
-		testrollingFileWriter, _ = newRollingFileWriterSize(testLogFileName, rollingArchiveNone, "", 100, 5, rollingNameModePostfix)
-		testHeadSplitter, _ = newSplitDispatcher(defaultformatter, []interface{}{testrollingFileWriter})
+		testrollingFileWriter, _ = NewRollingFileWriterSize(testLogFileName, rollingArchiveNone, "", 100, 5, rollingNameModePostfix)
+		testHeadSplitter, _ = NewSplitDispatcher(DefaultFormatter, []interface{}{testrollingFileWriter})
 		testExpected.LogType = syncloggerTypeFromString
 		testExpected.RootDispatcher = testHeadSplitter
 		parserTests = append(parserTests, parserTest{testName, testConfig, testExpected, false, nil})
@@ -334,11 +334,11 @@ func getParserTests() []parserTest {
 				<rollingfile type="date" filename="` + testLogFileName + `" datepattern="2006-01-02T15:04:05Z07:00" />
 			</outputs>
 		</seelog>`
-		testExpected = new(logConfig)
-		testExpected.Constraints, _ = newMinMaxConstraints(TraceLvl, CriticalLvl)
+		testExpected = new(configForParsing)
+		testExpected.Constraints, _ = NewMinMaxConstraints(TraceLvl, CriticalLvl)
 		testExpected.Exceptions = nil
-		testrollingFileWriterTime, _ := newRollingFileWriterTime(testLogFileName, rollingArchiveNone, "", 0, "2006-01-02T15:04:05Z07:00", rollingIntervalAny, rollingNameModePostfix)
-		testHeadSplitter, _ = newSplitDispatcher(defaultformatter, []interface{}{testrollingFileWriterTime})
+		testrollingFileWriterTime, _ := NewRollingFileWriterTime(testLogFileName, rollingArchiveNone, "", 0, "2006-01-02T15:04:05Z07:00", rollingIntervalAny, rollingNameModePostfix)
+		testHeadSplitter, _ = NewSplitDispatcher(DefaultFormatter, []interface{}{testrollingFileWriterTime})
 		testExpected.LogType = syncloggerTypeFromString
 		testExpected.RootDispatcher = testHeadSplitter
 		parserTests = append(parserTests, parserTest{testName, testConfig, testExpected, false, nil})
@@ -353,12 +353,12 @@ func getParserTests() []parserTest {
 				</buffered>
 			</outputs>
 		</seelog>`
-		testExpected = new(logConfig)
-		testExpected.Constraints, _ = newMinMaxConstraints(TraceLvl, CriticalLvl)
+		testExpected = new(configForParsing)
+		testExpected.Constraints, _ = NewMinMaxConstraints(TraceLvl, CriticalLvl)
 		testExpected.Exceptions = nil
-		testrollingFileWriterTime, _ = newRollingFileWriterTime(testLogFileName, rollingArchiveNone, "", 0, "2006-01-02T15:04:05Z07:00", rollingIntervalDaily, rollingNameModePostfix)
-		testbufferedWriter, _ := newBufferedWriter(testrollingFileWriterTime, 100500, 100)
-		testHeadSplitter, _ = newSplitDispatcher(defaultformatter, []interface{}{testbufferedWriter})
+		testrollingFileWriterTime, _ = NewRollingFileWriterTime(testLogFileName, rollingArchiveNone, "", 0, "2006-01-02T15:04:05Z07:00", rollingIntervalDaily, rollingNameModePostfix)
+		testbufferedWriter, _ := NewBufferedWriter(testrollingFileWriterTime, 100500, 100)
+		testHeadSplitter, _ = NewSplitDispatcher(DefaultFormatter, []interface{}{testbufferedWriter})
 		testExpected.LogType = syncloggerTypeFromString
 		testExpected.RootDispatcher = testHeadSplitter
 		parserTests = append(parserTests, parserTest{testName, testConfig, testExpected, false, nil})
@@ -378,14 +378,14 @@ func getParserTests() []parserTest {
 			</outputs>
 		</seelog>
 		`
-		testExpected = new(logConfig)
-		testExpected.Constraints, _ = newMinMaxConstraints(TraceLvl, CriticalLvl)
+		testExpected = new(configForParsing)
+		testExpected.Constraints, _ = NewMinMaxConstraints(TraceLvl, CriticalLvl)
 		testExpected.Exceptions = nil
-		testfileWriter1, _ := newFileWriter(testLogFileName2)
-		testfileWriter2, _ := newFileWriter(testLogFileName3)
-		testInnerSplitter, _ := newSplitDispatcher(defaultformatter, []interface{}{testfileWriter1, testfileWriter2})
-		testfileWriter, _ = newFileWriter(testLogFileName1)
-		testHeadSplitter, _ = newSplitDispatcher(defaultformatter, []interface{}{testfileWriter, testInnerSplitter})
+		testfileWriter1, _ := NewFileWriter(testLogFileName2)
+		testfileWriter2, _ := NewFileWriter(testLogFileName3)
+		testInnerSplitter, _ := NewSplitDispatcher(DefaultFormatter, []interface{}{testfileWriter1, testfileWriter2})
+		testfileWriter, _ = NewFileWriter(testLogFileName1)
+		testHeadSplitter, _ = NewSplitDispatcher(DefaultFormatter, []interface{}{testfileWriter, testInnerSplitter})
 		testExpected.LogType = syncloggerTypeFromString
 		testExpected.RootDispatcher = testHeadSplitter
 		parserTests = append(parserTests, parserTest{testName, testConfig, testExpected, false, nil})
@@ -400,15 +400,15 @@ func getParserTests() []parserTest {
 			</outputs>
 		</seelog>
 		`
-		testExpected = new(logConfig)
-		testExpected.Constraints, _ = newMinMaxConstraints(TraceLvl, CriticalLvl)
+		testExpected = new(configForParsing)
+		testExpected.Constraints, _ = NewMinMaxConstraints(TraceLvl, CriticalLvl)
 		testExpected.Exceptions = nil
-		testCustomReceiver, _ := newCustomReceiverDispatcher(defaultformatter, "custom-name-1", CustomReceiverInitArgs{
+		testCustomReceiver, _ := NewCustomReceiverDispatcher(DefaultFormatter, "custom-name-1", CustomReceiverInitArgs{
 			XmlCustomAttrs: map[string]string{
 				"test": "set",
 			},
 		})
-		testHeadSplitter, _ = newSplitDispatcher(defaultformatter, []interface{}{testCustomReceiver})
+		testHeadSplitter, _ = NewSplitDispatcher(DefaultFormatter, []interface{}{testCustomReceiver})
 		testExpected.LogType = syncloggerTypeFromString
 		testExpected.RootDispatcher = testHeadSplitter
 		parserTests = append(parserTests, parserTest{testName, testConfig, testExpected, false, nil})
@@ -421,8 +421,8 @@ func getParserTests() []parserTest {
 			</outputs>
 		</seelog>
 		`
-		testExpected = new(logConfig)
-		testExpected.Constraints, _ = newMinMaxConstraints(TraceLvl, CriticalLvl)
+		testExpected = new(configForParsing)
+		testExpected.Constraints, _ = NewMinMaxConstraints(TraceLvl, CriticalLvl)
 		testExpected.Exceptions = nil
 		crec := &customTestReceiver{}
 		cargs := CustomReceiverInitArgs{
@@ -431,8 +431,8 @@ func getParserTests() []parserTest {
 			},
 		}
 		crec.AfterParse(cargs)
-		testCustomReceiver2, _ := newCustomReceiverDispatcherByValue(defaultformatter, crec, "custom-name-2", cargs)
-		testHeadSplitter, _ = newSplitDispatcher(defaultformatter, []interface{}{testCustomReceiver2})
+		testCustomReceiver2, _ := NewCustomReceiverDispatcherByValue(DefaultFormatter, crec, "custom-name-2", cargs)
+		testHeadSplitter, _ = NewSplitDispatcher(DefaultFormatter, []interface{}{testCustomReceiver2})
 		testExpected.LogType = syncloggerTypeFromString
 		testExpected.RootDispatcher = testHeadSplitter
 		fnc := func(initArgs CustomReceiverInitArgs) (CustomReceiver, error) {
@@ -455,8 +455,8 @@ func getParserTests() []parserTest {
 			</outputs>
 		</seelog>
 		`
-		testExpected = new(logConfig)
-		testExpected.Constraints, _ = newMinMaxConstraints(TraceLvl, CriticalLvl)
+		testExpected = new(configForParsing)
+		testExpected.Constraints, _ = NewMinMaxConstraints(TraceLvl, CriticalLvl)
 		testExpected.Exceptions = nil
 		creccustom := &customTestReceiver{}
 		cargs3 := CustomReceiverInitArgs{
@@ -465,8 +465,8 @@ func getParserTests() []parserTest {
 			},
 		}
 		creccustom.AfterParse(cargs3)
-		testCustomReceiver, _ = newCustomReceiverDispatcherByValue(defaultformatter, creccustom, "-", cargs3)
-		testHeadSplitter, _ = newSplitDispatcher(defaultformatter, []interface{}{testCustomReceiver})
+		testCustomReceiver, _ = NewCustomReceiverDispatcherByValue(DefaultFormatter, creccustom, "-", cargs3)
+		testHeadSplitter, _ = NewSplitDispatcher(DefaultFormatter, []interface{}{testCustomReceiver})
 		testExpected.LogType = syncloggerTypeFromString
 		testExpected.RootDispatcher = testHeadSplitter
 		parserTests = append(parserTests, parserTest{testName, testConfig, testExpected, false, nil})
@@ -481,19 +481,19 @@ func getParserTests() []parserTest {
 			</outputs>
 		</seelog>
 		`
-		testExpected = new(logConfig)
-		testExpected.Constraints, _ = newMinMaxConstraints(TraceLvl, CriticalLvl)
+		testExpected = new(configForParsing)
+		testExpected.Constraints, _ = NewMinMaxConstraints(TraceLvl, CriticalLvl)
 		testExpected.Exceptions = nil
 		testCustomReceivers := make([]*customReceiverDispatcher, 3)
 		for i := 0; i < 3; i++ {
-			testCustomReceivers[i], _ = newCustomReceiverDispatcher(defaultformatter, "custom-name-1", CustomReceiverInitArgs{
+			testCustomReceivers[i], _ = NewCustomReceiverDispatcher(DefaultFormatter, "custom-name-1", CustomReceiverInitArgs{
 				XmlCustomAttrs: map[string]string{
 					"test": fmt.Sprintf("set%d", i+1),
 				},
 			})
 		}
 
-		testHeadSplitter, _ = newSplitDispatcher(defaultformatter, []interface{}{testCustomReceivers[0], testCustomReceivers[1], testCustomReceivers[2]})
+		testHeadSplitter, _ = NewSplitDispatcher(DefaultFormatter, []interface{}{testCustomReceivers[0], testCustomReceivers[1], testCustomReceivers[2]})
 		testExpected.LogType = syncloggerTypeFromString
 		testExpected.RootDispatcher = testHeadSplitter
 		parserTests = append(parserTests, parserTest{testName, testConfig, testExpected, false, nil})
@@ -510,12 +510,12 @@ func getParserTests() []parserTest {
 			</formats>
 		</seelog>
 		`
-		testExpected = new(logConfig)
-		testExpected.Constraints, _ = newMinMaxConstraints(TraceLvl, CriticalLvl)
+		testExpected = new(configForParsing)
+		testExpected.Constraints, _ = NewMinMaxConstraints(TraceLvl, CriticalLvl)
 		testExpected.Exceptions = nil
-		testfileWriter, _ = newFileWriter(testLogFileName)
-		testFormat, _ := newFormatter("%Level %Msg %File")
-		testHeadSplitter, _ = newSplitDispatcher(testFormat, []interface{}{testfileWriter})
+		testfileWriter, _ = NewFileWriter(testLogFileName)
+		testFormat, _ := NewFormatter("%Level %Msg %File")
+		testHeadSplitter, _ = NewSplitDispatcher(testFormat, []interface{}{testfileWriter})
 		testExpected.LogType = syncloggerTypeFromString
 		testExpected.RootDispatcher = testHeadSplitter
 		parserTests = append(parserTests, parserTest{testName, testConfig, testExpected, false, nil})
@@ -535,59 +535,59 @@ func getParserTests() []parserTest {
 			</formats>
 		</seelog>
 		`
-		testExpected = new(logConfig)
-		testExpected.Constraints, _ = newMinMaxConstraints(TraceLvl, CriticalLvl)
+		testExpected = new(configForParsing)
+		testExpected.Constraints, _ = NewMinMaxConstraints(TraceLvl, CriticalLvl)
 		testExpected.Exceptions = nil
-		testfileWriter, _ = newFileWriter(testLogFileName)
-		testfileWriter1, _ = newFileWriter(testLogFileName1)
-		testFormat1, _ := newFormatter("%Level %Msg %File")
-		testFormat2, _ := newFormatter("%l %Msg")
-		formattedWriter, _ := newFormattedWriter(testfileWriter1, testFormat2)
-		testHeadSplitter, _ = newSplitDispatcher(testFormat1, []interface{}{testfileWriter, formattedWriter})
+		testfileWriter, _ = NewFileWriter(testLogFileName)
+		testfileWriter1, _ = NewFileWriter(testLogFileName1)
+		testFormat1, _ := NewFormatter("%Level %Msg %File")
+		testFormat2, _ := NewFormatter("%l %Msg")
+		formattedWriter, _ := NewFormattedWriter(testfileWriter1, testFormat2)
+		testHeadSplitter, _ = NewSplitDispatcher(testFormat1, []interface{}{testfileWriter, formattedWriter})
 		testExpected.LogType = syncloggerTypeFromString
 		testExpected.RootDispatcher = testHeadSplitter
 		parserTests = append(parserTests, parserTest{testName, testConfig, testExpected, false, nil})
 
 		testName = "Minlevel = warn"
 		testConfig = `<seelog minlevel="warn"/>`
-		testExpected = new(logConfig)
-		testExpected.Constraints, _ = newMinMaxConstraints(WarnLvl, CriticalLvl)
+		testExpected = new(configForParsing)
+		testExpected.Constraints, _ = NewMinMaxConstraints(WarnLvl, CriticalLvl)
 		testExpected.Exceptions = nil
-		testconsoleWriter, _ = newConsoleWriter()
-		testHeadSplitter, _ = newSplitDispatcher(defaultformatter, []interface{}{testconsoleWriter})
+		testconsoleWriter, _ = NewConsoleWriter()
+		testHeadSplitter, _ = NewSplitDispatcher(DefaultFormatter, []interface{}{testconsoleWriter})
 		testExpected.LogType = asyncLooploggerTypeFromString
 		testExpected.RootDispatcher = testHeadSplitter
 		parserTests = append(parserTests, parserTest{testName, testConfig, testExpected, false, nil})
 
 		testName = "Maxlevel = trace"
 		testConfig = `<seelog maxlevel="trace"/>`
-		testExpected = new(logConfig)
-		testExpected.Constraints, _ = newMinMaxConstraints(TraceLvl, TraceLvl)
+		testExpected = new(configForParsing)
+		testExpected.Constraints, _ = NewMinMaxConstraints(TraceLvl, TraceLvl)
 		testExpected.Exceptions = nil
-		testconsoleWriter, _ = newConsoleWriter()
-		testHeadSplitter, _ = newSplitDispatcher(defaultformatter, []interface{}{testconsoleWriter})
+		testconsoleWriter, _ = NewConsoleWriter()
+		testHeadSplitter, _ = NewSplitDispatcher(DefaultFormatter, []interface{}{testconsoleWriter})
 		testExpected.LogType = asyncLooploggerTypeFromString
 		testExpected.RootDispatcher = testHeadSplitter
 		parserTests = append(parserTests, parserTest{testName, testConfig, testExpected, false, nil})
 
 		testName = "Level between info and error"
 		testConfig = `<seelog minlevel="info" maxlevel="error"/>`
-		testExpected = new(logConfig)
-		testExpected.Constraints, _ = newMinMaxConstraints(InfoLvl, ErrorLvl)
+		testExpected = new(configForParsing)
+		testExpected.Constraints, _ = NewMinMaxConstraints(InfoLvl, ErrorLvl)
 		testExpected.Exceptions = nil
-		testconsoleWriter, _ = newConsoleWriter()
-		testHeadSplitter, _ = newSplitDispatcher(defaultformatter, []interface{}{testconsoleWriter})
+		testconsoleWriter, _ = NewConsoleWriter()
+		testHeadSplitter, _ = NewSplitDispatcher(DefaultFormatter, []interface{}{testconsoleWriter})
 		testExpected.LogType = asyncLooploggerTypeFromString
 		testExpected.RootDispatcher = testHeadSplitter
 		parserTests = append(parserTests, parserTest{testName, testConfig, testExpected, false, nil})
 
 		testName = "Off with minlevel"
 		testConfig = `<seelog minlevel="off"/>`
-		testExpected = new(logConfig)
-		testExpected.Constraints, _ = newOffConstraints()
+		testExpected = new(configForParsing)
+		testExpected.Constraints, _ = NewOffConstraints()
 		testExpected.Exceptions = nil
-		testconsoleWriter, _ = newConsoleWriter()
-		testHeadSplitter, _ = newSplitDispatcher(defaultformatter, []interface{}{testconsoleWriter})
+		testconsoleWriter, _ = NewConsoleWriter()
+		testHeadSplitter, _ = NewSplitDispatcher(DefaultFormatter, []interface{}{testconsoleWriter})
 		testExpected.LogType = asyncLooploggerTypeFromString
 		testExpected.RootDispatcher = testHeadSplitter
 		parserTests = append(parserTests, parserTest{testName, testConfig, testExpected, false, nil})
@@ -598,12 +598,12 @@ func getParserTests() []parserTest {
 
 		testName = "Levels list"
 		testConfig = `<seelog levels="debug, info, critical"/>`
-		testExpected = new(logConfig)
-		testExpected.Constraints, _ = newListConstraints([]LogLevel{
+		testExpected = new(configForParsing)
+		testExpected.Constraints, _ = NewListConstraints([]LogLevel{
 			DebugLvl, InfoLvl, CriticalLvl})
 		testExpected.Exceptions = nil
-		testconsoleWriter, _ = newConsoleWriter()
-		testHeadSplitter, _ = newSplitDispatcher(defaultformatter, []interface{}{testconsoleWriter})
+		testconsoleWriter, _ = NewConsoleWriter()
+		testHeadSplitter, _ = NewSplitDispatcher(DefaultFormatter, []interface{}{testconsoleWriter})
 		testExpected.LogType = asyncLooploggerTypeFromString
 		testExpected.RootDispatcher = testHeadSplitter
 		parserTests = append(parserTests, parserTest{testName, testConfig, testExpected, false, nil})
@@ -694,13 +694,13 @@ func getParserTests() []parserTest {
 			</exceptions>
 		</seelog>
 		`
-		testExpected = new(logConfig)
-		testExpected.Constraints, _ = newMinMaxConstraints(TraceLvl, CriticalLvl)
-		listConstraint, _ := newOffConstraints()
-		exception, _ := newLogLevelException("Test*", "someFile.go", listConstraint)
-		testExpected.Exceptions = []*logLevelException{exception}
-		testconsoleWriter, _ = newConsoleWriter()
-		testHeadSplitter, _ = newSplitDispatcher(defaultformatter, []interface{}{testconsoleWriter})
+		testExpected = new(configForParsing)
+		testExpected.Constraints, _ = NewMinMaxConstraints(TraceLvl, CriticalLvl)
+		listConstraint, _ := NewOffConstraints()
+		exception, _ := NewLogLevelException("Test*", "someFile.go", listConstraint)
+		testExpected.Exceptions = []*LogLevelException{exception}
+		testconsoleWriter, _ = NewConsoleWriter()
+		testHeadSplitter, _ = NewSplitDispatcher(DefaultFormatter, []interface{}{testconsoleWriter})
 		testExpected.LogType = syncloggerTypeFromString
 		testExpected.RootDispatcher = testHeadSplitter
 		parserTests = append(parserTests, parserTest{testName, testConfig, testExpected, false, nil})
@@ -714,13 +714,13 @@ func getParserTests() []parserTest {
 			</exceptions>
 		</seelog>
 		`
-		testExpected = new(logConfig)
-		testExpected.Constraints, _ = newListConstraints([]LogLevel{ErrorLvl})
-		minMaxConstraint, _ := newMinMaxConstraints(TraceLvl, CriticalLvl)
-		exception, _ = newLogLevelException("*", "testfile.go", minMaxConstraint)
-		testExpected.Exceptions = []*logLevelException{exception}
-		testconsoleWriter, _ = newConsoleWriter()
-		testHeadSplitter, _ = newSplitDispatcher(defaultformatter, []interface{}{testconsoleWriter})
+		testExpected = new(configForParsing)
+		testExpected.Constraints, _ = NewListConstraints([]LogLevel{ErrorLvl})
+		minMaxConstraint, _ := NewMinMaxConstraints(TraceLvl, CriticalLvl)
+		exception, _ = NewLogLevelException("*", "testfile.go", minMaxConstraint)
+		testExpected.Exceptions = []*LogLevelException{exception}
+		testconsoleWriter, _ = NewConsoleWriter()
+		testHeadSplitter, _ = NewSplitDispatcher(DefaultFormatter, []interface{}{testconsoleWriter})
 		testExpected.LogType = syncloggerTypeFromString
 		testExpected.RootDispatcher = testHeadSplitter
 		parserTests = append(parserTests, parserTest{testName, testConfig, testExpected, false, nil})
@@ -733,13 +733,13 @@ func getParserTests() []parserTest {
 			</exceptions>
 		</seelog>
 		`
-		testExpected = new(logConfig)
-		testExpected.Constraints, _ = newOffConstraints()
-		minMaxConstraint, _ = newMinMaxConstraints(WarnLvl, CriticalLvl)
-		exception, _ = newLogLevelException("*", "testfile.go", minMaxConstraint)
-		testExpected.Exceptions = []*logLevelException{exception}
-		testconsoleWriter, _ = newConsoleWriter()
-		testHeadSplitter, _ = newSplitDispatcher(defaultformatter, []interface{}{testconsoleWriter})
+		testExpected = new(configForParsing)
+		testExpected.Constraints, _ = NewOffConstraints()
+		minMaxConstraint, _ = NewMinMaxConstraints(WarnLvl, CriticalLvl)
+		exception, _ = NewLogLevelException("*", "testfile.go", minMaxConstraint)
+		testExpected.Exceptions = []*LogLevelException{exception}
+		testconsoleWriter, _ = NewConsoleWriter()
+		testHeadSplitter, _ = NewSplitDispatcher(DefaultFormatter, []interface{}{testconsoleWriter})
 		testExpected.LogType = syncloggerTypeFromString
 		testExpected.RootDispatcher = testHeadSplitter
 		parserTests = append(parserTests, parserTest{testName, testConfig, testExpected, false, nil})
@@ -752,12 +752,12 @@ func getParserTests() []parserTest {
 				<console />
 			</outputs>
 		</seelog>`
-		testExpected = new(logConfig)
-		testExpected.Constraints, _ = newMinMaxConstraints(TraceLvl, CriticalLvl)
+		testExpected = new(configForParsing)
+		testExpected.Constraints, _ = NewMinMaxConstraints(TraceLvl, CriticalLvl)
 		testExpected.Exceptions = nil
-		testconsoleWriter, _ = newConsoleWriter()
+		testconsoleWriter, _ = NewConsoleWriter()
 		testFormat, _ = predefinedFormats[formatID]
-		testHeadSplitter, _ = newSplitDispatcher(testFormat, []interface{}{testconsoleWriter})
+		testHeadSplitter, _ = NewSplitDispatcher(testFormat, []interface{}{testconsoleWriter})
 		testExpected.LogType = syncloggerTypeFromString
 		testExpected.RootDispatcher = testHeadSplitter
 		parserTests = append(parserTests, parserTest{testName, testConfig, testExpected, false, nil})
@@ -774,12 +774,12 @@ func getParserTests() []parserTest {
 				<format id="` + formatID + `" format="%Level %Msg %File" />
 			</formats>
 		</seelog>`
-		testExpected = new(logConfig)
-		testExpected.Constraints, _ = newMinMaxConstraints(TraceLvl, CriticalLvl)
+		testExpected = new(configForParsing)
+		testExpected.Constraints, _ = NewMinMaxConstraints(TraceLvl, CriticalLvl)
 		testExpected.Exceptions = nil
-		testfileWriter, _ = newFileWriter(testLogFileName)
-		testFormat, _ = newFormatter("%Level %Msg %File")
-		testHeadSplitter, _ = newSplitDispatcher(testFormat, []interface{}{testfileWriter})
+		testfileWriter, _ = NewFileWriter(testLogFileName)
+		testFormat, _ = NewFormatter("%Level %Msg %File")
+		testHeadSplitter, _ = NewSplitDispatcher(testFormat, []interface{}{testfileWriter})
 		testExpected.LogType = syncloggerTypeFromString
 		testExpected.RootDispatcher = testHeadSplitter
 		parserTests = append(parserTests, parserTest{testName, testConfig, testExpected, false, nil})
@@ -791,11 +791,11 @@ func getParserTests() []parserTest {
 				<conn net="tcp" addr=":8888" />
 			</outputs>
 		</seelog>`
-		testExpected = new(logConfig)
-		testExpected.Constraints, _ = newMinMaxConstraints(TraceLvl, CriticalLvl)
+		testExpected = new(configForParsing)
+		testExpected.Constraints, _ = NewMinMaxConstraints(TraceLvl, CriticalLvl)
 		testExpected.Exceptions = nil
-		testConnWriter := newConnWriter("tcp", ":8888", false)
-		testHeadSplitter, _ = newSplitDispatcher(defaultformatter, []interface{}{testConnWriter})
+		testConnWriter := NewConnWriter("tcp", ":8888", false)
+		testHeadSplitter, _ = NewSplitDispatcher(DefaultFormatter, []interface{}{testConnWriter})
 		testExpected.LogType = syncloggerTypeFromString
 		testExpected.RootDispatcher = testHeadSplitter
 		parserTests = append(parserTests, parserTest{testName, testConfig, testExpected, false, nil})
@@ -807,11 +807,11 @@ func getParserTests() []parserTest {
 				<conn net="tcp" addr=":8888" reconnectonmsg="true" />
 			</outputs>
 		</seelog>`
-		testExpected = new(logConfig)
-		testExpected.Constraints, _ = newMinMaxConstraints(TraceLvl, CriticalLvl)
+		testExpected = new(configForParsing)
+		testExpected.Constraints, _ = NewMinMaxConstraints(TraceLvl, CriticalLvl)
 		testExpected.Exceptions = nil
-		testConnWriter = newConnWriter("tcp", ":8888", true)
-		testHeadSplitter, _ = newSplitDispatcher(defaultformatter, []interface{}{testConnWriter})
+		testConnWriter = NewConnWriter("tcp", ":8888", true)
+		testHeadSplitter, _ = NewSplitDispatcher(DefaultFormatter, []interface{}{testConnWriter})
 		testExpected.LogType = syncloggerTypeFromString
 		testExpected.RootDispatcher = testHeadSplitter
 		parserTests = append(parserTests, parserTest{testName, testConfig, testExpected, false, nil})
@@ -1000,14 +1000,14 @@ func getParserTests() []parserTest {
 				<format id="testFormat" format="%Level %Msg %File 123" />
 			</formats>
 		</seelog>`
-		testExpected = new(logConfig)
-		testExpected.Constraints, _ = newMinMaxConstraints(TraceLvl, CriticalLvl)
+		testExpected = new(configForParsing)
+		testExpected.Constraints, _ = NewMinMaxConstraints(TraceLvl, CriticalLvl)
 		testExpected.Exceptions = nil
-		testrollingFileWriterTime, _ = newRollingFileWriterTime(testLogFileName, rollingArchiveNone, "", 0, "2006-01-02T15:04:05Z07:00", rollingIntervalDaily, rollingNameModePrefix)
-		testbufferedWriter, _ = newBufferedWriter(testrollingFileWriterTime, 100500, 100)
-		testFormat, _ = newFormatter("%Level %Msg %File 123")
-		formattedWriter, _ = newFormattedWriter(testbufferedWriter, testFormat)
-		testHeadSplitter, _ = newSplitDispatcher(defaultformatter, []interface{}{formattedWriter})
+		testrollingFileWriterTime, _ = NewRollingFileWriterTime(testLogFileName, rollingArchiveNone, "", 0, "2006-01-02T15:04:05Z07:00", rollingIntervalDaily, rollingNameModePrefix)
+		testbufferedWriter, _ = NewBufferedWriter(testrollingFileWriterTime, 100500, 100)
+		testFormat, _ = NewFormatter("%Level %Msg %File 123")
+		formattedWriter, _ = NewFormattedWriter(testbufferedWriter, testFormat)
+		testHeadSplitter, _ = NewSplitDispatcher(DefaultFormatter, []interface{}{formattedWriter})
 		testExpected.LogType = syncloggerTypeFromString
 		testExpected.RootDispatcher = testHeadSplitter
 		parserTests = append(parserTests, parserTest{testName, testConfig, testExpected, false, nil})
@@ -1021,7 +1021,7 @@ func getParserTests() []parserTest {
 // terms of performance, but a valid one in terms of comparison, because
 // every seelog dispatcher/receiver must have a valid String() func
 // that fully represents its internal parameters.
-func configsAreEqual(conf1 *logConfig, conf2 interface{}) bool {
+func configsAreEqual(conf1 *configForParsing, conf2 interface{}) bool {
 	if conf1 == nil {
 		return conf2 == nil
 	}
@@ -1029,12 +1029,12 @@ func configsAreEqual(conf1 *logConfig, conf2 interface{}) bool {
 		return conf1 == nil
 	}
 
-	// logConfig, ok := conf2 //.(*logConfig)
+	// configForParsing, ok := conf2 //.(*configForParsing)
 	// if !ok {
 	// 	return false
 	// }
 
-	return fmt.Sprintf("%v", conf1) == fmt.Sprintf("%v", conf2) //logConfig)
+	return fmt.Sprintf("%v", conf1) == fmt.Sprintf("%v", conf2) //configForParsing)
 }
 
 func testLogFileFilter(fn string) bool {

--- a/agent/vendor/github.com/cihub/seelog/common_constraints.go
+++ b/agent/vendor/github.com/cihub/seelog/common_constraints.go
@@ -41,8 +41,8 @@ type minMaxConstraints struct {
 	max LogLevel
 }
 
-// newMinMaxConstraints creates a new minMaxConstraints struct with the specified min and max levels.
-func newMinMaxConstraints(min LogLevel, max LogLevel) (*minMaxConstraints, error) {
+// NewMinMaxConstraints creates a new minMaxConstraints struct with the specified min and max levels.
+func NewMinMaxConstraints(min LogLevel, max LogLevel) (*minMaxConstraints, error) {
 	if min > max {
 		return nil, fmt.Errorf("min level can't be greater than max. Got min: %d, max: %d", min, max)
 	}
@@ -72,8 +72,8 @@ type listConstraints struct {
 	allowedLevels map[LogLevel]bool
 }
 
-// newListConstraints creates a new listConstraints struct with the specified allowed levels.
-func newListConstraints(allowList []LogLevel) (*listConstraints, error) {
+// NewListConstraints creates a new listConstraints struct with the specified allowed levels.
+func NewListConstraints(allowList []LogLevel) (*listConstraints, error) {
 	if allowList == nil {
 		return nil, errors.New("list can't be nil")
 	}
@@ -149,7 +149,7 @@ func (listConstr *listConstraints) AllowedLevels() map[LogLevel]bool {
 type offConstraints struct {
 }
 
-func newOffConstraints() (*offConstraints, error) {
+func NewOffConstraints() (*offConstraints, error) {
 	return &offConstraints{}, nil
 }
 

--- a/agent/vendor/github.com/cihub/seelog/common_constraints_test.go
+++ b/agent/vendor/github.com/cihub/seelog/common_constraints_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func TestInvalidminMaxConstraints(t *testing.T) {
-	constr, err := newMinMaxConstraints(CriticalLvl, WarnLvl)
+	constr, err := NewMinMaxConstraints(CriticalLvl, WarnLvl)
 
 	if err == nil || constr != nil {
 		t.Errorf("expected an error and a nil value for minmax constraints: min = %d, max = %d. Got: %v, %v",
@@ -41,7 +41,7 @@ func TestInvalidminMaxConstraints(t *testing.T) {
 func TestInvalidLogLevels(t *testing.T) {
 	var invalidMin uint8 = 123
 	var invalidMax uint8 = 124
-	minMaxConstr, errMinMax := newMinMaxConstraints(LogLevel(invalidMin), LogLevel(invalidMax))
+	minMaxConstr, errMinMax := NewMinMaxConstraints(LogLevel(invalidMin), LogLevel(invalidMax))
 
 	if errMinMax == nil || minMaxConstr != nil {
 		t.Errorf("expected an error and a nil value for minmax constraints: min = %d, max = %d. Got: %v, %v",
@@ -51,7 +51,7 @@ func TestInvalidLogLevels(t *testing.T) {
 
 	invalidList := []LogLevel{145}
 
-	listConstr, errList := newListConstraints(invalidList)
+	listConstr, errList := NewListConstraints(invalidList)
 
 	if errList == nil || listConstr != nil {
 		t.Errorf("expected an error and a nil value for constraints list: %v. Got: %v, %v",
@@ -64,7 +64,7 @@ func TestlistConstraintsWithDuplicates(t *testing.T) {
 	duplicateList := []LogLevel{TraceLvl, DebugLvl, InfoLvl,
 		WarnLvl, ErrorLvl, CriticalLvl, CriticalLvl, CriticalLvl}
 
-	listConstr, errList := newListConstraints(duplicateList)
+	listConstr, errList := NewListConstraints(duplicateList)
 
 	if errList != nil || listConstr == nil {
 		t.Errorf("expected a valid constraints list struct for: %v, got error: %v, value: %v",
@@ -88,7 +88,7 @@ func TestlistConstraintsWithDuplicates(t *testing.T) {
 func TestlistConstraintsWithOffInList(t *testing.T) {
 	offList := []LogLevel{TraceLvl, DebugLvl, Off}
 
-	listConstr, errList := newListConstraints(offList)
+	listConstr, errList := NewListConstraints(offList)
 
 	if errList == nil || listConstr != nil {
 		t.Errorf("expected an error and a nil value for constraints list with 'Off':  %v. Got: %v, %v",
@@ -115,7 +115,7 @@ var minMaxTests = []logLevelTestCase{
 
 func TestValidminMaxConstraints(t *testing.T) {
 
-	constr, err := newMinMaxConstraints(InfoLvl, WarnLvl)
+	constr, err := NewMinMaxConstraints(InfoLvl, WarnLvl)
 
 	if err != nil || constr == nil {
 		t.Errorf("expected a valid constraints struct for minmax constraints: min = %d, max = %d. Got: %v, %v",
@@ -146,7 +146,7 @@ var listTests = []logLevelTestCase{
 
 func TestValidlistConstraints(t *testing.T) {
 	validList := []LogLevel{TraceLvl, InfoLvl, WarnLvl, CriticalLvl}
-	constr, err := newListConstraints(validList)
+	constr, err := NewListConstraints(validList)
 
 	if err != nil || constr == nil {
 		t.Errorf("expected a valid constraints list struct for: %v. Got error: %v, value: %v",
@@ -177,7 +177,7 @@ var offTests = []logLevelTestCase{
 
 func TestValidListoffConstraints(t *testing.T) {
 	validList := []LogLevel{Off}
-	constr, err := newListConstraints(validList)
+	constr, err := NewListConstraints(validList)
 
 	if err != nil || constr == nil {
 		t.Errorf("expected a valid constraints list struct for: %v. Got error: %v, value: %v",

--- a/agent/vendor/github.com/cihub/seelog/common_context.go
+++ b/agent/vendor/github.com/cihub/seelog/common_context.go
@@ -25,7 +25,7 @@
 package seelog
 
 import (
-	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -33,75 +33,60 @@ import (
 	"time"
 )
 
-var workingDir = ""
+var workingDir = "/"
 
 func init() {
-	setWorkDir()
-}
-
-func setWorkDir() {
-	workDir, workingDirError := os.Getwd()
-	if workingDirError != nil {
-		workingDir = string(os.PathSeparator)
-		return
+	wd, err := os.Getwd()
+	if err == nil {
+		workingDir = filepath.ToSlash(wd) + "/"
 	}
-
-	workingDir = workDir + string(os.PathSeparator)
 }
 
-// Represents runtime caller context
+// Represents runtime caller context.
 type LogContextInterface interface {
-	// Caller func name
+	// Caller's function name.
 	Func() string
-	// Caller line num
+	// Caller's line number.
 	Line() int
-	// Caller file short path
+	// Caller's file short path (in slashed form).
 	ShortPath() string
-	// Caller file full path
+	// Caller's file full path (in slashed form).
 	FullPath() string
-	// Caller file name (without path)
+	// Caller's file name (without path).
 	FileName() string
 	// True if the context is correct and may be used.
 	// If false, then an error in context evaluation occurred and
 	// all its other data may be corrupted.
 	IsValid() bool
-	// Time when log func was called
+	// Time when log function was called.
 	CallTime() time.Time
+	// Custom context that can be set by calling logger.SetContext
+	CustomContext() interface{}
 }
 
 // Returns context of the caller
-func currentContext() (LogContextInterface, error) {
-	return specificContext(1)
+func currentContext(custom interface{}) (LogContextInterface, error) {
+	return specifyContext(1, custom)
 }
 
-func extractCallerInfo(skip int) (fullPath string, shortPath string, funcName string, lineNumber int, err error) {
-	pc, fullPath, line, ok := runtime.Caller(skip)
-
+func extractCallerInfo(skip int) (fullPath string, shortPath string, funcName string, line int, err error) {
+	pc, fp, ln, ok := runtime.Caller(skip)
 	if !ok {
-		return "", "", "", 0, errors.New("error during runtime.Caller")
+		err = fmt.Errorf("error during runtime.Caller")
+		return
 	}
-
-	//TODO:Currently fixes bug in weekly.2012-03-13+: Caller returns incorrect separators
-	//Delete later
-
-	fullPath = strings.Replace(fullPath, "\\", string(os.PathSeparator), -1)
-	fullPath = strings.Replace(fullPath, "/", string(os.PathSeparator), -1)
-
-	if strings.HasPrefix(fullPath, workingDir) {
-		shortPath = fullPath[len(workingDir):]
+	line = ln
+	fullPath = fp
+	if strings.HasPrefix(fp, workingDir) {
+		shortPath = fp[len(workingDir):]
 	} else {
-		shortPath = fullPath
+		shortPath = fp
 	}
-
-	funName := runtime.FuncForPC(pc).Name()
-	var functionName string
-	if strings.HasPrefix(funName, workingDir) {
-		functionName = funName[len(workingDir):]
-	} else {
-		functionName = funName
+	funcName = runtime.FuncForPC(pc).Name()
+	if strings.HasPrefix(funcName, workingDir) {
+		funcName = funcName[len(workingDir):]
 	}
-
-	return fullPath, shortPath, functionName, line, nil
+	return
 }
 
 // Returns context of the function with placed "skip" stack frames of the caller
@@ -109,23 +94,21 @@ func extractCallerInfo(skip int) (fullPath string, shortPath string, funcName st
 // Context is returned in any situation, even if error occurs. But, if an error
 // occurs, the returned context is an error context, which contains no paths
 // or names, but states that they can't be extracted.
-func specificContext(skip int) (LogContextInterface, error) {
+func specifyContext(skip int, custom interface{}) (LogContextInterface, error) {
 	callTime := time.Now()
-
 	if skip < 0 {
-		negativeStackFrameErr := errors.New("can not skip negative stack frames")
-		return &errorContext{callTime, negativeStackFrameErr}, negativeStackFrameErr
+		err := fmt.Errorf("can not skip negative stack frames")
+		return &errorContext{callTime, err}, err
 	}
-
-	fullPath, shortPath, function, line, err := extractCallerInfo(skip + 2)
+	fullPath, shortPath, funcName, line, err := extractCallerInfo(skip + 2)
 	if err != nil {
 		return &errorContext{callTime, err}, err
 	}
 	_, fileName := filepath.Split(fullPath)
-	return &logContext{function, line, shortPath, fullPath, fileName, callTime}, nil
+	return &logContext{funcName, line, shortPath, fullPath, fileName, callTime, custom}, nil
 }
 
-// Represents a normal runtime caller context
+// Represents a normal runtime caller context.
 type logContext struct {
 	funcName  string
 	line      int
@@ -133,6 +116,7 @@ type logContext struct {
 	fullPath  string
 	fileName  string
 	callTime  time.Time
+	custom    interface{}
 }
 
 func (context *logContext) IsValid() bool {
@@ -163,17 +147,18 @@ func (context *logContext) CallTime() time.Time {
 	return context.callTime
 }
 
-const (
-	errorContextFunc      = "Func() error:"
-	errorContextShortPath = "ShortPath() error:"
-	errorContextFullPath  = "FullPath() error:"
-	errorContextFileName  = "FileName() error:"
-)
+func (context *logContext) CustomContext() interface{} {
+	return context.custom
+}
 
 // Represents an error context
 type errorContext struct {
 	errorTime time.Time
 	err       error
+}
+
+func (errContext *errorContext) getErrorText(prefix string) string {
+	return fmt.Sprintf("%s() error: %s", prefix, errContext.err)
 }
 
 func (errContext *errorContext) IsValid() bool {
@@ -185,21 +170,25 @@ func (errContext *errorContext) Line() int {
 }
 
 func (errContext *errorContext) Func() string {
-	return errorContextFunc + errContext.err.Error()
+	return errContext.getErrorText("Func")
 }
 
 func (errContext *errorContext) ShortPath() string {
-	return errorContextShortPath + errContext.err.Error()
+	return errContext.getErrorText("ShortPath")
 }
 
 func (errContext *errorContext) FullPath() string {
-	return errorContextFullPath + errContext.err.Error()
+	return errContext.getErrorText("FullPath")
 }
 
 func (errContext *errorContext) FileName() string {
-	return errorContextFileName + errContext.err.Error()
+	return errContext.getErrorText("FileName")
 }
 
 func (errContext *errorContext) CallTime() time.Time {
 	return errContext.errorTime
+}
+
+func (errContext *errorContext) CustomContext() interface{} {
+	return nil
 }

--- a/agent/vendor/github.com/cihub/seelog/common_exception.go
+++ b/agent/vendor/github.com/cihub/seelog/common_exception.go
@@ -37,9 +37,9 @@ var (
 	funcFormatValidator = regexp.MustCompile(`[a-zA-Z0-9_\*\.]*`)
 )
 
-// logLevelException represents an exceptional case used when you need some specific files or funcs to
+// LogLevelException represents an exceptional case used when you need some specific files or funcs to
 // override general constraints and to use their own.
-type logLevelException struct {
+type LogLevelException struct {
 	funcPatternParts []string
 	filePatternParts []string
 
@@ -49,13 +49,13 @@ type logLevelException struct {
 	constraints logLevelConstraints
 }
 
-// newLogLevelException creates a new exception.
-func newLogLevelException(funcPattern string, filePattern string, constraints logLevelConstraints) (*logLevelException, error) {
+// NewLogLevelException creates a new exception.
+func NewLogLevelException(funcPattern string, filePattern string, constraints logLevelConstraints) (*LogLevelException, error) {
 	if constraints == nil {
 		return nil, errors.New("constraints can not be nil")
 	}
 
-	exception := new(logLevelException)
+	exception := new(LogLevelException)
 
 	err := exception.initFuncPatternParts(funcPattern)
 	if err != nil {
@@ -74,28 +74,28 @@ func newLogLevelException(funcPattern string, filePattern string, constraints lo
 	return exception, nil
 }
 
-// MatchesContext returns true if context matches the patterns of this logLevelException
-func (logLevelEx *logLevelException) MatchesContext(context LogContextInterface) bool {
+// MatchesContext returns true if context matches the patterns of this LogLevelException
+func (logLevelEx *LogLevelException) MatchesContext(context LogContextInterface) bool {
 	return logLevelEx.match(context.Func(), context.FullPath())
 }
 
-// IsAllowed returns true if log level is allowed according to the constraints of this logLevelException
-func (logLevelEx *logLevelException) IsAllowed(level LogLevel) bool {
+// IsAllowed returns true if log level is allowed according to the constraints of this LogLevelException
+func (logLevelEx *LogLevelException) IsAllowed(level LogLevel) bool {
 	return logLevelEx.constraints.IsAllowed(level)
 }
 
 // FuncPattern returns the function pattern of a exception
-func (logLevelEx *logLevelException) FuncPattern() string {
+func (logLevelEx *LogLevelException) FuncPattern() string {
 	return logLevelEx.funcPattern
 }
 
 // FuncPattern returns the file pattern of a exception
-func (logLevelEx *logLevelException) FilePattern() string {
+func (logLevelEx *LogLevelException) FilePattern() string {
 	return logLevelEx.filePattern
 }
 
 // initFuncPatternParts checks whether the func filter has a correct format and splits funcPattern on parts
-func (logLevelEx *logLevelException) initFuncPatternParts(funcPattern string) (err error) {
+func (logLevelEx *LogLevelException) initFuncPatternParts(funcPattern string) (err error) {
 
 	if funcFormatValidator.FindString(funcPattern) != funcPattern {
 		return errors.New("func path \"" + funcPattern + "\" contains incorrect symbols. Only a-z A-Z 0-9 _ * . allowed)")
@@ -106,7 +106,7 @@ func (logLevelEx *logLevelException) initFuncPatternParts(funcPattern string) (e
 }
 
 // Checks whether the file filter has a correct format and splits file patterns using splitPattern.
-func (logLevelEx *logLevelException) initFilePatternParts(filePattern string) (err error) {
+func (logLevelEx *LogLevelException) initFilePatternParts(filePattern string) (err error) {
 
 	if fileFormatValidator.FindString(filePattern) != filePattern {
 		return errors.New("file path \"" + filePattern + "\" contains incorrect symbols. Only a-z A-Z 0-9 \\ / _ * . allowed)")
@@ -116,15 +116,15 @@ func (logLevelEx *logLevelException) initFilePatternParts(filePattern string) (e
 	return err
 }
 
-func (logLevelEx *logLevelException) match(funcPath string, filePath string) bool {
+func (logLevelEx *LogLevelException) match(funcPath string, filePath string) bool {
 	if !stringMatchesPattern(logLevelEx.funcPatternParts, funcPath) {
 		return false
 	}
 	return stringMatchesPattern(logLevelEx.filePatternParts, filePath)
 }
 
-func (logLevelEx *logLevelException) String() string {
-	str := fmt.Sprintf("Func: %s File: %s ", logLevelEx.funcPattern, logLevelEx.filePattern)
+func (logLevelEx *LogLevelException) String() string {
+	str := fmt.Sprintf("Func: %s File: %s", logLevelEx.funcPattern, logLevelEx.filePattern)
 
 	if logLevelEx.constraints != nil {
 		str += fmt.Sprintf("Constr: %s", logLevelEx.constraints)

--- a/agent/vendor/github.com/cihub/seelog/common_exception_test.go
+++ b/agent/vendor/github.com/cihub/seelog/common_exception_test.go
@@ -53,14 +53,14 @@ var exceptionTestCases = []exceptionTestCase{
 }
 
 func TestMatchingCorrectness(t *testing.T) {
-	constraints, err := newListConstraints([]LogLevel{TraceLvl})
+	constraints, err := NewListConstraints([]LogLevel{TraceLvl})
 	if err != nil {
 		t.Error(err)
 		return
 	}
 
 	for _, testCase := range exceptionTestCases {
-		rule, ruleError := newLogLevelException(testCase.funcPattern, testCase.filePattern, constraints)
+		rule, ruleError := NewLogLevelException(testCase.funcPattern, testCase.filePattern, constraints)
 		if ruleError != nil {
 			t.Fatalf("Unexpected error on rule creation: [ %v, %v ]. %v",
 				testCase.funcPattern, testCase.filePattern, ruleError)
@@ -75,13 +75,13 @@ func TestMatchingCorrectness(t *testing.T) {
 }
 
 func TestAsterisksReducing(t *testing.T) {
-	constraints, err := newListConstraints([]LogLevel{TraceLvl})
+	constraints, err := NewListConstraints([]LogLevel{TraceLvl})
 	if err != nil {
 		t.Error(err)
 		return
 	}
 
-	rule, err := newLogLevelException("***func**", "fi*****le", constraints)
+	rule, err := NewLogLevelException("***func**", "fi*****le", constraints)
 	if err != nil {
 		t.Error(err)
 		return

--- a/agent/vendor/github.com/cihub/seelog/dispatch_custom.go
+++ b/agent/vendor/github.com/cihub/seelog/dispatch_custom.go
@@ -151,9 +151,9 @@ type customReceiverDispatcher struct {
 	usedArgs           CustomReceiverInitArgs
 }
 
-// newCustomReceiverDispatcher creates a customReceiverDispatcher which dispatches data to a specific receiver created
+// NewCustomReceiverDispatcher creates a customReceiverDispatcher which dispatches data to a specific receiver created
 // using a <custom> tag in the config file.
-func newCustomReceiverDispatcher(formatter *formatter, customReceiverName string, cArgs CustomReceiverInitArgs) (*customReceiverDispatcher, error) {
+func NewCustomReceiverDispatcher(formatter *formatter, customReceiverName string, cArgs CustomReceiverInitArgs) (*customReceiverDispatcher, error) {
 	if formatter == nil {
 		return nil, errors.New("formatter cannot be nil")
 	}
@@ -174,9 +174,9 @@ func newCustomReceiverDispatcher(formatter *formatter, customReceiverName string
 	return disp, nil
 }
 
-// newCustomReceiverDispatcherByValue is basically the same as newCustomReceiverDispatcher, but using
+// NewCustomReceiverDispatcherByValue is basically the same as NewCustomReceiverDispatcher, but using
 // a specific CustomReceiver value instead of instantiating a new one by type.
-func newCustomReceiverDispatcherByValue(formatter *formatter, customReceiver CustomReceiver, name string, cArgs CustomReceiverInitArgs) (*customReceiverDispatcher, error) {
+func NewCustomReceiverDispatcherByValue(formatter *formatter, customReceiver CustomReceiver, name string, cArgs CustomReceiverInitArgs) (*customReceiverDispatcher, error) {
 	if formatter == nil {
 		return nil, errors.New("formatter cannot be nil")
 	}

--- a/agent/vendor/github.com/cihub/seelog/dispatch_customdispatcher_test.go
+++ b/agent/vendor/github.com/cihub/seelog/dispatch_customdispatcher_test.go
@@ -36,7 +36,7 @@ func TestCustomDispatcher_Message(t *testing.T) {
 	recName := "TestCustomDispatcher_Message"
 	RegisterReceiver(recName, &testCustomDispatcherMessageReceiver{})
 
-	customDispatcher, err := newCustomReceiverDispatcher(onlyMessageFormatForTest, recName, CustomReceiverInitArgs{
+	customDispatcher, err := NewCustomReceiverDispatcher(onlyMessageFormatForTest, recName, CustomReceiverInitArgs{
 		XmlCustomAttrs: map[string]string{
 			"test": "testdata",
 		},
@@ -46,7 +46,7 @@ func TestCustomDispatcher_Message(t *testing.T) {
 		return
 	}
 
-	context, err := currentContext()
+	context, err := currentContext(nil)
 	if err != nil {
 		t.Error(err)
 		return
@@ -90,7 +90,7 @@ func TestCustomDispatcher_Flush(t *testing.T) {
 	recName := "TestCustomDispatcher_Flush"
 	RegisterReceiver(recName, &testCustomDispatcherFlushReceiver{})
 
-	customDispatcher, err := newCustomReceiverDispatcher(onlyMessageFormatForTest, recName, CustomReceiverInitArgs{
+	customDispatcher, err := NewCustomReceiverDispatcher(onlyMessageFormatForTest, recName, CustomReceiverInitArgs{
 		XmlCustomAttrs: map[string]string{
 			"test": "testdata",
 		},
@@ -137,7 +137,7 @@ func TestCustomDispatcher_Close(t *testing.T) {
 	recName := "TestCustomDispatcher_Close"
 	RegisterReceiver(recName, &testCustomDispatcherCloseReceiver{})
 
-	customDispatcher, err := newCustomReceiverDispatcher(onlyMessageFormatForTest, recName, CustomReceiverInitArgs{
+	customDispatcher, err := NewCustomReceiverDispatcher(onlyMessageFormatForTest, recName, CustomReceiverInitArgs{
 		XmlCustomAttrs: map[string]string{
 			"test": "testdata",
 		},

--- a/agent/vendor/github.com/cihub/seelog/dispatch_dispatcher.go
+++ b/agent/vendor/github.com/cihub/seelog/dispatch_dispatcher.go
@@ -66,7 +66,7 @@ func createDispatcher(formatter *formatter, receivers []interface{}) (*dispatche
 
 		ioWriter, ok := receiver.(io.Writer)
 		if ok {
-			writer, err := newFormattedWriter(ioWriter, disp.formatter)
+			writer, err := NewFormattedWriter(ioWriter, disp.formatter)
 			if err != nil {
 				return nil, err
 			}

--- a/agent/vendor/github.com/cihub/seelog/dispatch_filterdispatcher.go
+++ b/agent/vendor/github.com/cihub/seelog/dispatch_filterdispatcher.go
@@ -35,8 +35,8 @@ type filterDispatcher struct {
 	allowList map[LogLevel]bool
 }
 
-// newFilterDispatcher creates a new filterDispatcher using a list of allowed levels.
-func newFilterDispatcher(formatter *formatter, receivers []interface{}, allowList ...LogLevel) (*filterDispatcher, error) {
+// NewFilterDispatcher creates a new filterDispatcher using a list of allowed levels.
+func NewFilterDispatcher(formatter *formatter, receivers []interface{}, allowList ...LogLevel) (*filterDispatcher, error) {
 	disp, err := createDispatcher(formatter, receivers)
 	if err != nil {
 		return nil, err

--- a/agent/vendor/github.com/cihub/seelog/dispatch_filterdispatcher_test.go
+++ b/agent/vendor/github.com/cihub/seelog/dispatch_filterdispatcher_test.go
@@ -30,13 +30,13 @@ import (
 
 func TestfilterDispatcher_Pass(t *testing.T) {
 	writer, _ := newBytesVerifier(t)
-	filter, err := newFilterDispatcher(onlyMessageFormatForTest, []interface{}{writer}, TraceLvl)
+	filter, err := NewFilterDispatcher(onlyMessageFormatForTest, []interface{}{writer}, TraceLvl)
 	if err != nil {
 		t.Error(err)
 		return
 	}
 
-	context, err := currentContext()
+	context, err := currentContext(nil)
 	if err != nil {
 		t.Error(err)
 		return
@@ -50,13 +50,13 @@ func TestfilterDispatcher_Pass(t *testing.T) {
 
 func TestfilterDispatcher_Deny(t *testing.T) {
 	writer, _ := newBytesVerifier(t)
-	filter, err := newFilterDispatcher(defaultformatter, []interface{}{writer})
+	filter, err := NewFilterDispatcher(DefaultFormatter, []interface{}{writer})
 	if err != nil {
 		t.Error(err)
 		return
 	}
 
-	context, err := currentContext()
+	context, err := currentContext(nil)
 	if err != nil {
 		t.Error(err)
 		return

--- a/agent/vendor/github.com/cihub/seelog/dispatch_splitdispatcher.go
+++ b/agent/vendor/github.com/cihub/seelog/dispatch_splitdispatcher.go
@@ -33,7 +33,7 @@ type splitDispatcher struct {
 	*dispatcher
 }
 
-func newSplitDispatcher(formatter *formatter, receivers []interface{}) (*splitDispatcher, error) {
+func NewSplitDispatcher(formatter *formatter, receivers []interface{}) (*splitDispatcher, error) {
 	disp, err := createDispatcher(formatter, receivers)
 	if err != nil {
 		return nil, err

--- a/agent/vendor/github.com/cihub/seelog/dispatch_splitdispatcher_test.go
+++ b/agent/vendor/github.com/cihub/seelog/dispatch_splitdispatcher_test.go
@@ -33,7 +33,7 @@ var onlyMessageFormatForTest *formatter
 
 func init() {
 	var err error
-	onlyMessageFormatForTest, err = newFormatter("%Msg")
+	onlyMessageFormatForTest, err = NewFormatter("%Msg")
 	if err != nil {
 		fmt.Println("Can not create only message format: " + err.Error())
 	}
@@ -42,13 +42,13 @@ func init() {
 func TestsplitDispatcher(t *testing.T) {
 	writer1, _ := newBytesVerifier(t)
 	writer2, _ := newBytesVerifier(t)
-	spliter, err := newSplitDispatcher(onlyMessageFormatForTest, []interface{}{writer1, writer2})
+	spliter, err := NewSplitDispatcher(onlyMessageFormatForTest, []interface{}{writer1, writer2})
 	if err != nil {
 		t.Error(err)
 		return
 	}
 
-	context, err := currentContext()
+	context, err := currentContext(nil)
 	if err != nil {
 		t.Error(err)
 		return

--- a/agent/vendor/github.com/cihub/seelog/format.go
+++ b/agent/vendor/github.com/cihub/seelog/format.go
@@ -25,6 +25,7 @@
 package seelog
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"strconv"
@@ -37,13 +38,13 @@ import (
 const (
 	FormatterSymbol = '%'
 )
+
 const (
-	formatterSymbolString   = "%"
 	formatterParameterStart = '('
 	formatterParameterEnd   = ')'
 )
 
-// These are the time and date formats that are used when %Date or %Time format aliases are used.
+// Time and date formats used for %Date and %Time aliases.
 const (
 	DateDefaultFormat = "2006-01-02"
 	TimeFormat        = "15:04:05"
@@ -51,18 +52,18 @@ const (
 
 var DefaultMsgFormat = "%Ns [%Level] %Msg%n"
 
-var defaultformatter *formatter
-var msgonlyformatter *formatter
+var (
+	DefaultFormatter *formatter
+	msgonlyformatter *formatter
+)
 
 func init() {
 	var err error
-	defaultformatter, err = newFormatter(DefaultMsgFormat)
-	if err != nil {
-		fmt.Println("Error during defaultformatter creation: " + err.Error())
+	if DefaultFormatter, err = NewFormatter(DefaultMsgFormat); err != nil {
+		reportInternalError(fmt.Errorf("error during creating DefaultFormatter: %s", err))
 	}
-	msgonlyformatter, err = newFormatter("%Msg")
-	if err != nil {
-		fmt.Println("Error during msgonlyformatter creation: " + err.Error())
+	if msgonlyformatter, err = NewFormatter("%Msg"); err != nil {
+		reportInternalError(fmt.Errorf("error during creating msgonlyformatter: %s", err))
 	}
 }
 
@@ -146,59 +147,53 @@ type formatter struct {
 	formatterFuncs    []FormatterFunc
 }
 
-// newFormatter creates a new formatter using a format string
-func newFormatter(formatString string) (*formatter, error) {
-	newformatter := new(formatter)
-	newformatter.fmtStringOriginal = formatString
-
-	err := newformatter.buildFormatterFuncs()
-	if err != nil {
+// NewFormatter creates a new formatter using a format string
+func NewFormatter(formatString string) (*formatter, error) {
+	fmtr := new(formatter)
+	fmtr.fmtStringOriginal = formatString
+	if err := buildFormatterFuncs(fmtr); err != nil {
 		return nil, err
 	}
-
-	return newformatter, nil
+	return fmtr, nil
 }
 
-func (formatter *formatter) buildFormatterFuncs() error {
-	formatter.formatterFuncs = make([]FormatterFunc, 0)
-	var fmtString string
-	for i := 0; i < len(formatter.fmtStringOriginal); i++ {
-		char := formatter.fmtStringOriginal[i]
-		if char != FormatterSymbol {
-			fmtString += string(char)
+func buildFormatterFuncs(formatter *formatter) error {
+	var (
+		fsbuf  = new(bytes.Buffer)
+		fsolm1 = len(formatter.fmtStringOriginal) - 1
+	)
+	for i := 0; i <= fsolm1; i++ {
+		if char := formatter.fmtStringOriginal[i]; char != FormatterSymbol {
+			fsbuf.WriteByte(char)
 			continue
 		}
-
-		isEndOfStr := i == len(formatter.fmtStringOriginal)-1
-		if isEndOfStr {
-			return fmt.Errorf("format error: %v - last symbol", formatterSymbolString)
+		// Check if the index is at the end of the string.
+		if i == fsolm1 {
+			return fmt.Errorf("format error: %c cannot be last symbol", FormatterSymbol)
 		}
-
-		isDoubledFormatterSymbol := formatter.fmtStringOriginal[i+1] == FormatterSymbol
-		if isDoubledFormatterSymbol {
-			fmtString += formatterSymbolString
+		// Check if the formatter symbol is doubled and skip it as nonmatching.
+		if formatter.fmtStringOriginal[i+1] == FormatterSymbol {
+			fsbuf.WriteRune(FormatterSymbol)
 			i++
 			continue
 		}
-
-		function, nextI, err := formatter.extractFormatterFunc(i + 1)
+		function, ni, err := formatter.extractFormatterFunc(i + 1)
 		if err != nil {
 			return err
 		}
-
-		fmtString += "%v"
-		i = nextI
+		// Append formatting string "%v".
+		fsbuf.Write([]byte{37, 118})
+		i = ni
 		formatter.formatterFuncs = append(formatter.formatterFuncs, function)
 	}
-
-	formatter.fmtString = fmtString
+	formatter.fmtString = fsbuf.String()
 	return nil
 }
 
 func (formatter *formatter) extractFormatterFunc(index int) (FormatterFunc, int, error) {
 	letterSequence := formatter.extractLetterSequence(index)
 	if len(letterSequence) == 0 {
-		return nil, 0, fmt.Errorf("format error: lack of formatter after %v. At %v", formatterSymbolString, index)
+		return nil, 0, fmt.Errorf("format error: lack of formatter after %c at %d", FormatterSymbol, index)
 	}
 
 	function, formatterLength, ok := formatter.findFormatterFunc(letterSequence)

--- a/agent/vendor/github.com/cihub/seelog/format_test.go
+++ b/agent/vendor/github.com/cihub/seelog/format_test.go
@@ -127,7 +127,7 @@ var formatTests = []formatTest{
 
 func TestFormats(t *testing.T) {
 
-	context, conErr := currentContext()
+	context, conErr := currentContext(nil)
 	if conErr != nil {
 		t.Fatal("Cannot get current context:" + conErr.Error())
 		return
@@ -135,7 +135,7 @@ func TestFormats(t *testing.T) {
 
 	for _, test := range formatTests {
 
-		form, err := newFormatter(test.formatString)
+		form, err := NewFormatter(test.formatString)
 
 		if (err != nil) != test.errorExpected {
 			t.Errorf("input: %s \nInput LL: %s\n* Expected error:%t Got error: %t\n",
@@ -158,7 +158,7 @@ func TestFormats(t *testing.T) {
 }
 
 func TestDateFormat(t *testing.T) {
-	_, err := newFormatter("%Date")
+	_, err := NewFormatter("%Date")
 	if err != nil {
 		t.Error("Unexpected error: " + err.Error())
 	}
@@ -168,13 +168,13 @@ func TestDateParameterizedFormat(t *testing.T) {
 	testFormat := "Mon Jan 02 2006 15:04:05"
 	preciseForamt := "Mon Jan 02 2006 15:04:05.000"
 
-	context, conErr := currentContext()
+	context, conErr := currentContext(nil)
 	if conErr != nil {
 		t.Fatal("Cannot get current context:" + conErr.Error())
 		return
 	}
 
-	form, err := newFormatter("%Date(" + preciseForamt + ")")
+	form, err := NewFormatter("%Date(" + preciseForamt + ")")
 	if err != nil {
 		t.Error("Unexpected error: " + err.Error())
 	}
@@ -187,7 +187,7 @@ func TestDateParameterizedFormat(t *testing.T) {
 		t.Errorf("incorrect message: %v. Expected %v or %v", msg, dateBefore, dateAfter)
 	}
 
-	_, err = newFormatter("%Date(" + preciseForamt)
+	_, err = NewFormatter("%Date(" + preciseForamt)
 	if err == nil {
 		t.Error("Expected error for invalid format")
 	}
@@ -217,13 +217,13 @@ func TestCustomFormatterRegistration(t *testing.T) {
 		t.Errorf("expected an error when trying to register a custom formatter with duplicate name")
 	}
 
-	context, conErr := currentContext()
+	context, conErr := currentContext(nil)
 	if conErr != nil {
 		t.Fatal("Cannot get current context:" + conErr.Error())
 		return
 	}
 
-	form, err := newFormatter("%Msg %TEST 123")
+	form, err := NewFormatter("%Msg %TEST 123")
 	if err != nil {
 		t.Fatalf("%s\n", err.Error())
 	}

--- a/agent/vendor/github.com/cihub/seelog/log.go
+++ b/agent/vendor/github.com/cihub/seelog/log.go
@@ -66,11 +66,11 @@ func init() {
 	Current = Default
 }
 
-func createLoggerFromConfig(config *logConfig) (LoggerInterface, error) {
+func createLoggerFromFullConfig(config *configForParsing) (LoggerInterface, error) {
 	if config.LogType == syncloggerTypeFromString {
-		return newSyncLogger(config), nil
+		return NewSyncLogger(&config.logConfig), nil
 	} else if config.LogType == asyncLooploggerTypeFromString {
-		return newAsyncLoopLogger(config), nil
+		return NewAsyncLoopLogger(&config.logConfig), nil
 	} else if config.LogType == asyncTimerloggerTypeFromString {
 		logData := config.LoggerData
 		if logData == nil {
@@ -82,7 +82,7 @@ func createLoggerFromConfig(config *logConfig) (LoggerInterface, error) {
 			return nil, errors.New("invalid async timer data")
 		}
 
-		logger, err := newAsyncTimerLogger(config, time.Duration(asyncInt.AsyncInterval))
+		logger, err := NewAsyncTimerLogger(&config.logConfig, time.Duration(asyncInt.AsyncInterval))
 		if !ok {
 			return nil, err
 		}
@@ -99,8 +99,8 @@ func createLoggerFromConfig(config *logConfig) (LoggerInterface, error) {
 			return nil, errors.New("invalid adaptive logger parameters")
 		}
 
-		logger, err := newAsyncAdaptiveLogger(
-			config,
+		logger, err := NewAsyncAdaptiveLogger(
+			&config.logConfig,
 			time.Duration(adaptData.MinInterval),
 			time.Duration(adaptData.MaxInterval),
 			adaptData.CriticalMsgCount,

--- a/agent/vendor/github.com/cihub/seelog/writers_bufferedwriter.go
+++ b/agent/vendor/github.com/cihub/seelog/writers_bufferedwriter.go
@@ -42,10 +42,10 @@ type bufferedWriter struct {
 	bufferSize  int           // max size of data chunk in bytes
 }
 
-// newBufferedWriter creates a new buffered writer struct.
+// NewBufferedWriter creates a new buffered writer struct.
 // bufferSize -- size of memory buffer in bytes
 // flushPeriod -- period in which data flushes from memory buffer in milliseconds. 0 - turn off this functionality
-func newBufferedWriter(innerWriter io.Writer, bufferSize int, flushPeriod time.Duration) (*bufferedWriter, error) {
+func NewBufferedWriter(innerWriter io.Writer, bufferSize int, flushPeriod time.Duration) (*bufferedWriter, error) {
 
 	if innerWriter == nil {
 		return nil, errors.New("argument is nil: innerWriter")

--- a/agent/vendor/github.com/cihub/seelog/writers_bufferedwriter_test.go
+++ b/agent/vendor/github.com/cihub/seelog/writers_bufferedwriter_test.go
@@ -30,7 +30,7 @@ import (
 
 func TestChunkWriteOnFilling(t *testing.T) {
 	writer, _ := newBytesVerifier(t)
-	bufferedWriter, err := newBufferedWriter(writer, 1024, 0)
+	bufferedWriter, err := NewBufferedWriter(writer, 1024, 0)
 
 	if err != nil {
 		t.Fatalf("Unexpected buffered writer creation error: %s", err.Error())
@@ -45,7 +45,7 @@ func TestChunkWriteOnFilling(t *testing.T) {
 
 func TestFlushByTimePeriod(t *testing.T) {
 	writer, _ := newBytesVerifier(t)
-	bufferedWriter, err := newBufferedWriter(writer, 1024, 10)
+	bufferedWriter, err := NewBufferedWriter(writer, 1024, 10)
 
 	if err != nil {
 		t.Fatalf("Unexpected buffered writer creation error: %s", err.Error())
@@ -61,7 +61,7 @@ func TestFlushByTimePeriod(t *testing.T) {
 
 func TestBigMessageMustPassMemoryBuffer(t *testing.T) {
 	writer, _ := newBytesVerifier(t)
-	bufferedWriter, err := newBufferedWriter(writer, 1024, 0)
+	bufferedWriter, err := NewBufferedWriter(writer, 1024, 0)
 
 	if err != nil {
 		t.Fatalf("Unexpected buffered writer creation error: %s", err.Error())

--- a/agent/vendor/github.com/cihub/seelog/writers_connwriter.go
+++ b/agent/vendor/github.com/cihub/seelog/writers_connwriter.go
@@ -44,7 +44,7 @@ type connWriter struct {
 
 // Creates writer to the address addr on the network netName.
 // Connection will be opened on each write if reconnectOnMsg = true
-func newConnWriter(netName string, addr string, reconnectOnMsg bool) *connWriter {
+func NewConnWriter(netName string, addr string, reconnectOnMsg bool) *connWriter {
 	newWriter := new(connWriter)
 
 	newWriter.net = netName

--- a/agent/vendor/github.com/cihub/seelog/writers_consolewriter.go
+++ b/agent/vendor/github.com/cihub/seelog/writers_consolewriter.go
@@ -31,7 +31,7 @@ type consoleWriter struct {
 }
 
 // Creates a new console writer. Returns error, if the console writer couldn't be created.
-func newConsoleWriter() (writer *consoleWriter, err error) {
+func NewConsoleWriter() (writer *consoleWriter, err error) {
 	newWriter := new(consoleWriter)
 
 	return newWriter, nil

--- a/agent/vendor/github.com/cihub/seelog/writers_filewriter.go
+++ b/agent/vendor/github.com/cihub/seelog/writers_filewriter.go
@@ -38,7 +38,7 @@ type fileWriter struct {
 }
 
 // Creates a new file and a corresponding writer. Returns error, if the file couldn't be created.
-func newFileWriter(fileName string) (writer *fileWriter, err error) {
+func NewFileWriter(fileName string) (writer *fileWriter, err error) {
 	newWriter := new(fileWriter)
 	newWriter.fileName = fileName
 

--- a/agent/vendor/github.com/cihub/seelog/writers_filewriter_test.go
+++ b/agent/vendor/github.com/cihub/seelog/writers_filewriter_test.go
@@ -41,13 +41,13 @@ var bytesFileTest = []byte(strings.Repeat("A", messageLen))
 
 func TestSimpleFileWriter(t *testing.T) {
 	t.Logf("Starting file writer tests")
-	newFileWriterTester(simplefileWriterTests, simplefileWriterGetter, t).test()
+	NewFileWriterTester(simplefileWriterTests, simplefileWriterGetter, t).test()
 }
 
 //===============================================================
 
 func simplefileWriterGetter(testCase *fileWriterTestCase) (io.WriteCloser, error) {
-	return newFileWriter(testCase.fileName)
+	return NewFileWriter(testCase.fileName)
 }
 
 //===============================================================
@@ -81,7 +81,7 @@ type fileWriterTester struct {
 	t            *testing.T
 }
 
-func newFileWriterTester(
+func NewFileWriterTester(
 	testCases []*fileWriterTestCase,
 	writerGetter func(*fileWriterTestCase) (io.WriteCloser, error),
 	t *testing.T) *fileWriterTester {

--- a/agent/vendor/github.com/cihub/seelog/writers_formattedwriter.go
+++ b/agent/vendor/github.com/cihub/seelog/writers_formattedwriter.go
@@ -35,7 +35,7 @@ type formattedWriter struct {
 	formatter *formatter
 }
 
-func newFormattedWriter(writer io.Writer, formatter *formatter) (*formattedWriter, error) {
+func NewFormattedWriter(writer io.Writer, formatter *formatter) (*formattedWriter, error) {
 	if formatter == nil {
 		return nil, errors.New("formatter can not be nil")
 	}

--- a/agent/vendor/github.com/cihub/seelog/writers_formattedwriter_test.go
+++ b/agent/vendor/github.com/cihub/seelog/writers_formattedwriter_test.go
@@ -39,19 +39,19 @@ func TestformattedWriter(t *testing.T) {
 		return
 	}
 
-	formatter, err := newFormatter(formatStr)
+	formatter, err := NewFormatter(formatStr)
 	if err != nil {
 		t.Error(err)
 		return
 	}
 
-	writer, err := newFormattedWriter(bytesVerifier, formatter)
+	writer, err := NewFormattedWriter(bytesVerifier, formatter)
 	if err != nil {
 		t.Error(err)
 		return
 	}
 
-	context, err := currentContext()
+	context, err := currentContext(nil)
 	if err != nil {
 		t.Error(err)
 		return

--- a/agent/vendor/github.com/cihub/seelog/writers_rollingfilewriter_test.go
+++ b/agent/vendor/github.com/cihub/seelog/writers_rollingfilewriter_test.go
@@ -57,16 +57,16 @@ func createRollingDatefileWriterTestCase(
 
 func TestRollingFileWriter(t *testing.T) {
 	t.Logf("Starting rolling file writer tests")
-	newFileWriterTester(rollingfileWriterTests, rollingFileWriterGetter, t).test()
+	NewFileWriterTester(rollingfileWriterTests, rollingFileWriterGetter, t).test()
 }
 
 //===============================================================
 
 func rollingFileWriterGetter(testCase *fileWriterTestCase) (io.WriteCloser, error) {
 	if testCase.rollingType == rollingTypeSize {
-		return newRollingFileWriterSize(testCase.fileName, rollingArchiveNone, "", testCase.fileSize, testCase.maxRolls, testCase.nameMode)
+		return NewRollingFileWriterSize(testCase.fileName, rollingArchiveNone, "", testCase.fileSize, testCase.maxRolls, testCase.nameMode)
 	} else if testCase.rollingType == rollingTypeTime {
-		return newRollingFileWriterTime(testCase.fileName, rollingArchiveNone, "", -1, testCase.datePattern, rollingIntervalDaily, testCase.nameMode)
+		return NewRollingFileWriterTime(testCase.fileName, rollingArchiveNone, "", -1, testCase.datePattern, rollingIntervalDaily, testCase.nameMode)
 	}
 
 	return nil, fmt.Errorf("incorrect rollingType")

--- a/agent/vendor/github.com/cihub/seelog/writers_smtpwriter.go
+++ b/agent/vendor/github.com/cihub/seelog/writers_smtpwriter.go
@@ -57,8 +57,8 @@ type smtpWriter struct {
 	subject            string
 }
 
-// newSMTPWriter returns a new SMTP-writer.
-func newSMTPWriter(sa, sn string, ras []string, hn, hp, un, pwd string, cacdps []string, subj string, headers []string) *smtpWriter {
+// NewSMTPWriter returns a new SMTP-writer.
+func NewSMTPWriter(sa, sn string, ras []string, hn, hp, un, pwd string, cacdps []string, subj string, headers []string) *smtpWriter {
 	return &smtpWriter{
 		auth:               smtp.PlainAuth("", un, pwd, hn),
 		hostName:           hn,
@@ -74,14 +74,12 @@ func newSMTPWriter(sa, sn string, ras []string, hn, hp, un, pwd string, cacdps [
 }
 
 func prepareMessage(senderAddr, senderName, subject string, body []byte, headers []string) []byte {
-	headerLines := fmt.Sprintf(rfc5321SubjectPattern, senderName, senderAddr, subject);
-
+	headerLines := fmt.Sprintf(rfc5321SubjectPattern, senderName, senderAddr, subject)
 	// Build header lines if configured.
 	if headers != nil && len(headers) > 0 {
 		headerLines += strings.Join(headers, "\n")
 		headerLines += "\n"
 	}
-
 	return append([]byte(headerLines), body...)
 }
 
@@ -104,7 +102,6 @@ func getTLSConfig(pemFileDirPaths []string, hostName string) (config *tls.Config
 		}
 		return false
 	}
-
 	for _, pemFileDirPath := range pemFileDirPaths {
 		pemFilePaths, err := getDirFilePaths(pemFileDirPath, pemFilePathFilter, false)
 		if err != nil {
@@ -120,7 +117,6 @@ func getTLSConfig(pemFileDirPaths []string, hostName string) (config *tls.Config
 			}
 		}
 	}
-
 	config = &tls.Config{RootCAs: x509.NewCertPool(), ServerName: hostName}
 	isAppended := config.RootCAs.AppendCertsFromPEM(pemEncodedContent)
 	if !isAppended {
@@ -213,6 +209,6 @@ func (smtpw *smtpWriter) Write(data []byte) (int, error) {
 
 // Close closes down SMTP-connection.
 func (smtpw *smtpWriter) Close() error {
-	// Do nothing as Write method opens and closes connection automatically
+	// Do nothing as Write method opens and closes connection automatically.
 	return nil
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
dep best practices, constrain seelog to version 2.6 because we were tied to a githash. Updated dependencies using [dep v0.4.1](https://github.com/golang/dep/releases/tag/v0.4.1):
```
% dep version
dep:
 version     : v0.4.1
 build date  : 2018-01-24
 git hash    : 37d9ea0a
 go version  : go1.9.1
 go compiler : gc
 platform    : linux/386
```
### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes --> yes
