### PR TITLE
Add integration test for engine restart

### DIFF
--- a/agent/engine/docker_image_manager_integ_test.go
+++ b/agent/engine/docker_image_manager_integ_test.go
@@ -54,7 +54,7 @@ func TestIntegImageCleanupHappyCase(t *testing.T) {
 	cfg.MinimumImageDeletionAge = 1 * time.Second
 	cfg.NumImagesToDeletePerCycle = 2
 	// start agent
-	taskEngine, done, _ := setup(cfg, t)
+	taskEngine, done, _ := setup(cfg, nil, t)
 
 	imageManager := taskEngine.(*DockerTaskEngine).imageManager.(*dockerImageManager)
 	imageManager.SetSaver(statemanager.NewNoopStateManager())
@@ -166,7 +166,7 @@ func TestIntegImageCleanupThreshold(t *testing.T) {
 	// Set to delete three images, but in this test we expect only two images to be removed
 	cfg.NumImagesToDeletePerCycle = 3
 	// start agent
-	taskEngine, done, _ := setup(cfg, t)
+	taskEngine, done, _ := setup(cfg, nil, t)
 
 	imageManager := taskEngine.(*DockerTaskEngine).imageManager.(*dockerImageManager)
 	imageManager.SetSaver(statemanager.NewNoopStateManager())
@@ -280,7 +280,7 @@ func TestImageWithSameNameAndDifferentID(t *testing.T) {
 	// Set low values so this test can complete in a sane amout of time
 	cfg.MinimumImageDeletionAge = 15 * time.Minute
 
-	taskEngine, done, _ := setup(cfg, t)
+	taskEngine, done, _ := setup(cfg, nil, t)
 	defer done()
 
 	dockerClient := taskEngine.(*DockerTaskEngine).client
@@ -418,7 +418,7 @@ func TestImageWithSameIDAndDifferentNames(t *testing.T) {
 	// Set low values so this test can complete in a sane amout of time
 	cfg.MinimumImageDeletionAge = 15 * time.Minute
 
-	taskEngine, done, _ := setup(cfg, t)
+	taskEngine, done, _ := setup(cfg, nil, t)
 	defer done()
 
 	dockerClient := taskEngine.(*DockerTaskEngine).client

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -614,7 +614,8 @@ func TestSteadyStatePoll(t *testing.T) {
 	// trigger steady state verification
 	mtasks := taskEngine.(*DockerTaskEngine).managedTasks
 	for _, task := range mtasks {
-		task.cancel()
+		// Trigger the steadyState check at least twice
+		triggerSteadyStateCheck(4, task)
 	}
 
 	// StopContainer might be invoked if the test execution is slow, during
@@ -1109,7 +1110,7 @@ func TestPauseContainerHappyPath(t *testing.T) {
 	// trigger steady state verification
 	mtasks := taskEngine.(*DockerTaskEngine).managedTasks
 	for _, task := range mtasks {
-		task.cancel()
+		triggerSteadyStateCheck(1, task)
 	}
 
 	var wg sync.WaitGroup

--- a/agent/engine/engine_integ_test.go
+++ b/agent/engine/engine_integ_test.go
@@ -39,9 +39,8 @@ import (
 )
 
 const (
-	testDockerStopTimeout       = 2 * time.Second
-	credentialsIDIntegTest      = "credsid"
-	waitTaskStateChangeDuration = 2 * time.Minute
+	testDockerStopTimeout  = 2 * time.Second
+	credentialsIDIntegTest = "credsid"
 )
 
 func init() {
@@ -66,10 +65,14 @@ func defaultTestConfigIntegTest() *config.Config {
 }
 
 func setupWithDefaultConfig(t *testing.T) (TaskEngine, func(), credentials.Manager) {
-	return setup(defaultTestConfigIntegTest(), t)
+	return setup(defaultTestConfigIntegTest(), nil, t)
 }
 
-func setup(cfg *config.Config, t *testing.T) (TaskEngine, func(), credentials.Manager) {
+func setupWithState(t *testing.T, state dockerstate.TaskEngineState) (TaskEngine, func(), credentials.Manager) {
+	return setup(defaultTestConfigIntegTest(), state, t)
+}
+
+func setup(cfg *config.Config, state dockerstate.TaskEngineState, t *testing.T) (TaskEngine, func(), credentials.Manager) {
 	if os.Getenv("ECS_SKIP_ENGINE_INTEG_TEST") != "" {
 		t.Skip("ECS_SKIP_ENGINE_INTEG_TEST")
 	}
@@ -82,7 +85,9 @@ func setup(cfg *config.Config, t *testing.T) (TaskEngine, func(), credentials.Ma
 		t.Fatalf("Error creating Docker client: %v", err)
 	}
 	credentialsManager := credentials.NewManager()
-	state := dockerstate.NewTaskEngineState()
+	if state == nil {
+		state = dockerstate.NewTaskEngineState()
+	}
 	imageManager := NewImageManager(cfg, dockerClient, state)
 	imageManager.SetSaver(statemanager.NewNoopStateManager())
 	metadataManager := containermetadata.NewManager(dockerClient, cfg)
@@ -224,7 +229,7 @@ func TestSweepContainer(t *testing.T) {
 	cfg := defaultTestConfigIntegTest()
 	cfg.TaskCleanupWaitDuration = 1 * time.Minute
 	cfg.ContainerMetadataEnabled = true
-	taskEngine, done, _ := setup(cfg, t)
+	taskEngine, done, _ := setup(cfg, nil, t)
 	defer done()
 
 	taskArn := "arn:aws:ecs:us-east-1:123456789012:task/testSweepContainer"
@@ -311,19 +316,79 @@ func TestContainerHealthCheck(t *testing.T) {
 	verifyTaskIsStopped(stateChangeEvents, testTask)
 }
 
-func waitForContainerHealthStatus(t *testing.T, testTask *api.Task) {
-	ctx, _ := context.WithTimeout(context.TODO(), waitTaskStateChangeDuration)
-	for {
-		select {
-		case <-ctx.Done():
-			t.Error("Timed out waiting for container health status")
-		default:
-			healthStatus := testTask.Containers[0].GetHealthStatus()
-			if healthStatus.Status.BackendStatus() == "UNKNOWN" {
-				time.Sleep(time.Second)
-				continue
-			}
-			return
-		}
+// TestEngineSynchronize tests the agent synchronize the container status on restart
+func TestEngineSynchronize(t *testing.T) {
+	taskEngine, done, _ := setupWithDefaultConfig(t)
+
+	taskArn := "arn:aws:ecs:us-east-1:123456789012:task/testEngineSynchronize"
+	testTask := createTestTask(taskArn)
+	testTask.Containers[0].Image = testVolumeImage
+
+	// Start a task
+	go taskEngine.AddTask(testTask)
+	verifyContainerRunningStateChange(t, taskEngine)
+	verifyTaskRunningStateChange(t, taskEngine)
+	// Record the container information
+	state := taskEngine.(*DockerTaskEngine).State()
+	containersMap, ok := state.ContainerMapByArn(taskArn)
+	require.True(t, ok, "no container found in the agent state")
+	require.Len(t, containersMap, 1)
+	containerIDs := state.GetAllContainerIDs()
+	require.Len(t, containerIDs, 1)
+	imageStates := state.AllImageStates()
+	assert.Len(t, imageStates, 1)
+	taskEngine.(*DockerTaskEngine).stopEngine()
+
+	containerBeforeSync, ok := containersMap[testTask.Containers[0].Name]
+	assert.True(t, ok, "container not found in the containers map")
+	// Task and Container restored from state file
+	containerSaved := &api.Container{
+		Name:                containerBeforeSync.Container.Name,
+		SentStatusUnsafe:    api.ContainerRunning,
+		DesiredStatusUnsafe: api.ContainerRunning,
 	}
+	task := &api.Task{
+		Arn: taskArn,
+		Containers: []*api.Container{
+			containerSaved,
+		},
+		KnownStatusUnsafe:   api.TaskRunning,
+		DesiredStatusUnsafe: api.TaskRunning,
+		SentStatusUnsafe:    api.TaskRunning,
+	}
+
+	state = dockerstate.NewTaskEngineState()
+	state.AddTask(task)
+	state.AddContainer(&api.DockerContainer{
+		DockerID:  containerBeforeSync.DockerID,
+		Container: containerSaved,
+	}, task)
+	state.AddImageState(imageStates[0])
+
+	// Simulate the agent restart
+	taskEngine, done, _ = setupWithState(t, state)
+	defer done()
+
+	taskEngine.MustInit(context.TODO())
+
+	// Check container status/metadata and image information are correctly synchronized
+	containerIDAfterSync := state.GetAllContainerIDs()
+	require.Len(t, containerIDAfterSync, 1)
+	containerAfterSync, ok := state.ContainerByID(containerIDAfterSync[0])
+	assert.True(t, ok, "no container found in the agent state")
+
+	assert.Equal(t, containerAfterSync.Container.GetKnownStatus(), containerBeforeSync.Container.GetKnownStatus())
+	assert.Equal(t, containerAfterSync.Container.GetLabels(), containerBeforeSync.Container.GetLabels())
+	assert.Equal(t, containerAfterSync.Container.GetStartedAt(), containerBeforeSync.Container.GetStartedAt())
+	assert.Equal(t, containerAfterSync.Container.GetCreatedAt(), containerBeforeSync.Container.GetCreatedAt())
+
+	imageStateAfterSync := state.AllImageStates()
+	assert.Len(t, imageStateAfterSync, 1)
+	assert.Equal(t, *imageStateAfterSync[0], *imageStates[0])
+
+	testTask.SetDesiredStatus(api.TaskStopped)
+	go taskEngine.AddTask(testTask)
+
+	verifyContainerStoppedStateChange(t, taskEngine)
+	verifyTaskStoppedStateChange(t, taskEngine)
 }

--- a/agent/engine/engine_unix_integ_test.go
+++ b/agent/engine/engine_unix_integ_test.go
@@ -489,7 +489,7 @@ func TestDockerCfgAuth(t *testing.T) {
 	cfg.EngineAuthType = "dockercfg"
 
 	removeImage(testAuthRegistryImage)
-	taskEngine, done, _ := setup(cfg, t)
+	taskEngine, done, _ := setup(cfg, nil, t)
 	defer done()
 	defer func() {
 		cfg.EngineAuthData = config.NewSensitiveRawMessage(nil)
@@ -522,7 +522,7 @@ func TestDockerAuth(t *testing.T) {
 		cfg.EngineAuthType = ""
 	}()
 
-	taskEngine, done, _ := setup(cfg, t)
+	taskEngine, done, _ := setup(cfg, nil, t)
 	defer done()
 	removeImage(testAuthRegistryImage)
 
@@ -773,7 +773,7 @@ func TestDockerStopTimeout(t *testing.T) {
 	defer os.Unsetenv("ECS_CONTAINER_STOP_TIMEOUT")
 	cfg := defaultTestConfigIntegTest()
 
-	taskEngine, _, _ := setup(cfg, t)
+	taskEngine, _, _ := setup(cfg, nil, t)
 
 	dockerTaskEngine := taskEngine.(*DockerTaskEngine)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
