### PR TITLE
 Pass GOARCH in vpc plugin build target to support multi-arch build

### DIFF
--- a/agent/ecscni/plugin.go
+++ b/agent/ecscni/plugin.go
@@ -36,7 +36,7 @@ const (
 	// ECSCNIVersion, ECSCNIGitHash, VPCCNIGitHash needs to be updated every time CNI plugin is updated
 	currentECSCNIVersion = "2018.10.0"
 	currentECSCNIGitHash = "93f4377604504bff92e7555da73b0cba732a4fbb"
-	currentVPCCNIGitHash = "76973f587f9dfb0b40092a78fb5623c9547bc647"
+	currentVPCCNIGitHash = "8b5e552209b0009aecf3c60568b5a5041c6342c0"
 )
 
 // CNIClient defines the method of setting/cleaning up container namespace

--- a/scripts/dockerfiles/Dockerfile.buildVPCCNIPlugins
+++ b/scripts/dockerfiles/Dockerfile.buildVPCCNIPlugins
@@ -14,6 +14,10 @@
 FROM golang:1.10
 MAINTAINER Amazon Web Services, Inc.
 
+ARG GOARCH
+
+ENV GOARCH ${GOARCH}
+
 RUN mkdir -p /go/src/github.com/aws/
 
 WORKDIR /go/src/github.com/aws/amazon-vpc-cni-plugins


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
We need to have Feng's change to pass GOARCH to vpc plugin build for aws-vpc-plugins package.
Existing aws-appmesh added GOARCH to its makefile build target from this [pr](https://github.com/aws/amazon-vpc-cni-plugins/pull/7)

### Implementation details
<!-- How are the changes implemented? -->
1. Cherry-picked Feng's commit from https://github.com/aws/amazon-ecs-agent/pull/1920 
2. Update sha for aws-vpc-plugins

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes

Manually tested to build on arm64 and amd64 and run an appmesh task. Both agents are able to invoke aws-appmesh binary.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
