### PR TITLE
dep: add unsigned suffix to staged Windows artifacts name

### DIFF
--- a/scripts/stage
+++ b/scripts/stage
@@ -91,8 +91,8 @@ stage_windows_s3() {
 	echo "Saved with md5sum $(cat ${zip_md5})"
 
 	for tag in ${IMAGE_TAG_VERSION} ${IMAGE_TAG_SHA} ${IMAGE_TAG_LATEST}; do
-		dryval s3_cp "${zipfile}.zip" "s3://${S3_BUCKET}/ecs-agent-windows-${tag}.zip"
-		dryval s3_cp "${zip_md5}" "s3://${S3_BUCKET}/ecs-agent-windows-${tag}.zip.md5"
+		dryval s3_cp "${zipfile}.zip" "s3://${S3_BUCKET}/ecs-agent-windows-${tag}-unsigned.zip"
+		dryval s3_cp "${zip_md5}" "s3://${S3_BUCKET}/ecs-agent-windows-${tag}-unsigned.zip.md5"
 		dryval s3_cp "${zip_manifest}" "s3://${S3_BUCKET}/ecs-agent-windows-${tag}.zip.json"
 	done
 	popd


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Add unsigned suffix to staged Windows artifacts name.

The reason why we need this is:
The Windows artifact that we upload in `ec2-stage` is the unsigned version, there will be other scripts that downloads the unsigned artifact, sign the executable file, zip again and upload the signed artifact. 

So mark the one uploaded by `ec2-stage` as unsigned to make it less confused, and also avoid any unsigned artifact being in the stage bucket.

<!-- What does this pull request do? -->


### Implementation details
Tested in my own AWS account, and the generated Windows artifacts have the "unsigned" suffix.


### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass


### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
