### PR TITLE
ssmsecret: populate region in error message and set terminal reason

### DIFF
--- a/agent/taskresource/ssmsecret/ssmsecret_test.go
+++ b/agent/taskresource/ssmsecret/ssmsecret_test.go
@@ -340,8 +340,8 @@ func TestCreateReturnMultipleErrors(t *testing.T) {
 	}
 
 	assert.Error(t, ssmRes.Create())
-	expectedError := "fetching secret data from ssm parameter store: invalid parameters: secret-name, "
-	assert.Equal(t, expectedError, ssmRes.GetTerminalReason())
+	expectedError := "fetching secret data from ssm parameter store: invalid parameters: secret-name,"
+	assert.Contains(t, ssmRes.GetTerminalReason(), expectedError)
 }
 
 func TestCreateReturnError(t *testing.T) {
@@ -389,7 +389,7 @@ func TestCreateReturnError(t *testing.T) {
 	}
 
 	assert.Error(t, ssmRes.Create())
-	expectedError := "fetching secret data from ssm parameter store: invalid parameters: secret-name, "
+	expectedError := "[us-west-2] fetching secret data from ssm parameter store: invalid parameters: secret-name, "
 	assert.Equal(t, expectedError, ssmRes.GetTerminalReason())
 }
 


### PR DESCRIPTION
### Summary
Populate region info to error message so customers can know what region causes issues.
Set terminal reason when cannot find credential roles.

### Testing
- [ ] Builds on Linux (`make release`)
- [ ] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [ ] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
