### PR TITLE
Skip checking public ip in TestContainerMetadataFile if needed

### DIFF
--- a/agent/functional_tests/testdata/taskdefinitions/container-metadata-file-validator-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/container-metadata-file-validator-windows/task-definition.json
@@ -12,6 +12,12 @@
         "retries": 2,
         "startPeriod": 1
       },
+      "environment": [
+        {
+          "name": "HAS_PUBLIC_IP",
+          "value": "$$$HAS_PUBLIC_IP$$$"
+        }
+      ],
       "entryPoint": ["powershell"],
       "command": ["$env:AWS_REGION=\"$$$TEST_REGION$$$\";.\\container-metadata-file-validator-windows.exe; exit $LASTEXITCODE"],
       "logConfiguration": {

--- a/agent/functional_tests/testdata/taskdefinitions/container-metadata-file-validator/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/container-metadata-file-validator/task-definition.json
@@ -11,6 +11,12 @@
         "retries": 2,
         "startPeriod": 1
       },
+      "environment": [
+        {
+          "name": "HAS_PUBLIC_IP",
+          "value": "$$$HAS_PUBLIC_IP$$$"
+        }
+      ],
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {

--- a/misc/container-metadata-file-validator/container-metadata-file-validator.go
+++ b/misc/container-metadata-file-validator/container-metadata-file-validator.go
@@ -20,17 +20,22 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strconv"
 	"time"
 )
 
 const (
 	containerMetadataFileEnvVar = "ECS_CONTAINER_METADATA_FILE"
+	hasPublicIpEnvVar           = "HAS_PUBLIC_IP"
 	MetadataInitialText         = "INITIAL"
 	MetadataReadyText           = "READY"
 )
 
 // MetadataStatus specifies the current update status of the metadata file.
 type MetadataStatus int32
+
+// hasPublicIp indicates whether the test is run on an instance that has public ip
+var hasPublicIp bool
 
 // Represents the int32 representations for MetadataStatus
 const (
@@ -92,7 +97,11 @@ func verifyContainerMetadataResponse(containerMetadataResponseMap map[string]jso
 		"MetadataFileStatus": MetadataReadyText,
 	}
 	// Fields that change dynamically, not predictable
-	taskExpectedFieldNotEmptyArray := []string{"TaskDefinitionFamily", "Cluster", "ContainerInstanceARN", "TaskARN", "TaskDefinitionRevision", "ContainerID", "DockerContainerName", "ImageID", "HostPublicIPv4Address"}
+	taskExpectedFieldNotEmptyArray := []string{"TaskDefinitionFamily", "Cluster", "ContainerInstanceARN", "TaskARN", "TaskDefinitionRevision", "ContainerID", "DockerContainerName", "ImageID"}
+
+	if hasPublicIp {
+		taskExpectedFieldNotEmptyArray = append(taskExpectedFieldNotEmptyArray, "HostPublicIPv4Address")
+	}
 
 	for fieldName, fieldVal := range containerExpectedFieldEqualMap {
 		if err = fieldEqual(containerMetadataResponseMap, fieldName, fieldVal); err != nil {
@@ -207,6 +216,13 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Unable to convert container metadata file to bytes: %v\n", err)
 		os.Exit(1)
 	}
+
+	boolVar, err := strconv.ParseBool(os.Getenv(hasPublicIpEnvVar))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Unable to parse environment variable %s: %v", hasPublicIpEnvVar, err)
+		os.Exit(1)
+	}
+	hasPublicIp = boolVar
 
 	// Parse file into struct to print to awslogs
 	var metadataResponse metadataSerializer


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
TestContainerMetadataFile was expecting a non-empty public ip in container metadata file, but we will only have it when the instance has public ip. Fixing by skipping the public ip check when instance doesn't have public ip.

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
