### PR TITLE
fix gogenerate for functional tests

### DIFF
--- a/agent/functional_tests/tests/generated/simpletests_unix/simpletests_generated_unix_test.go
+++ b/agent/functional_tests/tests/generated/simpletests_unix/simpletests_generated_unix_test.go
@@ -666,7 +666,7 @@ func TestInteractiveTty(t *testing.T) {
 	var testTasks []*TestTask
 	if "" == "true" {
 		for i := 0; i < 1; i++ {
-			tmpTask, err := agent.StartAWSVPCTask("network-link-2", nil)
+			tmpTask, err := agent.StartAWSVPCTask("interactive-tty", nil)
 			if err != nil {
 				t.Fatalf("Could not start task in awsvpc mode: %v", err)
 			}
@@ -722,7 +722,7 @@ func TestLinkVolumeDependencies(t *testing.T) {
 	var testTasks []*TestTask
 	if "" == "true" {
 		for i := 0; i < 1; i++ {
-			tmpTask, err := agent.StartAWSVPCTask("network-link", nil)
+			tmpTask, err := agent.StartAWSVPCTask("network-link-2", nil)
 			if err != nil {
 				t.Fatalf("Could not start task in awsvpc mode: %v", err)
 			}
@@ -775,10 +775,22 @@ func TestNetworkLink(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Could not register task definition: %v", err)
 	}
-	testTasks, err := agent.StartMultipleTasks(t, td, 1)
-	if err != nil {
-		t.Fatalf("Could not start task: %v", err)
+	var testTasks []*TestTask
+	if "" == "true" {
+		for i := 0; i < 1; i++ {
+			tmpTask, err := agent.StartAWSVPCTask("network-link", nil)
+			if err != nil {
+				t.Fatalf("Could not start task in awsvpc mode: %v", err)
+			}
+			testTasks = append(testTasks, tmpTask)
+		}
+	} else {
+		testTasks, err = agent.StartMultipleTasks(t, td, 1)
+		if err != nil {
+			t.Fatalf("Could not start task: %v", err)
+		}
 	}
+
 	timeout, err := time.ParseDuration("2m")
 	if err != nil {
 		t.Fatalf("Could not parse timeout: %#v", err)
@@ -810,7 +822,11 @@ func TestParallelPull(t *testing.T) {
 	if os.Getenv("ECS_FUNCTIONAL_PARALLEL") != "" {
 		t.Parallel()
 	}
-	agent := RunAgent(t, nil)
+	var options *AgentOptions
+	if "" == "true" {
+		options = &AgentOptions{EnableTaskENI: true}
+	}
+	agent := RunAgent(t, options)
 	defer agent.Cleanup()
 	agent.RequireVersion(">=1.0.0")
 
@@ -1154,7 +1170,11 @@ func TestSysctl(t *testing.T) {
 	if os.Getenv("ECS_FUNCTIONAL_PARALLEL") != "" {
 		t.Parallel()
 	}
-	agent := RunAgent(t, nil)
+	var options *AgentOptions
+	if "" == "true" {
+		options = &AgentOptions{EnableTaskENI: true}
+	}
+	agent := RunAgent(t, options)
 	defer agent.Cleanup()
 	agent.RequireVersion(">=1.14.4")
 
@@ -1165,7 +1185,7 @@ func TestSysctl(t *testing.T) {
 	var testTasks []*TestTask
 	if "" == "true" {
 		for i := 0; i < 1; i++ {
-			tmpTask, err := agent.StartAWSVPCTask("task-local-vol", nil)
+			tmpTask, err := agent.StartAWSVPCTask("sysctl", nil)
 			if err != nil {
 				t.Fatalf("Could not start task in awsvpc mode: %v", err)
 			}
@@ -1221,7 +1241,7 @@ func TestTaskLocalVolume(t *testing.T) {
 	var testTasks []*TestTask
 	if "" == "true" {
 		for i := 0; i < 1; i++ {
-			tmpTask, err := agent.StartAWSVPCTask("tmpfs", nil)
+			tmpTask, err := agent.StartAWSVPCTask("task-local-vol", nil)
 			if err != nil {
 				t.Fatalf("Could not start task in awsvpc mode: %v", err)
 			}
@@ -1277,7 +1297,7 @@ func TestTmpfs(t *testing.T) {
 	var testTasks []*TestTask
 	if "" == "true" {
 		for i := 0; i < 1; i++ {
-			tmpTask, err := agent.StartAWSVPCTask("nofiles-ulimit", nil)
+			tmpTask, err := agent.StartAWSVPCTask("tmpfs", nil)
 			if err != nil {
 				t.Fatalf("Could not start task in awsvpc mode: %v", err)
 			}
@@ -1333,7 +1353,7 @@ func TestNofilesULimit(t *testing.T) {
 	var testTasks []*TestTask
 	if "" == "true" {
 		for i := 0; i < 1; i++ {
-			tmpTask, err := agent.StartAWSVPCTask("user-nobody", nil)
+			tmpTask, err := agent.StartAWSVPCTask("nofiles-ulimit", nil)
 			if err != nil {
 				t.Fatalf("Could not start task in awsvpc mode: %v", err)
 			}
@@ -1389,7 +1409,7 @@ func TestUserNobody(t *testing.T) {
 	var testTasks []*TestTask
 	if "" == "true" {
 		for i := 0; i < 1; i++ {
-			tmpTask, err := agent.StartAWSVPCTask("working-dir", nil)
+			tmpTask, err := agent.StartAWSVPCTask("user-nobody", nil)
 			if err != nil {
 				t.Fatalf("Could not start task in awsvpc mode: %v", err)
 			}
@@ -1442,10 +1462,22 @@ func TestWorkingDir(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Could not register task definition: %v", err)
 	}
-	testTasks, err := agent.StartMultipleTasks(t, td, 1)
-	if err != nil {
-		t.Fatalf("Could not start task: %v", err)
+	var testTasks []*TestTask
+	if "" == "true" {
+		for i := 0; i < 1; i++ {
+			tmpTask, err := agent.StartAWSVPCTask("working-dir", nil)
+			if err != nil {
+				t.Fatalf("Could not start task in awsvpc mode: %v", err)
+			}
+			testTasks = append(testTasks, tmpTask)
+		}
+	} else {
+		testTasks, err = agent.StartMultipleTasks(t, td, 1)
+		if err != nil {
+			t.Fatalf("Could not start task: %v", err)
+		}
 	}
+
 	timeout, err := time.ParseDuration("2m")
 	if err != nil {
 		t.Fatalf("Could not parse timeout: %#v", err)


### PR DESCRIPTION

### Summary
run `make gogenerate` 

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [ ] Builds on Linux (`make release`)
- [ ] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [ ] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
