### PR TITLE
dockerapi: Migrated Events to Docker SDK

### DIFF
--- a/agent/dockerclient/dockerapi/docker_events_buffer_test.go
+++ b/agent/dockerclient/dockerapi/docker_events_buffer_test.go
@@ -16,26 +16,27 @@
 package dockerapi
 
 import (
+	"context"
 	"strconv"
 	"testing"
 
-	docker "github.com/fsouza/go-dockerclient"
+	"github.com/docker/docker/api/types/events"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestProduceConsume(t *testing.T) {
 	buffer := NewInfiniteBuffer()
-	producer := make(chan *docker.APIEvents)
-	consumer := make(chan *docker.APIEvents)
+	producer := make(chan events.Message)
+	consumer := make(chan *events.Message)
 
 	// Start the process of producer and consumer
-	go buffer.StartListening(producer)
+	go buffer.StartListening(context.TODO(), producer)
 	go buffer.Consume(consumer)
 
 	// writing multiple events to the buffer
 	go func() {
 		for i := 0; i < 10000; i++ {
-			producer <- &docker.APIEvents{
+			producer <- events.Message{
 				ID:     strconv.Itoa(i),
 				Type:   containerTypeEvent,
 				Status: "die",
@@ -50,19 +51,19 @@ func TestProduceConsume(t *testing.T) {
 
 func TestIgnoreEvents(t *testing.T) {
 	buffer := NewInfiniteBuffer()
-	producer := make(chan *docker.APIEvents)
-	consumer := make(chan *docker.APIEvents)
+	producer := make(chan events.Message)
+	consumer := make(chan *events.Message)
 
 	// Start the process of producer and consumer
-	go buffer.StartListening(producer)
+	go buffer.StartListening(context.TODO(), producer)
 	go buffer.Consume(consumer)
 
 	// event with empty ID
-	producer <- &docker.APIEvents{Type: containerTypeEvent, Status: "stop"}
+	producer <- events.Message{Type: containerTypeEvent, Status: "stop"}
 	// event with wrong type
-	producer <- &docker.APIEvents{ID: "id", Status: "stop", Type: "image"}
+	producer <- events.Message{ID: "id", Status: "stop", Type: "image"}
 	for _, event := range containerEvents {
-		producer <- &docker.APIEvents{ID: "id", Type: containerTypeEvent, Status: event + "invalid"}
+		producer <- events.Message{ID: "id", Type: containerTypeEvent, Status: event + "invalid"}
 	}
 
 	buffer.lock.Lock()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Migrating Events to Docker SDK
Pulled from https://github.com/aws/amazon-ecs-agent/pull/1498 and fixed remaining PR comments. Benchmark test will be done after go-dockerclient to SDK migration completes.

### Implementation details
- Migrated AddEventEventListener/RemoveEventListener from go-dockerclient to Events from the Docker SDK.
- docker.APIEvents --> events.Message
- The new channels returned from Events contains values and not pointers, so in order to receive them in StartListening(), you must force an evaluation of the variable by adding it as a parameter to the function.
  - This is because the goroutine is accessing the variable 'event' via the closure, and this reference is evaluated when its reached the event variable in CopyEvents. The event variable is being updated by the loop, so there's a race between the loop updates and the goroutines that have started.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
