### PR TITLE
docker_client moved into dockerapi pkg

### DIFF
--- a/agent/api/container.go
+++ b/agent/api/container.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"time"
 
+	apierrors "github.com/aws/amazon-ecs-agent/agent/api/errors"
 	"github.com/aws/amazon-ecs-agent/agent/credentials"
 	"github.com/aws/amazon-ecs-agent/agent/ecr"
 	"github.com/aws/aws-sdk-go/aws"
@@ -160,7 +161,7 @@ type Container struct {
 	// ApplyingError is an error that occurred trying to transition the container
 	// to its desired state. It is propagated to the backend in the form
 	// 'Name: ErrorString' as the 'reason' field.
-	ApplyingError *DefaultNamedError
+	ApplyingError *apierrors.DefaultNamedError
 
 	// SentStatusUnsafe represents the last KnownStatusUnsafe that was sent to the ECS
 	// SubmitContainerStateChange API.

--- a/agent/api/containeroverrides.go
+++ b/agent/api/containeroverrides.go
@@ -17,6 +17,7 @@ import (
 	"encoding/json"
 	"errors"
 
+	apierrors "github.com/aws/amazon-ecs-agent/agent/api/errors"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 )
 
@@ -49,14 +50,14 @@ func (overrides *ContainerOverrides) UnmarshalJSON(b []byte) error {
 			*overrides = ContainerOverrides(regular)
 			return nil
 		}
-		err = utils.NewMultiError(errors.New("Error unmarshalling ContainerOverrides"), err)
+		err = apierrors.NewMultiError(errors.New("Error unmarshalling ContainerOverrides"), err)
 	}
 
 	// Now the strongly typed way
 	var str string
 	err2 := json.Unmarshal(b, &str)
 	if err2 != nil {
-		return utils.NewMultiError(errors.New("Could not unmarshal ContainerOverrides into either an object or string respectively"), err, err2)
+		return apierrors.NewMultiError(errors.New("Could not unmarshal ContainerOverrides into either an object or string respectively"), err, err2)
 	}
 
 	// We have a string, let's try to unmarshal that into a typed object
@@ -67,8 +68,8 @@ func (overrides *ContainerOverrides) UnmarshalJSON(b []byte) error {
 			*overrides = ContainerOverrides(regular)
 			return nil
 		}
-		err3 = utils.NewMultiError(errors.New("Error unmarshalling ContainerOverrides"), err3)
+		err3 = apierrors.NewMultiError(errors.New("Error unmarshalling ContainerOverrides"), err3)
 	}
 
-	return utils.NewMultiError(errors.New("Could not unmarshal ContainerOverrides in any supported way"), err, err2, err3)
+	return apierrors.NewMultiError(errors.New("Could not unmarshal ContainerOverrides in any supported way"), err, err2, err3)
 }

--- a/agent/api/ecsclient/client.go
+++ b/agent/api/ecsclient/client.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
+	apierrors "github.com/aws/amazon-ecs-agent/agent/api/errors"
 	"github.com/aws/amazon-ecs-agent/agent/async"
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/ec2"
@@ -237,7 +238,7 @@ func findMissingAttributes(expectedAttributes, actualAttributes map[string]strin
 		}
 	}
 	if len(missingAttributes) > 0 {
-		err = utils.NewAttributeError("Attribute validation failed")
+		err = apierrors.NewAttributeError("Attribute validation failed")
 	}
 	return missingAttributes, err
 }

--- a/agent/api/errors/error_types.go
+++ b/agent/api/errors/error_types.go
@@ -11,12 +11,18 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package utils
+package errors
 
 import (
 	"fmt"
 	"strings"
 )
+
+// NamedError defines an interface that wraps error and add additional 'ErrorName' method
+type NamedError interface {
+	error
+	ErrorName() string
+}
 
 // Retriable defines an interface for retriable methods
 type Retriable interface {

--- a/agent/api/errors/errors.go
+++ b/agent/api/errors/errors.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package api
+package errors
 
 import (
 	"strings"
@@ -33,19 +33,18 @@ func IsInstanceTypeChangedError(err error) bool {
 	return false
 }
 
-type badVolumeError struct {
-	msg string
+// BadVolumeError represents an error caused by bad volume
+type BadVolumeError struct {
+	Msg string
 }
 
-func (err *badVolumeError) Error() string     { return err.msg }
-func (err *badVolumeError) ErrorName() string { return "InvalidVolumeError" }
-func (err *badVolumeError) Retry() bool       { return false }
+func (err *BadVolumeError) Error() string { return err.Msg }
 
-// NamedError defines an interface that wraps error and add additional 'ErrorName' method
-type NamedError interface {
-	error
-	ErrorName() string
-}
+// ErrorName returns name of the BadVolumeError
+func (err *BadVolumeError) ErrorName() string { return "InvalidVolumeError" }
+
+// Retry implements Retirable interface
+func (err *BadVolumeError) Retry() bool { return false }
 
 // DefaultNamedError is a wrapper type for 'error' which adds an optional name and provides a symmetric
 // marshal/unmarshal
@@ -77,22 +76,22 @@ func NewNamedError(err error) *DefaultNamedError {
 
 // HostConfigError represents an error caused by host configuration
 type HostConfigError struct {
-	msg string
+	Msg string
 }
 
 // Error returns the error as a string
-func (err *HostConfigError) Error() string { return err.msg }
+func (err *HostConfigError) Error() string { return err.Msg }
 
 // ErrorName returns the name of the error
 func (err *HostConfigError) ErrorName() string { return "HostConfigError" }
 
 // DockerClientConfigError represents the error caused by docker client
 type DockerClientConfigError struct {
-	msg string
+	Msg string
 }
 
 // Error returns the error as a string
-func (err *DockerClientConfigError) Error() string { return err.msg }
+func (err *DockerClientConfigError) Error() string { return err.Msg }
 
 // ErrorName returns the name of the error
 func (err *DockerClientConfigError) ErrorName() string { return "DockerClientConfigError" }

--- a/agent/api/port_binding.go
+++ b/agent/api/port_binding.go
@@ -16,6 +16,7 @@ package api
 import (
 	"strconv"
 
+	apierrors "github.com/aws/amazon-ecs-agent/agent/api/errors"
 	"github.com/fsouza/go-dockerclient"
 )
 
@@ -40,23 +41,23 @@ type PortBinding struct {
 
 // PortBindingFromDockerPortBinding constructs a PortBinding slice from a docker
 // NetworkSettings.Ports map.
-func PortBindingFromDockerPortBinding(dockerPortBindings map[docker.Port][]docker.PortBinding) ([]PortBinding, NamedError) {
+func PortBindingFromDockerPortBinding(dockerPortBindings map[docker.Port][]docker.PortBinding) ([]PortBinding, apierrors.NamedError) {
 	portBindings := make([]PortBinding, 0, len(dockerPortBindings))
 
 	for port, bindings := range dockerPortBindings {
 		containerPort, err := strconv.Atoi(port.Port())
 		if err != nil {
-			return nil, &DefaultNamedError{Name: UnparseablePortErrorName, Err: "Error parsing docker port as int " + err.Error()}
+			return nil, &apierrors.DefaultNamedError{Name: UnparseablePortErrorName, Err: "Error parsing docker port as int " + err.Error()}
 		}
 		protocol, err := NewTransportProtocol(port.Proto())
 		if err != nil {
-			return nil, &DefaultNamedError{Name: UnrecognizedTransportProtocolErrorName, Err: err.Error()}
+			return nil, &apierrors.DefaultNamedError{Name: UnrecognizedTransportProtocolErrorName, Err: err.Error()}
 		}
 
 		for _, binding := range bindings {
 			hostPort, err := strconv.Atoi(binding.HostPort)
 			if err != nil {
-				return nil, &DefaultNamedError{Name: UnparseablePortErrorName, Err: "Error parsing port binding as int " + err.Error()}
+				return nil, &apierrors.DefaultNamedError{Name: UnparseablePortErrorName, Err: "Error parsing port binding as int " + err.Error()}
 			}
 			portBindings = append(portBindings, PortBinding{
 				ContainerPort: uint16(containerPort),

--- a/agent/api/port_binding_test.go
+++ b/agent/api/port_binding_test.go
@@ -17,6 +17,7 @@ import (
 	"reflect"
 	"testing"
 
+	apierrors "github.com/aws/amazon-ecs-agent/agent/api/errors"
 	docker "github.com/fsouza/go-dockerclient"
 )
 
@@ -112,7 +113,7 @@ func TestPortBindingErrors(t *testing.T) {
 		if err == nil {
 			t.Errorf("Expected error converting port binding pair #%v", i)
 		}
-		namedErr, ok := err.(NamedError)
+		namedErr, ok := err.(apierrors.NamedError)
 		if !ok {
 			t.Errorf("Expected err to implement NamedError")
 		}

--- a/agent/api/task.go
+++ b/agent/api/task.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/acs/model/ecsacs"
+	apierrors "github.com/aws/amazon-ecs-agent/agent/api/errors"
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/credentials"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient"
@@ -418,14 +419,14 @@ func (task *Task) getEarliestKnownTaskStatusForContainers() TaskStatus {
 
 // DockerConfig converts the given container in this task to the format of
 // GoDockerClient's 'Config' struct
-func (task *Task) DockerConfig(container *Container, apiVersion dockerclient.DockerVersion) (*docker.Config, *DockerClientConfigError) {
+func (task *Task) DockerConfig(container *Container, apiVersion dockerclient.DockerVersion) (*docker.Config, *apierrors.DockerClientConfigError) {
 	return task.dockerConfig(container, apiVersion)
 }
 
-func (task *Task) dockerConfig(container *Container, apiVersion dockerclient.DockerVersion) (*docker.Config, *DockerClientConfigError) {
+func (task *Task) dockerConfig(container *Container, apiVersion dockerclient.DockerVersion) (*docker.Config, *apierrors.DockerClientConfigError) {
 	dockerVolumes, err := task.dockerConfigVolumes(container)
 	if err != nil {
-		return nil, &DockerClientConfigError{err.Error()}
+		return nil, &apierrors.DockerClientConfigError{err.Error()}
 	}
 
 	dockerEnv := make([]string, 0, len(container.Environment))
@@ -455,17 +456,17 @@ func (task *Task) dockerConfig(container *Container, apiVersion dockerclient.Doc
 
 	err = task.SetConfigHostconfigBasedOnVersion(container, config, nil, apiVersion)
 	if err != nil {
-		return nil, &DockerClientConfigError{"setting docker config failed, err: " + err.Error()}
+		return nil, &apierrors.DockerClientConfigError{"setting docker config failed, err: " + err.Error()}
 	}
 
 	if container.DockerConfig.Config != nil {
 		err := json.Unmarshal([]byte(aws.StringValue(container.DockerConfig.Config)), &config)
 		if err != nil {
-			return nil, &DockerClientConfigError{"Unable decode given docker config: " + err.Error()}
+			return nil, &apierrors.DockerClientConfigError{"Unable decode given docker config: " + err.Error()}
 		}
 	}
 	if container.HealthCheckType == dockerHealthCheckType && config.Healthcheck == nil {
-		return nil, &DockerClientConfigError{
+		return nil, &apierrors.DockerClientConfigError{
 			"docker health check is nil while container health check type is DOCKER"}
 	}
 
@@ -534,7 +535,7 @@ func (task *Task) dockerConfigVolumes(container *Container) (map[string]struct{}
 	for _, m := range container.MountPoints {
 		vol, exists := task.HostVolumeByName(m.SourceVolume)
 		if !exists {
-			return nil, &badVolumeError{"Container " + container.Name + " in task " + task.Arn + " references invalid volume " + m.SourceVolume}
+			return nil, &apierrors.BadVolumeError{"Container " + container.Name + " in task " + task.Arn + " references invalid volume " + m.SourceVolume}
 		}
 		// you can handle most volume mount types in the HostConfig at run-time;
 		// empty mounts are created by docker at create-time (Config) so set
@@ -543,7 +544,7 @@ func (task *Task) dockerConfigVolumes(container *Container) (map[string]struct{}
 			// if container.Name == emptyHostVolumeName && container.Type {
 			_, ok := vol.(*EmptyHostVolume)
 			if !ok {
-				return nil, &badVolumeError{"Empty volume container in task " + task.Arn + " was the wrong type"}
+				return nil, &apierrors.BadVolumeError{"Empty volume container in task " + task.Arn + " was the wrong type"}
 			}
 
 			volumeMap[m.ContainerPath] = struct{}{}
@@ -553,17 +554,17 @@ func (task *Task) dockerConfigVolumes(container *Container) (map[string]struct{}
 }
 
 // DockerHostConfig construct the configuration recognized by docker
-func (task *Task) DockerHostConfig(container *Container, dockerContainerMap map[string]*DockerContainer, apiVersion dockerclient.DockerVersion) (*docker.HostConfig, *HostConfigError) {
+func (task *Task) DockerHostConfig(container *Container, dockerContainerMap map[string]*DockerContainer, apiVersion dockerclient.DockerVersion) (*docker.HostConfig, *apierrors.HostConfigError) {
 	return task.dockerHostConfig(container, dockerContainerMap, apiVersion)
 }
 
 // ApplyExecutionRoleLogsAuth will check whether the task has execution role
 // credentials, and add the genereated credentials endpoint to the associated HostConfig
-func (task *Task) ApplyExecutionRoleLogsAuth(hostConfig *docker.HostConfig, credentialsManager credentials.Manager) *HostConfigError {
+func (task *Task) ApplyExecutionRoleLogsAuth(hostConfig *docker.HostConfig, credentialsManager credentials.Manager) *apierrors.HostConfigError {
 	id := task.GetExecutionCredentialsID()
 	if id == "" {
 		// No execution credentials set for the task. Do not inject the endpoint environment variable.
-		return &HostConfigError{"No execution credentials set for the task"}
+		return &apierrors.HostConfigError{"No execution credentials set for the task"}
 	}
 
 	executionRoleCredentials, ok := credentialsManager.GetTaskCredentials(id)
@@ -572,29 +573,29 @@ func (task *Task) ApplyExecutionRoleLogsAuth(hostConfig *docker.HostConfig, cred
 		// the id. This should never happen as the payload handler sets
 		// credentialsId for the task after adding credentials to the
 		// credentials manager
-		return &HostConfigError{"Unable to get execution role credentials for task"}
+		return &apierrors.HostConfigError{"Unable to get execution role credentials for task"}
 	}
 	credentialsEndpointRelativeURI := executionRoleCredentials.IAMRoleCredentials.GenerateCredentialsEndpointRelativeURI()
 	hostConfig.LogConfig.Config[awslogsCredsEndpointOpt] = credentialsEndpointRelativeURI
 	return nil
 }
 
-func (task *Task) dockerHostConfig(container *Container, dockerContainerMap map[string]*DockerContainer, apiVersion dockerclient.DockerVersion) (*docker.HostConfig, *HostConfigError) {
+func (task *Task) dockerHostConfig(container *Container, dockerContainerMap map[string]*DockerContainer, apiVersion dockerclient.DockerVersion) (*docker.HostConfig, *apierrors.HostConfigError) {
 	dockerLinkArr, err := task.dockerLinks(container, dockerContainerMap)
 	if err != nil {
-		return nil, &HostConfigError{err.Error()}
+		return nil, &apierrors.HostConfigError{err.Error()}
 	}
 
 	dockerPortMap := task.dockerPortMap(container)
 
 	volumesFrom, err := task.dockerVolumesFrom(container, dockerContainerMap)
 	if err != nil {
-		return nil, &HostConfigError{err.Error()}
+		return nil, &apierrors.HostConfigError{err.Error()}
 	}
 
 	binds, err := task.dockerHostBinds(container)
 	if err != nil {
-		return nil, &HostConfigError{err.Error()}
+		return nil, &apierrors.HostConfigError{err.Error()}
 	}
 
 	// Populate hostConfig
@@ -607,19 +608,19 @@ func (task *Task) dockerHostConfig(container *Container, dockerContainerMap map[
 
 	err = task.SetConfigHostconfigBasedOnVersion(container, nil, hostConfig, apiVersion)
 	if err != nil {
-		return nil, &HostConfigError{err.Error()}
+		return nil, &apierrors.HostConfigError{err.Error()}
 	}
 
 	if container.DockerConfig.HostConfig != nil {
 		err := json.Unmarshal([]byte(*container.DockerConfig.HostConfig), hostConfig)
 		if err != nil {
-			return nil, &HostConfigError{"Unable to decode given host config: " + err.Error()}
+			return nil, &apierrors.HostConfigError{"Unable to decode given host config: " + err.Error()}
 		}
 	}
 
 	err = task.platformHostConfigOverride(hostConfig)
 	if err != nil {
-		return nil, &HostConfigError{err.Error()}
+		return nil, &apierrors.HostConfigError{err.Error()}
 	}
 
 	// Determine if network mode should be overridden and override it if needed

--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -22,12 +22,14 @@ import (
 	acshandler "github.com/aws/amazon-ecs-agent/agent/acs/handler"
 	"github.com/aws/amazon-ecs-agent/agent/api"
 	"github.com/aws/amazon-ecs-agent/agent/api/ecsclient"
+	apierrors "github.com/aws/amazon-ecs-agent/agent/api/errors"
 	"github.com/aws/amazon-ecs-agent/agent/app/factory"
 	"github.com/aws/amazon-ecs-agent/agent/app/oswrapper"
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/containermetadata"
 	"github.com/aws/amazon-ecs-agent/agent/credentials"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/clientfactory"
+	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	"github.com/aws/amazon-ecs-agent/agent/ec2"
 	"github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
 	"github.com/aws/amazon-ecs-agent/agent/ecscni"
@@ -44,7 +46,6 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/statemanager"
 	"github.com/aws/amazon-ecs-agent/agent/stats"
 	"github.com/aws/amazon-ecs-agent/agent/tcs/handler"
-	"github.com/aws/amazon-ecs-agent/agent/utils"
 	"github.com/aws/amazon-ecs-agent/agent/version"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -90,7 +91,7 @@ type ecsAgent struct {
 	ctx                   context.Context
 	ec2MetadataClient     ec2.EC2MetadataClient
 	cfg                   *config.Config
-	dockerClient          engine.DockerClient
+	dockerClient          dockerapi.DockerClient
 	containerInstanceARN  string
 	credentialProvider    *aws_credentials.Credentials
 	stateManagerFactory   factory.StateManager
@@ -132,7 +133,7 @@ func newAgent(
 	seelog.Infof("Amazon ECS agent Version: %s, Commit: %s", version.Version, version.GitShortHash)
 	seelog.Debugf("Loaded config: %s", cfg.String())
 
-	dockerClient, err := engine.NewDockerGoClient(clientfactory.NewFactory(cfg.DockerEndpoint), cfg)
+	dockerClient, err := dockerapi.NewDockerGoClient(clientfactory.NewFactory(cfg.DockerEndpoint), cfg)
 	if err != nil {
 		// This is also non terminal in the current config
 		seelog.Criticalf("Error creating Docker client: %v", err)
@@ -464,14 +465,14 @@ func (agent *ecsAgent) registerContainerInstance(
 	containerInstanceArn, err := client.RegisterContainerInstance("", capabilities)
 	if err != nil {
 		seelog.Errorf("Error registering: %v", err)
-		if retriable, ok := err.(utils.Retriable); ok && !retriable.Retry() {
+		if retriable, ok := err.(apierrors.Retriable); ok && !retriable.Retry() {
 			return err
 		}
 		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == ecs.ErrCodeInvalidParameterException {
 			seelog.Critical("Instance registration attempt with an invalid parameter")
 			return err
 		}
-		if _, ok := err.(utils.AttributeError); ok {
+		if _, ok := err.(apierrors.AttributeError); ok {
 			seelog.Critical("Instance registration attempt with an invalid attribute")
 			return err
 		}
@@ -493,11 +494,11 @@ func (agent *ecsAgent) reregisterContainerInstance(client api.ECSClient, capabil
 		return nil
 	}
 	seelog.Errorf("Error re-registering: %v", err)
-	if api.IsInstanceTypeChangedError(err) {
+	if apierrors.IsInstanceTypeChangedError(err) {
 		seelog.Criticalf(instanceTypeMismatchErrorFormat, err)
 		return err
 	}
-	if _, ok := err.(utils.AttributeError); ok {
+	if _, ok := err.(apierrors.AttributeError); ok {
 		seelog.Critical("Instance re-registration attempt with an invalid attribute")
 		return err
 	}

--- a/agent/app/agent_test.go
+++ b/agent/app/agent_test.go
@@ -20,7 +20,7 @@ import (
 
 	"context"
 
-	"github.com/aws/amazon-ecs-agent/agent/api"
+	apierrors "github.com/aws/amazon-ecs-agent/agent/api/errors"
 	"github.com/aws/amazon-ecs-agent/agent/api/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/app/factory/mocks"
 	app_mocks "github.com/aws/amazon-ecs-agent/agent/app/mocks"
@@ -36,7 +36,6 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/sighandlers/exitcodes"
 	"github.com/aws/amazon-ecs-agent/agent/statemanager"
 	"github.com/aws/amazon-ecs-agent/agent/statemanager/mocks"
-	"github.com/aws/amazon-ecs-agent/agent/utils"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	aws_credentials "github.com/aws/aws-sdk-go/aws/credentials"
@@ -209,7 +208,7 @@ func TestDoStartRegisterContainerInstanceErrorTerminal(t *testing.T) {
 		dockerClient.EXPECT().SupportedVersions().Return(nil),
 		dockerClient.EXPECT().KnownVersions().Return(nil),
 		client.EXPECT().RegisterContainerInstance(gomock.Any(), gomock.Any()).Return(
-			"", utils.NewAttributeError("error")),
+			"", apierrors.NewAttributeError("error")),
 	)
 
 	cfg := getTestConfig()
@@ -604,7 +603,7 @@ func TestReregisterContainerInstanceInstanceTypeChanged(t *testing.T) {
 		mockDockerClient.EXPECT().SupportedVersions().Return(nil),
 		mockDockerClient.EXPECT().KnownVersions().Return(nil),
 		client.EXPECT().RegisterContainerInstance(containerInstanceARN, gomock.Any()).Return(
-			"", awserr.New("", api.InstanceTypeChangedErrorMessage, errors.New(""))),
+			"", awserr.New("", apierrors.InstanceTypeChangedErrorMessage, errors.New(""))),
 	)
 
 	cfg := getTestConfig()
@@ -639,7 +638,7 @@ func TestReregisterContainerInstanceAttributeError(t *testing.T) {
 		mockDockerClient.EXPECT().SupportedVersions().Return(nil),
 		mockDockerClient.EXPECT().KnownVersions().Return(nil),
 		client.EXPECT().RegisterContainerInstance(containerInstanceARN, gomock.Any()).Return(
-			"", utils.NewAttributeError("error")),
+			"", apierrors.NewAttributeError("error")),
 	)
 
 	cfg := getTestConfig()
@@ -738,7 +737,7 @@ func TestRegisterContainerInstanceWhenContainerInstanceARNIsNotSetCanRetryError(
 	client := mock_api.NewMockECSClient(ctrl)
 	mockCredentialsProvider := app_mocks.NewMockProvider(ctrl)
 
-	retriableError := utils.NewRetriableError(utils.NewRetriable(true), errors.New("error"))
+	retriableError := apierrors.NewRetriableError(apierrors.NewRetriable(true), errors.New("error"))
 	gomock.InOrder(
 		mockCredentialsProvider.EXPECT().Retrieve().Return(aws_credentials.Value{}, nil),
 		mockDockerClient.EXPECT().SupportedVersions().Return(nil),
@@ -772,7 +771,7 @@ func TestRegisterContainerInstanceWhenContainerInstanceARNIsNotSetCannotRetryErr
 	client := mock_api.NewMockECSClient(ctrl)
 	mockCredentialsProvider := app_mocks.NewMockProvider(ctrl)
 
-	cannotRetryError := utils.NewRetriableError(utils.NewRetriable(false), errors.New("error"))
+	cannotRetryError := apierrors.NewRetriableError(apierrors.NewRetriable(false), errors.New("error"))
 	gomock.InOrder(
 		mockCredentialsProvider.EXPECT().Retrieve().Return(aws_credentials.Value{}, nil),
 		mockDockerClient.EXPECT().SupportedVersions().Return(nil),
@@ -811,7 +810,7 @@ func TestRegisterContainerInstanceWhenContainerInstanceARNIsNotSetAttributeError
 		mockDockerClient.EXPECT().SupportedVersions().Return(nil),
 		mockDockerClient.EXPECT().KnownVersions().Return(nil),
 		client.EXPECT().RegisterContainerInstance("", gomock.Any()).Return(
-			"", utils.NewAttributeError("error")),
+			"", apierrors.NewAttributeError("error")),
 	)
 
 	cfg := getTestConfig()

--- a/agent/app/agent_unix_test.go
+++ b/agent/app/agent_unix_test.go
@@ -27,6 +27,7 @@ import (
 	app_mocks "github.com/aws/amazon-ecs-agent/agent/app/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/app/oswrapper/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	"github.com/aws/amazon-ecs-agent/agent/ec2"
 	"github.com/aws/amazon-ecs-agent/agent/ec2/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
@@ -60,7 +61,7 @@ func TestDoStartHappyPath(t *testing.T) {
 	mockCredentialsProvider := app_mocks.NewMockProvider(ctrl)
 	var discoverEndpointsInvoked sync.WaitGroup
 	discoverEndpointsInvoked.Add(2)
-	containerChangeEvents := make(chan engine.DockerContainerChangeEvent)
+	containerChangeEvents := make(chan dockerapi.DockerContainerChangeEvent)
 
 	// These calls are expected to happen, but cannot be ordered as they are
 	// invoked via go routines, which will lead to occasional test failues
@@ -68,7 +69,7 @@ func TestDoStartHappyPath(t *testing.T) {
 	imageManager.EXPECT().StartImageCleanupProcess(gomock.Any()).MaxTimes(1)
 	mockCredentialsProvider.EXPECT().IsExpired().Return(false).AnyTimes()
 	dockerClient.EXPECT().ListContainers(gomock.Any(), gomock.Any()).Return(
-		engine.ListContainersResponse{}).AnyTimes()
+		dockerapi.ListContainersResponse{}).AnyTimes()
 	client.EXPECT().DiscoverPollEndpoint(gomock.Any()).Do(func(x interface{}) {
 		// Ensures that the test waits until acs session has bee started
 		discoverEndpointsInvoked.Done()
@@ -119,7 +120,7 @@ func TestDoStartTaskENIHappyPath(t *testing.T) {
 	defer ctrl.Finish()
 
 	cniCapabilities := []string{ecscni.CapabilityAWSVPCNetworkingMode}
-	containerChangeEvents := make(chan engine.DockerContainerChangeEvent)
+	containerChangeEvents := make(chan dockerapi.DockerContainerChangeEvent)
 
 	cniClient := mock_ecscni.NewMockCNIClient(ctrl)
 	mockCredentialsProvider := app_mocks.NewMockProvider(ctrl)
@@ -135,7 +136,7 @@ func TestDoStartTaskENIHappyPath(t *testing.T) {
 	mockCredentialsProvider.EXPECT().IsExpired().Return(false).AnyTimes()
 	dockerClient.EXPECT().Version().AnyTimes()
 	dockerClient.EXPECT().ListContainers(gomock.Any(), gomock.Any()).Return(
-		engine.ListContainersResponse{}).AnyTimes()
+		dockerapi.ListContainersResponse{}).AnyTimes()
 	imageManager.EXPECT().StartImageCleanupProcess(gomock.Any()).MaxTimes(1)
 	client.EXPECT().DiscoverPollEndpoint(gomock.Any()).Do(func(x interface{}) {
 		// Ensures that the test waits until acs session has bee started
@@ -459,7 +460,7 @@ func TestDoStartCgroupInitHappyPath(t *testing.T) {
 	mockResource := mock_resources.NewMockResource(ctrl)
 	var discoverEndpointsInvoked sync.WaitGroup
 	discoverEndpointsInvoked.Add(2)
-	containerChangeEvents := make(chan engine.DockerContainerChangeEvent)
+	containerChangeEvents := make(chan dockerapi.DockerContainerChangeEvent)
 
 	dockerClient.EXPECT().Version().AnyTimes()
 	imageManager.EXPECT().StartImageCleanupProcess(gomock.Any()).MaxTimes(1)
@@ -488,7 +489,7 @@ func TestDoStartCgroupInitHappyPath(t *testing.T) {
 		client.EXPECT().DiscoverTelemetryEndpoint(gomock.Any()).Return(
 			"tele-endpoint", nil).AnyTimes(),
 		dockerClient.EXPECT().ListContainers(gomock.Any(), gomock.Any()).Return(
-			engine.ListContainersResponse{}).AnyTimes(),
+			dockerapi.ListContainersResponse{}).AnyTimes(),
 	)
 
 	cfg := config.DefaultConfig()

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	apierrors "github.com/aws/amazon-ecs-agent/agent/api/errors"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient"
 	"github.com/aws/amazon-ecs-agent/agent/ec2"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
@@ -359,7 +360,7 @@ func environmentConfig() (Config, error) {
 	steadyStateRate, burstRate := getTaskMetadataThrottles()
 
 	if len(errs) > 0 {
-		err = utils.NewMultiError(errs...)
+		err = apierrors.NewMultiError(errs...)
 	} else {
 		err = nil
 	}
@@ -554,7 +555,7 @@ func NewConfig(ec2client ec2.EC2MetadataClient) (config *Config, err error) {
 			errs = append(errs, errTmp)
 		}
 		if len(errs) != 0 {
-			err = utils.NewMultiError(errs...)
+			err = apierrors.NewMultiError(errs...)
 		} else {
 			err = nil
 		}

--- a/agent/containermetadata/types.go
+++ b/agent/containermetadata/types.go
@@ -72,11 +72,11 @@ func (status *MetadataStatus) UnmarshalText(text []byte) error {
 }
 
 // DockerMetadataClient is a wrapper for the docker interface functions we need
-// We use this as a dummy type to be able to pass in engine.DockerClient to
+// We use this as a dummy type to be able to pass in dockerapi.DockerClient to
 // our functions without creating import cycles
 // We make it exported because we need to use it for testing (Using the MockDockerClient
 // in engine package leads to import cycles)
-// The problems described above are indications engine.DockerClient needs to be moved
+// The problems described above are indications dockerapi.DockerClient needs to be moved
 // outside the engine package
 type DockerMetadataClient interface {
 	InspectContainer(string, time.Duration) (*docker.Container, error)
@@ -98,7 +98,7 @@ type NetworkMetadata struct {
 }
 
 // DockerContainerMetadata keeps track of all metadata acquired from Docker inspection
-// Has redundancies with engine.DockerContainerMetadata but this packages all
+// Has redundancies with dockerapi.DockerContainerMetadata but this packages all
 // docker metadata we want in the service so we can change features easily
 type DockerContainerMetadata struct {
 	containerID         string

--- a/agent/dockerclient/dockerapi/docker_events_buffer.go
+++ b/agent/dockerclient/dockerapi/docker_events_buffer.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package engine
+package dockerapi
 
 import (
 	"sync"

--- a/agent/dockerclient/dockerapi/docker_events_buffer_test.go
+++ b/agent/dockerclient/dockerapi/docker_events_buffer_test.go
@@ -12,7 +12,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package engine
+package dockerapi
 
 import (
 	"strconv"

--- a/agent/dockerclient/dockerapi/errors.go
+++ b/agent/dockerclient/dockerapi/errors.go
@@ -1,0 +1,264 @@
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package dockerapi
+
+import (
+	"time"
+
+	"github.com/aws/amazon-ecs-agent/agent/dockerclient"
+	docker "github.com/fsouza/go-dockerclient"
+)
+
+const (
+	// DockerTimeoutErrorName is the name of docker timeout error.
+	DockerTimeoutErrorName = "DockerTimeoutError"
+	// CannotInspectContainerErrorName is the name of container inspect error.
+	CannotInspectContainerErrorName = "CannotInspectContainerError"
+	// CannotDescribeContainerErrorName is the name of describe container error.
+	CannotDescribeContainerErrorName = "CannotDescribeContainerError"
+)
+
+// DockerTimeoutError is an error type for describing timeouts
+type DockerTimeoutError struct {
+	// Duration is the timeout period.
+	Duration time.Duration
+	// Transition is the description of operation that timed out.
+	Transition string
+}
+
+func (err *DockerTimeoutError) Error() string {
+	return "Could not transition to " + err.Transition + "; timed out after waiting " + err.Duration.String()
+}
+
+// ErrorName returns the name of the error
+func (err *DockerTimeoutError) ErrorName() string { return DockerTimeoutErrorName }
+
+// OutOfMemoryError is a type for errors caused by running out of memory
+type OutOfMemoryError struct{}
+
+func (err OutOfMemoryError) Error() string { return "Container killed due to memory usage" }
+
+// ErrorName returns the name of the error
+func (err OutOfMemoryError) ErrorName() string { return "OutOfMemoryError" }
+
+// DockerStateError is a wrapper around the error docker puts in the '.State.Error' field of its inspect output.
+type DockerStateError struct {
+	dockerError string
+	name        string
+}
+
+// NewDockerStateError creates a DockerStateError
+func NewDockerStateError(err string) DockerStateError {
+	// Add stringmatching logic as needed to provide better output than docker
+	return DockerStateError{
+		dockerError: err,
+		name:        "DockerStateError",
+	}
+}
+
+func (err DockerStateError) Error() string {
+	return err.dockerError
+}
+
+// ErrorName returns the name of the DockerStateError.
+func (err DockerStateError) ErrorName() string {
+	return err.name
+}
+
+// CannotGetDockerClientError is a type for failing to get a specific Docker client
+type CannotGetDockerClientError struct {
+	version dockerclient.DockerVersion
+	err     error
+}
+
+func (c CannotGetDockerClientError) Error() string {
+	if c.version != "" {
+		return "(v" + string(c.version) + ") - " + c.err.Error()
+	}
+	return c.err.Error()
+}
+
+// ErrorName returns the name of the CannotGetDockerClientError.
+func (CannotGetDockerClientError) ErrorName() string {
+	return "CannotGetDockerclientError"
+}
+
+// CannotStopContainerError indicates any error when trying to stop a container
+type CannotStopContainerError struct {
+	FromError error
+}
+
+func (err CannotStopContainerError) Error() string {
+	return err.FromError.Error()
+}
+
+// ErrorName returns name of the CannotStopContainerError.
+func (err CannotStopContainerError) ErrorName() string {
+	return "CannotStopContainerError"
+}
+
+// IsRetriableError returns a boolean indicating whether the call that
+// generated the error can be retried.
+// When stopping a container, most errors that we can get should be
+// considered retriable. However, in the case where the container is
+// already stopped or doesn't exist at all, there's no sense in
+// retrying.
+func (err CannotStopContainerError) IsRetriableError() bool {
+	if _, ok := err.FromError.(*docker.NoSuchContainer); ok {
+		return false
+	}
+	if _, ok := err.FromError.(*docker.ContainerNotRunning); ok {
+		return false
+	}
+
+	return true
+}
+
+// CannotPullContainerError indicates any error when trying to pull
+// a container image
+type CannotPullContainerError struct {
+	FromError error
+}
+
+func (err CannotPullContainerError) Error() string {
+	return err.FromError.Error()
+}
+
+// ErrorName returns name of the CannotPullContainerError.
+func (err CannotPullContainerError) ErrorName() string {
+	return "CannotPullContainerError"
+}
+
+// CannotPullECRContainerError indicates any error when trying to pull
+// a container image from ECR
+type CannotPullECRContainerError struct {
+	FromError error
+}
+
+func (err CannotPullECRContainerError) Error() string {
+	return err.FromError.Error()
+}
+
+// ErrorName returns name of the CannotPullECRContainerError.
+func (err CannotPullECRContainerError) ErrorName() string {
+	return "CannotPullECRContainerError"
+}
+
+// Retry fulfills the utils.Retrier interface and allows retries to be skipped by utils.Retry* functions
+func (err CannotPullECRContainerError) Retry() bool {
+	return false
+}
+
+// CreateEmptyVolumeError indicates any error when trying create empty volume
+type CreateEmptyVolumeError struct {
+	FromError error
+}
+
+func (err CreateEmptyVolumeError) Error() string {
+	return err.FromError.Error()
+}
+
+// ErrorName returns name of the CreateEmptyVolumeError.
+func (err CreateEmptyVolumeError) ErrorName() string {
+	return "CreateEmptyVolumeError"
+}
+
+// Retry fulfills the utils.Retrier interface and allows retries to be skipped by utils.Retry* functions
+func (err CreateEmptyVolumeError) Retry() bool {
+	return false
+}
+
+// CannotCreateContainerError indicates any error when trying to create a container
+type CannotCreateContainerError struct {
+	FromError error
+}
+
+func (err CannotCreateContainerError) Error() string {
+	return err.FromError.Error()
+}
+
+// ErrorName returns name of the CannotCreateContainerError.
+func (err CannotCreateContainerError) ErrorName() string {
+	return "CannotCreateContainerError"
+}
+
+// CannotStartContainerError indicates any error when trying to start a container
+type CannotStartContainerError struct {
+	FromError error
+}
+
+func (err CannotStartContainerError) Error() string {
+	return err.FromError.Error()
+}
+
+// ErrorName returns name of the CannotStartContainerError
+func (err CannotStartContainerError) ErrorName() string {
+	return "CannotStartContainerError"
+}
+
+// CannotInspectContainerError indicates any error when trying to inspect a container
+type CannotInspectContainerError struct {
+	FromError error
+}
+
+func (err CannotInspectContainerError) Error() string {
+	return err.FromError.Error()
+}
+
+// ErrorName returns name of the CannotInspectContainerError
+func (err CannotInspectContainerError) ErrorName() string {
+	return CannotInspectContainerErrorName
+}
+
+// CannotRemoveContainerError indicates any error when trying to remove a container
+type CannotRemoveContainerError struct {
+	FromError error
+}
+
+func (err CannotRemoveContainerError) Error() string {
+	return err.FromError.Error()
+}
+
+// ErrorName returns name of the CannotRemoveContainerError
+func (err CannotRemoveContainerError) ErrorName() string {
+	return "CannotRemoveContainerError"
+}
+
+// CannotDescribeContainerError indicates any error when trying to describe a container
+type CannotDescribeContainerError struct {
+	FromError error
+}
+
+func (err CannotDescribeContainerError) Error() string {
+	return err.FromError.Error()
+}
+
+// ErrorName returns name of the CannotDescribeContainerError
+func (err CannotDescribeContainerError) ErrorName() string {
+	return CannotDescribeContainerErrorName
+}
+
+// CannotListContainersError indicates any error when trying to list containers
+type CannotListContainersError struct {
+	FromError error
+}
+
+func (err CannotListContainersError) Error() string {
+	return err.FromError.Error()
+}
+
+// ErrorName returns name of the CannotListContainersError
+func (err CannotListContainersError) ErrorName() string {
+	return "CannotListContainersError"
+}

--- a/agent/dockerclient/dockerapi/errors_test.go
+++ b/agent/dockerclient/dockerapi/errors_test.go
@@ -12,7 +12,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package engine
+package dockerapi
 
 import (
 	"errors"

--- a/agent/dockerclient/dockerapi/repotag.go
+++ b/agent/dockerclient/dockerapi/repotag.go
@@ -8,7 +8,7 @@
 //
 // Modifications are Copyright 2016 Amazon.com, Inc. or its affiliates. Licensed under the Apache License 2.0
 
-package engine
+package dockerapi
 
 import "strings"
 

--- a/agent/dockerclient/dockerapi/types.go
+++ b/agent/dockerclient/dockerapi/types.go
@@ -11,13 +11,14 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package engine
+package dockerapi
 
 import (
 	"fmt"
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
+	apierrors "github.com/aws/amazon-ecs-agent/agent/api/errors"
 	"github.com/aws/aws-sdk-go/aws"
 )
 
@@ -55,7 +56,7 @@ type DockerContainerMetadata struct {
 	PortBindings []api.PortBinding
 	// Error wraps various container transition errors and is set if engine
 	// is unable to perform any of the required container transitions
-	Error engineError
+	Error apierrors.NamedError
 	// Volumes contains volume informaton for the container
 	Volumes map[string]string
 	// Labels contains labels set for the container

--- a/agent/engine/default.go
+++ b/agent/engine/default.go
@@ -19,13 +19,14 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/containermetadata"
 	"github.com/aws/amazon-ecs-agent/agent/credentials"
+	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
 	"github.com/aws/amazon-ecs-agent/agent/resources"
 )
 
 // NewTaskEngine returns a default TaskEngine
-func NewTaskEngine(cfg *config.Config, client DockerClient,
+func NewTaskEngine(cfg *config.Config, client dockerapi.DockerClient,
 	credentialsManager credentials.Manager,
 	containerChangeEventStream *eventstream.EventStream,
 	imageManager ImageManager, state dockerstate.TaskEngineState,

--- a/agent/engine/docker_image_manager.go
+++ b/agent/engine/docker_image_manager.go
@@ -20,8 +20,10 @@ import (
 	"time"
 
 	"context"
+
 	"github.com/aws/amazon-ecs-agent/agent/api"
 	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/engine/image"
 	"github.com/aws/amazon-ecs-agent/agent/statemanager"
@@ -47,7 +49,7 @@ type ImageManager interface {
 // It also has the cleanup policy configuration.
 type dockerImageManager struct {
 	imageStates                      []*image.ImageState
-	client                           DockerClient
+	client                           dockerapi.DockerClient
 	updateLock                       sync.RWMutex
 	imageCleanupTicker               *time.Ticker
 	state                            dockerstate.TaskEngineState
@@ -62,7 +64,7 @@ type dockerImageManager struct {
 type ImageStatesForDeletion []*image.ImageState
 
 // NewImageManager returns a new ImageManager
-func NewImageManager(cfg *config.Config, client DockerClient, state dockerstate.TaskEngineState) ImageManager {
+func NewImageManager(cfg *config.Config, client dockerapi.DockerClient, state dockerstate.TaskEngineState) ImageManager {
 	return &dockerImageManager{
 		client: client,
 		state:  state,
@@ -345,7 +347,7 @@ func (imageManager *dockerImageManager) deleteImage(imageID string, imageState *
 		return
 	}
 	seelog.Infof("Removing Image: %s", imageID)
-	err := imageManager.client.RemoveImage(imageID, removeImageTimeout)
+	err := imageManager.client.RemoveImage(imageID, dockerapi.RemoveImageTimeout)
 	if err != nil {
 		if err.Error() == imageNotFoundForDeletionError {
 			seelog.Errorf("Image already removed from the instance: %v", err)

--- a/agent/engine/docker_image_manager_integ_test.go
+++ b/agent/engine/docker_image_manager_integ_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
+	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	"github.com/aws/amazon-ecs-agent/agent/statemanager"
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/stretchr/testify/assert"
@@ -667,18 +668,18 @@ func verifyImagesAreNotRemoved(imageManager *dockerImageManager, imageIDs ...str
 }
 
 func cleanupImagesHappy(imageManager *dockerImageManager) {
-	imageManager.client.RemoveContainer("test1", removeContainerTimeout)
-	imageManager.client.RemoveContainer("test2", removeContainerTimeout)
-	imageManager.client.RemoveContainer("test3", removeContainerTimeout)
+	imageManager.client.RemoveContainer("test1", dockerapi.RemoveContainerTimeout)
+	imageManager.client.RemoveContainer("test2", dockerapi.RemoveContainerTimeout)
+	imageManager.client.RemoveContainer("test3", dockerapi.RemoveContainerTimeout)
 	imageManager.client.RemoveImage(test1Image1Name, imageRemovalTimeout)
 	imageManager.client.RemoveImage(test1Image2Name, imageRemovalTimeout)
 	imageManager.client.RemoveImage(test1Image3Name, imageRemovalTimeout)
 }
 
 func cleanupImagesThreshold(imageManager *dockerImageManager) {
-	imageManager.client.RemoveContainer("test1", removeContainerTimeout)
-	imageManager.client.RemoveContainer("test2", removeContainerTimeout)
-	imageManager.client.RemoveContainer("test3", removeContainerTimeout)
+	imageManager.client.RemoveContainer("test1", dockerapi.RemoveContainerTimeout)
+	imageManager.client.RemoveContainer("test2", dockerapi.RemoveContainerTimeout)
+	imageManager.client.RemoveContainer("test3", dockerapi.RemoveContainerTimeout)
 	imageManager.client.RemoveImage(test2Image1Name, imageRemovalTimeout)
 	imageManager.client.RemoveImage(test2Image2Name, imageRemovalTimeout)
 	imageManager.client.RemoveImage(test2Image3Name, imageRemovalTimeout)

--- a/agent/engine/docker_task_engine_unix_test.go
+++ b/agent/engine/docker_task_engine_unix_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
 	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	"github.com/aws/amazon-ecs-agent/agent/emptyvolume"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/resources/mock_resources"
@@ -61,7 +62,7 @@ func TestPullEmptyVolumeImage(t *testing.T) {
 	client.EXPECT().ImportLocalEmptyVolumeImage()
 
 	metadata := taskEngine.pullContainer(task, container)
-	assert.Equal(t, DockerContainerMetadata{}, metadata, "expected empty metadata")
+	assert.Equal(t, dockerapi.DockerContainerMetadata{}, metadata, "expected empty metadata")
 }
 
 func TestDeleteTask(t *testing.T) {

--- a/agent/engine/docker_task_engine_windows_test.go
+++ b/agent/engine/docker_task_engine_windows_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
 	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	"github.com/aws/amazon-ecs-agent/agent/emptyvolume"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/statemanager/mocks"
@@ -60,7 +61,7 @@ func TestPullEmptyVolumeImage(t *testing.T) {
 	client.EXPECT().PullImage(imageName, nil)
 
 	metadata := taskEngine.pullContainer(task, container)
-	assert.Equal(t, DockerContainerMetadata{}, metadata, "expected empty metadata")
+	assert.Equal(t, dockerapi.DockerContainerMetadata{}, metadata, "expected empty metadata")
 }
 
 func TestDeleteTask(t *testing.T) {

--- a/agent/engine/engine_integ_test.go
+++ b/agent/engine/engine_integ_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/containermetadata"
 	"github.com/aws/amazon-ecs-agent/agent/credentials"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/clientfactory"
+	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	"github.com/aws/amazon-ecs-agent/agent/ec2"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
@@ -87,7 +88,7 @@ func setup(cfg *config.Config, state dockerstate.TaskEngineState, t *testing.T) 
 		t.Skip("Docker not running")
 	}
 	clientFactory := clientfactory.NewFactory(dockerEndpoint)
-	dockerClient, err := NewDockerGoClient(clientFactory, cfg)
+	dockerClient, err := dockerapi.NewDockerGoClient(clientFactory, cfg)
 	if err != nil {
 		t.Fatalf("Error creating Docker client: %v", err)
 	}
@@ -174,17 +175,17 @@ func TestDockerStateToContainerState(t *testing.T) {
 	containerMetadata = taskEngine.(*DockerTaskEngine).createContainer(testTask, container)
 	assert.NoError(t, containerMetadata.Error)
 	state, _ := client.InspectContainer(containerMetadata.DockerID)
-	assert.Equal(t, api.ContainerCreated, dockerStateToState(state.State))
+	assert.Equal(t, api.ContainerCreated, dockerapi.DockerStateToState(state.State))
 
 	containerMetadata = taskEngine.(*DockerTaskEngine).startContainer(testTask, container)
 	assert.NoError(t, containerMetadata.Error)
 	state, _ = client.InspectContainer(containerMetadata.DockerID)
-	assert.Equal(t, api.ContainerRunning, dockerStateToState(state.State))
+	assert.Equal(t, api.ContainerRunning, dockerapi.DockerStateToState(state.State))
 
 	containerMetadata = taskEngine.(*DockerTaskEngine).stopContainer(testTask, container)
 	assert.NoError(t, containerMetadata.Error)
 	state, _ = client.InspectContainer(containerMetadata.DockerID)
-	assert.Equal(t, api.ContainerStopped, dockerStateToState(state.State))
+	assert.Equal(t, api.ContainerStopped, dockerapi.DockerStateToState(state.State))
 
 	// clean up the container
 	err = taskEngine.(*DockerTaskEngine).removeContainer(testTask, container)
@@ -199,7 +200,7 @@ func TestDockerStateToContainerState(t *testing.T) {
 	containerMetadata = taskEngine.(*DockerTaskEngine).startContainer(testTask, container)
 	assert.Error(t, containerMetadata.Error)
 	state, _ = client.InspectContainer(containerMetadata.DockerID)
-	assert.Equal(t, api.ContainerStopped, dockerStateToState(state.State))
+	assert.Equal(t, api.ContainerStopped, dockerapi.DockerStateToState(state.State))
 
 	// clean up the container
 	err = taskEngine.(*DockerTaskEngine).removeContainer(testTask, container)

--- a/agent/engine/engine_mocks.go
+++ b/agent/engine/engine_mocks.go
@@ -25,6 +25,7 @@ import (
 
 	api "github.com/aws/amazon-ecs-agent/agent/api"
 	dockerclient "github.com/aws/amazon-ecs-agent/agent/dockerclient"
+	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	"github.com/aws/amazon-ecs-agent/agent/ecr"
 	image "github.com/aws/amazon-ecs-agent/agent/engine/image"
 	statechange "github.com/aws/amazon-ecs-agent/agent/statechange"
@@ -223,9 +224,9 @@ func (mr *MockDockerClientMockRecorder) APIVersion() *gomock.Call {
 }
 
 // ContainerEvents mocks base method
-func (m *MockDockerClient) ContainerEvents(arg0 context.Context) (<-chan DockerContainerChangeEvent, error) {
+func (m *MockDockerClient) ContainerEvents(arg0 context.Context) (<-chan dockerapi.DockerContainerChangeEvent, error) {
 	ret := m.ctrl.Call(m, "ContainerEvents", arg0)
-	ret0, _ := ret[0].(<-chan DockerContainerChangeEvent)
+	ret0, _ := ret[0].(<-chan dockerapi.DockerContainerChangeEvent)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -236,9 +237,9 @@ func (mr *MockDockerClientMockRecorder) ContainerEvents(arg0 interface{}) *gomoc
 }
 
 // CreateContainer mocks base method
-func (m *MockDockerClient) CreateContainer(arg0 *go_dockerclient.Config, arg1 *go_dockerclient.HostConfig, arg2 string, arg3 time.Duration) DockerContainerMetadata {
+func (m *MockDockerClient) CreateContainer(arg0 *go_dockerclient.Config, arg1 *go_dockerclient.HostConfig, arg2 string, arg3 time.Duration) dockerapi.DockerContainerMetadata {
 	ret := m.ctrl.Call(m, "CreateContainer", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(DockerContainerMetadata)
+	ret0, _ := ret[0].(dockerapi.DockerContainerMetadata)
 	return ret0
 }
 
@@ -248,10 +249,10 @@ func (mr *MockDockerClientMockRecorder) CreateContainer(arg0, arg1, arg2, arg3 i
 }
 
 // DescribeContainer mocks base method
-func (m *MockDockerClient) DescribeContainer(arg0 string) (api.ContainerStatus, DockerContainerMetadata) {
+func (m *MockDockerClient) DescribeContainer(arg0 string) (api.ContainerStatus, dockerapi.DockerContainerMetadata) {
 	ret := m.ctrl.Call(m, "DescribeContainer", arg0)
 	ret0, _ := ret[0].(api.ContainerStatus)
-	ret1, _ := ret[1].(DockerContainerMetadata)
+	ret1, _ := ret[1].(dockerapi.DockerContainerMetadata)
 	return ret0, ret1
 }
 
@@ -261,9 +262,9 @@ func (mr *MockDockerClientMockRecorder) DescribeContainer(arg0 interface{}) *gom
 }
 
 // ImportLocalEmptyVolumeImage mocks base method
-func (m *MockDockerClient) ImportLocalEmptyVolumeImage() DockerContainerMetadata {
+func (m *MockDockerClient) ImportLocalEmptyVolumeImage() dockerapi.DockerContainerMetadata {
 	ret := m.ctrl.Call(m, "ImportLocalEmptyVolumeImage")
-	ret0, _ := ret[0].(DockerContainerMetadata)
+	ret0, _ := ret[0].(dockerapi.DockerContainerMetadata)
 	return ret0
 }
 
@@ -311,9 +312,9 @@ func (mr *MockDockerClientMockRecorder) KnownVersions() *gomock.Call {
 }
 
 // ListContainers mocks base method
-func (m *MockDockerClient) ListContainers(arg0 bool, arg1 time.Duration) ListContainersResponse {
+func (m *MockDockerClient) ListContainers(arg0 bool, arg1 time.Duration) dockerapi.ListContainersResponse {
 	ret := m.ctrl.Call(m, "ListContainers", arg0, arg1)
-	ret0, _ := ret[0].(ListContainersResponse)
+	ret0, _ := ret[0].(dockerapi.ListContainersResponse)
 	return ret0
 }
 
@@ -335,9 +336,9 @@ func (mr *MockDockerClientMockRecorder) LoadImage(arg0, arg1 interface{}) *gomoc
 }
 
 // PullImage mocks base method
-func (m *MockDockerClient) PullImage(arg0 string, arg1 *ecr.RegistryAuthenticationData) DockerContainerMetadata {
+func (m *MockDockerClient) PullImage(arg0 string, arg1 *ecr.RegistryAuthenticationData) dockerapi.DockerContainerMetadata {
 	ret := m.ctrl.Call(m, "PullImage", arg0, arg1)
-	ret0, _ := ret[0].(DockerContainerMetadata)
+	ret0, _ := ret[0].(dockerapi.DockerContainerMetadata)
 	return ret0
 }
 
@@ -371,9 +372,9 @@ func (mr *MockDockerClientMockRecorder) RemoveImage(arg0, arg1 interface{}) *gom
 }
 
 // StartContainer mocks base method
-func (m *MockDockerClient) StartContainer(arg0 string, arg1 time.Duration) DockerContainerMetadata {
+func (m *MockDockerClient) StartContainer(arg0 string, arg1 time.Duration) dockerapi.DockerContainerMetadata {
 	ret := m.ctrl.Call(m, "StartContainer", arg0, arg1)
-	ret0, _ := ret[0].(DockerContainerMetadata)
+	ret0, _ := ret[0].(dockerapi.DockerContainerMetadata)
 	return ret0
 }
 
@@ -396,9 +397,9 @@ func (mr *MockDockerClientMockRecorder) Stats(arg0, arg1 interface{}) *gomock.Ca
 }
 
 // StopContainer mocks base method
-func (m *MockDockerClient) StopContainer(arg0 string, arg1 time.Duration) DockerContainerMetadata {
+func (m *MockDockerClient) StopContainer(arg0 string, arg1 time.Duration) dockerapi.DockerContainerMetadata {
 	ret := m.ctrl.Call(m, "StopContainer", arg0, arg1)
-	ret0, _ := ret[0].(DockerContainerMetadata)
+	ret0, _ := ret[0].(dockerapi.DockerContainerMetadata)
 	return ret0
 }
 
@@ -433,9 +434,9 @@ func (mr *MockDockerClientMockRecorder) Version() *gomock.Call {
 }
 
 // WithVersion mocks base method
-func (m *MockDockerClient) WithVersion(arg0 dockerclient.DockerVersion) DockerClient {
+func (m *MockDockerClient) WithVersion(arg0 dockerclient.DockerVersion) dockerapi.DockerClient {
 	ret := m.ctrl.Call(m, "WithVersion", arg0)
-	ret0, _ := ret[0].(DockerClient)
+	ret0, _ := ret[0].(dockerapi.DockerClient)
 	return ret0
 }
 

--- a/agent/engine/engine_unix_integ_test.go
+++ b/agent/engine/engine_unix_integ_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
 	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	"github.com/aws/amazon-ecs-agent/agent/statechange"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 	"github.com/aws/amazon-ecs-agent/agent/utils/ttime"
@@ -682,7 +683,7 @@ func TestInitOOMEvent(t *testing.T) {
 		t.Logf("Docker version is 1.9.x (%s); not checking OOM reason", dockerVersion)
 		return
 	}
-	if !strings.HasPrefix(contEvent.Reason, OutOfMemoryError{}.ErrorName()) {
+	if !strings.HasPrefix(contEvent.Reason, dockerapi.OutOfMemoryError{}.ErrorName()) {
 		t.Errorf("Expected reason to have OOM error, was: %v", contEvent.Reason)
 	}
 }

--- a/agent/engine/errors.go
+++ b/agent/engine/errors.go
@@ -14,28 +14,12 @@
 package engine
 
 import (
-	"time"
-
 	"github.com/aws/amazon-ecs-agent/agent/api"
-	"github.com/aws/amazon-ecs-agent/agent/dockerclient"
-	docker "github.com/fsouza/go-dockerclient"
+	apierrors "github.com/aws/amazon-ecs-agent/agent/api/errors"
 )
-
-const (
-	dockerTimeoutErrorName          = "DockerTimeoutError"
-	cannotInspectContainerErrorName = "CannotInspectContainerError"
-	cannotDescribeContainerError    = "CannotDescribeContainerError"
-)
-
-// engineError wraps the error interface with an identifier method that
-// is used to classify the error type
-type engineError interface {
-	error
-	ErrorName() string
-}
 
 type cannotStopContainerError interface {
-	engineError
+	apierrors.NamedError
 	IsRetriableError() bool
 }
 
@@ -50,19 +34,6 @@ func (err *impossibleTransitionError) Error() string {
 }
 func (err *impossibleTransitionError) ErrorName() string { return "ImpossibleStateTransitionError" }
 
-// DockerTimeoutError is an error type for describing timeouts
-type DockerTimeoutError struct {
-	duration   time.Duration
-	transition string
-}
-
-func (err *DockerTimeoutError) Error() string {
-	return "Could not transition to " + err.transition + "; timed out after waiting " + err.duration.String()
-}
-
-// ErrorName returns the name of the error
-func (err *DockerTimeoutError) ErrorName() string { return dockerTimeoutErrorName }
-
 // ContainerVanishedError is a type for describing a container that does not exist
 type ContainerVanishedError struct{}
 
@@ -70,56 +41,6 @@ func (err ContainerVanishedError) Error() string { return "No container matching
 
 // ErrorName returns the name of the error
 func (err ContainerVanishedError) ErrorName() string { return "ContainerVanishedError" }
-
-// OutOfMemoryError is a type for errors caused by running out of memory
-type OutOfMemoryError struct{}
-
-func (err OutOfMemoryError) Error() string { return "Container killed due to memory usage" }
-
-// ErrorName returns the name of the error
-func (err OutOfMemoryError) ErrorName() string { return "OutOfMemoryError" }
-
-// DockerStateError is a wrapper around the error docker puts in the '.State.Error' field of its inspect output.
-type DockerStateError struct {
-	dockerError string
-	name        string
-}
-
-// NewDockerStateError creates a DockerStateError
-func NewDockerStateError(err string) DockerStateError {
-	// Add stringmatching logic as needed to provide better output than docker
-	return DockerStateError{
-		dockerError: err,
-		name:        "DockerStateError",
-	}
-}
-
-func (err DockerStateError) Error() string {
-	return err.dockerError
-}
-
-// ErrorName returns the name of the error
-func (err DockerStateError) ErrorName() string {
-	return err.name
-}
-
-// CannotGetDockerClientError is a type for failing to get a specific Docker client
-type CannotGetDockerClientError struct {
-	version dockerclient.DockerVersion
-	err     error
-}
-
-func (c CannotGetDockerClientError) Error() string {
-	if c.version != "" {
-		return "(v" + string(c.version) + ") - " + c.err.Error()
-	}
-	return c.err.Error()
-}
-
-// ErrorName returns the name of the error
-func (CannotGetDockerClientError) ErrorName() string {
-	return "CannotGetDockerclientError"
-}
 
 // TaskDependencyError is the error for task that dependencies can't
 // be resolved
@@ -148,164 +69,6 @@ func (err TaskStoppedBeforePullBeginError) Error() string {
 // ErrorName returns the name of the error
 func (TaskStoppedBeforePullBeginError) ErrorName() string {
 	return "TaskStoppedBeforePullBeginError"
-}
-
-// CannotStopContainerError indicates any error when trying to stop a container
-type CannotStopContainerError struct {
-	fromError error
-}
-
-func (err CannotStopContainerError) Error() string {
-	return err.fromError.Error()
-}
-
-func (err CannotStopContainerError) ErrorName() string {
-	return "CannotStopContainerError"
-}
-
-// IsRetriableError returns a boolean indicating whether the call that
-// generated the error can be retried.
-// When stopping a container, most errors that we can get should be
-// considered retriable. However, in the case where the container is
-// already stopped or doesn't exist at all, there's no sense in
-// retrying.
-func (err CannotStopContainerError) IsRetriableError() bool {
-	if _, ok := err.fromError.(*docker.NoSuchContainer); ok {
-		return false
-	}
-	if _, ok := err.fromError.(*docker.ContainerNotRunning); ok {
-		return false
-	}
-
-	return true
-}
-
-// CannotPullContainerError indicates any error when trying to pull
-// a container image
-type CannotPullContainerError struct {
-	fromError error
-}
-
-func (err CannotPullContainerError) Error() string {
-	return err.fromError.Error()
-}
-
-func (err CannotPullContainerError) ErrorName() string {
-	return "CannotPullContainerError"
-}
-
-// CannotPullECRContainerError indicates any error when trying to pull
-// a container image from ECR
-type CannotPullECRContainerError struct {
-	fromError error
-}
-
-func (err CannotPullECRContainerError) Error() string {
-	return err.fromError.Error()
-}
-
-func (err CannotPullECRContainerError) ErrorName() string {
-	return "CannotPullECRContainerError"
-}
-
-// Retry fulfills the utils.Retrier interface and allows retries to be skipped by utils.Retry* functions
-func (err CannotPullECRContainerError) Retry() bool {
-	return false
-}
-
-type CreateEmptyVolumeError struct {
-	fromError error
-}
-
-func (err CreateEmptyVolumeError) Error() string {
-	return err.fromError.Error()
-}
-
-func (err CreateEmptyVolumeError) ErrorName() string {
-	return "CreateEmptyVolumeError"
-}
-
-// Retry fulfills the utils.Retrier interface and allows retries to be skipped by utils.Retry* functions
-func (err CreateEmptyVolumeError) Retry() bool {
-	return false
-}
-
-// CannotCreateContainerError indicates any error when trying to create a container
-type CannotCreateContainerError struct {
-	fromError error
-}
-
-func (err CannotCreateContainerError) Error() string {
-	return err.fromError.Error()
-}
-
-func (err CannotCreateContainerError) ErrorName() string {
-	return "CannotCreateContainerError"
-}
-
-// CannotStartContainerError indicates any error when trying to start a container
-type CannotStartContainerError struct {
-	fromError error
-}
-
-func (err CannotStartContainerError) Error() string {
-	return err.fromError.Error()
-}
-
-func (err CannotStartContainerError) ErrorName() string {
-	return "CannotStartContainerError"
-}
-
-// CannotInspectContainerError indicates any error when trying to inspect a container
-type CannotInspectContainerError struct {
-	fromError error
-}
-
-func (err CannotInspectContainerError) Error() string {
-	return err.fromError.Error()
-}
-
-func (err CannotInspectContainerError) ErrorName() string {
-	return cannotInspectContainerErrorName
-}
-
-// CannotRemoveContainerError indicates any error when trying to remove a container
-type CannotRemoveContainerError struct {
-	fromError error
-}
-
-func (err CannotRemoveContainerError) Error() string {
-	return err.fromError.Error()
-}
-
-func (err CannotRemoveContainerError) ErrorName() string {
-	return "CannotRemoveContainerError"
-}
-
-// CannotDescribeContainerError indicates any error when trying to describe a container
-type CannotDescribeContainerError struct {
-	fromError error
-}
-
-func (err CannotDescribeContainerError) Error() string {
-	return err.fromError.Error()
-}
-
-func (err CannotDescribeContainerError) ErrorName() string {
-	return cannotDescribeContainerError
-}
-
-// CannotListContainersError indicates any error when trying to list containers
-type CannotListContainersError struct {
-	fromError error
-}
-
-func (err CannotListContainersError) Error() string {
-	return err.fromError.Error()
-}
-
-func (err CannotListContainersError) ErrorName() string {
-	return "CannotListContainersError"
 }
 
 // ContainerNetworkingError indicates any error when dealing with the network

--- a/agent/eni/networkutils/utils_linux.go
+++ b/agent/eni/networkutils/utils_linux.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	apierrors "github.com/aws/amazon-ecs-agent/agent/api/errors"
 	"github.com/aws/amazon-ecs-agent/agent/eni/netlinkwrapper"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 	"github.com/pkg/errors"
@@ -120,7 +121,7 @@ func (retriever *macAddressRetriever) retrieveOnce() error {
 	dev := filepath.Base(retriever.dev)
 	link, err := retriever.netlinkClient.LinkByName(dev)
 	if err != nil {
-		return utils.NewRetriableError(utils.NewRetriable(false), err)
+		return apierrors.NewRetriableError(apierrors.NewRetriable(false), err)
 	}
 	retriever.macAddress = link.Attrs().HardwareAddr.String()
 	return nil

--- a/agent/eni/pause/load.go
+++ b/agent/eni/pause/load.go
@@ -15,14 +15,14 @@ package pause
 
 import (
 	"github.com/aws/amazon-ecs-agent/agent/config"
-	"github.com/aws/amazon-ecs-agent/agent/engine"
+	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	docker "github.com/fsouza/go-dockerclient"
 )
 
 // Loader defines an interface for loading the pause container image. This is mostly
 // to facilitate mocking and testing of the LoadImage method
 type Loader interface {
-	LoadImage(cfg *config.Config, dockerClient engine.DockerClient) (*docker.Image, error)
+	LoadImage(cfg *config.Config, dockerClient dockerapi.DockerClient) (*docker.Image, error)
 }
 
 type loader struct{}

--- a/agent/eni/pause/mocks/load_mocks.go
+++ b/agent/eni/pause/mocks/load_mocks.go
@@ -21,7 +21,7 @@ import (
 	reflect "reflect"
 
 	config "github.com/aws/amazon-ecs-agent/agent/config"
-	engine "github.com/aws/amazon-ecs-agent/agent/engine"
+	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	go_dockerclient "github.com/fsouza/go-dockerclient"
 	gomock "github.com/golang/mock/gomock"
 )
@@ -50,7 +50,7 @@ func (m *MockLoader) EXPECT() *MockLoaderMockRecorder {
 }
 
 // LoadImage mocks base method
-func (m *MockLoader) LoadImage(arg0 *config.Config, arg1 engine.DockerClient) (*go_dockerclient.Image, error) {
+func (m *MockLoader) LoadImage(arg0 *config.Config, arg1 dockerapi.DockerClient) (*go_dockerclient.Image, error) {
 	ret := m.ctrl.Call(m, "LoadImage", arg0, arg1)
 	ret0, _ := ret[0].(*go_dockerclient.Image)
 	ret1, _ := ret[1].(error)

--- a/agent/eni/pause/pause_linux.go
+++ b/agent/eni/pause/pause_linux.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/aws/amazon-ecs-agent/agent/acs/update_handler/os"
 	"github.com/aws/amazon-ecs-agent/agent/config"
-	"github.com/aws/amazon-ecs-agent/agent/engine"
+	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	docker "github.com/fsouza/go-dockerclient"
 
 	log "github.com/cihub/seelog"
@@ -28,7 +28,7 @@ import (
 )
 
 // LoadImage helps load the pause container image for the agent
-func (*loader) LoadImage(cfg *config.Config, dockerClient engine.DockerClient) (*docker.Image, error) {
+func (*loader) LoadImage(cfg *config.Config, dockerClient dockerapi.DockerClient) (*docker.Image, error) {
 	log.Debugf("Loading pause container tarball: %s", cfg.PauseContainerTarballPath)
 	if err := loadFromFile(cfg.PauseContainerTarballPath, dockerClient, os.Default); err != nil {
 		return nil, err
@@ -38,7 +38,7 @@ func (*loader) LoadImage(cfg *config.Config, dockerClient engine.DockerClient) (
 		config.DefaultPauseContainerImageName, config.DefaultPauseContainerTag, dockerClient)
 }
 
-func loadFromFile(path string, dockerClient engine.DockerClient, fs os.FileSystem) error {
+func loadFromFile(path string, dockerClient dockerapi.DockerClient, fs os.FileSystem) error {
 	pauseContainerReader, err := fs.Open(path)
 	if err != nil {
 		if err.Error() == noSuchFile {
@@ -48,7 +48,7 @@ func loadFromFile(path string, dockerClient engine.DockerClient, fs os.FileSyste
 		return errors.Wrapf(err,
 			"pause container load: failed to read pause container image: %s", path)
 	}
-	if err := dockerClient.LoadImage(pauseContainerReader, engine.LoadImageTimeout); err != nil {
+	if err := dockerClient.LoadImage(pauseContainerReader, dockerapi.LoadImageTimeout); err != nil {
 		return errors.Wrapf(err,
 			"pause container load: failed to load pause container image: %s", path)
 	}
@@ -57,7 +57,7 @@ func loadFromFile(path string, dockerClient engine.DockerClient, fs os.FileSyste
 
 }
 
-func getPauseContainerImage(name string, tag string, dockerClient engine.DockerClient) (*docker.Image, error) {
+func getPauseContainerImage(name string, tag string, dockerClient dockerapi.DockerClient) (*docker.Image, error) {
 	imageName := fmt.Sprintf("%s:%s", name, tag)
 	log.Debugf("Inspecting pause container image: %s", imageName)
 

--- a/agent/eni/pause/pause_linux_test.go
+++ b/agent/eni/pause/pause_linux_test.go
@@ -22,8 +22,8 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/acs/update_handler/os/mock"
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/clientfactory/mocks"
+	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockeriface/mocks"
-	"github.com/aws/amazon-ecs-agent/agent/engine"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -46,7 +46,7 @@ func TestLoadFromFileWithReaderError(t *testing.T) {
 	mockDocker.EXPECT().Ping().AnyTimes().Return(nil)
 	factory := mock_clientfactory.NewMockFactory(ctrl)
 	factory.EXPECT().GetDefaultClient().AnyTimes().Return(mockDocker, nil)
-	client, err := engine.NewDockerGoClient(factory, &defaultConfig)
+	client, err := dockerapi.NewDockerGoClient(factory, &defaultConfig)
 	assert.NoError(t, err)
 
 	mockfs := mock_os.NewMockFileSystem(ctrl)
@@ -65,7 +65,7 @@ func TestLoadFromFileHappyPath(t *testing.T) {
 	mockDocker.EXPECT().Ping().AnyTimes().Return(nil)
 	factory := mock_clientfactory.NewMockFactory(ctrl)
 	factory.EXPECT().GetDefaultClient().AnyTimes().Return(mockDocker, nil)
-	client, err := engine.NewDockerGoClient(factory, &defaultConfig)
+	client, err := dockerapi.NewDockerGoClient(factory, &defaultConfig)
 	assert.NoError(t, err)
 
 	mockDocker.EXPECT().LoadImage(gomock.Any()).Return(nil)
@@ -87,7 +87,7 @@ func TestLoadFromFileDockerLoadImageError(t *testing.T) {
 	mockDocker.EXPECT().Ping().AnyTimes().Return(nil)
 	factory := mock_clientfactory.NewMockFactory(ctrl)
 	factory.EXPECT().GetDefaultClient().AnyTimes().Return(mockDocker, nil)
-	client, err := engine.NewDockerGoClient(factory, &defaultConfig)
+	client, err := dockerapi.NewDockerGoClient(factory, &defaultConfig)
 	assert.NoError(t, err)
 
 	mockDocker.EXPECT().LoadImage(gomock.Any()).Return(
@@ -108,7 +108,7 @@ func TestGetPauseContainerImageInspectImageError(t *testing.T) {
 	mockDocker.EXPECT().Ping().AnyTimes().Return(nil)
 	factory := mock_clientfactory.NewMockFactory(ctrl)
 	factory.EXPECT().GetDefaultClient().AnyTimes().Return(mockDocker, nil)
-	client, err := engine.NewDockerGoClient(factory, &defaultConfig)
+	client, err := dockerapi.NewDockerGoClient(factory, &defaultConfig)
 	assert.NoError(t, err)
 
 	mockDocker.EXPECT().InspectImage(pauseName+":"+pauseTag).Return(
@@ -126,7 +126,7 @@ func TestGetPauseContainerHappyPath(t *testing.T) {
 	mockDocker.EXPECT().Ping().AnyTimes().Return(nil)
 	factory := mock_clientfactory.NewMockFactory(ctrl)
 	factory.EXPECT().GetDefaultClient().AnyTimes().Return(mockDocker, nil)
-	client, err := engine.NewDockerGoClient(factory, &defaultConfig)
+	client, err := dockerapi.NewDockerGoClient(factory, &defaultConfig)
 	assert.NoError(t, err)
 
 	mockDocker.EXPECT().InspectImage(pauseName+":"+pauseTag).Return(nil, nil)

--- a/agent/eni/pause/pause_unsupported.go
+++ b/agent/eni/pause/pause_unsupported.go
@@ -19,13 +19,13 @@ import (
 	"runtime"
 
 	"github.com/aws/amazon-ecs-agent/agent/config"
-	"github.com/aws/amazon-ecs-agent/agent/engine"
+	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/pkg/errors"
 )
 
 // LoadImage returns UnsupportedPlatformError on the unsupported platform
-func (*loader) LoadImage(cfg *config.Config, dockerClient engine.DockerClient) (*docker.Image, error) {
+func (*loader) LoadImage(cfg *config.Config, dockerClient dockerapi.DockerClient) (*docker.Image, error) {
 	return nil, NewUnsupportedPlatformError(errors.Errorf(
 		"pause container load: unsupported platform: %s/%s",
 		runtime.GOOS, runtime.GOARCH))

--- a/agent/eni/watcher/watcher_linux.go
+++ b/agent/eni/watcher/watcher_linux.go
@@ -26,6 +26,7 @@ import (
 	"github.com/vishvananda/netlink"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
+	apierrors "github.com/aws/amazon-ecs-agent/agent/api/errors"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/eni/netlinkwrapper"
 	"github.com/aws/amazon-ecs-agent/agent/eni/networkutils"
@@ -311,7 +312,7 @@ func (udevWatcher *UdevWatcher) sendENIStateChangeWithRetries(parentCtx context.
 				return sendErr
 			}
 			// Not unmanagedENIError. Stop retrying when this happens
-			return utils.NewRetriableError(utils.NewRetriable(false), sendErr)
+			return apierrors.NewRetriableError(apierrors.NewRetriable(false), sendErr)
 		}
 
 		return nil

--- a/agent/eventhandler/handler_test.go
+++ b/agent/eventhandler/handler_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
+	apierrors "github.com/aws/amazon-ecs-agent/agent/api/errors"
 	"github.com/aws/amazon-ecs-agent/agent/api/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/statechange"
@@ -80,7 +81,7 @@ func TestSendsEventsOneEventRetries(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(2)
 
-	retriable := utils.NewRetriableError(utils.NewRetriable(true), errors.New("test"))
+	retriable := apierrors.NewRetriableError(apierrors.NewRetriable(true), errors.New("test"))
 	taskEvent := taskEvent(taskARN)
 
 	gomock.InOrder(

--- a/agent/sighandlers/termination_handler.go
+++ b/agent/sighandlers/termination_handler.go
@@ -25,10 +25,10 @@ import (
 	"syscall"
 	"time"
 
+	apierrors "github.com/aws/amazon-ecs-agent/agent/api/errors"
 	"github.com/aws/amazon-ecs-agent/agent/engine"
 	"github.com/aws/amazon-ecs-agent/agent/sighandlers/exitcodes"
 	"github.com/aws/amazon-ecs-agent/agent/statemanager"
-	"github.com/aws/amazon-ecs-agent/agent/utils"
 
 	"github.com/cihub/seelog"
 )
@@ -91,7 +91,7 @@ func FinalSave(saver statemanager.Saver, taskEngine engine.TaskEngine) error {
 	saveErr := <-stateSaved
 
 	if disableErr != nil || saveErr != nil {
-		return utils.NewMultiError(disableErr, saveErr)
+		return apierrors.NewMultiError(disableErr, saveErr)
 	}
 	return nil
 }

--- a/agent/stats/container.go
+++ b/agent/stats/container.go
@@ -18,7 +18,8 @@ import (
 	"time"
 
 	"context"
-	ecsengine "github.com/aws/amazon-ecs-agent/agent/engine"
+
+	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	"github.com/aws/amazon-ecs-agent/agent/stats/resolver"
 	"github.com/cihub/seelog"
 )
@@ -32,7 +33,7 @@ const (
 	ContainerStatsBufferLength = 120
 )
 
-func newStatsContainer(dockerID string, client ecsengine.DockerClient, resolver resolver.ContainerMetadataResolver) *StatsContainer {
+func newStatsContainer(dockerID string, client dockerapi.DockerClient, resolver resolver.ContainerMetadataResolver) *StatsContainer {
 	ctx, cancel := context.WithCancel(context.Background())
 	return &StatsContainer{
 		containerMetadata: &ContainerMetadata{

--- a/agent/stats/engine_integ_test.go
+++ b/agent/stats/engine_integ_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
 	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	ecsengine "github.com/aws/amazon-ecs-agent/agent/engine"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 
@@ -29,10 +30,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var dockerClient ecsengine.DockerClient
+var dockerClient dockerapi.DockerClient
 
 func init() {
-	dockerClient, _ = ecsengine.NewDockerGoClient(clientFactory, &cfg)
+	dockerClient, _ = dockerapi.NewDockerGoClient(clientFactory, &cfg)
 }
 
 func createRunningTask() *api.Task {
@@ -98,9 +99,9 @@ func TestStatsEngineWithExistingContainersWithoutHealth(t *testing.T) {
 	err = client.StopContainer(container.ID, defaultDockerTimeoutSeconds)
 	require.NoError(t, err, "stopping container failed")
 
-	err = engine.containerChangeEventStream.WriteToEventStream(ecsengine.DockerContainerChangeEvent{
+	err = engine.containerChangeEventStream.WriteToEventStream(dockerapi.DockerContainerChangeEvent{
 		Status: api.ContainerStopped,
-		DockerContainerMetadata: ecsengine.DockerContainerMetadata{
+		DockerContainerMetadata: dockerapi.DockerContainerMetadata{
 			DockerID: container.ID,
 		},
 	})
@@ -152,9 +153,9 @@ func TestStatsEngineWithNewContainersWithoutHealth(t *testing.T) {
 	defer client.StopContainer(container.ID, defaultDockerTimeoutSeconds)
 
 	// Write the container change event to event stream
-	err = engine.containerChangeEventStream.WriteToEventStream(ecsengine.DockerContainerChangeEvent{
+	err = engine.containerChangeEventStream.WriteToEventStream(dockerapi.DockerContainerChangeEvent{
 		Status: api.ContainerRunning,
-		DockerContainerMetadata: ecsengine.DockerContainerMetadata{
+		DockerContainerMetadata: dockerapi.DockerContainerMetadata{
 			DockerID: container.ID,
 		},
 	})
@@ -168,9 +169,9 @@ func TestStatsEngineWithNewContainersWithoutHealth(t *testing.T) {
 	err = client.StopContainer(container.ID, defaultDockerTimeoutSeconds)
 	require.NoError(t, err, "stopping container failed")
 	// Write the container change event to event stream
-	err = engine.containerChangeEventStream.WriteToEventStream(ecsengine.DockerContainerChangeEvent{
+	err = engine.containerChangeEventStream.WriteToEventStream(dockerapi.DockerContainerChangeEvent{
 		Status: api.ContainerStopped,
-		DockerContainerMetadata: ecsengine.DockerContainerMetadata{
+		DockerContainerMetadata: dockerapi.DockerContainerMetadata{
 			DockerID: container.ID,
 		},
 	})
@@ -237,9 +238,9 @@ func TestStatsEngineWithExistingContainers(t *testing.T) {
 	err = client.StopContainer(container.ID, defaultDockerTimeoutSeconds)
 	require.NoError(t, err, "stopping container failed")
 
-	err = engine.containerChangeEventStream.WriteToEventStream(ecsengine.DockerContainerChangeEvent{
+	err = engine.containerChangeEventStream.WriteToEventStream(dockerapi.DockerContainerChangeEvent{
 		Status: api.ContainerStopped,
-		DockerContainerMetadata: ecsengine.DockerContainerMetadata{
+		DockerContainerMetadata: dockerapi.DockerContainerMetadata{
 			DockerID: container.ID,
 		},
 	})
@@ -294,9 +295,9 @@ func TestStatsEngineWithNewContainers(t *testing.T) {
 	defer client.StopContainer(container.ID, defaultDockerTimeoutSeconds)
 
 	// Write the container change event to event stream
-	err = engine.containerChangeEventStream.WriteToEventStream(ecsengine.DockerContainerChangeEvent{
+	err = engine.containerChangeEventStream.WriteToEventStream(dockerapi.DockerContainerChangeEvent{
 		Status: api.ContainerRunning,
-		DockerContainerMetadata: ecsengine.DockerContainerMetadata{
+		DockerContainerMetadata: dockerapi.DockerContainerMetadata{
 			DockerID: container.ID,
 		},
 	})
@@ -312,9 +313,9 @@ func TestStatsEngineWithNewContainers(t *testing.T) {
 	require.NoError(t, err, "stopping container failed")
 
 	// Write the container change event to event stream
-	err = engine.containerChangeEventStream.WriteToEventStream(ecsengine.DockerContainerChangeEvent{
+	err = engine.containerChangeEventStream.WriteToEventStream(dockerapi.DockerContainerChangeEvent{
 		Status: api.ContainerStopped,
-		DockerContainerMetadata: ecsengine.DockerContainerMetadata{
+		DockerContainerMetadata: dockerapi.DockerContainerMetadata{
 			DockerID: container.ID,
 		},
 	})
@@ -372,17 +373,17 @@ func TestStatsEngineWithDockerTaskEngine(t *testing.T) {
 	require.NoError(t, err, "starting container failed")
 	defer client.StopContainer(unmappedContainer.ID, defaultDockerTimeoutSeconds)
 
-	err = containerChangeEventStream.WriteToEventStream(ecsengine.DockerContainerChangeEvent{
+	err = containerChangeEventStream.WriteToEventStream(dockerapi.DockerContainerChangeEvent{
 		Status: api.ContainerRunning,
-		DockerContainerMetadata: ecsengine.DockerContainerMetadata{
+		DockerContainerMetadata: dockerapi.DockerContainerMetadata{
 			DockerID: container.ID,
 		},
 	})
 	assert.NoError(t, err, "failed to write to container change event stream")
 
-	err = containerChangeEventStream.WriteToEventStream(ecsengine.DockerContainerChangeEvent{
+	err = containerChangeEventStream.WriteToEventStream(dockerapi.DockerContainerChangeEvent{
 		Status: api.ContainerRunning,
-		DockerContainerMetadata: ecsengine.DockerContainerMetadata{
+		DockerContainerMetadata: dockerapi.DockerContainerMetadata{
 			DockerID: unmappedContainer.ID,
 		},
 	})
@@ -396,9 +397,9 @@ func TestStatsEngineWithDockerTaskEngine(t *testing.T) {
 	err = client.StopContainer(container.ID, defaultDockerTimeoutSeconds)
 	require.NoError(t, err, "stopping container failed")
 
-	err = containerChangeEventStream.WriteToEventStream(ecsengine.DockerContainerChangeEvent{
+	err = containerChangeEventStream.WriteToEventStream(dockerapi.DockerContainerChangeEvent{
 		Status: api.ContainerStopped,
-		DockerContainerMetadata: ecsengine.DockerContainerMetadata{
+		DockerContainerMetadata: dockerapi.DockerContainerMetadata{
 			DockerID: container.ID,
 		},
 	})
@@ -447,9 +448,9 @@ func TestStatsEngineWithDockerTaskEngineMissingRemoveEvent(t *testing.T) {
 	err = client.StartContainer(container.ID, nil)
 	require.NoError(t, err, "starting container failed")
 
-	err = containerChangeEventStream.WriteToEventStream(ecsengine.DockerContainerChangeEvent{
+	err = containerChangeEventStream.WriteToEventStream(dockerapi.DockerContainerChangeEvent{
 		Status: api.ContainerRunning,
-		DockerContainerMetadata: ecsengine.DockerContainerMetadata{
+		DockerContainerMetadata: dockerapi.DockerContainerMetadata{
 			DockerID: container.ID,
 		},
 	})

--- a/agent/stats/engine_test.go
+++ b/agent/stats/engine_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
+	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	ecsengine "github.com/aws/amazon-ecs-agent/agent/engine"
 	mock_resolver "github.com/aws/amazon-ecs-agent/agent/stats/resolver/mock"
 
@@ -381,7 +382,7 @@ func TestSynchronizeOnRestart(t *testing.T) {
 	engine := NewDockerStatsEngine(&cfg, client, eventStream("TestSynchronizeOnRestart"))
 	engine.resolver = resolver
 
-	client.EXPECT().ListContainers(false, gomock.Any()).Return(ecsengine.ListContainersResponse{
+	client.EXPECT().ListContainers(false, gomock.Any()).Return(dockerapi.ListContainersResponse{
 		DockerIDs: []string{containerID},
 	})
 	client.EXPECT().Stats(containerID, gomock.Any()).Do(func(id string, ctx context.Context) {

--- a/agent/stats/types.go
+++ b/agent/stats/types.go
@@ -17,7 +17,8 @@ import (
 	"time"
 
 	"context"
-	ecsengine "github.com/aws/amazon-ecs-agent/agent/engine"
+
+	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	"github.com/aws/amazon-ecs-agent/agent/stats/resolver"
 )
 
@@ -46,7 +47,7 @@ type StatsContainer struct {
 	containerMetadata *ContainerMetadata
 	ctx               context.Context
 	cancel            context.CancelFunc
-	client            ecsengine.DockerClient
+	client            dockerapi.DockerClient
 	statsQueue        *Queue
 	resolver          resolver.ContainerMetadataResolver
 }

--- a/agent/utils/utils.go
+++ b/agent/utils/utils.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 	"strings"
 
+	apierrors "github.com/aws/amazon-ecs-agent/agent/api/errors"
 	"github.com/aws/amazon-ecs-agent/agent/logger"
 	"github.com/aws/amazon-ecs-agent/agent/utils/ttime"
 )
@@ -129,7 +130,7 @@ func RetryWithBackoffCtx(ctx context.Context, backoff Backoff, fn func() error) 
 
 		err = fn()
 
-		retriableErr, isRetriableErr := err.(Retriable)
+		retriableErr, isRetriableErr := err.(apierrors.Retriable)
 
 		if err == nil || (isRetriableErr && !retriableErr.Retry()) {
 			return err

--- a/agent/utils/utils_test.go
+++ b/agent/utils/utils_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	apierrors "github.com/aws/amazon-ecs-agent/agent/api/errors"
 	"github.com/aws/amazon-ecs-agent/agent/utils/ttime"
 	"github.com/aws/amazon-ecs-agent/agent/utils/ttime/mocks"
 	"github.com/golang/mock/gomock"
@@ -114,7 +115,7 @@ func TestRetryWithBackoff(t *testing.T) {
 	t.Run("no retries", func(t *testing.T) {
 		// no sleeps
 		RetryWithBackoff(NewSimpleBackoff(10*time.Second, 20*time.Second, 0, 2), func() error {
-			return NewRetriableError(NewRetriable(false), errors.New("can't retry"))
+			return apierrors.NewRetriableError(apierrors.NewRetriable(false), errors.New("can't retry"))
 		})
 	})
 }
@@ -142,7 +143,7 @@ func TestRetryWithBackoffCtx(t *testing.T) {
 	t.Run("no retries", func(t *testing.T) {
 		// no sleeps
 		RetryWithBackoffCtx(context.TODO(), NewSimpleBackoff(10*time.Second, 20*time.Second, 0, 2), func() error {
-			return NewRetriableError(NewRetriable(false), errors.New("can't retry"))
+			return apierrors.NewRetriableError(apierrors.NewRetriable(false), errors.New("can't retry"))
 		})
 	})
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
docker_client moved into agent/dockerapi pkg along with related files, enginError replaced with NamedError

### Implementation details
1. docker_client.go moved from engine/ to dockerclient/. This required a lot of constants and structs to be exported, as engine/ needed to access.
2. other related files (including corresponding _test.go files) moved from engine/ to dockerclient/:
docker_events_buffer.go
repotag.go
types.go 
3. engine/errors split into docker-related error and agent-side error, and moved into dockerclient/
4. engine.engineError is a duplicate of api.NamedError. api.NamedError is moved to api/errors package 
5. MetadataFromContainer function in docker_client.go refactored to lower cyclomatic complexity and pass the gocyclo static check


### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
