### PR TITLE
change supported cipher suites for agent client

### DIFF
--- a/agent/httpclient/httpclient.go
+++ b/agent/httpclient/httpclient.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/utils/cipher"
 	"github.com/aws/amazon-ecs-agent/agent/version"
 )
 
@@ -67,9 +68,11 @@ func New(timeout time.Duration, insecureSkipVerify bool) *http.Client {
 		}).Dial,
 		TLSHandshakeTimeout: 10 * time.Second,
 	}
-	if insecureSkipVerify {
-		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-	}
+
+	transport.TLSClientConfig = &tls.Config{}
+	cipher.WithSupportedCipherSuites(transport.TLSClientConfig)
+	transport.TLSClientConfig.InsecureSkipVerify = insecureSkipVerify
+
 	client := &http.Client{
 		Transport: &ecsRoundTripper{insecureSkipVerify, transport},
 		Timeout:   timeout,

--- a/agent/httpclient/httpclient_test.go
+++ b/agent/httpclient/httpclient_test.go
@@ -1,0 +1,32 @@
+// +build unit
+
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package httpclient
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/aws/amazon-ecs-agent/agent/utils/cipher"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewHttpClient(t *testing.T) {
+	expectedResult := New(time.Duration(10),true)
+	transport := expectedResult.Transport.(*ecsRoundTripper)
+	assert.Equal(t, cipher.SupportedCipherSuites, transport.transport.(*http.Transport).TLSClientConfig.CipherSuites)
+	assert.Equal(t, true, transport.transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify)
+}

--- a/agent/utils/cipher/cipher.go
+++ b/agent/utils/cipher/cipher.go
@@ -1,0 +1,36 @@
+// Copyright 2014-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// Package cipher provides customized cipher configuration for agent client
+package cipher
+
+import (
+	"crypto/tls"
+)
+// Only support a subset of ciphers, corresponding cipher suite names can be found here: https://golang.org/pkg/crypto/tls/#Config
+var SupportedCipherSuites = []uint16{
+	tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+	tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+	tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+	tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+	tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+	tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+	tls.TLS_RSA_WITH_AES_128_CBC_SHA256,
+	tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+	tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+	tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+}
+
+func WithSupportedCipherSuites(config *tls.Config) {
+	config.CipherSuites = SupportedCipherSuites
+}

--- a/agent/wsclient/client.go
+++ b/agent/wsclient/client.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
+	"github.com/aws/amazon-ecs-agent/agent/utils/cipher"
 	"github.com/aws/amazon-ecs-agent/agent/wsclient/wsconn"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/private/protocol/json/jsonutil"
@@ -159,6 +160,7 @@ func (cs *ClientServerImpl) Connect() error {
 
 	timeoutDialer := &net.Dialer{Timeout: wsConnectTimeout}
 	tlsConfig := &tls.Config{ServerName: parsedURL.Host, InsecureSkipVerify: cs.AgentConfig.AcceptInsecureCert}
+	cipher.WithSupportedCipherSuites(tlsConfig)
 
 	// Ensure that NO_PROXY gets set
 	noProxy := os.Getenv("NO_PROXY")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Make the code change to customize tls configuration in order to deprecate some weak cipher suites for agent client. After this change, supported cipher suites are as follows, 
      TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
      TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
      TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
      TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
      TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
      TLS_RSA_WITH_AES_128_GCM_SHA256,
      TLS_RSA_WITH_AES_128_CBC_SHA256,
      TLS_RSA_WITH_AES_128_CBC_SHA,
      TLS_RSA_WITH_AES_256_GCM_SHA384,
      TLS_RSA_WITH_AES_256_CBC_SHA

### Implementation details
When initializing agent client, call the method to change the CipherSuites attribute of tls config struct to only support cipher suites mentioned above. 

### Testing
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes

### Description for the changelog

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
