### PR TITLE
ENI trunking - Running trunk/branch AWSVPC task 

### DIFF
--- a/agent/acs/handler/payload_handler.go
+++ b/agent/acs/handler/payload_handler.go
@@ -13,9 +13,8 @@
 package handler
 
 import (
-	"fmt"
-
 	"context"
+	"fmt"
 
 	"github.com/aws/amazon-ecs-agent/agent/acs/model/ecsacs"
 	"github.com/aws/amazon-ecs-agent/agent/api"
@@ -220,7 +219,6 @@ func (payloadHandler *payloadRequestHandler) addPayloadTasks(payload *ecsacs.Pay
 				allTasksOK = false
 				continue
 			}
-
 			apiTask.SetTaskENI(eni)
 		}
 		// Add the app mesh information to task struct
@@ -322,12 +320,12 @@ func (payloadHandler *payloadRequestHandler) ackCredentials(messageID *string, c
 // and returns the boolean comparison result
 type skipAddTaskComparatorFunc func(apitaskstatus.TaskStatus) bool
 
-// isTaskStatusStopped returns true if the task status == STOPPTED
+// isTaskStatusStopped returns true if the task status == STOPPED
 func isTaskStatusStopped(status apitaskstatus.TaskStatus) bool {
 	return status == apitaskstatus.TaskStopped
 }
 
-// isTaskStatusNotStopped returns true if the task status != STOPPTED
+// isTaskStatusNotStopped returns true if the task status != STOPPED
 func isTaskStatusNotStopped(status apitaskstatus.TaskStatus) bool {
 	return status != apitaskstatus.TaskStopped
 }

--- a/agent/acs/handler/payload_handler_test.go
+++ b/agent/acs/handler/payload_handler_test.go
@@ -754,7 +754,7 @@ func TestPayloadHandlerAddedENITrunkToTask(t *testing.T) {
 				Arn: aws.String("arn"),
 				ElasticNetworkInterfaces: []*ecsacs.ElasticNetworkInterface{
 					{
-						InterfaceAssociationProtocol: aws.String(eni.BranchENIType),
+						InterfaceAssociationProtocol: aws.String(eni.VLANInterfaceAssociationProtocol),
 						AttachmentArn: aws.String("arn"),
 						Ec2Id:         aws.String("ec2id"),
 						Ipv4Addresses: []*ecsacs.IPv4AddressAssignment{
@@ -785,8 +785,9 @@ func TestPayloadHandlerAddedENITrunkToTask(t *testing.T) {
 
 	taskeni := addedTask.GetTaskENI()
 
-	assert.Equal(t, taskeni.ENIType, eni.BranchENIType)
+	assert.Equal(t, taskeni.InterfaceAssociationProtocol, eni.VLANInterfaceAssociationProtocol)
 	assert.Equal(t, taskeni.InterfaceVlanProperties.TrunkInterfaceMacAddress, "mac")
+	assert.Equal(t, taskeni.InterfaceVlanProperties.VlanID, "12345")
 }
 
 func TestPayloadHandlerAddedECRAuthData(t *testing.T) {

--- a/agent/acs/model/api/api-2.json
+++ b/agent/acs/model/api/api-2.json
@@ -282,9 +282,28 @@
         "useExecutionRole":{"shape":"Boolean"}
       }
     },
+
+    "NetworkInterfaceAssociationProtocol": {
+      "type": "string",
+      "enum": [
+        "default",
+        "vlan"
+      ]
+    },
+
+    "NetworkInterfaceVlanProperties": {
+      "type": "structure",
+      "members": {
+        "vlanId":{"shape":"String"},
+        "trunkInterfaceMacAddress":{"shape":"String"}
+      }
+    },
+
     "ElasticNetworkInterface":{
       "type":"structure",
       "members":{
+        "interfaceAssociationProtocol": {"shape": "NetworkInterfaceAssociationProtocol"},
+        "interfaceVlanProperties": {"shape": "NetworkInterfaceVlanProperties"},
         "macAddress":{"shape":"String"},
         "attachmentArn":{"shape":"String"},
         "ec2Id":{"shape":"String"},

--- a/agent/acs/model/ecsacs/api.go
+++ b/agent/acs/model/ecsacs/api.go
@@ -422,6 +422,10 @@ type ElasticNetworkInterface struct {
 
 	Ec2Id *string `locationName:"ec2Id" type:"string"`
 
+	InterfaceAssociationProtocol *string `locationName:"interfaceAssociationProtocol" type:"string" enum:"NetworkInterfaceAssociationProtocol"`
+
+	InterfaceVlanProperties *NetworkInterfaceVlanProperties `locationName:"interfaceVlanProperties" type:"structure"`
+
 	Ipv4Addresses []*IPv4AddressAssignment `locationName:"ipv4Addresses" type:"list"`
 
 	Ipv6Addresses []*IPv6AddressAssignment `locationName:"ipv6Addresses" type:"list"`
@@ -758,6 +762,24 @@ func (s NackRequest) String() string {
 
 // GoString returns the string representation
 func (s NackRequest) GoString() string {
+	return s.String()
+}
+
+type NetworkInterfaceVlanProperties struct {
+	_ struct{} `type:"structure"`
+
+	TrunkInterfaceMacAddress *string `locationName:"trunkInterfaceMacAddress" type:"string"`
+
+	VlanId *string `locationName:"vlanId" type:"string"`
+}
+
+// String returns the string representation
+func (s NetworkInterfaceVlanProperties) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s NetworkInterfaceVlanProperties) GoString() string {
 	return s.String()
 }
 

--- a/agent/api/eni/eni.go
+++ b/agent/api/eni/eni.go
@@ -200,9 +200,11 @@ func ValidateTaskENI(acsenis []*ecsacs.ElasticNetworkInterface) error {
 	if len(acsenis) != 1 {
 		return errors.Errorf("eni message validation: more than one ENIs in the message(%d)", len(acsenis))
 	} else if len(acsenis[0].Ipv4Addresses) != 1 {
-		return errors.Errorf("eni message validation: more than one ipv4 addresses in the message(%d)", len(acsenis[0].Ipv4Addresses))
+		return errors.Errorf("eni message validation: more than one ipv4 addresses in the message(%d)",
+			len(acsenis[0].Ipv4Addresses))
 	} else if len(acsenis[0].Ipv6Addresses) > 1 {
-		return errors.Errorf("eni message validation: more than one ipv6 addresses in the message(%d)", len(acsenis[0].Ipv6Addresses))
+		return errors.Errorf("eni message validation: more than one ipv6 addresses in the message(%d)",
+			len(acsenis[0].Ipv6Addresses))
 	}
 
 	if acsenis[0].MacAddress == nil {
@@ -214,14 +216,18 @@ func ValidateTaskENI(acsenis []*ecsacs.ElasticNetworkInterface) error {
 	}
 
 	if (acsenis[0].InterfaceAssociationProtocol != nil) && (aws.StringValue(acsenis[0].InterfaceAssociationProtocol) !=
-		VLANInterfaceAssociationProtocol) && (aws.StringValue(acsenis[0].InterfaceAssociationProtocol) != DefaultInterfaceAssociationProtocol) {
-		return errors.Errorf("Invalid ENI interface type: %s", aws.StringValue(acsenis[0].InterfaceAssociationProtocol))
+		VLANInterfaceAssociationProtocol) && (aws.StringValue(acsenis[0].InterfaceAssociationProtocol) !=
+		DefaultInterfaceAssociationProtocol) {
+		return errors.Errorf("invalid ENI interface type: %s",
+			aws.StringValue(acsenis[0].InterfaceAssociationProtocol))
 	}
 
 	// If ENI type is vlan, InterfaceVlanProperties must be not nil.
 	if aws.StringValue(acsenis[0].InterfaceAssociationProtocol) == VLANInterfaceAssociationProtocol {
-		if acsenis[0].InterfaceVlanProperties == nil || len(aws.StringValue(acsenis[0].InterfaceVlanProperties.VlanId)) == 0 || len(aws.StringValue(acsenis[0].InterfaceVlanProperties.TrunkInterfaceMacAddress)) == 0 {
-			return errors.Errorf("vlan interface properties missing.")
+		if acsenis[0].InterfaceVlanProperties == nil ||
+			len(aws.StringValue(acsenis[0].InterfaceVlanProperties.VlanId)) == 0 ||
+			len(aws.StringValue(acsenis[0].InterfaceVlanProperties.TrunkInterfaceMacAddress)) == 0 {
+			return errors.New("vlan interface properties missing.")
 		}
 	}
 

--- a/agent/api/eni/eni.go
+++ b/agent/api/eni/eni.go
@@ -26,6 +26,8 @@ import (
 type ENI struct {
 	// ID is the id of eni
 	ID string `json:"ec2Id"`
+	// ENIType is the type of ENI, valid value: "default", "vlan"
+	ENIType string `json:",omitempty"`
 	// IPV4Addresses is the ipv4 address associated with the eni
 	IPV4Addresses []*ENIIPV4Address
 	// IPV6Addresses is the ipv6 address associated with the eni
@@ -38,13 +40,30 @@ type ENI struct {
 	// DomainNameSearchList specifies the search list for the domain
 	// name lookup, for the eni
 	DomainNameSearchList []string `json:",omitempty"`
-
+	// InterfaceVlanProperties contains information for an interface
+	// that is supposed to be used as a VLAN device
+	InterfaceVlanProperties *InterfaceVlanProperties `json:",omitempty"`
 	// PrivateDNSName is the dns name assigned by the vpc to this eni
 	PrivateDNSName string `json:",omitempty"`
 	// SubnetGatewayIPV4Address is the address to the subnet gateway for
 	// the eni
 	SubnetGatewayIPV4Address string `json:",omitempty"`
 }
+
+// InterfaceVlanProperties contains information for an interface that
+// is supposed to be used as a VLAN device
+type InterfaceVlanProperties struct {
+	VlanID                   string
+	TrunkInterfaceMacAddress string
+}
+
+const (
+	// RegularENIType represents the standard ENI type.
+	RegularENIType = "default"
+
+	// BranchENIType represents the ENI with trunking enabled.
+	BranchENIType = "vlan"
+)
 
 // GetIPV4Addresses returns a list of ipv4 addresses allocated to the ENI
 func (eni *ENI) GetIPV4Addresses() []string {
@@ -87,10 +106,23 @@ func (eni *ENI) String() string {
 	for _, addr := range eni.IPV6Addresses {
 		ipv6Addresses = append(ipv6Addresses, addr.Address)
 	}
+
+	eniString := ""
+
+	if len(eni.ENIType) == 0 {
+		eniString += fmt.Sprintf(" ,ENI type: [%s]", eni.ENIType)
+	}
+
+	if eni.InterfaceVlanProperties != nil {
+		eniString += fmt.Sprintf(" ,VLan ID: [%s], TrunkInterfaceMacAddress: [%s]",
+			eni.InterfaceVlanProperties.VlanID, eni.InterfaceVlanProperties.TrunkInterfaceMacAddress)
+	}
+
 	return fmt.Sprintf(
-		"eni id:%s, mac: %s, hostname: %s, ipv4addresses: [%s], ipv6addresses: [%s], dns: [%s], dns search: [%s], gateway ipv4: [%s]",
-		eni.ID, eni.MacAddress, eni.GetHostname(), strings.Join(ipv4Addresses, ","), strings.Join(ipv6Addresses, ","),
-		strings.Join(eni.DomainNameServers, ","), strings.Join(eni.DomainNameSearchList, ","), eni.SubnetGatewayIPV4Address)
+		"eni id:%s, mac: %s, hostname: %s, ipv4addresses: [%s], ipv6addresses: [%s], dns: [%s], dns search: [%s],"+
+			" gateway ipv4: [%s][%s]", eni.ID, eni.MacAddress, eni.GetHostname(), strings.Join(ipv4Addresses, ","),
+		strings.Join(ipv6Addresses, ","), strings.Join(eni.DomainNameServers, ","),
+		strings.Join(eni.DomainNameSearchList, ","), eni.SubnetGatewayIPV4Address, eniString)
 }
 
 // ENIIPV4Address is the ipv4 information of the eni
@@ -132,6 +164,13 @@ func ENIFromACS(acsenis []*ecsacs.ElasticNetworkInterface) (*ENI, error) {
 		})
 	}
 
+	var interfaceVlanProperties InterfaceVlanProperties
+
+	if aws.StringValue(acsenis[0].InterfaceAssociationProtocol) == BranchENIType {
+		interfaceVlanProperties.TrunkInterfaceMacAddress = aws.StringValue(acsenis[0].InterfaceVlanProperties.TrunkInterfaceMacAddress)
+		interfaceVlanProperties.VlanID = aws.StringValue(acsenis[0].InterfaceVlanProperties.VlanId)
+	}
+
 	eni := &ENI{
 		ID:                       aws.StringValue(acsenis[0].Ec2Id),
 		IPV4Addresses:            ipv4,
@@ -139,7 +178,10 @@ func ENIFromACS(acsenis []*ecsacs.ElasticNetworkInterface) (*ENI, error) {
 		MacAddress:               aws.StringValue(acsenis[0].MacAddress),
 		PrivateDNSName:           aws.StringValue(acsenis[0].PrivateDnsName),
 		SubnetGatewayIPV4Address: aws.StringValue(acsenis[0].SubnetGatewayIpv4Address),
+		ENIType:                  aws.StringValue(acsenis[0].InterfaceAssociationProtocol),
+		InterfaceVlanProperties:  &interfaceVlanProperties,
 	}
+
 	for _, nameserverIP := range acsenis[0].DomainNameServers {
 		eni.DomainNameServers = append(eni.DomainNameServers, aws.StringValue(nameserverIP))
 	}
@@ -169,6 +211,18 @@ func ValidateTaskENI(acsenis []*ecsacs.ElasticNetworkInterface) error {
 
 	if acsenis[0].Ec2Id == nil {
 		return errors.Errorf("eni message validation: empty eni id in the message")
+	}
+
+	if (acsenis[0].InterfaceAssociationProtocol != nil) && (aws.StringValue(acsenis[0].InterfaceAssociationProtocol) !=
+		BranchENIType) && (aws.StringValue(acsenis[0].InterfaceAssociationProtocol) != RegularENIType) {
+		return errors.Errorf("Invalid ENI interface type: %s", aws.StringValue(acsenis[0].InterfaceAssociationProtocol))
+	}
+
+	// If ENI type is vlan, InterfaceVlanProperties must be not nil.
+	if aws.StringValue(acsenis[0].InterfaceAssociationProtocol) == BranchENIType {
+		if acsenis[0].InterfaceVlanProperties == nil || len(aws.StringValue(acsenis[0].InterfaceVlanProperties.VlanId)) == 0 || len(aws.StringValue(acsenis[0].InterfaceVlanProperties.TrunkInterfaceMacAddress)) == 0 {
+			return errors.Errorf("vlan interface properties missing.")
+		}
 	}
 
 	return nil

--- a/agent/api/eni/eni_test.go
+++ b/agent/api/eni/eni_test.go
@@ -108,11 +108,11 @@ func TestValidateENIFromACS(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestInvalidENItrunkingInterfaceMissing(t *testing.T) {
+func TestInvalidENIInterfaceVlanPropertyMissing(t *testing.T) {
 
 	acseni := []*ecsacs.ElasticNetworkInterface{
 		{
-			InterfaceAssociationProtocol: aws.String(BranchENIType),
+			InterfaceAssociationProtocol: aws.String(VLANInterfaceAssociationProtocol),
 			AttachmentArn: aws.String("arn"),
 			Ec2Id:         aws.String("ec2id"),
 			Ipv4Addresses: []*ecsacs.IPv4AddressAssignment{
@@ -135,7 +135,7 @@ func TestInvalidENItrunkingInterfaceMissing(t *testing.T) {
 
 }
 
-func TestInvalidENItrunkingRandomTrunkTask(t *testing.T) {
+func TestInvalidENIInvalidInterfaceAssociationProtocol(t *testing.T) {
 
 	acseni := []*ecsacs.ElasticNetworkInterface{
 		{

--- a/agent/api/eni/eni_test.go
+++ b/agent/api/eni/eni_test.go
@@ -107,3 +107,56 @@ func TestValidateENIFromACS(t *testing.T) {
 	err = ValidateTaskENI(acsenis)
 	assert.Error(t, err)
 }
+
+func TestInvalidENItrunkingInterfaceMissing(t *testing.T) {
+
+	acseni := []*ecsacs.ElasticNetworkInterface{
+		{
+			InterfaceAssociationProtocol: aws.String(BranchENIType),
+			AttachmentArn: aws.String("arn"),
+			Ec2Id:         aws.String("ec2id"),
+			Ipv4Addresses: []*ecsacs.IPv4AddressAssignment{
+				{
+					Primary:        aws.Bool(true),
+					PrivateAddress: aws.String("ipv4"),
+				},
+			},
+			Ipv6Addresses: []*ecsacs.IPv6AddressAssignment{
+				{
+					Address: aws.String("ipv6"),
+				},
+			},
+			MacAddress: aws.String("mac"),
+		},
+	}
+
+	err := ValidateTaskENI(acseni)
+	assert.Error(t, err)
+
+}
+
+func TestInvalidENItrunkingRandomTrunkTask(t *testing.T) {
+
+	acseni := []*ecsacs.ElasticNetworkInterface{
+		{
+			InterfaceAssociationProtocol: aws.String("no-eni"),
+			AttachmentArn: aws.String("arn"),
+			Ec2Id:         aws.String("ec2id"),
+			Ipv4Addresses: []*ecsacs.IPv4AddressAssignment{
+				{
+					Primary:        aws.Bool(true),
+					PrivateAddress: aws.String("ipv4"),
+				},
+			},
+			Ipv6Addresses: []*ecsacs.IPv6AddressAssignment{
+				{
+					Address: aws.String("ipv6"),
+				},
+			},
+			MacAddress: aws.String("mac"),
+		},
+	}
+
+	err := ValidateTaskENI(acseni)
+	assert.Error(t, err)
+}

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -235,7 +235,8 @@ func TaskFromACS(acsTask *ecsacs.Task, envelope *ecsacs.PayloadMessage) (*Task, 
 		}
 		container.TransitionDependenciesMap = make(map[apicontainerstatus.ContainerStatus]apicontainer.TransitionDependencySet)
 	}
-	// initialize resources map for task
+
+	//initialize resources map for task
 	task.ResourcesMapUnsafe = make(map[string][]taskresource.TaskResource)
 	return task, nil
 }

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -737,6 +737,12 @@ func convertENIToCNIConfig(eni *apieni.ENI, cfg *ecscni.Config) {
 	if len(eni.IPV6Addresses) > 0 {
 		cfg.ENIIPV6Address = eni.IPV6Addresses[0].Address
 	}
+
+	// Populate Trunk ENI fields
+	if eni.InterfaceAssociationProtocol == apieni.VLANInterfaceAssociationProtocol {
+		cfg.TrunkMACAddress = eni.InterfaceVlanProperties.TrunkInterfaceMacAddress
+		cfg.BranchVlanID = eni.InterfaceVlanProperties.VlanID
+	}
 }
 
 // convertAppMeshToCNIConfig converts input app mesh config into cni config

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -740,6 +740,7 @@ func convertENIToCNIConfig(eni *apieni.ENI, cfg *ecscni.Config) {
 
 	// Populate Trunk ENI fields
 	if eni.InterfaceAssociationProtocol == apieni.VLANInterfaceAssociationProtocol {
+		cfg.InterfaceAssociationProtocol = eni.InterfaceAssociationProtocol
 		cfg.TrunkMACAddress = eni.InterfaceVlanProperties.TrunkInterfaceMacAddress
 		cfg.BranchVlanID = eni.InterfaceVlanProperties.VlanID
 	}

--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -114,7 +114,6 @@ func (agent *ecsAgent) capabilities() ([]*ecs.Attribute, error) {
 	}
 
 	capabilities = agent.appendTaskENICapabilities(capabilities)
-	capabilities = agent.appendENITrunkingCapabilities(capabilities)
 
 	capabilities = agent.appendDockerDependentCapabilities(capabilities, supportedVersions)
 

--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -114,6 +114,7 @@ func (agent *ecsAgent) capabilities() ([]*ecs.Attribute, error) {
 	}
 
 	capabilities = agent.appendTaskENICapabilities(capabilities)
+	capabilities = agent.appendENITrunkingCapabilities(capabilities)
 
 	capabilities = agent.appendDockerDependentCapabilities(capabilities, supportedVersions)
 

--- a/agent/app/agent_unix.go
+++ b/agent/app/agent_unix.go
@@ -66,7 +66,7 @@ func (agent *ecsAgent) initializeTaskENIDependencies(state dockerstate.TaskEngin
 	// Check if the Agent process's pid  == 1, which means it's running without an init system
 	if agent.os.Getpid() == initPID {
 		// This is a terminal error. Bad things happen with invoking the
-		// the ENI plugin when there's no init process in the pid namesapce.
+		// the ENI plugin when there's no init process in the pid namespace.
 		// Specifically, the DHClient processes that are started as children
 		// of the Agent will not be reaped leading to the ENI device
 		// disappearing until the Agent is killed.

--- a/agent/ecs_client/model/ecs/api.go
+++ b/agent/ecs_client/model/ecs/api.go
@@ -3183,13 +3183,13 @@ func (c *ECS) SubmitAttachmentStateChangesRequest(input *SubmitAttachmentStateCh
 	return
 }
 
-// SubmitAttachmentStateChanges API operation for Amazon EC2 Container Service.
+// SubmitAttachmentStateChanges API operation for Amazon Elastic Container Service.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
 // the error.
 //
-// See the AWS API reference guide for Amazon EC2 Container Service's
+// See the AWS API reference guide for Amazon Elastic Container Service's
 // API operation SubmitAttachmentStateChanges for usage and error information.
 //
 // Returned Error Codes:

--- a/agent/ecscni/plugin.go
+++ b/agent/ecscni/plugin.go
@@ -36,10 +36,11 @@ import (
 const (
 	currentCNISpec = "0.3.1"
 	// ECSCNIVersion, ECSCNIGitHash, VPCCNIGitHash needs to be updated every time CNI plugin is updated
-	currentECSCNIVersion = "2018.10.0"
-	currentECSCNIGitHash = "93f4377604504bff92e7555da73b0cba732a4fbb"
-	currentVPCCNIGitHash = "76973f587f9dfb0b40092a78fb5623c9547bc647"
-	vpcCNIPluginPath     = "/log/vpc-branch-eni.log"
+	currentECSCNIVersion      = "2018.10.0"
+	currentECSCNIGitHash      = "93f4377604504bff92e7555da73b0cba732a4fbb"
+	currentVPCCNIGitHash      = "8b5e552209b0009aecf3c60568b5a5041c6342c0"
+	vpcCNIPluginPath          = "/log/vpc-branch-eni.log"
+	vpcCNIPluginInterfaceType = "vlan"
 )
 
 // CNIClient defines the method of setting/cleaning up container namespace
@@ -405,6 +406,7 @@ func (client *cniClient) createBranchENINetworkConfig(cfg *Config) (string, *lib
 		BranchMACAddress:       cfg.ENIMACAddress,
 		BlockInstanceMetdata:   cfg.BlockInstanceMetdata,
 		BranchGatewayIPAddress: BranchGatewayIPAddress,
+		InterfaceType:          vpcCNIPluginInterfaceType,
 	}
 	networkConfig, err := client.constructNetworkConfig(eniConf, ECSBranchENIPluginName)
 	if err != nil {

--- a/agent/ecscni/types.go
+++ b/agent/ecscni/types.go
@@ -188,12 +188,12 @@ type Config struct {
 	MinSupportedCNIVersion string
 	//  ENIID is the id of ec2 eni
 	ENIID string
-	// ENIType is the type of eni, can be "standard" or "vlan-tagged"
-	ENIType string
-	// BranchVlanID is the VLAN ID to be used by a "vlan-tagged" ENI
+	// InterfaceAssociationProtocol is the type of eni, can be "default" or "vlan"
+	InterfaceAssociationProtocol string
+	// BranchVlanID is the VLAN ID to be used by a "vlan" ENI
 	BranchVlanID string `json:"branchVlandID,omitempty"`
 	// TrunkMACAddress is the MAC address of the associated Trunk ENI
-	// for an ENI of type "vlan-tagged"
+	// for an ENI of type "vlan"
 	TrunkMACAddress string `json:"trunkMACAddress,omitempty"`
 	// ContainerID is the id of container of which to set up the network namespace
 	ContainerID string

--- a/agent/ecscni/types.go
+++ b/agent/ecscni/types.go
@@ -153,6 +153,32 @@ type AppMeshConfig struct {
 	EgressIgnoredIPs []string `json:"egressIgnoredIPs,omitempty"`
 }
 
+// BranchENIConfig contains all the information needed to invoke the vpc-branch-eni plugin
+type BranchENIConfig struct {
+	// CNIVersion is the CNI spec version to use
+	CNIVersion string `json:"cniVersion,omitempty"`
+	// Name is the CNI network name
+	Name string `json:"name,omitempty"`
+	// Type is the CNI plugin name
+	Type string `json:"type,omitempty"`
+
+	// TrunkMACAddress is the MAC address of the trunk ENI
+	TrunkMACAddress string `json:"trunkMACAddress,omitempty"`
+	// BranchVlanID is the VLAN ID of the branch ENI
+	BranchVlanID string `json:"branchVlanID,omitempty"`
+	// BranchMacAddress is the MAC address of the branch ENI
+	BranchMACAddress string `json:"branchMACAddress"`
+	// BranchIPAddress is the IP address of the branch ENI
+	BranchIPAddress string `json:"branchIPAddress"`
+	// BranchGatewayIPAddress is the IP address of the branch ENI's default gateway.
+	BranchGatewayIPAddress string `json:"branchGatewayIPAddress"`
+	// InterfaceType is the type of the interface to connect the branch ENI to
+	InterfaceType string `json:"interfaceType,omitempty"`
+	// BlockInstanceMetdata specifies if InstanceMetadata endpoint should be
+	// blocked
+	BlockInstanceMetdata bool `json:"blockInstanceMetadata"`
+}
+
 // Config contains all the information to set up the container namespace using
 // the plugins
 type Config struct {
@@ -162,6 +188,13 @@ type Config struct {
 	MinSupportedCNIVersion string
 	//  ENIID is the id of ec2 eni
 	ENIID string
+	// ENIType is the type of eni, can be "standard" or "vlan-tagged"
+	ENIType string
+	// BranchVlanID is the VLAN ID to be used by a "vlan-tagged" ENI
+	BranchVlanID string `json:"branchVlandID,omitempty"`
+	// TrunkMACAddress is the MAC address of the associated Trunk ENI
+	// for an ENI of type "vlan-tagged"
+	TrunkMACAddress string `json:"trunkMACAddress,omitempty"`
 	// ContainerID is the id of container of which to set up the network namespace
 	ContainerID string
 	// ContainerPID is the pid of the container

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -498,12 +498,12 @@ func (engine *DockerTaskEngine) deleteTask(task *apitask.Task) {
 	} else {
 		// A Trunk/Branch awsvpc task doesn't have an ENI attachment corresponds to the task's ENI,
 		// so such deletion should be skipped
-		if eniTask.ENIType != eni.BranchENIType {
+		if eniTask.InterfaceAssociationProtocol != eni.VLANInterfaceAssociationProtocol {
 			seelog.Debugf("Task engine [%s]: removing the eni from agent state", task.Arn)
 			engine.state.RemoveENIAttachment(eniTask.MacAddress)
 		} else {
 			seelog.Debugf("Task engine [%s]: Not removing the eni from agent state as it is a "+
-				"trunk ENI", task.Arn)
+				"branch ENI", task.Arn)
 		}
 	}
 	seelog.Debugf("Task engine [%s]: finished removing task data, removing task from managed tasks", task.Arn)
@@ -1072,13 +1072,6 @@ func (engine *DockerTaskEngine) buildCNIConfigFromTaskContainer(task *apitask.Ta
 	cfg.ContainerPID = strconv.Itoa(containerInspectOutput.State.Pid)
 	cfg.ContainerID = containerInspectOutput.ID
 	cfg.BlockInstanceMetdata = engine.cfg.AWSVPCBlockInstanceMetdata
-
-	// Populate Trunk ENI fields
-	if task.ENI.ENIType == eni.BranchENIType {
-		cfg.ENIType = eni.BranchENIType
-		cfg.TrunkMACAddress = task.ENI.InterfaceVlanProperties.TrunkInterfaceMacAddress
-		cfg.BranchVlanID = task.ENI.InterfaceVlanProperties.VlanID
-	}
 
 	return cfg, nil
 }

--- a/agent/engine/docker_task_engine_linux_test.go
+++ b/agent/engine/docker_task_engine_linux_test.go
@@ -1,4 +1,4 @@
-// +build unit
+// +build linux,unit
 
 // Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //

--- a/agent/engine/docker_task_engine_linux_test.go
+++ b/agent/engine/docker_task_engine_linux_test.go
@@ -1,4 +1,4 @@
-// +build linux,unit
+// +build unit
 
 // Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
@@ -193,7 +193,6 @@ func TestDeleteTaskBranchENIEnabled(t *testing.T) {
 	gomock.InOrder(
 		mockControl.EXPECT().Remove("cgroupRoot").Return(nil),
 		mockState.EXPECT().RemoveTask(task),
-		mockState.EXPECT().RemoveENIAttachment(mac),
 		mockSaver.EXPECT().Save(),
 	)
 

--- a/agent/engine/docker_task_engine_linux_test.go
+++ b/agent/engine/docker_task_engine_linux_test.go
@@ -165,6 +165,41 @@ func TestDeleteTask(t *testing.T) {
 	taskEngine.deleteTask(task)
 }
 
+func TestDeleteTaskBranchENIEnabled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockControl := mock_control.NewMockControl(ctrl)
+	cgroupResource := cgroup.NewCgroupResource("", mockControl, nil, "cgroupRoot", "", specs.LinuxResources{})
+	task := &apitask.Task{
+		ENI: &apieni.ENI{
+			MacAddress: mac,
+			InterfaceAssociationProtocol: apieni.VLANInterfaceAssociationProtocol,
+		},
+	}
+	task.ResourcesMapUnsafe = make(map[string][]taskresource.TaskResource)
+	task.AddResource("cgroup", cgroupResource)
+	cfg := defaultConfig
+	cfg.TaskCPUMemLimit = config.ExplicitlyEnabled
+	mockState := mock_dockerstate.NewMockTaskEngineState(ctrl)
+	mockSaver := mock_statemanager.NewMockStateManager(ctrl)
+
+	taskEngine := &DockerTaskEngine{
+		state: mockState,
+		saver: mockSaver,
+		cfg:   &cfg,
+	}
+
+	gomock.InOrder(
+		mockControl.EXPECT().Remove("cgroupRoot").Return(nil),
+		mockState.EXPECT().RemoveTask(task),
+		mockState.EXPECT().RemoveENIAttachment(mac),
+		mockSaver.EXPECT().Save(),
+	)
+
+	taskEngine.deleteTask(task)
+}
+
 // TestResourceContainerProgressionFailure ensures that task moves to STOPPED when
 // resource creation fails
 func TestResourceContainerProgressionFailure(t *testing.T) {

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -1258,9 +1258,9 @@ func TestBuildTrunkCNIConfigFromTaskContainer(t *testing.T) {
 
 			testTask := testdata.LoadTask("sleep5")
 			testTask.SetTaskENI(&apieni.ENI{
-				ID: "TestBuildCNIConfigFromTaskContainer",
-				MacAddress: mac,
-				ENIType: apieni.BranchENIType,
+				ID:                           "TestBuildCNIConfigFromTaskContainer",
+				MacAddress:                   mac,
+				InterfaceAssociationProtocol: apieni.VLANInterfaceAssociationProtocol,
 				InterfaceVlanProperties: &apieni.InterfaceVlanProperties{
 					VlanID:                   "1234",
 					TrunkInterfaceMacAddress: "macTrunk",
@@ -1285,7 +1285,7 @@ func TestBuildTrunkCNIConfigFromTaskContainer(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, "macTrunk", cniConfig.TrunkMACAddress)
 			assert.Equal(t, "1234", cniConfig.BranchVlanID)
-			assert.Equal(t, apieni.BranchENIType, cniConfig.ENIType)
+			assert.Equal(t, apieni.VLANInterfaceAssociationProtocol, cniConfig.InterfaceAssociationProtocol)
 		})
 	}
 }

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -1246,6 +1246,50 @@ func TestBuildCNIConfigFromTaskContainer(t *testing.T) {
 	}
 }
 
+func TestBuildTrunkCNIConfigFromTaskContainer(t *testing.T) {
+	for _, blockIMDS := range []bool{true, false} {
+		t.Run(fmt.Sprintf("When BlockInstanceMetadata is %t", blockIMDS), func(t *testing.T) {
+			config := defaultConfig
+			config.AWSVPCBlockInstanceMetdata = blockIMDS
+			ctx, cancel := context.WithCancel(context.TODO())
+			defer cancel()
+			ctrl, dockerClient, _, taskEngine, _, _, _ := mocks(t, ctx, &config)
+			defer ctrl.Finish()
+
+			testTask := testdata.LoadTask("sleep5")
+			testTask.SetTaskENI(&apieni.ENI{
+				ID: "TestBuildCNIConfigFromTaskContainer",
+				MacAddress: mac,
+				ENIType: apieni.BranchENIType,
+				InterfaceVlanProperties: &apieni.InterfaceVlanProperties{
+					VlanID:                   "1234",
+					TrunkInterfaceMacAddress: "macTrunk",
+				},
+			})
+			container := &apicontainer.Container{
+				Name: "container",
+			}
+			taskEngine.(*DockerTaskEngine).state.AddContainer(&apicontainer.DockerContainer{
+				Container:  container,
+				DockerName: dockerContainerName,
+			}, testTask)
+
+			dockerClient.EXPECT().InspectContainer(gomock.Any(), dockerContainerName, gomock.Any()).Return(&types.ContainerJSON{
+				ContainerJSONBase: &types.ContainerJSONBase{
+					ID:    containerID,
+					State: &types.ContainerState{Pid: containerPid},
+				},
+			}, nil)
+
+			cniConfig, err := taskEngine.(*DockerTaskEngine).buildCNIConfigFromTaskContainer(testTask, container)
+			assert.NoError(t, err)
+			assert.Equal(t, "macTrunk", cniConfig.TrunkMACAddress)
+			assert.Equal(t, "1234", cniConfig.BranchVlanID)
+			assert.Equal(t, apieni.BranchENIType, cniConfig.ENIType)
+		})
+	}
+}
+
 func TestBuildCNIConfigFromTaskContainerInspectError(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()

--- a/agent/engine/dockerstate/docker_task_engine_state.go
+++ b/agent/engine/dockerstate/docker_task_engine_state.go
@@ -222,7 +222,6 @@ func (state *DockerTaskEngineState) RemoveENIAttachment(mac string) {
 	}
 	state.lock.Lock()
 	defer state.lock.Unlock()
-
 	if _, ok := state.eniAttachments[mac]; ok {
 		delete(state.eniAttachments, mac)
 	} else {

--- a/agent/functional_tests/tests/generated/simpletests_unix/simpletests_generated_unix_test.go
+++ b/agent/functional_tests/tests/generated/simpletests_unix/simpletests_generated_unix_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"testing"
 	"time"
+
 	. "github.com/aws/amazon-ecs-agent/agent/functional_tests/util"
 )
 
@@ -916,7 +917,7 @@ func TestNetworkLink(t *testing.T) {
 
 // TestParallelPull check docker pull in parallel works for docker >= 1.11.1
 func TestParallelPull(t *testing.T) {
-	
+
 	// Test only available on instance with total memory more than 1300 MB
 	RequireMinimumMemory(t, 1300)
 

--- a/agent/functional_tests/tests/generated/simpletests_windows/simpletests_generated_windows_test.go
+++ b/agent/functional_tests/tests/generated/simpletests_windows/simpletests_generated_windows_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"testing"
 	"time"
+
 	. "github.com/aws/amazon-ecs-agent/agent/functional_tests/util"
 )
 
@@ -43,16 +44,13 @@ func TestContainerOrderingTimedout(t *testing.T) {
 	agent.RequireVersion(">=1.25.0")
 
 	td, err := GetTaskDefinition("container-ordering-timedout-windows")
-
 	if err != nil {
 		t.Fatalf("Could not register task definition: %v", err)
 	}
 	var testTasks []*TestTask
 	if "" == "true" {
 		for i := 0; i < 1; i++ {
-
 			tmpTask, err := agent.StartAWSVPCTask("container-ordering-timedout-windows", nil)
-
 			if err != nil {
 				t.Fatalf("Could not start task in awsvpc mode: %v", err)
 			}
@@ -98,7 +96,6 @@ func TestContainerOrdering(t *testing.T) {
 	agent.RequireVersion(">=1.25.0")
 
 	td, err := GetTaskDefinition("container-ordering-windows")
-
 	if err != nil {
 		t.Fatalf("Could not register task definition: %v", err)
 	}
@@ -106,7 +103,6 @@ func TestContainerOrdering(t *testing.T) {
 	if "" == "true" {
 		for i := 0; i < 1; i++ {
 			tmpTask, err := agent.StartAWSVPCTask("container-ordering-windows", nil)
-
 			if err != nil {
 				t.Fatalf("Could not start task in awsvpc mode: %v", err)
 			}

--- a/agent/statemanager/state_manager.go
+++ b/agent/statemanager/state_manager.go
@@ -87,8 +87,6 @@ const (
 	// 	 a) Add 'attachmentType' field to 'api.ENIAttachment'
 	//	 b) Add 'InterfaceAssociationProtocol' field to 'api.ENI'
 	//	 c) Add 'InterfaceVlanProperties' field to 'api.ENI'
-	//	 d) Add 'NetworkInterfaceVlanProperties' struct
-	//	 e) Add 'NetworkInterfaceAssociationProtocol' struct
 
 	ECSDataVersion = 22
 

--- a/agent/statemanager/state_manager.go
+++ b/agent/statemanager/state_manager.go
@@ -83,7 +83,13 @@ const (
 	//   b) Add 'StartTime' field to 'api.container.Container'
 	//   c) Add 'StopTime' field to 'api.container.Container'
 	// 21) Add 'target' field to the Secret struct
-	// 22) Add 'attachmentType' field to 'api.ENIAttachment'
+	// 22)
+	// 	 a) Add 'attachmentType' field to 'api.ENIAttachment'
+	//	 b) Add 'InterfaceAssociationProtocol' field to 'api.ENI'
+	//	 c) Add 'InterfaceVlanProperties' field to 'api.ENI'
+	//	 d) Add 'NetworkInterfaceVlanProperties' struct
+	//	 e) Add 'NetworkInterfaceAssociationProtocol' struct
+
 	ECSDataVersion = 22
 
 	// ecsDataFile specifies the filename in the ECS_DATADIR

--- a/agent/tcs/handler/handler.go
+++ b/agent/tcs/handler/handler.go
@@ -59,6 +59,7 @@ func StartMetricsSession(params *TelemetrySessionParams) {
 
 	err = params.StatsEngine.MustInit(params.Ctx, params.TaskEngine, params.Cfg.Cluster,
 		params.ContainerInstanceArn)
+
 	if err != nil {
 		seelog.Warnf("Error initializing metrics engine: %v", err)
 		return

--- a/agent/tcs/handler/handler.go
+++ b/agent/tcs/handler/handler.go
@@ -59,7 +59,6 @@ func StartMetricsSession(params *TelemetrySessionParams) {
 
 	err = params.StatsEngine.MustInit(params.Ctx, params.TaskEngine, params.Cfg.Cluster,
 		params.ContainerInstanceArn)
-
 	if err != nil {
 		seelog.Warnf("Error initializing metrics engine: %v", err)
 		return


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR is WIP for ENI trunking:
- Model changes for ACS and CNI plugin.
- Invoke the correct CNI plugin based on ENI received.

### Implementation details
#### High level workflow

For an AWSVPC task using trunk ENI "vpc-branch-eni" CNI plugin will be used(for ADD and DEL) instead of "ecs-cni" plugin when setting up pause container namespace.
 
#### Model changes
- "InterfaceVlanProperties" struct added. It will contain mac address and ID of the trunk ENI.
- "ENI" struct extended to add "InterfaceAssociationProtocol" field and "InterfaceVlanProperties" field. InterfaceAssociationProtocol type indicates the type of ENI. It could be either "default" or "vlan". "InterfaceVlanProperties" field points to  InterfaceVlanProperties struct which will contain trunk ENI information. 
- "BranchENIConfig" struct added. This will be used to invoke the "vpc-branch-eni" plugin in the similar fashion as "ENIConfig" is used for invoking "ecs-cni" plugin. 
- A "Config" object contains all the information required for invoking the CNI plugin which sets up the pause container's network namespace. The config object is extended to include trunk ENI information which will be needed to construct "BranchENIConfig" object.
 
### Testing
<!-- How was this tested? -->
- Unit tests added.
- Manual testing by building a modified version on agent on an instance and running a task.
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes:yes
### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
