### PR TITLE
Update task cleanup wait logic to clean task resources immediately in…

### DIFF
--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -1092,18 +1092,16 @@ func (mtask *managedTask) time() ttime.Time {
 
 func (mtask *managedTask) cleanupTask(taskStoppedDuration time.Duration) {
 	cleanupTimeDuration := mtask.GetKnownStatusTime().Add(taskStoppedDuration).Sub(ttime.Now())
-	// There is a potential deadlock here if cleanupTime is negative. Ignore the computed
-	// value in this case in favor of the default config value.
+	cleanupTime := make(<-chan time.Time)
 	if cleanupTimeDuration < 0 {
-		seelog.Infof("Managed task [%s]: Cleanup Duration is too short. Resetting to: %s",
-			mtask.Arn, config.DefaultTaskCleanupWaitDuration.String())
-		cleanupTimeDuration = config.DefaultTaskCleanupWaitDuration
+		seelog.Infof("Managed task [%s]: Cleanup Duration has been exceeded. Starting cleanup now ", mtask.Arn)
+		cleanupTime = mtask.time().After(time.Nanosecond)
+	} else {
+		cleanupTime = mtask.time().After(cleanupTimeDuration)
 	}
-	cleanupTime := mtask.time().After(cleanupTimeDuration)
 	cleanupTimeBool := make(chan struct{})
 	go func() {
 		<-cleanupTime
-		cleanupTimeBool <- struct{}{}
 		close(cleanupTimeBool)
 	}()
 	// wait for the cleanup time to elapse, signalled by cleanupTimeBool


### PR DESCRIPTION
Update task cleanup wait logic to clean task resources immediately instead of waiting 3 hours

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Currently if the clean up duration for tasks are not defined, It defaults to 3hr. The current logic in cleanupTask is once it passed the cleanup time, agent will wait for 3 more hours (DefaultTaskCleanupWaitDuration) instead of cleaning up the task immediately. Instead with below changes, it will begin cleanup immediately .

### Implementation details
Once it passed the cleanup time, it waits a nanosecond and begins the cleanup task.

### Testing
Created a task definition that uses a volume called test_vol. The check for successful clean being that docker volume ls does not return test_vol in the list.
Five cases tested.
1. No cleanup is specified - The cleanup duration is set to 3hrs
2. Cleanup specified is negative - The cleanup is set to 3hrs
3. Cleanup specified is less than minimum value - The cleanup is set to 3hrs
4. Cleanup specified is 10 mins - Clean up begins after 5min after container goes to stop state 
5. Cleanup specified is 5mins - Clean up begins after 5min after container goes to stop state

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
