### PR TITLE
Separate the call of different plugins in ecscni

### DIFF
--- a/agent/ecscni/plugin_test.go
+++ b/agent/ecscni/plugin_test.go
@@ -26,16 +26,22 @@ func TestSetupNS(t *testing.T) {
 	err := json.Unmarshal([]byte(additionalRoutesJson), &additionalRoutes)
 	assert.NoError(t, err)
 
-	libcniClient.EXPECT().AddNetworkList(gomock.Any(), gomock.Any()).Return(&current.Result{}, nil).Do(
-		func(net *libcni.NetworkConfigList, rt *libcni.RuntimeConf) {
-			assert.Len(t, net.Plugins, 2, "expected 2 plugins for SetupNS")
-			bridgePlugin := net.Plugins[1]
-			assert.Equal(t, ECSBridgePluginName, bridgePlugin.Network.Type, "second plugin should be bridge")
-			var bridgeConfig BridgeConfig
-			err := json.Unmarshal(bridgePlugin.Bytes, &bridgeConfig)
-			assert.NoError(t, err, "unmarshal BridgeConfig")
-			assert.Len(t, bridgeConfig.IPAM.IPV4Routes, 3, "default route plus two extra routes")
-		})
+	gomock.InOrder(
+		// ENI plugin was called first
+		libcniClient.EXPECT().AddNetwork(gomock.Any(), gomock.Any()).Return(&current.Result{}, nil).Do(
+			func(net *libcni.NetworkConfig, rt *libcni.RuntimeConf) {
+				assert.Equal(t, ECSENIPluginName, net.Network.Type, "second plugin should be eni")
+			}),
+		// Bridge plugin was called last
+		libcniClient.EXPECT().AddNetwork(gomock.Any(), gomock.Any()).Return(&current.Result{}, nil).Do(
+			func(net *libcni.NetworkConfig, rt *libcni.RuntimeConf) {
+				assert.Equal(t, ECSBridgePluginName, net.Network.Type, "first plugin should be bridge")
+				var bridgeConfig BridgeConfig
+				err := json.Unmarshal(net.Bytes, &bridgeConfig)
+				assert.NoError(t, err, "unmarshal BridgeConfig")
+				assert.Len(t, bridgeConfig.IPAM.IPV4Routes, 3, "default route plus two extra routes")
+			}),
+	)
 
 	_, err = ecscniClient.SetupNS(&Config{AdditionalLocalRoutes: additionalRoutes})
 	assert.NoError(t, err)
@@ -49,7 +55,8 @@ func TestCleanupNS(t *testing.T) {
 	libcniClient := mock_libcni.NewMockCNI(ctrl)
 	ecscniClient.(*cniClient).libcni = libcniClient
 
-	libcniClient.EXPECT().DelNetworkList(gomock.Any(), gomock.Any()).Return(nil)
+	// This will be called for both bridge and eni plugin
+	libcniClient.EXPECT().DelNetwork(gomock.Any(), gomock.Any()).Return(nil).Times(2)
 
 	additionalRoutesJson := `["169.254.172.1/32", "10.11.12.13/32"]`
 	var additionalRoutes []cnitypes.IPNet
@@ -67,15 +74,15 @@ func TestReleaseIPInIPAM(t *testing.T) {
 	libcniClient := mock_libcni.NewMockCNI(ctrl)
 	ecscniClient.(*cniClient).libcni = libcniClient
 
-	libcniClient.EXPECT().DelNetworkList(gomock.Any(), gomock.Any()).Return(nil)
+	libcniClient.EXPECT().DelNetwork(gomock.Any(), gomock.Any()).Return(nil)
 
 	err := ecscniClient.ReleaseIPResource(&Config{})
 	assert.NoError(t, err)
 }
 
-// TestConstructNetworkConfig tests constructNetworkConfig creates the correct
-// configuration for bridge/eni plugin
-func TestConstructNetworkConfigWithoutIPAM(t *testing.T) {
+// TestConstructENINetworkConfig tests createENINetworkConfig creates the correct
+// configuration for eni plugin
+func TestConstructENINetworkConfig(t *testing.T) {
 	ecscniClient := NewClient(&Config{})
 
 	config := &Config{
@@ -85,27 +92,15 @@ func TestConstructNetworkConfigWithoutIPAM(t *testing.T) {
 		ENIIPV4Address:       "172.31.21.40",
 		ENIIPV6Address:       "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
 		ENIMACAddress:        "02:7b:64:49:b1:40",
-		BridgeName:           "bridge-test1",
 		BlockInstanceMetdata: true,
 	}
 
-	networkConfigList, err := ecscniClient.(*cniClient).createNetworkConfig(config, ecscniClient.(*cniClient).createBridgeNetworkConfigWithoutIPAM)
-	assert.NoError(t, err, "construct cni plugins configuration failed")
-
-	bridgeConfig := &BridgeConfig{}
+	_, eniNetworkConfig, err := ecscniClient.(*cniClient).createENINetworkConfig(config)
+	assert.NoError(t, err, "construct eni network config failed")
 	eniConfig := &ENIConfig{}
-	for _, plugin := range networkConfigList.Plugins {
-		var err error
-		if plugin.Network.Type == ECSBridgePluginName {
-			err = json.Unmarshal(plugin.Bytes, bridgeConfig)
-		} else if plugin.Network.Type == ECSENIPluginName {
-			err = json.Unmarshal(plugin.Bytes, eniConfig)
-		}
-		assert.NoError(t, err, "unmarshal config from bytes failed")
-	}
+	err = json.Unmarshal(eniNetworkConfig.Bytes, eniConfig)
+	assert.NoError(t, err, "unmarshal config from bytes failed")
 
-	assert.Equal(t, config.BridgeName, bridgeConfig.BridgeName)
-	assert.Equal(t, IPAMConfig{}, bridgeConfig.IPAM)
 	assert.Equal(t, config.ENIID, eniConfig.ENIID)
 	assert.Equal(t, config.ENIIPV4Address, eniConfig.IPV4Address)
 	assert.Equal(t, config.ENIIPV6Address, eniConfig.IPV6Address)
@@ -113,8 +108,28 @@ func TestConstructNetworkConfigWithoutIPAM(t *testing.T) {
 	assert.True(t, eniConfig.BlockInstanceMetdata)
 }
 
-// TestConstructNetworkConfig tests constructNetworkConfig creates the correct
-// configuration for bridge/eni/ipam plugin
+// TestConstructBridgeNetworkConfigWithoutIPAM tests createBridgeNetworkConfigWithoutIPAM creates the right configuration for bridge plugin
+func TestConstructBridgeNetworkConfigWithoutIPAM(t *testing.T) {
+	ecscniClient := NewClient(&Config{})
+
+	config := &Config{
+		ContainerID:  "containerid12",
+		ContainerPID: "pid",
+		BridgeName:   "bridge-test1",
+	}
+
+	_, bridgeNetworkConfig, err := ecscniClient.(*cniClient).createBridgeNetworkConfigWithoutIPAM(config)
+	assert.NoError(t, err, "construct bridge network config failed")
+	bridgeConfig := &BridgeConfig{}
+	err = json.Unmarshal(bridgeNetworkConfig.Bytes, bridgeConfig)
+
+	assert.NoError(t, err, "unmarshal bridge config from bytes failed")
+	assert.Equal(t, config.BridgeName, bridgeConfig.BridgeName)
+	assert.Equal(t, IPAMConfig{}, bridgeConfig.IPAM)
+}
+
+// TestConstructBridgeNetworkConfigWithIPAM tests createBridgeNetworkConfigWithIPAM
+// creates the correct configuration for bridge and ipam plugin
 func TestConstructNetworkConfig(t *testing.T) {
 	ecscniClient := NewClient(&Config{})
 
@@ -124,41 +139,22 @@ func TestConstructNetworkConfig(t *testing.T) {
 	assert.NoError(t, err)
 
 	config := &Config{
-		ENIID:                 "eni-12345678",
 		ContainerID:           "containerid12",
 		ContainerPID:          "pid",
-		ENIIPV4Address:        "172.31.21.40",
-		ENIIPV6Address:        "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
-		ENIMACAddress:         "02:7b:64:49:b1:40",
 		BridgeName:            "bridge-test1",
-		BlockInstanceMetdata:  true,
 		AdditionalLocalRoutes: additionalRoutes,
 	}
 
-	networkConfigList, err := ecscniClient.(*cniClient).createNetworkConfig(config, ecscniClient.(*cniClient).createBridgeNetworkConfigWithIPAM)
-	assert.NoError(t, err, "construct cni plugins configuration failed")
+	_, bridgeNetworkConfig, err := ecscniClient.(*cniClient).createBridgeNetworkConfigWithIPAM(config)
+	assert.NoError(t, err, "construct bridge plugins configuration failed")
 
 	bridgeConfig := &BridgeConfig{}
-	eniConfig := &ENIConfig{}
-	for _, plugin := range networkConfigList.Plugins {
-		var err error
-		switch plugin.Network.Type {
-		case ECSBridgePluginName:
-			err = json.Unmarshal(plugin.Bytes, bridgeConfig)
-		case ECSENIPluginName:
-			err = json.Unmarshal(plugin.Bytes, eniConfig)
-		}
-		assert.NoError(t, err, "unmarshal config from bytes failed for plugin %s\n%s", plugin.Network.Type, string(plugin.Bytes))
-	}
+	err = json.Unmarshal(bridgeNetworkConfig.Bytes, bridgeConfig)
+	assert.NoError(t, err, "unmarshal bridge config from bytes failed: %s", string(bridgeNetworkConfig.Bytes))
 
 	assert.Equal(t, config.BridgeName, bridgeConfig.BridgeName)
 	assert.Equal(t, ecsSubnet, bridgeConfig.IPAM.IPV4Subnet)
 	assert.Equal(t, TaskIAMRoleEndpoint, bridgeConfig.IPAM.IPV4Routes[0].Dst.String())
-	assert.Equal(t, config.ENIID, eniConfig.ENIID)
-	assert.Equal(t, config.ENIIPV4Address, eniConfig.IPV4Address)
-	assert.Equal(t, config.ENIIPV6Address, eniConfig.IPV6Address)
-	assert.Equal(t, config.ENIMACAddress, eniConfig.MACAddress)
-	assert.True(t, eniConfig.BlockInstanceMetdata)
 }
 
 func TestCNIPluginVersion(t *testing.T) {

--- a/agent/ecscni/types.go
+++ b/agent/ecscni/types.go
@@ -23,8 +23,10 @@ const (
 	// capabilitiesCommand is the command used to get the capabilities of a
 	// CNI plugin
 	capabilitiesCommand = "--capabilities"
-	// defaultEthName is the name of veth pair name in the container namespace
-	defaultEthName = "ecs-eth0"
+	// defaultVethName is the name of veth pair name in the container namespace
+	defaultVethName = "ecs-eth0"
+	// defaultENIName is the name of eni interface name in the container namespace
+	defaultENIName = "eth0"
 	// defaultBridgeName is the default name of bridge created for container to
 	// communicate with ecs-agent
 	defaultBridgeName = "ecs-bridge"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Fix #1151
Previously all the plugins were invoked in one call in agent `AddNetworkList` with the same runtime configuration, this PR separates them into different calls with `AddNetwork` so that each plugin can have different runtime config.

### Implementation details
<!-- How are the changes implemented? -->
Replace the `AddNetworkList` with `AddNetwork` and call the plugin in the order of `ecs-eni` and then `ecs-bridge`.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass
- [x] Checked out the latest `amazon-ecs-cni-plugin`(including aws/amazon-ecs-cni-plugins#59) and run a task with `awsvpc` mode, the container namespace was set correctly.
New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
yes