### PR TITLE
agent: Migrated ContainerCreate, ContainerInspect, HostConfig, and Config to Docker SDK

### DIFF
--- a/agent/api/container/container_test.go
+++ b/agent/api/container/container_test.go
@@ -24,23 +24,25 @@ import (
 	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
 
 	"github.com/aws/amazon-ecs-agent/agent/utils"
-	"github.com/fsouza/go-dockerclient"
+	dockercontainer "github.com/docker/docker/api/types/container"
 	"github.com/stretchr/testify/assert"
 )
 
 type configPair struct {
-	Container *Container
-	Config    *docker.Config
+	Container  *Container
+	Config     *dockercontainer.Config
+	HostConfig *dockercontainer.HostConfig
 }
 
 func (pair configPair) Equal() bool {
 	conf := pair.Config
 	cont := pair.Container
+	hostConf := pair.HostConfig
 
-	if (conf.Memory / 1024 / 1024) != int64(cont.Memory) {
+	if (hostConf.Memory / 1024 / 1024) != int64(cont.Memory) {
 		return false
 	}
-	if conf.CPUShares != int64(cont.CPU) {
+	if hostConf.CPUShares != int64(cont.CPU) {
 		return false
 	}
 	if conf.Image != cont.Image {

--- a/agent/api/container/port_binding.go
+++ b/agent/api/container/port_binding.go
@@ -17,7 +17,7 @@ import (
 	"strconv"
 
 	apierrors "github.com/aws/amazon-ecs-agent/agent/api/errors"
-	"github.com/fsouza/go-dockerclient"
+	"github.com/docker/go-connections/nat"
 )
 
 const (
@@ -41,11 +41,11 @@ type PortBinding struct {
 
 // PortBindingFromDockerPortBinding constructs a PortBinding slice from a docker
 // NetworkSettings.Ports map.
-func PortBindingFromDockerPortBinding(dockerPortBindings map[docker.Port][]docker.PortBinding) ([]PortBinding, apierrors.NamedError) {
+func PortBindingFromDockerPortBinding(dockerPortBindings nat.PortMap) ([]PortBinding, apierrors.NamedError) {
 	portBindings := make([]PortBinding, 0, len(dockerPortBindings))
 
 	for port, bindings := range dockerPortBindings {
-		containerPort, err := strconv.Atoi(port.Port())
+		containerPort, err := nat.ParsePort(port.Port())
 		if err != nil {
 			return nil, &apierrors.DefaultNamedError{Name: UnparseablePortErrorName, Err: "Error parsing docker port as int " + err.Error()}
 		}

--- a/agent/api/container/port_binding_test.go
+++ b/agent/api/container/port_binding_test.go
@@ -20,17 +20,19 @@ import (
 	"testing"
 
 	apierrors "github.com/aws/amazon-ecs-agent/agent/api/errors"
-	docker "github.com/fsouza/go-dockerclient"
+	"github.com/docker/go-connections/nat"
 )
 
 func TestPortBindingFromDockerPortBinding(t *testing.T) {
 	pairs := []struct {
-		dockerPortBindings map[docker.Port][]docker.PortBinding
+		dockerPortBindings nat.PortMap
 		ecsPortBindings    []PortBinding
 	}{
 		{
-			map[docker.Port][]docker.PortBinding{
-				"53/udp": {{HostIP: "1.2.3.4", HostPort: "55"}},
+			nat.PortMap{
+				nat.Port("53/udp"): []nat.PortBinding{
+					{HostIP: "1.2.3.4", HostPort: "55"},
+				},
 			},
 			[]PortBinding{
 				{
@@ -42,8 +44,8 @@ func TestPortBindingFromDockerPortBinding(t *testing.T) {
 			},
 		},
 		{
-			map[docker.Port][]docker.PortBinding{
-				"80/tcp": {
+			nat.PortMap{
+				nat.Port("80/tcp"): []nat.PortBinding{
 					{HostIP: "2.3.4.5", HostPort: "8080"},
 					{HostIP: "5.6.7.8", HostPort: "80"},
 				},
@@ -78,12 +80,12 @@ func TestPortBindingFromDockerPortBinding(t *testing.T) {
 
 func TestPortBindingErrors(t *testing.T) {
 	badInputs := []struct {
-		dockerPortBindings map[docker.Port][]docker.PortBinding
+		dockerPortBindings nat.PortMap
 		errorName          string
 	}{
 		{
-			map[docker.Port][]docker.PortBinding{
-				"woof/tcp": {
+			nat.PortMap{
+				nat.Port("woof/tcp"): []nat.PortBinding{
 					{HostIP: "2.3.4.5", HostPort: "8080"},
 					{HostIP: "5.6.7.8", HostPort: "80"},
 				},
@@ -91,8 +93,8 @@ func TestPortBindingErrors(t *testing.T) {
 			UnparseablePortErrorName,
 		},
 		{
-			map[docker.Port][]docker.PortBinding{
-				"80/tcp": {
+			nat.PortMap{
+				nat.Port("80/tcp"): []nat.PortBinding{
 					{HostIP: "2.3.4.5", HostPort: "8080"},
 					{HostIP: "5.6.7.8", HostPort: "bark"},
 				},
@@ -100,8 +102,8 @@ func TestPortBindingErrors(t *testing.T) {
 			UnparseablePortErrorName,
 		},
 		{
-			map[docker.Port][]docker.PortBinding{
-				"80/bark": {
+			nat.PortMap{
+				nat.Port("80/bark"): []nat.PortBinding{
 					{HostIP: "2.3.4.5", HostPort: "8080"},
 					{HostIP: "5.6.7.8", HostPort: "80"},
 				},

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -33,7 +33,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/credentials"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient"
-	dockerapi "github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
+	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	"github.com/aws/amazon-ecs-agent/agent/ecscni"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/asmauth"
@@ -46,8 +46,10 @@ import (
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/private/protocol/json/jsonutil"
 	"github.com/cihub/seelog"
-	"github.com/fsouza/go-dockerclient"
+	dockercontainer "github.com/docker/docker/api/types/container"
+	"github.com/docker/go-connections/nat"
 	"github.com/pkg/errors"
+	"github.com/docker/docker/api/types"
 )
 
 const (
@@ -560,7 +562,7 @@ func (task *Task) HostVolumeByName(name string) (taskresourcevolume.Volume, bool
 // UpdateMountPoints updates the mount points of volumes that were created
 // without specifying a host path.  This is used as part of the empty host
 // volume feature.
-func (task *Task) UpdateMountPoints(cont *apicontainer.Container, vols []docker.Mount) {
+func (task *Task) UpdateMountPoints(cont *apicontainer.Container, vols []types.MountPoint) {
 	for _, mountPoint := range cont.MountPoints {
 		containerPath := getCanonicalPath(mountPoint.ContainerPath)
 		for _, vol := range vols {
@@ -648,21 +650,15 @@ func (task *Task) getEarliestKnownTaskStatusForContainers() apitaskstatus.TaskSt
 }
 
 // DockerConfig converts the given container in this task to the format of
-// GoDockerClient's 'Config' struct
-func (task *Task) DockerConfig(container *apicontainer.Container, apiVersion dockerclient.DockerVersion) (*docker.Config, *apierrors.DockerClientConfigError) {
+// the Docker SDK 'Config' struct
+func (task *Task) DockerConfig(container *apicontainer.Container, apiVersion dockerclient.DockerVersion) (*dockercontainer.Config, *apierrors.DockerClientConfigError) {
 	return task.dockerConfig(container, apiVersion)
 }
 
-func (task *Task) dockerConfig(container *apicontainer.Container, apiVersion dockerclient.DockerVersion) (*docker.Config, *apierrors.DockerClientConfigError) {
+func (task *Task) dockerConfig(container *apicontainer.Container, apiVersion dockerclient.DockerVersion) (*dockercontainer.Config, *apierrors.DockerClientConfigError) {
 	dockerEnv := make([]string, 0, len(container.Environment))
 	for envKey, envVal := range container.Environment {
 		dockerEnv = append(dockerEnv, envKey+"="+envVal)
-	}
-
-	// Convert MB to B
-	dockerMem := int64(container.Memory * 1024 * 1024)
-	if dockerMem != 0 && dockerMem < apicontainer.DockerContainerMinimumMemoryInBytes {
-		dockerMem = apicontainer.DockerContainerMinimumMemoryInBytes
 	}
 
 	var entryPoint []string
@@ -670,7 +666,7 @@ func (task *Task) dockerConfig(container *apicontainer.Container, apiVersion doc
 		entryPoint = *container.EntryPoint
 	}
 
-	config := &docker.Config{
+	containerConfig := &dockercontainer.Config{
 		Image:        container.Image,
 		Cmd:          container.Command,
 		Entrypoint:   entryPoint,
@@ -678,90 +674,47 @@ func (task *Task) dockerConfig(container *apicontainer.Container, apiVersion doc
 		Env:          dockerEnv,
 	}
 
-	err := task.SetConfigHostconfigBasedOnVersion(container, config, nil, apiVersion)
-	if err != nil {
-		return nil, &apierrors.DockerClientConfigError{"setting docker config failed, err: " + err.Error()}
-	}
-
 	if container.DockerConfig.Config != nil {
-		err := json.Unmarshal([]byte(aws.StringValue(container.DockerConfig.Config)), &config)
+		err := json.Unmarshal([]byte(aws.StringValue(container.DockerConfig.Config)), &containerConfig)
 		if err != nil {
 			return nil, &apierrors.DockerClientConfigError{"Unable decode given docker config: " + err.Error()}
 		}
 	}
-	if container.HealthCheckType == apicontainer.DockerHealthCheckType && config.Healthcheck == nil {
+	if container.HealthCheckType == apicontainer.DockerHealthCheckType && containerConfig.Healthcheck == nil {
 		return nil, &apierrors.DockerClientConfigError{
 			"docker health check is nil while container health check type is DOCKER"}
 	}
 
-	if config.Labels == nil {
-		config.Labels = make(map[string]string)
+	if containerConfig.Labels == nil {
+		containerConfig.Labels = make(map[string]string)
 	}
 
 	if container.Type == apicontainer.ContainerCNIPause {
 		// apply hostname to pause container's docker config
-		return task.applyENIHostname(config), nil
+		return task.applyENIHostname(containerConfig), nil
 	}
 
-	return config, nil
+	return containerConfig, nil
 }
 
-// SetConfigHostconfigBasedOnVersion sets the fields in both Config and HostConfig based on api version for backward compatibility
-func (task *Task) SetConfigHostconfigBasedOnVersion(container *apicontainer.Container, config *docker.Config, hc *docker.HostConfig, apiVersion dockerclient.DockerVersion) error {
-	// Convert MB to B
-	dockerMem := int64(container.Memory * 1024 * 1024)
-	if dockerMem != 0 && dockerMem < apicontainer.DockerContainerMinimumMemoryInBytes {
-		seelog.Warnf("Task %s container %s memory setting is too low, increasing to %d bytes",
-			task.Arn, container.Name, apicontainer.DockerContainerMinimumMemoryInBytes)
-		dockerMem = apicontainer.DockerContainerMinimumMemoryInBytes
-	}
-	cpuShare := task.dockerCPUShares(container.CPU)
-
-	// Docker copied Memory and cpu field into hostconfig in 1.6 with api version(1.18)
-	// https://github.com/moby/moby/commit/837eec064d2d40a4d86acbc6f47fada8263e0d4c
-	dockerAPIVersion, err := docker.NewAPIVersion(string(apiVersion))
-	if err != nil {
-		seelog.Errorf("Creating docker api version failed, err: %v", err)
-		return err
-	}
-
-	dockerAPIVersion_1_18 := docker.APIVersion([]int{1, 18})
-	if dockerAPIVersion.GreaterThanOrEqualTo(dockerAPIVersion_1_18) {
-		// Set the memory and cpu in host config
-		if hc != nil {
-			hc.Memory = dockerMem
-			hc.CPUShares = cpuShare
-		}
-		return nil
-	}
-
-	// Set the memory and cpu in config
-	if config != nil {
-		config.Memory = dockerMem
-		config.CPUShares = cpuShare
-	}
-
-	return nil
-}
-
-func (task *Task) dockerExposedPorts(container *apicontainer.Container) map[docker.Port]struct{} {
-	dockerExposedPorts := make(map[docker.Port]struct{})
+func (task *Task) dockerExposedPorts(container *apicontainer.Container) nat.PortSet {
+	dockerExposedPorts := make(map[nat.Port]struct{})
 
 	for _, portBinding := range container.Ports {
-		dockerPort := docker.Port(strconv.Itoa(int(portBinding.ContainerPort)) + "/" + portBinding.Protocol.String())
+		dockerPort := nat.Port(strconv.Itoa(int(portBinding.ContainerPort)) + "/" + portBinding.Protocol.String())
 		dockerExposedPorts[dockerPort] = struct{}{}
 	}
 	return dockerExposedPorts
 }
 
 // DockerHostConfig construct the configuration recognized by docker
-func (task *Task) DockerHostConfig(container *apicontainer.Container, dockerContainerMap map[string]*apicontainer.DockerContainer, apiVersion dockerclient.DockerVersion) (*docker.HostConfig, *apierrors.HostConfigError) {
+func (task *Task) DockerHostConfig(container *apicontainer.Container, dockerContainerMap map[string]*apicontainer.DockerContainer, apiVersion dockerclient.DockerVersion) (*dockercontainer.HostConfig, *apierrors.HostConfigError) {
 	return task.dockerHostConfig(container, dockerContainerMap, apiVersion)
 }
 
 // ApplyExecutionRoleLogsAuth will check whether the task has execution role
 // credentials, and add the genereated credentials endpoint to the associated HostConfig
-func (task *Task) ApplyExecutionRoleLogsAuth(hostConfig *docker.HostConfig, credentialsManager credentials.Manager) *apierrors.HostConfigError {
+func (task *Task) ApplyExecutionRoleLogsAuth(hostConfig *dockercontainer.HostConfig, credentialsManager credentials.Manager) *apierrors.HostConfigError {
 	id := task.GetExecutionCredentialsID()
 	if id == "" {
 		// No execution credentials set for the task. Do not inject the endpoint environment variable.
@@ -781,7 +734,7 @@ func (task *Task) ApplyExecutionRoleLogsAuth(hostConfig *docker.HostConfig, cred
 	return nil
 }
 
-func (task *Task) dockerHostConfig(container *apicontainer.Container, dockerContainerMap map[string]*apicontainer.DockerContainer, apiVersion dockerclient.DockerVersion) (*docker.HostConfig, *apierrors.HostConfigError) {
+func (task *Task) dockerHostConfig(container *apicontainer.Container, dockerContainerMap map[string]*apicontainer.DockerContainer, apiVersion dockerclient.DockerVersion) (*dockercontainer.HostConfig, *apierrors.HostConfigError) {
 	dockerLinkArr, err := task.dockerLinks(container, dockerContainerMap)
 	if err != nil {
 		return nil, &apierrors.HostConfigError{err.Error()}
@@ -799,17 +752,15 @@ func (task *Task) dockerHostConfig(container *apicontainer.Container, dockerCont
 		return nil, &apierrors.HostConfigError{err.Error()}
 	}
 
+	resources := task.getDockerResources(container)
+
 	// Populate hostConfig
-	hostConfig := &docker.HostConfig{
+	hostConfig := &dockercontainer.HostConfig{
 		Links:        dockerLinkArr,
 		Binds:        binds,
 		PortBindings: dockerPortMap,
 		VolumesFrom:  volumesFrom,
-	}
-
-	err = task.SetConfigHostconfigBasedOnVersion(container, nil, hostConfig, apiVersion)
-	if err != nil {
-		return nil, &apierrors.HostConfigError{err.Error()}
+		Resources:    resources,
 	}
 
 	if container.DockerConfig.HostConfig != nil {
@@ -829,7 +780,7 @@ func (task *Task) dockerHostConfig(container *apicontainer.Container, dockerCont
 	if !ok {
 		return hostConfig, nil
 	}
-	hostConfig.NetworkMode = networkMode
+	hostConfig.NetworkMode = dockercontainer.NetworkMode(networkMode)
 	// Override 'awsvpc' parameters if needed
 	if container.Type == apicontainer.ContainerCNIPause {
 
@@ -844,6 +795,24 @@ func (task *Task) dockerHostConfig(container *apicontainer.Container, dockerCont
 	}
 
 	return hostConfig, nil
+}
+
+// Requires an *apicontainer.Container and returns the Resources for the HostConfig struct
+func (task *Task) getDockerResources(container *apicontainer.Container) dockercontainer.Resources {
+	// Convert MB to B and set Memory
+	dockerMem := int64(container.Memory * 1024 * 1024)
+	if dockerMem != 0 && dockerMem < apicontainer.DockerContainerMinimumMemoryInBytes {
+		seelog.Warnf("Task %s container %s memory setting is too low, increasing to %d bytes",
+			task.Arn, container.Name, apicontainer.DockerContainerMinimumMemoryInBytes)
+		dockerMem = apicontainer.DockerContainerMinimumMemoryInBytes
+	}
+	// Set CPUShares
+	cpuShare := task.dockerCPUShares(container.CPU)
+	resources := dockercontainer.Resources{
+		Memory:    dockerMem,
+		CPUShares: cpuShare,
+	}
+	return resources
 }
 
 // shouldOverrideNetworkMode returns true if the network mode of the container needs
@@ -896,7 +865,7 @@ func (task *Task) shouldOverrideNetworkMode(container *apicontainer.Container, d
 // 2. ENI has custom DNS IPs and search list associated with it
 // This should only be done for the pause container as other containers inherit
 // /etc/resolv.conf of this container (they share the network namespace)
-func (task *Task) overrideDNS(hostConfig *docker.HostConfig) *docker.HostConfig {
+func (task *Task) overrideDNS(hostConfig *dockercontainer.HostConfig) *dockercontainer.HostConfig {
 	eni := task.GetTaskENI()
 	if eni == nil {
 		return hostConfig
@@ -911,7 +880,7 @@ func (task *Task) overrideDNS(hostConfig *docker.HostConfig) *docker.HostConfig 
 // applyENIHostname adds the hostname provided by the ENI message to the
 // container's docker config. At the time of implmentation, we are only using it
 // to configure the pause container for awsvpc tasks
-func (task *Task) applyENIHostname(dockerConfig *docker.Config) *docker.Config {
+func (task *Task) applyENIHostname(dockerConfig *dockercontainer.Config) *dockercontainer.Config {
 	eni := task.GetTaskENI()
 	if eni == nil {
 		return dockerConfig
@@ -975,16 +944,16 @@ func (task *Task) dockerLinks(container *apicontainer.Container, dockerContainer
 	return dockerLinkArr, nil
 }
 
-func (task *Task) dockerPortMap(container *apicontainer.Container) map[docker.Port][]docker.PortBinding {
-	dockerPortMap := make(map[docker.Port][]docker.PortBinding)
+func (task *Task) dockerPortMap(container *apicontainer.Container) nat.PortMap {
+	dockerPortMap := nat.PortMap{}
 
 	for _, portBinding := range container.Ports {
-		dockerPort := docker.Port(strconv.Itoa(int(portBinding.ContainerPort)) + "/" + portBinding.Protocol.String())
+		dockerPort := nat.Port(strconv.Itoa(int(portBinding.ContainerPort)) + "/" + portBinding.Protocol.String())
 		currentMappings, existing := dockerPortMap[dockerPort]
 		if existing {
-			dockerPortMap[dockerPort] = append(currentMappings, docker.PortBinding{HostPort: strconv.Itoa(int(portBinding.HostPort))})
+			dockerPortMap[dockerPort] = append(currentMappings, nat.PortBinding{HostPort: strconv.Itoa(int(portBinding.HostPort))})
 		} else {
-			dockerPortMap[dockerPort] = []docker.PortBinding{{HostPort: strconv.Itoa(int(portBinding.HostPort))}}
+			dockerPortMap[dockerPort] = []nat.PortBinding{{HostPort: strconv.Itoa(int(portBinding.HostPort))}}
 		}
 	}
 	return dockerPortMap

--- a/agent/api/task/task_linux.go
+++ b/agent/api/task/task_linux.go
@@ -26,16 +26,12 @@ import (
 	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
 	resourcetype "github.com/aws/amazon-ecs-agent/agent/taskresource/types"
 	"github.com/cihub/seelog"
-	docker "github.com/fsouza/go-dockerclient"
+	dockercontainer "github.com/docker/docker/api/types/container"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 )
 
 const (
-	//memorySwappinessDefault is the expected default value for this platform. This is used in task_windows.go
-	//and is maintained here for unix default. Also used for testing
-	memorySwappinessDefault = 0
-
 	defaultCPUPeriod = 100 * time.Millisecond // 100ms
 	// With a 100ms CPU period, we can express 0.01 vCPU to 10 vCPUs
 	maxTaskVCPULimit = 10
@@ -188,14 +184,14 @@ func (task *Task) buildLinuxMemorySpec() (specs.LinuxMemory, error) {
 }
 
 // platformHostConfigOverride to override platform specific feature sets
-func (task *Task) platformHostConfigOverride(hostConfig *docker.HostConfig) error {
+func (task *Task) platformHostConfigOverride(hostConfig *dockercontainer.HostConfig) error {
 	// Override cgroup parent
 	return task.overrideCgroupParent(hostConfig)
 }
 
 // overrideCgroupParent updates hostconfig with cgroup parent when task cgroups
 // are enabled
-func (task *Task) overrideCgroupParent(hostConfig *docker.HostConfig) error {
+func (task *Task) overrideCgroupParent(hostConfig *dockercontainer.HostConfig) error {
 	task.lock.RLock()
 	defer task.lock.RUnlock()
 	if task.MemoryCPULimitsEnabled {

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -46,11 +46,12 @@ import (
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 
 	"github.com/aws/aws-sdk-go/aws"
-	docker "github.com/fsouza/go-dockerclient"
+	"github.com/docker/docker/api/types"
+	dockercontainer "github.com/docker/docker/api/types/container"
+	"github.com/docker/go-units"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/docker/docker/api/types"
 )
 
 const dockerIDPrefix = "dockerid-"
@@ -92,7 +93,7 @@ func TestDockerConfigPortBinding(t *testing.T) {
 	}
 }
 
-func TestDockerConfigCPUShareZero(t *testing.T) {
+func TestDockerHostConfigCPUShareZero(t *testing.T) {
 	testTask := &Task{
 		Containers: []*apicontainer.Container{
 			{
@@ -102,17 +103,21 @@ func TestDockerConfigCPUShareZero(t *testing.T) {
 		},
 	}
 
-	config, err := testTask.DockerConfig(testTask.Containers[0], defaultDockerClientAPIVersion)
+	hostconfig, err := testTask.DockerHostConfig(testTask.Containers[0], dockerMap(testTask), defaultDockerClientAPIVersion)
 	if err != nil {
 		t.Error(err)
 	}
-
-	if config.CPUShares != 2 {
+	if runtime.GOOS == "windows" {
+		if hostconfig.CPUShares != 0 {
+			// CPUShares will always be 0 on windows
+			t.Error("CPU shares expected to be 0 on windows")
+		}
+	} else if hostconfig.CPUShares != 2 {
 		t.Error("CPU shares of 0 did not get changed to 2")
 	}
 }
 
-func TestDockerConfigCPUShareMinimum(t *testing.T) {
+func TestDockerHostConfigCPUShareMinimum(t *testing.T) {
 	testTask := &Task{
 		Containers: []*apicontainer.Container{
 			{
@@ -122,17 +127,22 @@ func TestDockerConfigCPUShareMinimum(t *testing.T) {
 		},
 	}
 
-	config, err := testTask.DockerConfig(testTask.Containers[0], defaultDockerClientAPIVersion)
+	hostconfig, err := testTask.DockerHostConfig(testTask.Containers[0], dockerMap(testTask), defaultDockerClientAPIVersion)
 	if err != nil {
 		t.Error(err)
 	}
 
-	if config.CPUShares != 2 {
-		t.Error("CPU shares of 1 did not get changed to 2")
+	if runtime.GOOS == "windows" {
+		if hostconfig.CPUShares != 0 {
+			// CPUShares will always be 0 on windows
+			t.Error("CPU shares expected to be 0 on windows")
+		}
+	} else if hostconfig.CPUShares != 2 {
+		t.Error("CPU shares of 0 did not get changed to 2")
 	}
 }
 
-func TestDockerConfigCPUShareUnchanged(t *testing.T) {
+func TestDockerHostConfigCPUShareUnchanged(t *testing.T) {
 	testTask := &Task{
 		Containers: []*apicontainer.Container{
 			{
@@ -142,12 +152,17 @@ func TestDockerConfigCPUShareUnchanged(t *testing.T) {
 		},
 	}
 
-	config, err := testTask.DockerConfig(testTask.Containers[0], defaultDockerClientAPIVersion)
+	hostconfig, err := testTask.DockerHostConfig(testTask.Containers[0], dockerMap(testTask), defaultDockerClientAPIVersion)
 	if err != nil {
 		t.Error(err)
 	}
 
-	if config.CPUShares != 100 {
+	if runtime.GOOS == "windows" {
+		if hostconfig.CPUShares != 0 {
+			// CPUShares will always be 0 on windows
+			t.Error("CPU shares expected to be 0 on windows")
+		}
+	} else if hostconfig.CPUShares != 100 {
 		t.Error("CPU shares unexpectedly changed")
 	}
 }
@@ -198,20 +213,21 @@ func TestDockerHostConfigVolumesFrom(t *testing.T) {
 }
 
 func TestDockerHostConfigRawConfig(t *testing.T) {
-	rawHostConfigInput := docker.HostConfig{
+	rawHostConfigInput := dockercontainer.HostConfig{
 		Privileged:     true,
 		ReadonlyRootfs: true,
 		DNS:            []string{"dns1, dns2"},
 		DNSSearch:      []string{"dns.search"},
 		ExtraHosts:     []string{"extra:hosts"},
 		SecurityOpt:    []string{"foo", "bar"},
-		CPUShares:      2,
-		LogConfig: docker.LogConfig{
+		Resources: dockercontainer.Resources{
+			CPUShares: 2,
+			Ulimits:   []*units.Ulimit{{Name: "ulimit name", Soft: 10, Hard: 100}},
+		},
+		LogConfig: dockercontainer.LogConfig{
 			Type:   "foo",
 			Config: map[string]string{"foo": "bar"},
 		},
-		Ulimits:          []docker.ULimit{{Name: "ulimit name", Soft: 10, Hard: 100}},
-		MemorySwappiness: memorySwappinessDefault,
 	}
 
 	rawHostConfig, err := json.Marshal(&rawHostConfigInput)
@@ -267,12 +283,18 @@ func TestDockerHostConfigPauseContainer(t *testing.T) {
 	// for a non pause container
 	config, err := testTask.DockerHostConfig(customContainer, dockerMap(testTask), defaultDockerClientAPIVersion)
 	assert.Nil(t, err)
-	assert.Equal(t, "container:"+dockerIDPrefix+PauseContainerName, config.NetworkMode)
+	assert.Equal(t, "container:"+dockerIDPrefix+PauseContainerName, string(config.NetworkMode))
+
+	// Verify that the network mode is not set to "none"  for the
+	// empty volume container
+	config, err = testTask.DockerHostConfig(testTask.Containers[1], dockerMap(testTask), defaultDockerClientAPIVersion)
+	assert.Nil(t, err)
+	assert.Equal(t, networkModeNone, string(config.NetworkMode))
 
 	// Verify that the network mode is set to "none" for the pause container
 	config, err = testTask.DockerHostConfig(pauseContainer, dockerMap(testTask), defaultDockerClientAPIVersion)
 	assert.Nil(t, err)
-	assert.Equal(t, networkModeNone, config.NetworkMode)
+	assert.Equal(t, networkModeNone, string(config.NetworkMode))
 
 	// Verify that overridden DNS settings are set for the pause container
 	// and not set for non pause containers
@@ -329,11 +351,10 @@ func TestBadDockerHostConfigRawConfig(t *testing.T) {
 }
 
 func TestDockerConfigRawConfig(t *testing.T) {
-	rawConfigInput := docker.Config{
+	rawConfigInput := dockercontainer.Config{
 		Hostname:        "hostname",
 		Domainname:      "domainname",
 		NetworkDisabled: true,
-		DNS:             []string{"dnsfoo", "dnsbar"},
 		WorkingDir:      "workdir",
 		User:            "user",
 	}
@@ -363,7 +384,6 @@ func TestDockerConfigRawConfig(t *testing.T) {
 	}
 
 	expectedOutput := rawConfigInput
-	expectedOutput.CPUShares = 2
 
 	assertSetStructFieldsEqual(t, expectedOutput, *config)
 }
@@ -396,7 +416,7 @@ func TestDockerConfigRawConfigNilLabel(t *testing.T) {
 
 func TestDockerConfigRawConfigMerging(t *testing.T) {
 	// Use a struct that will marshal to the actual message we expect; not
-	// docker.Config which will include a lot of zero values.
+	// dockercontainer.Config which will include a lot of zero values.
 	rawConfigInput := struct {
 		User string `json:"User,omitempty" yaml:"User,omitempty"`
 	}{
@@ -430,11 +450,9 @@ func TestDockerConfigRawConfigMerging(t *testing.T) {
 		t.Fatal(configErr)
 	}
 
-	expected := docker.Config{
-		Memory:    1000 * 1024 * 1024,
-		CPUShares: 50,
-		Image:     "image",
-		User:      "user",
+	expected := dockercontainer.Config{
+		Image: "image",
+		User:  "user",
 	}
 
 	assertSetStructFieldsEqual(t, expected, *config)
@@ -524,6 +542,82 @@ func TestGetCredentialsEndpointWhenCredentialsAreNotSet(t *testing.T) {
 			t.Errorf("'%s' environment variable should not be set for container '%s'", awsSDKCredentialsRelativeURIPathEnvironmentVariableName, container.Name)
 		}
 	}
+}
+
+func TestGetDockerResources(t *testing.T) {
+	testTask := &Task{
+		Arn:     "arn:aws:ecs:us-east-1:012345678910:task/c09f0188-7f87-4b0f-bfc3-16296622b6fe",
+		Family:  "myFamily",
+		Version: "1",
+		Containers: []*apicontainer.Container{
+			{
+				Name:   "c1",
+				CPU:    uint(10),
+				Memory: uint(256),
+			},
+		},
+	}
+	resources := testTask.getDockerResources(testTask.Containers[0])
+	assert.Equal(t, int64(10), resources.CPUShares, "Wrong number of CPUShares")
+	assert.Equal(t, int64(268435456), resources.Memory, "Wrong amount of memory")
+}
+
+func TestGetDockerResourcesCPUTooLow(t *testing.T) {
+	testTask := &Task{
+		Arn:     "arn:aws:ecs:us-east-1:012345678910:task/c09f0188-7f87-4b0f-bfc3-16296622b6fe",
+		Family:  "myFamily",
+		Version: "1",
+		Containers: []*apicontainer.Container{
+			{
+				Name:   "c1",
+				CPU:    uint(0),
+				Memory: uint(256),
+			},
+		},
+	}
+	resources := testTask.getDockerResources(testTask.Containers[0])
+	assert.Equal(t, int64(268435456), resources.Memory, "Wrong amount of memory")
+
+	// Minimum requirement of 2 CPU Shares
+	if resources.CPUShares != 2 {
+		t.Error("CPU shares of 0 did not get changed to 2")
+	}
+}
+
+func TestGetDockerResourcesMemoryTooLow(t *testing.T) {
+	testTask := &Task{
+		Arn:     "arn:aws:ecs:us-east-1:012345678910:task/c09f0188-7f87-4b0f-bfc3-16296622b6fe",
+		Family:  "myFamily",
+		Version: "1",
+		Containers: []*apicontainer.Container{
+			{
+				Name:   "c1",
+				CPU:    uint(10),
+				Memory: uint(1),
+			},
+		},
+	}
+	resources := testTask.getDockerResources(testTask.Containers[0])
+	assert.Equal(t, int64(10), resources.CPUShares, "Wrong number of CPUShares")
+	assert.Equal(t, int64(apicontainer.DockerContainerMinimumMemoryInBytes), resources.Memory,
+		"Wrong amount of memory")
+}
+
+func TestGetDockerResourcesUnspecifiedMemory(t *testing.T) {
+	testTask := &Task{
+		Arn:     "arn:aws:ecs:us-east-1:012345678910:task/c09f0188-7f87-4b0f-bfc3-16296622b6fe",
+		Family:  "myFamily",
+		Version: "1",
+		Containers: []*apicontainer.Container{
+			{
+				Name: "c1",
+				CPU:  uint(10),
+			},
+		},
+	}
+	resources := testTask.getDockerResources(testTask.Containers[0])
+	assert.Equal(t, int64(10), resources.CPUShares, "Wrong number of CPUShares")
+	assert.Equal(t, int64(0), resources.Memory, "Wrong amount of memory")
 }
 
 func TestPostUnmarshalTaskWithDockerVolumes(t *testing.T) {
@@ -1178,8 +1272,8 @@ func TestApplyExecutionRoleLogsAuthSet(t *testing.T) {
 	credentialsIDInTask := "credsid"
 	expectedEndpoint := "/v2/credentials/" + credentialsIDInTask
 
-	rawHostConfigInput := docker.HostConfig{
-		LogConfig: docker.LogConfig{
+	rawHostConfigInput := dockercontainer.HostConfig{
+		LogConfig: dockercontainer.LogConfig{
 			Type:   "foo",
 			Config: map[string]string{"foo": "bar"},
 		},
@@ -1227,8 +1321,8 @@ func TestApplyExecutionRoleLogsAuthFailEmptyCredentialsID(t *testing.T) {
 	defer ctrl.Finish()
 	credentialsManager := mock_credentials.NewMockManager(ctrl)
 
-	rawHostConfigInput := docker.HostConfig{
-		LogConfig: docker.LogConfig{
+	rawHostConfigInput := dockercontainer.HostConfig{
+		LogConfig: dockercontainer.LogConfig{
 			Type:   "foo",
 			Config: map[string]string{"foo": "bar"},
 		},
@@ -1269,8 +1363,8 @@ func TestApplyExecutionRoleLogsAuthFailNoCredentialsForTask(t *testing.T) {
 
 	credentialsIDInTask := "credsid"
 
-	rawHostConfigInput := docker.HostConfig{
-		LogConfig: docker.LogConfig{
+	rawHostConfigInput := dockercontainer.HostConfig{
+		LogConfig: dockercontainer.LogConfig{
 			Type:   "foo",
 			Config: map[string]string{"foo": "bar"},
 		},
@@ -1320,19 +1414,12 @@ func TestSetMinimumMemoryLimit(t *testing.T) {
 	hostconfig, err := testTask.DockerHostConfig(testTask.Containers[0], dockerMap(testTask), defaultDockerClientAPIVersion)
 	assert.Nil(t, err)
 
-	config, cerr := testTask.DockerConfig(testTask.Containers[0], defaultDockerClientAPIVersion)
-	assert.Nil(t, cerr)
-
-	assert.Equal(t, int64(apicontainer.DockerContainerMinimumMemoryInBytes), config.Memory)
-	assert.Empty(t, hostconfig.Memory)
+	assert.Equal(t, int64(apicontainer.DockerContainerMinimumMemoryInBytes), hostconfig.Memory)
 
 	hostconfig, err = testTask.DockerHostConfig(testTask.Containers[0], dockerMap(testTask), dockerclient.Version_1_18)
 	assert.Nil(t, err)
 
-	config, cerr = testTask.DockerConfig(testTask.Containers[0], dockerclient.Version_1_18)
-	assert.Nil(t, err)
 	assert.Equal(t, int64(apicontainer.DockerContainerMinimumMemoryInBytes), hostconfig.Memory)
-	assert.Empty(t, config.Memory)
 }
 
 // TestContainerHealthConfig tests that we set the correct container health check config

--- a/agent/api/task/task_unsupported.go
+++ b/agent/api/task/task_unsupported.go
@@ -21,14 +21,10 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	"github.com/cihub/seelog"
-	docker "github.com/fsouza/go-dockerclient"
+	dockercontainer "github.com/docker/docker/api/types/container"
 )
 
 const (
-	//memorySwappinessDefault is the expected default value for this platform. This is used in task_windows.go
-	//and is maintained here for unix default. Also used for testing
-	memorySwappinessDefault = 0
-
 	defaultCPUPeriod = 100 * time.Millisecond // 100ms
 	// With a 100ms CPU period, we can express 0.01 vCPU to 10 vCPUs
 	maxTaskVCPULimit = 10
@@ -54,7 +50,7 @@ func (task *Task) initializeCgroupResourceSpec(cgroupPath string, resourceFields
 	return nil
 }
 
-func (task *Task) platformHostConfigOverride(hostConfig *docker.HostConfig) error {
+func (task *Task) platformHostConfigOverride(hostConfig *dockercontainer.HostConfig) error {
 	return nil
 }
 

--- a/agent/api/task/task_windows.go
+++ b/agent/api/task/task_windows.go
@@ -25,12 +25,10 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	taskresourcevolume "github.com/aws/amazon-ecs-agent/agent/taskresource/volume"
 	"github.com/cihub/seelog"
-	docker "github.com/fsouza/go-dockerclient"
+	dockercontainer "github.com/docker/docker/api/types/container"
 )
 
 const (
-	//memorySwappinessDefault is the expected default value for this platform
-	memorySwappinessDefault = -1
 	// cpuSharesPerCore represents the cpu shares of a cpu core in docker
 	cpuSharesPerCore  = 1024
 	percentageFactor  = 100
@@ -79,8 +77,7 @@ func getCanonicalPath(path string) string {
 
 // platformHostConfigOverride provides an entry point to set up default HostConfig options to be
 // passed to Docker API.
-func (task *Task) platformHostConfigOverride(hostConfig *docker.HostConfig) error {
-	task.overrideDefaultMemorySwappiness(hostConfig)
+func (task *Task) platformHostConfigOverride(hostConfig *dockercontainer.HostConfig) error {
 	// Convert the CPUShares to CPUPercent
 	hostConfig.CPUPercent = hostConfig.CPUShares * percentageFactor / int64(cpuShareScaleFactor)
 	if hostConfig.CPUPercent == 0 && hostConfig.CPUShares != 0 {
@@ -92,16 +89,6 @@ func (task *Task) platformHostConfigOverride(hostConfig *docker.HostConfig) erro
 	}
 	hostConfig.CPUShares = 0
 	return nil
-}
-
-// overrideDefaultMemorySwappiness Overrides the value of MemorySwappiness to -1
-// Version 1.12.x of Docker for Windows would ignore the unsupported option MemorySwappiness.
-// Version 17.03.x will cause an error if any value other than -1 is passed in for MemorySwappiness.
-// This bug is not noticed when no value is passed in. However, the go-dockerclient client version
-// we are using removed the json option omitempty causing this parameter to default to 0 if empty.
-// https://github.com/fsouza/go-dockerclient/commit/72342f96fabfa614a94b6ca57d987eccb8a836bf
-func (task *Task) overrideDefaultMemorySwappiness(hostConfig *docker.HostConfig) {
-	hostConfig.MemorySwappiness = memorySwappinessDefault
 }
 
 // dockerCPUShares converts containerCPU shares if needed as per the logic stated below:

--- a/agent/api/task/task_windows_test.go
+++ b/agent/api/task/task_windows_test.go
@@ -26,15 +26,14 @@ import (
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	apitaskstatus "github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/agent/config"
-	"github.com/aws/amazon-ecs-agent/agent/dockerclient"
 	taskresourcevolume "github.com/aws/amazon-ecs-agent/agent/taskresource/volume"
 
-	"github.com/fsouza/go-dockerclient"
+	dockercontainer "github.com/docker/docker/api/types/container"
 	"github.com/stretchr/testify/assert"
+	"github.com/aws/amazon-ecs-agent/agent/dockerclient"
 )
 
 const (
-	expectedMemorySwappinessDefault = memorySwappinessDefault
 	minDockerClientAPIVersion       = dockerclient.Version_1_24
 )
 
@@ -112,53 +111,21 @@ func TestWindowsPlatformHostConfigOverride(t *testing.T) {
 
 	task := &Task{}
 
-	hostConfig := &docker.HostConfig{CPUShares: int64(1 * cpuSharesPerCore)}
+	hostConfig := &dockercontainer.HostConfig{Resources: dockercontainer.Resources{CPUShares: int64(1 * cpuSharesPerCore)}}
 
 	task.platformHostConfigOverride(hostConfig)
 	assert.Equal(t, int64(1*cpuSharesPerCore*percentageFactor)/int64(cpuShareScaleFactor), hostConfig.CPUPercent)
 	assert.Equal(t, int64(0), hostConfig.CPUShares)
-	assert.EqualValues(t, expectedMemorySwappinessDefault, hostConfig.MemorySwappiness)
 
-	hostConfig = &docker.HostConfig{CPUShares: 10}
+	hostConfig = &dockercontainer.HostConfig{Resources: dockercontainer.Resources{CPUShares: 10}}
 	task.platformHostConfigOverride(hostConfig)
 	assert.Equal(t, int64(minimumCPUPercent), hostConfig.CPUPercent)
 	assert.Empty(t, hostConfig.CPUShares)
 }
 
-func TestWindowsMemorySwappinessOption(t *testing.T) {
-	// Testing sending a task to windows overriding MemorySwappiness value
-	rawHostConfigInput := docker.HostConfig{}
-
-	rawHostConfig, err := json.Marshal(&rawHostConfigInput)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	testTask := &Task{
-		Arn:     "arn:aws:ecs:us-east-1:012345678910:task/c09f0188-7f87-4b0f-bfc3-16296622b6fe",
-		Family:  "myFamily",
-		Version: "1",
-		Containers: []*apicontainer.Container{
-			{
-				Name: "c1",
-				DockerConfig: apicontainer.DockerConfig{
-					HostConfig: strptr(string(rawHostConfig)),
-				},
-			},
-		},
-	}
-
-	config, configErr := testTask.DockerHostConfig(testTask.Containers[0], dockerMap(testTask), minDockerClientAPIVersion)
-	if configErr != nil {
-		t.Fatal(configErr)
-	}
-
-	assert.EqualValues(t, expectedMemorySwappinessDefault, config.MemorySwappiness)
-}
-
 func TestDockerHostConfigRawConfigMerging(t *testing.T) {
 	// Use a struct that will marshal to the actual message we expect; not
-	// docker.HostConfig which will include a lot of zero values.
+	// dockercontainer.HostConfig which will include a lot of zero values.
 	rawHostConfigInput := struct {
 		Privileged  bool     `json:"Privileged,omitempty" yaml:"Privileged,omitempty"`
 		SecurityOpt []string `json:"SecurityOpt,omitempty" yaml:"SecurityOpt,omitempty"`
@@ -196,43 +163,19 @@ func TestDockerHostConfigRawConfigMerging(t *testing.T) {
 	hostConfig, configErr := testTask.DockerHostConfig(testTask.Containers[0], dockerMap(testTask), minDockerClientAPIVersion)
 	assert.Nil(t, configErr)
 
-	expected := docker.HostConfig{
-		Memory:           apicontainer.DockerContainerMinimumMemoryInBytes,
-		Privileged:       true,
-		SecurityOpt:      []string{"foo", "bar"},
-		VolumesFrom:      []string{"dockername-c2"},
-		MemorySwappiness: memorySwappinessDefault,
-		CPUPercent:       minimumCPUPercent,
-	}
-
-	assertSetStructFieldsEqual(t, expected, *hostConfig)
-}
-
-// TestSetConfigHostconfigBasedOnAPIVersion tests the docker hostconfig was correctly
-// set based on the docker client version
-func TestSetConfigHostconfigBasedOnAPIVersion(t *testing.T) {
-	memoryMiB := 500
-	testTask := &Task{
-		Containers: []*apicontainer.Container{
-			{
-				Name:   "c1",
-				CPU:    uint(10),
-				Memory: uint(memoryMiB),
-			},
+	expected := dockercontainer.HostConfig{
+		Resources: dockercontainer.Resources{
+			// Convert MB to B and set Memory
+			Memory:     apicontainer.DockerContainerMinimumMemoryInBytes,
+			CPUPercent: minimumCPUPercent,
 		},
+		Privileged:  true,
+		SecurityOpt: []string{"foo", "bar"},
+		VolumesFrom: []string{"dockername-c2"},
 	}
 
-	hostconfig, err := testTask.DockerHostConfig(testTask.Containers[0], dockerMap(testTask), minDockerClientAPIVersion)
-	assert.Nil(t, err)
-
-	config, cerr := testTask.DockerConfig(testTask.Containers[0], minDockerClientAPIVersion)
-	assert.Nil(t, cerr)
-	assert.Equal(t, int64(memoryMiB*1024*1024), hostconfig.Memory)
-	assert.Empty(t, hostconfig.CPUShares)
-	assert.Equal(t, int64(minimumCPUPercent), hostconfig.CPUPercent)
-
-	assert.Empty(t, config.CPUShares)
-	assert.Empty(t, config.Memory)
+	assert.Nil(t, expected.MemorySwappiness, "Expected default memorySwappiness to be nil")
+	assertSetStructFieldsEqual(t, expected, *hostConfig)
 }
 
 func TestCPUPercentBasedOnUnboundedEnabled(t *testing.T) {

--- a/agent/containermetadata/manager.go
+++ b/agent/containermetadata/manager.go
@@ -25,7 +25,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/utils/ioutilwrapper"
 	"github.com/aws/amazon-ecs-agent/agent/utils/oswrapper"
 
-	docker "github.com/fsouza/go-dockerclient"
+	dockercontainer "github.com/docker/docker/api/types/container"
 )
 
 const (
@@ -41,7 +41,7 @@ const (
 // operations
 type Manager interface {
 	SetContainerInstanceARN(string)
-	Create(*docker.Config, *docker.HostConfig, *apitask.Task, string) error
+	Create(*dockercontainer.Config, *dockercontainer.HostConfig, *apitask.Task, string) error
 	Update(context.Context, string, *apitask.Task, string) error
 	Clean(string) error
 }
@@ -88,7 +88,7 @@ func (manager *metadataManager) SetContainerInstanceARN(containerInstanceARN str
 // Create creates the metadata file and adds the metadata directory to
 // the container's mounted host volumes
 // Pointer hostConfig is modified directly so there is risk of concurrency errors.
-func (manager *metadataManager) Create(config *docker.Config, hostConfig *docker.HostConfig, task *apitask.Task, containerName string) error {
+func (manager *metadataManager) Create(config *dockercontainer.Config, hostConfig *dockercontainer.HostConfig, task *apitask.Task, containerName string) error {
 	// Create task and container directories if they do not yet exist
 	metadataDirectoryPath, err := getMetadataFilePath(task.Arn, containerName, manager.dataDir)
 	// Stop metadata creation if path is malformed for any reason

--- a/agent/containermetadata/manager_test.go
+++ b/agent/containermetadata/manager_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/utils/ioutilwrapper/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/utils/oswrapper/mocks"
 
-	docker "github.com/fsouza/go-dockerclient"
+	"github.com/docker/docker/api/types"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 )
@@ -127,18 +127,20 @@ func TestUpdateNotRunningFail(t *testing.T) {
 	mockTaskARN := validTaskARN
 	mockTask := &apitask.Task{Arn: mockTaskARN}
 	mockContainerName := containerName
-	mockState := docker.State{
+	mockState := types.ContainerState{
 		Running: false,
 	}
-	mockContainer := &docker.Container{
-		State: mockState,
+	mockContainer := types.ContainerJSON{
+		ContainerJSONBase: &types.ContainerJSONBase{
+			State: &mockState,
+		},
 	}
 
 	newManager := &metadataManager{
 		client: mockClient,
 	}
 
-	mockClient.EXPECT().InspectContainer(gomock.Any(), mockDockerID, inspectContainerTimeout).Return(mockContainer, nil)
+	mockClient.EXPECT().InspectContainer(gomock.Any(), mockDockerID, inspectContainerTimeout).Return(&mockContainer, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	err := newManager.Update(ctx, mockDockerID, mockTask, mockContainerName)

--- a/agent/containermetadata/manager_unix_test.go
+++ b/agent/containermetadata/manager_unix_test.go
@@ -21,7 +21,9 @@ import (
 
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 
-	docker "github.com/fsouza/go-dockerclient"
+	"github.com/docker/docker/api/types"
+	dockercontainer "github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 )
@@ -34,8 +36,8 @@ func TestCreate(t *testing.T) {
 	mockTaskARN := validTaskARN
 	mockTask := &apitask.Task{Arn: mockTaskARN}
 	mockContainerName := containerName
-	mockConfig := &docker.Config{Env: make([]string, 0)}
-	mockHostConfig := &docker.HostConfig{Binds: make([]string, 0)}
+	mockConfig := &dockercontainer.Config{Env: make([]string, 0)}
+	mockHostConfig := &dockercontainer.HostConfig{Binds: make([]string, 0)}
 
 	gomock.InOrder(
 		mockOS.EXPECT().MkdirAll(gomock.Any(), gomock.Any()).Return(nil),
@@ -67,17 +69,21 @@ func TestUpdate(t *testing.T) {
 	mockTaskARN := validTaskARN
 	mockTask := &apitask.Task{Arn: mockTaskARN}
 	mockContainerName := containerName
-	mockState := docker.State{
+	mockState := types.ContainerState{
 		Running: true,
 	}
 
-	mockConfig := &docker.Config{Image: "image"}
+	mockConfig := &dockercontainer.Config{Image: "image"}
 
-	mockNetworks := make(map[string]docker.ContainerNetwork)
-	mockNetworkSettings := &docker.NetworkSettings{Networks: mockNetworks}
+	mockNetworks := map[string]*network.EndpointSettings{}
+	mockNetworkSettings := &types.NetworkSettings{
+		Networks: mockNetworks,
+	}
 
-	mockContainer := &docker.Container{
-		State:           mockState,
+	mockContainer := types.ContainerJSON{
+		ContainerJSONBase: &types.ContainerJSONBase{
+			State: &mockState,
+		},
 		Config:          mockConfig,
 		NetworkSettings: mockNetworkSettings,
 	}
@@ -89,7 +95,7 @@ func TestUpdate(t *testing.T) {
 	}
 
 	gomock.InOrder(
-		mockClient.EXPECT().InspectContainer(gomock.Any(), mockDockerID, inspectContainerTimeout).Return(mockContainer, nil),
+		mockClient.EXPECT().InspectContainer(gomock.Any(), mockDockerID, inspectContainerTimeout).Return(&mockContainer, nil),
 		mockIOUtil.EXPECT().TempFile(gomock.Any(), gomock.Any()).Return(mockFile, nil),
 		mockFile.EXPECT().Write(gomock.Any()).Return(0, nil),
 		mockFile.EXPECT().Chmod(gomock.Any()).Return(nil),

--- a/agent/containermetadata/manager_windows_test.go
+++ b/agent/containermetadata/manager_windows_test.go
@@ -21,9 +21,11 @@ import (
 
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 
-	docker "github.com/fsouza/go-dockerclient"
+	"github.com/docker/docker/api/types"
+	dockercontainer "github.com/docker/docker/api/types/container"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"github.com/docker/docker/api/types/network"
 )
 
 // TestCreate is the mainline case for metadata create
@@ -34,8 +36,8 @@ func TestCreate(t *testing.T) {
 	mockTaskARN := validTaskARN
 	mockTask := &apitask.Task{Arn: mockTaskARN}
 	mockContainerName := containerName
-	mockConfig := &docker.Config{Env: make([]string, 0)}
-	mockHostConfig := &docker.HostConfig{Binds: make([]string, 0)}
+	mockConfig := &dockercontainer.Config{Env: make([]string, 0)}
+	mockHostConfig := &dockercontainer.HostConfig{Binds: make([]string, 0)}
 
 	gomock.InOrder(
 		mockOS.EXPECT().MkdirAll(gomock.Any(), gomock.Any()).Return(nil),
@@ -64,19 +66,21 @@ func TestUpdate(t *testing.T) {
 	mockTaskARN := validTaskARN
 	mockTask := &apitask.Task{Arn: mockTaskARN}
 	mockContainerName := containerName
-	mockState := docker.State{
+	mockState := types.ContainerState{
 		Running: true,
 	}
 
-	mockConfig := &docker.Config{Image: "image"}
+	mockConfig := &dockercontainer.Config{Image: "image"}
 
-	mockNetworks := make(map[string]docker.ContainerNetwork)
-	mockNetworkSettings := &docker.NetworkSettings{Networks: mockNetworks}
+	mockNetworks := map[string]*network.EndpointSettings{}
+	mockNetworkSettings := types.NetworkSettings{Networks: mockNetworks}
 
-	mockContainer := &docker.Container{
-		State:           mockState,
+	mockContainer := types.ContainerJSON{
+		ContainerJSONBase: &types.ContainerJSONBase{
+			State:           &mockState,
+		},
 		Config:          mockConfig,
-		NetworkSettings: mockNetworkSettings,
+		NetworkSettings: &mockNetworkSettings,
 	}
 
 	newManager := &metadataManager{
@@ -85,7 +89,7 @@ func TestUpdate(t *testing.T) {
 	}
 
 	gomock.InOrder(
-		mockClient.EXPECT().InspectContainer(gomock.Any(), mockDockerID, inspectContainerTimeout).Return(mockContainer, nil),
+		mockClient.EXPECT().InspectContainer(gomock.Any(), mockDockerID, inspectContainerTimeout).Return(&mockContainer, nil),
 		mockOS.EXPECT().OpenFile(gomock.Any(), gomock.Any(), gomock.Any()).Return(mockFile, nil),
 		mockFile.EXPECT().Write(gomock.Any()).Return(0, nil),
 		mockFile.EXPECT().Sync().Return(nil),

--- a/agent/containermetadata/mocks/containermetadata_mocks.go
+++ b/agent/containermetadata/mocks/containermetadata_mocks.go
@@ -23,7 +23,8 @@ import (
 	time "time"
 
 	task "github.com/aws/amazon-ecs-agent/agent/api/task"
-	go_dockerclient "github.com/fsouza/go-dockerclient"
+	types "github.com/docker/docker/api/types"
+	container "github.com/docker/docker/api/types/container"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -63,7 +64,7 @@ func (mr *MockManagerMockRecorder) Clean(arg0 interface{}) *gomock.Call {
 }
 
 // Create mocks base method
-func (m *MockManager) Create(arg0 *go_dockerclient.Config, arg1 *go_dockerclient.HostConfig, arg2 *task.Task, arg3 string) error {
+func (m *MockManager) Create(arg0 *container.Config, arg1 *container.HostConfig, arg2 *task.Task, arg3 string) error {
 	ret := m.ctrl.Call(m, "Create", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -120,9 +121,9 @@ func (m *MockDockerMetadataClient) EXPECT() *MockDockerMetadataClientMockRecorde
 }
 
 // InspectContainer mocks base method
-func (m *MockDockerMetadataClient) InspectContainer(arg0 context.Context, arg1 string, arg2 time.Duration) (*go_dockerclient.Container, error) {
+func (m *MockDockerMetadataClient) InspectContainer(arg0 context.Context, arg1 string, arg2 time.Duration) (*types.ContainerJSON, error) {
 	ret := m.ctrl.Call(m, "InspectContainer", arg0, arg1, arg2)
-	ret0, _ := ret[0].(*go_dockerclient.Container)
+	ret0, _ := ret[0].(*types.ContainerJSON)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/agent/containermetadata/parse_metadata_test.go
+++ b/agent/containermetadata/parse_metadata_test.go
@@ -20,7 +20,10 @@ import (
 
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 
-	docker "github.com/fsouza/go-dockerclient"
+	"github.com/docker/docker/api/types"
+	dockercontainer "github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
+	"github.com/docker/go-connections/nat"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -88,12 +91,15 @@ func TestParseHasConfig(t *testing.T) {
 	mockCluster := cluster
 	mockContainerInstanceARN := containerInstanceARN
 
-	mockConfig := &docker.Config{Image: "image"}
+	mockConfig := &dockercontainer.Config{Image: "image"}
 
-	mockNetworks := make(map[string]docker.ContainerNetwork)
-	mockNetworkSettings := &docker.NetworkSettings{Networks: mockNetworks}
+	mockNetworks := map[string]*network.EndpointSettings{}
+	mockNetworkSettings := &types.NetworkSettings{Networks: mockNetworks}
 
-	mockContainer := &docker.Container{Config: mockConfig, NetworkSettings: mockNetworkSettings}
+	mockContainer := &types.ContainerJSON{
+		Config:          mockConfig,
+		NetworkSettings: mockNetworkSettings,
+	}
 
 	expectedStatus := string(MetadataReady)
 
@@ -119,17 +125,27 @@ func TestParseHasNetworkSettingsPortBindings(t *testing.T) {
 	mockCluster := cluster
 	mockContainerInstanceARN := containerInstanceARN
 
-	mockPorts := make(map[docker.Port][]docker.PortBinding)
-	mockPortBinding := make([]docker.PortBinding, 0)
-	mockPortBinding = append(mockPortBinding, docker.PortBinding{HostIP: "0.0.0.0", HostPort: "8080"})
+	mockPorts := nat.PortMap{}
+	mockPortBinding := make([]nat.PortBinding, 0)
+	mockPortBinding = append(mockPortBinding, nat.PortBinding{HostIP: "0.0.0.0", HostPort: "8080"})
 	mockPorts["80/tcp"] = mockPortBinding
 
-	mockHostConfig := &docker.HostConfig{NetworkMode: "bridge"}
-	mockNetworks := make(map[string]docker.ContainerNetwork)
-	mockNetworks["bridge"] = docker.ContainerNetwork{}
-	mockNetworks["network0"] = docker.ContainerNetwork{}
-	mockNetworkSettings := &docker.NetworkSettings{Networks: mockNetworks, Ports: mockPorts}
-	mockContainer := &docker.Container{HostConfig: mockHostConfig, NetworkSettings: mockNetworkSettings}
+	mockHostConfig := &dockercontainer.HostConfig{NetworkMode: "bridge"}
+	mockNetworks := map[string]*network.EndpointSettings{}
+	mockNetworks["bridge"] = &network.EndpointSettings{}
+	mockNetworks["network0"] = &network.EndpointSettings{}
+	mockNetworkSettings := &types.NetworkSettings{
+		NetworkSettingsBase: types.NetworkSettingsBase{
+			Ports: mockPorts,
+		},
+		Networks: mockNetworks,
+	}
+	mockContainer := &types.ContainerJSON{
+		ContainerJSONBase: &types.ContainerJSONBase{
+			HostConfig: mockHostConfig,
+		},
+		NetworkSettings: mockNetworkSettings,
+	}
 
 	expectedStatus := string(MetadataReady)
 
@@ -159,9 +175,17 @@ func TestParseHasNetworkSettingsNetworksEmpty(t *testing.T) {
 	mockCluster := cluster
 	mockContainerInstanceARN := containerInstanceARN
 
-	mockHostConfig := &docker.HostConfig{NetworkMode: "bridge"}
-	mockNetworkSettings := &docker.NetworkSettings{IPAddress: "0.0.0.0"}
-	mockContainer := &docker.Container{HostConfig: mockHostConfig, NetworkSettings: mockNetworkSettings}
+	mockHostConfig := &dockercontainer.HostConfig{NetworkMode: "bridge"}
+	mockNetworkSettings := &types.NetworkSettings{
+		DefaultNetworkSettings: types.DefaultNetworkSettings{
+			IPAddress: "0.0.0.0",
+		}}
+	mockContainer := &types.ContainerJSON{
+		ContainerJSONBase: &types.ContainerJSONBase{
+			HostConfig: mockHostConfig,
+		},
+		NetworkSettings: mockNetworkSettings,
+	}
 
 	expectedStatus := string(MetadataReady)
 
@@ -186,12 +210,19 @@ func TestParseHasNetworkSettingsNetworksNonEmpty(t *testing.T) {
 	mockCluster := cluster
 	mockContainerInstanceARN := containerInstanceARN
 
-	mockHostConfig := &docker.HostConfig{NetworkMode: "bridge"}
-	mockNetworks := make(map[string]docker.ContainerNetwork)
-	mockNetworks["bridge"] = docker.ContainerNetwork{}
-	mockNetworks["network0"] = docker.ContainerNetwork{}
-	mockNetworkSettings := &docker.NetworkSettings{Networks: mockNetworks}
-	mockContainer := &docker.Container{HostConfig: mockHostConfig, NetworkSettings: mockNetworkSettings}
+	mockHostConfig := &dockercontainer.HostConfig{NetworkMode: dockercontainer.NetworkMode("bridge")}
+	mockNetworks := map[string]*network.EndpointSettings{}
+	mockNetworks["bridge"] = &network.EndpointSettings{}
+	mockNetworks["network0"] = &network.EndpointSettings{}
+	mockNetworkSettings := &types.NetworkSettings{
+		Networks: mockNetworks,
+	}
+	mockContainer := &types.ContainerJSON{
+		ContainerJSONBase: &types.ContainerJSONBase{
+			HostConfig: mockHostConfig,
+		},
+		NetworkSettings: mockNetworkSettings,
+	}
 
 	expectedStatus := string(MetadataReady)
 
@@ -209,6 +240,40 @@ func TestParseHasNetworkSettingsNetworksNonEmpty(t *testing.T) {
 	assert.Equal(t, len(metadata.dockerContainerMetadata.networkInfo.networks), 2, "Expected two networks")
 }
 
+func TestParseHasNoContainerJSONBase(t *testing.T) {
+	mockTaskARN := validTaskARN
+	mockTask := &apitask.Task{Arn: mockTaskARN}
+	mockContainerName := containerName
+	mockCluster := cluster
+	mockContainerInstanceARN := containerInstanceARN
+
+	mockConfig := &dockercontainer.Config{Image: "image"}
+	mockNetworkSettings := &types.NetworkSettings{
+		DefaultNetworkSettings: types.DefaultNetworkSettings{
+			IPAddress: "0.0.0.0",
+		}}
+	mockContainer := &types.ContainerJSON{
+		NetworkSettings: mockNetworkSettings,
+		Config:          mockConfig,
+	}
+
+	expectedStatus := string(MetadataReady)
+
+	newManager := &metadataManager{
+		cluster:              mockCluster,
+		containerInstanceARN: mockContainerInstanceARN,
+	}
+
+	metadata := newManager.parseMetadata(mockContainer, mockTask, mockContainerName)
+	assert.Equal(t, metadata.cluster, mockCluster, "Expected cluster "+mockCluster)
+	assert.Equal(t, metadata.taskMetadata.containerName, mockContainerName, "Expected container name "+mockContainerName)
+	assert.Equal(t, metadata.taskMetadata.taskARN, mockTaskARN, "Expected task ARN "+mockTaskARN)
+	assert.Equal(t, metadata.containerInstanceARN, mockContainerInstanceARN, "Expected container instance ARN "+mockContainerInstanceARN)
+	assert.Equal(t, string(metadata.metadataStatus), expectedStatus, "Expected status "+expectedStatus)
+	assert.Equal(t, len(metadata.dockerContainerMetadata.networkInfo.networks), 0, "Expected one network")
+	assert.Equal(t, metadata.dockerContainerMetadata.imageName, "image")
+}
+
 func TestParseTaskDefinitionSettings(t *testing.T) {
 	mockTaskARN := validTaskARN
 	mockTask := &apitask.Task{Arn: mockTaskARN}
@@ -216,10 +281,20 @@ func TestParseTaskDefinitionSettings(t *testing.T) {
 	mockCluster := cluster
 	mockContainerInstanceARN := containerInstanceARN
 
-	mockHostConfig := &docker.HostConfig{NetworkMode: "bridge"}
-	mockConfig := &docker.Config{Image: "image"}
-	mockNetworkSettings := &docker.NetworkSettings{IPAddress: "0.0.0.0"}
-	mockContainer := &docker.Container{HostConfig: mockHostConfig, Config: mockConfig, NetworkSettings: mockNetworkSettings}
+	mockHostConfig := &dockercontainer.HostConfig{NetworkMode: dockercontainer.NetworkMode("bridge")}
+	mockConfig := &dockercontainer.Config{Image: "image"}
+	mockNetworkSettings := &types.NetworkSettings{
+		NetworkSettingsBase: types.NetworkSettingsBase{
+			LinkLocalIPv6Address: "0.0.0.0",
+		},
+	}
+	mockContainer := &types.ContainerJSON{
+		ContainerJSONBase: &types.ContainerJSONBase{
+			HostConfig: mockHostConfig,
+		},
+		Config:          mockConfig,
+		NetworkSettings: mockNetworkSettings,
+	}
 
 	expectedStatus := string(MetadataReady)
 

--- a/agent/containermetadata/types.go
+++ b/agent/containermetadata/types.go
@@ -20,8 +20,7 @@ import (
 	"time"
 
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
-
-	docker "github.com/fsouza/go-dockerclient"
+	"github.com/docker/docker/api/types"
 )
 
 const (
@@ -80,7 +79,7 @@ func (status *MetadataStatus) UnmarshalText(text []byte) error {
 // The problems described above are indications dockerapi.DockerClient needs to be moved
 // outside the engine package
 type DockerMetadataClient interface {
-	InspectContainer(context.Context, string, time.Duration) (*docker.Container, error)
+	InspectContainer(context.Context, string, time.Duration) (*types.ContainerJSON, error)
 }
 
 // Network is a struct that keeps track of metadata of a network interface

--- a/agent/dockerclient/dockerapi/docker_client_test.go
+++ b/agent/dockerclient/dockerapi/docker_client_test.go
@@ -43,8 +43,11 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/docker/docker/api/types"
+	dockercontainer "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/volume"
+	"github.com/docker/go-connections/nat"
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -355,46 +358,55 @@ func TestGetRepositoryWithUntaggedImage(t *testing.T) {
 }
 
 func TestCreateContainerTimeout(t *testing.T) {
-	mockDocker, _, client, _, _, _, done := dockerClientSetup(t)
+	_, mockDockerSDK, client, _, _, _, done := dockerClientSetup(t)
 	defer done()
 
 	wait := &sync.WaitGroup{}
 	wait.Add(1)
-	config := docker.CreateContainerOptions{Config: &docker.Config{Memory: 100}, Name: "containerName"}
-	mockDocker.EXPECT().CreateContainer(gomock.Any()).Do(func(x interface{}) {
+	hostConfig := &dockercontainer.HostConfig{Resources: dockercontainer.Resources{Memory: 100}}
+	mockDockerSDK.EXPECT().ContainerCreate(gomock.Any(), &dockercontainer.Config{}, hostConfig,
+		&network.NetworkingConfig{}, "containerName").Do(func(v, w, x, y, z interface{}) {
 		wait.Wait()
-	}).MaxTimes(1).Return(nil, errors.New("test error"))
+	}).MaxTimes(1).Return(dockercontainer.ContainerCreateCreatedBody{}, errors.New("test error"))
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-	metadata := client.CreateContainer(ctx, config.Config, nil, config.Name, xContainerShortTimeout)
+	metadata := client.CreateContainer(ctx, &dockercontainer.Config{}, hostConfig, "containerName", xContainerShortTimeout)
 	assert.Error(t, metadata.Error, "expected error for pull timeout")
 	assert.Equal(t, "DockerTimeoutError", metadata.Error.(apierrors.NamedError).ErrorName())
 	wait.Done()
 }
 
 func TestCreateContainer(t *testing.T) {
-	mockDocker, _, client, _, _, _, done := dockerClientSetup(t)
+	_, mockDockerSDK, client, _, _, _, done := dockerClientSetup(t)
 	defer done()
 
-	config := docker.CreateContainerOptions{Config: &docker.Config{Memory: 100}, Name: "containerName"}
+	name := "containerName"
+	hostConfig := &dockercontainer.HostConfig{Resources: dockercontainer.Resources{Memory: 100}}
 	gomock.InOrder(
-		mockDocker.EXPECT().CreateContainer(gomock.Any()).Do(func(opts docker.CreateContainerOptions) {
-			assert.True(t, reflect.DeepEqual(opts.Config, config.Config),
-				"Mismatch in create container config, %v != %v", opts.Config, config.Config)
-			assert.Equal(t, config.Name, opts.Name,
-				"Mismatch in create container options, %s != %s", opts.Name, config.Name)
-		}).Return(&docker.Container{ID: "id"}, nil),
+		mockDockerSDK.EXPECT().ContainerCreate(gomock.Any(), gomock.Any(), hostConfig, gomock.Any(), name).
+			Do(func(v, w, x, y, z interface{}) {
+				assert.True(t, reflect.DeepEqual(x, hostConfig),
+					"Mismatch in create container HostConfig, %v != %v", y, hostConfig)
+				assert.Equal(t, z, name,
+					"Mismatch in create container options, %s != %s", z, name)
+			}).Return(dockercontainer.ContainerCreateCreatedBody{ID: "id"}, nil),
+		mockDockerSDK.EXPECT().ContainerInspect(gomock.Any(), "id").
+			Return(types.ContainerJSON{
+				ContainerJSONBase: &types.ContainerJSONBase{
+					ID: "id",
+				},
+			}, nil),
 	)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-	metadata := client.CreateContainer(ctx, config.Config, nil, config.Name, 1*time.Second)
+	metadata := client.CreateContainer(ctx, nil, hostConfig, name, 1*time.Second)
 	assert.NoError(t, metadata.Error)
 	assert.Equal(t, "id", metadata.DockerID)
 	assert.Nil(t, metadata.ExitCode, "Expected a created container to not have an exit code")
 }
 
 func TestStartContainerTimeout(t *testing.T) {
-	mockDocker, mockDockerSDK, client, _, _, _, done := dockerClientSetup(t)
+	_, mockDockerSDK, client, _, _, _, done := dockerClientSetup(t)
 	defer done()
 
 	wait := &sync.WaitGroup{}
@@ -402,7 +414,7 @@ func TestStartContainerTimeout(t *testing.T) {
 	mockDockerSDK.EXPECT().ContainerStart(gomock.Any(), "id", types.ContainerStartOptions{}).Do(func(x, y, z interface{}) {
 		wait.Wait() // wait until timeout happens
 	}).MaxTimes(1)
-	mockDocker.EXPECT().InspectContainerWithContext("id", gomock.Any()).Return(nil, errors.New("test error")).AnyTimes()
+	mockDockerSDK.EXPECT().ContainerInspect(gomock.Any(), "id").Return(types.ContainerJSON{}, errors.New("test error")).AnyTimes()
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	metadata := client.StartContainer(ctx, "id", xContainerShortTimeout)
@@ -412,12 +424,16 @@ func TestStartContainerTimeout(t *testing.T) {
 }
 
 func TestStartContainer(t *testing.T) {
-	mockDocker, mockDockerSDK, client, _, _, _, done := dockerClientSetup(t)
+	_, mockDockerSDK, client, _, _, _, done := dockerClientSetup(t)
 	defer done()
 
 	gomock.InOrder(
 		mockDockerSDK.EXPECT().ContainerStart(gomock.Any(), "id", types.ContainerStartOptions{}).Return(nil),
-		mockDocker.EXPECT().InspectContainerWithContext("id", gomock.Any()).Return(&docker.Container{ID: "id"}, nil),
+		mockDockerSDK.EXPECT().ContainerInspect(gomock.Any(), "id").
+			Return(types.ContainerJSON{
+				ContainerJSONBase: &types.ContainerJSONBase{
+					ID: "id",
+				}}, nil),
 	)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
@@ -429,7 +445,7 @@ func TestStartContainer(t *testing.T) {
 func TestStopContainerTimeout(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.DockerStopTimeout = xContainerShortTimeout
-	mockDocker, mockDockerSDK, client, _, _, _, done := dockerClientSetupWithConfig(t, cfg)
+	_, mockDockerSDK, client, _, _, _, done := dockerClientSetupWithConfig(t, cfg)
 	defer done()
 
 	wait := &sync.WaitGroup{}
@@ -438,7 +454,7 @@ func TestStopContainerTimeout(t *testing.T) {
 		wait.Wait()
 		// Don't return, verify timeout happens
 	}).MaxTimes(1).Return(errors.New("test error"))
-	mockDocker.EXPECT().InspectContainerWithContext(gomock.Any(), gomock.Any()).AnyTimes()
+	mockDockerSDK.EXPECT().ContainerInspect(gomock.Any(), gomock.Any()).AnyTimes()
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	metadata := client.StopContainer(ctx, "id", xContainerShortTimeout)
@@ -448,12 +464,23 @@ func TestStopContainerTimeout(t *testing.T) {
 }
 
 func TestStopContainer(t *testing.T) {
-	mockDocker, mockDockerSDK, client, _, _, _, done := dockerClientSetup(t)
+	_, mockDockerSDK, client, _, _, _, done := dockerClientSetup(t)
 	defer done()
 
 	gomock.InOrder(
 		mockDockerSDK.EXPECT().ContainerStop(gomock.Any(), "id", &client.config.DockerStopTimeout).Return(nil),
-		mockDocker.EXPECT().InspectContainerWithContext("id", gomock.Any()).Return(&docker.Container{ID: "id", State: docker.State{ExitCode: 10}}, nil),
+		mockDockerSDK.EXPECT().ContainerInspect(gomock.Any(), "id").
+			Return(
+				types.ContainerJSON{
+					ContainerJSONBase: &types.ContainerJSONBase{
+						ID: "id",
+						State: &types.ContainerState{
+							ExitCode: 10,
+						},
+					},
+					Config: &dockercontainer.Config{},
+				},
+				nil),
 	)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
@@ -503,15 +530,15 @@ func TestRemoveContainer(t *testing.T) {
 }
 
 func TestInspectContainerTimeout(t *testing.T) {
-	mockDocker, _, client, _, _, _, done := dockerClientSetup(t)
+	_, mockDockerSDK, client, _, _, _, done := dockerClientSetup(t)
 	defer done()
 
 	wait := &sync.WaitGroup{}
 	wait.Add(1)
-	mockDocker.EXPECT().InspectContainerWithContext("id", gomock.Any()).Do(func(x, ctx interface{}) {
+	mockDockerSDK.EXPECT().ContainerInspect(gomock.Any(), "id").Do(func(ctx, x interface{}) {
 		wait.Wait()
 		// Don't return, verify timeout happens
-	}).MaxTimes(1).Return(nil, errors.New("test error"))
+	}).MaxTimes(1).Return(types.ContainerJSON{}, errors.New("test error"))
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	_, err := client.InspectContainer(ctx, "id", xContainerShortTimeout)
@@ -521,23 +548,26 @@ func TestInspectContainerTimeout(t *testing.T) {
 }
 
 func TestInspectContainer(t *testing.T) {
-	mockDocker, _, client, _, _, _, done := dockerClientSetup(t)
+	_, mockDockerSDK, client, _, _, _, done := dockerClientSetup(t)
 	defer done()
 
-	containerOutput := docker.Container{ID: "id",
-		State: docker.State{
-			ExitCode: 10,
-			Health: docker.Health{
-				Status: "healthy",
-				Log: []docker.HealthCheck{
-					{
-						ExitCode: 1,
-						Output:   "health output",
+	containerOutput := types.ContainerJSON{
+		ContainerJSONBase: &types.ContainerJSONBase{
+			ID: "id",
+			State: &types.ContainerState{
+				ExitCode: 10,
+				Health: &types.Health{
+					Status: "healthy",
+					Log: []*types.HealthcheckResult{
+						{
+							ExitCode: 1,
+							Output:   "health output",
+						},
 					},
 				},
 			}}}
 	gomock.InOrder(
-		mockDocker.EXPECT().InspectContainerWithContext("id", gomock.Any()).Return(&containerOutput, nil),
+		mockDockerSDK.EXPECT().ContainerInspect(gomock.Any(), "id").Return(containerOutput, nil),
 	)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
@@ -547,7 +577,7 @@ func TestInspectContainer(t *testing.T) {
 }
 
 func TestContainerEvents(t *testing.T) {
-	mockDocker, _, client, _, _, _, done := dockerClientSetup(t)
+	mockDocker, mockDockerSDK, client, _, _, _, done := dockerClientSetup(t)
 	defer done()
 
 	var events chan<- *docker.APIEvents
@@ -565,16 +595,24 @@ func TestContainerEvents(t *testing.T) {
 	assert.Equal(t, event.DockerID, "containerId", "Wrong docker id")
 	assert.Equal(t, event.Status, apicontainerstatus.ContainerCreated, "Wrong status")
 
-	container := &docker.Container{
-		ID: "cid2",
-		NetworkSettings: &docker.NetworkSettings{
-			Ports: map[docker.Port][]docker.PortBinding{
-				"80/tcp": {{HostPort: "9001"}},
+	container := types.ContainerJSON{
+		ContainerJSONBase: &types.ContainerJSONBase{
+			ID: "cid2",
+		},
+		NetworkSettings: &types.NetworkSettings{
+			NetworkSettingsBase: types.NetworkSettingsBase{
+				Ports: nat.PortMap{
+					nat.Port("80/tcp"): []nat.PortBinding{{HostPort: "9001"}},
+				},
 			},
 		},
-		Mounts: []docker.Mount{{Source: "/host/path", Destination: "/container/path"}},
+		Config: &dockercontainer.Config{},
+		Mounts: []types.MountPoint{
+			{Source: "/host/path",
+				Destination: "/container/path"},
+		},
 	}
-	mockDocker.EXPECT().InspectContainerWithContext("cid2", gomock.Any()).Return(container, nil)
+	mockDockerSDK.EXPECT().ContainerInspect(gomock.Any(), "cid2").Return(container, nil)
 	go func() {
 		events <- &docker.APIEvents{Type: "container", ID: "cid2", Status: "start"}
 	}()
@@ -587,14 +625,16 @@ func TestContainerEvents(t *testing.T) {
 	assert.Equal(t, event.Volumes[0].Destination, "/container/path", "Incorrect volume mapping")
 
 	for i := 0; i < 2; i++ {
-		stoppedContainer := &docker.Container{
-			ID: "cid3" + strconv.Itoa(i),
-			State: docker.State{
-				FinishedAt: time.Now(),
-				ExitCode:   20,
+		stoppedContainer := types.ContainerJSON{
+			ContainerJSONBase: &types.ContainerJSONBase{
+				ID: "cid3" + strconv.Itoa(i),
+				State: &types.ContainerState{
+					FinishedAt: (time.Now()).Format(time.RFC3339),
+					ExitCode:   20,
+				},
 			},
 		}
-		mockDocker.EXPECT().InspectContainerWithContext("cid3"+strconv.Itoa(i), gomock.Any()).Return(stoppedContainer, nil)
+		mockDockerSDK.EXPECT().ContainerInspect(gomock.Any(), "cid3"+strconv.Itoa(i)).Return(stoppedContainer, nil)
 	}
 	go func() {
 		events <- &docker.APIEvents{Type: "container", ID: "cid30", Status: "stop"}
@@ -608,21 +648,22 @@ func TestContainerEvents(t *testing.T) {
 		assert.Equal(t, aws.IntValue(anEvent.ExitCode), 20, "Incorrect exit code")
 	}
 
-	containerWithHealthInfo := &docker.Container{
-		ID: "container_health",
-		State: docker.State{
-			Health: docker.Health{
-				Status: "healthy",
-				Log: []docker.HealthCheck{
-					{
-						ExitCode: 1,
-						Output:   "health output",
+	containerWithHealthInfo := types.ContainerJSON{
+		ContainerJSONBase: &types.ContainerJSONBase{
+			ID: "container_health",
+			State: &types.ContainerState{
+				Health: &types.Health{
+					Status: "healthy",
+					Log: []*types.HealthcheckResult{
+						{
+							ExitCode: 1,
+							Output:   "health output",
+						},
 					},
 				},
-			},
-		},
+			}},
 	}
-	mockDocker.EXPECT().InspectContainerWithContext("container_health", gomock.Any()).Return(containerWithHealthInfo, nil)
+	mockDockerSDK.EXPECT().ContainerInspect(gomock.Any(), "container_health").Return(containerWithHealthInfo, nil)
 	go func() {
 		events <- &docker.APIEvents{
 			Type:   "container",
@@ -824,10 +865,9 @@ func TestUsesVersionedClient(t *testing.T) {
 
 	vclient := client.WithVersion(dockerclient.DockerVersion("1.20"))
 
-	factory.EXPECT().GetClient(dockerclient.DockerVersion("1.20")).Return(mockDocker, nil)
-	sdkFactory.EXPECT().GetClient(dockerclient.DockerVersion("1.20")).Return(mockDockerSDK, nil)
+	sdkFactory.EXPECT().GetClient(dockerclient.DockerVersion("1.20")).Times(2).Return(mockDockerSDK, nil)
 	mockDockerSDK.EXPECT().ContainerStart(gomock.Any(), gomock.Any(), types.ContainerStartOptions{}).Return(nil)
-	mockDocker.EXPECT().InspectContainerWithContext(gomock.Any(), gomock.Any()).Return(nil, errors.New("test error"))
+	mockDockerSDK.EXPECT().ContainerInspect(gomock.Any(), gomock.Any()).Return(types.ContainerJSON{}, errors.New("test error"))
 	vclient.StartContainer(ctx, "foo", defaultTestConfig().ContainerStartTimeout)
 }
 
@@ -1236,61 +1276,78 @@ func TestECRAuthCacheWithDifferentExecutionRole(t *testing.T) {
 }
 
 func TestMetadataFromContainer(t *testing.T) {
-	ports := map[docker.Port][]docker.PortBinding{
-		docker.Port("80/tcp"): []docker.PortBinding{
+	ports := nat.PortMap{
+		"80/tcp": []nat.PortBinding{
 			{
 				HostIP:   "0.0.0.0",
 				HostPort: "80",
 			},
 		},
 	}
-	volumes := []docker.Mount{
-		{
-			Source:      "/foo",
-			Destination: "/bar",
+	// Representation of Volumes in ContainerJSON
+	volumes := []types.MountPoint{
+		{Destination: "/foo",
+			Source: "/bar",
 		},
 	}
 	labels := map[string]string{
 		"name": "metadata",
 	}
 
-	created := time.Now()
-	started := time.Now()
-	finished := time.Now()
+	created := time.Now().Format(time.RFC3339)
+	started := time.Now().Format(time.RFC3339)
+	finished := time.Now().Format(time.RFC3339)
 
-	dockerContainer := &docker.Container{
-		NetworkSettings: &docker.NetworkSettings{
-			Ports: ports,
+	dockerContainer := types.ContainerJSON{
+		NetworkSettings: &types.NetworkSettings{
+			NetworkSettingsBase: types.NetworkSettingsBase{
+				Ports: ports,
+			},
 		},
-		ID:     "1234",
-		Mounts: volumes,
-		Config: &docker.Config{
+		ContainerJSONBase: &types.ContainerJSONBase{
+			ID:      "1234",
+			Created: created,
+			State: &types.ContainerState{
+				Running:    true,
+				StartedAt:  started,
+				FinishedAt: finished,
+			},
+		},
+		Config: &dockercontainer.Config{
 			Labels: labels,
 		},
-		Created: created,
-		State: docker.State{
-			Running:    true,
-			StartedAt:  started,
-			FinishedAt: finished,
-		},
+		Mounts: volumes,
 	}
 
-	metadata := MetadataFromContainer(dockerContainer)
+	metadata := MetadataFromContainer(&dockerContainer)
 	assert.Equal(t, "1234", metadata.DockerID)
 	assert.Equal(t, volumes, metadata.Volumes)
 	assert.Equal(t, labels, metadata.Labels)
 	assert.Len(t, metadata.PortBindings, 1)
-	assert.Equal(t, created, metadata.CreatedAt)
-	assert.Equal(t, started, metadata.StartedAt)
-	assert.Equal(t, finished, metadata.FinishedAt)
+
+	// Need to convert both strings to same format to be able to compare. Parse and Format are not inverses.
+	createdTimeSDK, _ := time.Parse(time.RFC3339, dockerContainer.Created)
+	startedTimeSDK, _ := time.Parse(time.RFC3339, dockerContainer.State.StartedAt)
+	finishedTimeSDK, _ := time.Parse(time.RFC3339, dockerContainer.State.FinishedAt)
+
+	createdTime, _ := time.Parse(time.RFC3339, created)
+	startedTime, _ := time.Parse(time.RFC3339, started)
+	finishedTime, _ := time.Parse(time.RFC3339, finished)
+
+	assert.True(t, createdTime.Equal(createdTimeSDK))
+	assert.True(t, startedTime.Equal(startedTimeSDK))
+	assert.True(t, finishedTime.Equal(finishedTimeSDK))
 }
 
 func TestMetadataFromContainerHealthCheckWithNoLogs(t *testing.T) {
 
-	dockerContainer := &docker.Container{
-		State: docker.State{
-			Health: docker.Health{Status: "unhealthy"},
-		}}
+	dockerContainer := &types.ContainerJSON{
+		ContainerJSONBase: &types.ContainerJSONBase{
+			State: &types.ContainerState{
+				Health: &types.Health{Status: "unhealthy"},
+			},
+		},
+	}
 
 	metadata := MetadataFromContainer(dockerContainer)
 	assert.Equal(t, apicontainerstatus.ContainerUnhealthy, metadata.Health.Status)

--- a/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
+++ b/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
@@ -28,6 +28,7 @@ import (
 	dockerclient "github.com/aws/amazon-ecs-agent/agent/dockerclient"
 	dockerapi "github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	types "github.com/docker/docker/api/types"
+	container0 "github.com/docker/docker/api/types/container"
 	filters "github.com/docker/docker/api/types/filters"
 	go_dockerclient "github.com/fsouza/go-dockerclient"
 	gomock "github.com/golang/mock/gomock"
@@ -83,7 +84,7 @@ func (mr *MockDockerClientMockRecorder) ContainerEvents(arg0 interface{}) *gomoc
 }
 
 // CreateContainer mocks base method
-func (m *MockDockerClient) CreateContainer(arg0 context.Context, arg1 *go_dockerclient.Config, arg2 *go_dockerclient.HostConfig, arg3 string, arg4 time.Duration) dockerapi.DockerContainerMetadata {
+func (m *MockDockerClient) CreateContainer(arg0 context.Context, arg1 *container0.Config, arg2 *container0.HostConfig, arg3 string, arg4 time.Duration) dockerapi.DockerContainerMetadata {
 	ret := m.ctrl.Call(m, "CreateContainer", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(dockerapi.DockerContainerMetadata)
 	return ret0
@@ -120,9 +121,9 @@ func (mr *MockDockerClientMockRecorder) DescribeContainer(arg0, arg1 interface{}
 }
 
 // InspectContainer mocks base method
-func (m *MockDockerClient) InspectContainer(arg0 context.Context, arg1 string, arg2 time.Duration) (*go_dockerclient.Container, error) {
+func (m *MockDockerClient) InspectContainer(arg0 context.Context, arg1 string, arg2 time.Duration) (*types.ContainerJSON, error) {
 	ret := m.ctrl.Call(m, "InspectContainer", arg0, arg1, arg2)
-	ret0, _ := ret[0].(*go_dockerclient.Container)
+	ret0, _ := ret[0].(*types.ContainerJSON)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/agent/dockerclient/dockerapi/types.go
+++ b/agent/dockerclient/dockerapi/types.go
@@ -61,7 +61,7 @@ type DockerContainerMetadata struct {
 	// is unable to perform any of the required container transitions
 	Error apierrors.NamedError
 	// Volumes contains volume informaton for the container
-	Volumes []docker.Mount
+	Volumes []types.MountPoint
 	// Labels contains labels set for the container
 	Labels map[string]string
 	// CreatedAt is the timestamp of container creation

--- a/agent/engine/common_test.go
+++ b/agent/engine/common_test.go
@@ -35,7 +35,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/engine/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/statechange"
 	"github.com/aws/amazon-ecs-agent/agent/utils/ttime/mocks"
-	docker "github.com/fsouza/go-dockerclient"
+	dockercontainer "github.com/docker/docker/api/types/container"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 )
@@ -158,7 +158,7 @@ func validateContainerRunWorkflow(t *testing.T,
 	dockerConfig.Labels["com.amazonaws.ecs.task-definition-version"] = task.Version
 	dockerConfig.Labels["com.amazonaws.ecs.cluster"] = ""
 	client.EXPECT().CreateContainer(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(
-		func(ctx interface{}, config *docker.Config, y interface{}, containerName string, z time.Duration) {
+		func(ctx interface{}, config *dockercontainer.Config, y interface{}, containerName string, z time.Duration) {
 			assert.True(t, reflect.DeepEqual(dockerConfig, config),
 				"Mismatch in container config; expected: %v, got: %v", dockerConfig, config)
 			// sleep5 task contains only one container. Just assign

--- a/agent/engine/docker_task_engine_linux_test.go
+++ b/agent/engine/docker_task_engine_linux_test.go
@@ -40,10 +40,10 @@ import (
 	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
 	"github.com/aws/amazon-ecs-agent/agent/utils/ioutilwrapper/mocks"
 	"github.com/aws/aws-sdk-go/aws"
-	docker "github.com/fsouza/go-dockerclient"
 	"github.com/golang/mock/gomock"
-	specs "github.com/opencontainers/runtime-spec/specs-go"
 
+	dockercontainer "github.com/docker/docker/api/types/container"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -99,7 +99,7 @@ func TestResourceContainerProgression(t *testing.T) {
 		imageManager.EXPECT().GetImageStateFromImageName(sleepContainer.Image).Return(nil, false),
 		client.EXPECT().APIVersion().Return(defaultDockerClientAPIVersion, nil),
 		client.EXPECT().CreateContainer(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(
-			func(ctx interface{}, config *docker.Config, hostConfig *docker.HostConfig, containerName string, z time.Duration) {
+			func(ctx interface{}, config *dockercontainer.Config, hostConfig *dockercontainer.HostConfig, containerName string, z time.Duration) {
 				assert.True(t, strings.Contains(containerName, sleepContainer.Name))
 				containerEventsWG.Add(1)
 				go func() {

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -59,6 +59,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	"github.com/containernetworking/cni/pkg/types/current"
+	"github.com/docker/docker/api/types"
+	dockercontainer "github.com/docker/docker/api/types/container"
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/golang/mock/gomock"
 	"github.com/pborman/uuid"
@@ -322,7 +324,7 @@ func TestTaskWithSteadyStateResourcesProvisioned(t *testing.T) {
 		// Ensure that the pause container is created first
 		client.EXPECT().APIVersion().Return(defaultDockerClientAPIVersion, nil),
 		client.EXPECT().CreateContainer(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(
-			func(ctx interface{}, config *docker.Config, hostConfig *docker.HostConfig, containerName string, z time.Duration) {
+			func(ctx interface{}, config *dockercontainer.Config, hostConfig *dockercontainer.HostConfig, containerName string, z time.Duration) {
 				sleepTask.SetTaskENI(&apieni.ENI{
 					ID: "TestTaskWithSteadyStateResourcesProvisioned",
 					IPV4Addresses: []*apieni.ENIIPV4Address{
@@ -338,7 +340,7 @@ func TestTaskWithSteadyStateResourcesProvisioned(t *testing.T) {
 						},
 					},
 				})
-				assert.Equal(t, "none", hostConfig.NetworkMode)
+				assert.Equal(t, "none", string(hostConfig.NetworkMode))
 				assert.True(t, strings.Contains(containerName, pauseContainer.Name))
 				containerEventsWG.Add(1)
 				go func() {
@@ -355,9 +357,11 @@ func TestTaskWithSteadyStateResourcesProvisioned(t *testing.T) {
 					containerEventsWG.Done()
 				}()
 			}).Return(dockerapi.DockerContainerMetadata{DockerID: containerID + ":" + pauseContainer.Name}),
-		client.EXPECT().InspectContainer(gomock.Any(), gomock.Any(), gomock.Any()).Return(&docker.Container{
-			ID:    containerID,
-			State: docker.State{Pid: 23},
+		client.EXPECT().InspectContainer(gomock.Any(), gomock.Any(), gomock.Any()).Return(&types.ContainerJSON{
+			ContainerJSONBase: &types.ContainerJSONBase{
+				ID:    containerID,
+				State: &types.ContainerState{Pid: 23},
+			},
 		}, nil),
 		// Then setting up the pause container network namespace
 		mockCNIClient.EXPECT().SetupNS(gomock.Any(), gomock.Any(), gomock.Any()).Return(nsResult, nil),
@@ -365,9 +369,9 @@ func TestTaskWithSteadyStateResourcesProvisioned(t *testing.T) {
 		// Once the pause container is started, sleep container will be created
 		client.EXPECT().APIVersion().Return(defaultDockerClientAPIVersion, nil),
 		client.EXPECT().CreateContainer(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(
-			func(ctx interface{}, config *docker.Config, hostConfig *docker.HostConfig, containerName string, z time.Duration) {
+			func(ctx interface{}, config *dockercontainer.Config, hostConfig *dockercontainer.HostConfig, containerName string, z time.Duration) {
 				assert.True(t, strings.Contains(containerName, sleepContainer.Name))
-				assert.Equal(t, "container:"+containerID+":"+pauseContainer.Name, hostConfig.NetworkMode)
+				assert.Equal(t, "container:"+containerID+":"+pauseContainer.Name, string(hostConfig.NetworkMode))
 				containerEventsWG.Add(1)
 				go func() {
 					eventStream <- createDockerEvent(apicontainerstatus.ContainerCreated)
@@ -391,10 +395,13 @@ func TestTaskWithSteadyStateResourcesProvisioned(t *testing.T) {
 	assert.Equal(t, sleepTask.Arn, taskARNByIP)
 	cleanup := make(chan time.Time, 1)
 	mockTime.EXPECT().After(gomock.Any()).Return(cleanup).AnyTimes()
-	client.EXPECT().InspectContainer(gomock.Any(), gomock.Any(), gomock.Any()).Return(&docker.Container{
-		ID:    containerID,
-		State: docker.State{Pid: 23},
-	}, nil)
+	client.EXPECT().InspectContainer(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		&types.ContainerJSON{
+			ContainerJSONBase: &types.ContainerJSONBase{
+				ID:    containerID,
+				State: &types.ContainerState{Pid: 23},
+			},
+		}, nil)
 	mockCNIClient.EXPECT().CleanupNS(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 	client.EXPECT().StopContainer(gomock.Any(), containerID+":"+pauseContainer.Name, gomock.Any()).MinTimes(1)
 	mockCNIClient.EXPECT().ReleaseIPResource(gomock.Any()).Return(nil).MaxTimes(1)
@@ -1062,7 +1069,7 @@ func TestPauseContainerHappyPath(t *testing.T) {
 		dockerClient.EXPECT().APIVersion().Return(defaultDockerClientAPIVersion, nil),
 		dockerClient.EXPECT().CreateContainer(
 			gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(
-			func(ctx interface{}, config *docker.Config, x, y, z interface{}) {
+			func(ctx interface{}, config *dockercontainer.Config, x, y, z interface{}) {
 				name, ok := config.Labels[labelPrefix+"container-name"]
 				assert.True(t, ok)
 				assert.Equal(t, apitask.PauseContainerName, name)
@@ -1070,9 +1077,11 @@ func TestPauseContainerHappyPath(t *testing.T) {
 		dockerClient.EXPECT().StartContainer(gomock.Any(), pauseContainerID, defaultConfig.ContainerStartTimeout).Return(
 			dockerapi.DockerContainerMetadata{DockerID: "pauseContainerID"}),
 		dockerClient.EXPECT().InspectContainer(gomock.Any(), gomock.Any(), gomock.Any()).Return(
-			&docker.Container{
-				ID:    pauseContainerID,
-				State: docker.State{Pid: containerPid},
+			&types.ContainerJSON{
+				ContainerJSONBase: &types.ContainerJSONBase{
+					ID:    pauseContainerID,
+					State: &types.ContainerState{Pid: containerPid},
+				},
 			}, nil),
 		cniClient.EXPECT().SetupNS(gomock.Any(), gomock.Any(), gomock.Any()).Return(nsResult, nil),
 	)
@@ -1104,9 +1113,11 @@ func TestPauseContainerHappyPath(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	mockTime.EXPECT().After(gomock.Any()).Return(cleanup).MinTimes(1)
-	dockerClient.EXPECT().InspectContainer(gomock.Any(), gomock.Any(), gomock.Any()).Return(&docker.Container{
-		ID:    pauseContainerID,
-		State: docker.State{Pid: containerPid},
+	dockerClient.EXPECT().InspectContainer(gomock.Any(), gomock.Any(), gomock.Any()).Return(&types.ContainerJSON{
+		ContainerJSONBase: &types.ContainerJSONBase{
+			ID:    pauseContainerID,
+			State: &types.ContainerState{Pid: containerPid},
+		},
 	}, nil)
 	cniClient.EXPECT().CleanupNS(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 	dockerClient.EXPECT().StopContainer(gomock.Any(), pauseContainerID, gomock.Any()).Return(
@@ -1175,9 +1186,11 @@ func TestBuildCNIConfigFromTaskContainer(t *testing.T) {
 				DockerName: dockerContainerName,
 			}, testTask)
 
-			dockerClient.EXPECT().InspectContainer(gomock.Any(), dockerContainerName, gomock.Any()).Return(&docker.Container{
-				ID:    containerID,
-				State: docker.State{Pid: containerPid},
+			dockerClient.EXPECT().InspectContainer(gomock.Any(), dockerContainerName, gomock.Any()).Return(&types.ContainerJSON{
+				ContainerJSONBase: &types.ContainerJSONBase{
+					ID:    containerID,
+					State: &types.ContainerState{Pid: containerPid},
+				},
 			}, nil)
 
 			cniConfig, err := taskEngine.(*DockerTaskEngine).buildCNIConfigFromTaskContainer(testTask, container)
@@ -1254,9 +1267,11 @@ func TestStopPauseContainerCleanupCalled(t *testing.T) {
 	}, testTask)
 
 	gomock.InOrder(
-		dockerClient.EXPECT().InspectContainer(gomock.Any(), dockerContainerName, gomock.Any()).Return(&docker.Container{
-			ID:    containerID,
-			State: docker.State{Pid: containerPid},
+		dockerClient.EXPECT().InspectContainer(gomock.Any(), dockerContainerName, gomock.Any()).Return(&types.ContainerJSON{
+			ContainerJSONBase: &types.ContainerJSONBase{
+				ID:    containerID,
+				State: &types.ContainerState{Pid: containerPid},
+			},
 		}, nil),
 		mockCNIClient.EXPECT().CleanupNS(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil),
 		dockerClient.EXPECT().StopContainer(gomock.Any(),
@@ -2049,12 +2064,17 @@ func TestContainerMetadataUpdatedOnRestart(t *testing.T) {
 						Volume: &taskresourcevolume.LocalDockerVolume{},
 					},
 				}
-				client.EXPECT().InspectContainer(gomock.Any(), dockerContainer.DockerName, gomock.Any()).Return(&docker.Container{
-					ID: dockerID,
-					Config: &docker.Config{
+				client.EXPECT().InspectContainer(gomock.Any(), dockerContainer.DockerName, gomock.Any()).Return(&types.ContainerJSON{
+					ContainerJSONBase: &types.ContainerJSONBase{
+						ID:      dockerID,
+						Created: (tc.created).Format(time.RFC3339),
+						State: &types.ContainerState{
+							Health: &types.Health{},
+						},
+					},
+					Config: &dockercontainer.Config{
 						Labels: labels,
 					},
-					Created: tc.created,
 				}, nil)
 				imageManager.EXPECT().RecordContainerReference(dockerContainer.Container).AnyTimes()
 			} else {
@@ -2073,9 +2093,9 @@ func TestContainerMetadataUpdatedOnRestart(t *testing.T) {
 
 			taskEngine.(*DockerTaskEngine).synchronizeContainerStatus(dockerContainer, task)
 			assert.Equal(t, labels, dockerContainer.Container.GetLabels())
-			assert.Equal(t, tc.created, dockerContainer.Container.GetCreatedAt())
-			assert.Equal(t, tc.started, dockerContainer.Container.GetStartedAt())
-			assert.Equal(t, tc.finished, dockerContainer.Container.GetFinishedAt())
+			assert.Equal(t, (tc.created).Format(time.RFC3339), (dockerContainer.Container.GetCreatedAt()).Format(time.RFC3339))
+			assert.Equal(t, (tc.started).Format(time.RFC3339), (dockerContainer.Container.GetStartedAt()).Format(time.RFC3339))
+			assert.Equal(t, (tc.finished).Format(time.RFC3339), (dockerContainer.Container.GetFinishedAt()).Format(time.RFC3339))
 			if tc.stage == "started" {
 				assert.Equal(t, uint16(80), dockerContainer.Container.KnownPortBindingsUnsafe[0].ContainerPort)
 			}

--- a/agent/engine/engine_integ_test.go
+++ b/agent/engine/engine_integ_test.go
@@ -34,10 +34,9 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	taskresourcevolume "github.com/aws/amazon-ecs-agent/agent/taskresource/volume"
-	docker "github.com/fsouza/go-dockerclient"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	sdk "github.com/docker/docker/client"
+	sdkClient "github.com/docker/docker/client"
 	"github.com/docker/docker/api/types"
 )
 
@@ -93,7 +92,7 @@ func dialWithRetries(proto string, address string, tries int, timeout time.Durat
 }
 
 func removeImage(t *testing.T, img string) {
-	client, err := sdk.NewClientWithOpts(sdk.WithHost(endpoint))
+	client, err := sdkClient.NewClientWithOpts(sdkClient.WithHost(endpoint))
 	require.NoError(t, err, "create docker client failed")
 	client.ImageRemove(context.TODO(), img, types.ImageRemoveOptions{})
 }
@@ -104,10 +103,13 @@ func TestDockerStateToContainerState(t *testing.T) {
 	taskEngine, done, _ := setupWithDefaultConfig(t)
 	defer done()
 
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
 	testTask := createTestTask("test_task")
 	container := testTask.Containers[0]
 
-	client, err := docker.NewClientFromEnv()
+	client, err := sdkClient.NewClientWithOpts(sdkClient.WithHost(endpoint))
 	require.NoError(t, err, "Creating go docker client failed")
 
 	containerMetadata := taskEngine.(*DockerTaskEngine).pullContainer(testTask, container)
@@ -115,18 +117,18 @@ func TestDockerStateToContainerState(t *testing.T) {
 
 	containerMetadata = taskEngine.(*DockerTaskEngine).createContainer(testTask, container)
 	assert.NoError(t, containerMetadata.Error)
-	state, _ := client.InspectContainer(containerMetadata.DockerID)
-	assert.Equal(t, apicontainerstatus.ContainerCreated, dockerapi.DockerStateToState(state.State))
+	state, _ := client.ContainerInspect(ctx, containerMetadata.DockerID)
+	assert.Equal(t, apicontainerstatus.ContainerCreated, dockerapi.DockerStateToState(state.ContainerJSONBase.State))
 
 	containerMetadata = taskEngine.(*DockerTaskEngine).startContainer(testTask, container)
 	assert.NoError(t, containerMetadata.Error)
-	state, _ = client.InspectContainer(containerMetadata.DockerID)
-	assert.Equal(t, apicontainerstatus.ContainerRunning, dockerapi.DockerStateToState(state.State))
+	state, _ = client.ContainerInspect(ctx, containerMetadata.DockerID)
+	assert.Equal(t, apicontainerstatus.ContainerRunning, dockerapi.DockerStateToState(state.ContainerJSONBase.State))
 
 	containerMetadata = taskEngine.(*DockerTaskEngine).stopContainer(testTask, container)
 	assert.NoError(t, containerMetadata.Error)
-	state, _ = client.InspectContainer(containerMetadata.DockerID)
-	assert.Equal(t, apicontainerstatus.ContainerStopped, dockerapi.DockerStateToState(state.State))
+	state, _ = client.ContainerInspect(ctx, containerMetadata.DockerID)
+	assert.Equal(t, apicontainerstatus.ContainerStopped, dockerapi.DockerStateToState(state.ContainerJSONBase.State))
 
 	// clean up the container
 	err = taskEngine.(*DockerTaskEngine).removeContainer(testTask, container)
@@ -140,8 +142,8 @@ func TestDockerStateToContainerState(t *testing.T) {
 	assert.NoError(t, containerMetadata.Error)
 	containerMetadata = taskEngine.(*DockerTaskEngine).startContainer(testTask, container)
 	assert.Error(t, containerMetadata.Error)
-	state, _ = client.InspectContainer(containerMetadata.DockerID)
-	assert.Equal(t, apicontainerstatus.ContainerStopped, dockerapi.DockerStateToState(state.State))
+	state, _ = client.ContainerInspect(ctx, containerMetadata.DockerID)
+	assert.Equal(t, apicontainerstatus.ContainerStopped, dockerapi.DockerStateToState(state.ContainerJSONBase.State))
 
 	// clean up the container
 	err = taskEngine.(*DockerTaskEngine).removeContainer(testTask, container)

--- a/agent/engine/engine_unix_integ_test.go
+++ b/agent/engine/engine_unix_integ_test.go
@@ -43,7 +43,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/utils/ttime"
 
 	"github.com/aws/aws-sdk-go/aws"
-	sdk "github.com/docker/docker/client"
+	sdkClient "github.com/docker/docker/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -196,7 +196,7 @@ func TestPortForward(t *testing.T) {
 	// Kill the existing container now to make the test run more quickly.
 	containerMap, _ := taskEngine.(*DockerTaskEngine).state.ContainerMapByArn(testTask.Arn)
 	cid := containerMap[testTask.Containers[0].Name].DockerID
-	client, _ := sdk.NewClientWithOpts(sdk.WithHost(endpoint))
+	client, _ := sdkClient.NewClientWithOpts(sdkClient.WithHost(endpoint))
 	err = client.ContainerKill(context.TODO(), cid, "SIGKILL")
 	assert.NoError(t, err, "Could not kill container", err)
 
@@ -728,7 +728,7 @@ func TestSignalEvent(t *testing.T) {
 	// Signal the container now
 	containerMap, _ := taskEngine.(*DockerTaskEngine).state.ContainerMapByArn(testTask.Arn)
 	cid := containerMap[testTask.Containers[0].Name].DockerID
-	client, _ := sdk.NewClientWithOpts(sdk.WithHost(endpoint))
+	client, _ := sdkClient.NewClientWithOpts(sdkClient.WithHost(endpoint))
 	err := client.ContainerKill(context.TODO(), cid, "SIGUSR1")
 	assert.NoError(t, err, "Could not signal container", err)
 

--- a/agent/engine/engine_windows_integ_test.go
+++ b/agent/engine/engine_windows_integ_test.go
@@ -16,6 +16,7 @@
 package engine
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -35,7 +36,7 @@ import (
 	taskresourcevolume "github.com/aws/amazon-ecs-agent/agent/taskresource/volume"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 	"github.com/aws/aws-sdk-go/aws"
-	docker "github.com/fsouza/go-dockerclient"
+	sdkClient "github.com/docker/docker/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -157,8 +158,8 @@ func createVolumeTask(scope, arn, volume string, autoprovision bool) (*apitask.T
 // TODO Modify the container ip to localhost after the AMI has the required feature
 // https://github.com/docker/for-win/issues/204#issuecomment-352899657
 
-func getContainerIP(client *docker.Client, id string) (string, error) {
-	dockerContainer, err := client.InspectContainer(id)
+func getContainerIP(client *sdkClient.Client, id string) (string, error) {
+	dockerContainer, err := client.ContainerInspect(context.TODO(), id)
 	if err != nil {
 		return "", err
 	}
@@ -261,7 +262,7 @@ func TestPortForward(t *testing.T) {
 	defer done()
 
 	stateChangeEvents := taskEngine.StateChangeEvents()
-	client, _ := docker.NewClient(endpoint)
+	client, _ := sdkClient.NewClientWithOpts(sdkClient.WithHost(endpoint))
 
 	testArn := "testPortForwardFail"
 	testTask := createTestTask(testArn)
@@ -283,8 +284,11 @@ func TestPortForward(t *testing.T) {
 	_, err = net.DialTimeout("tcp", fmt.Sprintf("%s:%d", cip, containerPortOne), dialTimeout)
 	assert.Error(t, err, "Did not expect to be able to dial port %d but didn't get error", containerPortOne)
 
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
 	// Kill the existing container now to make the test run more quickly.
-	err = client.KillContainer(docker.KillContainerOptions{ID: cid})
+	err = client.ContainerKill(ctx, cid, "SIGKILL")
 	assert.NoError(t, err, "Could not kill container")
 
 	verifyTaskIsStopped(stateChangeEvents, testTask)
@@ -339,7 +343,7 @@ func TestMultiplePortForwards(t *testing.T) {
 	defer done()
 
 	stateChangeEvents := taskEngine.StateChangeEvents()
-	client, _ := docker.NewClient(endpoint)
+	client, _ := sdkClient.NewClientWithOpts(sdkClient.WithHost(endpoint))
 
 	// Forward it and make sure that works
 	testArn := "testMultiplePortForwards"
@@ -424,7 +428,7 @@ func TestDynamicPortForward(t *testing.T) {
 	}
 	assert.NotEqual(t, bindingFor24751, 0, "could not find the port mapping for %d", containerPortOne)
 
-	client, _ := docker.NewClient(endpoint)
+	client, _ := sdkClient.NewClientWithOpts(sdkClient.WithHost(endpoint))
 	containerMap, _ := taskEngine.(*DockerTaskEngine).state.ContainerMapByArn(testTask.Arn)
 	cid := containerMap[testTask.Containers[0].Name].DockerID
 	cip, err := getContainerIP(client, cid)
@@ -487,7 +491,7 @@ func TestMultipleDynamicPortForward(t *testing.T) {
 	assert.NotZero(t, bindingFor24751_1, "could not find the port mapping for ", containerPortOne)
 	assert.NotZero(t, bindingFor24751_2, "could not find the port mapping for ", containerPortOne)
 
-	client, _ := docker.NewClient(endpoint)
+	client, _ := sdkClient.NewClientWithOpts(sdkClient.WithHost(endpoint))
 	containerMap, _ := taskEngine.(*DockerTaskEngine).state.ContainerMapByArn(testTask.Arn)
 	cid := containerMap[testTask.Containers[0].Name].DockerID
 	cip, err := getContainerIP(client, cid)

--- a/agent/functional_tests/tests/functionaltests_test.go
+++ b/agent/functional_tests/tests/functionaltests_test.go
@@ -27,7 +27,6 @@ import (
 
 	ecsapi "github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
 	. "github.com/aws/amazon-ecs-agent/agent/functional_tests/util"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"

--- a/agent/stats/common_test.go
+++ b/agent/stats/common_test.go
@@ -29,7 +29,9 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/tcs/model/ecstcs"
 
 	"github.com/aws/aws-sdk-go/aws"
-	docker "github.com/fsouza/go-dockerclient"
+	dockercontainer "github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
+	sdkClient "github.com/docker/docker/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -72,24 +74,28 @@ func eventStream(name string) *eventstream.EventStream {
 
 // createGremlin creates the gremlin container using the docker client.
 // It is used only in the test code.
-func createGremlin(client *docker.Client) (*docker.Container, error) {
-	container, err := client.CreateContainer(docker.CreateContainerOptions{
-		Config: &docker.Config{
+func createGremlin(client *sdkClient.Client) (*dockercontainer.ContainerCreateCreatedBody, error) {
+	containerGremlin, err := client.ContainerCreate(context.TODO(),
+		&dockercontainer.Config{
 			Image: testImageName,
 		},
-	})
+		&dockercontainer.HostConfig{},
+		&network.NetworkingConfig{},
+		"")
 
-	return container, err
+	return &containerGremlin, err
 }
 
-func createHealthContainer(client *docker.Client) (*docker.Container, error) {
-	container, err := client.CreateContainer(docker.CreateContainerOptions{
-		Config: &docker.Config{
+func createHealthContainer(client *sdkClient.Client) (*dockercontainer.ContainerCreateCreatedBody, error) {
+	container, err := client.ContainerCreate(context.TODO(),
+		&dockercontainer.Config{
 			Image: testContainerHealthImageName,
 		},
-	})
+		&dockercontainer.HostConfig{},
+		&network.NetworkingConfig{},
+		"")
 
-	return container, err
+	return &container, err
 }
 
 type IntegContainerMetadataResolver struct {

--- a/agent/stats/common_unix_test.go
+++ b/agent/stats/common_unix_test.go
@@ -25,14 +25,12 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 
 	sdkClient "github.com/docker/docker/client"
-	docker "github.com/fsouza/go-dockerclient"
 )
 
 var (
 	testImageName    = "amazon/amazon-ecs-gremlin:make"
 	endpoint         = utils.DefaultIfBlank(os.Getenv(ecsengine.DockerEndpointEnvVariable), ecsengine.DockerDefaultEndpoint)
-	client, _        = docker.NewClient(endpoint)
-	sdkclient, _     = sdkClient.NewClientWithOpts(sdkClient.WithHost(endpoint))
+	client, _        = sdkClient.NewClientWithOpts(sdkClient.WithHost(endpoint))
 	clientFactory    = clientfactory.NewFactory(context.TODO(), endpoint)
 	sdkClientFactory = sdkclientfactory.NewFactory(context.TODO(), endpoint)
 	ctx              = context.TODO()

--- a/agent/stats/common_windows_test.go
+++ b/agent/stats/common_windows_test.go
@@ -25,14 +25,12 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 
 	sdkClient "github.com/docker/docker/client"
-	docker "github.com/fsouza/go-dockerclient"
 )
 
 var (
 	testImageName    = "amazon/amazon-ecs-stats:make"
 	endpoint         = utils.DefaultIfBlank(os.Getenv(ecsengine.DockerEndpointEnvVariable), "npipe:////./pipe/docker_engine")
-	client, _        = docker.NewClient(endpoint)
-	sdkclient, _     = sdkClient.NewClientWithOpts(sdkClient.WithHost(endpoint))
+	client, _        = sdkClient.NewClientWithOpts(sdkClient.WithHost(endpoint))
 	clientFactory    = clientfactory.NewFactory(context.TODO(), endpoint)
 	sdkClientFactory = sdkclientfactory.NewFactory(context.TODO(), endpoint)
 	ctx              = context.TODO()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->
### Summary
<!-- What does this pull request do? -->
Migrated ContainerCreate, ContainerInspect, HostConfig, and Config to Docker SDK
Continuation of https://github.com/aws/amazon-ecs-agent/pull/1530 that was accidentally closed.
### Implementation details
<!-- How are the changes implemented? -->
This PR is comprised of 3 commits
**agent: Migrated HostConfig and Config to Docker SDK**
  - Replaced go-dockerclient HostConfig and Config with Docker SDK HostConfig and Config
  - Replaced with Find/Replace to move quickly. Refactoring of this step is done in "agent migration refactoring" commit.

**dockerapi: Migrated ContainerCreate and ContainerInspect to Docker SDK**
  - migrated these two API calls to Docker SDK
  - Required more effort as function headers for these had to be changed in DockerClient interface to remove reliance on go-dockerclient Container type

**agent: Migration refactoring**
  - Meat of PR is this commit. Contains refactoring required from migration of types and changes needed out side the dockerclient package.


- There are quite a few times where I use time.Parse, or time.Format() to test whether the time in the ContainerJSON is correct. ContainerJSON stores the StartedAt and FinishedAt fields as strings, whereas go-dockerclient stored them as time.Times. Parse and Format are not inverses, so comparisons require both the time.Time and string variables to be converted.


Link to branch: https://github.com/kavoor/amazon-ecs-agent/tree/moby
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enhancement - Migrated HostConfig and Config to the Docker SDK
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.