### PR TITLE
engine: wire context into methods that invoke Docker API call

### DIFF
--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -536,6 +536,7 @@ func (agent *ecsAgent) startAsyncRoutines(
 	go eventhandler.HandleEngineEvents(taskEngine, client, taskHandler)
 
 	telemetrySessionParams := tcshandler.TelemetrySessionParams{
+		Ctx:                           agent.ctx,
 		CredentialProvider:            agent.credentialProvider,
 		Cfg:                           agent.cfg,
 		ContainerInstanceArn:          agent.containerInstanceARN,

--- a/agent/app/agent_unix.go
+++ b/agent/app/agent_unix.go
@@ -1,6 +1,6 @@
 // +build linux
 
-// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -77,7 +77,7 @@ func (agent *ecsAgent) initializeTaskENIDependencies(state dockerstate.TaskEngin
 
 	if agent.cfg.ShouldLoadPauseContainerTarball() {
 		// Load the pause container's image from the 'disk'
-		if _, err := agent.pauseLoader.LoadImage(agent.cfg, agent.dockerClient); err != nil {
+		if _, err := agent.pauseLoader.LoadImage(agent.ctx, agent.cfg, agent.dockerClient); err != nil {
 			if pause.IsNoSuchFileError(err) || pause.UnsupportedPlatform(err) {
 				// If the pause container's image tarball doesn't exist or if the
 				// invocation is done for an unsupported platform, we cannot recover.

--- a/agent/app/agent_unix_test.go
+++ b/agent/app/agent_unix_test.go
@@ -1,6 +1,6 @@
 // +build linux
 
-// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -69,7 +69,7 @@ func TestDoStartHappyPath(t *testing.T) {
 	dockerClient.EXPECT().Version().AnyTimes()
 	imageManager.EXPECT().StartImageCleanupProcess(gomock.Any()).MaxTimes(1)
 	mockCredentialsProvider.EXPECT().IsExpired().Return(false).AnyTimes()
-	dockerClient.EXPECT().ListContainers(gomock.Any(), gomock.Any()).Return(
+	dockerClient.EXPECT().ListContainers(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		dockerapi.ListContainersResponse{}).AnyTimes()
 	client.EXPECT().DiscoverPollEndpoint(gomock.Any()).Do(func(x interface{}) {
 		// Ensures that the test waits until acs session has bee started
@@ -136,7 +136,7 @@ func TestDoStartTaskENIHappyPath(t *testing.T) {
 	// invoked via go routines, which will lead to occasional test failues
 	mockCredentialsProvider.EXPECT().IsExpired().Return(false).AnyTimes()
 	dockerClient.EXPECT().Version().AnyTimes()
-	dockerClient.EXPECT().ListContainers(gomock.Any(), gomock.Any()).Return(
+	dockerClient.EXPECT().ListContainers(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		dockerapi.ListContainersResponse{}).AnyTimes()
 	imageManager.EXPECT().StartImageCleanupProcess(gomock.Any()).MaxTimes(1)
 	client.EXPECT().DiscoverPollEndpoint(gomock.Any()).Do(func(x interface{}) {
@@ -159,7 +159,7 @@ func TestDoStartTaskENIHappyPath(t *testing.T) {
 		cniClient.EXPECT().Capabilities(ecscni.ECSENIPluginName).Return(cniCapabilities, nil),
 		cniClient.EXPECT().Capabilities(ecscni.ECSBridgePluginName).Return(cniCapabilities, nil),
 		cniClient.EXPECT().Capabilities(ecscni.ECSIPAMPluginName).Return(cniCapabilities, nil),
-		mockPauseLoader.EXPECT().LoadImage(gomock.Any(), gomock.Any()).Return(nil, nil),
+		mockPauseLoader.EXPECT().LoadImage(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil),
 		state.EXPECT().ENIByMac(gomock.Any()).Return(nil, false).AnyTimes(),
 		mockCredentialsProvider.EXPECT().Retrieve().Return(credentials.Value{}, nil),
 		dockerClient.EXPECT().SupportedVersions().Return(nil),
@@ -431,7 +431,7 @@ func TestInitializeTaskENIDependenciesPauseLoaderError(t *testing.T) {
 				cniClient.EXPECT().Capabilities(ecscni.ECSENIPluginName).Return(cniCapabilities, nil),
 				cniClient.EXPECT().Capabilities(ecscni.ECSBridgePluginName).Return(cniCapabilities, nil),
 				cniClient.EXPECT().Capabilities(ecscni.ECSIPAMPluginName).Return(cniCapabilities, nil),
-				mockPauseLoader.EXPECT().LoadImage(gomock.Any(), gomock.Any()).Return(nil, loadErr),
+				mockPauseLoader.EXPECT().LoadImage(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, loadErr),
 			)
 			cfg := getTestConfig()
 			agent := &ecsAgent{
@@ -489,7 +489,7 @@ func TestDoStartCgroupInitHappyPath(t *testing.T) {
 		}).Return("telemetry-endpoint", nil),
 		client.EXPECT().DiscoverTelemetryEndpoint(gomock.Any()).Return(
 			"tele-endpoint", nil).AnyTimes(),
-		dockerClient.EXPECT().ListContainers(gomock.Any(), gomock.Any()).Return(
+		dockerClient.EXPECT().ListContainers(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 			dockerapi.ListContainersResponse{}).AnyTimes(),
 	)
 

--- a/agent/containermetadata/manager.go
+++ b/agent/containermetadata/manager.go
@@ -14,15 +14,16 @@
 package containermetadata
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 	"time"
 
+	"github.com/aws/amazon-ecs-agent/agent/api"
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/utils/ioutilwrapper"
 	"github.com/aws/amazon-ecs-agent/agent/utils/oswrapper"
-	"github.com/aws/amazon-ecs-agent/agent/api"
 
 	docker "github.com/fsouza/go-dockerclient"
 )
@@ -41,7 +42,7 @@ const (
 type Manager interface {
 	SetContainerInstanceARN(string)
 	Create(*docker.Config, *docker.HostConfig, *api.Task, string) error
-	Update(string, *api.Task, string) error
+	Update(context.Context, string, *api.Task, string) error
 	Clean(string) error
 }
 
@@ -116,9 +117,9 @@ func (manager *metadataManager) Create(config *docker.Config, hostConfig *docker
 }
 
 // Update updates the metadata file after container starts and dynamic metadata is available
-func (manager *metadataManager) Update(dockerID string, task *api.Task, containerName string) error {
+func (manager *metadataManager) Update(ctx context.Context, dockerID string, task *api.Task, containerName string) error {
 	// Get docker container information through api call
-	dockerContainer, err := manager.client.InspectContainer(dockerID, inspectContainerTimeout)
+	dockerContainer, err := manager.client.InspectContainer(ctx, dockerID, inspectContainerTimeout)
 	if err != nil {
 		return err
 	}

--- a/agent/containermetadata/manager_test.go
+++ b/agent/containermetadata/manager_test.go
@@ -15,13 +15,14 @@
 package containermetadata
 
 import (
+	"context"
 	"errors"
 	"testing"
 
+	"github.com/aws/amazon-ecs-agent/agent/api"
 	"github.com/aws/amazon-ecs-agent/agent/containermetadata/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/utils/ioutilwrapper/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/utils/oswrapper/mocks"
-	"github.com/aws/amazon-ecs-agent/agent/api"
 
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/golang/mock/gomock"
@@ -108,8 +109,10 @@ func TestUpdateInspectFail(t *testing.T) {
 		client: mockClient,
 	}
 
-	mockClient.EXPECT().InspectContainer(mockDockerID, inspectContainerTimeout).Return(nil, errors.New("Inspect fail"))
-	err := newManager.Update(mockDockerID, mockTask, mockContainerName)
+	mockClient.EXPECT().InspectContainer(gomock.Any(), mockDockerID, inspectContainerTimeout).Return(nil, errors.New("Inspect fail"))
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	err := newManager.Update(ctx, mockDockerID, mockTask, mockContainerName)
 
 	assert.Error(t, err, "Expected inspect error to result in update fail")
 }
@@ -134,8 +137,10 @@ func TestUpdateNotRunningFail(t *testing.T) {
 		client: mockClient,
 	}
 
-	mockClient.EXPECT().InspectContainer(mockDockerID, inspectContainerTimeout).Return(mockContainer, nil)
-	err := newManager.Update(mockDockerID, mockTask, mockContainerName)
+	mockClient.EXPECT().InspectContainer(gomock.Any(), mockDockerID, inspectContainerTimeout).Return(mockContainer, nil)
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	err := newManager.Update(ctx, mockDockerID, mockTask, mockContainerName)
 	assert.Error(t, err)
 }
 

--- a/agent/containermetadata/manager_unix_test.go
+++ b/agent/containermetadata/manager_unix_test.go
@@ -15,6 +15,7 @@
 package containermetadata
 
 import (
+	"context"
 	"testing"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
@@ -87,7 +88,7 @@ func TestUpdate(t *testing.T) {
 	}
 
 	gomock.InOrder(
-		mockClient.EXPECT().InspectContainer(mockDockerID, inspectContainerTimeout).Return(mockContainer, nil),
+		mockClient.EXPECT().InspectContainer(gomock.Any(), mockDockerID, inspectContainerTimeout).Return(mockContainer, nil),
 		mockIOUtil.EXPECT().TempFile(gomock.Any(), gomock.Any()).Return(mockFile, nil),
 		mockFile.EXPECT().Write(gomock.Any()).Return(0, nil),
 		mockFile.EXPECT().Chmod(gomock.Any()).Return(nil),
@@ -95,7 +96,9 @@ func TestUpdate(t *testing.T) {
 		mockOS.EXPECT().Rename(gomock.Any(), gomock.Any()).Return(nil),
 		mockFile.EXPECT().Close().Return(nil),
 	)
-	err := newManager.Update(mockDockerID, mockTask, mockContainerName)
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	err := newManager.Update(ctx, mockDockerID, mockTask, mockContainerName)
 
 	assert.NoError(t, err)
 }

--- a/agent/containermetadata/manager_windows_test.go
+++ b/agent/containermetadata/manager_windows_test.go
@@ -15,6 +15,7 @@
 package containermetadata
 
 import (
+	"context"
 	"testing"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
@@ -83,13 +84,15 @@ func TestUpdate(t *testing.T) {
 	}
 
 	gomock.InOrder(
-		mockClient.EXPECT().InspectContainer(mockDockerID, inspectContainerTimeout).Return(mockContainer, nil),
+		mockClient.EXPECT().InspectContainer(gomock.Any(), mockDockerID, inspectContainerTimeout).Return(mockContainer, nil),
 		mockOS.EXPECT().OpenFile(gomock.Any(), gomock.Any(), gomock.Any()).Return(mockFile, nil),
 		mockFile.EXPECT().Write(gomock.Any()).Return(0, nil),
 		mockFile.EXPECT().Sync().Return(nil),
 		mockFile.EXPECT().Close().Return(nil),
 	)
-	err := newManager.Update(mockDockerID, mockTask, mockContainerName)
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	err := newManager.Update(ctx, mockDockerID, mockTask, mockContainerName)
 
 	assert.NoError(t, err)
 }

--- a/agent/containermetadata/mocks/containermetadata_mocks.go
+++ b/agent/containermetadata/mocks/containermetadata_mocks.go
@@ -18,11 +18,11 @@
 package mock_containermetadata
 
 import (
+	context "context"
 	reflect "reflect"
 	time "time"
 
-	"github.com/aws/amazon-ecs-agent/agent/api"
-
+	api "github.com/aws/amazon-ecs-agent/agent/api"
 	go_dockerclient "github.com/fsouza/go-dockerclient"
 	gomock "github.com/golang/mock/gomock"
 )
@@ -85,15 +85,15 @@ func (mr *MockManagerMockRecorder) SetContainerInstanceARN(arg0 interface{}) *go
 }
 
 // Update mocks base method
-func (m *MockManager) Update(arg0 string, arg1 *api.Task, arg2 string) error {
-	ret := m.ctrl.Call(m, "Update", arg0, arg1, arg2)
+func (m *MockManager) Update(arg0 context.Context, arg1 string, arg2 *api.Task, arg3 string) error {
+	ret := m.ctrl.Call(m, "Update", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Update indicates an expected call of Update
-func (mr *MockManagerMockRecorder) Update(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockManager)(nil).Update), arg0, arg1, arg2)
+func (mr *MockManagerMockRecorder) Update(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockManager)(nil).Update), arg0, arg1, arg2, arg3)
 }
 
 // MockDockerMetadataClient is a mock of DockerMetadataClient interface
@@ -120,14 +120,14 @@ func (m *MockDockerMetadataClient) EXPECT() *MockDockerMetadataClientMockRecorde
 }
 
 // InspectContainer mocks base method
-func (m *MockDockerMetadataClient) InspectContainer(arg0 string, arg1 time.Duration) (*go_dockerclient.Container, error) {
-	ret := m.ctrl.Call(m, "InspectContainer", arg0, arg1)
+func (m *MockDockerMetadataClient) InspectContainer(arg0 context.Context, arg1 string, arg2 time.Duration) (*go_dockerclient.Container, error) {
+	ret := m.ctrl.Call(m, "InspectContainer", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*go_dockerclient.Container)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // InspectContainer indicates an expected call of InspectContainer
-func (mr *MockDockerMetadataClientMockRecorder) InspectContainer(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InspectContainer", reflect.TypeOf((*MockDockerMetadataClient)(nil).InspectContainer), arg0, arg1)
+func (mr *MockDockerMetadataClientMockRecorder) InspectContainer(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InspectContainer", reflect.TypeOf((*MockDockerMetadataClient)(nil).InspectContainer), arg0, arg1, arg2)
 }

--- a/agent/containermetadata/types.go
+++ b/agent/containermetadata/types.go
@@ -14,6 +14,7 @@
 package containermetadata
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -79,7 +80,7 @@ func (status *MetadataStatus) UnmarshalText(text []byte) error {
 // The problems described above are indications dockerapi.DockerClient needs to be moved
 // outside the engine package
 type DockerMetadataClient interface {
-	InspectContainer(string, time.Duration) (*docker.Container, error)
+	InspectContainer(context.Context, string, time.Duration) (*docker.Container, error)
 }
 
 // Network is a struct that keeps track of metadata of a network interface

--- a/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
+++ b/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
@@ -81,28 +81,28 @@ func (mr *MockDockerClientMockRecorder) ContainerEvents(arg0 interface{}) *gomoc
 }
 
 // CreateContainer mocks base method
-func (m *MockDockerClient) CreateContainer(arg0 *go_dockerclient.Config, arg1 *go_dockerclient.HostConfig, arg2 string, arg3 time.Duration) dockerapi.DockerContainerMetadata {
-	ret := m.ctrl.Call(m, "CreateContainer", arg0, arg1, arg2, arg3)
+func (m *MockDockerClient) CreateContainer(arg0 context.Context, arg1 *go_dockerclient.Config, arg2 *go_dockerclient.HostConfig, arg3 string, arg4 time.Duration) dockerapi.DockerContainerMetadata {
+	ret := m.ctrl.Call(m, "CreateContainer", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(dockerapi.DockerContainerMetadata)
 	return ret0
 }
 
 // CreateContainer indicates an expected call of CreateContainer
-func (mr *MockDockerClientMockRecorder) CreateContainer(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateContainer", reflect.TypeOf((*MockDockerClient)(nil).CreateContainer), arg0, arg1, arg2, arg3)
+func (mr *MockDockerClientMockRecorder) CreateContainer(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateContainer", reflect.TypeOf((*MockDockerClient)(nil).CreateContainer), arg0, arg1, arg2, arg3, arg4)
 }
 
 // DescribeContainer mocks base method
-func (m *MockDockerClient) DescribeContainer(arg0 string) (api.ContainerStatus, dockerapi.DockerContainerMetadata) {
-	ret := m.ctrl.Call(m, "DescribeContainer", arg0)
+func (m *MockDockerClient) DescribeContainer(arg0 context.Context, arg1 string) (api.ContainerStatus, dockerapi.DockerContainerMetadata) {
+	ret := m.ctrl.Call(m, "DescribeContainer", arg0, arg1)
 	ret0, _ := ret[0].(api.ContainerStatus)
 	ret1, _ := ret[1].(dockerapi.DockerContainerMetadata)
 	return ret0, ret1
 }
 
 // DescribeContainer indicates an expected call of DescribeContainer
-func (mr *MockDockerClientMockRecorder) DescribeContainer(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeContainer", reflect.TypeOf((*MockDockerClient)(nil).DescribeContainer), arg0)
+func (mr *MockDockerClientMockRecorder) DescribeContainer(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeContainer", reflect.TypeOf((*MockDockerClient)(nil).DescribeContainer), arg0, arg1)
 }
 
 // ImportLocalEmptyVolumeImage mocks base method
@@ -118,16 +118,16 @@ func (mr *MockDockerClientMockRecorder) ImportLocalEmptyVolumeImage() *gomock.Ca
 }
 
 // InspectContainer mocks base method
-func (m *MockDockerClient) InspectContainer(arg0 string, arg1 time.Duration) (*go_dockerclient.Container, error) {
-	ret := m.ctrl.Call(m, "InspectContainer", arg0, arg1)
+func (m *MockDockerClient) InspectContainer(arg0 context.Context, arg1 string, arg2 time.Duration) (*go_dockerclient.Container, error) {
+	ret := m.ctrl.Call(m, "InspectContainer", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*go_dockerclient.Container)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // InspectContainer indicates an expected call of InspectContainer
-func (mr *MockDockerClientMockRecorder) InspectContainer(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InspectContainer", reflect.TypeOf((*MockDockerClient)(nil).InspectContainer), arg0, arg1)
+func (mr *MockDockerClientMockRecorder) InspectContainer(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InspectContainer", reflect.TypeOf((*MockDockerClient)(nil).InspectContainer), arg0, arg1, arg2)
 }
 
 // InspectImage mocks base method
@@ -156,27 +156,27 @@ func (mr *MockDockerClientMockRecorder) KnownVersions() *gomock.Call {
 }
 
 // ListContainers mocks base method
-func (m *MockDockerClient) ListContainers(arg0 bool, arg1 time.Duration) dockerapi.ListContainersResponse {
-	ret := m.ctrl.Call(m, "ListContainers", arg0, arg1)
+func (m *MockDockerClient) ListContainers(arg0 context.Context, arg1 bool, arg2 time.Duration) dockerapi.ListContainersResponse {
+	ret := m.ctrl.Call(m, "ListContainers", arg0, arg1, arg2)
 	ret0, _ := ret[0].(dockerapi.ListContainersResponse)
 	return ret0
 }
 
 // ListContainers indicates an expected call of ListContainers
-func (mr *MockDockerClientMockRecorder) ListContainers(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListContainers", reflect.TypeOf((*MockDockerClient)(nil).ListContainers), arg0, arg1)
+func (mr *MockDockerClientMockRecorder) ListContainers(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListContainers", reflect.TypeOf((*MockDockerClient)(nil).ListContainers), arg0, arg1, arg2)
 }
 
 // LoadImage mocks base method
-func (m *MockDockerClient) LoadImage(arg0 io.Reader, arg1 time.Duration) error {
-	ret := m.ctrl.Call(m, "LoadImage", arg0, arg1)
+func (m *MockDockerClient) LoadImage(arg0 context.Context, arg1 io.Reader, arg2 time.Duration) error {
+	ret := m.ctrl.Call(m, "LoadImage", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // LoadImage indicates an expected call of LoadImage
-func (mr *MockDockerClientMockRecorder) LoadImage(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadImage", reflect.TypeOf((*MockDockerClient)(nil).LoadImage), arg0, arg1)
+func (mr *MockDockerClientMockRecorder) LoadImage(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadImage", reflect.TypeOf((*MockDockerClient)(nil).LoadImage), arg0, arg1, arg2)
 }
 
 // PullImage mocks base method
@@ -192,39 +192,39 @@ func (mr *MockDockerClientMockRecorder) PullImage(arg0, arg1 interface{}) *gomoc
 }
 
 // RemoveContainer mocks base method
-func (m *MockDockerClient) RemoveContainer(arg0 string, arg1 time.Duration) error {
-	ret := m.ctrl.Call(m, "RemoveContainer", arg0, arg1)
+func (m *MockDockerClient) RemoveContainer(arg0 context.Context, arg1 string, arg2 time.Duration) error {
+	ret := m.ctrl.Call(m, "RemoveContainer", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RemoveContainer indicates an expected call of RemoveContainer
-func (mr *MockDockerClientMockRecorder) RemoveContainer(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveContainer", reflect.TypeOf((*MockDockerClient)(nil).RemoveContainer), arg0, arg1)
+func (mr *MockDockerClientMockRecorder) RemoveContainer(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveContainer", reflect.TypeOf((*MockDockerClient)(nil).RemoveContainer), arg0, arg1, arg2)
 }
 
 // RemoveImage mocks base method
-func (m *MockDockerClient) RemoveImage(arg0 string, arg1 time.Duration) error {
-	ret := m.ctrl.Call(m, "RemoveImage", arg0, arg1)
+func (m *MockDockerClient) RemoveImage(arg0 context.Context, arg1 string, arg2 time.Duration) error {
+	ret := m.ctrl.Call(m, "RemoveImage", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RemoveImage indicates an expected call of RemoveImage
-func (mr *MockDockerClientMockRecorder) RemoveImage(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveImage", reflect.TypeOf((*MockDockerClient)(nil).RemoveImage), arg0, arg1)
+func (mr *MockDockerClientMockRecorder) RemoveImage(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveImage", reflect.TypeOf((*MockDockerClient)(nil).RemoveImage), arg0, arg1, arg2)
 }
 
 // StartContainer mocks base method
-func (m *MockDockerClient) StartContainer(arg0 string, arg1 time.Duration) dockerapi.DockerContainerMetadata {
-	ret := m.ctrl.Call(m, "StartContainer", arg0, arg1)
+func (m *MockDockerClient) StartContainer(arg0 context.Context, arg1 string, arg2 time.Duration) dockerapi.DockerContainerMetadata {
+	ret := m.ctrl.Call(m, "StartContainer", arg0, arg1, arg2)
 	ret0, _ := ret[0].(dockerapi.DockerContainerMetadata)
 	return ret0
 }
 
 // StartContainer indicates an expected call of StartContainer
-func (mr *MockDockerClientMockRecorder) StartContainer(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartContainer", reflect.TypeOf((*MockDockerClient)(nil).StartContainer), arg0, arg1)
+func (mr *MockDockerClientMockRecorder) StartContainer(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartContainer", reflect.TypeOf((*MockDockerClient)(nil).StartContainer), arg0, arg1, arg2)
 }
 
 // Stats mocks base method
@@ -241,15 +241,15 @@ func (mr *MockDockerClientMockRecorder) Stats(arg0, arg1 interface{}) *gomock.Ca
 }
 
 // StopContainer mocks base method
-func (m *MockDockerClient) StopContainer(arg0 string, arg1 time.Duration) dockerapi.DockerContainerMetadata {
-	ret := m.ctrl.Call(m, "StopContainer", arg0, arg1)
+func (m *MockDockerClient) StopContainer(arg0 context.Context, arg1 string, arg2 time.Duration) dockerapi.DockerContainerMetadata {
+	ret := m.ctrl.Call(m, "StopContainer", arg0, arg1, arg2)
 	ret0, _ := ret[0].(dockerapi.DockerContainerMetadata)
 	return ret0
 }
 
 // StopContainer indicates an expected call of StopContainer
-func (mr *MockDockerClientMockRecorder) StopContainer(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopContainer", reflect.TypeOf((*MockDockerClient)(nil).StopContainer), arg0, arg1)
+func (mr *MockDockerClientMockRecorder) StopContainer(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopContainer", reflect.TypeOf((*MockDockerClient)(nil).StopContainer), arg0, arg1, arg2)
 }
 
 // SupportedVersions mocks base method

--- a/agent/engine/common_test.go
+++ b/agent/engine/common_test.go
@@ -153,8 +153,8 @@ func validateContainerRunWorkflow(t *testing.T,
 	dockerConfig.Labels["com.amazonaws.ecs.task-definition-family"] = task.Family
 	dockerConfig.Labels["com.amazonaws.ecs.task-definition-version"] = task.Version
 	dockerConfig.Labels["com.amazonaws.ecs.cluster"] = ""
-	client.EXPECT().CreateContainer(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(
-		func(config *docker.Config, y interface{}, containerName string, z time.Duration) {
+	client.EXPECT().CreateContainer(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(
+		func(ctx interface{}, config *docker.Config, y interface{}, containerName string, z time.Duration) {
 			assert.True(t, reflect.DeepEqual(dockerConfig, config),
 				"Mismatch in container config; expected: %v, got: %v", dockerConfig, config)
 			// sleep5 task contains only one container. Just assign
@@ -167,8 +167,8 @@ func validateContainerRunWorkflow(t *testing.T,
 			}()
 		}).Return(dockerapi.DockerContainerMetadata{DockerID: containerID})
 	defaultConfig := config.DefaultConfig()
-	client.EXPECT().StartContainer(containerID, defaultConfig.ContainerStartTimeout).Do(
-		func(id string, timeout time.Duration) {
+	client.EXPECT().StartContainer(gomock.Any(), containerID, defaultConfig.ContainerStartTimeout).Do(
+		func(ctx interface{}, id string, timeout time.Duration) {
 			containerEventsWG.Add(1)
 			go func() {
 				eventStream <- createDockerEvent(api.ContainerRunning)

--- a/agent/engine/docker_image_manager_integ_test.go
+++ b/agent/engine/docker_image_manager_integ_test.go
@@ -19,6 +19,7 @@ package engine
 
 import (
 	"container/list"
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -123,7 +124,9 @@ func TestIntegImageCleanupHappyCase(t *testing.T) {
 	}
 
 	// Call Image removal
-	imageManager.removeUnusedImages()
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	imageManager.removeUnusedImages(ctx)
 
 	// Verify top 2 LRU images are deleted from image manager
 	err = verifyImagesAreRemoved(imageManager, imageState1ImageID, imageState2ImageID)
@@ -241,7 +244,9 @@ func TestIntegImageCleanupThreshold(t *testing.T) {
 	}
 
 	// Call Image removal
-	imageManager.removeUnusedImages()
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	imageManager.removeUnusedImages(ctx)
 
 	// Verify Image1 & Image3 are removed from ImageManager as they are beyond the minimumAge threshold
 	err = verifyImagesAreRemoved(imageManager, imageState1ImageID, imageState3ImageID)
@@ -395,7 +400,9 @@ func TestImageWithSameNameAndDifferentID(t *testing.T) {
 	err = verifyTaskIsCleanedUp("task3", taskEngine)
 	assert.NoError(t, err, "task3")
 
-	imageManager.removeUnusedImages()
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	imageManager.removeUnusedImages(ctx)
 
 	// Verify all the three images are removed from image manager
 	err = verifyImagesAreRemoved(imageManager, imageID1, imageID2, imageID3)
@@ -524,7 +531,9 @@ func TestImageWithSameIDAndDifferentNames(t *testing.T) {
 	err = verifyTaskIsCleanedUp("task3", taskEngine)
 	assert.NoError(t, err, "task3")
 
-	imageManager.removeUnusedImages()
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	imageManager.removeUnusedImages(ctx)
 
 	// Verify all the images are removed from image manager
 	err = verifyImagesAreRemoved(imageManager, imageID1)
@@ -668,19 +677,23 @@ func verifyImagesAreNotRemoved(imageManager *dockerImageManager, imageIDs ...str
 }
 
 func cleanupImagesHappy(imageManager *dockerImageManager) {
-	imageManager.client.RemoveContainer("test1", dockerapi.RemoveContainerTimeout)
-	imageManager.client.RemoveContainer("test2", dockerapi.RemoveContainerTimeout)
-	imageManager.client.RemoveContainer("test3", dockerapi.RemoveContainerTimeout)
-	imageManager.client.RemoveImage(test1Image1Name, imageRemovalTimeout)
-	imageManager.client.RemoveImage(test1Image2Name, imageRemovalTimeout)
-	imageManager.client.RemoveImage(test1Image3Name, imageRemovalTimeout)
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	imageManager.client.RemoveContainer(ctx, "test1", dockerapi.RemoveContainerTimeout)
+	imageManager.client.RemoveContainer(ctx, "test2", dockerapi.RemoveContainerTimeout)
+	imageManager.client.RemoveContainer(ctx, "test3", dockerapi.RemoveContainerTimeout)
+	imageManager.client.RemoveImage(ctx, test1Image1Name, imageRemovalTimeout)
+	imageManager.client.RemoveImage(ctx, test1Image2Name, imageRemovalTimeout)
+	imageManager.client.RemoveImage(ctx, test1Image3Name, imageRemovalTimeout)
 }
 
 func cleanupImagesThreshold(imageManager *dockerImageManager) {
-	imageManager.client.RemoveContainer("test1", dockerapi.RemoveContainerTimeout)
-	imageManager.client.RemoveContainer("test2", dockerapi.RemoveContainerTimeout)
-	imageManager.client.RemoveContainer("test3", dockerapi.RemoveContainerTimeout)
-	imageManager.client.RemoveImage(test2Image1Name, imageRemovalTimeout)
-	imageManager.client.RemoveImage(test2Image2Name, imageRemovalTimeout)
-	imageManager.client.RemoveImage(test2Image3Name, imageRemovalTimeout)
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	imageManager.client.RemoveContainer(ctx, "test1", dockerapi.RemoveContainerTimeout)
+	imageManager.client.RemoveContainer(ctx, "test2", dockerapi.RemoveContainerTimeout)
+	imageManager.client.RemoveContainer(ctx, "test3", dockerapi.RemoveContainerTimeout)
+	imageManager.client.RemoveImage(ctx, test2Image1Name, imageRemovalTimeout)
+	imageManager.client.RemoveImage(ctx, test2Image2Name, imageRemovalTimeout)
+	imageManager.client.RemoveImage(ctx, test2Image3Name, imageRemovalTimeout)
 }

--- a/agent/engine/task_manager_test.go
+++ b/agent/engine/task_manager_test.go
@@ -1011,7 +1011,7 @@ func TestCleanupTask(t *testing.T) {
 
 	// Expectations to verify that the task gets removed
 	mockState.EXPECT().ContainerMapByArn(mTask.Arn).Return(map[string]*api.DockerContainer{container.Name: dockerContainer}, true)
-	mockClient.EXPECT().RemoveContainer(dockerContainer.DockerName, gomock.Any()).Return(nil)
+	mockClient.EXPECT().RemoveContainer(gomock.Any(), dockerContainer.DockerName, gomock.Any()).Return(nil)
 	mockImageManager.EXPECT().RemoveContainerReferenceFromImageState(container).Return(nil)
 	mockState.EXPECT().RemoveTask(mTask.Task)
 	mTask.cleanupTask(taskStoppedDuration)
@@ -1079,7 +1079,7 @@ func TestCleanupTaskWaitsForStoppedSent(t *testing.T) {
 	// Expectations to verify that the task gets removed
 	mockState.EXPECT().ContainerMapByArn(mTask.Arn).Return(
 		map[string]*api.DockerContainer{container.Name: dockerContainer}, true)
-	mockClient.EXPECT().RemoveContainer(dockerContainer.DockerName, gomock.Any()).Return(nil)
+	mockClient.EXPECT().RemoveContainer(gomock.Any(), dockerContainer.DockerName, gomock.Any()).Return(nil)
 	mockImageManager.EXPECT().RemoveContainerReferenceFromImageState(container).Return(nil)
 	mockState.EXPECT().RemoveTask(mTask.Task)
 	mTask.cleanupTask(taskStoppedDuration)
@@ -1206,7 +1206,7 @@ func TestCleanupTaskENIs(t *testing.T) {
 
 	// Expectations to verify that the task gets removed
 	mockState.EXPECT().ContainerMapByArn(mTask.Arn).Return(map[string]*api.DockerContainer{container.Name: dockerContainer}, true)
-	mockClient.EXPECT().RemoveContainer(dockerContainer.DockerName, gomock.Any()).Return(nil)
+	mockClient.EXPECT().RemoveContainer(gomock.Any(), dockerContainer.DockerName, gomock.Any()).Return(nil)
 	mockImageManager.EXPECT().RemoveContainerReferenceFromImageState(container).Return(nil)
 	mockState.EXPECT().RemoveTask(mTask.Task)
 	mockState.EXPECT().RemoveENIAttachment(mac)
@@ -1320,7 +1320,7 @@ func TestCleanupTaskWithInvalidInterval(t *testing.T) {
 
 	// Expectations to verify that the task gets removed
 	mockState.EXPECT().ContainerMapByArn(mTask.Arn).Return(map[string]*api.DockerContainer{container.Name: dockerContainer}, true)
-	mockClient.EXPECT().RemoveContainer(dockerContainer.DockerName, gomock.Any()).Return(nil)
+	mockClient.EXPECT().RemoveContainer(gomock.Any(), dockerContainer.DockerName, gomock.Any()).Return(nil)
 	mockImageManager.EXPECT().RemoveContainerReferenceFromImageState(container).Return(nil)
 	mockState.EXPECT().RemoveTask(mTask.Task)
 	mTask.cleanupTask(taskStoppedDuration)
@@ -1379,7 +1379,7 @@ func TestCleanupTaskWithResourceHappyPath(t *testing.T) {
 
 	// Expectations to verify that the task gets removed
 	mockState.EXPECT().ContainerMapByArn(mTask.Arn).Return(map[string]*api.DockerContainer{container.Name: dockerContainer}, true)
-	mockClient.EXPECT().RemoveContainer(dockerContainer.DockerName, gomock.Any()).Return(nil)
+	mockClient.EXPECT().RemoveContainer(gomock.Any(), dockerContainer.DockerName, gomock.Any()).Return(nil)
 	mockImageManager.EXPECT().RemoveContainerReferenceFromImageState(container).Return(nil)
 	mockState.EXPECT().RemoveTask(mTask.Task)
 	mockResource.EXPECT().Cleanup(gomock.Any()).Return(nil)
@@ -1439,7 +1439,7 @@ func TestCleanupTaskWithResourceErrorPath(t *testing.T) {
 
 	// Expectations to verify that the task gets removed
 	mockState.EXPECT().ContainerMapByArn(mTask.Arn).Return(map[string]*api.DockerContainer{container.Name: dockerContainer}, true)
-	mockClient.EXPECT().RemoveContainer(dockerContainer.DockerName, gomock.Any()).Return(nil)
+	mockClient.EXPECT().RemoveContainer(gomock.Any(), dockerContainer.DockerName, gomock.Any()).Return(nil)
 	mockImageManager.EXPECT().RemoveContainerReferenceFromImageState(container).Return(nil)
 	mockState.EXPECT().RemoveTask(mTask.Task)
 	mockResource.EXPECT().Cleanup(gomock.Any()).Return(errors.New("resource cleanup error"))

--- a/agent/eni/pause/load.go
+++ b/agent/eni/pause/load.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -14,6 +14,8 @@
 package pause
 
 import (
+	"context"
+
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	docker "github.com/fsouza/go-dockerclient"
@@ -22,7 +24,7 @@ import (
 // Loader defines an interface for loading the pause container image. This is mostly
 // to facilitate mocking and testing of the LoadImage method
 type Loader interface {
-	LoadImage(cfg *config.Config, dockerClient dockerapi.DockerClient) (*docker.Image, error)
+	LoadImage(ctx context.Context, cfg *config.Config, dockerClient dockerapi.DockerClient) (*docker.Image, error)
 }
 
 type loader struct{}

--- a/agent/eni/pause/mocks/load_mocks.go
+++ b/agent/eni/pause/mocks/load_mocks.go
@@ -18,10 +18,11 @@
 package mock_pause
 
 import (
+	context "context"
 	reflect "reflect"
 
 	config "github.com/aws/amazon-ecs-agent/agent/config"
-	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
+	dockerapi "github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	go_dockerclient "github.com/fsouza/go-dockerclient"
 	gomock "github.com/golang/mock/gomock"
 )
@@ -50,14 +51,14 @@ func (m *MockLoader) EXPECT() *MockLoaderMockRecorder {
 }
 
 // LoadImage mocks base method
-func (m *MockLoader) LoadImage(arg0 *config.Config, arg1 dockerapi.DockerClient) (*go_dockerclient.Image, error) {
-	ret := m.ctrl.Call(m, "LoadImage", arg0, arg1)
+func (m *MockLoader) LoadImage(arg0 context.Context, arg1 *config.Config, arg2 dockerapi.DockerClient) (*go_dockerclient.Image, error) {
+	ret := m.ctrl.Call(m, "LoadImage", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*go_dockerclient.Image)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // LoadImage indicates an expected call of LoadImage
-func (mr *MockLoaderMockRecorder) LoadImage(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadImage", reflect.TypeOf((*MockLoader)(nil).LoadImage), arg0, arg1)
+func (mr *MockLoaderMockRecorder) LoadImage(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadImage", reflect.TypeOf((*MockLoader)(nil).LoadImage), arg0, arg1, arg2)
 }

--- a/agent/eni/pause/pause_linux.go
+++ b/agent/eni/pause/pause_linux.go
@@ -16,6 +16,7 @@
 package pause
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/aws/amazon-ecs-agent/agent/acs/update_handler/os"
@@ -28,9 +29,9 @@ import (
 )
 
 // LoadImage helps load the pause container image for the agent
-func (*loader) LoadImage(cfg *config.Config, dockerClient dockerapi.DockerClient) (*docker.Image, error) {
+func (*loader) LoadImage(ctx context.Context, cfg *config.Config, dockerClient dockerapi.DockerClient) (*docker.Image, error) {
 	log.Debugf("Loading pause container tarball: %s", cfg.PauseContainerTarballPath)
-	if err := loadFromFile(cfg.PauseContainerTarballPath, dockerClient, os.Default); err != nil {
+	if err := loadFromFile(ctx, cfg.PauseContainerTarballPath, dockerClient, os.Default); err != nil {
 		return nil, err
 	}
 
@@ -38,7 +39,7 @@ func (*loader) LoadImage(cfg *config.Config, dockerClient dockerapi.DockerClient
 		config.DefaultPauseContainerImageName, config.DefaultPauseContainerTag, dockerClient)
 }
 
-func loadFromFile(path string, dockerClient dockerapi.DockerClient, fs os.FileSystem) error {
+func loadFromFile(ctx context.Context, path string, dockerClient dockerapi.DockerClient, fs os.FileSystem) error {
 	pauseContainerReader, err := fs.Open(path)
 	if err != nil {
 		if err.Error() == noSuchFile {
@@ -48,7 +49,7 @@ func loadFromFile(path string, dockerClient dockerapi.DockerClient, fs os.FileSy
 		return errors.Wrapf(err,
 			"pause container load: failed to read pause container image: %s", path)
 	}
-	if err := dockerClient.LoadImage(pauseContainerReader, dockerapi.LoadImageTimeout); err != nil {
+	if err := dockerClient.LoadImage(ctx, pauseContainerReader, dockerapi.LoadImageTimeout); err != nil {
 		return errors.Wrapf(err,
 			"pause container load: failed to load pause container image: %s", path)
 	}

--- a/agent/eni/pause/pause_linux_test.go
+++ b/agent/eni/pause/pause_linux_test.go
@@ -1,6 +1,6 @@
 // +build linux
 
-// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -16,6 +16,7 @@
 package pause
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -52,7 +53,9 @@ func TestLoadFromFileWithReaderError(t *testing.T) {
 	mockfs := mock_os.NewMockFileSystem(ctrl)
 	mockfs.EXPECT().Open(pauseTarballPath).Return(nil, errors.New("Dummy Reader Error"))
 
-	err = loadFromFile(pauseTarballPath, client, mockfs)
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	err = loadFromFile(ctx, pauseTarballPath, client, mockfs)
 	assert.Error(t, err)
 }
 
@@ -73,7 +76,9 @@ func TestLoadFromFileHappyPath(t *testing.T) {
 	mockfs := mock_os.NewMockFileSystem(ctrl)
 	mockfs.EXPECT().Open(pauseTarballPath).Return(nil, nil)
 
-	err = loadFromFile(pauseTarballPath, client, mockfs)
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	err = loadFromFile(ctx, pauseTarballPath, client, mockfs)
 	assert.NoError(t, err)
 }
 
@@ -96,7 +101,9 @@ func TestLoadFromFileDockerLoadImageError(t *testing.T) {
 	mockfs := mock_os.NewMockFileSystem(ctrl)
 	mockfs.EXPECT().Open(pauseTarballPath).Return(nil, nil)
 
-	err = loadFromFile(pauseTarballPath, client, mockfs)
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	err = loadFromFile(ctx, pauseTarballPath, client, mockfs)
 	assert.Error(t, err)
 }
 

--- a/agent/eni/pause/pause_unsupported.go
+++ b/agent/eni/pause/pause_unsupported.go
@@ -1,6 +1,6 @@
 // +build !linux
 
-// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -16,6 +16,7 @@
 package pause
 
 import (
+	"context"
 	"runtime"
 
 	"github.com/aws/amazon-ecs-agent/agent/config"
@@ -25,7 +26,7 @@ import (
 )
 
 // LoadImage returns UnsupportedPlatformError on the unsupported platform
-func (*loader) LoadImage(cfg *config.Config, dockerClient dockerapi.DockerClient) (*docker.Image, error) {
+func (*loader) LoadImage(ctx context.Context, cfg *config.Config, dockerClient dockerapi.DockerClient) (*docker.Image, error) {
 	return nil, NewUnsupportedPlatformError(errors.Errorf(
 		"pause container load: unsupported platform: %s/%s",
 		runtime.GOOS, runtime.GOARCH))

--- a/agent/stats/engine_integ_test.go
+++ b/agent/stats/engine_integ_test.go
@@ -16,6 +16,7 @@
 package stats
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -87,7 +88,9 @@ func TestStatsEngineWithExistingContainersWithoutHealth(t *testing.T) {
 
 	// Simulate container start prior to listener initialization.
 	time.Sleep(checkPointSleep)
-	err = engine.MustInit(taskEngine, defaultCluster, defaultContainerInstance)
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	err = engine.MustInit(ctx, taskEngine, defaultCluster, defaultContainerInstance)
 	require.NoError(t, err, "initializing stats engine failed")
 	defer engine.containerChangeEventStream.Unsubscribe(containerChangeHandler)
 
@@ -144,7 +147,9 @@ func TestStatsEngineWithNewContainersWithoutHealth(t *testing.T) {
 		},
 		testTask)
 
-	err = engine.MustInit(taskEngine, defaultCluster, defaultContainerInstance)
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	err = engine.MustInit(ctx, taskEngine, defaultCluster, defaultContainerInstance)
 	require.NoError(t, err, "initializing stats engine failed")
 	defer engine.containerChangeEventStream.Unsubscribe(containerChangeHandler)
 
@@ -222,7 +227,9 @@ func TestStatsEngineWithExistingContainers(t *testing.T) {
 
 	// Simulate container start prior to listener initialization.
 	time.Sleep(checkPointSleep)
-	err = engine.MustInit(taskEngine, defaultCluster, defaultContainerInstance)
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	err = engine.MustInit(ctx, taskEngine, defaultCluster, defaultContainerInstance)
 	assert.NoError(t, err, "initializing stats engine failed")
 	defer engine.containerChangeEventStream.Unsubscribe(containerChangeHandler)
 
@@ -286,7 +293,9 @@ func TestStatsEngineWithNewContainers(t *testing.T) {
 		},
 		testTask)
 
-	err = engine.MustInit(taskEngine, defaultCluster, defaultContainerInstance)
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	err = engine.MustInit(ctx, taskEngine, defaultCluster, defaultContainerInstance)
 	require.NoError(t, err, "initializing stats engine failed")
 	defer engine.containerChangeEventStream.Unsubscribe(containerChangeHandler)
 
@@ -360,7 +369,9 @@ func TestStatsEngineWithDockerTaskEngine(t *testing.T) {
 
 	// Create a new docker stats engine
 	statsEngine := NewDockerStatsEngine(&cfg, dockerClient, containerChangeEventStream)
-	err = statsEngine.MustInit(taskEngine, defaultCluster, defaultContainerInstance)
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	err = statsEngine.MustInit(ctx, taskEngine, defaultCluster, defaultContainerInstance)
 	require.NoError(t, err, "initializing stats engine failed")
 	defer statsEngine.removeAll()
 	defer statsEngine.containerChangeEventStream.Unsubscribe(containerChangeHandler)
@@ -440,7 +451,9 @@ func TestStatsEngineWithDockerTaskEngineMissingRemoveEvent(t *testing.T) {
 
 	// Create a new docker stats engine
 	statsEngine := NewDockerStatsEngine(&cfg, dockerClient, containerChangeEventStream)
-	err = statsEngine.MustInit(taskEngine, defaultCluster, defaultContainerInstance)
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	err = statsEngine.MustInit(ctx, taskEngine, defaultCluster, defaultContainerInstance)
 	require.NoError(t, err, "initializing stats engine failed")
 	defer statsEngine.removeAll()
 	defer statsEngine.containerChangeEventStream.Unsubscribe(containerChangeHandler)

--- a/agent/tcs/handler/handler.go
+++ b/agent/tcs/handler/handler.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -47,7 +47,7 @@ const (
 // StartMetricsSession starts a metric session. It initializes the stats engine
 // and invokes StartSession.
 func StartMetricsSession(params TelemetrySessionParams) {
-	err := params.StatsEngine.MustInit(params.TaskEngine, params.Cfg.Cluster,
+	err := params.StatsEngine.MustInit(params.Ctx, params.TaskEngine, params.Cfg.Cluster,
 		params.ContainerInstanceArn)
 	if err != nil {
 		seelog.Warnf("Error initializing metrics engine: %v", err)

--- a/agent/tcs/handler/types.go
+++ b/agent/tcs/handler/types.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -14,6 +14,7 @@
 package tcshandler
 
 import (
+	"context"
 	"sync"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
@@ -28,6 +29,7 @@ import (
 // TelemetrySessionParams contains all the parameters required to start a tcs
 // session
 type TelemetrySessionParams struct {
+	Ctx                           context.Context
 	ContainerInstanceArn          string
 	CredentialProvider            *credentials.Credentials
 	Cfg                           *config.Config


### PR DESCRIPTION
This pr is to fix issue #1212.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Pass the context into the Docker API call instead of creating context inside Docker API call. 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
