### PR TITLE
config: make docker health check configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ additional details on each available environment variable.
 | `ECS_CONTAINER_INSTANCE_TAGS` | `{"tag_key": "tag_val"}` | The metadata that you apply to the container instance to help you categorize and organize them. Each tag consists of a key and an optional value, both of which you define. Tag keys can have a maximum character length of 128 characters, and tag values can have a maximum length of 256 characters. If tags also exist on your container instance that are propagated using the `ECS_CONTAINER_INSTANCE_PROPAGATE_TAGS_FROM` parameter, those tags will be overwritten by the tags specified using `ECS_CONTAINER_INSTANCE_TAGS`. | `{}` | `{}` |
 | `ECS_ENABLE_UNTRACKED_IMAGE_CLEANUP` | `true` | Whether to allow the ECS agent to delete containers and images that are not part of ECS tasks. | `false` | `false` |
 | `ECS_EXCLUDE_UNTRACKED_IMAGE` | `alpine:latest` | Comma seperated list of `imageName:tag` of images that should not be deleted by the ECS agent if `ECS_ENABLE_UNTRACKED_IMAGE_CLEANUP` is enabled. | | |
+| `ECS_DISABLE_DOCKER_HEALTH_CHECK` | `false` | Whether to disable the Docker Container health check for the ECS Agent. | `false` | `false` |
 
 ### Persistence
 

--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -143,7 +143,7 @@ func (agent *ecsAgent) appendDockerDependentCapabilities(capabilities []*ecs.Att
 		capabilities = appendNameOnlyAttribute(capabilities, attributePrefix+"execution-role-ecr-pull")
 	}
 
-	if _, ok := supportedVersions[dockerclient.Version_1_24]; ok {
+	if _, ok := supportedVersions[dockerclient.Version_1_24]; ok && !agent.cfg.DisableDockerHealthCheck {
 		// Docker health check was added in API 1.24
 		capabilities = appendNameOnlyAttribute(capabilities, attributePrefix+"container-health-check")
 	}

--- a/agent/app/agent_capability_test.go
+++ b/agent/app/agent_capability_test.go
@@ -599,6 +599,42 @@ func TestCapabilitiesContainerHealth(t *testing.T) {
 	assert.True(t, ok, "Could not find container health check capability when expected; got capabilities %v", capabilities)
 }
 
+func TestCapabilitiesContainerHealthDisabled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := mock_dockerapi.NewMockDockerClient(ctrl)
+	mockMobyPlugins := mock_mobypkgwrapper.NewMockPlugins(ctrl)
+
+	client.EXPECT().SupportedVersions().Return([]dockerclient.DockerVersion{
+		dockerclient.Version_1_24,
+	})
+	client.EXPECT().KnownVersions().Return(nil)
+	mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{}, nil)
+	client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
+		gomock.Any()).AnyTimes().Return([]string{}, nil)
+
+	ctx, cancel := context.WithCancel(context.TODO())
+	// Cancel the context to cancel async routines
+	defer cancel()
+	agent := &ecsAgent{
+		ctx:          ctx,
+		cfg:          &config.Config{DisableDockerHealthCheck: true},
+		dockerClient: client,
+		mobyPlugins:  mockMobyPlugins,
+	}
+
+	capabilities, err := agent.capabilities()
+	require.NoError(t, err)
+
+	capMap := make(map[string]bool)
+	for _, capability := range capabilities {
+		capMap[aws.StringValue(capability.Name)] = true
+	}
+
+	assert.NotContains(t, "ecs.capability.container-health-check", "Find container health check capability unexpected when it is disabled")
+}
+
 func TestCapabilitesListPluginsErrorCase(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -532,6 +532,7 @@ func environmentConfig() (Config, error) {
 		ContainerInstancePropagateTagsFrom:  parseContainerInstancePropagateTagsFrom(),
 		PollMetrics:                         utils.ParseBool(os.Getenv("ECS_POLL_METRICS"), false),
 		PollingMetricsWaitDuration:          parseEnvVariableDuration("ECS_POLLING_METRICS_WAIT_DURATION"),
+		DisableDockerHealthCheck:            utils.ParseBool(os.Getenv("ECS_DISABLE_DOCKER_HEALTH_CHECK"), false),
 	}, err
 }
 

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -183,10 +183,12 @@ func TestTrimWhitespace(t *testing.T) {
 
 func TestConfigBoolean(t *testing.T) {
 	defer setTestRegion()()
+	defer setTestEnv("ECS_DISABLE_DOCKER_HEALTH_CHECK", "true")()
 	defer setTestEnv("ECS_DISABLE_METRICS", "true")()
 	cfg, err := NewConfig(ec2.NewBlackholeEC2MetadataClient())
 	assert.NoError(t, err)
 	assert.True(t, cfg.DisableMetrics)
+	assert.True(t, cfg.DisableDockerHealthCheck)
 }
 
 func TestBadLoggingDriverSerialization(t *testing.T) {

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -97,6 +97,10 @@ type Config struct {
 	// again when PollMetrics is set to true
 	PollingMetricsWaitDuration time.Duration
 
+	// DisableDockerHealthCheck configures whether container health feature was enabled
+	// on the instance
+	DisableDockerHealthCheck bool
+
 	// ReservedMemory specifies the amount of memory (in MB) to reserve for things
 	// other than containers managed by ECS
 	ReservedMemory uint16

--- a/agent/tcs/handler/handler.go
+++ b/agent/tcs/handler/handler.go
@@ -47,7 +47,17 @@ const (
 // StartMetricsSession starts a metric session. It initializes the stats engine
 // and invokes StartSession.
 func StartMetricsSession(params TelemetrySessionParams) {
-	err := params.StatsEngine.MustInit(params.Ctx, params.TaskEngine, params.Cfg.Cluster,
+	ok, err := params.isContainerHealthMetricsDisabled()
+	if err != nil {
+		seelog.Warnf("Error starting metrics session: %v", err)
+		return
+	}
+	if ok {
+		seelog.Warnf("Metrics were disabled, not starting the telemetry session")
+		return
+	}
+
+	err = params.StatsEngine.MustInit(params.Ctx, params.TaskEngine, params.Cfg.Cluster,
 		params.ContainerInstanceArn)
 	if err != nil {
 		seelog.Warnf("Error initializing metrics engine: %v", err)

--- a/agent/tcs/handler/handler_test.go
+++ b/agent/tcs/handler/handler_test.go
@@ -73,6 +73,19 @@ func (*mockStatsEngine) GetTaskHealthMetrics() (*ecstcs.HealthMetadata, []*ecstc
 	return nil, nil, nil
 }
 
+// TestDisableMetrics tests the StartMetricsSession will return immediately if
+// the metrics was disabled
+func TestDisableMetrics(t *testing.T) {
+	params := TelemetrySessionParams{
+		Cfg: &config.Config{
+			DisableMetrics:           true,
+			DisableDockerHealthCheck: true,
+		},
+	}
+
+	StartMetricsSession(params)
+}
+
 func TestFormatURL(t *testing.T) {
 	endpoint := "http://127.0.0.0.1/"
 	wsurl := formatURL(endpoint, testClusterArn, testInstanceArn)

--- a/agent/tcs/handler/types.go
+++ b/agent/tcs/handler/types.go
@@ -24,6 +24,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/stats"
 	"github.com/aws/amazon-ecs-agent/agent/utils/ttime"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/pkg/errors"
 )
 
 // TelemetrySessionParams contains all the parameters required to start a tcs
@@ -49,4 +50,11 @@ func (params *TelemetrySessionParams) time() ttime.Time {
 		}
 	})
 	return params._time
+}
+
+func (params *TelemetrySessionParams) isContainerHealthMetricsDisabled() (bool, error) {
+	if params.Cfg != nil {
+		return params.Cfg.DisableMetrics && params.Cfg.DisableDockerHealthCheck, nil
+	}
+	return false, errors.New("Config is empty in the tcs session parameter")
 }

--- a/agent/tcs/handler/types_test.go
+++ b/agent/tcs/handler/types_test.go
@@ -1,0 +1,74 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package tcshandler
+
+import (
+	"testing"
+
+	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsMetricsDisabled(t *testing.T) {
+	tcs := []struct {
+		param       *TelemetrySessionParams
+		result      bool
+		err         error
+		description string
+	}{
+		{
+			param:       &TelemetrySessionParams{},
+			result:      false,
+			err:         errors.New("Config is empty in the tcs session parameter"),
+			description: "Config not set should cause error",
+		},
+		{
+			param:       &TelemetrySessionParams{Cfg: &config.Config{DisableMetrics: false, DisableDockerHealthCheck: false}},
+			result:      false,
+			err:         nil,
+			description: "No metrics was disable should return false",
+		},
+		{
+			param:       &TelemetrySessionParams{Cfg: &config.Config{DisableMetrics: true, DisableDockerHealthCheck: false}},
+			result:      false,
+			err:         nil,
+			description: "Only health metrics was disable should return false",
+		},
+		{
+			param:       &TelemetrySessionParams{Cfg: &config.Config{DisableMetrics: false, DisableDockerHealthCheck: true}},
+			result:      false,
+			err:         nil,
+			description: "Only telemetry metrics was disable should return false",
+		},
+		{
+			param:       &TelemetrySessionParams{Cfg: &config.Config{DisableMetrics: true, DisableDockerHealthCheck: true}},
+			result:      true,
+			err:         nil,
+			description: "both telemetry and health metrics were disable should return true",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.description, func(t *testing.T) {
+			ok, err := tc.param.isContainerHealthMetricsDisabled()
+			if tc.err != nil {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tc.result, ok)
+		})
+	}
+}


### PR DESCRIPTION
### Summary
<!-- What does this pull request do? -->
carried over from https://github.com/aws/amazon-ecs-agent/pull/1522

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [ ] Builds on Linux (`make release`)
- [ ] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [ ] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
