### PR TITLE
Only create default cluster when it doesn't exist

### DIFF
--- a/agent/api/ecsclient/client.go
+++ b/agent/api/ecsclient/client.go
@@ -124,13 +124,17 @@ func (client *APIECSClient) RegisterContainerInstance(containerInstanceArn strin
 		if err == nil {
 			return containerInstanceArn, availabilityzone, nil
 		}
-		// If trying to register fails, try to create the cluster before calling
+
+		// If trying to register fails because the default cluster doesn't exist, try to create the cluster before calling
 		// register again
-		clusterRef, err = client.CreateCluster(clusterRef)
-		if err != nil {
-			return "", "", err
+		if apierrors.IsClusterNotFoundError(err) {
+			clusterRef, err = client.CreateCluster(clusterRef)
+			if err != nil {
+				return "", "", err
+			}
 		}
 	}
+
 	return client.registerContainerInstance(clusterRef, containerInstanceArn, attributes, tags, registrationToken)
 }
 

--- a/agent/api/errors/errors.go
+++ b/agent/api/errors/errors.go
@@ -24,12 +24,21 @@ import (
 // instance type changed error when registering a container instance
 const InstanceTypeChangedErrorMessage = "Container instance type changes are not supported."
 
+const ClusterNotFoundErrorMessage = "Cluster not found."
+
 // IsInstanceTypeChangedError returns true if the error when
 // registering the container instance is because of instance type being
 // changed
 func IsInstanceTypeChangedError(err error) bool {
 	if awserr, ok := err.(awserr.Error); ok {
 		return strings.Contains(awserr.Message(), InstanceTypeChangedErrorMessage)
+	}
+	return false
+}
+
+func IsClusterNotFoundError(err error) bool {
+	if awserr, ok := err.(awserr.Error); ok {
+		return strings.Contains(awserr.Message(), ClusterNotFoundErrorMessage)
 	}
 	return false
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Previously, when agent has a blank cluster name, and fails to register container instance, it blindly tries to create the default cluster without look at what error it got. However, RCI could fail because of other error other than ClusterNotFound, and in that case we shouldn't try to create the default cluster. This causes customer to unexpectly hit API limit for CreateCluster when RCI fails for other reason.

This PR fixes this by checking the RCI error, and only trying to create the default cluster when the error is "Cluster not found".

### Implementation details
<!-- How are the changes implemented? -->
See above.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
