### PR TITLE
Expose PlatformFields field in order for it to be persisted in state

### DIFF
--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -157,8 +157,8 @@ type Task struct {
 	// MemoryCPULimitsEnabled to determine if task supports CPU, memory limits
 	MemoryCPULimitsEnabled bool `json:"MemoryCPULimitsEnabled,omitempty"`
 
-	// platformFields consists of fields specific to linux/windows for a task
-	platformFields platformFields
+	// PlatformFields consists of fields specific to linux/windows for a task
+	PlatformFields PlatformFields `json:"PlatformFields,omitempty"`
 
 	// terminalReason should be used when we explicitly move a task to stopped.
 	// This ensures the task object carries some context for why it was explicitly

--- a/agent/api/task/task_linux.go
+++ b/agent/api/task/task_linux.go
@@ -59,8 +59,8 @@ const (
 	bytesPerMegabyte  = 1024 * 1024
 )
 
-// platformFields consists of fields specific to Linux for a task
-type platformFields struct{}
+// PlatformFields consists of fields specific to Linux for a task
+type PlatformFields struct{}
 
 func (task *Task) adjustForPlatform(cfg *config.Config) {
 	task.lock.Lock()

--- a/agent/api/task/task_unsupported.go
+++ b/agent/api/task/task_unsupported.go
@@ -51,8 +51,8 @@ const (
 	bytesPerMegabyte  = 1024 * 1024
 )
 
-// platformFields consists of fields specific to Linux for a task
-type platformFields struct{}
+// PlatformFields consists of fields specific to Linux for a task
+type PlatformFields struct{}
 
 func (task *Task) adjustForPlatform(cfg *config.Config) {
 	task.lock.Lock()

--- a/agent/api/task/task_windows.go
+++ b/agent/api/task/task_windows.go
@@ -37,11 +37,11 @@ const (
 	minimumCPUPercent = 1
 )
 
-// platformFields consists of fields specific to Windows for a task
-type platformFields struct {
-	// cpuUnbounded determines whether a mix of unbounded and bounded CPU tasks
+// PlatformFields consists of fields specific to Windows for a task
+type PlatformFields struct {
+	// CpuUnbounded determines whether a mix of unbounded and bounded CPU tasks
 	// are allowed to run in the instance
-	cpuUnbounded bool
+	CpuUnbounded bool `json:"cpuUnbounded"`
 }
 
 var cpuShareScaleFactor = runtime.NumCPU() * cpuSharesPerCore
@@ -49,10 +49,10 @@ var cpuShareScaleFactor = runtime.NumCPU() * cpuSharesPerCore
 // adjustForPlatform makes Windows-specific changes to the task after unmarshal
 func (task *Task) adjustForPlatform(cfg *config.Config) {
 	task.downcaseAllVolumePaths()
-	platformFields := platformFields{
-		cpuUnbounded: cfg.PlatformVariables.CPUUnbounded,
+	platformFields := PlatformFields{
+		CpuUnbounded: cfg.PlatformVariables.CPUUnbounded,
 	}
-	task.platformFields = platformFields
+	task.PlatformFields = platformFields
 }
 
 // downcaseAllVolumePaths forces all volume paths (host path and container path)
@@ -109,7 +109,7 @@ func (task *Task) overrideDefaultMemorySwappiness(hostConfig *docker.HostConfig)
 // want.  Instead, we convert 0 to 2 to be closer to expected behavior. The
 // reason for 2 over 1 is that 1 is an invalid value (Linux's choice, not Docker's).
 func (task *Task) dockerCPUShares(containerCPU uint) int64 {
-	if containerCPU <= 1 && !task.platformFields.cpuUnbounded {
+	if containerCPU <= 1 && !task.PlatformFields.CpuUnbounded {
 		seelog.Debugf(
 			"Converting CPU shares to allowed minimum of 2 for task arn: [%s] and cpu shares: %d",
 			task.Arn, containerCPU)

--- a/agent/api/task/task_windows_test.go
+++ b/agent/api/task/task_windows_test.go
@@ -295,8 +295,8 @@ func TestCPUPercentBasedOnUnboundedEnabled(t *testing.T) {
 						CPU:  uint(tc.cpu),
 					},
 				},
-				platformFields: platformFields{
-					cpuUnbounded: tc.cpuUnbounded,
+				PlatformFields: PlatformFields{
+					CpuUnbounded: tc.cpuUnbounded,
 				},
 			}
 

--- a/agent/statemanager/state_manager.go
+++ b/agent/statemanager/state_manager.go
@@ -64,7 +64,8 @@ const (
 	//  b)Remove `AppliedStatus` field form 'apicontainer.Container'
 	// 12) Deprecate 'TransitionDependencySet' and add new 'TransitionDependenciesMap' in 'apicontainer.Container'
 	// 13) Add 'resources' field to 'api.task.task'
-	ECSDataVersion = 13
+	// 14) Add 'PlatformFields' field to 'api.task.task'
+	ECSDataVersion = 14
 
 	// ecsDataFile specifies the filename in the ECS_DATADIR
 	ecsDataFile = "ecs_agent_data.json"


### PR DESCRIPTION
### Summary
We run windows clusters with the `ECS_ENABLE_CPU_UNBOUNDED_WINDOWS_WORKAROUND` environment variable. We also reboot our instances in order to install some software when we start them. When rebooting, the tasks that have already been received by the instance are persisted to disk but the variable where `ECS_ENABLE_CPU_UNBOUNDED_WINDOWS_WORKAROUND` is not exposed in the JSON. These tasks are therefore restarted with 2 CPU units instead of 0 (unbounded). PlatformFields must be persisted in order to maintain consistent behavior.

Thanks

### Implementation details
Converted PlatformFields to a public attribute and added json field tags.

### Testing
Runs on our ECS clusters

- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
