### PR TITLE
Adding adapter to have volumes/links use DependsOn field

### DIFF
--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -72,6 +72,8 @@ const (
 	NvidiaVisibleDevicesEnvVar = "NVIDIA_VISIBLE_DEVICES"
 	GPUAssociationType         = "gpu"
 
+	ContainerOrderingStartCondition = "START"
+
 	arnResourceSections  = 2
 	arnResourceDelimiter = "/"
 	// networkModeNone specifies the string used to define the `none` docker networking mode
@@ -250,6 +252,18 @@ func (task *Task) PostUnmarshalTask(cfg *config.Config,
 		}
 	}
 
+	err := task.initializeContainerOrderingForVolumes()
+	if err != nil {
+		seelog.Errorf("Task [%s]: could not initialize volumes dependency for container: %v", task.Arn, err)
+		return apierrors.NewResourceInitError(task.Arn, err)
+	}
+
+	err = task.initializeContainerOrderingForLinks()
+	if err != nil {
+		seelog.Errorf("Task [%s]: could not initialize links dependency for container: %v", task.Arn, err)
+		return apierrors.NewResourceInitError(task.Arn, err)
+	}
+
 	if task.requiresASMDockerAuthData() {
 		task.initializeASMAuthResource(credentialsManager, resourceFields)
 	}
@@ -262,7 +276,7 @@ func (task *Task) PostUnmarshalTask(cfg *config.Config,
 		task.initializeASMSecretResource(credentialsManager, resourceFields)
 	}
 
-	err := task.initializeDockerLocalVolumes(dockerClient, ctx)
+	err = task.initializeDockerLocalVolumes(dockerClient, ctx)
 	if err != nil {
 		return apierrors.NewResourceInitError(task.Arn, err)
 	}
@@ -1239,6 +1253,41 @@ func (task *Task) shouldOverrideIPCMode(container *apicontainer.Container, docke
 	default:
 		return false, ""
 	}
+}
+
+func (task *Task) initializeContainerOrderingForVolumes() error {
+	for _, container := range task.Containers {
+		if len(container.VolumesFrom) > 0 {
+			for _, volume := range container.VolumesFrom {
+				if _, ok := task.ContainerByName(volume.SourceContainer); !ok {
+					return fmt.Errorf("could not find container with name %s", volume.SourceContainer)
+				}
+				dependOn := apicontainer.DependsOn{Container: volume.SourceContainer, Condition: ContainerOrderingStartCondition}
+				container.DependsOn = append(container.DependsOn, dependOn)
+			}
+		}
+	}
+	return nil
+}
+
+func (task *Task) initializeContainerOrderingForLinks() error {
+	for _, container := range task.Containers {
+		if len(container.Links) > 0 {
+			for _, link := range container.Links {
+				linkParts := strings.Split(link, ":")
+				if len(linkParts) > 2 {
+					return fmt.Errorf("Invalid link format")
+				}
+				linkName := linkParts[0]
+				if _, ok := task.ContainerByName(linkName); !ok {
+					return fmt.Errorf("could not find container with name %s", linkName)
+				}
+				dependOn := apicontainer.DependsOn{Container: linkName, Condition: ContainerOrderingStartCondition}
+				container.DependsOn = append(container.DependsOn, dependOn)
+			}
+		}
+	}
+	return nil
 }
 
 func (task *Task) dockerLinks(container *apicontainer.Container, dockerContainerMap map[string]*apicontainer.DockerContainer) ([]string, error) {

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -2816,3 +2816,100 @@ func TestAssociationByTypeAndName(t *testing.T) {
 	association, ok = task.AssociationByTypeAndName("other-type", "dev1")
 	assert.False(t, ok)
 }
+
+func TestInitializeContainerOrderingWithLinksAndVolumesFrom(t *testing.T) {
+	containerWithOnlyVolume := &apicontainer.Container{
+		Name:   "myName",
+		Image:  "image:tag",
+		VolumesFrom: []apicontainer.VolumeFrom{{SourceContainer: "myName1"}},
+	}
+
+	containerWithOnlyLink := &apicontainer.Container{
+		Name:  "myName1",
+		Image: "image:tag",
+		Links:  []string{"myName"},
+	}
+
+	containerWithBothVolumeAndLink := &apicontainer.Container{
+		Name:   "myName2",
+		Image:  "image:tag",
+		VolumesFrom: []apicontainer.VolumeFrom{{SourceContainer: "myName"}},
+		Links:  []string{"myName1"},
+	}
+
+	containerWithNoVolumeOrLink := &apicontainer.Container{
+		Name:  "myName3",
+		Image: "image:tag",
+	}
+
+	task := &Task{
+		Arn:                "test",
+		ResourcesMapUnsafe: make(map[string][]taskresource.TaskResource),
+		Containers:         []*apicontainer.Container{containerWithOnlyVolume, containerWithOnlyLink,
+		                                              containerWithBothVolumeAndLink, containerWithNoVolumeOrLink},
+	}
+
+	err := task.initializeContainerOrderingForVolumes()
+	assert.NoError(t, err)
+	err = task.initializeContainerOrderingForLinks()
+	assert.NoError(t, err)
+
+	containerResultWithVolume := task.Containers[0]
+	assert.Equal(t,  "myName1", containerResultWithVolume.DependsOn[0].Container)
+	assert.Equal(t,  ContainerOrderingStartCondition, containerResultWithVolume.DependsOn[0].Condition)
+
+	containerResultWithLink := task.Containers[1]
+	assert.Equal(t,  "myName", containerResultWithLink.DependsOn[0].Container)
+	assert.Equal(t,  ContainerOrderingStartCondition, containerResultWithLink.DependsOn[0].Condition)
+
+	containerResultWithBothVolumeAndLink := task.Containers[2]
+	assert.Equal(t,  "myName", containerResultWithBothVolumeAndLink.DependsOn[0].Container)
+	assert.Equal(t,  ContainerOrderingStartCondition, containerResultWithBothVolumeAndLink.DependsOn[0].Condition)
+	assert.Equal(t,  "myName1", containerResultWithBothVolumeAndLink.DependsOn[1].Container)
+	assert.Equal(t,  ContainerOrderingStartCondition, containerResultWithBothVolumeAndLink.DependsOn[1].Condition)
+
+	containerResultWithNoVolumeOrLink := task.Containers[3]
+	assert.Equal(t,  0, len(containerResultWithNoVolumeOrLink.DependsOn))
+}
+
+func TestInitializeContainerOrderingWithError(t *testing.T) {
+	containerWithVolumeError := &apicontainer.Container{
+		Name:   "myName",
+		Image:  "image:tag",
+		VolumesFrom: []apicontainer.VolumeFrom{{SourceContainer: "dummyContainer"}},
+	}
+
+	containerWithLinkError1 := &apicontainer.Container{
+		Name:  "myName1",
+		Image: "image:tag",
+		Links: []string{"dummyContainer"},
+	}
+
+	containerWithLinkError2 := &apicontainer.Container{
+		Name:  "myName2",
+		Image: "image:tag",
+		Links: []string{"myName:link1:link2"},
+	}
+
+	task1 := &Task{
+		Arn:                "test",
+		ResourcesMapUnsafe: make(map[string][]taskresource.TaskResource),
+		Containers:         []*apicontainer.Container{containerWithVolumeError, containerWithLinkError1},
+	}
+
+	task2 := &Task{
+		Arn:                "test",
+		ResourcesMapUnsafe: make(map[string][]taskresource.TaskResource),
+		Containers:         []*apicontainer.Container{containerWithVolumeError, containerWithLinkError2},
+	}
+
+	errVolume1 := task1.initializeContainerOrderingForVolumes()
+	assert.Error(t, errVolume1)
+	errLink1 := task1.initializeContainerOrderingForLinks()
+	assert.Error(t, errLink1)
+
+	errVolume2 := task2.initializeContainerOrderingForVolumes()
+	assert.Error(t, errVolume2)
+	errLink2 := task2.initializeContainerOrderingForLinks()
+	assert.Error(t, errLink2)
+}

--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -42,6 +42,7 @@ const (
 	capabiltyPIDAndIPCNamespaceSharing          = "pid-ipc-namespace-sharing"
 	capabilityNvidiaDriverVersionInfix          = "nvidia-driver-version."
 	capabilityECREndpoint                       = "ecr-endpoint"
+	capabilityContainerOrdering                 = "container-ordering"
 	taskEIAAttributeSuffix                      = "task-eia"
 )
 
@@ -140,6 +141,9 @@ func (agent *ecsAgent) capabilities() ([]*ecs.Attribute, error) {
 
 	// support elastic inference in agent
 	capabilities = appendNameOnlyAttribute(capabilities, attributePrefix+taskEIAAttributeSuffix)
+
+	// support container ordering in agent
+	capabilities = appendNameOnlyAttribute(capabilities, attributePrefix+capabilityContainerOrdering)
 
 	return capabilities, nil
 }

--- a/agent/app/agent_capability_test.go
+++ b/agent/app/agent_capability_test.go
@@ -126,6 +126,9 @@ func TestCapabilities(t *testing.T) {
 			{
 				Name: aws.String(attributePrefix + taskEIAAttributeSuffix),
 			},
+			{
+				Name: aws.String(attributePrefix + capabilityContainerOrdering),
+			},
 		}...)
 
 	ctx, cancel := context.WithCancel(context.TODO())


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This implements how VolumesFrom and Links field in Container can start to use the DependsOn field in container
### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [ ] Builds on Linux (`make release`)
- [ ] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [ ] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=30s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
