### PR TITLE
Close the response body even when the status code is not OK

### DIFF
--- a/misc/taskmetadata-validator/taskmetadata-validator.go
+++ b/misc/taskmetadata-validator/taskmetadata-validator.go
@@ -177,10 +177,12 @@ func metadataResponseOnce(client *http.Client, endpoint string, respType string)
 	if err != nil {
 		return nil, fmt.Errorf("%s: unable to get response: %v", respType, err)
 	}
+	if resp.Body != nil {
+		defer resp.Body.Close()
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("%s: incorrect status code  %d", respType, resp.StatusCode)
 	}
-	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("task metadata: unable to read response body: %v", err)


### PR DESCRIPTION
### Summary
If the task metadata `Get` call returns a non OK HTTP status, the response body will never be closed.

### Implementation details
Moved the deferred close up before the status check in `metadataResponseOnce()`.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [X] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: no

### Description for the changelog
Bug - Close the response body for non 200 HTTP responses.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
