### PR TITLE
Enable windows integ/functional test to pass in image name as a parameter.

### DIFF
--- a/agent/engine/engine_windows_integ_test.go
+++ b/agent/engine/engine_windows_integ_test.go
@@ -58,7 +58,7 @@ func isDockerRunning() bool { return true }
 func createTestContainer() *apicontainer.Container {
 	return &apicontainer.Container{
 		Name:                "windows",
-		Image:               "microsoft/windowsservercore",
+		Image:               "amazon-ecs-ftest-windows-base:make",
 		Essential:           true,
 		DesiredStatusUnsafe: apicontainerstatus.ContainerRunning,
 		CPU:                 512,
@@ -67,7 +67,7 @@ func createTestContainer() *apicontainer.Container {
 }
 
 // getLongRunningCommand returns the command that keeps the container running for the container
-// that uses the default integ test image (microsoft/windowsservercore for windows)
+// that uses the default integ test image (amazon-ecs-ftest-windows-base:make for windows)
 func getLongRunningCommand() []string {
 	return []string{"ping", "-t", "localhost"}
 }

--- a/agent/engine/ordering_integ_windows_test.go
+++ b/agent/engine/ordering_integ_windows_test.go
@@ -16,7 +16,7 @@
 package engine
 
 const (
-	baseImageForOS = "microsoft/windowsservercore"
+	baseImageForOS = "amazon-ecs-ftest-windows-base:make"
 )
 
 var (

--- a/agent/functional_tests/testdata/taskdefinitions/awslogs-datetime-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/awslogs-datetime-windows/task-definition.json
@@ -5,7 +5,7 @@
     "memory": 512,
     "name": "awslogs-datetime-windows",
     "cpu": 1024,
-    "image": "microsoft/windowsservercore",
+    "image": "amazon-ecs-ftest-windows-base:make",
     "entryPoint": ["powershell"],
     "command": ["echo", "\"May 01, 2017 19:00:01 ECS\nMay 01, 2017 19:00:04 Agent\nRunning\nin the instance\""],
     "logConfiguration": {

--- a/agent/functional_tests/testdata/taskdefinitions/awslogs-multiline-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/awslogs-multiline-windows/task-definition.json
@@ -5,7 +5,7 @@
     "memory": 512,
     "name": "awslogs-multiline-windows",
     "cpu": 1024,
-    "image": "microsoft/windowsservercore",
+    "image": "amazon-ecs-ftest-windows-base:make",
     "entryPoint": ["powershell"],
     "command": ["echo", "\"INFO: ECS Agent\nRunning\nINFO: Instance\""],
     "logConfiguration": {

--- a/agent/functional_tests/testdata/taskdefinitions/awslogs-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/awslogs-windows/task-definition.json
@@ -5,7 +5,7 @@
     "memory": 512,
     "name": "awslogs",
     "cpu": 1024,
-    "image": "microsoft/windowsservercore",
+    "image": "amazon-ecs-ftest-windows-base:make",
     "logConfiguration": {
         "logDriver": "awslogs",
         "options": {

--- a/agent/functional_tests/testdata/taskdefinitions/cleanup-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/cleanup-windows/task-definition.json
@@ -1,7 +1,7 @@
 {
   "family": "ecsftest-cleanup-windows",
   "containerDefinitions": [{
-    "image": "microsoft/windowsservercore",
+    "image": "amazon-ecs-ftest-windows-base:make",
     "name": "cleanup-windows",
     "cpu": 1024,
     "memory": 512,

--- a/agent/functional_tests/testdata/taskdefinitions/container-ordering-complete-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/container-ordering-complete-windows/task-definition.json
@@ -3,7 +3,7 @@
   "containerDefinitions": [
     {
       "name": "complete",
-      "image": "microsoft/windowsservercore",
+      "image": "amazon-ecs-ftest-windows-base:make",
       "cpu": 0,
       "memory": 64,
       "essential": true,
@@ -24,7 +24,7 @@
     },
     {
       "name": "complete-dependency",
-      "image": "microsoft/windowsservercore",
+      "image": "amazon-ecs-ftest-windows-base:make",
       "cpu": 0,
       "memory": 64,
       "essential": false,

--- a/agent/functional_tests/testdata/taskdefinitions/container-ordering-healthy-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/container-ordering-healthy-windows/task-definition.json
@@ -3,7 +3,7 @@
   "containerDefinitions": [
     {
       "name": "healthy",
-      "image": "microsoft/windowsservercore",
+      "image": "amazon-ecs-ftest-windows-base:make",
       "cpu": 0,
       "memory": 64,
       "essential": false,
@@ -24,7 +24,7 @@
     },
     {
       "name": "healthy-dependency",
-      "image": "microsoft/windowsservercore",
+      "image": "amazon-ecs-ftest-windows-base:make",
       "cpu": 0,
       "memory": 64,
       "essential": true,

--- a/agent/functional_tests/testdata/taskdefinitions/container-ordering-success-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/container-ordering-success-windows/task-definition.json
@@ -3,7 +3,7 @@
   "containerDefinitions": [
     {
       "name": "success",
-      "image": "microsoft/windowsservercore",
+      "image": "amazon-ecs-ftest-windows-base:make",
       "cpu": 0,
       "memory": 64,
       "essential": true,
@@ -24,7 +24,7 @@
     },
     {
       "name": "success-dependency",
-      "image": "microsoft/windowsservercore",
+      "image": "amazon-ecs-ftest-windows-base:make",
       "cpu": 0,
       "memory": 64,
       "essential": false,

--- a/agent/functional_tests/testdata/taskdefinitions/container-ordering-timedout-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/container-ordering-timedout-windows/task-definition.json
@@ -3,7 +3,7 @@
   "containerDefinitions": [
     {
       "name": "success-timeout",
-      "image": "microsoft/windowsservercore",
+      "image": "amazon-ecs-ftest-windows-base:make",
       "cpu": 0,
       "memory": 128,
       "essential": true,
@@ -17,7 +17,7 @@
     },
     {
       "name": "success-timeout-dependency",
-      "image": "microsoft/windowsservercore",
+      "image": "amazon-ecs-ftest-windows-base:make",
       "cpu": 0,
       "memory": 128,
       "essential": false,

--- a/agent/functional_tests/testdata/taskdefinitions/datavolume-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/datavolume-windows/task-definition.json
@@ -5,7 +5,7 @@
     "host": {}
   }],
   "containerDefinitions": [{
-    "image": "microsoft/windowsservercore",
+    "image": "amazon-ecs-ftest-windows-base:make",
     "name": "exit",
     "cpu": 1024,
     "memory": 256,
@@ -15,7 +15,7 @@
     }],
     "command": ["powershell", "-c", "while (1) { sleep 1; if (test-path \"C:/data/success\") { exit 42 }}; done"]
   }, {
-    "image": "microsoft/windowsservercore",
+    "image": "amazon-ecs-ftest-windows-base:make",
     "name": "dataSource",
     "cpu": 1024,
     "memory": 256,
@@ -25,7 +25,7 @@
     }],
     "command": ["powershell", "-c", "New-Item -ItemType file C:/data/success"]
   }, {
-    "image": "microsoft/windowsservercore",
+    "image": "amazon-ecs-ftest-windows-base:make",
     "name": "data-volume-source",
     "cpu": 1024,
     "memory": 256,

--- a/agent/functional_tests/testdata/taskdefinitions/hostname-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/hostname-windows/task-definition.json
@@ -1,7 +1,7 @@
 {
   "family": "ecsftest-hostname",
   "containerDefinitions": [{
-    "image": "microsoft/windowsservercore",
+    "image": "amazon-ecs-ftest-windows-base:make",
     "name": "exit",
     "cpu": 1024,
     "memory": 512,

--- a/agent/functional_tests/testdata/taskdefinitions/labels-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/labels-windows/task-definition.json
@@ -1,7 +1,7 @@
 {
   "family": "ecsftest-labels-windows",
   "containerDefinitions": [{
-    "image": "microsoft/windowsservercore",
+    "image": "amazon-ecs-ftest-windows-base:make",
     "name": "labeled",
     "cpu": 1024,
     "memory": 512,

--- a/agent/functional_tests/testdata/taskdefinitions/logdriver-jsonfile-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/logdriver-jsonfile-windows/task-definition.json
@@ -1,7 +1,7 @@
 {
   "family": "ecsinteg-json-file-rollover",
   "containerDefinitions": [{
-    "image": "microsoft/windowsservercore",
+    "image": "amazon-ecs-ftest-windows-base:make",
     "name": "exit",
     "memory": 512,
     "cpu": 1024,

--- a/agent/functional_tests/testdata/taskdefinitions/network-mode-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/network-mode-windows/task-definition.json
@@ -2,7 +2,7 @@
   "family": "ecsftest-networkmode",
   "networkMode": "$$$$NETWORK_MODE$$$$",
   "containerDefinitions": [{
-    "image": "microsoft/windowsservercore",
+    "image": "amazon-ecs-ftest-windows-base:make",
     "entryPoint": ["powershell"],
     "command": ["sleep", "60"],
     "name": "network-$$$$NETWORK_MODE$$$$",

--- a/agent/functional_tests/testdata/taskdefinitions/savedstate-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/savedstate-windows/task-definition.json
@@ -1,7 +1,7 @@
 {
   "family": "ecsftest-savedstate-windows",
   "containerDefinitions": [{
-    "image": "microsoft/windowsservercore",
+    "image": "amazon-ecs-ftest-windows-base:make",
     "name": "savedstate-windows",
     "cpu": 1024,
     "memory": 512,

--- a/agent/functional_tests/testdata/taskdefinitions/simple-exit-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/simple-exit-windows/task-definition.json
@@ -1,7 +1,7 @@
 {
   "family": "ecsinteg-simple-exit-windows",
   "containerDefinitions": [{
-    "image": "microsoft/windowsservercore",
+    "image": "amazon-ecs-ftest-windows-base:make",
     "name": "exit",
     "cpu": 1024,
     "memory": 512,

--- a/agent/functional_tests/testdata/taskdefinitions/task-local-vol-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/task-local-vol-windows/task-definition.json
@@ -2,7 +2,7 @@
     "family": "ecsftest-task-local-volume",
     "containerDefinitions": [
         {
-            "image": "microsoft/windowsservercore",
+            "image": "amazon-ecs-ftest-windows-base:make",
             "name": "exit",
             "cpu": 1024,
             "memory": 256,

--- a/agent/functional_tests/testdata/taskdefinitions/task-shared-vol-read-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/task-shared-vol-read-windows/task-definition.json
@@ -3,7 +3,7 @@
     "containerDefinitions": [
         {
             "name": "task-shared-vol-read",
-            "image": "microsoft/windowsservercore",
+            "image": "amazon-ecs-ftest-windows-base:make",
             "cpu": 1024,
             "memory": 256,
             "essential": true,

--- a/agent/functional_tests/testdata/taskdefinitions/task-shared-vol-write-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/task-shared-vol-write-windows/task-definition.json
@@ -2,7 +2,7 @@
     "family": "ecsftest-task-local-volume",
     "containerDefinitions": [
         {
-            "image": "microsoft/windowsservercore",
+            "image": "amazon-ecs-ftest-windows-base:make",
             "name": "task-shared-vol-write-windows",
             "cpu": 1024,
             "memory": 256,

--- a/agent/functional_tests/testdata/taskdefinitions/working-dir-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/working-dir-windows/task-definition.json
@@ -1,7 +1,7 @@
 {
   "family": "ecsftest-working-dir-windows",
   "containerDefinitions": [{
-    "image": "microsoft/windowsservercore",
+    "image": "amazon-ecs-ftest-windows-base:make",
     "name": "exit",
     "cpu": 1024,
     "memory": 512,

--- a/misc/container-health-windows/windows.dockerfile
+++ b/misc/container-health-windows/windows.dockerfile
@@ -10,7 +10,7 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-FROM microsoft/windowsservercore
+FROM amazon-ecs-ftest-windows-base:make
 
 MAINTAINER Amazon Web Services, Inc.
 

--- a/misc/container-metadata-file-validator-windows/container-metadata-file-validator-windows.dockerfile
+++ b/misc/container-metadata-file-validator-windows/container-metadata-file-validator-windows.dockerfile
@@ -11,6 +11,6 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-FROM microsoft/windowsservercore
+FROM amazon-ecs-ftest-windows-base:make
 
 ADD container-metadata-file-validator-windows.exe container-metadata-file-validator-windows.exe

--- a/misc/image-cleanup-test-images/windows0.dockerfile
+++ b/misc/image-cleanup-test-images/windows0.dockerfile
@@ -10,7 +10,7 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-FROM microsoft/windowsservercore
+FROM amazon-ecs-ftest-windows-base:make
 
 MAINTAINER Amazon Web Services, Inc.
 

--- a/misc/image-cleanup-test-images/windows1.dockerfile
+++ b/misc/image-cleanup-test-images/windows1.dockerfile
@@ -10,7 +10,7 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-FROM microsoft/windowsservercore
+FROM amazon-ecs-ftest-windows-base:make
 
 MAINTAINER Amazon Web Services, Inc.
 

--- a/misc/image-cleanup-test-images/windows2.dockerfile
+++ b/misc/image-cleanup-test-images/windows2.dockerfile
@@ -10,7 +10,7 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-FROM microsoft/windowsservercore
+FROM amazon-ecs-ftest-windows-base:make
 
 MAINTAINER Amazon Web Services, Inc.
 

--- a/misc/image-cleanup-test-images/windows3.dockerfile
+++ b/misc/image-cleanup-test-images/windows3.dockerfile
@@ -10,7 +10,7 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-FROM microsoft/windowsservercore
+FROM amazon-ecs-ftest-windows-base:make
 
 MAINTAINER Amazon Web Services, Inc.
 

--- a/misc/image-cleanup-test-images/windows4.dockerfile
+++ b/misc/image-cleanup-test-images/windows4.dockerfile
@@ -10,7 +10,7 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-FROM microsoft/windowsservercore
+FROM amazon-ecs-ftest-windows-base:make
 
 MAINTAINER Amazon Web Services, Inc.
 

--- a/misc/image-cleanup-test-images/windows5.dockerfile
+++ b/misc/image-cleanup-test-images/windows5.dockerfile
@@ -10,7 +10,7 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-FROM microsoft/windowsservercore
+FROM amazon-ecs-ftest-windows-base:make
 
 MAINTAINER Amazon Web Services, Inc.
 

--- a/misc/image-cleanup-test-images/windows6.dockerfile
+++ b/misc/image-cleanup-test-images/windows6.dockerfile
@@ -10,7 +10,7 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-FROM microsoft/windowsservercore
+FROM amazon-ecs-ftest-windows-base:make
 
 MAINTAINER Amazon Web Services, Inc.
 

--- a/misc/image-cleanup-test-images/windows7.dockerfile
+++ b/misc/image-cleanup-test-images/windows7.dockerfile
@@ -10,7 +10,7 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-FROM microsoft/windowsservercore
+FROM amazon-ecs-ftest-windows-base:make
 
 MAINTAINER Amazon Web Services, Inc.
 

--- a/misc/image-cleanup-test-images/windows8.dockerfile
+++ b/misc/image-cleanup-test-images/windows8.dockerfile
@@ -10,7 +10,7 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-FROM microsoft/windowsservercore
+FROM amazon-ecs-ftest-windows-base:make
 
 MAINTAINER Amazon Web Services, Inc.
 

--- a/misc/image-cleanup-test-images/windows9.dockerfile
+++ b/misc/image-cleanup-test-images/windows9.dockerfile
@@ -10,7 +10,7 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-FROM microsoft/windowsservercore
+FROM amazon-ecs-ftest-windows-base:make
 
 MAINTAINER Amazon Web Services, Inc.
 

--- a/misc/netkitten/windows.dockerfile
+++ b/misc/netkitten/windows.dockerfile
@@ -10,7 +10,7 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-FROM microsoft/windowsservercore
+FROM amazon-ecs-ftest-windows-base:make
 
 MAINTAINER Amazon Web Services, Inc.
 

--- a/misc/stats-windows/windows.dockerfile
+++ b/misc/stats-windows/windows.dockerfile
@@ -10,7 +10,7 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-FROM microsoft/windowsservercore
+FROM amazon-ecs-ftest-windows-base:make
 
 MAINTAINER Amazon Web Services, Inc.
 

--- a/misc/v3-task-endpoint-validator-windows/v3-task-endpoint-validator-windows.dockerfile
+++ b/misc/v3-task-endpoint-validator-windows/v3-task-endpoint-validator-windows.dockerfile
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-FROM microsoft/windowsservercore
+FROM amazon-ecs-ftest-windows-base:make
 
 ADD application.ps1 application.ps1
 ADD v3-task-endpoint-validator-windows.exe v3-task-endpoint-validator-windows.exe

--- a/misc/volumes-test/windows.dockerfile
+++ b/misc/volumes-test/windows.dockerfile
@@ -11,7 +11,7 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-FROM microsoft/windowsservercore
+FROM amazon-ecs-ftest-windows-base:make
 MAINTAINER Amazon Web Services, Inc.
 
 SHELL ["powershell", "-command"]

--- a/misc/windows-iam/iamroles.dockerfile
+++ b/misc/windows-iam/iamroles.dockerfile
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-FROM microsoft/windowsservercore
+FROM amazon-ecs-ftest-windows-base:make
 
 ADD application.ps1 application.ps1
 ADD ec2.exe ec2.exe

--- a/misc/windows-listen80/listen80.dockerfile
+++ b/misc/windows-listen80/listen80.dockerfile
@@ -11,5 +11,5 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-FROM microsoft/windowsservercore
+FROM amazon-ecs-ftest-windows-base:make
 ADD listen80.exe listen80.exe

--- a/misc/windows-telemetry/windows.dockerfile
+++ b/misc/windows-telemetry/windows.dockerfile
@@ -10,7 +10,8 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-FROM microsoft/windowsservercore
+
+FROM amazon-ecs-ftest-windows-base:make
 
 ADD stress.exe stress.exe
 ENTRYPOINT ["./stress.exe"]

--- a/scripts/generate_image.ps1
+++ b/scripts/generate_image.ps1
@@ -99,6 +99,7 @@ Import-Module AWSPowerShell
 
 echo "Pulling microsoft/windowsservercore:latest..."
 docker pull microsoft/windowsservercore:latest
+docker tag microsoft/windowsservercore:latest amazon-ecs-ftest-windows-base:make
 
 $ENV:ECS_WINDOWS_TEST_DIR="${BUILD_ROOT}"
 $ENV:ECS_FTEST_TMP="${WORK_ROOT}\ftest_temp"

--- a/scripts/run-functional-tests.ps1
+++ b/scripts/run-functional-tests.ps1
@@ -11,6 +11,17 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+Param (
+  [string]$BaseImageName="microsoft/windowsservercore"
+)
+
+# Prepared base image
+$dockerImages = Invoke-Expression "docker images"
+if (-Not ($dockerImages -like "*$BaseImageName*")) {
+    Invoke-Expression "docker pull $BaseImageName"
+}
+Invoke-Expression "docker tag $BaseImageName amazon-ecs-ftest-windows-base:make"
+
 Invoke-Expression "${PSScriptRoot}\..\misc\windows-iam\Setup_Iam.ps1"
 Invoke-Expression "${PSScriptRoot}\..\misc\windows-listen80\Setup_Listen80.ps1"
 Invoke-Expression "${PSScriptRoot}\..\misc\windows-telemetry\build.ps1"

--- a/scripts/run-integ-tests.ps1
+++ b/scripts/run-integ-tests.ps1
@@ -11,6 +11,17 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+Param (
+  [string]$BaseImageName="microsoft/windowsservercore"
+)
+
+# Prepare windows base image
+$dockerImages = Invoke-Expression "docker images"
+if (-Not ($dockerImages -like "*$BaseImageName*")) {
+  Invoke-Expression "docker pull $BaseImageName"
+}
+Invoke-Expression "docker tag $BaseImageName amazon-ecs-ftest-windows-base:make"
+
 # Prepare dependencies
 Invoke-Expression "${PSScriptRoot}\..\misc\volumes-test\build.ps1"
 Invoke-Expression "${PSScriptRoot}\..\misc\image-cleanup-test-images\build.ps1"


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Enable windows functional test to pass in image name as a parameter. This is needed becasue microsoft/windowsservercore only supports 2016, it does not run on WS2019 machines.
We need to pass in a different base image for functional tests to run on WS2019 machines.

### Implementation details
<!-- How are the changes implemented? -->
1. Allow integ test functional test to pass base image as parameter
2. Tag amazon-ecs-ftest-windows-base:make from base image parameter
3. Change all existing microsoft/windowsservercore to use amazon-ecs-ftest-windows-base:make

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> NA

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
