### PR TITLE
go vet cleanup

### DIFF
--- a/agent/api/task/taskvolume.go
+++ b/agent/api/task/taskvolume.go
@@ -67,8 +67,6 @@ func (tv *TaskVolume) UnmarshalJSON(b []byte) error {
 	default:
 		return errors.Errorf("invalid Volume: type must be docker or host, got %q", tv.Type)
 	}
-
-	return errors.New("unrecognized volume type; try updating me")
 }
 
 // MarshalJSON overrides the logic for JSON-encoding a  TaskVolume object

--- a/agent/ecscni/types.go
+++ b/agent/ecscni/types.go
@@ -113,7 +113,7 @@ type ENIConfig struct {
 	// IPV4Address is the ipv4 of eni
 	IPV4Address string `json:"ipv4-address"`
 	// IPV6Address is the ipv6 of eni
-	IPV6Address string `json:"ipv6-address, omitempty"`
+	IPV6Address string `json:"ipv6-address,omitempty"`
 	// MacAddress is the mac address of eni
 	MACAddress string `json:"mac"`
 	// BlockInstanceMetdata specifies if InstanceMetadata endpoint should be

--- a/agent/engine/docker_image_manager.go
+++ b/agent/engine/docker_image_manager.go
@@ -71,8 +71,8 @@ type ImageStatesForDeletion []*image.ImageState
 // NewImageManager returns a new ImageManager
 func NewImageManager(cfg *config.Config, client dockerapi.DockerClient, state dockerstate.TaskEngineState) ImageManager {
 	return &dockerImageManager{
-		client: client,
-		state:  state,
+		client:                             client,
+		state:                              state,
 		minimumAgeBeforeDeletion:           cfg.MinimumImageDeletionAge,
 		numImagesToDelete:                  cfg.NumImagesToDeletePerCycle,
 		imageCleanupTimeInterval:           cfg.ImageCleanupInterval,
@@ -368,7 +368,7 @@ func (imageManager *dockerImageManager) getNonECSContainerIDs(ctx context.Contex
 	var allContainersIDs []string
 	listContainersResponse := imageManager.client.ListContainers(ctx, true, dockerclient.ListContainersTimeout)
 	if listContainersResponse.Error != nil {
-		fmt.Errorf("error listing containers: %v", listContainersResponse.Error)
+		return nil, fmt.Errorf("Error listing containers: %v", listContainersResponse.Error)
 	}
 	for _, dockerID := range listContainersResponse.DockerIDs {
 		allContainersIDs = append(allContainersIDs, dockerID)

--- a/agent/eventhandler/task_handler.go
+++ b/agent/eventhandler/task_handler.go
@@ -157,7 +157,8 @@ func (handler *TaskHandler) AddStateChangeEvent(change statechange.Event, client
 // startDrainEventsTicker starts a ticker that periodically drains the events queue
 // by submitting state change events to the ECS backend
 func (handler *TaskHandler) startDrainEventsTicker() {
-	derivedCtx, _ := context.WithCancel(handler.ctx)
+	derivedCtx, cancel := context.WithCancel(handler.ctx)
+	defer cancel()
 	ticker := utils.NewJitteredTicker(derivedCtx, handler.minDrainEventsFrequency, handler.maxDrainEventsFrequency)
 	for {
 		select {

--- a/agent/gpu/nvidia_gpu_manager_unix.go
+++ b/agent/gpu/nvidia_gpu_manager_unix.go
@@ -44,7 +44,7 @@ type NvidiaGPUManager struct {
 	DriverVersion string                `json:"DriverVersion"`
 	GPUIDs        []string              `json:"GPUIDs"`
 	GPUDevices    []*ecs.PlatformDevice `json:"-"`
-	lock          sync.RWMutex          `json:"-"`
+	lock          sync.RWMutex
 }
 
 const (

--- a/agent/utils/ticker_test.go
+++ b/agent/utils/ticker_test.go
@@ -26,7 +26,8 @@ const (
 )
 
 func TestTickerHappyCase(t *testing.T) {
-	ctx, _ := context.WithTimeout(context.Background(), 1000*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 1000*time.Millisecond)
+	defer cancel()
 	mTicker := NewJitteredTicker(ctx, 10*time.Millisecond, 100*time.Millisecond)
 
 	times := 0


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This makes changes based on suggestions from running `go vet`.  There was some unreachable code, and code that was not used.  
There are 2 changes given the warning: `the cancel function returned by context.WithTimeout should be called, not discarded, to avoid a context leak`.  I referenced examples in  https://golang.org/pkg/context/ to make this fix.

### Testing
I built agent and ran tests.
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [ ] Builds on Linux (`make release`)
- [ ] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [ ] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=30s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: (there are no substantive changes)

### Description for the changelog
initial cleanup based on go vet warnings

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
