### PR TITLE
engine: adding poll function during progressTask

### DIFF
--- a/agent/engine/docker_image_manager_test.go
+++ b/agent/engine/docker_image_manager_test.go
@@ -145,8 +145,8 @@ func TestRecordContainerReferenceInspectError(t *testing.T) {
 	client := mock_dockerapi.NewMockDockerClient(ctrl)
 
 	imageManager := &dockerImageManager{
-		client: client,
-		state:  dockerstate.NewTaskEngineState(),
+		client:                   client,
+		state:                    dockerstate.NewTaskEngineState(),
 		minimumAgeBeforeDeletion: config.DefaultImageDeletionAge,
 		numImagesToDelete:        config.DefaultNumImagesToDeletePerCycle,
 		imageCleanupTimeInterval: config.DefaultImageCleanupTimeInterval,
@@ -179,8 +179,8 @@ func TestRecordContainerReferenceWithNoImageName(t *testing.T) {
 	client := mock_dockerapi.NewMockDockerClient(ctrl)
 
 	imageManager := &dockerImageManager{
-		client: client,
-		state:  dockerstate.NewTaskEngineState(),
+		client:                   client,
+		state:                    dockerstate.NewTaskEngineState(),
 		minimumAgeBeforeDeletion: config.DefaultImageDeletionAge,
 		numImagesToDelete:        config.DefaultNumImagesToDeletePerCycle,
 		imageCleanupTimeInterval: config.DefaultImageCleanupTimeInterval,
@@ -406,8 +406,8 @@ func TestRemoveContainerReferenceFromImageStateWithNoReference(t *testing.T) {
 	client := mock_dockerapi.NewMockDockerClient(ctrl)
 
 	imageManager := &dockerImageManager{
-		client: client,
-		state:  dockerstate.NewTaskEngineState(),
+		client:                   client,
+		state:                    dockerstate.NewTaskEngineState(),
 		minimumAgeBeforeDeletion: config.DefaultImageDeletionAge,
 		numImagesToDelete:        config.DefaultNumImagesToDeletePerCycle,
 		imageCleanupTimeInterval: config.DefaultImageCleanupTimeInterval,
@@ -442,8 +442,8 @@ func TestGetCandidateImagesForDeletionImageNoImageState(t *testing.T) {
 	client := mock_dockerapi.NewMockDockerClient(ctrl)
 
 	imageManager := &dockerImageManager{
-		client: client,
-		state:  dockerstate.NewTaskEngineState(),
+		client:                   client,
+		state:                    dockerstate.NewTaskEngineState(),
 		minimumAgeBeforeDeletion: config.DefaultImageDeletionAge,
 		numImagesToDelete:        config.DefaultNumImagesToDeletePerCycle,
 		imageCleanupTimeInterval: config.DefaultImageCleanupTimeInterval,
@@ -462,8 +462,8 @@ func TestGetCandidateImagesForDeletionImageJustPulled(t *testing.T) {
 	client := mock_dockerapi.NewMockDockerClient(ctrl)
 
 	imageManager := &dockerImageManager{
-		client: client,
-		state:  dockerstate.NewTaskEngineState(),
+		client:                   client,
+		state:                    dockerstate.NewTaskEngineState(),
 		minimumAgeBeforeDeletion: config.DefaultImageDeletionAge,
 		numImagesToDelete:        config.DefaultNumImagesToDeletePerCycle,
 		imageCleanupTimeInterval: config.DefaultImageCleanupTimeInterval,
@@ -487,8 +487,8 @@ func TestGetCandidateImagesForDeletionImageHasContainerReference(t *testing.T) {
 	client := mock_dockerapi.NewMockDockerClient(ctrl)
 
 	imageManager := &dockerImageManager{
-		client: client,
-		state:  dockerstate.NewTaskEngineState(),
+		client:                   client,
+		state:                    dockerstate.NewTaskEngineState(),
 		minimumAgeBeforeDeletion: config.DefaultImageDeletionAge,
 		numImagesToDelete:        config.DefaultNumImagesToDeletePerCycle,
 		imageCleanupTimeInterval: config.DefaultImageCleanupTimeInterval,
@@ -528,8 +528,8 @@ func TestGetCandidateImagesForDeletionImageHasMoreContainerReferences(t *testing
 	client := mock_dockerapi.NewMockDockerClient(ctrl)
 
 	imageManager := &dockerImageManager{
-		client: client,
-		state:  dockerstate.NewTaskEngineState(),
+		client:                   client,
+		state:                    dockerstate.NewTaskEngineState(),
 		minimumAgeBeforeDeletion: config.DefaultImageDeletionAge,
 		numImagesToDelete:        config.DefaultNumImagesToDeletePerCycle,
 		imageCleanupTimeInterval: config.DefaultImageCleanupTimeInterval,
@@ -606,8 +606,8 @@ func TestImageCleanupExclusionListWithSingleName(t *testing.T) {
 		PulledAt: time.Now().AddDate(0, -2, 0),
 	}
 	imageManager := &dockerImageManager{
-		client: client,
-		state:  dockerstate.NewTaskEngineState(),
+		client:                    client,
+		state:                     dockerstate.NewTaskEngineState(),
 		minimumAgeBeforeDeletion:  config.DefaultImageDeletionAge,
 		numImagesToDelete:         config.DefaultNumImagesToDeletePerCycle,
 		imageCleanupTimeInterval:  config.DefaultImageCleanupTimeInterval,
@@ -665,8 +665,8 @@ func TestImageCleanupExclusionListWithMultipleNames(t *testing.T) {
 		PulledAt: time.Now().AddDate(0, -2, 0),
 	}
 	imageManager := &dockerImageManager{
-		client: client,
-		state:  dockerstate.NewTaskEngineState(),
+		client:                    client,
+		state:                     dockerstate.NewTaskEngineState(),
 		minimumAgeBeforeDeletion:  config.DefaultImageDeletionAge,
 		numImagesToDelete:         config.DefaultNumImagesToDeletePerCycle,
 		imageCleanupTimeInterval:  config.DefaultImageCleanupTimeInterval,
@@ -731,8 +731,8 @@ func TestGetLeastRecentlyUsedImagesLessThanFive(t *testing.T) {
 	client := mock_dockerapi.NewMockDockerClient(ctrl)
 
 	imageManager := &dockerImageManager{
-		client: client,
-		state:  dockerstate.NewTaskEngineState(),
+		client:                   client,
+		state:                    dockerstate.NewTaskEngineState(),
 		minimumAgeBeforeDeletion: config.DefaultImageDeletionAge,
 		numImagesToDelete:        config.DefaultNumImagesToDeletePerCycle,
 		imageCleanupTimeInterval: config.DefaultImageCleanupTimeInterval,
@@ -765,8 +765,8 @@ func TestRemoveAlreadyExistingImageNameWithDifferentID(t *testing.T) {
 	client := mock_dockerapi.NewMockDockerClient(ctrl)
 
 	imageManager := &dockerImageManager{
-		client: client,
-		state:  dockerstate.NewTaskEngineState(),
+		client:                   client,
+		state:                    dockerstate.NewTaskEngineState(),
 		minimumAgeBeforeDeletion: config.DefaultImageDeletionAge,
 		numImagesToDelete:        config.DefaultNumImagesToDeletePerCycle,
 		imageCleanupTimeInterval: config.DefaultImageCleanupTimeInterval,
@@ -816,8 +816,8 @@ func TestImageCleanupHappyPath(t *testing.T) {
 	client := mock_dockerapi.NewMockDockerClient(ctrl)
 
 	imageManager := &dockerImageManager{
-		client: client,
-		state:  dockerstate.NewTaskEngineState(),
+		client:                   client,
+		state:                    dockerstate.NewTaskEngineState(),
 		minimumAgeBeforeDeletion: 1 * time.Millisecond,
 		numImagesToDelete:        config.DefaultNumImagesToDeletePerCycle,
 		imageCleanupTimeInterval: config.DefaultImageCleanupTimeInterval,
@@ -873,8 +873,8 @@ func TestImageCleanupCannotRemoveImage(t *testing.T) {
 	client := mock_dockerapi.NewMockDockerClient(ctrl)
 
 	imageManager := &dockerImageManager{
-		client: client,
-		state:  dockerstate.NewTaskEngineState(),
+		client:                   client,
+		state:                    dockerstate.NewTaskEngineState(),
 		minimumAgeBeforeDeletion: config.DefaultImageDeletionAge,
 		numImagesToDelete:        config.DefaultNumImagesToDeletePerCycle,
 		imageCleanupTimeInterval: config.DefaultImageCleanupTimeInterval,
@@ -931,8 +931,8 @@ func TestImageCleanupRemoveImageById(t *testing.T) {
 	client := mock_dockerapi.NewMockDockerClient(ctrl)
 
 	imageManager := &dockerImageManager{
-		client: client,
-		state:  dockerstate.NewTaskEngineState(),
+		client:                   client,
+		state:                    dockerstate.NewTaskEngineState(),
 		minimumAgeBeforeDeletion: config.DefaultImageDeletionAge,
 		numImagesToDelete:        config.DefaultNumImagesToDeletePerCycle,
 		imageCleanupTimeInterval: config.DefaultImageCleanupTimeInterval,
@@ -984,8 +984,8 @@ func TestNonECSImageAndContainersCleanupRemoveImage(t *testing.T) {
 	defer ctrl.Finish()
 	client := mock_dockerapi.NewMockDockerClient(ctrl)
 	imageManager := &dockerImageManager{
-		client: client,
-		state:  dockerstate.NewTaskEngineState(),
+		client:                    client,
+		state:                     dockerstate.NewTaskEngineState(),
 		minimumAgeBeforeDeletion:  config.DefaultImageDeletionAge,
 		numImagesToDelete:         config.DefaultNumImagesToDeletePerCycle,
 		imageCleanupTimeInterval:  config.DefaultImageCleanupTimeInterval,
@@ -1220,8 +1220,8 @@ func TestConcurrentRemoveUnusedImages(t *testing.T) {
 	client := mock_dockerapi.NewMockDockerClient(ctrl)
 
 	imageManager := &dockerImageManager{
-		client: client,
-		state:  dockerstate.NewTaskEngineState(),
+		client:                   client,
+		state:                    dockerstate.NewTaskEngineState(),
 		minimumAgeBeforeDeletion: config.DefaultImageDeletionAge,
 		numImagesToDelete:        config.DefaultNumImagesToDeletePerCycle,
 		imageCleanupTimeInterval: config.DefaultImageCleanupTimeInterval,

--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -47,6 +47,7 @@ const (
 	// and start processing the task or start another round of waiting
 	waitForPullCredentialsTimeout         = 1 * time.Minute
 	defaultTaskSteadyStatePollInterval    = 5 * time.Minute
+	transitionPollTime                    = 5 * time.Second
 	stoppedSentWaitInterval               = 30 * time.Second
 	maxStoppedWaitTimes                   = 72 * time.Hour / stoppedSentWaitInterval
 	taskUnableToTransitionToStoppedReason = "TaskStateError: Agent could not progress task's state to stopped"
@@ -83,6 +84,7 @@ type acsTransition struct {
 type containerTransition struct {
 	nextState      apicontainerstatus.ContainerStatus
 	actionRequired bool
+	blockedOn      *apicontainer.DependsOn
 	reason         error
 }
 
@@ -163,21 +165,21 @@ type managedTask struct {
 func (engine *DockerTaskEngine) newManagedTask(task *apitask.Task) *managedTask {
 	ctx, cancel := context.WithCancel(engine.ctx)
 	t := &managedTask{
-		ctx:                      ctx,
-		cancel:                   cancel,
-		Task:                     task,
-		acsMessages:              make(chan acsTransition),
-		dockerMessages:           make(chan dockerContainerChange),
-		resourceStateChangeEvent: make(chan resourceStateChange),
+		ctx:                        ctx,
+		cancel:                     cancel,
+		Task:                       task,
+		acsMessages:                make(chan acsTransition),
+		dockerMessages:             make(chan dockerContainerChange),
+		resourceStateChangeEvent:   make(chan resourceStateChange),
 		engine:                     engine,
 		cfg:                        engine.cfg,
 		stateChangeEvents:          engine.stateChangeEvents,
 		containerChangeEventStream: engine.containerChangeEventStream,
-		saver:                   engine.saver,
-		credentialsManager:      engine.credentialsManager,
-		cniClient:               engine.cniClient,
-		taskStopWG:              engine.taskStopGroup,
-		steadyStatePollInterval: engine.taskSteadyStatePollInterval,
+		saver:                      engine.saver,
+		credentialsManager:         engine.credentialsManager,
+		cniClient:                  engine.cniClient,
+		taskStopWG:                 engine.taskStopGroup,
+		steadyStatePollInterval:    engine.taskSteadyStatePollInterval,
 	}
 	engine.managedTasks[task.Arn] = t
 	return t
@@ -740,16 +742,36 @@ func (mtask *managedTask) progressTask() {
 			transitionChangeEntity <- resource.GetName()
 		})
 
-	anyContainerTransition, contTransitions, reasons := mtask.startContainerTransitions(
+	anyContainerTransition, blockedDependencies, contTransitions, reasons := mtask.startContainerTransitions(
 		func(container *apicontainer.Container, nextStatus apicontainerstatus.ContainerStatus) {
 			mtask.engine.transitionContainer(mtask.Task, container, nextStatus)
 			transitionChange <- struct{}{}
 			transitionChangeEntity <- container.Name
 		})
 
-	if !anyContainerTransition && !anyResourceTransition {
-		if !mtask.waitForExecutionCredentialsFromACS(reasons) {
-			mtask.onContainersUnableToTransitionState()
+	atLeastOneTransitionStarted := anyResourceTransition || anyContainerTransition
+
+	blockedByOrderingDependencies := len(blockedDependencies) > 0
+
+	// If no transitions happened and we aren't blocked by ordering dependencies, then we are possibly in a state where
+	// its impossible for containers to move forward. We will do an additional check to see if we are waiting for ACS
+	// execution credentials. If not, then we will abort the task progression.
+	if !atLeastOneTransitionStarted && !blockedByOrderingDependencies {
+		if !mtask.isWaitingForACSExecutionCredentials(reasons) {
+			mtask.handleContainersUnableToTransitionState()
+		}
+		return
+	}
+
+	// If no containers are starting and we are blocked on ordering dependencies, we should watch for the task to change
+	// over time. This will update the containers if they become healthy or stop, which makes it possible for the
+	// conditions "HEALTHY" and "SUCCESS" to succeed.
+	if !atLeastOneTransitionStarted && blockedByOrderingDependencies {
+		go mtask.engine.checkTaskState(mtask.Task)
+		ctx, cancel := context.WithTimeout(context.Background(), transitionPollTime)
+		defer cancel()
+		for timeout := mtask.waitEvent(ctx.Done()); !timeout; {
+			timeout = mtask.waitEvent(ctx.Done())
 		}
 		return
 	}
@@ -781,9 +803,9 @@ func (mtask *managedTask) progressTask() {
 	}
 }
 
-// waitForExecutionCredentialsFromACS checks if the container that can't be transitioned
+// isWaitingForACSExecutionCredentials checks if the container that can't be transitioned
 // was caused by waiting for credentials and start waiting
-func (mtask *managedTask) waitForExecutionCredentialsFromACS(reasons []error) bool {
+func (mtask *managedTask) isWaitingForACSExecutionCredentials(reasons []error) bool {
 	for _, reason := range reasons {
 		if reason == dependencygraph.CredentialsNotResolvedErr {
 			seelog.Debugf("Managed task [%s]: waiting for credentials to pull from ECR", mtask.Arn)
@@ -803,15 +825,19 @@ func (mtask *managedTask) waitForExecutionCredentialsFromACS(reasons []error) bo
 
 // startContainerTransitions steps through each container in the task and calls
 // the passed transition function when a transition should occur.
-func (mtask *managedTask) startContainerTransitions(transitionFunc containerTransitionFunc) (bool, map[string]apicontainerstatus.ContainerStatus, []error) {
+func (mtask *managedTask) startContainerTransitions(transitionFunc containerTransitionFunc) (bool, map[string]apicontainer.DependsOn, map[string]apicontainerstatus.ContainerStatus, []error) {
 	anyCanTransition := false
 	var reasons []error
+	blocked := make(map[string]apicontainer.DependsOn)
 	transitions := make(map[string]apicontainerstatus.ContainerStatus)
 	for _, cont := range mtask.Containers {
 		transition := mtask.containerNextState(cont)
 		if transition.reason != nil {
 			// container can't be transitioned
 			reasons = append(reasons, transition.reason)
+			if transition.blockedOn != nil {
+				blocked[cont.Name] = *transition.blockedOn
+			}
 			continue
 		}
 
@@ -844,7 +870,7 @@ func (mtask *managedTask) startContainerTransitions(transitionFunc containerTran
 		go transitionFunc(cont, transition.nextState)
 	}
 
-	return anyCanTransition, transitions, reasons
+	return anyCanTransition, blocked, transitions, reasons
 }
 
 // startResourceTransitions steps through each resource in the task and calls
@@ -956,7 +982,7 @@ func (mtask *managedTask) containerNextState(container *apicontainer.Container) 
 			reason:         dependencygraph.ContainerPastDesiredStatusErr,
 		}
 	}
-	if err := dependencygraph.DependenciesAreResolved(container, mtask.Containers,
+	if blocked, err := dependencygraph.DependenciesAreResolved(container, mtask.Containers,
 		mtask.Task.GetExecutionCredentialsID(), mtask.credentialsManager, mtask.GetResources()); err != nil {
 		seelog.Debugf("Managed task [%s]: can't apply state to container [%s] yet due to unresolved dependencies: %v",
 			mtask.Arn, container.Name, err)
@@ -964,6 +990,7 @@ func (mtask *managedTask) containerNextState(container *apicontainer.Container) 
 			nextState:      apicontainerstatus.ContainerStatusNone,
 			actionRequired: false,
 			reason:         err,
+			blockedOn:      blocked,
 		}
 	}
 
@@ -1018,7 +1045,7 @@ func (mtask *managedTask) resourceNextState(resource taskresource.TaskResource) 
 	}
 }
 
-func (mtask *managedTask) onContainersUnableToTransitionState() {
+func (mtask *managedTask) handleContainersUnableToTransitionState() {
 	seelog.Criticalf("Managed task [%s]: task in a bad state; it's not steadystate but no containers want to transition",
 		mtask.Arn)
 	if mtask.GetDesiredStatus().Terminal() {

--- a/agent/engine/task_manager_test.go
+++ b/agent/engine/task_manager_test.go
@@ -635,7 +635,7 @@ func TestStartContainerTransitionsWhenForwardTransitionPossible(t *testing.T) {
 			}
 
 			waitForAssertions.Add(2)
-			canTransition, transitions, _ := task.startContainerTransitions(
+			canTransition, _, transitions, _ := task.startContainerTransitions(
 				func(cont *apicontainer.Container, nextStatus apicontainerstatus.ContainerStatus) {
 					if cont.Name == firstContainerName {
 						assert.Equal(t, nextStatus, apicontainerstatus.ContainerRunning, "Mismatch for first container next status")
@@ -697,7 +697,7 @@ func TestStartContainerTransitionsWhenForwardTransitionIsNotPossible(t *testing.
 		engine: &DockerTaskEngine{},
 	}
 
-	canTransition, transitions, _ := task.startContainerTransitions(
+	canTransition, _, transitions, _ := task.startContainerTransitions(
 		func(cont *apicontainer.Container, nextStatus apicontainerstatus.ContainerStatus) {
 			t.Error("Transition function should not be called when no transitions are possible")
 		})
@@ -765,7 +765,7 @@ func TestStartContainerTransitionsInvokesHandleContainerChange(t *testing.T) {
 	}()
 
 	go task.waitEvent(nil)
-	canTransition, transitions, _ := task.startContainerTransitions(
+	canTransition, _, transitions, _ := task.startContainerTransitions(
 		func(cont *apicontainer.Container, nextStatus apicontainerstatus.ContainerStatus) {
 			t.Error("Invalid code path. The transition function should not be invoked when transitioning container from CREATED -> STOPPED")
 		})
@@ -875,7 +875,7 @@ func TestOnContainersUnableToTransitionStateForDesiredStoppedTask(t *testing.T) 
 		eventsGenerated.Done()
 	}()
 
-	task.onContainersUnableToTransitionState()
+	task.handleContainersUnableToTransitionState()
 	eventsGenerated.Wait()
 
 	assert.Equal(t, task.GetDesiredStatus(), apitaskstatus.TaskStopped)
@@ -897,7 +897,7 @@ func TestOnContainersUnableToTransitionStateForDesiredRunningTask(t *testing.T) 
 		},
 	}
 
-	task.onContainersUnableToTransitionState()
+	task.handleContainersUnableToTransitionState()
 	assert.Equal(t, task.GetDesiredStatus(), apitaskstatus.TaskStopped)
 	assert.Equal(t, task.Containers[0].GetDesiredStatus(), apicontainerstatus.ContainerStopped)
 }
@@ -1314,7 +1314,7 @@ func TestTaskWaitForExecutionCredentials(t *testing.T) {
 				go func() { task.acsMessages <- acsTransition{desiredStatus: apitaskstatus.TaskRunning} }()
 			}
 
-			assert.Equal(t, tc.result, task.waitForExecutionCredentialsFromACS(tc.errs), tc.msg)
+			assert.Equal(t, tc.result, task.isWaitingForACSExecutionCredentials(tc.errs), tc.msg)
 		})
 	}
 }

--- a/agent/engine/task_manager_unix_test.go
+++ b/agent/engine/task_manager_unix_test.go
@@ -263,7 +263,7 @@ func TestStartResourceTransitionsEmpty(t *testing.T) {
 					ResourcesMapUnsafe:  make(map[string][]taskresource.TaskResource),
 					DesiredStatusUnsafe: apitaskstatus.TaskRunning,
 				},
-				ctx: ctx,
+				ctx:                      ctx,
 				resourceStateChangeEvent: make(chan resourceStateChange),
 			}
 			mtask.Task.AddResource("cgroup", res)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This ensures that SUCCESS and HEALTHY conditions are reachable
when progressTask sees no activity.


### Implementation details
<!-- How are the changes implemented? -->
Prior to this commit, we only tracked state we explicitly tried to
change when the task was starting. We did not respond to the event
stream or any other source of information from Docker. This means
that when we are waiting for certain dependency conditions
("SUCCESS", "COMPLETE", or "HEALTHY") the task progression logic
does not update the agent-internal model of container state.

Since we rely on that state for determining when conditions are
met, tasks would get stuck in infinite startup loops. This change
adds a call to engine.checkTaskState(), which explicity updates
any changed container state. We only call this function if we know
that we are waiting on the aforementioned subset of dependency
conditions.


### Testing
We manually tested use cases involving "success" and "healthy".

Integ tests are on the way.

New tests cover the changes: **WIP**, will be added to this PR or another one depending on how lengthly they get.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
