### PR TITLE
Adding ListPlugins wrapper

### DIFF
--- a/agent/engine/dockeriface/interface.go
+++ b/agent/engine/dockeriface/interface.go
@@ -41,6 +41,7 @@ type Client interface {
 	CreateVolume(opts docker.CreateVolumeOptions) (*docker.Volume, error)
 	InspectVolume(name string) (*docker.Volume, error)
 	RemoveVolume(name string) error
+	ListPlugins(ctx context.Context) ([]docker.PluginDetail, error)
 	Stats(opts docker.StatsOptions) error
 	Version() (*docker.Env, error)
 	RemoveImage(imageName string) error

--- a/agent/engine/dockeriface/mocks/dockeriface_mocks.go
+++ b/agent/engine/dockeriface/mocks/dockeriface_mocks.go
@@ -230,6 +230,17 @@ func (_mr *_MockClientRecorder) RemoveVolume(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveVolume", arg0)
 }
 
+func (_m *MockClient) ListPlugins(_param0 context.Context) ([]go_dockerclient.PluginDetail, error) {
+	ret := _m.ctrl.Call(_m, "ListPlugins", _param0)
+	ret0, _ := ret[0].([]go_dockerclient.PluginDetail)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockClientRecorder) ListPlugins(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListPlugins", arg0)
+}
+
 func (_m *MockClient) Stats(_param0 go_dockerclient.StatsOptions) error {
 	ret := _m.ctrl.Call(_m, "Stats", _param0)
 	ret0, _ := ret[0].(error)

--- a/agent/engine/engine_mocks.go
+++ b/agent/engine/engine_mocks.go
@@ -454,6 +454,28 @@ func (_m *MockDockerClient) RemoveVolume(_param0 string, _param1 time.Duration) 
 	ret0, _ := ret[0].(error)
 	return ret0
 }
+
+func (_m *MockDockerClient) ListPluginsWithFilters(_param0 bool, _param1 []string, _param2 time.Duration) ([]string, error) {
+	ret := _m.ctrl.Call(_m, "ListPluginsWithFilters", _param0, _param1, _param2)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockDockerClientRecorder) ListPluginsWithFilters(_param0, _param1, _param2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListPluginsWithFilters", _param0, _param1, _param2)
+}
+
+func (_m *MockDockerClient) ListPlugins(_param0 time.Duration) listPluginsResponse {
+	ret := _m.ctrl.Call(_m, "ListPlugins", _param0)
+	ret0, _ := ret[0].(listPluginsResponse)
+	return ret0
+}
+
+func (_mr *_MockDockerClientRecorder) ListPlugins(_param0 time.Duration) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListPlugins", _param0)
+}
+
 func (_m *MockImageManager) SetSaver(_param0 statemanager.Saver) {
 	_m.ctrl.Call(_m, "SetSaver", _param0)
 }

--- a/agent/engine/errors.go
+++ b/agent/engine/errors.go
@@ -373,3 +373,16 @@ func (err CannotRemoveVolumeError) Error() string {
 func (err CannotRemoveVolumeError) ErrorName() string {
 	return "CannotRemoveVolumeError"
 }
+
+// CannotListPluginsError indicates any error when trying to list docker plugins
+type CannotListPluginsError struct {
+	fromError error
+}
+
+func (err CannotListPluginsError) Error() string {
+	return err.fromError.Error()
+}
+
+func (err CannotListPluginsError) ErrorName() string {
+	return "CannotListPluginsError"
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Adding wrapper method for go-dockerclient's ListPlugins method, and a convenience method (ListPluginsWithFilters) to apply search filters (see https://docs.docker.com/engine/reference/commandline/plugin_ls/#filtering). go-dockerclient's ListPlugins method currently does not handle filters, but when we or someone else submits PR for the fix we will refactor these methods.

### Implementation details
ListPlugins wrapper method and ListPluginsWithFilters on top of it.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
