### PR TITLE
Fill in Type field when invoking ipam DEL command

### DIFF
--- a/agent/ecscni/plugin.go
+++ b/agent/ecscni/plugin.go
@@ -404,6 +404,7 @@ func (client *cniClient) createIPAMNetworkConfig(cfg *Config) (string, *libcni.N
 
 	ipamNetworkConfig := IPAMNetworkConfig{
 		Name:       ECSIPAMPluginName,
+		Type:       ECSIPAMPluginName,
 		CNIVersion: client.cniVersion,
 		IPAM:       ipamConfig,
 	}

--- a/agent/ecscni/types.go
+++ b/agent/ecscni/types.go
@@ -60,6 +60,7 @@ const (
 //IPAMNetworkConfig is the config format accepted by the plugin
 type IPAMNetworkConfig struct {
 	Name       string     `json:"name,omitempty"`
+	Type       string     `json:"type,omitempty"`
 	CNIVersion string     `json:"cniVersion,omitempty"`
 	IPAM       IPAMConfig `json:"ipam"`
 }

--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -568,13 +568,13 @@ func (mtask *managedTask) releaseIPInIPAM() {
 
 	cfg, err := mtask.BuildCNIConfig()
 	if err != nil {
-		seelog.Warnf("Managed task [%s]: failed to release ip; unable to build cni configuration: %v",
+		seelog.Errorf("Managed task [%s]: failed to release ip; unable to build cni configuration: %v",
 			mtask.Arn, err)
 		return
 	}
 	err = mtask.cniClient.ReleaseIPResource(mtask.ctx, cfg, ipamCleanupTmeout)
 	if err != nil {
-		seelog.Warnf("Managed task [%s]: failed to release ip; IPAM error: %v",
+		seelog.Errorf("Managed task [%s]: failed to release ip; IPAM error: %v",
 			mtask.Arn, err)
 		return
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
After updating libcni to 0.7.0 (https://github.com/aws/amazon-ecs-agent/pull/2036), agent fails to invoke IPAM DEL command when cleaning up awsvpc task:
```
2019-06-14T17:17:30Z [WARN] Managed task [...]: failed to release ip; IPAM error: error parsing configuration: missing 'type'
```
This results in IPAM record not being deleted on the instance, which can ultimately lead to exhausting ip address, and when that happens, subsequent awsvpc task will fail to launch:
```
...error transitioning container [~internal~ecs~pause] to [RESOURCES_PROVISIONED]: container resource provisioning: failed to setup network namespace: cni setup: invoke bridge plugin failed: bridge ipam ADD: failed to execute plugin: ecs-ipam: getIPV4AddressFromDB commands: failed to get available ip from the db: getAvailableIP ipstore: failed to find available ip addresses in the subnet
```

It appears that starting from libcni 0.7.0, the package mandates the json blob in [NetworkConfig.Bytes](https://github.com/containernetworking/cni/blob/master/libcni/api.go#L57) to have a non-empty Type field, and we are not filling in this field when invoking IPAM DEL command, so the invocation fails. This PR fill in the field to conform with what the package expects.

### Implementation details
<!-- How are the changes implemented? -->
Fill in the Type field with plugin name.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes
Added unit test. Manually tested that the ip record is deleted in /var/lib/ecs/data/eni-ipam.db with the fix. I checked whether i can add a functional test for this, but seems like the boltdb file written by the ipam plugin can't be opened by non-root user which makes this tricky.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Bug - Fixed a bug where IPAM record was not deleted when cleaning up awsvpc task.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
