### PR TITLE
add more forgiving idle percent

### DIFF
--- a/agent/functional_tests/util/utils.go
+++ b/agent/functional_tests/util/utils.go
@@ -353,13 +353,14 @@ func VerifyMetrics(cwclient *cloudwatch.CloudWatch, params *cloudwatch.GetMetric
 		return nil, fmt.Errorf("Incorrect SampleCount %f, expected 1", *datapoint.SampleCount)
 	}
 
+	// idleCluster cloudWatch average may have intermittent jumps above 0,
 	if idleCluster {
-		if *datapoint.Average != 0.0 {
-			return nil, fmt.Errorf("non-zero utilization for idle cluster")
+		if *datapoint.Average >= 5.0 {
+			return nil, fmt.Errorf("utilization is >= five percent for idle cluster")
 		}
 	} else {
-		if *datapoint.Average == 0.0 {
-			return nil, fmt.Errorf("utilization is zero for non-idle cluster")
+		if *datapoint.Average < 5.0 {
+			return nil, fmt.Errorf("utilization is < five percent for non-idle cluster")
 		}
 	}
 	return datapoint, nil


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
When checking cloudwatch metrics for a manual run of telemetry test, I found that there are intermittent bursts in idle traffic from 0.0 to 0.062 and 0.011.  
When we check for idle cpu/memory elsewhere we have a range of 0-5%.  This change will make the failure case as forgiving as our other checks.  

### Implementation details
This changes the range for idle and non-idle to include any percentages up to 5% rather than a hard 0.0%

### Description for the changelog
Functional test fix for intermittent failure case.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
