### PR TITLE
Udpate concurrent call limit to 10

### DIFF
--- a/agent/eventhandler/task_handler.go
+++ b/agent/eventhandler/task_handler.go
@@ -34,7 +34,7 @@ import (
 const (
 	// concurrentEventCalls is the maximum number of tasks that may be handled at
 	// once by the TaskHandler
-	concurrentEventCalls = 3
+	concurrentEventCalls = 10
 
 	// drainEventsFrequency is the frequency at the which unsent events batched
 	// by the task handler are sent to the backend


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Update upper limit of concurrent task state change calls to 10

### Implementation details
This was set at 3, which was chosen arbitrarily. Below is the benchmarking result with limit 5, 10, and 15, compared to the agent V1.22.0. At 15 it shows degradation compared to 10, but is still better than at 3. Therefore, new upper limit of 10 was chosen based on the result.
This resolves https://github.com/aws/amazon-ecs-agent/issues/797

Agent | Task-per-instance | Instances | Tasks | P0 | P50 | P90 | P99 | P100 | Mean | Placement-success-rate | Launch-success-rate
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
V1.22.0 | 100 | 8 | 800 | 1.02 | 6.16 | 65.83 | 207.24 | 286.33 | 22.61 | 100% | 99.54%
concurrentEventCalls = 5 | 100 | 8 | 800 | 1.07 | 5.93 | 26.25 | 113.01 | 198.12 | 13.51 | 100% | 99.77%
concurrentEventCalls = 10 | 100 | 8 | 800 | 1.11 | 4.04 | 6.07 | 8.48 | 14.47 | 4.18 | 100% | 99.86%
concurrentEventCalls = 15 | 100 | 8 | 800 | 1.03 | 5.30 | 57.64 | 146.93 | 226.13 | 16.60 | 100% | 100%
V1.22.0 | 50 | 8 | 400 | 1.16 | 4.81 | 8.02 | 12.16 | 15.41 | 5.16 | 100% | 99.88%
concurrentEventCalls = 5 | 50 | 8 | 400 | 1.01 | 3.80 | 6.10 | 9.02 | 10.67 | 3.97 | 100% | 99.65%
concurrentEventCalls = 10 | 50 | 8 | 400 | 0.88 | 3.43 | 5.14 | 7.06 | 9.53 | 3.50 | 100% | 99.90%
concurrentEventCalls = 15 | 50 | 8 | 400 | 0.83 | 3.88 | 6.04 | 8.86 | 11.69 | 4.05 | 100% | 100%
V1.22.0 | 5 | 8 | 40 | 0.84 | 3.28 | 15.96 | 22.97 | 23.70 | 4.79 | 100% | 100%
concurrentEventCalls = 5 | 5 | 8 | 40 | 0.88 | 3.43 | 4.97 | 7.42 | 8.29 | 3.37 | 100% | 100%
concurrentEventCalls = 10 | 5 | 8 | 40 | 0.83 | 3.02 | 4.43 | 5.69 | 5.98 | 2.99 | 100% | 100%
concurrentEventCalls = 15 | 5 | 8 | 40 | 0.92 | 3.10 | 4.42 | 5.91 | 7.57 | 3.07 | 100% | 100%

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: N/A

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
