### PR TITLE
Set router skip clean to false 

### DIFF
--- a/agent/functional_tests/testdata/taskdefinitions/task-server-endpoint-validator/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/task-server-endpoint-validator/task-definition.json
@@ -1,0 +1,11 @@
+{
+    "family": "task-server-endpoint-validator",
+    "taskRoleArn": "$$$TASK_ROLE$$$",
+    "networkMode": "host",
+    "containerDefinitions": [{
+        "image": "amazonlinux:2",
+        "name": "task_server_endpoint_validator_container",
+        "memory": 256,
+        "command": ["sh", "-c", "curl -L -o /dev/null -s -w \"%{http_code}\n\" http://169.254.170.2/$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI | grep \"200\" && exit 42 || exit 1"]
+    }]
+}

--- a/agent/handlers/task_server_setup.go
+++ b/agent/handlers/task_server_setup.go
@@ -56,9 +56,9 @@ func taskServerSetup(credentialsManager credentials.Manager,
 	containerInstanceArn string) *http.Server {
 	muxRouter := mux.NewRouter()
 
-	// Set this so that for request like "/v3//metadata/task", the Agent will pass
-	// it to task metadata handler instead of returning a 301 error.
-	muxRouter.SkipClean(true)
+	// Set this to false so that for request like "//v3//metadata/task"
+	// to permanently redirect(301) to "/v3/metadata/task" handler
+	muxRouter.SkipClean(false)
 
 	muxRouter.HandleFunc(v1.CredentialsPath,
 		v1.CredentialsHandler(credentialsManager, auditLogger))
@@ -79,7 +79,7 @@ func taskServerSetup(credentialsManager credentials.Manager,
 	loggingMuxRouter.Handle(rootPath, tollbooth.LimitHandler(
 		limiter, NewLoggingHandler(muxRouter)))
 
-	loggingMuxRouter.SkipClean(true)
+	loggingMuxRouter.SkipClean(false)
 
 	server := http.Server{
 		Addr:         ":" + strconv.Itoa(config.AgentCredentialsPort),


### PR DESCRIPTION
<!--Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This enables agent to handle request like "//v2/credential" correctly. This brings back the support for //path that agent version 1.20.3 or before
https://github.com/aws/amazon-ecs-agent/issues/1839

### Implementation details
<!-- How are the changes implemented? -->
set router skip clean to false
doc for skip clean https://godoc.org/github.com/gorilla/mux#Router.SkipClean

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

yes,

unit test, functional test

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
