### PR TITLE
Removing mountpoint from createVolume function

### DIFF
--- a/agent/engine/docker_client.go
+++ b/agent/engine/docker_client.go
@@ -150,7 +150,7 @@ type DockerClient interface {
 	ListContainers(bool, time.Duration) ListContainersResponse
 
 	// CreateVolume creates a docker volume. A timeout value should be provided for the request
-	CreateVolume(string, string, string, map[string]string, map[string]string, time.Duration) volumeResponse
+	CreateVolume(string, string, map[string]string, map[string]string, time.Duration) volumeResponse
 
 	// InspectVolume returns a volume by its name. A timeout value should be provided for the request
 	InspectVolume(string, time.Duration) volumeResponse
@@ -978,7 +978,6 @@ type volumeResponse struct {
 }
 
 func (dg *dockerGoClient) CreateVolume(name string,
-	mountpoint string,
 	driver string,
 	driverOptions map[string]string,
 	labels map[string]string,
@@ -993,7 +992,7 @@ func (dg *dockerGoClient) CreateVolume(name string,
 	// Buffered channel so in the case of timeout it takes one write, never gets
 	// read, and can still be GC'd
 	response := make(chan volumeResponse, 1)
-	go func() { response <- dg.createVolume(ctx, name, mountpoint, driver, driverOptions, labels) }()
+	go func() { response <- dg.createVolume(ctx, name, driver, driverOptions, labels) }()
 
 	// Wait until we get a response or for the 'done' context channel
 	select {
@@ -1014,7 +1013,6 @@ func (dg *dockerGoClient) CreateVolume(name string,
 
 func (dg *dockerGoClient) createVolume(ctx context.Context,
 	name string,
-	mountpoint string,
 	driver string,
 	driverOptions map[string]string,
 	labels map[string]string) volumeResponse {

--- a/agent/engine/docker_client_test.go
+++ b/agent/engine/docker_client_test.go
@@ -1298,7 +1298,7 @@ func TestCreateVolumeTimeout(t *testing.T) {
 		// TODO remove the MaxTimes by cancel the context passed to CreateVolume
 		// when issue #1212 is resolved
 	}).MaxTimes(1)
-	volumeResponse := client.CreateVolume("name", "mountpoint", "driver", nil, nil, timeout)
+	volumeResponse := client.CreateVolume("name", "driver", nil, nil, timeout)
 	assert.Error(t, volumeResponse.Error, "expected error for timeout")
 	assert.Equal(t, "DockerTimeoutError", volumeResponse.Error.(api.NamedError).ErrorName())
 	wait.Done()
@@ -1309,7 +1309,7 @@ func TestCreateVolumeError(t *testing.T) {
 	defer done()
 
 	mockDocker.EXPECT().CreateVolume(gomock.Any()).Return(nil, errors.New("some docker error"))
-	volumeResponse := client.CreateVolume("name", "mountpoint", "driver", nil, nil, 1*time.Second)
+	volumeResponse := client.CreateVolume("name", "driver", nil, nil, 1*time.Second)
 	assert.Equal(t, "CannotCreateVolumeError", volumeResponse.Error.(api.NamedError).ErrorName())
 }
 
@@ -1331,7 +1331,7 @@ func TestCreateVolume(t *testing.T) {
 			assert.EqualValues(t, opts.DriverOpts, driverOptions)
 		}).Return(&docker.Volume{Name: volumeName, Driver: driver, Mountpoint: mountPoint, Labels: nil}, nil),
 	)
-	volumeResponse := client.CreateVolume(volumeName, mountPoint, driver, driverOptions, nil, 1*time.Second)
+	volumeResponse := client.CreateVolume(volumeName, driver, driverOptions, nil, 1*time.Second)
 	assert.NoError(t, volumeResponse.Error)
 	assert.Equal(t, volumeResponse.Volume.Name, volumeName)
 	assert.Equal(t, volumeResponse.Volume.Driver, driver)

--- a/agent/engine/engine_mocks.go
+++ b/agent/engine/engine_mocks.go
@@ -437,8 +437,8 @@ func (_mr *_MockImageManagerRecorder) RemoveContainerReferenceFromImageState(arg
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveContainerReferenceFromImageState", arg0)
 }
 
-func (_m *MockDockerClient) CreateVolume(_param0 string, _param1 string, _param2 string, _param3 map[string]string, _param4 map[string]string, _param5 time.Duration) volumeResponse {
-	ret := _m.ctrl.Call(_m, "CreateVolume", _param0, _param1, _param2, _param3, _param4, _param5)
+func (_m *MockDockerClient) CreateVolume(_param0 string, _param1 string, _param2 map[string]string, _param3 map[string]string, _param4 time.Duration) volumeResponse {
+	ret := _m.ctrl.Call(_m, "CreateVolume", _param0, _param1, _param2, _param3, _param4)
 	ret0, _ := ret[0].(volumeResponse)
 	return ret0
 }

--- a/agent/taskresource/volume.go
+++ b/agent/taskresource/volume.go
@@ -22,6 +22,7 @@ import (
 // VolumeResource represents docker volume resource
 type VolumeResource struct {
 	Name                string
+	// Mountpoint is a read-only field returned from docker
 	Mountpoint          string
 	Driver              string
 	Labels              map[string]string


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Removing mountpoint param from createVolume function, as it's a readonly field returned from docker.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: N/A

### Description for the changelog
Changelog not updated

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
