### PR TITLE
Bump health check timeout for flakey test TestContainerHealthCheck

### DIFF
--- a/agent/engine/engine_integ_test.go
+++ b/agent/engine/engine_integ_test.go
@@ -56,7 +56,7 @@ const (
 			"HealthCheck":{
 				"Test":["CMD-SHELL", "echo hello"],
 				"Interval":100000000,
-				"Timeout":100000000,
+				"Timeout":2000000000,
 				"StartPeriod":100000000,
 				"Retries":3}
 		}`


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Fix https://github.com/aws/amazon-ecs-agent/issues/2111. The test was failing because health check command timed out. Looking at the container started by the failed test on windows 2019 i found the following:
```
                    {
                        "Start": "2019-07-10T22:06:34.9576203Z",
                        "End": "2019-07-10T22:06:35.0641014Z",
                        "ExitCode": -1,
                        "Output": "Health check exceeded timeout (100ms)"
                    },
                    {
                        "Start": "2019-07-10T22:06:35.3378287Z",
                        "End": "2019-07-10T22:06:35.4380006Z",
                        "ExitCode": -1,
                        "Output": "Health check exceeded timeout (100ms)"
                    },
                    {
                        "Start": "2019-07-10T22:06:35.9419997Z",
                        "End": "2019-07-10T22:06:36.0484608Z",
                        "ExitCode": -1,
                        "Output": "Health check exceeded timeout (100ms)"
                    },
                    {
                        "Start": "2019-07-10T22:06:36.5227924Z",
                        "End": "2019-07-10T22:06:36.6243695Z",
                        "ExitCode": -1,
                        "Output": "Health check exceeded timeout (100ms)"
                    }
```
After bumping the health check timeout, the test passed and inspecting the container shows the following:
```
                    {
                        "Start": "2019-07-10T22:32:44.8474776Z",
                        "End": "2019-07-10T22:32:45.1178095Z",
                        "ExitCode": 0,
                        "Output": "hello\r\n"
                    },
                    {
                        "Start": "2019-07-10T22:32:45.2271147Z",
                        "End": "2019-07-10T22:32:45.7345656Z",
                        "ExitCode": 0,
                        "Output": "hello\r\n"
                    }
```
So it looks like the health check command takes more than 100ms on windows 2019. 
This PR bumps the timeout to 2s. Without the bump this test almost always failed when i ran it manually on windows 2019. With the bump the test does not fail after running 10 times.

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
