### PR TITLE
Functional tests for sysctl,interactive,tty Docker fields

### DIFF
--- a/agent/ecs_client/model/api/api-2.json
+++ b/agent/ecs_client/model/api/api-2.json
@@ -701,10 +701,13 @@
         "dnsSearchDomains":{"shape":"StringList"},
         "extraHosts":{"shape":"HostEntryList"},
         "dockerSecurityOptions":{"shape":"StringList"},
+        "interactive":{"shape":"BoxedBoolean"},
+        "pseudoTerminal":{"shape":"BoxedBoolean"},
         "dockerLabels":{"shape":"DockerLabelsMap"},
         "ulimits":{"shape":"UlimitList"},
         "logConfiguration":{"shape":"LogConfiguration"},
-        "healthCheck":{"shape":"HealthCheck"}
+        "healthCheck":{"shape":"HealthCheck"},
+        "systemControls":{"shape":"SystemControls"}
       }
     },
     "ContainerDefinitions":{
@@ -1716,6 +1719,17 @@
       "members":{
         "acknowledgment":{"shape":"String"}
       }
+    },
+    "SystemControl":{
+      "type":"structure",
+      "members":{
+       "namespace":{"shape":"String"},
+       "value":{"shape":"String"}
+      }
+    },
+    "SystemControls":{
+      "type":"list",
+      "member":{"shape":"SystemControl"}
     },
     "TargetNotFoundException":{
       "type":"structure",

--- a/agent/ecs_client/model/ecs/api.go
+++ b/agent/ecs_client/model/ecs/api.go
@@ -4136,6 +4136,8 @@ type ContainerDefinition struct {
 	//    name (for example, quay.io/assemblyline/ubuntu).
 	Image *string `locationName:"image" type:"string"`
 
+	Interactive *bool `locationName:"interactive" type:"boolean"`
+
 	// The link parameter allows containers to communicate with each other without
 	// the need for port mappings. Only supported if the network mode of a task
 	// definition is set to bridge. The name:internalName construct is analogous
@@ -4297,6 +4299,8 @@ type ContainerDefinition struct {
 	// Fargate launch type.
 	Privileged *bool `locationName:"privileged" type:"boolean"`
 
+	PseudoTerminal *bool `locationName:"pseudoTerminal" type:"boolean"`
+
 	// When this parameter is true, the container is given read-only access to its
 	// root file system. This parameter maps to ReadonlyRootfs in the Create a container
 	// (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
@@ -4308,6 +4312,8 @@ type ContainerDefinition struct {
 
 	// The private repository authentication credentials to use.
 	RepositoryCredentials *RepositoryCredentials `locationName:"repositoryCredentials" type:"structure"`
+
+	SystemControls []*SystemControl `locationName:"systemControls" type:"list"`
 
 	// A list of ulimits to set in the container. This parameter maps to Ulimits
 	// in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
@@ -4487,6 +4493,12 @@ func (s *ContainerDefinition) SetImage(v string) *ContainerDefinition {
 	return s
 }
 
+// SetInteractive sets the Interactive field's value.
+func (s *ContainerDefinition) SetInteractive(v bool) *ContainerDefinition {
+	s.Interactive = &v
+	return s
+}
+
 // SetLinks sets the Links field's value.
 func (s *ContainerDefinition) SetLinks(v []*string) *ContainerDefinition {
 	s.Links = v
@@ -4541,6 +4553,12 @@ func (s *ContainerDefinition) SetPrivileged(v bool) *ContainerDefinition {
 	return s
 }
 
+// SetPseudoTerminal sets the PseudoTerminal field's value.
+func (s *ContainerDefinition) SetPseudoTerminal(v bool) *ContainerDefinition {
+	s.PseudoTerminal = &v
+	return s
+}
+
 // SetReadonlyRootFilesystem sets the ReadonlyRootFilesystem field's value.
 func (s *ContainerDefinition) SetReadonlyRootFilesystem(v bool) *ContainerDefinition {
 	s.ReadonlyRootFilesystem = &v
@@ -4550,6 +4568,12 @@ func (s *ContainerDefinition) SetReadonlyRootFilesystem(v bool) *ContainerDefini
 // SetRepositoryCredentials sets the RepositoryCredentials field's value.
 func (s *ContainerDefinition) SetRepositoryCredentials(v *RepositoryCredentials) *ContainerDefinition {
 	s.RepositoryCredentials = v
+	return s
+}
+
+// SetSystemControls sets the SystemControls field's value.
+func (s *ContainerDefinition) SetSystemControls(v []*SystemControl) *ContainerDefinition {
+	s.SystemControls = v
 	return s
 }
 
@@ -9723,6 +9747,36 @@ func (s *SubmitTaskStateChangeOutput) SetAcknowledgment(v string) *SubmitTaskSta
 	return s
 }
 
+type SystemControl struct {
+	_ struct{} `type:"structure"`
+
+	Namespace *string `locationName:"namespace" type:"string"`
+
+	Value *string `locationName:"value" type:"string"`
+}
+
+// String returns the string representation
+func (s SystemControl) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s SystemControl) GoString() string {
+	return s.String()
+}
+
+// SetNamespace sets the Namespace field's value.
+func (s *SystemControl) SetNamespace(v string) *SystemControl {
+	s.Namespace = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *SystemControl) SetValue(v string) *SystemControl {
+	s.Value = &v
+	return s
+}
+
 // Details on a task in a cluster.
 type Task struct {
 	_ struct{} `type:"structure"`
@@ -11145,19 +11199,19 @@ const (
 )
 
 const (
-	// ScopeTask is a Scope enum value
-	ScopeTask = "task"
-
-	// ScopeShared is a Scope enum value
-	ScopeShared = "shared"
-)
-
-const (
 	// SchedulingStrategyReplica is a SchedulingStrategy enum value
 	SchedulingStrategyReplica = "REPLICA"
 
 	// SchedulingStrategyDaemon is a SchedulingStrategy enum value
 	SchedulingStrategyDaemon = "DAEMON"
+)
+
+const (
+	// ScopeTask is a Scope enum value
+	ScopeTask = "task"
+
+	// ScopeShared is a Scope enum value
+	ScopeShared = "shared"
 )
 
 const (

--- a/agent/functional_tests/testdata/simpletests_unix/interactive-tty.json
+++ b/agent/functional_tests/testdata/simpletests_unix/interactive-tty.json
@@ -1,0 +1,10 @@
+{
+  "Name": "InteractiveTty",
+  "Description": "checks that interactive tty works",
+  "TaskDefinition": "interactive-tty",
+  "Version": ">=1.0.0",
+  "Timeout": "2m",
+  "ExitCodes": {
+    "exit": 42
+  }
+}

--- a/agent/functional_tests/testdata/simpletests_unix/sysctl.json
+++ b/agent/functional_tests/testdata/simpletests_unix/sysctl.json
@@ -1,0 +1,10 @@
+{
+  "Name": "Sysctl",
+  "Description": "checks that sysctl works",
+  "TaskDefinition": "sysctl",
+  "Version": ">=1.14.4",
+  "Timeout": "2m",
+  "ExitCodes": {
+    "exit": 42
+  }
+}

--- a/agent/functional_tests/testdata/taskdefinitions/interactive-tty/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/interactive-tty/task-definition.json
@@ -1,0 +1,12 @@
+{
+  "family": "ecsftest-interactive-tty",
+  "containerDefinitions": [{
+    "image": "127.0.0.1:51670/ubuntu:latest",
+    "name": "exit",
+    "cpu": 10,
+    "memory": 10,
+    "interactive":true,
+    "pseudoTerminal":true,
+    "command": ["sh", "-c", "if [ -t 0 ] ; then exit 42; else exit 1; fi"]
+  }]
+}

--- a/agent/functional_tests/testdata/taskdefinitions/sysctl/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/sysctl/task-definition.json
@@ -1,0 +1,14 @@
+{
+  "family": "ecsftest-sysctl",
+  "containerDefinitions": [{
+    "image": "127.0.0.1:51670/ubuntu:latest",
+    "name": "exit",
+    "cpu": 10,
+    "memory": 10,
+    "systemControls": [{
+        "namespace":"net.ipv4.conf.default.rp_filter",
+        "value":"0"
+    }],
+    "command": ["sh", "-c", "sysctl net.ipv4.conf.default.rp_filter | grep \"net.ipv4.conf.default.rp_filter = 0\" && exit 42 || exit 1"]
+  }]
+}


### PR DESCRIPTION
### Summary
Functional tests for sysctl,interactive,tty Docker fields

### Implementation details
`t -0` checks if the container shell is interactive.
`net.ipv4.conf.default.rp_filter` is turned off using `sysctl` field. the same is checked from inside the container. 

### Testing
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes

### Description for the changelog
NA

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
