### PR TITLE
set nvidia container runtime name

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ additional details on each available environment variable.
 | `ECS_SHARED_VOLUME_MATCH_FULL_CONFIG` | `true` | When `true`, ECS Agent will compare name, driver options, and labels to make sure volumes are identical. When `false`, Agent will short circuit shared volume comparison if the names match. This is the default Docker behavior. If a volume is shared across instances, this should be set to `false`. | `false` | `false`|
 | `ECS_CONTAINER_INSTANCE_PROPAGATE_TAGS_FROM` | `ec2_instance` | If `ec2_instance` is specified, existing tags defined on the container instance will be registered to Amazon ECS and will be discoverable using the `ListTagsForResource` API. Using this requires that the IAM role associated with the container instance have the `ec2:DescribeTags` action allowed. | `none` | `none` |
 | `ECS_CONTAINER_INSTANCE_TAGS` | `{"tag_key": "tag_val"}` | The metadata that you apply to the container instance to help you categorize and organize them. Each tag consists of a key and an optional value, both of which you define. Tag keys can have a maximum character length of 128 characters, and tag values can have a maximum length of 256 characters. If tags also exist on your container instance that are propagated using the `ECS_CONTAINER_INSTANCE_PROPAGATE_TAGS_FROM` parameter, those tags will be overwritten by the tags specified using `ECS_CONTAINER_INSTANCE_TAGS`. | `{}` | `{}` |
+| `ECS_NVIDIA_RUNTIME` | ecs-nvidia | The Nvidia Runtime to be used to pass Nvidia GPU devices to containers. | ecs-nvidia | Not Applicable |
+
 
 ### Persistence
 

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -70,7 +70,7 @@ const (
 
 	NvidiaVisibleDevicesEnvVar = "NVIDIA_VISIBLE_DEVICES"
 	GPUAssociationType         = "gpu"
-	NvidiaRuntime              = "nvidia"
+	NvidiaRuntime              = "ecs-nvidia"
 
 	arnResourceSections  = 2
 	arnResourceDelimiter = "/"

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -933,7 +933,10 @@ func (task *Task) dockerHostConfig(container *apicontainer.Container, dockerCont
 	}
 
 	if task.shouldRequireNvidiaRuntime(container) {
-		seelog.Debugf("Setting runtime as nvidia for container %s", container.Name)
+		if task.NvidiaRuntime == "" {
+			return nil, &apierrors.HostConfigError{"Runtime is not set for GPU containers"}
+		}
+		seelog.Debugf("Setting runtime as %s for container %s", task.NvidiaRuntime, container.Name)
 		hostConfig.Runtime = task.NvidiaRuntime
 	}
 

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -2391,3 +2391,33 @@ func TestDockerHostConfigRuntimeWithoutGPU(t *testing.T) {
 	dockerHostConfig, _ := testTask.DockerHostConfig(testTask.Containers[0], dockerMap(testTask), defaultDockerClientAPIVersion)
 	assert.Equal(t, "", dockerHostConfig.Runtime)
 }
+
+func TestDockerHostConfigNoNvidiaRuntime(t *testing.T) {
+	testTask := &Task{
+		Arn: "test",
+		Containers: []*apicontainer.Container{
+			{
+				Name:   "myName1",
+				Image:  "image:tag",
+				GPUIDs: []string{"gpu1"},
+			},
+		},
+		Associations: []Association{
+			{
+				Containers: []string{
+					"myName1",
+				},
+				Content: EncodedString{
+					Encoding: "base64",
+					Value:    "val",
+				},
+				Name: "gpu1",
+				Type: "gpu",
+			},
+		},
+	}
+
+	testTask.addGPUResource()
+	_, err := testTask.DockerHostConfig(testTask.Containers[0], dockerMap(testTask), defaultDockerClientAPIVersion)
+	assert.Error(t, err)
+}

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -929,11 +929,11 @@ func TestAddNamespaceSharingProvisioningDependency(t *testing.T) {
 			IPCMode: aTest.IPCMode,
 			Containers: []*apicontainer.Container{
 				{
-					Name: "c1",
+					Name:                      "c1",
 					TransitionDependenciesMap: make(map[apicontainerstatus.ContainerStatus]apicontainer.TransitionDependencySet),
 				},
 				{
-					Name: "c2",
+					Name:                      "c2",
 					TransitionDependenciesMap: make(map[apicontainerstatus.ContainerStatus]apicontainer.TransitionDependencySet),
 				},
 			},
@@ -1122,7 +1122,7 @@ func TestTaskFromACS(t *testing.T) {
 				},
 				Content: EncodedString{
 					Encoding: "base64",
-					Value: "val",
+					Value:    "val",
 				},
 				Name: "gpu1",
 				Type: "gpu",
@@ -1728,19 +1728,19 @@ func TestRecordExecutionStoppedAt(t *testing.T) {
 			essential:             true,
 			status:                apicontainerstatus.ContainerStopped,
 			executionStoppedAtSet: true,
-			msg: "essential container stopped should have executionStoppedAt set",
+			msg:                   "essential container stopped should have executionStoppedAt set",
 		},
 		{
 			essential:             false,
 			status:                apicontainerstatus.ContainerStopped,
 			executionStoppedAtSet: false,
-			msg: "non essential container stopped should not cause executionStoppedAt set",
+			msg:                   "non essential container stopped should not cause executionStoppedAt set",
 		},
 		{
 			essential:             true,
 			status:                apicontainerstatus.ContainerRunning,
 			executionStoppedAtSet: false,
-			msg: "essential non-stop status change should not cause executionStoppedAt set",
+			msg:                   "essential non-stop status change should not cause executionStoppedAt set",
 		},
 	}
 
@@ -2240,13 +2240,13 @@ func TestRequiresSSMSecretNoSecret(t *testing.T) {
 
 func TestAddGPUResource(t *testing.T) {
 	container := &apicontainer.Container{
-		Name:                      "myName",
-		Image:                     "image:tag",
+		Name:  "myName",
+		Image: "image:tag",
 	}
 
 	container1 := &apicontainer.Container{
-		Name:                      "myName1",
-		Image:                     "image:tag",
+		Name:  "myName1",
+		Image: "image:tag",
 	}
 
 	association := []Association{
@@ -2256,7 +2256,7 @@ func TestAddGPUResource(t *testing.T) {
 			},
 			Content: EncodedString{
 				Encoding: "base64",
-				Value: "val",
+				Value:    "val",
 			},
 			Name: "gpu1",
 			Type: "gpu",
@@ -2267,7 +2267,7 @@ func TestAddGPUResource(t *testing.T) {
 			},
 			Content: EncodedString{
 				Encoding: "base64",
-				Value: "val",
+				Value:    "val",
 			},
 			Name: "gpu2",
 			Type: "gpu",
@@ -2290,8 +2290,8 @@ func TestAddGPUResource(t *testing.T) {
 
 func TestAddGPUResourceWithInvalidContainer(t *testing.T) {
 	container := &apicontainer.Container{
-		Name:                      "myName",
-		Image:                     "image:tag",
+		Name:  "myName",
+		Image: "image:tag",
 	}
 
 	association := []Association{
@@ -2301,7 +2301,7 @@ func TestAddGPUResourceWithInvalidContainer(t *testing.T) {
 			},
 			Content: EncodedString{
 				Encoding: "base64",
-				Value: "val",
+				Value:    "val",
 			},
 			Name: "gpu1",
 			Type: "gpu",
@@ -2320,14 +2320,14 @@ func TestAddGPUResourceWithInvalidContainer(t *testing.T) {
 
 func TestPopulateGPUEnvironmentVariables(t *testing.T) {
 	container := &apicontainer.Container{
-		Name:                      "myName",
-		Image:                     "image:tag",
-		GPUIDs:                    []string{"gpu1", "gpu2"},
+		Name:   "myName",
+		Image:  "image:tag",
+		GPUIDs: []string{"gpu1", "gpu2"},
 	}
 
 	container1 := &apicontainer.Container{
-		Name:                      "myName1",
-		Image:                     "image:tag",
+		Name:  "myName1",
+		Image: "image:tag",
 	}
 
 	task := &Task{
@@ -2347,12 +2347,12 @@ func TestPopulateGPUEnvironmentVariables(t *testing.T) {
 
 func TestDockerHostConfigNvidiaRuntime(t *testing.T) {
 	testTask := &Task{
-		Arn:     "test",
+		Arn: "test",
 		Containers: []*apicontainer.Container{
 			{
-				Name:  "myName1",
-				Image: "image:tag",
-				GPUIDs:	[]string{"gpu1"},
+				Name:   "myName1",
+				Image:  "image:tag",
+				GPUIDs: []string{"gpu1"},
 			},
 		},
 		Associations: []Association{
@@ -2362,22 +2362,23 @@ func TestDockerHostConfigNvidiaRuntime(t *testing.T) {
 				},
 				Content: EncodedString{
 					Encoding: "base64",
-					Value: "val",
+					Value:    "val",
 				},
 				Name: "gpu1",
 				Type: "gpu",
 			},
 		},
+		NvidiaRuntime: config.DefaultNvidiaRuntime,
 	}
 
 	testTask.addGPUResource()
 	dockerHostConfig, _ := testTask.DockerHostConfig(testTask.Containers[0], dockerMap(testTask), defaultDockerClientAPIVersion)
-	assert.Equal(t, NvidiaRuntime, dockerHostConfig.Runtime)
+	assert.Equal(t, testTask.NvidiaRuntime, dockerHostConfig.Runtime)
 }
 
 func TestDockerHostConfigRuntimeWithoutGPU(t *testing.T) {
 	testTask := &Task{
-		Arn:     "test",
+		Arn: "test",
 		Containers: []*apicontainer.Container{
 			{
 				Name:  "myName1",

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -492,7 +492,7 @@ func environmentConfig() (Config, error) {
 		ContainerInstanceTags:              containerInstanceTags,
 		ContainerInstancePropagateTagsFrom: parseContainerInstancePropagateTagsFrom(),
 		GPUSupportEnabled:                  utils.ParseBool(os.Getenv("ECS_ENABLE_GPU_SUPPORT"), false),
-		NvidiaRuntime:                      parseNvidiaRuntime(),
+		NvidiaRuntime:                      os.Getenv("ECS_NVIDIA_RUNTIME"),
 	}, err
 }
 

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -107,6 +107,9 @@ const (
 
 	// DefaultTaskMetadataBurstRate is set to handle 60 burst requests at once
 	DefaultTaskMetadataBurstRate = 60
+
+	// DefaultNvidiaRuntime is the name of the runtime to pass Nvidia GPUs to containers
+	DefaultNvidiaRuntime = "ecs-nvidia"
 )
 
 const (
@@ -489,6 +492,7 @@ func environmentConfig() (Config, error) {
 		ContainerInstanceTags:              containerInstanceTags,
 		ContainerInstancePropagateTagsFrom: parseContainerInstancePropagateTagsFrom(),
 		GPUSupportEnabled:                  utils.ParseBool(os.Getenv("ECS_ENABLE_GPU_SUPPORT"), false),
+		NvidiaRuntime:                      parseNvidiaRuntime(),
 	}, err
 }
 

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -703,14 +703,6 @@ func TestGPUSupportEnabled(t *testing.T) {
 	assert.True(t, cfg.GPUSupportEnabled, "Wrong value for GPUSupportEnabled")
 }
 
-func TestEmptyNvidiaRuntime(t *testing.T) {
-	defer setTestRegion()()
-	defer setTestEnv("ECS_NVIDIA_RUNTIME", "")()
-	cfg, err := NewConfig(ec2.NewBlackholeEC2MetadataClient())
-	assert.NoError(t, err)
-	assert.Equal(t, DefaultNvidiaRuntime, cfg.NvidiaRuntime, "Wrong value for NvidiaRuntime")
-}
-
 func setTestRegion() func() {
 	return setTestEnv("AWS_DEFAULT_REGION", "us-west-2")
 }

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -112,6 +112,7 @@ func TestEnvironmentConfig(t *testing.T) {
 	defer setTestEnv("ECS_TASK_METADATA_RPS_LIMIT", "1000,1100")()
 	defer setTestEnv("ECS_SHARED_VOLUME_MATCH_FULL_CONFIG", "true")()
 	defer setTestEnv("ECS_ENABLE_GPU_SUPPORT", "true")()
+	defer setTestEnv("ECS_NVIDIA_RUNTIME", "nvidia")()
 	additionalLocalRoutesJSON := `["1.2.3.4/22","5.6.7.8/32"]`
 	setTestEnv("ECS_AWSVPC_ADDITIONAL_LOCAL_ROUTES", additionalLocalRoutesJSON)
 	setTestEnv("ECS_ENABLE_CONTAINER_METADATA", "true")
@@ -153,6 +154,7 @@ func TestEnvironmentConfig(t *testing.T) {
 	assert.Equal(t, 1100, conf.TaskMetadataBurstRate)
 	assert.True(t, conf.SharedVolumeMatchFullConfig, "Wrong value for SharedVolumeMatchFullConfig")
 	assert.True(t, conf.GPUSupportEnabled, "Wrong value for GPUSupportEnabled")
+	assert.Equal(t, "nvidia", conf.NvidiaRuntime)
 }
 
 func TestTrimWhitespaceWhenCreating(t *testing.T) {
@@ -699,6 +701,14 @@ func TestGPUSupportEnabled(t *testing.T) {
 	cfg, err := NewConfig(ec2.NewBlackholeEC2MetadataClient())
 	assert.NoError(t, err)
 	assert.True(t, cfg.GPUSupportEnabled, "Wrong value for GPUSupportEnabled")
+}
+
+func TestEmptyNvidiaRuntime(t *testing.T) {
+	defer setTestRegion()()
+	defer setTestEnv("ECS_NVIDIA_RUNTIME", "")()
+	cfg, err := NewConfig(ec2.NewBlackholeEC2MetadataClient())
+	assert.NoError(t, err)
+	assert.Equal(t, DefaultNvidiaRuntime, cfg.NvidiaRuntime, "Wrong value for NvidiaRuntime")
 }
 
 func setTestRegion() func() {

--- a/agent/config/config_unix.go
+++ b/agent/config/config_unix.go
@@ -73,6 +73,7 @@ func DefaultConfig() Config {
 		SharedVolumeMatchFullConfig:        false, // only requiring shared volumes to match on name, which is default docker behavior
 		ImagePullInactivityTimeout:         defaultImagePullInactivityTimeout,
 		ContainerInstancePropagateTagsFrom: ContainerInstancePropagateTagsFromNoneType,
+		NvidiaRuntime:                      DefaultNvidiaRuntime,
 	}
 }
 

--- a/agent/config/config_unix_test.go
+++ b/agent/config/config_unix_test.go
@@ -190,3 +190,11 @@ func setupFileConfiguration(t *testing.T, configContent string) string {
 
 	return file.Name()
 }
+
+func TestEmptyNvidiaRuntime(t *testing.T) {
+	defer setTestRegion()()
+	defer setTestEnv("ECS_NVIDIA_RUNTIME", "")()
+	cfg, err := NewConfig(ec2.NewBlackholeEC2MetadataClient())
+	assert.NoError(t, err)
+	assert.Equal(t, DefaultNvidiaRuntime, cfg.NvidiaRuntime, "Wrong value for NvidiaRuntime")
+}

--- a/agent/config/parse.go
+++ b/agent/config/parse.go
@@ -252,14 +252,6 @@ func parseContainerInstancePropagateTagsFrom() ContainerInstancePropagateTagsFro
 	}
 }
 
-func parseNvidiaRuntime() string {
-	runtime := os.Getenv("ECS_NVIDIA_RUNTIME")
-	if runtime != "" {
-		return runtime
-	}
-	return DefaultNvidiaRuntime
-}
-
 func parseEnvVariableUint16(envVar string) uint16 {
 	envVal := os.Getenv(envVar)
 	var var16 uint16

--- a/agent/config/parse.go
+++ b/agent/config/parse.go
@@ -252,6 +252,14 @@ func parseContainerInstancePropagateTagsFrom() ContainerInstancePropagateTagsFro
 	}
 }
 
+func parseNvidiaRuntime() string {
+	runtime := os.Getenv("ECS_NVIDIA_RUNTIME")
+	if runtime != "" {
+		return runtime
+	}
+	return DefaultNvidiaRuntime
+}
+
 func parseEnvVariableUint16(envVar string) uint16 {
 	envVal := os.Getenv(envVar)
 	var var16 uint16

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -253,4 +253,7 @@ type Config struct {
 	GPUSupportEnabled bool
 	// ImageCleanupExclusionList is the list of image names customers want to keep for their own use and delete automatically
 	ImageCleanupExclusionList []string
+
+	// NvidiaRuntime is the runtime to be used for passing Nvidia GPU devices to containers
+	NvidiaRuntime string `trim:"true"`
 }

--- a/agent/statemanager/state_manager.go
+++ b/agent/statemanager/state_manager.go
@@ -74,6 +74,7 @@ const (
 	// 19)
 	//   a) Add 'Associations' field to 'api.task.task'
 	//   b) Add 'GPUIDs' field to 'apicontainer.Container'
+	//   c) Add 'NvidiaRuntime' field to 'api.task.task'
 	ECSDataVersion = 19
 
 	// ecsDataFile specifies the filename in the ECS_DATADIR


### PR DESCRIPTION

### Summary
ECS will use the default runtime name "ecs-nvidia"
Making the runtime name configurable using environment variable `ECS_NVIDIA_RUNTIME` 

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
N/A

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
