### PR TITLE
taskresource: add terminalReason msg string

### DIFF
--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -47,7 +47,6 @@ const (
 	stoppedSentWaitInterval               = 30 * time.Second
 	maxStoppedWaitTimes                   = 72 * time.Hour / stoppedSentWaitInterval
 	taskUnableToTransitionToStoppedReason = "TaskStateError: Agent could not progress task's state to stopped"
-	taskUnableToCreatePlatformResources   = "TaskStateError: Agent could not create task's platform resources"
 )
 
 var (
@@ -469,6 +468,7 @@ func (mtask *managedTask) handleResourceStateChange(resChange resourceStateChang
 		seelog.Errorf("Managed task [%s]: error while creating resource %s, setting the task's desired status to STOPPED",
 			mtask.Arn, res.GetName())
 		mtask.SetDesiredStatus(apitask.TaskStopped)
+		mtask.SetTerminalReason(res.GetTerminalReason())
 		mtask.engine.saver.Save()
 	}
 }
@@ -763,10 +763,20 @@ func (mtask *managedTask) progressTask() {
 	mtask.waitForTransition(transitions, transitionChange, transitionChangeEntity)
 	// update the task status
 	changed := mtask.UpdateStatus()
+
+	// If knownStatus changed, let it be known
+	mtask.emitEventIfStatusChanged(changed)
+}
+
+func (mtask *managedTask) emitEventIfStatusChanged(changed bool) {
 	if changed {
 		seelog.Debugf("Managed task [%s]: container or resource change also resulted in task change", mtask.Arn)
-		// If knownStatus changed, let it be known
-		mtask.emitTaskEvent(mtask.Task, "")
+
+		var taskStateChangeReason string
+		if mtask.GetKnownStatus().Terminal() {
+			taskStateChangeReason = mtask.GetTerminalReason()
+		}
+		mtask.emitTaskEvent(mtask.Task, taskStateChangeReason)
 	}
 }
 

--- a/agent/taskresource/cgroup/cgroup.go
+++ b/agent/taskresource/cgroup/cgroup.go
@@ -32,10 +32,11 @@ import (
 )
 
 const (
-	memorySubsystem         = "/memory"
-	memoryUseHierarchy      = "memory.use_hierarchy"
-	rootReadOnlyPermissions = os.FileMode(400)
-	resourceName            = "cgroup"
+	memorySubsystem           = "/memory"
+	memoryUseHierarchy        = "memory.use_hierarchy"
+	rootReadOnlyPermissions   = os.FileMode(400)
+	resourceName              = "cgroup"
+	resourceProvisioningError = "CgroupError: Agent could not create task's platform resources"
 )
 
 var (
@@ -80,6 +81,14 @@ func NewCgroupResource(taskARN string,
 	}
 	c.initializeResourceStatusToTransitionFunction()
 	return c
+}
+
+// GetTerminalReason returns an error string to propagate up through to task
+// state change messages
+func (cgroup *CgroupResource) GetTerminalReason() string {
+	// for cgroups we can send up a static string because this is an
+	// implementation detail and unrelated to customer resources
+	return resourceProvisioningError
 }
 
 func (cgroup *CgroupResource) initializeResourceStatusToTransitionFunction() {

--- a/agent/taskresource/cgroup/cgroup_unsupported.go
+++ b/agent/taskresource/cgroup/cgroup_unsupported.go
@@ -105,6 +105,10 @@ func (c *CgroupResource) StatusString(status taskresource.ResourceStatus) string
 	return "undefined"
 }
 
+func (c *CgroupResource) GetTerminalReason() string {
+	return "undefined"
+}
+
 // MarshalJSON marshals CgroupResource object
 func (c *CgroupResource) MarshalJSON() ([]byte, error) {
 	return nil, errors.New("unsupported platform")

--- a/agent/taskresource/interface.go
+++ b/agent/taskresource/interface.go
@@ -67,6 +67,9 @@ type TaskResource interface {
 	SetAppliedStatus(status ResourceStatus) bool
 	// StatusString returns the string of the resource status
 	StatusString(status ResourceStatus) string
+	// GetTerminalReason returns string describing why the resource failed to
+	// provision
+	GetTerminalReason() string
 
 	json.Marshaler
 	json.Unmarshaler

--- a/agent/taskresource/mocks/taskresource_mocks.go
+++ b/agent/taskresource/mocks/taskresource_mocks.go
@@ -144,6 +144,18 @@ func (mr *MockTaskResourceMockRecorder) GetName() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetName", reflect.TypeOf((*MockTaskResource)(nil).GetName))
 }
 
+// GetTerminalReason mocks base method
+func (m *MockTaskResource) GetTerminalReason() string {
+	ret := m.ctrl.Call(m, "GetTerminalReason")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetTerminalReason indicates an expected call of GetTerminalReason
+func (mr *MockTaskResourceMockRecorder) GetTerminalReason() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTerminalReason", reflect.TypeOf((*MockTaskResource)(nil).GetTerminalReason))
+}
+
 // KnownCreated mocks base method
 func (m *MockTaskResource) KnownCreated() bool {
 	ret := m.ctrl.Call(m, "KnownCreated")

--- a/agent/taskresource/volume/dockervolume.go
+++ b/agent/taskresource/volume/dockervolume.go
@@ -22,6 +22,8 @@ import (
 	"time"
 )
 
+const resourceProvisioningError = "VolumeError: Agent could not create task's volume resources"
+
 // VolumeResource represents volume resource
 type VolumeResource struct {
 	// Name is the name of docker volume
@@ -71,6 +73,12 @@ func NewVolumeResource(name string,
 		},
 		client: client,
 	}
+}
+
+// GetTerminalReason returns an error string to propagate up through to task
+// state change messages
+func (vol *VolumeResource) GetTerminalReason() string {
+	return resourceProvisioningError
 }
 
 // SetDesiredStatus safely sets the desired status of the resource


### PR DESCRIPTION
### Summary
<!-- What does this pull request do? -->
This change adds a terminalReason message to the task struct. The intended use is for the field in the task to be set when the agent explicitly transitions a task to stopped.

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [ ] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [ ] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
