### PR TITLE
updating reference to golang 1.7 to 1.9

### DIFF
--- a/misc/netkitten/build.ps1
+++ b/misc/netkitten/build.ps1
@@ -20,7 +20,7 @@ cp C:\nk\netkitten.exe C:\netkitten
 
 docker run `
   --volume ${PSScriptRoot}:C:\netkitten `
-  golang:1.7-windowsservercore `
+  golang:1.9-windowsservercore `
   powershell ${buildscript}
 
 docker build -t "amazon/amazon-ecs-netkitten:make" -f "${PSScriptRoot}/windows.dockerfile" ${PSScriptRoot}

--- a/misc/taskmetadata-validator/build-in-docker
+++ b/misc/taskmetadata-validator/build-in-docker
@@ -21,4 +21,4 @@ docker run \
 	-v ${AGENT_VENDOR_DIR}:/gopath/src \
 	-e CGO_ENABLED=0 \
 	-e GOPATH=/go:/gopath \
-	golang:1.7 go build -a -x -ldflags '-s' -o /out/taskmetadata-validator /in/taskmetadata-validator.go
+	golang:1.9 go build -a -x -ldflags '-s' -o /out/taskmetadata-validator /in/taskmetadata-validator.go

--- a/misc/telemetry/Dockerfile
+++ b/misc/telemetry/Dockerfile
@@ -10,7 +10,7 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-FROM golang:1.7
+FROM golang:1.9
 
 WORKDIR /gopath
 

--- a/misc/windows-iam/Setup_Iam.ps1
+++ b/misc/windows-iam/Setup_Iam.ps1
@@ -26,7 +26,7 @@ go build -o C:\IAM\ec2.exe C:\IAM\ec2.go
 cp C:\IAM\ec2.exe C:\ecs
 "@
 
-$buildimage="golang:1.7-windowsservercore"
+$buildimage="golang:1.9-windowsservercore"
 docker pull $buildimage
 
 docker run `

--- a/scripts/dockerfiles/Dockerfile.buildCNIPlugins
+++ b/scripts/dockerfiles/Dockerfile.buildCNIPlugins
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-FROM golang:1.7
+FROM golang:1.9
 MAINTAINER Amazon Web Services, Inc.
 
 RUN mkdir -p /go/src/github.com/aws/


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Updating reference to golang 1.7 to 1.9

### Implementation details
These probably should've been updated last time we updated to golang 1.9. 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
