### PR TITLE
Resolving few TODOs in functional tests

### DIFF
--- a/agent/functional_tests/tests/functionaltests_unix_test.go
+++ b/agent/functional_tests/tests/functionaltests_unix_test.go
@@ -788,13 +788,12 @@ func TestRunAWSVPCTaskWithENITrunkingEndPointValidation(t *testing.T) {
 	_, err := ECS.PutAccountSetting(&putAccountSettingInput)
 	assert.NoError(t, err)
 
-
 	os.Setenv("ECS_FTEST_FORCE_NET_HOST", "true")
 	agent := RunAgent(t, &AgentOptions{
 		EnableTaskENI: true,
 		ExtraEnvironment: map[string]string{
-			"ECS_ENABLE_TASK_IAM_ROLE": "true",
-			"ECS_ENABLE_HIGH_DENSITY_ENI": "true",
+			"ECS_ENABLE_TASK_IAM_ROLE":      "true",
+			"ECS_ENABLE_HIGH_DENSITY_ENI":   "true",
 			"ECS_AVAILABLE_LOGGING_DRIVERS": `["awslogs"]`,
 		},
 	})
@@ -814,7 +813,6 @@ func TestRunAWSVPCTaskWithENITrunkingEndPointValidation(t *testing.T) {
 	tdOverrides := make(map[string]string)
 	tdOverrides["$$$TASK_ROLE$$$"] = roleArn
 	tdOverrides["$$$TEST_REGION$$$"] = *ECS.Config.Region
-
 
 	numToRun := 5
 	tasks := make([]*TestTask, numToRun)
@@ -1532,8 +1530,7 @@ func TestRunGPUTask(t *testing.T) {
 		GPUEnabled: true,
 	})
 	defer agent.Cleanup()
-	// TODO: after release, change it to 1.24.0
-	agent.RequireVersion(">=1.22.0")
+	agent.RequireVersion(">=1.24.0")
 
 	testTask, err := agent.StartTask(t, "nvidia-gpu")
 	require.NoError(t, err)
@@ -1659,8 +1656,7 @@ func TestAppMeshCNIPlugin(t *testing.T) {
 		},
 	})
 	defer agent.Cleanup()
-	// TODO: after release, change it to 1.26.0
-	agent.RequireVersion(">=1.25.3")
+	agent.RequireVersion(">=1.26.0")
 
 	tdOverrides := make(map[string]string)
 	tdOverrides["$$$TEST_REGION$$$"] = *ECS.Config.Region
@@ -1724,12 +1720,12 @@ func TestTrunkENIAttachDetachWorkflow(t *testing.T) {
 	// Expect one more interface to be attached (i.e. the Trunk)
 	macs, err := GetNetworkInterfaceMacs()
 	require.NoError(t, err)
-	assert.Equal(t, existingInterfaceCount + 1, len(macs))
+	assert.Equal(t, existingInterfaceCount+1, len(macs))
 
 	// Check that there's one ENI attachment in DescribeContainerInstances response and it matches
 	// the one on the instance
 	resp, err := ECS.DescribeContainerInstances(&ecsapi.DescribeContainerInstancesInput{
-		Cluster: &agent.Cluster,
+		Cluster:            &agent.Cluster,
 		ContainerInstances: aws.StringSlice([]string{agent.ContainerInstanceArn}),
 	})
 	require.NoError(t, err)

--- a/agent/functional_tests/tests/functionaltests_windows_test.go
+++ b/agent/functional_tests/tests/functionaltests_windows_test.go
@@ -233,8 +233,7 @@ func TestAWSLogsDriverMultilinePattern(t *testing.T) {
 	agent := RunAgent(t, &agentOptions)
 	defer agent.Cleanup()
 
-	// TODO: Change the version required
-	agent.RequireVersion(">=1.16.1") //Required for awslogs driver multiline pattern option
+	agent.RequireVersion(">=1.17.0") //Required for awslogs driver multiline pattern option
 
 	tdOverrides := make(map[string]string)
 	tdOverrides["$$$TEST_REGION$$$"] = aws.StringValue(ECS.Config.Region)
@@ -284,8 +283,7 @@ func TestAWSLogsDriverDatetimeFormat(t *testing.T) {
 	agent := RunAgent(t, &agentOptions)
 	defer agent.Cleanup()
 
-	// TODO: Change the version required
-	agent.RequireVersion(">=1.16.1") //Required for awslogs driver datetime format option
+	agent.RequireVersion(">=1.17.0") //Required for awslogs driver datetime format option
 
 	tdOverrides := make(map[string]string)
 	tdOverrides["$$$TEST_REGION$$$"] = aws.StringValue(ECS.Config.Region)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Updating required agent versions for few functional tests, as indicated by todo comment.
For windows tests, fix was done through https://github.com/aws/amazon-ecs-agent/issues/1111, for agent v1.17.0.

### Implementation details
updated required agent version string in tests

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: N/A

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
