### PR TITLE
dockerapi: Migrated ImageInspect, ImageLoad, and ImageTag to Docker SDK

### DIFF
--- a/agent/dockerclient/dockerapi/docker_client.go
+++ b/agent/dockerclient/dockerapi/docker_client.go
@@ -194,7 +194,7 @@ type DockerClient interface {
 	APIVersion() (dockerclient.DockerVersion, error)
 
 	// InspectImage returns information about the specified image.
-	InspectImage(string) (*docker.Image, error)
+	InspectImage(string) (*types.ImageInspect, error)
 
 	// RemoveImage removes the metadata associated with an image and may remove the underlying layer data. A timeout
 	// value and a context should be provided for the request.
@@ -492,8 +492,7 @@ func (dg *dockerGoClient) ImportLocalEmptyVolumeImage() DockerContainerMetadata 
 }
 
 func (dg *dockerGoClient) createScratchImageIfNotExists(ctx context.Context) error {
-	client, err := dg.dockerClient()
-	sdkclient, err := dg.sdkDockerClient()
+	client, err := dg.sdkDockerClient()
 	if err != nil {
 		return err
 	}
@@ -501,7 +500,7 @@ func (dg *dockerGoClient) createScratchImageIfNotExists(ctx context.Context) err
 	scratchCreateLock.Lock()
 	defer scratchCreateLock.Unlock()
 
-	_, err = client.InspectImage(emptyvolume.Image + ":" + emptyvolume.Tag)
+	_, _, err = client.ImageInspectWithRaw(ctx, emptyvolume.Image + ":" + emptyvolume.Tag)
 	if err == nil {
 		seelog.Debug("DockerGoClient: empty volume image is already present, skipping import")
 		// Already exists; assume that it's okay to use it
@@ -525,16 +524,17 @@ func (dg *dockerGoClient) createScratchImageIfNotExists(ctx context.Context) err
 	}
 	seelog.Debug("DockerGoClient: importing empty volume image")
 	// Create it from an empty tarball
-	_, err = sdkclient.ImageImport(ctx, importSrc, emptyvolume.Image + ":" + emptyvolume.Tag, importOpts)
+	_, err = client.ImageImport(ctx, importSrc, emptyvolume.Image + ":" + emptyvolume.Tag, importOpts)
 	return err
 }
 
-func (dg *dockerGoClient) InspectImage(image string) (*docker.Image, error) {
-	client, err := dg.dockerClient()
+func (dg *dockerGoClient) InspectImage(image string) (*types.ImageInspect, error) {
+	client, err := dg.sdkDockerClient()
 	if err != nil {
 		return nil, err
 	}
-	return client.InspectImage(image)
+	imageData, _, err := client.ImageInspectWithRaw(dg.context, image)
+	return &imageData, err
 }
 
 func (dg *dockerGoClient) getAuthdata(image string, authData *apicontainer.RegistryAuthenticationData) (docker.AuthConfiguration, error) {
@@ -1338,10 +1338,7 @@ func (dg *dockerGoClient) LoadImage(ctx context.Context, inputStream io.Reader, 
 
 	response := make(chan error, 1)
 	go func() {
-		response <- dg.loadImage(docker.LoadImageOptions{
-			InputStream: inputStream,
-			Context:     ctx,
-		})
+		response <- dg.loadImage(ctx, inputStream)
 	}()
 	select {
 	case resp := <-response:
@@ -1351,10 +1348,11 @@ func (dg *dockerGoClient) LoadImage(ctx context.Context, inputStream io.Reader, 
 	}
 }
 
-func (dg *dockerGoClient) loadImage(opts docker.LoadImageOptions) error {
-	client, err := dg.dockerClient()
+func (dg *dockerGoClient) loadImage(ctx context.Context, reader io.Reader) error {
+	client, err := dg.sdkDockerClient()
 	if err != nil {
 		return err
 	}
-	return client.LoadImage(opts)
+	_, err = client.ImageLoad(ctx, reader, false)
+	return err
 }

--- a/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
+++ b/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
@@ -27,6 +27,7 @@ import (
 	status "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	dockerclient "github.com/aws/amazon-ecs-agent/agent/dockerclient"
 	dockerapi "github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
+	types "github.com/docker/docker/api/types"
 	go_dockerclient "github.com/fsouza/go-dockerclient"
 	gomock "github.com/golang/mock/gomock"
 )
@@ -143,9 +144,9 @@ func (mr *MockDockerClientMockRecorder) InspectContainer(arg0, arg1, arg2 interf
 }
 
 // InspectImage mocks base method
-func (m *MockDockerClient) InspectImage(arg0 string) (*go_dockerclient.Image, error) {
+func (m *MockDockerClient) InspectImage(arg0 string) (*types.ImageInspect, error) {
 	ret := m.ctrl.Call(m, "InspectImage", arg0)
-	ret0, _ := ret[0].(*go_dockerclient.Image)
+	ret0, _ := ret[0].(*types.ImageInspect)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/agent/engine/common_integ_test.go
+++ b/agent/engine/common_integ_test.go
@@ -70,18 +70,19 @@ func verifyContainerStoppedStateChange(t *testing.T, taskEngine TaskEngine) {
 }
 
 func setup(cfg *config.Config, state dockerstate.TaskEngineState, t *testing.T) (TaskEngine, func(), credentials.Manager) {
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
 	if os.Getenv("ECS_SKIP_ENGINE_INTEG_TEST") != "" {
 		t.Skip("ECS_SKIP_ENGINE_INTEG_TEST")
 	}
 	if !isDockerRunning() {
 		t.Skip("Docker not running")
 	}
-	ctx, cancel := context.WithCancel(context.TODO())
-	defer cancel()
 
 	clientFactory := clientfactory.NewFactory(ctx, dockerEndpoint)
 	sdkClientFactory := sdkclientfactory.NewFactory(ctx, dockerEndpoint)
-	dockerClient, err := dockerapi.NewDockerGoClient(clientFactory, sdkClientFactory, cfg, ctx)
+	dockerClient, err := dockerapi.NewDockerGoClient(clientFactory, sdkClientFactory, cfg, context.Background())
 	if err != nil {
 		t.Fatalf("Error creating Docker client: %v", err)
 	}

--- a/agent/engine/docker_image_manager_integ_test.go
+++ b/agent/engine/docker_image_manager_integ_test.go
@@ -31,7 +31,9 @@ import (
 	apitaskstatus "github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient"
 	"github.com/aws/amazon-ecs-agent/agent/statemanager"
-	docker "github.com/fsouza/go-dockerclient"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -138,11 +140,11 @@ func TestIntegImageCleanupHappyCase(t *testing.T) {
 
 	// Verify top 2 LRU images are removed from docker
 	_, err = taskEngine.(*DockerTaskEngine).client.InspectImage(imageState1ImageID)
-	if err != docker.ErrNoSuchImage {
+	if !client.IsErrNotFound(err) {
 		t.Fatalf("Image was not removed successfully")
 	}
 	_, err = taskEngine.(*DockerTaskEngine).client.InspectImage(imageState2ImageID)
-	if err != docker.ErrNoSuchImage {
+	if !client.IsErrNotFound(err) {
 		t.Fatalf("Image was not removed successfully")
 	}
 
@@ -251,11 +253,11 @@ func TestIntegImageCleanupThreshold(t *testing.T) {
 
 	// Verify Image1 & Image3 are removed from docker
 	_, err = taskEngine.(*DockerTaskEngine).client.InspectImage(imageState1ImageID)
-	if err != docker.ErrNoSuchImage {
+	if !client.IsErrNotFound(err) {
 		t.Fatalf("Image was not removed successfully")
 	}
 	_, err = taskEngine.(*DockerTaskEngine).client.InspectImage(imageState3ImageID)
-	if err != docker.ErrNoSuchImage {
+	if !client.IsErrNotFound(err) {
 		t.Fatalf("Image was not removed successfully")
 	}
 
@@ -271,6 +273,8 @@ func TestIntegImageCleanupThreshold(t *testing.T) {
 func TestImageWithSameNameAndDifferentID(t *testing.T) {
 	cfg := defaultTestConfigIntegTest()
 	cfg.TaskCleanupWaitDuration = 1 * time.Second
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
 
 	// Set low values so this test can complete in a sane amout of time
 	cfg.MinimumImageDeletionAge = 15 * time.Minute
@@ -281,8 +285,8 @@ func TestImageWithSameNameAndDifferentID(t *testing.T) {
 	dockerClient := taskEngine.(*DockerTaskEngine).client
 
 	// DockerClient doesn't implement TagImage, create a go docker client
-	goDockerClient, err := docker.NewClientFromEnv()
-	require.NoError(t, err, "Creating go docker client failed")
+	sdkDockerClient, err := client.NewClientWithOpts()
+	require.NoError(t, err, "Creating SDK docker client failed")
 
 	imageManager := taskEngine.(*DockerTaskEngine).imageManager.(*dockerImageManager)
 	imageManager.SetSaver(statemanager.NewNoopStateManager())
@@ -290,15 +294,15 @@ func TestImageWithSameNameAndDifferentID(t *testing.T) {
 	stateChangeEvents := taskEngine.StateChangeEvents()
 
 	// Pull the images needed for the test
-	if _, err = dockerClient.InspectImage(test3Image1Name); err == docker.ErrNoSuchImage {
+	if _, err = dockerClient.InspectImage(test3Image1Name); client.IsErrNotFound(err) {
 		metadata := dockerClient.PullImage(test3Image1Name, nil)
 		assert.NoError(t, metadata.Error, "Failed to pull image %s", test3Image1Name)
 	}
-	if _, err = dockerClient.InspectImage(test3Image2Name); err == docker.ErrNoSuchImage {
+	if _, err = dockerClient.InspectImage(test3Image2Name); client.IsErrNotFound(err) {
 		metadata := dockerClient.PullImage(test3Image2Name, nil)
 		assert.NoError(t, metadata.Error, "Failed to pull image %s", test3Image2Name)
 	}
-	if _, err = dockerClient.InspectImage(test3Image3Name); err == docker.ErrNoSuchImage {
+	if _, err = dockerClient.InspectImage(test3Image3Name); client.IsErrNotFound(err) {
 		metadata := dockerClient.PullImage(test3Image3Name, nil)
 		assert.NoError(t, metadata.Error, "Failed to pull image %s", test3Image3Name)
 	}
@@ -313,7 +317,7 @@ func TestImageWithSameNameAndDifferentID(t *testing.T) {
 	task2.Containers[0].Image = identicalImageName
 	task3.Containers[0].Image = identicalImageName
 
-	err = renameImage(test3Image1Name, "testimagewithsamenameanddifferentid", "latest", goDockerClient)
+	err = renameImage(test3Image1Name, task1.Containers[0].Image, sdkDockerClient)
 	assert.NoError(t, err, "Renaming the image failed")
 
 	// start and wait for task1 to be running
@@ -328,7 +332,7 @@ func TestImageWithSameNameAndDifferentID(t *testing.T) {
 	imageID1 := imageState1.Image.ImageID
 
 	// Using another image but rename to the same name as task1 for task2
-	err = renameImage(test3Image2Name, "testimagewithsamenameanddifferentid", "latest", goDockerClient)
+	err = renameImage(test3Image2Name, task2.Containers[0].Image, sdkDockerClient)
 	require.NoError(t, err, "Renaming the image failed")
 
 	// Start and wait for task2 to be running
@@ -344,7 +348,7 @@ func TestImageWithSameNameAndDifferentID(t *testing.T) {
 	require.NotEqual(t, imageID2, imageID1, "The image id in task 2 should be different from image in task 1")
 
 	// Using a different image for task3 and rename it to the same name as task1 and task2
-	err = renameImage(test3Image3Name, "testimagewithsamenameanddifferentid", "latest", goDockerClient)
+	err = renameImage(test3Image3Name, task3.Containers[0].Image, sdkDockerClient)
 	require.NoError(t, err, "Renaming the image failed")
 
 	// Start and wait for task3 to be running
@@ -389,8 +393,6 @@ func TestImageWithSameNameAndDifferentID(t *testing.T) {
 	err = verifyTaskIsCleanedUp("task3", taskEngine)
 	assert.NoError(t, err, "task3")
 
-	ctx, cancel := context.WithCancel(context.TODO())
-	defer cancel()
 	imageManager.removeUnusedImages(ctx)
 
 	// Verify all the three images are removed from image manager
@@ -399,11 +401,11 @@ func TestImageWithSameNameAndDifferentID(t *testing.T) {
 
 	// Verify images are removed by docker
 	_, err = taskEngine.(*DockerTaskEngine).client.InspectImage(imageID1)
-	assert.Equal(t, docker.ErrNoSuchImage, err, "Image was not removed successfully, image: %s", imageID1)
+	assert.True(t, client.IsErrNotFound(err), "Image was not removed successfully, image: %s", imageID1)
 	_, err = taskEngine.(*DockerTaskEngine).client.InspectImage(imageID2)
-	assert.Equal(t, docker.ErrNoSuchImage, err, "Image was not removed successfully, image: %s", imageID2)
+	assert.True(t, client.IsErrNotFound(err), "Image was not removed successfully, image: %s", imageID2)
 	_, err = taskEngine.(*DockerTaskEngine).client.InspectImage(imageID3)
-	assert.Equal(t, docker.ErrNoSuchImage, err, "Image was not removed successfully, image: %s", imageID3)
+	assert.True(t, client.IsErrNotFound(err), "Image was not removed successfully, image: %s", imageID3)
 }
 
 // TestImageWithSameIDAndDifferentNames tests images can be correctly removed if
@@ -411,6 +413,8 @@ func TestImageWithSameNameAndDifferentID(t *testing.T) {
 func TestImageWithSameIDAndDifferentNames(t *testing.T) {
 	cfg := defaultTestConfigIntegTest()
 	cfg.TaskCleanupWaitDuration = 1 * time.Second
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
 
 	// Set low values so this test can complete in a sane amout of time
 	cfg.MinimumImageDeletionAge = 15 * time.Minute
@@ -421,7 +425,7 @@ func TestImageWithSameIDAndDifferentNames(t *testing.T) {
 	dockerClient := taskEngine.(*DockerTaskEngine).client
 
 	// DockerClient doesn't implement TagImage, so create a go docker client
-	goDockerClient, err := docker.NewClientFromEnv()
+	sdkDockerClient, err := client.NewClientWithOpts()
 	require.NoError(t, err, "Creating docker client failed")
 
 	imageManager := taskEngine.(*DockerTaskEngine).imageManager.(*dockerImageManager)
@@ -438,13 +442,13 @@ func TestImageWithSameIDAndDifferentNames(t *testing.T) {
 	task3.Containers[0].Image = "testimagewithsameidanddifferentnames-3:latest"
 
 	// Pull the images needed for the test
-	if _, err = dockerClient.InspectImage(test4Image1Name); err == docker.ErrNoSuchImage {
+	if _, err = dockerClient.InspectImage(test4Image1Name); client.IsErrNotFound(err) {
 		metadata := dockerClient.PullImage(test4Image1Name, nil)
 		assert.NoError(t, metadata.Error, "Failed to pull image %s", test4Image1Name)
 	}
 
 	// Using testImage1Name for all the tasks but with different name
-	err = renameImage(test4Image1Name, "testimagewithsameidanddifferentnames-1", "latest", goDockerClient)
+	err = renameImage(test4Image1Name, task1.Containers[0].Image, sdkDockerClient)
 	require.NoError(t, err, "Renaming image failed")
 
 	// Start and wait for task1 to be running
@@ -458,11 +462,7 @@ func TestImageWithSameIDAndDifferentNames(t *testing.T) {
 	imageID1 := imageState1.Image.ImageID
 
 	// copy the image for task2 to run with same image but different name
-	err = goDockerClient.TagImage(task1.Containers[0].Image, docker.TagImageOptions{
-		Repo:  "testimagewithsameidanddifferentnames-2",
-		Tag:   "latest",
-		Force: false,
-	})
+	err = sdkDockerClient.ImageTag(ctx, task1.Containers[0].Image, task2.Containers[0].Image)
 	require.NoError(t, err, "Trying to copy image failed")
 
 	// Start and wait for task2 to be running
@@ -477,11 +477,7 @@ func TestImageWithSameIDAndDifferentNames(t *testing.T) {
 	require.Equal(t, imageID2, imageID1, "The image id in task2 should be same as in task1")
 
 	// make task3 use the same image name but different image id
-	err = goDockerClient.TagImage(task1.Containers[0].Image, docker.TagImageOptions{
-		Repo:  "testimagewithsameidanddifferentnames-3",
-		Tag:   "latest",
-		Force: false,
-	})
+	err = sdkDockerClient.ImageTag(ctx, task1.Containers[0].Image, task3.Containers[0].Image)
 	require.NoError(t, err, "Trying to copy image failed")
 
 	// Start and wait for task3 to be running
@@ -520,8 +516,6 @@ func TestImageWithSameIDAndDifferentNames(t *testing.T) {
 	err = verifyTaskIsCleanedUp("task3", taskEngine)
 	assert.NoError(t, err, "task3")
 
-	ctx, cancel := context.WithCancel(context.TODO())
-	defer cancel()
 	imageManager.removeUnusedImages(ctx)
 
 	// Verify all the images are removed from image manager
@@ -530,24 +524,23 @@ func TestImageWithSameIDAndDifferentNames(t *testing.T) {
 
 	// Verify images are removed by docker
 	_, err = taskEngine.(*DockerTaskEngine).client.InspectImage(imageID1)
-	assert.Equal(t, docker.ErrNoSuchImage, err, "Image was not removed successfully")
+	assert.True(t, client.IsErrNotFound(err), "Image was not removed successfully")
 }
 
-// renameImage retag the image and delete the original tag
-func renameImage(original, repo, tag string, client *docker.Client) error {
-	err := client.TagImage(original, docker.TagImageOptions{
-		Repo:  repo,
-		Tag:   tag,
-		Force: false,
-	})
+// renameImage retag the image with the target tag and delete the source tag
+func renameImage(source string, target string, client *client.Client) error {
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
+	err := client.ImageTag(ctx, source, target)
 	if err != nil {
 		return fmt.Errorf("Trying to tag image failed, err: %v", err)
 	}
 
-	// delete the original tag
-	err = client.RemoveImage(original)
+	// delete the source tag
+	_, err = client.ImageRemove(ctx, source, types.ImageRemoveOptions{})
 	if err != nil {
-		return fmt.Errorf("Failed to remove the original tag of the image: %s", original)
+		return fmt.Errorf("Failed to remove the source tag of the image: %s", source)
 	}
 
 	return nil

--- a/agent/engine/docker_image_manager_test.go
+++ b/agent/engine/docker_image_manager_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/engine/image"
 	"github.com/aws/amazon-ecs-agent/agent/statemanager"
 
-	docker "github.com/fsouza/go-dockerclient"
+	"github.com/docker/docker/api/types"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -58,7 +58,7 @@ func TestImagePullRemoveDeadlock(t *testing.T) {
 		Name:  "sleep",
 		Image: "busybox",
 	}
-	sleepContainerImageInspected := &docker.Image{
+	sleepContainerImageInspected := &types.ImageInspect{
 		ID: "sha256:qwerty",
 	}
 
@@ -109,7 +109,7 @@ func TestAddAndRemoveContainerToImageStateReferenceHappyPath(t *testing.T) {
 	}
 	sourceImageState.AddImageName(container.Image)
 	imageManager.(*dockerImageManager).addImageState(sourceImageState)
-	imageInspected := &docker.Image{
+	imageInspected := &types.ImageInspect{
 		ID: "sha256:qwerty",
 	}
 	client.EXPECT().InspectImage(container.Image).Return(imageInspected, nil)
@@ -194,7 +194,7 @@ func TestRecordContainerReferenceWithNoImageName(t *testing.T) {
 		PulledAt: time.Now(),
 	}
 	imageManager.addImageState(sourceImageState)
-	imageInspected := &docker.Image{
+	imageInspected := &types.ImageInspect{
 		ID: "sha256:qwerty",
 	}
 	client.EXPECT().InspectImage(container.Image).Return(imageInspected, nil).AnyTimes()
@@ -350,7 +350,7 @@ func TestRemoveContainerReferenceFromInvalidImageState(t *testing.T) {
 	container := &apicontainer.Container{
 		Image: "myContainerImage",
 	}
-	imageInspected := &docker.Image{
+	imageInspected := &types.ImageInspect{
 		ID: "sha256:qwerty",
 	}
 	client.EXPECT().InspectImage(container.Image).Return(imageInspected, nil).AnyTimes()
@@ -421,7 +421,7 @@ func TestRemoveContainerReferenceFromImageStateWithNoReference(t *testing.T) {
 		PulledAt: time.Now(),
 	}
 	imageManager.addImageState(sourceImageState)
-	imageInspected := &docker.Image{
+	imageInspected := &types.ImageInspect{
 		ID: "sha256:qwerty",
 	}
 	client.EXPECT().InspectImage(container.Image).Return(imageInspected, nil).AnyTimes()
@@ -503,7 +503,7 @@ func TestGetCandidateImagesForDeletionImageHasContainerReference(t *testing.T) {
 		PulledAt: time.Now().AddDate(0, -2, 0),
 	}
 	imageManager.addImageState(sourceImageState)
-	imageInspected := &docker.Image{
+	imageInspected := &types.ImageInspect{
 		ID: "sha256:qwerty",
 	}
 	client.EXPECT().InspectImage(container.Image).Return(imageInspected, nil).AnyTimes()
@@ -548,7 +548,7 @@ func TestGetCandidateImagesForDeletionImageHasMoreContainerReferences(t *testing
 		PulledAt: time.Now().AddDate(0, -2, 0),
 	}
 	imageManager.addImageState(sourceImageState)
-	imageInspected := &docker.Image{
+	imageInspected := &types.ImageInspect{
 		ID: "sha256:qwerty",
 	}
 	client.EXPECT().InspectImage(container.Image).Return(imageInspected, nil).AnyTimes()
@@ -666,7 +666,7 @@ func TestRemoveAlreadyExistingImageNameWithDifferentID(t *testing.T) {
 		ImageID: "sha256:qwerty",
 	}
 	sourceImage.Names = append(sourceImage.Names, container.Image)
-	imageInspected := &docker.Image{
+	imageInspected := &types.ImageInspect{
 		ID: "sha256:qwerty",
 	}
 	client.EXPECT().InspectImage(container.Image).Return(imageInspected, nil)
@@ -678,7 +678,7 @@ func TestRemoveAlreadyExistingImageNameWithDifferentID(t *testing.T) {
 		Name:  "testContainer1",
 		Image: "testContainerImage",
 	}
-	imageInspected1 := &docker.Image{
+	imageInspected1 := &types.ImageInspect{
 		ID: "sha256:asdfg",
 	}
 	client.EXPECT().InspectImage(container.Image).Return(imageInspected1, nil)
@@ -713,7 +713,7 @@ func TestImageCleanupHappyPath(t *testing.T) {
 		Name:  "testContainer",
 		Image: "testContainerImage",
 	}
-	imageInspected := &docker.Image{
+	imageInspected := &types.ImageInspect{
 		ID: "sha256:qwerty",
 	}
 	client.EXPECT().InspectImage(container.Image).Return(imageInspected, nil).AnyTimes()
@@ -769,7 +769,7 @@ func TestImageCleanupCannotRemoveImage(t *testing.T) {
 		ImageID: "sha256:qwerty",
 	}
 	sourceImage.Names = append(sourceImage.Names, container.Image)
-	imageInspected := &docker.Image{
+	imageInspected := &types.ImageInspect{
 		ID: "sha256:qwerty",
 	}
 	client.EXPECT().InspectImage(container.Image).Return(imageInspected, nil).AnyTimes()
@@ -822,7 +822,7 @@ func TestImageCleanupRemoveImageById(t *testing.T) {
 		ImageID: "sha256:qwerty",
 	}
 	sourceImage.Names = append(sourceImage.Names, container.Image)
-	imageInspected := &docker.Image{
+	imageInspected := &types.ImageInspect{
 		ID: "sha256:qwerty",
 	}
 	client.EXPECT().InspectImage(container.Image).Return(imageInspected, nil).AnyTimes()
@@ -860,7 +860,7 @@ func TestDeleteImage(t *testing.T) {
 		Name:  "testContainer",
 		Image: "testContainerImage",
 	}
-	imageInspected := &docker.Image{
+	imageInspected := &types.ImageInspect{
 		ID: "sha256:qwerty",
 	}
 	client.EXPECT().InspectImage(container.Image).Return(imageInspected, nil).AnyTimes()
@@ -891,7 +891,7 @@ func TestDeleteImageNotFoundError(t *testing.T) {
 		Name:  "testContainer",
 		Image: "testContainerImage",
 	}
-	imageInspected := &docker.Image{
+	imageInspected := &types.ImageInspect{
 		ID: "sha256:qwerty",
 	}
 	client.EXPECT().InspectImage(container.Image).Return(imageInspected, nil).AnyTimes()
@@ -923,7 +923,7 @@ func TestDeleteImageOtherRemoveImageErrors(t *testing.T) {
 		Name:  "testContainer",
 		Image: "testContainerImage",
 	}
-	imageInspected := &docker.Image{
+	imageInspected := &types.ImageInspect{
 		ID: "sha256:qwerty",
 	}
 	client.EXPECT().InspectImage(container.Image).Return(imageInspected, nil).AnyTimes()
@@ -991,7 +991,7 @@ func TestGetImageStateFromImageName(t *testing.T) {
 		Name:  "testContainer",
 		Image: "testContainerImage",
 	}
-	imageInspected := &docker.Image{
+	imageInspected := &types.ImageInspect{
 		ID: "sha256:qwerty",
 	}
 	client.EXPECT().InspectImage(container.Image).Return(imageInspected, nil).AnyTimes()
@@ -1015,7 +1015,7 @@ func TestGetImageStateFromImageNameNoImageState(t *testing.T) {
 		Name:  "testContainer",
 		Image: "testContainerImage",
 	}
-	imageInspected := &docker.Image{
+	imageInspected := &types.ImageInspect{
 		ID: "sha256:qwerty",
 	}
 	client.EXPECT().InspectImage(container.Image).Return(imageInspected, nil).AnyTimes()
@@ -1053,7 +1053,7 @@ func TestConcurrentRemoveUnusedImages(t *testing.T) {
 		ImageID: "sha256:qwerty",
 	}
 	sourceImage.Names = append(sourceImage.Names, container.Image)
-	imageInspected := &docker.Image{
+	imageInspected := &types.ImageInspect{
 		ID: "sha256:qwerty",
 	}
 	client.EXPECT().InspectImage(container.Image).Return(imageInspected, nil).AnyTimes()

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -16,6 +16,7 @@
 package engine
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -63,8 +64,6 @@ import (
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"context"
 )
 
 const (

--- a/agent/engine/engine_integ_test.go
+++ b/agent/engine/engine_integ_test.go
@@ -37,6 +37,8 @@ import (
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	sdk "github.com/docker/docker/client"
+	"github.com/docker/docker/api/types"
 )
 
 const (
@@ -91,9 +93,9 @@ func dialWithRetries(proto string, address string, tries int, timeout time.Durat
 }
 
 func removeImage(t *testing.T, img string) {
-	client, err := docker.NewClient(endpoint)
+	client, err := sdk.NewClientWithOpts(sdk.WithHost(endpoint))
 	require.NoError(t, err, "create docker client failed")
-	client.RemoveImage(img)
+	client.ImageRemove(context.TODO(), img, types.ImageRemoveOptions{})
 }
 
 // TestDockerStateToContainerState tests convert the container status from

--- a/agent/eni/pause/load.go
+++ b/agent/eni/pause/load.go
@@ -18,13 +18,13 @@ import (
 
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
-	docker "github.com/fsouza/go-dockerclient"
+	"github.com/docker/docker/api/types"
 )
 
 // Loader defines an interface for loading the pause container image. This is mostly
 // to facilitate mocking and testing of the LoadImage method
 type Loader interface {
-	LoadImage(ctx context.Context, cfg *config.Config, dockerClient dockerapi.DockerClient) (*docker.Image, error)
+	LoadImage(ctx context.Context, cfg *config.Config, dockerClient dockerapi.DockerClient) (*types.ImageInspect, error)
 }
 
 type loader struct{}

--- a/agent/eni/pause/mocks/load_mocks.go
+++ b/agent/eni/pause/mocks/load_mocks.go
@@ -23,7 +23,7 @@ import (
 
 	config "github.com/aws/amazon-ecs-agent/agent/config"
 	dockerapi "github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
-	go_dockerclient "github.com/fsouza/go-dockerclient"
+	types "github.com/docker/docker/api/types"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -51,9 +51,9 @@ func (m *MockLoader) EXPECT() *MockLoaderMockRecorder {
 }
 
 // LoadImage mocks base method
-func (m *MockLoader) LoadImage(arg0 context.Context, arg1 *config.Config, arg2 dockerapi.DockerClient) (*go_dockerclient.Image, error) {
+func (m *MockLoader) LoadImage(arg0 context.Context, arg1 *config.Config, arg2 dockerapi.DockerClient) (*types.ImageInspect, error) {
 	ret := m.ctrl.Call(m, "LoadImage", arg0, arg1, arg2)
-	ret0, _ := ret[0].(*go_dockerclient.Image)
+	ret0, _ := ret[0].(*types.ImageInspect)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/agent/eni/pause/pause_linux.go
+++ b/agent/eni/pause/pause_linux.go
@@ -23,14 +23,14 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
-	docker "github.com/fsouza/go-dockerclient"
 
 	log "github.com/cihub/seelog"
+	"github.com/docker/docker/api/types"
 	"github.com/pkg/errors"
 )
 
 // LoadImage helps load the pause container image for the agent
-func (*loader) LoadImage(ctx context.Context, cfg *config.Config, dockerClient dockerapi.DockerClient) (*docker.Image, error) {
+func (*loader) LoadImage(ctx context.Context, cfg *config.Config, dockerClient dockerapi.DockerClient) (*types.ImageInspect, error) {
 	log.Debugf("Loading pause container tarball: %s", cfg.PauseContainerTarballPath)
 	if err := loadFromFile(ctx, cfg.PauseContainerTarballPath, dockerClient, os.Default); err != nil {
 		return nil, err
@@ -59,7 +59,7 @@ func loadFromFile(ctx context.Context, path string, dockerClient dockerapi.Docke
 
 }
 
-func getPauseContainerImage(name string, tag string, dockerClient dockerapi.DockerClient) (*docker.Image, error) {
+func getPauseContainerImage(name string, tag string, dockerClient dockerapi.DockerClient) (*types.ImageInspect, error) {
 	imageName := fmt.Sprintf("%s:%s", name, tag)
 	log.Debugf("Inspecting pause container image: %s", imageName)
 

--- a/agent/eni/pause/pause_linux_test.go
+++ b/agent/eni/pause/pause_linux_test.go
@@ -90,7 +90,7 @@ func TestLoadFromFileHappyPath(t *testing.T) {
 
 	client, err := dockerapi.NewDockerGoClient(factory, sdkFactory, &defaultConfig, ctx)
 	assert.NoError(t, err)
-	mockDocker.EXPECT().LoadImage(gomock.Any()).Return(nil)
+	mockDockerSDK.EXPECT().ImageLoad(gomock.Any(), gomock.Any(), false).Return(types.ImageLoadResponse{}, nil)
 	mockfs := mock_os.NewMockFileSystem(ctrl)
 	mockfs.EXPECT().Open(pauseTarballPath).Return(nil, nil)
 
@@ -120,7 +120,7 @@ func TestLoadFromFileDockerLoadImageError(t *testing.T) {
 
 	client, err := dockerapi.NewDockerGoClient(factory, sdkFactory, &defaultConfig, ctx)
 	assert.NoError(t, err)
-	mockDocker.EXPECT().LoadImage(gomock.Any()).Return(
+	mockDockerSDK.EXPECT().ImageLoad(gomock.Any(), gomock.Any(), false).Return( types.ImageLoadResponse{},
 		errors.New("Dummy Load Image Error"))
 	mockfs := mock_os.NewMockFileSystem(ctrl)
 
@@ -149,8 +149,8 @@ func TestGetPauseContainerImageInspectImageError(t *testing.T) {
 
 	client, err := dockerapi.NewDockerGoClient(factory, sdkFactory, &defaultConfig, ctx)
 	assert.NoError(t, err)
-	mockDocker.EXPECT().InspectImage(pauseName+":"+pauseTag).Return(
-		nil, errors.New("error"))
+	mockDockerSDK.EXPECT().ImageInspectWithRaw(gomock.Any(), pauseName+":"+pauseTag).Return(
+		types.ImageInspect{}, nil, errors.New("error"))
 
 	_, err = getPauseContainerImage(pauseName, pauseTag, client)
 	assert.Error(t, err)
@@ -176,7 +176,7 @@ func TestGetPauseContainerHappyPath(t *testing.T) {
 
 	client, err := dockerapi.NewDockerGoClient(factory, sdkFactory, &defaultConfig, ctx)
 	assert.NoError(t, err)
-	mockDocker.EXPECT().InspectImage(pauseName+":"+pauseTag).Return(nil, nil)
+	mockDockerSDK.EXPECT().ImageInspectWithRaw(gomock.Any(), pauseName+":"+pauseTag).Return(types.ImageInspect{}, nil, nil)
 
 	_, err = getPauseContainerImage(pauseName, pauseTag, client)
 	assert.NoError(t, err)

--- a/agent/eni/pause/pause_unsupported.go
+++ b/agent/eni/pause/pause_unsupported.go
@@ -21,12 +21,12 @@ import (
 
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
-	docker "github.com/fsouza/go-dockerclient"
+	"github.com/docker/docker/api/types"
 	"github.com/pkg/errors"
 )
 
 // LoadImage returns UnsupportedPlatformError on the unsupported platform
-func (*loader) LoadImage(ctx context.Context, cfg *config.Config, dockerClient dockerapi.DockerClient) (*docker.Image, error) {
+func (*loader) LoadImage(ctx context.Context, cfg *config.Config, dockerClient dockerapi.DockerClient) (*types.ImageInspect, error) {
 	return nil, NewUnsupportedPlatformError(errors.Errorf(
 		"pause container load: unsupported platform: %s/%s",
 		runtime.GOOS, runtime.GOARCH))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Migrated ImageInspect, ImageLoad, and ImageTag to Docker SDK
### Implementation details
<!-- How are the changes implemented? -->
- Migrated docker.Image to the Docker SDK type ImageInspect
- Migrated ImageInspect, ImageLoad, ContainerKill, and ImageTag to Docker SDK
- Migrated errors to Docker SDK (errNoSuchImage)
- Updated files affected by these migrations to correct types, mocks, and function parameters.
Link to Branch: https://github.com/kavoor/amazon-ecs-agent/tree/imgMoby
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enhancement - Migrated ImageInspect and ImageLoad to Docker SDK
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
