### PR TITLE
acs, engine, wsclient: small spelling fixes

### DIFF
--- a/agent/acs/handler/acs_handler.go
+++ b/agent/acs/handler/acs_handler.go
@@ -179,7 +179,7 @@ func NewSession(ctx context.Context,
 // If the instance is deregistered, Start() would emit an event to the
 // deregister-instance event stream and sets the connection backoff time to 1 hour.
 func (acsSession *session) Start() error {
-	// connectToACS channel is used to inidcate the intent to connect to ACS
+	// connectToACS channel is used to indicate the intent to connect to ACS
 	// It's processed by the select loop to connect to ACS
 	connectToACS := make(chan struct{})
 	// This is required to trigger the first connection to ACS. Subsequent
@@ -222,7 +222,7 @@ func (acsSession *session) Start() error {
 					// to reconnect to ACS
 					sendEmptyMessageOnChannel(connectToACS)
 				} else {
-					// Wait was interrupted. We expect the session to close as canelling
+					// Wait was interrupted. We expect the session to close as canceling
 					// the session context is the only way to end up here. Print a message
 					// to indicate the same
 					seelog.Info("Interrupted waiting for reconnect delay to elapse; Expect session to close")
@@ -322,8 +322,8 @@ func (acsSession *session) startACSSession(client wsclient.ClientServer) error {
 		utils.AddJitter(acsSession.heartbeatTimeout(), acsSession.heartbeatJitter()), func() {
 			// If we do not have an error connecting and remain connected for at
 			// least 1 or so minutes, reset the backoff. This prevents disconnect
-			// errors that only happen infrequently from damaging the
-			// reconnectability as significantly.
+			// errors that only happen infrequently from damaging the reconnect
+			// delay as significantly.
 			acsSession.backoff.Reset()
 		})
 	defer backoffResetTimer.Stop()
@@ -445,7 +445,7 @@ func anyMessageHandler(timer ttime.Timer, client wsclient.ClientServer) func(int
 			seelog.Warnf("Unable to extend read deadline for ACS connection: %v", err)
 		}
 
-		// Reset hearbeat timer
+		// Reset heartbeat timer
 		timer.Reset(utils.AddJitter(heartbeatTimeout, heartbeatJitter))
 	}
 }
@@ -459,7 +459,7 @@ func isInactiveInstanceError(acsError error) bool {
 }
 
 // sendEmptyMessageOnChannel sends an empty message using a go-routine on the
-// sepcified channel
+// specified channel
 func sendEmptyMessageOnChannel(channel chan<- struct{}) {
 	go func() {
 		channel <- struct{}{}

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -566,7 +566,7 @@ func (engine *DockerTaskEngine) handleDockerEvent(event dockerapi.DockerContaine
 		return
 	}
 
-	// Container health status change doesnot affect the container status
+	// Container health status change does not affect the container status
 	// no need to process this in task manager
 	if event.Type == apicontainer.ContainerHealthEvent {
 		if cont.Container.HealthStatusShouldBeReported() {

--- a/agent/wsclient/client.go
+++ b/agent/wsclient/client.go
@@ -132,7 +132,7 @@ type ClientServerImpl struct {
 }
 
 // Connect opens a connection to the backend and upgrades it to a websocket. Calls to
-// 'MakeRequest' can be made after calling this, but responss will not be
+// 'MakeRequest' can be made after calling this, but responses will not be
 // receivable until 'Serve' is also called.
 func (cs *ClientServerImpl) Connect() error {
 	seelog.Debugf("Establishing a Websocket connection to %s", cs.URL)


### PR DESCRIPTION
### Summary
Small spelling fixes

### Testing
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: no

### Description for the changelog
None

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
