### PR TITLE
Support secret log options for firelens

### DIFF
--- a/agent/api/container/container_test.go
+++ b/agent/api/container/container_test.go
@@ -415,56 +415,96 @@ func TestShouldCreateWithASMSecret(t *testing.T) {
 	}
 }
 
-func TestHasSecretAsEnvOrLogDriver(t *testing.T) {
-	cases := []struct {
-		in  Container
-		out bool
+func TestHasSecret(t *testing.T) {
+	isEnvOrLogDriverSecret := func(s Secret) bool {
+		return s.Type == SecretTypeEnv || s.Target == SecretTargetLogDriver
+	}
+	isSSMLogDriverSecret := func(s Secret) bool {
+		return s.Provider == SecretProviderSSM && s.Target == SecretTargetLogDriver
+	}
+
+	testCases := []struct {
+		name    string
+		f       func(s Secret) bool
+		secrets []Secret
+		res     bool
 	}{
-		{Container{
-			Name:  "myName",
-			Image: "image:tag",
-			Secrets: []Secret{
-				Secret{
+		{
+			name: "test env secret",
+			f:    isEnvOrLogDriverSecret,
+			secrets: []Secret{
+				{
 					Provider:  "asm",
 					Name:      "secret",
 					Type:      "ENVIRONMENT_VARIABLE",
 					ValueFrom: "/test/secretName",
 				}},
-		}, true},
-		{Container{
-			Name:    "myName",
-			Image:   "image:tag",
-			Secrets: nil,
-		}, false},
-		{Container{
-			Name:  "myName",
-			Image: "image:tag",
-			Secrets: []Secret{
-				Secret{
+			res: true,
+		},
+		{
+			name: "test no secret",
+			f:    isEnvOrLogDriverSecret,
+		},
+		{
+			name: "test mount point secret",
+			f:    isEnvOrLogDriverSecret,
+			secrets: []Secret{
+				{
 					Provider:  "asm",
 					Name:      "secret",
 					Type:      "MOUNT_POINT",
 					ValueFrom: "/test/secretName",
 				}},
-		}, false},
-		{Container{
-			Name:  "myName",
-			Image: "image:tag",
-			Secrets: []Secret{
-				Secret{
+			res: false,
+		},
+		{
+			name: "test log driver secret",
+			f:    isEnvOrLogDriverSecret,
+			secrets: []Secret{
+				{
 					Provider:  "asm",
 					Name:      "splunk-token",
 					ValueFrom: "/test/secretName",
 					Target:    "LOG_DRIVER",
 				}},
-		}, true},
+			res: true,
+		},
+		{
+			name: "test secret provider ssm",
+			f:    isSSMLogDriverSecret,
+			secrets: []Secret{
+				{
+					Name:     "secret",
+					Provider: SecretProviderSSM,
+					Target:   SecretTargetLogDriver,
+				},
+			},
+			res: true,
+		},
+		{
+			name: "test wrong secret provider",
+			f:    isSSMLogDriverSecret,
+			secrets: []Secret{
+				{
+					Name:     "secret",
+					Provider: "dummy",
+					Target:   SecretTargetLogDriver,
+				},
+			},
+			res: false,
+		},
 	}
 
-	for _, test := range cases {
-		container := test.in
-		assert.Equal(t, test.out, container.HasSecretAsEnvOrLogDriver())
-	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &Container{
+				Name:    "c",
+				Secrets: tc.secrets,
+			}
 
+			assert.Equal(t, tc.res, c.HasSecret(tc.f))
+		})
+	}
 }
 
 func TestPerContainerTimeouts(t *testing.T) {
@@ -534,4 +574,37 @@ func TestAddContainerDependency(t *testing.T) {
 		ContainerName: "container2",
 		Condition:     "START",
 	})
+}
+
+func TestGetLogDriver(t *testing.T) {
+	getContainer := func(hostConfig string) *Container {
+		c := &Container{
+			Name: "c",
+		}
+		c.DockerConfig.HostConfig = &hostConfig
+		return c
+	}
+
+	testCases := []struct {
+		name      string
+		container *Container
+		logDriver string
+	}{
+		{
+			name:      "positive case",
+			container: getContainer(`{"LogConfig":{"Type":"logdriver"}}`),
+			logDriver: "logdriver",
+		},
+		{
+			name:      "negative case",
+			container: getContainer("invalid"),
+			logDriver: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.logDriver, tc.container.GetLogDriver())
+		})
+	}
 }

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -107,6 +107,14 @@ const (
 	// firelensDriverName is the log driver name for containers that want to use the firelens container to send logs.
 	firelensDriverName = "awsfirelens"
 
+	// firelensConfigVarFmt specifies the format for firelens config variable name. The first placeholder
+	// is option name. The second placeholder is container name.
+	firelensConfigVarFmt = "%s_%s"
+	// firelensConfigVarPlaceholderFmtFluentd and firelensConfigVarPlaceholderFmtFluentbit specify the config var
+	// placeholder format expected by fluentd and fluentbit respectively.
+	firelensConfigVarPlaceholderFmtFluentd   = "\"#{ENV['%s']}\""
+	firelensConfigVarPlaceholderFmtFluentbit = "${%s}"
+
 	// awsExecutionEnvKey is the key of the env specifying the execution environment.
 	awsExecutionEnvKey = "AWS_EXECUTION_ENV"
 	// ec2ExecutionEnv specifies the ec2 execution environment.
@@ -324,14 +332,19 @@ func (task *Task) PostUnmarshalTask(cfg *config.Config,
 	// Adds necessary Pause containers for sharing PID or IPC namespaces
 	task.addNamespaceSharingProvisioningDependency(cfg)
 
-	if task.hasFirelensContainer() {
-		return task.applyFirelensSetup(cfg, resourceFields)
+	firelensContainer := task.getFirelensContainer()
+	if firelensContainer != nil {
+		err = task.applyFirelensSetup(cfg, resourceFields, firelensContainer)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }
 
-func (task *Task) applyFirelensSetup(cfg *config.Config, resourceFields *taskresource.ResourceFields) error {
-	err := task.initializeFirelensResource(cfg, resourceFields)
+func (task *Task) applyFirelensSetup(cfg *config.Config, resourceFields *taskresource.ResourceFields,
+	firelensContainer *apicontainer.Container) error {
+	err := task.initializeFirelensResource(cfg, resourceFields, firelensContainer)
 	if err != nil {
 		return apierrors.NewResourceInitError(task.Arn, err)
 	}
@@ -675,7 +688,28 @@ func (task *Task) initializeSSMSecretResource(credentialsManager credentials.Man
 				resourcestatus.ResourceStatus(ssmsecret.SSMSecretCreated),
 				apicontainerstatus.ContainerCreated)
 		}
+
+		// Firelens container needs to depends on secret if other containers use secret log options.
+		if container.GetFirelensConfig() != nil && task.firelensDependsOnSecretResource(apicontainer.SecretProviderSSM) {
+			container.BuildResourceDependency(ssmSecretResource.GetName(),
+				resourcestatus.ResourceStatus(ssmsecret.SSMSecretCreated),
+				apicontainerstatus.ContainerCreated)
+		}
 	}
+}
+
+// firelensDependsOnSecret checks whether the firelens container needs to depends on a secret resource of
+// a certain provider type.
+func (task *Task) firelensDependsOnSecretResource(secretProvider string) bool {
+	isLogDriverSecretWithGivenProvider := func(s apicontainer.Secret) bool {
+		return s.Provider == secretProvider && s.Target == apicontainer.SecretTargetLogDriver
+	}
+	for _, container := range task.Containers {
+		if container.GetLogDriver() == firelensDriverName && container.HasSecret(isLogDriverSecretWithGivenProvider) {
+			return true
+		}
+	}
+	return false
 }
 
 // getAllSSMSecretRequirements stores all secrets in a map whose key is region and value is all
@@ -722,6 +756,13 @@ func (task *Task) initializeASMSecretResource(credentialsManager credentials.Man
 				resourcestatus.ResourceStatus(asmsecret.ASMSecretCreated),
 				apicontainerstatus.ContainerCreated)
 		}
+
+		// Firelens container needs to depends on secret if other containers use secret log options.
+		if container.GetFirelensConfig() != nil && task.firelensDependsOnSecretResource(apicontainer.SecretProviderASM) {
+			container.BuildResourceDependency(asmSecretResource.GetName(),
+				resourcestatus.ResourceStatus(asmsecret.ASMSecretCreated),
+				apicontainerstatus.ContainerCreated)
+		}
 	}
 }
 
@@ -742,27 +783,40 @@ func (task *Task) getAllASMSecretRequirements() map[string]apicontainer.Secret {
 	return reqs
 }
 
-// hasFirelensContainer returns true if the task has a firelens container.
-func (task *Task) hasFirelensContainer() bool {
+// getFirelensContainer returns the firelens container in the task, if there is one.
+func (task *Task) getFirelensContainer() *apicontainer.Container {
 	for _, container := range task.Containers {
-		if container.FirelensConfig != nil { // This is a firelens container.
-			return true
+		if container.GetFirelensConfig() != nil { // This is a firelens container.
+			return container
 		}
 	}
-	return false
+	return nil
 }
 
 // initializeFirelensResource initializes the firelens task resource and adds it as a dependency of the
 // firelens container.
-func (task *Task) initializeFirelensResource(config *config.Config, resourceFields *taskresource.ResourceFields) error {
-	containerToLogOptions, err := task.collectLogOptions()
+func (task *Task) initializeFirelensResource(config *config.Config, resourceFields *taskresource.ResourceFields,
+	firelensContainer *apicontainer.Container) error {
+	if firelensContainer.GetFirelensConfig() == nil {
+		return errors.New("firelens container config doesn't exist")
+	}
+
+	containerToLogOptions := make(map[string]map[string]string)
+	// Collect plain text log options.
+	err := task.collectFirelensLogOptions(containerToLogOptions)
+	if err != nil {
+		return errors.Wrap(err, "unable to initialize firelens resource")
+	}
+
+	// Collect secret log options.
+	err = task.collectFirelensLogEnvOptions(containerToLogOptions, firelensContainer.FirelensConfig.Type)
 	if err != nil {
 		return errors.Wrap(err, "unable to initialize firelens resource")
 	}
 
 	var firelensResource *firelens.FirelensResource
 	for _, container := range task.Containers {
-		firelensConfig := container.FirelensConfig
+		firelensConfig := container.GetFirelensConfig()
 		if firelensConfig != nil {
 			var ec2InstanceID string
 			if container.Environment != nil && container.Environment[awsExecutionEnvKey] == ec2ExecutionEnv {
@@ -789,7 +843,7 @@ func (task *Task) initializeFirelensResource(config *config.Config, resourceFiel
 func (task *Task) addFirelensContainerDependency() error {
 	var firelensContainer *apicontainer.Container
 	for _, container := range task.Containers {
-		if container.FirelensConfig != nil {
+		if container.GetFirelensConfig() != nil {
 			firelensContainer = container
 		}
 	}
@@ -799,12 +853,13 @@ func (task *Task) addFirelensContainerDependency() error {
 	}
 
 	for _, container := range task.Containers {
-		if container.DockerConfig.HostConfig == nil {
+		containerHostConfig := container.GetHostConfig()
+		if containerHostConfig == nil {
 			continue
 		}
 
 		hostConfig := &dockercontainer.HostConfig{}
-		err := json.Unmarshal([]byte(*container.DockerConfig.HostConfig), hostConfig)
+		err := json.Unmarshal([]byte(*containerHostConfig), hostConfig)
 		if err != nil {
 			return errors.Wrapf(err, "unable to decode host config of container %s", container.Name)
 		}
@@ -823,11 +878,11 @@ func (task *Task) addFirelensContainerDependency() error {
 	return nil
 }
 
-// collectLogOptions collects the log options for all the containers that use the firelens container
+// collectFirelensLogOptions collects the log options for all the containers that use the firelens container
 // as the log driver.
-func (task *Task) collectLogOptions() (map[string]map[string]string, error) {
-	containerToLogOptions := make(map[string]map[string]string)
-
+// containerToLogOptions is a nested map. Top level key is the container name. Second level is a map storing
+// the log option key and value of the container.
+func (task *Task) collectFirelensLogOptions(containerToLogOptions map[string]map[string]string) error {
 	for _, container := range task.Containers {
 		if container.DockerConfig.HostConfig == nil {
 			continue
@@ -836,15 +891,51 @@ func (task *Task) collectLogOptions() (map[string]map[string]string, error) {
 		hostConfig := &dockercontainer.HostConfig{}
 		err := json.Unmarshal([]byte(*container.DockerConfig.HostConfig), hostConfig)
 		if err != nil {
-			return nil, errors.Wrapf(err, "unable to decode host config of container %s", container.Name)
+			return errors.Wrapf(err, "unable to decode host config of container %s", container.Name)
 		}
 
 		if hostConfig.LogConfig.Type == firelensDriverName {
-			containerToLogOptions[container.Name] = hostConfig.LogConfig.Config
+			if containerToLogOptions[container.Name] == nil {
+				containerToLogOptions[container.Name] = make(map[string]string)
+			}
+			for k, v := range hostConfig.LogConfig.Config {
+				containerToLogOptions[container.Name][k] = v
+			}
 		}
 	}
 
-	return containerToLogOptions, nil
+	return nil
+}
+
+// collectFirelensLogEnvOptions collects all the log secret options. Each secret log option will have a value
+// of a config file variable (e.g. "${config_var_name}") and we will pass the secret value as env to the firelens
+// container and it will resolve the config file variable from the env.
+// Each config variable name has a format of log-option-key_container-name. We need the container name because options
+// from different containers using awsfirelens log driver in a task will be presented in the same firelens config file.
+func (task *Task) collectFirelensLogEnvOptions(containerToLogOptions map[string]map[string]string, firelensConfigType string) error {
+	placeholderFmt := ""
+	switch firelensConfigType {
+	case firelens.FirelensConfigTypeFluentd:
+		placeholderFmt = firelensConfigVarPlaceholderFmtFluentd
+	case firelens.FirelensConfigTypeFluentbit:
+		placeholderFmt = firelensConfigVarPlaceholderFmtFluentbit
+	default:
+		return errors.Errorf("unsupported firelens config type %s", firelensConfigType)
+	}
+
+	for _, container := range task.Containers {
+		for _, secret := range container.Secrets {
+			if secret.Target == apicontainer.SecretTargetLogDriver {
+				if containerToLogOptions[container.Name] == nil {
+					containerToLogOptions[container.Name] = make(map[string]string)
+				}
+
+				containerToLogOptions[container.Name][secret.Name] = fmt.Sprintf(placeholderFmt,
+					fmt.Sprintf(firelensConfigVarFmt, secret.Name, container.Name))
+			}
+		}
+	}
+	return nil
 }
 
 // AddFirelensContainerBindMounts adds config file bind mount and socket directory bind mount to the firelens
@@ -2067,6 +2158,12 @@ func (task *Task) PopulateSecrets(hostConfig *dockercontainer.HostConfig, contai
 		asmRes = resource[0].(*asmsecret.ASMSecretResource)
 	}
 
+	populateContainerSecrets(hostConfig, container, ssmRes, asmRes)
+	return nil
+}
+
+func populateContainerSecrets(hostConfig *dockercontainer.HostConfig, container *apicontainer.Container,
+	ssmRes *ssmsecret.SSMSecretResource, asmRes *asmsecret.ASMSecretResource) {
 	envVars := make(map[string]string)
 
 	logDriverTokenName := ""
@@ -2093,7 +2190,14 @@ func (task *Task) PopulateSecrets(hostConfig *dockercontainer.HostConfig, contai
 			envVars[secret.Name] = secretVal
 			continue
 		}
+
 		if secret.Target == apicontainer.SecretTargetLogDriver {
+			// Log driver secrets for container using awsfirelens log driver won't be saved in log config and passed to
+			// Docker here. They will only be used to configure the firelens container.
+			if container.GetLogDriver() == firelensDriverName {
+				continue
+			}
+
 			logDriverTokenName = secret.Name
 			logDriverTokenSecretValue = secretVal
 
@@ -2106,7 +2210,82 @@ func (task *Task) PopulateSecrets(hostConfig *dockercontainer.HostConfig, contai
 	}
 
 	container.MergeEnvironmentVariables(envVars)
+}
+
+// PopulateSecretLogOptionsToFirelensContainer collects secret log option values for awsfirelens log driver from task
+// resource and specified then as envs of firelens container. Firelens container will use the envs to resolve config
+// file variables constructed for secret log options when loading the config file.
+func (task *Task) PopulateSecretLogOptionsToFirelensContainer(firelensContainer *apicontainer.Container) *apierrors.DockerClientConfigError {
+	firelensENVs := make(map[string]string)
+
+	var ssmRes *ssmsecret.SSMSecretResource
+	var asmRes *asmsecret.ASMSecretResource
+
+	resource, ok := task.getSSMSecretsResource()
+	if ok {
+		ssmRes = resource[0].(*ssmsecret.SSMSecretResource)
+	}
+
+	resource, ok = task.getASMSecretsResource()
+	if ok {
+		asmRes = resource[0].(*asmsecret.ASMSecretResource)
+	}
+
+	for _, container := range task.Containers {
+		if container.GetLogDriver() != firelensDriverName {
+			continue
+		}
+
+		logDriverSecretData, err := collectLogDriverSecretData(container.Secrets, ssmRes, asmRes)
+		if err != nil {
+			return &apierrors.DockerClientConfigError{
+				Msg: fmt.Sprintf("unable to generate config to create firelens container: %v", err),
+			}
+		}
+
+		for key, value := range logDriverSecretData {
+			envKey := fmt.Sprintf(firelensConfigVarFmt, key, container.Name)
+			firelensENVs[envKey] = value
+		}
+	}
+
+	firelensContainer.MergeEnvironmentVariables(firelensENVs)
 	return nil
+}
+
+// collectLogDriverSecretData collects all the secret values for log driver secrets.
+func collectLogDriverSecretData(secrets []apicontainer.Secret, ssmRes *ssmsecret.SSMSecretResource,
+	asmRes *asmsecret.ASMSecretResource) (map[string]string, error) {
+	secretData := make(map[string]string)
+	for _, secret := range secrets {
+		if secret.Target != apicontainer.SecretTargetLogDriver {
+			continue
+		}
+
+		secretVal := ""
+		cacheKey := secret.GetSecretResourceCacheKey()
+		if secret.Provider == apicontainer.SecretProviderSSM {
+			if ssmRes == nil {
+				return nil, errors.Errorf("missing secret value for secret %s", secret.Name)
+			}
+
+			if secretValue, ok := ssmRes.GetCachedSecretValue(cacheKey); ok {
+				secretVal = secretValue
+			}
+		} else if secret.Provider == apicontainer.SecretProviderASM {
+			if asmRes == nil {
+				return nil, errors.Errorf("missing secret value for secret %s", secret.Name)
+			}
+
+			if secretValue, ok := asmRes.GetCachedSecretValue(cacheKey); ok {
+				secretVal = secretValue
+			}
+		}
+
+		secretData[secret.Name] = secretVal
+	}
+
+	return secretData, nil
 }
 
 // getASMSecretsResource retrieves asmsecret resource from resource map

--- a/agent/api/task/task_linux_test.go
+++ b/agent/api/task/task_linux_test.go
@@ -27,8 +27,10 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
+	"github.com/aws/amazon-ecs-agent/agent/taskresource/asmsecret"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/cgroup/control/mock_control"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/firelens"
+	"github.com/aws/amazon-ecs-agent/agent/taskresource/ssmsecret"
 	mock_ioutilwrapper "github.com/aws/amazon-ecs-agent/agent/utils/ioutilwrapper/mocks"
 	"github.com/golang/mock/gomock"
 
@@ -581,10 +583,22 @@ func TestPostUnmarshalWithFirelensContainer(t *testing.T) {
 	}
 	assert.NoError(t, task.PostUnmarshalTask(cfg, nil, resourceFields, nil, nil))
 	resources := task.GetResources()
-	assert.Equal(t, 1, len(resources))
-	assert.Equal(t, 1, len(task.Containers[1].TransitionDependenciesMap))
+	assert.Len(t, resources, 2)
+	assert.Len(t, task.Containers[1].TransitionDependenciesMap, 1)
+	assert.Len(t, task.Containers[1].TransitionDependenciesMap[apicontainerstatus.ContainerCreated].ResourceDependencies, 2)
+	var firelensResource *firelens.FirelensResource
+	var secretResource *ssmsecret.SSMSecretResource
+	for _, resource := range resources {
+		if resource.GetName() == firelens.ResourceName {
+			firelensResource = resource.(*firelens.FirelensResource)
+		} else if resource.GetName() == ssmsecret.ResourceName {
+			secretResource = resource.(*ssmsecret.SSMSecretResource)
+		}
+	}
 
-	firelensResource := resources[0].(*firelens.FirelensResource)
+	assert.NotNil(t, firelensResource)
+	assert.NotNil(t, secretResource)
+
 	assert.Equal(t, testCluster, firelensResource.GetCluster())
 	assert.Equal(t, validTaskArn, firelensResource.GetTaskARN())
 	assert.Equal(t, testTaskDefFamily+":"+testTaskDefVersion, firelensResource.GetTaskDefinition())
@@ -615,25 +629,27 @@ func TestPostUnmarshalWithFirelensContainerError(t *testing.T) {
 	assert.Error(t, task.PostUnmarshalTask(cfg, nil, resourceFields, nil, nil))
 }
 
-func TestHasFirelensContainer(t *testing.T) {
+func TestGetFirelensContainer(t *testing.T) {
+	firelensContainer := &apicontainer.Container{
+		Name: "c",
+		FirelensConfig: &apicontainer.FirelensConfig{
+			Type: firelens.FirelensConfigTypeFluentd,
+		},
+	}
+
 	testCases := []struct {
-		name                 string
-		task                 *Task
-		hasFirelensContainer bool
+		name              string
+		task              *Task
+		firelensContainer *apicontainer.Container
 	}{
 		{
 			name: "task has firelens container",
 			task: &Task{
 				Containers: []*apicontainer.Container{
-					{
-						Name: "c",
-						FirelensConfig: &apicontainer.FirelensConfig{
-							Type: firelens.FirelensConfigTypeFluentd,
-						},
-					},
+					firelensContainer,
 				},
 			},
-			hasFirelensContainer: true,
+			firelensContainer: firelensContainer,
 		},
 		{
 			name: "task doesn't have firelens container",
@@ -644,13 +660,13 @@ func TestHasFirelensContainer(t *testing.T) {
 					},
 				},
 			},
-			hasFirelensContainer: false,
+			firelensContainer: nil,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.hasFirelensContainer, tc.task.hasFirelensContainer())
+			assert.Equal(t, tc.firelensContainer, tc.task.getFirelensContainer())
 		})
 	}
 }
@@ -672,11 +688,19 @@ func TestInitializeFirelensResource(t *testing.T) {
 		shouldFail            bool
 		shouldHaveInstanceID  bool
 		shouldDisableMetadata bool
+		expectedLogOptions    map[string]map[string]string
 	}{
 		{
 			name:                 "test initialize firelens resource fluentd",
 			task:                 getFirelensTask(t),
 			shouldHaveInstanceID: true,
+			expectedLogOptions: map[string]map[string]string{
+				"logsender": {
+					"key1":        "value1",
+					"key2":        "value2",
+					"secret-name": "\"#{ENV['secret-name_logsender']}\"",
+				},
+			},
 		},
 		{
 			name: "test initialize firelens resource fluentbit",
@@ -686,6 +710,13 @@ func TestInitializeFirelensResource(t *testing.T) {
 				return task
 			}(),
 			shouldHaveInstanceID: true,
+			expectedLogOptions: map[string]map[string]string{
+				"logsender": {
+					"key1":        "value1",
+					"key2":        "value2",
+					"secret-name": "${secret-name_logsender}",
+				},
+			},
 		},
 		{
 			name: "test initialize firelens resource without ec2 instance id",
@@ -694,6 +725,13 @@ func TestInitializeFirelensResource(t *testing.T) {
 				task.Containers[1].Environment = nil
 				return task
 			}(),
+			expectedLogOptions: map[string]map[string]string{
+				"logsender": {
+					"key1":        "value1",
+					"key2":        "value2",
+					"secret-name": "\"#{ENV['secret-name_logsender']}\"",
+				},
+			},
 		},
 		{
 			name: "test initialize firelens resource disables ecs log metadata",
@@ -704,6 +742,13 @@ func TestInitializeFirelensResource(t *testing.T) {
 			}(),
 			shouldHaveInstanceID:  true,
 			shouldDisableMetadata: true,
+			expectedLogOptions: map[string]map[string]string{
+				"logsender": {
+					"key1":        "value1",
+					"key2":        "value2",
+					"secret-name": "\"#{ENV['secret-name_logsender']}\"",
+				},
+			},
 		},
 		{
 			name: "test initialize firelens resource invalid host config",
@@ -727,7 +772,7 @@ func TestInitializeFirelensResource(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := tc.task.initializeFirelensResource(cfg, resourceFields)
+			err := tc.task.initializeFirelensResource(cfg, resourceFields, tc.task.Containers[1])
 			if tc.shouldFail {
 				assert.Error(t, err)
 			} else {
@@ -743,8 +788,7 @@ func TestInitializeFirelensResource(t *testing.T) {
 				assert.Equal(t, testTaskDefFamily+":"+testTaskDefVersion, firelensResource.GetTaskDefinition())
 				assert.Equal(t, testDataDir+"/firelens/task-id", firelensResource.GetResourceDir())
 				assert.NotNil(t, firelensResource.GetContainerToLogOptions())
-				assert.Equal(t, "value1", firelensResource.GetContainerToLogOptions()["logsender"]["key1"])
-				assert.Equal(t, "value2", firelensResource.GetContainerToLogOptions()["logsender"]["key2"])
+				assert.Equal(t, tc.expectedLogOptions, firelensResource.GetContainerToLogOptions())
 				assert.Equal(t, !tc.shouldDisableMetadata, firelensResource.GetECSMetadataEnabled())
 
 				if tc.shouldHaveInstanceID {
@@ -757,21 +801,32 @@ func TestInitializeFirelensResource(t *testing.T) {
 	}
 }
 
-func TestCollectLogOptions(t *testing.T) {
+func TestCollectFirelensLogOptions(t *testing.T) {
 	task := getFirelensTask(t)
 
-	containerToLogOptions, err := task.collectLogOptions()
+	containerToLogOptions := make(map[string]map[string]string)
+	err := task.collectFirelensLogOptions(containerToLogOptions)
 	assert.NoError(t, err)
 	assert.Equal(t, "value1", containerToLogOptions["logsender"]["key1"])
 	assert.Equal(t, "value2", containerToLogOptions["logsender"]["key2"])
 }
 
-func TestCollectLogOptionsInvalidOptions(t *testing.T) {
+func TestCollectFirelensLogOptionsInvalidOptions(t *testing.T) {
 	task := getFirelensTask(t)
 	task.Containers[0].DockerConfig.HostConfig = strptr(string("invalid"))
 
-	_, err := task.collectLogOptions()
+	containerToLogOptions := make(map[string]map[string]string)
+	err := task.collectFirelensLogOptions(containerToLogOptions)
 	assert.Error(t, err)
+}
+
+func TestCollectFirelensLogEnvOptions(t *testing.T) {
+	task := getFirelensTask(t)
+
+	containerToLogOptions := make(map[string]map[string]string)
+	err := task.collectFirelensLogEnvOptions(containerToLogOptions, "fluentd")
+	assert.NoError(t, err)
+	assert.Equal(t, "\"#{ENV['secret-name_logsender']}\"", containerToLogOptions["logsender"]["secret-name"])
 }
 
 func TestAddFirelensContainerDependency(t *testing.T) {
@@ -854,6 +909,90 @@ func TestAddFirelensContainerBindMounts(t *testing.T) {
 	}
 }
 
+func TestFirelensDependsOnSecretResource(t *testing.T) {
+	testCases := []struct {
+		name     string
+		provider string
+		task     *Task
+		res      bool
+	}{
+		{
+			name:     "depends on ssm",
+			provider: apicontainer.SecretProviderSSM,
+			task:     getFirelensTask(t),
+			res:      true,
+		},
+		{
+			name:     "depends on asm",
+			provider: apicontainer.SecretProviderASM,
+			task: func() *Task {
+				task := getFirelensTask(t)
+				task.Containers[0].Secrets[0].Provider = apicontainer.SecretProviderASM
+				return task
+			}(),
+			res: true,
+		},
+		{
+			name:     "no dependency",
+			provider: apicontainer.SecretProviderSSM,
+			task: func() *Task {
+				task := getFirelensTask(t)
+				task.Containers[0].Secrets = []apicontainer.Secret{}
+				return task
+			}(),
+			res: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.res, tc.task.firelensDependsOnSecretResource(tc.provider))
+		})
+	}
+}
+
+func TestPopulateSecretLogOptionsToFirelensContainer(t *testing.T) {
+	task := getFirelensTask(t)
+	ssmRes := &ssmsecret.SSMSecretResource{}
+	ssmRes.SetCachedSecretValue("secret-value-from_us-west-2", "secret-val")
+	task.AddResource(ssmsecret.ResourceName, ssmRes)
+
+	assert.Nil(t, task.PopulateSecretLogOptionsToFirelensContainer(task.Containers[1]))
+	assert.Len(t, task.Containers[1].Environment, 2)
+	assert.Equal(t, "secret-val", task.Containers[1].Environment["secret-name_logsender"])
+}
+
+func TestCollectLogDriverSecretData(t *testing.T) {
+	ssmRes := &ssmsecret.SSMSecretResource{}
+	ssmRes.SetCachedSecretValue("secret-value-from_us-west-2", "secret-val")
+
+	asmRes := &asmsecret.ASMSecretResource{}
+	asmRes.SetCachedSecretValue("secret-value-from-asm_us-west-2", "secret-val-asm")
+
+	secrets := []apicontainer.Secret{
+		{
+			Name:      "secret-name",
+			Provider:  apicontainer.SecretProviderSSM,
+			Target:    apicontainer.SecretTargetLogDriver,
+			ValueFrom: "secret-value-from",
+			Region:    "us-west-2",
+		},
+		{
+			Name:      "secret-name-asm",
+			Provider:  apicontainer.SecretProviderASM,
+			Target:    apicontainer.SecretTargetLogDriver,
+			ValueFrom: "secret-value-from-asm",
+			Region:    "us-west-2",
+		},
+	}
+
+	secretData, err := collectLogDriverSecretData(secrets, ssmRes, asmRes)
+	assert.NoError(t, err)
+	assert.Len(t, secretData, 2)
+	assert.Equal(t, "secret-val", secretData["secret-name"])
+	assert.Equal(t, "secret-val-asm", secretData["secret-name-asm"])
+}
+
 // getFirelensTask returns a sample firelens task.
 func getFirelensTask(t *testing.T) *Task {
 	rawHostConfigInput := dockercontainer.HostConfig{
@@ -880,6 +1019,17 @@ func getFirelensTask(t *testing.T) *Task {
 				DockerConfig: apicontainer.DockerConfig{
 					HostConfig: strptr(string(rawHostConfig)),
 				},
+				Secrets: []apicontainer.Secret{
+					{
+						Name:      "secret-name",
+						ValueFrom: "secret-value-from",
+						Region:    "us-west-2",
+
+						Target:   apicontainer.SecretTargetLogDriver,
+						Provider: apicontainer.SecretProviderSSM,
+					},
+				},
+				TransitionDependenciesMap: make(map[apicontainerstatus.ContainerStatus]apicontainer.TransitionDependencySet),
 			},
 			{
 				Name: "firelenscontainer",

--- a/agent/engine/engine_sudo_linux_integ_test.go
+++ b/agent/engine/engine_sudo_linux_integ_test.go
@@ -57,7 +57,6 @@ const (
 	testInstanceID     = "testInstanceID"
 	testTaskDefFamily  = "testFamily"
 	testTaskDefVersion = "1"
-	firelensDriverName = "awsfirelens"
 	testECSRegion      = "us-east-1"
 	testLogGroupName   = "test-fluentbit"
 	testLogGroupPrefix = "firelens-fluentbit-"
@@ -243,7 +242,7 @@ func createFirelensTask(t *testing.T) *apitask.Task {
 	testTask := createTestTask(validTaskArnPrefix + uuid.New())
 	rawHostConfigInputForLogSender := dockercontainer.HostConfig{
 		LogConfig: dockercontainer.LogConfig{
-			Type: firelensDriverName,
+			Type: logDriverTypeFirelens,
 			Config: map[string]string{
 				"Name":              "cloudwatch",
 				"exclude-pattern":   "exclude",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Since log options for awsfirelens log driver are written to config file rather than passed to Docker, secret log options for awsfirelens log driver need to be implemented differently as well. This PR implements it.

### Implementation details
<!-- How are the changes implemented? -->
The workflow is as follow:
1. Each secret log option for a container using awsfirelens driver has a value of a config file variable with name option-key_container-name when generating the config file.
2. When creating the firelens container, retrieves the secret log option value from secret  task resource and set the value of each config file variable to the secret value as the container's env.
3. Firelens container will then resolve the config file variable to the secret value when loading the config file base on the env.

Besides the above workflow, logic is added to let firelens container depends on secret resource when needed.

### Example
As an example, suppose we are using cloudwatch plugin for fluentbit firelens router, with a plain text log option "region" with value "us-west-2", and a secret log option "log_group_name", with value stored in ssm parameter "log_group_key", the task definition will be something like the following:
```
{
	"family": "xxx",
	"executionRoleArn": "xxx",
	"containerDefinitions": [
		{
			...
			"name": "log_router", // firelens container
			"firelensConfiguration": {
				"type": "fluentbit"
			}
		 },
		 {
			 ...
			 "name": "app", // application container that sends log using firelens
			 "logConfiguration": {
				 "logDriver":"awsfirelens",
				 "options": {
					"Name": "cloudwatch",
					"region": "us-west-2",
					"...
				},
				"secretOptions": [{
					"name": "log_group_name",
					"valueFrom": "log_group_key"
				}]
			}
		}
	]
}
```
When running the above task definition, container "app" will have a Secret looks like the following:
```
{
    Name: "log_group_name",
    ValueFrom: "log_group_key",
    Target: "log_driver",
    Provider: "ssm",
}
```

When initializing the firelens task resource, we initialize it with the following log options:
```
option 1 (plain text log option): key - region, value - us-west-2
option 2 (secret log option): key - log_group_name, value - ${log_group_name_app}

containerToLogOptions parameter for initializeFirelensResource will look like the following
{
"app": {
    "region": "us-west-2",
    "log_group_name": "${log_group_name_app}"
}
}
```
The options got written to firelens config file like the following (xxx will be task id):
```
...
<match app-xxx>
    Name cloudwatch
    region us-west-2
    log_group_name ${log_group_name_app}
</match>
...
```
When creating the firelens container, suppose the log group name stored in the ssm parameter is "testing", we inject an env with key "log_group_name_app" and value "testing" to firelens container's env. When firelens container starts and loads its config file, it will attempt to resolve the config variable ${log_group_name_app} with its env, and the config will be resolved  to:
```
...
<match app-xxx>
    Name cloudwatch
    region us-west-2
    log_group_name testing
</match>
...
```
And then the plugin will be properly initialize with the above config.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Unit tests added. Manually run tasks against gamma to verify it works. For functional tests I will modify the ones in https://github.com/aws/amazon-ecs-agent/pull/2134 to cover secret log options.

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
