### PR TITLE
Fix for TestOOMTask

### DIFF
--- a/agent/functional_tests/util/utils_unix.go
+++ b/agent/functional_tests/util/utils_unix.go
@@ -38,6 +38,7 @@ import (
 	dockercontainer "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 	docker "github.com/docker/docker/client"
+	"runtime"
 )
 
 const (
@@ -260,7 +261,14 @@ func (agent *TestAgent) StartAgent() error {
 // * EXECDRIVER_PATH: the path of metrics
 func (agent *TestAgent) getBindMounts() []string {
 	var binds []string
-	cgroupPath := utils.DefaultIfBlank(os.Getenv("CGROUP_PATH"), defaultCgroupPath)
+	var cgroupPath string
+
+	if runtime.GOARCH == "arm64" {
+		cgroupPath = utils.DefaultIfBlank(os.Getenv("CGROUP_PATH"), defaultCgroupPathAgentMount)
+	} else {
+		cgroupPath = utils.DefaultIfBlank(os.Getenv("CGROUP_PATH"), defaultCgroupPath)
+	}
+
 	cgroupBind := cgroupPath + ":" + defaultCgroupPathAgentMount
 	binds = append(binds, cgroupBind)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

ARM and AL2 instances have cgroupPath in a different path than for AL1 instances. That is why TestOOMTask was failing on ARM instances but passing for the linux functional test suite.

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
