### PR TITLE
dockerapi: Migrated ImageImport to Docker SDK

### DIFF
--- a/agent/dockerclient/dockerapi/docker_client.go
+++ b/agent/dockerclient/dockerapi/docker_client.go
@@ -41,6 +41,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/utils/ttime"
 
 	"github.com/cihub/seelog"
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/volume"
 	docker "github.com/fsouza/go-dockerclient"
 )
@@ -228,6 +229,7 @@ type dockerGoClient struct {
 	auth             dockerauth.DockerAuthProvider
 	ecrTokenCache    async.Cache
 	config           *config.Config
+	context          context.Context
 
 	_time     ttime.Time
 	_timeOnce sync.Once
@@ -243,6 +245,7 @@ func (dg *dockerGoClient) WithVersion(version dockerclient.DockerVersion) Docker
 		version:          version,
 		auth:             dg.auth,
 		config:           dg.config,
+		context:          dg.context,
 	}
 }
 
@@ -295,6 +298,7 @@ func NewDockerGoClient(clientFactory clientfactory.Factory, sdkclientFactory sdk
 		ecrClientFactory: ecr.NewECRFactory(cfg.AcceptInsecureCert),
 		ecrTokenCache:    async.NewLRUCache(tokenCacheSize, tokenCacheTTL),
 		config:           cfg,
+		context:          ctx,
 	}, nil
 }
 
@@ -472,7 +476,7 @@ func (dg *dockerGoClient) ImportLocalEmptyVolumeImage() DockerContainerMetadata 
 
 	response := make(chan DockerContainerMetadata, 1)
 	go func() {
-		err := dg.createScratchImageIfNotExists()
+		err := dg.createScratchImageIfNotExists(dg.context)
 		var wrapped apierrors.NamedError
 		if err != nil {
 			wrapped = CreateEmptyVolumeError{err}
@@ -487,8 +491,9 @@ func (dg *dockerGoClient) ImportLocalEmptyVolumeImage() DockerContainerMetadata 
 	}
 }
 
-func (dg *dockerGoClient) createScratchImageIfNotExists() error {
+func (dg *dockerGoClient) createScratchImageIfNotExists(ctx context.Context) error {
 	client, err := dg.dockerClient()
+	sdkclient, err := dg.sdkDockerClient()
 	if err != nil {
 		return err
 	}
@@ -511,14 +516,16 @@ func (dg *dockerGoClient) createScratchImageIfNotExists() error {
 		writer.Close()
 	}()
 
+	importSrc := types.ImageImportSource{
+		Source:     reader,
+		SourceName: "-",
+	}
+	importOpts := types.ImageImportOptions{
+		Tag:     emptyvolume.Tag,
+	}
 	seelog.Debug("DockerGoClient: importing empty volume image")
 	// Create it from an empty tarball
-	err = client.ImportImage(docker.ImportImageOptions{
-		Repository:  emptyvolume.Image,
-		Tag:         emptyvolume.Tag,
-		Source:      "-",
-		InputStream: reader,
-	})
+	_, err = sdkclient.ImageImport(ctx, importSrc, emptyvolume.Image + ":" + emptyvolume.Tag, importOpts)
 	return err
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Migrated ImageImport to Docker SDK
### Implementation details
<!-- How are the changes implemented? -->
Migrated import image API from go-dockerclient to Docker SDK counterpart. Migrated data structures to create a scratch image and updated mocks accordingly.

Added context field to DockerGoClient to pass to ImageImport as changing function headers greatly increased scope.

Changes were implemented by swapping API calls to new SDK Client. All changes could be done under the DockerClient interface making this migration fairly straightforward.

Link to branch : https://github.com/kavoor/amazon-ecs-agent/tree/import
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->

- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enhancement - Migrated ImageImport to Docker SDK
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
