### PR TITLE
Increase steady state and burst throttles for task endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 * Bug - Fixed a bug that was causing a runtime panic by accessing negative index in the health check log slice. [#1239](https://github.com/aws/amazon-ecs-agent/pull/1239)
 * Bug - Workaround for an issue where CPU percent was set to 1 when CPU was not
   set or set to zero(unbounded) in Windows [#1227](https://github.com/aws/amazon-ecs-agent/pull/1227)
+* Bug - Fixed a bug where steady state throttle limits for task metadata endpoints
+  were too low for applications [#1240](https://github.com/aws/amazon-ecs-agent/pull/1240)
 
 ## 1.17.0
 * Feature - Support a HTTP endpoint for `awsvpc` tasks to query metadata

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ additional details on each available environment variable.
 | `ECS_ENABLE_TASK_CPU_MEM_LIMIT` | `true` | Whether to enable task-level cpu and memory limits | `true` | `false` |
 | `ECS_CGROUP_PATH` | `/sys/fs/cgroup` | The root cgroup path that is expected by the ECS agent. This is the path that accessible from the agent mount. | `/sys/fs/cgroup` | Not applicable |
 | `ECS_ENABLE_CPU_UNBOUNDED_WINDOWS_WORKAROUND` | `true` | When `true`, ECS will allow CPU unbounded(CPU=`0`) tasks to run along with CPU bounded tasks in Windows. | Not applicable | `false` |
+| `ECS_TASK_METADATA_RPS_LIMIT` | `100,150` | Comma separated integer values for steady state and burst throttle limits for task metadata endpoint | `40,60` | `40,60` |
 
 ### Persistence
 

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -82,6 +82,7 @@ func TestEnvironmentConfig(t *testing.T) {
 	defer setTestEnv("ECS_NUM_IMAGES_DELETE_PER_CYCLE", "2")()
 	defer setTestEnv("ECS_INSTANCE_ATTRIBUTES", "{\"my_attribute\": \"testing\"}")()
 	defer setTestEnv("ECS_ENABLE_TASK_ENI", "true")()
+	defer setTestEnv("ECS_TASK_METADATA_RPS_LIMIT", "1000,1100")()
 	additionalLocalRoutesJSON := `["1.2.3.4/22","5.6.7.8/32"]`
 	setTestEnv("ECS_AWSVPC_ADDITIONAL_LOCAL_ROUTES", additionalLocalRoutesJSON)
 	setTestEnv("ECS_ENABLE_CONTAINER_METADATA", "true")
@@ -115,6 +116,8 @@ func TestEnvironmentConfig(t *testing.T) {
 	assert.Equal(t, additionalLocalRoutesJSON, string(serializedAdditionalLocalRoutesJSON))
 	assert.Equal(t, "/etc/ecs/", conf.DataDirOnHost, "Wrong value for DataDirOnHost")
 	assert.True(t, conf.ContainerMetadataEnabled, "Wrong value for ContainerMetadataEnabled")
+	assert.Equal(t, 1000, conf.TaskMetadataSteadyStateRate)
+	assert.Equal(t, 1100, conf.TaskMetadataBurstRate)
 }
 
 func TestTrimWhitespaceWhenCreating(t *testing.T) {
@@ -354,6 +357,74 @@ func TestAWSLogsExecutionRole(t *testing.T) {
 	conf, err := environmentConfig()
 	assert.NoError(t, err)
 	assert.True(t, conf.OverrideAWSLogsExecutionRole)
+}
+
+func TestTaskMetadataRPSLimits(t *testing.T) {
+	testCases := []struct {
+		name                    string
+		envVarVal               string
+		expectedSteadyStateRate int
+		expectedBurstRate       int
+	}{
+		{
+			name:                    "negative limit values",
+			envVarVal:               "-10,-10",
+			expectedSteadyStateRate: DefaultTaskMetadataSteadyStateRate,
+			expectedBurstRate:       DefaultTaskMetadataBurstRate,
+		},
+		{
+			name:                    "negative limit,valid burst",
+			envVarVal:               "-10,10",
+			expectedSteadyStateRate: DefaultTaskMetadataSteadyStateRate,
+			expectedBurstRate:       DefaultTaskMetadataBurstRate,
+		},
+		{
+			name:                    "missing limit,valid burst",
+			envVarVal:               " ,10",
+			expectedSteadyStateRate: DefaultTaskMetadataSteadyStateRate,
+			expectedBurstRate:       DefaultTaskMetadataBurstRate,
+		},
+		{
+			name:                    "valid limit,missing burst",
+			envVarVal:               "10,",
+			expectedSteadyStateRate: DefaultTaskMetadataSteadyStateRate,
+			expectedBurstRate:       DefaultTaskMetadataBurstRate,
+		},
+		{
+			name:                    "empty variable",
+			envVarVal:               "",
+			expectedSteadyStateRate: DefaultTaskMetadataSteadyStateRate,
+			expectedBurstRate:       DefaultTaskMetadataBurstRate,
+		},
+		{
+			name:                    "missing burst",
+			envVarVal:               "10",
+			expectedSteadyStateRate: DefaultTaskMetadataSteadyStateRate,
+			expectedBurstRate:       DefaultTaskMetadataBurstRate,
+		},
+		{
+			name:                    "more than expected values",
+			envVarVal:               "10,10,10",
+			expectedSteadyStateRate: DefaultTaskMetadataSteadyStateRate,
+			expectedBurstRate:       DefaultTaskMetadataBurstRate,
+		},
+		{
+			name:                    "values with spaces",
+			envVarVal:               "  10 ,5  ",
+			expectedSteadyStateRate: 10,
+			expectedBurstRate:       5,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer setTestEnv("ECS_TASK_METADATA_RPS_LIMIT", tc.envVarVal)()
+			defer setTestRegion()()
+			cfg, err := NewConfig(ec2.NewBlackholeEC2MetadataClient())
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedSteadyStateRate, cfg.TaskMetadataSteadyStateRate)
+			assert.Equal(t, tc.expectedBurstRate, cfg.TaskMetadataBurstRate)
+		})
+	}
 }
 
 func setTestRegion() func() {

--- a/agent/config/config_unix.go
+++ b/agent/config/config_unix.go
@@ -60,6 +60,8 @@ func DefaultConfig() Config {
 		ContainerMetadataEnabled:    false,
 		TaskCPUMemLimit:             DefaultEnabled,
 		CgroupPath:                  defaultCgroupPath,
+		TaskMetadataSteadyStateRate: DefaultTaskMetadataSteadyStateRate,
+		TaskMetadataBurstRate:       DefaultTaskMetadataBurstRate,
 	}
 }
 

--- a/agent/config/config_unix_test.go
+++ b/agent/config/config_unix_test.go
@@ -58,6 +58,10 @@ func TestConfigDefault(t *testing.T) {
 	assert.Equal(t, defaultCNIPluginsPath, cfg.CNIPluginsPath, "CNIPluginsPath default is set incorrectly")
 	assert.False(t, cfg.AWSVPCBlockInstanceMetdata, "AWSVPCBlockInstanceMetdata default is incorrectly set")
 	assert.Equal(t, "/var/lib/ecs", cfg.DataDirOnHost, "Default DataDirOnHost set incorrectly")
+	assert.Equal(t, DefaultTaskMetadataSteadyStateRate, cfg.TaskMetadataSteadyStateRate,
+		"Default TaskMetadataSteadyStateRate is set incorrectly")
+	assert.Equal(t, DefaultTaskMetadataBurstRate, cfg.TaskMetadataBurstRate,
+		"Default TaskMetadataBurstRate is set incorrectly")
 }
 
 // TestConfigFromFile tests the configuration can be read from file

--- a/agent/config/config_windows.go
+++ b/agent/config/config_windows.go
@@ -83,6 +83,8 @@ func DefaultConfig() Config {
 		ContainerMetadataEnabled:    false,
 		TaskCPUMemLimit:             ExplicitlyDisabled,
 		PlatformVariables:           platformVariables,
+		TaskMetadataSteadyStateRate: DefaultTaskMetadataSteadyStateRate,
+		TaskMetadataBurstRate:       DefaultTaskMetadataBurstRate,
 	}
 }
 

--- a/agent/config/config_windows_test.go
+++ b/agent/config/config_windows_test.go
@@ -52,6 +52,10 @@ func TestConfigDefault(t *testing.T) {
 	assert.Equal(t, DefaultNumImagesToDeletePerCycle, cfg.NumImagesToDeletePerCycle, "NumImagesToDeletePerCycle default is set incorrectly")
 	assert.Equal(t, `C:\ProgramData\Amazon\ECS\data`, cfg.DataDirOnHost, "Default DataDirOnHost set incorrectly")
 	assert.False(t, cfg.PlatformVariables.CPUUnbounded, "CPUUnbounded should be false by default")
+	assert.Equal(t, DefaultTaskMetadataSteadyStateRate, cfg.TaskMetadataSteadyStateRate,
+		"Default TaskMetadataSteadyStateRate is set incorrectly")
+	assert.Equal(t, DefaultTaskMetadataBurstRate, cfg.TaskMetadataBurstRate,
+		"Default TaskMetadataBurstRate is set incorrectly")
 }
 
 func TestConfigIAMTaskRolesReserves80(t *testing.T) {

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -201,4 +201,10 @@ type Config struct {
 
 	// PlatformVariables consists of configuration variables specific to linux/windows
 	PlatformVariables PlatformVariables
+
+	// TaskMetadataSteadyStateRate specifies the steady state throttle for the task metadata endpoint
+	TaskMetadataSteadyStateRate int
+
+	// TaskMetadataBurstRate specifies the burst rate throttle for the task metadata endpoint
+	TaskMetadataBurstRate int
 }

--- a/agent/handlers/taskmetadata/handler_test.go
+++ b/agent/handlers/taskmetadata/handler_test.go
@@ -23,6 +23,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/credentials"
 	mock_credentials "github.com/aws/amazon-ecs-agent/agent/credentials/mocks"
 	mock_audit "github.com/aws/amazon-ecs-agent/agent/logger/audit/mocks"
@@ -174,7 +175,8 @@ func testErrorResponsesFromServer(t *testing.T, path string, expectedErrorMessag
 
 	credentialsManager := mock_credentials.NewMockManager(ctrl)
 	auditLog := mock_audit.NewMockAuditLogger(ctrl)
-	server := setupServer(credentialsManager, auditLog, nil, "", nil)
+	server := setupServer(credentialsManager, auditLog, nil, "", nil, config.DefaultTaskMetadataSteadyStateRate,
+		config.DefaultTaskMetadataBurstRate)
 
 	recorder := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", path, nil)
@@ -207,7 +209,8 @@ func getResponseForCredentialsRequest(t *testing.T, expectedStatus int,
 	defer ctrl.Finish()
 	credentialsManager := mock_credentials.NewMockManager(ctrl)
 	auditLog := mock_audit.NewMockAuditLogger(ctrl)
-	server := setupServer(credentialsManager, auditLog, nil, "", nil)
+	server := setupServer(credentialsManager, auditLog, nil, "", nil, config.DefaultTaskMetadataSteadyStateRate,
+		config.DefaultTaskMetadataBurstRate)
 	recorder := httptest.NewRecorder()
 
 	creds, ok := getCredentials()

--- a/agent/handlers/taskmetadata/taskinfo_test.go
+++ b/agent/handlers/taskmetadata/taskinfo_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
+	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/containermetadata"
 	"github.com/aws/amazon-ecs-agent/agent/credentials"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate/mocks"
@@ -165,7 +166,8 @@ func TestTaskMetadata(t *testing.T) {
 		state.EXPECT().TaskByArn(taskARN).Return(task, true),
 		state.EXPECT().ContainerMapByArn(taskARN).Return(containerNameToDockerContainer, true),
 	)
-	server := setupServer(credentials.NewManager(), auditLog, state, clusterName, statsEngine)
+	server := setupServer(credentials.NewManager(), auditLog, state, clusterName, statsEngine,
+		config.DefaultTaskMetadataSteadyStateRate, config.DefaultTaskMetadataBurstRate)
 	recorder := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", metadataPath, nil)
 	req.RemoteAddr = remoteIP + ":" + remotePort
@@ -192,7 +194,8 @@ func TestContainerMetadata(t *testing.T) {
 		state.EXPECT().ContainerByID(containerID).Return(dockerContainer, true),
 		state.EXPECT().TaskByID(containerID).Return(task, true),
 	)
-	server := setupServer(credentials.NewManager(), auditLog, state, clusterName, statsEngine)
+	server := setupServer(credentials.NewManager(), auditLog, state, clusterName, statsEngine,
+		config.DefaultTaskMetadataSteadyStateRate, config.DefaultTaskMetadataBurstRate)
 	recorder := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", metadataPath+"/"+containerID, nil)
 	req.RemoteAddr = remoteIP + ":" + remotePort
@@ -219,7 +222,8 @@ func TestContainerStats(t *testing.T) {
 		state.EXPECT().GetTaskByIPAddress(remoteIP).Return(taskARN, true),
 		statsEngine.EXPECT().ContainerDockerStats(taskARN, containerID).Return(dockerStats, nil),
 	)
-	server := setupServer(credentials.NewManager(), auditLog, state, clusterName, statsEngine)
+	server := setupServer(credentials.NewManager(), auditLog, state, clusterName, statsEngine,
+		config.DefaultTaskMetadataSteadyStateRate, config.DefaultTaskMetadataBurstRate)
 	recorder := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", statsPath+"/"+containerID, nil)
 	req.RemoteAddr = remoteIP + ":" + remotePort
@@ -252,7 +256,8 @@ func TestTaskStats(t *testing.T) {
 		state.EXPECT().ContainerMapByArn(taskARN).Return(containerMap, true),
 		statsEngine.EXPECT().ContainerDockerStats(taskARN, containerID).Return(dockerStats, nil),
 	)
-	server := setupServer(credentials.NewManager(), auditLog, state, clusterName, statsEngine)
+	server := setupServer(credentials.NewManager(), auditLog, state, clusterName, statsEngine,
+		config.DefaultTaskMetadataSteadyStateRate, config.DefaultTaskMetadataBurstRate)
 	recorder := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", statsPath, nil)
 	req.RemoteAddr = remoteIP + ":" + remotePort


### PR DESCRIPTION
## Summary
This addresses https://github.com/aws/amazon-ecs-agent/issues/1231 

### Implementation details
default steady state throttle of 40 rps and burst of 60 rps.
values configurable through `ECS_TASK_METADATA_RPS_LIMIT` environment variable.

### Testing
<!-- How was this tested? -->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes

### Description for the changelog

### Licensing
This contribution is under the terms of the Apache 2.0 License: yes
