### PR TITLE
Add Docker.AuthConfig in ECRAuthData

### DIFF
--- a/agent/api/container/registryauth.go
+++ b/agent/api/container/registryauth.go
@@ -36,6 +36,7 @@ type ECRAuthData struct {
 	RegistryID       string `json:"registryId"`
 	UseExecutionRole bool   `json:"useExecutionRole"`
 	pullCredentials  credentials.IAMRoleCredentials
+	dockerAuthConfig types.AuthConfig
 	lock             sync.RWMutex
 }
 
@@ -67,6 +68,23 @@ func (auth *ECRAuthData) SetPullCredentials(creds credentials.IAMRoleCredentials
 	defer auth.lock.Unlock()
 
 	auth.pullCredentials = creds
+}
+
+// GetDockerAuthConfig returns the pull credentials in the auth
+func (auth *ECRAuthData) GetDockerAuthConfig() types.AuthConfig {
+	auth.lock.RLock()
+	defer auth.lock.RUnlock()
+
+	return auth.dockerAuthConfig
+}
+
+// SetDockerAuthConfig sets the credentials to pull from ECR in the
+// ecr auth data
+func (auth *ECRAuthData) SetDockerAuthConfig(dac types.AuthConfig) {
+	auth.lock.Lock()
+	defer auth.lock.Unlock()
+
+	auth.dockerAuthConfig = dac
 }
 
 // GetDockerAuthConfig returns the pull credentials in the auth


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Add the `dockerAuthType` in `ECRAuthData` to unify the `RegistryAuthData` structure, this will give us the ability to refactor the `ECRAuthData` as a resource like `ASMAuthData`.

### Implementation details
<!-- How are the changes implemented? -->
Add the `dockerAuthConfig` in `ECRAuthData` and the getter/setter as `ASMAuthData`.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
