### PR TITLE
Fix TestOOMContainer on Windows

### DIFF
--- a/misc/windows-python/build.ps1
+++ b/misc/windows-python/build.ps1
@@ -11,5 +11,5 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-docker pull python:3-windowsservercore
-docker tag python:3-windowsservercore amazon/amazon-ecs-windows-python:make
+docker pull python:3-windowsservercore-ltsc2016
+docker tag python:3-windowsservercore-ltsc2016 amazon/amazon-ecs-windows-python:make


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Fixing functional test TestOOMContainer on Windows: https://github.com/aws/amazon-ecs-agent/issues/1763.

### Implementation details
<!-- How are the changes implemented? -->
The test was failing because docker failed to pull image "python:3-windowsservercore". Our test ran on windows server 2016 so it cannot pull an image built from windows server core 1709 ([Version compatibility](https://docs.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/version-compatibility)). Looks like recently "python:3-windowsservercore" points to the 1709 image version rather than 2016 version. This PR changes the test to use the 2016 one explicitly.

I tried the following on our test facility and ended up with the conclusion above:
```
docker pull python:3-windowsservercore -> fail (what we currently do)
docker pull python:3-windowsservercore-1709 -> fail
docker pull python:3-windowsservercore-ltsc2016 -> succeed
```

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [ ] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
