### PR TITLE
dockerapi: Migrated ImageInspect, ImageLoad, and ImageRemove to Docke…

### DIFF
--- a/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
+++ b/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
@@ -27,6 +27,7 @@ import (
 	status "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	dockerclient "github.com/aws/amazon-ecs-agent/agent/dockerclient"
 	dockerapi "github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
+	types "github.com/docker/docker/api/types"
 	go_dockerclient "github.com/fsouza/go-dockerclient"
 	gomock "github.com/golang/mock/gomock"
 )
@@ -143,9 +144,9 @@ func (mr *MockDockerClientMockRecorder) InspectContainer(arg0, arg1, arg2 interf
 }
 
 // InspectImage mocks base method
-func (m *MockDockerClient) InspectImage(arg0 string) (*go_dockerclient.Image, error) {
+func (m *MockDockerClient) InspectImage(arg0 string) (*types.ImageInspect, error) {
 	ret := m.ctrl.Call(m, "InspectImage", arg0)
-	ret0, _ := ret[0].(*go_dockerclient.Image)
+	ret0, _ := ret[0].(*types.ImageInspect)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/agent/engine/docker_image_manager_test.go
+++ b/agent/engine/docker_image_manager_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/engine/image"
 	"github.com/aws/amazon-ecs-agent/agent/statemanager"
 
-	docker "github.com/fsouza/go-dockerclient"
+	"github.com/docker/docker/api/types"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -58,7 +58,7 @@ func TestImagePullRemoveDeadlock(t *testing.T) {
 		Name:  "sleep",
 		Image: "busybox",
 	}
-	sleepContainerImageInspected := &docker.Image{
+	sleepContainerImageInspected := &types.ImageInspect{
 		ID: "sha256:qwerty",
 	}
 
@@ -109,7 +109,7 @@ func TestAddAndRemoveContainerToImageStateReferenceHappyPath(t *testing.T) {
 	}
 	sourceImageState.AddImageName(container.Image)
 	imageManager.(*dockerImageManager).addImageState(sourceImageState)
-	imageInspected := &docker.Image{
+	imageInspected := &types.ImageInspect{
 		ID: "sha256:qwerty",
 	}
 	client.EXPECT().InspectImage(container.Image).Return(imageInspected, nil)
@@ -194,7 +194,7 @@ func TestRecordContainerReferenceWithNoImageName(t *testing.T) {
 		PulledAt: time.Now(),
 	}
 	imageManager.addImageState(sourceImageState)
-	imageInspected := &docker.Image{
+	imageInspected := &types.ImageInspect{
 		ID: "sha256:qwerty",
 	}
 	client.EXPECT().InspectImage(container.Image).Return(imageInspected, nil).AnyTimes()
@@ -350,7 +350,7 @@ func TestRemoveContainerReferenceFromInvalidImageState(t *testing.T) {
 	container := &apicontainer.Container{
 		Image: "myContainerImage",
 	}
-	imageInspected := &docker.Image{
+	imageInspected := &types.ImageInspect{
 		ID: "sha256:qwerty",
 	}
 	client.EXPECT().InspectImage(container.Image).Return(imageInspected, nil).AnyTimes()
@@ -421,7 +421,7 @@ func TestRemoveContainerReferenceFromImageStateWithNoReference(t *testing.T) {
 		PulledAt: time.Now(),
 	}
 	imageManager.addImageState(sourceImageState)
-	imageInspected := &docker.Image{
+	imageInspected := &types.ImageInspect{
 		ID: "sha256:qwerty",
 	}
 	client.EXPECT().InspectImage(container.Image).Return(imageInspected, nil).AnyTimes()
@@ -503,7 +503,7 @@ func TestGetCandidateImagesForDeletionImageHasContainerReference(t *testing.T) {
 		PulledAt: time.Now().AddDate(0, -2, 0),
 	}
 	imageManager.addImageState(sourceImageState)
-	imageInspected := &docker.Image{
+	imageInspected := &types.ImageInspect{
 		ID: "sha256:qwerty",
 	}
 	client.EXPECT().InspectImage(container.Image).Return(imageInspected, nil).AnyTimes()
@@ -548,7 +548,7 @@ func TestGetCandidateImagesForDeletionImageHasMoreContainerReferences(t *testing
 		PulledAt: time.Now().AddDate(0, -2, 0),
 	}
 	imageManager.addImageState(sourceImageState)
-	imageInspected := &docker.Image{
+	imageInspected := &types.ImageInspect{
 		ID: "sha256:qwerty",
 	}
 	client.EXPECT().InspectImage(container.Image).Return(imageInspected, nil).AnyTimes()
@@ -666,7 +666,7 @@ func TestRemoveAlreadyExistingImageNameWithDifferentID(t *testing.T) {
 		ImageID: "sha256:qwerty",
 	}
 	sourceImage.Names = append(sourceImage.Names, container.Image)
-	imageInspected := &docker.Image{
+	imageInspected := &types.ImageInspect{
 		ID: "sha256:qwerty",
 	}
 	client.EXPECT().InspectImage(container.Image).Return(imageInspected, nil)
@@ -678,7 +678,7 @@ func TestRemoveAlreadyExistingImageNameWithDifferentID(t *testing.T) {
 		Name:  "testContainer1",
 		Image: "testContainerImage",
 	}
-	imageInspected1 := &docker.Image{
+	imageInspected1 := &types.ImageInspect{
 		ID: "sha256:asdfg",
 	}
 	client.EXPECT().InspectImage(container.Image).Return(imageInspected1, nil)
@@ -713,7 +713,7 @@ func TestImageCleanupHappyPath(t *testing.T) {
 		Name:  "testContainer",
 		Image: "testContainerImage",
 	}
-	imageInspected := &docker.Image{
+	imageInspected := &types.ImageInspect{
 		ID: "sha256:qwerty",
 	}
 	client.EXPECT().InspectImage(container.Image).Return(imageInspected, nil).AnyTimes()
@@ -769,7 +769,7 @@ func TestImageCleanupCannotRemoveImage(t *testing.T) {
 		ImageID: "sha256:qwerty",
 	}
 	sourceImage.Names = append(sourceImage.Names, container.Image)
-	imageInspected := &docker.Image{
+	imageInspected := &types.ImageInspect{
 		ID: "sha256:qwerty",
 	}
 	client.EXPECT().InspectImage(container.Image).Return(imageInspected, nil).AnyTimes()
@@ -822,7 +822,7 @@ func TestImageCleanupRemoveImageById(t *testing.T) {
 		ImageID: "sha256:qwerty",
 	}
 	sourceImage.Names = append(sourceImage.Names, container.Image)
-	imageInspected := &docker.Image{
+	imageInspected := &types.ImageInspect{
 		ID: "sha256:qwerty",
 	}
 	client.EXPECT().InspectImage(container.Image).Return(imageInspected, nil).AnyTimes()
@@ -860,7 +860,7 @@ func TestDeleteImage(t *testing.T) {
 		Name:  "testContainer",
 		Image: "testContainerImage",
 	}
-	imageInspected := &docker.Image{
+	imageInspected := &types.ImageInspect{
 		ID: "sha256:qwerty",
 	}
 	client.EXPECT().InspectImage(container.Image).Return(imageInspected, nil).AnyTimes()
@@ -891,7 +891,7 @@ func TestDeleteImageNotFoundError(t *testing.T) {
 		Name:  "testContainer",
 		Image: "testContainerImage",
 	}
-	imageInspected := &docker.Image{
+	imageInspected := &types.ImageInspect{
 		ID: "sha256:qwerty",
 	}
 	client.EXPECT().InspectImage(container.Image).Return(imageInspected, nil).AnyTimes()
@@ -923,7 +923,7 @@ func TestDeleteImageOtherRemoveImageErrors(t *testing.T) {
 		Name:  "testContainer",
 		Image: "testContainerImage",
 	}
-	imageInspected := &docker.Image{
+	imageInspected := &types.ImageInspect{
 		ID: "sha256:qwerty",
 	}
 	client.EXPECT().InspectImage(container.Image).Return(imageInspected, nil).AnyTimes()
@@ -991,7 +991,7 @@ func TestGetImageStateFromImageName(t *testing.T) {
 		Name:  "testContainer",
 		Image: "testContainerImage",
 	}
-	imageInspected := &docker.Image{
+	imageInspected := &types.ImageInspect{
 		ID: "sha256:qwerty",
 	}
 	client.EXPECT().InspectImage(container.Image).Return(imageInspected, nil).AnyTimes()
@@ -1015,7 +1015,7 @@ func TestGetImageStateFromImageNameNoImageState(t *testing.T) {
 		Name:  "testContainer",
 		Image: "testContainerImage",
 	}
-	imageInspected := &docker.Image{
+	imageInspected := &types.ImageInspect{
 		ID: "sha256:qwerty",
 	}
 	client.EXPECT().InspectImage(container.Image).Return(imageInspected, nil).AnyTimes()
@@ -1053,7 +1053,7 @@ func TestConcurrentRemoveUnusedImages(t *testing.T) {
 		ImageID: "sha256:qwerty",
 	}
 	sourceImage.Names = append(sourceImage.Names, container.Image)
-	imageInspected := &docker.Image{
+	imageInspected := &types.ImageInspect{
 		ID: "sha256:qwerty",
 	}
 	client.EXPECT().InspectImage(container.Image).Return(imageInspected, nil).AnyTimes()

--- a/agent/eni/pause/load.go
+++ b/agent/eni/pause/load.go
@@ -18,13 +18,13 @@ import (
 
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
-	docker "github.com/fsouza/go-dockerclient"
+	"github.com/docker/docker/api/types"
 )
 
 // Loader defines an interface for loading the pause container image. This is mostly
 // to facilitate mocking and testing of the LoadImage method
 type Loader interface {
-	LoadImage(ctx context.Context, cfg *config.Config, dockerClient dockerapi.DockerClient) (*docker.Image, error)
+	LoadImage(ctx context.Context, cfg *config.Config, dockerClient dockerapi.DockerClient) (*types.ImageInspect, error)
 }
 
 type loader struct{}

--- a/agent/eni/pause/mocks/load_mocks.go
+++ b/agent/eni/pause/mocks/load_mocks.go
@@ -23,7 +23,7 @@ import (
 
 	config "github.com/aws/amazon-ecs-agent/agent/config"
 	dockerapi "github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
-	go_dockerclient "github.com/fsouza/go-dockerclient"
+	types "github.com/docker/docker/api/types"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -51,9 +51,9 @@ func (m *MockLoader) EXPECT() *MockLoaderMockRecorder {
 }
 
 // LoadImage mocks base method
-func (m *MockLoader) LoadImage(arg0 context.Context, arg1 *config.Config, arg2 dockerapi.DockerClient) (*go_dockerclient.Image, error) {
+func (m *MockLoader) LoadImage(arg0 context.Context, arg1 *config.Config, arg2 dockerapi.DockerClient) (*types.ImageInspect, error) {
 	ret := m.ctrl.Call(m, "LoadImage", arg0, arg1, arg2)
-	ret0, _ := ret[0].(*go_dockerclient.Image)
+	ret0, _ := ret[0].(*types.ImageInspect)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/agent/eni/pause/pause_linux.go
+++ b/agent/eni/pause/pause_linux.go
@@ -23,14 +23,14 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
-	docker "github.com/fsouza/go-dockerclient"
 
 	log "github.com/cihub/seelog"
+	"github.com/docker/docker/api/types"
 	"github.com/pkg/errors"
 )
 
 // LoadImage helps load the pause container image for the agent
-func (*loader) LoadImage(ctx context.Context, cfg *config.Config, dockerClient dockerapi.DockerClient) (*docker.Image, error) {
+func (*loader) LoadImage(ctx context.Context, cfg *config.Config, dockerClient dockerapi.DockerClient) (*types.ImageInspect, error) {
 	log.Debugf("Loading pause container tarball: %s", cfg.PauseContainerTarballPath)
 	if err := loadFromFile(ctx, cfg.PauseContainerTarballPath, dockerClient, os.Default); err != nil {
 		return nil, err
@@ -59,7 +59,7 @@ func loadFromFile(ctx context.Context, path string, dockerClient dockerapi.Docke
 
 }
 
-func getPauseContainerImage(name string, tag string, dockerClient dockerapi.DockerClient) (*docker.Image, error) {
+func getPauseContainerImage(name string, tag string, dockerClient dockerapi.DockerClient) (*types.ImageInspect, error) {
 	imageName := fmt.Sprintf("%s:%s", name, tag)
 	log.Debugf("Inspecting pause container image: %s", imageName)
 

--- a/agent/eni/pause/pause_unsupported.go
+++ b/agent/eni/pause/pause_unsupported.go
@@ -21,12 +21,12 @@ import (
 
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
-	docker "github.com/fsouza/go-dockerclient"
+	"github.com/docker/docker/api/types"
 	"github.com/pkg/errors"
 )
 
 // LoadImage returns UnsupportedPlatformError on the unsupported platform
-func (*loader) LoadImage(ctx context.Context, cfg *config.Config, dockerClient dockerapi.DockerClient) (*docker.Image, error) {
+func (*loader) LoadImage(ctx context.Context, cfg *config.Config, dockerClient dockerapi.DockerClient) (*types.ImageInspect, error) {
 	return nil, NewUnsupportedPlatformError(errors.Errorf(
 		"pause container load: unsupported platform: %s/%s",
 		runtime.GOOS, runtime.GOARCH))


### PR DESCRIPTION
…r SDK

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Migrated ImageInspect, ImageLoad, and ImageRemove to Docker SDK
### Implementation details
<!-- How are the changes implemented? -->
Changes were implemented by swapping API calls to new SDK Client.

 The function header of InspectImage was changed because the scope of files affected was minimal and it provided better readability than converting between the Docker SDK ImageInspect type and the go-dockerclient Image type.

A context field was added to the DockerGoClient struct because the Docker SDK ImageInspectWithRaw API call required a context, and to modify that function header and propagate this change throughout the Agent repository proved to greatly increase scope. 

A context was already required in the NewDockerGoClient() function and this context is passed to ImageInspectWithRaw().

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enhancement - ImageInspect, ImageLoad, and ImageRemove migrated to Docker SDK

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
