### PR TITLE
removing unwanted debug log

### DIFF
--- a/agent/stats/utils.go
+++ b/agent/stats/utils.go
@@ -54,7 +54,6 @@ func isNetworkStatsError(err error) bool {
 
 func getNetworkStats(dockerStats *types.StatsJSON) *NetworkStats {
 	if dockerStats.Networks == nil {
-		seelog.Debug("Network stats not reported for container")
 		return nil
 	}
 	networkStats := &NetworkStats{}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This log statement was getting logged almost every second for network modes, which do not have docker network stats.
```
2019-06-04T23:31:36Z [DEBUG] Network stats not reported for container
2019-06-04T23:31:37Z [DEBUG] Network stats not reported for container
2019-06-04T23:31:38Z [DEBUG] Network stats not reported for container
2019-06-04T23:31:39Z [DEBUG] Network stats not reported for container
2019-06-04T23:31:40Z [DEBUG] Network stats not reported for container
2019-06-04T23:31:41Z [DEBUG] Network stats not reported for container
2019-06-04T23:31:42Z [DEBUG] Network stats not reported for container
2019-06-04T23:31:43Z [DEBUG] Network stats not reported for container
2019-06-04T23:31:44Z [DEBUG] Network stats not reported for container
2019-06-04T23:31:45Z [DEBUG] Network stats not reported for container
2019-06-04T23:31:46Z [DEBUG] Network stats not reported for container
2019-06-04T23:31:47Z [DEBUG] Network stats not reported for container
2019-06-04T23:31:48Z [DEBUG] Network stats not reported for container
2019-06-04T23:31:49Z [DEBUG] Network stats not reported for container
2019-06-04T23:31:50Z [DEBUG] Network stats not reported for container
```
Removing it, since its not necessary

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
