### PR TITLE
Adjust functional tests memory

### DIFF
--- a/agent/functional_tests/testdata/taskdefinitions/add-drop-capabilities/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/add-drop-capabilities/task-definition.json
@@ -4,7 +4,7 @@
     "image": "127.0.0.1:51670/ubuntu:latest",
     "name": "exit",
     "cpu": 10,
-    "memory": 10,
+    "memory": 64,
     "linuxParameters": {
       "capabilities": {
         "add": ["SYS_ADMIN"],

--- a/agent/functional_tests/testdata/taskdefinitions/awslogs-datetime/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/awslogs-datetime/task-definition.json
@@ -2,7 +2,7 @@
   "family": "ecs-awslogs-datetime-test",
   "containerDefinitions": [{
     "essential": true,
-    "memory": 10,
+    "memory": 64,
     "name": "awslogs-datetime",
     "cpu": 10,
     "image": "busybox:latest",

--- a/agent/functional_tests/testdata/taskdefinitions/awslogs-multiline/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/awslogs-multiline/task-definition.json
@@ -2,7 +2,7 @@
   "family": "ecs-awslogs-multiline-test",
   "containerDefinitions": [{
     "essential": true,
-    "memory": 10,
+    "memory": 64,
     "name": "awslogs-multiline",
     "cpu": 10,
     "image": "busybox:latest",

--- a/agent/functional_tests/testdata/taskdefinitions/awslogs/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/awslogs/task-definition.json
@@ -2,7 +2,7 @@
   "family": "ecs-awslogs-test",
   "containerDefinitions": [{
     "essential": true,
-    "memory": 10,
+    "memory": 64,
     "name": "awslogs",
     "cpu": 10,
     "image": "busybox:latest",

--- a/agent/functional_tests/testdata/taskdefinitions/datavolume/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/datavolume/task-definition.json
@@ -8,7 +8,7 @@
     "image": "127.0.0.1:51670/busybox:latest",
     "name": "exit",
     "cpu": 10,
-    "memory": 10,
+    "memory": 64,
     "essential": true,
     "volumesFrom": [{
       "sourceContainer": "data-volume-source"
@@ -18,7 +18,7 @@
     "image": "127.0.0.1:51670/busybox:latest",
     "name": "dataSource",
     "cpu": 10,
-    "memory": 10,
+    "memory": 64,
     "essential": false,
     "volumesFrom": [{
       "sourceContainer": "data-volume-source"
@@ -28,7 +28,7 @@
     "image": "127.0.0.1:51670/busybox:latest",
     "name": "data-volume-source",
     "cpu": 10,
-    "memory": 10,
+    "memory": 64,
     "essential": false,
     "mountPoints": [{
       "sourceVolume": "test",

--- a/agent/functional_tests/testdata/taskdefinitions/datavolume2/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/datavolume2/task-definition.json
@@ -7,7 +7,7 @@
   "containerDefinitions": [{
     "name": "datavolume",
     "image": "127.0.0.1:51670/busybox:latest",
-    "memory": 20,
+    "memory": 64,
     "mountPoints": [{
       "sourceVolume": "vol",
       "containerPath": "/data"
@@ -16,7 +16,7 @@
   }, {
     "name": "a",
     "image": "127.0.0.1:51670/busybox:latest",
-    "memory": 20,
+    "memory": 64,
     "command": ["sh", "-c", "echo 42 | nc -l -p 9000"],
     "volumesFrom": [{
       "sourceContainer": "datavolume"
@@ -24,7 +24,7 @@
   }, {
     "name": "exit",
     "image": "127.0.0.1:51670/busybox:latest",
-    "memory": 20,
+    "memory": 64,
     "portMappings": [{
       "containerPort": 80
     }],

--- a/agent/functional_tests/testdata/taskdefinitions/devices/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/devices/task-definition.json
@@ -4,7 +4,7 @@
     "image": "127.0.0.1:51670/ubuntu:latest",
     "name": "exit",
     "cpu": 10,
-    "memory": 10,
+    "memory": 64,
     "linuxParameters": {
       "devices":[
         {

--- a/agent/functional_tests/testdata/taskdefinitions/dns-search-domains/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/dns-search-domains/task-definition.json
@@ -4,7 +4,7 @@
     "image": "busybox:latest",
     "name": "exit",
     "cpu": 10,
-    "memory": 10,
+    "memory": 64,
     "dnsSearchDomains": ["search.example.com"],
     "command": ["sh", "-c", "egrep \"search\\s+search.example.com\" /etc/resolv.conf && exit 42 || exit 1"]
   }]

--- a/agent/functional_tests/testdata/taskdefinitions/dns-servers/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/dns-servers/task-definition.json
@@ -4,7 +4,7 @@
     "image": "busybox:latest",
     "name": "exit",
     "cpu": 10,
-    "memory": 10,
+    "memory": 64,
     "dnsServers": ["1.2.3.4"],
     "command": ["sh", "-c", "egrep \"nameserver\\s+1\\.2\\.3\\.4\" /etc/resolv.conf && exit 42 || exit 1"]
   }]

--- a/agent/functional_tests/testdata/taskdefinitions/extra-hosts/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/extra-hosts/task-definition.json
@@ -4,7 +4,7 @@
     "image": "busybox:latest",
     "name": "exit",
     "cpu": 10,
-    "memory": 10,
+    "memory": 64,
     "extraHosts": [{"hostname": "test.local", "ipAddress": "127.10.10.10"}],
     "command": ["sh", "-c", "egrep \"127\\.10\\.10\\.10\\s+test\\.local\" /etc/hosts && exit 42 || exit 1"]
   }]

--- a/agent/functional_tests/testdata/taskdefinitions/fluentd-log-tag/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/fluentd-log-tag/task-definition.json
@@ -6,7 +6,7 @@
          "image":"127.0.0.1:51670/ubuntu:latest",
          "essential":true,
          "cpu":10,
-         "memory":10,
+         "memory": 64,
          "command":[
             "sh",
             "-c",

--- a/agent/functional_tests/testdata/taskdefinitions/fluentd-tag/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/fluentd-tag/task-definition.json
@@ -6,7 +6,7 @@
          "image":"127.0.0.1:51670/ubuntu:latest",
          "essential":true,
          "cpu":10,
-         "memory":10,
+         "memory": 64,
          "command":[
             "sh",
             "-c",

--- a/agent/functional_tests/testdata/taskdefinitions/hostname/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/hostname/task-definition.json
@@ -4,7 +4,7 @@
     "image": "busybox:latest",
     "name": "exit",
     "cpu": 10,
-    "memory": 10,
+    "memory": 64,
     "hostname": "foobarbaz",
     "command": ["sh", "-c", "[ \"$(hostname)\" == \"foobarbaz\" ] && exit 42 || exit 1"]
   }]

--- a/agent/functional_tests/testdata/taskdefinitions/init-process/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/init-process/task-definition.json
@@ -4,7 +4,7 @@
     "image": "127.0.0.1:51670/ubuntu:latest",
     "name": "exit",
     "cpu": 10,
-    "memory": 10,
+    "memory": 64,
     "linuxParameters": {
       "initProcessEnabled":true
     },

--- a/agent/functional_tests/testdata/taskdefinitions/interactive-tty/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/interactive-tty/task-definition.json
@@ -4,7 +4,7 @@
     "image": "127.0.0.1:51670/ubuntu:latest",
     "name": "exit",
     "cpu": 10,
-    "memory": 10,
+    "memory": 64,
     "interactive":true,
     "pseudoTerminal":true,
     "command": ["sh", "-c", "if [ -t 0 ] ; then exit 42; else exit 1; fi"]

--- a/agent/functional_tests/testdata/taskdefinitions/labels/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/labels/task-definition.json
@@ -4,7 +4,7 @@
     "image": "busybox:latest",
     "name": "labeled",
     "cpu": 10,
-    "memory": 10,
+    "memory": 64,
     "dockerLabels": {
       "label1": "",
       "com.foo.label2": "value"

--- a/agent/functional_tests/testdata/taskdefinitions/logdriver-jsonfile/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/logdriver-jsonfile/task-definition.json
@@ -3,7 +3,7 @@
   "containerDefinitions": [{
     "image": "busybox:latest",
     "name": "exit",
-    "memory": 10,
+    "memory": 64,
     "cpu": 10,
     "logConfiguration": {
       "logDriver": "json-file",

--- a/agent/functional_tests/testdata/taskdefinitions/network-disabled/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/network-disabled/task-definition.json
@@ -4,7 +4,7 @@
     "image": "busybox:latest",
     "name": "exit",
     "cpu": 10,
-    "memory": 10,
+    "memory": 64,
     "disableNetworking": true,
     "command": ["sh", "-c", "[ -z \"$(ifconfig | grep \"inet addr\" | grep -v \"127\\.0\\.0\\.1\")\" ] && exit 42 || exit 1"]
   }]

--- a/agent/functional_tests/testdata/taskdefinitions/network-link-2/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/network-link-2/task-definition.json
@@ -4,7 +4,7 @@
     "name": "a",
     "image": "127.0.0.1:51670/busybox:latest",
     "cpu": 0,
-    "memory": 8,
+    "memory": 64,
     "essential": true,
     "command": ["sh", "-c", "while true; do sleep 1; done"]
   },
@@ -13,7 +13,7 @@
     "image": "127.0.0.1:51670/busybox:latest",
     "links": ["a:a"],
     "cpu": 0,
-    "memory": 8,
+    "memory": 64,
     "essential": true,
     "command": ["sh", "-c", "while true; do sleep 1; done"]
   },
@@ -23,7 +23,7 @@
     "links": ["a:a"],
     "volumesFrom": [{"sourceContainer": "a"}],
     "cpu": 0,
-    "memory": 8,
+    "memory": 64,
     "essential": true,
     "command": ["sh", "-c", "while true; do sleep 1; done"]
   },
@@ -33,7 +33,7 @@
     "links": ["a:a", "bb:bb", "b:b"],
     "volumesFrom": [{"sourceContainer": "a"}],
     "cpu": 0,
-    "memory": 8,
+    "memory": 64,
     "essential": true,
     "command": ["sh", "-c", "while true; do sleep 1; done"]
   },
@@ -42,7 +42,7 @@
     "image": "127.0.0.1:51670/busybox:latest",
     "volumesFrom": [{"sourceContainer": "c"}],
     "cpu": 0,
-    "memory": 8,
+    "memory": 64,
     "essential": true,
     "command": ["sh", "-c", "while true; do sleep 1; done"]
   },
@@ -50,7 +50,7 @@
     "name": "exit",
     "image": "127.0.0.1:51670/busybox:latest",
     "cpu": 0,
-    "memory": 8,
+    "memory": 64,
     "links": ["d:d"],
     "command": ["sh", "-c", "exit 42"]
   }]

--- a/agent/functional_tests/testdata/taskdefinitions/network-link/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/network-link/task-definition.json
@@ -10,7 +10,7 @@
     "name": "exit",
     "image": "127.0.0.1:51670/busybox:latest",
     "cpu": 10,
-    "memory": 10,
+    "memory": 64,
     "links": ["nginx:nginx"],
     "command": ["sh", "-c", "sleep 1; wget -O- http://nginx && exit 42; exit -1"]
   }]

--- a/agent/functional_tests/testdata/taskdefinitions/nofiles-ulimit/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/nofiles-ulimit/task-definition.json
@@ -4,7 +4,7 @@
     "image": "busybox:latest",
     "name": "exit",
     "cpu": 10,
-    "memory": 10,
+    "memory": 64,
     "ulimits": [{"name":"nofile", "softLimit": 123, "hardLimit": 234}],
     "command": ["sh", "-c", "[ \"$(cat /proc/self/limits  | grep \"^Max open files\" | awk '{print $4\" \"$5}')\" == \"123 234\" ] && exit 42 || exit 1"]
   }]

--- a/agent/functional_tests/testdata/taskdefinitions/oom-container/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/oom-container/task-definition.json
@@ -2,7 +2,7 @@
   "family": "ecsftest-oom-container",
   "containerDefinitions": [{
     "essential": true,
-    "memory": 10,
+    "memory": 64,
     "name": "error",
     "cpu": 1,
     "image": "127.0.0.1:51670/python:2",

--- a/agent/functional_tests/testdata/taskdefinitions/oom-task/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/oom-task/task-definition.json
@@ -1,6 +1,6 @@
 {
   "family": "ecsftest-oom-task",
-  "memory": "10",
+  "memory": "64",
   "containerDefinitions": [{
     "essential": true,
     "name": "error",

--- a/agent/functional_tests/testdata/taskdefinitions/parallel-pull/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/parallel-pull/task-definition.json
@@ -6,14 +6,14 @@
         "image": "127.0.0.1:51670/busybox:parallel-pull-fts",
         "cpu": 10,
         "command":  [ "sh", "-c", "while [ true ]; do sleep 1s; date +%T; done"],
-        "memory": 10,
+        "memory": 64,
         "essential": true
     },
     {
         "name": "ubuntu",
         "image": "127.0.0.1:51670/ubuntu:parallel-pull-fts",
         "cpu": 10,
-        "memory": 10,
+        "memory": 64,
         "essential": true,
         "command": ["bash", "-c", "while [ true ]; do date +%T; sleep 1s; done"]
     },
@@ -27,7 +27,7 @@
         "name": "debian",
         "image": "127.0.0.1:51670/debian:parallel-pull-fts",
         "cpu": 10,
-        "memory": 10,
+        "memory": 64,
         "essential": true,
         "command": ["bash", "-c", "while [ true ]; do date +%T; sleep 1s; done"]
     },
@@ -35,7 +35,7 @@
         "name": "debian-2",
         "image": "127.0.0.1:51670/debian:parallel-pull-fts",
         "cpu": 10,
-        "memory": 10,
+        "memory": 64,
         "essential": true,
         "command": ["bash", "-c", "while [ true ]; do date +%T; sleep 1s; done"]
     },
@@ -43,7 +43,7 @@
         "name": "httpd",
         "image": "127.0.0.1:51670/httpd:parallel-pull-fts",
         "cpu": 10,
-        "memory": 10,
+        "memory": 64,
         "essential": true
     },
     {
@@ -64,7 +64,7 @@
         "name": "redis",
         "image": "127.0.0.1:51670/redis:parallel-pull-fts",
         "cpu": 10,
-        "memory": 10,
+        "memory": 64,
         "essential": true
     },
     {

--- a/agent/functional_tests/testdata/taskdefinitions/private-registry-auth-asm-validator-unix/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/private-registry-auth-asm-validator-unix/task-definition.json
@@ -7,7 +7,7 @@
     "repositoryCredentials": {"credentialsParameter": "$$$REPOSITORY_CREDENTIALS$$$"},
     "name": "private-registry-auth-asm-validator",
     "cpu": 10,
-    "memory": 10,
+    "memory": 64,
     "essential": true,
     "command": ["sh", "-c", "exit 42"]
   }]

--- a/agent/functional_tests/testdata/taskdefinitions/privileged/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/privileged/task-definition.json
@@ -4,7 +4,7 @@
     "image": "busybox:latest",
     "name": "exit",
     "cpu": 10,
-    "memory": 10,
+    "memory": 64,
     "privileged": true,
     "command": ["sh", "-c", "mkdir /test && mount --rbind /test /tmp && exit 42 || exit 1"]
   }]

--- a/agent/functional_tests/testdata/taskdefinitions/readonly-rootfs/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/readonly-rootfs/task-definition.json
@@ -4,7 +4,7 @@
     "image": "busybox:latest",
     "name": "exit",
     "cpu": 10,
-    "memory": 10,
+    "memory": 64,
     "readonlyRootFilesystem": true,
     "command": ["sh", "-c", "touch /readonly && exit 1 || exit 42"]
   }]

--- a/agent/functional_tests/testdata/taskdefinitions/simple-exit-authed/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/simple-exit-authed/task-definition.json
@@ -4,7 +4,7 @@
     "image": "127.0.0.1:51671/busybox:latest",
     "name": "exit",
     "cpu": 10,
-    "memory": 10,
+    "memory": 64,
     "essential": true,
     "command": ["sh", "-c", "exit 42"]
   }]

--- a/agent/functional_tests/testdata/taskdefinitions/simple-exit/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/simple-exit/task-definition.json
@@ -4,7 +4,7 @@
     "image": "127.0.0.1:51670/busybox:latest",
     "name": "exit",
     "cpu": 10,
-    "memory": 10,
+    "memory": 64,
     "essential": true,
     "command": ["sh", "-c", "exit 42"]
   }]

--- a/agent/functional_tests/testdata/taskdefinitions/sysctl/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/sysctl/task-definition.json
@@ -4,7 +4,7 @@
     "image": "127.0.0.1:51670/ubuntu:latest",
     "name": "exit",
     "cpu": 10,
-    "memory": 10,
+    "memory": 64,
     "systemControls": [{
         "namespace":"net.ipv4.conf.default.rp_filter",
         "value":"0"

--- a/agent/functional_tests/testdata/taskdefinitions/user-nobody/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/user-nobody/task-definition.json
@@ -4,7 +4,7 @@
     "image": "busybox:latest",
     "name": "exit",
     "cpu": 10,
-    "memory": 10,
+    "memory": 64,
     "user": "nobody",
     "command": ["sh", "-c", "[ \"$(whoami)\" == \"nobody\" ] && exit 42 || exit 1"]
   }]

--- a/agent/functional_tests/testdata/taskdefinitions/working-dir/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/working-dir/task-definition.json
@@ -4,7 +4,7 @@
     "image": "busybox:latest",
     "name": "exit",
     "cpu": 10,
-    "memory": 10,
+    "memory": 64,
     "workingDirectory": "/var",
     "command": ["sh", "-c", "[ \"$(pwd)\" == \"/var\" ] && exit 42 || exit 1"]
   }]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Newly patched version of docker will sometimes fail to start a container if it has fairly low (~10mb) memory.

### Implementation details
Reworking all of our tests to use much more memory

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
