### PR TITLE
custom unmarshal resources in task struct

### DIFF
--- a/agent/acs/handler/payload_handler_test.go
+++ b/agent/acs/handler/payload_handler_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/eventhandler"
 	"github.com/aws/amazon-ecs-agent/agent/statemanager"
 	"github.com/aws/amazon-ecs-agent/agent/statemanager/mocks"
+	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	"github.com/aws/amazon-ecs-agent/agent/wsclient/mock"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/golang/mock/gomock"
@@ -142,7 +143,8 @@ func TestHandlePayloadMessageStateSaveError(t *testing.T) {
 
 	// We expect task to be added to the engine even though it hasn't been saved
 	expectedTask := &apitask.Task{
-		Arn: "t1",
+		Arn:                "t1",
+		ResourcesMapUnsafe: make(map[string][]taskresource.TaskResource),
 	}
 
 	assert.Equal(t, addedTask, expectedTask, "added task is not expected")
@@ -188,7 +190,8 @@ func TestHandlePayloadMessageAckedWhenTaskAdded(t *testing.T) {
 
 	// Verify if task added == expected task
 	expectedTask := &apitask.Task{
-		Arn: "t1",
+		Arn:                "t1",
+		ResourcesMapUnsafe: make(map[string][]taskresource.TaskResource),
 	}
 	assert.Equal(t, addedTask, expectedTask, "received task is not expected")
 }
@@ -364,7 +367,8 @@ func TestPayloadBufferHandler(t *testing.T) {
 
 	// Verify if the task added to the engine is correct
 	expectedTask := &apitask.Task{
-		Arn: taskArn,
+		Arn:                taskArn,
+		ResourcesMapUnsafe: make(map[string][]taskresource.TaskResource),
 	}
 	assert.Equal(t, addedTask, expectedTask, "received task is not expected")
 }
@@ -596,7 +600,8 @@ func validateTaskAndCredentials(taskCredentialsAck,
 	}
 
 	expectedTask := &apitask.Task{
-		Arn: expectedTaskArn,
+		Arn:                expectedTaskArn,
+		ResourcesMapUnsafe: make(map[string][]taskresource.TaskResource),
 	}
 	expectedTask.SetCredentialsID(expectedTaskCredentials.CredentialsID)
 

--- a/agent/api/task/task_linux.go
+++ b/agent/api/task/task_linux.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/cgroup"
+	restype "github.com/aws/amazon-ecs-agent/agent/taskresource/types"
 	"github.com/cihub/seelog"
 	docker "github.com/fsouza/go-dockerclient"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -77,7 +78,7 @@ func (task *Task) initializeCgroupResourceSpec(cgroupPath string, resourceFields
 	}
 	cgroupResource := cgroup.NewCgroupResource(task.Arn, resourceFields.Control,
 		resourceFields.IOUtil, cgroupRoot, cgroupPath, resSpec)
-	task.Resources = append(task.Resources, cgroupResource)
+	task.AddResource(restype.CgroupKey, cgroupResource)
 	for _, container := range task.Containers {
 		container.BuildResourceDependency(cgroupResource.GetName(),
 			taskresource.ResourceStatus(cgroup.CgroupCreated),

--- a/agent/api/task/task_linux_test.go
+++ b/agent/api/task/task_linux_test.go
@@ -396,6 +396,7 @@ func TestInitCgroupResourceSpecHappyPath(t *testing.T) {
 			},
 		},
 		MemoryCPULimitsEnabled: true,
+		ResourcesMapUnsafe:     make(map[string][]taskresource.TaskResource),
 	}
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -405,7 +406,7 @@ func TestInitCgroupResourceSpecHappyPath(t *testing.T) {
 		Control: mockControl,
 		IOUtil:  mockIO,
 	}))
-	assert.Equal(t, 1, len(task.Resources))
+	assert.Equal(t, 1, len(task.GetResources()))
 	assert.Equal(t, 1, len(task.Containers[0].TransitionDependenciesMap))
 }
 
@@ -421,9 +422,10 @@ func TestInitCgroupResourceSpecInvalidARN(t *testing.T) {
 			},
 		},
 		MemoryCPULimitsEnabled: true,
+		ResourcesMapUnsafe:     make(map[string][]taskresource.TaskResource),
 	}
 	assert.Error(t, task.initializeCgroupResourceSpec("", nil))
-	assert.Equal(t, 0, len(task.Resources))
+	assert.Equal(t, 0, len(task.GetResources()))
 	assert.Equal(t, 0, len(task.Containers[0].TransitionDependenciesMap))
 }
 
@@ -441,9 +443,10 @@ func TestInitCgroupResourceSpecInvalidMem(t *testing.T) {
 			},
 		},
 		MemoryCPULimitsEnabled: true,
+		ResourcesMapUnsafe:     make(map[string][]taskresource.TaskResource),
 	}
 	assert.Error(t, task.initializeCgroupResourceSpec("", nil))
-	assert.Equal(t, 0, len(task.Resources))
+	assert.Equal(t, 0, len(task.GetResources()))
 	assert.Equal(t, 0, len(task.Containers[0].TransitionDependenciesMap))
 }
 
@@ -458,11 +461,12 @@ func TestPostUnmarshalWithCPULimitsFail(t *testing.T) {
 				TransitionDependenciesMap: make(map[apicontainer.ContainerStatus]apicontainer.TransitionDependencySet),
 			},
 		},
+		ResourcesMapUnsafe: make(map[string][]taskresource.TaskResource),
 	}
 	cfg := config.Config{
 		TaskCPUMemLimit: config.ExplicitlyEnabled,
 	}
 	assert.Error(t, task.PostUnmarshalTask(&cfg, nil, nil))
-	assert.Equal(t, 0, len(task.Resources))
+	assert.Equal(t, 0, len(task.GetResources()))
 	assert.Equal(t, 0, len(task.Containers[0].TransitionDependenciesMap))
 }

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/credentials"
 	"github.com/aws/amazon-ecs-agent/agent/credentials/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient"
+	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	"github.com/aws/amazon-ecs-agent/agent/utils/ttime"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -717,6 +718,7 @@ func TestTaskFromACS(t *testing.T) {
 		StartSequenceNumber: 42,
 		CPU:                 2.0,
 		Memory:              512,
+		ResourcesMapUnsafe:  make(map[string][]taskresource.TaskResource),
 	}
 
 	seqNum := int64(42)

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -464,7 +464,7 @@ func (engine *DockerTaskEngine) sweepTask(task *apitask.Task) {
 }
 
 func (engine *DockerTaskEngine) deleteTask(task *apitask.Task) {
-	for _, resource := range task.Resources {
+	for _, resource := range task.GetResources() {
 		err := resource.Cleanup()
 		if err != nil {
 			seelog.Warnf("Task engine [%s]: unable to cleanup resource %s: %v",

--- a/agent/engine/task_manager_test.go
+++ b/agent/engine/task_manager_test.go
@@ -993,7 +993,8 @@ func TestCleanupTask(t *testing.T) {
 		cfg:   taskEngine.cfg,
 		saver: taskEngine.saver,
 	}
-	mTask.Task.Resources = []taskresource.TaskResource{mockResource}
+	mTask.Task.ResourcesMapUnsafe = make(map[string][]taskresource.TaskResource)
+	mTask.AddResource("mockResource", mockResource)
 	mTask.SetKnownStatus(apitask.TaskStopped)
 	mTask.SetSentStatus(apitask.TaskStopped)
 	container := mTask.Containers[0]
@@ -1366,7 +1367,8 @@ func TestCleanupTaskWithResourceHappyPath(t *testing.T) {
 		cfg:   taskEngine.cfg,
 		saver: taskEngine.saver,
 	}
-	mTask.Task.Resources = []taskresource.TaskResource{mockResource}
+	mTask.Task.ResourcesMapUnsafe = make(map[string][]taskresource.TaskResource)
+	mTask.AddResource("mockResource", mockResource)
 	mTask.SetKnownStatus(apitask.TaskStopped)
 	mTask.SetSentStatus(apitask.TaskStopped)
 	container := mTask.Containers[0]
@@ -1427,10 +1429,10 @@ func TestCleanupTaskWithResourceErrorPath(t *testing.T) {
 		cfg:   taskEngine.cfg,
 		saver: taskEngine.saver,
 	}
-	mTask.Task.Resources = []taskresource.TaskResource{mockResource}
+	mTask.Task.ResourcesMapUnsafe = make(map[string][]taskresource.TaskResource)
+	mTask.AddResource("mockResource", mockResource)
 	mTask.SetKnownStatus(apitask.TaskStopped)
 	mTask.SetSentStatus(apitask.TaskStopped)
-
 	container := mTask.Containers[0]
 	dockerContainer := &apicontainer.DockerContainer{
 		DockerName: "dockerContainer",
@@ -1525,7 +1527,7 @@ func TestWaitForHostResources(t *testing.T) {
 func TestWaitForResourceTransition(t *testing.T) {
 	task := &managedTask{
 		Task: &apitask.Task{
-			Resources: []taskresource.TaskResource{},
+			ResourcesMapUnsafe: make(map[string][]taskresource.TaskResource),
 		},
 	}
 	transition := make(chan struct{}, 1)
@@ -1554,8 +1556,8 @@ func TestApplyResourceStateHappyPath(t *testing.T) {
 	mockResource := mock_taskresource.NewMockTaskResource(ctrl)
 	task := &managedTask{
 		Task: &apitask.Task{
-			Arn:       "arn",
-			Resources: []taskresource.TaskResource{},
+			Arn:                "arn",
+			ResourcesMapUnsafe: make(map[string][]taskresource.TaskResource),
 		},
 	}
 	gomock.InOrder(
@@ -1591,8 +1593,8 @@ func TestApplyResourceStateFailures(t *testing.T) {
 			mockResource := mock_taskresource.NewMockTaskResource(ctrl)
 			task := &managedTask{
 				Task: &apitask.Task{
-					Arn:       "arn",
-					Resources: []taskresource.TaskResource{},
+					Arn:                "arn",
+					ResourcesMapUnsafe: make(map[string][]taskresource.TaskResource),
 				},
 			}
 			gomock.InOrder(

--- a/agent/taskresource/cgroup/cgroup.go
+++ b/agent/taskresource/cgroup/cgroup.go
@@ -44,15 +44,15 @@ var (
 
 // CgroupResource represents Cgroup resource
 type CgroupResource struct {
-	taskARN				   string
-	control				   cgroupres.Control
-	cgroupRoot			   string
-	cgroupMountPath			   string
-	resourceSpec			   specs.LinuxResources
-	ioutil				   ioutilwrapper.IOUtil
-	createdAt			   time.Time
-	desiredStatusUnsafe		   taskresource.ResourceStatus
-	knownStatusUnsafe		   taskresource.ResourceStatus
+	taskARN             string
+	control             cgroupres.Control
+	cgroupRoot          string
+	cgroupMountPath     string
+	resourceSpec        specs.LinuxResources
+	ioutil              ioutilwrapper.IOUtil
+	createdAt           time.Time
+	desiredStatusUnsafe taskresource.ResourceStatus
+	knownStatusUnsafe   taskresource.ResourceStatus
 	// appliedStatus is the status that has been "applied" (e.g., we've called some
 	// operation such as 'Create' on the resource) but we don't yet know that the
 	// application was successful, which may then change the known status. This is
@@ -60,7 +60,7 @@ type CgroupResource struct {
 	appliedStatus                      taskresource.ResourceStatus
 	resourceStatusToTransitionFunction map[taskresource.ResourceStatus]func() error
 	// lock is used for fields that are accessed and updated concurrently
-	lock				   sync.RWMutex
+	lock sync.RWMutex
 }
 
 // NewCgroupResource is used to return an object that implements the Resource interface
@@ -330,4 +330,18 @@ func (cgroup *CgroupResource) UnmarshalJSON(b []byte) error {
 		cgroup.SetKnownStatus(taskresource.ResourceStatus(*temp.KnownStatus))
 	}
 	return nil
+}
+
+// GetCgroupRoot returns cgroup root of the resource
+func (cgroup *CgroupResource) GetCgroupRoot() string {
+	cgroup.lock.RLock()
+	defer cgroup.lock.RUnlock()
+	return cgroup.cgroupRoot
+}
+
+// GetCgroupMountPath returns cgroup mount path of the resource
+func (cgroup *CgroupResource) GetCgroupMountPath() string {
+	cgroup.lock.RLock()
+	defer cgroup.lock.RUnlock()
+	return cgroup.cgroupMountPath
 }

--- a/agent/taskresource/cgroup/cgroup_test.go
+++ b/agent/taskresource/cgroup/cgroup_test.go
@@ -159,8 +159,8 @@ func TestUnmarshal(t *testing.T) {
 	err := unmarshalledCgroup.UnmarshalJSON(bytes)
 	assert.NoError(t, err)
 
-	assert.Equal(t, cgroupRoot, unmarshalledCgroup.cgroupRoot)
-	assert.Equal(t, cgroupMountPath, unmarshalledCgroup.cgroupMountPath)
+	assert.Equal(t, cgroupRoot, unmarshalledCgroup.GetCgroupRoot())
+	assert.Equal(t, cgroupMountPath, unmarshalledCgroup.GetCgroupMountPath())
 	assert.Equal(t, time.Time{}, unmarshalledCgroup.GetCreatedAt())
 	assert.Equal(t, taskresource.ResourceStatus(CgroupCreated), unmarshalledCgroup.GetDesiredStatus())
 	assert.Equal(t, taskresource.ResourceStatus(CgroupStatusNone), unmarshalledCgroup.GetKnownStatus())

--- a/agent/taskresource/cgroup/cgroup_unsupported.go
+++ b/agent/taskresource/cgroup/cgroup_unsupported.go
@@ -1,0 +1,116 @@
+// +build !linux
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cgroup
+
+import (
+	"errors"
+	"time"
+
+	"github.com/aws/amazon-ecs-agent/agent/taskresource"
+)
+
+// CgroupResource represents Cgroup resource
+type CgroupResource struct{}
+
+// SetDesiredStatus safely sets the desired status of the resource
+func (c *CgroupResource) SetDesiredStatus(status taskresource.ResourceStatus) {}
+
+// GetDesiredStatus safely returns the desired status of the task
+func (c *CgroupResource) GetDesiredStatus() taskresource.ResourceStatus {
+	return taskresource.ResourceStatusNone
+}
+
+// GetName safely returns the name of the resource
+func (c *CgroupResource) GetName() string {
+	return "undefined"
+}
+
+// DesiredTerminal returns true if the cgroup's desired status is REMOVED
+func (c *CgroupResource) DesiredTerminal() bool {
+	return false
+}
+
+// KnownCreated returns true if the cgroup's known status is CREATED
+func (c *CgroupResource) KnownCreated() bool {
+	return false
+}
+
+// TerminalStatus returns the last transition state of cgroup
+func (c *CgroupResource) TerminalStatus() taskresource.ResourceStatus {
+	return taskresource.ResourceStatusNone
+}
+
+// NextKnownState returns the state that the resource should progress to based
+// on its `KnownState`.
+func (c *CgroupResource) NextKnownState() taskresource.ResourceStatus {
+	return taskresource.ResourceStatusNone
+}
+
+// ApplyTransition calls the function required to move to the specified status
+func (c *CgroupResource) ApplyTransition(nextState taskresource.ResourceStatus) error {
+	return errors.New("unsupported platform")
+}
+
+// SteadyState returns the transition state of the resource defined as "ready"
+func (c *CgroupResource) SteadyState() taskresource.ResourceStatus {
+	return taskresource.ResourceStatusNone
+}
+
+// SetKnownStatus safely sets the currently known status of the resource
+func (c *CgroupResource) SetKnownStatus(status taskresource.ResourceStatus) {}
+
+// SetAppliedStatus sets the applied status of resource and returns whether
+// the resource is already in a transition
+func (c *CgroupResource) SetAppliedStatus(status taskresource.ResourceStatus) bool {
+	return false
+}
+
+// GetKnownStatus safely returns the currently known status of the task
+func (c *CgroupResource) GetKnownStatus() taskresource.ResourceStatus {
+	return taskresource.ResourceStatusNone
+}
+
+// SetCreatedAt sets the timestamp for resource's creation time
+func (c *CgroupResource) SetCreatedAt(createdAt time.Time) {}
+
+// GetCreatedAt sets the timestamp for resource's creation time
+func (c *CgroupResource) GetCreatedAt() time.Time {
+	return time.Time{}
+}
+
+// Create creates cgroup root for the task
+func (c *CgroupResource) Create() error {
+	return errors.New("unsupported platform")
+}
+
+// Cleanup removes the cgroup root created for the task
+func (c *CgroupResource) Cleanup() error {
+	return errors.New("unsupported platform")
+}
+
+// StatusString returns the string of the cgroup resource status
+func (c *CgroupResource) StatusString(status taskresource.ResourceStatus) string {
+	return "undefined"
+}
+
+// MarshalJSON marshals CgroupResource object
+func (c *CgroupResource) MarshalJSON() ([]byte, error) {
+	return nil, errors.New("unsupported platform")
+}
+
+// UnmarshalJSON unmarshals CgroupResource object
+func (c *CgroupResource) UnmarshalJSON(b []byte) error {
+	return errors.New("unsupported platform")
+}

--- a/agent/taskresource/types/types.go
+++ b/agent/taskresource/types/types.go
@@ -1,0 +1,65 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package types
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/aws/amazon-ecs-agent/agent/taskresource"
+	cgroupres "github.com/aws/amazon-ecs-agent/agent/taskresource/cgroup"
+)
+
+const (
+	// CgroupKey is the string used in resources map to represent cgroup resource
+	CgroupKey = "cgroup"
+)
+
+// ResourcesMap represents the map of resource type to the corresponding resource
+// objects
+type ResourcesMap map[string][]taskresource.TaskResource
+
+// UnmarshalJSON unmarshals ResourcesMap object
+func (rm *ResourcesMap) UnmarshalJSON(data []byte) error {
+	resources := make(map[string]json.RawMessage)
+	err := json.Unmarshal(data, &resources)
+	if err != nil {
+		return err
+	}
+	result := make(map[string][]taskresource.TaskResource)
+	for key, value := range resources {
+		switch key {
+		case CgroupKey:
+			var cgroups []json.RawMessage
+			err = json.Unmarshal(value, &cgroups)
+			if err != nil {
+				return err
+			}
+			for _, c := range cgroups {
+				cgroup := &cgroupres.CgroupResource{}
+				err := cgroup.UnmarshalJSON(c)
+				if err != nil {
+					return err
+				}
+				result[key] = append(result[key], cgroup)
+			}
+		// TODO: add a case for volume resource. Currently it is not added since it does
+		// not fully implement TaskResource
+		default:
+			return errors.New("Unsupported resource type")
+		}
+	}
+	*rm = result
+	return nil
+}

--- a/agent/taskresource/types/types_linux_test.go
+++ b/agent/taskresource/types/types_linux_test.go
@@ -1,0 +1,41 @@
+// +build linux
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package types
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aws/amazon-ecs-agent/agent/taskresource"
+	cgroupres "github.com/aws/amazon-ecs-agent/agent/taskresource/cgroup"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnmarshalResourcesMap(t *testing.T) {
+	cgroupRoot := "/ecs/taskid"
+	cgroupMountPath := "/sys/fs/cgroup"
+	bytes := []byte(`{"cgroup":[{"CgroupRoot":"/ecs/taskid","CgroupMountPath":"/sys/fs/cgroup","CreatedAt":"0001-01-01T00:00:00Z","DesiredStatus":"REMOVED","KnownStatus":"REMOVED"}]}`)
+	unmarshalledMap := make(ResourcesMap)
+	err := unmarshalledMap.UnmarshalJSON(bytes)
+	assert.NoError(t, err)
+	var cgroupResource *cgroupres.CgroupResource
+	cgroupResource = unmarshalledMap["cgroup"][0].(*cgroupres.CgroupResource)
+	assert.Equal(t, cgroupRoot, cgroupResource.GetCgroupRoot())
+	assert.Equal(t, cgroupMountPath, cgroupResource.GetCgroupMountPath())
+	assert.Equal(t, time.Time{}, cgroupResource.GetCreatedAt())
+	assert.Equal(t, taskresource.ResourceStatus(cgroupres.CgroupRemoved), cgroupResource.GetDesiredStatus())
+	assert.Equal(t, taskresource.ResourceStatus(cgroupres.CgroupRemoved), cgroupResource.GetKnownStatus())
+}


### PR DESCRIPTION
### Summary
adding custom unmarshaller for task resource interface

### Implementation details
Introduce new map structure for list of resources to implement custom unmarshaler for `TaskResource` interface type

### Testing
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
