### PR TITLE
Fix windows validator test

### DIFF
--- a/misc/v3-task-endpoint-validator-windows/v3-task-endpoint-validator-windows.go
+++ b/misc/v3-task-endpoint-validator-windows/v3-task-endpoint-validator-windows.go
@@ -170,7 +170,7 @@ func verifyTaskMetadataResponse(taskMetadataRawMsg json.RawMessage) error {
 		"KnownStatus":   "RUNNING",
 	}
 
-	taskExpectedFieldNotEmptyArray := []string{"Cluster", "TaskARN", "Family", "Revision", "PullStartedAt", "PullStoppedAt", "Containers", "AvailabilityZone"}
+	taskExpectedFieldNotEmptyArray := []string{"Cluster", "TaskARN", "Family", "Revision", "Containers", "AvailabilityZone"}
 	if checkContainerInstanceTags {
 		taskExpectedFieldNotEmptyArray = append(taskExpectedFieldNotEmptyArray, "ContainerInstanceTags")
 	}
@@ -184,6 +184,14 @@ func verifyTaskMetadataResponse(taskMetadataRawMsg json.RawMessage) error {
 	for _, fieldName := range taskExpectedFieldNotEmptyArray {
 		if err = fieldNotEmpty(taskMetadataResponseMap, fieldName); err != nil {
 			return err
+		}
+	}
+
+	// When pull behavior is set to 'prefer-cached', the pull values are unset
+	// TODO: figure out how to test both conditions on windows.
+	for _, fieldName := range []string{"PullStartedAt", "PullStoppedAt"} {
+		if err = fieldNotEmpty(taskMetadataResponseMap, fieldName); err != nil {
+			fmt.Printf("WARN: '%s' is not set, but this value isn't expected when pull is disabled.", fieldName)
 		}
 	}
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
We switched the pull behavior to prefer-cached on windows tests. However, the metadata validator explicitly validates that PullStartedAt is set in all cases. This will prevent the test from failing, but we need a better plan for the long term.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
