### PR TITLE
functional test: enable container health test

### DIFF
--- a/agent/acs/handler/acs_handler_test.go
+++ b/agent/acs/handler/acs_handler_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/wsclient/mock"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/gorilla/websocket"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/golang/mock/gomock"
@@ -667,7 +668,7 @@ func TestHandlerStopsWhenContextIsCancelled(t *testing.T) {
 		mockWsClient.EXPECT().Serve().Return(io.EOF),
 		mockWsClient.EXPECT().Serve().Do(func() {
 			cancel()
-		}).Return(io.EOF),
+		}).Return(errors.New("InactiveInstanceException")),
 	)
 	acsSession := session{
 		containerInstanceARN: "myArn",

--- a/agent/functional_tests/testdata/taskdefinitions/container-health-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/container-health-windows/task-definition.json
@@ -9,7 +9,7 @@
         "memory": 500,
         "healthCheck": {
             "command": ["CMD-SHELL", "echo hello"],
-            "interval": 1,
+            "interval": 5,
             "timeout": 2,
             $$$$START_PERIOD$$$$
             "retries": 3

--- a/agent/functional_tests/testdata/taskdefinitions/container-health/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/container-health/task-definition.json
@@ -9,7 +9,7 @@
         "memory": 300,
         "healthCheck": {
             "command": ["CMD-SHELL", "echo hello"],
-            "interval": 1,
+            "interval": 5,
             "timeout": 2,
             $$$$START_PERIOD$$$$
             "retries": 3

--- a/agent/functional_tests/tests/functionaltests_test.go
+++ b/agent/functional_tests/tests/functionaltests_test.go
@@ -417,7 +417,7 @@ func containerHealthWithoutStartPeriodTest(t *testing.T, taskDefinition string) 
 	RequireDockerVersion(t, ">=1.12.0") // container health check was added in Docker 1.12.0
 	// StartPeriod of container health check was added in 17.05.0,
 	// don't test it here, it should be tested in containerHealthWithStartPeriodTest
-	RequireDockerVersion(t, "<17.05.0")
+	RequireDockerAPIVersion(t, "<1.29")
 
 	tdOverrides := map[string]string{
 		"$$$$START_PERIOD$$$$": "",
@@ -427,7 +427,7 @@ func containerHealthWithoutStartPeriodTest(t *testing.T, taskDefinition string) 
 }
 
 func containerHealthWithStartPeriodTest(t *testing.T, taskDefinition string) {
-	RequireDockerVersion(t, ">=17.05.0") // StartPeriod of container health check was added in 17.05.0
+	RequireDockerAPIVersion(t, ">=1.29") // StartPeriod of container health check was added in 17.05.0
 
 	tdOverrides := map[string]string{
 		"$$$$START_PERIOD$$$$": `"startPeriod": 1,`,

--- a/agent/functional_tests/tests/functionaltests_unix_test.go
+++ b/agent/functional_tests/tests/functionaltests_unix_test.go
@@ -891,15 +891,11 @@ func TestPrivateRegistryAuthOverASM(t *testing.T) {
 
 // TestContainerHealthMetrics tests the container health metrics was sent to backend
 func TestContainerHealthMetrics(t *testing.T) {
-	// TODO remove this after backend changes deployed
-	t.Skip("Not supported")
 	containerHealthWithoutStartPeriodTest(t, "container-health")
 }
 
 // TestContainerHealthMetricsWithStartPeriod tests the container health metrics
 // with start period configured in the task definition
 func TestContainerHealthMetricsWithStartPeriod(t *testing.T) {
-	// TODO remove this after backend changes deployed
-	t.Skip("Not supported")
 	containerHealthWithStartPeriodTest(t, "container-health")
 }

--- a/agent/functional_tests/tests/functionaltests_windows_test.go
+++ b/agent/functional_tests/tests/functionaltests_windows_test.go
@@ -342,15 +342,11 @@ func TestAWSLogsDriverDatetimeFormat(t *testing.T) {
 
 // TestContainerHealthMetrics tests the container health metrics was sent to backend
 func TestContainerHealthMetrics(t *testing.T) {
-	// TODO remove this after backend changes deployed
-	t.Skip("Not supported")
 	containerHealthWithoutStartPeriodTest(t, "container-health-windows")
 }
 
 // TestContainerHealthMetricsWithStartPeriod tests the container health metrics
 // with start period configured in the task definition
 func TestContainerHealthMetricsWithStartPeriod(t *testing.T) {
-	// TODO remove this after backend changes deployed
-	t.Skip("Not supported")
 	containerHealthWithStartPeriodTest(t, "container-health-windows")
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
