### PR TITLE
Fixing test failure on mac

### DIFF
--- a/agent/engine/docker_task_engine_linux_test.go
+++ b/agent/engine/docker_task_engine_linux_test.go
@@ -1,0 +1,170 @@
+// +build linux,!integration
+
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+package engine
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aws/amazon-ecs-agent/agent/api"
+	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
+	"github.com/aws/amazon-ecs-agent/agent/engine/testdata"
+	"github.com/aws/amazon-ecs-agent/agent/resources/cgroup/mock_control"
+	"github.com/aws/amazon-ecs-agent/agent/taskresource"
+	"github.com/aws/amazon-ecs-agent/agent/taskresource/cgroup"
+	"github.com/aws/amazon-ecs-agent/agent/utils/ioutilwrapper/mocks"
+	"github.com/aws/aws-sdk-go/aws"
+	docker "github.com/fsouza/go-dockerclient"
+	"github.com/golang/mock/gomock"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	cgroupMountPath = "/sys/fs/cgroup"
+)
+
+func init() {
+	defaultConfig = config.DefaultConfig()
+	defaultConfig.TaskCPUMemLimit = config.ExplicitlyDisabled
+}
+
+// TestResourceContainerProgression tests the container progression based on a
+// resource dependency
+func TestResourceContainerProgression(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	ctrl, client, mockTime, taskEngine, _, imageManager, _ := mocks(t, ctx, &defaultConfig)
+	defer ctrl.Finish()
+
+	sleepTask := testdata.LoadTask("sleep5")
+	sleepContainer := sleepTask.Containers[0]
+	sleepContainer.TransitionDependenciesMap = make(map[api.ContainerStatus]api.TransitionDependencySet)
+	sleepContainer.BuildResourceDependency("cgroup", taskresource.ResourceCreated, api.ContainerPulled)
+
+	mockControl := mock_cgroup.NewMockControl(ctrl)
+	mockIO := mock_ioutilwrapper.NewMockIOUtil(ctrl)
+	taskID, err := sleepTask.GetID()
+	assert.NoError(t, err)
+	cgroupMemoryPath := fmt.Sprintf("/sys/fs/cgroup/memory/ecs/%s/memory.use_hierarchy", taskID)
+	cgroupRoot := fmt.Sprintf("/ecs/%s", taskID)
+	cgroupResource := cgroup.NewCgroupResource(sleepTask.Arn, mockControl, cgroupRoot, cgroupMountPath, specs.LinuxResources{})
+	cgroupResource.SetIOUtil(mockIO)
+
+	sleepTask.Resources = []taskresource.TaskResource{cgroupResource}
+	sleepTask.Resources[0].SetDesiredStatus(taskresource.ResourceCreated)
+
+	eventStream := make(chan dockerapi.DockerContainerChangeEvent)
+	// containerEventsWG is used to force the test to wait until the container created and started
+	// events are processed
+	containerEventsWG := sync.WaitGroup{}
+	if dockerVersionCheckDuringInit {
+		client.EXPECT().Version()
+	}
+	client.EXPECT().ContainerEvents(gomock.Any()).Return(eventStream, nil)
+	gomock.InOrder(
+		// Ensure that the resource is created first
+		mockControl.EXPECT().Exists(gomock.Any()).Return(false),
+		mockControl.EXPECT().Create(gomock.Any()).Return(nil, nil),
+		mockIO.EXPECT().WriteFile(cgroupMemoryPath, gomock.Any(), gomock.Any()).Return(nil),
+		imageManager.EXPECT().AddAllImageStates(gomock.Any()).AnyTimes(),
+		client.EXPECT().PullImage(sleepContainer.Image, nil).Return(dockerapi.DockerContainerMetadata{}),
+		imageManager.EXPECT().RecordContainerReference(sleepContainer).Return(nil),
+		imageManager.EXPECT().GetImageStateFromImageName(sleepContainer.Image).Return(nil),
+		client.EXPECT().APIVersion().Return(defaultDockerClientAPIVersion, nil),
+		client.EXPECT().CreateContainer(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(
+			func(ctx interface{}, config *docker.Config, hostConfig *docker.HostConfig, containerName string, z time.Duration) {
+				assert.True(t, strings.Contains(containerName, sleepContainer.Name))
+				containerEventsWG.Add(1)
+				go func() {
+					eventStream <- createDockerEvent(api.ContainerCreated)
+					containerEventsWG.Done()
+				}()
+			}).Return(dockerapi.DockerContainerMetadata{DockerID: containerID + ":" + sleepContainer.Name}),
+		// Next, the sleep container is started
+		client.EXPECT().StartContainer(gomock.Any(), containerID+":"+sleepContainer.Name, defaultConfig.ContainerStartTimeout).Do(
+			func(ctx interface{}, id string, timeout time.Duration) {
+				containerEventsWG.Add(1)
+				go func() {
+					eventStream <- createDockerEvent(api.ContainerRunning)
+					containerEventsWG.Done()
+				}()
+			}).Return(dockerapi.DockerContainerMetadata{DockerID: containerID + ":" + sleepContainer.Name}),
+	)
+
+	addTaskToEngine(t, ctx, taskEngine, sleepTask, mockTime, containerEventsWG)
+
+	cleanup := make(chan time.Time, 1)
+	mockTime.EXPECT().After(gomock.Any()).Return(cleanup).AnyTimes()
+
+	// Simulate a container stop event from docker
+	eventStream <- dockerapi.DockerContainerChangeEvent{
+		Status: api.ContainerStopped,
+		DockerContainerMetadata: dockerapi.DockerContainerMetadata{
+			DockerID: containerID + ":" + sleepContainer.Name,
+			ExitCode: aws.Int(exitCode),
+		},
+	}
+	waitForStopEvents(t, taskEngine.StateChangeEvents(), true)
+}
+
+// TestResourceContainerProgressionFailure ensures that task moves to STOPPED when
+// resource creation fails
+func TestResourceContainerProgressionFailure(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	ctrl, client, mockTime, taskEngine, _, _, _ := mocks(t, ctx, &defaultConfig)
+	defer ctrl.Finish()
+	sleepTask := testdata.LoadTask("sleep5")
+	sleepContainer := sleepTask.Containers[0]
+	sleepContainer.TransitionDependenciesMap = make(map[api.ContainerStatus]api.TransitionDependencySet)
+	sleepContainer.BuildResourceDependency("cgroup", taskresource.ResourceCreated, api.ContainerPulled)
+
+	mockControl := mock_cgroup.NewMockControl(ctrl)
+	taskID, err := sleepTask.GetID()
+	assert.NoError(t, err)
+	cgroupRoot := fmt.Sprintf("/ecs/%s", taskID)
+	cgroupResource := cgroup.NewCgroupResource(sleepTask.Arn, mockControl, cgroupRoot, cgroupMountPath, specs.LinuxResources{})
+
+	sleepTask.Resources = []taskresource.TaskResource{cgroupResource}
+	sleepTask.Resources[0].SetDesiredStatus(taskresource.ResourceCreated)
+
+	eventStream := make(chan dockerapi.DockerContainerChangeEvent)
+	if dockerVersionCheckDuringInit {
+		client.EXPECT().Version()
+	}
+	client.EXPECT().ContainerEvents(gomock.Any()).Return(eventStream, nil)
+	gomock.InOrder(
+		// resource creation failure
+		mockControl.EXPECT().Exists(gomock.Any()).Return(false),
+		mockControl.EXPECT().Create(gomock.Any()).Return(nil, errors.New("cgroup create error")),
+	)
+	mockTime.EXPECT().Now().Return(time.Now()).AnyTimes()
+
+	err = taskEngine.Init(ctx)
+	assert.NoError(t, err)
+
+	taskEngine.AddTask(sleepTask)
+	cleanup := make(chan time.Time, 1)
+	mockTime.EXPECT().After(gomock.Any()).Return(cleanup).AnyTimes()
+	waitForStopEvents(t, taskEngine.StateChangeEvents(), true)
+}

--- a/agent/engine/docker_task_engine_unix_test.go
+++ b/agent/engine/docker_task_engine_unix_test.go
@@ -17,28 +17,16 @@ package engine
 import (
 	"context"
 	"errors"
-	"fmt"
-	"strings"
-	"sync"
 	"testing"
-	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	"github.com/aws/amazon-ecs-agent/agent/emptyvolume"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate/mocks"
-	"github.com/aws/amazon-ecs-agent/agent/engine/testdata"
-	"github.com/aws/amazon-ecs-agent/agent/resources/cgroup/mock_control"
 	"github.com/aws/amazon-ecs-agent/agent/resources/mock_resources"
 	"github.com/aws/amazon-ecs-agent/agent/statemanager/mocks"
-	"github.com/aws/amazon-ecs-agent/agent/taskresource"
-	"github.com/aws/amazon-ecs-agent/agent/taskresource/cgroup"
-	"github.com/aws/amazon-ecs-agent/agent/utils/ioutilwrapper/mocks"
-	"github.com/aws/aws-sdk-go/aws"
-	docker "github.com/fsouza/go-dockerclient"
 	"github.com/golang/mock/gomock"
-	specs "github.com/opencontainers/runtime-spec/specs-go"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -50,7 +38,6 @@ const (
 	// isParallelPullCompatible is invoked during engine intialization
 	// on linux. Docker client's Version() call needs to be mocked
 	dockerVersionCheckDuringInit = true
-	cgroupMountPath              = "/sys/fs/cgroup"
 )
 
 func TestPullEmptyVolumeImage(t *testing.T) {
@@ -127,125 +114,4 @@ func TestEngineDisableConcurrentPull(t *testing.T) {
 	dockerTaskEngine, _ := taskEngine.(*DockerTaskEngine)
 	assert.False(t, dockerTaskEngine.enableConcurrentPull,
 		"Task engine should not be able to perform concurrent pulling for version < 1.11.1")
-}
-
-// TestResourceContainerProgression tests the container progression based on a
-// resource dependency
-func TestResourceContainerProgression(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.TODO())
-	defer cancel()
-	ctrl, client, mockTime, taskEngine, _, imageManager, _ := mocks(t, ctx, &defaultConfig)
-	defer ctrl.Finish()
-
-	sleepTask := testdata.LoadTask("sleep5")
-	sleepContainer := sleepTask.Containers[0]
-	sleepContainer.TransitionDependenciesMap = make(map[api.ContainerStatus]api.TransitionDependencySet)
-	sleepContainer.BuildResourceDependency("cgroup", taskresource.ResourceCreated, api.ContainerPulled)
-
-	mockControl := mock_cgroup.NewMockControl(ctrl)
-	mockIO := mock_ioutilwrapper.NewMockIOUtil(ctrl)
-	taskID, err := sleepTask.GetID()
-	assert.NoError(t, err)
-	cgroupMemoryPath := fmt.Sprintf("/sys/fs/cgroup/memory/ecs/%s/memory.use_hierarchy", taskID)
-	cgroupRoot := fmt.Sprintf("/ecs/%s", taskID)
-	cgroupResource := cgroup.NewCgroupResource(sleepTask.Arn, mockControl, cgroupRoot, cgroupMountPath, specs.LinuxResources{})
-	cgroupResource.SetIOUtil(mockIO)
-
-	sleepTask.Resources = []taskresource.TaskResource{cgroupResource}
-	sleepTask.Resources[0].SetDesiredStatus(taskresource.ResourceCreated)
-
-	eventStream := make(chan dockerapi.DockerContainerChangeEvent)
-	// containerEventsWG is used to force the test to wait until the container created and started
-	// events are processed
-	containerEventsWG := sync.WaitGroup{}
-	if dockerVersionCheckDuringInit {
-		client.EXPECT().Version()
-	}
-	client.EXPECT().ContainerEvents(gomock.Any()).Return(eventStream, nil)
-	gomock.InOrder(
-		// Ensure that the resource is created first
-		mockControl.EXPECT().Exists(gomock.Any()).Return(false),
-		mockControl.EXPECT().Create(gomock.Any()).Return(nil, nil),
-		mockIO.EXPECT().WriteFile(cgroupMemoryPath, gomock.Any(), gomock.Any()).Return(nil),
-		imageManager.EXPECT().AddAllImageStates(gomock.Any()).AnyTimes(),
-		client.EXPECT().PullImage(sleepContainer.Image, nil).Return(dockerapi.DockerContainerMetadata{}),
-		imageManager.EXPECT().RecordContainerReference(sleepContainer).Return(nil),
-		imageManager.EXPECT().GetImageStateFromImageName(sleepContainer.Image).Return(nil),
-		client.EXPECT().APIVersion().Return(defaultDockerClientAPIVersion, nil),
-		client.EXPECT().CreateContainer(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(
-			func(ctx interface{}, config *docker.Config, hostConfig *docker.HostConfig, containerName string, z time.Duration) {
-				assert.True(t, strings.Contains(containerName, sleepContainer.Name))
-				containerEventsWG.Add(1)
-				go func() {
-					eventStream <- createDockerEvent(api.ContainerCreated)
-					containerEventsWG.Done()
-				}()
-			}).Return(dockerapi.DockerContainerMetadata{DockerID: containerID + ":" + sleepContainer.Name}),
-		// Next, the sleep container is started
-		client.EXPECT().StartContainer(gomock.Any(), containerID+":"+sleepContainer.Name, defaultConfig.ContainerStartTimeout).Do(
-			func(ctx interface{}, id string, timeout time.Duration) {
-				containerEventsWG.Add(1)
-				go func() {
-					eventStream <- createDockerEvent(api.ContainerRunning)
-					containerEventsWG.Done()
-				}()
-			}).Return(dockerapi.DockerContainerMetadata{DockerID: containerID + ":" + sleepContainer.Name}),
-	)
-
-	addTaskToEngine(t, ctx, taskEngine, sleepTask, mockTime, containerEventsWG)
-
-	cleanup := make(chan time.Time, 1)
-	mockTime.EXPECT().After(gomock.Any()).Return(cleanup).AnyTimes()
-
-	// Simulate a container stop event from docker
-	eventStream <- dockerapi.DockerContainerChangeEvent{
-		Status: api.ContainerStopped,
-		DockerContainerMetadata: dockerapi.DockerContainerMetadata{
-			DockerID: containerID + ":" + sleepContainer.Name,
-			ExitCode: aws.Int(exitCode),
-		},
-	}
-	waitForStopEvents(t, taskEngine.StateChangeEvents(), true)
-}
-
-// TestResourceContainerProgressionFailure ensures that task moves to STOPPED when
-// resource creation fails
-func TestResourceContainerProgressionFailure(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.TODO())
-	defer cancel()
-	ctrl, client, mockTime, taskEngine, _, _, _ := mocks(t, ctx, &defaultConfig)
-	defer ctrl.Finish()
-	sleepTask := testdata.LoadTask("sleep5")
-	sleepContainer := sleepTask.Containers[0]
-	sleepContainer.TransitionDependenciesMap = make(map[api.ContainerStatus]api.TransitionDependencySet)
-	sleepContainer.BuildResourceDependency("cgroup", taskresource.ResourceCreated, api.ContainerPulled)
-
-	mockControl := mock_cgroup.NewMockControl(ctrl)
-	taskID, err := sleepTask.GetID()
-	assert.NoError(t, err)
-	cgroupRoot := fmt.Sprintf("/ecs/%s", taskID)
-	cgroupResource := cgroup.NewCgroupResource(sleepTask.Arn, mockControl, cgroupRoot, cgroupMountPath, specs.LinuxResources{})
-
-	sleepTask.Resources = []taskresource.TaskResource{cgroupResource}
-	sleepTask.Resources[0].SetDesiredStatus(taskresource.ResourceCreated)
-
-	eventStream := make(chan dockerapi.DockerContainerChangeEvent)
-	if dockerVersionCheckDuringInit {
-		client.EXPECT().Version()
-	}
-	client.EXPECT().ContainerEvents(gomock.Any()).Return(eventStream, nil)
-	gomock.InOrder(
-		// resource creation failure
-		mockControl.EXPECT().Exists(gomock.Any()).Return(false),
-		mockControl.EXPECT().Create(gomock.Any()).Return(nil, errors.New("cgroup create error")),
-	)
-	mockTime.EXPECT().Now().Return(time.Now()).AnyTimes()
-
-	err = taskEngine.Init(ctx)
-	assert.NoError(t, err)
-
-	taskEngine.AddTask(sleepTask)
-	cleanup := make(chan time.Time, 1)
-	mockTime.EXPECT().After(gomock.Any()).Return(cleanup).AnyTimes()
-	waitForStopEvents(t, taskEngine.StateChangeEvents(), true)
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
On mac, make test fails with: 
`agent/engine/docker_task_engine_unix_test.go:32:2: build constraints exclude all Go files in /Users/yhlee/go/src/github.com/aws/amazon-ecs-agent/agent/resources/cgroup/mock_control`

### Implementation details
Separated cgroup specific tests to build with linux tag.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
