### PR TITLE
add network stats to container metrics

### DIFF
--- a/agent/stats/common_test.go
+++ b/agent/stats/common_test.go
@@ -154,9 +154,6 @@ func validateContainerMetrics(containerMetrics []*ecstcs.ContainerMetric, expect
 		if containerMetric.MemoryStatsSet == nil {
 			return fmt.Errorf("MemoryStatsSet is nil")
 		}
-		if containerMetric.NetworkStatsSet == nil {
-			return fmt.Errorf("NetworkStatsSet is nil")
-		}
 	}
 	return nil
 }
@@ -251,14 +248,14 @@ func validateEmptyTaskHealthMetrics(t *testing.T, engine *DockerStatsEngine) {
 
 func createFakeContainerStats() []*ContainerStats {
 	netStats := &NetworkStats{
-		rxBytes:   796,
-		rxDropped: 6,
-		rxErrors:  0,
-		rxPackets: 10,
-		txBytes:   8192,
-		txDropped: 5,
-		txErrors:  0,
-		txPackets: 60,
+		RxBytes:   796,
+		RxDropped: 6,
+		RxErrors:  0,
+		RxPackets: 10,
+		TxBytes:   8192,
+		TxDropped: 5,
+		TxErrors:  0,
+		TxPackets: 60,
 	}
 	return []*ContainerStats{
 		{22400432, 1839104, uint64(0), uint64(0), netStats, parseNanoTime("2015-02-12T21:22:05.131117533Z")},

--- a/agent/stats/common_test.go
+++ b/agent/stats/common_test.go
@@ -154,6 +154,9 @@ func validateContainerMetrics(containerMetrics []*ecstcs.ContainerMetric, expect
 		if containerMetric.MemoryStatsSet == nil {
 			return fmt.Errorf("MemoryStatsSet is nil")
 		}
+		if containerMetric.NetworkStatsSet == nil {
+			return fmt.Errorf("NetworkStatsSet is nil")
+		}
 	}
 	return nil
 }
@@ -247,9 +250,19 @@ func validateEmptyTaskHealthMetrics(t *testing.T, engine *DockerStatsEngine) {
 }
 
 func createFakeContainerStats() []*ContainerStats {
+	netStats := &NetworkStats{
+		rxBytes:   796,
+		rxDropped: 6,
+		rxErrors:  0,
+		rxPackets: 10,
+		txBytes:   8192,
+		txDropped: 5,
+		txErrors:  0,
+		txPackets: 60,
+	}
 	return []*ContainerStats{
-		{22400432, 1839104, uint64(0), uint64(0), parseNanoTime("2015-02-12T21:22:05.131117533Z")},
-		{116499979, 3649536, uint64(0), uint64(0), parseNanoTime("2015-02-12T21:22:05.232291187Z")},
+		{22400432, 1839104, uint64(0), uint64(0), netStats, parseNanoTime("2015-02-12T21:22:05.131117533Z")},
+		{116499979, 3649536, uint64(0), uint64(0), netStats, parseNanoTime("2015-02-12T21:22:05.232291187Z")},
 	}
 }
 

--- a/agent/stats/engine.go
+++ b/agent/stats/engine.go
@@ -594,23 +594,16 @@ func (engine *DockerStatsEngine) taskContainerMetricsUnsafe(taskArn string) ([]*
 			continue
 		}
 
-		// Get memory stats set.
+		// Get memory stats set
 		memoryStatsSet, err := container.statsQueue.GetMemoryStatsSet()
 		if err != nil {
 			seelog.Warnf("Error getting memory stats, err: %v, container: %v", err, dockerID)
 			continue
 		}
 
-		networkStatsSet, err := container.statsQueue.GetNetworkStatsSet()
-		if err != nil {
-			// we log the error and still continue to publish cpu, memory stats and empty/partial network stats
-			seelog.Warnf("Error getting network stats: %v, container: %v", err, dockerID)
-		}
-
 		containerMetrics = append(containerMetrics, &ecstcs.ContainerMetric{
-			CpuStatsSet:     cpuStatsSet,
-			MemoryStatsSet:  memoryStatsSet,
-			NetworkStatsSet: networkStatsSet,
+			CpuStatsSet:    cpuStatsSet,
+			MemoryStatsSet: memoryStatsSet,
 		})
 
 	}

--- a/agent/stats/engine.go
+++ b/agent/stats/engine.go
@@ -601,9 +601,16 @@ func (engine *DockerStatsEngine) taskContainerMetricsUnsafe(taskArn string) ([]*
 			continue
 		}
 
+		networkStatsSet, err := container.statsQueue.GetNetworkStatsSet()
+		if err != nil {
+			// we log the error and still continue to publish cpu, memory stats and empty/partial network stats
+			seelog.Warnf("Error getting network stats: %v, container: %v", err, dockerID)
+		}
+
 		containerMetrics = append(containerMetrics, &ecstcs.ContainerMetric{
-			CpuStatsSet:    cpuStatsSet,
-			MemoryStatsSet: memoryStatsSet,
+			CpuStatsSet:     cpuStatsSet,
+			MemoryStatsSet:  memoryStatsSet,
+			NetworkStatsSet: networkStatsSet,
 		})
 
 	}

--- a/agent/stats/engine_test.go
+++ b/agent/stats/engine_test.go
@@ -190,20 +190,7 @@ func TestStatsEngineMetadataInStatsSets(t *testing.T) {
 	engine.addAndStartStatsContainer("c1")
 	ts1 := parseNanoTime("2015-02-12T21:22:05.131117533Z")
 	ts2 := parseNanoTime("2015-02-12T21:22:05.232291187Z")
-	netStats := &NetworkStats{
-		rxBytes:   796,
-		rxDropped: 6,
-		rxErrors:  0,
-		rxPackets: 10,
-		txBytes:   8192,
-		txDropped: 5,
-		txErrors:  0,
-		txPackets: 60,
-	}
-	containerStats := []*ContainerStats{
-		{22400432, 1839104, uint64(0), uint64(0), netStats, ts1},
-		{116499979, 3649536, uint64(0), uint64(0), netStats, ts2},
-	}
+	containerStats := createFakeContainerStats()
 	dockerStats := []*types.StatsJSON{{}, {}}
 	dockerStats[0].Read = ts1
 	dockerStats[1].Read = ts2

--- a/agent/stats/engine_test.go
+++ b/agent/stats/engine_test.go
@@ -190,11 +190,21 @@ func TestStatsEngineMetadataInStatsSets(t *testing.T) {
 	engine.addAndStartStatsContainer("c1")
 	ts1 := parseNanoTime("2015-02-12T21:22:05.131117533Z")
 	ts2 := parseNanoTime("2015-02-12T21:22:05.232291187Z")
-	containerStats := []*ContainerStats{
-		{22400432, 1839104, uint64(0), uint64(0), ts1},
-		{116499979, 3649536, uint64(0), uint64(0), ts2},
+	netStats := &NetworkStats{
+		rxBytes:   796,
+		rxDropped: 6,
+		rxErrors:  0,
+		rxPackets: 10,
+		txBytes:   8192,
+		txDropped: 5,
+		txErrors:  0,
+		txPackets: 60,
 	}
-	dockerStats := []*types.StatsJSON{{}, {},}
+	containerStats := []*ContainerStats{
+		{22400432, 1839104, uint64(0), uint64(0), netStats, ts1},
+		{116499979, 3649536, uint64(0), uint64(0), netStats, ts2},
+	}
+	dockerStats := []*types.StatsJSON{{}, {}}
 	dockerStats[0].Read = ts1
 	dockerStats[1].Read = ts2
 	containers, _ := engine.tasksToContainers["t1"]

--- a/agent/stats/queue.go
+++ b/agent/stats/queue.go
@@ -179,56 +179,56 @@ func (queue *Queue) GetNetworkStatsSet() (*ecstcs.NetworkStatsSet, error) {
 
 func getNetworkRxBytes(s *UsageStats) uint64 {
 	if s.NetworkStats != nil {
-		return s.NetworkStats.rxBytes
+		return s.NetworkStats.RxBytes
 	}
 	return uint64(0)
 }
 
 func getNetworkRxDropped(s *UsageStats) uint64 {
 	if s.NetworkStats != nil {
-		return s.NetworkStats.rxDropped
+		return s.NetworkStats.RxDropped
 	}
 	return uint64(0)
 }
 
 func getNetworkRxErrors(s *UsageStats) uint64 {
 	if s.NetworkStats != nil {
-		return s.NetworkStats.rxErrors
+		return s.NetworkStats.RxErrors
 	}
 	return uint64(0)
 }
 
 func getNetworkRxPackets(s *UsageStats) uint64 {
 	if s.NetworkStats != nil {
-		return s.NetworkStats.rxPackets
+		return s.NetworkStats.RxPackets
 	}
 	return uint64(0)
 }
 
 func getNetworkTxBytes(s *UsageStats) uint64 {
 	if s.NetworkStats != nil {
-		return s.NetworkStats.txBytes
+		return s.NetworkStats.TxBytes
 	}
 	return uint64(0)
 }
 
 func getNetworkTxDropped(s *UsageStats) uint64 {
 	if s.NetworkStats != nil {
-		return s.NetworkStats.txDropped
+		return s.NetworkStats.TxDropped
 	}
 	return uint64(0)
 }
 
 func getNetworkTxErrors(s *UsageStats) uint64 {
 	if s.NetworkStats != nil {
-		return s.NetworkStats.txErrors
+		return s.NetworkStats.TxErrors
 	}
 	return uint64(0)
 }
 
 func getNetworkTxPackets(s *UsageStats) uint64 {
 	if s.NetworkStats != nil {
-		return s.NetworkStats.txPackets
+		return s.NetworkStats.TxPackets
 	}
 	return uint64(0)
 }

--- a/agent/stats/queue_test.go
+++ b/agent/stats/queue_test.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/tcs/model/ecstcs"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/stretchr/testify/assert"
 )
@@ -155,14 +154,14 @@ func createQueue(size int, predictableHighUtilization bool) *Queue {
 			storageReadBytes:  uintStats[i],
 			storageWriteBytes: uintStats[i],
 			networkStats: &NetworkStats{
-				rxBytes:   uintStats[i],
-				rxDropped: 0,
-				rxErrors:  uintStats[i],
-				rxPackets: uintStats[i],
-				txBytes:   uintStats[i],
-				txDropped: uintStats[i],
-				txErrors:  0,
-				txPackets: uintStats[i],
+				RxBytes:   uintStats[i],
+				RxDropped: 0,
+				RxErrors:  uintStats[i],
+				RxPackets: uintStats[i],
+				TxBytes:   uintStats[i],
+				TxDropped: uintStats[i],
+				TxErrors:  0,
+				TxPackets: uintStats[i],
 			},
 			timestamp: time})
 	}

--- a/agent/stats/types.go
+++ b/agent/stats/types.go
@@ -28,16 +28,30 @@ type ContainerStats struct {
 	memoryUsage       uint64
 	storageReadBytes  uint64
 	storageWriteBytes uint64
+	networkStats      *NetworkStats
 	timestamp         time.Time
+}
+
+// NetworkStats contains the network stats information for a container
+type NetworkStats struct {
+	rxBytes   uint64
+	rxDropped uint64
+	rxErrors  uint64
+	rxPackets uint64
+	txBytes   uint64
+	txDropped uint64
+	txErrors  uint64
+	txPackets uint64
 }
 
 // UsageStats abstracts the format in which the queue stores data.
 type UsageStats struct {
-	CPUUsagePerc      float32   `json:"cpuUsagePerc"`
-	MemoryUsageInMegs uint32    `json:"memoryUsageInMegs"`
-	StorageReadBytes  uint64    `json:"storageReadBytes"`
-	StorageWriteBytes uint64    `json:"storageWriteBytes"`
-	Timestamp         time.Time `json:"timestamp"`
+	CPUUsagePerc      float32       `json:"cpuUsagePerc"`
+	MemoryUsageInMegs uint32        `json:"memoryUsageInMegs"`
+	StorageReadBytes  uint64        `json:"storageReadBytes"`
+	StorageWriteBytes uint64        `json:"storageWriteBytes"`
+	NetworkStats      *NetworkStats `json:"networkStats"`
+	Timestamp         time.Time     `json:"timestamp"`
 	cpuUsage          uint64
 }
 

--- a/agent/stats/types.go
+++ b/agent/stats/types.go
@@ -34,14 +34,14 @@ type ContainerStats struct {
 
 // NetworkStats contains the network stats information for a container
 type NetworkStats struct {
-	rxBytes   uint64
-	rxDropped uint64
-	rxErrors  uint64
-	rxPackets uint64
-	txBytes   uint64
-	txDropped uint64
-	txErrors  uint64
-	txPackets uint64
+	RxBytes   uint64 `json:"rxBytes"`
+	RxDropped uint64 `json:"rxDropped"`
+	RxErrors  uint64 `json:"rxErrors"`
+	RxPackets uint64 `json:"rxPackets"`
+	TxBytes   uint64 `json:"txBytes"`
+	TxDropped uint64 `json:"txDropped"`
+	TxErrors  uint64 `json:"txErrors"`
+	TxPackets uint64 `json:"txPackets"`
 }
 
 // UsageStats abstracts the format in which the queue stores data.

--- a/agent/stats/unix_test_stats.json
+++ b/agent/stats/unix_test_stats.json
@@ -57,5 +57,27 @@
             "rss": 10
         },
         "privateworkingset": 10
+    },
+    "networks": {
+        "eth0": {
+            "rx_bytes": 796,
+            "rx_packets": 10,
+            "rx_errors": 0,
+            "rx_dropped": 0,
+            "tx_bytes": 8192,
+            "tx_packets": 112,
+            "tx_errors": 0,
+            "tx_dropped": 5
+        },
+        "eth1": {
+            "rx_bytes": 300,
+            "rx_packets": 4,
+            "rx_errors": 0,
+            "rx_dropped": 1,
+            "tx_bytes": 800,
+            "tx_packets": 11,
+            "tx_errors": 0,
+            "tx_dropped": 5
+        }
     }
 }

--- a/agent/stats/utils.go
+++ b/agent/stats/utils.go
@@ -54,19 +54,20 @@ func isNetworkStatsError(err error) bool {
 
 func getNetworkStats(dockerStats *types.StatsJSON) *NetworkStats {
 	if dockerStats.Networks == nil {
+		seelog.Debug("Network stats not reported for container")
 		return nil
 	}
 	networkStats := &NetworkStats{}
 	for _, netStats := range dockerStats.Networks {
-		networkStats.rxBytes += netStats.RxBytes
-		networkStats.rxDropped += netStats.RxDropped
-		networkStats.rxErrors += netStats.RxErrors
-		networkStats.rxPackets += netStats.RxPackets
+		networkStats.RxBytes += netStats.RxBytes
+		networkStats.RxDropped += netStats.RxDropped
+		networkStats.RxErrors += netStats.RxErrors
+		networkStats.RxPackets += netStats.RxPackets
 
-		networkStats.txBytes += netStats.TxBytes
-		networkStats.txDropped += netStats.TxDropped
-		networkStats.txErrors += netStats.TxErrors
-		networkStats.txPackets += netStats.TxPackets
+		networkStats.TxBytes += netStats.TxBytes
+		networkStats.TxDropped += netStats.TxDropped
+		networkStats.TxErrors += netStats.TxErrors
+		networkStats.TxPackets += netStats.TxPackets
 	}
 	return networkStats
 }

--- a/agent/stats/utils.go
+++ b/agent/stats/utils.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/cihub/seelog"
+	"github.com/docker/docker/api/types"
 )
 
 // networkStatsErrorPattern defines the pattern that is used to evaluate
@@ -49,4 +50,23 @@ func isNetworkStatsError(err error) bool {
 	}
 
 	return matched
+}
+
+func getNetworkStats(dockerStats *types.StatsJSON) *NetworkStats {
+	if dockerStats.Networks == nil {
+		return nil
+	}
+	networkStats := &NetworkStats{}
+	for _, netStats := range dockerStats.Networks {
+		networkStats.rxBytes += netStats.RxBytes
+		networkStats.rxDropped += netStats.RxDropped
+		networkStats.rxErrors += netStats.RxErrors
+		networkStats.rxPackets += netStats.RxPackets
+
+		networkStats.txBytes += netStats.TxBytes
+		networkStats.txDropped += netStats.TxDropped
+		networkStats.txErrors += netStats.TxErrors
+		networkStats.txPackets += netStats.TxPackets
+	}
+	return networkStats
 }

--- a/agent/stats/utils_test.go
+++ b/agent/stats/utils_test.go
@@ -21,6 +21,19 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	// below is the sum of each field in each network interface json in unix_test_stats.json
+	expectedRxBytes   = uint64(1096)
+	expectedRxPackets = uint64(14)
+	expectedRxDropped = uint64(1)
+	expectedRxErrors  = uint64(0)
+	expectedTxBytes   = uint64(8992)
+	expectedTxPackets = uint64(123)
+	expectedTxDropped = uint64(10)
+	expectedTxErrors  = uint64(0)
 )
 
 func TestIsNetworkStatsError(t *testing.T) {
@@ -68,4 +81,15 @@ func TestDockerStatsToContainerStatsMemUsage(t *testing.T) {
 	if containerStats.memoryUsage != 10 {
 		t.Error("Unexpected value for memoryUsage", containerStats.memoryUsage)
 	}
+}
+
+func validateNetworkMetrics(t *testing.T, netStats *NetworkStats) {
+	assert.Equal(t, expectedRxBytes, netStats.rxBytes)
+	assert.Equal(t, expectedRxPackets, netStats.rxPackets)
+	assert.Equal(t, expectedRxDropped, netStats.rxDropped)
+	assert.Equal(t, expectedRxErrors, netStats.rxErrors)
+	assert.Equal(t, expectedTxBytes, netStats.txBytes)
+	assert.Equal(t, expectedTxPackets, netStats.txPackets)
+	assert.Equal(t, expectedTxDropped, netStats.txDropped)
+	assert.Equal(t, expectedTxErrors, netStats.txErrors)
 }

--- a/agent/stats/utils_test.go
+++ b/agent/stats/utils_test.go
@@ -84,12 +84,12 @@ func TestDockerStatsToContainerStatsMemUsage(t *testing.T) {
 }
 
 func validateNetworkMetrics(t *testing.T, netStats *NetworkStats) {
-	assert.Equal(t, expectedRxBytes, netStats.rxBytes)
-	assert.Equal(t, expectedRxPackets, netStats.rxPackets)
-	assert.Equal(t, expectedRxDropped, netStats.rxDropped)
-	assert.Equal(t, expectedRxErrors, netStats.rxErrors)
-	assert.Equal(t, expectedTxBytes, netStats.txBytes)
-	assert.Equal(t, expectedTxPackets, netStats.txPackets)
-	assert.Equal(t, expectedTxDropped, netStats.txDropped)
-	assert.Equal(t, expectedTxErrors, netStats.txErrors)
+	assert.Equal(t, expectedRxBytes, netStats.RxBytes)
+	assert.Equal(t, expectedRxPackets, netStats.RxPackets)
+	assert.Equal(t, expectedRxDropped, netStats.RxDropped)
+	assert.Equal(t, expectedRxErrors, netStats.RxErrors)
+	assert.Equal(t, expectedTxBytes, netStats.TxBytes)
+	assert.Equal(t, expectedTxPackets, netStats.TxPackets)
+	assert.Equal(t, expectedTxDropped, netStats.TxDropped)
+	assert.Equal(t, expectedTxErrors, netStats.TxErrors)
 }

--- a/agent/stats/utils_unix.go
+++ b/agent/stats/utils_unix.go
@@ -31,6 +31,19 @@ func dockerStatsToContainerStats(dockerStats *types.StatsJSON) (*ContainerStats,
 
 	cpuUsage := dockerStats.CPUStats.CPUUsage.TotalUsage / numCores
 	memoryUsage := dockerStats.MemoryStats.Usage - dockerStats.MemoryStats.Stats["cache"]
+	storageReadBytes, storageWriteBytes := getStorageStats(dockerStats)
+	networkStats := getNetworkStats(dockerStats)
+	return &ContainerStats{
+		cpuUsage:          cpuUsage,
+		memoryUsage:       memoryUsage,
+		storageReadBytes:  storageReadBytes,
+		storageWriteBytes: storageWriteBytes,
+		networkStats:      networkStats,
+		timestamp:         dockerStats.Read,
+	}, nil
+}
+
+func getStorageStats(dockerStats *types.StatsJSON) (uint64, uint64) {
 	// initialize block io and loop over stats to aggregate
 	storageReadBytes := uint64(0)
 	storageWriteBytes := uint64(0)
@@ -45,11 +58,5 @@ func dockerStatsToContainerStats(dockerStats *types.StatsJSON) (*ContainerStats,
 			continue
 		}
 	}
-	return &ContainerStats{
-		cpuUsage:          cpuUsage,
-		memoryUsage:       memoryUsage,
-		storageReadBytes:  storageReadBytes,
-		storageWriteBytes: storageWriteBytes,
-		timestamp:         dockerStats.Read,
-	}, nil
+	return storageReadBytes, storageWriteBytes
 }

--- a/agent/stats/utils_unix_test.go
+++ b/agent/stats/utils_unix_test.go
@@ -36,7 +36,7 @@ func TestDockerStatsToContainerStatsZeroCoresGeneratesError(t *testing.T) {
 	assert.Error(t, err, "expected error converting container stats with empty PercpuUsage")
 }
 
-func TestDockerStatsToContainerStatsCpuUsage(t *testing.T) {
+func TestDockerStatsToContainerStats(t *testing.T) {
 	// numCores is a global variable in package agent/stats
 	// which denotes the number of cpu cores
 	// TODO should we take this from the docker stats `online_cpus`?
@@ -49,17 +49,11 @@ func TestDockerStatsToContainerStatsCpuUsage(t *testing.T) {
 	assert.NoError(t, err, "converting container stats failed")
 	require.NotNil(t, containerStats, "containerStats should not be nil")
 	assert.Equal(t, uint64(65714455379), containerStats.cpuUsage, "unexpected value for cpuUsage", containerStats.cpuUsage)
-}
-
-func TestDockerStatsToContainerStatsStorageBytes(t *testing.T) {
-	inputJsonFile, _ := filepath.Abs("./unix_test_stats.json")
-	jsonBytes, _ := ioutil.ReadFile(inputJsonFile)
-	dockerStat := &types.StatsJSON{}
-	json.Unmarshal([]byte(jsonBytes), dockerStat)
-	containerStats, err := dockerStatsToContainerStats(dockerStat)
-	assert.NoError(t, err, "converting container stats failed")
-	require.NotNil(t, containerStats, "containerStats should not be nil")
-
+	// storage bytes check
 	assert.Equal(t, uint64(3), containerStats.storageReadBytes, "unexpected value for storageReadBytes", containerStats.storageReadBytes)
 	assert.Equal(t, uint64(15), containerStats.storageWriteBytes, "Unexpected value for storageWriteBytes", containerStats.storageWriteBytes)
+	// network stats check
+	netStats := containerStats.networkStats
+	assert.NotNil(t, netStats, "networkStats should not be nil")
+	validateNetworkMetrics(t, netStats)
 }

--- a/agent/stats/utils_windows.go
+++ b/agent/stats/utils_windows.go
@@ -30,9 +30,11 @@ func dockerStatsToContainerStats(dockerStats *types.StatsJSON) (*ContainerStats,
 
 	cpuUsage := (dockerStats.CPUStats.CPUUsage.TotalUsage * 100) / numCores
 	memoryUsage := dockerStats.MemoryStats.PrivateWorkingSet
+	networkStats := getNetworkStats(dockerStats)
 	return &ContainerStats{
-		cpuUsage:    cpuUsage,
-		memoryUsage: memoryUsage,
-		timestamp:   dockerStats.Read,
+		cpuUsage:     cpuUsage,
+		memoryUsage:  memoryUsage,
+		timestamp:    dockerStats.Read,
+		networkStats: networkStats,
 	}, nil
 }

--- a/agent/stats/utils_windows_test.go
+++ b/agent/stats/utils_windows_test.go
@@ -17,6 +17,8 @@ package stats
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"path/filepath"
 	"testing"
 
 	"github.com/docker/docker/api/types"
@@ -61,4 +63,18 @@ func TestDockerStatsToContainerStatsCpuUsage(t *testing.T) {
 	assert.NoError(t, err, "converting container stats failed")
 	require.NotNil(t, containerStats, "containerStats should not be nil")
 	assert.Equal(t, uint64(2500), containerStats.cpuUsage, "unexpected value for cpuUsage", containerStats.cpuUsage)
+}
+
+func TestDockerStatsToContainerStats(t *testing.T) {
+	inputJsonFile, _ := filepath.Abs("./windows_test_stats.json")
+	jsonBytes, _ := ioutil.ReadFile(inputJsonFile)
+	dockerStat := &types.StatsJSON{}
+	json.Unmarshal([]byte(jsonBytes), dockerStat)
+	containerStats, err := dockerStatsToContainerStats(dockerStat)
+	assert.NoError(t, err, "converting container stats failed")
+	require.NotNil(t, containerStats, "containerStats should not be nil")
+	// network stats check
+	netStats := containerStats.networkStats
+	assert.NotNil(t, netStats, "networkStats should not be nil")
+	validateNetworkMetrics(t, netStats)
 }

--- a/agent/stats/windows_test_stats.json
+++ b/agent/stats/windows_test_stats.json
@@ -1,0 +1,20 @@
+{
+    "networks": {
+        "eth0": {
+            "rx_bytes": 796,
+            "rx_packets": 10,
+            "rx_dropped": 0,
+            "tx_bytes": 8192,
+            "tx_packets": 112,
+            "tx_dropped": 5
+        },
+        "eth1": {
+            "rx_bytes": 300,
+            "rx_packets": 4,
+            "rx_dropped": 1,
+            "tx_bytes": 800,
+            "tx_packets": 11,
+            "tx_dropped": 5
+        }
+    }
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Adds new network stats to task metrics. 
Piggybacks on https://github.com/aws/amazon-ecs-agent/pull/2012 with minor refactoring, windows network metrics and adding to CW metrics. 

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
