### PR TITLE
update storage-stats test container to read and write from disk

### DIFF
--- a/misc/storage-stats/Dockerfile
+++ b/misc/storage-stats/Dockerfile
@@ -19,4 +19,4 @@ COPY main.go .
 RUN go build -o storagestats main.go
 
 ENTRYPOINT ["./storagestats"]
-CMD [ "-sleep", "5000", "-bytecount", "1073741823"]
+CMD [ "-sleep", "5000", "-bytecount", "8192"]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This updates the disk-stats functional test container for linux to read/write directly to/from block storage.  It also fixes the massive size of bytes being written previously, which generally just uses too much cpu to actually run.

### Implementation details
Reads are done using the `syscall.O_DIRECT` flag, which bypasses the filesystem cache.  

### Testing
tested using linux cluster, run in functional test context.

<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
