### PR TITLE
Fix flaky unit test in docker client

### DIFF
--- a/agent/dockerclient/dockerapi/docker_client_test.go
+++ b/agent/dockerclient/dockerapi/docker_client_test.go
@@ -380,7 +380,7 @@ func TestCreateContainer(t *testing.T) {
 	)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-	metadata := client.CreateContainer(ctx, nil, hostConfig, name, 1*time.Second)
+	metadata := client.CreateContainer(ctx, nil, hostConfig, name, dockerclient.CreateContainerTimeout)
 	assert.NoError(t, metadata.Error)
 	assert.Equal(t, "id", metadata.DockerID)
 	assert.Nil(t, metadata.ExitCode, "Expected a created container to not have an exit code")
@@ -1091,7 +1091,7 @@ func TestRemoveImage(t *testing.T) {
 	mockDockerSDK.EXPECT().ImageRemove(gomock.Any(), "image", types.ImageRemoveOptions{}).Return([]types.ImageDeleteResponseItem{}, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-	err := client.RemoveImage(ctx, "image", 2*time.Millisecond)
+	err := client.RemoveImage(ctx, "image", dockerclient.RemoveImageTimeout)
 	assert.NoError(t, err, "Did not expect error, err: %v", err)
 }
 
@@ -1105,7 +1105,7 @@ func TestLoadImageHappyPath(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-	err := client.LoadImage(ctx, nil, time.Second)
+	err := client.LoadImage(ctx, nil, dockerclient.LoadImageTimeout)
 	assert.NoError(t, err)
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Found the following error in travis ci:
```
--- FAIL: TestRemoveImage (0.01s)
	<autogenerated>:1: 
			Error Trace:	docker_client_test.go:1095
			Error:      	Received unexpected error:
			            	Could not transition to removing image; timed out after waiting 2ms
			Test:       	TestRemoveImage
			Messages:   	Did not expect error, err: Could not transition to removing image; timed out after waiting 2ms
	<autogenerated>:1: missing call(s) to *mock_sdkclient.MockClient.ImageRemove(is anything, is equal to image, is equal to {false false}) /home/travis/gopath/src/github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi/docker_client_test.go:1091
	<autogenerated>:1: aborting test due to missing call(s)
```

This is because we passed in a too short timeout value, increase the timeout will resolve this issue, also increase the timeout for `TestCreateContainer` and `TestLoadImageHappyPath` to prevent potential flakiness.

Run three tests for 1000 times:

```
GOCACHE=off go test -run TestCreateContainer -count 1000 -tags unit ./agent/dockerclient/dockerapi/
ok  	github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi	7.046s
GOCACHE=off go test -run TestLoadImageHappyPath -count 1000 -tags unit ./agent/dockerclient/dockerapi/
ok  	github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi	0.201s
GOCACHE=off go test -run TestRemoveImage -count 1000 -tags unit ./agent/dockerclient/dockerapi/
ok  	github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi	2.914s
```
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [ ] Builds on Linux (`make release`)
- [ ] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [ ] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass


### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
