### PR TITLE
handlers: remove logging of URI in HTTP requests

### DIFF
--- a/agent/handlers/logging_handler.go
+++ b/agent/handlers/logging_handler.go
@@ -23,6 +23,6 @@ func NewLoggingHandler(handler http.Handler) LoggingHandler {
 }
 
 func (lh LoggingHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	log.Info("Handling http request", "method", r.Method, "from", r.RemoteAddr, "uri", r.RequestURI)
+	log.Info("Handling http request", "method", r.Method, "from", r.RemoteAddr)
 	lh.h.ServeHTTP(w, r)
 }


### PR DESCRIPTION
### Summary
remove logging of URI in HTTP requests

### Testing
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes

### Description for the changelog

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
