### PR TITLE
Implement log router task resource

### DIFF
--- a/agent/Gopkg.lock
+++ b/agent/Gopkg.lock
@@ -61,6 +61,14 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:83cedb03ada7f52025f19d4e1fef1193b0c95dd3d1ec463488e5b9865bcf5af3"
+  name = "github.com/awslabs/go-config-generator-for-fluentd-and-fluentbit"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "d9b7ac1ed5905d5434dd21ebc1582389b4ae91d1"
+
+[[projects]]
+  branch = "master"
   digest = "1:d6afaeed1502aa28e80a4ed0981d570ad91b2579193404256ce672ed0a609e0d"
   name = "github.com/beorn7/perks"
   packages = ["quantile"]
@@ -506,6 +514,7 @@
     "github.com/aws/aws-sdk-go/service/secretsmanager",
     "github.com/aws/aws-sdk-go/service/secretsmanager/secretsmanageriface",
     "github.com/aws/aws-sdk-go/service/ssm",
+    "github.com/awslabs/go-config-generator-for-fluentd-and-fluentbit",
     "github.com/cihub/seelog",
     "github.com/containerd/cgroups",
     "github.com/containernetworking/cni/libcni",

--- a/agent/Gopkg.toml
+++ b/agent/Gopkg.toml
@@ -92,3 +92,7 @@ required = ["github.com/golang/mock/mockgen/model"]
 [[constraint]]
   name = "github.com/prometheus/client_golang"
   version = "0.9.0"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/awslabs/go-config-generator-for-fluentd-and-fluentbit"

--- a/agent/taskresource/logrouter/json_unix.go
+++ b/agent/taskresource/logrouter/json_unix.go
@@ -1,0 +1,110 @@
+// +build linux
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package logrouter
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/pkg/errors"
+
+	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
+)
+
+type logRouterResourceJSON struct {
+	Cluster                string
+	TaskARN                string
+	TaskDefinition         string
+	EC2InstanceID          string
+	ResourceDir            string
+	LogRouterType          string
+	ECSMetadataEnabled     bool
+	ContainersToLogOptions map[string]map[string]string
+	TerminalReason         string
+
+	CreatedAt     time.Time
+	DesiredStatus *LogRouterStatus
+	KnownStatus   *LogRouterStatus
+	AppliedStatus *LogRouterStatus
+}
+
+// MarshalJSON marshals logRouter object into bytes of json.
+func (logRouter *LogRouterResource) MarshalJSON() ([]byte, error) {
+	if logRouter == nil {
+		return nil, errors.New("log router resource is nil")
+	}
+
+	logRouter.lock.RLock()
+	defer logRouter.lock.RUnlock()
+
+	return json.Marshal(logRouterResourceJSON{
+		Cluster:                logRouter.cluster,
+		TaskARN:                logRouter.taskARN,
+		TaskDefinition:         logRouter.taskDefinition,
+		EC2InstanceID:          logRouter.ec2InstanceID,
+		ResourceDir:            logRouter.resourceDir,
+		LogRouterType:          logRouter.logRouterType,
+		ECSMetadataEnabled:     logRouter.ecsMetadataEnabled,
+		ContainersToLogOptions: logRouter.containerToLogOptions,
+		TerminalReason:         logRouter.terminalReason,
+		CreatedAt:              logRouter.createdAtUnsafe,
+		DesiredStatus: func() *LogRouterStatus {
+			desiredStatus := logRouter.desiredStatusUnsafe
+			s := LogRouterStatus(desiredStatus)
+			return &s
+		}(),
+		KnownStatus: func() *LogRouterStatus {
+			knownStatus := logRouter.knownStatusUnsafe
+			s := LogRouterStatus(knownStatus)
+			return &s
+		}(),
+		AppliedStatus: func() *LogRouterStatus {
+			appliedStatus := logRouter.appliedStatusUnsafe
+			s := LogRouterStatus(appliedStatus)
+			return &s
+		}(),
+	})
+}
+
+// UnmarshalJSON unmarshals bytes of json into logRouter object.
+func (logRouter *LogRouterResource) UnmarshalJSON(b []byte) error {
+	if logRouter == nil {
+		return errors.New("log router resource is nil")
+	}
+
+	temp := logRouterResourceJSON{}
+	if err := json.Unmarshal(b, &temp); err != nil {
+		return err
+	}
+
+	logRouter.lock.Lock()
+	defer logRouter.lock.Unlock()
+
+	logRouter.cluster = temp.Cluster
+	logRouter.taskARN = temp.TaskARN
+	logRouter.taskDefinition = temp.TaskDefinition
+	logRouter.ec2InstanceID = temp.EC2InstanceID
+	logRouter.resourceDir = temp.ResourceDir
+	logRouter.logRouterType = temp.LogRouterType
+	logRouter.ecsMetadataEnabled = temp.ECSMetadataEnabled
+	logRouter.containerToLogOptions = temp.ContainersToLogOptions
+	logRouter.terminalReason = temp.TerminalReason
+	logRouter.createdAtUnsafe = temp.CreatedAt
+	logRouter.desiredStatusUnsafe = resourcestatus.ResourceStatus(*temp.DesiredStatus)
+	logRouter.knownStatusUnsafe = resourcestatus.ResourceStatus(*temp.KnownStatus)
+	logRouter.appliedStatusUnsafe = resourcestatus.ResourceStatus(*temp.AppliedStatus)
+
+	return nil
+}

--- a/agent/taskresource/logrouter/json_unix_test.go
+++ b/agent/taskresource/logrouter/json_unix_test.go
@@ -1,0 +1,68 @@
+// +build linux,unit
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package logrouter
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
+)
+
+func TestMarshalUnmarshalJSON(t *testing.T) {
+	testCreatedAt := time.Now()
+	testContainerToLogOptions := map[string]map[string]string{
+		"container": testFluentdOptions,
+	}
+
+	logRouterResIn := &LogRouterResource{
+		cluster:               testCluster,
+		taskARN:               testTaskARN,
+		taskDefinition:        testTaskDefinition,
+		ec2InstanceID:         testEC2InstanceID,
+		resourceDir:           testResourceDir,
+		logRouterType:         LogRouterTypeFluentd,
+		ecsMetadataEnabled:    true,
+		containerToLogOptions: testContainerToLogOptions,
+		terminalReason:        testTerminalResason,
+		createdAtUnsafe:       testCreatedAt,
+		desiredStatusUnsafe:   resourcestatus.ResourceCreated,
+		knownStatusUnsafe:     resourcestatus.ResourceCreated,
+		appliedStatusUnsafe:   resourcestatus.ResourceCreated,
+	}
+
+	bytes, err := json.Marshal(logRouterResIn)
+	require.NoError(t, err)
+
+	logRouterResOut := &LogRouterResource{}
+	err = json.Unmarshal(bytes, logRouterResOut)
+	require.NoError(t, err)
+	assert.Equal(t, testCluster, logRouterResOut.cluster)
+	assert.Equal(t, testTaskARN, logRouterResOut.taskARN)
+	assert.Equal(t, testTaskDefinition, logRouterResOut.taskDefinition)
+	assert.True(t, logRouterResOut.ecsMetadataEnabled)
+	assert.Equal(t, testContainerToLogOptions, logRouterResOut.containerToLogOptions)
+	assert.Equal(t, testTerminalResason, logRouterResOut.terminalReason)
+	// Can't use assert.Equal for time here. See https://github.com/golang/go/issues/22957.
+	assert.True(t, testCreatedAt.Equal(logRouterResOut.createdAtUnsafe))
+	assert.Equal(t, resourcestatus.ResourceCreated, logRouterResOut.desiredStatusUnsafe)
+	assert.Equal(t, resourcestatus.ResourceCreated, logRouterResOut.knownStatusUnsafe)
+	assert.Equal(t, resourcestatus.ResourceCreated, logRouterResOut.appliedStatusUnsafe)
+	assert.Equal(t, testTerminalResason, logRouterResOut.terminalReason)
+}

--- a/agent/taskresource/logrouter/logconfig_unix.go
+++ b/agent/taskresource/logrouter/logconfig_unix.go
@@ -1,0 +1,145 @@
+// +build linux
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package logrouter
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	generator "github.com/awslabs/go-config-generator-for-fluentd-and-fluentbit"
+)
+
+const (
+	// LogRouterTypeFluentd is the type of a fluentd log router.
+	LogRouterTypeFluentd = "fluentd"
+
+	// LogRouterTypeFluentbit is the type of a fluentbit log router.
+	LogRouterTypeFluentbit = "fluentbit"
+
+	// socketInputNameFluentd is the name of the socket input plugin for fluentd.
+	socketInputNameFluentd = "unix"
+
+	// socketInputNameFluentbit is the name of the socket input plugin for fluentbit.
+	socketInputNameFluentbit = "forward"
+
+	// socketInputPathOptionFluentd is the key for specifying socket path for fluentd.
+	socketInputPathOptionFluentd = "path"
+
+	// socketInputPathOptionFluentbit is the key for specifying socket path for fluentbit.
+	socketInputPathOptionFluentbit = "unix_path"
+
+	// outputTypeLogOptionKeyFluentd is the key for the log option that specifies output plugin type for fluentd.
+	outputTypeLogOptionKeyFluentd = "@type"
+
+	// outputTypeLogOptionKeyFluentbit is the key for the log option that specifies output plugin type for fluentbit.
+	outputTypeLogOptionKeyFluentbit = "Name"
+
+	// includePatternKey is the key for include pattern.
+	includePatternKey = "include-pattern"
+
+	// excludePatternKey is the key for exclude pattern.
+	excludePatternKey = "exclude-pattern"
+
+	// socketPath is the path for socket file.
+	socketPath = "/var/run/fluent.sock"
+)
+
+// generateConfig generates a FluentConfig object that contains all necessary information to construct
+// a fluentd or fluentbit config file for the log router.
+func (logRouter *LogRouterResource) generateConfig() (generator.FluentConfig, error) {
+	config := generator.New()
+
+	// Specify log stream input, which is a unix socket that will be used for communication between log router container
+	// and other containers.
+	var inputName, inputPathOption string
+	if logRouter.logRouterType == LogRouterTypeFluentd {
+		inputName = socketInputNameFluentd
+		inputPathOption = socketInputPathOptionFluentd
+	} else {
+		inputName = socketInputNameFluentbit
+		inputPathOption = socketInputPathOptionFluentbit
+	}
+	config.AddInput(inputName, "", map[string]string{
+		inputPathOption: socketPath,
+	})
+
+	if logRouter.ecsMetadataEnabled {
+		// Add ecs metadata fields to the log stream.
+		config.AddFieldToRecord("ecs_cluster", logRouter.cluster, "*").
+			AddFieldToRecord("ecs_task_arn", logRouter.taskARN, "*").
+			AddFieldToRecord("ecs_task_definition", logRouter.taskDefinition, "*")
+		if logRouter.ec2InstanceID != "" {
+			config.AddFieldToRecord("ec2_instance_id", logRouter.ec2InstanceID, "*")
+		}
+	}
+
+	// Specify log stream output. Each container that uses the log router container to stream logs
+	// will have its own output section, with its own log options.
+	fields := strings.Split(logRouter.taskARN, "/")
+	taskID := fields[len(fields)-1]
+	for containerName, logOptions := range logRouter.containerToLogOptions {
+		tag := containerName + "-" + taskID // Each output section is distinguished by a tag specific to a container.
+		newConfig, err := addOutputSection(tag, logRouter.logRouterType, logOptions, config)
+		if err != nil {
+			return nil, fmt.Errorf("unable to apply log options of container %s to log router config: %v", containerName, err)
+		}
+		config = newConfig
+	}
+
+	return config, nil
+}
+
+// addOutputSection adds an output section in the log config for a container. It's constructed based on the
+// container's log options.
+// logOptions is a set of key-value pairs, which includes the following:
+//     1. The name of the output plugin (required). For fluentd, the key is "@type", for fluentbit, the key is "Name".
+//     2. include-pattern (optional): a regex specifying the logs to be included.
+//     3. exclude-pattern (optional): a regex specifying the logs to be excluded.
+//     4. All other key-value pairs are customer specified options for the plugin. They are unique for each plugin and
+//        we don't check them.
+func addOutputSection(tag, logRouterType string, logOptions map[string]string, config generator.FluentConfig) (generator.FluentConfig, error) {
+	var outputKey string
+	if logRouterType == LogRouterTypeFluentd {
+		outputKey = outputTypeLogOptionKeyFluentd
+	} else {
+		outputKey = outputTypeLogOptionKeyFluentbit
+	}
+
+	output, ok := logOptions[outputKey]
+	if !ok {
+		return config, errors.New(
+			fmt.Sprintf("missing output option %s which is required for log router type %s",
+				outputKey, logRouterType))
+	}
+
+	outputOptions := make(map[string]string)
+	for key, value := range logOptions {
+		switch key {
+		case outputKey:
+			continue
+		case includePatternKey:
+			config.AddIncludeFilter(value, "log", tag)
+		case excludePatternKey:
+			config.AddExcludeFilter(value, "log", tag)
+		default: // This is a plugin specific option.
+			outputOptions[key] = value
+		}
+	}
+
+	config.AddOutput(output, tag, outputOptions)
+	return config, nil
+}

--- a/agent/taskresource/logrouter/logconfig_unix_test.go
+++ b/agent/taskresource/logrouter/logconfig_unix_test.go
@@ -1,0 +1,216 @@
+// +build linux,unit
+
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package logrouter
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	testFluentdOptions = map[string]string{
+		"@type":               "kinesis_firehose",
+		"region":              "us-west-2",
+		"deliver_stream_name": "my-stream",
+		"include-pattern":     "*failure*",
+		"exclude-pattern":     "*success*",
+	}
+
+	testFluentbitOptions = map[string]string{
+		"Name":                "kinesis_firehose",
+		"region":              "us-west-2",
+		"deliver_stream_name": "my-stream",
+		"include-pattern":     "*failure*",
+		"exclude-pattern":     "*success*",
+	}
+
+	expectedFluentdConfig = `
+<source>
+    @type unix
+    path /var/run/fluent.sock
+</source>
+
+<filter container-3de392df-6bfa-470b-97ed-aa6f482cd7a>
+    @type  grep
+    <regexp>
+        key log
+        pattern *failure*
+    </regexp>
+</filter>
+
+<filter container-3de392df-6bfa-470b-97ed-aa6f482cd7a>
+    @type  grep
+    <exclude>
+        key log
+        pattern *success*
+    </exclude>
+</filter>
+
+<filter *>
+    @type record_transformer
+    <record>
+        ec2_instance_id i-123456789a
+        ecs_cluster mycluster
+        ecs_task_arn arn:aws:ecs:us-east-2:01234567891011:task/mycluster/3de392df-6bfa-470b-97ed-aa6f482cd7a
+        ecs_task_definition taskdefinition:1
+    </record>
+</filter>
+
+<match container-3de392df-6bfa-470b-97ed-aa6f482cd7a>
+    @type kinesis_firehose
+    deliver_stream_name my-stream
+    region us-west-2
+</match>
+`
+	expectedFluentbitConfig = `
+[INPUT]
+    Name forward
+    unix_path /var/run/fluent.sock
+
+[FILTER]
+    Name   grep
+    Match container-3de392df-6bfa-470b-97ed-aa6f482cd7a
+    Regex  log *failure*
+
+[FILTER]
+    Name   grep
+    Match container-3de392df-6bfa-470b-97ed-aa6f482cd7a
+    Exclude log *success*
+
+[FILTER]
+    Name record_modifier
+    Match *
+    Record ec2_instance_id i-123456789a
+    Record ecs_cluster mycluster
+    Record ecs_task_arn arn:aws:ecs:us-east-2:01234567891011:task/mycluster/3de392df-6bfa-470b-97ed-aa6f482cd7a
+    Record ecs_task_definition taskdefinition:1
+
+[OUTPUT]
+    Name kinesis_firehose
+    Match container-3de392df-6bfa-470b-97ed-aa6f482cd7a
+    deliver_stream_name my-stream
+    region us-west-2
+`
+	expectedFluentdConfigWithoutECSMetadata = `
+<source>
+    @type unix
+    path /var/run/fluent.sock
+</source>
+
+<filter container-3de392df-6bfa-470b-97ed-aa6f482cd7a>
+    @type  grep
+    <regexp>
+        key log
+        pattern *failure*
+    </regexp>
+</filter>
+
+<filter container-3de392df-6bfa-470b-97ed-aa6f482cd7a>
+    @type  grep
+    <exclude>
+        key log
+        pattern *success*
+    </exclude>
+</filter>
+
+<match container-3de392df-6bfa-470b-97ed-aa6f482cd7a>
+    @type kinesis_firehose
+    deliver_stream_name my-stream
+    region us-west-2
+</match>
+`
+)
+
+func TestGenerateFluentdConfig(t *testing.T) {
+	containerToLogOptions := map[string]map[string]string{
+		"container": testFluentdOptions,
+	}
+
+	logRouterResource := NewLogRouterResource(testCluster, testTaskARN, testTaskDefinition, testEC2InstanceID,
+		testDataDir, LogRouterTypeFluentd, true, containerToLogOptions)
+
+	config, err := logRouterResource.generateConfig()
+	assert.NoError(t, err)
+
+	configBytes := new(bytes.Buffer)
+	err = config.WriteFluentdConfig(configBytes)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedFluentdConfig, configBytes.String())
+}
+
+func TestGenerateFluentbitConfig(t *testing.T) {
+	containerToLogOptions := map[string]map[string]string{
+		"container": testFluentbitOptions,
+	}
+
+	logRouterResource := NewLogRouterResource(testCluster, testTaskARN, testTaskDefinition, testEC2InstanceID,
+		testDataDir, LogRouterTypeFluentbit, true, containerToLogOptions)
+
+	config, err := logRouterResource.generateConfig()
+	assert.NoError(t, err)
+
+	configBytes := new(bytes.Buffer)
+	err = config.WriteFluentBitConfig(configBytes)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedFluentbitConfig, configBytes.String())
+}
+
+func TestGenerateFluentdConfigMissingOutputName(t *testing.T) {
+	containerToLogOptions := map[string]map[string]string{
+		"container": {
+			"key1": "value1",
+		},
+	}
+
+	logRouterResource := NewLogRouterResource(testCluster, testTaskARN, testTaskDefinition, testEC2InstanceID,
+		testDataDir, LogRouterTypeFluentd, true, containerToLogOptions)
+
+	_, err := logRouterResource.generateConfig()
+	assert.Error(t, err)
+}
+
+func TestGenerateFLuentbitConfigMissingOutputName(t *testing.T) {
+	containerToLogOptions := map[string]map[string]string{
+		"container": {
+			"key1": "value1",
+		},
+	}
+
+	logRouterResource := NewLogRouterResource(testCluster, testTaskARN, testTaskDefinition, testEC2InstanceID,
+		testDataDir, LogRouterTypeFluentbit, true, containerToLogOptions)
+
+	_, err := logRouterResource.generateConfig()
+	assert.Error(t, err)
+}
+
+func TestGenerateConfigWithECSMetadataDisabled(t *testing.T) {
+	containerToLogOptions := map[string]map[string]string{
+		"container": testFluentdOptions,
+	}
+
+	logRouterResource := NewLogRouterResource(testCluster, testTaskARN, testTaskDefinition, testEC2InstanceID,
+		testDataDir, LogRouterTypeFluentd, false, containerToLogOptions)
+
+	config, err := logRouterResource.generateConfig()
+	assert.NoError(t, err)
+
+	configBytes := new(bytes.Buffer)
+	err = config.WriteFluentdConfig(configBytes)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedFluentdConfigWithoutECSMetadata, configBytes.String())
+}

--- a/agent/taskresource/logrouter/logrouter_unimplemented.go
+++ b/agent/taskresource/logrouter/logrouter_unimplemented.go
@@ -1,0 +1,135 @@
+// +build !linux
+
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package logrouter
+
+import (
+	"errors"
+	"time"
+
+	"github.com/aws/amazon-ecs-agent/agent/api/task/status"
+	"github.com/aws/amazon-ecs-agent/agent/taskresource"
+	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
+)
+
+const (
+	// ResourceName is the name of the log router resource.
+	ResourceName = "logrouter"
+)
+
+// LogRouterResource represents the log router resource.
+type LogRouterResource struct{}
+
+// SetDesiredStatus safely sets the desired status of the resource.
+func (logRouter *LogRouterResource) SetDesiredStatus(status resourcestatus.ResourceStatus) {}
+
+// GetDesiredStatus safely returns the desired status of the resource.
+func (logRouter *LogRouterResource) GetDesiredStatus() resourcestatus.ResourceStatus {
+	return resourcestatus.ResourceStatusNone
+}
+
+// GetName safely returns the name of the resource.
+func (logRouter *LogRouterResource) GetName() string {
+	return "undefined"
+}
+
+// DesiredTerminal returns true if the resource's desired status is REMOVED.
+func (logRouter *LogRouterResource) DesiredTerminal() bool {
+	return false
+}
+
+// KnownCreated returns true if the resource's known status is CREATED.
+func (logRouter *LogRouterResource) KnownCreated() bool {
+	return false
+}
+
+// TerminalStatus returns the last transition state of log router resource.
+func (logRouter *LogRouterResource) TerminalStatus() resourcestatus.ResourceStatus {
+	return resourcestatus.ResourceStatusNone
+}
+
+// NextKnownState returns the state that the resource should progress to based
+// on its `KnownState`.
+func (logRouter *LogRouterResource) NextKnownState() resourcestatus.ResourceStatus {
+	return resourcestatus.ResourceStatusNone
+}
+
+// ApplyTransition calls the function required to move to the specified status.
+func (logRouter *LogRouterResource) ApplyTransition(nextState resourcestatus.ResourceStatus) error {
+	return errors.New("not implemented")
+}
+
+// SteadyState returns the transition state of the resource defined as "ready".
+func (logRouter *LogRouterResource) SteadyState() resourcestatus.ResourceStatus {
+	return resourcestatus.ResourceStatusNone
+}
+
+// SetKnownStatus safely sets the currently known status of the resource.
+func (logRouter *LogRouterResource) SetKnownStatus(status resourcestatus.ResourceStatus) {}
+
+// SetAppliedStatus sets the applied status of resource and returns whether
+// the resource is already in a transition.
+func (logRouter *LogRouterResource) SetAppliedStatus(status resourcestatus.ResourceStatus) bool {
+	return false
+}
+
+// GetKnownStatus safely returns the currently known status of the resource.
+func (logRouter *LogRouterResource) GetKnownStatus() resourcestatus.ResourceStatus {
+	return resourcestatus.ResourceStatusNone
+}
+
+// SetCreatedAt sets the timestamp for resource's creation time.
+func (logRouter *LogRouterResource) SetCreatedAt(createdAt time.Time) {}
+
+// GetCreatedAt sets the timestamp for resource's creation time.
+func (logRouter *LogRouterResource) GetCreatedAt() time.Time {
+	return time.Time{}
+}
+
+// Create creates the log router resource.
+func (logRouter *LogRouterResource) Create() error {
+	return errors.New("not implemented")
+}
+
+// Cleanup cleans up the log router resource.
+func (logRouter *LogRouterResource) Cleanup() error {
+	return errors.New("not implemented")
+}
+
+// StatusString returns the string of the log router resource status.
+func (logRouter *LogRouterResource) StatusString(status resourcestatus.ResourceStatus) string {
+	return "undefined"
+}
+
+// GetTerminalReason returns the terminal reason for the resource.
+func (logRouter *LogRouterResource) GetTerminalReason() string {
+	return "undefined"
+}
+
+// MarshalJSON marshals LogRouterResource object.
+func (logRouter *LogRouterResource) MarshalJSON() ([]byte, error) {
+	return nil, errors.New("not implemented")
+}
+
+// UnmarshalJSON unmarshals LogRouterResource object.
+func (logRouter *LogRouterResource) UnmarshalJSON(b []byte) error {
+	return errors.New("not implemented")
+}
+
+// Initialize fills in the resource fields.
+func (logRouter *LogRouterResource) Initialize(resourceFields *taskresource.ResourceFields,
+	taskKnownStatus status.TaskStatus,
+	taskDesiredStatus status.TaskStatus) {
+}

--- a/agent/taskresource/logrouter/logrouter_unix.go
+++ b/agent/taskresource/logrouter/logrouter_unix.go
@@ -1,0 +1,355 @@
+// +build linux
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package logrouter
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/cihub/seelog"
+	"github.com/pkg/errors"
+
+	"github.com/aws/amazon-ecs-agent/agent/api/task/status"
+	"github.com/aws/amazon-ecs-agent/agent/taskresource"
+	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
+	"github.com/aws/amazon-ecs-agent/agent/utils/ioutilwrapper"
+	"github.com/aws/amazon-ecs-agent/agent/utils/oswrapper"
+)
+
+const (
+	// ResourceName is the name of the log router resource.
+	ResourceName = "logrouter"
+	// tempFile is the name of the temp file generated during generating config file.
+	tempFile = "temp_config_file"
+	// configFilePerm is the permission for the log router config file.
+	configFilePerm = 0644
+)
+
+// LogRouterResource models fluentd/fluentbit log router related resources as a task resource.
+type LogRouterResource struct {
+	// Fields that are specific to log router resource.
+	cluster               string
+	taskARN               string
+	taskDefinition        string
+	ec2InstanceID         string
+	resourceDir           string
+	logRouterType         string
+	ecsMetadataEnabled    bool
+	containerToLogOptions map[string]map[string]string
+	os                    oswrapper.OS
+	ioutil                ioutilwrapper.IOUtil
+
+	// Fields for the common functionality of task resource.
+	createdAtUnsafe     time.Time
+	desiredStatusUnsafe resourcestatus.ResourceStatus
+	knownStatusUnsafe   resourcestatus.ResourceStatus
+	appliedStatusUnsafe resourcestatus.ResourceStatus
+	statusToTransitions map[resourcestatus.ResourceStatus]func() error
+	terminalReason      string
+	terminalReasonOnce  sync.Once
+	lock                sync.RWMutex
+}
+
+// NewLogRouterResource returns a new LogRouterResource.
+func NewLogRouterResource(cluster, taskARN, taskDefinition, ec2InstanceID, dataDir, logRouterType string,
+	ecsMetadataEnabled bool, containerToLogOptions map[string]map[string]string) *LogRouterResource {
+	logRouterResource := &LogRouterResource{
+		cluster:               cluster,
+		taskARN:               taskARN,
+		taskDefinition:        taskDefinition,
+		ec2InstanceID:         ec2InstanceID,
+		logRouterType:         logRouterType,
+		ecsMetadataEnabled:    ecsMetadataEnabled,
+		containerToLogOptions: containerToLogOptions,
+		os:                    oswrapper.NewOS(),
+		ioutil:                ioutilwrapper.NewIOUtil(),
+	}
+
+	fields := strings.Split(taskARN, "/")
+	taskID := fields[len(fields)-1]
+	logRouterResource.resourceDir = filepath.Join(filepath.Join(dataDir, "logrouter"), taskID)
+
+	logRouterResource.initStatusToTransition()
+	return logRouterResource
+}
+
+// Initialize initializes the resource.
+func (logRouter *LogRouterResource) Initialize(resourceFields *taskresource.ResourceFields,
+	taskKnownStatus status.TaskStatus, taskDesiredStatus status.TaskStatus) {
+	logRouter.lock.Lock()
+	defer logRouter.lock.Unlock()
+
+	logRouter.initStatusToTransition()
+}
+
+func (logRouter *LogRouterResource) initStatusToTransition() {
+	resourceStatusToTransitionFunction := map[resourcestatus.ResourceStatus]func() error{
+		resourcestatus.ResourceStatus(LogRouterCreated): logRouter.Create,
+	}
+	logRouter.statusToTransitions = resourceStatusToTransitionFunction
+}
+
+// GetName returns the name of the resource.
+func (logRouter *LogRouterResource) GetName() string {
+	return ResourceName
+}
+
+// DesiredTerminal returns true if the resource's desired status is REMOVED.
+func (logRouter *LogRouterResource) DesiredTerminal() bool {
+	logRouter.lock.RLock()
+	defer logRouter.lock.RUnlock()
+
+	return logRouter.desiredStatusUnsafe == resourcestatus.ResourceStatus(LogRouterRemoved)
+}
+
+func (logRouter *LogRouterResource) setTerminalReason(reason string) {
+	logRouter.terminalReasonOnce.Do(func() {
+		seelog.Infof("log router resource: setting terminal reason for task: [%s]", logRouter.taskARN)
+		logRouter.terminalReason = reason
+	})
+}
+
+// GetTerminalReason returns an error string to propagate up through to task
+// state change messages.
+func (logRouter *LogRouterResource) GetTerminalReason() string {
+	logRouter.lock.RLock()
+	defer logRouter.lock.RUnlock()
+
+	return logRouter.terminalReason
+}
+
+// SetDesiredStatus safely sets the desired status of the resource.
+func (logRouter *LogRouterResource) SetDesiredStatus(status resourcestatus.ResourceStatus) {
+	logRouter.lock.Lock()
+	defer logRouter.lock.Unlock()
+
+	logRouter.desiredStatusUnsafe = status
+}
+
+// GetDesiredStatus safely returns the desired status of the task.
+func (logRouter *LogRouterResource) GetDesiredStatus() resourcestatus.ResourceStatus {
+	logRouter.lock.RLock()
+	defer logRouter.lock.RUnlock()
+
+	return logRouter.desiredStatusUnsafe
+}
+
+// SetKnownStatus safely sets the currently known status of the resource.
+func (logRouter *LogRouterResource) SetKnownStatus(status resourcestatus.ResourceStatus) {
+	logRouter.lock.Lock()
+	defer logRouter.lock.Unlock()
+
+	logRouter.knownStatusUnsafe = status
+}
+
+// GetKnownStatus safely returns the currently known status of the task.
+func (logRouter *LogRouterResource) GetKnownStatus() resourcestatus.ResourceStatus {
+	logRouter.lock.RLock()
+	defer logRouter.lock.RUnlock()
+
+	return logRouter.knownStatusUnsafe
+}
+
+// KnownCreated returns true if the resource's known status is CREATED.
+func (logRouter *LogRouterResource) KnownCreated() bool {
+	logRouter.lock.RLock()
+	defer logRouter.lock.RUnlock()
+
+	return logRouter.knownStatusUnsafe == resourcestatus.ResourceStatus(LogRouterCreated)
+}
+
+// TerminalStatus returns the last transition state of resource.
+func (logRouter *LogRouterResource) TerminalStatus() resourcestatus.ResourceStatus {
+	return resourcestatus.ResourceStatus(LogRouterRemoved)
+}
+
+// NextKnownState returns the state that the resource should
+// progress to based on its `KnownState`.
+func (logRouter *LogRouterResource) NextKnownState() resourcestatus.ResourceStatus {
+	return logRouter.GetKnownStatus() + 1
+}
+
+// SteadyState returns the transition state of the resource defined as "ready".
+func (logRouter *LogRouterResource) SteadyState() resourcestatus.ResourceStatus {
+	return resourcestatus.ResourceStatus(LogRouterCreated)
+}
+
+// ApplyTransition calls the function required to move to the specified status.
+func (logRouter *LogRouterResource) ApplyTransition(nextState resourcestatus.ResourceStatus) error {
+	logRouter.lock.Lock()
+	defer logRouter.lock.Unlock()
+
+	transitionFunc, ok := logRouter.statusToTransitions[nextState]
+	if !ok {
+		err := errors.Errorf("resource [%s]: impossible to transition to %s", ResourceName,
+			logRouter.StatusString(nextState))
+		logRouter.setTerminalReason(err.Error())
+		return err
+	}
+	return transitionFunc()
+}
+
+// SetAppliedStatus sets the applied status of resource and returns whether
+// the resource is already in a transition.
+func (logRouter *LogRouterResource) SetAppliedStatus(status resourcestatus.ResourceStatus) bool {
+	logRouter.lock.Lock()
+	defer logRouter.lock.Unlock()
+
+	if logRouter.appliedStatusUnsafe != resourcestatus.ResourceStatus(LogRouterStatusNone) {
+		// Return false to indicate the set operation failed.
+		return false
+	}
+
+	logRouter.appliedStatusUnsafe = status
+	return true
+}
+
+// GetAppliedStatus returns the applied status.
+func (logRouter *LogRouterResource) GetAppliedStatus() resourcestatus.ResourceStatus {
+	logRouter.lock.RLock()
+	defer logRouter.lock.RUnlock()
+
+	return logRouter.appliedStatusUnsafe
+}
+
+// StatusString returns the string representation of the resource status.
+func (logRouter *LogRouterResource) StatusString(status resourcestatus.ResourceStatus) string {
+	return LogRouterStatus(status).String()
+}
+
+// SetCreatedAt sets the timestamp for resource's creation time.
+func (logRouter *LogRouterResource) SetCreatedAt(createdAt time.Time) {
+	if createdAt.IsZero() {
+		return
+	}
+	logRouter.lock.Lock()
+	defer logRouter.lock.Unlock()
+
+	logRouter.createdAtUnsafe = createdAt
+}
+
+// GetCreatedAt returns the timestamp for resource's creation time.
+func (logRouter *LogRouterResource) GetCreatedAt() time.Time {
+	logRouter.lock.RLock()
+	defer logRouter.lock.RUnlock()
+
+	return logRouter.createdAtUnsafe
+}
+
+// Create performs resource creation. This includes creating a config directory, a socket directory, and generating
+// a config file under the config directory.
+func (logRouter *LogRouterResource) Create() error {
+	// Fail fast if log router type is invalid.
+	if logRouter.logRouterType != LogRouterTypeFluentd && logRouter.logRouterType != LogRouterTypeFluentbit {
+		err := errors.New(fmt.Sprintf("invalid log router type: %s", logRouter.logRouterType))
+		logRouter.setTerminalReason(err.Error())
+		return err
+	}
+
+	err := logRouter.createDirectories()
+	if err != nil {
+		err = errors.Wrapf(err, "unable to initialize resource directory %s", logRouter.resourceDir)
+		logRouter.setTerminalReason(err.Error())
+		return err
+	}
+
+	err = logRouter.generateConfigFile()
+	if err != nil {
+		err = errors.Wrap(err, "unable to generate log router config file")
+		logRouter.setTerminalReason(err.Error())
+		return err
+	}
+
+	return nil
+}
+
+// createDirectories creates two directories:
+//  - $(DATA_DIR)/logrouter/$(TASK_ID)/config: used to store log router config file. The config file under this directory
+//    will be mounted to the log router container at an expected path.
+//  - $(DATA_DIR)/logrouter/$(TASK_ID)/socket: used to store the unix socket. This directory will be mounted to
+//    the log router container and it will generate a socket file under this directory. Containers that use log router
+//    will then use this socket to send logs to log router.
+func (logRouter *LogRouterResource) createDirectories() error {
+	configDir := filepath.Join(logRouter.resourceDir, "config")
+	err := logRouter.os.MkdirAll(configDir, os.ModePerm)
+	if err != nil {
+		return errors.Wrap(err, "unable to create config directory")
+	}
+
+	socketDir := filepath.Join(logRouter.resourceDir, "socket")
+	err = logRouter.os.MkdirAll(socketDir, os.ModePerm)
+	if err != nil {
+		return errors.Wrap(err, "unable to create socket directory")
+	}
+	return nil
+}
+
+// generateConfigFile generates a log router config file at $(RESOURCE_DIR)/config/fluent.conf.
+// This contains configs needed by the router container to properly route logs.
+func (logRouter *LogRouterResource) generateConfigFile() error {
+	config, err := logRouter.generateConfig()
+	if err != nil {
+		return errors.Wrap(err, "unable to generate log router config")
+	}
+
+	temp, err := logRouter.ioutil.TempFile(logRouter.resourceDir, tempFile)
+	if err != nil {
+		return err
+	}
+	defer temp.Close()
+	if logRouter.logRouterType == LogRouterTypeFluentd {
+		err = config.WriteFluentdConfig(temp)
+	} else {
+		err = config.WriteFluentBitConfig(temp)
+	}
+	if err != nil {
+		return err
+	}
+
+	err = temp.Chmod(os.FileMode(configFilePerm))
+	if err != nil {
+		return err
+	}
+
+	// Persist the config file to disk.
+	err = temp.Sync()
+	if err != nil {
+		return err
+	}
+
+	confFilePath := filepath.Join(logRouter.resourceDir, "config", "fluent.conf")
+	err = logRouter.os.Rename(temp.Name(), confFilePath)
+	if err != nil {
+		return err
+	}
+
+	seelog.Infof("Generated log router config file at: %s", confFilePath)
+	return nil
+}
+
+// Cleanup performs resource cleanup.
+func (logRouter *LogRouterResource) Cleanup() error {
+	err := logRouter.os.RemoveAll(logRouter.resourceDir)
+	if err != nil {
+		return fmt.Errorf("unable to remove log router resource directory %s: %v", logRouter.resourceDir, err)
+	}
+
+	seelog.Infof("Removed log router resource directory at %s", logRouter.resourceDir)
+	return nil
+}

--- a/agent/taskresource/logrouter/logrouter_unix_test.go
+++ b/agent/taskresource/logrouter/logrouter_unix_test.go
@@ -1,0 +1,262 @@
+// +build linux,unit
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package logrouter
+
+import (
+	"os"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+
+	mock_ioutilwrapper "github.com/aws/amazon-ecs-agent/agent/utils/ioutilwrapper/mocks"
+	mock_oswrapper "github.com/aws/amazon-ecs-agent/agent/utils/oswrapper/mocks"
+)
+
+const (
+	testCluster         = "mycluster"
+	testTaskARN         = "arn:aws:ecs:us-east-2:01234567891011:task/mycluster/3de392df-6bfa-470b-97ed-aa6f482cd7a"
+	testTaskDefinition  = "taskdefinition:1"
+	testEC2InstanceID   = "i-123456789a"
+	testDataDir         = "testdatadir"
+	testResourceDir     = "testresourcedir"
+	testTerminalResason = "testterminalreason"
+	testTempFile        = "testtempfile"
+)
+
+func setup(t *testing.T) (*mock_oswrapper.MockOS, *mock_oswrapper.MockFile, *mock_ioutilwrapper.MockIOUtil, func()) {
+	ctrl := gomock.NewController(t)
+
+	mockOS := mock_oswrapper.NewMockOS(ctrl)
+	mockFile := mock_oswrapper.NewMockFile(ctrl)
+	mockIOUtil := mock_ioutilwrapper.NewMockIOUtil(ctrl)
+
+	return mockOS, mockFile, mockIOUtil, ctrl.Finish
+}
+
+func newMockLogRouterResource(logRouterType string, logRouterOptions map[string]string, mockOS *mock_oswrapper.MockOS,
+	mockIOUtil *mock_ioutilwrapper.MockIOUtil) *LogRouterResource {
+	return &LogRouterResource{
+		cluster:        testCluster,
+		taskARN:        testTaskARN,
+		taskDefinition: testTaskDefinition,
+		ec2InstanceID:  testEC2InstanceID,
+		resourceDir:    testResourceDir,
+		logRouterType:  logRouterType,
+		containerToLogOptions: map[string]map[string]string{
+			"container": logRouterOptions,
+		},
+		os:     mockOS,
+		ioutil: mockIOUtil,
+	}
+}
+
+func TestCreateLogRouterResourceFluentd(t *testing.T) {
+	mockOS, mockFile, mockIOUtil, done := setup(t)
+	defer done()
+
+	logRouterResource := newMockLogRouterResource(LogRouterTypeFluentd, testFluentdOptions, mockOS, mockIOUtil)
+
+	gomock.InOrder(
+		mockOS.EXPECT().MkdirAll(testResourceDir+"/config", os.ModePerm),
+		mockOS.EXPECT().MkdirAll(testResourceDir+"/socket", os.ModePerm),
+		mockIOUtil.EXPECT().TempFile(testResourceDir, tempFile).Return(mockFile, nil),
+		mockFile.EXPECT().Write(gomock.Any()).AnyTimes(),
+		mockFile.EXPECT().Chmod(os.FileMode(configFilePerm)),
+		mockFile.EXPECT().Sync(),
+		mockFile.EXPECT().Name().Return(testTempFile),
+		mockOS.EXPECT().Rename(testTempFile, testResourceDir+"/config/fluent.conf"),
+		mockFile.EXPECT().Close(),
+	)
+
+	assert.NoError(t, logRouterResource.Create())
+}
+
+func TestCreateLogRouterResourceFluentbit(t *testing.T) {
+	mockOS, mockFile, mockIOUtil, done := setup(t)
+	defer done()
+
+	logRouterResource := newMockLogRouterResource(LogRouterTypeFluentbit, testFluentbitOptions, mockOS, mockIOUtil)
+
+	gomock.InOrder(
+		mockOS.EXPECT().MkdirAll(testResourceDir+"/config", os.ModePerm),
+		mockOS.EXPECT().MkdirAll(testResourceDir+"/socket", os.ModePerm),
+		mockIOUtil.EXPECT().TempFile(testResourceDir, tempFile).Return(mockFile, nil),
+		mockFile.EXPECT().Write(gomock.Any()).AnyTimes(),
+		mockFile.EXPECT().Chmod(os.FileMode(configFilePerm)),
+		mockFile.EXPECT().Sync(),
+		mockFile.EXPECT().Name().Return(testTempFile),
+		mockOS.EXPECT().Rename(testTempFile, testResourceDir+"/config/fluent.conf"),
+		mockFile.EXPECT().Close(),
+	)
+
+	assert.NoError(t, logRouterResource.Create())
+}
+
+func TestCreateLogRouterResourceInvalidType(t *testing.T) {
+	mockOS, _, mockIOUtil, done := setup(t)
+	defer done()
+
+	logRouterResource := newMockLogRouterResource(LogRouterTypeFluentd, testFluentdOptions, mockOS, mockIOUtil)
+	logRouterResource.logRouterType = "invalid"
+
+	assert.Error(t, logRouterResource.Create())
+	assert.NotEmpty(t, logRouterResource.terminalReason)
+}
+
+func TestCreateLogRouterResourceCreateConfigDirError(t *testing.T) {
+	mockOS, _, mockIOUtil, done := setup(t)
+	defer done()
+
+	logRouterResource := newMockLogRouterResource(LogRouterTypeFluentd, testFluentdOptions, mockOS, mockIOUtil)
+
+	gomock.InOrder(
+		mockOS.EXPECT().MkdirAll(testResourceDir+"/config", os.ModePerm).Return(errors.New("test error")),
+	)
+
+	assert.Error(t, logRouterResource.Create())
+	assert.NotEmpty(t, logRouterResource.terminalReason)
+}
+
+func TestCreateLogRouterResourceCreateSocketDirError(t *testing.T) {
+	mockOS, _, mockIOUtil, done := setup(t)
+	defer done()
+
+	logRouterResource := newMockLogRouterResource(LogRouterTypeFluentd, testFluentdOptions, mockOS, mockIOUtil)
+
+	gomock.InOrder(
+		mockOS.EXPECT().MkdirAll(testResourceDir+"/config", os.ModePerm),
+		mockOS.EXPECT().MkdirAll(testResourceDir+"/socket", os.ModePerm).Return(errors.New("test error")),
+	)
+
+	assert.Error(t, logRouterResource.Create())
+	assert.NotEmpty(t, logRouterResource.terminalReason)
+}
+
+func TestCreateLogRouterResourceGenerateConfigError(t *testing.T) {
+	mockOS, _, mockIOUtil, done := setup(t)
+	defer done()
+
+	logRouterResource := newMockLogRouterResource(LogRouterTypeFluentd, testFluentdOptions, mockOS, mockIOUtil)
+	logRouterResource.containerToLogOptions = map[string]map[string]string{
+		"container": {},
+	}
+
+	gomock.InOrder(
+		mockOS.EXPECT().MkdirAll(testResourceDir+"/config", os.ModePerm),
+		mockOS.EXPECT().MkdirAll(testResourceDir+"/socket", os.ModePerm),
+	)
+
+	assert.Error(t, logRouterResource.Create())
+	assert.NotEmpty(t, logRouterResource.terminalReason)
+}
+
+func TestCreateLogRouterResourceCreateTempFileError(t *testing.T) {
+	mockOS, _, mockIOUtil, done := setup(t)
+	defer done()
+
+	logRouterResource := newMockLogRouterResource(LogRouterTypeFluentd, testFluentdOptions, mockOS, mockIOUtil)
+
+	gomock.InOrder(
+		mockOS.EXPECT().MkdirAll(testResourceDir+"/config", os.ModePerm),
+		mockOS.EXPECT().MkdirAll(testResourceDir+"/socket", os.ModePerm),
+		mockIOUtil.EXPECT().TempFile(testResourceDir, tempFile).Return(nil, errors.New("test error")),
+	)
+
+	assert.Error(t, logRouterResource.Create())
+	assert.NotEmpty(t, logRouterResource.terminalReason)
+}
+
+func TestCreateLogRouterResourceWriteConfigFileError(t *testing.T) {
+	mockOS, mockFile, mockIOUtil, done := setup(t)
+	defer done()
+
+	logRouterResource := newMockLogRouterResource(LogRouterTypeFluentd, testFluentdOptions, mockOS, mockIOUtil)
+
+	gomock.InOrder(
+		mockOS.EXPECT().MkdirAll(testResourceDir+"/config", os.ModePerm),
+		mockOS.EXPECT().MkdirAll(testResourceDir+"/socket", os.ModePerm),
+		mockIOUtil.EXPECT().TempFile(testResourceDir, tempFile).Return(mockFile, nil),
+		mockFile.EXPECT().Write(gomock.Any()).AnyTimes().Return(0, errors.New("test error")),
+		mockFile.EXPECT().Close(),
+	)
+
+	assert.Error(t, logRouterResource.Create())
+	assert.NotEmpty(t, logRouterResource.terminalReason)
+}
+
+func TestCreateLogRouterResourceChmodError(t *testing.T) {
+	mockOS, mockFile, mockIOUtil, done := setup(t)
+	defer done()
+
+	logRouterResource := newMockLogRouterResource(LogRouterTypeFluentd, testFluentdOptions, mockOS, mockIOUtil)
+
+	gomock.InOrder(
+		mockOS.EXPECT().MkdirAll(testResourceDir+"/config", os.ModePerm),
+		mockOS.EXPECT().MkdirAll(testResourceDir+"/socket", os.ModePerm),
+		mockIOUtil.EXPECT().TempFile(testResourceDir, tempFile).Return(mockFile, nil),
+		mockFile.EXPECT().Write(gomock.Any()).AnyTimes(),
+		mockFile.EXPECT().Chmod(os.FileMode(configFilePerm)).Return(errors.New("test error")),
+		mockFile.EXPECT().Close(),
+	)
+
+	assert.Error(t, logRouterResource.Create())
+	assert.NotEmpty(t, logRouterResource.terminalReason)
+}
+
+func TestCreateLogRouterResourceRenameError(t *testing.T) {
+	mockOS, mockFile, mockIOUtil, done := setup(t)
+	defer done()
+
+	logRouterResource := newMockLogRouterResource(LogRouterTypeFluentd, testFluentdOptions, mockOS, mockIOUtil)
+
+	gomock.InOrder(
+		mockOS.EXPECT().MkdirAll(testResourceDir+"/config", os.ModePerm),
+		mockOS.EXPECT().MkdirAll(testResourceDir+"/socket", os.ModePerm),
+		mockIOUtil.EXPECT().TempFile(testResourceDir, tempFile).Return(mockFile, nil),
+		mockFile.EXPECT().Write(gomock.Any()).AnyTimes(),
+		mockFile.EXPECT().Chmod(os.FileMode(configFilePerm)),
+		mockFile.EXPECT().Sync(),
+		mockFile.EXPECT().Name().Return(testTempFile),
+		mockOS.EXPECT().Rename(testTempFile, testResourceDir+"/config/fluent.conf").Return(errors.New("test error")),
+		mockFile.EXPECT().Close(),
+	)
+
+	assert.Error(t, logRouterResource.Create())
+	assert.NotEmpty(t, logRouterResource.terminalReason)
+}
+
+func TestCleanupLogRouterResource(t *testing.T) {
+	mockOS, _, mockIOUtil, done := setup(t)
+	defer done()
+
+	logRouterResource := newMockLogRouterResource(LogRouterTypeFluentd, testFluentdOptions, mockOS, mockIOUtil)
+
+	mockOS.EXPECT().RemoveAll(testResourceDir)
+
+	assert.NoError(t, logRouterResource.Cleanup())
+}
+
+func TestCleanupLogRouterResourceError(t *testing.T) {
+	mockOS, _, mockIOUtil, done := setup(t)
+	defer done()
+
+	logRouterResource := newMockLogRouterResource(LogRouterTypeFluentd, testFluentdOptions, mockOS, mockIOUtil)
+
+	mockOS.EXPECT().RemoveAll(testResourceDir).Return(errors.New("test error"))
+
+	assert.Error(t, logRouterResource.Cleanup())
+}

--- a/agent/taskresource/logrouter/logrouterstatus.go
+++ b/agent/taskresource/logrouter/logrouterstatus.go
@@ -1,0 +1,78 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package logrouter
+
+import (
+	"errors"
+	"strings"
+
+	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
+)
+
+type LogRouterStatus resourcestatus.ResourceStatus
+
+const (
+	// LogRouterStatusNone is the zero state of a logrouter task resource.
+	LogRouterStatusNone LogRouterStatus = iota
+	// LogRouterCreated represents the status of a logrouter task resource which has been created.
+	LogRouterCreated
+	// LogRouterRemoved represents the status of a logrouter task resource which has been cleaned up.
+	LogRouterRemoved
+)
+
+var logRouterStatusMap = map[string]LogRouterStatus{
+	"NONE":    LogRouterStatusNone,
+	"CREATED": LogRouterCreated,
+	"REMOVED": LogRouterRemoved,
+}
+
+// String returns a human readable string representation of this object.
+func (as LogRouterStatus) String() string {
+	for k, v := range logRouterStatusMap {
+		if v == as {
+			return k
+		}
+	}
+	return "NONE"
+}
+
+// MarshalJSON overrides the logic for JSON-encoding the ResourceStatus type.
+func (as *LogRouterStatus) MarshalJSON() ([]byte, error) {
+	if as == nil {
+		return nil, errors.New("logrouter resource status is nil")
+	}
+	return []byte(`"` + as.String() + `"`), nil
+}
+
+// UnmarshalJSON overrides the logic for parsing the JSON-encoded ResourceStatus data.
+func (as *LogRouterStatus) UnmarshalJSON(b []byte) error {
+	if strings.ToLower(string(b)) == "null" {
+		*as = LogRouterStatusNone
+		return nil
+	}
+
+	if b[0] != '"' || b[len(b)-1] != '"' {
+		*as = LogRouterStatusNone
+		return errors.New("resource status unmarshal: status must be a string or null; Got " + string(b))
+	}
+
+	strStatus := string(b[1 : len(b)-1])
+	stat, ok := logRouterStatusMap[strStatus]
+	if !ok {
+		*as = LogRouterStatusNone
+		return errors.New("resource status unmarshal: unrecognized status")
+	}
+	*as = stat
+	return nil
+}

--- a/agent/taskresource/logrouter/logrouterstatus_test.go
+++ b/agent/taskresource/logrouter/logrouterstatus_test.go
@@ -1,0 +1,149 @@
+// +build unit
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package logrouter
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStatusString(t *testing.T) {
+	cases := []struct {
+		Name               string
+		InLogRouterStatus  LogRouterStatus
+		OutLogRouterStatus string
+	}{
+		{
+			Name:               "ToStringLogRouterStatusNone",
+			InLogRouterStatus:  LogRouterStatusNone,
+			OutLogRouterStatus: "NONE",
+		},
+		{
+			Name:               "ToStringLogRouterStatusCreated",
+			InLogRouterStatus:  LogRouterCreated,
+			OutLogRouterStatus: "CREATED",
+		},
+		{
+			Name:               "ToStringLogRouterStatusRemoved",
+			InLogRouterStatus:  LogRouterRemoved,
+			OutLogRouterStatus: "REMOVED",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			assert.Equal(t, c.OutLogRouterStatus, c.InLogRouterStatus.String())
+		})
+	}
+}
+
+func TestMarshalNilLogRouterStatus(t *testing.T) {
+	var status *LogRouterStatus
+	bytes, err := status.MarshalJSON()
+
+	assert.Nil(t, bytes)
+	assert.Error(t, err)
+}
+
+func TestMarshalLogRouterStatus(t *testing.T) {
+	cases := []struct {
+		Name               string
+		InLogRouterStatus  LogRouterStatus
+		OutLogRouterStatus string
+	}{
+		{
+			Name:               "MarshallLogRouterStatusNone",
+			InLogRouterStatus:  LogRouterStatusNone,
+			OutLogRouterStatus: "\"NONE\"",
+		},
+		{
+			Name:               "MarshallLogRouterCreated",
+			InLogRouterStatus:  LogRouterCreated,
+			OutLogRouterStatus: "\"CREATED\"",
+		},
+		{
+			Name:               "MarshallLogRouterRemoved",
+			InLogRouterStatus:  LogRouterRemoved,
+			OutLogRouterStatus: "\"REMOVED\"",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			bytes, err := c.InLogRouterStatus.MarshalJSON()
+			assert.NoError(t, err)
+			assert.Equal(t, c.OutLogRouterStatus, string(bytes[:]))
+		})
+	}
+}
+
+func TestUnmarshalLogRouterStatus(t *testing.T) {
+	cases := []struct {
+		Name               string
+		InLogRouterStatus  string
+		OutLogRouterStatus LogRouterStatus
+		ShouldError        bool
+	}{
+		{
+			Name:               "UnmarshalLogRouterStatusNone",
+			InLogRouterStatus:  "\"NONE\"",
+			OutLogRouterStatus: LogRouterStatusNone,
+			ShouldError:        false,
+		},
+		{
+			Name:               "UnmarshalLogRouterCreated",
+			InLogRouterStatus:  "\"CREATED\"",
+			OutLogRouterStatus: LogRouterCreated,
+			ShouldError:        false,
+		},
+		{
+			Name:               "UnmarshalLogRouterRemoved",
+			InLogRouterStatus:  "\"REMOVED\"",
+			OutLogRouterStatus: LogRouterRemoved,
+			ShouldError:        false,
+		},
+		{
+			Name:               "UnmarshalLogRouterStatusNull",
+			InLogRouterStatus:  "null",
+			OutLogRouterStatus: LogRouterStatusNone,
+			ShouldError:        false,
+		},
+		{
+			Name:              "UnmarshalLogRouterStatusNonString",
+			InLogRouterStatus: "1",
+			ShouldError:       true,
+		},
+		{
+			Name:              "UnmarshalLogRouterStatusUnmappedStatus",
+			InLogRouterStatus: "\"INVALID\"",
+			ShouldError:       true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			var status LogRouterStatus
+			err := json.Unmarshal([]byte(c.InLogRouterStatus), &status)
+			if c.ShouldError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, c.OutLogRouterStatus, status)
+			}
+		})
+	}
+}

--- a/agent/taskresource/types/types.go
+++ b/agent/taskresource/types/types.go
@@ -21,6 +21,7 @@ import (
 	asmauthres "github.com/aws/amazon-ecs-agent/agent/taskresource/asmauth"
 	asmsecretres "github.com/aws/amazon-ecs-agent/agent/taskresource/asmsecret"
 	cgroupres "github.com/aws/amazon-ecs-agent/agent/taskresource/cgroup"
+	"github.com/aws/amazon-ecs-agent/agent/taskresource/logrouter"
 	ssmsecretres "github.com/aws/amazon-ecs-agent/agent/taskresource/ssmsecret"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/volume"
 )
@@ -36,6 +37,8 @@ const (
 	SSMSecretKey = ssmsecretres.ResourceName
 	// ASMSecretKey is the string used in resources map to represent asm secret
 	ASMSecretKey = asmsecretres.ResourceName
+	// LogRouterKey is the string used in resources map to represent log router resource
+	LogRouterKey = logrouter.ResourceName
 )
 
 // ResourcesMap represents the map of resource type to the corresponding resource
@@ -71,6 +74,8 @@ func unmarshalResource(key string, value json.RawMessage, result map[string][]ta
 		return unmarshalSSMSecretKey(key, value, result)
 	case ASMSecretKey:
 		return unmarshalASMSecretKey(key, value, result)
+	case LogRouterKey:
+		return unmarshalLogRouterKey(key, value, result)
 	default:
 		return errors.New("Unsupported resource type")
 	}
@@ -159,6 +164,25 @@ func unmarshalASMSecretKey(key string, value json.RawMessage, result map[string]
 		if err != nil {
 			return err
 		}
+		result[key] = append(result[key], res)
+	}
+	return nil
+}
+
+func unmarshalLogRouterKey(key string, value json.RawMessage, result map[string][]taskresource.TaskResource) error {
+	var logRouters []json.RawMessage
+	err := json.Unmarshal(value, &logRouters)
+	if err != nil {
+		return err
+	}
+
+	for _, logRouter := range logRouters {
+		res := &logrouter.LogRouterResource{}
+		err := res.UnmarshalJSON(logRouter)
+		if err != nil {
+			return err
+		}
+
 		result[key] = append(result[key], res)
 	}
 	return nil

--- a/agent/vendor/github.com/awslabs/go-config-generator-for-fluentd-and-fluentbit/CODE_OF_CONDUCT.md
+++ b/agent/vendor/github.com/awslabs/go-config-generator-for-fluentd-and-fluentbit/CODE_OF_CONDUCT.md
@@ -1,0 +1,4 @@
+## Code of Conduct
+This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct).
+For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact
+opensource-codeofconduct@amazon.com with any additional questions or comments.

--- a/agent/vendor/github.com/awslabs/go-config-generator-for-fluentd-and-fluentbit/CONTRIBUTING.md
+++ b/agent/vendor/github.com/awslabs/go-config-generator-for-fluentd-and-fluentbit/CONTRIBUTING.md
@@ -1,0 +1,61 @@
+# Contributing Guidelines
+
+Thank you for your interest in contributing to our project. Whether it's a bug report, new feature, correction, or additional
+documentation, we greatly value feedback and contributions from our community.
+
+Please read through this document before submitting any issues or pull requests to ensure we have all the necessary
+information to effectively respond to your bug report or contribution.
+
+
+## Reporting Bugs/Feature Requests
+
+We welcome you to use the GitHub issue tracker to report bugs or suggest features.
+
+When filing an issue, please check [existing open](https://github.com/awslabs/go-config-generator-for-fluentd-and-fluentbit/issues), or [recently closed](https://github.com/awslabs/go-config-generator-for-fluentd-and-fluentbit/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aclosed%20), issues to make sure somebody else hasn't already
+reported the issue. Please try to include as much information as you can. Details like these are incredibly useful:
+
+* A reproducible test case or series of steps
+* The version of our code being used
+* Any modifications you've made relevant to the bug
+* Anything unusual about your environment or deployment
+
+
+## Contributing via Pull Requests
+Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:
+
+1. You are working against the latest source on the *master* branch.
+2. You check existing open, and recently merged, pull requests to make sure someone else hasn't addressed the problem already.
+3. You open an issue to discuss any significant work - we would hate for your time to be wasted.
+
+To send us a pull request, please:
+
+1. Fork the repository.
+2. Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
+3. Ensure local tests pass.
+4. Commit to your fork using clear commit messages.
+5. Send us a pull request, answering any default questions in the pull request interface.
+6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
+
+GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
+[creating a pull request](https://help.github.com/articles/creating-a-pull-request/).
+
+
+## Finding contributions to work on
+Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any ['help wanted'](https://github.com/awslabs/go-config-generator-for-fluentd-and-fluentbit/labels/help%20wanted) issues is a great place to start.
+
+
+## Code of Conduct
+This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct).
+For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact
+opensource-codeofconduct@amazon.com with any additional questions or comments.
+
+
+## Security issue notifications
+If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public github issue.
+
+
+## Licensing
+
+See the [LICENSE](https://github.com/awslabs/go-config-generator-for-fluentd-and-fluentbit/blob/master/LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
+
+We may ask you to sign a [Contributor License Agreement (CLA)](http://en.wikipedia.org/wiki/Contributor_License_Agreement) for larger changes.

--- a/agent/vendor/github.com/awslabs/go-config-generator-for-fluentd-and-fluentbit/LICENSE
+++ b/agent/vendor/github.com/awslabs/go-config-generator-for-fluentd-and-fluentbit/LICENSE
@@ -1,0 +1,14 @@
+Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/agent/vendor/github.com/awslabs/go-config-generator-for-fluentd-and-fluentbit/Makefile
+++ b/agent/vendor/github.com/awslabs/go-config-generator-for-fluentd-and-fluentbit/Makefile
@@ -1,0 +1,16 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# 	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+.PHONY: test
+test:
+	go test -timeout=120s -v -cover ./...

--- a/agent/vendor/github.com/awslabs/go-config-generator-for-fluentd-and-fluentbit/README.md
+++ b/agent/vendor/github.com/awslabs/go-config-generator-for-fluentd-and-fluentbit/README.md
@@ -1,0 +1,45 @@
+## Go Config Generator For Fluentd And Fluentbit
+
+A Go Library for programmatically generating Fluentd and Fluent Bit Configuration.
+
+For example usage, see the [unit test file](generator_test.go).
+
+The library exports the following interface:
+
+```
+type FluentConfig interface {
+	// AddInput adds an input/source directive
+	AddInput(name string, tag string, options map[string]string) FluentConfig
+
+	// AddIncludeFilter adds a regex filter that only allows logs which match the regex
+	AddIncludeFilter(regex string, key string, tag string) FluentConfig
+
+	// AddExcludeFilter adds a regex filter that only allows logs which do not match the regex
+	AddExcludeFilter(regex string, key string, tag string) FluentConfig
+
+	// AddFieldToRecord adds a key value pair to log records
+	AddFieldToRecord(key string, value string, tag string) FluentConfig
+
+	// AddExternalConfig adds an @INCLUDE directive to reference an external config file
+	AddExternalConfig(filePath string, position IncludePosition) FluentConfig
+
+	// AddOutput adds an output/log destination
+	AddOutput(name string, tag string, options map[string]string) FluentConfig
+
+	// WriteFluentdConfig outputs the config in Fluentd syntax
+	WriteFluentdConfig(wr io.Writer) error
+
+	// WriteFluentBitConfig outputs the config in Fluent Bit syntax
+	WriteFluentBitConfig(wr io.Writer) error
+}
+```
+
+The library uses Fluent Bit terminology in the interface; `AddInput` adds a 'source' in Fluentd syntax, and the `name` argument is used as the plugin `@type`.
+
+## License Summary
+
+This sample code is made available under the MIT-0 license. See the LICENSE file.
+
+#### Security disclosures
+
+If you think you’ve found a potential security issue, please do not post it in the Issues.  Instead, please follow the instructions [here](https://aws.amazon.com/security/vulnerability-reporting/) or email AWS security directly at [aws-security@amazon.com](mailto:aws-security@amazon.com).

--- a/agent/vendor/github.com/awslabs/go-config-generator-for-fluentd-and-fluentbit/fluent-bit-template.go
+++ b/agent/vendor/github.com/awslabs/go-config-generator-for-fluentd-and-fluentbit/fluent-bit-template.go
@@ -1,0 +1,63 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package generator
+
+var fluentBitConfigTemplate = `{{- range .IncludeConfigHeadOfFile -}}
+@INCLUDE {{ . }}
+{{ end -}}
+{{- range .Inputs }}
+[INPUT]
+    Name {{ .Name }}
+    {{- if .Tag }}Tag {{ .Tag }}{{- end }}
+    {{- range $key, $value := .Options }}
+    {{ $key }} {{ $value }}
+    {{- end }}
+{{ end -}}
+{{- range .IncludeConfigAfterInputs }}
+@INCLUDE {{ . }}
+{{ end -}}
+{{- range .IncludeFilters }}
+[FILTER]
+    Name   grep
+    Match {{ .Tag }}
+    Regex  {{ .Key }} {{ .Regex }}
+{{ end -}}
+{{- range .ExcludeFilters }}
+[FILTER]
+    Name   grep
+    Match {{ .Tag }}
+    Exclude {{ .Key }} {{ .Regex }}
+{{ end -}}
+{{- range $tag, $modifier := .ModifyRecords }}
+[FILTER]
+    Name record_modifier
+    Match {{ $tag }}
+    {{- range $key, $value := $modifier.NewFields }}
+    Record {{ $key }} {{ $value }}
+    {{- end }}
+{{ end -}}
+{{- range .IncludeConfigAfterFilters }}
+@INCLUDE {{ . }}
+{{ end -}}
+{{- range .Outputs }}
+[OUTPUT]
+    Name {{ .Name }}
+    Match {{ .Tag }}
+    {{- range $key, $value := .Options }}
+    {{ $key }} {{ $value }}
+    {{- end }}
+{{ end -}}
+{{- range .IncludeConfigEndOfFile }}
+@INCLUDE {{ . }}
+{{ end -}}`

--- a/agent/vendor/github.com/awslabs/go-config-generator-for-fluentd-and-fluentbit/fluentd-template.go
+++ b/agent/vendor/github.com/awslabs/go-config-generator-for-fluentd-and-fluentbit/fluentd-template.go
@@ -1,0 +1,72 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package generator
+
+var fluentDConfigTemplate = `{{- range .IncludeConfigHeadOfFile -}}
+@include {{ . }}
+{{ end -}}
+{{- range .Inputs }}
+<source>
+    @type {{ .Name }}
+    {{- if .Tag }}tag {{ .Tag }}{{- end }}
+    {{- range $key, $value := .Options }}
+    {{ $key }} {{ $value }}
+    {{- end }}
+</source>
+{{ end -}}
+{{- range .IncludeConfigAfterInputs }}
+@include {{ . }}
+{{ end -}}
+{{- range .IncludeFilters }}
+<filter {{ .Tag }}>
+    @type  grep
+    <regexp>
+        key {{ .Key }}
+        pattern {{ .Regex }}
+    </regexp>
+</filter>
+{{ end -}}
+{{- range .ExcludeFilters }}
+<filter {{ .Tag }}>
+    @type  grep
+    <exclude>
+        key {{ .Key }}
+        pattern {{ .Regex }}
+    </exclude>
+</filter>
+{{ end -}}
+{{- range $tag, $modifier := .ModifyRecords }}
+<filter {{ $tag }}>
+    @type record_transformer
+    <record>
+        {{- range $key, $value := $modifier.NewFields }}
+        {{ $key }} {{ $value }}
+        {{- end }}
+    </record>
+</filter>
+{{ end -}}
+{{- range .IncludeConfigAfterFilters }}
+@include {{ . }}
+{{ end -}}
+{{- range .Outputs }}
+<match {{ .Tag }}>
+    @type {{ .Name }}
+    {{- range $key, $value := .Options }}
+    {{ $key }} {{ $value }}
+    {{- end }}
+</match>
+{{ end -}}
+{{- range .IncludeConfigEndOfFile }}
+@include {{ . }}
+{{ end -}}`

--- a/agent/vendor/github.com/awslabs/go-config-generator-for-fluentd-and-fluentbit/generator.go
+++ b/agent/vendor/github.com/awslabs/go-config-generator-for-fluentd-and-fluentbit/generator.go
@@ -1,0 +1,178 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package generator
+
+import (
+	"io"
+	"text/template"
+)
+
+// IncludePosition is a type to represent the position of an @INCLUDE directive
+// to include external config
+type IncludePosition int
+
+// This library assumes that the config is structured as follows:
+// 1. Sources/inputs
+// 2. Filters
+// 3. Outputs
+const (
+	// HeadOfFile: The external config is included as the first directive in the config file
+	HeadOfFile IncludePosition = iota
+	// AfterInputs: The external config is included after the input/source directives
+	AfterInputs
+	// AfterFilters: The external config is included after the filter directives
+	AfterFilters
+	// EndOfFile: The external config is included at the end of the file
+	EndOfFile
+)
+
+// FluentConfig is the interface for generating fluentd and fluentbit config
+type FluentConfig interface {
+	AddInput(name string, tag string, options map[string]string) FluentConfig
+	AddIncludeFilter(regex string, key string, tag string) FluentConfig
+	AddExcludeFilter(regex string, key string, tag string) FluentConfig
+	AddFieldToRecord(key string, value string, tag string) FluentConfig
+	AddExternalConfig(filePath string, position IncludePosition) FluentConfig
+	AddOutput(name string, tag string, options map[string]string) FluentConfig
+	WriteFluentdConfig(wr io.Writer) error
+	WriteFluentBitConfig(wr io.Writer) error
+}
+
+// New Creates a new Fluent Config generater
+func New() FluentConfig {
+	return &FluentConfigGenerator{
+		ModifyRecords: make(map[string]RecordModifier),
+	}
+}
+
+// FluentConfigGenerator implements FluentConfig
+// It and all its fields must be public, so that the template library can
+// use them when
+type FluentConfigGenerator struct {
+	Inputs                    []LogPipe
+	ModifyRecords             map[string]RecordModifier
+	IncludeFilters            []RegexFilter
+	ExcludeFilters            []RegexFilter
+	IncludeConfigHeadOfFile   []string
+	IncludeConfigAfterInputs  []string
+	IncludeConfigAfterFilters []string
+	IncludeConfigEndOfFile    []string
+	Outputs                   []LogPipe
+}
+
+// LogPipe can represent an input or an output plugin
+type LogPipe struct {
+	Name    string
+	Tag     string
+	Options map[string]string
+}
+
+// RecordModifier tracks new fields added to log records
+type RecordModifier struct {
+	NewFields map[string]string
+}
+
+// RegexFilter represents a filter for logs
+type RegexFilter struct {
+	Regex string
+	Key   string
+	Tag   string
+}
+
+// AddInput add an input/source directive
+func (config *FluentConfigGenerator) AddInput(name string, tag string, options map[string]string) FluentConfig {
+	config.Inputs = append(config.Inputs, LogPipe{
+		Name:    name,
+		Tag:     tag,
+		Options: options,
+	})
+	return config
+}
+
+// AddIncludeFilter adds a regex filter that only allows logs which match the regex
+func (config *FluentConfigGenerator) AddIncludeFilter(regex string, key string, tag string) FluentConfig {
+	config.IncludeFilters = append(config.IncludeFilters, RegexFilter{
+		Regex: regex,
+		Key:   key,
+		Tag:   tag,
+	})
+	return config
+}
+
+// AddExcludeFilter adds a regex filter that only allows logs which do not match the regex
+func (config *FluentConfigGenerator) AddExcludeFilter(regex string, key string, tag string) FluentConfig {
+	config.ExcludeFilters = append(config.ExcludeFilters, RegexFilter{
+		Regex: regex,
+		Key:   key,
+		Tag:   tag,
+	})
+	return config
+}
+
+// AddFieldToRecord adds a key value pair to log records
+func (config *FluentConfigGenerator) AddFieldToRecord(key string, value string, tag string) FluentConfig {
+	_, ok := config.ModifyRecords[tag]
+	if !ok {
+		config.ModifyRecords[tag] = RecordModifier{
+			NewFields: make(map[string]string),
+		}
+	}
+	config.ModifyRecords[tag].NewFields[key] = value
+
+	return config
+}
+
+// AddExternalConfig adds an @INCLUDE directive to reference an external config file
+func (config *FluentConfigGenerator) AddExternalConfig(filePath string, position IncludePosition) FluentConfig {
+	switch position {
+	case HeadOfFile:
+		config.IncludeConfigHeadOfFile = append(config.IncludeConfigHeadOfFile, filePath)
+	case AfterInputs:
+		config.IncludeConfigAfterInputs = append(config.IncludeConfigAfterInputs, filePath)
+	case AfterFilters:
+		config.IncludeConfigAfterFilters = append(config.IncludeConfigAfterFilters, filePath)
+	case EndOfFile:
+		config.IncludeConfigEndOfFile = append(config.IncludeConfigEndOfFile, filePath)
+	}
+
+	return config
+}
+
+// AddOutput adds an output/log destination
+func (config *FluentConfigGenerator) AddOutput(name string, tag string, options map[string]string) FluentConfig {
+	config.Outputs = append(config.Outputs, LogPipe{
+		Name:    name,
+		Tag:     tag,
+		Options: options,
+	})
+	return config
+}
+
+// WriteFluentdConfig outputs the config in Fluentd syntax
+func (config *FluentConfigGenerator) WriteFluentdConfig(wr io.Writer) error {
+	tmpl, err := template.New("fluent.conf").Parse(fluentDConfigTemplate)
+	if err != nil {
+		return err
+	}
+	return tmpl.Execute(wr, config)
+}
+
+// WriteFluentBitConfig outputs the config in Fluent Bit syntax
+func (config *FluentConfigGenerator) WriteFluentBitConfig(wr io.Writer) error {
+	tmpl, err := template.New("fluent-bit.conf").Parse(fluentBitConfigTemplate)
+	if err != nil {
+		return err
+	}
+	return tmpl.Execute(wr, config)
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Implement log router related resource as a task resource. Log router task resource models log router related resources as a task resource. Creating this resource prepares everything a log router container needs, which includes creating a config directory, a socket directory, and a config file generated under the config directory. Cleaning up this resource means removing all those directories and config file. 

This PR only covers implementing this task resource, but not using it. The resource will later be added as a dependency for a log router container in a separate PR.

### Implementation details
<!-- How are the changes implemented? -->
Followed similar pattern as other task resource. Log router specific logic is mostly in resource's Create() and Cleanup() method.

For readability purpose I separate the changes in several commits. 
Commit 1: Add fluent config generator vendor package. (https://github.com/awslabs/go-config-generator-for-fluentd-and-fluentbit), which is used to generate the config file. License will be added in a separate PR.
Commit 2: Implementation.
Commit 3: Unit tests.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes
Unit test added. Manually test this by injecting [test code](https://github.com/fenxiong/amazon-ecs-agent/commit/8414ac855b9ba7de33f4bdaffc25123e366da626) in task.go and docker_task_engine.go and verified that the generated config file and socket directory can be used by the log router to send logs for both fluentd and fluentbit.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
