### PR TITLE
Add capabilities for log router and change the name for log driver

### DIFF
--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -49,6 +49,9 @@ const (
 	taskEIAAttributeSuffix                      = "task-eia"
 	taskENITrunkingAttributeSuffix              = "task-eni-trunking"
 	branchCNIPluginVersionSuffix                = "branch-cni-plugin-version"
+	capabilityAWSRouterFluentd                  = "awsrouter.fluentd"
+	capabilityAWSRouterFluentbit                = "awsrouter.fluentbit"
+	capabilityAWSRouterLoggingDriver            = "logging-driver.awsrouter"
 )
 
 // capabilities returns the supported capabilities of this agent / docker-client pair.
@@ -86,6 +89,9 @@ const (
 //    ecs.capability.aws-appmesh
 //    ecs.capability.task-eia
 //    ecs.capability.task-eni-trunking
+//    ecs.capability.awsrouter.fluentd
+//    ecs.capability.awsrouter.fluentbit
+//    com.amazonaws.ecs.capability.logging-driver.awsrouter
 func (agent *ecsAgent) capabilities() ([]*ecs.Attribute, error) {
 	var capabilities []*ecs.Attribute
 
@@ -163,6 +169,15 @@ func (agent *ecsAgent) capabilities() ([]*ecs.Attribute, error) {
 
 	// support elastic inference in agent
 	capabilities = agent.appendTaskEIACapabilities(capabilities)
+
+	// support aws router capabilities for fluentd
+	capabilities = agent.appendAWSRouterFluentdCapabilities(capabilities)
+
+	// support aws router capabilities for fluentbit
+	capabilities = agent.appendAWSRouterFluentbitCapabilities(capabilities)
+
+	// support aws router capabilities for log driver router
+	capabilities = agent.appendAWSLoggingDriverCapabilities(capabilities)
 
 	return capabilities, nil
 }

--- a/agent/app/agent_capability_unix.go
+++ b/agent/app/agent_capability_unix.go
@@ -114,3 +114,15 @@ func (agent *ecsAgent) appendAppMeshCapabilities(capabilities []*ecs.Attribute) 
 func (agent *ecsAgent) appendTaskEIACapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
 	return appendNameOnlyAttribute(capabilities, attributePrefix+taskEIAAttributeSuffix)
 }
+
+func (agent *ecsAgent) appendAWSRouterFluentdCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
+	return appendNameOnlyAttribute(capabilities, attributePrefix+capabilityAWSRouterFluentd)
+}
+
+func (agent *ecsAgent) appendAWSRouterFluentbitCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
+	return appendNameOnlyAttribute(capabilities, attributePrefix+capabilityAWSRouterFluentbit)
+}
+
+func (agent *ecsAgent) appendAWSLoggingDriverCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
+	return appendNameOnlyAttribute(capabilities, capabilityPrefix+capabilityAWSRouterLoggingDriver)
+}

--- a/agent/app/agent_capability_unspecified.go
+++ b/agent/app/agent_capability_unspecified.go
@@ -85,3 +85,15 @@ func (agent *ecsAgent) appendAppMeshCapabilities(capabilities []*ecs.Attribute) 
 func (agent *ecsAgent) appendTaskEIACapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
 	return capabilities
 }
+
+func (agent *ecsAgent) appendAWSRouterFluentdCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
+	return capabilities
+}
+
+func (agent *ecsAgent) appendAWSRouterFluentbitCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
+	return capabilities
+}
+
+func (agent *ecsAgent) appendAWSLoggingDriverCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
+	return capabilities
+}

--- a/agent/app/agent_capability_windows.go
+++ b/agent/app/agent_capability_windows.go
@@ -44,3 +44,15 @@ func (agent *ecsAgent) appendAppMeshCapabilities(capabilities []*ecs.Attribute) 
 func (agent *ecsAgent) appendTaskEIACapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
 	return capabilities
 }
+
+func (agent *ecsAgent) appendAWSRouterFluentdCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
+	return capabilities
+}
+
+func (agent *ecsAgent) appendAWSRouterFluentbitCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
+	return capabilities
+}
+
+func (agent *ecsAgent) appendAWSLoggingDriverCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
+	return capabilities
+}

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -72,7 +72,7 @@ const (
 	maxEngineConnectRetryDelay         = 2 * time.Second
 	engineConnectRetryJitterMultiplier = 0.20
 	engineConnectRetryDelayMultiplier  = 1.5
-	logConfigType                      = "awslogrouter"
+	logConfigType                      = "awsrouter"
 	logDriverType                      = "fluentd"
 	logDriverTag                       = "tag"
 	logDriverFluentdAddress            = "fluentd-address"
@@ -878,7 +878,7 @@ func (engine *DockerTaskEngine) createContainer(task *apitask.Task, container *a
 		return dockerapi.DockerContainerMetadata{Error: apierrors.NamedError(hcerr)}
 	}
 
-	// If the container is using a special log driver type "awslogrouter", it means the container wants to use
+	// If the container is using a special log driver type "awsrouter", it means the container wants to use
 	// log router to send logs. In this case, override the log driver type to be fluentd
 	// and specify appropriate tag and fluentd-address, so that the logs are sent to and routed by the log router
 	// For reference - https://docs.docker.com/config/containers/logging/fluentd/

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -2704,7 +2704,7 @@ func TestCreateContainerAddLogDriverConfig(t *testing.T) {
 	taskID := "task-id"
 	taskFamily := "logSenderTaskFamily"
 	taskVersion := "1"
-	awslogRouterType := "awslogrouter"
+	awslogRouterType := "awsrouter"
 	notAWSlogRouterType := "notawslogrouter"
 	dataLogDriverPath := "/data/logrouter/"
 	dataLogDriverSocketPath := "/socket/fluent.sock"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Adding new capabilities 
ecs.capability.awsrouter.fluentd
ecs.capability.awsrouter.fluentbit
com.amazonaws.ecs.capability.logging-driver.awsrouter
And changing the name of log driver name

### Testing
make test on linux and mac
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
