### PR TITLE
makefile: test-silent doesn't work on mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ test:
 	${GOTEST} -tags unit -timeout=30s ./agent/...
 
 test-silent:
-	$(eval undefine VERBOSE)
+	$(eval VERBOSE=)
 	${GOTEST} -tags unit -timeout=30s ./agent/...
 
 run-integ-tests: test-registry gremlin container-health-check-image run-sudo-tests


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
undefine wasn't working on mac. Setting the variable (VERBOSE) to nothing seems to work though.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
