### PR TITLE
Adding Integ Tests for Granular Stop Timeout

### DIFF
--- a/agent/engine/common_integ_test.go
+++ b/agent/engine/common_integ_test.go
@@ -108,8 +108,8 @@ func createTestContainerWithImageAndName(image string, name string) *apicontaine
 		Command:             []string{},
 		Essential:           true,
 		DesiredStatusUnsafe: apicontainerstatus.ContainerRunning,
-		CPU:                 100,
-		Memory:              80,
+		CPU:                 1024,
+		Memory:              128,
 	}
 }
 

--- a/agent/engine/ordering_integ_test.go
+++ b/agent/engine/ordering_integ_test.go
@@ -78,7 +78,6 @@ func TestDependencyHealthCheck(t *testing.T) {
 	}()
 
 	waitFinished(t, finished, orderingTimeout)
-
 }
 
 // TestDependencyComplete validates that the COMPLETE dependency condition will resolve when the child container exits
@@ -96,7 +95,7 @@ func TestDependencyComplete(t *testing.T) {
 	dependency := createTestContainerWithImageAndName(baseImageForOS, "dependency")
 
 	parent.EntryPoint = &entryPointForOS
-	parent.Command = []string{"sleep 5 && exit 0"}
+	parent.Command = []string{"sleep 5"}
 	parent.DependsOn = []apicontainer.DependsOn{
 		{
 			ContainerName: "dependency",
@@ -158,7 +157,7 @@ func TestDependencySuccess(t *testing.T) {
 	}
 
 	dependency.EntryPoint = &entryPointForOS
-	dependency.Command = []string{"sleep 10 && exit 0"}
+	dependency.Command = []string{"sleep 10"}
 	dependency.Essential = false
 
 	testTask.Containers = []*apicontainer.Container{
@@ -258,7 +257,7 @@ func TestDependencySuccessTimeout(t *testing.T) {
 	}
 
 	dependency.EntryPoint = &entryPointForOS
-	dependency.Command = []string{"sleep 15 && exit 0"}
+	dependency.Command = []string{"sleep 15"}
 	dependency.Essential = false
 
 	// set the timeout to be shorter than the amount of time it takes to stop
@@ -340,17 +339,6 @@ func TestDependencyHealthyTimeout(t *testing.T) {
 	}()
 
 	waitFinished(t, finished, orderingTimeout)
-}
-
-func waitFinished(t *testing.T, finished <-chan interface{}, duration time.Duration) {
-	select {
-	case <-finished:
-		t.Log("Finished successfully.")
-		return
-	case <-time.After(90 * time.Second):
-		t.Error("timed out after: ", duration)
-		t.FailNow()
-	}
 }
 
 // TestShutdownOrder
@@ -447,4 +435,17 @@ func TestShutdownOrder(t *testing.T) {
 		close(finished)
 	}()
 
+	waitFinished(t, finished, orderingTimeout)
+}
+
+
+func waitFinished(t *testing.T, finished <-chan interface{}, duration time.Duration) {
+	select {
+	case <-finished:
+		t.Log("Finished successfully.")
+		return
+	case <-time.After(90 * time.Second):
+		t.Error("timed out after: ", duration)
+		t.FailNow()
+	}
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### TraceLog Events
```
2019-02-26T01:22:44Z [INFO] Managed task [testDependencyHealthyTimeout]: sent container change event [dependency]: testDependencyHealthyTimeout dependency -> STOPPED, Exit 0, , Known Sent: NONE
2019-02-26T01:22:44Z [INFO] Task engine [testDependencyHealthyTimeout]: stopping container [parent1]
2019-02-26T01:22:44Z [INFO] Task engine [testDependencyHealthyTimeout]: stopping container [parent2]
2019-02-26T01:22:49Z [WARN] Managed task [testDependencyHealthyTimeout]: failed to write container [parent1] change event to tcs event stream: Event stream is closed
2019-02-26T01:22:49Z [INFO] Managed task [testDependencyHealthyTimeout]: sending container change event [parent1]: testDependencyHealthyTimeout parent1 -> STOPPED, Exit 137, , Known Sent: NONE
2019-02-26T01:22:49Z [INFO] Managed task [testDependencyHealthyTimeout]: sent container change event [parent1]: testDependencyHealthyTimeout parent1 -> STOPPED, Exit 137, , Known Sent: NONE
2019-02-26T01:22:49Z [INFO] Managed task [testDependencyHealthyTimeout]: redundant container state change. parent1 to STOPPED, but already STOPPED
2019-02-26T01:22:49Z [INFO] Managed task [testDependencyHealthyTimeout]: redundant container state change. parent1 to STOPPED, but already STOPPED
2019-02-26T01:23:15Z [WARN] Managed task [testDependencyHealthyTimeout]: failed to write container [parent2] change event to tcs event stream: Event stream is closed
2019-02-26T01:23:15Z [INFO] Managed task [testDependencyHealthyTimeout]: sending container change event [parent2]: testDependencyHealthyTimeout parent2 -> STOPPED, Exit 0, , Known Sent: NONE
2019-02-26T01:23:15Z [INFO] Managed task [testDependencyHealthyTimeout]: sent container change event [parent2]: testDependencyHealthyTimeout parent2 -> STOPPED, Exit 0, , Known Sent: NONE
2019-02-26T01:23:15Z [INFO] Managed task [testDependencyHealthyTimeout]: sending task change event [testDependencyHealthyTimeout -> STOPPED, Known Sent: NONE, PullStartedAt: 2019-02-26 01:22:13.449581324 +0000 UTC m=+0.041705235, PullStoppedAt: 2019-02-26 01:22:14.147765508 +0000 UTC m=+0.739889420, ExecutionStoppedAt: 2019-02-26 01:22:44.374414138 +0000 UTC m=+30.966538059]
--- PASS: TestGranularStopTimeout (61.84s)
	ordering_integ_test.go:411: Finished successfully.
2019-02-26T01:23:15Z [INFO] Managed task [testDependencyHealthyTimeout]: sent task change event [testDependencyHealthyTimeout -> STOPPED, Known Sent: NONE, PullStartedAt: 2019-02-26 01:22:13.449581324 +0000 UTC m=+0.041705235, PullStoppedAt: 2019-02-26 01:22:14.147765508 +0000 UTC m=+0.739889420, ExecutionStoppedAt: 2019-02-26 01:22:44.374414138 +0000 UTC m=+30.966538059]
PASS
```

### Summary
<!-- What does this pull request do? -->

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
