### PR TITLE
ImageDigest only for ECR

### DIFF
--- a/agent/engine/docker_image_manager_test.go
+++ b/agent/engine/docker_image_manager_test.go
@@ -286,7 +286,7 @@ func TestFetchRepoDigest(t *testing.T) {
 			container: &apicontainer.Container{
 				Name:        "testContainer1",
 				Image:       "repo1",
-				ImageDigest: "digest1",
+				ImageDigest: "",
 			},
 			imageInspected: &types.ImageInspect{
 				RepoDigests: []string{"repo1@digest1", "repo2@digest2", "repo3@digest3"},
@@ -296,7 +296,7 @@ func TestFetchRepoDigest(t *testing.T) {
 			container: &apicontainer.Container{
 				Name:        "testContainer2",
 				Image:       "repo1:latest",
-				ImageDigest: "digest1",
+				ImageDigest: "",
 			},
 			imageInspected: &types.ImageInspect{
 				RepoDigests: []string{"repo1@digest1", "repo2@digest2", "repo3@digest3"},
@@ -306,7 +306,7 @@ func TestFetchRepoDigest(t *testing.T) {
 			container: &apicontainer.Container{
 				Name:        "testContainer3",
 				Image:       "repo1@sha256:12345",
-				ImageDigest: "sha256:12345",
+				ImageDigest: "",
 			},
 			imageInspected: &types.ImageInspect{
 				RepoDigests: []string{"repo1@sha256:12345", "repo2@digest2", "repo3"},
@@ -330,6 +330,38 @@ func TestFetchRepoDigest(t *testing.T) {
 			},
 			imageInspected: &types.ImageInspect{
 				RepoDigests: []string{"mysql", "repo2@digest2"},
+			},
+		},
+		{
+			container: &apicontainer.Container{
+				Name:        "testContainer6",
+				Image:       "123456781234.dkr.ecr.us-west-2.amazonaws.com/test-rci@sha256:d1c14fcf2e9476ed58ebc4251b211f403f271e96b6c3d9ada0f1c5454ca4d230",
+				ImageDigest: "sha256:d1c14fcf2e9476ed58ebc4251b211f403f271e96b6c3d9ada0f1c5454ca4d230",
+				RegistryAuthentication: &apicontainer.RegistryAuthenticationData{
+					Type: "ecr",
+					ECRAuthData: &apicontainer.ECRAuthData{
+						RegistryID: "123456781234",
+					},
+				},
+			},
+			imageInspected: &types.ImageInspect{
+				RepoDigests: []string{"repo1@digest1", "repo2@digest2", "123456781234.dkr.ecr.us-west-2.amazonaws.com/test-rci@sha256:d1c14fcf2e9476ed58ebc4251b211f403f271e96b6c3d9ada0f1c5454ca4d230"},
+			},
+		},
+		{
+			container: &apicontainer.Container{
+				Name:        "testContainer7",
+				Image:       "123456781234.dkr.ecr.us-west-2.amazonaws.com/ubuntu:trusty",
+				ImageDigest: "sha256:2feffff9eeca4e736f9f8e57813a97fe930554f474f7795ffa5a9261adeaaf44",
+				RegistryAuthentication: &apicontainer.RegistryAuthenticationData{
+					Type: "ecr",
+					ECRAuthData: &apicontainer.ECRAuthData{
+						RegistryID: "123456781234",
+					},
+				},
+			},
+			imageInspected: &types.ImageInspect{
+				RepoDigests: []string{"repo1@digest1", "repo2@digest2", "", "123456781234.dkr.ecr.us-west-2.amazonaws.com/ubuntu@sha256:2feffff9eeca4e736f9f8e57813a97fe930554f474f7795ffa5a9261adeaaf44"},
 			},
 		},
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Fetch the image RepoDigest only for ECR.
run docker images --digests
### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
container repositories support two kinds of digests: manifest digests and index digests.  Manifest digests are the digests for the manifest which represents a specific os and architecture that an image was built for.Index digests that image digest that build on top of manifest digest (we can get this from docker images —digests). When user directly pull an image from DockerHub, user get a digest as we called index digest. When the same image in ECR repo, we get the digest called manifest digest. ECR doesn’t currently support index digests, so users won’t see this behavior. Dockerhub displays the manifest digest on their website, but the index digest is what is recorded by the docker daemon. This may confuse customers which ImageDigest that they use (manifest digest or index digest).

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
