### PR TITLE
dockerapi: Migrated VolumeRemove and APIVersion to Docker SDK

### DIFF
--- a/agent/dockerclient/dockerapi/docker_client.go
+++ b/agent/dockerclient/dockerapi/docker_client.go
@@ -1181,12 +1181,12 @@ func (dg *dockerGoClient) RemoveVolume(ctx context.Context, name string, timeout
 }
 
 func (dg *dockerGoClient) removeVolume(ctx context.Context, name string) error {
-	client, err := dg.dockerClient()
+	client, err := dg.sdkDockerClient()
 	if err != nil {
 		return &CannotGetDockerClientError{version: dg.version, err: err}
 	}
 
-	ok := client.RemoveVolume(name)
+	ok := client.VolumeRemove(ctx, name, false)
 	if ok != nil {
 		return &CannotRemoveVolumeError{err}
 	}
@@ -1266,11 +1266,11 @@ func (dg *dockerGoClient) listPlugins(ctx context.Context) ListPluginsResponse {
 
 // APIVersion returns the client api version
 func (dg *dockerGoClient) APIVersion() (dockerclient.DockerVersion, error) {
-	client, err := dg.dockerClient()
+	client, err := dg.sdkDockerClient()
 	if err != nil {
 		return "", err
 	}
-	return dg.clientFactory.FindClientAPIVersion(client), nil
+	return dg.sdkClientFactory.FindClientAPIVersion(client), nil
 }
 
 // Stats returns a channel of *docker.Stats entries for the container.

--- a/agent/dockerclient/dockerapi/docker_client_test.go
+++ b/agent/dockerclient/dockerapi/docker_client_test.go
@@ -1445,12 +1445,13 @@ func TestInspectVolume(t *testing.T) {
 }
 
 func TestRemoveVolumeTimeout(t *testing.T) {
-	mockDocker, _, client, _, _, _, done := dockerClientSetup(t)
+	_, mockDockerSDK, client, _, _, _, done := dockerClientSetup(t)
 	defer done()
 
 	wait := &sync.WaitGroup{}
 	wait.Add(1)
-	mockDocker.EXPECT().RemoveVolume(gomock.Any()).Do(func(x interface{}) {
+	mockDockerSDK.EXPECT().VolumeRemove(gomock.Any(),"name", false).Do(func(ctx context.Context,
+		x interface{}, y bool) {
 		wait.Wait()
 	}).MaxTimes(1)
 	ctx, cancel := context.WithCancel(context.TODO())
@@ -1462,10 +1463,10 @@ func TestRemoveVolumeTimeout(t *testing.T) {
 }
 
 func TestRemoveVolumeError(t *testing.T) {
-	mockDocker, _, client, _, _, _, done := dockerClientSetup(t)
+	_, mockDockerSDK, client, _, _, _, done := dockerClientSetup(t)
 	defer done()
 
-	mockDocker.EXPECT().RemoveVolume(gomock.Any()).Return(errors.New("some docker error"))
+	mockDockerSDK.EXPECT().VolumeRemove(gomock.Any(), "name", false).Return(errors.New("some docker error"))
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	err := client.RemoveVolume(ctx, "name", RemoveVolumeTimeout)
@@ -1473,12 +1474,12 @@ func TestRemoveVolumeError(t *testing.T) {
 }
 
 func TestRemoveVolume(t *testing.T) {
-	mockDocker, _, client, _, _, _, done := dockerClientSetup(t)
+	_, mockDockerSDK, client, _, _, _, done := dockerClientSetup(t)
 	defer done()
 
 	volumeName := "volumeName"
 
-	mockDocker.EXPECT().RemoveVolume(volumeName).Return(nil)
+	mockDockerSDK.EXPECT().VolumeRemove(gomock.Any(), volumeName, false).Return(nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	err := client.RemoveVolume(ctx, volumeName, RemoveVolumeTimeout)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->
### Summary
<!-- What does this pull request do? -->
Migration for VolumeRemove and APIVersion from go-dockerclient to the DockerSDK

### Implementation details
<!-- How are the changes implemented? -->
Changes were implemented by swapping API calls to new SDK Client. All changes could be done under the DockerClient interface making this migration fairly straightforward.

The VolumeRemove API call takes in a boolean for the force flag to remove a volume. Go-dockerclient did not support this flag, so 'false' is used as a placeholder.
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
--> Enhancement - VolumeRemove and APIVersion migrated to Docker SDK

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
