### PR TITLE
Set up log router resource and log router container config

### DIFF
--- a/agent/app/agent_unix.go
+++ b/agent/app/agent_unix.go
@@ -214,6 +214,7 @@ func (agent *ecsAgent) initializeResourceFields(credentialsManager credentials.M
 			ASMClientCreator:   asmfactory.NewClientCreator(),
 			SSMClientCreator:   ssmfactory.NewSSMClientCreator(),
 			CredentialsManager: credentialsManager,
+			EC2InstanceID:      agent.getEC2InstanceID(),
 		},
 		Ctx:              agent.ctx,
 		DockerClient:     agent.dockerClient,

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -893,9 +893,15 @@ func (engine *DockerTaskEngine) createContainer(task *apitask.Task, container *a
 		}
 	}
 
+	if container.LogRouter != nil {
+		err := task.AddLogRouterBindMounts(container.LogRouter.Type, hostConfig, engine.cfg)
+		if err != nil {
+			return dockerapi.DockerContainerMetadata{Error: apierrors.NamedError(err)}
+		}
+	}
+
 	//Apply the log driver secret into container's LogConfig and Env secrets to container.Environment
 	if container.HasSecretAsEnvOrLogDriver() {
-		//splunkToken, ok := hostConfig.LogConfig.Config["splunk-token"]
 		err := task.PopulateSecrets(hostConfig, container)
 
 		if err != nil {

--- a/agent/statemanager/state_manager.go
+++ b/agent/statemanager/state_manager.go
@@ -87,7 +87,9 @@ const (
 	// 	 a) Add 'attachmentType' field to 'api.ENIAttachment'
 	//	 b) Add 'InterfaceAssociationProtocol' field to 'api.ENI'
 	//	 c) Add 'InterfaceVlanProperties' field to 'api.ENI'
-	// 23) Add 'LogRouter' field to 'Container' struct
+	// 23)
+	//   a) Add 'LogRouter' field to 'Container' struct
+	//   b) Add 'logrouter' field to 'resources'
 
 	ECSDataVersion = 23
 

--- a/agent/taskresource/logrouter/logrouter_unimplemented.go
+++ b/agent/taskresource/logrouter/logrouter_unimplemented.go
@@ -27,10 +27,20 @@ import (
 const (
 	// ResourceName is the name of the log router resource.
 	ResourceName = "logrouter"
+	// LogRouterTypeFluentd is the type of a fluentd log router.
+	LogRouterTypeFluentd = "fluentd"
+	// LogRouterTypeFluentbit is the type of a fluentbit log router.
+	LogRouterTypeFluentbit = "fluentbit"
 )
 
 // LogRouterResource represents the log router resource.
 type LogRouterResource struct{}
+
+// NewLogRouterResource returns a new LogRouterResource.
+func NewLogRouterResource(cluster, taskARN, taskDefinition, ec2InstanceID, dataDir, logRouterType string,
+	ecsMetadataEnabled bool, containerToLogOptions map[string]map[string]string) *LogRouterResource {
+	return &LogRouterResource{}
+}
 
 // SetDesiredStatus safely sets the desired status of the resource.
 func (logRouter *LogRouterResource) SetDesiredStatus(status resourcestatus.ResourceStatus) {}

--- a/agent/taskresource/logrouter/logrouter_unix.go
+++ b/agent/taskresource/logrouter/logrouter_unix.go
@@ -43,7 +43,7 @@ const (
 
 // LogRouterResource models fluentd/fluentbit log router related resources as a task resource.
 type LogRouterResource struct {
-	// Fields that are specific to log router resource.
+	// Fields that are specific to log router resource. They are only set at initialization so are not protected by lock.
 	cluster               string
 	taskARN               string
 	taskDefinition        string
@@ -55,7 +55,7 @@ type LogRouterResource struct {
 	os                    oswrapper.OS
 	ioutil                ioutilwrapper.IOUtil
 
-	// Fields for the common functionality of task resource.
+	// Fields for the common functionality of task resource. Access to these fields are protected by lock.
 	createdAtUnsafe     time.Time
 	desiredStatusUnsafe resourcestatus.ResourceStatus
 	knownStatusUnsafe   resourcestatus.ResourceStatus
@@ -87,6 +87,48 @@ func NewLogRouterResource(cluster, taskARN, taskDefinition, ec2InstanceID, dataD
 
 	logRouterResource.initStatusToTransition()
 	return logRouterResource
+}
+
+// GetCluster returns the cluster.
+// Note: this method is currently only used in test. If this is going to be invoked by code, you should add lock.
+func (logRouter *LogRouterResource) GetCluster() string {
+	return logRouter.cluster
+}
+
+// GetTaskARN returns the task arn.
+// Note: this method is currently only used in test. If this is going to be invoked by code, you should add lock.
+func (logRouter *LogRouterResource) GetTaskARN() string {
+	return logRouter.taskARN
+}
+
+// GetTaskDefinition returns the task definition.
+// Note: this method is currently only used in test. If this is going to be invoked by code, you should add lock.
+func (logRouter *LogRouterResource) GetTaskDefinition() string {
+	return logRouter.taskDefinition
+}
+
+// GetEC2InstanceID returns the ec2 instance id.
+// Note: this method is currently only used in test. If this is going to be invoked by code, you should add lock.
+func (logRouter *LogRouterResource) GetEC2InstanceID() string {
+	return logRouter.ec2InstanceID
+}
+
+// GetResourceDir returns the resource dir.
+// Note: this method is currently only used in test. If this is going to be invoked by code, you should add lock.
+func (logRouter *LogRouterResource) GetResourceDir() string {
+	return logRouter.resourceDir
+}
+
+// GetECSMetadataEnabled returns whether ecs metadata is enabled.
+// Note: this method is currently only used in test. If this is going to be invoked by code, you should add lock.
+func (logRouter *LogRouterResource) GetECSMetadataEnabled() bool {
+	return logRouter.ecsMetadataEnabled
+}
+
+// GetContainerToLogOptions returns a map of containers' log options.
+// Note: this method is currently only used in test. If this is going to be invoked by code, you should add lock.
+func (logRouter *LogRouterResource) GetContainerToLogOptions() map[string]map[string]string {
+	return logRouter.containerToLogOptions
 }
 
 // Initialize initializes the resource.

--- a/agent/taskresource/types_common.go
+++ b/agent/taskresource/types_common.go
@@ -25,4 +25,5 @@ type ResourceFieldsCommon struct {
 	ASMClientCreator   asmfactory.ClientCreator
 	SSMClientCreator   ssmfactory.SSMClientCreator
 	CredentialsManager credentials.Manager
+	EC2InstanceID      string
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->
### Summary
<!-- What does this pull request do? -->
Set up log router resource and log router container config:
1. When there's a log router container in a task, initialize a log router task resource and add it as a dependency of the log router container.
2. When creating the log router container, add config file bind mount and socket directory bind mount to its host config.

### Implementation details
<!-- How are the changes implemented? -->
1 is done in task's PostUnmarshalTask method similar to what was done for initializing other task resource.
2 is done in engine's createContainer method.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Unit tests added. Manually tested this by injecting [test code](https://github.com/fenxiong/amazon-ecs-agent/commit/8df9c520ce342f7b64b7c8d6da34f2298958d630) that hardcodes the missing pieces.

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
