### PR TITLE
Updating Task Model and implementing docker flags --pid and --ipc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 1.20.4-dev
+* Bug - Fixed a bug where Windows drive volume couldn't be mounted [#1571](https://github.com/aws/amazon-ecs-agent/pull/1571)
+* Bug - Fixed a bug where the Agent's Windows binaries didn't use consistent naming [#1573](https://github.com/aws/amazon-ecs-agent/pull/1573)
+* Bug - Fixed a bug where a port used by WinRM service was not reserved by the Agent by default [#1577](https://github.com/aws/amazon-ecs-agent/pull/1577)
+
 ## 1.20.3
 * Enhancement - Deprecate support for serial docker image pull [#1569](https://github.com/aws/amazon-ecs-agent/pull/1569)
 * Enhancement - Update the `amazon-ecs-cni-plugins` to `2018.08.0`

--- a/LICENSE
+++ b/LICENSE
@@ -1,616 +1,202 @@
-** github.com/aws/aws-sdk-go; version v1.10.30 -- https://github.com/aws/aws-sdk-go
-** github.com/containerd/cgroups; version c3fc2b77b568af2406f3931cf3d3f17d76736886 -- https://github.com/containerd/cgroups
-** github.com/containerd/continuity; version 1bed1ecb1dc42d8f4d2ac8c23e5cac64749e82c9 -- https://github.com/containerd/continuity
-** github.com/containernetworking/cni; version v0.5.2 -- https://github.com/containernetworking/cni
-** github.com/coreos/go-systemd; version 24036eb3df68550d24a2736c5d013f4e83366866 -- https://github.com/coreos/go-systemd
-** github.com/docker/docker; version e4d0fe84f9ea88b0e0cfd847412c9f29442cc62d -- https://github.com/moby/moby
-** github.com/docker/go-connections; version v0.3.0 -- https://github.com/docker/go-connections
-** github.com/docker/go-units; version v0.3.2 -- https://github.com/docker/go-units
-** github.com/go-ini/ini; version v1.31.1 -- https://github.com/go-ini/ini
-** github.com/golang/mock; version bd3c8e81be01eef76d4b503f5e687d2d1354d2d9 -- https://github.com/golang/mock/blob/master/LICENSE
-** github.com/jmespath/go-jmespath; version 0b12d6b5 -- https://github.com/jmespath/go-jmespath
-** github.com/opencontainers/go-digest; version v1.0.0-rc1 -- https://github.com/opencontainers/go-digest
-** github.com/opencontainers/image-spec; version v1.0.1 -- https://github.com/opencontainers/image-spec
-** github.com/opencontainers/runc; version v0.1.1 -- https://github.com/opencontainers/runc
-** github.com/opencontainers/runtime-spec; version d349388c43b01b2ea695965ae561b5bddb81318f -- https://github.com/opencontainers/runtime-spec
-** github.com/vishvananda/netlink; version fe3b5664d23a11b52ba59bece4ff29c52772a56b -- https://github.com/vishvananda/netlink
-** github.com/vishvananda/netns; version be1fbeda19366dea804f00efff2dd73a1642fdcc -- https://github.com/vishvananda/netns
-
-Apache License
-Version 2.0, January 2004
-http://www.apache.org/licenses/
-
-TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-1. Definitions.
-
-"License" shall mean the terms and conditions for use, reproduction, and
-distribution as defined by Sections 1 through 9 of this document.
-
-"Licensor" shall mean the copyright owner or entity authorized by the copyright
-owner that is granting the License.
-
-"Legal Entity" shall mean the union of the acting entity and all other entities
-that control, are controlled by, or are under common control with that entity.
-For the purposes of this definition, "control" means (i) the power, direct or
-indirect, to cause the direction or management of such entity, whether by
-contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the
-outstanding shares, or (iii) beneficial ownership of such entity.
-
-"You" (or "Your") shall mean an individual or Legal Entity exercising
-permissions granted by this License.
-
-"Source" form shall mean the preferred form for making modifications, including
-but not limited to software source code, documentation source, and
-configuration files.
-
-"Object" form shall mean any form resulting from mechanical transformation or
-translation of a Source form, including but not limited to compiled object
-code, generated documentation, and conversions to other media types.
-
-"Work" shall mean the work of authorship, whether in Source or Object form,
-made available under the License, as indicated by a copyright notice that is
-included in or attached to the work (an example is provided in the Appendix
-below).
-
-"Derivative Works" shall mean any work, whether in Source or Object form, that
-is based on (or derived from) the Work and for which the editorial revisions,
-annotations, elaborations, or other modifications represent, as a whole, an
-original work of authorship. For the purposes of this License, Derivative Works
-shall not include works that remain separable from, or merely link (or bind by
-name) to the interfaces of, the Work and Derivative Works thereof.
-
-"Contribution" shall mean any work of authorship, including the original
-version of the Work and any modifications or additions to that Work or
-Derivative Works thereof, that is intentionally submitted to Licensor for
-inclusion in the Work by the copyright owner or by an individual or Legal
-Entity authorized to submit on behalf of the copyright owner. For the purposes
-of this definition, "submitted" means any form of electronic, verbal, or
-written communication sent to the Licensor or its representatives, including
-but not limited to communication on electronic mailing lists, source code
-control systems, and issue tracking systems that are managed by, or on behalf
-of, the Licensor for the purpose of discussing and improving the Work, but
-excluding communication that is conspicuously marked or otherwise designated in
-writing by the copyright owner as "Not a Contribution."
-
-"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
-of whom a Contribution has been received by Licensor and subsequently
-incorporated within the Work.
-
-2. Grant of Copyright License. Subject to the terms and conditions of this
-License, each Contributor hereby grants to You a perpetual, worldwide,
-non-exclusive, no-charge, royalty-free, irrevocable copyright license to
-reproduce, prepare Derivative Works of, publicly display, publicly perform,
-sublicense, and distribute the Work and such Derivative Works in Source or
-Object form.
-
-3. Grant of Patent License. Subject to the terms and conditions of this
-License, each Contributor hereby grants to You a perpetual, worldwide,
-non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this
-section) patent license to make, have made, use, offer to sell, sell, import,
-and otherwise transfer the Work, where such license applies only to those
-patent claims licensable by such Contributor that are necessarily infringed by
-their Contribution(s) alone or by combination of their Contribution(s) with the
-Work to which such Contribution(s) was submitted. If You institute patent
-litigation against any entity (including a cross-claim or counterclaim in a
-lawsuit) alleging that the Work or a Contribution incorporated within the Work
-constitutes direct or contributory patent infringement, then any patent
-licenses granted to You under this License for that Work shall terminate as of
-the date such litigation is filed.
-
-4. Redistribution. You may reproduce and distribute copies of the Work or
-Derivative Works thereof in any medium, with or without modifications, and in
-Source or Object form, provided that You meet the following conditions:
-
-(a) You must give any other recipients of the Work or Derivative Works a copy
-of this License; and
-
-(b) You must cause any modified files to carry prominent notices stating that
-You changed the files; and
-
-(c) You must retain, in the Source form of any Derivative Works that You
-distribute, all copyright, patent, trademark, and attribution notices from the
-Source form of the Work, excluding those notices that do not pertain to any
-part of the Derivative Works; and
-
-(d) If the Work includes a "NOTICE" text file as part of its distribution, then
-any Derivative Works that You distribute must include a readable copy of the
-attribution notices contained within such NOTICE file, excluding those notices
-that do not pertain to any part of the Derivative Works, in at least one of the
-following places: within a NOTICE text file distributed as part of the
-Derivative Works; within the Source form or documentation, if provided along
-with the Derivative Works; or, within a display generated by the Derivative
-Works, if and wherever such third-party notices normally appear. The contents
-of the NOTICE file are for informational purposes only and do not modify the
-License. You may add Your own attribution notices within Derivative Works that
-You distribute, alongside or as an addendum to the NOTICE text from the Work,
-provided that such additional attribution notices cannot be construed as
-modifying the License.
-
-You may add Your own copyright statement to Your modifications and may provide
-additional or different license terms and conditions for use, reproduction, or
-distribution of Your modifications, or for any such Derivative Works as a
-whole, provided Your use, reproduction, and distribution of the Work otherwise
-complies with the conditions stated in this License.
-
-5. Submission of Contributions. Unless You explicitly state otherwise, any
-Contribution intentionally submitted for inclusion in the Work by You to the
-Licensor shall be under the terms and conditions of this License, without any
-additional terms or conditions. Notwithstanding the above, nothing herein shall
-supersede or modify the terms of any separate license agreement you may have
-executed with Licensor regarding such Contributions.
-
-6. Trademarks. This License does not grant permission to use the trade names,
-trademarks, service marks, or product names of the Licensor, except as required
-for reasonable and customary use in describing the origin of the Work and
-reproducing the content of the NOTICE file.
-
-7. Disclaimer of Warranty. Unless required by applicable law or agreed to in
-writing, Licensor provides the Work (and each Contributor provides its
-Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied, including, without limitation, any warranties
-or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-PARTICULAR PURPOSE. You are solely responsible for determining the
-appropriateness of using or redistributing the Work and assume any risks
-associated with Your exercise of permissions under this License.
-
-8. Limitation of Liability. In no event and under no legal theory, whether in
-tort (including negligence), contract, or otherwise, unless required by
-applicable law (such as deliberate and grossly negligent acts) or agreed to in
-writing, shall any Contributor be liable to You for damages, including any
-direct, indirect, special, incidental, or consequential damages of any
-character arising as a result of this License or out of the use or inability to
-use the Work (including but not limited to damages for loss of goodwill, work
-stoppage, computer failure or malfunction, or any and all other commercial
-damages or losses), even if such Contributor has been advised of the
-possibility of such damages.
-
-9. Accepting Warranty or Additional Liability. While redistributing the Work or
-Derivative Works thereof, You may choose to offer, and charge a fee for,
-acceptance of support, warranty, indemnity, or other liability obligations
-and/or rights consistent with this License. However, in accepting such
-obligations, You may act only on Your own behalf and on Your sole
-responsibility, not on behalf of any other Contributor, and only if You agree
-to indemnify, defend, and hold each Contributor harmless for any liability
-incurred by, or claims asserted against, such Contributor by reason of your
-accepting any such warranty or additional liability.
-
-END OF TERMS AND CONDITIONS
-
-APPENDIX: How to apply the Apache License to your work.
-
-To apply the Apache License to your work, attach the following boilerplate
-notice, with the fields enclosed by brackets "[]" replaced with your own
-identifying information. (Don't include the brackets!)  The text should be
-enclosed in the appropriate comment syntax for the file format. We also
-recommend that a file or class name and description of purpose be included on
-the same "printed page" as the copyright notice for easier identification
-within third-party archives.
-
-Copyright [yyyy] [name of copyright owner]
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-* For github.com/aws/aws-sdk-go see also this required NOTICE:
-AWS SDK for Go
-Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved. 
-Copyright 2014-2015 Stripe, Inc.
-* For github.com/containerd/cgroups see also this required NOTICE:
-Copyright (c) 2016-2017 the containerd authors
-* For github.com/containerd/continuity see also this required NOTICE:
-Copyright (c) 2016-2017 the containerd authors
-* For github.com/containernetworking/cni see also this required NOTICE:
-Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
-* For github.com/coreos/go-systemd see also this required NOTICE:
-Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
-* For github.com/docker/docker see also this required NOTICE:
-Copyright 2013-2017 Docker, Inc.
-* For github.com/docker/go-connections see also this required NOTICE:
-Copyright 2015 Docker, Inc.
-* For github.com/docker/go-units see also this required NOTICE:
-Copyright 2015 Docker, Inc.
-* For github.com/go-ini/ini see also this required NOTICE:
-Copyright 2014 Unknwon
-* For github.com/golang/mock see also this required NOTICE:
-Alex Reece <awreece@gmail.com>
-Google Inc.
-* For github.com/jmespath/go-jmespath see also this required NOTICE:
-Copyright 2015 James Saryerwinnie
-* For github.com/opencontainers/go-digest see also this required NOTICE:
-Copyright © 2016 Docker, Inc.
-* For github.com/opencontainers/image-spec see also this required NOTICE:
-Copyright 2016 The Linux Foundation.
-* For github.com/opencontainers/runc see also this required NOTICE:
-Copyright 2014 Docker, Inc.
-* For github.com/opencontainers/runtime-spec see also this required NOTICE:
-Copyright 2015 The Linux Foundation.
-* For github.com/vishvananda/netlink see also this required NOTICE:
-Copyright 2014 Vishvananda Ishaya.
-Copyright 2014 Docker, Inc.
-* For github.com/vishvananda/netns see also this required NOTICE:
-Copyright 2014 Vishvananda Ishaya.
-Copyright 2014 Docker, Inc.
-
------
-
-** github.com/fsouza/go-dockerclient; version d25e8d2941bd448756b336a2ec3abf79802d6ddf -- https://github.com/fsouza/go-dockerclient
-Copyright (c) 2013-2017, go-dockerclient authors
-** github.com/godbus/dbus; version v4.1.0 -- https://github.com/godbus/dbus
-Copyright (c) 2013, Georg Reinke (<guelfey at gmail dot com>), Google
-** github.com/gorilla/websocket; version 0868951cdb8e69bc42df4598bdc6164ff2f1a072 -- https://github.com/gorilla/websocket
-Copyright (c) 2013 The Gorilla WebSocket Authors. All rights reserved.
-** github.com/Nvveen/Gotty; version cd527374f1e5bff4938207604a14f2e38a9cf512 -- https://github.com/Nvveen/Gotty
-Copyright (c) 2012, Neal van Veen (nealvanveen@gmail.com)
-** github.com/pkg/errors; version c605e284fe17294bda444b34710735b29d1a9d90 -- https://github.com/pkg/errors
-Copyright (c) 2015, Dave Cheney <dave@cheney.net>
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice, this
-list of conditions and the following disclaimer. 
-
-2. Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation
-and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
------
-
-** golang.org/x/tools; version 1 -- https://github.com/golang/tools
-Copyright (c) 2009 The Go Authors. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are
- met:
- 
-    * Redistributions of source code must retain the above copyright
- notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above
- copyright notice, this list of conditions and the following disclaimer
- in the documentation and/or other materials provided with the
- distribution.
-    * Neither the name of Google Inc. nor the names of its
- contributors may be used to endorse or promote products derived from
- this software without specific prior written permission.
- 
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
- A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
- OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
- LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
- THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
------
-
-** gorilla/mux; version v1.6.2 -- https://github.com/gorilla/mux
-Copyright (c) 2012-2018 The Gorilla Authors. All rights reserved.
-
-Copyright (c) 2012-2018 The Gorilla Authors. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-* Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-* Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-* Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
------
-
-** golang.org/x/crypto; version (master) -- https://github.com/golang/crypto
-Copyright (c) 2009 The Go Authors. All rights reserved.
-** golang.org/x/net; version master -- https://go.googlesource.com/net/
-Copyright (c) 2009 The Go Authors. All rights reserved.
-** https://github.com/golang/time; version NA -- https://github.com/golang/time
-Copyright (c) 2009 The Go Authors. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-* Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-* Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-* Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
------
-
-** golang.org/x/sys; version master -- https://github.com/golang/sys
-Copyright (c) 2009 The Go Authors. All rights reserved.
-
-Copyright (c) 2009 The Go Authors. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-* Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-* Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-* Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
------
-
-** github.com/cihub/seelog; version 0fa7e41d2b9600ca6b7e1592478124e4f800f724 -- https://github.com/cihub/seelog
-Copyright (c) 2012, Cloud Instruments Co., Ltd. <info@cin.io>
-** github.com/pborman/uuid; version ca53cad383cad2479bbba7f7a1a05797ec1386e4 -- https://github.com/pborman/uuid
-Copyright (c) 2009,2014 Google Inc. All rights reserved.
-** github.com/pmezard/go-difflib; version v1.0.0 -- https://github.com/pmezard/go-difflib
-Copyright (c) 2013, Patrick Mezard
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice, this
-list of conditions and the following disclaimer. 
-
-2. Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation
-and/or other materials provided with the distribution. 
-
-3. Neither the name of the copyright holder nor the names of its contributors
-may be used to endorse or promote products derived from this software without
-specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
-
------
-
-** github.com/davecgh/go-spew; version v1.1.0 -- https://github.com/davecgh/go-spew
-Copyright (c) 2012-2016 Dave Collins <dave@davec.name>
-
-ISC License:
-
-Copyright (c) 2004-2010 by Internet Systems Consortium, Inc. ("ISC")
-Copyright (c) 1995-2003 by Internet Software Consortium
-
-Permission to use, copy, modify, and/or distribute this software for any
-purpose with or without fee is hereby granted, provided that the above
-copyright notice and this permission notice appear in all copies.
-
-THE SOFTWARE IS PROVIDED "AS IS" AND ISC DISCLAIMS ALL WARRANTIES WITH REGARD
-TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
-FITNESS. IN NO EVENT SHALL ISC BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR
-CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,
-DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
-ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
-SOFTWARE.
-
------
-
-** github.com/patrickmn/go-cache; version v2.1.0 -- https://github.com/patrickmn/go-cache
-Copyright (c) 2012-2017 Patrick Mylund Nielsen and the go-cache contributors
-
-Copyright (c) 2012-2017 Patrick Mylund Nielsen and the go-cache contributors
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
------
-
-** github.com/Azure/go-ansiterm; version fa152c58bc15761d0200cb75fe958b89a9d4888e -- https://github.com/Azure/go-ansiterm
-Copyright (c) 2015 Microsoft Corporation
-** github.com/deniswernert/udev; version 82fe5be8ca5f7d8255cc838723687f61bb175120 -- https://github.com/deniswernert/udev
-Copyright (c) 2014 deniswernert
-** github.com/Microsoft/go-winio; version v0.3.6 -- https://github.com/Microsoft/go-winio
-Copyright (c) 2015 Microsoft
-** github.com/Sirupsen/logrus; version 3ec0642a7fb6488f65b06f9040adc67e3990296a -- https://github.com/Sirupsen/logrus
-Copyright (c) 2014 Simon Eskildsen
-
-MIT License
-
-Copyright (c) <year> <copyright holders>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-of the Software, and to permit persons to whom the Software is furnished to do
-so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
------
-
-** https://github.com/didip/tollbooth; version v3.0.2 -- https://github.com/didip/tollbooth
-NA
-
-The MIT License (MIT)
-
-Copyright (c) 2015 Didip Kerabat
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
------
-
-** github.com/stretchr/testify; version d77da356e56a7428ad25149ca77381849a6a5232 -- https://github.com/stretchr/testify
-Copyright (c) 2012 - 2013 Mat Ryer and Tyler Bunnell
-
-Copyright (c) 2012 - 2013 Mat Ryer and Tyler Bunnell
-
-Please consider promoting this project if you find it useful.
-
-Permission is hereby granted, free of charge, to any person 
-obtaining a copy of this software and associated documentation 
-files (the "Software"), to deal in the Software without restriction, 
-including without limitation the rights to use, copy, modify, merge, 
-publish, distribute, sublicense, and/or sell copies of the Software, 
-and to permit persons to whom the Software is furnished to do so, 
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included
-in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES 
-OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, 
-DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT 
-OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE 
-OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
------
-
-** github.com/gogo/protobuf; version v0.5 -- https://github.com/gogo/protobuf
-Copyright (c) 2013, The GoGo Authors. All rights reserved.
-
-Protocol Buffers for Go with Gadgets
-
-Copyright (c) 2013, The GoGo Authors. All rights reserved.
-http://github.com/gogo/protobuf
-
-Go support for Protocol Buffers - Google's data interchange format
-
-Copyright 2010 The Go Authors.  All rights reserved.
-https://github.com/golang/protobuf
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-    * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-    * Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Amazon Elastic Container Service Agent
-Copyright 2014-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 
 **********************

--- a/THIRD-PARTY
+++ b/THIRD-PARTY
@@ -1,0 +1,616 @@
+** github.com/aws/aws-sdk-go; version v1.10.30 -- https://github.com/aws/aws-sdk-go
+** github.com/containerd/cgroups; version c3fc2b77b568af2406f3931cf3d3f17d76736886 -- https://github.com/containerd/cgroups
+** github.com/containerd/continuity; version 1bed1ecb1dc42d8f4d2ac8c23e5cac64749e82c9 -- https://github.com/containerd/continuity
+** github.com/containernetworking/cni; version v0.5.2 -- https://github.com/containernetworking/cni
+** github.com/coreos/go-systemd; version 24036eb3df68550d24a2736c5d013f4e83366866 -- https://github.com/coreos/go-systemd
+** github.com/docker/docker; version e4d0fe84f9ea88b0e0cfd847412c9f29442cc62d -- https://github.com/moby/moby
+** github.com/docker/go-connections; version v0.3.0 -- https://github.com/docker/go-connections
+** github.com/docker/go-units; version v0.3.2 -- https://github.com/docker/go-units
+** github.com/go-ini/ini; version v1.31.1 -- https://github.com/go-ini/ini
+** github.com/golang/mock; version bd3c8e81be01eef76d4b503f5e687d2d1354d2d9 -- https://github.com/golang/mock/blob/master/LICENSE
+** github.com/jmespath/go-jmespath; version 0b12d6b5 -- https://github.com/jmespath/go-jmespath
+** github.com/opencontainers/go-digest; version v1.0.0-rc1 -- https://github.com/opencontainers/go-digest
+** github.com/opencontainers/image-spec; version v1.0.1 -- https://github.com/opencontainers/image-spec
+** github.com/opencontainers/runc; version v0.1.1 -- https://github.com/opencontainers/runc
+** github.com/opencontainers/runtime-spec; version d349388c43b01b2ea695965ae561b5bddb81318f -- https://github.com/opencontainers/runtime-spec
+** github.com/vishvananda/netlink; version fe3b5664d23a11b52ba59bece4ff29c52772a56b -- https://github.com/vishvananda/netlink
+** github.com/vishvananda/netns; version be1fbeda19366dea804f00efff2dd73a1642fdcc -- https://github.com/vishvananda/netns
+
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, "control" means (i) the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and
+configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object
+code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form,
+made available under the License, as indicated by a copyright notice that is
+included in or attached to the work (an example is provided in the Appendix
+below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
+name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original
+version of the Work and any modifications or additions to that Work or
+Derivative Works thereof, that is intentionally submitted to Licensor for
+inclusion in the Work by the copyright owner or by an individual or Legal
+Entity authorized to submit on behalf of the copyright owner. For the purposes
+of this definition, "submitted" means any form of electronic, verbal, or
+written communication sent to the Licensor or its representatives, including
+but not limited to communication on electronic mailing lists, source code
+control systems, and issue tracking systems that are managed by, or on behalf
+of, the Licensor for the purpose of discussing and improving the Work, but
+excluding communication that is conspicuously marked or otherwise designated in
+writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this
+License, each Contributor hereby grants to You a perpetual, worldwide,
+non-exclusive, no-charge, royalty-free, irrevocable copyright license to
+reproduce, prepare Derivative Works of, publicly display, publicly perform,
+sublicense, and distribute the Work and such Derivative Works in Source or
+Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this
+License, each Contributor hereby grants to You a perpetual, worldwide,
+non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this
+section) patent license to make, have made, use, offer to sell, sell, import,
+and otherwise transfer the Work, where such license applies only to those
+patent claims licensable by such Contributor that are necessarily infringed by
+their Contribution(s) alone or by combination of their Contribution(s) with the
+Work to which such Contribution(s) was submitted. If You institute patent
+litigation against any entity (including a cross-claim or counterclaim in a
+lawsuit) alleging that the Work or a Contribution incorporated within the Work
+constitutes direct or contributory patent infringement, then any patent
+licenses granted to You under this License for that Work shall terminate as of
+the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or
+Derivative Works thereof in any medium, with or without modifications, and in
+Source or Object form, provided that You meet the following conditions:
+
+(a) You must give any other recipients of the Work or Derivative Works a copy
+of this License; and
+
+(b) You must cause any modified files to carry prominent notices stating that
+You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works that You
+distribute, all copyright, patent, trademark, and attribution notices from the
+Source form of the Work, excluding those notices that do not pertain to any
+part of the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its distribution, then
+any Derivative Works that You distribute must include a readable copy of the
+attribution notices contained within such NOTICE file, excluding those notices
+that do not pertain to any part of the Derivative Works, in at least one of the
+following places: within a NOTICE text file distributed as part of the
+Derivative Works; within the Source form or documentation, if provided along
+with the Derivative Works; or, within a display generated by the Derivative
+Works, if and wherever such third-party notices normally appear. The contents
+of the NOTICE file are for informational purposes only and do not modify the
+License. You may add Your own attribution notices within Derivative Works that
+You distribute, alongside or as an addendum to the NOTICE text from the Work,
+provided that such additional attribution notices cannot be construed as
+modifying the License.
+
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a
+whole, provided Your use, reproduction, and distribution of the Work otherwise
+complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any
+Contribution intentionally submitted for inclusion in the Work by You to the
+Licensor shall be under the terms and conditions of this License, without any
+additional terms or conditions. Notwithstanding the above, nothing herein shall
+supersede or modify the terms of any separate license agreement you may have
+executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names,
+trademarks, service marks, or product names of the Licensor, except as required
+for reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in
+writing, Licensor provides the Work (and each Contributor provides its
+Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied, including, without limitation, any warranties
+or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE. You are solely responsible for determining the
+appropriateness of using or redistributing the Work and assume any risks
+associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in
+tort (including negligence), contract, or otherwise, unless required by
+applicable law (such as deliberate and grossly negligent acts) or agreed to in
+writing, shall any Contributor be liable to You for damages, including any
+direct, indirect, special, incidental, or consequential damages of any
+character arising as a result of this License or out of the use or inability to
+use the Work (including but not limited to damages for loss of goodwill, work
+stoppage, computer failure or malfunction, or any and all other commercial
+damages or losses), even if such Contributor has been advised of the
+possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or
+Derivative Works thereof, You may choose to offer, and charge a fee for,
+acceptance of support, warranty, indemnity, or other liability obligations
+and/or rights consistent with this License. However, in accepting such
+obligations, You may act only on Your own behalf and on Your sole
+responsibility, not on behalf of any other Contributor, and only if You agree
+to indemnify, defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason of your
+accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate
+notice, with the fields enclosed by brackets "[]" replaced with your own
+identifying information. (Don't include the brackets!)  The text should be
+enclosed in the appropriate comment syntax for the file format. We also
+recommend that a file or class name and description of purpose be included on
+the same "printed page" as the copyright notice for easier identification
+within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+* For github.com/aws/aws-sdk-go see also this required NOTICE:
+AWS SDK for Go
+Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved. 
+Copyright 2014-2015 Stripe, Inc.
+* For github.com/containerd/cgroups see also this required NOTICE:
+Copyright (c) 2016-2017 the containerd authors
+* For github.com/containerd/continuity see also this required NOTICE:
+Copyright (c) 2016-2017 the containerd authors
+* For github.com/containernetworking/cni see also this required NOTICE:
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+* For github.com/coreos/go-systemd see also this required NOTICE:
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+* For github.com/docker/docker see also this required NOTICE:
+Copyright 2013-2017 Docker, Inc.
+* For github.com/docker/go-connections see also this required NOTICE:
+Copyright 2015 Docker, Inc.
+* For github.com/docker/go-units see also this required NOTICE:
+Copyright 2015 Docker, Inc.
+* For github.com/go-ini/ini see also this required NOTICE:
+Copyright 2014 Unknwon
+* For github.com/golang/mock see also this required NOTICE:
+Alex Reece <awreece@gmail.com>
+Google Inc.
+* For github.com/jmespath/go-jmespath see also this required NOTICE:
+Copyright 2015 James Saryerwinnie
+* For github.com/opencontainers/go-digest see also this required NOTICE:
+Copyright © 2016 Docker, Inc.
+* For github.com/opencontainers/image-spec see also this required NOTICE:
+Copyright 2016 The Linux Foundation.
+* For github.com/opencontainers/runc see also this required NOTICE:
+Copyright 2014 Docker, Inc.
+* For github.com/opencontainers/runtime-spec see also this required NOTICE:
+Copyright 2015 The Linux Foundation.
+* For github.com/vishvananda/netlink see also this required NOTICE:
+Copyright 2014 Vishvananda Ishaya.
+Copyright 2014 Docker, Inc.
+* For github.com/vishvananda/netns see also this required NOTICE:
+Copyright 2014 Vishvananda Ishaya.
+Copyright 2014 Docker, Inc.
+
+-----
+
+** github.com/fsouza/go-dockerclient; version d25e8d2941bd448756b336a2ec3abf79802d6ddf -- https://github.com/fsouza/go-dockerclient
+Copyright (c) 2013-2017, go-dockerclient authors
+** github.com/godbus/dbus; version v4.1.0 -- https://github.com/godbus/dbus
+Copyright (c) 2013, Georg Reinke (<guelfey at gmail dot com>), Google
+** github.com/gorilla/websocket; version 0868951cdb8e69bc42df4598bdc6164ff2f1a072 -- https://github.com/gorilla/websocket
+Copyright (c) 2013 The Gorilla WebSocket Authors. All rights reserved.
+** github.com/Nvveen/Gotty; version cd527374f1e5bff4938207604a14f2e38a9cf512 -- https://github.com/Nvveen/Gotty
+Copyright (c) 2012, Neal van Veen (nealvanveen@gmail.com)
+** github.com/pkg/errors; version c605e284fe17294bda444b34710735b29d1a9d90 -- https://github.com/pkg/errors
+Copyright (c) 2015, Dave Cheney <dave@cheney.net>
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer. 
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+-----
+
+** golang.org/x/tools; version 1 -- https://github.com/golang/tools
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are
+ met:
+ 
+    * Redistributions of source code must retain the above copyright
+ notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+ copyright notice, this list of conditions and the following disclaimer
+ in the documentation and/or other materials provided with the
+ distribution.
+    * Neither the name of Google Inc. nor the names of its
+ contributors may be used to endorse or promote products derived from
+ this software without specific prior written permission.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+-----
+
+** gorilla/mux; version v1.6.2 -- https://github.com/gorilla/mux
+Copyright (c) 2012-2018 The Gorilla Authors. All rights reserved.
+
+Copyright (c) 2012-2018 The Gorilla Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+* Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+-----
+
+** golang.org/x/crypto; version (master) -- https://github.com/golang/crypto
+Copyright (c) 2009 The Go Authors. All rights reserved.
+** golang.org/x/net; version master -- https://go.googlesource.com/net/
+Copyright (c) 2009 The Go Authors. All rights reserved.
+** https://github.com/golang/time; version NA -- https://github.com/golang/time
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+* Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+-----
+
+** golang.org/x/sys; version master -- https://github.com/golang/sys
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+* Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+-----
+
+** github.com/cihub/seelog; version 0fa7e41d2b9600ca6b7e1592478124e4f800f724 -- https://github.com/cihub/seelog
+Copyright (c) 2012, Cloud Instruments Co., Ltd. <info@cin.io>
+** github.com/pborman/uuid; version ca53cad383cad2479bbba7f7a1a05797ec1386e4 -- https://github.com/pborman/uuid
+Copyright (c) 2009,2014 Google Inc. All rights reserved.
+** github.com/pmezard/go-difflib; version v1.0.0 -- https://github.com/pmezard/go-difflib
+Copyright (c) 2013, Patrick Mezard
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer. 
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution. 
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+
+-----
+
+** github.com/davecgh/go-spew; version v1.1.0 -- https://github.com/davecgh/go-spew
+Copyright (c) 2012-2016 Dave Collins <dave@davec.name>
+
+ISC License:
+
+Copyright (c) 2004-2010 by Internet Systems Consortium, Inc. ("ISC")
+Copyright (c) 1995-2003 by Internet Software Consortium
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND ISC DISCLAIMS ALL WARRANTIES WITH REGARD
+TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL ISC BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR
+CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,
+DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
+SOFTWARE.
+
+-----
+
+** github.com/patrickmn/go-cache; version v2.1.0 -- https://github.com/patrickmn/go-cache
+Copyright (c) 2012-2017 Patrick Mylund Nielsen and the go-cache contributors
+
+Copyright (c) 2012-2017 Patrick Mylund Nielsen and the go-cache contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+-----
+
+** github.com/Azure/go-ansiterm; version fa152c58bc15761d0200cb75fe958b89a9d4888e -- https://github.com/Azure/go-ansiterm
+Copyright (c) 2015 Microsoft Corporation
+** github.com/deniswernert/udev; version 82fe5be8ca5f7d8255cc838723687f61bb175120 -- https://github.com/deniswernert/udev
+Copyright (c) 2014 deniswernert
+** github.com/Microsoft/go-winio; version v0.3.6 -- https://github.com/Microsoft/go-winio
+Copyright (c) 2015 Microsoft
+** github.com/Sirupsen/logrus; version 3ec0642a7fb6488f65b06f9040adc67e3990296a -- https://github.com/Sirupsen/logrus
+Copyright (c) 2014 Simon Eskildsen
+
+MIT License
+
+Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+-----
+
+** https://github.com/didip/tollbooth; version v3.0.2 -- https://github.com/didip/tollbooth
+NA
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Didip Kerabat
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+-----
+
+** github.com/stretchr/testify; version d77da356e56a7428ad25149ca77381849a6a5232 -- https://github.com/stretchr/testify
+Copyright (c) 2012 - 2013 Mat Ryer and Tyler Bunnell
+
+Copyright (c) 2012 - 2013 Mat Ryer and Tyler Bunnell
+
+Please consider promoting this project if you find it useful.
+
+Permission is hereby granted, free of charge, to any person 
+obtaining a copy of this software and associated documentation 
+files (the "Software"), to deal in the Software without restriction, 
+including without limitation the rights to use, copy, modify, merge, 
+publish, distribute, sublicense, and/or sell copies of the Software, 
+and to permit persons to whom the Software is furnished to do so, 
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES 
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, 
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT 
+OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE 
+OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+-----
+
+** github.com/gogo/protobuf; version v0.5 -- https://github.com/gogo/protobuf
+Copyright (c) 2013, The GoGo Authors. All rights reserved.
+
+Protocol Buffers for Go with Gadgets
+
+Copyright (c) 2013, The GoGo Authors. All rights reserved.
+http://github.com/gogo/protobuf
+
+Go support for Protocol Buffers - Google's data interchange format
+
+Copyright 2010 The Go Authors.  All rights reserved.
+https://github.com/golang/protobuf
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+    * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/agent/acs/model/api/api-2.json
+++ b/agent/acs/model/api/api-2.json
@@ -464,7 +464,9 @@
         "executionRoleCredentials":{"shape":"IAMRoleCredentials"},
         "elasticNetworkInterfaces":{"shape":"ElasticNetworkInterfaceList"},
         "cpu":{"shape":"Double"},
-        "memory":{"shape":"Integer"}
+        "memory":{"shape":"Integer"},
+        "pidMode":{"shape":"String"},
+        "ipcMode":{"shape":"String"}
       }
     },
     "TaskList":{

--- a/agent/acs/model/ecsacs/api.go
+++ b/agent/acs/model/ecsacs/api.go
@@ -710,9 +710,13 @@ type Task struct {
 
 	Family *string `locationName:"family" type:"string"`
 
+	IpcMode *string `locationName:"ipcMode" type:"string"`
+
 	Memory *int64 `locationName:"memory" type:"integer"`
 
 	Overrides *string `locationName:"overrides" type:"string"`
+
+	PidMode *string `locationName:"pidMode" type:"string"`
 
 	RoleCredentials *IAMRoleCredentials `locationName:"roleCredentials" type:"structure"`
 

--- a/agent/api/container/container.go
+++ b/agent/api/container/container.go
@@ -401,8 +401,8 @@ func (c *Container) GetNextKnownStateProgression() apicontainerstatus.ContainerS
 	return c.GetKnownStatus() + 1
 }
 
-// IsInternal returns true if the container type is either `ContainerEmptyHostVolume`
-// or `ContainerCNIPause`. It returns false otherwise
+// IsInternal returns true if the container type is `ContainerCNIPause`
+// or `ContainerNamespacePause`. It returns false otherwise
 func (c *Container) IsInternal() bool {
 	if c.Type == ContainerNormal {
 		return false

--- a/agent/api/container/container_test.go
+++ b/agent/api/container/container_test.go
@@ -122,6 +122,7 @@ func TestIsInternal(t *testing.T) {
 		{&Container{Type: ContainerNormal}, false},
 		{&Container{Type: ContainerCNIPause}, true},
 		{&Container{Type: ContainerEmptyHostVolume}, true},
+		{&Container{Type: ContainerNamespacePause}, true},
 	}
 
 	for _, tc := range testCases {

--- a/agent/api/container/containertype.go
+++ b/agent/api/container/containertype.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -30,6 +30,11 @@ const (
 	// ContainerCNIPause represents the internal container type for the
 	// pause container
 	ContainerCNIPause
+
+	// ContainerNamespacePause represents the internal container type for
+	// sharing either PID or IPC resource namespaces. Regardless if one or
+	// both flags are used, only 1 of these containers need to be active
+	ContainerNamespacePause
 )
 
 // ContainerType represents the type of the internal container created
@@ -39,6 +44,7 @@ var stringToContainerType = map[string]ContainerType{
 	"NORMAL":            ContainerNormal,
 	"EMPTY_HOST_VOLUME": ContainerEmptyHostVolume,
 	"CNI_PAUSE":         ContainerCNIPause,
+	"NAMESPACE_PAUSE":   ContainerNamespacePause,
 }
 
 // String converts the container type enum to a string

--- a/agent/api/container/containertype_test.go
+++ b/agent/api/container/containertype_test.go
@@ -35,6 +35,7 @@ func TestMarshalContainerType(t *testing.T) {
 		{containerTypeWrapper{ContainerNormal}, `{"IsInternal":"NORMAL"}`},
 		{containerTypeWrapper{ContainerEmptyHostVolume}, `{"IsInternal":"EMPTY_HOST_VOLUME"}`},
 		{containerTypeWrapper{ContainerCNIPause}, `{"IsInternal":"CNI_PAUSE"}`},
+		{containerTypeWrapper{ContainerNamespacePause}, `{"IsInternal":"NAMESPACE_PAUSE"}`},
 	}
 
 	for _, tc := range testCases {
@@ -56,6 +57,7 @@ func TestUnmarhsalContainerType(t *testing.T) {
 		{containerTypeWrapper{ContainerNormal}, `{"IsInternal":"NORMAL"}`},
 		{containerTypeWrapper{ContainerEmptyHostVolume}, `{"IsInternal":"EMPTY_HOST_VOLUME"}`},
 		{containerTypeWrapper{ContainerCNIPause}, `{"IsInternal":"CNI_PAUSE"}`},
+		{containerTypeWrapper{ContainerNamespacePause}, `{"IsInternal":"NAMESPACE_PAUSE"}`},
 		{containerTypeWrapper{ContainerNormal}, `{"IsInternal":null}`},
 		{containerTypeWrapper{ContainerNormal}, `{"IsInternal":false}`},
 		{containerTypeWrapper{ContainerEmptyHostVolume}, `{"IsInternal":true}`},

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -51,8 +51,12 @@ import (
 )
 
 const (
-	// PauseContainerName is the internal name for the pause container
-	PauseContainerName = "~internal~ecs~pause"
+	// NetworkPauseContainerName is the internal name for the pause container
+	NetworkPauseContainerName = "~internal~ecs~pause~network"
+
+	// NamespacePauseContainerName is the internal name for the IPC resource namespace and/or
+	// PID namespace sharing pause container
+	NamespacePauseContainerName = "~internal~ecs~pause~namespace"
 
 	emptyHostVolumeName = "~internal~ecs-emptyvolume-source"
 
@@ -65,13 +69,21 @@ const (
 	arnResourceDelimiter = "/"
 	// networkModeNone specifies the string used to define the `none` docker networking mode
 	networkModeNone = "none"
-	// networkModeContainerPrefix specifies the prefix string used for setting the
-	// container's network mode to be mapped to that of another existing container
-	networkModeContainerPrefix = "container:"
+	// dockerMappingContainerPrefix specifies the prefix string used for setting the
+	// container's option (network, ipc, or pid) to that of another existing container
+	dockerMappingContainerPrefix = "container:"
 
 	// awslogsCredsEndpointOpt is the awslogs option that is used to pass in an
 	// http endpoint for authentication
 	awslogsCredsEndpointOpt = "awslogs-credentials-endpoint"
+
+	// These contants identify the docker flag options
+	pidModeHost     = "host"
+	pidModeTask     = "task"
+	ipcModeHost     = "host"
+	ipcModeTask     = "task"
+	ipcModeSharable = "shareable"
+	ipcModeNone     = "none"
 )
 
 // TaskOverrides are the overrides applied to a task
@@ -167,6 +179,14 @@ type Task struct {
 	terminalReason     string
 	terminalReasonOnce sync.Once
 
+	// PIDMode is used to determine how PID namespaces are organized between
+	// containers of the Task
+	PIDMode string `json:"PidMode,omitempty"`
+
+	// IPCMode is used to determine how IPC resources should be shared among
+	// containers of the Task
+	IPCMode string `json:"IpcMode,omitempty"`
+
 	// lock is for protecting all fields in the task struct
 	lock sync.RWMutex
 }
@@ -233,6 +253,9 @@ func (task *Task) PostUnmarshalTask(cfg *config.Config,
 
 	task.initializeCredentialsEndpoint(credentialsManager)
 	task.addNetworkResourceProvisioningDependency(cfg)
+	// Adds necessary Pause containers for sharing PID or IPC namespaces
+	task.addNamespaceSharingProvisioningDependency(cfg)
+
 	return nil
 }
 
@@ -526,7 +549,7 @@ func (task *Task) addNetworkResourceProvisioningDependency(cfg *config.Config) {
 	}
 	pauseContainer := apicontainer.NewContainerWithSteadyState(apicontainerstatus.ContainerResourcesProvisioned)
 	pauseContainer.TransitionDependenciesMap = make(map[apicontainerstatus.ContainerStatus]apicontainer.TransitionDependencySet)
-	pauseContainer.Name = PauseContainerName
+	pauseContainer.Name = NetworkPauseContainerName
 	pauseContainer.Image = fmt.Sprintf("%s:%s", cfg.PauseContainerImageName, cfg.PauseContainerTag)
 	pauseContainer.Essential = true
 	pauseContainer.Type = apicontainer.ContainerCNIPause
@@ -536,8 +559,30 @@ func (task *Task) addNetworkResourceProvisioningDependency(cfg *config.Config) {
 		if container.IsInternal() {
 			continue
 		}
-		container.BuildContainerDependency(PauseContainerName, apicontainerstatus.ContainerResourcesProvisioned, apicontainerstatus.ContainerPulled)
+		container.BuildContainerDependency(NetworkPauseContainerName, apicontainerstatus.ContainerResourcesProvisioned, apicontainerstatus.ContainerPulled)
 		pauseContainer.BuildContainerDependency(container.Name, apicontainerstatus.ContainerStopped, apicontainerstatus.ContainerStopped)
+	}
+}
+
+func (task *Task) addNamespaceSharingProvisioningDependency(cfg *config.Config) {
+	// Pause container does not need to be created if no namespace sharing will be done at task level
+	if task.getIPCMode() != ipcModeTask && task.getPIDMode() != pidModeTask {
+		return
+	}
+	namespacePauseContainer := apicontainer.NewContainerWithSteadyState(apicontainerstatus.ContainerRunning)
+	namespacePauseContainer.TransitionDependenciesMap = make(map[apicontainerstatus.ContainerStatus]apicontainer.TransitionDependencySet)
+	namespacePauseContainer.Name = NamespacePauseContainerName
+	namespacePauseContainer.Image = fmt.Sprintf("%s:%s", config.DefaultPauseContainerImageName, config.DefaultPauseContainerTag)
+	namespacePauseContainer.Essential = true
+	namespacePauseContainer.Type = apicontainer.ContainerNamespacePause
+	task.Containers = append(task.Containers, namespacePauseContainer)
+
+	for _, container := range task.Containers {
+		if container.IsInternal() {
+			continue
+		}
+		container.BuildContainerDependency(NamespacePauseContainerName, apicontainerstatus.ContainerRunning, apicontainerstatus.ContainerPulled)
+		namespacePauseContainer.BuildContainerDependency(container.Name, apicontainerstatus.ContainerStopped, apicontainerstatus.ContainerStopped)
 	}
 }
 
@@ -831,21 +876,29 @@ func (task *Task) dockerHostConfig(container *apicontainer.Container, dockerCont
 
 	// Determine if network mode should be overridden and override it if needed
 	ok, networkMode := task.shouldOverrideNetworkMode(container, dockerContainerMap)
-	if !ok {
-		return hostConfig, nil
-	}
-	hostConfig.NetworkMode = networkMode
-	// Override 'awsvpc' parameters if needed
-	if container.Type == apicontainer.ContainerCNIPause {
+	if ok {
+		hostConfig.NetworkMode = networkMode
+		// Override 'awsvpc' parameters if needed
+		if container.Type == apicontainer.ContainerCNIPause {
+			// apply ExtraHosts to HostConfig for pause container
+			if hosts := task.generateENIExtraHosts(); hosts != nil {
+				hostConfig.ExtraHosts = append(hostConfig.ExtraHosts, hosts...)
+			}
 
-		// apply ExtraHosts to HostConfig for pause container
-		if hosts := task.generateENIExtraHosts(); hosts != nil {
-			hostConfig.ExtraHosts = append(hostConfig.ExtraHosts, hosts...)
+			// Override the DNS settings for the pause container if ENI has custom
+			// DNS settings
+			return task.overrideDNS(hostConfig), nil
 		}
+	}
 
-		// Override the DNS settings for the pause container if ENI has custom
-		// DNS settings
-		return task.overrideDNS(hostConfig), nil
+	ok, pidMode := task.shouldOverridePIDMode(container, dockerContainerMap)
+	if ok {
+		hostConfig.PidMode = pidMode
+	}
+
+	ok, ipcMode := task.shouldOverrideIPCMode(container, dockerContainerMap)
+	if ok {
+		hostConfig.IpcMode = ipcMode
 	}
 
 	return hostConfig, nil
@@ -892,7 +945,7 @@ func (task *Task) shouldOverrideNetworkMode(container *apicontainer.Container, d
 			container.String(), task.String())
 		return false, ""
 	}
-	return true, networkModeContainerPrefix + pauseContainer.DockerID
+	return true, dockerMappingContainerPrefix + pauseContainer.DockerID
 }
 
 // overrideDNS overrides a container's host config if the following conditions are
@@ -951,6 +1004,95 @@ func (task *Task) generateENIExtraHosts() []string {
 		extraHosts = append(extraHosts, host)
 	}
 	return extraHosts
+}
+
+// shouldOverridePIDMode returns true if the PIDMode of the container needs
+// to be overridden. It also returns the override string in this case. It returns
+// false otherwise
+func (task *Task) shouldOverridePIDMode(container *apicontainer.Container, dockerContainerMap map[string]*apicontainer.DockerContainer) (bool, string) {
+	// If the container is an internal container (ContainerEmptyHostVolume,
+	// ContainerCNIPause, or ContainerNamespacePause), then PID namespace for
+	// the container itself should be private (default Docker option)
+	if container.IsInternal() {
+		return false, ""
+	}
+
+	switch task.getPIDMode() {
+	case pidModeHost:
+		return true, pidModeHost
+
+	case pidModeTask:
+		pauseCont, ok := task.ContainerByName(NamespacePauseContainerName)
+		if !ok {
+			seelog.Criticalf("Namespace Pause container not found in the task: %s; Setting Task's Desired Status to Stopped", task.Arn)
+			task.SetDesiredStatus(apitaskstatus.TaskStopped)
+			return false, ""
+		}
+		pauseDockerID, ok := dockerContainerMap[pauseCont.Name]
+		if !ok || pauseDockerID == nil {
+			// Docker container shouldn't be nil or not exist if the Container definition within task exists; implies code-bug
+			seelog.Criticalf("Namespace Pause container not found in the task: %s; Setting Task's Desired Status to Stopped", task.Arn)
+			task.SetDesiredStatus(apitaskstatus.TaskStopped)
+			return false, ""
+		}
+		return true, dockerMappingContainerPrefix + pauseDockerID.DockerID
+
+	// If PIDMode is not Host or Task, then no need to override
+	default:
+		return false, ""
+	}
+}
+
+// shouldOverrideIPCMode returns true if the IPCMode of the container needs
+// to be overridden. It also returns the override string in this case. It returns
+// false otherwise
+func (task *Task) shouldOverrideIPCMode(container *apicontainer.Container, dockerContainerMap map[string]*apicontainer.DockerContainer) (bool, string) {
+	// All internal containers do not need the same IPCMode. The NamespaceContainerPause
+	// needs to be "shareable" if ipcMode is "task". All other internal containers should
+	// defer to the Docker daemon default option (either shareable or private depending on
+	// version and configuration)
+	if container.IsInternal() {
+		if container.Type == apicontainer.ContainerNamespacePause {
+			// Setting NamespaceContainerPause to be sharable with other containers
+			if task.getIPCMode() == ipcModeTask {
+				return true, ipcModeSharable
+			}
+		}
+		// Defaulting to Docker daemon default option
+		return false, ""
+	}
+
+	switch task.getIPCMode() {
+	// No IPCMode provided in Task Definition, no need to override
+	case "":
+		return false, ""
+
+	// IPCMode is none - container will have own private namespace with /dev/shm not mounted
+	case ipcModeNone:
+		return true, ipcModeNone
+
+	case ipcModeHost:
+		return true, ipcModeHost
+
+	case ipcModeTask:
+		pauseCont, ok := task.ContainerByName(NamespacePauseContainerName)
+		if !ok {
+			seelog.Criticalf("Namespace Pause container not found in the task: %s; Setting Task's Desired Status to Stopped", task.Arn)
+			task.SetDesiredStatus(apitaskstatus.TaskStopped)
+			return false, ""
+		}
+		pauseDockerID, ok := dockerContainerMap[pauseCont.Name]
+		if !ok || pauseDockerID == nil {
+			// Docker container shouldn't be nill or not exist if the Container definition within task exists; implies code-bug
+			seelog.Criticalf("Namespace Pause container not found in the task: %s; Setting Task's Desired Status to Stopped", task.Arn)
+			task.SetDesiredStatus(apitaskstatus.TaskStopped)
+			return false, ""
+		}
+		return true, dockerMappingContainerPrefix + pauseDockerID.DockerID
+
+	default:
+		return false, ""
+	}
 }
 
 func (task *Task) dockerLinks(container *apicontainer.Container, dockerContainerMap map[string]*apicontainer.DockerContainer) ([]string, error) {
@@ -1448,4 +1590,20 @@ func (task *Task) InitializeResources(resourceFields *taskresource.ResourceField
 			resource.Initialize(resourceFields, task.KnownStatusUnsafe, task.DesiredStatusUnsafe)
 		}
 	}
+}
+
+// Retrieves a Task's PIDMode
+func (task *Task) getPIDMode() string {
+	task.lock.RLock()
+	defer task.lock.RUnlock()
+
+	return task.PIDMode
+}
+
+// Retrieves a Task's IPCMode
+func (task *Task) getIPCMode() string {
+	task.lock.RLock()
+	defer task.lock.RUnlock()
+
+	return task.IPCMode
 }

--- a/agent/api/task/task_linux_test.go
+++ b/agent/api/task/task_linux_test.go
@@ -64,7 +64,7 @@ func TestAddNetworkResourceProvisioningDependencyWithENI(t *testing.T) {
 		ENI: &apieni.ENI{},
 		Containers: []*apicontainer.Container{
 			{
-				Name: "c1",
+				Name:                      "c1",
 				TransitionDependenciesMap: make(map[apicontainerstatus.ContainerStatus]apicontainer.TransitionDependencySet),
 			},
 		},
@@ -76,7 +76,7 @@ func TestAddNetworkResourceProvisioningDependencyWithENI(t *testing.T) {
 	testTask.addNetworkResourceProvisioningDependency(cfg)
 	assert.Equal(t, 2, len(testTask.Containers),
 		"addNetworkResourceProvisioningDependency should add another container")
-	pauseContainer, ok := testTask.ContainerByName(PauseContainerName)
+	pauseContainer, ok := testTask.ContainerByName(NetworkPauseContainerName)
 	require.True(t, ok, "Expected to find pause container")
 	assert.Equal(t, apicontainer.ContainerCNIPause, pauseContainer.Type, "pause container should have correct type")
 	assert.True(t, pauseContainer.Essential, "pause container should be essential")
@@ -392,7 +392,7 @@ func TestInitCgroupResourceSpecHappyPath(t *testing.T) {
 		Memory: taskMemoryLimit,
 		Containers: []*apicontainer.Container{
 			{
-				Name: "c1",
+				Name:                      "c1",
 				TransitionDependenciesMap: make(map[apicontainerstatus.ContainerStatus]apicontainer.TransitionDependencySet),
 			},
 		},
@@ -420,7 +420,7 @@ func TestInitCgroupResourceSpecInvalidARN(t *testing.T) {
 		Version: "1",
 		Containers: []*apicontainer.Container{
 			{
-				Name: "c1",
+				Name:                      "c1",
 				TransitionDependenciesMap: make(map[apicontainerstatus.ContainerStatus]apicontainer.TransitionDependencySet),
 			},
 		},
@@ -440,8 +440,8 @@ func TestInitCgroupResourceSpecInvalidMem(t *testing.T) {
 		Memory: taskMemoryLimit,
 		Containers: []*apicontainer.Container{
 			{
-				Name:   "C1",
-				Memory: uint(2048), // container memory > task memory
+				Name:                      "C1",
+				Memory:                    uint(2048), // container memory > task memory
 				TransitionDependenciesMap: make(map[apicontainerstatus.ContainerStatus]apicontainer.TransitionDependencySet),
 			},
 		},
@@ -460,7 +460,7 @@ func TestPostUnmarshalWithCPULimitsFail(t *testing.T) {
 		Version: "1",
 		Containers: []*apicontainer.Container{
 			{
-				Name: "c1",
+				Name:                      "c1",
 				TransitionDependenciesMap: make(map[apicontainerstatus.ContainerStatus]apicontainer.TransitionDependencySet),
 			},
 		},

--- a/agent/app/agent_unix.go
+++ b/agent/app/agent_unix.go
@@ -81,17 +81,15 @@ func (agent *ecsAgent) initializeTaskENIDependencies(state dockerstate.TaskEngin
 		return err, true
 	}
 
-	if agent.cfg.ShouldLoadPauseContainerTarball() {
-		// Load the pause container's image from the 'disk'
-		if _, err := agent.pauseLoader.LoadImage(agent.ctx, agent.cfg, agent.dockerClient); err != nil {
-			if pause.IsNoSuchFileError(err) || pause.UnsupportedPlatform(err) {
-				// If the pause container's image tarball doesn't exist or if the
-				// invocation is done for an unsupported platform, we cannot recover.
-				// Return the error as terminal for these cases
-				return err, true
-			}
-			return err, false
+	// Load the pause container's image from the 'disk'
+	if _, err := agent.pauseLoader.LoadImage(agent.ctx, agent.cfg, agent.dockerClient); err != nil {
+		if pause.IsNoSuchFileError(err) || pause.UnsupportedPlatform(err) {
+			// If the pause container's image tarball doesn't exist or if the
+			// invocation is done for an unsupported platform, we cannot recover.
+			// Return the error as terminal for these cases
+			return err, true
 		}
+		return err, false
 	}
 
 	if err := agent.startUdevWatcher(state, taskEngine.StateChangeEvents()); err != nil {

--- a/agent/config/config_unix.go
+++ b/agent/config/config_unix.go
@@ -74,19 +74,13 @@ func DefaultConfig() Config {
 
 func (cfg *Config) platformOverrides() {}
 
-// ShouldLoadPauseContainerTarball determines whether the pause container
-// tarball should be loaded into Docker or not.  This function will return
-// false is the default image name/tag have been overridden, because we do not
-// expect the tarball to match the overridden name/tag.
-func (cfg *Config) ShouldLoadPauseContainerTarball() bool {
-	return cfg.PauseContainerImageName == DefaultPauseContainerImageName &&
-		cfg.PauseContainerTag == DefaultPauseContainerTag
-}
-
 // platformString returns platform-specific config data that can be serialized
 // to string for debugging
 func (cfg *Config) platformString() string {
-	if cfg.ShouldLoadPauseContainerTarball() {
+	// Returns a string if the default image name/tag of the Pause container has
+	// been overridden
+	if cfg.PauseContainerImageName == DefaultPauseContainerImageName &&
+		cfg.PauseContainerTag == DefaultPauseContainerTag {
 		return fmt.Sprintf(", PauseContainerImageName: %s, PauseContainerTag: %s",
 			cfg.PauseContainerImageName, cfg.PauseContainerTag)
 	}

--- a/agent/config/config_unix_test.go
+++ b/agent/config/config_unix_test.go
@@ -172,16 +172,6 @@ func TestBadFileContent(t *testing.T) {
 	assert.Error(t, err, "create configuration should fail")
 }
 
-func TestShouldLoadPauseContainerTarball(t *testing.T) {
-	cfg := DefaultConfig()
-	assert.True(t, cfg.ShouldLoadPauseContainerTarball(), "should load tarball by default")
-	cfg.PauseContainerTag = "foo!"
-	assert.False(t, cfg.ShouldLoadPauseContainerTarball(), "should not load tarball if tag differs")
-	cfg = DefaultConfig()
-	cfg.PauseContainerImageName = "foo!"
-	assert.False(t, cfg.ShouldLoadPauseContainerTarball(), "should not load tarball if image name differs")
-}
-
 // setupFileConfiguration create a temp file store the configuration
 func setupFileConfiguration(t *testing.T, configContent string) string {
 	file, err := ioutil.TempFile("", "ecs-test")

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -720,7 +720,7 @@ func TestCreateContainerMergesLabels(t *testing.T) {
 		"com.amazonaws.ecs.task-definition-family":  "myFamily",
 		"com.amazonaws.ecs.task-definition-version": "1",
 		"com.amazonaws.ecs.cluster":                 "",
-		"key": "value",
+		"key":                                       "value",
 	}
 	client.EXPECT().APIVersion().Return(defaultDockerClientAPIVersion, nil).AnyTimes()
 	client.EXPECT().CreateContainer(gomock.Any(), expectedConfig, gomock.Any(), gomock.Any(), gomock.Any())
@@ -1014,7 +1014,7 @@ func TestPauseContainerHappyPath(t *testing.T) {
 			func(ctx interface{}, config *docker.Config, x, y, z interface{}) {
 				name, ok := config.Labels[labelPrefix+"container-name"]
 				assert.True(t, ok)
-				assert.Equal(t, apitask.PauseContainerName, name)
+				assert.Equal(t, apitask.NetworkPauseContainerName, name)
 			}).Return(dockerapi.DockerContainerMetadata{DockerID: "pauseContainerID"}),
 		dockerClient.EXPECT().StartContainer(gomock.Any(), pauseContainerID, defaultConfig.ContainerStartTimeout).Return(
 			dockerapi.DockerContainerMetadata{DockerID: "pauseContainerID"}),

--- a/agent/statemanager/state_manager.go
+++ b/agent/statemanager/state_manager.go
@@ -65,7 +65,8 @@ const (
 	// 12) Deprecate 'TransitionDependencySet' and add new 'TransitionDependenciesMap' in 'apicontainer.Container'
 	// 13) Add 'resources' field to 'api.task.task'
 	// 14) Add 'PlatformFields' field to 'api.task.task'
-	ECSDataVersion = 14
+	// 15) Add 'PIDMode' and 'IPCMode' fields to 'api.task.task'
+	ECSDataVersion = 15
 
 	// ecsDataFile specifies the filename in the ECS_DATADIR
 	ecsDataFile = "ecs_agent_data.json"

--- a/agent/utils/license.go
+++ b/agent/utils/license.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -24,8 +24,9 @@ type LicenseProvider interface {
 type licenseProvider struct{}
 
 const (
-	licenseFile = "LICENSE"
-	noticeFile  = "NOTICE"
+	licenseFile    = "LICENSE"
+	noticeFile     = "NOTICE"
+	thirdPartyFile = "THIRD-PARTY"
 )
 
 var readFile = ioutil.ReadFile
@@ -45,7 +46,12 @@ func (l *licenseProvider) GetText() (string, error) {
 		return "", err
 	}
 
+	thirdPartyText, err := readFile(thirdPartyFile)
+	if err != nil {
+		return "", err
+	}
+
 	separator := "\n" + strings.Repeat("=", 80) + "\n"
 
-	return string(licenseText) + separator + string(noticeText), nil
+	return string(licenseText) + separator + string(noticeText) + separator + string(thirdPartyText), nil
 }

--- a/agent/utils/license_test.go
+++ b/agent/utils/license_test.go
@@ -33,7 +33,7 @@ func TestGetTextSuccess(t *testing.T) {
 		t.Error("Did not expect error", err)
 	}
 
-	expectedText := "LICENSE\n" + strings.Repeat("=", 80) + "\nNOTICE"
+	expectedText := "LICENSE\n" + strings.Repeat("=", 80) + "\nNOTICE\n" + strings.Repeat("=", 80) + "\nTHIRD-PARTY"
 	if text != expectedText {
 		t.Errorf("Expected %s but was %s", expectedText, text)
 	}

--- a/scripts/dockerfiles/Dockerfile.release
+++ b/scripts/dockerfiles/Dockerfile.release
@@ -16,7 +16,7 @@
 FROM amazon/amazon-ecs-scratch:make
 
 COPY out/amazon-ecs-agent /agent
-COPY ["LICENSE", "NOTICE", "/"]
+COPY ["LICENSE", "NOTICE", "THIRD-PARTY", "/"]
 
 COPY out/amazon-ecs-pause.tar /images/amazon-ecs-pause.tar
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Updates the Agent Task model to include PidMode and IpcMode for sharing PID namespace and IPC resource namespace, respectively. 
Adding unit tests for Pid and Ipc resource namespace sharing

### Implementation details
<!-- How are the changes implemented? -->
Agent Task struct is updated to support the PidMode and IpcMode that is in the Task struct received in the payload message from ACS. 
In PostUnmarshalTask(), the task is used to determine if a Pause container for namespace sharing needs to be provisioned. If so, it is added as an internal container to the task. 
In CreateContainer(), the DockerHostConfig() method determines if the current container's PidMode and IpcOption needs to be changed. 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->
Unit Tests cover the added Pause container provisioning methods and DockerHostConfig updates
### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Adding ECS Agent support for the --pid and --ipc Docker flags
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
