### PR TITLE
engine: container health integ test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,7 +221,7 @@ cni-plugins: get-cni-sources .out-stamp
 	@echo "Built amazon-ecs-cni-plugins successfully."
 
 run-integ-tests: test-registry gremlin container-health-check-image
-	. ./scripts/shared_env && go test -race -tags integration -timeout=5m -v ./agent/engine/... ./agent/stats/... ./agent/app/...
+	. ./scripts/shared_env && go test -race -tags integration -timeout=7m -v ./agent/engine/... ./agent/stats/... ./agent/app/...
 
 .PHONY: codebuild
 codebuild: get-deps test-artifacts .out-stamp

--- a/scripts/run-integ-tests.ps1
+++ b/scripts/run-integ-tests.ps1
@@ -21,7 +21,7 @@ Invoke-Expression "${PSScriptRoot}\..\misc\container-health-windows\build.ps1"
 $cwd = (pwd).Path
 try {
   cd "${PSScriptRoot}"
-  go test -race -tags integration -timeout=15m -v ../agent/engine ../agent/stats ../agent/app
+  go test -race -tags integration -timeout=20m -v ../agent/engine ../agent/stats ../agent/app
   $testsExitCode = $LastExitCode
 } finally {
   cd "$cwd"


### PR DESCRIPTION
### Summary
Container health check integ test

### Implementation details
Start task with docker health check enabled 
Verify health status set

### Testing
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes

### Licensing
This contribution is under the terms of the Apache 2.0 License: yes
