### PR TITLE
adding CreateVolume function to docker_client

### DIFF
--- a/agent/engine/dockeriface/interface.go
+++ b/agent/engine/dockeriface/interface.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -38,6 +38,7 @@ type Client interface {
 	StartContainerWithContext(id string, hostConfig *docker.HostConfig, ctx context.Context) error
 	StopContainer(id string, timeout uint) error
 	StopContainerWithContext(id string, timeout uint, ctx context.Context) error
+	CreateVolume(opts docker.CreateVolumeOptions) (*docker.Volume, error)
 	Stats(opts docker.StatsOptions) error
 	Version() (*docker.Env, error)
 	RemoveImage(imageName string) error

--- a/agent/engine/dockeriface/mocks/dockeriface_mocks.go
+++ b/agent/engine/dockeriface/mocks/dockeriface_mocks.go
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -196,6 +196,17 @@ func (_m *MockClient) StartContainerWithContext(_param0 string, _param1 *go_dock
 
 func (_mr *_MockClientRecorder) StartContainerWithContext(arg0, arg1, arg2 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "StartContainerWithContext", arg0, arg1, arg2)
+}
+
+func (_m *MockClient) CreateVolume(_param0 go_dockerclient.CreateVolumeOptions) (*go_dockerclient.Volume, error) {
+	ret := _m.ctrl.Call(_m, "CreateVolume", _param0)
+	ret0, _ := ret[0].(*go_dockerclient.Volume)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockClientRecorder) CreateVolume(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateVolume", arg0)
 }
 
 func (_m *MockClient) Stats(_param0 go_dockerclient.StatsOptions) error {

--- a/agent/engine/engine_mocks.go
+++ b/agent/engine/engine_mocks.go
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -435,6 +435,12 @@ func (_m *MockImageManager) RemoveContainerReferenceFromImageState(_param0 *api.
 
 func (_mr *_MockImageManagerRecorder) RemoveContainerReferenceFromImageState(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveContainerReferenceFromImageState", arg0)
+}
+
+func (_m *MockDockerClient) CreateVolume(_param0 string, _param1 string, _param2 string, _param3 map[string]string, _param4 map[string]string, _param5 time.Duration) volumeResponse {
+	ret := _m.ctrl.Call(_m, "CreateVolume", _param0, _param1, _param2, _param3, _param4, _param5)
+	ret0, _ := ret[0].(volumeResponse)
+	return ret0
 }
 
 func (_m *MockImageManager) SetSaver(_param0 statemanager.Saver) {

--- a/agent/engine/errors.go
+++ b/agent/engine/errors.go
@@ -334,3 +334,16 @@ func (err CannotGetDockerClientVersionError) ErrorName() string {
 func (err CannotGetDockerClientVersionError) Error() string {
 	return err.fromError.Error()
 }
+
+// CannotCreateVolumeError indicates any error when trying to create a volume
+type CannotCreateVolumeError struct {
+	fromError error
+}
+
+func (err CannotCreateVolumeError) Error() string {
+	return err.fromError.Error()
+}
+
+func (err CannotCreateVolumeError) ErrorName() string {
+	return "CannotCreateVolumeError"
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
CreateVolume function added to docker_client

### Implementation details
A wrapper for docker.CreateVolume API is added to docker_client.go
For the interest of keeping commits small, I'll add remaining volume APIs (list, inspect, and delete) separately.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes (unit tests added)

### Description for the changelog
changelog not updated

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
