### PR TITLE
Fix supported instance types for trunking tests

### DIFF
--- a/agent/functional_tests/tests/functionaltests_unix_test.go
+++ b/agent/functional_tests/tests/functionaltests_unix_test.go
@@ -57,6 +57,8 @@ const (
 	fluentdLogPath                  = "/tmp/ftslog"
 )
 
+var trunkingInstancePrefixes = []string{"c5.", "m5."}
+
 // TestRunManyTasks runs several tasks in short succession and expects them to
 // all run.
 func TestRunManyTasks(t *testing.T) {
@@ -776,7 +778,7 @@ func TestAgentIntrospectionValidator(t *testing.T) {
 func TestRunAWSVPCTaskWithENITrunkingEndPointValidation(t *testing.T) {
 	RequireDockerVersion(t, ">=17.06.0-ce")
 
-	RequireInstanceTypes(t, []string{"c5", "m5"})
+	RequireInstanceTypes(t, trunkingInstancePrefixes)
 
 	// Enable ENI Trunking account setting
 	putAccountSettingInput := ecsapi.PutAccountSettingInput{
@@ -1678,7 +1680,7 @@ func TestAppMeshCNIPlugin(t *testing.T) {
 func TestTrunkENIAttachDetachWorkflow(t *testing.T) {
 	asyncWaitDuration := 30 * time.Second
 
-	RequireInstanceTypes(t, []string{"c5", "m5"})
+	RequireInstanceTypes(t, trunkingInstancePrefixes)
 
 	// Enable ENI Trunking account setting
 	putAccountSettingInput := ecsapi.PutAccountSettingInput{


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Instance types like "m5a", "c5n" etc don't support eni trunking. Fix the required instance types.

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
