### PR TITLE
Checking dependency resolution after timeout and successful exit check

### DIFF
--- a/agent/engine/dependencygraph/graph.go
+++ b/agent/engine/dependencygraph/graph.go
@@ -223,10 +223,6 @@ func verifyContainerOrderingStatusResolvable(target *apicontainer.Container, exi
 			return nil, fmt.Errorf("dependency graph: container ordering dependency [%v] for target [%v] does not exist.", dependencyContainer, target)
 		}
 
-		if !resolves(target, dependencyContainer, dependency.Condition) {
-			return &dependency, fmt.Errorf("dependency graph: failed to resolve the container ordering dependency [%v] for target [%v]", dependencyContainer, target)
-		}
-
 		// We want to check whether the dependency container has timed out only if target has not been created yet.
 		// If the target is already created, then everything is normal and dependency can be and is resolved.
 		// However, if dependency container has already stopped, then it cannot time out.
@@ -242,6 +238,10 @@ func verifyContainerOrderingStatusResolvable(target *apicontainer.Container, exi
 			if !hasDependencyStoppedSuccessfully(dependencyContainer, dependency.Condition) {
 				return nil, fmt.Errorf("dependency graph: failed to resolve container ordering dependency [%v] for target [%v] as dependency did not exit successfully.", dependencyContainer, target)
 			}
+		}
+
+		if !resolves(target, dependencyContainer, dependency.Condition) {
+			return &dependency, fmt.Errorf("dependency graph: failed to resolve the container ordering dependency [%v] for target [%v]", dependencyContainer, target)
 		}
 	}
 	return nil, nil

--- a/agent/engine/ordering_integ_test.go
+++ b/agent/engine/ordering_integ_test.go
@@ -184,7 +184,6 @@ func TestDependencySuccess(t *testing.T) {
 // TestDependencySuccess validates that the SUCCESS dependency condition will fail when the child exits 1. This is a
 // contrast to how COMPLETE behaves. Instead of starting the parent, the task should simply exit.
 func TestDependencySuccessErrored(t *testing.T) {
-	t.Skip("TODO: this test exposes a bug. Fix the bug and then remove this skip.")
 	taskEngine, done, _ := setupWithDefaultConfig(t)
 	defer done()
 
@@ -226,7 +225,6 @@ func TestDependencySuccessErrored(t *testing.T) {
 
 // TestDependencySuccessTimeout
 func TestDependencySuccessTimeout(t *testing.T) {
-	t.Skip("TODO: this test exposes a bug. Fix the bug and then remove this skip.")
 	taskEngine, done, _ := setupWithDefaultConfig(t)
 	defer done()
 
@@ -271,7 +269,6 @@ func TestDependencySuccessTimeout(t *testing.T) {
 
 // TestDependencyHealthyTimeout
 func TestDependencyHealthyTimeout(t *testing.T) {
-	t.Skip("TODO: this test exposes a bug. Fix the bug and then remove this skip.")
 	taskEngine, done, _ := setupWithDefaultConfig(t)
 	defer done()
 


### PR DESCRIPTION
Initially, we were first checking if the dependency is resolved. If resolved, then we checked if the dependency timed out or exitted unsuccessfully. But later we realized that, in doing so we are not checking the timeout and succssfully exitted or not if dependency not resolved. That is why, moved the timeout check and successfully completed check before checking whether the dependency has resolved or not.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
