### PR TITLE
add agent and docker version to tcs ws URL

### DIFF
--- a/agent/acs/handler/acs_handler_test.go
+++ b/agent/acs/handler/acs_handler_test.go
@@ -167,35 +167,15 @@ func TestACSWSURL(t *testing.T) {
 	wsurl := acsWsURL(acsURL, "myCluster", "myContainerInstance", taskEngine, &mockSessionResources{})
 
 	parsed, err := url.Parse(wsurl)
-	if err != nil {
-		t.Fatal("Should be able to parse url")
-	}
-
-	if parsed.Path != "/ws" {
-		t.Fatal("Wrong path")
-	}
-
-	if parsed.Query().Get("clusterArn") != "myCluster" {
-		t.Fatal("Wrong cluster")
-	}
-	if parsed.Query().Get("containerInstanceArn") != "myContainerInstance" {
-		t.Fatal("Wrong cluster")
-	}
-	if parsed.Query().Get("agentVersion") != version.Version {
-		t.Fatal("Wrong cluster")
-	}
-	if parsed.Query().Get("agentHash") != version.GitHashString() {
-		t.Fatal("Wrong cluster")
-	}
-	if parsed.Query().Get("dockerVersion") != "DockerVersion: Docker version result" {
-		t.Fatal("Wrong docker version")
-	}
-	if parsed.Query().Get(sendCredentialsURLParameterName) != "true" {
-		t.Fatalf("Wrong value set for: %s", sendCredentialsURLParameterName)
-	}
-	if parsed.Query().Get("seqNum") != "1" {
-		t.Fatal("Wrong seqNum")
-	}
+	assert.NoError(t, err, "should be able to parse URL")
+	assert.Equal(t, "/ws", parsed.Path, "wrong path")
+	assert.Equal(t, "myCluster", parsed.Query().Get("clusterArn"), "wrong cluster")
+	assert.Equal(t, "myContainerInstance", parsed.Query().Get("containerInstanceArn"), "wrong container instance")
+	assert.Equal(t, version.Version, parsed.Query().Get("agentVersion"), "wrong agent version")
+	assert.Equal(t, version.GitHashString(), parsed.Query().Get("agentHash"), "wrong agent hash")
+	assert.Equal(t, "DockerVersion: Docker version result", parsed.Query().Get("dockerVersion"), "wrong docker version")
+	assert.Equalf(t, "true", parsed.Query().Get(sendCredentialsURLParameterName), "Wrong value set for: %s", sendCredentialsURLParameterName)
+	assert.Equal(t, "1", parsed.Query().Get("seqNum"), "wrong seqNum")
 }
 
 // TestHandlerReconnectsOnConnectErrors tests if handler reconnects retries

--- a/agent/tcs/handler/handler.go
+++ b/agent/tcs/handler/handler.go
@@ -25,6 +25,7 @@ import (
 	tcsclient "github.com/aws/amazon-ecs-agent/agent/tcs/client"
 	"github.com/aws/amazon-ecs-agent/agent/tcs/model/ecstcs"
 	"github.com/aws/amazon-ecs-agent/agent/utils/retry"
+	"github.com/aws/amazon-ecs-agent/agent/version"
 	"github.com/aws/amazon-ecs-agent/agent/wsclient"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/cihub/seelog"
@@ -187,5 +188,7 @@ func formatURL(endpoint string, cluster string, containerInstance string) string
 	query := url.Values{}
 	query.Set("cluster", cluster)
 	query.Set("containerInstance", containerInstance)
+	query.Set("agentVersion", version.Version)
+	query.Set("agentHash", version.GitHashString())
 	return tcsURL + "ws?" + query.Encode()
 }

--- a/agent/tcs/handler/handler_test.go
+++ b/agent/tcs/handler/handler_test.go
@@ -30,9 +30,11 @@ import (
 
 	mock_api "github.com/aws/amazon-ecs-agent/agent/api/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/config"
+	mock_engine "github.com/aws/amazon-ecs-agent/agent/engine/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
 	tcsclient "github.com/aws/amazon-ecs-agent/agent/tcs/client"
 	"github.com/aws/amazon-ecs-agent/agent/tcs/model/ecstcs"
+	"github.com/aws/amazon-ecs-agent/agent/version"
 	"github.com/aws/amazon-ecs-agent/agent/wsclient"
 	wsmock "github.com/aws/amazon-ecs-agent/agent/wsclient/mock/utils"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -88,23 +90,20 @@ func TestDisableMetrics(t *testing.T) {
 
 func TestFormatURL(t *testing.T) {
 	endpoint := "http://127.0.0.0.1/"
-	wsurl := formatURL(endpoint, testClusterArn, testInstanceArn)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	taskEngine := mock_engine.NewMockTaskEngine(ctrl)
 
+	taskEngine.EXPECT().Version().Return("Docker version result", nil)
+	wsurl := formatURL(endpoint, testClusterArn, testInstanceArn, taskEngine)
 	parsed, err := url.Parse(wsurl)
-	if err != nil {
-		t.Fatal("Should be able to parse url")
-	}
-
-	if parsed.Path != "/ws" {
-		t.Fatal("Wrong path")
-	}
-
-	if parsed.Query().Get("cluster") != testClusterArn {
-		t.Fatal("Wrong cluster")
-	}
-	if parsed.Query().Get("containerInstance") != testInstanceArn {
-		t.Fatal("Wrong cluster")
-	}
+	assert.NoError(t, err, "should be able to parse URL")
+	assert.Equal(t, "/ws", parsed.Path, "wrong path")
+	assert.Equal(t, testClusterArn, parsed.Query().Get("cluster"), "wrong cluster")
+	assert.Equal(t, testInstanceArn, parsed.Query().Get("containerInstance"), "wrong container instance")
+	assert.Equal(t, version.Version, parsed.Query().Get("agentVersion"), "wrong agent version")
+	assert.Equal(t, version.GitHashString(), parsed.Query().Get("agentHash"), "wrong agent hash")
+	assert.Equal(t, "Docker version result", parsed.Query().Get("dockerVersion"), "wrong docker version")
 }
 
 func TestStartSession(t *testing.T) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
adds agent hash, agent and docker version to tcs ws URL
refactor tests to use assert 

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
