### PR TITLE
[wip] Add AWSDomain in Config and compose awslogs endpoint

### DIFF
--- a/agent/api/ecsclient/client.go
+++ b/agent/api/ecsclient/client.go
@@ -64,6 +64,9 @@ func NewECSClient(
 	ecsConfig.Credentials = credentialProvider
 	ecsConfig.Region = &config.AWSRegion
 	ecsConfig.HTTPClient = httpclient.New(roundtripTimeout, config.AcceptInsecureCert)
+	if config.EndpointCompositionEnabled {
+		ecsConfig.Endpoint = aws.String(utils.ComposeEndpointURL(ecs.ServiceName, config.AWSRegion, config.AWSDomain))
+	}
 	if config.APIEndpoint != "" {
 		ecsConfig.Endpoint = &config.APIEndpoint
 	}

--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -139,7 +139,7 @@ func newAgent(
 	seelog.Infof("Amazon ECS agent Version: %s, Commit: %s", version.Version, version.GitShortHash)
 	seelog.Debugf("Loaded config: %s", cfg.String())
 
-	ec2Client := ec2.NewClientImpl(cfg.AWSRegion)
+	ec2Client := ec2.NewClientImpl(cfg)
 	dockerClient, err := dockerapi.NewDockerGoClient(sdkclientfactory.NewFactory(ctx, cfg.DockerEndpoint), cfg, ctx)
 
 	if err != nil {

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -51,6 +51,10 @@ type Config struct {
 	// will be fatal.
 	AWSRegion string `missing:"fatal" trim:"true"`
 
+	// AWSDomain is the domain to run in (such as "amazonaws.com"). This value will
+	// be inferred from the EC2 metadata service.
+	AWSDomain string `trim:"true"`
+
 	// ReservedPorts is an array of ports which should be registered as
 	// unavailable. If not set, they default to [22,2375,2376,51678].
 	ReservedPorts []uint16
@@ -283,4 +287,10 @@ type Config struct {
 
 	// TaskMetadataAZDisabled specifies if availability zone should be disabled in Task Metadata endpoint
 	TaskMetadataAZDisabled bool
+
+	// EndpointCompositionEnable specifies if the Agent is capable of composing
+	// endpoint URL for all the clients (like EC2, SSM clients). This will make
+	// Agent work for isolate regions where client endpoint UR are not supported
+	// by public AWS GO SDK.
+	EndpointCompositionEnabled bool
 }

--- a/agent/ec2/ec2_client.go
+++ b/agent/ec2/ec2_client.go
@@ -16,7 +16,9 @@ package ec2
 import (
 	"strings"
 
+	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
+	"github.com/aws/amazon-ecs-agent/agent/utils"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	ec2sdk "github.com/aws/aws-sdk-go/service/ec2"
@@ -49,10 +51,14 @@ type ClientImpl struct {
 	client ClientSDK
 }
 
-func NewClientImpl(awsRegion string) Client {
+func NewClientImpl(config *config.Config) Client {
 	var ec2Config aws.Config
-	ec2Config.Region = aws.String(awsRegion)
-	client := ec2sdk.New(session.New(&ec2Config), aws.NewConfig().WithMaxRetries(clientRetriesNum))
+	ec2Config.Region = aws.String(config.AWSRegion)
+	if config.EndpointCompositionEnabled {
+		ec2Config.Endpoint = aws.String(utils.ComposeEndpointURL(ec2sdk.ServiceName, config.AWSRegion, config.AWSDomain))
+	}
+	ec2Config.MaxRetries = aws.Int(clientRetriesNum)
+	client := ec2sdk.New(session.New(&ec2Config))
 	return &ClientImpl{
 		client: client,
 	}

--- a/agent/engine/common_test.go
+++ b/agent/engine/common_test.go
@@ -143,6 +143,7 @@ func validateContainerRunWorkflow(t *testing.T,
 	imageManager.EXPECT().RecordContainerReference(container).Return(nil)
 	imageManager.EXPECT().GetImageStateFromImageName(gomock.Any()).Return(nil, false)
 	client.EXPECT().APIVersion().Return(defaultDockerClientAPIVersion, nil)
+	client.EXPECT().Version(gomock.Any(), gomock.Any()).Return(defaultDockerVersion, nil)
 	dockerConfig, err := task.DockerConfig(container, defaultDockerClientAPIVersion)
 	if err != nil {
 		t.Fatal(err)
@@ -229,10 +230,12 @@ func addTaskToEngine(t *testing.T,
 	taskEngine TaskEngine,
 	sleepTask *apitask.Task,
 	mockTime *mock_ttime.MockTime,
+	mockDockerClient *mock_dockerapi.MockDockerClient,
 	createStartEventsReported *sync.WaitGroup) {
 	// steadyStateCheckWait is used to force the test to wait until the steady-state check
 	// has been invoked at least once
 	mockTime.EXPECT().Now().Return(time.Now()).AnyTimes()
+	mockDockerClient.EXPECT().Version(gomock.Any(), gomock.Any()).Return(defaultDockerVersion, nil).AnyTimes()
 
 	err := taskEngine.Init(ctx)
 	assert.NoError(t, err)

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -845,14 +845,20 @@ func (engine *DockerTaskEngine) createContainer(task *apitask.Task, container *a
 	// we have to do this in create, not start, because docker no longer handles
 	// merging create config with start hostconfig the same; e.g. memory limits
 	// get lost
-	dockerClientVersion, versionErr := client.APIVersion()
-	if versionErr != nil {
-		return dockerapi.DockerContainerMetadata{Error: CannotGetDockerClientVersionError{versionErr}}
+	dockerClientVersion, dcvErr := client.APIVersion()
+	if dcvErr != nil {
+		return dockerapi.DockerContainerMetadata{Error: CannotGetDockerClientVersionError{dcvErr}}
 	}
 
-	hostConfig, hcerr := task.DockerHostConfig(container, containerMap, dockerClientVersion)
-	if hcerr != nil {
-		return dockerapi.DockerContainerMetadata{Error: apierrors.NamedError(hcerr)}
+	dockerVersion, dvErr := engine.Version()
+
+	if dvErr != nil {
+		return dockerapi.DockerContainerMetadata{Error: CannotGetDockerVersionError{dvErr}}
+	}
+
+	hostConfig, hcErr := task.DockerHostConfig(engine.cfg, container, containerMap, dockerClientVersion, dockerVersion)
+	if hcErr != nil {
+		return dockerapi.DockerContainerMetadata{Error: apierrors.NamedError(hcErr)}
 	}
 
 	if container.AWSLogAuthExecutionRole() {

--- a/agent/engine/errors.go
+++ b/agent/engine/errors.go
@@ -97,3 +97,15 @@ func (err CannotGetDockerClientVersionError) ErrorName() string {
 func (err CannotGetDockerClientVersionError) Error() string {
 	return err.fromError.Error()
 }
+
+// CannotGetDockerVersionError indicates error when trying to get docker version
+type CannotGetDockerVersionError struct {
+	fromError error
+}
+
+func (err CannotGetDockerVersionError) ErrorName() string {
+	return "CannotGetDockerVersionError"
+}
+func (err CannotGetDockerVersionError) Error() string {
+	return err.fromError.Error()
+}

--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -51,7 +51,7 @@ const (
 	maxStoppedWaitTimes                   = 72 * time.Hour / stoppedSentWaitInterval
 	taskUnableToTransitionToStoppedReason = "TaskStateError: Agent could not progress task's state to stopped"
 )
-
+a
 var (
 	_stoppedSentWaitInterval       = stoppedSentWaitInterval
 	_maxStoppedWaitTimes           = int(maxStoppedWaitTimes)

--- a/agent/taskresource/ssmsecret/ssmsecret.go
+++ b/agent/taskresource/ssmsecret/ssmsecret.go
@@ -16,13 +16,15 @@ package ssmsecret
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/cihub/seelog"
-	"github.com/pkg/errors"
 	"sync"
 	"time"
 
+	"github.com/cihub/seelog"
+	"github.com/pkg/errors"
+
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/api/task/status"
+	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/credentials"
 	"github.com/aws/amazon-ecs-agent/agent/ssm"
 	"github.com/aws/amazon-ecs-agent/agent/ssm/factory"
@@ -41,6 +43,7 @@ const (
 // SSMSecretResource represents secrets as a task resource.
 // The secrets are stored in SSM Parameter Store.
 type SSMSecretResource struct {
+	cfg                 *config.Config
 	taskARN             string
 	createdAt           time.Time
 	desiredStatusUnsafe resourcestatus.ResourceStatus
@@ -73,13 +76,15 @@ type SSMSecretResource struct {
 }
 
 // NewSSMSecretResource creates a new SSMSecretResource object
-func NewSSMSecretResource(taskARN string,
+func NewSSMSecretResource(cfg *config.Config,
+	taskARN string,
 	ssmSecrets map[string][]apicontainer.Secret,
 	executionCredentialsID string,
 	credentialsManager credentials.Manager,
 	ssmClientCreator factory.SSMClientCreator) *SSMSecretResource {
 
 	s := &SSMSecretResource{
+		cfg:                    cfg,
 		taskARN:                taskARN,
 		requiredSecrets:        ssmSecrets,
 		credentialsManager:     credentialsManager,

--- a/agent/utils/utils.go
+++ b/agent/utils/utils.go
@@ -23,6 +23,8 @@ import (
 	"strconv"
 	"strings"
 
+	"fmt"
+
 	"github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
 	"github.com/aws/amazon-ecs-agent/agent/logger"
 	"github.com/aws/aws-sdk-go/aws"
@@ -159,4 +161,8 @@ func MapToTags(tagsMap map[string]string) []*ecs.Tag {
 	}
 
 	return tags
+}
+
+func ComposeEndpointURL(serviceName, region, domain string) string {
+	return fmt.Sprintf("%s.%s.%s", serviceName, region, domain)
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Compose the awslogs endpoint and pass it to Docker, this prevents us from being blocked by two cases:
1. Docker doesn't update AWS SDK in time when there is a new AWS region.
2. The new AWS region is not recorded in AWS SDK.

I have submitted a [PR](https://github.com/moby/moby/pull/37374) to moby which introduces `awslogs-endpoint` log option.

Since Docker does check on log options, and current log options do not include `awslogs-endpoint`, this PR cannot be merged (but still needs review!) until we know the Docker version that supports `awslogs-endpoint` (both for Windows and Linux).

TODO:
1. Update `awslogsEndpointMinimumDockerVersion` when we know the Docker version that supports `awslogs-endpoint`.
2. Add entry in `CHANGELOG.md` when we are sure about the Agent version will support this feature.

### Implementation details
<!-- How are the changes implemented? -->
1. Get AWSDomain from EC2 metadata, add it to config.
2. Pass the config to `DockerHostConfig` method, construct a CloudWatch Logs endpoint using `config.AWSDomain`, `config.AWSRegion`/`awslogs-region` log option, add it to `awslogs-endpoint` option.
3. Add tests, refactor some tests, some manual tests with manually compiled Docker.

Reason that I don't use AWS SDK to construct the endpoint: 
The AWS SDK package doesn't expose the method to construct an endpoint without scheme, the endpoint you can get is like `https://logs.us-west-2.amazonaws.com`, but the endpoint we want is like `logs.us-west-2.amazonaws.com`. And some region is probably not in AWS SDK. 

Since we know from AWS SDK that the endpoint pattern is `{service}.{region}.{dnsSuffix}`, we can simply construct it by ourself.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes

### Description for the changelog
* Enhancement - Add AWSDomain in config, construct awslogs endpoint and pass it to Docker.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
