### PR TITLE
dockerapi: Migrated RemoveImage to Docker SDK

### DIFF
--- a/agent/dockerclient/dockerapi/docker_client.go
+++ b/agent/dockerclient/dockerapi/docker_client.go
@@ -41,6 +41,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/utils/ttime"
 
 	"github.com/cihub/seelog"
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/volume"
 	docker "github.com/fsouza/go-dockerclient"
 )
@@ -1307,7 +1308,7 @@ func (dg *dockerGoClient) RemoveImage(ctx context.Context, imageName string, tim
 	defer cancel()
 
 	response := make(chan error, 1)
-	go func() { response <- dg.removeImage(imageName) }()
+	go func() { response <- dg.removeImage(ctx, imageName) }()
 	select {
 	case resp := <-response:
 		return resp
@@ -1316,12 +1317,13 @@ func (dg *dockerGoClient) RemoveImage(ctx context.Context, imageName string, tim
 	}
 }
 
-func (dg *dockerGoClient) removeImage(imageName string) error {
-	client, err := dg.dockerClient()
+func (dg *dockerGoClient) removeImage(ctx context.Context, imageName string) error {
+	client, err := dg.sdkDockerClient()
 	if err != nil {
 		return err
 	}
-	return client.RemoveImage(imageName)
+	_, err = client.ImageRemove(ctx, imageName,types.ImageRemoveOptions{})
+	return err
 }
 
 // LoadImage invokes loads an image from an input stream, with a specified timeout

--- a/agent/dockerclient/dockerapi/docker_client_test.go
+++ b/agent/dockerclient/dockerapi/docker_client_test.go
@@ -987,12 +987,12 @@ func TestStatsClientError(t *testing.T) {
 }
 
 func TestRemoveImageTimeout(t *testing.T) {
-	mockDocker, _, client, _, _, _, done := dockerClientSetup(t)
+	_, mockDockerSDK, client, _, _, _, done := dockerClientSetup(t)
 	defer done()
 
 	wait := sync.WaitGroup{}
 	wait.Add(1)
-	mockDocker.EXPECT().RemoveImage("image").Do(func(x interface{}) {
+	mockDockerSDK.EXPECT().ImageRemove(gomock.Any(), "image", types.ImageRemoveOptions{}).Do(func(x, y, z interface{}) {
 		wait.Wait()
 	})
 	ctx, cancel := context.WithCancel(context.TODO())
@@ -1003,11 +1003,11 @@ func TestRemoveImageTimeout(t *testing.T) {
 }
 
 func TestRemoveImage(t *testing.T) {
-	mockDocker, _, client, testTime, _, _, done := dockerClientSetup(t)
+	_, mockDockerSDK, client, testTime, _, _, done := dockerClientSetup(t)
 	defer done()
 
 	testTime.EXPECT().After(gomock.Any()).AnyTimes()
-	mockDocker.EXPECT().RemoveImage("image").Return(nil)
+	mockDockerSDK.EXPECT().ImageRemove(gomock.Any(), "image", types.ImageRemoveOptions{}).Return([]types.ImageDeleteResponseItem{}, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	err := client.RemoveImage(ctx, "image", 2*time.Millisecond)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Migrated ImageRemove to Docker SDK
### Implementation details
<!-- How are the changes implemented? -->
The Docker SDK ImageRemove call introduces the option to add flags when removing an image.
-  -f forces removal of the image
-  --no-prune does not delete untagged parents

The previous go-dockerclient version of the API call did not give these options and set them to their defaults as false and false. A placeholder struct ImageRemoveOptions was added to allow flags to be passed in in the future for new features.

Changes were implemented by swapping API calls to new SDK Client. All changes could be done under the DockerClient interface making this migration fairly straightforward.

Link to branch :  https://github.com/kavoor/amazon-ecs-agent/tree/ImageRemove
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enhancement - Migrated ImageRemove to Docker SDK
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
