### PR TITLE
Make docker health check configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ additional details on each available environment variable.
 | `ECS_CGROUP_PATH` | `/sys/fs/cgroup` | The root cgroup path that is expected by the ECS agent. This is the path that accessible from the agent mount. | `/sys/fs/cgroup` | Not applicable |
 | `ECS_ENABLE_CPU_UNBOUNDED_WINDOWS_WORKAROUND` | `true` | When `true`, ECS will allow CPU unbounded(CPU=`0`) tasks to run along with CPU bounded tasks in Windows. | Not applicable | `false` |
 | `ECS_TASK_METADATA_RPS_LIMIT` | `100,150` | Comma separated integer values for steady state and burst throttle limits for task metadata endpoint | `40,60` | `40,60` |
+| `ECS_DISABLE_DOCKER_HEALTH_CHECK` | `false` | Whether to disable the Docker Container health check for the ECS Agent. | `false` | `false` |
 
 ### Persistence
 

--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -121,7 +121,7 @@ func (agent *ecsAgent) appendDockerDependentCapabilities(capabilities []*ecs.Att
 		capabilities = appendNameOnlyAttribute(capabilities, attributePrefix+"execution-role-ecr-pull")
 	}
 
-	if _, ok := supportedVersions[dockerclient.Version_1_24]; ok {
+	if _, ok := supportedVersions[dockerclient.Version_1_24]; ok && !agent.cfg.DisableDockerHealthCheck {
 		// Docker health check was added in API 1.24
 		capabilities = appendNameOnlyAttribute(capabilities, attributePrefix+"container-health-check")
 	}

--- a/agent/app/agent_capability_test.go
+++ b/agent/app/agent_capability_test.go
@@ -587,6 +587,43 @@ func TestCapabilitiesContainerHealth(t *testing.T) {
 	assert.True(t, ok, "Could not find container health check capability when expected; got capabilities %v", capabilities)
 }
 
+func TestCapabilitiesContainerHealthDisabled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := mock_dockerapi.NewMockDockerClient(ctrl)
+	mockMobyPlugins := mock_mobypkgwrapper.NewMockPlugins(ctrl)
+
+	client.EXPECT().SupportedVersions().Return([]dockerclient.DockerVersion{
+		dockerclient.Version_1_24,
+	})
+	client.EXPECT().KnownVersions().Return(nil)
+	mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{}, nil)
+	client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
+		gomock.Any()).AnyTimes().Return([]string{}, nil)
+
+	ctx, cancel := context.WithCancel(context.TODO())
+	// Cancel the context to cancel async routines
+	defer cancel()
+	agent := &ecsAgent{
+		ctx:          ctx,
+		cfg:          &config.Config{DisableDockerHealthCheck: true},
+		dockerClient: client,
+		mobyPlugins:  mockMobyPlugins,
+	}
+
+	capabilities, err := agent.capabilities()
+	require.NoError(t, err)
+
+	capMap := make(map[string]bool)
+	for _, capability := range capabilities {
+		capMap[aws.StringValue(capability.Name)] = true
+	}
+
+	_, ok := capMap["ecs.capability.container-health-check"]
+	assert.False(t, ok, "Find container health check capability unexpected when it is disabled")
+}
+
 func TestCapabilitesListPluginsErrorCase(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -391,6 +391,7 @@ func environmentConfig() (Config, error) {
 		UpdatesEnabled:                   utils.ParseBool(os.Getenv("ECS_UPDATES_ENABLED"), false),
 		UpdateDownloadDir:                os.Getenv("ECS_UPDATE_DOWNLOAD_DIR"),
 		DisableMetrics:                   utils.ParseBool(os.Getenv("ECS_DISABLE_METRICS"), false),
+		DisableDockerHealthCheck:         utils.ParseBool(os.Getenv("ECS_DISABLE_DOCKER_HEALTH_CHECK"), false),
 		ReservedMemory:                   parseEnvVariableUint16("ECS_RESERVED_MEMORY"),
 		AvailableLoggingDrivers:          parseAvailableLoggingDrivers(),
 		PrivilegedDisabled:               utils.ParseBool(os.Getenv("ECS_DISABLE_PRIVILEGED"), false),

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -151,10 +151,12 @@ func TestTrimWhitespace(t *testing.T) {
 
 func TestConfigBoolean(t *testing.T) {
 	defer setTestRegion()()
+	defer setTestEnv("ECS_DISABLE_DOCKER_HEALTH_CHECK", "true")()
 	defer setTestEnv("ECS_DISABLE_METRICS", "true")()
 	cfg, err := NewConfig(ec2.NewBlackholeEC2MetadataClient())
 	assert.NoError(t, err)
 	assert.True(t, cfg.DisableMetrics)
+	assert.True(t, cfg.DisableDockerHealthCheck)
 }
 
 func TestBadLoggingDriverSerialization(t *testing.T) {

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -85,6 +85,10 @@ type Config struct {
 	// sent to the ECS telemetry endpoint
 	DisableMetrics bool
 
+	// DisableDockerHealthCheck configures whether container health feature was enabled
+	// on the instance
+	DisableDockerHealthCheck bool
+
 	// ReservedMemory specifies the amount of memory (in MB) to reserve for things
 	// other than containers managed by ECS
 	ReservedMemory uint16

--- a/agent/tcs/handler/handler.go
+++ b/agent/tcs/handler/handler.go
@@ -47,7 +47,17 @@ const (
 // StartMetricsSession starts a metric session. It initializes the stats engine
 // and invokes StartSession.
 func StartMetricsSession(params TelemetrySessionParams) {
-	err := params.StatsEngine.MustInit(params.Ctx, params.TaskEngine, params.Cfg.Cluster,
+	ok, err := params.isMetricsDisabled()
+	if err != nil {
+		seelog.Warnf("Error starting metrics session: %v", err)
+		return
+	}
+	if ok {
+		seelog.Warnf("Metrics were disabled, not start the telemetry session")
+		return
+	}
+
+	err = params.StatsEngine.MustInit(params.Ctx, params.TaskEngine, params.Cfg.Cluster,
 		params.ContainerInstanceArn)
 	if err != nil {
 		seelog.Warnf("Error initializing metrics engine: %v", err)

--- a/agent/tcs/handler/handler_test.go
+++ b/agent/tcs/handler/handler_test.go
@@ -73,6 +73,19 @@ func (*mockStatsEngine) GetTaskHealthMetrics() (*ecstcs.HealthMetadata, []*ecstc
 	return nil, nil, nil
 }
 
+// TestDisableMetrics tests the StartMetricsSession will return immediately if
+// the metrics was disabled
+func TestDisableMetrics(t *testing.T) {
+	params := TelemetrySessionParams{
+		Cfg: &config.Config{
+			DisableMetrics:           true,
+			DisableDockerHealthCheck: true,
+		},
+	}
+
+	StartMetricsSession(params)
+}
+
 func TestFormatURL(t *testing.T) {
 	endpoint := "http://127.0.0.0.1/"
 	wsurl := formatURL(endpoint, testClusterArn, testInstanceArn)

--- a/agent/tcs/handler/types.go
+++ b/agent/tcs/handler/types.go
@@ -24,6 +24,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/stats"
 	"github.com/aws/amazon-ecs-agent/agent/utils/ttime"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/pkg/errors"
 )
 
 // TelemetrySessionParams contains all the parameters required to start a tcs
@@ -49,4 +50,11 @@ func (params *TelemetrySessionParams) time() ttime.Time {
 		}
 	})
 	return params._time
+}
+
+func (params *TelemetrySessionParams) isMetricsDisabled() (bool, error) {
+	if params.Cfg != nil {
+		return params.Cfg.DisableMetrics && params.Cfg.DisableDockerHealthCheck, nil
+	}
+	return false, errors.New("Config is empty in the tcs session parameter")
 }

--- a/agent/tcs/handler/types_test.go
+++ b/agent/tcs/handler/types_test.go
@@ -1,0 +1,66 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package tcshandler
+
+import (
+	"testing"
+
+	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsMetricsDisabled(t *testing.T) {
+	tcs := []struct {
+		param       *TelemetrySessionParams
+		result      bool
+		err         error
+		description string
+	}{
+		{
+			param:       &TelemetrySessionParams{},
+			result:      false,
+			err:         errors.New("Config is empty in the tcs session parameter"),
+			description: "Config not set should cause error",
+		},
+		{
+			param:       &TelemetrySessionParams{Cfg: &config.Config{DisableMetrics: false, DisableDockerHealthCheck: false}},
+			result:      false,
+			err:         nil,
+			description: "No metrics was disable should return false",
+		},
+		{
+			param:       &TelemetrySessionParams{Cfg: &config.Config{DisableMetrics: true, DisableDockerHealthCheck: false}},
+			result:      false,
+			err:         nil,
+			description: "Only telemetry metrics was disable should return false",
+		},
+		{
+			param:       &TelemetrySessionParams{Cfg: &config.Config{DisableMetrics: true, DisableDockerHealthCheck: true}},
+			result:      true,
+			err:         nil,
+			description: "both telemetry and health metrics were disable should return true",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.description, func(t *testing.T) {
+			ok, err := tc.param.isMetricsDisabled()
+			if tc.err != nil {
+				assert.Error(t, err)
+			}
+			assert.Equal(t, tc.result, ok)
+		})
+	}
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Fix #1235 Add an environment variable to disable the container health check.

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [ ] Builds on Linux (`make release`)
- [ ] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [ ] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
