### PR TITLE
dockerapi: Support for Docker SDK Client

### DIFF
--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -27,6 +27,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/containermetadata"
 	"github.com/aws/amazon-ecs-agent/agent/credentials"
+	"github.com/aws/amazon-ecs-agent/agent/dockerclient/sdkclientfactory"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/clientfactory"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	"github.com/aws/amazon-ecs-agent/agent/ec2"
@@ -135,7 +136,7 @@ func newAgent(
 	seelog.Debugf("Loaded config: %s", cfg.String())
 
 	dockerClient, err := dockerapi.NewDockerGoClient(
-		clientfactory.NewFactory(ctx, cfg.DockerEndpoint), cfg)
+		clientfactory.NewFactory(ctx, cfg.DockerEndpoint), sdkclientfactory.NewFactory(ctx, cfg.DockerEndpoint), cfg, ctx)
 	if err != nil {
 		// This is also non terminal in the current config
 		seelog.Criticalf("Error creating Docker client: %v", err)

--- a/agent/eni/pause/pause_linux_test.go
+++ b/agent/eni/pause/pause_linux_test.go
@@ -25,9 +25,12 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/clientfactory/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockeriface/mocks"
+	"github.com/aws/amazon-ecs-agent/agent/dockerclient/sdkclient/mocks"
+	"github.com/aws/amazon-ecs-agent/agent/dockerclient/sdkclientfactory/mocks"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"github.com/docker/docker/api/types"
 )
 
 const (
@@ -43,18 +46,25 @@ func TestLoadFromFileWithReaderError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	// go-dockerclient tests
 	mockDocker := mock_dockeriface.NewMockClient(ctrl)
 	mockDocker.EXPECT().Ping().AnyTimes().Return(nil)
 	factory := mock_clientfactory.NewMockFactory(ctrl)
 	factory.EXPECT().GetDefaultClient().AnyTimes().Return(mockDocker, nil)
-	client, err := dockerapi.NewDockerGoClient(factory, &defaultConfig)
-	assert.NoError(t, err)
-
-	mockfs := mock_os.NewMockFileSystem(ctrl)
-	mockfs.EXPECT().Open(pauseTarballPath).Return(nil, errors.New("Dummy Reader Error"))
+	// Docker SDK tests
+	mockDockerSDK := mock_sdkclient.NewMockClient(ctrl)
+	mockDockerSDK.EXPECT().Ping(gomock.Any()).Return(types.Ping{}, nil)
+	sdkFactory := mock_sdkclientfactory.NewMockFactory(ctrl)
+	sdkFactory.EXPECT().GetDefaultClient().AnyTimes().Return(mockDockerSDK, nil)
 
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
+
+	client, err := dockerapi.NewDockerGoClient(factory, sdkFactory, &defaultConfig, ctx)
+	assert.NoError(t, err)
+	mockfs := mock_os.NewMockFileSystem(ctrl)
+	mockfs.EXPECT().Open(pauseTarballPath).Return(nil, errors.New("Dummy Reader Error"))
+
 	err = loadFromFile(ctx, pauseTarballPath, client, mockfs)
 	assert.Error(t, err)
 }
@@ -64,20 +74,26 @@ func TestLoadFromFileHappyPath(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	// go-dockerclient tests
 	mockDocker := mock_dockeriface.NewMockClient(ctrl)
 	mockDocker.EXPECT().Ping().AnyTimes().Return(nil)
 	factory := mock_clientfactory.NewMockFactory(ctrl)
 	factory.EXPECT().GetDefaultClient().AnyTimes().Return(mockDocker, nil)
-	client, err := dockerapi.NewDockerGoClient(factory, &defaultConfig)
-	assert.NoError(t, err)
-
-	mockDocker.EXPECT().LoadImage(gomock.Any()).Return(nil)
-
-	mockfs := mock_os.NewMockFileSystem(ctrl)
-	mockfs.EXPECT().Open(pauseTarballPath).Return(nil, nil)
+	// Docker SDK tests
+	mockDockerSDK := mock_sdkclient.NewMockClient(ctrl)
+	mockDockerSDK.EXPECT().Ping(gomock.Any()).Return(types.Ping{}, nil)
+	sdkFactory := mock_sdkclientfactory.NewMockFactory(ctrl)
+	sdkFactory.EXPECT().GetDefaultClient().AnyTimes().Return(mockDockerSDK, nil)
 
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
+
+	client, err := dockerapi.NewDockerGoClient(factory, sdkFactory, &defaultConfig, ctx)
+	assert.NoError(t, err)
+	mockDocker.EXPECT().LoadImage(gomock.Any()).Return(nil)
+	mockfs := mock_os.NewMockFileSystem(ctrl)
+	mockfs.EXPECT().Open(pauseTarballPath).Return(nil, nil)
+
 	err = loadFromFile(ctx, pauseTarballPath, client, mockfs)
 	assert.NoError(t, err)
 }
@@ -88,21 +104,27 @@ func TestLoadFromFileDockerLoadImageError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	// go-dockerclient tests
 	mockDocker := mock_dockeriface.NewMockClient(ctrl)
 	mockDocker.EXPECT().Ping().AnyTimes().Return(nil)
 	factory := mock_clientfactory.NewMockFactory(ctrl)
 	factory.EXPECT().GetDefaultClient().AnyTimes().Return(mockDocker, nil)
-	client, err := dockerapi.NewDockerGoClient(factory, &defaultConfig)
-	assert.NoError(t, err)
-
-	mockDocker.EXPECT().LoadImage(gomock.Any()).Return(
-		errors.New("Dummy Load Image Error"))
-
-	mockfs := mock_os.NewMockFileSystem(ctrl)
-	mockfs.EXPECT().Open(pauseTarballPath).Return(nil, nil)
+	// Docker SDK tests
+	mockDockerSDK := mock_sdkclient.NewMockClient(ctrl)
+	mockDockerSDK.EXPECT().Ping(gomock.Any()).Return(types.Ping{}, nil)
+	sdkFactory := mock_sdkclientfactory.NewMockFactory(ctrl)
+	sdkFactory.EXPECT().GetDefaultClient().AnyTimes().Return(mockDockerSDK, nil)
 
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
+
+	client, err := dockerapi.NewDockerGoClient(factory, sdkFactory, &defaultConfig, ctx)
+	assert.NoError(t, err)
+	mockDocker.EXPECT().LoadImage(gomock.Any()).Return(
+		errors.New("Dummy Load Image Error"))
+	mockfs := mock_os.NewMockFileSystem(ctrl)
+
+	mockfs.EXPECT().Open(pauseTarballPath).Return(nil, nil)
 	err = loadFromFile(ctx, pauseTarballPath, client, mockfs)
 	assert.Error(t, err)
 }
@@ -111,13 +133,22 @@ func TestGetPauseContainerImageInspectImageError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	// go-dockerclient tests
 	mockDocker := mock_dockeriface.NewMockClient(ctrl)
 	mockDocker.EXPECT().Ping().AnyTimes().Return(nil)
 	factory := mock_clientfactory.NewMockFactory(ctrl)
 	factory.EXPECT().GetDefaultClient().AnyTimes().Return(mockDocker, nil)
-	client, err := dockerapi.NewDockerGoClient(factory, &defaultConfig)
-	assert.NoError(t, err)
+	// Docker SDK tests
+	mockDockerSDK := mock_sdkclient.NewMockClient(ctrl)
+	mockDockerSDK.EXPECT().Ping(gomock.Any()).Return(types.Ping{}, nil)
+	sdkFactory := mock_sdkclientfactory.NewMockFactory(ctrl)
+	sdkFactory.EXPECT().GetDefaultClient().AnyTimes().Return(mockDockerSDK, nil)
 
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
+	client, err := dockerapi.NewDockerGoClient(factory, sdkFactory, &defaultConfig, ctx)
+	assert.NoError(t, err)
 	mockDocker.EXPECT().InspectImage(pauseName+":"+pauseTag).Return(
 		nil, errors.New("error"))
 
@@ -129,13 +160,22 @@ func TestGetPauseContainerHappyPath(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	// go-dockerclient tests
 	mockDocker := mock_dockeriface.NewMockClient(ctrl)
 	mockDocker.EXPECT().Ping().AnyTimes().Return(nil)
 	factory := mock_clientfactory.NewMockFactory(ctrl)
 	factory.EXPECT().GetDefaultClient().AnyTimes().Return(mockDocker, nil)
-	client, err := dockerapi.NewDockerGoClient(factory, &defaultConfig)
-	assert.NoError(t, err)
+	// Docker SDK tests
+	mockDockerSDK := mock_sdkclient.NewMockClient(ctrl)
+	mockDockerSDK.EXPECT().Ping(gomock.Any()).Return(types.Ping{}, nil)
+	sdkFactory := mock_sdkclientfactory.NewMockFactory(ctrl)
+	sdkFactory.EXPECT().GetDefaultClient().AnyTimes().Return(mockDockerSDK, nil)
 
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
+	client, err := dockerapi.NewDockerGoClient(factory, sdkFactory, &defaultConfig, ctx)
+	assert.NoError(t, err)
 	mockDocker.EXPECT().InspectImage(pauseName+":"+pauseTag).Return(nil, nil)
 
 	_, err = getPauseContainerImage(pauseName, pauseTag, client)

--- a/agent/stats/common_test.go
+++ b/agent/stats/common_test.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"testing"
 	"time"
+	"context"
 
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
@@ -26,8 +27,6 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/statechange"
 	"github.com/aws/amazon-ecs-agent/agent/statemanager"
 	"github.com/aws/amazon-ecs-agent/agent/tcs/model/ecstcs"
-
-	"context"
 
 	"github.com/aws/aws-sdk-go/aws"
 	docker "github.com/fsouza/go-dockerclient"

--- a/agent/stats/common_unix_test.go
+++ b/agent/stats/common_unix_test.go
@@ -21,14 +21,17 @@ import (
 
 	ecsengine "github.com/aws/amazon-ecs-agent/agent/engine"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
-
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/clientfactory"
+	"github.com/aws/amazon-ecs-agent/agent/dockerclient/sdkclientfactory"
+
 	docker "github.com/fsouza/go-dockerclient"
 )
 
 var (
-	testImageName = "amazon/amazon-ecs-gremlin:make"
-	endpoint      = utils.DefaultIfBlank(os.Getenv(ecsengine.DockerEndpointEnvVariable), ecsengine.DockerDefaultEndpoint)
-	client, _     = docker.NewClient(endpoint)
-	clientFactory = clientfactory.NewFactory(context.TODO(), endpoint)
+	testImageName    = "amazon/amazon-ecs-gremlin:make"
+	endpoint         = utils.DefaultIfBlank(os.Getenv(ecsengine.DockerEndpointEnvVariable), ecsengine.DockerDefaultEndpoint)
+	client, _        = docker.NewClient(endpoint)
+	clientFactory    = clientfactory.NewFactory(context.TODO(), endpoint)
+	sdkClientFactory = sdkclientfactory.NewFactory(context.TODO(), endpoint)
+	ctx              = context.TODO()
 )

--- a/agent/stats/common_windows_test.go
+++ b/agent/stats/common_windows_test.go
@@ -21,14 +21,17 @@ import (
 
 	ecsengine "github.com/aws/amazon-ecs-agent/agent/engine"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
-
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/clientfactory"
+	"github.com/aws/amazon-ecs-agent/agent/dockerclient/sdkclientfactory"
+
 	docker "github.com/fsouza/go-dockerclient"
 )
 
 var (
-	testImageName = "amazon/amazon-ecs-stats:make"
-	endpoint      = utils.DefaultIfBlank(os.Getenv(ecsengine.DockerEndpointEnvVariable), "npipe:////./pipe/docker_engine")
-	client, _     = docker.NewClient(endpoint)
-	clientFactory = clientfactory.NewFactory(context.TODO(), endpoint)
+	testImageName    = "amazon/amazon-ecs-stats:make"
+	endpoint         = utils.DefaultIfBlank(os.Getenv(ecsengine.DockerEndpointEnvVariable), "npipe:////./pipe/docker_engine")
+	client, _        = docker.NewClient(endpoint)
+	clientFactory    = clientfactory.NewFactory(context.TODO(), endpoint)
+	sdkClientFactory = sdkclientfactory.NewFactory(context.TODO(), endpoint)
+	ctx              = context.TODO()
 )

--- a/agent/stats/container.go
+++ b/agent/stats/container.go
@@ -16,7 +16,6 @@ package stats
 import (
 	"errors"
 	"time"
-
 	"context"
 
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"

--- a/agent/stats/engine_integ_test.go
+++ b/agent/stats/engine_integ_test.go
@@ -35,7 +35,7 @@ import (
 var dockerClient dockerapi.DockerClient
 
 func init() {
-	dockerClient, _ = dockerapi.NewDockerGoClient(clientFactory, &cfg)
+	dockerClient, _ = dockerapi.NewDockerGoClient(clientFactory, sdkClientFactory, &cfg, ctx)
 }
 
 func createRunningTask() *apitask.Task {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Adds support for Docker SDK Clients to exists side-by-side with go-dockerclient Clients.
This will allow the API calls to be migrated one-by-one until all of the API calls come from the Docker SDK Client. At this point, the go-dockerclient Clients will be removed.

### Implementation details
<!-- How are the changes implemented? -->

 - An **sdkClientFactory** field was added to the dockerGoClient struct to allow Docker SDK Clients to be generated. 
   - The DockerGoClient abstraction over both the go-dockerclient clientfactory and the Docker SDK clientfactory will make it easier to swap which client is making the API call at the function level.
   - This is because the dockerGoClients implement the DockerClient interface, the functions being migrated.
- To create these new dockerGoClients, a parameter for the new **sdkClientFactory** was added to **NewDockerGoClient()** to pass in when creating the dockerGoClient.
   - Code for NewDockerGoClient() was written with separation between go-dockerclient and Docker SDK calls to make it easier to remove go-dockerclient later on.
  - At every place "NewDockerGoClient" is called, the argument for sdkClientFactory was added, and the mocks for these packages were adjusted likewise.
   - Passing in the new arguments for sdkClientFactory was simple as both clientFactory and sdkClientFactory take in the same arguments.
- sdkDockerClient() was added as a getter method for the sdkClients
- A test for Ping() was added for the Docker SDK clients as it is called in NewDockerGoClient().

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
--> Feature - Support for Docker SDK Clients

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
