### PR TITLE
Increasing verbosity of some of our logs

### DIFF
--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -892,7 +892,7 @@ func (task *Task) UpdateMountPoints(cont *apicontainer.Container, vols []types.M
 // there was no change
 // Invariant: task known status is the minimum of container known status
 func (task *Task) updateTaskKnownStatus() (newStatus apitaskstatus.TaskStatus) {
-	seelog.Debugf("Updating task's known status, task: %s", task.String())
+	seelog.Debugf("api/task: Updating task's known status, task: %s", task.String())
 	// Set to a large 'impossible' status that can't be the min
 	containerEarliestKnownStatus := apicontainerstatus.ContainerZombie
 	var earliestKnownStatusContainer *apicontainer.Container
@@ -913,7 +913,7 @@ func (task *Task) updateTaskKnownStatus() (newStatus apitaskstatus.TaskStatus) {
 			containerEarliestKnownStatus.String(), task)
 		return apitaskstatus.TaskStatusNone
 	}
-	seelog.Debugf("Container with earliest known container is [%s] for task: %s",
+	seelog.Debugf("api/task: Container with earliest known container is [%s] for task: %s",
 		earliestKnownStatusContainer.String(), task.String())
 	// If the essential container is stopped while other containers may be running
 	// don't update the task status until the other containers are stopped.
@@ -929,7 +929,7 @@ func (task *Task) updateTaskKnownStatus() (newStatus apitaskstatus.TaskStatus) {
 	// statuses and compute the min of this
 	earliestKnownTaskStatus := task.getEarliestKnownTaskStatusForContainers()
 	if task.GetKnownStatus() < earliestKnownTaskStatus {
-		seelog.Debugf("Updating task's known status to: %s, task: %s",
+		seelog.Infof("api/task: Updating task's known status to: %s, task: %s",
 			earliestKnownTaskStatus.String(), task.String())
 		task.SetKnownStatus(earliestKnownTaskStatus)
 		return task.GetKnownStatus()
@@ -1482,7 +1482,7 @@ func (task *Task) updateTaskDesiredStatusUnsafe() {
 	// Otherwise, the task's desired status is unchanged (typically running, but no need to change)
 	for _, cont := range task.Containers {
 		if cont.Essential && (cont.KnownTerminal() || cont.DesiredTerminal()) {
-			seelog.Debugf("Updating task desired status to stopped because of container: [%s]; task: [%s]",
+			seelog.Infof("api/task: Updating task desired status to stopped because of container: [%s]; task: [%s]",
 				cont.Name, task.stringUnsafe())
 			task.DesiredStatusUnsafe = apitaskstatus.TaskStopped
 		}

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -452,7 +452,7 @@ func (engine *DockerTaskEngine) sweepTask(task *apitask.Task) {
 	for _, cont := range task.Containers {
 		err := engine.removeContainer(task, cont)
 		if err != nil {
-			seelog.Debugf("Task engine [%s]: unable to remove old container [%s]: %v",
+			seelog.Infof("Task engine [%s]: unable to remove old container [%s]: %v",
 				task.Arn, cont.Name, err)
 		}
 		// Internal container(created by ecs-agent) state isn't recorded
@@ -483,7 +483,7 @@ func (engine *DockerTaskEngine) deleteTask(task *apitask.Task) {
 			seelog.Warnf("Task engine [%s]: unable to cleanup resource %s: %v",
 				task.Arn, resource.GetName(), err)
 		} else {
-			seelog.Debugf("Task engine [%s]: resource %s cleanup complete", task.Arn,
+			seelog.Infof("Task engine [%s]: resource %s cleanup complete", task.Arn,
 				resource.GetName())
 		}
 	}
@@ -495,10 +495,10 @@ func (engine *DockerTaskEngine) deleteTask(task *apitask.Task) {
 	if eni == nil {
 		seelog.Debugf("Task engine [%s]: no eni associated with task", task.Arn)
 	} else {
-		seelog.Debugf("Task engine [%s]: removing the eni from agent state", task.Arn)
+		seelog.Infof("Task engine [%s]: removing the eni from agent state", task.Arn)
 		engine.state.RemoveENIAttachment(eni.MacAddress)
 	}
-	seelog.Debugf("Task engine [%s]: finished removing task data, removing task from managed tasks", task.Arn)
+	seelog.Infof("Task engine [%s]: finished removing task data, removing task from managed tasks", task.Arn)
 	delete(engine.managedTasks, task.Arn)
 	engine.tasksLock.Unlock()
 	engine.saver.Save()
@@ -507,7 +507,7 @@ func (engine *DockerTaskEngine) deleteTask(task *apitask.Task) {
 func (engine *DockerTaskEngine) emitTaskEvent(task *apitask.Task, reason string) {
 	event, err := api.NewTaskStateChangeEvent(task, reason)
 	if err != nil {
-		seelog.Debugf("Task engine [%s]: unable to create task state change event: %v", task.Arn, err)
+		seelog.Infof("Task engine [%s]: unable to create task state change event: %v", task.Arn, err)
 		return
 	}
 

--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -216,7 +216,7 @@ func (mtask *managedTask) overseeTask() {
 		if !mtask.GetKnownStatus().Terminal() {
 			// If we aren't terminal and we aren't steady state, we should be
 			// able to move some containers along.
-			seelog.Debugf("Managed task [%s]: task not steady state or terminal; progressing it",
+			seelog.Infof("Managed task [%s]: task not steady state or terminal; progressing it",
 				mtask.Arn)
 
 			mtask.progressTask()
@@ -238,7 +238,7 @@ func (mtask *managedTask) overseeTask() {
 	}
 	// We only break out of the above if this task is known to be stopped. Do
 	// onetime cleanup here, including removing the task after a timeout
-	seelog.Debugf("Managed task [%s]: task has reached stopped. Waiting for container cleanup", mtask.Arn)
+	seelog.Infof("Managed task [%s]: task has reached stopped. Waiting for container cleanup", mtask.Arn)
 	mtask.cleanupCredentials()
 	if mtask.StopSequenceNumber != 0 {
 		seelog.Debugf("Managed task [%s]: marking done for this sequence: %d",
@@ -336,25 +336,25 @@ func (mtask *managedTask) cleanupCredentials() {
 // channel. When the Done channel is signalled by the context, waitEvent will
 // return true.
 func (mtask *managedTask) waitEvent(stopWaiting <-chan struct{}) bool {
-	seelog.Debugf("Managed task [%s]: waiting for event for task", mtask.Arn)
+	seelog.Infof("Managed task [%s]: waiting for event for task", mtask.Arn)
 	select {
 	case acsTransition := <-mtask.acsMessages:
-		seelog.Debugf("Managed task [%s]: got acs event", mtask.Arn)
+		seelog.Infof("Managed task [%s]: got acs event", mtask.Arn)
 		mtask.handleDesiredStatusChange(acsTransition.desiredStatus, acsTransition.seqnum)
 		return false
 	case dockerChange := <-mtask.dockerMessages:
-		seelog.Debugf("Managed task [%s]: got container [%s] event: [%s]",
+		seelog.Infof("Managed task [%s]: got container [%s] event: [%s]",
 			mtask.Arn, dockerChange.container.Name, dockerChange.event.Status.String())
 		mtask.handleContainerChange(dockerChange)
 		return false
 	case resChange := <-mtask.resourceStateChangeEvent:
 		res := resChange.resource
-		seelog.Debugf("Managed task [%s]: got resource [%s] event: [%s]",
+		seelog.Infof("Managed task [%s]: got resource [%s] event: [%s]",
 			mtask.Arn, res.GetName(), res.StatusString(resChange.nextState))
 		mtask.handleResourceStateChange(resChange)
 		return false
 	case <-stopWaiting:
-		seelog.Debugf("Managed task [%s]: no longer waiting", mtask.Arn)
+		seelog.Infof("Managed task [%s]: no longer waiting", mtask.Arn)
 		return true
 	}
 }
@@ -366,15 +366,15 @@ func (mtask *managedTask) waitEvent(stopWaiting <-chan struct{}) bool {
 func (mtask *managedTask) handleDesiredStatusChange(desiredStatus apitaskstatus.TaskStatus, seqnum int64) {
 	// Handle acs message changes this task's desired status to whatever
 	// acs says it should be if it is compatible
-	seelog.Debugf("Managed task [%s]: new acs transition to: %s; sequence number: %d; task stop sequence number: %d",
+	seelog.Infof("Managed task [%s]: new acs transition to: %s; sequence number: %d; task stop sequence number: %d",
 		mtask.Arn, desiredStatus.String(), seqnum, mtask.StopSequenceNumber)
 	if desiredStatus <= mtask.GetDesiredStatus() {
-		seelog.Debugf("Managed task [%s]: redundant task transition from [%s] to [%s], ignoring",
+		seelog.Infof("Managed task [%s]: redundant task transition from [%s] to [%s], ignoring",
 			mtask.Arn, mtask.GetDesiredStatus().String(), desiredStatus.String())
 		return
 	}
 	if desiredStatus == apitaskstatus.TaskStopped && seqnum != 0 && mtask.GetStopSequenceNumber() == 0 {
-		seelog.Debugf("Managed task [%s]: task moving to stopped, adding to stopgroup with sequence number: %d",
+		seelog.Infof("Managed task [%s]: task moving to stopped, adding to stopgroup with sequence number: %d",
 			mtask.Arn, seqnum)
 		mtask.SetStopSequenceNumber(seqnum)
 		mtask.taskStopWG.Add(seqnum, 1)
@@ -397,7 +397,7 @@ func (mtask *managedTask) handleContainerChange(containerChange dockerContainerC
 	}
 
 	event := containerChange.event
-	seelog.Debugf("Managed task [%s]: handling container change [%v] for container [%s]",
+	seelog.Infof("Managed task [%s]: handling container change [%v] for container [%s]",
 		mtask.Arn, event, container.Name)
 
 	// If this is a backwards transition stopped->running, the first time set it
@@ -438,7 +438,7 @@ func (mtask *managedTask) handleContainerChange(containerChange dockerContainerC
 
 	mtask.emitContainerEvent(mtask.Task, container, "")
 	if mtask.UpdateStatus() {
-		seelog.Debugf("Managed task [%s]: container change also resulted in task change [%s]: [%s]",
+		seelog.Infof("Managed task [%s]: container change also resulted in task change [%s]: [%s]",
 			mtask.Arn, container.Name, mtask.GetDesiredStatus().String())
 		// If knownStatus changed, let it be known
 		var taskStateChangeReason string
@@ -447,8 +447,6 @@ func (mtask *managedTask) handleContainerChange(containerChange dockerContainerC
 		}
 		mtask.emitTaskEvent(mtask.Task, taskStateChangeReason)
 	}
-	seelog.Debugf("Managed task [%s]: container change also resulted in task change [%s]: [%s]",
-		mtask.Arn, container.Name, mtask.GetDesiredStatus().String())
 }
 
 // handleResourceStateChange attempts to update resource's known status depending on
@@ -477,7 +475,7 @@ func (mtask *managedTask) handleResourceStateChange(resChange resourceStateChang
 		mtask.engine.saver.Save()
 		return
 	}
-	seelog.Debugf("Managed task [%s]: error while transitioning resource %s to %s: %v",
+	seelog.Infof("Managed task [%s]: unable to transition resource %s to %s: %v",
 		mtask.Arn, res.GetName(), res.StatusString(status), err)
 	if status == res.SteadyState() {
 		seelog.Errorf("Managed task [%s]: error while creating resource %s, setting the task's desired status to STOPPED",
@@ -513,7 +511,7 @@ func (mtask *managedTask) emitTaskEvent(task *apitask.Task, reason string) {
 func (mtask *managedTask) emitContainerEvent(task *apitask.Task, cont *apicontainer.Container, reason string) {
 	event, err := api.NewContainerStateChangeEvent(task, cont, reason)
 	if err != nil {
-		seelog.Debugf("Managed task [%s]: unable to create state change event for container [%s]: %v",
+		seelog.Infof("Managed task [%s]: unable to create state change event for container [%s]: %v",
 			task.Arn, cont.Name, err)
 		return
 	}
@@ -796,9 +794,8 @@ func (mtask *managedTask) progressTask() {
 	// transitions to complete
 	mtask.waitForTransition(transitions, transitionChange, transitionChangeEntity)
 	// update the task status
-	changed := mtask.UpdateStatus()
-	if changed {
-		seelog.Debugf("Managed task [%s]: container or resource change also resulted in task change", mtask.Arn)
+	if mtask.UpdateStatus() {
+		seelog.Infof("Managed task [%s]: container or resource change also resulted in task change", mtask.Arn)
 
 		// If knownStatus changed, let it be known
 		var taskStateChangeReason string
@@ -814,14 +811,14 @@ func (mtask *managedTask) progressTask() {
 func (mtask *managedTask) isWaitingForACSExecutionCredentials(reasons []error) bool {
 	for _, reason := range reasons {
 		if reason == dependencygraph.CredentialsNotResolvedErr {
-			seelog.Debugf("Managed task [%s]: waiting for credentials to pull from ECR", mtask.Arn)
+			seelog.Infof("Managed task [%s]: waiting for credentials to pull from ECR", mtask.Arn)
 
 			timeoutCtx, timeoutCancel := context.WithTimeout(mtask.ctx, waitForPullCredentialsTimeout)
 			defer timeoutCancel()
 
 			timedOut := mtask.waitEvent(timeoutCtx.Done())
 			if timedOut {
-				seelog.Debugf("Managed task [%s]: timed out waiting for acs credentials message", mtask.Arn)
+				seelog.Infof("Managed task [%s]: timed out waiting for acs credentials message", mtask.Arn)
 			}
 			return true
 		}
@@ -943,7 +940,7 @@ func (mtask *managedTask) applyResourceState(resource taskresource.TaskResource,
 			mtask.Arn, resName, resStatus, err)
 		return err
 	}
-	seelog.Debugf("Managed task [%s]: transitioned resource [%s] to [%s]",
+	seelog.Infof("Managed task [%s]: transitioned resource [%s] to [%s]",
 		mtask.Arn, resName, resStatus)
 	return nil
 }
@@ -1098,7 +1095,7 @@ func (mtask *managedTask) cleanupTask(taskStoppedDuration time.Duration) {
 	// There is a potential deadlock here if cleanupTime is negative. Ignore the computed
 	// value in this case in favor of the default config value.
 	if cleanupTimeDuration < 0 {
-		seelog.Debugf("Managed task [%s]: Cleanup Duration is too short. Resetting to: %s",
+		seelog.Infof("Managed task [%s]: Cleanup Duration is too short. Resetting to: %s",
 			mtask.Arn, config.DefaultTaskCleanupWaitDuration.String())
 		cleanupTimeDuration = config.DefaultTaskCleanupWaitDuration
 	}


### PR DESCRIPTION
### Summary
<!-- What does this pull request do? -->
reopening https://github.com/aws/amazon-ecs-agent/pull/1688

> Some of our logs around the task lifecycle are only logged at debug  level.
This can make identifying problems a difficult task unless debug logs are
provided. This is an attempt to make our logs more useful when ran with
default settings.

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
