### PR TITLE
engine: add inactivity timeout for image pulling

### DIFF
--- a/agent/engine/docker_client.go
+++ b/agent/engine/docker_client.go
@@ -83,6 +83,10 @@ const (
 	// around a docker bug which sometimes results in pulls not progressing.
 	dockerPullBeginTimeout = 5 * time.Minute
 
+	// dockerPullInactivityTimeout is the amount of time that we will
+	// wait when the pulling does not progress
+	dockerPullInactivityTimeout = 1 * time.Minute
+
 	// pullStatusSuppressDelay controls the time where pull status progress bar
 	// output will be suppressed in debug mode
 	pullStatusSuppressDelay = 2 * time.Second
@@ -311,6 +315,7 @@ func (dg *dockerGoClient) pullImage(image string, authData *api.RegistryAuthenti
 	opts := docker.PullImageOptions{
 		Repository:   repository,
 		OutputStream: pullWriter,
+		InactivityTimeout: dockerPullInactivityTimeout,
 	}
 	timeout := dg.time().After(dockerPullBeginTimeout)
 	// pullBegan is a channel indicating that we have seen at least one line of data on the 'OutputStream' above.

--- a/agent/engine/docker_client_test.go
+++ b/agent/engine/docker_client_test.go
@@ -167,6 +167,19 @@ func TestPullImageGlobalTimeout(t *testing.T) {
 	wait.Done()
 }
 
+func TestPullImageInactivityTimeout(t *testing.T) {
+	mockDocker, client, testTime, _, _, done := dockerClientSetup(t)
+	defer done()
+
+	testTime.EXPECT().After(gomock.Any()).AnyTimes()
+	mockDocker.EXPECT().PullImage(&pullImageOptsMatcher{"image:latest"}, gomock.Any()).Return(
+		docker.ErrInactivityTimeout).Times(maximumPullRetries) // expected number of retries
+
+	metadata := client.PullImage("image", nil)
+	assert.Error(t, metadata.Error, "Expected error for pull inactivity timeout")
+	assert.Equal(t, "CannotPullContainerError", metadata.Error.(api.NamedError).ErrorName(), "Wrong error type")
+}
+
 func TestPullImage(t *testing.T) {
 	mockDocker, client, testTime, _, _, done := dockerClientSetup(t)
 	defer done()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This pull request is for issue 1249 here: https://github.com/aws/amazon-ecs-agent/issues/1249, which is to introduce InactivityTimeout for image pulling.

### Implementation details
<!-- How are the changes implemented? -->
By using the inactivity timeout parameter supported by go-dockerclient.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes<!-- yes|no -->

Three manual testings are performed as follow, with timeout set to 5 seconds:
(1) Start pulling a large image, send SIGSTOP to Docker daemon process, see whether inactivity timeout is triggered; send SIGCONT to Docker daemon process, see whether pulling resumes.
Result: after SIGSTOP, timeout is triggered; after SIGCONT, pulling resumes

(2) Start pulling a large image (from ECR), blackhole ECR, see whether timeout is triggered; remove blackhole, see whether pulling resumes
Result: after adding blackhole, the pulling fails immediately due to connection failure, and doesn't reach the timeout limit.

(3) Start pulling a large image, randomly drop 50% of packets on the host during the pull
Result: inactivity timeout is not triggered; pulling succeeds normally

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enhancement - Introduce InactivityTimeout to image pulling.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
