### PR TITLE
Change volume plugin attribute name

### DIFF
--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -38,7 +38,7 @@ const (
 	taskENIBlockInstanceMetadataAttributeSuffix = "task-eni-block-instance-metadata"
 	cniPluginVersionSuffix                      = "cni-plugin-version"
 	capabilityTaskCPUMemLimit                   = "task-cpu-mem-limit"
-	capabilityDockerVolumeDriverInfix           = "docker-volume-driver."
+	capabilityDockerPluginInfix                 = "docker-plugin."
 	attributeSeparator                          = "."
 )
 
@@ -214,12 +214,12 @@ func (agent *ecsAgent) appendVolumeDriverCapabilities(capabilities []*ecs.Attrib
 		seelog.Warnf("Scanning plugins failed: %v", err)
 		// do not return yet, we need the list of plugins below. range handles nil slice.
 	}
-	capabilities = appendNameOnlyAttribute(capabilities, attributePrefix+capabilityDockerVolumeDriverInfix+volume.DockerLocalVolumeDriver)
+	capabilities = appendNameOnlyAttribute(capabilities, attributePrefix+capabilityDockerPluginInfix+volume.DockerLocalVolumeDriver)
 
 	for _, pluginName := range nonStandardizedPlugins {
 		// Replace the ':' to '.' in the plugin name for attributes
 		capabilities = appendNameOnlyAttribute(capabilities,
-			attributePrefix+capabilityDockerVolumeDriverInfix+strings.Replace(pluginName, config.DockerTagSeparator, attributeSeparator, -1))
+			attributePrefix+capabilityDockerPluginInfix+strings.Replace(pluginName, config.DockerTagSeparator, attributeSeparator, -1))
 	}
 
 	// for standardized plugins, call docker's plugin ls API
@@ -236,11 +236,11 @@ func (agent *ecsAgent) appendVolumeDriverCapabilities(capabilities []*ecs.Attrib
 	for _, pluginName := range standardizedPlugins {
 		names := strings.Split(pluginName, config.DockerTagSeparator)
 		if len(names) > 1 && names[len(names)-1] == config.DefaultDockerTag {
-			capabilities = appendNameOnlyAttribute(capabilities, attributePrefix+capabilityDockerVolumeDriverInfix+strings.Join(names[:len(names)-1], attributeSeparator))
+			capabilities = appendNameOnlyAttribute(capabilities, attributePrefix+capabilityDockerPluginInfix+strings.Join(names[:len(names)-1], attributeSeparator))
 		}
 
 		capabilities = appendNameOnlyAttribute(capabilities,
-			attributePrefix+capabilityDockerVolumeDriverInfix+strings.Replace(pluginName, config.DockerTagSeparator, attributeSeparator, -1))
+			attributePrefix+capabilityDockerPluginInfix+strings.Replace(pluginName, config.DockerTagSeparator, attributeSeparator, -1))
 	}
 	return capabilities
 }

--- a/agent/app/agent_capability_test.go
+++ b/agent/app/agent_capability_test.go
@@ -106,19 +106,19 @@ func TestCapabilities(t *testing.T) {
 				Name: aws.String(attributePrefix + taskENIBlockInstanceMetadataAttributeSuffix),
 			},
 			{
-				Name: aws.String("ecs.capability.docker-volume-driver.local"),
+				Name: aws.String("ecs.capability.docker-plugin.local"),
 			},
 			{
-				Name: aws.String(attributePrefix + "docker-volume-driver.fancyvolumedriver"),
+				Name: aws.String(attributePrefix + "docker-plugin.fancyvolumedriver"),
 			},
 			{
-				Name: aws.String(attributePrefix + "docker-volume-driver.coolvolumedriver"),
+				Name: aws.String(attributePrefix + "docker-plugin.coolvolumedriver"),
 			},
 			{
-				Name: aws.String(attributePrefix + "docker-volume-driver.volumedriver"),
+				Name: aws.String(attributePrefix + "docker-plugin.volumedriver"),
 			},
 			{
-				Name: aws.String(attributePrefix + "docker-volume-driver.volumedriver.latest"),
+				Name: aws.String(attributePrefix + "docker-plugin.volumedriver.latest"),
 			},
 		}...)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
