### PR TITLE
Capability and plugin verification for eni trunking

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ additional details on each available environment variable.
 | `ECS_IMAGE_PULL_INACTIVITY_TIMEOUT` | 1m | The time to wait after docker pulls complete waiting for extraction of a container. Useful for tuning large Windows containers. | 1m | 3m |
 | `ECS_INSTANCE_ATTRIBUTES` | `{"stack": "prod"}` | These attributes take effect only during initial registration. After the agent has joined an ECS cluster, use the PutAttributes API action to add additional attributes. For more information, see [Amazon ECS Container Agent Configuration](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-config.html) in the Amazon ECS Developer Guide.| `{}` | `{}` |
 | `ECS_ENABLE_TASK_ENI` | `false` | Whether to enable task networking for task to be launched with its own network interface | `false` | Not applicable |
+| `ECS_ENABLE_HIGH_DENSITY_ENI` | `false` | Whether to enable high density eni feature when using task networking | `true` | Not applicable |
 | `ECS_CNI_PLUGINS_PATH` | `/ecs/cni` | The path where the cni binary file is located | `/amazon-ecs-cni-plugins` | Not applicable |
 | `ECS_AWSVPC_BLOCK_IMDS` | `true` | Whether to block access to [Instance Metadata](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) for Tasks started with `awsvpc` network mode | `false` | Not applicable |
 | `ECS_AWSVPC_ADDITIONAL_LOCAL_ROUTES` | `["10.0.15.0/24"]` | In `awsvpc` network mode, traffic to these prefixes will be routed via the host bridge instead of the task ENI | `[]` | Not applicable |

--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -45,6 +45,8 @@ const (
 	capabilityECREndpoint                       = "ecr-endpoint"
 	capabilityContainerOrdering                 = "container-ordering"
 	taskEIAAttributeSuffix                      = "task-eia"
+	taskENITrunkingAttributeSuffix              = "task-eni-trunking"
+	branchCNIPluginVersionSuffix                = "branch-cni-plugin-version"
 )
 
 // capabilities returns the supported capabilities of this agent / docker-client pair.
@@ -79,6 +81,7 @@ const (
 //    ecs.capability.secrets.asm.environment-variables
 //    ecs.capability.aws-appmesh
 //    ecs.capability.task-eia
+//    ecs.capability.task-eni-trunking
 func (agent *ecsAgent) capabilities() ([]*ecs.Attribute, error) {
 	var capabilities []*ecs.Attribute
 
@@ -111,6 +114,8 @@ func (agent *ecsAgent) capabilities() ([]*ecs.Attribute, error) {
 	}
 
 	capabilities = agent.appendTaskENICapabilities(capabilities)
+	capabilities = agent.appendENITrunkingCapabilities(capabilities)
+
 	capabilities = agent.appendDockerDependentCapabilities(capabilities, supportedVersions)
 
 	// TODO: gate this on docker api version when ecs supported docker includes
@@ -236,6 +241,7 @@ func (agent *ecsAgent) appendTaskENICapabilities(capabilities []*ecs.Attribute) 
 			return capabilities
 		}
 		capabilities = append(capabilities, taskENIVersionAttribute)
+
 		// We only care about AWSVPCBlockInstanceMetdata if Task ENI is enabled
 		if agent.cfg.AWSVPCBlockInstanceMetdata {
 			// If the Block Instance Metadata flag is set for AWS VPC networking mode, register a capability
@@ -245,6 +251,7 @@ func (agent *ecsAgent) appendTaskENICapabilities(capabilities []*ecs.Attribute) 
 			})
 		}
 	}
+
 	return capabilities
 }
 

--- a/agent/app/agent_capability_windows.go
+++ b/agent/app/agent_capability_windows.go
@@ -28,3 +28,7 @@ func (agent *ecsAgent) appendVolumeDriverCapabilities(capabilities []*ecs.Attrib
 func (agent *ecsAgent) appendNvidiaDriverVersionAttribute(capabilities []*ecs.Attribute) []*ecs.Attribute {
 	return capabilities
 }
+
+func (agent *ecsAgent) appendENITrunkingCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
+	return capabilities
+}

--- a/agent/app/agent_unix.go
+++ b/agent/app/agent_unix.go
@@ -49,6 +49,7 @@ var awsVPCCNIPlugins = []string{ecscni.ECSENIPluginName,
 	ecscni.ECSBridgePluginName,
 	ecscni.ECSIPAMPluginName,
 	ecscni.ECSAppMeshPluginName,
+	ecscni.ECSBranchENIPluginName,
 }
 
 // startWindowsService is not supported on Linux
@@ -150,9 +151,15 @@ func isInstanceLaunchedInVPC(err error) bool {
 // b. ecs-bridge
 // c. ecs-ipam
 // d. aws-appmesh
+// e. vpc-branch-eni
 func (agent *ecsAgent) verifyCNIPluginsCapabilities() error {
 	// Check if we can get capabilities from each plugin
 	for _, plugin := range awsVPCCNIPlugins {
+		// skip verifying branch cni plugin if eni trunking is not enabled
+		if plugin == ecscni.ECSBranchENIPluginName && agent.cfg != nil && !agent.cfg.ENITrunkingEnabled {
+			continue
+		}
+
 		capabilities, err := agent.cniClient.Capabilities(plugin)
 		if err != nil {
 			return err

--- a/agent/app/agent_unix_test.go
+++ b/agent/app/agent_unix_test.go
@@ -171,12 +171,14 @@ func TestDoStartTaskENIHappyPath(t *testing.T) {
 		cniClient.EXPECT().Capabilities(ecscni.ECSBridgePluginName).Return(cniCapabilities, nil),
 		cniClient.EXPECT().Capabilities(ecscni.ECSIPAMPluginName).Return(cniCapabilities, nil),
 		cniClient.EXPECT().Capabilities(ecscni.ECSAppMeshPluginName).Return(cniCapabilities, nil),
+		cniClient.EXPECT().Capabilities(ecscni.ECSBranchENIPluginName).Return(cniCapabilities, nil),
 		mockPauseLoader.EXPECT().LoadImage(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil),
 		state.EXPECT().ENIByMac(gomock.Any()).Return(nil, false).AnyTimes(),
 		mockCredentialsProvider.EXPECT().Retrieve().Return(credentials.Value{}, nil),
 		dockerClient.EXPECT().SupportedVersions().Return(nil),
 		dockerClient.EXPECT().KnownVersions().Return(nil),
 		cniClient.EXPECT().Version(ecscni.ECSENIPluginName).Return("v1", nil),
+		cniClient.EXPECT().Version(ecscni.ECSBranchENIPluginName).Return("v2", nil),
 		mockMobyPlugins.EXPECT().Scan().Return([]string{}, nil),
 		dockerClient.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
 			gomock.Any()).Return([]string{}, nil),
@@ -205,6 +207,7 @@ func TestDoStartTaskENIHappyPath(t *testing.T) {
 
 	cfg := getTestConfig()
 	cfg.TaskENIEnabled = true
+	cfg.ENITrunkingEnabled = true
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines
 	defer cancel()
@@ -322,9 +325,13 @@ func TestQueryCNIPluginsCapabilitiesHappyPath(t *testing.T) {
 		cniClient.EXPECT().Capabilities(ecscni.ECSBridgePluginName).Return(cniCapabilities, nil),
 		cniClient.EXPECT().Capabilities(ecscni.ECSIPAMPluginName).Return(cniCapabilities, nil),
 		cniClient.EXPECT().Capabilities(ecscni.ECSAppMeshPluginName).Return(cniCapabilities, nil),
+		cniClient.EXPECT().Capabilities(ecscni.ECSBranchENIPluginName).Return(cniCapabilities, nil),
 	)
 	agent := &ecsAgent{
 		cniClient: cniClient,
+		cfg: &config.Config{
+			ENITrunkingEnabled: true,
+		},
 	}
 	assert.NoError(t, agent.verifyCNIPluginsCapabilities())
 }

--- a/agent/config/config_unix.go
+++ b/agent/config/config_unix.go
@@ -88,6 +88,10 @@ func (cfg *Config) platformOverrides() {
 	if cfg.PrometheusMetricsEnabled {
 		cfg.ReservedPorts = append(cfg.ReservedPorts, AgentPrometheusExpositionPort)
 	}
+
+	if cfg.TaskENIEnabled { // when task networking is enabled, eni trunking is enabled by default
+		cfg.ENITrunkingEnabled = utils.ParseBool(os.Getenv("ECS_ENABLE_HIGH_DENSITY_ENI"), true)
+	}
 }
 
 // platformString returns platform-specific config data that can be serialized

--- a/agent/config/config_unix_test.go
+++ b/agent/config/config_unix_test.go
@@ -191,6 +191,29 @@ func TestPrometheusMetricsPlatformOverrides(t *testing.T) {
 	assert.Equal(t, 6, len(cfg.ReservedPorts), "Reserved ports should have added Prometheus endpoint")
 }
 
+// TestENITrunkingEnabled tests that when task networking is enabled, eni trunking is enabled by default
+func TestENITrunkingEnabled(t *testing.T) {
+	defer setTestRegion()()
+	defer setTestEnv("ECS_ENABLE_TASK_ENI", "true")()
+	cfg, err := NewConfig(ec2.NewBlackholeEC2MetadataClient())
+	require.NoError(t, err)
+
+	cfg.platformOverrides()
+	assert.True(t, cfg.ENITrunkingEnabled, "ENI trunking should be enabled")
+}
+
+// TestENITrunkingDisabled tests that when task networking is enabled, eni trunking can be disabled
+func TestENITrunkingDisabled(t *testing.T) {
+	defer setTestRegion()()
+	defer setTestEnv("ECS_ENABLE_TASK_ENI", "true")()
+	cfg, err := NewConfig(ec2.NewBlackholeEC2MetadataClient())
+	require.NoError(t, err)
+
+	defer setTestEnv("ECS_ENABLE_HIGH_DENSITY_ENI", "false")()
+	cfg.platformOverrides()
+	assert.False(t, cfg.ENITrunkingEnabled, "ENI trunking should be disabled")
+}
+
 // setupFileConfiguration create a temp file store the configuration
 func setupFileConfiguration(t *testing.T, configContent string) string {
 	file, err := ioutil.TempFile("", "ecs-test")

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -159,6 +159,10 @@ type Config struct {
 	// defined EC2 networks
 	TaskENIEnabled bool
 
+	// ENITrunkingEnabled specifies if the Agent is enabled to launch awsvpc
+	// task with ENI Trunking
+	ENITrunkingEnabled bool
+
 	// ImageCleanupDisabled specifies whether the Agent will periodically perform
 	// automated image cleanup
 	ImageCleanupDisabled bool

--- a/agent/ecscni/types.go
+++ b/agent/ecscni/types.go
@@ -46,6 +46,8 @@ const (
 	ECSENIPluginName = "ecs-eni"
 	// ECSAppMeshPluginName is the binary of aws-appmesh plugin
 	ECSAppMeshPluginName = "aws-appmesh"
+	// ECSBranchENIPluginName is the binary of the branch-eni plugin
+	ECSBranchENIPluginName = "vpc-branch-eni"
 	// TaskIAMRoleEndpoint is the endpoint of ecs-agent exposes credentials for
 	// task IAM role
 	TaskIAMRoleEndpoint = "169.254.170.2/32"

--- a/scripts/dockerfiles/Dockerfile.buildVPCCNIPlugins
+++ b/scripts/dockerfiles/Dockerfile.buildVPCCNIPlugins
@@ -18,4 +18,4 @@ RUN mkdir -p /go/src/github.com/aws/
 
 WORKDIR /go/src/github.com/aws/amazon-vpc-cni-plugins
 
-CMD ["make", "aws-appmesh"]
+CMD ["make", "aws-appmesh", "vpc-branch-eni"]

--- a/scripts/dockerfiles/Dockerfile.buildVPCCNIPlugins
+++ b/scripts/dockerfiles/Dockerfile.buildVPCCNIPlugins
@@ -14,6 +14,10 @@
 FROM golang:1.10
 MAINTAINER Amazon Web Services, Inc.
 
+ARG GOARCH
+
+ENV GOARCH ${GOARCH}
+
 RUN mkdir -p /go/src/github.com/aws/
 
 WORKDIR /go/src/github.com/aws/amazon-vpc-cni-plugins


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Capability and plugin verification for eni trunking.

### Implementation details
<!-- How are the changes implemented? -->
Changes involve:
  1. Add capability "task-eni-trunking" to indicate eni trunking support
  2. Add branch plugin capability verification
  3. Add branch plugin version attribute
  4. Add agent config ECS_ENABLE_HIGH_DENSITY_ENI for enabling eni trunking
  5. Integrate with plugin packaging changes

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> unit tests added.

Manual tests:
```
# enable eni trunking by default
docker run -e ECS_ENABLE_TASK_ENI=true -v /var/run/docker.sock:/var/run/docker.sock amazon/amazon-ecs-agent --ecs-attributes | grep -E "(trunk|branch)"
ecs.capability.task-eni-trunking
ecs.capability.branch-cni-plugin-version	76973f58-

# enable explicitly
docker run -e ECS_ENABLE_TASK_ENI=true -e ECS_ENABLE_HIGH_DENSITY_ENI=true -v /var/run/docker.sock:/var/run/docker.sock amazon/amazon-ecs-agent --ecs-attributes | grep -E "(trunk|branch)"
ecs.capability.task-eni-trunking
ecs.capability.branch-cni-plugin-version	76973f58-

# disable explicitly
docker run -e ECS_ENABLE_TASK_ENI=true -e ECS_ENABLE_HIGH_DENSITY_ENI=false -v /var/run/docker.sock:/var/run/docker.sock amazon/amazon-ecs-agent --ecs-attributes | grep -E "(trunk|branch)"
(no output)
```

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
