### PR TITLE
eni: increase test retry duration, swap assert() params

### DIFF
--- a/agent/eni/networkutils/utils_linux_test.go
+++ b/agent/eni/networkutils/utils_linux_test.go
@@ -54,7 +54,7 @@ func TestGetMACAddress(t *testing.T) {
 	ctx := context.TODO()
 	mac, err := GetMACAddress(ctx, time.Millisecond, randomDevice, mockNetlink)
 	assert.Nil(t, err)
-	assert.Equal(t, mac, validMAC)
+	assert.Equal(t, validMAC, mac)
 }
 
 // TestGetMACAddressWithNetlinkError attempts to test the netlinkClient
@@ -95,11 +95,11 @@ func TestGetMACAddressNotFoundRetry(t *testing.T) {
 		}, nil),
 	)
 	ctx := context.TODO()
-	// Set max retry duration to twice that of the min backoff to ensure that there's
+	// Set max retry duration to twice that of the max backoff to ensure that there's
 	// enough time to retry
-	mac, err := GetMACAddress(ctx, 2*macAddressBackoffMin, randomDevice, mockNetlink)
+	mac, err := GetMACAddress(ctx, 2*macAddressBackoffMax, randomDevice, mockNetlink)
 	assert.NoError(t, err)
-	assert.Equal(t, mac, validMAC)
+	assert.Equal(t, validMAC, mac)
 }
 
 // TestGetMACAddressNotFoundRetryExpires tests if the backoff-retry logic for
@@ -132,6 +132,6 @@ func TestIsValidDevicePathTableTest(t *testing.T) {
 
 	for _, entry := range table {
 		status := IsValidNetworkDevice(entry.input)
-		assert.Equal(t, status, entry.output)
+		assert.Equal(t, entry.output, status)
 	}
 }


### PR DESCRIPTION
### Summary
* increase retry duration for test, see https://github.com/aws/amazon-ecs-agent/issues/1245
* swapped params on calls to assert.* as per [expected ordering](https://godoc.org/github.com/stretchr/testify/assert#Equal)
* ran `go test -race . -run=TestGetMACAddressNotFoundRetry -count=1000`
### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [ ] Builds on Linux (`make release`)
- [ ] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [ ] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
