### PR TITLE
Add firelens container health check support

### DIFF
--- a/agent/Gopkg.lock
+++ b/agent/Gopkg.lock
@@ -61,11 +61,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:83cedb03ada7f52025f19d4e1fef1193b0c95dd3d1ec463488e5b9865bcf5af3"
+  digest = "1:8611d685d67d4d44786ca9fe2d9641647e60087bfcb71674fd3424c86617bbb4"
   name = "github.com/awslabs/go-config-generator-for-fluentd-and-fluentbit"
   packages = ["."]
   pruneopts = "UT"
-  revision = "d9b7ac1ed5905d5434dd21ebc1582389b4ae91d1"
+  revision = "55d4fd2e6f353637f53296306078fa4e9d753c1f"
 
 [[projects]]
   branch = "master"

--- a/agent/taskresource/firelens/firelensconfig_unix_test.go
+++ b/agent/taskresource/firelens/firelensconfig_unix_test.go
@@ -175,6 +175,12 @@ var (
     Listen 0.0.0.0
     Port 24224
 
+[INPUT]
+    Name tcp
+    Tag firelens-healthcheck
+    Listen 127.0.0.1
+    Port 8877
+
 [FILTER]
     Name   grep
     Match container-firelens*
@@ -192,6 +198,10 @@ var (
     Record ecs_cluster mycluster
     Record ecs_task_arn arn:aws:ecs:us-east-2:01234567891011:task/mycluster/3de392df-6bfa-470b-97ed-aa6f482cd7a
     Record ecs_task_definition taskdefinition:1
+
+[OUTPUT]
+    Name null
+    Match firelens-healthcheck
 
 [OUTPUT]
     Name kinesis_firehose

--- a/agent/vendor/github.com/awslabs/go-config-generator-for-fluentd-and-fluentbit/fluent-bit-template.go
+++ b/agent/vendor/github.com/awslabs/go-config-generator-for-fluentd-and-fluentbit/fluent-bit-template.go
@@ -19,7 +19,9 @@ var fluentBitConfigTemplate = `{{- range .IncludeConfigHeadOfFile -}}
 {{- range .Inputs }}
 [INPUT]
     Name {{ .Name }}
-    {{- if .Tag }}Tag {{ .Tag }}{{- end }}
+    {{- if .Tag }}
+    Tag {{ .Tag }}
+    {{- end }}
     {{- range $key, $value := .Options }}
     {{ $key }} {{ $value }}
     {{- end }}

--- a/agent/vendor/github.com/awslabs/go-config-generator-for-fluentd-and-fluentbit/fluentd-template.go
+++ b/agent/vendor/github.com/awslabs/go-config-generator-for-fluentd-and-fluentbit/fluentd-template.go
@@ -19,7 +19,9 @@ var fluentDConfigTemplate = `{{- range .IncludeConfigHeadOfFile -}}
 {{- range .Inputs }}
 <source>
     @type {{ .Name }}
-    {{- if .Tag }}tag {{ .Tag }}{{- end }}
+    {{- if .Tag }}
+    tag {{ .Tag }}
+    {{- end }}
     {{- range $key, $value := .Options }}
     {{ $key }} {{ $value }}
     {{- end }}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->
### Note
This depends on https://github.com/aws/amazon-ecs-agent/pull/2181. Changes are in second commit of this pr.

### Summary
<!-- What does this pull request do? -->
 Add firelens container health check support for bridge and awsvpc network mode.

### Implementation details
<!-- How are the changes implemented? -->
Add an input section in firelens config file so that it listens to a port for health check messages, and an output section that consumes the health check messages - 
```
[INPUT]
    Name tcp
    Tag firelens-healthcheck
    Listen 127.0.0.1
    Port 8877

[OUTPUT]
    Name null
    Match firelens-healthcheck
```
With these sections customer can use a container health check command to do health check on firelens container to verify the server is up and running - 
```
echo '{"health": "check"}' | nc 127.0.0.1 8877 || exit 1
```
Health check is only supported for fluentbit but not fluentd because ECS only maintains image for fluentbit and we can ensure `nc` is installed on the image.

https://github.com/awslabs/go-config-generator-for-fluentd-and-fluentbit dependency is updated to fix a bug in template that affects the health check sections.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes
Modified existing unit tests to cover the changes; manually verified that the health check command works. functional test is waiting on @PettitWesley to add `nc` to amazon/aws-for-fluent-bit image.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
