### PR TITLE
Add new EI capability for checking cpu AVX/SSE support

### DIFF
--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -47,6 +47,7 @@ const (
 	capabilityECREndpoint                       = "ecr-endpoint"
 	capabilityContainerOrdering                 = "container-ordering"
 	taskEIAAttributeSuffix                      = "task-eia"
+	taskEIAWithOptimizedCPU                     = "task-eia.optimized-cpu"
 	taskENITrunkingAttributeSuffix              = "task-eni-trunking"
 	branchCNIPluginVersionSuffix                = "branch-cni-plugin-version"
 )
@@ -86,6 +87,7 @@ const (
 //    ecs.capability.aws-appmesh
 //    ecs.capability.task-eia
 //    ecs.capability.task-eni-trunking
+//    ecs.capability.task-eia.optimized-cpu
 func (agent *ecsAgent) capabilities() ([]*ecs.Attribute, error) {
 	var capabilities []*ecs.Attribute
 

--- a/agent/app/agent_capability_unix.go
+++ b/agent/app/agent_capability_unix.go
@@ -1,6 +1,6 @@
 // +build linux
 
-// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -24,8 +24,17 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
 	"github.com/aws/amazon-ecs-agent/agent/ecscni"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/volume"
+	"github.com/aws/amazon-ecs-agent/agent/utils"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/cihub/seelog"
+)
+
+const (
+	AVX         = "avx"
+	AVX2        = "avx2"
+	SSE41       = "sse4_1"
+	SSE42       = "sse4_2"
+	CpuInfoPath = "/proc/cpuinfo"
 )
 
 func (agent *ecsAgent) appendVolumeDriverCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
@@ -112,5 +121,28 @@ func (agent *ecsAgent) appendAppMeshCapabilities(capabilities []*ecs.Attribute) 
 }
 
 func (agent *ecsAgent) appendTaskEIACapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
-	return appendNameOnlyAttribute(capabilities, attributePrefix+taskEIAAttributeSuffix)
+
+	capabilities = appendNameOnlyAttribute(capabilities, attributePrefix+taskEIAAttributeSuffix)
+
+	eiaRequiredFlags := []string{AVX, AVX2, SSE41, SSE42}
+	cpuInfo, err := utils.ReadCPUInfo(CpuInfoPath)
+	if err != nil {
+		seelog.Warnf("Unable to read cpuinfo: %v", err)
+		return capabilities
+	}
+
+	flagMap := utils.GetCPUFlags(cpuInfo)
+	missingFlags := []string{}
+	for _, requiredFlag := range eiaRequiredFlags {
+		if _, ok := flagMap[requiredFlag]; !ok {
+			missingFlags = append(missingFlags, requiredFlag)
+		}
+	}
+
+	if len(missingFlags) > 0 {
+		seelog.Infof("Missing cpu flags for EIA support: %v", strings.Join(missingFlags, ","))
+		return capabilities
+	}
+
+	return appendNameOnlyAttribute(capabilities, attributePrefix+taskEIAWithOptimizedCPU)
 }

--- a/agent/app/agent_capability_unix_test.go
+++ b/agent/app/agent_capability_unix_test.go
@@ -1,6 +1,6 @@
 // +build linux,unit
 
-// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -16,9 +16,10 @@
 package app
 
 import (
-	"testing"
-
 	"context"
+	"os"
+	"path/filepath"
+	"testing"
 
 	app_mocks "github.com/aws/amazon-ecs-agent/agent/app/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/config"
@@ -29,6 +30,7 @@ import (
 	mock_ecscni "github.com/aws/amazon-ecs-agent/agent/ecscni/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/gpu"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
+	"github.com/aws/amazon-ecs-agent/agent/utils"
 	mock_mobypkgwrapper "github.com/aws/amazon-ecs-agent/agent/utils/mobypkgwrapper/mocks"
 	"github.com/aws/aws-sdk-go/aws"
 	aws_credentials "github.com/aws/aws-sdk-go/aws/credentials"
@@ -624,9 +626,14 @@ func TestAppMeshCapabilitiesUnix(t *testing.T) {
 	}
 }
 
-func TestTaskEIACapabilitiesUnix(t *testing.T) {
+func TestTaskEIACapabilitiesNoOptimizedCPU(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
+
+	utils.OpenFile = func(path string) (*os.File, error) {
+		return os.Open(filepath.Join(".", "testdata", "test_cpu_info_fail"))
+	}
+	defer resetOpenFile()
 
 	client := mock_dockerapi.NewMockDockerClient(ctrl)
 	mockMobyPlugins := mock_mobypkgwrapper.NewMockPlugins(ctrl)
@@ -647,52 +654,6 @@ func TestTaskEIACapabilitiesUnix(t *testing.T) {
 			gomock.Any()).AnyTimes().Return([]string{}, nil),
 	)
 
-	expectedCapabilityNames := []string{
-		"com.amazonaws.ecs.capability.docker-remote-api.1.17",
-	}
-
-	var expectedCapabilities []*ecs.Attribute
-	for _, name := range expectedCapabilityNames {
-		expectedCapabilities = append(expectedCapabilities,
-			&ecs.Attribute{Name: aws.String(name)})
-	}
-	expectedCapabilities = append(expectedCapabilities,
-		[]*ecs.Attribute{
-			// linux specific capabilities
-			{
-				Name: aws.String("ecs.capability.docker-plugin.local"),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilityPrivateRegistryAuthASM),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilitySecretEnvSSM),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilitySecretLogDriverSSM),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilityECREndpoint),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilitySecretEnvASM),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilitySecretLogDriverASM),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilityContainerOrdering),
-			},
-			{
-				Name: aws.String(attributePrefix + capabiltyPIDAndIPCNamespaceSharing),
-			},
-			{
-				Name: aws.String(attributePrefix + appMeshAttributeSuffix),
-			},
-			{
-				Name: aws.String(attributePrefix + taskEIAAttributeSuffix),
-			},
-		}...)
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines
 	defer cancel()
@@ -705,9 +666,54 @@ func TestTaskEIACapabilitiesUnix(t *testing.T) {
 	}
 	capabilities, err := agent.capabilities()
 	assert.NoError(t, err)
+	assert.Contains(t, capabilities, &ecs.Attribute{Name: aws.String(attributePrefix + taskEIAAttributeSuffix)})
+	assert.NotContains(t, capabilities, &ecs.Attribute{Name: aws.String(attributePrefix + taskEIAWithOptimizedCPU)})
+}
 
-	for i, expected := range expectedCapabilities {
-		assert.Equal(t, aws.StringValue(expected.Name), aws.StringValue(capabilities[i].Name))
-		assert.Equal(t, aws.StringValue(expected.Value), aws.StringValue(capabilities[i].Value))
+func TestTaskEIACapabilitiesWithOptimizedCPU(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := mock_dockerapi.NewMockDockerClient(ctrl)
+	mockMobyPlugins := mock_mobypkgwrapper.NewMockPlugins(ctrl)
+	mockCredentialsProvider := app_mocks.NewMockProvider(ctrl)
+
+	conf := &config.Config{
+		PrivilegedDisabled: true,
 	}
+
+	utils.OpenFile = func(path string) (*os.File, error) {
+		return os.Open(filepath.Join(".", "testdata", "test_cpu_info"))
+	}
+	defer resetOpenFile()
+
+	gomock.InOrder(
+		client.EXPECT().SupportedVersions().Return([]dockerclient.DockerVersion{
+			dockerclient.Version_1_17,
+		}),
+		client.EXPECT().KnownVersions().Return([]dockerclient.DockerVersion{
+			dockerclient.Version_1_17,
+		}),
+		mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{}, nil),
+		client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
+			gomock.Any()).AnyTimes().Return([]string{}, nil),
+	)
+
+	ctx, cancel := context.WithCancel(context.TODO())
+	// Cancel the context to cancel async routines
+	defer cancel()
+	agent := &ecsAgent{
+		ctx:                ctx,
+		cfg:                conf,
+		dockerClient:       client,
+		credentialProvider: aws_credentials.NewCredentials(mockCredentialsProvider),
+		mobyPlugins:        mockMobyPlugins,
+	}
+	capabilities, err := agent.capabilities()
+	assert.NoError(t, err)
+	assert.Contains(t, capabilities, &ecs.Attribute{Name: aws.String(attributePrefix + taskEIAWithOptimizedCPU)})
+}
+
+func resetOpenFile() {
+	utils.OpenFile = os.Open
 }

--- a/agent/app/testdata/test_cpu_info
+++ b/agent/app/testdata/test_cpu_info
@@ -1,0 +1,21 @@
+processor       : 0
+vendor_id       : GenuineIntel
+cpu family      : 6
+model           : 85
+model name      : Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz
+stepping        : 4
+microcode       : 0x200005e
+cpu MHz         : 2500.000
+cache size      : 33792 KB
+physical id     : 0
+siblings        : 8
+core id         : 3
+cpu cores       : 4
+apicid          : 6
+initial apicid  : 6
+fpu             : yes
+fpu_exception   : yes
+cpuid level     : 13
+wp              : yes
+flags           : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse4_1 sse4_2 avx ht syscall avx2 pdpe1gb rdtscp lm constant_tsc a nopl xtopology
+

--- a/agent/app/testdata/test_cpu_info_fail
+++ b/agent/app/testdata/test_cpu_info_fail
@@ -1,0 +1,42 @@
+processor       : 0
+vendor_id       : GenuineIntel
+cpu family      : 6
+model           : 85
+model name      : Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz
+stepping        : 4
+microcode       : 0x200005e
+cpu MHz         : 2500.000
+cache size      : 33792 KB
+physical id     : 0
+siblings        : 8
+core id         : 3
+cpu cores       : 4
+apicid          : 6
+initial apicid  : 6
+fpu             : yes
+fpu_exception   : yes
+cpuid level     : 13
+wp              : yes
+flags           : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse4_1 sse4_2 avx ht syscall pdpe1gb rdtscp lm constant_tsc a nopl xtopology
+
+processor       : 1
+vendor_id       : GenuineIntel
+cpu family      : 6
+model           : 85
+model name      : Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz
+stepping        : 4
+microcode       : 0x200005e
+cpu MHz         : 2500.000
+cache size      : 33792 KB
+physical id     : 0
+siblings        : 8
+core id         : 3
+cpu cores       : 4
+apicid          : 6
+initial apicid  : 6
+fpu             : yes
+fpu_exception   : yes
+cpuid level     : 13
+wp              : yes
+flags           : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse4_1 sse4_2 avx ht syscall pdpe1gb rdtscp lm constant_tsc a nopl xtopology
+

--- a/agent/ecscni/plugin.go
+++ b/agent/ecscni/plugin.go
@@ -38,7 +38,7 @@ const (
 	// ECSCNIVersion, ECSCNIGitHash, VPCCNIGitHash needs to be updated every time CNI plugin is updated
 	currentECSCNIVersion      = "2019.06.0"
 	currentECSCNIGitHash      = "91ccefc8864ec14a32bd2b9d7e7de3060b685383"
-	currentVPCCNIGitHash      = "fa071b269ea57644ab566cc915698c61369e158f"
+	currentVPCCNIGitHash      = "cdd89b926ed29fe8ad3a229cafd65119a2833a3b"
 	vpcCNIPluginPath          = "/log/vpc-branch-eni.log"
 	vpcCNIPluginInterfaceType = "vlan"
 )

--- a/agent/utils/cpuinfo.go
+++ b/agent/utils/cpuinfo.go
@@ -1,0 +1,95 @@
+// +build linux
+
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package utils
+
+import (
+	"bufio"
+	"os"
+	"strings"
+)
+
+type CPUInfo struct {
+	Processors []Processor `json:"processors"`
+}
+
+type Processor struct {
+	Flags []string `json:"flags"`
+}
+
+var (
+	OpenFile = os.Open
+)
+
+func ReadCPUInfo(path string) (*CPUInfo, error) {
+	file, err := OpenFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	var lines []string
+
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+
+	var cpuinfo = CPUInfo{}
+	var processor = &Processor{}
+
+	for i, line := range lines {
+		var key string
+		var value string
+
+		if len(line) == 0 && i != len(lines)-1 {
+			// end of processor
+			cpuinfo.Processors = append(cpuinfo.Processors, *processor)
+			processor = &Processor{}
+			continue
+		} else if i == len(lines)-1 {
+			cpuinfo.Processors = append(cpuinfo.Processors, *processor)
+			continue
+		}
+
+		fields := strings.Split(line, ":")
+		if len(fields) < 2 {
+			continue
+		}
+		key = strings.TrimSpace(fields[0])
+		value = strings.TrimSpace(fields[1])
+
+		switch key {
+		case "flags", "Features":
+			processor.Flags = strings.FieldsFunc(value, func(r rune) bool {
+				return r == ',' || r == ' '
+			})
+		}
+	}
+	return &cpuinfo, nil
+}
+
+// GetCPUFlags merges all processors' flags and return as a map. Returning map makes it
+// easy to check whether a flag exists or not.
+func GetCPUFlags(cpuInfo *CPUInfo) map[string]bool {
+	flagMap := map[string]bool{}
+	for _, proc := range cpuInfo.Processors {
+		for _, flag := range proc.Flags {
+			flagMap[flag] = true
+		}
+	}
+	return flagMap
+}

--- a/agent/utils/cpuinfo_test.go
+++ b/agent/utils/cpuinfo_test.go
@@ -1,0 +1,71 @@
+// +build linux,unit
+
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package utils
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReadCPUInfoWithFlags(t *testing.T) {
+	path := filepath.Join(".", "testdata", "test_cpu_info")
+	cpuInfo, err := ReadCPUInfo(path)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(cpuInfo.Processors))
+	assert.Equal(t, 8, len(cpuInfo.Processors[0].Flags))
+	assert.Equal(t, 10, len(cpuInfo.Processors[1].Flags))
+}
+
+func TestReadCPUInfoWithFlagsARM(t *testing.T) {
+	path := filepath.Join(".", "testdata", "test_cpu_info_arm")
+	cpuInfo, err := ReadCPUInfo(path)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(cpuInfo.Processors))
+	assert.Equal(t, 8, len(cpuInfo.Processors[0].Flags))
+	assert.Equal(t, 9, len(cpuInfo.Processors[1].Flags))
+}
+
+func TestReadCPUInfoNoFlags(t *testing.T) {
+	path := filepath.Join(".", "testdata", "test_cpu_info_no_flag")
+	cpuInfo, err := ReadCPUInfo(path)
+	assert.Nil(t, err)
+	proc := cpuInfo.Processors[0]
+	assert.Nil(t, proc.Flags)
+}
+
+func TestReadCPUInfoError(t *testing.T) {
+	path := filepath.Join(".", "testdata", "test_cpu_info_error")
+	cpu, err := ReadCPUInfo(path)
+	assert.Nil(t, cpu)
+	assert.Error(t, err)
+}
+
+func TestGetCPUFlags(t *testing.T) {
+	proc1 := Processor{
+		Flags: []string{"flag1", "flag2"},
+	}
+	proc2 := Processor{
+		Flags: []string{"flag1", "flag3"},
+	}
+	cpu := &CPUInfo{
+		[]Processor{proc1, proc2},
+	}
+
+	flagMap := GetCPUFlags(cpu)
+	assert.Equal(t, 3, len(flagMap))
+}

--- a/agent/utils/ioutilwrapper/mocks/ioutilwrapper_mocks.go
+++ b/agent/utils/ioutilwrapper/mocks/ioutilwrapper_mocks.go
@@ -51,7 +51,6 @@ func (m *MockIOUtil) EXPECT() *MockIOUtilMockRecorder {
 
 // TempFile mocks base method
 func (m *MockIOUtil) TempFile(arg0, arg1 string) (oswrapper.File, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TempFile", arg0, arg1)
 	ret0, _ := ret[0].(oswrapper.File)
 	ret1, _ := ret[1].(error)
@@ -60,13 +59,11 @@ func (m *MockIOUtil) TempFile(arg0, arg1 string) (oswrapper.File, error) {
 
 // TempFile indicates an expected call of TempFile
 func (mr *MockIOUtilMockRecorder) TempFile(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TempFile", reflect.TypeOf((*MockIOUtil)(nil).TempFile), arg0, arg1)
 }
 
 // WriteFile mocks base method
 func (m *MockIOUtil) WriteFile(arg0 string, arg1 []byte, arg2 os.FileMode) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WriteFile", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -74,6 +71,5 @@ func (m *MockIOUtil) WriteFile(arg0 string, arg1 []byte, arg2 os.FileMode) error
 
 // WriteFile indicates an expected call of WriteFile
 func (mr *MockIOUtilMockRecorder) WriteFile(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteFile", reflect.TypeOf((*MockIOUtil)(nil).WriteFile), arg0, arg1, arg2)
 }

--- a/agent/utils/testdata/test_cpu_info
+++ b/agent/utils/testdata/test_cpu_info
@@ -1,0 +1,24 @@
+processor       : 0
+vendor_id       : GenuineIntel
+cpu family      : 6
+model           : 85
+model name      : Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz
+stepping        : 4
+fpu             : yes
+fpu_exception   : yes
+cpuid level     : 13
+wp              : yes
+flags           : fpu vme de pse tsc msr pae mce
+
+processor       : 1
+vendor_id       : GenuineIntel
+cpu family      : 6
+model           : 85
+model name      : Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz
+stepping        : 4
+fpu             : yes
+fpu_exception   : yes
+cpuid level     : 13
+wp              : yes
+flags           : fpu vme de pse tsc msr pae mce cx8 avx
+

--- a/agent/utils/testdata/test_cpu_info_arm
+++ b/agent/utils/testdata/test_cpu_info_arm
@@ -1,0 +1,18 @@
+processor	: 0
+BogoMIPS	: 166.66
+Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32
+CPU implementer	: 0x41
+CPU architecture: 8
+CPU variant	: 0x0
+CPU part	: 0xd08
+CPU revision	: 3
+
+processor	: 1
+BogoMIPS	: 166.66
+Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32 cpuid
+CPU implementer	: 0x41
+CPU architecture: 8
+CPU variant	: 0x0
+CPU part	: 0xd08
+CPU revision	: 3
+

--- a/agent/utils/testdata/test_cpu_info_no_flag
+++ b/agent/utils/testdata/test_cpu_info_no_flag
@@ -1,0 +1,11 @@
+processor       : 0
+vendor_id       : GenuineIntel
+cpu family      : 6
+model           : 85
+model name      : Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz
+stepping        : 4
+microcode       : 0x200005e
+cpu MHz         : 2500.000
+cache size      : 33792 KB
+physical id     : 0
+


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
In order to not impact performance of DL job, it requires CPU has support for AVX, AVX2, SSE4.1 and SSE4.2 instruction sets. Agent will check for this and advertise as a new capability so that Backend can place tasks accordingly. 

### Implementation details
<!-- How are the changes implemented? -->
1. Whether each processor supports the required instruction set is reflected in /proc/cpuinfo file as 'flags' or 'Features'. 
2. Normally for all processors on the same host, they should have same values for 'flags' or 'Features'. However, there is possibility that customers may change some configuration which make it different. Here, I merge the values from all processors. (There are some examples in the added testdata folder).

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
1. Add new unit tests
2. Build agent and manually test on multiple platforms: AL1, AL2, ARM

New tests cover the changes: <!-- yes|no -->
yes
### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
