### PR TITLE
vendor: gorilla/websocket constrain to version 1.2.0

### DIFF
--- a/agent/Gopkg.lock
+++ b/agent/Gopkg.lock
@@ -193,7 +193,8 @@
 [[projects]]
   name = "github.com/gorilla/websocket"
   packages = ["."]
-  revision = "0868951cdb8e69bc42df4598bdc6164ff2f1a072"
+  revision = "ea4d1f681babbce9545c9c5f3d5194a789c89f5b"
+  version = "v1.2.0"
 
 [[projects]]
   name = "github.com/jmespath/go-jmespath"
@@ -326,6 +327,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "aa121c36f9f7f82cdfeba64e43e0987eb8f962e95f4539dbcdfead65d85aabe7"
+  inputs-digest = "51cd6532582aaef6e5ff0b6e7920fe74c1786d5dbbcc1e26bba7bff2e00fadc0"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/agent/Gopkg.toml
+++ b/agent/Gopkg.toml
@@ -55,7 +55,7 @@
 
 [[constraint]]
   name = "github.com/gorilla/websocket"
-  revision ="0868951cdb8e69bc42df4598bdc6164ff2f1a072"
+  version = "v1.2.0"
 
 [[constraint]]
   name = "github.com/opencontainers/runtime-spec"

--- a/agent/vendor/github.com/gorilla/websocket/.travis.yml
+++ b/agent/vendor/github.com/gorilla/websocket/.travis.yml
@@ -7,6 +7,7 @@ matrix:
     - go: 1.5
     - go: 1.6
     - go: 1.7
+    - go: 1.8
     - go: tip
   allow_failures:
     - go: tip

--- a/agent/vendor/github.com/gorilla/websocket/client_clone.go
+++ b/agent/vendor/github.com/gorilla/websocket/client_clone.go
@@ -1,0 +1,16 @@
+// Copyright 2013 The Gorilla WebSocket Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build go1.8
+
+package websocket
+
+import "crypto/tls"
+
+func cloneTLSConfig(cfg *tls.Config) *tls.Config {
+	if cfg == nil {
+		return &tls.Config{}
+	}
+	return cfg.Clone()
+}

--- a/agent/vendor/github.com/gorilla/websocket/client_clone_legacy.go
+++ b/agent/vendor/github.com/gorilla/websocket/client_clone_legacy.go
@@ -1,0 +1,38 @@
+// Copyright 2013 The Gorilla WebSocket Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !go1.8
+
+package websocket
+
+import "crypto/tls"
+
+// cloneTLSConfig clones all public fields except the fields
+// SessionTicketsDisabled and SessionTicketKey. This avoids copying the
+// sync.Mutex in the sync.Once and makes it safe to call cloneTLSConfig on a
+// config in active use.
+func cloneTLSConfig(cfg *tls.Config) *tls.Config {
+	if cfg == nil {
+		return &tls.Config{}
+	}
+	return &tls.Config{
+		Rand:                     cfg.Rand,
+		Time:                     cfg.Time,
+		Certificates:             cfg.Certificates,
+		NameToCertificate:        cfg.NameToCertificate,
+		GetCertificate:           cfg.GetCertificate,
+		RootCAs:                  cfg.RootCAs,
+		NextProtos:               cfg.NextProtos,
+		ServerName:               cfg.ServerName,
+		ClientAuth:               cfg.ClientAuth,
+		ClientCAs:                cfg.ClientCAs,
+		InsecureSkipVerify:       cfg.InsecureSkipVerify,
+		CipherSuites:             cfg.CipherSuites,
+		PreferServerCipherSuites: cfg.PreferServerCipherSuites,
+		ClientSessionCache:       cfg.ClientSessionCache,
+		MinVersion:               cfg.MinVersion,
+		MaxVersion:               cfg.MaxVersion,
+		CurvePreferences:         cfg.CurvePreferences,
+	}
+}

--- a/agent/vendor/github.com/gorilla/websocket/compression.go
+++ b/agent/vendor/github.com/gorilla/websocket/compression.go
@@ -1,4 +1,4 @@
-// Copyright 2016 The Gorilla WebSocket Authors. All rights reserved.
+// Copyright 2017 The Gorilla WebSocket Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -9,22 +9,48 @@ import (
 	"errors"
 	"io"
 	"strings"
+	"sync"
 )
 
-func decompressNoContextTakeover(r io.Reader) io.Reader {
+const (
+	minCompressionLevel     = -2 // flate.HuffmanOnly not defined in Go < 1.6
+	maxCompressionLevel     = flate.BestCompression
+	defaultCompressionLevel = 1
+)
+
+var (
+	flateWriterPools [maxCompressionLevel - minCompressionLevel + 1]sync.Pool
+	flateReaderPool  = sync.Pool{New: func() interface{} {
+		return flate.NewReader(nil)
+	}}
+)
+
+func decompressNoContextTakeover(r io.Reader) io.ReadCloser {
 	const tail =
 	// Add four bytes as specified in RFC
 	"\x00\x00\xff\xff" +
 		// Add final block to squelch unexpected EOF error from flate reader.
 		"\x01\x00\x00\xff\xff"
 
-	return flate.NewReader(io.MultiReader(r, strings.NewReader(tail)))
+	fr, _ := flateReaderPool.Get().(io.ReadCloser)
+	fr.(flate.Resetter).Reset(io.MultiReader(r, strings.NewReader(tail)), nil)
+	return &flateReadWrapper{fr}
 }
 
-func compressNoContextTakeover(w io.WriteCloser) (io.WriteCloser, error) {
+func isValidCompressionLevel(level int) bool {
+	return minCompressionLevel <= level && level <= maxCompressionLevel
+}
+
+func compressNoContextTakeover(w io.WriteCloser, level int) io.WriteCloser {
+	p := &flateWriterPools[level-minCompressionLevel]
 	tw := &truncWriter{w: w}
-	fw, err := flate.NewWriter(tw, 3)
-	return &flateWrapper{fw: fw, tw: tw}, err
+	fw, _ := p.Get().(*flate.Writer)
+	if fw == nil {
+		fw, _ = flate.NewWriter(tw, level)
+	} else {
+		fw.Reset(tw)
+	}
+	return &flateWriteWrapper{fw: fw, tw: tw, p: p}
 }
 
 // truncWriter is an io.Writer that writes all but the last four bytes of the
@@ -63,17 +89,26 @@ func (w *truncWriter) Write(p []byte) (int, error) {
 	return n + nn, err
 }
 
-type flateWrapper struct {
+type flateWriteWrapper struct {
 	fw *flate.Writer
 	tw *truncWriter
+	p  *sync.Pool
 }
 
-func (w *flateWrapper) Write(p []byte) (int, error) {
+func (w *flateWriteWrapper) Write(p []byte) (int, error) {
+	if w.fw == nil {
+		return 0, errWriteClosed
+	}
 	return w.fw.Write(p)
 }
 
-func (w *flateWrapper) Close() error {
+func (w *flateWriteWrapper) Close() error {
+	if w.fw == nil {
+		return errWriteClosed
+	}
 	err1 := w.fw.Flush()
+	w.p.Put(w.fw)
+	w.fw = nil
 	if w.tw.p != [4]byte{0, 0, 0xff, 0xff} {
 		return errors.New("websocket: internal error, unexpected bytes at end of flate stream")
 	}
@@ -82,4 +117,32 @@ func (w *flateWrapper) Close() error {
 		return err1
 	}
 	return err2
+}
+
+type flateReadWrapper struct {
+	fr io.ReadCloser
+}
+
+func (r *flateReadWrapper) Read(p []byte) (int, error) {
+	if r.fr == nil {
+		return 0, io.ErrClosedPipe
+	}
+	n, err := r.fr.Read(p)
+	if err == io.EOF {
+		// Preemptively place the reader back in the pool. This helps with
+		// scenarios where the application does not call NextReader() soon after
+		// this final read.
+		r.Close()
+	}
+	return n, err
+}
+
+func (r *flateReadWrapper) Close() error {
+	if r.fr == nil {
+		return io.ErrClosedPipe
+	}
+	err := r.fr.Close()
+	flateReaderPool.Put(r.fr)
+	r.fr = nil
+	return err
 }

--- a/agent/vendor/github.com/gorilla/websocket/compression_test.go
+++ b/agent/vendor/github.com/gorilla/websocket/compression_test.go
@@ -2,7 +2,9 @@ package websocket
 
 import (
 	"bytes"
+	"fmt"
 	"io"
+	"io/ioutil"
 	"testing"
 )
 
@@ -26,6 +28,53 @@ func TestTruncWriter(t *testing.T) {
 		}
 		if b.String() != data[:len(data)-len(w.p)] {
 			t.Errorf("%d: %q", n, b.String())
+		}
+	}
+}
+
+func textMessages(num int) [][]byte {
+	messages := make([][]byte, num)
+	for i := 0; i < num; i++ {
+		msg := fmt.Sprintf("planet: %d, country: %d, city: %d, street: %d", i, i, i, i)
+		messages[i] = []byte(msg)
+	}
+	return messages
+}
+
+func BenchmarkWriteNoCompression(b *testing.B) {
+	w := ioutil.Discard
+	c := newConn(fakeNetConn{Reader: nil, Writer: w}, false, 1024, 1024)
+	messages := textMessages(100)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c.WriteMessage(TextMessage, messages[i%len(messages)])
+	}
+	b.ReportAllocs()
+}
+
+func BenchmarkWriteWithCompression(b *testing.B) {
+	w := ioutil.Discard
+	c := newConn(fakeNetConn{Reader: nil, Writer: w}, false, 1024, 1024)
+	messages := textMessages(100)
+	c.enableWriteCompression = true
+	c.newCompressionWriter = compressNoContextTakeover
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c.WriteMessage(TextMessage, messages[i%len(messages)])
+	}
+	b.ReportAllocs()
+}
+
+func TestValidCompressionLevel(t *testing.T) {
+	c := newConn(fakeNetConn{}, false, 1024, 1024)
+	for _, level := range []int{minCompressionLevel - 1, maxCompressionLevel + 1} {
+		if err := c.SetCompressionLevel(level); err == nil {
+			t.Errorf("no error for level %d", level)
+		}
+	}
+	for _, level := range []int{minCompressionLevel, maxCompressionLevel} {
+		if err := c.SetCompressionLevel(level); err != nil {
+			t.Errorf("error for level %d", level)
 		}
 	}
 }

--- a/agent/vendor/github.com/gorilla/websocket/conn_broadcast_test.go
+++ b/agent/vendor/github.com/gorilla/websocket/conn_broadcast_test.go
@@ -1,0 +1,134 @@
+// Copyright 2017 The Gorilla WebSocket Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build go1.7
+
+package websocket
+
+import (
+	"io"
+	"io/ioutil"
+	"sync/atomic"
+	"testing"
+)
+
+// broadcastBench allows to run broadcast benchmarks.
+// In every broadcast benchmark we create many connections, then send the same
+// message into every connection and wait for all writes complete. This emulates
+// an application where many connections listen to the same data - i.e. PUB/SUB
+// scenarios with many subscribers in one channel.
+type broadcastBench struct {
+	w           io.Writer
+	message     *broadcastMessage
+	closeCh     chan struct{}
+	doneCh      chan struct{}
+	count       int32
+	conns       []*broadcastConn
+	compression bool
+	usePrepared bool
+}
+
+type broadcastMessage struct {
+	payload  []byte
+	prepared *PreparedMessage
+}
+
+type broadcastConn struct {
+	conn  *Conn
+	msgCh chan *broadcastMessage
+}
+
+func newBroadcastConn(c *Conn) *broadcastConn {
+	return &broadcastConn{
+		conn:  c,
+		msgCh: make(chan *broadcastMessage, 1),
+	}
+}
+
+func newBroadcastBench(usePrepared, compression bool) *broadcastBench {
+	bench := &broadcastBench{
+		w:           ioutil.Discard,
+		doneCh:      make(chan struct{}),
+		closeCh:     make(chan struct{}),
+		usePrepared: usePrepared,
+		compression: compression,
+	}
+	msg := &broadcastMessage{
+		payload: textMessages(1)[0],
+	}
+	if usePrepared {
+		pm, _ := NewPreparedMessage(TextMessage, msg.payload)
+		msg.prepared = pm
+	}
+	bench.message = msg
+	bench.makeConns(10000)
+	return bench
+}
+
+func (b *broadcastBench) makeConns(numConns int) {
+	conns := make([]*broadcastConn, numConns)
+
+	for i := 0; i < numConns; i++ {
+		c := newConn(fakeNetConn{Reader: nil, Writer: b.w}, true, 1024, 1024)
+		if b.compression {
+			c.enableWriteCompression = true
+			c.newCompressionWriter = compressNoContextTakeover
+		}
+		conns[i] = newBroadcastConn(c)
+		go func(c *broadcastConn) {
+			for {
+				select {
+				case msg := <-c.msgCh:
+					if b.usePrepared {
+						c.conn.WritePreparedMessage(msg.prepared)
+					} else {
+						c.conn.WriteMessage(TextMessage, msg.payload)
+					}
+					val := atomic.AddInt32(&b.count, 1)
+					if val%int32(numConns) == 0 {
+						b.doneCh <- struct{}{}
+					}
+				case <-b.closeCh:
+					return
+				}
+			}
+		}(conns[i])
+	}
+	b.conns = conns
+}
+
+func (b *broadcastBench) close() {
+	close(b.closeCh)
+}
+
+func (b *broadcastBench) runOnce() {
+	for _, c := range b.conns {
+		c.msgCh <- b.message
+	}
+	<-b.doneCh
+}
+
+func BenchmarkBroadcast(b *testing.B) {
+	benchmarks := []struct {
+		name        string
+		usePrepared bool
+		compression bool
+	}{
+		{"NoCompression", false, false},
+		{"WithCompression", false, true},
+		{"NoCompressionPrepared", true, false},
+		{"WithCompressionPrepared", true, true},
+	}
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			bench := newBroadcastBench(bm.usePrepared, bm.compression)
+			defer bench.close()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				bench.runOnce()
+			}
+			b.ReportAllocs()
+		})
+	}
+}

--- a/agent/vendor/github.com/gorilla/websocket/doc.go
+++ b/agent/vendor/github.com/gorilla/websocket/doc.go
@@ -118,9 +118,10 @@
 //
 // Applications are responsible for ensuring that no more than one goroutine
 // calls the write methods (NextWriter, SetWriteDeadline, WriteMessage,
-// WriteJSON) concurrently and that no more than one goroutine calls the read
-// methods (NextReader, SetReadDeadline, ReadMessage, ReadJSON, SetPongHandler,
-// SetPingHandler) concurrently.
+// WriteJSON, EnableWriteCompression, SetCompressionLevel) concurrently and
+// that no more than one goroutine calls the read methods (NextReader,
+// SetReadDeadline, ReadMessage, ReadJSON, SetPongHandler, SetPingHandler)
+// concurrently.
 //
 // The Close and WriteControl methods can be called concurrently with all other
 // methods.
@@ -150,19 +151,25 @@
 // application's responsibility to check the Origin header before calling
 // Upgrade.
 //
-// Compression [Experimental]
+// Compression EXPERIMENTAL
 //
 // Per message compression extensions (RFC 7692) are experimentally supported
 // by this package in a limited capacity. Setting the EnableCompression option
 // to true in Dialer or Upgrader will attempt to negotiate per message deflate
-// support. If compression was successfully negotiated with the connection's
-// peer, any message received in compressed form will be automatically
-// decompressed. All Read methods will return uncompressed bytes.
+// support.
+//
+//  var upgrader = websocket.Upgrader{
+//      EnableCompression: true,
+//  }
+//
+// If compression was successfully negotiated with the connection's peer, any
+// message received in compressed form will be automatically decompressed.
+// All Read methods will return uncompressed bytes.
 //
 // Per message compression of messages written to a connection can be enabled
 // or disabled by calling the corresponding Conn method:
 //
-// conn.EnableWriteCompression(true)
+//  conn.EnableWriteCompression(false)
 //
 // Currently this package does not support compression with "context takeover".
 // This means that messages must be compressed and decompressed in isolation,

--- a/agent/vendor/github.com/gorilla/websocket/mask.go
+++ b/agent/vendor/github.com/gorilla/websocket/mask.go
@@ -2,19 +2,13 @@
 // this source code is governed by a BSD-style license that can be found in the
 // LICENSE file.
 
+// +build !appengine
+
 package websocket
 
-import (
-	"math/rand"
-	"unsafe"
-)
+import "unsafe"
 
 const wordSize = int(unsafe.Sizeof(uintptr(0)))
-
-func newMaskKey() [4]byte {
-	n := rand.Uint32()
-	return [4]byte{byte(n), byte(n >> 8), byte(n >> 16), byte(n >> 24)}
-}
 
 func maskBytes(key [4]byte, pos int, b []byte) int {
 

--- a/agent/vendor/github.com/gorilla/websocket/mask_safe.go
+++ b/agent/vendor/github.com/gorilla/websocket/mask_safe.go
@@ -1,0 +1,15 @@
+// Copyright 2016 The Gorilla WebSocket Authors. All rights reserved.  Use of
+// this source code is governed by a BSD-style license that can be found in the
+// LICENSE file.
+
+// +build appengine
+
+package websocket
+
+func maskBytes(key [4]byte, pos int, b []byte) int {
+	for i := range b {
+		b[i] ^= key[pos&3]
+		pos++
+	}
+	return pos & 3
+}

--- a/agent/vendor/github.com/gorilla/websocket/mask_test.go
+++ b/agent/vendor/github.com/gorilla/websocket/mask_test.go
@@ -3,7 +3,7 @@
 // LICENSE file.
 
 // Require 1.7 for sub-bencmarks
-// +build go1.7
+// +build go1.7,!appengine
 
 package websocket
 

--- a/agent/vendor/github.com/gorilla/websocket/prepared.go
+++ b/agent/vendor/github.com/gorilla/websocket/prepared.go
@@ -1,0 +1,103 @@
+// Copyright 2017 The Gorilla WebSocket Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package websocket
+
+import (
+	"bytes"
+	"net"
+	"sync"
+	"time"
+)
+
+// PreparedMessage caches on the wire representations of a message payload.
+// Use PreparedMessage to efficiently send a message payload to multiple
+// connections. PreparedMessage is especially useful when compression is used
+// because the CPU and memory expensive compression operation can be executed
+// once for a given set of compression options.
+type PreparedMessage struct {
+	messageType int
+	data        []byte
+	err         error
+	mu          sync.Mutex
+	frames      map[prepareKey]*preparedFrame
+}
+
+// prepareKey defines a unique set of options to cache prepared frames in PreparedMessage.
+type prepareKey struct {
+	isServer         bool
+	compress         bool
+	compressionLevel int
+}
+
+// preparedFrame contains data in wire representation.
+type preparedFrame struct {
+	once sync.Once
+	data []byte
+}
+
+// NewPreparedMessage returns an initialized PreparedMessage. You can then send
+// it to connection using WritePreparedMessage method. Valid wire
+// representation will be calculated lazily only once for a set of current
+// connection options.
+func NewPreparedMessage(messageType int, data []byte) (*PreparedMessage, error) {
+	pm := &PreparedMessage{
+		messageType: messageType,
+		frames:      make(map[prepareKey]*preparedFrame),
+		data:        data,
+	}
+
+	// Prepare a plain server frame.
+	_, frameData, err := pm.frame(prepareKey{isServer: true, compress: false})
+	if err != nil {
+		return nil, err
+	}
+
+	// To protect against caller modifying the data argument, remember the data
+	// copied to the plain server frame.
+	pm.data = frameData[len(frameData)-len(data):]
+	return pm, nil
+}
+
+func (pm *PreparedMessage) frame(key prepareKey) (int, []byte, error) {
+	pm.mu.Lock()
+	frame, ok := pm.frames[key]
+	if !ok {
+		frame = &preparedFrame{}
+		pm.frames[key] = frame
+	}
+	pm.mu.Unlock()
+
+	var err error
+	frame.once.Do(func() {
+		// Prepare a frame using a 'fake' connection.
+		// TODO: Refactor code in conn.go to allow more direct construction of
+		// the frame.
+		mu := make(chan bool, 1)
+		mu <- true
+		var nc prepareConn
+		c := &Conn{
+			conn:                   &nc,
+			mu:                     mu,
+			isServer:               key.isServer,
+			compressionLevel:       key.compressionLevel,
+			enableWriteCompression: true,
+			writeBuf:               make([]byte, defaultWriteBufferSize+maxFrameHeaderSize),
+		}
+		if key.compress {
+			c.newCompressionWriter = compressNoContextTakeover
+		}
+		err = c.WriteMessage(pm.messageType, pm.data)
+		frame.data = nc.buf.Bytes()
+	})
+	return pm.messageType, frame.data, err
+}
+
+type prepareConn struct {
+	buf bytes.Buffer
+	net.Conn
+}
+
+func (pc *prepareConn) Write(p []byte) (int, error)        { return pc.buf.Write(p) }
+func (pc *prepareConn) SetWriteDeadline(t time.Time) error { return nil }

--- a/agent/vendor/github.com/gorilla/websocket/prepared_test.go
+++ b/agent/vendor/github.com/gorilla/websocket/prepared_test.go
@@ -1,0 +1,74 @@
+// Copyright 2017 The Gorilla WebSocket Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package websocket
+
+import (
+	"bytes"
+	"compress/flate"
+	"math/rand"
+	"testing"
+)
+
+var preparedMessageTests = []struct {
+	messageType            int
+	isServer               bool
+	enableWriteCompression bool
+	compressionLevel       int
+}{
+	// Server
+	{TextMessage, true, false, flate.BestSpeed},
+	{TextMessage, true, true, flate.BestSpeed},
+	{TextMessage, true, true, flate.BestCompression},
+	{PingMessage, true, false, flate.BestSpeed},
+	{PingMessage, true, true, flate.BestSpeed},
+
+	// Client
+	{TextMessage, false, false, flate.BestSpeed},
+	{TextMessage, false, true, flate.BestSpeed},
+	{TextMessage, false, true, flate.BestCompression},
+	{PingMessage, false, false, flate.BestSpeed},
+	{PingMessage, false, true, flate.BestSpeed},
+}
+
+func TestPreparedMessage(t *testing.T) {
+	for _, tt := range preparedMessageTests {
+		var data = []byte("this is a test")
+		var buf bytes.Buffer
+		c := newConn(fakeNetConn{Reader: nil, Writer: &buf}, tt.isServer, 1024, 1024)
+		if tt.enableWriteCompression {
+			c.newCompressionWriter = compressNoContextTakeover
+		}
+		c.SetCompressionLevel(tt.compressionLevel)
+
+		// Seed random number generator for consistent frame mask.
+		rand.Seed(1234)
+
+		if err := c.WriteMessage(tt.messageType, data); err != nil {
+			t.Fatal(err)
+		}
+		want := buf.String()
+
+		pm, err := NewPreparedMessage(tt.messageType, data)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Scribble on data to ensure that NewPreparedMessage takes a snapshot.
+		copy(data, "hello world")
+
+		// Seed random number generator for consistent frame mask.
+		rand.Seed(1234)
+
+		buf.Reset()
+		if err := c.WritePreparedMessage(pm); err != nil {
+			t.Fatal(err)
+		}
+		got := buf.String()
+
+		if got != want {
+			t.Errorf("write message != prepared message for %+v", tt)
+		}
+	}
+}

--- a/agent/vendor/github.com/gorilla/websocket/server.go
+++ b/agent/vendor/github.com/gorilla/websocket/server.go
@@ -28,8 +28,9 @@ type Upgrader struct {
 	HandshakeTimeout time.Duration
 
 	// ReadBufferSize and WriteBufferSize specify I/O buffer sizes. If a buffer
-	// size is zero, then a default value of 4096 is used. The I/O buffer sizes
-	// do not limit the size of the messages that can be sent or received.
+	// size is zero, then buffers allocated by the HTTP server are used. The
+	// I/O buffer sizes do not limit the size of the messages that can be sent
+	// or received.
 	ReadBufferSize, WriteBufferSize int
 
 	// Subprotocols specifies the server's supported protocols in order of
@@ -104,23 +105,23 @@ func (u *Upgrader) selectSubprotocol(r *http.Request, responseHeader http.Header
 // response.
 func (u *Upgrader) Upgrade(w http.ResponseWriter, r *http.Request, responseHeader http.Header) (*Conn, error) {
 	if r.Method != "GET" {
-		return u.returnError(w, r, http.StatusMethodNotAllowed, "websocket: method not GET")
+		return u.returnError(w, r, http.StatusMethodNotAllowed, "websocket: not a websocket handshake: request method is not GET")
 	}
 
 	if _, ok := responseHeader["Sec-Websocket-Extensions"]; ok {
-		return u.returnError(w, r, http.StatusInternalServerError, "websocket: application specific Sec-Websocket-Extensions headers are unsupported")
-	}
-
-	if !tokenListContainsValue(r.Header, "Sec-Websocket-Version", "13") {
-		return u.returnError(w, r, http.StatusBadRequest, "websocket: version != 13")
+		return u.returnError(w, r, http.StatusInternalServerError, "websocket: application specific 'Sec-Websocket-Extensions' headers are unsupported")
 	}
 
 	if !tokenListContainsValue(r.Header, "Connection", "upgrade") {
-		return u.returnError(w, r, http.StatusBadRequest, "websocket: could not find connection header with token 'upgrade'")
+		return u.returnError(w, r, http.StatusBadRequest, "websocket: not a websocket handshake: 'upgrade' token not found in 'Connection' header")
 	}
 
 	if !tokenListContainsValue(r.Header, "Upgrade", "websocket") {
-		return u.returnError(w, r, http.StatusBadRequest, "websocket: could not find upgrade header with token 'websocket'")
+		return u.returnError(w, r, http.StatusBadRequest, "websocket: not a websocket handshake: 'websocket' token not found in 'Upgrade' header")
+	}
+
+	if !tokenListContainsValue(r.Header, "Sec-Websocket-Version", "13") {
+		return u.returnError(w, r, http.StatusBadRequest, "websocket: unsupported version: 13 not found in 'Sec-Websocket-Version' header")
 	}
 
 	checkOrigin := u.CheckOrigin
@@ -128,12 +129,12 @@ func (u *Upgrader) Upgrade(w http.ResponseWriter, r *http.Request, responseHeade
 		checkOrigin = checkSameOrigin
 	}
 	if !checkOrigin(r) {
-		return u.returnError(w, r, http.StatusForbidden, "websocket: origin not allowed")
+		return u.returnError(w, r, http.StatusForbidden, "websocket: 'Origin' header value not allowed")
 	}
 
 	challengeKey := r.Header.Get("Sec-Websocket-Key")
 	if challengeKey == "" {
-		return u.returnError(w, r, http.StatusBadRequest, "websocket: key missing or blank")
+		return u.returnError(w, r, http.StatusBadRequest, "websocket: not a websocket handshake: `Sec-Websocket-Key' header is missing or blank")
 	}
 
 	subprotocol := u.selectSubprotocol(r, responseHeader)
@@ -152,7 +153,6 @@ func (u *Upgrader) Upgrade(w http.ResponseWriter, r *http.Request, responseHeade
 
 	var (
 		netConn net.Conn
-		br      *bufio.Reader
 		err     error
 	)
 
@@ -160,19 +160,18 @@ func (u *Upgrader) Upgrade(w http.ResponseWriter, r *http.Request, responseHeade
 	if !ok {
 		return u.returnError(w, r, http.StatusInternalServerError, "websocket: response does not implement http.Hijacker")
 	}
-	var rw *bufio.ReadWriter
-	netConn, rw, err = h.Hijack()
+	var brw *bufio.ReadWriter
+	netConn, brw, err = h.Hijack()
 	if err != nil {
 		return u.returnError(w, r, http.StatusInternalServerError, err.Error())
 	}
-	br = rw.Reader
 
-	if br.Buffered() > 0 {
+	if brw.Reader.Buffered() > 0 {
 		netConn.Close()
 		return nil, errors.New("websocket: client sent data before handshake is complete")
 	}
 
-	c := newConn(netConn, true, u.ReadBufferSize, u.WriteBufferSize)
+	c := newConnBRW(netConn, true, u.ReadBufferSize, u.WriteBufferSize, brw)
 	c.subprotocol = subprotocol
 
 	if compress {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
dep best practices, constrain gorilla/websocket to version 1.2.0 because we were tied to a githash. Upgrade to [gorilla/websocket 1.2.0](https://github.com/gorilla/websocket/releases/tag/v1.2.0) includes, "v1.2.0 addresses client compression bugs, improves error messages surrounding HTTP Upgrade requests, and improves the safety around how bytes were masked."

Updated dependencies using [dep v0.4.1](https://github.com/golang/dep/releases/tag/v0.4.1):

```
% dep version
dep:
 version     : v0.4.1
 build date  : 2018-01-24
 git hash    : 37d9ea0a
 go version  : go1.9.1
 go compiler : gc
 platform    : linux/386
```
### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [ ] Builds on Linux (`make release`)
- [ ] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [ ] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
