### PR TITLE
revert windows script to golang:1.7

### DIFF
--- a/misc/netkitten/build.ps1
+++ b/misc/netkitten/build.ps1
@@ -20,7 +20,7 @@ cp C:\nk\netkitten.exe C:\netkitten
 
 docker run `
   --volume ${PSScriptRoot}:C:\netkitten `
-  golang:1.9-windowsservercore `
+  golang:1.7-windowsservercore `
   powershell ${buildscript}
 
 docker build -t "amazon/amazon-ecs-netkitten:make" -f "${PSScriptRoot}/windows.dockerfile" ${PSScriptRoot}

--- a/misc/windows-iam/Setup_Iam.ps1
+++ b/misc/windows-iam/Setup_Iam.ps1
@@ -26,7 +26,7 @@ go build -o C:\IAM\ec2.exe C:\IAM\ec2.go
 cp C:\IAM\ec2.exe C:\ecs
 "@
 
-$buildimage="golang:1.9-windowsservercore"
+$buildimage="golang:1.7-windowsservercore"
 docker pull $buildimage
 
 docker run `


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Fixing windows integ test that broke after references to golang 1.7 were updated to 1.9

### Implementation details
Reverting windows script back to reference golang:1.7-windowsservercore.
We should look into what in golang:1.7-windowsservercore is breaking port forwarding tests, but given that this was a cleanup task that's not necessary for the next release, I'm opting to rollback rather than forward.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
