### PR TITLE
Dryrun dryruns manifest-tool command

### DIFF
--- a/scripts/publish-docker-images
+++ b/scripts/publish-docker-images
@@ -123,7 +123,7 @@ push_multi-arch_manifest_docker_hub() {
 		# Replace the tags in multi-arch.yaml
 		sed -e "s/\${docker-image-tag}/${image_tag}/"  ../scripts/multi-arch.yaml > multi-arch-temp.yaml
 		# Generate the manifest list and push to docker hub
-		./manifest-tool push from-spec multi-arch-temp.yaml
+		dryval ./manifest-tool push from-spec multi-arch-temp.yaml
 		rm multi-arch-temp.yaml
 	done
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
`manifest-tool` expects the new images uploaded in `publish-docker-images` to be present on docker hub. In case of `dryrun`, the new images won't be present on docker hub and manifest-tool will break.

With this PR, `-d` flag will be respected for `manifest-tool` command.   

### Implementation details
<!-- How are the changes implemented? -->

### Testing
Tested with `-d` set to `true` and `false`.  
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->


### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
