### PR TITLE
dockerapi: Migrated AuthConfigration type to Docker SDK

### DIFF
--- a/agent/api/container/container.go
+++ b/agent/api/container/container.go
@@ -25,7 +25,7 @@ import (
 	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
 	"github.com/aws/aws-sdk-go/aws"
 
-	docker "github.com/fsouza/go-dockerclient"
+	"github.com/docker/docker/api/types"
 )
 
 const (
@@ -662,6 +662,6 @@ func (c *Container) ShouldPullWithASMAuth() bool {
 // SetASMDockerAuthConfig add the docker auth config data to the
 // RegistryAuthentication struct held by the container, this is then passed down
 // to the docker client to pull the image
-func (c *Container) SetASMDockerAuthConfig(dac docker.AuthConfiguration) {
+func (c *Container) SetASMDockerAuthConfig(dac types.AuthConfig) {
 	c.RegistryAuthentication.ASMAuthData.SetDockerAuthConfig(dac)
 }

--- a/agent/api/container/registryauth.go
+++ b/agent/api/container/registryauth.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/aws/amazon-ecs-agent/agent/credentials"
 
-	docker "github.com/fsouza/go-dockerclient"
+	"github.com/docker/docker/api/types"
 )
 
 // RegistryAuthenticationData is the authentication data sent by the ECS backend.  Currently, the only supported
@@ -49,7 +49,7 @@ type ASMAuthData struct {
 	Region string `json:"region"`
 	// dockerAuthConfig gets populated during the ASM resource creation
 	// by the task engine
-	dockerAuthConfig docker.AuthConfiguration
+	dockerAuthConfig types.AuthConfig
 	lock             sync.RWMutex
 }
 
@@ -70,7 +70,7 @@ func (auth *ECRAuthData) SetPullCredentials(creds credentials.IAMRoleCredentials
 }
 
 // GetDockerAuthConfig returns the pull credentials in the auth
-func (auth *ASMAuthData) GetDockerAuthConfig() docker.AuthConfiguration {
+func (auth *ASMAuthData) GetDockerAuthConfig() types.AuthConfig {
 	auth.lock.RLock()
 	defer auth.lock.RUnlock()
 
@@ -79,7 +79,7 @@ func (auth *ASMAuthData) GetDockerAuthConfig() docker.AuthConfiguration {
 
 // SetDockerAuthConfig sets the credentials to pull from ECR in the
 // auth
-func (auth *ASMAuthData) SetDockerAuthConfig(dac docker.AuthConfiguration) {
+func (auth *ASMAuthData) SetDockerAuthConfig(dac types.AuthConfig) {
 	auth.lock.Lock()
 	defer auth.lock.Unlock()
 

--- a/agent/asm/asm.go
+++ b/agent/asm/asm.go
@@ -19,7 +19,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	"github.com/aws/aws-sdk-go/service/secretsmanager/secretsmanageriface"
-	docker "github.com/fsouza/go-dockerclient"
+	"github.com/docker/docker/api/types"
 	"github.com/pkg/errors"
 )
 
@@ -32,29 +32,29 @@ type AuthDataValue struct {
 
 // GetDockerAuthFromASM makes the api call to the AWS Secrets Manager service to
 // retrieve the docker auth data
-func GetDockerAuthFromASM(secretID string, client secretsmanageriface.SecretsManagerAPI) (docker.AuthConfiguration, error) {
+func GetDockerAuthFromASM(secretID string, client secretsmanageriface.SecretsManagerAPI) (types.AuthConfig, error) {
 	in := &secretsmanager.GetSecretValueInput{
 		SecretId: aws.String(secretID),
 	}
 
 	out, err := client.GetSecretValue(in)
 	if err != nil {
-		return docker.AuthConfiguration{}, errors.Wrapf(err,
+		return types.AuthConfig{}, errors.Wrapf(err,
 			"asm fetching secret from the service for %s", secretID)
 	}
 
 	return extractASMValue(out)
 }
 
-func extractASMValue(out *secretsmanager.GetSecretValueOutput) (docker.AuthConfiguration, error) {
+func extractASMValue(out *secretsmanager.GetSecretValueOutput) (types.AuthConfig, error) {
 	if out == nil {
-		return docker.AuthConfiguration{}, errors.New(
+		return types.AuthConfig{}, errors.New(
 			"asm fetching authorization data: empty response")
 	}
 
 	secretValue := aws.StringValue(out.SecretString)
 	if secretValue == "" {
-		return docker.AuthConfiguration{}, errors.New(
+		return types.AuthConfig{}, errors.New(
 			"asm fetching authorization data: empty secrets value")
 	}
 
@@ -62,7 +62,7 @@ func extractASMValue(out *secretsmanager.GetSecretValueOutput) (docker.AuthConfi
 	err := json.Unmarshal([]byte(secretValue), &authDataValue)
 	if err != nil {
 		// could  not unmarshal, incorrect secret value schema
-		return docker.AuthConfiguration{}, errors.New(
+		return types.AuthConfig{}, errors.New(
 			"asm fetching authorization data: unable to unmarshal secret value, invalid schema")
 	}
 
@@ -70,16 +70,16 @@ func extractASMValue(out *secretsmanager.GetSecretValueOutput) (docker.AuthConfi
 	password := aws.StringValue(authDataValue.Password)
 
 	if username == "" {
-		return docker.AuthConfiguration{}, errors.New(
+		return types.AuthConfig{}, errors.New(
 			"asm fetching username: AuthorizationData is malformed, empty field")
 	}
 
 	if password == "" {
-		return docker.AuthConfiguration{}, errors.New(
+		return types.AuthConfig{}, errors.New(
 			"asm fetching password: AuthorizationData is malformed, empty field")
 	}
 
-	dac := docker.AuthConfiguration{
+	dac := types.AuthConfig{
 		Username: username,
 		Password: password,
 	}

--- a/agent/dockerclient/dockerapi/docker_client.go
+++ b/agent/dockerclient/dockerapi/docker_client.go
@@ -373,7 +373,13 @@ func (dg *dockerGoClient) pullImage(image string, authData *apicontainer.Registr
 		return CannotGetDockerClientError{version: dg.version, err: err}
 	}
 
-	authConfig, err := dg.getAuthdata(image, authData)
+	sdkAuthConfig, err := dg.getAuthdata(image, authData)
+	authConfig := docker.AuthConfiguration{
+		Username:      sdkAuthConfig.Username,
+		Password:      sdkAuthConfig.Password,
+		Email:         sdkAuthConfig.Email,
+		ServerAddress: sdkAuthConfig.ServerAddress,
+	}
 	if err != nil {
 		return wrapPullErrorAsNamedError(err)
 	}
@@ -396,6 +402,7 @@ func (dg *dockerGoClient) pullImage(image string, authData *apicontainer.Registr
 	go dg.filterPullDebugOutput(pullDebugOut, pullBegan, image)
 
 	pullFinished := make(chan error, 1)
+	// TODO Migrate Pull Image once Inactivity Timeout is sorted out
 	go func() {
 		pullFinished <- client.PullImage(opts, authConfig)
 		seelog.Debugf("DockerGoClient: pulling image complete: %s", image)
@@ -531,7 +538,7 @@ func (dg *dockerGoClient) InspectImage(image string) (*docker.Image, error) {
 	return client.InspectImage(image)
 }
 
-func (dg *dockerGoClient) getAuthdata(image string, authData *apicontainer.RegistryAuthenticationData) (docker.AuthConfiguration, error) {
+func (dg *dockerGoClient) getAuthdata(image string, authData *apicontainer.RegistryAuthenticationData) (types.AuthConfig, error) {
 
 	if authData == nil {
 		return dg.auth.GetAuthconfig(image, nil)

--- a/agent/dockerclient/dockerauth/dockerauth.go
+++ b/agent/dockerclient/dockerauth/dockerauth.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -23,7 +23,8 @@ import (
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 
 	"github.com/cihub/seelog"
-	docker "github.com/fsouza/go-dockerclient"
+	"github.com/docker/docker/api/types"
+	"github.com/fsouza/go-dockerclient"
 )
 
 func NewDockerAuthProvider(authType string, authData json.RawMessage) DockerAuthProvider {
@@ -37,7 +38,7 @@ type dockerAuthProvider struct {
 }
 
 // map from registry url (minus schema) to auth information
-type dockerAuths map[string]docker.AuthConfiguration
+type dockerAuths map[string]types.AuthConfig
 
 type dockercfgConfigEntry struct {
 	Auth string `json:"auth"`
@@ -46,7 +47,7 @@ type dockercfgConfigEntry struct {
 type dockercfgData map[string]dockercfgConfigEntry
 
 // GetAuthconfig retrieves the correct auth configuration for the given repository
-func (authProvider *dockerAuthProvider) GetAuthconfig(image string, registryAuthData *apicontainer.RegistryAuthenticationData) (docker.AuthConfiguration, error) {
+func (authProvider *dockerAuthProvider) GetAuthconfig(image string, registryAuthData *apicontainer.RegistryAuthenticationData) (types.AuthConfig, error) {
 	// Ignore 'tag', not used in auth determination
 	repository, _ := docker.ParseRepositoryTag(image)
 	authDataMap := authProvider.authMap
@@ -86,7 +87,7 @@ func (authProvider *dockerAuthProvider) GetAuthconfig(image string, registryAuth
 	if longestKey != "" {
 		return authDataMap[longestKey], nil
 	}
-	return docker.AuthConfiguration{}, nil
+	return types.AuthConfig{}, nil
 }
 
 // Normalize all auth types into a uniform 'dockerAuths' type.
@@ -120,7 +121,7 @@ func parseAuthData(authType string, authData json.RawMessage) dockerAuths {
 				seelog.Warnf("Malformed auth data for registry %v; must contain ':'", registry)
 				continue
 			}
-			intermediateAuthData[registry] = docker.AuthConfiguration{
+			intermediateAuthData[registry] = types.AuthConfig{
 				Username: usernamePass[0],
 				Password: usernamePass[1],
 			}

--- a/agent/dockerclient/dockerauth/dockerauth_test.go
+++ b/agent/dockerclient/dockerauth/dockerauth_test.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"testing"
 
-	docker "github.com/fsouza/go-dockerclient"
+	"github.com/docker/docker/api/types"
 )
 
 type authTestPair struct {
@@ -121,7 +121,7 @@ func TestAuthErrors(t *testing.T) {
 	for _, pair := range badPairs {
 		provider := NewDockerAuthProvider(pair.t, []byte(pair.a))
 		result, _ := provider.GetAuthconfig("nginx", nil)
-		if !reflect.DeepEqual(result, docker.AuthConfiguration{}) {
+		if !reflect.DeepEqual(result, types.AuthConfig{}) {
 			t.Errorf("Expected empty auth config for %v; got %v", pair, result)
 		}
 	}
@@ -131,7 +131,7 @@ func TestAuthErrors(t *testing.T) {
 func TestEmptyConfig(t *testing.T) {
 	provider := NewDockerAuthProvider("", []byte(""))
 	authConfig, _ := provider.GetAuthconfig("nginx", nil)
-	if !reflect.DeepEqual(authConfig, docker.AuthConfiguration{}) {
+	if !reflect.DeepEqual(authConfig, types.AuthConfig{}) {
 		t.Errorf("Expected empty authconfig to not return any auth data at all")
 	}
 }

--- a/agent/dockerclient/dockerauth/ecr.go
+++ b/agent/dockerclient/dockerauth/ecr.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -27,7 +27,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 	"github.com/aws/aws-sdk-go/aws"
 	log "github.com/cihub/seelog"
-	docker "github.com/fsouza/go-dockerclient"
+	"github.com/docker/docker/api/types"
 )
 
 type cacheKey struct {
@@ -66,16 +66,16 @@ func NewECRAuthProvider(ecrFactory ecr.ECRFactory, cache async.Cache) DockerAuth
 
 // GetAuthconfig retrieves the correct auth configuration for the given repository
 func (authProvider *ecrAuthProvider) GetAuthconfig(image string,
-	registryAuthData *apicontainer.RegistryAuthenticationData) (docker.AuthConfiguration, error) {
+	registryAuthData *apicontainer.RegistryAuthenticationData) (types.AuthConfig, error) {
 
 	if registryAuthData == nil {
-		return docker.AuthConfiguration{}, fmt.Errorf("dockerauth: missing container's registry auth data")
+		return types.AuthConfig{}, fmt.Errorf("dockerauth: missing container's registry auth data")
 	}
 
 	authData := registryAuthData.ECRAuthData
 
 	if authData == nil {
-		return docker.AuthConfiguration{}, fmt.Errorf("dockerauth: missing container's ecr auth data")
+		return types.AuthConfig{}, fmt.Errorf("dockerauth: missing container's ecr auth data")
 	}
 
 	// First try to get the token from cache, if the token does not exist,
@@ -104,7 +104,7 @@ func (authProvider *ecrAuthProvider) GetAuthconfig(image string,
 }
 
 // getAuthconfigFromCache retrieves the token from cache
-func (authProvider *ecrAuthProvider) getAuthConfigFromCache(key cacheKey) *docker.AuthConfiguration {
+func (authProvider *ecrAuthProvider) getAuthConfigFromCache(key cacheKey) *types.AuthConfig {
 	token, ok := authProvider.tokenCache.Get(key.String())
 	if !ok {
 		return nil
@@ -133,20 +133,20 @@ func (authProvider *ecrAuthProvider) getAuthConfigFromCache(key cacheKey) *docke
 }
 
 // getAuthConfigFromECR calls the ECR API to get docker auth config
-func (authProvider *ecrAuthProvider) getAuthConfigFromECR(image string, key cacheKey, authData *apicontainer.ECRAuthData) (docker.AuthConfiguration, error) {
+func (authProvider *ecrAuthProvider) getAuthConfigFromECR(image string, key cacheKey, authData *apicontainer.ECRAuthData) (types.AuthConfig, error) {
 	// Create ECR client to get the token
 	client, err := authProvider.factory.GetClient(authData)
 	if err != nil {
-		return docker.AuthConfiguration{}, err
+		return types.AuthConfig{}, err
 	}
 
 	log.Debugf("Calling ECR.GetAuthorizationToken for %s", image)
 	ecrAuthData, err := client.GetAuthorizationToken(authData.RegistryID)
 	if err != nil {
-		return docker.AuthConfiguration{}, err
+		return types.AuthConfig{}, err
 	}
 	if ecrAuthData == nil {
-		return docker.AuthConfiguration{}, fmt.Errorf("ecr auth: missing AuthorizationData in ECR response for %s", image)
+		return types.AuthConfig{}, fmt.Errorf("ecr auth: missing AuthorizationData in ECR response for %s", image)
 	}
 
 	// Verify the auth data has the correct format for ECR
@@ -158,16 +158,16 @@ func (authProvider *ecrAuthProvider) getAuthConfigFromECR(image string, key cach
 		authProvider.tokenCache.Set(key.String(), ecrAuthData)
 		return extractToken(ecrAuthData)
 	}
-	return docker.AuthConfiguration{}, fmt.Errorf("ecr auth: AuthorizationData is malformed for %s", image)
+	return types.AuthConfig{}, fmt.Errorf("ecr auth: AuthorizationData is malformed for %s", image)
 }
 
-func extractToken(authData *ecrapi.AuthorizationData) (docker.AuthConfiguration, error) {
+func extractToken(authData *ecrapi.AuthorizationData) (types.AuthConfig, error) {
 	decodedToken, err := base64.StdEncoding.DecodeString(aws.StringValue(authData.AuthorizationToken))
 	if err != nil {
-		return docker.AuthConfiguration{}, err
+		return types.AuthConfig{}, err
 	}
 	parts := strings.SplitN(string(decodedToken), ":", 2)
-	return docker.AuthConfiguration{
+	return types.AuthConfig{
 		Username:      parts[0],
 		Password:      parts[1],
 		ServerAddress: aws.StringValue(authData.ProxyEndpoint),

--- a/agent/dockerclient/dockerauth/ecr_test.go
+++ b/agent/dockerclient/dockerauth/ecr_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/ecr/mocks"
 	ecrapi "github.com/aws/amazon-ecs-agent/agent/ecr/model/ecr"
 	"github.com/aws/aws-sdk-go/aws"
-	docker "github.com/fsouza/go-dockerclient"
+	"github.com/docker/docker/api/types"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -121,7 +121,7 @@ func TestGetAuthConfigNoMatchAuthorizationToken(t *testing.T) {
 
 	authconfig, err := provider.GetAuthconfig(proxyEndpoint+"/myimage", registryAuthData)
 	require.Error(t, err, "Expected error if the proxy does not match")
-	assert.Equal(t, docker.AuthConfiguration{}, authconfig, "Expected Authconfig to be empty, but was %v", authconfig)
+	assert.Equal(t, types.AuthConfig{}, authconfig, "Expected Authconfig to be empty, but was %v", authconfig)
 }
 
 func TestGetAuthConfigBadBase64(t *testing.T) {
@@ -156,7 +156,7 @@ func TestGetAuthConfigBadBase64(t *testing.T) {
 
 	authconfig, err := provider.GetAuthconfig(proxyEndpoint+"/myimage", registryAuthData)
 	require.Error(t, err, "Expected error to be present, but was nil", err)
-	assert.Equal(t, docker.AuthConfiguration{}, authconfig, "Expected Authconfig to be empty, but was %v", authconfig)
+	assert.Equal(t, types.AuthConfig{}, authconfig, "Expected Authconfig to be empty, but was %v", authconfig)
 }
 
 func TestGetAuthConfigMissingResponse(t *testing.T) {
@@ -189,7 +189,7 @@ func TestGetAuthConfigMissingResponse(t *testing.T) {
 		t.Fatal("Expected error to be present, but was nil", err)
 	}
 	require.Error(t, err, "Expected error to be present, but was nil", err)
-	assert.Equal(t, docker.AuthConfiguration{}, authconfig, "Expected Authconfig to be empty, but was %v", authconfig)
+	assert.Equal(t, types.AuthConfig{}, authconfig, "Expected Authconfig to be empty, but was %v", authconfig)
 }
 
 func TestGetAuthConfigECRError(t *testing.T) {
@@ -219,7 +219,7 @@ func TestGetAuthConfigECRError(t *testing.T) {
 
 	authconfig, err := provider.GetAuthconfig(proxyEndpoint+"/myimage", registryAuthData)
 	require.Error(t, err, "Expected error to be present, but was nil", err)
-	assert.Equal(t, docker.AuthConfiguration{}, authconfig, "Expected Authconfig to be empty, but was %v", authconfig)
+	assert.Equal(t, types.AuthConfig{}, authconfig, "Expected Authconfig to be empty, but was %v", authconfig)
 }
 
 func TestGetAuthConfigNoAuthData(t *testing.T) {
@@ -234,7 +234,7 @@ func TestGetAuthConfigNoAuthData(t *testing.T) {
 
 	authconfig, err := provider.GetAuthconfig(proxyEndpoint+"/myimage", nil)
 	require.Error(t, err, "Expected error to be present, but was nil", err)
-	assert.Equal(t, docker.AuthConfiguration{}, authconfig, "Expected Authconfig to be empty, but was %v", authconfig)
+	assert.Equal(t, types.AuthConfig{}, authconfig, "Expected Authconfig to be empty, but was %v", authconfig)
 }
 
 func TestIsTokenValid(t *testing.T) {

--- a/agent/dockerclient/dockerauth/interface.go
+++ b/agent/dockerclient/dockerauth/interface.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -17,10 +17,10 @@ package dockerauth
 
 import (
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
-	docker "github.com/fsouza/go-dockerclient"
+	"github.com/docker/docker/api/types"
 )
 
 // DockerAuthProvider is something that can give the auth information for a given docker image
 type DockerAuthProvider interface {
-	GetAuthconfig(image string, registryAuthData *apicontainer.RegistryAuthenticationData) (docker.AuthConfiguration, error)
+	GetAuthconfig(image string, registryAuthData *apicontainer.RegistryAuthenticationData) (types.AuthConfig, error)
 }

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -15,6 +15,7 @@
 package engine
 
 import (
+	"context"
 	"regexp"
 	"strconv"
 	"sync"
@@ -42,11 +43,9 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 	utilsync "github.com/aws/amazon-ecs-agent/agent/utils/sync"
 	"github.com/aws/amazon-ecs-agent/agent/utils/ttime"
-	docker "github.com/fsouza/go-dockerclient"
-
-	"context"
 
 	"github.com/cihub/seelog"
+	"github.com/docker/docker/api/types"
 	"github.com/pkg/errors"
 )
 
@@ -812,7 +811,7 @@ func (engine *DockerTaskEngine) pullAndUpdateContainerReference(task *apitask.Ta
 				},
 			}
 		}
-		defer container.SetASMDockerAuthConfig(docker.AuthConfiguration{})
+		defer container.SetASMDockerAuthConfig(types.AuthConfig{})
 	}
 
 	metadata := engine.client.PullImage(container.Image, container.RegistryAuthentication)

--- a/agent/taskresource/asmauth/asmauth.go
+++ b/agent/taskresource/asmauth/asmauth.go
@@ -27,8 +27,8 @@ import (
 	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
 
 	"github.com/cihub/seelog"
-	"github.com/fsouza/go-dockerclient"
 	"github.com/pkg/errors"
+	"github.com/docker/docker/api/types"
 )
 
 const (
@@ -55,7 +55,7 @@ type ASMAuthResource struct {
 
 	// required for asm private registry auth
 	requiredASMResources []*apicontainer.ASMAuthData
-	dockerAuthData       map[string]docker.AuthConfiguration
+	dockerAuthData       map[string]types.AuthConfig
 	// asmClientCreator is a factory interface that creates new ASM clients. This is
 	// needed mostly for testing as we're creating an asm client per every item in
 	// the requiredASMResources list. Each of these items could be from different
@@ -250,7 +250,7 @@ func (auth *ASMAuthResource) GetCreatedAt() time.Time {
 func (auth *ASMAuthResource) Create() error {
 	seelog.Infof("ASM Auth: Retrieving credentials for containers in task: [%s]", auth.taskARN)
 	if auth.dockerAuthData == nil {
-		auth.dockerAuthData = make(map[string]docker.AuthConfiguration)
+		auth.dockerAuthData = make(map[string]types.AuthConfig)
 	}
 	for _, a := range auth.GetRequiredASMResources() {
 		err := auth.retrieveASMDockerAuthData(a)
@@ -328,7 +328,7 @@ func (auth *ASMAuthResource) clearASMDockerAuthConfig() {
 
 // GetASMDockerAuthConfig retrieves the docker private registry auth data from
 // the task
-func (auth *ASMAuthResource) GetASMDockerAuthConfig(secretID string) (docker.AuthConfiguration, bool) {
+func (auth *ASMAuthResource) GetASMDockerAuthConfig(secretID string) (types.AuthConfig, bool) {
 	auth.lock.RLock()
 	defer auth.lock.RUnlock()
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Migrated AuthConfigration type to Docker SDK
### Implementation details
<!-- How are the changes implemented? -->
Migrated AuthConfigration type to Docker SDK type AuthConfig to setup migration of Pull Image.  AuthConfig contains all of the necessary fields in AuthConfiguration and migration was relatively straightforward.

A TODO was added to migrate pull image and remove conversion from AuthConfig to docker.AuthConfiguration once the inactivity timeout is figured out.

Link to branch: https://github.com/kavoor/amazon-ecs-agent/tree/auth
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enhancement - Migrated AuthConfiguration type to Docker SDK
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
