### PR TITLE
engine: docker healthcheck logLength index fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.17.1-dev
+* Bug - Fixed a bug that was causing a runtime panic by accessing negative index in the health check log slice. [#1239](https://github.com/aws/amazon-ecs-agent/pull/1239)
+
 ## 1.17.0
 * Feature - Support a HTTP endpoint for `awsvpc` tasks to query metadata
 * Feature - Support Docker health check

--- a/agent/engine/docker_client_test.go
+++ b/agent/engine/docker_client_test.go
@@ -1271,3 +1271,14 @@ func TestMetadataFromContainer(t *testing.T) {
 	assert.Equal(t, started, metadata.StartedAt)
 	assert.Equal(t, finished, metadata.FinishedAt)
 }
+
+func TestMetadataFromContainerHealthCheckWithNoLogs(t *testing.T) {
+
+	dockerContainer := &docker.Container{
+		State: docker.State{
+			Health: docker.Health{Status: "unhealthy"},
+		}}
+
+	metadata := metadataFromContainer(dockerContainer)
+	assert.Equal(t, api.ContainerUnhealthy, metadata.Health.Status)
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This change addresses https://github.com/aws/amazon-ecs-agent/issues/1237 by adding a zero check before accessing the `Health.Log` slice. Also adds corresponding test.

The issue was surfaced when the agent recieved a Docker health check message indicating the container was `unhealthy` but sent an empty `[]HealthCheck` in `Health.Log`. 

We have not reproduced the issue, but are handling this case by doing a length check on `Health.Log`.

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
