### PR TITLE
amazon-vpc-cni-plugins: update to latest commit

### DIFF
--- a/agent/ecscni/plugin.go
+++ b/agent/ecscni/plugin.go
@@ -38,7 +38,7 @@ const (
 	// ECSCNIVersion, ECSCNIGitHash, VPCCNIGitHash needs to be updated every time CNI plugin is updated
 	currentECSCNIVersion      = "2019.06.0"
 	currentECSCNIGitHash      = "91ccefc8864ec14a32bd2b9d7e7de3060b685383"
-	currentVPCCNIGitHash      = "85d8d2b11deb6cb3fd0e911e12379ddc0d7019ba"
+	currentVPCCNIGitHash      = "fa071b269ea57644ab566cc915698c61369e158f"
 	vpcCNIPluginPath          = "/log/vpc-branch-eni.log"
 	vpcCNIPluginInterfaceType = "vlan"
 )


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This brings in a fix to remove eni trunking's dependency on ec2-net-utils (https://github.com/aws/amazon-vpc-cni-plugins/commit/fa071b269ea57644ab566cc915698c61369e158f). Previously we implicitly depend on ec2-net-utils to bring up the trunk interface.

### Implementation details
<!-- How are the changes implemented? -->
git submodule init --update --remote

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Bug: update amazon-vpc-cni-plugins to latest version to include a fix (https://github.com/aws/amazon-vpc-cni-plugins/commit/fa071b269ea57644ab566cc915698c61369e158f) that allows awsvpcTrunking to work without ec2-net-utils.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
