### PR TITLE
v3 metadata networks response for non-awsvpc tasks

### DIFF
--- a/agent/api/container/container.go
+++ b/agent/api/container/container.go
@@ -216,6 +216,12 @@ type Container struct {
 	// VolumesUnsafe is an array of volume mounts in the container.
 	VolumesUnsafe []types.MountPoint `json:"-"`
 
+	// NetworkModeUnsafe is the network mode in which the container is started
+	NetworkModeUnsafe string `json:"-"`
+
+	// NetworksUnsafe denotes the Docker Network Settings in the container.
+	NetworkSettingsUnsafe *types.NetworkSettings `json:"-"`
+
 	// SteadyStateStatusUnsafe specifies the steady state status for the container
 	// If uninitialized, it's assumed to be set to 'ContainerRunning'. Even though
 	// it's not only supposed to be set when the container is being created, it's
@@ -591,6 +597,38 @@ func (c *Container) GetVolumes() []types.MountPoint {
 	defer c.lock.RUnlock()
 
 	return c.VolumesUnsafe
+}
+
+// SetNetworkSettings sets the networks field in a container
+func (c *Container) SetNetworkSettings(networks *types.NetworkSettings) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	c.NetworkSettingsUnsafe = networks
+}
+
+// GetNetworkSettings returns the networks field in a container
+func (c *Container) GetNetworkSettings() *types.NetworkSettings {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	return c.NetworkSettingsUnsafe
+}
+
+// SetNetworkMode sets the network mode of the container
+func (c *Container) SetNetworkMode(networkMode string) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	c.NetworkModeUnsafe = networkMode
+}
+
+// GetNetworkMode returns the network mode of the container
+func (c *Container) GetNetworkMode() string {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	return c.NetworkModeUnsafe
 }
 
 // HealthStatusShouldBeReported returns true if the health check is defined in

--- a/agent/dockerclient/dockerapi/docker_client.go
+++ b/agent/dockerclient/dockerapi/docker_client.go
@@ -771,6 +771,15 @@ func MetadataFromContainer(dockerContainer *types.ContainerJSON) DockerContainer
 		StartedAt:    startedTime,
 		FinishedAt:   finishedTime,
 	}
+
+	if dockerContainer.NetworkSettings != nil {
+		metadata.NetworkSettings = dockerContainer.NetworkSettings
+	}
+
+	if dockerContainer.HostConfig != nil {
+		metadata.NetworkMode = string(dockerContainer.HostConfig.NetworkMode)
+	}
+
 	if dockerContainer.Config != nil {
 		metadata.Labels = dockerContainer.Config.Labels
 	}

--- a/agent/dockerclient/dockerapi/docker_client_test.go
+++ b/agent/dockerclient/dockerapi/docker_client_test.go
@@ -1425,6 +1425,9 @@ func TestMetadataFromContainer(t *testing.T) {
 			NetworkSettingsBase: types.NetworkSettingsBase{
 				Ports: ports,
 			},
+			DefaultNetworkSettings: types.DefaultNetworkSettings{
+				IPAddress: "17.0.0.3",
+			},
 		},
 		ContainerJSONBase: &types.ContainerJSONBase{
 			ID:      "1234",
@@ -1433,6 +1436,9 @@ func TestMetadataFromContainer(t *testing.T) {
 				Running:    true,
 				StartedAt:  started,
 				FinishedAt: finished,
+			},
+			HostConfig: &dockercontainer.HostConfig{
+				NetworkMode: dockercontainer.NetworkMode("bridge"),
 			},
 		},
 		Config: &dockercontainer.Config{
@@ -1446,6 +1452,9 @@ func TestMetadataFromContainer(t *testing.T) {
 	assert.Equal(t, volumes, metadata.Volumes)
 	assert.Equal(t, labels, metadata.Labels)
 	assert.Len(t, metadata.PortBindings, 1)
+	assert.Equal(t, "bridge", metadata.NetworkMode)
+	assert.NotNil(t, metadata.NetworkSettings)
+	assert.Equal(t, "17.0.0.3", metadata.NetworkSettings.IPAddress)
 
 	// Need to convert both strings to same format to be able to compare. Parse and Format are not inverses.
 	createdTimeSDK, _ := time.Parse(time.RFC3339, dockerContainer.Created)

--- a/agent/dockerclient/dockerapi/types.go
+++ b/agent/dockerclient/dockerapi/types.go
@@ -71,6 +71,10 @@ type DockerContainerMetadata struct {
 	FinishedAt time.Time
 	// Health contains the result of a container health check
 	Health apicontainer.HealthStatus
+	// NetworkMode denotes the network mode in which the container is started
+	NetworkMode string
+	// NetworksUnsafe denotes the Docker Network Settings in the container
+	NetworkSettings *types.NetworkSettings
 }
 
 // ListContainersResponse encapsulates the response from the docker client for the

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -355,6 +355,8 @@ func updateContainerMetadata(metadata *dockerapi.DockerContainerMetadata, contai
 	if container.HealthStatusShouldBeReported() {
 		container.SetHealthStatus(metadata.Health)
 	}
+	container.SetNetworkMode(metadata.NetworkMode)
+	container.SetNetworkSettings(metadata.NetworkSettings)
 }
 
 // synchronizeContainerStatus checks and updates the container status with docker

--- a/agent/handlers/task_server_setup_test.go
+++ b/agent/handlers/task_server_setup_test.go
@@ -83,6 +83,8 @@ const (
 	associationName            = "dev1"
 	associationEncoding        = "base64"
 	associationValue           = "val"
+	bridgeMode                 = "bridge"
+	bridgeIPAddr               = "17.0.0.3"
 )
 
 var (
@@ -192,10 +194,99 @@ var (
 		Associations: []string{associationName},
 	}
 	expectedAssociationResponse = associationValue
+
+	bridgeTask = &apitask.Task{
+		Arn:                      taskARN,
+		Associations:             []apitask.Association{association},
+		Family:                   family,
+		Version:                  version,
+		DesiredStatusUnsafe:      apitaskstatus.TaskRunning,
+		KnownStatusUnsafe:        apitaskstatus.TaskRunning,
+		CPU:                      cpu,
+		Memory:                   memory,
+		PullStartedAtUnsafe:      now,
+		PullStoppedAtUnsafe:      now,
+		ExecutionStoppedAtUnsafe: now,
+	}
+	container1 = &apicontainer.Container{
+		Name:                containerName,
+		Image:               imageName,
+		ImageID:             imageID,
+		DesiredStatusUnsafe: apicontainerstatus.ContainerRunning,
+		KnownStatusUnsafe:   apicontainerstatus.ContainerRunning,
+		CPU:                 cpu,
+		Memory:              memory,
+		Type:                apicontainer.ContainerNormal,
+		Ports: []apicontainer.PortBinding{
+			{
+				ContainerPort: containerPort,
+				Protocol:      apicontainer.TransportProtocolTCP,
+			},
+		},
+		NetworkModeUnsafe: bridgeMode,
+		NetworkSettingsUnsafe: &types.NetworkSettings{
+			DefaultNetworkSettings: types.DefaultNetworkSettings{
+				IPAddress: bridgeIPAddr,
+			},
+		},
+	}
+	bridgeContainer = &apicontainer.DockerContainer{
+		DockerID:   containerID,
+		DockerName: containerName,
+		Container:  container1,
+	}
+	containerNameToBridgeContainer = map[string]*apicontainer.DockerContainer{
+		taskARN: bridgeContainer,
+	}
+	expectedBridgeContainerResponse = v2.ContainerResponse{
+		ID:            containerID,
+		Name:          containerName,
+		DockerName:    containerName,
+		Image:         imageName,
+		ImageID:       imageID,
+		DesiredStatus: statusRunning,
+		KnownStatus:   statusRunning,
+		Limits: v2.LimitsResponse{
+			CPU:    aws.Float64(cpu),
+			Memory: aws.Int64(memory),
+		},
+		Type:   containerType,
+		Labels: labels,
+		Ports: []v1.PortResponse{
+			{
+				ContainerPort: containerPort,
+				Protocol:      containerPortProtocol,
+			},
+		},
+		Networks: []containermetadata.Network{
+			{
+				NetworkMode:   bridgeMode,
+				IPv4Addresses: []string{bridgeIPAddr},
+			},
+		},
+	}
+	expectedBridgeTaskResponse = v2.TaskResponse{
+		Cluster:       clusterName,
+		TaskARN:       taskARN,
+		Family:        family,
+		Revision:      version,
+		DesiredStatus: statusRunning,
+		KnownStatus:   statusRunning,
+		Containers:    []v2.ContainerResponse{expectedBridgeContainerResponse},
+		Limits: &v2.LimitsResponse{
+			CPU:    aws.Float64(cpu),
+			Memory: aws.Int64(memory),
+		},
+		PullStartedAt:      aws.Time(now.UTC()),
+		PullStoppedAt:      aws.Time(now.UTC()),
+		ExecutionStoppedAt: aws.Time(now.UTC()),
+		AvailabilityZone:   availabilityzone,
+	}
 )
 
 func init() {
 	container.SetLabels(labels)
+	container1.SetLabels(labels)
 }
 
 // TestInvalidPath tests if HTTP status code 404 is returned when invalid path is queried.
@@ -678,6 +769,65 @@ func TestV3TaskMetadata(t *testing.T) {
 	err = json.Unmarshal(res, &taskResponse)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedTaskResponse, taskResponse)
+}
+
+func TestV3BridgeTaskMetadata(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	state := mock_dockerstate.NewMockTaskEngineState(ctrl)
+	auditLog := mock_audit.NewMockAuditLogger(ctrl)
+	statsEngine := mock_stats.NewMockEngine(ctrl)
+	ecsClient := mock_api.NewMockECSClient(ctrl)
+
+	gomock.InOrder(
+		state.EXPECT().TaskARNByV3EndpointID(v3EndpointID).Return(taskARN, true),
+		state.EXPECT().TaskByArn(taskARN).Return(bridgeTask, true),
+		state.EXPECT().ContainerMapByArn(taskARN).Return(containerNameToBridgeContainer, true),
+		state.EXPECT().TaskByArn(taskARN).Return(bridgeTask, true),
+		state.EXPECT().ContainerByID(containerID).Return(bridgeContainer, true),
+	)
+	server := taskServerSetup(credentials.NewManager(), auditLog, state, ecsClient, clusterName, statsEngine,
+		config.DefaultTaskMetadataSteadyStateRate, config.DefaultTaskMetadataBurstRate, availabilityzone, containerInstanceArn)
+	recorder := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", v3BasePath+v3EndpointID+"/task", nil)
+	server.Handler.ServeHTTP(recorder, req)
+	res, err := ioutil.ReadAll(recorder.Body)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	var taskResponse v2.TaskResponse
+	err = json.Unmarshal(res, &taskResponse)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedBridgeTaskResponse, taskResponse)
+}
+
+func TestV3BridgeContainerMetadata(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	state := mock_dockerstate.NewMockTaskEngineState(ctrl)
+	auditLog := mock_audit.NewMockAuditLogger(ctrl)
+	statsEngine := mock_stats.NewMockEngine(ctrl)
+	ecsClient := mock_api.NewMockECSClient(ctrl)
+
+	gomock.InOrder(
+		state.EXPECT().DockerIDByV3EndpointID(v3EndpointID).Return(containerID, true),
+		state.EXPECT().ContainerByID(containerID).Return(bridgeContainer, true),
+		state.EXPECT().TaskByID(containerID).Return(bridgeTask, true),
+		state.EXPECT().ContainerByID(containerID).Return(bridgeContainer, true),
+	)
+	server := taskServerSetup(credentials.NewManager(), auditLog, state, ecsClient, clusterName, statsEngine,
+		config.DefaultTaskMetadataSteadyStateRate, config.DefaultTaskMetadataBurstRate, "", containerInstanceArn)
+	recorder := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", v3BasePath+v3EndpointID, nil)
+	server.Handler.ServeHTTP(recorder, req)
+	res, err := ioutil.ReadAll(recorder.Body)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	var containerResponse v2.ContainerResponse
+	err = json.Unmarshal(res, &containerResponse)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedBridgeContainerResponse, containerResponse)
 }
 
 // Test API calls for propagating Tags to Task Metadata

--- a/agent/handlers/task_server_setup_test.go
+++ b/agent/handlers/task_server_setup_test.go
@@ -664,6 +664,7 @@ func TestV3TaskMetadata(t *testing.T) {
 		state.EXPECT().TaskARNByV3EndpointID(v3EndpointID).Return(taskARN, true),
 		state.EXPECT().TaskByArn(taskARN).Return(task, true),
 		state.EXPECT().ContainerMapByArn(taskARN).Return(containerNameToDockerContainer, true),
+		state.EXPECT().TaskByArn(taskARN).Return(task, true),
 	)
 	server := taskServerSetup(credentials.NewManager(), auditLog, state, ecsClient, clusterName, statsEngine,
 		config.DefaultTaskMetadataSteadyStateRate, config.DefaultTaskMetadataBurstRate, availabilityzone, containerInstanceArn)
@@ -734,6 +735,7 @@ func TestV3TaskMetadataWithTags(t *testing.T) {
 				Value: &taskTag2Val,
 			},
 		}, nil),
+		state.EXPECT().TaskByArn(taskARN).Return(task, true),
 	)
 	server := taskServerSetup(credentials.NewManager(), auditLog, state, ecsClient, clusterName, statsEngine,
 		config.DefaultTaskMetadataSteadyStateRate, config.DefaultTaskMetadataBurstRate, availabilityzone, containerInstanceArn)

--- a/agent/handlers/v3/container_metadata_handler.go
+++ b/agent/handlers/v3/container_metadata_handler.go
@@ -18,10 +18,12 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/aws/amazon-ecs-agent/agent/containermetadata"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/handlers/utils"
 	"github.com/aws/amazon-ecs-agent/agent/handlers/v2"
 	"github.com/cihub/seelog"
+	"github.com/pkg/errors"
 )
 
 // ContainerMetadataPath specifies the relative URI path for serving container metadata.
@@ -37,10 +39,66 @@ func ContainerMetadataHandler(state dockerstate.TaskEngineState) func(http.Respo
 			utils.WriteJSONToResponse(w, http.StatusBadRequest, responseJSON, utils.RequestTypeContainerMetadata)
 			return
 		}
-
+		containerResponse, err := GetContainerResponse(containerID, state)
+		if err != nil {
+			errResponseJSON, _ := json.Marshal(err.Error())
+			utils.WriteJSONToResponse(w, http.StatusBadRequest, errResponseJSON, utils.RequestTypeContainerMetadata)
+			return
+		}
 		seelog.Infof("V3 container metadata handler: writing response for container '%s'", containerID)
 
-		// v3 handler shares the same container metadata response format with v2 handler.
-		v2.WriteContainerMetadataResponse(w, containerID, state)
+		responseJSON, _ := json.Marshal(containerResponse)
+		utils.WriteJSONToResponse(w, http.StatusOK, responseJSON, utils.RequestTypeContainerMetadata)
 	}
+}
+
+// GetContainerResponse gets container response for v3 metadata
+func GetContainerResponse(containerID string, state dockerstate.TaskEngineState) (*v2.ContainerResponse, error) {
+	containerResponse, err := v2.NewContainerResponse(containerID, state)
+	if err != nil {
+		return nil, errors.Errorf("Unable to generate metadata for container '%s'", containerID)
+	}
+	// fill in network details if not set
+	if containerResponse.Networks == nil {
+		if containerResponse.Networks, err = GetContainerNetworkMetadata(containerID, state); err != nil {
+			return nil, err
+		}
+	}
+	return containerResponse, nil
+}
+
+// GetContainerNetworkMetadata returns the network metadata for the container
+func GetContainerNetworkMetadata(containerID string, state dockerstate.TaskEngineState) ([]containermetadata.Network, error) {
+	dockerContainer, ok := state.ContainerByID(containerID)
+	if !ok {
+		return nil, errors.Errorf("Unable to find container '%s'", containerID)
+	}
+	// the logic here has been reused from
+	// https://github.com/aws/amazon-ecs-agent/blob/0c8913ba33965cf6ffdd6253fad422458d9346bd/agent/containermetadata/parse_metadata.go#L123
+	settings := dockerContainer.Container.GetNetworkSettings()
+	if settings == nil {
+		return nil, errors.Errorf("Unable to generate network response for container '%s'", containerID)
+	}
+	// This metadata is the information provided in older versions of the API
+	// We get the NetworkMode (Network interface name) from the HostConfig because this
+	// this is the network with which the container is created
+	ipv4AddressFromSettings := settings.IPAddress
+	networkModeFromHostConfig := dockerContainer.Container.GetNetworkMode()
+
+	// Extensive Network information is not available for Docker API versions 1.17-1.20
+	// Instead we only get the details of the first network
+	networks := make([]containermetadata.Network, 0)
+	if len(settings.Networks) > 0 {
+		for modeFromSettings, containerNetwork := range settings.Networks {
+			networkMode := modeFromSettings
+			ipv4Addresses := []string{containerNetwork.IPAddress}
+			network := containermetadata.Network{NetworkMode: networkMode, IPv4Addresses: ipv4Addresses}
+			networks = append(networks, network)
+		}
+	} else {
+		ipv4Addresses := []string{ipv4AddressFromSettings}
+		network := containermetadata.Network{NetworkMode: networkModeFromHostConfig, IPv4Addresses: ipv4Addresses}
+		networks = append(networks, network)
+	}
+	return networks, nil
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
v3 metadata networks response for non-awsvpc tasks was empty. Add networks response for all modes. 

### Implementation details
adding network metadata to v2 task/container metadata responses 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=30s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: yes

manual testing:
```
curl $ECS_CONTAINER_METADATA_URI | python -mjson.tool
{
    "CreatedAt": "2019-02-04T23:09:18.482622006Z",
    "DesiredStatus": "RUNNING",
    "DockerId": "c39b3407963ca852f3f905c2739458f4bfbf5a6daa39415637d725ef651bc94d",
    "DockerName": "ecs-sleep-5-busy-sleep-aacfbbedecb6f0cde801",
    "Image": "ubuntu",
    "ImageID": "sha256:20bb25d32758db4f91b18a9581794cfaa6a8c5fbad80093e9a9e42211e131a48",
    "KnownStatus": "RUNNING",
    "Labels": {
        "com.amazonaws.ecs.cluster": "default",
        "com.amazonaws.ecs.container-name": "busy-sleep",
        "com.amazonaws.ecs.task-arn": "arn:aws:ecs:us-west-2::task/b2f909df-43e5-4717-a8c6-99905475cd03",
        "com.amazonaws.ecs.task-definition-family": "sleep",
        "com.amazonaws.ecs.task-definition-version": "5"
    },
    "Limits": {
        "CPU": 512,
        "Memory": 100
    },
    "Name": "busy-sleep",
    "Networks": [
        {
            "IPv4Addresses": [
                "172.17.0.2"
            ],
            "NetworkMode": "default"
        }
    ],
    "StartedAt": "2019-02-04T23:09:19.00245409Z",
    "Type": "NORMAL"
}

curl $ECS_CONTAINER_METADATA_URI/task | python -mjson.tool
{
    "AvailabilityZone": "us-west-2a",
    "Cluster": "default",
    "Containers": [
        {
            "CreatedAt": "2019-02-04T23:09:18.482622006Z",
            "DesiredStatus": "RUNNING",
            "DockerId": "c39b3407963ca852f3f905c2739458f4bfbf5a6daa39415637d725ef651bc94d",
            "DockerName": "ecs-sleep-5-busy-sleep-aacfbbedecb6f0cde801",
            "Image": "ubuntu",
            "ImageID": "sha256:20bb25d32758db4f91b18a9581794cfaa6a8c5fbad80093e9a9e42211e131a48",
            "KnownStatus": "RUNNING",
            "Labels": {
                "com.amazonaws.ecs.cluster": "default",
                "com.amazonaws.ecs.container-name": "busy-sleep",
                "com.amazonaws.ecs.task-arn": "arn:aws:ecs:us-west-2::task/b2f909df-43e5-4717-a8c6-99905475cd03",
                "com.amazonaws.ecs.task-definition-family": "sleep",
                "com.amazonaws.ecs.task-definition-version": "5"
            },
            "Limits": {
                "CPU": 512,
                "Memory": 100
            },
            "Name": "busy-sleep",
            "Networks": [
                {
                    "IPv4Addresses": [
                        "172.17.0.2"
                    ],
                    "NetworkMode": "default"
                }
            ],
            "StartedAt": "2019-02-04T23:09:19.00245409Z",
            "Type": "NORMAL"
        }
    ],
    "DesiredStatus": "RUNNING",
    "Family": "sleep",
    "KnownStatus": "RUNNING",
    "PullStartedAt": "2019-02-04T23:09:15.072280841Z",
    "PullStoppedAt": "2019-02-04T23:09:18.475952428Z",
    "Revision": "5",
    "TaskARN": "arn:aws:ecs:us-west-2:074626758757:task/b2f909df-43e5-4717-a8c6-99905475cd03"
}
```

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
