### PR TITLE
handlers: add eni info to instrospection endpoint

### DIFF
--- a/agent/api/container.go
+++ b/agent/api/container.go
@@ -493,10 +493,10 @@ func (c *Container) GetLabels() map[string]string {
 	return c.labels
 }
 
-// SetKnownPortBindings gets the ports for a container
+// SetKnownPortBindings sets the ports for a container
 func (c *Container) SetKnownPortBindings(ports []PortBinding) {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
+	c.lock.Lock()
+	defer c.lock.Unlock()
 
 	c.KnownPortBindingsUnsafe = ports
 }

--- a/agent/api/container.go
+++ b/agent/api/container.go
@@ -177,8 +177,8 @@ type Container struct {
 	// and `SetKnownExitCode`.
 	KnownExitCodeUnsafe *int `json:"KnownExitCode"`
 
-	// KnownPortBindings is an array of port bindings for the container.
-	KnownPortBindings []PortBinding
+	// KnownPortBindingsUnsafe is an array of port bindings for the container.
+	KnownPortBindingsUnsafe []PortBinding `json:"KnownPortBindings"`
 
 	// SteadyStateStatusUnsafe specifies the steady state status for the container
 	// If uninitialized, it's assumed to be set to 'ContainerRunning'. Even though
@@ -493,12 +493,20 @@ func (c *Container) GetLabels() map[string]string {
 	return c.labels
 }
 
-// GetPorts gets the ports for a container
-func (c *Container) GetPorts() []PortBinding {
+// SetKnownPortBindings gets the ports for a container
+func (c *Container) SetKnownPortBindings(ports []PortBinding) {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 
-	return c.Ports
+	c.KnownPortBindingsUnsafe = ports
+}
+
+// GetKnownPortBindings gets the ports for a container
+func (c *Container) GetKnownPortBindings() []PortBinding {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	return c.KnownPortBindingsUnsafe
 }
 
 // HealthStatusShouldBeReported returns true if the health check is defined in

--- a/agent/api/container.go
+++ b/agent/api/container.go
@@ -493,6 +493,14 @@ func (c *Container) GetLabels() map[string]string {
 	return c.labels
 }
 
+// GetPorts gets the ports for a container
+func (c *Container) GetPorts() []PortBinding {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	return c.Ports
+}
+
 // HealthStatusShouldBeReported returns true if the health check is defined in
 // the task definition
 func (c *Container) HealthStatusShouldBeReported() bool {

--- a/agent/api/statechange.go
+++ b/agent/api/statechange.go
@@ -128,7 +128,7 @@ func NewContainerStateChangeEvent(task *Task, cont *Container, reason string) (C
 		ContainerName: cont.Name,
 		Status:        contKnownStatus.BackendStatus(cont.GetSteadyStateStatus()),
 		ExitCode:      cont.GetKnownExitCode(),
-		PortBindings:  cont.KnownPortBindings,
+		PortBindings:  cont.GetKnownPortBindings(),
 		Reason:        reason,
 		Container:     cont,
 	}

--- a/agent/api/testutils/container_equal.go
+++ b/agent/api/testutils/container_equal.go
@@ -54,7 +54,7 @@ func ContainersEqual(lhs, rhs *api.Container) bool {
 	if !utils.SlicesDeepEqual(lhs.Ports, rhs.Ports) {
 		return false
 	}
-	if !utils.SlicesDeepEqual(lhs.KnownPortBindings, rhs.KnownPortBindings) {
+	if !utils.SlicesDeepEqual(lhs.KnownPortBindingsUnsafe, rhs.KnownPortBindingsUnsafe) {
 		return false
 	}
 	if lhs.Essential != rhs.Essential {

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -314,8 +314,8 @@ func updateContainerMetadata(metadata *DockerContainerMetadata, container *api.C
 	}
 
 	// Set port mappings
-	if len(metadata.PortBindings) != 0 && len(container.KnownPortBindings) == 0 {
-		container.KnownPortBindings = metadata.PortBindings
+	if len(metadata.PortBindings) != 0 && len(container.GetKnownPortBindings()) == 0 {
+		container.SetKnownPortBindings(metadata.PortBindings)
 	}
 	// update the container health information
 	if container.HealthStatusShouldBeReported() {

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -1858,7 +1858,7 @@ func TestContainerMetadataUpdatedOnRestart(t *testing.T) {
 				assert.Equal(t, "tmp", task.Volumes[0].Volume.SourcePath())
 			}
 			if tc.stage == "started" {
-				assert.Equal(t, uint16(80), dockerContainer.Container.KnownPortBindings[0].ContainerPort)
+				assert.Equal(t, uint16(80), dockerContainer.Container.KnownPortBindingsUnsafe[0].ContainerPort)
 			}
 			if tc.stage == "finished" {
 				assert.False(t, task.GetExecutionStoppedAt().IsZero())

--- a/agent/engine/dockerstate/json_test.go
+++ b/agent/engine/dockerstate/json_test.go
@@ -75,7 +75,7 @@ const (
               "AppliedStatus": "NONE",
               "ApplyingError": null,
               "SentStatus": "NONE",
-              "KnownPortBindings": []
+              "KnownPortBindingsUnsafe": []
             },
             {
               "Name": "~internal~ecs~pause",
@@ -110,7 +110,7 @@ const (
               "AppliedStatus": "NONE",
               "ApplyingError": null,
               "SentStatus": "NONE",
-              "KnownPortBindings": [],
+              "KnownPortBindingsUnsafe": [],
               "SteadyStateStatus": "RESOURCES_PROVISIONED"
             }
           ],
@@ -171,7 +171,7 @@ const (
             "AppliedStatus": "NONE",
             "ApplyingError": null,
             "SentStatus": "NONE",
-            "KnownPortBindings": [],
+            "KnownPortBindingsUnsafe": [],
             "SteadyStateStatus": "RESOURCES_PROVISIONED"
           }
         },
@@ -224,7 +224,7 @@ const (
             "AppliedStatus": "NONE",
             "ApplyingError": null,
             "SentStatus": "NONE",
-            "KnownPortBindings": []
+            "KnownPortBindingsUnsafe": []
           }
         }
       },

--- a/agent/engine/testdata/test_tasks/sleep5.json
+++ b/agent/engine/testdata/test_tasks/sleep5.json
@@ -26,7 +26,7 @@
       "ApplyingError":null,
       "SentStatus":"NONE",
       "KnownExitCode":null,
-      "KnownPortBindings":null,
+      "KnownPortBindingsUnsafe":null,
       "StatusLock":{}
     }
   ],

--- a/agent/engine/testdata/test_tasks/sleep5TaskCgroup.json
+++ b/agent/engine/testdata/test_tasks/sleep5TaskCgroup.json
@@ -26,7 +26,7 @@
       "ApplyingError":null,
       "SentStatus":"NONE",
       "KnownExitCode":null,
-      "KnownPortBindings":null,
+      "KnownPortBindingsUnsafe":null,
       "StatusLock":{}
     }
   ],

--- a/agent/handlers/types/v1/response.go
+++ b/agent/handlers/types/v1/response.go
@@ -45,6 +45,6 @@ type ContainerResponse struct {
 	DockerId   string
 	DockerName string
 	Name       string
-	Ports      []v2.PortResponse
-	Networks   []containermetadata.Network
+	Ports      []v2.PortResponse           `json:",omitempty"`
+	Networks   []containermetadata.Network `json:",omitempty"`
 }

--- a/agent/handlers/types/v1/response.go
+++ b/agent/handlers/types/v1/response.go
@@ -13,6 +13,11 @@
 
 package v1
 
+import (
+	"github.com/aws/amazon-ecs-agent/agent/containermetadata"
+	"github.com/aws/amazon-ecs-agent/agent/handlers/types/v2"
+)
+
 // MetadataResponse is the schema for the metadata response JSON object
 type MetadataResponse struct {
 	Cluster              string
@@ -40,4 +45,6 @@ type ContainerResponse struct {
 	DockerId   string
 	DockerName string
 	Name       string
+	Ports      []v2.PortResponse
+	Networks   []containermetadata.Network
 }

--- a/agent/handlers/v1_handlers.go
+++ b/agent/handlers/v1_handlers.go
@@ -39,6 +39,7 @@ const (
 	dockerIdQueryField = "dockerid"
 	taskArnQueryField  = "taskarn"
 	dockerShortIdLen   = 12
+	networkModeAwsvpc  = "awsvpc"
 )
 
 type rootResponse struct {
@@ -103,7 +104,7 @@ func newContainerResponse(dockerContainer *api.DockerContainer, eni *api.ENI) v1
 		DockerName: dockerContainer.DockerName,
 	}
 
-	for _, binding := range container.GetPorts() {
+	for _, binding := range container.GetKnownPortBindings() {
 		port := v2.PortResponse{
 			ContainerPort: binding.ContainerPort,
 			Protocol:      binding.Protocol.String(),
@@ -121,7 +122,7 @@ func newContainerResponse(dockerContainer *api.DockerContainer, eni *api.ENI) v1
 	if eni != nil {
 		resp.Networks = []containermetadata.Network{
 			{
-				NetworkMode:   "awsvpc",
+				NetworkMode:   networkModeAwsvpc,
 				IPv4Addresses: eni.GetIPV4Addresses(),
 				IPv6Addresses: eni.GetIPV6Addresses(),
 			},

--- a/agent/handlers/v1_handlers.go
+++ b/agent/handlers/v1_handlers.go
@@ -23,9 +23,11 @@ import (
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
 	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/containermetadata"
 	"github.com/aws/amazon-ecs-agent/agent/engine"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/handlers/types/v1"
+	"github.com/aws/amazon-ecs-agent/agent/handlers/types/v2"
 	"github.com/aws/amazon-ecs-agent/agent/logger"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 	"github.com/aws/amazon-ecs-agent/agent/version"
@@ -66,11 +68,12 @@ func metadataV1RequestHandlerMaker(containerInstanceArn *string, cfg *config.Con
 
 func newTaskResponse(task *api.Task, containerMap map[string]*api.DockerContainer) *v1.TaskResponse {
 	containers := []v1.ContainerResponse{}
-	for containerName, container := range containerMap {
+	for _, container := range containerMap {
 		if container.Container.IsInternal() {
 			continue
 		}
-		containers = append(containers, v1.ContainerResponse{DockerId: container.DockerID, DockerName: container.DockerName, Name: containerName})
+		containerResponse := newContainerResponse(container, task.GetTaskENI())
+		containers = append(containers, containerResponse)
 	}
 
 	knownStatus := task.GetKnownStatus()
@@ -90,6 +93,41 @@ func newTaskResponse(task *api.Task, containerMap map[string]*api.DockerContaine
 		Version:       task.Version,
 		Containers:    containers,
 	}
+}
+
+func newContainerResponse(dockerContainer *api.DockerContainer, eni *api.ENI) v1.ContainerResponse {
+	container := dockerContainer.Container
+	resp := v1.ContainerResponse{
+		Name:       container.Name,
+		DockerId:   dockerContainer.DockerID,
+		DockerName: dockerContainer.DockerName,
+	}
+
+	for _, binding := range container.GetPorts() {
+		port := v2.PortResponse{
+			ContainerPort: binding.ContainerPort,
+			Protocol:      binding.Protocol.String(),
+		}
+
+		if eni == nil {
+			port.HostPort = binding.HostPort
+		} else {
+			port.HostPort = port.ContainerPort
+		}
+
+		resp.Ports = append(resp.Ports, port)
+	}
+
+	if eni != nil {
+		resp.Networks = []containermetadata.Network{
+			{
+				NetworkMode:   "awsvpc",
+				IPv4Addresses: eni.GetIPV4Addresses(),
+				IPv6Addresses: eni.GetIPV6Addresses(),
+			},
+		}
+	}
+	return resp
 }
 
 func newTasksResponse(state dockerstate.TaskEngineState) *v1.TasksResponse {

--- a/agent/handlers/v1_handlers_test.go
+++ b/agent/handlers/v1_handlers_test.go
@@ -138,10 +138,41 @@ func TestGetAWSVPCTaskByTaskArn(t *testing.T) {
 	resp := v1.TasksResponse{Tasks: []*v1.TaskResponse{&taskResponse}}
 
 	assert.Equal(t, eniIPV4Address, resp.Tasks[0].Containers[0].Networks[0].IPv4Addresses[0])
+	taskDiffHelper(t, []*api.Task{testTasks[3]}, resp)
+}
+
+func TestGetHostNeworkingTaskByTaskArn(t *testing.T) {
+	recorder := performMockRequest(t, "/v1/tasks?taskarn=hostModeNetworkingTask")
+
+	var taskResponse v1.TaskResponse
+	err := json.Unmarshal(recorder.Body.Bytes(), &taskResponse)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp := v1.TasksResponse{Tasks: []*v1.TaskResponse{&taskResponse}}
+
 	assert.Equal(t, uint16(80), resp.Tasks[0].Containers[0].Ports[0].ContainerPort)
 	assert.Equal(t, "tcp", resp.Tasks[0].Containers[0].Ports[0].Protocol)
 
-	taskDiffHelper(t, []*api.Task{testTasks[3]}, resp)
+	taskDiffHelper(t, []*api.Task{testTasks[4]}, resp)
+}
+
+func TestGetBridgeNeworkingTaskByTaskArn(t *testing.T) {
+	recorder := performMockRequest(t, "/v1/tasks?taskarn=bridgeModeNetworkingTask")
+
+	var taskResponse v1.TaskResponse
+	err := json.Unmarshal(recorder.Body.Bytes(), &taskResponse)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp := v1.TasksResponse{Tasks: []*v1.TaskResponse{&taskResponse}}
+
+	assert.Equal(t, uint16(80), resp.Tasks[0].Containers[0].Ports[0].ContainerPort)
+	assert.Equal(t, "tcp", resp.Tasks[0].Containers[0].Ports[0].Protocol)
+
+	taskDiffHelper(t, []*api.Task{testTasks[5]}, resp)
 }
 
 func TestGetTaskByTaskArnNotFound(t *testing.T) {
@@ -331,18 +362,50 @@ var testTasks = []*api.Task{
 		Containers: []*api.Container{
 			{
 				Name: "awsvpc",
-				KnownPortBindingsUnsafe: []api.PortBinding{
-					{
-						ContainerPort: 80,
-						Protocol:      api.TransportProtocolTCP,
-					},
-				},
 			},
 		},
 		ENI: &api.ENI{
 			IPV4Addresses: []*api.ENIIPV4Address{
 				{
 					Address: eniIPV4Address,
+				},
+			},
+		},
+	},
+	{
+		Arn:                 "hostModeNetworkingTask",
+		DesiredStatusUnsafe: api.TaskRunning,
+		KnownStatusUnsafe:   api.TaskRunning,
+		Family:              "test",
+		Version:             "1",
+		Containers: []*api.Container{
+			{
+				Name: "awsvpc",
+				Ports: []api.PortBinding{
+					{
+						ContainerPort: 80,
+						HostPort:      80,
+						Protocol:      api.TransportProtocolTCP,
+					},
+				},
+			},
+		},
+	},
+	{
+		Arn:                 "bridgeModeNetworkingTask",
+		DesiredStatusUnsafe: api.TaskRunning,
+		KnownStatusUnsafe:   api.TaskRunning,
+		Family:              "test",
+		Version:             "1",
+		Containers: []*api.Container{
+			{
+				Name: "awsvpc",
+				KnownPortBindingsUnsafe: []api.PortBinding{
+					{
+						ContainerPort: 80,
+						HostPort:      80,
+						Protocol:      api.TransportProtocolTCP,
+					},
 				},
 			},
 		},

--- a/agent/handlers/v1_handlers_test.go
+++ b/agent/handlers/v1_handlers_test.go
@@ -331,7 +331,7 @@ var testTasks = []*api.Task{
 		Containers: []*api.Container{
 			{
 				Name: "awsvpc",
-				Ports: []api.PortBinding{
+				KnownPortBindingsUnsafe: []api.PortBinding{
 					{
 						ContainerPort: 80,
 						Protocol:      api.TransportProtocolTCP,


### PR DESCRIPTION
### Summary
<!-- What does this pull request do? -->
adding eni info to instrospection endpoint, addresses https://github.com/aws/amazon-ecs-agent/issues/1247

in awsvpc mode:
```
$ curl localhost:51678/v1/tasks | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   433  100   433    0     0   270k      0 --:--:-- --:--:-- --:--:--  422k
  {
      "Arn": "arn:aws:ecs:us-west-2:410584942969:task/c1bc8e40-35d9-4e1e-ba36-3e366fd8c97c",
      "DesiredStatus": "RUNNING",
      "KnownStatus": "RUNNING",
      "Family": "sleep300",
      "Version": "6",
      "Containers": [
        {
          "DockerId": "fc43f49749cfa09fba02ccf7cdf88c453604b05686b07b278de849466c32ec1f",
          "DockerName": "ecs-sleep300-6-sleep-aef3d2fbb494a5e08201",
          "Name": "sleep",
          "Ports": [],
          "Networks": [
            {
              "NetworkMode": "awsvpc",
              "IPv4Addresses": [
                "172.31.23.89"
              ]
            }
          ]
        }
      ]
    }
```

in bridge mode:
```
  {
      "Arn": "arn:aws:ecs:us-west-2:410584942969:task/5a54d2c3-9a13-42a0-82aa-4ffbe0570de1",
      "DesiredStatus": "RUNNING",
      "KnownStatus": "RUNNING",
      "Family": "sleep300",
      "Version": "8",
      "Containers": [
        {
          "DockerId": "58a5d93e855286c6d5557b2acc2aec9ef932e7da7c7004c73cfedb1f24bd8be2",
          "DockerName": "ecs-sleep300-8-sleep-beabc8d5aaf593ff0c00",
          "Name": "sleep",
          "Ports": [
            {
              "ContainerPort": 80,
              "Protocol": "tcp",
              "HostPort": 80
            },
            {
              "ContainerPort": 88,
              "Protocol": "tcp",
              "HostPort": 32769
            },
            {
              "ContainerPort": 90,
              "Protocol": "tcp",
              "HostPort": 32768
            }
          ],
          "Networks": null
        }
      ]
    }
```
in host mode:
```
  {
  "Tasks": [
    {
      "Arn": "arn:aws:ecs:us-west-2:410584942969:task/93a01f80-25c2-4517-9e5f-c302a8228623",
      "DesiredStatus": "RUNNING",
      "KnownStatus": "RUNNING",
      "Family": "sleep300",
      "Version": "7",
      "Containers": [
        {
          "DockerId": "cf8d7dc7532e0fc0b84605af13ecd6fb6822a38e50e1cb1fe774782d88a963b2",
          "DockerName": "ecs-sleep300-7-sleep-ceeaf4c78ea281ac3000",
          "Name": "sleep",
          "Ports": [
            {
              "ContainerPort": 80,
              "Protocol": "tcp",
              "HostPort": 80
            },
            {
              "ContainerPort": 90,
              "Protocol": "udp",
              "HostPort": 90
            }
          ],
          "Networks": null
        }
      ]
    }
  ]
}
```
### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [ ] Builds on Linux (`make release`)
- [ ] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [ ] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
