### PR TITLE
Update firelens functional test to test health check and local config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -235,13 +235,13 @@ namespace-tests:
 test-registry: netkitten volumes-test namespace-tests pause-container squid awscli image-cleanup-test-images fluentd \
 				agent-introspection-validator taskmetadata-validator v3-task-endpoint-validator \
 				container-metadata-file-validator elastic-inference-validator appmesh-plugin-validator \
-				eni-trunking-validator
+				eni-trunking-validator firelens-fluentbit-test-image firelens-fluentd-test-image
 	@./scripts/setup-test-registry
 
 
 # TODO, replace this with a build on dockerhub or a mechanism for the
 # functional tests themselves to build this
-.PHONY: squid awscli fluentd gremlin agent-introspection-validator taskmetadata-validator v3-task-endpoint-validator container-metadata-file-validator elastic-inference-validator image-cleanup-test-images ecr-execution-role-image container-health-check-image telemetry-test-image storage-stats-test-image
+.PHONY: squid awscli fluentd gremlin agent-introspection-validator taskmetadata-validator v3-task-endpoint-validator container-metadata-file-validator elastic-inference-validator image-cleanup-test-images ecr-execution-role-image container-health-check-image telemetry-test-image storage-stats-test-image firelens-fluentbit-test-image firelens-fluentd-test-image
 
 squid:
 	$(MAKE) -C misc/squid $(MFLAGS)
@@ -293,6 +293,14 @@ container-health-check-image:
 
 appmesh-plugin-validator:
 	$(MAKE) -C misc/appmesh-plugin-validator $(MFLAGS)
+
+firelens-fluentbit-test-image:
+ifneq (${BUILD_PLATFORM},aarch64) # fluentbit image isn't supported on ARM.
+	$(MAKE) -C misc/firelens-fluentbit $(MFLAGS)
+endif
+
+firelens-fluentd-test-image:
+	$(MAKE) -C misc/firelens-fluentd $(MFLAGS)
 
 # all .go files in the agent, excluding vendor/, model/ and testutils/ directories, and all *_test.go and *_mocks.go files
 GOFILES:=$(shell go list -f '{{$$p := .}}{{range $$f := .GoFiles}}{{$$p.Dir}}/{{$$f}} {{end}}' ./agent/... \
@@ -380,6 +388,8 @@ clean:
 	-$(MAKE) -C misc/storage-stats $(MFLAGS) clean
 	-$(MAKE) -C misc/appmesh-plugin-validator $(MFLAGS) clean
 	-$(MAKE) -C misc/eni-trunking-validator $(MFLAGS) clean
+	-$(MAKE) -C misc/firelens-fluentbit $(MFLAGS) clean
+	-$(MAKE) -C misc/firelens-fluentd $(MFLAGS) clean
 	-rm -f .get-deps-stamp
 	-rm -f .builder-image-stamp
 	-rm -f .out-stamp

--- a/agent/functional_tests/testdata/taskdefinitions/firelens-fluentbit/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/firelens-fluentbit/task-definition.json
@@ -6,11 +6,15 @@
   "containerDefinitions": [
     {
       "name": "firelens",
-      "image": "amazon/aws-for-fluent-bit:1.2.0",
+      "image": "127.0.0.1:51670/amazon/firelens-fluentbit:latest",
       "essential": true,
       "memory": 256,
       "firelensConfiguration": {
-        "type": "fluentbit"
+        "type": "fluentbit",
+        "options": {
+          "config-file-type": "file",
+          "config-file-value": "/tmp/local.conf"
+        }
       },
       "environment": [
         {
@@ -25,6 +29,11 @@
           "awslogs-region":"$$$TEST_REGION$$$",
           "awslogs-stream-prefix":"firelens-container"
         }
+      },
+      "healthCheck": {
+        "command": ["CMD-SHELL", "echo '{\"health\": \"check\"}' | nc 127.0.0.1 8877 || exit 1"],
+        "interval": 5,
+        "retries": 5
       }
     },
     {
@@ -46,7 +55,13 @@
           "name": "$$$SECRET_OPTION_KEY$$$",
           "valueFrom": "$$$SECRET_OPTION_PARAM$$$"
         }]
-      }
+      },
+      "dependsOn": [
+        {
+          "containerName": "firelens",
+          "condition": "HEALTHY"
+        }
+      ]
     }
   ]
 }

--- a/agent/functional_tests/testdata/taskdefinitions/firelens-fluentd/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/firelens-fluentd/task-definition.json
@@ -6,11 +6,15 @@
   "containerDefinitions": [
     {
       "name": "firelens",
-      "image": "fluentd:v1.4-2",
+      "image": "127.0.0.1:51670/amazon/firelens-fluentd:latest",
       "essential": true,
       "memory": 256,
       "firelensConfiguration": {
-        "type": "fluentd"
+        "type": "fluentd",
+        "options": {
+          "config-file-type": "file",
+          "config-file-value": "/tmp/local.conf"
+        }
       },
       "environment": [
         {

--- a/agent/functional_tests/tests/functionaltests_unix_test.go
+++ b/agent/functional_tests/tests/functionaltests_unix_test.go
@@ -1812,7 +1812,8 @@ func TestFirelensFluentd(t *testing.T) {
 		return message
 	}
 
-	testFirelens(t, "fluentd", "@type", "stdout", getLogSenderMessageFunc)
+	testFirelens(t, "fluentd", "@type", "stdout",
+		getLogSenderMessageFunc)
 }
 
 // TestFirelensFluentbit starts a task that has a log sender container and a firelens container with configuration type
@@ -1841,7 +1842,8 @@ func TestFirelensFluentbit(t *testing.T) {
 		return message
 	}
 
-	testFirelens(t, "fluentbit", "Name", "cloudwatch", getLogSenderMessageFunc)
+	testFirelens(t, "fluentbit", "Name", "cloudwatch",
+		getLogSenderMessageFunc)
 }
 
 func testFirelens(t *testing.T, firelensConfigType, secretLogOptionKey, secretLogOptionValue string,
@@ -1900,7 +1902,8 @@ func testFirelens(t *testing.T, firelensConfigType, secretLogOptionKey, secretLo
 	agent := RunAgent(t, agentOptions)
 	defer agent.Cleanup()
 
-	agent.RequireVersion(">=1.30.0")
+	// TODO: change to 1.31.0 before merging feature branch
+	agent.RequireVersion(">=1.29.1")
 
 	tdOverrides := make(map[string]string)
 	tdOverrides["$$$TEST_REGION$$$"] = *ECS.Config.Region
@@ -1933,4 +1936,5 @@ func testFirelens(t *testing.T, firelensConfigType, secretLogOptionKey, secretLo
 	assert.Equal(t, agent.Cluster, jsonBlob["ecs_cluster"])
 	assert.Equal(t, *testTask.TaskArn, jsonBlob["ecs_task_arn"])
 	assert.Contains(t, *testTask.TaskDefinitionArn, jsonBlob["ecs_task_definition"])
+	assert.Equal(t, "external_config_value", jsonBlob["external_config_key"])
 }

--- a/agent/functional_tests/tests/functionaltests_unix_test.go
+++ b/agent/functional_tests/tests/functionaltests_unix_test.go
@@ -1902,8 +1902,7 @@ func testFirelens(t *testing.T, firelensConfigType, secretLogOptionKey, secretLo
 	agent := RunAgent(t, agentOptions)
 	defer agent.Cleanup()
 
-	// TODO: change to 1.31.0 before merging feature branch
-	agent.RequireVersion(">=1.29.1")
+	agent.RequireVersion(">=1.31.0")
 
 	tdOverrides := make(map[string]string)
 	tdOverrides["$$$TEST_REGION$$$"] = *ECS.Config.Region

--- a/misc/firelens-fluentbit/Dockerfile
+++ b/misc/firelens-fluentbit/Dockerfile
@@ -1,0 +1,17 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+FROM amazon/aws-for-fluent-bit:1.2.0
+ADD local.conf /tmp/local.conf
+# TODO: remove below once amazon/aws-for-fluent-bit has nc by default
+RUN yum upgrade -y && yum install -y nc

--- a/misc/firelens-fluentbit/Makefile
+++ b/misc/firelens-fluentbit/Makefile
@@ -1,0 +1,20 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+.PHONY: all
+
+all:
+	docker build -t amazon/firelens-fluentbit:make -f Dockerfile .
+
+clean:
+	-docker rmi -f "amazon/firelens-fluentbit:make"

--- a/misc/firelens-fluentbit/local.conf
+++ b/misc/firelens-fluentbit/local.conf
@@ -1,0 +1,4 @@
+[FILTER]
+    Name record_modifier
+    Match *
+    Record external_config_key external_config_value

--- a/misc/firelens-fluentd/Dockerfile
+++ b/misc/firelens-fluentd/Dockerfile
@@ -1,0 +1,15 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+FROM fluentd:v1.4-2
+ADD local.conf /tmp/local.conf

--- a/misc/firelens-fluentd/Makefile
+++ b/misc/firelens-fluentd/Makefile
@@ -1,0 +1,20 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+.PHONY: all
+
+all:
+	docker build -t amazon/firelens-fluentd:make -f Dockerfile .
+
+clean:
+	-docker rmi -f "amazon/firelens-fluentd:make"

--- a/misc/firelens-fluentd/local.conf
+++ b/misc/firelens-fluentd/local.conf
@@ -1,0 +1,6 @@
+<filter *>
+    @type record_transformer
+    <record>
+        external_config_key external_config_value
+    </record>
+</filter>

--- a/scripts/setup-test-registry
+++ b/scripts/setup-test-registry
@@ -62,10 +62,15 @@ for image in "amazon/amazon-ecs-netkitten" "amazon/amazon-ecs-volumes-test" "ama
 				"amazon/image-cleanup-test-image3" "amazon/fluentd" "amazon/amazon-ecs-agent-introspection-validator" \
 				"amazon/amazon-ecs-taskmetadata-validator" "amazon/amazon-ecs-v3-task-endpoint-validator" \
 				"amazon/amazon-ecs-container-metadata-file-validator" "amazon/amazon-ecs-elastic-inference-validator" \
-				"amazon/amazon-appmesh-plugin-validator" "amazon/amazon-ecs-eni-trunking-validator"; do
-				mirror_local_image "${image}:make" "127.0.0.1:51670/${image}:latest"
+				"amazon/amazon-appmesh-plugin-validator" "amazon/amazon-ecs-eni-trunking-validator" \
+				"amazon/firelens-fluentd"; do
+  mirror_local_image "${image}:make" "127.0.0.1:51670/${image}:latest"
 done
 
+# amazon/firelens-fluentbit:make is only built on amd but not arm.
+if [[ -n $(docker images -q amazon/firelens-fluentbit:make) ]]; then
+	mirror_local_image "amazon/firelens-fluentbit:make" "127.0.0.1:51670/amazon/firelens-fluentbit:latest"
+fi
 
 # Remove the tag so this image can be deleted successfully in the docker image cleanup integ tests
 docker rmi amazon/image-cleanup-test-image1:make amazon/image-cleanup-test-image2:make amazon/image-cleanup-test-image3:make


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->
### Summary
<!-- What does this pull request do? -->
Update firelens functional test to test health check (https://github.com/aws/amazon-ecs-agent/pull/2189) and local config (part of https://github.com/aws/amazon-ecs-agent/pull/2179). Functional test for s3 config will be added separately later because it's still pending some service side changes.

### Implementation details
<!-- How are the changes implemented? -->
For local config:
Build fluentd and fluentbit images with an external config file at a given path, update functional test task definition to use the config, and update the checks to make sure the config is used.
The external config simply specifies a key value pair to be included in log stream output.

For health check:
Update functional test task definition to use health check.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
