### PR TITLE
Get region from AWS SDK if NoIID = true

### DIFF
--- a/agent/ec2/blackhole_ec2_metadata_client.go
+++ b/agent/ec2/blackhole_ec2_metadata_client.go
@@ -60,3 +60,7 @@ func (blackholeMetadataClient) GetDynamicData(path string) (string, error) {
 func (blackholeMetadataClient) GetUserData() (string, error) {
 	return "", errors.New("blackholed")
 }
+
+func (blackholeMetadataClient) Region() (string, error) {
+	return "", errors.New("blackholed")
+}

--- a/agent/ec2/ec2_metadata_client.go
+++ b/agent/ec2/ec2_metadata_client.go
@@ -55,6 +55,7 @@ type HttpClient interface {
 	GetDynamicData(string) (string, error)
 	GetInstanceIdentityDocument() (ec2metadata.EC2InstanceIdentityDocument, error)
 	GetUserData() (string, error)
+	Region() (string, error)
 }
 
 // EC2MetadataClient is the client used to get metadata from instance metadata service
@@ -68,6 +69,7 @@ type EC2MetadataClient interface {
 	PrimaryENIMAC() (string, error)
 	InstanceID() (string, error)
 	GetUserData() (string, error)
+	Region() (string, error)
 }
 
 type ec2MetadataClientImpl struct {
@@ -154,4 +156,9 @@ func (c *ec2MetadataClientImpl) InstanceID() (string, error) {
 // GetUserData returns the userdata that was configured for the
 func (c *ec2MetadataClientImpl) GetUserData() (string, error) {
 	return c.client.GetUserData()
+}
+
+// Region returns the region the instance is running in.
+func (c *ec2MetadataClientImpl) Region() (string, error) {
+	return c.client.Region()
 }

--- a/agent/ec2/mocks/ec2_mocks.go
+++ b/agent/ec2/mocks/ec2_mocks.go
@@ -141,6 +141,19 @@ func (mr *MockEC2MetadataClientMockRecorder) PrimaryENIMAC() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrimaryENIMAC", reflect.TypeOf((*MockEC2MetadataClient)(nil).PrimaryENIMAC))
 }
 
+// Region mocks base method
+func (m *MockEC2MetadataClient) Region() (string, error) {
+	ret := m.ctrl.Call(m, "Region")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Region indicates an expected call of Region
+func (mr *MockEC2MetadataClientMockRecorder) Region() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Region", reflect.TypeOf((*MockEC2MetadataClient)(nil).Region))
+}
+
 // SubnetID mocks base method
 func (m *MockEC2MetadataClient) SubnetID(arg0 string) (string, error) {
 	ret := m.ctrl.Call(m, "SubnetID", arg0)
@@ -240,6 +253,19 @@ func (m *MockHttpClient) GetUserData() (string, error) {
 // GetUserData indicates an expected call of GetUserData
 func (mr *MockHttpClientMockRecorder) GetUserData() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserData", reflect.TypeOf((*MockHttpClient)(nil).GetUserData))
+}
+
+// Region mocks base method
+func (m *MockHttpClient) Region() (string, error) {
+	ret := m.ctrl.Call(m, "Region")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Region indicates an expected call of Region
+func (mr *MockHttpClientMockRecorder) Region() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Region", reflect.TypeOf((*MockHttpClient)(nil).Region))
 }
 
 // MockClient is a mock of Client interface


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
if NoIID is set to true, we get region from AWS SDK ec2 metadata service.

### Implementation details
we already had EC2 MetadataService client, added Region() method wrapper.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
