### PR TITLE
Filter out propagated 'aws:' tags and remove skipped tagging test

### DIFF
--- a/agent/ec2/ec2_client_test.go
+++ b/agent/ec2/ec2_client_test.go
@@ -59,6 +59,18 @@ func TestDescribeECSTagsForInstance(t *testing.T) {
 				Key:   aws.String("key"),
 				Value: aws.String("value"),
 			},
+			{
+				Key:   aws.String("aws:key"),
+				Value: aws.String("aws:value"),
+			},
+			{
+				Key:   aws.String("aWS:key"),
+				Value: aws.String("value"),
+			},
+			{
+				Key:   aws.String("key"),
+				Value: aws.String("Aws:value"),
+			},
 		},
 	}
 

--- a/agent/functional_tests/tests/functionaltests_test.go
+++ b/agent/functional_tests/tests/functionaltests_test.go
@@ -636,8 +636,6 @@ func testV3TaskEndpoint(t *testing.T, taskName, containerName, networkMode, awsl
 }
 
 func TestContainerInstanceTags(t *testing.T) {
-	t.Skip("Skipping TestContainerInstanceTags")
-
 	// We need long container instance ARN for tagging APIs, PutAccountSettingInput
 	// will enable long container instance ARN.
 	putAccountSettingInput := ecsapi.PutAccountSettingInput{
@@ -688,8 +686,7 @@ func TestContainerInstanceTags(t *testing.T) {
 	}
 	agent := RunAgent(t, agentOptions)
 	defer agent.Cleanup()
-	// Change the required Agent version to v1.22.0 during 1.22.0 staging or after staging.
-	agent.RequireVersion(">=1.21.0")
+	agent.RequireVersion(">=1.22.0")
 
 	// Verify the tags are registered.
 	ListTagsForResourceInput := ecsapi.ListTagsForResourceInput{


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR is mainly to resolve issue #1704.

1. Filter propagated tags start with "aws:"
2. Remove the skipped tagging functional tests

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [ ] Builds on Linux (`make release`)
- [ ] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [ ] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass


### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
