### PR TITLE
Functional Tests: pull fewer images

### DIFF
--- a/agent/functional_tests/testdata/taskdefinitions/oom-container/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/oom-container/task-definition.json
@@ -5,8 +5,8 @@
     "memory": 64,
     "name": "error",
     "cpu": 1,
-    "image": "127.0.0.1:51670/python:2",
-    "command": ["python", "-c", "foo=' '*1024*1024*512; import time; time.sleep(10)"]
+    "image": "amazon/amazon-ecs-stress:make",
+    "command": ["-concurrency", "10", "-memory", "100"]
   }]
 }
 

--- a/agent/functional_tests/testdata/taskdefinitions/oom-task/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/oom-task/task-definition.json
@@ -5,8 +5,8 @@
     "essential": true,
     "name": "error",
     "cpu": 1,
-    "image": "127.0.0.1:51670/python:2",
-    "command": ["python", "-c", "foo=' '*1024*1024*512; import time; time.sleep(10)"]
+    "image": "amazon/amazon-ecs-stress:make",
+    "command": ["-concurrency", "10", "-memory", "100"]
   }]
 }
 

--- a/agent/functional_tests/testdata/taskdefinitions/parallel-pull/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/parallel-pull/task-definition.json
@@ -5,7 +5,6 @@
         "name": "busybox",
         "image": "127.0.0.1:51670/busybox:parallel-pull-fts",
         "cpu": 10,
-        "command":  [ "sh", "-c", "while [ true ]; do sleep 1s; date +%T; done"],
         "memory": 64,
         "essential": true
     },
@@ -14,8 +13,7 @@
         "image": "127.0.0.1:51670/ubuntu:parallel-pull-fts",
         "cpu": 10,
         "memory": 64,
-        "essential": true,
-        "command": ["bash", "-c", "while [ true ]; do date +%T; sleep 1s; done"]
+        "essential": true
     },
     {
         "name": "consul",
@@ -28,16 +26,14 @@
         "image": "127.0.0.1:51670/debian:parallel-pull-fts",
         "cpu": 10,
         "memory": 64,
-        "essential": true,
-        "command": ["bash", "-c", "while [ true ]; do date +%T; sleep 1s; done"]
+        "essential": true
     },
     {
         "name": "debian-2",
         "image": "127.0.0.1:51670/debian:parallel-pull-fts",
         "cpu": 10,
         "memory": 64,
-        "essential": true,
-        "command": ["bash", "-c", "while [ true ]; do date +%T; sleep 1s; done"]
+        "essential": true
     },
     {
         "name": "httpd",

--- a/agent/functional_tests/testdata/taskdefinitions/telemetry/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/telemetry/task-definition.json
@@ -4,6 +4,6 @@
     "containerDefinitions": [{
         "memory": 2000,
         "name": "telemetry",
-        "image": "amazon/amazon-ecs-telemetry-test:make"
+        "image": "amazon/amazon-ecs-stress:make"
     }]
 }

--- a/agent/functional_tests/tests/functionaltests_unix_test.go
+++ b/agent/functional_tests/tests/functionaltests_unix_test.go
@@ -99,7 +99,12 @@ func TestOOMContainer(t *testing.T) {
 	RequireMinimumMemory(t, 600)
 
 	RequireDockerVersion(t, "<1.9.0,>1.9.1") // https://github.com/docker/docker/issues/18510
-	agent := RunAgent(t, nil)
+	agentOptions := &AgentOptions{
+		ExtraEnvironment: map[string]string{
+			"ECS_IMAGE_PULL_BEHAVIOR": "prefer-cached",
+		},
+	}
+	agent := RunAgent(t, agentOptions)
 	defer agent.Cleanup()
 
 	testTask, err := agent.StartTask(t, "oom-container")
@@ -113,7 +118,12 @@ func TestOOMTask(t *testing.T) {
 	// oom container task requires 500MB of memory; requires a bit more to be stable
 	RequireMinimumMemory(t, 600)
 
-	agent := RunAgent(t, nil)
+	agentOptions := &AgentOptions{
+		ExtraEnvironment: map[string]string{
+			"ECS_IMAGE_PULL_BEHAVIOR": "prefer-cached",
+		},
+	}
+	agent := RunAgent(t, agentOptions)
 	defer agent.Cleanup()
 
 	agent.RequireVersion(">=1.16.0")

--- a/misc/telemetry/Makefile
+++ b/misc/telemetry/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all
 all:
-	docker build -t amazon/amazon-ecs-telemetry-test:make .
+	docker build -t amazon/amazon-ecs-stress:make .
 
 clean:
-	-docker rmi -f "amazon/amazon-ecs-telemetry-test:make"
+	-docker rmi -f "amazon/amazon-ecs-stress:make"

--- a/scripts/setup-test-registry
+++ b/scripts/setup-test-registry
@@ -67,7 +67,6 @@ docker rmi amazon/image-cleanup-test-image1:make amazon/image-cleanup-test-image
 
 mirror_image busybox:1.29.3 "127.0.0.1:51670/busybox:latest"
 mirror_image "$NGINX_IMAGE" "127.0.0.1:51670/nginx:latest"
-mirror_image python:2.7.15 "127.0.0.1:51670/python:2"
 mirror_image ubuntu:16.04 "127.0.0.1:51670/ubuntu:latest"
 
 # create a context folder used by docker build. It will only have a file

--- a/scripts/setup-test-registry
+++ b/scripts/setup-test-registry
@@ -17,7 +17,6 @@
 set -e
 
 REGISTRY_IMAGE="registry:2.7.0"
-
 NGINX_IMAGE="nginx:1.15.8"
 
 ROOT=$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )
@@ -45,52 +44,48 @@ mirror_local_image() {
   docker rmi $2
 }
 
+setup_parallel_pull_image() {
+  local image_name="127.0.0.1:51670/$1:parallel-pull-fts"
+  echo "Generating parallel pull image $image_name"
+ 
+  # Get new random bits every time we build 
+  head -c 25m < /dev/urandom > docker-context/random-bits
+  docker build -t "$image_name" docker-context
+
+  echo "Done generating parallel pull image $image_name"
+  mirror_local_image "$image_name" "$image_name"
+}
+
+
 for image in "amazon/amazon-ecs-netkitten" "amazon/amazon-ecs-volumes-test" "amazon/amazon-ecs-pid-namespace-test" "amazon/amazon-ecs-ipc-namespace-test" "amazon/squid" "amazon/awscli" "amazon/image-cleanup-test-image1" "amazon/image-cleanup-test-image2" "amazon/image-cleanup-test-image3" "amazon/fluentd" "amazon/amazon-ecs-agent-introspection-validator" "amazon/amazon-ecs-taskmetadata-validator" "amazon/amazon-ecs-v3-task-endpoint-validator" "amazon/amazon-ecs-container-metadata-file-validator" "amazon/amazon-ecs-elastic-inference-validator" "amazon/amazon-appmesh-plugin-validator"; do
   mirror_local_image "${image}:make" "127.0.0.1:51670/${image}:latest"
 done
 
 
 # Remove the tag so this image can be deleted successfully in the docker image cleanup integ tests
-docker rmi amazon/image-cleanup-test-image1:make
-docker rmi amazon/image-cleanup-test-image2:make
-docker rmi amazon/image-cleanup-test-image3:make
+docker rmi amazon/image-cleanup-test-image1:make amazon/image-cleanup-test-image2:make amazon/image-cleanup-test-image3:make
 
-BUSYBOX_IMAGE="busybox:1.29.3"
-NGINX_IMAGE="nginx:1.15.8"
-PYTHON2_IMAGE="python:2.7.15"
-UBUNTU_IMAGE="ubuntu:16.04"
+mirror_image busybox:1.29.3 "127.0.0.1:51670/busybox:latest"
+mirror_image "$NGINX_IMAGE" "127.0.0.1:51670/nginx:latest"
+mirror_image python:2.7.15 "127.0.0.1:51670/python:2"
+mirror_image ubuntu:16.04 "127.0.0.1:51670/ubuntu:latest"
 
-PARALLEL_PULL_FTS_BUSYBOX=${BUSYBOX_IMAGE}
-PARALLEL_PULL_FTS_UBUNTU=${UBUNTU_IMAGE}
-PARALLEL_PULL_FTS_NGINX=${NGINX_IMAGE}
-PARALLEL_PULL_FTS_CONSUL="consul:1.3.0"
-PARALLEL_PULL_FTS_DEBIAN="debian:stable"
+# create a context folder used by docker build. It will only have a file
+# full of random bits so that the parallel pull images are different.
+mkdir -p docker-context
+cat << EOF > docker-context/Dockerfile
+FROM amazon/amazon-ecs-pause:0.1.0 
+ADD random-bits /random-bits
+EOF
 
-BUILD_PLATFORM=$(uname -m)
+for image in "busybox" "ubuntu" "consul" "debian" "httpd" "crux" "nginx" "redis"; do
+  setup_parallel_pull_image $image
+done
 
-if [[ "$BUILD_PLATFORM" == "aarch64" ]]; then
-    PARALLEL_PULL_FTS_HTTPD="arm64v8/httpd:2.4"
-else
-    PARALLEL_PULL_FTS_HTTPD="httpd@sha256:0d817a924bed1a216f12a0f4947b5f8a2f173bd5a9cebfe1382d024287154c99"
-fi
+# cleanup the context
+rm -rf docker-context 
 
-PARALLEL_PULL_FTS_CRUX="crux:3.0"
-PARALLEL_PULL_FTS_REDIS="redis:4.0.13"
-PARALLEL_PULL_FTS_REGISTRY=${REGISTRY_IMAGE}
-
-mirror_image ${BUSYBOX_IMAGE} "127.0.0.1:51670/busybox:latest"
-mirror_image ${NGINX_IMAGE} "127.0.0.1:51670/nginx:latest"
-mirror_image ${PYTHON2_IMAGE} "127.0.0.1:51670/python:2"
-mirror_image ${UBUNTU_IMAGE} "127.0.0.1:51670/ubuntu:latest"
-mirror_image ${PARALLEL_PULL_FTS_BUSYBOX} "127.0.0.1:51670/busybox:parallel-pull-fts"
-mirror_image ${PARALLEL_PULL_FTS_UBUNTU} "127.0.0.1:51670/ubuntu:parallel-pull-fts"
-mirror_image ${PARALLEL_PULL_FTS_CONSUL} "127.0.0.1:51670/consul:parallel-pull-fts"
-mirror_image ${PARALLEL_PULL_FTS_DEBIAN} "127.0.0.1:51670/debian:parallel-pull-fts"
-mirror_image ${PARALLEL_PULL_FTS_HTTPD} "127.0.0.1:51670/httpd:parallel-pull-fts"
-mirror_image ${PARALLEL_PULL_FTS_CRUX} "127.0.0.1:51670/crux:parallel-pull-fts"
-mirror_image ${PARALLEL_PULL_FTS_NGINX} "127.0.0.1:51670/nginx:parallel-pull-fts"
-mirror_image ${PARALLEL_PULL_FTS_REDIS} "127.0.0.1:51670/redis:parallel-pull-fts"
-mirror_local_image ${PARALLEL_PULL_FTS_REGISTRY} "127.0.0.1:51670/registry:parallel-pull-fts"
+mirror_local_image "${REGISTRY_IMAGE}" "127.0.0.1:51670/registry:parallel-pull-fts"
 
 
 # Now setup a v2 registry with auth... aka nginx with basic auth in front of it


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This removes the need to pull python, consul, debian, httpd, crux, and redis containers as part of the functional test run.

### Implementation details
Many of the containers were only used for the parallel pull test. However, this was kind of slow and caused occasional failures (particularly in Arm testing).   Reducing the number of pulls should make testing more consistent. 

One way of doing this is to generate the containers on disk instead. For parallel pull, the content isn't important: it only matters that we are pulling lots of containers at once. 

For python, we only required it for a one-liner to allocate memory. The telemetry container already does this, so I'm reusing that instead of pulling python.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
