### PR TITLE
Using correct error to construct CannotRemoveVolumeError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 1.28.1
+* Bug - Fixed a bug where docker volume deletion resulted in nullpointer [#2059](https://github.com/aws/amazon-ecs-agent/pull/2059)
+
 ## 1.28.0
 * Feature - Introduce high density awsvpc tasks support
 * Enhancement - Introduce `ECS_CGROUP_CPU_PERIOD` to make cgroup cpu period configurable [@boynux](https://github.com/boynux) [#1941](https://github.com/aws/amazon-ecs-agent/pull/1941)

--- a/agent/dockerclient/dockerapi/docker_client.go
+++ b/agent/dockerclient/dockerapi/docker_client.go
@@ -945,8 +945,8 @@ func (dg *dockerGoClient) handleContainerEvents(ctx context.Context,
 		metadata := dg.containerMetadata(ctx, containerID)
 
 		changedContainers <- DockerContainerChangeEvent{
-			Status:                  status,
-			Type:                    eventType,
+			Status: status,
+			Type:   eventType,
 			DockerContainerMetadata: metadata,
 		}
 	}
@@ -1209,8 +1209,8 @@ func (dg *dockerGoClient) removeVolume(ctx context.Context, name string) error {
 		return &CannotGetDockerClientError{version: dg.version, err: err}
 	}
 
-	ok := client.VolumeRemove(ctx, name, false)
-	if ok != nil {
+	err = client.VolumeRemove(ctx, name, false)
+	if err != nil {
 		return &CannotRemoveVolumeError{err}
 	}
 

--- a/agent/dockerclient/dockerapi/docker_client_test.go
+++ b/agent/dockerclient/dockerapi/docker_client_test.go
@@ -1624,6 +1624,7 @@ func TestRemoveVolumeError(t *testing.T) {
 	defer cancel()
 	err := client.RemoveVolume(ctx, "name", dockerclient.RemoveVolumeTimeout)
 	assert.Equal(t, "CannotRemoveVolumeError", err.(apierrors.NamedError).ErrorName())
+	assert.NotNil(t, err.Error(), "Nested error cannot be nil")
 }
 
 func TestRemoveVolume(t *testing.T) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
We are constructing CannotRemoveVolumeError with wrong docker error, which can result in nullpointer

### Implementation details
Using the correct docker error object

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
