### PR TITLE
network stats integration tests

### DIFF
--- a/agent/stats/common_test.go
+++ b/agent/stats/common_test.go
@@ -75,12 +75,14 @@ func eventStream(name string) *eventstream.EventStream {
 
 // createGremlin creates the gremlin container using the docker client.
 // It is used only in the test code.
-func createGremlin(client *sdkClient.Client) (*dockercontainer.ContainerCreateCreatedBody, error) {
+func createGremlin(client *sdkClient.Client, netMode string) (*dockercontainer.ContainerCreateCreatedBody, error) {
 	containerGremlin, err := client.ContainerCreate(context.TODO(),
 		&dockercontainer.Config{
 			Image: testImageName,
 		},
-		&dockercontainer.HostConfig{},
+		&dockercontainer.HostConfig{
+			NetworkMode: dockercontainer.NetworkMode(netMode),
+		},
 		&network.NetworkingConfig{},
 		"")
 

--- a/agent/stats/engine_integ_test.go
+++ b/agent/stats/engine_integ_test.go
@@ -65,7 +65,7 @@ func TestStatsEngineWithExistingContainersWithoutHealth(t *testing.T) {
 	timeout := defaultDockerTimeoutSeconds
 
 	// Create a container to get the container id.
-	container, err := createGremlin(client)
+	container, err := createGremlin(client, "default")
 	require.NoError(t, err, "creating container failed")
 	defer client.ContainerRemove(ctx, container.ID, types.ContainerRemoveOptions{Force: true})
 
@@ -128,7 +128,7 @@ func TestStatsEngineWithNewContainersWithoutHealth(t *testing.T) {
 	// Assign ContainerStop timeout to addressable variable
 	timeout := defaultDockerTimeoutSeconds
 
-	container, err := createGremlin(client)
+	container, err := createGremlin(client, "default")
 	require.NoError(t, err, "creating container failed")
 	defer client.ContainerRemove(ctx, container.ID, types.ContainerRemoveOptions{Force: true})
 
@@ -345,7 +345,7 @@ func TestStatsEngineWithNewContainersWithPolling(t *testing.T) {
 	cfg.PollMetrics = true
 	cfg.PollingMetricsWaitDuration = 1 * time.Second
 	// Create a new docker client with new config
-	dockerClientForNewContainersWithPolling, _  := dockerapi.NewDockerGoClient(sdkClientFactory, &cfg, ctx)
+	dockerClientForNewContainersWithPolling, _ := dockerapi.NewDockerGoClient(sdkClientFactory, &cfg, ctx)
 	// Create a new docker stats engine
 	engine := NewDockerStatsEngine(&cfg, dockerClientForNewContainersWithPolling, eventStream("TestStatsEngineWithNewContainers"))
 	defer engine.removeAll()
@@ -573,4 +573,89 @@ func TestStatsEngineWithDockerTaskEngineMissingRemoveEvent(t *testing.T) {
 	// Should not contain any metrics after cleanup.
 	validateIdleContainerMetrics(t, statsEngine)
 	validateEmptyTaskHealthMetrics(t, statsEngine)
+}
+
+func TestStatsEngineWithNetworkStatsDefaultMode(t *testing.T) {
+	testNetworkModeStats(t, "default", false)
+}
+
+func testNetworkModeStats(t *testing.T, networkMode string, statsEmpty bool) {
+	// Create a new docker stats engine
+	engine := NewDockerStatsEngine(&cfg, dockerClient, eventStream("TestStatsEngineWithNetworkStats"))
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
+	// Assign ContainerStop timeout to addressable variable
+	timeout := defaultDockerTimeoutSeconds
+
+	// Create a container to get the container id.
+	container, err := createGremlin(client, networkMode)
+	require.NoError(t, err, "creating container failed")
+	defer client.ContainerRemove(ctx, container.ID, types.ContainerRemoveOptions{Force: true})
+
+	engine.cluster = defaultCluster
+	engine.containerInstanceArn = defaultContainerInstance
+
+	err = client.ContainerStart(ctx, container.ID, types.ContainerStartOptions{})
+	require.NoError(t, err, "starting container failed")
+	defer client.ContainerStop(ctx, container.ID, &timeout)
+
+	containerChangeEventStream := eventStream("TestStatsEngineWithNetworkStats")
+	taskEngine := ecsengine.NewTaskEngine(&config.Config{}, nil, nil, containerChangeEventStream,
+		nil, dockerstate.NewTaskEngineState(), nil, nil)
+	testTask := createRunningTask()
+
+	// Populate Tasks and Container map in the engine.
+	dockerTaskEngine := taskEngine.(*ecsengine.DockerTaskEngine)
+	dockerTaskEngine.State().AddTask(testTask)
+	dockerTaskEngine.State().AddContainer(
+		&apicontainer.DockerContainer{
+			DockerID:   container.ID,
+			DockerName: "gremlin",
+			Container:  testTask.Containers[0],
+		},
+		testTask)
+
+	// Inspect the container and populate the container's network mode
+	// This is done as part of Task Engine
+	// https://github.com/aws/amazon-ecs-agent/blob/d2456beb048d36bfe18159ad7f35ca6b78bb9ee9/agent/engine/docker_task_engine.go#L364
+	dockerContainer, err := client.ContainerInspect(ctx, container.ID)
+	require.NoError(t, err, "inspecting container failed")
+	netMode := string(dockerContainer.HostConfig.NetworkMode)
+	testTask.Containers[0].SetNetworkMode(netMode)
+
+	// Simulate container start prior to listener initialization.
+	time.Sleep(checkPointSleep)
+	err = engine.MustInit(ctx, taskEngine, defaultCluster, defaultContainerInstance)
+	require.NoError(t, err, "initializing stats engine failed")
+	defer engine.containerChangeEventStream.Unsubscribe(containerChangeHandler)
+
+	// Wait for the stats collection go routine to start.
+	time.Sleep(checkPointSleep)
+	_, taskMetrics, err := engine.GetInstanceMetrics()
+	assert.NoError(t, err, "gettting instance metrics failed")
+	taskMetric := taskMetrics[0]
+	for _, containerMetric := range taskMetric.ContainerMetrics {
+		if statsEmpty {
+			assert.Nil(t, containerMetric.NetworkStatsSet, "network stats should be empty for %s network mode", networkMode)
+		} else {
+			assert.NotNil(t, containerMetric.NetworkStatsSet, "network stats should be non-empty for %s network mode", networkMode)
+		}
+	}
+
+	err = client.ContainerStop(ctx, container.ID, &timeout)
+	require.NoError(t, err, "stopping container failed")
+
+	err = engine.containerChangeEventStream.WriteToEventStream(dockerapi.DockerContainerChangeEvent{
+		Status: apicontainerstatus.ContainerStopped,
+		DockerContainerMetadata: dockerapi.DockerContainerMetadata{
+			DockerID: container.ID,
+		},
+	})
+	assert.NoError(t, err, "failed to write to container change event stream")
+	time.Sleep(waitForCleanupSleep)
+
+	// Should not contain any metrics after cleanup.
+	validateIdleContainerMetrics(t, engine)
+	validateEmptyTaskHealthMetrics(t, engine)
 }

--- a/agent/stats/engine_unix_integ_test.go
+++ b/agent/stats/engine_unix_integ_test.go
@@ -1,0 +1,34 @@
+// +build !windows,integration
+
+// Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package stats
+
+import (
+	"testing"
+)
+
+func TestStatsEngineWithNetworkStatsDifferentModes(t *testing.T) {
+	var networkModes = []struct {
+		NetworkMode string
+		StatsEmpty  bool
+	}{
+		{"bridge", false},
+		{"host", true},
+		{"none", true},
+	}
+	for _, tc := range networkModes {
+		testNetworkModeStats(t, tc.NetworkMode, tc.StatsEmpty)
+	}
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Linux: none, host, bridge/default network modes (awsvpc in a different PR) 
Windows: default/nat 
The above are tested to verify if the network stats to be sent to TCS are empty/non-empty 


### Implementation details
the tests follow the similar pattern as existing ones in stats/engine_integ_test.go

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
