### PR TITLE
add functional tests for secrets phase 2

### DIFF
--- a/agent/functional_tests/testdata/taskdefinitions/secrets-environment-variables/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/secrets-environment-variables/task-definition.json
@@ -1,9 +1,9 @@
 {
-  "family": "ssm-integration",
+  "family": "secrets-integration",
   "executionRoleArn": "$$$EXECUTION_ROLE$$$",
   "containerDefinitions": [
     {
-      "name": "ssmsecrets-environment-variables",
+      "name": "secrets-environment-variables",
       "image": "busybox:latest",
       "cpu": 100,
       "memory": 100,
@@ -12,7 +12,7 @@
       "secrets": [
         {
           "name": "$$$SECRET_NAME$$$",
-          "valueFrom": "$$$SSM_PARAMETER_NAME$$$"
+          "valueFrom": "$$$SECRET_VALUE_FROM$$$"
         }
       ]
     }

--- a/agent/functional_tests/util/utils.go
+++ b/agent/functional_tests/util/utils.go
@@ -16,6 +16,7 @@
 package util
 
 import (
+	"context"
 	"crypto/md5"
 	"encoding/json"
 	"fmt"
@@ -29,8 +30,6 @@ import (
 	"testing"
 	"time"
 
-	"context"
-
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/sdkclientfactory"
 	"github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
 	"github.com/aws/amazon-ecs-agent/agent/handlers/v1"
@@ -38,6 +37,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	"github.com/aws/aws-sdk-go/service/iam"
@@ -103,6 +103,16 @@ func GetTaskDefinitionWithOverrides(name string, overrides map[string]string) (s
 		return "", err
 	}
 	return fmt.Sprintf("%s:%d", *registered.TaskDefinition.Family, *registered.TaskDefinition.Revision), nil
+}
+
+func IsCNPartition() bool {
+	partitions := endpoints.DefaultPartitions()
+	p, _ := endpoints.PartitionForRegion(partitions, *ECS.Config.Region)
+
+	if p.ID() == endpoints.AwsCnPartition().ID() {
+		return true
+	}
+	return false
 }
 
 type TestAgent struct {


### PR DESCRIPTION
### Summary
Add functional tests for secrets phase 2 and add logic to skip func tests related to secrets manager in China partition.

### Implementation details
1. Add functional test case TestASMSecretsARN to test secret integrating with AWS secrets manager. So far, the test will not run in Octokitten since it requires the agent version 1.23.0. However, when I tested, I removed this requirement and the test successfully ran.

2. Add logic to detect whether the tests are running in the China partition, and skip the tests related to AWS secrets manager if it is. I launched an instance in cn-north-1 region and already tested there. 

### Testing
- [ ] Builds on Linux (`make release`)
- [ ] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [ ] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

The failed test is TestOOMContainer, which is a flaky test
New tests cover the changes: yes

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
