### PR TITLE
Reformatting travis config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,17 @@
 language: go
+go_import_path: github.com/aws/amazon-ecs-agent
 sudo: false
 go:
-  - 1.9
-os:
-  - windows
-  - linux
-go_import_path: github.com/aws/amazon-ecs-agent
-script:
-  - |
-    (
-      if [ "$TRAVIS_OS_NAME" = 'windows' ]; then
-        go test -race -tags unit -timeout 40s ./agent/...
-      else
-        make get-deps
-        make test
-        make static-check
-        make xplatform-build
-      fi
-    )
+  - 1.11
+
+matrix:
+  include:
+    - os: linux
+      script:
+        - make get-deps
+        - make test
+        - make static-check
+        - make xplatform-build
+    - os: windows
+      script:
+        - go test -v -race -tags unit -timeout 40s ./agent/...

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -905,12 +905,12 @@ func (task *Task) dockerConfig(container *apicontainer.Container, apiVersion doc
 	if container.DockerConfig.Config != nil {
 		err := json.Unmarshal([]byte(aws.StringValue(container.DockerConfig.Config)), &containerConfig)
 		if err != nil {
-			return nil, &apierrors.DockerClientConfigError{"Unable decode given docker config: " + err.Error()}
+			return nil, &apierrors.DockerClientConfigError{Msg: "Unable decode given docker config: " + err.Error()}
 		}
 	}
 	if container.HealthCheckType == apicontainer.DockerHealthCheckType && containerConfig.Healthcheck == nil {
 		return nil, &apierrors.DockerClientConfigError{
-			"docker health check is nil while container health check type is DOCKER"}
+			Msg: "docker health check is nil while container health check type is DOCKER"}
 	}
 
 	if containerConfig.Labels == nil {
@@ -946,7 +946,7 @@ func (task *Task) ApplyExecutionRoleLogsAuth(hostConfig *dockercontainer.HostCon
 	id := task.GetExecutionCredentialsID()
 	if id == "" {
 		// No execution credentials set for the task. Do not inject the endpoint environment variable.
-		return &apierrors.HostConfigError{"No execution credentials set for the task"}
+		return &apierrors.HostConfigError{Msg: "No execution credentials set for the task"}
 	}
 
 	executionRoleCredentials, ok := credentialsManager.GetTaskCredentials(id)
@@ -955,7 +955,7 @@ func (task *Task) ApplyExecutionRoleLogsAuth(hostConfig *dockercontainer.HostCon
 		// the id. This should never happen as the payload handler sets
 		// credentialsId for the task after adding credentials to the
 		// credentials manager
-		return &apierrors.HostConfigError{"Unable to get execution role credentials for task"}
+		return &apierrors.HostConfigError{Msg: "Unable to get execution role credentials for task"}
 	}
 	credentialsEndpointRelativeURI := executionRoleCredentials.IAMRoleCredentials.GenerateCredentialsEndpointRelativeURI()
 	hostConfig.LogConfig.Config[awslogsCredsEndpointOpt] = credentialsEndpointRelativeURI
@@ -965,19 +965,19 @@ func (task *Task) ApplyExecutionRoleLogsAuth(hostConfig *dockercontainer.HostCon
 func (task *Task) dockerHostConfig(container *apicontainer.Container, dockerContainerMap map[string]*apicontainer.DockerContainer, apiVersion dockerclient.DockerVersion) (*dockercontainer.HostConfig, *apierrors.HostConfigError) {
 	dockerLinkArr, err := task.dockerLinks(container, dockerContainerMap)
 	if err != nil {
-		return nil, &apierrors.HostConfigError{err.Error()}
+		return nil, &apierrors.HostConfigError{Msg: err.Error()}
 	}
 
 	dockerPortMap := task.dockerPortMap(container)
 
 	volumesFrom, err := task.dockerVolumesFrom(container, dockerContainerMap)
 	if err != nil {
-		return nil, &apierrors.HostConfigError{err.Error()}
+		return nil, &apierrors.HostConfigError{Msg: err.Error()}
 	}
 
 	binds, err := task.dockerHostBinds(container)
 	if err != nil {
-		return nil, &apierrors.HostConfigError{err.Error()}
+		return nil, &apierrors.HostConfigError{Msg: err.Error()}
 	}
 
 	resources := task.getDockerResources(container)
@@ -993,7 +993,7 @@ func (task *Task) dockerHostConfig(container *apicontainer.Container, dockerCont
 
 	if task.isGPUEnabled() && task.shouldRequireNvidiaRuntime(container) {
 		if task.NvidiaRuntime == "" {
-			return nil, &apierrors.HostConfigError{"Runtime is not set for GPU containers"}
+			return nil, &apierrors.HostConfigError{Msg: "Runtime is not set for GPU containers"}
 		}
 		seelog.Debugf("Setting runtime as %s for container %s", task.NvidiaRuntime, container.Name)
 		hostConfig.Runtime = task.NvidiaRuntime
@@ -1002,13 +1002,13 @@ func (task *Task) dockerHostConfig(container *apicontainer.Container, dockerCont
 	if container.DockerConfig.HostConfig != nil {
 		err := json.Unmarshal([]byte(*container.DockerConfig.HostConfig), hostConfig)
 		if err != nil {
-			return nil, &apierrors.HostConfigError{"Unable to decode given host config: " + err.Error()}
+			return nil, &apierrors.HostConfigError{Msg: "Unable to decode given host config: " + err.Error()}
 		}
 	}
 
 	err = task.platformHostConfigOverride(hostConfig)
 	if err != nil {
-		return nil, &apierrors.HostConfigError{err.Error()}
+		return nil, &apierrors.HostConfigError{Msg: err.Error()}
 	}
 
 	// Determine if network mode should be overridden and override it if needed
@@ -1754,7 +1754,7 @@ func (task *Task) PopulateSecrets(hostConfig *dockercontainer.HostConfig, contai
 	if container.ShouldCreateWithSSMSecret() {
 		resource, ok := task.getSSMSecretsResource()
 		if !ok {
-			return &apierrors.DockerClientConfigError{"task secret data: unable to fetch SSM Secrets resource"}
+			return &apierrors.DockerClientConfigError{Msg: "task secret data: unable to fetch SSM Secrets resource"}
 		}
 		ssmRes = resource[0].(*ssmsecret.SSMSecretResource)
 	}
@@ -1762,7 +1762,7 @@ func (task *Task) PopulateSecrets(hostConfig *dockercontainer.HostConfig, contai
 	if container.ShouldCreateWithASMSecret() {
 		resource, ok := task.getASMSecretsResource()
 		if !ok {
-			return &apierrors.DockerClientConfigError{"task secret data: unable to fetch ASM Secrets resource"}
+			return &apierrors.DockerClientConfigError{Msg: "task secret data: unable to fetch ASM Secrets resource"}
 		}
 		asmRes = resource[0].(*asmsecret.ASMSecretResource)
 	}

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -1081,7 +1081,7 @@ func (engine *DockerTaskEngine) stopContainer(task *apitask.Task, container *api
 	dockerContainer, ok := containerMap[container.Name]
 	if !ok {
 		return dockerapi.DockerContainerMetadata{
-			Error: dockerapi.CannotStopContainerError{errors.Errorf("Container not recorded as created")},
+			Error: dockerapi.CannotStopContainerError{FromError: errors.Errorf("Container not recorded as created")},
 		}
 	}
 

--- a/agent/handlers/v1/credentials_handler.go
+++ b/agent/handlers/v1/credentials_handler.go
@@ -103,7 +103,7 @@ func processCredentialsRequest(credentialsManager credentials.Manager, r *http.R
 		return nil, "", "", msg, errors.New(errText)
 	}
 
-	if utils.ZeroOrNil(credentials) {
+	if utils.ZeroOrNil(credentials.ARN) && utils.ZeroOrNil(credentials.IAMRoleCredentials) {
 		// This can happen when the agent is restarted and is reconciling its state.
 		errText := errPrefix + "Credentials uninitialized for ID"
 		seelog.Infof("%s. Request IP Address: %s", errText, r.RemoteAddr)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
cleaned up travis.yml file to look nicer

### Implementation details
Reformatted to use matrix construct.
Updated go version from 1.9 to 1.11, and fixed new go vet failures from it:
- composite literals using unkeyed field
- copying lock value 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: N/A no agent code change made

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
