### PR TITLE
fix windows drive volume mounting

### DIFF
--- a/agent/api/task/task_windows.go
+++ b/agent/api/task/task_windows.go
@@ -74,7 +74,22 @@ func (task *Task) downcaseAllVolumePaths() {
 }
 
 func getCanonicalPath(path string) string {
-	return filepath.Clean(strings.ToLower(path))
+	lowercasedPath := strings.ToLower(path)
+	// if the path is a bare drive like "d:", don't filepath.Clean it because it will add a '.'.
+	// this is to fix the case where mounting from D:\ to D: is supported by docker but not ecs
+	if isBareDrive(lowercasedPath) {
+		return lowercasedPath
+	}
+
+	return filepath.Clean(lowercasedPath)
+}
+
+func isBareDrive(path string) bool {
+	if filepath.VolumeName(path) == path {
+		return true
+	}
+
+	return false
 }
 
 // platformHostConfigOverride provides an entry point to set up default HostConfig options to be

--- a/agent/api/task/task_windows_test.go
+++ b/agent/api/task/task_windows_test.go
@@ -295,3 +295,29 @@ func TestCPUPercentBasedOnUnboundedEnabled(t *testing.T) {
 		})
 	}
 }
+
+func TestGetCanonicalPath(t *testing.T) {
+	testcases := []struct {
+		name           string
+		path           string
+		expectedResult string
+	}{
+		{
+			name:           "folderPath",
+			path:           `C:\myFile`,
+			expectedResult: `c:\myfile`,
+		},
+		{
+			name:           "drivePath",
+			path:           `D:`,
+			expectedResult: `d:`,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := getCanonicalPath(tc.path)
+			assert.Equal(t, result, tc.expectedResult)
+		})
+	}
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
For windows volume task, the agent fails to support a mounting from drive to drive, because when the container path is a bare drive like 'D:', the agent changes it to 'd:.' in the getCanonicalPath function, which is no longer supported by Docker because that is a directory, but container path can only be either a directory in C drive, or another drive. This pr is to fix this issue.

### Implementation details
<!-- How are the changes implemented? -->
Treat the bare drive path specially in getCanonicalPath.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->
unit test added; manual test is performed to verify that this fixes the issue; functional test is not added because it seems to be nontrivial to add another drive.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
