### PR TITLE
Deprecate 'TransitionDependencySet' for 'TransitionDependenciesMap'

### DIFF
--- a/agent/api/container.go
+++ b/agent/api/container.go
@@ -130,16 +130,7 @@ type Container struct {
 
 	// TransitionDependenciesMap is a map of the dependent container status to other
 	// dependencies that must be satisfied in order for this container to transition.
-	TransitionDependenciesMap map[ContainerStatus]TransitionDependencySet
-
-	// TransitionDependencySet is a set of dependencies that must be satisfied
-	// in order for this container to transition.  Each transition dependency
-	// specifies a resource upon which the transition is dependent, a status
-	// that depends on the resource, and the state of the dependency that
-	// satisfies.
-	// Deprecated: Use TransitionDependenciesMap instead. TransitionDependencySet is
-	// retained for compatibility with old state files.
-	TransitionDependencySet TransitionDependencySet `json:"TransitionDependencySet"`
+	TransitionDependenciesMap TransitionDependenciesMap `json:"TransitionDependencySet"`
 
 	// SteadyStateDependencies is a list of containers that must be in "steady state" before
 	// this one is created

--- a/agent/api/transitiondependency_test.go
+++ b/agent/api/transitiondependency_test.go
@@ -1,0 +1,57 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package api
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnmarshalOldTransitionDependencySet(t *testing.T) {
+	bytes := []byte(`{
+	  "ContainerDependencies": [
+	    {
+	      "ContainerName": "container",
+	      "SatisfiedStatus": "RUNNING",
+	      "DependentStatus": "RUNNING"
+	    }
+	  ]
+	}`)
+	unmarshalledTdMap := TransitionDependenciesMap{}
+	err := json.Unmarshal(bytes, &unmarshalledTdMap)
+	assert.NoError(t, err)
+	assert.Len(t, unmarshalledTdMap, 1)
+	assert.NotNil(t, unmarshalledTdMap[ContainerRunning])
+	dep := unmarshalledTdMap[ContainerRunning].ContainerDependencies
+	assert.Len(t, dep, 1)
+	assert.Equal(t, "container", dep[0].ContainerName)
+	assert.Equal(t, ContainerRunning, dep[0].SatisfiedStatus)
+	assert.Equal(t, ContainerStatusNone, dep[0].DependentStatus)
+}
+
+func TestUnmarshalNewTransitionDependencySet(t *testing.T) {
+	bytes := []byte(`{"1":{"ContainerDependencies":[{"ContainerName":"container","SatisfiedStatus":"RUNNING"}]}}`)
+	unmarshalledTdMap := TransitionDependenciesMap{}
+	err := json.Unmarshal(bytes, &unmarshalledTdMap)
+	assert.NoError(t, err)
+	assert.Len(t, unmarshalledTdMap, 1)
+	assert.NotNil(t, unmarshalledTdMap[ContainerPulled])
+	dep := unmarshalledTdMap[ContainerPulled].ContainerDependencies
+	assert.Len(t, dep, 1)
+	assert.Equal(t, "container", dep[0].ContainerName)
+	assert.Equal(t, ContainerRunning, dep[0].SatisfiedStatus)
+	assert.Equal(t, ContainerStatusNone, dep[0].DependentStatus)
+}

--- a/agent/statemanager/state_manager.go
+++ b/agent/statemanager/state_manager.go
@@ -59,7 +59,8 @@ const (
 	//   d) Added task cgroup related fields ('CPU', 'Memory', 'MemoryCPULimitsEnabled') to 'api.Task'
 	// 9) Add 'ipToTask' map to state file
 	// 10) Add 'healthCheckType' field in 'api.Container'
-	ECSDataVersion = 10
+	// 11) Deprecate 'TransitionDependencySet' and add new 'TransitionDependenciesMap' in 'api.Container'
+	ECSDataVersion = 11
 
 	// ecsDataFile specifies the filename in the ECS_DATADIR
 	ecsDataFile = "ecs_agent_data.json"


### PR DESCRIPTION
### Summary
Handle the unmarshaling of old 'TransitionDependencySet' in the state files to the new type 'TransitionDependenciesMap' introduced in https://github.com/aws/amazon-ecs-agent/pull/1279

### Implementation details
- Use the old tag name 'TransitionDependencySet' for the new 'TransitionDependenciesMap' type. In JSON unmarshal, check if the type of the json blob is a map. If not, unmarshal to the old type and convert it to the new map type. 
- Bump state file version

### Testing
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
