### PR TITLE
Updating a functional test

### DIFF
--- a/agent/functional_tests/testdata/taskdefinitions/hostname-awsvpc/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/hostname-awsvpc/task-definition.json
@@ -6,7 +6,7 @@
         "name": "exit",
         "image": "127.0.0.1:51670/ubuntu:latest",
         "cpu": 100,
-        "command":  [ "sh", "-c", "hostname | grep \"ip-[0-9]*-[0-9]*-[0-9]*-[0-9]*.*.compute.internal\"; if [ $? -eq 0 ]; then exit 0; else exit 1; fi" ],
+        "command":  [ "sh", "-c", "hostname | grep \"ip-[0-9]*-[0-9]*-[0-9]*-[0-9]*.*.internal\"; if [ $? -eq 0 ]; then exit 0; else exit 1; fi" ],
         "memory": 100,
         "essential": true
       }]


### PR DESCRIPTION
Its possible to get an internal IP address that looks like this:

```
ip-10-0-1-1.ec2.internal
```

... which will completely fill the old regex check.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
