### PR TITLE
Agent Binary Executable Name Change

### DIFF
--- a/agent/functional_tests/README.md
+++ b/agent/functional_tests/README.md
@@ -66,7 +66,7 @@ done first:
 
 ### Windows
 
-Before running these tests, you should build the ECS agent (as `agent.exe`) and
+Before running these tests, you should build the ECS agent (as `amazon-ecs-agent.exe`) and
 record the directory where the binary is present in the `ECS_WINDOWS_TEST_DIR`
 environment variable.
 
@@ -75,7 +75,7 @@ You can configure the following environment variables to change test
 execution behavior:
 * `AWS_REGION`: Control the region that is used for test execution
 * `ECS_CLUSTER`: Control the cluster used for test execution
-* `ECS_WINDOWS_TEST_DIR`: Override the path used to find `agent.exe`
+* `ECS_WINDOWS_TEST_DIR`: Override the path used to find `amazon-ecs-agent.exe`
 * `ECS_FTEST_TMP`: Override the default temporary directory used for storing
   test logs and data files
 

--- a/agent/functional_tests/util/utils_windows.go
+++ b/agent/functional_tests/util/utils_windows.go
@@ -120,7 +120,7 @@ func (agent *TestAgent) StartAgent() error {
 			os.Setenv(k, v)
 		}
 	}
-	agentInvoke := exec.Command(".\\agent.exe")
+	agentInvoke := exec.Command(".\\amazon-ecs-agent.exe")
 	if TestDirectory := os.Getenv("ECS_WINDOWS_TEST_DIR"); TestDirectory != "" {
 		agentInvoke.Dir = TestDirectory
 	}

--- a/misc/windows-deploy/amazon-ecs-agent.ps1
+++ b/misc/windows-deploy/amazon-ecs-agent.ps1
@@ -70,7 +70,7 @@ try {
     try {
         .\amazon-ecs-agent.exe
     } catch {
-        LogMsg -message "Could not start agent.exe." -logLevel "ERROR"
+        LogMsg -message "Could not start amazon-ecs-agent.exe." -logLevel "ERROR"
         LogMsg -message $_.Exception.Message -logLevel "ERROR"
         exit 2
     }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This PR renames the binary used for windows testing from `agent` to `amazon-ecs-agent` to keep the naming consistent across the codebase. It addresses the issue #1207. Corresponding changes need to be made to internal test for windows functional test to pass. 


### Testing
The changes were tested by running against the modified internal tests in the personal account. 
 
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [ ] Builds on Linux (`make release`)
- [ ] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [ ] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass



### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
