### PR TITLE
Export SHAs docker hub image

### DIFF
--- a/scripts/publish-docker-images
+++ b/scripts/publish-docker-images
@@ -35,11 +35,11 @@ usage() {
 	echo
 	echo "Options"
 	echo "  -d  true|false  Dryrun (default is true)"
-	echo "  -p  PROFILE	 AWS CLI Profile (default is none)"
-	echo "  -s  BUCKET	  AWS S3 Bucket for staging"
-	echo "  -i  IMAGE	   Docker image name"
-	echo "	-f  FILE PATH	Path to file where manifest JSON output is stored"
-	echo "  -h			  Display this help message"
+	echo "  -p  PROFILE	 	AWS CLI Profile (default is none)"
+	echo "  -s  BUCKET	  	AWS S3 Bucket for staging"
+	echo "  -i  IMAGE	   	Docker image name"
+	echo "	-f  FILE_PATH	Path to file where manifest JSON output is stored"
+	echo "  -h			  	Display this help message"
 }
 
 verify_md5() {
@@ -63,17 +63,17 @@ push_linux_amd_agent_docker_hub() {
 	s3_cp "s3://${STAGE_S3_BUCKET}/ecs-agent-${IMAGE_TAG_SHA}.tar.md5" "${tarball_md5}"
 	echo "Checking ecs-agent-${IMAGE_TAG_SHA}.tar md5 sum against ecs-agent-${IMAGE_TAG_SHA}.tar.md5"
 
-	verify_md5 ${tarball} ${tarball_md5}
+	verify_md5 "${tarball}" "${tarball_md5}"
 	echo "md5sum Check Successful"
 
 	# Pushing to docker hub
 	docker load < "${tarball}"
-	for image_tag in ${IMAGE_TAG_VERSION_AMD} ${IMAGE_TAG_SHA_AMD} ${IMAGE_TAG_LATEST_AMD}; do
-		tag_and_push_docker ${IMAGE_NAME} ${image_tag}
+	for image_tag in "${IMAGE_TAG_VERSION_AMD}" "${IMAGE_TAG_SHA_AMD}" "${IMAGE_TAG_LATEST_AMD}"; do
+		tag_and_push_docker "${IMAGE_NAME}" "${image_tag}"
 	done
 
-	rm ${tarball}
-	rm ${tarball_md5}
+	rm "${tarball}"
+	rm "${tarball_md5}"
 }
 
 push_linux_arm_agent_docker_hub() {
@@ -89,17 +89,17 @@ push_linux_arm_agent_docker_hub() {
 	s3_cp "s3://${STAGE_S3_BUCKET}/ecs-agent-arm64-${IMAGE_TAG_SHA}.tar.md5" "${tarball_md5_arm}"
 	echo "Checking ecs-agent-arm64-${IMAGE_TAG_SHA}.tar md5 sum against ecs-agent-arm64-${IMAGE_TAG_SHA}.tar.md5"
 
-	verify_md5 ${tarball_arm} ${tarball_md5_arm}
+	verify_md5 "${tarball_arm}" "${tarball_md5_arm}"
 	echo "md5sum Check Successful"
 
 	# Pushing to docker hub
 	docker load < "${tarball_arm}"
-	for image_tag in ${IMAGE_TAG_VERSION_ARM} ${IMAGE_TAG_SHA_ARM} ${IMAGE_TAG_LATEST_ARM}; do
-		tag_and_push_docker ${IMAGE_NAME} ${image_tag}
+	for image_tag in "${IMAGE_TAG_VERSION_ARM}" "${IMAGE_TAG_SHA_ARM}" "${IMAGE_TAG_LATEST_ARM}"; do
+		tag_and_push_docker "${IMAGE_NAME}" "${image_tag}"
 	done
 
-	rm ${tarball_arm}
-	rm ${tarball_md5_arm}
+	rm "${tarball_arm}"
+	rm "${tarball_md5_arm}"
 }
 
 push_multi-arch_manifest_docker_hub() {
@@ -111,17 +111,15 @@ push_multi-arch_manifest_docker_hub() {
 
 	manifest_tool_dir="manifest-tool"
 	# Remove manifest-tool folder if it already exists
-	rm -rf ${manifest_tool_dir}
+	rm -rf "${manifest_tool_dir}"
 
-	manifest_tool_commit_id="6bcfccea0827b4ff930f2798440cfce6cd4f1318" # v0.9.0
 	# Clone the manifest-tool from github
-	git clone https://github.com/estesp/manifest-tool ${manifest_tool_dir}
-	cd ${manifest_tool_dir}
-	git checkout ${manifest_tool_commit_id}
+	git clone --depth 1 --branch v0.9.0 https://github.com/estesp/manifest-tool "${manifest_tool_dir}"
+
+	pushd "${manifest_tool_dir}"
 
 	make build
-
-	for image_tag in ${IMAGE_TAG_VERSION} ${IMAGE_TAG_SHA} ${IMAGE_TAG_LATEST}; do
+	for image_tag in "${IMAGE_TAG_VERSION}" "${IMAGE_TAG_SHA}" "${IMAGE_TAG_LATEST}"; do
 		# Replace the tags in multi-arch.yaml
 		sed -e "s/\${docker-image-tag}/${image_tag}/"  ../scripts/multi-arch.yaml > multi-arch-temp.yaml
 		# Generate the manifest list and push to docker hub
@@ -129,27 +127,31 @@ push_multi-arch_manifest_docker_hub() {
 		rm multi-arch-temp.yaml
 	done
 
+
 	# Create digest files
-	if [[ ! -z "${FILE_PATH}" ]]; then
-		if [[ -d "${FILE_PATH}" ]]; then
+	if [[ -n "${FILE_PATH}" ]]; then
 			echo "Creating digest files"
+			# Generate a combined JSON object for each image name with its
+			# manifest-tool output of the form:
+			#
+			# {
+			#    "amazon/amazon-ecs-agent:sha": [ ...inspected-manifest ],
+			# 	 "amazon/amazon-ecs-agent:arm64-sha": [ ...inspected-manifest ],
+			# 	 "amazon/amazon-ecs-agent:amd64-sha": [ ...inspected-manifest ]
+			# }
+			# The JSON is stored in a file passed in -f parameter
 
-			./manifest-tool inspect --raw "${IMAGE_NAME}:${IMAGE_TAG_LATEST}" \
-				> "${FILE_PATH}/${IMAGE_TAG_SHA}-digest.json"
-
-			./manifest-tool inspect --raw "${IMAGE_NAME}:${IMAGE_TAG_LATEST_ARM}" \
-				> "${FILE_PATH}/${IMAGE_TAG_SHA_ARM}-digest.json"
-
-			./manifest-tool inspect --raw "${IMAGE_NAME}:${IMAGE_TAG_LATEST_AMD}" \
-				> "${FILE_PATH}/${IMAGE_TAG_SHA_AMD}-digest.json"
+			{
+				for v in "${IMAGE_TAG_SHA}" "${IMAGE_TAG_SHA_ARM}" "${IMAGE_TAG_SHA_AMD}"; do
+					./manifest-tool inspect --raw "${IMAGE_NAME}:${v}" | jq "{\"${IMAGE_NAME}:${v}\":.}"
+				done
+			} | jq -s add > "${FILE_PATH}"
 
 			echo "Digest file created"
-		else
-			echo "File path is not valid: ${FILE_PATH}"
-		fi
 	fi
 
-	rm -rf ${manifest_tool_dir}
+	popd
+	rm -rf "${manifest_tool_dir}"
 
 }
 

--- a/scripts/publish-docker-images
+++ b/scripts/publish-docker-images
@@ -21,8 +21,8 @@ IMAGE_NAME="amazon/amazon-ecs-agent"
 
 AWS_PROFILE=""
 STAGE_S3_BUCKET=""
-
-source $(dirname "${0}")/publishing-common.sh
+S3_ACL_OVERRIDE=""
+source scripts/publishing-common.sh
 
 usage() {
 	echo "Usage: ${0} -s BUCKET [OPTIONS]"
@@ -68,8 +68,10 @@ push_linux_amd_agent_docker_hub() {
 	# Pushing to docker hub
 	docker load < "${tarball}"
 	for image_tag in ${IMAGE_TAG_VERSION_AMD} ${IMAGE_TAG_SHA_AMD} ${IMAGE_TAG_LATEST_AMD}; do
-		tag_and_push_docker ${IMAGE_NAME} ${image_tag}
+		AMD_IMAGE_SHA=$(tag_and_push_docker ${IMAGE_NAME} ${image_tag})
 	done
+
+	export AMD_IMAGE_SHA
 
 	rm ${tarball}
 	rm ${tarball_md5}
@@ -94,8 +96,10 @@ push_linux_arm_agent_docker_hub() {
 	# Pushing to docker hub
 	docker load < "${tarball_arm}"
 	for image_tag in ${IMAGE_TAG_VERSION_ARM} ${IMAGE_TAG_SHA_ARM} ${IMAGE_TAG_LATEST_ARM}; do
-		tag_and_push_docker ${IMAGE_NAME} ${image_tag}
+		ARM_IMAGE_SHA=$(tag_and_push_docker ${IMAGE_NAME} ${image_tag})
 	done
+
+	export ARM_IMAGE_SHA
 
 	rm ${tarball_arm}
 	rm ${tarball_md5_arm}
@@ -123,9 +127,10 @@ push_multi-arch_manifest_docker_hub() {
 		# Replace the tags in multi-arch.yaml
 		sed -e "s/\${docker-image-tag}/${image_tag}/"  ../scripts/multi-arch.yaml > multi-arch-temp.yaml
 		# Generate the manifest list and push to docker hub
-		dryval ./manifest-tool push from-spec multi-arch-temp.yaml
+		MULTIARCH_IMAGE_SHA=$(dryval ./manifest-tool push from-spec multi-arch-temp.yaml)
 		rm multi-arch-temp.yaml
 	done
+	export MULTIARCH_IMAGE_SHA
 
 	rm -rf ${manifest_tool_dir}
 

--- a/scripts/publish-docker-images
+++ b/scripts/publish-docker-images
@@ -22,7 +22,8 @@ IMAGE_NAME="amazon/amazon-ecs-agent"
 AWS_PROFILE=""
 STAGE_S3_BUCKET=""
 S3_ACL_OVERRIDE=""
-source scripts/publishing-common.sh
+DIR="$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )"
+source ${DIR}/publishing-common.sh
 
 usage() {
 	echo "Usage: ${0} -s BUCKET [OPTIONS]"

--- a/scripts/publish-docker-images
+++ b/scripts/publish-docker-images
@@ -23,7 +23,11 @@ AWS_PROFILE=""
 STAGE_S3_BUCKET=""
 S3_ACL_OVERRIDE=""
 DIR="$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )"
-source ${DIR}/publishing-common.sh
+source "${DIR}/publishing-common.sh"
+
+AMD_IMAGE_SHA=""
+ARM_IMAGE_SHA=""
+MULTIARCH_IMAGE_SHA=""
 
 usage() {
 	echo "Usage: ${0} -s BUCKET [OPTIONS]"
@@ -72,8 +76,6 @@ push_linux_amd_agent_docker_hub() {
 		AMD_IMAGE_SHA=$(tag_and_push_docker ${IMAGE_NAME} ${image_tag} | tail -1 | cut -d" " -f3)
 	done
 
-	export AMD_IMAGE_SHA
-
 	rm ${tarball}
 	rm ${tarball_md5}
 }
@@ -99,8 +101,6 @@ push_linux_arm_agent_docker_hub() {
 	for image_tag in ${IMAGE_TAG_VERSION_ARM} ${IMAGE_TAG_SHA_ARM} ${IMAGE_TAG_LATEST_ARM}; do
 		ARM_IMAGE_SHA=$(tag_and_push_docker ${IMAGE_NAME} ${image_tag} | tail -1 | cut -d" " -f3)
 	done
-
-	export ARM_IMAGE_SHA
 
 	rm ${tarball_arm}
 	rm ${tarball_md5_arm}
@@ -132,7 +132,6 @@ push_multi-arch_manifest_docker_hub() {
 		MULTIARCH_IMAGE_SHA=$(dryval ./manifest-tool push from-spec multi-arch-temp.yaml| tail -1 | cut -d" " -f2)
 		rm multi-arch-temp.yaml
 	done
-	export MULTIARCH_IMAGE_SHA
 
 	rm -rf ${manifest_tool_dir}
 

--- a/scripts/publish-docker-images
+++ b/scripts/publish-docker-images
@@ -68,7 +68,7 @@ push_linux_amd_agent_docker_hub() {
 	# Pushing to docker hub
 	docker load < "${tarball}"
 	for image_tag in ${IMAGE_TAG_VERSION_AMD} ${IMAGE_TAG_SHA_AMD} ${IMAGE_TAG_LATEST_AMD}; do
-		AMD_IMAGE_SHA=$(tag_and_push_docker ${IMAGE_NAME} ${image_tag})
+		AMD_IMAGE_SHA=$(tag_and_push_docker ${IMAGE_NAME} ${image_tag} | tail -1 | cut -d" " -f3)
 	done
 
 	export AMD_IMAGE_SHA
@@ -96,7 +96,7 @@ push_linux_arm_agent_docker_hub() {
 	# Pushing to docker hub
 	docker load < "${tarball_arm}"
 	for image_tag in ${IMAGE_TAG_VERSION_ARM} ${IMAGE_TAG_SHA_ARM} ${IMAGE_TAG_LATEST_ARM}; do
-		ARM_IMAGE_SHA=$(tag_and_push_docker ${IMAGE_NAME} ${image_tag})
+		ARM_IMAGE_SHA=$(tag_and_push_docker ${IMAGE_NAME} ${image_tag} | tail -1 | cut -d" " -f3)
 	done
 
 	export ARM_IMAGE_SHA
@@ -127,7 +127,8 @@ push_multi-arch_manifest_docker_hub() {
 		# Replace the tags in multi-arch.yaml
 		sed -e "s/\${docker-image-tag}/${image_tag}/"  ../scripts/multi-arch.yaml > multi-arch-temp.yaml
 		# Generate the manifest list and push to docker hub
-		MULTIARCH_IMAGE_SHA=$(dryval ./manifest-tool push from-spec multi-arch-temp.yaml)
+
+		MULTIARCH_IMAGE_SHA=$(dryval ./manifest-tool push from-spec multi-arch-temp.yaml| tail -1 | cut -d" " -f2)
 		rm multi-arch-temp.yaml
 	done
 	export MULTIARCH_IMAGE_SHA

--- a/scripts/publish-docker-images
+++ b/scripts/publish-docker-images
@@ -21,13 +21,8 @@ IMAGE_NAME="amazon/amazon-ecs-agent"
 
 AWS_PROFILE=""
 STAGE_S3_BUCKET=""
-S3_ACL_OVERRIDE=""
-DIR="$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )"
-source "${DIR}/publishing-common.sh"
 
-AMD_IMAGE_SHA=""
-ARM_IMAGE_SHA=""
-MULTIARCH_IMAGE_SHA=""
+source $(dirname "${0}")/publishing-common.sh
 
 usage() {
 	echo "Usage: ${0} -s BUCKET [OPTIONS]"
@@ -43,6 +38,7 @@ usage() {
 	echo "  -p  PROFILE	 AWS CLI Profile (default is none)"
 	echo "  -s  BUCKET	  AWS S3 Bucket for staging"
 	echo "  -i  IMAGE	   Docker image name"
+	echo "	-f  FILE PATH	Path to file where manifest JSON output is stored"
 	echo "  -h			  Display this help message"
 }
 
@@ -73,7 +69,7 @@ push_linux_amd_agent_docker_hub() {
 	# Pushing to docker hub
 	docker load < "${tarball}"
 	for image_tag in ${IMAGE_TAG_VERSION_AMD} ${IMAGE_TAG_SHA_AMD} ${IMAGE_TAG_LATEST_AMD}; do
-		AMD_IMAGE_SHA=$(tag_and_push_docker ${IMAGE_NAME} ${image_tag} | tail -1 | cut -d" " -f3)
+		tag_and_push_docker ${IMAGE_NAME} ${image_tag}
 	done
 
 	rm ${tarball}
@@ -99,7 +95,7 @@ push_linux_arm_agent_docker_hub() {
 	# Pushing to docker hub
 	docker load < "${tarball_arm}"
 	for image_tag in ${IMAGE_TAG_VERSION_ARM} ${IMAGE_TAG_SHA_ARM} ${IMAGE_TAG_LATEST_ARM}; do
-		ARM_IMAGE_SHA=$(tag_and_push_docker ${IMAGE_NAME} ${image_tag} | tail -1 | cut -d" " -f3)
+		tag_and_push_docker ${IMAGE_NAME} ${image_tag}
 	done
 
 	rm ${tarball_arm}
@@ -124,21 +120,40 @@ push_multi-arch_manifest_docker_hub() {
 	git checkout ${manifest_tool_commit_id}
 
 	make build
+
 	for image_tag in ${IMAGE_TAG_VERSION} ${IMAGE_TAG_SHA} ${IMAGE_TAG_LATEST}; do
 		# Replace the tags in multi-arch.yaml
 		sed -e "s/\${docker-image-tag}/${image_tag}/"  ../scripts/multi-arch.yaml > multi-arch-temp.yaml
 		# Generate the manifest list and push to docker hub
-
-		MULTIARCH_IMAGE_SHA=$(dryval ./manifest-tool push from-spec multi-arch-temp.yaml| tail -1 | cut -d" " -f2)
+		dryval ./manifest-tool push from-spec multi-arch-temp.yaml
 		rm multi-arch-temp.yaml
 	done
+
+	# Create digest files
+	if [[ ! -z "${FILE_PATH}" ]]; then
+		if [[ -d "${FILE_PATH}" ]]; then
+			echo "Creating digest files"
+
+			./manifest-tool inspect --raw "${IMAGE_NAME}:${IMAGE_TAG_LATEST}" \
+				> "${FILE_PATH}/${IMAGE_TAG_SHA}-digest.json"
+
+			./manifest-tool inspect --raw "${IMAGE_NAME}:${IMAGE_TAG_LATEST_ARM}" \
+				> "${FILE_PATH}/${IMAGE_TAG_SHA_ARM}-digest.json"
+
+			./manifest-tool inspect --raw "${IMAGE_NAME}:${IMAGE_TAG_LATEST_AMD}" \
+				> "${FILE_PATH}/${IMAGE_TAG_SHA_AMD}-digest.json"
+
+			echo "Digest file created"
+		else
+			echo "File path is not valid: ${FILE_PATH}"
+		fi
+	fi
 
 	rm -rf ${manifest_tool_dir}
 
 }
 
-
-while getopts ":d:p:s:i" opt; do
+while getopts ":d:p:s:i:f:" opt; do
 	case ${opt} in
 		d)
 			if [[ "${OPTARG}" = "false" ]]; then
@@ -155,6 +170,9 @@ while getopts ":d:p:s:i" opt; do
 			;;
 		i)
 			IMAGE_NAME="${OPTARG}"
+			;;
+		f)
+			FILE_PATH="${OPTARG}"
 			;;
 		\?)
 			echo "Invalid option -${OPTARG}" >&2
@@ -174,7 +192,7 @@ while getopts ":d:p:s:i" opt; do
 done
 
 
-if [ -z "${STAGE_S3_BUCKET}" ]; then
+if [[ -z "${STAGE_S3_BUCKET}" ]]; then
 	usage
 	exit 1
 fi

--- a/scripts/publishing-common.sh
+++ b/scripts/publishing-common.sh
@@ -13,7 +13,8 @@
 # License for the specific language governing permissions and
 # limitations under the License.
 
-export VERSION=$(cat VERSION)
+DIR="$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )"
+export VERSION=$(cat ${DIR}/../VERSION)
 
 export IMAGE_TAG_LATEST="latest"
 export IMAGE_TAG_SHA=$(git rev-parse --short=8 HEAD)

--- a/scripts/publishing-common.sh
+++ b/scripts/publishing-common.sh
@@ -13,7 +13,7 @@
 # License for the specific language governing permissions and
 # limitations under the License.
 
-export VERSION=$(cat $(dirname "${0}")/../VERSION)
+export VERSION=$(cat VERSION)
 
 export IMAGE_TAG_LATEST="latest"
 export IMAGE_TAG_SHA=$(git rev-parse --short=8 HEAD)

--- a/scripts/publishing-common.sh
+++ b/scripts/publishing-common.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 DIR="$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )"
-export VERSION=$(cat ${DIR}/../VERSION)
+export VERSION=$(cat "${DIR}/../VERSION")
 
 export IMAGE_TAG_LATEST="latest"
 export IMAGE_TAG_SHA=$(git rev-parse --short=8 HEAD)

--- a/scripts/publishing-common.sh
+++ b/scripts/publishing-common.sh
@@ -18,14 +18,15 @@ export VERSION=$(cat "${DIR}/../VERSION")
 
 export IMAGE_TAG_LATEST="latest"
 export IMAGE_TAG_SHA=$(git rev-parse --short=8 HEAD)
+
 export IMAGE_TAG_VERSION="v${VERSION}"
 
-export IMAGE_TAG_LATEST_ARM="arm64-latest"
-export IMAGE_TAG_SHA_ARM="arm64-$(git rev-parse --short=8 HEAD)"
+export IMAGE_TAG_LATEST_ARM="arm64-${IMAGE_TAG_LATEST}"
+export IMAGE_TAG_SHA_ARM="arm64-${IMAGE_TAG_SHA}"
 export IMAGE_TAG_VERSION_ARM="arm64-v${VERSION}"
 
-export IMAGE_TAG_LATEST_AMD="amd64-latest"
-export IMAGE_TAG_SHA_AMD="amd64-$(git rev-parse --short=8 HEAD)"
+export IMAGE_TAG_LATEST_AMD="amd64-${IMAGE_TAG_LATEST}"
+export IMAGE_TAG_SHA_AMD="amd64-${IMAGE_TAG_SHA}"
 export IMAGE_TAG_VERSION_AMD="amd64-v${VERSION}"
 
 SUPPORTED_OSES=("linux" "windows")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
publish-docker-images now export SHAs of the uploaded image that can be used by other scripts.

### Implementation details
<!-- How are the changes implemented? -->

### Testing
The script is exporting the right SHAs.

Here is a sample run of the script(changed to use my personal docker hub account), I have added "echo" after export command to see the values of variables being exported:

```bash

88e9fe5231bf:amazon-ecs-agent shugy$ ./scripts/publish-docker-images -s codebuild-agent-source -d false

======================================================
Pushing linux amd images to docker hub
======================================================

Copying s3://codebuild-agent-source/ecs-agent-30c0caea.tar to /var/folders/8f/f7l_y7l96z53x4sm1zm2qm3s1srydb/T/tmp.qmVTdKvB
download: s3://codebuild-agent-source/ecs-agent-30c0caea.tar to ../../../../../../../var/folders/8f/f7l_y7l96z53x4sm1zm2qm3s1srydb/T/tmp.qmVTdKvB
Copying s3://codebuild-agent-source/ecs-agent-30c0caea.tar.md5 to /var/folders/8f/f7l_y7l96z53x4sm1zm2qm3s1srydb/T/tmp.otBbFnGn
download: s3://codebuild-agent-source/ecs-agent-30c0caea.tar.md5 to ../../../../../../../var/folders/8f/f7l_y7l96z53x4sm1zm2qm3s1srydb/T/tmp.otBbFnGn
Checking ecs-agent-30c0caea.tar md5 sum against ecs-agent-30c0caea.tar.md5
md5sum Check Successful
Loaded image: amazon/amazon-ecs-agent:latest
RUNNING: docker push shugy/amazon-ecs-agent:amd64-v1.26.0
RUNNING: docker push shugy/amazon-ecs-agent:amd64-30c0caea
RUNNING: docker push shugy/amazon-ecs-agent:amd64-latest
sha256:a10696b0fa9340ae408c6d5f5b5130e9afc5fe0916f8b65e56dfd92916edbf66 <==AMD_IMAGE_SHA

=======================================================
Pushing linux arm images to docker hub
=======================================================

Copying s3://codebuild-agent-source/ecs-agent-arm64-30c0caea.tar to /var/folders/8f/f7l_y7l96z53x4sm1zm2qm3s1srydb/T/tmp.QDSAKROr
download: s3://codebuild-agent-source/ecs-agent-arm64-30c0caea.tar to ../../../../../../../var/folders/8f/f7l_y7l96z53x4sm1zm2qm3s1srydb/T/tmp.QDSAKROr
Copying s3://codebuild-agent-source/ecs-agent-arm64-30c0caea.tar.md5 to /var/folders/8f/f7l_y7l96z53x4sm1zm2qm3s1srydb/T/tmp.zJxcECcM
download: s3://codebuild-agent-source/ecs-agent-arm64-30c0caea.tar.md5 to ../../../../../../../var/folders/8f/f7l_y7l96z53x4sm1zm2qm3s1srydb/T/tmp.zJxcECcM
Checking ecs-agent-arm64-30c0caea.tar md5 sum against ecs-agent-arm64-30c0caea.tar.md5
md5sum Check Successful
Loaded image: amazon/amazon-ecs-agent:latest
RUNNING: docker push shugy/amazon-ecs-agent:arm64-v1.26.0
RUNNING: docker push shugy/amazon-ecs-agent:arm64-30c0caea
RUNNING: docker push shugy/amazon-ecs-agent:arm64-latest
sha256:a10696b0fa9340ae408c6d5f5b5130e9afc5fe0916f8b65e56dfd92916edbf66 <==ARM_IMAGE_SHA


==========================================================
Pushing multi-arch manifest list to docker hub
==========================================================

Cloning into 'manifest-tool'...
remote: Enumerating objects: 4603, done.
remote: Total 4603 (delta 0), reused 0 (delta 0), pack-reused 4603
Receiving objects: 100% (4603/4603), 3.70 MiB | 9.51 MiB/s, done.
Resolving deltas: 100% (1919/1919), done.
Note: checking out '6bcfccea0827b4ff930f2798440cfce6cd4f1318'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b <new-branch-name>

HEAD is now at 6bcfcce Merge pull request #62 from estesp/prepare-v0.9.0
go build -ldflags "-X main.gitCommit="6bcfccea0827b4ff930f2798440cfce6cd4f1318"" -o manifest-tool github.com/estesp/manifest-tool
RUNNING: ./manifest-tool push from-spec multi-arch-temp.yaml
RUNNING: ./manifest-tool push from-spec multi-arch-temp.yaml
RUNNING: ./manifest-tool push from-spec multi-arch-temp.yaml
sha256:ca6b2f6e04f25e8c614a455cb72b544c5dff5a5cb9653a01900028dee6491388 <==MULTIARCH_IMAGE_SHA

```
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
