### PR TITLE
adds biginteger as uint64

### DIFF
--- a/agent/vendor/github.com/aws/aws-sdk-go/private/model/api/shape.go
+++ b/agent/vendor/github.com/aws/aws-sdk-go/private/model/api/shape.go
@@ -340,6 +340,8 @@ func goType(s *Shape, withPkgName bool) string {
 		return "*int64"
 	case "float", "double":
 		return "*float64"
+	case "biginteger":
+		return "*uint64"
 	case "timestamp":
 		s.API.imports["time"] = true
 		return "*time.Time"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This adds the biginteger type as a uint64.  

### Testing
I tested this manually by creating a new model change, then generating api.go with the biginteger.  It generated the file I was expecting to see.

New tests cover the changes: No

### Description for the changelog
Improves internal type handling.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
