### PR TITLE
generic task resource interface and volume resource implementation

### DIFF
--- a/agent/taskresource/interface.go
+++ b/agent/taskresource/interface.go
@@ -1,0 +1,41 @@
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package taskresource
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// ResourceStatus is an enumeration of valid states of task resource lifecycle
+type ResourceStatus int32
+
+// TaskResource is a wrapper for task level resource methods we need
+type TaskResource interface {
+	// SetDesiredStatus sets the desired status of the resource
+	SetDesiredStatus(ResourceStatus)
+	// GetDesiredStatus gets the desired status of the resource
+	GetDesiredStatus() ResourceStatus
+	// SetKnownStatus sets the desired status of the resource
+	SetKnownStatus(ResourceStatus)
+	// GetKnownStatus gets the desired status of the resource
+	GetKnownStatus() ResourceStatus
+	// SetCreatedAt sets the timestamp for resource's creation time
+	SetCreatedAt(time.Time)
+	// GetCreatedAt sets the timestamp for resource's creation time
+	GetCreatedAt() time.Time
+
+	json.Marshaler
+	json.Unmarshaler
+}

--- a/agent/taskresource/volume.go
+++ b/agent/taskresource/volume.go
@@ -1,0 +1,152 @@
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package taskresource
+
+import (
+	"encoding/json"
+	"sync"
+	"time"
+)
+
+// VolumeResource represents docker volume resource
+type VolumeResource struct {
+	Name                string
+	Mountpoint          string
+	Driver              string
+	DriverOptions       map[string]string
+	Labels              map[string]string
+	createdAtUnsafe     time.Time
+	desiredStatusUnsafe VolumeStatus
+	knownStatusUnsafe   VolumeStatus
+	// lock is used for fields that are accessed and updated concurrently
+	lock sync.RWMutex
+}
+
+// NewVolumeResource returns a docker volume wrapper object
+func NewVolumeResource(name string, 
+	mountPoint string, 
+	driver string, 
+	driverOptions map[string]string, 
+	labels map[string]string) *VolumeResource {
+
+	return &VolumeResource{
+		Name: name,
+		Mountpoint: mountPoint,
+		Driver: driver,
+		DriverOptions: driverOptions,
+		Labels: labels,
+	}
+}
+
+// SetDesiredStatus safely sets the desired status of the resource
+func (vol *VolumeResource) SetDesiredStatus(status VolumeStatus) {
+	vol.lock.Lock()
+	defer vol.lock.Unlock()
+
+	vol.desiredStatusUnsafe = status
+}
+
+// GetDesiredStatus safely returns the desired status of the task
+func (vol *VolumeResource) GetDesiredStatus() VolumeStatus {
+	vol.lock.RLock()
+	defer vol.lock.RUnlock()
+
+	return vol.desiredStatusUnsafe
+}
+
+// SetKnownStatus safely sets the currently known status of the resource
+func (vol *VolumeResource) SetKnownStatus(status VolumeStatus) {
+	vol.lock.Lock()
+	defer vol.lock.Unlock()
+
+	vol.knownStatusUnsafe = status
+}
+
+// GetKnownStatus safely returns the currently known status of the task
+func (vol *VolumeResource) GetKnownStatus() VolumeStatus {
+	vol.lock.RLock()
+	defer vol.lock.RUnlock()
+
+	return vol.knownStatusUnsafe
+}
+
+// SetCreatedAt sets the timestamp for resource's creation time
+func (vol *VolumeResource) SetCreatedAt(createdAt time.Time) {
+	if createdAt.IsZero() {
+		return
+	}
+	vol.lock.Lock()
+	defer vol.lock.Unlock()
+
+	vol.createdAtUnsafe = createdAt
+}
+
+// GetCreatedAt sets the timestamp for resource's creation time
+func (vol *VolumeResource) GetCreatedAt() time.Time {
+	vol.lock.RLock()
+	defer vol.lock.RUnlock()
+
+	return vol.createdAtUnsafe
+}
+
+// volumeResourceJSON duplicates VolumeResource fields, only for marshalling and unmarshalling purposes
+type volumeResourceJSON struct {
+	Name          string            `json:"Name"`
+	Mountpoint    string            `json:"MountPoint"`
+	Driver        string            `json:"Driver"`
+	DriverOptions map[string]string `json:"DriverOptions"`
+	Labels        map[string]string `json:"Labels"`
+	CreatedAt     time.Time
+	DesiredStatus *VolumeStatus `json:"DesiredStatus"`
+	KnownStatus   *VolumeStatus `json:"KnownStatus"`
+}
+
+// MarshalJSON marshals VolumeResource object using duplicate struct VolumeResourceJSON
+func (vol *VolumeResource) MarshalJSON() ([]byte, error) {
+	if vol == nil {
+		return nil, nil
+	}
+	return json.Marshal(volumeResourceJSON{
+		vol.Name,
+		vol.Mountpoint,
+		vol.Driver,
+		vol.DriverOptions,
+		vol.Labels,
+		vol.GetCreatedAt(),
+		func() *VolumeStatus { desiredState := vol.GetDesiredStatus(); return &desiredState }(),
+		func() *VolumeStatus { knownState := vol.GetKnownStatus(); return &knownState }(),
+	})
+}
+
+// UnmarshalJSON unmarshals VolumeResource object using duplicate struct VolumeResourceJSON
+func (vol *VolumeResource) UnmarshalJSON(b []byte) error {
+	temp := &volumeResourceJSON{}
+
+	if err := json.Unmarshal(b, &temp); err != nil {
+		return err
+	}
+
+	vol.Name = temp.Name
+	vol.Mountpoint = temp.Mountpoint
+	vol.Driver = temp.Driver
+	vol.DriverOptions = temp.DriverOptions
+	vol.Labels = temp.Labels
+	if temp.DesiredStatus != nil {
+		vol.SetDesiredStatus(*temp.DesiredStatus)
+	}
+	if temp.KnownStatus != nil {
+		vol.SetKnownStatus(*temp.KnownStatus)
+	}
+	return nil
+}

--- a/agent/taskresource/volume_test.go
+++ b/agent/taskresource/volume_test.go
@@ -1,0 +1,70 @@
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package taskresource
+
+import (
+	"testing"
+	"time"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMarshall(t *testing.T) {
+	volumeStr := "{\"Name\":\"volumeName\",\"MountPoint\":\"mountPoint\",\"Driver\":\"drive\"," +
+		"\"DriverOptions\":{\"opt1\":\"val1\",\"opt2\":\"val2\"},\"Labels\":{}," +
+		"\"CreatedAt\":\"0001-01-01T00:00:00Z\",\"DesiredStatus\":\"CREATED\",\"KnownStatus\":\"NONE\"}"
+	name := "volumeName"
+	mountPoint := "mountPoint"
+	driver := "drive"
+	driverOptions := map[string]string{
+		"opt1": "val1",
+		"opt2": "val2",
+	}
+
+	labels := make(map[string]string)
+
+	volume := NewVolumeResource(name, mountPoint, driver, driverOptions, labels)
+	volume.SetDesiredStatus(VolumeCreated)
+	volume.SetKnownStatus(VolumeStatusNone)
+
+	bytes, err := volume.MarshalJSON()
+	assert.NoError(t, err)
+	assert.Equal(t, volumeStr, string(bytes[:]))
+}
+func TestUnmarshall(t *testing.T) {
+	name := "volumeName"
+	mountPoint := "mountPoint"
+	driver := "drive"
+	driverOptions := map[string]string{
+		"opt1": "val1",
+	}
+
+	labels := map[string]string{
+		"lab1": "label",
+	}
+	bytes := []byte("{\"Name\":\"volumeName\",\"MountPoint\":\"mountPoint\",\"Driver\":\"drive\"," +
+		"\"DriverOptions\":{\"opt1\":\"val1\"},\"Labels\":{\"lab1\":\"label\"}," +
+		"\"CreatedAt\":\"0001-01-01T00:00:00Z\",\"DesiredStatus\":\"CREATED\",\"KnownStatus\":\"NONE\"}")
+	unmarshalledVolume := &VolumeResource{}
+	err := unmarshalledVolume.UnmarshalJSON(bytes)
+	assert.NoError(t, err)
+
+	assert.Equal(t, name, unmarshalledVolume.Name)
+	assert.Equal(t, mountPoint, unmarshalledVolume.Mountpoint)
+	assert.Equal(t, driver, unmarshalledVolume.Driver)
+	assert.Equal(t, driverOptions, unmarshalledVolume.DriverOptions)
+	assert.Equal(t, labels, unmarshalledVolume.Labels)
+	assert.Equal(t, time.Time{}, unmarshalledVolume.GetCreatedAt())
+	assert.Equal(t, VolumeCreated, unmarshalledVolume.GetDesiredStatus())
+	assert.Equal(t, VolumeStatusNone, unmarshalledVolume.GetKnownStatus())
+}

--- a/agent/taskresource/volumestatus.go
+++ b/agent/taskresource/volumestatus.go
@@ -1,0 +1,92 @@
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package taskresource
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/aws/amazon-ecs-agent/agent/api"
+)
+
+// VolumeStatus defines resource statuses for docker volume
+type VolumeStatus ResourceStatus 
+
+const (
+	// VolumeStatusNone is the zero state of a task resource
+	VolumeStatusNone VolumeStatus = iota
+	// VolumeCreated represents a task resource which has been created
+	VolumeCreated
+	// VolumeCleaned represents a task resource which has been cleaned up
+	VolumeCleaned
+)
+
+var resourceStatusMap = map[string]VolumeStatus{
+	"NONE":    VolumeStatusNone,
+	"CREATED": VolumeCreated,
+	"CLEANED": VolumeCleaned,
+}
+
+// StatusString returns a human readable string representation of this object
+func (vs VolumeStatus) String() string {
+	for k, v := range resourceStatusMap {
+		if v == vs {
+			return k
+		}
+	}
+	return "NONE"
+}
+
+// TaskStatus maps the resource status to the corresponding task status.
+func (vs VolumeStatus) TaskStatus() api.TaskStatus {
+	switch vs {
+	case VolumeStatusNone:
+		return api.TaskStatusNone
+	case VolumeCreated:
+		return api.TaskCreated
+	case VolumeCleaned:
+		return api.TaskZombie
+	}
+	return api.TaskStatusNone
+}
+
+// MarshalJSON overrides the logic for JSON-encoding the ResourceStatus type
+func (vs *VolumeStatus) MarshalJSON() ([]byte, error) {
+	if vs == nil {
+		return nil, nil
+	}
+	return []byte(`"` + vs.String() + `"`), nil
+}
+
+// UnmarshalJSON overrides the logic for parsing the JSON-encoded ResourceStatus data
+func (vs *VolumeStatus) UnmarshalJSON(b []byte) error {
+	if strings.ToLower(string(b)) == "null" {
+		*vs = VolumeStatusNone
+		return nil
+	}
+
+	if b[0] != '"' || b[len(b)-1] != '"' {
+		*vs = VolumeStatusNone
+		return errors.New("resource status unmarshal: status must be a string or null; Got " + string(b))
+	}
+
+	strStatus := string(b[1 : len(b)-1])
+	stat, ok := resourceStatusMap[strStatus]
+	if !ok {
+		*vs = VolumeStatusNone
+		return errors.New("resource status unmarshal: unrecognized status")
+	}
+	*vs = stat
+	return nil
+}

--- a/agent/taskresource/volumestatus_test.go
+++ b/agent/taskresource/volumestatus_test.go
@@ -1,0 +1,99 @@
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package taskresource
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/aws/amazon-ecs-agent/agent/api"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStatusString(t *testing.T) {
+	var resourceStatus VolumeStatus
+
+	resourceStatus = VolumeStatusNone
+	assert.Equal(t, resourceStatus.String(), "NONE")
+	resourceStatus = VolumeCreated
+	assert.Equal(t, resourceStatus.String(), "CREATED")
+	resourceStatus = VolumeCleaned
+	assert.Equal(t, resourceStatus.String(), "CLEANED")
+}
+
+func TestTaskStatus(t *testing.T) {
+	var resourceStatus VolumeStatus
+
+	resourceStatus = VolumeStatusNone
+	assert.Equal(t, resourceStatus.TaskStatus(), api.TaskStatusNone)
+	resourceStatus = VolumeCreated
+	assert.Equal(t, resourceStatus.TaskStatus(), api.TaskCreated)
+	resourceStatus = VolumeCleaned
+	assert.Equal(t, resourceStatus.TaskStatus(), api.TaskZombie)
+}
+
+func TestMarshalVolumeStatus(t *testing.T) {
+	status := VolumeStatusNone
+	bytes, err := status.MarshalJSON()
+
+	assert.NoError(t, err)
+	assert.Equal(t, `"NONE"`, string(bytes[:]))
+}
+
+func TestMarshalNilVolumeStatus(t *testing.T) {
+	var status *VolumeStatus
+	bytes, err := status.MarshalJSON()
+	
+	assert.Nil(t, bytes)
+	assert.Nil(t, err)
+}
+
+type testVolumeStatus struct {
+	SomeStatus VolumeStatus `json:"status"`
+}
+
+func TestUnmarshalVolumeStatus(t *testing.T) {
+	status := VolumeStatusNone
+
+	err := json.Unmarshal([]byte(`"CREATED"`), &status)
+	assert.NoError(t, err)
+	assert.Equal(t, VolumeCreated, status, "CREATED should unmarshal to CREATED, not " + status.String())
+
+	var testStatus testVolumeStatus
+	err = json.Unmarshal([]byte(`{"status":"CLEANED"}`), &testStatus)
+	assert.NoError(t, err)
+	assert.Equal(t, VolumeCleaned, testStatus.SomeStatus, "CLEANED should unmarshal to CLEANED, not " + testStatus.SomeStatus.String())
+}
+
+func TestUnmarshalNullVolumeStatus(t *testing.T) {
+	status := VolumeCreated
+	err := json.Unmarshal([]byte("null"), &status)
+	assert.NoError(t, err)
+	assert.Equal(t, VolumeStatusNone, status, "null should unmarshal to None, not " + status.String())
+}
+
+func TestUnmarshalNonStringVolumeStatusDefaultNone(t *testing.T) {
+	status := VolumeCreated
+	err := json.Unmarshal([]byte(`1`), &status)
+	assert.NotNil(t, err)
+	assert.Equal(t, VolumeStatusNone, status, "non-string status should unmarshal to None, not " + status.String())
+}
+
+func TestUnmarshalUnmappedVolumeStatusDefaultNone(t *testing.T) {
+	status := VolumeCleaned
+	err := json.Unmarshal([]byte(`"SOMEOTHER"`), &status)
+	assert.NotNil(t, err)
+	assert.Equal(t, VolumeStatusNone, status, "Unmapped status should unmarshal to None, not " + status.String())
+}
+


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Adding generic task resource interface and volume resource implementation

### Implementation details
**TaskResource** interface defines common methods for all resources to implement.
**ResourceStatus** represents resource status.

**VolumeResource** implements TaskResource interface
**VolumeStatus** wraps ResourceStatus to define volume-specific statuses

Note the interface is expected to evolve as more concrete resources are implemented, even for the VolumeResource.

### Testing
<!-- How was this tested? -->
Added unit tests for VolumeResource and VolumeStatus

- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes

### Description for the changelog
Changelog not updated

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: yes
