### PR TITLE
Fix inactivity timeout unit tests

### DIFF
--- a/agent/dockerclient/dockerapi/docker_client_test.go
+++ b/agent/dockerclient/dockerapi/docker_client_test.go
@@ -169,7 +169,7 @@ func TestPullImageInactivityTimeout(t *testing.T) {
 	mockDockerSDK, client, testTime, _, _, done := dockerClientSetup(t)
 	defer done()
 
-	client.config.ImagePullInactivityTimeout = 100 * time.Millisecond
+	client.config.ImagePullInactivityTimeout = 1 * time.Millisecond
 
 	testTime.EXPECT().After(gomock.Any()).AnyTimes()
 	mockDockerSDK.EXPECT().ImagePull(gomock.Any(), "image:latest", gomock.Any()).DoAndReturn(
@@ -1067,7 +1067,7 @@ func waitForStats(t *testing.T, stat *types.StatsJSON) {
 }
 
 func TestStatsInactivityTimeout(t *testing.T) {
-	shortInactivityTimeout := 100 * time.Millisecond
+	shortInactivityTimeout := 1 * time.Millisecond
 	mockDockerSDK, client, _, _, _, done := dockerClientSetup(t)
 	defer done()
 	mockDockerSDK.EXPECT().ContainerStats(gomock.Any(), gomock.Any(), true).Return(types.ContainerStats{


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Fix inactivity timeout unit tests - https://github.com/aws/amazon-ecs-agent/issues/1918 https://github.com/aws/amazon-ecs-agent/issues/1864

### Implementation details
<!-- How are the changes implemented? -->
In TestPullImageInactivityTimeout and TestStatsInactivityTimeout, on rare case, the inactivity handling goroutine has some delay and isn't able to trigger inactivity timeout before the reader finishes reading. This only happens in travis windows unit test, and when i reproduce (by triggering travis in my own fork), TestPullImageInactivityTimeout fails about 1 in 1000 times and TestStatsInactivityTimeout fails once in 3000 times. After reducing the timeout to 1 the tests don't fail in 5000 times.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
