### PR TITLE
add StorageStatsSet and windows stats collection

### DIFF
--- a/agent/stats/engine.go
+++ b/agent/stats/engine.go
@@ -594,7 +594,6 @@ func (engine *DockerStatsEngine) taskContainerMetricsUnsafe(taskArn string) ([]*
 			continue
 		}
 
-		// Get memory stats set
 		memoryStatsSet, err := container.statsQueue.GetMemoryStatsSet()
 		if err != nil {
 			seelog.Warnf("Error getting memory stats, err: %v, container: %v", err, dockerID)

--- a/agent/stats/queue.go
+++ b/agent/stats/queue.go
@@ -128,14 +128,19 @@ func (queue *Queue) GetMemoryStatsSet() (*ecstcs.CWStatsSet, error) {
 	return queue.getCWStatsSet(getMemoryUsagePerc)
 }
 
-// GetStorageReadStatsSet gets the stats set for aggregate storage read
-func (queue *Queue) GetStorageReadStatsSet() (*ecstcs.ULongStatsSet, error) {
-	return queue.getULongStatsSet(getStorageReadBytes)
-}
-
-// GetStorageWriteStatsSet gets the stats set for aggregate storage written
-func (queue *Queue) GetStorageWriteStatsSet() (*ecstcs.ULongStatsSet, error) {
-	return queue.getULongStatsSet(getStorageWriteBytes)
+// GetStorageStatsSet gets the stats set for aggregate storage
+func (queue *Queue) GetStorageStatsSet() (*ecstcs.StorageStatsSet, error) {
+	storageStatsSet := &ecstcs.StorageStatsSet{}
+	var err error
+	storageStatsSet.ReadSizeBytes, err = queue.getULongStatsSet(getStorageReadBytes)
+	if err != nil {
+		seelog.Warnf("Error getting storage read size bytes: %v", err)
+	}
+	storageStatsSet.WriteSizeBytes, err = queue.getULongStatsSet(getStorageWriteBytes)
+	if err != nil {
+		seelog.Warnf("Error getting storage write size bytes: %v", err)
+	}
+	return storageStatsSet, err
 }
 
 // GetNetworkStatsSet gets the stats set for network metrics.

--- a/agent/stats/queue_test.go
+++ b/agent/stats/queue_test.go
@@ -219,11 +219,12 @@ func TestQueueAddRemove(t *testing.T) {
 		t.Error("Sum value incorrectly set: ", *memStatsSet.Sum)
 	}
 
-	storageReadStatsSet, err := queue.GetStorageReadStatsSet()
+	storageStatsSet, err := queue.GetStorageStatsSet()
 	if err != nil {
-		t.Error("Error getting storage read stats set:", err)
+		t.Error("Error getting storage stats set:", err)
 	}
 	// assuming min is initialized to math.MaxUint64 then truncated
+	storageReadStatsSet := storageStatsSet.ReadSizeBytes
 	if *storageReadStatsSet.Min == int64(math.MaxInt64) &&
 		*storageReadStatsSet.OverflowMin == int64(math.MaxInt64) {
 		t.Error("Min value incorrectly set: ", *storageReadStatsSet.Min)
@@ -238,10 +239,7 @@ func TestQueueAddRemove(t *testing.T) {
 		t.Error("Sum value incorrectly set: ", *storageReadStatsSet.Sum)
 	}
 
-	storageWriteStatsSet, err := queue.GetStorageWriteStatsSet()
-	if err != nil {
-		t.Error("Error getting storage read stats set:", err)
-	}
+	storageWriteStatsSet := storageStatsSet.WriteSizeBytes
 	if *storageWriteStatsSet.Min == int64(math.MaxInt64) {
 		t.Error("Min value incorrectly set: ", *storageWriteStatsSet.Min)
 	}
@@ -328,7 +326,8 @@ func TestQueueUintStats(t *testing.T) {
 		t.Errorf("Buffer size is incorrect. Expected: %d, Got: %d", queueLength, len(buf))
 	}
 
-	storageReadStatsSet, err := queue.GetStorageReadStatsSet()
+	storageStatsSet, err := queue.GetStorageStatsSet()
+	storageReadStatsSet := storageStatsSet.ReadSizeBytes
 
 	if err != nil {
 		t.Error("Error getting storage read stats set:", err)

--- a/agent/stats/utils_unix_test.go
+++ b/agent/stats/utils_unix_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDockerStatsToContainerStatsZeroCoresGeneratesError(t *testing.T) {
+func TestDockerStatsToContainerStatsEmptyCpuUsageGeneratesError(t *testing.T) {
 	inputJsonFile, _ := filepath.Abs("./unix_test_stats.json")
 	jsonBytes, _ := ioutil.ReadFile(inputJsonFile)
 	dockerStat := &types.StatsJSON{}

--- a/agent/stats/utils_windows.go
+++ b/agent/stats/utils_windows.go
@@ -31,10 +31,14 @@ func dockerStatsToContainerStats(dockerStats *types.StatsJSON) (*ContainerStats,
 	cpuUsage := (dockerStats.CPUStats.CPUUsage.TotalUsage * 100) / numCores
 	memoryUsage := dockerStats.MemoryStats.PrivateWorkingSet
 	networkStats := getNetworkStats(dockerStats)
+	storageReadBytes := dockerStats.StorageStats.ReadSizeBytes
+	storageWriteBytes := dockerStats.StorageStats.WriteSizeBytes
 	return &ContainerStats{
-		cpuUsage:     cpuUsage,
-		memoryUsage:  memoryUsage,
-		timestamp:    dockerStats.Read,
-		networkStats: networkStats,
+		cpuUsage:          cpuUsage,
+		memoryUsage:       memoryUsage,
+		timestamp:         dockerStats.Read,
+		storageReadBytes:  storageReadBytes,
+		storageWriteBytes: storageWriteBytes,
+		networkStats:      networkStats,
 	}, nil
 }

--- a/agent/stats/utils_windows_test.go
+++ b/agent/stats/utils_windows_test.go
@@ -28,6 +28,7 @@ import (
 
 func TestDockerStatsToContainerStatsZeroCoresGeneratesError(t *testing.T) {
 	numCores = uint64(0)
+	// not using windows_test_stats.json here to save file open/read time
 	jsonStat := fmt.Sprintf(`
 		{
 			"cpu_stats":{
@@ -42,30 +43,8 @@ func TestDockerStatsToContainerStatsZeroCoresGeneratesError(t *testing.T) {
 	assert.Error(t, err, "expected error converting container stats with zero cpu cores")
 }
 
-func TestDockerStatsToContainerStatsCpuUsage(t *testing.T) {
-	// doing this with json makes me sad, but is the easiest way to deal with
-	// the inner structs
-
-	// numCores is a global variable in package agent/stats
-	// which denotes the number of cpu cores
-	numCores = 4
-	jsonStat := fmt.Sprintf(`
-		{
-			"cpu_stats":{
-				"cpu_usage":{
-					"total_usage":%d
-				}
-			}
-		}`, 100)
-	dockerStat := &types.StatsJSON{}
-	json.Unmarshal([]byte(jsonStat), dockerStat)
-	containerStats, err := dockerStatsToContainerStats(dockerStat)
-	assert.NoError(t, err, "converting container stats failed")
-	require.NotNil(t, containerStats, "containerStats should not be nil")
-	assert.Equal(t, uint64(2500), containerStats.cpuUsage, "unexpected value for cpuUsage", containerStats.cpuUsage)
-}
-
 func TestDockerStatsToContainerStats(t *testing.T) {
+	numCores = 4
 	inputJsonFile, _ := filepath.Abs("./windows_test_stats.json")
 	jsonBytes, _ := ioutil.ReadFile(inputJsonFile)
 	dockerStat := &types.StatsJSON{}
@@ -73,8 +52,14 @@ func TestDockerStatsToContainerStats(t *testing.T) {
 	containerStats, err := dockerStatsToContainerStats(dockerStat)
 	assert.NoError(t, err, "converting container stats failed")
 	require.NotNil(t, containerStats, "containerStats should not be nil")
-	// network stats check
 	netStats := containerStats.networkStats
 	assert.NotNil(t, netStats, "networkStats should not be nil")
 	validateNetworkMetrics(t, netStats)
+	assert.Equal(t, uint64(2500), containerStats.cpuUsage,
+		"unexpected value for cpuUsage", containerStats.cpuUsage)
+	assert.Equal(t, uint64(3), containerStats.storageReadBytes,
+		"unexpected value for storageReadBytes", containerStats.storageReadBytes)
+	assert.Equal(t, uint64(15), containerStats.storageWriteBytes,
+		"Unexpected value for storageWriteBytes", containerStats.storageWriteBytes)
+
 }

--- a/agent/stats/windows_test_stats.json
+++ b/agent/stats/windows_test_stats.json
@@ -1,4 +1,48 @@
 {
+    "blkio_stats": {
+        "io_service_bytes_recursive": null,
+        "io_serviced_recursive": null,
+        "io_queue_recursive": null,
+        "io_service_time_recursive": null,
+        "io_wait_time_recursive": null,
+        "io_merged_recursive": null,
+        "io_time_recursive": null,
+        "sectors_recursive": null
+    },
+    "num_procs": 8,
+    "storage_stats": {
+        "read_count_normalized": 1,
+        "read_size_bytes": 3,
+        "write_count_normalized": 1,
+        "write_size_bytes": 15
+    },
+    "cpu_stats": {
+        "cpu_usage": {
+            "total_usage": 100
+        },
+        "throttling_data": {
+            "periods": 0,
+            "throttled_periods": 0,
+            "throttled_time": 0
+        }
+    },
+    "precpu_stats": {
+        "cpu_usage": {
+            "total_usage": 0,
+            "usage_in_kernelmode": 0,
+            "usage_in_usermode": 0
+        },
+        "throttling_data": {
+            "periods": 0,
+            "throttled_periods": 0,
+            "throttled_time": 0
+        }
+    },
+    "memory_stats": {
+        "commitbytes": 114061312,
+        "commitpeakbytes": 139227136,
+        "privateworkingset": 85532672
+    },
     "networks": {
         "eth0": {
             "rx_bytes": 796,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Adds the StorageStatsSet which we will be using in engine.go.  Adds windows storage stats read from docker stats.

### Implementation details
The `GetStorageStatsSet()` queue method is a combination of the logic previously in `GetStorageReadStatsSet()` and `GetStorageWriteStatsSet()`.  Based on the model, these will not be used individually for logging to cloudwatch.
### Testing
Unit tests added and modified to check new functionality.
Added windows_test_stats.json which mimics the response from windows docker stats output.
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

### Description for the changelog
updates storageStatsSet

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
