### PR TITLE
Removing driverOptions from internal volume struct

### DIFF
--- a/agent/engine/docker_client.go
+++ b/agent/engine/docker_client.go
@@ -1034,7 +1034,6 @@ func (dg *dockerGoClient) createVolume(ctx context.Context,
 		dockerVolume.Name,
 		dockerVolume.Mountpoint,
 		dockerVolume.Driver,
-		driverOptions,
 		dockerVolume.Labels)
 	return volumeResponse{Volume: volume, Error: nil}
 }

--- a/agent/taskresource/volume.go
+++ b/agent/taskresource/volume.go
@@ -24,7 +24,6 @@ type VolumeResource struct {
 	Name                string
 	Mountpoint          string
 	Driver              string
-	DriverOptions       map[string]string
 	Labels              map[string]string
 	createdAtUnsafe     time.Time
 	desiredStatusUnsafe VolumeStatus
@@ -37,14 +36,12 @@ type VolumeResource struct {
 func NewVolumeResource(name string, 
 	mountPoint string, 
 	driver string, 
-	driverOptions map[string]string, 
 	labels map[string]string) *VolumeResource {
 
 	return &VolumeResource{
 		Name: name,
 		Mountpoint: mountPoint,
 		Driver: driver,
-		DriverOptions: driverOptions,
 		Labels: labels,
 	}
 }
@@ -105,7 +102,6 @@ type volumeResourceJSON struct {
 	Name          string            `json:"Name"`
 	Mountpoint    string            `json:"MountPoint"`
 	Driver        string            `json:"Driver"`
-	DriverOptions map[string]string `json:"DriverOptions"`
 	Labels        map[string]string `json:"Labels"`
 	CreatedAt     time.Time
 	DesiredStatus *VolumeStatus `json:"DesiredStatus"`
@@ -121,7 +117,6 @@ func (vol *VolumeResource) MarshalJSON() ([]byte, error) {
 		vol.Name,
 		vol.Mountpoint,
 		vol.Driver,
-		vol.DriverOptions,
 		vol.Labels,
 		vol.GetCreatedAt(),
 		func() *VolumeStatus { desiredState := vol.GetDesiredStatus(); return &desiredState }(),
@@ -140,7 +135,6 @@ func (vol *VolumeResource) UnmarshalJSON(b []byte) error {
 	vol.Name = temp.Name
 	vol.Mountpoint = temp.Mountpoint
 	vol.Driver = temp.Driver
-	vol.DriverOptions = temp.DriverOptions
 	vol.Labels = temp.Labels
 	if temp.DesiredStatus != nil {
 		vol.SetDesiredStatus(*temp.DesiredStatus)

--- a/agent/taskresource/volume_test.go
+++ b/agent/taskresource/volume_test.go
@@ -20,20 +20,15 @@ import (
 )
 
 func TestMarshall(t *testing.T) {
-	volumeStr := "{\"Name\":\"volumeName\",\"MountPoint\":\"mountPoint\",\"Driver\":\"drive\"," +
-		"\"DriverOptions\":{\"opt1\":\"val1\",\"opt2\":\"val2\"},\"Labels\":{}," +
+	volumeStr := "{\"Name\":\"volumeName\",\"MountPoint\":\"mountPoint\",\"Driver\":\"drive\",\"Labels\":{}," +
 		"\"CreatedAt\":\"0001-01-01T00:00:00Z\",\"DesiredStatus\":\"CREATED\",\"KnownStatus\":\"NONE\"}"
 	name := "volumeName"
 	mountPoint := "mountPoint"
 	driver := "drive"
-	driverOptions := map[string]string{
-		"opt1": "val1",
-		"opt2": "val2",
-	}
 
 	labels := make(map[string]string)
 
-	volume := NewVolumeResource(name, mountPoint, driver, driverOptions, labels)
+	volume := NewVolumeResource(name, mountPoint, driver, labels)
 	volume.SetDesiredStatus(VolumeCreated)
 	volume.SetKnownStatus(VolumeStatusNone)
 
@@ -45,15 +40,11 @@ func TestUnmarshall(t *testing.T) {
 	name := "volumeName"
 	mountPoint := "mountPoint"
 	driver := "drive"
-	driverOptions := map[string]string{
-		"opt1": "val1",
-	}
 
 	labels := map[string]string{
 		"lab1": "label",
 	}
-	bytes := []byte("{\"Name\":\"volumeName\",\"MountPoint\":\"mountPoint\",\"Driver\":\"drive\"," +
-		"\"DriverOptions\":{\"opt1\":\"val1\"},\"Labels\":{\"lab1\":\"label\"}," +
+	bytes := []byte("{\"Name\":\"volumeName\",\"MountPoint\":\"mountPoint\",\"Driver\":\"drive\",\"Labels\":{\"lab1\":\"label\"}," +
 		"\"CreatedAt\":\"0001-01-01T00:00:00Z\",\"DesiredStatus\":\"CREATED\",\"KnownStatus\":\"NONE\"}")
 	unmarshalledVolume := &VolumeResource{}
 	err := unmarshalledVolume.UnmarshalJSON(bytes)
@@ -62,7 +53,6 @@ func TestUnmarshall(t *testing.T) {
 	assert.Equal(t, name, unmarshalledVolume.Name)
 	assert.Equal(t, mountPoint, unmarshalledVolume.Mountpoint)
 	assert.Equal(t, driver, unmarshalledVolume.Driver)
-	assert.Equal(t, driverOptions, unmarshalledVolume.DriverOptions)
 	assert.Equal(t, labels, unmarshalledVolume.Labels)
 	assert.Equal(t, time.Time{}, unmarshalledVolume.GetCreatedAt())
 	assert.Equal(t, VolumeCreated, unmarshalledVolume.GetDesiredStatus())


### PR DESCRIPTION
go-dockerclient's volume doesn't return this field (see https://tinyurl.com/y7e4nllt)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
go-dockerclient's volume struct never returns the driver options that was passed when volume is created.

### Implementation details
Removed driver options map from internal volume struct, as we won't have access to this field except when we are creating the volume.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
