### PR TITLE
empty network stats for host and awsvpc mode

### DIFF
--- a/agent/stats/container.go
+++ b/agent/stats/container.go
@@ -41,8 +41,9 @@ func newStatsContainer(dockerID string, client dockerapi.DockerClient, resolver 
 	ctx, cancel := context.WithCancel(context.Background())
 	return &StatsContainer{
 		containerMetadata: &ContainerMetadata{
-			DockerID: dockerID,
-			Name:     dockerContainer.Container.Name,
+			DockerID:    dockerID,
+			Name:        dockerContainer.Container.Name,
+			NetworkMode: dockerContainer.Container.GetNetworkMode(),
 		},
 		ctx:      ctx,
 		cancel:   cancel,

--- a/agent/stats/engine_unix_test.go
+++ b/agent/stats/engine_unix_test.go
@@ -1,0 +1,38 @@
+//+build unit
+
+// Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package stats
+
+import (
+	"testing"
+
+	apieni "github.com/aws/amazon-ecs-agent/agent/api/eni"
+)
+
+func TestLinuxTaskNetworkStatsSet(t *testing.T) {
+	var networkModes = []struct {
+		ENI         *apieni.ENI
+		NetworkMode string
+		StatsEmpty  bool
+	}{
+		{&apieni.ENI{ID: "ec2Id"}, "", true},
+		{nil, "host", true},
+		{nil, "bridge", false},
+		{nil, "none", true},
+	}
+	for _, tc := range networkModes {
+		testNetworkModeStats(t, tc.NetworkMode, tc.ENI, tc.StatsEmpty)
+	}
+}

--- a/agent/stats/types.go
+++ b/agent/stats/types.go
@@ -57,8 +57,9 @@ type UsageStats struct {
 
 // ContainerMetadata contains meta-data information for a container.
 type ContainerMetadata struct {
-	DockerID string `json:"-"`
-	Name     string `json:"-"`
+	DockerID    string `json:"-"`
+	Name        string `json:"-"`
+	NetworkMode string `json:"-"`
 }
 
 // StatsContainer abstracts methods to gather and aggregate utilization data for a container.


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Currently, Docker does not return Network stats for ECS network
modes - awsvpc, host. Send empty network metrics to TCS for
those network modes. Earlier, we were sending zero value network stats.

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
