### PR TITLE
Wire context for PullImage API

### DIFF
--- a/agent/containermetadata/manager.go
+++ b/agent/containermetadata/manager.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -18,13 +18,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"time"
 
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/dockerclient"
 	"github.com/aws/amazon-ecs-agent/agent/utils/ioutilwrapper"
 	"github.com/aws/amazon-ecs-agent/agent/utils/oswrapper"
-
 	dockercontainer "github.com/docker/docker/api/types/container"
 )
 
@@ -32,7 +31,6 @@ const (
 	// metadataEnvironmentVariable is the environment variable passed to the
 	// container for the metadata file path.
 	metadataEnvironmentVariable = "ECS_CONTAINER_METADATA_FILE"
-	inspectContainerTimeout     = 30 * time.Second
 	metadataFile                = "ecs-container-metadata.json"
 	metadataPerm                = 0644
 )
@@ -137,7 +135,7 @@ func (manager *metadataManager) Create(config *dockercontainer.Config, hostConfi
 // Update updates the metadata file after container starts and dynamic metadata is available
 func (manager *metadataManager) Update(ctx context.Context, dockerID string, task *apitask.Task, containerName string) error {
 	// Get docker container information through api call
-	dockerContainer, err := manager.client.InspectContainer(ctx, dockerID, inspectContainerTimeout)
+	dockerContainer, err := manager.client.InspectContainer(ctx, dockerID, dockerclient.InspectContainerTimeout)
 	if err != nil {
 		return err
 	}

--- a/agent/containermetadata/manager_test.go
+++ b/agent/containermetadata/manager_test.go
@@ -1,6 +1,6 @@
 // +build unit
 
-// Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -22,6 +22,7 @@ import (
 
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	"github.com/aws/amazon-ecs-agent/agent/containermetadata/mocks"
+	"github.com/aws/amazon-ecs-agent/agent/dockerclient"
 	"github.com/aws/amazon-ecs-agent/agent/utils/ioutilwrapper/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/utils/oswrapper/mocks"
 
@@ -131,7 +132,7 @@ func TestUpdateInspectFail(t *testing.T) {
 		client: mockClient,
 	}
 
-	mockClient.EXPECT().InspectContainer(gomock.Any(), mockDockerID, inspectContainerTimeout).Return(nil, errors.New("Inspect fail"))
+	mockClient.EXPECT().InspectContainer(gomock.Any(), mockDockerID, dockerclient.InspectContainerTimeout).Return(nil, errors.New("Inspect fail"))
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	err := newManager.Update(ctx, mockDockerID, mockTask, mockContainerName)
@@ -161,7 +162,7 @@ func TestUpdateNotRunningFail(t *testing.T) {
 		client: mockClient,
 	}
 
-	mockClient.EXPECT().InspectContainer(gomock.Any(), mockDockerID, inspectContainerTimeout).Return(&mockContainer, nil)
+	mockClient.EXPECT().InspectContainer(gomock.Any(), mockDockerID, dockerclient.InspectContainerTimeout).Return(&mockContainer, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	err := newManager.Update(ctx, mockDockerID, mockTask, mockContainerName)

--- a/agent/containermetadata/manager_unix_test.go
+++ b/agent/containermetadata/manager_unix_test.go
@@ -1,6 +1,6 @@
 // +build unit,!windows
 
-// Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
-
+	"github.com/aws/amazon-ecs-agent/agent/dockerclient"
 	"github.com/docker/docker/api/types"
 	dockercontainer "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
@@ -95,7 +95,7 @@ func TestUpdate(t *testing.T) {
 	}
 
 	gomock.InOrder(
-		mockClient.EXPECT().InspectContainer(gomock.Any(), mockDockerID, inspectContainerTimeout).Return(&mockContainer, nil),
+		mockClient.EXPECT().InspectContainer(gomock.Any(), mockDockerID, dockerclient.InspectContainerTimeout).Return(&mockContainer, nil),
 		mockIOUtil.EXPECT().TempFile(gomock.Any(), gomock.Any()).Return(mockFile, nil),
 		mockFile.EXPECT().Write(gomock.Any()).Return(0, nil),
 		mockFile.EXPECT().Chmod(gomock.Any()).Return(nil),

--- a/agent/containermetadata/manager_windows_test.go
+++ b/agent/containermetadata/manager_windows_test.go
@@ -20,12 +20,12 @@ import (
 	"testing"
 
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
-
+	"github.com/aws/amazon-ecs-agent/agent/dockerclient"
 	"github.com/docker/docker/api/types"
 	dockercontainer "github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
-	"github.com/docker/docker/api/types/network"
 )
 
 // TestCreate is the mainline case for metadata create
@@ -77,7 +77,7 @@ func TestUpdate(t *testing.T) {
 
 	mockContainer := types.ContainerJSON{
 		ContainerJSONBase: &types.ContainerJSONBase{
-			State:           &mockState,
+			State: &mockState,
 		},
 		Config:          mockConfig,
 		NetworkSettings: &mockNetworkSettings,
@@ -89,7 +89,7 @@ func TestUpdate(t *testing.T) {
 	}
 
 	gomock.InOrder(
-		mockClient.EXPECT().InspectContainer(gomock.Any(), mockDockerID, inspectContainerTimeout).Return(&mockContainer, nil),
+		mockClient.EXPECT().InspectContainer(gomock.Any(), mockDockerID, dockerclient.InspectContainerTimeout).Return(&mockContainer, nil),
 		mockOS.EXPECT().OpenFile(gomock.Any(), gomock.Any(), gomock.Any()).Return(mockFile, nil),
 		mockFile.EXPECT().Write(gomock.Any()).Return(0, nil),
 		mockFile.EXPECT().Sync().Return(nil),

--- a/agent/dockerclient/dockerapi/docker_client_test.go
+++ b/agent/dockerclient/dockerapi/docker_client_test.go
@@ -1,6 +1,6 @@
 // +build unit
 
-// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -113,7 +113,6 @@ func TestPullImageOutputTimeout(t *testing.T) {
 
 	pullBeginTimeout := make(chan time.Time)
 	testTime.EXPECT().After(dockerclient.DockerPullBeginTimeout).Return(pullBeginTimeout).MinTimes(1)
-	testTime.EXPECT().After(dockerclient.PullImageTimeout).MinTimes(1)
 
 	// multiple invocations will happen due to retries, but all should timeout
 	mockDockerSDK.EXPECT().ImagePull(gomock.Any(), "image:latest", gomock.Any()).DoAndReturn(
@@ -126,7 +125,9 @@ func TestPullImageOutputTimeout(t *testing.T) {
 			return reader, nil
 		}).Times(maximumPullRetries) // expected number of retries
 
-	metadata := client.PullImage("image", nil)
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	metadata := client.PullImage(ctx, "image", nil, dockerclient.PullImageTimeout)
 	assert.Error(t, metadata.Error, "Expected error for pull timeout")
 	assert.Equal(t, "DockerTimeoutError", metadata.Error.(apierrors.NamedError).ErrorName())
 }
@@ -135,25 +136,21 @@ func TestImagePullGlobalTimeout(t *testing.T) {
 	mockDockerSDK, client, testTime, _, _, done := dockerClientSetup(t)
 	defer done()
 
+	wait := &sync.WaitGroup{}
+	wait.Add(1)
 	pullBeginTimeout := make(chan time.Time, 1)
 	testTime.EXPECT().After(dockerclient.DockerPullBeginTimeout).Return(pullBeginTimeout)
-	pullTimeout := make(chan time.Time, 1)
-	testTime.EXPECT().After(dockerclient.PullImageTimeout).Return(pullTimeout)
 
-	mockDockerSDK.EXPECT().ImagePull(gomock.Any(), "image:latest", gomock.Any()).DoAndReturn(
-		func(x, y, z interface{}) (io.ReadCloser, error) {
-			pullBeginTimeout <- time.Now()
-			pullTimeout <- time.Now()
+	mockDockerSDK.EXPECT().ImagePull(gomock.Any(), "image:latest", gomock.Any()).Do(func(x, y, z interface{}) {
+		wait.Wait()
+	}).Return(mockReadCloser{reader: strings.NewReader(`{"status":"pull in progress"}`)}, nil).MaxTimes(1)
 
-			reader := mockReadCloser{
-				reader: strings.NewReader(`{"status":"pull in progress"}`),
-			}
-			return reader, nil
-		})
-
-	metadata := client.PullImage("image", nil)
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	metadata := client.PullImage(ctx, "image", nil, xContainerShortTimeout)
 	assert.Error(t, metadata.Error, "Expected error for pull timeout")
 	assert.Equal(t, "DockerTimeoutError", metadata.Error.(apierrors.NamedError).ErrorName())
+	wait.Done()
 }
 
 func TestPullImageInactivityTimeout(t *testing.T) {
@@ -173,7 +170,9 @@ func TestPullImageInactivityTimeout(t *testing.T) {
 			return reader, nil
 		}).Times(maximumPullRetries) // expected number of retries
 
-	metadata := client.PullImage("image", nil)
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	metadata := client.PullImage(ctx, "image", nil, dockerclient.PullImageTimeout)
 	assert.Error(t, metadata.Error, "Expected error for pull inactivity timeout")
 	assert.Equal(t, "CannotPullContainerError", metadata.Error.(apierrors.NamedError).ErrorName(), "Wrong error type")
 }
@@ -189,7 +188,9 @@ func TestImagePull(t *testing.T) {
 			reader: strings.NewReader(`{"status":"pull complete"}`),
 		}, nil)
 
-	metadata := client.PullImage("image", nil)
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	metadata := client.PullImage(ctx, "image", nil, dockerclient.PullImageTimeout)
 	assert.NoError(t, metadata.Error, "Expected pull to succeed")
 }
 
@@ -205,7 +206,9 @@ func TestImagePullTag(t *testing.T) {
 			reader: strings.NewReader(`{"status":"pull complete"}`),
 		}, nil)
 
-	metadata := client.PullImage("image:mytag", nil)
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	metadata := client.PullImage(ctx, "image:mytag", nil, dockerclient.PullImageTimeout)
 	assert.NoError(t, metadata.Error, "Expected pull to succeed")
 }
 
@@ -219,7 +222,9 @@ func TestImagePullDigest(t *testing.T) {
 			reader: strings.NewReader(`{"status":"pull complete"}`),
 		}, nil)
 
-	metadata := client.PullImage("image@sha256:bc8813ea7b3603864987522f02a76101c17ad122e1c46d790efc0fca78ca7bfb", nil)
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	metadata := client.PullImage(ctx, "image@sha256:bc8813ea7b3603864987522f02a76101c17ad122e1c46d790efc0fca78ca7bfb", nil, dockerclient.PullImageTimeout)
 	assert.NoError(t, metadata.Error, "Expected pull to succeed")
 }
 
@@ -263,7 +268,9 @@ func TestPullImageECRSuccess(t *testing.T) {
 			reader: strings.NewReader(`{"status":"pull complete"}`),
 		}, nil)
 
-	metadata := client.PullImage(image, authData)
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	metadata := client.PullImage(ctx, image, authData, dockerclient.PullImageTimeout)
 	assert.NoError(t, metadata.Error, "Expected pull to succeed")
 }
 
@@ -308,7 +315,7 @@ func TestPullImageECRAuthFail(t *testing.T) {
 	ecrClientFactory.EXPECT().GetClient(authData.ECRAuthData).Return(ecrClient, nil)
 	ecrClient.EXPECT().GetAuthorizationToken(gomock.Any()).Return(nil, errors.New("test error"))
 
-	metadata := client.PullImage(image, authData)
+	metadata := client.PullImage(ctx, image, authData, dockerclient.PullImageTimeout)
 	assert.Error(t, metadata.Error, "expected pull to fail")
 }
 
@@ -326,7 +333,9 @@ func TestPullImageError(t *testing.T) {
 			return reader, nil
 		}).Times(maximumPullRetries) // expected number of retries
 
-	metadata := client.PullImage("image", nil)
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	metadata := client.PullImage(ctx, "image", nil, dockerclient.PullImageTimeout)
 	assert.Error(t, metadata.Error, "toomanyrequests: Rate exceeded")
 	assert.Equal(t, "CannotPullContainerError", metadata.Error.(apierrors.NamedError).ErrorName(), "Wrong error type")
 }
@@ -1186,19 +1195,21 @@ func TestECRAuthCacheWithoutExecutionRole(t *testing.T) {
 			reader: strings.NewReader(`{"status":"pull complete"}`),
 		}, nil).Times(4)
 
-	metadata := client.PullImage(image, authData)
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	metadata := client.PullImage(ctx, image, authData, dockerclient.PullImageTimeout)
 	assert.NoError(t, metadata.Error, "Expected pull to succeed")
 
 	// Pull from the same registry shouldn't expect ecr client call
-	metadata = client.PullImage(image+"2", authData)
+	metadata = client.PullImage(ctx, image+"2", authData, dockerclient.PullImageTimeout)
 	assert.NoError(t, metadata.Error, "Expected pull to succeed")
 
 	// Pull from the same registry shouldn't expect ecr client call
-	metadata = client.PullImage(image+"3", authData)
+	metadata = client.PullImage(ctx, image+"3", authData, dockerclient.PullImageTimeout)
 	assert.NoError(t, metadata.Error, "Expected pull to succeed")
 
 	// Pull from the same registry shouldn't expect ecr client call
-	metadata = client.PullImage(image+"4", authData)
+	metadata = client.PullImage(ctx, image+"4", authData, dockerclient.PullImageTimeout)
 	assert.NoError(t, metadata.Error, "Expected pull to succeed")
 }
 
@@ -1240,7 +1251,9 @@ func TestECRAuthCacheForDifferentRegistry(t *testing.T) {
 			reader: strings.NewReader(`{"status":"pull complete"}`),
 		}, nil).Times(2)
 
-	metadata := client.PullImage(image, authData)
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	metadata := client.PullImage(ctx, image, authData, dockerclient.PullImageTimeout)
 	assert.NoError(t, metadata.Error, "Expected pull to succeed")
 
 	// Pull from the different registry should expect ECR client call
@@ -1252,7 +1265,7 @@ func TestECRAuthCacheForDifferentRegistry(t *testing.T) {
 			AuthorizationToken: aws.String(base64.StdEncoding.EncodeToString([]byte(username + ":" + password))),
 			ExpiresAt:          aws.Time(time.Now().Add(10 * time.Hour)),
 		}, nil).Times(1)
-	metadata = client.PullImage(image, authData)
+	metadata = client.PullImage(ctx, image, authData, dockerclient.PullImageTimeout)
 	assert.NoError(t, metadata.Error, "Expected pull to succeed")
 }
 
@@ -1297,15 +1310,17 @@ func TestECRAuthCacheWithSameExecutionRole(t *testing.T) {
 			reader: strings.NewReader(`{"status":"pull complete"}`),
 		}, nil).Times(3)
 
-	metadata := client.PullImage(image, authData)
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	metadata := client.PullImage(ctx, image, authData, dockerclient.PullImageTimeout)
 	assert.NoError(t, metadata.Error, "Expected pull to succeed")
 
 	// Pull from the same registry shouldn't expect ecr client call
-	metadata = client.PullImage(image+"2", authData)
+	metadata = client.PullImage(ctx, image+"2", authData, dockerclient.PullImageTimeout)
 	assert.NoError(t, metadata.Error, "Expected pull to succeed")
 
 	// Pull from the same registry shouldn't expect ecr client call
-	metadata = client.PullImage(image+"3", authData)
+	metadata = client.PullImage(ctx, image+"3", authData, dockerclient.PullImageTimeout)
 	assert.NoError(t, metadata.Error, "Expected pull to succeed")
 }
 
@@ -1350,7 +1365,9 @@ func TestECRAuthCacheWithDifferentExecutionRole(t *testing.T) {
 			reader: strings.NewReader(`{"status":"pull complete"}`),
 		}, nil).Times(2)
 
-	metadata := client.PullImage(image, authData)
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	metadata := client.PullImage(ctx, image, authData, dockerclient.PullImageTimeout)
 	assert.NoError(t, metadata.Error, "Expected pull to succeed")
 
 	// Pull from the same registry but with different role
@@ -1364,7 +1381,7 @@ func TestECRAuthCacheWithDifferentExecutionRole(t *testing.T) {
 			AuthorizationToken: aws.String(base64.StdEncoding.EncodeToString([]byte(username + ":" + password))),
 			ExpiresAt:          aws.Time(time.Now().Add(10 * time.Hour)),
 		}, nil).Times(1)
-	metadata = client.PullImage(image, authData)
+	metadata = client.PullImage(ctx, image, authData, dockerclient.PullImageTimeout)
 	assert.NoError(t, metadata.Error, "Expected pull to succeed")
 }
 

--- a/agent/dockerclient/dockerapi/inactivity_timeout_handler.go
+++ b/agent/dockerclient/dockerapi/inactivity_timeout_handler.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -34,8 +34,8 @@ func (p *proxyReader) Read(data []byte) (int, error) {
 }
 
 // When pulling an image, the docker api will pull and then subsequently unzip the downloaded artifacts. Docker does
-// not seperate the "pull" from the "unpack" step. What this means is that this timeout doesn't 'tick' while unpacking
-// the downloaded files. This only causes noticable impact with large files, but we should investigate improving this.
+// not separate the "pull" from the "unpack" step. What this means is that this timeout doesn't 'tick' while unpacking
+// the downloaded files. This only causes noticeable impact with large files, but we should investigate improving this.
 func handleInactivityTimeout(reader io.ReadCloser, timeout time.Duration, cancelRequest func(), canceled *uint32) (io.ReadCloser, chan<- struct{}) {
 	done := make(chan struct{})
 	proxyReader := &proxyReader{ReadCloser: reader}

--- a/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
+++ b/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
@@ -231,15 +231,15 @@ func (mr *MockDockerClientMockRecorder) LoadImage(arg0, arg1, arg2 interface{}) 
 }
 
 // PullImage mocks base method
-func (m *MockDockerClient) PullImage(arg0 string, arg1 *container.RegistryAuthenticationData) dockerapi.DockerContainerMetadata {
-	ret := m.ctrl.Call(m, "PullImage", arg0, arg1)
+func (m *MockDockerClient) PullImage(arg0 context.Context, arg1 string, arg2 *container.RegistryAuthenticationData, arg3 time.Duration) dockerapi.DockerContainerMetadata {
+	ret := m.ctrl.Call(m, "PullImage", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(dockerapi.DockerContainerMetadata)
 	return ret0
 }
 
 // PullImage indicates an expected call of PullImage
-func (mr *MockDockerClientMockRecorder) PullImage(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PullImage", reflect.TypeOf((*MockDockerClient)(nil).PullImage), arg0, arg1)
+func (mr *MockDockerClientMockRecorder) PullImage(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PullImage", reflect.TypeOf((*MockDockerClient)(nil).PullImage), arg0, arg1, arg2, arg3)
 }
 
 // RemoveContainer mocks base method

--- a/agent/engine/common_test.go
+++ b/agent/engine/common_test.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -139,7 +139,7 @@ func validateContainerRunWorkflow(t *testing.T,
 	assertions func(),
 ) {
 	imageManager.EXPECT().AddAllImageStates(gomock.Any()).AnyTimes()
-	client.EXPECT().PullImage(container.Image, nil).Return(dockerapi.DockerContainerMetadata{})
+	client.EXPECT().PullImage(gomock.Any(), container.Image, nil, gomock.Any()).Return(dockerapi.DockerContainerMetadata{})
 	imageManager.EXPECT().RecordContainerReference(container).Return(nil)
 	imageManager.EXPECT().GetImageStateFromImageName(gomock.Any()).Return(nil, false)
 	client.EXPECT().APIVersion().Return(defaultDockerClientAPIVersion, nil)

--- a/agent/engine/docker_image_manager.go
+++ b/agent/engine/docker_image_manager.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/engine/docker_image_manager_integ_test.go
+++ b/agent/engine/docker_image_manager_integ_test.go
@@ -1,5 +1,5 @@
 // +build integration
-// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -296,15 +296,15 @@ func TestImageWithSameNameAndDifferentID(t *testing.T) {
 
 	// Pull the images needed for the test
 	if _, err = dockerClient.InspectImage(test3Image1Name); client.IsErrNotFound(err) {
-		metadata := dockerClient.PullImage(test3Image1Name, nil)
+		metadata := dockerClient.PullImage(ctx, test3Image1Name, nil, dockerclient.LoadImageTimeout)
 		assert.NoError(t, metadata.Error, "Failed to pull image %s", test3Image1Name)
 	}
 	if _, err = dockerClient.InspectImage(test3Image2Name); client.IsErrNotFound(err) {
-		metadata := dockerClient.PullImage(test3Image2Name, nil)
+		metadata := dockerClient.PullImage(ctx, test3Image2Name, nil, dockerclient.LoadImageTimeout)
 		assert.NoError(t, metadata.Error, "Failed to pull image %s", test3Image2Name)
 	}
 	if _, err = dockerClient.InspectImage(test3Image3Name); client.IsErrNotFound(err) {
-		metadata := dockerClient.PullImage(test3Image3Name, nil)
+		metadata := dockerClient.PullImage(ctx, test3Image3Name, nil, dockerclient.LoadImageTimeout)
 		assert.NoError(t, metadata.Error, "Failed to pull image %s", test3Image3Name)
 	}
 
@@ -444,7 +444,7 @@ func TestImageWithSameIDAndDifferentNames(t *testing.T) {
 
 	// Pull the images needed for the test
 	if _, err = dockerClient.InspectImage(test4Image1Name); client.IsErrNotFound(err) {
-		metadata := dockerClient.PullImage(test4Image1Name, nil)
+		metadata := dockerClient.PullImage(ctx, test4Image1Name, nil, dockerclient.PullImageTimeout)
 		assert.NoError(t, metadata.Error, "Failed to pull image %s", test4Image1Name)
 	}
 

--- a/agent/engine/docker_image_manager_test.go
+++ b/agent/engine/docker_image_manager_test.go
@@ -1,6 +1,6 @@
 // +build unit
 
-// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -145,8 +145,8 @@ func TestRecordContainerReferenceInspectError(t *testing.T) {
 	client := mock_dockerapi.NewMockDockerClient(ctrl)
 
 	imageManager := &dockerImageManager{
-		client:                   client,
-		state:                    dockerstate.NewTaskEngineState(),
+		client: client,
+		state:  dockerstate.NewTaskEngineState(),
 		minimumAgeBeforeDeletion: config.DefaultImageDeletionAge,
 		numImagesToDelete:        config.DefaultNumImagesToDeletePerCycle,
 		imageCleanupTimeInterval: config.DefaultImageCleanupTimeInterval,
@@ -179,8 +179,8 @@ func TestRecordContainerReferenceWithNoImageName(t *testing.T) {
 	client := mock_dockerapi.NewMockDockerClient(ctrl)
 
 	imageManager := &dockerImageManager{
-		client:                   client,
-		state:                    dockerstate.NewTaskEngineState(),
+		client: client,
+		state:  dockerstate.NewTaskEngineState(),
 		minimumAgeBeforeDeletion: config.DefaultImageDeletionAge,
 		numImagesToDelete:        config.DefaultNumImagesToDeletePerCycle,
 		imageCleanupTimeInterval: config.DefaultImageCleanupTimeInterval,
@@ -406,8 +406,8 @@ func TestRemoveContainerReferenceFromImageStateWithNoReference(t *testing.T) {
 	client := mock_dockerapi.NewMockDockerClient(ctrl)
 
 	imageManager := &dockerImageManager{
-		client:                   client,
-		state:                    dockerstate.NewTaskEngineState(),
+		client: client,
+		state:  dockerstate.NewTaskEngineState(),
 		minimumAgeBeforeDeletion: config.DefaultImageDeletionAge,
 		numImagesToDelete:        config.DefaultNumImagesToDeletePerCycle,
 		imageCleanupTimeInterval: config.DefaultImageCleanupTimeInterval,
@@ -442,8 +442,8 @@ func TestGetCandidateImagesForDeletionImageNoImageState(t *testing.T) {
 	client := mock_dockerapi.NewMockDockerClient(ctrl)
 
 	imageManager := &dockerImageManager{
-		client:                   client,
-		state:                    dockerstate.NewTaskEngineState(),
+		client: client,
+		state:  dockerstate.NewTaskEngineState(),
 		minimumAgeBeforeDeletion: config.DefaultImageDeletionAge,
 		numImagesToDelete:        config.DefaultNumImagesToDeletePerCycle,
 		imageCleanupTimeInterval: config.DefaultImageCleanupTimeInterval,
@@ -462,8 +462,8 @@ func TestGetCandidateImagesForDeletionImageJustPulled(t *testing.T) {
 	client := mock_dockerapi.NewMockDockerClient(ctrl)
 
 	imageManager := &dockerImageManager{
-		client:                   client,
-		state:                    dockerstate.NewTaskEngineState(),
+		client: client,
+		state:  dockerstate.NewTaskEngineState(),
 		minimumAgeBeforeDeletion: config.DefaultImageDeletionAge,
 		numImagesToDelete:        config.DefaultNumImagesToDeletePerCycle,
 		imageCleanupTimeInterval: config.DefaultImageCleanupTimeInterval,
@@ -487,8 +487,8 @@ func TestGetCandidateImagesForDeletionImageHasContainerReference(t *testing.T) {
 	client := mock_dockerapi.NewMockDockerClient(ctrl)
 
 	imageManager := &dockerImageManager{
-		client:                   client,
-		state:                    dockerstate.NewTaskEngineState(),
+		client: client,
+		state:  dockerstate.NewTaskEngineState(),
 		minimumAgeBeforeDeletion: config.DefaultImageDeletionAge,
 		numImagesToDelete:        config.DefaultNumImagesToDeletePerCycle,
 		imageCleanupTimeInterval: config.DefaultImageCleanupTimeInterval,
@@ -528,8 +528,8 @@ func TestGetCandidateImagesForDeletionImageHasMoreContainerReferences(t *testing
 	client := mock_dockerapi.NewMockDockerClient(ctrl)
 
 	imageManager := &dockerImageManager{
-		client:                   client,
-		state:                    dockerstate.NewTaskEngineState(),
+		client: client,
+		state:  dockerstate.NewTaskEngineState(),
 		minimumAgeBeforeDeletion: config.DefaultImageDeletionAge,
 		numImagesToDelete:        config.DefaultNumImagesToDeletePerCycle,
 		imageCleanupTimeInterval: config.DefaultImageCleanupTimeInterval,
@@ -606,8 +606,8 @@ func TestImageCleanupExclusionListWithSingleName(t *testing.T) {
 		PulledAt: time.Now().AddDate(0, -2, 0),
 	}
 	imageManager := &dockerImageManager{
-		client:                    client,
-		state:                     dockerstate.NewTaskEngineState(),
+		client: client,
+		state:  dockerstate.NewTaskEngineState(),
 		minimumAgeBeforeDeletion:  config.DefaultImageDeletionAge,
 		numImagesToDelete:         config.DefaultNumImagesToDeletePerCycle,
 		imageCleanupTimeInterval:  config.DefaultImageCleanupTimeInterval,
@@ -665,8 +665,8 @@ func TestImageCleanupExclusionListWithMultipleNames(t *testing.T) {
 		PulledAt: time.Now().AddDate(0, -2, 0),
 	}
 	imageManager := &dockerImageManager{
-		client:                    client,
-		state:                     dockerstate.NewTaskEngineState(),
+		client: client,
+		state:  dockerstate.NewTaskEngineState(),
 		minimumAgeBeforeDeletion:  config.DefaultImageDeletionAge,
 		numImagesToDelete:         config.DefaultNumImagesToDeletePerCycle,
 		imageCleanupTimeInterval:  config.DefaultImageCleanupTimeInterval,
@@ -731,8 +731,8 @@ func TestGetLeastRecentlyUsedImagesLessThanFive(t *testing.T) {
 	client := mock_dockerapi.NewMockDockerClient(ctrl)
 
 	imageManager := &dockerImageManager{
-		client:                   client,
-		state:                    dockerstate.NewTaskEngineState(),
+		client: client,
+		state:  dockerstate.NewTaskEngineState(),
 		minimumAgeBeforeDeletion: config.DefaultImageDeletionAge,
 		numImagesToDelete:        config.DefaultNumImagesToDeletePerCycle,
 		imageCleanupTimeInterval: config.DefaultImageCleanupTimeInterval,
@@ -765,8 +765,8 @@ func TestRemoveAlreadyExistingImageNameWithDifferentID(t *testing.T) {
 	client := mock_dockerapi.NewMockDockerClient(ctrl)
 
 	imageManager := &dockerImageManager{
-		client:                   client,
-		state:                    dockerstate.NewTaskEngineState(),
+		client: client,
+		state:  dockerstate.NewTaskEngineState(),
 		minimumAgeBeforeDeletion: config.DefaultImageDeletionAge,
 		numImagesToDelete:        config.DefaultNumImagesToDeletePerCycle,
 		imageCleanupTimeInterval: config.DefaultImageCleanupTimeInterval,
@@ -816,8 +816,8 @@ func TestImageCleanupHappyPath(t *testing.T) {
 	client := mock_dockerapi.NewMockDockerClient(ctrl)
 
 	imageManager := &dockerImageManager{
-		client:                   client,
-		state:                    dockerstate.NewTaskEngineState(),
+		client: client,
+		state:  dockerstate.NewTaskEngineState(),
 		minimumAgeBeforeDeletion: 1 * time.Millisecond,
 		numImagesToDelete:        config.DefaultNumImagesToDeletePerCycle,
 		imageCleanupTimeInterval: config.DefaultImageCleanupTimeInterval,
@@ -873,8 +873,8 @@ func TestImageCleanupCannotRemoveImage(t *testing.T) {
 	client := mock_dockerapi.NewMockDockerClient(ctrl)
 
 	imageManager := &dockerImageManager{
-		client:                   client,
-		state:                    dockerstate.NewTaskEngineState(),
+		client: client,
+		state:  dockerstate.NewTaskEngineState(),
 		minimumAgeBeforeDeletion: config.DefaultImageDeletionAge,
 		numImagesToDelete:        config.DefaultNumImagesToDeletePerCycle,
 		imageCleanupTimeInterval: config.DefaultImageCleanupTimeInterval,
@@ -931,8 +931,8 @@ func TestImageCleanupRemoveImageById(t *testing.T) {
 	client := mock_dockerapi.NewMockDockerClient(ctrl)
 
 	imageManager := &dockerImageManager{
-		client:                   client,
-		state:                    dockerstate.NewTaskEngineState(),
+		client: client,
+		state:  dockerstate.NewTaskEngineState(),
 		minimumAgeBeforeDeletion: config.DefaultImageDeletionAge,
 		numImagesToDelete:        config.DefaultNumImagesToDeletePerCycle,
 		imageCleanupTimeInterval: config.DefaultImageCleanupTimeInterval,
@@ -984,8 +984,8 @@ func TestNonECSImageAndContainersCleanupRemoveImage(t *testing.T) {
 	defer ctrl.Finish()
 	client := mock_dockerapi.NewMockDockerClient(ctrl)
 	imageManager := &dockerImageManager{
-		client:                    client,
-		state:                     dockerstate.NewTaskEngineState(),
+		client: client,
+		state:  dockerstate.NewTaskEngineState(),
 		minimumAgeBeforeDeletion:  config.DefaultImageDeletionAge,
 		numImagesToDelete:         config.DefaultNumImagesToDeletePerCycle,
 		imageCleanupTimeInterval:  config.DefaultImageCleanupTimeInterval,
@@ -1220,8 +1220,8 @@ func TestConcurrentRemoveUnusedImages(t *testing.T) {
 	client := mock_dockerapi.NewMockDockerClient(ctrl)
 
 	imageManager := &dockerImageManager{
-		client:                   client,
-		state:                    dockerstate.NewTaskEngineState(),
+		client: client,
+		state:  dockerstate.NewTaskEngineState(),
 		minimumAgeBeforeDeletion: config.DefaultImageDeletionAge,
 		numImagesToDelete:        config.DefaultNumImagesToDeletePerCycle,
 		imageCleanupTimeInterval: config.DefaultImageCleanupTimeInterval,

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -792,7 +792,7 @@ func (engine *DockerTaskEngine) pullAndUpdateContainerReference(task *apitask.Ta
 		defer container.SetASMDockerAuthConfig(types.AuthConfig{})
 	}
 
-	metadata := engine.client.PullImage(container.Image, container.RegistryAuthentication)
+	metadata := engine.client.PullImage(engine.ctx, container.Image, container.RegistryAuthentication, dockerclient.PullImageTimeout)
 
 	// Don't add internal images(created by ecs-agent) into imagemanger state
 	if container.IsInternal() {

--- a/agent/engine/docker_task_engine_linux_test.go
+++ b/agent/engine/docker_task_engine_linux_test.go
@@ -91,7 +91,7 @@ func TestResourceContainerProgression(t *testing.T) {
 		mockControl.EXPECT().Create(gomock.Any()).Return(nil, nil),
 		mockIO.EXPECT().WriteFile(cgroupMemoryPath, gomock.Any(), gomock.Any()).Return(nil),
 		imageManager.EXPECT().AddAllImageStates(gomock.Any()).AnyTimes(),
-		client.EXPECT().PullImage(sleepContainer.Image, nil).Return(dockerapi.DockerContainerMetadata{}),
+		client.EXPECT().PullImage(gomock.Any(), sleepContainer.Image, nil, gomock.Any()).Return(dockerapi.DockerContainerMetadata{}),
 		imageManager.EXPECT().RecordContainerReference(sleepContainer).Return(nil),
 		imageManager.EXPECT().GetImageStateFromImageName(sleepContainer.Image).Return(nil, false),
 		client.EXPECT().APIVersion().Return(defaultDockerClientAPIVersion, nil),

--- a/scripts/generate/mockgen.go
+++ b/scripts/generate/mockgen.go
@@ -64,7 +64,6 @@ func main() {
 		fmt.Println(err)
 		os.Exit(1)
 	}
-
 }
 
 func generateMocks(packageName string, interfaces string, outputPath string) error {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
We have context wired for other docker APIs but we didn't do that for PullImage, so add the context to the PullImage API and change a bunch of tests to accommodate the API change.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [ ] Builds on Linux (`make release`)
- [ ] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [ ] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=30s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
