### PR TITLE
Progress task resources

### DIFF
--- a/agent/api/task.go
+++ b/agent/api/task.go
@@ -866,36 +866,55 @@ func (task *Task) UpdateStatus() bool {
 
 // UpdateDesiredStatus sets the known status of the task
 func (task *Task) UpdateDesiredStatus() {
-	task.updateTaskDesiredStatus()
-	task.updateContainerDesiredStatus()
+	task.lock.Lock()
+	defer task.lock.Unlock()
+	task.updateTaskDesiredStatusUnsafe()
+	task.updateContainerDesiredStatusUnsafe(task.DesiredStatusUnsafe)
+	task.updateResourceDesiredStatusUnsafe(task.DesiredStatusUnsafe)
 }
 
-// updateTaskDesiredStatus determines what status the task should properly be at based on the containers' statuses
+// updateTaskDesiredStatusUnsafe determines what status the task should properly be at based on the containers' statuses
 // Invariant: task desired status must be stopped if any essential container is stopped
-func (task *Task) updateTaskDesiredStatus() {
-	seelog.Debugf("Updating task: [%s]", task.String())
+func (task *Task) updateTaskDesiredStatusUnsafe() {
+	seelog.Debugf("Updating task: [%s]", task.stringUnsafe())
 
 	// A task's desired status is stopped if any essential container is stopped
 	// Otherwise, the task's desired status is unchanged (typically running, but no need to change)
 	for _, cont := range task.Containers {
 		if cont.Essential && (cont.KnownTerminal() || cont.DesiredTerminal()) {
 			seelog.Debugf("Updating task desired status to stopped because of container: [%s]; task: [%s]",
-				cont.Name, task.String())
-			task.SetDesiredStatus(TaskStopped)
+				cont.Name, task.stringUnsafe())
+			task.DesiredStatusUnsafe = TaskStopped
 		}
 	}
 }
 
-// updateContainerDesiredStatus sets all container's desired status's to the
+// updateContainerDesiredStatusUnsafe sets all container's desired status's to the
 // task's desired status
 // Invariant: container desired status is <= task desired status converted to container status
 // Note: task desired status and container desired status is typically only RUNNING or STOPPED
-func (task *Task) updateContainerDesiredStatus() {
+func (task *Task) updateContainerDesiredStatusUnsafe(taskDesiredStatus TaskStatus) {
 	for _, c := range task.Containers {
-		taskDesiredStatus := task.GetDesiredStatus()
 		taskDesiredStatusToContainerStatus := taskDesiredStatus.ContainerStatus(c.GetSteadyStateStatus())
 		if c.GetDesiredStatus() < taskDesiredStatusToContainerStatus {
 			c.SetDesiredStatus(taskDesiredStatusToContainerStatus)
+		}
+	}
+}
+
+// updateResourceDesiredStatusUnsafe sets all resources' desired status depending on the
+// task's desired status
+// TODO: Create a mapping of resource status to the corresponding task status and use it here
+func (task *Task) updateResourceDesiredStatusUnsafe(taskDesiredStatus TaskStatus) {
+	for _, r := range task.Resources {
+		if taskDesiredStatus == TaskRunning {
+			if r.GetDesiredStatus() < r.SteadyState() {
+				r.SetDesiredStatus(r.SteadyState())
+			}
+		} else {
+			if r.GetDesiredStatus() < r.TerminalStatus() {
+				r.SetDesiredStatus(r.TerminalStatus())
+			}
 		}
 	}
 }
@@ -1094,7 +1113,11 @@ func (task *Task) GetExecutionStoppedAt() time.Time {
 func (task *Task) String() string {
 	task.lock.Lock()
 	defer task.lock.Unlock()
+	return task.stringUnsafe()
+}
 
+// stringUnsafe returns a human readable string representation of this object
+func (task *Task) stringUnsafe() string {
 	res := fmt.Sprintf("%s:%s %s, TaskStatus: (%s->%s)",
 		task.Family, task.Version, task.Arn,
 		task.KnownStatusUnsafe.String(), task.DesiredStatusUnsafe.String())

--- a/agent/engine/docker_task_engine_unix_test.go
+++ b/agent/engine/docker_task_engine_unix_test.go
@@ -17,16 +17,28 @@ package engine
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	"github.com/aws/amazon-ecs-agent/agent/emptyvolume"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate/mocks"
+	"github.com/aws/amazon-ecs-agent/agent/engine/testdata"
+	"github.com/aws/amazon-ecs-agent/agent/resources/cgroup/mock_control"
 	"github.com/aws/amazon-ecs-agent/agent/resources/mock_resources"
 	"github.com/aws/amazon-ecs-agent/agent/statemanager/mocks"
+	"github.com/aws/amazon-ecs-agent/agent/taskresource"
+	"github.com/aws/amazon-ecs-agent/agent/taskresource/cgroup"
+	"github.com/aws/amazon-ecs-agent/agent/utils/ioutilwrapper/mocks"
+	"github.com/aws/aws-sdk-go/aws"
+	docker "github.com/fsouza/go-dockerclient"
 	"github.com/golang/mock/gomock"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -38,6 +50,7 @@ const (
 	// isParallelPullCompatible is invoked during engine intialization
 	// on linux. Docker client's Version() call needs to be mocked
 	dockerVersionCheckDuringInit = true
+	cgroupMountPath              = "/sys/fs/cgroup"
 )
 
 func TestPullEmptyVolumeImage(t *testing.T) {
@@ -75,7 +88,7 @@ func TestDeleteTask(t *testing.T) {
 		},
 	}
 
-	cfg := &defaultConfig
+	cfg := defaultConfig
 	cfg.TaskCPUMemLimit = config.ExplicitlyEnabled
 	mockState := mock_dockerstate.NewMockTaskEngineState(ctrl)
 	mockSaver := mock_statemanager.NewMockStateManager(ctrl)
@@ -83,7 +96,7 @@ func TestDeleteTask(t *testing.T) {
 	taskEngine := &DockerTaskEngine{
 		state:    mockState,
 		saver:    mockSaver,
-		cfg:      &defaultConfig,
+		cfg:      &cfg,
 		resource: mockResource,
 	}
 
@@ -114,4 +127,125 @@ func TestEngineDisableConcurrentPull(t *testing.T) {
 	dockerTaskEngine, _ := taskEngine.(*DockerTaskEngine)
 	assert.False(t, dockerTaskEngine.enableConcurrentPull,
 		"Task engine should not be able to perform concurrent pulling for version < 1.11.1")
+}
+
+// TestResourceContainerProgression tests the container progression based on a
+// resource dependency
+func TestResourceContainerProgression(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	ctrl, client, mockTime, taskEngine, _, imageManager, _ := mocks(t, ctx, &defaultConfig)
+	defer ctrl.Finish()
+
+	sleepTask := testdata.LoadTask("sleep5")
+	sleepContainer := sleepTask.Containers[0]
+	sleepContainer.TransitionDependenciesMap = make(map[api.ContainerStatus]api.TransitionDependencySet)
+	sleepContainer.BuildResourceDependency("cgroup", taskresource.ResourceCreated, api.ContainerPulled)
+
+	mockControl := mock_cgroup.NewMockControl(ctrl)
+	mockIO := mock_ioutilwrapper.NewMockIOUtil(ctrl)
+	taskID, err := sleepTask.GetID()
+	assert.NoError(t, err)
+	cgroupMemoryPath := fmt.Sprintf("/sys/fs/cgroup/memory/ecs/%s/memory.use_hierarchy", taskID)
+	cgroupRoot := fmt.Sprintf("/ecs/%s", taskID)
+	cgroupResource := cgroup.NewCgroupResource(sleepTask.Arn, mockControl, cgroupRoot, cgroupMountPath, specs.LinuxResources{})
+	cgroupResource.SetIOUtil(mockIO)
+
+	sleepTask.Resources = []taskresource.TaskResource{cgroupResource}
+	sleepTask.Resources[0].SetDesiredStatus(taskresource.ResourceCreated)
+
+	eventStream := make(chan dockerapi.DockerContainerChangeEvent)
+	// containerEventsWG is used to force the test to wait until the container created and started
+	// events are processed
+	containerEventsWG := sync.WaitGroup{}
+	if dockerVersionCheckDuringInit {
+		client.EXPECT().Version()
+	}
+	client.EXPECT().ContainerEvents(gomock.Any()).Return(eventStream, nil)
+	gomock.InOrder(
+		// Ensure that the resource is created first
+		mockControl.EXPECT().Exists(gomock.Any()).Return(false),
+		mockControl.EXPECT().Create(gomock.Any()).Return(nil, nil),
+		mockIO.EXPECT().WriteFile(cgroupMemoryPath, gomock.Any(), gomock.Any()).Return(nil),
+		imageManager.EXPECT().AddAllImageStates(gomock.Any()).AnyTimes(),
+		client.EXPECT().PullImage(sleepContainer.Image, nil).Return(dockerapi.DockerContainerMetadata{}),
+		imageManager.EXPECT().RecordContainerReference(sleepContainer).Return(nil),
+		imageManager.EXPECT().GetImageStateFromImageName(sleepContainer.Image).Return(nil),
+		client.EXPECT().APIVersion().Return(defaultDockerClientAPIVersion, nil),
+		client.EXPECT().CreateContainer(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(
+			func(ctx interface{}, config *docker.Config, hostConfig *docker.HostConfig, containerName string, z time.Duration) {
+				assert.True(t, strings.Contains(containerName, sleepContainer.Name))
+				containerEventsWG.Add(1)
+				go func() {
+					eventStream <- createDockerEvent(api.ContainerCreated)
+					containerEventsWG.Done()
+				}()
+			}).Return(dockerapi.DockerContainerMetadata{DockerID: containerID + ":" + sleepContainer.Name}),
+		// Next, the sleep container is started
+		client.EXPECT().StartContainer(gomock.Any(), containerID+":"+sleepContainer.Name, defaultConfig.ContainerStartTimeout).Do(
+			func(ctx interface{}, id string, timeout time.Duration) {
+				containerEventsWG.Add(1)
+				go func() {
+					eventStream <- createDockerEvent(api.ContainerRunning)
+					containerEventsWG.Done()
+				}()
+			}).Return(dockerapi.DockerContainerMetadata{DockerID: containerID + ":" + sleepContainer.Name}),
+	)
+
+	addTaskToEngine(t, ctx, taskEngine, sleepTask, mockTime, containerEventsWG)
+
+	cleanup := make(chan time.Time, 1)
+	mockTime.EXPECT().After(gomock.Any()).Return(cleanup).AnyTimes()
+
+	// Simulate a container stop event from docker
+	eventStream <- dockerapi.DockerContainerChangeEvent{
+		Status: api.ContainerStopped,
+		DockerContainerMetadata: dockerapi.DockerContainerMetadata{
+			DockerID: containerID + ":" + sleepContainer.Name,
+			ExitCode: aws.Int(exitCode),
+		},
+	}
+	waitForStopEvents(t, taskEngine.StateChangeEvents(), true)
+}
+
+// TestResourceContainerProgressionFailure ensures that task moves to STOPPED when
+// resource creation fails
+func TestResourceContainerProgressionFailure(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	ctrl, client, mockTime, taskEngine, _, _, _ := mocks(t, ctx, &defaultConfig)
+	defer ctrl.Finish()
+	sleepTask := testdata.LoadTask("sleep5")
+	sleepContainer := sleepTask.Containers[0]
+	sleepContainer.TransitionDependenciesMap = make(map[api.ContainerStatus]api.TransitionDependencySet)
+	sleepContainer.BuildResourceDependency("cgroup", taskresource.ResourceCreated, api.ContainerPulled)
+
+	mockControl := mock_cgroup.NewMockControl(ctrl)
+	taskID, err := sleepTask.GetID()
+	assert.NoError(t, err)
+	cgroupRoot := fmt.Sprintf("/ecs/%s", taskID)
+	cgroupResource := cgroup.NewCgroupResource(sleepTask.Arn, mockControl, cgroupRoot, cgroupMountPath, specs.LinuxResources{})
+
+	sleepTask.Resources = []taskresource.TaskResource{cgroupResource}
+	sleepTask.Resources[0].SetDesiredStatus(taskresource.ResourceCreated)
+
+	eventStream := make(chan dockerapi.DockerContainerChangeEvent)
+	if dockerVersionCheckDuringInit {
+		client.EXPECT().Version()
+	}
+	client.EXPECT().ContainerEvents(gomock.Any()).Return(eventStream, nil)
+	gomock.InOrder(
+		// resource creation failure
+		mockControl.EXPECT().Exists(gomock.Any()).Return(false),
+		mockControl.EXPECT().Create(gomock.Any()).Return(nil, errors.New("cgroup create error")),
+	)
+	mockTime.EXPECT().Now().Return(time.Now()).AnyTimes()
+
+	err = taskEngine.Init(ctx)
+	assert.NoError(t, err)
+
+	taskEngine.AddTask(sleepTask)
+	cleanup := make(chan time.Time, 1)
+	mockTime.EXPECT().After(gomock.Any()).Return(cleanup).AnyTimes()
+	waitForStopEvents(t, taskEngine.StateChangeEvents(), true)
 }

--- a/agent/engine/task_manager_unix_test.go
+++ b/agent/engine/task_manager_unix_test.go
@@ -1,0 +1,271 @@
+// +build linux,!integration
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package engine
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/aws/amazon-ecs-agent/agent/statemanager/mocks"
+	"github.com/aws/amazon-ecs-agent/agent/taskresource"
+	"github.com/aws/amazon-ecs-agent/agent/taskresource/cgroup"
+	"github.com/golang/mock/gomock"
+
+	"github.com/aws/amazon-ecs-agent/agent/api"
+	"github.com/stretchr/testify/assert"
+)
+
+// These tests use cgroup resource, which is linux specific.
+// generic resource's(eg.volume) tests should be added to common test file.
+func TestHandleResourceStateChangeAndSave(t *testing.T) {
+	testCases := []struct {
+		Name               string
+		KnownStatus        taskresource.ResourceStatus
+		DesiredKnownStatus taskresource.ResourceStatus
+		Err                error
+		ChangedKnownStatus taskresource.ResourceStatus
+		TaskDesiredStatus  api.TaskStatus
+	}{
+		{
+			Name:               "error while steady state transition",
+			KnownStatus:        taskresource.ResourceStatus(cgroup.CgroupStatusNone),
+			DesiredKnownStatus: taskresource.ResourceStatus(cgroup.CgroupCreated),
+			Err:                errors.New("transition error"),
+			ChangedKnownStatus: taskresource.ResourceStatus(cgroup.CgroupStatusNone),
+			TaskDesiredStatus:  api.TaskStopped,
+		},
+		{
+			Name:               "steady state transition",
+			KnownStatus:        taskresource.ResourceStatus(cgroup.CgroupStatusNone),
+			DesiredKnownStatus: taskresource.ResourceStatus(cgroup.CgroupCreated),
+			Err:                nil,
+			ChangedKnownStatus: taskresource.ResourceStatus(cgroup.CgroupCreated),
+			TaskDesiredStatus:  api.TaskRunning,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			mockSaver := mock_statemanager.NewMockStateManager(ctrl)
+			res := &cgroup.CgroupResource{}
+			res.SetKnownStatus(tc.KnownStatus)
+			mtask := managedTask{
+				Task: &api.Task{
+					Arn:                 "task1",
+					Resources:           []taskresource.TaskResource{res},
+					DesiredStatusUnsafe: api.TaskRunning,
+				},
+				engine: &DockerTaskEngine{},
+			}
+			mtask.engine.SetSaver(mockSaver)
+			gomock.InOrder(
+				mockSaver.EXPECT().Save(),
+			)
+			mtask.handleResourceStateChange(resourceStateChange{
+				res, tc.DesiredKnownStatus, tc.Err,
+			})
+			assert.Equal(t, tc.ChangedKnownStatus, res.GetKnownStatus())
+			assert.Equal(t, tc.TaskDesiredStatus, mtask.GetDesiredStatus())
+		})
+	}
+}
+
+func TestHandleResourceStateChangeNoSave(t *testing.T) {
+	testCases := []struct {
+		Name               string
+		KnownStatus        taskresource.ResourceStatus
+		DesiredKnownStatus taskresource.ResourceStatus
+		Err                error
+		ChangedKnownStatus taskresource.ResourceStatus
+		TaskDesiredStatus  api.TaskStatus
+	}{
+		{
+			Name:               "steady state transition already done",
+			KnownStatus:        taskresource.ResourceStatus(cgroup.CgroupCreated),
+			DesiredKnownStatus: taskresource.ResourceStatus(cgroup.CgroupCreated),
+			Err:                nil,
+			ChangedKnownStatus: taskresource.ResourceStatus(cgroup.CgroupCreated),
+			TaskDesiredStatus:  api.TaskRunning,
+		},
+		{
+			Name:               "transition state less than known status",
+			DesiredKnownStatus: taskresource.ResourceStatus(cgroup.CgroupStatusNone),
+			Err:                nil,
+			KnownStatus:        taskresource.ResourceStatus(cgroup.CgroupCreated),
+			ChangedKnownStatus: taskresource.ResourceStatus(cgroup.CgroupCreated),
+			TaskDesiredStatus:  api.TaskRunning,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			res := &cgroup.CgroupResource{}
+			res.SetKnownStatus(tc.KnownStatus)
+			mtask := managedTask{
+				Task: &api.Task{
+					Arn:                 "task1",
+					Resources:           []taskresource.TaskResource{res},
+					DesiredStatusUnsafe: api.TaskRunning,
+				},
+			}
+			mtask.handleResourceStateChange(resourceStateChange{
+				res, tc.DesiredKnownStatus, tc.Err,
+			})
+			assert.Equal(t, tc.ChangedKnownStatus, res.GetKnownStatus())
+			assert.Equal(t, tc.TaskDesiredStatus, mtask.GetDesiredStatus())
+		})
+	}
+}
+
+func TestResourceNextState(t *testing.T) {
+	testCases := []struct {
+		Name             string
+		ResKnownStatus   taskresource.ResourceStatus
+		ResDesiredStatus taskresource.ResourceStatus
+		NextState        taskresource.ResourceStatus
+		ActionRequired   bool
+	}{
+		{
+			Name:             "next state happy path",
+			ResKnownStatus:   taskresource.ResourceStatus(cgroup.CgroupStatusNone),
+			ResDesiredStatus: taskresource.ResourceStatus(cgroup.CgroupCreated),
+			NextState:        taskresource.ResourceStatus(cgroup.CgroupCreated),
+			ActionRequired:   true,
+		},
+		{
+			Name:             "desired terminal",
+			ResKnownStatus:   taskresource.ResourceStatus(cgroup.CgroupStatusNone),
+			ResDesiredStatus: taskresource.ResourceStatus(cgroup.CgroupRemoved),
+			NextState:        taskresource.ResourceStatus(cgroup.CgroupRemoved),
+			ActionRequired:   false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			res := cgroup.CgroupResource{}
+			res.SetKnownStatus(tc.ResKnownStatus)
+			res.SetDesiredStatus(tc.ResDesiredStatus)
+			mtask := managedTask{
+				Task: &api.Task{},
+			}
+			transition := mtask.resourceNextState(&res)
+			assert.Equal(t, tc.NextState, transition.nextState)
+			assert.Equal(t, tc.ActionRequired, transition.actionRequired)
+		})
+	}
+}
+
+func TestStartResourceTransitionsHappyPath(t *testing.T) {
+	testCases := []struct {
+		Name             string
+		ResKnownStatus   taskresource.ResourceStatus
+		ResDesiredStatus taskresource.ResourceStatus
+		TransitionStatus taskresource.ResourceStatus
+		StatusString     string
+		CanTransition    bool
+		TransitionsLen   int
+	}{
+		{
+			Name:             "none to created",
+			ResKnownStatus:   taskresource.ResourceStatus(cgroup.CgroupStatusNone),
+			ResDesiredStatus: taskresource.ResourceStatus(cgroup.CgroupCreated),
+			TransitionStatus: taskresource.ResourceStatus(cgroup.CgroupCreated),
+			StatusString:     "CREATED",
+			CanTransition:    true,
+			TransitionsLen:   1,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			res := &cgroup.CgroupResource{}
+			res.SetKnownStatus(tc.ResKnownStatus)
+			res.SetDesiredStatus(tc.ResDesiredStatus)
+
+			task := &managedTask{
+				Task: &api.Task{
+					Resources:           []taskresource.TaskResource{res},
+					DesiredStatusUnsafe: api.TaskRunning,
+				},
+			}
+			wg := sync.WaitGroup{}
+			wg.Add(1)
+			canTransition, transitions := task.startResourceTransitions(
+				func(resource taskresource.TaskResource, nextStatus taskresource.ResourceStatus) {
+					assert.Equal(t, nextStatus, tc.TransitionStatus)
+					wg.Done()
+				})
+			wg.Wait()
+			assert.Equal(t, tc.CanTransition, canTransition)
+			assert.Len(t, transitions, tc.TransitionsLen)
+			resTransition, ok := transitions["cgroup"]
+			assert.True(t, ok)
+			assert.Equal(t, resTransition, tc.StatusString)
+		})
+	}
+}
+
+func TestStartResourceTransitionsEmpty(t *testing.T) {
+	testCases := []struct {
+		Name          string
+		KnownStatus   taskresource.ResourceStatus
+		DesiredStatus taskresource.ResourceStatus
+		CanTransition bool
+	}{
+		{
+			Name:          "known < desired",
+			KnownStatus:   taskresource.ResourceStatus(cgroup.CgroupCreated),
+			DesiredStatus: taskresource.ResourceStatus(cgroup.CgroupRemoved),
+			CanTransition: true,
+		},
+		{
+			Name:          "known equals desired",
+			KnownStatus:   taskresource.ResourceStatus(cgroup.CgroupCreated),
+			DesiredStatus: taskresource.ResourceStatus(cgroup.CgroupCreated),
+			CanTransition: false,
+		},
+		{
+			Name:          "known > desired",
+			KnownStatus:   taskresource.ResourceStatus(cgroup.CgroupRemoved),
+			DesiredStatus: taskresource.ResourceStatus(cgroup.CgroupCreated),
+			CanTransition: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.TODO())
+			defer cancel()
+			res := &cgroup.CgroupResource{}
+			res.SetKnownStatus(tc.KnownStatus)
+			res.SetDesiredStatus(tc.DesiredStatus)
+
+			task := &managedTask{
+				Task: &api.Task{
+					Resources:           []taskresource.TaskResource{res},
+					DesiredStatusUnsafe: api.TaskRunning,
+				},
+				ctx: ctx,
+				resourceStateChangeEvent: make(chan resourceStateChange),
+			}
+			canTransition, transitions := task.startResourceTransitions(
+				func(resource taskresource.TaskResource, nextStatus taskresource.ResourceStatus) {
+					t.Error("Transition function should not be called when no transitions are possible")
+				})
+			assert.Equal(t, tc.CanTransition, canTransition)
+			assert.Empty(t, transitions)
+		})
+	}
+}

--- a/agent/taskresource/interface.go
+++ b/agent/taskresource/interface.go
@@ -21,6 +21,15 @@ import (
 // ResourceStatus is an enumeration of valid states of task resource lifecycle
 type ResourceStatus int32
 
+const (
+	// ResourceStatusNone is the zero state of a task resource
+	ResourceStatusNone ResourceStatus = iota
+	// ResourceCreated represents state where task resource has been created
+	ResourceCreated
+	// ResourceRemoved represents state where task resource has been cleaned up
+	ResourceRemoved
+)
+
 // TaskResource is a wrapper for task level resource methods we need
 type TaskResource interface {
 	// SetDesiredStatus sets the desired status of the resource
@@ -41,6 +50,23 @@ type TaskResource interface {
 	Cleanup() error
 	// GetName returns the unique name of the resource
 	GetName() string
+	// DesiredTeminal returns true if remove is in terminal state
+	DesiredTerminal() bool
+	// KnownCreated returns true if resource state is CREATED
+	KnownCreated() bool
+	// TerminalStatus returns the last transition state of the resource
+	TerminalStatus() ResourceStatus
+	// NextKnownState returns resource's next state
+	NextKnownState() ResourceStatus
+	// ApplyTransition calls the function required to move to the specified status
+	ApplyTransition(ResourceStatus) error
+	// SteadyState returns the transition state of the resource defined as "ready"
+	SteadyState() ResourceStatus
+	// SetAppliedStatus sets the applied status of resource and returns whether
+	// the resource is already in a transition
+	SetAppliedStatus(status ResourceStatus) bool
+	// StatusString returns the string of the resource status
+	StatusString(status ResourceStatus) string
 
 	json.Marshaler
 	json.Unmarshaler

--- a/agent/taskresource/mocks/taskresource_mocks.go
+++ b/agent/taskresource/mocks/taskresource_mocks.go
@@ -48,6 +48,18 @@ func (m *MockTaskResource) EXPECT() *MockTaskResourceMockRecorder {
 	return m.recorder
 }
 
+// ApplyTransition mocks base method
+func (m *MockTaskResource) ApplyTransition(arg0 taskresource.ResourceStatus) error {
+	ret := m.ctrl.Call(m, "ApplyTransition", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplyTransition indicates an expected call of ApplyTransition
+func (mr *MockTaskResourceMockRecorder) ApplyTransition(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyTransition", reflect.TypeOf((*MockTaskResource)(nil).ApplyTransition), arg0)
+}
+
 // Cleanup mocks base method
 func (m *MockTaskResource) Cleanup() error {
 	ret := m.ctrl.Call(m, "Cleanup")
@@ -70,6 +82,18 @@ func (m *MockTaskResource) Create() error {
 // Create indicates an expected call of Create
 func (mr *MockTaskResourceMockRecorder) Create() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockTaskResource)(nil).Create))
+}
+
+// DesiredTerminal mocks base method
+func (m *MockTaskResource) DesiredTerminal() bool {
+	ret := m.ctrl.Call(m, "DesiredTerminal")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// DesiredTerminal indicates an expected call of DesiredTerminal
+func (mr *MockTaskResourceMockRecorder) DesiredTerminal() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DesiredTerminal", reflect.TypeOf((*MockTaskResource)(nil).DesiredTerminal))
 }
 
 // GetCreatedAt mocks base method
@@ -120,6 +144,18 @@ func (mr *MockTaskResourceMockRecorder) GetName() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetName", reflect.TypeOf((*MockTaskResource)(nil).GetName))
 }
 
+// KnownCreated mocks base method
+func (m *MockTaskResource) KnownCreated() bool {
+	ret := m.ctrl.Call(m, "KnownCreated")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// KnownCreated indicates an expected call of KnownCreated
+func (mr *MockTaskResourceMockRecorder) KnownCreated() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KnownCreated", reflect.TypeOf((*MockTaskResource)(nil).KnownCreated))
+}
+
 // MarshalJSON mocks base method
 func (m *MockTaskResource) MarshalJSON() ([]byte, error) {
 	ret := m.ctrl.Call(m, "MarshalJSON")
@@ -131,6 +167,30 @@ func (m *MockTaskResource) MarshalJSON() ([]byte, error) {
 // MarshalJSON indicates an expected call of MarshalJSON
 func (mr *MockTaskResourceMockRecorder) MarshalJSON() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarshalJSON", reflect.TypeOf((*MockTaskResource)(nil).MarshalJSON))
+}
+
+// NextKnownState mocks base method
+func (m *MockTaskResource) NextKnownState() taskresource.ResourceStatus {
+	ret := m.ctrl.Call(m, "NextKnownState")
+	ret0, _ := ret[0].(taskresource.ResourceStatus)
+	return ret0
+}
+
+// NextKnownState indicates an expected call of NextKnownState
+func (mr *MockTaskResourceMockRecorder) NextKnownState() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NextKnownState", reflect.TypeOf((*MockTaskResource)(nil).NextKnownState))
+}
+
+// SetAppliedStatus mocks base method
+func (m *MockTaskResource) SetAppliedStatus(arg0 taskresource.ResourceStatus) bool {
+	ret := m.ctrl.Call(m, "SetAppliedStatus", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// SetAppliedStatus indicates an expected call of SetAppliedStatus
+func (mr *MockTaskResourceMockRecorder) SetAppliedStatus(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAppliedStatus", reflect.TypeOf((*MockTaskResource)(nil).SetAppliedStatus), arg0)
 }
 
 // SetCreatedAt mocks base method
@@ -161,6 +221,42 @@ func (m *MockTaskResource) SetKnownStatus(arg0 taskresource.ResourceStatus) {
 // SetKnownStatus indicates an expected call of SetKnownStatus
 func (mr *MockTaskResourceMockRecorder) SetKnownStatus(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetKnownStatus", reflect.TypeOf((*MockTaskResource)(nil).SetKnownStatus), arg0)
+}
+
+// StatusString mocks base method
+func (m *MockTaskResource) StatusString(arg0 taskresource.ResourceStatus) string {
+	ret := m.ctrl.Call(m, "StatusString", arg0)
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// StatusString indicates an expected call of StatusString
+func (mr *MockTaskResourceMockRecorder) StatusString(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StatusString", reflect.TypeOf((*MockTaskResource)(nil).StatusString), arg0)
+}
+
+// SteadyState mocks base method
+func (m *MockTaskResource) SteadyState() taskresource.ResourceStatus {
+	ret := m.ctrl.Call(m, "SteadyState")
+	ret0, _ := ret[0].(taskresource.ResourceStatus)
+	return ret0
+}
+
+// SteadyState indicates an expected call of SteadyState
+func (mr *MockTaskResourceMockRecorder) SteadyState() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SteadyState", reflect.TypeOf((*MockTaskResource)(nil).SteadyState))
+}
+
+// TerminalStatus mocks base method
+func (m *MockTaskResource) TerminalStatus() taskresource.ResourceStatus {
+	ret := m.ctrl.Call(m, "TerminalStatus")
+	ret0, _ := ret[0].(taskresource.ResourceStatus)
+	return ret0
+}
+
+// TerminalStatus indicates an expected call of TerminalStatus
+func (mr *MockTaskResourceMockRecorder) TerminalStatus() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TerminalStatus", reflect.TypeOf((*MockTaskResource)(nil).TerminalStatus))
 }
 
 // UnmarshalJSON mocks base method


### PR DESCRIPTION
### Summary
This PR addresses transition of task resources for creation and deletion. 

### Implementation details
Resource transition follows similar logic as today's container transition. 

Some key implementation changes: 
- `progressTask` (earlier called `progressContainers`) will now wait for at least one of either container or resource transition to complete
- If resource creation fails, the desired status of task is marked as STOPPED.  
- No transition function is called for a resource's terminal status (resource removed/cleaned). Instead resources will be cleaned up in `deleteTask` operation. This ensures that we do not block task stop (waiting for resources to be cleaned). 

TODO
- [x] Implement `String()` for `ResourceStatus` 
- [x] Add unit tests for new methods 

### Testing
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
