### PR TITLE
updating ACS model: new volume and ENI subnetGatewayIpv4Address

### DIFF
--- a/agent/acs/model/api/api-2.json
+++ b/agent/acs/model/api/api-2.json
@@ -188,6 +188,10 @@
       }
     },
     "Double":{"type":"double"},
+    "DriverType":{
+      "type":"string",
+      "enum":["Docker"]
+    },
     "ECRAuthData":{
       "type":"structure",
       "members":{
@@ -207,7 +211,8 @@
         "ipv6Addresses":{"shape":"IPv6AddressList"},
         "domainName":{"shape":"StringList"},
         "domainNameServers":{"shape":"StringList"},
-        "privateDnsName":{"shape":"String"}
+        "privateDnsName":{"shape":"String"},
+        "subnetGatewayIpv4Address":{"shape":"String"}
       }
     },
     "ElasticNetworkInterfaceList":{
@@ -415,6 +420,11 @@
       "type":"list",
       "member":{"shape":"String"}
     },
+    "StringMap":{
+      "type":"map",
+      "key":{"shape":"String"},
+      "value":{"shape":"String"}
+    },
     "Task":{
       "type":"structure",
       "members":{
@@ -463,7 +473,11 @@
       "type":"structure",
       "members":{
         "name":{"shape":"String"},
-        "host":{"shape":"HostVolumeProperties"}
+        "host":{"shape":"HostVolumeProperties"},
+        "driver":{"shape":"String"},
+        "driverOpts":{"shape":"StringMap"},
+        "labels":{"shape":"StringMap"},
+        "driverType":{"shape":"DriverType"}
       }
     },
     "VolumeFrom":{

--- a/agent/acs/model/ecsacs/api.go
+++ b/agent/acs/model/ecsacs/api.go
@@ -219,6 +219,8 @@ type ElasticNetworkInterface struct {
 	MacAddress *string `locationName:"macAddress" type:"string"`
 
 	PrivateDnsName *string `locationName:"privateDnsName" type:"string"`
+
+	SubnetGatewayIpv4Address *string `locationName:"subnetGatewayIpv4Address" type:"string"`
 }
 
 // String returns the string representation
@@ -742,7 +744,15 @@ func (s VersionInfo) GoString() string {
 type Volume struct {
 	_ struct{} `type:"structure"`
 
+	Driver *string `locationName:"driver" type:"string"`
+
+	DriverOpts map[string]*string `locationName:"driverOpts" type:"map"`
+
+	DriverType *string `locationName:"driverType" type:"string" enum:"DriverType"`
+
 	Host *HostVolumeProperties `locationName:"host" type:"structure"`
+
+	Labels map[string]*string `locationName:"labels" type:"map"`
 
 	Name *string `locationName:"name" type:"string"`
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
updating to use the latest ACS model

### Implementation details
auto-generating json and api file based on the latest ACS model

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
