### PR TITLE
gpu: removed unused fields

### DIFF
--- a/agent/gpu/nvidia_gpu_manager_unix.go
+++ b/agent/gpu/nvidia_gpu_manager_unix.go
@@ -35,18 +35,15 @@ type GPUManager interface {
 	GetDevices() []*ecs.PlatformDevice
 	SetDriverVersion(string)
 	GetDriverVersion() string
-	SetRuntimeVersion(string)
-	GetRuntimeVersion() string
 }
 
 // NvidiaGPUManager is used as a wrapper for NVML APIs and implements GPUManager
 // interface
 type NvidiaGPUManager struct {
-	DriverVersion       string                `json:"DriverVersion"`
-	NvidiaDockerVersion string                `json:"NvidiaDockerVersion"`
-	GPUIDs              []string              `json:"GPUIDs"`
-	GPUDevices          []*ecs.PlatformDevice `json:"-"`
-	lock                sync.RWMutex          `json:"-"`
+	DriverVersion string                `json:"DriverVersion"`
+	GPUIDs        []string              `json:"GPUIDs"`
+	GPUDevices    []*ecs.PlatformDevice `json:"-"`
+	lock          sync.RWMutex          `json:"-"`
 }
 
 const (
@@ -75,11 +72,10 @@ func (n *NvidiaGPUManager) Initialize() error {
 			return errors.Wrapf(err, "could not unmarshal GPU file content")
 		}
 		n.SetDriverVersion(nvidiaGPUInfo.GetDriverVersion())
-               nvidiaGPUInfo.lock.RLock()
-               gpuIDs := nvidiaGPUInfo.GetGPUIDsUnsafe()
-               nvidiaGPUInfo.lock.RUnlock()
+		nvidiaGPUInfo.lock.RLock()
+		gpuIDs := nvidiaGPUInfo.GetGPUIDsUnsafe()
+		nvidiaGPUInfo.lock.RUnlock()
 		n.SetGPUIDs(gpuIDs)
-		n.SetRuntimeVersion(nvidiaGPUInfo.GetRuntimeVersion())
 		n.SetDevices()
 	}
 	return nil
@@ -132,20 +128,6 @@ func (n *NvidiaGPUManager) GetDriverVersion() string {
 	n.lock.RLock()
 	defer n.lock.RUnlock()
 	return n.DriverVersion
-}
-
-// SetRuntimeVersion is a setter for nvidia docker version
-func (n *NvidiaGPUManager) SetRuntimeVersion(version string) {
-	n.lock.Lock()
-	defer n.lock.Unlock()
-	n.NvidiaDockerVersion = version
-}
-
-// GetRuntimeVersion is a getter for nvidia docker version
-func (n *NvidiaGPUManager) GetRuntimeVersion() string {
-	n.lock.RLock()
-	defer n.lock.RUnlock()
-	return n.NvidiaDockerVersion
 }
 
 func (n *NvidiaGPUManager) SetDevices() {

--- a/agent/gpu/nvidia_gpu_manager_unix_test.go
+++ b/agent/gpu/nvidia_gpu_manager_unix_test.go
@@ -46,7 +46,7 @@ func TestNvidiaGPUManagerInitialize(t *testing.T) {
 		return true
 	}
 	GetGPUInfoJSON = func() ([]byte, error) {
-		return []byte(`{"DriverVersion":"396.44","NvidiaDockerVersion":"1.0","GPUIDs":["id1","id2","id3"]}`), nil
+		return []byte(`{"DriverVersion":"396.44","GPUIDs":["id1","id2","id3"]}`), nil
 	}
 	defer func() {
 		GPUInfoFileExists = CheckForGPUInfoFile
@@ -56,7 +56,6 @@ func TestNvidiaGPUManagerInitialize(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"id1", "id2", "id3"}, nvidiaGPUManager.GetGPUIDsUnsafe())
 	assert.Equal(t, "396.44", nvidiaGPUManager.GetDriverVersion())
-	assert.Equal(t, "1.0", nvidiaGPUManager.GetRuntimeVersion())
 	assert.True(t, reflect.DeepEqual(devices, nvidiaGPUManager.GetDevices()))
 }
 
@@ -76,7 +75,6 @@ func TestNvidiaGPUManagerError(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, nvidiaGPUManager.GetGPUIDsUnsafe())
 	assert.Empty(t, nvidiaGPUManager.GetDriverVersion())
-	assert.Empty(t, nvidiaGPUManager.GetRuntimeVersion())
 }
 
 func TestSetGPUDevices(t *testing.T) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
nvidia docker version is not used anymore. removing relevant code. 

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
