### PR TITLE
Replacing role ARN with AccessKeyId for ecr auth config cache

### DIFF
--- a/agent/dockerclient/dockerapi/docker_client_test.go
+++ b/agent/dockerclient/dockerapi/docker_client_test.go
@@ -1358,7 +1358,7 @@ func TestECRAuthCacheWithDifferentExecutionRole(t *testing.T) {
 		},
 	}
 	authData.ECRAuthData.SetPullCredentials(credentials.IAMRoleCredentials{
-		RoleArn: "executionRole",
+		AccessKeyID: "executionRoleAccessKeyId",
 	})
 
 	imageEndpoint := "registry.endpoint"

--- a/agent/dockerclient/dockerauth/ecr.go
+++ b/agent/dockerclient/dockerauth/ecr.go
@@ -32,7 +32,7 @@ import (
 
 type cacheKey struct {
 	region           string
-	roleARN          string
+	roleAK           string
 	registryID       string
 	endpointOverride string
 }
@@ -52,7 +52,7 @@ const (
 
 // String formats the cachKey as a string
 func (key *cacheKey) String() string {
-	return fmt.Sprintf("%s-%s-%s-%s", key.roleARN, key.region, key.registryID, key.endpointOverride)
+	return fmt.Sprintf("%s-%s-%s-%s", key.roleAK, key.region, key.registryID, key.endpointOverride)
 }
 
 // NewECRAuthProvider returns a DockerAuthProvider that can handle retrieve
@@ -87,10 +87,10 @@ func (authProvider *ecrAuthProvider) GetAuthconfig(image string,
 	}
 
 	// If the container is using execution role credentials to pull,
-	// add the roleARN as part of the cache key so that docker auth for
+	// add the role access key id as part of the cache key so that docker auth for
 	// containers pull with the same role can be cached
 	if authData.GetPullCredentials() != (credentials.IAMRoleCredentials{}) {
-		key.roleARN = authData.GetPullCredentials().RoleArn
+		key.roleAK = authData.GetPullCredentials().AccessKeyID
 	}
 
 	// Try to get the auth config from cache

--- a/agent/dockerclient/dockerauth/ecr_test.go
+++ b/agent/dockerclient/dockerauth/ecr_test.go
@@ -285,7 +285,7 @@ func TestAuthorizationTokenCacheMiss(t *testing.T) {
 		EndpointOverride: "my.endpoint",
 	}
 	authData.SetPullCredentials(credentials.IAMRoleCredentials{
-		RoleArn: "arn:aws:iam::123456789012:role/test",
+		AccessKeyID: "ABCD1234",
 	})
 
 	registryAuthData := &apicontainer.RegistryAuthenticationData{
@@ -293,7 +293,7 @@ func TestAuthorizationTokenCacheMiss(t *testing.T) {
 	}
 
 	key := cacheKey{
-		roleARN:          authData.GetPullCredentials().RoleArn,
+		roleAK:           authData.GetPullCredentials().AccessKeyID,
 		region:           authData.Region,
 		registryID:       authData.RegistryID,
 		endpointOverride: authData.EndpointOverride,
@@ -382,7 +382,7 @@ func TestAuthorizationTokenCacheWithCredentialsHit(t *testing.T) {
 		EndpointOverride: "my.endpoint",
 	}
 	authData.SetPullCredentials(credentials.IAMRoleCredentials{
-		RoleArn: "arn:aws:iam::123456789012:role/test",
+		AccessKeyID: "ABCD12345",
 	})
 
 	registryAuthData := &apicontainer.RegistryAuthenticationData{
@@ -390,7 +390,7 @@ func TestAuthorizationTokenCacheWithCredentialsHit(t *testing.T) {
 	}
 
 	key := cacheKey{
-		roleARN:          authData.GetPullCredentials().RoleArn,
+		roleAK:           authData.GetPullCredentials().AccessKeyID,
 		region:           authData.Region,
 		registryID:       authData.RegistryID,
 		endpointOverride: authData.EndpointOverride,
@@ -429,7 +429,7 @@ func TestAuthorizationTokenCacheHitExpired(t *testing.T) {
 		EndpointOverride: "my.endpoint",
 	}
 	authData.SetPullCredentials(credentials.IAMRoleCredentials{
-		RoleArn: "arn:aws:iam::123456789012:role/test",
+		AccessKeyID: "ABCDE1234",
 	})
 
 	registryAuthData := &apicontainer.RegistryAuthenticationData{
@@ -437,7 +437,7 @@ func TestAuthorizationTokenCacheHitExpired(t *testing.T) {
 	}
 
 	key := cacheKey{
-		roleARN:          authData.GetPullCredentials().RoleArn,
+		roleAK:           authData.GetPullCredentials().AccessKeyID,
 		region:           authData.Region,
 		registryID:       authData.RegistryID,
 		endpointOverride: authData.EndpointOverride,
@@ -487,7 +487,7 @@ func TestExtractECRTokenError(t *testing.T) {
 		EndpointOverride: "my.endpoint",
 	}
 	authData.SetPullCredentials(credentials.IAMRoleCredentials{
-		RoleArn: "arn:aws:iam::123456789012:role/test",
+		AccessKeyID: "EDCBA54321",
 	})
 
 	registryAuthData := &apicontainer.RegistryAuthenticationData{
@@ -495,7 +495,7 @@ func TestExtractECRTokenError(t *testing.T) {
 	}
 
 	key := cacheKey{
-		roleARN:          authData.GetPullCredentials().RoleArn,
+		roleAK:           authData.GetPullCredentials().AccessKeyID,
 		region:           authData.Region,
 		registryID:       authData.RegistryID,
 		endpointOverride: authData.EndpointOverride,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Replacing role ARN with role Access Key ID, as role ARN is not unique if the role name is the same. 
This can be a problem if customer is using CFN with named task execution role and reusing existing cluster.

### Implementation details
Cache key roleARN field is replaced with roleAK

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
