### PR TITLE
use GPU 0 in integration test

### DIFF
--- a/agent/engine/engine_unix_integ_test.go
+++ b/agent/engine/engine_unix_integ_test.go
@@ -216,7 +216,7 @@ func createTestGPUTask() *apitask.Task {
 					Encoding: "base64",
 					Value:    "val",
 				},
-				Name: "1",
+				Name: "0",
 				Type: apitask.GPUAssociationType,
 			},
 		},
@@ -1433,14 +1433,14 @@ func TestGPUAssociationTask(t *testing.T) {
 	go taskEngine.AddTask(testTask)
 
 	verifyTaskIsRunning(stateChangeEvents, testTask)
-	assert.Equal(t, []string{"1"}, container.GPUIDs)
-	assert.Equal(t, "1", container.Environment[apitask.NvidiaVisibleDevicesEnvVar])
+	assert.Equal(t, []string{"0"}, container.GPUIDs)
+	assert.Equal(t, "0", container.Environment[apitask.NvidiaVisibleDevicesEnvVar])
 
 	containerMap, _ := taskEngine.(*DockerTaskEngine).state.ContainerMapByArn(testTask.Arn)
 	cid := containerMap[testTask.Containers[0].Name].DockerID
 	state, _ := client.ContainerInspect(ctx, cid)
 	assert.Equal(t, testTask.NvidiaRuntime, state.HostConfig.Runtime)
-	assert.Contains(t, state.Config.Env, "NVIDIA_VISIBLE_DEVICES=1")
+	assert.Contains(t, state.Config.Env, "NVIDIA_VISIBLE_DEVICES=0")
 
 	taskUpdate := *testTask
 	taskUpdate.SetDesiredStatus(apitaskstatus.TaskStopped)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
currently, the integration test adds GPU number 1 to the container. Instead use GPU 0, so that the test can also run on instances which have only one GPU 

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes

### Description for the changelog
N/A

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
