### PR TITLE
dockerclient: adding comment to inactivity handler on migration branch

### DIFF
--- a/agent/dockerclient/dockerapi/inactivity_timeout_handler.go
+++ b/agent/dockerclient/dockerapi/inactivity_timeout_handler.go
@@ -33,6 +33,9 @@ func (p *proxyReader) Read(data []byte) (int, error) {
 	return p.ReadCloser.Read(data)
 }
 
+// When pulling an image, the docker api will pull and then subsequently unzip the downloaded artifacts. Docker does
+// not seperate the "pull" from the "unpack" step. What this means is that this timeout doesn't 'tick' while unpacking
+// the downloaded files. This only causes noticable impact with large files, but we should investigate improving this.
 func handleInactivityTimeout(reader io.ReadCloser, timeout time.Duration, cancelRequest func(), canceled *uint32) (io.ReadCloser, chan<- struct{}) {
 	done := make(chan struct{})
 	proxyReader := &proxyReader{ReadCloser: reader}


### PR DESCRIPTION
Adding a comment about code that we ported from go-dockerclient.