### PR TITLE
stats: Migrated stats tests to Docker SDK

### DIFF
--- a/agent/stats/common_test.go
+++ b/agent/stats/common_test.go
@@ -14,10 +14,10 @@
 package stats
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
-	"context"
 
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
@@ -41,7 +41,7 @@ const (
 	testContainerHealthImageName = "amazon/amazon-ecs-containerhealthcheck:make"
 
 	// defaultDockerTimeoutSeconds is the timeout for dialing the docker remote API.
-	defaultDockerTimeoutSeconds uint = 10
+	defaultDockerTimeoutSeconds = time.Second * 10
 
 	// waitForCleanupSleep is the sleep duration in milliseconds
 	// for the waiting after container cleanup before checking the state of the manager.

--- a/agent/stats/common_unix_test.go
+++ b/agent/stats/common_unix_test.go
@@ -19,11 +19,12 @@ import (
 	"context"
 	"os"
 
-	ecsengine "github.com/aws/amazon-ecs-agent/agent/engine"
-	"github.com/aws/amazon-ecs-agent/agent/utils"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/clientfactory"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/sdkclientfactory"
+	ecsengine "github.com/aws/amazon-ecs-agent/agent/engine"
+	"github.com/aws/amazon-ecs-agent/agent/utils"
 
+	sdkClient "github.com/docker/docker/client"
 	docker "github.com/fsouza/go-dockerclient"
 )
 
@@ -31,6 +32,7 @@ var (
 	testImageName    = "amazon/amazon-ecs-gremlin:make"
 	endpoint         = utils.DefaultIfBlank(os.Getenv(ecsengine.DockerEndpointEnvVariable), ecsengine.DockerDefaultEndpoint)
 	client, _        = docker.NewClient(endpoint)
+	sdkclient, _     = sdkClient.NewClientWithOpts(sdkClient.WithHost(endpoint))
 	clientFactory    = clientfactory.NewFactory(context.TODO(), endpoint)
 	sdkClientFactory = sdkclientfactory.NewFactory(context.TODO(), endpoint)
 	ctx              = context.TODO()

--- a/agent/stats/common_windows_test.go
+++ b/agent/stats/common_windows_test.go
@@ -19,11 +19,12 @@ import (
 	"context"
 	"os"
 
-	ecsengine "github.com/aws/amazon-ecs-agent/agent/engine"
-	"github.com/aws/amazon-ecs-agent/agent/utils"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/clientfactory"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/sdkclientfactory"
+	ecsengine "github.com/aws/amazon-ecs-agent/agent/engine"
+	"github.com/aws/amazon-ecs-agent/agent/utils"
 
+	sdkClient "github.com/docker/docker/client"
 	docker "github.com/fsouza/go-dockerclient"
 )
 
@@ -31,6 +32,7 @@ var (
 	testImageName    = "amazon/amazon-ecs-stats:make"
 	endpoint         = utils.DefaultIfBlank(os.Getenv(ecsengine.DockerEndpointEnvVariable), "npipe:////./pipe/docker_engine")
 	client, _        = docker.NewClient(endpoint)
+	sdkclient, _     = sdkClient.NewClientWithOpts(sdkClient.WithHost(endpoint))
 	clientFactory    = clientfactory.NewFactory(context.TODO(), endpoint)
 	sdkClientFactory = sdkclientfactory.NewFactory(context.TODO(), endpoint)
 	ctx              = context.TODO()

--- a/agent/stats/container.go
+++ b/agent/stats/container.go
@@ -14,9 +14,9 @@
 package stats
 
 import (
+	"context"
 	"errors"
 	"time"
-	"context"
 
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	"github.com/aws/amazon-ecs-agent/agent/stats/resolver"

--- a/agent/stats/engine_integ_test.go
+++ b/agent/stats/engine_integ_test.go
@@ -29,7 +29,7 @@ import (
 	ecsengine "github.com/aws/amazon-ecs-agent/agent/engine"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 
-	docker "github.com/fsouza/go-dockerclient"
+	"github.com/docker/docker/api/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -59,20 +59,20 @@ func TestStatsEngineWithExistingContainersWithoutHealth(t *testing.T) {
 	// Create a new docker stats engine
 	engine := NewDockerStatsEngine(&cfg, dockerClient, eventStream("TestStatsEngineWithExistingContainersWithoutHealth"))
 
+	// Assign ContainerStop timeout to addressable variable
+	timeout := defaultDockerTimeoutSeconds
+
 	// Create a container to get the container id.
 	container, err := createGremlin(client)
 	require.NoError(t, err, "creating container failed")
-	defer client.RemoveContainer(docker.RemoveContainerOptions{
-		ID:    container.ID,
-		Force: true,
-	})
+	defer sdkclient.ContainerRemove(ctx, container.ID, types.ContainerRemoveOptions{Force: true})
 
 	engine.cluster = defaultCluster
 	engine.containerInstanceArn = defaultContainerInstance
 
-	err = client.StartContainer(container.ID, nil)
+	err = sdkclient.ContainerStart(ctx, container.ID, types.ContainerStartOptions{})
 	require.NoError(t, err, "starting container failed")
-	defer client.StopContainer(container.ID, defaultDockerTimeoutSeconds)
+	defer sdkclient.ContainerStop(ctx, container.ID, &timeout)
 
 	containerChangeEventStream := eventStream("TestStatsEngineWithExistingContainersWithoutHealth")
 	taskEngine := ecsengine.NewTaskEngine(&config.Config{}, nil, nil, containerChangeEventStream,
@@ -102,7 +102,7 @@ func TestStatsEngineWithExistingContainersWithoutHealth(t *testing.T) {
 	validateInstanceMetrics(t, engine)
 	validateEmptyTaskHealthMetrics(t, engine)
 
-	err = client.StopContainer(container.ID, defaultDockerTimeoutSeconds)
+	err = sdkclient.ContainerStop(ctx, container.ID, &timeout)
 	require.NoError(t, err, "stopping container failed")
 
 	err = engine.containerChangeEventStream.WriteToEventStream(dockerapi.DockerContainerChangeEvent{
@@ -125,12 +125,12 @@ func TestStatsEngineWithNewContainersWithoutHealth(t *testing.T) {
 	engine := NewDockerStatsEngine(&cfg, dockerClient, eventStream("TestStatsEngineWithNewContainers"))
 	defer engine.removeAll()
 
+	// Assign ContainerStop timeout to addressable variable
+	timeout := defaultDockerTimeoutSeconds
+
 	container, err := createGremlin(client)
 	require.NoError(t, err, "creating container failed")
-	defer client.RemoveContainer(docker.RemoveContainerOptions{
-		ID:    container.ID,
-		Force: true,
-	})
+	defer sdkclient.ContainerRemove(ctx, container.ID, types.ContainerRemoveOptions{Force: true})
 
 	engine.cluster = defaultCluster
 	engine.containerInstanceArn = defaultContainerInstance
@@ -156,9 +156,9 @@ func TestStatsEngineWithNewContainersWithoutHealth(t *testing.T) {
 	require.NoError(t, err, "initializing stats engine failed")
 	defer engine.containerChangeEventStream.Unsubscribe(containerChangeHandler)
 
-	err = client.StartContainer(container.ID, nil)
+	err = sdkclient.ContainerStart(ctx, container.ID, types.ContainerStartOptions{})
 	require.NoError(t, err, "starting container failed")
-	defer client.StopContainer(container.ID, defaultDockerTimeoutSeconds)
+	defer sdkclient.ContainerStop(ctx, container.ID, &timeout)
 
 	// Write the container change event to event stream
 	err = engine.containerChangeEventStream.WriteToEventStream(dockerapi.DockerContainerChangeEvent{
@@ -174,7 +174,7 @@ func TestStatsEngineWithNewContainersWithoutHealth(t *testing.T) {
 	validateInstanceMetrics(t, engine)
 	validateEmptyTaskHealthMetrics(t, engine)
 
-	err = client.StopContainer(container.ID, defaultDockerTimeoutSeconds)
+	err = sdkclient.ContainerStop(ctx, container.ID, &timeout)
 	require.NoError(t, err, "stopping container failed")
 	// Write the container change event to event stream
 	err = engine.containerChangeEventStream.WriteToEventStream(dockerapi.DockerContainerChangeEvent{
@@ -199,17 +199,17 @@ func TestStatsEngineWithExistingContainers(t *testing.T) {
 	// Create a container to get the container id.
 	container, err := createHealthContainer(client)
 	require.NoError(t, err, "creating container failed")
-	defer client.RemoveContainer(docker.RemoveContainerOptions{
-		ID:    container.ID,
-		Force: true,
-	})
+	defer sdkclient.ContainerRemove(ctx, container.ID, types.ContainerRemoveOptions{Force: true})
+
+	// Assign ContainerStop timeout to addressable variable
+	timeout := defaultDockerTimeoutSeconds
 
 	engine.cluster = defaultCluster
 	engine.containerInstanceArn = defaultContainerInstance
 
-	err = client.StartContainer(container.ID, nil)
+	err = sdkclient.ContainerStart(ctx, container.ID, types.ContainerStartOptions{})
 	require.NoError(t, err, "starting container failed")
-	defer client.StopContainer(container.ID, defaultDockerTimeoutSeconds)
+	defer sdkclient.ContainerStop(ctx, container.ID, &timeout)
 
 	containerChangeEventStream := eventStream("TestStatsEngineWithExistingContainers")
 	taskEngine := ecsengine.NewTaskEngine(&config.Config{}, nil, nil, containerChangeEventStream,
@@ -245,7 +245,7 @@ func TestStatsEngineWithExistingContainers(t *testing.T) {
 	// Verify the health metrics of container
 	validateTaskHealthMetrics(t, engine)
 
-	err = client.StopContainer(container.ID, defaultDockerTimeoutSeconds)
+	err = sdkclient.ContainerStop(ctx, container.ID, &timeout)
 	require.NoError(t, err, "stopping container failed")
 
 	err = engine.containerChangeEventStream.WriteToEventStream(dockerapi.DockerContainerChangeEvent{
@@ -268,12 +268,12 @@ func TestStatsEngineWithNewContainers(t *testing.T) {
 	engine := NewDockerStatsEngine(&cfg, dockerClient, eventStream("TestStatsEngineWithNewContainers"))
 	defer engine.removeAll()
 
+	// Assign ContainerStop timeout to addressable variable
+	timeout := defaultDockerTimeoutSeconds
+
 	container, err := createHealthContainer(client)
 	require.NoError(t, err, "creating container failed")
-	defer client.RemoveContainer(docker.RemoveContainerOptions{
-		ID:    container.ID,
-		Force: true,
-	})
+	defer sdkclient.ContainerRemove(ctx, container.ID, types.ContainerRemoveOptions{Force: true})
 
 	engine.cluster = defaultCluster
 	engine.containerInstanceArn = defaultContainerInstance
@@ -302,9 +302,9 @@ func TestStatsEngineWithNewContainers(t *testing.T) {
 	require.NoError(t, err, "initializing stats engine failed")
 	defer engine.containerChangeEventStream.Unsubscribe(containerChangeHandler)
 
-	err = client.StartContainer(container.ID, nil)
+	err = sdkclient.ContainerStart(ctx, container.ID, types.ContainerStartOptions{})
 	require.NoError(t, err, "starting container failed")
-	defer client.StopContainer(container.ID, defaultDockerTimeoutSeconds)
+	defer sdkclient.ContainerStop(ctx, container.ID, &timeout)
 
 	// Write the container change event to event stream
 	err = engine.containerChangeEventStream.WriteToEventStream(dockerapi.DockerContainerChangeEvent{
@@ -321,7 +321,7 @@ func TestStatsEngineWithNewContainers(t *testing.T) {
 	// Verify the health metrics of container
 	validateTaskHealthMetrics(t, engine)
 
-	err = client.StopContainer(container.ID, defaultDockerTimeoutSeconds)
+	err = sdkclient.ContainerStop(ctx, container.ID, &timeout)
 	require.NoError(t, err, "stopping container failed")
 
 	// Write the container change event to event stream
@@ -347,16 +347,10 @@ func TestStatsEngineWithDockerTaskEngine(t *testing.T) {
 	container, err := createHealthContainer(client)
 	require.NoError(t, err, "creating container failed")
 
-	defer client.RemoveContainer(docker.RemoveContainerOptions{
-		ID:    container.ID,
-		Force: true,
-	})
+	defer sdkclient.ContainerRemove(ctx, container.ID, types.ContainerRemoveOptions{Force: true})
 	unmappedContainer, err := createHealthContainer(client)
 	require.NoError(t, err, "creating container failed")
-	defer client.RemoveContainer(docker.RemoveContainerOptions{
-		ID:    unmappedContainer.ID,
-		Force: true,
-	})
+	defer sdkclient.ContainerRemove(ctx, unmappedContainer.ID, types.ContainerRemoveOptions{Force: true})
 	testTask := createRunningTask()
 	// enable the health check of the container
 	testTask.Containers[0].HealthCheckType = "docker"
@@ -380,13 +374,16 @@ func TestStatsEngineWithDockerTaskEngine(t *testing.T) {
 	defer statsEngine.removeAll()
 	defer statsEngine.containerChangeEventStream.Unsubscribe(containerChangeHandler)
 
-	err = client.StartContainer(container.ID, nil)
-	require.NoError(t, err, "starting container failed")
-	defer client.StopContainer(container.ID, defaultDockerTimeoutSeconds)
+	// Assign ContainerStop timeout to addressable variable
+	timeout := defaultDockerTimeoutSeconds
 
-	err = client.StartContainer(unmappedContainer.ID, nil)
+	err = sdkclient.ContainerStart(ctx, container.ID, types.ContainerStartOptions{})
 	require.NoError(t, err, "starting container failed")
-	defer client.StopContainer(unmappedContainer.ID, defaultDockerTimeoutSeconds)
+	defer sdkclient.ContainerStop(ctx, container.ID, &timeout)
+
+	err = sdkclient.ContainerStart(ctx, container.ID, types.ContainerStartOptions{})
+	require.NoError(t, err, "starting container failed")
+	defer sdkclient.ContainerStop(ctx, unmappedContainer.ID, &timeout)
 
 	err = containerChangeEventStream.WriteToEventStream(dockerapi.DockerContainerChangeEvent{
 		Status: apicontainerstatus.ContainerRunning,
@@ -409,7 +406,7 @@ func TestStatsEngineWithDockerTaskEngine(t *testing.T) {
 	validateInstanceMetrics(t, statsEngine)
 	validateTaskHealthMetrics(t, statsEngine)
 
-	err = client.StopContainer(container.ID, defaultDockerTimeoutSeconds)
+	err = sdkclient.ContainerStop(ctx, container.ID, &timeout)
 	require.NoError(t, err, "stopping container failed")
 
 	err = containerChangeEventStream.WriteToEventStream(dockerapi.DockerContainerChangeEvent{
@@ -434,10 +431,7 @@ func TestStatsEngineWithDockerTaskEngineMissingRemoveEvent(t *testing.T) {
 
 	container, err := createHealthContainer(client)
 	require.NoError(t, err, "creating container failed")
-	defer client.RemoveContainer(docker.RemoveContainerOptions{
-		ID:    container.ID,
-		Force: true,
-	})
+	defer sdkclient.ContainerRemove(ctx, container.ID, types.ContainerRemoveOptions{Force: true})
 	testTask := createRunningTask()
 	// enable container health check of this container
 	testTask.Containers[0].HealthCheckType = "docker"
@@ -463,7 +457,7 @@ func TestStatsEngineWithDockerTaskEngineMissingRemoveEvent(t *testing.T) {
 	defer statsEngine.removeAll()
 	defer statsEngine.containerChangeEventStream.Unsubscribe(containerChangeHandler)
 
-	err = client.StartContainer(container.ID, nil)
+	err = sdkclient.ContainerStart(ctx, container.ID, types.ContainerStartOptions{})
 	require.NoError(t, err, "starting container failed")
 
 	err = containerChangeEventStream.WriteToEventStream(dockerapi.DockerContainerChangeEvent{
@@ -474,14 +468,14 @@ func TestStatsEngineWithDockerTaskEngineMissingRemoveEvent(t *testing.T) {
 	})
 	assert.NoError(t, err, "failed to write to container change event stream")
 
+	// Assign ContainerStop timeout to addressable variable
+	timeout := defaultDockerTimeoutSeconds
+
 	// Wait for the stats collection go routine to start.
 	time.Sleep(checkPointSleep)
-	err = client.StopContainer(container.ID, defaultDockerTimeoutSeconds)
+	err = sdkclient.ContainerStop(ctx, container.ID, &timeout)
 	require.NoError(t, err, "stopping container failed")
-	err = client.RemoveContainer(docker.RemoveContainerOptions{
-		ID:    container.ID,
-		Force: true,
-	})
+	err = sdkclient.ContainerRemove(ctx, container.ID, types.ContainerRemoveOptions{Force: true})
 	require.NoError(t, err, "removing container failed")
 
 	time.Sleep(checkPointSleep)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Migrates stats package types + functions to Docker SDK
### Implementation details
<!-- How are the changes implemented? -->
- ContainerStop require a *time.Duration argument. Before, we would just pass in the timeout constant of type uint to the go-dockerclient function. In Go, constants are not addressable because they are not always in runtime memory and therefore, you need to assign them to an addressable variable before use.
- Migrated functions and types from package stats to Docker SDK in preparation for HostConfig/Config migration
- Main purpose is to offload file changes not directly related to hostConfig/config migration to a separate PR
- Note: ContainerStats() migration will happen in later PR. Once that happens, the stats package will have no reliance on fsouza/go-dockerclient.

Link to branch: https://github.com/kavoor/amazon-ecs-agent/tree/stats_prep

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enhancement - Migrated stats package tests to Docker SDK
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
