### PR TITLE
eni/watcher: skip logging eni status sent error

### DIFF
--- a/agent/eni/watcher/watcher_linux.go
+++ b/agent/eni/watcher/watcher_linux.go
@@ -18,6 +18,7 @@ package watcher
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	log "github.com/cihub/seelog"
@@ -73,6 +74,10 @@ const (
 	// for the host to learn about an ENIs mac address from netlink.LinkList().
 	// We are capping off this duration to 1s assuming worst-case behavior
 	macAddressRetryTimeout = 2 * time.Second
+
+	// eniStatusSentMsg is the error message to use when trying to send an eni status that's
+	// already been sent
+	eniStatusSentMsg = "eni status already sent"
 )
 
 // UdevWatcher maintains the state of attached ENIs
@@ -184,6 +189,11 @@ func (udevWatcher *UdevWatcher) reconcileOnce() error {
 	// Add new interfaces next
 	for mac := range currentState {
 		if err := udevWatcher.sendENIStateChange(mac); err != nil {
+			// skip logging status sent error as it's redundant and doesn't really indicate a problem
+			if strings.Contains(err.Error(), eniStatusSentMsg) {
+				continue
+			}
+
 			log.Warnf("Udev watcher reconciliation: unable to send state change: %v", err)
 		}
 	}
@@ -201,7 +211,7 @@ func (udevWatcher *UdevWatcher) sendENIStateChange(mac string) error {
 		return &unmanagedENIError{mac}
 	}
 	if eni.IsSent() {
-		return errors.Errorf("udev watcher send ENI state change: eni status already sent: %s", eni.String())
+		return errors.Errorf("udev watcher send ENI state change: %s: %s", eniStatusSentMsg, eni.String())
 	}
 	if eni.HasExpired() {
 		// Agent is aware of the ENI, but we decide not to ack it


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Currently when eni trunking is turned on, the following warning log repeatedly appears every 30 seconds:
```
2019-04-18T02:43:50Z [WARN] Udev watcher reconciliation: unable to send state change: udev watcher send ENI state change: eni status already sent: ENI Attachment: attachment=arn:aws:ecs:us-west-2:xxxxx:attachment/31ed60cc-4aa9-4d69-9281-b0fa9ee50b0a;attachmentType=instance-eni;attachmentSent=true;mac=06:49:fd:79:f4:10;status=ATTACHED;expiresAt=2019-04-18 02:45:53.693192688 +0000 UTC m=+183.540686203
```
This does not really indicate a problem since we did not actually call the api to send something we already sent. it's just that the watcher will log this whenever it finds the eni. In eni trunking we attach an ENI upon startup, so the log appears all the time. Since we already have log when submitting eni state change, this log is not needed for debug and is confusing, so removing it.

Note that the log is also removed when eni trunking is disabled, as i don't think it has any value in that case either so didn't differentiate between the two.

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

Manually tested this by launching an instance with eni trunking enabled.


### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
