### PR TITLE
adding cgroup as task resource

### DIFF
--- a/agent/acs/handler/payload_handler.go
+++ b/agent/acs/handler/payload_handler.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 
 	"context"
+
 	"github.com/aws/amazon-ecs-agent/agent/acs/model/ecsacs"
 	"github.com/aws/amazon-ecs-agent/agent/api"
 	"github.com/aws/amazon-ecs-agent/agent/credentials"
@@ -263,12 +264,7 @@ func (payloadHandler *payloadRequestHandler) addTasks(payload *ecsacs.PayloadMes
 		if skipAddTask(task.GetDesiredStatus()) {
 			continue
 		}
-		err := payloadHandler.taskEngine.AddTask(task)
-		if err != nil {
-			seelog.Warnf("Could not add task; taskengine probably disabled, err: %v", err)
-			// Don't ack
-			allTasksOK = false
-		}
+		payloadHandler.taskEngine.AddTask(task)
 
 		ackCredentials := func(id string, description string) {
 			ack, err := payloadHandler.ackCredentials(payload.MessageId, id)

--- a/agent/acs/handler/payload_handler_test.go
+++ b/agent/acs/handler/payload_handler_test.go
@@ -111,42 +111,6 @@ func TestHandlePayloadMessageWithNoMessageId(t *testing.T) {
 	assert.Error(t, err, "Expected error while adding a task with no message id")
 }
 
-// TestHandlePayloadMessageAddTaskError tests that agent does not ack payload messages
-// when task engine fails to add tasks
-func TestHandlePayloadMessageAddTaskError(t *testing.T) {
-	tester := setup(t)
-	defer tester.ctrl.Finish()
-
-	// Return error from AddTask
-	tester.mockTaskEngine.EXPECT().AddTask(gomock.Any()).Return(fmt.Errorf("oops")).Times(2)
-
-	// Test AddTask error with RUNNING task
-	payloadMessage := &ecsacs.PayloadMessage{
-		Tasks: []*ecsacs.Task{
-			{
-				Arn:           aws.String("t1"),
-				DesiredStatus: aws.String("RUNNING"),
-			},
-		},
-		MessageId: aws.String(payloadMessageId),
-	}
-	err := tester.payloadHandler.handleSingleMessage(payloadMessage)
-	assert.Error(t, err, "Expected error while adding the task")
-
-	payloadMessage = &ecsacs.PayloadMessage{
-		Tasks: []*ecsacs.Task{
-			{
-				Arn:           aws.String("t1"),
-				DesiredStatus: aws.String("STOPPED"),
-			},
-		},
-		MessageId: aws.String(payloadMessageId),
-	}
-	// Test AddTask error with STOPPED task
-	err = tester.payloadHandler.handleSingleMessage(payloadMessage)
-	assert.Error(t, err, "Expected error while adding the task")
-}
-
 // TestHandlePayloadMessageStateSaveError tests that agent does not ack payload messages
 // when state saver fails to save state
 func TestHandlePayloadMessageStateSaveError(t *testing.T) {

--- a/agent/api/errors/errors.go
+++ b/agent/api/errors/errors.go
@@ -14,6 +14,7 @@
 package errors
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -95,3 +96,25 @@ func (err *DockerClientConfigError) Error() string { return err.Msg }
 
 // ErrorName returns the name of the error
 func (err *DockerClientConfigError) ErrorName() string { return "DockerClientConfigError" }
+
+// ResourceInitError is a task error for which a required resource cannot
+// be initialized
+type ResourceInitError struct {
+	taskARN string
+	origErr error
+}
+
+// NewResourceInitError creates an error for resource initialize failure
+func NewResourceInitError(taskARN string, origErr error) *ResourceInitError {
+	return &ResourceInitError{taskARN, origErr}
+}
+
+// Error returns the error as a string
+func (err *ResourceInitError) Error() string {
+	return fmt.Sprintf("resource cannot be initialized for task %s: %v", err.taskARN, err.origErr)
+}
+
+// ErrorName is the name of the error
+func (err *ResourceInitError) ErrorName() string {
+	return "ResourceInitializationError"
+}

--- a/agent/api/task_test.go
+++ b/agent/api/task_test.go
@@ -562,7 +562,7 @@ func TestPostUnmarshalTaskWithEmptyVolumes(t *testing.T) {
 	assert.Nil(t, err, "Should be able to handle acs task")
 	assert.Equal(t, 2, len(task.Containers)) // before PostUnmarshalTask
 	cfg := config.Config{}
-	task.PostUnmarshalTask(&cfg, nil)
+	task.PostUnmarshalTask(&cfg, nil, nil)
 
 	assert.Equal(t, 3, len(task.Containers), "Should include new container for volumes")
 	emptyContainer, ok := task.ContainerByName(emptyHostVolumeName)

--- a/agent/api/task_windows.go
+++ b/agent/api/task_windows.go
@@ -16,11 +16,13 @@
 package api
 
 import (
+	"errors"
 	"path/filepath"
 	"runtime"
 	"strings"
 
 	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	"github.com/cihub/seelog"
 	docker "github.com/fsouza/go-dockerclient"
 )
@@ -113,4 +115,8 @@ func (task *Task) dockerCPUShares(containerCPU uint) int64 {
 		return 2
 	}
 	return int64(containerCPU)
+}
+
+func (task *Task) initializeCgroupResourceSpec(cgroupPath string, resourceFields *taskresource.ResourceFields) error {
+	return errors.New("unsupported platform")
 }

--- a/agent/api/task_windows_test.go
+++ b/agent/api/task_windows_test.go
@@ -107,7 +107,7 @@ func TestPostUnmarshalWindowsCanonicalPaths(t *testing.T) {
 	task, err := TaskFromACS(&taskFromAcs, &ecsacs.PayloadMessage{SeqNum: &seqNum})
 	assert.Nil(t, err, "Should be able to handle acs task")
 	cfg := config.Config{TaskCPUMemLimit: config.ExplicitlyDisabled}
-	task.PostUnmarshalTask(&cfg, nil)
+	task.PostUnmarshalTask(&cfg, nil, nil)
 
 	assert.Equal(t, expectedTask.Containers, task.Containers, "Containers should be equal")
 	assert.Equal(t, expectedTask.Volumes, task.Volumes, "Volumes should be equal")

--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -40,11 +40,11 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
 	"github.com/aws/amazon-ecs-agent/agent/handlers"
 	"github.com/aws/amazon-ecs-agent/agent/handlers/taskmetadata"
-	"github.com/aws/amazon-ecs-agent/agent/resources"
 	"github.com/aws/amazon-ecs-agent/agent/sighandlers"
 	"github.com/aws/amazon-ecs-agent/agent/sighandlers/exitcodes"
 	"github.com/aws/amazon-ecs-agent/agent/statemanager"
 	"github.com/aws/amazon-ecs-agent/agent/stats"
+	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	"github.com/aws/amazon-ecs-agent/agent/tcs/handler"
 	"github.com/aws/amazon-ecs-agent/agent/utils/mobypkgwrapper"
 	"github.com/aws/amazon-ecs-agent/agent/version"
@@ -104,9 +104,9 @@ type ecsAgent struct {
 	subnet                string
 	mac                   string
 	metadataManager       containermetadata.Manager
-	resource              resources.Resource
 	terminationHandler    sighandlers.TerminationHandler
 	mobyPlugins           mobypkgwrapper.Plugins
+	resourceFields        *taskresource.ResourceFields
 }
 
 // newAgent returns a new ecsAgent object, but does not start anything
@@ -168,7 +168,6 @@ func newAgent(
 		}),
 		os:                 oswrapper.New(),
 		metadataManager:    metadataManager,
-		resource:           resources.New(),
 		terminationHandler: sighandlers.StartDefaultTerminationHandler,
 		mobyPlugins:        mobypkgwrapper.NewPlugins(),
 	}, nil
@@ -202,6 +201,9 @@ func (agent *ecsAgent) start() int {
 	imageManager := engine.NewImageManager(agent.cfg, agent.dockerClient, state)
 	client := ecsclient.NewECSClient(agent.credentialProvider, agent.cfg, agent.ec2MetadataClient)
 
+	if agent.cfg.TaskCPUMemLimit.Enabled() {
+		agent.initializeResourceFields()
+	}
 	return agent.doStart(containerChangeEventStream, credentialsManager, state, imageManager, client)
 }
 
@@ -213,6 +215,14 @@ func (agent *ecsAgent) doStart(containerChangeEventStream *eventstream.EventStre
 	state dockerstate.TaskEngineState,
 	imageManager engine.ImageManager,
 	client api.ECSClient) int {
+
+	// Conditionally create '/ecs' cgroup root
+	if agent.cfg.TaskCPUMemLimit.Enabled() {
+		if err := agent.cgroupInit(); err != nil {
+			seelog.Criticalf("Unable to initialize cgroup root for ECS: %v", err)
+			return exitcodes.ExitTerminal
+		}
+	}
 
 	// Create the task engine
 	taskEngine, currentEC2InstanceID, err := agent.newTaskEngine(containerChangeEventStream,
@@ -227,22 +237,6 @@ func (agent *ecsAgent) doStart(containerChangeEventStream *eventstream.EventStre
 	if err != nil {
 		seelog.Criticalf("Error creating state manager: %v", err)
 		return exitcodes.ExitTerminal
-	}
-
-	// Conditionally create '/ecs' cgroup root
-	if agent.cfg.TaskCPUMemLimit.Enabled() {
-		agent.resource.ApplyConfigDependencies(agent.cfg)
-		err = agent.resource.Init()
-		// When task CPU and memory limits are enabled, all tasks are placed
-		// under the '/ecs' cgroup root.
-		if err != nil {
-			if agent.cfg.TaskCPUMemLimit == config.ExplicitlyEnabled {
-				seelog.Criticalf("Unable to setup '/ecs' cgroup: %v", err)
-				return exitcodes.ExitTerminal
-			}
-			seelog.Warnf("Disabling TaskCPUMemLimit because agent is unabled to setup '/ecs' cgroup: %v", err)
-			agent.cfg.TaskCPUMemLimit = config.ExplicitlyDisabled
-		}
 	}
 
 	var vpcSubnetAttributes []*ecs.Attribute
@@ -316,13 +310,14 @@ func (agent *ecsAgent) newTaskEngine(containerChangeEventStream *eventstream.Eve
 		seelog.Info("Checkpointing not enabled; a new container instance will be created each time the agent is run")
 		return engine.NewTaskEngine(agent.cfg, agent.dockerClient, credentialsManager,
 			containerChangeEventStream, imageManager, state,
-			agent.metadataManager, agent.resource), "", nil
+			agent.metadataManager, agent.resourceFields), "", nil
 	}
 
 	// We try to set these values by loading the existing state file first
 	var previousCluster, previousEC2InstanceID, previousContainerInstanceArn string
 	previousTaskEngine := engine.NewTaskEngine(agent.cfg, agent.dockerClient,
-		credentialsManager, containerChangeEventStream, imageManager, state, agent.metadataManager, agent.resource)
+		credentialsManager, containerChangeEventStream, imageManager, state,
+		agent.metadataManager, agent.resourceFields)
 
 	// previousStateManager is used to verify that our current runtime configuration is
 	// compatible with our past configuration as reflected by our state-file
@@ -354,7 +349,8 @@ func (agent *ecsAgent) newTaskEngine(containerChangeEventStream *eventstream.Eve
 		state.Reset()
 		// Reset taskEngine; all the other values are still default
 		return engine.NewTaskEngine(agent.cfg, agent.dockerClient, credentialsManager,
-			containerChangeEventStream, imageManager, state, agent.metadataManager, agent.resource), currentEC2InstanceID, nil
+			containerChangeEventStream, imageManager, state, agent.metadataManager,
+			agent.resourceFields), currentEC2InstanceID, nil
 	}
 
 	if previousCluster != "" {

--- a/agent/app/agent_unix.go
+++ b/agent/app/agent_unix.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/ec2"
 	"github.com/aws/amazon-ecs-agent/agent/ecscni"
 	"github.com/aws/amazon-ecs-agent/agent/engine"
@@ -26,7 +27,10 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/eni/pause"
 	"github.com/aws/amazon-ecs-agent/agent/eni/udevwrapper"
 	"github.com/aws/amazon-ecs-agent/agent/eni/watcher"
+	"github.com/aws/amazon-ecs-agent/agent/resources/cgroup"
 	"github.com/aws/amazon-ecs-agent/agent/statechange"
+	"github.com/aws/amazon-ecs-agent/agent/taskresource"
+	"github.com/aws/amazon-ecs-agent/agent/utils/ioutilwrapper"
 	"github.com/cihub/seelog"
 	"github.com/pkg/errors"
 )
@@ -182,4 +186,28 @@ func contains(capabilities []string, capability string) bool {
 	}
 
 	return false
+}
+
+// initializeResourceFields exists mainly for testing doStart() to use mock Control
+// object
+func (agent *ecsAgent) initializeResourceFields() {
+	agent.resourceFields = &taskresource.ResourceFields{
+		Control: cgroup.New(),
+		IOUtil:  ioutilwrapper.NewIOUtil(),
+	}
+}
+
+func (agent *ecsAgent) cgroupInit() error {
+	err := agent.resourceFields.Control.Init()
+	// When task CPU and memory limits are enabled, all tasks are placed
+	// under the '/ecs' cgroup root.
+	if err == nil {
+		return nil
+	}
+	if agent.cfg.TaskCPUMemLimit == config.ExplicitlyEnabled {
+		return errors.Wrapf(err, "unable to setup '/ecs' cgroup")
+	}
+	seelog.Warnf("Disabling TaskCPUMemLimit because agent is unabled to setup '/ecs' cgroup: %v", err)
+	agent.cfg.TaskCPUMemLimit = config.ExplicitlyDisabled
+	return nil
 }

--- a/agent/app/agent_windows.go
+++ b/agent/app/agent_windows.go
@@ -246,3 +246,9 @@ func (t *termHandlerIndicator) wait() uint32 {
 	defer t.mu.Unlock()
 	return t.exitCode
 }
+
+func (agent *ecsAgent) initializeResourceFields() {}
+
+func (agent *ecsAgent) cgroupInit() error {
+	return errors.New("unsupported platform")
+}

--- a/agent/app/agent_windows_test.go
+++ b/agent/app/agent_windows_test.go
@@ -21,8 +21,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/ec2"
 	"github.com/aws/amazon-ecs-agent/agent/engine/mocks"
+	"github.com/aws/amazon-ecs-agent/agent/eventstream"
 	"github.com/aws/amazon-ecs-agent/agent/sighandlers"
+	"github.com/aws/amazon-ecs-agent/agent/sighandlers/exitcodes"
 	statemanager_mocks "github.com/aws/amazon-ecs-agent/agent/statemanager/mocks"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -265,4 +269,29 @@ func TestHandler_Execute_AgentStops(t *testing.T) {
 	}()
 
 	wg.Wait()
+}
+
+func TestDoStartTaskLimitsFail(t *testing.T) {
+	ctrl, credentialsManager, state, imageManager, client,
+		dockerClient, stateManagerFactory, saveableOptionFactory := setup(t)
+	defer ctrl.Finish()
+
+	cfg := getTestConfig()
+	cfg.Checkpoint = true
+	cfg.TaskCPUMemLimit = config.ExplicitlyEnabled
+	ctx, cancel := context.WithCancel(context.TODO())
+	// Cancel the context to cancel async routines
+	defer cancel()
+	agent := &ecsAgent{
+		ctx:                   ctx,
+		cfg:                   &cfg,
+		dockerClient:          dockerClient,
+		stateManagerFactory:   stateManagerFactory,
+		saveableOptionFactory: saveableOptionFactory,
+		ec2MetadataClient:     ec2.NewBlackholeEC2MetadataClient(),
+	}
+
+	exitCode := agent.doStart(eventstream.NewEventStream("events", ctx),
+		credentialsManager, state, imageManager, client)
+	assert.Equal(t, exitcodes.ExitTerminal, exitCode)
 }

--- a/agent/engine/default.go
+++ b/agent/engine/default.go
@@ -22,7 +22,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
-	"github.com/aws/amazon-ecs-agent/agent/resources"
+	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 )
 
 // NewTaskEngine returns a default TaskEngine
@@ -31,11 +31,11 @@ func NewTaskEngine(cfg *config.Config, client dockerapi.DockerClient,
 	containerChangeEventStream *eventstream.EventStream,
 	imageManager ImageManager, state dockerstate.TaskEngineState,
 	metadataManager containermetadata.Manager,
-	resource resources.Resource) TaskEngine {
+	resourceFields *taskresource.ResourceFields) TaskEngine {
 
 	taskEngine := NewDockerTaskEngine(cfg, client, credentialsManager,
 		containerChangeEventStream, imageManager,
-		state, metadataManager, resource)
+		state, metadataManager, resourceFields)
 
 	return taskEngine
 }

--- a/agent/engine/docker_task_engine_linux_test.go
+++ b/agent/engine/docker_task_engine_linux_test.go
@@ -67,8 +67,7 @@ func TestResourceContainerProgression(t *testing.T) {
 	assert.NoError(t, err)
 	cgroupMemoryPath := fmt.Sprintf("/sys/fs/cgroup/memory/ecs/%s/memory.use_hierarchy", taskID)
 	cgroupRoot := fmt.Sprintf("/ecs/%s", taskID)
-	cgroupResource := cgroup.NewCgroupResource(sleepTask.Arn, mockControl, cgroupRoot, cgroupMountPath, specs.LinuxResources{})
-	cgroupResource.SetIOUtil(mockIO)
+	cgroupResource := cgroup.NewCgroupResource(sleepTask.Arn, mockControl, mockIO, cgroupRoot, cgroupMountPath, specs.LinuxResources{})
 
 	sleepTask.Resources = []taskresource.TaskResource{cgroupResource}
 	sleepTask.Resources[0].SetDesiredStatus(taskresource.ResourceCreated)
@@ -143,7 +142,7 @@ func TestResourceContainerProgressionFailure(t *testing.T) {
 	taskID, err := sleepTask.GetID()
 	assert.NoError(t, err)
 	cgroupRoot := fmt.Sprintf("/ecs/%s", taskID)
-	cgroupResource := cgroup.NewCgroupResource(sleepTask.Arn, mockControl, cgroupRoot, cgroupMountPath, specs.LinuxResources{})
+	cgroupResource := cgroup.NewCgroupResource(sleepTask.Arn, mockControl, nil, cgroupRoot, cgroupMountPath, specs.LinuxResources{})
 
 	sleepTask.Resources = []taskresource.TaskResource{cgroupResource}
 	sleepTask.Resources[0].SetDesiredStatus(taskresource.ResourceCreated)

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -40,7 +40,6 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/engine/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/engine/testdata"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
-	"github.com/aws/amazon-ecs-agent/agent/resources/mock_resources"
 	"github.com/aws/amazon-ecs-agent/agent/statemanager/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/utils/ttime/mocks"
 	"github.com/aws/aws-sdk-go/aws"
@@ -112,10 +111,9 @@ func mocks(t *testing.T, ctx context.Context, cfg *config.Config) (*gomock.Contr
 	containerChangeEventStream.StartListening()
 	imageManager := mock_engine.NewMockImageManager(ctrl)
 	metadataManager := mock_containermetadata.NewMockManager(ctrl)
-	mockResource := mock_resources.NewMockResource(ctrl)
 
 	taskEngine := NewTaskEngine(cfg, client, credentialsManager, containerChangeEventStream,
-		imageManager, dockerstate.NewTaskEngineState(), metadataManager, mockResource)
+		imageManager, dockerstate.NewTaskEngineState(), metadataManager, nil)
 	taskEngine.(*DockerTaskEngine)._time = mockTime
 	taskEngine.(*DockerTaskEngine).ctx = ctx
 
@@ -155,13 +153,6 @@ func TestBatchContainerHappyPath(t *testing.T) {
 			metadataCleanError:  errors.New("clean metadata error"),
 			taskCPULimit:        config.ExplicitlyDisabled,
 		},
-		{
-			name:                "Task CPU Limit Succeeds",
-			metadataCreateError: nil,
-			metadataUpdateError: nil,
-			metadataCleanError:  nil,
-			taskCPULimit:        config.ExplicitlyEnabled,
-		},
 	}
 
 	for _, tc := range testcases {
@@ -197,18 +188,6 @@ func TestBatchContainerHappyPath(t *testing.T) {
 				name := <-containerName
 				setCreatedContainerName(name)
 			}()
-			mockResource := mock_resources.NewMockResource(ctrl)
-			if tc.taskCPULimit.Enabled() {
-				taskEngine.(*DockerTaskEngine).resource = mockResource
-				// TODO Currently, the resource Setup() method gets invoked multiple
-				// times for a task. This is really a bug and a fortunate occurrence
-				// that cgroup creation APIs behave idempotently.
-				//
-				// This should be modified so that 'Setup' is invoked exactly once
-				// by moving the cgroup creation to a "resource setup" step in the
-				// task life-cycle and performing the setup only in this stage
-				mockResource.EXPECT().Setup(sleepTask).Return(nil).MinTimes(1)
-			}
 
 			for _, container := range sleepTask.Containers {
 				validateContainerRunWorkflow(t, container, sleepTask, imageManager,
@@ -253,10 +232,6 @@ func TestBatchContainerHappyPath(t *testing.T) {
 			// As above, duplicate events should not be a problem
 			taskEngine.AddTask(sleepTaskStop)
 			taskEngine.AddTask(sleepTaskStop)
-
-			if tc.taskCPULimit.Enabled() {
-				mockResource.EXPECT().Cleanup(sleepTask).Return(nil)
-			}
 			// Expect a bunch of steady state 'poll' describes when we trigger cleanup
 			client.EXPECT().RemoveContainer(gomock.Any(), gomock.Any(), gomock.Any()).Do(
 				func(ctx interface{}, removedContainerName string, timeout time.Duration) {

--- a/agent/engine/docker_task_engine_unix_test.go
+++ b/agent/engine/docker_task_engine_unix_test.go
@@ -16,18 +16,27 @@ package engine
 
 import (
 	"context"
-	"errors"
+	"fmt"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/credentials"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	"github.com/aws/amazon-ecs-agent/agent/emptyvolume"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate/mocks"
-	"github.com/aws/amazon-ecs-agent/agent/resources/mock_resources"
+	"github.com/aws/amazon-ecs-agent/agent/engine/testdata"
+	"github.com/aws/amazon-ecs-agent/agent/resources/cgroup/mock_control"
 	"github.com/aws/amazon-ecs-agent/agent/statemanager/mocks"
+	"github.com/aws/amazon-ecs-agent/agent/taskresource"
+	"github.com/aws/amazon-ecs-agent/agent/taskresource/cgroup"
+	"github.com/aws/amazon-ecs-agent/agent/utils/ioutilwrapper/mocks"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/golang/mock/gomock"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -70,26 +79,28 @@ func TestDeleteTask(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	mockControl := mock_cgroup.NewMockControl(ctrl)
+	cgroupResource := cgroup.NewCgroupResource("", mockControl, nil, "cgroupRoot", "", specs.LinuxResources{})
 	task := &api.Task{
 		ENI: &api.ENI{
 			MacAddress: mac,
 		},
+		Resources: []taskresource.TaskResource{cgroupResource},
 	}
 
 	cfg := defaultConfig
 	cfg.TaskCPUMemLimit = config.ExplicitlyEnabled
 	mockState := mock_dockerstate.NewMockTaskEngineState(ctrl)
 	mockSaver := mock_statemanager.NewMockStateManager(ctrl)
-	mockResource := mock_resources.NewMockResource(ctrl)
+
 	taskEngine := &DockerTaskEngine{
-		state:    mockState,
-		saver:    mockSaver,
-		cfg:      &cfg,
-		resource: mockResource,
+		state: mockState,
+		saver: mockSaver,
+		cfg:   &cfg,
 	}
 
 	gomock.InOrder(
-		mockResource.EXPECT().Cleanup(task).Return(errors.New("error")),
+		mockControl.EXPECT().Remove("cgroupRoot").Return(nil),
 		mockState.EXPECT().RemoveTask(task),
 		mockState.EXPECT().RemoveENIAttachment(mac),
 		mockSaver.EXPECT().Save(),
@@ -115,4 +126,152 @@ func TestEngineDisableConcurrentPull(t *testing.T) {
 	dockerTaskEngine, _ := taskEngine.(*DockerTaskEngine)
 	assert.False(t, dockerTaskEngine.enableConcurrentPull,
 		"Task engine should not be able to perform concurrent pulling for version < 1.11.1")
+}
+
+func TestTaskCPULimitHappyPath(t *testing.T) {
+	testcases := []struct {
+		name                string
+		metadataCreateError error
+		metadataUpdateError error
+		metadataCleanError  error
+		taskCPULimit        config.Conditional
+	}{
+		{
+			name:                "Task CPU Limit Succeeds",
+			metadataCreateError: nil,
+			metadataUpdateError: nil,
+			metadataCleanError:  nil,
+			taskCPULimit:        config.ExplicitlyEnabled,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			metadataConfig := defaultConfig
+			metadataConfig.TaskCPUMemLimit = tc.taskCPULimit
+			metadataConfig.ContainerMetadataEnabled = true
+			ctx, cancel := context.WithCancel(context.TODO())
+			defer cancel()
+			ctrl, client, mockTime, taskEngine, credentialsManager, imageManager, metadataManager := mocks(
+				t, ctx, &metadataConfig)
+			defer ctrl.Finish()
+
+			roleCredentials := credentials.TaskIAMRoleCredentials{
+				IAMRoleCredentials: credentials.IAMRoleCredentials{CredentialsID: "credsid"},
+			}
+			credentialsManager.EXPECT().GetTaskCredentials(credentialsID).Return(roleCredentials, true).AnyTimes()
+			credentialsManager.EXPECT().RemoveCredentials(credentialsID)
+
+			sleepTask := testdata.LoadTask("sleep5")
+			sleepContainer := sleepTask.Containers[0]
+			sleepContainer.TransitionDependenciesMap = make(map[apicontainer.ContainerStatus]apicontainer.TransitionDependencySet)
+			sleepTask.SetCredentialsID(credentialsID)
+			eventStream := make(chan dockerapi.DockerContainerChangeEvent)
+			// containerEventsWG is used to force the test to wait until the container created and started
+			// events are processed
+			containerEventsWG := sync.WaitGroup{}
+
+			if dockerVersionCheckDuringInit {
+				client.EXPECT().Version().Return("1.12.6", nil)
+			}
+			client.EXPECT().ContainerEvents(gomock.Any()).Return(eventStream, nil)
+			containerName := make(chan string)
+			go func() {
+				name := <-containerName
+				setCreatedContainerName(name)
+			}()
+			mockControl := mock_cgroup.NewMockControl(ctrl)
+			mockIO := mock_ioutilwrapper.NewMockIOUtil(ctrl)
+			taskID, err := sleepTask.GetID()
+			assert.NoError(t, err)
+			cgroupMemoryPath := fmt.Sprintf("/sys/fs/cgroup/memory/ecs/%s/memory.use_hierarchy", taskID)
+			if tc.taskCPULimit.Enabled() {
+				// TODO Currently, the resource Setup() method gets invoked multiple
+				// times for a task. This is really a bug and a fortunate occurrence
+				// that cgroup creation APIs behave idempotently.
+				//
+				// This should be modified so that 'Setup' is invoked exactly once
+				// by moving the cgroup creation to a "resource setup" step in the
+				// task life-cycle and performing the setup only in this stage
+				taskEngine.(*DockerTaskEngine).resourceFields = &taskresource.ResourceFields{
+					Control: mockControl,
+					IOUtil:  mockIO,
+				}
+				mockControl.EXPECT().Exists(gomock.Any()).Return(false)
+				mockControl.EXPECT().Create(gomock.Any()).Return(nil, nil)
+				mockIO.EXPECT().WriteFile(cgroupMemoryPath, gomock.Any(), gomock.Any()).Return(nil)
+			}
+
+			for _, container := range sleepTask.Containers {
+				validateContainerRunWorkflow(t, container, sleepTask, imageManager,
+					client, &roleCredentials, containerEventsWG,
+					eventStream, containerName, func() {
+						metadataManager.EXPECT().Create(gomock.Any(), gomock.Any(),
+							gomock.Any(), gomock.Any()).Return(tc.metadataCreateError)
+						metadataManager.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any(),
+							gomock.Any()).Return(tc.metadataUpdateError)
+					})
+			}
+
+			addTaskToEngine(t, ctx, taskEngine, sleepTask, mockTime, containerEventsWG)
+			cleanup := make(chan time.Time, 1)
+			defer close(cleanup)
+			mockTime.EXPECT().After(gomock.Any()).Return(cleanup).MinTimes(1)
+			client.EXPECT().DescribeContainer(gomock.Any(), gomock.Any()).AnyTimes()
+			// Simulate a container stop event from docker
+			eventStream <- dockerapi.DockerContainerChangeEvent{
+				Status: apicontainer.ContainerStopped,
+				DockerContainerMetadata: dockerapi.DockerContainerMetadata{
+					DockerID: containerID,
+					ExitCode: aws.Int(exitCode),
+				},
+			}
+
+			// StopContainer might be invoked if the test execution is slow, during
+			// the cleanup phase. Account for that.
+			client.EXPECT().StopContainer(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+				dockerapi.DockerContainerMetadata{DockerID: containerID}).AnyTimes()
+			waitForStopEvents(t, taskEngine.StateChangeEvents(), true)
+			// This ensures that managedTask.waitForStopReported makes progress
+			sleepTask.SetSentStatus(api.TaskStopped)
+			// Extra events should not block forever; duplicate acs and docker events are possible
+			go func() { eventStream <- createDockerEvent(apicontainer.ContainerStopped) }()
+			go func() { eventStream <- createDockerEvent(apicontainer.ContainerStopped) }()
+
+			sleepTaskStop := testdata.LoadTask("sleep5")
+			sleepContainer = sleepTaskStop.Containers[0]
+			sleepContainer.TransitionDependenciesMap = make(map[apicontainer.ContainerStatus]apicontainer.TransitionDependencySet)
+			sleepTaskStop.SetCredentialsID(credentialsID)
+			sleepTaskStop.SetDesiredStatus(api.TaskStopped)
+			taskEngine.AddTask(sleepTaskStop)
+			// As above, duplicate events should not be a problem
+			taskEngine.AddTask(sleepTaskStop)
+			taskEngine.AddTask(sleepTaskStop)
+			cgroupRoot := fmt.Sprintf("/ecs/%s", taskID)
+			if tc.taskCPULimit.Enabled() {
+				mockControl.EXPECT().Remove(cgroupRoot).Return(nil)
+			}
+			// Expect a bunch of steady state 'poll' describes when we trigger cleanup
+			client.EXPECT().RemoveContainer(gomock.Any(), gomock.Any(), gomock.Any()).Do(
+				func(ctx interface{}, removedContainerName string, timeout time.Duration) {
+					assert.Equal(t, getCreatedContainerName(), removedContainerName,
+						"Container name mismatch")
+				}).Return(nil)
+
+			imageManager.EXPECT().RemoveContainerReferenceFromImageState(gomock.Any())
+			metadataManager.EXPECT().Clean(gomock.Any()).Return(tc.metadataCleanError)
+			// trigger cleanup
+			cleanup <- time.Now()
+			go func() { eventStream <- createDockerEvent(apicontainer.ContainerStopped) }()
+			// Wait for the task to actually be dead; if we just fallthrough immediately,
+			// the remove might not have happened (expectation failure)
+			for {
+				tasks, _ := taskEngine.(*DockerTaskEngine).ListTasks()
+				if len(tasks) == 0 {
+					break
+				}
+				time.Sleep(5 * time.Millisecond)
+			}
+		})
+	}
 }

--- a/agent/engine/engine_integ_test.go
+++ b/agent/engine/engine_integ_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/ec2"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
-	"github.com/aws/amazon-ecs-agent/agent/resources"
 	"github.com/aws/amazon-ecs-agent/agent/statemanager"
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/stretchr/testify/assert"
@@ -100,11 +99,9 @@ func setup(cfg *config.Config, state dockerstate.TaskEngineState, t *testing.T) 
 	imageManager := NewImageManager(cfg, dockerClient, state)
 	imageManager.SetSaver(statemanager.NewNoopStateManager())
 	metadataManager := containermetadata.NewManager(dockerClient, cfg)
-	resource := resources.New()
-	resource.ApplyConfigDependencies(cfg)
 
 	taskEngine := NewDockerTaskEngine(cfg, dockerClient, credentialsManager,
-		eventstream.NewEventStream("ENGINEINTEGTEST", context.Background()), imageManager, state, metadataManager, resource)
+		eventstream.NewEventStream("ENGINEINTEGTEST", context.Background()), imageManager, state, metadataManager, nil)
 	taskEngine.MustInit(context.TODO())
 	return taskEngine, func() {
 		taskEngine.Shutdown()

--- a/agent/engine/interface.go
+++ b/agent/engine/interface.go
@@ -17,6 +17,7 @@ import (
 	"encoding/json"
 
 	"context"
+
 	"github.com/aws/amazon-ecs-agent/agent/api"
 	"github.com/aws/amazon-ecs-agent/agent/statechange"
 	"github.com/aws/amazon-ecs-agent/agent/statemanager"
@@ -39,7 +40,7 @@ type TaskEngine interface {
 
 	// AddTask adds a new task to the task engine and manages its container's
 	// lifecycle. If it returns an error, the task was not added.
-	AddTask(*api.Task) error
+	AddTask(*api.Task)
 
 	// ListTasks lists all the tasks being managed by the TaskEngine.
 	ListTasks() ([]*api.Task, error)

--- a/agent/engine/mocks/engine_mocks.go
+++ b/agent/engine/mocks/engine_mocks.go
@@ -53,10 +53,8 @@ func (m *MockTaskEngine) EXPECT() *MockTaskEngineMockRecorder {
 }
 
 // AddTask mocks base method
-func (m *MockTaskEngine) AddTask(arg0 *api.Task) error {
-	ret := m.ctrl.Call(m, "AddTask", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
+func (m *MockTaskEngine) AddTask(arg0 *api.Task) {
+	m.ctrl.Call(m, "AddTask", arg0)
 }
 
 // AddTask indicates an expected call of AddTask

--- a/agent/statemanager/state_manager_test.go
+++ b/agent/statemanager/state_manager_test.go
@@ -40,7 +40,8 @@ func TestLoadsV1DataCorrectly(t *testing.T) {
 	defer cleanup()
 	cfg := &config.Config{DataDir: filepath.Join(".", "testdata", "v1", "1")}
 
-	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil)
+	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(),
+		nil, nil)
 	var containerInstanceArn, cluster, savedInstanceID string
 	var sequenceNumber int64
 

--- a/agent/statemanager/state_manager_unix_test.go
+++ b/agent/statemanager/state_manager_unix_test.go
@@ -43,9 +43,11 @@ func TestStateManager(t *testing.T) {
 
 	// Now let's make some state to save
 	containerInstanceArn := ""
-	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil)
+	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(),
+		nil, nil)
 
-	manager, err = statemanager.NewStateManager(cfg, statemanager.AddSaveable("TaskEngine", taskEngine), statemanager.AddSaveable("ContainerInstanceArn", &containerInstanceArn))
+	manager, err = statemanager.NewStateManager(cfg, statemanager.AddSaveable("TaskEngine", taskEngine),
+		statemanager.AddSaveable("ContainerInstanceArn", &containerInstanceArn))
 	require.Nil(t, err)
 
 	containerInstanceArn = "containerInstanceArn"
@@ -59,10 +61,12 @@ func TestStateManager(t *testing.T) {
 	assertFileMode(t, filepath.Join(tmpDir, "ecs_agent_data.json"))
 
 	// Now make sure we can load that state sanely
-	loadedTaskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil)
+	loadedTaskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(),
+		nil, nil)
 	var loadedContainerInstanceArn string
 
-	manager, err = statemanager.NewStateManager(cfg, statemanager.AddSaveable("TaskEngine", &loadedTaskEngine), statemanager.AddSaveable("ContainerInstanceArn", &loadedContainerInstanceArn))
+	manager, err = statemanager.NewStateManager(cfg, statemanager.AddSaveable("TaskEngine", &loadedTaskEngine),
+		statemanager.AddSaveable("ContainerInstanceArn", &loadedContainerInstanceArn))
 	require.Nil(t, err)
 
 	err = manager.Load()

--- a/agent/stats/common_test.go
+++ b/agent/stats/common_test.go
@@ -267,8 +267,7 @@ func (engine *MockTaskEngine) StateChangeEvents() chan statechange.Event {
 func (engine *MockTaskEngine) SetSaver(statemanager.Saver) {
 }
 
-func (engine *MockTaskEngine) AddTask(*api.Task) error {
-	return nil
+func (engine *MockTaskEngine) AddTask(*api.Task) {
 }
 
 func (engine *MockTaskEngine) ListTasks() ([]*api.Task, error) {

--- a/agent/stats/engine_integ_test.go
+++ b/agent/stats/engine_integ_test.go
@@ -340,7 +340,8 @@ func TestStatsEngineWithNewContainers(t *testing.T) {
 
 func TestStatsEngineWithDockerTaskEngine(t *testing.T) {
 	containerChangeEventStream := eventStream("TestStatsEngineWithDockerTaskEngine")
-	taskEngine := ecsengine.NewTaskEngine(&config.Config{}, nil, nil, containerChangeEventStream, nil, dockerstate.NewTaskEngineState(), nil, nil)
+	taskEngine := ecsengine.NewTaskEngine(&config.Config{}, nil, nil, containerChangeEventStream,
+		nil, dockerstate.NewTaskEngineState(), nil, nil)
 	container, err := createHealthContainer(client)
 	require.NoError(t, err, "creating container failed")
 
@@ -426,7 +427,8 @@ func TestStatsEngineWithDockerTaskEngine(t *testing.T) {
 
 func TestStatsEngineWithDockerTaskEngineMissingRemoveEvent(t *testing.T) {
 	containerChangeEventStream := eventStream("TestStatsEngineWithDockerTaskEngineMissingRemoveEvent")
-	taskEngine := ecsengine.NewTaskEngine(&config.Config{}, nil, nil, containerChangeEventStream, nil, dockerstate.NewTaskEngineState(), nil, nil)
+	taskEngine := ecsengine.NewTaskEngine(&config.Config{}, nil, nil, containerChangeEventStream,
+		nil, dockerstate.NewTaskEngineState(), nil, nil)
 
 	container, err := createHealthContainer(client)
 	require.NoError(t, err, "creating container failed")

--- a/agent/taskresource/cgroup/cgroup.go
+++ b/agent/taskresource/cgroup/cgroup.go
@@ -60,22 +60,23 @@ type CgroupResource struct {
 	appliedStatus                      taskresource.ResourceStatus
 	resourceStatusToTransitionFunction map[taskresource.ResourceStatus]func() error
 	// lock is used for fields that are accessed and updated concurrently
-	lock sync.RWMutex
+	lock				   sync.RWMutex
 }
 
 // NewCgroupResource is used to return an object that implements the Resource interface
 func NewCgroupResource(taskARN string,
 	control cgroupres.Control,
+	ioutil ioutilwrapper.IOUtil,
 	cgroupRoot string,
 	cgroupMountPath string,
 	resourceSpec specs.LinuxResources) *CgroupResource {
 	c := &CgroupResource{
 		taskARN:         taskARN,
 		control:         control,
+		ioutil:          ioutil,
 		cgroupRoot:      cgroupRoot,
 		cgroupMountPath: cgroupMountPath,
 		resourceSpec:    resourceSpec,
-		ioutil:          ioutilwrapper.NewIOUtil(),
 	}
 	c.initializeResourceStatusToTransitionFunction()
 	return c

--- a/agent/taskresource/cgroup/cgroup_test.go
+++ b/agent/taskresource/cgroup/cgroup_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/amazon-ecs-agent/agent/engine/testdata"
 	"github.com/aws/amazon-ecs-agent/agent/resources/cgroup"
 	"github.com/aws/amazon-ecs-agent/agent/resources/cgroup/factory/mock"
 	"github.com/aws/amazon-ecs-agent/agent/resources/cgroup/mock_control"
@@ -38,6 +37,7 @@ const (
 	invalidTaskArn  = "invalid:task::arn"
 	cgroupMountPath = "/sys/fs/cgroup"
 	taskName        = "sleep5TaskCgroup"
+	taskID          = "taskID"
 )
 
 func TestCreateHappyPath(t *testing.T) {
@@ -47,9 +47,6 @@ func TestCreateHappyPath(t *testing.T) {
 	mockControl := mock_cgroup.NewMockControl(ctrl)
 	mockIO := mock_ioutilwrapper.NewMockIOUtil(ctrl)
 
-	task := testdata.LoadTask(taskName)
-	taskID, err := task.GetID()
-	assert.NoError(t, err)
 	cgroupMemoryPath := fmt.Sprintf("/sys/fs/cgroup/memory/ecs/%s/memory.use_hierarchy", taskID)
 	cgroupRoot := fmt.Sprintf("/ecs/%s", taskID)
 
@@ -58,8 +55,7 @@ func TestCreateHappyPath(t *testing.T) {
 		mockControl.EXPECT().Create(gomock.Any()).Return(nil, nil),
 		mockIO.EXPECT().WriteFile(cgroupMemoryPath, gomock.Any(), gomock.Any()).Return(nil),
 	)
-	cgroupResource := NewCgroupResource(task.Arn, mockControl, cgroupRoot, cgroupMountPath, specs.LinuxResources{})
-	cgroupResource.ioutil = mockIO
+	cgroupResource := NewCgroupResource("taskArn", mockControl, mockIO, cgroupRoot, cgroupMountPath, specs.LinuxResources{})
 	assert.NoError(t, cgroupResource.Create())
 }
 
@@ -70,17 +66,13 @@ func TestCreateCgroupPathExists(t *testing.T) {
 	mockControl := mock_cgroup.NewMockControl(ctrl)
 	mockIO := mock_ioutilwrapper.NewMockIOUtil(ctrl)
 
-	task := testdata.LoadTask(taskName)
-	taskID, err := task.GetID()
-	assert.NoError(t, err)
 	cgroupRoot := fmt.Sprintf("/ecs/%s", taskID)
 
 	gomock.InOrder(
 		mockControl.EXPECT().Exists(gomock.Any()).Return(true),
 	)
 
-	cgroupResource := NewCgroupResource(task.Arn, mockControl, cgroupRoot, cgroupMountPath, specs.LinuxResources{})
-	cgroupResource.ioutil = mockIO
+	cgroupResource := NewCgroupResource("taskArn", mockControl, mockIO, cgroupRoot, cgroupMountPath, specs.LinuxResources{})
 	assert.NoError(t, cgroupResource.Create())
 }
 
@@ -92,9 +84,6 @@ func TestCreateCgroupError(t *testing.T) {
 	mockIO := mock_ioutilwrapper.NewMockIOUtil(ctrl)
 	mockCgroup := mock_cgroups.NewMockCgroup(ctrl)
 
-	task := testdata.LoadTask(taskName)
-	taskID, err := task.GetID()
-	assert.NoError(t, err)
 	cgroupRoot := fmt.Sprintf("/ecs/%s", taskID)
 
 	gomock.InOrder(
@@ -102,8 +91,7 @@ func TestCreateCgroupError(t *testing.T) {
 		mockControl.EXPECT().Create(gomock.Any()).Return(mockCgroup, errors.New("cgroup create error")),
 	)
 
-	cgroupResource := NewCgroupResource(task.Arn, mockControl, cgroupRoot, cgroupMountPath, specs.LinuxResources{})
-	cgroupResource.ioutil = mockIO
+	cgroupResource := NewCgroupResource("taskArn", mockControl, mockIO, cgroupRoot, cgroupMountPath, specs.LinuxResources{})
 	assert.Error(t, cgroupResource.Create())
 }
 
@@ -112,14 +100,11 @@ func TestCleanupHappyPath(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockControl := mock_cgroup.NewMockControl(ctrl)
-	task := testdata.LoadTask(taskName)
-	taskID, err := task.GetID()
-	assert.NoError(t, err)
 	cgroupRoot := fmt.Sprintf("/ecs/%s", taskID)
 
 	mockControl.EXPECT().Remove(cgroupRoot).Return(nil)
 
-	cgroupResource := NewCgroupResource(task.Arn, mockControl, cgroupRoot, cgroupMountPath, specs.LinuxResources{})
+	cgroupResource := NewCgroupResource("taskArn", mockControl, nil, cgroupRoot, cgroupMountPath, specs.LinuxResources{})
 	assert.NoError(t, cgroupResource.Cleanup())
 }
 
@@ -128,14 +113,11 @@ func TestCleanupRemoveError(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockControl := mock_cgroup.NewMockControl(ctrl)
-	task := testdata.LoadTask(taskName)
-	taskID, err := task.GetID()
-	assert.NoError(t, err)
 	cgroupRoot := fmt.Sprintf("/ecs/%s", taskID)
 
 	mockControl.EXPECT().Remove(gomock.Any()).Return(errors.New("cgroup remove error"))
 
-	cgroupResource := NewCgroupResource(task.Arn, mockControl, cgroupRoot, cgroupMountPath, specs.LinuxResources{})
+	cgroupResource := NewCgroupResource("taskArn", mockControl, nil, cgroupRoot, cgroupMountPath, specs.LinuxResources{})
 	assert.Error(t, cgroupResource.Cleanup())
 }
 
@@ -144,14 +126,11 @@ func TestCleanupCgroupDeletedError(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockControl := mock_cgroup.NewMockControl(ctrl)
-	task := testdata.LoadTask(taskName)
-	taskID, err := task.GetID()
-	assert.NoError(t, err)
 	cgroupRoot := fmt.Sprintf("/ecs/%s", taskID)
 
 	mockControl.EXPECT().Remove(gomock.Any()).Return(cgroups.ErrCgroupDeleted)
 
-	cgroupResource := NewCgroupResource(task.Arn, mockControl, cgroupRoot, cgroupMountPath, specs.LinuxResources{})
+	cgroupResource := NewCgroupResource("taskArn", mockControl, nil, cgroupRoot, cgroupMountPath, specs.LinuxResources{})
 	assert.NoError(t, cgroupResource.Cleanup())
 }
 
@@ -162,7 +141,7 @@ func TestMarshal(t *testing.T) {
 	cgroupRoot := "/ecs/taskid"
 	cgroupMountPath := "/sys/fs/cgroup"
 
-	cgroup := NewCgroupResource("", cgroup.New(), cgroupRoot, cgroupMountPath, specs.LinuxResources{})
+	cgroup := NewCgroupResource("", cgroup.New(), nil, cgroupRoot, cgroupMountPath, specs.LinuxResources{})
 	cgroup.SetDesiredStatus(taskresource.ResourceStatus(CgroupCreated))
 	cgroup.SetKnownStatus(taskresource.ResourceStatus(CgroupStatusNone))
 

--- a/agent/taskresource/types_unix.go
+++ b/agent/taskresource/types_unix.go
@@ -1,0 +1,28 @@
+// +build linux
+
+// Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package taskresource
+
+import (
+	"github.com/aws/amazon-ecs-agent/agent/resources/cgroup"
+	"github.com/aws/amazon-ecs-agent/agent/utils/ioutilwrapper"
+)
+
+// ResourceFields is the list of fields required for creation of task resources
+// obtained from engine
+type ResourceFields struct {
+	Control cgroup.Control
+	IOUtil  ioutilwrapper.IOUtil
+}

--- a/agent/taskresource/types_windows.go
+++ b/agent/taskresource/types_windows.go
@@ -1,0 +1,20 @@
+// +build windows
+
+// Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package taskresource
+
+// ResourceFields is the list of fields required for creation of task resources
+// obtained from engine
+type ResourceFields struct{}


### PR DESCRIPTION
### Summary
This PR initializes cgroup as a task resource and gets added to task and as resource dependency to the containers. Still a WIP (tests to be fixed and added).

### Implementation details
- agent uses cgroup controller directly to initialize the root cgroup `/ecs` for the instance. 
- previous cgroup implementation's create and delete function calls are removed since these are now taken care by `progressTask`.
- In `PostUnmarshalTask`, cgroup resource is initialized and added as resource dependency to the task's containers. 

passing cgroup controller object to resource creation:
In the PR, a new structure is introduced called `ResourceFields` which wraps cgroup controller created in agent/engine that is also required for cgroup resource creation in linux. This way, its easier to test by mocking out controller. 
Other ways to do this and why I was skeptical to use them: 
- pass the cgroup control object directly all the way from agent -> task engine -> task -> cgroup resource.
pros: no need for a new struct.
cons: control would now be part of everything though this is meaningless in windows, since they do not support cgroups. `_unsupported.go` files need to be added to support this.
- create `cgroup` task resource in agent.go and pass that to task through engine. 
pro: cgroup control need not be exposed to agent/engine. 
con: other things are needed to create the cgroup resource such as taskArn etc , which is not available at this point. `cgroup` resource object should ideally be created in `PostUnmarshalTask`. this is also useless in windows.
Open to discussion.

### Testing
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass
- [x] Manual testing - 
With this set of changes, a task was placed on the instance. Resource cgroup is first created, and containers do not progress until then due to dependency. Containers then progress and after task is stopped, cgroup is removed later. 

New tests cover the changes: <!-- yes|no -->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
