### PR TITLE
adds StorageReadBytes and StorageWriteBytes to rawstats collection

### DIFF
--- a/agent/stats/common_test.go
+++ b/agent/stats/common_test.go
@@ -248,8 +248,8 @@ func validateEmptyTaskHealthMetrics(t *testing.T, engine *DockerStatsEngine) {
 
 func createFakeContainerStats() []*ContainerStats {
 	return []*ContainerStats{
-		{22400432, 1839104, parseNanoTime("2015-02-12T21:22:05.131117533Z")},
-		{116499979, 3649536, parseNanoTime("2015-02-12T21:22:05.232291187Z")},
+		{22400432, 1839104, uint64(0), uint64(0), parseNanoTime("2015-02-12T21:22:05.131117533Z")},
+		{116499979, 3649536, uint64(0), uint64(0), parseNanoTime("2015-02-12T21:22:05.232291187Z")},
 	}
 }
 

--- a/agent/stats/engine_test.go
+++ b/agent/stats/engine_test.go
@@ -191,8 +191,8 @@ func TestStatsEngineMetadataInStatsSets(t *testing.T) {
 	ts1 := parseNanoTime("2015-02-12T21:22:05.131117533Z")
 	ts2 := parseNanoTime("2015-02-12T21:22:05.232291187Z")
 	containerStats := []*ContainerStats{
-		{22400432, 1839104, ts1},
-		{116499979, 3649536, ts2},
+		{22400432, 1839104, uint64(0), uint64(0), ts1},
+		{116499979, 3649536, uint64(0), uint64(0), ts2},
 	}
 	dockerStats := []*types.StatsJSON{{}, {},}
 	dockerStats[0].Read = ts1

--- a/agent/stats/queue_test.go
+++ b/agent/stats/queue_test.go
@@ -30,6 +30,9 @@ const (
 	// predictableHighMemoryUtilizationInMiB is the expected Memory usage in MiB for
 	// the "predictableHighMemoryUtilizationInBytes" value (7377772544 / (1024 * 1024))
 	predictableHighMemoryUtilizationInMiB = 7035
+	// the "predictableInt64Overflow" requires 3 metrics to guarantee overflow
+	// note math.MaxInt64 is odd, so integer division will trim off 1
+	predictableInt64Overflow = math.MaxInt64 / int64(2)
 )
 
 func getTimestamps() []time.Time {
@@ -60,7 +63,7 @@ func getTimestamps() []time.Time {
 
 }
 
-func getCPUTimes() []uint64 {
+func getUintStats() []uint64 {
 	return []uint64{
 		22400432,
 		116499979,
@@ -122,18 +125,34 @@ func getPredictableHighMemoryUtilizationInBytes(size int) []uint64 {
 	return memBytes
 }
 
-func createQueue(size int, predictableHighMemoryUtilization bool) *Queue {
+func getLargeInt64Stats(size int) []uint64 {
+	var uintStats []uint64
+	for i := 0; i < size; i++ {
+		uintStats = append(uintStats, uint64(predictableInt64Overflow))
+	}
+	return uintStats
+}
+
+func createQueue(size int, predictableHighUtilization bool) *Queue {
 	timestamps := getTimestamps()
-	cpuTimes := getCPUTimes()
+	cpuTimes := getUintStats()
 	var memoryUtilizationInBytes []uint64
-	if predictableHighMemoryUtilization {
+	var uintStats []uint64
+	if predictableHighUtilization {
 		memoryUtilizationInBytes = getPredictableHighMemoryUtilizationInBytes(len(cpuTimes))
+		uintStats = getLargeInt64Stats(len(cpuTimes))
 	} else {
 		memoryUtilizationInBytes = getRandomMemoryUtilizationInBytes()
+		uintStats = getUintStats()
 	}
 	queue := NewQueue(size)
 	for i, time := range timestamps {
-		queue.add(&ContainerStats{cpuUsage: cpuTimes[i], memoryUsage: memoryUtilizationInBytes[i], timestamp: time})
+		queue.add(&ContainerStats{
+			cpuUsage:          cpuTimes[i],
+			memoryUsage:       memoryUtilizationInBytes[i],
+			storageReadBytes:  uintStats[i],
+			storageWriteBytes: uintStats[i],
+			timestamp:         time})
 	}
 	return queue
 }
@@ -141,7 +160,7 @@ func createQueue(size int, predictableHighMemoryUtilization bool) *Queue {
 func TestQueueAddRemove(t *testing.T) {
 	timestamps := getTimestamps()
 	queueLength := 5
-	// Set predictableHighMemoryUtilization to false, expect random values when aggregated.
+	// Set predictableHighUtilization to false, expect random values when aggregated.
 	queue := createQueue(queueLength, false)
 	buf := queue.buffer
 	if len(buf) != queueLength {
@@ -157,7 +176,7 @@ func TestQueueAddRemove(t *testing.T) {
 
 	cpuStatsSet, err := queue.GetCPUStatsSet()
 	if err != nil {
-		t.Error("Error gettting cpu stats set:", err)
+		t.Error("Error getting cpu stats set:", err)
 	}
 	if *cpuStatsSet.Min == math.MaxFloat64 || math.IsNaN(*cpuStatsSet.Min) {
 		t.Error("Min value incorrectly set: ", *cpuStatsSet.Min)
@@ -174,12 +193,12 @@ func TestQueueAddRemove(t *testing.T) {
 
 	memStatsSet, err := queue.GetMemoryStatsSet()
 	if err != nil {
-		t.Error("Error gettting memory stats set:", err)
+		t.Error("Error getting memory stats set:", err)
 	}
-	if *memStatsSet.Min == float64(-math.MaxFloat32) {
+	if *memStatsSet.Min == math.MaxFloat64 || math.IsNaN(*memStatsSet.Min) {
 		t.Error("Min value incorrectly set: ", *memStatsSet.Min)
 	}
-	if *memStatsSet.Max == 0 {
+	if *memStatsSet.Max == -math.MaxFloat64 || math.IsNaN(*memStatsSet.Max) {
 		t.Error("Max value incorrectly set: ", *memStatsSet.Max)
 	}
 	if *memStatsSet.SampleCount != int64(queueLength) {
@@ -189,9 +208,45 @@ func TestQueueAddRemove(t *testing.T) {
 		t.Error("Sum value incorrectly set: ", *memStatsSet.Sum)
 	}
 
+	storageReadStatsSet, err := queue.GetStorageReadStatsSet()
+	if err != nil {
+		t.Error("Error getting storage read stats set:", err)
+	}
+	// assuming min is initialized to math.MaxUint64 then truncated
+	if *storageReadStatsSet.Min == int64(math.MaxInt64) &&
+		*storageReadStatsSet.OverflowMin == int64(math.MaxInt64) {
+		t.Error("Min value incorrectly set: ", *storageReadStatsSet.Min)
+	}
+	if *storageReadStatsSet.Max == 0 {
+		t.Error("Max value incorrectly set: ", *storageReadStatsSet.Max)
+	}
+	if *storageReadStatsSet.SampleCount != int64(queueLength) {
+		t.Error("Expected samplecount: ", queueLength, " got: ", *storageReadStatsSet.SampleCount)
+	}
+	if *storageReadStatsSet.Sum == 0 {
+		t.Error("Sum value incorrectly set: ", *storageReadStatsSet.Sum)
+	}
+
+	storageWriteStatsSet, err := queue.GetStorageWriteStatsSet()
+	if err != nil {
+		t.Error("Error getting storage read stats set:", err)
+	}
+	if *storageWriteStatsSet.Min == int64(math.MaxInt64) {
+		t.Error("Min value incorrectly set: ", *storageWriteStatsSet.Min)
+	}
+	if *storageWriteStatsSet.Max == 0 {
+		t.Error("Max value incorrectly set: ", *storageWriteStatsSet.Max)
+	}
+	if *storageWriteStatsSet.SampleCount != int64(queueLength) {
+		t.Error("Expected samplecount: ", queueLength, " got: ", *storageWriteStatsSet.SampleCount)
+	}
+	if *storageWriteStatsSet.Sum == 0 {
+		t.Error("Sum value incorrectly set: ", *storageWriteStatsSet.Sum)
+	}
+
 	rawUsageStats, err := queue.GetRawUsageStats(2 * queueLength)
 	if err != nil {
-		t.Error("Error gettting raw usage stats: ", err)
+		t.Error("Error getting raw usage stats: ", err)
 	}
 
 	if len(rawUsageStats) != queueLength {
@@ -215,10 +270,37 @@ func TestQueueAddRemove(t *testing.T) {
 
 }
 
+func TestQueueUintStats(t *testing.T) {
+	queueLength := 3
+	queue := createQueue(queueLength, true)
+	buf := queue.buffer
+	if len(buf) != queueLength {
+		t.Errorf("Buffer size is incorrect. Expected: %d, Got: %d", queueLength, len(buf))
+	}
+
+	storageReadStatsSet, err := queue.GetStorageReadStatsSet()
+
+	if err != nil {
+		t.Error("Error getting storage read stats set:", err)
+	}
+	// assuming min is initialized to math.MaxUint64 then truncated
+	// min/max should be the same as predictableInt64Overflow
+	// their overflow should be 0
+	assert.Equal(t, *storageReadStatsSet.Min, predictableInt64Overflow)
+	assert.Equal(t, *storageReadStatsSet.OverflowMin, int64(0))
+	assert.Equal(t, *storageReadStatsSet.Max, predictableInt64Overflow)
+	assert.Equal(t, *storageReadStatsSet.OverflowMax, int64(0))
+	// the sum of three predictableInt64Overflow should be equal to MaxInt64
+	// with an overflow of predictableInt64Overflow - 1
+	// (see the definition of predictableInt64Overflow for why -1)
+	assert.Equal(t, *storageReadStatsSet.Sum, int64(math.MaxInt64))
+	assert.Equal(t, *storageReadStatsSet.OverflowSum, predictableInt64Overflow-1)
+}
+
 func TestQueueAddPredictableHighMemoryUtilization(t *testing.T) {
 	timestamps := getTimestamps()
 	queueLength := 5
-	// Set predictableHighMemoryUtilization to true
+	// Set predictableHighUtilization to true
 	// This lets us compare the computed values against pre-computed expected values
 	queue := createQueue(queueLength, true)
 	buf := queue.buffer
@@ -235,7 +317,7 @@ func TestQueueAddPredictableHighMemoryUtilization(t *testing.T) {
 
 	memStatsSet, err := queue.GetMemoryStatsSet()
 	if err != nil {
-		t.Error("Error gettting memory stats set:", err)
+		t.Error("Error getting memory stats set:", err)
 	}
 
 	// Test if both min and max for memory utilization are set to 7035MiB
@@ -255,6 +337,24 @@ func TestQueueAddPredictableHighMemoryUtilization(t *testing.T) {
 	if *memStatsSet.Sum != expectedMemoryUsageInMiBSum {
 		t.Errorf("Sum value incorrectly set: %.0f, expected %.0f", *memStatsSet.Sum, expectedMemoryUsageInMiBSum)
 	}
+}
+
+// tests just below and just above the threshold (+/- 1) of int64
+func TestUintOverflow(t *testing.T) {
+	var underUint, overUint uint64
+	underUint = uint64(math.MaxInt64 - 1)
+	overUint = uint64(math.MaxInt64 + 1)
+
+	baseUnderUint, overflowUnderUint := getInt64WithOverflow(underUint)
+	baseMaxInt, overflowMaxInt := getInt64WithOverflow(uint64(math.MaxInt64))
+	baseOverUint, overflowOverUint := getInt64WithOverflow(overUint)
+
+	assert.Equal(t, baseUnderUint, int64(math.MaxInt64-1))
+	assert.Equal(t, overflowUnderUint, int64(0))
+	assert.Equal(t, baseMaxInt, int64(math.MaxInt64))
+	assert.Equal(t, overflowMaxInt, int64(0))
+	assert.Equal(t, baseOverUint, int64(math.MaxInt64))
+	assert.Equal(t, overflowOverUint, int64(1))
 }
 
 func TestCpuStatsSetNotSetToInfinity(t *testing.T) {

--- a/agent/stats/types.go
+++ b/agent/stats/types.go
@@ -24,15 +24,19 @@ import (
 
 // ContainerStats encapsulates the raw CPU and memory utilization from cgroup fs.
 type ContainerStats struct {
-	cpuUsage    uint64
-	memoryUsage uint64
-	timestamp   time.Time
+	cpuUsage          uint64
+	memoryUsage       uint64
+	storageReadBytes  uint64
+	storageWriteBytes uint64
+	timestamp         time.Time
 }
 
 // UsageStats abstracts the format in which the queue stores data.
 type UsageStats struct {
 	CPUUsagePerc      float32   `json:"cpuUsagePerc"`
 	MemoryUsageInMegs uint32    `json:"memoryUsageInMegs"`
+	StorageReadBytes  uint64    `json:"storageReadBytes"`
+	StorageWriteBytes uint64    `json:"storageWriteBytes"`
 	Timestamp         time.Time `json:"timestamp"`
 	cpuUsage          uint64
 }

--- a/agent/stats/unix_test_stats.json
+++ b/agent/stats/unix_test_stats.json
@@ -1,0 +1,61 @@
+{
+    "blkio_stats": {
+        "io_service_bytes_recursive": [
+            {
+                "major": 202,
+                "minor": 192,
+                "op": "Read",
+                "value": 1 
+            },
+            {
+                "major": 202,
+                "minor": 192,
+                "op": "Write",
+                "value": 5 
+            },
+           {
+                "major": 202,
+                "minor": 26368,
+                "op": "Read",
+                "value": 1 
+            },
+            {
+                "major": 202,
+                "minor": 26368,
+                "op": "Write",
+                "value": 5 
+            },
+            {
+                "major": 253,
+                "minor": 1,
+                "op": "Read",
+                "value": 1
+            },
+            {
+                "major": 253,
+                "minor": 1,
+                "op": "Write",
+                "value": 5 
+            }
+        ]
+    },
+    "cpu_stats": {
+        "cpu_usage": {
+            "total_usage": 262857821518,
+            "percpu_usage": [
+                129951031737,
+                132906789781
+            ]
+        },
+        "online_cpus": 2
+    },
+    "memory_stats":{
+        "usage": 30,
+        "max_usage": 100,
+        "stats": {
+            "cache": 20,
+            "rss": 10
+        },
+        "privateworkingset": 10
+    }
+}

--- a/agent/stats/utils_unix.go
+++ b/agent/stats/utils_unix.go
@@ -31,9 +31,25 @@ func dockerStatsToContainerStats(dockerStats *types.StatsJSON) (*ContainerStats,
 
 	cpuUsage := dockerStats.CPUStats.CPUUsage.TotalUsage / numCores
 	memoryUsage := dockerStats.MemoryStats.Usage - dockerStats.MemoryStats.Stats["cache"]
+	// initialize block io and loop over stats to aggregate
+	storageReadBytes := uint64(0)
+	storageWriteBytes := uint64(0)
+	for _, blockStat := range dockerStats.BlkioStats.IoServiceBytesRecursive {
+		switch op := blockStat.Op; op {
+		case "Read":
+			storageReadBytes += blockStat.Value
+		case "Write":
+			storageWriteBytes += blockStat.Value
+		default:
+			//ignoring "Async", "Total", "Sum", etc
+			continue
+		}
+	}
 	return &ContainerStats{
-		cpuUsage:    cpuUsage,
-		memoryUsage: memoryUsage,
-		timestamp:   dockerStats.Read,
+		cpuUsage:          cpuUsage,
+		memoryUsage:       memoryUsage,
+		storageReadBytes:  storageReadBytes,
+		storageWriteBytes: storageWriteBytes,
+		timestamp:         dockerStats.Read,
 	}, nil
 }

--- a/agent/stats/utils_unix_test.go
+++ b/agent/stats/utils_unix_test.go
@@ -16,7 +16,8 @@ package stats
 
 import (
 	"encoding/json"
-	"fmt"
+	"io/ioutil"
+	"path/filepath"
 	"testing"
 
 	"github.com/docker/docker/api/types"
@@ -25,43 +26,40 @@ import (
 )
 
 func TestDockerStatsToContainerStatsZeroCoresGeneratesError(t *testing.T) {
-	// doing this with json makes me sad, but is the easiest way to deal with
-	// the inner structs
-	jsonStat := fmt.Sprintf(`
-		{
-			"cpu_stats":{
-				"cpu_usage":{
-					"total_usage":%d
-				}
-			}
-		}`, 100)
+	inputJsonFile, _ := filepath.Abs("./unix_test_stats.json")
+	jsonBytes, _ := ioutil.ReadFile(inputJsonFile)
 	dockerStat := &types.StatsJSON{}
-	json.Unmarshal([]byte(jsonStat), dockerStat)
+	json.Unmarshal([]byte(jsonBytes), dockerStat)
+	// empty the PercpuUsage array
+	dockerStat.CPUStats.CPUUsage.PercpuUsage = make([]uint64, 0)
 	_, err := dockerStatsToContainerStats(dockerStat)
 	assert.Error(t, err, "expected error converting container stats with empty PercpuUsage")
 }
 
 func TestDockerStatsToContainerStatsCpuUsage(t *testing.T) {
-	// doing this with json makes me sad, but is the easiest way to deal with
-	// the inner structs
-
 	// numCores is a global variable in package agent/stats
 	// which denotes the number of cpu cores
+	// TODO should we take this from the docker stats `online_cpus`?
 	numCores = 4
-	jsonStat := fmt.Sprintf(`
-		{
-			"cpu_stats":{
-				"cpu_usage":{
-					"percpu_usage":[%d, %d, %d, %d],
-					"total_usage":%d
-				}
-			}
-		}`, 1, 2, 3, 4, 100)
+	inputJsonFile, _ := filepath.Abs("./unix_test_stats.json")
+	jsonBytes, _ := ioutil.ReadFile(inputJsonFile)
 	dockerStat := &types.StatsJSON{}
-	json.Unmarshal([]byte(jsonStat), dockerStat)
+	json.Unmarshal([]byte(jsonBytes), dockerStat)
 	containerStats, err := dockerStatsToContainerStats(dockerStat)
 	assert.NoError(t, err, "converting container stats failed")
-
 	require.NotNil(t, containerStats, "containerStats should not be nil")
-	assert.Equal(t, uint64(25), containerStats.cpuUsage, "unexpected value for cpuUsage", containerStats.cpuUsage)
+	assert.Equal(t, uint64(65714455379), containerStats.cpuUsage, "unexpected value for cpuUsage", containerStats.cpuUsage)
+}
+
+func TestDockerStatsToContainerStatsStorageBytes(t *testing.T) {
+	inputJsonFile, _ := filepath.Abs("./unix_test_stats.json")
+	jsonBytes, _ := ioutil.ReadFile(inputJsonFile)
+	dockerStat := &types.StatsJSON{}
+	json.Unmarshal([]byte(jsonBytes), dockerStat)
+	containerStats, err := dockerStatsToContainerStats(dockerStat)
+	assert.NoError(t, err, "converting container stats failed")
+	require.NotNil(t, containerStats, "containerStats should not be nil")
+
+	assert.Equal(t, uint64(3), containerStats.storageReadBytes, "unexpected value for storageReadBytes", containerStats.storageReadBytes)
+	assert.Equal(t, uint64(15), containerStats.storageWriteBytes, "Unexpected value for storageWriteBytes", containerStats.storageWriteBytes)
 }


### PR DESCRIPTION
adds ULongStatsSet with int64 truncation to queue

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This adds StorageReadBytes and StorageWriteBytes to the rawstats collection as well as adding ULongStatsSet and int64 truncation to the queue.  

### Implementation details
changes follow existing patterns across multiple files.  Where necessary I changed names to be more general for re-use.

### Testing
For most of this, I followed TDD and wrote my tests first, then updated the stats code.  I added multiple tests to cover the new stats, and the overflow uint64 --> int64 truncation. 

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
add block stats collection

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
