### PR TITLE
agent: ran gofmt

### DIFF
--- a/agent/api/ecsclient/client.go
+++ b/agent/api/ecsclient/client.go
@@ -271,7 +271,7 @@ func getCpuAndMemory() (int64, int64) {
 }
 
 func (client *APIECSClient) getAdditionalAttributes() []*ecs.Attribute {
-	return []*ecs.Attribute{&ecs.Attribute{
+	return []*ecs.Attribute{{
 		Name:  aws.String("ecs.os-type"),
 		Value: aws.String(config.OSType),
 	}}

--- a/agent/api/ecsclient/client_test.go
+++ b/agent/api/ecsclient/client_test.go
@@ -115,7 +115,7 @@ func (lhs *taskSubmitInputMatcher) Matches(x interface{}) bool {
 	}
 
 	if len(lhs.Attachments) != 0 {
-		for i, _ := range lhs.Attachments {
+		for i := range lhs.Attachments {
 			if !(equal(lhs.Attachments[i].Status, rhs.Attachments[i].Status) &&
 				equal(lhs.Attachments[i].AttachmentArn, rhs.Attachments[i].AttachmentArn)) {
 				return false

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -250,10 +250,10 @@ func TestDockerHostConfigPauseContainer(t *testing.T) {
 			ID: "eniID",
 		},
 		Containers: []*apicontainer.Container{
-			&apicontainer.Container{
+			{
 				Name: "c1",
 			},
-			&apicontainer.Container{
+			{
 				Name: PauseContainerName,
 				Type: apicontainer.ContainerCNIPause,
 			},
@@ -862,15 +862,15 @@ func TestTaskUpdateKnownStatusToPendingWithEssentialContainerStoppedWhenSteadySt
 	testTask := &Task{
 		KnownStatusUnsafe: apitaskstatus.TaskStatusNone,
 		Containers: []*apicontainer.Container{
-			&apicontainer.Container{
+			{
 				KnownStatusUnsafe: apicontainerstatus.ContainerCreated,
 				Essential:         true,
 			},
-			&apicontainer.Container{
+			{
 				KnownStatusUnsafe: apicontainerstatus.ContainerStopped,
 				Essential:         true,
 			},
-			&apicontainer.Container{
+			{
 				KnownStatusUnsafe:       apicontainerstatus.ContainerCreated,
 				Essential:               true,
 				SteadyStateStatusUnsafe: &resourcesProvisioned,
@@ -898,8 +898,8 @@ func TestGetEarliestTaskStatusForContainersWhenKnownStatusIsNotSetForContainers(
 	testTask := &Task{
 		KnownStatusUnsafe: apitaskstatus.TaskStatusNone,
 		Containers: []*apicontainer.Container{
-			&apicontainer.Container{},
-			&apicontainer.Container{},
+			{},
+			{},
 		},
 	}
 	assert.Equal(t, testTask.getEarliestKnownTaskStatusForContainers(), apitaskstatus.TaskStatusNone)
@@ -909,10 +909,10 @@ func TestGetEarliestTaskStatusForContainersWhenSteadyStateIsRunning(t *testing.T
 	testTask := &Task{
 		KnownStatusUnsafe: apitaskstatus.TaskStatusNone,
 		Containers: []*apicontainer.Container{
-			&apicontainer.Container{
+			{
 				KnownStatusUnsafe: apicontainerstatus.ContainerCreated,
 			},
-			&apicontainer.Container{
+			{
 				KnownStatusUnsafe: apicontainerstatus.ContainerRunning,
 			},
 		},
@@ -932,13 +932,13 @@ func TestGetEarliestTaskStatusForContainersWhenSteadyStateIsResourceProvisioned(
 	testTask := &Task{
 		KnownStatusUnsafe: apitaskstatus.TaskStatusNone,
 		Containers: []*apicontainer.Container{
-			&apicontainer.Container{
+			{
 				KnownStatusUnsafe: apicontainerstatus.ContainerCreated,
 			},
-			&apicontainer.Container{
+			{
 				KnownStatusUnsafe: apicontainerstatus.ContainerRunning,
 			},
-			&apicontainer.Container{
+			{
 				KnownStatusUnsafe:       apicontainerstatus.ContainerRunning,
 				SteadyStateStatusUnsafe: &resourcesProvisioned,
 			},
@@ -964,13 +964,13 @@ func TestTaskUpdateKnownStatusChecksSteadyStateWhenSetToRunning(t *testing.T) {
 	testTask := &Task{
 		KnownStatusUnsafe: apitaskstatus.TaskStatusNone,
 		Containers: []*apicontainer.Container{
-			&apicontainer.Container{
+			{
 				KnownStatusUnsafe: apicontainerstatus.ContainerCreated,
 			},
-			&apicontainer.Container{
+			{
 				KnownStatusUnsafe: apicontainerstatus.ContainerRunning,
 			},
-			&apicontainer.Container{
+			{
 				KnownStatusUnsafe: apicontainerstatus.ContainerRunning,
 			},
 		},
@@ -995,15 +995,15 @@ func TestTaskUpdateKnownStatusChecksSteadyStateWhenSetToResourceProvisioned(t *t
 	testTask := &Task{
 		KnownStatusUnsafe: apitaskstatus.TaskStatusNone,
 		Containers: []*apicontainer.Container{
-			&apicontainer.Container{
+			{
 				KnownStatusUnsafe: apicontainerstatus.ContainerCreated,
 				Essential:         true,
 			},
-			&apicontainer.Container{
+			{
 				KnownStatusUnsafe: apicontainerstatus.ContainerRunning,
 				Essential:         true,
 			},
-			&apicontainer.Container{
+			{
 				KnownStatusUnsafe:       apicontainerstatus.ContainerRunning,
 				Essential:               true,
 				SteadyStateStatusUnsafe: &resourcesProvisioned,

--- a/agent/api/task/taskvolume_test.go
+++ b/agent/api/task/taskvolume_test.go
@@ -63,9 +63,9 @@ func TestMarshalUnmarshalTaskVolumes(t *testing.T) {
 	task := &Task{
 		Arn: "test",
 		Volumes: []TaskVolume{
-			TaskVolume{Name: "1", Type: HostVolumeType, Volume: &taskresourcevolume.LocalDockerVolume{}},
-			TaskVolume{Name: "2", Type: HostVolumeType, Volume: &taskresourcevolume.FSHostVolume{FSSourcePath: "/path"}},
-			TaskVolume{Name: "3", Type: DockerVolumeType, Volume: &taskresourcevolume.DockerVolumeConfig{Scope: "task", Driver: "local"}},
+			{Name: "1", Type: HostVolumeType, Volume: &taskresourcevolume.LocalDockerVolume{}},
+			{Name: "2", Type: HostVolumeType, Volume: &taskresourcevolume.FSHostVolume{FSSourcePath: "/path"}},
+			{Name: "3", Type: DockerVolumeType, Volume: &taskresourcevolume.DockerVolumeConfig{Scope: "task", Driver: "local"}},
 		},
 	}
 

--- a/agent/config/types_unix.go
+++ b/agent/config/types_unix.go
@@ -15,4 +15,4 @@
 package config
 
 // PlatformVariables consists of configuration variables specific to Linux
-type PlatformVariables struct {}
+type PlatformVariables struct{}

--- a/agent/dockerclient/dockerapi/docker_client_test.go
+++ b/agent/dockerclient/dockerapi/docker_client_test.go
@@ -1196,7 +1196,7 @@ func TestECRAuthCacheWithDifferentExecutionRole(t *testing.T) {
 
 func TestMetadataFromContainer(t *testing.T) {
 	ports := map[docker.Port][]docker.PortBinding{
-		docker.Port("80/tcp"): []docker.PortBinding{
+		docker.Port("80/tcp"): {
 			{
 				HostIP:   "0.0.0.0",
 				HostPort: "80",
@@ -1462,13 +1462,13 @@ func TestListPluginsWithFilter(t *testing.T) {
 	defer done()
 
 	plugins := []docker.PluginDetail{
-		docker.PluginDetail{
+		{
 			ID:     "id1",
 			Name:   "name1",
 			Tag:    "tag1",
 			Active: false,
 		},
-		docker.PluginDetail{
+		{
 			ID:     "id2",
 			Name:   "name2",
 			Tag:    "tag2",
@@ -1481,7 +1481,7 @@ func TestListPluginsWithFilter(t *testing.T) {
 				},
 			},
 		},
-		docker.PluginDetail{
+		{
 			ID:     "id3",
 			Name:   "name3",
 			Tag:    "tag3",

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -1645,7 +1645,7 @@ func TestTaskUseExecutionRolePullPrivateRegistryImage(t *testing.T) {
 	asmAuthRes := asmauth.NewASMAuthResource(testTask.Arn, requiredASMResources,
 		credentialsID, credentialsManager, asmClientCreator)
 	testTask.ResourcesMapUnsafe = map[string][]taskresource.TaskResource{
-		asmauth.ResourceName: []taskresource.TaskResource{asmAuthRes},
+		asmauth.ResourceName: {asmAuthRes},
 	}
 	mockASMClient := mock_secretsmanageriface.NewMockSecretsManagerAPI(ctrl)
 	asmAuthDataBytes, _ := json.Marshal(&asm.AuthDataValue{
@@ -2262,7 +2262,7 @@ func TestSynchronizeResource(t *testing.T) {
 	cgroupResource := mock_taskresource.NewMockTaskResource(ctrl)
 	testTask := testdata.LoadTask("sleep5")
 	testTask.ResourcesMapUnsafe = map[string][]taskresource.TaskResource{
-		"cgroup": []taskresource.TaskResource{
+		"cgroup": {
 			cgroupResource,
 		},
 	}

--- a/agent/eni/watcher/watcher_linux.go
+++ b/agent/eni/watcher/watcher_linux.go
@@ -182,7 +182,7 @@ func (udevWatcher *UdevWatcher) reconcileOnce() error {
 	// the race here. The state would be corrected during the next reconciliation loop.
 
 	// Add new interfaces next
-	for mac, _ := range currentState {
+	for mac := range currentState {
 		if err := udevWatcher.sendENIStateChange(mac); err != nil {
 			log.Warnf("Udev watcher reconciliation: unable to send state change: %v", err)
 		}

--- a/agent/eventhandler/handler_test.go
+++ b/agent/eventhandler/handler_test.go
@@ -405,8 +405,8 @@ func TestGetBatchedContainerEvents(t *testing.T) {
 
 	handler := &TaskHandler{
 		tasksToContainerStates: map[string][]api.ContainerStateChange{
-			"t1": []api.ContainerStateChange{},
-			"t2": []api.ContainerStateChange{},
+			"t1": {},
+			"t2": {},
 		},
 		state: state,
 	}
@@ -427,7 +427,7 @@ func TestGetBatchedContainerEventsStoppedTask(t *testing.T) {
 
 	handler := &TaskHandler{
 		tasksToContainerStates: map[string][]api.ContainerStateChange{
-			"t1": []api.ContainerStateChange{},
+			"t1": {},
 		},
 		state: state,
 	}

--- a/agent/functional_tests/util/utils_windows.go
+++ b/agent/functional_tests/util/utils_windows.go
@@ -136,7 +136,7 @@ func (agent *TestAgent) StartAgent() error {
 
 func (agent *TestAgent) Cleanup() {
 	if agent.Options != nil {
-		for k, _ := range agent.Options.ExtraEnvironment {
+		for k := range agent.Options.ExtraEnvironment {
 			os.Unsetenv(k)
 		}
 	}

--- a/agent/handlers/taskmetadata/taskinfo_test.go
+++ b/agent/handlers/taskmetadata/taskinfo_test.go
@@ -253,7 +253,7 @@ func TestTaskStats(t *testing.T) {
 
 	dockerStats := &docker.Stats{NumProcs: 2}
 	containerMap := map[string]*apicontainer.DockerContainer{
-		containerName: &apicontainer.DockerContainer{
+		containerName: {
 			DockerID: containerID,
 		},
 	}

--- a/agent/handlers/v1/response_test.go
+++ b/agent/handlers/v1/response_test.go
@@ -109,7 +109,7 @@ func TestTaskResponse(t *testing.T) {
 	}
 
 	containerNameToDockerContainer := map[string]*apicontainer.DockerContainer{
-		taskARN: &apicontainer.DockerContainer{
+		taskARN: {
 			DockerID:   containerID,
 			DockerName: containerName,
 			Container:  container,

--- a/agent/handlers/v2/response_test.go
+++ b/agent/handlers/v2/response_test.go
@@ -105,7 +105,7 @@ func TestTaskResponse(t *testing.T) {
 	}
 	container.SetLabels(labels)
 	containerNameToDockerContainer := map[string]*apicontainer.DockerContainer{
-		taskARN: &apicontainer.DockerContainer{
+		taskARN: {
 			DockerID:   containerID,
 			DockerName: containerName,
 			Container:  container,

--- a/agent/handlers/v2/stats_response_test.go
+++ b/agent/handlers/v2/stats_response_test.go
@@ -35,7 +35,7 @@ func TestTaskStatsResponseSuccess(t *testing.T) {
 
 	dockerStats := &docker.Stats{NumProcs: 2}
 	containerMap := map[string]*apicontainer.DockerContainer{
-		containerName: &apicontainer.DockerContainer{
+		containerName: {
 			DockerID: containerID,
 		},
 	}

--- a/agent/handlers/v2_server_setup_test.go
+++ b/agent/handlers/v2_server_setup_test.go
@@ -475,7 +475,7 @@ func TestTaskStats(t *testing.T) {
 
 	dockerStats := &docker.Stats{NumProcs: 2}
 	containerMap := map[string]*apicontainer.DockerContainer{
-		containerName: &apicontainer.DockerContainer{
+		containerName: {
 			DockerID: containerID,
 		},
 	}

--- a/agent/httpclient/httpclient_test.go
+++ b/agent/httpclient/httpclient_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestNewHttpClient(t *testing.T) {
-	expectedResult := New(time.Duration(10),true)
+	expectedResult := New(time.Duration(10), true)
 	transport := expectedResult.Transport.(*ecsRoundTripper)
 	assert.Equal(t, cipher.SupportedCipherSuites, transport.transport.(*http.Transport).TLSClientConfig.CipherSuites)
 	assert.Equal(t, true, transport.transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify)

--- a/agent/statemanager/state_manager_test.go
+++ b/agent/statemanager/state_manager_test.go
@@ -104,7 +104,7 @@ func TestLoadsV13DataCorrectly(t *testing.T) {
 	err = stateManager.Load()
 	assert.NoError(t, err)
 
-	assert.Equal(t,  "test", cluster)
+	assert.Equal(t, "test", cluster)
 	assert.EqualValues(t, 0, sequenceNumber)
 	tasks, err := taskEngine.ListTasks()
 	assert.NoError(t, err)

--- a/agent/statemanager/state_manager_windows_test.go
+++ b/agent/statemanager/state_manager_windows_test.go
@@ -21,8 +21,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/aws/amazon-ecs-agent/agent/statemanager/dependencies/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/statemanager/dependencies/mocks"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/sys/windows/registry"
@@ -172,8 +172,6 @@ func TestStateManagerLoadV13Data(t *testing.T) {
 	assert.Equal(t, "arn:aws:ecs:us-west-2:694464167470:container-instance/5e94f1e5-2177-4440-ab84-196d1a6072da", containerInstanceArn)
 	assert.Equal(t, "i-04e73559ead350d79", savedInstanceID)
 }
-
-
 
 func TestStateManagerSaveCreateFileError(t *testing.T) {
 	mockRegistry, mockKey, mockFS, _, manager, cleanup := setup(t)

--- a/agent/utils/cipher/cipher.go
+++ b/agent/utils/cipher/cipher.go
@@ -17,6 +17,7 @@ package cipher
 import (
 	"crypto/tls"
 )
+
 // Only support a subset of ciphers, corresponding cipher suite names can be found here: https://golang.org/pkg/crypto/tls/#Config
 var SupportedCipherSuites = []uint16{
 	tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,


### PR DESCRIPTION
### Summary
inspired by this [line change](https://github.com/aws/amazon-ecs-agent/pull/1569/files#diff-b9aa12c3425c34d6f330f28407f779f6L156)
### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [ ] Builds on Linux (`make release`)
- [ ] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [ ] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
