### PR TITLE
Add option to delay pause container teardown

### DIFF
--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -288,6 +288,10 @@ type Config struct {
 	// TaskMetadataAZDisabled specifies if availability zone should be disabled in Task Metadata endpoint
 	TaskMetadataAZDisabled bool
 
+	// ENIPauseContainerCleanupDelaySeconds specifies how long to wait before cleaning up the pause container after all
+	// other containers have stopped.
+	ENIPauseContainerCleanupDelaySeconds int
+
 	// CgroupCPUPeriod is config option to set different CFS quota and period values in microsecond, defaults to 100 ms
 	CgroupCPUPeriod time.Duration
 }


### PR DESCRIPTION
Adds an option (ENIPauseContainerCleanupDelaySeconds) to delay the cleanup
of the pause container that owns the network namespace for AWSVPC
network mode tasks. In practice, this won't be used unless other
applications on host are making use of the AWSVPC ENI.

The option can be used by setting ecs.config.json:

```
{
    "ENIPauseContainerCleanupDelaySeconds": 10
}
```

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

I'll manually validate this change as well. 

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
