### PR TITLE
Replace mongo

### DIFF
--- a/agent/functional_tests/testdata/taskdefinitions/parallel-pull/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/parallel-pull/task-definition.json
@@ -47,17 +47,10 @@
         "essential": true
     },
     {
-        "name": "mongo",
-        "image": "127.0.0.1:51670/mongo:parallel-pull-fts",
+        "name": "redis-2",
+        "image": "127.0.0.1:51670/redis:parallel-pull-fts",
         "cpu": 10,
         "memory": 100,
-        "essential": true
-    },
-    {
-        "name": "nginx",
-        "image": "127.0.0.1:51670/nginx:parallel-pull-fts",
-        "cpu": 10,
-        "memory": 50,
         "essential": true
     },
     {
@@ -65,6 +58,13 @@
         "image": "127.0.0.1:51670/redis:parallel-pull-fts",
         "cpu": 10,
         "memory": 64,
+        "essential": true
+    },
+    {
+        "name": "nginx",
+        "image": "127.0.0.1:51670/nginx:parallel-pull-fts",
+        "cpu": 10,
+        "memory": 50,
         "essential": true
     },
     {

--- a/agent/functional_tests/tests/generated/simpletests_unix/simpletests_generated_unix_test.go
+++ b/agent/functional_tests/tests/generated/simpletests_unix/simpletests_generated_unix_test.go
@@ -813,7 +813,7 @@ func TestNetworkLink(t *testing.T) {
 
 // TestParallelPull check docker pull in parallel works for docker >= 1.11.1
 func TestParallelPull(t *testing.T) {
-
+	
 	// Test only available on instance with total memory more than 1300 MB
 	RequireMinimumMemory(t, 1300)
 

--- a/scripts/setup-test-registry
+++ b/scripts/setup-test-registry
@@ -74,7 +74,7 @@ else
     PARALLEL_PULL_FTS_HTTPD="httpd@sha256:0d817a924bed1a216f12a0f4947b5f8a2f173bd5a9cebfe1382d024287154c99"
 fi
 
-PARALLEL_PULL_FTS_MONGO="mongo:4.1"
+PARALLEL_PULL_FTS_CRUX="crux:3.0"
 PARALLEL_PULL_FTS_REDIS="redis:5.0"
 PARALLEL_PULL_FTS_REGISTRY=${REGISTRY_IMAGE}
 
@@ -87,7 +87,7 @@ mirror_image ${PARALLEL_PULL_FTS_UBUNTU} "127.0.0.1:51670/ubuntu:parallel-pull-f
 mirror_image ${PARALLEL_PULL_FTS_CONSUL} "127.0.0.1:51670/consul:parallel-pull-fts"
 mirror_image ${PARALLEL_PULL_FTS_DEBIAN} "127.0.0.1:51670/debian:parallel-pull-fts"
 mirror_image ${PARALLEL_PULL_FTS_HTTPD} "127.0.0.1:51670/httpd:parallel-pull-fts"
-mirror_image ${PARALLEL_PULL_FTS_MONGO} "127.0.0.1:51670/mongo:parallel-pull-fts"
+mirror_image ${PARALLEL_PULL_FTS_CRUX} "127.0.0.1:51670/crux:parallel-pull-fts"
 mirror_image ${PARALLEL_PULL_FTS_NGINX} "127.0.0.1:51670/nginx:parallel-pull-fts"
 mirror_image ${PARALLEL_PULL_FTS_REDIS} "127.0.0.1:51670/redis:parallel-pull-fts"
 mirror_local_image ${PARALLEL_PULL_FTS_REGISTRY} "127.0.0.1:51670/registry:parallel-pull-fts"

--- a/scripts/upload-images
+++ b/scripts/upload-images
@@ -59,7 +59,6 @@ PARALLEL_PULL_FTS_NGINX=${NGINX_IMAGE}
 PARALLEL_PULL_FTS_CONSUL="consul:1.3.0"
 PARALLEL_PULL_FTS_DEBIAN="debian:stable"
 PARALLEL_PULL_FTS_HTTPD="httpd:2.4"
-PARALLEL_PULL_FTS_MONGO="mongo:4.1"
 PARALLEL_PULL_FTS_REDIS="redis:5.0"
 
 
@@ -76,7 +75,7 @@ for image in "amazon-ecs-netkitten" "amazon-ecs-volumes-test" "squid" "awscli" "
 done
 
 
-for image in "executionrole" "busybox" "nginx" "python" "ubuntu" "consul" "debian" "httpd" "mongo" "redis" "registry"; do
+for image in "executionrole" "busybox" "nginx" "python" "ubuntu" "consul" "debian" "httpd" "redis" "registry"; do
   # Create the repository if it does not exist
   if ! aws ecr describe-repositories --region ${AWS_DEFAULT_REGION}| grep -q "repositoryName\": \"${NAMESPACE}/${image}" ;
   then
@@ -99,7 +98,6 @@ mirror_image ${PARALLEL_PULL_FTS_UBUNTU} "${PREFIX}/ubuntu:parallel-pull-fts"
 mirror_image ${PARALLEL_PULL_FTS_CONSUL} "${PREFIX}/consul:parallel-pull-fts"
 mirror_image ${PARALLEL_PULL_FTS_DEBIAN} "${PREFIX}/debian:parallel-pull-fts"
 mirror_image ${PARALLEL_PULL_FTS_HTTPD} "${PREFIX}/httpd:parallel-pull-fts"
-mirror_image ${PARALLEL_PULL_FTS_MONGO} "${PREFIX}/mongo:parallel-pull-fts"
 mirror_image ${PARALLEL_PULL_FTS_NGINX} "${PREFIX}/nginx:parallel-pull-fts"
 mirror_image ${PARALLEL_PULL_FTS_REDIS} "${PREFIX}/redis:parallel-pull-fts"
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Mongo images are replaced with redis and crux images. Using Mongo images were leading to unpredictable results in functional and integration tests everytime Mongo images were updated on docker hub.

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
Integ tests are passing for Arm and Linux. 
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
