### PR TITLE
Adding inspect and remove volume API wrappers

### DIFF
--- a/agent/engine/docker_client.go
+++ b/agent/engine/docker_client.go
@@ -152,6 +152,12 @@ type DockerClient interface {
 	// CreateVolume creates a docker volume. A timeout value should be provided for the request
 	CreateVolume(string, string, string, map[string]string, map[string]string, time.Duration) volumeResponse
 
+	// InspectVolume returns a volume by its name. A timeout value should be provided for the request
+	InspectVolume(string, time.Duration) volumeResponse
+
+	// RemoveVolume removes a volume by its name. A timeout value should be provided for the request
+	RemoveVolume(string, time.Duration) error
+
 	// Stats returns a channel of stat data for the specified container. A context should be provided so the request can
 	// be canceled.
 	Stats(string, context.Context) (<-chan *docker.Stats, error)
@@ -978,8 +984,7 @@ func (dg *dockerGoClient) CreateVolume(name string,
 	labels map[string]string,
 	timeout time.Duration) volumeResponse {
 	// Create a context that times out after the 'timeout' duration
-	// This is defined by the const 'createContainerTimeout'. Injecting the 'timeout'
-	// makes it easier to write tests.
+	// Injecting the 'timeout' makes it easier to write tests.
 	// Eventually, the context should be initialized from a parent root context
 	// instead of TODO.
 	ctx, cancel := context.WithTimeout(context.TODO(), timeout)
@@ -999,7 +1004,7 @@ func (dg *dockerGoClient) CreateVolume(name string,
 		// send back the DockerTimeoutError
 		err := ctx.Err()
 		if err == context.DeadlineExceeded {
-			return volumeResponse{Volume: nil, Error: &DockerTimeoutError{timeout, "created"}}
+			return volumeResponse{Volume: nil, Error: &DockerTimeoutError{timeout, "creating volume"}}
 		}
 		// Context was canceled even though there was no timeout. Send
 		// back an error.
@@ -1015,7 +1020,7 @@ func (dg *dockerGoClient) createVolume(ctx context.Context,
 	labels map[string]string) volumeResponse {
 	client, err := dg.dockerClient()
 	if err != nil {
-		return volumeResponse{Volume: nil, Error: CannotGetDockerClientError{version: dg.version, err: err}}
+		return volumeResponse{Volume: nil, Error: &CannotGetDockerClientError{version: dg.version, err: err}}
 	}
 
 	volumeOptions := docker.CreateVolumeOptions{
@@ -1027,7 +1032,7 @@ func (dg *dockerGoClient) createVolume(ctx context.Context,
 	}
 	dockerVolume, err := client.CreateVolume(volumeOptions)
 	if err != nil {
-		return volumeResponse{Volume: nil, Error: CannotCreateVolumeError{err}}
+		return volumeResponse{Volume: nil, Error: &CannotCreateVolumeError{err}}
 	}
 
 	volume := taskresource.NewVolumeResource(
@@ -1036,6 +1041,99 @@ func (dg *dockerGoClient) createVolume(ctx context.Context,
 		dockerVolume.Driver,
 		dockerVolume.Labels)
 	return volumeResponse{Volume: volume, Error: nil}
+}
+
+func (dg *dockerGoClient) InspectVolume(name string, timeout time.Duration) volumeResponse {
+	// Create a context that times out after the 'timeout' duration
+	// Injecting the 'timeout' makes it easier to write tests.
+	// Eventually, the context should be initialized from a parent root context
+	// instead of TODO.
+	ctx, cancel := context.WithTimeout(context.TODO(), timeout)
+	defer cancel()
+
+	// Buffered channel so in the case of timeout it takes one write, never gets
+	// read, and can still be GC'd
+	response := make(chan volumeResponse, 1)
+	go func() { response <- dg.inspectVolume(ctx, name) }()
+
+	// Wait until we get a response or for the 'done' context channel
+	select {
+	case resp := <-response:
+		return resp
+	case <-ctx.Done():
+		// Context has either expired or canceled. If it has timed out,
+		// send back the DockerTimeoutError
+		err := ctx.Err()
+		if err == context.DeadlineExceeded {
+			return volumeResponse{Volume: nil, Error: &DockerTimeoutError{timeout, "inspecting volume"}}
+		}
+		// Context was canceled even though there was no timeout. Send
+		// back an error.
+		return volumeResponse{Volume: nil, Error: &CannotInspectVolumeError{err}}
+	}
+}
+
+func (dg *dockerGoClient) inspectVolume(ctx context.Context, name string) volumeResponse {
+	client, err := dg.dockerClient()
+	if err != nil {
+		return volumeResponse{Volume: nil, Error: &CannotGetDockerClientError{version: dg.version, err: err}}
+	}
+
+	dockerVolume, err := client.InspectVolume(name)
+	if err != nil {
+		return volumeResponse{Volume: nil, Error: &CannotInspectVolumeError{err}}
+	}
+
+	volume := taskresource.NewVolumeResource(
+		dockerVolume.Name,
+		dockerVolume.Mountpoint,
+		dockerVolume.Driver,
+		dockerVolume.Labels)
+	return volumeResponse{Volume: volume, Error: nil}
+}
+
+func (dg *dockerGoClient) RemoveVolume(name string, timeout time.Duration) error {
+	// Create a context that times out after the 'timeout' duration
+	// Injecting the 'timeout' makes it easier to write tests.
+	// Eventually, the context should be initialized from a parent root context
+	// instead of TODO.
+	ctx, cancel := context.WithTimeout(context.TODO(), timeout)
+	defer cancel()
+
+	// Buffered channel so in the case of timeout it takes one write, never gets
+	// read, and can still be GC'd
+	response := make(chan error, 1)
+	go func() { response <- dg.removeVolume(ctx, name) }()
+
+	// Wait until we get a response or for the 'done' context channel
+	select {
+	case resp := <-response:
+		return resp
+	case <-ctx.Done():
+		// Context has either expired or canceled. If it has timed out,
+		// send back the DockerTimeoutError
+		err := ctx.Err()
+		if err == context.DeadlineExceeded {
+			return &DockerTimeoutError{timeout, "removing volume"}
+		}
+		// Context was canceled even though there was no timeout. Send
+		// back an error.
+		return &CannotRemoveVolumeError{err}
+	}
+}
+
+func (dg *dockerGoClient) removeVolume(ctx context.Context, name string) error {
+	client, err := dg.dockerClient()
+	if err != nil {
+		return &CannotGetDockerClientError{version: dg.version, err: err}
+	}
+
+	ok := client.RemoveVolume(name)
+	if ok != nil {
+		return &CannotRemoveVolumeError{err}
+	}
+
+	return nil
 }
 
 // APIVersion returns the client api version

--- a/agent/engine/dockeriface/interface.go
+++ b/agent/engine/dockeriface/interface.go
@@ -39,6 +39,8 @@ type Client interface {
 	StopContainer(id string, timeout uint) error
 	StopContainerWithContext(id string, timeout uint, ctx context.Context) error
 	CreateVolume(opts docker.CreateVolumeOptions) (*docker.Volume, error)
+	InspectVolume(name string) (*docker.Volume, error)
+	RemoveVolume(name string) error
 	Stats(opts docker.StatsOptions) error
 	Version() (*docker.Env, error)
 	RemoveImage(imageName string) error

--- a/agent/engine/dockeriface/mocks/dockeriface_mocks.go
+++ b/agent/engine/dockeriface/mocks/dockeriface_mocks.go
@@ -209,6 +209,27 @@ func (_mr *_MockClientRecorder) CreateVolume(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateVolume", arg0)
 }
 
+func (_m *MockClient) InspectVolume(_param0 string) (*go_dockerclient.Volume, error) {
+	ret := _m.ctrl.Call(_m, "InspectVolume", _param0)
+	ret0, _ := ret[0].(*go_dockerclient.Volume)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockClientRecorder) InspectVolume(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "InspectVolume", arg0)
+}
+
+func (_m *MockClient) RemoveVolume(_param0 string) error {
+	ret := _m.ctrl.Call(_m, "RemoveVolume", _param0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockClientRecorder) RemoveVolume(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveVolume", arg0)
+}
+
 func (_m *MockClient) Stats(_param0 go_dockerclient.StatsOptions) error {
 	ret := _m.ctrl.Call(_m, "Stats", _param0)
 	ret0, _ := ret[0].(error)

--- a/agent/engine/engine_mocks.go
+++ b/agent/engine/engine_mocks.go
@@ -443,6 +443,17 @@ func (_m *MockDockerClient) CreateVolume(_param0 string, _param1 string, _param2
 	return ret0
 }
 
+func (_m *MockDockerClient) InspectVolume(_param0 string, _param1 time.Duration) volumeResponse {
+	ret := _m.ctrl.Call(_m, "InspectVolume", _param0, _param1)
+	ret0, _ := ret[0].(volumeResponse)
+	return ret0
+}
+
+func (_m *MockDockerClient) RemoveVolume(_param0 string, _param1 time.Duration) error {
+	ret := _m.ctrl.Call(_m, "InspectVolume", _param0, _param1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
 func (_m *MockImageManager) SetSaver(_param0 statemanager.Saver) {
 	_m.ctrl.Call(_m, "SetSaver", _param0)
 }

--- a/agent/engine/errors.go
+++ b/agent/engine/errors.go
@@ -347,3 +347,29 @@ func (err CannotCreateVolumeError) Error() string {
 func (err CannotCreateVolumeError) ErrorName() string {
 	return "CannotCreateVolumeError"
 }
+
+// CannotInspectVolumeError indicates any error when trying to inspect a volume
+type CannotInspectVolumeError struct {
+	fromError error
+}
+
+func (err CannotInspectVolumeError) Error() string {
+	return err.fromError.Error()
+}
+
+func (err CannotInspectVolumeError) ErrorName() string {
+	return "CannotInspectVolumeError"
+}
+
+// CannotRemoveVolumeError indicates any error when trying to inspect a volume
+type CannotRemoveVolumeError struct {
+	fromError error
+}
+
+func (err CannotRemoveVolumeError) Error() string {
+	return err.fromError.Error()
+}
+
+func (err CannotRemoveVolumeError) ErrorName() string {
+	return "CannotRemoveVolumeError"
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Adding InspectVolume and RemoveVolume go-dockerclient API wrappers

### Implementation details
Implementing InspectVolume and RemoveVolume functions in docker-client.go

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes

### Description for the changelog
Changelog not updated

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
