### PR TITLE
dockerapi: Migrated VersionWithContext to Docker SDK

### DIFF
--- a/agent/dockerclient/dockerapi/docker_client.go
+++ b/agent/dockerclient/dockerapi/docker_client.go
@@ -1014,11 +1014,11 @@ func (dg *dockerGoClient) listContainers(ctx context.Context, all bool) ListCont
 }
 
 func (dg *dockerGoClient) SupportedVersions() []dockerclient.DockerVersion {
-	return dg.clientFactory.FindSupportedAPIVersions()
+	return dg.sdkClientFactory.FindSupportedAPIVersions()
 }
 
 func (dg *dockerGoClient) KnownVersions() []dockerclient.DockerVersion {
-	return dg.clientFactory.FindKnownAPIVersions()
+	return dg.sdkClientFactory.FindKnownAPIVersions()
 }
 
 func (dg *dockerGoClient) Version(ctx context.Context, timeout time.Duration) (string, error) {
@@ -1030,16 +1030,16 @@ func (dg *dockerGoClient) Version(ctx context.Context, timeout time.Duration) (s
 	derivedCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	client, err := dg.dockerClient()
+	client, err := dg.sdkDockerClient()
 	if err != nil {
 		return "", err
 	}
-	info, err := client.VersionWithContext(derivedCtx)
+	info, err := client.ServerVersion(derivedCtx)
 	if err != nil {
 		return "", err
 	}
 
-	version = info.Get("Version")
+	version = info.Version
 	dg.setDaemonVersion(version)
 	return version, nil
 }

--- a/agent/dockerclient/dockerapi/docker_client_test.go
+++ b/agent/dockerclient/dockerapi/docker_client_test.go
@@ -754,10 +754,10 @@ func TestContainerEvents(t *testing.T) {
 }
 
 func TestDockerVersion(t *testing.T) {
-	mockDocker, _, client, _, _, _, done := dockerClientSetup(t)
+	_, mockDockerSDK, client, _, _, _, done := dockerClientSetup(t)
 	defer done()
 
-	mockDocker.EXPECT().VersionWithContext(gomock.Any()).Return(&docker.Env{"Version=1.6.0"}, nil)
+	mockDockerSDK.EXPECT().ServerVersion(gomock.Any()).Return(types.Version{Version:"1.6.0"}, nil)
 
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Migrated VersionWithContext to Docker SDK
### Implementation details
<!-- How are the changes implemented? -->
- Swapped VerisonWithContext with its Docker SDK counterpart, ServerVersion and updated mocks accordingly.
- Additionally, SupportedVersions() and KnownVersions() were swapped to sdkClientFactory to get closer to removing clientfactory altogether.

Link to branch : https://github.com/kavoor/amazon-ecs-agent/tree/version

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
** will update tests as they complete**
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enhancement - Migrated VersionWithContext to Docker SDK

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
