### PR TITLE
dep: add makefile target to standardize dep usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ _bin/
 *-stamp
 /.idea/
 /misc/taskmetadata-validator/taskmetadata-validator
+/bin

--- a/Makefile
+++ b/Makefile
@@ -288,6 +288,23 @@ static-check: gocyclo
 
 get-deps: .get-deps-stamp
 
+
+PLATFORM:=$(shell uname -s)
+ifeq (${PLATFORM},Linux)
+		dep_arch=linux-386
+	else ifeq (${PLATFORM},Darwin)
+		dep_arch=darwin-386
+	endif
+
+DEP_VERSION=v0.4.1
+.PHONY: get-dep
+get-dep: bin/dep
+
+bin/dep:
+	mkdir -p ./bin
+	curl -L https://github.com/golang/dep/releases/download/$(DEP_VERSION)/dep-${dep_arch} -o ./bin/dep
+	chmod +x ./bin/dep
+
 clean:
 	# ensure docker is running and we can talk to it, abort if not:
 	docker ps > /dev/null
@@ -306,4 +323,5 @@ clean:
 	-rm -f .get-deps-stamp
 	-rm -f .builder-image-stamp
 	-rm -f .out-stamp
+	-rm -rf $(PWD)/bin
 


### PR DESCRIPTION
### Summary
<!-- What does this pull request do? -->
add Makefile target to track dep version used for dependency management for the repo

### Implementation details
<!-- How are the changes implemented? -->
added target for `get-dep`

<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [ ] Builds on Linux (`make release`)
- [ ] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [ ] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
