### PR TITLE
Replace host setup script with ECS tools module in ECS optimized AMI

### DIFF
--- a/agent/engine/engine_windows_integ_test.go
+++ b/agent/engine/engine_windows_integ_test.go
@@ -46,7 +46,7 @@ const (
 	dockerEndpoint              = "npipe:////./pipe/docker_engine"
 	testVolumeImage             = "amazon/amazon-ecs-volumes-test:make"
 	testRegistryImage           = "amazon/amazon-ecs-netkitten:make"
-	testHelloworldImage         = "cggruszka/microsoft-windows-helloworld:latest"
+	testBaseImage               = "amazon-ecs-ftest-windows-base:make"
 	dockerVolumeDirectoryFormat = "c:\\ProgramData\\docker\\volumes\\%s\\_data"
 )
 
@@ -58,7 +58,7 @@ func isDockerRunning() bool { return true }
 func createTestContainer() *apicontainer.Container {
 	return &apicontainer.Container{
 		Name:                "windows",
-		Image:               "amazon-ecs-ftest-windows-base:make",
+		Image:               testBaseImage,
 		Essential:           true,
 		DesiredStatusUnsafe: apicontainerstatus.ContainerRunning,
 		CPU:                 512,
@@ -102,7 +102,7 @@ func createTestHealthCheckTask(arn string) *apitask.Task {
 		DesiredStatusUnsafe: apitaskstatus.TaskRunning,
 		Containers:          []*apicontainer.Container{createTestContainer()},
 	}
-	testTask.Containers[0].Image = "microsoft/nanoserver"
+	testTask.Containers[0].Image = testBaseImage
 	testTask.Containers[0].Name = "test-health-check"
 	testTask.Containers[0].HealthCheckType = "docker"
 	testTask.Containers[0].Command = []string{"powershell", "-command", "Start-Sleep -s 300"}
@@ -203,10 +203,11 @@ func TestStartStopUnpulledImage(t *testing.T) {
 	taskEngine, done, _ := setupWithDefaultConfig(t)
 	defer done()
 	// Ensure this image isn't pulled by deleting it
-	removeImage(t, testHelloworldImage)
+	baseImg := os.Getenv("BASE_IMAGE_NAME")
+	removeImage(t, baseImg)
 
 	testTask := createTestTask("testStartUnpulled")
-	testTask.Containers[0].Image = testHelloworldImage
+	testTask.Containers[0].Image = baseImg
 
 	stateChangeEvents := taskEngine.StateChangeEvents()
 
@@ -228,14 +229,14 @@ func TestStartStopUnpulledImage(t *testing.T) {
 // TestStartStopUnpulledImageDigest ensures that an unpulled image with
 // specified digest is successfully pulled, run, and stopped via docker.
 func TestStartStopUnpulledImageDigest(t *testing.T) {
-	imageDigest := "cggruszka/microsoft-windows-helloworld@sha256:89282ba3e122e461381eae854d142c6c4895fcc1087d4849dbe4786fb21018f8"
+	baseImgWithDigest := os.Getenv("BASE_IMAGE_NAME_WITH_DIGEST")
 	taskEngine, done, _ := setupWithDefaultConfig(t)
 	defer done()
 	// Ensure this image isn't pulled by deleting it
-	removeImage(t, imageDigest)
+	removeImage(t, baseImgWithDigest)
 
 	testTask := createTestTask("testStartUnpulledDigest")
-	testTask.Containers[0].Image = imageDigest
+	testTask.Containers[0].Image = baseImgWithDigest
 
 	stateChangeEvents := taskEngine.StateChangeEvents()
 

--- a/misc/v3-task-endpoint-validator-windows/setup-v3-task-endpoint-validator.ps1
+++ b/misc/v3-task-endpoint-validator-windows/setup-v3-task-endpoint-validator.ps1
@@ -14,7 +14,7 @@
 $oldPref = $ErrorActionPreference
 $ErrorActionPreference = 'Stop'
 
-Invoke-Expression ${PSScriptRoot}\..\windows-deploy\hostsetup.ps1
+Invoke-Expression "Import-Module ECSTools; Initialize-ECSHost"
 
 # Create amazon/amazon-ecs-v3-task-endpoint-validator-windows for tests
 Invoke-Expression "go get github.com/docker/docker/api/types github.com/pkg/errors"

--- a/misc/windows-iam/Setup_Iam.ps1
+++ b/misc/windows-iam/Setup_Iam.ps1
@@ -14,7 +14,7 @@
 $oldPref = $ErrorActionPreference
 $ErrorActionPreference = 'Stop'
 
-Invoke-Expression ${PSScriptRoot}\..\windows-deploy\hostsetup.ps1
+Invoke-Expression "Import-Module ECSTools; Initialize-ECSHost"
 
 Invoke-Expression "go get -u  github.com/aws/aws-sdk-go"
 Invoke-Expression "go get -u  github.com/aws/aws-sdk-go/aws"

--- a/scripts/run-functional-tests.ps1
+++ b/scripts/run-functional-tests.ps1
@@ -12,8 +12,17 @@
 # permissions and limitations under the License.
 
 Param (
-  [string]$BaseImageName="microsoft/windowsservercore"
+  [string]$Platform="windows2016"
 )
+
+if ($Platform -like "windows2016") {
+  $BaseImageName="mcr.microsoft.com/windows/servercore:ltsc2016"
+} elseif ($Platform -like "windows2019")  {
+  $BaseImageName="mcr.microsoft.com/windows/servercore:ltsc2019"
+} else {
+  echo "Invalid platform parameter"
+  exit 1
+}
 
 # Prepared base image
 $dockerImages = Invoke-Expression "docker images"

--- a/scripts/run-integ-tests.ps1
+++ b/scripts/run-integ-tests.ps1
@@ -12,8 +12,22 @@
 # permissions and limitations under the License.
 
 Param (
-  [string]$BaseImageName="microsoft/windowsservercore"
+  [string]$Platform="windows2016"
 )
+
+if ($Platform -like "windows2016") {
+  $BaseImageName="mcr.microsoft.com/windows/servercore:ltsc2016"
+  $BaseImageNameWithDigest="mcr.microsoft.com/windows/servercore@sha256:91368f3cff77ad42259ccb3bf3d1a4e145cf5fa9e486f23999d32711c2913f3e"
+} elseif ($Platform -like "windows2019")  {
+  $BaseImageName="mcr.microsoft.com/windows/servercore:ltsc2019"
+  $BaseImageNameWithDigest="mcr.microsoft.com/windows/servercore@sha256:e20960b4c06acee08af55164e3abc37b39cdc128ce2f5fcdf3397c738cb91069"
+} else {
+  echo "Invalid platform parameter"
+  exit 1
+}
+
+$env:BASE_IMAGE_NAME=$BaseImageName
+$env:BASE_IMAGE_NAME_WITH_DIGEST=$BaseImageNameWithDigest
 
 # Prepare windows base image
 $dockerImages = Invoke-Expression "docker images"


### PR DESCRIPTION
Gradually deprecating hostsetup script, as we decided that hostsetup is outdated here:
https://github.com/aws/amazon-ecs-agent/issues/1198. Also changed ability to pass in
test base image to the ability to pass in platform and define ecs test base image in
our script to help customers to run functional test on their own

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> NA (automation tests pass, need automation framework to be updated ).

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
