### PR TITLE
adds nil check and logging for windows and unix stats

### DIFF
--- a/agent/stats/utils_unix.go
+++ b/agent/stats/utils_unix.go
@@ -43,7 +43,11 @@ func dockerStatsToContainerStats(dockerStats *types.StatsJSON) (*ContainerStats,
 	}, nil
 }
 
+// Safe return of storage stats based on Docker Stats (Unix)
 func getStorageStats(dockerStats *types.StatsJSON) (uint64, uint64) {
+	if dockerStats.BlkioStats.IoServiceBytesRecursive == nil {
+		seelog.Debug("storage stats (Unix) not reported for container")
+	}
 	// initialize block io and loop over stats to aggregate
 	storageReadBytes := uint64(0)
 	storageWriteBytes := uint64(0)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Adds nil check and logging for disk metrics collection from docker stats.

### Implementation details
Initialize all returns to `uint64(0)` so we will never have a nil stats return value.  Add log statements when nil fields are encountered in Docker stats for expected disk metrics.

### Testing
Tested manually on linux and windows ec2.
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
adds safety checks to disk metrics collection

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
