### PR TITLE
Adding ListPlugins wrapper

### DIFF
--- a/agent/api/statechange_test.go
+++ b/agent/api/statechange_test.go
@@ -49,7 +49,7 @@ func TestShouldBeReported(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		t.Run(fmt.Sprintf("task change status: %s, container change: %s", tc.status, len(tc.containerChange) > 0),
+		t.Run(fmt.Sprintf("task change status: %s, container change: %t", tc.status, len(tc.containerChange) > 0),
 			func(t *testing.T) {
 				taskChange := TaskStateChange{
 					Status:     tc.status,

--- a/agent/engine/docker_client.go
+++ b/agent/engine/docker_client.go
@@ -54,6 +54,9 @@ const (
 	healthCheckUnhealthy = "unhealthy"
 	// maxHealthCheckOutputLength is the maximum length of healthcheck command output that agent will save
 	maxHealthCheckOutputLength = 1024
+
+	// VolumeDriverType is one of the plugin capabilities see https://docs.docker.com/engine/reference/commandline/plugin_ls/#filtering
+	VolumeDriverType = "volumedriver"
 )
 
 // Timelimits for docker operations enforced above docker
@@ -73,6 +76,8 @@ const (
 	removeContainerTimeout  = 5 * time.Minute
 	inspectContainerTimeout = 30 * time.Second
 	removeImageTimeout      = 3 * time.Minute
+
+	ListPluginsTimeout = 1 * time.Minute
 
 	// Parameters for caching the docker auth for ECR
 	tokenCacheSize = 100
@@ -157,6 +162,14 @@ type DockerClient interface {
 
 	// RemoveVolume removes a volume by its name. A timeout value should be provided for the request
 	RemoveVolume(string, time.Duration) error
+
+	// ListPluginsWithFilters returns the set of docker plugins installed on the host, filtered by options provided.
+	// A timeout value should be provided for the request.
+	ListPluginsWithFilters(bool, []string, time.Duration) ([]string, error)
+
+	// ListPlugins returns the set of docker plugins installed on the host. A timeout value should be provided for
+	// the request.
+	ListPlugins(time.Duration) listPluginsResponse
 
 	// Stats returns a channel of stat data for the specified container. A context should be provided so the request can
 	// be canceled.
@@ -974,7 +987,7 @@ func (dg *dockerGoClient) Version() (string, error) {
 
 type volumeResponse struct {
 	Volume *taskresource.VolumeResource
-	Error       error
+	Error  error
 }
 
 func (dg *dockerGoClient) CreateVolume(name string,
@@ -1132,6 +1145,85 @@ func (dg *dockerGoClient) removeVolume(ctx context.Context, name string) error {
 	}
 
 	return nil
+}
+
+type listPluginsResponse struct {
+	Plugins []docker.PluginDetail
+	Error   error
+}
+
+// ListPluginsWithFilters currently is a convenience method as go-dockerclient doesn't implement fitered list. When we or someone else submits
+// PR for the fix we will refactor this to pass in the fiters.
+func (dg *dockerGoClient) ListPluginsWithFilters(enabledFilter bool, capabilityFilter []string, timeout time.Duration) ([]string, error) {
+
+	var filteredPluginNames []string
+	response := dg.ListPlugins(timeout)
+
+	if response.Error != nil {
+		return nil, response.Error
+	}
+
+	for _, pluginDetail := range response.Plugins {
+		if pluginDetail.Active != enabledFilter {
+			continue
+		}
+
+		// One plugin might have multiple capabilities, see https://docs.docker.com/engine/reference/commandline/plugin_ls/#filtering
+		for _, pluginType := range pluginDetail.Config.Interface.Types {
+			for _, capability := range capabilityFilter {
+				// capability looks like volumedriver, pluginType looks like docker.volumedriver/1.0 (prefix.capability/version)
+				if strings.Contains(pluginType, capability) {
+					filteredPluginNames = append(filteredPluginNames, pluginDetail.Name)
+					break
+				}
+			}
+		}
+	}
+	return filteredPluginNames, nil
+}
+
+func (dg *dockerGoClient) ListPlugins(timeout time.Duration) listPluginsResponse {
+	// Create a context that times out after the 'timeout' duration
+	// Injecting the 'timeout' makes it easier to write tests.
+	// Eventually, the context should be initialized from a parent root context
+	// instead of TODO.
+	ctx, cancel := context.WithTimeout(context.TODO(), timeout)
+	defer cancel()
+
+	// Buffered channel so in the case of timeout it takes one write, never gets
+	// read, and can still be GC'd
+	response := make(chan listPluginsResponse, 1)
+	go func() { response <- dg.listPlugins(ctx) }()
+
+	// Wait until we get a response or for the 'done' context channel
+	select {
+	case resp := <-response:
+		return resp
+	case <-ctx.Done():
+		// Context has either expired or canceled. If it has timed out,
+		// send back the DockerTimeoutError
+		err := ctx.Err()
+		if err == context.DeadlineExceeded {
+			return listPluginsResponse{Plugins: nil, Error: &DockerTimeoutError{timeout, "listing plugins"}}
+		}
+		// Context was canceled even though there was no timeout. Send
+		// back an error.
+		return listPluginsResponse{Plugins: nil, Error: &CannotListPluginsError{err}}
+	}
+}
+
+func (dg *dockerGoClient) listPlugins(ctx context.Context) listPluginsResponse {
+	client, err := dg.dockerClient()
+	if err != nil {
+		return listPluginsResponse{Plugins: nil, Error: &CannotGetDockerClientError{version: dg.version, err: err}}
+	}
+
+	plugins, err := client.ListPlugins(ctx)
+	if err != nil {
+		return listPluginsResponse{Plugins: nil, Error: &CannotListPluginsError{err}}
+	}
+
+	return listPluginsResponse{Plugins: plugins, Error: nil}
 }
 
 // APIVersion returns the client api version

--- a/agent/engine/docker_client_test.go
+++ b/agent/engine/docker_client_test.go
@@ -1435,3 +1435,104 @@ func TestRemoveVolume(t *testing.T) {
 	err := client.RemoveVolume(volumeName, inspectContainerTimeout)
 	assert.NoError(t, err)
 }
+
+func TestListPluginsTimeout(t *testing.T) {
+	timeout := 10*time.Millisecond
+	mockDocker, client, _, _, _, done := dockerClientSetup(t)
+	defer done()
+
+	warp := make(chan time.Time)
+	wait := &sync.WaitGroup{}
+	wait.Add(1)
+	mockDocker.EXPECT().ListPlugins(gomock.Any()).Do(func(x interface{}) {
+		warp <- time.Now()
+		wait.Wait()
+		// Don't return, verify timeout happens
+		// TODO remove the MaxTimes by cancel the context passed to CreateVolume
+		// when issue #1212 is resolved
+	}).MaxTimes(1)
+	response := client.ListPlugins(timeout)
+	assert.Error(t, response.Error, "expected error for timeout")
+	assert.Equal(t, "DockerTimeoutError", response.Error.(api.NamedError).ErrorName())
+	wait.Done()
+}
+
+func TestListPluginsError(t *testing.T) {
+	mockDocker, client, _, _, _, done := dockerClientSetup(t)
+	defer done()
+
+	mockDocker.EXPECT().ListPlugins(gomock.Any()).Return(nil, errors.New("some docker error"))
+	response := client.ListPlugins(1*time.Second)
+	assert.Equal(t, "CannotListPluginsError", response.Error.(api.NamedError).ErrorName())
+}
+
+func TestListPlugins(t *testing.T) {
+	mockDocker, client, _, _, _, done := dockerClientSetup(t)
+	defer done()
+
+	pluginID := "id"
+	pluginName := "name"
+	pluginTag := "tag"
+	pluginDetail := docker.PluginDetail{
+		ID: pluginID,
+		Name: pluginName,
+		Tag: pluginTag,
+		Active: true,
+	}
+
+	mockDocker.EXPECT().ListPlugins(gomock.Any()).Return([]docker.PluginDetail{pluginDetail}, nil)
+
+	response := client.ListPlugins(inspectContainerTimeout)
+	assert.NoError(t, response.Error)
+	assert.Equal(t, pluginDetail.ID, response.Plugins[0].ID)
+	assert.Equal(t, pluginDetail.Name, response.Plugins[0].Name)
+	assert.Equal(t, pluginDetail.Tag, response.Plugins[0].Tag)
+	assert.True(t, response.Plugins[0].Active)
+}
+
+func TestListPluginsWithFilter(t *testing.T) {
+	mockDocker, client, _, _, _, done := dockerClientSetup(t)
+	defer done()
+
+	plugins := []docker.PluginDetail{
+		docker.PluginDetail{
+			ID: "id1",
+			Name: "name1",
+			Tag: "tag1",
+			Active: false,
+		},
+		docker.PluginDetail{
+			ID: "id2",
+			Name: "name2",
+			Tag: "tag2",
+			Active: true,
+			Config: docker.PluginConfig{
+				Description:   "A sample volume plugin for Docker",
+				Interface: docker.PluginInterface{
+					Types:  []string{"docker.volumedriver/1.0"},
+					Socket: "plugins.sock",
+				},
+			},
+		},
+		docker.PluginDetail{
+			ID: "id3",
+			Name: "name3",
+			Tag: "tag3",
+			Active: true,
+			Config: docker.PluginConfig{
+				Description:   "A sample network plugin for Docker",
+				Interface: docker.PluginInterface{
+					Types:  []string{"docker.networkdriver/1.0"},
+					Socket: "plugins.sock",
+				},
+			},
+		},
+	}
+
+	mockDocker.EXPECT().ListPlugins(gomock.Any()).Return(plugins, nil)
+
+	pluginNames, error := client.ListPluginsWithFilters(true, []string{VolumeDriverType}, inspectContainerTimeout)
+	assert.NoError(t, error)
+	assert.Equal(t, 1, len(pluginNames))
+	assert.Equal(t, "name2", pluginNames[0])
+}

--- a/agent/engine/dockeriface/interface.go
+++ b/agent/engine/dockeriface/interface.go
@@ -41,6 +41,7 @@ type Client interface {
 	CreateVolume(opts docker.CreateVolumeOptions) (*docker.Volume, error)
 	InspectVolume(name string) (*docker.Volume, error)
 	RemoveVolume(name string) error
+	ListPlugins(ctx context.Context) ([]docker.PluginDetail, error)
 	Stats(opts docker.StatsOptions) error
 	Version() (*docker.Env, error)
 	RemoveImage(imageName string) error

--- a/agent/engine/dockeriface/mocks/dockeriface_mocks.go
+++ b/agent/engine/dockeriface/mocks/dockeriface_mocks.go
@@ -230,6 +230,17 @@ func (_mr *_MockClientRecorder) RemoveVolume(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveVolume", arg0)
 }
 
+func (_m *MockClient) ListPlugins(_param0 context.Context) ([]go_dockerclient.PluginDetail, error) {
+	ret := _m.ctrl.Call(_m, "ListPlugins", _param0)
+	ret0, _ := ret[0].([]go_dockerclient.PluginDetail)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockClientRecorder) ListPlugins(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListPlugins", arg0)
+}
+
 func (_m *MockClient) Stats(_param0 go_dockerclient.StatsOptions) error {
 	ret := _m.ctrl.Call(_m, "Stats", _param0)
 	ret0, _ := ret[0].(error)

--- a/agent/engine/engine_mocks.go
+++ b/agent/engine/engine_mocks.go
@@ -454,6 +454,28 @@ func (_m *MockDockerClient) RemoveVolume(_param0 string, _param1 time.Duration) 
 	ret0, _ := ret[0].(error)
 	return ret0
 }
+
+func (_m *MockDockerClient) ListPluginsWithFilters(_param0 bool, _param1 []string, _param2 time.Duration) ([]string, error) {
+	ret := _m.ctrl.Call(_m, "ListPluginsWithFilters", _param0, _param1, _param2)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockDockerClientRecorder) ListPluginsWithFilters(_param0, _param1, _param2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListPluginsWithFilters", _param0, _param1, _param2)
+}
+
+func (_m *MockDockerClient) ListPlugins(_param0 time.Duration) listPluginsResponse {
+	ret := _m.ctrl.Call(_m, "ListPlugins", _param0)
+	ret0, _ := ret[0].(listPluginsResponse)
+	return ret0
+}
+
+func (_mr *_MockDockerClientRecorder) ListPlugins(_param0 time.Duration) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListPlugins", _param0)
+}
+
 func (_m *MockImageManager) SetSaver(_param0 statemanager.Saver) {
 	_m.ctrl.Call(_m, "SetSaver", _param0)
 }

--- a/agent/engine/errors.go
+++ b/agent/engine/errors.go
@@ -361,6 +361,19 @@ func (err CannotInspectVolumeError) ErrorName() string {
 	return "CannotInspectVolumeError"
 }
 
+// CannotListPluginsError indicates any error when trying to list docker plugins
+type CannotListPluginsError struct {
+	fromError error
+}
+
+func (err CannotListPluginsError) Error() string {
+	return err.fromError.Error()
+}
+
+func (err CannotListPluginsError) ErrorName() string {
+	return "CannotListPluginsError"
+}
+
 // CannotRemoveVolumeError indicates any error when trying to inspect a volume
 type CannotRemoveVolumeError struct {
 	fromError error


### PR DESCRIPTION
fixing broken build due to wrong printf format

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Adding ListPlugins wrapper in docker_client

### Implementation details
<!-- How are the changes implemented? -->
Note that go-dockerclient currently does not handle filters (for enabled=bool and capability=*driver, see https://docs.docker.com/engine/reference/commandline/plugin_ls/#filtering) in their implementation of listPlugins. I've added "ListPluginsWithFilters" as a convenience method for now, but am planning on submitting PR to go-dockerclient for this, after which we can clean up our implementation. Also, note that ListPlugins currently returns a list of full plugin objects, which is a pretty big nested structure (see response schema in https://docs.docker.com/engine/api/v1.30/#operation/PluginList). I've simplified our interface to deal with only the names of the plugins for now, but this is also up for discussion.


### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes

### Description for the changelog
Changelog not updated

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
