### PR TITLE
use 'nvidia' as default nvidia runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ additional details on each available environment variable.
 | `ECS_SHARED_VOLUME_MATCH_FULL_CONFIG` | `true` | When `true`, ECS Agent will compare name, driver options, and labels to make sure volumes are identical. When `false`, Agent will short circuit shared volume comparison if the names match. This is the default Docker behavior. If a volume is shared across instances, this should be set to `false`. | `false` | `false`|
 | `ECS_CONTAINER_INSTANCE_PROPAGATE_TAGS_FROM` | `ec2_instance` | If `ec2_instance` is specified, existing tags defined on the container instance will be registered to Amazon ECS and will be discoverable using the `ListTagsForResource` API. Using this requires that the IAM role associated with the container instance have the `ec2:DescribeTags` action allowed. | `none` | `none` |
 | `ECS_CONTAINER_INSTANCE_TAGS` | `{"tag_key": "tag_val"}` | The metadata that you apply to the container instance to help you categorize and organize them. Each tag consists of a key and an optional value, both of which you define. Tag keys can have a maximum character length of 128 characters, and tag values can have a maximum length of 256 characters. If tags also exist on your container instance that are propagated using the `ECS_CONTAINER_INSTANCE_PROPAGATE_TAGS_FROM` parameter, those tags will be overwritten by the tags specified using `ECS_CONTAINER_INSTANCE_TAGS`. | `{}` | `{}` |
-| `ECS_NVIDIA_RUNTIME` | ecs-nvidia | The Nvidia Runtime to be used to pass Nvidia GPU devices to containers. | ecs-nvidia | Not Applicable |
+| `ECS_NVIDIA_RUNTIME` | nvidia | The Nvidia Runtime to be used to pass Nvidia GPU devices to containers. | nvidia | Not Applicable |
 
 
 ### Persistence

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -109,7 +109,7 @@ const (
 	DefaultTaskMetadataBurstRate = 60
 
 	// DefaultNvidiaRuntime is the name of the runtime to pass Nvidia GPUs to containers
-	DefaultNvidiaRuntime = "ecs-nvidia"
+	DefaultNvidiaRuntime = "nvidia"
 )
 
 const (


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
fallback to using 'nvidia' as the container runtime for GPU containers

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [ ] Builds on Linux (`make release`)
- [ ] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [ ] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
