### PR TITLE
Add func test for trunk eni attach/detach workflow

### DIFF
--- a/agent/ec2/blackhole_ec2_metadata_client.go
+++ b/agent/ec2/blackhole_ec2_metadata_client.go
@@ -37,6 +37,10 @@ func (blackholeMetadataClient) PrimaryENIMAC() (string, error) {
 	return "", errors.New("blackholed")
 }
 
+func (blackholeMetadataClient) AllENIMacs() (string, error) {
+	return "", errors.New("blackholed")
+}
+
 func (blackholeMetadataClient) VPCID(mac string) (string, error) {
 	return "", errors.New("blackholed")
 }

--- a/agent/ec2/ec2_metadata_client.go
+++ b/agent/ec2/ec2_metadata_client.go
@@ -30,6 +30,7 @@ const (
 	InstanceIdentityDocumentResource          = "instance-identity/document"
 	InstanceIdentityDocumentSignatureResource = "instance-identity/signature"
 	MacResource                               = "mac"
+	AllMacResource                            = "network/interfaces/macs"
 	VPCIDResourceFormat                       = "network/interfaces/macs/%s/vpc-id"
 	SubnetIDResourceFormat                    = "network/interfaces/macs/%s/subnet-id"
 	InstanceIDResource                        = "instance-id"
@@ -68,6 +69,7 @@ type EC2MetadataClient interface {
 	VPCID(mac string) (string, error)
 	SubnetID(mac string) (string, error)
 	PrimaryENIMAC() (string, error)
+	AllENIMacs() (string, error)
 	InstanceID() (string, error)
 	GetUserData() (string, error)
 	Region() (string, error)
@@ -136,6 +138,11 @@ func (c *ec2MetadataClientImpl) GetMetadata(path string) (string, error) {
 // network interface of the instance
 func (c *ec2MetadataClientImpl) PrimaryENIMAC() (string, error) {
 	return c.client.GetMetadata(MacResource)
+}
+
+// AllENIMacs returns the mac addresses for all the network interfaces attached to the instance
+func (c *ec2MetadataClientImpl) AllENIMacs() (string, error) {
+	return c.client.GetMetadata(AllMacResource)
 }
 
 // VPCID returns the VPC id for the network interface, given

--- a/agent/ec2/ec2_metadata_client_test.go
+++ b/agent/ec2/ec2_metadata_client_test.go
@@ -35,6 +35,7 @@ import (
 const (
 	testRoleName = "test-role"
 	mac          = "01:23:45:67:89:ab"
+	macs         = "01:23:45:67:89:ab/\n01:23:45:67:89:ac"
 	vpcID        = "vpc-1234"
 	subnetID     = "subnet-1234"
 	iidRegion    = "us-east-1"
@@ -150,6 +151,20 @@ func TestPrimaryMAC(t *testing.T) {
 	macResponse, err := testClient.PrimaryENIMAC()
 	assert.NoError(t, err)
 	assert.Equal(t, mac, macResponse)
+}
+
+func TestAllENIMacs(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockGetter := mock_ec2.NewMockHttpClient(ctrl)
+	testClient := ec2.NewEC2MetadataClient(mockGetter)
+
+	mockGetter.EXPECT().GetMetadata(ec2.AllMacResource).Return(macs, nil)
+
+	macsResponse, err := testClient.AllENIMacs()
+	assert.NoError(t, err)
+	assert.Equal(t, macs, macsResponse)
 }
 
 func TestVPCID(t *testing.T) {

--- a/agent/ec2/mocks/ec2_mocks.go
+++ b/agent/ec2/mocks/ec2_mocks.go
@@ -50,6 +50,19 @@ func (m *MockEC2MetadataClient) EXPECT() *MockEC2MetadataClientMockRecorder {
 	return m.recorder
 }
 
+// AllENIMacs mocks base method
+func (m *MockEC2MetadataClient) AllENIMacs() (string, error) {
+	ret := m.ctrl.Call(m, "AllENIMacs")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AllENIMacs indicates an expected call of AllENIMacs
+func (mr *MockEC2MetadataClientMockRecorder) AllENIMacs() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllENIMacs", reflect.TypeOf((*MockEC2MetadataClient)(nil).AllENIMacs))
+}
+
 // DefaultCredentials mocks base method
 func (m *MockEC2MetadataClient) DefaultCredentials() (*ec2.RoleCredentials, error) {
 	ret := m.ctrl.Call(m, "DefaultCredentials")

--- a/agent/functional_tests/tests/functionaltests_unix_test.go
+++ b/agent/functional_tests/tests/functionaltests_unix_test.go
@@ -799,8 +799,7 @@ func TestRunAWSVPCTaskWithENITrunkingEndPointValidation(t *testing.T) {
 
 	defer agent.Cleanup()
 
-	// TODO: change back to 1.27.1 when merging the pr
-	agent.RequireVersion(">=1.26.0")
+	agent.RequireVersion(">=1.27.1")
 
 	roleArn := os.Getenv("TASK_IAM_ROLE_ARN")
 	if utils.ZeroOrNil(roleArn) {
@@ -1717,8 +1716,8 @@ func TestTrunkENIAttachDetachWorkflow(t *testing.T) {
 		err = WaitNetworkInterfaceCount(existingInterfaceCount, asyncWaitDuration)
 		assert.NoError(t, err)
 	}()
-	// TODO: when merging the changes, change to 1.27.1
-	agent.RequireVersion(">=1.26.0")
+
+	agent.RequireVersion(">=1.27.1")
 
 	// Expect one more interface to be attached (i.e. the Trunk)
 	macs, err := GetNetworkInterfaceMacs()

--- a/agent/functional_tests/tests/functionaltests_unix_test.go
+++ b/agent/functional_tests/tests/functionaltests_unix_test.go
@@ -799,7 +799,8 @@ func TestRunAWSVPCTaskWithENITrunkingEndPointValidation(t *testing.T) {
 
 	defer agent.Cleanup()
 
-	agent.RequireVersion(">=1.27.1")
+	// TODO: change back to 1.27.1 when merging the pr
+	agent.RequireVersion(">=1.26.0")
 
 	roleArn := os.Getenv("TASK_IAM_ROLE_ARN")
 	if utils.ZeroOrNil(roleArn) {
@@ -1671,4 +1672,76 @@ func TestAppMeshCNIPlugin(t *testing.T) {
 	exitCode, _ := task.ContainerExitcode("app-mesh")
 
 	assert.Equal(t, 42, exitCode, fmt.Sprintf("Expected exit code of 42; got %d", exitCode))
+}
+
+// TestTrunkENIAttachDetachWorkflow tests that when ENI trunking is enabled, the Trunk ENI is attached
+// when container instance reaches ACTIVE status, and it's detached when the container instance is deregistered
+func TestTrunkENIAttachDetachWorkflow(t *testing.T) {
+	asyncWaitDuration := 30 * time.Second
+
+	RequireInstanceTypes(t, []string{"c5", "m5"})
+
+	// Enable ENI Trunking account setting
+	putAccountSettingInput := ecsapi.PutAccountSettingInput{
+		Name:  aws.String("awsvpcTrunking"),
+		Value: aws.String("enabled"),
+	}
+	_, err := ECS.PutAccountSetting(&putAccountSettingInput)
+	require.NoError(t, err)
+
+	existingMacs, err := GetNetworkInterfaceMacs()
+	require.NoError(t, err)
+	existingInterfaceCount := len(existingMacs)
+
+	agentOptions := &AgentOptions{
+		EnableTaskENI: true,
+	}
+	os.Setenv("ECS_FTEST_FORCE_NET_HOST", "true")
+
+	agent := RunAgent(t, agentOptions)
+	defer func() {
+		// Cleanup needs to happen regardless of what happened elsewhere
+		defer agent.TestCleanup()
+
+		err := agent.StopAgent()
+		require.NoError(t, err)
+
+		_, err = ECS.DeregisterContainerInstance(&ecsapi.DeregisterContainerInstanceInput{
+			Cluster:           &agent.Cluster,
+			ContainerInstance: &agent.ContainerInstanceArn,
+			Force:             aws.Bool(true),
+		})
+		require.NoError(t, err)
+
+		// Wait and verify that the Trunk ENI is detached after deregistration
+		err = WaitNetworkInterfaceCount(existingInterfaceCount, asyncWaitDuration)
+		assert.NoError(t, err)
+	}()
+	// TODO: when merging the changes, change to 1.27.1
+	agent.RequireVersion(">=1.26.0")
+
+	// Expect one more interface to be attached (i.e. the Trunk)
+	macs, err := GetNetworkInterfaceMacs()
+	require.NoError(t, err)
+	assert.Equal(t, existingInterfaceCount + 1, len(macs))
+
+	// Check that there's one ENI attachment in DescribeContainerInstances response and it matches
+	// the one on the instance
+	resp, err := ECS.DescribeContainerInstances(&ecsapi.DescribeContainerInstancesInput{
+		Cluster: &agent.Cluster,
+		ContainerInstances: aws.StringSlice([]string{agent.ContainerInstanceArn}),
+	})
+	require.NoError(t, err)
+	describedContainerInstance := resp.ContainerInstances[0]
+	assert.Equal(t, "ACTIVE", aws.StringValue(describedContainerInstance.Status))
+	assert.Equal(t, 1, len(describedContainerInstance.Attachments))
+	checkMacSucceeds := false
+	for _, detail := range describedContainerInstance.Attachments[0].Details {
+		if aws.StringValue(detail.Name) == "macAddress" {
+			if strings.Contains(strings.Join(macs, "\n"), aws.StringValue(detail.Value)) {
+				checkMacSucceeds = true
+			}
+		}
+	}
+	assert.True(t, checkMacSucceeds)
 }

--- a/agent/functional_tests/util/utils.go
+++ b/agent/functional_tests/util/utils.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/sdkclientfactory"
+	"github.com/aws/amazon-ecs-agent/agent/ec2"
 	"github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
 	"github.com/aws/amazon-ecs-agent/agent/handlers/v1"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
@@ -192,6 +193,16 @@ func (agent *TestAgent) platformIndependentCleanup() {
 		ContainerInstance: &agent.ContainerInstanceArn,
 		Force:             aws.Bool(true),
 	})
+}
+
+// Cleanup without stopping the Agent and deregistering.
+func (agent *TestAgent) TestCleanup() {
+	if agent.t.Failed() {
+		agent.t.Logf("Preserving test dir for failed test %s", agent.TestDir)
+	} else {
+		agent.t.Logf("Removing test dir for passed test %s", agent.TestDir)
+		os.RemoveAll(agent.TestDir)
+	}
 }
 
 func (agent *TestAgent) StartMultipleTasks(t *testing.T, taskDefinition string, num int) ([]*TestTask, error) {
@@ -720,6 +731,20 @@ func RequireRegions(t *testing.T, supportedRegions []string, region string) {
 	}
 }
 
+// RequireInstanceTypes skips the test if current instance type is not a supported instance type
+func RequireInstanceTypes(t *testing.T, supportedTypePrefixes []string) {
+	iid, _ := ec2.NewEC2MetadataClient(nil).InstanceIdentityDocument()
+	instanceType := iid.InstanceType
+	for _, prefix := range supportedTypePrefixes {
+		if strings.HasPrefix(instanceType, prefix) {
+			return
+		}
+	}
+
+	t.Skipf("Skipped because the instance type %s is not a supported instance type. Supported instance type: %v",
+		instanceType, supportedTypePrefixes)
+}
+
 // GetInstanceProfileName gets the instance profile name
 func GetInstanceMetadata(path string) (string, error) {
 	ec2MetadataClient := ec2metadata.New(session.New())
@@ -943,4 +968,49 @@ func (agent *TestAgent) getContainerInstanceStatus() (string, error) {
 	}
 
 	return aws.StringValue(res.ContainerInstances[0].Status), nil
+}
+
+// GetNetworkInterfaceMacs returns a list of macs of all the network interfaces attached to the instance
+func GetNetworkInterfaceMacs() ([]string, error) {
+	macs, err := ec2.NewEC2MetadataClient(nil).AllENIMacs()
+	if err != nil {
+		return nil, err
+	}
+
+	return strings.Split(macs, "\n"), nil
+}
+
+// WaitNetworkInterfaceCount waits until there are certain number of ENIs attached to the instance
+func WaitNetworkInterfaceCount(desiredCount int, timeout time.Duration) error {
+	timer := time.NewTimer(timeout)
+	errChan := make(chan error, 1)
+	networkInterfaceCount := 0
+
+	cancelled := false
+	go func() {
+		for !cancelled {
+			macs, err := GetNetworkInterfaceMacs()
+			count := len(macs)
+			if err != nil {
+				errChan <- err
+				return
+			}
+			networkInterfaceCount = count
+
+			if count == desiredCount {
+				break
+			}
+			time.Sleep(5 * time.Second)
+		}
+		errChan <- nil
+	}()
+
+	select {
+	case err := <-errChan:
+		return err
+	case <-timer.C:
+		cancelled = true
+		return errors.Errorf("Timed out waiting for instance to have %d network interfaces attached; number of interfaces attached: %d",
+			desiredCount, networkInterfaceCount)
+	}
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->
### Summary
<!-- What does this pull request do? -->
Add func test for trunk eni attach/detach workflow.

### Implementation details
<!-- How are the changes implemented? -->
The test verifies that when ENI trunking is enabled, the Trunk ENI is attached when container instance reaches ACTIVE status, and it's detached when the container instance is deregistered.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

Test passes with gamma. cannot pass with prod yet.
Update: test passes with prod now.

```
=== RUN   TestTrunkENIAttachDetachWorkflow
--- PASS: TestTrunkENIAttachDetachWorkflow (31.70s)
	utils_unix.go:130: Created directory /tmp/ecs_integ_testdata042066345 to store test data in
	utils_unix.go:146: Launching agent with image: amazon/amazon-ecs-agent:latest
	utils_unix.go:237: Agent started as docker container: 46652bd4cb18e2f6293f71c966cf1321068faec9a5b88c17b730226af5120d1c
	utils.go:177: Found agent metadata: {Cluster:ecs-functional-tests ContainerInstanceArn:0xc420298410 Version:Amazon ECS Agent - v1.26.1 (d030fc86)}
	utils.go:202: Removing test dir for passed test /tmp/ecs_integ_testdata042066345
PASS
ok  	github.com/aws/amazon-ecs-agent/agent/functional_tests/tests	31.799s
```

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
