### PR TITLE
Added support for automatic spot instance draining.

### DIFF
--- a/agent/api/ecsclient/client.go
+++ b/agent/api/ecsclient/client.go
@@ -576,8 +576,5 @@ func (client *APIECSClient) UpdateContainerInstancesState(instanceARN string, st
 		Status:             aws.String(status),
 		Cluster:            &client.config.Cluster,
 	})
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }

--- a/agent/api/ecsclient/client.go
+++ b/agent/api/ecsclient/client.go
@@ -568,3 +568,16 @@ func (client *APIECSClient) GetResourceTags(resourceArn string) ([]*ecs.Tag, err
 	}
 	return output.Tags, nil
 }
+
+func (client *APIECSClient) UpdateContainerInstancesState(instanceARN string, status string) error {
+	seelog.Debugf("Invoking UpdateContainerInstancesState, status='%s' instanceARN='%s'", status, instanceARN)
+	_, err := client.standardClient.UpdateContainerInstancesState(&ecs.UpdateContainerInstancesStateInput{
+		ContainerInstances: []*string{aws.String(instanceARN)},
+		Status:             aws.String(status),
+		Cluster:            &client.config.Cluster,
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/agent/api/ecsclient/client_test.go
+++ b/agent/api/ecsclient/client_test.go
@@ -748,6 +748,78 @@ func TestDiscoverNilTelemetryEndpoint(t *testing.T) {
 	}
 }
 
+func TestUpdateContainerInstancesState(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	client, mc, _ := NewMockClient(mockCtrl, ec2.NewBlackholeEC2MetadataClient(), nil)
+
+	instanceARN := "myInstanceARN"
+	status := "DRAINING"
+	mc.EXPECT().UpdateContainerInstancesState(&ecs.UpdateContainerInstancesStateInput{
+		ContainerInstances: []*string{aws.String(instanceARN)},
+		Status:             aws.String(status),
+		Cluster:            aws.String(configuredCluster),
+	}).Return(&ecs.UpdateContainerInstancesStateOutput{}, nil)
+
+	err := client.UpdateContainerInstancesState(instanceARN, status)
+	if err != nil {
+		t.Errorf("Unexpected error calling UpdateContainerInstancesState: %s", err)
+	}
+}
+
+func TestUpdateContainerInstancesStateError(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	client, mc, _ := NewMockClient(mockCtrl, ec2.NewBlackholeEC2MetadataClient(), nil)
+
+	instanceARN := "myInstanceARN"
+	status := "DRAINING"
+	mc.EXPECT().UpdateContainerInstancesState(&ecs.UpdateContainerInstancesStateInput{
+		ContainerInstances: []*string{aws.String(instanceARN)},
+		Status:             aws.String(status),
+		Cluster:            aws.String(configuredCluster),
+	}).Return(nil, fmt.Errorf("ERROR"))
+
+	err := client.UpdateContainerInstancesState(instanceARN, status)
+	if err == nil {
+		t.Errorf("Expected an error calling UpdateContainerInstancesState but got nil")
+	}
+}
+
+func TestGetResourceTags(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	client, mc, _ := NewMockClient(mockCtrl, ec2.NewBlackholeEC2MetadataClient(), nil)
+
+	instanceARN := "myInstanceARN"
+	mc.EXPECT().ListTagsForResource(&ecs.ListTagsForResourceInput{
+		ResourceArn: aws.String(instanceARN),
+	}).Return(&ecs.ListTagsForResourceOutput{
+		Tags: containerInstanceTags,
+	}, nil)
+
+	_, err := client.GetResourceTags(instanceARN)
+	if err != nil {
+		t.Errorf("Unexpected error calling GetResourceTags: %s", err)
+	}
+}
+
+func TestGetResourceTagsError(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	client, mc, _ := NewMockClient(mockCtrl, ec2.NewBlackholeEC2MetadataClient(), nil)
+
+	instanceARN := "myInstanceARN"
+	mc.EXPECT().ListTagsForResource(&ecs.ListTagsForResourceInput{
+		ResourceArn: aws.String(instanceARN),
+	}).Return(nil, fmt.Errorf("ERROR"))
+
+	_, err := client.GetResourceTags(instanceARN)
+	if err == nil {
+		t.Errorf("Expected an error calling GetResourceTags but got nil")
+	}
+}
+
 func TestDiscoverPollEndpointCacheHit(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()

--- a/agent/api/ecsclient/client_test.go
+++ b/agent/api/ecsclient/client_test.go
@@ -762,9 +762,7 @@ func TestUpdateContainerInstancesState(t *testing.T) {
 	}).Return(&ecs.UpdateContainerInstancesStateOutput{}, nil)
 
 	err := client.UpdateContainerInstancesState(instanceARN, status)
-	if err != nil {
-		t.Errorf("Unexpected error calling UpdateContainerInstancesState: %s", err)
-	}
+	assert.NoError(t, err, fmt.Sprintf("Unexpected error calling UpdateContainerInstancesState: %s", err))
 }
 
 func TestUpdateContainerInstancesStateError(t *testing.T) {
@@ -781,9 +779,7 @@ func TestUpdateContainerInstancesStateError(t *testing.T) {
 	}).Return(nil, fmt.Errorf("ERROR"))
 
 	err := client.UpdateContainerInstancesState(instanceARN, status)
-	if err == nil {
-		t.Errorf("Expected an error calling UpdateContainerInstancesState but got nil")
-	}
+	assert.Error(t, err, "Expected an error calling UpdateContainerInstancesState but got nil")
 }
 
 func TestGetResourceTags(t *testing.T) {
@@ -799,9 +795,7 @@ func TestGetResourceTags(t *testing.T) {
 	}, nil)
 
 	_, err := client.GetResourceTags(instanceARN)
-	if err != nil {
-		t.Errorf("Unexpected error calling GetResourceTags: %s", err)
-	}
+	assert.NoError(t, err, fmt.Sprintf("Unexpected error calling GetResourceTags: %s", err))
 }
 
 func TestGetResourceTagsError(t *testing.T) {
@@ -815,9 +809,7 @@ func TestGetResourceTagsError(t *testing.T) {
 	}).Return(nil, fmt.Errorf("ERROR"))
 
 	_, err := client.GetResourceTags(instanceARN)
-	if err == nil {
-		t.Errorf("Expected an error calling GetResourceTags but got nil")
-	}
+	assert.Error(t, err, "Expected an error calling GetResourceTags but got nil")
 }
 
 func TestDiscoverPollEndpointCacheHit(t *testing.T) {

--- a/agent/api/interface.go
+++ b/agent/api/interface.go
@@ -45,6 +45,9 @@ type ECSClient interface {
 	DiscoverTelemetryEndpoint(containerInstanceArn string) (string, error)
 	// GetResourceTags retrieves the Tags associated with a certain resource
 	GetResourceTags(resourceArn string) ([]*ecs.Tag, error)
+	// UpdateContainerInstancesState updates the given container Instance ID with
+	// the given status. Only valid statuses are ACTIVE and DRAINING.
+	UpdateContainerInstancesState(instanceARN, status string) error
 }
 
 // ECSSDK is an interface that specifies the subset of the AWS Go SDK's ECS
@@ -55,6 +58,7 @@ type ECSSDK interface {
 	RegisterContainerInstance(*ecs.RegisterContainerInstanceInput) (*ecs.RegisterContainerInstanceOutput, error)
 	DiscoverPollEndpoint(*ecs.DiscoverPollEndpointInput) (*ecs.DiscoverPollEndpointOutput, error)
 	ListTagsForResource(*ecs.ListTagsForResourceInput) (*ecs.ListTagsForResourceOutput, error)
+	UpdateContainerInstancesState(input *ecs.UpdateContainerInstancesStateInput) (*ecs.UpdateContainerInstancesStateOutput, error)
 }
 
 // ECSSubmitStateSDK is an interface with customized ecs client that

--- a/agent/api/mocks/api_mocks.go
+++ b/agent/api/mocks/api_mocks.go
@@ -109,6 +109,21 @@ func (mr *MockECSSDKMockRecorder) RegisterContainerInstance(arg0 interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterContainerInstance", reflect.TypeOf((*MockECSSDK)(nil).RegisterContainerInstance), arg0)
 }
 
+// UpdateContainerInstancesState mocks base method
+func (m *MockECSSDK) UpdateContainerInstancesState(arg0 *ecs.UpdateContainerInstancesStateInput) (*ecs.UpdateContainerInstancesStateOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateContainerInstancesState", arg0)
+	ret0, _ := ret[0].(*ecs.UpdateContainerInstancesStateOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateContainerInstancesState indicates an expected call of UpdateContainerInstancesState
+func (mr *MockECSSDKMockRecorder) UpdateContainerInstancesState(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateContainerInstancesState", reflect.TypeOf((*MockECSSDK)(nil).UpdateContainerInstancesState), arg0)
+}
+
 // MockECSSubmitStateSDK is a mock of ECSSubmitStateSDK interface
 type MockECSSubmitStateSDK struct {
 	ctrl     *gomock.Controller
@@ -301,4 +316,18 @@ func (m *MockECSClient) SubmitTaskStateChange(arg0 api.TaskStateChange) error {
 func (mr *MockECSClientMockRecorder) SubmitTaskStateChange(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitTaskStateChange", reflect.TypeOf((*MockECSClient)(nil).SubmitTaskStateChange), arg0)
+}
+
+// UpdateContainerInstancesState mocks base method
+func (m *MockECSClient) UpdateContainerInstancesState(arg0, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateContainerInstancesState", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateContainerInstancesState indicates an expected call of UpdateContainerInstancesState
+func (mr *MockECSClientMockRecorder) UpdateContainerInstancesState(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateContainerInstancesState", reflect.TypeOf((*MockECSClient)(nil).UpdateContainerInstancesState), arg0, arg1)
 }

--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -621,14 +621,14 @@ func (agent *ecsAgent) startAsyncRoutines(
 }
 
 func (agent *ecsAgent) startSpotInstanceDrainingPoller(client api.ECSClient) {
-	for !agent.spotTerminationTimeCheck(client) {
+	for !agent.spotInstanceDrainingPoller(client) {
 		time.Sleep(time.Second)
 	}
 }
 
-// spotTerminationTimeCheck returns true if spot instance termination time has been
-// set and the container instance state is successfully set.
-func (agent *ecsAgent) spotTerminationTimeCheck(client api.ECSClient) bool {
+// spotInstanceDrainingPoller returns true if spot instance termination time has been
+// set AND the container instance state is successfully updated to DRAINING.
+func (agent *ecsAgent) spotInstanceDrainingPoller(client api.ECSClient) bool {
 	// this endpoint 404s unless a termination time has been set, so expect failure in most cases.
 	termtime, err := agent.ec2MetadataClient.SpotTerminationTime()
 	if err == nil && len(termtime) > 0 {

--- a/agent/ec2/blackhole_ec2_metadata_client.go
+++ b/agent/ec2/blackhole_ec2_metadata_client.go
@@ -76,3 +76,7 @@ func (blackholeMetadataClient) PrivateIPv4Address() (string, error) {
 func (blackholeMetadataClient) PublicIPv4Address() (string, error) {
 	return "", errors.New("blackholed")
 }
+
+func (blackholeMetadataClient) SpotTerminationTime() (string, error) {
+	return "", errors.New("blackholed")
+}

--- a/agent/ec2/ec2_metadata_client.go
+++ b/agent/ec2/ec2_metadata_client.go
@@ -33,6 +33,7 @@ const (
 	AllMacResource                            = "network/interfaces/macs"
 	VPCIDResourceFormat                       = "network/interfaces/macs/%s/vpc-id"
 	SubnetIDResourceFormat                    = "network/interfaces/macs/%s/subnet-id"
+	SpotTerminationTimeResource               = "spot/termination-time"
 	InstanceIDResource                        = "instance-id"
 	PrivateIPv4Resource                       = "local-ipv4"
 	PublicIPv4Resource                        = "public-ipv4"
@@ -76,6 +77,7 @@ type EC2MetadataClient interface {
 	Region() (string, error)
 	PrivateIPv4Address() (string, error)
 	PublicIPv4Address() (string, error)
+	SpotTerminationTime() (string, error)
 }
 
 type ec2MetadataClientImpl struct {
@@ -183,4 +185,11 @@ func (c *ec2MetadataClientImpl) PublicIPv4Address() (string, error) {
 // PrivateIPv4Address returns the private IPv4 of this instance
 func (c *ec2MetadataClientImpl) PrivateIPv4Address() (string, error) {
 	return c.client.GetMetadata(PrivateIPv4Resource)
+}
+
+// SpotTerminationTime returns the spot termination time, if it has been set.
+// If the time has not been set (ie, the instance is not scheduled for termination)
+// then this function returns an error.
+func (c *ec2MetadataClientImpl) SpotTerminationTime() (string, error) {
+	return c.client.GetMetadata(SpotTerminationTimeResource)
 }

--- a/agent/ec2/ec2_metadata_client_test.go
+++ b/agent/ec2/ec2_metadata_client_test.go
@@ -224,3 +224,31 @@ func TestPublicIPv4Address(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, publicIP, publicIPResponse)
 }
+
+func TestSpotTerminationTime(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockGetter := mock_ec2.NewMockHttpClient(ctrl)
+	testClient := ec2.NewEC2MetadataClient(mockGetter)
+
+	mockGetter.EXPECT().GetMetadata(
+		ec2.SpotTerminationTimeResource).Return("2019-08-26T17:54:20Z", nil)
+	resp, err := testClient.SpotTerminationTime()
+	assert.NoError(t, err)
+	assert.Equal(t, "2019-08-26T17:54:20Z", resp)
+}
+
+func TestSpotTerminationTimeError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockGetter := mock_ec2.NewMockHttpClient(ctrl)
+	testClient := ec2.NewEC2MetadataClient(mockGetter)
+
+	mockGetter.EXPECT().GetMetadata(
+		ec2.SpotTerminationTimeResource).Return("", fmt.Errorf("ERROR"))
+	resp, err := testClient.SpotTerminationTime()
+	assert.Error(t, err)
+	assert.Equal(t, "", resp)
+}

--- a/agent/ec2/mocks/ec2_mocks.go
+++ b/agent/ec2/mocks/ec2_mocks.go
@@ -216,6 +216,21 @@ func (mr *MockEC2MetadataClientMockRecorder) Region() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Region", reflect.TypeOf((*MockEC2MetadataClient)(nil).Region))
 }
 
+// SpotTerminationTime mocks base method
+func (m *MockEC2MetadataClient) SpotTerminationTime() (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SpotTerminationTime")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SpotTerminationTime indicates an expected call of SpotTerminationTime
+func (mr *MockEC2MetadataClientMockRecorder) SpotTerminationTime() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SpotTerminationTime", reflect.TypeOf((*MockEC2MetadataClient)(nil).SpotTerminationTime))
+}
+
 // SubnetID mocks base method
 func (m *MockEC2MetadataClient) SubnetID(arg0 string) (string, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
### Summary

This change adds a polling go-routine to the agent that checks if the instance has been scheduled for a [spot termination.](https://aws.amazon.com/blogs/aws/new-ec2-spot-instance-termination-notices/) If it has, agent will set the [instance's state to DRAINING](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/container-instance-draining.html).

see also https://github.com/aws/containers-roadmap/issues/190

### Implementation details

1. Added a new function to the internal ECS client: UpdateContainerInstancesState
2. Added a new function to the internal ec2 metadata client: SpotTerminationTime, checks metadata endpoint at spot/termination-time for a termination notice. If the notice has not been set this endpoint will 404.
3. Added a polling go-routine to check if the spot termination time has been set every 1s. If it has been set, the agent updates the container instance state to DRAINING.

### Testing

Unit tests added with full coverage. All integration tests run. Manually tested to verify functionality.

New tests cover the changes: yes

### Description for the changelog

Added support for automatic spot instance draining.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
