### PR TITLE
 Add functional tests for log router

### DIFF
--- a/agent/ecs_client/model/api/api-2.json
+++ b/agent/ecs_client/model/api/api-2.json
@@ -728,7 +728,8 @@
         "reason":{"shape":"String"},
         "networkBindings":{"shape":"NetworkBindings"},
         "networkInterfaces":{"shape":"NetworkInterfaces"},
-        "healthStatus":{"shape":"HealthStatus"}
+        "healthStatus":{"shape":"HealthStatus"},
+        "firelensConfiguration":{"shape":"FirelensConfiguration"}
       }
     },
     "ContainerCondition":{
@@ -780,7 +781,8 @@
         "logConfiguration":{"shape":"LogConfiguration"},
         "healthCheck":{"shape":"HealthCheck"},
         "systemControls":{"shape":"SystemControls"},
-        "resourceRequirements":{"shape":"ResourceRequirements"}
+        "resourceRequirements":{"shape":"ResourceRequirements"},
+        "firelensConfiguration":{"shape": "FirelensConfiguration"}
       }
     },
     "ContainerDefinitions":{
@@ -1447,8 +1449,29 @@
         "gelf",
         "fluentd",
         "awslogs",
-        "splunk"
+        "splunk",
+        "awsfirelens"
       ]
+    },
+    "FirelensConfiguration":{
+      "type":"structure",
+      "required":["type"],
+      "members":{
+        "type":{"shape":"FirelensConfigurationType"},
+        "options":{"shape":"FirelensConfigurationOptionsMap"}
+      }
+    },
+    "FirelensConfigurationType":{
+      "type":"string",
+      "enum":[
+        "fluentd",
+        "fluentbit"
+      ]
+    },
+    "FirelensConfigurationOptionsMap": {
+      "type":"map",
+      "key":{"shape":"String"},
+      "value":{"shape":"String"}
     },
     "Long":{"type":"long"},
     "MissingVersionException":{

--- a/agent/ecs_client/model/ecs/api.go
+++ b/agent/ecs_client/model/ecs/api.go
@@ -4177,6 +4177,8 @@ type Container struct {
 	// The exit code returned from the container.
 	ExitCode *int64 `locationName:"exitCode" type:"integer"`
 
+	FirelensConfiguration *FirelensConfiguration `locationName:"firelensConfiguration" type:"structure"`
+
 	// The health status of the container. If health checks are not configured for
 	// this container in its task definition, then it reports health status as UNKNOWN.
 	HealthStatus *string `locationName:"healthStatus" type:"string" enum:"HealthStatus"`
@@ -4220,6 +4222,12 @@ func (s *Container) SetContainerArn(v string) *Container {
 // SetExitCode sets the ExitCode field's value.
 func (s *Container) SetExitCode(v int64) *Container {
 	s.ExitCode = &v
+	return s
+}
+
+// SetFirelensConfiguration sets the FirelensConfiguration field's value.
+func (s *Container) SetFirelensConfiguration(v *FirelensConfiguration) *Container {
+	s.FirelensConfiguration = v
 	return s
 }
 
@@ -4431,6 +4439,8 @@ type ContainerDefinition struct {
 	//
 	// This parameter is not supported for Windows containers.
 	ExtraHosts []*HostEntry `locationName:"extraHosts" type:"list"`
+
+	FirelensConfiguration *FirelensConfiguration `locationName:"firelensConfiguration" type:"structure"`
 
 	// The health check command and associated configuration parameters for the
 	// container. This parameter maps to HealthCheck in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
@@ -4733,6 +4743,11 @@ func (s *ContainerDefinition) Validate() error {
 			}
 		}
 	}
+	if s.FirelensConfiguration != nil {
+		if err := s.FirelensConfiguration.Validate(); err != nil {
+			invalidParams.AddNested("FirelensConfiguration", err.(request.ErrInvalidParams))
+		}
+	}
 	if s.HealthCheck != nil {
 		if err := s.HealthCheck.Validate(); err != nil {
 			invalidParams.AddNested("HealthCheck", err.(request.ErrInvalidParams))
@@ -4849,6 +4864,12 @@ func (s *ContainerDefinition) SetEssential(v bool) *ContainerDefinition {
 // SetExtraHosts sets the ExtraHosts field's value.
 func (s *ContainerDefinition) SetExtraHosts(v []*HostEntry) *ContainerDefinition {
 	s.ExtraHosts = v
+	return s
+}
+
+// SetFirelensConfiguration sets the FirelensConfiguration field's value.
+func (s *ContainerDefinition) SetFirelensConfiguration(v *FirelensConfiguration) *ContainerDefinition {
+	s.FirelensConfiguration = v
 	return s
 }
 
@@ -6959,6 +6980,50 @@ func (s *Failure) SetArn(v string) *Failure {
 // SetReason sets the Reason field's value.
 func (s *Failure) SetReason(v string) *Failure {
 	s.Reason = &v
+	return s
+}
+
+type FirelensConfiguration struct {
+	_ struct{} `type:"structure"`
+
+	Options map[string]*string `locationName:"options" type:"map"`
+
+	// Type is a required field
+	Type *string `locationName:"type" type:"string" required:"true" enum:"FirelensConfigurationType"`
+}
+
+// String returns the string representation
+func (s FirelensConfiguration) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s FirelensConfiguration) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *FirelensConfiguration) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "FirelensConfiguration"}
+	if s.Type == nil {
+		invalidParams.Add(request.NewErrParamRequired("Type"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetOptions sets the Options field's value.
+func (s *FirelensConfiguration) SetOptions(v map[string]*string) *FirelensConfiguration {
+	s.Options = v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *FirelensConfiguration) SetType(v string) *FirelensConfiguration {
+	s.Type = &v
 	return s
 }
 
@@ -12354,6 +12419,14 @@ const (
 )
 
 const (
+	// FirelensConfigurationTypeFluentd is a FirelensConfigurationType enum value
+	FirelensConfigurationTypeFluentd = "fluentd"
+
+	// FirelensConfigurationTypeFluentbit is a FirelensConfigurationType enum value
+	FirelensConfigurationTypeFluentbit = "fluentbit"
+)
+
+const (
 	// HealthStatusHealthy is a HealthStatus enum value
 	HealthStatusHealthy = "HEALTHY"
 
@@ -12404,6 +12477,9 @@ const (
 
 	// LogDriverSplunk is a LogDriver enum value
 	LogDriverSplunk = "splunk"
+
+	// LogDriverAwsfirelens is a LogDriver enum value
+	LogDriverAwsfirelens = "awsfirelens"
 )
 
 const (

--- a/agent/engine/dockerstate/testutils/docker_state_equal.go
+++ b/agent/engine/dockerstate/testutils/docker_state_equal.go
@@ -16,8 +16,10 @@
 // allows this to happen
 package testutils
 
-import "github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
-import api_testutils "github.com/aws/amazon-ecs-agent/agent/api/testutils"
+import (
+	api_testutils "github.com/aws/amazon-ecs-agent/agent/api/testutils"
+	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
+)
 
 // DockerStatesEqual determines if the two given dockerstates are equal, for
 // equal meaning they have the same tasks and their tasks are equal

--- a/agent/engine/testutils/docker_task_engine_equal.go
+++ b/agent/engine/testutils/docker_task_engine_equal.go
@@ -16,8 +16,10 @@
 // allows this to happen
 package testutils
 
-import "github.com/aws/amazon-ecs-agent/agent/engine"
-import state_testutil "github.com/aws/amazon-ecs-agent/agent/engine/dockerstate/testutils"
+import (
+	"github.com/aws/amazon-ecs-agent/agent/engine"
+	state_testutil "github.com/aws/amazon-ecs-agent/agent/engine/dockerstate/testutils"
+)
 
 // DockerTaskEnginesEqual determines if the lhs and rhs task engines given are
 // equal (as defined by their state being equal)

--- a/agent/functional_tests/testdata/taskdefinitions/firelens-fluentbit/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/firelens-fluentbit/task-definition.json
@@ -1,0 +1,52 @@
+{
+  "family": "ecsftest-firelens-fluentbit",
+  "networkMode": "bridge",
+  "taskRoleArn": "$$$TASK_ROLE$$$",
+  "executionRoleArn": "$$$EXECUTION_ROLE$$$",
+  "containerDefinitions": [
+    {
+      "name": "firelens",
+      "image": "amazon/aws-for-fluent-bit:1.2.0",
+      "essential": true,
+      "memory": 256,
+      "firelensConfiguration": {
+        "type": "fluentbit"
+      },
+      "environment": [
+        {
+          "name": "FLB_LOG_LEVEL",
+          "value": "debug"
+        }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group":"ecs-functional-tests",
+          "awslogs-region":"$$$TEST_REGION$$$",
+          "awslogs-stream-prefix":"firelens-container"
+        }
+      }
+    },
+    {
+      "name": "logsender",
+      "image": "busybox:latest",
+      "essential": true,
+      "memory": 256,
+      "command": ["sh", "-c", "echo pass; echo filtered"],
+      "logConfiguration": {
+        "logDriver": "awsfirelens",
+        "options": {
+          "include-pattern": "pass",
+          "exclude-pattern": "filtered",
+          "region": "$$$TEST_REGION$$$",
+          "log_group_name": "ecs-functional-tests",
+          "log_stream_prefix": "firelens-fluentbit-"
+        },
+        "secretOptions": [{
+          "name": "$$$SECRET_OPTION_KEY$$$",
+          "valueFrom": "$$$SECRET_OPTION_PARAM$$$"
+        }]
+      }
+    }
+  ]
+}

--- a/agent/functional_tests/testdata/taskdefinitions/firelens-fluentd/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/firelens-fluentd/task-definition.json
@@ -1,0 +1,50 @@
+{
+  "family": "ecsftest-firelens-fluentd",
+  "networkMode": "bridge",
+  "taskRoleArn": "$$$TASK_ROLE$$$",
+  "executionRoleArn": "$$$EXECUTION_ROLE$$$",
+  "containerDefinitions": [
+    {
+      "name": "firelens",
+      "image": "fluentd:v1.4-2",
+      "essential": true,
+      "memory": 256,
+      "firelensConfiguration": {
+        "type": "fluentd"
+      },
+      "environment": [
+        {
+          "name": "FLUENTD_OPT",
+          "value": "-v"
+        }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group":"ecs-functional-tests",
+          "awslogs-region":"$$$TEST_REGION$$$",
+          "awslogs-stream-prefix":"firelens-fluentd",
+          "awslogs-multiline-pattern":"^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}"
+        }
+      }
+    },
+    {
+      "name": "logsender",
+      "image": "busybox:latest",
+      "essential": true,
+      "memory": 256,
+      "command": ["sh", "-c", "echo pass; echo filtered"],
+      "logConfiguration": {
+        "logDriver": "awsfirelens",
+        "options": {
+          "include-pattern": "pass",
+          "exclude-pattern": "filtered"
+        },
+        "secretOptions": [{
+          "name": "$$$SECRET_OPTION_KEY$$$",
+          "valueFrom": "$$$SECRET_OPTION_PARAM$$$"
+        }]
+      }
+    }
+  ]
+}

--- a/agent/functional_tests/tests/functionaltests_test.go
+++ b/agent/functional_tests/tests/functionaltests_test.go
@@ -769,6 +769,41 @@ func waitCloudwatchLogs(client *cloudwatchlogs.CloudWatchLogs, params *cloudwatc
 
 	return nil, fmt.Errorf("Timeout waiting for the logs to be sent to cloud watch logs")
 }
+
+func waitCloudwatchLogsWithFilter(client *cloudwatchlogs.CloudWatchLogs, params *cloudwatchlogs.FilterLogEventsInput,
+	timeout time.Duration) (*cloudwatchlogs.FilterLogEventsOutput, error) {
+	timer := time.NewTimer(timeout)
+
+	waitEventErr := make(chan error, 1)
+	cancelled := false
+
+	var output *cloudwatchlogs.FilterLogEventsOutput
+	go func() {
+		for !cancelled {
+			resp, err := client.FilterLogEvents(params)
+			if err != nil {
+				awsError, ok := err.(awserr.Error)
+				if !ok || awsError.Code() != "ResourceNotFoundException" {
+					waitEventErr <- err
+				}
+			} else if len(resp.Events) > 0 {
+				output = resp
+				waitEventErr <- nil
+				break
+			}
+			time.Sleep(time.Second)
+		}
+	}()
+
+	select{
+	case err := <- waitEventErr:
+		return output, err
+	case <-timer.C:
+		cancelled = true
+		return nil, fmt.Errorf("timeout waiting for the logs to be sent to cloudwatch logs")
+	}
+}
+
 func testV3TaskEndpoint(t *testing.T, taskName, containerName, networkMode, awslogsPrefix string) {
 	agentOptions := &AgentOptions{
 		EnableTaskENI: true,

--- a/agent/functional_tests/tests/functionaltests_unix_test.go
+++ b/agent/functional_tests/tests/functionaltests_unix_test.go
@@ -17,6 +17,7 @@ package functional_tests
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -1747,4 +1748,163 @@ func TestTrunkENIAttachDetachWorkflow(t *testing.T) {
 		}
 	}
 	assert.True(t, checkMacSucceeds)
+}
+
+// TestFirelensFluentd starts a task that has a log sender container and a firelens container with configuration type
+// as fluentd. The log sender container is configured to send logs via the firelens container. It echoes something
+// and then exits. The firelens container is configured to route the logs from the log sender container to its stdout.
+// The firelens container itself is configured to use the awslogs logging driver, so that we can examine its stdout
+// by querying cloudwatch logs.
+// Since the test is similar to TestFirelensFluentbit, the common parts of the two tests are extracted to a helper method
+// testFirelens, while the different parts are covered in getLogSenderMessageFunc.
+func TestFirelensFluentd(t *testing.T) {
+	// getLogSenderMessageFunc defines a function that specifies how to find the log sender's logs after the task
+	// finished running.
+	getLogSenderMessageFunc := func(taskID string, t *testing.T) string {
+		cwlClient := cloudwatchlogs.New(session.New(), aws.NewConfig().WithRegion(*ECS.Config.Region))
+		params := &cloudwatchlogs.FilterLogEventsInput{
+			LogGroupName:  aws.String(awslogsLogGroupName),
+			LogStreamNames: aws.StringSlice([]string{fmt.Sprintf("firelens-fluentd/firelens/%s", taskID)}),
+			// The firelens container's stdout contains both log sender's log and its own logs.
+			// Filter out the logs that belong to the firelens container itself.
+			FilterPattern: aws.String(`?"\"log\":\"pass\"" ?"\"log\":\"filtered\""`),
+		}
+
+		resp, err := waitCloudwatchLogsWithFilter(cwlClient, params, 30 * time.Second)
+		require.NoError(t, err, "CloudWatchLogs get log failed")
+
+		// Expect one message sent from the log sender.
+		assert.Equal(t, 1, len(resp.Events))
+		line := aws.StringValue(resp.Events[0].Message)
+
+		// Format of the log should be something like:
+		// Timestamp containerName-taskID: {"source":"stdout","log":"...","container_id":"...","container_name":"...","ec2_instance_id":"...","ecs_cluster":"...","ecs_task_arn":"...","ecs_task_definition":"..."}
+		// Return the last part which will be checked by the caller (testFirelens).
+		fields := strings.Split(line, " ")
+		message := fields[len(fields)-1]
+
+		return message
+	}
+
+	testFirelens(t, "fluentd", "@type", "stdout", getLogSenderMessageFunc)
+}
+
+// TestFirelensFluentbit starts a task that has a log sender container and a firelens container with configuration type
+// as fluentbit. The log sender container is configured to send logs via the firelens container. It echoes something
+// and then exits. The firelens container is configured to route the logs from the log sender container directly to
+// cloudwatch logs (with a fluentbit cloudwatch plugin that's available in the amazon/aws-for-fluent-bit container image).
+func TestFirelensFluentbit(t *testing.T) {
+	if runtime.GOARCH == "arm64" {
+		t.Skip("Skipping the test as the fluentbit image doesn't support arm right now.")
+	}
+
+	// getLogSenderMessageFunc defines a function that specifies how to find the log sender's logs after the task
+	// finished running.
+	getLogSenderMessageFunc := func(taskID string, t *testing.T) string {
+		cwlClient := cloudwatchlogs.New(session.New(), aws.NewConfig().WithRegion(*ECS.Config.Region))
+		params := &cloudwatchlogs.GetLogEventsInput{
+			LogGroupName:  aws.String(awslogsLogGroupName),
+			LogStreamName: aws.String(fmt.Sprintf("firelens-fluentbit-logsender-firelens-%s", taskID)),
+		}
+
+		// Expect one message sent from the log sender.
+		resp, err := waitCloudwatchLogs(cwlClient, params)
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(resp.Events))
+		message := aws.StringValue(resp.Events[0].Message)
+		return message
+	}
+
+	testFirelens(t, "fluentbit", "Name", "cloudwatch", getLogSenderMessageFunc)
+}
+
+func testFirelens(t *testing.T, firelensConfigType, secretLogOptionKey, secretLogOptionValue string,
+	getLogSenderMessageFunc func(string, *testing.T)string) {
+	if os.Getenv("TEST_DISABLE_EXECUTION_ROLE") == "true" {
+		t.Skip("TEST_DISABLE_EXECUTION_ROLE was set to true")
+	}
+
+	taskRoleArn := os.Getenv("TASK_IAM_ROLE_ARN")
+	if utils.ZeroOrNil(taskRoleArn) {
+		t.Skip("Skipping the test since TASK_IAM_ROLE_ARN is not set")
+	}
+
+	iid, _ := ec2.NewEC2MetadataClient(nil).InstanceIdentityDocument()
+	instanceID := iid.InstanceID
+
+	parameterName := fmt.Sprintf("FunctionalTest-FirelensLogOptionSecret-%s", firelensConfigType)
+	ssmClient := ssm.New(session.New(), aws.NewConfig().WithRegion(*ECS.Config.Region))
+	input := &ssm.PutParameterInput{
+		Description: aws.String(
+			"Resource created for the ECS Agent Functional Tests: TestFirelensFluentd and TestFirelensFluentbit"),
+		Name:        aws.String(parameterName),
+		Value:       aws.String(secretLogOptionValue),
+		Type:        aws.String("String"),
+	}
+
+	// create parameter in parameter store if it does not exist
+	_, err := ssmClient.PutParameter(input)
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			case ssm.ErrCodeParameterAlreadyExists:
+				t.Logf("Parameter %v already exists in SSM Parameter Store", parameterName)
+				break
+			default:
+				require.NoError(t, err, "SSM PutParameter call failed")
+			}
+		}
+	}
+
+	// socket path has a length limit of 108 characters on Linux. The default temp data dir used in our functional
+	// tests unfortunately causes the socket used by firelens container to be slightly longer than that. So I have
+	// to override the path to be shorter.
+	tempDirPrefix := os.Getenv("ECS_FTEST_TMP")
+	tempDir, err := ioutil.TempDir(tempDirPrefix, "")
+	agentOptions := &AgentOptions{
+		ExtraEnvironment: map[string]string{
+			"ECS_ENGINE_TASK_CLEANUP_WAIT_DURATION": "1m",
+			"ECS_AVAILABLE_LOGGING_DRIVERS": `["awslogs"]`,
+			"ECS_ENABLE_AWSLOGS_EXECUTIONROLE_OVERRIDE": "true",
+			"ECS_ENABLE_TASK_IAM_ROLE": "true",
+		},
+		TempDirOverride: tempDir,
+	}
+	os.Setenv("ECS_FTEST_FORCE_NET_HOST", "true")
+	agent := RunAgent(t, agentOptions)
+	defer agent.Cleanup()
+
+	agent.RequireVersion(">=1.30.0")
+
+	tdOverrides := make(map[string]string)
+	tdOverrides["$$$TEST_REGION$$$"] = *ECS.Config.Region
+	tdOverrides["$$$SECRET_OPTION_KEY$$$"] = secretLogOptionKey
+	tdOverrides["$$$SECRET_OPTION_PARAM$$$"] = parameterName
+	tdOverrides["$$$TASK_ROLE$$$"] = taskRoleArn
+	tdOverrides["$$$EXECUTION_ROLE$$$"] = os.Getenv("ECS_FTS_EXECUTION_ROLE")
+
+	testTask, err := agent.StartTaskWithTaskDefinitionOverrides(t, "firelens-"+firelensConfigType, tdOverrides)
+	require.NoError(t, err)
+
+	err = testTask.WaitStopped(waitTaskStateChangeDuration)
+	require.NoError(t, err)
+
+	taskID, err := GetTaskID(aws.StringValue(testTask.TaskArn))
+	require.NoError(t, err)
+	message := getLogSenderMessageFunc(taskID, t)
+
+	// Message should be like: {"source":"stdout","log":"...","container_id":"...","container_name":"...","ec2_instance_id":"...","ecs_cluster":"...","ecs_task_arn":"...","ecs_task_definition":"..."}.
+	// Verify each of the field.
+	jsonBlob := make(map[string]string)
+	err = json.Unmarshal([]byte(message), &jsonBlob)
+	require.NoError(t, err)
+
+	assert.Equal(t, "stdout", jsonBlob["source"])
+	assert.Equal(t, "pass", jsonBlob["log"])
+	assert.Contains(t, jsonBlob, "container_id")
+	assert.Contains(t, jsonBlob["container_name"], "logsender")
+	assert.Equal(t, instanceID, jsonBlob["ec2_instance_id"])
+	assert.Equal(t, agent.Cluster, jsonBlob["ecs_cluster"])
+	assert.Equal(t, *testTask.TaskArn, jsonBlob["ecs_task_arn"])
+	assert.Contains(t, *testTask.TaskDefinitionArn, jsonBlob["ecs_task_definition"])
 }

--- a/agent/functional_tests/util/utils_unix.go
+++ b/agent/functional_tests/util/utils_unix.go
@@ -113,22 +113,29 @@ func RunAgent(t *testing.T, options *AgentOptions) *TestAgent {
 		}
 	}
 
-	tmpdirOverride := os.Getenv("ECS_FTEST_TMP")
+	agentTempDir := ""
+	if options != nil && options.TempDirOverride != "" {
+		agentTempDir = options.TempDirOverride
+	} else {
+		tmpdirOverride := os.Getenv("ECS_FTEST_TMP")
 
-	agentTempdir, err := ioutil.TempDir(tmpdirOverride, "ecs_integ_testdata")
-	if err != nil {
-		t.Fatal("Could not create temp dir for test")
+		dir, err := ioutil.TempDir(tmpdirOverride, "ecs_integ_testdata")
+		if err != nil {
+			t.Fatal("Could not create temp dir for test")
+		}
+		agentTempDir = dir
 	}
-	logdir := filepath.Join(agentTempdir, "log")
-	datadir := filepath.Join(agentTempdir, "data")
+
+	logdir := filepath.Join(agentTempDir, "log")
+	datadir := filepath.Join(agentTempDir, "data")
 	os.Mkdir(logdir, 0755)
 	os.Mkdir(datadir, 0755)
-	agent.TestDir = agentTempdir
+	agent.TestDir = agentTempDir
 	agent.Options = options
 	if options == nil {
 		agent.Options = &AgentOptions{}
 	}
-	t.Logf("Created directory %s to store test data in", agentTempdir)
+	t.Logf("Created directory %s to store test data in", agentTempDir)
 
 	err = agent.StartAgent()
 	if err != nil {

--- a/agent/taskresource/firelens/firelens_unix.go
+++ b/agent/taskresource/firelens/firelens_unix.go
@@ -344,6 +344,10 @@ func (firelens *FirelensResource) Create() error {
 //  - $(DATA_DIR)/firelens/$(TASK_ID)/socket: used to store the unix socket. This directory will be mounted to
 //    the firelens container and it will generate a socket file under this directory. Containers that use firelens to
 //    send logs will then use this socket to send logs to the firelens container.
+// Note: socket path has a limit of at most 108 characters on Linux. If using default data dir, the
+// resulting socket path will be 79 characters (/var/lib/ecs/data/firelens/<task-id>/socket/fluent.sock) which is fine.
+// However if ECS_HOST_DATA_DIR is specified to be a longer path, we will exceed the limit and fail. I don't really
+// see a way to avoid this failure since ECS_HOST_DATA_DIR can be arbitrary long..
 func (firelens *FirelensResource) createDirectories() error {
 	configDir := filepath.Join(firelens.resourceDir, "config")
 	err := firelens.os.MkdirAll(configDir, os.ModePerm)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->
### Summary
<!-- What does this pull request do? -->
Add functional tests firelens. This includes two tests, one for fluentd and one for fluentbit.

### Implementation details
<!-- How are the changes implemented? -->
1. TestFirelensFluentd starts a task that has a log sender container and a firelens container with configuration type as fluentd. The log sender container is configured to send logs via the firelens container. It echoes something and then exits. The firelens container is configured to route the logs from the log sender container to its stdout. The firelens container itself is configured to use the awslogs logging driver, so that we can examine its stdout by querying cloudwatch logs.
2. TestFirelensFluentbit starts a task that has a log sender container and a firelens container with configuration type as fluentbit. The log sender container is configured to send logs via the firelens container. It echoes something and then exits. The firelens container is configured to route the logs from the log sender container directly to cloudwatch logs (with a fluentbit cloudwatch plugin that's available in the amazon/aws-for-fluent-bit container image).

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
