### PR TITLE
Add opts

### DIFF
--- a/agent/taskresource/efs/efs_linux.go
+++ b/agent/taskresource/efs/efs_linux.go
@@ -15,6 +15,7 @@ package efs
 
 import (
 	"errors"
+	"path/filepath"
 	"runtime"
 	"time"
 
@@ -25,7 +26,6 @@ import (
 const (
 	defaultOptsForEFS  = "rsize=1048576,wsize=1048576,timeo=10,hard,retrans=2,noresvport"
 	enforcedOptsForEFS = "fg,vers=4"
-	defaultSource      = ":/"
 	fsTypeNFS          = "nfs"
 	defaultMountFlag   = uintptr(0)
 	defaultUnmountFlag = 0
@@ -90,10 +90,7 @@ func (nm *NFSMount) doMount() error {
 	opts := mergeOptions(defaultOptsForEFS, addressOpt, nm.AdditionalOpts, enforcedOptsForEFS)
 
 	// NFS expects the source to appear like ${IP}:/${SourceDirectory}
-	source := nm.IPAddress + defaultSource
-	if nm.SourceDirectory != "" {
-		source = source + nm.SourceDirectory
-	}
+	source := nm.IPAddress + ":" + filepath.Join("/", nm.SourceDirectory)
 
 	mountFlag := defaultMountFlag
 	if nm.ReadOnly {

--- a/agent/taskresource/efs/options_linux.go
+++ b/agent/taskresource/efs/options_linux.go
@@ -1,0 +1,105 @@
+package efs
+
+import (
+	"errors"
+	"strings"
+)
+
+var supportedNfsOpts = map[string]string{
+	"resvport": "noresvport",
+	"soft":     "hard",
+	"ac":       "noac",
+	"fg":       "bg",
+	"intr":     "nointr",
+	"cto":      "nocto",
+	"rsize":    "",
+	"wsize":    "",
+	"timeo":    "",
+	"retrans":  "",
+}
+
+// checkOptionSet validates customer input against the supported NFS options
+// TODO: move to service layer exclusively?
+func checkOptionSet(optionSet string) error {
+	options := strings.Split(optionSet, ",")
+	for _, option := range options {
+		split := strings.Split(option, "=")
+		found := false
+		for k, v := range supportedNfsOpts {
+			if k == split[0] || v == split[0] {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return errors.New("unsupported nfs option: " + split[0])
+		}
+	}
+	return nil
+}
+
+// mergeOptions collapses sets of options into one, preferring the option to
+// the right. Order is not preserved. Flag values (ie, for the 'ro' flag) are not extracted.
+func mergeOptions(sets ...string) string {
+	valueMap := make(map[string]string)
+	optMap := make(map[string]bool)
+	for _, options := range sets {
+		for _, option := range strings.Split(options, ",") {
+			split := strings.Split(option, "=")
+			key := split[0]
+			if key == "" {
+				continue
+			}
+			normalizedKey, reverse := parseMountOptions(key)
+
+			optMap[normalizedKey] = reverse
+
+			if len(split) > 1 {
+				valueMap[normalizedKey] = split[1]
+			}
+		}
+	}
+
+	b := strings.Builder{}
+	// we don't want to add a comma to the first option -- but every subsequent option needs to be prepended with a comma
+	addComma := false
+
+	// 'shouldReverse' means we should use the right-hand-side (value) of the supportedNfsOpts map
+	for normalizedKey, shouldReverse := range optMap {
+		if addComma {
+			b.WriteString(",")
+		}
+		if shouldReverse {
+			b.WriteString(supportedNfsOpts[normalizedKey])
+		} else {
+			b.WriteString(normalizedKey)
+		}
+		if value, ok := valueMap[normalizedKey]; ok {
+			b.WriteString("=")
+			b.WriteString(value)
+		}
+		addComma = true
+	}
+	return b.String()
+}
+
+// parseMountOptions takes a mount option and returns true if its discovered as an NFS option. Some options also have
+// inverse options (eg, "cto" vs "nocto") so we normalize that and return a boolean value if it should be reversed.
+func parseMountOptions(mountOpt string) (normalizedKey string, reverse bool) {
+	if mountOpt == "" {
+		return
+	}
+
+	normalizedKey = mountOpt
+	for k, v := range supportedNfsOpts {
+		if mountOpt == k {
+			return
+		}
+		if mountOpt == v {
+			normalizedKey = k
+			reverse = true
+			return
+		}
+	}
+	return
+}

--- a/agent/taskresource/efs/options_linux_test.go
+++ b/agent/taskresource/efs/options_linux_test.go
@@ -1,0 +1,18 @@
+package efs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMerge(t *testing.T) {
+	optA := "hard,noresvport,timeo=24"
+	optB := "hard,resvport,timeo=10,vers=5"
+	merged := mergeOptions(defaultOptsForEFS, optA, optB)
+
+	assert.Contains(t, merged, "timeo=10", "timeo should persist the right hand side value (10)")
+	assert.Contains(t, merged, "resvport")
+	assert.NotContains(t, merged, "noresvport")
+	assert.Contains(t, merged, "vers=5")
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Adds options for 'readonly' and 'additional options', meaning we can now specify read only mounts and supported nfs options.

Fixes a bug with "source directory" where a double slash would be present (ie, `//foo/bar`).

### Implementation Details
We maintain a map of supported nfs options and compare client input to the supported option list. Options provided by clients will override default values.

### Testing
Additional unit tests

New tests cover the changes: yes

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
