### PR TITLE
config: add port 5986 to windows default reserved ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ additional details on each available environment variable.
 | Environment Key | Example Value(s)            | Description | Default value on Linux | Default value on Windows |
 |:----------------|:----------------------------|:------------|:-----------------------|:-------------------------|
 | `ECS_CLUSTER`       | clusterName             | The cluster this agent should check into. | default | default |
-| `ECS_RESERVED_PORTS` | `[22, 80, 5000, 8080]` | An array of ports that should be marked as unavailable for scheduling on this container instance. | `[22, 2375, 2376, 51678, 51679]` | `[53, 135, 139, 445, 2375, 2376, 3389, 5985, 51678, 51679]`
+| `ECS_RESERVED_PORTS` | `[22, 80, 5000, 8080]` | An array of ports that should be marked as unavailable for scheduling on this container instance. | `[22, 2375, 2376, 51678, 51679]` | `[53, 135, 139, 445, 2375, 2376, 3389, 5985, 5986, 51678, 51679]`
 | `ECS_RESERVED_PORTS_UDP` | `[53, 123]` | An array of UDP ports that should be marked as unavailable for scheduling on this container instance. | `[]` | `[]` |
 | `ECS_ENGINE_AUTH_TYPE`     |  "docker" &#124; "dockercfg" | The type of auth data that is stored in the `ECS_ENGINE_AUTH_DATA` key. | | |
 | `ECS_ENGINE_AUTH_DATA`     | See the [dockerauth documentation](https://godoc.org/github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerauth) | Docker [auth data](https://godoc.org/github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerauth) formatted as defined by `ECS_ENGINE_AUTH_TYPE`. | | |

--- a/agent/config/config_windows.go
+++ b/agent/config/config_windows.go
@@ -36,8 +36,10 @@ const (
 	rpcPort = 135
 	// Server Message Block (SMB) over TCP
 	smbPort = 445
-	// Windows Remote Management (WinRM) listener
-	winRMPort = 5985
+	// HTTP port for Windows Remote Management (WinRM) listener
+	winRMPortHTTP = 5985
+	// HTTPS port for Windows Remote Management (WinRM) listener
+	winRMPortHTTPS = 5986
 	// DNS client
 	dnsPort = 53
 	// NetBIOS over TCP/IP
@@ -66,7 +68,8 @@ func DefaultConfig() Config {
 			rdpPort,
 			rpcPort,
 			smbPort,
-			winRMPort,
+			winRMPortHTTP,
+			winRMPortHTTPS,
 			dnsPort,
 			netBIOSPort,
 		},

--- a/agent/config/config_windows_test.go
+++ b/agent/config/config_windows_test.go
@@ -36,7 +36,7 @@ func TestConfigDefault(t *testing.T) {
 	assert.Equal(t, "npipe:////./pipe/docker_engine", cfg.DockerEndpoint, "Default docker endpoint set incorrectly")
 	assert.Equal(t, `C:\ProgramData\Amazon\ECS\data`, cfg.DataDir, "Default datadir set incorrectly")
 	assert.False(t, cfg.DisableMetrics, "Default disablemetrics set incorrectly")
-	assert.Equal(t, 10, len(cfg.ReservedPorts), "Default reserved ports set incorrectly")
+	assert.Equal(t, 11, len(cfg.ReservedPorts), "Default reserved ports set incorrectly")
 	assert.Equal(t, uint16(0), cfg.ReservedMemory, "Default reserved memory set incorrectly")
 	assert.Equal(t, 30*time.Second, cfg.DockerStopTimeout, "Default docker stop container timeout set incorrectly")
 	assert.Equal(t, 8*time.Minute, cfg.ContainerStartTimeout, "Default docker start container timeout set incorrectly")
@@ -75,7 +75,8 @@ func TestConfigIAMTaskRolesReserves80(t *testing.T) {
 		rdpPort,
 		rpcPort,
 		smbPort,
-		winRMPort,
+		winRMPortHTTP,
+		winRMPortHTTPS,
 		dnsPort,
 		netBIOSPort,
 		httpPort,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Fix https://github.com/aws/amazon-ecs-agent/issues/920. Add port 5986 to windows default reserved tcp ports.

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
