### PR TITLE
Fix bug in secret log options for firelens

### DIFF
--- a/agent/api/task/task_linux_test.go
+++ b/agent/api/task/task_linux_test.go
@@ -698,7 +698,7 @@ func TestInitializeFirelensResource(t *testing.T) {
 				"logsender": {
 					"key1":        "value1",
 					"key2":        "value2",
-					"secret-name": "\"#{ENV['secret-name_logsender']}\"",
+					"secret-name": "\"#{ENV['secret-name_0']}\"",
 				},
 			},
 		},
@@ -714,7 +714,7 @@ func TestInitializeFirelensResource(t *testing.T) {
 				"logsender": {
 					"key1":        "value1",
 					"key2":        "value2",
-					"secret-name": "${secret-name_logsender}",
+					"secret-name": "${secret-name_0}",
 				},
 			},
 		},
@@ -729,7 +729,7 @@ func TestInitializeFirelensResource(t *testing.T) {
 				"logsender": {
 					"key1":        "value1",
 					"key2":        "value2",
-					"secret-name": "\"#{ENV['secret-name_logsender']}\"",
+					"secret-name": "\"#{ENV['secret-name_0']}\"",
 				},
 			},
 		},
@@ -746,7 +746,7 @@ func TestInitializeFirelensResource(t *testing.T) {
 				"logsender": {
 					"key1":        "value1",
 					"key2":        "value2",
-					"secret-name": "\"#{ENV['secret-name_logsender']}\"",
+					"secret-name": "\"#{ENV['secret-name_0']}\"",
 				},
 			},
 		},
@@ -826,7 +826,7 @@ func TestCollectFirelensLogEnvOptions(t *testing.T) {
 	containerToLogOptions := make(map[string]map[string]string)
 	err := task.collectFirelensLogEnvOptions(containerToLogOptions, "fluentd")
 	assert.NoError(t, err)
-	assert.Equal(t, "\"#{ENV['secret-name_logsender']}\"", containerToLogOptions["logsender"]["secret-name"])
+	assert.Equal(t, "\"#{ENV['secret-name_0']}\"", containerToLogOptions["logsender"]["secret-name"])
 }
 
 func TestAddFirelensContainerDependency(t *testing.T) {
@@ -1003,7 +1003,7 @@ func TestPopulateSecretLogOptionsToFirelensContainer(t *testing.T) {
 
 	assert.Nil(t, task.PopulateSecretLogOptionsToFirelensContainer(task.Containers[1]))
 	assert.Len(t, task.Containers[1].Environment, 2)
-	assert.Equal(t, "secret-val", task.Containers[1].Environment["secret-name_logsender"])
+	assert.Equal(t, "secret-val", task.Containers[1].Environment["secret-name_0"])
 }
 
 func TestCollectLogDriverSecretData(t *testing.T) {

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -2995,3 +2995,24 @@ func TestTaskFromACSPerContainerTimeouts(t *testing.T) {
 	assert.Equal(t, task.Containers[0].StartTimeout, expectedTimeout)
 	assert.Equal(t, task.Containers[0].StopTimeout, expectedTimeout)
 }
+
+func TestGetContainerIndex(t *testing.T) {
+	task := &Task{
+		Containers: []*apicontainer.Container{
+			{
+				Name: "c1",
+			},
+			{
+				Name: "p",
+				Type: apicontainer.ContainerCNIPause,
+			},
+			{
+				Name: "c2",
+			},
+		},
+	}
+
+	assert.Equal(t, 0, task.GetContainerIndex("c1"))
+	assert.Equal(t, 1, task.GetContainerIndex("c2"))
+	assert.Equal(t, -1, task.GetContainerIndex("p"))
+}

--- a/agent/engine/docker_task_engine_linux_test.go
+++ b/agent/engine/docker_task_engine_linux_test.go
@@ -463,14 +463,14 @@ func TestCreateFirelensContainer(t *testing.T) {
 			task:                 getTask(firelens.FirelensConfigTypeFluentd),
 			expectedConfigBind:   defaultConfig.DataDirOnHost + "/data/firelens/task-id/config/fluent.conf:/fluentd/etc/fluent.conf",
 			expectedSocketBind:   defaultConfig.DataDirOnHost + "/data/firelens/task-id/socket/:/var/run/",
-			expectedLogOptionEnv: "secret-name_logsender=secret-val",
+			expectedLogOptionEnv: "secret-name_1=secret-val",
 		},
 		{
 			name:                 "test create fluentbit firelens container",
 			task:                 getTask(firelens.FirelensConfigTypeFluentbit),
 			expectedConfigBind:   defaultConfig.DataDirOnHost + "/data/firelens/task-id/config/fluent.conf:/fluent-bit/etc/fluent-bit.conf",
 			expectedSocketBind:   defaultConfig.DataDirOnHost + "/data/firelens/task-id/socket/:/var/run/",
-			expectedLogOptionEnv: "secret-name_logsender=secret-val",
+			expectedLogOptionEnv: "secret-name_1=secret-val",
 		},
 	}
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Previously, container name is appended to firelens config variable name in order to differentiate log options from different containers (see description in https://github.com/aws/amazon-ecs-agent/pull/2150 for more details). For fluentd this doesn't work when container name has hyphen in it, potentially because ruby (fluentd source) doesn't allow hyphen in env name.. Fix by using the index of the container instead.

### Implementation details
<!-- How are the changes implemented? -->
Change firelensConfigVarFmt and fill in index. The index doesn't count internal container so that we don't need to worry about potentially getting different index because an internal container is injected (internal container doesn't use firelens anyway).

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Existing unit tests modified for the change. Manually ran task and verified the fix.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
