### PR TITLE
moving container related files from api/ to api/container/

### DIFF
--- a/agent/acs/handler/acs_handler_test.go
+++ b/agent/acs/handler/acs_handler_test.go
@@ -29,6 +29,7 @@ import (
 	"context"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/api/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	rolecredentials "github.com/aws/amazon-ecs-agent/agent/credentials"
@@ -1140,11 +1141,11 @@ func validateAddedTask(expectedTask api.Task, addedTask api.Task) error {
 
 // validateAddedContainer validates fields in addedContainer for expected values
 // It returns an error if there's a mismatch
-func validateAddedContainer(expectedContainer *api.Container, addedContainer *api.Container) error {
-	// The ecsacs.Task -> api.Task conversion initializes all fields in api.Container
+func validateAddedContainer(expectedContainer *apicontainer.Container, addedContainer *apicontainer.Container) error {
+	// The ecsacs.Task -> api.Task conversion initializes all fields in apicontainer.Container
 	// with empty objects. So, we create a new object to compare with only those
 	// fields that we are intrested in for comparison
-	containerToCompareFromAdded := &api.Container{
+	containerToCompareFromAdded := &apicontainer.Container{
 		Name:      addedContainer.Name,
 		CPU:       addedContainer.CPU,
 		Essential: addedContainer.Essential,

--- a/agent/api/container/container.go
+++ b/agent/api/container/container.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package api
+package container
 
 import (
 	"fmt"
@@ -37,8 +37,8 @@ const (
 	// execution role
 	awslogsAuthExecutionRole = "ExecutionRole"
 
-	// dockerHealthCheckType is the type of container health check provided by docker
-	dockerHealthCheckType = "docker"
+	// DockerHealthCheckType is the type of container health check provided by docker
+	DockerHealthCheckType = "docker"
 )
 
 // DockerConfig represents additional metadata about a container to run. It's
@@ -205,6 +205,20 @@ type DockerContainer struct {
 	DockerName string // needed for linking
 
 	Container *Container
+}
+
+// MountPoint describes the in-container location of a Volume and references
+// that Volume by name.
+type MountPoint struct {
+	SourceVolume  string `json:"sourceVolume"`
+	ContainerPath string `json:"containerPath"`
+	ReadOnly      bool   `json:"readOnly"`
+}
+
+// VolumeFrom is a volume which references another container as its source.
+type VolumeFrom struct {
+	SourceContainer string `json:"sourceContainer"`
+	ReadOnly        bool   `json:"readOnly"`
 }
 
 // String returns a human readable string representation of DockerContainer
@@ -516,7 +530,7 @@ func (c *Container) GetKnownPortBindings() []PortBinding {
 // HealthStatusShouldBeReported returns true if the health check is defined in
 // the task definition
 func (c *Container) HealthStatusShouldBeReported() bool {
-	return c.HealthCheckType == dockerHealthCheckType
+	return c.HealthCheckType == DockerHealthCheckType
 }
 
 // SetHealthStatus sets the container health status

--- a/agent/api/container/container_test.go
+++ b/agent/api/container/container_test.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package api
+package container
 
 import (
 	"fmt"
@@ -202,7 +202,7 @@ func TestSetHealtStatus(t *testing.T) {
 func TestHealthStatusShouldBeReported(t *testing.T) {
 	container := Container{}
 	assert.False(t, container.HealthStatusShouldBeReported(), "Health status of container that does not have HealthCheckType set should not be reported")
-	container.HealthCheckType = dockerHealthCheckType
+	container.HealthCheckType = DockerHealthCheckType
 	assert.True(t, container.HealthStatusShouldBeReported(), "Health status of container that has docker HealthCheckType set should be reported")
 	container.HealthCheckType = "unknown"
 	assert.False(t, container.HealthStatusShouldBeReported(), "Health status of container that has non-docker HealthCheckType set should not be reported")

--- a/agent/api/container/container_unix.go
+++ b/agent/api/container/container_unix.go
@@ -13,7 +13,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package api
+package container
 
 const (
 	// DockerContainerMinimumMemoryInBytes is the minimum amount of

--- a/agent/api/container/container_windows.go
+++ b/agent/api/container/container_windows.go
@@ -13,7 +13,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package api
+package container
 
 const (
 	// DockerContainerMinimumMemoryInBytes is the minimum amount of

--- a/agent/api/container/containerevent.go
+++ b/agent/api/container/containerevent.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package api
+package container
 
 // DockerEventType represents the type of docker events
 type DockerEventType int

--- a/agent/api/container/containeroverrides.go
+++ b/agent/api/container/containeroverrides.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package api
+package container
 
 import (
 	"encoding/json"

--- a/agent/api/container/containeroverrides_test.go
+++ b/agent/api/container/containeroverrides_test.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package api
+package container
 
 import (
 	"encoding/json"

--- a/agent/api/container/containerstatus.go
+++ b/agent/api/container/containerstatus.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package api
+package container
 
 import (
 	"errors"
@@ -89,31 +89,6 @@ func (cs ContainerStatus) String() string {
 		}
 	}
 	return "NONE"
-}
-
-// TaskStatus maps the container status to the corresponding task status. The
-// transition map is illustrated below.
-//
-// Container: None -> Pulled -> Created -> Running -> Provisioned -> Stopped -> Zombie
-//
-// Task     : None ->     Created       ->         Running        -> Stopped
-func (cs *ContainerStatus) TaskStatus(steadyStateStatus ContainerStatus) TaskStatus {
-	switch *cs {
-	case ContainerStatusNone:
-		return TaskStatusNone
-	case steadyStateStatus:
-		return TaskRunning
-	case ContainerCreated:
-		return TaskCreated
-	case ContainerStopped:
-		return TaskStopped
-	}
-
-	if *cs == ContainerRunning && steadyStateStatus == ContainerResourcesProvisioned {
-		return TaskCreated
-	}
-
-	return TaskStatusNone
 }
 
 // ShouldReportToBackend returns true if the container status is recognized as a

--- a/agent/api/container/containerstatus_test.go
+++ b/agent/api/container/containerstatus_test.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package api
+package container
 
 import (
 	"encoding/json"
@@ -20,41 +20,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 )
-
-func TestTaskStatus(t *testing.T) {
-	// Effectively set containerStatus := ContainerStatusNone, we expect the task state
-	// to be TaskStatusNone
-	var containerStatus ContainerStatus
-	assert.Equal(t, containerStatus.TaskStatus(ContainerRunning), TaskStatusNone)
-	assert.Equal(t, containerStatus.TaskStatus(ContainerResourcesProvisioned), TaskStatusNone)
-
-	// When container state is PULLED, Task state is still NONE
-	containerStatus = ContainerPulled
-	assert.Equal(t, containerStatus.TaskStatus(ContainerRunning), TaskStatusNone)
-	assert.Equal(t, containerStatus.TaskStatus(ContainerResourcesProvisioned), TaskStatusNone)
-
-	// When container state is CREATED, Task state is CREATED as well
-	containerStatus = ContainerCreated
-	assert.Equal(t, containerStatus.TaskStatus(ContainerRunning), TaskCreated)
-	assert.Equal(t, containerStatus.TaskStatus(ContainerResourcesProvisioned), TaskCreated)
-
-	containerStatus = ContainerRunning
-	// When container state is RUNNING and steadyState is RUNNING, Task state is RUNNING as well
-	assert.Equal(t, containerStatus.TaskStatus(ContainerRunning), TaskRunning)
-	// When container state is RUNNING and steadyState is RESOURCES_PROVISIONED, Task state
-	// still CREATED
-	assert.Equal(t, containerStatus.TaskStatus(ContainerResourcesProvisioned), TaskCreated)
-
-	containerStatus = ContainerResourcesProvisioned
-	// When container state is RESOURCES_PROVISIONED and steadyState is RESOURCES_PROVISIONED,
-	// Task state is RUNNING
-	assert.Equal(t, containerStatus.TaskStatus(ContainerResourcesProvisioned), TaskRunning)
-
-	// When container state is STOPPED, Task state is STOPPED as well
-	containerStatus = ContainerStopped
-	assert.Equal(t, containerStatus.TaskStatus(ContainerRunning), TaskStopped)
-	assert.Equal(t, containerStatus.TaskStatus(ContainerResourcesProvisioned), TaskStopped)
-}
 
 func TestShouldReportToBackend(t *testing.T) {
 	// ContainerStatusNone is not reported to backend

--- a/agent/api/container/containertype.go
+++ b/agent/api/container/containertype.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package api
+package container
 
 import (
 	"errors"

--- a/agent/api/container/containertype_test.go
+++ b/agent/api/container/containertype_test.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package api
+package container
 
 import (
 	"encoding/json"

--- a/agent/api/container/port_binding.go
+++ b/agent/api/container/port_binding.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package api
+package container
 
 import (
 	"strconv"

--- a/agent/api/container/port_binding_test.go
+++ b/agent/api/container/port_binding_test.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package api
+package container
 
 import (
 	"reflect"

--- a/agent/api/container/transitiondependency.go
+++ b/agent/api/container/transitiondependency.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package api
+package container
 
 import (
 	"encoding/json"

--- a/agent/api/container/transitiondependency_test.go
+++ b/agent/api/container/transitiondependency_test.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package api
+package container
 
 import (
 	"encoding/json"

--- a/agent/api/container/transport.go
+++ b/agent/api/container/transport.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package api
+package container
 
 import (
 	"errors"

--- a/agent/api/container/transport_test.go
+++ b/agent/api/container/transport_test.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package api
+package container
 
 import (
 	"encoding/json"

--- a/agent/api/ecsclient/client.go
+++ b/agent/api/ecsclient/client.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apierrors "github.com/aws/amazon-ecs-agent/agent/api/errors"
 	"github.com/aws/amazon-ecs-agent/agent/async"
 	"github.com/aws/amazon-ecs-agent/agent/config"
@@ -356,7 +357,7 @@ func (client *APIECSClient) buildContainerStateChangePayload(change api.Containe
 	}
 	status := change.Status
 
-	if status != api.ContainerStopped && status != api.ContainerRunning {
+	if status != apicontainer.ContainerStopped && status != apicontainer.ContainerRunning {
 		seelog.Warnf("Not submitting unsupported upstream container state %s for container %s in task %s",
 			status.String(), change.ContainerName, change.TaskArn)
 		return nil

--- a/agent/api/ecsclient/client_test.go
+++ b/agent/api/ecsclient/client_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/api/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/async"
 	"github.com/aws/amazon-ecs-agent/agent/async/mocks"
@@ -153,8 +154,8 @@ func TestSubmitContainerStateChange(t *testing.T) {
 	err := client.SubmitContainerStateChange(api.ContainerStateChange{
 		TaskArn:       "arn",
 		ContainerName: "cont",
-		Status:        api.ContainerRunning,
-		PortBindings: []api.PortBinding{
+		Status:        apicontainer.ContainerRunning,
+		PortBindings: []apicontainer.PortBinding{
 			{
 				BindIP:        "1.2.3.4",
 				ContainerPort: 1,
@@ -164,7 +165,7 @@ func TestSubmitContainerStateChange(t *testing.T) {
 				BindIP:        "2.2.3.4",
 				ContainerPort: 3,
 				HostPort:      4,
-				Protocol:      api.TransportProtocolUDP,
+				Protocol:      apicontainer.TransportProtocolUDP,
 			},
 		},
 	})
@@ -201,10 +202,10 @@ func TestSubmitContainerStateChangeFull(t *testing.T) {
 	err := client.SubmitContainerStateChange(api.ContainerStateChange{
 		TaskArn:       "arn",
 		ContainerName: "cont",
-		Status:        api.ContainerStopped,
+		Status:        apicontainer.ContainerStopped,
 		ExitCode:      &exitCode,
 		Reason:        reason,
-		PortBindings: []api.PortBinding{
+		PortBindings: []apicontainer.PortBinding{
 			{},
 		},
 	})
@@ -234,7 +235,7 @@ func TestSubmitContainerStateChangeReason(t *testing.T) {
 	err := client.SubmitContainerStateChange(api.ContainerStateChange{
 		TaskArn:       "arn",
 		ContainerName: "cont",
-		Status:        api.ContainerStopped,
+		Status:        apicontainer.ContainerStopped,
 		ExitCode:      &exitCode,
 		Reason:        reason,
 	})
@@ -265,7 +266,7 @@ func TestSubmitContainerStateChangeLongReason(t *testing.T) {
 	err := client.SubmitContainerStateChange(api.ContainerStateChange{
 		TaskArn:       "arn",
 		ContainerName: "cont",
-		Status:        api.ContainerStopped,
+		Status:        apicontainer.ContainerStopped,
 		ExitCode:      &exitCode,
 		Reason:        reason,
 	})
@@ -723,7 +724,7 @@ func TestSubmitContainerStateChangeWhileTaskInPending(t *testing.T) {
 			{
 				TaskArn:       "arn",
 				ContainerName: "container",
-				Status:        api.ContainerRunning,
+				Status:        apicontainer.ContainerRunning,
 			},
 		},
 	}

--- a/agent/api/statechange.go
+++ b/agent/api/statechange.go
@@ -18,6 +18,7 @@ import (
 	"strconv"
 	"time"
 
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/statechange"
 	"github.com/pkg/errors"
 
@@ -32,7 +33,7 @@ type ContainerStateChange struct {
 	// ContainerName is the name of the container
 	ContainerName string
 	// Status is the status to send
-	Status ContainerStatus
+	Status apicontainer.ContainerStatus
 
 	// Reason may contain details of why the container stopped
 	Reason string
@@ -40,11 +41,11 @@ type ContainerStateChange struct {
 	ExitCode *int
 	// PortBindings are the details of the host ports picked for the specified
 	// container ports
-	PortBindings []PortBinding
+	PortBindings []apicontainer.PortBinding
 
 	// Container is a pointer to the container involved in the state change that gives the event handler a hook into
 	// storing what status was sent.  This is used to ensure the same event is handled only once.
-	Container *Container
+	Container *apicontainer.Container
 }
 
 // TaskStateChange represents a state change that needs to be sent to the
@@ -101,7 +102,7 @@ func NewTaskStateChangeEvent(task *Task, reason string) (TaskStateChange, error)
 }
 
 // NewContainerStateChangeEvent creates a new container state change event
-func NewContainerStateChangeEvent(task *Task, cont *Container, reason string) (ContainerStateChange, error) {
+func NewContainerStateChangeEvent(task *Task, cont *apicontainer.Container, reason string) (ContainerStateChange, error) {
 	var event ContainerStateChange
 	contKnownStatus := cont.GetKnownStatus()
 	if !contKnownStatus.ShouldReportToBackend(cont.GetSteadyStateStatus()) {

--- a/agent/api/statusmapping.go
+++ b/agent/api/statusmapping.go
@@ -1,0 +1,58 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package api
+
+import (
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+)
+
+// MapToTaskStatus maps the container status to the corresponding task status. The
+// transition map is illustrated below.
+//
+// Container: None -> Pulled -> Created -> Running -> Provisioned -> Stopped -> Zombie
+//
+// Task     : None ->     Created       ->         Running        -> Stopped
+func MapToTaskStatus(knownState apicontainer.ContainerStatus, steadyState apicontainer.ContainerStatus) TaskStatus {
+	switch knownState {
+	case apicontainer.ContainerStatusNone:
+		return TaskStatusNone
+	case steadyState:
+		return TaskRunning
+	case apicontainer.ContainerCreated:
+		return TaskCreated
+	case apicontainer.ContainerStopped:
+		return TaskStopped
+	}
+
+	if knownState == apicontainer.ContainerRunning && steadyState == apicontainer.ContainerResourcesProvisioned {
+		return TaskCreated
+	}
+
+	return TaskStatusNone
+}
+
+// ContainerStatus maps the task status to the corresponding container status
+func (ts *TaskStatus) ContainerStatus(steadyState apicontainer.ContainerStatus) apicontainer.ContainerStatus {
+	switch *ts {
+	case TaskStatusNone:
+		return apicontainer.ContainerStatusNone
+	case TaskCreated:
+		return apicontainer.ContainerCreated
+	case TaskRunning:
+		return steadyState
+	case TaskStopped:
+		return apicontainer.ContainerStopped
+	}
+	return apicontainer.ContainerStatusNone
+}

--- a/agent/api/statusmapping_test.go
+++ b/agent/api/statusmapping_test.go
@@ -1,0 +1,56 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package api
+
+import (
+	"testing"
+
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTaskStatus(t *testing.T) {
+	// Effectively set containerStatus := ContainerStatusNone, we expect the task state
+	// to be TaskStatusNone
+	var containerStatus apicontainer.ContainerStatus
+	assert.Equal(t, MapToTaskStatus(containerStatus, apicontainer.ContainerRunning), TaskStatusNone)
+	assert.Equal(t, MapToTaskStatus(containerStatus, apicontainer.ContainerResourcesProvisioned), TaskStatusNone)
+
+	// When container state is PULLED, Task state is still NONE
+	containerStatus = apicontainer.ContainerPulled
+	assert.Equal(t, MapToTaskStatus(containerStatus, apicontainer.ContainerRunning), TaskStatusNone)
+	assert.Equal(t, MapToTaskStatus(containerStatus, apicontainer.ContainerResourcesProvisioned), TaskStatusNone)
+
+	// When container state is CREATED, Task state is CREATED as well
+	containerStatus = apicontainer.ContainerCreated
+	assert.Equal(t, MapToTaskStatus(containerStatus, apicontainer.ContainerRunning), TaskCreated)
+	assert.Equal(t, MapToTaskStatus(containerStatus, apicontainer.ContainerResourcesProvisioned), TaskCreated)
+
+	containerStatus = apicontainer.ContainerRunning
+	// When container state is RUNNING and steadyState is RUNNING, Task state is RUNNING as well
+	assert.Equal(t, MapToTaskStatus(containerStatus, apicontainer.ContainerRunning), TaskRunning)
+	// When container state is RUNNING and steadyState is RESOURCES_PROVISIONED, Task state
+	// still CREATED
+	assert.Equal(t, MapToTaskStatus(containerStatus, apicontainer.ContainerResourcesProvisioned), TaskCreated)
+
+	containerStatus = apicontainer.ContainerResourcesProvisioned
+	// When container state is RESOURCES_PROVISIONED and steadyState is RESOURCES_PROVISIONED,
+	// Task state is RUNNING
+	assert.Equal(t, MapToTaskStatus(containerStatus, apicontainer.ContainerResourcesProvisioned), TaskRunning)
+
+	// When container state is STOPPED, Task state is STOPPED as well
+	containerStatus = apicontainer.ContainerStopped
+	assert.Equal(t, MapToTaskStatus(containerStatus, apicontainer.ContainerRunning), TaskStopped)
+	assert.Equal(t, MapToTaskStatus(containerStatus, apicontainer.ContainerResourcesProvisioned), TaskStopped)
+}

--- a/agent/api/task_unix_test.go
+++ b/agent/api/task_unix_test.go
@@ -20,9 +20,9 @@ import (
 	"testing"
 	"time"
 
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient"
-
 	docker "github.com/fsouza/go-dockerclient"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
@@ -55,7 +55,7 @@ const (
 
 func TestAddNetworkResourceProvisioningDependencyNop(t *testing.T) {
 	testTask := &Task{
-		Containers: []*Container{
+		Containers: []*apicontainer.Container{
 			{
 				Name: "c1",
 			},
@@ -68,10 +68,10 @@ func TestAddNetworkResourceProvisioningDependencyNop(t *testing.T) {
 func TestAddNetworkResourceProvisioningDependencyWithENI(t *testing.T) {
 	testTask := &Task{
 		ENI: &ENI{},
-		Containers: []*Container{
+		Containers: []*apicontainer.Container{
 			{
 				Name: "c1",
-				TransitionDependenciesMap: make(map[ContainerStatus]TransitionDependencySet),
+				TransitionDependenciesMap: make(map[apicontainer.ContainerStatus]apicontainer.TransitionDependencySet),
 			},
 		},
 	}
@@ -84,7 +84,7 @@ func TestAddNetworkResourceProvisioningDependencyWithENI(t *testing.T) {
 		"addNetworkResourceProvisioningDependency should add another container")
 	pauseContainer, ok := testTask.ContainerByName(PauseContainerName)
 	require.True(t, ok, "Expected to find pause container")
-	assert.Equal(t, ContainerCNIPause, pauseContainer.Type, "pause container should have correct type")
+	assert.Equal(t, apicontainer.ContainerCNIPause, pauseContainer.Type, "pause container should have correct type")
 	assert.True(t, pauseContainer.Essential, "pause container should be essential")
 	assert.Equal(t, cfg.PauseContainerImageName+":"+cfg.PauseContainerTag, pauseContainer.Image,
 		"pause container should use configured image")
@@ -169,7 +169,7 @@ func TestBuildLinuxResourceSpecCPU(t *testing.T) {
 func TestBuildLinuxResourceSpecWithoutTaskCPULimits(t *testing.T) {
 	task := &Task{
 		Arn: validTaskArn,
-		Containers: []*Container{
+		Containers: []*apicontainer.Container{
 			{
 				Name: "C1",
 			},
@@ -192,7 +192,7 @@ func TestBuildLinuxResourceSpecWithoutTaskCPULimits(t *testing.T) {
 func TestBuildLinuxResourceSpecWithoutTaskCPUWithContainerCPULimits(t *testing.T) {
 	task := &Task{
 		Arn: validTaskArn,
-		Containers: []*Container{
+		Containers: []*apicontainer.Container{
 			{
 				Name: "C1",
 				CPU:  uint(512),
@@ -220,7 +220,7 @@ func TestBuildLinuxResourceSpecInvalidMem(t *testing.T) {
 		Arn:    validTaskArn,
 		CPU:    float64(taskVCPULimit),
 		Memory: taskMemoryLimit,
-		Containers: []*Container{
+		Containers: []*apicontainer.Container{
 			{
 				Name:   "C1",
 				Memory: uint(2048),
@@ -290,7 +290,7 @@ func TestPlatformHostConfigOverrideErrorPath(t *testing.T) {
 		CPU:                    float64(taskVCPULimit),
 		Memory:                 int64(taskMemoryLimit),
 		MemoryCPULimitsEnabled: true,
-		Containers: []*Container{
+		Containers: []*apicontainer.Container{
 			{
 				Name: "c1",
 			},
@@ -322,14 +322,14 @@ func TestDockerHostConfigRawConfigMerging(t *testing.T) {
 		Arn:     "arn:aws:ecs:us-east-1:012345678910:task/c09f0188-7f87-4b0f-bfc3-16296622b6fe",
 		Family:  "myFamily",
 		Version: "1",
-		Containers: []*Container{
+		Containers: []*apicontainer.Container{
 			{
 				Name:        "c1",
 				Image:       "image",
 				CPU:         50,
 				Memory:      100,
-				VolumesFrom: []VolumeFrom{{SourceContainer: "c2"}},
-				DockerConfig: DockerConfig{
+				VolumesFrom: []apicontainer.VolumeFrom{{SourceContainer: "c2"}},
+				DockerConfig: apicontainer.DockerConfig{
 					HostConfig: strptr(string(rawHostConfig)),
 				},
 			},
@@ -358,7 +358,7 @@ func TestDockerHostConfigRawConfigMerging(t *testing.T) {
 func TestSetConfigHostconfigBasedOnAPIVersion(t *testing.T) {
 	memoryMiB := 500
 	testTask := &Task{
-		Containers: []*Container{
+		Containers: []*apicontainer.Container{
 			{
 				Name:   "c1",
 				CPU:    uint(10),

--- a/agent/api/task_windows_test.go
+++ b/agent/api/task_windows_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/aws/amazon-ecs-agent/agent/acs/model/ecsacs"
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient"
 
@@ -79,16 +80,16 @@ func TestPostUnmarshalWindowsCanonicalPaths(t *testing.T) {
 		DesiredStatusUnsafe: TaskRunning,
 		Family:              "myFamily",
 		Version:             "1",
-		Containers: []*Container{
+		Containers: []*apicontainer.Container{
 			{
 				Name: "myName",
-				MountPoints: []MountPoint{
+				MountPoints: []apicontainer.MountPoint{
 					{
 						ContainerPath: `c:\container\path`,
 						SourceVolume:  "sourceVolume",
 					},
 				},
-				TransitionDependenciesMap: make(map[ContainerStatus]TransitionDependencySet),
+				TransitionDependenciesMap: make(map[apicontainer.ContainerStatus]apicontainer.TransitionDependencySet),
 			},
 		},
 		Volumes: []TaskVolume{
@@ -144,10 +145,10 @@ func TestWindowsMemorySwappinessOption(t *testing.T) {
 		Arn:     "arn:aws:ecs:us-east-1:012345678910:task/c09f0188-7f87-4b0f-bfc3-16296622b6fe",
 		Family:  "myFamily",
 		Version: "1",
-		Containers: []*Container{
+		Containers: []*apicontainer.Container{
 			{
 				Name: "c1",
-				DockerConfig: DockerConfig{
+				DockerConfig: apicontainer.DockerConfig{
 					HostConfig: strptr(string(rawHostConfig)),
 				},
 			},
@@ -182,14 +183,14 @@ func TestDockerHostConfigRawConfigMerging(t *testing.T) {
 		Arn:     "arn:aws:ecs:us-east-1:012345678910:task/c09f0188-7f87-4b0f-bfc3-16296622b6fe",
 		Family:  "myFamily",
 		Version: "1",
-		Containers: []*Container{
+		Containers: []*apicontainer.Container{
 			{
 				Name:        "c1",
 				Image:       "image",
 				CPU:         10,
 				Memory:      100,
-				VolumesFrom: []VolumeFrom{{SourceContainer: "c2"}},
-				DockerConfig: DockerConfig{
+				VolumesFrom: []apicontainer.VolumeFrom{{SourceContainer: "c2"}},
+				DockerConfig: apicontainer.DockerConfig{
 					HostConfig: strptr(string(rawHostConfig)),
 				},
 			},
@@ -203,7 +204,7 @@ func TestDockerHostConfigRawConfigMerging(t *testing.T) {
 	assert.Nil(t, configErr)
 
 	expected := docker.HostConfig{
-		Memory:           DockerContainerMinimumMemoryInBytes,
+		Memory:           apicontainer.DockerContainerMinimumMemoryInBytes,
 		Privileged:       true,
 		SecurityOpt:      []string{"foo", "bar"},
 		VolumesFrom:      []string{"dockername-c2"},
@@ -219,7 +220,7 @@ func TestDockerHostConfigRawConfigMerging(t *testing.T) {
 func TestSetConfigHostconfigBasedOnAPIVersion(t *testing.T) {
 	memoryMiB := 500
 	testTask := &Task{
-		Containers: []*Container{
+		Containers: []*apicontainer.Container{
 			{
 				Name:   "c1",
 				CPU:    uint(10),
@@ -283,7 +284,7 @@ func TestCPUPercentBasedOnUnboundedEnabled(t *testing.T) {
 		t.Run(fmt.Sprintf("container cpu-%d,cpu unbounded tasks enabled- %t,expected cpu percent-%d",
 			tc.cpu, tc.cpuUnbounded, tc.cpuPercent), func(t *testing.T) {
 			testTask := &Task{
-				Containers: []*Container{
+				Containers: []*apicontainer.Container{
 					{
 						Name: "c1",
 						CPU:  uint(tc.cpu),

--- a/agent/api/taskstatus.go
+++ b/agent/api/taskstatus.go
@@ -71,21 +71,6 @@ func (ts *TaskStatus) BackendRecognized() bool {
 	return *ts == TaskRunning || *ts == TaskStopped
 }
 
-// ContainerStatus maps the task status to the corresponding container status
-func (ts *TaskStatus) ContainerStatus(steadyState ContainerStatus) ContainerStatus {
-	switch *ts {
-	case TaskStatusNone:
-		return ContainerStatusNone
-	case TaskCreated:
-		return ContainerCreated
-	case TaskRunning:
-		return steadyState
-	case TaskStopped:
-		return ContainerStopped
-	}
-	return ContainerStatusNone
-}
-
 // Terminal returns true if the Task status is STOPPED
 func (ts TaskStatus) Terminal() bool {
 	return ts == TaskStopped

--- a/agent/api/testutils/container_equal.go
+++ b/agent/api/testutils/container_equal.go
@@ -19,7 +19,7 @@ package testutils
 import (
 	"reflect"
 
-	"github.com/aws/amazon-ecs-agent/agent/api"
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 )
 
@@ -27,7 +27,7 @@ import (
 // This is not exact equality, but logical equality.
 // TODO: use reflection along with `equal:"unordered"` annotations on slices to
 // replace this verbose code (low priority, but would be fun)
-func ContainersEqual(lhs, rhs *api.Container) bool {
+func ContainersEqual(lhs, rhs *apicontainer.Container) bool {
 	if lhs == rhs {
 		return true
 	}
@@ -90,7 +90,7 @@ func ContainersEqual(lhs, rhs *api.Container) bool {
 }
 
 // ContainerOverridesEqual determines if two container overrides are equal
-func ContainerOverridesEqual(lhs, rhs api.ContainerOverrides) bool {
+func ContainerOverridesEqual(lhs, rhs apicontainer.ContainerOverrides) bool {
 	if lhs.Command == nil || rhs.Command == nil {
 		if lhs.Command != rhs.Command {
 			return false

--- a/agent/api/testutils/container_equal_test.go
+++ b/agent/api/testutils/container_equal_test.go
@@ -17,65 +17,62 @@ import (
 	"fmt"
 	"testing"
 
-	. "github.com/aws/amazon-ecs-agent/agent/api"
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestContainerEqual(t *testing.T) {
 
-	exitCodeContainer := func(p *int) Container {
-		c := Container{}
+	exitCodeContainer := func(p *int) apicontainer.Container {
+		c := apicontainer.Container{}
 		c.SetKnownExitCode(p)
 		return c
 	}
 
 	testCases := []struct {
-		lhs           Container
-		rhs           Container
+		lhs           apicontainer.Container
+		rhs           apicontainer.Container
 		shouldBeEqual bool
 	}{
 		// Equal Pairs
-		{Container{Name: "name"}, Container{Name: "name"}, true},
-		{Container{Image: "nginx"}, Container{Image: "nginx"}, true},
-		{Container{Command: []string{"c"}}, Container{Command: []string{"c"}}, true},
-		{Container{CPU: 1}, Container{CPU: 1}, true},
-		{Container{Memory: 1}, Container{Memory: 1}, true},
-		{Container{Links: []string{"1", "2"}}, Container{Links: []string{"1", "2"}}, true},
-		{Container{Links: []string{"1", "2"}}, Container{Links: []string{"2", "1"}}, true},
-		{Container{VolumesFrom: []VolumeFrom{{"1", false}, {"2", true}}}, Container{VolumesFrom: []VolumeFrom{{"1", false}, {"2", true}}}, true},
-		{Container{VolumesFrom: []VolumeFrom{{"1", false}, {"2", true}}}, Container{VolumesFrom: []VolumeFrom{{"2", true}, {"1", false}}}, true},
-		{Container{Ports: []PortBinding{{1, 2, "1", TransportProtocolTCP}}}, Container{Ports: []PortBinding{{1, 2, "1", TransportProtocolTCP}}}, true},
-		{Container{Essential: true}, Container{Essential: true}, true},
-		{Container{EntryPoint: nil}, Container{EntryPoint: nil}, true},
-		{Container{EntryPoint: &[]string{"1", "2"}}, Container{EntryPoint: &[]string{"1", "2"}}, true},
-		{Container{Environment: map[string]string{}}, Container{Environment: map[string]string{}}, true},
-		{Container{Environment: map[string]string{"a": "b", "c": "d"}}, Container{Environment: map[string]string{"c": "d", "a": "b"}}, true},
-		{Container{DesiredStatusUnsafe: ContainerRunning}, Container{DesiredStatusUnsafe: ContainerRunning}, true},
-		{Container{AppliedStatus: ContainerRunning}, Container{AppliedStatus: ContainerRunning}, true},
-		{Container{KnownStatusUnsafe: ContainerRunning}, Container{KnownStatusUnsafe: ContainerRunning}, true},
+		{apicontainer.Container{Name: "name"}, apicontainer.Container{Name: "name"}, true},
+		{apicontainer.Container{Image: "nginx"}, apicontainer.Container{Image: "nginx"}, true},
+		{apicontainer.Container{Command: []string{"c"}}, apicontainer.Container{Command: []string{"c"}}, true},
+		{apicontainer.Container{CPU: 1}, apicontainer.Container{CPU: 1}, true},
+		{apicontainer.Container{Memory: 1}, apicontainer.Container{Memory: 1}, true},
+		{apicontainer.Container{Links: []string{"1", "2"}}, apicontainer.Container{Links: []string{"1", "2"}}, true},
+		{apicontainer.Container{Links: []string{"1", "2"}}, apicontainer.Container{Links: []string{"2", "1"}}, true},
+		{apicontainer.Container{Ports: []apicontainer.PortBinding{{1, 2, "1", apicontainer.TransportProtocolTCP}}}, apicontainer.Container{Ports: []apicontainer.PortBinding{{1, 2, "1", apicontainer.TransportProtocolTCP}}}, true},
+		{apicontainer.Container{Essential: true}, apicontainer.Container{Essential: true}, true},
+		{apicontainer.Container{EntryPoint: nil}, apicontainer.Container{EntryPoint: nil}, true},
+		{apicontainer.Container{EntryPoint: &[]string{"1", "2"}}, apicontainer.Container{EntryPoint: &[]string{"1", "2"}}, true},
+		{apicontainer.Container{Environment: map[string]string{}}, apicontainer.Container{Environment: map[string]string{}}, true},
+		{apicontainer.Container{Environment: map[string]string{"a": "b", "c": "d"}}, apicontainer.Container{Environment: map[string]string{"c": "d", "a": "b"}}, true},
+		{apicontainer.Container{DesiredStatusUnsafe: apicontainer.ContainerRunning}, apicontainer.Container{DesiredStatusUnsafe: apicontainer.ContainerRunning}, true},
+		{apicontainer.Container{AppliedStatus: apicontainer.ContainerRunning}, apicontainer.Container{AppliedStatus: apicontainer.ContainerRunning}, true},
+		{apicontainer.Container{KnownStatusUnsafe: apicontainer.ContainerRunning}, apicontainer.Container{KnownStatusUnsafe: apicontainer.ContainerRunning}, true},
 		{exitCodeContainer(aws.Int(1)), exitCodeContainer(aws.Int(1)), true},
 		{exitCodeContainer(nil), exitCodeContainer(nil), true},
 		// Unequal Pairs
-		{Container{Name: "name"}, Container{Name: "名前"}, false},
-		{Container{Image: "nginx"}, Container{Image: "えんじんえっくす"}, false},
-		{Container{Command: []string{"c"}}, Container{Command: []string{"し"}}, false},
-		{Container{Command: []string{"c", "b"}}, Container{Command: []string{"b", "c"}}, false},
-		{Container{CPU: 1}, Container{CPU: 2e2}, false},
-		{Container{Memory: 1}, Container{Memory: 2e2}, false},
-		{Container{Links: []string{"1", "2"}}, Container{Links: []string{"1", "二"}}, false},
-		{Container{VolumesFrom: []VolumeFrom{{"1", false}, {"2", true}}}, Container{VolumesFrom: []VolumeFrom{{"1", false}, {"二", false}}}, false},
-		{Container{Ports: []PortBinding{{1, 2, "1", TransportProtocolTCP}}}, Container{Ports: []PortBinding{{1, 2, "二", TransportProtocolTCP}}}, false},
-		{Container{Ports: []PortBinding{{1, 2, "1", TransportProtocolTCP}}}, Container{Ports: []PortBinding{{1, 22, "1", TransportProtocolTCP}}}, false},
-		{Container{Ports: []PortBinding{{1, 2, "1", TransportProtocolTCP}}}, Container{Ports: []PortBinding{{1, 2, "1", TransportProtocolUDP}}}, false},
-		{Container{Essential: true}, Container{Essential: false}, false},
-		{Container{EntryPoint: nil}, Container{EntryPoint: &[]string{"nonnil"}}, false},
-		{Container{EntryPoint: &[]string{"1", "2"}}, Container{EntryPoint: &[]string{"2", "1"}}, false},
-		{Container{EntryPoint: &[]string{"1", "2"}}, Container{EntryPoint: &[]string{"1", "二"}}, false},
-		{Container{Environment: map[string]string{"a": "b", "c": "d"}}, Container{Environment: map[string]string{"し": "d", "a": "b"}}, false},
-		{Container{DesiredStatusUnsafe: ContainerRunning}, Container{DesiredStatusUnsafe: ContainerStopped}, false},
-		{Container{AppliedStatus: ContainerRunning}, Container{AppliedStatus: ContainerStopped}, false},
-		{Container{KnownStatusUnsafe: ContainerRunning}, Container{KnownStatusUnsafe: ContainerStopped}, false},
+		{apicontainer.Container{Name: "name"}, apicontainer.Container{Name: "名前"}, false},
+		{apicontainer.Container{Image: "nginx"}, apicontainer.Container{Image: "えんじんえっくす"}, false},
+		{apicontainer.Container{Command: []string{"c"}}, apicontainer.Container{Command: []string{"し"}}, false},
+		{apicontainer.Container{Command: []string{"c", "b"}}, apicontainer.Container{Command: []string{"b", "c"}}, false},
+		{apicontainer.Container{CPU: 1}, apicontainer.Container{CPU: 2e2}, false},
+		{apicontainer.Container{Memory: 1}, apicontainer.Container{Memory: 2e2}, false},
+		{apicontainer.Container{Links: []string{"1", "2"}}, apicontainer.Container{Links: []string{"1", "二"}}, false},
+		{apicontainer.Container{Ports: []apicontainer.PortBinding{{1, 2, "1", apicontainer.TransportProtocolTCP}}}, apicontainer.Container{Ports: []apicontainer.PortBinding{{1, 2, "二", apicontainer.TransportProtocolTCP}}}, false},
+		{apicontainer.Container{Ports: []apicontainer.PortBinding{{1, 2, "1", apicontainer.TransportProtocolTCP}}}, apicontainer.Container{Ports: []apicontainer.PortBinding{{1, 22, "1", apicontainer.TransportProtocolTCP}}}, false},
+		{apicontainer.Container{Ports: []apicontainer.PortBinding{{1, 2, "1", apicontainer.TransportProtocolTCP}}}, apicontainer.Container{Ports: []apicontainer.PortBinding{{1, 2, "1", apicontainer.TransportProtocolUDP}}}, false},
+		{apicontainer.Container{Essential: true}, apicontainer.Container{Essential: false}, false},
+		{apicontainer.Container{EntryPoint: nil}, apicontainer.Container{EntryPoint: &[]string{"nonnil"}}, false},
+		{apicontainer.Container{EntryPoint: &[]string{"1", "2"}}, apicontainer.Container{EntryPoint: &[]string{"2", "1"}}, false},
+		{apicontainer.Container{EntryPoint: &[]string{"1", "2"}}, apicontainer.Container{EntryPoint: &[]string{"1", "二"}}, false},
+		{apicontainer.Container{Environment: map[string]string{"a": "b", "c": "d"}}, apicontainer.Container{Environment: map[string]string{"し": "d", "a": "b"}}, false},
+		{apicontainer.Container{DesiredStatusUnsafe: apicontainer.ContainerRunning}, apicontainer.Container{DesiredStatusUnsafe: apicontainer.ContainerStopped}, false},
+		{apicontainer.Container{AppliedStatus: apicontainer.ContainerRunning}, apicontainer.Container{AppliedStatus: apicontainer.ContainerStopped}, false},
+		{apicontainer.Container{KnownStatusUnsafe: apicontainer.ContainerRunning}, apicontainer.Container{KnownStatusUnsafe: apicontainer.ContainerStopped}, false},
 		{exitCodeContainer(aws.Int(0)), exitCodeContainer(aws.Int(42)), false},
 		{exitCodeContainer(nil), exitCodeContainer(aws.Int(12)), false},
 	}

--- a/agent/api/testutils/task_equal_test.go
+++ b/agent/api/testutils/task_equal_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	. "github.com/aws/amazon-ecs-agent/agent/api"
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -32,7 +33,7 @@ func TestTaskEqual(t *testing.T) {
 		{Task{Arn: "a"}, Task{Arn: "a"}, true},
 		{Task{Family: "a"}, Task{Family: "a"}, true},
 		{Task{Version: "a"}, Task{Version: "a"}, true},
-		{Task{Containers: []*Container{{Name: "a"}}}, Task{Containers: []*Container{{Name: "a"}}}, true},
+		{Task{Containers: []*apicontainer.Container{{Name: "a"}}}, Task{Containers: []*apicontainer.Container{{Name: "a"}}}, true},
 		{Task{DesiredStatusUnsafe: TaskRunning}, Task{DesiredStatusUnsafe: TaskRunning}, true},
 		{Task{KnownStatusUnsafe: TaskRunning}, Task{KnownStatusUnsafe: TaskRunning}, true},
 
@@ -40,7 +41,7 @@ func TestTaskEqual(t *testing.T) {
 		{Task{Arn: "a"}, Task{Arn: "あ"}, false},
 		{Task{Family: "a"}, Task{Family: "あ"}, false},
 		{Task{Version: "a"}, Task{Version: "あ"}, false},
-		{Task{Containers: []*Container{{Name: "a"}}}, Task{Containers: []*Container{{Name: "あ"}}}, false},
+		{Task{Containers: []*apicontainer.Container{{Name: "a"}}}, Task{Containers: []*apicontainer.Container{{Name: "あ"}}}, false},
 		{Task{DesiredStatusUnsafe: TaskRunning}, Task{DesiredStatusUnsafe: TaskStopped}, false},
 		{Task{KnownStatusUnsafe: TaskRunning}, Task{KnownStatusUnsafe: TaskStopped}, false},
 	}

--- a/agent/api/types_unmarshal_test.go
+++ b/agent/api/types_unmarshal_test.go
@@ -3,18 +3,20 @@ package api
 import (
 	"encoding/json"
 	"testing"
+
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 )
 
 func TestVolumesFromUnmarshal(t *testing.T) {
-	var vols []VolumeFrom
+	var vols []apicontainer.VolumeFrom
 	err := json.Unmarshal([]byte(`[{"sourceContainer":"c1"},{"sourceContainer":"c2","readOnly":true}]`), &vols)
 	if err != nil {
 		t.Fatal("Unable to unmarshal json")
 	}
-	if (vols[0] != VolumeFrom{SourceContainer: "c1", ReadOnly: false}) {
+	if (vols[0] != apicontainer.VolumeFrom{SourceContainer: "c1", ReadOnly: false}) {
 		t.Error("VolumeFrom 1 didn't match expected output")
 	}
-	if (vols[1] != VolumeFrom{SourceContainer: "c2", ReadOnly: true}) {
+	if (vols[1] != apicontainer.VolumeFrom{SourceContainer: "c2", ReadOnly: true}) {
 		t.Error("VolumeFrom 2 didn't match expected output")
 	}
 }

--- a/agent/api/volume.go
+++ b/agent/api/volume.go
@@ -13,14 +13,6 @@
 
 package api
 
-// MountPoint describes the in-container location of a Volume and references
-// that Volume by name.
-type MountPoint struct {
-	SourceVolume  string `json:"sourceVolume"`
-	ContainerPath string `json:"containerPath"`
-	ReadOnly      bool   `json:"readOnly"`
-}
-
 // HostVolume is an interface for something that may be used as the host half of a
 // docker volume mount
 type HostVolume interface {
@@ -46,10 +38,4 @@ type EmptyHostVolume struct {
 // SourcePath returns the generated host path for the volume
 func (e *EmptyHostVolume) SourcePath() string {
 	return e.HostPath
-}
-
-// VolumeFrom is a volume which references another container as its source.
-type VolumeFrom struct {
-	SourceContainer string `json:"sourceContainer"`
-	ReadOnly        bool   `json:"readOnly"`
 }

--- a/agent/containermetadata/parse_metadata.go
+++ b/agent/containermetadata/parse_metadata.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 
 	"github.com/cihub/seelog"
 	docker "github.com/fsouza/go-dockerclient"
@@ -29,11 +30,11 @@ import (
 // errors here and handle them at this or the above stage.
 func (manager *metadataManager) parseMetadataAtContainerCreate(task *api.Task, containerName string) Metadata {
 	return Metadata{
-		cluster:              manager.cluster,
-		taskMetadata:         TaskMetadata{
-			containerName: containerName,
-			taskARN: task.Arn,
-			taskDefinitionFamily: task.Family,
+		cluster: manager.cluster,
+		taskMetadata: TaskMetadata{
+			containerName:          containerName,
+			taskARN:                task.Arn,
+			taskDefinitionFamily:   task.Family,
 			taskDefinitionRevision: task.Version,
 		},
 		containerInstanceARN: manager.containerInstanceARN,
@@ -48,11 +49,11 @@ func (manager *metadataManager) parseMetadataAtContainerCreate(task *api.Task, c
 func (manager *metadataManager) parseMetadata(dockerContainer *docker.Container, task *api.Task, containerName string) Metadata {
 	dockerMD := parseDockerContainerMetadata(task.Arn, containerName, dockerContainer)
 	return Metadata{
-		cluster:                 manager.cluster,
-		taskMetadata:            TaskMetadata{
-			containerName: containerName,
-			taskARN: task.Arn,
-			taskDefinitionFamily: task.Family,
+		cluster: manager.cluster,
+		taskMetadata: TaskMetadata{
+			containerName:          containerName,
+			taskARN:                task.Arn,
+			taskDefinitionFamily:   task.Family,
 			taskDefinitionRevision: task.Version,
 		},
 		dockerContainerMetadata: dockerMD,
@@ -87,8 +88,8 @@ func parseDockerContainerMetadata(taskARN string, containerName string, dockerCo
 	}
 
 	// Get Port bindings from NetworkSettings
-	var ports []api.PortBinding
-	ports, err = api.PortBindingFromDockerPortBinding(dockerContainer.NetworkSettings.Ports)
+	var ports []apicontainer.PortBinding
+	ports, err = apicontainer.PortBindingFromDockerPortBinding(dockerContainer.NetworkSettings.Ports)
 	if err != nil {
 		seelog.Warnf("Failed to parse container metadata for task %s container %s: %v", taskARN, containerName, err)
 	}

--- a/agent/containermetadata/types.go
+++ b/agent/containermetadata/types.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/aws/amazon-ecs-agent/agent/api"
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 
 	docker "github.com/fsouza/go-dockerclient"
 )
@@ -107,7 +107,7 @@ type DockerContainerMetadata struct {
 	imageID             string
 	imageName           string
 	networkMode         string
-	ports               []api.PortBinding
+	ports               []apicontainer.PortBinding
 	networkInfo         NetworkMetadata
 }
 
@@ -135,19 +135,19 @@ type Metadata struct {
 // metadataSerializer is an intermediate struct that converts the information
 // in Metadata into information to encode into JSON
 type metadataSerializer struct {
-	Cluster                string            `json:"Cluster,omitempty"`
-	ContainerInstanceARN   string            `json:"ContainerInstanceARN,omitempty"`
-	TaskARN                string            `json:"TaskARN,omitempty"`
-	TaskDefinitionFamily   string            `json:"TaskDefinitionFamily,omitempty"`
-	TaskDefinitionRevision string            `json:"TaskDefinitionRevision,omitempty"`
-	ContainerID            string            `json:"ContainerID,omitempty"`
-	ContainerName          string            `json:"ContainerName,omitempty"`
-	DockerContainerName    string            `json:"DockerContainerName,omitempty"`
-	ImageID                string            `json:"ImageID,omitempty"`
-	ImageName              string            `json:"ImageName,omitempty"`
-	Ports                  []api.PortBinding `json:"PortMappings,omitempty"`
-	Networks               []Network         `json:"Networks,omitempty"`
-	MetadataFileStatus     MetadataStatus    `json:"MetadataFileStatus,omitempty"`
+	Cluster                string                     `json:"Cluster,omitempty"`
+	ContainerInstanceARN   string                     `json:"ContainerInstanceARN,omitempty"`
+	TaskARN                string                     `json:"TaskARN,omitempty"`
+	TaskDefinitionFamily   string                     `json:"TaskDefinitionFamily,omitempty"`
+	TaskDefinitionRevision string                     `json:"TaskDefinitionRevision,omitempty"`
+	ContainerID            string                     `json:"ContainerID,omitempty"`
+	ContainerName          string                     `json:"ContainerName,omitempty"`
+	DockerContainerName    string                     `json:"DockerContainerName,omitempty"`
+	ImageID                string                     `json:"ImageID,omitempty"`
+	ImageName              string                     `json:"ImageName,omitempty"`
+	Ports                  []apicontainer.PortBinding `json:"PortMappings,omitempty"`
+	Networks               []Network                  `json:"Networks,omitempty"`
+	MetadataFileStatus     MetadataStatus             `json:"MetadataFileStatus,omitempty"`
 }
 
 func (m Metadata) MarshalJSON() ([]byte, error) {

--- a/agent/dockerclient/dockerapi/docker_client_test.go
+++ b/agent/dockerclient/dockerapi/docker_client_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/amazon-ecs-agent/agent/api"
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apierrors "github.com/aws/amazon-ecs-agent/agent/api/errors"
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/credentials"
@@ -589,7 +589,7 @@ func TestContainerEvents(t *testing.T) {
 
 	event := <-dockerEvents
 	assert.Equal(t, event.DockerID, "containerId", "Wrong docker id")
-	assert.Equal(t, event.Status, api.ContainerCreated, "Wrong status")
+	assert.Equal(t, event.Status, apicontainer.ContainerCreated, "Wrong status")
 
 	container := &docker.Container{
 		ID: "cid2",
@@ -606,7 +606,7 @@ func TestContainerEvents(t *testing.T) {
 	}()
 	event = <-dockerEvents
 	assert.Equal(t, event.DockerID, "cid2", "Wrong docker id")
-	assert.Equal(t, event.Status, api.ContainerRunning, "Wrong status")
+	assert.Equal(t, event.Status, apicontainer.ContainerRunning, "Wrong status")
 	assert.Equal(t, event.PortBindings[0].ContainerPort, uint16(80), "Incorrect port bindings")
 	assert.Equal(t, event.PortBindings[0].HostPort, uint16(9001), "Incorrect port bindings")
 	assert.Equal(t, event.Volumes["/host/path"], "/container/path", "Incorrect volume mapping")
@@ -629,7 +629,7 @@ func TestContainerEvents(t *testing.T) {
 	for i := 0; i < 2; i++ {
 		anEvent := <-dockerEvents
 		assert.True(t, anEvent.DockerID == "cid30" || anEvent.DockerID == "cid31", "Wrong container id: "+anEvent.DockerID)
-		assert.Equal(t, anEvent.Status, api.ContainerStopped, "Should be stopped")
+		assert.Equal(t, anEvent.Status, apicontainer.ContainerStopped, "Should be stopped")
 		assert.Equal(t, aws.IntValue(anEvent.ExitCode), 20, "Incorrect exit code")
 	}
 
@@ -661,8 +661,8 @@ func TestContainerEvents(t *testing.T) {
 	}()
 
 	anEvent := <-dockerEvents
-	assert.Equal(t, anEvent.Type, api.ContainerHealthEvent, "unexpected docker events type received")
-	assert.Equal(t, anEvent.Health.Status, api.ContainerHealthy)
+	assert.Equal(t, anEvent.Type, apicontainer.ContainerHealthEvent, "unexpected docker events type received")
+	assert.Equal(t, anEvent.Health.Status, apicontainer.ContainerHealthy)
 	assert.Equal(t, anEvent.Health.Output, "health output")
 
 	// Verify the following events do not translate into our event stream
@@ -1316,7 +1316,7 @@ func TestMetadataFromContainerHealthCheckWithNoLogs(t *testing.T) {
 		}}
 
 	metadata := MetadataFromContainer(dockerContainer)
-	assert.Equal(t, api.ContainerUnhealthy, metadata.Health.Status)
+	assert.Equal(t, apicontainer.ContainerUnhealthy, metadata.Health.Status)
 }
 
 func TestCreateVolumeTimeout(t *testing.T) {

--- a/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
+++ b/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
@@ -23,7 +23,7 @@ import (
 	reflect "reflect"
 	time "time"
 
-	api "github.com/aws/amazon-ecs-agent/agent/api"
+	container "github.com/aws/amazon-ecs-agent/agent/api/container"
 	dockerclient "github.com/aws/amazon-ecs-agent/agent/dockerclient"
 	dockerapi "github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	ecr "github.com/aws/amazon-ecs-agent/agent/ecr"
@@ -105,9 +105,9 @@ func (mr *MockDockerClientMockRecorder) CreateVolume(arg0, arg1, arg2, arg3, arg
 }
 
 // DescribeContainer mocks base method
-func (m *MockDockerClient) DescribeContainer(arg0 context.Context, arg1 string) (api.ContainerStatus, dockerapi.DockerContainerMetadata) {
+func (m *MockDockerClient) DescribeContainer(arg0 context.Context, arg1 string) (container.ContainerStatus, dockerapi.DockerContainerMetadata) {
 	ret := m.ctrl.Call(m, "DescribeContainer", arg0, arg1)
-	ret0, _ := ret[0].(api.ContainerStatus)
+	ret0, _ := ret[0].(container.ContainerStatus)
 	ret1, _ := ret[1].(dockerapi.DockerContainerMetadata)
 	return ret0, ret1
 }

--- a/agent/dockerclient/dockerapi/types.go
+++ b/agent/dockerclient/dockerapi/types.go
@@ -17,7 +17,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/aws/amazon-ecs-agent/agent/api"
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apierrors "github.com/aws/amazon-ecs-agent/agent/api/errors"
 	"github.com/aws/aws-sdk-go/aws"
 	docker "github.com/fsouza/go-dockerclient"
@@ -40,11 +40,11 @@ func (cnferror ContainerNotFound) Error() string {
 // DockerContainerChangeEvent is a type for container change events
 type DockerContainerChangeEvent struct {
 	// Status represents the container's status in the event
-	Status api.ContainerStatus
+	Status apicontainer.ContainerStatus
 	// DockerContainerMetadata is the metadata of the container in the event
 	DockerContainerMetadata
 	// Type is the event type received from docker events
-	Type api.DockerEventType
+	Type apicontainer.DockerEventType
 }
 
 // DockerContainerMetadata is a type for metadata about Docker containers
@@ -54,7 +54,7 @@ type DockerContainerMetadata struct {
 	// ExitCode contains container's exit code if it has stopped
 	ExitCode *int
 	// PortBindings is the list of port binding information of the container
-	PortBindings []api.PortBinding
+	PortBindings []apicontainer.PortBinding
 	// Error wraps various container transition errors and is set if engine
 	// is unable to perform any of the required container transitions
 	Error apierrors.NamedError
@@ -69,7 +69,7 @@ type DockerContainerMetadata struct {
 	// FinishedAt is the timestamp of container stop
 	FinishedAt time.Time
 	// Health contains the result of a container health check
-	Health api.HealthStatus
+	Health apicontainer.HealthStatus
 }
 
 // ListContainersResponse encapsulates the response from the docker client for the

--- a/agent/engine/dependencygraph/graph.go
+++ b/agent/engine/dependencygraph/graph.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/credentials"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	log "github.com/cihub/seelog"
@@ -52,8 +53,8 @@ var (
 // order.  ValidDependencies is called during DockerTaskEngine.AddTask to
 // verify that a startup order can exist.
 func ValidDependencies(task *api.Task) bool {
-	unresolved := make([]*api.Container, len(task.Containers))
-	resolved := make([]*api.Container, 0, len(task.Containers))
+	unresolved := make([]*apicontainer.Container, len(task.Containers))
+	resolved := make([]*apicontainer.Container, 0, len(task.Containers))
 
 	copy(unresolved, task.Containers)
 
@@ -83,8 +84,8 @@ OuterLoop:
 // This function is used for verifying that a state should be resolvable, not
 // for actually deciding what to do. `DependenciesAreResolved` should be used for
 // that purpose instead.
-func dependenciesCanBeResolved(target *api.Container, by []*api.Container) bool {
-	nameMap := make(map[string]*api.Container)
+func dependenciesCanBeResolved(target *apicontainer.Container, by []*apicontainer.Container) bool {
+	nameMap := make(map[string]*apicontainer.Container)
 	for _, cont := range by {
 		nameMap[cont.Name] = cont
 	}
@@ -105,8 +106,8 @@ func dependenciesCanBeResolved(target *api.Container, by []*api.Container) bool 
 // Transitions are between known statuses (whether the container can move to
 // the next known status), not desired statuses; the desired status typically
 // is either RUNNING or STOPPED.
-func DependenciesAreResolved(target *api.Container,
-	by []*api.Container,
+func DependenciesAreResolved(target *apicontainer.Container,
+	by []*apicontainer.Container,
 	id string,
 	manager credentials.Manager,
 	resources []taskresource.TaskResource) error {
@@ -114,7 +115,7 @@ func DependenciesAreResolved(target *api.Container,
 		return CredentialsNotResolvedErr
 	}
 
-	nameMap := make(map[string]*api.Container)
+	nameMap := make(map[string]*apicontainer.Container)
 	for _, cont := range by {
 		nameMap[cont.Name] = cont
 	}
@@ -156,10 +157,10 @@ func linksToContainerNames(links []string) []string {
 	return names
 }
 
-func executionCredentialsResolved(target *api.Container, id string, manager credentials.Manager) bool {
-	if target.GetKnownStatus() >= api.ContainerPulled ||
+func executionCredentialsResolved(target *apicontainer.Container, id string, manager credentials.Manager) bool {
+	if target.GetKnownStatus() >= apicontainer.ContainerPulled ||
 		!target.ShouldPullWithExecutionRole() ||
-		target.GetDesiredStatus() >= api.ContainerStopped {
+		target.GetDesiredStatus() >= apicontainer.ContainerStopped {
 		return true
 	}
 
@@ -171,9 +172,10 @@ func executionCredentialsResolved(target *api.Container, id string, manager cred
 // target depends on `dependencies` (which are container names) and there are
 // `existingContainers` (map from name to container). The `resolves` function
 // passed should return true if the named container is resolved.
-func verifyStatusResolvable(target *api.Container, existingContainers map[string]*api.Container, dependencies []string, resolves func(*api.Container, *api.Container) bool) bool {
+func verifyStatusResolvable(target *apicontainer.Container, existingContainers map[string]*apicontainer.Container,
+	dependencies []string, resolves func(*apicontainer.Container, *apicontainer.Container) bool) bool {
 	targetGoal := target.GetDesiredStatus()
-	if targetGoal != target.GetSteadyStateStatus() && targetGoal != api.ContainerCreated {
+	if targetGoal != target.GetSteadyStateStatus() && targetGoal != apicontainer.ContainerCreated {
 		// A container can always stop, die, or reach whatever other state it
 		// wants regardless of what dependencies it has
 		return true
@@ -191,11 +193,11 @@ func verifyStatusResolvable(target *api.Container, existingContainers map[string
 	return true
 }
 
-func verifyTransitionDependenciesResolved(target *api.Container,
-	existingContainers map[string]*api.Container,
+func verifyTransitionDependenciesResolved(target *apicontainer.Container,
+	existingContainers map[string]*apicontainer.Container,
 	existingResources map[string]taskresource.TaskResource) error {
 	targetGoal := target.GetDesiredStatus()
-	if targetGoal >= api.ContainerStopped {
+	if targetGoal >= apicontainer.ContainerStopped {
 		// A container can always stop, die, or reach whatever other state it
 		// wants regardless of what dependencies it has
 		return nil
@@ -210,7 +212,7 @@ func verifyTransitionDependenciesResolved(target *api.Container,
 	return nil
 }
 
-func verifyContainerDependenciesResolved(target *api.Container, existingContainers map[string]*api.Container) bool {
+func verifyContainerDependenciesResolved(target *apicontainer.Container, existingContainers map[string]*apicontainer.Container) bool {
 	targetNext := target.GetNextKnownStateProgression()
 	containerDependencies := target.TransitionDependenciesMap[targetNext].ContainerDependencies
 	for _, containerDependency := range containerDependencies {
@@ -225,7 +227,7 @@ func verifyContainerDependenciesResolved(target *api.Container, existingContaine
 	return true
 }
 
-func verifyResourceDependenciesResolved(target *api.Container, existingResources map[string]taskresource.TaskResource) bool {
+func verifyResourceDependenciesResolved(target *apicontainer.Container, existingResources map[string]taskresource.TaskResource) bool {
 	targetNext := target.GetNextKnownStateProgression()
 	resourceDependencies := target.TransitionDependenciesMap[targetNext].ResourceDependencies
 	for _, resourceDependency := range resourceDependencies {
@@ -240,14 +242,14 @@ func verifyResourceDependenciesResolved(target *api.Container, existingResources
 	return true
 }
 
-func linkCanResolve(target *api.Container, link *api.Container) bool {
+func linkCanResolve(target *apicontainer.Container, link *apicontainer.Container) bool {
 	targetDesiredStatus := target.GetDesiredStatus()
 	linkDesiredStatus := link.GetDesiredStatus()
-	if targetDesiredStatus == api.ContainerCreated {
+	if targetDesiredStatus == apicontainer.ContainerCreated {
 		// The 'target' container desires to be moved to 'Created' state.
 		// Allow this only if the desired status of the linked container is
 		// 'Created' or if the linked container is in 'steady state'
-		return linkDesiredStatus == api.ContainerCreated || linkDesiredStatus == link.GetSteadyStateStatus()
+		return linkDesiredStatus == apicontainer.ContainerCreated || linkDesiredStatus == link.GetSteadyStateStatus()
 	} else if targetDesiredStatus == target.GetSteadyStateStatus() {
 		// The 'target' container desires to be moved to its 'steady' state.
 		// Allow this only if the linked container is in 'steady state' as well
@@ -257,14 +259,14 @@ func linkCanResolve(target *api.Container, link *api.Container) bool {
 	return false
 }
 
-func linkIsResolved(target *api.Container, link *api.Container) bool {
+func linkIsResolved(target *apicontainer.Container, link *apicontainer.Container) bool {
 	targetDesiredStatus := target.GetDesiredStatus()
-	if targetDesiredStatus == api.ContainerCreated {
+	if targetDesiredStatus == apicontainer.ContainerCreated {
 		// The 'target' container desires to be moved to 'Created' state.
 		// Allow this only if the known status of the linked container is
 		// 'Created' or if the linked container is in 'steady state'
 		linkKnownStatus := link.GetKnownStatus()
-		return linkKnownStatus == api.ContainerCreated || link.IsKnownSteadyState()
+		return linkKnownStatus == apicontainer.ContainerCreated || link.IsKnownSteadyState()
 	} else if targetDesiredStatus == target.GetSteadyStateStatus() {
 		// The 'target' container desires to be moved to its 'steady' state.
 		// Allow this only if the linked container is in 'steady state' as well
@@ -274,9 +276,9 @@ func linkIsResolved(target *api.Container, link *api.Container) bool {
 	return false
 }
 
-func volumeCanResolve(target *api.Container, volume *api.Container) bool {
+func volumeCanResolve(target *apicontainer.Container, volume *apicontainer.Container) bool {
 	targetDesiredStatus := target.GetDesiredStatus()
-	if targetDesiredStatus != api.ContainerCreated && targetDesiredStatus != target.GetSteadyStateStatus() {
+	if targetDesiredStatus != apicontainer.ContainerCreated && targetDesiredStatus != target.GetSteadyStateStatus() {
 		// The 'target' container doesn't desire to move to either 'Created' or the 'steady' state,
 		// which is not allowed
 		log.Errorf("Failed to resolve the desired status of the volume [%v] for the target [%v]", volume, target)
@@ -287,14 +289,14 @@ func volumeCanResolve(target *api.Container, volume *api.Container) bool {
 	// Allow this only if the known status of the source volume container is
 	// any of 'Created', 'steady state' or 'Stopped'
 	volumeDesiredStatus := volume.GetDesiredStatus()
-	return volumeDesiredStatus == api.ContainerCreated ||
+	return volumeDesiredStatus == apicontainer.ContainerCreated ||
 		volumeDesiredStatus == volume.GetSteadyStateStatus() ||
-		volumeDesiredStatus == api.ContainerStopped
+		volumeDesiredStatus == apicontainer.ContainerStopped
 }
 
-func volumeIsResolved(target *api.Container, volume *api.Container) bool {
+func volumeIsResolved(target *apicontainer.Container, volume *apicontainer.Container) bool {
 	targetDesiredStatus := target.GetDesiredStatus()
-	if targetDesiredStatus != api.ContainerCreated && targetDesiredStatus != api.ContainerRunning {
+	if targetDesiredStatus != apicontainer.ContainerCreated && targetDesiredStatus != apicontainer.ContainerRunning {
 		// The 'target' container doesn't desire to be moved to 'Created' or the 'steady' state.
 		// Do not allow it.
 		log.Errorf("Failed to resolve if the volume [%v] has been resolved for the target [%v]", volume, target)
@@ -305,19 +307,19 @@ func volumeIsResolved(target *api.Container, volume *api.Container) bool {
 	// Allow this only if the known status of the source volume container is
 	// any of 'Created', 'steady state' or 'Stopped'
 	knownStatus := volume.GetKnownStatus()
-	return knownStatus == api.ContainerCreated ||
+	return knownStatus == apicontainer.ContainerCreated ||
 		knownStatus == volume.GetSteadyStateStatus() ||
-		knownStatus == api.ContainerStopped
+		knownStatus == apicontainer.ContainerStopped
 }
 
-func onSteadyStateCanResolve(target *api.Container, run *api.Container) bool {
-	return target.GetDesiredStatus() >= api.ContainerCreated &&
+func onSteadyStateCanResolve(target *apicontainer.Container, run *apicontainer.Container) bool {
+	return target.GetDesiredStatus() >= apicontainer.ContainerCreated &&
 		run.GetDesiredStatus() >= run.GetSteadyStateStatus()
 }
 
 // onSteadyStateIsResolved defines a relationship where a target cannot be
 // created until 'dependency' has reached the steady state. Transitions include pulling.
-func onSteadyStateIsResolved(target *api.Container, run *api.Container) bool {
-	return target.GetDesiredStatus() >= api.ContainerCreated &&
+func onSteadyStateIsResolved(target *apicontainer.Container, run *apicontainer.Container) bool {
+	return target.GetDesiredStatus() >= apicontainer.ContainerCreated &&
 		run.GetKnownStatus() >= run.GetSteadyStateStatus()
 }

--- a/agent/engine/dependencygraph/graph_unix_test.go
+++ b/agent/engine/dependencygraph/graph_unix_test.go
@@ -17,7 +17,7 @@ package dependencygraph
 import (
 	"testing"
 
-	"github.com/aws/amazon-ecs-agent/agent/api"
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/cgroup"
 	"github.com/stretchr/testify/assert"
@@ -26,32 +26,32 @@ import (
 func TestVerifyCgroupDependenciesResolved(t *testing.T) {
 	testcases := []struct {
 		Name             string
-		TargetKnown      api.ContainerStatus
-		TargetDep        api.ContainerStatus
+		TargetKnown      apicontainer.ContainerStatus
+		TargetDep        apicontainer.ContainerStatus
 		DependencyKnown  taskresource.ResourceStatus
 		RequiredStatus   taskresource.ResourceStatus
 		ExpectedResolved bool
 	}{
 		{
 			Name:             "resource none,container pull depends on resource created",
-			TargetKnown:      api.ContainerStatusNone,
-			TargetDep:        api.ContainerPulled,
+			TargetKnown:      apicontainer.ContainerStatusNone,
+			TargetDep:        apicontainer.ContainerPulled,
 			DependencyKnown:  taskresource.ResourceStatus(cgroup.CgroupStatusNone),
 			RequiredStatus:   taskresource.ResourceStatus(cgroup.CgroupCreated),
 			ExpectedResolved: false,
 		},
 		{
 			Name:             "resource created,container pull depends on resource created",
-			TargetKnown:      api.ContainerStatusNone,
-			TargetDep:        api.ContainerPulled,
+			TargetKnown:      apicontainer.ContainerStatusNone,
+			TargetDep:        apicontainer.ContainerPulled,
 			DependencyKnown:  taskresource.ResourceStatus(cgroup.CgroupCreated),
 			RequiredStatus:   taskresource.ResourceStatus(cgroup.CgroupCreated),
 			ExpectedResolved: true,
 		},
 		{
 			Name:             "resource none,container create depends on resource created",
-			TargetKnown:      api.ContainerStatusNone,
-			TargetDep:        api.ContainerCreated,
+			TargetKnown:      apicontainer.ContainerStatusNone,
+			TargetDep:        apicontainer.ContainerCreated,
 			DependencyKnown:  taskresource.ResourceStatus(cgroup.CgroupStatusNone),
 			RequiredStatus:   taskresource.ResourceStatus(cgroup.CgroupCreated),
 			ExpectedResolved: true,
@@ -61,9 +61,9 @@ func TestVerifyCgroupDependenciesResolved(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			cgroupResource := &cgroup.CgroupResource{}
 			cgroupResource.SetKnownStatus(tc.DependencyKnown)
-			target := &api.Container{
+			target := &apicontainer.Container{
 				KnownStatusUnsafe:         tc.TargetKnown,
-				TransitionDependenciesMap: make(map[api.ContainerStatus]api.TransitionDependencySet),
+				TransitionDependenciesMap: make(map[apicontainer.ContainerStatus]apicontainer.TransitionDependencySet),
 			}
 			target.BuildResourceDependency("cgroup", tc.RequiredStatus, tc.TargetDep)
 			resources := make(map[string]taskresource.TaskResource)

--- a/agent/engine/docker_image_manager.go
+++ b/agent/engine/docker_image_manager.go
@@ -21,7 +21,7 @@ import (
 
 	"context"
 
-	"github.com/aws/amazon-ecs-agent/agent/api"
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
@@ -37,8 +37,8 @@ const (
 // ImageManager is responsible for saving the Image states,
 // adding and removing container references to ImageStates
 type ImageManager interface {
-	RecordContainerReference(container *api.Container) error
-	RemoveContainerReferenceFromImageState(container *api.Container) error
+	RecordContainerReference(container *apicontainer.Container) error
+	RemoveContainerReferenceFromImageState(container *apicontainer.Container) error
 	AddAllImageStates(imageStates []*image.ImageState)
 	GetImageStateFromImageName(containerImageName string) *image.ImageState
 	StartImageCleanupProcess(ctx context.Context)
@@ -93,7 +93,7 @@ func (imageManager *dockerImageManager) GetImageStatesCount() int {
 }
 
 // RecordContainerReference adds container reference to the corresponding imageState object
-func (imageManager *dockerImageManager) RecordContainerReference(container *api.Container) error {
+func (imageManager *dockerImageManager) RecordContainerReference(container *apicontainer.Container) error {
 	// the image state has been updated, save the new state
 	defer imageManager.saver.ForceSave()
 	// On agent restart, container ID was retrieved from agent state file
@@ -124,7 +124,7 @@ func (imageManager *dockerImageManager) RecordContainerReference(container *api.
 	return nil
 }
 
-func (imageManager *dockerImageManager) addContainerReferenceToExistingImageState(container *api.Container) bool {
+func (imageManager *dockerImageManager) addContainerReferenceToExistingImageState(container *apicontainer.Container) bool {
 	// this lock is used for reading the image states in the image manager
 	imageManager.updateLock.RLock()
 	defer imageManager.updateLock.RUnlock()
@@ -136,7 +136,7 @@ func (imageManager *dockerImageManager) addContainerReferenceToExistingImageStat
 	return ok
 }
 
-func (imageManager *dockerImageManager) addContainerReferenceToNewImageState(container *api.Container, imageSize int64) {
+func (imageManager *dockerImageManager) addContainerReferenceToNewImageState(container *apicontainer.Container, imageSize int64) {
 	// this lock is used while creating and adding new image state to image manager
 	imageManager.updateLock.Lock()
 	defer imageManager.updateLock.Unlock()
@@ -161,7 +161,7 @@ func (imageManager *dockerImageManager) addContainerReferenceToNewImageState(con
 }
 
 // RemoveContainerReferenceFromImageState removes container reference from the corresponding imageState object
-func (imageManager *dockerImageManager) RemoveContainerReferenceFromImageState(container *api.Container) error {
+func (imageManager *dockerImageManager) RemoveContainerReferenceFromImageState(container *apicontainer.Container) error {
 	// the image state has been updated, save the new state
 	defer imageManager.saver.ForceSave()
 	// this lock is for reading image states and finding the one that the container belongs to

--- a/agent/engine/docker_image_manager_integ_test.go
+++ b/agent/engine/docker_image_manager_integ_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	"github.com/aws/amazon-ecs-agent/agent/statemanager"
 	docker "github.com/fsouza/go-dockerclient"
@@ -570,12 +571,12 @@ func createImageCleanupHappyTestTask(taskName string) *api.Task {
 		Family:              taskName,
 		Version:             "1",
 		DesiredStatusUnsafe: api.TaskRunning,
-		Containers: []*api.Container{
+		Containers: []*apicontainer.Container{
 			{
 				Name:                "test1",
 				Image:               test1Image1Name,
 				Essential:           false,
-				DesiredStatusUnsafe: api.ContainerRunning,
+				DesiredStatusUnsafe: apicontainer.ContainerRunning,
 				CPU:                 512,
 				Memory:              256,
 			},
@@ -583,7 +584,7 @@ func createImageCleanupHappyTestTask(taskName string) *api.Task {
 				Name:                "test2",
 				Image:               test1Image2Name,
 				Essential:           false,
-				DesiredStatusUnsafe: api.ContainerRunning,
+				DesiredStatusUnsafe: apicontainer.ContainerRunning,
 				CPU:                 512,
 				Memory:              256,
 			},
@@ -591,7 +592,7 @@ func createImageCleanupHappyTestTask(taskName string) *api.Task {
 				Name:                "test3",
 				Image:               test1Image3Name,
 				Essential:           false,
-				DesiredStatusUnsafe: api.ContainerRunning,
+				DesiredStatusUnsafe: apicontainer.ContainerRunning,
 				CPU:                 512,
 				Memory:              256,
 			},
@@ -605,12 +606,12 @@ func createImageCleanupThresholdTestTask(taskName string) *api.Task {
 		Family:              taskName,
 		Version:             "1",
 		DesiredStatusUnsafe: api.TaskRunning,
-		Containers: []*api.Container{
+		Containers: []*apicontainer.Container{
 			{
 				Name:                "test1",
 				Image:               test2Image1Name,
 				Essential:           false,
-				DesiredStatusUnsafe: api.ContainerRunning,
+				DesiredStatusUnsafe: apicontainer.ContainerRunning,
 				CPU:                 512,
 				Memory:              256,
 			},
@@ -618,7 +619,7 @@ func createImageCleanupThresholdTestTask(taskName string) *api.Task {
 				Name:                "test2",
 				Image:               test2Image2Name,
 				Essential:           false,
-				DesiredStatusUnsafe: api.ContainerRunning,
+				DesiredStatusUnsafe: apicontainer.ContainerRunning,
 				CPU:                 512,
 				Memory:              256,
 			},
@@ -626,7 +627,7 @@ func createImageCleanupThresholdTestTask(taskName string) *api.Task {
 				Name:                "test3",
 				Image:               test2Image3Name,
 				Essential:           false,
-				DesiredStatusUnsafe: api.ContainerRunning,
+				DesiredStatusUnsafe: apicontainer.ContainerRunning,
 				CPU:                 512,
 				Memory:              256,
 			},

--- a/agent/engine/docker_image_manager_test.go
+++ b/agent/engine/docker_image_manager_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/amazon-ecs-agent/agent/api"
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi/mocks"
@@ -53,7 +53,7 @@ func TestImagePullRemoveDeadlock(t *testing.T) {
 	imageManager := NewImageManager(cfg, client, dockerstate.NewTaskEngineState())
 	imageManager.SetSaver(statemanager.NewNoopStateManager())
 
-	sleepContainer := &api.Container{
+	sleepContainer := &apicontainer.Container{
 		Name:  "sleep",
 		Image: "busybox",
 	}
@@ -95,7 +95,7 @@ func TestAddAndRemoveContainerToImageStateReferenceHappyPath(t *testing.T) {
 	imageManager := NewImageManager(defaultTestConfig(), client, dockerstate.NewTaskEngineState())
 	imageManager.SetSaver(statemanager.NewNoopStateManager())
 
-	container := &api.Container{
+	container := &apicontainer.Container{
 		Name:  "testContainer",
 		Image: "testContainerImage",
 	}
@@ -147,7 +147,7 @@ func TestRecordContainerReferenceInspectError(t *testing.T) {
 	}
 	imageManager.SetSaver(statemanager.NewNoopStateManager())
 
-	container := &api.Container{
+	container := &apicontainer.Container{
 		Name:  "testContainer",
 		Image: "testContainerImage",
 	}
@@ -181,7 +181,7 @@ func TestRecordContainerReferenceWithNoImageName(t *testing.T) {
 	}
 	imageManager.SetSaver(statemanager.NewNoopStateManager())
 
-	container := &api.Container{
+	container := &apicontainer.Container{
 		Name:  "testContainer",
 		Image: "testContainerImage",
 	}
@@ -220,7 +220,7 @@ func TestAddInvalidContainerReferenceToImageState(t *testing.T) {
 	imageManager := NewImageManager(defaultTestConfig(), client, dockerstate.NewTaskEngineState())
 	imageManager.SetSaver(statemanager.NewNoopStateManager())
 
-	container := &api.Container{
+	container := &apicontainer.Container{
 		Image: "",
 	}
 	err := imageManager.RecordContainerReference(container)
@@ -235,7 +235,7 @@ func TestAddContainerReferenceToExistingImageState(t *testing.T) {
 	client := mock_dockerapi.NewMockDockerClient(ctrl)
 	imageManager := &dockerImageManager{client: client, state: dockerstate.NewTaskEngineState()}
 	imageID := "sha256:qwerty"
-	container := &api.Container{
+	container := &apicontainer.Container{
 		Name:    "testContainer",
 		Image:   "testContainerImage",
 		ImageID: imageID,
@@ -271,7 +271,7 @@ func TestAddContainerReferenceToExistingImageStateNoState(t *testing.T) {
 	defer ctrl.Finish()
 	client := mock_dockerapi.NewMockDockerClient(ctrl)
 	imageManager := &dockerImageManager{client: client, state: dockerstate.NewTaskEngineState()}
-	container := &api.Container{
+	container := &apicontainer.Container{
 		Name:    "testContainer",
 		Image:   "testContainerImage",
 		ImageID: "sha256:qwerty",
@@ -289,7 +289,7 @@ func TestAddContainerReferenceToNewImageState(t *testing.T) {
 	imageID := "sha256:qwerty"
 	var imageSize int64
 	imageSize = 18767
-	container := &api.Container{
+	container := &apicontainer.Container{
 		Name:    "testContainer",
 		Image:   "testContainerImage",
 		ImageID: imageID,
@@ -309,7 +309,7 @@ func TestAddContainerReferenceToNewImageStateAddedState(t *testing.T) {
 	imageID := "sha256:qwerty"
 	var imageSize int64
 	imageSize = 18767
-	container := &api.Container{
+	container := &apicontainer.Container{
 		Name:    "testContainer",
 		Image:   "testContainerImage",
 		ImageID: imageID,
@@ -346,7 +346,7 @@ func TestRemoveContainerReferenceFromInvalidImageState(t *testing.T) {
 	imageManager := NewImageManager(defaultTestConfig(), client, dockerstate.NewTaskEngineState())
 	imageManager.SetSaver(statemanager.NewNoopStateManager())
 
-	container := &api.Container{
+	container := &apicontainer.Container{
 		Image: "myContainerImage",
 	}
 	imageInspected := &docker.Image{
@@ -367,7 +367,7 @@ func TestRemoveInvalidContainerReferenceFromImageState(t *testing.T) {
 	imageManager := NewImageManager(defaultTestConfig(), client, dockerstate.NewTaskEngineState())
 	imageManager.SetSaver(statemanager.NewNoopStateManager())
 
-	container := &api.Container{
+	container := &apicontainer.Container{
 		Image: "",
 	}
 	err := imageManager.RemoveContainerReferenceFromImageState(container)
@@ -384,7 +384,7 @@ func TestRemoveContainerReferenceFromImageStateInspectError(t *testing.T) {
 	imageManager := NewImageManager(defaultTestConfig(), client, dockerstate.NewTaskEngineState())
 	imageManager.SetSaver(statemanager.NewNoopStateManager())
 
-	container := &api.Container{
+	container := &apicontainer.Container{
 		Image: "myContainerImage",
 	}
 	client.EXPECT().InspectImage(container.Image).Return(nil, errors.New("error inspecting")).AnyTimes()
@@ -408,7 +408,7 @@ func TestRemoveContainerReferenceFromImageStateWithNoReference(t *testing.T) {
 	}
 	imageManager.SetSaver(statemanager.NewNoopStateManager())
 
-	container := &api.Container{
+	container := &apicontainer.Container{
 		Name:  "testContainer",
 		Image: "testContainerImage",
 	}
@@ -489,7 +489,7 @@ func TestGetCandidateImagesForDeletionImageHasContainerReference(t *testing.T) {
 	}
 	imageManager.SetSaver(statemanager.NewNoopStateManager())
 
-	container := &api.Container{
+	container := &apicontainer.Container{
 		Name:  "testContainer",
 		Image: "testContainerImage",
 	}
@@ -530,11 +530,11 @@ func TestGetCandidateImagesForDeletionImageHasMoreContainerReferences(t *testing
 	}
 	imageManager.SetSaver(statemanager.NewNoopStateManager())
 
-	container := &api.Container{
+	container := &apicontainer.Container{
 		Name:  "testContainer",
 		Image: "testContainerImage",
 	}
-	container2 := &api.Container{
+	container2 := &apicontainer.Container{
 		Name:  "testContainer2",
 		Image: "testContainerImage",
 	}
@@ -657,7 +657,7 @@ func TestRemoveAlreadyExistingImageNameWithDifferentID(t *testing.T) {
 	}
 	imageManager.SetSaver(statemanager.NewNoopStateManager())
 
-	container := &api.Container{
+	container := &apicontainer.Container{
 		Name:  "testContainer",
 		Image: "testContainerImage",
 	}
@@ -673,7 +673,7 @@ func TestRemoveAlreadyExistingImageNameWithDifferentID(t *testing.T) {
 	if err != nil {
 		t.Error("Error in adding container to an existing image state")
 	}
-	container1 := &api.Container{
+	container1 := &apicontainer.Container{
 		Name:  "testContainer1",
 		Image: "testContainerImage",
 	}
@@ -708,7 +708,7 @@ func TestImageCleanupHappyPath(t *testing.T) {
 	}
 
 	imageManager.SetSaver(statemanager.NewNoopStateManager())
-	container := &api.Container{
+	container := &apicontainer.Container{
 		Name:  "testContainer",
 		Image: "testContainerImage",
 	}
@@ -760,7 +760,7 @@ func TestImageCleanupCannotRemoveImage(t *testing.T) {
 	}
 
 	imageManager.SetSaver(statemanager.NewNoopStateManager())
-	container := &api.Container{
+	container := &apicontainer.Container{
 		Name:  "testContainer",
 		Image: "testContainerImage",
 	}
@@ -812,7 +812,7 @@ func TestImageCleanupRemoveImageById(t *testing.T) {
 	}
 
 	imageManager.SetSaver(statemanager.NewNoopStateManager())
-	container := &api.Container{
+	container := &apicontainer.Container{
 		Name:  "testContainer",
 		Image: "testContainerImage",
 	}
@@ -854,7 +854,7 @@ func TestDeleteImage(t *testing.T) {
 	client := mock_dockerapi.NewMockDockerClient(ctrl)
 	imageManager := &dockerImageManager{client: client, state: dockerstate.NewTaskEngineState()}
 	imageManager.SetSaver(statemanager.NewNoopStateManager())
-	container := &api.Container{
+	container := &apicontainer.Container{
 		Name:  "testContainer",
 		Image: "testContainerImage",
 	}
@@ -885,7 +885,7 @@ func TestDeleteImageNotFoundError(t *testing.T) {
 	client := mock_dockerapi.NewMockDockerClient(ctrl)
 	imageManager := &dockerImageManager{client: client, state: dockerstate.NewTaskEngineState()}
 	imageManager.SetSaver(statemanager.NewNoopStateManager())
-	container := &api.Container{
+	container := &apicontainer.Container{
 		Name:  "testContainer",
 		Image: "testContainerImage",
 	}
@@ -916,7 +916,7 @@ func TestDeleteImageOtherRemoveImageErrors(t *testing.T) {
 	client := mock_dockerapi.NewMockDockerClient(ctrl)
 	imageManager := &dockerImageManager{client: client, state: dockerstate.NewTaskEngineState()}
 	imageManager.SetSaver(statemanager.NewNoopStateManager())
-	container := &api.Container{
+	container := &apicontainer.Container{
 		Name:  "testContainer",
 		Image: "testContainerImage",
 	}
@@ -983,7 +983,7 @@ func TestGetImageStateFromImageName(t *testing.T) {
 	client := mock_dockerapi.NewMockDockerClient(ctrl)
 	imageManager := &dockerImageManager{client: client, state: dockerstate.NewTaskEngineState()}
 	imageManager.SetSaver(statemanager.NewNoopStateManager())
-	container := &api.Container{
+	container := &apicontainer.Container{
 		Name:  "testContainer",
 		Image: "testContainerImage",
 	}
@@ -1007,7 +1007,7 @@ func TestGetImageStateFromImageNameNoImageState(t *testing.T) {
 	client := mock_dockerapi.NewMockDockerClient(ctrl)
 	imageManager := &dockerImageManager{client: client, state: dockerstate.NewTaskEngineState()}
 	imageManager.SetSaver(statemanager.NewNoopStateManager())
-	container := &api.Container{
+	container := &apicontainer.Container{
 		Name:  "testContainer",
 		Image: "testContainerImage",
 	}
@@ -1041,7 +1041,7 @@ func TestConcurrentRemoveUnusedImages(t *testing.T) {
 	}
 
 	imageManager.SetSaver(statemanager.NewNoopStateManager())
-	container := &api.Container{
+	container := &apicontainer.Container{
 		Name:  "testContainer",
 		Image: "testContainerImage",
 	}

--- a/agent/engine/docker_task_engine_unix_test.go
+++ b/agent/engine/docker_task_engine_unix_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	"github.com/aws/amazon-ecs-agent/agent/emptyvolume"
@@ -50,12 +51,12 @@ func TestPullEmptyVolumeImage(t *testing.T) {
 	taskEngine.SetSaver(saver)
 
 	imageName := "image"
-	container := &api.Container{
-		Type:  api.ContainerEmptyHostVolume,
+	container := &apicontainer.Container{
+		Type:  apicontainer.ContainerEmptyHostVolume,
 		Image: imageName,
 	}
 	task := &api.Task{
-		Containers: []*api.Container{container},
+		Containers: []*apicontainer.Container{container},
 	}
 
 	assert.True(t, emptyvolume.LocalImage, "empty volume image is local")

--- a/agent/engine/docker_task_engine_windows_test.go
+++ b/agent/engine/docker_task_engine_windows_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	"github.com/aws/amazon-ecs-agent/agent/emptyvolume"
@@ -49,12 +50,12 @@ func TestPullEmptyVolumeImage(t *testing.T) {
 	taskEngine._time = nil
 
 	imageName := "image"
-	container := &api.Container{
-		Type:  api.ContainerEmptyHostVolume,
+	container := &apicontainer.Container{
+		Type:  apicontainer.ContainerEmptyHostVolume,
 		Image: imageName,
 	}
 	task := &api.Task{
-		Containers: []*api.Container{container},
+		Containers: []*apicontainer.Container{container},
 	}
 
 	assert.False(t, emptyvolume.LocalImage, "Windows empty volume image is not local")

--- a/agent/engine/dockerstate/dockerstate_test.go
+++ b/agent/engine/dockerstate/dockerstate_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/engine/image"
 
 	"github.com/stretchr/testify/assert"
@@ -107,12 +108,12 @@ func TestAddRemoveENIAttachment(t *testing.T) {
 
 func TestTwophaseAddContainer(t *testing.T) {
 	state := NewTaskEngineState()
-	testTask := &api.Task{Arn: "test", Containers: []*api.Container{{
+	testTask := &api.Task{Arn: "test", Containers: []*apicontainer.Container{{
 		Name: "testContainer",
 	}}}
 	state.AddTask(testTask)
 
-	state.AddContainer(&api.DockerContainer{DockerName: "dockerName", Container: testTask.Containers[0]}, testTask)
+	state.AddContainer(&apicontainer.DockerContainer{DockerName: "dockerName", Container: testTask.Containers[0]}, testTask)
 
 	if len(state.AllTasks()) != 1 {
 		t.Fatal("Should have 1 task")
@@ -142,7 +143,7 @@ func TestTwophaseAddContainer(t *testing.T) {
 		t.Fatal("DockerID Should be blank")
 	}
 
-	state.AddContainer(&api.DockerContainer{DockerName: "dockerName", Container: testTask.Containers[0], DockerID: "did"}, testTask)
+	state.AddContainer(&apicontainer.DockerContainer{DockerName: "dockerName", Container: testTask.Containers[0], DockerID: "did"}, testTask)
 
 	containerMap, ok = state.ContainerMapByArn("test")
 	if !ok {
@@ -171,26 +172,26 @@ func TestTwophaseAddContainer(t *testing.T) {
 
 func TestRemoveTask(t *testing.T) {
 	state := NewTaskEngineState()
-	testContainer1 := &api.Container{
+	testContainer1 := &apicontainer.Container{
 		Name: "c1",
 	}
 
 	containerID := "did"
-	testDockerContainer1 := &api.DockerContainer{
+	testDockerContainer1 := &apicontainer.DockerContainer{
 		DockerID:  containerID,
 		Container: testContainer1,
 	}
-	testContainer2 := &api.Container{
+	testContainer2 := &apicontainer.Container{
 		Name: "c2",
 	}
-	testDockerContainer2 := &api.DockerContainer{
+	testDockerContainer2 := &apicontainer.DockerContainer{
 		// DockerName is used before the DockerID is assigned
 		DockerName: "docker-name-2",
 		Container:  testContainer2,
 	}
 	testTask := &api.Task{
 		Arn:        "t1",
-		Containers: []*api.Container{testContainer1, testContainer2},
+		Containers: []*apicontainer.Container{testContainer1, testContainer2},
 	}
 
 	state.AddTask(testTask)
@@ -313,9 +314,9 @@ func TestAddContainerNameAndID(t *testing.T) {
 	task := &api.Task{
 		Arn: "taskArn",
 	}
-	container := &api.DockerContainer{
+	container := &apicontainer.DockerContainer{
 		DockerName: "ecs-test-container-1",
-		Container: &api.Container{
+		Container: &apicontainer.Container{
 			Name: "test",
 		},
 	}
@@ -330,10 +331,10 @@ func TestAddContainerNameAndID(t *testing.T) {
 	_, ok = state.ContainerByID(container.DockerName)
 	assert.True(t, ok, "container with DockerName should be added to the state")
 
-	container = &api.DockerContainer{
+	container = &apicontainer.DockerContainer{
 		DockerName: "ecs-test-container-1",
 		DockerID:   "dockerid",
-		Container: &api.Container{
+		Container: &apicontainer.Container{
 			Name: "test",
 		},
 	}

--- a/agent/engine/dockerstate/json.go
+++ b/agent/engine/dockerstate/json.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/engine/image"
 )
 
@@ -25,8 +26,8 @@ import (
 // DockerTaskEngine state
 type savedState struct {
 	Tasks          []*api.Task
-	IdToContainer  map[string]*api.DockerContainer `json:"IdToContainer"` // DockerId -> api.DockerContainer
-	IdToTask       map[string]string               `json:"IdToTask"`      // DockerId -> taskarn
+	IdToContainer  map[string]*apicontainer.DockerContainer `json:"IdToContainer"` // DockerId -> apicontainer.DockerContainer
+	IdToTask       map[string]string                        `json:"IdToTask"`      // DockerId -> taskarn
 	ImageStates    []*image.ImageState
 	ENIAttachments []*api.ENIAttachment `json:"ENIAttachments"`
 	IPToTask       map[string]string    `json:"IPToTask"`

--- a/agent/engine/dockerstate/mocks/dockerstate_mocks.go
+++ b/agent/engine/dockerstate/mocks/dockerstate_mocks.go
@@ -21,6 +21,7 @@ import (
 	reflect "reflect"
 
 	api "github.com/aws/amazon-ecs-agent/agent/api"
+	container "github.com/aws/amazon-ecs-agent/agent/api/container"
 	image "github.com/aws/amazon-ecs-agent/agent/engine/image"
 	gomock "github.com/golang/mock/gomock"
 )
@@ -49,7 +50,7 @@ func (m *MockTaskEngineState) EXPECT() *MockTaskEngineStateMockRecorder {
 }
 
 // AddContainer mocks base method
-func (m *MockTaskEngineState) AddContainer(arg0 *api.DockerContainer, arg1 *api.Task) {
+func (m *MockTaskEngineState) AddContainer(arg0 *container.DockerContainer, arg1 *api.Task) {
 	m.ctrl.Call(m, "AddContainer", arg0, arg1)
 }
 
@@ -123,9 +124,9 @@ func (mr *MockTaskEngineStateMockRecorder) AllTasks() *gomock.Call {
 }
 
 // ContainerByID mocks base method
-func (m *MockTaskEngineState) ContainerByID(arg0 string) (*api.DockerContainer, bool) {
+func (m *MockTaskEngineState) ContainerByID(arg0 string) (*container.DockerContainer, bool) {
 	ret := m.ctrl.Call(m, "ContainerByID", arg0)
-	ret0, _ := ret[0].(*api.DockerContainer)
+	ret0, _ := ret[0].(*container.DockerContainer)
 	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }
@@ -136,9 +137,9 @@ func (mr *MockTaskEngineStateMockRecorder) ContainerByID(arg0 interface{}) *gomo
 }
 
 // ContainerMapByArn mocks base method
-func (m *MockTaskEngineState) ContainerMapByArn(arg0 string) (map[string]*api.DockerContainer, bool) {
+func (m *MockTaskEngineState) ContainerMapByArn(arg0 string) (map[string]*container.DockerContainer, bool) {
 	ret := m.ctrl.Call(m, "ContainerMapByArn", arg0)
-	ret0, _ := ret[0].(map[string]*api.DockerContainer)
+	ret0, _ := ret[0].(map[string]*container.DockerContainer)
 	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }

--- a/agent/engine/dockerstate/testutils/json_test.go
+++ b/agent/engine/dockerstate/testutils/json_test.go
@@ -21,16 +21,17 @@ import (
 	"testing"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/stretchr/testify/assert"
 )
 
-func createTestContainer(num int) *api.Container {
-	return &api.Container{
+func createTestContainer(num int) *apicontainer.Container {
+	return &apicontainer.Container{
 		Name:                "busybox-" + strconv.Itoa(num),
 		Image:               "busybox:latest",
 		Essential:           true,
-		DesiredStatusUnsafe: api.ContainerRunning,
+		DesiredStatusUnsafe: apicontainer.ContainerRunning,
 	}
 }
 
@@ -40,7 +41,7 @@ func createTestTask(arn string, numContainers int) *api.Task {
 		Family:              arn,
 		Version:             "1",
 		DesiredStatusUnsafe: api.TaskRunning,
-		Containers:          []*api.Container{},
+		Containers:          []*apicontainer.Container{},
 	}
 
 	for i := 0; i < numContainers; i++ {
@@ -72,7 +73,7 @@ func TestJsonEncoding(t *testing.T) {
 	testTask := createTestTask("test1", 1)
 	testState.AddTask(testTask)
 	for i, cont := range testTask.Containers {
-		testState.AddContainer(&api.DockerContainer{DockerID: "docker" + strconv.Itoa(i), DockerName: "someName", Container: cont}, testTask)
+		testState.AddContainer(&apicontainer.DockerContainer{DockerID: "docker" + strconv.Itoa(i), DockerName: "someName", Container: cont}, testTask)
 	}
 	other := decodeEqual(t, testState)
 	_, ok := other.ContainerMapByArn("test1")

--- a/agent/engine/errors.go
+++ b/agent/engine/errors.go
@@ -14,7 +14,7 @@
 package engine
 
 import (
-	"github.com/aws/amazon-ecs-agent/agent/api"
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apierrors "github.com/aws/amazon-ecs-agent/agent/api/errors"
 )
 
@@ -26,7 +26,7 @@ type cannotStopContainerError interface {
 // impossibleTransitionError is an error that occurs when an event causes a
 // container to try and transition to a state that it cannot be moved to
 type impossibleTransitionError struct {
-	state api.ContainerStatus
+	state apicontainer.ContainerStatus
 }
 
 func (err *impossibleTransitionError) Error() string {

--- a/agent/engine/mocks/engine_mocks.go
+++ b/agent/engine/mocks/engine_mocks.go
@@ -22,6 +22,7 @@ import (
 	reflect "reflect"
 
 	api "github.com/aws/amazon-ecs-agent/agent/api"
+	container "github.com/aws/amazon-ecs-agent/agent/api/container"
 	image "github.com/aws/amazon-ecs-agent/agent/engine/image"
 	statechange "github.com/aws/amazon-ecs-agent/agent/statechange"
 	statemanager "github.com/aws/amazon-ecs-agent/agent/statemanager"
@@ -227,7 +228,7 @@ func (mr *MockImageManagerMockRecorder) GetImageStateFromImageName(arg0 interfac
 }
 
 // RecordContainerReference mocks base method
-func (m *MockImageManager) RecordContainerReference(arg0 *api.Container) error {
+func (m *MockImageManager) RecordContainerReference(arg0 *container.Container) error {
 	ret := m.ctrl.Call(m, "RecordContainerReference", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -239,7 +240,7 @@ func (mr *MockImageManagerMockRecorder) RecordContainerReference(arg0 interface{
 }
 
 // RemoveContainerReferenceFromImageState mocks base method
-func (m *MockImageManager) RemoveContainerReferenceFromImageState(arg0 *api.Container) error {
+func (m *MockImageManager) RemoveContainerReferenceFromImageState(arg0 *container.Container) error {
 	ret := m.ctrl.Call(m, "RemoveContainerReferenceFromImageState", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0

--- a/agent/eventhandler/handler_test.go
+++ b/agent/eventhandler/handler_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apierrors "github.com/aws/amazon-ecs-agent/agent/api/errors"
 	"github.com/aws/amazon-ecs-agent/agent/api/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate/mocks"
@@ -154,9 +155,9 @@ func TestSendsEventsContainerDifferences(t *testing.T) {
 	client.EXPECT().SubmitTaskStateChange(gomock.Any()).Do(func(change api.TaskStateChange) {
 		assert.Equal(t, 2, len(change.Containers))
 		assert.Equal(t, taskARN, change.Containers[0].TaskArn)
-		assert.Equal(t, api.ContainerRunning, change.Containers[0].Status)
+		assert.Equal(t, apicontainer.ContainerRunning, change.Containers[0].Status)
 		assert.Equal(t, taskARN, change.Containers[1].TaskArn)
-		assert.Equal(t, api.ContainerStopped, change.Containers[1].Status)
+		assert.Equal(t, apicontainer.ContainerStopped, change.Containers[1].Status)
 		wg.Done()
 	})
 
@@ -237,7 +238,7 @@ func TestSendsEventsDedupe(t *testing.T) {
 	task1 := taskEvent(taskARNA)
 	task1.(api.TaskStateChange).Task.SetSentStatus(api.TaskRunning)
 	cont1 := containerEvent(taskARNA)
-	cont1.(api.ContainerStateChange).Container.SetSentStatus(api.ContainerRunning)
+	cont1.(api.ContainerStateChange).Container.SetSentStatus(apicontainer.ContainerRunning)
 
 	handler.AddStateChangeEvent(cont1, client)
 	handler.AddStateChangeEvent(task1, client)
@@ -245,7 +246,7 @@ func TestSendsEventsDedupe(t *testing.T) {
 	task2 := taskEvent(taskARNB)
 	task2.(api.TaskStateChange).Task.SetSentStatus(api.TaskStatusNone)
 	cont2 := containerEvent(taskARNB)
-	cont2.(api.ContainerStateChange).Container.SetSentStatus(api.ContainerRunning)
+	cont2.(api.ContainerStateChange).Container.SetSentStatus(apicontainer.ContainerRunning)
 
 	// Expect to send a task status but not a container status
 	client.EXPECT().SubmitTaskStateChange(gomock.Any()).Do(func(change api.TaskStateChange) {
@@ -304,11 +305,11 @@ func TestCleanupTaskEventAfterSubmit(t *testing.T) {
 }
 
 func containerEvent(arn string) statechange.Event {
-	return api.ContainerStateChange{TaskArn: arn, ContainerName: "containerName", Status: api.ContainerRunning, Container: &api.Container{}}
+	return api.ContainerStateChange{TaskArn: arn, ContainerName: "containerName", Status: apicontainer.ContainerRunning, Container: &apicontainer.Container{}}
 }
 
 func containerEventStopped(arn string) statechange.Event {
-	return api.ContainerStateChange{TaskArn: arn, ContainerName: "containerName", Status: api.ContainerStopped, Container: &api.Container{}}
+	return api.ContainerStateChange{TaskArn: arn, ContainerName: "containerName", Status: apicontainer.ContainerStopped, Container: &apicontainer.Container{}}
 }
 
 func taskEvent(arn string) statechange.Event {

--- a/agent/eventhandler/task_handler_types_test.go
+++ b/agent/eventhandler/task_handler_types_test.go
@@ -19,12 +19,13 @@ import (
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestShouldContainerEventBeSent(t *testing.T) {
 	event := newSendableContainerEvent(api.ContainerStateChange{
-		Status: api.ContainerStopped,
+		Status: apicontainer.ContainerStopped,
 	})
 	assert.Equal(t, true, event.containerShouldBeSent())
 	assert.Equal(t, false, event.taskShouldBeSent())
@@ -83,15 +84,15 @@ func TestShouldTaskEventBeSent(t *testing.T) {
 				},
 				Containers: []api.ContainerStateChange{
 					{
-						Container: &api.Container{
-							SentStatusUnsafe:  api.ContainerRunning,
-							KnownStatusUnsafe: api.ContainerRunning,
+						Container: &apicontainer.Container{
+							SentStatusUnsafe:  apicontainer.ContainerRunning,
+							KnownStatusUnsafe: apicontainer.ContainerRunning,
 						},
 					},
 					{
-						Container: &api.Container{
-							SentStatusUnsafe:  api.ContainerRunning,
-							KnownStatusUnsafe: api.ContainerStopped,
+						Container: &apicontainer.Container{
+							SentStatusUnsafe:  apicontainer.ContainerRunning,
+							KnownStatusUnsafe: apicontainer.ContainerStopped,
 						},
 					},
 				},
@@ -108,9 +109,9 @@ func TestShouldTaskEventBeSent(t *testing.T) {
 				},
 				Containers: []api.ContainerStateChange{
 					{
-						Container: &api.Container{
-							SentStatusUnsafe:  api.ContainerStatusNone,
-							KnownStatusUnsafe: api.ContainerRunning,
+						Container: &apicontainer.Container{
+							SentStatusUnsafe:  apicontainer.ContainerStatusNone,
+							KnownStatusUnsafe: apicontainer.ContainerRunning,
 						},
 					},
 				},
@@ -126,15 +127,15 @@ func TestShouldTaskEventBeSent(t *testing.T) {
 				},
 				Containers: []api.ContainerStateChange{
 					{
-						Container: &api.Container{
-							SentStatusUnsafe:  api.ContainerRunning,
-							KnownStatusUnsafe: api.ContainerRunning,
+						Container: &apicontainer.Container{
+							SentStatusUnsafe:  apicontainer.ContainerRunning,
+							KnownStatusUnsafe: apicontainer.ContainerRunning,
 						},
 					},
 					{
-						Container: &api.Container{
-							SentStatusUnsafe:  api.ContainerStopped,
-							KnownStatusUnsafe: api.ContainerStopped,
+						Container: &apicontainer.Container{
+							SentStatusUnsafe:  apicontainer.ContainerStopped,
+							KnownStatusUnsafe: apicontainer.ContainerStopped,
 						},
 					},
 				},

--- a/agent/handlers/taskmetadata/taskinfo_test.go
+++ b/agent/handlers/taskmetadata/taskinfo_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/containermetadata"
 	"github.com/aws/amazon-ecs-agent/agent/credentials"
@@ -76,28 +77,28 @@ var (
 		PullStoppedAtUnsafe:      now,
 		ExecutionStoppedAtUnsafe: now,
 	}
-	container = &api.Container{
+	container = &apicontainer.Container{
 		Name:                containerName,
 		Image:               imageName,
 		ImageID:             imageID,
-		DesiredStatusUnsafe: api.ContainerRunning,
-		KnownStatusUnsafe:   api.ContainerRunning,
+		DesiredStatusUnsafe: apicontainer.ContainerRunning,
+		KnownStatusUnsafe:   apicontainer.ContainerRunning,
 		CPU:                 cpu,
 		Memory:              memory,
-		Type:                api.ContainerNormal,
-		Ports: []api.PortBinding{
+		Type:                apicontainer.ContainerNormal,
+		Ports: []apicontainer.PortBinding{
 			{
 				ContainerPort: containerPort,
-				Protocol:      api.TransportProtocolTCP,
+				Protocol:      apicontainer.TransportProtocolTCP,
 			},
 		},
 	}
-	dockerContainer = &api.DockerContainer{
+	dockerContainer = &apicontainer.DockerContainer{
 		DockerID:   containerID,
 		DockerName: containerName,
 		Container:  container,
 	}
-	containerNameToDockerContainer = map[string]*api.DockerContainer{
+	containerNameToDockerContainer = map[string]*apicontainer.DockerContainer{
 		taskARN: dockerContainer,
 	}
 	labels = map[string]string{
@@ -246,8 +247,8 @@ func TestTaskStats(t *testing.T) {
 	statsEngine := mock_stats.NewMockEngine(ctrl)
 
 	dockerStats := &docker.Stats{NumProcs: 2}
-	containerMap := map[string]*api.DockerContainer{
-		containerName: &api.DockerContainer{
+	containerMap := map[string]*apicontainer.DockerContainer{
+		containerName: &apicontainer.DockerContainer{
 			DockerID: containerID,
 		},
 	}

--- a/agent/handlers/types/v2/response.go
+++ b/agent/handlers/types/v2/response.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/containermetadata"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/aws-sdk-go/aws"
@@ -58,7 +59,7 @@ type ContainerResponse struct {
 	FinishedAt    *time.Time `json:",omitempty"`
 	Type          string
 	Networks      []containermetadata.Network `json:",omitempty"`
-	Health        *api.HealthStatus           `json:",omitempty"`
+	Health        *apicontainer.HealthStatus  `json:",omitempty"`
 }
 
 // LimitsResponse defines the schema for task/cpu limits response
@@ -150,7 +151,7 @@ func NewContainerResponse(containerID string,
 	return &resp, nil
 }
 
-func newContainerResponse(dockerContainer *api.DockerContainer,
+func newContainerResponse(dockerContainer *apicontainer.DockerContainer,
 	eni *api.ENI,
 	state dockerstate.TaskEngineState) ContainerResponse {
 	container := dockerContainer.Container

--- a/agent/handlers/types/v2/response_test.go
+++ b/agent/handlers/types/v2/response_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate/mocks"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/golang/mock/gomock"
@@ -65,19 +66,19 @@ func TestTaskResponse(t *testing.T) {
 		PullStoppedAtUnsafe:      now,
 		ExecutionStoppedAtUnsafe: now,
 	}
-	container := &api.Container{
+	container := &apicontainer.Container{
 		Name:                containerName,
 		Image:               imageName,
 		ImageID:             imageID,
-		DesiredStatusUnsafe: api.ContainerRunning,
-		KnownStatusUnsafe:   api.ContainerRunning,
+		DesiredStatusUnsafe: apicontainer.ContainerRunning,
+		KnownStatusUnsafe:   apicontainer.ContainerRunning,
 		CPU:                 cpu,
 		Memory:              memory,
-		Type:                api.ContainerNormal,
-		Ports: []api.PortBinding{
+		Type:                apicontainer.ContainerNormal,
+		Ports: []apicontainer.PortBinding{
 			{
 				ContainerPort: 80,
-				Protocol:      api.TransportProtocolTCP,
+				Protocol:      apicontainer.TransportProtocolTCP,
 			},
 		},
 	}
@@ -87,8 +88,8 @@ func TestTaskResponse(t *testing.T) {
 		"foo": "bar",
 	}
 	container.SetLabels(labels)
-	containerNameToDockerContainer := map[string]*api.DockerContainer{
-		taskARN: &api.DockerContainer{
+	containerNameToDockerContainer := map[string]*apicontainer.DockerContainer{
+		taskARN: &apicontainer.DockerContainer{
 			DockerID:   containerID,
 			DockerName: containerName,
 			Container:  container,
@@ -128,24 +129,24 @@ func TestContainerResponse(t *testing.T) {
 			defer ctrl.Finish()
 
 			state := mock_dockerstate.NewMockTaskEngineState(ctrl)
-			container := &api.Container{
+			container := &apicontainer.Container{
 				Name:                containerName,
 				Image:               imageName,
 				ImageID:             imageID,
-				DesiredStatusUnsafe: api.ContainerRunning,
-				KnownStatusUnsafe:   api.ContainerRunning,
+				DesiredStatusUnsafe: apicontainer.ContainerRunning,
+				KnownStatusUnsafe:   apicontainer.ContainerRunning,
 				CPU:                 cpu,
 				Memory:              memory,
-				Type:                api.ContainerNormal,
+				Type:                apicontainer.ContainerNormal,
 				HealthCheckType:     tc.healthCheckType,
-				Health: api.HealthStatus{
-					Status: api.ContainerHealthy,
+				Health: apicontainer.HealthStatus{
+					Status: apicontainer.ContainerHealthy,
 					Since:  aws.Time(time.Now()),
 				},
-				Ports: []api.PortBinding{
+				Ports: []apicontainer.PortBinding{
 					{
 						ContainerPort: 80,
-						Protocol:      api.TransportProtocolTCP,
+						Protocol:      apicontainer.TransportProtocolTCP,
 					},
 				},
 			}
@@ -155,7 +156,7 @@ func TestContainerResponse(t *testing.T) {
 				"foo": "bar",
 			}
 			container.SetLabels(labels)
-			dockerContainer := &api.DockerContainer{
+			dockerContainer := &apicontainer.DockerContainer{
 				DockerID:   containerID,
 				DockerName: containerName,
 				Container:  container,

--- a/agent/handlers/types/v2/stats_response_test.go
+++ b/agent/handlers/types/v2/stats_response_test.go
@@ -16,7 +16,7 @@ package v2
 import (
 	"testing"
 
-	"github.com/aws/amazon-ecs-agent/agent/api"
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/stats/mock"
 	docker "github.com/fsouza/go-dockerclient"
@@ -32,8 +32,8 @@ func TestTaskStatsResponseSuccess(t *testing.T) {
 	statsEngine := mock_stats.NewMockEngine(ctrl)
 
 	dockerStats := &docker.Stats{NumProcs: 2}
-	containerMap := map[string]*api.DockerContainer{
-		containerName: &api.DockerContainer{
+	containerMap := map[string]*apicontainer.DockerContainer{
+		containerName: &apicontainer.DockerContainer{
 			DockerID: containerID,
 		},
 	}

--- a/agent/handlers/v1_handlers.go
+++ b/agent/handlers/v1_handlers.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/containermetadata"
 	"github.com/aws/amazon-ecs-agent/agent/engine"
@@ -67,7 +68,7 @@ func metadataV1RequestHandlerMaker(containerInstanceArn *string, cfg *config.Con
 	}
 }
 
-func newTaskResponse(task *api.Task, containerMap map[string]*api.DockerContainer) *v1.TaskResponse {
+func newTaskResponse(task *api.Task, containerMap map[string]*apicontainer.DockerContainer) *v1.TaskResponse {
 	containers := []v1.ContainerResponse{}
 	for _, container := range containerMap {
 		if container.Container.IsInternal() {
@@ -96,7 +97,7 @@ func newTaskResponse(task *api.Task, containerMap map[string]*api.DockerContaine
 	}
 }
 
-func newContainerResponse(dockerContainer *api.DockerContainer, eni *api.ENI) v1.ContainerResponse {
+func newContainerResponse(dockerContainer *apicontainer.DockerContainer, eni *api.ENI) v1.ContainerResponse {
 	container := dockerContainer.Container
 	resp := v1.ContainerResponse{
 		Name:       container.Name,
@@ -118,7 +119,7 @@ func newContainerResponse(dockerContainer *api.DockerContainer, eni *api.ENI) v1
 	return resp
 }
 
-func newPortBindingsResponse(dockerContainer *api.DockerContainer, eni *api.ENI) []v2.PortResponse {
+func newPortBindingsResponse(dockerContainer *apicontainer.DockerContainer, eni *api.ENI) []v2.PortResponse {
 	container := dockerContainer.Container
 	resp := []v2.PortResponse{}
 

--- a/agent/handlers/v1_handlers_test.go
+++ b/agent/handlers/v1_handlers_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/handlers/mocks"
@@ -198,7 +199,7 @@ func TestBackendMismatchMapping(t *testing.T) {
 
 	mockStateResolver := mock_handlers.NewMockDockerStateResolver(ctrl)
 
-	containers := []*api.Container{
+	containers := []*apicontainer.Container{
 		{
 			Name: "c1",
 		},
@@ -320,7 +321,7 @@ var testTasks = []*api.Task{
 		KnownStatusUnsafe:   api.TaskRunning,
 		Family:              "test",
 		Version:             "1",
-		Containers: []*api.Container{
+		Containers: []*apicontainer.Container{
 			{
 				Name: "one",
 			},
@@ -335,7 +336,7 @@ var testTasks = []*api.Task{
 		KnownStatusUnsafe:   api.TaskRunning,
 		Family:              "test",
 		Version:             "2",
-		Containers: []*api.Container{
+		Containers: []*apicontainer.Container{
 			{
 				Name: "foo",
 			},
@@ -347,7 +348,7 @@ var testTasks = []*api.Task{
 		KnownStatusUnsafe:   api.TaskRunning,
 		Family:              "test",
 		Version:             "2",
-		Containers: []*api.Container{
+		Containers: []*apicontainer.Container{
 			{
 				Name: "shortId",
 			},
@@ -359,7 +360,7 @@ var testTasks = []*api.Task{
 		KnownStatusUnsafe:   api.TaskRunning,
 		Family:              "test",
 		Version:             "1",
-		Containers: []*api.Container{
+		Containers: []*apicontainer.Container{
 			{
 				Name: "awsvpc",
 			},
@@ -378,14 +379,14 @@ var testTasks = []*api.Task{
 		KnownStatusUnsafe:   api.TaskRunning,
 		Family:              "test",
 		Version:             "1",
-		Containers: []*api.Container{
+		Containers: []*apicontainer.Container{
 			{
 				Name: "awsvpc",
-				Ports: []api.PortBinding{
+				Ports: []apicontainer.PortBinding{
 					{
 						ContainerPort: 80,
 						HostPort:      80,
-						Protocol:      api.TransportProtocolTCP,
+						Protocol:      apicontainer.TransportProtocolTCP,
 					},
 				},
 			},
@@ -397,14 +398,14 @@ var testTasks = []*api.Task{
 		KnownStatusUnsafe:   api.TaskRunning,
 		Family:              "test",
 		Version:             "1",
-		Containers: []*api.Container{
+		Containers: []*apicontainer.Container{
 			{
 				Name: "awsvpc",
-				KnownPortBindingsUnsafe: []api.PortBinding{
+				KnownPortBindingsUnsafe: []apicontainer.PortBinding{
 					{
 						ContainerPort: 80,
 						HostPort:      80,
-						Protocol:      api.TransportProtocolTCP,
+						Protocol:      apicontainer.TransportProtocolTCP,
 					},
 				},
 			},
@@ -416,7 +417,7 @@ func stateSetupHelper(state dockerstate.TaskEngineState, tasks []*api.Task) {
 	for _, task := range tasks {
 		state.AddTask(task)
 		for _, container := range task.Containers {
-			state.AddContainer(&api.DockerContainer{
+			state.AddContainer(&apicontainer.DockerContainer{
 				Container:  container,
 				DockerID:   "dockerid-" + task.Arn + "-" + container.Name,
 				DockerName: "dockername-" + task.Arn + "-" + container.Name,

--- a/agent/statemanager/state_manager.go
+++ b/agent/statemanager/state_manager.go
@@ -44,25 +44,25 @@ const (
 	// 4) Add 'DockerConfig' struct
 	// 5) Add 'ImageStates' struct as part of ImageManager
 	// 6)
-	//   a) Refactor 'Internal' field in 'api.Container' to 'Type' enum
+	//   a) Refactor 'Internal' field in 'apicontainer.Container' to 'Type' enum
 	//   b) Add 'ContainerResourcesProvisioned' as a new 'ContainerStatus' enum
 	//   c) Add 'SteadyStateStatus' field to 'Container' struct
 	//   d) Add 'ENIAttachments' struct
 	//   e) Deprecate 'SteadyStateDependencies' in favor of 'TransitionDependencySet'
 	// 7)
-	//   a) Add 'MetadataUpdated' field to 'api.Container'
+	//   a) Add 'MetadataUpdated' field to 'apicontainer.Container'
 	//   b) Add 'DomainNameServers' and 'DomainNameSearchList' in `api.ENI`
 	// 8)
 	//   a) Add 'UseExecutionRole' in `api.ECRAuthData`
 	//   b) Add `executionCredentialsID` in `api.Task`
-	//   c) Add 'LogsAuthStrategy' field to 'api.Container'
+	//   c) Add 'LogsAuthStrategy' field to 'apicontainer.Container'
 	//   d) Added task cgroup related fields ('CPU', 'Memory', 'MemoryCPULimitsEnabled') to 'api.Task'
 	// 9) Add 'ipToTask' map to state file
-	// 10) Add 'healthCheckType' field in 'api.Container'
+	// 10) Add 'healthCheckType' field in 'apicontainer.Container'
 	// 11)
 	//  a) Add 'PrivateDNSName' field to 'api.ENI'
-	//  b)Remove `AppliedStatus` field form 'api.Container'
-	// 12) Deprecate 'TransitionDependencySet' and add new 'TransitionDependenciesMap' in 'api.Container'
+	//  b)Remove `AppliedStatus` field form 'apicontainer.Container'
+	// 12) Deprecate 'TransitionDependencySet' and add new 'TransitionDependenciesMap' in 'apicontainer.Container'
 	ECSDataVersion = 12
 
 	// ecsDataFile specifies the filename in the ECS_DATADIR

--- a/agent/statemanager/state_manager_test.go
+++ b/agent/statemanager/state_manager_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/engine"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
@@ -66,9 +67,9 @@ func TestLoadsV1DataCorrectly(t *testing.T) {
 
 	require.NotNil(t, deadTask)
 	assert.Equal(t, deadTask.GetSentStatus(), api.TaskStopped)
-	assert.Equal(t, deadTask.Containers[0].SentStatusUnsafe, api.ContainerStopped)
-	assert.Equal(t, deadTask.Containers[0].DesiredStatusUnsafe, api.ContainerStopped)
-	assert.Equal(t, deadTask.Containers[0].KnownStatusUnsafe, api.ContainerStopped)
+	assert.Equal(t, deadTask.Containers[0].SentStatusUnsafe, apicontainer.ContainerStopped)
+	assert.Equal(t, deadTask.Containers[0].DesiredStatusUnsafe, apicontainer.ContainerStopped)
+	assert.Equal(t, deadTask.Containers[0].KnownStatusUnsafe, apicontainer.ContainerStopped)
 
 	exitCode := deadTask.Containers[0].KnownExitCodeUnsafe
 	require.NotNil(t, exitCode)

--- a/agent/stats/common_test.go
+++ b/agent/stats/common_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
@@ -27,6 +28,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/tcs/model/ecstcs"
 
 	"context"
+
 	"github.com/aws/aws-sdk-go/aws"
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/stretchr/testify/assert"
@@ -93,13 +95,13 @@ func createHealthContainer(client *docker.Client) (*docker.Container, error) {
 
 type IntegContainerMetadataResolver struct {
 	containerIDToTask            map[string]*api.Task
-	containerIDToDockerContainer map[string]*api.DockerContainer
+	containerIDToDockerContainer map[string]*apicontainer.DockerContainer
 }
 
 func newIntegContainerMetadataResolver() *IntegContainerMetadataResolver {
 	resolver := IntegContainerMetadataResolver{
 		containerIDToTask:            make(map[string]*api.Task),
-		containerIDToDockerContainer: make(map[string]*api.DockerContainer),
+		containerIDToDockerContainer: make(map[string]*apicontainer.DockerContainer),
 	}
 
 	return &resolver
@@ -114,7 +116,7 @@ func (resolver *IntegContainerMetadataResolver) ResolveTask(containerID string) 
 	return task, nil
 }
 
-func (resolver *IntegContainerMetadataResolver) ResolveContainer(containerID string) (*api.DockerContainer, error) {
+func (resolver *IntegContainerMetadataResolver) ResolveContainer(containerID string) (*apicontainer.DockerContainer, error) {
 	container, exists := resolver.containerIDToDockerContainer[containerID]
 	if !exists {
 		return nil, fmt.Errorf("unmapped container")

--- a/agent/stats/container_test.go
+++ b/agent/stats/container_test.go
@@ -23,7 +23,7 @@ import (
 
 	"context"
 
-	"github.com/aws/amazon-ecs-agent/agent/api"
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi/mocks"
 	mock_resolver "github.com/aws/amazon-ecs-agent/agent/stats/resolver/mock"
 	docker "github.com/fsouza/go-dockerclient"
@@ -137,10 +137,10 @@ func TestContainerStatsCollectionReconnection(t *testing.T) {
 	closedChan := make(chan *docker.Stats)
 	close(closedChan)
 
-	mockContainer := &api.DockerContainer{
+	mockContainer := &apicontainer.DockerContainer{
 		DockerID: dockerID,
-		Container: &api.Container{
-			KnownStatusUnsafe: api.ContainerRunning,
+		Container: &apicontainer.Container{
+			KnownStatusUnsafe: apicontainer.ContainerRunning,
 		},
 	}
 	gomock.InOrder(
@@ -178,10 +178,10 @@ func TestContainerStatsCollectionStopsIfContainerIsTerminal(t *testing.T) {
 	close(closedChan)
 
 	statsErr := fmt.Errorf("test error")
-	mockContainer := &api.DockerContainer{
+	mockContainer := &apicontainer.DockerContainer{
 		DockerID: dockerID,
-		Container: &api.Container{
-			KnownStatusUnsafe: api.ContainerStopped,
+		Container: &apicontainer.Container{
+			KnownStatusUnsafe: apicontainer.ContainerStopped,
 		},
 	}
 	gomock.InOrder(

--- a/agent/stats/engine.go
+++ b/agent/stats/engine.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	ecsengine "github.com/aws/amazon-ecs-agent/agent/engine"
@@ -99,7 +100,7 @@ func (resolver *DockerContainerMetadataResolver) ResolveTask(dockerID string) (*
 }
 
 // ResolveContainer resolves the api container object, given container id.
-func (resolver *DockerContainerMetadataResolver) ResolveContainer(dockerID string) (*api.DockerContainer, error) {
+func (resolver *DockerContainerMetadataResolver) ResolveContainer(dockerID string) (*apicontainer.DockerContainer, error) {
 	if resolver.dockerTaskEngine == nil {
 		return nil, fmt.Errorf("Docker task engine uninitialized")
 	}
@@ -504,9 +505,9 @@ func (engine *DockerStatsEngine) handleDockerEvents(events ...interface{}) error
 		}
 
 		switch dockerContainerChangeEvent.Status {
-		case api.ContainerRunning:
+		case apicontainer.ContainerRunning:
 			engine.addAndStartStatsContainer(dockerContainerChangeEvent.DockerID)
-		case api.ContainerStopped:
+		case apicontainer.ContainerStopped:
 			engine.removeContainer(dockerContainerChangeEvent.DockerID)
 		default:
 			seelog.Debugf("Ignoring event for container, id: %s, status: %d", dockerContainerChangeEvent.DockerID, dockerContainerChangeEvent.Status)

--- a/agent/stats/engine_integ_test.go
+++ b/agent/stats/engine_integ_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	ecsengine "github.com/aws/amazon-ecs-agent/agent/engine"
@@ -44,7 +45,7 @@ func createRunningTask() *api.Task {
 		KnownStatusUnsafe:   api.TaskRunning,
 		Family:              taskDefinitionFamily,
 		Version:             taskDefinitionVersion,
-		Containers: []*api.Container{
+		Containers: []*apicontainer.Container{
 			{
 				Name: containerName,
 			},
@@ -79,7 +80,7 @@ func TestStatsEngineWithExistingContainersWithoutHealth(t *testing.T) {
 	dockerTaskEngine := taskEngine.(*ecsengine.DockerTaskEngine)
 	dockerTaskEngine.State().AddTask(testTask)
 	dockerTaskEngine.State().AddContainer(
-		&api.DockerContainer{
+		&apicontainer.DockerContainer{
 			DockerID:   container.ID,
 			DockerName: "gremlin",
 			Container:  testTask.Containers[0],
@@ -103,7 +104,7 @@ func TestStatsEngineWithExistingContainersWithoutHealth(t *testing.T) {
 	require.NoError(t, err, "stopping container failed")
 
 	err = engine.containerChangeEventStream.WriteToEventStream(dockerapi.DockerContainerChangeEvent{
-		Status: api.ContainerStopped,
+		Status: apicontainer.ContainerStopped,
 		DockerContainerMetadata: dockerapi.DockerContainerMetadata{
 			DockerID: container.ID,
 		},
@@ -140,7 +141,7 @@ func TestStatsEngineWithNewContainersWithoutHealth(t *testing.T) {
 	dockerTaskEngine := taskEngine.(*ecsengine.DockerTaskEngine)
 	dockerTaskEngine.State().AddTask(testTask)
 	dockerTaskEngine.State().AddContainer(
-		&api.DockerContainer{
+		&apicontainer.DockerContainer{
 			DockerID:   container.ID,
 			DockerName: "gremlin",
 			Container:  testTask.Containers[0],
@@ -159,7 +160,7 @@ func TestStatsEngineWithNewContainersWithoutHealth(t *testing.T) {
 
 	// Write the container change event to event stream
 	err = engine.containerChangeEventStream.WriteToEventStream(dockerapi.DockerContainerChangeEvent{
-		Status: api.ContainerRunning,
+		Status: apicontainer.ContainerRunning,
 		DockerContainerMetadata: dockerapi.DockerContainerMetadata{
 			DockerID: container.ID,
 		},
@@ -175,7 +176,7 @@ func TestStatsEngineWithNewContainersWithoutHealth(t *testing.T) {
 	require.NoError(t, err, "stopping container failed")
 	// Write the container change event to event stream
 	err = engine.containerChangeEventStream.WriteToEventStream(dockerapi.DockerContainerChangeEvent{
-		Status: api.ContainerStopped,
+		Status: apicontainer.ContainerStopped,
 		DockerContainerMetadata: dockerapi.DockerContainerMetadata{
 			DockerID: container.ID,
 		},
@@ -218,7 +219,7 @@ func TestStatsEngineWithExistingContainers(t *testing.T) {
 	dockerTaskEngine := taskEngine.(*ecsengine.DockerTaskEngine)
 	dockerTaskEngine.State().AddTask(testTask)
 	dockerTaskEngine.State().AddContainer(
-		&api.DockerContainer{
+		&apicontainer.DockerContainer{
 			DockerID:   container.ID,
 			DockerName: "container-health",
 			Container:  testTask.Containers[0],
@@ -246,7 +247,7 @@ func TestStatsEngineWithExistingContainers(t *testing.T) {
 	require.NoError(t, err, "stopping container failed")
 
 	err = engine.containerChangeEventStream.WriteToEventStream(dockerapi.DockerContainerChangeEvent{
-		Status: api.ContainerStopped,
+		Status: apicontainer.ContainerStopped,
 		DockerContainerMetadata: dockerapi.DockerContainerMetadata{
 			DockerID: container.ID,
 		},
@@ -286,7 +287,7 @@ func TestStatsEngineWithNewContainers(t *testing.T) {
 	dockerTaskEngine := taskEngine.(*ecsengine.DockerTaskEngine)
 	dockerTaskEngine.State().AddTask(testTask)
 	dockerTaskEngine.State().AddContainer(
-		&api.DockerContainer{
+		&apicontainer.DockerContainer{
 			DockerID:   container.ID,
 			DockerName: "container-health",
 			Container:  testTask.Containers[0],
@@ -305,7 +306,7 @@ func TestStatsEngineWithNewContainers(t *testing.T) {
 
 	// Write the container change event to event stream
 	err = engine.containerChangeEventStream.WriteToEventStream(dockerapi.DockerContainerChangeEvent{
-		Status: api.ContainerRunning,
+		Status: apicontainer.ContainerRunning,
 		DockerContainerMetadata: dockerapi.DockerContainerMetadata{
 			DockerID: container.ID,
 		},
@@ -323,7 +324,7 @@ func TestStatsEngineWithNewContainers(t *testing.T) {
 
 	// Write the container change event to event stream
 	err = engine.containerChangeEventStream.WriteToEventStream(dockerapi.DockerContainerChangeEvent{
-		Status: api.ContainerStopped,
+		Status: apicontainer.ContainerStopped,
 		DockerContainerMetadata: dockerapi.DockerContainerMetadata{
 			DockerID: container.ID,
 		},
@@ -360,7 +361,7 @@ func TestStatsEngineWithDockerTaskEngine(t *testing.T) {
 	dockerTaskEngine := taskEngine.(*ecsengine.DockerTaskEngine)
 	dockerTaskEngine.State().AddTask(testTask)
 	dockerTaskEngine.State().AddContainer(
-		&api.DockerContainer{
+		&apicontainer.DockerContainer{
 			DockerID:   container.ID,
 			DockerName: "container-health",
 			Container:  testTask.Containers[0],
@@ -385,7 +386,7 @@ func TestStatsEngineWithDockerTaskEngine(t *testing.T) {
 	defer client.StopContainer(unmappedContainer.ID, defaultDockerTimeoutSeconds)
 
 	err = containerChangeEventStream.WriteToEventStream(dockerapi.DockerContainerChangeEvent{
-		Status: api.ContainerRunning,
+		Status: apicontainer.ContainerRunning,
 		DockerContainerMetadata: dockerapi.DockerContainerMetadata{
 			DockerID: container.ID,
 		},
@@ -393,7 +394,7 @@ func TestStatsEngineWithDockerTaskEngine(t *testing.T) {
 	assert.NoError(t, err, "failed to write to container change event stream")
 
 	err = containerChangeEventStream.WriteToEventStream(dockerapi.DockerContainerChangeEvent{
-		Status: api.ContainerRunning,
+		Status: apicontainer.ContainerRunning,
 		DockerContainerMetadata: dockerapi.DockerContainerMetadata{
 			DockerID: unmappedContainer.ID,
 		},
@@ -409,7 +410,7 @@ func TestStatsEngineWithDockerTaskEngine(t *testing.T) {
 	require.NoError(t, err, "stopping container failed")
 
 	err = containerChangeEventStream.WriteToEventStream(dockerapi.DockerContainerChangeEvent{
-		Status: api.ContainerStopped,
+		Status: apicontainer.ContainerStopped,
 		DockerContainerMetadata: dockerapi.DockerContainerMetadata{
 			DockerID: container.ID,
 		},
@@ -436,13 +437,13 @@ func TestStatsEngineWithDockerTaskEngineMissingRemoveEvent(t *testing.T) {
 	testTask := createRunningTask()
 	// enable container health check of this container
 	testTask.Containers[0].HealthCheckType = "docker"
-	testTask.Containers[0].KnownStatusUnsafe = api.ContainerStopped
+	testTask.Containers[0].KnownStatusUnsafe = apicontainer.ContainerStopped
 
 	// Populate Tasks and Container map in the engine.
 	dockerTaskEngine := taskEngine.(*ecsengine.DockerTaskEngine)
 	dockerTaskEngine.State().AddTask(testTask)
 	dockerTaskEngine.State().AddContainer(
-		&api.DockerContainer{
+		&apicontainer.DockerContainer{
 			DockerID:   container.ID,
 			DockerName: "container-health",
 			Container:  testTask.Containers[0],
@@ -462,7 +463,7 @@ func TestStatsEngineWithDockerTaskEngineMissingRemoveEvent(t *testing.T) {
 	require.NoError(t, err, "starting container failed")
 
 	err = containerChangeEventStream.WriteToEventStream(dockerapi.DockerContainerChangeEvent{
-		Status: api.ContainerRunning,
+		Status: apicontainer.ContainerRunning,
 		DockerContainerMetadata: dockerapi.DockerContainerMetadata{
 			DockerID: container.ID,
 		},

--- a/agent/stats/engine_test.go
+++ b/agent/stats/engine_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi/mocks"
 	mock_resolver "github.com/aws/amazon-ecs-agent/agent/stats/resolver/mock"
@@ -45,8 +46,8 @@ func TestStatsEngineAddRemoveContainers(t *testing.T) {
 	resolver.EXPECT().ResolveTask("c4").AnyTimes().Return(nil, fmt.Errorf("unmapped container"))
 	resolver.EXPECT().ResolveTask("c5").AnyTimes().Return(t2, nil)
 	resolver.EXPECT().ResolveTask("c6").AnyTimes().Return(t3, nil)
-	resolver.EXPECT().ResolveContainer(gomock.Any()).AnyTimes().Return(&api.DockerContainer{
-		Container: &api.Container{},
+	resolver.EXPECT().ResolveContainer(gomock.Any()).AnyTimes().Return(&apicontainer.DockerContainer{
+		Container: &apicontainer.Container{},
 	}, nil)
 	mockStatsChannel := make(chan *docker.Stats)
 	defer close(mockStatsChannel)
@@ -170,8 +171,8 @@ func TestStatsEngineMetadataInStatsSets(t *testing.T) {
 	mockDockerClient := mock_dockerapi.NewMockDockerClient(mockCtrl)
 	t1 := &api.Task{Arn: "t1", Family: "f1"}
 	resolver.EXPECT().ResolveTask("c1").AnyTimes().Return(t1, nil)
-	resolver.EXPECT().ResolveContainer(gomock.Any()).AnyTimes().Return(&api.DockerContainer{
-		Container: &api.Container{},
+	resolver.EXPECT().ResolveContainer(gomock.Any()).AnyTimes().Return(&apicontainer.DockerContainer{
+		Container: &apicontainer.Container{},
 	}, nil)
 	mockDockerClient.EXPECT().Stats(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 
@@ -283,13 +284,13 @@ func TestGetTaskHealthMetrics(t *testing.T) {
 
 	containerID := "containerID"
 	resolver := mock_resolver.NewMockContainerMetadataResolver(mockCtrl)
-	resolver.EXPECT().ResolveContainer(containerID).Return(&api.DockerContainer{
+	resolver.EXPECT().ResolveContainer(containerID).Return(&apicontainer.DockerContainer{
 		DockerID: containerID,
-		Container: &api.Container{
-			KnownStatusUnsafe: api.ContainerRunning,
+		Container: &apicontainer.Container{
+			KnownStatusUnsafe: apicontainer.ContainerRunning,
 			HealthCheckType:   "docker",
-			Health: api.HealthStatus{
-				Status: api.ContainerHealthy,
+			Health: apicontainer.HealthStatus{
+				Status: apicontainer.ContainerHealthy,
 				Since:  aws.Time(time.Now()),
 			},
 		},
@@ -325,13 +326,13 @@ func TestGetTaskHealthMetricsStoppedContainer(t *testing.T) {
 
 	containerID := "containerID"
 	resolver := mock_resolver.NewMockContainerMetadataResolver(mockCtrl)
-	resolver.EXPECT().ResolveContainer(containerID).Return(&api.DockerContainer{
+	resolver.EXPECT().ResolveContainer(containerID).Return(&apicontainer.DockerContainer{
 		DockerID: containerID,
-		Container: &api.Container{
-			KnownStatusUnsafe: api.ContainerStopped,
+		Container: &apicontainer.Container{
+			KnownStatusUnsafe: apicontainer.ContainerStopped,
 			HealthCheckType:   "docker",
-			Health: api.HealthStatus{
-				Status: api.ContainerHealthy,
+			Health: apicontainer.HealthStatus{
+				Status: apicontainer.ContainerHealthy,
 				Since:  aws.Time(time.Now()),
 			},
 		},
@@ -371,9 +372,9 @@ func TestMetricsDisabled(t *testing.T) {
 		KnownStatusUnsafe: api.TaskRunning,
 		Family:            "f1",
 	}, nil)
-	resolver.EXPECT().ResolveContainer(containerID).Return(&api.DockerContainer{
+	resolver.EXPECT().ResolveContainer(containerID).Return(&apicontainer.DockerContainer{
 		DockerID: containerID,
-		Container: &api.Container{
+		Container: &apicontainer.Container{
 			HealthCheckType: "docker",
 		},
 	}, nil)
@@ -417,9 +418,9 @@ func TestSynchronizeOnRestart(t *testing.T) {
 		KnownStatusUnsafe: api.TaskRunning,
 		Family:            "f1",
 	}, nil)
-	resolver.EXPECT().ResolveContainer(containerID).Return(&api.DockerContainer{
+	resolver.EXPECT().ResolveContainer(containerID).Return(&apicontainer.DockerContainer{
 		DockerID: containerID,
-		Container: &api.Container{
+		Container: &apicontainer.Container{
 			HealthCheckType: "docker",
 		},
 	}, nil)

--- a/agent/stats/resolver/mock/resolver.go
+++ b/agent/stats/resolver/mock/resolver.go
@@ -21,6 +21,7 @@ import (
 	reflect "reflect"
 
 	api "github.com/aws/amazon-ecs-agent/agent/api"
+	container "github.com/aws/amazon-ecs-agent/agent/api/container"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -48,9 +49,9 @@ func (m *MockContainerMetadataResolver) EXPECT() *MockContainerMetadataResolverM
 }
 
 // ResolveContainer mocks base method
-func (m *MockContainerMetadataResolver) ResolveContainer(arg0 string) (*api.DockerContainer, error) {
+func (m *MockContainerMetadataResolver) ResolveContainer(arg0 string) (*container.DockerContainer, error) {
 	ret := m.ctrl.Call(m, "ResolveContainer", arg0)
-	ret0, _ := ret[0].(*api.DockerContainer)
+	ret0, _ := ret[0].(*container.DockerContainer)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/agent/stats/resolver/resolver.go
+++ b/agent/stats/resolver/resolver.go
@@ -13,12 +13,15 @@
 
 package resolver
 
-import "github.com/aws/amazon-ecs-agent/agent/api"
+import (
+	"github.com/aws/amazon-ecs-agent/agent/api"
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+)
 
 //go:generate go run ../../../scripts/generate/mockgen.go github.com/aws/amazon-ecs-agent/agent/stats/resolver ContainerMetadataResolver mock/$GOFILE
 
 // ContainerMetadataResolver defines methods to resolve meta-data.
 type ContainerMetadataResolver interface {
 	ResolveTask(string) (*api.Task, error)
-	ResolveContainer(string) (*api.DockerContainer, error)
+	ResolveContainer(string) (*apicontainer.DockerContainer, error)
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Refactoring container related code under api package to its own sub package. Will do the same with task related code after this. Container, Task, and volume are very tightly coupled under api package, so refactoring it in pieces.

### Implementation details
1. Moved MountPoint and VolumeFrom from api/volume to api/container, these are likely to be moved into taskresource/volume later
2. Took TaskStatus function in containerstatus.go and ContainerStatus function in taskstatus.go into statusmapping.go
3. Moved following files from api/ to api/container/:
container.go
container_test.go
container_unix.go
container_windows.go
containerevent.go
containeroverrides.go
containeroverrides_test.go
containerstatus.go
containerstatus_test.go
containertype.go
containertype_test.go
port_binding.go
port_binding_test.go
transitiondependency.go
transitiondependency_test.go
transport.go
transport_test.go

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
