### PR TITLE
Tests for CNI plugin added

### DIFF
--- a/agent/ecscni/plugin.go
+++ b/agent/ecscni/plugin.go
@@ -33,8 +33,9 @@ import (
 
 const (
 	currentCNISpec = "0.3.1"
+	// CNIVersion and CNIGitHash needs to be updated every time CNI plugin is updated
 	currentCNIVersion = "2018.08.0"
-	CNIGitHash = "a134a973585b560439ed25ec3857e4789bfeb89f"
+	currentCNIGitHash = "a134a973585b560439ed25ec3857e4789bfeb89f"
 )
 
 // CNIClient defines the method of setting/cleaning up container namespace

--- a/agent/ecscni/plugin.go
+++ b/agent/ecscni/plugin.go
@@ -31,7 +31,11 @@ import (
 	"github.com/pkg/errors"
 )
 
-const currentCNISpec = "0.3.1"
+const (
+	currentCNISpec = "0.3.1"
+	currentCNIVersion = "2018.08.0"
+	CNIGitHash = "a134a973585b560439ed25ec3857e4789bfeb89f"
+)
 
 // CNIClient defines the method of setting/cleaning up container namespace
 type CNIClient interface {

--- a/agent/ecscni/plugin_test.go
+++ b/agent/ecscni/plugin_test.go
@@ -21,10 +21,10 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
-	"path/filepath"
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/ecscni/mocks_libcni"
@@ -264,31 +264,30 @@ func TestCNIPluginVersion(t *testing.T) {
 	}
 }
 
-// Returns the version in CNI plugin VERSION file as a string
-func getCNIVersionString(t *testing.T) string {
-	// ../../amazon-ecs-cni-plugins/VERSION
-	var versionFilePath = filepath.Clean(filepath.Join("..","..","amazon-ecs-cni-plugins","VERSION"))
-	fmt.Println(versionFilePath)
-	versionStr, err := ioutil.ReadFile(versionFilePath)
-	assert.NoError(t, err, "Error reading the CNI plugin version file")
-	return strings.TrimSpace(string(versionStr))
-}
-
 // Asserts that CNI plugin version matches the expected version
 func TestCNIPluginVersionNumber(t *testing.T) {
-	var versionStr = getCNIVersionString(t)
+	versionStr := getCNIVersionString(t)
 	assert.Equal(t, currentCNIVersion, versionStr)
 }
 
 // Asserts that CNI plugin version is upgraded when new commits are made to CNI plugin submodule
 func TestCNIPluginVersionUpgrade(t *testing.T) {
-	var versionStr = getCNIVersionString(t)
+	versionStr := getCNIVersionString(t)
 	cmd := exec.Command("git", "submodule")
 	versionInfo, err := cmd.Output()
-	versionInfoStr := string(versionInfo)
 	assert.NoError(t, err, "Error running the command: git submodule")
+	versionInfoStr := string(versionInfo)
 	// If a new commit is added, version should be upgraded
-	if (string(CNIGitHash) != strings.Split(versionInfoStr, " ")[1]) {
-		assert.NotEqual(t, string(currentCNIVersion), versionStr)
+	if currentCNIGitHash != strings.Split(versionInfoStr, " ")[1] {
+		assert.NotEqual(t, currentCNIVersion, versionStr)
 	}
+}
+
+// Returns the version in CNI plugin VERSION file as a string
+func getCNIVersionString(t *testing.T) string {
+	// ../../amazon-ecs-cni-plugins/VERSION
+	versionFilePath := filepath.Clean(filepath.Join("..", "..", "amazon-ecs-cni-plugins", "VERSION"))
+	versionStr, err := ioutil.ReadFile(versionFilePath)
+	assert.NoError(t, err, "Error reading the CNI plugin version file")
+	return strings.TrimSpace(string(versionStr))
 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,8 @@ install:
   - rmdir c:\go /s /q
   - appveyor DownloadFile https://storage.googleapis.com/golang/go%GOVERSION%.windows-amd64.zip
   - 7z x go%GOVERSION%.windows-amd64.zip -y -oC:\ > NUL
+  - cd %APPVEYOR_BUILD_FOLDER%
+  - git submodule update --init --recursive
 build_script:
   - go build ./agent
 test_script:

--- a/scripts/cleanbuild
+++ b/scripts/cleanbuild
@@ -37,4 +37,5 @@ git clone -c user.name="cleanbuild" -c user.email="cleanbuild" /src/amazon-ecs-a
 export ECS_RELEASE="cleanbuild"
 
 cd /go/src/github.com/aws/amazon-ecs-agent
+
 exec ./scripts/build true /out


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This PR adds the test to validate:
- CNI plugin version is always updated when new commits are made to the CNI repository  
- CNI plugin version is always the one expected by the agent codebase 

### Implementation details
Two unit tests are added to ensure the same. 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
