### PR TITLE
make TestAgentIntrospectionValidator less flakey

### DIFF
--- a/agent/functional_tests/testdata/taskdefinitions/agent-introspection-validator/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/agent-introspection-validator/task-definition.json
@@ -2,7 +2,7 @@
   "family": "ecsftest-agent-introspection-validator",
   "networkMode": "host",
   "containerDefinitions": [{
-    "image": "amazon/amazon-ecs-agent-introspection-validator:make",
+    "image": "127.0.0.1:51670/amazon/amazon-ecs-agent-introspection-validator:latest",
     "name": "agent-introspection-validator",
     "memory": 50,
     "logConfiguration": {

--- a/misc/agent-introspection-validator/agent-introspection-validator.go
+++ b/misc/agent-introspection-validator/agent-introspection-validator.go
@@ -268,6 +268,12 @@ func main() {
 		Timeout: 5 * time.Second,
 	}
 
+	// Wait for a while before checking because it's possible that the volumes field in container
+	// is not available when we just started the container, because it is populated after we
+	// start the container, inspect it and get the volumes from inspectContainer response.
+	// TODO: we probably should change something in agent so that the volumes field is ready before we start the container
+	time.Sleep(3 * time.Second)
+
 	tasksMetadataPath := agentIntrospectionEndpoint + "tasks"
 	tasksMetadata, err := getTasksMetadata(client, tasksMetadataPath)
 	if err != nil {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
TestAgentIntrospectionValidator is a [known flakey test](https://github.com/aws/amazon-ecs-agent/issues/1596), and it seems that it's failing because the volumes field could be unavailable when a container just starts. This is because the volumes field is only populated after we start the container, inspect it and get the volumes from inspectContainer response (see https://github.com/aws/amazon-ecs-agent/pull/1531). Let the validator sleep for a while to make it less flakey, considering the fact that TestTaskMetadataValidator should suffer from the same issue but it's not identified as a flakey test because it sleeps for a while before checking (https://github.com/aws/amazon-ecs-agent/blob/master/misc/taskmetadata-validator/taskmetadata-validator.go#L214).

Also fix the task def for TestAgentIntrospectionValidator to use local test registry image. This mostly won't affect the test but will cause agent to keep trying to pull the image "amazon/amazon-ecs-agent-introspection-validator:make" because it won't be able to pull it.

### Implementation details
<!-- How are the changes implemented? -->
See above.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
