### PR TITLE
Update build tools for 8 char short sha

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,7 +212,7 @@ get-cni-sources:
 cni-plugins: get-cni-sources .out-stamp
 	@docker build -f scripts/dockerfiles/Dockerfile.buildCNIPlugins -t "amazon/amazon-ecs-build-cniplugins:make" .
 	docker run --rm --net=none \
-		-e GIT_SHORT_HASH=$(shell cd $(ECS_CNI_REPOSITORY_SRC_DIR) && git rev-parse --short HEAD) \
+		-e GIT_SHORT_HASH=$(shell cd $(ECS_CNI_REPOSITORY_SRC_DIR) && git rev-parse --short=8 HEAD) \
 		-e GIT_PORCELAIN=$(shell cd $(ECS_CNI_REPOSITORY_SRC_DIR) && git status --porcelain 2> /dev/null | wc -l | sed 's/^ *//') \
 		-u "$(USERID)" \
 		-v "$(PWD)/out/cni-plugins:/go/src/github.com/aws/amazon-ecs-cni-plugins/bin/plugins" \

--- a/scripts/publishing-common.sh
+++ b/scripts/publishing-common.sh
@@ -16,7 +16,7 @@
 export VERSION=$(cat $(dirname "${0}")/../VERSION)
 
 export IMAGE_TAG_LATEST="latest"
-export IMAGE_TAG_SHA=$(git rev-parse --short HEAD)
+export IMAGE_TAG_SHA=$(git rev-parse --short=8 HEAD)
 export IMAGE_TAG_VERSION="v${VERSION}"
 
 SUPPORTED_OSES=("linux" "windows")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Use 8 character sha in publishing common for scripts.

### Implementation details
I changed `--short` to `--short=8`.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
