### PR TITLE
Boolean for autoprovision flipped when we renamed it from preprovisoned

### DIFF
--- a/agent/api/task/taskvolume_test.go
+++ b/agent/api/task/taskvolume_test.go
@@ -128,7 +128,7 @@ func TestInitializeSharedProvisionedVolume(t *testing.T) {
 				Type: "docker",
 				Volume: &taskresourcevolume.DockerVolumeConfig{
 					Scope:         "shared",
-					Autoprovision: true,
+					Autoprovision: false,
 				},
 			},
 		},
@@ -166,7 +166,7 @@ func TestInitializeSharedProvisionedVolumeError(t *testing.T) {
 				Type: "docker",
 				Volume: &taskresourcevolume.DockerVolumeConfig{
 					Scope:         "shared",
-					Autoprovision: true,
+					Autoprovision: false,
 				},
 			},
 		},
@@ -221,7 +221,7 @@ func TestInitializeSharedNonProvisionedVolume(t *testing.T) {
 	assert.Len(t, testTask.Containers[0].TransitionDependenciesMap, 0, "resource already exists")
 }
 
-func TestInitializeSharedNonProvisionedVolumeNotFoundError(t *testing.T) {
+func TestInitializeSharedAutoprovisionVolumeNotFoundError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	dockerClient := mock_dockerapi.NewMockDockerClient(ctrl)
 
@@ -244,7 +244,7 @@ func TestInitializeSharedNonProvisionedVolumeNotFoundError(t *testing.T) {
 				Type: "docker",
 				Volume: &taskresourcevolume.DockerVolumeConfig{
 					Scope:         "shared",
-					Autoprovision: false,
+					Autoprovision: true,
 				},
 			},
 		},
@@ -257,7 +257,7 @@ func TestInitializeSharedNonProvisionedVolumeNotFoundError(t *testing.T) {
 	assert.Len(t, testTask.Containers[0].TransitionDependenciesMap, 1, "volume resource should be in the container dependency map")
 }
 
-func TestInitializeSharedNonProvisionedVolumeNotMatchError(t *testing.T) {
+func TestInitializeSharedAutoprovisionVolumeNotMatchError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	dockerClient := mock_dockerapi.NewMockDockerClient(ctrl)
 
@@ -280,7 +280,7 @@ func TestInitializeSharedNonProvisionedVolumeNotMatchError(t *testing.T) {
 				Type: "docker",
 				Volume: &taskresourcevolume.DockerVolumeConfig{
 					Scope:         "shared",
-					Autoprovision: false,
+					Autoprovision: true,
 				},
 			},
 		},
@@ -295,7 +295,7 @@ func TestInitializeSharedNonProvisionedVolumeNotMatchError(t *testing.T) {
 	assert.Error(t, err, "volume resource details not match should cause task fail")
 }
 
-func TestInitializeSharedNonProvisionedVolumeTimeout(t *testing.T) {
+func TestInitializeSharedAutoprovisionVolumeTimeout(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	dockerClient := mock_dockerapi.NewMockDockerClient(ctrl)
 
@@ -318,7 +318,7 @@ func TestInitializeSharedNonProvisionedVolumeTimeout(t *testing.T) {
 				Type: "docker",
 				Volume: &taskresourcevolume.DockerVolumeConfig{
 					Scope:         "shared",
-					Autoprovision: false,
+					Autoprovision: true,
 				},
 			},
 		},

--- a/agent/engine/engine_unix_integ_test.go
+++ b/agent/engine/engine_unix_integ_test.go
@@ -85,7 +85,7 @@ func createTestHealthCheckTask(arn string) *apitask.Task {
 	return testTask
 }
 
-func createVolumeTask(scope, arn, volume string, provisioned bool) (*apitask.Task, string, error) {
+func createVolumeTask(scope, arn, volume string, autoprovision bool) (*apitask.Task, string, error) {
 	tmpDirectory, err := ioutil.TempDir("", "ecs_test")
 	if err != nil {
 		return nil, "", err
@@ -96,19 +96,24 @@ func createVolumeTask(scope, arn, volume string, provisioned bool) (*apitask.Tas
 	}
 
 	testTask := createTestTask(arn)
+
+	volumeConfig := &taskresourcevolume.DockerVolumeConfig{
+		Scope:  scope,
+		Driver: "local",
+		DriverOpts: map[string]string{
+			"device": tmpDirectory,
+			"o":      "bind",
+		},
+	}
+	if scope == "shared" {
+		volumeConfig.Autoprovision = autoprovision
+	}
+
 	testTask.Volumes = []apitask.TaskVolume{
 		{
-			Type: "docker",
-			Name: volume,
-			Volume: &taskresourcevolume.DockerVolumeConfig{
-				Scope:         scope,
-				Autoprovision: provisioned,
-				Driver:        "local",
-				DriverOpts: map[string]string{
-					"device": tmpDirectory,
-					"o":      "bind",
-				},
-			},
+			Type:   "docker",
+			Name:   volume,
+			Volume: volumeConfig,
 		},
 	}
 
@@ -850,7 +855,7 @@ func TestTaskLevelVolume(t *testing.T) {
 	defer done()
 	stateChangeEvents := taskEngine.StateChangeEvents()
 
-	testTask, tmpDirectory, err := createVolumeTask("task", "TestTaskLevelVolume", "TestTaskLevelVolume", false)
+	testTask, tmpDirectory, err := createVolumeTask("task", "TestTaskLevelVolume", "TestTaskLevelVolume", true)
 	defer os.Remove(tmpDirectory)
 	require.NoError(t, err, "creating test task failed")
 

--- a/agent/engine/engine_windows_integ_test.go
+++ b/agent/engine/engine_windows_integ_test.go
@@ -111,17 +111,22 @@ func createTestHealthCheckTask(arn string) *apitask.Task {
 	return testTask
 }
 
-func createVolumeTask(scope, arn, volume string, provisioned bool) (*apitask.Task, string, error) {
+func createVolumeTask(scope, arn, volume string, autoprovision bool) (*apitask.Task, string, error) {
 	testTask := createTestTask(arn)
+
+	volumeConfig := &taskresourcevolume.DockerVolumeConfig{
+		Scope:  scope,
+		Driver: "local",
+	}
+	if scope == "shared" {
+		volumeConfig.Autoprovision = autoprovision
+	}
+
 	testTask.Volumes = []apitask.TaskVolume{
 		{
-			Type: "docker",
-			Name: volume,
-			Volume: &taskresourcevolume.DockerVolumeConfig{
-				Scope:         scope,
-				Autoprovision: provisioned,
-				Driver:        "local",
-			},
+			Type:   "docker",
+			Name:   volume,
+			Volume: volumeConfig,
 		},
 	}
 
@@ -574,7 +579,7 @@ func TestTaskLevelVolume(t *testing.T) {
 	defer done()
 	stateChangeEvents := taskEngine.StateChangeEvents()
 
-	testTask, tmpDirectory, err := createVolumeTask("task", "TestTaskLevelVolume", "TestTaskLevelVolume", false)
+	testTask, tmpDirectory, err := createVolumeTask("task", "TestTaskLevelVolume", "TestTaskLevelVolume", true)
 	defer os.Remove(tmpDirectory)
 	require.NoError(t, err, "creating test task failed")
 

--- a/agent/functional_tests/testdata/taskdefinitions/task-shared-vol-read-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/task-shared-vol-read-windows/task-definition.json
@@ -21,7 +21,7 @@
             "name": "task-shared",
             "dockerVolumeConfiguration" : {
                 "scope": "shared",
-                "autoprovision": true,
+                "autoprovision": false,
                 "driver": "local",
                 "labels": {
                     "mylables": "test"

--- a/agent/functional_tests/testdata/taskdefinitions/task-shared-vol-read/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/task-shared-vol-read/task-definition.json
@@ -21,7 +21,7 @@
             "name": "task-shared",
             "dockerVolumeConfiguration" : {
                 "scope": "shared",
-                "autoprovision": true,
+                "autoprovision": false,
                 "driver": "local",
                 "driverOpts": {
                     "type": "tmpfs",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
"Preprovisioned" flag was renamed to "autoprovision" which flipped the meaning of its boolean value. This was not reflected in the code.

### Implementation details
if !autoprovision is the same test as if preprovisioned

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
