### PR TITLE
Adding more randomness to the state change batches timer

### DIFF
--- a/agent/utils/ticker.go
+++ b/agent/utils/ticker.go
@@ -1,0 +1,52 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+package utils
+
+import (
+	"context"
+	"math/rand"
+	"time"
+)
+
+// NewJitteredTicker works like a time.Ticker except with randomly distributed ticks
+// between start and end duration.
+func NewJitteredTicker(ctx context.Context, start, end time.Duration) <-chan time.Time {
+	ticker := make(chan time.Time, 1)
+
+	go func() {
+		defer close(ticker)
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				time.Sleep(randomDuration(start, end))
+				sendNow(ticker)
+			}
+		}
+	}()
+
+	return ticker
+}
+
+func randomDuration(start, end time.Duration) time.Duration {
+	return time.Duration(start.Nanoseconds()+rand.Int63n(end.Nanoseconds()-start.Nanoseconds())) * time.Nanosecond
+}
+
+func sendNow(ticker chan<- time.Time) {
+	select {
+	case ticker <- time.Now():
+	default:
+	}
+}

--- a/agent/utils/ticker_test.go
+++ b/agent/utils/ticker_test.go
@@ -1,0 +1,78 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+package utils
+
+import (
+	"context"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	TheBestNumber = 28
+)
+
+func TestTickerHappyCase(t *testing.T) {
+	ctx, _ := context.WithTimeout(context.Background(), 1000*time.Millisecond)
+	mTicker := NewJitteredTicker(ctx, 10*time.Millisecond, 100*time.Millisecond)
+
+	times := 0
+	for {
+		_, ok := <-mTicker
+		times++
+		if !ok {
+			break
+		}
+	}
+
+	if times < 10 || times > 100 {
+		t.Error("Should tick at least 10 but less than 100 times: ", times)
+	}
+}
+
+func TestRandomDuration(t *testing.T) {
+	// The best randomness is deterministic
+	rand.Seed(TheBestNumber)
+
+	start := 10 * time.Second
+	end := 20 * time.Second
+
+	for i := 0; i < 10000; i++ {
+		c := randomDuration(start, end)
+		if c < start || c > end {
+			t.Errorf("Generated a bad time! seconds: %v nanoseconds: %d", c, c.Nanoseconds())
+		}
+	}
+}
+
+func TestSendNowDoesNotBlock(t *testing.T) {
+	c := make(chan time.Time, 1)
+	sendNow(c)
+	sendNow(c)
+
+	times := 0
+loop:
+	for {
+		select {
+		case <-c:
+			times++
+		default:
+			break loop
+		}
+	}
+
+	assert.Equal(t, 1, times, "Channel didn't have exactly one message on the queue")
+}


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Currently, we call the SubmitTaskStateChange API every 20 seconds. If a large
number of agents all start at the same time within a cluster, this
synchronization can cause a cluster to hit throttle limits. This can slow
the cluster scale up process.

By introducing jitter into the timer, we can further distribute the API calls
and make the throttling less likely.

### Implementation details
<!-- How are the changes implemented? -->
This is implemented by changing the static 20 second ticker to tick randomly between 10 and 30 seconds.


### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [ ] Builds on Linux (`make release`)
- [ ] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [ ] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enhancement - Improving SubmitTaskStateChange performance in large clusters

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
