### PR TITLE
unnnbreak my dev: return http request signing errors

### DIFF
--- a/agent/acs/client/acs_client_test.go
+++ b/agent/acs/client/acs_client_test.go
@@ -82,6 +82,8 @@ const (
 	rwTimeout       = time.Second
 )
 
+var testCreds = credentials.NewStaticCredentials("test-id", "test-secret", "test-token")
+
 var testCfg = &config.Config{
 	AcceptInsecureCert: true,
 	AWSRegion:          "us-east-1",
@@ -235,7 +237,7 @@ func TestConnect(t *testing.T) {
 		t.Fatal(<-serverErr)
 	}()
 
-	cs := New(server.URL, testCfg, credentials.AnonymousCredentials, rwTimeout)
+	cs := New(server.URL, testCfg, testCreds, rwTimeout)
 	// Wait for up to a second for the mock server to launch
 	for i := 0; i < 100; i++ {
 		err = cs.Connect()
@@ -306,7 +308,7 @@ func TestConnectClientError(t *testing.T) {
 	}))
 	defer testServer.Close()
 
-	cs := New(testServer.URL, testCfg, credentials.AnonymousCredentials, rwTimeout)
+	cs := New(testServer.URL, testCfg, testCreds, rwTimeout)
 	err := cs.Connect()
 	_, ok := err.(*wsclient.WSError)
 	assert.True(t, ok)
@@ -314,7 +316,6 @@ func TestConnectClientError(t *testing.T) {
 }
 
 func testCS(conn *mock_wsconn.MockWebsocketConn) wsclient.ClientServer {
-	testCreds := credentials.AnonymousCredentials
 	foo := New("localhost:443", testCfg, testCreds, rwTimeout)
 	cs := foo.(*clientServer)
 	cs.SetConnection(conn)

--- a/agent/acs/handler/acs_handler_test.go
+++ b/agent/acs/handler/acs_handler_test.go
@@ -134,6 +134,8 @@ var testConfig = &config.Config{
 	AcceptInsecureCert: true,
 }
 
+var testCreds = credentials.NewStaticCredentials("test-id", "test-secret", "test-token")
+
 type mockSessionResources struct {
 	client wsclient.ClientServer
 }
@@ -222,7 +224,7 @@ func TestHandlerReconnectsOnConnectErrors(t *testing.T) {
 	)
 	acsSession := session{
 		containerInstanceARN: "myArn",
-		credentialsProvider:  credentials.AnonymousCredentials,
+		credentialsProvider:  testCreds,
 		agentConfig:          testConfig,
 		taskEngine:           taskEngine,
 		ecsClient:            ecsClient,
@@ -366,7 +368,7 @@ func TestHandlerReconnectsWithoutBackoffOnEOFError(t *testing.T) {
 	)
 	acsSession := session{
 		containerInstanceARN:            "myArn",
-		credentialsProvider:             credentials.AnonymousCredentials,
+		credentialsProvider:             testCreds,
 		agentConfig:                     testConfig,
 		taskEngine:                      taskEngine,
 		ecsClient:                       ecsClient,
@@ -429,7 +431,7 @@ func TestHandlerReconnectsWithBackoffOnNonEOFError(t *testing.T) {
 	)
 	acsSession := session{
 		containerInstanceARN:          "myArn",
-		credentialsProvider:           credentials.AnonymousCredentials,
+		credentialsProvider:           testCreds,
 		agentConfig:                   testConfig,
 		taskEngine:                    taskEngine,
 		ecsClient:                     ecsClient,
@@ -488,7 +490,7 @@ func TestHandlerGeneratesDeregisteredInstanceEvent(t *testing.T) {
 	inactiveInstanceReconnectDelay := 200 * time.Millisecond
 	acsSession := session{
 		containerInstanceARN:            "myArn",
-		credentialsProvider:             credentials.AnonymousCredentials,
+		credentialsProvider:             testCreds,
 		agentConfig:                     testConfig,
 		taskEngine:                      taskEngine,
 		ecsClient:                       ecsClient,
@@ -557,7 +559,7 @@ func TestHandlerReconnectDelayForInactiveInstanceError(t *testing.T) {
 	)
 	acsSession := session{
 		containerInstanceARN:            "myArn",
-		credentialsProvider:             credentials.AnonymousCredentials,
+		credentialsProvider:             testCreds,
 		agentConfig:                     testConfig,
 		taskEngine:                      taskEngine,
 		ecsClient:                       ecsClient,
@@ -615,7 +617,7 @@ func TestHandlerReconnectsOnServeErrors(t *testing.T) {
 
 	acsSession := session{
 		containerInstanceARN: "myArn",
-		credentialsProvider:  credentials.AnonymousCredentials,
+		credentialsProvider:  testCreds,
 		agentConfig:          testConfig,
 		taskEngine:           taskEngine,
 		ecsClient:            ecsClient,
@@ -666,7 +668,7 @@ func TestHandlerStopsWhenContextIsCancelled(t *testing.T) {
 	)
 	acsSession := session{
 		containerInstanceARN: "myArn",
-		credentialsProvider:  credentials.AnonymousCredentials,
+		credentialsProvider:  testCreds,
 		agentConfig:          testConfig,
 		taskEngine:           taskEngine,
 		ecsClient:            ecsClient,
@@ -720,7 +722,7 @@ func TestHandlerReconnectsOnDiscoverPollEndpointError(t *testing.T) {
 	)
 	acsSession := session{
 		containerInstanceARN: "myArn",
-		credentialsProvider:  credentials.AnonymousCredentials,
+		credentialsProvider:  testCreds,
 		agentConfig:          testConfig,
 		taskEngine:           taskEngine,
 		ecsClient:            ecsClient,
@@ -793,7 +795,7 @@ func TestConnectionIsClosedOnIdle(t *testing.T) {
 	}).Return(nil)
 	acsSession := session{
 		containerInstanceARN: "myArn",
-		credentialsProvider:  credentials.AnonymousCredentials,
+		credentialsProvider:  testCreds,
 		agentConfig:          testConfig,
 		taskEngine:           taskEngine,
 		ecsClient:            ecsClient,
@@ -844,9 +846,10 @@ func TestHandlerDoesntLeakGoroutines(t *testing.T) {
 
 	ended := make(chan bool, 1)
 	go func() {
+
 		acsSession := session{
 			containerInstanceARN: "myArn",
-			credentialsProvider:  credentials.AnonymousCredentials,
+			credentialsProvider:  testCreds,
 			agentConfig:          testConfig,
 			taskEngine:           taskEngine,
 			ecsClient:            ecsClient,
@@ -855,7 +858,7 @@ func TestHandlerDoesntLeakGoroutines(t *testing.T) {
 			ctx:                  ctx,
 			_heartbeatTimeout:    1 * time.Second,
 			backoff:              utils.NewSimpleBackoff(connectionBackoffMin, connectionBackoffMax, connectionBackoffJitter, connectionBackoffMultiplier),
-			resources:            newSessionResources(credentials.AnonymousCredentials),
+			resources:            newSessionResources(testCreds),
 			credentialsManager:   rolecredentials.NewManager(),
 		}
 		acsSession.Start()
@@ -932,7 +935,7 @@ func TestStartSessionHandlesRefreshCredentialsMessages(t *testing.T) {
 			testConfig,
 			nil,
 			"myArn",
-			credentials.AnonymousCredentials,
+			testCreds,
 			ecsClient,
 			dockerstate.NewTaskEngineState(),
 			stateManager,
@@ -1031,7 +1034,7 @@ func TestHandlerReconnectsCorrectlySetsSendCredentialsURLParameter(t *testing.T)
 	mockWsClient.EXPECT().AddRequestHandler(gomock.Any()).AnyTimes()
 	mockWsClient.EXPECT().Close().Return(nil).AnyTimes()
 	mockWsClient.EXPECT().Serve().Return(io.EOF).AnyTimes()
-	resources := newSessionResources(credentials.AnonymousCredentials)
+	resources := newSessionResources(testCreds)
 	gomock.InOrder(
 		// When the websocket client connects to ACS for the first
 		// time, 'sendCredentials' should be set to true
@@ -1047,7 +1050,7 @@ func TestHandlerReconnectsCorrectlySetsSendCredentialsURLParameter(t *testing.T)
 
 	acsSession := session{
 		containerInstanceARN: "myArn",
-		credentialsProvider:  credentials.AnonymousCredentials,
+		credentialsProvider:  testCreds,
 		agentConfig:          testConfig,
 		taskEngine:           taskEngine,
 		ecsClient:            ecsClient,

--- a/agent/tcs/client/client_test.go
+++ b/agent/tcs/client/client_test.go
@@ -46,6 +46,8 @@ const (
 	rwTimeout                  = time.Second
 )
 
+var testCreds = credentials.NewStaticCredentials("test-id", "test-secret", "test-token")
+
 type mockStatsEngine struct{}
 
 func (*mockStatsEngine) GetInstanceMetrics() (*ecstcs.MetricsMetadata, []*ecstcs.TaskMetric, error) {
@@ -167,12 +169,12 @@ func TestPublishMetricsRequest(t *testing.T) {
 
 	cs := testCS(conn)
 	defer cs.Close()
-
 	err := cs.MakeRequest(&ecstcs.PublishMetricsRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
 }
+
 func TestPublishMetricsOnceEmptyStatsError(t *testing.T) {
 	cs := clientServer{
 		statsEngine: &emptyStatsEngine{},
@@ -237,12 +239,11 @@ func TestPublishOnceNonIdleStatsEngine(t *testing.T) {
 }
 
 func testCS(conn *mock_wsconn.MockWebsocketConn) wsclient.ClientServer {
-	testCreds := credentials.AnonymousCredentials
 	cfg := &config.Config{
 		AWSRegion:          "us-east-1",
 		AcceptInsecureCert: true,
 	}
-	cs := New("localhost:443", cfg, testCreds, &mockStatsEngine{},
+	cs := New("https://aws.amazon.com/ecs", cfg, testCreds, &mockStatsEngine{},
 		testPublishMetricsInterval, rwTimeout, false).(*clientServer)
 	cs.SetConnection(conn)
 	return cs
@@ -309,10 +310,10 @@ func TestMetricsDisabled(t *testing.T) {
 	mockStatsEngine := mock_stats.NewMockEngine(ctrl)
 
 	cfg := config.DefaultConfig()
-	testCreds := credentials.AnonymousCredentials
 
 	cs := New("", &cfg, testCreds, mockStatsEngine, testPublishMetricsInterval, rwTimeout, true)
 	cs.SetConnection(conn)
+
 	metricsPublished := make(chan struct{})
 
 	// stats engine should only be called for getting health metrics
@@ -340,7 +341,6 @@ func TestCreatePublishHealthRequestsEmpty(t *testing.T) {
 	conn := mock_wsconn.NewMockWebsocketConn(ctrl)
 	mockStatsEngine := mock_stats.NewMockEngine(ctrl)
 	cfg := config.DefaultConfig()
-	testCreds := credentials.AnonymousCredentials
 
 	cs := New("", &cfg, testCreds, mockStatsEngine, testPublishMetricsInterval, rwTimeout, true)
 	cs.SetConnection(conn)
@@ -361,7 +361,6 @@ func TestCreatePublishHealthRequests(t *testing.T) {
 	conn := mock_wsconn.NewMockWebsocketConn(ctrl)
 	mockStatsEngine := mock_stats.NewMockEngine(ctrl)
 	cfg := config.DefaultConfig()
-	testCreds := credentials.AnonymousCredentials
 
 	cs := New("", &cfg, testCreds, mockStatsEngine, testPublishMetricsInterval, rwTimeout, true)
 	cs.SetConnection(conn)

--- a/agent/tcs/handler/handler_test.go
+++ b/agent/tcs/handler/handler_test.go
@@ -50,6 +50,8 @@ const (
 
 type mockStatsEngine struct{}
 
+var testCreds = credentials.NewStaticCredentials("test-id", "test-secret", "test-token")
+
 var testCfg = &config.Config{
 	AcceptInsecureCert: true,
 	AWSRegion:          "us-east-1",
@@ -116,7 +118,7 @@ func TestStartSession(t *testing.T) {
 
 	deregisterInstanceEventStream := eventstream.NewEventStream("Deregister_Instance", context.Background())
 	// Start a session with the test server.
-	go startSession(server.URL, testCfg, credentials.AnonymousCredentials, &mockStatsEngine{},
+	go startSession(server.URL, testCfg, testCreds, &mockStatsEngine{},
 		defaultHeartbeatTimeout, defaultHeartbeatJitter,
 		testPublishMetricsInterval, deregisterInstanceEventStream)
 
@@ -180,7 +182,7 @@ func TestSessionConnectionClosedByRemote(t *testing.T) {
 	defer cancel()
 
 	// Start a session with the test server.
-	err = startSession(server.URL, testCfg, credentials.AnonymousCredentials, &mockStatsEngine{},
+	err = startSession(server.URL, testCfg, testCreds, &mockStatsEngine{},
 		defaultHeartbeatTimeout, defaultHeartbeatJitter,
 		testPublishMetricsInterval, deregisterInstanceEventStream)
 
@@ -217,7 +219,7 @@ func TestConnectionInactiveTimeout(t *testing.T) {
 	deregisterInstanceEventStream.StartListening()
 	defer cancel()
 	// Start a session with the test server.
-	err = startSession(server.URL, testCfg, credentials.AnonymousCredentials, &mockStatsEngine{},
+	err = startSession(server.URL, testCfg, testCreds, &mockStatsEngine{},
 		50*time.Millisecond, 100*time.Millisecond,
 		testPublishMetricsInterval, deregisterInstanceEventStream)
 	// if we are not blocked here, then the test pass as it will reconnect in StartSession

--- a/agent/utils/sign_http_request.go
+++ b/agent/utils/sign_http_request.go
@@ -20,10 +20,17 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/signer/v4"
+	"github.com/cihub/seelog"
+	"github.com/pkg/errors"
 )
 
 // SignHTTPRequest signs an http.Request struct with authv4 using the given region, service, and credentials.
-func SignHTTPRequest(req *http.Request, region, service string, creds *credentials.Credentials, body io.ReadSeeker) {
+func SignHTTPRequest(req *http.Request, region, service string, creds *credentials.Credentials, body io.ReadSeeker) error {
 	signer := v4.NewSigner(creds)
-	signer.Sign(req, body, service, region, time.Now())
+	_, err := signer.Sign(req, body, service, region, time.Now())
+	if err != nil {
+		seelog.Warnf("Signing HTTP request failed: %v", err)
+		return errors.Wrap(err, "aws sdk http signer: failed to sign http request")
+	}
+	return nil
 }

--- a/agent/wsclient/client.go
+++ b/agent/wsclient/client.go
@@ -152,7 +152,10 @@ func (cs *ClientServerImpl) Connect() error {
 	request, _ := http.NewRequest("GET", parsedURL.String(), nil)
 
 	// Sign the request; we'll send its headers via the websocket client which includes the signature
-	utils.SignHTTPRequest(request, cs.AgentConfig.AWSRegion, ServiceName, cs.CredentialProvider, nil)
+	err = utils.SignHTTPRequest(request, cs.AgentConfig.AWSRegion, ServiceName, cs.CredentialProvider, nil)
+	if err != nil {
+		return err
+	}
 
 	timeoutDialer := &net.Dialer{Timeout: wsConnectTimeout}
 	tlsConfig := &tls.Config{ServerName: parsedURL.Host, InsecureSkipVerify: cs.AgentConfig.AcceptInsecureCert}

--- a/agent/wsclient/client_test.go
+++ b/agent/wsclient/client_test.go
@@ -89,6 +89,7 @@ func TestConcurrentWritesDontPanic(t *testing.T) {
 
 func getClientServer(url string) *ClientServerImpl {
 	types := []interface{}{ecsacs.AckRequest{}}
+	testCreds := credentials.NewStaticCredentials("test-id", "test-secret", "test-token")
 
 	return &ClientServerImpl{
 		URL: url,
@@ -97,7 +98,7 @@ func getClientServer(url string) *ClientServerImpl {
 			AWSRegion:          "us-east-1",
 			DockerEndpoint:     "unix://" + dockerEndpoint,
 		},
-		CredentialProvider: credentials.AnonymousCredentials,
+		CredentialProvider: testCreds,
 		TypeDecoder:        BuildTypeDecoder(types),
 		RWTimeout:          time.Second,
 	}


### PR DESCRIPTION
### Summary
This change [unbreaks my dev](https://www.youtube.com/watch?v=wugSagirkBI). The aws sdk update now returns errors if `signer.Sign()` is not passed a `aws.ReadSeekCloser`, we used to pass in a `bytes.Buffer`, but since that doesn't implement a `Seek()` method, we were receiving an error from the sdk. Now we are instead passing in a `bytes.Reader`.

This change also returns errors thrown by the aws sdk when signing http requests and adds logic to pass the error up. We also make corresponding changes to tests to account for these new errors that are being surfaced. We had to swap out the AnonymousCredentials since they were passing in [empty strings](https://github.com/aws/aws-sdk-go/blob/master/aws/credentials/credentials.go#L69) and causing the sdk's signing code paths to return errors about empty creds.

### Implementation details
<!-- How are the changes implemented? -->
🙃

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
