### PR TITLE
Change task server endpoint to 127.0.0.1

### DIFF
--- a/agent/functional_tests/tests/functionaltests_test.go
+++ b/agent/functional_tests/tests/functionaltests_test.go
@@ -686,14 +686,9 @@ func testV3TaskEndpoint(t *testing.T, taskName, containerName, networkMode, awsl
 		ExtraEnvironment: map[string]string{
 			"ECS_AVAILABLE_LOGGING_DRIVERS": `["awslogs"]`,
 		},
-		PortBindings: map[nat.Port]map[string]string{
-			"51679/tcp": {
-				"HostIP":   "0.0.0.0",
-				"HostPort": "51679",
-			},
-		},
 	}
 
+	os.Setenv("ECS_FTEST_FORCE_NET_HOST", "true")
 	agent := RunAgent(t, agentOptions)
 	defer agent.Cleanup()
 

--- a/agent/functional_tests/tests/functionaltests_unix_test.go
+++ b/agent/functional_tests/tests/functionaltests_unix_test.go
@@ -43,8 +43,6 @@ import (
 	dockercontainer "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 	docker "github.com/docker/docker/client"
-	"github.com/docker/go-connections/nat"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -397,13 +395,8 @@ func TestTaskIAMRolesNetHostMode(t *testing.T) {
 			"ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST": "true",
 			"ECS_ENABLE_TASK_IAM_ROLE":              "true",
 		},
-		PortBindings: map[nat.Port]map[string]string{
-			"51679/tcp": {
-				"HostIP":   "0.0.0.0",
-				"HostPort": "51679",
-			},
-		},
 	}
+	os.Setenv("ECS_FTEST_FORCE_NET_HOST", "true")
 	agent := RunAgent(t, agentOptions)
 	defer agent.Cleanup()
 
@@ -420,13 +413,8 @@ func TestTaskIAMRolesDefaultNetworkMode(t *testing.T) {
 		ExtraEnvironment: map[string]string{
 			"ECS_ENABLE_TASK_IAM_ROLE": "true",
 		},
-		PortBindings: map[nat.Port]map[string]string{
-			"51679/tcp": {
-				"HostIP":   "0.0.0.0",
-				"HostPort": "51679",
-			},
-		},
 	}
+	os.Setenv("ECS_FTEST_FORCE_NET_HOST", "true")
 	agent := RunAgent(t, agentOptions)
 	defer agent.Cleanup()
 
@@ -699,6 +687,7 @@ func TestTaskMetadataValidator(t *testing.T) {
 	cwlClient.CreateLogGroup(&cloudwatchlogs.CreateLogGroupInput{
 		LogGroupName: aws.String(awslogsLogGroupName),
 	})
+	os.Setenv("ECS_FTEST_FORCE_NET_HOST", "true")
 	agent := RunAgent(t, &AgentOptions{
 		EnableTaskENI: true,
 		ExtraEnvironment: map[string]string{
@@ -1405,6 +1394,7 @@ func TestElasticInferenceValidator(t *testing.T) {
 			"ECS_AVAILABLE_LOGGING_DRIVERS": `["awslogs"]`,
 		},
 	}
+	os.Setenv("ECS_FTEST_FORCE_NET_HOST", "true")
 
 	agent := RunAgent(t, agentOptions)
 	defer agent.Cleanup()
@@ -1439,14 +1429,9 @@ func TestServerEndpointValidator(t *testing.T) {
 			"ECS_ENABLE_TASK_IAM_ROLE":              "true",
 			"ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST": "true",
 		},
-		PortBindings: map[nat.Port]map[string]string{
-			"51679/tcp": {
-				"HostIP":   "0.0.0.0",
-				"HostPort": "51679",
-			},
-		},
 	}
 
+	os.Setenv("ECS_FTEST_FORCE_NET_HOST", "true")
 	agent := RunAgent(t, agentOptions)
 	defer agent.Cleanup()
 

--- a/agent/handlers/task_server_setup.go
+++ b/agent/handlers/task_server_setup.go
@@ -82,7 +82,7 @@ func taskServerSetup(credentialsManager credentials.Manager,
 	loggingMuxRouter.SkipClean(false)
 
 	server := http.Server{
-		Addr:         ":" + strconv.Itoa(config.AgentCredentialsPort),
+		Addr:         "127.0.0.1:" + strconv.Itoa(config.AgentCredentialsPort),
 		Handler:      loggingMuxRouter,
 		ReadTimeout:  readTimeout,
 		WriteTimeout: writeTimeout,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Change task server endpoint to 127.0.0.1 from 0.0.0.0

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
* curl localhost:51679 (server responsive)
* curl hostip:51679 (server not responsive)

New tests cover the changes: <!-- yes|no --> No. Fixed some functional tests when switching to localhost.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
