### PR TITLE
Propagating Container Instance and Task Tags to Task Metadata endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,7 @@ test-in-docker:
 	docker run --net=none -v "$(PWD):/go/src/github.com/aws/amazon-ecs-agent" --privileged "amazon/amazon-ecs-agent-test:make"
 
 run-functional-tests: testnnp test-registry ecr-execution-role-image telemetry-test-image
-	. ./scripts/shared_env && go test -tags functional -timeout=30m -v ./agent/functional_tests/...
+	. ./scripts/shared_env && go test -tags functional -timeout=32m -v ./agent/functional_tests/...
 
 .PHONY: build-image-for-ecr ecr-execution-role-image-for-upload upload-images replicate-images
 

--- a/agent/api/ecsclient/client.go
+++ b/agent/api/ecsclient/client.go
@@ -523,3 +523,13 @@ func (client *APIECSClient) discoverPollEndpoint(containerInstanceArn string) (*
 	client.pollEndpoinCache.Set(containerInstanceArn, output)
 	return output, nil
 }
+
+func (client *APIECSClient) GetResourceTags(resourceArn string) ([]*ecs.Tag, error) {
+	output, err := client.standardClient.ListTagsForResource(&ecs.ListTagsForResourceInput{
+		ResourceArn: &resourceArn,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return output.Tags, nil
+}

--- a/agent/api/interface.go
+++ b/agent/api/interface.go
@@ -40,6 +40,8 @@ type ECSClient interface {
 	// DiscoverTelemetryEndpoint takes a ContainerInstanceARN and returns the
 	// endpoint at which this Agent should contact Telemetry Service
 	DiscoverTelemetryEndpoint(containerInstanceArn string) (string, error)
+	// GetTaskTags retrieves the Tags associated with a certain Task
+	GetResourceTags(resourceArn string) ([]*ecs.Tag, error)
 }
 
 // ECSSDK is an interface that specifies the subset of the AWS Go SDK's ECS
@@ -49,6 +51,7 @@ type ECSSDK interface {
 	CreateCluster(*ecs.CreateClusterInput) (*ecs.CreateClusterOutput, error)
 	RegisterContainerInstance(*ecs.RegisterContainerInstanceInput) (*ecs.RegisterContainerInstanceOutput, error)
 	DiscoverPollEndpoint(*ecs.DiscoverPollEndpointInput) (*ecs.DiscoverPollEndpointOutput, error)
+	ListTagsForResource(*ecs.ListTagsForResourceInput) (*ecs.ListTagsForResourceOutput, error)
 }
 
 // ECSSubmitStateSDK is an interface with customized ecs client that

--- a/agent/api/mocks/api_mocks.go
+++ b/agent/api/mocks/api_mocks.go
@@ -74,6 +74,19 @@ func (mr *MockECSSDKMockRecorder) DiscoverPollEndpoint(arg0 interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DiscoverPollEndpoint", reflect.TypeOf((*MockECSSDK)(nil).DiscoverPollEndpoint), arg0)
 }
 
+// ListTagsForResource mocks base method
+func (m *MockECSSDK) ListTagsForResource(arg0 *ecs.ListTagsForResourceInput) (*ecs.ListTagsForResourceOutput, error) {
+	ret := m.ctrl.Call(m, "ListTagsForResource", arg0)
+	ret0, _ := ret[0].(*ecs.ListTagsForResourceOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListTagsForResource indicates an expected call of ListTagsForResource
+func (mr *MockECSSDKMockRecorder) ListTagsForResource(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTagsForResource", reflect.TypeOf((*MockECSSDK)(nil).ListTagsForResource), arg0)
+}
+
 // RegisterContainerInstance mocks base method
 func (m *MockECSSDK) RegisterContainerInstance(arg0 *ecs.RegisterContainerInstanceInput) (*ecs.RegisterContainerInstanceOutput, error) {
 	ret := m.ctrl.Call(m, "RegisterContainerInstance", arg0)
@@ -183,6 +196,19 @@ func (m *MockECSClient) DiscoverTelemetryEndpoint(arg0 string) (string, error) {
 // DiscoverTelemetryEndpoint indicates an expected call of DiscoverTelemetryEndpoint
 func (mr *MockECSClientMockRecorder) DiscoverTelemetryEndpoint(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DiscoverTelemetryEndpoint", reflect.TypeOf((*MockECSClient)(nil).DiscoverTelemetryEndpoint), arg0)
+}
+
+// GetResourceTags mocks base method
+func (m *MockECSClient) GetResourceTags(arg0 string) ([]*ecs.Tag, error) {
+	ret := m.ctrl.Call(m, "GetResourceTags", arg0)
+	ret0, _ := ret[0].([]*ecs.Tag)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetResourceTags indicates an expected call of GetResourceTags
+func (mr *MockECSClientMockRecorder) GetResourceTags(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResourceTags", reflect.TypeOf((*MockECSClient)(nil).GetResourceTags), arg0)
 }
 
 // RegisterContainerInstance mocks base method

--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -559,7 +559,7 @@ func (agent *ecsAgent) startAsyncRoutines(
 	statsEngine := stats.NewDockerStatsEngine(agent.cfg, agent.dockerClient, containerChangeEventStream)
 
 	// Start serving the endpoint to fetch IAM Role credentials and other task metadata
-	go handlers.ServeTaskHTTPEndpoint(credentialsManager, state, agent.containerInstanceARN, agent.cfg, statsEngine, agent.availabilityZone)
+	go handlers.ServeTaskHTTPEndpoint(credentialsManager, state, client, agent.containerInstanceARN, agent.cfg, statsEngine, agent.availabilityZone)
 
 	// Start sending events to the backend
 	go eventhandler.HandleEngineEvents(taskEngine, client, taskHandler)

--- a/agent/ecs_client/model/api/api-2.json
+++ b/agent/ecs_client/model/api/api-2.json
@@ -777,7 +777,8 @@
         "attachments":{"shape":"Attachments"},
         "clientToken":{
           "shape":"String"
-        }
+        },
+        "tags":{"shape":"Tags"}
       }
     },
     "ContainerInstanceStatus":{
@@ -1623,6 +1624,12 @@
         "stringSetValue":{"shape":"StringList"}
       }
     },
+    "ResourceNotFoundException":{
+      "type":"structure",
+      "members":{
+      },
+      "exception":true
+    },
     "Resources":{
       "type":"list",
       "member":{"shape":"Resource"}
@@ -1663,6 +1670,13 @@
       "enum":[
         "REPLICA",
         "DAEMON"
+      ]
+    },
+    "Scope":{
+      "type":"string",
+      "enum":[
+        "task",
+        "shared"
       ]
     },
     "Secret":{
@@ -1940,7 +1954,8 @@
         "launchType":{"shape":"LaunchType"},
         "platformVersion":{"shape":"String"},
         "attachments":{"shape":"Attachments"},
-        "healthStatus":{"shape":"HealthStatus"}
+        "healthStatus":{"shape":"HealthStatus"},
+        "tags":{"shape":"Tags"}
       }
     },
     "TaskDefinition":{

--- a/agent/ecs_client/model/api/docs-2.json
+++ b/agent/ecs_client/model/api/docs-2.json
@@ -676,6 +676,16 @@
       "refs": {
       }
     },
+    "ListTagsForResourceRequest": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "ListTagsForResourceResponse": {
+      "base": null,
+      "refs": {
+      }
+    },
     "ListTaskDefinitionFamiliesRequest": {
       "base": null,
       "refs": {
@@ -951,7 +961,13 @@
       "refs": {
         "CreateServiceRequest$schedulingStrategy": "<p>The scheduling strategy to use for the service. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonECS/latest/developerguideecs_services.html\">Services</a>.</p> <p>There are two service scheduler strategies available:</p> <ul> <li> <p> <code>REPLICA</code>-The replica scheduling strategy places and maintains the desired number of tasks across your cluster. By default, the service scheduler spreads tasks across Availability Zones. You can use task placement strategies and constraints to customize task placement decisions.</p> </li> <li> <p> <code>DAEMON</code>-The daemon scheduling strategy deploys exactly one task on each active container instance that meets all of the task placement constraints that you specify in your cluster. When using this strategy, there is no need to specify a desired number of tasks, a task placement strategy, or use Service Auto Scaling policies.</p> <note> <p>Fargate tasks do not support the <code>DAEMON</code> scheduling strategy.</p> </note> </li> </ul>",
         "ListServicesRequest$schedulingStrategy": "<p>The scheduling strategy for services to list.</p>",
-        "Service$schedulingStrategy": "<p>The scheduling strategy to use for the service. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonECS/latest/developerguideecs_services.html\">Services</a>.</p> <p>There are two service scheduler strategies available:</p> <ul> <li> <p> <code>REPLICA</code>-The replica scheduling strategy places and maintains the desired number of tasks across your cluster. By default, the service scheduler spreads tasks across Availability Zones. You can use task placement strategies and constraints to customize task placement decisions.</p> </li> <li> <p> <code>DAEMON</code>-The daemon scheduling strategy deploys exactly one task on each container instance in your cluster. When using this strategy, do not specify a desired number of tasks or any task placement strategies.</p> <note> <p>Fargate tasks do not support the <code>DAEMON</code> scheduling strategy.</p> </note> </li> </ul>"
+        "Service$schedulingStrategy": "<p>The scheduling strategy to use for the service. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_services.html\">Services</a>.</p> <p>There are two service scheduler strategies available:</p> <ul> <li> <p> <code>REPLICA</code>-The replica scheduling strategy places and maintains the desired number of tasks across your cluster. By default, the service scheduler spreads tasks across Availability Zones. You can use task placement strategies and constraints to customize task placement decisions.</p> </li> <li> <p> <code>DAEMON</code>-The daemon scheduling strategy deploys exactly one task on each container instance in your cluster. When you are using this strategy, do not specify a desired number of tasks or any task placement strategies.</p> <note> <p>Fargate tasks do not support the <code>DAEMON</code> scheduling strategy.</p> </note> </li> </ul>"
+      }
+    },
+    "Scope": {
+      "base": null,
+      "refs": {
+        "DockerVolumeConfiguration$scope": "<p>The scope for the Docker volume that determines its lifecycle. Docker volumes that are scoped to a <code>task</code> are automatically provisioned when the task starts and destroyed when the task stops. Docker volumes that are scoped as <code>shared</code> persist after the task stops.</p>"
       }
     },
     "Secret": {
@@ -1130,6 +1146,7 @@
         "ListServicesRequest$cluster": "<p>The short name or full Amazon Resource Name (ARN) of the cluster that hosts the services to list. If you do not specify a cluster, the default cluster is assumed.</p>",
         "ListServicesRequest$nextToken": "<p>The <code>nextToken</code> value returned from a previous paginated <code>ListServices</code> request where <code>maxResults</code> was used and the results exceeded the value of that parameter. Pagination continues from the end of the previous results that returned the <code>nextToken</code> value.</p> <note> <p>This token should be treated as an opaque identifier that is only used to retrieve the next items in a list and not for other programmatic purposes.</p> </note>",
         "ListServicesResponse$nextToken": "<p>The <code>nextToken</code> value to include in a future <code>ListServices</code> request. When the results of a <code>ListServices</code> request exceed <code>maxResults</code>, this value can be used to retrieve the next page of results. This value is <code>null</code> when there are no more results to return.</p>",
+        "ListTagsForResourceRequest$resourceArn": "<p>The Amazon Resource Name (ARN) that identifies the resource for which to list the tags. Currently, the supported resources are Amazon ECS tasks, services, task definitions, clusters, and container instances.</p>",
         "ListTaskDefinitionFamiliesRequest$familyPrefix": "<p>The <code>familyPrefix</code> is a string that is used to filter the results of <code>ListTaskDefinitionFamilies</code>. If you specify a <code>familyPrefix</code>, only task definition family names that begin with the <code>familyPrefix</code> string are returned.</p>",
         "ListTaskDefinitionFamiliesRequest$nextToken": "<p>The <code>nextToken</code> value returned from a previous paginated <code>ListTaskDefinitionFamilies</code> request where <code>maxResults</code> was used and the results exceeded the value of that parameter. Pagination continues from the end of the previous results that returned the <code>nextToken</code> value.</p> <note> <p>This token should be treated as an opaque identifier that is only used to retrieve the next items in a list and not for other programmatic purposes.</p> </note>",
         "ListTaskDefinitionFamiliesResponse$nextToken": "<p>The <code>nextToken</code> value to include in a future <code>ListTaskDefinitionFamilies</code> request. When the results of a <code>ListTaskDefinitionFamilies</code> request exceed <code>maxResults</code>, this value can be used to retrieve the next page of results. This value is <code>null</code> when there are no more results to return.</p>",
@@ -1292,6 +1309,14 @@
     "SubmitTaskStateChangeResponse": {
       "base": null,
       "refs": {
+      }
+    },
+    "Tags": {
+      "base": null,
+      "refs": {
+        "ContainerInstance$tags": "<p>The metadata that you apply to the container instance to help you categorize and organize them. Each tag consists of a key and an optional value, both of which you define. Tag keys can have a maximum character length of 128 characters, and tag values can have a maximum length of 256 characters.</p>",
+        "ListTagsForResourceResponse$tags": "<p>The tags for the resource.</p>",
+        "Task$tags": "<p>The metadata that you apply to the task to help you categorize and organize them. Each tag consists of a key and an optional value, both of which you define. Tag keys can have a maximum character length of 128 characters, and tag values can have a maximum length of 256 characters.</p>"
       }
     },
     "TargetNotFoundException": {

--- a/agent/ecs_client/model/ecs/api.go
+++ b/agent/ecs_client/model/ecs/api.go
@@ -4939,6 +4939,12 @@ type ContainerInstance struct {
 	// in the Amazon Elastic Container Service Developer Guide.
 	Status *string `locationName:"status" type:"string"`
 
+	// The metadata that you apply to the container instance to help you categorize
+	// and organize them. Each tag consists of a key and an optional value, both
+	// of which you define. Tag keys can have a maximum character length of 128
+	// characters, and tag values can have a maximum length of 256 characters.
+	Tags []*Tag `locationName:"tags" type:"list"`
+
 	// The version counter for the container instance. Every time a container instance
 	// experiences a change that triggers a CloudWatch event, the version counter
 	// is incremented. If you are replicating your Amazon ECS container instance
@@ -5038,6 +5044,12 @@ func (s *ContainerInstance) SetRunningTasksCount(v int64) *ContainerInstance {
 // SetStatus sets the Status field's value.
 func (s *ContainerInstance) SetStatus(v string) *ContainerInstance {
 	s.Status = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *ContainerInstance) SetTags(v []*Tag) *ContainerInstance {
+	s.Tags = v
 	return s
 }
 
@@ -6678,6 +6690,10 @@ type DockerVolumeConfiguration struct {
 
 	Labels map[string]*string `locationName:"labels" type:"map"`
 
+	// The scope for the Docker volume that determines its lifecycle. Docker volumes
+	// that are scoped to a task are automatically provisioned when the task starts
+	// and destroyed when the task stops. Docker volumes that are scoped as shared
+	// persist after the task stops.
 	Scope *string `locationName:"scope" type:"string" enum:"Scope"`
 }
 
@@ -7597,6 +7613,10 @@ func (s *ListServicesOutput) SetServiceArns(v []*string) *ListServicesOutput {
 type ListTagsForResourceInput struct {
 	_ struct{} `type:"structure"`
 
+	// The Amazon Resource Name (ARN) that identifies the resource for which to
+	// list the tags. Currently, the supported resources are Amazon ECS tasks, services,
+	// task definitions, clusters, and container instances.
+	//
 	// ResourceArn is a required field
 	ResourceArn *string `locationName:"resourceArn" type:"string" required:"true"`
 }
@@ -7633,6 +7653,7 @@ func (s *ListTagsForResourceInput) SetResourceArn(v string) *ListTagsForResource
 type ListTagsForResourceOutput struct {
 	_ struct{} `type:"structure"`
 
+	// The tags for the resource.
 	Tags []*Tag `locationName:"tags" type:"list"`
 }
 
@@ -9564,7 +9585,7 @@ type Service struct {
 	RunningCount *int64 `locationName:"runningCount" type:"integer"`
 
 	// The scheduling strategy to use for the service. For more information, see
-	// Services (http://docs.aws.amazon.com/AmazonECS/latest/developerguideecs_services.html).
+	// Services (http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_services.html).
 	//
 	// There are two service scheduler strategies available:
 	//
@@ -9574,8 +9595,8 @@ type Service struct {
 	//    and constraints to customize task placement decisions.
 	//
 	//    * DAEMON-The daemon scheduling strategy deploys exactly one task on each
-	//    container instance in your cluster. When using this strategy, do not specify
-	//    a desired number of tasks or any task placement strategies.
+	//    container instance in your cluster. When you are using this strategy,
+	//    do not specify a desired number of tasks or any task placement strategies.
 	//
 	// Fargate tasks do not support the DAEMON scheduling strategy.
 	SchedulingStrategy *string `locationName:"schedulingStrategy" type:"string" enum:"SchedulingStrategy"`
@@ -10591,6 +10612,12 @@ type Task struct {
 	// state to STOPPED).
 	StoppingAt *time.Time `locationName:"stoppingAt" type:"timestamp"`
 
+	// The metadata that you apply to the task to help you categorize and organize
+	// them. Each tag consists of a key and an optional value, both of which you
+	// define. Tag keys can have a maximum character length of 128 characters, and
+	// tag values can have a maximum length of 256 characters.
+	Tags []*Tag `locationName:"tags" type:"list"`
+
 	// The Amazon Resource Name (ARN) of the task.
 	TaskArn *string `locationName:"taskArn" type:"string"`
 
@@ -10757,6 +10784,12 @@ func (s *Task) SetStoppedReason(v string) *Task {
 // SetStoppingAt sets the StoppingAt field's value.
 func (s *Task) SetStoppingAt(v time.Time) *Task {
 	s.StoppingAt = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *Task) SetTags(v []*Tag) *Task {
+	s.Tags = v
 	return s
 }
 

--- a/agent/engine/dockerstate/docker_task_engine_state.go
+++ b/agent/engine/dockerstate/docker_task_engine_state.go
@@ -73,6 +73,7 @@ type TaskEngineState interface {
 	DockerIDByV3EndpointID(v3EndpointID string) (string, bool)
 	// TaskARNByV3EndpointID returns a taskARN for a given v3 endpoint ID
 	TaskARNByV3EndpointID(v3EndpointID string) (string, bool)
+
 	json.Marshaler
 	json.Unmarshaler
 }

--- a/agent/functional_tests/testdata/taskdefinitions/taskmetadata-validator-awsvpc/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/taskmetadata-validator-awsvpc/task-definition.json
@@ -12,6 +12,7 @@
         "retries": 2,
         "startPeriod": 1
     },
+    "command": ["$$$CHECK_TAGS$$$"],
     "logConfiguration": {
         "logDriver": "awslogs",
         "options": {

--- a/agent/functional_tests/testdata/taskdefinitions/v3-task-endpoint-validator-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/v3-task-endpoint-validator-windows/task-definition.json
@@ -13,7 +13,7 @@
       "startPeriod": 1
     },
     "entryPoint": ["powershell"],
-    "command": [".\\application.ps1; $env:AWS_REGION=\"$$$TEST_REGION$$$\";.\\v3-task-endpoint-validator-windows.exe; exit $LASTEXITCODE"],
+    "command": [".\\application.ps1; $env:AWS_REGION=\"$$$TEST_REGION$$$\";.\\v3-task-endpoint-validator-windows.exe $$$CHECK_TAGS$$$; exit $LASTEXITCODE"],
     "logConfiguration": {
       "logDriver": "awslogs",
       "options": {

--- a/agent/functional_tests/testdata/taskdefinitions/v3-task-endpoint-validator/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/v3-task-endpoint-validator/task-definition.json
@@ -12,6 +12,7 @@
       "retries": 2,
       "startPeriod": 1
     },
+    "command": ["$$$CHECK_TAGS$$$"],
     "logConfiguration": {
       "logDriver": "awslogs",
       "options": {

--- a/agent/functional_tests/tests/functionaltests_windows_test.go
+++ b/agent/functional_tests/tests/functionaltests_windows_test.go
@@ -184,6 +184,10 @@ func TestV3TaskEndpointDefaultNetworkMode(t *testing.T) {
 	testV3TaskEndpoint(t, "v3-task-endpoint-validator-windows", "v3-task-endpoint-validator-windows", "", "ecs-functional-tests-v3-task-endpoint-validator-windows")
 }
 
+func TestV3TaskEndpointTags(t *testing.T) {
+	testV3TaskEndpointTags(t, "v3-task-endpoint-validator-windows", "v3-task-endpoint-validator-windows", "")
+}
+
 // TestMetadataServiceValidator Tests that the metadata file can be accessed from the
 // container using the ECS_CONTAINER_METADATA_FILE environment variables
 func TestMetadataServiceValidator(t *testing.T) {

--- a/agent/handlers/task_server_setup.go
+++ b/agent/handlers/task_server_setup.go
@@ -18,6 +18,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/aws/amazon-ecs-agent/agent/api"
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/credentials"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
@@ -46,11 +47,13 @@ const (
 func taskServerSetup(credentialsManager credentials.Manager,
 	auditLogger audit.AuditLogger,
 	state dockerstate.TaskEngineState,
+	ecsClient api.ECSClient,
 	cluster string,
 	statsEngine stats.Engine,
 	steadyStateRate int,
 	burstRate int,
-	availabilityZone string) *http.Server {
+	availabilityZone string,
+	containerInstanceArn string) *http.Server {
 	muxRouter := mux.NewRouter()
 
 	// Set this so that for request like "/v3//metadata/task", the Agent will pass
@@ -60,9 +63,9 @@ func taskServerSetup(credentialsManager credentials.Manager,
 	muxRouter.HandleFunc(v1.CredentialsPath,
 		v1.CredentialsHandler(credentialsManager, auditLogger))
 
-	v2HandlersSetup(muxRouter, state, statsEngine, cluster, credentialsManager, auditLogger, availabilityZone)
+	v2HandlersSetup(muxRouter, state, ecsClient, statsEngine, cluster, credentialsManager, auditLogger, availabilityZone, containerInstanceArn)
 
-	v3HandlersSetup(muxRouter, state, statsEngine, cluster, availabilityZone)
+	v3HandlersSetup(muxRouter, state, ecsClient, statsEngine, cluster, availabilityZone, containerInstanceArn)
 
 	limiter := tollbooth.NewLimiter(int64(steadyStateRate), nil)
 	limiter.SetOnLimitReached(handlersutils.LimitReachedHandler(auditLogger))
@@ -91,15 +94,19 @@ func taskServerSetup(credentialsManager credentials.Manager,
 // v2HandlersSetup adds all handlers in v2 package to the mux router.
 func v2HandlersSetup(muxRouter *mux.Router,
 	state dockerstate.TaskEngineState,
+	ecsClient api.ECSClient,
 	statsEngine stats.Engine,
 	cluster string,
 	credentialsManager credentials.Manager,
 	auditLogger audit.AuditLogger,
-	availabilityZone string) {
+	availabilityZone string,
+	containerInstanceArn string) {
 	muxRouter.HandleFunc(v2.CredentialsPath, v2.CredentialsHandler(credentialsManager, auditLogger))
-	muxRouter.HandleFunc(v2.ContainerMetadataPath, v2.TaskContainerMetadataHandler(state, cluster, availabilityZone))
-	muxRouter.HandleFunc(v2.TaskMetadataPath, v2.TaskContainerMetadataHandler(state, cluster, availabilityZone))
-	muxRouter.HandleFunc(v2.TaskMetadataPathWithSlash, v2.TaskContainerMetadataHandler(state, cluster, availabilityZone))
+	muxRouter.HandleFunc(v2.ContainerMetadataPath, v2.TaskContainerMetadataHandler(state, ecsClient, cluster, availabilityZone, containerInstanceArn, false))
+	muxRouter.HandleFunc(v2.TaskMetadataPath, v2.TaskContainerMetadataHandler(state, ecsClient, cluster, availabilityZone, containerInstanceArn, false))
+	muxRouter.HandleFunc(v2.TaskWithTagsMetadataPath, v2.TaskContainerMetadataHandler(state, ecsClient, cluster, availabilityZone, containerInstanceArn, true))
+	muxRouter.HandleFunc(v2.TaskMetadataPathWithSlash, v2.TaskContainerMetadataHandler(state, ecsClient, cluster, availabilityZone, containerInstanceArn, false))
+	muxRouter.HandleFunc(v2.TaskWithTagsMetadataPathWithSlash, v2.TaskContainerMetadataHandler(state, ecsClient, cluster, availabilityZone, containerInstanceArn, true))
 	muxRouter.HandleFunc(v2.ContainerStatsPath, v2.TaskContainerStatsHandler(state, statsEngine))
 	muxRouter.HandleFunc(v2.TaskStatsPath, v2.TaskContainerStatsHandler(state, statsEngine))
 	muxRouter.HandleFunc(v2.TaskStatsPathWithSlash, v2.TaskContainerStatsHandler(state, statsEngine))
@@ -108,11 +115,14 @@ func v2HandlersSetup(muxRouter *mux.Router,
 // v3HandlersSetup adds all handlers in v3 package to the mux router.
 func v3HandlersSetup(muxRouter *mux.Router,
 	state dockerstate.TaskEngineState,
+	ecsClient api.ECSClient,
 	statsEngine stats.Engine,
 	cluster string,
-	availabilityZone string) {
+	availabilityZone string,
+	containerInstanceArn string) {
 	muxRouter.HandleFunc(v3.ContainerMetadataPath, v3.ContainerMetadataHandler(state))
-	muxRouter.HandleFunc(v3.TaskMetadataPath, v3.TaskMetadataHandler(state, cluster, availabilityZone))
+	muxRouter.HandleFunc(v3.TaskMetadataPath, v3.TaskMetadataHandler(state, ecsClient, cluster, availabilityZone, containerInstanceArn, false))
+	muxRouter.HandleFunc(v3.TaskWithTagsMetadataPath, v3.TaskMetadataHandler(state, ecsClient, cluster, availabilityZone, containerInstanceArn, true))
 	muxRouter.HandleFunc(v3.ContainerStatsPath, v3.ContainerStatsHandler(state, statsEngine))
 	muxRouter.HandleFunc(v3.TaskStatsPath, v3.TaskStatsHandler(state, statsEngine))
 }
@@ -121,6 +131,7 @@ func v3HandlersSetup(muxRouter *mux.Router,
 // for tasks being managed by the agent.
 func ServeTaskHTTPEndpoint(credentialsManager credentials.Manager,
 	state dockerstate.TaskEngineState,
+	ecsClient api.ECSClient,
 	containerInstanceArn string,
 	cfg *config.Config,
 	statsEngine stats.Engine,
@@ -136,8 +147,8 @@ func ServeTaskHTTPEndpoint(credentialsManager credentials.Manager,
 
 	auditLogger := audit.NewAuditLog(containerInstanceArn, cfg, logger)
 
-	server := taskServerSetup(credentialsManager, auditLogger, state, cfg.Cluster, statsEngine,
-		cfg.TaskMetadataSteadyStateRate, cfg.TaskMetadataBurstRate, availabilityZone)
+	server := taskServerSetup(credentialsManager, auditLogger, state, ecsClient, cfg.Cluster, statsEngine,
+		cfg.TaskMetadataSteadyStateRate, cfg.TaskMetadataBurstRate, availabilityZone, containerInstanceArn)
 
 	for {
 		utils.RetryWithBackoff(utils.NewSimpleBackoff(time.Second, time.Minute, 0.2, 2), func() error {

--- a/agent/handlers/task_server_setup_test.go
+++ b/agent/handlers/task_server_setup_test.go
@@ -29,12 +29,14 @@ import (
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	apieni "github.com/aws/amazon-ecs-agent/agent/api/eni"
+	mock_api "github.com/aws/amazon-ecs-agent/agent/api/mocks"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	apitaskstatus "github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/containermetadata"
 	"github.com/aws/amazon-ecs-agent/agent/credentials"
 	mock_credentials "github.com/aws/amazon-ecs-agent/agent/credentials/mocks"
+	"github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/handlers/utils"
 	"github.com/aws/amazon-ecs-agent/agent/handlers/v1"
@@ -48,32 +50,34 @@ import (
 )
 
 const (
-	clusterName           = "default"
-	remoteIP              = "169.254.170.3"
-	remotePort            = "32146"
-	taskARN               = "t1"
-	family                = "sleep"
-	version               = "1"
-	containerID           = "cid"
-	containerName         = "sleepy"
-	imageName             = "busybox"
-	imageID               = "bUsYbOx"
-	cpu                   = 1024
-	memory                = 512
-	statusRunning         = "RUNNING"
-	containerType         = "NORMAL"
-	containerPort         = 80
-	containerPortProtocol = "tcp"
-	eniIPv4Address        = "10.0.0.2"
-	roleArn               = "r1"
-	accessKeyID           = "ak"
-	secretAccessKey       = "sk"
-	credentialsID         = "credentialsId"
-	v2BaseStatsPath       = "/v2/stats"
-	v2BaseMetadataPath    = "/v2/metadata"
-	v3BasePath            = "/v3/"
-	v3EndpointID          = "v3eid"
-	availabilityzone      = "us-west-2b"
+	clusterName                = "default"
+	remoteIP                   = "169.254.170.3"
+	remotePort                 = "32146"
+	taskARN                    = "t1"
+	family                     = "sleep"
+	version                    = "1"
+	containerID                = "cid"
+	containerName              = "sleepy"
+	imageName                  = "busybox"
+	imageID                    = "bUsYbOx"
+	cpu                        = 1024
+	memory                     = 512
+	statusRunning              = "RUNNING"
+	containerType              = "NORMAL"
+	containerPort              = 80
+	containerPortProtocol      = "tcp"
+	eniIPv4Address             = "10.0.0.2"
+	roleArn                    = "r1"
+	accessKeyID                = "ak"
+	secretAccessKey            = "sk"
+	credentialsID              = "credentialsId"
+	v2BaseStatsPath            = "/v2/stats"
+	v2BaseMetadataPath         = "/v2/metadata"
+	v2BaseMetadataWithTagsPath = "/v2/metadataWithTags"
+	v3BasePath                 = "/v3/"
+	v3EndpointID               = "v3eid"
+	availabilityzone           = "us-west-2b"
+	containerInstanceArn       = "containerInstanceArn-test"
 )
 
 var (
@@ -312,8 +316,9 @@ func testErrorResponsesFromServer(t *testing.T, path string, expectedErrorMessag
 
 	credentialsManager := mock_credentials.NewMockManager(ctrl)
 	auditLog := mock_audit.NewMockAuditLogger(ctrl)
-	server := taskServerSetup(credentialsManager, auditLog, nil, "", nil, config.DefaultTaskMetadataSteadyStateRate,
-		config.DefaultTaskMetadataBurstRate, "")
+	ecsClient := mock_api.NewMockECSClient(ctrl)
+	server := taskServerSetup(credentialsManager, auditLog, nil, ecsClient, "", nil, config.DefaultTaskMetadataSteadyStateRate,
+		config.DefaultTaskMetadataBurstRate, "", containerInstanceArn)
 
 	recorder := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", path, nil)
@@ -346,8 +351,9 @@ func getResponseForCredentialsRequest(t *testing.T, expectedStatus int,
 	defer ctrl.Finish()
 	credentialsManager := mock_credentials.NewMockManager(ctrl)
 	auditLog := mock_audit.NewMockAuditLogger(ctrl)
-	server := taskServerSetup(credentialsManager, auditLog, nil, "", nil, config.DefaultTaskMetadataSteadyStateRate,
-		config.DefaultTaskMetadataBurstRate, "")
+	ecsClient := mock_api.NewMockECSClient(ctrl)
+	server := taskServerSetup(credentialsManager, auditLog, nil, ecsClient, "", nil, config.DefaultTaskMetadataSteadyStateRate,
+		config.DefaultTaskMetadataBurstRate, "", containerInstanceArn)
 	recorder := httptest.NewRecorder()
 
 	creds, ok := getCredentials()
@@ -407,14 +413,15 @@ func TestV2TaskMetadata(t *testing.T) {
 			state := mock_dockerstate.NewMockTaskEngineState(ctrl)
 			auditLog := mock_audit.NewMockAuditLogger(ctrl)
 			statsEngine := mock_stats.NewMockEngine(ctrl)
+			ecsClient := mock_api.NewMockECSClient(ctrl)
 
 			gomock.InOrder(
 				state.EXPECT().GetTaskByIPAddress(remoteIP).Return(taskARN, true),
 				state.EXPECT().TaskByArn(taskARN).Return(task, true),
 				state.EXPECT().ContainerMapByArn(taskARN).Return(containerNameToDockerContainer, true),
 			)
-			server := taskServerSetup(credentials.NewManager(), auditLog, state, clusterName, statsEngine,
-				config.DefaultTaskMetadataSteadyStateRate, config.DefaultTaskMetadataBurstRate, availabilityzone)
+			server := taskServerSetup(credentials.NewManager(), auditLog, state, ecsClient, clusterName, statsEngine,
+				config.DefaultTaskMetadataSteadyStateRate, config.DefaultTaskMetadataBurstRate, availabilityzone, containerInstanceArn)
 			recorder := httptest.NewRecorder()
 			req, _ := http.NewRequest("GET", tc.path, nil)
 			req.RemoteAddr = remoteIP + ":" + remotePort
@@ -430,6 +437,91 @@ func TestV2TaskMetadata(t *testing.T) {
 	}
 }
 
+func TestV2TaskWithTagsMetadata(t *testing.T) {
+	testCases := []struct {
+		path string
+	}{
+		{
+			v2BaseMetadataWithTagsPath,
+		},
+		{
+			v2BaseMetadataWithTagsPath + "/",
+		},
+	}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("Testing path: %s", tc.path), func(t *testing.T) {
+			state := mock_dockerstate.NewMockTaskEngineState(ctrl)
+			auditLog := mock_audit.NewMockAuditLogger(ctrl)
+			statsEngine := mock_stats.NewMockEngine(ctrl)
+			ecsClient := mock_api.NewMockECSClient(ctrl)
+
+			expectedTaskResponseWithTags := expectedTaskResponse
+			expectedContainerInstanceTags := map[string]string{
+				"ContainerInstanceTag1": "firstTag",
+				"ContainerInstanceTag2": "secondTag",
+			}
+			expectedTaskResponseWithTags.ContainerInstanceTags = expectedContainerInstanceTags
+			expectedTaskTags := map[string]string{
+				"TaskTag1": "firstTag",
+				"TaskTag2": "secondTag",
+			}
+			expectedTaskResponseWithTags.TaskTags = expectedTaskTags
+
+			contInstTag1Key := "ContainerInstanceTag1"
+			contInstTag1Val := "firstTag"
+			contInstTag2Key := "ContainerInstanceTag2"
+			contInstTag2Val := "secondTag"
+			taskTag1Key := "TaskTag1"
+			taskTag1Val := "firstTag"
+			taskTag2Key := "TaskTag2"
+			taskTag2Val := "secondTag"
+
+			gomock.InOrder(
+				state.EXPECT().GetTaskByIPAddress(remoteIP).Return(taskARN, true),
+				state.EXPECT().TaskByArn(taskARN).Return(task, true),
+				state.EXPECT().ContainerMapByArn(taskARN).Return(containerNameToDockerContainer, true),
+				ecsClient.EXPECT().GetResourceTags(containerInstanceArn).Return([]*ecs.Tag{
+					&ecs.Tag{
+						Key:   &contInstTag1Key,
+						Value: &contInstTag1Val,
+					},
+					&ecs.Tag{
+						Key:   &contInstTag2Key,
+						Value: &contInstTag2Val,
+					},
+				}, nil),
+				ecsClient.EXPECT().GetResourceTags(taskARN).Return([]*ecs.Tag{
+					&ecs.Tag{
+						Key:   &taskTag1Key,
+						Value: &taskTag1Val,
+					},
+					&ecs.Tag{
+						Key:   &taskTag2Key,
+						Value: &taskTag2Val,
+					},
+				}, nil),
+			)
+			server := taskServerSetup(credentials.NewManager(), auditLog, state, ecsClient, clusterName, statsEngine,
+				config.DefaultTaskMetadataSteadyStateRate, config.DefaultTaskMetadataBurstRate, availabilityzone, containerInstanceArn)
+			recorder := httptest.NewRecorder()
+			req, _ := http.NewRequest("GET", v2BaseMetadataWithTagsPath, nil)
+			req.RemoteAddr = remoteIP + ":" + remotePort
+			server.Handler.ServeHTTP(recorder, req)
+			res, err := ioutil.ReadAll(recorder.Body)
+			assert.NoError(t, err)
+			assert.Equal(t, http.StatusOK, recorder.Code)
+			var taskResponse v2.TaskResponse
+			err = json.Unmarshal(res, &taskResponse)
+			assert.NoError(t, err)
+			assert.Equal(t, expectedTaskResponseWithTags, taskResponse)
+		})
+	}
+}
+
 func TestV2ContainerMetadata(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -437,14 +529,15 @@ func TestV2ContainerMetadata(t *testing.T) {
 	state := mock_dockerstate.NewMockTaskEngineState(ctrl)
 	auditLog := mock_audit.NewMockAuditLogger(ctrl)
 	statsEngine := mock_stats.NewMockEngine(ctrl)
+	ecsClient := mock_api.NewMockECSClient(ctrl)
 
 	gomock.InOrder(
 		state.EXPECT().GetTaskByIPAddress(remoteIP).Return(taskARN, true),
 		state.EXPECT().ContainerByID(containerID).Return(dockerContainer, true),
 		state.EXPECT().TaskByID(containerID).Return(task, true),
 	)
-	server := taskServerSetup(credentials.NewManager(), auditLog, state, clusterName, statsEngine,
-		config.DefaultTaskMetadataSteadyStateRate, config.DefaultTaskMetadataBurstRate, "")
+	server := taskServerSetup(credentials.NewManager(), auditLog, state, ecsClient, clusterName, statsEngine,
+		config.DefaultTaskMetadataSteadyStateRate, config.DefaultTaskMetadataBurstRate, "", containerInstanceArn)
 	recorder := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", v2BaseMetadataPath+"/"+containerID, nil)
 	req.RemoteAddr = remoteIP + ":" + remotePort
@@ -465,14 +558,15 @@ func TestV2ContainerStats(t *testing.T) {
 	state := mock_dockerstate.NewMockTaskEngineState(ctrl)
 	auditLog := mock_audit.NewMockAuditLogger(ctrl)
 	statsEngine := mock_stats.NewMockEngine(ctrl)
+	ecsClient := mock_api.NewMockECSClient(ctrl)
 
 	dockerStats := &docker.Stats{NumProcs: 2}
 	gomock.InOrder(
 		state.EXPECT().GetTaskByIPAddress(remoteIP).Return(taskARN, true),
 		statsEngine.EXPECT().ContainerDockerStats(taskARN, containerID).Return(dockerStats, nil),
 	)
-	server := taskServerSetup(credentials.NewManager(), auditLog, state, clusterName, statsEngine,
-		config.DefaultTaskMetadataSteadyStateRate, config.DefaultTaskMetadataBurstRate, "")
+	server := taskServerSetup(credentials.NewManager(), auditLog, state, ecsClient, clusterName, statsEngine,
+		config.DefaultTaskMetadataSteadyStateRate, config.DefaultTaskMetadataBurstRate, "", containerInstanceArn)
 	recorder := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", v2BaseStatsPath+"/"+containerID, nil)
 	req.RemoteAddr = remoteIP + ":" + remotePort
@@ -506,6 +600,7 @@ func TestV2TaskStats(t *testing.T) {
 			state := mock_dockerstate.NewMockTaskEngineState(ctrl)
 			auditLog := mock_audit.NewMockAuditLogger(ctrl)
 			statsEngine := mock_stats.NewMockEngine(ctrl)
+			ecsClient := mock_api.NewMockECSClient(ctrl)
 
 			dockerStats := &docker.Stats{NumProcs: 2}
 			containerMap := map[string]*apicontainer.DockerContainer{
@@ -518,8 +613,8 @@ func TestV2TaskStats(t *testing.T) {
 				state.EXPECT().ContainerMapByArn(taskARN).Return(containerMap, true),
 				statsEngine.EXPECT().ContainerDockerStats(taskARN, containerID).Return(dockerStats, nil),
 			)
-			server := taskServerSetup(credentials.NewManager(), auditLog, state, clusterName, statsEngine,
-				config.DefaultTaskMetadataSteadyStateRate, config.DefaultTaskMetadataBurstRate, "")
+			server := taskServerSetup(credentials.NewManager(), auditLog, state, ecsClient, clusterName, statsEngine,
+				config.DefaultTaskMetadataSteadyStateRate, config.DefaultTaskMetadataBurstRate, "", containerInstanceArn)
 			recorder := httptest.NewRecorder()
 			req, _ := http.NewRequest("GET", tc.path, nil)
 			req.RemoteAddr = remoteIP + ":" + remotePort
@@ -544,14 +639,15 @@ func TestV3TaskMetadata(t *testing.T) {
 	state := mock_dockerstate.NewMockTaskEngineState(ctrl)
 	auditLog := mock_audit.NewMockAuditLogger(ctrl)
 	statsEngine := mock_stats.NewMockEngine(ctrl)
+	ecsClient := mock_api.NewMockECSClient(ctrl)
 
 	gomock.InOrder(
 		state.EXPECT().TaskARNByV3EndpointID(v3EndpointID).Return(taskARN, true),
 		state.EXPECT().TaskByArn(taskARN).Return(task, true),
 		state.EXPECT().ContainerMapByArn(taskARN).Return(containerNameToDockerContainer, true),
 	)
-	server := taskServerSetup(credentials.NewManager(), auditLog, state, clusterName, statsEngine,
-		config.DefaultTaskMetadataSteadyStateRate, config.DefaultTaskMetadataBurstRate, availabilityzone)
+	server := taskServerSetup(credentials.NewManager(), auditLog, state, ecsClient, clusterName, statsEngine,
+		config.DefaultTaskMetadataSteadyStateRate, config.DefaultTaskMetadataBurstRate, availabilityzone, containerInstanceArn)
 	recorder := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", v3BasePath+v3EndpointID+"/task", nil)
 	server.Handler.ServeHTTP(recorder, req)
@@ -564,6 +660,76 @@ func TestV3TaskMetadata(t *testing.T) {
 	assert.Equal(t, expectedTaskResponse, taskResponse)
 }
 
+// Test API calls for propagating Tags to Task Metadata
+func TestV3TaskMetadataWithTags(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	state := mock_dockerstate.NewMockTaskEngineState(ctrl)
+	auditLog := mock_audit.NewMockAuditLogger(ctrl)
+	statsEngine := mock_stats.NewMockEngine(ctrl)
+	ecsClient := mock_api.NewMockECSClient(ctrl)
+
+	expectedTaskResponseWithTags := expectedTaskResponse
+	expectedContainerInstanceTags := map[string]string{
+		"ContainerInstanceTag1": "firstTag",
+		"ContainerInstanceTag2": "secondTag",
+	}
+	expectedTaskResponseWithTags.ContainerInstanceTags = expectedContainerInstanceTags
+	expectedTaskTags := map[string]string{
+		"TaskTag1": "firstTag",
+		"TaskTag2": "secondTag",
+	}
+	expectedTaskResponseWithTags.TaskTags = expectedTaskTags
+
+	contInstTag1Key := "ContainerInstanceTag1"
+	contInstTag1Val := "firstTag"
+	contInstTag2Key := "ContainerInstanceTag2"
+	contInstTag2Val := "secondTag"
+	taskTag1Key := "TaskTag1"
+	taskTag1Val := "firstTag"
+	taskTag2Key := "TaskTag2"
+	taskTag2Val := "secondTag"
+
+	gomock.InOrder(
+		state.EXPECT().TaskARNByV3EndpointID(v3EndpointID).Return(taskARN, true),
+		state.EXPECT().TaskByArn(taskARN).Return(task, true),
+		state.EXPECT().ContainerMapByArn(taskARN).Return(containerNameToDockerContainer, true),
+		ecsClient.EXPECT().GetResourceTags(containerInstanceArn).Return([]*ecs.Tag{
+			&ecs.Tag{
+				Key:   &contInstTag1Key,
+				Value: &contInstTag1Val,
+			},
+			&ecs.Tag{
+				Key:   &contInstTag2Key,
+				Value: &contInstTag2Val,
+			},
+		}, nil),
+		ecsClient.EXPECT().GetResourceTags(taskARN).Return([]*ecs.Tag{
+			&ecs.Tag{
+				Key:   &taskTag1Key,
+				Value: &taskTag1Val,
+			},
+			&ecs.Tag{
+				Key:   &taskTag2Key,
+				Value: &taskTag2Val,
+			},
+		}, nil),
+	)
+	server := taskServerSetup(credentials.NewManager(), auditLog, state, ecsClient, clusterName, statsEngine,
+		config.DefaultTaskMetadataSteadyStateRate, config.DefaultTaskMetadataBurstRate, availabilityzone, containerInstanceArn)
+	recorder := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", v3BasePath+v3EndpointID+"/taskWithTags", nil)
+	server.Handler.ServeHTTP(recorder, req)
+	res, err := ioutil.ReadAll(recorder.Body)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	var taskResponse v2.TaskResponse
+	err = json.Unmarshal(res, &taskResponse)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedTaskResponseWithTags, taskResponse)
+}
+
 func TestV3ContainerMetadata(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -571,14 +737,15 @@ func TestV3ContainerMetadata(t *testing.T) {
 	state := mock_dockerstate.NewMockTaskEngineState(ctrl)
 	auditLog := mock_audit.NewMockAuditLogger(ctrl)
 	statsEngine := mock_stats.NewMockEngine(ctrl)
+	ecsClient := mock_api.NewMockECSClient(ctrl)
 
 	gomock.InOrder(
 		state.EXPECT().DockerIDByV3EndpointID(v3EndpointID).Return(containerID, true),
 		state.EXPECT().ContainerByID(containerID).Return(dockerContainer, true),
 		state.EXPECT().TaskByID(containerID).Return(task, true),
 	)
-	server := taskServerSetup(credentials.NewManager(), auditLog, state, clusterName, statsEngine,
-		config.DefaultTaskMetadataSteadyStateRate, config.DefaultTaskMetadataBurstRate, "")
+	server := taskServerSetup(credentials.NewManager(), auditLog, state, ecsClient, clusterName, statsEngine,
+		config.DefaultTaskMetadataSteadyStateRate, config.DefaultTaskMetadataBurstRate, "", containerInstanceArn)
 	recorder := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", v3BasePath+v3EndpointID, nil)
 	server.Handler.ServeHTTP(recorder, req)
@@ -598,6 +765,7 @@ func TestV3TaskStats(t *testing.T) {
 	state := mock_dockerstate.NewMockTaskEngineState(ctrl)
 	auditLog := mock_audit.NewMockAuditLogger(ctrl)
 	statsEngine := mock_stats.NewMockEngine(ctrl)
+	ecsClient := mock_api.NewMockECSClient(ctrl)
 
 	dockerStats := &docker.Stats{NumProcs: 2}
 
@@ -612,8 +780,8 @@ func TestV3TaskStats(t *testing.T) {
 		state.EXPECT().ContainerMapByArn(taskARN).Return(containerMap, true),
 		statsEngine.EXPECT().ContainerDockerStats(taskARN, containerID).Return(dockerStats, nil),
 	)
-	server := taskServerSetup(credentials.NewManager(), auditLog, state, clusterName, statsEngine,
-		config.DefaultTaskMetadataSteadyStateRate, config.DefaultTaskMetadataBurstRate, "")
+	server := taskServerSetup(credentials.NewManager(), auditLog, state, ecsClient, clusterName, statsEngine,
+		config.DefaultTaskMetadataSteadyStateRate, config.DefaultTaskMetadataBurstRate, "", containerInstanceArn)
 	recorder := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", v3BasePath+v3EndpointID+"/task/stats", nil)
 	server.Handler.ServeHTTP(recorder, req)
@@ -635,6 +803,7 @@ func TestV3ContainerStats(t *testing.T) {
 	state := mock_dockerstate.NewMockTaskEngineState(ctrl)
 	auditLog := mock_audit.NewMockAuditLogger(ctrl)
 	statsEngine := mock_stats.NewMockEngine(ctrl)
+	ecsClient := mock_api.NewMockECSClient(ctrl)
 
 	dockerStats := &docker.Stats{NumProcs: 2}
 
@@ -643,8 +812,8 @@ func TestV3ContainerStats(t *testing.T) {
 		state.EXPECT().DockerIDByV3EndpointID(v3EndpointID).Return(containerID, true),
 		statsEngine.EXPECT().ContainerDockerStats(taskARN, containerID).Return(dockerStats, nil),
 	)
-	server := taskServerSetup(credentials.NewManager(), auditLog, state, clusterName, statsEngine,
-		config.DefaultTaskMetadataSteadyStateRate, config.DefaultTaskMetadataBurstRate, "")
+	server := taskServerSetup(credentials.NewManager(), auditLog, state, ecsClient, clusterName, statsEngine,
+		config.DefaultTaskMetadataSteadyStateRate, config.DefaultTaskMetadataBurstRate, "", containerInstanceArn)
 	recorder := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", v3BasePath+v3EndpointID+"/stats", nil)
 	server.Handler.ServeHTTP(recorder, req)
@@ -677,9 +846,10 @@ func TestTaskHTTPEndpointErrorCode404(t *testing.T) {
 	state := mock_dockerstate.NewMockTaskEngineState(ctrl)
 	auditLog := mock_audit.NewMockAuditLogger(ctrl)
 	statsEngine := mock_stats.NewMockEngine(ctrl)
+	ecsClient := mock_api.NewMockECSClient(ctrl)
 
-	server := taskServerSetup(credentials.NewManager(), auditLog, state, clusterName, statsEngine,
-		config.DefaultTaskMetadataSteadyStateRate, config.DefaultTaskMetadataBurstRate, "")
+	server := taskServerSetup(credentials.NewManager(), auditLog, state, ecsClient, clusterName, statsEngine,
+		config.DefaultTaskMetadataSteadyStateRate, config.DefaultTaskMetadataBurstRate, "", containerInstanceArn)
 
 	for _, testPath := range testPaths {
 		t.Run(fmt.Sprintf("Test path: %s", testPath), func(t *testing.T) {
@@ -717,9 +887,10 @@ func TestTaskHTTPEndpointErrorCode400(t *testing.T) {
 	state := mock_dockerstate.NewMockTaskEngineState(ctrl)
 	auditLog := mock_audit.NewMockAuditLogger(ctrl)
 	statsEngine := mock_stats.NewMockEngine(ctrl)
+	ecsClient := mock_api.NewMockECSClient(ctrl)
 
-	server := taskServerSetup(credentials.NewManager(), auditLog, state, clusterName, statsEngine,
-		config.DefaultTaskMetadataSteadyStateRate, config.DefaultTaskMetadataBurstRate, "")
+	server := taskServerSetup(credentials.NewManager(), auditLog, state, ecsClient, clusterName, statsEngine,
+		config.DefaultTaskMetadataSteadyStateRate, config.DefaultTaskMetadataBurstRate, "", containerInstanceArn)
 
 	for _, testPath := range testPaths {
 		t.Run(fmt.Sprintf("Test path: %s", testPath), func(t *testing.T) {

--- a/agent/handlers/v2/response_test.go
+++ b/agent/handlers/v2/response_test.go
@@ -24,8 +24,10 @@ import (
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	apieni "github.com/aws/amazon-ecs-agent/agent/api/eni"
+	mock_api "github.com/aws/amazon-ecs-agent/agent/api/mocks"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	apitaskstatus "github.com/aws/amazon-ecs-agent/agent/api/task/status"
+	"github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate/mocks"
 	"github.com/aws/aws-sdk-go/aws"
 	docker "github.com/fsouza/go-dockerclient"
@@ -34,21 +36,22 @@ import (
 )
 
 const (
-	taskARN          = "t1"
-	cluster          = "default"
-	family           = "sleep"
-	version          = "1"
-	containerID      = "cid"
-	containerName    = "sleepy"
-	imageName        = "busybox"
-	imageID          = "bUsYbOx"
-	cpu              = 1024
-	memory           = 512
-	eniIPv4Address   = "10.0.0.2"
-	volName          = "volume1"
-	volSource        = "/var/lib/volume1"
-	volDestination   = "/volume"
-	availabilityZone = "us-west-2b"
+	taskARN              = "t1"
+	cluster              = "default"
+	family               = "sleep"
+	version              = "1"
+	containerID          = "cid"
+	containerName        = "sleepy"
+	imageName            = "busybox"
+	imageID              = "bUsYbOx"
+	cpu                  = 1024
+	memory               = 512
+	eniIPv4Address       = "10.0.0.2"
+	volName              = "volume1"
+	volSource            = "/var/lib/volume1"
+	volDestination       = "/volume"
+	availabilityZone     = "us-west-2b"
+	containerInstanceArn = "containerInstance-test"
 )
 
 func TestTaskResponse(t *testing.T) {
@@ -56,6 +59,7 @@ func TestTaskResponse(t *testing.T) {
 	defer ctrl.Finish()
 
 	state := mock_dockerstate.NewMockTaskEngineState(ctrl)
+	ecsClient := mock_api.NewMockECSClient(ctrl)
 	now := time.Now()
 	task := &apitask.Task{
 		Arn:                 taskARN,
@@ -117,7 +121,7 @@ func TestTaskResponse(t *testing.T) {
 		state.EXPECT().ContainerMapByArn(taskARN).Return(containerNameToDockerContainer, true),
 	)
 
-	taskResponse, err := NewTaskResponse(taskARN, state, cluster, availabilityZone)
+	taskResponse, err := NewTaskResponse(taskARN, state, ecsClient, cluster, availabilityZone, containerInstanceArn, false)
 	assert.NoError(t, err)
 	_, err = json.Marshal(taskResponse)
 	assert.NoError(t, err)
@@ -251,9 +255,18 @@ func TestTaskResponseMarshal(t *testing.T) {
 				},
 			},
 		},
+		"ContainerInstanceTags": map[string]interface{}{
+			"ContainerInstanceTag1": "firstTag",
+			"ContainerInstanceTag2": "secondTag",
+		},
+		"TaskTags": map[string]interface{}{
+			"TaskTag1": "firstTag",
+			"TaskTag2": "secondTag",
+		},
 	}
 
 	state := mock_dockerstate.NewMockTaskEngineState(ctrl)
+	ecsClient := mock_api.NewMockECSClient(ctrl)
 
 	task := &apitask.Task{
 		Arn:                 taskARN,
@@ -291,12 +304,41 @@ func TestTaskResponseMarshal(t *testing.T) {
 		},
 	}
 
+	contInstTag1Key := "ContainerInstanceTag1"
+	contInstTag1Val := "firstTag"
+	contInstTag2Key := "ContainerInstanceTag2"
+	contInstTag2Val := "secondTag"
+	taskTag1Key := "TaskTag1"
+	taskTag1Val := "firstTag"
+	taskTag2Key := "TaskTag2"
+	taskTag2Val := "secondTag"
+
 	gomock.InOrder(
 		state.EXPECT().TaskByArn(taskARN).Return(task, true),
 		state.EXPECT().ContainerMapByArn(taskARN).Return(containerNameToDockerContainer, true),
+		ecsClient.EXPECT().GetResourceTags(containerInstanceArn).Return([]*ecs.Tag{
+			&ecs.Tag{
+				Key:   &contInstTag1Key,
+				Value: &contInstTag1Val,
+			},
+			&ecs.Tag{
+				Key:   &contInstTag2Key,
+				Value: &contInstTag2Val,
+			},
+		}, nil),
+		ecsClient.EXPECT().GetResourceTags(taskARN).Return([]*ecs.Tag{
+			&ecs.Tag{
+				Key:   &taskTag1Key,
+				Value: &taskTag1Val,
+			},
+			&ecs.Tag{
+				Key:   &taskTag2Key,
+				Value: &taskTag2Val,
+			},
+		}, nil),
 	)
 
-	taskResponse, err := NewTaskResponse(taskARN, state, cluster, availabilityZone)
+	taskResponse, err := NewTaskResponse(taskARN, state, ecsClient, cluster, availabilityZone, containerInstanceArn, true)
 	assert.NoError(t, err)
 
 	taskResponseJSON, err := json.Marshal(taskResponse)

--- a/agent/handlers/v2/task_container_metadata_handler.go
+++ b/agent/handlers/v2/task_container_metadata_handler.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/aws/amazon-ecs-agent/agent/api"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/handlers/utils"
 	"github.com/cihub/seelog"
@@ -31,15 +32,21 @@ const (
 	// TaskMetadataPath specifies the relative URI path for serving task metadata.
 	TaskMetadataPath = "/v2/metadata"
 
+	// TaskWithTagsMetadataPath specifies the relative URI path for serving task metadata with Container Instance and Task Tags.
+	TaskWithTagsMetadataPath = "/v2/metadataWithTags"
+
 	// TaskMetadataPathWithSlash specifies the relative URI path for serving task metadata.
 	TaskMetadataPathWithSlash = TaskMetadataPath + "/"
+
+	// TaskWithTagsMetadataPath specifies the relative URI path for serving task metadata with Container Instance and Task Tags.
+	TaskWithTagsMetadataPathWithSlash = TaskWithTagsMetadataPath + "/"
 )
 
 // ContainerMetadataPath specifies the relative URI path for serving container metadata.
 var ContainerMetadataPath = TaskMetadataPathWithSlash + utils.ConstructMuxVar(metadataContainerIDMuxName, utils.AnythingButEmptyRegEx)
 
 // TaskContainerMetadataHandler returns the handler method for handling task and container metadata requests.
-func TaskContainerMetadataHandler(state dockerstate.TaskEngineState, cluster string, az string) func(http.ResponseWriter, *http.Request) {
+func TaskContainerMetadataHandler(state dockerstate.TaskEngineState, ecsClient api.ECSClient, cluster, az, containerInstanceArn string, propagateTags bool) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		taskARN, err := getTaskARNByRequest(r, state)
 		if err != nil {
@@ -55,7 +62,7 @@ func TaskContainerMetadataHandler(state dockerstate.TaskEngineState, cluster str
 		}
 
 		seelog.Infof("V2 task/container metadata handler: writing response for task '%s'", taskARN)
-		WriteTaskMetadataResponse(w, taskARN, cluster, state, az)
+		WriteTaskMetadataResponse(w, taskARN, cluster, state, ecsClient, az, containerInstanceArn, propagateTags)
 	}
 }
 
@@ -73,9 +80,9 @@ func WriteContainerMetadataResponse(w http.ResponseWriter, containerID string, s
 }
 
 // WriteTaskMetadataResponse writes the task metadata to response writer.
-func WriteTaskMetadataResponse(w http.ResponseWriter, taskARN string, cluster string, state dockerstate.TaskEngineState, az string) {
+func WriteTaskMetadataResponse(w http.ResponseWriter, taskARN string, cluster string, state dockerstate.TaskEngineState, ecsClient api.ECSClient, az, containerInstanceArn string, propagateTags bool) {
 	// Generate a response for the task
-	taskResponse, err := NewTaskResponse(taskARN, state, cluster, az)
+	taskResponse, err := NewTaskResponse(taskARN, state, ecsClient, cluster, az, containerInstanceArn, propagateTags)
 	if err != nil {
 		errResponseJSON, _ := json.Marshal("Unable to generate metadata for task: '" + taskARN + "'")
 		utils.WriteJSONToResponse(w, http.StatusBadRequest, errResponseJSON, utils.RequestTypeTaskMetadata)

--- a/misc/v3-task-endpoint-validator/Dockerfile
+++ b/misc/v3-task-endpoint-validator/Dockerfile
@@ -14,5 +14,4 @@ FROM busybox:1.29.3
 
 MAINTAINER Amazon Web Services, Inc.
 COPY v3-task-endpoint-validator /
-
 ENTRYPOINT ["/v3-task-endpoint-validator"]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Makes Container Instance and Task Tags available to Task Metadata v3 endpoint on a different URL (/taskWithTags)
### Implementation details
<!-- How are the changes implemented? -->
-Updates the ECS API to get API calls for Tags.
-Passes container instance ARN to metadata setup to retrieve tags through ECS API calls
-Adds ECS Client to Docker Task State for ECS API calls
-Increments Functional Test timeout by 2 minutes
-Modifies V3TaskMetadataValidator image to accept argument to check Tags for functional test

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Progagating Container Instance and Task Tags to Task Metadata endpoint /taskWithTags
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
