### PR TITLE
Fix a bug where network stats is not presented in container stats

### DIFF
--- a/agent/dockerclient/dockerapi/docker_client_test.go
+++ b/agent/dockerclient/dockerapi/docker_client_test.go
@@ -1049,7 +1049,7 @@ func (ms mockStream) Read(data []byte) (n int, err error) {
 func (ms mockStream) Close() error {
 	return nil
 }
-func waitForStats(t *testing.T, stat *types.Stats) {
+func waitForStats(t *testing.T, stat *types.StatsJSON) {
 	ctx, cancel := context.WithTimeout(context.TODO(), 10*time.Second)
 	defer cancel()
 	for {

--- a/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
+++ b/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
@@ -291,9 +291,9 @@ func (mr *MockDockerClientMockRecorder) StartContainer(arg0, arg1, arg2 interfac
 }
 
 // Stats mocks base method
-func (m *MockDockerClient) Stats(arg0 context.Context, arg1 string, arg2 time.Duration) (<-chan *types.Stats, error) {
+func (m *MockDockerClient) Stats(arg0 context.Context, arg1 string, arg2 time.Duration) (<-chan *types.StatsJSON, error) {
 	ret := m.ctrl.Call(m, "Stats", arg0, arg1, arg2)
-	ret0, _ := ret[0].(<-chan *types.Stats)
+	ret0, _ := ret[0].(<-chan *types.StatsJSON)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/agent/handlers/task_server_setup_test.go
+++ b/agent/handlers/task_server_setup_test.go
@@ -670,7 +670,8 @@ func TestV2ContainerStats(t *testing.T) {
 	statsEngine := mock_stats.NewMockEngine(ctrl)
 	ecsClient := mock_api.NewMockECSClient(ctrl)
 
-	dockerStats := &types.Stats{NumProcs: 2}
+	dockerStats := &types.StatsJSON{}
+	dockerStats.NumProcs = 2
 	gomock.InOrder(
 		state.EXPECT().GetTaskByIPAddress(remoteIP).Return(taskARN, true),
 		statsEngine.EXPECT().ContainerDockerStats(taskARN, containerID).Return(dockerStats, nil),
@@ -684,7 +685,7 @@ func TestV2ContainerStats(t *testing.T) {
 	res, err := ioutil.ReadAll(recorder.Body)
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusOK, recorder.Code)
-	var statsFromResult *types.Stats
+	var statsFromResult *types.StatsJSON
 	err = json.Unmarshal(res, &statsFromResult)
 	assert.NoError(t, err)
 	assert.Equal(t, dockerStats.NumProcs, statsFromResult.NumProcs)
@@ -712,7 +713,8 @@ func TestV2TaskStats(t *testing.T) {
 			statsEngine := mock_stats.NewMockEngine(ctrl)
 			ecsClient := mock_api.NewMockECSClient(ctrl)
 
-			dockerStats := &types.Stats{NumProcs: 2}
+			dockerStats := &types.StatsJSON{}
+			dockerStats.NumProcs = 2
 			containerMap := map[string]*apicontainer.DockerContainer{
 				containerName: {
 					DockerID: containerID,
@@ -732,7 +734,7 @@ func TestV2TaskStats(t *testing.T) {
 			res, err := ioutil.ReadAll(recorder.Body)
 			assert.NoError(t, err)
 			assert.Equal(t, http.StatusOK, recorder.Code)
-			var statsFromResult map[string]*types.Stats
+			var statsFromResult map[string]*types.StatsJSON
 			err = json.Unmarshal(res, &statsFromResult)
 			assert.NoError(t, err)
 			containerStats, ok := statsFromResult[containerID]
@@ -938,7 +940,8 @@ func TestV3TaskStats(t *testing.T) {
 	statsEngine := mock_stats.NewMockEngine(ctrl)
 	ecsClient := mock_api.NewMockECSClient(ctrl)
 
-	dockerStats := &types.Stats{NumProcs: 2}
+	dockerStats := &types.StatsJSON{}
+	dockerStats.NumProcs = 2
 
 	containerMap := map[string]*apicontainer.DockerContainer{
 		containerName: {
@@ -959,7 +962,7 @@ func TestV3TaskStats(t *testing.T) {
 	res, err := ioutil.ReadAll(recorder.Body)
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusOK, recorder.Code)
-	var statsFromResult map[string]*types.Stats
+	var statsFromResult map[string]*types.StatsJSON
 	err = json.Unmarshal(res, &statsFromResult)
 	assert.NoError(t, err)
 	containerStats, ok := statsFromResult[containerID]
@@ -976,7 +979,8 @@ func TestV3ContainerStats(t *testing.T) {
 	statsEngine := mock_stats.NewMockEngine(ctrl)
 	ecsClient := mock_api.NewMockECSClient(ctrl)
 
-	dockerStats := &types.Stats{NumProcs: 2}
+	dockerStats := &types.StatsJSON{}
+	dockerStats.NumProcs = 2
 
 	gomock.InOrder(
 		state.EXPECT().TaskARNByV3EndpointID(v3EndpointID).Return(taskARN, true),
@@ -991,7 +995,7 @@ func TestV3ContainerStats(t *testing.T) {
 	res, err := ioutil.ReadAll(recorder.Body)
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusOK, recorder.Code)
-	var statsFromResult *types.Stats
+	var statsFromResult *types.StatsJSON
 	err = json.Unmarshal(res, &statsFromResult)
 	assert.NoError(t, err)
 	assert.Equal(t, dockerStats.NumProcs, statsFromResult.NumProcs)

--- a/agent/handlers/v2/stats_response.go
+++ b/agent/handlers/v2/stats_response.go
@@ -24,7 +24,7 @@ import (
 // NewTaskStatsResponse returns a new task stats response object
 func NewTaskStatsResponse(taskARN string,
 	state dockerstate.TaskEngineState,
-	statsEngine stats.Engine) (map[string]*types.Stats, error) {
+	statsEngine stats.Engine) (map[string]*types.StatsJSON, error) {
 
 	containerMap, ok := state.ContainerMapByArn(taskARN)
 	if !ok {
@@ -33,7 +33,7 @@ func NewTaskStatsResponse(taskARN string,
 			taskARN)
 	}
 
-	resp := make(map[string]*types.Stats)
+	resp := make(map[string]*types.StatsJSON)
 	for _, dockerContainer := range containerMap {
 		containerID := dockerContainer.DockerID
 		dockerStats, err := statsEngine.ContainerDockerStats(taskARN, containerID)

--- a/agent/handlers/v2/stats_response_test.go
+++ b/agent/handlers/v2/stats_response_test.go
@@ -33,7 +33,8 @@ func TestTaskStatsResponseSuccess(t *testing.T) {
 	state := mock_dockerstate.NewMockTaskEngineState(ctrl)
 	statsEngine := mock_stats.NewMockEngine(ctrl)
 
-	dockerStats := &types.Stats{NumProcs: 2}
+	dockerStats := &types.StatsJSON{}
+	dockerStats.NumProcs = 2
 	containerMap := map[string]*apicontainer.DockerContainer{
 		containerName: {
 			DockerID: containerID,

--- a/agent/stats/container_test.go
+++ b/agent/stats/container_test.go
@@ -56,12 +56,12 @@ func TestContainerStatsCollection(t *testing.T) {
 
 	dockerID := "container1"
 	ctx, cancel := context.WithCancel(context.TODO())
-	statChan := make(chan *types.Stats)
+	statChan := make(chan *types.StatsJSON)
 	mockDockerClient.EXPECT().Stats(ctx, dockerID, dockerclient.StatsInactivityTimeout).Return(statChan, nil)
 	go func() {
 		for _, stat := range statsData {
 			// doing this with json makes me sad, but is the easiest way to
-			// deal with the types.Stats.MemoryStats inner struct
+			// deal with the types.StatsJSON.MemoryStats inner struct
 			jsonStat := fmt.Sprintf(`
 				{
 					"memory_stats": {"usage":%d, "privateworkingset":%d},
@@ -72,7 +72,7 @@ func TestContainerStatsCollection(t *testing.T) {
 						}
 					}
 				}`, stat.memBytes, stat.memBytes, stat.cpuTime, stat.cpuTime)
-			dockerStat := &types.Stats{}
+			dockerStat := &types.StatsJSON{}
 			json.Unmarshal([]byte(jsonStat), dockerStat)
 			dockerStat.Read = stat.timestamp
 			statChan <- dockerStat
@@ -134,9 +134,9 @@ func TestContainerStatsCollectionReconnection(t *testing.T) {
 	dockerID := "container1"
 	ctx, cancel := context.WithCancel(context.TODO())
 
-	statChan := make(chan *types.Stats)
+	statChan := make(chan *types.StatsJSON)
 	statErr := fmt.Errorf("test error")
-	closedChan := make(chan *types.Stats)
+	closedChan := make(chan *types.StatsJSON)
 	close(closedChan)
 
 	mockContainer := &apicontainer.DockerContainer{
@@ -176,7 +176,7 @@ func TestContainerStatsCollectionStopsIfContainerIsTerminal(t *testing.T) {
 	dockerID := "container1"
 	ctx, cancel := context.WithCancel(context.TODO())
 
-	closedChan := make(chan *types.Stats)
+	closedChan := make(chan *types.StatsJSON)
 	close(closedChan)
 
 	statsErr := fmt.Errorf("test error")

--- a/agent/stats/engine.go
+++ b/agent/stats/engine.go
@@ -63,7 +63,7 @@ type DockerContainerMetadataResolver struct {
 // defined to make testing easier.
 type Engine interface {
 	GetInstanceMetrics() (*ecstcs.MetricsMetadata, []*ecstcs.TaskMetric, error)
-	ContainerDockerStats(taskARN string, containerID string) (*types.Stats, error)
+	ContainerDockerStats(taskARN string, containerID string) (*types.StatsJSON, error)
 	GetTaskHealthMetrics() (*ecstcs.HealthMetadata, []*ecstcs.TaskHealth, error)
 }
 
@@ -648,7 +648,7 @@ func (engine *DockerStatsEngine) resetStatsUnsafe() {
 }
 
 // ContainerDockerStats returns the last stored raw docker stats object for a container
-func (engine *DockerStatsEngine) ContainerDockerStats(taskARN string, containerID string) (*types.Stats, error) {
+func (engine *DockerStatsEngine) ContainerDockerStats(taskARN string, containerID string) (*types.StatsJSON, error) {
 	engine.lock.RLock()
 	defer engine.lock.RUnlock()
 

--- a/agent/stats/engine_test.go
+++ b/agent/stats/engine_test.go
@@ -52,7 +52,7 @@ func TestStatsEngineAddRemoveContainers(t *testing.T) {
 	resolver.EXPECT().ResolveContainer(gomock.Any()).AnyTimes().Return(&apicontainer.DockerContainer{
 		Container: &apicontainer.Container{},
 	}, nil)
-	mockStatsChannel := make(chan *types.Stats)
+	mockStatsChannel := make(chan *types.StatsJSON)
 	defer close(mockStatsChannel)
 	mockDockerClient.EXPECT().Stats(gomock.Any(), gomock.Any(), gomock.Any()).Return(mockStatsChannel, nil).AnyTimes()
 
@@ -194,14 +194,9 @@ func TestStatsEngineMetadataInStatsSets(t *testing.T) {
 		{22400432, 1839104, ts1},
 		{116499979, 3649536, ts2},
 	}
-	dockerStats := []*types.Stats{
-		{
-			Read: ts1,
-		},
-		{
-			Read: ts2,
-		},
-	}
+	dockerStats := []*types.StatsJSON{{}, {},}
+	dockerStats[0].Read = ts1
+	dockerStats[1].Read = ts2
 	containers, _ := engine.tasksToContainers["t1"]
 	for _, statsContainer := range containers {
 		for i := 0; i < 2; i++ {
@@ -398,7 +393,7 @@ func TestSynchronizeOnRestart(t *testing.T) {
 	defer ctrl.Finish()
 
 	containerID := "containerID"
-	statsChan := make(chan *types.Stats)
+	statsChan := make(chan *types.StatsJSON)
 	statsStarted := make(chan struct{})
 	client := mock_dockerapi.NewMockDockerClient(ctrl)
 	resolver := mock_resolver.NewMockContainerMetadataResolver(ctrl)

--- a/agent/stats/mock/engine.go
+++ b/agent/stats/mock/engine.go
@@ -49,9 +49,9 @@ func (m *MockEngine) EXPECT() *MockEngineMockRecorder {
 }
 
 // ContainerDockerStats mocks base method
-func (m *MockEngine) ContainerDockerStats(arg0, arg1 string) (*types.Stats, error) {
+func (m *MockEngine) ContainerDockerStats(arg0, arg1 string) (*types.StatsJSON, error) {
 	ret := m.ctrl.Call(m, "ContainerDockerStats", arg0, arg1)
-	ret0, _ := ret[0].(*types.Stats)
+	ret0, _ := ret[0].(*types.StatsJSON)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/agent/stats/queue.go
+++ b/agent/stats/queue.go
@@ -36,7 +36,7 @@ type Queue struct {
 	buffer        []UsageStats
 	maxSize       int
 	lastResetTime time.Time
-	lastStat      *types.Stats
+	lastStat      *types.StatsJSON
 	lock          sync.RWMutex
 }
 
@@ -57,7 +57,7 @@ func (queue *Queue) Reset() {
 }
 
 // Add adds a new set of container stats to the queue.
-func (queue *Queue) Add(dockerStat *types.Stats) error {
+func (queue *Queue) Add(dockerStat *types.StatsJSON) error {
 	queue.setLastStat(dockerStat)
 	stat, err := dockerStatsToContainerStats(dockerStat)
 	if err != nil {
@@ -67,7 +67,7 @@ func (queue *Queue) Add(dockerStat *types.Stats) error {
 	return nil
 }
 
-func (queue *Queue) setLastStat(stat *types.Stats) {
+func (queue *Queue) setLastStat(stat *types.StatsJSON) {
 	queue.lock.Lock()
 	defer queue.lock.Unlock()
 
@@ -108,7 +108,7 @@ func (queue *Queue) add(rawStat *ContainerStats) {
 }
 
 // GetLastStat returns the last recorded raw statistics object from docker
-func (queue *Queue) GetLastStat() *types.Stats {
+func (queue *Queue) GetLastStat() *types.StatsJSON {
 	queue.lock.RLock()
 	defer queue.lock.RUnlock()
 

--- a/agent/stats/utils_test.go
+++ b/agent/stats/utils_test.go
@@ -56,7 +56,7 @@ func TestDockerStatsToContainerStatsMemUsage(t *testing.T) {
 				"privateworkingset": %d
 			}
 		}`, 1, 2, 3, 4, 100, 30, 100, 20, 10, 10)
-	dockerStat := &types.Stats{}
+	dockerStat := &types.StatsJSON{}
 	json.Unmarshal([]byte(jsonStat), dockerStat)
 	containerStats, err := dockerStatsToContainerStats(dockerStat)
 	if err != nil {

--- a/agent/stats/utils_unix.go
+++ b/agent/stats/utils_unix.go
@@ -22,7 +22,7 @@ import (
 )
 
 // dockerStatsToContainerStats returns a new object of the ContainerStats object from docker stats.
-func dockerStatsToContainerStats(dockerStats *types.Stats) (*ContainerStats, error) {
+func dockerStatsToContainerStats(dockerStats *types.StatsJSON) (*ContainerStats, error) {
 	// The length of PercpuUsage represents the number of cores in an instance.
 	if len(dockerStats.CPUStats.CPUUsage.PercpuUsage) == 0 || numCores == uint64(0) {
 		seelog.Debug("Invalid container statistics reported, no cpu core usage reported")

--- a/agent/stats/utils_unix_test.go
+++ b/agent/stats/utils_unix_test.go
@@ -35,7 +35,7 @@ func TestDockerStatsToContainerStatsZeroCoresGeneratesError(t *testing.T) {
 				}
 			}
 		}`, 100)
-	dockerStat := &types.Stats{}
+	dockerStat := &types.StatsJSON{}
 	json.Unmarshal([]byte(jsonStat), dockerStat)
 	_, err := dockerStatsToContainerStats(dockerStat)
 	assert.Error(t, err, "expected error converting container stats with empty PercpuUsage")
@@ -57,7 +57,7 @@ func TestDockerStatsToContainerStatsCpuUsage(t *testing.T) {
 				}
 			}
 		}`, 1, 2, 3, 4, 100)
-	dockerStat := &types.Stats{}
+	dockerStat := &types.StatsJSON{}
 	json.Unmarshal([]byte(jsonStat), dockerStat)
 	containerStats, err := dockerStatsToContainerStats(dockerStat)
 	assert.NoError(t, err, "converting container stats failed")

--- a/agent/stats/utils_windows.go
+++ b/agent/stats/utils_windows.go
@@ -22,7 +22,7 @@ import (
 )
 
 // dockerStatsToContainerStats returns a new object of the ContainerStats object from docker stats.
-func dockerStatsToContainerStats(dockerStats *types.Stats) (*ContainerStats, error) {
+func dockerStatsToContainerStats(dockerStats *types.StatsJSON) (*ContainerStats, error) {
 	if numCores == uint64(0) {
 		seelog.Error("Invalid number of cpu cores acquired from the system")
 		return nil, fmt.Errorf("invalid number of cpu cores acquired from the system")

--- a/agent/stats/utils_windows_test.go
+++ b/agent/stats/utils_windows_test.go
@@ -34,7 +34,7 @@ func TestDockerStatsToContainerStatsZeroCoresGeneratesError(t *testing.T) {
 				}
 			}
 		}`, 100)
-	dockerStat := &types.Stats{}
+	dockerStat := &types.StatsJSON{}
 	json.Unmarshal([]byte(jsonStat), dockerStat)
 	_, err := dockerStatsToContainerStats(dockerStat)
 	assert.Error(t, err, "expected error converting container stats with zero cpu cores")
@@ -55,7 +55,7 @@ func TestDockerStatsToContainerStatsCpuUsage(t *testing.T) {
 				}
 			}
 		}`, 100)
-	dockerStat := &types.Stats{}
+	dockerStat := &types.StatsJSON{}
 	json.Unmarshal([]byte(jsonStat), dockerStat)
 	containerStats, err := dockerStatsToContainerStats(dockerStat)
 	assert.NoError(t, err, "converting container stats failed")

--- a/agent/tcs/client/client_test.go
+++ b/agent/tcs/client/client_test.go
@@ -56,7 +56,7 @@ func (*mockStatsEngine) GetInstanceMetrics() (*ecstcs.MetricsMetadata, []*ecstcs
 	return nil, nil, fmt.Errorf("uninitialized")
 }
 
-func (*mockStatsEngine) ContainerDockerStats(taskARN string, id string) (*types.Stats, error) {
+func (*mockStatsEngine) ContainerDockerStats(taskARN string, id string) (*types.StatsJSON, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 
@@ -70,7 +70,7 @@ func (*emptyStatsEngine) GetInstanceMetrics() (*ecstcs.MetricsMetadata, []*ecstc
 	return nil, nil, fmt.Errorf("empty stats")
 }
 
-func (*emptyStatsEngine) ContainerDockerStats(taskARN string, id string) (*types.Stats, error) {
+func (*emptyStatsEngine) ContainerDockerStats(taskARN string, id string) (*types.StatsJSON, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 
@@ -90,7 +90,7 @@ func (*idleStatsEngine) GetInstanceMetrics() (*ecstcs.MetricsMetadata, []*ecstcs
 	return metadata, []*ecstcs.TaskMetric{}, nil
 }
 
-func (*idleStatsEngine) ContainerDockerStats(taskARN string, id string) (*types.Stats, error) {
+func (*idleStatsEngine) ContainerDockerStats(taskARN string, id string) (*types.StatsJSON, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 
@@ -118,7 +118,7 @@ func (engine *nonIdleStatsEngine) GetInstanceMetrics() (*ecstcs.MetricsMetadata,
 	return metadata, taskMetrics, nil
 }
 
-func (*nonIdleStatsEngine) ContainerDockerStats(taskARN string, id string) (*types.Stats, error) {
+func (*nonIdleStatsEngine) ContainerDockerStats(taskARN string, id string) (*types.StatsJSON, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 

--- a/agent/tcs/handler/handler_test.go
+++ b/agent/tcs/handler/handler_test.go
@@ -65,7 +65,7 @@ func (*mockStatsEngine) GetInstanceMetrics() (*ecstcs.MetricsMetadata, []*ecstcs
 	return req.Metadata, req.TaskMetrics, nil
 }
 
-func (*mockStatsEngine) ContainerDockerStats(taskARN string, id string) (*types.Stats, error) {
+func (*mockStatsEngine) ContainerDockerStats(taskARN string, id string) (*types.StatsJSON, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 

--- a/misc/taskmetadata-validator/taskmetadata-validator.go
+++ b/misc/taskmetadata-validator/taskmetadata-validator.go
@@ -157,7 +157,7 @@ func containerMetadata(client *http.Client, id string) (*ContainerResponse, erro
 	return &containerMetadata, nil
 }
 
-func taskStats(client *http.Client) (map[string]*types.Stats, error) {
+func taskStats(client *http.Client) (map[string]*types.StatsJSON, error) {
 	body, err := metadataResponse(client, v2StatsEndpoint, "task stats")
 	if err != nil {
 		return nil, err
@@ -165,7 +165,7 @@ func taskStats(client *http.Client) (map[string]*types.Stats, error) {
 
 	fmt.Printf("Received task stats: %s \n", string(body))
 
-	var taskStats map[string]*types.Stats
+	var taskStats map[string]*types.StatsJSON
 	err = json.Unmarshal(body, &taskStats)
 	if err != nil {
 		return nil, fmt.Errorf("task stats: unable to parse response body: %v", err)
@@ -174,7 +174,7 @@ func taskStats(client *http.Client) (map[string]*types.Stats, error) {
 	return taskStats, nil
 }
 
-func containerStats(client *http.Client, id string) (*types.Stats, error) {
+func containerStats(client *http.Client, id string) (*types.StatsJSON, error) {
 	body, err := metadataResponse(client, v2StatsEndpoint+"/"+id, "container stats")
 	if err != nil {
 		return nil, err
@@ -182,7 +182,7 @@ func containerStats(client *http.Client, id string) (*types.Stats, error) {
 
 	fmt.Printf("Received container stats: %s \n", string(body))
 
-	var containerStats types.Stats
+	var containerStats types.StatsJSON
 	err = json.Unmarshal(body, &containerStats)
 	if err != nil {
 		return nil, fmt.Errorf("container stats: unable to parse response body: %v", err)

--- a/misc/v3-task-endpoint-validator-windows/setup-v3-task-endpoint-validator.ps1
+++ b/misc/v3-task-endpoint-validator-windows/setup-v3-task-endpoint-validator.ps1
@@ -17,6 +17,7 @@ $ErrorActionPreference = 'Stop'
 Invoke-Expression ${PSScriptRoot}\..\windows-deploy\hostsetup.ps1
 
 # Create amazon/amazon-ecs-v3-task-endpoint-validator-windows for tests
+Invoke-Expression "go get github.com/docker/docker/api/types github.com/pkg/errors"
 Invoke-Expression "go build -o ${PSScriptRoot}\v3-task-endpoint-validator-windows.exe ${PSScriptRoot}\v3-task-endpoint-validator-windows.go" 
 Invoke-Expression "docker build -t amazon/amazon-ecs-v3-task-endpoint-validator-windows --file ${PSScriptRoot}\v3-task-endpoint-validator-windows.dockerfile ${PSScriptRoot}"
 $ErrorActionPreference = $oldPref


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Fix a bug where network stats are not presented in container stats.

### Implementation details
<!-- How are the changes implemented? -->
When switching to use Docker Go SDK, we used [types.Stats](https://github.com/docker/go-docker/blob/master/api/types/stats.go#L153) to save the stats response from corresponding Docker Engine API. This struct doesn't contain all fields in the API response, notably the "networks" field is missing and therefore the field isn't presented in container stats response. This field was populated when we were using fsouza/go-dockerclient prior to v1.24.0. Fixing it by changing to use [types.StatsJSON](https://github.com/docker/go-docker/blob/master/api/types/stats.go#L173) struct which contains the "networks" field along with fields in types.Stats. 

Related issue: https://github.com/aws/amazon-ecs-agent/issues/1927

#### Backward compatibility
Since types.StatsJSON contains strictly more fields than types.Stats, this change should be backward compatible.

#### Docker engine api version
The "networks" field is added in Docker Engine API version 1.21, corresponding to Docker version 1.9.x. Since we already deprecated support for Docker version older than 1.9 we should always expect the field to be presented.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes

The "networks" field will be populated by Docker in bridge network mode on Linux, and nat network mode on Windows. Related v3 metadata functional tests are updated to check that the field is populated in those modes (v2 metadata is not affected since it only works for awsvpc network mode). Also did manual tests to verify that it works.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Bug - Fixed a bug where network stats are not presented in container stats

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
