### PR TITLE
Add changelog, refactor terminal reason for secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
+## 1.22.0-dev
+* Feature - Add support for ECS Secrets integrating with AWS Systems Manager Parameter Store
 
 ## 1.21.0
 * Feature - Add v3 task metadata support for awsvpc, host and bridge network mode
-* Enhancement - Update the `amazon-ecs-cni-plugins` to `2018.10.0` [1610](https://github.com/aws/amazon-ecs-agent/pull/1610)
+* Enhancement - Update the `amazon-ecs-cni-plugins` to `2018.10.0` [#1610](https://github.com/aws/amazon-ecs-agent/pull/1610)
 * Enhancement - Configurable image pull inactivity timeout [@wattdave](https://github.com/wattdave) [#1566](https://github.com/aws/amazon-ecs-agent/pull/1566)
 * Bug - Fixed a bug where Windows drive volume couldn't be mounted [#1571](https://github.com/aws/amazon-ecs-agent/pull/1571)
 * Bug - Fixed a bug where the Agent's Windows binaries didn't use consistent naming [#1573](https://github.com/aws/amazon-ecs-agent/pull/1573)

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -1463,7 +1463,11 @@ func (task *Task) SetTerminalReason(reason string) {
 	seelog.Infof("Task [%s]: attempting to set terminal reason for task [%s]", task.Arn, reason)
 	task.terminalReasonOnce.Do(func() {
 		seelog.Infof("Task [%s]: setting terminal reason for task [%s]", task.Arn, reason)
-		task.terminalReason = reason
+
+		// Converts the first letter of terminal reason into capital letter
+		words := strings.Fields(reason)
+		words[0] = strings.Title(words[0])
+		task.terminalReason = strings.Join(words, " ")
 	})
 }
 

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -1500,7 +1500,7 @@ func TestMarshalUnmarshalTaskASMResource(t *testing.T) {
 
 func TestSetTerminalReason(t *testing.T) {
 
-	expectedTerminalReason := "failed to provison resource"
+	expectedTerminalReason := "Failed to provision resource"
 	overrideTerminalReason := "should not override terminal reason"
 
 	task := &Task{}

--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -114,6 +114,7 @@ func (agent *ecsAgent) capabilities() ([]*ecs.Attribute, error) {
 	// aws secrets manager
 	capabilities = appendNameOnlyAttribute(capabilities, attributePrefix+capabilityPrivateRegistryAuthASM)
 
+	// ecs agent version 1.22.0 supports ecs secrets integrating with aws systems manager
 	capabilities = appendNameOnlyAttribute(capabilities, attributePrefix+capabilitySecretEnvSSM)
 
 	return capabilities, nil

--- a/agent/taskresource/ssmsecret/ssmsecret.go
+++ b/agent/taskresource/ssmsecret/ssmsecret.go
@@ -336,7 +336,7 @@ func (secret *SSMSecretResource) retrieveSSMSecretValues(region string, names []
 	seelog.Infof("ssm secret resource: retrieving resource for secrets %v in region [%s] in task: [%s]", names, region, secret.taskARN)
 	secValueMap, err := ssm.GetSecretsFromSSM(names, ssmClient)
 	if err != nil {
-		errorEvents <- fmt.Errorf("[%s] %v", region, err)
+		errorEvents <- fmt.Errorf("fetching secret data from SSM Parameter Store in %s: %v", region, err)
 		return
 	}
 

--- a/agent/taskresource/ssmsecret/ssmsecret_test.go
+++ b/agent/taskresource/ssmsecret/ssmsecret_test.go
@@ -340,7 +340,7 @@ func TestCreateReturnMultipleErrors(t *testing.T) {
 	}
 
 	assert.Error(t, ssmRes.Create())
-	expectedError := "fetching secret data from ssm parameter store: invalid parameters: secret-name,"
+	expectedError := "invalid parameters: secret-name"
 	assert.Contains(t, ssmRes.GetTerminalReason(), expectedError)
 }
 
@@ -389,7 +389,7 @@ func TestCreateReturnError(t *testing.T) {
 	}
 
 	assert.Error(t, ssmRes.Create())
-	expectedError := "[us-west-2] fetching secret data from ssm parameter store: invalid parameters: secret-name, "
+	expectedError := "fetching secret data from SSM Parameter Store in us-west-2: invalid parameters: secret-name"
 	assert.Equal(t, expectedError, ssmRes.GetTerminalReason())
 }
 


### PR DESCRIPTION
### Summary
1. Add changelog item for secrets
2. Capitalize the first letter of task terminal reason for better displaying it to customers

### Testing
- [ ] Builds on Linux (`make release`)
- [ ] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [ ] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
