### PR TITLE
Fix flaky v3 endpoint tests

### DIFF
--- a/misc/agent-introspection-validator/agent-introspection-validator.go
+++ b/misc/agent-introspection-validator/agent-introspection-validator.go
@@ -20,8 +20,6 @@ import (
 	"net/http"
 	"os"
 	"time"
-
-	"github.com/cihub/seelog"
 )
 
 const (
@@ -86,7 +84,7 @@ func getTasksMetadata(client *http.Client, path string) (*TasksResponse, error) 
 		return nil, err
 	}
 
-	seelog.Infof("Received tasks metadata: %s \n", string(body))
+	fmt.Printf("Received tasks metadata: %s \n", string(body))
 
 	err = verifyTasksMetadata(body)
 	if err != nil {
@@ -108,7 +106,7 @@ func getTaskMetadata(client *http.Client, path string) (*TaskResponse, error) {
 		return nil, err
 	}
 
-	seelog.Infof("Received task metadata: %s \n", string(body))
+	fmt.Printf("Received task metadata: %s \n", string(body))
 
 	err = verifyTaskMetadata(body)
 	if err != nil {

--- a/misc/v3-task-endpoint-validator-windows/setup-v3-task-endpoint-validator.ps1
+++ b/misc/v3-task-endpoint-validator-windows/setup-v3-task-endpoint-validator.ps1
@@ -20,7 +20,6 @@ Invoke-Expression ${PSScriptRoot}\..\windows-deploy\hostsetup.ps1
 $buildscript = @"
 mkdir C:\V3
 cp C:\ecs\v3-task-endpoint-validator-windows.go C:\V3
-go get -u  github.com/cihub/seelog
 go build -o C:\V3\v3-task-endpoint-validator-windows.exe C:\V3\v3-task-endpoint-validator-windows.go
 cp C:\V3\v3-task-endpoint-validator-windows.exe C:\ecs
 "@

--- a/misc/v3-task-endpoint-validator-windows/v3-task-endpoint-validator-windows.go
+++ b/misc/v3-task-endpoint-validator-windows/v3-task-endpoint-validator-windows.go
@@ -20,8 +20,6 @@ import (
 	"net/http"
 	"os"
 	"time"
-
-	"github.com/cihub/seelog"
 )
 
 const (
@@ -103,7 +101,7 @@ func verifyContainerMetadata(client *http.Client, containerMetadataEndpoint stri
 		return err
 	}
 
-	seelog.Infof("Received container metadata: %s \n", string(body))
+	fmt.Printf("Received container metadata: %s \n", string(body))
 
 	var containerMetadata ContainerResponse
 	if err = json.Unmarshal(body, &containerMetadata); err != nil {
@@ -123,7 +121,7 @@ func verifyTaskMetadata(client *http.Client, taskMetadataEndpoint string) error 
 		return err
 	}
 
-	seelog.Infof("Received task metadata: %s \n", string(body))
+	fmt.Printf("Received task metadata: %s \n", string(body))
 
 	var taskMetadata TaskResponse
 	if err = json.Unmarshal(body, &taskMetadata); err != nil {
@@ -143,7 +141,7 @@ func verifyContainerStats(client *http.Client, containerStatsEndpoint string) er
 		return err
 	}
 
-	seelog.Infof("Received container stats: %s \n", string(body))
+	fmt.Printf("Received container stats: %s \n", string(body))
 
 	return nil
 }
@@ -154,7 +152,7 @@ func verifyTaskStats(client *http.Client, taskStatsEndpoint string) error {
 		return err
 	}
 
-	seelog.Infof("Received task stats: %s \n", string(body))
+	fmt.Printf("Received task stats: %s \n", string(body))
 
 	return nil
 }
@@ -166,12 +164,11 @@ func verifyTaskMetadataResponse(taskMetadataRawMsg json.RawMessage) error {
 
 	taskExpectedFieldEqualMap := map[string]interface{}{
 		"Cluster":       "ecs-functional-tests",
-		"Revision":      "1",
 		"DesiredStatus": "RUNNING",
 		"KnownStatus":   "RUNNING",
 	}
 
-	taskExpectedFieldNotEmptyArray := []string{"TaskARN", "Family", "PullStartedAt", "PullStoppedAt", "Containers"}
+	taskExpectedFieldNotEmptyArray := []string{"TaskARN", "Family", "Revision", "PullStartedAt", "PullStoppedAt", "Containers"}
 
 	for fieldName, fieldVal := range taskExpectedFieldEqualMap {
 		if err = fieldEqual(taskMetadataResponseMap, fieldName, fieldVal); err != nil {
@@ -322,22 +319,22 @@ func main() {
 	taskStatsPath := v3BaseEndpoint + "/task/stats"
 
 	if err := verifyContainerMetadata(client, containerMetadataPath); err != nil {
-		seelog.Errorf("Container metadata: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Unable to get container metadata: %v\n", err)
 		os.Exit(1)
 	}
 
 	if err := verifyTaskMetadata(client, taskMetadataPath); err != nil {
-		seelog.Errorf("Task metadata: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Unable to get task metadata: %v\n", err)
 		os.Exit(1)
 	}
 
 	if err := verifyContainerStats(client, containerStatsPath); err != nil {
-		seelog.Errorf("Container stats: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Unable to get container stats: %v\n", err)
 		os.Exit(1)
 	}
 
 	if err := verifyTaskStats(client, taskStatsPath); err != nil {
-		seelog.Errorf("Task stats: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Unable to get task stats: %v\n", err)
 		os.Exit(1)
 	}
 

--- a/misc/v3-task-endpoint-validator/v3-task-endpoint-validator.go
+++ b/misc/v3-task-endpoint-validator/v3-task-endpoint-validator.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/cihub/seelog"
 	docker "github.com/fsouza/go-dockerclient"
 )
 
@@ -106,7 +105,7 @@ func verifyContainerMetadata(client *http.Client, containerMetadataEndpoint stri
 		return err
 	}
 
-	seelog.Infof("Received container metadata: %s \n", string(body))
+	fmt.Printf("Received container metadata: %s \n", string(body))
 
 	var containerMetadata ContainerResponse
 	if err = json.Unmarshal(body, &containerMetadata); err != nil {
@@ -126,7 +125,7 @@ func verifyTaskMetadata(client *http.Client, taskMetadataEndpoint string) error 
 		return err
 	}
 
-	seelog.Infof("Received task metadata: %s \n", string(body))
+	fmt.Printf("Received task metadata: %s \n", string(body))
 
 	var taskMetadata TaskResponse
 	if err = json.Unmarshal(body, &taskMetadata); err != nil {
@@ -146,7 +145,7 @@ func verifyContainerStats(client *http.Client, containerStatsEndpoint string) er
 		return err
 	}
 
-	seelog.Infof("Received container stats: %s \n", string(body))
+	fmt.Printf("Received container stats: %s \n", string(body))
 
 	var containerStats docker.Stats
 	err = json.Unmarshal(body, &containerStats)
@@ -163,7 +162,7 @@ func verifyTaskStats(client *http.Client, taskStatsEndpoint string) error {
 		return err
 	}
 
-	seelog.Infof("Received task stats: %s \n", string(body))
+	fmt.Printf("Received task stats: %s \n", string(body))
 
 	var taskStats map[string]*docker.Stats
 	err = json.Unmarshal(body, &taskStats)
@@ -181,12 +180,11 @@ func verifyTaskMetadataResponse(taskMetadataRawMsg json.RawMessage) error {
 
 	taskExpectedFieldEqualMap := map[string]interface{}{
 		"Cluster":       "ecs-functional-tests",
-		"Revision":      "1",
 		"DesiredStatus": "RUNNING",
 		"KnownStatus":   "RUNNING",
 	}
 
-	taskExpectedFieldNotEmptyArray := []string{"TaskARN", "Family", "PullStartedAt", "PullStoppedAt", "Containers"}
+	taskExpectedFieldNotEmptyArray := []string{"TaskARN", "Family", "Revision", "PullStartedAt", "PullStoppedAt", "Containers"}
 
 	for fieldName, fieldVal := range taskExpectedFieldEqualMap {
 		if err = fieldEqual(taskMetadataResponseMap, fieldName, fieldVal); err != nil {
@@ -424,22 +422,22 @@ func main() {
 	taskStatsPath := v3BaseEndpoint + "/task/stats"
 
 	if err := verifyContainerMetadata(client, containerMetadataPath); err != nil {
-		seelog.Errorf("Container metadata: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Unable to get container metadata: %v\n", err)
 		os.Exit(1)
 	}
 
 	if err := verifyTaskMetadata(client, taskMetadataPath); err != nil {
-		seelog.Errorf("Task metadata: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Unable to get task metadata: %v\n", err)
 		os.Exit(1)
 	}
 
 	if err := verifyContainerStats(client, containerStatsPath); err != nil {
-		seelog.Errorf("Container stats: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Unable to get container stats: %v\n", err)
 		os.Exit(1)
 	}
 
 	if err := verifyTaskStats(client, taskStatsPath); err != nil {
-		seelog.Errorf("Task stats: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Unable to get task stats: %v\n", err)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Modify logging for v3 endpoint tests. Previously we use `seelog`, but we didn't call `flush` after using seelog. Sometimes even flush won't work because in the test we just call `os.Exit()` to exit and the logs don't have enough time to be flushed. I ended up just using `fmt` which is a simpler solution.

The tests fail on prod but not fail on my local is because the revision of the task definition is 2 in prod but our code always checks the revision should be 1. To prevent this from happening, I will just remove the revision check.

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass


### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
