### PR TITLE
dockerapi: Migrated ContainerStart to Docker SDK

### DIFF
--- a/agent/dockerclient/dockerapi/docker_client.go
+++ b/agent/dockerclient/dockerapi/docker_client.go
@@ -41,6 +41,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/utils/ttime"
 
 	"github.com/cihub/seelog"
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/volume"
 	docker "github.com/fsouza/go-dockerclient"
 )
@@ -629,12 +630,12 @@ func (dg *dockerGoClient) StartContainer(ctx context.Context, id string, timeout
 }
 
 func (dg *dockerGoClient) startContainer(ctx context.Context, id string) DockerContainerMetadata {
-	client, err := dg.dockerClient()
+	client, err := dg.sdkDockerClient()
 	if err != nil {
 		return DockerContainerMetadata{Error: CannotGetDockerClientError{version: dg.version, err: err}}
 	}
 
-	err = client.StartContainerWithContext(id, nil, ctx)
+	err = client.ContainerStart(ctx, id, types.ContainerStartOptions{} )
 	metadata := dg.containerMetadata(ctx, id)
 	if err != nil {
 		metadata.Error = CannotStartContainerError{err}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Migration for ContainerStart to the Docker SDK
### Implementation details
<!-- How are the changes implemented? -->
- Changes were implemented by swapping API calls to new SDK Client. 
- ContainerStart() takes in a ContainerStartOptions{} that can take in two flags, --checkpoint and --checkpoint-dir,  that are both experimental daemon options and not supported by the go-dockerclient.  
- All changes could be done under the DockerClient interface making this migration fairly straightforward.

Documentation for experimental daemon options for ContainerStart:
https://docs.docker.com/engine/reference/commandline/container_start/#description

Link to branch:
https://github.com/kavoor/amazon-ecs-agent/commits/containerStart

The tests were updated to allow the mock of the SDK client to call ContainerStart. 
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->

- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enhancement - ContainerStart migrated to Docker SDK
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
