### PR TITLE
test: add functional test for v3 task endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,5 @@ _bin/
 *-stamp
 /.idea/
 /misc/taskmetadata-validator/taskmetadata-validator
+/misc/v3-task-endpoint-validator/v3-task-endpoint-validator
 /bin

--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ test-artifacts-linux: $(LINUX_ARTIFACTS_TARGETS)
 test-artifacts: test-artifacts-windows test-artifacts-linux
 
 # Run our 'test' registry needed for integ and functional tests
-test-registry: netkitten volumes-test squid awscli image-cleanup-test-images fluentd taskmetadata-validator
+test-registry: netkitten volumes-test squid awscli image-cleanup-test-images fluentd taskmetadata-validator v3-task-endpoint-validator
 	@./scripts/setup-test-registry
 
 test-in-docker:
@@ -242,7 +242,7 @@ volumes-test:
 
 # TODO, replace this with a build on dockerhub or a mechanism for the
 # functional tests themselves to build this
-.PHONY: squid awscli fluentd gremlin taskmetadata-validator image-cleanup-test-images ecr-execution-role-image container-health-check-image telemetry-test-image
+.PHONY: squid awscli fluentd gremlin taskmetadata-validator v3-task-endpoint-validator image-cleanup-test-images ecr-execution-role-image container-health-check-image telemetry-test-image
 squid:
 	$(MAKE) -C misc/squid $(MFLAGS)
 
@@ -263,6 +263,9 @@ image-cleanup-test-images:
 
 taskmetadata-validator:
 	$(MAKE) -C misc/taskmetadata-validator $(MFLAGS)
+
+v3-task-endpoint-validator:
+	$(MAKE) -C misc/v3-task-endpoint-validator $(MFLAGS)
 
 ecr-execution-role-image:
 	$(MAKE) -C misc/ecr $(MFLAGS)
@@ -322,6 +325,7 @@ clean:
 	-$(MAKE) -C misc/testnnp $(MFLAGS) clean
 	-$(MAKE) -C misc/image-cleanup-test-images $(MFLAGS) clean
 	-$(MAKE) -C misc/taskmetadata-validator $(MFLAGS) clean
+	-$(MAKE) -C misc/v3-task-endpoint-validator $(MFLAGS) clean
 	-$(MAKE) -C misc/container-health $(MFLAGS) clean
 	-$(MAKE) -C misc/telemetry $(MFLAGS) clean
 	-rm -f .get-deps-stamp

--- a/agent/functional_tests/README.md
+++ b/agent/functional_tests/README.md
@@ -23,6 +23,11 @@ Before running these tests, you should build the ECS agent and tag its image as
 
 You should also run the registry the tests pull from. This can most easily be done via `make test-registry`.
 
+You should run following commands to set up the IP tables rules:
+* `sysctl -w net.ipv4.conf.all.route_localnet=1`
+* `iptables -t nat -A PREROUTING -p tcp -d 169.254.170.2 --dport 80 -j DNAT --to-destination 127.0.0.1:51679`
+* `iptables -t nat -A OUTPUT -d 169.254.170.2 -p tcp -m tcp --dport 80 -j REDIRECT --to-ports 51679`
+
 #### Environment variables
 In order to run telemetry functional test in non Amazon Linux AMI environment
 with older versions of the ECS agent (pre-1.10.0), the following environment
@@ -44,8 +49,6 @@ execution behavior:
 #### Additional setup for IAM roles
 In order to run TaskIamRole functional tests, the following steps should be
 done first:
-* Run command: `sysctl -w net.ipv4.conf.all.route_localnet=1` and
-  `iptables -t nat -A PREROUTING -p tcp -d 169.254.170.2 --dport 80 -j DNAT --to-destination 127.0.0.1:51679`.
 * Set the environment variable of IAM roles the test will use:
   `export TASK_IAM_ROLE_ARN="iam role arn"`. The role should have the
   `ec2:DescribeRegions` permission and have a trust relationship with
@@ -54,8 +57,6 @@ done first:
   In this case, the IAM role should additionally have the
   `iam:GetInstanceProfile` permission.
 * To skip the test `TestTaskIAMRolesDefaultNetworkMode`, please set `TEST_DISABLE_TASK_IAM_ROLE` to be true.
-* Testing under net=host network mode requires additional commands:
-  `iptables -t nat -A OUTPUT -d 169.254.170.2 -p tcp -m tcp --dport 80 -j REDIRECT --to-ports 51679`
 * To skip the test `TestTaskIAMRolesNetHostMode`, please set `TEST_DISABLE_TASK_IAM_ROLE_NET_HOST` to be true.
 
 

--- a/agent/functional_tests/testdata/taskdefinitions/v3-task-endpoint-validator-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/v3-task-endpoint-validator-windows/task-definition.json
@@ -1,0 +1,26 @@
+{
+  "family": "ecsftest-v3-task-endpoint-validator-windows",
+  "containerDefinitions": [{
+    "image": "amazon/amazon-ecs-v3-task-endpoint-validator-windows",
+    "name": "v3-task-endpoint-validator-windows",
+    "memory": 512,
+    "cpu": 1024,
+    "healthCheck": {
+      "command": ["CMD-SHELL", "echo hello"],
+      "interval": 5,
+      "timeout": 5,
+      "retries": 2,
+      "startPeriod": 1
+    },
+    "entryPoint": ["powershell"],
+    "command": [".\\application.ps1; $env:AWS_REGION=\"$$$TEST_REGION$$$\";.\\v3-task-endpoint-validator-windows.exe; exit $LASTEXITCODE"],
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group":"ecs-functional-tests",
+        "awslogs-region":"$$$TEST_REGION$$$",
+        "awslogs-stream-prefix":"$$$TEST_AWSLOGS_STREAM_PREFIX$$$"
+      }
+    }
+  }]
+}

--- a/agent/functional_tests/testdata/taskdefinitions/v3-task-endpoint-validator/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/v3-task-endpoint-validator/task-definition.json
@@ -1,0 +1,24 @@
+{
+  "family": "ecsftest-v3-task-endpoint-validator",
+  "networkMode": "$$$NETWORK_MODE$$$",
+  "containerDefinitions": [{
+    "image": "127.0.0.1:51670/amazon/amazon-ecs-v3-task-endpoint-validator:latest",
+    "name": "v3-task-endpoint-validator",
+    "memory": 50,
+    "healthCheck": {
+      "command": ["CMD-SHELL", "echo hello"],
+      "interval": 5,
+      "timeout": 5,
+      "retries": 2,
+      "startPeriod": 1
+    },
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group":"ecs-functional-tests",
+        "awslogs-region":"$$$TEST_REGION$$$",
+        "awslogs-stream-prefix":"$$$TEST_AWSLOGS_STREAM_PREFIX$$$"
+      }
+    }
+  }]
+}

--- a/agent/functional_tests/tests/functionaltests_windows_test.go
+++ b/agent/functional_tests/tests/functionaltests_windows_test.go
@@ -161,7 +161,7 @@ func taskIamRolesTest(networkMode string, agent *TestAgent, t *testing.T) {
 	}
 	if !iamRoleEnabled {
 		task.Stop()
-		t.Fatalf("Could not found AWS_CONTAINER_CREDENTIALS_RELATIVE_URI in the container environment variable")
+		t.Fatal("Could not found AWS_CONTAINER_CREDENTIALS_RELATIVE_URI in the container environment variable")
 	}
 
 	// Task will only run one command "aws ec2 describe-regions"
@@ -178,7 +178,10 @@ func taskIamRolesTest(networkMode string, agent *TestAgent, t *testing.T) {
 	if containerMetaData.State.ExitCode != 42 {
 		t.Fatalf("Container exit code non-zero: %v", containerMetaData.State.ExitCode)
 	}
+}
 
+func TestV3TaskEndpointDefaultNetworkMode(t *testing.T) {
+	testV3TaskEndpoint(t, "v3-task-endpoint-validator-windows", "v3-task-endpoint-validator-windows", "", "ecs-functional-tests-v3-task-endpoint-validator-windows")
 }
 
 // TestMetadataServiceValidator Tests that the metadata file can be accessed from the

--- a/misc/v3-task-endpoint-validator-windows/application.ps1
+++ b/misc/v3-task-endpoint-validator-windows/application.ps1
@@ -1,0 +1,17 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+$gateway = (Get-WMIObject -Class Win32_IP4RouteTable | Where { $_.Destination -eq '0.0.0.0' -and $_.Mask -eq '0.0.0.0' } | Sort-Object Metric1 | Select NextHop).NextHop
+$ifIndex = (Get-NetAdapter -InterfaceDescription "Hyper-V Virtual Ethernet*" | Sort-Object | Select ifIndex).ifIndex
+route -p add 169.254.170.2 mask 255.255.255.255 0.0.0.0
+New-NetRoute -DestinationPrefix 169.254.169.254/32 -InterfaceIndex $ifindex -NextHop $gateway

--- a/misc/v3-task-endpoint-validator-windows/setup-v3-task-endpoint-validator.ps1
+++ b/misc/v3-task-endpoint-validator-windows/setup-v3-task-endpoint-validator.ps1
@@ -1,0 +1,37 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+$oldPref = $ErrorActionPreference
+$ErrorActionPreference = 'Stop'
+
+Invoke-Expression ${PSScriptRoot}\..\windows-deploy\hostsetup.ps1
+
+# Create amazon/amazon-ecs-v3-task-endpoint-validator-windows for tests
+$buildscript = @"
+mkdir C:\V3
+cp C:\ecs\v3-task-endpoint-validator-windows.go C:\V3
+go get -u  github.com/cihub/seelog
+go build -o C:\V3\v3-task-endpoint-validator-windows.exe C:\V3\v3-task-endpoint-validator-windows.go
+cp C:\V3\v3-task-endpoint-validator-windows.exe C:\ecs
+"@
+
+$buildimage="golang:1.7-windowsservercore"
+docker pull $buildimage
+
+docker run `
+  --volume ${PSScriptRoot}:C:\ecs `
+  $buildimage `
+  powershell ${buildscript}
+
+Invoke-Expression "docker build -t amazon/amazon-ecs-v3-task-endpoint-validator-windows --file ${PSScriptRoot}\v3-task-endpoint-validator-windows.dockerfile ${PSScriptRoot}"
+$ErrorActionPreference = $oldPref

--- a/misc/v3-task-endpoint-validator-windows/v3-task-endpoint-validator-windows.dockerfile
+++ b/misc/v3-task-endpoint-validator-windows/v3-task-endpoint-validator-windows.dockerfile
@@ -1,0 +1,17 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+FROM microsoft/windowsservercore:latest
+
+ADD application.ps1 application.ps1
+ADD v3-task-endpoint-validator-windows.exe v3-task-endpoint-validator-windows.exe

--- a/misc/v3-task-endpoint-validator-windows/v3-task-endpoint-validator-windows.go
+++ b/misc/v3-task-endpoint-validator-windows/v3-task-endpoint-validator-windows.go
@@ -1,0 +1,345 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/cihub/seelog"
+)
+
+const (
+	containerMetadataEnvVar = "ECS_CONTAINER_METADATA_URI"
+	maxRetries              = 4
+	durationBetweenRetries  = time.Second
+)
+
+// TaskResponse defines the schema for the task response JSON object
+type TaskResponse struct {
+	Cluster            string              `json:"Cluster"`
+	TaskARN            string              `json:"TaskARN"`
+	Family             string              `json:"Family"`
+	Revision           string              `json:"Revision"`
+	DesiredStatus      string              `json:"DesiredStatus,omitempty"`
+	KnownStatus        string              `json:"KnownStatus"`
+	Containers         []ContainerResponse `json:"Containers,omitempty"`
+	Limits             *LimitsResponse     `json:"Limits,omitempty"`
+	PullStartedAt      *time.Time          `json:"PullStartedAt,omitempty"`
+	PullStoppedAt      *time.Time          `json:"PullStoppedAt,omitempty"`
+	ExecutionStoppedAt *time.Time          `json:"ExecutionStoppedAt,omitempty"`
+}
+
+// ContainerResponse defines the schema for the container response
+// JSON object
+type ContainerResponse struct {
+	ID            string            `json:"DockerId"`
+	Name          string            `json:"Name"`
+	DockerName    string            `json:"DockerName"`
+	Image         string            `json:"Image"`
+	ImageID       string            `json:"ImageID"`
+	Ports         []PortResponse    `json:"Ports,omitempty"`
+	Labels        map[string]string `json:"Labels,omitempty"`
+	DesiredStatus string            `json:"DesiredStatus"`
+	KnownStatus   string            `json:"KnownStatus"`
+	ExitCode      *int              `json:"ExitCode,omitempty"`
+	Limits        LimitsResponse    `json:"Limits"`
+	CreatedAt     *time.Time        `json:"CreatedAt,omitempty"`
+	StartedAt     *time.Time        `json:"StartedAt,omitempty"`
+	FinishedAt    *time.Time        `json:"FinishedAt,omitempty"`
+	Type          string            `json:"Type"`
+	Networks      []Network         `json:"Networks,omitempty"`
+	Health        HealthStatus      `json:"Health,omitempty"`
+}
+
+// LimitsResponse defines the schema for task/cpu limits response
+// JSON object
+type LimitsResponse struct {
+	CPU    *float64 `json:"CPU,omitempty"`
+	Memory *int64   `json:"Memory,omitempty"`
+}
+
+type HealthStatus struct {
+	Status   string     `json:"status,omitempty"`
+	Since    *time.Time `json:"statusSince,omitempty"`
+	ExitCode int        `json:"exitCode,omitempty"`
+	Output   string     `json:"output,omitempty"`
+}
+
+// PortResponse defines the schema for portmapping response JSON
+// object.
+type PortResponse struct {
+	ContainerPort uint16 `json:"ContainerPort,omitempty"`
+	Protocol      string `json:"Protocol,omitempty"`
+	HostPort      uint16 `json:"HostPort,omitempty"`
+}
+
+// Network is a struct that keeps track of metadata of a network interface
+type Network struct {
+	NetworkMode   string   `json:"NetworkMode,omitempty"`
+	IPv4Addresses []string `json:"IPv4Addresses,omitempty"`
+	IPv6Addresses []string `json:"IPv6Addresses,omitempty"`
+}
+
+func verifyContainerMetadata(client *http.Client, containerMetadataEndpoint string) error {
+	var err error
+	body, err := metadataResponse(client, containerMetadataEndpoint)
+	if err != nil {
+		return err
+	}
+
+	seelog.Infof("Received container metadata: %s \n", string(body))
+
+	var containerMetadata ContainerResponse
+	if err = json.Unmarshal(body, &containerMetadata); err != nil {
+		return fmt.Errorf("unable to parse response body: %v", err)
+	}
+
+	if err = verifyContainerMetadataResponse(body); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func verifyTaskMetadata(client *http.Client, taskMetadataEndpoint string) error {
+	body, err := metadataResponse(client, taskMetadataEndpoint)
+	if err != nil {
+		return err
+	}
+
+	seelog.Infof("Received task metadata: %s \n", string(body))
+
+	var taskMetadata TaskResponse
+	if err = json.Unmarshal(body, &taskMetadata); err != nil {
+		return fmt.Errorf("unable to parse response body: %v", err)
+	}
+
+	if err = verifyTaskMetadataResponse(body); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func verifyContainerStats(client *http.Client, containerStatsEndpoint string) error {
+	body, err := metadataResponse(client, containerStatsEndpoint)
+	if err != nil {
+		return err
+	}
+
+	seelog.Infof("Received container stats: %s \n", string(body))
+
+	return nil
+}
+
+func verifyTaskStats(client *http.Client, taskStatsEndpoint string) error {
+	body, err := metadataResponse(client, taskStatsEndpoint)
+	if err != nil {
+		return err
+	}
+
+	seelog.Infof("Received task stats: %s \n", string(body))
+
+	return nil
+}
+
+func verifyTaskMetadataResponse(taskMetadataRawMsg json.RawMessage) error {
+	var err error
+	taskMetadataResponseMap := make(map[string]json.RawMessage)
+	json.Unmarshal(taskMetadataRawMsg, &taskMetadataResponseMap)
+
+	taskExpectedFieldEqualMap := map[string]interface{}{
+		"Cluster":       "ecs-functional-tests",
+		"Revision":      "1",
+		"DesiredStatus": "RUNNING",
+		"KnownStatus":   "RUNNING",
+	}
+
+	taskExpectedFieldNotEmptyArray := []string{"TaskARN", "Family", "PullStartedAt", "PullStoppedAt", "Containers"}
+
+	for fieldName, fieldVal := range taskExpectedFieldEqualMap {
+		if err = fieldEqual(taskMetadataResponseMap, fieldName, fieldVal); err != nil {
+			return err
+		}
+	}
+
+	for _, fieldName := range taskExpectedFieldNotEmptyArray {
+		if err = fieldNotEmpty(taskMetadataResponseMap, fieldName); err != nil {
+			return err
+		}
+	}
+
+	var containersMetadataResponseArray []json.RawMessage
+	json.Unmarshal(taskMetadataResponseMap["Containers"], &containersMetadataResponseArray)
+
+	return verifyContainerMetadataResponse(containersMetadataResponseArray[0])
+}
+
+func verifyContainerMetadataResponse(containerMetadataRawMsg json.RawMessage) error {
+	var err error
+	containerMetadataResponseMap := make(map[string]json.RawMessage)
+	json.Unmarshal(containerMetadataRawMsg, &containerMetadataResponseMap)
+
+	containerExpectedFieldEqualMap := map[string]interface{}{
+		"Name":          "v3-task-endpoint-validator-windows",
+		"Image":         "amazon/amazon-ecs-v3-task-endpoint-validator-windows",
+		"DesiredStatus": "RUNNING",
+		"KnownStatus":   "RUNNING",
+		"Type":          "NORMAL",
+	}
+
+	taskExpectedFieldNotEmptyArray := []string{"DockerId", "DockerName", "ImageID", "Limits", "CreatedAt", "StartedAt", "Health"}
+
+	for fieldName, fieldVal := range containerExpectedFieldEqualMap {
+		if err = fieldEqual(containerMetadataResponseMap, fieldName, fieldVal); err != nil {
+			return err
+		}
+	}
+
+	for _, fieldName := range taskExpectedFieldNotEmptyArray {
+		if err = fieldNotEmpty(containerMetadataResponseMap, fieldName); err != nil {
+			return err
+		}
+	}
+
+	if err = verifyLimitResponse(containerMetadataResponseMap["Limits"]); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func verifyLimitResponse(limitRawMsg json.RawMessage) error {
+	var err error
+	limitResponseMap := make(map[string]json.RawMessage)
+	json.Unmarshal(limitRawMsg, &limitResponseMap)
+
+	limitExpectedFieldEqualMap := map[string]interface{}{
+		"CPU":    float64(1024),
+		"Memory": float64(512),
+	}
+
+	for fieldName, fieldVal := range limitExpectedFieldEqualMap {
+		if err = fieldEqual(limitResponseMap, fieldName, fieldVal); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func metadataResponse(client *http.Client, endpoint string) ([]byte, error) {
+	var resp []byte
+	var err error
+	for i := 0; i < maxRetries; i++ {
+		resp, err = metadataResponseOnce(client, endpoint)
+		if err == nil {
+			return resp, nil
+		}
+		fmt.Fprintf(os.Stderr, "Attempt [%d/%d]: unable to get metadata response from '%s': %v",
+			i, maxRetries, endpoint, err)
+		time.Sleep(durationBetweenRetries)
+	}
+
+	return nil, err
+}
+
+func metadataResponseOnce(client *http.Client, endpoint string) ([]byte, error) {
+	resp, err := client.Get(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get response: %v", err)
+	}
+	if resp.Body != nil {
+		defer resp.Body.Close()
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("incorrect status code  %d", resp.StatusCode)
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read response body: %v", err)
+	}
+
+	return body, nil
+}
+
+func notEmptyErrMsg(fieldName string) error {
+	return fmt.Errorf("field %s should not be empty", fieldName)
+}
+
+func fieldNotEmpty(rawMsgMap map[string]json.RawMessage, fieldName string) error {
+	if rawMsgMap[fieldName] == nil {
+		return notEmptyErrMsg(fieldName)
+	}
+
+	return nil
+}
+
+func fieldEqual(rawMsgMap map[string]json.RawMessage, fieldName string, fieldVal interface{}) error {
+	if err := fieldNotEmpty(rawMsgMap, fieldName); err != nil {
+		return err
+	}
+
+	var actualFieldVal interface{}
+	json.Unmarshal(rawMsgMap[fieldName], &actualFieldVal)
+
+	if fieldVal != actualFieldVal {
+		return fmt.Errorf("incorrect field value for field %s, expected %v, received %v",
+			fieldName, fieldVal, actualFieldVal)
+	}
+
+	return nil
+}
+
+func main() {
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+	}
+
+	// Wait for the Health information to be ready
+	time.Sleep(5 * time.Second)
+
+	v3BaseEndpoint := os.Getenv(containerMetadataEnvVar)
+	containerMetadataPath := v3BaseEndpoint
+	taskMetadataPath := v3BaseEndpoint + "/task"
+	containerStatsPath := v3BaseEndpoint + "/stats"
+	taskStatsPath := v3BaseEndpoint + "/task/stats"
+
+	if err := verifyContainerMetadata(client, containerMetadataPath); err != nil {
+		seelog.Infof("Container metadata: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := verifyTaskMetadata(client, taskMetadataPath); err != nil {
+		seelog.Infof("Task metadata: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := verifyContainerStats(client, containerStatsPath); err != nil {
+		seelog.Infof("Container stats: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := verifyTaskStats(client, taskStatsPath); err != nil {
+		seelog.Infof("Task stats: %v\n", err)
+		os.Exit(1)
+	}
+
+	os.Exit(42)
+}

--- a/misc/v3-task-endpoint-validator/Dockerfile
+++ b/misc/v3-task-endpoint-validator/Dockerfile
@@ -1,0 +1,18 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+FROM busybox@sha256:5551dbdfc48d66734d0f01cafee0952cb6e8eeecd1e2492240bf2fd9640c2279
+
+MAINTAINER Amazon Web Services, Inc.
+COPY v3-task-endpoint-validator /
+
+ENTRYPOINT ["/v3-task-endpoint-validator"]

--- a/misc/v3-task-endpoint-validator/Makefile
+++ b/misc/v3-task-endpoint-validator/Makefile
@@ -1,0 +1,25 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+.PHONY: all clean v3-task-endpoint-validator image
+
+all: v3-task-endpoint-validator image
+
+v3-task-endpoint-validator: v3-task-endpoint-validator.go
+	@./build-in-docker
+
+image: v3-task-endpoint-validator
+	docker build -t amazon/amazon-ecs-v3-task-endpoint-validator:make .
+
+clean:
+	rm -f taskmetadata-validator
+	-docker rmi -f "amazon/amazon-ecs-v3-task-endpoint-validator:make"

--- a/misc/v3-task-endpoint-validator/build-in-docker
+++ b/misc/v3-task-endpoint-validator/build-in-docker
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+CUR_DIR=$(pwd)
+AGENT_VENDOR_DIR=$(echo $(cd ${CUR_DIR}/../../agent/vendor;pwd))
+
+docker run \
+	-v ${CUR_DIR}:/out \
+	-v ${CUR_DIR}/v3-task-endpoint-validator.go:/in/v3-task-endpoint-validator.go \
+	-v ${AGENT_VENDOR_DIR}:/gopath/src \
+	-e CGO_ENABLED=0 \
+	-e GOPATH=/go:/gopath \
+	golang:1.9 go build -a -x -ldflags '-s' -o /out/v3-task-endpoint-validator /in/v3-task-endpoint-validator.go

--- a/misc/v3-task-endpoint-validator/v3-task-endpoint-validator.go
+++ b/misc/v3-task-endpoint-validator/v3-task-endpoint-validator.go
@@ -1,0 +1,442 @@
+// Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/cihub/seelog"
+	docker "github.com/fsouza/go-dockerclient"
+)
+
+const (
+	containerMetadataEnvVar = "ECS_CONTAINER_METADATA_URI"
+	maxRetries              = 4
+	durationBetweenRetries  = time.Second
+)
+
+var isAWSVPCNetworkMode bool
+
+// TaskResponse defines the schema for the task response JSON object
+type TaskResponse struct {
+	Cluster            string              `json:"Cluster"`
+	TaskARN            string              `json:"TaskARN"`
+	Family             string              `json:"Family"`
+	Revision           string              `json:"Revision"`
+	DesiredStatus      string              `json:"DesiredStatus,omitempty"`
+	KnownStatus        string              `json:"KnownStatus"`
+	Containers         []ContainerResponse `json:"Containers,omitempty"`
+	Limits             *LimitsResponse     `json:"Limits,omitempty"`
+	PullStartedAt      *time.Time          `json:"PullStartedAt,omitempty"`
+	PullStoppedAt      *time.Time          `json:"PullStoppedAt,omitempty"`
+	ExecutionStoppedAt *time.Time          `json:"ExecutionStoppedAt,omitempty"`
+}
+
+// ContainerResponse defines the schema for the container response
+// JSON object
+type ContainerResponse struct {
+	ID            string            `json:"DockerId"`
+	Name          string            `json:"Name"`
+	DockerName    string            `json:"DockerName"`
+	Image         string            `json:"Image"`
+	ImageID       string            `json:"ImageID"`
+	Ports         []PortResponse    `json:"Ports,omitempty"`
+	Labels        map[string]string `json:"Labels,omitempty"`
+	DesiredStatus string            `json:"DesiredStatus"`
+	KnownStatus   string            `json:"KnownStatus"`
+	ExitCode      *int              `json:"ExitCode,omitempty"`
+	Limits        LimitsResponse    `json:"Limits"`
+	CreatedAt     *time.Time        `json:"CreatedAt,omitempty"`
+	StartedAt     *time.Time        `json:"StartedAt,omitempty"`
+	FinishedAt    *time.Time        `json:"FinishedAt,omitempty"`
+	Type          string            `json:"Type"`
+	Networks      []Network         `json:"Networks,omitempty"`
+	Health        HealthStatus      `json:"Health,omitempty"`
+}
+
+// LimitsResponse defines the schema for task/cpu limits response
+// JSON object
+type LimitsResponse struct {
+	CPU    *float64 `json:"CPU,omitempty"`
+	Memory *int64   `json:"Memory,omitempty"`
+}
+
+type HealthStatus struct {
+	Status   string     `json:"status,omitempty"`
+	Since    *time.Time `json:"statusSince,omitempty"`
+	ExitCode int        `json:"exitCode,omitempty"`
+	Output   string     `json:"output,omitempty"`
+}
+
+// PortResponse defines the schema for portmapping response JSON
+// object.
+type PortResponse struct {
+	ContainerPort uint16 `json:"ContainerPort,omitempty"`
+	Protocol      string `json:"Protocol,omitempty"`
+	HostPort      uint16 `json:"HostPort,omitempty"`
+}
+
+// Network is a struct that keeps track of metadata of a network interface
+type Network struct {
+	NetworkMode   string   `json:"NetworkMode,omitempty"`
+	IPv4Addresses []string `json:"IPv4Addresses,omitempty"`
+	IPv6Addresses []string `json:"IPv6Addresses,omitempty"`
+}
+
+func verifyContainerMetadata(client *http.Client, containerMetadataEndpoint string) error {
+	var err error
+	body, err := metadataResponse(client, containerMetadataEndpoint)
+	if err != nil {
+		return err
+	}
+
+	seelog.Infof("Received container metadata: %s \n", string(body))
+
+	var containerMetadata ContainerResponse
+	if err = json.Unmarshal(body, &containerMetadata); err != nil {
+		return fmt.Errorf("unable to parse response body: %v", err)
+	}
+
+	if err = verifyContainerMetadataResponse(body); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func verifyTaskMetadata(client *http.Client, taskMetadataEndpoint string) error {
+	body, err := metadataResponse(client, taskMetadataEndpoint)
+	if err != nil {
+		return err
+	}
+
+	seelog.Infof("Received task metadata: %s \n", string(body))
+
+	var taskMetadata TaskResponse
+	if err = json.Unmarshal(body, &taskMetadata); err != nil {
+		return fmt.Errorf("unable to parse response body: %v", err)
+	}
+
+	if err = verifyTaskMetadataResponse(body); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func verifyContainerStats(client *http.Client, containerStatsEndpoint string) error {
+	body, err := metadataResponse(client, containerStatsEndpoint)
+	if err != nil {
+		return err
+	}
+
+	seelog.Infof("Received container stats: %s \n", string(body))
+
+	var containerStats docker.Stats
+	err = json.Unmarshal(body, &containerStats)
+	if err != nil {
+		return fmt.Errorf("container stats: unable to parse response body: %v", err)
+	}
+
+	return nil
+}
+
+func verifyTaskStats(client *http.Client, taskStatsEndpoint string) error {
+	body, err := metadataResponse(client, taskStatsEndpoint)
+	if err != nil {
+		return err
+	}
+
+	seelog.Infof("Received task stats: %s \n", string(body))
+
+	var taskStats map[string]*docker.Stats
+	err = json.Unmarshal(body, &taskStats)
+	if err != nil {
+		return fmt.Errorf("task stats: unable to parse response body: %v", err)
+	}
+
+	return nil
+}
+
+func verifyTaskMetadataResponse(taskMetadataRawMsg json.RawMessage) error {
+	var err error
+	taskMetadataResponseMap := make(map[string]json.RawMessage)
+	json.Unmarshal(taskMetadataRawMsg, &taskMetadataResponseMap)
+
+	taskExpectedFieldEqualMap := map[string]interface{}{
+		"Cluster":       "ecs-functional-tests",
+		"Revision":      "1",
+		"DesiredStatus": "RUNNING",
+		"KnownStatus":   "RUNNING",
+	}
+
+	taskExpectedFieldNotEmptyArray := []string{"TaskARN", "Family", "PullStartedAt", "PullStoppedAt", "Containers"}
+
+	for fieldName, fieldVal := range taskExpectedFieldEqualMap {
+		if err = fieldEqual(taskMetadataResponseMap, fieldName, fieldVal); err != nil {
+			return err
+		}
+	}
+
+	for _, fieldName := range taskExpectedFieldNotEmptyArray {
+		if err = fieldNotEmpty(taskMetadataResponseMap, fieldName); err != nil {
+			return err
+		}
+	}
+
+	var containersMetadataResponseArray []json.RawMessage
+	json.Unmarshal(taskMetadataResponseMap["Containers"], &containersMetadataResponseArray)
+
+	if isAWSVPCNetworkMode {
+		if len(containersMetadataResponseArray) != 2 {
+			return fmt.Errorf("incorrect number of containers, expected 2, received %d",
+				len(containersMetadataResponseArray))
+		}
+
+		ok, err := isPauseContainer(containersMetadataResponseArray[0])
+		if err != nil {
+			return err
+		}
+		if ok {
+			return verifyContainerMetadataResponse(containersMetadataResponseArray[1])
+		} else {
+			return verifyContainerMetadataResponse(containersMetadataResponseArray[0])
+		}
+	} else {
+		if len(containersMetadataResponseArray) != 1 {
+			return fmt.Errorf("incorrect number of containers, expected 1, received %d",
+				len(containersMetadataResponseArray))
+		}
+
+		return verifyContainerMetadataResponse(containersMetadataResponseArray[0])
+	}
+
+	return nil
+}
+
+func isPauseContainer(containerMetadataRawMsg json.RawMessage) (bool, error) {
+	var err error
+	containerMetadataResponseMap := make(map[string]json.RawMessage)
+	json.Unmarshal(containerMetadataRawMsg, &containerMetadataResponseMap)
+
+	if err = fieldNotEmpty(containerMetadataResponseMap, "Name"); err != nil {
+		return false, err
+	}
+
+	var actualContainerName string
+	json.Unmarshal(containerMetadataResponseMap["Name"], &actualContainerName)
+
+	if actualContainerName == "~internal~ecs~pause" {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func verifyContainerMetadataResponse(containerMetadataRawMsg json.RawMessage) error {
+	var err error
+	containerMetadataResponseMap := make(map[string]json.RawMessage)
+	json.Unmarshal(containerMetadataRawMsg, &containerMetadataResponseMap)
+
+	containerExpectedFieldEqualMap := map[string]interface{}{
+		"Name":          "v3-task-endpoint-validator",
+		"Image":         "127.0.0.1:51670/amazon/amazon-ecs-v3-task-endpoint-validator:latest",
+		"DesiredStatus": "RUNNING",
+		"KnownStatus":   "RUNNING",
+		"Type":          "NORMAL",
+	}
+
+	taskExpectedFieldNotEmptyArray := []string{"DockerId", "DockerName", "ImageID", "Limits", "CreatedAt", "StartedAt", "Health", "Networks"}
+
+	for fieldName, fieldVal := range containerExpectedFieldEqualMap {
+		if err = fieldEqual(containerMetadataResponseMap, fieldName, fieldVal); err != nil {
+			return err
+		}
+	}
+
+	for _, fieldName := range taskExpectedFieldNotEmptyArray {
+		if err = fieldNotEmpty(containerMetadataResponseMap, fieldName); err != nil {
+			return err
+		}
+	}
+
+	if err = verifyLimitResponse(containerMetadataResponseMap["Limits"]); err != nil {
+		return err
+	}
+	if err = verifyNetworksResponse(containerMetadataResponseMap["Networks"]); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func verifyLimitResponse(limitRawMsg json.RawMessage) error {
+	var err error
+	limitResponseMap := make(map[string]json.RawMessage)
+	json.Unmarshal(limitRawMsg, &limitResponseMap)
+
+	limitExpectedFieldEqualMap := map[string]interface{}{
+		"CPU":    float64(1024),
+		"Memory": float64(512),
+	}
+
+	for fieldName, fieldVal := range limitExpectedFieldEqualMap {
+		if err = fieldEqual(limitResponseMap, fieldName, fieldVal); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func verifyNetworksResponse(networksRawMsg json.RawMessage) error {
+	var err error
+
+	var networksResponseArray []json.RawMessage
+	json.Unmarshal(networksRawMsg, &networksResponseArray)
+
+	if len(networksResponseArray) == 1 {
+		networkResponseMap := make(map[string]json.RawMessage)
+		json.Unmarshal(networksResponseArray[0], &networkResponseMap)
+
+		if err = fieldEqual(networkResponseMap, "NetworkMode", "awsvpc"); err != nil {
+			return err
+		}
+
+		if err = fieldNotEmpty(networkResponseMap, "IPv4Addresses"); err != nil {
+			return err
+		}
+
+		var ipv4AddressesResponseArray []json.RawMessage
+		json.Unmarshal(networkResponseMap["IPv4Addresses"], &ipv4AddressesResponseArray)
+
+		if len(ipv4AddressesResponseArray) != 1 {
+			return fmt.Errorf("incorrect number of IPv4Addresses, expected 1, received %d",
+				len(ipv4AddressesResponseArray))
+		}
+
+		isAWSVPCNetworkMode = true
+	} else if len(networksResponseArray) != 0 {
+		return fmt.Errorf("incorrect number of networks, expected 0 or 1, received %d",
+			len(networksResponseArray))
+	}
+
+	return nil
+}
+
+func metadataResponse(client *http.Client, endpoint string) ([]byte, error) {
+	var resp []byte
+	var err error
+	for i := 0; i < maxRetries; i++ {
+		resp, err = metadataResponseOnce(client, endpoint)
+		if err == nil {
+			return resp, nil
+		}
+		fmt.Fprintf(os.Stderr, "Attempt [%d/%d]: unable to get metadata response from '%s': %v",
+			i, maxRetries, endpoint, err)
+		time.Sleep(durationBetweenRetries)
+	}
+
+	return nil, err
+}
+
+func metadataResponseOnce(client *http.Client, endpoint string) ([]byte, error) {
+	resp, err := client.Get(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get response: %v", err)
+	}
+	if resp.Body != nil {
+		defer resp.Body.Close()
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("incorrect status code  %d", resp.StatusCode)
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read response body: %v", err)
+	}
+
+	return body, nil
+}
+
+func notEmptyErrMsg(fieldName string) error {
+	return fmt.Errorf("field %s should not be empty", fieldName)
+}
+
+func fieldNotEmpty(rawMsgMap map[string]json.RawMessage, fieldName string) error {
+	if rawMsgMap[fieldName] == nil {
+		return notEmptyErrMsg(fieldName)
+	}
+
+	return nil
+}
+
+func fieldEqual(rawMsgMap map[string]json.RawMessage, fieldName string, fieldVal interface{}) error {
+	if err := fieldNotEmpty(rawMsgMap, fieldName); err != nil {
+		return err
+	}
+
+	var actualFieldVal interface{}
+	json.Unmarshal(rawMsgMap[fieldName], &actualFieldVal)
+
+	if fieldVal != actualFieldVal {
+		return fmt.Errorf("incorrect field value for field %s, expected %v, received %v",
+			fieldName, fieldVal, actualFieldVal)
+	}
+
+	return nil
+}
+
+func main() {
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+	}
+
+	// Wait for the Health information to be ready
+	time.Sleep(5 * time.Second)
+
+	isAWSVPCNetworkMode = false
+	v3BaseEndpoint := os.Getenv(containerMetadataEnvVar)
+	containerMetadataPath := v3BaseEndpoint
+	taskMetadataPath := v3BaseEndpoint + "/task"
+	containerStatsPath := v3BaseEndpoint + "/stats"
+	taskStatsPath := v3BaseEndpoint + "/task/stats"
+
+	if err := verifyContainerMetadata(client, containerMetadataPath); err != nil {
+		seelog.Infof("Container metadata: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := verifyTaskMetadata(client, taskMetadataPath); err != nil {
+		seelog.Infof("Task metadata: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := verifyContainerStats(client, containerStatsPath); err != nil {
+		seelog.Infof("Container stats: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := verifyTaskStats(client, taskStatsPath); err != nil {
+		seelog.Infof("Task stats: %v\n", err)
+		os.Exit(1)
+	}
+
+	os.Exit(42)
+}

--- a/scripts/run-functional-tests.ps1
+++ b/scripts/run-functional-tests.ps1
@@ -16,6 +16,7 @@ Invoke-Expression "${PSScriptRoot}\..\misc\windows-listen80\Setup_Listen80.ps1"
 Invoke-Expression "${PSScriptRoot}\..\misc\windows-telemetry\build.ps1"
 Invoke-Expression "${PSScriptRoot}\..\misc\windows-python\build.ps1"
 Invoke-Expression "${PSScriptRoot}\..\misc\container-health-windows\build.ps1"
+Invoke-Expression "${PSScriptRoot}\..\misc\v3-task-endpoint-validator-windows\setup-v3-task-endpoint-validator.ps1"
 
 # Run the tests
 $cwd = (pwd).Path

--- a/scripts/setup-test-registry
+++ b/scripts/setup-test-registry
@@ -65,7 +65,7 @@ mirror_local_image() {
   docker rmi $2
 }
 
-for image in "amazon/amazon-ecs-netkitten" "amazon/amazon-ecs-volumes-test" "amazon/squid" "amazon/awscli" "amazon/image-cleanup-test-image1" "amazon/image-cleanup-test-image2" "amazon/image-cleanup-test-image3" "amazon/fluentd" "amazon/amazon-ecs-taskmetadata-validator"; do
+for image in "amazon/amazon-ecs-netkitten" "amazon/amazon-ecs-volumes-test" "amazon/squid" "amazon/awscli" "amazon/image-cleanup-test-image1" "amazon/image-cleanup-test-image2" "amazon/image-cleanup-test-image3" "amazon/fluentd" "amazon/amazon-ecs-taskmetadata-validator" "amazon/amazon-ecs-v3-task-endpoint-validator"; do
   mirror_local_image "${image}:make" "127.0.0.1:51670/${image}:latest"
 done
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Add function test for v3 task endpoint that was added in [this](https://github.com/aws/amazon-ecs-agent/pull/1504) PR.

### Implementation details
<!-- How are the changes implemented? -->


### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes


### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
