### PR TITLE
third-party update for docker/distribution (tt/0157225015)

### DIFF
--- a/THIRD-PARTY
+++ b/THIRD-PARTY
@@ -3,6 +3,7 @@
 ** github.com/containerd/continuity; version 1bed1ecb1dc42d8f4d2ac8c23e5cac64749e82c9 -- https://github.com/containerd/continuity
 ** github.com/containernetworking/cni; version v0.5.2 -- https://github.com/containernetworking/cni
 ** github.com/coreos/go-systemd; version 24036eb3df68550d24a2736c5d013f4e83366866 -- https://github.com/coreos/go-systemd
+** github.com/docker/distribution; version 749f6afb4572201e3c37325d0ffedb6f32be8950 -- https://www.docker.com
 ** github.com/docker/docker; version e4d0fe84f9ea88b0e0cfd847412c9f29442cc62d -- https://github.com/moby/moby
 ** github.com/docker/go-connections; version v0.3.0 -- https://github.com/docker/go-connections
 ** github.com/docker/go-units; version v0.3.2 -- https://github.com/docker/go-units
@@ -213,6 +214,8 @@ Copyright (c) 2016-2017 the containerd authors
 Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
 * For github.com/coreos/go-systemd see also this required NOTICE:
 Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+* For github.com/docker/distribution see also this required NOTICE:
+Copyright 2013-2017 Docker, Inc.
 * For github.com/docker/docker see also this required NOTICE:
 Copyright 2013-2017 Docker, Inc.
 * For github.com/docker/go-connections see also this required NOTICE:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
updating third-party license reference for the docker SDK distribution (see tt/0157225015)

### Implementation details
text file update

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [ ] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [ ] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: N/A

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
