### PR TITLE
volume: set the type to default if not specified

### DIFF
--- a/agent/api/task/taskvolume_test.go
+++ b/agent/api/task/taskvolume_test.go
@@ -32,6 +32,33 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestMarshalUnmarshalOldTaskVolumes(t *testing.T) {
+	taskData := `{"volumes":[{"host":{"sourcePath":"/path"},"name":"1"},{"host":{"sourcePath":""}, "name":"2"}]}`
+
+	var out Task
+	err := json.Unmarshal([]byte(taskData), &out)
+	require.NoError(t, err, "Could not unmarshal task")
+	require.Len(t, out.Volumes, 2, "Incorrect number of volumes")
+
+	var v1, v2 TaskVolume
+
+	for _, v := range out.Volumes {
+		switch v.Name {
+		case "1":
+			v1 = v
+		case "2":
+			v2 = v
+		}
+	}
+
+	_, ok := v1.Volume.(*taskresourcevolume.FSHostVolume)
+	assert.True(t, ok, "Expected v1 to be host volume")
+	assert.Equal(t, "/path", v1.Volume.(*taskresourcevolume.FSHostVolume).FSSourcePath, "Unmarshaled v2 didn't match marshalled v2")
+	_, ok = v2.Volume.(*taskresourcevolume.LocalDockerVolume)
+	assert.True(t, ok, "Expected v2 to be local empty volume")
+	assert.Equal(t, "", v2.Volume.Source(), "Expected v2 to have 'sourcepath' work correctly")
+}
+
 func TestMarshalUnmarshalTaskVolumes(t *testing.T) {
 	task := &Task{
 		Arn: "test",
@@ -65,7 +92,7 @@ func TestMarshalUnmarshalTaskVolumes(t *testing.T) {
 
 	_, ok := v1.Volume.(*taskresourcevolume.LocalDockerVolume)
 	assert.True(t, ok, "Expected v1 to be local empty volume")
-	assert.Equal(t, "/path", v2.Volume.Source(), "Expected v2 to have 'sourcepath' work correctly")
+	assert.Equal(t, "", v1.Volume.Source(), "Expected v2 to have 'sourcepath' work correctly")
 	_, ok = v2.Volume.(*taskresourcevolume.FSHostVolume)
 	assert.True(t, ok, "Expected v2 to be host volume")
 	assert.Equal(t, "/path", v2.Volume.(*taskresourcevolume.FSHostVolume).FSSourcePath, "Unmarshaled v2 didn't match marshalled v2")

--- a/agent/api/task/taskvolume_test.go
+++ b/agent/api/task/taskvolume_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 func TestMarshalUnmarshalOldTaskVolumes(t *testing.T) {
-	taskData := `{"volumes":[{"host":{"sourcePath":"/path"},"name":"1"},{"host":{"sourcePath":""}, "name":"2"}]}`
+	taskData := `{"volumes":[{"host":{"sourcePath":"/path"},"name":"1"},{"host":{"hostpath":""}, "name":"2"}]}`
 
 	var out Task
 	err := json.Unmarshal([]byte(taskData), &out)

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -337,6 +337,11 @@ func updateContainerMetadata(metadata *dockerapi.DockerContainerMetadata, contai
 		container.SetLabels(metadata.Labels)
 	}
 
+	// Update volume for empty volume container
+	if metadata.Volumes != nil && container.IsInternal() {
+		task.UpdateMountPoints(container, metadata.Volumes)
+	}
+
 	// Set Exitcode if it's not set
 	if metadata.ExitCode != nil {
 		container.SetKnownExitCode(metadata.ExitCode)

--- a/agent/functional_tests/testdata/taskdefinitions/task-shared-vol-read/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/task-shared-vol-read/task-definition.json
@@ -23,10 +23,6 @@
                 "scope": "shared",
                 "autoprovision": false,
                 "driver": "local",
-                "driverOpts": {
-                    "type": "tmpfs",
-                    "device": "tmpfs"
-                },
                 "labels": {
                     "mylables": "test"
                 }

--- a/agent/functional_tests/testdata/taskdefinitions/task-shared-vol-write/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/task-shared-vol-write/task-definition.json
@@ -23,10 +23,6 @@
                 "scope": "shared",
                 "autoprovision": true,
                 "driver": "local",
-                "driverOpts": {
-                    "type": "tmpfs",
-                    "device": "tmpfs"
-                },
                 "labels": {
                     "mylables": "test"
                 }

--- a/agent/functional_tests/tests/functionaltests_unix_test.go
+++ b/agent/functional_tests/tests/functionaltests_unix_test.go
@@ -910,15 +910,15 @@ func TestTwoTasksSharedLocalVolume(t *testing.T) {
 	wTask, err := agent.StartTask(t, "task-shared-vol-write")
 	require.NoError(t, err, "Register task definition failed")
 
-	// then reader task
-	rTask, err := agent.StartTask(t, "task-shared-vol-read")
-	require.NoError(t, err, "Register task definition failed")
-
-	// clean up
+	// Wait for the first task to create the volume
 	wErr := wTask.WaitStopped(waitTaskStateChangeDuration)
 	require.NoError(t, wErr, "Error waiting for task to transition to STOPPED")
 	wExitCode, _ := wTask.ContainerExitcode("task-shared-vol-write")
 	assert.Equal(t, 42, wExitCode, fmt.Sprintf("Expected exit code of 42; got %d", wExitCode))
+
+	// then reader task try to read from the volume
+	rTask, err := agent.StartTask(t, "task-shared-vol-read")
+	require.NoError(t, err, "Register task definition failed")
 
 	rErr := rTask.WaitStopped(waitTaskStateChangeDuration)
 	require.NoError(t, rErr, "Error waiting for task to transition to STOPPED")

--- a/agent/functional_tests/tests/functionaltests_windows_test.go
+++ b/agent/functional_tests/tests/functionaltests_windows_test.go
@@ -359,13 +359,13 @@ func TestTwoTasksSharedLocalVolume(t *testing.T) {
 	wTask, wTaskErr := agent.StartTask(t, "task-shared-vol-write-windows")
 	require.NoError(t, wTaskErr, "Register task definition failed")
 
-	rTask, rTaskErr := agent.StartTask(t, "task-shared-vol-read-windows")
-	require.NoError(t, rTaskErr, "Register task definition failed")
-
 	wErr := wTask.WaitStopped(waitTaskStateChangeDuration)
 	assert.NoError(t, wErr, "Expect task to be stopped")
 	wExitCode := wTask.Containers[0].ExitCode
 	assert.NotEqual(t, 42, wExitCode, fmt.Sprintf("Expected exit code of 42; got %d", wExitCode))
+
+	rTask, rTaskErr := agent.StartTask(t, "task-shared-vol-read-windows")
+	require.NoError(t, rTaskErr, "Register task definition failed")
 
 	rErr := rTask.WaitStopped(waitTaskStateChangeDuration)
 	assert.NoError(t, rErr, "Expect task to be stopped")

--- a/agent/taskresource/volume/dockervolume.go
+++ b/agent/taskresource/volume/dockervolume.go
@@ -292,7 +292,7 @@ func (vol *VolumeResource) Create() error {
 	}
 
 	// set readonly field after creation
-	vol.setMountPoint(volumeResponse.DockerVolume.Mountpoint)
+	vol.setMountPoint(volumeResponse.DockerVolume.Name)
 	return nil
 }
 

--- a/agent/taskresource/volume/dockervolume_test.go
+++ b/agent/taskresource/volume/dockervolume_test.go
@@ -56,7 +56,7 @@ func TestCreateSuccess(t *testing.T) {
 	volume, _ := NewVolumeResource(ctx, name, name, scope, autoprovision, driver, driverOptions, nil, mockClient)
 	err := volume.Create()
 	assert.NoError(t, err)
-	assert.Equal(t, mountPoint, volume.VolumeConfig.Mountpoint)
+	assert.Equal(t, name, volume.VolumeConfig.Mountpoint)
 }
 
 func TestCreateError(t *testing.T) {


### PR DESCRIPTION
With the new volume driver support, a new field was added to the volume
struct, where it's not set in the old state file. This PR try to set the
volume type to default if it's not set or restored from old state file.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Fix #1507 

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
