### PR TITLE
Change fluent tag format for Firelens

### DIFF
--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -16,6 +16,7 @@ package engine
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -82,6 +83,9 @@ const (
 	logDriverAsyncConnect   = "fluentd-async-connect"
 	dataLogDriverSocketPath = "/socket/fluent.sock"
 	socketPathPrefix        = "unix://"
+
+	// fluentTagDockerFormat is the format for the log tag, which is "containerName-firelens-taskID"
+	fluentTagDockerFormat = "%s-firelens-%s"
 )
 
 // DockerTaskEngine is a state machine for managing a task and its containers
@@ -992,7 +996,7 @@ func (engine *DockerTaskEngine) createContainer(task *apitask.Task, container *a
 func getFirelensLogConfig(task *apitask.Task, container *apicontainer.Container, hostConfig *dockercontainer.HostConfig, cfg *config.Config) dockercontainer.LogConfig {
 	fields := strings.Split(task.Arn, "/")
 	taskID := fields[len(fields)-1]
-	tag := container.Name + "-" + taskID
+	tag := fmt.Sprintf(fluentTagDockerFormat, container.Name, taskID)
 	fluentd := socketPathPrefix + filepath.Join(cfg.DataDirOnHost, dataLogDriverPath, taskID, dataLogDriverSocketPath)
 	logConfig := hostConfig.LogConfig
 	logConfig.Type = logDriverTypeFluentd

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -2751,7 +2751,7 @@ func TestCreateContainerAddFirelensLogDriverConfig(t *testing.T) {
 			name:                           "test container that uses firelens log driver",
 			task:                           getTask(logDriverTypeFirelens),
 			expectedLogConfigType:          logDriverTypeFluentd,
-			expectedLogConfigTag:           taskName + "-" + taskID,
+			expectedLogConfigTag:           taskName + "-firelens-" + taskID,
 			expectedFluentdAsyncConnect:    strconv.FormatBool(true),
 			expectedLogConfigFluentAddress: socketPathPrefix + filepath.Join(defaultConfig.DataDirOnHost, dataLogDriverPath, taskID, dataLogDriverSocketPath),
 		},

--- a/agent/engine/engine_sudo_linux_integ_test.go
+++ b/agent/engine/engine_sudo_linux_integ_test.go
@@ -203,7 +203,7 @@ func TestFirelensFluentbit(t *testing.T) {
 	cwlClient := cloudwatchlogs.New(session.New(), aws.NewConfig().WithRegion(testECSRegion))
 	params := &cloudwatchlogs.GetLogEventsInput{
 		LogGroupName:  aws.String(testLogGroupName),
-		LogStreamName: aws.String(fmt.Sprintf("firelens-fluentbit-logsender-%s", taskID)),
+		LogStreamName: aws.String(fmt.Sprintf("firelens-fluentbit-logsender-firelens-%s", taskID)),
 	}
 
 	// wait for the cloud watch logs

--- a/agent/taskresource/firelens/firelensconfig_unix.go
+++ b/agent/taskresource/firelens/firelensconfig_unix.go
@@ -16,7 +16,6 @@ package firelens
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/pkg/errors"
 
@@ -56,6 +55,9 @@ const (
 
 	// socketPath is the path for socket file.
 	socketPath = "/var/run/fluent.sock"
+
+	// fluentTagOutputFormat is the format for the log tag, which is container name with "-firelens" appended
+	fluentTagOutputFormat = "%s-firelens*"
 )
 
 // generateConfig generates a FluentConfig object that contains all necessary information to construct
@@ -89,10 +91,8 @@ func (firelens *FirelensResource) generateConfig() (generator.FluentConfig, erro
 
 	// Specify log stream output. Each container that uses the firelens container to stream logs
 	// will have its own output section, with its own log options.
-	fields := strings.Split(firelens.taskARN, "/")
-	taskID := fields[len(fields)-1]
 	for containerName, logOptions := range firelens.containerToLogOptions {
-		tag := containerName + "-" + taskID // Each output section is distinguished by a tag specific to a container.
+		tag := fmt.Sprintf(fluentTagOutputFormat, containerName) // Each output section is distinguished by a tag specific to a container.
 		newConfig, err := addOutputSection(tag, firelens.firelensConfigType, logOptions, config)
 		if err != nil {
 			return nil, fmt.Errorf("unable to apply log options of container %s to firelens config: %v", containerName, err)

--- a/agent/taskresource/firelens/firelensconfig_unix_test.go
+++ b/agent/taskresource/firelens/firelensconfig_unix_test.go
@@ -45,7 +45,7 @@ var (
     path /var/run/fluent.sock
 </source>
 
-<filter container-3de392df-6bfa-470b-97ed-aa6f482cd7a>
+<filter container-firelens*>
     @type  grep
     <regexp>
         key log
@@ -53,7 +53,7 @@ var (
     </regexp>
 </filter>
 
-<filter container-3de392df-6bfa-470b-97ed-aa6f482cd7a>
+<filter container-firelens*>
     @type  grep
     <exclude>
         key log
@@ -71,7 +71,7 @@ var (
     </record>
 </filter>
 
-<match container-3de392df-6bfa-470b-97ed-aa6f482cd7a>
+<match container-firelens*>
     @type kinesis_firehose
     deliver_stream_name my-stream
     region us-west-2
@@ -84,12 +84,12 @@ var (
 
 [FILTER]
     Name   grep
-    Match container-3de392df-6bfa-470b-97ed-aa6f482cd7a
+    Match container-firelens*
     Regex  log *failure*
 
 [FILTER]
     Name   grep
-    Match container-3de392df-6bfa-470b-97ed-aa6f482cd7a
+    Match container-firelens*
     Exclude log *success*
 
 [FILTER]
@@ -102,7 +102,7 @@ var (
 
 [OUTPUT]
     Name kinesis_firehose
-    Match container-3de392df-6bfa-470b-97ed-aa6f482cd7a
+    Match container-firelens*
     deliver_stream_name my-stream
     region us-west-2
 `
@@ -112,7 +112,7 @@ var (
     path /var/run/fluent.sock
 </source>
 
-<filter container-3de392df-6bfa-470b-97ed-aa6f482cd7a>
+<filter container-firelens*>
     @type  grep
     <regexp>
         key log
@@ -120,7 +120,7 @@ var (
     </regexp>
 </filter>
 
-<filter container-3de392df-6bfa-470b-97ed-aa6f482cd7a>
+<filter container-firelens*>
     @type  grep
     <exclude>
         key log
@@ -128,7 +128,7 @@ var (
     </exclude>
 </filter>
 
-<match container-3de392df-6bfa-470b-97ed-aa6f482cd7a>
+<match container-firelens*>
     @type kinesis_firehose
     deliver_stream_name my-stream
     region us-west-2


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Change the fluent tag format for FireLens.

Container logs from Docker will have a tag in the format of `container_name-firelens-taskID`. This is because the tag will become part of the log stream name in the CloudWatch plugin, so the Task ID must be in there so that each task has a unique stream.

The filters/outputs will match with the expression `container_name-firelens*`. This is done so that customers can use the Fluent Logger SDKs (in the future, once we enable that) and tag their logs with `container_name-firelens*` if they want to use the outputs configured in the task definition.
### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
N/A
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
