### PR TITLE
Makefile: increase the timeout for unit test

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,7 @@ Please provide the following information:
 <!--
 Note for external contributors:
 `make test` and `make run-integ-tests` can run in a Linux development
-environment like your laptop.  `go test -timeout=25s ./agent/...` and
+environment like your laptop.  `go test -timeout=30s ./agent/...` and
 `.\scripts\run-integ.tests.ps1` can run in a Windows development environment
 like your laptop.  Please ensure unit and integration tests pass (on at least
 one platform) before opening the pull request.  `make run-functional-tests` and
@@ -29,7 +29,7 @@ in your own account, we can run the tests and provide test results.
 - [ ] Builds on Linux (`make release`)
 - [ ] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
 - [ ] Unit tests on Linux (`make test`) pass
-- [ ] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
+- [ ] Unit tests on Windows (`go test -timeout=30s ./agent/...`) pass
 - [ ] Integration tests on Linux (`make run-integ-tests`) pass
 - [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
 - [ ] Functional tests on Linux (`make run-functional-tests`) pass

--- a/Makefile
+++ b/Makefile
@@ -91,14 +91,14 @@ misc/certs/ca-certificates.crt:
 
 ifeq (${BUILD_PLATFORM},aarch64)
 test::
-	. ./scripts/shared_env && go test -tags unit -timeout=25s -v -cover $(shell go list ./agent/... | grep -v /vendor/)
+	. ./scripts/shared_env && go test -tags unit -timeout=30s -v -cover $(shell go list ./agent/... | grep -v /vendor/)
 else
 test::
-	. ./scripts/shared_env && go test -race -tags unit -timeout=25s -v -cover $(shell go list ./agent/... | grep -v /vendor/)
+	. ./scripts/shared_env && go test -race -tags unit -timeout=30s -v -cover $(shell go list ./agent/... | grep -v /vendor/)
 endif
 
 test-silent:
-	. ./scripts/shared_env && go test -timeout=25s -cover $(shell go list ./agent/... | grep -v /vendor/)
+	. ./scripts/shared_env && go test -timeout=30s -cover $(shell go list ./agent/... | grep -v /vendor/)
 
 benchmark-test:
 	. ./scripts/shared_env && go test -run=XX -bench=. $(shell go list ./agent/... | grep -v /vendor/)


### PR DESCRIPTION
### Summary
Some new unit tests about metrics were added in the last release, which costs around 5s. So increase the unit test timeout by 5s.

### Implementation details
Update the Makefile and bump up the timeout.
Tested 'make test' on a linux instance with new timeout for 10 times and they were all passed.

### Testing
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [ ] Builds on Linux (`make release`)
- [ ] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [ ] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
