### PR TITLE
Fix error detection case when image that is being deleted does not exist - continued.

### DIFF
--- a/agent/engine/docker_image_manager.go
+++ b/agent/engine/docker_image_manager.go
@@ -547,7 +547,7 @@ func (imageManager *dockerImageManager) deleteImage(ctx context.Context, imageID
 	seelog.Infof("Removing Image: %s", imageID)
 	err := imageManager.client.RemoveImage(ctx, imageID, dockerclient.RemoveImageTimeout)
 	if err != nil {
-		if strings.Contains(err.Error(), imageNotFoundForDeletionError) {
+		if strings.Contains(strings.ToLower(err.Error()), imageNotFoundForDeletionError) {
 			seelog.Errorf("Image already removed from the instance: %v", err)
 		} else {
 			seelog.Errorf("Error removing Image %v - %v", imageID, err)

--- a/agent/engine/docker_image_manager_test.go
+++ b/agent/engine/docker_image_manager_test.go
@@ -1347,7 +1347,7 @@ func TestDeleteImageNotFoundError(t *testing.T) {
 	}
 	imageState, _ := imageManager.getImageState(imageInspected.ID)
 	client.EXPECT().RemoveImage(gomock.Any(), container.Image, dockerclient.RemoveImageTimeout).Return(
-		errors.New("no such image: " + container.Image))
+		errors.New("No such image: " + container.Image))
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	imageManager.deleteImage(ctx, container.Image, imageState)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Corrects the fix provided in https://github.com/aws/amazon-ecs-agent/pull/1897.

We were experiencing images not being removed and upgraded `ecs-agent` to fix the issue, after seeing the above PR.
It did not fix the issue. 

Investigation revealed that the above PR does not fix the issue (at least for more recent docker versions because the actual error return from docker is `Error: No such image` - capital `N`.

### Implementation details
Make the string contains check for `no such image` case insensitive.

### Testing
<!-- How was this tested? -->
 - update test `TestDeleteImageNotFoundError` to make the error the correct case.
 - left test `TestDeleteImageNotFoundOldDockerMessageError` alone, using existing lower case error message. I am not sure if that is the correct case for old docker versions, but now we have 2 tests covering both cases.

New tests cover the changes: yes, corrected existing.

### Description for the changelog
Bug - Fix cleaning up images when some images are not found. Continuation of #1897

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
