### PR TITLE
Add functional tests for secrets 

### DIFF
--- a/agent/ecs_client/model/api/api-2.json
+++ b/agent/ecs_client/model/api/api-2.json
@@ -734,6 +734,7 @@
         "mountPoints":{"shape":"MountPointList"},
         "volumesFrom":{"shape":"VolumeFromList"},
         "linuxParameters":{"shape":"LinuxParameters"},
+        "secrets":{"shape":"SecretList"},
         "hostname":{"shape":"String"},
         "user":{"shape":"String"},
         "workingDirectory":{"shape":"String"},
@@ -1657,6 +1658,21 @@
         "REPLICA",
         "DAEMON"
       ]
+    },
+    "Secret":{
+      "type":"structure",
+      "required":[
+        "name",
+        "valueFrom"
+      ],
+      "members":{
+        "name":{"shape":"String"},
+        "valueFrom":{"shape":"String"}
+      }
+    },
+    "SecretList":{
+      "type":"list",
+      "member":{"shape":"Secret"}
     },
     "ServerException":{
       "type":"structure",

--- a/agent/ecs_client/model/api/docs-2.json
+++ b/agent/ecs_client/model/api/docs-2.json
@@ -954,6 +954,18 @@
         "Service$schedulingStrategy": "<p>The scheduling strategy to use for the service. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonECS/latest/developerguideecs_services.html\">Services</a>.</p> <p>There are two service scheduler strategies available:</p> <ul> <li> <p> <code>REPLICA</code>-The replica scheduling strategy places and maintains the desired number of tasks across your cluster. By default, the service scheduler spreads tasks across Availability Zones. You can use task placement strategies and constraints to customize task placement decisions.</p> </li> <li> <p> <code>DAEMON</code>-The daemon scheduling strategy deploys exactly one task on each container instance in your cluster. When using this strategy, do not specify a desired number of tasks or any task placement strategies.</p> <note> <p>Fargate tasks do not support the <code>DAEMON</code> scheduling strategy.</p> </note> </li> </ul>"
       }
     },
+    "Secret": {
+      "base": null,
+      "refs": {
+        "SecretList$member": null
+      }
+    },
+    "SecretList": {
+      "base": null,
+      "refs": {
+        "ContainerDefinition$secrets": null
+      }
+    },
     "ServerException": {
       "base": "<p>These errors are usually caused by a server issue.</p>",
       "refs": {
@@ -1162,6 +1174,8 @@
         "RunTaskRequest$startedBy": "<p>An optional tag specified when a task is started. For example if you automatically trigger a task to run a batch process job, you could apply a unique identifier for that job to your task with the <code>startedBy</code> parameter. You can then identify which tasks belong to that job by filtering the results of a <a>ListTasks</a> call with the <code>startedBy</code> value. Up to 36 letters (uppercase and lowercase), numbers, hyphens, and underscores are allowed.</p> <p>If a task is started by an Amazon ECS service, then the <code>startedBy</code> parameter contains the deployment ID of the service that starts it.</p>",
         "RunTaskRequest$group": "<p>The name of the task group to associate with the task. The default value is the family name of the task definition (for example, family:my-family-name).</p>",
         "RunTaskRequest$platformVersion": "<p>The platform version on which to run your task. If one is not specified, the latest version is used by default.</p>",
+        "Secret$name": null,
+        "Secret$valueFrom": null,
         "ServerException$message": null,
         "Service$serviceArn": "<p>The ARN that identifies the service. The ARN contains the <code>arn:aws:ecs</code> namespace, followed by the Region of the service, the AWS account ID of the service owner, the <code>service</code> namespace, and then the service name. For example, <code>arn:aws:ecs:<i>region</i>:<i>012345678910</i>:service/<i>my-service</i> </code>.</p>",
         "Service$serviceName": "<p>The name of your service. Up to 255 letters (uppercase and lowercase), numbers, hyphens, and underscores are allowed. Service names must be unique within a cluster, but you can have similarly named services in multiple clusters within a Region or across multiple Regions.</p>",

--- a/agent/ecs_client/model/ecs/api.go
+++ b/agent/ecs_client/model/ecs/api.go
@@ -4566,6 +4566,8 @@ type ContainerDefinition struct {
 	// The private repository authentication credentials to use.
 	RepositoryCredentials *RepositoryCredentials `locationName:"repositoryCredentials" type:"structure"`
 
+	Secrets []*Secret `locationName:"secrets" type:"list"`
+
 	SystemControls []*SystemControl `locationName:"systemControls" type:"list"`
 
 	// A list of ulimits to set in the container. This parameter maps to Ulimits
@@ -4643,6 +4645,16 @@ func (s *ContainerDefinition) Validate() error {
 	if s.RepositoryCredentials != nil {
 		if err := s.RepositoryCredentials.Validate(); err != nil {
 			invalidParams.AddNested("RepositoryCredentials", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.Secrets != nil {
+		for i, v := range s.Secrets {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Secrets", i), err.(request.ErrInvalidParams))
+			}
 		}
 	}
 	if s.Ulimits != nil {
@@ -4821,6 +4833,12 @@ func (s *ContainerDefinition) SetReadonlyRootFilesystem(v bool) *ContainerDefini
 // SetRepositoryCredentials sets the RepositoryCredentials field's value.
 func (s *ContainerDefinition) SetRepositoryCredentials(v *RepositoryCredentials) *ContainerDefinition {
 	s.RepositoryCredentials = v
+	return s
+}
+
+// SetSecrets sets the Secrets field's value.
+func (s *ContainerDefinition) SetSecrets(v []*Secret) *ContainerDefinition {
+	s.Secrets = v
 	return s
 }
 
@@ -9406,6 +9424,54 @@ func (s *RunTaskOutput) SetFailures(v []*Failure) *RunTaskOutput {
 // SetTasks sets the Tasks field's value.
 func (s *RunTaskOutput) SetTasks(v []*Task) *RunTaskOutput {
 	s.Tasks = v
+	return s
+}
+
+type Secret struct {
+	_ struct{} `type:"structure"`
+
+	// Name is a required field
+	Name *string `locationName:"name" type:"string" required:"true"`
+
+	// ValueFrom is a required field
+	ValueFrom *string `locationName:"valueFrom" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s Secret) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s Secret) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Secret) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Secret"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.ValueFrom == nil {
+		invalidParams.Add(request.NewErrParamRequired("ValueFrom"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetName sets the Name field's value.
+func (s *Secret) SetName(v string) *Secret {
+	s.Name = &v
+	return s
+}
+
+// SetValueFrom sets the ValueFrom field's value.
+func (s *Secret) SetValueFrom(v string) *Secret {
+	s.ValueFrom = &v
 	return s
 }
 

--- a/agent/functional_tests/testdata/taskdefinitions/ssmsecrets-environment-variables/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/ssmsecrets-environment-variables/task-definition.json
@@ -1,0 +1,20 @@
+{
+  "family": "ssm-integration",
+  "executionRoleArn": "$$$EXECUTION_ROLE$$$",
+  "containerDefinitions": [
+    {
+      "name": "ssmsecrets-environment-variables",
+      "image": "busybox:latest",
+      "cpu": 100,
+      "memory": 100,
+      "command": ["sh", "-c", "if echo $SECRET_NAME | grep \"secretValue\"; then exit 42; else exit 1; fi"
+      ],
+      "secrets": [
+        {
+          "name": "$$$SECRET_NAME$$$",
+          "valueFrom": "$$$SSM_PARAMETER_NAME$$$"
+        }
+      ]
+    }
+  ]
+}

--- a/agent/functional_tests/tests/functionaltests_unix_test.go
+++ b/agent/functional_tests/tests/functionaltests_unix_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
+	"github.com/aws/aws-sdk-go/service/ssm"
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1069,4 +1070,165 @@ func TestTaskIPCNamespaceSharing(t *testing.T) {
 	sErr = sTask.WaitStopped(waitTaskStateChangeDuration)
 	require.NoError(t, sErr, "Error waiting for ipc-namespace-task-share task to stop")
 	assert.Equal(t, 2, rExitCode, "Container could see IPC resource, but shouldn't")
+}
+
+// TestSSMSecretsNonEncryptedParameter tests the workflow for retrieving secrets from SSM Parameter Store,
+// here secret is a non encrypted parameter
+func TestSSMSecretsNonEncryptedParameterARN(t *testing.T) {
+
+	if os.Getenv("TEST_DISABLE_EXECUTION_ROLE") == "true" {
+		t.Skip("TEST_DISABLE_EXECUTION_ROLE was set to true")
+	}
+
+	executionRole := os.Getenv("ECS_FTS_EXECUTION_ROLE")
+	// execution role arn is following the pattern arn:aws:iam::accountId:role/***
+	executionRoleArr := strings.Split(executionRole, ":")
+	partition := executionRoleArr[1]
+	accountId := executionRoleArr[4]
+
+	parameterName := "FunctionalTest-SSMSecretsString"
+	secretName := "SECRET_NAME"
+	region := *ECS.Config.Region
+	ssmClient := ssm.New(session.New(), aws.NewConfig().WithRegion(region))
+	input := &ssm.PutParameterInput{
+		Description: aws.String("Resource created for the ECS Agent Functional Test: TestSSMSecretsNonEncryptedParameter"),
+		Name:        aws.String(parameterName),
+		Value:       aws.String("secretValue"),
+		Type:        aws.String("String"),
+	}
+
+	// create parameter in parameter store if it does not exist
+	_, err := ssmClient.PutParameter(input)
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			case ssm.ErrCodeParameterAlreadyExists:
+				t.Logf("Parameter %v already exists in SSM Parameter Store", parameterName)
+				break
+			default:
+				require.NoError(t, err, "SSM PutParameter call failed")
+			}
+		}
+	}
+
+	agent := RunAgent(t, nil)
+	defer agent.Cleanup()
+
+	agent.RequireVersion(">=1.22.0")
+
+	tdOverrides := make(map[string]string)
+	tdOverrides["$$$SECRET_NAME$$$"] = secretName
+
+	arn := fmt.Sprintf("arn:%s:ssm:%s:%s:parameter/%s", partition, region, accountId, parameterName)
+	tdOverrides["$$$SSM_PARAMETER_NAME$$$"] = arn
+	tdOverrides["$$$EXECUTION_ROLE$$$"] = executionRole
+
+	task, err := agent.StartTaskWithTaskDefinitionOverrides(t, "ssmsecrets-environment-variables", tdOverrides)
+	require.NoError(t, err, "Failed to start task for ssmsecrets environment variables")
+
+	err = task.WaitStopped(waitTaskStateChangeDuration)
+	require.NoError(t, err)
+	exitCode, _ := task.ContainerExitcode("ssmsecrets-environment-variables")
+	assert.Equal(t, 42, exitCode, fmt.Sprintf("Expected exit code of 42; got %d", exitCode))
+}
+
+// TestSSMSecretsEncryptedParameter tests the workflow for retrieving secrets from SSM Parameter Store,
+// here secret is an encrypted parameter
+func TestSSMSecretsEncryptedParameter(t *testing.T) {
+
+	if os.Getenv("TEST_DISABLE_EXECUTION_ROLE") == "true" {
+		t.Skip("TEST_DISABLE_EXECUTION_ROLE was set to true")
+	}
+
+	parameterName := "FunctionalTest-SSMSecretsSecureString"
+	secretName := "SECRET_NAME"
+	ssmClient := ssm.New(session.New(), aws.NewConfig().WithRegion(*ECS.Config.Region))
+	input := &ssm.PutParameterInput{
+		Description: aws.String("Resource created for the ECS Agent Functional Test: TestSSMSecretsEncryptedParameter"),
+		Name:        aws.String(parameterName),
+		Value:       aws.String("secretValue"),
+		Type:        aws.String("SecureString"),
+	}
+
+	// create parameter in parameter store if it does not exist
+	_, err := ssmClient.PutParameter(input)
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			case ssm.ErrCodeParameterAlreadyExists:
+				t.Logf("Parameter %v already exists in SSM Parameter Store", parameterName)
+				break
+			default:
+				require.NoError(t, err, "SSM PutParameter call failed")
+			}
+		}
+	}
+
+	agent := RunAgent(t, nil)
+	defer agent.Cleanup()
+
+	agent.RequireVersion(">=1.22.0")
+
+	tdOverrides := make(map[string]string)
+	tdOverrides["$$$SECRET_NAME$$$"] = secretName
+	tdOverrides["$$$SSM_PARAMETER_NAME$$$"] = parameterName
+	tdOverrides["$$$EXECUTION_ROLE$$$"] = os.Getenv("ECS_FTS_EXECUTION_ROLE")
+
+	task, err := agent.StartTaskWithTaskDefinitionOverrides(t, "ssmsecrets-environment-variables", tdOverrides)
+	require.NoError(t, err, "Failed to start task for ssmsecrets environment variables")
+
+	err = task.WaitStopped(waitTaskStateChangeDuration)
+	require.NoError(t, err)
+	exitCode, _ := task.ContainerExitcode("ssmsecrets-environment-variables")
+	assert.Equal(t, 42, exitCode, fmt.Sprintf("Expected exit code of 42; got %d", exitCode))
+}
+
+// TestSSMSecretsEncryptedASMSecrets tests the workflow for retrieving secrets from SSM Parameter Store,
+// here secret is a secret in secrets manager passing through parameter store
+func TestSSMSecretsEncryptedASMSecrets(t *testing.T) {
+
+	if os.Getenv("TEST_DISABLE_EXECUTION_ROLE") == "true" {
+		t.Skip("TEST_DISABLE_EXECUTION_ROLE was set to true")
+	}
+
+	parameterName := "/aws/reference/secretsmanager/FunctionalTest-SSMSecretsSecretFromASM"
+	secretName := "SECRET_NAME"
+	asmClient := secretsmanager.New(session.New(), aws.NewConfig().WithRegion(*ECS.Config.Region))
+	input := &secretsmanager.CreateSecretInput{
+		Description:  aws.String("Resource created for the ECS Agent Functional Test: TestSSMSecretsEncryptedASMSecrets"),
+		Name:         aws.String("FunctionalTest-SSMSecretsSecretFromASM"),
+		SecretString: aws.String("secretValue"),
+	}
+
+	// create parameter in parameter store if it does not exist
+	_, err := asmClient.CreateSecret(input)
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			case secretsmanager.ErrCodeResourceExistsException:
+				t.Logf("Secret FunctionalTest-SSMSecretsSecretFromASM already exists in AWS Secrets Manager")
+				break
+			default:
+				require.NoError(t, err, "Secrets Manager CreateSecret call failed")
+			}
+		}
+	}
+
+	agent := RunAgent(t, nil)
+	defer agent.Cleanup()
+
+	agent.RequireVersion(">=1.22.0")
+
+	tdOverrides := make(map[string]string)
+	tdOverrides["$$$SECRET_NAME$$$"] = secretName
+	tdOverrides["$$$SSM_PARAMETER_NAME$$$"] = parameterName
+	tdOverrides["$$$EXECUTION_ROLE$$$"] = os.Getenv("ECS_FTS_EXECUTION_ROLE")
+
+	task, err := agent.StartTaskWithTaskDefinitionOverrides(t, "ssmsecrets-environment-variables", tdOverrides)
+	require.NoError(t, err, "Failed to start task for ssmsecrets environment variables")
+
+	err = task.WaitStopped(waitTaskStateChangeDuration)
+	require.NoError(t, err)
+	exitCode, _ := task.ContainerExitcode("ssmsecrets-environment-variables")
+	assert.Equal(t, 42, exitCode, fmt.Sprintf("Expected exit code of 42; got %d", exitCode))
 }


### PR DESCRIPTION
### Summary
Add essential functional tests for secrets. So far it is only for phase 1, which is integrating with SSM Parameter Store. Functional tests for phase 2 will be added later.

### Testing
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes

The functional tests currently are broken cause permission hasn't been updated

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
