### PR TITLE
Removing get-deps target for codebuild

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -228,7 +228,7 @@ run-sudo-tests:
 	. ./scripts/shared_env && sudo -E ${GO_EXECUTABLE} test -race -tags sudo -timeout=1m -v ./agent/engine/...
 
 .PHONY: codebuild
-codebuild: get-deps test-artifacts .out-stamp
+codebuild: test-artifacts .out-stamp
 	$(MAKE) release TARGET_OS="linux"
 	TARGET_OS="linux" ./scripts/local-save
 	$(MAKE) docker-release TARGET_OS="windows"


### PR DESCRIPTION
The codebuild target doesn't require get-deps, and it will break
execution when it tries to fetch the dependencies.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
