### PR TITLE
[preview; not ready to be merged] Wire the subnet gateway config to ENI plugin

### DIFF
--- a/agent/api/eni.go
+++ b/agent/api/eni.go
@@ -41,6 +41,9 @@ type ENI struct {
 
 	// PrivateDNSName is the dns name assigned by the vpc to this eni
 	PrivateDNSName string `json:",omitempty"`
+	// SubnetGatewayIPV4Address is the address to the subnet gateway for
+	// the eni
+	SubnetGatewayIPV4Address string `json:",omitempty"`
 }
 
 // GetIPV4Addresses returns a list of ipv4 addresses allocated to the ENI
@@ -66,6 +69,11 @@ func (eni *ENI) GetIPV6Addresses() []string {
 // GetHostname returns the hostname assigned to the ENI
 func (eni *ENI) GetHostname() string {
 	return eni.PrivateDNSName
+}
+
+// GetSubnetGatewayIPV4Address returns the hostname assigned to the ENI
+func (eni *ENI) GetSubnetGatewayIPV4Address() string {
+	return eni.SubnetGatewayIPV4Address
 }
 
 // String returns a human readable version of the ENI object
@@ -124,11 +132,12 @@ func ENIFromACS(acsenis []*ecsacs.ElasticNetworkInterface) (*ENI, error) {
 	}
 
 	eni := &ENI{
-		ID:             aws.StringValue(acsenis[0].Ec2Id),
-		IPV4Addresses:  ipv4,
-		IPV6Addresses:  ipv6,
-		MacAddress:     aws.StringValue(acsenis[0].MacAddress),
-		PrivateDNSName: aws.StringValue(acsenis[0].PrivateDnsName),
+		ID:                       aws.StringValue(acsenis[0].Ec2Id),
+		IPV4Addresses:            ipv4,
+		IPV6Addresses:            ipv6,
+		MacAddress:               aws.StringValue(acsenis[0].MacAddress),
+		PrivateDNSName:           aws.StringValue(acsenis[0].PrivateDnsName),
+		SubnetGatewayIPV4Address: aws.StringValue(acsenis[0].SubnetGatewayIpv4Address),
 	}
 	for _, nameserverIP := range acsenis[0].DomainNameServers {
 		eni.DomainNameServers = append(eni.DomainNameServers, aws.StringValue(nameserverIP))

--- a/agent/api/eni.go
+++ b/agent/api/eni.go
@@ -87,9 +87,9 @@ func (eni *ENI) String() string {
 		ipv6Addresses = append(ipv6Addresses, addr.Address)
 	}
 	return fmt.Sprintf(
-		"eni id:%s, mac: %s, hostname: %s, ipv4addresses: [%s], ipv6addresses: [%s], dns: [%s], dns search: [%s]",
+		"eni id:%s, mac: %s, hostname: %s, ipv4addresses: [%s], ipv6addresses: [%s], dns: [%s], dns search: [%s], gateway ipv4: [%s]",
 		eni.ID, eni.MacAddress, eni.GetHostname(), strings.Join(ipv4Addresses, ","), strings.Join(ipv6Addresses, ","),
-		strings.Join(eni.DomainNameServers, ","), strings.Join(eni.DomainNameSearchList, ","))
+		strings.Join(eni.DomainNameServers, ","), strings.Join(eni.DomainNameSearchList, ","), eni.SubnetGatewayIPV4Address)
 }
 
 // ENIIPV4Address is the ipv4 information of the eni

--- a/agent/api/task.go
+++ b/agent/api/task.go
@@ -255,6 +255,7 @@ func (task *Task) BuildCNIConfig() (*ecscni.Config, error) {
 	cfg.ENIID = eni.ID
 	cfg.ID = eni.MacAddress
 	cfg.ENIMACAddress = eni.MacAddress
+	cfg.SubnetGatewayIPV4Address = eni.GetSubnetGatewayIPV4Address()
 	for _, ipv4 := range eni.IPV4Addresses {
 		if ipv4.Primary {
 			cfg.ENIIPV4Address = ipv4.Address

--- a/agent/ecscni/plugin.go
+++ b/agent/ecscni/plugin.go
@@ -104,7 +104,7 @@ func (client *cniClient) setupNS(cfg *Config) (*current.Result, error) {
 		NetNS:       fmt.Sprintf(netnsFormat, cfg.ContainerPID),
 	}
 
-	seelog.Debugf("Starting setup the ENI (%s) in container namespace: %s", cfg.ENIID, cfg.ContainerID)
+	seelog.Debugf("[ECSCNI] Starting setup the ENI (%s) in container namespace: %s", cfg.ENIID, cfg.ContainerID)
 	os.Setenv("ECS_CNI_LOGLEVEL", logger.GetLevel())
 	defer os.Unsetenv("ECS_CNI_LOGLEVEL")
 
@@ -113,16 +113,16 @@ func (client *cniClient) setupNS(cfg *Config) (*current.Result, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "cni setup: invoke eni plugin failed")
 	}
-	seelog.Debugf("ECSCNI: Set up eni done: %s", result.String())
+	seelog.Debugf("[ECSCNI] Set up eni done: %s", result.String())
 
 	// Invoke bridge plugin ADD command
 	result, err = client.add(runtimeConfig, cfg, client.createBridgeNetworkConfigWithIPAM)
 	if err != nil {
 		return nil, errors.Wrap(err, "cni setup: invoke bridge plugin failed")
 	}
-	seelog.Debugf("ECSCNI: Set up container namespace done: %s", result.String())
+	seelog.Debugf("[ECSCNI] Set up container namespace done: %s", result.String())
 	if _, err = result.GetAsVersion(currentCNISpec); err != nil {
-		seelog.Warnf("ECSCNI: Unable to convert result to spec version %s; error: %v; result is of version: %s",
+		seelog.Warnf("[ECSCNI] Unable to convert result to spec version %s; error: %v; result is of version: %s",
 			currentCNISpec, err, result.Version())
 		return nil, err
 	}
@@ -168,19 +168,19 @@ func (client *cniClient) cleanupNS(cfg *Config) error {
 
 	os.Setenv("ECS_CNI_LOGLEVEL", logger.GetLevel())
 	defer os.Unsetenv("ECS_CNI_LOGLEVEL")
-	seelog.Debugf("ECSCNI: Starting clean up the container namespace: %s", cfg.ContainerID)
+	seelog.Debugf("[ECSCNI] Starting clean up the container namespace: %s", cfg.ContainerID)
 	// clean up the network namespace is separate from releasing the IP from IPAM
 	err := client.del(runtimeConfig, cfg, client.createBridgeNetworkConfigWithoutIPAM)
 	if err != nil {
 		return errors.Wrap(err, "cni cleanup: invoke bridge plugin failed")
 	}
-	seelog.Debugf("ECSCNI: bridge cleanup done: %s", cfg.ContainerID)
+	seelog.Debugf("[ECSCNI] bridge cleanup done: %s", cfg.ContainerID)
 
 	err = client.del(runtimeConfig, cfg, client.createENINetworkConfig)
 	if err != nil {
 		return errors.Wrap(err, "cni cleanup: invoke eni plugin failed")
 	}
-	seelog.Debugf("ECSCNI: container namespace cleanup done: %s", cfg.ContainerID)
+	seelog.Debugf("[ECSCNI] container namespace cleanup done: %s", cfg.ContainerID)
 	return nil
 }
 
@@ -191,7 +191,7 @@ func (client *cniClient) ReleaseIPResource(cfg *Config) error {
 		NetNS:       fmt.Sprintf(netnsFormat, cfg.ContainerPID),
 	}
 
-	seelog.Debugf("Releasing the ip resource from ipam db, id: [%s], ip: [%v]", cfg.ID, cfg.IPAMV4Address)
+	seelog.Debugf("[ECSCNI] Releasing the ip resource from ipam db, id: [%s], ip: [%v]", cfg.ID, cfg.IPAMV4Address)
 	os.Setenv("ECS_CNI_LOGLEVEL", logger.GetLevel())
 	defer os.Unsetenv("ECS_CNI_LOGLEVEL")
 	return client.del(runtimeConfig, cfg, client.createIPAMNetworkConfig)
@@ -275,7 +275,7 @@ func (client *cniClient) createBridgeConfig(cfg *Config) BridgeConfig {
 func (client *cniClient) constructNetworkConfig(cfg interface{}, plugin string) (*libcni.NetworkConfig, error) {
 	configBytes, err := json.Marshal(cfg)
 	if err != nil {
-		seelog.Errorf("Marshal configuration for plugin %s failed, error: %v", plugin, err)
+		seelog.Errorf("[ECSCNI] Marshal configuration for plugin %s failed, error: %v", plugin, err)
 		return nil, err
 	}
 	networkConfig := &libcni.NetworkConfig{
@@ -290,13 +290,14 @@ func (client *cniClient) constructNetworkConfig(cfg interface{}, plugin string) 
 
 func (client *cniClient) createENINetworkConfig(cfg *Config) (string, *libcni.NetworkConfig, error) {
 	eniConf := ENIConfig{
-		Type:                 ECSENIPluginName,
-		CNIVersion:           client.cniVersion,
-		ENIID:                cfg.ENIID,
-		IPV4Address:          cfg.ENIIPV4Address,
-		MACAddress:           cfg.ENIMACAddress,
-		IPV6Address:          cfg.ENIIPV6Address,
-		BlockInstanceMetdata: cfg.BlockInstanceMetdata,
+		Type:                     ECSENIPluginName,
+		CNIVersion:               client.cniVersion,
+		ENIID:                    cfg.ENIID,
+		IPV4Address:              cfg.ENIIPV4Address,
+		MACAddress:               cfg.ENIMACAddress,
+		IPV6Address:              cfg.ENIIPV6Address,
+		BlockInstanceMetdata:     cfg.BlockInstanceMetdata,
+		SubnetGatewayIPV4Address: cfg.SubnetGatewayIPV4Address,
 	}
 	networkConfig, err := client.constructNetworkConfig(eniConf, ECSENIPluginName)
 	if err != nil {
@@ -337,7 +338,7 @@ func (client *cniClient) createIPAMConfig(cfg *Config) (IPAMConfig, error) {
 		},
 	}
 	for _, route := range cfg.AdditionalLocalRoutes {
-		seelog.Debugf("Adding an additional route for %s", route)
+		seelog.Debugf("[ECSCNI] Adding an additional route for %s", route)
 		ipNetRoute := (net.IPNet)(route)
 		routes = append(routes, &cnitypes.Route{Dst: ipNetRoute})
 	}

--- a/agent/ecscni/plugin_test.go
+++ b/agent/ecscni/plugin_test.go
@@ -142,13 +142,14 @@ func TestConstructENINetworkConfig(t *testing.T) {
 	ecscniClient := NewClient(&Config{})
 
 	config := &Config{
-		ENIID:                "eni-12345678",
-		ContainerID:          "containerid12",
-		ContainerPID:         "pid",
-		ENIIPV4Address:       "172.31.21.40",
-		ENIIPV6Address:       "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
-		ENIMACAddress:        "02:7b:64:49:b1:40",
-		BlockInstanceMetdata: true,
+		ENIID:                    "eni-12345678",
+		ContainerID:              "containerid12",
+		ContainerPID:             "pid",
+		ENIIPV4Address:           "172.31.21.40",
+		ENIIPV6Address:           "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+		ENIMACAddress:            "02:7b:64:49:b1:40",
+		BlockInstanceMetdata:     true,
+		SubnetGatewayIPV4Address: "172.31.1.1/20",
 	}
 
 	_, eniNetworkConfig, err := ecscniClient.(*cniClient).createENINetworkConfig(config)
@@ -162,6 +163,7 @@ func TestConstructENINetworkConfig(t *testing.T) {
 	assert.Equal(t, config.ENIIPV6Address, eniConfig.IPV6Address)
 	assert.Equal(t, config.ENIMACAddress, eniConfig.MACAddress)
 	assert.True(t, eniConfig.BlockInstanceMetdata)
+	assert.Equal(t, config.SubnetGatewayIPV4Address, eniConfig.SubnetGatewayIPV4Address)
 }
 
 // TestConstructBridgeNetworkConfigWithoutIPAM tests createBridgeNetworkConfigWithoutIPAM creates the right configuration for bridge plugin

--- a/agent/ecscni/types.go
+++ b/agent/ecscni/types.go
@@ -151,4 +151,7 @@ type Config struct {
 	BlockInstanceMetdata bool
 	// AdditionalLocalRoutes specifies additional routes to be added to the task namespace
 	AdditionalLocalRoutes []cnitypes.IPNet
+	// WIP
+	// SubnetGatewayIPV4Address is the address to the subnet gate for the eni
+	SubnetGatewayIPV4Address string
 }

--- a/agent/ecscni/types.go
+++ b/agent/ecscni/types.go
@@ -119,6 +119,9 @@ type ENIConfig struct {
 	// BlockInstanceMetdata specifies if InstanceMetadata endpoint should be
 	// blocked
 	BlockInstanceMetdata bool `json:"block-instance-metadata"`
+	// SubnetGatewayIPV4Address specifies the ipv4 address of the subnet gateway
+	// for the ENI
+	SubnetGatewayIPV4Address string `json:"subnetgateway-ipv4-address"`
 }
 
 // Config contains all the information to set up the container namespace using
@@ -151,7 +154,6 @@ type Config struct {
 	BlockInstanceMetdata bool
 	// AdditionalLocalRoutes specifies additional routes to be added to the task namespace
 	AdditionalLocalRoutes []cnitypes.IPNet
-	// WIP
 	// SubnetGatewayIPV4Address is the address to the subnet gate for the eni
 	SubnetGatewayIPV4Address string
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Wire the subnet gateway config to ENI plugin

### Implementation details
<!-- How are the changes implemented? -->
This PR complements https://github.com/aws/amazon-ecs-cni-plugins/pull/81 by wiring in the subnet gateway address in plugin args. However, we need to wait for changes in the service to be deployed before merging this. The subnet gateway ipv4 address being sent from ACS lacks netmask today, which needs to be fixed before this is merged/released.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [ ] Builds on Linux (`make release`)
- [ ] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [ ] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: Yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
