### PR TITLE
test: add functional test for agent introspection endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,6 @@ _bin/
 /misc/pause-container/pause
 *-stamp
 /.idea/
+/misc/agent-introspection-validator/agent-introspection-validator
 /misc/taskmetadata-validator/taskmetadata-validator
 /bin

--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ test-artifacts-linux: $(LINUX_ARTIFACTS_TARGETS)
 test-artifacts: test-artifacts-windows test-artifacts-linux
 
 # Run our 'test' registry needed for integ and functional tests
-test-registry: netkitten volumes-test squid awscli image-cleanup-test-images fluentd taskmetadata-validator
+test-registry: netkitten volumes-test squid awscli image-cleanup-test-images fluentd agent-introspection-validator taskmetadata-validator
 	@./scripts/setup-test-registry
 
 test-in-docker:
@@ -242,7 +242,7 @@ volumes-test:
 
 # TODO, replace this with a build on dockerhub or a mechanism for the
 # functional tests themselves to build this
-.PHONY: squid awscli fluentd gremlin taskmetadata-validator image-cleanup-test-images ecr-execution-role-image container-health-check-image telemetry-test-image
+.PHONY: squid awscli fluentd gremlin agent-introspection-validator taskmetadata-validator image-cleanup-test-images ecr-execution-role-image container-health-check-image telemetry-test-image
 squid:
 	$(MAKE) -C misc/squid $(MFLAGS)
 
@@ -260,6 +260,9 @@ testnnp:
 
 image-cleanup-test-images:
 	$(MAKE) -C misc/image-cleanup-test-images $(MFLAGS)
+
+agent-introspection-validator:
+	$(MAKE) -C misc/agent-introspection-validator $(MFLAGS)
 
 taskmetadata-validator:
 	$(MAKE) -C misc/taskmetadata-validator $(MFLAGS)
@@ -321,6 +324,7 @@ clean:
 	-$(MAKE) -C misc/gremlin $(MFLAGS) clean
 	-$(MAKE) -C misc/testnnp $(MFLAGS) clean
 	-$(MAKE) -C misc/image-cleanup-test-images $(MFLAGS) clean
+	-$(MAKE) -C misc/agent-introspection-validator $(MFLAGS) clean
 	-$(MAKE) -C misc/taskmetadata-validator $(MFLAGS) clean
 	-$(MAKE) -C misc/container-health $(MFLAGS) clean
 	-$(MAKE) -C misc/telemetry $(MFLAGS) clean

--- a/agent/functional_tests/testdata/taskdefinitions/agent-introspection-validator/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/agent-introspection-validator/task-definition.json
@@ -1,0 +1,17 @@
+{
+  "family": "ecsftest-agent-introspection-validator",
+  "networkMode": "host",
+  "containerDefinitions": [{
+    "image": "amazon/amazon-ecs-agent-introspection-validator:make",
+    "name": "agent-introspection-validator",
+    "memory": 50,
+    "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+            "awslogs-group":"ecs-functional-tests",
+            "awslogs-region":"$$$TEST_REGION$$$",
+            "awslogs-stream-prefix":"ecs-functional-tests-agent-introspection-validator"
+        }
+    }
+  }]
+}

--- a/misc/agent-introspection-validator/Dockerfile
+++ b/misc/agent-introspection-validator/Dockerfile
@@ -1,0 +1,18 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+FROM busybox@sha256:5551dbdfc48d66734d0f01cafee0952cb6e8eeecd1e2492240bf2fd9640c2279
+
+MAINTAINER Amazon Web Services, Inc.
+COPY agent-introspection-validator /
+
+ENTRYPOINT ["/agent-introspection-validator"]

--- a/misc/agent-introspection-validator/Makefile
+++ b/misc/agent-introspection-validator/Makefile
@@ -1,0 +1,25 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+.PHONY: all clean agent-introspection-validator image
+
+all: agent-introspection-validator image
+
+agent-introspection-validator: agent-introspection-validator.go
+	@./build-in-docker
+
+image: agent-introspection-validator
+	docker build -t amazon/amazon-ecs-agent-introspection-validator:make .
+
+clean:
+	rm -f agent-introspection-validator
+	-docker rmi -f "amazon/amazon-ecs-agent-introspection-validator:make"

--- a/misc/agent-introspection-validator/agent-introspection-validator.go
+++ b/misc/agent-introspection-validator/agent-introspection-validator.go
@@ -1,0 +1,287 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/cihub/seelog"
+)
+
+const (
+	agentIntrospectionEndpoint = "http://localhost:51678/v1/"
+	maxRetries                 = 4
+	durationBetweenRetries     = time.Second
+	containerName              = "agent-introspection-validator"
+	tasksMetadataRespType      = "tasks metadata"
+	taskMetadataRespType       = "task metadata"
+)
+
+// TaskResponse is the schema for the task response JSON object
+type TaskResponse struct {
+	Arn           string              `json:"Arn"`
+	DesiredStatus string              `json:"DesiredStatus,omitempty"`
+	KnownStatus   string              `json:"KnownStatus"`
+	Family        string              `json:"Family"`
+	Version       string              `json:"Version"`
+	Containers    []ContainerResponse `json:"Containers"`
+}
+
+// TasksResponse is the schema for the tasks response JSON object
+type TasksResponse struct {
+	Tasks []*TaskResponse `json:"Tasks"`
+}
+
+// ContainerResponse is the schema for the container response JSON object
+type ContainerResponse struct {
+	DockerID   string         `json:"DockerId"`
+	DockerName string         `json:"DockerName"`
+	Name       string         `json:"Name"`
+	Ports      []PortResponse `json:"Ports,omitempty"`
+	Networks   Network        `json:"Networks,omitempty"`
+}
+
+// PortResponse defines the schema for portmapping response JSON
+// object.
+type PortResponse struct {
+	ContainerPort uint16 `json:"ContainerPort,omitempty"`
+	Protocol      string `json:"Protocol,omitempty"`
+	HostPort      uint16 `json:"HostPort,omitempty"`
+}
+
+// Network is a struct that keeps track of metadata of a network interface
+type Network struct {
+	NetworkMode   string   `json:"NetworkMode,omitempty"`
+	IPv4Addresses []string `json:"IPv4Addresses,omitempty"`
+	IPv6Addresses []string `json:"IPv6Addresses,omitempty"`
+}
+
+func getTasksMetadata(client *http.Client, path string) (*TasksResponse, error) {
+	body, err := metadataResponse(client, path, tasksMetadataRespType)
+	if err != nil {
+		return nil, err
+	}
+
+	seelog.Infof("Received tasks metadata: %s \n", string(body))
+
+	err = verifyTasksMetadata(body)
+	if err != nil {
+		return nil, fmt.Errorf("%s: unable to verify response: %v", tasksMetadataRespType, err)
+	}
+
+	var tasksMetadata TasksResponse
+	err = json.Unmarshal(body, &tasksMetadata)
+	if err != nil {
+		return nil, fmt.Errorf("%s: unable to parse response body: %v", tasksMetadataRespType, err)
+	}
+
+	return &tasksMetadata, nil
+}
+
+func getTaskMetadata(client *http.Client, path string) (*TaskResponse, error) {
+	body, err := metadataResponse(client, path, taskMetadataRespType)
+	if err != nil {
+		return nil, err
+	}
+
+	seelog.Infof("Received task metadata: %s \n", string(body))
+
+	err = verifyTaskMetadata(body)
+	if err != nil {
+		return nil, fmt.Errorf("%s: unable to verify response: %v", taskMetadataRespType, err)
+	}
+
+	var taskMetadata TaskResponse
+	err = json.Unmarshal(body, &taskMetadata)
+	if err != nil {
+		return nil, fmt.Errorf("%s: unable to parse response body: %v", taskMetadataRespType, err)
+	}
+
+	return &taskMetadata, nil
+}
+
+// verifyTasksMetadata verifies the number of tasks in tasks metadata.
+func verifyTasksMetadata(tasksMetadataRawMsg json.RawMessage) error {
+	var tasksMetadataMap map[string]json.RawMessage
+	json.Unmarshal(tasksMetadataRawMsg, &tasksMetadataMap)
+
+	if tasksMetadataMap["Tasks"] == nil {
+		return notEmptyErrMsg("Tasks")
+	}
+
+	var tasksMetadataArray []json.RawMessage
+	json.Unmarshal(tasksMetadataMap["Tasks"], &tasksMetadataArray)
+
+	if len(tasksMetadataArray) != 1 {
+		return fmt.Errorf("incorrect number of tasks, expected 1, received %d",
+			len(tasksMetadataArray))
+	}
+
+	return verifyTaskMetadata(tasksMetadataArray[0])
+}
+
+// verifyTaskMetadata verifies the number of containers in task metadata, make
+// sure each necessary field is not empty, we cannot check the values of those fields
+// since they are dynamic. It also verifies the container metadata.
+func verifyTaskMetadata(taskMetadataRawMsg json.RawMessage) error {
+	taskMetadataMap := make(map[string]json.RawMessage)
+	json.Unmarshal(taskMetadataRawMsg, &taskMetadataMap)
+
+	if taskMetadataMap["Arn"] == nil {
+		return notEmptyErrMsg("Arn")
+	}
+
+	if taskMetadataMap["DesiredStatus"] == nil {
+		return notEmptyErrMsg("DesiredStatus")
+	}
+
+	if taskMetadataMap["KnownStatus"] == nil {
+		return notEmptyErrMsg("KnownStatus")
+	}
+
+	if taskMetadataMap["Family"] == nil {
+		return notEmptyErrMsg("Family")
+	}
+
+	if taskMetadataMap["Version"] == nil {
+		return notEmptyErrMsg("Version")
+	}
+
+	if taskMetadataMap["Containers"] == nil {
+		return notEmptyErrMsg("Containers")
+	}
+
+	var containersMetadataArray []json.RawMessage
+	json.Unmarshal(taskMetadataMap["Containers"], &containersMetadataArray)
+	if len(containersMetadataArray) != 1 {
+		return fmt.Errorf("incorrect number of containers, expected 1, received %d",
+			len(containersMetadataArray))
+	}
+
+	return verifyContainerMetadata(containersMetadataArray[0])
+}
+
+// verifyContainerMetadata verifies the container name of the container metadata,
+// and each necessary field is not empty.
+func verifyContainerMetadata(containerMetadataRawMsg json.RawMessage) error {
+	containerMetadataMap := make(map[string]json.RawMessage)
+	json.Unmarshal(containerMetadataRawMsg, &containerMetadataMap)
+
+	if containerMetadataMap["Name"] == nil {
+		return notEmptyErrMsg("Name")
+	}
+
+	var actualContainerName string
+	json.Unmarshal(containerMetadataMap["Name"] ,&actualContainerName)
+
+	if actualContainerName != containerName {
+		return fmt.Errorf("incorrect container name, expected %s, received %s",
+			containerName, actualContainerName)
+	}
+
+	if containerMetadataMap["DockerId"] == nil {
+		return notEmptyErrMsg("DockerId")
+	}
+
+	if containerMetadataMap["DockerName"] == nil {
+		return notEmptyErrMsg("DockerName")
+	}
+
+	return nil
+}
+
+func notEmptyErrMsg(fieldName string) error {
+	return fmt.Errorf("field %s should not be empty", fieldName)
+}
+
+func metadataResponse(client *http.Client, endpoint string, respType string) ([]byte, error) {
+	var resp []byte
+	var err error
+	for i := 0; i < maxRetries; i++ {
+		resp, err = metadataResponseOnce(client, endpoint, respType)
+		if err == nil {
+			return resp, nil
+		}
+		fmt.Fprintf(os.Stderr, "Attempt [%d/%d]: unable to get metadata response for '%s' from '%s': %v",
+			i, maxRetries, respType, endpoint, err)
+		time.Sleep(durationBetweenRetries)
+	}
+
+	return nil, err
+}
+
+func metadataResponseOnce(client *http.Client, endpoint string, respType string) ([]byte, error) {
+	resp, err := client.Get(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("%s: unable to get response: %v", respType, err)
+	}
+	if resp.Body != nil {
+		defer resp.Body.Close()
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%s: incorrect status code  %d", respType, resp.StatusCode)
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("%s: unable to read response body: %v", respType, err)
+	}
+
+	return body, nil
+}
+
+func getTaskARNFromTasksMetadata(tasksMetadata *TasksResponse) string {
+	return tasksMetadata.Tasks[0].Arn
+}
+
+func getDockerIDFromTaskMetadata(taskMetadata *TaskResponse) string {
+	return taskMetadata.Containers[0].DockerID
+}
+
+func main() {
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+	}
+
+	tasksMetadataPath := agentIntrospectionEndpoint + "tasks"
+	tasksMetadata, err := getTasksMetadata(client, tasksMetadataPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Unable to get tasks metadata for '%s': %v", tasksMetadataPath, err)
+		os.Exit(1)
+	}
+
+	// Use task arn to get task metadata
+	taskARN := getTaskARNFromTasksMetadata(tasksMetadata)
+	taskMetadataTaskARNPath := agentIntrospectionEndpoint + "tasks?taskarn=" + taskARN
+	taskMetadata, err := getTaskMetadata(client, taskMetadataTaskARNPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Unable to get task metadata for '%s': %v", taskMetadataTaskARNPath, err)
+		os.Exit(1)
+	}
+
+	// Use docker id to get task metadata
+	dockerID := getDockerIDFromTaskMetadata(taskMetadata)
+	taskMetadataDockerIDPath := agentIntrospectionEndpoint + "tasks?dockerid=" + dockerID
+	_, err = getTaskMetadata(client, taskMetadataDockerIDPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Unable to get task metadata for '%s': %v", taskMetadataDockerIDPath, err)
+		os.Exit(1)
+	}
+
+	os.Exit(42)
+}

--- a/misc/agent-introspection-validator/build-in-docker
+++ b/misc/agent-introspection-validator/build-in-docker
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+CUR_DIR=$(pwd)
+AGENT_VENDOR_DIR=$(echo $(cd ${CUR_DIR}/../../agent/vendor;pwd))
+
+docker run \
+	-v ${CUR_DIR}:/out \
+	-v ${CUR_DIR}/agent-introspection-validator.go:/in/agent-introspection-validator.go \
+	-v ${AGENT_VENDOR_DIR}:/gopath/src \
+	-e CGO_ENABLED=0 \
+	-e GOPATH=/go:/gopath \
+	golang:1.9 go build -a -x -ldflags '-s' -o /out/agent-introspection-validator /in/agent-introspection-validator.go

--- a/scripts/setup-test-registry
+++ b/scripts/setup-test-registry
@@ -65,7 +65,7 @@ mirror_local_image() {
   docker rmi $2
 }
 
-for image in "amazon/amazon-ecs-netkitten" "amazon/amazon-ecs-volumes-test" "amazon/squid" "amazon/awscli" "amazon/image-cleanup-test-image1" "amazon/image-cleanup-test-image2" "amazon/image-cleanup-test-image3" "amazon/fluentd" "amazon/amazon-ecs-taskmetadata-validator"; do
+for image in "amazon/amazon-ecs-netkitten" "amazon/amazon-ecs-volumes-test" "amazon/squid" "amazon/awscli" "amazon/image-cleanup-test-image1" "amazon/image-cleanup-test-image2" "amazon/image-cleanup-test-image3" "amazon/fluentd" "amazon/amazon-ecs-agent-introspection-validator" "amazon/amazon-ecs-taskmetadata-validator"; do
   mirror_local_image "${image}:make" "127.0.0.1:51670/${image}:latest"
 done
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Add functional test for agent introspection endpoint.

### Implementation details
<!-- How are the changes implemented? -->
The `AgentIntrospectionValidator` basically mimics `TaskMetadataValidator`:
1. Start a container to query the agent introspection endpoint, the container is started with `host` mode, so it's similar to the case when you ssh into the container instance and query the introspection endpoint.
2. In the container, the tasks metadata and task metadata path are queried, they are unmarshalled to v1 response struct, since the the value of the fields are dynamic, for the most of them we only check if they are empty.
3. The Agent metadata is already checked when we start Agent in the functional test, so we don't check it in the container.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass


### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
