### PR TITLE
Cgroup Resource sudo integration test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ misc/certs/ca-certificates.crt:
 	docker run "amazon/amazon-ecs-agent-cert-source:make" cat /etc/ssl/certs/ca-certificates.crt > misc/certs/ca-certificates.crt
 
 test:
-	. ./scripts/shared_env && go test -race -timeout=25s -v -cover $(shell go list ./agent/... | grep -v /vendor/)
+	. ./scripts/shared_env && go test -race -tags unit -timeout=25s -v -cover $(shell go list ./agent/... | grep -v /vendor/)
 
 test-silent:
 	. ./scripts/shared_env && go test -timeout=25s -cover $(shell go list ./agent/... | grep -v /vendor/)

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@
 # language governing permissions and limitations under the License.
 
 USERID=$(shell id -u)
+GO_EXECUTABLE=$(shell command -v go 2> /dev/null)
 
 .PHONY: all gobuild static docker release certs test clean netkitten test-registry run-functional-tests benchmark-test gogenerate run-integ-tests pause-container get-cni-sources cni-plugins test-artifacts
 
@@ -220,8 +221,11 @@ cni-plugins: get-cni-sources .out-stamp
 		"amazon/amazon-ecs-build-cniplugins:make"
 	@echo "Built amazon-ecs-cni-plugins successfully."
 
-run-integ-tests: test-registry gremlin container-health-check-image
+run-integ-tests: test-registry gremlin container-health-check-image run-sudo-tests
 	. ./scripts/shared_env && go test -race -tags integration -timeout=7m -v ./agent/engine/... ./agent/stats/... ./agent/app/...
+
+run-sudo-tests:
+	. ./scripts/shared_env && sudo -E ${GO_EXECUTABLE} test -race -tags sudo -timeout=1m -v ./agent/engine/...
 
 .PHONY: codebuild
 codebuild: get-deps test-artifacts .out-stamp

--- a/agent/acs/client/acs_client_test.go
+++ b/agent/acs/client/acs_client_test.go
@@ -1,4 +1,6 @@
-// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/acs/client/acs_error_test.go
+++ b/agent/acs/client/acs_error_test.go
@@ -1,4 +1,6 @@
-// Copyright 2014-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/acs/handler/acs_handler_test.go
+++ b/agent/acs/handler/acs_handler_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 // Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/acs/handler/attach_eni_handler_test.go
+++ b/agent/acs/handler/attach_eni_handler_test.go
@@ -1,4 +1,6 @@
-// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/acs/handler/payload_handler_test.go
+++ b/agent/acs/handler/payload_handler_test.go
@@ -1,4 +1,6 @@
-// Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/acs/handler/refresh_credentials_handler_test.go
+++ b/agent/acs/handler/refresh_credentials_handler_test.go
@@ -1,4 +1,6 @@
-// Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/acs/update_handler/updater_test.go
+++ b/agent/acs/update_handler/updater_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 // Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/api/container/container_test.go
+++ b/agent/api/container/container_test.go
@@ -1,4 +1,6 @@
-// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/api/container/containeroverrides_test.go
+++ b/agent/api/container/containeroverrides_test.go
@@ -1,4 +1,6 @@
-// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/api/container/containerstatus_test.go
+++ b/agent/api/container/containerstatus_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 // Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/api/container/containertype_test.go
+++ b/agent/api/container/containertype_test.go
@@ -1,4 +1,6 @@
-// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/api/container/port_binding_test.go
+++ b/agent/api/container/port_binding_test.go
@@ -1,4 +1,6 @@
-// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/api/container/transitiondependency_test.go
+++ b/agent/api/container/transitiondependency_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/api/container/transport_test.go
+++ b/agent/api/container/transport_test.go
@@ -1,4 +1,6 @@
-// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/api/ecsclient/client_test.go
+++ b/agent/api/ecsclient/client_test.go
@@ -1,4 +1,6 @@
-// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/api/ecsclient/retry_handler_test.go
+++ b/agent/api/ecsclient/retry_handler_test.go
@@ -1,4 +1,6 @@
-// Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/api/eni/eni_test.go
+++ b/agent/api/eni/eni_test.go
@@ -1,4 +1,6 @@
-// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/api/eni/eniattachment_test.go
+++ b/agent/api/eni/eniattachment_test.go
@@ -1,4 +1,6 @@
-// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/api/statechange_test.go
+++ b/agent/api/statechange_test.go
@@ -1,4 +1,6 @@
-// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/api/task/statusmapping_test.go
+++ b/agent/api/task/statusmapping_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/api/task/task_linux_test.go
+++ b/agent/api/task/task_linux_test.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux,unit
 
 // Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 // Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/api/task/task_windows_test.go
+++ b/agent/api/task/task_windows_test.go
@@ -1,4 +1,4 @@
-// +build windows
+// +build windows,unit
 
 // Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //

--- a/agent/api/task/taskstatus_test.go
+++ b/agent/api/task/taskstatus_test.go
@@ -1,4 +1,6 @@
-// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/api/task/taskvolume_test.go
+++ b/agent/api/task/taskvolume_test.go
@@ -1,4 +1,6 @@
-// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/api/task/types_unmarshal_test.go
+++ b/agent/api/task/types_unmarshal_test.go
@@ -1,3 +1,18 @@
+// +build unit
+
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
 package task
 
 import (

--- a/agent/api/task/util_test.go
+++ b/agent/api/task/util_test.go
@@ -1,4 +1,6 @@
-// Copyright 2014-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/api/testutils/container_equal_test.go
+++ b/agent/api/testutils/container_equal_test.go
@@ -1,4 +1,6 @@
-// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/api/testutils/task_equal_test.go
+++ b/agent/api/testutils/task_equal_test.go
@@ -1,4 +1,6 @@
-// Copyright 2014-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/app/agent_capability_test.go
+++ b/agent/app/agent_capability_test.go
@@ -1,4 +1,6 @@
-// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/app/agent_compatibility_linux_test.go
+++ b/agent/app/agent_compatibility_linux_test.go
@@ -1,6 +1,6 @@
-// +build linux
+// +build linux,unit
 
-// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/app/agent_test.go
+++ b/agent/app/agent_test.go
@@ -1,4 +1,6 @@
-// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/app/agent_unix_test.go
+++ b/agent/app/agent_unix_test.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux,unit
 
 // Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //

--- a/agent/app/agent_windows_test.go
+++ b/agent/app/agent_windows_test.go
@@ -1,6 +1,6 @@
-// +build windows
+// +build windows,unit
 
-// Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/async/lru_cache_test.go
+++ b/agent/async/lru_cache_test.go
@@ -1,4 +1,6 @@
-// Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/config/conditional_test.go
+++ b/agent/config/conditional_test.go
@@ -1,4 +1,6 @@
-// Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2015-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 // Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/config/config_unix_test.go
+++ b/agent/config/config_unix_test.go
@@ -1,4 +1,5 @@
-// +build !windows
+// +build !windows,unit
+
 // Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/config/config_windows_test.go
+++ b/agent/config/config_windows_test.go
@@ -1,4 +1,5 @@
-// !build windows
+// +build windows,unit
+
 // Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/config/sensitive_test.go
+++ b/agent/config/sensitive_test.go
@@ -1,4 +1,6 @@
-// Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2015-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/containermetadata/manager_test.go
+++ b/agent/containermetadata/manager_test.go
@@ -1,4 +1,5 @@
-// +build !integration
+// +build unit
+
 // Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/containermetadata/manager_unix_test.go
+++ b/agent/containermetadata/manager_unix_test.go
@@ -1,4 +1,5 @@
-// +build !integration,!windows
+// +build unit,!windows
+
 // Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/containermetadata/manager_windows_test.go
+++ b/agent/containermetadata/manager_windows_test.go
@@ -1,4 +1,5 @@
-// +build !integration, windows
+// +build unit,windows
+
 // Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/containermetadata/parse_metadata_test.go
+++ b/agent/containermetadata/parse_metadata_test.go
@@ -1,4 +1,5 @@
-// +build !integration
+// +build unit
+
 // Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/containermetadata/types_test.go
+++ b/agent/containermetadata/types_test.go
@@ -1,4 +1,5 @@
-// +build !integration
+// +build unit
+
 // Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
@@ -15,8 +16,9 @@
 package containermetadata
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestUnMarshalText(t *testing.T) {

--- a/agent/containermetadata/utils_test.go
+++ b/agent/containermetadata/utils_test.go
@@ -1,4 +1,5 @@
-// +build !integration
+// +build unit
+
 // Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/containermetadata/write_metadata_test.go
+++ b/agent/containermetadata/write_metadata_test.go
@@ -1,4 +1,5 @@
-// +build !integration
+// +build unit
+
 // Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/containermetadata/write_metadata_unix_test.go
+++ b/agent/containermetadata/write_metadata_unix_test.go
@@ -1,4 +1,5 @@
-// +build !integration, !windows
+// +build unit, !windows
+
 // Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/containermetadata/write_metadata_windows_test.go
+++ b/agent/containermetadata/write_metadata_windows_test.go
@@ -1,4 +1,5 @@
-// +build !integration, windows
+// +build unit, windows
+
 // Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/credentials/manager_test.go
+++ b/agent/credentials/manager_test.go
@@ -1,4 +1,6 @@
-// Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/dockerclient/clientfactory/dockerclientfactory_test.go
+++ b/agent/dockerclient/clientfactory/dockerclientfactory_test.go
@@ -1,5 +1,6 @@
-// +build !integration
-// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/dockerclient/clientfactory/dockerclientfactory_unix_test.go
+++ b/agent/dockerclient/clientfactory/dockerclientfactory_unix_test.go
@@ -1,5 +1,6 @@
-// +build !integration,!windows
-// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit,!windows
+
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/dockerclient/clientfactory/dockerclientfactory_windows_test.go
+++ b/agent/dockerclient/clientfactory/dockerclientfactory_windows_test.go
@@ -1,5 +1,6 @@
-// +build !integration,windows
-// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit,windows
+
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/dockerclient/dockerapi/docker_client_test.go
+++ b/agent/dockerclient/dockerapi/docker_client_test.go
@@ -1,4 +1,5 @@
-// +build !integration
+// +build unit
+
 // Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/dockerclient/dockerapi/docker_events_buffer_test.go
+++ b/agent/dockerclient/dockerapi/docker_events_buffer_test.go
@@ -1,4 +1,5 @@
-// +build !integration
+// +build unit
+
 // Copyright 2017 - 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/dockerclient/dockerapi/errors_test.go
+++ b/agent/dockerclient/dockerapi/errors_test.go
@@ -1,4 +1,5 @@
-// +build !integration
+// +build unit
+
 // Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/dockerclient/dockerauth/dockerauth_test.go
+++ b/agent/dockerclient/dockerauth/dockerauth_test.go
@@ -1,5 +1,6 @@
-// +build !integration
-// Copyright 2014-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/dockerclient/dockerauth/ecr_test.go
+++ b/agent/dockerclient/dockerauth/ecr_test.go
@@ -1,5 +1,6 @@
-// +build !integration
-// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/ec2/ec2_metadata_client_test.go
+++ b/agent/ec2/ec2_metadata_client_test.go
@@ -1,4 +1,6 @@
-// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/ecr/client_test.go
+++ b/agent/ecr/client_test.go
@@ -1,4 +1,6 @@
-// Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/ecscni/plugin_test.go
+++ b/agent/ecscni/plugin_test.go
@@ -1,3 +1,18 @@
+// +build unit
+
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
 package ecscni
 
 import (

--- a/agent/engine/common_integ_test.go
+++ b/agent/engine/common_integ_test.go
@@ -1,4 +1,5 @@
 // +build sudo integration
+
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/engine/common_integ_test.go
+++ b/agent/engine/common_integ_test.go
@@ -1,0 +1,93 @@
+// +build sudo integration
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package engine
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/aws/amazon-ecs-agent/agent/api"
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
+	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/containermetadata"
+	"github.com/aws/amazon-ecs-agent/agent/credentials"
+	"github.com/aws/amazon-ecs-agent/agent/dockerclient/clientfactory"
+	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
+	"github.com/aws/amazon-ecs-agent/agent/ec2"
+	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
+	"github.com/aws/amazon-ecs-agent/agent/eventstream"
+	"github.com/aws/amazon-ecs-agent/agent/statemanager"
+	"github.com/stretchr/testify/assert"
+)
+
+func defaultTestConfigIntegTest() *config.Config {
+	cfg, _ := config.NewConfig(ec2.NewBlackholeEC2MetadataClient())
+	cfg.TaskCPUMemLimit = config.ExplicitlyDisabled
+	return cfg
+}
+
+func createTestTask(arn string) *apitask.Task {
+	return &apitask.Task{
+		Arn:                 arn,
+		Family:              "family",
+		Version:             "1",
+		DesiredStatusUnsafe: apitask.TaskRunning,
+		Containers:          []*apicontainer.Container{createTestContainer()},
+	}
+}
+
+func verifyContainerRunningStateChange(t *testing.T, taskEngine TaskEngine) {
+	stateChangeEvents := taskEngine.StateChangeEvents()
+	event := <-stateChangeEvents
+	assert.Equal(t, event.(api.ContainerStateChange).Status, apicontainer.ContainerRunning,
+		"Expected container to be RUNNING")
+}
+
+func verifyContainerStoppedStateChange(t *testing.T, taskEngine TaskEngine) {
+	stateChangeEvents := taskEngine.StateChangeEvents()
+	event := <-stateChangeEvents
+	assert.Equal(t, event.(api.ContainerStateChange).Status, apicontainer.ContainerStopped,
+		"Expected container to be STOPPED")
+}
+
+func setup(cfg *config.Config, state dockerstate.TaskEngineState, t *testing.T) (TaskEngine, func(), credentials.Manager) {
+	if os.Getenv("ECS_SKIP_ENGINE_INTEG_TEST") != "" {
+		t.Skip("ECS_SKIP_ENGINE_INTEG_TEST")
+	}
+	if !isDockerRunning() {
+		t.Skip("Docker not running")
+	}
+	clientFactory := clientfactory.NewFactory(dockerEndpoint)
+	dockerClient, err := dockerapi.NewDockerGoClient(clientFactory, cfg)
+	if err != nil {
+		t.Fatalf("Error creating Docker client: %v", err)
+	}
+	credentialsManager := credentials.NewManager()
+	if state == nil {
+		state = dockerstate.NewTaskEngineState()
+	}
+	imageManager := NewImageManager(cfg, dockerClient, state)
+	imageManager.SetSaver(statemanager.NewNoopStateManager())
+	metadataManager := containermetadata.NewManager(dockerClient, cfg)
+
+	taskEngine := NewDockerTaskEngine(cfg, dockerClient, credentialsManager,
+		eventstream.NewEventStream("ENGINEINTEGTEST", context.Background()), imageManager, state, metadataManager, nil)
+	taskEngine.MustInit(context.TODO())
+	return taskEngine, func() {
+		taskEngine.Shutdown()
+	}, credentialsManager
+}

--- a/agent/engine/common_unix_integ_test.go
+++ b/agent/engine/common_unix_integ_test.go
@@ -1,5 +1,6 @@
 // +build linux
 // +build sudo integration
+
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/engine/common_unix_integ_test.go
+++ b/agent/engine/common_unix_integ_test.go
@@ -1,0 +1,50 @@
+// +build linux
+// +build sudo integration
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package engine
+
+import (
+	"os"
+
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+)
+
+const (
+	testRegistryImage = "127.0.0.1:51670/amazon/amazon-ecs-netkitten:latest"
+	dockerEndpoint    = "unix:///var/run/docker.sock"
+)
+
+func createTestContainer() *apicontainer.Container {
+	return createTestContainerWithImageAndName(testRegistryImage, "netcat")
+}
+
+func createTestContainerWithImageAndName(image string, name string) *apicontainer.Container {
+	return &apicontainer.Container{
+		Name:                name,
+		Image:               image,
+		Command:             []string{},
+		Essential:           true,
+		DesiredStatusUnsafe: apicontainer.ContainerRunning,
+		CPU:                 100,
+		Memory:              80,
+	}
+}
+
+func isDockerRunning() bool {
+	if _, err := os.Stat("/var/run/docker.sock"); err != nil {
+		return false
+	}
+	return true
+}

--- a/agent/engine/dependencygraph/graph_test.go
+++ b/agent/engine/dependencygraph/graph_test.go
@@ -1,4 +1,5 @@
-// +build !integration,!sudo
+// +build unit
+
 // Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/engine/dependencygraph/graph_test.go
+++ b/agent/engine/dependencygraph/graph_test.go
@@ -1,4 +1,4 @@
-// +build !integration
+// +build !integration,!sudo
 // Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/engine/dependencygraph/graph_unix_test.go
+++ b/agent/engine/dependencygraph/graph_unix_test.go
@@ -1,4 +1,4 @@
-// +build linux,!integration
+// +build linux,!integration,!sudo
 // Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/engine/dependencygraph/graph_unix_test.go
+++ b/agent/engine/dependencygraph/graph_unix_test.go
@@ -1,4 +1,5 @@
-// +build linux,!integration,!sudo
+// +build linux,unit
+
 // Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/engine/docker_image_manager_integ_test.go
+++ b/agent/engine/docker_image_manager_integ_test.go
@@ -1,4 +1,4 @@
-// +build integration
+// +build !sudo,integration
 // Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/engine/docker_image_manager_integ_test.go
+++ b/agent/engine/docker_image_manager_integ_test.go
@@ -1,4 +1,4 @@
-// +build !sudo,integration
+// +build integration
 // Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/engine/docker_image_manager_test.go
+++ b/agent/engine/docker_image_manager_test.go
@@ -1,4 +1,5 @@
-// +build !integration,!sudo
+// +build unit
+
 // Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/engine/docker_image_manager_test.go
+++ b/agent/engine/docker_image_manager_test.go
@@ -1,4 +1,4 @@
-// +build !integration
+// +build !integration,!sudo
 // Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/engine/docker_image_manager_unix_integ_test.go
+++ b/agent/engine/docker_image_manager_unix_integ_test.go
@@ -1,4 +1,4 @@
-// +build !sudo,!windows,integration
+// +build !windows,integration
 // Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/engine/docker_image_manager_unix_integ_test.go
+++ b/agent/engine/docker_image_manager_unix_integ_test.go
@@ -1,4 +1,4 @@
-// +build !windows,integration
+// +build !sudo,!windows,integration
 // Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/engine/docker_image_manager_windows_integ_test.go
+++ b/agent/engine/docker_image_manager_windows_integ_test.go
@@ -1,4 +1,4 @@
-// +build windows,integration
+// +build !sudo,windows,integration
 // Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/engine/docker_image_manager_windows_integ_test.go
+++ b/agent/engine/docker_image_manager_windows_integ_test.go
@@ -1,4 +1,4 @@
-// +build !sudo,windows,integration
+// +build windows,integration
 // Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/engine/docker_task_engine_linux_test.go
+++ b/agent/engine/docker_task_engine_linux_test.go
@@ -1,4 +1,4 @@
-// +build linux,!integration
+// +build linux,!integration,!sudo
 
 // Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //

--- a/agent/engine/docker_task_engine_linux_test.go
+++ b/agent/engine/docker_task_engine_linux_test.go
@@ -1,4 +1,4 @@
-// +build linux,!integration,!sudo
+// +build linux,unit
 
 // Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -1,4 +1,5 @@
-// +build !integration,!sudo
+// +build unit
+
 // Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -1,4 +1,4 @@
-// +build !integration
+// +build !integration,!sudo
 // Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/engine/docker_task_engine_unix_test.go
+++ b/agent/engine/docker_task_engine_unix_test.go
@@ -1,4 +1,4 @@
-// +build !windows,!integration,!sudo
+// +build !windows,unit
 
 // Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //

--- a/agent/engine/docker_task_engine_unix_test.go
+++ b/agent/engine/docker_task_engine_unix_test.go
@@ -1,4 +1,4 @@
-// +build !windows,!integration
+// +build !windows,!integration,!sudo
 
 // Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //

--- a/agent/engine/docker_task_engine_windows_test.go
+++ b/agent/engine/docker_task_engine_windows_test.go
@@ -1,4 +1,4 @@
-// +build windows,!integration,!sudo
+// +build windows,unit
 
 // Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //

--- a/agent/engine/docker_task_engine_windows_test.go
+++ b/agent/engine/docker_task_engine_windows_test.go
@@ -1,4 +1,4 @@
-// +build windows,!integration
+// +build windows,!integration,!sudo
 
 // Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //

--- a/agent/engine/dockerstate/dockerstate_test.go
+++ b/agent/engine/dockerstate/dockerstate_test.go
@@ -1,5 +1,6 @@
-// +build !integration,!sudo
-// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/engine/dockerstate/dockerstate_test.go
+++ b/agent/engine/dockerstate/dockerstate_test.go
@@ -1,4 +1,4 @@
-// +build !integration
+// +build !integration,!sudo
 // Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/engine/dockerstate/json_test.go
+++ b/agent/engine/dockerstate/json_test.go
@@ -1,3 +1,4 @@
+// +build !integration,!sudo
 // Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/engine/dockerstate/json_test.go
+++ b/agent/engine/dockerstate/json_test.go
@@ -1,5 +1,6 @@
-// +build !integration,!sudo
-// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/engine/dockerstate/testutils/json_test.go
+++ b/agent/engine/dockerstate/testutils/json_test.go
@@ -1,5 +1,6 @@
-// +build !integration,!sudo
-// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/engine/dockerstate/testutils/json_test.go
+++ b/agent/engine/dockerstate/testutils/json_test.go
@@ -1,4 +1,4 @@
-// +build !integration
+// +build !integration,!sudo
 // Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/engine/engine_sudo_linux_integ_test.go
+++ b/agent/engine/engine_sudo_linux_integ_test.go
@@ -1,0 +1,80 @@
+// +build linux,sudo
+
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package engine
+
+import (
+	"testing"
+	"time"
+
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
+	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/resources/cgroup"
+	"github.com/aws/amazon-ecs-agent/agent/taskresource"
+	"github.com/aws/amazon-ecs-agent/agent/utils/ioutilwrapper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStartStopWithCgroup(t *testing.T) {
+	cfg := defaultTestConfigIntegTest()
+	cfg.TaskCleanupWaitDuration = 1 * time.Second
+	cfg.TaskCPUMemLimit = config.ExplicitlyEnabled
+	cfg.CgroupPath = "/cgroup"
+
+	taskEngine, done, _ := setup(cfg, nil, t)
+	defer done()
+
+	stateChangeEvents := taskEngine.StateChangeEvents()
+
+	taskArn := "arn:aws:ecs:us-east-1:123456789012:task/testCgroup"
+	testTask := createTestTask(taskArn)
+	testTask.ResourcesMapUnsafe = make(map[string][]taskresource.TaskResource)
+	for _, container := range testTask.Containers {
+		container.TransitionDependenciesMap = make(map[apicontainer.ContainerStatus]apicontainer.TransitionDependencySet)
+	}
+	control := cgroup.New()
+	taskEngine.(*DockerTaskEngine).resourceFields = &taskresource.ResourceFields{
+		Control: control,
+		IOUtil:  ioutilwrapper.NewIOUtil(),
+	}
+	go taskEngine.AddTask(testTask)
+
+	verifyContainerRunningStateChange(t, taskEngine)
+	verifyTaskIsRunning(stateChangeEvents, testTask)
+
+	verifyContainerStoppedStateChange(t, taskEngine)
+	verifyTaskIsStopped(stateChangeEvents, testTask)
+
+	// Should be stopped, let's verify it's still listed...
+	task, ok := taskEngine.(*DockerTaskEngine).State().TaskByArn(taskArn)
+	assert.True(t, ok, "Expected task to be present still, but wasn't")
+
+	cgroupRoot, err := testTask.BuildCgroupRoot()
+	assert.Nil(t, err)
+	assert.True(t, control.Exists(cgroupRoot))
+
+	task.SetSentStatus(apitask.TaskStopped) // cleanupTask waits for TaskStopped to be sent before cleaning
+	time.Sleep(cfg.TaskCleanupWaitDuration)
+	for i := 0; i < 60; i++ {
+		_, ok = taskEngine.(*DockerTaskEngine).State().TaskByArn(taskArn)
+		if !ok {
+			break
+		}
+		time.Sleep(1 * time.Second)
+	}
+	assert.False(t, ok, "Expected container to have been swept but was not")
+	assert.False(t, control.Exists(cgroupRoot))
+}

--- a/agent/engine/engine_unix_integ_test.go
+++ b/agent/engine/engine_unix_integ_test.go
@@ -1,4 +1,4 @@
-// +build !sudo,!windows,integration
+// +build !windows,integration
 
 // Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //

--- a/agent/engine/engine_unix_integ_test.go
+++ b/agent/engine/engine_unix_integ_test.go
@@ -1,4 +1,4 @@
-// +build !windows,integration
+// +build !sudo,!windows,integration
 
 // Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
@@ -42,10 +42,8 @@ import (
 )
 
 const (
-	dockerEndpoint        = "unix:///var/run/docker.sock"
 	testRegistryHost      = "127.0.0.1:51670"
 	testBusyboxImage      = testRegistryHost + "/busybox:latest"
-	testRegistryImage     = "127.0.0.1:51670/amazon/amazon-ecs-netkitten:latest"
 	testAuthRegistryHost  = "127.0.0.1:51671"
 	testAuthRegistryImage = "127.0.0.1:51671/amazon/amazon-ecs-netkitten:latest"
 	testVolumeImage       = "127.0.0.1:51670/amazon/amazon-ecs-volumes-test:latest"
@@ -56,29 +54,6 @@ const (
 var (
 	endpoint = utils.DefaultIfBlank(os.Getenv(DockerEndpointEnvVariable), DockerDefaultEndpoint)
 )
-
-func isDockerRunning() bool {
-	if _, err := os.Stat("/var/run/docker.sock"); err != nil {
-		return false
-	}
-	return true
-}
-
-func createTestContainer() *apicontainer.Container {
-	return createTestContainerWithImageAndName(testRegistryImage, "netcat")
-}
-
-func createTestContainerWithImageAndName(image string, name string) *apicontainer.Container {
-	return &apicontainer.Container{
-		Name:                name,
-		Image:               image,
-		Command:             []string{},
-		Essential:           true,
-		DesiredStatusUnsafe: apicontainer.ContainerRunning,
-		CPU:                 100,
-		Memory:              80,
-	}
-}
 
 func createTestHealthCheckTask(arn string) *apitask.Task {
 	testTask := &apitask.Task{

--- a/agent/engine/engine_windows_integ_test.go
+++ b/agent/engine/engine_windows_integ_test.go
@@ -1,4 +1,4 @@
-// +build windows,integration
+// +build !sudo,windows,integration
 
 // Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //

--- a/agent/engine/engine_windows_integ_test.go
+++ b/agent/engine/engine_windows_integ_test.go
@@ -1,4 +1,4 @@
-// +build !sudo,windows,integration
+// +build windows,integration
 
 // Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //

--- a/agent/engine/task_manager_test.go
+++ b/agent/engine/task_manager_test.go
@@ -1,4 +1,5 @@
-// +build !integration,!sudo
+// +build unit
+
 // Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/engine/task_manager_test.go
+++ b/agent/engine/task_manager_test.go
@@ -1,4 +1,4 @@
-// +build !integration
+// +build !integration,!sudo
 // Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/engine/task_manager_unix_test.go
+++ b/agent/engine/task_manager_unix_test.go
@@ -1,4 +1,4 @@
-// +build linux,!integration
+// +build linux,!integration,!sudo
 // Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/engine/task_manager_unix_test.go
+++ b/agent/engine/task_manager_unix_test.go
@@ -1,4 +1,5 @@
-// +build linux,!integration,!sudo
+// +build linux,unit
+
 // Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/eni/networkutils/utils_linux_test.go
+++ b/agent/eni/networkutils/utils_linux_test.go
@@ -1,6 +1,6 @@
-// +build linux
+// +build linux,unit
 
-// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/eni/pause/error_test.go
+++ b/agent/eni/pause/error_test.go
@@ -1,4 +1,6 @@
-// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/eni/pause/pause_linux_test.go
+++ b/agent/eni/pause/pause_linux_test.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux,unit
 
 // Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //

--- a/agent/eni/watcher/watcher_linux_test.go
+++ b/agent/eni/watcher/watcher_linux_test.go
@@ -1,6 +1,6 @@
-// +build linux
+// +build linux,unit
 
-// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/eventhandler/handler_test.go
+++ b/agent/eventhandler/handler_test.go
@@ -1,4 +1,6 @@
-// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/eventhandler/task_handler_types_test.go
+++ b/agent/eventhandler/task_handler_types_test.go
@@ -1,4 +1,6 @@
-// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/eventstream/eventstream_test.go
+++ b/agent/eventstream/eventstream_test.go
@@ -1,4 +1,6 @@
-// Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -10,6 +12,7 @@
 // on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
+
 package eventstream
 
 import (

--- a/agent/handlers/taskmetadata/handler_test.go
+++ b/agent/handlers/taskmetadata/handler_test.go
@@ -1,4 +1,6 @@
-// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/handlers/taskmetadata/taskinfo_test.go
+++ b/agent/handlers/taskmetadata/taskinfo_test.go
@@ -1,4 +1,6 @@
-// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/handlers/types/v2/response_test.go
+++ b/agent/handlers/types/v2/response_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 // Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/handlers/types/v2/stats_response_test.go
+++ b/agent/handlers/types/v2/stats_response_test.go
@@ -1,4 +1,6 @@
-// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/handlers/v1_handlers_test.go
+++ b/agent/handlers/v1_handlers_test.go
@@ -1,4 +1,6 @@
-// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/logger/audit/audit_log_test.go
+++ b/agent/logger/audit/audit_log_test.go
@@ -1,4 +1,6 @@
-// Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/logger/shim_test.go
+++ b/agent/logger/shim_test.go
@@ -1,4 +1,6 @@
-// Copyright 2014-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/statemanager/helper_unix_test.go
+++ b/agent/statemanager/helper_unix_test.go
@@ -1,6 +1,6 @@
-// +build !windows
+// +build !windows,unit
 
-// Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2016-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/statemanager/helper_windows_test.go
+++ b/agent/statemanager/helper_windows_test.go
@@ -1,4 +1,4 @@
-// +build windows
+// +build windows,unit
 
 // Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //

--- a/agent/statemanager/state_manager_test.go
+++ b/agent/statemanager/state_manager_test.go
@@ -1,4 +1,6 @@
-// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/statemanager/state_manager_unix_test.go
+++ b/agent/statemanager/state_manager_unix_test.go
@@ -1,6 +1,6 @@
-// +build !windows
+// +build !windows,unit
 
-// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/statemanager/state_manager_windows_test.go
+++ b/agent/statemanager/state_manager_windows_test.go
@@ -1,6 +1,6 @@
-// +build windows
+// +build windows,unit
 
-// Copyright 2014-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/stats/container_test.go
+++ b/agent/stats/container_test.go
@@ -1,5 +1,6 @@
-//+build !integration
-// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//+build unit
+
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/stats/engine_test.go
+++ b/agent/stats/engine_test.go
@@ -1,4 +1,5 @@
-//+build !integration
+//+build unit
+
 // Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/stats/queue_test.go
+++ b/agent/stats/queue_test.go
@@ -1,5 +1,6 @@
-//+build !integration
-// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//+build unit
+
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/stats/utils_test.go
+++ b/agent/stats/utils_test.go
@@ -1,5 +1,6 @@
-//+build !integration
-// Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//+build unit
+
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/stats/utils_unix_test.go
+++ b/agent/stats/utils_unix_test.go
@@ -1,6 +1,6 @@
-// +build !windows,!integration
+// +build !windows,unit
 
-// Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/stats/utils_windows_test.go
+++ b/agent/stats/utils_windows_test.go
@@ -1,4 +1,4 @@
-// +build windows,!integration
+// +build windows,unit
 
 // Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //

--- a/agent/taskresource/cgroup/cgroup_test.go
+++ b/agent/taskresource/cgroup/cgroup_test.go
@@ -1,4 +1,5 @@
-// +build linux
+// +build linux,unit
+
 // Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/taskresource/cgroup/cgroupstatus_test.go
+++ b/agent/taskresource/cgroup/cgroupstatus_test.go
@@ -1,4 +1,5 @@
-// +build linux
+// +build linux,unit
+
 // Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/taskresource/types/types_linux_test.go
+++ b/agent/taskresource/types/types_linux_test.go
@@ -1,4 +1,5 @@
-// +build linux
+// +build linux,unit
+
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/taskresource/volume/volume_test.go
+++ b/agent/taskresource/volume/volume_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 // Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/taskresource/volume/volumestatus_test.go
+++ b/agent/taskresource/volume/volumestatus_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 // Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/agent/tcs/client/client_test.go
+++ b/agent/tcs/client/client_test.go
@@ -1,4 +1,6 @@
-// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/tcs/handler/handler_test.go
+++ b/agent/tcs/handler/handler_test.go
@@ -1,4 +1,6 @@
-// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -25,6 +27,7 @@ import (
 	"time"
 
 	"context"
+
 	"github.com/aws/amazon-ecs-agent/agent/api/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"

--- a/agent/utils/backoff_test.go
+++ b/agent/utils/backoff_test.go
@@ -1,4 +1,6 @@
-// Copyright 2014-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/utils/json_test.go
+++ b/agent/utils/json_test.go
@@ -1,4 +1,6 @@
-// Copyright 2014-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/utils/license_test.go
+++ b/agent/utils/license_test.go
@@ -1,4 +1,6 @@
-// Copyright 2014-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/utils/sync/sequential_waitgroup_test.go
+++ b/agent/utils/sync/sequential_waitgroup_test.go
@@ -1,4 +1,6 @@
-// Copyright 2014-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/utils/utils_test.go
+++ b/agent/utils/utils_test.go
@@ -1,4 +1,6 @@
-// Copyright 2014-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// +build unit
+
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/wsclient/client_test.go
+++ b/agent/wsclient/client_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 // Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,4 +13,4 @@ install:
 build_script:
   - go build ./agent
 test_script:
-  - for /f "" %%G in ('go list github.com/aws/amazon-ecs-agent/agent/... ^| find /i /v "/vendor/"') do ( go test -race -timeout 40s %%G & IF ERRORLEVEL == 1 EXIT 1) 
+  - for /f "" %%G in ('go list github.com/aws/amazon-ecs-agent/agent/... ^| find /i /v "/vendor/"') do ( go test -race -tags unit -timeout 40s %%G & IF ERRORLEVEL == 1 EXIT 1) 

--- a/misc/taskmetadata-validator/build-in-docker
+++ b/misc/taskmetadata-validator/build-in-docker
@@ -21,4 +21,4 @@ docker run \
 	-v ${AGENT_VENDOR_DIR}:/gopath/src \
 	-e CGO_ENABLED=0 \
 	-e GOPATH=/go:/gopath \
-	golang:1.7 go build -a -x -ldflags '-s' -o /out/taskmetadata-validator /in/taskmetadata-validator.go
+	golang:1.9 go build -a -x -ldflags '-s' -o /out/taskmetadata-validator /in/taskmetadata-validator.go

--- a/scripts/run-unit-tests.ps1
+++ b/scripts/run-unit-tests.ps1
@@ -16,11 +16,10 @@ $cwd = (pwd).Path
 try {
     cd $cwd
     $packages=go list .\agent\... | Where-Object {$_ -NotMatch 'vendor'}
-    go test -v -timeout=40s $packages
+    go test -v -tags unit -timeout=40s $packages
     $testsExitCode = $LastExitCode
 } finally {
     cd "$cwd"
 }
 
 exit $testsExitCode
-


### PR DESCRIPTION
### Summary
Integration test for task's cgroup resource creation and deletion as sudo 

### Implementation details
- added new make target `run-sudo-tests` for running integration tests as sudo
- added tags `!sudo` for other test files since `-tags sudo` runs all tests without sudo build tags too. 
- separated out some common functions needed for integration tests into `common_integ_test.go` and `common_unix_integ_test.go`.

### Testing
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
