### PR TITLE
[wip] acs, eni, api: update acs model, pass s/n gw address to cni config

### DIFF
--- a/agent/acs/model/api/api-2.json
+++ b/agent/acs/model/api/api-2.json
@@ -188,6 +188,10 @@
       }
     },
     "Double":{"type":"double"},
+    "DriverType":{
+      "type":"string",
+      "enum":["Docker"]
+    },
     "ECRAuthData":{
       "type":"structure",
       "members":{
@@ -207,7 +211,8 @@
         "ipv6Addresses":{"shape":"IPv6AddressList"},
         "domainName":{"shape":"StringList"},
         "domainNameServers":{"shape":"StringList"},
-        "privateDnsName":{"shape":"String"}
+        "privateDnsName":{"shape":"String"},
+        "subnetGatewayIpv4Address":{"shape":"String"}
       }
     },
     "ElasticNetworkInterfaceList":{
@@ -415,6 +420,11 @@
       "type":"list",
       "member":{"shape":"String"}
     },
+    "StringMap":{
+      "type":"map",
+      "key":{"shape":"String"},
+      "value":{"shape":"String"}
+    },
     "Task":{
       "type":"structure",
       "members":{
@@ -463,7 +473,11 @@
       "type":"structure",
       "members":{
         "name":{"shape":"String"},
-        "host":{"shape":"HostVolumeProperties"}
+        "host":{"shape":"HostVolumeProperties"},
+        "driver":{"shape":"String"},
+        "driverOpts":{"shape":"StringMap"},
+        "labels":{"shape":"StringMap"},
+        "driverType":{"shape":"DriverType"}
       }
     },
     "VolumeFrom":{

--- a/agent/acs/model/ecsacs/api.go
+++ b/agent/acs/model/ecsacs/api.go
@@ -219,6 +219,8 @@ type ElasticNetworkInterface struct {
 	MacAddress *string `locationName:"macAddress" type:"string"`
 
 	PrivateDnsName *string `locationName:"privateDnsName" type:"string"`
+
+	SubnetGatewayIpv4Address *string `locationName:"subnetGatewayIpv4Address" type:"string"`
 }
 
 // String returns the string representation
@@ -742,7 +744,15 @@ func (s VersionInfo) GoString() string {
 type Volume struct {
 	_ struct{} `type:"structure"`
 
+	Driver *string `locationName:"driver" type:"string"`
+
+	DriverOpts map[string]*string `locationName:"driverOpts" type:"map"`
+
+	DriverType *string `locationName:"driverType" type:"string" enum:"DriverType"`
+
 	Host *HostVolumeProperties `locationName:"host" type:"structure"`
+
+	Labels map[string]*string `locationName:"labels" type:"map"`
 
 	Name *string `locationName:"name" type:"string"`
 }

--- a/agent/api/eni.go
+++ b/agent/api/eni.go
@@ -41,6 +41,9 @@ type ENI struct {
 
 	// PrivateDNSName is the dns name assigned by the vpc to this eni
 	PrivateDNSName string `json:",omitempty"`
+	// SubnetGatewayIPV4Address is the address to the subnet gateway for
+	// the eni
+	SubnetGatewayIPV4Address string `json:",omitempty"`
 }
 
 // GetIPV4Addresses returns a list of ipv4 addresses allocated to the ENI
@@ -66,6 +69,11 @@ func (eni *ENI) GetIPV6Addresses() []string {
 // GetHostname returns the hostname assigned to the ENI
 func (eni *ENI) GetHostname() string {
 	return eni.PrivateDNSName
+}
+
+// GetSubnetGatewayIPV4Address returns the hostname assigned to the ENI
+func (eni *ENI) GetSubnetGatewayIPV4Address() string {
+	return eni.SubnetGatewayIPV4Address
 }
 
 // String returns a human readable version of the ENI object
@@ -124,11 +132,12 @@ func ENIFromACS(acsenis []*ecsacs.ElasticNetworkInterface) (*ENI, error) {
 	}
 
 	eni := &ENI{
-		ID:             aws.StringValue(acsenis[0].Ec2Id),
-		IPV4Addresses:  ipv4,
-		IPV6Addresses:  ipv6,
-		MacAddress:     aws.StringValue(acsenis[0].MacAddress),
-		PrivateDNSName: aws.StringValue(acsenis[0].PrivateDnsName),
+		ID:                       aws.StringValue(acsenis[0].Ec2Id),
+		IPV4Addresses:            ipv4,
+		IPV6Addresses:            ipv6,
+		MacAddress:               aws.StringValue(acsenis[0].MacAddress),
+		PrivateDNSName:           aws.StringValue(acsenis[0].PrivateDnsName),
+		SubnetGatewayIPV4Address: aws.StringValue(acsenis[0].SubnetGatewayIpv4Address),
 	}
 	for _, nameserverIP := range acsenis[0].DomainNameServers {
 		eni.DomainNameServers = append(eni.DomainNameServers, aws.StringValue(nameserverIP))

--- a/agent/api/task.go
+++ b/agent/api/task.go
@@ -254,6 +254,7 @@ func (task *Task) BuildCNIConfig() (*ecscni.Config, error) {
 	cfg.ENIID = eni.ID
 	cfg.ID = eni.MacAddress
 	cfg.ENIMACAddress = eni.MacAddress
+	cfg.SubnetGatewayIPV4Address = eni.GetSubnetGatewayIPV4Address()
 	for _, ipv4 := range eni.IPV4Addresses {
 		if ipv4.Primary {
 			cfg.ENIIPV4Address = ipv4.Address

--- a/agent/ecscni/types.go
+++ b/agent/ecscni/types.go
@@ -151,4 +151,7 @@ type Config struct {
 	BlockInstanceMetdata bool
 	// AdditionalLocalRoutes specifies additional routes to be added to the task namespace
 	AdditionalLocalRoutes []cnitypes.IPNet
+	// WIP
+	// SubnetGatewayIPV4Address is the address to the subnet gate for the eni
+	SubnetGatewayIPV4Address string
 }


### PR DESCRIPTION
### Summary
<!-- What does this pull request do? -->
This PR includes two main changes:
* consume latest acs models, note that this model update brings in volume driver changes as well
* pass s/n gw address from acs eni payload to cni plugin via config

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [ ] Builds on Linux (`make release`)
- [ ] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [ ] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
