### PR TITLE
V13 unit test

### DIFF
--- a/agent/statemanager/state_manager_test.go
+++ b/agent/statemanager/state_manager_test.go
@@ -82,3 +82,49 @@ func TestLoadsV1DataCorrectly(t *testing.T) {
 	expected, _ := time.Parse(time.RFC3339, "2015-04-28T17:29:48.129140193Z")
 	assert.Equal(t, deadTask.GetKnownStatusTime(), expected)
 }
+
+func TestLoadsV13DataCorrectly(t *testing.T) {
+	cleanup, err := setupWindowsTest(filepath.Join(".", "testdata", "v13", "1", "ecs_agent_data.json"))
+	require.Nil(t, err, "Failed to set up test")
+	defer cleanup()
+	cfg := &config.Config{DataDir: filepath.Join(".", "testdata", "v13", "1")}
+
+	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil)
+	var containerInstanceArn, cluster, savedInstanceID string
+	var sequenceNumber int64
+
+	stateManager, err := statemanager.NewStateManager(cfg,
+		statemanager.AddSaveable("TaskEngine", taskEngine),
+		statemanager.AddSaveable("ContainerInstanceArn", &containerInstanceArn),
+		statemanager.AddSaveable("Cluster", &cluster),
+		statemanager.AddSaveable("EC2InstanceID", &savedInstanceID),
+		statemanager.AddSaveable("SeqNum", &sequenceNumber),
+	)
+	assert.NoError(t, err)
+	err = stateManager.Load()
+	assert.NoError(t, err)
+
+	assert.Equal(t, cluster, "test")
+	assert.True(t, sequenceNumber == 0)
+	tasks, err := taskEngine.ListTasks()
+	assert.NoError(t, err)
+	var deadTask *apitask.Task
+	for _, task := range tasks {
+		if task.Arn == "arn:aws:ecs:us-west-2:694464167470:task/5e9f6adb-2a02-48db-860f-41e12c4ced32" {
+			deadTask = task
+		}
+	}
+	require.NotNil(t, deadTask)
+	assert.Equal(t, deadTask.GetSentStatus(), apitaskstatus.TaskRunning)
+	assert.Equal(t, deadTask.Containers[0].SentStatusUnsafe, apicontainerstatus.ContainerRunning)
+	assert.Equal(t, deadTask.Containers[0].DesiredStatusUnsafe, apicontainerstatus.ContainerRunning)
+	assert.Equal(t, deadTask.Containers[0].KnownStatusUnsafe, apicontainerstatus.ContainerRunning)
+
+	exitCode := deadTask.Containers[0].KnownExitCodeUnsafe
+	require.NotNil(t, exitCode)
+	assert.Equal(t, *exitCode, 128)
+
+	expected, _ := time.Parse(time.RFC3339, "2015-04-28T17:29:48.129140193Z")
+	assert.Equal(t, deadTask.GetKnownStatusTime(), expected)
+
+}

--- a/agent/statemanager/state_manager_windows_test.go
+++ b/agent/statemanager/state_manager_windows_test.go
@@ -21,12 +21,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	"golang.org/x/sys/windows/registry"
-
-	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/statemanager/dependencies/mocks"
+	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/windows/registry"
 )
 
 func setup(t *testing.T, options ...Option) (
@@ -147,6 +146,34 @@ func TestStateManagerLoadV1Data(t *testing.T) {
 	assert.Equal(t, "arn:aws:ecs:us-west-2:1234567890:container-instance/a9f8e650-e66e-466d-9b0e-3cbce3ba5245", containerInstanceArn)
 	assert.Equal(t, "i-00000000", savedInstanceID)
 }
+
+func TestStateManagerLoadV13Data(t *testing.T) {
+	var containerInstanceArn, cluster, savedInstanceID string
+	var sequenceNumber int64
+	mockRegistry, mockKey, mockFS, _, manager, cleanup := setup(t,
+		AddSaveable("ContainerInstanceArn", &containerInstanceArn),
+		AddSaveable("Cluster", &cluster),
+		AddSaveable("EC2InstanceID", &savedInstanceID),
+		AddSaveable("SeqNum", &sequenceNumber))
+	defer cleanup()
+	dataFile, err := os.Open(filepath.Join(".", "testdata", "v13", "1", ecsDataFile))
+	assert.Nil(t, err, "Error opening test data")
+	defer dataFile.Close()
+	// TODO figure out why gomock does not like registry.READ as the mode
+	mockRegistry.EXPECT().OpenKey(ecsDataFileRootKey, ecsDataFileKeyPath, gomock.Any()).Return(mockKey, nil)
+	mockKey.EXPECT().GetStringValue(ecsDataFileValueName).Return(`C:\data.json`, uint32(0), nil)
+	mockKey.EXPECT().Close()
+	mockFS.EXPECT().Open(`C:\data.json`).Return(dataFile, nil)
+	mockFS.EXPECT().ReadAll(dataFile).Return(ioutil.ReadAll(dataFile))
+	err = manager.Load()
+	assert.Nil(t, err, "Error loading state")
+	assert.Equal(t, "test", cluster, "Wrong cluster")
+	assert.Equal(t, int64(0), sequenceNumber, "v13 should give a sequence number of 0")
+	assert.Equal(t, "arn:aws:ecs:us-west-2:694464167470:container-instance/5e94f1e5-2177-4440-ab84-196d1a6072da", containerInstanceArn)
+	assert.Equal(t, "i-04e73559ead350d79", savedInstanceID)
+}
+
+
 
 func TestStateManagerSaveCreateFileError(t *testing.T) {
 	mockRegistry, mockKey, mockFS, _, manager, cleanup := setup(t)

--- a/agent/statemanager/testdata/v13/1/ecs_agent_data.json
+++ b/agent/statemanager/testdata/v13/1/ecs_agent_data.json
@@ -1,0 +1,1917 @@
+{
+  "Data": {
+    "Cluster": "test",
+    "ContainerInstanceArn": "arn:aws:ecs:us-west-2:694464167470:container-instance/5e94f1e5-2177-4440-ab84-196d1a6072da",
+    "EC2InstanceID": "i-04e73559ead350d79",
+    "TaskEngine": {
+      "Tasks": [
+        {
+          "Arn": "arn:aws:ecs:us-west-2:694464167470:task/07561700-2a73-4b23-97a7-1335841dc1b5",
+          "Family": "test_ecs_agent_volume",
+          "Version": "3",
+          "Containers": [
+            {
+              "Name": "web",
+              "Image": "nginx",
+              "ImageID": "sha256:71c43202b8ac897ff4d048d3b37bdf4eb543ec5c03fd017c3e12c616c6792206",
+              "Command": null,
+              "Cpu": 100,
+              "Memory": 100,
+              "Links": null,
+              "volumesFrom": [],
+              "mountPoints": [
+                {
+                  "sourceVolume": "webdata",
+                  "containerPath": "/usr/share/nginx/html",
+                  "readOnly": false
+                }
+              ],
+              "portMappings": [],
+              "Essential": true,
+              "EntryPoint": null,
+              "environment": {
+                "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI": "/v2/credentials/cfc30f23-a1dc-426c-9baa-5542a0f972c7"
+              },
+              "overrides": {
+                "command": null
+              },
+              "dockerConfig": {
+                "config": "{}",
+                "hostConfig": "{\"CapAdd\":[],\"CapDrop\":[]}",
+                "version": "1.17"
+              },
+              "registryAuthentication": null,
+              "LogsAuthStrategy": "",
+              "desiredStatus": "STOPPED",
+              "KnownStatus": "STOPPED",
+              "TransitionDependencySet": {
+                "1": {
+                  "ContainerDependencies": null,
+                  "ResourceDependencies": [
+                    {
+                      "Name": "cgroup",
+                      "RequiredStatus": 1
+                    }
+                  ]
+                }
+              },
+              "RunDependencies": null,
+              "IsInternal": "NORMAL",
+              "ApplyingError": null,
+              "SentStatus": "STOPPED",
+              "metadataFileUpdated": false,
+              "KnownExitCode": 0,
+              "KnownPortBindings": null
+            },
+            {
+              "Name": "mysql",
+              "Image": "mysql:5.7",
+              "ImageID": "sha256:43b029b6b6406b40f1ba51b069980b5c14b701786830a41ebb489ad3bbf3d928",
+              "Command": [],
+              "Cpu": 100,
+              "Memory": 500,
+              "Links": [],
+              "volumesFrom": [],
+              "mountPoints": [
+                {
+                  "sourceVolume": "database_scratch",
+                  "containerPath": "/var/scratch",
+                  "readOnly": false
+                }
+              ],
+              "portMappings": [],
+              "Essential": true,
+              "EntryPoint": null,
+              "environment": {
+                "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI": "/v2/credentials/cfc30f23-a1dc-426c-9baa-5542a0f972c7",
+                "MYSQL_ROOT_PASSWORD": "password"
+              },
+              "overrides": {
+                "command": null
+              },
+              "dockerConfig": {
+                "config": "{}",
+                "hostConfig": "{\"Privileged\":false,\"ReadonlyRootfs\":false,\"Dns\":[],\"DnsSearch\":[],\"SecurityOpt\":[],\"LogConfig\":{\"Type\":\"awslogs\",\"Config\":{\"awslogs-group\":\"tutorial-mysql\",\"awslogs-stream\":\"mysql/mysql/07561700-2a73-4b23-97a7-1335841dc1b5\",\"awslogs-region\":\"us-east-1\"}},\"CapAdd\":[],\"CapDrop\":[]}",
+                "version": "1.19"
+              },
+              "registryAuthentication": null,
+              "LogsAuthStrategy": "ExecutionRole",
+              "desiredStatus": "STOPPED",
+              "KnownStatus": "STOPPED",
+              "TransitionDependencySet": {
+                "1": {
+                  "ContainerDependencies": null,
+                  "ResourceDependencies": [
+                    {
+                      "Name": "cgroup",
+                      "RequiredStatus": 1
+                    },
+                    {
+                      "Name": "database_scratch",
+                      "RequiredStatus": 1
+                    }
+                  ]
+                }
+              },
+              "RunDependencies": null,
+              "IsInternal": "NORMAL",
+              "ApplyingError": null,
+              "SentStatus": "STOPPED",
+              "metadataFileUpdated": false,
+              "KnownExitCode": 0,
+              "KnownPortBindings": null
+            },
+            {
+              "Name": "wordpress",
+              "Image": "wordpress",
+              "ImageID": "sha256:41e689eea0cdaab1280ed184f117171f0897a9353b3bd4cc321f0839d4027511",
+              "Command": [],
+              "Cpu": 100,
+              "Memory": 500,
+              "Links": [
+                "mysql"
+              ],
+              "volumesFrom": [],
+              "mountPoints": [
+                {
+                  "sourceVolume": "database_scratch",
+                  "containerPath": "/var/scratch",
+                  "readOnly": false
+                }
+              ],
+              "portMappings": [
+                {
+                  "ContainerPort": 80,
+                  "HostPort": 80,
+                  "BindIp": "",
+                  "Protocol": "tcp"
+                }
+              ],
+              "Essential": true,
+              "EntryPoint": null,
+              "environment": {
+                "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI": "/v2/credentials/cfc30f23-a1dc-426c-9baa-5542a0f972c7"
+              },
+              "overrides": {
+                "command": null
+              },
+              "dockerConfig": {
+                "config": "{}",
+                "hostConfig": "{\"Privileged\":false,\"ReadonlyRootfs\":false,\"Dns\":[],\"DnsSearch\":[],\"SecurityOpt\":[],\"LogConfig\":{\"Type\":\"awslogs\",\"Config\":{\"awslogs-group\":\"tutorial-wordpress\",\"awslogs-stream\":\"wordpress/wordpress/07561700-2a73-4b23-97a7-1335841dc1b5\",\"awslogs-region\":\"us-east-1\"}},\"CapAdd\":[],\"CapDrop\":[]}",
+                "version": "1.19"
+              },
+              "registryAuthentication": null,
+              "LogsAuthStrategy": "ExecutionRole",
+              "desiredStatus": "STOPPED",
+              "KnownStatus": "STOPPED",
+              "TransitionDependencySet": {
+                "1": {
+                  "ContainerDependencies": null,
+                  "ResourceDependencies": [
+                    {
+                      "Name": "cgroup",
+                      "RequiredStatus": 1
+                    },
+                    {
+                      "Name": "database_scratch",
+                      "RequiredStatus": 1
+                    }
+                  ]
+                }
+              },
+              "RunDependencies": null,
+              "IsInternal": "NORMAL",
+              "ApplyingError": null,
+              "SentStatus": "STOPPED",
+              "metadataFileUpdated": false,
+              "KnownExitCode": 0,
+              "KnownPortBindings": [
+                {
+                  "ContainerPort": 80,
+                  "HostPort": 80,
+                  "BindIp": "0.0.0.0",
+                  "Protocol": "tcp"
+                }
+              ]
+            }
+          ],
+          "resources": {
+            "cgroup": [
+              {
+                "cgroupRoot": "/ecs/07561700-2a73-4b23-97a7-1335841dc1b5",
+                "cgroupMountPath": "/sys/fs/cgroup",
+                "createdAt": "0001-01-01T00:00:00Z",
+                "desiredStatus": "REMOVED",
+                "knownStatus": "REMOVED",
+                "resourceSpec": {
+                  "cpu": {
+                    "shares": 300
+                  }
+                }
+              }
+            ],
+            "dockerVolume": [
+              {
+                "name": "database_scratch",
+                "dockerVolumeConfiguration": {
+                  "scope": "task",
+                  "autoprovision": false,
+                  "mountPoint": "ecs-test_ecs_agent_volume-3-database_scratch-b09de5a99def91c44800",
+                  "driver": "local",
+                  "driverOpts": {},
+                  "labels": {},
+                  "dockerVolumeName": "ecs-test_ecs_agent_volume-3-database_scratch-b09de5a99def91c44800"
+                },
+                "createdAt": "0001-01-01T00:00:00Z",
+                "desiredStatus": "REMOVED",
+                "knownStatus": "REMOVED"
+              },
+              {
+                "name": "database_scratch",
+                "dockerVolumeConfiguration": {
+                  "scope": "task",
+                  "autoprovision": false,
+                  "mountPoint": "ecs-test_ecs_agent_volume-3-database_scratch-b09de5a99def91c44800",
+                  "driver": "local",
+                  "driverOpts": {},
+                  "labels": {},
+                  "dockerVolumeName": "ecs-test_ecs_agent_volume-3-database_scratch-b09de5a99def91c44800"
+                },
+                "createdAt": "0001-01-01T00:00:00Z",
+                "desiredStatus": "REMOVED",
+                "knownStatus": "REMOVED"
+              }
+            ]
+          },
+          "volumes": [
+            {
+              "host": {
+                "hostPath": "ecs-test_ecs_agent_volume-3-database_scratch-b09de5a99def91c44800"
+              },
+              "name": "database_scratch",
+              "type": "host"
+            },
+            {
+              "host": {
+                "sourcePath": "/ecs/webdata"
+              },
+              "name": "webdata",
+              "type": "host"
+            }
+          ],
+          "DesiredStatus": "STOPPED",
+          "KnownStatus": "STOPPED",
+          "KnownTime": "2018-09-05T00:03:08.08384055Z",
+          "PullStartedAt": "2018-09-04T23:37:52.060886108Z",
+          "PullStoppedAt": "2018-09-04T23:37:57.268923251Z",
+          "ExecutionStoppedAt": "2018-09-05T00:03:06.379939421Z",
+          "SentStatus": "STOPPED",
+          "StartSequenceNumber": 12,
+          "StopSequenceNumber": 13,
+          "executionCredentialsID": "cfc30f23-a1dc-426c-9baa-5542a0f972c7",
+          "ENI": null,
+          "MemoryCPULimitsEnabled": true
+        },
+        {
+          "Arn": "arn:aws:ecs:us-west-2:694464167470:task/4df3bcd3-e82b-4163-8657-00806b6c4ddd",
+          "Family": "test_ecs_agent",
+          "Version": "1",
+          "Containers": [
+            {
+              "Name": "wordpress",
+              "Image": "wordpress",
+              "ImageID": "sha256:3745a1731caf02a64618ba59dc8ea194de0d09d371f3f570e2a10902fdb5c9a8",
+              "Command": [],
+              "Cpu": 100,
+              "Memory": 500,
+              "Links": [
+                "mysql"
+              ],
+              "volumesFrom": [],
+              "mountPoints": [],
+              "portMappings": [
+                {
+                  "ContainerPort": 80,
+                  "HostPort": 80,
+                  "BindIp": "",
+                  "Protocol": "tcp"
+                }
+              ],
+              "Essential": true,
+              "EntryPoint": null,
+              "environment": {},
+              "overrides": {
+                "command": null
+              },
+              "dockerConfig": {
+                "config": "{}",
+                "hostConfig": "{\"Privileged\":false,\"ReadonlyRootfs\":false,\"Dns\":[],\"DnsSearch\":[],\"ExtraHosts\":[],\"SecurityOpt\":[],\"LogConfig\":{\"Type\":\"awslogs\",\"Config\":{\"awslogs-group\":\"tutorial-wordpress\",\"awslogs-stream\":\"wordpress/wordpress/4df3bcd3-e82b-4163-8657-00806b6c4ddd\",\"awslogs-region\":\"us-east-1\"}},\"CapAdd\":[],\"CapDrop\":[],\"Devices\":[]}",
+                "version": "1.19"
+              },
+              "registryAuthentication": null,
+              "LogsAuthStrategy": "",
+              "desiredStatus": "STOPPED",
+              "KnownStatus": "STOPPED",
+              "TransitionDependencySet": {
+                "1": {
+                  "ContainerDependencies": null,
+                  "ResourceDependencies": [
+                    {
+                      "Name": "cgroup",
+                      "RequiredStatus": 1
+                    }
+                  ]
+                }
+              },
+              "RunDependencies": null,
+              "IsInternal": "NORMAL",
+              "ApplyingError": null,
+              "SentStatus": "STOPPED",
+              "metadataFileUpdated": false,
+              "KnownExitCode": 0,
+              "KnownPortBindings": [
+                {
+                  "ContainerPort": 80,
+                  "HostPort": 80,
+                  "BindIp": "0.0.0.0",
+                  "Protocol": "tcp"
+                }
+              ]
+            },
+            {
+              "Name": "mysql",
+              "Image": "mysql:5.7",
+              "ImageID": "sha256:43b029b6b6406b40f1ba51b069980b5c14b701786830a41ebb489ad3bbf3d928",
+              "Command": [],
+              "Cpu": 100,
+              "Memory": 500,
+              "Links": [],
+              "volumesFrom": [],
+              "mountPoints": [],
+              "portMappings": [],
+              "Essential": true,
+              "EntryPoint": null,
+              "environment": {
+                "MYSQL_ROOT_PASSWORD": "password"
+              },
+              "overrides": {
+                "command": null
+              },
+              "dockerConfig": {
+                "config": "{}",
+                "hostConfig": "{\"Privileged\":false,\"ReadonlyRootfs\":false,\"Dns\":[],\"DnsSearch\":[],\"ExtraHosts\":[],\"SecurityOpt\":[],\"LogConfig\":{\"Type\":\"awslogs\",\"Config\":{\"awslogs-group\":\"tutorial-mysql\",\"awslogs-stream\":\"mysql/mysql/4df3bcd3-e82b-4163-8657-00806b6c4ddd\",\"awslogs-region\":\"us-east-1\"}},\"CapAdd\":[],\"CapDrop\":[],\"Devices\":[]}",
+                "version": "1.19"
+              },
+              "registryAuthentication": null,
+              "LogsAuthStrategy": "",
+              "desiredStatus": "STOPPED",
+              "KnownStatus": "STOPPED",
+              "TransitionDependencySet": {
+                "1": {
+                  "ContainerDependencies": null,
+                  "ResourceDependencies": [
+                    {
+                      "Name": "cgroup",
+                      "RequiredStatus": 1
+                    }
+                  ]
+                }
+              },
+              "RunDependencies": null,
+              "IsInternal": "NORMAL",
+              "ApplyingError": null,
+              "SentStatus": "STOPPED",
+              "metadataFileUpdated": false,
+              "KnownExitCode": 0,
+              "KnownPortBindings": null
+            }
+          ],
+          "resources": {
+            "cgroup": [
+              {
+                "cgroupRoot": "/ecs/4df3bcd3-e82b-4163-8657-00806b6c4ddd",
+                "cgroupMountPath": "/sys/fs/cgroup",
+                "createdAt": "0001-01-01T00:00:00Z",
+                "desiredStatus": "REMOVED",
+                "knownStatus": "REMOVED",
+                "resourceSpec": {
+                  "cpu": {
+                    "shares": 200
+                  }
+                }
+              }
+            ]
+          },
+          "volumes": [],
+          "DesiredStatus": "STOPPED",
+          "KnownStatus": "STOPPED",
+          "KnownTime": "2018-09-04T21:22:47.95130532Z",
+          "PullStartedAt": "2018-08-29T21:57:14.898457389Z",
+          "PullStoppedAt": "2018-08-29T21:57:52.131091934Z",
+          "ExecutionStoppedAt": "2018-09-04T21:22:46.575215381Z",
+          "SentStatus": "STOPPED",
+          "StartSequenceNumber": 2,
+          "StopSequenceNumber": 5,
+          "executionCredentialsID": "",
+          "ENI": null,
+          "MemoryCPULimitsEnabled": true
+        },
+        {
+          "Arn": "arn:aws:ecs:us-west-2:694464167470:task/5e9f6adb-2a02-48db-860f-41e12c4ced32",
+          "Family": "test_ecs_agent_volume",
+          "Version": "4",
+          "Containers": [
+            {
+              "Name": "wordpress",
+              "Image": "wordpress",
+              "ImageID": "sha256:41e689eea0cdaab1280ed184f117171f0897a9353b3bd4cc321f0839d4027511",
+              "Command": [],
+              "Cpu": 100,
+              "Memory": 500,
+              "Links": [
+                "mysql"
+              ],
+              "volumesFrom": [],
+              "mountPoints": [
+                {
+                  "sourceVolume": "database_scratch",
+                  "containerPath": "/var/scratch",
+                  "readOnly": false
+                }
+              ],
+              "portMappings": [
+                {
+                  "ContainerPort": 80,
+                  "HostPort": 80,
+                  "BindIp": "",
+                  "Protocol": "tcp"
+                }
+              ],
+              "Essential": true,
+              "EntryPoint": null,
+              "environment": {
+                "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI": "/v2/credentials/9878f2d2-4c20-4ea3-875e-f44cc9c86bdb"
+              },
+              "overrides": {
+                "command": null
+              },
+              "dockerConfig": {
+                "config": "{}",
+                "hostConfig": "{\"Privileged\":false,\"ReadonlyRootfs\":false,\"Dns\":[],\"DnsSearch\":[],\"SecurityOpt\":[],\"LogConfig\":{\"Type\":\"awslogs\",\"Config\":{\"awslogs-group\":\"tutorial-wordpress\",\"awslogs-stream\":\"wordpress/wordpress/5e9f6adb-2a02-48db-860f-41e12c4ced32\",\"awslogs-region\":\"us-east-1\"}},\"CapAdd\":[],\"CapDrop\":[]}",
+                "version": "1.19"
+              },
+              "registryAuthentication": null,
+              "LogsAuthStrategy": "ExecutionRole",
+              "desiredStatus": "RUNNING",
+              "KnownStatus": "RUNNING",
+              "TransitionDependencySet": {
+                "1": {
+                  "ContainerDependencies": null,
+                  "ResourceDependencies": [
+                    {
+                      "Name": "cgroup",
+                      "RequiredStatus": 1
+                    },
+                    {
+                      "Name": "database_scratch",
+                      "RequiredStatus": 1
+                    }
+                  ]
+                }
+              },
+              "RunDependencies": null,
+              "IsInternal": "NORMAL",
+              "ApplyingError": null,
+              "SentStatus": "RUNNING",
+              "metadataFileUpdated": false,
+              "KnownExitCode": 128,
+              "KnownPortBindings": [
+                {
+                  "ContainerPort": 80,
+                  "HostPort": 80,
+                  "BindIp": "0.0.0.0",
+                  "Protocol": "tcp"
+                }
+              ]
+            },
+            {
+              "Name": "mysql",
+              "Image": "mysql:5.7",
+              "ImageID": "sha256:43b029b6b6406b40f1ba51b069980b5c14b701786830a41ebb489ad3bbf3d928",
+              "Command": [],
+              "Cpu": 100,
+              "Memory": 500,
+              "Links": [],
+              "volumesFrom": [
+                {
+                  "sourceContainer": "web",
+                  "readOnly": false
+                }
+              ],
+              "mountPoints": [
+                {
+                  "sourceVolume": "database_scratch",
+                  "containerPath": "/var/scratch",
+                  "readOnly": false
+                }
+              ],
+              "portMappings": [],
+              "Essential": true,
+              "EntryPoint": null,
+              "environment": {
+                "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI": "/v2/credentials/9878f2d2-4c20-4ea3-875e-f44cc9c86bdb",
+                "MYSQL_ROOT_PASSWORD": "password"
+              },
+              "overrides": {
+                "command": null
+              },
+              "dockerConfig": {
+                "config": "{}",
+                "hostConfig": "{\"Privileged\":false,\"ReadonlyRootfs\":false,\"Dns\":[],\"DnsSearch\":[],\"SecurityOpt\":[],\"LogConfig\":{\"Type\":\"awslogs\",\"Config\":{\"awslogs-group\":\"tutorial-mysql\",\"awslogs-stream\":\"mysql/mysql/5e9f6adb-2a02-48db-860f-41e12c4ced32\",\"awslogs-region\":\"us-east-1\"}},\"CapAdd\":[],\"CapDrop\":[]}",
+                "version": "1.19"
+              },
+              "registryAuthentication": null,
+              "LogsAuthStrategy": "ExecutionRole",
+              "desiredStatus": "RUNNING",
+              "KnownStatus": "RUNNING",
+              "TransitionDependencySet": {
+                "1": {
+                  "ContainerDependencies": null,
+                  "ResourceDependencies": [
+                    {
+                      "Name": "cgroup",
+                      "RequiredStatus": 1
+                    },
+                    {
+                      "Name": "database_scratch",
+                      "RequiredStatus": 1
+                    }
+                  ]
+                }
+              },
+              "RunDependencies": null,
+              "IsInternal": "NORMAL",
+              "ApplyingError": null,
+              "SentStatus": "RUNNING",
+              "metadataFileUpdated": false,
+              "KnownExitCode": 128,
+              "KnownPortBindings": null
+            },
+            {
+              "Name": "web",
+              "Image": "nginx",
+              "ImageID": "sha256:71c43202b8ac897ff4d048d3b37bdf4eb543ec5c03fd017c3e12c616c6792206",
+              "Command": null,
+              "Cpu": 100,
+              "Memory": 100,
+              "Links": null,
+              "volumesFrom": [],
+              "mountPoints": [
+                {
+                  "sourceVolume": "webdata",
+                  "containerPath": "/usr/share/nginx/html",
+                  "readOnly": false
+                }
+              ],
+              "portMappings": [],
+              "Essential": true,
+              "EntryPoint": null,
+              "environment": {
+                "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI": "/v2/credentials/9878f2d2-4c20-4ea3-875e-f44cc9c86bdb"
+              },
+              "overrides": {
+                "command": null
+              },
+              "dockerConfig": {
+                "config": "{}",
+                "hostConfig": "{\"CapAdd\":[],\"CapDrop\":[]}",
+                "version": "1.17"
+              },
+              "registryAuthentication": null,
+              "LogsAuthStrategy": "",
+              "desiredStatus": "RUNNING",
+              "KnownStatus": "RUNNING",
+              "TransitionDependencySet": {
+                "1": {
+                  "ContainerDependencies": null,
+                  "ResourceDependencies": [
+                    {
+                      "Name": "cgroup",
+                      "RequiredStatus": 1
+                    }
+                  ]
+                }
+              },
+              "RunDependencies": null,
+              "IsInternal": "NORMAL",
+              "ApplyingError": null,
+              "SentStatus": "RUNNING",
+              "metadataFileUpdated": false,
+              "KnownExitCode": null,
+              "KnownPortBindings": null
+            }
+          ],
+          "resources": {
+            "cgroup": [
+              {
+                "cgroupRoot": "/ecs/5e9f6adb-2a02-48db-860f-41e12c4ced32",
+                "cgroupMountPath": "/sys/fs/cgroup",
+                "createdAt": "0001-01-01T00:00:00Z",
+                "desiredStatus": "CREATED",
+                "knownStatus": "CREATED",
+                "resourceSpec": {
+                  "cpu": {
+                    "shares": 300
+                  }
+                }
+              }
+            ],
+            "dockerVolume": [
+              {
+                "name": "database_scratch",
+                "dockerVolumeConfiguration": {
+                  "scope": "task",
+                  "autoprovision": false,
+                  "mountPoint": "ecs-test_ecs_agent_volume-4-database_scratch-cea890f19992a7d81f00",
+                  "driver": "local",
+                  "driverOpts": {},
+                  "labels": {},
+                  "dockerVolumeName": "ecs-test_ecs_agent_volume-4-database_scratch-cea890f19992a7d81f00"
+                },
+                "createdAt": "0001-01-01T00:00:00Z",
+                "desiredStatus": "CREATED",
+                "knownStatus": "CREATED"
+              },
+              {
+                "name": "database_scratch",
+                "dockerVolumeConfiguration": {
+                  "scope": "task",
+                  "autoprovision": false,
+                  "mountPoint": "ecs-test_ecs_agent_volume-4-database_scratch-cea890f19992a7d81f00",
+                  "driver": "local",
+                  "driverOpts": {},
+                  "labels": {},
+                  "dockerVolumeName": "ecs-test_ecs_agent_volume-4-database_scratch-cea890f19992a7d81f00"
+                },
+                "createdAt": "0001-01-01T00:00:00Z",
+                "desiredStatus": "CREATED",
+                "knownStatus": "CREATED"
+              }
+            ]
+          },
+          "volumes": [
+            {
+              "host": {
+                "hostPath": "ecs-test_ecs_agent_volume-4-database_scratch-cea890f19992a7d81f00"
+              },
+              "name": "database_scratch",
+              "type": "host"
+            },
+            {
+              "host": {
+                "sourcePath": "/ecs/webdata"
+              },
+              "name": "webdata",
+              "type": "host"
+            }
+          ],
+          "DesiredStatus": "RUNNING",
+          "KnownStatus": "RUNNING",
+          "KnownTime": "2015-04-28T17:29:48.129140193Z",
+          "PullStartedAt": "2018-09-05T00:03:28.735989723Z",
+          "PullStoppedAt": "2018-09-05T00:03:34.431770163Z",
+          "ExecutionStoppedAt": "0001-01-01T00:00:00Z",
+          "SentStatus": "RUNNING",
+          "StartSequenceNumber": 14,
+          "StopSequenceNumber": 0,
+          "executionCredentialsID": "9878f2d2-4c20-4ea3-875e-f44cc9c86bdb",
+          "ENI": null,
+          "MemoryCPULimitsEnabled": true
+        },
+        {
+          "Arn": "arn:aws:ecs:us-west-2:694464167470:task/2ed4780b-5007-4684-9df9-93ea12a36d0a",
+          "Family": "test_ecs_agent_volume",
+          "Version": "1",
+          "Containers": [
+            {
+              "Name": "wordpress",
+              "Image": "wordpress",
+              "ImageID": "sha256:41e689eea0cdaab1280ed184f117171f0897a9353b3bd4cc321f0839d4027511",
+              "Command": [],
+              "Cpu": 100,
+              "Memory": 500,
+              "Links": [
+                "mysql"
+              ],
+              "volumesFrom": [],
+              "mountPoints": [],
+              "portMappings": [
+                {
+                  "ContainerPort": 80,
+                  "HostPort": 80,
+                  "BindIp": "",
+                  "Protocol": "tcp"
+                }
+              ],
+              "Essential": true,
+              "EntryPoint": null,
+              "environment": {
+                "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI": "/v2/credentials/9203b948-8e5c-4efc-953d-0d2ffcbdc9cc"
+              },
+              "overrides": {
+                "command": null
+              },
+              "dockerConfig": {
+                "config": "{}",
+                "hostConfig": "{\"Privileged\":false,\"ReadonlyRootfs\":false,\"Dns\":[],\"DnsSearch\":[],\"SecurityOpt\":[],\"LogConfig\":{\"Type\":\"awslogs\",\"Config\":{\"awslogs-group\":\"tutorial-wordpress\",\"awslogs-stream\":\"wordpress/wordpress/2ed4780b-5007-4684-9df9-93ea12a36d0a\",\"awslogs-region\":\"us-east-1\"}},\"CapAdd\":[],\"CapDrop\":[]}",
+                "version": "1.25"
+              },
+              "registryAuthentication": null,
+              "LogsAuthStrategy": "ExecutionRole",
+              "desiredStatus": "STOPPED",
+              "KnownStatus": "STOPPED",
+              "TransitionDependencySet": {
+                "1": {
+                  "ContainerDependencies": null,
+                  "ResourceDependencies": [
+                    {
+                      "Name": "cgroup",
+                      "RequiredStatus": 1
+                    }
+                  ]
+                }
+              },
+              "RunDependencies": null,
+              "IsInternal": "NORMAL",
+              "ApplyingError": null,
+              "SentStatus": "STOPPED",
+              "metadataFileUpdated": false,
+              "KnownExitCode": 0,
+              "KnownPortBindings": [
+                {
+                  "ContainerPort": 80,
+                  "HostPort": 80,
+                  "BindIp": "0.0.0.0",
+                  "Protocol": "tcp"
+                }
+              ]
+            },
+            {
+              "Name": "mysql",
+              "Image": "mysql:5.7",
+              "ImageID": "sha256:43b029b6b6406b40f1ba51b069980b5c14b701786830a41ebb489ad3bbf3d928",
+              "Command": [],
+              "Cpu": 100,
+              "Memory": 500,
+              "Links": [],
+              "volumesFrom": [],
+              "mountPoints": [],
+              "portMappings": [],
+              "Essential": true,
+              "EntryPoint": null,
+              "environment": {
+                "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI": "/v2/credentials/9203b948-8e5c-4efc-953d-0d2ffcbdc9cc",
+                "MYSQL_ROOT_PASSWORD": "password"
+              },
+              "overrides": {
+                "command": null
+              },
+              "dockerConfig": {
+                "config": "{}",
+                "hostConfig": "{\"Privileged\":false,\"ReadonlyRootfs\":false,\"Dns\":[],\"DnsSearch\":[],\"SecurityOpt\":[],\"LogConfig\":{\"Type\":\"awslogs\",\"Config\":{\"awslogs-group\":\"tutorial-mysql\",\"awslogs-stream\":\"mysql/mysql/2ed4780b-5007-4684-9df9-93ea12a36d0a\",\"awslogs-region\":\"us-east-1\"}},\"CapAdd\":[],\"CapDrop\":[]}",
+                "version": "1.25"
+              },
+              "registryAuthentication": null,
+              "LogsAuthStrategy": "ExecutionRole",
+              "desiredStatus": "STOPPED",
+              "KnownStatus": "STOPPED",
+              "TransitionDependencySet": {
+                "1": {
+                  "ContainerDependencies": null,
+                  "ResourceDependencies": [
+                    {
+                      "Name": "cgroup",
+                      "RequiredStatus": 1
+                    }
+                  ]
+                }
+              },
+              "RunDependencies": null,
+              "IsInternal": "NORMAL",
+              "ApplyingError": null,
+              "SentStatus": "STOPPED",
+              "metadataFileUpdated": false,
+              "KnownExitCode": 0,
+              "KnownPortBindings": null
+            }
+          ],
+          "resources": {
+            "cgroup": [
+              {
+                "cgroupRoot": "/ecs/2ed4780b-5007-4684-9df9-93ea12a36d0a",
+                "cgroupMountPath": "/sys/fs/cgroup",
+                "createdAt": "0001-01-01T00:00:00Z",
+                "desiredStatus": "REMOVED",
+                "knownStatus": "REMOVED",
+                "resourceSpec": {
+                  "cpu": {
+                    "shares": 200
+                  }
+                }
+              }
+            ],
+            "dockerVolume": [
+              {
+                "name": "testvol",
+                "dockerVolumeConfiguration": {
+                  "scope": "task",
+                  "autoprovision": false,
+                  "mountPoint": "ecs-test_ecs_agent_volume-1-testvol-dafba9beddab8cfbc601",
+                  "driver": "local",
+                  "driverOpts": null,
+                  "labels": null,
+                  "dockerVolumeName": "ecs-test_ecs_agent_volume-1-testvol-dafba9beddab8cfbc601"
+                },
+                "createdAt": "0001-01-01T00:00:00Z",
+                "desiredStatus": "REMOVED",
+                "knownStatus": "REMOVED"
+              }
+            ]
+          },
+          "volumes": [
+            {
+              "dockerVolumeConfiguration": {
+                "scope": "task",
+                "autoprovision": false,
+                "mountPoint": "ecs-test_ecs_agent_volume-1-testvol-dafba9beddab8cfbc601",
+                "driver": "local",
+                "driverOpts": null,
+                "labels": null,
+                "dockerVolumeName": "ecs-test_ecs_agent_volume-1-testvol-dafba9beddab8cfbc601"
+              },
+              "name": "testvol",
+              "type": "docker"
+            }
+          ],
+          "DesiredStatus": "STOPPED",
+          "KnownStatus": "STOPPED",
+          "KnownTime": "2018-09-04T21:45:10.431524931Z",
+          "PullStartedAt": "2018-09-04T21:23:54.483442983Z",
+          "PullStoppedAt": "2018-09-04T21:24:06.744814164Z",
+          "ExecutionStoppedAt": "2018-09-04T21:45:09.188239659Z",
+          "SentStatus": "STOPPED",
+          "StartSequenceNumber": 6,
+          "StopSequenceNumber": 7,
+          "executionCredentialsID": "9203b948-8e5c-4efc-953d-0d2ffcbdc9cc",
+          "ENI": null,
+          "MemoryCPULimitsEnabled": true
+        },
+        {
+          "Arn": "arn:aws:ecs:us-west-2:694464167470:task/8905424a-575a-4185-aeeb-15a58abd1112",
+          "Family": "test_ecs_agent_volume",
+          "Version": "2",
+          "Containers": [
+            {
+              "Name": "mysql",
+              "Image": "mysql:5.7",
+              "ImageID": "sha256:43b029b6b6406b40f1ba51b069980b5c14b701786830a41ebb489ad3bbf3d928",
+              "Command": [],
+              "Cpu": 100,
+              "Memory": 500,
+              "Links": [],
+              "volumesFrom": [],
+              "mountPoints": [
+                {
+                  "sourceVolume": "database_scratch",
+                  "containerPath": "/var/scratch",
+                  "readOnly": false
+                }
+              ],
+              "portMappings": [],
+              "Essential": true,
+              "EntryPoint": null,
+              "environment": {
+                "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI": "/v2/credentials/c8d7f417-fc5f-47e4-b2de-b2e01735e541",
+                "MYSQL_ROOT_PASSWORD": "password"
+              },
+              "overrides": {
+                "command": null
+              },
+              "dockerConfig": {
+                "config": "{}",
+                "hostConfig": "{\"Privileged\":false,\"ReadonlyRootfs\":false,\"Dns\":[],\"DnsSearch\":[],\"SecurityOpt\":[],\"LogConfig\":{\"Type\":\"awslogs\",\"Config\":{\"awslogs-group\":\"tutorial-mysql\",\"awslogs-stream\":\"mysql/mysql/8905424a-575a-4185-aeeb-15a58abd1112\",\"awslogs-region\":\"us-east-1\"}},\"CapAdd\":[],\"CapDrop\":[]}",
+                "version": "1.19"
+              },
+              "registryAuthentication": null,
+              "LogsAuthStrategy": "ExecutionRole",
+              "desiredStatus": "STOPPED",
+              "KnownStatus": "STOPPED",
+              "TransitionDependencySet": {
+                "1": {
+                  "ContainerDependencies": null,
+                  "ResourceDependencies": [
+                    {
+                      "Name": "cgroup",
+                      "RequiredStatus": 1
+                    },
+                    {
+                      "Name": "database_scratch",
+                      "RequiredStatus": 1
+                    }
+                  ]
+                }
+              },
+              "RunDependencies": null,
+              "IsInternal": "NORMAL",
+              "ApplyingError": null,
+              "SentStatus": "STOPPED",
+              "metadataFileUpdated": false,
+              "KnownExitCode": 0,
+              "KnownPortBindings": null
+            },
+            {
+              "Name": "wordpress",
+              "Image": "wordpress",
+              "ImageID": "sha256:41e689eea0cdaab1280ed184f117171f0897a9353b3bd4cc321f0839d4027511",
+              "Command": [],
+              "Cpu": 100,
+              "Memory": 500,
+              "Links": [
+                "mysql"
+              ],
+              "volumesFrom": [],
+              "mountPoints": [
+                {
+                  "sourceVolume": "database_scratch",
+                  "containerPath": "/var/scratch",
+                  "readOnly": false
+                }
+              ],
+              "portMappings": [
+                {
+                  "ContainerPort": 80,
+                  "HostPort": 80,
+                  "BindIp": "",
+                  "Protocol": "tcp"
+                }
+              ],
+              "Essential": true,
+              "EntryPoint": null,
+              "environment": {
+                "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI": "/v2/credentials/c8d7f417-fc5f-47e4-b2de-b2e01735e541"
+              },
+              "overrides": {
+                "command": null
+              },
+              "dockerConfig": {
+                "config": "{}",
+                "hostConfig": "{\"Privileged\":false,\"ReadonlyRootfs\":false,\"Dns\":[],\"DnsSearch\":[],\"SecurityOpt\":[],\"LogConfig\":{\"Type\":\"awslogs\",\"Config\":{\"awslogs-group\":\"tutorial-wordpress\",\"awslogs-stream\":\"wordpress/wordpress/8905424a-575a-4185-aeeb-15a58abd1112\",\"awslogs-region\":\"us-east-1\"}},\"CapAdd\":[],\"CapDrop\":[]}",
+                "version": "1.19"
+              },
+              "registryAuthentication": null,
+              "LogsAuthStrategy": "ExecutionRole",
+              "desiredStatus": "STOPPED",
+              "KnownStatus": "STOPPED",
+              "TransitionDependencySet": {
+                "1": {
+                  "ContainerDependencies": null,
+                  "ResourceDependencies": [
+                    {
+                      "Name": "cgroup",
+                      "RequiredStatus": 1
+                    },
+                    {
+                      "Name": "database_scratch",
+                      "RequiredStatus": 1
+                    }
+                  ]
+                }
+              },
+              "RunDependencies": null,
+              "IsInternal": "NORMAL",
+              "ApplyingError": null,
+              "SentStatus": "STOPPED",
+              "metadataFileUpdated": false,
+              "KnownExitCode": 0,
+              "KnownPortBindings": [
+                {
+                  "ContainerPort": 80,
+                  "HostPort": 80,
+                  "BindIp": "0.0.0.0",
+                  "Protocol": "tcp"
+                }
+              ]
+            }
+          ],
+          "resources": {
+            "cgroup": [
+              {
+                "cgroupRoot": "/ecs/8905424a-575a-4185-aeeb-15a58abd1112",
+                "cgroupMountPath": "/sys/fs/cgroup",
+                "createdAt": "0001-01-01T00:00:00Z",
+                "desiredStatus": "REMOVED",
+                "knownStatus": "REMOVED",
+                "resourceSpec": {
+                  "cpu": {
+                    "shares": 200
+                  }
+                }
+              }
+            ],
+            "dockerVolume": [
+              {
+                "name": "database_scratch",
+                "dockerVolumeConfiguration": {
+                  "scope": "task",
+                  "autoprovision": false,
+                  "mountPoint": "ecs-test_ecs_agent_volume-2-database_scratch-a2acf7badbd1b3dba501",
+                  "driver": "local",
+                  "driverOpts": {},
+                  "labels": {},
+                  "dockerVolumeName": "ecs-test_ecs_agent_volume-2-database_scratch-a2acf7badbd1b3dba501"
+                },
+                "createdAt": "0001-01-01T00:00:00Z",
+                "desiredStatus": "REMOVED",
+                "knownStatus": "REMOVED"
+              },
+              {
+                "name": "database_scratch",
+                "dockerVolumeConfiguration": {
+                  "scope": "task",
+                  "autoprovision": false,
+                  "mountPoint": "ecs-test_ecs_agent_volume-2-database_scratch-a2acf7badbd1b3dba501",
+                  "driver": "local",
+                  "driverOpts": {},
+                  "labels": {},
+                  "dockerVolumeName": "ecs-test_ecs_agent_volume-2-database_scratch-a2acf7badbd1b3dba501"
+                },
+                "createdAt": "0001-01-01T00:00:00Z",
+                "desiredStatus": "REMOVED",
+                "knownStatus": "REMOVED"
+              }
+            ]
+          },
+          "volumes": [
+            {
+              "host": {
+                "hostPath": "ecs-test_ecs_agent_volume-2-database_scratch-a2acf7badbd1b3dba501"
+              },
+              "name": "database_scratch",
+              "type": "host"
+            }
+          ],
+          "DesiredStatus": "STOPPED",
+          "KnownStatus": "STOPPED",
+          "KnownTime": "2018-09-04T23:37:30.607536177Z",
+          "PullStartedAt": "2018-09-04T23:20:00.025320791Z",
+          "PullStoppedAt": "2018-09-04T23:20:04.280841618Z",
+          "ExecutionStoppedAt": "2018-09-04T23:37:29.599493396Z",
+          "SentStatus": "STOPPED",
+          "StartSequenceNumber": 10,
+          "StopSequenceNumber": 11,
+          "executionCredentialsID": "c8d7f417-fc5f-47e4-b2de-b2e01735e541",
+          "ENI": null,
+          "MemoryCPULimitsEnabled": true
+        }
+      ],
+      "IdToContainer": {
+        "0431789e4b25f9bcaceffcd95ff5b966f49e50b04ee0fd165944cb33d709ffd8": {
+          "DockerId": "0431789e4b25f9bcaceffcd95ff5b966f49e50b04ee0fd165944cb33d709ffd8",
+          "DockerName": "ecs-test_ecs_agent_volume-4-wordpress-d6959c87e5c5f2b3a501",
+          "Container": {
+            "Name": "wordpress",
+            "Image": "wordpress",
+            "ImageID": "sha256:41e689eea0cdaab1280ed184f117171f0897a9353b3bd4cc321f0839d4027511",
+            "Command": [],
+            "Cpu": 100,
+            "Memory": 500,
+            "Links": [
+              "mysql"
+            ],
+            "volumesFrom": [],
+            "mountPoints": [
+              {
+                "sourceVolume": "database_scratch",
+                "containerPath": "/var/scratch",
+                "readOnly": false
+              }
+            ],
+            "portMappings": [
+              {
+                "ContainerPort": 80,
+                "HostPort": 80,
+                "BindIp": "",
+                "Protocol": "tcp"
+              }
+            ],
+            "Essential": true,
+            "EntryPoint": null,
+            "environment": {
+              "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI": "/v2/credentials/9878f2d2-4c20-4ea3-875e-f44cc9c86bdb"
+            },
+            "overrides": {
+              "command": null
+            },
+            "dockerConfig": {
+              "config": "{}",
+              "hostConfig": "{\"Privileged\":false,\"ReadonlyRootfs\":false,\"Dns\":[],\"DnsSearch\":[],\"SecurityOpt\":[],\"LogConfig\":{\"Type\":\"awslogs\",\"Config\":{\"awslogs-group\":\"tutorial-wordpress\",\"awslogs-stream\":\"wordpress/wordpress/5e9f6adb-2a02-48db-860f-41e12c4ced32\",\"awslogs-region\":\"us-east-1\"}},\"CapAdd\":[],\"CapDrop\":[]}",
+              "version": "1.19"
+            },
+            "registryAuthentication": null,
+            "LogsAuthStrategy": "ExecutionRole",
+            "desiredStatus": "RUNNING",
+            "KnownStatus": "RUNNING",
+            "TransitionDependencySet": {
+              "1": {
+                "ContainerDependencies": null,
+                "ResourceDependencies": [
+                  {
+                    "Name": "cgroup",
+                    "RequiredStatus": 1
+                  },
+                  {
+                    "Name": "database_scratch",
+                    "RequiredStatus": 1
+                  }
+                ]
+              }
+            },
+            "RunDependencies": null,
+            "IsInternal": "NORMAL",
+            "ApplyingError": null,
+            "SentStatus": "RUNNING",
+            "metadataFileUpdated": false,
+            "KnownExitCode": null,
+            "KnownPortBindings": [
+              {
+                "ContainerPort": 80,
+                "HostPort": 80,
+                "BindIp": "0.0.0.0",
+                "Protocol": "tcp"
+              }
+            ]
+          }
+        },
+        "35eb8db23206ee8213b481d055d48521095fc58b8dac6f00b5925f27ccf41668": {
+          "DockerId": "35eb8db23206ee8213b481d055d48521095fc58b8dac6f00b5925f27ccf41668",
+          "DockerName": "ecs-test_ecs_agent-1-mysql-fcd9cea18faaca944300",
+          "Container": {
+            "Name": "mysql",
+            "Image": "mysql:5.7",
+            "ImageID": "sha256:43b029b6b6406b40f1ba51b069980b5c14b701786830a41ebb489ad3bbf3d928",
+            "Command": [],
+            "Cpu": 100,
+            "Memory": 500,
+            "Links": [],
+            "volumesFrom": [],
+            "mountPoints": [],
+            "portMappings": [],
+            "Essential": true,
+            "EntryPoint": null,
+            "environment": {
+              "MYSQL_ROOT_PASSWORD": "password"
+            },
+            "overrides": {
+              "command": null
+            },
+            "dockerConfig": {
+              "config": "{}",
+              "hostConfig": "{\"Privileged\":false,\"ReadonlyRootfs\":false,\"Dns\":[],\"DnsSearch\":[],\"ExtraHosts\":[],\"SecurityOpt\":[],\"LogConfig\":{\"Type\":\"awslogs\",\"Config\":{\"awslogs-group\":\"tutorial-mysql\",\"awslogs-stream\":\"mysql/mysql/4df3bcd3-e82b-4163-8657-00806b6c4ddd\",\"awslogs-region\":\"us-east-1\"}},\"CapAdd\":[],\"CapDrop\":[],\"Devices\":[]}",
+              "version": "1.19"
+            },
+            "registryAuthentication": null,
+            "LogsAuthStrategy": "",
+            "desiredStatus": "STOPPED",
+            "KnownStatus": "STOPPED",
+            "TransitionDependencySet": {
+              "1": {
+                "ContainerDependencies": null,
+                "ResourceDependencies": [
+                  {
+                    "Name": "cgroup",
+                    "RequiredStatus": 1
+                  }
+                ]
+              }
+            },
+            "RunDependencies": null,
+            "IsInternal": "NORMAL",
+            "ApplyingError": null,
+            "SentStatus": "STOPPED",
+            "metadataFileUpdated": false,
+            "KnownExitCode": 0,
+            "KnownPortBindings": null
+          }
+        },
+        "3989b97524fc7f7125b461dec17c0732e9b951fe8bb8a6c14a7d82c952e9816e": {
+          "DockerId": "3989b97524fc7f7125b461dec17c0732e9b951fe8bb8a6c14a7d82c952e9816e",
+          "DockerName": "ecs-test_ecs_agent-1-wordpress-b0a28483e1e08bb89d01",
+          "Container": {
+            "Name": "wordpress",
+            "Image": "wordpress",
+            "ImageID": "sha256:3745a1731caf02a64618ba59dc8ea194de0d09d371f3f570e2a10902fdb5c9a8",
+            "Command": [],
+            "Cpu": 100,
+            "Memory": 500,
+            "Links": [
+              "mysql"
+            ],
+            "volumesFrom": [],
+            "mountPoints": [],
+            "portMappings": [
+              {
+                "ContainerPort": 80,
+                "HostPort": 80,
+                "BindIp": "",
+                "Protocol": "tcp"
+              }
+            ],
+            "Essential": true,
+            "EntryPoint": null,
+            "environment": {},
+            "overrides": {
+              "command": null
+            },
+            "dockerConfig": {
+              "config": "{}",
+              "hostConfig": "{\"Privileged\":false,\"ReadonlyRootfs\":false,\"Dns\":[],\"DnsSearch\":[],\"ExtraHosts\":[],\"SecurityOpt\":[],\"LogConfig\":{\"Type\":\"awslogs\",\"Config\":{\"awslogs-group\":\"tutorial-wordpress\",\"awslogs-stream\":\"wordpress/wordpress/4df3bcd3-e82b-4163-8657-00806b6c4ddd\",\"awslogs-region\":\"us-east-1\"}},\"CapAdd\":[],\"CapDrop\":[],\"Devices\":[]}",
+              "version": "1.19"
+            },
+            "registryAuthentication": null,
+            "LogsAuthStrategy": "",
+            "desiredStatus": "STOPPED",
+            "KnownStatus": "STOPPED",
+            "TransitionDependencySet": {
+              "1": {
+                "ContainerDependencies": null,
+                "ResourceDependencies": [
+                  {
+                    "Name": "cgroup",
+                    "RequiredStatus": 1
+                  }
+                ]
+              }
+            },
+            "RunDependencies": null,
+            "IsInternal": "NORMAL",
+            "ApplyingError": null,
+            "SentStatus": "STOPPED",
+            "metadataFileUpdated": false,
+            "KnownExitCode": 0,
+            "KnownPortBindings": [
+              {
+                "ContainerPort": 80,
+                "HostPort": 80,
+                "BindIp": "0.0.0.0",
+                "Protocol": "tcp"
+              }
+            ]
+          }
+        },
+        "48f328a4b3cf0e20bd1b8c28f771fd7ea00f6a4b5154e4c0c1b59d638049e212": {
+          "DockerId": "48f328a4b3cf0e20bd1b8c28f771fd7ea00f6a4b5154e4c0c1b59d638049e212",
+          "DockerName": "ecs-test_ecs_agent_volume-3-mysql-88c3d896c6d0e0aa8301",
+          "Container": {
+            "Name": "mysql",
+            "Image": "mysql:5.7",
+            "ImageID": "sha256:43b029b6b6406b40f1ba51b069980b5c14b701786830a41ebb489ad3bbf3d928",
+            "Command": [],
+            "Cpu": 100,
+            "Memory": 500,
+            "Links": [],
+            "volumesFrom": [],
+            "mountPoints": [
+              {
+                "sourceVolume": "database_scratch",
+                "containerPath": "/var/scratch",
+                "readOnly": false
+              }
+            ],
+            "portMappings": [],
+            "Essential": true,
+            "EntryPoint": null,
+            "environment": {
+              "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI": "/v2/credentials/cfc30f23-a1dc-426c-9baa-5542a0f972c7",
+              "MYSQL_ROOT_PASSWORD": "password"
+            },
+            "overrides": {
+              "command": null
+            },
+            "dockerConfig": {
+              "config": "{}",
+              "hostConfig": "{\"Privileged\":false,\"ReadonlyRootfs\":false,\"Dns\":[],\"DnsSearch\":[],\"SecurityOpt\":[],\"LogConfig\":{\"Type\":\"awslogs\",\"Config\":{\"awslogs-group\":\"tutorial-mysql\",\"awslogs-stream\":\"mysql/mysql/07561700-2a73-4b23-97a7-1335841dc1b5\",\"awslogs-region\":\"us-east-1\"}},\"CapAdd\":[],\"CapDrop\":[]}",
+              "version": "1.19"
+            },
+            "registryAuthentication": null,
+            "LogsAuthStrategy": "ExecutionRole",
+            "desiredStatus": "STOPPED",
+            "KnownStatus": "STOPPED",
+            "TransitionDependencySet": {
+              "1": {
+                "ContainerDependencies": null,
+                "ResourceDependencies": [
+                  {
+                    "Name": "cgroup",
+                    "RequiredStatus": 1
+                  },
+                  {
+                    "Name": "database_scratch",
+                    "RequiredStatus": 1
+                  }
+                ]
+              }
+            },
+            "RunDependencies": null,
+            "IsInternal": "NORMAL",
+            "ApplyingError": null,
+            "SentStatus": "STOPPED",
+            "metadataFileUpdated": false,
+            "KnownExitCode": 0,
+            "KnownPortBindings": null
+          }
+        },
+        "4ad79b0c31b196a52ef5a9b21f25cfb7c4e73fc139e5693a1b98afdeb2a52e95": {
+          "DockerId": "4ad79b0c31b196a52ef5a9b21f25cfb7c4e73fc139e5693a1b98afdeb2a52e95",
+          "DockerName": "ecs-test_ecs_agent_volume-1-wordpress-b4b8aee28fa7a3936e00",
+          "Container": {
+            "Name": "wordpress",
+            "Image": "wordpress",
+            "ImageID": "sha256:41e689eea0cdaab1280ed184f117171f0897a9353b3bd4cc321f0839d4027511",
+            "Command": [],
+            "Cpu": 100,
+            "Memory": 500,
+            "Links": [
+              "mysql"
+            ],
+            "volumesFrom": [],
+            "mountPoints": [],
+            "portMappings": [
+              {
+                "ContainerPort": 80,
+                "HostPort": 80,
+                "BindIp": "",
+                "Protocol": "tcp"
+              }
+            ],
+            "Essential": true,
+            "EntryPoint": null,
+            "environment": {
+              "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI": "/v2/credentials/9203b948-8e5c-4efc-953d-0d2ffcbdc9cc"
+            },
+            "overrides": {
+              "command": null
+            },
+            "dockerConfig": {
+              "config": "{}",
+              "hostConfig": "{\"Privileged\":false,\"ReadonlyRootfs\":false,\"Dns\":[],\"DnsSearch\":[],\"SecurityOpt\":[],\"LogConfig\":{\"Type\":\"awslogs\",\"Config\":{\"awslogs-group\":\"tutorial-wordpress\",\"awslogs-stream\":\"wordpress/wordpress/2ed4780b-5007-4684-9df9-93ea12a36d0a\",\"awslogs-region\":\"us-east-1\"}},\"CapAdd\":[],\"CapDrop\":[]}",
+              "version": "1.25"
+            },
+            "registryAuthentication": null,
+            "LogsAuthStrategy": "ExecutionRole",
+            "desiredStatus": "STOPPED",
+            "KnownStatus": "STOPPED",
+            "TransitionDependencySet": {
+              "1": {
+                "ContainerDependencies": null,
+                "ResourceDependencies": [
+                  {
+                    "Name": "cgroup",
+                    "RequiredStatus": 1
+                  }
+                ]
+              }
+            },
+            "RunDependencies": null,
+            "IsInternal": "NORMAL",
+            "ApplyingError": null,
+            "SentStatus": "STOPPED",
+            "metadataFileUpdated": false,
+            "KnownExitCode": 0,
+            "KnownPortBindings": [
+              {
+                "ContainerPort": 80,
+                "HostPort": 80,
+                "BindIp": "0.0.0.0",
+                "Protocol": "tcp"
+              }
+            ]
+          }
+        },
+        "70a0c660570fda4723fd5fe3850910417047806b9fdf187f2040c974dc2c9ec5": {
+          "DockerId": "70a0c660570fda4723fd5fe3850910417047806b9fdf187f2040c974dc2c9ec5",
+          "DockerName": "ecs-test_ecs_agent_volume-4-web-a2b69bc99990fdaacf01",
+          "Container": {
+            "Name": "web",
+            "Image": "nginx",
+            "ImageID": "sha256:71c43202b8ac897ff4d048d3b37bdf4eb543ec5c03fd017c3e12c616c6792206",
+            "Command": null,
+            "Cpu": 100,
+            "Memory": 100,
+            "Links": null,
+            "volumesFrom": [],
+            "mountPoints": [
+              {
+                "sourceVolume": "webdata",
+                "containerPath": "/usr/share/nginx/html",
+                "readOnly": false
+              }
+            ],
+            "portMappings": [],
+            "Essential": true,
+            "EntryPoint": null,
+            "environment": {
+              "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI": "/v2/credentials/9878f2d2-4c20-4ea3-875e-f44cc9c86bdb"
+            },
+            "overrides": {
+              "command": null
+            },
+            "dockerConfig": {
+              "config": "{}",
+              "hostConfig": "{\"CapAdd\":[],\"CapDrop\":[]}",
+              "version": "1.17"
+            },
+            "registryAuthentication": null,
+            "LogsAuthStrategy": "",
+            "desiredStatus": "RUNNING",
+            "KnownStatus": "RUNNING",
+            "TransitionDependencySet": {
+              "1": {
+                "ContainerDependencies": null,
+                "ResourceDependencies": [
+                  {
+                    "Name": "cgroup",
+                    "RequiredStatus": 1
+                  }
+                ]
+              }
+            },
+            "RunDependencies": null,
+            "IsInternal": "NORMAL",
+            "ApplyingError": null,
+            "SentStatus": "RUNNING",
+            "metadataFileUpdated": false,
+            "KnownExitCode": null,
+            "KnownPortBindings": null
+          }
+        },
+        "7f6c84edd68a793cb01b853ffe562983ca6263e9d7b1eacaa08bd8f965fc40b2": {
+          "DockerId": "7f6c84edd68a793cb01b853ffe562983ca6263e9d7b1eacaa08bd8f965fc40b2",
+          "DockerName": "ecs-test_ecs_agent_volume-3-wordpress-e6e6efe9a2e8fea00e00",
+          "Container": {
+            "Name": "wordpress",
+            "Image": "wordpress",
+            "ImageID": "sha256:41e689eea0cdaab1280ed184f117171f0897a9353b3bd4cc321f0839d4027511",
+            "Command": [],
+            "Cpu": 100,
+            "Memory": 500,
+            "Links": [
+              "mysql"
+            ],
+            "volumesFrom": [],
+            "mountPoints": [
+              {
+                "sourceVolume": "database_scratch",
+                "containerPath": "/var/scratch",
+                "readOnly": false
+              }
+            ],
+            "portMappings": [
+              {
+                "ContainerPort": 80,
+                "HostPort": 80,
+                "BindIp": "",
+                "Protocol": "tcp"
+              }
+            ],
+            "Essential": true,
+            "EntryPoint": null,
+            "environment": {
+              "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI": "/v2/credentials/cfc30f23-a1dc-426c-9baa-5542a0f972c7"
+            },
+            "overrides": {
+              "command": null
+            },
+            "dockerConfig": {
+              "config": "{}",
+              "hostConfig": "{\"Privileged\":false,\"ReadonlyRootfs\":false,\"Dns\":[],\"DnsSearch\":[],\"SecurityOpt\":[],\"LogConfig\":{\"Type\":\"awslogs\",\"Config\":{\"awslogs-group\":\"tutorial-wordpress\",\"awslogs-stream\":\"wordpress/wordpress/07561700-2a73-4b23-97a7-1335841dc1b5\",\"awslogs-region\":\"us-east-1\"}},\"CapAdd\":[],\"CapDrop\":[]}",
+              "version": "1.19"
+            },
+            "registryAuthentication": null,
+            "LogsAuthStrategy": "ExecutionRole",
+            "desiredStatus": "STOPPED",
+            "KnownStatus": "STOPPED",
+            "TransitionDependencySet": {
+              "1": {
+                "ContainerDependencies": null,
+                "ResourceDependencies": [
+                  {
+                    "Name": "cgroup",
+                    "RequiredStatus": 1
+                  },
+                  {
+                    "Name": "database_scratch",
+                    "RequiredStatus": 1
+                  }
+                ]
+              }
+            },
+            "RunDependencies": null,
+            "IsInternal": "NORMAL",
+            "ApplyingError": null,
+            "SentStatus": "STOPPED",
+            "metadataFileUpdated": false,
+            "KnownExitCode": 0,
+            "KnownPortBindings": [
+              {
+                "ContainerPort": 80,
+                "HostPort": 80,
+                "BindIp": "0.0.0.0",
+                "Protocol": "tcp"
+              }
+            ]
+          }
+        },
+        "9c055b417f3ac9e8bd9bd2f410621513fde8d21b6badfa2e1353e03acdfb183c": {
+          "DockerId": "9c055b417f3ac9e8bd9bd2f410621513fde8d21b6badfa2e1353e03acdfb183c",
+          "DockerName": "ecs-test_ecs_agent_volume-1-mysql-96828abf899894cd2200",
+          "Container": {
+            "Name": "mysql",
+            "Image": "mysql:5.7",
+            "ImageID": "sha256:43b029b6b6406b40f1ba51b069980b5c14b701786830a41ebb489ad3bbf3d928",
+            "Command": [],
+            "Cpu": 100,
+            "Memory": 500,
+            "Links": [],
+            "volumesFrom": [],
+            "mountPoints": [],
+            "portMappings": [],
+            "Essential": true,
+            "EntryPoint": null,
+            "environment": {
+              "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI": "/v2/credentials/9203b948-8e5c-4efc-953d-0d2ffcbdc9cc",
+              "MYSQL_ROOT_PASSWORD": "password"
+            },
+            "overrides": {
+              "command": null
+            },
+            "dockerConfig": {
+              "config": "{}",
+              "hostConfig": "{\"Privileged\":false,\"ReadonlyRootfs\":false,\"Dns\":[],\"DnsSearch\":[],\"SecurityOpt\":[],\"LogConfig\":{\"Type\":\"awslogs\",\"Config\":{\"awslogs-group\":\"tutorial-mysql\",\"awslogs-stream\":\"mysql/mysql/2ed4780b-5007-4684-9df9-93ea12a36d0a\",\"awslogs-region\":\"us-east-1\"}},\"CapAdd\":[],\"CapDrop\":[]}",
+              "version": "1.25"
+            },
+            "registryAuthentication": null,
+            "LogsAuthStrategy": "ExecutionRole",
+            "desiredStatus": "STOPPED",
+            "KnownStatus": "STOPPED",
+            "TransitionDependencySet": {
+              "1": {
+                "ContainerDependencies": null,
+                "ResourceDependencies": [
+                  {
+                    "Name": "cgroup",
+                    "RequiredStatus": 1
+                  }
+                ]
+              }
+            },
+            "RunDependencies": null,
+            "IsInternal": "NORMAL",
+            "ApplyingError": null,
+            "SentStatus": "STOPPED",
+            "metadataFileUpdated": false,
+            "KnownExitCode": 0,
+            "KnownPortBindings": null
+          }
+        },
+        "a8339115667b86946178395c2c1f612877441fbbb9c2befa2fa3622792363995": {
+          "DockerId": "a8339115667b86946178395c2c1f612877441fbbb9c2befa2fa3622792363995",
+          "DockerName": "ecs-test_ecs_agent_volume-2-mysql-d8a5dffe93fee3a45900",
+          "Container": {
+            "Name": "mysql",
+            "Image": "mysql:5.7",
+            "ImageID": "sha256:43b029b6b6406b40f1ba51b069980b5c14b701786830a41ebb489ad3bbf3d928",
+            "Command": [],
+            "Cpu": 100,
+            "Memory": 500,
+            "Links": [],
+            "volumesFrom": [],
+            "mountPoints": [
+              {
+                "sourceVolume": "database_scratch",
+                "containerPath": "/var/scratch",
+                "readOnly": false
+              }
+            ],
+            "portMappings": [],
+            "Essential": true,
+            "EntryPoint": null,
+            "environment": {
+              "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI": "/v2/credentials/c8d7f417-fc5f-47e4-b2de-b2e01735e541",
+              "MYSQL_ROOT_PASSWORD": "password"
+            },
+            "overrides": {
+              "command": null
+            },
+            "dockerConfig": {
+              "config": "{}",
+              "hostConfig": "{\"Privileged\":false,\"ReadonlyRootfs\":false,\"Dns\":[],\"DnsSearch\":[],\"SecurityOpt\":[],\"LogConfig\":{\"Type\":\"awslogs\",\"Config\":{\"awslogs-group\":\"tutorial-mysql\",\"awslogs-stream\":\"mysql/mysql/8905424a-575a-4185-aeeb-15a58abd1112\",\"awslogs-region\":\"us-east-1\"}},\"CapAdd\":[],\"CapDrop\":[]}",
+              "version": "1.19"
+            },
+            "registryAuthentication": null,
+            "LogsAuthStrategy": "ExecutionRole",
+            "desiredStatus": "STOPPED",
+            "KnownStatus": "STOPPED",
+            "TransitionDependencySet": {
+              "1": {
+                "ContainerDependencies": null,
+                "ResourceDependencies": [
+                  {
+                    "Name": "cgroup",
+                    "RequiredStatus": 1
+                  },
+                  {
+                    "Name": "database_scratch",
+                    "RequiredStatus": 1
+                  }
+                ]
+              }
+            },
+            "RunDependencies": null,
+            "IsInternal": "NORMAL",
+            "ApplyingError": null,
+            "SentStatus": "STOPPED",
+            "metadataFileUpdated": false,
+            "KnownExitCode": 0,
+            "KnownPortBindings": null
+          }
+        },
+        "b740715aba5edb16ca7a437b0d8e8e99c07d3378b5acd9929ff9fd6fb1b10329": {
+          "DockerId": "b740715aba5edb16ca7a437b0d8e8e99c07d3378b5acd9929ff9fd6fb1b10329",
+          "DockerName": "ecs-test_ecs_agent_volume-4-mysql-acb0cce2e1cafdb43400",
+          "Container": {
+            "Name": "mysql",
+            "Image": "mysql:5.7",
+            "ImageID": "sha256:43b029b6b6406b40f1ba51b069980b5c14b701786830a41ebb489ad3bbf3d928",
+            "Command": [],
+            "Cpu": 100,
+            "Memory": 500,
+            "Links": [],
+            "volumesFrom": [
+              {
+                "sourceContainer": "web",
+                "readOnly": false
+              }
+            ],
+            "mountPoints": [
+              {
+                "sourceVolume": "database_scratch",
+                "containerPath": "/var/scratch",
+                "readOnly": false
+              }
+            ],
+            "portMappings": [],
+            "Essential": true,
+            "EntryPoint": null,
+            "environment": {
+              "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI": "/v2/credentials/9878f2d2-4c20-4ea3-875e-f44cc9c86bdb",
+              "MYSQL_ROOT_PASSWORD": "password"
+            },
+            "overrides": {
+              "command": null
+            },
+            "dockerConfig": {
+              "config": "{}",
+              "hostConfig": "{\"Privileged\":false,\"ReadonlyRootfs\":false,\"Dns\":[],\"DnsSearch\":[],\"SecurityOpt\":[],\"LogConfig\":{\"Type\":\"awslogs\",\"Config\":{\"awslogs-group\":\"tutorial-mysql\",\"awslogs-stream\":\"mysql/mysql/5e9f6adb-2a02-48db-860f-41e12c4ced32\",\"awslogs-region\":\"us-east-1\"}},\"CapAdd\":[],\"CapDrop\":[]}",
+              "version": "1.19"
+            },
+            "registryAuthentication": null,
+            "LogsAuthStrategy": "ExecutionRole",
+            "desiredStatus": "RUNNING",
+            "KnownStatus": "RUNNING",
+            "TransitionDependencySet": {
+              "1": {
+                "ContainerDependencies": null,
+                "ResourceDependencies": [
+                  {
+                    "Name": "cgroup",
+                    "RequiredStatus": 1
+                  },
+                  {
+                    "Name": "database_scratch",
+                    "RequiredStatus": 1
+                  }
+                ]
+              }
+            },
+            "RunDependencies": null,
+            "IsInternal": "NORMAL",
+            "ApplyingError": null,
+            "SentStatus": "RUNNING",
+            "metadataFileUpdated": false,
+            "KnownExitCode": null,
+            "KnownPortBindings": null
+          }
+        },
+        "ddc3fe26a2d386c4a78ef07e5de02fa883ae17c094836490a1950afb77a3d1e0": {
+          "DockerId": "ddc3fe26a2d386c4a78ef07e5de02fa883ae17c094836490a1950afb77a3d1e0",
+          "DockerName": "ecs-test_ecs_agent_volume-2-wordpress-96d892e7cf89a1db5400",
+          "Container": {
+            "Name": "wordpress",
+            "Image": "wordpress",
+            "ImageID": "sha256:41e689eea0cdaab1280ed184f117171f0897a9353b3bd4cc321f0839d4027511",
+            "Command": [],
+            "Cpu": 100,
+            "Memory": 500,
+            "Links": [
+              "mysql"
+            ],
+            "volumesFrom": [],
+            "mountPoints": [
+              {
+                "sourceVolume": "database_scratch",
+                "containerPath": "/var/scratch",
+                "readOnly": false
+              }
+            ],
+            "portMappings": [
+              {
+                "ContainerPort": 80,
+                "HostPort": 80,
+                "BindIp": "",
+                "Protocol": "tcp"
+              }
+            ],
+            "Essential": true,
+            "EntryPoint": null,
+            "environment": {
+              "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI": "/v2/credentials/c8d7f417-fc5f-47e4-b2de-b2e01735e541"
+            },
+            "overrides": {
+              "command": null
+            },
+            "dockerConfig": {
+              "config": "{}",
+              "hostConfig": "{\"Privileged\":false,\"ReadonlyRootfs\":false,\"Dns\":[],\"DnsSearch\":[],\"SecurityOpt\":[],\"LogConfig\":{\"Type\":\"awslogs\",\"Config\":{\"awslogs-group\":\"tutorial-wordpress\",\"awslogs-stream\":\"wordpress/wordpress/8905424a-575a-4185-aeeb-15a58abd1112\",\"awslogs-region\":\"us-east-1\"}},\"CapAdd\":[],\"CapDrop\":[]}",
+              "version": "1.19"
+            },
+            "registryAuthentication": null,
+            "LogsAuthStrategy": "ExecutionRole",
+            "desiredStatus": "STOPPED",
+            "KnownStatus": "STOPPED",
+            "TransitionDependencySet": {
+              "1": {
+                "ContainerDependencies": null,
+                "ResourceDependencies": [
+                  {
+                    "Name": "cgroup",
+                    "RequiredStatus": 1
+                  },
+                  {
+                    "Name": "database_scratch",
+                    "RequiredStatus": 1
+                  }
+                ]
+              }
+            },
+            "RunDependencies": null,
+            "IsInternal": "NORMAL",
+            "ApplyingError": null,
+            "SentStatus": "STOPPED",
+            "metadataFileUpdated": false,
+            "KnownExitCode": 0,
+            "KnownPortBindings": [
+              {
+                "ContainerPort": 80,
+                "HostPort": 80,
+                "BindIp": "0.0.0.0",
+                "Protocol": "tcp"
+              }
+            ]
+          }
+        },
+        "e9825dcf2be29cd2b315f0d7dc12122fa5147ac3e5d850e6067c08e59054eb10": {
+          "DockerId": "e9825dcf2be29cd2b315f0d7dc12122fa5147ac3e5d850e6067c08e59054eb10",
+          "DockerName": "ecs-test_ecs_agent_volume-3-web-de8aed84b0feddd54800",
+          "Container": {
+            "Name": "web",
+            "Image": "nginx",
+            "ImageID": "sha256:71c43202b8ac897ff4d048d3b37bdf4eb543ec5c03fd017c3e12c616c6792206",
+            "Command": null,
+            "Cpu": 100,
+            "Memory": 100,
+            "Links": null,
+            "volumesFrom": [],
+            "mountPoints": [
+              {
+                "sourceVolume": "webdata",
+                "containerPath": "/usr/share/nginx/html",
+                "readOnly": false
+              }
+            ],
+            "portMappings": [],
+            "Essential": true,
+            "EntryPoint": null,
+            "environment": {
+              "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI": "/v2/credentials/cfc30f23-a1dc-426c-9baa-5542a0f972c7"
+            },
+            "overrides": {
+              "command": null
+            },
+            "dockerConfig": {
+              "config": "{}",
+              "hostConfig": "{\"CapAdd\":[],\"CapDrop\":[]}",
+              "version": "1.17"
+            },
+            "registryAuthentication": null,
+            "LogsAuthStrategy": "",
+            "desiredStatus": "STOPPED",
+            "KnownStatus": "STOPPED",
+            "TransitionDependencySet": {
+              "1": {
+                "ContainerDependencies": null,
+                "ResourceDependencies": [
+                  {
+                    "Name": "cgroup",
+                    "RequiredStatus": 1
+                  }
+                ]
+              }
+            },
+            "RunDependencies": null,
+            "IsInternal": "NORMAL",
+            "ApplyingError": null,
+            "SentStatus": "STOPPED",
+            "metadataFileUpdated": false,
+            "KnownExitCode": 0,
+            "KnownPortBindings": null
+          }
+        }
+      },
+      "IdToTask": {
+        "0431789e4b25f9bcaceffcd95ff5b966f49e50b04ee0fd165944cb33d709ffd8": "arn:aws:ecs:us-west-2:694464167470:task/5e9f6adb-2a02-48db-860f-41e12c4ced32",
+        "35eb8db23206ee8213b481d055d48521095fc58b8dac6f00b5925f27ccf41668": "arn:aws:ecs:us-west-2:694464167470:task/4df3bcd3-e82b-4163-8657-00806b6c4ddd",
+        "3989b97524fc7f7125b461dec17c0732e9b951fe8bb8a6c14a7d82c952e9816e": "arn:aws:ecs:us-west-2:694464167470:task/4df3bcd3-e82b-4163-8657-00806b6c4ddd",
+        "48f328a4b3cf0e20bd1b8c28f771fd7ea00f6a4b5154e4c0c1b59d638049e212": "arn:aws:ecs:us-west-2:694464167470:task/07561700-2a73-4b23-97a7-1335841dc1b5",
+        "4ad79b0c31b196a52ef5a9b21f25cfb7c4e73fc139e5693a1b98afdeb2a52e95": "arn:aws:ecs:us-west-2:694464167470:task/2ed4780b-5007-4684-9df9-93ea12a36d0a",
+        "70a0c660570fda4723fd5fe3850910417047806b9fdf187f2040c974dc2c9ec5": "arn:aws:ecs:us-west-2:694464167470:task/5e9f6adb-2a02-48db-860f-41e12c4ced32",
+        "7f6c84edd68a793cb01b853ffe562983ca6263e9d7b1eacaa08bd8f965fc40b2": "arn:aws:ecs:us-west-2:694464167470:task/07561700-2a73-4b23-97a7-1335841dc1b5",
+        "9c055b417f3ac9e8bd9bd2f410621513fde8d21b6badfa2e1353e03acdfb183c": "arn:aws:ecs:us-west-2:694464167470:task/2ed4780b-5007-4684-9df9-93ea12a36d0a",
+        "a8339115667b86946178395c2c1f612877441fbbb9c2befa2fa3622792363995": "arn:aws:ecs:us-west-2:694464167470:task/8905424a-575a-4185-aeeb-15a58abd1112",
+        "b740715aba5edb16ca7a437b0d8e8e99c07d3378b5acd9929ff9fd6fb1b10329": "arn:aws:ecs:us-west-2:694464167470:task/5e9f6adb-2a02-48db-860f-41e12c4ced32",
+        "ddc3fe26a2d386c4a78ef07e5de02fa883ae17c094836490a1950afb77a3d1e0": "arn:aws:ecs:us-west-2:694464167470:task/8905424a-575a-4185-aeeb-15a58abd1112",
+        "e9825dcf2be29cd2b315f0d7dc12122fa5147ac3e5d850e6067c08e59054eb10": "arn:aws:ecs:us-west-2:694464167470:task/07561700-2a73-4b23-97a7-1335841dc1b5"
+      },
+      "ImageStates": [
+        {
+          "Image": {
+            "ImageID": "sha256:43b029b6b6406b40f1ba51b069980b5c14b701786830a41ebb489ad3bbf3d928",
+            "Names": [
+              "mysql:5.7"
+            ],
+            "Size": 372018417
+          },
+          "PulledAt": "2018-08-29T21:57:31.097572576Z",
+          "LastUsedAt": "2018-08-29T21:57:31.097573818Z",
+          "PullSucceeded": true
+        },
+        {
+          "Image": {
+            "ImageID": "sha256:3745a1731caf02a64618ba59dc8ea194de0d09d371f3f570e2a10902fdb5c9a8",
+            "Names": [],
+            "Size": 408052303
+          },
+          "PulledAt": "2018-08-29T21:57:52.130592565Z",
+          "LastUsedAt": "2018-08-29T21:57:52.130593862Z",
+          "PullSucceeded": true
+        },
+        {
+          "Image": {
+            "ImageID": "sha256:41e689eea0cdaab1280ed184f117171f0897a9353b3bd4cc321f0839d4027511",
+            "Names": [
+              "wordpress"
+            ],
+            "Size": 408052303
+          },
+          "PulledAt": "2018-09-04T21:24:06.719607322Z",
+          "LastUsedAt": "2018-09-04T21:24:06.719608614Z",
+          "PullSucceeded": true
+        },
+        {
+          "Image": {
+            "ImageID": "sha256:71c43202b8ac897ff4d048d3b37bdf4eb543ec5c03fd017c3e12c616c6792206",
+            "Names": [
+              "nginx"
+            ],
+            "Size": 109037164
+          },
+          "PulledAt": "2018-09-04T23:37:57.26769346Z",
+          "LastUsedAt": "2018-09-04T23:37:57.267694871Z",
+          "PullSucceeded": true
+        }
+      ],
+      "ENIAttachments": null,
+      "IPToTask": {}
+    }
+  },
+  "Version": 13
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This pull request adds the unit tests that validate the version 13 state file is correct.  

- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->


### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
