### PR TITLE
taskresources: set terminal reason msg for all errors

### DIFF
--- a/agent/taskresource/volume/dockervolume.go
+++ b/agent/taskresource/volume/dockervolume.go
@@ -34,10 +34,9 @@ const (
 	// SharedScope indicates that the volume's lifecycle is outside the scope of task
 	SharedScope = "shared"
 	// DockerLocalVolumeDriver is the name of the docker default volume driver
-	DockerLocalVolumeDriver = "local"
+	DockerLocalVolumeDriver   = "local"
+	resourceProvisioningError = "VolumeError: Agent could not create task's volume resources"
 )
-
-const resourceProvisioningError = "VolumeError: Agent could not create task's volume resources"
 
 // VolumeResource represents volume resource
 type VolumeResource struct {
@@ -56,6 +55,12 @@ type VolumeResource struct {
 	statusToTransitions map[resourcestatus.ResourceStatus]func() error
 	client              dockerapi.DockerClient
 	ctx                 context.Context
+
+	// terminalReason should be set for resource creation failures. This ensures
+	// the resource object carries some context for why provisoning failed.
+	terminalReason     string
+	terminalReasonOnce sync.Once
+
 	// lock is used for fields that are accessed and updated concurrently
 	lock sync.RWMutex
 }
@@ -147,7 +152,17 @@ func (vol *VolumeResource) DesiredTerminal() bool {
 // GetTerminalReason returns an error string to propagate up through to task
 // state change messages
 func (vol *VolumeResource) GetTerminalReason() string {
-	return resourceProvisioningError
+	if vol.terminalReason == "" {
+		return resourceProvisioningError
+	}
+	return vol.terminalReason
+}
+
+func (vol *VolumeResource) setTerminalReason(reason string) {
+	vol.terminalReasonOnce.Do(func() {
+		seelog.Infof("Volume Resource [%s]: setting terminal reason for volume resource", vol.Name)
+		vol.terminalReason = reason
+	})
 }
 
 // SetDesiredStatus safely sets the desired status of the resource
@@ -210,8 +225,10 @@ func (vol *VolumeResource) SteadyState() resourcestatus.ResourceStatus {
 func (vol *VolumeResource) ApplyTransition(nextState resourcestatus.ResourceStatus) error {
 	transitionFunc, ok := vol.statusToTransitions[nextState]
 	if !ok {
-		return errors.Errorf("volume [%s]: transition to %s impossible", vol.Name,
+		errW := errors.Errorf("volume [%s]: transition to %s impossible", vol.Name,
 			vol.StatusString(nextState))
+		vol.setTerminalReason(errW.Error())
+		return errW
 	}
 	return transitionFunc()
 }
@@ -289,6 +306,7 @@ func (vol *VolumeResource) Create() error {
 		dockerclient.CreateVolumeTimeout)
 
 	if volumeResponse.Error != nil {
+		vol.setTerminalReason(volumeResponse.Error.Error())
 		return volumeResponse.Error
 	}
 
@@ -309,6 +327,7 @@ func (vol *VolumeResource) Cleanup() error {
 	err := vol.client.RemoveVolume(vol.ctx, vol.VolumeConfig.DockerVolumeName, dockerclient.RemoveVolumeTimeout)
 
 	if err != nil {
+		vol.setTerminalReason(err.Error())
 		return err
 	}
 	return nil

--- a/agent/taskresource/volume/dockervolume_test.go
+++ b/agent/taskresource/volume/dockervolume_test.go
@@ -113,9 +113,10 @@ func TestCleanupError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockClient := mock_dockerapi.NewMockDockerClient(ctrl)
+	mockClient.EXPECT().RemoveVolume(gomock.Any(), gomock.Any(), gomock.Any()).Return(fmt.Errorf("Test this is propogated"))
 
 	name := "volumeName"
-	scope := "shared"
+	scope := "task"
 	autoprovision := false
 	driver := "driver"
 
@@ -123,7 +124,9 @@ func TestCleanupError(t *testing.T) {
 	defer cancel()
 	volume, _ := NewVolumeResource(ctx, name, name, scope, autoprovision, driver, nil, nil, mockClient)
 	err := volume.Cleanup()
-	assert.Nil(t, err)
+	assert.Error(t, err)
+	assert.Equal(t, "Test this is propogated", err.Error())
+	assert.Equal(t, "Test this is propogated", volume.GetTerminalReason())
 }
 
 func TestApplyTransitionForTaskScopeVolume(t *testing.T) {


### PR DESCRIPTION
closes #1631

### Summary

This adds a terminal reason to all relevant errors in taskresources

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
