### PR TITLE
Collecting and exposing Agent metrics including API call monitoring

### DIFF
--- a/THIRD-PARTY
+++ b/THIRD-PARTY
@@ -3,6 +3,7 @@
 ** github.com/containerd/continuity; version 1bed1ecb1dc42d8f4d2ac8c23e5cac64749e82c9 -- https://github.com/containerd/continuity
 ** github.com/containernetworking/cni; version v0.5.2 -- https://github.com/containernetworking/cni
 ** github.com/coreos/go-systemd; version 24036eb3df68550d24a2736c5d013f4e83366866 -- https://github.com/coreos/go-systemd
+** github.com/docker/distribution; version 749f6afb4572201e3c37325d0ffedb6f32be8950 -- https://www.docker.com
 ** github.com/docker/docker; version e4d0fe84f9ea88b0e0cfd847412c9f29442cc62d -- https://github.com/moby/moby
 ** github.com/docker/go-connections; version v0.3.0 -- https://github.com/docker/go-connections
 ** github.com/docker/go-units; version v0.3.2 -- https://github.com/docker/go-units
@@ -13,6 +14,7 @@
 ** github.com/opencontainers/image-spec; version v1.0.1 -- https://github.com/opencontainers/image-spec
 ** github.com/opencontainers/runc; version v0.1.1 -- https://github.com/opencontainers/runc
 ** github.com/opencontainers/runtime-spec; version d349388c43b01b2ea695965ae561b5bddb81318f -- https://github.com/opencontainers/runtime-spec
+** github.com/prometheus/client_golang; version 0.9.0 -- https://github.com/prometheus/client_golang
 ** github.com/vishvananda/netlink; version fe3b5664d23a11b52ba59bece4ff29c52772a56b -- https://github.com/vishvananda/netlink
 ** github.com/vishvananda/netns; version be1fbeda19366dea804f00efff2dd73a1642fdcc -- https://github.com/vishvananda/netns
 
@@ -213,6 +215,8 @@ Copyright (c) 2016-2017 the containerd authors
 Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
 * For github.com/coreos/go-systemd see also this required NOTICE:
 Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+* For github.com/docker/distribution see also this required NOTICE:
+Copyright 2013-2017 Docker, Inc.
 * For github.com/docker/docker see also this required NOTICE:
 Copyright 2013-2017 Docker, Inc.
 * For github.com/docker/go-connections see also this required NOTICE:
@@ -234,6 +238,32 @@ Copyright 2016 The Linux Foundation.
 Copyright 2014 Docker, Inc.
 * For github.com/opencontainers/runtime-spec see also this required NOTICE:
 Copyright 2015 The Linux Foundation.
+* For github.com/prometheus/client_golang see also this required NOTICE:
+Prometheus instrumentation library for Go applications
+Copyright 2012-2015 The Prometheus Authors
+
+This product includes software developed at
+SoundCloud Ltd. (http://soundcloud.com/).
+
+
+The following components are included in this product:
+
+perks - a fork of https://github.com/bmizerany/perks
+https://github.com/beorn7/perks
+Copyright 2013-2015 Blake Mizerany, Björn Rabenstein
+See https://github.com/beorn7/perks/blob/master/README.md for license
+details.
+
+Go support for Protocol Buffers - Google's data interchange format
+http://github.com/golang/protobuf/
+Copyright 2010 The Go Authors
+See source code for license details.
+
+Support for streaming Protocol Buffer messages for the Go language
+(golang).
+https://github.com/matttproud/golang_protobuf_extensions
+Copyright 2013 Matt T. Proud
+Licensed under the Apache License, Version 2.0
 * For github.com/vishvananda/netlink see also this required NOTICE:
 Copyright 2014 Vishvananda Ishaya.
 Copyright 2014 Docker, Inc.

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -47,6 +47,9 @@ const (
 	// AgentCredentialsPort is used to serve the credentials for tasks.
 	AgentCredentialsPort = 51679
 
+	// AgentPrometheusExpositionPort is used to expose Prometheus metrics that can be scraped by a Prometheus server
+	AgentPrometheusExpositionPort = 51680
+
 	// defaultConfigFileName is the default (json-formatted) config file
 	defaultConfigFileName = "/etc/ecs_container_agent/config.json"
 

--- a/agent/config/config_unix.go
+++ b/agent/config/config_unix.go
@@ -16,9 +16,11 @@ package config
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient"
+	"github.com/aws/amazon-ecs-agent/agent/utils"
 )
 
 const (
@@ -73,10 +75,16 @@ func DefaultConfig() Config {
 		SharedVolumeMatchFullConfig:        false, // only requiring shared volumes to match on name, which is default docker behavior
 		ImagePullInactivityTimeout:         defaultImagePullInactivityTimeout,
 		ContainerInstancePropagateTagsFrom: ContainerInstancePropagateTagsFromNoneType,
+		PrometheusMetricsEnabled:           false,
 	}
 }
 
-func (cfg *Config) platformOverrides() {}
+func (cfg *Config) platformOverrides() {
+	cfg.PrometheusMetricsEnabled = utils.ParseBool(os.Getenv("ECS_ENABLE_PROMETHEUS_METRICS"), false)
+	if cfg.PrometheusMetricsEnabled {
+		cfg.ReservedPorts = append(cfg.ReservedPorts, AgentPrometheusExpositionPort)
+	}
+}
 
 // platformString returns platform-specific config data that can be serialized
 // to string for debugging

--- a/agent/config/config_unix_test.go
+++ b/agent/config/config_unix_test.go
@@ -180,6 +180,17 @@ func TestBadFileContent(t *testing.T) {
 	assert.Error(t, err, "create configuration should fail")
 }
 
+func TestPrometheusMetricsPlatformOverrides(t *testing.T) {
+	defer setTestRegion()()
+	cfg, err := NewConfig(ec2.NewBlackholeEC2MetadataClient())
+	require.NoError(t, err)
+
+	defer setTestEnv("ECS_ENABLE_PROMETHEUS_METRICS", "true")()
+	cfg.platformOverrides()
+	assert.True(t, cfg.PrometheusMetricsEnabled, "Prometheus metrics should be enabled")
+	assert.Equal(t, 6, len(cfg.ReservedPorts), "Reserved ports should have added Prometheus endpoint")
+}
+
 // setupFileConfiguration create a temp file store the configuration
 func setupFileConfiguration(t *testing.T, configContent string) string {
 	file, err := ioutil.TempFile("", "ecs-test")

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -189,6 +189,11 @@ type Config struct {
 	// the image from the tarball; the referenced image must already be loaded.
 	PauseContainerTag string
 
+	// PrometheusMetricsEnabled configures whether Agent metrics should be
+	// collected and published to the specified endpoint. This is disabled by
+	// default.
+	PrometheusMetricsEnabled bool
+
 	// AWSVPCBlockInstanceMetdata specifies if InstanceMetadata endpoint should be blocked
 	// for tasks that are launched with network mode "awsvpc" when ECS_AWSVPC_BLOCK_IMDS=true
 	AWSVPCBlockInstanceMetdata bool

--- a/agent/dockerclient/dockerapi/docker_client.go
+++ b/agent/dockerclient/dockerapi/docker_client.go
@@ -37,6 +37,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/sdkclient"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/sdkclientfactory"
 	"github.com/aws/amazon-ecs-agent/agent/ecr"
+	"github.com/aws/amazon-ecs-agent/agent/metrics"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 	"github.com/aws/amazon-ecs-agent/agent/utils/ttime"
 
@@ -319,7 +320,7 @@ func (dg *dockerGoClient) PullImage(image string, authData *apicontainer.Registr
 	timeout := dg.time().After(pullImageTimeout)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-
+	defer metrics.MetricsEngineGlobal.RecordDockerMetric("PULL_IMAGE")()
 	response := make(chan DockerContainerMetadata, 1)
 	go func() {
 		imagePullBackoff := utils.NewSimpleBackoff(minimumPullRetryDelay,
@@ -482,6 +483,7 @@ func getRepository(image string) string {
 }
 
 func (dg *dockerGoClient) InspectImage(image string) (*types.ImageInspect, error) {
+	defer metrics.MetricsEngineGlobal.RecordDockerMetric("INSPECT_IMAGE")()
 	client, err := dg.sdkDockerClient()
 	if err != nil {
 		return nil, err
@@ -520,7 +522,7 @@ func (dg *dockerGoClient) CreateContainer(ctx context.Context,
 	timeout time.Duration) DockerContainerMetadata {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-
+	defer metrics.MetricsEngineGlobal.RecordDockerMetric("CREATE_CONTAINER")()
 	// Buffered channel so in the case of timeout it takes one write, never gets
 	// read, and can still be GC'd
 	response := make(chan DockerContainerMetadata, 1)
@@ -564,7 +566,7 @@ func (dg *dockerGoClient) createContainer(ctx context.Context,
 func (dg *dockerGoClient) StartContainer(ctx context.Context, id string, timeout time.Duration) DockerContainerMetadata {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-
+	defer metrics.MetricsEngineGlobal.RecordDockerMetric("START_CONTAINER")()
 	// Buffered channel so in the case of timeout it takes one write, never gets
 	// read, and can still be GC'd
 	response := make(chan DockerContainerMetadata, 1)
@@ -632,7 +634,7 @@ func (dg *dockerGoClient) InspectContainer(ctx context.Context, dockerID string,
 	}
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-
+	defer metrics.MetricsEngineGlobal.RecordDockerMetric("INSPECT_CONTAINER")()
 	// Buffered channel so in the case of timeout it takes one write, never gets
 	// read, and can still be GC'd
 	response := make(chan inspectResponse, 1)
@@ -667,7 +669,7 @@ func (dg *dockerGoClient) inspectContainer(ctx context.Context, dockerID string)
 func (dg *dockerGoClient) StopContainer(ctx context.Context, dockerID string, timeout time.Duration) DockerContainerMetadata {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-
+	defer metrics.MetricsEngineGlobal.RecordDockerMetric("STOP_CONTAINER")()
 	// Buffered channel so in the case of timeout it takes one write, never gets
 	// read, and can still be GC'd
 	response := make(chan DockerContainerMetadata, 1)
@@ -709,7 +711,7 @@ func (dg *dockerGoClient) stopContainer(ctx context.Context, dockerID string) Do
 func (dg *dockerGoClient) RemoveContainer(ctx context.Context, dockerID string, timeout time.Duration) error {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-
+	defer metrics.MetricsEngineGlobal.RecordDockerMetric("REMOVE_CONTAINER")()
 	// Buffered channel so in the case of timeout it takes one write, never gets
 	// read, and can still be GC'd
 	response := make(chan error, 1)
@@ -943,8 +945,8 @@ func (dg *dockerGoClient) handleContainerEvents(ctx context.Context,
 		metadata := dg.containerMetadata(ctx, containerID)
 
 		changedContainers <- DockerContainerChangeEvent{
-			Status: status,
-			Type:   eventType,
+			Status:                  status,
+			Type:                    eventType,
 			DockerContainerMetadata: metadata,
 		}
 	}
@@ -1048,7 +1050,7 @@ func (dg *dockerGoClient) CreateVolume(ctx context.Context, name string,
 	timeout time.Duration) SDKVolumeResponse {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-
+	defer metrics.MetricsEngineGlobal.RecordDockerMetric("CREATE_VOLUME")()
 	// Buffered channel so in the case of timeout it takes one write, never gets
 	// read, and can still be GC'd
 	response := make(chan SDKVolumeResponse, 1)
@@ -1098,7 +1100,7 @@ func (dg *dockerGoClient) createVolume(ctx context.Context,
 func (dg *dockerGoClient) InspectVolume(ctx context.Context, name string, timeout time.Duration) SDKVolumeResponse {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-
+	defer metrics.MetricsEngineGlobal.RecordDockerMetric("INSPECT_VOLUME")()
 	// Buffered channel so in the case of timeout it takes one write, never gets
 	// read, and can still be GC'd
 	response := make(chan SDKVolumeResponse, 1)
@@ -1140,7 +1142,7 @@ func (dg *dockerGoClient) inspectVolume(ctx context.Context, name string) SDKVol
 func (dg *dockerGoClient) RemoveVolume(ctx context.Context, name string, timeout time.Duration) error {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-
+	defer metrics.MetricsEngineGlobal.RecordDockerMetric("REMOVE_VOLUME")()
 	// Buffered channel so in the case of timeout it takes one write, never gets
 	// read, and can still be GC'd
 	response := make(chan error, 1)
@@ -1327,7 +1329,7 @@ func (dg *dockerGoClient) removeImage(ctx context.Context, imageName string) err
 func (dg *dockerGoClient) LoadImage(ctx context.Context, inputStream io.Reader, timeout time.Duration) error {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-
+	defer metrics.MetricsEngineGlobal.RecordDockerMetric("LOAD_IMAGE")()
 	response := make(chan error, 1)
 	go func() {
 		response <- dg.loadImage(ctx, inputStream)

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -36,6 +36,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/engine/dependencygraph"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
+	"github.com/aws/amazon-ecs-agent/agent/metrics"
 	"github.com/aws/amazon-ecs-agent/agent/statechange"
 	"github.com/aws/amazon-ecs-agent/agent/statemanager"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
@@ -415,6 +416,7 @@ func (engine *DockerTaskEngine) synchronizeContainerStatus(container *apicontain
 // checkTaskState inspects the state of all containers within a task and writes
 // their state to the managed task's container channel.
 func (engine *DockerTaskEngine) checkTaskState(task *apitask.Task) {
+	defer metrics.MetricsEngineGlobal.RecordTaskEngineMetric("CHECK_TASK_STATE")()
 	taskContainers, ok := engine.state.ContainerMapByArn(task.Arn)
 	if !ok {
 		seelog.Warnf("Task engine [%s]: could not check task state; no task in state", task.Arn)
@@ -614,6 +616,7 @@ func (engine *DockerTaskEngine) StateChangeEvents() chan statechange.Event {
 
 // AddTask starts tracking a task
 func (engine *DockerTaskEngine) AddTask(task *apitask.Task) {
+	defer metrics.MetricsEngineGlobal.RecordTaskEngineMetric("ADD_TASK")()
 	err := task.PostUnmarshalTask(engine.cfg, engine.credentialsManager,
 		engine.resourceFields, engine.client, engine.ctx)
 	if err != nil {

--- a/agent/eventhandler/task_handler.go
+++ b/agent/eventhandler/task_handler.go
@@ -25,6 +25,7 @@ import (
 	apitaskstatus "github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
+	"github.com/aws/amazon-ecs-agent/agent/metrics"
 	"github.com/aws/amazon-ecs-agent/agent/statechange"
 	"github.com/aws/amazon-ecs-agent/agent/statemanager"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
@@ -267,6 +268,7 @@ func (handler *TaskHandler) getTaskEventsUnsafe(event *sendableEvent) *taskSenda
 // Continuously retries sending an event until it succeeds, sleeping between each
 // attempt
 func (handler *TaskHandler) submitTaskEvents(taskEvents *taskSendableEvents, client api.ECSClient, taskARN string) {
+	defer metrics.MetricsEngineGlobal.RecordECSClientMetric("SUBMIT_TASK_EVENTS")()
 	defer handler.removeTaskEvents(taskARN)
 
 	backoff := utils.NewSimpleBackoff(submitStateBackoffMin, submitStateBackoffMax,

--- a/agent/metrics/generic_metrics_client.go
+++ b/agent/metrics/generic_metrics_client.go
@@ -1,0 +1,136 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package metrics
+
+import (
+	"context"
+	"crypto/md5"
+	"fmt"
+	"math/rand"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/cihub/seelog"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	callTimeout = 2 * time.Minute
+)
+
+// A GenericMetricsClient records 3 metrics:
+// 1) A Prometheus summary vector representing call durations for different API calls
+// 2) A durations guage vector that updates the last recorded duration for the API call
+// 	  allowing for a time series view in the Prometheus browser
+// 3) A counter vector that increments call counts for each API call
+// The outstandingCalls map allows Fired CallStarts to be matched with Fired CallEnds
+type GenericMetrics struct {
+	durationVec      *prometheus.SummaryVec
+	durations        *prometheus.GaugeVec
+	counterVec       *prometheus.CounterVec
+	lock             sync.RWMutex
+	outstandingCalls map[string]time.Time
+}
+
+func Init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+// This function creates a hash of the callName and a randomly generated number.
+// The hash serves to match the call invokation with the call's end, which is
+// required to compute the call duration. The final metric is observed when the
+// FireCallEnd function is called.
+// If callID is empty, then we initiate the call with FireCallStart
+// We use a channel holding 1 bool to ensure that the FireCallEnd is called AFTER
+// the FireCallStart (because these are done in separate go routines)
+func (gm *GenericMetrics) RecordCall(callID, callName string, callTime time.Time, callStarted chan bool) string {
+	if callID == "" {
+		hashData := []byte("GenericMetrics-" + callName + strconv.FormatFloat(float64(rand.Float32()), 'f', -1, 32))
+		hash := fmt.Sprintf("%x", md5.Sum(hashData))
+		// Go routines are utilized to avoid blocking the main thread in case of
+		// resource contention with var outstandingCalls
+		go gm.FireCallStart(hash, callName, callTime, callStarted)
+		go gm.IncrementCallCount(callName)
+		return hash
+	} else {
+		go gm.FireCallEnd(callID, callName, callTime, callStarted)
+		return ""
+	}
+}
+
+func (gm *GenericMetrics) FireCallStart(callHash, callName string, timestamp time.Time, callStarted chan bool) {
+	gm.lock.Lock()
+	defer gm.lock.Unlock()
+	// Check map to see if call is outstanding, otherwise, store in map
+	if _, found := gm.outstandingCalls[callHash]; !found {
+		gm.outstandingCalls[callHash] = timestamp
+	} else {
+		seelog.Errorf("Call is already outstanding: %s", callName)
+	}
+	callStarted <- true
+}
+
+func (gm *GenericMetrics) FireCallEnd(callHash, callName string, timestamp time.Time, callStarted chan bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			seelog.Errorf("FireCallEnd for %s panicked. Recovering quietly: %s", callName, r)
+		}
+	}()
+	// We will block until the FireCallStart complement has completed
+	ctx, cancel := context.WithTimeout(context.Background(), callTimeout)
+	defer cancel()
+	select {
+	case <-ctx.Done():
+		seelog.Errorf("FireCallEnd timed out with %s", callName)
+		gm.lock.Lock()
+		delete(gm.outstandingCalls, callHash)
+		gm.lock.Unlock()
+		return
+	case <-callStarted:
+		break
+	}
+
+	gm.lock.Lock()
+	defer gm.lock.Unlock()
+	// Check map to see if call is outstanding and calculate duration
+	if timeStart, found := gm.outstandingCalls[callHash]; found {
+		seconds := timestamp.Sub(timeStart)
+		gm.durationVec.WithLabelValues(callName).Observe(seconds.Seconds())
+		gm.durations.WithLabelValues(callName).Set(seconds.Seconds())
+		delete(gm.outstandingCalls, callHash)
+	} else {
+		seelog.Errorf("Call is not outstanding: %s", callName)
+	}
+}
+
+// Simple Timeout function
+func startTimeout(timeout chan bool) {
+	time.Sleep(callTimeout)
+	timeout <- true
+}
+
+// This function increments the call count for a specific API call
+// This is invoked at the API call's start, whereas the duration metrics
+// are updated at the API call's end.
+func (gm *GenericMetrics) IncrementCallCount(callName string) {
+	defer func() {
+		if r := recover(); r != nil {
+			seelog.Errorf("IncrementCallCount for %s panicked. Recovering quietly: %s", callName, r)
+		}
+	}()
+	gm.lock.Lock()
+	defer gm.lock.Unlock()
+	gm.counterVec.WithLabelValues(callName).Inc()
+}

--- a/agent/metrics/interface.go
+++ b/agent/metrics/interface.go
@@ -1,0 +1,79 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package metrics
+
+import (
+	"time"
+
+	"github.com/aws/amazon-ecs-agent/agent/config"
+)
+
+// MetricsClient defines the behavior for any Client that uses the
+// MetricsEngine_ interface to collect metrics for Prometheus.
+// Clients should all have the same type of metrics collected
+// (Durations, counts, etc.)
+// In particular, the API calls we monitor in the Agent code (TaskEngine,
+// Docker, ECSClient, etc.) utilize call durations and counts which are
+// encapsulated in the GenericMetricsClient.
+// This interface is extensible for future clients that require different
+// collection behaviors.
+type MetricsClient interface {
+	// RecordCall is responsible for accepting a call ID, call Name,
+	// and timestamp for the call.
+	// The specific behavior of RecordCall is dependent on the type of client
+	// that is used. It is the responsibility of the MetricsEngine to call the
+	// appropriate RecordCall(...) method.
+	// This method is the defining function for this interface.
+	// We use a channel holding 1 bool to ensure that the FireCallEnd is called AFTER
+	// the FireCallStart (because these are done in separate go routines)
+	RecordCall(string, string, time.Time, chan bool) string
+
+	// In order to record call duration, we must fire a method's start and end
+	// at different times (once at the beginning and once at the end). Ideally,
+	// RecordCall should handle this through an execution and returned function
+	// to be deferred (see docker_client.go for usage examples)
+	FireCallStart(string, string, time.Time, chan bool)
+	FireCallEnd(string, string, time.Time, chan bool)
+
+	// This function will increment the call count. The metric for call duration
+	// should ideally have the accurate call count as well, but the Prometheus
+	// summary metric is updated for count when the FireCallEnd(...) function is
+	// called. When a FireCallStart(...) is called but its FireCallEnd(...) is not,
+	// we will see a discrepancy between the Summary's count and this Gauge count
+	IncrementCallCount(string)
+}
+
+// MetricsEngine_ is an interface that drives metric collection over
+// all existing MetricsClients. The APIType parameter corresponds to
+// the type of MetricsClient RecordCall(...) function that will be used.
+// The MetricsEngine_ should be instantiated at Agent startup time with
+// Agent configurations and context passed as parameters
+type MetricsEngine_ interface {
+	// This init function initializes the Global MetricsEngine variable that
+	// can be accessed throughout the Agent codebase on packages that the
+	// metrics package does not depend on (cyclic dependencies not allowed).
+	MustInit(*config.Config)
+
+	// This function calls a specific APIType's Client's RecordCall(...) method.
+	// As discussed in the comments for MetricsClient, different Clients have
+	// have different RecordCall(...) behaviors. Wrapper functions for this
+	// function should be created like recordGenericMetric(...) in metrics_engine.go
+	// to record 2 metrics (function invokation and deferred function end).
+	recordMetric(APIType, string, string)
+
+	// publishMetrics is used to listen on defined ports on localhost
+	// for incoming requests to expose metrics. An externally run Prometheus
+	// server can then 'scrape' the exposed metrics for collection and storage
+	publishMetrics()
+}

--- a/agent/metrics/metrics_engine.go
+++ b/agent/metrics/metrics_engine.go
@@ -1,0 +1,157 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/cihub/seelog"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+type APIType int32
+type MetricsEngine struct {
+	collection     bool
+	cfg            *config.Config
+	ctx            context.Context
+	Registry       *prometheus.Registry
+	managedMetrics map[APIType]MetricsClient
+}
+
+const (
+	DockerAPI APIType = iota
+	TaskEngine
+	StateManager
+	ECSClient
+)
+
+// Maintained list of APIs for which we collect metrics. MetricsClients will be
+// initialized using Factory method when a MetricsEngine is created.
+var (
+	managedAPIs = map[APIType]string{
+		DockerAPI:    "Docker_API",
+		TaskEngine:   "Task_Engine",
+		StateManager: "State_Manager",
+		ECSClient:    "ECS_Client",
+	}
+	MetricsEngineGlobal *MetricsEngine = &MetricsEngine{
+		collection: false,
+	}
+)
+
+// Function called during Agent start up to expose metrics on a local endpoint
+func PublishMetrics() {
+	if MetricsEngineGlobal.collection {
+		MetricsEngineGlobal.publishMetrics()
+	}
+}
+
+// Initializes the Global MetricsEngine used throughout Agent
+// Currently, we use the Prometheus Global Default Registerer, which also collecs
+// basic Go application metrics that we use (like memory usage).
+// In future cases, we can use a custom Prometheus Registry to group metrics.
+// For unit testing purposes, we only focus on API calls and use our own Registry
+func MustInit(cfg *config.Config, registry ...*prometheus.Registry) {
+	if !cfg.PrometheusMetricsEnabled {
+		return
+	}
+	var registryToUse *prometheus.Registry
+	if len(registry) > 0 {
+		registryToUse = registry[0]
+	} else {
+		registryToUse = prometheus.DefaultRegisterer.(*prometheus.Registry)
+	}
+	MetricsEngineGlobal = NewMetricsEngine(cfg, registryToUse)
+	MetricsEngineGlobal.collection = true
+}
+
+// We create a MetricsClient for all managed APIs (APIs for which we will collect
+// metrics)
+func NewMetricsEngine(cfg *config.Config, registry *prometheus.Registry) *MetricsEngine {
+	metricsEngine := &MetricsEngine{
+		cfg:            cfg,
+		Registry:       registry,
+		managedMetrics: make(map[APIType]MetricsClient),
+	}
+	for managedAPI, _ := range managedAPIs {
+		aClient := NewMetricsClient(managedAPI, metricsEngine.Registry)
+		metricsEngine.managedMetrics[managedAPI] = aClient
+	}
+	return metricsEngine
+}
+
+// Wrapper function that allows APIs to call a single function
+func (engine *MetricsEngine) RecordDockerMetric(callName string) func() {
+	return engine.recordGenericMetric(DockerAPI, callName)
+}
+
+// Wrapper function that allows APIs to call a single function
+func (engine *MetricsEngine) RecordTaskEngineMetric(callName string) func() {
+	return engine.recordGenericMetric(TaskEngine, callName)
+}
+
+// Wrapper function that allows APIs to call a single function
+func (engine *MetricsEngine) RecordStateManagerMetric(callName string) func() {
+	return engine.recordGenericMetric(StateManager, callName)
+}
+
+// Wrapper function that allows APIs to call a single function
+func (engine *MetricsEngine) RecordECSClientMetric(callName string) func() {
+	return engine.recordGenericMetric(ECSClient, callName)
+}
+
+// Records a call's start and returns a function to be deferred.
+// Wrapper functions will use this function for GenericMetricsClients.
+// If Metrics collection is enabled from the cfg, we record a metric with callID
+// as an empty string (signaling a call start), and then return a function to
+// record a second metric with a non-empty callID.
+// We use a channel holding 1 bool to ensure that the FireCallEnd is called AFTER
+// the FireCallStart (because these are done in separate go routines)
+// Recording a metric in an API needs only a wrapper function that supplies the
+// APIType and called using the following format:
+// defer metrics.MetricsEngineGlobal.RecordMetricWrapper(callName)()
+func (engine *MetricsEngine) recordGenericMetric(apiType APIType, callName string) func() {
+	callStarted := make(chan bool, 1)
+	if engine == nil || !engine.collection {
+		return func() {
+		}
+	}
+	callID := engine.recordMetric(apiType, callName, "", callStarted)
+	return func() {
+		engine.recordMetric(apiType, callName, callID, callStarted)
+	}
+}
+
+func (engine *MetricsEngine) recordMetric(apiType APIType, callName, callID string, callStarted chan bool) string {
+	return engine.managedMetrics[apiType].RecordCall(callID, callName, time.Now(), callStarted)
+}
+
+// Function that exposes all Agent Metrics on a given port.
+func (engine *MetricsEngine) publishMetrics() {
+	go func() {
+		// Because we are using the DefaultRegisterer in Prometheus, we can use
+		// the promhttp.Handler() function. In future cases for custom registers,
+		// we can use promhttp.HandlerFor(customRegisterer, promhttp.HandlerOpts{})
+		http.Handle("/metrics", promhttp.Handler())
+		err := http.ListenAndServe(fmt.Sprintf(":%d", config.AgentPrometheusExpositionPort), nil)
+		if err != nil {
+			seelog.Errorf("Error publishing metrics: %s", err.Error())
+		}
+	}()
+}

--- a/agent/metrics/metrics_factory.go
+++ b/agent/metrics/metrics_factory.go
@@ -1,0 +1,82 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package metrics
+
+import (
+	"time"
+
+	"github.com/cihub/seelog"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	AgentNamespace        = "AgentMetrics"
+	DockerSubsystem       = "DockerAPI"
+	TaskEngineSubsystem   = "TaskEngine"
+	StateManagerSubsystem = "StateManager"
+	ECSClientSubsystem    = "ECSClient"
+)
+
+// A factory method that enables various MetricsClients to be created.
+func NewMetricsClient(api APIType, registry *prometheus.Registry) MetricsClient {
+	switch api {
+	case DockerAPI:
+		return NewGenericMetricsClient(DockerSubsystem, registry)
+	case TaskEngine:
+		return NewGenericMetricsClient(TaskEngineSubsystem, registry)
+	case StateManager:
+		return NewGenericMetricsClient(StateManagerSubsystem, registry)
+	case ECSClient:
+		return NewGenericMetricsClient(ECSClientSubsystem, registry)
+	default:
+		seelog.Error("Unmanaged MetricsClient cannot be created.")
+		return nil
+	}
+}
+
+func NewGenericMetricsClient(subsystem string, registry *prometheus.Registry) *GenericMetrics {
+	aDurationVec := prometheus.NewSummaryVec(prometheus.SummaryOpts{
+		Namespace:  AgentNamespace,
+		Subsystem:  subsystem,
+		Name:       "duration_seconds",
+		Help:       subsystem + " call duration in seconds",
+		Objectives: make(map[float64]float64),
+	}, []string{"Call"})
+	registry.MustRegister(aDurationVec)
+
+	aCounterVec := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: AgentNamespace,
+		Subsystem: subsystem,
+		Name:      "call_count",
+	}, []string{"Call"})
+	registry.MustRegister(aCounterVec)
+
+	aGaugeVec := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: AgentNamespace,
+			Subsystem: subsystem,
+			Name:      "call_duration",
+			Help:      subsystem + " call duration in seconds individual",
+		},
+		[]string{"Call"})
+	registry.MustRegister(aGaugeVec)
+
+	genericMetrics := &GenericMetrics{
+		durationVec:      aDurationVec,
+		counterVec:       aCounterVec,
+		durations:        aGaugeVec,
+		outstandingCalls: make(map[string]time.Time),
+	}
+	return genericMetrics
+}

--- a/agent/metrics/metrics_test.go
+++ b/agent/metrics/metrics_test.go
@@ -1,0 +1,225 @@
+// +build linux,unit
+
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package metrics
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+)
+
+// Create default config for Metrics. PrometheusMetricsEnabled is set to false
+// by default, so it must be turned on
+func getTestConfig() config.Config {
+	cfg := config.DefaultConfig()
+	cfg.PrometheusMetricsEnabled = true
+	return cfg
+}
+
+// Tests if MetricsEngineGlobal variable is initialized and if all managed
+// MetricsClients are initialized
+func TestMetricsEngineInit(t *testing.T) {
+	defer func() {
+		MetricsEngineGlobal = &MetricsEngine{
+			collection: false,
+		}
+	}()
+	cfg := getTestConfig()
+	MustInit(&cfg, prometheus.NewRegistry())
+	assert.NotNil(t, MetricsEngineGlobal)
+	assert.Equal(t, len(MetricsEngineGlobal.managedMetrics), len(managedAPIs))
+}
+
+// Tests if a default config will start Prometheus metrics. Should be disabled
+// by default.
+func TestDisablePrometheusMetrics(t *testing.T) {
+	defer func() {
+		MetricsEngineGlobal = &MetricsEngine{
+			collection: false,
+		}
+	}()
+	cfg := getTestConfig()
+	cfg.PrometheusMetricsEnabled = false
+	MustInit(&cfg, prometheus.NewRegistry())
+	PublishMetrics()
+	assert.False(t, MetricsEngineGlobal.collection)
+}
+
+// Mimicks metric collection of Docker API calls through Go routines. The method
+// call to record a metric is the same used by various clients throughout Agent.
+// We sleep the go routine to simulate "work" being done.
+// We can determine the expected values for the metrics and create a map of them,
+// which will then be used to verify the accuracy of the metrics collected.
+func TestMetricCollection(t *testing.T) {
+	defer func() {
+		MetricsEngineGlobal = &MetricsEngine{
+			collection: false,
+		}
+	}()
+	cfg := getTestConfig()
+	MustInit(&cfg, prometheus.NewRegistry())
+	MetricsEngineGlobal.collection = true
+
+	var DockerMetricSleepTime4 time.Duration = 4 * time.Second
+	var DockerMetricSleepTime2 time.Duration = 2 * time.Second
+
+	var wg sync.WaitGroup
+	wg.Add(40)
+
+	// These Go routines simulate metrics collection
+	go func() {
+		for i := 0; i < 10; i++ {
+			go func() {
+				defer wg.Done()
+				defer MetricsEngineGlobal.RecordDockerMetric("START")()
+				time.Sleep(DockerMetricSleepTime4)
+			}()
+		}
+	}()
+	go func() {
+		for i := 0; i < 10; i++ {
+			go func() {
+				defer wg.Done()
+				defer MetricsEngineGlobal.RecordDockerMetric("START")()
+				time.Sleep(DockerMetricSleepTime2)
+			}()
+		}
+	}()
+	go func() {
+		for i := 0; i < 10; i++ {
+			go func() {
+				defer wg.Done()
+				defer MetricsEngineGlobal.RecordDockerMetric("STOP")()
+				time.Sleep(DockerMetricSleepTime4)
+			}()
+		}
+	}()
+	go func() {
+		for i := 0; i < 10; i++ {
+			go func() {
+				defer wg.Done()
+				defer MetricsEngineGlobal.RecordDockerMetric("STOP")()
+				time.Sleep(DockerMetricSleepTime2)
+			}()
+		}
+	}()
+	time.Sleep(2 * time.Second)
+	wg.Wait()
+
+	// This will gather all collected metrics and store them in a MetricFamily list
+	// All metric families can be printed by looping over this variable using
+	// fmt.Println(proto.MarshalTextString(metricFamilies[n])) where n = index
+	metricFamilies, err := MetricsEngineGlobal.Registry.Gather()
+	assert.NoError(t, err)
+
+	// Here we set up the expectations. These are known values which make verfication
+	// easier.
+	expected := make(metricMap)
+	expected["AgentMetrics_DockerAPI_call_count"] = make(map[string][]interface{})
+	expected["AgentMetrics_DockerAPI_call_count"]["CallSTART"] = []interface{}{
+		"COUNTER",
+		20.0,
+	}
+	expected["AgentMetrics_DockerAPI_call_count"]["CallSTOP"] = []interface{}{
+		"COUNTER",
+		20.0,
+	}
+	expected["AgentMetrics_DockerAPI_call_duration"] = make(map[string][]interface{})
+	expected["AgentMetrics_DockerAPI_call_duration"]["CallSTART"] = []interface{}{
+		"GUAGE",
+		0.0,
+	}
+	expected["AgentMetrics_DockerAPI_call_duration"]["CallSTOP"] = []interface{}{
+		"GUAGE",
+		0.0,
+	}
+	expected["AgentMetrics_DockerAPI_duration_seconds"] = make(map[string][]interface{})
+	expected["AgentMetrics_DockerAPI_duration_seconds"]["CallSTART"] = []interface{}{
+		"SUMMARY",
+		3.0,
+	}
+	expected["AgentMetrics_DockerAPI_duration_seconds"]["CallSTOP"] = []interface{}{
+		"SUMMARY",
+		3.0,
+	}
+	// We will do a simple tree search to verify all metrics in metricsFamilies
+	// are as expected
+	assert.True(t, verifyStats(metricFamilies, expected), "Metrics are not accurate")
+}
+
+// A type for storing a Tree-based map. We map the MetricName to a map of metrics
+// under that name. This second map indexes by MetricLabelName+MetricLabelValue to
+// a slice MetricType and MetricValue.
+//MetricName:metricLabelName+metricLabelValue:[metricType, metricValue]
+type metricMap map[string]map[string][]interface{}
+
+// In order to verify the MetricFamily with the expected metric values, we do a simple
+// tree search to verify that all stats in the MetricFamily coincide with the expected
+// metric values.
+// This method only verifes that all metrics in var metricsReceived are present in
+// var expectedMetrics
+func verifyStats(metricsReceived []*dto.MetricFamily, expectedMetrics metricMap) bool {
+	var threshhold float64 = 0.1 // Maximum threshhold for two metrics being equal
+	for _, metricFamily := range metricsReceived {
+		if metricList, found := expectedMetrics[metricFamily.GetName()]; found {
+			for _, metric := range metricFamily.GetMetric() {
+				if aMetric, found := metricList[metric.GetLabel()[0].GetName()+metric.GetLabel()[0].GetValue()]; found {
+					metricTypeExpected := string(aMetric[0].(string))
+					metricValExpected := float64(aMetric[1].(float64))
+					switch metricTypeExpected {
+					case "GUAGE":
+						continue
+					case "COUNTER":
+						if !compareDiff(metricValExpected, metric.GetCounter().GetValue(), threshhold) {
+							fmt.Printf("Does not match SUMMARY. Expected: %f, Received: %f\n", metricValExpected, metric.GetCounter().GetValue())
+							return false
+						}
+					case "SUMMARY":
+						if !compareDiff(metricValExpected, metric.GetSummary().GetSampleSum()/float64(metric.GetSummary().GetSampleCount()), threshhold) {
+							fmt.Printf("Does not match SUMMARY. Expected: %f, Received: %f\n", metricValExpected, metric.GetSummary().GetSampleSum()/float64(metric.GetSummary().GetSampleCount()))
+							return false
+						}
+					default:
+						fmt.Println("Metric Type not recognized")
+						return false
+					}
+				} else {
+					fmt.Println("MetricLabel Name and Value combo not found")
+					return false
+				}
+			}
+		} else {
+			fmt.Println("MetricName not found")
+			return false
+		}
+	}
+	return true
+}
+
+// Helper function to determine if two values (a and b) are within a percentage of a
+func compareDiff(a, b, deltaMin float64) bool {
+	diff := a - b
+	if diff < 0 {
+		diff = -diff
+	}
+	return diff <= (a * deltaMin)
+}

--- a/agent/statemanager/state_manager.go
+++ b/agent/statemanager/state_manager.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/logger"
+	"github.com/aws/amazon-ecs-agent/agent/metrics"
 )
 
 const (
@@ -192,6 +193,7 @@ func AddSaveable(name string, saveable Saveable) Option {
 // Save triggers a save to file, though respects a minimum save interval to wait
 // between saves.
 func (manager *basicStateManager) Save() error {
+	defer metrics.MetricsEngineGlobal.RecordStateManagerMetric("SAVE")()
 	manager.saveTimesLock.Lock()
 	defer manager.saveTimesLock.Unlock()
 	if time.Since(manager.lastSave) >= minSaveInterval {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Initializes a MetricsEngine that is called throughout various APIs (Docker, ECS Task Handler, State Manager) to record call counts and durations
Unit testing is done on MetricsEngine
A new ReservedPort for Prometheus endpoint exposition is added at 51680

### Implementation details
<!-- How are the changes implemented? -->
New 'metrics' package and global variable MetricsEngineGlobal used throughout Agent
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Exposing Prometheus metrics to an endpoint on host EC2 instance
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
