### PR TITLE
Skipping ftest requiring public IP for now

### DIFF
--- a/agent/functional_tests/tests/functionaltests_test.go
+++ b/agent/functional_tests/tests/functionaltests_test.go
@@ -759,6 +759,11 @@ func testContainerMetadataFile(t *testing.T, taskName, awslogsPrefix string) {
 	// TODO: Bump version to 1.24.0 (or next release after 1.23.0)
 	agent.RequireVersion(">=1.22.0")
 
+	ec2MetadataClient := ec2.NewEC2MetadataClient(nil)
+	if ec2MetadataClient.PublicIPv4Address() == "" {
+		t.Skip("Skipping test, instance does not have PublicIPv4 Address")
+	}
+
 	tdOverrides := make(map[string]string)
 	tdOverrides["$$$TEST_REGION$$$"] = *ECS.Config.Region
 	tdOverrides["$$$TEST_AWSLOGS_STREAM_PREFIX$$$"] = awslogsPrefix


### PR DESCRIPTION
We've changed to run tests in private vpc, this will be reviewed later.

### Summary
temporarily skipping testContainerMetadataFile, this gets run in public vpc during ami build

### Implementation details
skip if public IPv4 address is not available

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: NA

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
