### PR TITLE
Adding pull inactivity timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Changelog
+
 ## 1.21.0-dev
 * Feature - Add v3 task metadata support for awsvpc, host and bridge network mode
 * Enhancement - Update the `amazon-ecs-cni-plugins` to `2018.10.0` [1608](https://github.com/aws/amazon-ecs-agent/pull/1608)
-
-## 1.20.4
+* Enhancement - Configurable image pull inactivity timeout [@wattdave](https://github.com/wattdave) [#1566](https://github.com/aws/amazon-ecs-agent/pull/1566)
 * Bug - Fixed a bug where Windows drive volume couldn't be mounted [#1571](https://github.com/aws/amazon-ecs-agent/pull/1571)
 * Bug - Fixed a bug where the Agent's Windows binaries didn't use consistent naming [#1573](https://github.com/aws/amazon-ecs-agent/pull/1573)
 * Bug - Fixed a bug where a port used by WinRM service was not reserved by the Agent by default [#1577](https://github.com/aws/amazon-ecs-agent/pull/1577)

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ additional details on each available environment variable.
 | `ECS_ENABLE_CPU_UNBOUNDED_WINDOWS_WORKAROUND` | `true` | When `true`, ECS will allow CPU unbounded(CPU=`0`) tasks to run along with CPU bounded tasks in Windows. | Not applicable | `false` |
 | `ECS_TASK_METADATA_RPS_LIMIT` | `100,150` | Comma separated integer values for steady state and burst throttle limits for task metadata endpoint | `40,60` | `40,60` |
 | `ECS_SHARED_VOLUME_MATCH_FULL_CONFIG` | `true` | When `true`, ECS Agent will compare name, driver options, and labels to make sure volumes are identical. When `false`, Agent will short circuit shared volume comparison if the names match. This is the default Docker behavior. If a volume is shared across instances, this should be set to `false`. | `false` | `false`|
+| `ECS_DOCKER_PULL_INACTIVITY_TIMEOUT` | 1m | The time to wait after docker pulls complete waiting for extraction of a container. Useful for tuning large Windows containers. | 1m | 1m |
 
 ### Persistence
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ additional details on each available environment variable.
 | `ECS_IMAGE_MINIMUM_CLEANUP_AGE` | 30m | The minimum time interval between when an image is pulled and when it can be considered for automated image cleanup. | 1h | 1h |
 | `ECS_NUM_IMAGES_DELETE_PER_CYCLE` | 5 | The maximum number of images to delete in a single automated image cleanup cycle. If set to less than 1, the value is ignored. | 5 | 5 |
 | `ECS_IMAGE_PULL_BEHAVIOR` | &lt;default &#124; always &#124; once &#124; prefer-cached &gt; | The behavior used to customize the pull image process. If `default` is specified, the image will be pulled remotely, if the pull fails then the cached image in the instance will be used. If `always` is specified, the image will be pulled remotely, if the pull fails then the task will fail. If `once` is specified, the image will be pulled remotely if it has not been pulled before or if the image was removed by image cleanup, otherwise the cached image in the instance will be used. If `prefer-cached` is specified, the image will be pulled remotely if there is no cached image, otherwise the cached image in the instance will be used. | default | default |
+| `ECS_IMAGE_PULL_INACTIVITY_TIMEOUT` | 1m | The time to wait after docker pulls complete waiting for extraction of a container. Useful for tuning large Windows containers. | 1m | 3m |
 | `ECS_INSTANCE_ATTRIBUTES` | `{"stack": "prod"}` | These attributes take effect only during initial registration. After the agent has joined an ECS cluster, use the PutAttributes API action to add additional attributes. For more information, see [Amazon ECS Container Agent Configuration](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-config.html) in the Amazon ECS Developer Guide.| `{}` | `{}` |
 | `ECS_ENABLE_TASK_ENI` | `false` | Whether to enable task networking for task to be launched with its own network interface | `false` | Not applicable |
 | `ECS_CNI_PLUGINS_PATH` | `/ecs/cni` | The path where the cni binary file is located | `/amazon-ecs-cni-plugins` | Not applicable |
@@ -131,7 +132,6 @@ additional details on each available environment variable.
 | `ECS_ENABLE_CPU_UNBOUNDED_WINDOWS_WORKAROUND` | `true` | When `true`, ECS will allow CPU unbounded(CPU=`0`) tasks to run along with CPU bounded tasks in Windows. | Not applicable | `false` |
 | `ECS_TASK_METADATA_RPS_LIMIT` | `100,150` | Comma separated integer values for steady state and burst throttle limits for task metadata endpoint | `40,60` | `40,60` |
 | `ECS_SHARED_VOLUME_MATCH_FULL_CONFIG` | `true` | When `true`, ECS Agent will compare name, driver options, and labels to make sure volumes are identical. When `false`, Agent will short circuit shared volume comparison if the names match. This is the default Docker behavior. If a volume is shared across instances, this should be set to `false`. | `false` | `false`|
-| `ECS_DOCKER_PULL_INACTIVITY_TIMEOUT` | 1m | The time to wait after docker pulls complete waiting for extraction of a container. Useful for tuning large Windows containers. | 1m | 1m |
 
 ### Persistence
 

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -77,6 +77,10 @@ const (
 	// a task's container. This is used to enforce sane values for the config.TaskCleanupWaitDuration field.
 	minimumTaskCleanupWaitDuration = 1 * time.Minute
 
+	// minimumDockerPullInactivityTimeout specifies the minimum duration to wait before cleaning up
+	// a task's container. This is used to enforce sane values for the config.TaskCleanupWaitDuration field.
+	minimumDockerPullInactivityTimeout = 1 * time.Minute
+
 	// minimumDockerStopTimeout specifies the minimum value for docker StopContainer API
 	minimumDockerStopTimeout = 1 * time.Second
 
@@ -255,6 +259,11 @@ func (cfg *Config) validateAndOverrideBounds() error {
 	if cfg.TaskCleanupWaitDuration < minimumTaskCleanupWaitDuration {
 		seelog.Warnf("Invalid value for image cleanup duration, will be overridden with the default value: %s. Parsed value: %v, minimum value: %v.", DefaultTaskCleanupWaitDuration.String(), cfg.TaskCleanupWaitDuration, minimumTaskCleanupWaitDuration)
 		cfg.TaskCleanupWaitDuration = DefaultTaskCleanupWaitDuration
+	}
+
+	if cfg.DockerPullInactivityTimeout < minimumDockerPullInactivityTimeout {
+		seelog.Warnf("Invalid value for docker pull inactivity timeout duration, will be overridden with the default value: %s. Parsed value: %v, minimum value: %v.", defaultDockerPullInactivityTimeout.String(), cfg.DockerPullInactivityTimeout, minimumDockerPullInactivityTimeout)
+		cfg.DockerPullInactivityTimeout = defaultDockerPullInactivityTimeout
 	}
 
 	if cfg.ImageCleanupInterval < minimumImageCleanupInterval {
@@ -438,6 +447,7 @@ func environmentConfig() (Config, error) {
 		TaskCPUMemLimit:                  parseTaskCPUMemLimitEnabled(),
 		DockerStopTimeout:                parseDockerStopTimeout(),
 		ContainerStartTimeout:            parseContainerStartTimeout(),
+		DockerPullInactivityTimeout:	  parseDockerPullInactivityTimeout(),
 		CredentialsAuditLogFile:          os.Getenv("ECS_AUDIT_LOGFILE"),
 		CredentialsAuditLogDisabled:      utils.ParseBool(os.Getenv("ECS_AUDIT_LOGFILE_DISABLED"), false),
 		TaskIAMRoleEnabledForNetworkHost: utils.ParseBool(os.Getenv("ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST"), false),

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -77,9 +77,9 @@ const (
 	// a task's container. This is used to enforce sane values for the config.TaskCleanupWaitDuration field.
 	minimumTaskCleanupWaitDuration = 1 * time.Minute
 
-	// minimumDockerPullInactivityTimeout specifies the minimum duration to wait before cleaning up
-	// a task's container. This is used to enforce sane values for the config.TaskCleanupWaitDuration field.
-	minimumDockerPullInactivityTimeout = 1 * time.Minute
+	// minimumImagePullInactivityTimeout specifies the minimum amount of time for that an image can be
+	// 'stuck' in the pull / unpack step. Very small values are unsafe and lead to high failure rate.
+	minimumImagePullInactivityTimeout = 1 * time.Minute
 
 	// minimumDockerStopTimeout specifies the minimum value for docker StopContainer API
 	minimumDockerStopTimeout = 1 * time.Second
@@ -261,9 +261,9 @@ func (cfg *Config) validateAndOverrideBounds() error {
 		cfg.TaskCleanupWaitDuration = DefaultTaskCleanupWaitDuration
 	}
 
-	if cfg.DockerPullInactivityTimeout < minimumDockerPullInactivityTimeout {
-		seelog.Warnf("Invalid value for docker pull inactivity timeout duration, will be overridden with the default value: %s. Parsed value: %v, minimum value: %v.", defaultDockerPullInactivityTimeout.String(), cfg.DockerPullInactivityTimeout, minimumDockerPullInactivityTimeout)
-		cfg.DockerPullInactivityTimeout = defaultDockerPullInactivityTimeout
+	if cfg.ImagePullInactivityTimeout < minimumImagePullInactivityTimeout {
+		seelog.Warnf("Invalid value for image pull inactivity timeout duration, will be overridden with the default value: %s. Parsed value: %v, minimum value: %v.", defaultImagePullInactivityTimeout.String(), cfg.ImagePullInactivityTimeout, minimumImagePullInactivityTimeout)
+		cfg.ImagePullInactivityTimeout = defaultImagePullInactivityTimeout
 	}
 
 	if cfg.ImageCleanupInterval < minimumImageCleanupInterval {
@@ -447,7 +447,7 @@ func environmentConfig() (Config, error) {
 		TaskCPUMemLimit:                  parseTaskCPUMemLimitEnabled(),
 		DockerStopTimeout:                parseDockerStopTimeout(),
 		ContainerStartTimeout:            parseContainerStartTimeout(),
-		DockerPullInactivityTimeout:	  parseDockerPullInactivityTimeout(),
+		ImagePullInactivityTimeout:       parseImagePullInactivityTimeout(),
 		CredentialsAuditLogFile:          os.Getenv("ECS_AUDIT_LOGFILE"),
 		CredentialsAuditLogDisabled:      utils.ParseBool(os.Getenv("ECS_AUDIT_LOGFILE_DISABLED"), false),
 		TaskIAMRoleEnabledForNetworkHost: utils.ParseBool(os.Getenv("ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST"), false),

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -74,6 +74,7 @@ func TestEnvironmentConfig(t *testing.T) {
 	defer setTestEnv("ECS_RESERVED_MEMORY", "20")()
 	defer setTestEnv("ECS_CONTAINER_STOP_TIMEOUT", "60s")()
 	defer setTestEnv("ECS_CONTAINER_START_TIMEOUT", "5m")()
+	defer setTestEnv("ECS_DOCKER_PULL_INACTIVITY_TIMEOUT", "10m")()
 	defer setTestEnv("ECS_AVAILABLE_LOGGING_DRIVERS", "[\""+string(dockerclient.SyslogDriver)+"\"]")()
 	defer setTestEnv("ECS_SELINUX_CAPABLE", "true")()
 	defer setTestEnv("ECS_APPARMOR_CAPABLE", "true")()
@@ -247,6 +248,26 @@ func TestInvalidFormatContainerStartTimeout(t *testing.T) {
 	assert.Equal(t, conf.ContainerStartTimeout, defaultContainerStartTimeout, "Wrong value for ContainerStartTimeout")
 }
 
+func TestInvalidFormatDockerInactivityTimeout(t *testing.T) {
+	defer setTestRegion()()
+	defer setTestEnv("ECS_DOCKER_PULL_INACTIVITY_TIMEOUT", "invalid")()
+	ctrl := gomock.NewController(t)
+	mockEc2Metadata := mock_ec2.NewMockEC2MetadataClient(ctrl)
+	conf, err := NewConfig(mockEc2Metadata)
+	assert.NoError(t, err)
+	assert.Equal(t, conf.DockerPullInactivityTimeout, defaultDockerPullInactivityTimeout, "Wrong value for DockerPullInactivityTimeout")
+}
+
+func TestInvalidValueDockerInactivityTimeout(t *testing.T) {
+	defer setTestRegion()()
+	defer setTestEnv("ECS_DOCKER_PULL_INACTIVITY_TIMEOUT", "-10s")()
+	ctrl := gomock.NewController(t)
+	mockEc2Metadata := mock_ec2.NewMockEC2MetadataClient(ctrl)
+	conf, err := NewConfig(mockEc2Metadata)
+	assert.NoError(t, err)
+	assert.Equal(t, conf.DockerPullInactivityTimeout, minimumDockerPullInactivityTimeout, "Wrong value for DockerPullInactivityTimeout")
+}
+
 func TestZeroValueContainerStartTimeout(t *testing.T) {
 	defer setTestRegion()()
 	defer setTestEnv("ECS_CONTAINER_START_TIMEOUT", "0s")()
@@ -267,6 +288,26 @@ func TestInvalidValueContainerStartTimeout(t *testing.T) {
 	conf, err := NewConfig(mockEc2Metadata)
 	assert.NoError(t, err)
 	assert.Equal(t, conf.ContainerStartTimeout, minimumContainerStartTimeout, "Wrong value for ContainerStartTimeout")
+}
+
+func TestZeroValueDockerPullInactivityTimeout(t *testing.T) {
+	defer setTestRegion()()
+	defer setTestEnv("ECS_DOCKER_PULL_INACTIVITY_TIMEOUT", "0s")()
+	ctrl := gomock.NewController(t)
+	mockEc2Metadata := mock_ec2.NewMockEC2MetadataClient(ctrl)
+	conf, err := NewConfig(mockEc2Metadata)
+	assert.NoError(t, err)
+	assert.Equal(t, conf.DockerPullInactivityTimeout, defaultDockerPullInactivityTimeout, "Wrong value for DockerPullInactivityTimeout")
+}
+
+func TestInvalidValueDockerPullInactivityTimeout(t *testing.T) {
+	defer setTestRegion()()
+	defer setTestEnv("ECS_DOCKER_PULL_INACTIVITY_TIMEOUT", "-10s")()
+	ctrl := gomock.NewController(t)
+	mockEc2Metadata := mock_ec2.NewMockEC2MetadataClient(ctrl)
+	conf, err := NewConfig(mockEc2Metadata)
+	assert.NoError(t, err)
+	assert.Equal(t, conf.DockerPullInactivityTimeout, minimumDockerPullInactivityTimeout, "Wrong value for DockerPullInactivityTimeout")
 }
 
 func TestInvalidFormatParseEnvVariableUint16(t *testing.T) {

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -74,7 +74,7 @@ func TestEnvironmentConfig(t *testing.T) {
 	defer setTestEnv("ECS_RESERVED_MEMORY", "20")()
 	defer setTestEnv("ECS_CONTAINER_STOP_TIMEOUT", "60s")()
 	defer setTestEnv("ECS_CONTAINER_START_TIMEOUT", "5m")()
-	defer setTestEnv("ECS_DOCKER_PULL_INACTIVITY_TIMEOUT", "10m")()
+	defer setTestEnv("ECS_IMAGE_PULL_INACTIVITY_TIMEOUT", "10m")()
 	defer setTestEnv("ECS_AVAILABLE_LOGGING_DRIVERS", "[\""+string(dockerclient.SyslogDriver)+"\"]")()
 	defer setTestEnv("ECS_SELINUX_CAPABLE", "true")()
 	defer setTestEnv("ECS_APPARMOR_CAPABLE", "true")()
@@ -207,10 +207,7 @@ func TestCheckpointWithoutECSDataDir(t *testing.T) {
 func TestInvalidFormatDockerStopTimeout(t *testing.T) {
 	defer setTestRegion()()
 	defer setTestEnv("ECS_CONTAINER_STOP_TIMEOUT", "invalid")()
-	ctrl := gomock.NewController(t)
-	mockEc2Metadata := mock_ec2.NewMockEC2MetadataClient(ctrl)
-	mockEc2Metadata.EXPECT().GetUserData()
-	conf, err := NewConfig(mockEc2Metadata)
+	conf, err := NewConfig(ec2.NewBlackholeEC2MetadataClient())
 	assert.NoError(t, err)
 	assert.Equal(t, conf.DockerStopTimeout, defaultDockerStopTimeout, "Wrong value for DockerStopTimeout")
 }
@@ -218,10 +215,7 @@ func TestInvalidFormatDockerStopTimeout(t *testing.T) {
 func TestZeroValueDockerStopTimeout(t *testing.T) {
 	defer setTestRegion()()
 	defer setTestEnv("ECS_CONTAINER_STOP_TIMEOUT", "0s")()
-	ctrl := gomock.NewController(t)
-	mockEc2Metadata := mock_ec2.NewMockEC2MetadataClient(ctrl)
-	mockEc2Metadata.EXPECT().GetUserData()
-	conf, err := NewConfig(mockEc2Metadata)
+	conf, err := NewConfig(ec2.NewBlackholeEC2MetadataClient())
 	assert.NoError(t, err)
 	assert.Equal(t, conf.DockerStopTimeout, defaultDockerStopTimeout, "Wrong value for DockerStopTimeout")
 }
@@ -229,10 +223,7 @@ func TestZeroValueDockerStopTimeout(t *testing.T) {
 func TestInvalidValueDockerStopTimeout(t *testing.T) {
 	defer setTestRegion()()
 	defer setTestEnv("ECS_CONTAINER_STOP_TIMEOUT", "-10s")()
-	ctrl := gomock.NewController(t)
-	mockEc2Metadata := mock_ec2.NewMockEC2MetadataClient(ctrl)
-	mockEc2Metadata.EXPECT().GetUserData()
-	conf, err := NewConfig(mockEc2Metadata)
+	conf, err := NewConfig(ec2.NewBlackholeEC2MetadataClient())
 	assert.NoError(t, err)
 	assert.Equal(t, conf.DockerStopTimeout, minimumDockerStopTimeout, "Wrong value for DockerStopTimeout")
 }
@@ -240,41 +231,40 @@ func TestInvalidValueDockerStopTimeout(t *testing.T) {
 func TestInvalidFormatContainerStartTimeout(t *testing.T) {
 	defer setTestRegion()()
 	defer setTestEnv("ECS_CONTAINER_START_TIMEOUT", "invalid")()
-	ctrl := gomock.NewController(t)
-	mockEc2Metadata := mock_ec2.NewMockEC2MetadataClient(ctrl)
-	mockEc2Metadata.EXPECT().GetUserData()
-	conf, err := NewConfig(mockEc2Metadata)
+	conf, err := NewConfig(ec2.NewBlackholeEC2MetadataClient())
 	assert.NoError(t, err)
 	assert.Equal(t, conf.ContainerStartTimeout, defaultContainerStartTimeout, "Wrong value for ContainerStartTimeout")
 }
 
 func TestInvalidFormatDockerInactivityTimeout(t *testing.T) {
 	defer setTestRegion()()
-	defer setTestEnv("ECS_DOCKER_PULL_INACTIVITY_TIMEOUT", "invalid")()
-	ctrl := gomock.NewController(t)
-	mockEc2Metadata := mock_ec2.NewMockEC2MetadataClient(ctrl)
-	conf, err := NewConfig(mockEc2Metadata)
+	defer setTestEnv("ECS_IMAGE_PULL_INACTIVITY_TIMEOUT", "invalid")()
+	conf, err := NewConfig(ec2.NewBlackholeEC2MetadataClient())
 	assert.NoError(t, err)
-	assert.Equal(t, conf.DockerPullInactivityTimeout, defaultDockerPullInactivityTimeout, "Wrong value for DockerPullInactivityTimeout")
+	assert.Equal(t, conf.ImagePullInactivityTimeout, defaultImagePullInactivityTimeout, "Wrong value for ImagePullInactivityTimeout")
 }
 
-func TestInvalidValueDockerInactivityTimeout(t *testing.T) {
+func TestTooSmallDockerInactivityTimeout(t *testing.T) {
 	defer setTestRegion()()
-	defer setTestEnv("ECS_DOCKER_PULL_INACTIVITY_TIMEOUT", "-10s")()
-	ctrl := gomock.NewController(t)
-	mockEc2Metadata := mock_ec2.NewMockEC2MetadataClient(ctrl)
-	conf, err := NewConfig(mockEc2Metadata)
+	defer setTestEnv("ECS_IMAGE_PULL_INACTIVITY_TIMEOUT", "5s")()
+	conf, err := NewConfig(ec2.NewBlackholeEC2MetadataClient())
 	assert.NoError(t, err)
-	assert.Equal(t, conf.DockerPullInactivityTimeout, minimumDockerPullInactivityTimeout, "Wrong value for DockerPullInactivityTimeout")
+	assert.Equal(t, conf.ImagePullInactivityTimeout, minimumImagePullInactivityTimeout, "Wrong value for ImagePullInactivityTimeout")
 }
 
+func TestNegativeValueDockerInactivityTimeout(t *testing.T) {
+	defer setTestRegion()()
+	defer setTestEnv("ECS_IMAGE_PULL_INACTIVITY_TIMEOUT", "-10s")()
+	conf, err := NewConfig(ec2.NewBlackholeEC2MetadataClient())
+	assert.NoError(t, err)
+	assert.Equal(t, conf.ImagePullInactivityTimeout, minimumImagePullInactivityTimeout, "Wrong value for ImagePullInactivityTimeout")
+}
+
+// Zero is also how the config api handles 'bad' values... so we get a 'default' and not a minimum
 func TestZeroValueContainerStartTimeout(t *testing.T) {
 	defer setTestRegion()()
 	defer setTestEnv("ECS_CONTAINER_START_TIMEOUT", "0s")()
-	ctrl := gomock.NewController(t)
-	mockEc2Metadata := mock_ec2.NewMockEC2MetadataClient(ctrl)
-	mockEc2Metadata.EXPECT().GetUserData()
-	conf, err := NewConfig(mockEc2Metadata)
+	conf, err := NewConfig(ec2.NewBlackholeEC2MetadataClient())
 	assert.NoError(t, err)
 	assert.Equal(t, conf.ContainerStartTimeout, defaultContainerStartTimeout, "Wrong value for ContainerStartTimeout")
 }
@@ -282,10 +272,7 @@ func TestZeroValueContainerStartTimeout(t *testing.T) {
 func TestInvalidValueContainerStartTimeout(t *testing.T) {
 	defer setTestRegion()()
 	defer setTestEnv("ECS_CONTAINER_START_TIMEOUT", "-10s")()
-	ctrl := gomock.NewController(t)
-	mockEc2Metadata := mock_ec2.NewMockEC2MetadataClient(ctrl)
-	mockEc2Metadata.EXPECT().GetUserData()
-	conf, err := NewConfig(mockEc2Metadata)
+	conf, err := NewConfig(ec2.NewBlackholeEC2MetadataClient())
 	assert.NoError(t, err)
 	assert.Equal(t, conf.ContainerStartTimeout, minimumContainerStartTimeout, "Wrong value for ContainerStartTimeout")
 }
@@ -293,21 +280,17 @@ func TestInvalidValueContainerStartTimeout(t *testing.T) {
 func TestZeroValueDockerPullInactivityTimeout(t *testing.T) {
 	defer setTestRegion()()
 	defer setTestEnv("ECS_DOCKER_PULL_INACTIVITY_TIMEOUT", "0s")()
-	ctrl := gomock.NewController(t)
-	mockEc2Metadata := mock_ec2.NewMockEC2MetadataClient(ctrl)
-	conf, err := NewConfig(mockEc2Metadata)
+	conf, err := NewConfig(ec2.NewBlackholeEC2MetadataClient())
 	assert.NoError(t, err)
-	assert.Equal(t, conf.DockerPullInactivityTimeout, defaultDockerPullInactivityTimeout, "Wrong value for DockerPullInactivityTimeout")
+	assert.Equal(t, conf.ImagePullInactivityTimeout, defaultImagePullInactivityTimeout, "Wrong value for ImagePullInactivityTimeout")
 }
 
 func TestInvalidValueDockerPullInactivityTimeout(t *testing.T) {
 	defer setTestRegion()()
 	defer setTestEnv("ECS_DOCKER_PULL_INACTIVITY_TIMEOUT", "-10s")()
-	ctrl := gomock.NewController(t)
-	mockEc2Metadata := mock_ec2.NewMockEC2MetadataClient(ctrl)
-	conf, err := NewConfig(mockEc2Metadata)
+	conf, err := NewConfig(ec2.NewBlackholeEC2MetadataClient())
 	assert.NoError(t, err)
-	assert.Equal(t, conf.DockerPullInactivityTimeout, minimumDockerPullInactivityTimeout, "Wrong value for DockerPullInactivityTimeout")
+	assert.Equal(t, conf.ImagePullInactivityTimeout, defaultImagePullInactivityTimeout, "Wrong value for ImagePullInactivityTimeout")
 }
 
 func TestInvalidFormatParseEnvVariableUint16(t *testing.T) {

--- a/agent/config/config_unix.go
+++ b/agent/config/config_unix.go
@@ -37,7 +37,7 @@ const (
 	// minimumContainerStartTimeout specifies the minimum value for starting a container
 	minimumContainerStartTimeout = 45 * time.Second
 	// default docker inactivity time is extra time needed on container extraction
-	defaultDockerPullInactivityTimeout = 1 * time.Minute
+	defaultImagePullInactivityTimeout = 1 * time.Minute
 )
 
 // DefaultConfig returns the default configuration for Linux

--- a/agent/config/config_unix.go
+++ b/agent/config/config_unix.go
@@ -36,6 +36,8 @@ const (
 	defaultContainerStartTimeout = 3 * time.Minute
 	// minimumContainerStartTimeout specifies the minimum value for starting a container
 	minimumContainerStartTimeout = 45 * time.Second
+	// default docker inactivity time is extra time needed on container extraction
+	defaultDockerPullInactivityTimeout = 1 * time.Minute
 )
 
 // DefaultConfig returns the default configuration for Linux

--- a/agent/config/config_windows.go
+++ b/agent/config/config_windows.go
@@ -48,8 +48,8 @@ const (
 	defaultContainerStartTimeout = 8 * time.Minute
 	// minimumContainerStartTimeout specifies the minimum value for starting a container
 	minimumContainerStartTimeout = 2 * time.Minute
-	// default docker inactivity time is extra time needed on container extraction
-	defaultDockerPullInactivityTimeout = 1 * time.Minute
+	// default image pull inactivity time is extra time needed on container extraction
+	defaultImagePullInactivityTimeout = 3 * time.Minute
 )
 
 // DefaultConfig returns the default configuration for Windows
@@ -85,7 +85,7 @@ func DefaultConfig() Config {
 		TaskCleanupWaitDuration:     DefaultTaskCleanupWaitDuration,
 		DockerStopTimeout:           defaultDockerStopTimeout,
 		ContainerStartTimeout:       defaultContainerStartTimeout,
-		DockerPullInactivityTimeout: defaultDockerPullInactivityTimeout,
+		ImagePullInactivityTimeout:  defaultImagePullInactivityTimeout,
 		CredentialsAuditLogFile:     filepath.Join(ecsRoot, defaultCredentialsAuditLogFile),
 		CredentialsAuditLogDisabled: false,
 		ImageCleanupDisabled:        false,

--- a/agent/config/config_windows.go
+++ b/agent/config/config_windows.go
@@ -48,6 +48,8 @@ const (
 	defaultContainerStartTimeout = 8 * time.Minute
 	// minimumContainerStartTimeout specifies the minimum value for starting a container
 	minimumContainerStartTimeout = 2 * time.Minute
+	// default docker inactivity time is extra time needed on container extraction
+	defaultDockerPullInactivityTimeout = 1 * time.Minute
 )
 
 // DefaultConfig returns the default configuration for Windows
@@ -83,6 +85,7 @@ func DefaultConfig() Config {
 		TaskCleanupWaitDuration:     DefaultTaskCleanupWaitDuration,
 		DockerStopTimeout:           defaultDockerStopTimeout,
 		ContainerStartTimeout:       defaultContainerStartTimeout,
+		DockerPullInactivityTimeout: defaultDockerPullInactivityTimeout,
 		CredentialsAuditLogFile:     filepath.Join(ecsRoot, defaultCredentialsAuditLogFile),
 		CredentialsAuditLogDisabled: false,
 		ImageCleanupDisabled:        false,

--- a/agent/config/parse.go
+++ b/agent/config/parse.go
@@ -91,6 +91,20 @@ func parseContainerStartTimeout() time.Duration {
 	return containerStartTimeout
 }
 
+func parseDockerPullInactivityTimeout() time.Duration {
+	var dockerPullInactivityTimeout time.Duration
+	parsedDockerPullInactivityTimeout := parseEnvVariableDuration("ECS_DOCKER_PULL_INACTIVITY_TIMEOUT")
+	if parsedDockerPullInactivityTimeout >= minimumDockerPullInactivityTimeout {
+		dockerPullInactivityTimeout = parsedDockerPullInactivityTimeout
+		// do the parsedStartTimeout != 0 check for the same reason as in getDockerStopTimeout()
+	} else if parsedDockerPullInactivityTimeout != 0 {
+		dockerPullInactivityTimeout = minimumDockerPullInactivityTimeout
+		seelog.Warnf("Discarded invalid value for docker pull inactivity timeout, parsed as: %v", parsedDockerPullInactivityTimeout)
+	}
+	return dockerPullInactivityTimeout
+}
+
+
 func parseAvailableLoggingDrivers() []dockerclient.LoggingDriver {
 	availableLoggingDriversEnv := os.Getenv("ECS_AVAILABLE_LOGGING_DRIVERS")
 	loggingDriverDecoder := json.NewDecoder(strings.NewReader(availableLoggingDriversEnv))

--- a/agent/config/parse.go
+++ b/agent/config/parse.go
@@ -91,19 +91,18 @@ func parseContainerStartTimeout() time.Duration {
 	return containerStartTimeout
 }
 
-func parseDockerPullInactivityTimeout() time.Duration {
-	var dockerPullInactivityTimeout time.Duration
-	parsedDockerPullInactivityTimeout := parseEnvVariableDuration("ECS_DOCKER_PULL_INACTIVITY_TIMEOUT")
-	if parsedDockerPullInactivityTimeout >= minimumDockerPullInactivityTimeout {
-		dockerPullInactivityTimeout = parsedDockerPullInactivityTimeout
+func parseImagePullInactivityTimeout() time.Duration {
+	var imagePullInactivityTimeout time.Duration
+	parsedImagePullInactivityTimeout := parseEnvVariableDuration("ECS_IMAGE_PULL_INACTIVITY_TIMEOUT")
+	if parsedImagePullInactivityTimeout >= minimumImagePullInactivityTimeout {
+		imagePullInactivityTimeout = parsedImagePullInactivityTimeout
 		// do the parsedStartTimeout != 0 check for the same reason as in getDockerStopTimeout()
-	} else if parsedDockerPullInactivityTimeout != 0 {
-		dockerPullInactivityTimeout = minimumDockerPullInactivityTimeout
-		seelog.Warnf("Discarded invalid value for docker pull inactivity timeout, parsed as: %v", parsedDockerPullInactivityTimeout)
+	} else if parsedImagePullInactivityTimeout != 0 {
+		imagePullInactivityTimeout = minimumImagePullInactivityTimeout
+		seelog.Warnf("Discarded invalid value for image pull inactivity timeout, parsed as: %v", parsedImagePullInactivityTimeout)
 	}
-	return dockerPullInactivityTimeout
+	return imagePullInactivityTimeout
 }
-
 
 func parseAvailableLoggingDrivers() []dockerclient.LoggingDriver {
 	availableLoggingDriversEnv := os.Getenv("ECS_AVAILABLE_LOGGING_DRIVERS")

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -96,6 +96,9 @@ type Config struct {
 	// ContainerStartTimeout specifies the amount of time to wait to start a container
 	ContainerStartTimeout time.Duration
 
+	// DockerPullInactivityTimeout is here to override the amount of time to wait when extracting a container
+	DockerPullInactivityTimeout time.Duration
+
 	// AvailableLoggingDrivers specifies the logging drivers available for use
 	// with Docker.  If not set, it defaults to ["json-file","none"].
 	AvailableLoggingDrivers []dockerclient.LoggingDriver

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -96,8 +96,8 @@ type Config struct {
 	// ContainerStartTimeout specifies the amount of time to wait to start a container
 	ContainerStartTimeout time.Duration
 
-	// DockerPullInactivityTimeout is here to override the amount of time to wait when extracting a container
-	DockerPullInactivityTimeout time.Duration
+	// ImagePullInactivityTimeout is here to override the amount of time to wait when pulling and extracting a container
+	ImagePullInactivityTimeout time.Duration
 
 	// AvailableLoggingDrivers specifies the logging drivers available for use
 	// with Docker.  If not set, it defaults to ["json-file","none"].

--- a/agent/dockerclient/dockerapi/docker_client.go
+++ b/agent/dockerclient/dockerapi/docker_client.go
@@ -90,10 +90,6 @@ const (
 	// around a docker bug which sometimes results in pulls not progressing.
 	dockerPullBeginTimeout = 5 * time.Minute
 
-	// dockerPullInactivityTimeout is the amount of time that we will
-	// wait when the pulling does not progress
-	dockerPullInactivityTimeout = 1 * time.Minute
-
 	// pullStatusSuppressDelay controls the time where pull status progress bar
 	// output will be suppressed in debug mode
 	pullStatusSuppressDelay = 2 * time.Second
@@ -343,7 +339,7 @@ func (dg *dockerGoClient) pullImage(image string, authData *apicontainer.Registr
 	opts := docker.PullImageOptions{
 		Repository:        repository,
 		OutputStream:      pullWriter,
-		InactivityTimeout: dockerPullInactivityTimeout,
+		InactivityTimeout: dg.config.DockerPullInactivityTimeout,
 	}
 	timeout := dg.time().After(dockerPullBeginTimeout)
 	// pullBegan is a channel indicating that we have seen at least one line of data on the 'OutputStream' above.

--- a/agent/dockerclient/dockerapi/docker_client.go
+++ b/agent/dockerclient/dockerapi/docker_client.go
@@ -339,7 +339,7 @@ func (dg *dockerGoClient) pullImage(image string, authData *apicontainer.Registr
 	opts := docker.PullImageOptions{
 		Repository:        repository,
 		OutputStream:      pullWriter,
-		InactivityTimeout: dg.config.DockerPullInactivityTimeout,
+		InactivityTimeout: dg.config.ImagePullInactivityTimeout,
 	}
 	timeout := dg.time().After(dockerPullBeginTimeout)
 	// pullBegan is a channel indicating that we have seen at least one line of data on the 'OutputStream' above.
@@ -845,8 +845,8 @@ func (dg *dockerGoClient) handleContainerEvents(ctx context.Context,
 		metadata := dg.containerMetadata(ctx, containerID)
 
 		changedContainers <- DockerContainerChangeEvent{
-			Status: status,
-			Type:   eventType,
+			Status:                  status,
+			Type:                    eventType,
 			DockerContainerMetadata: metadata,
 		}
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
* Carrying #1566 
* Changelog fix (since we dropped 1.20.4)
* longer timeout defaults on windows. 

### Implementation details
<!-- How are the changes implemented? -->
Windows containers tend to be larger, and so we see more failures due to extraction timeouts on windows instances. For linux, this doesn't need to be larger except in a smaller subset of scenarios.

This problem boils down to an issue with the Inactivity Timeout feature of go-dockerclient. For the image create case, docker doesn't separate the 'pull' from the 'extract' workflow, so the timeout applies to both. I've added a comment in the moby branch in #1606 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
