### PR TITLE
Refactor Container Dependency model

### DIFF
--- a/agent/api/container.go
+++ b/agent/api/container.go
@@ -538,3 +538,23 @@ func (c *Container) GetHealthStatus() HealthStatus {
 
 	return copyHealth
 }
+
+// BuildContainerDependency adds a new dependency container and satisfied status
+// to the dependent container
+func (c *Container) BuildContainerDependency(contName string,
+	satisfiedStatus ContainerStatus,
+	dependentStatus ContainerStatus) {
+	if c.TransitionDependenciesMap == nil {
+		c.TransitionDependenciesMap = make(map[ContainerStatus]TransitionDependencySet)
+	}
+	contDep := ContainerDependency{
+		ContainerName:   contName,
+		SatisfiedStatus: satisfiedStatus,
+	}
+	if _, ok := c.TransitionDependenciesMap[dependentStatus]; !ok {
+		c.TransitionDependenciesMap[dependentStatus] = TransitionDependencySet{}
+	}
+	deps := c.TransitionDependenciesMap[dependentStatus]
+	deps.ContainerDependencies = append(deps.ContainerDependencies, contDep)
+	c.TransitionDependenciesMap[dependentStatus] = deps
+}

--- a/agent/api/container.go
+++ b/agent/api/container.go
@@ -128,11 +128,17 @@ type Container struct {
 	// is handled properly so that the state storage continues to work.
 	KnownStatusUnsafe ContainerStatus `json:"KnownStatus"`
 
+	// TransitionDependenciesMap is a map of the dependent container status to other
+	// dependencies that must be satisfied in order for this container to transition.
+	TransitionDependenciesMap map[ContainerStatus]TransitionDependencySet
+
 	// TransitionDependencySet is a set of dependencies that must be satisfied
 	// in order for this container to transition.  Each transition dependency
 	// specifies a resource upon which the transition is dependent, a status
 	// that depends on the resource, and the state of the dependency that
 	// satisfies.
+	// Deprecated: Use TransitionDependenciesMap instead. TransitionDependencySet is
+	// retained for compatibility with old state files.
 	TransitionDependencySet TransitionDependencySet `json:"TransitionDependencySet"`
 
 	// SteadyStateDependencies is a list of containers that must be in "steady state" before

--- a/agent/api/container_test.go
+++ b/agent/api/container_test.go
@@ -205,3 +205,15 @@ func TestHealthStatusShouldBeReported(t *testing.T) {
 	container.HealthCheckType = "unknown"
 	assert.False(t, container.HealthStatusShouldBeReported(), "Health status of container that has non-docker HealthCheckType set should not be reported")
 }
+
+func TestBuildContainerDependency(t *testing.T) {
+	container := Container{}
+	depContName := "dep"
+	container.BuildContainerDependency(depContName, ContainerRunning, ContainerRunning)
+	assert.NotNil(t, container.TransitionDependenciesMap)
+	contDep := container.TransitionDependenciesMap[ContainerRunning].ContainerDependencies
+	assert.Len(t, container.TransitionDependenciesMap, 1)
+	assert.Len(t, contDep, 1)
+	assert.Equal(t, contDep[0].ContainerName, depContName)
+	assert.Equal(t, contDep[0].SatisfiedStatus, ContainerRunning)
+}

--- a/agent/api/task.go
+++ b/agent/api/task.go
@@ -171,19 +171,7 @@ func (task *Task) initializeEmptyVolumes() {
 				continue
 			}
 			if _, ok := vol.(*EmptyHostVolume); ok {
-				if container.TransitionDependenciesMap == nil {
-					container.TransitionDependenciesMap = make(map[ContainerStatus]TransitionDependencySet)
-				}
-				contDep := ContainerDependency{
-					ContainerName:   emptyHostVolumeName,
-					SatisfiedStatus: ContainerRunning,
-				}
-				if _, ok := container.TransitionDependenciesMap[ContainerCreated]; !ok {
-					container.TransitionDependenciesMap[ContainerCreated] = TransitionDependencySet{}
-				}
-				deps := container.TransitionDependenciesMap[ContainerCreated]
-				deps.ContainerDependencies = append(deps.ContainerDependencies, contDep)
-				container.TransitionDependenciesMap[ContainerCreated] = deps
+				container.BuildContainerDependency(emptyHostVolumeName, ContainerRunning, ContainerCreated)
 				requiredEmptyVolumes = append(requiredEmptyVolumes, mountPoint.SourceVolume)
 			}
 		}
@@ -291,19 +279,7 @@ func (task *Task) addNetworkResourceProvisioningDependency(cfg *config.Config) {
 		if container.IsInternal() {
 			continue
 		}
-		contDep := ContainerDependency{
-			ContainerName:   PauseContainerName,
-			SatisfiedStatus: ContainerResourcesProvisioned,
-		}
-		if container.TransitionDependenciesMap == nil {
-			container.TransitionDependenciesMap = make(map[ContainerStatus]TransitionDependencySet)
-		}
-		if _, ok := container.TransitionDependenciesMap[ContainerPulled]; !ok {
-			container.TransitionDependenciesMap[ContainerPulled] = TransitionDependencySet{}
-		}
-		deps := container.TransitionDependenciesMap[ContainerPulled]
-		deps.ContainerDependencies = append(deps.ContainerDependencies, contDep)
-		container.TransitionDependenciesMap[ContainerPulled] = deps
+		container.BuildContainerDependency(PauseContainerName, ContainerResourcesProvisioned, ContainerPulled)
 	}
 	pauseContainer := NewContainerWithSteadyState(ContainerResourcesProvisioned)
 	pauseContainer.Name = PauseContainerName

--- a/agent/api/transitiondependency.go
+++ b/agent/api/transitiondependency.go
@@ -17,5 +17,5 @@ type ContainerDependency struct {
 	SatisfiedStatus ContainerStatus `json:"SatisfiedStatus"`
 	// DependentStatus defines the status that cannot be reached until the
 	// resource satisfies the dependency
-	DependentStatus ContainerStatus `json:"DependentStatus"`
+	DependentStatus ContainerStatus `json:"DependentStatus,omitempty"`
 }

--- a/agent/engine/dependencygraph/graph_test.go
+++ b/agent/engine/dependencygraph/graph_test.go
@@ -577,13 +577,7 @@ func TestVerifyTransitionDependenciesResolved(t *testing.T) {
 				KnownStatusUnsafe:   tc.TargetKnown,
 				DesiredStatusUnsafe: tc.TargetDesired,
 			}
-			target.TransitionDependenciesMap = make(map[api.ContainerStatus]api.TransitionDependencySet)
-			deps := api.TransitionDependencySet{}
-			deps.ContainerDependencies = append(deps.ContainerDependencies, api.ContainerDependency{
-				ContainerName:   tc.DependencyName,
-				SatisfiedStatus: tc.SatisfiedStatus,
-			})
-			target.TransitionDependenciesMap[tc.TargetNext] = deps
+			target.BuildContainerDependency(tc.DependencyName, tc.SatisfiedStatus, tc.TargetNext)
 			dep := &api.Container{
 				Name:              tc.DependencyName,
 				KnownStatusUnsafe: tc.DependencyKnown,

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -285,13 +285,15 @@ func TestTaskWithSteadyStateResourcesProvisioned(t *testing.T) {
 	taskEngine.(*DockerTaskEngine).cniClient = mockCNIClient
 	// sleep5 contains a single 'sleep' container, with DesiredStatus == RUNNING
 	sleepTask := testdata.LoadTask("sleep5")
-	sleepTask.Containers[0].TransitionDependencySet.ContainerDependencies = []api.ContainerDependency{
-		{
-			ContainerName:   "pause",
-			SatisfiedStatus: api.ContainerRunning,
-			DependentStatus: api.ContainerPulled,
-		}}
 	sleepContainer := sleepTask.Containers[0]
+	sleepContainer.TransitionDependenciesMap = make(map[api.ContainerStatus]api.TransitionDependencySet)
+	deps := api.TransitionDependencySet{}
+	deps.ContainerDependencies = append(deps.ContainerDependencies, api.ContainerDependency{
+		ContainerName:   "pause",
+		SatisfiedStatus: api.ContainerRunning,
+	})
+	sleepContainer.TransitionDependenciesMap[api.ContainerPulled] = deps
+
 	// Add a second container with DesiredStatus == RESOURCES_PROVISIONED and
 	// steadyState == RESOURCES_PROVISIONED
 	pauseContainer := api.NewContainerWithSteadyState(api.ContainerResourcesProvisioned)

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -286,14 +286,7 @@ func TestTaskWithSteadyStateResourcesProvisioned(t *testing.T) {
 	// sleep5 contains a single 'sleep' container, with DesiredStatus == RUNNING
 	sleepTask := testdata.LoadTask("sleep5")
 	sleepContainer := sleepTask.Containers[0]
-	sleepContainer.TransitionDependenciesMap = make(map[api.ContainerStatus]api.TransitionDependencySet)
-	deps := api.TransitionDependencySet{}
-	deps.ContainerDependencies = append(deps.ContainerDependencies, api.ContainerDependency{
-		ContainerName:   "pause",
-		SatisfiedStatus: api.ContainerRunning,
-	})
-	sleepContainer.TransitionDependenciesMap[api.ContainerPulled] = deps
-
+	sleepContainer.BuildContainerDependency("pause", api.ContainerRunning, api.ContainerPulled)
 	// Add a second container with DesiredStatus == RESOURCES_PROVISIONED and
 	// steadyState == RESOURCES_PROVISIONED
 	pauseContainer := api.NewContainerWithSteadyState(api.ContainerResourcesProvisioned)

--- a/agent/engine/task_manager_test.go
+++ b/agent/engine/task_manager_test.go
@@ -391,13 +391,7 @@ func TestContainerNextStateWithTransitionDependencies(t *testing.T) {
 				DesiredStatusUnsafe: tc.containerDesiredStatus,
 				KnownStatusUnsafe:   tc.containerCurrentStatus,
 			}
-			container.TransitionDependenciesMap = make(map[api.ContainerStatus]api.TransitionDependencySet)
-			deps := api.TransitionDependencySet{}
-			deps.ContainerDependencies = append(deps.ContainerDependencies, api.ContainerDependency{
-				ContainerName:   dependencyName,
-				SatisfiedStatus: tc.dependencySatisfiedStatus,
-			})
-			container.TransitionDependenciesMap[tc.containerDependentStatus] = deps
+			container.BuildContainerDependency(dependencyName, tc.dependencySatisfiedStatus, tc.containerDependentStatus)
 			dependency := &api.Container{
 				Name:              dependencyName,
 				KnownStatusUnsafe: tc.dependencyCurrentStatus,

--- a/agent/engine/task_manager_test.go
+++ b/agent/engine/task_manager_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"context"
+
 	"github.com/golang/mock/gomock"
 )
 
@@ -389,14 +390,14 @@ func TestContainerNextStateWithTransitionDependencies(t *testing.T) {
 			container := &api.Container{
 				DesiredStatusUnsafe: tc.containerDesiredStatus,
 				KnownStatusUnsafe:   tc.containerCurrentStatus,
-				TransitionDependencySet: api.TransitionDependencySet{
-					ContainerDependencies: []api.ContainerDependency{{
-						ContainerName:   dependencyName,
-						DependentStatus: tc.containerDependentStatus,
-						SatisfiedStatus: tc.dependencySatisfiedStatus,
-					}},
-				},
 			}
+			container.TransitionDependenciesMap = make(map[api.ContainerStatus]api.TransitionDependencySet)
+			deps := api.TransitionDependencySet{}
+			deps.ContainerDependencies = append(deps.ContainerDependencies, api.ContainerDependency{
+				ContainerName:   dependencyName,
+				SatisfiedStatus: tc.dependencySatisfiedStatus,
+			})
+			container.TransitionDependenciesMap[tc.containerDependentStatus] = deps
 			dependency := &api.Container{
 				Name:              dependencyName,
 				KnownStatusUnsafe: tc.dependencyCurrentStatus,


### PR DESCRIPTION
### Summary
Deprecate `TransitionDependencySet` type in `api.Container` used to specify container dependencies for state transitions. The new map type is called `TransitionDependencies`.

### Implementation details
This PR focuses on adding the new `TransitionDependencies` type which is a map of the dependent container status to the existing `TransitionDependencySet` type, which is a list of `ContainerDependency` with the status of the container that satisfies the dependency (excluding the `DependentStatus` field).
Note: This PR does not yet construct the `TransitionDependencies` object from `TransitionDependencySet` type, if present in old state files. This will be handled in a separate PR. 

### Testing
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
