### PR TITLE
add storage-stats task for functional testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,13 +208,13 @@ test-in-docker:
 	# Privileged needed for docker-in-docker so integ tests pass
 	docker run --net=none -v "$(PWD):/go/src/github.com/aws/amazon-ecs-agent" --privileged "amazon/amazon-ecs-agent-test:make"
 
-run-functional-tests: testnnp test-registry ecr-execution-role-image telemetry-test-image
+run-functional-tests: testnnp test-registry ecr-execution-role-image telemetry-test-image storage-stats-test-image
 	. ./scripts/shared_env && go test -tags functional -timeout=60m -v ./agent/functional_tests/...
 
 .PHONY: build-image-for-ecr ecr-execution-role-image-for-upload upload-images replicate-images
 
 build-image-for-ecr: netkitten volumes-test squid awscli image-cleanup-test-images fluentd taskmetadata-validator \
-						testnnp container-health-check-image telemetry-test-image ecr-execution-role-image-for-upload
+						testnnp container-health-check-image telemetry-test-image storage-stats-test-image ecr-execution-role-image-for-upload
 
 ecr-execution-role-image-for-upload:
 	$(MAKE) -C misc/ecr-execution-role-upload $(MFLAGS)
@@ -321,7 +321,8 @@ namespace-tests:
 
 # TODO, replace this with a build on dockerhub or a mechanism for the
 # functional tests themselves to build this
-.PHONY: squid awscli fluentd gremlin agent-introspection-validator taskmetadata-validator v3-task-endpoint-validator container-metadata-file-validator elastic-inference-validator image-cleanup-test-images ecr-execution-role-image container-health-check-image telemetry-test-image
+.PHONY: squid awscli fluentd gremlin agent-introspection-validator taskmetadata-validator v3-task-endpoint-validator container-metadata-file-validator elastic-inference-validator image-cleanup-test-images ecr-execution-role-image container-health-check-image telemetry-test-image storage-stats-test-image
+
 squid:
 	$(MAKE) -C misc/squid $(MFLAGS)
 
@@ -363,6 +364,9 @@ ecr-execution-role-image:
 
 telemetry-test-image:
 	$(MAKE) -C misc/telemetry $(MFLAGS)
+
+storage-stats-test-image:
+	$(MAKE) -C misc/storage-stats $(MFLAGS)
 
 container-health-check-image:
 	$(MAKE) -C misc/container-health $(MFLAGS)
@@ -438,6 +442,7 @@ clean:
 	-$(MAKE) -C misc/elastic-inference-validator $(MFLAGS) clean
 	-$(MAKE) -C misc/container-health $(MFLAGS) clean
 	-$(MAKE) -C misc/telemetry $(MFLAGS) clean
+	-$(MAKE) -C misc/storage-stats $(MFLAGS) clean
 	-$(MAKE) -C misc/appmesh-plugin-validator $(MFLAGS) clean
 	-$(MAKE) -C misc/eni-trunking-validator $(MFLAGS) clean
 	-rm -f .get-deps-stamp

--- a/misc/storage-stats/Dockerfile
+++ b/misc/storage-stats/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+FROM golang:1.12
+
+WORKDIR /gopath
+
+COPY main.go .
+
+RUN go build -o storagestats main.go
+
+ENTRYPOINT ["./storagestats"]
+CMD [ "-sleep", "5000", "-bytecount", "1073741823"]

--- a/misc/storage-stats/Makefile
+++ b/misc/storage-stats/Makefile
@@ -1,0 +1,6 @@
+.PHONY: all
+all:
+	docker build -t amazon/amazon-ecs-storage-stats-test:make .
+
+clean:
+	-docker rmi -f "amazon/amazon-ecs-storage-stats-test:make"

--- a/misc/storage-stats/main.go
+++ b/misc/storage-stats/main.go
@@ -1,0 +1,66 @@
+// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"time"
+)
+
+func check(e error) {
+	if e != nil {
+		fmt.Printf("error: %v\n", e)
+	}
+}
+
+func writeBytes(byteCount int64) error {
+	tmpFile, err := ioutil.TempFile(os.TempDir(), "blocktest-")
+	defer func() {
+		err = tmpFile.Close()
+		check(err)
+		err = os.Remove(tmpFile.Name())
+		check(err)
+	}()
+	//populate content with random bytes
+	writeBytes := make([]byte, byteCount)
+	rand.Read(writeBytes)
+	// write and flush to disk to force block write
+	bytesWritten, err := tmpFile.Write(writeBytes)
+	if err != nil {
+		return err
+	}
+	err = tmpFile.Sync()
+	if err != nil {
+		return err
+	}
+	fmt.Printf("wrote %d bytes\n", bytesWritten)
+	return nil
+}
+
+func main() {
+	sleepInterval := flag.Int("sleep", 1000, "length of sleep interval")
+	byteCount := flag.Int64("bytecount", 1024, "size in bytes to be written per interval")
+	flag.Parse()
+	for {
+		// Storage stats are cumulative.
+		// We do incremental writes with sleep to create
+		// a predictable increase over time.
+		writeBytes(*byteCount)
+		time.Sleep(time.Duration(int32(*sleepInterval)) * time.Millisecond)
+	}
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This task generates predictable block writes over time.  It will be used for the end-to-end testing of the StorageStatsSet, in a similar way that we test telemetry now.

### Implementation details
The task writes a big chunk of bytes to the disk at intervals.  The number of bytes as well as the wait interval will need to be tweaked -- these are a general outline.  The number of bytes is `(maxInt32 / 2) - 1`; the wait interval between writes is 5 seconds.

NOTE: I'm punting on the block read portion of the stats for now.  I haven't found a viable way to break through the filesystem cache.

### Testing
I tested locally on multiple instance types, including windows.  I ran docker stats on the host machine to be sure I was hitting the block device.

<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: not yet -- this is the first part of the functional test which will need to wait until cloudwatch integration is complete.

### Description for the changelog
Add storage-stats-task for testing

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
