### PR TITLE
engine,dockerclient: per container start/stop timeouts

### DIFF
--- a/agent/acs/model/api/api-2.json
+++ b/agent/acs/model/api/api-2.json
@@ -204,7 +204,9 @@
         "registryAuthentication":{"shape":"RegistryAuthenticationData"},
         "logsAuthStrategy":{"shape":"AuthStrategy"},
         "secrets":{"shape":"SecretList"},
-        "dependsOn":{"shape": "DependsOnList"}
+        "dependsOn":{"shape": "DependsOnList"},
+        "startTimeout":{"shape":"Integer"},
+        "stopTimeout":{"shape":"Integer"}
       }
     },
     "ContainerList":{

--- a/agent/acs/model/ecsacs/api.go
+++ b/agent/acs/model/ecsacs/api.go
@@ -238,6 +238,10 @@ type Container struct {
 
 	Secrets []*Secret `locationName:"secrets" type:"list"`
 
+	StartTimeout *int64 `locationName:"startTimeout" type:"integer"`
+
+	StopTimeout *int64 `locationName:"stopTimeout" type:"integer"`
+
 	VolumesFrom []*VolumeFrom `locationName:"volumesFrom" type:"list"`
 }
 

--- a/agent/api/container/container.go
+++ b/agent/api/container/container.go
@@ -140,6 +140,12 @@ type Container struct {
 	// LogsAuthStrategy specifies how the logs driver for the container will be
 	// authenticated
 	LogsAuthStrategy string
+	// StartTimeout specifies the time the agent waits for StartContainer api call
+	// before timing out
+	StartTimeout uint
+	// StopTimeout specifies the time value to be passed as StopContainer api call
+	StopTimeout uint
+
 	// lock is used for fields that are accessed and updated concurrently
 	lock sync.RWMutex
 
@@ -866,4 +872,18 @@ func (c *Container) HasSecretAsEnv() bool {
 		}
 	}
 	return false
+}
+
+func (c *Container) GetStartTimeout() time.Duration {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	return time.Duration(c.StartTimeout) * time.Second
+}
+
+func (c *Container) GetStopTimeout() time.Duration {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	return time.Duration(c.StopTimeout) * time.Second
 }

--- a/agent/api/container/container_test.go
+++ b/agent/api/container/container_test.go
@@ -327,7 +327,7 @@ func TestMergeEnvironmentVariables(t *testing.T) {
 		},
 
 		{
-			Name: "merge single item to nil container env var map",
+			Name:                   "merge single item to nil container env var map",
 			InContainerEnvironment: nil,
 			InEnvVarMap: map[string]string{
 				"SECRET1": "secret1"},
@@ -357,7 +357,7 @@ func TestMergeEnvironmentVariables(t *testing.T) {
 		},
 
 		{
-			Name: "merge nil to nil container env var map",
+			Name:                   "merge nil to nil container env var map",
 			InContainerEnvironment: nil,
 			InEnvVarMap:            nil,
 			OutEnvVarMap:           map[string]string{},
@@ -454,4 +454,17 @@ func TestHasSecretAsEnv(t *testing.T) {
 		assert.Equal(t, test.out, container.HasSecretAsEnv())
 	}
 
+}
+
+func TestPerContainerTimeouts(t *testing.T) {
+	timeout := uint(10)
+	expectedTimeout := time.Duration(timeout) * time.Second
+
+	container := Container{
+		StartTimeout: timeout,
+		StopTimeout:  timeout,
+	}
+
+	assert.Equal(t, container.GetStartTimeout(), expectedTimeout)
+	assert.Equal(t, container.GetStopTimeout(), expectedTimeout)
 }

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -2945,7 +2945,7 @@ func TestInitializeContainerOrderingWithError(t *testing.T) {
 	assert.Error(t, errLink2)
 }
 
-func TestPostUnmarshalPerContainerTimeouts(t *testing.T) {
+func TestTaskFromACSPerContainerTimeouts(t *testing.T) {
 	modelTimeout := int64(10)
 	expectedTimeout := uint(modelTimeout)
 

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -2845,28 +2845,27 @@ func TestTaskGPUDisabled(t *testing.T) {
 			},
 		},
 	}
-
 	assert.False(t, testTask.isGPUEnabled())
 }
 
 func TestInitializeContainerOrderingWithLinksAndVolumesFrom(t *testing.T) {
 	containerWithOnlyVolume := &apicontainer.Container{
-		Name:   "myName",
-		Image:  "image:tag",
+		Name:        "myName",
+		Image:       "image:tag",
 		VolumesFrom: []apicontainer.VolumeFrom{{SourceContainer: "myName1"}},
 	}
 
 	containerWithOnlyLink := &apicontainer.Container{
 		Name:  "myName1",
 		Image: "image:tag",
-		Links:  []string{"myName"},
+		Links: []string{"myName"},
 	}
 
 	containerWithBothVolumeAndLink := &apicontainer.Container{
-		Name:   "myName2",
-		Image:  "image:tag",
+		Name:        "myName2",
+		Image:       "image:tag",
 		VolumesFrom: []apicontainer.VolumeFrom{{SourceContainer: "myName"}},
-		Links:  []string{"myName1"},
+		Links:       []string{"myName1"},
 	}
 
 	containerWithNoVolumeOrLink := &apicontainer.Container{
@@ -2877,8 +2876,8 @@ func TestInitializeContainerOrderingWithLinksAndVolumesFrom(t *testing.T) {
 	task := &Task{
 		Arn:                "test",
 		ResourcesMapUnsafe: make(map[string][]taskresource.TaskResource),
-		Containers:         []*apicontainer.Container{containerWithOnlyVolume, containerWithOnlyLink,
-		                                              containerWithBothVolumeAndLink, containerWithNoVolumeOrLink},
+		Containers: []*apicontainer.Container{containerWithOnlyVolume, containerWithOnlyLink,
+			containerWithBothVolumeAndLink, containerWithNoVolumeOrLink},
 	}
 
 	err := task.initializeContainerOrderingForVolumes()
@@ -2887,27 +2886,27 @@ func TestInitializeContainerOrderingWithLinksAndVolumesFrom(t *testing.T) {
 	assert.NoError(t, err)
 
 	containerResultWithVolume := task.Containers[0]
-	assert.Equal(t,  "myName1", containerResultWithVolume.DependsOn[0].Container)
-	assert.Equal(t,  ContainerOrderingStartCondition, containerResultWithVolume.DependsOn[0].Condition)
+	assert.Equal(t, "myName1", containerResultWithVolume.DependsOn[0].Container)
+	assert.Equal(t, ContainerOrderingStartCondition, containerResultWithVolume.DependsOn[0].Condition)
 
 	containerResultWithLink := task.Containers[1]
-	assert.Equal(t,  "myName", containerResultWithLink.DependsOn[0].Container)
-	assert.Equal(t,  ContainerOrderingRunningCondition, containerResultWithLink.DependsOn[0].Condition)
+	assert.Equal(t, "myName", containerResultWithLink.DependsOn[0].Container)
+	assert.Equal(t, ContainerOrderingRunningCondition, containerResultWithLink.DependsOn[0].Condition)
 
 	containerResultWithBothVolumeAndLink := task.Containers[2]
-	assert.Equal(t,  "myName", containerResultWithBothVolumeAndLink.DependsOn[0].Container)
-	assert.Equal(t,  ContainerOrderingStartCondition, containerResultWithBothVolumeAndLink.DependsOn[0].Condition)
-	assert.Equal(t,  "myName1", containerResultWithBothVolumeAndLink.DependsOn[1].Container)
-	assert.Equal(t,  ContainerOrderingRunningCondition, containerResultWithBothVolumeAndLink.DependsOn[1].Condition)
+	assert.Equal(t, "myName", containerResultWithBothVolumeAndLink.DependsOn[0].Container)
+	assert.Equal(t, ContainerOrderingStartCondition, containerResultWithBothVolumeAndLink.DependsOn[0].Condition)
+	assert.Equal(t, "myName1", containerResultWithBothVolumeAndLink.DependsOn[1].Container)
+	assert.Equal(t, ContainerOrderingRunningCondition, containerResultWithBothVolumeAndLink.DependsOn[1].Condition)
 
 	containerResultWithNoVolumeOrLink := task.Containers[3]
-	assert.Equal(t,  0, len(containerResultWithNoVolumeOrLink.DependsOn))
+	assert.Equal(t, 0, len(containerResultWithNoVolumeOrLink.DependsOn))
 }
 
 func TestInitializeContainerOrderingWithError(t *testing.T) {
 	containerWithVolumeError := &apicontainer.Container{
-		Name:   "myName",
-		Image:  "image:tag",
+		Name:        "myName",
+		Image:       "image:tag",
 		VolumesFrom: []apicontainer.VolumeFrom{{SourceContainer: "dummyContainer"}},
 	}
 
@@ -2944,4 +2943,24 @@ func TestInitializeContainerOrderingWithError(t *testing.T) {
 	assert.Error(t, errVolume2)
 	errLink2 := task2.initializeContainerOrderingForLinks()
 	assert.Error(t, errLink2)
+}
+
+func TestPostUnmarshalPerContainerTimeouts(t *testing.T) {
+	modelTimeout := int64(10)
+	expectedTimeout := uint(modelTimeout)
+
+	taskFromACS := ecsacs.Task{
+		Containers: []*ecsacs.Container{
+			{
+				StartTimeout: aws.Int64(modelTimeout),
+				StopTimeout:  aws.Int64(modelTimeout),
+			},
+		},
+	}
+	seqNum := int64(42)
+	task, err := TaskFromACS(&taskFromACS, &ecsacs.PayloadMessage{SeqNum: &seqNum})
+	assert.Nil(t, err, "Should be able to handle acs task")
+
+	assert.Equal(t, task.Containers[0].StartTimeout, expectedTimeout)
+	assert.Equal(t, task.Containers[0].StopTimeout, expectedTimeout)
 }

--- a/agent/dockerclient/dockerapi/docker_client_test.go
+++ b/agent/dockerclient/dockerapi/docker_client_test.go
@@ -468,6 +468,7 @@ func TestStopContainerTimeout(t *testing.T) {
 	cfg.DockerStopTimeout = xContainerShortTimeout
 	mockDockerSDK, client, _, _, _, done := dockerClientSetupWithConfig(t, cfg)
 	defer done()
+	ctxTimeoutStopContainer = xContainerShortTimeout
 
 	wait := &sync.WaitGroup{}
 	wait.Add(1)

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -1271,7 +1271,7 @@ func TestStopPauseContainerCleanupCalled(t *testing.T) {
 		mockCNIClient.EXPECT().CleanupNS(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil),
 		dockerClient.EXPECT().StopContainer(gomock.Any(),
 			containerID,
-			defaultConfig.DockerStopTimeout+dockerclient.StopContainerTimeout,
+			defaultConfig.DockerStopTimeout,
 		).Return(dockerapi.DockerContainerMetadata{}),
 	)
 

--- a/agent/engine/engine_unix_integ_test.go
+++ b/agent/engine/engine_unix_integ_test.go
@@ -1447,3 +1447,42 @@ func TestGPUAssociationTask(t *testing.T) {
 	go taskEngine.AddTask(&taskUpdate)
 	verifyTaskIsStopped(stateChangeEvents, testTask)
 }
+
+func TestPerContainerStopTimeout(t *testing.T) {
+	// set the global stop timemout, but this should be ignored since the per container value is set
+	globalStopContainerTimeout := 1000 * time.Second
+	os.Setenv("ECS_CONTAINER_STOP_TIMEOUT", globalStopContainerTimeout.String())
+	defer os.Unsetenv("ECS_CONTAINER_STOP_TIMEOUT")
+	cfg := defaultTestConfigIntegTest()
+
+	taskEngine, _, _ := setup(cfg, nil, t)
+
+	dockerTaskEngine := taskEngine.(*DockerTaskEngine)
+
+	if dockerTaskEngine.cfg.DockerStopTimeout != globalStopContainerTimeout {
+		t.Errorf("Expect ECS_CONTAINER_STOP_TIMEOUT to be set to , %v", dockerTaskEngine.cfg.DockerStopTimeout)
+	}
+
+	testTask := createTestTask("TestDockerStopTimeout")
+	testTask.Containers[0].Command = []string{"sh", "-c", "trap 'echo hello' SIGTERM; while true; do echo `date +%T`; sleep 1s; done;"}
+	testTask.Containers[0].Image = testBusyboxImage
+	testTask.Containers[0].Name = "test-docker-timeout"
+	testTask.Containers[0].StopTimeout = uint(testDockerStopTimeout.Seconds())
+
+	go dockerTaskEngine.AddTask(testTask)
+
+	verifyContainerRunningStateChange(t, taskEngine)
+	verifyTaskRunningStateChange(t, taskEngine)
+
+	startTime := ttime.Now()
+	dockerTaskEngine.stopContainer(testTask, testTask.Containers[0])
+
+	verifyContainerStoppedStateChange(t, taskEngine)
+
+	if ttime.Since(startTime) < testDockerStopTimeout {
+		t.Errorf("Container stopped before the timeout: %v", ttime.Since(startTime))
+	}
+	if ttime.Since(startTime) > testDockerStopTimeout+1*time.Second {
+		t.Errorf("Container should have stopped eariler, but stopped after %v", ttime.Since(startTime))
+	}
+}

--- a/agent/statemanager/state_manager.go
+++ b/agent/statemanager/state_manager.go
@@ -78,7 +78,10 @@ const (
 	//   a) Add 'Associations' field to 'api.task.task'
 	//   b) Add 'GPUIDs' field to 'apicontainer.Container'
 	//   c) Add 'NvidiaRuntime' field to 'api.task.task'
-	// 20) Add 'DependsOn' field to 'apicontainer.Container'
+	// 20)
+	//   a) Add 'DependsOn' field to 'apicontainer.Container'
+	//   b) Add 'StartTime' field to 'api.container.Container'
+	//   c) Add 'StopTime' field to 'api.container.Container'
 	ECSDataVersion = 20
 
 	// ecsDataFile specifies the filename in the ECS_DATADIR

--- a/agent/statemanager/state_manager_test.go
+++ b/agent/statemanager/state_manager_test.go
@@ -362,3 +362,38 @@ func TestLoadsDataForContainerOrdering(t *testing.T) {
 	assert.Equal(t, "container_1", dependsOn[0].Container)
 	assert.Equal(t, "START", dependsOn[0].Condition)
 }
+
+func TestLoadsDataForPerContainerTimeouts(t *testing.T) {
+	cleanup, err := setupWindowsTest(filepath.Join(".", "testdata", "v20", "perContainerTimeouts", "ecs_agent_data.json"))
+	require.Nil(t, err, "Failed to set up test")
+	defer cleanup()
+	cfg := &config.Config{DataDir: filepath.Join(".", "testdata", "v20", "perContainerTimeouts")}
+	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil)
+	var containerInstanceArn, cluster, savedInstanceID string
+	var sequenceNumber int64
+	stateManager, err := statemanager.NewStateManager(cfg,
+		statemanager.AddSaveable("TaskEngine", taskEngine),
+		statemanager.AddSaveable("ContainerInstanceArn", &containerInstanceArn),
+		statemanager.AddSaveable("Cluster", &cluster),
+		statemanager.AddSaveable("EC2InstanceID", &savedInstanceID),
+		statemanager.AddSaveable("SeqNum", &sequenceNumber),
+	)
+	assert.NoError(t, err)
+	err = stateManager.Load()
+	assert.NoError(t, err)
+	assert.Equal(t, "state-file", cluster)
+	assert.EqualValues(t, 0, sequenceNumber)
+
+	tasks, err := taskEngine.ListTasks()
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(tasks))
+
+	task := tasks[0]
+	assert.Equal(t, "arn:aws:ecs:us-west-2:1234567890:task/33425c99-5db7-45fb-8244-bc94d00661e4", task.Arn)
+	assert.Equal(t, "per-container-timeouts", task.Family)
+	assert.Equal(t, 1, len(task.Containers))
+
+	c1 := task.Containers[0]
+	assert.Equal(t, uint(10), c1.StartTimeout)
+	assert.Equal(t, uint(10), c1.StopTimeout)
+}

--- a/agent/statemanager/testdata/v20/perContainerTimeouts/ecs_agent_data.json
+++ b/agent/statemanager/testdata/v20/perContainerTimeouts/ecs_agent_data.json
@@ -1,0 +1,202 @@
+{
+  "Data": {
+    "Cluster": "state-file",
+    "ContainerInstanceArn": "arn:aws:ecs:us-west-2:1234567890:container-instance/46efd519-df3f-4096-8f34-faebb1747752",
+    "EC2InstanceID": "i-0da29eb1a8a98768b",
+    "TaskEngine": {
+      "Tasks": [
+        {
+          "Arn": "arn:aws:ecs:us-west-2:1234567890:task/33425c99-5db7-45fb-8244-bc94d00661e4",
+          "Family": "per-container-timeouts",
+          "Version": "1",
+          "Containers": [
+            {
+              "Name": "container_1",
+              "Image": "amazonlinux:1",
+              "ImageID": "sha256:7f929d2604c7e504a568eac9a2523c1b9e9b15e1fcee4076e1411a552913d08e",
+              "Command": [
+                "sleep",
+                "3600"
+              ],
+              "Cpu": 0,
+              "GPUIDs": ["0", "1"],
+              "Memory": 512,
+              "Links": null,
+              "volumesFrom": [],
+              "mountPoints": [],
+              "portMappings": [],
+              "Essential": true,
+              "StartTimeout":10,
+              "StopTimeout":10,
+              "EntryPoint": null,
+              "environment": {
+                "NVIDIA_VISIBLE_DEVICES": "0,1"
+              },
+              "overrides": {
+                "command": null
+              },
+              "dockerConfig": {
+                "config": "{}",
+                "hostConfig": "{\"CapAdd\":[],\"CapDrop\":[]}",
+                "version": "1.17"
+              },
+              "registryAuthentication": null,
+              "secrets": [],
+              "LogsAuthStrategy": "",
+              "desiredStatus": "RUNNING",
+              "KnownStatus": "RUNNING",
+              "TransitionDependencySet": {
+                "1": {
+                  "ContainerDependencies": null,
+                  "ResourceDependencies": [
+                    {
+                      "Name": "cgroup",
+                      "RequiredStatus": 1
+                    }
+                  ]
+                }
+              },
+              "RunDependencies": null,
+              "IsInternal": "NORMAL",
+              "ApplyingError": {
+                "error": "API error (500): Get https://registry-1.docker.io/v2/library/amazonlinux/manifests/1: toomanyrequests: too many failed login attempts for username or IP address\n",
+                "name": "CannotPullContainerError"
+              },
+              "SentStatus": "RUNNING",
+              "metadataFileUpdated": false,
+              "KnownExitCode": null,
+              "KnownPortBindings": null
+            }
+          ],
+          "Associations": [
+            {
+              "Containers": ["container_1"],
+              "Content": {
+                "Encoding": "base64",
+                "Value": "val"
+              },
+              "Name": "0",
+              "Type": "gpu"
+            },
+            {
+              "Containers": ["container_1"],
+              "Content": {
+                "Encoding": "base64",
+                "Value": "val"
+              },
+              "Name": "1",
+              "Type": "gpu"
+            }
+          ],
+          "resources": {
+            "cgroup": [
+              {
+                "cgroupRoot": "/ecs/33425c99-5db7-45fb-8244-bc94d00661e4",
+                "cgroupMountPath": "/sys/fs/cgroup",
+                "createdAt": "0001-01-01T00:00:00Z",
+                "desiredStatus": "CREATED",
+                "knownStatus": "CREATED",
+                "resourceSpec": {
+                  "cpu": {
+                    "shares": 2
+                  }
+                }
+              }
+            ]
+          },
+          "volumes": [],
+          "DesiredStatus": "RUNNING",
+          "KnownStatus": "RUNNING",
+          "KnownTime": "2018-10-04T18:05:49.121835686Z",
+          "PullStartedAt": "2018-10-04T18:05:34.359798761Z",
+          "PullStoppedAt": "2018-10-04T18:05:48.445985904Z",
+          "ExecutionStoppedAt": "0001-01-01T00:00:00Z",
+          "SentStatus": "RUNNING",
+          "StartSequenceNumber": 2,
+          "StopSequenceNumber": 0,
+          "executionCredentialsID": "b1a6ede6-1a9f-4ab3-a02e-bd3e51b11244",
+          "ENI": null,
+          "MemoryCPULimitsEnabled": true,
+          "PlatformFields": {}
+        }
+      ],
+      "IdToContainer": {
+        "8f5e6e3091f221c876103289ddabcbcdeb64acd7ac7e2d0cf4da2be2be9d8956": {
+          "DockerId": "8f5e6e3091f221c876103289ddabcbcdeb64acd7ac7e2d0cf4da2be2be9d8956",
+          "DockerName": "ecs-private-registry-state-1-container1-a68ef4b6e0fba38d3500",
+          "Container": {
+            "Name": "container_1",
+            "Image": "amazonlinux:1",
+            "ImageID": "sha256:7f929d2604c7e504a568eac9a2523c1b9e9b15e1fcee4076e1411a552913d08e",
+            "Command": [
+              "sleep",
+              "3600"
+            ],
+            "Cpu": 0,
+            "Memory": 512,
+            "Links": null,
+            "volumesFrom": [],
+            "mountPoints": [],
+            "portMappings": [],
+            "Essential": true,
+            "EntryPoint": null,
+            "environment": {},
+            "overrides": {
+              "command": null
+            },
+            "dockerConfig": {
+              "config": "{}",
+              "hostConfig": "{\"CapAdd\":[],\"CapDrop\":[]}",
+              "version": "1.17"
+            },
+            "registryAuthentication": null,
+            "LogsAuthStrategy": "",
+            "desiredStatus": "RUNNING",
+            "KnownStatus": "RUNNING",
+            "TransitionDependencySet": {
+              "1": {
+                "ContainerDependencies": null,
+                "ResourceDependencies": [
+                  {
+                    "Name": "cgroup",
+                    "RequiredStatus": 1
+                  }
+                ]
+              }
+            },
+            "RunDependencies": null,
+            "IsInternal": "NORMAL",
+            "ApplyingError": {
+              "error": "API error (500): Get https://registry-1.docker.io/v2/library/amazonlinux/manifests/1: toomanyrequests: too many failed login attempts for username or IP address\n",
+              "name": "CannotPullContainerError"
+            },
+            "SentStatus": "RUNNING",
+            "metadataFileUpdated": false,
+            "KnownExitCode": null,
+            "KnownPortBindings": null
+          }
+        }
+      },
+      "IdToTask": {
+        "8f5e6e3091f221c876103289ddabcbcdeb64acd7ac7e2d0cf4da2be2be9d8956": "arn:aws:ecs:us-west-2:1234567890:task/33425c99-5db7-45fb-8244-bc94d00661e4"
+      },
+      "ImageStates": [
+        {
+          "Image": {
+            "ImageID": "sha256:7f929d2604c7e504a568eac9a2523c1b9e9b15e1fcee4076e1411a552913d08e",
+            "Names": [
+              "amazonlinux:1"
+            ],
+            "Size": 165452304
+          },
+          "PulledAt": "2018-10-04T18:05:48.445644088Z",
+          "LastUsedAt": "2018-10-04T18:05:48.445645342Z",
+          "PullSucceeded": false
+        }
+      ],
+      "ENIAttachments": null,
+      "IPToTask": {}
+    }
+  },
+  "Version": 20
+}


### PR DESCRIPTION
### Summary
* start timeout is governed by the agent and is the context timeout for
the StartContainer api call

* stop timeout is the parameter passed to StopContainer and is time the
docker daemon waits after a StopContainer call to issue a SIGKILL to the
container

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes
unit test:
* `TestPerContainerTimeouts`
* `TestPostUnmarshalPerContainerTimeouts`

integ test: 
* `TestPerContainerStopTimeout`

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
* Feature - Support for granular start and stop timeouts per container

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
