### PR TITLE
Some formatting and basic powershell cleanups in hostsetup.ps1

### DIFF
--- a/misc/windows-deploy/hostsetup.ps1
+++ b/misc/windows-deploy/hostsetup.ps1
@@ -21,13 +21,13 @@ $credentialAddress = "169.254.170.2"
 $credentialPort = "51679"
 $loopbackAddress = "127.0.0.1"
 
-$Adapter = ( Get-NetAdapter -Name "*APIPA*" )
+$adapter = ( Get-NetAdapter -Name "*APIPA*" )
 if( -not $adapter ) {
 	# APIPA nat adapter controls IP range 169.254.x.x on windows.
 	Add-VMNetworkAdapter -VMNetworkAdapterName "APIPA" -SwitchName nat -ManagementOS
 }
 
-$ifIndex = $Adapter.ifIndex
+$ifIndex = $adapter.ifIndex
 
 $dockerSubnet = ( docker network inspect nat | ConvertFrom-Json ).IPAM.Config.Subnet
 

--- a/misc/windows-deploy/hostsetup.ps1
+++ b/misc/windows-deploy/hostsetup.ps1
@@ -21,19 +21,19 @@ $credentialAddress = "169.254.170.2"
 $credentialPort = "51679"
 $loopbackAddress = "127.0.0.1"
 
-$adapter = (Get-NetAdapter -Name "*APIPA*")
-if(!($adapter)) {
+$Adapter = ( Get-NetAdapter -Name "*APIPA*" )
+if( -not $adapter ) {
 	# APIPA nat adapter controls IP range 169.254.x.x on windows.
 	Add-VMNetworkAdapter -VMNetworkAdapterName "APIPA" -SwitchName nat -ManagementOS
 }
 
-$ifIndex = (Get-NetAdapter -Name "*APIPA*" | Sort-Object | Select ifIndex).ifIndex
+$ifIndex = $Adapter.ifIndex
 
-$dockerSubnet = (docker network inspect nat | ConvertFrom-Json).IPAM.Config.Subnet
+$dockerSubnet = ( docker network inspect nat | ConvertFrom-Json ).IPAM.Config.Subnet
 
 # This address will only exist on systems that have already set up the routes.
-$ip = (Get-NetRoute -InterfaceIndex $ifIndex -DestinationPrefix $dockerSubnet)
-if(!($ip)) {
+$ip = Get-NetRoute -InterfaceIndex $ifIndex -DestinationPrefix $dockerSubnet
+if( -not $ip ) {
 
 	# This command tells the APIPA interface that this IP exists.
 	New-NetIPAddress -InterfaceIndex $ifIndex -IPAddress $credentialAddress -PrefixLength 32
@@ -49,4 +49,4 @@ if(!($ip)) {
 	netsh interface portproxy add v4tov4 listenaddress=$credentialAddress listenport=80 connectaddress=$loopbackAddress connectport=$credentialPort
 }
 
-$ErrorActionPreference=$oldActionPref
+$ErrorActionPreference=$oldActionPref1


### PR DESCRIPTION

### Summary
There were some items that could help improve the formatting, readability, and minor improvements to performance.

### Implementation details
Just a bit of formatting using VSCode and a bit of hand changes.

### Testing
Ran the unit tests on a windows machine but didn't have the ability to run the full test suite.

- [x] Builds on Linux (`make release`)
- [X] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [ ] Unit tests on Linux (`make test`) pass
- [X] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: No

### Description for the changelog
- Enhancement - Formatting and cleanups for the hostsetup script

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. Yes I do
