### PR TITLE
api/engine: pass ssm parameters to container via envvars

### DIFF
--- a/agent/api/container/container.go
+++ b/agent/api/container/container.go
@@ -758,3 +758,19 @@ func (c *Container) ShouldCreateWithSSMSecret() bool {
 	}
 	return false
 }
+
+// MergeEnvironmentVariables appends additional envVarName:envVarValue pairs to
+// the the container's enviornment values structure
+func (c *Container) MergeEnvironmentVariables(secrets map[string]string) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	// don't assume that the environment variable map has been initialized by others
+	if c.Environment == nil {
+		c.Environment = make(map[string]string)
+	}
+
+	for k, v := range secrets {
+		c.Environment[k] = v
+	}
+}

--- a/agent/api/container/container.go
+++ b/agent/api/container/container.go
@@ -257,6 +257,12 @@ type Secret struct {
 	Provider      string `json:"provider"`
 }
 
+// GetSSMSecretResourceCacheKey returns the key required to access the secret
+// from the ssmsecret resource
+func (s *Secret) GetSSMSecretResourceCacheKey() string {
+	return s.ValueFrom + "_" + s.Region
+}
+
 // String returns a human readable string representation of DockerContainer
 func (dc *DockerContainer) String() string {
 	if dc == nil {
@@ -761,7 +767,7 @@ func (c *Container) ShouldCreateWithSSMSecret() bool {
 
 // MergeEnvironmentVariables appends additional envVarName:envVarValue pairs to
 // the the container's enviornment values structure
-func (c *Container) MergeEnvironmentVariables(secrets map[string]string) {
+func (c *Container) MergeEnvironmentVariables(envVars map[string]string) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
@@ -770,7 +776,7 @@ func (c *Container) MergeEnvironmentVariables(secrets map[string]string) {
 		c.Environment = make(map[string]string)
 	}
 
-	for k, v := range secrets {
+	for k, v := range envVars {
 		c.Environment[k] = v
 	}
 }

--- a/agent/api/container/container_test.go
+++ b/agent/api/container/container_test.go
@@ -17,6 +17,7 @@ package container
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
@@ -31,38 +32,6 @@ import (
 type configPair struct {
 	Container *Container
 	Config    *docker.Config
-}
-
-var shouldCreateWithSecretsTests = []struct {
-	in Container
-	out bool
-}{
-	{Container{
-		Name:    "myName",
-		Image:   "image:tag",
-		Secrets: []Secret{
-			Secret{
-			Provider:  "ssm",
-			Name:      "secret",
-			ValueFrom: "/test/secretName",
-		}},
-	}, true},
-	{Container{
-		Name:    "myName",
-		Image:   "image:tag",
-		Secrets: nil,
-	}, false},
-	{Container{
-		Name:    "myName",
-		Image:   "image:tag",
-		Secrets: []Secret{
-			Secret{
-			Provider:  "asm",
-			Name:      "secret",
-			ValueFrom: "/test/secretName",
-		}},
-	}, false},
-
 }
 
 func (pair configPair) Equal() bool {
@@ -298,8 +267,109 @@ func TestInjectV3MetadataEndpoint(t *testing.T) {
 }
 
 func TestShouldCreateWithSSMSecret(t *testing.T) {
-	for _, test := range shouldCreateWithSecretsTests {
+	cases := []struct {
+		in  Container
+		out bool
+	}{
+		{Container{
+			Name:  "myName",
+			Image: "image:tag",
+			Secrets: []Secret{
+				Secret{
+					Provider:  "ssm",
+					Name:      "secret",
+					ValueFrom: "/test/secretName",
+				}},
+		}, true},
+		{Container{
+			Name:    "myName",
+			Image:   "image:tag",
+			Secrets: nil,
+		}, false},
+		{Container{
+			Name:  "myName",
+			Image: "image:tag",
+			Secrets: []Secret{
+				Secret{
+					Provider:  "asm",
+					Name:      "secret",
+					ValueFrom: "/test/secretName",
+				}},
+		}, false},
+	}
+
+	for _, test := range cases {
 		container := test.in
 		assert.Equal(t, test.out, container.ShouldCreateWithSSMSecret())
+	}
+}
+
+func TestMergeEnvironmentVariables(t *testing.T) {
+	cases := []struct {
+		Name                   string
+		InContainerEnvironment map[string]string
+		InEnvVarMap            map[string]string
+		OutEnvVarMap           map[string]string
+	}{
+		{
+			Name: "merge single item",
+			InContainerEnvironment: map[string]string{
+				"CONFIG1": "config1"},
+			InEnvVarMap: map[string]string{
+				"SECRET1": "secret1"},
+			OutEnvVarMap: map[string]string{
+				"CONFIG1": "config1",
+				"SECRET1": "secret1",
+			},
+		},
+
+		{
+			Name: "merge single item to nil container env var map",
+			InContainerEnvironment: nil,
+			InEnvVarMap: map[string]string{
+				"SECRET1": "secret1"},
+			OutEnvVarMap: map[string]string{
+				"SECRET1": "secret1",
+			},
+		},
+
+		{
+			Name: "merge zero items to existing container env var map",
+			InContainerEnvironment: map[string]string{
+				"CONFIG1": "config1"},
+			InEnvVarMap: map[string]string{},
+			OutEnvVarMap: map[string]string{
+				"CONFIG1": "config1",
+			},
+		},
+
+		{
+			Name: "merge nil to existing container env var map",
+			InContainerEnvironment: map[string]string{
+				"CONFIG1": "config1"},
+			InEnvVarMap: nil,
+			OutEnvVarMap: map[string]string{
+				"CONFIG1": "config1",
+			},
+		},
+
+		{
+			Name: "merge nil to nil container env var map",
+			InContainerEnvironment: nil,
+			InEnvVarMap:            nil,
+			OutEnvVarMap:           map[string]string{},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			container := Container{
+				Environment: c.InContainerEnvironment,
+			}
+
+			container.MergeEnvironmentVariables(c.InEnvVarMap)
+			mapEq := reflect.DeepEqual(c.OutEnvVarMap, container.Environment)
+			assert.True(t, mapEq)
+		})
 	}
 }

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -1514,8 +1514,8 @@ func (task *Task) PopulateSSMSecrets(container *apicontainer.Container) *apierro
 
 	for _, secret := range container.Secrets {
 		if secret.Provider == apicontainer.SecretProviderSSM {
-			k := secret.ValueFrom + "_" + secret.Region
-			if secretValue, ok := ssmResource.GetSecretValue(k); ok {
+			k := secret.GetSSMSecretResourceCacheKey()
+			if secretValue, ok := ssmResource.GetCachedSecretValue(k); ok {
 				envVars[secret.Name] = secretValue
 			}
 		}

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -854,6 +854,14 @@ func (engine *DockerTaskEngine) createContainer(task *apitask.Task, container *a
 		}
 	}
 
+	// apply secrets to container.Environment
+	if container.ShouldCreateWithSSMSecret() {
+		err := task.PopulateSSMSecrets(container)
+		if err != nil {
+			return dockerapi.DockerContainerMetadata{Error: apierrors.NamedError(err)}
+		}
+	}
+
 	config, err := task.DockerConfig(container, dockerClientVersion)
 	if err != nil {
 		return dockerapi.DockerContainerMetadata{Error: apierrors.NamedError(err)}

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -1631,8 +1631,6 @@ func TestTaskUseExecutionRolePullPrivateRegistryImage(t *testing.T) {
 	}
 	requiredASMResources := []*apicontainer.ASMAuthData{asmAuthData}
 	asmClientCreator := mock_asm_factory.NewMockClientCreator(ctrl)
-	if false {
-	}
 	asmAuthRes := asmauth.NewASMAuthResource(testTask.Arn, requiredASMResources,
 		credentialsID, credentialsManager, asmClientCreator)
 	testTask.ResourcesMapUnsafe = map[string][]taskresource.TaskResource{
@@ -2273,7 +2271,6 @@ func TestSynchronizeResource(t *testing.T) {
 	dockerTaskEngine.synchronizeState()
 }
 
-// WIP
 func TestTaskSSMSecretsEnvironmentVariables(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -33,7 +33,7 @@ import (
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	apitaskstatus "github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/agent/asm"
-	"github.com/aws/amazon-ecs-agent/agent/asm/factory/mocks"
+	mock_asm_factory "github.com/aws/amazon-ecs-agent/agent/asm/factory/mocks"
 	mock_secretsmanageriface "github.com/aws/amazon-ecs-agent/agent/asm/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/containermetadata/mocks"
@@ -49,14 +49,18 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/engine/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/engine/testdata"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
+	mock_ssm_factory "github.com/aws/amazon-ecs-agent/agent/ssm/factory/mocks"
+	mock_ssmiface "github.com/aws/amazon-ecs-agent/agent/ssm/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/statemanager/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/asmauth"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/mocks"
+	"github.com/aws/amazon-ecs-agent/agent/taskresource/ssmsecret"
 	taskresourcevolume "github.com/aws/amazon-ecs-agent/agent/taskresource/volume"
 	"github.com/aws/amazon-ecs-agent/agent/utils/ttime/mocks"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
+	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/containernetworking/cni/pkg/types/current"
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/golang/mock/gomock"
@@ -1626,7 +1630,9 @@ func TestTaskUseExecutionRolePullPrivateRegistryImage(t *testing.T) {
 		ASMAuthData: asmAuthData,
 	}
 	requiredASMResources := []*apicontainer.ASMAuthData{asmAuthData}
-	asmClientCreator := mock_factory.NewMockClientCreator(ctrl)
+	asmClientCreator := mock_asm_factory.NewMockClientCreator(ctrl)
+	if false {
+	}
 	asmAuthRes := asmauth.NewASMAuthResource(testTask.Arn, requiredASMResources,
 		credentialsID, credentialsManager, asmClientCreator)
 	testTask.ResourcesMapUnsafe = map[string][]taskresource.TaskResource{
@@ -2265,4 +2271,129 @@ func TestSynchronizeResource(t *testing.T) {
 	// Set the task to be stopped so that the process can done quickly
 	testTask.SetDesiredStatus(apitaskstatus.TaskStopped)
 	dockerTaskEngine.synchronizeState()
+}
+
+// WIP
+func TestTaskSSMSecretsEnvironmentVariables(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	ctrl, client, mockTime, taskEngine, credentialsManager, _, _ := mocks(t, ctx, &defaultConfig)
+	defer ctrl.Finish()
+
+	// metadata required for createContainer workflow validation
+	ssmTaskARN := "ssmSecretsTask"
+	ssmTaskFamily := "ssmSecretsTaskFamily"
+	ssmTaskVersion := "1"
+	ssmTaskContainerName := "ssmSecretsContainer"
+
+	// metadata required for ssm secret resource validation
+	secretName := "mySecret"
+	secretValueFrom := "ssm/mySecret"
+	secretRetrievedValue := "mySecretValue"
+	secretRegion := "us-west-2"
+
+	expectedEnvVar := secretName + "=" + secretRetrievedValue
+
+	secrets := []apicontainer.Secret{
+		{
+			Name:      secretName,
+			ValueFrom: secretValueFrom,
+			Region:    secretRegion,
+			Type:      "ENVIRONMENT_VARIABLES",
+			Provider:  "ssm",
+		},
+	}
+
+	// sample test
+	testTask := &apitask.Task{
+		Arn:     ssmTaskARN,
+		Family:  ssmTaskFamily,
+		Version: ssmTaskVersion,
+		Containers: []*apicontainer.Container{
+			{
+				Name:    ssmTaskContainerName,
+				Secrets: secrets,
+			},
+		},
+	}
+
+	// metadata required for execution role authentication workflow
+	credentialsID := "execution role"
+	executionRoleCredentials := credentials.IAMRoleCredentials{
+		CredentialsID: credentialsID,
+	}
+	taskIAMcreds := credentials.TaskIAMRoleCredentials{
+		IAMRoleCredentials: executionRoleCredentials,
+	}
+
+	// configure the task and container to use execution role
+	testTask.SetExecutionRoleCredentialsID(credentialsID)
+
+	// validate base config
+	expectedConfig, err := testTask.DockerConfig(testTask.Containers[0], defaultDockerClientAPIVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedConfig.Labels = map[string]string{
+		"com.amazonaws.ecs.task-arn":                ssmTaskARN,
+		"com.amazonaws.ecs.container-name":          ssmTaskContainerName,
+		"com.amazonaws.ecs.task-definition-family":  ssmTaskFamily,
+		"com.amazonaws.ecs.task-definition-version": ssmTaskVersion,
+		"com.amazonaws.ecs.cluster":                 "",
+	}
+
+	// required to validate container config includes secrets as environment variables
+	expectedConfig.Env = []string{expectedEnvVar}
+
+	// required for validating ssm workflows
+	ssmClientCreator := mock_ssm_factory.NewMockSSMClientCreator(ctrl)
+	mockSSMClient := mock_ssmiface.NewMockSSMClient(ctrl)
+
+	ssmRequirements := map[string][]apicontainer.Secret{
+		secretRegion: secrets,
+	}
+
+	ssmSecretRes := ssmsecret.NewSSMSecretResource(
+		testTask.Arn,
+		ssmRequirements,
+		credentialsID,
+		credentialsManager,
+		ssmClientCreator)
+
+	testTask.ResourcesMapUnsafe = map[string][]taskresource.TaskResource{
+		ssmsecret.ResourceName: {ssmSecretRes},
+	}
+
+	ssmClientOutput := &ssm.GetParametersOutput{
+		InvalidParameters: []*string{},
+		Parameters: []*ssm.Parameter{
+			&ssm.Parameter{
+				Name:  aws.String(secretValueFrom),
+				Value: aws.String(secretRetrievedValue),
+			},
+		},
+	}
+
+	reqSecretNames := []*string{aws.String(secretValueFrom)}
+
+	credentialsManager.EXPECT().GetTaskCredentials(credentialsID).Return(taskIAMcreds, true)
+	ssmClientCreator.EXPECT().NewSSMClient(region, executionRoleCredentials).Return(mockSSMClient)
+
+	mockSSMClient.EXPECT().GetParameters(gomock.Any()).Do(func(in *ssm.GetParametersInput) {
+		assert.Equal(t, in.Names, reqSecretNames)
+	}).Return(ssmClientOutput, nil).Times(1)
+
+	require.NoError(t, ssmSecretRes.Create())
+
+	mockTime.EXPECT().Now().AnyTimes()
+	client.EXPECT().APIVersion().Return(defaultDockerClientAPIVersion, nil).AnyTimes()
+
+	// test validates that the expectedConfig includes secrets are appended as
+	// environment varibles
+	client.EXPECT().CreateContainer(gomock.Any(), expectedConfig, gomock.Any(), gomock.Any(), gomock.Any())
+
+	ret := taskEngine.(*DockerTaskEngine).createContainer(testTask, testTask.Containers[0])
+
+	assert.Nil(t, ret.Error)
 }

--- a/agent/taskresource/ssmsecret/ssmsecret.go
+++ b/agent/taskresource/ssmsecret/ssmsecret.go
@@ -304,12 +304,11 @@ func (secret *SSMSecretResource) retrieveSSMSecretValuesByRegion(region string, 
 	var secretNames []string
 
 	for _, s := range secrets {
-		secretName := s.ValueFrom
-		secretKey := secretName + "_" + region
-		if _, ok := secret.getCachedSecretValue(secretKey); ok {
+		secretKey := s.GetSSMSecretResourceCacheKey()
+		if _, ok := secret.GetCachedSecretValue(secretKey); ok {
 			continue
 		}
-		secretNames = append(secretNames, secretName)
+		secretNames = append(secretNames, s.ValueFrom)
 		if len(secretNames) == MaxBatchNum {
 			secretNamesTmp := make([]string, MaxBatchNum)
 			copy(secretNamesTmp, secretNames)
@@ -348,15 +347,6 @@ func (secret *SSMSecretResource) retrieveSSMSecretValues(region string, names []
 	}
 }
 
-// GetSecretValue returns the value retrieved from SSM
-func (secret *SSMSecretResource) GetSecretValue(key string) (string, bool) {
-	secret.lock.RLock()
-	defer secret.lock.RUnlock()
-
-	s, ok := secret.secretData[key]
-	return s, ok
-}
-
 // getRequiredSecrets returns the requiredSecrets field of ssmsecret task resource
 func (secret *SSMSecretResource) getRequiredSecrets() map[string][]apicontainer.Secret {
 	secret.lock.RLock()
@@ -390,8 +380,8 @@ func (secret *SSMSecretResource) clearSSMSecretValue() {
 	}
 }
 
-// getCachedSecretValue retrieves the secret value from secretData field
-func (secret *SSMSecretResource) getCachedSecretValue(secretKey string) (string, bool) {
+// GetCachedSecretValue retrieves the secret value from secretData field
+func (secret *SSMSecretResource) GetCachedSecretValue(secretKey string) (string, bool) {
 	secret.lock.RLock()
 	defer secret.lock.RUnlock()
 

--- a/agent/taskresource/ssmsecret/ssmsecret.go
+++ b/agent/taskresource/ssmsecret/ssmsecret.go
@@ -348,6 +348,15 @@ func (secret *SSMSecretResource) retrieveSSMSecretValues(region string, names []
 	}
 }
 
+// GetSecretValue returns the value retrieved from SSM
+func (secret *SSMSecretResource) GetSecretValue(key string) (string, bool) {
+	secret.lock.RLock()
+	defer secret.lock.RUnlock()
+
+	s, ok := secret.secretData[key]
+	return s, ok
+}
+
 // getRequiredSecrets returns the requiredSecrets field of ssmsecret task resource
 func (secret *SSMSecretResource) getRequiredSecrets() map[string][]apicontainer.Secret {
 	secret.lock.RLock()

--- a/agent/taskresource/ssmsecret/ssmsecret_test.go
+++ b/agent/taskresource/ssmsecret/ssmsecret_test.go
@@ -113,11 +113,11 @@ func TestCreateAndGetWithOneCall(t *testing.T) {
 	}
 	require.NoError(t, ssmRes.Create())
 
-	value1, ok := ssmRes.getCachedSecretValue(secretKeyWest1)
+	value1, ok := ssmRes.GetCachedSecretValue(secretKeyWest1)
 	require.True(t, ok)
 	assert.Equal(t, secretValue, value1)
 
-	value2, ok := ssmRes.getCachedSecretValue(secretKeyWest2)
+	value2, ok := ssmRes.GetCachedSecretValue(secretKeyWest2)
 	require.True(t, ok)
 	assert.Equal(t, secretValue, value2)
 }
@@ -182,11 +182,11 @@ func TestCreateAndGetWithTwoCallsAcrossRegions(t *testing.T) {
 	}
 	require.NoError(t, ssmRes.Create())
 
-	value1, ok := ssmRes.getCachedSecretValue(secretKeyWest1)
+	value1, ok := ssmRes.GetCachedSecretValue(secretKeyWest1)
 	require.True(t, ok)
 	assert.Equal(t, secretValue, value1)
 
-	value2, ok := ssmRes.getCachedSecretValue(secretKeyEast1)
+	value2, ok := ssmRes.GetCachedSecretValue(secretKeyEast1)
 	require.True(t, ok)
 	assert.Equal(t, secretValue, value2)
 }
@@ -279,7 +279,7 @@ func TestCreateAndGetWithTwoCallsInSameRegion(t *testing.T) {
 
 	for i := 1; i <= 12; i++ {
 		num := strconv.Itoa(i)
-		value, ok := ssmRes.getCachedSecretValue("secret-name-" + num + "_" + region1)
+		value, ok := ssmRes.GetCachedSecretValue("secret-name-" + num + "_" + region1)
 		require.True(t, ok)
 		assert.Equal(t, "secret-value-"+num, value)
 	}


### PR DESCRIPTION
### Summary
<!-- What does this pull request do? -->
This commit adds changes to take prepared ssmsecret resources and inject
them into the container's env struct so it is added to the docker
container config before create container is called.

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [ ] Builds on Linux (`make release`)
- [ ] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [ ] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
