### PR TITLE
Validating that the dependency container has not timed out

### DIFF
--- a/agent/engine/dependencygraph/graph_test.go
+++ b/agent/engine/dependencygraph/graph_test.go
@@ -18,6 +18,7 @@ package dependencygraph
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
@@ -881,5 +882,52 @@ func assertContainerOrderingHealthyConditionResolved(f func(target *apicontainer
 		}
 		resolved := f(target, dep, depCond)
 		assert.Equal(t, expectedResolved, resolved)
+	}
+}
+
+func TestStartTimeoutForContainerOrdering(t *testing.T) {
+	testcases := []struct {
+		DependencyStartedAt    time.Time
+		DependencyStartTimeout uint
+		DependencyCondition    string
+		ExpectedTimedOut       bool
+	}{
+		{
+			DependencyStartedAt:    time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC),
+			DependencyStartTimeout: 10,
+			DependencyCondition:    healthyCondition,
+			ExpectedTimedOut:       true,
+		},
+		{
+			DependencyStartedAt:    time.Date(4000, 1, 1, 0, 0, 0, 0, time.UTC),
+			DependencyStartTimeout: 10,
+			DependencyCondition:    successCondition,
+			ExpectedTimedOut:       false,
+		},
+		{
+			DependencyStartedAt:    time.Time{},
+			DependencyStartTimeout: 10,
+			DependencyCondition:    successCondition,
+			ExpectedTimedOut:       false,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(fmt.Sprintf("T:dependency time out: %v", tc.ExpectedTimedOut),
+			assertContainerOrderingNotTimedOut(hasDependencyTimedOut, tc.DependencyStartedAt, tc.DependencyStartTimeout, tc.DependencyCondition, tc.ExpectedTimedOut))
+	}
+}
+
+func assertContainerOrderingNotTimedOut(f func(dep *apicontainer.Container, depCond string) bool, startedAt time.Time, timeout uint, depCond string, expectedTimedOut bool) func(t *testing.T) {
+	return func(t *testing.T) {
+		dep := &apicontainer.Container{
+			Name:         "dep",
+			StartTimeout: timeout,
+		}
+
+		dep.SetStartedAt(startedAt)
+
+		timedOut := f(dep, depCond)
+		assert.Equal(t, expectedTimedOut, timedOut)
 	}
 }


### PR DESCRIPTION
Here, the time duration(StartTimeout) mentioned by the user for a container is expired or not is checked before resolving the dependency for target container.

For example,
* if a target container 'A' has dependency on container 'B' and the dependency condiiton is 'SUCCESS', then the dependency will not be resolved if B times out before exitting successfully with exit code 0.
* if a target container 'A' has dependency on container 'B' and the dependency condiiton is 'COMPLETE', then the dependency will not be resolved if B times out before exitting.
* if a target container 'A' has dependency on container 'B' and the dependency condiiton is 'HEALTHY', then the dependency will not be resolved if B times out before emtting 'Healthy' status.

The advantage of this is that the user will get to know that something is wrong with the task if the task is stuck in pending.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
