### PR TITLE
Fixing hostname test

### DIFF
--- a/agent/functional_tests/testdata/taskdefinitions/hostname-awsvpc/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/hostname-awsvpc/task-definition.json
@@ -6,7 +6,7 @@
         "name": "exit",
         "image": "127.0.0.1:51670/ubuntu:latest",
         "cpu": 100,
-        "command":  [ "sh", "-c", "hostname | grep \"ip-[0-9]*-[0-9]*-[0-9]*-[0-9]*.*.compute.internal\"; if [ $? -eq 0 ]; then exit 0; else exit 1; fi" ],
+        "command":  [ "sh", "-c", "hostname | grep \"ip-[0-9]*-[0-9]*-[0-9]*-[0-9]*.*.compute.internal\" && exit 0 || exit 1" ],
         "memory": 100,
         "essential": true
       }]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Fixes the awsvpc hostname test

### Implementation details
<!-- How are the changes implemented? -->

`$?` doesn't do what we expect it to in this command -- it doesn't reference the status mid-line in sh. It a lot more straightforward to rely on the `&&` operation. 

Ex: run `sh -c "false; echo $?"` vs `sh -c "false && echo 0 || echo 1"`

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
