### PR TITLE
Revise telemetry tests to use average across normalized datapoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,7 @@ test-in-docker:
 	docker run --net=none -v "$(PWD):/go/src/github.com/aws/amazon-ecs-agent" --privileged "amazon/amazon-ecs-agent-test:make"
 
 run-functional-tests: testnnp test-registry ecr-execution-role-image telemetry-test-image
-	. ./scripts/shared_env && go test -tags functional -timeout=45m -v ./agent/functional_tests/...
+	. ./scripts/shared_env && go test -tags functional -timeout=60m -v ./agent/functional_tests/...
 
 .PHONY: build-image-for-ecr ecr-execution-role-image-for-upload upload-images replicate-images
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Updates testTelemetry functional tests to validate against a trimmed average across multiple CloudWatch DataPoints rather validate against a single CloudWatch datapoint (which we are currently doing)
This also re-orders the telemetry test code and adds comments so it is more clear to follow.

NOTE this change adds 12 minutes to the total length of the functional tests.  See implementation details below for more.

### Implementation details
The test has been flaky because docker stats logs errant metrics which sometimes land outside our delta of +|- 5%.  We are only checking a single CloudWatch DataPoint, which means that we have a higher risk of failure.
I ran the telemetry task multiple times on various architectures (linux|arm|windows|gpu) and captured the metrics.  For each there were errant spikes or valleys sometimes greater than our delta, especially for windows.  
Currently, we poll CloudWatch metrics for 4 minutes in each state (idle|busy|idle) which gets us ~2 CloudWatch DataPoints for each state.  We take the last DataPoint's .Average field and validate whether it lands within the delta.  

To make the test less flaky I am polling for a longer period so we end up with more DataPoints ~7-8 for a 10 minute 'busy' polling interval.  I trim off the max and min points, then average up the remaining points.  This gets us a more indicative true average to check against.   

### Testing
I ran this with various polling windows across multiple architectures.  This helped me land on an ideal polling interval of 10 minutes; Over 100 runs I found that more time didn't alleviate the errant failures, and less time increased the failure rate more as I removed DataPoints.  
I found that the idle state never had peaks larger that ~0.1% which meant that I could use the original polling interval of 4 minutes.  
I have verbose logs of the updates complete with timings and CloudWatch DataPoint array values for anyone who wants them.

Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

### Description for the changelog
Update testTelemetry functional tests to use trimmed average.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
