### PR TITLE
add fluentd-async-connect as option to containers using log router

### DIFF
--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -77,6 +77,7 @@ const (
 	logDriverTag                       = "tag"
 	logDriverFluentdAddress            = "fluentd-address"
 	dataLogDriverPath                  = "/data/logrouter/"
+	logDriverAsyncConnect              = "fluentd-async-connect"
 	dataLogDriverSocketPath            = "/socket/fluent.sock"
 	socketPathPrefix                   = "unix://"
 )
@@ -976,6 +977,7 @@ func getLogRouterConfig(task *apitask.Task, container *apicontainer.Container, h
 	}
 	logConfig.Config[logDriverTag] = tag
 	logConfig.Config[logDriverFluentdAddress] = fluentd
+	logConfig.Config[logDriverAsyncConnect] = strconv.FormatBool(true)
 	return logConfig
 }
 

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -2745,6 +2745,7 @@ func TestCreateContainerAddLogDriverConfig(t *testing.T) {
 		expectedLogConfigType          string
 		expectedLogConfigTag           string
 		expectedLogConfigFluentAddress string
+		expectedFluentdAsyncConnect    string
 	}{
 		{
 			name:                           "test with awslogrouter container",
@@ -2752,6 +2753,7 @@ func TestCreateContainerAddLogDriverConfig(t *testing.T) {
 			expectedLogConfigType:          "fluentd",
 			expectedLogConfigTag:           taskName + "-" + taskID,
 			expectedLogConfigFluentAddress: filepath.Join(socketPathPrefix, defaultConfig.DataDirOnHost, dataLogDriverPath, taskID, dataLogDriverSocketPath),
+			expectedFluentdAsyncConnect:    strconv.FormatBool(true),
 		},
 		{
 			name:                           "test without awslogrouter container",
@@ -2759,6 +2761,7 @@ func TestCreateContainerAddLogDriverConfig(t *testing.T) {
 			expectedLogConfigType:          notAWSlogRouterType,
 			expectedLogConfigTag:           "",
 			expectedLogConfigFluentAddress: "",
+			expectedFluentdAsyncConnect:    "",
 		},
 	}
 
@@ -2779,6 +2782,7 @@ func TestCreateContainerAddLogDriverConfig(t *testing.T) {
 					assert.Equal(t, hostConfig.LogConfig.Type, tc.expectedLogConfigType)
 					assert.Equal(t, hostConfig.LogConfig.Config["tag"], tc.expectedLogConfigTag)
 					assert.Equal(t, hostConfig.LogConfig.Config["fluentd-address"], tc.expectedLogConfigFluentAddress)
+					assert.Equal(t, hostConfig.LogConfig.Config["fluentd-async-connect"], tc.expectedFluentdAsyncConnect)
 				})
 			ret := taskEngine.(*DockerTaskEngine).createContainer(tc.task, tc.task.Containers[0])
 			assert.NoError(t, ret.Error)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Adding a new log opts value 'fluentd-async-connect' to containers that use log router.

### Implementation details
<!-- How are the changes implemented? -->

### Testing
make test and make run-integ-tests 
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
