### PR TITLE
handlers: Add Volumes to v1 and v2 metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 1.20.2-dev
+* Enhancement - Added Volumes metadata as part of v1 and v2 metadata endpoints [#1531](https://github.com/aws/amazon-ecs-agent/pull/1531)
 * Bug - Fixed a bug where unrecognized task cannot be stopped [#1467](https://github.com/aws/amazon-ecs-agent/pull/1467)
 * Enhancement - Added ECS config field to provide optionally comparing shared volumes' full details (driver options and labels), or names only [#1519](https://github.com/aws/amazon-ecs-agent/pull/1519)
 

--- a/agent/api/container/container.go
+++ b/agent/api/container/container.go
@@ -191,7 +191,7 @@ type Container struct {
 	KnownPortBindingsUnsafe []PortBinding `json:"KnownPortBindings"`
 
 	// VolumesUnsafe is an array of volume mounts in the container.
-	VolumesUnsafe []docker.Mount
+	VolumesUnsafe []docker.Mount `json:"-"`
 
 	// SteadyStateStatusUnsafe specifies the steady state status for the container
 	// If uninitialized, it's assumed to be set to 'ContainerRunning'. Even though

--- a/agent/api/container/container.go
+++ b/agent/api/container/container.go
@@ -190,6 +190,9 @@ type Container struct {
 	// KnownPortBindingsUnsafe is an array of port bindings for the container.
 	KnownPortBindingsUnsafe []PortBinding `json:"KnownPortBindings"`
 
+	// VolumesUnsafe is an array of volume mounts in the container.
+	VolumesUnsafe []docker.Mount
+
 	// SteadyStateStatusUnsafe specifies the steady state status for the container
 	// If uninitialized, it's assumed to be set to 'ContainerRunning'. Even though
 	// it's not only supposed to be set when the container is being created, it's
@@ -533,6 +536,22 @@ func (c *Container) GetKnownPortBindings() []PortBinding {
 	defer c.lock.RUnlock()
 
 	return c.KnownPortBindingsUnsafe
+}
+
+// SetVolumes sets the volumes mounted in a container
+func (c *Container) SetVolumes(volumes []docker.Mount) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	c.VolumesUnsafe = volumes
+}
+
+// GetVolumes returns the volumes mounted in a container
+func (c *Container) GetVolumes() []docker.Mount {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	return c.VolumesUnsafe
 }
 
 // HealthStatusShouldBeReported returns true if the health check is defined in

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -337,8 +337,12 @@ func updateContainerMetadata(metadata *dockerapi.DockerContainerMetadata, contai
 	}
 
 	// Update volume for empty volume container
-	if metadata.Volumes != nil && container.IsInternal() {
-		task.UpdateMountPoints(container, metadata.Volumes)
+	if metadata.Volumes != nil {
+		if container.IsInternal() {
+			task.UpdateMountPoints(container, metadata.Volumes)
+		} else {
+			container.SetVolumes(metadata.Volumes)
+		}
 	}
 
 	// Set Exitcode if it's not set

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -1935,6 +1935,13 @@ func TestSynchronizeContainerStatus(t *testing.T) {
 	labels := map[string]string{
 		"name": "metadata",
 	}
+	volumes := []docker.Mount{
+		{
+			Name:        "volume",
+			Source:      "/src/vol",
+			Destination: "/vol",
+		},
+	}
 	created := time.Now()
 	gomock.InOrder(
 		client.EXPECT().DescribeContainer(gomock.Any(), dockerID).Return(apicontainerstatus.ContainerRunning,
@@ -1942,12 +1949,14 @@ func TestSynchronizeContainerStatus(t *testing.T) {
 				Labels:    labels,
 				DockerID:  dockerID,
 				CreatedAt: created,
+				Volumes:   volumes,
 			}),
 		imageManager.EXPECT().RecordContainerReference(dockerContainer.Container),
 	)
 	taskEngine.(*DockerTaskEngine).synchronizeContainerStatus(dockerContainer, nil)
 	assert.Equal(t, created, dockerContainer.Container.GetCreatedAt())
 	assert.Equal(t, labels, dockerContainer.Container.GetLabels())
+	assert.Equal(t, volumes, dockerContainer.Container.GetVolumes())
 }
 
 // TestHandleDockerHealthEvent tests the docker health event will only cause the

--- a/agent/functional_tests/testdata/taskdefinitions/agent-introspection-validator/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/agent-introspection-validator/task-definition.json
@@ -12,6 +12,21 @@
             "awslogs-region":"$$$TEST_REGION$$$",
             "awslogs-stream-prefix":"ecs-functional-tests-agent-introspection-validator"
         }
-    }
-  }]
+    },
+    "mountPoints": [
+        {
+          "sourceVolume": "task-local",
+          "containerPath": "/ecs/"
+        }
+    ]
+    }],
+    "volumes":[
+        {
+            "name": "task-local",
+            "dockerVolumeConfiguration" :{
+                "scope": "task",
+                "driver": "local"
+            }
+        }
+    ]
 }

--- a/agent/functional_tests/testdata/taskdefinitions/taskmetadata-validator-awsvpc/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/taskmetadata-validator-awsvpc/task-definition.json
@@ -19,6 +19,21 @@
             "awslogs-region":"$$$TEST_REGION$$$",
             "awslogs-stream-prefix":"ecs-functional-tests-taskmetadata-validator"
         }
-    }
-  }]
+    },
+    "mountPoints": [
+        {
+          "sourceVolume": "task-local",
+          "containerPath": "/ecs/"
+        }
+    ]
+  }],
+  "volumes":[
+      {
+          "name": "task-local",
+          "dockerVolumeConfiguration" :{
+              "scope": "task",
+              "driver": "local"
+          }
+      }
+  ]
 }

--- a/agent/functional_tests/testdata/taskdefinitions/taskmetadata-validator-awsvpc/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/taskmetadata-validator-awsvpc/task-definition.json
@@ -22,16 +22,17 @@
     },
     "mountPoints": [
         {
-          "sourceVolume": "task-local",
+          "sourceVolume": "shared-local",
           "containerPath": "/ecs/"
         }
     ]
   }],
   "volumes":[
       {
-          "name": "task-local",
+          "name": "shared-local",
           "dockerVolumeConfiguration" :{
-              "scope": "task",
+              "scope": "shared",
+              "autoprovision":true,
               "driver": "local"
           }
       }

--- a/agent/functional_tests/tests/functionaltests_unix_test.go
+++ b/agent/functional_tests/tests/functionaltests_unix_test.go
@@ -627,7 +627,7 @@ func TestAgentIntrospectionValidator(t *testing.T) {
 	defer agent.Cleanup()
 	// The Agent version was 1.14.2 when we added changes to agent introspection
 	// endpoint feature for the last time.
-	agent.RequireVersion(">1.14.1")
+	agent.RequireVersion(">1.20.1")
 
 	tdOverrides := make(map[string]string)
 	tdOverrides["$$$TEST_REGION$$$"] = *ECS.Config.Region
@@ -663,7 +663,7 @@ func TestTaskMetadataValidator(t *testing.T) {
 		},
 	})
 	defer agent.Cleanup()
-	agent.RequireVersion(">1.16.2")
+	agent.RequireVersion(">1.20.1")
 
 	tdOverrides := make(map[string]string)
 	tdOverrides["$$$TEST_REGION$$$"] = *ECS.Config.Region

--- a/agent/functional_tests/tests/functionaltests_unix_test.go
+++ b/agent/functional_tests/tests/functionaltests_unix_test.go
@@ -625,8 +625,6 @@ func TestAgentIntrospectionValidator(t *testing.T) {
 		},
 	})
 	defer agent.Cleanup()
-	// The Agent version was 1.14.2 when we added changes to agent introspection
-	// endpoint feature for the last time.
 	agent.RequireVersion(">1.20.1")
 
 	tdOverrides := make(map[string]string)

--- a/agent/handlers/v1/response.go
+++ b/agent/handlers/v1/response.go
@@ -51,6 +51,14 @@ type ContainerResponse struct {
 	Name       string                      `json:"Name"`
 	Ports      []PortResponse              `json:"Ports,omitempty"`
 	Networks   []containermetadata.Network `json:"Networks,omitempty"`
+	Volumes    []VolumeResponse            `json:"Volumes,omitempty"`
+}
+
+// VolumeResponse is the schema for the volume response JSON object
+type VolumeResponse struct {
+	DockerName  string `json:"DockerName,omitempty"`
+	Source      string `json:"Source,omitempty"`
+	Destination string `json:"Destination,omitempty"`
 }
 
 // PortResponse defines the schema for portmapping response JSON
@@ -101,6 +109,7 @@ func NewContainerResponse(dockerContainer *apicontainer.DockerContainer, eni *ap
 	}
 
 	resp.Ports = NewPortBindingsResponse(dockerContainer, eni)
+	resp.Volumes = NewVolumesResponse(dockerContainer)
 
 	if eni != nil {
 		resp.Networks = []containermetadata.Network{
@@ -140,6 +149,25 @@ func NewPortBindingsResponse(dockerContainer *apicontainer.DockerContainer, eni 
 		}
 
 		resp = append(resp, port)
+	}
+	return resp
+}
+
+// NewVolumesResponse creates VolumeResponse for a container
+func NewVolumesResponse(dockerContainer *apicontainer.DockerContainer) []VolumeResponse {
+	container := dockerContainer.Container
+	resp := []VolumeResponse{}
+
+	volumes := container.GetVolumes()
+
+	for _, volume := range volumes {
+		volResp := VolumeResponse{
+			DockerName:  volume.Name,
+			Source:      volume.Source,
+			Destination: volume.Destination,
+		}
+
+		resp = append(resp, volResp)
 	}
 	return resp
 }

--- a/agent/handlers/v1/response.go
+++ b/agent/handlers/v1/response.go
@@ -156,7 +156,7 @@ func NewPortBindingsResponse(dockerContainer *apicontainer.DockerContainer, eni 
 // NewVolumesResponse creates VolumeResponse for a container
 func NewVolumesResponse(dockerContainer *apicontainer.DockerContainer) []VolumeResponse {
 	container := dockerContainer.Container
-	resp := []VolumeResponse{}
+	var resp []VolumeResponse
 
 	volumes := container.GetVolumes()
 

--- a/agent/handlers/v1/response_test.go
+++ b/agent/handlers/v1/response_test.go
@@ -16,11 +16,12 @@ package v1
 import (
 	"encoding/json"
 	"testing"
-	
+
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apieni "github.com/aws/amazon-ecs-agent/agent/api/eni"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	apitaskstatus "github.com/aws/amazon-ecs-agent/agent/api/task/status"
+	docker "github.com/fsouza/go-dockerclient"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -31,34 +32,44 @@ const (
 	containerID    = "cid"
 	containerName  = "sleepy"
 	eniIPv4Address = "10.0.0.2"
+	volName        = "volume1"
+	volSource      = "/var/lib/volume1"
+	volDestination = "/volume"
 )
 
 func TestTaskResponse(t *testing.T) {
 	expectedTaskResponseMap := map[string]interface{}{
-		"Arn": "t1",
+		"Arn":           "t1",
 		"DesiredStatus": "RUNNING",
-		"KnownStatus": "RUNNING",
-		"Family": "sleep",
-		"Version": "1",
+		"KnownStatus":   "RUNNING",
+		"Family":        "sleep",
+		"Version":       "1",
 		"Containers": []interface{}{
 			map[string]interface{}{
-				"DockerId": "cid",
+				"DockerId":   "cid",
 				"DockerName": "sleepy",
-				"Name": "sleepy",
+				"Name":       "sleepy",
 				"Ports": []interface{}{
 					map[string]interface{}{
 						// The number should be float here, because when we unmarshal
 						// something and we don't specify the number type, it will be
 						// set to float.
 						"ContainerPort": float64(80),
-						"Protocol": "tcp",
-						"HostPort": float64(80),
+						"Protocol":      "tcp",
+						"HostPort":      float64(80),
 					},
 				},
 				"Networks": []interface{}{
 					map[string]interface{}{
-						"NetworkMode": "awsvpc",
+						"NetworkMode":   "awsvpc",
 						"IPv4Addresses": []interface{}{"10.0.0.2"},
+					},
+				},
+				"Volumes": []interface{}{
+					map[string]interface{}{
+						"DockerName":  volName,
+						"Source":      volSource,
+						"Destination": volDestination,
 					},
 				},
 			},
@@ -66,36 +77,43 @@ func TestTaskResponse(t *testing.T) {
 	}
 
 	task := &apitask.Task{
-	   Arn:                 taskARN,
-	   Family:              family,
-	   Version:             version,
-	   DesiredStatusUnsafe: apitaskstatus.TaskRunning,
-	   KnownStatusUnsafe:   apitaskstatus.TaskRunning,
-	   ENI: &apieni.ENI{
-	      IPV4Addresses: []*apieni.ENIIPV4Address{
-	         {
-	            Address: eniIPv4Address,
-	         },
-	      },
-	   },
+		Arn:                 taskARN,
+		Family:              family,
+		Version:             version,
+		DesiredStatusUnsafe: apitaskstatus.TaskRunning,
+		KnownStatusUnsafe:   apitaskstatus.TaskRunning,
+		ENI: &apieni.ENI{
+			IPV4Addresses: []*apieni.ENIIPV4Address{
+				{
+					Address: eniIPv4Address,
+				},
+			},
+		},
 	}
 
 	container := &apicontainer.Container{
-	   Name: containerName,
-	   Ports: []apicontainer.PortBinding{
-	      {
-	         ContainerPort: 80,
-	         Protocol:      apicontainer.TransportProtocolTCP,
-	      },
-	   },
+		Name: containerName,
+		Ports: []apicontainer.PortBinding{
+			{
+				ContainerPort: 80,
+				Protocol:      apicontainer.TransportProtocolTCP,
+			},
+		},
+		VolumesUnsafe: []docker.Mount{
+			{
+				Name:        volName,
+				Source:      volSource,
+				Destination: volDestination,
+			},
+		},
 	}
 
 	containerNameToDockerContainer := map[string]*apicontainer.DockerContainer{
-	   taskARN: &apicontainer.DockerContainer{
-	      DockerID:   containerID,
-	      DockerName: containerName,
-	      Container:  container,
-	   },
+		taskARN: &apicontainer.DockerContainer{
+			DockerID:   containerID,
+			DockerName: containerName,
+			Container:  container,
+		},
 	}
 
 	taskResponse := NewTaskResponse(task, containerNameToDockerContainer)
@@ -112,38 +130,52 @@ func TestTaskResponse(t *testing.T) {
 
 func TestContainerResponse(t *testing.T) {
 	expectedContainerResponseMap := map[string]interface{}{
-		"DockerId": "cid",
+		"DockerId":   "cid",
 		"DockerName": "sleepy",
-		"Name": "sleepy",
+		"Name":       "sleepy",
 		"Ports": []interface{}{
 			map[string]interface{}{
 				"ContainerPort": float64(80),
-				"Protocol": "tcp",
-				"HostPort": float64(80),
+				"Protocol":      "tcp",
+				"HostPort":      float64(80),
 			},
 		},
 		"Networks": []interface{}{
 			map[string]interface{}{
-				"NetworkMode": "awsvpc",
+				"NetworkMode":   "awsvpc",
 				"IPv4Addresses": []interface{}{"10.0.0.2"},
+			},
+		},
+		"Volumes": []interface{}{
+			map[string]interface{}{
+				"DockerName":  volName,
+				"Source":      volSource,
+				"Destination": volDestination,
 			},
 		},
 	}
 
 	container := &apicontainer.Container{
-	   Name: containerName,
-	   Ports: []apicontainer.PortBinding{
-	      {
-	         ContainerPort: 80,
-	         Protocol:      apicontainer.TransportProtocolTCP,
-	      },
-	   },
+		Name: containerName,
+		Ports: []apicontainer.PortBinding{
+			{
+				ContainerPort: 80,
+				Protocol:      apicontainer.TransportProtocolTCP,
+			},
+		},
+		VolumesUnsafe: []docker.Mount{
+			{
+				Name:        volName,
+				Source:      volSource,
+				Destination: volDestination,
+			},
+		},
 	}
 
 	dockerContainer := &apicontainer.DockerContainer{
-	   DockerID:   containerID,
-	   DockerName: containerName,
-	   Container:  container,
+		DockerID:   containerID,
+		DockerName: containerName,
+		Container:  container,
 	}
 
 	eni := &apieni.ENI{
@@ -179,7 +211,7 @@ func TestPortBindingsResponse(t *testing.T) {
 	}
 
 	dockerContainer := &apicontainer.DockerContainer{
-		Container:  container,
+		Container: container,
 	}
 
 	PortBindingsResponse := NewPortBindingsResponse(dockerContainer, nil)
@@ -187,4 +219,27 @@ func TestPortBindingsResponse(t *testing.T) {
 	assert.Equal(t, uint16(80), PortBindingsResponse[0].ContainerPort)
 	assert.Equal(t, uint16(80), PortBindingsResponse[0].HostPort)
 	assert.Equal(t, "tcp", PortBindingsResponse[0].Protocol)
+}
+
+func TestVolumesResponse(t *testing.T) {
+	container := &apicontainer.Container{
+		Name: containerName,
+		VolumesUnsafe: []docker.Mount{
+			{
+				Name:        volName,
+				Source:      volSource,
+				Destination: volDestination,
+			},
+		},
+	}
+
+	dockerContainer := &apicontainer.DockerContainer{
+		Container: container,
+	}
+
+	VolumesResponse := NewVolumesResponse(dockerContainer)
+
+	assert.Equal(t, volName, VolumesResponse[0].DockerName)
+	assert.Equal(t, volSource, VolumesResponse[0].Source)
+	assert.Equal(t, volDestination, VolumesResponse[0].Destination)
 }

--- a/agent/handlers/v2/response.go
+++ b/agent/handlers/v2/response.go
@@ -62,6 +62,7 @@ type ContainerResponse struct {
 	Type          string                      `json:"Type"`
 	Networks      []containermetadata.Network `json:"Networks,omitempty"`
 	Health        *apicontainer.HealthStatus  `json:"Health,omitempty"`
+	Volumes       []v1.VolumeResponse         `json:"Volumes,omitempty"`
 }
 
 // LimitsResponse defines the schema for task/cpu limits response
@@ -208,5 +209,6 @@ func newContainerResponse(dockerContainer *apicontainer.DockerContainer,
 		}
 	}
 
+	resp.Volumes = v1.NewVolumesResponse(dockerContainer)
 	return resp
 }

--- a/agent/handlers/v2/response_test.go
+++ b/agent/handlers/v2/response_test.go
@@ -28,6 +28,7 @@ import (
 	apitaskstatus "github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate/mocks"
 	"github.com/aws/aws-sdk-go/aws"
+	docker "github.com/fsouza/go-dockerclient"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 )
@@ -44,6 +45,9 @@ const (
 	cpu            = 1024
 	memory         = 512
 	eniIPv4Address = "10.0.0.2"
+	volName        = "volume1"
+	volSource      = "/var/lib/volume1"
+	volDestination = "/volume"
 )
 
 func TestTaskResponse(t *testing.T) {
@@ -84,6 +88,13 @@ func TestTaskResponse(t *testing.T) {
 			{
 				ContainerPort: 80,
 				Protocol:      apicontainer.TransportProtocolTCP,
+			},
+		},
+		VolumesUnsafe: []docker.Mount{
+			{
+				Name:        volName,
+				Source:      volSource,
+				Destination: volDestination,
 			},
 		},
 	}
@@ -152,6 +163,13 @@ func TestContainerResponse(t *testing.T) {
 					{
 						ContainerPort: 80,
 						Protocol:      apicontainer.TransportProtocolTCP,
+					},
+				},
+				VolumesUnsafe: []docker.Mount{
+					{
+						Name:        volName,
+						Source:      volSource,
+						Destination: volDestination,
 					},
 				},
 			}

--- a/misc/agent-introspection-validator/agent-introspection-validator.go
+++ b/misc/agent-introspection-validator/agent-introspection-validator.go
@@ -50,11 +50,12 @@ type TasksResponse struct {
 
 // ContainerResponse is the schema for the container response JSON object
 type ContainerResponse struct {
-	DockerID   string         `json:"DockerId"`
-	DockerName string         `json:"DockerName"`
-	Name       string         `json:"Name"`
-	Ports      []PortResponse `json:"Ports,omitempty"`
-	Networks   Network        `json:"Networks,omitempty"`
+	DockerID   string           `json:"DockerId"`
+	DockerName string           `json:"DockerName"`
+	Name       string           `json:"Name"`
+	Ports      []PortResponse   `json:"Ports,omitempty"`
+	Networks   Network          `json:"Networks,omitempty"`
+	Volumes    []VolumeResponse `json:"Volumes,omitempty"`
 }
 
 // PortResponse defines the schema for portmapping response JSON
@@ -70,6 +71,13 @@ type Network struct {
 	NetworkMode   string   `json:"NetworkMode,omitempty"`
 	IPv4Addresses []string `json:"IPv4Addresses,omitempty"`
 	IPv6Addresses []string `json:"IPv6Addresses,omitempty"`
+}
+
+// VolumeResponse is the schema for the volume response JSON object
+type VolumeResponse struct {
+	DockerName  string `json:"DockerName,omitempty"`
+	Source      string `json:"Source,omitempty"`
+	Destination string `json:"Destination,omitempty"`
 }
 
 func getTasksMetadata(client *http.Client, path string) (*TasksResponse, error) {
@@ -188,7 +196,7 @@ func verifyContainerMetadata(containerMetadataRawMsg json.RawMessage) error {
 	}
 
 	var actualContainerName string
-	json.Unmarshal(containerMetadataMap["Name"] ,&actualContainerName)
+	json.Unmarshal(containerMetadataMap["Name"], &actualContainerName)
 
 	if actualContainerName != containerName {
 		return fmt.Errorf("incorrect container name, expected %s, received %s",
@@ -201,6 +209,10 @@ func verifyContainerMetadata(containerMetadataRawMsg json.RawMessage) error {
 
 	if containerMetadataMap["DockerName"] == nil {
 		return notEmptyErrMsg("DockerName")
+	}
+
+	if containerMetadataMap["Volumes"] == nil {
+		return notEmptyErrMsg("Volumes")
 	}
 
 	return nil

--- a/misc/taskmetadata-validator/taskmetadata-validator.go
+++ b/misc/taskmetadata-validator/taskmetadata-validator.go
@@ -256,6 +256,11 @@ func main() {
 		os.Exit(1)
 	}
 
+	if containerMetadata.Volumes[0].DockerName != "shared-local" || containerMetadata.Volumes[0].Destination != "/ecs" {
+		fmt.Fprintf(os.Stderr, "Volume metadata fields incorrect")
+		os.Exit(1)
+	}
+
 	_, err = taskStats(client)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Unable to get task stats: %v", err)

--- a/misc/taskmetadata-validator/taskmetadata-validator.go
+++ b/misc/taskmetadata-validator/taskmetadata-validator.go
@@ -61,8 +61,9 @@ type ContainerResponse struct {
 	StartedAt     *time.Time `json:",omitempty"`
 	FinishedAt    *time.Time `json:",omitempty"`
 	Type          string
-	Health        HealthStatus `json:"health,omitempty"`
-	Networks      []Network    `json:",omitempty"`
+	Health        HealthStatus     `json:"health,omitempty"`
+	Networks      []Network        `json:",omitempty"`
+	Volumes       []VolumeResponse `json:"Volumes,omitempty"`
 }
 
 type HealthStatus struct {
@@ -92,6 +93,13 @@ type Network struct {
 	NetworkMode   string   `json:"NetworkMode,omitempty"`
 	IPv4Addresses []string `json:"IPv4Addresses,omitempty"`
 	IPv6Addresses []string `json:"IPv6Addresses,omitempty"`
+}
+
+// VolumeResponse is the schema for the volume response JSON object
+type VolumeResponse struct {
+	DockerName  string `json:"DockerName,omitempty"`
+	Source      string `json:"Source,omitempty"`
+	Destination string `json:"Destination,omitempty"`
 }
 
 func taskMetadata(client *http.Client) (*TaskResponse, error) {
@@ -241,6 +249,11 @@ func main() {
 			fmt.Fprintf(os.Stderr, "Container health metadata unexpected, got: %s\n", containerMetadata.Health)
 			os.Exit(1)
 		}
+	}
+
+	if containerMetadata.Volumes == nil {
+		fmt.Fprintf(os.Stderr, "Expected container volume metadata to be non-empty")
+		os.Exit(1)
 	}
 
 	_, err = taskStats(client)


### PR DESCRIPTION
### Summary
Expose volumes metadata as part of each container in task through v1 and v2 metadata endpoint. 
This addresses https://github.com/aws/amazon-ecs-agent/issues/1516 

### Implementation details

new task metadata(from functional tests): 
```
[Info] Received tasks metadata:
{
    "Tasks": [
        {
            "Arn": "arn:aws:ecs:us-west-2:074626758757:task/0353708a-6653-4bc2-9e84-ad2dcc8fe68c",
            "DesiredStatus": "RUNNING",
            "KnownStatus": "RUNNING",
            "Family": "ecsftest-agent-introspection-validator-4c0f2e0d3d9e85fd9e5ca7fdf73a3628",
            "Version": "1",
            "Containers": [
                {
                    "DockerId": "9c562697bcbeab2ce97491080d78dbeb38e64d21203417895edf1b5ce203ba24",
                    "DockerName": "ecs-ecsftest-agent-introspection-validator-4c0f2e0d3d9e85fd9e5ca7fdf73a3628-1-agent-introspection-validator-be84a5fd9680eac74b00",
                    "Name": "agent-introspection-validator",
                    "Volumes": [
                        {
                            "DockerName": "ecs-ecsftest-agent-introspection-validator-4c0f2e0d3d9e85fd9e5ca7fdf73a3628-1-task-local-bcb19ac3cc93fe8f8901",
                            "Source": "/var/lib/docker/volumes/ecs-ecsftest-agent-introspection-validator-4c0f2e0d3d9e85fd9e5ca7fdf73a3628-1-task-local-bcb19ac3cc93fe8f8901/_data",
                            "Destination": "/ecs"
                        }
                    ]
                }
            ]
        }
    ]
}
```

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes

### Description for the changelog


### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
