### PR TITLE
dependencygraph: Enforce shutdown order

### DIFF
--- a/agent/engine/dependencygraph/graph.go
+++ b/agent/engine/dependencygraph/graph.go
@@ -328,9 +328,7 @@ func containerOrderingDependenciesIsResolved(target *apicontainer.Container,
 		// The 'target' container desires to be moved to 'Created' or the 'steady' state.
 		// Allow this only if the known status of the dependency container state is already started
 		// i.e it's state is any of 'Created', 'steady state' or 'Stopped'
-		return dependsOnContainerKnownStatus == apicontainerstatus.ContainerCreated ||
-			dependsOnContainerKnownStatus == apicontainerstatus.ContainerStopped ||
-			dependsOnContainerKnownStatus == dependsOnContainer.GetSteadyStateStatus()
+		return dependsOnContainerKnownStatus >= apicontainerstatus.ContainerCreated
 
 	case runningCondition:
 		if targetDesiredStatus == apicontainerstatus.ContainerCreated {

--- a/agent/functional_tests/testdata/simpletests_unix/link-volume-depencies.json
+++ b/agent/functional_tests/testdata/simpletests_unix/link-volume-depencies.json
@@ -3,7 +3,7 @@
   "Description": "Tests that the dependency graph of task definitions is resolved correctly",
   "TaskDefinition": "network-link-2",
   "Version": ">=1.0.0",
-  "Timeout": "2m",
+  "Timeout": "5m",
   "ExitCodes": {
     "exit": 42
   }

--- a/agent/functional_tests/testdata/simpletests_windows/datavolume-windows.json
+++ b/agent/functional_tests/testdata/simpletests_windows/datavolume-windows.json
@@ -3,7 +3,7 @@
   "Description": "Check that basic data volumes work",
   "TaskDefinition": "datavolume-windows",
   "Version": ">=1.0.0",
-  "Timeout": "2m",
+  "Timeout": "5m",
   "ExitCodes": {
     "exit": 42
   }

--- a/agent/functional_tests/testdata/taskdefinitions/datavolume-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/datavolume-windows/task-definition.json
@@ -34,6 +34,6 @@
       "sourceVolume": "test",
       "containerPath": "C:/data/"
     }],
-    "command": ["data volumes shouldn't need to run"]
+    "command": ["powershell", "-c", "exit"]
   }]
 }

--- a/agent/functional_tests/tests/generated/simpletests_unix/simpletests_generated_unix_test.go
+++ b/agent/functional_tests/tests/generated/simpletests_unix/simpletests_generated_unix_test.go
@@ -735,7 +735,7 @@ func TestLinkVolumeDependencies(t *testing.T) {
 		}
 	}
 
-	timeout, err := time.ParseDuration("2m")
+	timeout, err := time.ParseDuration("5m")
 	if err != nil {
 		t.Fatalf("Could not parse timeout: %#v", err)
 	}

--- a/agent/functional_tests/tests/generated/simpletests_windows/simpletests_generated_windows_test.go
+++ b/agent/functional_tests/tests/generated/simpletests_windows/simpletests_generated_windows_test.go
@@ -63,7 +63,7 @@ func TestDataVolume(t *testing.T) {
 		}
 	}
 
-	timeout, err := time.ParseDuration("2m")
+	timeout, err := time.ParseDuration("5m")
 	if err != nil {
 		t.Fatalf("Could not parse timeout: %#v", err)
 	}


### PR DESCRIPTION
### Summary

Enforce shutdown ordering within a task.

### Implementation details

We now apply shutdown order in any dependency case, including
dependsOn directives, links, or volumes. What this means is that
agent will now make a best effort attempt to shutdown containers
in the inverse order they were created.

For example, a container using a link for communication will wait
until the linked container has terminated before terminating
itself. Likewise, a container named in another container's
dependsOn directive will wait until that dependent container
terminates.

One note about the current implementation is that the dependencies
aren't assumed to be transitive, so if a chain exists such that:

A -> B -> C

Container "C" will shutdown before "B", but it won't check status
against container "A" explicity. If A depends on C, we expect:

A -> B -> C
     A -> C

The lack of transitive dependency logic applies is consistent with
startup order as of this commit.
 
### Testing
Added additional tests to cover the shutdown use cases.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
