### PR TITLE
Increase Windows functional test timeout

### DIFF
--- a/scripts/run-functional-tests.ps1
+++ b/scripts/run-functional-tests.ps1
@@ -23,7 +23,7 @@ Invoke-Expression "${PSScriptRoot}\..\misc\container-metadata-file-validator-win
 $cwd = (pwd).Path
 try {
   cd "${PSScriptRoot}"
-  go test -tags functional -timeout=30m -v ../agent/functional_tests/tests
+  go test -tags functional -timeout=40m -v ../agent/functional_tests/tests
   $handwrittenExitCode = $LastExitCode
   echo "Handwritten functional tests exited with ${handwrittenExitCode}"
   go test -tags functional -timeout=30m -v ../agent/functional_tests/tests/generated/simpletests_windows


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Simply increase the timeout by 10min, this is a fix for issue #1786 (which is seen in many PRs) in short term.


### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [ ] Builds on Linux (`make release`)
- [ ] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [ ] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=30s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
