### PR TITLE
change supported cipher suites for agent client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.19.0-dev
+* Feature - Private registry can be authenticated through task definition using AWS Secrets Manager [#1427](https://github.com/aws/amazon-ecs-agent/pull/1427)
+
 ## 1.18.0
 * Feature - Configurable container image pull behavior [#1348](https://github.com/aws/amazon-ecs-agent/pull/1348)
 * Bug - Fixed a bug where Docker Version() API never returns by adding a timeout [#1363](https://github.com/aws/amazon-ecs-agent/pull/1363)

--- a/agent/httpclient/httpclient.go
+++ b/agent/httpclient/httpclient.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/version"
+	"github.com/aws/amazon-ecs-agent/agent/utils/agent_tls"
 )
 
 const defaultTimeout = 10 * time.Minute
@@ -67,8 +68,11 @@ func New(timeout time.Duration, insecureSkipVerify bool) *http.Client {
 		}).Dial,
 		TLSHandshakeTimeout: 10 * time.Second,
 	}
+
+	transport.TLSClientConfig = &tls.Config{}
+	agent_tls.SetCipherCuites(transport.TLSClientConfig)
 	if insecureSkipVerify {
-		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+		transport.TLSClientConfig.InsecureSkipVerify = true
 	}
 	client := &http.Client{
 		Transport: &ecsRoundTripper{insecureSkipVerify, transport},

--- a/agent/httpclient/httpclient_test.go
+++ b/agent/httpclient/httpclient_test.go
@@ -1,0 +1,16 @@
+package httpclient
+
+import (
+	"testing"
+	"time"
+	"github.com/stretchr/testify/assert"
+	"github.com/aws/amazon-ecs-agent/agent/utils/agent_tls"
+	"net/http"
+)
+
+func TestNewHttpClient(t *testing.T) {
+	expectedResult := New(time.Duration(10),true)
+	transport := expectedResult.Transport.(*ecsRoundTripper)
+	assert.Equal(t, transport.transport.(*http.Transport).TLSClientConfig.CipherSuites, agent_tls.SupportedCipherSuites)
+	assert.Equal(t, transport.transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify, true)
+}

--- a/agent/utils/agent_tls/agent_tls.go
+++ b/agent/utils/agent_tls/agent_tls.go
@@ -1,0 +1,11 @@
+package agent_tls
+
+import (
+	"crypto/tls"
+)
+// Only support a subset of ciphers, corresponding cipher suite names can be found here: https://golang.org/pkg/crypto/tls/#Config
+var SupportedCipherSuites = []uint16{0xc02f, 0xc027, 0xc013, 0xc030, 0xc014, 0x009c, 0x003c, 0x002f, 0x009d, 0x0035}
+
+func SetCipherCuites(config *tls.Config) {
+	config.CipherSuites = SupportedCipherSuites
+}

--- a/agent/wsclient/client.go
+++ b/agent/wsclient/client.go
@@ -42,6 +42,7 @@ import (
 	"github.com/cihub/seelog"
 	"github.com/gorilla/websocket"
 	"github.com/pkg/errors"
+	"github.com/aws/amazon-ecs-agent/agent/utils/agent_tls"
 )
 
 const (
@@ -159,6 +160,7 @@ func (cs *ClientServerImpl) Connect() error {
 
 	timeoutDialer := &net.Dialer{Timeout: wsConnectTimeout}
 	tlsConfig := &tls.Config{ServerName: parsedURL.Host, InsecureSkipVerify: cs.AgentConfig.AcceptInsecureCert}
+	agent_tls.SetCipherCuites(tlsConfig)
 
 	// Ensure that NO_PROXY gets set
 	noProxy := os.Getenv("NO_PROXY")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary

### Implementation details

### Testing

### Description for the changelog

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
