### PR TITLE
add nil check for block stats

### DIFF
--- a/agent/stats/utils_unix.go
+++ b/agent/stats/utils_unix.go
@@ -45,6 +45,10 @@ func dockerStatsToContainerStats(dockerStats *types.StatsJSON) (*ContainerStats,
 
 func getStorageStats(dockerStats *types.StatsJSON) (uint64, uint64) {
 	// initialize block io and loop over stats to aggregate
+	if dockerStats.BlkioStats.IoServiceBytesRecursive == nil {
+		seelog.Debug("Storage stats not reported for container")
+		return uint64(0), uint64(0)
+	}
 	storageReadBytes := uint64(0)
 	storageWriteBytes := uint64(0)
 	for _, blockStat := range dockerStats.BlkioStats.IoServiceBytesRecursive {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Adds a nil check for `BlkioStats.IoServiceBytesRecursive`.  All other stats are zero initialized so we are safe with the implementation as-is.

### Implementation details


### Testing
manually on linux and windows instances
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: no

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
