### PR TITLE
Make acs handler tests more predictable

### DIFF
--- a/agent/acs/handler/acs_handler.go
+++ b/agent/acs/handler/acs_handler.go
@@ -206,7 +206,7 @@ func (acsSession *session) Start() error {
 			if shouldReconnectWithoutBackoff(acsError) {
 				// If ACS closed the connection, there's no need to backoff,
 				// reconnect immediately
-				seelog.Info("ACS Websocket connection closed for a valid reason")
+				seelog.Infof("ACS Websocket connection closed for a valid reason: %v", acsError)
 				acsSession.backoff.Reset()
 				sendEmptyMessageOnChannel(connectToACS)
 			} else {
@@ -219,6 +219,7 @@ func (acsSession *session) Start() error {
 					// If the context was not cancelled and we've waited for the
 					// wait duration without any errors, send the message to the channel
 					// to reconnect to ACS
+					seelog.Info("Done waiting; reconnecting to ACS")
 					sendEmptyMessageOnChannel(connectToACS)
 				} else {
 					// Wait was interrupted. We expect the session to close as canceling
@@ -308,6 +309,7 @@ func (acsSession *session) startACSSession(client wsclient.ClientServer) error {
 		seelog.Errorf("Error connecting to ACS: %v", err)
 		return err
 	}
+
 	seelog.Info("Connected to ACS endpoint")
 	// Start inactivity timer for closing the connection
 	timer := newDisconnectionTimer(client, acsSession.heartbeatTimeout(), acsSession.heartbeatJitter())
@@ -337,11 +339,13 @@ func (acsSession *session) startACSSession(client wsclient.ClientServer) error {
 		case <-acsSession.ctx.Done():
 			// Stop receiving and sending messages from and to ACS when
 			// the context received from the main function is canceled
+			seelog.Infof("ACS session context cancelled.")
 			return acsSession.ctx.Err()
 		case err := <-serveErr:
 			// Stop receiving and sending messages from and to ACS when
 			// client.Serve returns an error. This can happen when the
 			// the connection is closed by ACS or the agent
+			seelog.Errorf("Error serving to ACS Webserver: %v", err)
 			return err
 		}
 	}

--- a/agent/acs/handler/acs_handler_test.go
+++ b/agent/acs/handler/acs_handler_test.go
@@ -225,7 +225,7 @@ func TestHandlerReconnectsOnConnectErrors(t *testing.T) {
 		// test  to time out as the context is never cancelled
 		mockWsClient.EXPECT().Connect().Do(func() {
 			cancel()
-		}).MinTimes(1),
+		}).Return(nil).MinTimes(1),
 	)
 	acsSession := session{
 		containerInstanceARN: "myArn",
@@ -717,7 +717,7 @@ func TestHandlerReconnectsOnDiscoverPollEndpointError(t *testing.T) {
 	mockWsClient.EXPECT().Connect().Do(func() {
 		// Serve() cancels the context
 		cancel()
-	}).MinTimes(1)
+	}).Return(nil).MinTimes(1)
 
 	gomock.InOrder(
 		// DiscoverPollEndpoint returns an error on its first invocation

--- a/agent/acs/handler/acs_handler_test.go
+++ b/agent/acs/handler/acs_handler_test.go
@@ -215,6 +215,7 @@ func TestHandlerReconnectsOnConnectErrors(t *testing.T) {
 	mockWsClient := mock_wsclient.NewMockClientServer(ctrl)
 	mockWsClient.EXPECT().SetAnyRequestHandler(gomock.Any()).AnyTimes()
 	mockWsClient.EXPECT().AddRequestHandler(gomock.Any()).AnyTimes()
+	mockWsClient.EXPECT().Serve().AnyTimes()
 	mockWsClient.EXPECT().Close().Return(nil).AnyTimes()
 	gomock.InOrder(
 		// Connect fails 10 times
@@ -224,7 +225,7 @@ func TestHandlerReconnectsOnConnectErrors(t *testing.T) {
 		// test  to time out as the context is never cancelled
 		mockWsClient.EXPECT().Connect().Do(func() {
 			cancel()
-		}).Return(io.EOF).MinTimes(1),
+		}).MinTimes(1),
 	)
 	acsSession := session{
 		containerInstanceARN: "myArn",
@@ -616,7 +617,7 @@ func TestHandlerReconnectsOnServeErrors(t *testing.T) {
 		// test to time out as the context is never cancelled
 		mockWsClient.EXPECT().Serve().Do(func() {
 			cancel()
-		}).Return(io.EOF),
+		}),
 	)
 
 	acsSession := session{
@@ -711,12 +712,12 @@ func TestHandlerReconnectsOnDiscoverPollEndpointError(t *testing.T) {
 	mockWsClient := mock_wsclient.NewMockClientServer(ctrl)
 	mockWsClient.EXPECT().SetAnyRequestHandler(gomock.Any()).AnyTimes()
 	mockWsClient.EXPECT().AddRequestHandler(gomock.Any()).AnyTimes()
-	mockWsClient.EXPECT().Connect().Return(nil).AnyTimes()
+	mockWsClient.EXPECT().Serve().AnyTimes()
 	mockWsClient.EXPECT().Close().Return(nil).AnyTimes()
-	mockWsClient.EXPECT().Serve().Do(func() {
+	mockWsClient.EXPECT().Connect().Do(func() {
 		// Serve() cancels the context
 		cancel()
-	}).Return(io.EOF).MinTimes(1)
+	}).MinTimes(1)
 
 	gomock.InOrder(
 		// DiscoverPollEndpoint returns an error on its first invocation
@@ -761,7 +762,6 @@ func TestHandlerReconnectsOnDiscoverPollEndpointError(t *testing.T) {
 	if timeSinceStart > 2*connectionBackoffMin {
 		t.Errorf("Duration since start is greater than maximum anticipated wait time: %v", timeSinceStart.String())
 	}
-
 }
 
 // TestConnectionIsClosedOnIdle tests if the connection to ACS is closed


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary

Currently in the [select statement here](https://github.com/aws/amazon-ecs-agent/blob/aabe65ee15a013a6bc594da52b94d817419ee74a/agent/acs/handler/acs_handler.go#L335), both the conditions `<-acsSession.ctx.Done()` and `err := <-serveErr` will be true for the tests `TestHandlerReconnectsOnConnectErrors`, `TestHandlerReconnectsOnDiscoverPollEndpointError` towards the end of the test, because of how the mocks are structured in the test. Specifically:

```Go
	mockWsClient.EXPECT().Serve().Do(func() {
		// Serve() cancels the context
		cancel()
	}).Return(io.EOF).MinTimes(1)
```
`Cancel()` triggers the `<-acsSession.ctx.Done()` part and `.Return(io.EOF)` triggers the `err := <-serveErr`. 

This makes the behavior of the function unpredictable as either of the select condition could be selected and each it leads to different code path when it returns to `Start()` function.

By changing the mock to 

```Go
mockWsClient.EXPECT().Connect().Do(func() {
		// Serve() cancels the context
		cancel()
	}).Return(nil).MinTimes(1)
```
We have a more predictable path for the test where it will always trigger `<-acsSession.ctx.Done()` in the select case. 

Also adding some logs which will help in tracing out what code path test is taking. 

### Implementation details
<!-- How are the changes implemented? -->

### Testing
Tested by adding `close(connectToACS)` [here](https://github.com/aws/amazon-ecs-agent/blob/master/agent/acs/handler/acs_handler.go#L231) and running `TestHandlerReconnectsOnConnectErrors`, `TestHandlerReconnectsOnDiscoverPollEndpointError` 100 times each. The tests passed everytime after this change, failed intermittently before. 
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
