### PR TITLE
Adding parenthesis in README and removing unnecessary env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ PS C:\> Set-Location ${ecsExeDir}
 PS C:\> # Set $EnableTaskIAMRoles to $true to enable task IAM roles
 PS C:\> # Note that enabling IAM roles will make port 80 unavailable for tasks.
 PS C:\> [bool]$EnableTaskIAMRoles = $false
-PS C:\> if (${EnableTaskIAMRoles} {
+PS C:\> if (${EnableTaskIAMRoles}) {
 >> .\hostsetup.ps1
 >> }
 PS C:\> # Install the agent service

--- a/scripts/shared_env
+++ b/scripts/shared_env
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may
 # not use this file except in compliance with the License. A copy of the
@@ -16,7 +16,6 @@
 # setting any other common environment variables
 # It is expected to be 'sourced' while the CWD is the root of the repository
 
-export GO15VENDOREXPERIMENT=1
 # Include generate scripts.
 # The existing PATH should have a recent 'go' binary on it, as well as basic posix tools
 export PATH="$(pwd)/scripts/generate:${PATH}"


### PR DESCRIPTION
Adding quick fixes to README and shared_env

### Summary
1) Matches an unmatched parenthesis in the README.
2) Removes the GO15VENDOREXPERIMENT environment variable that is no longer needed because Go v1.9 automatically checks the /vendor folder.

### Implementation details
Added a parenthesis in the README where it was needed. 
Removed the line that added the GO15VENDOREXPERIMENT environment variable in shared_var file. 

### Testing
All tests in Octokitten run and passed. 

- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
Adding parentheses in README and removing unnecessary env var

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
