### PR TITLE
Functional test for ENI Trunking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,11 @@ test-artifacts-linux: $(LINUX_ARTIFACTS_TARGETS)
 test-artifacts: test-artifacts-windows test-artifacts-linux
 
 # Run our 'test' registry needed for integ and functional tests
-test-registry: netkitten volumes-test namespace-tests pause-container squid awscli image-cleanup-test-images fluentd agent-introspection-validator taskmetadata-validator v3-task-endpoint-validator container-metadata-file-validator elastic-inference-validator appmesh-plugin-validator
+test-registry: netkitten volumes-test namespace-tests pause-container squid awscli image-cleanup-test-images fluentd agent-introspection-validator taskmetadata-validator v3-task-endpoint-validator container-metadata-file-validator elastic-inference-validator
+test-registry: netkitten volumes-test namespace-tests pause-container squid awscli image-cleanup-test-images fluentd \
+				agent-introspection-validator taskmetadata-validator v3-task-endpoint-validator \
+				container-metadata-file-validator elastic-inference-validator appmesh-plugin-validator \
+				eni-trunking-validator
 	@./scripts/setup-test-registry
 
 test-in-docker:
@@ -209,7 +213,8 @@ run-functional-tests: testnnp test-registry ecr-execution-role-image telemetry-t
 
 .PHONY: build-image-for-ecr ecr-execution-role-image-for-upload upload-images replicate-images
 
-build-image-for-ecr: netkitten volumes-test squid awscli image-cleanup-test-images fluentd taskmetadata-validator testnnp container-health-check-image telemetry-test-image ecr-execution-role-image-for-upload
+build-image-for-ecr: netkitten volumes-test squid awscli image-cleanup-test-images fluentd taskmetadata-validator \
+						testnnp container-health-check-image telemetry-test-image ecr-execution-role-image-for-upload
 
 ecr-execution-role-image-for-upload:
 	$(MAKE) -C misc/ecr-execution-role-upload $(MFLAGS)
@@ -344,6 +349,9 @@ taskmetadata-validator:
 v3-task-endpoint-validator:
 	$(MAKE) -C misc/v3-task-endpoint-validator $(MFLAGS)
 
+eni-trunking-validator:
+	$(MAKE) -C misc/eni-trunking-validator $(MFLAGS)
+
 container-metadata-file-validator:
 	$(MAKE) -C misc/container-metadata-file-validator $(MFLAGS)
 
@@ -431,6 +439,7 @@ clean:
 	-$(MAKE) -C misc/container-health $(MFLAGS) clean
 	-$(MAKE) -C misc/telemetry $(MFLAGS) clean
 	-$(MAKE) -C misc/appmesh-plugin-validator $(MFLAGS) clean
+	-$(MAKE) -C misc/eni-trunking-validator $(MFLAGS) clean
 	-rm -f .get-deps-stamp
 	-rm -f .builder-image-stamp
 	-rm -f .out-stamp

--- a/THIRD-PARTY
+++ b/THIRD-PARTY
@@ -713,3 +713,26 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+-----
+
+** github.com/sparrc/go-ping; version v0.0.0-20181106165434-ef3ab45e41b0 -- https://github.com/sparrc/go-ping
+Copyright (c) 2016 Cameron Sparr
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/agent/Gopkg.lock
+++ b/agent/Gopkg.lock
@@ -538,7 +538,6 @@
     "github.com/stretchr/testify/require",
     "github.com/stretchr/testify/suite",
     "github.com/vishvananda/netlink",
-    "golang.org/x/net/context",
     "golang.org/x/sys/windows",
     "golang.org/x/sys/windows/registry",
     "golang.org/x/sys/windows/svc",

--- a/agent/functional_tests/testdata/taskdefinitions/test-eni-trunking/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/test-eni-trunking/task-definition.json
@@ -1,0 +1,22 @@
+{
+  "family": "test-eni-trunking",
+  "networkMode": "awsvpc",
+  "taskRoleArn": "$$$TASK_ROLE$$$",
+  "containerDefinitions": [
+	{
+	  "name": "eni-trunking-validator",
+	  "image": "127.0.0.1:51670/amazon/amazon-ecs-eni-trunking-validator:latest",
+	  "command": [""],
+	  "essential": true,
+	  "memory": 512,
+	  "logConfiguration": {
+		"logDriver": "awslogs",
+		"options": {
+		  "awslogs-group":"ecs-functional-tests",
+		  "awslogs-region":"$$$TEST_REGION$$$",
+		  "awslogs-stream-prefix":"ecs-functional-tests-eni-trunking-validator"
+		}
+	  }
+	}
+  ]
+}

--- a/misc/eni-trunking-validator/Dockerfile
+++ b/misc/eni-trunking-validator/Dockerfile
@@ -1,0 +1,18 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+FROM busybox:1.29.3
+
+MAINTAINER Amazon Web Services, Inc.
+COPY eni-trunking-validator /
+
+ENTRYPOINT ["/eni-trunking-validator"]

--- a/misc/eni-trunking-validator/Makefile
+++ b/misc/eni-trunking-validator/Makefile
@@ -1,0 +1,25 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+.PHONY: all clean eni-trunking-validator image
+
+all: eni-trunking-validator image
+
+eni-trunking-validator: eni-trunking-validator.go
+	@./build-in-docker
+
+image: eni-trunking-validator
+	docker build -t amazon/amazon-ecs-eni-trunking-validator:make .
+
+clean:
+	rm -f eni-trunking-validator
+	-docker rmi -f "amazon/amazon-ecs-eni-trunking-validator:make"

--- a/misc/eni-trunking-validator/build-in-docker
+++ b/misc/eni-trunking-validator/build-in-docker
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+CUR_DIR=$(pwd)
+AGENT_VENDOR_DIR=$(echo $(cd ${CUR_DIR}/../../agent/vendor;pwd))
+
+docker run \
+	-v ${CUR_DIR}:/out \
+	-v ${CUR_DIR}/eni-trunking-validator.go:/in/eni-trunking-validator.go \
+	-v ${CUR_DIR}/go.mod:/in/go.mod\
+	-v ${CUR_DIR}/go.sum:/in/go.sum \
+	-v ${AGENT_VENDOR_DIR}:/gopath/src \
+	-e CGO_ENABLED=0 \
+	-e GO111MODULE=on \
+	-e GOPATH=/go:/gopath \
+	golang:1.12 go build -a -x -ldflags '-s' -o /out/eni-trunking-validator /in/eni-trunking-validator.go

--- a/misc/eni-trunking-validator/eni-trunking-validator.go
+++ b/misc/eni-trunking-validator/eni-trunking-validator.go
@@ -1,0 +1,253 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/sparrc/go-ping"
+)
+
+const (
+	imdsEndpoint            = "http://169.254.169.254/latest/meta-data/"
+	v2MetadataEndpoint      = "http://169.254.170.2/v2/metadata"
+	v2StatsEndpoint         = "http://169.254.170.2/v2/stats"
+	containerMetadataEnvVar = "ECS_CONTAINER_METADATA_URI"
+	maxRetries              = 4
+	durationBetweenRetries  = time.Second
+)
+
+func verifyEndPoint(client *http.Client, endPoint string) error {
+	_, err := metadataResponse(client, endPoint)
+	return err
+}
+
+func metadataResponse(client *http.Client, endpoint string) ([]byte, error) {
+	var resp []byte
+	var err error
+	for i := 0; i < maxRetries; i++ {
+		resp, err = metadataResponseOnce(client, endpoint)
+		if err == nil {
+			return resp, nil
+		}
+		fmt.Fprintf(os.Stderr, "attempt [%d/%d]: unable to get metadata response from '%s': %v \n",
+			i, maxRetries, endpoint, err)
+		time.Sleep(durationBetweenRetries)
+	}
+
+	return nil, err
+}
+
+func metadataResponseOnce(client *http.Client, endpoint string) ([]byte, error) {
+	resp, err := client.Get(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get response: %v \n", err)
+	}
+	if resp.Body != nil {
+		defer resp.Body.Close()
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("incorrect status code  %d \n", resp.StatusCode)
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("task metadata: unable to read response body: %v \n", err)
+	}
+
+	return body, nil
+}
+
+func verifyV2Endpoints(client *http.Client) {
+	err := verifyEndPoint(client, v2MetadataEndpoint)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "unable to get task metadata: %v", err)
+		os.Exit(1)
+	}
+
+	err = verifyEndPoint(client, v2StatsEndpoint)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "unable to get task stats: %v", err)
+		os.Exit(1)
+	}
+}
+
+func verifyV3Endpoints(client *http.Client) {
+	v3BaseEndpoint := os.Getenv(containerMetadataEnvVar)
+
+	taskMetadataPath := v3BaseEndpoint + "/task"
+
+	containerStatsPath := v3BaseEndpoint + "/stats"
+	taskStatsPath := v3BaseEndpoint + "/task/stats"
+
+	if err := verifyEndPoint(client, v3BaseEndpoint); err != nil {
+		fmt.Fprintf(os.Stderr, "unable to get container metadata: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := verifyEndPoint(client, taskMetadataPath); err != nil {
+		fmt.Fprintf(os.Stderr, "unable to get task metadata: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := verifyEndPoint(client, containerStatsPath); err != nil {
+		fmt.Fprintf(os.Stderr, "unable to get container stats: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := verifyEndPoint(client, taskStatsPath); err != nil {
+		fmt.Fprintf(os.Stderr, "unable to get task stats: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func verifyIAMRoleEndpoint(client *http.Client) {
+	credentialsRelativeUri := os.Getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")
+	if len(credentialsRelativeUri) == 0 {
+		fmt.Fprintf(os.Stderr, "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI environment variable missing")
+		os.Exit(1)
+	}
+	fmt.Printf("IAM role found: %s\n", credentialsRelativeUri)
+
+	IAMRoleEndPoint := "http://169.254.170.2" + credentialsRelativeUri
+	_, err := metadataResponse(client, IAMRoleEndPoint)
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error pinging IAM role endpoint:%s\n", credentialsRelativeUri)
+		os.Exit(1)
+	}
+
+}
+
+func verifyHostName() {
+	cmd := exec.Command("hostname")
+	hostname, err := cmd.Output()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error executing `hostname` command: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("Hostname Found: %s\n", string(hostname))
+
+	regexExpPattern := "ip-[0-9]*-[0-9]*-[0-9]*-[0-9]*.*.internal"
+	_, errMatch := regexp.MatchString(regexExpPattern, string(hostname))
+	if errMatch != nil {
+		fmt.Fprintf(os.Stderr, "incorrect format hostname: %s\n", hostname)
+		os.Exit(1)
+	}
+}
+
+func verifyIMDSConnectivity(client *http.Client) {
+	_, err := metadataResponse(client, imdsEndpoint)
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error pinging imds endpoint:%s\n", imdsEndpoint)
+		os.Exit(1)
+	}
+}
+
+func verifySubnetGatewayEndpoint(client *http.Client) {
+	baseURL := imdsEndpoint + "network/interfaces/macs/"
+	body, err := metadataResponse(client, baseURL)
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error pinging endpoint: %s\n", baseURL)
+		os.Exit(1)
+	}
+	macAddress := strings.Split(string(body), "\n")[0]
+	fmt.Printf("Received mac address: %s \n", macAddress)
+	pingUrl := strings.Join([]string{baseURL, macAddress, "subnet-ipv4-cidr-block"}, "")
+	subnetCIDR, errSubnet := metadataResponse(client, pingUrl)
+	fmt.Printf("Received CIDR: %s\n", string(subnetCIDR))
+
+	if errSubnet != nil {
+		fmt.Fprintf(os.Stderr, "error pinging endpoint: %s\n", pingUrl)
+		os.Exit(1)
+	}
+
+	defaultSubnet, err := computeIPV4GatewayNetmask(string(subnetCIDR))
+	if err != nil {
+		fmt.Fprint(os.Stderr, "Error computing default subnet gateway IPV4: %s\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("Subnet Found: %s\n", defaultSubnet)
+	pinger, errSubnetPing := ping.NewPinger(defaultSubnet)
+
+	if errSubnetPing != nil {
+		fmt.Fprintf(os.Stderr, "error pinging subnet: %s\n", errSubnetPing.Error())
+		os.Exit(1)
+	}
+
+	pingerCount := 10
+	packetLossAllowed := 20.0 // percentage of packet loss allowed
+	pingerTimeout := 5 * time.Second
+
+	pinger.SetPrivileged(true) // ping will run with super-user privileges
+	pinger.Count = pingerCount
+	pinger.Timeout = pingerTimeout
+
+	pinger.Run()                 // blocks until finished
+	stats := pinger.Statistics() // get send/receive/rtt stats
+	fmt.Printf("\n--- %s ping statistics ---\n", stats.Addr)
+	fmt.Printf("%d packets transmitted, %d packets received, %v%% packet loss\n",
+		stats.PacketsSent, stats.PacketsRecv, stats.PacketLoss)
+	fmt.Printf("round-trip min/avg/max/stddev = %v/%v/%v/%v\n",
+		stats.MinRtt, stats.AvgRtt, stats.MaxRtt, stats.StdDevRtt)
+
+	if stats.PacketLoss > packetLossAllowed {
+		fmt.Fprint(os.Stderr, "packets were lost when pinging subnet gateway")
+		os.Exit(1)
+	}
+}
+
+// computeIPV4GatewayNetmask computes the subnet gateway for
+// the gateway given the ipv4 cidr block for the ENI
+// Gateways are provided in VPC subnets at base +1
+func computeIPV4GatewayNetmask(cidrBlock string) (string, error) {
+	// The IPV4 CIDR block is of the format ip-addr/netmask
+	ip, _, err := net.ParseCIDR(cidrBlock)
+	if err != nil {
+		return "", fmt.Errorf("Failed to parse cidrBlock with error: %q", err)
+	}
+
+	ip4 := ip.To4()
+	if ip4 == nil {
+		return "", fmt.Errorf("unable to parse ipv4 gateway from cidr block '%s'", cidrBlock)
+	}
+
+	// ipv4 gateway is the first available IP address in the subnet
+	ip4[3] = ip4[3] + 1
+	return ip4.String(), nil
+}
+
+func main() {
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+	}
+
+	verifyV3Endpoints(client)
+	verifyV2Endpoints(client)
+	verifyIAMRoleEndpoint(client)
+	verifyHostName()
+	verifyIMDSConnectivity(client)
+	verifySubnetGatewayEndpoint(client)
+
+	os.Exit(42)
+}

--- a/misc/eni-trunking-validator/go.mod
+++ b/misc/eni-trunking-validator/go.mod
@@ -1,0 +1,6 @@
+module github.com/aws/amazon-ecs-agent/misc/eni-trunking-validator
+
+require (
+	github.com/sparrc/go-ping v0.0.0-20181106165434-ef3ab45e41b0
+	golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3 // indirect
+)

--- a/misc/eni-trunking-validator/go.sum
+++ b/misc/eni-trunking-validator/go.sum
@@ -1,0 +1,7 @@
+github.com/sparrc/go-ping v0.0.0-20181106165434-ef3ab45e41b0 h1:mu7brOsdaH5Dqf93vdch+mr/0To8Sgc+yInt/jE/RJM=
+github.com/sparrc/go-ping v0.0.0-20181106165434-ef3ab45e41b0/go.mod h1:eMyUVp6f/5jnzM+3zahzl7q6UXLbgSc3MKg/+ow9QW0=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3 h1:0GoQqolDA55aaLxZyTzK/Y2ePZzZTUrRacwib7cNsYQ=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/scripts/setup-test-registry
+++ b/scripts/setup-test-registry
@@ -45,7 +45,14 @@ mirror_local_image() {
   docker rmi $2
 }
 
-for image in "amazon/amazon-ecs-netkitten" "amazon/amazon-ecs-volumes-test" "amazon/amazon-ecs-pid-namespace-test" "amazon/amazon-ecs-ipc-namespace-test" "amazon/squid" "amazon/awscli" "amazon/image-cleanup-test-image1" "amazon/image-cleanup-test-image2" "amazon/image-cleanup-test-image3" "amazon/fluentd" "amazon/amazon-ecs-agent-introspection-validator" "amazon/amazon-ecs-taskmetadata-validator" "amazon/amazon-ecs-v3-task-endpoint-validator" "amazon/amazon-ecs-container-metadata-file-validator" "amazon/amazon-ecs-elastic-inference-validator" "amazon/amazon-appmesh-plugin-validator"; do
+for image in "amazon/amazon-ecs-netkitten" "amazon/amazon-ecs-volumes-test" "amazon/amazon-ecs-pid-namespace-test" \
+				"amazon/amazon-ecs-ipc-namespace-test" "amazon/squid" "amazon/awscli" \
+				"amazon/image-cleanup-test-image1" "amazon/image-cleanup-test-image2" \
+				"amazon/image-cleanup-test-image3" "amazon/fluentd" "amazon/amazon-ecs-agent-introspection-validator" \
+				"amazon/amazon-ecs-taskmetadata-validator" "amazon/amazon-ecs-v3-task-endpoint-validator" \
+				"amazon/amazon-ecs-container-metadata-file-validator" "amazon/amazon-ecs-elastic-inference-validator" \
+				"amazon/amazon-appmesh-plugin-validator" "amazon/amazon-ecs-eni-trunking-validator"; do
+
   mirror_local_image "${image}:make" "127.0.0.1:51670/${image}:latest"
 done
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This PR adds a functional test which verifies that the container in instance with ENI trunking enabled is able to :
- Reach metadata endpoints for both V2/V3
- Use task IAM role credentials
- Reach IMDS
- Hostname exist
- Ping the default subnet gateway

The functional test runs 5 tasks to ensure that the instance supports high number of ENI which is not supported without trunking enabled. 

### Implementation details
There is a [flag](https://github.com/aws/amazon-ecs-agent/pull/1967/files#diff-01b0080f9f8415380a17c70351248178R680) which when set to true will enable ENI trunking. 

### Testing
#### Amazon Linux - c5.2xlarge(amzn-ami-hvm-2018.03.0.20181129-x86_64-gp2)
```bash
=== RUN   TestRunAWSVPCTaskWithENITrunkingEndPointValidation
--- PASS: TestRunAWSVPCTaskWithENITrunkingEndPointValidation (33.14s)
    utils_unix.go:130: Created directory /tmp/ecs_integ_testdata798796383 to store test data in
    utils_unix.go:146: Launching agent with image: amazon/amazon-ecs-agent:make
    utils_unix.go:237: Agent started as docker container: 0e95074e5e20000372980a462ca09a9d3f8e1aeafd7f54b9b2b9c3a001df5f57
    utils.go:177: Found agent metadata: {Cluster:ecs-functional-tests ContainerInstanceArn:0xc0003b4140 Version:Amazon ECS Agent - v1.26.1 (d92a3414)}
    utils.go:262: Task definition: test-eni-trunking-6d478d54e77111289c534d8c078ce95e:1
    utils.go:270: Starting 'awsvpc' task in subnet: subnet-63d45628
    utils.go:282: Task Respone: {
          Failures: [],
          Tasks: [{
              Attachments: [{
                  Details: [{
                      Name: "subnetId",
                      Value: "subnet-63d45628"
                    }],
                  Id: "21cd4e50-8a39-45b1-8edc-6261e07d27d7",
                  Status: "PRECREATED",
                  Type: "ElasticNetworkInterface"
                }],
              ClusterArn: "arn:aws:ecs:us-west-2:694464167470:cluster/ecs-functional-tests",
              ContainerInstanceArn: "arn:aws:ecs:us-west-2:694464167470:container-instance/ecs-functional-tests/d30f89f81bf0449b8db3737776e4fd3b",
              Containers: [{
                  ContainerArn: "arn:aws:ecs:us-west-2:694464167470:container/e185384e-9f83-4bf7-80f8-2c93e412ad1c",
                  LastStatus: "PENDING",
                  Name: "eni-trunking-validator",
                  NetworkInterfaces: [],
                  TaskArn: "arn:aws:ecs:us-west-2:694464167470:task/628e9d2b-1353-4ea4-bb95-1a0fd9280290"
                }],
              Cpu: "0",
              CreatedAt: 2019-04-20 00:16:35 +0000 UTC,
              DesiredStatus: "RUNNING",
              Group: "family:test-eni-trunking-6d478d54e77111289c534d8c078ce95e",
              LastStatus: "PROVISIONING",
              LaunchType: "EC2",
              Memory: "512",
              Overrides: {
                ContainerOverrides: [{
                    Name: "eni-trunking-validator"
                  }]
              },
              Tags: [],
              TaskArn: "arn:aws:ecs:us-west-2:694464167470:task/628e9d2b-1353-4ea4-bb95-1a0fd9280290",
              TaskDefinitionArn: "arn:aws:ecs:us-west-2:694464167470:task-definition/test-eni-trunking-6d478d54e77111289c534d8c078ce95e:1",
              Version: 1
            }]
        }
    utils.go:283: Task Respone: <nil>
    utils.go:293: Started task: arn:aws:ecs:us-west-2:694464167470:task/628e9d2b-1353-4ea4-bb95-1a0fd9280290
    utils.go:262: Task definition: test-eni-trunking-6d478d54e77111289c534d8c078ce95e:1
    utils.go:270: Starting 'awsvpc' task in subnet: subnet-63d45628
    utils.go:282: Task Respone: {
          Failures: [],
          Tasks: [{
              Attachments: [{
                  Details: [{
                      Name: "subnetId",
                      Value: "subnet-63d45628"
                    }],
                  Id: "641239fa-529c-439a-95cb-63b30cc56fb1",
                  Status: "PRECREATED",
                  Type: "ElasticNetworkInterface"
                }],
              ClusterArn: "arn:aws:ecs:us-west-2:694464167470:cluster/ecs-functional-tests",
              ContainerInstanceArn: "arn:aws:ecs:us-west-2:694464167470:container-instance/ecs-functional-tests/d30f89f81bf0449b8db3737776e4fd3b",
              Containers: [{
                  ContainerArn: "arn:aws:ecs:us-west-2:694464167470:container/e9b3ab84-a091-44ee-8c0b-24bbd504da2f",
                  LastStatus: "PENDING",
                  Name: "eni-trunking-validator",
                  NetworkInterfaces: [],
                  TaskArn: "arn:aws:ecs:us-west-2:694464167470:task/8a4c31be-3069-4de6-a420-d72f73138796"
                }],
              Cpu: "0",
              CreatedAt: 2019-04-20 00:16:36 +0000 UTC,
              DesiredStatus: "RUNNING",
              Group: "family:test-eni-trunking-6d478d54e77111289c534d8c078ce95e",
              LastStatus: "PROVISIONING",
              LaunchType: "EC2",
              Memory: "512",
              Overrides: {
                ContainerOverrides: [{
                    Name: "eni-trunking-validator"
                  }]
              },
              Tags: [],
              TaskArn: "arn:aws:ecs:us-west-2:694464167470:task/8a4c31be-3069-4de6-a420-d72f73138796",
              TaskDefinitionArn: "arn:aws:ecs:us-west-2:694464167470:task-definition/test-eni-trunking-6d478d54e77111289c534d8c078ce95e:1",
              Version: 1
            }]
        }
    utils.go:283: Task Respone: <nil>
    utils.go:293: Started task: arn:aws:ecs:us-west-2:694464167470:task/8a4c31be-3069-4de6-a420-d72f73138796
    utils.go:262: Task definition: test-eni-trunking-6d478d54e77111289c534d8c078ce95e:1
    utils.go:270: Starting 'awsvpc' task in subnet: subnet-63d45628
    utils.go:282: Task Respone: {
          Failures: [],
          Tasks: [{
              Attachments: [{
                  Details: [{
                      Name: "subnetId",
                      Value: "subnet-63d45628"
                    }],
                  Id: "2e15a1ac-d9c9-49f7-949b-bd37f6b19a8b",
                  Status: "PRECREATED",
                  Type: "ElasticNetworkInterface"
                }],
              ClusterArn: "arn:aws:ecs:us-west-2:694464167470:cluster/ecs-functional-tests",
              ContainerInstanceArn: "arn:aws:ecs:us-west-2:694464167470:container-instance/ecs-functional-tests/d30f89f81bf0449b8db3737776e4fd3b",
              Containers: [{
                  ContainerArn: "arn:aws:ecs:us-west-2:694464167470:container/6fc94714-0793-4097-b73a-c8f5c5876f48",
                  LastStatus: "PENDING",
                  Name: "eni-trunking-validator",
                  NetworkInterfaces: [],
                  TaskArn: "arn:aws:ecs:us-west-2:694464167470:task/d89deca5-0224-4a85-a8b0-1a57dcf6c137"
                }],
              Cpu: "0",
              CreatedAt: 2019-04-20 00:16:36 +0000 UTC,
              DesiredStatus: "RUNNING",
              Group: "family:test-eni-trunking-6d478d54e77111289c534d8c078ce95e",
              LastStatus: "PROVISIONING",
              LaunchType: "EC2",
              Memory: "512",
              Overrides: {
                ContainerOverrides: [{
                    Name: "eni-trunking-validator"
                  }]
              },
              Tags: [],
              TaskArn: "arn:aws:ecs:us-west-2:694464167470:task/d89deca5-0224-4a85-a8b0-1a57dcf6c137",
              TaskDefinitionArn: "arn:aws:ecs:us-west-2:694464167470:task-definition/test-eni-trunking-6d478d54e77111289c534d8c078ce95e:1",
              Version: 1
            }]
        }
    utils.go:283: Task Respone: <nil>
    utils.go:293: Started task: arn:aws:ecs:us-west-2:694464167470:task/d89deca5-0224-4a85-a8b0-1a57dcf6c137
    utils.go:262: Task definition: test-eni-trunking-6d478d54e77111289c534d8c078ce95e:1
    utils.go:270: Starting 'awsvpc' task in subnet: subnet-63d45628
    utils.go:282: Task Respone: {
          Failures: [],
          Tasks: [{
              Attachments: [{
                  Details: [{
                      Name: "subnetId",
                      Value: "subnet-63d45628"
                    }],
                  Id: "f5ec0635-1253-4d79-8fc1-bd5758b31e30",
                  Status: "PRECREATED",
                  Type: "ElasticNetworkInterface"
                }],
              ClusterArn: "arn:aws:ecs:us-west-2:694464167470:cluster/ecs-functional-tests",
              ContainerInstanceArn: "arn:aws:ecs:us-west-2:694464167470:container-instance/ecs-functional-tests/d30f89f81bf0449b8db3737776e4fd3b",
              Containers: [{
                  ContainerArn: "arn:aws:ecs:us-west-2:694464167470:container/317dc0fa-7e29-4d06-b567-2b7f806281fd",
                  LastStatus: "PENDING",
                  Name: "eni-trunking-validator",
                  NetworkInterfaces: [],
                  TaskArn: "arn:aws:ecs:us-west-2:694464167470:task/5888be55-d7dc-494e-b297-7d67f0d6a83a"
                }],
              Cpu: "0",
              CreatedAt: 2019-04-20 00:16:36 +0000 UTC,
              DesiredStatus: "RUNNING",
              Group: "family:test-eni-trunking-6d478d54e77111289c534d8c078ce95e",
              LastStatus: "PROVISIONING",
              LaunchType: "EC2",
              Memory: "512",
              Overrides: {
                ContainerOverrides: [{
                    Name: "eni-trunking-validator"
                  }]
              },
              Tags: [],
              TaskArn: "arn:aws:ecs:us-west-2:694464167470:task/5888be55-d7dc-494e-b297-7d67f0d6a83a",
              TaskDefinitionArn: "arn:aws:ecs:us-west-2:694464167470:task-definition/test-eni-trunking-6d478d54e77111289c534d8c078ce95e:1",
              Version: 1
            }]
        }
    utils.go:283: Task Respone: <nil>
    utils.go:293: Started task: arn:aws:ecs:us-west-2:694464167470:task/5888be55-d7dc-494e-b297-7d67f0d6a83a
    utils.go:262: Task definition: test-eni-trunking-6d478d54e77111289c534d8c078ce95e:1
    utils.go:270: Starting 'awsvpc' task in subnet: subnet-63d45628
    utils.go:282: Task Respone: {
          Failures: [],
          Tasks: [{
              Attachments: [{
                  Details: [{
                      Name: "subnetId",
                      Value: "subnet-63d45628"
                    }],
                  Id: "ce0e786e-4e2f-4bdb-a52c-2786e831433d",
                  Status: "PRECREATED",
                  Type: "ElasticNetworkInterface"
                }],
              ClusterArn: "arn:aws:ecs:us-west-2:694464167470:cluster/ecs-functional-tests",
              ContainerInstanceArn: "arn:aws:ecs:us-west-2:694464167470:container-instance/ecs-functional-tests/d30f89f81bf0449b8db3737776e4fd3b",
              Containers: [{
                  ContainerArn: "arn:aws:ecs:us-west-2:694464167470:container/b7d492aa-8517-483f-b2d5-f9f441082d26",
                  LastStatus: "PENDING",
                  Name: "eni-trunking-validator",
                  NetworkInterfaces: [],
                  TaskArn: "arn:aws:ecs:us-west-2:694464167470:task/ab569485-d7cf-4e54-a287-50bf64e09276"
                }],
              Cpu: "0",
              CreatedAt: 2019-04-20 00:16:36 +0000 UTC,
              DesiredStatus: "RUNNING",
              Group: "family:test-eni-trunking-6d478d54e77111289c534d8c078ce95e",
              LastStatus: "PROVISIONING",
              LaunchType: "EC2",
              Memory: "512",
              Overrides: {
                ContainerOverrides: [{
                    Name: "eni-trunking-validator"
                  }]
              },
              Tags: [],
              TaskArn: "arn:aws:ecs:us-west-2:694464167470:task/ab569485-d7cf-4e54-a287-50bf64e09276",
              TaskDefinitionArn: "arn:aws:ecs:us-west-2:694464167470:task-definition/test-eni-trunking-6d478d54e77111289c534d8c078ce95e:1",
              Version: 1
            }]
        }
    utils.go:283: Task Respone: <nil>
    utils.go:293: Started task: arn:aws:ecs:us-west-2:694464167470:task/ab569485-d7cf-4e54-a287-50bf64e09276
    functionaltests_unix_test.go:832: Ran 5 containers;
    utils.go:187: Removing test dir for passed test /tmp/ecs_integ_testdata798796383
PASS
ok  	github.com/aws/amazon-ecs-agent/agent/functional_tests/tests	33.226s
?   	github.com/aws/amazon-ecs-agent/agent/functional_tests/tests/generated	[no test files]
testing: warning: no tests to run
PASS
```

#### Amazon Linux - m5.4xlarge(amzn-ami-hvm-2018.03.0.20181129-x86_64-gp2)
```bash
=== RUN   TestRunAWSVPCTaskWithENITrunkingEndPointValidation
--- PASS: TestRunAWSVPCTaskWithENITrunkingEndPointValidation (32.50s)
    utils_unix.go:130: Created directory /tmp/ecs_integ_testdata240385962 to store test data in
    utils_unix.go:146: Launching agent with image: amazon/amazon-ecs-agent:make
    utils_unix.go:237: Agent started as docker container: eae46f30ecf342b4ddf22c13c64615661a6050994bb86f271e07c606916fdf8f
    utils.go:177: Found agent metadata: {Cluster:ecs-functional-tests ContainerInstanceArn:0xc00036de70 Version:Amazon ECS Agent - v1.26.1 (acaaab45)}
    utils.go:262: Task definition: test-eni-trunking-6d478d54e77111289c534d8c078ce95e:1
    utils.go:270: Starting 'awsvpc' task in subnet: subnet-9e81e0e7
    utils.go:282: Task Respone: {
          Failures: [],
          Tasks: [{
              Attachments: [{
                  Details: [{
                      Name: "subnetId",
                      Value: "subnet-9e81e0e7"
                    }],
                  Id: "e85220db-843d-4796-b621-bdb71879bf0b",
                  Status: "PRECREATED",
                  Type: "ElasticNetworkInterface"
                }],
              ClusterArn: "arn:aws:ecs:us-west-2:694464167470:cluster/ecs-functional-tests",
              ContainerInstanceArn: "arn:aws:ecs:us-west-2:694464167470:container-instance/ecs-functional-tests/e253c3fd96624d54b0f6cc3ee8a62c45",
              Containers: [{
                  ContainerArn: "arn:aws:ecs:us-west-2:694464167470:container/2f3dad27-a4d9-4c11-babd-19e1ce2cc89a",
                  LastStatus: "PENDING",
                  Name: "eni-trunking-validator",
                  NetworkInterfaces: [],
                  TaskArn: "arn:aws:ecs:us-west-2:694464167470:task/c23a03cf-1fae-4d1d-8449-48496191b6c4"
                }],
              Cpu: "0",
              CreatedAt: 2019-04-22 19:20:49 +0000 UTC,
              DesiredStatus: "RUNNING",
              Group: "family:test-eni-trunking-6d478d54e77111289c534d8c078ce95e",
              LastStatus: "PROVISIONING",
              LaunchType: "EC2",
              Memory: "512",
              Overrides: {
                ContainerOverrides: [{
                    Name: "eni-trunking-validator"
                  }]
              },
              Tags: [],
              TaskArn: "arn:aws:ecs:us-west-2:694464167470:task/c23a03cf-1fae-4d1d-8449-48496191b6c4",
              TaskDefinitionArn: "arn:aws:ecs:us-west-2:694464167470:task-definition/test-eni-trunking-6d478d54e77111289c534d8c078ce95e:1",
              Version: 1
            }]
        }
    utils.go:283: Task Respone: <nil>
    utils.go:293: Started task: arn:aws:ecs:us-west-2:694464167470:task/c23a03cf-1fae-4d1d-8449-48496191b6c4
    utils.go:262: Task definition: test-eni-trunking-6d478d54e77111289c534d8c078ce95e:1
    utils.go:270: Starting 'awsvpc' task in subnet: subnet-9e81e0e7
    utils.go:282: Task Respone: {
          Failures: [],
          Tasks: [{
              Attachments: [{
                  Details: [{
                      Name: "subnetId",
                      Value: "subnet-9e81e0e7"
                    }],
                  Id: "ba3410e1-fb70-4945-b57e-5c0d374a597b",
                  Status: "PRECREATED",
                  Type: "ElasticNetworkInterface"
                }],
              ClusterArn: "arn:aws:ecs:us-west-2:694464167470:cluster/ecs-functional-tests",
              ContainerInstanceArn: "arn:aws:ecs:us-west-2:694464167470:container-instance/ecs-functional-tests/e253c3fd96624d54b0f6cc3ee8a62c45",
              Containers: [{
                  ContainerArn: "arn:aws:ecs:us-west-2:694464167470:container/7f97e469-2f1a-45d0-a1ac-ceb3702c6ff6",
                  LastStatus: "PENDING",
                  Name: "eni-trunking-validator",
                  NetworkInterfaces: [],
                  TaskArn: "arn:aws:ecs:us-west-2:694464167470:task/4d928aa3-ddb9-4697-98a2-dcd47cde2a41"
                }],
              Cpu: "0",
              CreatedAt: 2019-04-22 19:20:50 +0000 UTC,
              DesiredStatus: "RUNNING",
              Group: "family:test-eni-trunking-6d478d54e77111289c534d8c078ce95e",
              LastStatus: "PROVISIONING",
              LaunchType: "EC2",
              Memory: "512",
              Overrides: {
                ContainerOverrides: [{
                    Name: "eni-trunking-validator"
                  }]
              },
              Tags: [],
              TaskArn: "arn:aws:ecs:us-west-2:694464167470:task/4d928aa3-ddb9-4697-98a2-dcd47cde2a41",
              TaskDefinitionArn: "arn:aws:ecs:us-west-2:694464167470:task-definition/test-eni-trunking-6d478d54e77111289c534d8c078ce95e:1",
              Version: 1
            }]
        }
    utils.go:283: Task Respone: <nil>
    utils.go:293: Started task: arn:aws:ecs:us-west-2:694464167470:task/4d928aa3-ddb9-4697-98a2-dcd47cde2a41
    functionaltests_unix_test.go:832: Ran 2 containers;
    utils.go:187: Removing test dir for passed test /tmp/ecs_integ_testdata240385962
PASS
```

#### Amazon Linux 2 - c5.4xlarge(amzn2-ami-hvm-2.0.20190313-x86_64-gp2)
```bash
=== RUN   TestRunAWSVPCTaskWithENITrunkingEndPointValidation
--- PASS: TestRunAWSVPCTaskWithENITrunkingEndPointValidation (32.40s)
    utils_unix.go:130: Created directory /tmp/ecs_integ_testdata514533806 to store test data in
    utils_unix.go:146: Launching agent with image: amazon/amazon-ecs-agent:make
    utils_unix.go:237: Agent started as docker container: 342e208fea80b3632681b52f932f8ef6581f750ed52a46e1bf491c2c8bad131d
    utils.go:177: Found agent metadata: {Cluster:ecs-functional-tests ContainerInstanceArn:0xc00007dc10 Version:Amazon ECS Agent - v1.26.1 (acaaab45)}
    utils.go:262: Task definition: test-eni-trunking-6d478d54e77111289c534d8c078ce95e:1
    utils.go:270: Starting 'awsvpc' task in subnet: subnet-98f886c2
    utils.go:282: Task Respone: {
          Failures: [],
          Tasks: [{
              Attachments: [{
                  Details: [{
                      Name: "subnetId",
                      Value: "subnet-98f886c2"
                    }],
                  Id: "706b472c-b890-47a6-af35-10ff62315935",
                  Status: "PRECREATED",
                  Type: "ElasticNetworkInterface"
                }],
              ClusterArn: "arn:aws:ecs:us-west-2:694464167470:cluster/ecs-functional-tests",
              ContainerInstanceArn: "arn:aws:ecs:us-west-2:694464167470:container-instance/cfe90ab3-5e54-40f8-a999-329605e10dd8",
              Containers: [{
                  ContainerArn: "arn:aws:ecs:us-west-2:694464167470:container/6b6c8f9a-68ca-45f9-803d-2c57c2a8c143",
                  LastStatus: "PENDING",
                  Name: "eni-trunking-validator",
                  NetworkInterfaces: [],
                  TaskArn: "arn:aws:ecs:us-west-2:694464167470:task/9fcdd39c-a51d-45d2-9155-909b37a0611f"
                }],
              Cpu: "0",
              CreatedAt: 2019-04-22 19:13:18 +0000 UTC,
              DesiredStatus: "RUNNING",
              Group: "family:test-eni-trunking-6d478d54e77111289c534d8c078ce95e",
              LastStatus: "PROVISIONING",
              LaunchType: "EC2",
              Memory: "512",
              Overrides: {
                ContainerOverrides: [{
                    Name: "eni-trunking-validator"
                  }]
              },
              Tags: [],
              TaskArn: "arn:aws:ecs:us-west-2:694464167470:task/9fcdd39c-a51d-45d2-9155-909b37a0611f",
              TaskDefinitionArn: "arn:aws:ecs:us-west-2:694464167470:task-definition/test-eni-trunking-6d478d54e77111289c534d8c078ce95e:1",
              Version: 1
            }]
        }
    utils.go:283: Task Respone: <nil>
    utils.go:293: Started task: arn:aws:ecs:us-west-2:694464167470:task/9fcdd39c-a51d-45d2-9155-909b37a0611f
    utils.go:262: Task definition: test-eni-trunking-6d478d54e77111289c534d8c078ce95e:1
    utils.go:270: Starting 'awsvpc' task in subnet: subnet-98f886c2
    utils.go:282: Task Respone: {
          Failures: [],
          Tasks: [{
              Attachments: [{
                  Details: [{
                      Name: "subnetId",
                      Value: "subnet-98f886c2"
                    }],
                  Id: "9dae032c-4332-4ff4-b222-187ce89cbf8a",
                  Status: "PRECREATED",
                  Type: "ElasticNetworkInterface"
                }],
              ClusterArn: "arn:aws:ecs:us-west-2:694464167470:cluster/ecs-functional-tests",
              ContainerInstanceArn: "arn:aws:ecs:us-west-2:694464167470:container-instance/cfe90ab3-5e54-40f8-a999-329605e10dd8",
              Containers: [{
                  ContainerArn: "arn:aws:ecs:us-west-2:694464167470:container/5423dc12-aed0-479f-9e34-36284fa6b6ea",
                  LastStatus: "PENDING",
                  Name: "eni-trunking-validator",
                  NetworkInterfaces: [],
                  TaskArn: "arn:aws:ecs:us-west-2:694464167470:task/ce8adf6e-b915-433e-890e-5c206138625d"
                }],
              Cpu: "0",
              CreatedAt: 2019-04-22 19:13:18 +0000 UTC,
              DesiredStatus: "RUNNING",
              Group: "family:test-eni-trunking-6d478d54e77111289c534d8c078ce95e",
              LastStatus: "PROVISIONING",
              LaunchType: "EC2",
              Memory: "512",
              Overrides: {
                ContainerOverrides: [{
                    Name: "eni-trunking-validator"
                  }]
              },
              Tags: [],
              TaskArn: "arn:aws:ecs:us-west-2:694464167470:task/ce8adf6e-b915-433e-890e-5c206138625d",
              TaskDefinitionArn: "arn:aws:ecs:us-west-2:694464167470:task-definition/test-eni-trunking-6d478d54e77111289c534d8c078ce95e:1",
              Version: 1
            }]
        }
    utils.go:283: Task Respone: <nil>
    utils.go:293: Started task: arn:aws:ecs:us-west-2:694464167470:task/ce8adf6e-b915-433e-890e-5c206138625d
    functionaltests_unix_test.go:832: Ran 2 containers;
    utils.go:187: Removing test dir for passed test /tmp/ecs_integ_testdata514533806
PASS
```

#### Amazon Linux 2 - m5.4xlarge(amzn2-ami-hvm-2.0.20190313-x86_64-gp2)
```bash
=== RUN   TestRunAWSVPCTaskWithENITrunkingEndPointValidation
--- PASS: TestRunAWSVPCTaskWithENITrunkingEndPointValidation (32.99s)
    utils_unix.go:130: Created directory /tmp/ecs_integ_testdata836407758 to store test data in
    utils_unix.go:146: Launching agent with image: amazon/amazon-ecs-agent:make
    utils_unix.go:237: Agent started as docker container: 653e3695d0fb2d17e54b51ef3d0c9dab0c0ea6efc243db85ca32be1af586f715
    utils.go:177: Found agent metadata: {Cluster:ecs-functional-tests ContainerInstanceArn:0xc0002e0820 Version:Amazon ECS Agent - v1.26.1 (acaaab45)}
    utils.go:262: Task definition: test-eni-trunking-6d478d54e77111289c534d8c078ce95e:1
    utils.go:270: Starting 'awsvpc' task in subnet: subnet-9e81e0e7
    utils.go:282: Task Respone: {
          Failures: [],
          Tasks: [{
              Attachments: [{
                  Details: [{
                      Name: "subnetId",
                      Value: "subnet-9e81e0e7"
                    }],
                  Id: "778e1b28-0f34-440e-aa46-cf2561cfe921",
                  Status: "PRECREATED",
                  Type: "ElasticNetworkInterface"
                }],
              ClusterArn: "arn:aws:ecs:us-west-2:694464167470:cluster/ecs-functional-tests",
              ContainerInstanceArn: "arn:aws:ecs:us-west-2:694464167470:container-instance/ecs-functional-tests/8a9a80dfdd87407a974a3543d4416791",
              Containers: [{
                  ContainerArn: "arn:aws:ecs:us-west-2:694464167470:container/0e9cf924-7fcd-4f65-9edb-cff8bbf459e7",
                  LastStatus: "PENDING",
                  Name: "eni-trunking-validator",
                  NetworkInterfaces: [],
                  TaskArn: "arn:aws:ecs:us-west-2:694464167470:task/e7a4b8ab-4aef-4d16-a2ba-b1c476c5e0d5"
                }],
              Cpu: "0",
              CreatedAt: 2019-04-22 20:34:47 +0000 UTC,
              DesiredStatus: "RUNNING",
              Group: "family:test-eni-trunking-6d478d54e77111289c534d8c078ce95e",
              LastStatus: "PROVISIONING",
              LaunchType: "EC2",
              Memory: "512",
              Overrides: {
                ContainerOverrides: [{
                    Name: "eni-trunking-validator"
                  }]
              },
              Tags: [],
              TaskArn: "arn:aws:ecs:us-west-2:694464167470:task/e7a4b8ab-4aef-4d16-a2ba-b1c476c5e0d5",
              TaskDefinitionArn: "arn:aws:ecs:us-west-2:694464167470:task-definition/test-eni-trunking-6d478d54e77111289c534d8c078ce95e:1",
              Version: 1
            }]
        }
    utils.go:283: Task Respone: <nil>
    utils.go:293: Started task: arn:aws:ecs:us-west-2:694464167470:task/e7a4b8ab-4aef-4d16-a2ba-b1c476c5e0d5
    utils.go:262: Task definition: test-eni-trunking-6d478d54e77111289c534d8c078ce95e:1
    utils.go:270: Starting 'awsvpc' task in subnet: subnet-9e81e0e7
    utils.go:282: Task Respone: {
          Failures: [],
          Tasks: [{
              Attachments: [{
                  Details: [{
                      Name: "subnetId",
                      Value: "subnet-9e81e0e7"
                    }],
                  Id: "00204ec1-5251-4a74-9787-c3f354df0076",
                  Status: "PRECREATED",
                  Type: "ElasticNetworkInterface"
                }],
              ClusterArn: "arn:aws:ecs:us-west-2:694464167470:cluster/ecs-functional-tests",
              ContainerInstanceArn: "arn:aws:ecs:us-west-2:694464167470:container-instance/ecs-functional-tests/8a9a80dfdd87407a974a3543d4416791",
              Containers: [{
                  ContainerArn: "arn:aws:ecs:us-west-2:694464167470:container/70e4152f-4a3c-4836-820b-d8aa202374dd",
                  LastStatus: "PENDING",
                  Name: "eni-trunking-validator",
                  NetworkInterfaces: [],
                  TaskArn: "arn:aws:ecs:us-west-2:694464167470:task/94b710ce-18d2-46ba-a662-16105ce17e98"
                }],
              Cpu: "0",
              CreatedAt: 2019-04-22 20:34:48 +0000 UTC,
              DesiredStatus: "RUNNING",
              Group: "family:test-eni-trunking-6d478d54e77111289c534d8c078ce95e",
              LastStatus: "PROVISIONING",
              LaunchType: "EC2",
              Memory: "512",
              Overrides: {
                ContainerOverrides: [{
                    Name: "eni-trunking-validator"
                  }]
              },
              Tags: [],
              TaskArn: "arn:aws:ecs:us-west-2:694464167470:task/94b710ce-18d2-46ba-a662-16105ce17e98",
              TaskDefinitionArn: "arn:aws:ecs:us-west-2:694464167470:task-definition/test-eni-trunking-6d478d54e77111289c534d8c078ce95e:1",
              Version: 1
            }]
        }
    utils.go:283: Task Respone: <nil>
    utils.go:293: Started task: arn:aws:ecs:us-west-2:694464167470:task/94b710ce-18d2-46ba-a662-16105ce17e98
    functionaltests_unix_test.go:832: Ran 2 containers;
    utils.go:187: Removing test dir for passed test /tmp/ecs_integ_testdata836407758
PASS
ok  	github.com/aws/amazon-ecs-agent/agent/functional_tests/tests	33.079s
?   	github.com/aws/amazon-ecs-agent/agent/functional_tests/tests/generated	[no test files]
testing: warning: no tests to run
```

#### Amazon Linux 2(arm64) - a1.large(amzn2-ami-hvm-2.0.20190313-arm64-gp2):
```bash
=== RUN   TestRunAWSVPCTaskWithENITrunkingEndPointValidation
--- PASS: TestRunAWSVPCTaskWithENITrunkingEndPointValidation (32.97s)
    utils_unix.go:130: Created directory /tmp/ecs_integ_testdata353694437 to store test data in
    utils_unix.go:146: Launching agent with image: amazon/amazon-ecs-agent:make
    utils_unix.go:237: Agent started as docker container: d160051a88bcfa856c371be4e99accb0a2797491e48332eedc361eb1ed419012
    utils.go:177: Found agent metadata: {Cluster:ecs-functional-tests ContainerInstanceArn:0xc00045cab0 Version:Amazon ECS Agent - v1.26.1 (acaaab45)}
    utils.go:262: Task definition: test-eni-trunking-6d478d54e77111289c534d8c078ce95e:1
    utils.go:270: Starting 'awsvpc' task in subnet: subnet-9e81e0e7
    utils.go:282: Task Respone: {
          Failures: [],
          Tasks: [{
              Attachments: [{
                  Details: [{
                      Name: "subnetId",
                      Value: "subnet-9e81e0e7"
                    }],
                  Id: "12d27373-b20c-4a96-9dff-6c906a710a6f",
                  Status: "PRECREATED",
                  Type: "ElasticNetworkInterface"
                }],
              ClusterArn: "arn:aws:ecs:us-west-2:694464167470:cluster/ecs-functional-tests",
              ContainerInstanceArn: "arn:aws:ecs:us-west-2:694464167470:container-instance/ecs-functional-tests/138ed6c626b740eb94ff30bbdfaa85fd",
              Containers: [{
                  ContainerArn: "arn:aws:ecs:us-west-2:694464167470:container/b3378b0a-093e-4a43-a624-2bde13f17ee8",
                  LastStatus: "PENDING",
                  Name: "eni-trunking-validator",
                  NetworkInterfaces: [],
                  TaskArn: "arn:aws:ecs:us-west-2:694464167470:task/409f7f3d-80d0-4291-b81c-2da2e020067e"
                }],
              Cpu: "0",
              CreatedAt: 2019-04-22 20:43:24 +0000 UTC,
              DesiredStatus: "RUNNING",
              Group: "family:test-eni-trunking-6d478d54e77111289c534d8c078ce95e",
              LastStatus: "PROVISIONING",
              LaunchType: "EC2",
              Memory: "512",
              Overrides: {
                ContainerOverrides: [{
                    Name: "eni-trunking-validator"
                  }]
              },
              Tags: [],
              TaskArn: "arn:aws:ecs:us-west-2:694464167470:task/409f7f3d-80d0-4291-b81c-2da2e020067e",
              TaskDefinitionArn: "arn:aws:ecs:us-west-2:694464167470:task-definition/test-eni-trunking-6d478d54e77111289c534d8c078ce95e:1",
              Version: 1
            }]
        }
    utils.go:283: Task Respone: <nil>
    utils.go:293: Started task: arn:aws:ecs:us-west-2:694464167470:task/409f7f3d-80d0-4291-b81c-2da2e020067e
    utils.go:262: Task definition: test-eni-trunking-6d478d54e77111289c534d8c078ce95e:1
    utils.go:270: Starting 'awsvpc' task in subnet: subnet-9e81e0e7
    utils.go:282: Task Respone: {
          Failures: [],
          Tasks: [{
              Attachments: [{
                  Details: [{
                      Name: "subnetId",
                      Value: "subnet-9e81e0e7"
                    }],
                  Id: "c72bbbf3-aeb4-40c0-ae4f-76004d58854f",
                  Status: "PRECREATED",
                  Type: "ElasticNetworkInterface"
                }],
              ClusterArn: "arn:aws:ecs:us-west-2:694464167470:cluster/ecs-functional-tests",
              ContainerInstanceArn: "arn:aws:ecs:us-west-2:694464167470:container-instance/ecs-functional-tests/138ed6c626b740eb94ff30bbdfaa85fd",
              Containers: [{
                  ContainerArn: "arn:aws:ecs:us-west-2:694464167470:container/6e602638-2e79-492f-a621-71355e95c9b7",
                  LastStatus: "PENDING",
                  Name: "eni-trunking-validator",
                  NetworkInterfaces: [],
                  TaskArn: "arn:aws:ecs:us-west-2:694464167470:task/11a8f2f4-621f-4283-a710-75a8424b9368"
                }],
              Cpu: "0",
              CreatedAt: 2019-04-22 20:43:24 +0000 UTC,
              DesiredStatus: "RUNNING",
              Group: "family:test-eni-trunking-6d478d54e77111289c534d8c078ce95e",
              LastStatus: "PROVISIONING",
              LaunchType: "EC2",
              Memory: "512",
              Overrides: {
                ContainerOverrides: [{
                    Name: "eni-trunking-validator"
                  }]
              },
              Tags: [],
              TaskArn: "arn:aws:ecs:us-west-2:694464167470:task/11a8f2f4-621f-4283-a710-75a8424b9368",
              TaskDefinitionArn: "arn:aws:ecs:us-west-2:694464167470:task-definition/test-eni-trunking-6d478d54e77111289c534d8c078ce95e:1",
              Version: 1
            }]
        }
    utils.go:283: Task Respone: <nil>
    utils.go:293: Started task: arn:aws:ecs:us-west-2:694464167470:task/11a8f2f4-621f-4283-a710-75a8424b9368
    functionaltests_unix_test.go:832: Ran 2 containers;
    utils.go:187: Removing test dir for passed test /tmp/ecs_integ_testdata353694437
PASS
```


<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->



### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
