### PR TITLE
increase windows integration tests timeout

### DIFF
--- a/scripts/run-integ-tests.ps1
+++ b/scripts/run-integ-tests.ps1
@@ -22,7 +22,7 @@ Invoke-Expression "${PSScriptRoot}\..\misc\netkitten\build.ps1"
 $cwd = (pwd).Path
 try {
   cd "${PSScriptRoot}"
-  go test -race -tags integration -timeout=20m -v ../agent/engine ../agent/stats ../agent/app
+  go test -race -tags integration -timeout=25m -v ../agent/engine ../agent/stats ../agent/app
   $testsExitCode = $LastExitCode
 } finally {
   cd "$cwd"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
addressing https://github.com/aws/amazon-ecs-agent/issues/1835 

after increasing test timeout, all tests pass in local.

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
