### PR TITLE
Adding to existing integ tests to increase coverage

### DIFF
--- a/agent/engine/engine_integ_test.go
+++ b/agent/engine/engine_integ_test.go
@@ -51,7 +51,7 @@ func init() {
 func createTestTask(arn string) *api.Task {
 	return &api.Task{
 		Arn:                 arn,
-		Family:              arn,
+		Family:              "family",
 		Version:             "1",
 		DesiredStatusUnsafe: api.TaskRunning,
 		Containers:          []*api.Container{createTestContainer()},
@@ -90,7 +90,7 @@ func setup(cfg *config.Config, t *testing.T) (TaskEngine, func(), credentials.Ma
 
 	taskEngine := NewDockerTaskEngine(cfg, dockerClient, credentialsManager,
 		eventstream.NewEventStream("ENGINEINTEGTEST", context.Background()), imageManager, state, metadataManager, resource)
-	taskEngine.Init(context.TODO())
+	taskEngine.MustInit(context.TODO())
 	return taskEngine, func() {
 		taskEngine.Shutdown()
 	}, credentialsManager
@@ -216,12 +216,14 @@ func TestEmptyHostVolumeMount(t *testing.T) {
 func TestSweepContainer(t *testing.T) {
 	cfg := defaultTestConfigIntegTest()
 	cfg.TaskCleanupWaitDuration = 1 * time.Minute
+	cfg.ContainerMetadataEnabled = true
 	taskEngine, done, _ := setup(cfg, t)
 	defer done()
 
 	stateChangeEvents := taskEngine.StateChangeEvents()
 
-	testTask := createTestTask("testSweepContainer")
+	taskArn := "arn:aws:ecs:us-east-1:123456789012:task/testSweepContainer"
+	testTask := createTestTask(taskArn)
 
 	go taskEngine.AddTask(testTask)
 
@@ -237,19 +239,26 @@ func TestSweepContainer(t *testing.T) {
 	event = <-stateChangeEvents
 	assert.Equal(t, event.(api.TaskStateChange).Status, api.TaskStopped, "Expected task to be STOPPED")
 
+	tasks, _ := taskEngine.ListTasks()
+	assert.Equal(t, len(tasks), 1)
+	assert.Equal(t, tasks[0].GetKnownStatus(), api.TaskStopped)
+
 	// Should be stopped, let's verify it's still listed...
-	task, ok := taskEngine.(*DockerTaskEngine).State().TaskByArn("testSweepContainer")
+	task, ok := taskEngine.(*DockerTaskEngine).State().TaskByArn(taskArn)
 	assert.True(t, ok, "Expected task to be present still, but wasn't")
 	task.SetSentStatus(api.TaskStopped) // cleanupTask waits for TaskStopped to be sent before cleaning
 	time.Sleep(1 * time.Minute)
 	for i := 0; i < 60; i++ {
-		_, ok = taskEngine.(*DockerTaskEngine).State().TaskByArn("testSweepContainer")
+		_, ok = taskEngine.(*DockerTaskEngine).State().TaskByArn(taskArn)
 		if !ok {
 			break
 		}
 		time.Sleep(1 * time.Second)
 	}
 	assert.False(t, ok, "Expected container to have been swept but was not")
+
+	tasks, _ = taskEngine.ListTasks()
+	assert.Equal(t, len(tasks), 0)
 }
 
 // TestStartStopWithCredentials starts and stops a task for which credentials id


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Increasing integ test coverage (from 56.5% to 58.2%)

### Implementation details
Adding to existing integ tests (minimal change)

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: N/A

### Description for the changelog
No changes to changelog

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License:  yes 
