### PR TITLE
#1144 - > Do not pass the MemoryReservation parameter to docker on windows

### DIFF
--- a/agent/api/task_windows.go
+++ b/agent/api/task_windows.go
@@ -73,6 +73,10 @@ func (task *Task) platformHostConfigOverride(hostConfig *docker.HostConfig) erro
 		hostConfig.CPUPercent = minimumCPUPercent
 	}
 	hostConfig.CPUShares = 0
+
+	// As of version  17.06.2-ee-6 of docker. MemoryReservation is not supported on windows. This ensures that
+	// this parameter is not passed, allowing to launch a container without a hard limit.
+	hostConfig.MemoryReservation = 0
 	return nil
 }
 


### PR DESCRIPTION
### Summary
This fixes #1144

### Implementation details
task_windows.go removes the MemoryReservation HostConfig parameter.

### Testing
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes

This contribution is under the terms of the Apache 2.0 License: yes
