### PR TITLE
task manager: fix the edge case for stopping container

### DIFF
--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -983,7 +983,14 @@ func (mtask *managedTask) containerNextState(container *apicontainer.Container) 
 			// Agent.
 			// 2. The task has already been cleaned up, in this case any stopped container
 			// will not be stopped by Agent when they come back.
-			if container.GetAppliedStatus() == apicontainerstatus.ContainerRunning {
+			//
+			// If the container's AppliedStatus is stopped, we shouldn't mark it as stopped
+			// for the same reason. This could happen when we failed to start container because of
+			// StartContainer times out, Agent will schedule a StopContainer API call, that API call
+			// could change the applied status to stopped, and we want to wait for the
+			// StopContainer API call to be finished.
+			if container.GetAppliedStatus() == apicontainerstatus.ContainerRunning ||
+				container.GetAppliedStatus() == apicontainerstatus.ContainerStopped {
 				nextState = apicontainerstatus.ContainerStatusNone
 			}
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR fixes another edge case in our run task workflow. When the StartContainer API call is timed out, Agent will make [StopContainer API call](https://github.com/aws/amazon-ecs-agent/blob/master/agent/engine/task_manager.go#L661), in this case we shouldn't mark the container's known status as stopped directly, we should wait for the StopContainer API call to be finished.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [ ] Builds on Linux (`make release`)
- [ ] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [ ] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
* Bug - Fixed a bug where container were marked as stopped before the StopContainer API is finished 

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
