### PR TITLE
add govet target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ all: docker
 gobuild:
 	./scripts/build false
 
+
 # create output directories
 .out-stamp:
 	mkdir -p ./out/test-artifacts ./out/cni-plugins
@@ -344,15 +345,19 @@ gocyclo:
 	# Run gocyclo over all .go files
 	gocyclo -over 15 ${GOFILES}
 
+# same as gofiles above, but without the `-f`
+.PHONY: govet
+govet:
+	go vet $(shell go list ./agent/... | grep -v /vendor/ | grep -v /testutils/ | grep -v _test\.go$ | grep -v /mocks | grep -v /model) 
+
 .PHONY: fmtcheck
 fmtcheck:
 	$(eval DIFFS:=$(shell gofmt -l ${GOFILES}))
 	@if [ -n "$(DIFFS)" ]; then echo "Files incorrectly formatted. Fix formatting by running gofmt:"; echo "$(DIFFS)"; exit 1; fi
 	
 
-#TODO, create and add go vet target
 .PHONY: static-check
-static-check: gocyclo fmtcheck
+static-check: gocyclo fmtcheck govet
 
 .get-deps-stamp:
 	go get golang.org/x/tools/cmd/cover


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This adds the `govet` target which will run `go vet` on all files in agent/ dir except mock files.  We are excluding mock files.  See implementation details below>>

### Implementation details
We have overloaded the canonical methods MarshalJSON and UnmarshalJSON and have mocks to test these overloaded methods.  
Problem: MarshalJSON() and UnmarshalJSON() are canonical methods, with hardcoded signature expectations: https://golang.org/src/cmd/vet/method.go 
while go mock requires two methods per mock: https://github.com/golang/mock/blob/master/sample/concurrent/mock/concurrent_mock.go (see the 2 sum method signatures at the bottom)
This requires either that we make changes to the method names themselves (risky) or exclude the mocks from `go vet` (less risky)

I've added a follow-up task to rename these methods and remove the exclusion from the `gomake` target.

### Testing
tested on ECS optimized EC2 Amazon Linux instance.
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=30s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: no

Also ran static-check target as part of build via travis ci:
output logs: https://api.travis-ci.org/v3/job/484041959/log.txt

### Description for the changelog
Add govet target to Makefile

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
