### PR TITLE
delete log groups created by stats functional tests

### DIFF
--- a/agent/functional_tests/tests/functionaltests_test.go
+++ b/agent/functional_tests/tests/functionaltests_test.go
@@ -670,7 +670,13 @@ func telemetryStorageStatsTest(t *testing.T, taskDefinition string) {
 		ClusterName: aws.String(newClusterName),
 	})
 	require.NoError(t, err, "Failed to create cluster")
-	defer DeleteCluster(t, newClusterName)
+	defer func() {
+		DeleteCluster(t, newClusterName)
+		cwlClient := cloudwatchlogs.New(session.New(), aws.NewConfig().WithRegion(*ECS.Config.Region))
+		cwlClient.DeleteLogGroup(&cloudwatchlogs.DeleteLogGroupInput{
+			LogGroupName: aws.String(fmt.Sprintf("/aws/ecs/containerinsights/%s/performance", newClusterName)),
+		})
+	}()
 
 	agentOptions := AgentOptions{
 		ExtraEnvironment: map[string]string{
@@ -747,7 +753,13 @@ func telemetryNetworkStatsTest(t *testing.T, networkMode string, taskDefinition 
 		ClusterName: aws.String(newClusterName),
 	})
 	require.NoError(t, err, "Failed to create cluster")
-	defer DeleteCluster(t, newClusterName)
+	defer func() {
+		DeleteCluster(t, newClusterName)
+		cwlClient := cloudwatchlogs.New(session.New(), aws.NewConfig().WithRegion(*ECS.Config.Region))
+		cwlClient.DeleteLogGroup(&cloudwatchlogs.DeleteLogGroupInput{
+			LogGroupName: aws.String(fmt.Sprintf("/aws/ecs/containerinsights/%s/performance", newClusterName)),
+		})
+	}()
 	os.Setenv("ECS_FTEST_FORCE_NET_HOST", "true")
 	agentOptions := AgentOptions{
 		EnableTaskENI: true,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Manually verified that log groups are removed as well 

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
