### PR TITLE
dockerclient: change volumes to mounts in docker container metadata

### DIFF
--- a/agent/dockerclient/dockerapi/types.go
+++ b/agent/dockerclient/dockerapi/types.go
@@ -60,7 +60,7 @@ type DockerContainerMetadata struct {
 	// is unable to perform any of the required container transitions
 	Error apierrors.NamedError
 	// Volumes contains volume informaton for the container
-	Volumes map[string]string
+	Volumes []docker.Mount
 	// Labels contains labels set for the container
 	Labels map[string]string
 	// CreatedAt is the timestamp of container creation


### PR DESCRIPTION
### Summary
Docker had `Volumes` field of type `map[string]string` returned from `InspectContainer` call till API Version 1.20. 
After 1.20 , it was changed to `Mounts` of the type `[]Mount`. We were still backfilling `Volumes` using `Mounts` to support backwards compatibility. Now that the minimum API version supported by Agent is 1.21, we won't need the hack anymore. This PR removes it. This is also needed as part of exposing Volumes information as part of task metadata. 
More info: 
https://github.com/docker/docker/issues/27601
https://github.com/moby/moby/blob/v1.12.2/daemon/inspect_unix.go#L38-L43 

### Implementation details

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes

### Description for the changelog
N/A

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
