### PR TITLE
[WIP] Add credential spec support to agent

### DIFF
--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -816,7 +816,7 @@ func (task *Task) dockerHostConfig(container *apicontainer.Container, dockerCont
 		}
 	}
 
-	err = task.platformHostConfigOverride(hostConfig)
+	err = task.platformHostConfigOverride(container, hostConfig)
 	if err != nil {
 		return nil, &apierrors.HostConfigError{err.Error()}
 	}

--- a/agent/api/task/task_linux.go
+++ b/agent/api/task/task_linux.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 	"time"
 
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
@@ -201,7 +202,7 @@ func (task *Task) buildLinuxMemorySpec() (specs.LinuxMemory, error) {
 }
 
 // platformHostConfigOverride to override platform specific feature sets
-func (task *Task) platformHostConfigOverride(hostConfig *docker.HostConfig) error {
+func (task *Task) platformHostConfigOverride(container *apicontainer.Container, hostConfig *docker.HostConfig) error {
 	// Override cgroup parent
 	return task.overrideCgroupParent(hostConfig)
 }

--- a/agent/api/task/task_linux_test.go
+++ b/agent/api/task/task_linux_test.go
@@ -272,7 +272,7 @@ func TestPlatformHostConfigOverride(t *testing.T) {
 
 	hostConfig := &docker.HostConfig{}
 
-	assert.NoError(t, task.platformHostConfigOverride(hostConfig))
+	assert.NoError(t, task.platformHostConfigOverride(nil, hostConfig))
 	assert.NotEmpty(t, hostConfig)
 	assert.Equal(t, expectedCgroupRoot, hostConfig.CgroupParent)
 }

--- a/agent/api/task/task_unsupported.go
+++ b/agent/api/task/task_unsupported.go
@@ -18,6 +18,7 @@ package task
 import (
 	"time"
 
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	"github.com/cihub/seelog"
@@ -66,7 +67,7 @@ func (task *Task) initializeCgroupResourceSpec(cgroupPath string, resourceFields
 	return nil
 }
 
-func (task *Task) platformHostConfigOverride(hostConfig *docker.HostConfig) error {
+func (task *Task) platformHostConfigOverride(container *apicontainer.Container, hostConfig *docker.HostConfig) error {
 	return nil
 }
 

--- a/agent/api/task/task_windows.go
+++ b/agent/api/task/task_windows.go
@@ -106,7 +106,7 @@ func (task *Task) handleSecurityOpts(container *apicontainer.Container, hostConf
 			hostConfig.SecurityOpt[i] = "credentialspec=file://" + name
 			// Create the directory if needed
 			credentialspecFolderPath := filepath.Join(os.Getenv("ProgramData"), "Docker", "credentialspecs")
-			dir, err := os.MkdirAll(credentialspecFolderPath)
+			err := os.MkdirAll(credentialspecFolderPath, os.ModeDir)
 			if err != nil {
 				return err
 			}

--- a/agent/api/task/task_windows.go
+++ b/agent/api/task/task_windows.go
@@ -39,8 +39,7 @@ const (
 	percentageFactor  = 100
 	minimumCPUPercent = 1
 
-	ecsDataFileRootKey = registry.LOCAL_MACHINE
-	ecsDataFileKeyPath = `SOFTWARE\Amazon\ECS Agent\State File`
+	credentialspecFolderPath := filepath.Join(os.Getenv("ProgramData"), "Docker", "credentialspecs")
 )
 
 // platformFields consists of fields specific to Windows for a task
@@ -108,10 +107,13 @@ func (task *Task) handleSecurityOpts(container *apicontainer.Container, hostConf
 			contents := strings.TrimPrefix(opt, "credentialspec=")
 			// Overwrite the hostConfig with the name of the file where it's stored
 			hostConfig.SecurityOpt[i] = "credentialspec=file://" + name
+			// Create the directory if needed
+			dir, err := os.MkdirAll(credentialspecFolderPath)
+			if err != nil {
+				return err
+			}
 			// Create the file
-			path := filepath.Join(os.Getenv("ProgramData"), "Docker", "credentialspecs", name)
-			f, err := os.Create(path)
-			// TODO better error handling?
+			f, err := os.Create(filepath.Join(credentialspecFolderPath, name))
 			if err != nil {
 				return err
 			}

--- a/agent/api/task/task_windows.go
+++ b/agent/api/task/task_windows.go
@@ -28,7 +28,6 @@ import (
 	taskresourcevolume "github.com/aws/amazon-ecs-agent/agent/taskresource/volume"
 	"github.com/cihub/seelog"
 	docker "github.com/fsouza/go-dockerclient"
-	"golang.org/x/sys/windows/registry"
 )
 
 const (
@@ -38,8 +37,6 @@ const (
 	cpuSharesPerCore  = 1024
 	percentageFactor  = 100
 	minimumCPUPercent = 1
-
-	credentialspecFolderPath := filepath.Join(os.Getenv("ProgramData"), "Docker", "credentialspecs")
 )
 
 // platformFields consists of fields specific to Windows for a task
@@ -108,6 +105,7 @@ func (task *Task) handleSecurityOpts(container *apicontainer.Container, hostConf
 			// Overwrite the hostConfig with the name of the file where it's stored
 			hostConfig.SecurityOpt[i] = "credentialspec=file://" + name
 			// Create the directory if needed
+			credentialspecFolderPath := filepath.Join(os.Getenv("ProgramData"), "Docker", "credentialspecs")
 			dir, err := os.MkdirAll(credentialspecFolderPath)
 			if err != nil {
 				return err

--- a/agent/api/task/task_windows_test.go
+++ b/agent/api/task/task_windows_test.go
@@ -18,6 +18,9 @@ package task
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"runtime"
 	"testing"
 
@@ -126,13 +129,13 @@ func TestWindowsPlatformHostConfigOverride(t *testing.T) {
 
 	hostConfig := &docker.HostConfig{CPUShares: int64(1 * cpuSharesPerCore)}
 
-	task.platformHostConfigOverride(hostConfig)
+	task.platformHostConfigOverride(nil, hostConfig)
 	assert.Equal(t, int64(1*cpuSharesPerCore*percentageFactor)/int64(cpuShareScaleFactor), hostConfig.CPUPercent)
 	assert.Equal(t, int64(0), hostConfig.CPUShares)
 	assert.EqualValues(t, expectedMemorySwappinessDefault, hostConfig.MemorySwappiness)
 
 	hostConfig = &docker.HostConfig{CPUShares: 10}
-	task.platformHostConfigOverride(hostConfig)
+	task.platformHostConfigOverride(nil, hostConfig)
 	assert.Equal(t, int64(minimumCPUPercent), hostConfig.CPUPercent)
 	assert.Empty(t, hostConfig.CPUShares)
 }
@@ -306,4 +309,42 @@ func TestCPUPercentBasedOnUnboundedEnabled(t *testing.T) {
 			assert.Equal(t, tc.cpuPercent, hostconfig.CPUPercent)
 		})
 	}
+}
+
+// TestWindowsPlatformHostConfigOverrideCredSpec tests the docker hostconfig was correctly transformed and written
+func TestWindowsPlatformHostConfigOverrideCredSpec(t *testing.T) {
+	// Testing Windows platform override for HostConfig.
+	// Expects MemorySwappiness option to be set to -1
+	// And that the credentialspec was transformed/written to disk
+
+	container := &apicontainer.Container{
+		Name: "c1",
+	}
+	task := &Task{
+		Arn:        "test",
+		Containers: []*apicontainer.Container{container},
+	}
+
+	hostConfig := &docker.HostConfig{
+		SecurityOpt: []string{"credentialspec={\"key\":\"value\"}"},
+		CPUShares:   int64(1 * cpuSharesPerCore),
+	}
+
+	task.platformHostConfigOverride(container, hostConfig)
+	assert.Equal(t, int64(1*cpuSharesPerCore*percentageFactor)/int64(cpuShareScaleFactor), hostConfig.CPUPercent)
+	assert.Equal(t, int64(0), hostConfig.CPUShares)
+	assert.EqualValues(t, []string{"credentialspec=file://test-c1.json"}, hostConfig.SecurityOpt)
+	assert.EqualValues(t, expectedMemorySwappinessDefault, hostConfig.MemorySwappiness)
+
+	hostConfig = &docker.HostConfig{CPUShares: 10}
+	task.platformHostConfigOverride(container, hostConfig)
+	assert.Equal(t, int64(minimumCPUPercent), hostConfig.CPUPercent)
+	assert.Empty(t, hostConfig.CPUShares)
+
+	name := task.Arn + "-" + container.Name + ".json"
+	path := filepath.Join(os.Getenv("ProgramData"), "Docker", "credentialspecs", name)
+	dat, err := ioutil.ReadFile(path)
+	assert.Nil(t, err)
+	assert.EqualValues(t, "{\"key\":\"value\"}", string(dat))
+	os.Remove(path)
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This pull request adds support for credentialspec files, addressing feature request #1540

### Implementation details
<!-- How are the changes implemented? -->
When a task definition defines a container with dockerSecurityOptions containing an entry of "credentialspec=somejsonblob", the amazon ecs agent writes that blob to {env:ProgramData}/Docker/credentialspecs/taskarn-containername.json, and replaces the entry with "credentialspec=file://taskarn-containername.json" so that Docker can consume the blob. This is necessary since at current, Docker only supports reading credentialspec files from the credentialspecs folder or from a particular registry key. 
Notes:
* task definition validation does not currently allow credentialspec to be specified as a dockerSecurityOption, so that will need to be tweaked before this is useful.
* The host must be domain joined and have the desired gMSAs installed, which this PR does not seek to address.

Work remaining: 
* Additional integration test
* Additional functional test
* Cleanup credentialspecs when task is done? (should be <10KB per file, but still)

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [ ] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [ ] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no --> in progress (unit tests only)

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
* Feature - Add credentialspec support for Windows containers
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
