### PR TITLE
Modified pull image retry with 1100ms * 2^n strategy and rename Simpl…

### DIFF
--- a/agent/acs/handler/acs_handler.go
+++ b/agent/acs/handler/acs_handler.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"time"
 
-	acsclient "github.com/aws/amazon-ecs-agent/agent/acs/client"
+	"github.com/aws/amazon-ecs-agent/agent/acs/client"
 	"github.com/aws/amazon-ecs-agent/agent/acs/model/ecsacs"
 	"github.com/aws/amazon-ecs-agent/agent/acs/update_handler"
 	"github.com/aws/amazon-ecs-agent/agent/api"
@@ -34,7 +34,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/eventhandler"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
 	"github.com/aws/amazon-ecs-agent/agent/statemanager"
-	"github.com/aws/amazon-ecs-agent/agent/utils"
+	"github.com/aws/amazon-ecs-agent/agent/utils/retry"
 	"github.com/aws/amazon-ecs-agent/agent/utils/ttime"
 	"github.com/aws/amazon-ecs-agent/agent/version"
 	"github.com/aws/amazon-ecs-agent/agent/wsclient"
@@ -88,7 +88,7 @@ type session struct {
 	taskHandler                     *eventhandler.TaskHandler
 	ctx                             context.Context
 	cancel                          context.CancelFunc
-	backoff                         utils.Backoff
+	backoff                         retry.Backoff
 	resources                       sessionResources
 	_heartbeatTimeout               time.Duration
 	_heartbeatJitter                time.Duration
@@ -145,7 +145,7 @@ func NewSession(ctx context.Context,
 	credentialsManager rolecredentials.Manager,
 	taskHandler *eventhandler.TaskHandler) Session {
 	resources := newSessionResources(credentialsProvider)
-	backoff := utils.NewSimpleBackoff(connectionBackoffMin, connectionBackoffMax,
+	backoff := retry.NewExponentialBackoff(connectionBackoffMin, connectionBackoffMax,
 		connectionBackoffJitter, connectionBackoffMultiplier)
 	derivedContext, cancel := context.WithCancel(ctx)
 
@@ -318,7 +318,7 @@ func (acsSession *session) startACSSession(client wsclient.ClientServer) error {
 	acsSession.resources.connectedToACS()
 
 	backoffResetTimer := time.AfterFunc(
-		utils.AddJitter(acsSession.heartbeatTimeout(), acsSession.heartbeatJitter()), func() {
+		retry.AddJitter(acsSession.heartbeatTimeout(), acsSession.heartbeatJitter()), func() {
 			// If we do not have an error connecting and remain connected for at
 			// least 1 or so minutes, reset the backoff. This prevents disconnect
 			// errors that only happen infrequently from damaging the reconnect
@@ -423,7 +423,7 @@ func acsWsURL(endpoint, cluster, containerInstanceArn string, taskEngine engine.
 // newDisconnectionTimer creates a new time object, with a callback to
 // disconnect from ACS on inactivity
 func newDisconnectionTimer(client wsclient.ClientServer, timeout time.Duration, jitter time.Duration) ttime.Timer {
-	timer := time.AfterFunc(utils.AddJitter(timeout, jitter), func() {
+	timer := time.AfterFunc(retry.AddJitter(timeout, jitter), func() {
 		seelog.Warn("ACS Connection hasn't had any activity for too long; closing connection")
 		if err := client.Close(); err != nil {
 			seelog.Warnf("Error disconnecting: %v", err)
@@ -445,7 +445,7 @@ func anyMessageHandler(timer ttime.Timer, client wsclient.ClientServer) func(int
 		}
 
 		// Reset heartbeat timer
-		timer.Reset(utils.AddJitter(heartbeatTimeout, heartbeatJitter))
+		timer.Reset(retry.AddJitter(heartbeatTimeout, heartbeatJitter))
 	}
 }
 

--- a/agent/acs/handler/acs_handler_test.go
+++ b/agent/acs/handler/acs_handler_test.go
@@ -1,6 +1,6 @@
 // +build unit
 
-// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -41,8 +41,8 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/eventhandler"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
 	"github.com/aws/amazon-ecs-agent/agent/statemanager"
-	"github.com/aws/amazon-ecs-agent/agent/utils"
 	"github.com/aws/amazon-ecs-agent/agent/utils/mocks"
+	"github.com/aws/amazon-ecs-agent/agent/utils/retry"
 	"github.com/aws/amazon-ecs-agent/agent/version"
 	"github.com/aws/amazon-ecs-agent/agent/wsclient"
 	"github.com/aws/amazon-ecs-agent/agent/wsclient/mock"
@@ -234,7 +234,7 @@ func TestHandlerReconnectsOnConnectErrors(t *testing.T) {
 		ecsClient:            ecsClient,
 		stateManager:         stateManager,
 		taskHandler:          taskHandler,
-		backoff:              utils.NewSimpleBackoff(connectionBackoffMin, connectionBackoffMax, connectionBackoffJitter, connectionBackoffMultiplier),
+		backoff:              retry.NewExponentialBackoff(connectionBackoffMin, connectionBackoffMax, connectionBackoffJitter, connectionBackoffMultiplier),
 		ctx:                  ctx,
 		cancel:               cancel,
 		resources:            &mockSessionResources{mockWsClient},
@@ -501,7 +501,7 @@ func TestHandlerGeneratesDeregisteredInstanceEvent(t *testing.T) {
 		deregisterInstanceEventStream:   deregisterInstanceEventStream,
 		stateManager:                    stateManager,
 		taskHandler:                     taskHandler,
-		backoff:                         utils.NewSimpleBackoff(connectionBackoffMin, connectionBackoffMax, connectionBackoffJitter, connectionBackoffMultiplier),
+		backoff:                         retry.NewExponentialBackoff(connectionBackoffMin, connectionBackoffMax, connectionBackoffJitter, connectionBackoffMultiplier),
 		ctx:                             ctx,
 		cancel:                          cancel,
 		resources:                       &mockSessionResources{mockWsClient},
@@ -570,7 +570,7 @@ func TestHandlerReconnectDelayForInactiveInstanceError(t *testing.T) {
 		deregisterInstanceEventStream:   deregisterInstanceEventStream,
 		stateManager:                    stateManager,
 		taskHandler:                     taskHandler,
-		backoff:                         utils.NewSimpleBackoff(connectionBackoffMin, connectionBackoffMax, connectionBackoffJitter, connectionBackoffMultiplier),
+		backoff:                         retry.NewExponentialBackoff(connectionBackoffMin, connectionBackoffMax, connectionBackoffJitter, connectionBackoffMultiplier),
 		ctx:                             ctx,
 		cancel:                          cancel,
 		resources:                       &mockSessionResources{mockWsClient},
@@ -627,7 +627,7 @@ func TestHandlerReconnectsOnServeErrors(t *testing.T) {
 		ecsClient:            ecsClient,
 		stateManager:         stateManager,
 		taskHandler:          taskHandler,
-		backoff:              utils.NewSimpleBackoff(connectionBackoffMin, connectionBackoffMax, connectionBackoffJitter, connectionBackoffMultiplier),
+		backoff:              retry.NewExponentialBackoff(connectionBackoffMin, connectionBackoffMax, connectionBackoffJitter, connectionBackoffMultiplier),
 		ctx:                  ctx,
 		cancel:               cancel,
 		resources:            &mockSessionResources{mockWsClient},
@@ -678,7 +678,7 @@ func TestHandlerStopsWhenContextIsCancelled(t *testing.T) {
 		ecsClient:            ecsClient,
 		stateManager:         stateManager,
 		taskHandler:          taskHandler,
-		backoff:              utils.NewSimpleBackoff(connectionBackoffMin, connectionBackoffMax, connectionBackoffJitter, connectionBackoffMultiplier),
+		backoff:              retry.NewExponentialBackoff(connectionBackoffMin, connectionBackoffMax, connectionBackoffJitter, connectionBackoffMultiplier),
 		ctx:                  ctx,
 		cancel:               cancel,
 		resources:            &mockSessionResources{mockWsClient},
@@ -732,7 +732,7 @@ func TestHandlerReconnectsOnDiscoverPollEndpointError(t *testing.T) {
 		ecsClient:            ecsClient,
 		stateManager:         stateManager,
 		taskHandler:          taskHandler,
-		backoff:              utils.NewSimpleBackoff(connectionBackoffMin, connectionBackoffMax, connectionBackoffJitter, connectionBackoffMultiplier),
+		backoff:              retry.NewExponentialBackoff(connectionBackoffMin, connectionBackoffMax, connectionBackoffJitter, connectionBackoffMultiplier),
 		ctx:                  ctx,
 		cancel:               cancel,
 		resources:            &mockSessionResources{mockWsClient},
@@ -806,7 +806,7 @@ func TestConnectionIsClosedOnIdle(t *testing.T) {
 		stateManager:         stateManager,
 		taskHandler:          taskHandler,
 		ctx:                  context.Background(),
-		backoff:              utils.NewSimpleBackoff(connectionBackoffMin, connectionBackoffMax, connectionBackoffJitter, connectionBackoffMultiplier),
+		backoff:              retry.NewExponentialBackoff(connectionBackoffMin, connectionBackoffMax, connectionBackoffJitter, connectionBackoffMultiplier),
 		resources:            &mockSessionResources{},
 		_heartbeatTimeout:    20 * time.Millisecond,
 		_heartbeatJitter:     10 * time.Millisecond,
@@ -861,7 +861,7 @@ func TestHandlerDoesntLeakGoroutines(t *testing.T) {
 			taskHandler:          taskHandler,
 			ctx:                  ctx,
 			_heartbeatTimeout:    1 * time.Second,
-			backoff:              utils.NewSimpleBackoff(connectionBackoffMin, connectionBackoffMax, connectionBackoffJitter, connectionBackoffMultiplier),
+			backoff:              retry.NewExponentialBackoff(connectionBackoffMin, connectionBackoffMax, connectionBackoffJitter, connectionBackoffMultiplier),
 			resources:            newSessionResources(testCreds),
 			credentialsManager:   rolecredentials.NewManager(),
 		}
@@ -1062,7 +1062,7 @@ func TestHandlerReconnectsCorrectlySetsSendCredentialsURLParameter(t *testing.T)
 		taskHandler:          taskHandler,
 		ctx:                  ctx,
 		resources:            resources,
-		backoff:              utils.NewSimpleBackoff(connectionBackoffMin, connectionBackoffMax, connectionBackoffJitter, connectionBackoffMultiplier),
+		backoff:              retry.NewExponentialBackoff(connectionBackoffMin, connectionBackoffMax, connectionBackoffJitter, connectionBackoffMultiplier),
 		_heartbeatTimeout:    20 * time.Millisecond,
 		_heartbeatJitter:     10 * time.Millisecond,
 	}

--- a/agent/dockerclient/dockerapi/docker_client.go
+++ b/agent/dockerclient/dockerapi/docker_client.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -41,6 +41,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/ecr"
 	"github.com/aws/amazon-ecs-agent/agent/metrics"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
+	"github.com/aws/amazon-ecs-agent/agent/utils/retry"
 	"github.com/aws/amazon-ecs-agent/agent/utils/ttime"
 
 	"github.com/cihub/seelog"
@@ -84,9 +85,9 @@ const (
 
 	// retry settings for pulling images
 	maximumPullRetries        = 5
-	minimumPullRetryDelay     = 250 * time.Millisecond
-	maximumPullRetryDelay     = 1 * time.Second
-	pullRetryDelayMultiplier  = 1.5
+	minimumPullRetryDelay     = 1100 * time.Millisecond
+	maximumPullRetryDelay     = 5 * time.Second
+	pullRetryDelayMultiplier  = 2
 	pullRetryJitterMultiplier = 0.2
 )
 
@@ -205,6 +206,7 @@ type dockerGoClient struct {
 	ecrTokenCache    async.Cache
 	config           *config.Config
 	context          context.Context
+	imagePullBackoff retry.Backoff
 
 	_time     ttime.Time
 	_timeOnce sync.Once
@@ -270,6 +272,8 @@ func NewDockerGoClient(sdkclientFactory sdkclientfactory.Factory,
 		ecrTokenCache:    async.NewLRUCache(tokenCacheSize, tokenCacheTTL),
 		config:           cfg,
 		context:          ctx,
+		imagePullBackoff: retry.NewExponentialBackoff(minimumPullRetryDelay, maximumPullRetryDelay,
+			pullRetryJitterMultiplier, pullRetryDelayMultiplier),
 	}, nil
 }
 
@@ -298,9 +302,7 @@ func (dg *dockerGoClient) PullImage(image string, authData *apicontainer.Registr
 	defer metrics.MetricsEngineGlobal.RecordDockerMetric("PULL_IMAGE")()
 	response := make(chan DockerContainerMetadata, 1)
 	go func() {
-		imagePullBackoff := utils.NewSimpleBackoff(minimumPullRetryDelay,
-			maximumPullRetryDelay, pullRetryJitterMultiplier, pullRetryDelayMultiplier)
-		err := utils.RetryNWithBackoffCtx(ctx, imagePullBackoff, maximumPullRetries,
+		err := retry.RetryNWithBackoffCtx(ctx, dg.imagePullBackoff, maximumPullRetries,
 			func() error {
 				err := dg.pullImage(ctx, image, authData)
 				if err != nil {

--- a/agent/dockerclient/dockerapi/docker_client_test.go
+++ b/agent/dockerclient/dockerapi/docker_client_test.go
@@ -1,6 +1,6 @@
 // +build unit
 
-// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -39,6 +39,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/ec2"
 	"github.com/aws/amazon-ecs-agent/agent/ecr/mocks"
 	ecrapi "github.com/aws/amazon-ecs-agent/agent/ecr/model/ecr"
+	"github.com/aws/amazon-ecs-agent/agent/utils/retry"
 	"github.com/aws/amazon-ecs-agent/agent/utils/ttime/mocks"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -64,6 +65,15 @@ const xContainerShortTimeout = 1 * time.Millisecond
 // docker client APIs that test if the underlying context gets canceled
 // upon the expiration of the timeout duration.
 const xImageShortTimeout = 1 * time.Millisecond
+
+const (
+	// retry settings for pulling images mock backoff
+	xMaximumPullRetries        = 5
+	xMinimumPullRetryDelay     = 25 * time.Millisecond
+	xMaximumPullRetryDelay     = 100 * time.Microsecond
+	xPullRetryDelayMultiplier  = 2
+	xPullRetryJitterMultiplier = 0.2
+)
 
 func defaultTestConfig() *config.Config {
 	cfg, _ := config.NewConfig(ec2.NewBlackholeEC2MetadataClient())
@@ -104,6 +114,8 @@ func dockerClientSetupWithConfig(t *testing.T, conf config.Config) (
 	ecrClientFactory := mock_ecr.NewMockECRFactory(ctrl)
 	goClient.ecrClientFactory = ecrClientFactory
 	goClient._time = mockTime
+	goClient.imagePullBackoff = retry.NewExponentialBackoff(xMinimumPullRetryDelay, xMaximumPullRetryDelay,
+		xPullRetryJitterMultiplier, xPullRetryDelayMultiplier)
 	return mockDockerSDK, goClient, mockTime, ctrl, ecrClientFactory, ctrl.Finish
 }
 

--- a/agent/dockerclient/dockerauth/ecr.go
+++ b/agent/dockerclient/dockerauth/ecr.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -24,7 +24,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/credentials"
 	"github.com/aws/amazon-ecs-agent/agent/ecr"
 	ecrapi "github.com/aws/amazon-ecs-agent/agent/ecr/model/ecr"
-	"github.com/aws/amazon-ecs-agent/agent/utils"
+	"github.com/aws/amazon-ecs-agent/agent/utils/retry"
 	"github.com/aws/aws-sdk-go/aws"
 	log "github.com/cihub/seelog"
 	"github.com/docker/docker/api/types"
@@ -182,7 +182,7 @@ func (authProvider *ecrAuthProvider) IsTokenValid(authData *ecrapi.Authorization
 	}
 
 	refreshTime := aws.TimeValue(authData.ExpiresAt).
-		Add(-1 * utils.AddJitter(MinimumJitterDuration, MinimumJitterDuration))
+		Add(-1 * retry.AddJitter(MinimumJitterDuration, MinimumJitterDuration))
 
 	return time.Now().Before(refreshTime)
 }

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -41,6 +41,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/statemanager"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
+	"github.com/aws/amazon-ecs-agent/agent/utils/retry"
 	utilsync "github.com/aws/amazon-ecs-agent/agent/utils/sync"
 	"github.com/aws/amazon-ecs-agent/agent/utils/ttime"
 
@@ -53,20 +54,19 @@ const (
 	//DockerEndpointEnvVariable is the environment variable that can override the Docker endpoint
 	DockerEndpointEnvVariable = "DOCKER_HOST"
 	// DockerDefaultEndpoint is the default value for the Docker endpoint
-	DockerDefaultEndpoint        = "unix:///var/run/docker.sock"
-	capabilityPrefix             = "com.amazonaws.ecs.capability."
-	capabilityTaskIAMRole        = "task-iam-role"
-	capabilityTaskIAMRoleNetHost = "task-iam-role-network-host"
-	capabilityTaskCPUMemLimit    = "task-cpu-mem-limit"
-	attributePrefix              = "ecs.capability."
-	labelPrefix                  = "com.amazonaws.ecs."
-	labelTaskARN                 = labelPrefix + "task-arn"
-	labelContainerName           = labelPrefix + "container-name"
-	labelTaskDefinitionFamily    = labelPrefix + "task-definition-family"
-	labelTaskDefinitionVersion   = labelPrefix + "task-definition-version"
-	labelCluster                 = labelPrefix + "cluster"
-	cniSetupTimeout              = 1 * time.Minute
-	cniCleanupTimeout            = 30 * time.Second
+	DockerDefaultEndpoint              = "unix:///var/run/docker.sock"
+	labelPrefix                        = "com.amazonaws.ecs."
+	labelTaskARN                       = labelPrefix + "task-arn"
+	labelContainerName                 = labelPrefix + "container-name"
+	labelTaskDefinitionFamily          = labelPrefix + "task-definition-family"
+	labelTaskDefinitionVersion         = labelPrefix + "task-definition-version"
+	labelCluster                       = labelPrefix + "cluster"
+	cniSetupTimeout                    = 1 * time.Minute
+	cniCleanupTimeout                  = 30 * time.Second
+	minEngineConnectRetryDelay         = 200 * time.Second
+	maxEngineConnectRetryDelay         = 2 * time.Second
+	engineConnectRetryJitterMultiplier = 0.20
+	engineConnectRetryDelayMultiplier  = 1.5
 )
 
 // DockerTaskEngine is a state machine for managing a task and its containers
@@ -229,8 +229,9 @@ func (engine *DockerTaskEngine) MustInit(ctx context.Context) {
 	defer engine.mustInitLock.Unlock()
 
 	errorOnce := sync.Once{}
-	taskEngineConnectBackoff := utils.NewSimpleBackoff(200*time.Millisecond, 2*time.Second, 0.20, 1.5)
-	utils.RetryWithBackoff(taskEngineConnectBackoff, func() error {
+	taskEngineConnectBackoff := retry.NewExponentialBackoff(minEngineConnectRetryDelay, maxEngineConnectRetryDelay,
+		engineConnectRetryJitterMultiplier, engineConnectRetryDelayMultiplier)
+	retry.RetryWithBackoff(taskEngineConnectBackoff, func() error {
 		if engine.initialized {
 			return nil
 		}

--- a/agent/eni/networkutils/utils_linux.go
+++ b/agent/eni/networkutils/utils_linux.go
@@ -1,6 +1,6 @@
 // +build linux
 
-// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -24,7 +24,7 @@ import (
 
 	apierrors "github.com/aws/amazon-ecs-agent/agent/api/errors"
 	"github.com/aws/amazon-ecs-agent/agent/eni/netlinkwrapper"
-	"github.com/aws/amazon-ecs-agent/agent/utils"
+	"github.com/aws/amazon-ecs-agent/agent/utils/retry"
 	"github.com/pkg/errors"
 
 	"github.com/cihub/seelog"
@@ -79,12 +79,12 @@ func GetMACAddress(ctx context.Context,
 // address is empty, it retries the operation with a timeout specified by the
 // caller
 func (retriever *macAddressRetriever) retrieve() (string, error) {
-	backoff := utils.NewSimpleBackoff(macAddressBackoffMin, macAddressBackoffMax,
+	backoff := retry.NewExponentialBackoff(macAddressBackoffMin, macAddressBackoffMax,
 		macAddressBackoffJitter, macAddressBackoffMultiple)
 	ctx, cancel := context.WithTimeout(retriever.ctx, retriever.timeout)
 	defer cancel()
 
-	err := utils.RetryWithBackoffCtx(ctx, backoff, func() error {
+	err := retry.RetryWithBackoffCtx(ctx, backoff, func() error {
 		retErr := retriever.retrieveOnce()
 		if retErr != nil {
 			seelog.Warnf("Unable to retrieve mac address for device '%s': %v",

--- a/agent/eventhandler/task_handler_types.go
+++ b/agent/eventhandler/task_handler_types.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -21,7 +21,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/api"
 	apitaskstatus "github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/agent/statemanager"
-	"github.com/aws/amazon-ecs-agent/agent/utils"
+	"github.com/aws/amazon-ecs-agent/agent/utils/retry"
 	"github.com/cihub/seelog"
 )
 
@@ -145,7 +145,7 @@ func (event *sendableEvent) send(
 	client api.ECSClient,
 	eventToSubmit *list.Element,
 	stateSaver statemanager.Saver,
-	backoff utils.Backoff,
+	backoff retry.Backoff,
 	taskEvents *taskSendableEvents) error {
 
 	seelog.Infof("TaskHandler: Sending %s change: %s", eventType, event.toString())

--- a/agent/handlers/introspection_server_setup.go
+++ b/agent/handlers/introspection_server_setup.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -25,7 +25,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/engine"
 	handlersutils "github.com/aws/amazon-ecs-agent/agent/handlers/utils"
 	"github.com/aws/amazon-ecs-agent/agent/handlers/v1"
-	"github.com/aws/amazon-ecs-agent/agent/utils"
+	"github.com/aws/amazon-ecs-agent/agent/utils/retry"
 	"github.com/cihub/seelog"
 )
 
@@ -83,7 +83,7 @@ func ServeIntrospectionHTTPEndpoint(containerInstanceArn *string, taskEngine eng
 	server := introspectionServerSetup(containerInstanceArn, dockerTaskEngine, cfg)
 	for {
 		once := sync.Once{}
-		utils.RetryWithBackoff(utils.NewSimpleBackoff(time.Second, time.Minute, 0.2, 2), func() error {
+		retry.RetryWithBackoff(retry.NewExponentialBackoff(time.Second, time.Minute, 0.2, 2), func() error {
 			// TODO, make this cancellable and use the passed in context; for
 			// now, not critical if this gets interrupted
 			err := server.ListenAndServe()

--- a/agent/handlers/task_server_setup.go
+++ b/agent/handlers/task_server_setup.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -28,7 +28,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/handlers/v3"
 	"github.com/aws/amazon-ecs-agent/agent/logger/audit"
 	"github.com/aws/amazon-ecs-agent/agent/stats"
-	"github.com/aws/amazon-ecs-agent/agent/utils"
+	"github.com/aws/amazon-ecs-agent/agent/utils/retry"
 	"github.com/cihub/seelog"
 	"github.com/didip/tollbooth"
 	"github.com/gorilla/mux"
@@ -154,7 +154,7 @@ func ServeTaskHTTPEndpoint(credentialsManager credentials.Manager,
 		cfg.TaskMetadataSteadyStateRate, cfg.TaskMetadataBurstRate, availabilityZone, containerInstanceArn)
 
 	for {
-		utils.RetryWithBackoff(utils.NewSimpleBackoff(time.Second, time.Minute, 0.2, 2), func() error {
+		retry.RetryWithBackoff(retry.NewExponentialBackoff(time.Second, time.Minute, 0.2, 2), func() error {
 			// TODO, make this cancellable and use the passed in context;
 			err := server.ListenAndServe()
 			if err != nil {

--- a/agent/utils/retry/backoff.go
+++ b/agent/utils/retry/backoff.go
@@ -1,0 +1,36 @@
+// Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package retry
+
+import (
+	"math/rand"
+	"time"
+)
+
+type Backoff interface {
+	Reset()
+	Duration() time.Duration
+}
+
+// AddJitter adds an amount of jitter between 0 and the given jitter to the
+// given duration
+func AddJitter(duration time.Duration, jitter time.Duration) time.Duration {
+	var randJitter int64
+	if jitter.Nanoseconds() == 0 {
+		randJitter = 0
+	} else {
+		randJitter = rand.Int63n(jitter.Nanoseconds())
+	}
+	return time.Duration(duration.Nanoseconds() + randJitter)
+}

--- a/agent/utils/retry/backoff_test.go
+++ b/agent/utils/retry/backoff_test.go
@@ -1,6 +1,6 @@
 // +build unit
 
-// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -13,35 +13,12 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package utils
+package retry
 
 import (
 	"testing"
 	"time"
 )
-
-func TestSimpleBackoff(t *testing.T) {
-	sb := NewSimpleBackoff(10*time.Second, time.Minute, 0, 2)
-
-	for i := 0; i < 2; i++ {
-		duration := sb.Duration()
-		if duration.Nanoseconds() != 10*time.Second.Nanoseconds() {
-			t.Error("Initial duration incorrect. Got ", duration.Nanoseconds())
-		}
-
-		duration = sb.Duration()
-		if duration.Nanoseconds() != 20*time.Second.Nanoseconds() {
-			t.Error("Increase incorrect")
-		}
-		_ = sb.Duration() // 40s
-		duration = sb.Duration()
-		if duration.Nanoseconds() != 60*time.Second.Nanoseconds() {
-			t.Error("Didn't stop at maximum")
-		}
-		sb.Reset()
-		// loop to redo the above tests after resetting, they should be the same
-	}
-}
 
 func TestJitter(t *testing.T) {
 	for i := 0; i < 10; i++ {

--- a/agent/utils/retry/exponential_backoff.go
+++ b/agent/utils/retry/exponential_backoff.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -11,21 +11,15 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package utils
+package retry
 
 import (
 	"math"
-	"math/rand"
 	"sync"
 	"time"
 )
 
-type Backoff interface {
-	Reset()
-	Duration() time.Duration
-}
-
-type SimpleBackoff struct {
+type ExponentialBackoff struct {
 	current        time.Duration
 	start          time.Duration
 	max            time.Duration
@@ -35,14 +29,15 @@ type SimpleBackoff struct {
 }
 
 // NewSimpleBackoff creates a Backoff which ranges from min to max increasing by
-// multiple each time.
+// multiple each time. (t = start * multiple * n for the nth iteration)
 // It also adds (and yes, the jitter is always added, never
 // subtracted) a random amount of jitter up to jitterMultiple percent (that is,
 // jitterMultiple = 0.0 is no jitter, 0.15 is 15% added jitter). The total time
 // may exceed "max" when accounting for jitter, such that the absolute max is
 // max + max * jiterMultiple
-func NewSimpleBackoff(min, max time.Duration, jitterMultiple, multiple float64) *SimpleBackoff {
-	return &SimpleBackoff{
+
+func NewExponentialBackoff(min, max time.Duration, jitterMultiple, multiple float64) *ExponentialBackoff {
+	return &ExponentialBackoff{
 		start:          min,
 		current:        min,
 		max:            max,
@@ -51,29 +46,16 @@ func NewSimpleBackoff(min, max time.Duration, jitterMultiple, multiple float64) 
 	}
 }
 
-func (sb *SimpleBackoff) Duration() time.Duration {
+func (sb *ExponentialBackoff) Duration() time.Duration {
 	sb.mu.Lock()
 	defer sb.mu.Unlock()
 	ret := sb.current
-	sb.current = time.Duration(math.Min(float64(sb.max.Nanoseconds()), float64(float64(sb.current.Nanoseconds())*sb.multiple)))
-
+	sb.current = time.Duration(math.Min(float64(sb.max.Nanoseconds()), float64(sb.current.Nanoseconds())*sb.multiple))
 	return AddJitter(ret, time.Duration(int64(float64(ret)*sb.jitterMultiple)))
 }
 
-func (sb *SimpleBackoff) Reset() {
+func (sb *ExponentialBackoff) Reset() {
 	sb.mu.Lock()
 	defer sb.mu.Unlock()
 	sb.current = sb.start
-}
-
-// AddJitter adds an amount of jitter between 0 and the given jitter to the
-// given duration
-func AddJitter(duration time.Duration, jitter time.Duration) time.Duration {
-	var randJitter int64
-	if jitter.Nanoseconds() == 0 {
-		randJitter = 0
-	} else {
-		randJitter = rand.Int63n(jitter.Nanoseconds())
-	}
-	return time.Duration(duration.Nanoseconds() + randJitter)
 }

--- a/agent/utils/retry/exponential_backoff_test.go
+++ b/agent/utils/retry/exponential_backoff_test.go
@@ -1,0 +1,46 @@
+// +build unit
+
+// Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+package retry
+
+import (
+	"testing"
+	"time"
+)
+
+func TestExponentialBackoff(t *testing.T) {
+	sb := NewExponentialBackoff(10*time.Second, time.Minute, 0, 2)
+
+	for i := 0; i < 2; i++ {
+		duration := sb.Duration()
+		if duration.Nanoseconds() != 10*time.Second.Nanoseconds() {
+			t.Error("Initial duration incorrect. Got ", duration.Nanoseconds())
+		}
+
+		duration = sb.Duration()
+		if duration.Nanoseconds() != 20*time.Second.Nanoseconds() {
+			t.Error("Increase incorrect")
+		}
+		duration = sb.Duration() // 40s
+		if duration.Nanoseconds() != 40*time.Second.Nanoseconds() {
+			t.Error("Increase incorrect")
+		}
+		duration = sb.Duration()
+		if duration.Nanoseconds() != 60*time.Second.Nanoseconds() {
+			t.Error("Didn't stop at maximum")
+		}
+		sb.Reset()
+		// loop to redo the above tests after resetting, they should be the same
+	}
+}

--- a/agent/utils/retry/retry.go
+++ b/agent/utils/retry/retry.go
@@ -1,0 +1,84 @@
+// Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package retry
+
+import (
+	apierrors "github.com/aws/amazon-ecs-agent/agent/api/errors"
+	"github.com/aws/amazon-ecs-agent/agent/utils/ttime"
+	"golang.org/x/net/context"
+)
+
+var _time ttime.Time = &ttime.DefaultTime{}
+
+// RetryWithBackoff takes a Backoff and a function to call that returns an error
+// If the error is nil then the function will no longer be called
+// If the error is Retriable then that will be used to determine if it should be
+// retried
+func RetryWithBackoff(backoff Backoff, fn func() error) error {
+	return RetryWithBackoffCtx(context.Background(), backoff, fn)
+}
+
+// RetryWithBackoffCtx takes a context, a Backoff, and a function to call that returns an error
+// If the context is done, nil will be returned
+// If the error is nil then the function will no longer be called
+// If the error is Retriable then that will be used to determine if it should be
+// retried
+func RetryWithBackoffCtx(ctx context.Context, backoff Backoff, fn func() error) error {
+	var err error
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+
+		err = fn()
+
+		retriableErr, isRetriableErr := err.(apierrors.Retriable)
+
+		if err == nil || (isRetriableErr && !retriableErr.Retry()) {
+			return err
+		}
+
+		_time.Sleep(backoff.Duration())
+	}
+}
+
+// RetryNWithBackoff takes a Backoff, a maximum number of tries 'n', and a
+// function that returns an error. The function is called until either it does
+// not return an error or the maximum tries have been reached.
+// If the error returned is Retriable, the Retriability of it will be respected.
+// If the number of tries is exhausted, the last error will be returned.
+func RetryNWithBackoff(backoff Backoff, n int, fn func() error) error {
+	return RetryNWithBackoffCtx(context.Background(), backoff, n, fn)
+}
+
+// RetryNWithBackoffCtx takes a context, a Backoff, a maximum number of tries 'n', and a function that returns an error.
+// The function is called until it does not return an error, the context is done, or the maximum tries have been
+// reached.
+// If the error returned is Retriable, the Retriability of it will be respected.
+// If the number of tries is exhausted, the last error will be returned.
+func RetryNWithBackoffCtx(ctx context.Context, backoff Backoff, n int, fn func() error) error {
+	var err error
+	RetryWithBackoffCtx(ctx, backoff, func() error {
+		err = fn()
+		n--
+		if n == 0 {
+			// Break out after n tries
+			return nil
+		}
+		return err
+	})
+	return err
+}

--- a/agent/utils/retry/retry_test.go
+++ b/agent/utils/retry/retry_test.go
@@ -1,0 +1,185 @@
+// +build unit
+
+// Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package retry
+
+import (
+	"errors"
+	apierrors "github.com/aws/amazon-ecs-agent/agent/api/errors"
+	"github.com/aws/amazon-ecs-agent/agent/utils/ttime"
+	"github.com/aws/amazon-ecs-agent/agent/utils/ttime/mocks"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/context"
+	"testing"
+	"time"
+)
+
+func TestRetryWithBackoff(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mocktime := mock_ttime.NewMockTime(ctrl)
+	_time = mocktime
+	defer func() { _time = &ttime.DefaultTime{} }()
+
+	t.Run("retries", func(t *testing.T) {
+		mocktime.EXPECT().Sleep(100 * time.Millisecond).Times(3)
+		counter := 3
+		RetryWithBackoff(NewExponentialBackoff(100*time.Millisecond, 100*time.Millisecond, 0, 1), func() error {
+			if counter == 0 {
+				return nil
+			}
+			counter--
+			return errors.New("err")
+		})
+		assert.Equal(t, 0, counter, "Counter didn't go to 0; didn't get retried enough")
+	})
+
+	t.Run("no retries", func(t *testing.T) {
+		// no sleeps
+		RetryWithBackoff(NewExponentialBackoff(10*time.Second, 20*time.Second, 0, 2), func() error {
+			return apierrors.NewRetriableError(apierrors.NewRetriable(false), errors.New("can't retry"))
+		})
+	})
+}
+
+func TestRetryWithBackoffCtx(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mocktime := mock_ttime.NewMockTime(ctrl)
+	_time = mocktime
+	defer func() { _time = &ttime.DefaultTime{} }()
+
+	t.Run("retries", func(t *testing.T) {
+		mocktime.EXPECT().Sleep(100 * time.Millisecond).Times(3)
+		counter := 3
+		RetryWithBackoffCtx(context.TODO(), NewExponentialBackoff(100*time.Millisecond, 100*time.Millisecond, 0, 1), func() error {
+			if counter == 0 {
+				return nil
+			}
+			counter--
+			return errors.New("err")
+		})
+		assert.Equal(t, 0, counter, "Counter didn't go to 0; didn't get retried enough")
+	})
+
+	t.Run("no retries", func(t *testing.T) {
+		// no sleeps
+		RetryWithBackoffCtx(context.TODO(), NewExponentialBackoff(10*time.Second, 20*time.Second, 0, 2), func() error {
+			return apierrors.NewRetriableError(apierrors.NewRetriable(false), errors.New("can't retry"))
+		})
+	})
+
+	t.Run("cancel context", func(t *testing.T) {
+		mocktime.EXPECT().Sleep(100 * time.Millisecond).Times(2)
+		counter := 2
+		ctx, cancel := context.WithCancel(context.TODO())
+		RetryWithBackoffCtx(ctx, NewExponentialBackoff(100*time.Millisecond, 100*time.Millisecond, 0, 1), func() error {
+			counter--
+			if counter == 0 {
+				cancel()
+			}
+			return errors.New("err")
+		})
+		assert.Equal(t, 0, counter, "Counter not 0; went the wrong number of times")
+	})
+
+}
+
+func TestRetryNWithBackoff(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mocktime := mock_ttime.NewMockTime(ctrl)
+	_time = mocktime
+	defer func() { _time = &ttime.DefaultTime{} }()
+
+	t.Run("count exceeded", func(t *testing.T) {
+		// 2 tries, 1 sleep
+		mocktime.EXPECT().Sleep(100 * time.Millisecond).Times(1)
+		counter := 3
+		err := RetryNWithBackoff(NewExponentialBackoff(100*time.Millisecond, 100*time.Millisecond, 0, 1), 2, func() error {
+			counter--
+			return errors.New("err")
+		})
+		assert.Equal(t, 1, counter, "Should have stopped after two tries")
+		assert.Error(t, err)
+	})
+
+	t.Run("retry succeeded", func(t *testing.T) {
+		// 3 tries, 2 sleeps
+		mocktime.EXPECT().Sleep(100 * time.Millisecond).Times(2)
+		counter := 3
+		err := RetryNWithBackoff(NewExponentialBackoff(100*time.Millisecond, 100*time.Millisecond, 0, 1), 5, func() error {
+			counter--
+			if counter == 0 {
+				return nil
+			}
+			return errors.New("err")
+		})
+		assert.Equal(t, 0, counter)
+		assert.NoError(t, err)
+	})
+}
+
+func TestRetryNWithBackoffCtx(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mocktime := mock_ttime.NewMockTime(ctrl)
+	_time = mocktime
+	defer func() { _time = &ttime.DefaultTime{} }()
+
+	t.Run("count exceeded", func(t *testing.T) {
+		// 2 tries, 1 sleep
+		mocktime.EXPECT().Sleep(100 * time.Millisecond).Times(1)
+		counter := 3
+		err := RetryNWithBackoffCtx(context.TODO(), NewExponentialBackoff(100*time.Millisecond, 100*time.Millisecond, 0, 1), 2, func() error {
+			counter--
+			return errors.New("err")
+		})
+		assert.Equal(t, 1, counter, "Should have stopped after two tries")
+		assert.Error(t, err)
+	})
+
+	t.Run("retry succeeded", func(t *testing.T) {
+		// 3 tries, 2 sleeps
+		mocktime.EXPECT().Sleep(100 * time.Millisecond).Times(2)
+		counter := 3
+		err := RetryNWithBackoffCtx(context.TODO(), NewExponentialBackoff(100*time.Millisecond, 100*time.Millisecond, 0, 1), 5, func() error {
+			counter--
+			if counter == 0 {
+				return nil
+			}
+			return errors.New("err")
+		})
+		assert.Equal(t, 0, counter)
+		assert.NoError(t, err)
+	})
+
+	t.Run("cancel context", func(t *testing.T) {
+		// 2 tries, 2 sleeps
+		mocktime.EXPECT().Sleep(100 * time.Millisecond).Times(2)
+		counter := 3
+		ctx, cancel := context.WithCancel(context.TODO())
+		err := RetryNWithBackoffCtx(ctx, NewExponentialBackoff(100*time.Millisecond, 100*time.Millisecond, 0, 1), 5, func() error {
+			counter--
+			if counter == 1 {
+				cancel()
+			}
+			return errors.New("err")
+		})
+		assert.Equal(t, 1, counter, "Should have stopped after two tries")
+		assert.Error(t, err)
+	})
+}

--- a/agent/utils/utils.go
+++ b/agent/utils/utils.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -14,7 +14,6 @@
 package utils
 
 import (
-	"context"
 	"crypto/rand"
 	"encoding/binary"
 	"encoding/hex"
@@ -24,10 +23,8 @@ import (
 	"strconv"
 	"strings"
 
-	apierrors "github.com/aws/amazon-ecs-agent/agent/api/errors"
 	"github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
 	"github.com/aws/amazon-ecs-agent/agent/logger"
-	"github.com/aws/amazon-ecs-agent/agent/utils/ttime"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 )
@@ -105,70 +102,6 @@ func RandHex() string {
 
 func Strptr(s string) *string {
 	return &s
-}
-
-var _time ttime.Time = &ttime.DefaultTime{}
-
-// RetryWithBackoff takes a Backoff and a function to call that returns an error
-// If the error is nil then the function will no longer be called
-// If the error is Retriable then that will be used to determine if it should be
-// retried
-func RetryWithBackoff(backoff Backoff, fn func() error) error {
-	return RetryWithBackoffCtx(context.Background(), backoff, fn)
-}
-
-// RetryWithBackoffCtx takes a context, a Backoff, and a function to call that returns an error
-// If the context is done, nil will be returned
-// If the error is nil then the function will no longer be called
-// If the error is Retriable then that will be used to determine if it should be
-// retried
-func RetryWithBackoffCtx(ctx context.Context, backoff Backoff, fn func() error) error {
-	var err error
-	for {
-		select {
-		case <-ctx.Done():
-			return nil
-		default:
-		}
-
-		err = fn()
-
-		retriableErr, isRetriableErr := err.(apierrors.Retriable)
-
-		if err == nil || (isRetriableErr && !retriableErr.Retry()) {
-			return err
-		}
-
-		_time.Sleep(backoff.Duration())
-	}
-}
-
-// RetryNWithBackoff takes a Backoff, a maximum number of tries 'n', and a
-// function that returns an error. The function is called until either it does
-// not return an error or the maximum tries have been reached.
-// If the error returned is Retriable, the Retriability of it will be respected.
-// If the number of tries is exhausted, the last error will be returned.
-func RetryNWithBackoff(backoff Backoff, n int, fn func() error) error {
-	return RetryNWithBackoffCtx(context.Background(), backoff, n, fn)
-}
-
-// RetryNWithBackoffCtx takes a context, a Backoff, a maximum number of tries 'n', and a function that returns an error.
-// The function is called until it does not return an error, the context is done, or the maximum tries have been
-// reached.
-// If the error returned is Retriable, the Retriability of it will be respected.
-// If the number of tries is exhausted, the last error will be returned.
-func RetryNWithBackoffCtx(ctx context.Context, backoff Backoff, n int, fn func() error) error {
-	var err error
-	RetryWithBackoffCtx(ctx, backoff, func() error {
-		err = fn()
-		n--
-		if n == 0 {
-			// Break out after n tries
-			return nil
-		}
-		return err
-	})
-	return err
 }
 
 // Uint16SliceToStringSlice converts a slice of type uint16 to a slice of type

--- a/agent/utils/utils_test.go
+++ b/agent/utils/utils_test.go
@@ -1,6 +1,6 @@
 // +build unit
 
-// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -16,19 +16,13 @@
 package utils
 
 import (
-	"context"
 	"errors"
 	"sort"
 	"testing"
-	"time"
 
-	apierrors "github.com/aws/amazon-ecs-agent/agent/api/errors"
 	"github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
-	"github.com/aws/amazon-ecs-agent/agent/utils/ttime"
-	"github.com/aws/amazon-ecs-agent/agent/utils/ttime/mocks"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -96,163 +90,6 @@ func TestSlicesDeepEqual(t *testing.T) {
 			assert.Equal(t, tc.expected, SlicesDeepEqual(tc.left, tc.right))
 		})
 	}
-}
-
-func TestRetryWithBackoff(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-	mocktime := mock_ttime.NewMockTime(ctrl)
-	_time = mocktime
-	defer func() { _time = &ttime.DefaultTime{} }()
-
-	t.Run("retries", func(t *testing.T) {
-		mocktime.EXPECT().Sleep(100 * time.Millisecond).Times(3)
-		counter := 3
-		RetryWithBackoff(NewSimpleBackoff(100*time.Millisecond, 100*time.Millisecond, 0, 1), func() error {
-			if counter == 0 {
-				return nil
-			}
-			counter--
-			return errors.New("err")
-		})
-		assert.Equal(t, 0, counter, "Counter didn't go to 0; didn't get retried enough")
-	})
-
-	t.Run("no retries", func(t *testing.T) {
-		// no sleeps
-		RetryWithBackoff(NewSimpleBackoff(10*time.Second, 20*time.Second, 0, 2), func() error {
-			return apierrors.NewRetriableError(apierrors.NewRetriable(false), errors.New("can't retry"))
-		})
-	})
-}
-
-func TestRetryWithBackoffCtx(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-	mocktime := mock_ttime.NewMockTime(ctrl)
-	_time = mocktime
-	defer func() { _time = &ttime.DefaultTime{} }()
-
-	t.Run("retries", func(t *testing.T) {
-		mocktime.EXPECT().Sleep(100 * time.Millisecond).Times(3)
-		counter := 3
-		RetryWithBackoffCtx(context.TODO(), NewSimpleBackoff(100*time.Millisecond, 100*time.Millisecond, 0, 1), func() error {
-			if counter == 0 {
-				return nil
-			}
-			counter--
-			return errors.New("err")
-		})
-		assert.Equal(t, 0, counter, "Counter didn't go to 0; didn't get retried enough")
-	})
-
-	t.Run("no retries", func(t *testing.T) {
-		// no sleeps
-		RetryWithBackoffCtx(context.TODO(), NewSimpleBackoff(10*time.Second, 20*time.Second, 0, 2), func() error {
-			return apierrors.NewRetriableError(apierrors.NewRetriable(false), errors.New("can't retry"))
-		})
-	})
-
-	t.Run("cancel context", func(t *testing.T) {
-		mocktime.EXPECT().Sleep(100 * time.Millisecond).Times(2)
-		counter := 2
-		ctx, cancel := context.WithCancel(context.TODO())
-		RetryWithBackoffCtx(ctx, NewSimpleBackoff(100*time.Millisecond, 100*time.Millisecond, 0, 1), func() error {
-			counter--
-			if counter == 0 {
-				cancel()
-			}
-			return errors.New("err")
-		})
-		assert.Equal(t, 0, counter, "Counter not 0; went the wrong number of times")
-	})
-
-}
-
-func TestRetryNWithBackoff(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-	mocktime := mock_ttime.NewMockTime(ctrl)
-	_time = mocktime
-	defer func() { _time = &ttime.DefaultTime{} }()
-
-	t.Run("count exceeded", func(t *testing.T) {
-		// 2 tries, 1 sleep
-		mocktime.EXPECT().Sleep(100 * time.Millisecond).Times(1)
-		counter := 3
-		err := RetryNWithBackoff(NewSimpleBackoff(100*time.Millisecond, 100*time.Millisecond, 0, 1), 2, func() error {
-			counter--
-			return errors.New("err")
-		})
-		assert.Equal(t, 1, counter, "Should have stopped after two tries")
-		assert.Error(t, err)
-	})
-
-	t.Run("retry succeeded", func(t *testing.T) {
-		// 3 tries, 2 sleeps
-		mocktime.EXPECT().Sleep(100 * time.Millisecond).Times(2)
-		counter := 3
-		err := RetryNWithBackoff(NewSimpleBackoff(100*time.Millisecond, 100*time.Millisecond, 0, 1), 5, func() error {
-			counter--
-			if counter == 0 {
-				return nil
-			}
-			return errors.New("err")
-		})
-		assert.Equal(t, 0, counter)
-		assert.NoError(t, err)
-	})
-}
-
-func TestRetryNWithBackoffCtx(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-	mocktime := mock_ttime.NewMockTime(ctrl)
-	_time = mocktime
-	defer func() { _time = &ttime.DefaultTime{} }()
-
-	t.Run("count exceeded", func(t *testing.T) {
-		// 2 tries, 1 sleep
-		mocktime.EXPECT().Sleep(100 * time.Millisecond).Times(1)
-		counter := 3
-		err := RetryNWithBackoffCtx(context.TODO(), NewSimpleBackoff(100*time.Millisecond, 100*time.Millisecond, 0, 1), 2, func() error {
-			counter--
-			return errors.New("err")
-		})
-		assert.Equal(t, 1, counter, "Should have stopped after two tries")
-		assert.Error(t, err)
-	})
-
-	t.Run("retry succeeded", func(t *testing.T) {
-		// 3 tries, 2 sleeps
-		mocktime.EXPECT().Sleep(100 * time.Millisecond).Times(2)
-		counter := 3
-		err := RetryNWithBackoffCtx(context.TODO(), NewSimpleBackoff(100*time.Millisecond, 100*time.Millisecond, 0, 1), 5, func() error {
-			counter--
-			if counter == 0 {
-				return nil
-			}
-			return errors.New("err")
-		})
-		assert.Equal(t, 0, counter)
-		assert.NoError(t, err)
-	})
-
-	t.Run("cancel context", func(t *testing.T) {
-		// 2 tries, 2 sleeps
-		mocktime.EXPECT().Sleep(100 * time.Millisecond).Times(2)
-		counter := 3
-		ctx, cancel := context.WithCancel(context.TODO())
-		err := RetryNWithBackoffCtx(ctx, NewSimpleBackoff(100*time.Millisecond, 100*time.Millisecond, 0, 1), 5, func() error {
-			counter--
-			if counter == 1 {
-				cancel()
-			}
-			return errors.New("err")
-		})
-		assert.Equal(t, 1, counter, "Should have stopped after two tries")
-		assert.Error(t, err)
-	})
 }
 
 func TestParseBool(t *testing.T) {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,4 +13,4 @@ install:
 build_script:
   - go build ./agent
 test_script:
-  - for /f "" %%G in ('go list github.com/aws/amazon-ecs-agent/agent/... ^| find /i /v "/vendor/"') do ( go test -race -tags unit -timeout 40s %%G & IF ERRORLEVEL == 1 EXIT 1) 
+  - for /f "" %%G in ('go list github.com/aws/amazon-ecs-agent/agent/... ^| find /i /v "/vendor/"') do ( go test -race -tags unit -timeout 40s %%G & IF ERRORLEVEL == 1 EXIT 1)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
* Change retry interval for image pull from (250ms * 1.5^n) to (1.1s * 2^n) to make sure pull retry jumps over image pull throttle bucket for ECR images 
* Rename SimpleBackoff to ExponentialBackoff to align with what it actually does
* Refactor retry+backoff into its own package

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
make release, make test
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [ ] Builds on Linux (`make release`)
- [ ] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [ ] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=30s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
