### PR TITLE
pass TelemetrySessionParams by reference

### DIFF
--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -603,7 +603,7 @@ func (agent *ecsAgent) startAsyncRoutines(
 	}
 
 	// Start metrics session in a go routine
-	go tcshandler.StartMetricsSession(telemetrySessionParams)
+	go tcshandler.StartMetricsSession(&telemetrySessionParams)
 }
 
 // startACSSession starts a session with ECS's Agent Communication service. This

--- a/agent/tcs/handler/handler.go
+++ b/agent/tcs/handler/handler.go
@@ -46,7 +46,7 @@ const (
 
 // StartMetricsSession starts a metric session. It initializes the stats engine
 // and invokes StartSession.
-func StartMetricsSession(params TelemetrySessionParams) {
+func StartMetricsSession(params *TelemetrySessionParams) {
 	ok, err := params.isContainerHealthMetricsDisabled()
 	if err != nil {
 		seelog.Warnf("Error starting metrics session: %v", err)
@@ -74,7 +74,7 @@ func StartMetricsSession(params TelemetrySessionParams) {
 // using the passed in arguments.
 // The engine is expected to initialized and gathering container metrics by
 // the time the websocket client starts using it.
-func StartSession(params TelemetrySessionParams, statsEngine stats.Engine) error {
+func StartSession(params *TelemetrySessionParams, statsEngine stats.Engine) error {
 	backoff := utils.NewSimpleBackoff(time.Second, 1*time.Minute, 0.2, 2)
 	for {
 		tcsError := startTelemetrySession(params, statsEngine)
@@ -88,7 +88,7 @@ func StartSession(params TelemetrySessionParams, statsEngine stats.Engine) error
 	}
 }
 
-func startTelemetrySession(params TelemetrySessionParams, statsEngine stats.Engine) error {
+func startTelemetrySession(params *TelemetrySessionParams, statsEngine stats.Engine) error {
 	tcsEndpoint, err := params.ECSClient.DiscoverTelemetryEndpoint(params.ContainerInstanceArn)
 	if err != nil {
 		seelog.Errorf("tcs: unable to discover poll endpoint: %v", err)

--- a/agent/tcs/handler/handler_test.go
+++ b/agent/tcs/handler/handler_test.go
@@ -83,7 +83,7 @@ func TestDisableMetrics(t *testing.T) {
 		},
 	}
 
-	StartMetricsSession(params)
+	StartMetricsSession(&params)
 }
 
 func TestFormatURL(t *testing.T) {
@@ -254,7 +254,7 @@ func TestDiscoverEndpointAndStartSession(t *testing.T) {
 	mockEcs := mock_api.NewMockECSClient(ctrl)
 	mockEcs.EXPECT().DiscoverTelemetryEndpoint(gomock.Any()).Return("", errors.New("error"))
 
-	err := startTelemetrySession(TelemetrySessionParams{ECSClient: mockEcs}, nil)
+	err := startTelemetrySession(&TelemetrySessionParams{ECSClient: mockEcs}, nil)
 	if err == nil {
 		t.Error("Expected error from startTelemetrySession when DiscoverTelemetryEndpoint returns error")
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
TelemetrySessionParams uses sync.Once which internally contains a mutex.  `go vet` hates it when we pass copies of mutexes around.  
Let's pass by reference instead.

### Testing
Ran tests on my Linux EC2 (Latest EBS AMI).  Tests passed.
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=30s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes, (tests updated to cover the changes)

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
