### PR TITLE
Updating secret name used in ftest to the one created from test autom…

### DIFF
--- a/agent/functional_tests/tests/functionaltests_unix_test.go
+++ b/agent/functional_tests/tests/functionaltests_unix_test.go
@@ -1283,7 +1283,7 @@ func TestASMSecretsARN(t *testing.T) {
 		t.Skip("Skip TestASMSecretsARN in China partition")
 	}
 
-	secret := "FunctionalTest-SSMSecretsSecretFromASM"
+	secret := "FunctionalTest-SSMSecretsEncryptedASMSecrets"
 	asmClient := secretsmanager.New(session.New(), aws.NewConfig().WithRegion(*ECS.Config.Region))
 	input := &secretsmanager.CreateSecretInput{
 		Description:  aws.String("Resource created for the ECS Agent Functional Test: TestASMSecretsARN"),

--- a/agent/functional_tests/tests/functionaltests_unix_test.go
+++ b/agent/functional_tests/tests/functionaltests_unix_test.go
@@ -1231,12 +1231,12 @@ func TestSSMSecretsEncryptedASMSecrets(t *testing.T) {
 		t.Skip("Skip TestSSMSecretsEncryptedParameter in China partition")
 	}
 
-	parameterName := "/aws/reference/secretsmanager/FunctionalTest-SSMSecretsSecretFromASM"
+	parameterName := "/aws/reference/secretsmanager/FunctionalTest-SSMSecretsEncryptedASMSecrets"
 	secretName := "SECRET_NAME"
 	asmClient := secretsmanager.New(session.New(), aws.NewConfig().WithRegion(*ECS.Config.Region))
 	input := &secretsmanager.CreateSecretInput{
 		Description:  aws.String("Resource created for the ECS Agent Functional Test: TestSSMSecretsEncryptedASMSecrets"),
-		Name:         aws.String("FunctionalTest-SSMSecretsSecretFromASM"),
+		Name:         aws.String("FunctionalTest-SSMSecretsEncryptedASMSecrets"),
 		SecretString: aws.String("secretValue"),
 	}
 
@@ -1246,7 +1246,7 @@ func TestSSMSecretsEncryptedASMSecrets(t *testing.T) {
 		if aerr, ok := err.(awserr.Error); ok {
 			switch aerr.Code() {
 			case secretsmanager.ErrCodeResourceExistsException:
-				t.Logf("Secret FunctionalTest-SSMSecretsSecretFromASM already exists in AWS Secrets Manager")
+				t.Logf("Secret FunctionalTest-SSMSecretsEncryptedASMSecrets already exists in AWS Secrets Manager")
 				break
 			default:
 				require.NoError(t, err, "Secrets Manager CreateSecret call failed")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
functional test case is referring to outdated resource name, updated it to use the latest one.

### Implementation details
ftest resource name updated

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
