### PR TITLE
Adjust firelens fluentd functional test

### DIFF
--- a/agent/functional_tests/testdata/taskdefinitions/firelens-fluentd/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/firelens-fluentd/task-definition.json
@@ -33,7 +33,7 @@
       "image": "busybox:latest",
       "essential": true,
       "memory": 256,
-      "command": ["sh", "-c", "echo pass; echo filtered"],
+      "command": ["sh", "-c", "sleep 5s; echo pass; echo filtered"],
       "logConfiguration": {
         "logDriver": "awsfirelens",
         "options": {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
The test fails occasionally because the firelens container is stopped before it starts the fluentd server. Specifically the following happens in a failing test:
1. Firelens container starts, but has not yet started its fluentd server;
2. Log sender container, which has a START dependency on firelens container, starts following 1;
3. Log sender container sends a log and exit;
4. Task desires stopped because log sender container is essential;
5. Firelens container, which still has not started the server yet, is stopped, and misses processing the log.

This PR adds a sleep in the log sender container which allows the firelens container to have some time starting up, which makes the test less flakey.

### Implementation details
<!-- How are the changes implemented? -->
Add a sleep in task def.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
I've spun up multiple instances to run the tests both with the fix and without the fix, and the test did not fail with the fix.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
