### PR TITLE
Fix Windows Functional Tests

### DIFF
--- a/agent/engine/ordering_integ_test.go
+++ b/agent/engine/ordering_integ_test.go
@@ -43,16 +43,17 @@ func TestDependencyHealthCheck(t *testing.T) {
 	dependency := createTestContainerWithImageAndName(baseImageForOS, "dependency")
 
 	parent.EntryPoint = &entryPointForOS
-	parent.Command = []string{"sleep 5 && exit 1"}
+	parent.Command = []string{"exit 0"}
 	parent.DependsOn = []apicontainer.DependsOn{
 		{
 			ContainerName: "dependency",
 			Condition:     "HEALTHY",
 		},
 	}
+	parent.Essential = true
 
 	dependency.EntryPoint = &entryPointForOS
-	dependency.Command = []string{"sleep 60 && exit 0"}
+	dependency.Command = []string{"sleep 90"}
 	dependency.HealthCheckType = apicontainer.DockerHealthCheckType
 	dependency.DockerConfig.Config = aws.String(alwaysHealthyHealthCheckConfig)
 

--- a/agent/functional_tests/tests/functionaltests_windows_test.go
+++ b/agent/functional_tests/tests/functionaltests_windows_test.go
@@ -210,8 +210,6 @@ func TestOOMContainer(t *testing.T) {
 
 	testTask, err := agent.StartTask(t, "oom-windows")
 	require.NoError(t, err, "Expected to start invalid-image task")
-	err = testTask.WaitRunning(waitTaskStateChangeDuration)
-	assert.NoError(t, err, "Expect task to be running")
 	err = testTask.WaitStopped(waitTaskStateChangeDuration)
 	assert.NoError(t, err, "Expect task to be stopped")
 	assert.NotEqual(t, 0, testTask.Containers[0].ExitCode, "container should fail with memory error")

--- a/misc/v3-task-endpoint-validator-windows/setup-v3-task-endpoint-validator.ps1
+++ b/misc/v3-task-endpoint-validator-windows/setup-v3-task-endpoint-validator.ps1
@@ -14,6 +14,8 @@
 $oldPref = $ErrorActionPreference
 $ErrorActionPreference = 'Stop'
 
+Invoke-Expression ${PSScriptRoot}\..\windows-deploy\hostsetup.ps1
+
 # Create amazon/amazon-ecs-v3-task-endpoint-validator-windows for tests
 Invoke-Expression "go build -o ${PSScriptRoot}\v3-task-endpoint-validator-windows.exe ${PSScriptRoot}\v3-task-endpoint-validator-windows.go" 
 Invoke-Expression "docker build -t amazon/amazon-ecs-v3-task-endpoint-validator-windows --file ${PSScriptRoot}\v3-task-endpoint-validator-windows.dockerfile ${PSScriptRoot}"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Fix TestOOMContainer, TestTaskIamRolesDefaultNetworkMode, TestV3TaskEndpointDefaultNetworkMode and TestV3TaskEndpointTags. As per https://github.com/aws/amazon-ecs-agent/issues/1869.

Also bring in one of derek's windows integ test fix into dev (https://github.com/aws/amazon-ecs-agent/pull/1919/commits/e80ccb86c90aa5fefbd8bf175c57aabc9119d4ce).

### Implementation details
<!-- How are the changes implemented? -->
#### TestOOMContainer
TestOOMContainer runs a task that's expected to fail fast because the container tries to use too much memory. The test had a check where it was waiting for the task to reach running, but since the task stops quickly, it's possible that when the test describes the task, the task has already stopped and the test fails with the following:
```
Error Trace:	functionaltests_windows_test.go:214
Error:      	Received unexpected error:
        	Task terminal; will never reach RUNNING
```

 Fixing by removing the wait running check.

#### TestTaskIamRolesDefaultNetworkMode / TestV3TaskEndpointDefaultNetworkMode / TestV3TaskEndpointTags
There was a race condition in setting up credential port forwarding in which the adapter has multiple addresses before the new ip is assigned. Allowing this race condition can cause the netsh interface portproxy setup to result in the network adapter in an unrecoverable bad state where the proxy is unable to listen on port 80 because the port is in use by a non-functional proxy rule.

This race condition happened rarely before, but started becoming a problem when changes were made to let windows test run faster (#1886), which let TestV3TaskEndpointDefaultNetworkMode, TestV3TaskEndpointTags and TestV3TaskEndpointDefaultNetworkMode have a high failure rate because they need the credential port forwarding.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
