### PR TITLE
Ecs secrets asm2

### DIFF
--- a/agent/acs/model/api/api-2.json
+++ b/agent/acs/model/api/api-2.json
@@ -437,7 +437,10 @@
     },
     "SecretProvider":{
       "type":"string",
-      "enum":["ssm"]
+      "enum":[
+        "ssm",
+        "asm"
+      ]
     },
     "SecretType":{
       "type":"string",

--- a/agent/statemanager/state_manager.go
+++ b/agent/statemanager/state_manager.go
@@ -70,7 +70,9 @@ const (
 	// 17)
 	//   a) Add 'secrets' field to 'apicontainer.Container'
 	//   b) Add 'ssmsecret' field to 'resources'
-	// 18) Add 'AvailabilityZone' field to the TaskResponse struct
+	// 18)
+	//   a) Add 'AvailabilityZone' field to the TaskResponse struct
+	//   b) Add 'asmsecret' field to 'resources'
 	ECSDataVersion = 18
 
 	// ecsDataFile specifies the filename in the ECS_DATADIR

--- a/agent/statemanager/testdata/v17/secrets/ecs_agent_data.json
+++ b/agent/statemanager/testdata/v17/secrets/ecs_agent_data.json
@@ -44,14 +44,6 @@
                   "containerPath": null,
                   "type": "ENVIRONMENT_VARIABLE",
                   "region": "us-west-2"
-                },
-                {
-                  "name": "asm-secret",
-                  "valueFrom": "secret-value-from",
-                  "provider": "asm",
-                  "containerPath": null,
-                  "type": "ENVIRONMENT_VARIABLE",
-                  "region": "us-west-2"
                 }
               ],
               "LogsAuthStrategy": "",
@@ -85,27 +77,6 @@
             }
           ],
           "resources": {
-            "asmsecret": [
-              {
-                "taskARN": "/ecs/33425c99-5db7-45fb-8244-bc94d00661e4",
-                "executionCredentialsID": "b1a6ede6-1a9f-4ab3-a02e-bd3e51b11244",
-                "createdAt": "0001-01-01T00:00:00Z",
-                "desiredStatus": "CREATED",
-                "knownStatus": "CREATED",
-                "secretResources": {
-                  "us-west-2": [
-                    {
-                      "name": "asm-secret",
-                      "valueFrom": "secret-value-from",
-                      "provider": "asm",
-                      "containerPath": null,
-                      "type": "ENVIRONMENT_VARIABLE",
-                      "region": "us-west-2"
-                    }
-                  ]
-                }
-              }
-            ],
             "ssmsecret": [
               {
                 "taskARN": "/ecs/33425c99-5db7-45fb-8244-bc94d00661e4",
@@ -244,5 +215,5 @@
       "IPToTask": {}
     }
   },
-  "Version": 16
+  "Version": 17
 }

--- a/agent/statemanager/testdata/v18/secrets/ecs_agent_data.json
+++ b/agent/statemanager/testdata/v18/secrets/ecs_agent_data.json
@@ -1,0 +1,252 @@
+{
+  "Data": {
+    "Cluster": "state-file",
+    "ContainerInstanceArn": "arn:aws:ecs:us-west-2:1234567890:container-instance/46efd519-df3f-4096-8f34-faebb1747752",
+    "EC2InstanceID": "i-0da29eb1a8a98768b",
+    "TaskEngine": {
+      "Tasks": [
+        {
+          "Arn": "arn:aws:ecs:us-west-2:1234567890:task/33425c99-5db7-45fb-8244-bc94d00661e4",
+          "Family": "secrets-state",
+          "Version": "1",
+          "Containers": [
+            {
+              "Name": "container_1",
+              "Image": "amazonlinux:1",
+              "ImageID": "sha256:7f929d2604c7e504a568eac9a2523c1b9e9b15e1fcee4076e1411a552913d08e",
+              "Command": [
+                "sleep",
+                "3600"
+              ],
+              "Cpu": 0,
+              "Memory": 512,
+              "Links": null,
+              "volumesFrom": [],
+              "mountPoints": [],
+              "portMappings": [],
+              "Essential": true,
+              "EntryPoint": null,
+              "environment": {},
+              "overrides": {
+                "command": null
+              },
+              "dockerConfig": {
+                "config": "{}",
+                "hostConfig": "{\"CapAdd\":[],\"CapDrop\":[]}",
+                "version": "1.17"
+              },
+              "registryAuthentication": null,
+              "secrets": [
+                {
+                  "name": "ssm-secret",
+                  "valueFrom": "secret-value-from",
+                  "provider": "ssm",
+                  "containerPath": null,
+                  "type": "ENVIRONMENT_VARIABLE",
+                  "region": "us-west-2"
+                },
+                {
+                  "name": "asm-secret",
+                  "valueFrom": "secret-value-from",
+                  "provider": "asm",
+                  "containerPath": null,
+                  "type": "ENVIRONMENT_VARIABLE",
+                  "region": "us-west-2"
+                }
+              ],
+              "LogsAuthStrategy": "",
+              "desiredStatus": "RUNNING",
+              "KnownStatus": "RUNNING",
+              "TransitionDependencySet": {
+                "1": {
+                  "ContainerDependencies": null,
+                  "ResourceDependencies": [
+                    {
+                      "Name": "cgroup",
+                      "RequiredStatus": 1
+                    },
+                    {
+                      "Name": "ssmsecret",
+                      "RequiredStatus": 1
+                    },
+                    {
+                      "Name": "asmsecret",
+                      "RequiredStatus": 1
+                    }
+                  ]
+                }
+              },
+              "RunDependencies": null,
+              "IsInternal": "NORMAL",
+              "ApplyingError": {
+                "error": "API error (500): Get https://registry-1.docker.io/v2/library/amazonlinux/manifests/1: toomanyrequests: too many failed login attempts for username or IP address\n",
+                "name": "CannotPullContainerError"
+              },
+              "SentStatus": "RUNNING",
+              "metadataFileUpdated": false,
+              "KnownExitCode": null,
+              "KnownPortBindings": null
+            }
+          ],
+          "resources": {
+            "asmsecret": [
+              {
+                "taskARN": "/ecs/33425c99-5db7-45fb-8244-bc94d00661e4",
+                "executionCredentialsID": "b1a6ede6-1a9f-4ab3-a02e-bd3e51b11244",
+                "createdAt": "0001-01-01T00:00:00Z",
+                "desiredStatus": "CREATED",
+                "knownStatus": "CREATED",
+                "secretResources": {
+                  "secret-value-from_us-west-2": [
+                    {
+                      "name": "asm-secret",
+                      "valueFrom": "secret-value-from",
+                      "provider": "asm",
+                      "containerPath": null,
+                      "type": "ENVIRONMENT_VARIABLE",
+                      "region": "us-west-2"
+                    }
+                  ]
+                }
+              }
+            ],
+            "ssmsecret": [
+              {
+                "taskARN": "/ecs/33425c99-5db7-45fb-8244-bc94d00661e4",
+                "executionCredentialsID": "b1a6ede6-1a9f-4ab3-a02e-bd3e51b11244",
+                "createdAt": "0001-01-01T00:00:00Z",
+                "desiredStatus": "CREATED",
+                "knownStatus": "CREATED",
+                "secretResources": {
+                  "us-west-2": [
+                    {
+                      "name": "ssm-secret",
+                      "valueFrom": "secret-value-from",
+                      "provider": "ssm",
+                      "containerPath": null,
+                      "type": "ENVIRONMENT_VARIABLE",
+                      "region": "us-west-2"
+                    }
+                  ]
+                }
+              }
+            ],
+            "cgroup": [
+              {
+                "cgroupRoot": "/ecs/33425c99-5db7-45fb-8244-bc94d00661e4",
+                "cgroupMountPath": "/sys/fs/cgroup",
+                "createdAt": "0001-01-01T00:00:00Z",
+                "desiredStatus": "CREATED",
+                "knownStatus": "CREATED",
+                "resourceSpec": {
+                  "cpu": {
+                    "shares": 2
+                  }
+                }
+              }
+            ]
+          },
+          "volumes": [],
+          "DesiredStatus": "RUNNING",
+          "KnownStatus": "RUNNING",
+          "KnownTime": "2018-10-04T18:05:49.121835686Z",
+          "PullStartedAt": "2018-10-04T18:05:34.359798761Z",
+          "PullStoppedAt": "2018-10-04T18:05:48.445985904Z",
+          "ExecutionStoppedAt": "0001-01-01T00:00:00Z",
+          "SentStatus": "RUNNING",
+          "StartSequenceNumber": 2,
+          "StopSequenceNumber": 0,
+          "executionCredentialsID": "b1a6ede6-1a9f-4ab3-a02e-bd3e51b11244",
+          "ENI": null,
+          "MemoryCPULimitsEnabled": true,
+          "PlatformFields": {}
+        }
+      ],
+      "IdToContainer": {
+        "8f5e6e3091f221c876103289ddabcbcdeb64acd7ac7e2d0cf4da2be2be9d8956": {
+          "DockerId": "8f5e6e3091f221c876103289ddabcbcdeb64acd7ac7e2d0cf4da2be2be9d8956",
+          "DockerName": "ecs-private-registry-state-1-container1-a68ef4b6e0fba38d3500",
+          "Container": {
+            "Name": "container_1",
+            "Image": "amazonlinux:1",
+            "ImageID": "sha256:7f929d2604c7e504a568eac9a2523c1b9e9b15e1fcee4076e1411a552913d08e",
+            "Command": [
+              "sleep",
+              "3600"
+            ],
+            "Cpu": 0,
+            "Memory": 512,
+            "Links": null,
+            "volumesFrom": [],
+            "mountPoints": [],
+            "portMappings": [],
+            "Essential": true,
+            "EntryPoint": null,
+            "environment": {},
+            "overrides": {
+              "command": null
+            },
+            "dockerConfig": {
+              "config": "{}",
+              "hostConfig": "{\"CapAdd\":[],\"CapDrop\":[]}",
+              "version": "1.17"
+            },
+            "registryAuthentication": null,
+            "LogsAuthStrategy": "",
+            "desiredStatus": "RUNNING",
+            "KnownStatus": "RUNNING",
+            "TransitionDependencySet": {
+              "1": {
+                "ContainerDependencies": null,
+                "ResourceDependencies": [
+                  {
+                    "Name": "cgroup",
+                    "RequiredStatus": 1
+                  },
+                  {
+                    "Name": "ssmsecret",
+                    "RequiredStatus": 1
+                  },
+                  {
+                    "Name": "asmsecret",
+                    "RequiredStatus": 1
+                  }
+                ]
+              }
+            },
+            "RunDependencies": null,
+            "IsInternal": "NORMAL",
+            "ApplyingError": {
+              "error": "API error (500): Get https://registry-1.docker.io/v2/library/amazonlinux/manifests/1: toomanyrequests: too many failed login attempts for username or IP address\n",
+              "name": "CannotPullContainerError"
+            },
+            "SentStatus": "RUNNING",
+            "metadataFileUpdated": false,
+            "KnownExitCode": null,
+            "KnownPortBindings": null
+          }
+        }
+      },
+      "IdToTask": {
+        "8f5e6e3091f221c876103289ddabcbcdeb64acd7ac7e2d0cf4da2be2be9d8956": "arn:aws:ecs:us-west-2:1234567890:task/33425c99-5db7-45fb-8244-bc94d00661e4"
+      },
+      "ImageStates": [
+        {
+          "Image": {
+            "ImageID": "sha256:7f929d2604c7e504a568eac9a2523c1b9e9b15e1fcee4076e1411a552913d08e",
+            "Names": [
+              "amazonlinux:1"
+            ],
+            "Size": 165452304
+          },
+          "PulledAt": "2018-10-04T18:05:48.445644088Z",
+          "LastUsedAt": "2018-10-04T18:05:48.445645342Z",
+          "PullSucceeded": false
+        }
+      ],
+      "ENIAttachments": null,
+      "IPToTask": {}
+    }
+  },
+  "Version": 18
+}


### PR DESCRIPTION
### Summary
Update acs model and state file for asm secrets

### Testing
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
