### PR TITLE
Change termination-time query to instance-action

### DIFF
--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -15,6 +15,7 @@ package app
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -630,9 +631,28 @@ func (agent *ecsAgent) startSpotInstanceDrainingPoller(client api.ECSClient) {
 // set AND the container instance state is successfully updated to DRAINING.
 func (agent *ecsAgent) spotInstanceDrainingPoller(client api.ECSClient) bool {
 	// this endpoint 404s unless a interruption has been set, so expect failure in most cases.
-	termtime, err := agent.ec2MetadataClient.SpotInstanceAction()
-	if err == nil && len(termtime) > 0 {
-		seelog.Infof("Received a spot interruption (%s), setting state to DRAINING", termtime)
+	resp, err := agent.ec2MetadataClient.SpotInstanceAction()
+	if err == nil {
+		type InstanceAction struct {
+			Time   string
+			Action string
+		}
+		ia := InstanceAction{}
+
+		err := json.Unmarshal([]byte(resp), &ia)
+		if err != nil {
+			seelog.Errorf("Invalid response from /spot/instance-action endpoint: %s Error: %s", resp, err)
+			return false
+		}
+
+		switch ia.Action {
+		case "hibernate", "terminate", "stop":
+		default:
+			seelog.Errorf("Invalid response from /spot/instance-action endpoint: %s, Error: unrecognized action (%s)", resp, ia.Action)
+			return false
+		}
+
+		seelog.Infof("Received a spot interruption (%s) scheduled for %s, setting state to DRAINING", ia.Action, ia.Time)
 		err = client.UpdateContainerInstancesState(agent.containerInstanceARN, "DRAINING")
 		if err != nil {
 			seelog.Errorf("Error setting instance [ARN: %s] state to DRAINING: %s", agent.containerInstanceARN, err)

--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -622,6 +622,7 @@ func (agent *ecsAgent) startAsyncRoutines(
 }
 
 func (agent *ecsAgent) startSpotInstanceDrainingPoller(client api.ECSClient) {
+	seelog.Warnf("DEBUG REMOVE TODO::::: STARTING THE SPOT INSTANCE DRAILING POLLER")
 	for !agent.spotInstanceDrainingPoller(client) {
 		time.Sleep(time.Second)
 	}

--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -630,7 +630,7 @@ func (agent *ecsAgent) startSpotInstanceDrainingPoller(client api.ECSClient) {
 // set AND the container instance state is successfully updated to DRAINING.
 func (agent *ecsAgent) spotInstanceDrainingPoller(client api.ECSClient) bool {
 	// this endpoint 404s unless a termination time has been set, so expect failure in most cases.
-	termtime, err := agent.ec2MetadataClient.SpotTerminationTime()
+	termtime, err := agent.ec2MetadataClient.SpotInstanceAction()
 	if err == nil && len(termtime) > 0 {
 		seelog.Infof("Received a spot termination time (%s), setting state to DRAINING", termtime)
 		err = client.UpdateContainerInstancesState(agent.containerInstanceARN, "DRAINING")

--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -626,13 +626,13 @@ func (agent *ecsAgent) startSpotInstanceDrainingPoller(client api.ECSClient) {
 	}
 }
 
-// spotInstanceDrainingPoller returns true if spot instance termination time has been
+// spotInstanceDrainingPoller returns true if spot instance interruption has been
 // set AND the container instance state is successfully updated to DRAINING.
 func (agent *ecsAgent) spotInstanceDrainingPoller(client api.ECSClient) bool {
-	// this endpoint 404s unless a termination time has been set, so expect failure in most cases.
+	// this endpoint 404s unless a interruption has been set, so expect failure in most cases.
 	termtime, err := agent.ec2MetadataClient.SpotInstanceAction()
 	if err == nil && len(termtime) > 0 {
-		seelog.Infof("Received a spot termination time (%s), setting state to DRAINING", termtime)
+		seelog.Infof("Received a spot interruption (%s), setting state to DRAINING", termtime)
 		err = client.UpdateContainerInstancesState(agent.containerInstanceARN, "DRAINING")
 		if err != nil {
 			seelog.Errorf("Error setting instance [ARN: %s] state to DRAINING: %s", agent.containerInstanceARN, err)

--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -622,7 +622,6 @@ func (agent *ecsAgent) startAsyncRoutines(
 }
 
 func (agent *ecsAgent) startSpotInstanceDrainingPoller(client api.ECSClient) {
-	seelog.Warnf("DEBUG REMOVE TODO::::: STARTING THE SPOT INSTANCE DRAILING POLLER")
 	for !agent.spotInstanceDrainingPoller(client) {
 		time.Sleep(time.Second)
 	}

--- a/agent/app/agent_test.go
+++ b/agent/app/agent_test.go
@@ -1182,7 +1182,7 @@ func TestGetHostPublicIPv4AddressFromEC2MetadataFailWithError(t *testing.T) {
 	assert.Empty(t, agent.getHostPublicIPv4AddressFromEC2Metadata())
 }
 
-func TestSpotTerminationTimeCheck_Yes(t *testing.T) {
+func TestSpotInstanceActionCheck_Yes(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -1196,13 +1196,13 @@ func TestSpotTerminationTimeCheck_Yes(t *testing.T) {
 		ec2Client:            ec2Client,
 		containerInstanceARN: myARN,
 	}
-	ec2MetadataClient.EXPECT().SpotTerminationTime().Return("2019-08-26T18:21:08Z", nil)
+	ec2MetadataClient.EXPECT().SpotInstanceAction().Return("{\"action\": \"terminate\", \"time\": \"2017-09-18T08:22:00Z\"}", nil)
 	ecsClient.EXPECT().UpdateContainerInstancesState(myARN, "DRAINING").Return(nil)
 
 	assert.True(t, agent.spotInstanceDrainingPoller(ecsClient))
 }
 
-func TestSpotTerminationTimeCheck_EmptyTimestamp(t *testing.T) {
+func TestSpotInstanceActionCheck_EmptyTimestamp(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -1216,14 +1216,14 @@ func TestSpotTerminationTimeCheck_EmptyTimestamp(t *testing.T) {
 		ec2Client:            ec2Client,
 		containerInstanceARN: myARN,
 	}
-	ec2MetadataClient.EXPECT().SpotTerminationTime().Return("", nil)
+	ec2MetadataClient.EXPECT().SpotInstanceAction().Return("", nil)
 	// Container state should NOT be updated because the termination time field is empty.
 	ecsClient.EXPECT().UpdateContainerInstancesState(gomock.Any(), gomock.Any()).Times(0)
 
 	assert.False(t, agent.spotInstanceDrainingPoller(ecsClient))
 }
 
-func TestSpotTerminationTimeCheck_No(t *testing.T) {
+func TestSpotInstanceActionCheck_No(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -1237,7 +1237,7 @@ func TestSpotTerminationTimeCheck_No(t *testing.T) {
 		ec2Client:            ec2Client,
 		containerInstanceARN: myARN,
 	}
-	ec2MetadataClient.EXPECT().SpotTerminationTime().Return("", fmt.Errorf("404"))
+	ec2MetadataClient.EXPECT().SpotInstanceAction().Return("", fmt.Errorf("404"))
 
 	// Container state should NOT be updated because there is no termination time.
 	ecsClient.EXPECT().UpdateContainerInstancesState(gomock.Any(), gomock.Any()).Times(0)

--- a/agent/app/agent_test.go
+++ b/agent/app/agent_test.go
@@ -1182,7 +1182,14 @@ func TestGetHostPublicIPv4AddressFromEC2MetadataFailWithError(t *testing.T) {
 	assert.Empty(t, agent.getHostPublicIPv4AddressFromEC2Metadata())
 }
 
-func TestSpotInstanceActionCheck_Terminate(t *testing.T) {
+func TestSpotInstanceActionCheck_Sunny(t *testing.T) {
+	tests := []struct {
+		jsonresp string
+	}{
+		{jsonresp: `{"action": "terminate", "time": "2017-09-18T08:22:00Z"}`},
+		{jsonresp: `{"action": "hibernate", "time": "2017-09-18T08:22:00Z"}`},
+		{jsonresp: `{"action": "stop", "time": "2017-09-18T08:22:00Z"}`},
+	}
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -1190,19 +1197,28 @@ func TestSpotInstanceActionCheck_Terminate(t *testing.T) {
 	ec2Client := mock_ec2.NewMockClient(ctrl)
 	ecsClient := mock_api.NewMockECSClient(ctrl)
 
-	myARN := "myARN"
-	agent := &ecsAgent{
-		ec2MetadataClient:    ec2MetadataClient,
-		ec2Client:            ec2Client,
-		containerInstanceARN: myARN,
-	}
-	ec2MetadataClient.EXPECT().SpotInstanceAction().Return("{\"action\": \"terminate\", \"time\": \"2017-09-18T08:22:00Z\"}", nil)
-	ecsClient.EXPECT().UpdateContainerInstancesState(myARN, "DRAINING").Return(nil)
+	for _, test := range tests {
+		myARN := "myARN"
+		agent := &ecsAgent{
+			ec2MetadataClient:    ec2MetadataClient,
+			ec2Client:            ec2Client,
+			containerInstanceARN: myARN,
+		}
+		ec2MetadataClient.EXPECT().SpotInstanceAction().Return(test.jsonresp, nil)
+		ecsClient.EXPECT().UpdateContainerInstancesState(myARN, "DRAINING").Return(nil)
 
-	assert.True(t, agent.spotInstanceDrainingPoller(ecsClient))
+		assert.True(t, agent.spotInstanceDrainingPoller(ecsClient))
+	}
 }
 
-func TestSpotInstanceActionCheck_Stop(t *testing.T) {
+func TestSpotInstanceActionCheck_Fail(t *testing.T) {
+	tests := []struct {
+		jsonresp string
+	}{
+		{jsonresp: `{"action": "terminate" "time": "2017-09-18T08:22:00Z"}`}, // invalid json
+		{jsonresp: ``}, // empty json
+		{jsonresp: `{"action": "flip!", "time": "2017-09-18T08:22:00Z"}`}, // invalid action
+	}
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -1210,102 +1226,22 @@ func TestSpotInstanceActionCheck_Stop(t *testing.T) {
 	ec2Client := mock_ec2.NewMockClient(ctrl)
 	ecsClient := mock_api.NewMockECSClient(ctrl)
 
-	myARN := "myARN"
-	agent := &ecsAgent{
-		ec2MetadataClient:    ec2MetadataClient,
-		ec2Client:            ec2Client,
-		containerInstanceARN: myARN,
-	}
-	ec2MetadataClient.EXPECT().SpotInstanceAction().Return("{\"action\": \"stop\", \"time\": \"2017-09-18T08:22:00Z\"}", nil)
-	ecsClient.EXPECT().UpdateContainerInstancesState(myARN, "DRAINING").Return(nil)
+	for _, test := range tests {
+		myARN := "myARN"
+		agent := &ecsAgent{
+			ec2MetadataClient:    ec2MetadataClient,
+			ec2Client:            ec2Client,
+			containerInstanceARN: myARN,
+		}
+		ec2MetadataClient.EXPECT().SpotInstanceAction().Return(test.jsonresp, nil)
+		// Container state should NOT be updated because the termination time field is empty.
+		ecsClient.EXPECT().UpdateContainerInstancesState(gomock.Any(), gomock.Any()).Times(0)
 
-	assert.True(t, agent.spotInstanceDrainingPoller(ecsClient))
+		assert.False(t, agent.spotInstanceDrainingPoller(ecsClient))
+	}
 }
 
-func TestSpotInstanceActionCheck_Hibernate(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	ec2MetadataClient := mock_ec2.NewMockEC2MetadataClient(ctrl)
-	ec2Client := mock_ec2.NewMockClient(ctrl)
-	ecsClient := mock_api.NewMockECSClient(ctrl)
-
-	myARN := "myARN"
-	agent := &ecsAgent{
-		ec2MetadataClient:    ec2MetadataClient,
-		ec2Client:            ec2Client,
-		containerInstanceARN: myARN,
-	}
-	ec2MetadataClient.EXPECT().SpotInstanceAction().Return("{\"action\": \"hibernate\", \"time\": \"2017-09-18T08:22:00Z\"}", nil)
-	ecsClient.EXPECT().UpdateContainerInstancesState(myARN, "DRAINING").Return(nil)
-
-	assert.True(t, agent.spotInstanceDrainingPoller(ecsClient))
-}
-
-func TestSpotInstanceActionCheck_EmptyJSON(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	ec2MetadataClient := mock_ec2.NewMockEC2MetadataClient(ctrl)
-	ec2Client := mock_ec2.NewMockClient(ctrl)
-	ecsClient := mock_api.NewMockECSClient(ctrl)
-
-	myARN := "myARN"
-	agent := &ecsAgent{
-		ec2MetadataClient:    ec2MetadataClient,
-		ec2Client:            ec2Client,
-		containerInstanceARN: myARN,
-	}
-	ec2MetadataClient.EXPECT().SpotInstanceAction().Return("", nil)
-	// Container state should NOT be updated because the termination time field is empty.
-	ecsClient.EXPECT().UpdateContainerInstancesState(gomock.Any(), gomock.Any()).Times(0)
-
-	assert.False(t, agent.spotInstanceDrainingPoller(ecsClient))
-}
-
-func TestSpotInstanceActionCheck_InvalidJSON(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	ec2MetadataClient := mock_ec2.NewMockEC2MetadataClient(ctrl)
-	ec2Client := mock_ec2.NewMockClient(ctrl)
-	ecsClient := mock_api.NewMockECSClient(ctrl)
-
-	myARN := "myARN"
-	agent := &ecsAgent{
-		ec2MetadataClient:    ec2MetadataClient,
-		ec2Client:            ec2Client,
-		containerInstanceARN: myARN,
-	}
-	ec2MetadataClient.EXPECT().SpotInstanceAction().Return("{\"action\": \"terminate\" \"time\": \"2017-09-18T08:22:00Z\"}", nil)
-	// Container state should NOT be updated because the termination time field is empty.
-	ecsClient.EXPECT().UpdateContainerInstancesState(gomock.Any(), gomock.Any()).Times(0)
-
-	assert.False(t, agent.spotInstanceDrainingPoller(ecsClient))
-}
-
-func TestSpotInstanceActionCheck_UnknownInstanceAction(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	ec2MetadataClient := mock_ec2.NewMockEC2MetadataClient(ctrl)
-	ec2Client := mock_ec2.NewMockClient(ctrl)
-	ecsClient := mock_api.NewMockECSClient(ctrl)
-
-	myARN := "myARN"
-	agent := &ecsAgent{
-		ec2MetadataClient:    ec2MetadataClient,
-		ec2Client:            ec2Client,
-		containerInstanceARN: myARN,
-	}
-	ec2MetadataClient.EXPECT().SpotInstanceAction().Return("{\"action\": \"flip!\", \"time\": \"2017-09-18T08:22:00Z\"}", nil)
-	// Container state should NOT be updated because the termination time field is empty.
-	ecsClient.EXPECT().UpdateContainerInstancesState(gomock.Any(), gomock.Any()).Times(0)
-
-	assert.False(t, agent.spotInstanceDrainingPoller(ecsClient))
-}
-
-func TestSpotInstanceActionCheck_No(t *testing.T) {
+func TestSpotInstanceActionCheck_NoInstanceActionYet(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 

--- a/agent/ec2/blackhole_ec2_metadata_client.go
+++ b/agent/ec2/blackhole_ec2_metadata_client.go
@@ -77,6 +77,6 @@ func (blackholeMetadataClient) PublicIPv4Address() (string, error) {
 	return "", errors.New("blackholed")
 }
 
-func (blackholeMetadataClient) SpotTerminationTime() (string, error) {
+func (blackholeMetadataClient) SpotInstanceAction() (string, error) {
 	return "", errors.New("blackholed")
 }

--- a/agent/ec2/ec2_metadata_client.go
+++ b/agent/ec2/ec2_metadata_client.go
@@ -33,7 +33,7 @@ const (
 	AllMacResource                            = "network/interfaces/macs"
 	VPCIDResourceFormat                       = "network/interfaces/macs/%s/vpc-id"
 	SubnetIDResourceFormat                    = "network/interfaces/macs/%s/subnet-id"
-	SpotTerminationTimeResource               = "spot/termination-time"
+	SpotInstanceActionResource                = "spot/instance-action"
 	InstanceIDResource                        = "instance-id"
 	PrivateIPv4Resource                       = "local-ipv4"
 	PublicIPv4Resource                        = "public-ipv4"
@@ -77,7 +77,7 @@ type EC2MetadataClient interface {
 	Region() (string, error)
 	PrivateIPv4Address() (string, error)
 	PublicIPv4Address() (string, error)
-	SpotTerminationTime() (string, error)
+	SpotInstanceAction() (string, error)
 }
 
 type ec2MetadataClientImpl struct {
@@ -187,9 +187,10 @@ func (c *ec2MetadataClientImpl) PrivateIPv4Address() (string, error) {
 	return c.client.GetMetadata(PrivateIPv4Resource)
 }
 
-// SpotTerminationTime returns the spot termination time, if it has been set.
-// If the time has not been set (ie, the instance is not scheduled for termination)
+// SpotInstanceAction returns the spot instance-action, if it has been set.
+// If the time has not been set (ie, the instance is not scheduled for interruption)
 // then this function returns an error.
-func (c *ec2MetadataClientImpl) SpotTerminationTime() (string, error) {
-	return c.client.GetMetadata(SpotTerminationTimeResource)
+// see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-interruptions.html#using-spot-instances-managing-interruptions
+func (c *ec2MetadataClientImpl) SpotInstanceAction() (string, error) {
+	return c.client.GetMetadata(SpotInstanceActionResource)
 }

--- a/agent/ec2/ec2_metadata_client_test.go
+++ b/agent/ec2/ec2_metadata_client_test.go
@@ -225,7 +225,7 @@ func TestPublicIPv4Address(t *testing.T) {
 	assert.Equal(t, publicIP, publicIPResponse)
 }
 
-func TestSpotTerminationTime(t *testing.T) {
+func TestSpotInstanceAction(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -233,13 +233,13 @@ func TestSpotTerminationTime(t *testing.T) {
 	testClient := ec2.NewEC2MetadataClient(mockGetter)
 
 	mockGetter.EXPECT().GetMetadata(
-		ec2.SpotTerminationTimeResource).Return("2019-08-26T17:54:20Z", nil)
-	resp, err := testClient.SpotTerminationTime()
+		ec2.SpotInstanceActionResource).Return("{\"action\": \"terminate\", \"time\": \"2017-09-18T08:22:00Z\"}", nil)
+	resp, err := testClient.SpotInstanceAction()
 	assert.NoError(t, err)
-	assert.Equal(t, "2019-08-26T17:54:20Z", resp)
+	assert.Equal(t, "{\"action\": \"terminate\", \"time\": \"2017-09-18T08:22:00Z\"}", resp)
 }
 
-func TestSpotTerminationTimeError(t *testing.T) {
+func TestSpotInstanceActionError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -247,8 +247,8 @@ func TestSpotTerminationTimeError(t *testing.T) {
 	testClient := ec2.NewEC2MetadataClient(mockGetter)
 
 	mockGetter.EXPECT().GetMetadata(
-		ec2.SpotTerminationTimeResource).Return("", fmt.Errorf("ERROR"))
-	resp, err := testClient.SpotTerminationTime()
+		ec2.SpotInstanceActionResource).Return("", fmt.Errorf("ERROR"))
+	resp, err := testClient.SpotInstanceAction()
 	assert.Error(t, err)
 	assert.Equal(t, "", resp)
 }

--- a/agent/ec2/mocks/ec2_mocks.go
+++ b/agent/ec2/mocks/ec2_mocks.go
@@ -216,19 +216,19 @@ func (mr *MockEC2MetadataClientMockRecorder) Region() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Region", reflect.TypeOf((*MockEC2MetadataClient)(nil).Region))
 }
 
-// SpotTerminationTime mocks base method
-func (m *MockEC2MetadataClient) SpotTerminationTime() (string, error) {
+// SpotInstanceAction mocks base method
+func (m *MockEC2MetadataClient) SpotInstanceAction() (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SpotTerminationTime")
+	ret := m.ctrl.Call(m, "SpotInstanceAction")
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// SpotTerminationTime indicates an expected call of SpotTerminationTime
-func (mr *MockEC2MetadataClientMockRecorder) SpotTerminationTime() *gomock.Call {
+// SpotInstanceAction indicates an expected call of SpotInstanceAction
+func (mr *MockEC2MetadataClientMockRecorder) SpotInstanceAction() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SpotTerminationTime", reflect.TypeOf((*MockEC2MetadataClient)(nil).SpotTerminationTime))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SpotInstanceAction", reflect.TypeOf((*MockEC2MetadataClient)(nil).SpotInstanceAction))
 }
 
 // SubnetID mocks base method


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary

This is an update to https://github.com/aws/amazon-ecs-agent/pull/2182

The previous PR only handled the most common type of interruption notice: termination.

But it's possible for users to configure their spot instances to terminate via "stop" or "hibernate", so this PR will handle these types of notices as well.

### Implementation details

As explained here: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-interruptions.html#using-spot-instances-managing-interruptions, it's possible for spot instances to be interrupted with hibernate or stop actions.

In our implementation, we don't care about which action happened or what time the instance is scheduled to be interrupted. In the same way the termination-time endpoint worked, the instance-action endpoint will 404 until an instance-action has been scheduled (stop, hibernate, or terminate). So once we know that one of these interruptions has been scheduled, we simply set the instance status to DRAINING ASAP.

### Testing

unit, integration, manual

New tests cover the changes: yes

### Description for the changelog

Added support for automatic spot instance draining.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
