### PR TITLE
fixing telemetry polling test

### DIFF
--- a/agent/functional_tests/util/utils.go
+++ b/agent/functional_tests/util/utils.go
@@ -46,6 +46,7 @@ import (
 	"github.com/docker/docker/pkg/system"
 	"github.com/docker/go-connections/nat"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -602,19 +603,14 @@ func (task *TestTask) GetAttachmentInfo() ([]*ecs.KeyValuePair, error) {
 func RequireDockerVersion(t *testing.T, selector string) {
 	ctx := context.TODO()
 	dockerClient, err := docker.NewClientWithOpts(docker.WithVersion(sdkclientfactory.GetDefaultVersion().String()))
-	if err != nil {
-		t.Fatalf("Could not get docker client to check version: %v", err)
-	}
-	version, err := dockerClient.ServerVersion(ctx)
-	if err != nil {
-		t.Fatalf("Could not get docker version: %v", err)
-	}
-	dockerVersion := version.Version
+	require.NoError(t, err, "Could not get docker client to check version")
 
+	version, err := dockerClient.ServerVersion(ctx)
+	require.NoError(t, err, "Could not get docker version")
+
+	dockerVersion := version.Version
 	match, err := utils.Version(dockerVersion).Matches(selector)
-	if err != nil {
-		t.Fatalf("Could not check docker version to match required: %v", err)
-	}
+	require.NoError(t, err, "Could not check docker version to match required")
 
 	if !match {
 		t.Skipf("Skipping test; requires %v, but version is %v", selector, dockerVersion)
@@ -623,9 +619,7 @@ func RequireDockerVersion(t *testing.T, selector string) {
 
 func RequireMinimumMemory(t *testing.T, minimumMemoryInMegaBytes int) {
 	memInfo, err := system.ReadMemInfo()
-	if err != nil {
-		t.Fatalf("Could not check system memory info before checking minimum memory requirement: %v", err)
-	}
+	require.NoError(t, err, "Could not check system memory info before checking minimum memory requirement")
 
 	totalMemory := int(memInfo.MemTotal / bytePerMegabyte)
 	if totalMemory < minimumMemoryInMegaBytes {
@@ -636,13 +630,11 @@ func RequireMinimumMemory(t *testing.T, minimumMemoryInMegaBytes int) {
 func RequireDockerAPIVersion(t *testing.T, selector string) {
 	ctx := context.TODO()
 	dockerClient, err := docker.NewClientWithOpts(docker.WithVersion(sdkclientfactory.GetDefaultVersion().String()))
-	if err != nil {
-		t.Fatalf("Could not get docker client to check version: %v", err)
-	}
+	require.NoError(t, err, "Could not get docker client to check version")
+
 	version, err := dockerClient.ServerVersion(ctx)
-	if err != nil {
-		t.Fatalf("Could not get docker version: %v", err)
-	}
+	require.NoError(t, err, "Could not get docker version")
+
 	apiVersion := version.APIVersion
 	// adding zero patch to use semver comparator
 	// TODO: Implement non-semver comparator


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
fixing the new telemetry test with stats polling to require valid memory and cpu.

### Implementation details
see https://github.com/aws/amazon-ecs-agent/pull/1751 for more details

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [ ] Builds on Linux (`make release`)
- [ ] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [ ] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: N/A

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
