### PR TITLE
*: spelling fixes

### DIFF
--- a/agent/acs/handler/payload_handler.go
+++ b/agent/acs/handler/payload_handler.go
@@ -177,7 +177,7 @@ func (payloadHandler *payloadRequestHandler) handleSingleMessage(payload *ecsacs
 // it to the task engine. It returns a bool indicating if it could add every
 // task to the taskEngine and a slice of credential ack requests
 func (payloadHandler *payloadRequestHandler) addPayloadTasks(payload *ecsacs.PayloadMessage) ([]*ecsacs.IAMRoleCredentialsAckRequest, bool) {
-	// verify thatwe were able to work with all tasks in this payload so we know whether to ack the whole thing or not
+	// verify that we were able to work with all tasks in this payload so we know whether to ack the whole thing or not
 	allTasksOK := true
 
 	validTasks := make([]*apitask.Task, 0, len(payload.Tasks))

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -79,7 +79,7 @@ type TaskOverrides struct{}
 
 // Task is the internal representation of a task in the ECS agent
 type Task struct {
-	// Arn is the unique identifer for the task
+	// Arn is the unique identifier for the task
 	Arn string
 	// Overrides are the overrides applied to a task
 	Overrides TaskOverrides `json:"-"`
@@ -172,7 +172,7 @@ type Task struct {
 }
 
 // TaskFromACS translates ecsacs.Task to apitask.Task by first marshaling the received
-// ecsacs.Task to json and unmrashaling it as apitask.Task
+// ecsacs.Task to json and unmarshaling it as apitask.Task
 func TaskFromACS(acsTask *ecsacs.Task, envelope *ecsacs.PayloadMessage) (*Task, error) {
 	data, err := jsonutil.BuildJSON(acsTask)
 	if err != nil {

--- a/agent/dockerclient/dockerapi/docker_client.go
+++ b/agent/dockerclient/dockerapi/docker_client.go
@@ -347,7 +347,7 @@ func (dg *dockerGoClient) pullImage(image string, authData *apicontainer.Registr
 	}
 	timeout := dg.time().After(dockerPullBeginTimeout)
 	// pullBegan is a channel indicating that we have seen at least one line of data on the 'OutputStream' above.
-	// It is here to guard against a bug wherin docker never writes anything to that channel and hangs in pulling forever.
+	// It is here to guard against a bug wherein Docker never writes anything to that channel and hangs in pulling forever.
 	pullBegan := make(chan bool, 1)
 
 	go dg.filterPullDebugOutput(pullDebugOut, pullBegan, image)

--- a/agent/engine/interface.go
+++ b/agent/engine/interface.go
@@ -28,7 +28,7 @@ type TaskEngine interface {
 	Init(context.Context) error
 	MustInit(context.Context)
 	// Disable *must* only be called when this engine will no longer be used
-	// (e.g. right before exiting down the process). It will irreversably stop
+	// (e.g. right before exiting down the process). It will irreversibly stop
 	// this task engine from processing new tasks
 	Disable()
 


### PR DESCRIPTION
### Summary
Some spelling changes

### Testing
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: no

### Description for the changelog
N/A

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
