### PR TITLE
Fetch AMI ID dynamically

### DIFF
--- a/scripts/ec2_stage_arm.sh
+++ b/scripts/ec2_stage_arm.sh
@@ -19,7 +19,6 @@ DRYRUN=true
 
 AWS_PROFILE=""
 AWS_REGION="us-east-1"
-AMI_ID="ami-053b2a8c2f3e87928" #amzn2-ami-hvm-2.0.20181020.0-aarch64-gp2
 ARTIFACT_BUCKET=""
 SOURCE_BUCKET=""
 KEY_NAME=""
@@ -161,6 +160,23 @@ echo "======================================================"
 echo "${userdata}"
 echo "======================================================"
 echo
+
+# Install jq
+add-apt-repository ppa:eugenesan/ppa
+apt-get update
+apt-get install jq
+
+# Fetch the Arm AMI Id
+AMI_ID=$(aws ec2 describe-images \
+    --region "${AWS_REGION}" \
+    --owners amazon \
+    --filters "Name=architecture,Values=arm64" \
+    "Name=root-device-type,Values=ebs" \
+    "Name=state,Values=available" \
+    "Name=name,Values=amzn2-ami-hvm-*" \
+    --query 'Images[].ImageId' | jq '.[0]' |  sed 's/"//g')
+
+echo "AMI ID: ${AMI_ID}"
 
 ec2_instance_id=$(dryval aws ${profile} "--region=${AWS_REGION}" \
 	ec2 run-instances \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Currently AMI Id used for building Arm artifact is hardcoded in the build script.  This AMI ID may change and is region dependent. 
 
This change fetches the Arm AMI Id dynamically such that the build script can be run from any account and region. 

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [ ] Builds on Linux (`make release`)
- [ ] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [ ] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
