### PR TITLE
adds functional test for Block Metric

### DIFF
--- a/agent/functional_tests/testdata/taskdefinitions/storage-stats/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/storage-stats/task-definition.json
@@ -1,0 +1,9 @@
+{
+    "cpu": "1028",
+    "family": "storage-stats-test",
+    "containerDefinitions": [{
+        "memory": 2000,
+        "name": "storage-stats-test",
+        "image": "amazon/amazon-ecs-storage-stats-test:make"
+    }]
+}

--- a/agent/functional_tests/tests/functionaltests_unix_test.go
+++ b/agent/functional_tests/tests/functionaltests_unix_test.go
@@ -387,6 +387,12 @@ func TestTelemetryWithStatsPolling(t *testing.T) {
 	telemetryTestWithStatsPolling(t, "telemetry")
 }
 
+// TestTelemetryStorageStats tests whether agent can send metrics to TACS,
+// via cloudwatch metrics.  This is an end-to-end test.
+func TestTelemetryStorageStats(t *testing.T) {
+	telemetryStorageStatsTest(t, "storage-stats")
+}
+
 func TestTaskIAMRolesNetHostMode(t *testing.T) {
 	// The test runs only when the environment TEST_IAM_ROLE was set
 	if os.Getenv("TEST_DISABLE_TASK_IAM_ROLE_NET_HOST") == "true" {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This piggy-backs on the current process for TestTelemetry.  

We are just checking that metrics are available, ie metrics are not null and metrics have more than 0 datapoints.  

### Implementation details
The test starts up the `storage-stats-test` which generates predictable block writes/reads.  These are new metrics which will only become available with the `containerInsights=enabled` account setting for the cluster.

### Testing
<!-- How was this tested? -->
`go test -tags functional -timeout=20m -v ./agent/functional_tests/... -run TestTelemetryStorageStats`
This resulted in the following output: 
```
=== RUN   TestTelemetryStorageStats
--- PASS: TestTelemetryStorageStats (627.30s)
	utils_unix.go:131: Created directory /tmp/ecs_integ_testdata148905997 to store test data in
	utils_unix.go:153: Launching agent with image: amazon/amazon-ecs-agent:make
	utils_unix.go:244: Agent started as docker container: 3bd175a2ec2e46e75cdc2bf4fd324541ef38cf422e5c7d79d793cac2551e823a
	utils.go:178: Found agent metadata: {Cluster:ecstest-storagestats-1ee7b435-e4e3-4459-b91b-ee607bb94c71 ContainerInstanceArn:0xc4202d98a0 Version:Amazon ECS Agent - v1.28.1 (*1cdea216)}
	utils.go:209: Task definition: storage-stats-test-b9bb680a32296599e35351c7dc697c86:1
	utils.go:229: Started task: arn:aws:ecs:us-west-2:758282334450:task/cd52b244-72e8-449d-a626-66a79fb99b67
	utils.go:188: Removing test dir for passed test /tmp/ecs_integ_testdata148905997
PASS
ok  	github.com/aws/amazon-ecs-agent/agent/functional_tests/tests	627.424s
?   	github.com/aws/amazon-ecs-agent/agent/functional_tests/tests/generated	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/aws/amazon-ecs-agent/agent/functional_tests/tests/generated/simpletests_unix	0.137s [no tests to run]
?   	github.com/aws/amazon-ecs-agent/agent/functional_tests/util	[no test files]
```
<img width="1270" alt="Screen Shot 2019-07-08 at 3 45 42 PM" src="https://user-images.githubusercontent.com/4751028/60847712-8cbfed00-a198-11e9-9c3e-41538d8811f9.png">

update: ran with agent 1.28.0 and it skipped the test as expected
```
=== RUN   TestTelemetryStorageStats
--- SKIP: TestTelemetryStorageStats (2.09s)
	utils_unix.go:131: Created directory /tmp/ecs_integ_testdata671169402 to store test data in
	utils_unix.go:153: Launching agent with image: amazon/amazon-ecs-agent:make
	utils_unix.go:244: Agent started as docker container: 4397b9a01e0c66539db691958c7877d18868a0852afd4e5c477482f065d82dbe
	utils.go:178: Found agent metadata: {Cluster:ecstest-storagestats-05ca97b7-b3bd-4586-a0eb-dec6a04be643 ContainerInstanceArn:0xc420321c00 Version:Amazon ECS Agent - v1.28.1 (*1cdea216)}
	utils.go:560: Skipping test requiring version >=1.29.0; agent version 1.28.1
	utils.go:188: Removing test dir for passed test /tmp/ecs_integ_testdata671169402
PASS
ok  	github.com/aws/amazon-ecs-agent/agent/functional_tests/tests	2.214s
?   	github.com/aws/amazon-ecs-agent/agent/functional_tests/tests/generated	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/aws/amazon-ecs-agent/agent/functional_tests/tests/generated/simpletests_unix	0.137s [no tests to run]
```
New tests cover the changes: yes

### Description for the changelog
Add functional test for new metric reporting.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

