### PR TITLE
Bump windows ftest timeout

### DIFF
--- a/scripts/run-functional-tests.ps1
+++ b/scripts/run-functional-tests.ps1
@@ -33,7 +33,7 @@ Invoke-Expression "${PSScriptRoot}\..\misc\container-metadata-file-validator-win
 $cwd = (pwd).Path
 try {
   cd "${PSScriptRoot}"
-  go test -tags functional -timeout=40m -v ../agent/functional_tests/tests
+  go test -tags functional -timeout=60m -v ../agent/functional_tests/tests
   $handwrittenExitCode = $LastExitCode
   echo "Handwritten functional tests exited with ${handwrittenExitCode}"
   go test -tags functional -timeout=30m -v ../agent/functional_tests/tests/generated/simpletests_windows


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
We need to bump ftest timeout after the changes in https://github.com/aws/amazon-ecs-agent/pull/1978. Windows ftest timeout didn't get bumped so it's timing out.

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
