### PR TITLE
Logs image pull completed once after checking for errors

### DIFF
--- a/agent/dockerclient/dockerapi/docker_client.go
+++ b/agent/dockerclient/dockerapi/docker_client.go
@@ -360,7 +360,6 @@ func (dg *dockerGoClient) pullImage(image string, authData *apicontainer.Registr
 	pullFinished := make(chan error, 1)
 	go func() {
 		pullFinished <- client.PullImage(opts, authConfig)
-		seelog.Debugf("DockerGoClient: pulling image complete: %s", image)
 	}()
 
 	select {
@@ -370,17 +369,19 @@ func (dg *dockerGoClient) pullImage(image string, authData *apicontainer.Registr
 		if pullErr != nil {
 			return CannotPullContainerError{pullErr}
 		}
+		seelog.Debugf("DockerGoClient: pulling image complete: %s", image)
 		return nil
 	case <-timeout:
 		return &DockerTimeoutError{dockerPullBeginTimeout, "pullBegin"}
 	}
 	seelog.Debugf("DockerGoClient: pull began for image: %s", image)
-	defer seelog.Debugf("DockerGoClient: pull completed for image: %s", image)
 
 	err = <-pullFinished
 	if err != nil {
 		return CannotPullContainerError{err}
 	}
+
+	seelog.Debugf("DockerGoClient: pulling image complete: %s", image)
 	return nil
 }
 


### PR DESCRIPTION
### Summary
<!-- What does this pull request do? -->
Removes a duplicate log entry for successful pull image completion to avoid having two log lines that say roughly "pull image completed" for the same pull.

Moves the log entry for a successful pull after we check for errors in
the pull to avoid having a log say "pull image completed" when the pull errors.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
