### PR TITLE
gpu functional testing

### DIFF
--- a/agent/engine/engine_unix_integ_test.go
+++ b/agent/engine/engine_unix_integ_test.go
@@ -78,7 +78,7 @@ const (
 
 var (
 	endpoint            = utils.DefaultIfBlank(os.Getenv(DockerEndpointEnvVariable), DockerDefaultEndpoint)
-	TestGPUInstanceType = []string{"p2", "p3"}
+	TestGPUInstanceType = []string{"p2", "p3", "g3"}
 )
 
 func createTestHealthCheckTask(arn string) *apitask.Task {
@@ -120,29 +120,29 @@ func createNamespaceSharingTask(arn, pidMode, ipcMode, testImage string, theComm
 		DesiredStatusUnsafe: apitaskstatus.TaskRunning,
 		Containers: []*apicontainer.Container{
 			&apicontainer.Container{
-				Name:                "container0",
-				Image:               testImage,
-				DesiredStatusUnsafe: apicontainerstatus.ContainerRunning,
-				CPU:                 100,
-				Memory:              80,
+				Name:                      "container0",
+				Image:                     testImage,
+				DesiredStatusUnsafe:       apicontainerstatus.ContainerRunning,
+				CPU:                       100,
+				Memory:                    80,
 				TransitionDependenciesMap: make(map[apicontainerstatus.ContainerStatus]apicontainer.TransitionDependencySet),
 			},
 			&apicontainer.Container{
-				Name:                "container1",
-				Image:               testBusyboxImage,
-				Command:             theCommand,
-				DesiredStatusUnsafe: apicontainerstatus.ContainerRunning,
-				CPU:                 100,
-				Memory:              80,
+				Name:                      "container1",
+				Image:                     testBusyboxImage,
+				Command:                   theCommand,
+				DesiredStatusUnsafe:       apicontainerstatus.ContainerRunning,
+				CPU:                       100,
+				Memory:                    80,
 				TransitionDependenciesMap: make(map[apicontainerstatus.ContainerStatus]apicontainer.TransitionDependencySet),
 			},
 			&apicontainer.Container{
-				Name:                "container2",
-				Image:               testBusyboxImage,
-				Command:             theCommand,
-				DesiredStatusUnsafe: apicontainerstatus.ContainerRunning,
-				CPU:                 100,
-				Memory:              80,
+				Name:                      "container2",
+				Image:                     testBusyboxImage,
+				Command:                   theCommand,
+				DesiredStatusUnsafe:       apicontainerstatus.ContainerRunning,
+				CPU:                       100,
+				Memory:                    80,
 				TransitionDependenciesMap: make(map[apicontainerstatus.ContainerStatus]apicontainer.TransitionDependencySet),
 			},
 		},

--- a/agent/functional_tests/testdata/taskdefinitions/nvidia-gpu/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/nvidia-gpu/task-definition.json
@@ -1,0 +1,14 @@
+{
+    "family": "ecsftest-nvidia-gpu",
+    "containerDefinitions": [{
+      "image": "nvidia/cuda:9.0-base",
+      "name": "exit",
+      "cpu": 100,
+      "memory": 100,
+      "resourceRequirements": [{
+        "type":"GPU",
+        "value": "2"
+      }],
+      "command": ["sh", "-c", "nvidia-smi -L | wc -l | grep -w \"2\" && exit 42 || exit 1"]
+    }]
+}

--- a/agent/functional_tests/tests/functionaltests_unix_test.go
+++ b/agent/functional_tests/tests/functionaltests_unix_test.go
@@ -28,8 +28,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/amazon-ecs-agent/agent/ec2"
 	ecsapi "github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
 	. "github.com/aws/amazon-ecs-agent/agent/functional_tests/util"
+	"github.com/aws/amazon-ecs-agent/agent/gpu"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -1269,4 +1271,46 @@ func TestSSMSecretsEncryptedASMSecrets(t *testing.T) {
 	require.NoError(t, err)
 	exitCode, _ := task.ContainerExitcode("ssmsecrets-environment-variables")
 	assert.Equal(t, 42, exitCode, fmt.Sprintf("Expected exit code of 42; got %d", exitCode))
+}
+
+// Note: This functional test requires ECS GPU instance which has atleast 2 GPUs
+func TestRunGPUTask(t *testing.T) {
+	gpuInstances := []string{"p2", "p3", "g3"}
+	var isGPUInstance bool
+	iid, _ := ec2.NewEC2MetadataClient(nil).InstanceIdentityDocument()
+	for _, gpuInstance := range gpuInstances {
+		if strings.HasPrefix(iid.InstanceType, gpuInstance) {
+			// GPU test should only run on p2/p3/g3 ECS instances
+			isGPUInstance = true
+			break
+		}
+	}
+	if !isGPUInstance {
+		t.Skip("Skipped because the instance type is not a supported GPU instance type")
+	}
+	if _, err := os.Stat(gpu.NvidiaGPUInfoFilePath); os.IsNotExist(err) {
+		t.Skip("Skipped because GPU information file does not exist")
+	}
+	agent := RunAgent(t, &AgentOptions{
+		ExtraEnvironment: map[string]string{
+			// required environment variable to register with GPU devices
+			"ECS_ENABLE_GPU_SUPPORT": "true",
+		},
+		GPUEnabled: true,
+	})
+	defer agent.Cleanup()
+	// TODO: after release, change it to 1.24.0
+	agent.RequireVersion(">=1.22.0")
+
+	testTask, err := agent.StartTask(t, "nvidia-gpu")
+	require.NoError(t, err)
+
+	err = testTask.WaitStopped(2 * time.Minute)
+	require.NoError(t, err)
+
+	if exit, ok := testTask.ContainerExitcode("exit"); !ok || exit != 42 {
+		t.Errorf("Expected exit to exit with 42; actually exited (%v) with %v", ok, exit)
+	}
+
+	defer agent.SweepTask(testTask)
 }

--- a/agent/functional_tests/util/utils.go
+++ b/agent/functional_tests/util/utils.go
@@ -126,6 +126,7 @@ type AgentOptions struct {
 	ContainerLinks   []string
 	PortBindings     map[nat.Port]map[string]string
 	EnableTaskENI    bool
+	GPUEnabled       bool
 }
 
 // verifyIntrospectionAPI verifies that we can talk to the agent's introspection http endpoint.

--- a/agent/functional_tests/util/utils_unix.go
+++ b/agent/functional_tests/util/utils_unix.go
@@ -28,6 +28,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/sdkclientfactory"
 	"github.com/aws/amazon-ecs-agent/agent/ec2"
 	"github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
+	"github.com/aws/amazon-ecs-agent/agent/gpu"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -274,6 +275,13 @@ func (agent *TestAgent) getBindMounts() []string {
 	binds = append(binds, dockerEndpoint+":"+dockerEndpoint)
 	binds = append(binds, hostConfigDir+":"+configDirectory)
 	binds = append(binds, hostCacheDir+":"+cacheDirectory)
+
+	if agent.Options != nil {
+		if agent.Options.GPUEnabled {
+			// bind mount the GPU info directory on the instance created by init
+			binds = append(binds, gpu.GPUInfoDirPath+":"+gpu.GPUInfoDirPath)
+		}
+	}
 
 	return binds
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
A simple GPU functional test that verifies if the right number of GPU devices are assigned to the task's container 
NOTE: this cannot be merged until backend changes are in prod(test passes in gamma)

### Implementation details
Check if instance is of the type p2/p3/g3, set the config var `ECS_ENABLE_GPU_SUPPORT` and bind mount the gpu info file in the instance created by init to the functional test's agent container. 
Verify if two gpus are assigned to an nvidia cuda container.  **

** For the test, use a GPU instance that has atleast 2 Nvidia GPUs

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

Ran the test manually on p2,p3,g3 instances and it passes

Test output:
```
$ go test -v -tags functional -timeout 5m ./agent/functional_tests/... -run=TestRunGPUTask
?   	github.com/aws/amazon-ecs-agent/agent/functional_tests/generators	[no test files]
=== RUN   TestRunGPUTask
--- PASS: TestRunGPUTask (17.16s)
	utils_unix.go:130: Created directory /tmp/ecs_integ_testdata287691962 to store test data in
	utils_unix.go:146: Launching agent with image: amazon/amazon-ecs-agent:make
	utils_unix.go:233: Agent started as docker container: e759828da041456bbe2e9a02136a8eca47b490577b35a96306b3aeb65fe8a4ef
	utils.go:165: Found agent metadata: {Cluster:ecs-functional-tests ContainerInstanceArn:0xc420241630 Version:Amazon ECS Agent - v1.23.0 (*4451de4b)}
	utils.go:186: Task definition: ecsftest-nvidia-gpu-a56e78224672d662fdd4b5afea8cda9d:1
	utils.go:206: Started task: arn:aws:ecs:us-west-2:task/7bac22fc-ff75-41cf-a5e4-79fb577bec88
	utils.go:175: Removing test dir for passed test /tmp/ecs_integ_testdata287691962
PASS
ok  	github.com/aws/amazon-ecs-agent/agent/functional_tests/tests	17.272s
```

New tests cover the changes: yes

### Description for the changelog
N/A

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
