### PR TITLE
taskresource/cgroup: remove task dependency

### DIFF
--- a/agent/taskresource/interface.go
+++ b/agent/taskresource/interface.go
@@ -16,8 +16,6 @@ package taskresource
 import (
 	"encoding/json"
 	"time"
-
-	"github.com/aws/amazon-ecs-agent/agent/api"
 )
 
 // ResourceStatus is an enumeration of valid states of task resource lifecycle
@@ -38,7 +36,7 @@ type TaskResource interface {
 	// GetCreatedAt sets the timestamp for resource's creation time
 	GetCreatedAt() time.Time
 	// Create performs resource creation
-	Create(task *api.Task) error
+	Create() error
 	// Cleanup performs resource cleanup
 	Cleanup() error
 


### PR DESCRIPTION
### Summary
Minor refactor - Remove task dependency for resource creation.

### Implementation details
Changing method `Create(task *api.Task) error`  to `Create() error`. `api.Task` would contain list of resources in the future. Hence, removing dependency of task in resources package. 
Passing all the fields needed for resource creation to `CgroupResource` object. 

### Testing
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
