### PR TITLE
Functional tests for task specific and shared Docker volumes

### DIFF
--- a/agent/ecs_client/model/api/api-2.json
+++ b/agent/ecs_client/model/api/api-2.json
@@ -1036,6 +1036,16 @@
       "key":{"shape":"String"},
       "value":{"shape":"String"}
     },
+    "DockerVolumeConfiguration":{
+      "type":"structure",
+      "members":{
+        "scope":{"shape":"Scope"},
+        "autoprovision":{"shape":"BoxedBoolean"},
+        "driver":{"shape":"String"},
+        "driverOpts":{"shape":"StringMap"},
+        "labels":{"shape":"StringMap"}
+      }
+    },
     "Double":{"type":"double"},
     "EnvironmentVariables":{
       "type":"list",
@@ -1518,6 +1528,13 @@
         "failures":{"shape":"Failures"}
       }
     },
+    "Scope":{
+      "type":"string",
+      "enum":[
+        "task",
+        "shared"
+      ]
+    },
     "ServerException":{
       "type":"structure",
       "members":{
@@ -1641,6 +1658,11 @@
     "StringList":{
       "type":"list",
       "member":{"shape":"String"}
+    },
+    "StringMap":{
+      "type":"map",
+      "key":{"shape":"String"},
+      "value":{"shape":"String"}
     },
     "SubmitContainerStateChangeRequest":{
       "type":"structure",
@@ -1924,7 +1946,8 @@
       "type":"structure",
       "members":{
         "name":{"shape":"String"},
-        "host":{"shape":"HostVolumeProperties"}
+        "host":{"shape":"HostVolumeProperties"},
+        "dockerVolumeConfiguration":{"shape":"DockerVolumeConfiguration"}
       }
     },
     "VolumeFrom":{

--- a/agent/ecs_client/model/ecs/api.go
+++ b/agent/ecs_client/model/ecs/api.go
@@ -6237,6 +6237,60 @@ func (s *DiscoverPollEndpointOutput) SetTelemetryEndpoint(v string) *DiscoverPol
 	return s
 }
 
+type DockerVolumeConfiguration struct {
+	_ struct{} `type:"structure"`
+
+	Autoprovision *bool `locationName:"autoprovision" type:"boolean"`
+
+	Driver *string `locationName:"driver" type:"string"`
+
+	DriverOpts map[string]*string `locationName:"driverOpts" type:"map"`
+
+	Labels map[string]*string `locationName:"labels" type:"map"`
+
+	Scope *string `locationName:"scope" type:"string" enum:"Scope"`
+}
+
+// String returns the string representation
+func (s DockerVolumeConfiguration) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DockerVolumeConfiguration) GoString() string {
+	return s.String()
+}
+
+// SetAutoprovision sets the Autoprovision field's value.
+func (s *DockerVolumeConfiguration) SetAutoprovision(v bool) *DockerVolumeConfiguration {
+	s.Autoprovision = &v
+	return s
+}
+
+// SetDriver sets the Driver field's value.
+func (s *DockerVolumeConfiguration) SetDriver(v string) *DockerVolumeConfiguration {
+	s.Driver = &v
+	return s
+}
+
+// SetDriverOpts sets the DriverOpts field's value.
+func (s *DockerVolumeConfiguration) SetDriverOpts(v map[string]*string) *DockerVolumeConfiguration {
+	s.DriverOpts = v
+	return s
+}
+
+// SetLabels sets the Labels field's value.
+func (s *DockerVolumeConfiguration) SetLabels(v map[string]*string) *DockerVolumeConfiguration {
+	s.Labels = v
+	return s
+}
+
+// SetScope sets the Scope field's value.
+func (s *DockerVolumeConfiguration) SetScope(v string) *DockerVolumeConfiguration {
+	s.Scope = &v
+	return s
+}
+
 // A failed resource.
 type Failure struct {
 	_ struct{} `type:"structure"`
@@ -10682,6 +10736,8 @@ func (s *VersionInfo) SetDockerVersion(v string) *VersionInfo {
 type Volume struct {
 	_ struct{} `type:"structure"`
 
+	DockerVolumeConfiguration *DockerVolumeConfiguration `locationName:"dockerVolumeConfiguration" type:"structure"`
+
 	// The contents of the host parameter determine whether your data volume persists
 	// on the host container instance and where it is stored. If the host parameter
 	// is empty, then the Docker daemon assigns a host path for your data volume,
@@ -10708,6 +10764,12 @@ func (s Volume) String() string {
 // GoString returns the string representation
 func (s Volume) GoString() string {
 	return s.String()
+}
+
+// SetDockerVolumeConfiguration sets the DockerVolumeConfiguration field's value.
+func (s *Volume) SetDockerVolumeConfiguration(v *DockerVolumeConfiguration) *Volume {
+	s.DockerVolumeConfiguration = v
+	return s
 }
 
 // SetHost sets the Host field's value.
@@ -10910,6 +10972,14 @@ const (
 
 	// PlacementStrategyTypeBinpack is a PlacementStrategyType enum value
 	PlacementStrategyTypeBinpack = "binpack"
+)
+
+const (
+	// ScopeTask is a Scope enum value
+	ScopeTask = "task"
+
+	// ScopeShared is a Scope enum value
+	ScopeShared = "shared"
 )
 
 const (

--- a/agent/functional_tests/testdata/simpletests_unix/task-local-vol.json
+++ b/agent/functional_tests/testdata/simpletests_unix/task-local-vol.json
@@ -2,7 +2,7 @@
   "Name": "TaskLocalVolume",
   "Description": "Verify that task specific Docker volume works as expected",
   "TaskDefinition": "task-local-vol",
-  "Version": ">=1.18.0",
+  "Version": ">=1.19.0",
   "Timeout": "2m",
   "ExitCodes": {
     "exit": 42

--- a/agent/functional_tests/testdata/simpletests_unix/task-local-vol.json
+++ b/agent/functional_tests/testdata/simpletests_unix/task-local-vol.json
@@ -1,0 +1,10 @@
+{
+  "Name": "TaskLocalVolume",
+  "Description": "Verify that task specific Docker volume works as expected",
+  "TaskDefinition": "task-local-vol",
+  "Version": ">=1.18.0",
+  "Timeout": "2m",
+  "ExitCodes": {
+    "exit": 42
+  }
+}

--- a/agent/functional_tests/testdata/simpletests_unix/task-shared-vol.json
+++ b/agent/functional_tests/testdata/simpletests_unix/task-shared-vol.json
@@ -2,7 +2,7 @@
   "Name": "TaskSharedVolume",
   "Description": "Verify that shared Docker volume works as expected",
   "TaskDefinition": "task-shared-vol",
-  "Version": ">=1.18.0",
+  "Version": ">=1.19.0",
   "Timeout": "2m",
   "ExitCodes": {
     "exit": 42

--- a/agent/functional_tests/testdata/simpletests_unix/task-shared-vol.json
+++ b/agent/functional_tests/testdata/simpletests_unix/task-shared-vol.json
@@ -1,0 +1,10 @@
+{
+  "Name": "TaskSharedVolume",
+  "Description": "Verify that shared Docker volume works as expected",
+  "TaskDefinition": "task-shared-vol",
+  "Version": ">=1.18.0",
+  "Timeout": "2m",
+  "ExitCodes": {
+    "exit": 42
+  }
+}

--- a/agent/functional_tests/testdata/taskdefinitions/task-local-vol/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/task-local-vol/task-definition.json
@@ -1,0 +1,35 @@
+{
+    "family": "ecsftest-task-local-volume",
+    "containerDefinitions": [
+        {
+            "name": "exit",
+            "image": "127.0.0.1:51670/busybox:latest",
+            "cpu": 10,
+            "command":["sh", "-c", "touch /ecs/success; [ -f /ecs/success ] && exit 42 || exit 1"],
+            "memory": 256,
+            "memoryReservation": 128,
+            "mountPoints": [
+                {
+                  "sourceVolume": "task-local",
+                  "containerPath": "/ecs/"
+                }
+            ]
+        }
+    ],
+    "volumes":[
+        {
+            "name": "task-local",
+            "dockerVolumeConfiguration" : {
+                "scope": "task",
+                "driver": "local",
+                "driverOpts": {
+                    "type": "tmpfs",
+                    "device": "tmpfs"
+                },
+                "labels": {
+                    "mylables": "test"
+                }
+            }
+        }
+    ]
+}

--- a/agent/functional_tests/testdata/taskdefinitions/task-shared-vol/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/task-shared-vol/task-definition.json
@@ -1,0 +1,36 @@
+{
+    "family": "ecsftest-task-shared-volume",
+    "containerDefinitions": [
+        {
+            "name": "exit",
+            "image": "127.0.0.1:51670/busybox:latest",
+            "cpu": 10,
+            "command":["sh", "-c", "touch /ecs/success; [ -f /ecs/success ] && exit 42 || exit 1"],
+            "memory": 256,
+            "memoryReservation": 128,
+            "mountPoints": [
+                {
+                  "sourceVolume": "task-shared",
+                  "containerPath": "/ecs/"
+                }
+            ]
+        }
+    ],
+    "volumes":[
+        {
+            "name": "task-shared",
+            "dockerVolumeConfiguration" : {
+                "scope": "shared",
+                "autoprovision":"false",
+                "driver": "local",
+                "driverOpts": {
+                    "type": "tmpfs",
+                    "device": "tmpfs"
+                },
+                "labels": {
+                    "mylables": "test"
+                }
+            }
+        }
+    ]
+}

--- a/agent/functional_tests/tests/generated/simpletests_unix/simpletests_generated_unix_test.go
+++ b/agent/functional_tests/tests/generated/simpletests_unix/simpletests_generated_unix_test.go
@@ -762,6 +762,86 @@ func TestSimpleExit(t *testing.T) {
 
 }
 
+// TestTaskLocalVolume Verify that task specific Docker volume works as expected
+func TestTaskLocalVolume(t *testing.T) {
+
+	// Parallel is opt in because resource constraints could cause test failures
+	// on smaller instances
+	if os.Getenv("ECS_FUNCTIONAL_PARALLEL") != "" {
+		t.Parallel()
+	}
+	agent := RunAgent(t, nil)
+	defer agent.Cleanup()
+	agent.RequireVersion(">=1.18.0")
+
+	td, err := GetTaskDefinition("task-local-vol")
+	if err != nil {
+		t.Fatalf("Could not register task definition: %v", err)
+	}
+	testTasks, err := agent.StartMultipleTasks(t, td, 1)
+	if err != nil {
+		t.Fatalf("Could not start task: %v", err)
+	}
+	timeout, err := time.ParseDuration("2m")
+	if err != nil {
+		t.Fatalf("Could not parse timeout: %#v", err)
+	}
+
+	for _, testTask := range testTasks {
+		err = testTask.WaitStopped(timeout)
+		if err != nil {
+			t.Fatalf("Timed out waiting for task to reach stopped. Error %#v, task %#v", err, testTask)
+		}
+
+		if exit, ok := testTask.ContainerExitcode("exit"); !ok || exit != 42 {
+			t.Errorf("Expected exit to exit with 42; actually exited (%v) with %v", ok, exit)
+		}
+
+		defer agent.SweepTask(testTask)
+	}
+
+}
+
+// TestTaskSharedVolume Verify that shared Docker volume works as expected
+func TestTaskSharedVolume(t *testing.T) {
+
+	// Parallel is opt in because resource constraints could cause test failures
+	// on smaller instances
+	if os.Getenv("ECS_FUNCTIONAL_PARALLEL") != "" {
+		t.Parallel()
+	}
+	agent := RunAgent(t, nil)
+	defer agent.Cleanup()
+	agent.RequireVersion(">=1.18.0")
+
+	td, err := GetTaskDefinition("task-shared-vol")
+	if err != nil {
+		t.Fatalf("Could not register task definition: %v", err)
+	}
+	testTasks, err := agent.StartMultipleTasks(t, td, 1)
+	if err != nil {
+		t.Fatalf("Could not start task: %v", err)
+	}
+	timeout, err := time.ParseDuration("2m")
+	if err != nil {
+		t.Fatalf("Could not parse timeout: %#v", err)
+	}
+
+	for _, testTask := range testTasks {
+		err = testTask.WaitStopped(timeout)
+		if err != nil {
+			t.Fatalf("Timed out waiting for task to reach stopped. Error %#v, task %#v", err, testTask)
+		}
+
+		if exit, ok := testTask.ContainerExitcode("exit"); !ok || exit != 42 {
+			t.Errorf("Expected exit to exit with 42; actually exited (%v) with %v", ok, exit)
+		}
+
+		defer agent.SweepTask(testTask)
+	}
+
+}
+
 // TestTmpfs checks that adding tmpfs volume works
 func TestTmpfs(t *testing.T) {
 

--- a/agent/functional_tests/tests/generated/simpletests_unix/simpletests_generated_unix_test.go
+++ b/agent/functional_tests/tests/generated/simpletests_unix/simpletests_generated_unix_test.go
@@ -772,7 +772,7 @@ func TestTaskLocalVolume(t *testing.T) {
 	}
 	agent := RunAgent(t, nil)
 	defer agent.Cleanup()
-	agent.RequireVersion(">=1.18.0")
+	agent.RequireVersion(">=1.19.0")
 
 	td, err := GetTaskDefinition("task-local-vol")
 	if err != nil {
@@ -812,7 +812,7 @@ func TestTaskSharedVolume(t *testing.T) {
 	}
 	agent := RunAgent(t, nil)
 	defer agent.Cleanup()
-	agent.RequireVersion(">=1.18.0")
+	agent.RequireVersion(">=1.19.0")
 
 	td, err := GetTaskDefinition("task-shared-vol")
 	if err != nil {


### PR DESCRIPTION
### Summary
Functional tests for local and shared docker volumes for tasks

### Implementation details
Note: This PR cannot be merged until backend changes are in prod. 
TODO 
- [ ] Verify shared volumes not removed on task cleanup (only done manually for now)
- [ ] Shared, auto provisioned
- [ ] Windows tests

### Testing
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
