### PR TITLE
ImagePull logging fix

### DIFF
--- a/agent/dockerclient/dockerapi/docker_client.go
+++ b/agent/dockerclient/dockerapi/docker_client.go
@@ -409,6 +409,7 @@ func (dg *dockerGoClient) pullImage(ctx context.Context, image string, authData 
 
 		decoder := json.NewDecoder(reader)
 		data := new(ImagePullResponse)
+		var statusDisplayed time.Time
 		for err := decoder.Decode(data); err != io.EOF; err = decoder.Decode(data) {
 			if err != nil {
 				seelog.Warnf("DockerGoClient: Unable to decode pull event message for image %s: %v", image, err)
@@ -426,7 +427,7 @@ func (dg *dockerGoClient) pullImage(ctx context.Context, image string, authData 
 				pullBegan <- true
 			})
 
-			dg.filterPullDebugOutput(data, image)
+			statusDisplayed = dg.filterPullDebugOutput(data, image, statusDisplayed)
 
 			data = new(ImagePullResponse)
 		}
@@ -456,15 +457,12 @@ func (dg *dockerGoClient) pullImage(ctx context.Context, image string, authData 
 	return nil
 }
 
-func (dg *dockerGoClient) filterPullDebugOutput(data *ImagePullResponse, image string) {
-
-	var statusDisplayed time.Time
+func (dg *dockerGoClient) filterPullDebugOutput(data *ImagePullResponse, image string, statusDisplayed time.Time) time.Time {
 
 	now := time.Now()
 	if !strings.Contains(data.Progress, "[=") || now.After(statusDisplayed.Add(pullStatusSuppressDelay)) {
-		// skip most of the progress bar lines, but retain enough for debugging
-		seelog.Debugf("DockerGoClient: pulling image %s, status %s", image, data.Progress)
-		statusDisplayed = now
+		// data.Progress shows the progress bar lines for Status=downlaoding or Extracting, logging data.Status to retain enough for debugging
+		seelog.Debugf("DockerGoClient: pulling image %s, status %s", image, data.Status)
 	}
 
 	if strings.Contains(data.Status, "already being pulled by another client. Waiting.") {
@@ -472,6 +470,7 @@ func (dg *dockerGoClient) filterPullDebugOutput(data *ImagePullResponse, image s
 		seelog.Errorf("DockerGoClient: image 'pull' status marked as already being pulled for image %s, status %s",
 			image, data.Status)
 	}
+	return now
 }
 
 func getRepository(image string) string {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
- Fix for https://github.com/aws/amazon-ecs-agent/issues/1764
- Logging ImagePullResponse.Status instead of ImagePullResponse.Progress 
- Fixing pull status suppress logging logic

### Implementation details
- Response object changed when we migrated to SDK, but logging logic hadn't. ImagePullResponse.Progress is just the progress bar [===> ] while status is the succinct description.
- Logging suppression logic was broken, and wasn't actually suppressing debug level log entry for the image pull stream. 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: N/A

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
