### PR TITLE
Merging dev into moby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Changelog
 
-## 1.21.0-dev
+## 1.20.2-dev
+* Enhancement - Added ECS config field `ECS_SHARED_VOLUME_MATCH_FULL_CONFIG` to
+make the volume labels and driver options comparison configurable for shared volume [#1519](https://github.com/aws/amazon-ecs-agent/pull/1519)
+* Enhancement - Added Volumes metadata as part of v1 and v2 metadata endpoints [#1531](https://github.com/aws/amazon-ecs-agent/pull/1531)
 * Bug - Fixed a bug where unrecognized task cannot be stopped [#1467](https://github.com/aws/amazon-ecs-agent/pull/1467)
+* Bug - Fixed a bug where tasks with CPU windows unbounded field set are not honored
+on restart due to non-persistence of `PlatformFields` in agent state file [@julienduchesne](https://github.com/julienduchesne) [#1480](https://github.com/aws/amazon-ecs-agent/pull/1480)
 
 ## 1.20.1
 * Bug - Fixed a bug where the agent couldn't be upgraded if there are tasks that

--- a/Makefile
+++ b/Makefile
@@ -228,7 +228,7 @@ run-sudo-tests:
 	. ./scripts/shared_env && sudo -E ${GO_EXECUTABLE} test -race -tags sudo -timeout=1m -v ./agent/engine/...
 
 .PHONY: codebuild
-codebuild: get-deps test-artifacts .out-stamp
+codebuild: test-artifacts .out-stamp
 	$(MAKE) release TARGET_OS="linux"
 	TARGET_OS="linux" ./scripts/local-save
 	$(MAKE) docker-release TARGET_OS="windows"

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ additional details on each available environment variable.
 | `ECS_CGROUP_PATH` | `/sys/fs/cgroup` | The root cgroup path that is expected by the ECS agent. This is the path that accessible from the agent mount. | `/sys/fs/cgroup` | Not applicable |
 | `ECS_ENABLE_CPU_UNBOUNDED_WINDOWS_WORKAROUND` | `true` | When `true`, ECS will allow CPU unbounded(CPU=`0`) tasks to run along with CPU bounded tasks in Windows. | Not applicable | `false` |
 | `ECS_TASK_METADATA_RPS_LIMIT` | `100,150` | Comma separated integer values for steady state and burst throttle limits for task metadata endpoint | `40,60` | `40,60` |
+| `ECS_SHARED_VOLUME_MATCH_FULL_CONFIG` | `true` | When `true`, ECS Agent will compare name, driver options, and labels to make sure volumes are identical. When `false`, Agent will short circuit shared volume comparison if the names match. This is the default Docker behavior. If a volume is shared across instances, this should be set to `false`. | `false` | `false`|
 
 ### Persistence
 

--- a/agent/acs/handler/acs_handler.go
+++ b/agent/acs/handler/acs_handler.go
@@ -240,7 +240,7 @@ func (acsSession *session) Start() error {
 func (acsSession *session) startSessionOnce() error {
 	acsEndpoint, err := acsSession.ecsClient.DiscoverPollEndpoint(acsSession.containerInstanceARN)
 	if err != nil {
-		seelog.Errorf("Unable to discover poll endpoint, err: %v", err)
+		seelog.Errorf("acs: unable to discover poll endpoint, err: %v", err)
 		return err
 	}
 

--- a/agent/api/container/container.go
+++ b/agent/api/container/container.go
@@ -190,6 +190,9 @@ type Container struct {
 	// KnownPortBindingsUnsafe is an array of port bindings for the container.
 	KnownPortBindingsUnsafe []PortBinding `json:"KnownPortBindings"`
 
+	// VolumesUnsafe is an array of volume mounts in the container.
+	VolumesUnsafe []types.MountPoint `json:"-"`
+
 	// SteadyStateStatusUnsafe specifies the steady state status for the container
 	// If uninitialized, it's assumed to be set to 'ContainerRunning'. Even though
 	// it's not only supposed to be set when the container is being created, it's
@@ -533,6 +536,22 @@ func (c *Container) GetKnownPortBindings() []PortBinding {
 	defer c.lock.RUnlock()
 
 	return c.KnownPortBindingsUnsafe
+}
+
+// SetVolumes sets the volumes mounted in a container
+func (c *Container) SetVolumes(volumes []types.MountPoint) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	c.VolumesUnsafe = volumes
+}
+
+// GetVolumes returns the volumes mounted in a container
+func (c *Container) GetVolumes() []types.MountPoint {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	return c.VolumesUnsafe
 }
 
 // HealthStatusShouldBeReported returns true if the health check is defined in

--- a/agent/api/task/task_linux.go
+++ b/agent/api/task/task_linux.go
@@ -42,8 +42,8 @@ const (
 	bytesPerMegabyte  = 1024 * 1024
 )
 
-// platformFields consists of fields specific to Linux for a task
-type platformFields struct{}
+// PlatformFields consists of fields specific to Linux for a task
+type PlatformFields struct{}
 
 func (task *Task) adjustForPlatform(cfg *config.Config) {
 	task.lock.Lock()

--- a/agent/api/task/task_unsupported.go
+++ b/agent/api/task/task_unsupported.go
@@ -35,8 +35,8 @@ const (
 	bytesPerMegabyte  = 1024 * 1024
 )
 
-// platformFields consists of fields specific to Linux for a task
-type platformFields struct{}
+// PlatformFields consists of fields specific to Linux for a task
+type PlatformFields struct{}
 
 func (task *Task) adjustForPlatform(cfg *config.Config) {
 	task.lock.Lock()

--- a/agent/api/task/task_windows.go
+++ b/agent/api/task/task_windows.go
@@ -35,11 +35,11 @@ const (
 	minimumCPUPercent = 1
 )
 
-// platformFields consists of fields specific to Windows for a task
-type platformFields struct {
-	// cpuUnbounded determines whether a mix of unbounded and bounded CPU tasks
+// PlatformFields consists of fields specific to Windows for a task
+type PlatformFields struct {
+	// CpuUnbounded determines whether a mix of unbounded and bounded CPU tasks
 	// are allowed to run in the instance
-	cpuUnbounded bool
+	CpuUnbounded bool `json:"cpuUnbounded"`
 }
 
 var cpuShareScaleFactor = runtime.NumCPU() * cpuSharesPerCore
@@ -47,10 +47,10 @@ var cpuShareScaleFactor = runtime.NumCPU() * cpuSharesPerCore
 // adjustForPlatform makes Windows-specific changes to the task after unmarshal
 func (task *Task) adjustForPlatform(cfg *config.Config) {
 	task.downcaseAllVolumePaths()
-	platformFields := platformFields{
-		cpuUnbounded: cfg.PlatformVariables.CPUUnbounded,
+	platformFields := PlatformFields{
+		CpuUnbounded: cfg.PlatformVariables.CPUUnbounded,
 	}
-	task.platformFields = platformFields
+	task.PlatformFields = platformFields
 }
 
 // downcaseAllVolumePaths forces all volume paths (host path and container path)
@@ -96,7 +96,7 @@ func (task *Task) platformHostConfigOverride(hostConfig *dockercontainer.HostCon
 // want.  Instead, we convert 0 to 2 to be closer to expected behavior. The
 // reason for 2 over 1 is that 1 is an invalid value (Linux's choice, not Docker's).
 func (task *Task) dockerCPUShares(containerCPU uint) int64 {
-	if containerCPU <= 1 && !task.platformFields.cpuUnbounded {
+	if containerCPU <= 1 && !task.PlatformFields.CpuUnbounded {
 		seelog.Debugf(
 			"Converting CPU shares to allowed minimum of 2 for task arn: [%s] and cpu shares: %d",
 			task.Arn, containerCPU)

--- a/agent/api/task/task_windows_test.go
+++ b/agent/api/task/task_windows_test.go
@@ -226,8 +226,8 @@ func TestCPUPercentBasedOnUnboundedEnabled(t *testing.T) {
 						CPU:  uint(tc.cpu),
 					},
 				},
-				platformFields: platformFields{
-					cpuUnbounded: tc.cpuUnbounded,
+				PlatformFields: PlatformFields{
+					CpuUnbounded: tc.cpuUnbounded,
 				},
 			}
 

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -420,6 +420,7 @@ func environmentConfig() (Config, error) {
 		CgroupPath:                       os.Getenv("ECS_CGROUP_PATH"),
 		TaskMetadataSteadyStateRate:      steadyStateRate,
 		TaskMetadataBurstRate:            burstRate,
+		SharedVolumeMatchFullConfig:      utils.ParseBool(os.Getenv("ECS_SHARED_VOLUME_MATCH_FULL_CONFIG"), false),
 	}, err
 }
 

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -87,6 +87,7 @@ func TestEnvironmentConfig(t *testing.T) {
 	defer setTestEnv("ECS_INSTANCE_ATTRIBUTES", "{\"my_attribute\": \"testing\"}")()
 	defer setTestEnv("ECS_ENABLE_TASK_ENI", "true")()
 	defer setTestEnv("ECS_TASK_METADATA_RPS_LIMIT", "1000,1100")()
+	defer setTestEnv("ECS_SHARED_VOLUME_MATCH_FULL_CONFIG", "true")()
 	additionalLocalRoutesJSON := `["1.2.3.4/22","5.6.7.8/32"]`
 	setTestEnv("ECS_AWSVPC_ADDITIONAL_LOCAL_ROUTES", additionalLocalRoutesJSON)
 	setTestEnv("ECS_ENABLE_CONTAINER_METADATA", "true")
@@ -125,6 +126,7 @@ func TestEnvironmentConfig(t *testing.T) {
 	assert.True(t, conf.ContainerMetadataEnabled, "Wrong value for ContainerMetadataEnabled")
 	assert.Equal(t, 1000, conf.TaskMetadataSteadyStateRate)
 	assert.Equal(t, 1100, conf.TaskMetadataBurstRate)
+	assert.True(t, conf.SharedVolumeMatchFullConfig, "Wrong value for SharedVolumeMatchFullConfig")
 }
 
 func TestTrimWhitespaceWhenCreating(t *testing.T) {
@@ -379,6 +381,14 @@ func TestInvalidImagePullBehavior(t *testing.T) {
 	cfg, err := NewConfig(ec2.NewBlackholeEC2MetadataClient())
 	assert.NoError(t, err)
 	assert.Equal(t, cfg.ImagePullBehavior, ImagePullDefaultBehavior, "Wrong value for ImagePullBehavior")
+}
+
+func TestSharedVolumeMatchFullConfigEnabled(t *testing.T) {
+	defer setTestRegion()()
+	defer setTestEnv("ECS_SHARED_VOLUME_MATCH_FULL_CONFIG", "true")()
+	cfg, err := NewConfig(ec2.NewBlackholeEC2MetadataClient())
+	assert.NoError(t, err)
+	assert.True(t, cfg.SharedVolumeMatchFullConfig, "Wrong value for SharedVolumeMatchFullConfig")
 }
 
 func TestParseImagePullBehavior(t *testing.T) {

--- a/agent/config/config_unix.go
+++ b/agent/config/config_unix.go
@@ -68,6 +68,7 @@ func DefaultConfig() Config {
 		CgroupPath:                  defaultCgroupPath,
 		TaskMetadataSteadyStateRate: DefaultTaskMetadataSteadyStateRate,
 		TaskMetadataBurstRate:       DefaultTaskMetadataBurstRate,
+		SharedVolumeMatchFullConfig: false, // only requiring shared volumes to match on name, which is default docker behavior
 	}
 }
 

--- a/agent/config/config_unix_test.go
+++ b/agent/config/config_unix_test.go
@@ -64,6 +64,7 @@ func TestConfigDefault(t *testing.T) {
 		"Default TaskMetadataSteadyStateRate is set incorrectly")
 	assert.Equal(t, DefaultTaskMetadataBurstRate, cfg.TaskMetadataBurstRate,
 		"Default TaskMetadataBurstRate is set incorrectly")
+	assert.False(t, cfg.SharedVolumeMatchFullConfig, "Default SharedVolumeMatchFullConfig set incorrectly")
 }
 
 // TestConfigFromFile tests the configuration can be read from file

--- a/agent/config/config_windows.go
+++ b/agent/config/config_windows.go
@@ -91,6 +91,7 @@ func DefaultConfig() Config {
 		PlatformVariables:           platformVariables,
 		TaskMetadataSteadyStateRate: DefaultTaskMetadataSteadyStateRate,
 		TaskMetadataBurstRate:       DefaultTaskMetadataBurstRate,
+		SharedVolumeMatchFullConfig: false, //only requiring shared volumes to match on name, which is default docker behavior
 	}
 }
 

--- a/agent/config/config_windows_test.go
+++ b/agent/config/config_windows_test.go
@@ -58,6 +58,7 @@ func TestConfigDefault(t *testing.T) {
 		"Default TaskMetadataSteadyStateRate is set incorrectly")
 	assert.Equal(t, DefaultTaskMetadataBurstRate, cfg.TaskMetadataBurstRate,
 		"Default TaskMetadataBurstRate is set incorrectly")
+	assert.False(t, cfg.SharedVolumeMatchFullConfig, "Default SharedVolumeMatchFullConfig set incorrectly")
 }
 
 func TestConfigIAMTaskRolesReserves80(t *testing.T) {

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -218,4 +218,10 @@ type Config struct {
 
 	// TaskMetadataBurstRate specifies the burst rate throttle for the task metadata endpoint
 	TaskMetadataBurstRate int
+
+	// SharedVolumeMatchFullConfig is config option used to short-circuit volume validation against a
+	// provisioned volume, if false (default). If true, we perform deep comparison including driver options
+	// and labels. For comparing shared volume across 2 instances, this should be set to false as docker's
+	// default behavior is to match name only, and does not propagate driver options and labels through volume drivers.
+	SharedVolumeMatchFullConfig bool
 }

--- a/agent/dockerclient/dockerapi/docker_client.go
+++ b/agent/dockerclient/dockerapi/docker_client.go
@@ -408,7 +408,6 @@ func (dg *dockerGoClient) pullImage(image string, authData *apicontainer.Registr
 	// TODO Migrate Pull Image once Inactivity Timeout is sorted out
 	go func() {
 		pullFinished <- client.PullImage(opts, authConfig)
-		seelog.Debugf("DockerGoClient: pulling image complete: %s", image)
 	}()
 
 	select {
@@ -418,17 +417,19 @@ func (dg *dockerGoClient) pullImage(image string, authData *apicontainer.Registr
 		if pullErr != nil {
 			return CannotPullContainerError{pullErr}
 		}
+		seelog.Debugf("DockerGoClient: pulling image complete: %s", image)
 		return nil
 	case <-timeout:
 		return &DockerTimeoutError{dockerPullBeginTimeout, "pullBegin"}
 	}
 	seelog.Debugf("DockerGoClient: pull began for image: %s", image)
-	defer seelog.Debugf("DockerGoClient: pull completed for image: %s", image)
 
 	err = <-pullFinished
 	if err != nil {
 		return CannotPullContainerError{err}
 	}
+
+	seelog.Debugf("DockerGoClient: pulling image complete: %s", image)
 	return nil
 }
 

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -336,8 +336,12 @@ func updateContainerMetadata(metadata *dockerapi.DockerContainerMetadata, contai
 	}
 
 	// Update volume for empty volume container
-	if metadata.Volumes != nil && container.IsInternal() {
-		task.UpdateMountPoints(container, metadata.Volumes)
+	if metadata.Volumes != nil {
+		if container.IsInternal() {
+			task.UpdateMountPoints(container, metadata.Volumes)
+		} else {
+			container.SetVolumes(metadata.Volumes)
+		}
 	}
 
 	// Set Exitcode if it's not set

--- a/agent/functional_tests/testdata/taskdefinitions/agent-introspection-validator/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/agent-introspection-validator/task-definition.json
@@ -12,6 +12,21 @@
             "awslogs-region":"$$$TEST_REGION$$$",
             "awslogs-stream-prefix":"ecs-functional-tests-agent-introspection-validator"
         }
-    }
-  }]
+    },
+    "mountPoints": [
+        {
+          "sourceVolume": "task-local",
+          "containerPath": "/ecs/"
+        }
+    ]
+    }],
+    "volumes":[
+        {
+            "name": "task-local",
+            "dockerVolumeConfiguration" :{
+                "scope": "task",
+                "driver": "local"
+            }
+        }
+    ]
 }

--- a/agent/functional_tests/testdata/taskdefinitions/taskmetadata-validator-awsvpc/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/taskmetadata-validator-awsvpc/task-definition.json
@@ -19,6 +19,22 @@
             "awslogs-region":"$$$TEST_REGION$$$",
             "awslogs-stream-prefix":"ecs-functional-tests-taskmetadata-validator"
         }
-    }
-  }]
+    },
+    "mountPoints": [
+        {
+          "sourceVolume": "shared-local",
+          "containerPath": "/ecs/"
+        }
+    ]
+  }],
+  "volumes":[
+      {
+          "name": "shared-local",
+          "dockerVolumeConfiguration" :{
+              "scope": "shared",
+              "autoprovision":true,
+              "driver": "local"
+          }
+      }
+  ]
 }

--- a/agent/functional_tests/tests/functionaltests_unix_test.go
+++ b/agent/functional_tests/tests/functionaltests_unix_test.go
@@ -625,9 +625,7 @@ func TestAgentIntrospectionValidator(t *testing.T) {
 		},
 	})
 	defer agent.Cleanup()
-	// The Agent version was 1.14.2 when we added changes to agent introspection
-	// endpoint feature for the last time.
-	agent.RequireVersion(">1.14.1")
+	agent.RequireVersion(">1.20.1")
 
 	tdOverrides := make(map[string]string)
 	tdOverrides["$$$TEST_REGION$$$"] = *ECS.Config.Region
@@ -663,7 +661,7 @@ func TestTaskMetadataValidator(t *testing.T) {
 		},
 	})
 	defer agent.Cleanup()
-	agent.RequireVersion(">1.16.2")
+	agent.RequireVersion(">1.20.1")
 
 	tdOverrides := make(map[string]string)
 	tdOverrides["$$$TEST_REGION$$$"] = *ECS.Config.Region

--- a/agent/handlers/v1/response.go
+++ b/agent/handlers/v1/response.go
@@ -51,6 +51,14 @@ type ContainerResponse struct {
 	Name       string                      `json:"Name"`
 	Ports      []PortResponse              `json:"Ports,omitempty"`
 	Networks   []containermetadata.Network `json:"Networks,omitempty"`
+	Volumes    []VolumeResponse            `json:"Volumes,omitempty"`
+}
+
+// VolumeResponse is the schema for the volume response JSON object
+type VolumeResponse struct {
+	DockerName  string `json:"DockerName,omitempty"`
+	Source      string `json:"Source,omitempty"`
+	Destination string `json:"Destination,omitempty"`
 }
 
 // PortResponse defines the schema for portmapping response JSON
@@ -101,6 +109,7 @@ func NewContainerResponse(dockerContainer *apicontainer.DockerContainer, eni *ap
 	}
 
 	resp.Ports = NewPortBindingsResponse(dockerContainer, eni)
+	resp.Volumes = NewVolumesResponse(dockerContainer)
 
 	if eni != nil {
 		resp.Networks = []containermetadata.Network{
@@ -140,6 +149,25 @@ func NewPortBindingsResponse(dockerContainer *apicontainer.DockerContainer, eni 
 		}
 
 		resp = append(resp, port)
+	}
+	return resp
+}
+
+// NewVolumesResponse creates VolumeResponse for a container
+func NewVolumesResponse(dockerContainer *apicontainer.DockerContainer) []VolumeResponse {
+	container := dockerContainer.Container
+	var resp []VolumeResponse
+
+	volumes := container.GetVolumes()
+
+	for _, volume := range volumes {
+		volResp := VolumeResponse{
+			DockerName:  volume.Name,
+			Source:      volume.Source,
+			Destination: volume.Destination,
+		}
+
+		resp = append(resp, volResp)
 	}
 	return resp
 }

--- a/agent/handlers/v1/response_test.go
+++ b/agent/handlers/v1/response_test.go
@@ -16,11 +16,12 @@ package v1
 import (
 	"encoding/json"
 	"testing"
-	
+
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apieni "github.com/aws/amazon-ecs-agent/agent/api/eni"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	apitaskstatus "github.com/aws/amazon-ecs-agent/agent/api/task/status"
+	"github.com/docker/docker/api/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -31,34 +32,44 @@ const (
 	containerID    = "cid"
 	containerName  = "sleepy"
 	eniIPv4Address = "10.0.0.2"
+	volName        = "volume1"
+	volSource      = "/var/lib/volume1"
+	volDestination = "/volume"
 )
 
 func TestTaskResponse(t *testing.T) {
 	expectedTaskResponseMap := map[string]interface{}{
-		"Arn": "t1",
+		"Arn":           "t1",
 		"DesiredStatus": "RUNNING",
-		"KnownStatus": "RUNNING",
-		"Family": "sleep",
-		"Version": "1",
+		"KnownStatus":   "RUNNING",
+		"Family":        "sleep",
+		"Version":       "1",
 		"Containers": []interface{}{
 			map[string]interface{}{
-				"DockerId": "cid",
+				"DockerId":   "cid",
 				"DockerName": "sleepy",
-				"Name": "sleepy",
+				"Name":       "sleepy",
 				"Ports": []interface{}{
 					map[string]interface{}{
 						// The number should be float here, because when we unmarshal
 						// something and we don't specify the number type, it will be
 						// set to float.
 						"ContainerPort": float64(80),
-						"Protocol": "tcp",
-						"HostPort": float64(80),
+						"Protocol":      "tcp",
+						"HostPort":      float64(80),
 					},
 				},
 				"Networks": []interface{}{
 					map[string]interface{}{
-						"NetworkMode": "awsvpc",
+						"NetworkMode":   "awsvpc",
 						"IPv4Addresses": []interface{}{"10.0.0.2"},
+					},
+				},
+				"Volumes": []interface{}{
+					map[string]interface{}{
+						"DockerName":  volName,
+						"Source":      volSource,
+						"Destination": volDestination,
 					},
 				},
 			},
@@ -66,36 +77,43 @@ func TestTaskResponse(t *testing.T) {
 	}
 
 	task := &apitask.Task{
-	   Arn:                 taskARN,
-	   Family:              family,
-	   Version:             version,
-	   DesiredStatusUnsafe: apitaskstatus.TaskRunning,
-	   KnownStatusUnsafe:   apitaskstatus.TaskRunning,
-	   ENI: &apieni.ENI{
-	      IPV4Addresses: []*apieni.ENIIPV4Address{
-	         {
-	            Address: eniIPv4Address,
-	         },
-	      },
-	   },
+		Arn:                 taskARN,
+		Family:              family,
+		Version:             version,
+		DesiredStatusUnsafe: apitaskstatus.TaskRunning,
+		KnownStatusUnsafe:   apitaskstatus.TaskRunning,
+		ENI: &apieni.ENI{
+			IPV4Addresses: []*apieni.ENIIPV4Address{
+				{
+					Address: eniIPv4Address,
+				},
+			},
+		},
 	}
 
 	container := &apicontainer.Container{
-	   Name: containerName,
-	   Ports: []apicontainer.PortBinding{
-	      {
-	         ContainerPort: 80,
-	         Protocol:      apicontainer.TransportProtocolTCP,
-	      },
-	   },
+		Name: containerName,
+		Ports: []apicontainer.PortBinding{
+			{
+				ContainerPort: 80,
+				Protocol:      apicontainer.TransportProtocolTCP,
+			},
+		},
+		VolumesUnsafe: []types.MountPoint{
+			{
+				Name:        volName,
+				Source:      volSource,
+				Destination: volDestination,
+			},
+		},
 	}
 
 	containerNameToDockerContainer := map[string]*apicontainer.DockerContainer{
-	   taskARN: &apicontainer.DockerContainer{
-	      DockerID:   containerID,
-	      DockerName: containerName,
-	      Container:  container,
-	   },
+		taskARN: &apicontainer.DockerContainer{
+			DockerID:   containerID,
+			DockerName: containerName,
+			Container:  container,
+		},
 	}
 
 	taskResponse := NewTaskResponse(task, containerNameToDockerContainer)
@@ -112,38 +130,52 @@ func TestTaskResponse(t *testing.T) {
 
 func TestContainerResponse(t *testing.T) {
 	expectedContainerResponseMap := map[string]interface{}{
-		"DockerId": "cid",
+		"DockerId":   "cid",
 		"DockerName": "sleepy",
-		"Name": "sleepy",
+		"Name":       "sleepy",
 		"Ports": []interface{}{
 			map[string]interface{}{
 				"ContainerPort": float64(80),
-				"Protocol": "tcp",
-				"HostPort": float64(80),
+				"Protocol":      "tcp",
+				"HostPort":      float64(80),
 			},
 		},
 		"Networks": []interface{}{
 			map[string]interface{}{
-				"NetworkMode": "awsvpc",
+				"NetworkMode":   "awsvpc",
 				"IPv4Addresses": []interface{}{"10.0.0.2"},
+			},
+		},
+		"Volumes": []interface{}{
+			map[string]interface{}{
+				"DockerName":  volName,
+				"Source":      volSource,
+				"Destination": volDestination,
 			},
 		},
 	}
 
 	container := &apicontainer.Container{
-	   Name: containerName,
-	   Ports: []apicontainer.PortBinding{
-	      {
-	         ContainerPort: 80,
-	         Protocol:      apicontainer.TransportProtocolTCP,
-	      },
-	   },
+		Name: containerName,
+		Ports: []apicontainer.PortBinding{
+			{
+				ContainerPort: 80,
+				Protocol:      apicontainer.TransportProtocolTCP,
+			},
+		},
+		VolumesUnsafe: []types.MountPoint{
+			{
+				Name:        volName,
+				Source:      volSource,
+				Destination: volDestination,
+			},
+		},
 	}
 
 	dockerContainer := &apicontainer.DockerContainer{
-	   DockerID:   containerID,
-	   DockerName: containerName,
-	   Container:  container,
+		DockerID:   containerID,
+		DockerName: containerName,
+		Container:  container,
 	}
 
 	eni := &apieni.ENI{
@@ -179,7 +211,7 @@ func TestPortBindingsResponse(t *testing.T) {
 	}
 
 	dockerContainer := &apicontainer.DockerContainer{
-		Container:  container,
+		Container: container,
 	}
 
 	PortBindingsResponse := NewPortBindingsResponse(dockerContainer, nil)
@@ -187,4 +219,27 @@ func TestPortBindingsResponse(t *testing.T) {
 	assert.Equal(t, uint16(80), PortBindingsResponse[0].ContainerPort)
 	assert.Equal(t, uint16(80), PortBindingsResponse[0].HostPort)
 	assert.Equal(t, "tcp", PortBindingsResponse[0].Protocol)
+}
+
+func TestVolumesResponse(t *testing.T) {
+	container := &apicontainer.Container{
+		Name: containerName,
+		VolumesUnsafe: []types.MountPoint{
+			{
+				Name:        volName,
+				Source:      volSource,
+				Destination: volDestination,
+			},
+		},
+	}
+
+	dockerContainer := &apicontainer.DockerContainer{
+		Container: container,
+	}
+
+	VolumesResponse := NewVolumesResponse(dockerContainer)
+
+	assert.Equal(t, volName, VolumesResponse[0].DockerName)
+	assert.Equal(t, volSource, VolumesResponse[0].Source)
+	assert.Equal(t, volDestination, VolumesResponse[0].Destination)
 }

--- a/agent/handlers/v2/response.go
+++ b/agent/handlers/v2/response.go
@@ -62,6 +62,7 @@ type ContainerResponse struct {
 	Type          string                      `json:"Type"`
 	Networks      []containermetadata.Network `json:"Networks,omitempty"`
 	Health        *apicontainer.HealthStatus  `json:"Health,omitempty"`
+	Volumes       []v1.VolumeResponse         `json:"Volumes,omitempty"`
 }
 
 // LimitsResponse defines the schema for task/cpu limits response
@@ -208,5 +209,6 @@ func newContainerResponse(dockerContainer *apicontainer.DockerContainer,
 		}
 	}
 
+	resp.Volumes = v1.NewVolumesResponse(dockerContainer)
 	return resp
 }

--- a/agent/handlers/v2/response_test.go
+++ b/agent/handlers/v2/response_test.go
@@ -28,6 +28,7 @@ import (
 	apitaskstatus "github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate/mocks"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/docker/docker/api/types"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 )
@@ -44,6 +45,9 @@ const (
 	cpu            = 1024
 	memory         = 512
 	eniIPv4Address = "10.0.0.2"
+	volName        = "volume1"
+	volSource      = "/var/lib/volume1"
+	volDestination = "/volume"
 )
 
 func TestTaskResponse(t *testing.T) {
@@ -84,6 +88,13 @@ func TestTaskResponse(t *testing.T) {
 			{
 				ContainerPort: 80,
 				Protocol:      apicontainer.TransportProtocolTCP,
+			},
+		},
+		VolumesUnsafe: []types.MountPoint{
+			{
+				Name:        volName,
+				Source:      volSource,
+				Destination: volDestination,
 			},
 		},
 	}
@@ -152,6 +163,13 @@ func TestContainerResponse(t *testing.T) {
 					{
 						ContainerPort: 80,
 						Protocol:      apicontainer.TransportProtocolTCP,
+					},
+				},
+				VolumesUnsafe: []types.MountPoint{
+					{
+						Name:        volName,
+						Source:      volSource,
+						Destination: volDestination,
 					},
 				},
 			}

--- a/agent/statemanager/state_manager.go
+++ b/agent/statemanager/state_manager.go
@@ -64,7 +64,8 @@ const (
 	//  b)Remove `AppliedStatus` field form 'apicontainer.Container'
 	// 12) Deprecate 'TransitionDependencySet' and add new 'TransitionDependenciesMap' in 'apicontainer.Container'
 	// 13) Add 'resources' field to 'api.task.task'
-	ECSDataVersion = 13
+	// 14) Add 'PlatformFields' field to 'api.task.task'
+	ECSDataVersion = 14
 
 	// ecsDataFile specifies the filename in the ECS_DATADIR
 	ecsDataFile = "ecs_agent_data.json"

--- a/agent/taskresource/cgroup/cgroupstatus.go
+++ b/agent/taskresource/cgroup/cgroupstatus.go
@@ -39,7 +39,7 @@ var cgroupStatusMap = map[string]CgroupStatus{
 	"REMOVED": CgroupRemoved,
 }
 
-// StatusString returns a human readable string representation of this object
+// String returns a human readable string representation of this object
 func (cs CgroupStatus) String() string {
 	for k, v := range cgroupStatusMap {
 		if v == cs {

--- a/agent/tcs/handler/handler.go
+++ b/agent/tcs/handler/handler.go
@@ -81,7 +81,7 @@ func StartSession(params TelemetrySessionParams, statsEngine stats.Engine) error
 func startTelemetrySession(params TelemetrySessionParams, statsEngine stats.Engine) error {
 	tcsEndpoint, err := params.ECSClient.DiscoverTelemetryEndpoint(params.ContainerInstanceArn)
 	if err != nil {
-		seelog.Errorf("Unable to discover poll endpoint: %v", err)
+		seelog.Errorf("tcs: unable to discover poll endpoint: %v", err)
 		return err
 	}
 	url := formatURL(tcsEndpoint, params.Cfg.Cluster, params.ContainerInstanceArn)

--- a/misc/agent-introspection-validator/agent-introspection-validator.go
+++ b/misc/agent-introspection-validator/agent-introspection-validator.go
@@ -50,11 +50,12 @@ type TasksResponse struct {
 
 // ContainerResponse is the schema for the container response JSON object
 type ContainerResponse struct {
-	DockerID   string         `json:"DockerId"`
-	DockerName string         `json:"DockerName"`
-	Name       string         `json:"Name"`
-	Ports      []PortResponse `json:"Ports,omitempty"`
-	Networks   Network        `json:"Networks,omitempty"`
+	DockerID   string           `json:"DockerId"`
+	DockerName string           `json:"DockerName"`
+	Name       string           `json:"Name"`
+	Ports      []PortResponse   `json:"Ports,omitempty"`
+	Networks   Network          `json:"Networks,omitempty"`
+	Volumes    []VolumeResponse `json:"Volumes,omitempty"`
 }
 
 // PortResponse defines the schema for portmapping response JSON
@@ -70,6 +71,13 @@ type Network struct {
 	NetworkMode   string   `json:"NetworkMode,omitempty"`
 	IPv4Addresses []string `json:"IPv4Addresses,omitempty"`
 	IPv6Addresses []string `json:"IPv6Addresses,omitempty"`
+}
+
+// VolumeResponse is the schema for the volume response JSON object
+type VolumeResponse struct {
+	DockerName  string `json:"DockerName,omitempty"`
+	Source      string `json:"Source,omitempty"`
+	Destination string `json:"Destination,omitempty"`
 }
 
 func getTasksMetadata(client *http.Client, path string) (*TasksResponse, error) {
@@ -188,7 +196,7 @@ func verifyContainerMetadata(containerMetadataRawMsg json.RawMessage) error {
 	}
 
 	var actualContainerName string
-	json.Unmarshal(containerMetadataMap["Name"] ,&actualContainerName)
+	json.Unmarshal(containerMetadataMap["Name"], &actualContainerName)
 
 	if actualContainerName != containerName {
 		return fmt.Errorf("incorrect container name, expected %s, received %s",
@@ -201,6 +209,10 @@ func verifyContainerMetadata(containerMetadataRawMsg json.RawMessage) error {
 
 	if containerMetadataMap["DockerName"] == nil {
 		return notEmptyErrMsg("DockerName")
+	}
+
+	if containerMetadataMap["Volumes"] == nil {
+		return notEmptyErrMsg("Volumes")
 	}
 
 	return nil

--- a/misc/taskmetadata-validator/taskmetadata-validator.go
+++ b/misc/taskmetadata-validator/taskmetadata-validator.go
@@ -61,8 +61,9 @@ type ContainerResponse struct {
 	StartedAt     *time.Time `json:",omitempty"`
 	FinishedAt    *time.Time `json:",omitempty"`
 	Type          string
-	Health        HealthStatus `json:"health,omitempty"`
-	Networks      []Network    `json:",omitempty"`
+	Health        HealthStatus     `json:"health,omitempty"`
+	Networks      []Network        `json:",omitempty"`
+	Volumes       []VolumeResponse `json:"Volumes,omitempty"`
 }
 
 type HealthStatus struct {
@@ -92,6 +93,13 @@ type Network struct {
 	NetworkMode   string   `json:"NetworkMode,omitempty"`
 	IPv4Addresses []string `json:"IPv4Addresses,omitempty"`
 	IPv6Addresses []string `json:"IPv6Addresses,omitempty"`
+}
+
+// VolumeResponse is the schema for the volume response JSON object
+type VolumeResponse struct {
+	DockerName  string `json:"DockerName,omitempty"`
+	Source      string `json:"Source,omitempty"`
+	Destination string `json:"Destination,omitempty"`
 }
 
 func taskMetadata(client *http.Client) (*TaskResponse, error) {
@@ -241,6 +249,16 @@ func main() {
 			fmt.Fprintf(os.Stderr, "Container health metadata unexpected, got: %s\n", containerMetadata.Health)
 			os.Exit(1)
 		}
+	}
+
+	if containerMetadata.Volumes == nil {
+		fmt.Fprintf(os.Stderr, "Expected container volume metadata to be non-empty")
+		os.Exit(1)
+	}
+
+	if containerMetadata.Volumes[0].DockerName != "shared-local" || containerMetadata.Volumes[0].Destination != "/ecs" {
+		fmt.Fprintf(os.Stderr, "Volume metadata fields incorrect")
+		os.Exit(1)
 	}
 
 	_, err = taskStats(client)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
merging dev branch into moby branch, to keep it from diverging too far

### Implementation details
- merge dev into moby
- dev had few changes that introduced regression on go-dockerclient dependency for volumes (fom the "Add Volumes to v1 and v2 metadata" changes), which have been updated. 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: N/A

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
