### PR TITLE
Run make gogenerate, fix a few references

### DIFF
--- a/agent/api/ecsclient/client.go
+++ b/agent/api/ecsclient/client.go
@@ -402,7 +402,7 @@ func (client *APIECSClient) buildContainerStateChangePayload(change api.Containe
 	}
 	if change.RuntimeID != "" {
 		trimmedRuntimeID := trimString(change.RuntimeID, ecsMaxRuntimeIDLength)
-		statechange.RuntimeID = aws.String(trimmedRuntimeID)
+		statechange.RuntimeId = aws.String(trimmedRuntimeID)
 	}
 	if change.Reason != "" {
 		trimmedReason := trimString(change.Reason, ecsMaxReasonLength)
@@ -449,7 +449,7 @@ func (client *APIECSClient) SubmitContainerStateChange(change api.ContainerState
 	}
 	if change.RuntimeID != "" {
 		trimmedRuntimeID := trimString(change.RuntimeID, ecsMaxRuntimeIDLength)
-		req.RuntimeID = &trimmedRuntimeID
+		req.RuntimeId = &trimmedRuntimeID
 	}
 	if change.Reason != "" {
 		trimmedReason := trimString(change.Reason, ecsMaxReasonLength)

--- a/agent/api/ecsclient/client_test.go
+++ b/agent/api/ecsclient/client_test.go
@@ -165,7 +165,7 @@ func TestSubmitContainerStateChange(t *testing.T) {
 			Cluster:       strptr(configuredCluster),
 			Task:          strptr("arn"),
 			ContainerName: strptr("cont"),
-			RuntimeID:     strptr("runtime id"),
+			RuntimeId:     strptr("runtime id"),
 			Status:        strptr("RUNNING"),
 			NetworkBindings: []*ecs.NetworkBinding{
 				{
@@ -219,7 +219,7 @@ func TestSubmitContainerStateChangeFull(t *testing.T) {
 			Cluster:       strptr(configuredCluster),
 			Task:          strptr("arn"),
 			ContainerName: strptr("cont"),
-			RuntimeID:     strptr("runtime id"),
+			RuntimeId:     strptr("runtime id"),
 			Status:        strptr("STOPPED"),
 			ExitCode:      int64ptr(&exitCode),
 			Reason:        strptr(reason),
@@ -951,7 +951,7 @@ func TestSubmitContainerStateChangeWhileTaskInPending(t *testing.T) {
 					Containers: []*ecs.ContainerStateChange{
 						{
 							ContainerName:   strptr("container"),
-							RuntimeID:       strptr("runtimeid"),
+							RuntimeId:       strptr("runtimeid"),
 							Status:          strptr("RUNNING"),
 							NetworkBindings: []*ecs.NetworkBinding{},
 						},

--- a/agent/ecs_client/model/ecs/api.go
+++ b/agent/ecs_client/model/ecs/api.go
@@ -4199,8 +4199,7 @@ type Container struct {
 	// details about a running or stopped container.
 	Reason *string `locationName:"reason" type:"string"`
 
-	// The RuntimeID of the container
-	RuntimeID *string `locationName:"runtimeId" type:"string"`
+	RuntimeId *string `locationName:"runtimeId" type:"string"`
 
 	// The ARN of the task.
 	TaskArn *string `locationName:"taskArn" type:"string"`
@@ -4270,9 +4269,9 @@ func (s *Container) SetReason(v string) *Container {
 	return s
 }
 
-// SetRuntimeID sets the RuntimeID field's value.
-func (s *Container) SetRuntimeID(v string) *Container {
-	s.RuntimeID = &v
+// SetRuntimeId sets the RuntimeId field's value.
+func (s *Container) SetRuntimeId(v string) *Container {
+	s.RuntimeId = &v
 	return s
 }
 
@@ -5385,8 +5384,7 @@ type ContainerStateChange struct {
 	// The reason for the state change.
 	Reason *string `locationName:"reason" type:"string"`
 
-	// The docker ID of the container
-	RuntimeID *string `locationName:"runtimeId" type:"string"`
+	RuntimeId *string `locationName:"runtimeId" type:"string"`
 
 	// The status of the container.
 	Status *string `locationName:"status" type:"string"`
@@ -5426,9 +5424,9 @@ func (s *ContainerStateChange) SetReason(v string) *ContainerStateChange {
 	return s
 }
 
-// SetRuntimeID sets the RuntimeID field's value.
-func (s *ContainerStateChange) SetRuntimeID(v string) *ContainerStateChange {
-	s.RuntimeID = &v
+// SetRuntimeId sets the RuntimeId field's value.
+func (s *ContainerStateChange) SetRuntimeId(v string) *ContainerStateChange {
+	s.RuntimeId = &v
 	return s
 }
 
@@ -10737,8 +10735,7 @@ type SubmitContainerStateChangeInput struct {
 	// The reason for the state change request.
 	Reason *string `locationName:"reason" type:"string"`
 
-	// The Docker ID of the container
-	RuntimeID *string `locationName:"runtimeId" type:"string"`
+	RuntimeId *string `locationName:"runtimeId" type:"string"`
 
 	// The status of the state change request.
 	Status *string `locationName:"status" type:"string"`
@@ -10788,9 +10785,9 @@ func (s *SubmitContainerStateChangeInput) SetReason(v string) *SubmitContainerSt
 	return s
 }
 
-// SetRuntimeID sets the RuntimeID field's value.
-func (s *SubmitContainerStateChangeInput) SetRuntimeID(v string) *SubmitContainerStateChangeInput {
-	s.RuntimeID = &v
+// SetRuntimeId sets the RuntimeId field's value.
+func (s *SubmitContainerStateChangeInput) SetRuntimeId(v string) *SubmitContainerStateChangeInput {
+	s.RuntimeId = &v
 	return s
 }
 

--- a/agent/utils/ioutilwrapper/mocks/ioutilwrapper_mocks.go
+++ b/agent/utils/ioutilwrapper/mocks/ioutilwrapper_mocks.go
@@ -51,6 +51,7 @@ func (m *MockIOUtil) EXPECT() *MockIOUtilMockRecorder {
 
 // TempFile mocks base method
 func (m *MockIOUtil) TempFile(arg0, arg1 string) (oswrapper.File, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TempFile", arg0, arg1)
 	ret0, _ := ret[0].(oswrapper.File)
 	ret1, _ := ret[1].(error)
@@ -59,11 +60,13 @@ func (m *MockIOUtil) TempFile(arg0, arg1 string) (oswrapper.File, error) {
 
 // TempFile indicates an expected call of TempFile
 func (mr *MockIOUtilMockRecorder) TempFile(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TempFile", reflect.TypeOf((*MockIOUtil)(nil).TempFile), arg0, arg1)
 }
 
 // WriteFile mocks base method
 func (m *MockIOUtil) WriteFile(arg0 string, arg1 []byte, arg2 os.FileMode) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WriteFile", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -71,5 +74,6 @@ func (m *MockIOUtil) WriteFile(arg0 string, arg1 []byte, arg2 os.FileMode) error
 
 // WriteFile indicates an expected call of WriteFile
 func (mr *MockIOUtilMockRecorder) WriteFile(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteFile", reflect.TypeOf((*MockIOUtil)(nil).WriteFile), arg0, arg1, arg2)
 }


### PR DESCRIPTION
auto-generated file got hand-edited by accident. This fixes the naming
of a few structs and the references to them.

### Description for the changelog

Fix auto-generated RuntimeId struct fields.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
