### PR TITLE
phase 1: auto restart non-essential contianer & integ tests

### DIFF
--- a/agent/acs/model/api/api-2.json
+++ b/agent/acs/model/api/api-2.json
@@ -212,6 +212,8 @@
         "entryPoint":{"shape":"StringList"},
         "environment":{"shape":"EnvironmentVariables"},
         "essential":{"shape":"Boolean"},
+        "restartPolicy":{"shape":"RestartPolicy"},
+        "restartMaxAttempts":{"shape":"Integer"},
         "image":{"shape":"String"},
         "links":{"shape":"StringList"},
         "memory":{"shape":"Integer"},
@@ -230,6 +232,14 @@
         "stopTimeout":{"shape":"Integer"},
         "firelensConfiguration":{"shape":"FirelensConfiguration"}
       }
+    },
+    "RestartPolicy":{
+      "type":"string",
+      "enum":[
+        "NEVER",
+        "UNLESS_TASK_STOPPED",
+        "ON_FAILURE"
+      ]
     },
     "ContainerCondition":{
       "type":"string",

--- a/agent/acs/model/ecsacs/api.go
+++ b/agent/acs/model/ecsacs/api.go
@@ -310,6 +310,10 @@ type Container struct {
 
 	RegistryAuthentication *RegistryAuthenticationData `locationName:"registryAuthentication" type:"structure"`
 
+	RestartMaxAttempts *int64 `locationName:"restartMaxAttempts" type:"integer"`
+
+	RestartPolicy *string `locationName:"restartPolicy" type:"string" enum:"RestartPolicy"`
+
 	Secrets []*Secret `locationName:"secrets" type:"list"`
 
 	StartTimeout *int64 `locationName:"startTimeout" type:"integer"`

--- a/agent/api/container/container_test.go
+++ b/agent/api/container/container_test.go
@@ -78,6 +78,9 @@ func TestIsKnownSteadyState(t *testing.T) {
 	// Transition container to CREATED, still not in steady state
 	container.SetKnownStatus(apicontainerstatus.ContainerCreated)
 	assert.False(t, container.IsKnownSteadyState())
+	// Transition container to RESTARTING, still not in steady state
+	container.SetKnownStatus(apicontainerstatus.ContainerRestarting)
+	assert.False(t, container.IsKnownSteadyState())
 	// Transition container to RUNNING, now we're in steady state
 	container.SetKnownStatus(apicontainerstatus.ContainerRunning)
 	assert.True(t, container.IsKnownSteadyState())
@@ -102,6 +105,9 @@ func TestGetNextStateProgression(t *testing.T) {
 	assert.Equal(t, container.GetNextKnownStateProgression(), apicontainerstatus.ContainerCreated)
 	container.SetKnownStatus(apicontainerstatus.ContainerCreated)
 	// CREATED should transition to RUNNING
+	assert.Equal(t, container.GetNextKnownStateProgression(), apicontainerstatus.ContainerRunning)
+	// RESTARTING should transition to RUNNING
+	container.SetKnownStatus(apicontainerstatus.ContainerRestarting)
 	assert.Equal(t, container.GetNextKnownStateProgression(), apicontainerstatus.ContainerRunning)
 	container.SetKnownStatus(apicontainerstatus.ContainerRunning)
 	// RUNNING should transition to STOPPED

--- a/agent/api/container/status/containerstatus.go
+++ b/agent/api/container/status/containerstatus.go
@@ -25,6 +25,8 @@ const (
 	ContainerPulled
 	// ContainerCreated represents a container that has been created
 	ContainerCreated
+	// ContainerRestarting represents a container is waiting to be restarted
+	ContainerRestarting
 	// ContainerRunning represents a container that has started
 	ContainerRunning
 	// ContainerResourcesProvisioned represents a container that has completed provisioning all of its
@@ -62,6 +64,7 @@ var containerStatusMap = map[string]ContainerStatus{
 	"RUNNING":               ContainerRunning,
 	"RESOURCES_PROVISIONED": ContainerResourcesProvisioned,
 	"STOPPED":               ContainerStopped,
+	"RESTARTING":            ContainerRestarting,
 }
 
 // BackendStatus returns the container health status recognized by backend

--- a/agent/api/container/status/containerstatus_test.go
+++ b/agent/api/container/status/containerstatus_test.go
@@ -39,6 +39,10 @@ func TestShouldReportToBackend(t *testing.T) {
 	assert.False(t, containerStatus.ShouldReportToBackend(ContainerRunning))
 	assert.False(t, containerStatus.ShouldReportToBackend(ContainerResourcesProvisioned))
 
+	// ContainerRestarting is not reported to backend
+	containerStatus = ContainerRestarting
+	assert.False(t, containerStatus.ShouldReportToBackend(ContainerRunning))
+
 	containerStatus = ContainerRunning
 	// ContainerRunning is reported to backend if the steady state is RUNNING as well
 	assert.True(t, containerStatus.ShouldReportToBackend(ContainerRunning))

--- a/agent/api/task/status/statusmapping.go
+++ b/agent/api/task/status/statusmapping.go
@@ -18,7 +18,8 @@ import (
 )
 
 // MapContainerToTaskStatus maps the container status to the corresponding task status. The
-// transition map is illustrated below.
+// transition map is illustrated below. ContainerRestarting will mapped as Running for get
+// the earliest container status mapped to task status
 //
 // Container: None -> Pulled -> Created -> Running -> Provisioned -> Stopped -> Zombie
 //
@@ -33,6 +34,8 @@ func MapContainerToTaskStatus(knownState apicontainerstatus.ContainerStatus, ste
 		return TaskCreated
 	case apicontainerstatus.ContainerStopped:
 		return TaskStopped
+	case apicontainerstatus.ContainerRestarting:
+		return TaskRunning
 	}
 
 	if knownState == apicontainerstatus.ContainerRunning && steadyState == apicontainerstatus.ContainerResourcesProvisioned {

--- a/agent/api/task/status/statusmapping_test.go
+++ b/agent/api/task/status/statusmapping_test.go
@@ -39,6 +39,10 @@ func TestTaskStatus(t *testing.T) {
 	assert.Equal(t, MapContainerToTaskStatus(containerStatus, apicontainerstatus.ContainerRunning), TaskCreated)
 	assert.Equal(t, MapContainerToTaskStatus(containerStatus, apicontainerstatus.ContainerResourcesProvisioned), TaskCreated)
 
+	// When container state is RESTARTING, Task state is RUNNING
+	containerStatus = apicontainerstatus.ContainerRestarting
+	assert.Equal(t, MapContainerToTaskStatus(containerStatus, apicontainerstatus.ContainerRunning), TaskRunning)
+
 	containerStatus = apicontainerstatus.ContainerRunning
 	// When container state is RUNNING and steadyState is RUNNING, Task state is RUNNING as well
 	assert.Equal(t, MapContainerToTaskStatus(containerStatus, apicontainerstatus.ContainerRunning), TaskRunning)

--- a/agent/api/task/task_windows_test.go
+++ b/agent/api/task/task_windows_test.go
@@ -40,6 +40,9 @@ const (
 func TestPostUnmarshalWindowsCanonicalPaths(t *testing.T) {
 	// Testing type conversions, bleh. At least the type conversion itself
 	// doesn't look this messy.
+	boolptr := func(b bool) *bool {
+		return &b
+	}
 	taskFromAcs := ecsacs.Task{
 		Arn:           strptr("myArn"),
 		DesiredStatus: strptr("RUNNING"),
@@ -47,7 +50,8 @@ func TestPostUnmarshalWindowsCanonicalPaths(t *testing.T) {
 		Version:       strptr("1"),
 		Containers: []*ecsacs.Container{
 			{
-				Name: strptr("myName"),
+				Name:      strptr("myName"),
+				Essential: boolptr(true),
 				MountPoints: []*ecsacs.MountPoint{
 					{
 						ContainerPath: strptr(`C:/Container/Path`),
@@ -73,7 +77,8 @@ func TestPostUnmarshalWindowsCanonicalPaths(t *testing.T) {
 		Version:             "1",
 		Containers: []*apicontainer.Container{
 			{
-				Name: "myName",
+				Name:      "myName",
+				Essential: true,
 				MountPoints: []apicontainer.MountPoint{
 					{
 						ContainerPath: `c:\container\path`,

--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -46,6 +46,7 @@ const (
 	capabilityNvidiaDriverVersionInfix          = "nvidia-driver-version."
 	capabilityECREndpoint                       = "ecr-endpoint"
 	capabilityContainerOrdering                 = "container-ordering"
+	capabilityAutoRestartNonEssentialContainers = "auto-restart-non-essential-containers"
 	taskEIAAttributeSuffix                      = "task-eia"
 	taskEIAWithOptimizedCPU                     = "task-eia.optimized-cpu"
 	taskENITrunkingAttributeSuffix              = "task-eni-trunking"
@@ -180,6 +181,9 @@ func (agent *ecsAgent) capabilities() ([]*ecs.Attribute, error) {
 
 	// support aws router capabilities for log driver router
 	capabilities = agent.appendFirelensLoggingDriverCapabilities(capabilities)
+
+	// support auto restart non-essential container in agent
+	capabilities = appendNameOnlyAttribute(capabilities, attributePrefix+capabilityAutoRestartNonEssentialContainers)
 
 	return capabilities, nil
 }

--- a/agent/app/agent_capability_test.go
+++ b/agent/app/agent_capability_test.go
@@ -129,6 +129,9 @@ func TestCapabilities(t *testing.T) {
 			{
 				Name: aws.String(attributePrefix + capabilityContainerOrdering),
 			},
+			{
+				Name: aws.String(attributePrefix + capabilityAutoRestartNonEssentialContainers),
+			},
 		}...)
 
 	ctx, cancel := context.WithCancel(context.TODO())
@@ -145,9 +148,8 @@ func TestCapabilities(t *testing.T) {
 	capabilities, err := agent.capabilities()
 	assert.NoError(t, err)
 
-	for i, expected := range expectedCapabilities {
-		assert.Equal(t, aws.StringValue(expected.Name), aws.StringValue(capabilities[i].Name))
-		assert.Equal(t, aws.StringValue(expected.Value), aws.StringValue(capabilities[i].Value))
+	for _, expected := range expectedCapabilities {
+		assert.Contains(t, capabilities, expected)
 	}
 }
 

--- a/agent/app/agent_capability_windows_test.go
+++ b/agent/app/agent_capability_windows_test.go
@@ -210,6 +210,9 @@ func TestSupportedCapabilitiesWindows(t *testing.T) {
 			{
 				Name: aws.String(attributePrefix + capabilityContainerOrdering),
 			},
+			{
+				Name: aws.String(attributePrefix + capabilityAutoRestartNonEssentialContainers),
+			},
 		}...)
 
 	ctx, cancel := context.WithCancel(context.TODO())
@@ -226,8 +229,7 @@ func TestSupportedCapabilitiesWindows(t *testing.T) {
 	capabilities, err := agent.capabilities()
 	assert.NoError(t, err)
 	assert.Equal(t, len(expectedCapabilities), len(capabilities))
-	for i, expected := range expectedCapabilities {
-		assert.Equal(t, aws.StringValue(expected.Name), aws.StringValue(capabilities[i].Name))
-		assert.Equal(t, aws.StringValue(expected.Value), aws.StringValue(capabilities[i].Value))
+	for _, expected := range expectedCapabilities {
+		assert.Contains(t, capabilities, expected)
 	}
 }

--- a/agent/dockerclient/dockerapi/docker_client.go
+++ b/agent/dockerclient/dockerapi/docker_client.go
@@ -1332,7 +1332,6 @@ func (dg *dockerGoClient) Stats(ctx context.Context, id string, inactivityTimeou
 					seelog.Warnf("DockerGoClient: inactivity time exceeded timeout while retrieving stats for container %s", id)
 					return
 				}
-
 				statsChnl <- data
 				data = new(types.StatsJSON)
 			}

--- a/agent/engine/common_test.go
+++ b/agent/engine/common_test.go
@@ -92,7 +92,7 @@ func verifyTaskIsRunning(stateChangeEvents <-chan statechange.Event, task *apita
 			return nil
 		}
 		if taskEvent.Status > apitaskstatus.TaskRunning {
-			return fmt.Errorf("Task went straight to %s without running, task: %s", taskEvent.Status.String(), task.Arn)
+			return fmt.Errorf("task went straight to %s without running, task: %s", taskEvent.Status.String(), task.Arn)
 		}
 	}
 }
@@ -105,6 +105,20 @@ func verifyTaskIsStopped(stateChangeEvents <-chan statechange.Event, task *apita
 		}
 		taskEvent := event.(api.TaskStateChange)
 		if taskEvent.TaskARN == task.Arn && taskEvent.Status >= apitaskstatus.TaskStopped {
+			return
+		}
+	}
+}
+
+func verifyTaskIsStoppedWithReason(stateChangeEvents <-chan statechange.Event, task *apitask.Task) {
+	for {
+		event := <-stateChangeEvents
+		if event.GetEventType() != statechange.TaskEvent {
+			continue
+		}
+		taskEvent := event.(api.TaskStateChange)
+		if taskEvent.TaskARN == task.Arn && taskEvent.Status >= apitaskstatus.TaskStopped &&
+			taskEvent.Reason != "" {
 			return
 		}
 	}

--- a/agent/engine/common_unix_integ_test.go
+++ b/agent/engine/common_unix_integ_test.go
@@ -37,6 +37,11 @@ func getLongRunningCommand() []string {
 	return []string{"-loop=true"}
 }
 
+// getAlternateExitCodeCommand will exit alternately each time running the command by saving exit code to a file
+func getAlternateExitCodeCommand() []string {
+	return []string{"read t < t.file && let 't=1-t' || t=0; echo $t > t.file; exit $t"}
+}
+
 func isDockerRunning() bool {
 	_, err := os.Stat("/var/run/docker.sock")
 	return err == nil

--- a/agent/engine/dependencygraph/graph_test.go
+++ b/agent/engine/dependencygraph/graph_test.go
@@ -264,6 +264,11 @@ func TestOnSteadyStateIsResolved(t *testing.T) {
 		},
 		{
 			TargetDesired: apicontainerstatus.ContainerCreated,
+			RunKnown:      apicontainerstatus.ContainerRestarting,
+			Resolved:      false,
+		},
+		{
+			TargetDesired: apicontainerstatus.ContainerCreated,
 			RunKnown:      apicontainerstatus.ContainerRunning,
 			Resolved:      true,
 		},
@@ -689,6 +694,26 @@ func TestContainerOrderingCanResolve(t *testing.T) {
 	}
 }
 
+func TestContainerOrderingCanResolveForAlwaysRestartingContainer(t *testing.T) {
+	// always restarting containers should not be dependent for `SUCCESS` and `COMPLETE`
+	for _, depCond := range []string{successCondition, completeCondition} {
+		target := &apicontainer.Container{
+			DesiredStatusUnsafe: apicontainerstatus.ContainerRunning,
+		}
+		dep := &apicontainer.Container{
+			DesiredStatusUnsafe: apicontainerstatus.ContainerRunning,
+			KnownStatusUnsafe:   apicontainerstatus.ContainerRunning,
+			KnownExitCodeUnsafe: aws.Int(1),
+			RestartInfo: &apicontainer.RestartInfo{
+				RestartPolicy: apicontainer.UnlessTaskStopped,
+			},
+			Essential: false,
+		}
+		resolvable := containerOrderingDependenciesCanResolve(target, dep, depCond)
+		assert.Equal(t, false, resolvable)
+	}
+}
+
 func TestContainerOrderingIsResolved(t *testing.T) {
 	testcases := []struct {
 		TargetDesired       apicontainerstatus.ContainerStatus
@@ -710,6 +735,12 @@ func TestContainerOrderingIsResolved(t *testing.T) {
 			Resolved:            true,
 		},
 		{
+			TargetDesired:       apicontainerstatus.ContainerCreated,
+			DependencyKnown:     apicontainerstatus.ContainerRestarting,
+			DependencyCondition: createCondition,
+			Resolved:            true,
+		},
+		{
 			TargetDesired:       apicontainerstatus.ContainerRunning,
 			DependencyKnown:     apicontainerstatus.ContainerStopped,
 			DependencyCondition: createCondition,
@@ -734,6 +765,12 @@ func TestContainerOrderingIsResolved(t *testing.T) {
 			Resolved:            true,
 		},
 		{
+			TargetDesired:       apicontainerstatus.ContainerRunning,
+			DependencyKnown:     apicontainerstatus.ContainerRestarting,
+			DependencyCondition: createCondition,
+			Resolved:            true,
+		},
+		{
 			TargetDesired:       apicontainerstatus.ContainerCreated,
 			DependencyKnown:     apicontainerstatus.ContainerCreated,
 			DependencyCondition: startCondition,
@@ -741,6 +778,12 @@ func TestContainerOrderingIsResolved(t *testing.T) {
 		},
 		{
 			TargetDesired:       apicontainerstatus.ContainerCreated,
+			DependencyKnown:     apicontainerstatus.ContainerRestarting,
+			DependencyCondition: startCondition,
+			Resolved:            true,
+		},
+		{
+			TargetDesired:       apicontainerstatus.ContainerCreated,
 			DependencyKnown:     apicontainerstatus.ContainerRunning,
 			DependencyCondition: startCondition,
 			Resolved:            true,
@@ -779,6 +822,20 @@ func TestContainerOrderingIsResolved(t *testing.T) {
 		},
 		{
 			TargetDesired:       apicontainerstatus.ContainerRunning,
+			DependencyKnown:     apicontainerstatus.ContainerRestarting,
+			DependencyCondition: successCondition,
+			ExitCode:            0,
+			Resolved:            false,
+		},
+		{
+			TargetDesired:       apicontainerstatus.ContainerRunning,
+			DependencyKnown:     apicontainerstatus.ContainerRestarting,
+			DependencyCondition: successCondition,
+			ExitCode:            1,
+			Resolved:            false,
+		},
+		{
+			TargetDesired:       apicontainerstatus.ContainerRunning,
 			DependencyKnown:     apicontainerstatus.ContainerStopped,
 			DependencyCondition: completeCondition,
 			ExitCode:            0,
@@ -790,6 +847,20 @@ func TestContainerOrderingIsResolved(t *testing.T) {
 			DependencyCondition: completeCondition,
 			ExitCode:            1,
 			Resolved:            true,
+		},
+		{
+			TargetDesired:       apicontainerstatus.ContainerRunning,
+			DependencyKnown:     apicontainerstatus.ContainerRestarting,
+			DependencyCondition: completeCondition,
+			ExitCode:            0,
+			Resolved:            false,
+		},
+		{
+			TargetDesired:       apicontainerstatus.ContainerRunning,
+			DependencyKnown:     apicontainerstatus.ContainerRestarting,
+			DependencyCondition: completeCondition,
+			ExitCode:            1,
+			Resolved:            false,
 		},
 		{
 			TargetDesired:       apicontainerstatus.ContainerRunning,

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -454,6 +454,7 @@ func (engine *DockerTaskEngine) checkTaskState(task *apitask.Task) {
 		if !ok {
 			continue
 		}
+		restartAttempts := container.GetRestartAttempts()
 		status, metadata := engine.client.DescribeContainer(engine.ctx, dockerContainer.DockerID)
 		engine.tasksLock.RLock()
 		managedTask, ok := engine.managedTasks[task.Arn]
@@ -466,8 +467,43 @@ func (engine *DockerTaskEngine) checkTaskState(task *apitask.Task) {
 					Status:                  status,
 					DockerContainerMetadata: metadata,
 				},
+				fromDockerEvent:              false,
+				containerPrevRestartAttempts: restartAttempts,
 			})
 		}
+	}
+}
+
+// checkContainerState inspects the state of input container and writes
+// its state to the managed task's container channel.
+// TODO: Add Unit test
+func (engine *DockerTaskEngine) checkContainerState(container *apicontainer.Container, task *apitask.Task) {
+	taskContainers, ok := engine.state.ContainerMapByArn(task.Arn)
+	if !ok {
+		seelog.Warnf("Task engine [%s]: could not check container %s state; no task in state", task.Arn, container.Name)
+		return
+	}
+
+	dockerContainer, ok := taskContainers[container.Name]
+	if !ok {
+		return
+	}
+	restartAttempts := container.GetRestartAttempts()
+	status, metadata := engine.client.DescribeContainer(engine.ctx, dockerContainer.DockerID)
+	engine.tasksLock.RLock()
+	managedTask, ok := engine.managedTasks[task.Arn]
+	engine.tasksLock.RUnlock()
+
+	if ok {
+		managedTask.emitDockerContainerChange(dockerContainerChange{
+			container: container,
+			event: dockerapi.DockerContainerChangeEvent{
+				Status:                  status,
+				DockerContainerMetadata: metadata,
+			},
+			fromDockerEvent:              false,
+			containerPrevRestartAttempts: restartAttempts,
+		})
 	}
 }
 
@@ -636,7 +672,7 @@ func (engine *DockerTaskEngine) handleDockerEvent(event dockerapi.DockerContaine
 	}
 	seelog.Debugf("Task engine [%s]: writing docker event to the task: %s",
 		task.Arn, event.String())
-	managedTask.emitDockerContainerChange(dockerContainerChange{container: cont.Container, event: event})
+	managedTask.emitDockerContainerChange(dockerContainerChange{container: cont.Container, event: event, fromDockerEvent: true})
 	seelog.Debugf("Task engine [%s]: wrote docker event to the task: %s",
 		task.Arn, event.String())
 }
@@ -1235,6 +1271,10 @@ func (engine *DockerTaskEngine) updateTaskUnsafe(task *apitask.Task, update *api
 func (engine *DockerTaskEngine) transitionContainer(task *apitask.Task, container *apicontainer.Container, to apicontainerstatus.ContainerStatus) {
 	// Let docker events operate async so that we can continue to handle ACS / other requests
 	// This is safe because 'applyContainerState' will not mutate the task
+
+	// Get restartAttempts when making the api call, and include this in ContainerChange event, this is useful for
+	// restarting non-essential containers to check if it's a new status change.
+	restartAttempts := container.GetRestartAttempts()
 	metadata := engine.applyContainerState(task, container, to)
 
 	engine.tasksLock.RLock()
@@ -1247,6 +1287,8 @@ func (engine *DockerTaskEngine) transitionContainer(task *apitask.Task, containe
 				Status:                  to,
 				DockerContainerMetadata: metadata,
 			},
+			fromDockerEvent:              false,
+			containerPrevRestartAttempts: restartAttempts,
 		})
 	}
 }

--- a/agent/engine/engine_windows_integ_test.go
+++ b/agent/engine/engine_windows_integ_test.go
@@ -72,6 +72,11 @@ func getLongRunningCommand() []string {
 	return []string{"ping", "-t", "localhost"}
 }
 
+// getAlternateExitCodeCommand will exit alternately each time running the command by saving exit code to a file
+func getAlternateExitCodeCommand() []string {
+	return []string{"If($t = Get-Content test.txt) {$t=1-$t; echo $t} Else {$t=0}; echo $t > test.txt; exit $t"}
+}
+
 func createTestHostVolumeMountTask(tmpPath string) *apitask.Task {
 	testTask := createTestTask("testHostVolumeMount")
 	testTask.Volumes = []apitask.TaskVolume{{Name: "test-tmp", Volume: &taskresourcevolume.FSHostVolume{FSSourcePath: tmpPath}}}

--- a/agent/engine/task_manager_test.go
+++ b/agent/engine/task_manager_test.go
@@ -212,6 +212,177 @@ func TestHandleEventError(t *testing.T) {
 	}
 }
 
+func TestHandleEventErrorRestartingNonEssentialContainersFromDockerAPI(t *testing.T) {
+	testCases := []struct {
+		Name                                  string
+		EventStatus                           apicontainerstatus.ContainerStatus
+		CurrentContainerKnownStatus           apicontainerstatus.ContainerStatus
+		ImagePullBehavior                     config.ImagePullBehaviorType
+		Error                                 apierrors.NamedError
+		ExpectedContainerKnownStatusSet       bool
+		ExpectedContainerKnownStatus          apicontainerstatus.ContainerStatus
+		ExpectedContainerDesiredStatusStopped bool
+		ExpectedTaskDesiredStatusStopped      bool
+		ExpectedOK                            bool
+	}{
+		{
+			Name:                            "Stop timed out",
+			EventStatus:                     apicontainerstatus.ContainerStopped,
+			CurrentContainerKnownStatus:     apicontainerstatus.ContainerRunning,
+			Error:                           &dockerapi.DockerTimeoutError{},
+			ExpectedContainerKnownStatusSet: true,
+			ExpectedContainerKnownStatus:    apicontainerstatus.ContainerRunning,
+			ExpectedOK:                      false,
+		},
+		{
+			Name:                        "Retriable error with stop",
+			EventStatus:                 apicontainerstatus.ContainerStopped,
+			CurrentContainerKnownStatus: apicontainerstatus.ContainerRunning,
+			Error: &dockerapi.CannotStopContainerError{
+				FromError: errors.New(""),
+			},
+			ExpectedContainerKnownStatusSet: true,
+			ExpectedContainerKnownStatus:    apicontainerstatus.ContainerRunning,
+			ExpectedOK:                      false,
+		},
+		{
+			Name:                        "Unretriable error with Stop",
+			EventStatus:                 apicontainerstatus.ContainerStopped,
+			CurrentContainerKnownStatus: apicontainerstatus.ContainerRunning,
+			Error: &dockerapi.CannotStopContainerError{
+				FromError: dockerapi.NoSuchContainerError{},
+			},
+			ExpectedContainerKnownStatusSet:       true,
+			ExpectedContainerKnownStatus:          apicontainerstatus.ContainerStopped,
+			ExpectedContainerDesiredStatusStopped: true,
+			ExpectedOK:                            true,
+		},
+		{
+			Name:                            "Pull failed",
+			Error:                           &dockerapi.DockerTimeoutError{},
+			ExpectedContainerKnownStatusSet: true,
+			EventStatus:                     apicontainerstatus.ContainerPulled,
+			ExpectedOK:                      true,
+		},
+		{
+			Name:                        "Inspect failed during start",
+			EventStatus:                 apicontainerstatus.ContainerRunning,
+			CurrentContainerKnownStatus: apicontainerstatus.ContainerCreated,
+			Error: &dockerapi.CannotInspectContainerError{
+				FromError: errors.New("error"),
+			},
+			ExpectedContainerKnownStatusSet:       false,
+			ExpectedContainerDesiredStatusStopped: false,
+			ExpectedOK:                            false,
+		},
+		{
+			Name:                        "Inspect failed during restart",
+			EventStatus:                 apicontainerstatus.ContainerRunning,
+			CurrentContainerKnownStatus: apicontainerstatus.ContainerRestarting,
+			Error: &dockerapi.CannotInspectContainerError{
+				FromError: errors.New("error"),
+			},
+			ExpectedContainerKnownStatusSet:       false,
+			ExpectedContainerDesiredStatusStopped: false,
+			ExpectedOK:                            false,
+		},
+		{
+			Name:                                  "Start timed out",
+			EventStatus:                           apicontainerstatus.ContainerRunning,
+			CurrentContainerKnownStatus:           apicontainerstatus.ContainerCreated,
+			Error:                                 &dockerapi.DockerTimeoutError{},
+			ExpectedContainerKnownStatusSet:       false,
+			ExpectedContainerDesiredStatusStopped: false,
+			ExpectedOK:                            false,
+		},
+		{
+			Name:                                  "Restart timed out",
+			EventStatus:                           apicontainerstatus.ContainerRunning,
+			CurrentContainerKnownStatus:           apicontainerstatus.ContainerRestarting,
+			Error:                                 &dockerapi.DockerTimeoutError{},
+			ExpectedContainerKnownStatusSet:       false,
+			ExpectedContainerDesiredStatusStopped: false,
+			ExpectedOK:                            false,
+		},
+		{
+			Name:                        "Inspect failed during create",
+			EventStatus:                 apicontainerstatus.ContainerCreated,
+			CurrentContainerKnownStatus: apicontainerstatus.ContainerPulled,
+			Error: &dockerapi.CannotInspectContainerError{
+				FromError: errors.New("error"),
+			},
+			ExpectedContainerKnownStatusSet:       true,
+			ExpectedContainerKnownStatus:          apicontainerstatus.ContainerPulled,
+			ExpectedContainerDesiredStatusStopped: false,
+			ExpectedOK:                            false,
+		},
+		{
+			Name:                                  "Create timed out",
+			EventStatus:                           apicontainerstatus.ContainerCreated,
+			CurrentContainerKnownStatus:           apicontainerstatus.ContainerPulled,
+			Error:                                 &dockerapi.DockerTimeoutError{},
+			ExpectedContainerKnownStatusSet:       true,
+			ExpectedContainerKnownStatus:          apicontainerstatus.ContainerPulled,
+			ExpectedContainerDesiredStatusStopped: false,
+			ExpectedOK:                            false,
+		},
+		{
+			Name:        "Pull image fails and task fails",
+			EventStatus: apicontainerstatus.ContainerPulled,
+			Error: &dockerapi.CannotPullContainerError{
+				FromError: errors.New("error"),
+			},
+			ImagePullBehavior:                config.ImagePullAlwaysBehavior,
+			ExpectedContainerKnownStatusSet:  false,
+			ExpectedTaskDesiredStatusStopped: true,
+			ExpectedOK:                       false,
+		},
+	}
+
+	for _, tc := range testCases {
+		for _, policy := range []apicontainer.RestartPolicy{apicontainer.UnlessTaskStopped, apicontainer.OnFailure} {
+			t.Run(tc.Name, func(t *testing.T) {
+				container := &apicontainer.Container{
+					KnownStatusUnsafe: tc.CurrentContainerKnownStatus,
+					RestartInfo: &apicontainer.RestartInfo{
+						RestartPolicy: policy,
+					},
+				}
+				containerChange := dockerContainerChange{
+					container: container,
+					event: dockerapi.DockerContainerChangeEvent{
+						Status: tc.EventStatus,
+						DockerContainerMetadata: dockerapi.DockerContainerMetadata{
+							Error: tc.Error,
+						},
+					},
+					fromDockerEvent: false,
+				}
+				mtask := managedTask{
+					Task: &apitask.Task{
+						Arn: "task1",
+					},
+					engine: &DockerTaskEngine{},
+					cfg:    &config.Config{ImagePullBehavior: tc.ImagePullBehavior},
+				}
+				ok := mtask.handleEventError(containerChange, tc.CurrentContainerKnownStatus)
+				assert.Equal(t, tc.ExpectedOK, ok, "to proceed")
+				if tc.ExpectedContainerKnownStatusSet {
+					containerKnownStatus := containerChange.container.GetKnownStatus()
+					assert.Equal(t, tc.ExpectedContainerKnownStatus, containerKnownStatus,
+						"expected container known status %s != %s", tc.ExpectedContainerKnownStatus.String(), containerKnownStatus.String())
+				}
+				if tc.ExpectedContainerDesiredStatusStopped {
+					containerDesiredStatus := containerChange.container.GetDesiredStatus()
+					assert.Equal(t, apicontainerstatus.ContainerStopped, containerDesiredStatus,
+						"desired status %s != %s", apicontainerstatus.ContainerStopped.String(), containerDesiredStatus.String())
+				}
+				assert.Equal(t, tc.Error.ErrorName(), containerChange.container.ApplyingError.ErrorName())
+			})
+		}
+	}
+}
+
 func TestContainerNextState(t *testing.T) {
 	testCases := []struct {
 		containerCurrentStatus       apicontainerstatus.ContainerStatus
@@ -265,6 +436,21 @@ func TestContainerNextState(t *testing.T) {
 		// CREATED -> STOPPED transition will result in STOPPED and is allowed, but not
 		// actionable, when desired is STOPPED
 		{apicontainerstatus.ContainerCreated, apicontainerstatus.ContainerStopped, apicontainerstatus.ContainerStopped, false, nil},
+		// RESTARTING -> RUNNING transition is allowed and actionable, when desired is Running
+		// The expected next status is Running
+		{apicontainerstatus.ContainerRestarting, apicontainerstatus.ContainerRunning, apicontainerstatus.ContainerRunning, true, nil},
+		// RESTARTING -> CREATED transition is not allowed and not actionable,
+		// when desired is Running
+		{apicontainerstatus.ContainerRestarting, apicontainerstatus.ContainerCreated, apicontainerstatus.ContainerStatusNone, false, dependencygraph.ContainerPastDesiredStatusErr},
+		// RESTARTING -> NONE transition is not allowed and not actionable,
+		// when desired is Running
+		{apicontainerstatus.ContainerRestarting, apicontainerstatus.ContainerStatusNone, apicontainerstatus.ContainerStatusNone, false, dependencygraph.ContainerPastDesiredStatusErr},
+		// RESTARTING -> PULLED transition is not allowed and not actionable,
+		// when desired is Running
+		{apicontainerstatus.ContainerRestarting, apicontainerstatus.ContainerPulled, apicontainerstatus.ContainerStatusNone, false, dependencygraph.ContainerPastDesiredStatusErr},
+		// RESTARTING -> STOPPED transition will result in STOPPED and is allowed, but not
+		// actionable, when desired is STOPPED
+		{apicontainerstatus.ContainerRestarting, apicontainerstatus.ContainerStopped, apicontainerstatus.ContainerStopped, false, nil},
 		// RUNNING -> STOPPED transition is allowed and actionable, when desired is Running
 		// The expected next status is STOPPED
 		{apicontainerstatus.ContainerRunning, apicontainerstatus.ContainerStopped, apicontainerstatus.ContainerStopped, true, nil},
@@ -373,6 +559,18 @@ func TestContainerNextStateWithTransitionDependencies(t *testing.T) {
 			expectedTransitionActionable: false,
 			reason:                       dependencygraph.ErrContainerDependencyNotResolved,
 		},
+		// NONE -> RUNNING transition is not allowed and not actionable, when desired is Running and dependency is Restarting
+		{
+			name:                         "pull depends on running, dependency is restarting",
+			containerCurrentStatus:       apicontainerstatus.ContainerStatusNone,
+			containerDesiredStatus:       apicontainerstatus.ContainerRunning,
+			containerDependentStatus:     apicontainerstatus.ContainerPulled,
+			dependencyCurrentStatus:      apicontainerstatus.ContainerRestarting,
+			dependencySatisfiedStatus:    apicontainerstatus.ContainerRunning,
+			expectedContainerStatus:      apicontainerstatus.ContainerStatusNone,
+			expectedTransitionActionable: false,
+			reason:                       dependencygraph.ErrContainerDependencyNotResolved,
+		},
 		// NONE -> RUNNING transition is allowed and actionable, when desired is Running and dependency is Running
 		// The expected next status is Pulled
 		{
@@ -457,6 +655,8 @@ func TestContainerNextStateWithDependencies(t *testing.T) {
 		{apicontainerstatus.ContainerStatusNone, apicontainerstatus.ContainerRunning, apicontainerstatus.ContainerStatusNone, apicontainerstatus.ContainerStatusNone, false, dependencygraph.DependentContainerNotResolvedErr},
 		// NONE -> RUNNING transition is not allowed and not actionable, when desired is Running and dependency is Created
 		{apicontainerstatus.ContainerStatusNone, apicontainerstatus.ContainerRunning, apicontainerstatus.ContainerCreated, apicontainerstatus.ContainerStatusNone, false, dependencygraph.DependentContainerNotResolvedErr},
+		// NONE -> RUNNING transition is not allowed and not actionable, when desired is Running and dependency is Restarting
+		{apicontainerstatus.ContainerStatusNone, apicontainerstatus.ContainerRunning, apicontainerstatus.ContainerRestarting, apicontainerstatus.ContainerStatusNone, false, dependencygraph.DependentContainerNotResolvedErr},
 		// NONE -> RUNNING transition is allowed and actionable, when desired is Running and dependency is Running
 		// The expected next status is Pulled
 		{apicontainerstatus.ContainerStatusNone, apicontainerstatus.ContainerRunning, apicontainerstatus.ContainerRunning, apicontainerstatus.ContainerPulled, true, nil},
@@ -625,6 +825,7 @@ func TestStartContainerTransitionsWhenForwardTransitionPossible(t *testing.T) {
 			}
 
 			pauseContainerName := "pause"
+
 			waitForAssertions := sync.WaitGroup{}
 			if steadyState == apicontainerstatus.ContainerResourcesProvisioned {
 				pauseContainer := apicontainer.NewContainerWithSteadyState(steadyState)
@@ -845,7 +1046,7 @@ func TestWaitForContainerTransitionsForTerminalTask(t *testing.T) {
 	transitions[firstContainerName] = apicontainerstatus.ContainerPulled.String()
 	transitions[secondContainerName] = apicontainerstatus.ContainerPulled.String()
 
-	// Event though there are two keys in the transitions map, send
+	// event though there are two keys in the transitions map, send
 	// only one event. This tests that `waitForContainerTransition` doesn't
 	// block to receive two events and will still progress
 	go func() {

--- a/agent/stats/engine.go
+++ b/agent/stats/engine.go
@@ -517,7 +517,8 @@ func (engine *DockerStatsEngine) handleDockerEvents(events ...interface{}) error
 		case apicontainerstatus.ContainerStopped:
 			engine.removeContainer(dockerContainerChangeEvent.DockerID)
 		default:
-			seelog.Debugf("Ignoring event for container, id: %s, status: %d", dockerContainerChangeEvent.DockerID, dockerContainerChangeEvent.Status)
+			seelog.Debugf("Ignoring event for container, id: %s, status: %d", dockerContainerChangeEvent.DockerID,
+				dockerContainerChangeEvent.Status)
 		}
 	}
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Add auto restart non-essential container feature and integration tests.
### Implementation details
<!-- How are the changes implemented? -->
Add a new container status: "ContainerRestarting" which represents a container is waiting for restarting. 
### Testing
<!-- How was this tested? -->
Integration tests for different restart policies are implemented. 
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
