### PR TITLE
set containers DockerId per task

### DIFF
--- a/agent/api/container/container.go
+++ b/agent/api/container/container.go
@@ -96,6 +96,8 @@ type HealthStatus struct {
 type Container struct {
 	// Name is the name of the container specified in the task definition
 	Name string
+	// RuntimeID is the docker id of the container
+	RuntimeID string
 	// DependsOn is the field which specifies the ordering for container startup and shutdown.
 	DependsOn []DependsOn `json:"dependsOn,omitempty"`
 	// V3EndpointID is a container identifier used to construct v3 metadata endpoint; it's unique among
@@ -575,6 +577,22 @@ func (c *Container) SetLabels(labels map[string]string) {
 	defer c.lock.Unlock()
 
 	c.labels = labels
+}
+
+// SetRuntimeID sets the DockerID for a container
+func (c *Container) SetRuntimeID(RuntimeID string) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	c.RuntimeID = RuntimeID
+}
+
+// GetRuntimeID gets the DockerID for a container
+func (c *Container) GetRuntimeID() string {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	return c.RuntimeID
 }
 
 // GetLabels gets the labels for a container

--- a/agent/api/container/container_test.go
+++ b/agent/api/container/container_test.go
@@ -479,3 +479,10 @@ func TestPerContainerTimeouts(t *testing.T) {
 	assert.Equal(t, container.GetStartTimeout(), expectedTimeout)
 	assert.Equal(t, container.GetStopTimeout(), expectedTimeout)
 }
+
+func TestSetRuntimeIDInContainer(t *testing.T) {
+	container := Container{}
+	container.SetRuntimeID("asdfghjkl1234")
+	assert.Equal(t, "asdfghjkl1234", container.RuntimeID)
+	assert.Equal(t, "asdfghjkl1234", container.GetRuntimeID())
+}

--- a/agent/api/ecsclient/client_test.go
+++ b/agent/api/ecsclient/client_test.go
@@ -165,6 +165,7 @@ func TestSubmitContainerStateChange(t *testing.T) {
 			Cluster:       strptr(configuredCluster),
 			Task:          strptr("arn"),
 			ContainerName: strptr("cont"),
+			RuntimeID:     strptr("runtime id"),
 			Status:        strptr("RUNNING"),
 			NetworkBindings: []*ecs.NetworkBinding{
 				{
@@ -185,6 +186,7 @@ func TestSubmitContainerStateChange(t *testing.T) {
 	err := client.SubmitContainerStateChange(api.ContainerStateChange{
 		TaskArn:       "arn",
 		ContainerName: "cont",
+		RuntimeID:     "runtime id",
 		Status:        apicontainerstatus.ContainerRunning,
 		PortBindings: []apicontainer.PortBinding{
 			{
@@ -217,6 +219,7 @@ func TestSubmitContainerStateChangeFull(t *testing.T) {
 			Cluster:       strptr(configuredCluster),
 			Task:          strptr("arn"),
 			ContainerName: strptr("cont"),
+			RuntimeID:     strptr("runtime id"),
 			Status:        strptr("STOPPED"),
 			ExitCode:      int64ptr(&exitCode),
 			Reason:        strptr(reason),
@@ -233,6 +236,7 @@ func TestSubmitContainerStateChangeFull(t *testing.T) {
 	err := client.SubmitContainerStateChange(api.ContainerStateChange{
 		TaskArn:       "arn",
 		ContainerName: "cont",
+		RuntimeID:     "runtime id",
 		Status:        apicontainerstatus.ContainerStopped,
 		ExitCode:      &exitCode,
 		Reason:        reason,
@@ -928,6 +932,7 @@ func TestSubmitContainerStateChangeWhileTaskInPending(t *testing.T) {
 			{
 				TaskArn:       "arn",
 				ContainerName: "container",
+				RuntimeID:     "runtimeid",
 				Status:        apicontainerstatus.ContainerRunning,
 			},
 		},
@@ -946,6 +951,7 @@ func TestSubmitContainerStateChangeWhileTaskInPending(t *testing.T) {
 					Containers: []*ecs.ContainerStateChange{
 						{
 							ContainerName:   strptr("container"),
+							RuntimeID:       strptr("runtimeid"),
 							Status:          strptr("RUNNING"),
 							NetworkBindings: []*ecs.NetworkBinding{},
 						},

--- a/agent/api/statechange.go
+++ b/agent/api/statechange.go
@@ -34,6 +34,8 @@ import (
 type ContainerStateChange struct {
 	// TaskArn is the unique identifier for the task
 	TaskArn string
+	// RuntimeID is the dockerID of the container
+	RuntimeID string
 	// ContainerName is the name of the container
 	ContainerName string
 	// Status is the status to send
@@ -138,6 +140,7 @@ func NewContainerStateChangeEvent(task *apitask.Task, cont *apicontainer.Contain
 	event = ContainerStateChange{
 		TaskArn:       task.Arn,
 		ContainerName: cont.Name,
+		RuntimeID:     cont.GetRuntimeID(),
 		Status:        contKnownStatus.BackendStatus(cont.GetSteadyStateStatus()),
 		ExitCode:      cont.GetKnownExitCode(),
 		PortBindings:  cont.GetKnownPortBindings(),

--- a/agent/api/statechange_test.go
+++ b/agent/api/statechange_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 	"time"
 
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	apitaskstatus "github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	"github.com/stretchr/testify/assert"
@@ -82,4 +84,24 @@ func TestSetTaskTimestamps(t *testing.T) {
 	assert.Equal(t, t1.UTC().String(), change.PullStartedAt.String())
 	assert.Equal(t, t2.UTC().String(), change.PullStoppedAt.String())
 	assert.Equal(t, t3.UTC().String(), change.ExecutionStoppedAt.String())
+}
+
+func TestSetContainerRuntimeID(t *testing.T) {
+	task := &apitask.Task{}
+	steadyStateStatus := apicontainerstatus.ContainerRunning
+	Containers := []*apicontainer.Container{
+		{
+			RuntimeID:               "222",
+			KnownStatusUnsafe:       apicontainerstatus.ContainerRunning,
+			SentStatusUnsafe:        apicontainerstatus.ContainerStatusNone,
+			Type:                    apicontainer.ContainerNormal,
+			SteadyStateStatusUnsafe: &steadyStateStatus,
+		},
+	}
+
+	task.Containers = Containers
+	resp, ok := NewContainerStateChangeEvent(task, task.Containers[0], "")
+
+	assert.NoError(t, ok, "error create newContainerStateChangeEvent")
+	assert.Equal(t, "222", resp.RuntimeID)
 }

--- a/agent/ecs_client/model/api/api-2.json
+++ b/agent/ecs_client/model/api/api-2.json
@@ -723,6 +723,7 @@
         "containerArn":{"shape":"String"},
         "taskArn":{"shape":"String"},
         "name":{"shape":"String"},
+        "runtimeId":{"shape": "String"},
         "lastStatus":{"shape":"String"},
         "exitCode":{"shape":"BoxedInteger"},
         "reason":{"shape":"String"},
@@ -856,6 +857,7 @@
       "type":"structure",
       "members":{
         "containerName":{"shape":"String"},
+        "runtimeId":{"shape": "String"},
         "exitCode":{"shape":"BoxedInteger"},
         "networkBindings":{"shape":"NetworkBindings"},
         "reason":{"shape":"String"},
@@ -1975,6 +1977,7 @@
         "cluster":{"shape":"String"},
         "task":{"shape":"String"},
         "containerName":{"shape":"String"},
+        "runtimeId":{"shape": "String"},
         "status":{"shape":"String"},
         "exitCode":{"shape":"BoxedInteger"},
         "reason":{"shape":"String"},

--- a/agent/ecs_client/model/ecs/api.go
+++ b/agent/ecs_client/model/ecs/api.go
@@ -4197,6 +4197,9 @@ type Container struct {
 	// details about a running or stopped container.
 	Reason *string `locationName:"reason" type:"string"`
 
+	// The RuntimeID of the container
+	RuntimeID *string `locationName:"runtimeId" type:"string"`
+
 	// The ARN of the task.
 	TaskArn *string `locationName:"taskArn" type:"string"`
 }
@@ -4256,6 +4259,12 @@ func (s *Container) SetNetworkInterfaces(v []*NetworkInterface) *Container {
 // SetReason sets the Reason field's value.
 func (s *Container) SetReason(v string) *Container {
 	s.Reason = &v
+	return s
+}
+
+// SetRuntimeID sets the RuntimeID field's value.
+func (s *Container) SetRuntimeID(v string) *Container {
+	s.RuntimeID = &v
 	return s
 }
 
@@ -5355,6 +5364,9 @@ type ContainerStateChange struct {
 	// The reason for the state change.
 	Reason *string `locationName:"reason" type:"string"`
 
+	// The docker ID of the container
+	RuntimeID *string `locationName:"runtimeId" type:"string"`
+
 	// The status of the container.
 	Status *string `locationName:"status" type:"string"`
 }
@@ -5390,6 +5402,12 @@ func (s *ContainerStateChange) SetNetworkBindings(v []*NetworkBinding) *Containe
 // SetReason sets the Reason field's value.
 func (s *ContainerStateChange) SetReason(v string) *ContainerStateChange {
 	s.Reason = &v
+	return s
+}
+
+// SetRuntimeID sets the RuntimeID field's value.
+func (s *ContainerStateChange) SetRuntimeID(v string) *ContainerStateChange {
+	s.RuntimeID = &v
 	return s
 }
 
@@ -10654,6 +10672,9 @@ type SubmitContainerStateChangeInput struct {
 	// The reason for the state change request.
 	Reason *string `locationName:"reason" type:"string"`
 
+	// The Docker ID of the container
+	RuntimeID *string `locationName:"runtimeId" type:"string"`
+
 	// The status of the state change request.
 	Status *string `locationName:"status" type:"string"`
 
@@ -10699,6 +10720,12 @@ func (s *SubmitContainerStateChangeInput) SetNetworkBindings(v []*NetworkBinding
 // SetReason sets the Reason field's value.
 func (s *SubmitContainerStateChangeInput) SetReason(v string) *SubmitContainerStateChangeInput {
 	s.Reason = &v
+	return s
+}
+
+// SetRuntimeID sets the RuntimeID field's value.
+func (s *SubmitContainerStateChangeInput) SetRuntimeID(v string) *SubmitContainerStateChangeInput {
+	s.RuntimeID = &v
 	return s
 }
 

--- a/agent/engine/common_integ_test.go
+++ b/agent/engine/common_integ_test.go
@@ -62,11 +62,29 @@ func verifyContainerRunningStateChange(t *testing.T, taskEngine TaskEngine) {
 		"Expected container to be RUNNING")
 }
 
+func verifyContainerRunningStateChangeWithRuntimeID(t *testing.T, taskEngine TaskEngine) {
+	stateChangeEvents := taskEngine.StateChangeEvents()
+	event := <-stateChangeEvents
+	assert.Equal(t, event.(api.ContainerStateChange).Status, apicontainerstatus.ContainerRunning,
+		"Expected container to be RUNNING")
+	assert.NotEqual(t, "", event.(api.ContainerStateChange).RuntimeID,
+		"Expected container runtimeID should not empty")
+}
+
 func verifyContainerStoppedStateChange(t *testing.T, taskEngine TaskEngine) {
 	stateChangeEvents := taskEngine.StateChangeEvents()
 	event := <-stateChangeEvents
 	assert.Equal(t, event.(api.ContainerStateChange).Status, apicontainerstatus.ContainerStopped,
 		"Expected container to be STOPPED")
+}
+
+func verifyContainerStoppedStateChangeWithRuntimeID(t *testing.T, taskEngine TaskEngine) {
+	stateChangeEvents := taskEngine.StateChangeEvents()
+	event := <-stateChangeEvents
+	assert.Equal(t, event.(api.ContainerStateChange).Status, apicontainerstatus.ContainerStopped,
+		"Expected container to be STOPPED")
+	assert.NotEqual(t, "", event.(api.ContainerStateChange).RuntimeID,
+		"Expected container runtimeID should not empty")
 }
 
 func setup(cfg *config.Config, state dockerstate.TaskEngineState, t *testing.T) (TaskEngine, func(), credentials.Manager) {

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -942,6 +942,7 @@ func (engine *DockerTaskEngine) createContainer(task *apitask.Task, container *a
 	container.SetLabels(config.Labels)
 	seelog.Infof("Task engine [%s]: created docker container for task: %s -> %s, took %s",
 		task.Arn, container.Name, metadata.DockerID, time.Since(createContainerBegin))
+	container.SetRuntimeID(metadata.DockerID)
 	return metadata
 }
 

--- a/agent/engine/engine_integ_test.go
+++ b/agent/engine/engine_integ_test.go
@@ -82,11 +82,29 @@ func verifyTaskRunningStateChange(t *testing.T, taskEngine TaskEngine) {
 		"Expected task to be RUNNING")
 }
 
+func verifyTaskRunningStateChangeWithRuntimeID(t *testing.T, taskEngine TaskEngine) {
+	stateChangeEvents := taskEngine.StateChangeEvents()
+	event := <-stateChangeEvents
+	assert.Equal(t, event.(api.TaskStateChange).Status, apitaskstatus.TaskRunning,
+		"Expected task to be RUNNING")
+	assert.NotEqualf(t, "", event.(api.TaskStateChange).Task.Containers[0].RuntimeID,
+		"Expected task with runtimeID per container should not empty when Running")
+}
+
 func verifyTaskStoppedStateChange(t *testing.T, taskEngine TaskEngine) {
 	stateChangeEvents := taskEngine.StateChangeEvents()
 	event := <-stateChangeEvents
 	assert.Equal(t, event.(api.TaskStateChange).Status, apitaskstatus.TaskStopped,
 		"Expected task to be STOPPED")
+}
+
+func verifyTaskStoppedStateChangeWithRuntimeID(t *testing.T, taskEngine TaskEngine) {
+	stateChangeEvents := taskEngine.StateChangeEvents()
+	event := <-stateChangeEvents
+	assert.Equal(t, event.(api.TaskStateChange).Status, apitaskstatus.TaskStopped,
+		"Expected task to be STOPPED")
+	assert.NotEqual(t, "", event.(api.TaskStateChange).Task.Containers[0].RuntimeID,
+		"Expected task with runtimeID per container should not empty when stopped")
 }
 
 func dialWithRetries(proto string, address string, tries int, timeout time.Duration) (net.Conn, error) {
@@ -262,6 +280,20 @@ func TestStartStopWithCredentials(t *testing.T) {
 	// credentials id set in the task
 	_, ok := credentialsManager.GetTaskCredentials(credentialsIDIntegTest)
 	assert.False(t, ok, "Credentials not removed from credentials manager for stopped task")
+}
+
+// TestStartStopWithRuntimeID starts and stops a task for which runtimeID has been set.
+func TestStartStopWithRuntimeID(t *testing.T) {
+	taskEngine, done, _ := setupWithDefaultConfig(t)
+	defer done()
+
+	testTask := createTestTask("testTaskWithContainerID")
+	go taskEngine.AddTask(testTask)
+
+	verifyContainerRunningStateChangeWithRuntimeID(t, taskEngine)
+	verifyTaskRunningStateChangeWithRuntimeID(t, taskEngine)
+	verifyContainerStoppedStateChangeWithRuntimeID(t, taskEngine)
+	verifyTaskStoppedStateChangeWithRuntimeID(t, taskEngine)
 }
 
 func TestTaskStopWhenPullImageFail(t *testing.T) {

--- a/agent/statemanager/state_manager.go
+++ b/agent/statemanager/state_manager.go
@@ -87,8 +87,9 @@ const (
 	// 	 a) Add 'attachmentType' field to 'api.ENIAttachment'
 	//	 b) Add 'InterfaceAssociationProtocol' field to 'api.ENI'
 	//	 c) Add 'InterfaceVlanProperties' field to 'api.ENI'
+	// 23) Add 'RuntimeID' field to 'apicontainer.Container'
 
-	ECSDataVersion = 22
+	ECSDataVersion = 23
 
 	// ecsDataFile specifies the filename in the ECS_DATADIR
 	ecsDataFile = "ecs_agent_data.json"

--- a/agent/statemanager/state_manager_test.go
+++ b/agent/statemanager/state_manager_test.go
@@ -397,3 +397,34 @@ func TestLoadsDataForPerContainerTimeouts(t *testing.T) {
 	assert.Equal(t, uint(10), c1.StartTimeout)
 	assert.Equal(t, uint(10), c1.StopTimeout)
 }
+
+func TestLoadsDataForContainerRuntimeID(t *testing.T) {
+	cleanup, err := setupWindowsTest(filepath.Join(".", "testdata", "v23", "perContainerRuntimeID", "ecs_agent_data.json"))
+	require.Nil(t, err, "Failed to set up test")
+	defer cleanup()
+	cfg := &config.Config{DataDir: filepath.Join(".", "testdata", "v23", "perContainerRuntimeID")}
+	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil)
+	var containerInstanceArn, cluster, savedInstanceID string
+	var sequenceNumber int64
+	stateManager, err := statemanager.NewStateManager(cfg,
+		statemanager.AddSaveable("TaskEngine", taskEngine),
+		statemanager.AddSaveable("ContainerInstanceArn", &containerInstanceArn),
+		statemanager.AddSaveable("Cluster", &cluster),
+		statemanager.AddSaveable("EC2InstanceID", &savedInstanceID),
+		statemanager.AddSaveable("SeqNum", &sequenceNumber),
+	)
+	assert.NoError(t, err)
+	err = stateManager.Load()
+	assert.NoError(t, err)
+	tasks, err := taskEngine.ListTasks()
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(tasks))
+	assert.Equal(t, "state-file", cluster)
+	assert.EqualValues(t, 0, sequenceNumber)
+
+	task := tasks[0]
+	assert.Equal(t, "arn:aws:ecs:us-west-2:984736093387:task/70947c96-f64e-483a-a612-3fd4303546e7", task.Arn)
+	assert.Equal(t, "sleep360", task.Family)
+	assert.Equal(t, 1, len(task.Containers))
+	assert.Equal(t, "c6b1ea1004c6de778bdc4c00bc15085ef16b4b259f7dfc198a0a36b6629a7f90", task.Containers[0].RuntimeID)
+}

--- a/agent/statemanager/testdata/v23/perContainerRuntimeID/ecs_agent_data.json
+++ b/agent/statemanager/testdata/v23/perContainerRuntimeID/ecs_agent_data.json
@@ -1,0 +1,155 @@
+{
+  "Data": {
+    "Cluster": "state-file",
+    "ContainerInstanceArn": "arn:aws:ecs:us-west-2:984736093387:container-instance/ea27e41b-c6e4-45a9-a7a0-484c95abece7",
+    "EC2InstanceID": "i-0e38e94fed89f598f",
+    "TaskEngine": {
+      "Tasks": [
+        {
+          "Arn": "arn:aws:ecs:us-west-2:984736093387:task/70947c96-f64e-483a-a612-3fd4303546e7",
+          "Family": "sleep360",
+          "Version": "6",
+          "Containers": [
+            {
+              "Name": "sleep",
+              "RuntimeID": "c6b1ea1004c6de778bdc4c00bc15085ef16b4b259f7dfc198a0a36b6629a7f90",
+              "V3EndpointID": "6d4b6283-452e-42ef-bafc-7e7f5a6dac99",
+              "Image": "busybox",
+              "ImageID": "sha256:db8ee88ad75f6bdc74663f4992a185e2722fa29573abcc1a19186cc5ec09dceb",
+              "Command": [
+                "sleep",
+                "360"
+              ],
+              "Cpu": 10,
+              "GPUIDs": null,
+              "Memory": 100,
+              "Links": null,
+              "volumesFrom": [],
+              "mountPoints": [],
+              "portMappings": [],
+              "secrets": null,
+              "Essential": true,
+              "EntryPoint": null,
+              "environment": {
+                "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI": "/v2/credentials/16105516-51c7-41a2-ad8a-ba7411f309a0",
+                "AWS_EXECUTION_ENV": "AWS_ECS_EC2",
+                "ECS_CONTAINER_METADATA_URI": "http://169.254.170.2/v3/6d4b6283-452e-42ef-bafc-7e7f5a6dac99"
+              },
+              "overrides": {
+                "command": null
+              },
+              "dockerConfig": {
+                "config": "{}",
+                "hostConfig": "{\"CapAdd\":[],\"CapDrop\":[]}",
+                "version": "1.17"
+              },
+              "registryAuthentication": null,
+              "LogsAuthStrategy": "",
+              "StartTimeout": 0,
+              "StopTimeout": 0,
+              "desiredStatus": "RUNNING",
+              "KnownStatus": "RUNNING",
+              "RunDependencies": null,
+              "IsInternal": "NORMAL",
+              "ApplyingError": null,
+              "SentStatus": "RUNNING",
+              "metadataFileUpdated": false,
+              "KnownExitCode": null,
+              "KnownPortBindings": null
+            }
+          ],
+          "associations": [],
+          "volumes": [],
+          "DesiredStatus": "RUNNING",
+          "KnownStatus": "RUNNING",
+          "KnownTime": "2019-08-06T21:59:04.217198554Z",
+          "PullStartedAt": "2019-08-06T21:59:01.88671907Z",
+          "PullStoppedAt": "2019-08-06T21:59:03.799514307Z",
+          "ExecutionStoppedAt": "0001-01-01T00:00:00Z",
+          "SentStatus": "RUNNING",
+          "StartSequenceNumber": 2,
+          "StopSequenceNumber": 0,
+          "executionCredentialsID": "",
+          "ENI": null,
+          "AppMesh": null,
+          "MemoryCPULimitsEnabled": true,
+          "PlatformFields": {}
+        }
+      ],
+      "IdToContainer": {
+        "c6b1ea1004c6de778bdc4c00bc15085ef16b4b259f7dfc198a0a36b6629a7f90": {
+          "DockerId": "c6b1ea1004c6de778bdc4c00bc15085ef16b4b259f7dfc198a0a36b6629a7f90",
+          "DockerName": "ecs-sleep360-6-sleep-a2b4d9d6ef938afc6f00",
+          "Container": {
+            "Name": "sleep",
+            "RuntimeID": "c6b1ea1004c6de778bdc4c00bc15085ef16b4b259f7dfc198a0a36b6629a7f90",
+            "V3EndpointID": "6d4b6283-452e-42ef-bafc-7e7f5a6dac99",
+            "Image": "busybox",
+            "ImageID": "sha256:db8ee88ad75f6bdc74663f4992a185e2722fa29573abcc1a19186cc5ec09dceb",
+            "Command": [
+              "sleep",
+              "360"
+            ],
+            "Cpu": 10,
+            "GPUIDs": null,
+            "Memory": 100,
+            "Links": null,
+            "volumesFrom": [],
+            "mountPoints": [],
+            "portMappings": [],
+            "secrets": null,
+            "Essential": true,
+            "EntryPoint": null,
+            "environment": {
+              "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI": "/v2/credentials/16105516-51c7-41a2-ad8a-ba7411f309a0",
+              "AWS_EXECUTION_ENV": "AWS_ECS_EC2",
+              "ECS_CONTAINER_METADATA_URI": "http://169.254.170.2/v3/6d4b6283-452e-42ef-bafc-7e7f5a6dac99"
+            },
+            "overrides": {
+              "command": null
+            },
+            "dockerConfig": {
+              "config": "{}",
+              "hostConfig": "{\"CapAdd\":[],\"CapDrop\":[]}",
+              "version": "1.17"
+            },
+            "registryAuthentication": null,
+            "LogsAuthStrategy": "",
+            "StartTimeout": 0,
+            "StopTimeout": 0,
+            "desiredStatus": "RUNNING",
+            "KnownStatus": "RUNNING",
+            "RunDependencies": null,
+            "IsInternal": "NORMAL",
+            "ApplyingError": null,
+            "SentStatus": "RUNNING",
+            "metadataFileUpdated": false,
+            "KnownExitCode": null,
+            "KnownPortBindings": null
+          }
+        }
+      },
+      "IdToTask": {
+        "c6b1ea1004c6de778bdc4c00bc15085ef16b4b259f7dfc198a0a36b6629a7f90": "arn:aws:ecs:us-west-2:984736093387:task/70947c96-f64e-483a-a612-3fd4303546e7"
+      },
+      "ImageStates": [
+        {
+          "Image": {
+            "ImageID": "sha256:db8ee88ad75f6bdc74663f4992a185e2722fa29573abcc1a19186cc5ec09dceb",
+            "Names": [
+              "busybox"
+            ],
+            "Size": 1223894
+          },
+          "PulledAt": "2019-08-06T21:59:03.797764725Z",
+          "LastUsedAt": "2019-08-06T21:59:03.797764824Z",
+          "PullSucceeded": true
+        }
+      ],
+      "ENIAttachments": null,
+      "IPToTask": {}
+    },
+    "availabilityZone": "us-west-2b"
+  },
+  "Version": 23
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
expose container dockerId per task 
### Implementation details
<!-- How are the changes implemented? -->
update container runtimeId attribute to container and containerStatechange struct. 
set containerDockerId when container is created.
### Testing
<!-- How was this tested? -->

<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
