### PR TITLE
Don't install unnecessary packages in build env

### DIFF
--- a/scripts/dockerfiles/Dockerfile.build
+++ b/scripts/dockerfiles/Dockerfile.build
@@ -15,7 +15,7 @@ FROM golang:1.9
 MAINTAINER Amazon Web Services, Inc.
 
 RUN apt-get update && \
-    apt-get install -y gcc-mingw-w64
+    apt-get install -y --no-install-recommends gcc-mingw-w64
 
 RUN mkdir -p /go/src/github.com/aws/
 


### PR DESCRIPTION
### Summary

`scripts/dockerfiles/Dockerfile.build` installs the `gcc-mingw-w64` suite in order to facilitate the generation of Windows binaries. The gcc-mingw-w64 Recommends list includes a c++ compiler, a FORTRAN compiler, and an Ada compiler, all of which are large and none of which are needed for
building the agent. Because apt installs Recommends by default, every build ends up installing an extra 600 MB of unnecessary content. This change modifies the `apt-get` commandline used in Dockerfile.build to avoid installing these unnecessary packages.

This produces no visible changes to the agent behavior, so it does not require a changelog update.

### Testing

Generated a Windows built with:

```
$ docker rmi -f amazon/amazon-ecs-agent-build:make
$ make clean
$ make build-in-docker TARGET_OS=windows
```

Before the change, apt reports:
```
Need to get 208 MB of archives.
After this operation, 1174 MB of additional disk space will be used.
```
With the change, apt reports:
```
Need to get 80.7 MB of archives.
After this operation, 508 MB of additional disk space will be used.
```

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
