### PR TITLE
Add agent default endpoint IPs to appmesh egressIgnoredIP

### DIFF
--- a/agent/acs/handler/payload_handler_test.go
+++ b/agent/acs/handler/payload_handler_test.go
@@ -682,6 +682,8 @@ func TestPayloadHandlerAddedAppMeshToTask(t *testing.T) {
 	mockEgressIgnoredIPs := mockEgressIgnoredIP1 + "," + mockEgressIgnoredIP2
 	mockEgressIgnoredPorts := mockEgressIgnoredPort1 + "," + mockEgressIgnoredPort2
 	mockContainerName := "testEnvoyContainer"
+	taskMetadataEndpointIP     := "169.254.170.2"
+	instanceMetadataEndpointIP := "169.254.169.254"
 	tester := setup(t)
 	defer tester.ctrl.Finish()
 
@@ -726,9 +728,11 @@ func TestPayloadHandlerAddedAppMeshToTask(t *testing.T) {
 	assert.Equal(t, 2, len(appMesh.AppPorts))
 	assert.Equal(t, mockAppPort1, appMesh.AppPorts[0])
 	assert.Equal(t, mockAppPort2, appMesh.AppPorts[1])
-	assert.Equal(t, 2, len(appMesh.EgressIgnoredIPs))
+	assert.Equal(t, 4, len(appMesh.EgressIgnoredIPs))
 	assert.Equal(t, mockEgressIgnoredIP1, appMesh.EgressIgnoredIPs[0])
 	assert.Equal(t, mockEgressIgnoredIP2, appMesh.EgressIgnoredIPs[1])
+	assert.Equal(t, taskMetadataEndpointIP, appMesh.EgressIgnoredIPs[2])
+	assert.Equal(t, instanceMetadataEndpointIP, appMesh.EgressIgnoredIPs[3])
 	assert.Equal(t, 2, len(appMesh.EgressIgnoredPorts))
 	assert.Equal(t, mockEgressIgnoredPort1, appMesh.EgressIgnoredPorts[0])
 	assert.Equal(t, mockEgressIgnoredPort2, appMesh.EgressIgnoredPorts[1])

--- a/agent/api/appmesh/appmesh.go
+++ b/agent/api/appmesh/appmesh.go
@@ -21,15 +21,17 @@ import (
 )
 
 const (
-	appMesh            = "APPMESH"
-	splitter           = ","
-	ignoredUID         = "IgnoredUID"
-	ignoredGID         = "IgnoredGID"
-	proxyIngressPort   = "ProxyIngressPort"
-	proxyEgressPort    = "ProxyEgressPort"
-	appPorts           = "AppPorts"
-	egressIgnoredIPs   = "EgressIgnoredIPs"
-	egressIgnoredPorts = "EgressIgnoredPorts"
+	appMesh                    = "APPMESH"
+	splitter                   = ","
+	ignoredUID                 = "IgnoredUID"
+	ignoredGID                 = "IgnoredGID"
+	proxyIngressPort           = "ProxyIngressPort"
+	proxyEgressPort            = "ProxyEgressPort"
+	appPorts                   = "AppPorts"
+	egressIgnoredIPs           = "EgressIgnoredIPs"
+	egressIgnoredPorts         = "EgressIgnoredPorts"
+	taskMetadataEndpointIP     = "169.254.170.2"
+	instanceMetadataEndpointIP = "169.254.169.254"
 )
 
 // AppMesh contains information of app mesh config
@@ -57,27 +59,65 @@ func AppMeshFromACS(proxyConfig *ecsacs.ProxyConfiguration) (*AppMesh, error) {
 		return nil, fmt.Errorf("agent does not support proxy type other than app mesh")
 	}
 
-	var inputAppPorts []string
-	var inputEgressIgnoredIPs []string
-	var inputEgressIgnoredPorts []string
-
-	if proxyConfig.Properties[appPorts] != nil {
-		inputAppPorts = strings.Split(*proxyConfig.Properties[appPorts], splitter)
-	}
-	if proxyConfig.Properties[egressIgnoredIPs] != nil {
-		inputEgressIgnoredIPs = strings.Split(*proxyConfig.Properties[egressIgnoredIPs], splitter)
-	}
-	if proxyConfig.Properties[egressIgnoredPorts] != nil {
-		inputEgressIgnoredPorts = strings.Split(*proxyConfig.Properties[egressIgnoredPorts], splitter)
-	}
-
 	return &AppMesh{
 		IgnoredUID:         aws.StringValue(proxyConfig.Properties[ignoredUID]),
 		IgnoredGID:         aws.StringValue(proxyConfig.Properties[ignoredGID]),
 		ProxyIngressPort:   aws.StringValue(proxyConfig.Properties[proxyIngressPort]),
 		ProxyEgressPort:    aws.StringValue(proxyConfig.Properties[proxyEgressPort]),
-		AppPorts:           inputAppPorts,
-		EgressIgnoredIPs:   inputEgressIgnoredIPs,
-		EgressIgnoredPorts: inputEgressIgnoredPorts,
+		AppPorts:           buildAppPorts(proxyConfig),
+		EgressIgnoredIPs:   buildEgressIgnoredIPs(proxyConfig),
+		EgressIgnoredPorts: buildEgressIgnoredPorts(proxyConfig),
 	}, nil
+}
+
+// buildAppPorts creates app ports from proxy config
+func buildAppPorts(proxyConfig *ecsacs.ProxyConfiguration) []string {
+	var inputAppPorts []string
+	if proxyConfig.Properties[appPorts] != nil {
+		inputAppPorts = strings.Split(*proxyConfig.Properties[appPorts], splitter)
+	}
+	return inputAppPorts
+}
+
+// buildEgressIgnoredIPs creates egress ignored IPs from proxy config
+func buildEgressIgnoredIPs(proxyConfig *ecsacs.ProxyConfiguration) []string {
+	var inputEgressIgnoredIPs []string
+	if proxyConfig.Properties[egressIgnoredIPs] != nil {
+		inputEgressIgnoredIPs = strings.Split(*proxyConfig.Properties[egressIgnoredIPs], splitter)
+	}
+	// append agent default egress ignored IPs
+	return appendDefaultEgressIgnoredIPs(inputEgressIgnoredIPs)
+}
+
+// buildEgressIgnoredPorts creates egress ignored ports from proxy config
+func buildEgressIgnoredPorts(proxyConfig *ecsacs.ProxyConfiguration) []string {
+	var inputEgressIgnoredPorts []string
+	if proxyConfig.Properties[egressIgnoredPorts] != nil {
+		inputEgressIgnoredPorts = strings.Split(*proxyConfig.Properties[egressIgnoredPorts], splitter)
+	}
+	return inputEgressIgnoredPorts
+}
+
+// appendDefaultEgressIgnoredIPs append task metadata endpoint ip and
+// instance metadata ip address to egress ignored IPs if does not exist
+func appendDefaultEgressIgnoredIPs(egressIgnoredIPs []string) []string {
+	hasTaskMetadataEndpointIP := false
+	hasInstanceMetadataEndpointIP := false
+	for _, egressIgnoredIP := range egressIgnoredIPs {
+		if strings.TrimSpace(egressIgnoredIP) == taskMetadataEndpointIP {
+			hasTaskMetadataEndpointIP = true
+		}
+		if strings.TrimSpace(egressIgnoredIP) == instanceMetadataEndpointIP {
+			hasInstanceMetadataEndpointIP = true
+		}
+	}
+
+	if !hasTaskMetadataEndpointIP {
+		egressIgnoredIPs = append(egressIgnoredIPs, taskMetadataEndpointIP)
+	}
+	if !hasInstanceMetadataEndpointIP {
+		egressIgnoredIPs = append(egressIgnoredIPs, instanceMetadataEndpointIP)
+	}
+
+	return egressIgnoredIPs
 }

--- a/agent/api/appmesh/appmesh_test.go
+++ b/agent/api/appmesh/appmesh_test.go
@@ -55,6 +55,31 @@ func TestAppMeshFromACS(t *testing.T) {
 	assert.Equal(t, mockAppPort2, appMesh.AppPorts[1])
 	assert.Equal(t, mockEgressIgnoredIP1, appMesh.EgressIgnoredIPs[0])
 	assert.Equal(t, mockEgressIgnoredIP2, appMesh.EgressIgnoredIPs[1])
+	assert.Equal(t, taskMetadataEndpointIP, appMesh.EgressIgnoredIPs[2])
+	assert.Equal(t, instanceMetadataEndpointIP, appMesh.EgressIgnoredIPs[3])
+	assert.Equal(t, mockEgressIgnoredPort1, appMesh.EgressIgnoredPorts[0])
+	assert.Equal(t, mockEgressIgnoredPort2, appMesh.EgressIgnoredPorts[1])
+}
+
+func TestAppMeshFromACSContainsDefaultEgressIgnoredIP(t *testing.T) {
+	testProxyConfig := prepareProxyConfig()
+	egressIgnoredIPs := mockEgressIgnoredIPs + splitter + taskMetadataEndpointIP + splitter + instanceMetadataEndpointIP
+	testProxyConfig.Properties[egressIgnoredIPs] = aws.String(egressIgnoredIPs)
+
+	appMesh, err := AppMeshFromACS(&testProxyConfig)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, appMesh)
+	assert.Equal(t, mockIgnoredUID, appMesh.IgnoredUID)
+	assert.Equal(t, mockIgnoredGID, appMesh.IgnoredGID)
+	assert.Equal(t, mockProxyEgressPort, appMesh.ProxyEgressPort)
+	assert.Equal(t, mockProxyIngressPort, appMesh.ProxyIngressPort)
+	assert.Equal(t, mockAppPort1, appMesh.AppPorts[0])
+	assert.Equal(t, mockAppPort2, appMesh.AppPorts[1])
+	assert.Equal(t, mockEgressIgnoredIP1, appMesh.EgressIgnoredIPs[0])
+	assert.Equal(t, mockEgressIgnoredIP2, appMesh.EgressIgnoredIPs[1])
+	assert.Equal(t, taskMetadataEndpointIP, appMesh.EgressIgnoredIPs[2])
+	assert.Equal(t, instanceMetadataEndpointIP, appMesh.EgressIgnoredIPs[3])
 	assert.Equal(t, mockEgressIgnoredPort1, appMesh.EgressIgnoredPorts[0])
 	assert.Equal(t, mockEgressIgnoredPort2, appMesh.EgressIgnoredPorts[1])
 }
@@ -72,8 +97,8 @@ func TestAppMeshFromACSNonAppMeshProxyInput(t *testing.T) {
 func prepareProxyConfig() ecsacs.ProxyConfiguration {
 
 	return ecsacs.ProxyConfiguration{
-		Type:          aws.String(appMesh),
-		Properties:    map[string]*string{
+		Type: aws.String(appMesh),
+		Properties: map[string]*string{
 			ignoredUID:         aws.String(mockIgnoredUID),
 			ignoredGID:         aws.String(mockIgnoredGID),
 			proxyIngressPort:   aws.String(mockProxyIngressPort),


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
If user didn't input task metadata endpoint ip of agent or instance metadata
endpoint ip in appmesh enabled task, agent should add these two default IPs
into appmesh egressIgnoredIPs field as we don't want them to be redirect
to envoy proxy
Test failed since we are missing binary for aws-appmesh. we will combine this in app-mesh branch

### Implementation details
<!-- How are the changes implemented? -->
Add task metadata endpoint ip and ec2 instance metadata ip when we construct appmesh config from proxy config if these 2 ips are not input already

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
