### PR TITLE
Add amazon-vpc-cni-plugins into agent

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "amazon-ecs-cni-plugins"]
 	path = amazon-ecs-cni-plugins
 	url = https://github.com/aws/amazon-ecs-cni-plugins.git
+[submodule "amazon-vpc-cni-plugins"]
+	path = amazon-vpc-cni-plugins
+	url = https://github.com/aws/amazon-vpc-cni-plugins.git

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ gobuild:
 
 # create output directories
 .out-stamp:
-	mkdir -p ./out/test-artifacts ./out/cni-plugins
+	mkdir -p ./out/test-artifacts ./out/cni-plugins ./out/amazon-ecs-cni-plugins ./out/amazon-vpc-cni-plugins
 	touch .out-stamp
 
 # Basic go build
@@ -237,20 +237,36 @@ ECS_CNI_REPOSITORY_REVISION=master
 
 # Variable to override cni repository location
 ECS_CNI_REPOSITORY_SRC_DIR=$(PWD)/amazon-ecs-cni-plugins
+VPC_CNI_REPOSITORY_SRC_DIR=$(PWD)/amazon-vpc-cni-plugins
 
 get-cni-sources:
-	git submodule update --init --checkout
+	git submodule update --init --recursive --remote
 
-cni-plugins: get-cni-sources .out-stamp
-	@docker build -f scripts/dockerfiles/Dockerfile.buildCNIPlugins -t "amazon/amazon-ecs-build-cniplugins:make" .
+build-ecs-cni-plugins:
+	@docker build -f scripts/dockerfiles/Dockerfile.buildECSCNIPlugins -t "amazon/amazon-ecs-build-ecs-cni-plugins:make" .
 	docker run --rm --net=none \
 		-e GIT_SHORT_HASH=$(shell cd $(ECS_CNI_REPOSITORY_SRC_DIR) && git rev-parse --short=8 HEAD) \
 		-e GIT_PORCELAIN=$(shell cd $(ECS_CNI_REPOSITORY_SRC_DIR) && git status --porcelain 2> /dev/null | wc -l | sed 's/^ *//') \
 		-u "$(USERID)" \
-		-v "$(PWD)/out/cni-plugins:/go/src/github.com/aws/amazon-ecs-cni-plugins/bin/plugins" \
+		-v "$(PWD)/out/amazon-ecs-cni-plugins:/go/src/github.com/aws/amazon-ecs-cni-plugins/bin/plugins" \
 		-v "$(ECS_CNI_REPOSITORY_SRC_DIR):/go/src/github.com/aws/amazon-ecs-cni-plugins" \
-		"amazon/amazon-ecs-build-cniplugins:make"
+		"amazon/amazon-ecs-build-ecs-cni-plugins:make"
 	@echo "Built amazon-ecs-cni-plugins successfully."
+
+build-vpc-cni-plugins:
+	@docker build -f scripts/dockerfiles/Dockerfile.buildVPCCNIPlugins -t "amazon/amazon-ecs-build-vpc-cni-plugins:make" .
+	docker run --rm --net=none \
+		-e GIT_SHORT_HASH=$(shell cd $(VPC_CNI_REPOSITORY_SRC_DIR) && git rev-parse --short=8 HEAD) \
+		-u "$(USERID)" \
+		-v "$(PWD)/out/amazon-vpc-cni-plugins:/go/src/github.com/aws/amazon-vpc-cni-plugins/build/linux_amd64" \
+		-v "$(VPC_CNI_REPOSITORY_SRC_DIR):/go/src/github.com/aws/amazon-vpc-cni-plugins" \
+		"amazon/amazon-ecs-build-vpc-cni-plugins:make"
+	@echo "Built amazon-vpc-cni-plugins successfully."
+
+cni-plugins: get-cni-sources .out-stamp build-ecs-cni-plugins build-vpc-cni-plugins
+	mv $(PWD)/out/amazon-ecs-cni-plugins/* $(PWD)/out/cni-plugins
+	mv $(PWD)/out/amazon-vpc-cni-plugins/* $(PWD)/out/cni-plugins
+	@echo "Built all cni plugins successfully."
 
 ifeq (${BUILD_PLATFORM},aarch64)
 run-integ-tests: test-registry gremlin container-health-check-image run-sudo-tests

--- a/agent/ecscni/plugin.go
+++ b/agent/ecscni/plugin.go
@@ -33,9 +33,10 @@ import (
 
 const (
 	currentCNISpec = "0.3.1"
-	// CNIVersion and CNIGitHash needs to be updated every time CNI plugin is updated
-	currentCNIVersion = "2018.10.0"
-	currentCNIGitHash = "93f4377604504bff92e7555da73b0cba732a4fbb"
+	// ECSCNIVersion, ECSCNIGitHash, VPCCNIGitHash needs to be updated every time CNI plugin is updated
+	currentECSCNIVersion = "2018.10.0"
+	currentECSCNIGitHash = "93f4377604504bff92e7555da73b0cba732a4fbb"
+	currentVPCCNIGitHash = "490b13789ff416dec197eb1e3cb0e2a776e20efd"
 )
 
 // CNIClient defines the method of setting/cleaning up container namespace

--- a/agent/ecscni/plugin_test.go
+++ b/agent/ecscni/plugin_test.go
@@ -1,6 +1,6 @@
 // +build linux,unit
 
-// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -267,7 +267,7 @@ func TestCNIPluginVersion(t *testing.T) {
 // Asserts that CNI plugin version matches the expected version
 func TestCNIPluginVersionNumber(t *testing.T) {
 	versionStr := getCNIVersionString(t)
-	assert.Equal(t, currentCNIVersion, versionStr)
+	assert.Equal(t, currentECSCNIVersion, versionStr)
 }
 
 // Asserts that CNI plugin version is upgraded when new commits are made to CNI plugin submodule
@@ -276,10 +276,13 @@ func TestCNIPluginVersionUpgrade(t *testing.T) {
 	cmd := exec.Command("git", "submodule")
 	versionInfo, err := cmd.Output()
 	assert.NoError(t, err, "Error running the command: git submodule")
-	versionInfoStr := string(versionInfo)
+	versionInfoStrList := strings.Split(string(versionInfo), "\n")
 	// If a new commit is added, version should be upgraded
-	if currentCNIGitHash != strings.Split(versionInfoStr, " ")[1] {
-		assert.NotEqual(t, currentCNIVersion, versionStr)
+	if currentECSCNIGitHash != strings.Split(versionInfoStrList[0], " ")[1] {
+		assert.NotEqual(t, currentECSCNIVersion, versionStr)
+	}
+	if currentVPCCNIGitHash != strings.Split(versionInfoStrList[1], " ")[1] {
+		assert.NotEqual(t, currentVPCCNIGitHash, versionStr)
 	}
 }
 

--- a/scripts/dockerfiles/Dockerfile.buildECSCNIPlugins
+++ b/scripts/dockerfiles/Dockerfile.buildECSCNIPlugins
@@ -1,4 +1,4 @@
-# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may
 # not use this file except in compliance with the License. A copy of the

--- a/scripts/dockerfiles/Dockerfile.buildVPCCNIPlugins
+++ b/scripts/dockerfiles/Dockerfile.buildVPCCNIPlugins
@@ -1,0 +1,21 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+FROM golang:1.10
+MAINTAINER Amazon Web Services, Inc.
+
+RUN mkdir -p /go/src/github.com/aws/
+
+WORKDIR /go/src/github.com/aws/amazon-vpc-cni-plugins
+
+CMD ["make", "aws-appmesh"]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
1. Add dockerfile to build amazon-vpc-cni-plugins
2. Add build target in makefile for amazon-vpc-cni-plugins

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

* Pulled vendor file manually for amazon-vpc-cni-plugins packages. 
* Built successfully on my local host. Verified tests passed. 
* Able to invoke vpc plugin binaries 
* New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
