### PR TITLE
acs: add an empty task in TaskStateChange for unrecognized tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.21.0-dev
+* Bug - Fixed a bug where unrecognized task cannot be stopped [#1467](https://github.com/aws/amazon-ecs-agent/pull/1467)
+
 ## 1.20.1
 * Bug - Fixed a bug where the agent couldn't be upgraded if there are tasks that
   use volumes in the task definition on the instance

--- a/agent/acs/handler/acs_handler.go
+++ b/agent/acs/handler/acs_handler.go
@@ -16,13 +16,12 @@
 package handler
 
 import (
+	"context"
 	"io"
 	"net/url"
 	"strconv"
 	"strings"
 	"time"
-
-	"context"
 
 	acsclient "github.com/aws/amazon-ecs-agent/agent/acs/client"
 	"github.com/aws/amazon-ecs-agent/agent/acs/model/ecsacs"

--- a/agent/acs/handler/payload_handler.go
+++ b/agent/acs/handler/payload_handler.go
@@ -337,6 +337,10 @@ func (payloadHandler *payloadRequestHandler) handleUnrecognizedTask(task *ecsacs
 		TaskARN: *task.Arn,
 		Status:  apitaskstatus.TaskStopped,
 		Reason:  UnrecognizedTaskError{err}.Error(),
+		// The real task cannot be extracted from payload message, so we send an empty task.
+		// This is necessary because the task handler will not send an event whose
+		// Task is nil.
+		Task: &apitask.Task{},
 	}
 
 	payloadHandler.taskHandler.AddStateChangeEvent(taskEvent, payloadHandler.ecsClient)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Add an empty task in TaskStateChange for unrecognized tasks

This fixes a bug where unrecognized task cannot be stopped

### Implementation details
<!-- How are the changes implemented? -->
Currently when Agent receives a task from ACS, if it's malformed and Agent cannot recognize it, it will be handled by [handleUnrecognizedTask](https://github.com/aws/amazon-ecs-agent/blob/3631cb9de33a569d16e7a19d77105beeef8160c2/agent/acs/handler/payload_handler.go#L326) function. The `handleUnrecognizedTask` intends to send a task change event to stop the task, but it fails to do so, because it returns a `TaskStateChange` without a `Task` in it, and this will be discarded by taskHandler, as it should not be sent according to [taskShouldBeSent](https://github.com/aws/amazon-ecs-agent/blob/3631cb9de33a569d16e7a19d77105beeef8160c2/agent/eventhandler/task_handler_types.go#L81)

So this fix is to add an empty task in the result of `handleUnrecognizedTask` so that the task change will not be discarded.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Bug - Fixed a bug where unrecognized task cannot be stopped

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
