### PR TITLE
updating travis to do cross-platform build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ install: make get-deps
 script:
   - make test
   - make static-check
-  
+  - make xplatform-build

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 USERID=$(shell id -u)
 GO_EXECUTABLE=$(shell command -v go 2> /dev/null)
 
-.PHONY: all gobuild static docker release certs test clean netkitten test-registry namespace-tests run-functional-tests benchmark-test gogenerate run-integ-tests pause-container get-cni-sources cni-plugins test-artifacts
+.PHONY: all gobuild static xplatform-build docker release certs test clean netkitten test-registry namespace-tests run-functional-tests benchmark-test gogenerate run-integ-tests pause-container get-cni-sources cni-plugins test-artifacts
 BUILD_PLATFORM:=$(shell uname -m)
 
 all: docker
@@ -32,6 +32,11 @@ gobuild:
 # Basic go build
 static:
 	./scripts/build
+
+# Cross-platform build target for travis
+xplatform-build:
+	GOOS=linux GOARCH=arm64 ./scripts/build true "" false
+	GOOS=windows GOARCH=amd64 ./scripts/build true "" false
 
 BUILDER_IMAGE="amazon/amazon-ecs-agent-build:make"
 .builder-image-stamp: scripts/dockerfiles/Dockerfile.build

--- a/scripts/build
+++ b/scripts/build
@@ -21,8 +21,10 @@ set -ex
 # Pass in whether you want to build a static binary (true|false) and whether
 # the resulting binary should be moved to an output directory
 # The second option exists so that if built in a container, the result can be moved to a shared volume mount
+# The thrid option is for skipping version generation when running cross-platform build, as it results in exec format error
 static=${1:-true}
 output_directory=${2:-}
+version_gen=${3:-true}
 
 # Normalize to working directory being build root (up one level from ./scripts)
 ROOT=$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )
@@ -30,13 +32,15 @@ cd "${ROOT}"
 
 source ./scripts/shared_env
 
-# Versioning stuff. We run the generator to setup the version and then always
-# restore ourselves to a clean state
-cp agent/version/version.go agent/version/_version.go
-trap "cd \"${ROOT}\"; mv agent/version/_version.go agent/version/version.go" EXIT SIGHUP SIGINT SIGTERM
+if [[ "${version_gen}" == "true" ]]; then
+  # Versioning stuff. We run the generator to setup the version and then always
+  # restore ourselves to a clean state
+  cp agent/version/version.go agent/version/_version.go
+  trap "cd \"${ROOT}\"; mv agent/version/_version.go agent/version/version.go" EXIT SIGHUP SIGINT SIGTERM
 
-cd ./agent/version/
-go run gen/version-gen.go
+  cd ./agent/version/
+  go run gen/version-gen.go
+fi
 
 if [ "${TARGET_OS}" == "windows" ]; then
     unset static


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Adding cross-platform build commands in travis

### Implementation details
Added cross-platform build commands for windows and arm

### Testing
<!-- How was this tested? -->
Travis run on my branch:
```
...
The command "make static-check" exited with 0.

travis_time:start:100f24df
$ GOOS=linux GOARCH=arm64 go build -o ecs-agent ./agent
travis_time:end:100f24df:start=1546658801092082361,finish=1546658838845424490,duration=37753342129
The command "GOOS=linux GOARCH=arm64 go build -o ecs-agent ./agent" exited with 0.

travis_time:start:2d8a00a2
$ GOOS=windows GOARCH=amd64 go build -o ecs-agent ./agent
travis_time:end:2d8a00a2:start=1546658838849293976,finish=1546658875879529220,duration=37030235244
The command "GOOS=windows GOARCH=amd64 go build -o ecs-agent ./agent" exited with 0.
```

<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: N/A

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
