### PR TITLE
config: Add missing default on linux

### DIFF
--- a/agent/config/config_unix.go
+++ b/agent/config/config_unix.go
@@ -59,6 +59,7 @@ func DefaultConfig() Config {
 		ImageCleanupDisabled:        false,
 		MinimumImageDeletionAge:     DefaultImageDeletionAge,
 		ImageCleanupInterval:        DefaultImageCleanupTimeInterval,
+		ImagePullInactivityTimeout:  defaultImagePullInactivityTimeout,
 		NumImagesToDeletePerCycle:   DefaultNumImagesToDeletePerCycle,
 		CNIPluginsPath:              defaultCNIPluginsPath,
 		PauseContainerTarballPath:   pauseContainerTarballPath,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
The default was missing, causing a noisy "warn" log and inferring the default later. Fixes #1648 

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
