### PR TITLE
Add missing lock for accessing Container.DependsOn field

### DIFF
--- a/agent/api/container/container_test.go
+++ b/agent/api/container/container_test.go
@@ -531,7 +531,7 @@ func TestDependsOnContainer(t *testing.T) {
 			name: "test DependsOnContainer positive case",
 			container: &Container{
 				Name: "container1",
-				DependsOn: []DependsOn{
+				DependsOnUnsafe: []DependsOn{
 					{
 						ContainerName: "container2",
 						Condition:     "START",
@@ -545,7 +545,7 @@ func TestDependsOnContainer(t *testing.T) {
 			name: "test DependsOnContainer negative case",
 			container: &Container{
 				Name: "container1",
-				DependsOn: []DependsOn{
+				DependsOnUnsafe: []DependsOn{
 					{
 						ContainerName: "container2",
 						Condition:     "START",
@@ -570,7 +570,7 @@ func TestAddContainerDependency(t *testing.T) {
 	}
 	container.AddContainerDependency("container2", "START")
 
-	assert.Contains(t, container.DependsOn, DependsOn{
+	assert.Contains(t, container.DependsOnUnsafe, DependsOn{
 		ContainerName: "container2",
 		Condition:     "START",
 	})

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -1612,7 +1612,7 @@ func (task *Task) initializeContainerOrderingForVolumes() error {
 					return fmt.Errorf("could not find container with name %s", volume.SourceContainer)
 				}
 				dependOn := apicontainer.DependsOn{ContainerName: volume.SourceContainer, Condition: ContainerOrderingCreateCondition}
-				container.DependsOn = append(container.DependsOn, dependOn)
+				container.SetDependsOn(append(container.GetDependsOn(), dependOn))
 			}
 		}
 	}
@@ -1632,7 +1632,7 @@ func (task *Task) initializeContainerOrderingForLinks() error {
 					return fmt.Errorf("could not find container with name %s", linkName)
 				}
 				dependOn := apicontainer.DependsOn{ContainerName: linkName, Condition: ContainerOrderingStartCondition}
-				container.DependsOn = append(container.DependsOn, dependOn)
+				container.SetDependsOn(append(container.GetDependsOn(), dependOn))
 			}
 		}
 	}

--- a/agent/api/task/task_linux_test.go
+++ b/agent/api/task/task_linux_test.go
@@ -607,7 +607,7 @@ func TestPostUnmarshalWithFirelensContainer(t *testing.T) {
 	assert.NotNil(t, firelensResource.GetContainerToLogOptions())
 	assert.Equal(t, "value1", firelensResource.GetContainerToLogOptions()["logsender"]["key1"])
 	assert.Equal(t, "value2", firelensResource.GetContainerToLogOptions()["logsender"]["key2"])
-	assert.Contains(t, task.Containers[0].DependsOn, apicontainer.DependsOn{
+	assert.Contains(t, task.Containers[0].DependsOnUnsafe, apicontainer.DependsOn{
 		ContainerName: task.Containers[1].Name,
 		Condition:     ContainerOrderingStartCondition,
 	})
@@ -857,7 +857,7 @@ func TestAddFirelensContainerDependency(t *testing.T) {
 				task.Containers = append(task.Containers, &apicontainer.Container{
 					Name: "container2",
 				})
-				task.Containers[1].DependsOn = append(task.Containers[1].DependsOn, apicontainer.DependsOn{
+				task.Containers[1].DependsOnUnsafe = append(task.Containers[1].DependsOnUnsafe, apicontainer.DependsOn{
 					ContainerName: "container2",
 					Condition:     ContainerOrderingStartCondition,
 				})
@@ -873,11 +873,11 @@ func TestAddFirelensContainerDependency(t *testing.T) {
 			assert.NoError(t, err)
 
 			if tc.shouldAddDependency {
-				assert.Equal(t, 1, len(tc.task.Containers[0].DependsOn))
-				assert.Equal(t, tc.task.Containers[1].Name, tc.task.Containers[0].DependsOn[0].ContainerName)
-				assert.Equal(t, ContainerOrderingStartCondition, tc.task.Containers[0].DependsOn[0].Condition)
+				assert.Equal(t, 1, len(tc.task.Containers[0].DependsOnUnsafe))
+				assert.Equal(t, tc.task.Containers[1].Name, tc.task.Containers[0].DependsOnUnsafe[0].ContainerName)
+				assert.Equal(t, ContainerOrderingStartCondition, tc.task.Containers[0].DependsOnUnsafe[0].Condition)
 			} else {
-				assert.Empty(t, tc.task.Containers[0].DependsOn)
+				assert.Empty(t, tc.task.Containers[0].DependsOnUnsafe)
 			}
 		})
 	}

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -2917,21 +2917,21 @@ func TestInitializeContainerOrderingWithLinksAndVolumesFrom(t *testing.T) {
 	assert.NoError(t, err)
 
 	containerResultWithVolume := task.Containers[0]
-	assert.Equal(t, "myName1", containerResultWithVolume.DependsOn[0].ContainerName)
-	assert.Equal(t, ContainerOrderingCreateCondition, containerResultWithVolume.DependsOn[0].Condition)
+	assert.Equal(t, "myName1", containerResultWithVolume.DependsOnUnsafe[0].ContainerName)
+	assert.Equal(t, ContainerOrderingCreateCondition, containerResultWithVolume.DependsOnUnsafe[0].Condition)
 
 	containerResultWithLink := task.Containers[1]
-	assert.Equal(t, "myName", containerResultWithLink.DependsOn[0].ContainerName)
-	assert.Equal(t, ContainerOrderingStartCondition, containerResultWithLink.DependsOn[0].Condition)
+	assert.Equal(t, "myName", containerResultWithLink.DependsOnUnsafe[0].ContainerName)
+	assert.Equal(t, ContainerOrderingStartCondition, containerResultWithLink.DependsOnUnsafe[0].Condition)
 
 	containerResultWithBothVolumeAndLink := task.Containers[2]
-	assert.Equal(t, "myName", containerResultWithBothVolumeAndLink.DependsOn[0].ContainerName)
-	assert.Equal(t, ContainerOrderingCreateCondition, containerResultWithBothVolumeAndLink.DependsOn[0].Condition)
-	assert.Equal(t, "myName1", containerResultWithBothVolumeAndLink.DependsOn[1].ContainerName)
-	assert.Equal(t, ContainerOrderingStartCondition, containerResultWithBothVolumeAndLink.DependsOn[1].Condition)
+	assert.Equal(t, "myName", containerResultWithBothVolumeAndLink.DependsOnUnsafe[0].ContainerName)
+	assert.Equal(t, ContainerOrderingCreateCondition, containerResultWithBothVolumeAndLink.DependsOnUnsafe[0].Condition)
+	assert.Equal(t, "myName1", containerResultWithBothVolumeAndLink.DependsOnUnsafe[1].ContainerName)
+	assert.Equal(t, ContainerOrderingStartCondition, containerResultWithBothVolumeAndLink.DependsOnUnsafe[1].Condition)
 
 	containerResultWithNoVolumeOrLink := task.Containers[3]
-	assert.Equal(t, 0, len(containerResultWithNoVolumeOrLink.DependsOn))
+	assert.Equal(t, 0, len(containerResultWithNoVolumeOrLink.DependsOnUnsafe))
 }
 
 func TestInitializeContainerOrderingWithError(t *testing.T) {

--- a/agent/engine/dependencygraph/graph.go
+++ b/agent/engine/dependencygraph/graph.go
@@ -218,7 +218,8 @@ func verifyContainerOrderingStatusResolvable(target *apicontainer.Container, exi
 		return nil, nil
 	}
 
-	for _, dependency := range target.DependsOn {
+	targetDependencies := target.GetDependsOn()
+	for _, dependency := range targetDependencies {
 		dependencyContainer, ok := existingContainers[dependency.ContainerName]
 		if !ok {
 			return nil, fmt.Errorf("dependency graph: container ordering dependency [%v] for target [%v] does not exist.", dependencyContainer, target)
@@ -421,7 +422,8 @@ func verifyShutdownOrder(target *apicontainer.Container, existingContainers map[
 	missingShutdownDependencies := []string{}
 
 	for _, existingContainer := range existingContainers {
-		for _, dependency := range existingContainer.DependsOn {
+		dependencies := existingContainer.GetDependsOn()
+		for _, dependency := range dependencies {
 			// If another container declares a dependency on our target, we will want to verify that the container is
 			// stopped.
 			if dependency.ContainerName == target.Name {

--- a/agent/engine/dependencygraph/graph_test.go
+++ b/agent/engine/dependencygraph/graph_test.go
@@ -42,7 +42,7 @@ func volumeStrToVol(vols []string) []apicontainer.VolumeFrom {
 func steadyStateContainer(name string, dependsOn []apicontainer.DependsOn, desiredState apicontainerstatus.ContainerStatus, steadyState apicontainerstatus.ContainerStatus) *apicontainer.Container {
 	container := apicontainer.NewContainerWithSteadyState(steadyState)
 	container.Name = name
-	container.DependsOn = dependsOn
+	container.DependsOnUnsafe = dependsOn
 	container.DesiredStatusUnsafe = desiredState
 	return container
 }
@@ -50,7 +50,7 @@ func steadyStateContainer(name string, dependsOn []apicontainer.DependsOn, desir
 func createdContainer(name string, dependsOn []apicontainer.DependsOn, steadyState apicontainerstatus.ContainerStatus) *apicontainer.Container {
 	container := apicontainer.NewContainerWithSteadyState(steadyState)
 	container.Name = name
-	container.DependsOn = dependsOn
+	container.DependsOnUnsafe = dependsOn
 	container.DesiredStatusUnsafe = apicontainerstatus.ContainerCreated
 	return container
 }
@@ -901,22 +901,22 @@ func TestVerifyShutdownOrder(t *testing.T) {
 	others := map[string]*apicontainer.Container{
 		"A": {
 			Name:              "A",
-			DependsOn:         dependsOn("B"),
+			DependsOnUnsafe:   dependsOn("B"),
 			KnownStatusUnsafe: apicontainerstatus.ContainerStopped,
 		},
 		"B": {
 			Name:              "B",
-			DependsOn:         dependsOn("C", "D"),
+			DependsOnUnsafe:   dependsOn("C", "D"),
 			KnownStatusUnsafe: apicontainerstatus.ContainerRunning,
 		},
 		"C": {
 			Name:              "C",
-			DependsOn:         dependsOn("E", "F"),
+			DependsOnUnsafe:   dependsOn("E", "F"),
 			KnownStatusUnsafe: apicontainerstatus.ContainerStopped,
 		},
 		"D": {
 			Name:              "D",
-			DependsOn:         dependsOn("E"),
+			DependsOnUnsafe:   dependsOn("E"),
 			KnownStatusUnsafe: apicontainerstatus.ContainerRunning,
 		},
 	}

--- a/agent/engine/engine_sudo_linux_integ_test.go
+++ b/agent/engine/engine_sudo_linux_integ_test.go
@@ -271,7 +271,7 @@ func createFirelensTask(t *testing.T) *apitask.Task {
 					return &s
 				}(),
 			},
-			DependsOn: []apicontainer.DependsOn{
+			DependsOnUnsafe: []apicontainer.DependsOn{
 				{
 					ContainerName: "firelens",
 					Condition:     "START",

--- a/agent/engine/ordering_integ_test.go
+++ b/agent/engine/ordering_integ_test.go
@@ -44,7 +44,7 @@ func TestDependencyHealthCheck(t *testing.T) {
 
 	parent.EntryPoint = &entryPointForOS
 	parent.Command = []string{"exit 0"}
-	parent.DependsOn = []apicontainer.DependsOn{
+	parent.DependsOnUnsafe = []apicontainer.DependsOn{
 		{
 			ContainerName: "dependency",
 			Condition:     "HEALTHY",
@@ -97,7 +97,7 @@ func TestDependencyComplete(t *testing.T) {
 
 	parent.EntryPoint = &entryPointForOS
 	parent.Command = []string{"sleep 5"}
-	parent.DependsOn = []apicontainer.DependsOn{
+	parent.DependsOnUnsafe = []apicontainer.DependsOn{
 		{
 			ContainerName: "dependency",
 			Condition:     "COMPLETE",
@@ -150,7 +150,7 @@ func TestDependencySuccess(t *testing.T) {
 
 	parent.EntryPoint = &entryPointForOS
 	parent.Command = []string{"exit 0"}
-	parent.DependsOn = []apicontainer.DependsOn{
+	parent.DependsOnUnsafe = []apicontainer.DependsOn{
 		{
 			ContainerName: "dependency",
 			Condition:     "SUCCESS",
@@ -203,7 +203,7 @@ func TestDependencySuccessErrored(t *testing.T) {
 
 	parent.EntryPoint = &entryPointForOS
 	parent.Command = []string{"exit 0"}
-	parent.DependsOn = []apicontainer.DependsOn{
+	parent.DependsOnUnsafe = []apicontainer.DependsOn{
 		{
 			ContainerName: "dependency",
 			Condition:     "SUCCESS",
@@ -250,7 +250,7 @@ func TestDependencySuccessTimeout(t *testing.T) {
 
 	parent.EntryPoint = &entryPointForOS
 	parent.Command = []string{"exit 0"}
-	parent.DependsOn = []apicontainer.DependsOn{
+	parent.DependsOnUnsafe = []apicontainer.DependsOn{
 		{
 			ContainerName: "dependency",
 			Condition:     "SUCCESS",
@@ -300,7 +300,7 @@ func TestDependencyHealthyTimeout(t *testing.T) {
 
 	parent.EntryPoint = &entryPointForOS
 	parent.Command = []string{"exit 0"}
-	parent.DependsOn = []apicontainer.DependsOn{
+	parent.DependsOnUnsafe = []apicontainer.DependsOn{
 		{
 			ContainerName: "dependency",
 			Condition:     "HEALTHY",
@@ -361,7 +361,7 @@ func TestShutdownOrder(t *testing.T) {
 	parent.EntryPoint = &entryPointForOS
 	parent.Command = []string{"echo hi"}
 	parent.Essential = true
-	parent.DependsOn = []apicontainer.DependsOn{
+	parent.DependsOnUnsafe = []apicontainer.DependsOn{
 		{
 			ContainerName: "A",
 			Condition:     "START",
@@ -370,7 +370,7 @@ func TestShutdownOrder(t *testing.T) {
 
 	A.EntryPoint = &entryPointForOS
 	A.Command = []string{"sleep 100"}
-	A.DependsOn = []apicontainer.DependsOn{
+	A.DependsOnUnsafe = []apicontainer.DependsOn{
 		{
 			ContainerName: "B",
 			Condition:     "START",
@@ -379,7 +379,7 @@ func TestShutdownOrder(t *testing.T) {
 
 	B.EntryPoint = &entryPointForOS
 	B.Command = []string{"sleep 100"}
-	B.DependsOn = []apicontainer.DependsOn{
+	B.DependsOnUnsafe = []apicontainer.DependsOn{
 		{
 			ContainerName: "C",
 			Condition:     "START",

--- a/agent/engine/ordering_integ_unix_test.go
+++ b/agent/engine/ordering_integ_unix_test.go
@@ -46,7 +46,7 @@ func TestGranularStopTimeout(t *testing.T) {
 	parent.EntryPoint = &entryPointForOS
 	parent.Command = []string{"sleep 30"}
 	parent.Essential = true
-	parent.DependsOn = []apicontainer.DependsOn{
+	parent.DependsOnUnsafe = []apicontainer.DependsOn{
 		{
 			ContainerName: "dependency1",
 			Condition:     "START",

--- a/agent/statemanager/state_manager_test.go
+++ b/agent/statemanager/state_manager_test.go
@@ -358,7 +358,7 @@ func TestLoadsDataForContainerOrdering(t *testing.T) {
 	assert.Equal(t, "container-ordering-state", task.Family)
 	assert.Equal(t, 2, len(task.Containers))
 
-	dependsOn := task.Containers[1].DependsOn
+	dependsOn := task.Containers[1].DependsOnUnsafe
 	assert.Equal(t, "container_1", dependsOn[0].ContainerName)
 	assert.Equal(t, "START", dependsOn[0].Condition)
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Container's DependsOn field is being modified at multiple places so it needs to be protected by lock. This PR adds lock for accessing this field.

### Implementation details
<!-- How are the changes implemented? -->
Add lock and rename DependsOn to DependsOnUnsafe to indicate that access to this field needs to be protected by lock (the json tag for this field remains unchanged so this shouldn't affect acs message/state file marshal/unmarshal).

This touches some codes not related to logrouter. It's just that the logrouter branch is adding more references to this field so i'm merging the fix to logrouter branch to avoid future merge conflict. The fix will go into dev when feature branch is merged.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Rely on existing container dependency tests/state file unit test.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
