### PR TITLE
handlers/v1: add json tags to response structs

### DIFF
--- a/agent/handlers/v1/response.go
+++ b/agent/handlers/v1/response.go
@@ -31,11 +31,11 @@ type MetadataResponse struct {
 
 // TaskResponse is the schema for the task response JSON object
 type TaskResponse struct {
-	Arn           string
-	DesiredStatus string `json:",omitempty"`
-	KnownStatus   string
-	Family        string
-	Version       string
+	Arn           string `json:"Arn,omitempty"`
+	DesiredStatus string `json:"omitempty"`
+	KnownStatus   string `json:"KnownStatus,omitempty"`
+	Family        string `json:"Family,omitempty"`
+	Version       string `json:"Version,omitempty"`
 	Containers    []ContainerResponse
 }
 
@@ -46,19 +46,19 @@ type TasksResponse struct {
 
 // ContainerResponse is the schema for the container response JSON object
 type ContainerResponse struct {
-	DockerID   string
-	DockerName string
-	Name       string
-	Ports      []PortResponse              `json:",omitempty"`
-	Networks   []containermetadata.Network `json:",omitempty"`
+	DockerID   string                      `json:"DockerId,omitempty"`
+	DockerName string                      `json:"DockerName,omitempty"`
+	Name       string                      `json:"Name,omitempty"`
+	Ports      []PortResponse              `json:"omitempty"`
+	Networks   []containermetadata.Network `json:"omitempty"`
 }
 
 // PortResponse defines the schema for portmapping response JSON
 // object.
 type PortResponse struct {
-	ContainerPort uint16
-	Protocol      string
-	HostPort      uint16 `json:",omitempty"`
+	ContainerPort uint16 `json:"ContainerPort,omitempty"`
+	Protocol      string `json:"Protocol,omitempty"`
+	HostPort      uint16 `json:"omitempty"`
 }
 
 // NewTaskResponse creates a TaskResponse for a task.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [ ] Builds on Linux (`make release`)
- [ ] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [ ] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
