### PR TITLE
dockerapi: Migrated VolumeCreate and VolumeInspect to Docker SDK

### DIFF
--- a/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
+++ b/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
@@ -93,9 +93,9 @@ func (mr *MockDockerClientMockRecorder) CreateContainer(arg0, arg1, arg2, arg3, 
 }
 
 // CreateVolume mocks base method
-func (m *MockDockerClient) CreateVolume(arg0 context.Context, arg1, arg2 string, arg3, arg4 map[string]string, arg5 time.Duration) dockerapi.VolumeResponse {
+func (m *MockDockerClient) CreateVolume(arg0 context.Context, arg1, arg2 string, arg3, arg4 map[string]string, arg5 time.Duration) dockerapi.SDKVolumeResponse {
 	ret := m.ctrl.Call(m, "CreateVolume", arg0, arg1, arg2, arg3, arg4, arg5)
-	ret0, _ := ret[0].(dockerapi.VolumeResponse)
+	ret0, _ := ret[0].(dockerapi.SDKVolumeResponse)
 	return ret0
 }
 
@@ -156,9 +156,9 @@ func (mr *MockDockerClientMockRecorder) InspectImage(arg0 interface{}) *gomock.C
 }
 
 // InspectVolume mocks base method
-func (m *MockDockerClient) InspectVolume(arg0 context.Context, arg1 string, arg2 time.Duration) dockerapi.VolumeResponse {
+func (m *MockDockerClient) InspectVolume(arg0 context.Context, arg1 string, arg2 time.Duration) dockerapi.SDKVolumeResponse {
 	ret := m.ctrl.Call(m, "InspectVolume", arg0, arg1, arg2)
-	ret0, _ := ret[0].(dockerapi.VolumeResponse)
+	ret0, _ := ret[0].(dockerapi.SDKVolumeResponse)
 	return ret0
 }
 

--- a/agent/dockerclient/dockerapi/types.go
+++ b/agent/dockerclient/dockerapi/types.go
@@ -21,6 +21,7 @@ import (
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	apierrors "github.com/aws/amazon-ecs-agent/agent/api/errors"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/docker/docker/api/types"
 	docker "github.com/fsouza/go-dockerclient"
 )
 
@@ -83,8 +84,15 @@ type ListContainersResponse struct {
 }
 
 // VolumeResponse wrapper for CreateVolume and InspectVolume
+// TODO Remove type when migration is complete
 type VolumeResponse struct {
 	DockerVolume *docker.Volume
+	Error        error
+}
+
+// VolumeResponse wrapper for CreateVolume for SDK Clients
+type SDKVolumeResponse struct {
+	DockerVolume *types.Volume
 	Error        error
 }
 

--- a/agent/taskresource/volume/dockervolume_test.go
+++ b/agent/taskresource/volume/dockervolume_test.go
@@ -25,7 +25,8 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi/mocks"
 	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
-	docker "github.com/fsouza/go-dockerclient"
+
+	"github.com/docker/docker/api/types"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 )
@@ -46,8 +47,8 @@ func TestCreateSuccess(t *testing.T) {
 	}
 
 	mockClient.EXPECT().CreateVolume(gomock.Any(), name, driver, driverOptions, nil, dockerapi.CreateVolumeTimeout).Return(
-		dockerapi.VolumeResponse{
-			DockerVolume: &docker.Volume{Name: name, Driver: driver, Mountpoint: mountPoint, Labels: nil},
+		dockerapi.SDKVolumeResponse{
+			DockerVolume: &types.Volume{Name: name, Driver: driver, Mountpoint: mountPoint, Labels: nil},
 			Error:        nil,
 		})
 
@@ -74,7 +75,7 @@ func TestCreateError(t *testing.T) {
 	}
 
 	mockClient.EXPECT().CreateVolume(gomock.Any(), name, driver, nil, labels, dockerapi.CreateVolumeTimeout).Return(
-		dockerapi.VolumeResponse{
+		dockerapi.SDKVolumeResponse{
 			DockerVolume: nil,
 			Error:        errors.New("some error"),
 		})
@@ -137,8 +138,8 @@ func TestApplyTransitionForTaskScopeVolume(t *testing.T) {
 
 	gomock.InOrder(
 		mockClient.EXPECT().CreateVolume(gomock.Any(), name, driver, driverOptions, labels, dockerapi.CreateVolumeTimeout).Times(1).Return(
-			dockerapi.VolumeResponse{
-				DockerVolume: &docker.Volume{Name: name, Driver: driver, Mountpoint: mountPoint, Labels: nil},
+			dockerapi.SDKVolumeResponse{
+				DockerVolume: &types.Volume{Name: name, Driver: driver, Mountpoint: mountPoint, Labels: nil},
 				Error:        nil,
 			}),
 	)
@@ -160,8 +161,8 @@ func TestApplyTransitionForSharedScopeVolume(t *testing.T) {
 
 	gomock.InOrder(
 		mockClient.EXPECT().CreateVolume(gomock.Any(), name, driver, nil, nil, dockerapi.CreateVolumeTimeout).Times(1).Return(
-			dockerapi.VolumeResponse{
-				DockerVolume: &docker.Volume{Name: name, Driver: driver, Mountpoint: mountPoint, Labels: nil},
+			dockerapi.SDKVolumeResponse{
+				DockerVolume: &types.Volume{Name: name, Driver: driver, Mountpoint: mountPoint, Labels: nil},
 				Error:        nil,
 			}),
 		mockClient.EXPECT().RemoveVolume(gomock.Any(), name, dockerapi.RemoveVolumeTimeout).Times(0),


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->
### Summary
<!-- What does this pull request do? -->
Migration for VolumeCreate and VolumeInspect from go-dockerclient to the DockerSDK
### Implementation details
<!-- How are the changes implemented? -->
Changes were implemented by refactoring the DockerClient functions, VolumeCreate and VolumeInspect, with the Docker SDK API calls and introducing a few change to DockerClient interface. The tests were changed to test the new SDK API calls.

The DockerClient interface has to be changed slightly to accommodate returning a Docker SDK Volume type as this was simpler than converting between go-dockerclient Volume to Docker SDK Volume type within the function. This was mainly because there are only a handful of places in the code base that rely on this function's output type.

The mocks had to be regenerated for the new DockerClient interface as well.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enhancement - VolumeCreate and VolumeInspect migrated to Docker SDK

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
