### PR TITLE
Fixing agent functional tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,7 @@ test-in-docker:
 	docker run --net=none -v "$(PWD):/go/src/github.com/aws/amazon-ecs-agent" --privileged "amazon/amazon-ecs-agent-test:make"
 
 run-functional-tests: testnnp test-registry ecr-execution-role-image telemetry-test-image
-	. ./scripts/shared_env && go test -tags functional -timeout=34m -v ./agent/functional_tests/...
+	. ./scripts/shared_env && go test -tags functional -timeout=40m -v ./agent/functional_tests/...
 
 .PHONY: build-image-for-ecr ecr-execution-role-image-for-upload upload-images replicate-images
 

--- a/agent/functional_tests/generators/simpletests.go
+++ b/agent/functional_tests/generators/simpletests.go
@@ -64,6 +64,10 @@ import (
 
 // Test{{ $el.Name }} {{ $el.Description }}
 func Test{{ $el.Name }}(t *testing.T) {
+	{{if $el.MinimumMemory}}
+	// Test only available on instance with total memory more than {{ $el.MinimumMemory }} MB
+	RequireMinimumMemory(t, {{ $el.MinimumMemory }})
+	{{end}}
 	{{if $el.DockerVersion}}
 	// Test only available for docker version {{ $el.DockerVersion }}
 	RequireDockerVersion(t, "{{ $el.DockerVersion }}") 
@@ -153,6 +157,7 @@ func main() {
 		DockerVersion  string
 		Daemon         bool
 		AwsvpcMode     string
+		MinimumMemory  string
 	}
 
 	types := []struct {

--- a/agent/functional_tests/testdata/simpletests_unix/parallel-pull.json
+++ b/agent/functional_tests/testdata/simpletests_unix/parallel-pull.json
@@ -6,5 +6,6 @@
   "DockerVersion": ">=1.11.1",
   "Timeout": "1m",
   "Count": 4,
-  "Daemon": true
+  "Daemon": true,
+  "MinimumMemory": "1300"
 }

--- a/agent/functional_tests/testdata/simpletests_unix/shmsize.json
+++ b/agent/functional_tests/testdata/simpletests_unix/shmsize.json
@@ -6,5 +6,6 @@
   "Timeout": "2m",
   "ExitCodes": {
     "exit": 42
-  }
+  },
+  "MinimumMemory": "650"
 }

--- a/agent/functional_tests/testdata/simpletests_unix/tmpfs.json
+++ b/agent/functional_tests/testdata/simpletests_unix/tmpfs.json
@@ -6,5 +6,6 @@
   "Timeout": "2m",
   "ExitCodes": {
     "exit": 42
-  }
+  },
+  "MinimumMemory": "650"
 }

--- a/agent/functional_tests/testdata/taskdefinitions/oom-container/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/oom-container/task-definition.json
@@ -6,7 +6,7 @@
     "name": "error",
     "cpu": 1,
     "image": "127.0.0.1:51670/python:2",
-    "command": ["python", "-c", "foo=' '*1024*1024*1024; import time; time.sleep(10)"]
+    "command": ["python", "-c", "foo=' '*1024*1024*512; import time; time.sleep(10)"]
   }]
 }
 

--- a/agent/functional_tests/testdata/taskdefinitions/oom-task/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/oom-task/task-definition.json
@@ -1,12 +1,12 @@
 {
   "family": "ecsftest-oom-task",
-  "memory": "64",
+  "memory": "10",
   "containerDefinitions": [{
     "essential": true,
     "name": "error",
     "cpu": 1,
     "image": "127.0.0.1:51670/python:2",
-    "command": ["python", "-c", "foo=' '*1024*1024*1024; import time; time.sleep(10)"]
+    "command": ["python", "-c", "foo=' '*1024*1024*512; import time; time.sleep(10)"]
   }]
 }
 

--- a/agent/functional_tests/tests/functionaltests_unix_test.go
+++ b/agent/functional_tests/tests/functionaltests_unix_test.go
@@ -94,6 +94,9 @@ func TestRunManyTasks(t *testing.T) {
 
 // TestOOMContainer verifies that an OOM container returns an error
 func TestOOMContainer(t *testing.T) {
+	// oom container task requires 500MB of memory; requires a bit more to be stable
+	RequireMinimumMemory(t, 600)
+
 	RequireDockerVersion(t, "<1.9.0,>1.9.1") // https://github.com/docker/docker/issues/18510
 	agent := RunAgent(t, nil)
 	defer agent.Cleanup()
@@ -106,6 +109,9 @@ func TestOOMContainer(t *testing.T) {
 
 // TestOOMTask verifies that a task with a memory limit returns an error
 func TestOOMTask(t *testing.T) {
+	// oom container task requires 500MB of memory; requires a bit more to be stable
+	RequireMinimumMemory(t, 600)
+
 	agent := RunAgent(t, nil)
 	defer agent.Cleanup()
 

--- a/agent/functional_tests/tests/generated/simpletests_unix/simpletests_generated_unix_test.go
+++ b/agent/functional_tests/tests/generated/simpletests_unix/simpletests_generated_unix_test.go
@@ -814,6 +814,9 @@ func TestNetworkLink(t *testing.T) {
 // TestParallelPull check docker pull in parallel works for docker >= 1.11.1
 func TestParallelPull(t *testing.T) {
 
+	// Test only available on instance with total memory more than 1300 MB
+	RequireMinimumMemory(t, 1300)
+
 	// Test only available for docker version >=1.11.1
 	RequireDockerVersion(t, ">=1.11.1")
 
@@ -1053,6 +1056,9 @@ func TestSecurityOptNoNewPrivileges(t *testing.T) {
 // TestShmSize checks that setting size of shared memory volume works
 func TestShmSize(t *testing.T) {
 
+	// Test only available on instance with total memory more than 650 MB
+	RequireMinimumMemory(t, 650)
+
 	// Parallel is opt in because resource constraints could cause test failures
 	// on smaller instances
 	if os.Getenv("ECS_FUNCTIONAL_PARALLEL") != "" {
@@ -1276,6 +1282,9 @@ func TestTaskLocalVolume(t *testing.T) {
 
 // TestTmpfs checks that adding tmpfs volume works
 func TestTmpfs(t *testing.T) {
+
+	// Test only available on instance with total memory more than 650 MB
+	RequireMinimumMemory(t, 650)
 
 	// Parallel is opt in because resource constraints could cause test failures
 	// on smaller instances

--- a/agent/functional_tests/util/utils.go
+++ b/agent/functional_tests/util/utils.go
@@ -43,14 +43,15 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/docker/docker/api/types"
 	docker "github.com/docker/docker/client"
+	"github.com/docker/docker/pkg/system"
 	"github.com/docker/go-connections/nat"
-
 	"github.com/pkg/errors"
 )
 
 const (
 	arnResourceSections  = 2
 	arnResourceDelimiter = "/"
+	bytePerMegabyte      = 1024 * 1024
 )
 
 // GetTaskDefinition is a helper that provies the family:revision for the named
@@ -617,6 +618,18 @@ func RequireDockerVersion(t *testing.T, selector string) {
 
 	if !match {
 		t.Skipf("Skipping test; requires %v, but version is %v", selector, dockerVersion)
+	}
+}
+
+func RequireMinimumMemory(t *testing.T, minimumMemoryInMegaBytes int) {
+	memInfo, err := system.ReadMemInfo()
+	if err != nil {
+		t.Fatalf("Could not check system memory info before checking minimum memory requirement: %v", err)
+	}
+
+	totalMemory := int(memInfo.MemTotal / bytePerMegabyte)
+	if totalMemory < minimumMemoryInMegaBytes {
+		t.Skipf("Skipping the test since it requires %d MB of memory. Total memory on the instance: %d MB", minimumMemoryInMegaBytes, totalMemory)
 	}
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Agent functional tests have a large failure rate when running on a large scale, with a variety of instance types and regions. This PR is to fix a couple of problematic functional tests so that we can have a better passing rate.

### Note
Apart from fixing the existing tests, this pr also bumps functional test timeout to 36m which seems to be a bare minimum if we want to have a decent passing rate when running across different instance types and regions. And this doesn't consider the fact that we are adding another telemetry test that takes at least 4 minutes in another pr (https://github.com/aws/amazon-ecs-agent/pull/1646). We will likely need to increase the timeout to 40m, but i'm publishing the pr as 36m first.

Update: now that #1646 is merged, i'm bumping timeout to 40m

### Implementation details
<!-- How are the changes implemented? -->
Changes to functional tests are outlined below:
#### TestContainerInstanceTags
Tagging feature requires the account to enable long arn, so what this test was doing before is to enable long arn for the account at the beginning of the test, and disable it at the end. However, this introduces a race condition when multiple test runs happen at the same time, because each of them can be enabling/disabling long arn for the same account which causes the test to fail. I fix it by removing the disabling long arn action at the end, so essentially this change makes all tests to be tested with long arn enabled now.

#### TestTelemetry
TestTelemetry was having two kinds of problem: (1) It requires 2GB of memory so we will fail to start the task on the instance types that don't have that much of memory; (2) It specifies the cpu shares to be 25% of total cpu resources on the instance, however there's a valid range for this parameter and we exceed the range on certain instance types because we always use 25% cpu.
This pr fixes (1) by enforcing a minimum memory requirement (skipping the test if there's not enough memory), and (2) by bounding the value of the cpu parameter.

#### TestParallelPull, TestShmSize, TestTmpfs
Those tests were failing because of memory constraint too. Fixed by enforcing minimum memory requirement.

#### TestAgentIntrospectionValidator

TestAgentIntrospectionValidator fails occasionally because of a known race condition. The volumes field in metadata response is not immediately available to the container when it just starts, but only sometimes after. The test runs a validator inside the container which checks the volumes field in metadata response, and when the volumes field is not available, the test will fail. I was trying to fix it before by letting the validator sleep for 3 seconds before checking (https://github.com/aws/amazon-ecs-agent/pull/1718), but that doesn't seem to be a good approach because we'd always spend 3 seconds on it. This pr removes the dummy sleep and refactors the verification logic into the existing retry loop so we can retry when volumes field is not presented and verification fails, which seems to be a better approach.

#### TestOOMContainer
This test fails occasionally on small instance types where we expect the container to fail with OOM reason, but instead it fails with general failure. The container was trying to consume 1GB of memory, which exceeds the total memory available on small instances. In that case it seems that it's possible for the container to use up all the memory on the instance and fails before it gets killed by OOM killer and gets a OOM failure reason. The pr fixes this by enforcing a minimum memory requirement, and also reduces the memory that the container tries to consume from 1GB to 0.5GB so that we can test this on micro instances.

#### TestOOMTask
This test suffers from same problem that TestOOMContainer has, so it has TestOOMContainer's fix. Additionally, the test sometimes fails where the container didn't get killed and finished successfully instead. This seems to cause by the fact that the container may use some amount of swap memory and didn't exceed memory usage enforced by cgroup, because i observe from the logs that when the container gets killed because of oom, it's already using some of the swap memory:
```
  Dec 20 20:27:50 ip-10-0-105-75 kernel: Task in /ecs/cd954ebc-c18d-4e50-bb87-d2610194b686/            6fde705f6715c5c398a2a714146c80f728cddeb6059190cb95b2bda3b0d76346 killed as a result of limit of /    ecs/cd954ebc-c18d-4e50-bb87-d2610194b686/                                                            6fde705f6715c5c398a2a714146c80f728cddeb6059190cb95b2bda3b0d76346
  Dec 20 20:27:50 ip-10-0-105-75 kernel: memory: usage 10240kB, limit 10240kB, failcnt 1686
  Dec 20 20:27:50 ip-10-0-105-75 kernel: memory+swap: usage 20376kB, limit 20480kB, failcnt 9
  Dec 20 20:27:50 ip-10-0-105-75 kernel: kmem: usage 840kB, limit 9007199254740988kB, failcnt 0
```
This pr fixes this by reducing the memory value in the task definition for this test, which seems to make it more stable now.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
