### PR TITLE
Use Golang 1.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 go_import_path: github.com/aws/amazon-ecs-agent
 sudo: false
 go:
-  - 1.11
+  - 1.12
 
 matrix:
   include:

--- a/misc/agent-introspection-validator/build-in-docker
+++ b/misc/agent-introspection-validator/build-in-docker
@@ -21,4 +21,4 @@ docker run \
 	-v ${AGENT_VENDOR_DIR}:/gopath/src \
 	-e CGO_ENABLED=0 \
 	-e GOPATH=/go:/gopath \
-	golang:1.9 go build -a -x -ldflags '-s' -o /out/agent-introspection-validator /in/agent-introspection-validator.go
+	golang:1.12 go build -a -x -ldflags '-s' -o /out/agent-introspection-validator /in/agent-introspection-validator.go

--- a/misc/appmesh-plugin-validator/Dockerfile
+++ b/misc/appmesh-plugin-validator/Dockerfile
@@ -10,7 +10,7 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-FROM golang:1.9
+FROM golang:1.12
 
 MAINTAINER Amazon Web Services, Inc.
 COPY appmesh-plugin-validator /

--- a/misc/appmesh-plugin-validator/build-in-docker
+++ b/misc/appmesh-plugin-validator/build-in-docker
@@ -22,4 +22,4 @@ docker run \
 	-e CGO_ENABLED=0 \
 	-e GO111MODULE=on \
 	-w /in \
-	golang:1.11.5 go build -a -x -ldflags '-s' -o /out/appmesh-plugin-validator /in/appmesh-plugin-validator.go
+	golang:1.12 go build -a -x -ldflags '-s' -o /out/appmesh-plugin-validator /in/appmesh-plugin-validator.go

--- a/misc/container-metadata-file-validator/build-in-docker
+++ b/misc/container-metadata-file-validator/build-in-docker
@@ -21,4 +21,4 @@ docker run \
 	-v ${AGENT_VENDOR_DIR}:/gopath/src \
 	-e CGO_ENABLED=0 \
 	-e GOPATH=/go:/gopath \
-	golang:1.9 go build -a -x -ldflags '-s' -o /out/container-metadata-file-validator /in/container-metadata-file-validator.go
+	golang:1.12 go build -a -x -ldflags '-s' -o /out/container-metadata-file-validator /in/container-metadata-file-validator.go

--- a/misc/elastic-inference-validator/build-in-docker
+++ b/misc/elastic-inference-validator/build-in-docker
@@ -21,4 +21,4 @@ docker run \
 	-v ${AGENT_VENDOR_DIR}:/gopath/src \
 	-e CGO_ENABLED=0 \
 	-e GOPATH=/go:/gopath \
-	golang:1.9 go build -a -x -ldflags '-s' -o /out/elastic-inference-validator /in/elastic-inference-validator.go
+	golang:1.12 go build -a -x -ldflags '-s' -o /out/elastic-inference-validator /in/elastic-inference-validator.go

--- a/misc/gremlin/Makefile
+++ b/misc/gremlin/Makefile
@@ -15,7 +15,7 @@
 all: gremlin image
 
 gremlin: gremlin.go
-	docker run -v $(shell pwd):/out -v $(shell pwd)/gremlin.go:/in/gremlin.go -e CGO_ENABLED=0 golang:1.9 go build -a -x -ldflags '-s' -o /out/gremlin /in/gremlin.go
+	docker run -v $(shell pwd):/out -v $(shell pwd)/gremlin.go:/in/gremlin.go -e CGO_ENABLED=0 golang:1.12 go build -a -x -ldflags '-s' -o /out/gremlin /in/gremlin.go
 
 image: gremlin
 	@./docker-image

--- a/misc/netkitten/Makefile
+++ b/misc/netkitten/Makefile
@@ -15,7 +15,7 @@
 all: netkitten image
 
 netkitten:
-	docker run -v $(shell pwd):/out -v $(shell pwd)/netkitten.go:/in/netkitten.go -e CGO_ENABLED=0 golang:1.9 go build -a -installsuffix cgo -ldflags '-s' -o /out/netkitten /in/netkitten.go
+	docker run -v $(shell pwd):/out -v $(shell pwd)/netkitten.go:/in/netkitten.go -e CGO_ENABLED=0 golang:1.12 go build -a -installsuffix cgo -ldflags '-s' -o /out/netkitten /in/netkitten.go
 
 image: netkitten
 	@./docker-image

--- a/misc/taskmetadata-validator/build-in-docker
+++ b/misc/taskmetadata-validator/build-in-docker
@@ -21,4 +21,4 @@ docker run \
 	-v ${AGENT_VENDOR_DIR}:/gopath/src \
 	-e CGO_ENABLED=0 \
 	-e GOPATH=/go:/gopath \
-	golang:1.9 go build -a -x -ldflags '-s' -o /out/taskmetadata-validator /in/taskmetadata-validator.go
+	golang:1.12 go build -a -x -ldflags '-s' -o /out/taskmetadata-validator /in/taskmetadata-validator.go

--- a/misc/telemetry/Dockerfile
+++ b/misc/telemetry/Dockerfile
@@ -10,7 +10,7 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-FROM golang:1.9
+FROM golang:1.12
 
 WORKDIR /gopath
 

--- a/misc/v3-task-endpoint-validator/build-in-docker
+++ b/misc/v3-task-endpoint-validator/build-in-docker
@@ -21,4 +21,4 @@ docker run \
 	-v ${AGENT_VENDOR_DIR}:/gopath/src \
 	-e CGO_ENABLED=0 \
 	-e GOPATH=/go:/gopath \
-	golang:1.9 go build -a -x -ldflags '-s' -o /out/v3-task-endpoint-validator /in/v3-task-endpoint-validator.go
+	golang:1.12 go build -a -x -ldflags '-s' -o /out/v3-task-endpoint-validator /in/v3-task-endpoint-validator.go

--- a/scripts/dockerfiles/Dockerfile.build
+++ b/scripts/dockerfiles/Dockerfile.build
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-FROM golang:1.9
+FROM golang:1.12
 MAINTAINER Amazon Web Services, Inc.
 
 RUN apt-get update && \

--- a/scripts/dockerfiles/Dockerfile.buildECSCNIPlugins
+++ b/scripts/dockerfiles/Dockerfile.buildECSCNIPlugins
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-FROM golang:1.9
+FROM golang:1.12
 MAINTAINER Amazon Web Services, Inc.
 
 RUN mkdir -p /go/src/github.com/aws/

--- a/scripts/dockerfiles/Dockerfile.cleanbuild
+++ b/scripts/dockerfiles/Dockerfile.cleanbuild
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-FROM golang:1.9
+FROM golang:1.12
 MAINTAINER Amazon Web Services, Inc.
 
 COPY ./scripts/cleanbuild /scripts/cleanbuild


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Upgrades tests, travis, and release scripts to use Golang 1.12

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
