### PR TITLE
Replacing hostsetup.ps with ECSTools' Enable-ECSTaskIAMRoles

### DIFF
--- a/misc/windows-deploy/amazon-ecs-agent.ps1
+++ b/misc/windows-deploy/amazon-ecs-agent.ps1
@@ -10,7 +10,7 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-
+Import-Module ECSTools
 
 $ecsRootDir = "C:\ProgramData\Amazon\ECS\"
 
@@ -63,7 +63,7 @@ try {
 
     if([System.Environment]::GetEnvironmentVariable("ECS_ENABLE_TASK_IAM_ROLE", "Machine") -eq "true") {
         LogMsg "IAM roles environment variable is set."
-        .\hostsetup.ps1
+        Enable-ECSTaskIAMRoles
     }
 
     LogMsg "Starting agent... "

--- a/misc/windows-iam/Setup_Iam.ps1
+++ b/misc/windows-iam/Setup_Iam.ps1
@@ -10,11 +10,18 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
+echo "EBUG whoami:"
+whoami
+echo "DEBUG Env:PSModulePath: $Env:PSModulePath"
+echo "DEBUG getting available modules..."
+Get-Module -ListAvailable
+
+Import-Module ECSTools
 
 $oldPref = $ErrorActionPreference
 $ErrorActionPreference = 'Stop'
 
-Invoke-Expression ${PSScriptRoot}\..\windows-deploy\hostsetup.ps1
+Enable-ECSTaskIAMRoles
 
 # Create amazon/amazon-ecs-iamrolecontainer for tests
 $buildscript = @"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Replacing internal uses of hostsetup.ps1 script with new Enable-ECSTaskIAMRoles function. 

### Implementation details
references to old script have been updated to use new function; the new function is vended through ECSTools ps module on ECS optimized AMIs.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: N/A

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
