### PR TITLE
Fixing a few more functional tests

### DIFF
--- a/agent/functional_tests/tests/functionaltests_test.go
+++ b/agent/functional_tests/tests/functionaltests_test.go
@@ -564,6 +564,9 @@ func telemetryTest(t *testing.T, taskDefinition string) {
 }
 
 func telemetryTestWithStatsPolling(t *testing.T, taskDefinition string) {
+	// telemetry task requires 2GB of memory (for either linux or windows); requires a bit more to be stable
+	RequireMinimumMemory(t, 2200)
+	
 	// Try to let the container use 25% cpu, but bound it within valid range
 	cpuShare, expectedCPUPercentage := calculateCpuLimits(0.25)
 
@@ -944,10 +947,4 @@ func testV3TaskEndpointTags(t *testing.T, taskName, containerName, networkMode s
 
 	exitCode, _ := task.ContainerExitcode(containerName)
 	assert.Equal(t, 42, exitCode, fmt.Sprintf("Expected exit code of 42; got %d", exitCode))
-
-	DeleteAccountSettingInput := ecsapi.DeleteAccountSettingInput{
-		Name: aws.String("containerInstanceLongArnFormat"),
-	}
-	_, err = ECS.DeleteAccountSetting(&DeleteAccountSettingInput)
-	assert.NoError(t, err)
 }

--- a/agent/functional_tests/tests/functionaltests_unix_test.go
+++ b/agent/functional_tests/tests/functionaltests_unix_test.go
@@ -724,12 +724,6 @@ func TestTaskMetadataValidator(t *testing.T) {
 	exitCode, _ := task.ContainerExitcode("taskmetadata-validator")
 
 	assert.Equal(t, 42, exitCode, fmt.Sprintf("Expected exit code of 42; got %d", exitCode))
-
-	DeleteAccountSettingInput := ecsapi.DeleteAccountSettingInput{
-		Name: aws.String("containerInstanceLongArnFormat"),
-	}
-	_, err = ECS.DeleteAccountSetting(&DeleteAccountSettingInput)
-	assert.NoError(t, err)
 }
 
 // TestExecutionRole verifies that task can use the execution credentials to pull from ECR and


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Fixing a few more functional tests. They were added after 1.23.0 release so i wasn't fixing them in #1751.

### Implementation details
<!-- How are the changes implemented? -->
#### TestV3TaskEndpointTags TestTaskMetadataValidator
These two tests are flakey because of the same reason for TestContainerInstanceTags that was fixed in #1751. We cannot enable long arn at the start of test and disable it at the end, because we'd end up with race condition when multiple tests run at the same time.

#### TestTelemetryWithStatsPolling
This test needs a minimum memory requirement, same as TestTelemetry. i didn't notice this in #1755.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
