### PR TITLE
BugFix for hostmode support for Firelens

### DIFF
--- a/agent/api/container/container.go
+++ b/agent/api/container/container.go
@@ -990,6 +990,26 @@ func (c *Container) GetLogDriver() string {
 	return hostConfig.LogConfig.Type
 }
 
+// GetNetworkModeFromHostConfig returns the network mode used by the container from the host config .
+func (c *Container) GetNetworkModeFromHostConfig() string {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	if c.DockerConfig.HostConfig == nil {
+		return ""
+	}
+
+	hostConfig := &dockercontainer.HostConfig{}
+	// TODO return error to differentiate between error and default mode .
+	err := json.Unmarshal([]byte(*c.DockerConfig.HostConfig), hostConfig)
+	if err != nil {
+		seelog.Warnf("Encountered error when trying to get network mode for container %s: %v", err)
+		return ""
+	}
+
+	return hostConfig.NetworkMode.NetworkName()
+}
+
 // GetHostConfig returns the container's host config.
 func (c *Container) GetHostConfig() *string {
 	c.lock.RLock()

--- a/agent/api/container/container_test.go
+++ b/agent/api/container/container_test.go
@@ -615,3 +615,36 @@ func TestGetLogDriver(t *testing.T) {
 		})
 	}
 }
+
+func TestGetNetworkModeFromHostConfig(t *testing.T) {
+	getContainer := func(hostConfig string) *Container {
+		c := &Container{
+			Name: "c",
+		}
+		c.DockerConfig.HostConfig = &hostConfig
+		return c
+	}
+
+	testCases := []struct {
+		name           string
+		container      *Container
+		expectedOutput string
+	}{
+		{
+			name:           "bridge mode",
+			container:      getContainer("{\"NetworkMode\":\"bridge\"}"),
+			expectedOutput: "bridge",
+		},
+		{
+			name:           "invalid case",
+			container:      getContainer("invalid"),
+			expectedOutput: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectedOutput, tc.container.GetNetworkModeFromHostConfig())
+		})
+	}
+}

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -846,10 +846,10 @@ func (task *Task) initializeFirelensResource(config *config.Config, resourceFiel
 			var networkMode string
 			if task.IsNetworkModeAWSVPC() {
 				networkMode = AWSVPCNetworkMode
-			} else if container.GetNetworkMode() == "" {
+			} else if container.GetNetworkModeFromHostConfig() == "" || container.GetNetworkModeFromHostConfig() == BridgeNetworkMode {
 				networkMode = BridgeNetworkMode
 			} else {
-				networkMode = container.GetNetworkMode()
+				networkMode = container.GetNetworkModeFromHostConfig()
 			}
 			firelensResource, err = firelens.NewFirelensResource(config.Cluster, task.Arn, task.Family+":"+task.Version,
 				ec2InstanceID, config.DataDir, firelensConfig.Type, config.AWSRegion, networkMode, firelensConfig.Options, containerToLogOptions,

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -932,7 +932,7 @@ func (engine *DockerTaskEngine) createContainer(task *apitask.Task, container *a
 				fluentNetworkHost: FluentAWSVPCHostValue,
 				fluentNetworkPort: FluentNetworkPortValue,
 			})
-		} else if container.GetNetworkMode() == "" || container.GetNetworkMode() == apitask.BridgeNetworkMode {
+		} else if container.GetNetworkModeFromHostConfig() == "" || container.GetNetworkModeFromHostConfig() == apitask.BridgeNetworkMode {
 			ipAddress, ok := getContainerHostIP(task.GetFirelensContainer().GetNetworkSettings())
 			if !ok {
 				err := apierrors.DockerClientConfigError{Msg: "unable to get BridgeIP for task in bridge  mode"}
@@ -1086,7 +1086,7 @@ func (engine *DockerTaskEngine) startContainer(task *apitask.Task, container *ap
 	// For the supported network mode - bridge and awsvpc, the awsvpc take the host 127.0.0.1 but in bridge mode,
 	// there is a need to wait for the IP to be present before the container using the firelens can be created.
 	if dockerContainerMD.Error == nil && container.GetFirelensConfig() != nil {
-		if !task.IsNetworkModeAWSVPC() && (container.GetNetworkMode() == "" || container.GetNetworkMode() == apitask.BridgeNetworkMode) {
+		if !task.IsNetworkModeAWSVPC() && (container.GetNetworkModeFromHostConfig() == "" || container.GetNetworkModeFromHostConfig() == apitask.BridgeNetworkMode) {
 			_, gotContainerIP := getContainerHostIP(dockerContainerMD.NetworkSettings)
 			if !gotContainerIP {
 				getIPBridgeBackoff := retry.NewExponentialBackoff(minGetIPBridgeTimeout, maxGetIPBridgeTimeout, getIPBridgeRetryJitterMultiplier, getIPBridgeRetryDelayMultiplier)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
BugFix for hostmode support for Firelens. 

### Implementation details
Instead of getting network mode from the container itself, I changed it to get it hostconfig instead. 

### Testing
Checked to see the correct network mode is identified. 
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
