### PR TITLE
introduce `GPUSupportEnabled` config variable

### DIFF
--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -229,11 +229,12 @@ func (agent *ecsAgent) doStart(containerChangeEventStream *eventstream.EventStre
 			return exitcodes.ExitTerminal
 		}
 	}
-
-	err := agent.initializeGPUManager()
-	if err != nil {
-		seelog.Criticalf("Could not initialize Nvidia GPU Manager: %v", err)
-		return exitcodes.ExitError
+	if agent.cfg.GPUSupportEnabled {
+		err := agent.initializeGPUManager()
+		if err != nil {
+			seelog.Criticalf("Could not initialize Nvidia GPU Manager: %v", err)
+			return exitcodes.ExitError
+		}
 	}
 
 	// Create the task engine

--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -123,7 +123,9 @@ func (agent *ecsAgent) capabilities() ([]*ecs.Attribute, error) {
 	// with host EC2 instance and among containers within the task
 	capabilities = appendNameOnlyAttribute(capabilities, attributePrefix+capabiltyPIDAndIPCNamespaceSharing)
 
-	capabilities = agent.appendNvidiaDriverVersionAttribute(capabilities)
+	if agent.cfg.GPUSupportEnabled {
+		capabilities = agent.appendNvidiaDriverVersionAttribute(capabilities)
+	}
 
 	return capabilities, nil
 }

--- a/agent/app/agent_capability_unix_test.go
+++ b/agent/app/agent_capability_unix_test.go
@@ -149,6 +149,7 @@ func TestNvidiaDriverCapabilitiesUnix(t *testing.T) {
 	mockCredentialsProvider := app_mocks.NewMockProvider(ctrl)
 	conf := &config.Config{
 		PrivilegedDisabled: true,
+		GPUSupportEnabled:  true,
 	}
 
 	gomock.InOrder(

--- a/agent/app/agent_unix.go
+++ b/agent/app/agent_unix.go
@@ -231,8 +231,10 @@ func (agent *ecsAgent) initializeGPUManager() error {
 }
 
 func (agent *ecsAgent) getPlatformDevices() []*ecs.PlatformDevice {
-	if agent.resourceFields != nil && agent.resourceFields.NvidiaGPUManager != nil {
-		return agent.resourceFields.NvidiaGPUManager.GetDevices()
+	if agent.cfg.GPUSupportEnabled {
+		if agent.resourceFields != nil && agent.resourceFields.NvidiaGPUManager != nil {
+			return agent.resourceFields.NvidiaGPUManager.GetDevices()
+		}
 	}
 	return nil
 }

--- a/agent/app/agent_unix_test.go
+++ b/agent/app/agent_unix_test.go
@@ -639,6 +639,7 @@ func TestDoStartGPUManagerHappyPath(t *testing.T) {
 	)
 
 	cfg := getTestConfig()
+	cfg.GPUSupportEnabled = true
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines
 	defer cancel()
@@ -681,7 +682,7 @@ func TestDoStartGPUManagerInitError(t *testing.T) {
 	mockGPUManager.EXPECT().Initialize().Return(errors.New("init error"))
 
 	cfg := getTestConfig()
-
+	cfg.GPUSupportEnabled = true
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines
 	defer cancel()

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -478,6 +478,7 @@ func environmentConfig() (Config, error) {
 		SharedVolumeMatchFullConfig:        utils.ParseBool(os.Getenv("ECS_SHARED_VOLUME_MATCH_FULL_CONFIG"), false),
 		ContainerInstanceTags:              containerInstanceTags,
 		ContainerInstancePropagateTagsFrom: parseContainerInstancePropagateTagsFrom(),
+		GPUSupportEnabled:                  utils.ParseBool(os.Getenv("ECS_ENABLE_GPU_SUPPORT"), false),
 	}, err
 }
 

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -92,6 +92,7 @@ func TestEnvironmentConfig(t *testing.T) {
 	defer setTestEnv("ECS_ENABLE_TASK_ENI", "true")()
 	defer setTestEnv("ECS_TASK_METADATA_RPS_LIMIT", "1000,1100")()
 	defer setTestEnv("ECS_SHARED_VOLUME_MATCH_FULL_CONFIG", "true")()
+	defer setTestEnv("ECS_ENABLE_GPU_SUPPORT", "true")()
 	additionalLocalRoutesJSON := `["1.2.3.4/22","5.6.7.8/32"]`
 	setTestEnv("ECS_AWSVPC_ADDITIONAL_LOCAL_ROUTES", additionalLocalRoutesJSON)
 	setTestEnv("ECS_ENABLE_CONTAINER_METADATA", "true")
@@ -132,6 +133,7 @@ func TestEnvironmentConfig(t *testing.T) {
 	assert.Equal(t, 1000, conf.TaskMetadataSteadyStateRate)
 	assert.Equal(t, 1100, conf.TaskMetadataBurstRate)
 	assert.True(t, conf.SharedVolumeMatchFullConfig, "Wrong value for SharedVolumeMatchFullConfig")
+	assert.True(t, conf.GPUSupportEnabled, "Wrong value for GPUSupportEnabled")
 }
 
 func TestTrimWhitespaceWhenCreating(t *testing.T) {
@@ -663,6 +665,14 @@ func TestContainerInstancePropagateTagsFrom(t *testing.T) {
 				"Wrong value for ContainerInstancePropagateTagsFrom")
 		})
 	}
+}
+
+func TestGPUSupportEnabled(t *testing.T) {
+	defer setTestRegion()()
+	defer setTestEnv("ECS_ENABLE_GPU_SUPPORT", "true")()
+	cfg, err := NewConfig(ec2.NewBlackholeEC2MetadataClient())
+	assert.NoError(t, err)
+	assert.True(t, cfg.GPUSupportEnabled, "Wrong value for GPUSupportEnabled")
 }
 
 func setTestRegion() func() {

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -248,4 +248,7 @@ type Config struct {
 	// through RegisterContainerInstance call. Tags with the same keys from DescribeTags
 	// API call will be overridden.
 	ContainerInstanceTags map[string]string
+
+	// GPUSupportEnabled specifies if the Agent is capable of launching GPU tasks
+	GPUSupportEnabled bool
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Added new config field `GPUSupportEnabled` for detecting GPU AMIs

### Implementation details
Send platformDevices and capability based on the config var 
Not making changes to `README`, since its not recommended for customers to change this on GPU AMIs. 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
