### PR TITLE
dockerapi: Migrated PluginList to Docker SDK

### DIFF
--- a/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
+++ b/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
@@ -28,6 +28,7 @@ import (
 	dockerclient "github.com/aws/amazon-ecs-agent/agent/dockerclient"
 	dockerapi "github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	types "github.com/docker/docker/api/types"
+	filters "github.com/docker/docker/api/types/filters"
 	go_dockerclient "github.com/fsouza/go-dockerclient"
 	gomock "github.com/golang/mock/gomock"
 )
@@ -193,15 +194,15 @@ func (mr *MockDockerClientMockRecorder) ListContainers(arg0, arg1, arg2 interfac
 }
 
 // ListPlugins mocks base method
-func (m *MockDockerClient) ListPlugins(arg0 context.Context, arg1 time.Duration) dockerapi.ListPluginsResponse {
-	ret := m.ctrl.Call(m, "ListPlugins", arg0, arg1)
+func (m *MockDockerClient) ListPlugins(arg0 context.Context, arg1 time.Duration, arg2 filters.Args) dockerapi.ListPluginsResponse {
+	ret := m.ctrl.Call(m, "ListPlugins", arg0, arg1, arg2)
 	ret0, _ := ret[0].(dockerapi.ListPluginsResponse)
 	return ret0
 }
 
 // ListPlugins indicates an expected call of ListPlugins
-func (mr *MockDockerClientMockRecorder) ListPlugins(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPlugins", reflect.TypeOf((*MockDockerClient)(nil).ListPlugins), arg0, arg1)
+func (mr *MockDockerClientMockRecorder) ListPlugins(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPlugins", reflect.TypeOf((*MockDockerClient)(nil).ListPlugins), arg0, arg1, arg2)
 }
 
 // ListPluginsWithFilters mocks base method

--- a/agent/dockerclient/dockerapi/types.go
+++ b/agent/dockerclient/dockerapi/types.go
@@ -98,7 +98,7 @@ type SDKVolumeResponse struct {
 
 // ListPluginsResponse is a wrapper for ListPlugins api
 type ListPluginsResponse struct {
-	Plugins []docker.PluginDetail
+	Plugins []*types.Plugin
 	Error   error
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Migrated ListPlugins to Docker SDK
### Implementation details
<!-- How are the changes implemented? -->
- Migrated ListPlugins to the Docker SDK API call
- Removed code that filtered the plugins and instead pass in the filters to the Docker SDK API call, removing a TODO. 
- Updated mocks
- Updated tests with new plugin types, arguments, and outputs
- go fmt 

Link to branch: https://github.com/kavoor/amazon-ecs-agent/tree/listPlugin
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
** will update these as they complete **
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enhancement - Migrated PluginList to Docker SDK
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
