### PR TITLE
v3 task metadata validator tests enhancement

### DIFF
--- a/misc/v3-task-endpoint-validator-windows/v3-task-endpoint-validator-windows.go
+++ b/misc/v3-task-endpoint-validator-windows/v3-task-endpoint-validator-windows.go
@@ -164,12 +164,11 @@ func verifyTaskMetadataResponse(taskMetadataRawMsg json.RawMessage) error {
 	json.Unmarshal(taskMetadataRawMsg, &taskMetadataResponseMap)
 
 	taskExpectedFieldEqualMap := map[string]interface{}{
-		"Cluster":       "ecs-functional-tests",
 		"DesiredStatus": "RUNNING",
 		"KnownStatus":   "RUNNING",
 	}
 
-	taskExpectedFieldNotEmptyArray := []string{"TaskARN", "Family", "Revision", "PullStartedAt", "PullStoppedAt", "Containers", "AvailabilityZone"}
+	taskExpectedFieldNotEmptyArray := []string{"Cluster", "TaskARN", "Family", "Revision", "PullStartedAt", "PullStoppedAt", "Containers", "AvailabilityZone"}
 
 	for fieldName, fieldVal := range taskExpectedFieldEqualMap {
 		if err = fieldEqual(taskMetadataResponseMap, fieldName, fieldVal); err != nil {

--- a/misc/v3-task-endpoint-validator/v3-task-endpoint-validator.go
+++ b/misc/v3-task-endpoint-validator/v3-task-endpoint-validator.go
@@ -180,12 +180,11 @@ func verifyTaskMetadataResponse(taskMetadataRawMsg json.RawMessage) error {
 	json.Unmarshal(taskMetadataRawMsg, &taskMetadataResponseMap)
 
 	taskExpectedFieldEqualMap := map[string]interface{}{
-		"Cluster":       "ecs-functional-tests",
 		"DesiredStatus": "RUNNING",
 		"KnownStatus":   "RUNNING",
 	}
 
-	taskExpectedFieldNotEmptyArray := []string{"TaskARN", "Family", "Revision", "PullStartedAt", "PullStoppedAt", "Containers", "AvailabilityZone"}
+	taskExpectedFieldNotEmptyArray := []string{"Cluster", "TaskARN", "Family", "Revision", "PullStartedAt", "PullStoppedAt", "Containers", "AvailabilityZone"}
 
 	for fieldName, fieldVal := range taskExpectedFieldEqualMap {
 		if err = fieldEqual(taskMetadataResponseMap, fieldName, fieldVal); err != nil {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

When you run the task on your own ec2 instance, and set `ECS_CLUSTER` to something other than `ecs-functional-tests`, the cluster that is running your func test will not be `ecs-functional-tests`, so we'd better not check the cluster name in the metadata tests.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [ ] Builds on Linux (`make release`)
- [ ] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [ ] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass


### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
