### PR TITLE
Removing go-dockerclient dependencies in functional tests

### DIFF
--- a/agent/functional_tests/tests/functionaltests_windows_test.go
+++ b/agent/functional_tests/tests/functionaltests_windows_test.go
@@ -16,6 +16,7 @@
 package functional_tests
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -116,6 +117,7 @@ func TestTaskIamRolesDefaultNetworkMode(t *testing.T) {
 }
 
 func taskIamRolesTest(networkMode string, agent *TestAgent, t *testing.T) {
+	ctx := context.TODO()
 	RequireDockerVersion(t, ">=1.11.0") // TaskIamRole is available from agent 1.11.0
 	roleArn := os.Getenv("TASK_IAM_ROLE_ARN")
 	if utils.ZeroOrNil(roleArn) {
@@ -146,7 +148,7 @@ func taskIamRolesTest(networkMode string, agent *TestAgent, t *testing.T) {
 	}
 
 	// TaskIAMRoles enabled contaienr should have the ExtraEnvironment variable AWS_CONTAINER_CREDENTIALS_RELATIVE_URI
-	containerMetaData, err := agent.DockerClient.InspectContainer(containerId)
+	containerMetaData, err := agent.DockerClient.ContainerInspect(ctx, containerId)
 	if err != nil {
 		t.Fatalf("Could not inspect container for task: %v", err)
 	}
@@ -170,7 +172,7 @@ func taskIamRolesTest(networkMode string, agent *TestAgent, t *testing.T) {
 		t.Fatalf("Waiting task to stop error : %v", err)
 	}
 
-	containerMetaData, err = agent.DockerClient.InspectContainer(containerId)
+	containerMetaData, err = agent.DockerClient.ContainerInspect(ctx, containerId)
 	if err != nil {
 		t.Fatalf("Could not inspect container for task: %v", err)
 	}
@@ -187,6 +189,7 @@ func TestV3TaskEndpointDefaultNetworkMode(t *testing.T) {
 // TestMetadataServiceValidator Tests that the metadata file can be accessed from the
 // container using the ECS_CONTAINER_METADATA_FILE environment variables
 func TestMetadataServiceValidator(t *testing.T) {
+	ctx := context.TODO()
 	agentOptions := &AgentOptions{
 		ExtraEnvironment: map[string]string{
 			"ECS_ENABLE_CONTAINER_METADATA": "true",
@@ -215,7 +218,7 @@ func TestMetadataServiceValidator(t *testing.T) {
 		t.Fatalf("Error resolving docker id for container in task: %v", err)
 	}
 
-	containerMetaData, err := agent.DockerClient.InspectContainer(containerID)
+	containerMetaData, err := agent.DockerClient.ContainerInspect(ctx, containerID)
 	require.NoError(t, err, "Could not inspect container for task")
 
 	exitCode := containerMetaData.State.ExitCode

--- a/agent/functional_tests/util/utils.go
+++ b/agent/functional_tests/util/utils.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"context"
+
 	"github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
 	"github.com/aws/amazon-ecs-agent/agent/handlers/v1"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
@@ -39,7 +40,10 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	"github.com/aws/aws-sdk-go/service/iam"
-	docker "github.com/fsouza/go-dockerclient"
+
+	"github.com/docker/docker/api/types"
+	docker "github.com/docker/docker/client"
+	"github.com/docker/go-connections/nat"
 	"github.com/pkg/errors"
 )
 
@@ -117,7 +121,7 @@ type TestAgent struct {
 type AgentOptions struct {
 	ExtraEnvironment map[string]string
 	ContainerLinks   []string
-	PortBindings     map[docker.Port]map[string]string
+	PortBindings     map[nat.Port]map[string]string
 	EnableTaskENI    bool
 }
 
@@ -144,13 +148,14 @@ func (agent *TestAgent) verifyIntrospectionAPI() error {
 		}
 		time.Sleep(1 * time.Second)
 	}
+	ctx := context.TODO()
 	if localMetadata.ContainerInstanceArn == nil {
-		agent.DockerClient.StopContainer(agent.DockerID, 1)
+		stopTimeout := 1 * time.Second
+		agent.DockerClient.ContainerStop(ctx, agent.DockerID, &stopTimeout)
 		return errors.New("Could not get agent metadata after launching it")
 	}
 
 	agent.ContainerInstanceArn = *localMetadata.ContainerInstanceArn
-	fmt.Println("Container InstanceArn:", agent.ContainerInstanceArn)
 	agent.Cluster = localMetadata.Cluster
 	agent.Version = utils.ExtractVersion(localMetadata.Version)
 	agent.t.Logf("Found agent metadata: %+v", localMetadata)
@@ -593,51 +598,51 @@ func (task *TestTask) GetAttachmentInfo() ([]*ecs.KeyValuePair, error) {
 }
 
 func RequireDockerVersion(t *testing.T, selector string) {
-	dockerClient, err := docker.NewClientFromEnv()
+	ctx := context.TODO()
+	dockerClient, err := docker.NewEnvClient()
 	if err != nil {
 		t.Fatalf("Could not get docker client to check version: %v", err)
 	}
-	dockerVersion, err := dockerClient.Version()
+	version, err := dockerClient.ServerVersion(ctx)
 	if err != nil {
 		t.Fatalf("Could not get docker version: %v", err)
 	}
+	dockerVersion := version.Version
 
-	version := dockerVersion.Get("Version")
-
-	match, err := utils.Version(version).Matches(selector)
+	match, err := utils.Version(dockerVersion).Matches(selector)
 	if err != nil {
 		t.Fatalf("Could not check docker version to match required: %v", err)
 	}
 
 	if !match {
-		t.Skipf("Skipping test; requires %v, but version is %v", selector, version)
+		t.Skipf("Skipping test; requires %v, but version is %v", selector, dockerVersion)
 	}
 }
 
 func RequireDockerAPIVersion(t *testing.T, selector string) {
-	dockerClient, err := docker.NewClientFromEnv()
+	ctx := context.TODO()
+	dockerClient, err := docker.NewEnvClient()
 	if err != nil {
 		t.Fatalf("Could not get docker client to check version: %v", err)
 	}
-	dockerVersion, err := dockerClient.Version()
+	version, err := dockerClient.ServerVersion(ctx)
 	if err != nil {
 		t.Fatalf("Could not get docker version: %v", err)
 	}
-
-	version := dockerVersion.Get("ApiVersion")
+	apiVersion := version.APIVersion
 
 	// adding zero patch to use semver comparator
 	// TODO: Implement non-semver comparator
-	version += ".0"
+	apiVersion += ".0"
 	selector += ".0"
 
-	match, err := utils.Version(version).Matches(selector)
+	match, err := utils.Version(apiVersion).Matches(selector)
 	if err != nil {
 		t.Fatalf("Could not check docker api version to match required: %v", err)
 	}
 
 	if !match {
-		t.Skipf("Skipping test; requires %v, but api version is %v", selector, version)
+		t.Skipf("Skipping test; requires %v, but api version is %v", selector, apiVersion)
 	}
 }
 
@@ -707,7 +712,8 @@ func SearchStrInDir(dir, filePrefix, content string) error {
 
 // GetContainerNetworkMode gets the container network mode, given container id
 func (agent *TestAgent) GetContainerNetworkMode(containerId string) ([]string, error) {
-	containerMetaData, err := agent.DockerClient.InspectContainer(containerId)
+	ctx := context.TODO()
+	containerMetaData, err := agent.DockerClient.ContainerInspect(ctx, containerId)
 	if err != nil {
 		return nil, fmt.Errorf("Could not inspect container for task: %v", err)
 	}
@@ -739,11 +745,10 @@ func (agent *TestAgent) SweepTask(task *TestTask) error {
 
 	for _, container := range taskResponse.Containers {
 		ctx, _ := context.WithTimeout(context.Background(), 1*time.Minute)
-		agent.DockerClient.RemoveContainer(docker.RemoveContainerOptions{
-			ID:            container.DockerID,
+		agent.DockerClient.ContainerRemove(ctx, container.DockerID, types.ContainerRemoveOptions{
 			RemoveVolumes: true,
-			Force:         true,
-			Context:       ctx,
+			RemoveLinks:   false,
+			Force:         false,
 		})
 	}
 

--- a/agent/functional_tests/util/utils_unix.go
+++ b/agent/functional_tests/util/utils_unix.go
@@ -16,19 +16,26 @@
 package util
 
 import (
+	"context"
 	"errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/ec2"
 	"github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
-	docker "github.com/fsouza/go-dockerclient"
+	"github.com/docker/go-connections/nat"
+
+	"github.com/docker/docker/api/types"
+	dockercontainer "github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
+	docker "github.com/docker/docker/client"
 )
 
 const (
@@ -81,6 +88,7 @@ func init() {
 // 'amazon/amazon-ecs-agent:make', the version created locally by running
 // 'make'
 func RunAgent(t *testing.T, options *AgentOptions) *TestAgent {
+	ctx := context.TODO()
 	agent := &TestAgent{t: t}
 	agentImage := "amazon/amazon-ecs-agent:make"
 	if envImage := os.Getenv("ECS_AGENT_IMAGE"); envImage != "" {
@@ -88,15 +96,15 @@ func RunAgent(t *testing.T, options *AgentOptions) *TestAgent {
 	}
 	agent.Image = agentImage
 
-	dockerClient, err := docker.NewClientFromEnv()
+	dockerClient, err := docker.NewEnvClient()
 	if err != nil {
 		t.Fatal(err)
 	}
 	agent.DockerClient = dockerClient
 
-	_, err = dockerClient.InspectImage(agentImage)
+	_, _, err = dockerClient.ImageInspectWithRaw(ctx, agentImage)
 	if err != nil {
-		err = dockerClient.PullImage(docker.PullImageOptions{Repository: agentImage}, docker.AuthConfiguration{})
+		_, err = dockerClient.ImagePull(ctx, agentImage, types.ImagePullOptions{})
 		if err != nil {
 			t.Fatal("Could not launch agent", err)
 		}
@@ -127,14 +135,16 @@ func RunAgent(t *testing.T, options *AgentOptions) *TestAgent {
 }
 
 func (agent *TestAgent) StopAgent() error {
-	return agent.DockerClient.StopContainer(agent.DockerID, 10)
+	ctx := context.TODO()
+	containerStopTimeout := 10 * time.Second
+	return agent.DockerClient.ContainerStop(ctx, agent.DockerID, &containerStopTimeout)
 }
 
 func (agent *TestAgent) StartAgent() error {
 	agent.t.Logf("Launching agent with image: %s\n", agent.Image)
-	dockerConfig := &docker.Config{
+	dockerConfig := &dockercontainer.Config{
 		Image: agent.Image,
-		ExposedPorts: map[docker.Port]struct{}{
+		ExposedPorts: map[nat.Port]struct{}{
 			"51678/tcp": {},
 		},
 		Env: []string{
@@ -159,9 +169,9 @@ func (agent *TestAgent) StartAgent() error {
 
 	binds := agent.getBindMounts()
 
-	hostConfig := &docker.HostConfig{
+	hostConfig := &dockercontainer.HostConfig{
 		Binds: binds,
-		PortBindings: map[docker.Port][]docker.PortBinding{
+		PortBindings: map[nat.Port][]nat.PortBinding{
 			"51678/tcp": {{HostIP: "0.0.0.0"}},
 		},
 		Links: agent.Options.ContainerLinks,
@@ -188,10 +198,11 @@ func (agent *TestAgent) StartAgent() error {
 		}
 
 		for key, value := range agent.Options.PortBindings {
-			hostConfig.PortBindings[key] = []docker.PortBinding{{HostIP: value["HostIP"], HostPort: value["HostPort"]}}
+			hostConfig.PortBindings[key] = []nat.PortBinding{{HostIP: value["HostIP"], HostPort: value["HostPort"]}}
 			dockerConfig.ExposedPorts[key] = struct{}{}
 		}
 
+		hostCofigInit := true
 		if agent.Options.EnableTaskENI {
 			dockerConfig.Env = append(dockerConfig.Env, "ECS_ENABLE_TASK_ENI=true")
 			hostConfig.Binds = append(hostConfig.Binds,
@@ -201,35 +212,37 @@ func (agent *TestAgent) StartAgent() error {
 				"/sbin:/sbin:ro",
 			)
 			hostConfig.CapAdd = []string{"NET_ADMIN", "SYS_ADMIN"}
-			hostConfig.Init = true
+			hostConfig.Init = &hostCofigInit
 			hostConfig.NetworkMode = "host"
 		}
 
 	}
 
-	agentContainer, err := agent.DockerClient.CreateContainer(docker.CreateContainerOptions{
-		Config:     dockerConfig,
-		HostConfig: hostConfig,
-	})
+	ctx := context.TODO()
+	agentContainer, err := agent.DockerClient.ContainerCreate(ctx,
+		dockerConfig,
+		hostConfig,
+		&network.NetworkingConfig{},
+		"")
 	if err != nil {
 		agent.t.Fatal("Could not create agent container", err)
 	}
 	agent.DockerID = agentContainer.ID
 	agent.t.Logf("Agent started as docker container: %s\n", agentContainer.ID)
 
-	err = agent.DockerClient.StartContainer(agentContainer.ID, nil)
+	err = agent.DockerClient.ContainerStart(ctx, agentContainer.ID, types.ContainerStartOptions{})
 	if err != nil {
 		return errors.New("Could not start agent container " + err.Error())
 	}
 
-	containerMetadata, err := agent.DockerClient.InspectContainer(agentContainer.ID)
+	containerJSON, err := agent.DockerClient.ContainerInspect(ctx, agentContainer.ID)
 	if err != nil {
 		return errors.New("Could not inspect agent container: " + err.Error())
 	}
-	if containerMetadata.HostConfig.NetworkMode == "host" {
+	if containerJSON.HostConfig.NetworkMode == "host" {
 		agent.IntrospectionURL = "http://localhost:51678"
 	} else {
-		agent.IntrospectionURL = "http://localhost:" + containerMetadata.NetworkSettings.Ports["51678/tcp"][0].HostPort
+		agent.IntrospectionURL = "http://localhost:" + containerJSON.NetworkSettings.Ports["51678/tcp"][0].HostPort
 	}
 
 	return agent.verifyIntrospectionAPI()

--- a/agent/functional_tests/util/utils_windows.go
+++ b/agent/functional_tests/util/utils_windows.go
@@ -28,7 +28,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
-	docker "github.com/fsouza/go-dockerclient"
+	docker "github.com/docker/docker/client"
 	"golang.org/x/sys/windows/registry"
 )
 
@@ -66,7 +66,7 @@ func init() {
 func RunAgent(t *testing.T, options *AgentOptions) *TestAgent {
 	agent := &TestAgent{t: t}
 
-	dockerClient, err := docker.NewClientFromEnv()
+	dockerClient, err := docker.NewEnvClient()
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Replacing direct dependency on go-dockerclient with SDK in functional tests

### Implementation details
Replacing function calls and struct dependencies from go-dockerclient to SDK

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: N/A

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
