### PR TITLE
Enforce minimum docker version support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.20.0-dev
+* Feature - Add support for Docker volume plugins
+* Enhancement - Replace the empty container with Docker local volume
+* Enhancement - Deprecate support for Docker version older than 1.9.0 [#1477](https://github.com/aws/amazon-ecs-agent/pull/1477)
+
 ## 1.19.0
 * Feature - Private registry can be authenticated through task definition using AWS Secrets Manager [#1427](https://github.com/aws/amazon-ecs-agent/pull/1427)
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ The Amazon ECS Container Agent is a component of Amazon Elastic Container Servic
 The best source of information on running this software is the
 [Amazon ECS documentation](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ECS_agent.html).
 
+Please note that from Agent version 1.20.0, Minimum required Docker version is 1.9.0, corresponding to Docker API version 1.21. For more information, please visit [Amazon ECS Container Agent Versions](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/container_agent_versions.html).
+
 ### On the Amazon Linux AMI
 
 On the [Amazon Linux AMI](https://aws.amazon.com/amazon-linux-ami/), we provide an installable RPM which can be used via

--- a/agent/app/agent_unix_test.go
+++ b/agent/app/agent_unix_test.go
@@ -70,6 +70,7 @@ func TestDoStartHappyPath(t *testing.T) {
 	// These calls are expected to happen, but cannot be ordered as they are
 	// invoked via go routines, which will lead to occasional test failues
 	dockerClient.EXPECT().Version(gomock.Any(), gomock.Any()).AnyTimes()
+	dockerClient.EXPECT().SupportedVersions().Return(apiVersions)
 	imageManager.EXPECT().StartImageCleanupProcess(gomock.Any()).MaxTimes(1)
 	mockCredentialsProvider.EXPECT().IsExpired().Return(false).AnyTimes()
 	dockerClient.EXPECT().ListContainers(gomock.Any(), gomock.Any(), gomock.Any()).Return(
@@ -144,6 +145,7 @@ func TestDoStartTaskENIHappyPath(t *testing.T) {
 	// invoked via go routines, which will lead to occasional test failues
 	mockCredentialsProvider.EXPECT().IsExpired().Return(false).AnyTimes()
 	dockerClient.EXPECT().Version(gomock.Any(), gomock.Any()).AnyTimes()
+	dockerClient.EXPECT().SupportedVersions().Return(apiVersions)
 	dockerClient.EXPECT().ListContainers(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		dockerapi.ListContainersResponse{}).AnyTimes()
 	imageManager.EXPECT().StartImageCleanupProcess(gomock.Any()).MaxTimes(1)
@@ -477,6 +479,7 @@ func TestDoStartCgroupInitHappyPath(t *testing.T) {
 	containerChangeEvents := make(chan dockerapi.DockerContainerChangeEvent)
 
 	dockerClient.EXPECT().Version(gomock.Any(), gomock.Any()).AnyTimes()
+	dockerClient.EXPECT().SupportedVersions().Return(apiVersions)
 	imageManager.EXPECT().StartImageCleanupProcess(gomock.Any()).MaxTimes(1)
 	mockCredentialsProvider.EXPECT().IsExpired().Return(false).AnyTimes()
 
@@ -545,6 +548,7 @@ func TestDoStartCgroupInitErrorPath(t *testing.T) {
 	discoverEndpointsInvoked.Add(2)
 
 	dockerClient.EXPECT().Version(gomock.Any(), gomock.Any()).AnyTimes()
+	dockerClient.EXPECT().SupportedVersions().Return(apiVersions)
 	imageManager.EXPECT().StartImageCleanupProcess(gomock.Any()).MaxTimes(1)
 	mockCredentialsProvider.EXPECT().IsExpired().Return(false).AnyTimes()
 

--- a/agent/app/agent_windows_test.go
+++ b/agent/app/agent_windows_test.go
@@ -291,6 +291,8 @@ func TestDoStartTaskLimitsFail(t *testing.T) {
 		ec2MetadataClient:     ec2.NewBlackholeEC2MetadataClient(),
 	}
 
+	dockerClient.EXPECT().SupportedVersions().Return(apiVersions)
+
 	exitCode := agent.doStart(eventstream.NewEventStream("events", ctx),
 		credentialsManager, state, imageManager, client)
 	assert.Equal(t, exitcodes.ExitTerminal, exitCode)

--- a/agent/dockerclient/clientfactory/versionsupport_unix.go
+++ b/agent/dockerclient/clientfactory/versionsupport_unix.go
@@ -51,5 +51,5 @@ func getAgentVersions() []dockerclient.DockerVersion {
 
 // getDefaultVersion will return the default Docker API version for linux
 func getDefaultVersion() dockerclient.DockerVersion {
-	return dockerclient.Version_1_17
+	return dockerclient.Version_1_21
 }


### PR DESCRIPTION
…revious versions

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Deprecate support for docker version older than 1.9.0, by checking for Docker API 1.21 support. Using API version instead of Docker version since it's been more consistent historically.

### Implementation details
During agent startup, check for docker api version and return ExitTerminal if 1.21 is not supported. See https://docs.docker.com/develop/sdk/#api-version-matrix (docker 1.9.0 corresponds to api 1.21). 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
