### PR TITLE
Update registry image to make it Arm compatible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -253,7 +253,7 @@ cni-plugins: get-cni-sources .out-stamp
 
 ifeq (${BUILD_PLATFORM},aarch64)
 run-integ-tests: test-registry gremlin container-health-check-image run-sudo-tests
-	. ./scripts/shared_env && go test -tags integration -timeout=20m -v ./agent/engine/... ./agent/stats/... ./agent/app/...agent
+	. ./scripts/shared_env && go test -tags integration -timeout=20m -v ./agent/engine/... ./agent/stats/... ./agent/app/...
 else
 run-integ-tests: test-registry gremlin container-health-check-image run-sudo-tests
 	. ./scripts/shared_env && go test -race -tags integration -timeout=12m -v ./agent/engine/... ./agent/stats/... ./agent/app/...

--- a/agent/functional_tests/tests/functionaltests_unix_test.go
+++ b/agent/functional_tests/tests/functionaltests_unix_test.go
@@ -570,7 +570,8 @@ func TestFluentdTag(t *testing.T) {
 	// tag was added in docker 1.9.0
 	RequireDockerVersion(t, ">=1.9.0")
 
-	if runtime.GOOS == "arm64" {
+	// Skipping the test for arm as they do not have official support for Arm images
+	if runtime.GOARCH == "arm64" {
 		t.Skip()
 	}
 
@@ -584,7 +585,8 @@ func TestFluentdLogTag(t *testing.T) {
 	RequireDockerVersion(t, ">=1.8.0")
 	RequireDockerVersion(t, "<1.12.0")
 
-	if runtime.GOOS == "arm64" {
+	// Skipping the test for arm as they do not have official support for Arm images
+	if runtime.GOARCH == "arm64" {
 		t.Skip()
 	}
 

--- a/agent/functional_tests/tests/functionaltests_unix_test.go
+++ b/agent/functional_tests/tests/functionaltests_unix_test.go
@@ -572,7 +572,7 @@ func TestFluentdTag(t *testing.T) {
 
 	// Skipping the test for arm as they do not have official support for Arm images
 	if runtime.GOARCH == "arm64" {
-		t.Skip()
+		t.Skip("Skipping test, unsupported image for arm64")
 	}
 
 	fluentdDriverTest("fluentd-tag", t)
@@ -587,7 +587,7 @@ func TestFluentdLogTag(t *testing.T) {
 
 	// Skipping the test for arm as they do not have official support for Arm images
 	if runtime.GOARCH == "arm64" {
-		t.Skip()
+		t.Skip("Skipping test, unsupported image for arm64")
 	}
 
 	fluentdDriverTest("fluentd-log-tag", t)
@@ -760,7 +760,14 @@ func TestExecutionRole(t *testing.T) {
 	agent.RequireVersion(">=1.16.0")
 
 	tdOverrides := make(map[string]string)
-	testImage := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/executionrole:fts", accountID, *ECS.Config.Region)
+
+	testImage := ""
+
+	if runtime.GOARCH == "arm64" {
+		testImage = fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/executionrole:arm-fts", accountID, *ECS.Config.Region)
+	} else {
+		testImage = fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/executionrole:fts", accountID, *ECS.Config.Region)
+	}
 
 	tdOverrides["$$$$TEST_REGION$$$$"] = aws.StringValue(ECS.Config.Region)
 	tdOverrides["$$$$EXECUTION_ROLE$$$$"] = os.Getenv("ECS_FTS_EXECUTION_ROLE")

--- a/misc/ecr-execution-role-upload/dockerfile
+++ b/misc/ecr-execution-role-upload/dockerfile
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-FROM busybox@sha256:5551dbdfc48d66734d0f01cafee0952cb6e8eeecd1e2492240bf2fd9640c2279
+FROM busybox:1.29.3
 
 MAINTAINER Amazon Web Services, Inc.
 

--- a/scripts/setup-test-registry
+++ b/scripts/setup-test-registry
@@ -16,43 +16,21 @@
 # Also push images we will need to it.
 set -e
 
-REGISTRY_IMAGE="registry:2.6.2"
+REGISTRY_IMAGE="registry:2.7.0"
 
 NGINX_IMAGE="nginx:1.15"
 
 ROOT=$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )
 cd "${ROOT}"
 
+REGISTRY_CONTAINER_NAME="test-ecs-registry"
 
-REGISTRY_CONTAINER_NAME=test-ecs-registry
-status=$(docker inspect -f "{{ .State.Running }}" "$REGISTRY_CONTAINER_NAME") || true
+echo "Removing $REGISTRY_CONTAINER_NAME"
+# stop and remove the registry container. The script will not exit if the container is not running
+docker stop "$REGISTRY_CONTAINER_NAME" || true && docker rm "$REGISTRY_CONTAINER_NAME" || true
 
-if [[ "$status" == "false" ]]; then
-	docker rm -f "$REGISTRY_CONTAINER_NAME"
-fi
-
-# This will fail if we already have one running, but that's fine. We'll see it
-# running and push our image to it to make sure it's there
-if [[ "$status" != "true" ]]; then
-	docker run -d --name="$REGISTRY_CONTAINER_NAME" -e SETTINGS_FLAVOR=local -p "127.0.0.1:51670:5000" "${REGISTRY_IMAGE}"
-fi
-
-# Wait for it to be started which might include downloading the image
-status="false"
-for try in $(seq 1 300); do
-	status=$(docker inspect -f "{{ .State.Running }}" $REGISTRY_CONTAINER_NAME)
-	if [[ "$status" == "true" ]]; then
-		break
-	fi
-	sleep 1
-done
-
-if [[ "$status" != "true" ]]; then
-	echo "Unable to start test registry"
-	exit 1
-fi
-
-sleep 2
+echo "Running $REGISTRY_CONTAINER_NAME"
+docker run -d --name="$REGISTRY_CONTAINER_NAME" -e SETTINGS_FLAVOR=local -p "127.0.0.1:51670:5000" "${REGISTRY_IMAGE}"
 
 # Make sure our images are pushed to it
 mirror_image() {
@@ -61,6 +39,7 @@ mirror_image() {
 }
 
 mirror_local_image() {
+  echo "Mirroring $1"
   docker tag $1 $2
   docker push $2
   docker rmi $2
@@ -111,7 +90,8 @@ mirror_image ${PARALLEL_PULL_FTS_HTTPD} "127.0.0.1:51670/httpd:parallel-pull-fts
 mirror_image ${PARALLEL_PULL_FTS_MONGO} "127.0.0.1:51670/mongo:parallel-pull-fts"
 mirror_image ${PARALLEL_PULL_FTS_NGINX} "127.0.0.1:51670/nginx:parallel-pull-fts"
 mirror_image ${PARALLEL_PULL_FTS_REDIS} "127.0.0.1:51670/redis:parallel-pull-fts"
-mirror_image ${PARALLEL_PULL_FTS_REGISTRY} "127.0.0.1:51670/registry:parallel-pull-fts"
+mirror_local_image ${PARALLEL_PULL_FTS_REGISTRY} "127.0.0.1:51670/registry:parallel-pull-fts"
+
 
 # Now setup a v2 registry with auth... aka nginx with basic auth in front of it
 REGISTRY_AUTH_CONTAINER_NAME="test-ecs-registry-auth"

--- a/scripts/upload-images
+++ b/scripts/upload-images
@@ -84,12 +84,10 @@ for image in "executionrole" "busybox" "nginx" "python" "ubuntu" "consul" "debia
   fi
 done
 
-REGISTRY_IMAGE_CONTAINER="test-ecs-registry-container:arm"
-REGISTRY_IMAGE="registry:2.6.2"
+REGISTRY_CONTAINER_NAME="test-ecs-registry"
+REGISTRY_IMAGE="registry:2.7.0"
 
-docker build -t "${REGISTRY_IMAGE_CONTAINER}" "${REGISTRY_IMAGE}"
-
-mirror_local_image "${REGISTRY_IMAGE_CONTAINER}" "127.0.0.1:51670/registry:parallel-pull-fts"
+mirror_local_image "${REGISTRY_IMAGE}" "127.0.0.1:51670/registry:parallel-pull-fts"
 
 mirror_local_image "amazon/${ECR_ROLE_IMAGE}:fts" "${PREFIX}/${ECR_ROLE_IMAGE}:fts"
 mirror_image ${BUSYBOX_IMAGE} "${PREFIX}/busybox:latest"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
- Update the logic to check for running and stoping containers in `setup-test-registry`.
- Update registry image version. This version has comaptibilty with arm and amd architecture.
- Update busybox image version in `ecr-execution-role-upload` to keep it consistent with busybox at other places in the code.
- Replace `runtime.GOOS` with `runtime.GOARCH`. `GOOS` is the running program's operating system target and `GOARCH`  is the running program's architecture target: one of 386, amd64, arm and so on. `GOARCH` is correct usage for the use case.
- Create a separate `executionrole` image for amd and arm.  
`misc/ecr/build.sh` uploads `executionrole` image to ecr and does not update the image if it already exists. 
If this image corresponding to amd, integ test on arm will not update this image and try to use the amd image in arm. Vice versa is also true. So integ tests will fail on arm or amd depending on the image that is present in ecr. Keeping separate image for amd and arm ensures that correct image is used for correct architecture. 

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
Integ and functional tests are passing for Arm and x86 architecture. 
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=30s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
