### PR TITLE
 Adjust firelens default behaviors

### DIFF
--- a/agent/api/container/container.go
+++ b/agent/api/container/container.go
@@ -900,3 +900,28 @@ func (c *Container) GetStopTimeout() time.Duration {
 
 	return time.Duration(c.StopTimeout) * time.Second
 }
+
+// DependsOnContainer checks whether a container depends on another container.
+func (c *Container) DependsOnContainer(name string) bool {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	for _, dependsOn := range c.DependsOn {
+		if dependsOn.ContainerName == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+// AddContainerDependency adds a container dependency to a container.
+func (c *Container) AddContainerDependency(name string, condition string) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	c.DependsOn = append(c.DependsOn, DependsOn{
+		ContainerName: name,
+		Condition:     condition,
+	})
+}

--- a/agent/api/container/container_test.go
+++ b/agent/api/container/container_test.go
@@ -479,3 +479,59 @@ func TestPerContainerTimeouts(t *testing.T) {
 	assert.Equal(t, container.GetStartTimeout(), expectedTimeout)
 	assert.Equal(t, container.GetStopTimeout(), expectedTimeout)
 }
+
+func TestDependsOnContainer(t *testing.T) {
+	testCases := []struct {
+		name          string
+		container     *Container
+		dependsOnName string
+		dependsOn     bool
+	}{
+		{
+			name: "test DependsOnContainer positive case",
+			container: &Container{
+				Name: "container1",
+				DependsOn: []DependsOn{
+					{
+						ContainerName: "container2",
+						Condition:     "START",
+					},
+				},
+			},
+			dependsOnName: "container2",
+			dependsOn:     true,
+		},
+		{
+			name: "test DependsOnContainer negative case",
+			container: &Container{
+				Name: "container1",
+				DependsOn: []DependsOn{
+					{
+						ContainerName: "container2",
+						Condition:     "START",
+					},
+				},
+			},
+			dependsOnName: "container0",
+			dependsOn:     false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.dependsOn, tc.container.DependsOnContainer(tc.dependsOnName))
+		})
+	}
+}
+
+func TestAddContainerDependency(t *testing.T) {
+	container := &Container{
+		Name: "container1",
+	}
+	container.AddContainerDependency("container2", "START")
+
+	assert.Contains(t, container.DependsOn, DependsOn{
+		ContainerName: "container2",
+		Condition:     "START",
+	})
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->
### Summary
<!-- What does this pull request do? -->
Adjust firelens default behaviors. This includes:
1. Add a START dependency between each log sender container and the firelens container if there's no dependency between them.
2. Enable appending ecs metadata to log stream by default.

### Implementation details
<!-- How are the changes implemented? -->
Implemented in PostUnmarshalTask and its callees.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Added unit tests. Manually ran tasks against gamma and verified that the firelens container starts first and ecs metadata is enabled.

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
