### PR TITLE
pass reference to SetTaskCredentials()

### DIFF
--- a/agent/acs/handler/acs_handler_test.go
+++ b/agent/acs/handler/acs_handler_test.go
@@ -962,8 +962,8 @@ func TestStartSessionHandlesRefreshCredentialsMessages(t *testing.T) {
 		taskEngine.EXPECT().GetTaskByArn("t1").Return(taskFromEngine, true),
 		// The last invocation of SetCredentials is to update
 		// credentials when a refresh message is received by the handler
-		credentialsManager.EXPECT().SetTaskCredentials(gomock.Any()).Do(func(creds rolecredentials.TaskIAMRoleCredentials) {
-			updatedCredentials = creds
+		credentialsManager.EXPECT().SetTaskCredentials(gomock.Any()).Do(func(creds *rolecredentials.TaskIAMRoleCredentials) {
+			updatedCredentials = *creds
 			// Validate parsed credentials after the update
 			expectedCreds := rolecredentials.TaskIAMRoleCredentials{
 				ARN: "t1",

--- a/agent/acs/handler/payload_handler.go
+++ b/agent/acs/handler/payload_handler.go
@@ -199,10 +199,10 @@ func (payloadHandler *payloadRequestHandler) addPayloadTasks(payload *ecsacs.Pay
 			// credentials id for the task as well
 			taskIAMRoleCredentials := credentials.IAMRoleCredentialsFromACS(task.RoleCredentials, credentials.ApplicationRoleType)
 			err = payloadHandler.credentialsManager.SetTaskCredentials(
-				credentials.TaskIAMRoleCredentials{
+				&(credentials.TaskIAMRoleCredentials{
 					ARN:                aws.StringValue(task.Arn),
 					IAMRoleCredentials: taskIAMRoleCredentials,
-				})
+				}))
 			if err != nil {
 				payloadHandler.handleUnrecognizedTask(task, err, payload)
 				allTasksOK = false
@@ -228,10 +228,10 @@ func (payloadHandler *payloadRequestHandler) addPayloadTasks(payload *ecsacs.Pay
 			// task executionCredentials id.
 			taskExecutionIAMRoleCredentials := credentials.IAMRoleCredentialsFromACS(task.ExecutionRoleCredentials, credentials.ExecutionRoleType)
 			err = payloadHandler.credentialsManager.SetTaskCredentials(
-				credentials.TaskIAMRoleCredentials{
+				&(credentials.TaskIAMRoleCredentials{
 					ARN:                aws.StringValue(task.Arn),
 					IAMRoleCredentials: taskExecutionIAMRoleCredentials,
-				})
+				}))
 			if err != nil {
 				payloadHandler.handleUnrecognizedTask(task, err, payload)
 				allTasksOK = false

--- a/agent/acs/handler/refresh_credentials_handler.go
+++ b/agent/acs/handler/refresh_credentials_handler.go
@@ -133,10 +133,10 @@ func (refreshHandler *refreshCredentialsHandler) handleSingleMessage(message *ec
 		seelog.Errorf("Unknown RoleType for task in credentials message, roleType: %s arn: %s, messageId: %s", roleType, taskArn, messageId)
 	} else {
 		err = refreshHandler.credentialsManager.SetTaskCredentials(
-			credentials.TaskIAMRoleCredentials{
+			&(credentials.TaskIAMRoleCredentials{
 				ARN:                taskArn,
 				IAMRoleCredentials: credentials.IAMRoleCredentialsFromACS(message.RoleCredentials, roleType),
-			})
+			}))
 		if err != nil {
 			seelog.Errorf("Unable to update credentials for task, err: %v messageId: %s", err, messageId)
 			return fmt.Errorf("unable to update credentials %v", err)

--- a/agent/credentials/interface.go
+++ b/agent/credentials/interface.go
@@ -17,7 +17,7 @@ package credentials
 // instance of the credentials manager is created in the agent, and shared
 // between the task engine, acs and credentials handlers
 type Manager interface {
-	SetTaskCredentials(TaskIAMRoleCredentials) error
+	SetTaskCredentials(*TaskIAMRoleCredentials) error
 	GetTaskCredentials(string) (TaskIAMRoleCredentials, bool)
 	RemoveCredentials(string)
 }

--- a/agent/credentials/manager.go
+++ b/agent/credentials/manager.go
@@ -116,7 +116,7 @@ func NewManager() Manager {
 }
 
 // SetTaskCredentials adds or updates credentials in the credentials manager
-func (manager *credentialsManager) SetTaskCredentials(taskCredentials TaskIAMRoleCredentials) error {
+func (manager *credentialsManager) SetTaskCredentials(taskCredentials *TaskIAMRoleCredentials) error {
 	manager.taskCredentialsLock.Lock()
 	defer manager.taskCredentialsLock.Unlock()
 

--- a/agent/credentials/manager_test.go
+++ b/agent/credentials/manager_test.go
@@ -65,7 +65,7 @@ func TestGetTaskCredentialsUnknownId(t *testing.T) {
 // error when invalid credentials are used to set credentials
 func TestSetTaskCredentialsEmptyTaskCredentials(t *testing.T) {
 	manager := NewManager()
-	err := manager.SetTaskCredentials(TaskIAMRoleCredentials{})
+	err := manager.SetTaskCredentials(&TaskIAMRoleCredentials{})
 	assert.Error(t, err, "Expected error adding empty task credentials")
 }
 
@@ -73,7 +73,7 @@ func TestSetTaskCredentialsEmptyTaskCredentials(t *testing.T) {
 // error when credentials object with no credentials id is used to set credentials
 func TestSetTaskCredentialsNoCredentialsId(t *testing.T) {
 	manager := NewManager()
-	err := manager.SetTaskCredentials(TaskIAMRoleCredentials{ARN: "t1", IAMRoleCredentials: IAMRoleCredentials{}})
+	err := manager.SetTaskCredentials(&TaskIAMRoleCredentials{ARN: "t1", IAMRoleCredentials: IAMRoleCredentials{}})
 	assert.Error(t, err, "Expected error adding credentials payload without credential ID")
 }
 
@@ -81,7 +81,7 @@ func TestSetTaskCredentialsNoCredentialsId(t *testing.T) {
 // error when credentials object with no task arn used to set credentials
 func TestSetTaskCredentialsNoTaskArn(t *testing.T) {
 	manager := NewManager()
-	err := manager.SetTaskCredentials(TaskIAMRoleCredentials{IAMRoleCredentials: IAMRoleCredentials{CredentialsID: "id"}})
+	err := manager.SetTaskCredentials(&TaskIAMRoleCredentials{IAMRoleCredentials: IAMRoleCredentials{CredentialsID: "id"}})
 	assert.Error(t, err, "Expected error adding credentials payload without task ARN")
 }
 
@@ -101,7 +101,7 @@ func TestSetAndGetTaskCredentialsHappyPath(t *testing.T) {
 		},
 	}
 
-	err := manager.SetTaskCredentials(credentials)
+	err := manager.SetTaskCredentials(&credentials)
 	assert.NoError(t, err, "Error adding credentials")
 
 	credentialsFromManager, ok := manager.GetTaskCredentials("cid1")
@@ -119,7 +119,7 @@ func TestSetAndGetTaskCredentialsHappyPath(t *testing.T) {
 			CredentialsID:   "cid1",
 		},
 	}
-	err = manager.SetTaskCredentials(updatedCredentials)
+	err = manager.SetTaskCredentials(&updatedCredentials)
 	assert.NoError(t, err, "Error updating credentials")
 	credentialsFromManager, ok = manager.GetTaskCredentials("cid1")
 
@@ -158,7 +158,7 @@ func TestRemoveExistingCredentials(t *testing.T) {
 			CredentialsID:   "cid1",
 		},
 	}
-	err := manager.SetTaskCredentials(credentials)
+	err := manager.SetTaskCredentials(&credentials)
 	assert.NoError(t, err, "Error adding credentials")
 
 	credentialsFromManager, ok := manager.GetTaskCredentials("cid1")

--- a/agent/credentials/mocks/credentials_mocks.go
+++ b/agent/credentials/mocks/credentials_mocks.go
@@ -71,7 +71,7 @@ func (mr *MockManagerMockRecorder) RemoveCredentials(arg0 interface{}) *gomock.C
 }
 
 // SetTaskCredentials mocks base method
-func (m *MockManager) SetTaskCredentials(arg0 credentials.TaskIAMRoleCredentials) error {
+func (m *MockManager) SetTaskCredentials(arg0 *credentials.TaskIAMRoleCredentials) error {
 	ret := m.ctrl.Call(m, "SetTaskCredentials", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0

--- a/agent/engine/engine_integ_test.go
+++ b/agent/engine/engine_integ_test.go
@@ -235,7 +235,7 @@ func TestStartStopWithCredentials(t *testing.T) {
 	taskCredentials := credentials.TaskIAMRoleCredentials{
 		IAMRoleCredentials: credentials.IAMRoleCredentials{CredentialsID: credentialsIDIntegTest},
 	}
-	credentialsManager.SetTaskCredentials(taskCredentials)
+	credentialsManager.SetTaskCredentials(&taskCredentials)
 	testTask.SetCredentialsID(credentialsIDIntegTest)
 
 	go taskEngine.AddTask(testTask)

--- a/agent/engine/task_manager_test.go
+++ b/agent/engine/task_manager_test.go
@@ -68,10 +68,10 @@ func TestHandleEventError(t *testing.T) {
 		ExpectedOK                            bool
 	}{
 		{
-			Name:                        "Stop timed out",
-			EventStatus:                 apicontainerstatus.ContainerStopped,
-			CurrentContainerKnownStatus: apicontainerstatus.ContainerRunning,
-			Error: &dockerapi.DockerTimeoutError{},
+			Name:                            "Stop timed out",
+			EventStatus:                     apicontainerstatus.ContainerStopped,
+			CurrentContainerKnownStatus:     apicontainerstatus.ContainerRunning,
+			Error:                           &dockerapi.DockerTimeoutError{},
 			ExpectedContainerKnownStatusSet: true,
 			ExpectedContainerKnownStatus:    apicontainerstatus.ContainerRunning,
 			ExpectedOK:                      false,
@@ -100,17 +100,17 @@ func TestHandleEventError(t *testing.T) {
 			ExpectedOK:                            true,
 		},
 		{
-			Name:  "Pull failed",
-			Error: &dockerapi.DockerTimeoutError{},
+			Name:                            "Pull failed",
+			Error:                           &dockerapi.DockerTimeoutError{},
 			ExpectedContainerKnownStatusSet: true,
 			EventStatus:                     apicontainerstatus.ContainerPulled,
 			ExpectedOK:                      true,
 		},
 		{
-			Name:                        "Container vanished betweeen pull and running",
-			EventStatus:                 apicontainerstatus.ContainerRunning,
-			CurrentContainerKnownStatus: apicontainerstatus.ContainerPulled,
-			Error: &ContainerVanishedError{},
+			Name:                                  "Container vanished betweeen pull and running",
+			EventStatus:                           apicontainerstatus.ContainerRunning,
+			CurrentContainerKnownStatus:           apicontainerstatus.ContainerPulled,
+			Error:                                 &ContainerVanishedError{},
 			ExpectedContainerKnownStatusSet:       true,
 			ExpectedContainerKnownStatus:          apicontainerstatus.ContainerPulled,
 			ExpectedContainerDesiredStatusStopped: true,
@@ -129,10 +129,10 @@ func TestHandleEventError(t *testing.T) {
 			ExpectedOK:                            false,
 		},
 		{
-			Name:                        "Start timed out",
-			EventStatus:                 apicontainerstatus.ContainerRunning,
-			CurrentContainerKnownStatus: apicontainerstatus.ContainerCreated,
-			Error: &dockerapi.DockerTimeoutError{},
+			Name:                                  "Start timed out",
+			EventStatus:                           apicontainerstatus.ContainerRunning,
+			CurrentContainerKnownStatus:           apicontainerstatus.ContainerCreated,
+			Error:                                 &dockerapi.DockerTimeoutError{},
 			ExpectedContainerKnownStatusSet:       true,
 			ExpectedContainerKnownStatus:          apicontainerstatus.ContainerCreated,
 			ExpectedContainerDesiredStatusStopped: true,
@@ -151,10 +151,10 @@ func TestHandleEventError(t *testing.T) {
 			ExpectedOK:                            false,
 		},
 		{
-			Name:                        "Create timed out",
-			EventStatus:                 apicontainerstatus.ContainerCreated,
-			CurrentContainerKnownStatus: apicontainerstatus.ContainerPulled,
-			Error: &dockerapi.DockerTimeoutError{},
+			Name:                                  "Create timed out",
+			EventStatus:                           apicontainerstatus.ContainerCreated,
+			CurrentContainerKnownStatus:           apicontainerstatus.ContainerPulled,
+			Error:                                 &dockerapi.DockerTimeoutError{},
 			ExpectedContainerKnownStatusSet:       true,
 			ExpectedContainerKnownStatus:          apicontainerstatus.ContainerPulled,
 			ExpectedContainerDesiredStatusStopped: true,
@@ -350,7 +350,7 @@ func TestContainerNextStateWithTransitionDependencies(t *testing.T) {
 	}{
 		// NONE -> RUNNING transition is not allowed and not actionable, when pull depends on create and dependency is None
 		{
-			name: "pull depends on created, dependency is none",
+			name:                         "pull depends on created, dependency is none",
 			containerCurrentStatus:       apicontainerstatus.ContainerStatusNone,
 			containerDesiredStatus:       apicontainerstatus.ContainerRunning,
 			containerDependentStatus:     apicontainerstatus.ContainerPulled,
@@ -358,11 +358,11 @@ func TestContainerNextStateWithTransitionDependencies(t *testing.T) {
 			dependencySatisfiedStatus:    apicontainerstatus.ContainerCreated,
 			expectedContainerStatus:      apicontainerstatus.ContainerStatusNone,
 			expectedTransitionActionable: false,
-			reason: dependencygraph.ErrContainerDependencyNotResolved,
+			reason:                       dependencygraph.ErrContainerDependencyNotResolved,
 		},
 		// NONE -> RUNNING transition is not allowed and not actionable, when desired is Running and dependency is Created
 		{
-			name: "pull depends on running, dependency is created",
+			name:                         "pull depends on running, dependency is created",
 			containerCurrentStatus:       apicontainerstatus.ContainerStatusNone,
 			containerDesiredStatus:       apicontainerstatus.ContainerRunning,
 			containerDependentStatus:     apicontainerstatus.ContainerPulled,
@@ -370,12 +370,12 @@ func TestContainerNextStateWithTransitionDependencies(t *testing.T) {
 			dependencySatisfiedStatus:    apicontainerstatus.ContainerRunning,
 			expectedContainerStatus:      apicontainerstatus.ContainerStatusNone,
 			expectedTransitionActionable: false,
-			reason: dependencygraph.ErrContainerDependencyNotResolved,
+			reason:                       dependencygraph.ErrContainerDependencyNotResolved,
 		},
 		// NONE -> RUNNING transition is allowed and actionable, when desired is Running and dependency is Running
 		// The expected next status is Pulled
 		{
-			name: "pull depends on running, dependency is running, next status is pulled",
+			name:                         "pull depends on running, dependency is running, next status is pulled",
 			containerCurrentStatus:       apicontainerstatus.ContainerStatusNone,
 			containerDesiredStatus:       apicontainerstatus.ContainerRunning,
 			containerDependentStatus:     apicontainerstatus.ContainerPulled,
@@ -387,7 +387,7 @@ func TestContainerNextStateWithTransitionDependencies(t *testing.T) {
 		// NONE -> RUNNING transition is allowed and actionable, when desired is Running and dependency is Stopped
 		// The expected next status is Pulled
 		{
-			name: "pull depends on running, dependency is stopped, next status is pulled",
+			name:                         "pull depends on running, dependency is stopped, next status is pulled",
 			containerCurrentStatus:       apicontainerstatus.ContainerStatusNone,
 			containerDesiredStatus:       apicontainerstatus.ContainerRunning,
 			containerDependentStatus:     apicontainerstatus.ContainerPulled,
@@ -399,7 +399,7 @@ func TestContainerNextStateWithTransitionDependencies(t *testing.T) {
 		// NONE -> RUNNING transition is allowed and actionable, when desired is Running and dependency is None and
 		// dependent status is Running
 		{
-			name: "create depends on running, dependency is none, next status is pulled",
+			name:                         "create depends on running, dependency is none, next status is pulled",
 			containerCurrentStatus:       apicontainerstatus.ContainerStatusNone,
 			containerDesiredStatus:       apicontainerstatus.ContainerRunning,
 			containerDependentStatus:     apicontainerstatus.ContainerCreated,
@@ -523,7 +523,7 @@ func TestContainerNextStateWithPullCredentials(t *testing.T) {
 		credentialsManager: credentials.NewManager(),
 	}
 
-	err := taskEngine.credentialsManager.SetTaskCredentials(credentials.TaskIAMRoleCredentials{
+	err := taskEngine.credentialsManager.SetTaskCredentials(&credentials.TaskIAMRoleCredentials{
 		ARN: "taskarn",
 		IAMRoleCredentials: credentials.IAMRoleCredentials{
 			CredentialsID:   "existed",
@@ -1032,8 +1032,8 @@ func TestCleanupTask(t *testing.T) {
 		acsMessages:              make(chan acsTransition),
 		dockerMessages:           make(chan dockerContainerChange),
 		resourceStateChangeEvent: make(chan resourceStateChange),
-		cfg:   taskEngine.cfg,
-		saver: taskEngine.saver,
+		cfg:                      taskEngine.cfg,
+		saver:                    taskEngine.saver,
 	}
 	mTask.Task.ResourcesMapUnsafe = make(map[string][]taskresource.TaskResource)
 	mTask.AddResource("mockResource", mockResource)
@@ -1093,8 +1093,8 @@ func TestCleanupTaskWaitsForStoppedSent(t *testing.T) {
 		acsMessages:              make(chan acsTransition),
 		dockerMessages:           make(chan dockerContainerChange),
 		resourceStateChangeEvent: make(chan resourceStateChange),
-		cfg:   taskEngine.cfg,
-		saver: taskEngine.saver,
+		cfg:                      taskEngine.cfg,
+		saver:                    taskEngine.saver,
 	}
 	mTask.SetKnownStatus(apitaskstatus.TaskStopped)
 	mTask.SetSentStatus(apitaskstatus.TaskRunning)
@@ -1217,8 +1217,8 @@ func TestCleanupTaskENIs(t *testing.T) {
 		acsMessages:              make(chan acsTransition),
 		dockerMessages:           make(chan dockerContainerChange),
 		resourceStateChangeEvent: make(chan resourceStateChange),
-		cfg:   taskEngine.cfg,
-		saver: taskEngine.saver,
+		cfg:                      taskEngine.cfg,
+		saver:                    taskEngine.saver,
 	}
 	mTask.SetTaskENI(&apieni.ENI{
 		ID: "TestCleanupTaskENIs",
@@ -1347,8 +1347,8 @@ func TestCleanupTaskWithInvalidInterval(t *testing.T) {
 		acsMessages:              make(chan acsTransition),
 		dockerMessages:           make(chan dockerContainerChange),
 		resourceStateChangeEvent: make(chan resourceStateChange),
-		cfg:   taskEngine.cfg,
-		saver: taskEngine.saver,
+		cfg:                      taskEngine.cfg,
+		saver:                    taskEngine.saver,
 	}
 
 	mTask.SetKnownStatus(apitaskstatus.TaskStopped)
@@ -1406,8 +1406,8 @@ func TestCleanupTaskWithResourceHappyPath(t *testing.T) {
 		acsMessages:              make(chan acsTransition),
 		dockerMessages:           make(chan dockerContainerChange),
 		resourceStateChangeEvent: make(chan resourceStateChange),
-		cfg:   taskEngine.cfg,
-		saver: taskEngine.saver,
+		cfg:                      taskEngine.cfg,
+		saver:                    taskEngine.saver,
 	}
 	mTask.Task.ResourcesMapUnsafe = make(map[string][]taskresource.TaskResource)
 	mTask.AddResource("mockResource", mockResource)
@@ -1468,8 +1468,8 @@ func TestCleanupTaskWithResourceErrorPath(t *testing.T) {
 		acsMessages:              make(chan acsTransition),
 		dockerMessages:           make(chan dockerContainerChange),
 		resourceStateChangeEvent: make(chan resourceStateChange),
-		cfg:   taskEngine.cfg,
-		saver: taskEngine.saver,
+		cfg:                      taskEngine.cfg,
+		saver:                    taskEngine.saver,
 	}
 	mTask.Task.ResourcesMapUnsafe = make(map[string][]taskresource.TaskResource)
 	mTask.AddResource("mockResource", mockResource)
@@ -1508,7 +1508,7 @@ func TestHandleContainerChangeUpdateContainerHealth(t *testing.T) {
 	containerChangeEventStream.StartListening()
 
 	mTask := &managedTask{
-		Task: testdata.LoadTask("sleep5TaskCgroup"),
+		Task:                       testdata.LoadTask("sleep5TaskCgroup"),
 		containerChangeEventStream: containerChangeEventStream,
 		stateChangeEvents:          make(chan statechange.Event),
 	}
@@ -1883,7 +1883,7 @@ func TestStartVolumeResourceTransitionsEmpty(t *testing.T) {
 					ResourcesMapUnsafe:  make(map[string][]taskresource.TaskResource),
 					DesiredStatusUnsafe: apitaskstatus.TaskRunning,
 				},
-				ctx: ctx,
+				ctx:                      ctx,
 				resourceStateChangeEvent: make(chan resourceStateChange),
 			}
 			mtask.Task.AddResource(volumeName, res)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
SetTaskCredentials should take a reference to the credentials object (which contains a mutex).  This is another fix suggested by `go vet`

Also, this picked up some formatting changes from `go fmt` (which I run on all saves).

### Testing
ran unit tests on ECS AMI EC2.
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=30s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
