### PR TITLE
Fix for TestStatsEngineWithNewContainersWithPolling

### DIFF
--- a/agent/stats/engine_integ_test.go
+++ b/agent/stats/engine_integ_test.go
@@ -344,8 +344,10 @@ func TestStatsEngineWithNewContainersWithPolling(t *testing.T) {
 	// additional config fields to use polling instead of stream
 	cfg.PollMetrics = true
 	cfg.PollingMetricsWaitDuration = 1 * time.Second
+	// Create a new docker client with new config
+	dockerClientForNewContainersWithPolling, _  := dockerapi.NewDockerGoClient(sdkClientFactory, &cfg, ctx)
 	// Create a new docker stats engine
-	engine := NewDockerStatsEngine(&cfg, dockerClient, eventStream("TestStatsEngineWithNewContainers"))
+	engine := NewDockerStatsEngine(&cfg, dockerClientForNewContainersWithPolling, eventStream("TestStatsEngineWithNewContainers"))
 	defer engine.removeAll()
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
@@ -396,7 +398,7 @@ func TestStatsEngineWithNewContainersWithPolling(t *testing.T) {
 	assert.NoError(t, err, "failed to write to container change event stream")
 
 	// Wait for the stats collection go routine to start.
-	time.Sleep(checkPointSleep)
+	time.Sleep(10 * SleepBetweenUsageDataCollection)
 	validateInstanceMetrics(t, engine)
 	// Verify the health metrics of container
 	validateTaskHealthMetrics(t, engine)


### PR DESCRIPTION
Stats collection takes some more time to start and that is why
increasing the wait time. After making this change, I ran the test 50 times in both windows and linux and the test passes each time.


### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
