### PR TITLE
Migrating Container stats to Docker SDK

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -15,6 +15,9 @@ This product includes software developed at Docker, Inc. (https://www.docker.com
 This product contains software (https://github.com/kr/pty) developed
 by Keith Rarick, licensed under the MIT License.
 
+This product contains software (https://github.com/fsouza/go-dockerclient) developed
+by Francisco Souza under the Apache License 2.0 (see: inactivity_timeout_handler.go)
+
 The following is courtesy of our legal counsel:
 
 

--- a/agent/dockerclient/dockerapi/inactivity_timeout_handler.go
+++ b/agent/dockerclient/dockerapi/inactivity_timeout_handler.go
@@ -1,0 +1,57 @@
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package dockerapi
+
+import (
+	"io"
+	"sync/atomic"
+	"time"
+)
+
+type proxyReader struct {
+	io.ReadCloser
+	calls uint64
+}
+
+func (p *proxyReader) callCount() uint64 {
+	return atomic.LoadUint64(&p.calls)
+}
+
+func (p *proxyReader) Read(data []byte) (int, error) {
+	atomic.AddUint64(&p.calls, 1)
+	return p.ReadCloser.Read(data)
+}
+
+func handleInactivityTimeout(reader io.ReadCloser, timeout time.Duration, cancelRequest func(), canceled *uint32) (io.ReadCloser, chan<- struct{}) {
+	done := make(chan struct{})
+	proxyReader := &proxyReader{ReadCloser: reader}
+	go func() {
+		var lastCallCount uint64
+		for {
+			select {
+			case <-time.After(timeout):
+			case <-done:
+				return
+			}
+			curCallCount := proxyReader.callCount()
+			if curCallCount == lastCallCount {
+				atomic.AddUint32(canceled, 1)
+				cancelRequest()
+				return
+			}
+			lastCallCount = curCallCount
+		}
+	}()
+	return proxyReader, done
+}

--- a/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
+++ b/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
@@ -30,7 +30,6 @@ import (
 	types "github.com/docker/docker/api/types"
 	container0 "github.com/docker/docker/api/types/container"
 	filters "github.com/docker/docker/api/types/filters"
-	go_dockerclient "github.com/fsouza/go-dockerclient"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -280,9 +279,9 @@ func (mr *MockDockerClientMockRecorder) StartContainer(arg0, arg1, arg2 interfac
 }
 
 // Stats mocks base method
-func (m *MockDockerClient) Stats(arg0 string, arg1 context.Context) (<-chan *go_dockerclient.Stats, error) {
+func (m *MockDockerClient) Stats(arg0 string, arg1 context.Context) (<-chan *types.Stats, error) {
 	ret := m.ctrl.Call(m, "Stats", arg0, arg1)
-	ret0, _ := ret[0].(<-chan *go_dockerclient.Stats)
+	ret0, _ := ret[0].(<-chan *types.Stats)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
+++ b/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
@@ -279,16 +279,16 @@ func (mr *MockDockerClientMockRecorder) StartContainer(arg0, arg1, arg2 interfac
 }
 
 // Stats mocks base method
-func (m *MockDockerClient) Stats(arg0 string, arg1 context.Context) (<-chan *types.Stats, error) {
-	ret := m.ctrl.Call(m, "Stats", arg0, arg1)
+func (m *MockDockerClient) Stats(arg0 context.Context, arg1 string, arg2 time.Duration) (<-chan *types.Stats, error) {
+	ret := m.ctrl.Call(m, "Stats", arg0, arg1, arg2)
 	ret0, _ := ret[0].(<-chan *types.Stats)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Stats indicates an expected call of Stats
-func (mr *MockDockerClientMockRecorder) Stats(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stats", reflect.TypeOf((*MockDockerClient)(nil).Stats), arg0, arg1)
+func (mr *MockDockerClientMockRecorder) Stats(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stats", reflect.TypeOf((*MockDockerClient)(nil).Stats), arg0, arg1, arg2)
 }
 
 // StopContainer mocks base method

--- a/agent/handlers/taskmetadata/taskinfo_test.go
+++ b/agent/handlers/taskmetadata/taskinfo_test.go
@@ -33,10 +33,10 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/credentials"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/handlers/types/v2"
-	mock_audit "github.com/aws/amazon-ecs-agent/agent/logger/audit/mocks"
+	"github.com/aws/amazon-ecs-agent/agent/logger/audit/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/stats/mock"
 	"github.com/aws/aws-sdk-go/aws"
-	docker "github.com/fsouza/go-dockerclient"
+	"github.com/docker/docker/api/types"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 )
@@ -223,7 +223,7 @@ func TestContainerStats(t *testing.T) {
 	auditLog := mock_audit.NewMockAuditLogger(ctrl)
 	statsEngine := mock_stats.NewMockEngine(ctrl)
 
-	dockerStats := &docker.Stats{NumProcs: 2}
+	dockerStats := &types.Stats{NumProcs: 2}
 	gomock.InOrder(
 		state.EXPECT().GetTaskByIPAddress(remoteIP).Return(taskARN, true),
 		statsEngine.EXPECT().ContainerDockerStats(taskARN, containerID).Return(dockerStats, nil),
@@ -237,7 +237,7 @@ func TestContainerStats(t *testing.T) {
 	res, err := ioutil.ReadAll(recorder.Body)
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusOK, recorder.Code)
-	var statsFromResult *docker.Stats
+	var statsFromResult *types.Stats
 	err = json.Unmarshal(res, &statsFromResult)
 	assert.NoError(t, err)
 	assert.Equal(t, dockerStats.NumProcs, statsFromResult.NumProcs)
@@ -251,7 +251,7 @@ func TestTaskStats(t *testing.T) {
 	auditLog := mock_audit.NewMockAuditLogger(ctrl)
 	statsEngine := mock_stats.NewMockEngine(ctrl)
 
-	dockerStats := &docker.Stats{NumProcs: 2}
+	dockerStats := &types.Stats{NumProcs: 2}
 	containerMap := map[string]*apicontainer.DockerContainer{
 		containerName: &apicontainer.DockerContainer{
 			DockerID: containerID,
@@ -271,7 +271,7 @@ func TestTaskStats(t *testing.T) {
 	res, err := ioutil.ReadAll(recorder.Body)
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusOK, recorder.Code)
-	var statsFromResult map[string]*docker.Stats
+	var statsFromResult map[string]*types.Stats
 	err = json.Unmarshal(res, &statsFromResult)
 	assert.NoError(t, err)
 	containerStats, ok := statsFromResult[containerID]

--- a/agent/handlers/v2/stats_response.go
+++ b/agent/handlers/v2/stats_response.go
@@ -17,14 +17,14 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/stats"
 	"github.com/cihub/seelog"
-	docker "github.com/fsouza/go-dockerclient"
+	"github.com/docker/docker/api/types"
 	"github.com/pkg/errors"
 )
 
 // NewTaskStatsResponse returns a new task stats response object
 func NewTaskStatsResponse(taskARN string,
 	state dockerstate.TaskEngineState,
-	statsEngine stats.Engine) (map[string]*docker.Stats, error) {
+	statsEngine stats.Engine) (map[string]*types.Stats, error) {
 
 	containerMap, ok := state.ContainerMapByArn(taskARN)
 	if !ok {
@@ -33,7 +33,7 @@ func NewTaskStatsResponse(taskARN string,
 			taskARN)
 	}
 
-	resp := make(map[string]*docker.Stats)
+	resp := make(map[string]*types.Stats)
 	for _, dockerContainer := range containerMap {
 		containerID := dockerContainer.DockerID
 		dockerStats, err := statsEngine.ContainerDockerStats(taskARN, containerID)

--- a/agent/handlers/v2/stats_response_test.go
+++ b/agent/handlers/v2/stats_response_test.go
@@ -21,7 +21,7 @@ import (
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/stats/mock"
-	docker "github.com/fsouza/go-dockerclient"
+	"github.com/docker/docker/api/types"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 )
@@ -33,7 +33,7 @@ func TestTaskStatsResponseSuccess(t *testing.T) {
 	state := mock_dockerstate.NewMockTaskEngineState(ctrl)
 	statsEngine := mock_stats.NewMockEngine(ctrl)
 
-	dockerStats := &docker.Stats{NumProcs: 2}
+	dockerStats := &types.Stats{NumProcs: 2}
 	containerMap := map[string]*apicontainer.DockerContainer{
 		containerName: &apicontainer.DockerContainer{
 			DockerID: containerID,

--- a/agent/handlers/v2_server_setup_test.go
+++ b/agent/handlers/v2_server_setup_test.go
@@ -34,15 +34,15 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/containermetadata"
 	"github.com/aws/amazon-ecs-agent/agent/credentials"
-	mock_credentials "github.com/aws/amazon-ecs-agent/agent/credentials/mocks"
+	"github.com/aws/amazon-ecs-agent/agent/credentials/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/handlers/utils"
 	"github.com/aws/amazon-ecs-agent/agent/handlers/v1"
 	"github.com/aws/amazon-ecs-agent/agent/handlers/v2"
-	mock_audit "github.com/aws/amazon-ecs-agent/agent/logger/audit/mocks"
+	"github.com/aws/amazon-ecs-agent/agent/logger/audit/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/stats/mock"
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/fsouza/go-dockerclient"
+	"github.com/docker/docker/api/types"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 )
@@ -445,7 +445,7 @@ func TestContainerStats(t *testing.T) {
 	auditLog := mock_audit.NewMockAuditLogger(ctrl)
 	statsEngine := mock_stats.NewMockEngine(ctrl)
 
-	dockerStats := &docker.Stats{NumProcs: 2}
+	dockerStats := &types.Stats{NumProcs: 2}
 	gomock.InOrder(
 		state.EXPECT().GetTaskByIPAddress(remoteIP).Return(taskARN, true),
 		statsEngine.EXPECT().ContainerDockerStats(taskARN, containerID).Return(dockerStats, nil),
@@ -459,7 +459,7 @@ func TestContainerStats(t *testing.T) {
 	res, err := ioutil.ReadAll(recorder.Body)
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusOK, recorder.Code)
-	var statsFromResult *docker.Stats
+	var statsFromResult *types.Stats
 	err = json.Unmarshal(res, &statsFromResult)
 	assert.NoError(t, err)
 	assert.Equal(t, dockerStats.NumProcs, statsFromResult.NumProcs)
@@ -473,7 +473,7 @@ func TestTaskStats(t *testing.T) {
 	auditLog := mock_audit.NewMockAuditLogger(ctrl)
 	statsEngine := mock_stats.NewMockEngine(ctrl)
 
-	dockerStats := &docker.Stats{NumProcs: 2}
+	dockerStats := &types.Stats{NumProcs: 2}
 	containerMap := map[string]*apicontainer.DockerContainer{
 		containerName: &apicontainer.DockerContainer{
 			DockerID: containerID,
@@ -493,7 +493,7 @@ func TestTaskStats(t *testing.T) {
 	res, err := ioutil.ReadAll(recorder.Body)
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusOK, recorder.Code)
-	var statsFromResult map[string]*docker.Stats
+	var statsFromResult map[string]*types.Stats
 	err = json.Unmarshal(res, &statsFromResult)
 	assert.NoError(t, err)
 	containerStats, ok := statsFromResult[containerID]

--- a/agent/stats/container.go
+++ b/agent/stats/container.go
@@ -100,7 +100,7 @@ func (container *StatsContainer) processStatsStream() error {
 	if container.client == nil {
 		return errors.New("container processStatsStream: Client is not set.")
 	}
-	dockerStats, err := container.client.Stats(dockerID, container.ctx)
+	dockerStats, err := container.client.Stats(container.ctx, dockerID, dockerapi.StatsInactivityTimeout)
 	if err != nil {
 		return err
 	}

--- a/agent/stats/container_test.go
+++ b/agent/stats/container_test.go
@@ -27,8 +27,8 @@ import (
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi/mocks"
-	mock_resolver "github.com/aws/amazon-ecs-agent/agent/stats/resolver/mock"
-	docker "github.com/fsouza/go-dockerclient"
+	"github.com/aws/amazon-ecs-agent/agent/stats/resolver/mock"
+	"github.com/docker/docker/api/types"
 	"github.com/golang/mock/gomock"
 )
 
@@ -56,12 +56,12 @@ func TestContainerStatsCollection(t *testing.T) {
 
 	dockerID := "container1"
 	ctx, cancel := context.WithCancel(context.TODO())
-	statChan := make(chan *docker.Stats)
+	statChan := make(chan *types.Stats)
 	mockDockerClient.EXPECT().Stats(dockerID, ctx).Return(statChan, nil)
 	go func() {
 		for _, stat := range statsData {
 			// doing this with json makes me sad, but is the easiest way to
-			// deal with the docker.Stats.MemoryStats inner struct
+			// deal with the types.Stats.MemoryStats inner struct
 			jsonStat := fmt.Sprintf(`
 				{
 					"memory_stats": {"usage":%d, "privateworkingset":%d},
@@ -72,7 +72,7 @@ func TestContainerStatsCollection(t *testing.T) {
 						}
 					}
 				}`, stat.memBytes, stat.memBytes, stat.cpuTime, stat.cpuTime)
-			dockerStat := &docker.Stats{}
+			dockerStat := &types.Stats{}
 			json.Unmarshal([]byte(jsonStat), dockerStat)
 			dockerStat.Read = stat.timestamp
 			statChan <- dockerStat
@@ -134,9 +134,9 @@ func TestContainerStatsCollectionReconnection(t *testing.T) {
 	dockerID := "container1"
 	ctx, cancel := context.WithCancel(context.TODO())
 
-	statChan := make(chan *docker.Stats)
+	statChan := make(chan *types.Stats)
 	statErr := fmt.Errorf("test error")
-	closedChan := make(chan *docker.Stats)
+	closedChan := make(chan *types.Stats)
 	close(closedChan)
 
 	mockContainer := &apicontainer.DockerContainer{
@@ -176,7 +176,7 @@ func TestContainerStatsCollectionStopsIfContainerIsTerminal(t *testing.T) {
 	dockerID := "container1"
 	ctx, cancel := context.WithCancel(context.TODO())
 
-	closedChan := make(chan *docker.Stats)
+	closedChan := make(chan *types.Stats)
 	close(closedChan)
 
 	statsErr := fmt.Errorf("test error")

--- a/agent/stats/engine.go
+++ b/agent/stats/engine.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/cihub/seelog"
-	docker "github.com/fsouza/go-dockerclient"
 	"github.com/pborman/uuid"
 	"github.com/pkg/errors"
 
@@ -37,6 +36,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/stats/resolver"
 	"github.com/aws/amazon-ecs-agent/agent/tcs/model/ecstcs"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/docker/docker/api/types"
 )
 
 const (
@@ -64,7 +64,7 @@ type DockerContainerMetadataResolver struct {
 // defined to make testing easier.
 type Engine interface {
 	GetInstanceMetrics() (*ecstcs.MetricsMetadata, []*ecstcs.TaskMetric, error)
-	ContainerDockerStats(taskARN string, containerID string) (*docker.Stats, error)
+	ContainerDockerStats(taskARN string, containerID string) (*types.Stats, error)
 	GetTaskHealthMetrics() (*ecstcs.HealthMetadata, []*ecstcs.TaskHealth, error)
 }
 
@@ -649,7 +649,7 @@ func (engine *DockerStatsEngine) resetStatsUnsafe() {
 }
 
 // ContainerDockerStats returns the last stored raw docker stats object for a container
-func (engine *DockerStatsEngine) ContainerDockerStats(taskARN string, containerID string) (*docker.Stats, error) {
+func (engine *DockerStatsEngine) ContainerDockerStats(taskARN string, containerID string) (*types.Stats, error) {
 	engine.lock.RLock()
 	defer engine.lock.RUnlock()
 

--- a/agent/stats/engine_test.go
+++ b/agent/stats/engine_test.go
@@ -27,10 +27,10 @@ import (
 	apitaskstatus "github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi/mocks"
-	mock_resolver "github.com/aws/amazon-ecs-agent/agent/stats/resolver/mock"
+	"github.com/aws/amazon-ecs-agent/agent/stats/resolver/mock"
 
 	"github.com/aws/aws-sdk-go/aws"
-	docker "github.com/fsouza/go-dockerclient"
+	"github.com/docker/docker/api/types"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 )
@@ -52,7 +52,7 @@ func TestStatsEngineAddRemoveContainers(t *testing.T) {
 	resolver.EXPECT().ResolveContainer(gomock.Any()).AnyTimes().Return(&apicontainer.DockerContainer{
 		Container: &apicontainer.Container{},
 	}, nil)
-	mockStatsChannel := make(chan *docker.Stats)
+	mockStatsChannel := make(chan *types.Stats)
 	defer close(mockStatsChannel)
 	mockDockerClient.EXPECT().Stats(gomock.Any(), gomock.Any()).Return(mockStatsChannel, nil).AnyTimes()
 
@@ -194,7 +194,7 @@ func TestStatsEngineMetadataInStatsSets(t *testing.T) {
 		{22400432, 1839104, ts1},
 		{116499979, 3649536, ts2},
 	}
-	dockerStats := []*docker.Stats{
+	dockerStats := []*types.Stats{
 		{
 			Read: ts1,
 		},
@@ -398,7 +398,7 @@ func TestSynchronizeOnRestart(t *testing.T) {
 	defer ctrl.Finish()
 
 	containerID := "containerID"
-	statsChan := make(chan *docker.Stats)
+	statsChan := make(chan *types.Stats)
 	statsStarted := make(chan struct{})
 	client := mock_dockerapi.NewMockDockerClient(ctrl)
 	resolver := mock_resolver.NewMockContainerMetadataResolver(ctrl)

--- a/agent/stats/engine_test.go
+++ b/agent/stats/engine_test.go
@@ -54,7 +54,7 @@ func TestStatsEngineAddRemoveContainers(t *testing.T) {
 	}, nil)
 	mockStatsChannel := make(chan *types.Stats)
 	defer close(mockStatsChannel)
-	mockDockerClient.EXPECT().Stats(gomock.Any(), gomock.Any()).Return(mockStatsChannel, nil).AnyTimes()
+	mockDockerClient.EXPECT().Stats(gomock.Any(), gomock.Any(), gomock.Any()).Return(mockStatsChannel, nil).AnyTimes()
 
 	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestStatsEngineAddRemoveContainers"))
 	ctx, cancel := context.WithCancel(context.TODO())
@@ -177,7 +177,7 @@ func TestStatsEngineMetadataInStatsSets(t *testing.T) {
 	resolver.EXPECT().ResolveContainer(gomock.Any()).AnyTimes().Return(&apicontainer.DockerContainer{
 		Container: &apicontainer.Container{},
 	}, nil)
-	mockDockerClient.EXPECT().Stats(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	mockDockerClient.EXPECT().Stats(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 
 	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestStatsEngineMetadataInStatsSets"))
 	ctx, cancel := context.WithCancel(context.TODO())
@@ -412,7 +412,7 @@ func TestSynchronizeOnRestart(t *testing.T) {
 	client.EXPECT().ListContainers(gomock.Any(), false, gomock.Any()).Return(dockerapi.ListContainersResponse{
 		DockerIDs: []string{containerID},
 	})
-	client.EXPECT().Stats(containerID, gomock.Any()).Do(func(id string, ctx context.Context) {
+	client.EXPECT().Stats(gomock.Any(), containerID, gomock.Any()).Do(func(ctx context.Context, id string, inactivityTimeout time.Duration) {
 		statsStarted <- struct{}{}
 	}).Return(statsChan, nil)
 

--- a/agent/stats/mock/engine.go
+++ b/agent/stats/mock/engine.go
@@ -21,8 +21,8 @@ import (
 	reflect "reflect"
 
 	ecstcs "github.com/aws/amazon-ecs-agent/agent/tcs/model/ecstcs"
-	go_dockerclient "github.com/fsouza/go-dockerclient"
 	gomock "github.com/golang/mock/gomock"
+	"github.com/docker/docker/api/types"
 )
 
 // MockEngine is a mock of Engine interface
@@ -49,9 +49,9 @@ func (m *MockEngine) EXPECT() *MockEngineMockRecorder {
 }
 
 // ContainerDockerStats mocks base method
-func (m *MockEngine) ContainerDockerStats(arg0, arg1 string) (*go_dockerclient.Stats, error) {
+func (m *MockEngine) ContainerDockerStats(arg0, arg1 string) (*types.Stats, error) {
 	ret := m.ctrl.Call(m, "ContainerDockerStats", arg0, arg1)
-	ret0, _ := ret[0].(*go_dockerclient.Stats)
+	ret0, _ := ret[0].(*types.Stats)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/agent/stats/queue.go
+++ b/agent/stats/queue.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/aws/amazon-ecs-agent/agent/tcs/model/ecstcs"
 	"github.com/cihub/seelog"
-	docker "github.com/fsouza/go-dockerclient"
+	"github.com/docker/docker/api/types"
 )
 
 const (
@@ -36,7 +36,7 @@ type Queue struct {
 	buffer        []UsageStats
 	maxSize       int
 	lastResetTime time.Time
-	lastStat      *docker.Stats
+	lastStat      *types.Stats
 	lock          sync.RWMutex
 }
 
@@ -57,7 +57,7 @@ func (queue *Queue) Reset() {
 }
 
 // Add adds a new set of container stats to the queue.
-func (queue *Queue) Add(dockerStat *docker.Stats) error {
+func (queue *Queue) Add(dockerStat *types.Stats) error {
 	queue.setLastStat(dockerStat)
 	stat, err := dockerStatsToContainerStats(dockerStat)
 	if err != nil {
@@ -67,7 +67,7 @@ func (queue *Queue) Add(dockerStat *docker.Stats) error {
 	return nil
 }
 
-func (queue *Queue) setLastStat(stat *docker.Stats) {
+func (queue *Queue) setLastStat(stat *types.Stats) {
 	queue.lock.Lock()
 	defer queue.lock.Unlock()
 
@@ -108,7 +108,7 @@ func (queue *Queue) add(rawStat *ContainerStats) {
 }
 
 // GetLastStat returns the last recorded raw statistics object from docker
-func (queue *Queue) GetLastStat() *docker.Stats {
+func (queue *Queue) GetLastStat() *types.Stats {
 	queue.lock.RLock()
 	defer queue.lock.RUnlock()
 

--- a/agent/stats/utils_test.go
+++ b/agent/stats/utils_test.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"testing"
 
-	docker "github.com/fsouza/go-dockerclient"
+	"github.com/docker/docker/api/types"
 )
 
 func TestIsNetworkStatsError(t *testing.T) {
@@ -56,7 +56,7 @@ func TestDockerStatsToContainerStatsMemUsage(t *testing.T) {
 				"privateworkingset": %d
 			}
 		}`, 1, 2, 3, 4, 100, 30, 100, 20, 10, 10)
-	dockerStat := &docker.Stats{}
+	dockerStat := &types.Stats{}
 	json.Unmarshal([]byte(jsonStat), dockerStat)
 	containerStats, err := dockerStatsToContainerStats(dockerStat)
 	if err != nil {

--- a/agent/stats/utils_unix.go
+++ b/agent/stats/utils_unix.go
@@ -18,11 +18,11 @@ import (
 	"fmt"
 
 	"github.com/cihub/seelog"
-	docker "github.com/fsouza/go-dockerclient"
+	"github.com/docker/docker/api/types"
 )
 
 // dockerStatsToContainerStats returns a new object of the ContainerStats object from docker stats.
-func dockerStatsToContainerStats(dockerStats *docker.Stats) (*ContainerStats, error) {
+func dockerStatsToContainerStats(dockerStats *types.Stats) (*ContainerStats, error) {
 	// The length of PercpuUsage represents the number of cores in an instance.
 	if len(dockerStats.CPUStats.CPUUsage.PercpuUsage) == 0 || numCores == uint64(0) {
 		seelog.Debug("Invalid container statistics reported, no cpu core usage reported")
@@ -30,7 +30,7 @@ func dockerStatsToContainerStats(dockerStats *docker.Stats) (*ContainerStats, er
 	}
 
 	cpuUsage := dockerStats.CPUStats.CPUUsage.TotalUsage / numCores
-	memoryUsage := dockerStats.MemoryStats.Usage - dockerStats.MemoryStats.Stats.Cache
+	memoryUsage := dockerStats.MemoryStats.Usage - dockerStats.MemoryStats.Stats["cache"]
 	return &ContainerStats{
 		cpuUsage:    cpuUsage,
 		memoryUsage: memoryUsage,

--- a/agent/stats/utils_unix_test.go
+++ b/agent/stats/utils_unix_test.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"testing"
 
-	docker "github.com/fsouza/go-dockerclient"
+	"github.com/docker/docker/api/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -35,7 +35,7 @@ func TestDockerStatsToContainerStatsZeroCoresGeneratesError(t *testing.T) {
 				}
 			}
 		}`, 100)
-	dockerStat := &docker.Stats{}
+	dockerStat := &types.Stats{}
 	json.Unmarshal([]byte(jsonStat), dockerStat)
 	_, err := dockerStatsToContainerStats(dockerStat)
 	assert.Error(t, err, "expected error converting container stats with empty PercpuUsage")
@@ -57,7 +57,7 @@ func TestDockerStatsToContainerStatsCpuUsage(t *testing.T) {
 				}
 			}
 		}`, 1, 2, 3, 4, 100)
-	dockerStat := &docker.Stats{}
+	dockerStat := &types.Stats{}
 	json.Unmarshal([]byte(jsonStat), dockerStat)
 	containerStats, err := dockerStatsToContainerStats(dockerStat)
 	assert.NoError(t, err, "converting container stats failed")

--- a/agent/stats/utils_windows.go
+++ b/agent/stats/utils_windows.go
@@ -18,11 +18,11 @@ import (
 	"fmt"
 
 	"github.com/cihub/seelog"
-	docker "github.com/fsouza/go-dockerclient"
+	"github.com/docker/docker/api/types"
 )
 
 // dockerStatsToContainerStats returns a new object of the ContainerStats object from docker stats.
-func dockerStatsToContainerStats(dockerStats *docker.Stats) (*ContainerStats, error) {
+func dockerStatsToContainerStats(dockerStats *types.Stats) (*ContainerStats, error) {
 	if numCores == uint64(0) {
 		seelog.Error("Invalid number of cpu cores acquired from the system")
 		return nil, fmt.Errorf("invalid number of cpu cores acquired from the system")

--- a/agent/stats/utils_windows_test.go
+++ b/agent/stats/utils_windows_test.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"testing"
 
-	docker "github.com/fsouza/go-dockerclient"
+	"github.com/docker/docker/api/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -34,7 +34,7 @@ func TestDockerStatsToContainerStatsZeroCoresGeneratesError(t *testing.T) {
 				}
 			}
 		}`, 100)
-	dockerStat := &docker.Stats{}
+	dockerStat := &types.Stats{}
 	json.Unmarshal([]byte(jsonStat), dockerStat)
 	_, err := dockerStatsToContainerStats(dockerStat)
 	assert.Error(t, err, "expected error converting container stats with zero cpu cores")
@@ -55,7 +55,7 @@ func TestDockerStatsToContainerStatsCpuUsage(t *testing.T) {
 				}
 			}
 		}`, 100)
-	dockerStat := &docker.Stats{}
+	dockerStat := &types.Stats{}
 	json.Unmarshal([]byte(jsonStat), dockerStat)
 	containerStats, err := dockerStatsToContainerStats(dockerStat)
 	assert.NoError(t, err, "converting container stats failed")

--- a/agent/tcs/client/client_test.go
+++ b/agent/tcs/client/client_test.go
@@ -35,7 +35,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/wsclient/wsconn/mock"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
-	docker "github.com/fsouza/go-dockerclient"
+	"github.com/docker/docker/api/types"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 )
@@ -56,7 +56,7 @@ func (*mockStatsEngine) GetInstanceMetrics() (*ecstcs.MetricsMetadata, []*ecstcs
 	return nil, nil, fmt.Errorf("uninitialized")
 }
 
-func (*mockStatsEngine) ContainerDockerStats(taskARN string, id string) (*docker.Stats, error) {
+func (*mockStatsEngine) ContainerDockerStats(taskARN string, id string) (*types.Stats, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 
@@ -70,7 +70,7 @@ func (*emptyStatsEngine) GetInstanceMetrics() (*ecstcs.MetricsMetadata, []*ecstc
 	return nil, nil, fmt.Errorf("empty stats")
 }
 
-func (*emptyStatsEngine) ContainerDockerStats(taskARN string, id string) (*docker.Stats, error) {
+func (*emptyStatsEngine) ContainerDockerStats(taskARN string, id string) (*types.Stats, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 
@@ -90,7 +90,7 @@ func (*idleStatsEngine) GetInstanceMetrics() (*ecstcs.MetricsMetadata, []*ecstcs
 	return metadata, []*ecstcs.TaskMetric{}, nil
 }
 
-func (*idleStatsEngine) ContainerDockerStats(taskARN string, id string) (*docker.Stats, error) {
+func (*idleStatsEngine) ContainerDockerStats(taskARN string, id string) (*types.Stats, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 
@@ -118,7 +118,7 @@ func (engine *nonIdleStatsEngine) GetInstanceMetrics() (*ecstcs.MetricsMetadata,
 	return metadata, taskMetrics, nil
 }
 
-func (*nonIdleStatsEngine) ContainerDockerStats(taskARN string, id string) (*docker.Stats, error) {
+func (*nonIdleStatsEngine) ContainerDockerStats(taskARN string, id string) (*types.Stats, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 

--- a/agent/tcs/handler/handler_test.go
+++ b/agent/tcs/handler/handler_test.go
@@ -36,7 +36,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/wsclient"
 	wsmock "github.com/aws/amazon-ecs-agent/agent/wsclient/mock/utils"
 	"github.com/aws/aws-sdk-go/aws/credentials"
-	docker "github.com/fsouza/go-dockerclient"
+	"github.com/docker/docker/api/types"
 	"github.com/golang/mock/gomock"
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
@@ -65,7 +65,7 @@ func (*mockStatsEngine) GetInstanceMetrics() (*ecstcs.MetricsMetadata, []*ecstcs
 	return req.Metadata, req.TaskMetrics, nil
 }
 
-func (*mockStatsEngine) ContainerDockerStats(taskARN string, id string) (*docker.Stats, error) {
+func (*mockStatsEngine) ContainerDockerStats(taskARN string, id string) (*types.Stats, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 

--- a/misc/taskmetadata-validator/taskmetadata-validator.go
+++ b/misc/taskmetadata-validator/taskmetadata-validator.go
@@ -21,7 +21,7 @@ import (
 	"os"
 	"time"
 
-	docker "github.com/fsouza/go-dockerclient"
+	"github.com/docker/docker/api/types"
 )
 
 const (
@@ -136,7 +136,7 @@ func containerMetadata(client *http.Client, id string) (*ContainerResponse, erro
 	return &containerMetadata, nil
 }
 
-func taskStats(client *http.Client) (map[string]*docker.Stats, error) {
+func taskStats(client *http.Client) (map[string]*types.Stats, error) {
 	body, err := metadataResponse(client, v2StatsEndpoint, "task stats")
 	if err != nil {
 		return nil, err
@@ -144,7 +144,7 @@ func taskStats(client *http.Client) (map[string]*docker.Stats, error) {
 
 	fmt.Printf("Received task stats: %s \n", string(body))
 
-	var taskStats map[string]*docker.Stats
+	var taskStats map[string]*types.Stats
 	err = json.Unmarshal(body, &taskStats)
 	if err != nil {
 		return nil, fmt.Errorf("task stats: unable to parse response body: %v", err)
@@ -153,7 +153,7 @@ func taskStats(client *http.Client) (map[string]*docker.Stats, error) {
 	return taskStats, nil
 }
 
-func containerStats(client *http.Client, id string) (*docker.Stats, error) {
+func containerStats(client *http.Client, id string) (*types.Stats, error) {
 	body, err := metadataResponse(client, v2StatsEndpoint+"/"+id, "container stats")
 	if err != nil {
 		return nil, err
@@ -161,7 +161,7 @@ func containerStats(client *http.Client, id string) (*docker.Stats, error) {
 
 	fmt.Printf("Received container stats: %s \n", string(body))
 
-	var containerStats docker.Stats
+	var containerStats types.Stats
 	err = json.Unmarshal(body, &containerStats)
 	if err != nil {
 		return nil, fmt.Errorf("container stats: unable to parse response body: %v", err)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
- Migrating Stats to Docker SDK
- Implemented inactivity timeout handling

### Implementation details
- Replaced docker.Stats with types.Stats
- Added unit tests for new stats function
- Added a function to waitForStats in docker_client_tests.go as the API call is made within a goroutine and we need to make sure it is called to avoid "missing call" error.
- updated mocks w/ mocked io.Reader to mock Engine Response.
- copied how go-dockerclient handled inactivity timeout handling into docker_client.go

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
