### PR TITLE
Fix flakey test - TestDockerStateToContainerState

### DIFF
--- a/agent/engine/common_unix_integ_test.go
+++ b/agent/engine/common_unix_integ_test.go
@@ -31,6 +31,12 @@ func createTestContainer() *apicontainer.Container {
 	return createTestContainerWithImageAndName(testRegistryImage, "netcat")
 }
 
+// getLongRunningCommand returns the command that keeps the container running for the container
+// that uses the default integ test image (amazon/amazon-ecs-netkitten for unix)
+func getLongRunningCommand() []string {
+	return []string{"-loop=true"}
+}
+
 func isDockerRunning() bool {
 	_, err := os.Stat("/var/run/docker.sock")
 	return err == nil

--- a/agent/engine/engine_integ_test.go
+++ b/agent/engine/engine_integ_test.go
@@ -127,6 +127,10 @@ func TestDockerStateToContainerState(t *testing.T) {
 	testTask := createTestTask("test_task")
 	container := testTask.Containers[0]
 
+	// let the container keep running to prevent the edge case where it's already stopped when we check whether
+	// it's running
+	container.Command = getLongRunningCommand()
+
 	client, err := sdkClient.NewClientWithOpts(sdkClient.WithHost(endpoint), sdkClient.WithVersion(sdkclientfactory.GetDefaultVersion().String()))
 	require.NoError(t, err, "Creating go docker client failed")
 

--- a/agent/engine/engine_windows_integ_test.go
+++ b/agent/engine/engine_windows_integ_test.go
@@ -66,6 +66,12 @@ func createTestContainer() *apicontainer.Container {
 	}
 }
 
+// getLongRunningCommand returns the command that keeps the container running for the container
+// that uses the default integ test image (microsoft/windowsservercore for windows)
+func getLongRunningCommand() []string {
+	return []string{"ping", "-t", "localhost"}
+}
+
 func createTestHostVolumeMountTask(tmpPath string) *apitask.Task {
 	testTask := createTestTask("testHostVolumeMount")
 	testTask.Volumes = []apitask.TaskVolume{{Name: "test-tmp", Volume: &taskresourcevolume.FSHostVolume{FSSourcePath: tmpPath}}}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->
### Summary
<!-- What does this pull request do? -->
Fix flakey integ test TestDockerStateToContainerState. Issue: https://github.com/aws/amazon-ecs-agent/issues/1899.

### Implementation details
<!-- How are the changes implemented? -->
During the workflow of TestDockerStateToContainerState, it starts a container and checks whether it's running by inspecting it. However, the container it starts exits immediately, so it's possible that when we check whether the container is running it's already stopped. This leads to flakey test as per https://github.com/aws/amazon-ecs-agent/issues/1899. Fixing by letting the container keep running rather than exit itself.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
