### PR TITLE
Refactor error message

### DIFF
--- a/agent/acs/model/api/api-2.json
+++ b/agent/acs/model/api/api-2.json
@@ -437,7 +437,7 @@
     },
     "SecretProvider":{
       "type":"string",
-      "enum":["SSM"]
+      "enum":["ssm"]
     },
     "SecretType":{
       "type":"string",

--- a/agent/taskresource/ssmsecret/ssmsecret_test.go
+++ b/agent/taskresource/ssmsecret/ssmsecret_test.go
@@ -340,8 +340,8 @@ func TestCreateReturnMultipleErrors(t *testing.T) {
 	}
 
 	assert.Error(t, ssmRes.Create())
-	expectedError := "fetching secret data from ssm parameter store: invalid parameters: secret-name, "
-	assert.Equal(t, expectedError, ssmRes.GetTerminalReason())
+	expectedError := "fetching secret data from ssm parameter store: invalid parameters: secret-name,"
+	assert.Contains(t, ssmRes.GetTerminalReason(), expectedError)
 }
 
 func TestCreateReturnError(t *testing.T) {
@@ -389,7 +389,7 @@ func TestCreateReturnError(t *testing.T) {
 	}
 
 	assert.Error(t, ssmRes.Create())
-	expectedError := "fetching secret data from ssm parameter store: invalid parameters: secret-name, "
+	expectedError := "[us-west-2] fetching secret data from ssm parameter store: invalid parameters: secret-name, "
 	assert.Equal(t, expectedError, ssmRes.GetTerminalReason())
 }
 


### PR DESCRIPTION
### Summary
1. Populate region info to error message so customers can know what region causes issues. 
2. Set terminal reason when cannot find credential roles.

### Testing
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) 
(TestAgentIntrospectionValidator fails, flaky test)
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
