### PR TITLE
Wire in context to Docker volume API calls

### DIFF
--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -218,7 +218,7 @@ func (agent *ecsAgent) appendVolumeDriverCapabilities(capabilities []*ecs.Attrib
 	// for standardized plugins, call docker's plugin ls API
 	pluginEnabled := true
 	volumeDriverType := []string{dockerapi.VolumeDriverType}
-	standardizedPlugins, err := agent.dockerClient.ListPluginsWithFilters(pluginEnabled, volumeDriverType, dockerapi.ListPluginsTimeout)
+	standardizedPlugins, err := agent.dockerClient.ListPluginsWithFilters(agent.ctx, pluginEnabled, volumeDriverType, dockerapi.ListPluginsTimeout)
 	if err != nil {
 		seelog.Warnf("Listing plugins with filters enabled=%t, capabilities=%v failed: %v", pluginEnabled, volumeDriverType, err)
 		return capabilities

--- a/agent/app/agent_capability_test.go
+++ b/agent/app/agent_capability_test.go
@@ -74,7 +74,8 @@ func TestCapabilities(t *testing.T) {
 		}),
 		cniClient.EXPECT().Version(ecscni.ECSENIPluginName).Return("v1", nil),
 		mockMobyPlugins.EXPECT().Scan().Return([]string{"fancyvolumedriver"}, nil),
-		client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
+			gomock.Any()).Return(
 			[]string{"coolvolumedriver"}, nil),
 	)
 
@@ -144,7 +145,8 @@ func TestCapabilitiesECR(t *testing.T) {
 	})
 	client.EXPECT().KnownVersions().Return(nil)
 	mockMobyPlugins.EXPECT().Scan().Return([]string{}, nil)
-	client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{}, nil)
+	client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
+		gomock.Any()).Return([]string{}, nil)
 
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines
@@ -185,7 +187,8 @@ func TestCapabilitiesTaskIAMRoleForSupportedDockerVersion(t *testing.T) {
 	})
 	client.EXPECT().KnownVersions().Return(nil)
 	mockMobyPlugins.EXPECT().Scan().Return([]string{}, nil)
-	client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{}, nil)
+	client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
+		gomock.Any()).Return([]string{}, nil)
 
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines
@@ -223,7 +226,8 @@ func TestCapabilitiesTaskIAMRoleForUnSupportedDockerVersion(t *testing.T) {
 	})
 	client.EXPECT().KnownVersions().Return(nil)
 	mockMobyPlugins.EXPECT().Scan().Return([]string{}, nil)
-	client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{}, nil)
+	client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
+		gomock.Any()).Return([]string{}, nil)
 
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines
@@ -262,7 +266,8 @@ func TestCapabilitiesTaskIAMRoleNetworkHostForSupportedDockerVersion(t *testing.
 	})
 	client.EXPECT().KnownVersions().Return(nil)
 	mockMobyPlugins.EXPECT().Scan().Return([]string{}, nil)
-	client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{}, nil)
+	client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
+		gomock.Any()).Return([]string{}, nil)
 
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines
@@ -301,7 +306,8 @@ func TestCapabilitiesTaskIAMRoleNetworkHostForUnSupportedDockerVersion(t *testin
 	})
 	client.EXPECT().KnownVersions().Return(nil)
 	mockMobyPlugins.EXPECT().Scan().Return([]string{}, nil)
-	client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{}, nil)
+	client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
+		gomock.Any()).Return([]string{}, nil)
 
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines
@@ -352,7 +358,8 @@ func TestAWSVPCBlockInstanceMetadataWhenTaskENIIsDisabled(t *testing.T) {
 			dockerclient.Version_1_19,
 		}),
 		mockMobyPlugins.EXPECT().Scan().Return([]string{}, nil),
-		client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{}, nil),
+		client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
+			gomock.Any()).Return([]string{}, nil),
 	)
 
 	expectedCapabilityNames := []string{
@@ -412,7 +419,8 @@ func TestCapabilitiesExecutionRoleAWSLogs(t *testing.T) {
 	client.EXPECT().KnownVersions().Return(nil)
 	cniClient.EXPECT().Version(ecscni.ECSENIPluginName).Return("v1", errors.New("some error happened"))
 	mockMobyPlugins.EXPECT().Scan().Return([]string{}, nil)
-	client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{}, nil)
+	client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
+		gomock.Any()).Return([]string{}, nil)
 
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines
@@ -449,7 +457,8 @@ func TestCapabilitiesTaskResourceLimit(t *testing.T) {
 		client.EXPECT().SupportedVersions().Return(versionList),
 		client.EXPECT().KnownVersions().Return(versionList),
 		mockMobyPlugins.EXPECT().Scan().Return([]string{}, nil),
-		client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{}, nil),
+		client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
+			gomock.Any()).Return([]string{}, nil),
 	)
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines
@@ -488,7 +497,8 @@ func TestCapabilitesTaskResourceLimitDisabledByMissingDockerVersion(t *testing.T
 		client.EXPECT().SupportedVersions().Return(versionList),
 		client.EXPECT().KnownVersions().Return(versionList),
 		mockMobyPlugins.EXPECT().Scan().Return([]string{}, nil),
-		client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{}, nil),
+		client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
+			gomock.Any()).Return([]string{}, nil),
 	)
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines
@@ -552,7 +562,8 @@ func TestCapabilitiesContainerHealth(t *testing.T) {
 	})
 	client.EXPECT().KnownVersions().Return(nil)
 	mockMobyPlugins.EXPECT().Scan().Return([]string{}, nil)
-	client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{}, nil)
+	client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
+		gomock.Any()).Return([]string{}, nil)
 
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines
@@ -587,7 +598,8 @@ func TestCapabilitesListPluginsErrorCase(t *testing.T) {
 		client.EXPECT().SupportedVersions().Return(versionList),
 		client.EXPECT().KnownVersions().Return(versionList),
 		mockMobyPlugins.EXPECT().Scan().Return([]string{}, nil),
-		client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("listPlugins error happened")),
+		client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
+			gomock.Any()).Return(nil, errors.New("listPlugins error happened")),
 	)
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines
@@ -618,7 +630,8 @@ func TestCapabilitesScanPluginsErrorCase(t *testing.T) {
 		client.EXPECT().SupportedVersions().Return(versionList),
 		client.EXPECT().KnownVersions().Return(versionList),
 		mockMobyPlugins.EXPECT().Scan().Return(nil, errors.New("Scan plugins error happened")),
-		client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{}, nil),
+		client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
+			gomock.Any()).Return([]string{}, nil),
 	)
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines

--- a/agent/app/agent_test.go
+++ b/agent/app/agent_test.go
@@ -169,7 +169,8 @@ func TestDoStartRegisterContainerInstanceErrorTerminal(t *testing.T) {
 		dockerClient.EXPECT().SupportedVersions().Return(nil),
 		dockerClient.EXPECT().KnownVersions().Return(nil),
 		mockMobyPlugins.EXPECT().Scan().Return([]string{""}, nil),
-		dockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{}, nil),
+		dockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
+			gomock.Any()).Return([]string{}, nil),
 		client.EXPECT().RegisterContainerInstance(gomock.Any(), gomock.Any()).Return(
 			"", apierrors.NewAttributeError("error")),
 	)
@@ -204,7 +205,8 @@ func TestDoStartRegisterContainerInstanceErrorNonTerminal(t *testing.T) {
 		dockerClient.EXPECT().SupportedVersions().Return(nil),
 		dockerClient.EXPECT().KnownVersions().Return(nil),
 		mockMobyPlugins.EXPECT().Scan().Return([]string{""}, nil),
-		dockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{}, nil),
+		dockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
+			gomock.Any()).Return([]string{}, nil),
 		client.EXPECT().RegisterContainerInstance(gomock.Any(), gomock.Any()).Return(
 			"", errors.New("error")),
 	)
@@ -540,7 +542,8 @@ func TestReregisterContainerInstanceHappyPath(t *testing.T) {
 		mockDockerClient.EXPECT().SupportedVersions().Return(nil),
 		mockDockerClient.EXPECT().KnownVersions().Return(nil),
 		mockMobyPlugins.EXPECT().Scan().Return([]string{""}, nil),
-		mockDockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{}, nil),
+		mockDockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(),
+			gomock.Any(), gomock.Any()).Return([]string{}, nil),
 		client.EXPECT().RegisterContainerInstance(containerInstanceARN, gomock.Any()).Return(containerInstanceARN, nil),
 	)
 	cfg := getTestConfig()
@@ -576,7 +579,8 @@ func TestReregisterContainerInstanceInstanceTypeChanged(t *testing.T) {
 		mockDockerClient.EXPECT().SupportedVersions().Return(nil),
 		mockDockerClient.EXPECT().KnownVersions().Return(nil),
 		mockMobyPlugins.EXPECT().Scan().Return([]string{""}, nil),
-		mockDockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{}, nil),
+		mockDockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(),
+			gomock.Any(), gomock.Any()).Return([]string{}, nil),
 		client.EXPECT().RegisterContainerInstance(containerInstanceARN, gomock.Any()).Return(
 			"", awserr.New("", apierrors.InstanceTypeChangedErrorMessage, errors.New(""))),
 	)
@@ -615,7 +619,8 @@ func TestReregisterContainerInstanceAttributeError(t *testing.T) {
 		mockDockerClient.EXPECT().SupportedVersions().Return(nil),
 		mockDockerClient.EXPECT().KnownVersions().Return(nil),
 		mockMobyPlugins.EXPECT().Scan().Return([]string{}, nil),
-		mockDockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{}, nil),
+		mockDockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(),
+			gomock.Any(), gomock.Any()).Return([]string{}, nil),
 		client.EXPECT().RegisterContainerInstance(containerInstanceARN, gomock.Any()).Return(
 			"", apierrors.NewAttributeError("error")),
 	)
@@ -654,7 +659,8 @@ func TestReregisterContainerInstanceNonTerminalError(t *testing.T) {
 		mockDockerClient.EXPECT().SupportedVersions().Return(nil),
 		mockDockerClient.EXPECT().KnownVersions().Return(nil),
 		mockMobyPlugins.EXPECT().Scan().Return([]string{}, nil),
-		mockDockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{}, nil),
+		mockDockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(),
+			gomock.Any(), gomock.Any()).Return([]string{}, nil),
 		client.EXPECT().RegisterContainerInstance(containerInstanceARN, gomock.Any()).Return(
 			"", errors.New("error")),
 	)
@@ -693,7 +699,8 @@ func TestRegisterContainerInstanceWhenContainerInstanceARNIsNotSetHappyPath(t *t
 		mockDockerClient.EXPECT().SupportedVersions().Return(nil),
 		mockDockerClient.EXPECT().KnownVersions().Return(nil),
 		mockMobyPlugins.EXPECT().Scan().Return([]string{}, nil),
-		mockDockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{}, nil),
+		mockDockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(),
+			gomock.Any(), gomock.Any()).Return([]string{}, nil),
 		client.EXPECT().RegisterContainerInstance("", gomock.Any()).Return(containerInstanceARN, nil),
 		stateManager.EXPECT().Save(),
 	)
@@ -732,7 +739,8 @@ func TestRegisterContainerInstanceWhenContainerInstanceARNIsNotSetCanRetryError(
 		mockDockerClient.EXPECT().SupportedVersions().Return(nil),
 		mockDockerClient.EXPECT().KnownVersions().Return(nil),
 		mockMobyPlugins.EXPECT().Scan().Return([]string{}, nil),
-		mockDockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{}, nil),
+		mockDockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(),
+			gomock.Any(), gomock.Any()).Return([]string{}, nil),
 		client.EXPECT().RegisterContainerInstance("", gomock.Any()).Return("", retriableError),
 	)
 
@@ -770,7 +778,8 @@ func TestRegisterContainerInstanceWhenContainerInstanceARNIsNotSetCannotRetryErr
 		mockDockerClient.EXPECT().SupportedVersions().Return(nil),
 		mockDockerClient.EXPECT().KnownVersions().Return(nil),
 		mockMobyPlugins.EXPECT().Scan().Return([]string{}, nil),
-		mockDockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{}, nil),
+		mockDockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(),
+			gomock.Any(), gomock.Any()).Return([]string{}, nil),
 		client.EXPECT().RegisterContainerInstance("", gomock.Any()).Return("", cannotRetryError),
 	)
 
@@ -807,7 +816,8 @@ func TestRegisterContainerInstanceWhenContainerInstanceARNIsNotSetAttributeError
 		mockDockerClient.EXPECT().SupportedVersions().Return(nil),
 		mockDockerClient.EXPECT().KnownVersions().Return(nil),
 		mockMobyPlugins.EXPECT().Scan().Return([]string{}, nil),
-		mockDockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{}, nil),
+		mockDockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(),
+			gomock.Any(), gomock.Any()).Return([]string{}, nil),
 		client.EXPECT().RegisterContainerInstance("", gomock.Any()).Return(
 			"", apierrors.NewAttributeError("error")),
 	)
@@ -843,7 +853,8 @@ func TestRegisterContainerInstanceInvalidParameterTerminalError(t *testing.T) {
 		dockerClient.EXPECT().SupportedVersions().Return(nil),
 		dockerClient.EXPECT().KnownVersions().Return(nil),
 		mockMobyPlugins.EXPECT().Scan().Return([]string{}, nil),
-		dockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{}, nil),
+		dockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
+			gomock.Any()).Return([]string{}, nil),
 		client.EXPECT().RegisterContainerInstance(gomock.Any(), gomock.Any()).Return(
 			"", awserr.New("InvalidParameterException", "", nil)),
 	)

--- a/agent/app/agent_unix_test.go
+++ b/agent/app/agent_unix_test.go
@@ -91,7 +91,8 @@ func TestDoStartHappyPath(t *testing.T) {
 		dockerClient.EXPECT().SupportedVersions().Return(nil),
 		dockerClient.EXPECT().KnownVersions().Return(nil),
 		mockMobyPlugins.EXPECT().Scan().Return([]string{}, nil),
-		dockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{}, nil),
+		dockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
+			gomock.Any()).Return([]string{}, nil),
 		client.EXPECT().RegisterContainerInstance(gomock.Any(), gomock.Any()).Return("arn", nil),
 		imageManager.EXPECT().SetSaver(gomock.Any()),
 		dockerClient.EXPECT().ContainerEvents(gomock.Any()).Return(containerChangeEvents, nil),
@@ -173,7 +174,8 @@ func TestDoStartTaskENIHappyPath(t *testing.T) {
 		dockerClient.EXPECT().KnownVersions().Return(nil),
 		cniClient.EXPECT().Version(ecscni.ECSENIPluginName).Return("v1", nil),
 		mockMobyPlugins.EXPECT().Scan().Return([]string{}, nil),
-		dockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{}, nil),
+		dockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
+			gomock.Any()).Return([]string{}, nil),
 		client.EXPECT().RegisterContainerInstance(gomock.Any(), gomock.Any()).Do(
 			func(x interface{}, attributes []*ecs.Attribute) {
 				vpcFound := false
@@ -484,7 +486,8 @@ func TestDoStartCgroupInitHappyPath(t *testing.T) {
 		dockerClient.EXPECT().SupportedVersions().Return(nil),
 		dockerClient.EXPECT().KnownVersions().Return(nil),
 		mockMobyPlugins.EXPECT().Scan().Return([]string{}, nil),
-		dockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{}, nil),
+		dockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
+			gomock.Any()).Return([]string{}, nil),
 		client.EXPECT().RegisterContainerInstance(gomock.Any(), gomock.Any()).Return("arn", nil),
 		imageManager.EXPECT().SetSaver(gomock.Any()),
 		dockerClient.EXPECT().ContainerEvents(gomock.Any()).Return(containerChangeEvents, nil),

--- a/agent/dockerclient/dockerapi/docker_client.go
+++ b/agent/dockerclient/dockerapi/docker_client.go
@@ -162,21 +162,21 @@ type DockerClient interface {
 	ListContainers(context.Context, bool, time.Duration) ListContainersResponse
 
 	// CreateVolume creates a docker volume. A timeout value should be provided for the request
-	CreateVolume(string, string, map[string]string, map[string]string, time.Duration) VolumeResponse
+	CreateVolume(context.Context, string, string, map[string]string, map[string]string, time.Duration) VolumeResponse
 
 	// InspectVolume returns a volume by its name. A timeout value should be provided for the request
-	InspectVolume(string, time.Duration) VolumeResponse
+	InspectVolume(context.Context, string, time.Duration) VolumeResponse
 
 	// RemoveVolume removes a volume by its name. A timeout value should be provided for the request
-	RemoveVolume(string, time.Duration) error
+	RemoveVolume(context.Context, string, time.Duration) error
 
 	// ListPluginsWithFilters returns the set of docker plugins installed on the host, filtered by options provided.
 	// A timeout value should be provided for the request.
-	ListPluginsWithFilters(bool, []string, time.Duration) ([]string, error)
+	ListPluginsWithFilters(context.Context, bool, []string, time.Duration) ([]string, error)
 
 	// ListPlugins returns the set of docker plugins installed on the host. A timeout value should be provided for
 	// the request.
-	ListPlugins(time.Duration) ListPluginsResponse
+	ListPlugins(context.Context, time.Duration) ListPluginsResponse
 
 	// Stats returns a channel of stat data for the specified container. A context should be provided so the request can
 	// be canceled.
@@ -1009,16 +1009,12 @@ func (dg *dockerGoClient) setDaemonVersion(version string) {
 	dg.daemonVersionUnsafe = version
 }
 
-func (dg *dockerGoClient) CreateVolume(name string,
+func (dg *dockerGoClient) CreateVolume(ctx context.Context, name string,
 	driver string,
 	driverOptions map[string]string,
 	labels map[string]string,
 	timeout time.Duration) VolumeResponse {
-	// Create a context that times out after the 'timeout' duration
-	// Injecting the 'timeout' makes it easier to write tests.
-	// Eventually, the context should be initialized from a parent root context
-	// instead of TODO.
-	ctx, cancel := context.WithTimeout(context.TODO(), timeout)
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	// Buffered channel so in the case of timeout it takes one write, never gets
@@ -1068,12 +1064,8 @@ func (dg *dockerGoClient) createVolume(ctx context.Context,
 	return VolumeResponse{DockerVolume: dockerVolume, Error: nil}
 }
 
-func (dg *dockerGoClient) InspectVolume(name string, timeout time.Duration) VolumeResponse {
-	// Create a context that times out after the 'timeout' duration
-	// Injecting the 'timeout' makes it easier to write tests.
-	// Eventually, the context should be initialized from a parent root context
-	// instead of TODO.
-	ctx, cancel := context.WithTimeout(context.TODO(), timeout)
+func (dg *dockerGoClient) InspectVolume(ctx context.Context, name string, timeout time.Duration) VolumeResponse {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	// Buffered channel so in the case of timeout it takes one write, never gets
@@ -1114,12 +1106,8 @@ func (dg *dockerGoClient) inspectVolume(ctx context.Context, name string) Volume
 	return VolumeResponse{DockerVolume: dockerVolume, Error: nil}
 }
 
-func (dg *dockerGoClient) RemoveVolume(name string, timeout time.Duration) error {
-	// Create a context that times out after the 'timeout' duration
-	// Injecting the 'timeout' makes it easier to write tests.
-	// Eventually, the context should be initialized from a parent root context
-	// instead of TODO.
-	ctx, cancel := context.WithTimeout(context.TODO(), timeout)
+func (dg *dockerGoClient) RemoveVolume(ctx context.Context, name string, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	// Buffered channel so in the case of timeout it takes one write, never gets
@@ -1160,10 +1148,10 @@ func (dg *dockerGoClient) removeVolume(ctx context.Context, name string) error {
 
 // ListPluginsWithFilters currently is a convenience method as go-dockerclient doesn't implement fitered list. When we or someone else submits
 // PR for the fix we will refactor this to pass in the fiters. See https://docs.docker.com/engine/reference/commandline/plugin_ls/#filtering.
-func (dg *dockerGoClient) ListPluginsWithFilters(enabled bool, capabilities []string, timeout time.Duration) ([]string, error) {
+func (dg *dockerGoClient) ListPluginsWithFilters(ctx context.Context, enabled bool, capabilities []string, timeout time.Duration) ([]string, error) {
 
 	var filteredPluginNames []string
-	response := dg.ListPlugins(timeout)
+	response := dg.ListPlugins(ctx, timeout)
 
 	if response.Error != nil {
 		return nil, response.Error
@@ -1188,12 +1176,8 @@ func (dg *dockerGoClient) ListPluginsWithFilters(enabled bool, capabilities []st
 	return filteredPluginNames, nil
 }
 
-func (dg *dockerGoClient) ListPlugins(timeout time.Duration) ListPluginsResponse {
-	// Create a context that times out after the 'timeout' duration
-	// Injecting the 'timeout' makes it easier to write tests.
-	// Eventually, the context should be initialized from a parent root context
-	// instead of TODO.
-	ctx, cancel := context.WithTimeout(context.TODO(), timeout)
+func (dg *dockerGoClient) ListPlugins(ctx context.Context, timeout time.Duration) ListPluginsResponse {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	// Buffered channel so in the case of timeout it takes one write, never gets

--- a/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
+++ b/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
@@ -92,15 +92,15 @@ func (mr *MockDockerClientMockRecorder) CreateContainer(arg0, arg1, arg2, arg3, 
 }
 
 // CreateVolume mocks base method
-func (m *MockDockerClient) CreateVolume(arg0, arg1 string, arg2, arg3 map[string]string, arg4 time.Duration) dockerapi.VolumeResponse {
-	ret := m.ctrl.Call(m, "CreateVolume", arg0, arg1, arg2, arg3, arg4)
+func (m *MockDockerClient) CreateVolume(arg0 context.Context, arg1, arg2 string, arg3, arg4 map[string]string, arg5 time.Duration) dockerapi.VolumeResponse {
+	ret := m.ctrl.Call(m, "CreateVolume", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(dockerapi.VolumeResponse)
 	return ret0
 }
 
 // CreateVolume indicates an expected call of CreateVolume
-func (mr *MockDockerClientMockRecorder) CreateVolume(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVolume", reflect.TypeOf((*MockDockerClient)(nil).CreateVolume), arg0, arg1, arg2, arg3, arg4)
+func (mr *MockDockerClientMockRecorder) CreateVolume(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVolume", reflect.TypeOf((*MockDockerClient)(nil).CreateVolume), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // DescribeContainer mocks base method
@@ -155,15 +155,15 @@ func (mr *MockDockerClientMockRecorder) InspectImage(arg0 interface{}) *gomock.C
 }
 
 // InspectVolume mocks base method
-func (m *MockDockerClient) InspectVolume(arg0 string, arg1 time.Duration) dockerapi.VolumeResponse {
-	ret := m.ctrl.Call(m, "InspectVolume", arg0, arg1)
+func (m *MockDockerClient) InspectVolume(arg0 context.Context, arg1 string, arg2 time.Duration) dockerapi.VolumeResponse {
+	ret := m.ctrl.Call(m, "InspectVolume", arg0, arg1, arg2)
 	ret0, _ := ret[0].(dockerapi.VolumeResponse)
 	return ret0
 }
 
 // InspectVolume indicates an expected call of InspectVolume
-func (mr *MockDockerClientMockRecorder) InspectVolume(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InspectVolume", reflect.TypeOf((*MockDockerClient)(nil).InspectVolume), arg0, arg1)
+func (mr *MockDockerClientMockRecorder) InspectVolume(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InspectVolume", reflect.TypeOf((*MockDockerClient)(nil).InspectVolume), arg0, arg1, arg2)
 }
 
 // KnownVersions mocks base method
@@ -191,28 +191,28 @@ func (mr *MockDockerClientMockRecorder) ListContainers(arg0, arg1, arg2 interfac
 }
 
 // ListPlugins mocks base method
-func (m *MockDockerClient) ListPlugins(arg0 time.Duration) dockerapi.ListPluginsResponse {
-	ret := m.ctrl.Call(m, "ListPlugins", arg0)
+func (m *MockDockerClient) ListPlugins(arg0 context.Context, arg1 time.Duration) dockerapi.ListPluginsResponse {
+	ret := m.ctrl.Call(m, "ListPlugins", arg0, arg1)
 	ret0, _ := ret[0].(dockerapi.ListPluginsResponse)
 	return ret0
 }
 
 // ListPlugins indicates an expected call of ListPlugins
-func (mr *MockDockerClientMockRecorder) ListPlugins(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPlugins", reflect.TypeOf((*MockDockerClient)(nil).ListPlugins), arg0)
+func (mr *MockDockerClientMockRecorder) ListPlugins(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPlugins", reflect.TypeOf((*MockDockerClient)(nil).ListPlugins), arg0, arg1)
 }
 
 // ListPluginsWithFilters mocks base method
-func (m *MockDockerClient) ListPluginsWithFilters(arg0 bool, arg1 []string, arg2 time.Duration) ([]string, error) {
-	ret := m.ctrl.Call(m, "ListPluginsWithFilters", arg0, arg1, arg2)
+func (m *MockDockerClient) ListPluginsWithFilters(arg0 context.Context, arg1 bool, arg2 []string, arg3 time.Duration) ([]string, error) {
+	ret := m.ctrl.Call(m, "ListPluginsWithFilters", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListPluginsWithFilters indicates an expected call of ListPluginsWithFilters
-func (mr *MockDockerClientMockRecorder) ListPluginsWithFilters(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPluginsWithFilters", reflect.TypeOf((*MockDockerClient)(nil).ListPluginsWithFilters), arg0, arg1, arg2)
+func (mr *MockDockerClientMockRecorder) ListPluginsWithFilters(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPluginsWithFilters", reflect.TypeOf((*MockDockerClient)(nil).ListPluginsWithFilters), arg0, arg1, arg2, arg3)
 }
 
 // LoadImage mocks base method
@@ -264,15 +264,15 @@ func (mr *MockDockerClientMockRecorder) RemoveImage(arg0, arg1, arg2 interface{}
 }
 
 // RemoveVolume mocks base method
-func (m *MockDockerClient) RemoveVolume(arg0 string, arg1 time.Duration) error {
-	ret := m.ctrl.Call(m, "RemoveVolume", arg0, arg1)
+func (m *MockDockerClient) RemoveVolume(arg0 context.Context, arg1 string, arg2 time.Duration) error {
+	ret := m.ctrl.Call(m, "RemoveVolume", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RemoveVolume indicates an expected call of RemoveVolume
-func (mr *MockDockerClientMockRecorder) RemoveVolume(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveVolume", reflect.TypeOf((*MockDockerClient)(nil).RemoveVolume), arg0, arg1)
+func (mr *MockDockerClientMockRecorder) RemoveVolume(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveVolume", reflect.TypeOf((*MockDockerClient)(nil).RemoveVolume), arg0, arg1, arg2)
 }
 
 // StartContainer mocks base method


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Continuation of PR https://github.com/aws/amazon-ecs-agent/pull/1329 

### Implementation details
Wire in context to Docker's Volume API calls

### Testing
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
