### PR TITLE
check for nvidia runtime if GPU support enabled

### DIFF
--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -309,6 +309,15 @@ func (task *Task) addGPUResource() error {
 	return nil
 }
 
+func (task *Task) isGPUEnabled() bool {
+	for _, association := range task.Associations {
+		if association.Type == GPUAssociationType {
+			return true
+		}
+	}
+	return false
+}
+
 func (task *Task) populateGPUEnvironmentVariables() {
 	for _, container := range task.Containers {
 		if len(container.GPUIDs) > 0 {
@@ -982,7 +991,7 @@ func (task *Task) dockerHostConfig(container *apicontainer.Container, dockerCont
 		Resources:    resources,
 	}
 
-	if task.shouldRequireNvidiaRuntime(container) {
+	if task.isGPUEnabled() && task.shouldRequireNvidiaRuntime(container) {
 		if task.NvidiaRuntime == "" {
 			return nil, &apierrors.HostConfigError{"Runtime is not set for GPU containers"}
 		}

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -2816,3 +2816,35 @@ func TestAssociationByTypeAndName(t *testing.T) {
 	association, ok = task.AssociationByTypeAndName("other-type", "dev1")
 	assert.False(t, ok)
 }
+
+func TestTaskGPUEnabled(t *testing.T) {
+	testTask := &Task{
+		Associations: []Association{
+			{
+				Containers: []string{
+					"myName1",
+				},
+				Content: EncodedString{
+					Encoding: "base64",
+					Value:    "val",
+				},
+				Name: "gpu1",
+				Type: "gpu",
+			},
+		},
+	}
+
+	assert.True(t, testTask.isGPUEnabled())
+}
+
+func TestTaskGPUDisabled(t *testing.T) {
+	testTask := &Task{
+		Containers: []*apicontainer.Container{
+			{
+				Name: "myName1",
+			},
+		},
+	}
+
+	assert.False(t, testTask.isGPUEnabled())
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Currently if `NVIDIA_VISIBLE_DEVICES` is present in the environment variables, agent checks for runtime to be set irrespective of checking if ECS GPU support is present. 

this PR checks if ECS GPU support is present

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
