### PR TITLE
containermetadata: Metadata task definition fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 1.17.3-dev
+* Enhancement - Expose task definition family and task definition revision in container metadata file [#1295](https://github.com/aws/amazon-ecs-agent/pull/1295)
 * Bug - Fixed a bug where a stale websocket connection could linger [#1310](https://github.com/aws/amazon-ecs-agent/pull/1310)
 
 ## 1.17.2

--- a/agent/containermetadata/generate_mocks.go
+++ b/agent/containermetadata/generate_mocks.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/containermetadata/manager_unix_test.go
+++ b/agent/containermetadata/manager_unix_test.go
@@ -1,5 +1,5 @@
 // +build !integration,!windows
-// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -17,6 +17,8 @@ package containermetadata
 import (
 	"testing"
 
+	"github.com/aws/amazon-ecs-agent/agent/api"
+
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -28,6 +30,7 @@ func TestCreate(t *testing.T) {
 	defer done()
 
 	mockTaskARN := validTaskARN
+	mockTask := &api.Task{Arn: mockTaskARN}
 	mockContainerName := containerName
 	mockConfig := &docker.Config{Env: make([]string, 0)}
 	mockHostConfig := &docker.HostConfig{Binds: make([]string, 0)}
@@ -46,7 +49,7 @@ func TestCreate(t *testing.T) {
 		osWrap:     mockOS,
 		ioutilWrap: mockIOUtil,
 	}
-	err := newManager.Create(mockConfig, mockHostConfig, mockTaskARN, mockContainerName)
+	err := newManager.Create(mockConfig, mockHostConfig, mockTask, mockContainerName)
 
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(mockConfig.Env), "Unexpected number of environment variables in config")
@@ -60,6 +63,7 @@ func TestUpdate(t *testing.T) {
 
 	mockDockerID := dockerID
 	mockTaskARN := validTaskARN
+	mockTask := &api.Task{Arn: mockTaskARN}
 	mockContainerName := containerName
 	mockState := docker.State{
 		Running: true,
@@ -91,7 +95,7 @@ func TestUpdate(t *testing.T) {
 		mockOS.EXPECT().Rename(gomock.Any(), gomock.Any()).Return(nil),
 		mockFile.EXPECT().Close().Return(nil),
 	)
-	err := newManager.Update(mockDockerID, mockTaskARN, mockContainerName)
+	err := newManager.Update(mockDockerID, mockTask, mockContainerName)
 
 	assert.NoError(t, err)
 }

--- a/agent/containermetadata/manager_windows_test.go
+++ b/agent/containermetadata/manager_windows_test.go
@@ -1,5 +1,5 @@
 // +build !integration, windows
-// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -17,6 +17,8 @@ package containermetadata
 import (
 	"testing"
 
+	"github.com/aws/amazon-ecs-agent/agent/api"
+
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -28,6 +30,7 @@ func TestCreate(t *testing.T) {
 	defer done()
 
 	mockTaskARN := validTaskARN
+	mockTask := &api.Task{Arn: mockTaskARN}
 	mockContainerName := containerName
 	mockConfig := &docker.Config{Env: make([]string, 0)}
 	mockHostConfig := &docker.HostConfig{Binds: make([]string, 0)}
@@ -43,7 +46,7 @@ func TestCreate(t *testing.T) {
 	newManager := &metadataManager{
 		osWrap: mockOS,
 	}
-	err := newManager.Create(mockConfig, mockHostConfig, mockTaskARN, mockContainerName)
+	err := newManager.Create(mockConfig, mockHostConfig, mockTask, mockContainerName)
 
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(mockConfig.Env), "Unexpected number of environment variables in config")
@@ -57,6 +60,7 @@ func TestUpdate(t *testing.T) {
 
 	mockDockerID := dockerID
 	mockTaskARN := validTaskARN
+	mockTask := &api.Task{Arn: mockTaskARN}
 	mockContainerName := containerName
 	mockState := docker.State{
 		Running: true,
@@ -85,7 +89,7 @@ func TestUpdate(t *testing.T) {
 		mockFile.EXPECT().Sync().Return(nil),
 		mockFile.EXPECT().Close().Return(nil),
 	)
-	err := newManager.Update(mockDockerID, mockTaskARN, mockContainerName)
+	err := newManager.Update(mockDockerID, mockTask, mockContainerName)
 
 	assert.NoError(t, err)
 }

--- a/agent/containermetadata/mocks/containermetadata_mocks.go
+++ b/agent/containermetadata/mocks/containermetadata_mocks.go
@@ -21,6 +21,8 @@ import (
 	reflect "reflect"
 	time "time"
 
+	"github.com/aws/amazon-ecs-agent/agent/api"
+
 	go_dockerclient "github.com/fsouza/go-dockerclient"
 	gomock "github.com/golang/mock/gomock"
 )
@@ -61,7 +63,7 @@ func (mr *MockManagerMockRecorder) Clean(arg0 interface{}) *gomock.Call {
 }
 
 // Create mocks base method
-func (m *MockManager) Create(arg0 *go_dockerclient.Config, arg1 *go_dockerclient.HostConfig, arg2, arg3 string) error {
+func (m *MockManager) Create(arg0 *go_dockerclient.Config, arg1 *go_dockerclient.HostConfig, arg2 *api.Task, arg3 string) error {
 	ret := m.ctrl.Call(m, "Create", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -83,7 +85,7 @@ func (mr *MockManagerMockRecorder) SetContainerInstanceARN(arg0 interface{}) *go
 }
 
 // Update mocks base method
-func (m *MockManager) Update(arg0, arg1, arg2 string) error {
+func (m *MockManager) Update(arg0 string, arg1 *api.Task, arg2 string) error {
 	ret := m.ctrl.Call(m, "Update", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0

--- a/agent/containermetadata/parse_metadata.go
+++ b/agent/containermetadata/parse_metadata.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -27,10 +27,15 @@ import (
 // available prior to container creation
 // Since we accept incomplete metadata fields, we should not return
 // errors here and handle them at this or the above stage.
-func (manager *metadataManager) parseMetadataAtContainerCreate(taskARN string, containerName string) Metadata {
+func (manager *metadataManager) parseMetadataAtContainerCreate(task *api.Task, containerName string) Metadata {
 	return Metadata{
 		cluster:              manager.cluster,
-		taskMetadata:         TaskMetadata{containerName: containerName, taskARN: taskARN},
+		taskMetadata:         TaskMetadata{
+			containerName: containerName,
+			taskARN: task.Arn,
+			taskDefinitionFamily: task.Family,
+			taskDefinitionRevision: task.Version,
+		},
 		containerInstanceARN: manager.containerInstanceARN,
 		metadataStatus:       MetadataInitial,
 	}
@@ -40,11 +45,16 @@ func (manager *metadataManager) parseMetadataAtContainerCreate(taskARN string, c
 // configuration and data then packages it for JSON Marshaling
 // Since we accept incomplete metadata fields, we should not return
 // errors here and handle them at this or the above stage.
-func (manager *metadataManager) parseMetadata(dockerContainer *docker.Container, taskARN string, containerName string) Metadata {
-	dockerMD := parseDockerContainerMetadata(taskARN, containerName, dockerContainer)
+func (manager *metadataManager) parseMetadata(dockerContainer *docker.Container, task *api.Task, containerName string) Metadata {
+	dockerMD := parseDockerContainerMetadata(task.Arn, containerName, dockerContainer)
 	return Metadata{
 		cluster:                 manager.cluster,
-		taskMetadata:            TaskMetadata{containerName: containerName, taskARN: taskARN},
+		taskMetadata:            TaskMetadata{
+			containerName: containerName,
+			taskARN: task.Arn,
+			taskDefinitionFamily: task.Family,
+			taskDefinitionRevision: task.Version,
+		},
 		dockerContainerMetadata: dockerMD,
 		containerInstanceARN:    manager.containerInstanceARN,
 		metadataStatus:          MetadataReady,

--- a/agent/containermetadata/types.go
+++ b/agent/containermetadata/types.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -113,8 +113,10 @@ type DockerContainerMetadata struct {
 // TaskMetadata keeps track of all metadata associated with a task
 // provided by AWS, does not depend on the creation of the container
 type TaskMetadata struct {
-	containerName string
-	taskARN       string
+	containerName          string
+	taskARN                string
+	taskDefinitionFamily   string
+	taskDefinitionRevision string
 }
 
 // Metadata packages all acquired metadata and is used to format it
@@ -130,34 +132,38 @@ type Metadata struct {
 }
 
 // metadataSerializer is an intermediate struct that converts the information
-// in Metadata into information to encode into JSOn
+// in Metadata into information to encode into JSON
 type metadataSerializer struct {
-	Cluster              string            `json:"Cluster,omitempty"`
-	ContainerInstanceARN string            `json:"ContainerInstanceARN,omitempty"`
-	TaskARN              string            `json:"TaskARN,omitempty"`
-	ContainerID          string            `json:"ContainerID,omitempty"`
-	ContainerName        string            `json:"ContainerName,omitempty"`
-	DockerContainerName  string            `json:"DockerContainerName,omitempty"`
-	ImageID              string            `json:"ImageID,omitempty"`
-	ImageName            string            `json:"ImageName,omitempty"`
-	Ports                []api.PortBinding `json:"PortMappings,omitempty"`
-	Networks             []Network         `json:"Networks,omitempty"`
-	MetadataFileStatus   MetadataStatus    `json:"MetadataFileStatus,omitempty"`
+	Cluster                string            `json:"Cluster,omitempty"`
+	ContainerInstanceARN   string            `json:"ContainerInstanceARN,omitempty"`
+	TaskARN                string            `json:"TaskARN,omitempty"`
+	TaskDefinitionFamily   string            `json:"TaskDefinitionFamily,omitempty"`
+	TaskDefinitionRevision string            `json:"TaskDefinitionRevision,omitempty"`
+	ContainerID            string            `json:"ContainerID,omitempty"`
+	ContainerName          string            `json:"ContainerName,omitempty"`
+	DockerContainerName    string            `json:"DockerContainerName,omitempty"`
+	ImageID                string            `json:"ImageID,omitempty"`
+	ImageName              string            `json:"ImageName,omitempty"`
+	Ports                  []api.PortBinding `json:"PortMappings,omitempty"`
+	Networks               []Network         `json:"Networks,omitempty"`
+	MetadataFileStatus     MetadataStatus    `json:"MetadataFileStatus,omitempty"`
 }
 
 func (m Metadata) MarshalJSON() ([]byte, error) {
 	return json.Marshal(
 		metadataSerializer{
-			Cluster:              m.cluster,
-			ContainerInstanceARN: m.containerInstanceARN,
-			TaskARN:              m.taskMetadata.taskARN,
-			ContainerID:          m.dockerContainerMetadata.containerID,
-			ContainerName:        m.taskMetadata.containerName,
-			DockerContainerName:  m.dockerContainerMetadata.dockerContainerName,
-			ImageID:              m.dockerContainerMetadata.imageID,
-			ImageName:            m.dockerContainerMetadata.imageName,
-			Ports:                m.dockerContainerMetadata.ports,
-			Networks:             m.dockerContainerMetadata.networkInfo.networks,
-			MetadataFileStatus:   m.metadataStatus,
+			Cluster:                m.cluster,
+			ContainerInstanceARN:   m.containerInstanceARN,
+			TaskARN:                m.taskMetadata.taskARN,
+			TaskDefinitionFamily:   m.taskMetadata.taskDefinitionFamily,
+			TaskDefinitionRevision: m.taskMetadata.taskDefinitionRevision,
+			ContainerID:            m.dockerContainerMetadata.containerID,
+			ContainerName:          m.taskMetadata.containerName,
+			DockerContainerName:    m.dockerContainerMetadata.dockerContainerName,
+			ImageID:                m.dockerContainerMetadata.imageID,
+			ImageName:              m.dockerContainerMetadata.imageName,
+			Ports:                  m.dockerContainerMetadata.ports,
+			Networks:               m.dockerContainerMetadata.networkInfo.networks,
+			MetadataFileStatus:     m.metadataStatus,
 		})
 }

--- a/agent/containermetadata/types_test.go
+++ b/agent/containermetadata/types_test.go
@@ -1,5 +1,5 @@
 // +build !integration
-// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/containermetadata/utils.go
+++ b/agent/containermetadata/utils.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/containermetadata/utils_test.go
+++ b/agent/containermetadata/utils_test.go
@@ -1,5 +1,5 @@
 // +build !integration
-// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/containermetadata/write_metadata_test.go
+++ b/agent/containermetadata/write_metadata_test.go
@@ -1,5 +1,5 @@
 // +build !integration
-// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/containermetadata/write_metadata_unix.go
+++ b/agent/containermetadata/write_metadata_unix.go
@@ -1,6 +1,6 @@
 // +build !windows
 
-// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/containermetadata/write_metadata_unix_test.go
+++ b/agent/containermetadata/write_metadata_unix_test.go
@@ -1,5 +1,5 @@
 // +build !integration, !windows
-// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/containermetadata/write_metadata_windows.go
+++ b/agent/containermetadata/write_metadata_windows.go
@@ -1,6 +1,6 @@
 // +build windows
 
-// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/containermetadata/write_metadata_windows_test.go
+++ b/agent/containermetadata/write_metadata_windows_test.go
@@ -1,5 +1,5 @@
 // +build !integration, windows
-// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -819,7 +819,7 @@ func (engine *DockerTaskEngine) createContainer(task *api.Task, container *api.C
 	// Create metadata directory and file then populate it with common metadata of all containers of this task
 	// Afterwards add this directory to the container's mounts if file creation was successful
 	if engine.cfg.ContainerMetadataEnabled && !container.IsInternal() {
-		mderr := engine.metadataManager.Create(config, hostConfig, task.Arn, container.Name)
+		mderr := engine.metadataManager.Create(config, hostConfig, task, container.Name)
 		if mderr != nil {
 			seelog.Warnf("Task engine [%s]: unable to create metadata for container %s: %v",
 				task.Arn, container.Name, mderr)
@@ -872,7 +872,7 @@ func (engine *DockerTaskEngine) startContainer(task *api.Task, container *api.Co
 		engine.cfg.ContainerMetadataEnabled &&
 		!container.IsInternal() {
 		go func() {
-			err := engine.metadataManager.Update(dockerContainer.DockerID, task.Arn, container.Name)
+			err := engine.metadataManager.Update(dockerContainer.DockerID, task, container.Name)
 			if err != nil {
 				seelog.Warnf("Task engine [%s]: failed to update metadata file for container %s: %v",
 					task.Arn, container.Name, err)
@@ -1105,7 +1105,7 @@ func (engine *DockerTaskEngine) Version() (string, error) {
 }
 
 func (engine *DockerTaskEngine) updateMetadataFile(task *api.Task, cont *api.DockerContainer) {
-	err := engine.metadataManager.Update(cont.DockerID, task.Arn, cont.Container.Name)
+	err := engine.metadataManager.Update(cont.DockerID, task, cont.Container.Name)
 	if err != nil {
 		seelog.Errorf("Task engine [%s]: failed to update metadata file for container %s: %v",
 			task.Arn, cont.Container.Name, err)

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -1423,8 +1423,8 @@ func TestMetadataFileUpdatedAgentRestart(t *testing.T) {
 	saver.EXPECT().ForceSave().AnyTimes()
 
 	metadataManager.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any()).Do(
-		func(dockerID string, taskARN string, containerName string) {
-			assert.Equal(t, expectedTaskARN, taskARN)
+		func(dockerID string, task *api.Task, containerName string) {
+			assert.Equal(t, expectedTaskARN, task.Arn)
 			assert.Equal(t, expectedContainerName, containerName)
 			assert.Equal(t, expectedDockerID, dockerID)
 			metadataUpdateWG.Done()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This is to pick up and finish pr [#1122](https://github.com/aws/amazon-ecs-agent/pull/1122) to fix #1295.

Expose two more metadata fields, task definition family and task definition revision.

It also fixes some typos.

### Implementation details
Retrieve the fields from the existing task struct, and copy them into the metadata JSON.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enhancement - Expose two more metadata fields, task definition family and task definition revision

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
