### PR TITLE
Updating capabilities names to include 'Firelens'

### DIFF
--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -49,9 +49,9 @@ const (
 	taskEIAAttributeSuffix                      = "task-eia"
 	taskENITrunkingAttributeSuffix              = "task-eni-trunking"
 	branchCNIPluginVersionSuffix                = "branch-cni-plugin-version"
-	capabilityAWSRouterFluentd                  = "awsrouter.fluentd"
-	capabilityAWSRouterFluentbit                = "awsrouter.fluentbit"
-	capabilityAWSRouterLoggingDriver            = "logging-driver.awsrouter"
+	capabilityFirelensFluentd                   = "firelens.fluentd"
+	capabilityFirelensFluentbit                 = "firelens.fluentbit"
+	capabilityFirelensLoggingDriver             = "logging-driver.awsfirelens"
 )
 
 // capabilities returns the supported capabilities of this agent / docker-client pair.
@@ -89,9 +89,9 @@ const (
 //    ecs.capability.aws-appmesh
 //    ecs.capability.task-eia
 //    ecs.capability.task-eni-trunking
-//    ecs.capability.awsrouter.fluentd
-//    ecs.capability.awsrouter.fluentbit
-//    com.amazonaws.ecs.capability.logging-driver.awsrouter
+//    ecs.capability.firelens.fluentd
+//    ecs.capability.firelens.fluentbit
+//    com.amazonaws.ecs.capability.logging-driver.awsfirelens
 func (agent *ecsAgent) capabilities() ([]*ecs.Attribute, error) {
 	var capabilities []*ecs.Attribute
 
@@ -171,13 +171,13 @@ func (agent *ecsAgent) capabilities() ([]*ecs.Attribute, error) {
 	capabilities = agent.appendTaskEIACapabilities(capabilities)
 
 	// support aws router capabilities for fluentd
-	capabilities = agent.appendAWSRouterFluentdCapabilities(capabilities)
+	capabilities = agent.appendFirelensFluentdCapabilities(capabilities)
 
 	// support aws router capabilities for fluentbit
-	capabilities = agent.appendAWSRouterFluentbitCapabilities(capabilities)
+	capabilities = agent.appendFirelensFluentbitCapabilities(capabilities)
 
 	// support aws router capabilities for log driver router
-	capabilities = agent.appendAWSLoggingDriverCapabilities(capabilities)
+	capabilities = agent.appendFirelensLoggingDriverCapabilities(capabilities)
 
 	return capabilities, nil
 }

--- a/agent/app/agent_capability_unix.go
+++ b/agent/app/agent_capability_unix.go
@@ -82,9 +82,7 @@ func (agent *ecsAgent) appendENITrunkingCapabilities(capabilities []*ecs.Attribu
 	if !agent.cfg.ENITrunkingEnabled {
 		return capabilities
 	}
-
 	capabilities = appendNameOnlyAttribute(capabilities, attributePrefix+taskENITrunkingAttributeSuffix)
-
 	return agent.appendBranchENIPluginVersionAttribute(capabilities)
 }
 
@@ -115,14 +113,14 @@ func (agent *ecsAgent) appendTaskEIACapabilities(capabilities []*ecs.Attribute) 
 	return appendNameOnlyAttribute(capabilities, attributePrefix+taskEIAAttributeSuffix)
 }
 
-func (agent *ecsAgent) appendAWSRouterFluentdCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
-	return appendNameOnlyAttribute(capabilities, attributePrefix+capabilityAWSRouterFluentd)
+func (agent *ecsAgent) appendFirelensFluentdCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
+	return appendNameOnlyAttribute(capabilities, attributePrefix+capabilityFirelensFluentd)
 }
 
-func (agent *ecsAgent) appendAWSRouterFluentbitCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
-	return appendNameOnlyAttribute(capabilities, attributePrefix+capabilityAWSRouterFluentbit)
+func (agent *ecsAgent) appendFirelensFluentbitCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
+	return appendNameOnlyAttribute(capabilities, attributePrefix+capabilityFirelensFluentbit)
 }
 
-func (agent *ecsAgent) appendAWSLoggingDriverCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
-	return appendNameOnlyAttribute(capabilities, capabilityPrefix+capabilityAWSRouterLoggingDriver)
+func (agent *ecsAgent) appendFirelensLoggingDriverCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
+	return appendNameOnlyAttribute(capabilities, capabilityPrefix+capabilityFirelensLoggingDriver)
 }

--- a/agent/app/agent_capability_unix_test.go
+++ b/agent/app/agent_capability_unix_test.go
@@ -715,7 +715,6 @@ func TestTaskEIACapabilitiesUnix(t *testing.T) {
 func TestAWSLoggingDriverAndLogRouterCapabilitiesUnix(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
-
 	client := mock_dockerapi.NewMockDockerClient(ctrl)
 	mockMobyPlugins := mock_mobypkgwrapper.NewMockPlugins(ctrl)
 	mockCredentialsProvider := app_mocks.NewMockProvider(ctrl)
@@ -781,13 +780,13 @@ func TestAWSLoggingDriverAndLogRouterCapabilitiesUnix(t *testing.T) {
 				Name: aws.String(attributePrefix + taskEIAAttributeSuffix),
 			},
 			{
-				Name: aws.String(attributePrefix + capabilityAWSRouterFluentd),
+				Name: aws.String(attributePrefix + capabilityFirelensFluentd),
 			},
 			{
-				Name: aws.String(attributePrefix + capabilityAWSRouterFluentbit),
+				Name: aws.String(attributePrefix + capabilityFirelensFluentbit),
 			},
 			{
-				Name: aws.String(capabilityPrefix + capabilityAWSRouterLoggingDriver),
+				Name: aws.String(capabilityPrefix + capabilityFirelensLoggingDriver),
 			},
 		}...)
 	ctx, cancel := context.WithCancel(context.TODO())

--- a/agent/app/agent_capability_unspecified.go
+++ b/agent/app/agent_capability_unspecified.go
@@ -86,14 +86,14 @@ func (agent *ecsAgent) appendTaskEIACapabilities(capabilities []*ecs.Attribute) 
 	return capabilities
 }
 
-func (agent *ecsAgent) appendAWSRouterFluentdCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
+func (agent *ecsAgent) appendFirelensFluentdCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
 	return capabilities
 }
 
-func (agent *ecsAgent) appendAWSRouterFluentbitCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
+func (agent *ecsAgent) appendFirelensFluentbitCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
 	return capabilities
 }
 
-func (agent *ecsAgent) appendAWSLoggingDriverCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
+func (agent *ecsAgent) appendFirelensLoggingDriverCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
 	return capabilities
 }

--- a/agent/app/agent_capability_windows.go
+++ b/agent/app/agent_capability_windows.go
@@ -45,14 +45,14 @@ func (agent *ecsAgent) appendTaskEIACapabilities(capabilities []*ecs.Attribute) 
 	return capabilities
 }
 
-func (agent *ecsAgent) appendAWSRouterFluentdCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
+func (agent *ecsAgent) appendFirelensFluentdCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
 	return capabilities
 }
 
-func (agent *ecsAgent) appendAWSRouterFluentbitCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
+func (agent *ecsAgent) appendFirelensFluentbitCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
 	return capabilities
 }
 
-func (agent *ecsAgent) appendAWSLoggingDriverCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
+func (agent *ecsAgent) appendFirelensLoggingDriverCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
 	return capabilities
 }


### PR DESCRIPTION
Changing the capabilities to the new ones that were approved.

Summary
Implementation details
Testing
Ran
docker run -v /var/run/docker.sock:/var/run/docker.sock amazon/amazon-ecs-agent --ecs-attributes
To see the capabilities being updated.
ecs.capability.task-eia
ecs.capability.firelens.fluentd
ecs.capability.firelens.fluentbit
com.amazonaws.ecs.capability.logging-driver.awsfirelens

New tests cover the changes:

Description for the changelog
Licensing
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.