### PR TITLE
Add network support for firelens

### DIFF
--- a/agent/api/task/task_linux_test.go
+++ b/agent/api/task/task_linux_test.go
@@ -666,7 +666,7 @@ func TestGetFirelensContainer(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.firelensContainer, tc.task.getFirelensContainer())
+			assert.Equal(t, tc.firelensContainer, tc.task.GetFirelensContainer())
 		})
 	}
 }
@@ -1073,6 +1073,7 @@ func getFirelensTask(t *testing.T) *Task {
 						Provider: apicontainer.SecretProviderSSM,
 					},
 				},
+				NetworkModeUnsafe:         BridgeNetworkMode,
 				TransitionDependenciesMap: make(map[apicontainerstatus.ContainerStatus]apicontainer.TransitionDependencySet),
 			},
 			{
@@ -1086,6 +1087,7 @@ func getFirelensTask(t *testing.T) *Task {
 				Environment: map[string]string{
 					"AWS_EXECUTION_ENV": "AWS_ECS_EC2",
 				},
+				NetworkModeUnsafe:         BridgeNetworkMode,
 				TransitionDependenciesMap: make(map[apicontainerstatus.ContainerStatus]apicontainer.TransitionDependencySet),
 			},
 		},

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -68,6 +68,7 @@ import (
 	"github.com/containernetworking/cni/pkg/types/current"
 	"github.com/docker/docker/api/types"
 	dockercontainer "github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
 	"github.com/golang/mock/gomock"
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
@@ -96,6 +97,9 @@ const (
 	egressIgnoredIP             = "169.254.169.254"
 	expectedDelaySeconds        = 10
 	expectedDelay               = expectedDelaySeconds * time.Second
+	networkBridgeIP             = "bridgeIP"
+	networkModeBridge           = "bridge"
+	networkModeAWSVPC           = "awsvpc"
 )
 
 var (
@@ -2646,11 +2650,17 @@ func TestCreateContainerAddFirelensLogDriverConfig(t *testing.T) {
 	taskFamily := "logSenderTaskFamily"
 	taskVersion := "1"
 	logDriverTypeFirelens := "awsfirelens"
-	logDriverTypeOther := "other"
 	dataLogDriverPath := "/data/firelens/"
 	dataLogDriverSocketPath := "/socket/fluent.sock"
 	socketPathPrefix := "unix://"
-	getTask := func(logDriverType string) *apitask.Task {
+	networkModeBridge := "bridge"
+	networkModeAWSVPC := "awsvpc"
+	bridgeIPAddr := "bridgeIP"
+	envVarBridgeMode := "FLUENT_HOST=bridgeIP"
+	envVarPort := "FLUENT_PORT=24224"
+	envVarAWSVPCMode := "FLUENT_HOST=127.0.0.1"
+	eniIPv4Address := "10.0.0.2"
+	getTask := func(logDriverType string, networkMode string) *apitask.Task {
 		rawHostConfigInput := dockercontainer.HostConfig{
 			LogConfig: dockercontainer.LogConfig{
 				Type: logDriverType,
@@ -2675,11 +2685,74 @@ func TestCreateContainerAddFirelensLogDriverConfig(t *testing.T) {
 							return &s
 						}(),
 					},
+					NetworkModeUnsafe: networkMode,
+				},
+				{
+					Name: "test-container",
+					FirelensConfig: &apicontainer.FirelensConfig{
+						Type: "fluentd",
+					},
+					NetworkModeUnsafe: networkMode,
+					NetworkSettingsUnsafe: &types.NetworkSettings{
+						DefaultNetworkSettings: types.DefaultNetworkSettings{
+							IPAddress: bridgeIPAddr,
+						},
+					},
 				},
 			},
 		}
 	}
-
+	getTaskWithENI := func(logDriverType string, networkMode string) *apitask.Task {
+		rawHostConfigInput := dockercontainer.HostConfig{
+			LogConfig: dockercontainer.LogConfig{
+				Type: logDriverType,
+				Config: map[string]string{
+					"key1": "value1",
+					"key2": "value2",
+				},
+			},
+		}
+		rawHostConfig, err := json.Marshal(&rawHostConfigInput)
+		require.NoError(t, err)
+		return &apitask.Task{
+			Arn:     taskARN,
+			Version: taskVersion,
+			Family:  taskFamily,
+			ENIs: []*apieni.ENI{
+				{
+					IPV4Addresses: []*apieni.ENIIPV4Address{
+						{
+							Address: eniIPv4Address,
+						},
+					},
+				},
+			},
+			Containers: []*apicontainer.Container{
+				{
+					Name: taskName,
+					DockerConfig: apicontainer.DockerConfig{
+						HostConfig: func() *string {
+							s := string(rawHostConfig)
+							return &s
+						}(),
+					},
+					NetworkModeUnsafe: networkMode,
+				},
+				{
+					Name: "test-container",
+					FirelensConfig: &apicontainer.FirelensConfig{
+						Type: "fluentd",
+					},
+					NetworkModeUnsafe: networkMode,
+					NetworkSettingsUnsafe: &types.NetworkSettings{
+						DefaultNetworkSettings: types.DefaultNetworkSettings{
+							IPAddress: bridgeIPAddr,
+						},
+					},
+				},
+			},
+		}
+	}
 	testCases := []struct {
 		name                           string
 		task                           *apitask.Task
@@ -2687,22 +2760,38 @@ func TestCreateContainerAddFirelensLogDriverConfig(t *testing.T) {
 		expectedLogConfigTag           string
 		expectedLogConfigFluentAddress string
 		expectedFluentdAsyncConnect    string
+		expectedIPAddress              string
+		expectedPort                   string
 	}{
 		{
-			name:                           "test container that uses firelens log driver",
-			task:                           getTask(logDriverTypeFirelens),
+			name:                           "test container that uses firelens log driver with default mode",
+			task:                           getTask(logDriverTypeFirelens, ""),
 			expectedLogConfigType:          logDriverTypeFluentd,
 			expectedLogConfigTag:           taskName + "-firelens-" + taskID,
 			expectedFluentdAsyncConnect:    strconv.FormatBool(true),
 			expectedLogConfigFluentAddress: socketPathPrefix + filepath.Join(defaultConfig.DataDirOnHost, dataLogDriverPath, taskID, dataLogDriverSocketPath),
+			expectedIPAddress:              envVarBridgeMode,
+			expectedPort:                   envVarPort,
 		},
 		{
-			name:                           "test container that uses other log driver",
-			task:                           getTask(logDriverTypeOther),
-			expectedLogConfigType:          logDriverTypeOther,
-			expectedLogConfigTag:           "",
-			expectedLogConfigFluentAddress: "",
-			expectedFluentdAsyncConnect:    "",
+			name:                           "test container that uses firelens log driver with bridge mode",
+			task:                           getTask(logDriverTypeFirelens, networkModeBridge),
+			expectedLogConfigType:          logDriverTypeFluentd,
+			expectedLogConfigTag:           taskName + "-firelens-" + taskID,
+			expectedFluentdAsyncConnect:    strconv.FormatBool(true),
+			expectedLogConfigFluentAddress: socketPathPrefix + filepath.Join(defaultConfig.DataDirOnHost, dataLogDriverPath, taskID, dataLogDriverSocketPath),
+			expectedIPAddress:              envVarBridgeMode,
+			expectedPort:                   envVarPort,
+		},
+		{
+			name:                           "test container that uses firelens log driver with awsvpc mode",
+			task:                           getTaskWithENI(logDriverTypeFirelens, networkModeAWSVPC),
+			expectedLogConfigType:          logDriverTypeFluentd,
+			expectedLogConfigTag:           taskName + "-firelens-" + taskID,
+			expectedFluentdAsyncConnect:    strconv.FormatBool(true),
+			expectedLogConfigFluentAddress: socketPathPrefix + filepath.Join(defaultConfig.DataDirOnHost, dataLogDriverPath, taskID, dataLogDriverSocketPath),
+			expectedIPAddress:              envVarAWSVPCMode,
+			expectedPort:                   envVarPort,
 		},
 	}
 
@@ -2724,6 +2813,8 @@ func TestCreateContainerAddFirelensLogDriverConfig(t *testing.T) {
 					assert.Equal(t, tc.expectedLogConfigTag, hostConfig.LogConfig.Config["tag"])
 					assert.Equal(t, tc.expectedLogConfigFluentAddress, hostConfig.LogConfig.Config["fluentd-address"])
 					assert.Equal(t, tc.expectedFluentdAsyncConnect, hostConfig.LogConfig.Config["fluentd-async-connect"])
+					assert.Contains(t, config.Env, tc.expectedIPAddress)
+					assert.Contains(t, config.Env, tc.expectedPort)
 				})
 			ret := taskEngine.(*DockerTaskEngine).createContainer(tc.task, tc.task.Containers[0])
 			assert.NoError(t, ret.Error)
@@ -2761,4 +2852,157 @@ func TestCreateFirelensContainerSetFluentdUID(t *testing.T) {
 		})
 	ret := taskEngine.(*DockerTaskEngine).createContainer(testTask, testTask.Containers[0])
 	assert.NoError(t, ret.Error)
+}
+
+func TestGetBridgeIP(t *testing.T) {
+	networkDefaultIP := "defaultIP"
+	getNetwork := func(defaultIP string, bridgeIP string, networkMode string) *types.NetworkSettings {
+		endPoint := network.EndpointSettings{
+			IPAddress: bridgeIP,
+		}
+		return &types.NetworkSettings{
+			DefaultNetworkSettings: types.DefaultNetworkSettings{
+				IPAddress: defaultIP,
+			},
+			Networks: map[string]*network.EndpointSettings{
+				networkMode: &endPoint,
+			},
+		}
+	}
+	testCases := []struct {
+		defaultIP         string
+		bridgeIP          string
+		networkMode       string
+		expectedOk        bool
+		expectedIPAddress string
+	}{
+		{
+			defaultIP:         networkDefaultIP,
+			bridgeIP:          networkBridgeIP,
+			networkMode:       networkModeBridge,
+			expectedOk:        true,
+			expectedIPAddress: networkDefaultIP,
+		},
+		{
+			defaultIP:         "",
+			bridgeIP:          networkBridgeIP,
+			networkMode:       networkModeBridge,
+			expectedOk:        true,
+			expectedIPAddress: networkBridgeIP,
+		},
+		{
+			defaultIP:         "",
+			bridgeIP:          networkBridgeIP,
+			networkMode:       networkModeAWSVPC,
+			expectedOk:        false,
+			expectedIPAddress: "",
+		},
+		{
+			defaultIP:         "",
+			bridgeIP:          "",
+			networkMode:       networkModeBridge,
+			expectedOk:        false,
+			expectedIPAddress: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		IPAddress, ok := getContainerHostIP(getNetwork(tc.defaultIP, tc.bridgeIP, tc.networkMode))
+		assert.Equal(t, tc.expectedOk, ok)
+		assert.Equal(t, tc.expectedIPAddress, IPAddress)
+	}
+}
+
+func TestStartFirelensContainerRetryForContainerIP(t *testing.T) {
+	dockerMetaDataWithoutNetworkSettings := dockerapi.DockerContainerMetadata{
+		DockerID: dockerContainerName,
+		Volumes: []types.MountPoint{
+			{
+				Name:        "volume",
+				Source:      "/src/vol",
+				Destination: "/vol",
+			},
+		},
+	}
+	rawHostConfigInput := dockercontainer.HostConfig{
+		LogConfig: dockercontainer.LogConfig{
+			Type: "fluentd",
+			Config: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+		},
+	}
+	jsonBaseWithoutNetwork := &types.ContainerJSON{
+		ContainerJSONBase: &types.ContainerJSONBase{
+			ID:    containerID,
+			State: &types.ContainerState{Pid: containerPid},
+		},
+	}
+
+	jsonBaseWithNetwork := &types.ContainerJSON{
+		ContainerJSONBase: &types.ContainerJSONBase{
+			ID:    containerID,
+			State: &types.ContainerState{Pid: containerPid},
+		},
+		NetworkSettings: &types.NetworkSettings{
+			DefaultNetworkSettings: types.DefaultNetworkSettings{
+				IPAddress: networkBridgeIP,
+			},
+			Networks: map[string]*network.EndpointSettings{
+				apitask.BridgeNetworkMode: &network.EndpointSettings{
+					IPAddress: networkBridgeIP,
+				},
+			},
+		},
+	}
+	rawHostConfig, err := json.Marshal(&rawHostConfigInput)
+	require.NoError(t, err)
+	testTask := &apitask.Task{
+		Arn:     "arn:aws:ecs:region:account-id:task/task-id",
+		Version: "1",
+		Family:  "logSenderTaskFamily",
+		Containers: []*apicontainer.Container{
+			{
+				Name: "logSenderTask",
+				DockerConfig: apicontainer.DockerConfig{
+					HostConfig: func() *string {
+						s := string(rawHostConfig)
+						return &s
+					}(),
+				},
+				NetworkModeUnsafe: apitask.BridgeNetworkMode,
+			},
+			{
+				Name: "test-container",
+				FirelensConfig: &apicontainer.FirelensConfig{
+					Type: "fluentd",
+				},
+				NetworkModeUnsafe: apitask.BridgeNetworkMode,
+			},
+		},
+	}
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	ctrl, client, _, taskEngine, _, _, _ := mocks(t, ctx, &defaultConfig)
+	defer ctrl.Finish()
+	taskEngine.(*DockerTaskEngine).state.AddTask(testTask)
+	taskEngine.(*DockerTaskEngine).state.AddContainer(&apicontainer.DockerContainer{
+		Container:  testTask.Containers[1],
+		DockerName: "dockerContainerName",
+	}, testTask)
+
+	client.EXPECT().APIVersion().Return(defaultDockerClientAPIVersion, nil).AnyTimes()
+	client.EXPECT().StartContainer(gomock.Any(), gomock.Any(), gomock.Any()).Return(dockerMetaDataWithoutNetworkSettings).AnyTimes()
+	gomock.InOrder(
+		client.EXPECT().InspectContainer(gomock.Any(), dockerContainerName, gomock.Any()).
+			Return(jsonBaseWithoutNetwork, nil),
+		client.EXPECT().InspectContainer(gomock.Any(), dockerContainerName, gomock.Any()).
+			Return(jsonBaseWithoutNetwork, nil),
+		client.EXPECT().InspectContainer(gomock.Any(), dockerContainerName, gomock.Any()).
+			Return(jsonBaseWithNetwork, nil),
+	)
+	ret := taskEngine.(*DockerTaskEngine).startContainer(testTask, testTask.Containers[1])
+	assert.NoError(t, ret.Error)
+	assert.Equal(t, jsonBaseWithNetwork.NetworkSettings, ret.NetworkSettings)
 }

--- a/agent/statemanager/state_manager.go
+++ b/agent/statemanager/state_manager.go
@@ -91,8 +91,9 @@ const (
 	//	 a) Add 'RuntimeID' field to 'apicontainer.Container'
 	//	 b) Add 'FirelensConfig' field to 'Container' struct
 	//	 c) Add 'firelens' field to 'resources'
+	// 24) Add 'NetworkMode' to firelens task resource.
 
-	ECSDataVersion = 23
+	ECSDataVersion = 24
 
 	// ecsDataFile specifies the filename in the ECS_DATADIR
 	ecsDataFile = "ecs_agent_data.json"

--- a/agent/taskresource/firelens/firelens_unimplemented.go
+++ b/agent/taskresource/firelens/firelens_unimplemented.go
@@ -37,7 +37,7 @@ const (
 type FirelensResource struct{}
 
 // NewFirelensResource returns a new FirelensResource.
-func NewFirelensResource(cluster, taskARN, taskDefinition, ec2InstanceID, dataDir, firelensConfigType string,
+func NewFirelensResource(cluster, taskARN, taskDefinition, ec2InstanceID, dataDir, firelensConfigType, networkMode string,
 	ecsMetadataEnabled bool, containerToLogOptions map[string]map[string]string) *FirelensResource {
 	return &FirelensResource{}
 }

--- a/agent/taskresource/firelens/firelens_unix.go
+++ b/agent/taskresource/firelens/firelens_unix.go
@@ -54,6 +54,7 @@ type FirelensResource struct {
 	containerToLogOptions map[string]map[string]string
 	os                    oswrapper.OS
 	ioutil                ioutilwrapper.IOUtil
+	networkMode           string
 
 	// Fields for the common functionality of task resource. Access to these fields are protected by lock.
 	createdAtUnsafe     time.Time
@@ -67,7 +68,7 @@ type FirelensResource struct {
 }
 
 // NewFirelensResource returns a new FirelensResource.
-func NewFirelensResource(cluster, taskARN, taskDefinition, ec2InstanceID, dataDir, firelensConfigType string,
+func NewFirelensResource(cluster, taskARN, taskDefinition, ec2InstanceID, dataDir, firelensConfigType, networkMode string,
 	ecsMetadataEnabled bool, containerToLogOptions map[string]map[string]string) *FirelensResource {
 	firelensResource := &FirelensResource{
 		cluster:               cluster,
@@ -79,6 +80,7 @@ func NewFirelensResource(cluster, taskARN, taskDefinition, ec2InstanceID, dataDi
 		containerToLogOptions: containerToLogOptions,
 		os:                    oswrapper.NewOS(),
 		ioutil:                ioutilwrapper.NewIOUtil(),
+		networkMode:           networkMode,
 	}
 
 	fields := strings.Split(taskARN, "/")
@@ -141,6 +143,11 @@ func (firelens *FirelensResource) Initialize(resourceFields *taskresource.Resour
 	firelens.initStatusToTransition()
 	firelens.os = oswrapper.NewOS()
 	firelens.ioutil = ioutilwrapper.NewIOUtil()
+}
+
+// GetNetworkMode returns the network mode of the task.
+func (firelens *FirelensResource) GetNetworkMode() string {
+	return firelens.networkMode
 }
 
 func (firelens *FirelensResource) initStatusToTransition() {

--- a/agent/taskresource/firelens/json_unix.go
+++ b/agent/taskresource/firelens/json_unix.go
@@ -38,6 +38,7 @@ type firelensResourceJSON struct {
 	DesiredStatus *FirelensStatus
 	KnownStatus   *FirelensStatus
 	AppliedStatus *FirelensStatus
+	NetworkMode   string
 }
 
 // MarshalJSON marshals a FirelensResource object into bytes of json.
@@ -60,6 +61,7 @@ func (firelens *FirelensResource) MarshalJSON() ([]byte, error) {
 		ContainersToLogOptions: firelens.containerToLogOptions,
 		TerminalReason:         firelens.terminalReason,
 		CreatedAt:              firelens.createdAtUnsafe,
+		NetworkMode:            firelens.networkMode,
 		DesiredStatus: func() *FirelensStatus {
 			desiredStatus := firelens.desiredStatusUnsafe
 			s := FirelensStatus(desiredStatus)
@@ -105,6 +107,7 @@ func (firelens *FirelensResource) UnmarshalJSON(b []byte) error {
 	firelens.desiredStatusUnsafe = resourcestatus.ResourceStatus(*temp.DesiredStatus)
 	firelens.knownStatusUnsafe = resourcestatus.ResourceStatus(*temp.KnownStatus)
 	firelens.appliedStatusUnsafe = resourcestatus.ResourceStatus(*temp.AppliedStatus)
+	firelens.networkMode = temp.NetworkMode
 
 	return nil
 }

--- a/agent/taskresource/firelens/json_unix_test.go
+++ b/agent/taskresource/firelens/json_unix_test.go
@@ -45,6 +45,7 @@ func TestMarshalUnmarshalJSON(t *testing.T) {
 		desiredStatusUnsafe:   resourcestatus.ResourceCreated,
 		knownStatusUnsafe:     resourcestatus.ResourceCreated,
 		appliedStatusUnsafe:   resourcestatus.ResourceCreated,
+		networkMode:           bridgeNetworkMode,
 	}
 
 	bytes, err := json.Marshal(firelensResIn)
@@ -65,4 +66,5 @@ func TestMarshalUnmarshalJSON(t *testing.T) {
 	assert.Equal(t, resourcestatus.ResourceCreated, firelensResOut.knownStatusUnsafe)
 	assert.Equal(t, resourcestatus.ResourceCreated, firelensResOut.appliedStatusUnsafe)
 	assert.Equal(t, testTerminalResason, firelensResOut.terminalReason)
+	assert.Equal(t, bridgeNetworkMode, firelensResOut.networkMode)
 }


### PR DESCRIPTION
Summary
Support two types of network mode - bridge and AWSVPC. 
To enable networking we need to add teo env variables FLUENT_HOST and FLUENT_PORT. The value of FLUWNT_PORT is 24224 and the value of host will be 127.0.0.1 if network is awsvpc and will be value of bridge IP for bridge mode. Also, added the http specific values as input to config setting for Fluentd and Fluentbit respectively.
For GA launch, Host Mode is not supported.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes:yes.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
