### PR TITLE
Support for namespace-aware mounts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -241,7 +241,7 @@ test-registry: netkitten volumes-test namespace-tests pause-container squid awsc
 
 # TODO, replace this with a build on dockerhub or a mechanism for the
 # functional tests themselves to build this
-.PHONY: squid awscli fluentd gremlin agent-introspection-validator taskmetadata-validator v3-task-endpoint-validator container-metadata-file-validator elastic-inference-validator image-cleanup-test-images ecr-execution-role-image container-health-check-image telemetry-test-image storage-stats-test-image
+.PHONY: squid awscli fluentd gremlin agent-introspection-validator taskmetadata-validator v3-task-endpoint-validator container-metadata-file-validator elastic-inference-validator image-cleanup-test-images ecr-execution-role-image container-health-check-image telemetry-test-image storage-stats-test-image nfs-server-image
 
 squid:
 	$(MAKE) -C misc/squid $(MFLAGS)
@@ -293,6 +293,9 @@ container-health-check-image:
 
 appmesh-plugin-validator:
 	$(MAKE) -C misc/appmesh-plugin-validator $(MFLAGS)
+
+nfs-server-image:
+	cd misc/nfs; $(MAKE) $(MFLAGS)
 
 # all .go files in the agent, excluding vendor/, model/ and testutils/ directories, and all *_test.go and *_mocks.go files
 GOFILES:=$(shell go list -f '{{$$p := .}}{{range $$f := .GoFiles}}{{$$p.Dir}}/{{$$f}} {{end}}' ./agent/... \
@@ -380,6 +383,7 @@ clean:
 	-$(MAKE) -C misc/storage-stats $(MFLAGS) clean
 	-$(MAKE) -C misc/appmesh-plugin-validator $(MFLAGS) clean
 	-$(MAKE) -C misc/eni-trunking-validator $(MFLAGS) clean
+	-$(MAKE) -C misc/nfs $(MFLAGS) clean
 	-rm -f .get-deps-stamp
 	-rm -f .builder-image-stamp
 	-rm -f .out-stamp

--- a/agent/taskresource/efs/efs_integration_test.go
+++ b/agent/taskresource/efs/efs_integration_test.go
@@ -1,0 +1,175 @@
+// +build sudo
+
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+package efs
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	ipAddressEnvironmentKey     = "ECS_FTEST_EFS_IP_ADDRESS"
+	namespaceFileEnvironmentKey = "ECS_FTEST_EFS_NETWORK_NAMESPACE"
+	testData                    = "foo"
+
+	// These files are known to exist on the test efs instance.
+	// See misc/nfs/integ/*
+	knownSource      = "efs-integration-test"
+	knownFile        = "expected-file"
+	knownFileContent = "expected-content"
+)
+
+// ipAddress is the known address of the efs volume (or localhost if employed
+// with the namespace flag)
+var ipAddress = os.Getenv(ipAddressEnvironmentKey)
+
+// namespace is the path to a network namespace (eg, /proc/1234/ns/net)
+var namespace = os.Getenv(namespaceFileEnvironmentKey)
+
+// These tests require an EFS ip address and a network namespace handle in
+// order to run. The way the integ test runs automatically is:
+//
+// 1. A docker container is created with inbound and outbound network disabled
+//
+// 2. The docker container starts an nfs server listening on localhost
+//
+// 3. These tests are given '127.0.0.1' as the IP and the network namespace of
+// the docker container.
+//
+// Since the container's network mode is 'none', the _only_ way that the nfs
+// mount succeeds is if the mount function executes in the namespace. This
+// namespace swapping will be reused in awsvpc mode to send traffic over the
+// task ENI. See misc/nfs/Dockerfile and misc/nfs/Makefile for more details.
+
+// TestReadWrite verifies that we can write, read, and delete a file over NFS.
+func TestReadWrite(t *testing.T) {
+	skipIfEnvironmentNotSet(t)
+
+	mountPoint := newTestMountPoint(t)
+	defer mountPoint.cleanup()
+
+	m := &NFSMount{
+		IPAddress:       ipAddress,
+		TargetDirectory: mountPoint.path,
+		NamespacePath:   namespace,
+	}
+
+	require.NoError(t, m.Mount())
+	defer func() {
+		require.NoError(t, m.Unmount())
+	}()
+
+	f, err := ioutil.TempFile(mountPoint.path, "")
+	require.NoError(t, err, "Couldn't open file for writing in mounted directory")
+
+	_, err = f.WriteString(testData)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	// Read file back
+	readData, err := ioutil.ReadFile(f.Name())
+	require.NoError(t, err)
+	assert.Equal(t, string(readData), testData)
+
+	// Remove the file
+	require.NoError(t, os.Remove(f.Name()))
+}
+
+// TestReadKnownFile verifies that a mounted volume with expected contents can
+// be discovered and read
+func TestReadKnownFile(t *testing.T) {
+	skipIfEnvironmentNotSet(t)
+
+	mountPoint := newTestMountPoint(t)
+	defer mountPoint.cleanup()
+
+	m := &NFSMount{
+		IPAddress:       ipAddress,
+		TargetDirectory: mountPoint.path,
+		NamespacePath:   namespace,
+	}
+
+	require.NoError(t, m.Mount())
+	defer func() {
+		require.NoError(t, m.Unmount())
+	}()
+
+	data, err := ioutil.ReadFile(filepath.Join(mountPoint.path, knownSource, knownFile))
+	require.NoError(t, err, "known file not found on test efs instance")
+	assert.Equal(t, knownFileContent, string(data), "known file content mismatch")
+}
+
+// TestReadKnownFileWithSource does the same function as TestReadKnownFile, but also includes a source directory. This
+// effectively causes the mount to happen at a specific directory within the NFS filesystem instead of the root of the
+// filesystem.
+func TestReadKnownFileWithSource(t *testing.T) {
+	skipIfEnvironmentNotSet(t)
+
+	mountPoint := newTestMountPoint(t)
+	defer mountPoint.cleanup()
+
+	m := &NFSMount{
+		IPAddress:       ipAddress,
+		TargetDirectory: mountPoint.path,
+		SourceDirectory: knownSource,
+		NamespacePath:   namespace,
+	}
+
+	require.NoError(t, m.Mount())
+	defer func() {
+		require.NoError(t, m.Unmount())
+	}()
+
+	data, err := ioutil.ReadFile(filepath.Join(mountPoint.path, knownFile))
+	require.NoError(t, err, "known file not found on test efs instance")
+	assert.Equal(t, knownFileContent, string(data), "known file content mismatch")
+}
+
+// testMountPoint is a helper struct that creates a temporary mount point on
+// the host and cleans itself up after the test is finished.
+type testMountPoint struct {
+	path string
+	t    *testing.T
+}
+
+// newTestMountPoint creates a tempdir to be used as the target mount.
+func newTestMountPoint(t *testing.T) *testMountPoint {
+	targetPath, err := ioutil.TempDir("", "")
+	require.NoError(t, err)
+	return &testMountPoint{path: targetPath, t: t}
+}
+
+// cleanup simply removes the tempdir
+func (d *testMountPoint) cleanup() {
+	d.t.Log("Cleaning up directory: ", d.path)
+	if err := os.Remove(d.path); err != nil {
+		d.t.Log("Couldn't cleanup: ", err)
+	}
+}
+
+func skipIfEnvironmentNotSet(t *testing.T) {
+	if ipAddress == "" {
+		t.Skip("EFS integration test requires valid ip address")
+	}
+
+	if namespace == "" {
+		t.Skip("EFS integration test requires valid namespace path")
+	}
+}

--- a/agent/taskresource/efs/efs_linux.go
+++ b/agent/taskresource/efs/efs_linux.go
@@ -1,0 +1,125 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package efs
+
+import (
+	"errors"
+	"runtime"
+	"time"
+
+	"github.com/vishvananda/netns"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	// TODO: break this out into a better options stream (IE, we will need overrides when specified in the service)
+	defaultOptsForEFS = "rsize=1048576,wsize=1048576,timeo=10,hard,retrans=2,noresvport,vers=4"
+	defaultSource     = ":/"
+	fsTypeNFS         = "nfs"
+	mountFlags        = 0
+	unmountFlags      = 0
+	mountTimeout      = time.Minute
+)
+
+var (
+	errNoIPAddress    = errors.New("no IP Address set for nfs mount")
+	errMountTimeout   = errors.New("mount operation timed out")
+	errUnmountTimeout = errors.New("unmount operation timed out")
+)
+
+var (
+	mountSyscall        = unix.Mount
+	unmountSyscall      = unix.Unmount
+	setNamespaceSyscall = netns.Set
+	getNamespaceHelper  = netns.GetFromPath
+)
+
+// NFSMount uses the mount syscall to create a local nfs mount. It can optionally take a network namespace, which forces
+// the mount to use the networking configuration applied to the other namespace.
+type NFSMount struct {
+	IPAddress       string
+	TargetDirectory string
+	SourceDirectory string
+	NamespacePath   string
+}
+
+// Mount creates the nfs mount, placing it at TargetDirectory on the host
+func (nm *NFSMount) Mount() error {
+	if nm.IPAddress == "" {
+		return errNoIPAddress
+	}
+
+	timeout := time.NewTimer(mountTimeout)
+	defer timeout.Stop()
+
+	mountEvent := make(chan error)
+	go func() {
+		mountEvent <- nm.doMount()
+	}()
+
+	select {
+	case err := <-mountEvent:
+		return err
+	case <-timeout.C:
+		return errMountTimeout
+	}
+}
+
+// doMount handles the core mount logic. The main Mount() method spawns this
+// in a goroutine
+func (nm *NFSMount) doMount() error {
+	if nm.NamespacePath != "" {
+		runtime.LockOSThread()
+		if err := nm.setNameSpace(); err != nil {
+			return err
+		}
+	}
+
+	opts := defaultOptsForEFS + ",addr=" + nm.IPAddress
+
+	// NFS expects the source to appear like ${IP}:/${SourceDirectory}
+	source := nm.IPAddress + defaultSource
+	if nm.SourceDirectory != "" {
+		source = source + nm.SourceDirectory
+	}
+
+	return mountSyscall(source, nm.TargetDirectory, fsTypeNFS, mountFlags, opts)
+}
+
+// Unmount removes the nfs mount from the host.
+func (nm *NFSMount) Unmount() error {
+	timeout := time.NewTimer(mountTimeout)
+	defer timeout.Stop()
+
+	mountEvent := make(chan error)
+	go func() {
+		mountEvent <- unmountSyscall(nm.TargetDirectory, unmountFlags)
+	}()
+
+	select {
+	case err := <-mountEvent:
+		return err
+	case <-timeout.C:
+		return errUnmountTimeout
+	}
+}
+
+func (nm *NFSMount) setNameSpace() error {
+	handle, err := getNamespaceHelper(nm.NamespacePath)
+	if err != nil {
+		return err
+	}
+
+	return setNamespaceSyscall(handle)
+}

--- a/agent/taskresource/efs/efs_linux_test.go
+++ b/agent/taskresource/efs/efs_linux_test.go
@@ -1,0 +1,180 @@
+// +build unit
+
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+package efs
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/vishvananda/netns"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	testIP              = "0.0.0.0"
+	testTargetDirectory = "target"
+	testSourceDirectory = "source"
+	testNamespacePath   = "/test/ns/path"
+	testNsHandle        = netns.NsHandle(1)
+)
+
+// TestMount_HappyCase sets all of the values in NFSMount and asserts that each function is called with the expected
+// values.
+func TestMount_HappyCase(t *testing.T) {
+	defer reset()
+	mountSyscall = func(device string, target string, fstype string, flags uintptr, opts string) error {
+		assert.Equal(t, device, "0.0.0.0:/source")
+		assert.Equal(t, target, testTargetDirectory)
+		assert.Equal(t, fstype, "nfs")
+		assert.Equal(t, flags, uintptr(0))
+		assert.Equal(t, opts, "rsize=1048576,wsize=1048576,timeo=10,hard,retrans=2,noresvport,vers=4,addr=0.0.0.0")
+		return nil
+	}
+
+	getNamespaceHelper = func(nspath string) (netns.NsHandle, error) {
+		assert.Equal(t, nspath, "/test/ns/path")
+		return testNsHandle, nil
+	}
+
+	setNamespaceSyscall = func(handle netns.NsHandle) error {
+		assert.Equal(t, netns.NsHandle(1), handle)
+		return nil
+	}
+
+	mount := &NFSMount{
+		TargetDirectory: testTargetDirectory,
+		IPAddress:       testIP,
+		NamespacePath:   testNamespacePath,
+		SourceDirectory: testSourceDirectory,
+	}
+
+	assert.NoError(t, mount.Mount())
+}
+
+func TestMount_NoIPAddressError(t *testing.T) {
+	defer reset()
+	mountSyscall = mountFunction(nil)
+
+	mount := &NFSMount{
+		TargetDirectory: testTargetDirectory,
+	}
+
+	assert.Error(t, mount.Mount())
+}
+
+func TestMount_MountError(t *testing.T) {
+	defer reset()
+	expectedErr := errors.New("generic mount error")
+	mountSyscall = mountFunction(expectedErr)
+
+	mount := &NFSMount{
+		IPAddress:       testIP,
+		TargetDirectory: testTargetDirectory,
+	}
+
+	assert.EqualError(t, mount.Mount(), expectedErr.Error())
+}
+
+func TestUnmount_HappyCase(t *testing.T) {
+	defer reset()
+	unmountSyscall = func(target string, flags int) error {
+		assert.Equal(t, testTargetDirectory, target)
+		assert.Equal(t, flags, 0)
+		return nil
+	}
+
+	mount := &NFSMount{
+		TargetDirectory: testTargetDirectory,
+	}
+
+	assert.NoError(t, mount.Unmount())
+}
+
+func TestUnmount_ErrorCase(t *testing.T) {
+	defer reset()
+	expectedErr := errors.New("generic unmount error")
+	unmountSyscall = unmountFunction(expectedErr)
+
+	mount := &NFSMount{
+		TargetDirectory: testTargetDirectory,
+	}
+
+	assert.EqualError(t, mount.Unmount(), expectedErr.Error())
+}
+
+func TestMount_BadNamespace(t *testing.T) {
+	defer reset()
+	mountSyscall = mountFunction(nil)
+	expectedErr := errors.New("generic namespace get error")
+	getNamespaceHelper = getNamespaceHelperFunction(testNsHandle, expectedErr)
+
+	mount := &NFSMount{
+		TargetDirectory: testTargetDirectory,
+		IPAddress:       testIP,
+		NamespacePath:   testNamespacePath,
+	}
+
+	assert.EqualError(t, mount.Mount(), expectedErr.Error())
+}
+
+func TestMount_SetNamespaceFails(t *testing.T) {
+	defer reset()
+	mountSyscall = mountFunction(nil)
+	expectedErr := errors.New("generic namespace set error")
+	getNamespaceHelper = getNamespaceHelperFunction(testNsHandle, nil)
+	setNamespaceSyscall = setNamespaceFunction(expectedErr)
+
+	mount := &NFSMount{
+		TargetDirectory: testTargetDirectory,
+		IPAddress:       testIP,
+		NamespacePath:   testNamespacePath,
+	}
+
+	assert.EqualError(t, mount.Mount(), expectedErr.Error())
+}
+
+// The following functions are helpers for making simple mocks
+
+func mountFunction(err error) func(string, string, string, uintptr, string) error {
+	return func(string, string, string, uintptr, string) error {
+		return err
+	}
+}
+
+func unmountFunction(err error) func(string, int) error {
+	return func(string, int) error {
+		return err
+	}
+}
+
+func setNamespaceFunction(err error) func(netns.NsHandle) error {
+	return func(netns.NsHandle) error {
+		return err
+	}
+}
+
+func getNamespaceHelperFunction(handle netns.NsHandle, err error) func(string) (netns.NsHandle, error) {
+	return func(string) (netns.NsHandle, error) {
+		return handle, err
+	}
+}
+
+func reset() {
+	mountSyscall = unix.Mount
+	unmountSyscall = unix.Unmount
+	setNamespaceSyscall = netns.Set
+	getNamespaceHelper = netns.GetFromPath
+}

--- a/agent/taskresource/efs/efs_unspecified.go
+++ b/agent/taskresource/efs/efs_unspecified.go
@@ -1,0 +1,28 @@
+// +build !linux
+
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+package efs
+
+import "github.com/pkg/errors"
+
+// NFSMount is not supported on non-linux platforms
+type NFSMount struct{}
+
+func (nm *NFSMount) Mount() error {
+	return errors.New("efs mount not supported on this operating system")
+}
+
+func (nm *NFSMount) Unmount() error {
+	return errors.New("efs unmount not supported on this operating system")
+}

--- a/misc/nfs/Dockerfile
+++ b/misc/nfs/Dockerfile
@@ -1,0 +1,6 @@
+FROM amazonlinux:2
+
+# TODO: Make this clean up nfsd processes
+RUN yum update -y && yum install -y nfs-utils
+COPY nfs.sh /nfs.sh
+CMD "/nfs.sh"

--- a/misc/nfs/Makefile
+++ b/misc/nfs/Makefile
@@ -1,0 +1,33 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+.PHONY: all clean
+
+all: .docker-stamp 
+
+.docker-stamp:
+	docker build -t amazon/nfs-tester:make .
+	docker run -d \
+	    --tmpfs /proc/fs/nfsd \
+	    --tmpfs /var/lib/nfs/rpc_pipefs \
+	    --privileged \
+	    --net=none \
+	    --name=nfs-test \
+	    -v "$(PWD)/integ:/var/files" \
+	    amazon/nfs-tester:make
+	touch .docker-stamp
+
+clean:
+	-docker stop nfs-test
+	-docker rm nfs-test
+	-docker rmi -f "amazon/nfs-tester:make"
+	-rm -f .docker-stamp

--- a/misc/nfs/integ/efs-integration-test/expected-file
+++ b/misc/nfs/integ/efs-integration-test/expected-file
@@ -1,0 +1,1 @@
+expected-content

--- a/misc/nfs/nfs.sh
+++ b/misc/nfs/nfs.sh
@@ -1,0 +1,17 @@
+#/bin/sh
+
+set -e -x
+
+mount -t nfsd nfsd /proc/fs/nfsd
+mount -t rpc_pipefs sunrpc /var/lib/nfs/rpc_pipefs
+
+echo "/var/files *(rw,sync,no_subtree_check,fsid=0,no_root_squash,insecure)" > /etc/exports
+
+rpcbind -w
+rpc.mountd
+RPC_STATD_NO_NOTIFY=1 rpc.statd
+rpc.idmapd
+exportfs -r
+rpc.nfsd 8
+echo no more logs, just waiting now
+sleep infinity


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Adds a library that makes it possible to mount given a network namespace. This will eventually be used to send NFS traffic over different ENIs.


### Implementation details
<!-- How are the changes implemented? -->
This makes use of the mount syscall, so we don't need to directly depend on nfs utilities existing on the host operating system. 


### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Testing includes both integ and unit tests. 

The unit tests mostly assure us that errors are handled in correctly, and that the mount options are set correctly for the happy case. 

The integration tests are a bit more complicated. We setup a test nfs server inside a docker container and setup mount connections to it. Definitely take a look at the misc/nfs directory contents to see how the test mount is created and how it runs. If the explanations on the test don't make much sense, let me know and I'll try to clarify. I'd like to reuse this test container as we build out additional support.

New tests cover the changes: yes

### Description for the changelog
(none yet -- just library code)

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
