### PR TITLE
Add log for createContainer and startContainer

### DIFF
--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -839,6 +839,7 @@ func (engine *DockerTaskEngine) createContainer(task *api.Task, container *api.C
 		}
 	}
 
+	createContainerBegin := time.Now()
 	metadata := client.CreateContainer(engine.ctx, config, hostConfig, dockerContainerName, dockerapi.CreateContainerTimeout)
 	if metadata.DockerID != "" {
 		seelog.Infof("Task engine [%s]: created docker container for task: %s -> %s",
@@ -848,6 +849,8 @@ func (engine *DockerTaskEngine) createContainer(task *api.Task, container *api.C
 			Container:  container}, task)
 	}
 	container.SetLabels(config.Labels)
+	seelog.Infof("Task engine [%s]: created docker container for task: %s -> %s, took %s",
+		task.Arn, container.Name, metadata.DockerID, time.Since(createContainerBegin))
 	return metadata
 }
 
@@ -875,6 +878,7 @@ func (engine *DockerTaskEngine) startContainer(task *api.Task, container *api.Co
 			},
 		}
 	}
+	startContainerBegin := time.Now()
 	dockerContainerMD := client.StartContainer(engine.ctx, dockerContainer.DockerID, engine.cfg.ContainerStartTimeout)
 
 	// Get metadata through container inspection and available task information then write this to the metadata file
@@ -896,6 +900,8 @@ func (engine *DockerTaskEngine) startContainer(task *api.Task, container *api.Co
 				task.Arn, container.Name)
 		}()
 	}
+	seelog.Infof("Task engine [%s]: started docker container for task: %s -> %s, took %s",
+		task.Arn, container.Name, dockerContainerMD.DockerID, time.Since(startContainerBegin))
 	return dockerContainerMD
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This PR is to fix the issue [#724](https://github.com/aws/amazon-ecs-agent/issues/724)

Add logs to show the time cost of client API for createContainer and startContainer

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
