### PR TITLE
engine: update container metadata when container status stays the same

### DIFF
--- a/agent/engine/docker_image_manager_test.go
+++ b/agent/engine/docker_image_manager_test.go
@@ -1065,7 +1065,7 @@ func TestDeleteImage(t *testing.T) {
 }
 
 // This test tests that we detect correctly in agent when the agent is trying to delete image that
-// does not exist for older version of docker. 
+// does not exist for older version of docker.
 func TestDeleteImageNotFoundOldDockerMessageError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/agent/engine/ordering_integ_test.go
+++ b/agent/engine/ordering_integ_test.go
@@ -432,7 +432,6 @@ func TestShutdownOrder(t *testing.T) {
 	waitFinished(t, finished, shutdownOrderingTimeout)
 }
 
-
 func waitFinished(t *testing.T, finished <-chan interface{}, duration time.Duration) {
 	select {
 	case <-finished:

--- a/agent/engine/ordering_integ_unix_test.go
+++ b/agent/engine/ordering_integ_unix_test.go
@@ -49,11 +49,11 @@ func TestGranularStopTimeout(t *testing.T) {
 	parent.DependsOn = []apicontainer.DependsOn{
 		{
 			ContainerName: "dependency1",
-			Condition: "START",
+			Condition:     "START",
 		},
 		{
 			ContainerName: "dependency2",
-			Condition: "START",
+			Condition:     "START",
 		},
 	}
 


### PR DESCRIPTION
Agent discards container metadata update for redundant container status changing, however, for some cases, even the status is not changed, the metadata may change. Using container health status as an example, there is situation that when container status just transits to RUNNING, health status is still UNKNOWN and after some time, it changes to HEALTHY.

### Summary
<!-- What does this pull request do? -->

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->
yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
