### PR TITLE
Fix error detection case when image that is being deleted does not exist

### DIFF
--- a/agent/engine/docker_image_manager.go
+++ b/agent/engine/docker_image_manager.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -537,7 +538,7 @@ func (imageManager *dockerImageManager) deleteImage(ctx context.Context, imageID
 	seelog.Infof("Removing Image: %s", imageID)
 	err := imageManager.client.RemoveImage(ctx, imageID, dockerclient.RemoveImageTimeout)
 	if err != nil {
-		if err.Error() == imageNotFoundForDeletionError {
+		if strings.Contains(err.Error(), imageNotFoundForDeletionError) {
 			seelog.Errorf("Image already removed from the instance: %v", err)
 		} else {
 			seelog.Errorf("Error removing Image %v - %v", imageID, err)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Fixes #1871 

When the agent tries to remove an image that does not exist on the instance, the error message received back by the agent is `no such image: <image name>`.

Agent tries to match the error message with `no such image` instead of `no such image: <image name>`. As a result, agent is not able to correctly detect that the error thrown back is because the image does not exist.

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
Test `TestDeleteImageNotFoundError` modified to mock correct error message and fails without this change in place. 
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
