### PR TITLE
engine: modify create container log

### DIFF
--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -828,13 +828,13 @@ func (engine *DockerTaskEngine) createContainer(task *api.Task, container *api.C
 
 	metadata := client.CreateContainer(config, hostConfig, dockerContainerName, createContainerTimeout)
 	if metadata.DockerID != "" {
+		seelog.Infof("Task engine [%s]: created docker container for task: %s -> %s",
+			task.Arn, container.Name, metadata.DockerID)
 		engine.state.AddContainer(&api.DockerContainer{DockerID: metadata.DockerID,
 			DockerName: dockerContainerName,
 			Container:  container}, task)
 	}
 	container.SetLabels(config.Labels)
-	seelog.Infof("Task engine [%s]: created docker container for task: %s -> %s",
-		task.Arn, container.Name, metadata.DockerID)
 	return metadata
 }
 


### PR DESCRIPTION
Agent will currently log "created container" even if the call to
docker times out. This fixes that issue by tying the log line with
the state management call.
