### PR TITLE
change nginx from 1.15 to 1.15.8

### DIFF
--- a/scripts/setup-test-registry
+++ b/scripts/setup-test-registry
@@ -18,7 +18,7 @@ set -e
 
 REGISTRY_IMAGE="registry:2.7.0"
 
-NGINX_IMAGE="nginx:1.15"
+NGINX_IMAGE="nginx:1.15.8"
 
 ROOT=$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )
 cd "${ROOT}"
@@ -56,7 +56,7 @@ docker rmi amazon/image-cleanup-test-image2:make
 docker rmi amazon/image-cleanup-test-image3:make
 
 BUSYBOX_IMAGE="busybox:1.29.3"
-NGINX_IMAGE="nginx:1.15"
+NGINX_IMAGE="nginx:1.15.8"
 PYTHON2_IMAGE="python:2.7.15"
 UBUNTU_IMAGE="ubuntu:16.04"
 

--- a/scripts/upload-images
+++ b/scripts/upload-images
@@ -49,7 +49,7 @@ fi
 ECR_ROLE_IMAGE="executionrole"
 
 BUSYBOX_IMAGE="busybox:1.29.3"
-NGINX_IMAGE="nginx:1.15"
+NGINX_IMAGE="nginx:1.15.8"
 PYTHON2_IMAGE="python:2.7.15"
 UBUNTU_IMAGE="ubuntu:16.04"
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
nginx 1.15.9 is not yet available, we need to have a previous version of nginx for integ and functional test to run
### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

````
[ec2-user@ip-172-31-3-196 ~]$ docker pull nginx:1.15.8
1.15.8: Pulling from library/nginx
42367302fc78: Pull complete
a9cb25c539ce: Pull complete
07dff5c0fced: Pull complete
Digest: sha256:dd2d0ac3fff2f007d99e033b64854be0941e19a2ad51f174d9240dda20d9f534
Status: Downloaded newer image for nginx:1.15.8
````

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
