### PR TITLE
Functional test to test fluentd and fluentbit with fluent-logger

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -235,13 +235,14 @@ namespace-tests:
 test-registry: netkitten volumes-test namespace-tests pause-container squid awscli image-cleanup-test-images fluentd \
 				agent-introspection-validator taskmetadata-validator v3-task-endpoint-validator \
 				container-metadata-file-validator elastic-inference-validator appmesh-plugin-validator \
-				eni-trunking-validator firelens-fluentbit-test-image firelens-fluentd-test-image
+				eni-trunking-validator firelens-fluentbit-test-image firelens-fluentd-test-image \
+				firelens-fluent-logger-test-image
 	@./scripts/setup-test-registry
 
 
 # TODO, replace this with a build on dockerhub or a mechanism for the
 # functional tests themselves to build this
-.PHONY: squid awscli fluentd gremlin agent-introspection-validator taskmetadata-validator v3-task-endpoint-validator container-metadata-file-validator elastic-inference-validator image-cleanup-test-images ecr-execution-role-image container-health-check-image telemetry-test-image storage-stats-test-image firelens-fluentbit-test-image firelens-fluentd-test-image
+.PHONY: squid awscli fluentd gremlin agent-introspection-validator taskmetadata-validator v3-task-endpoint-validator container-metadata-file-validator elastic-inference-validator image-cleanup-test-images ecr-execution-role-image container-health-check-image telemetry-test-image storage-stats-test-image firelens-fluentbit-test-image firelens-fluentd-test-image firelens-fluent-logger-test-image
 
 squid:
 	$(MAKE) -C misc/squid $(MFLAGS)
@@ -301,6 +302,9 @@ endif
 
 firelens-fluentd-test-image:
 	$(MAKE) -C misc/firelens-fluentd $(MFLAGS)
+
+firelens-fluent-logger-test-image:
+	$(MAKE) -C misc/fluent-logger $(MFLAGS)
 
 # all .go files in the agent, excluding vendor/, model/ and testutils/ directories, and all *_test.go and *_mocks.go files
 GOFILES:=$(shell go list -f '{{$$p := .}}{{range $$f := .GoFiles}}{{$$p.Dir}}/{{$$f}} {{end}}' ./agent/... \
@@ -390,6 +394,7 @@ clean:
 	-$(MAKE) -C misc/eni-trunking-validator $(MFLAGS) clean
 	-$(MAKE) -C misc/firelens-fluentbit $(MFLAGS) clean
 	-$(MAKE) -C misc/firelens-fluentd $(MFLAGS) clean
+	-$(MAKE) -C misc/fluent-logger $(MFLAGS) clean
 	-rm -f .get-deps-stamp
 	-rm -f .builder-image-stamp
 	-rm -f .out-stamp

--- a/THIRD-PARTY
+++ b/THIRD-PARTY
@@ -736,3 +736,21 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+-----
+
+** https://github.com/fluent/fluent-logger-golang; version v1.4.0 --
+https://github.com/fluent/fluent-logger-golang
+Copyright (c) 2013 Tatsuo Kaniwa
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/agent/functional_tests/testdata/taskdefinitions/firelens-fluentbit-fluent-logger-awsvpc/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/firelens-fluentbit-fluent-logger-awsvpc/task-definition.json
@@ -1,0 +1,46 @@
+{
+  "family": "ecsftest-firelens-fluentbit-fluent-logger-awsvpc",
+  "networkMode": "awsvpc",
+  "taskRoleArn": "$$$TASK_ROLE$$$",
+  "executionRoleArn": "$$$EXECUTION_ROLE$$$",
+  "containerDefinitions": [
+    {
+      "name": "firelens",
+      "image": "127.0.0.1:51670/amazon/firelens-fluentbit:latest",
+      "essential": true,
+      "memory": 256,
+      "firelensConfiguration": {
+        "type": "fluentbit",
+        "options": {
+          "config-file-type": "file",
+          "config-file-value": "/tmp/local.conf"
+        }
+      },
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group":"ecs-functional-tests",
+          "awslogs-region":"$$$TEST_REGION$$$",
+          "awslogs-stream-prefix":"firelens-fluentbit"
+        }
+      }
+    },
+    {
+      "name": "logsender",
+      "image": "127.0.0.1:51670/amazon/fluent-logger:latest",
+      "essential": true,
+      "memory": 256,
+      "logConfiguration": {
+        "logDriver": "awsfirelens",
+        "options": {
+         "Name": "stdout"
+        }
+      },
+      "environment": [
+        {
+          "name": "LOGGER_UUID",
+          "value": "$$$LOGGER_UUID$$$"
+        }]
+    }
+  ]
+}

--- a/agent/functional_tests/testdata/taskdefinitions/firelens-fluentbit-fluent-logger/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/firelens-fluentbit-fluent-logger/task-definition.json
@@ -1,0 +1,69 @@
+{
+  "family": "ecsftest-firelens-fluentbit-fluent-logger",
+  "networkMode": "bridge",
+  "taskRoleArn": "$$$TASK_ROLE$$$",
+  "executionRoleArn": "$$$EXECUTION_ROLE$$$",
+  "containerDefinitions": [
+    {
+      "name": "firelens",
+      "image": "127.0.0.1:51670/amazon/firelens-fluentbit:latest",
+      "essential": true,
+      "memory": 256,
+      "firelensConfiguration": {
+        "type": "fluentbit",
+        "options": {
+          "config-file-type": "file",
+          "config-file-value": "/tmp/local.conf"
+        }
+      },
+      "environment": [
+        {
+          "name": "FLB_LOG_LEVEL",
+          "value": "debug"
+        }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group":"ecs-functional-tests",
+          "awslogs-region":"$$$TEST_REGION$$$",
+          "awslogs-stream-prefix":"firelens-container"
+        }
+      },
+      "healthCheck": {
+        "command": ["CMD-SHELL", "echo '{\"health\": \"check\"}' | nc 127.0.0.1 8877 || exit 1"],
+        "interval": 5,
+        "retries": 5
+      }
+    },
+    {
+      "name": "logsender",
+      "image": "127.0.0.1:51670/amazon/fluent-logger:latest",
+      "essential": true,
+      "memory": 256,
+      "logConfiguration": {
+        "logDriver": "awsfirelens",
+        "options": {
+          "region": "$$$TEST_REGION$$$",
+          "log_group_name": "ecs-functional-tests",
+          "log_stream_prefix": "firelens-fluentbit-"
+        },
+        "secretOptions": [{
+          "name": "$$$SECRET_OPTION_KEY$$$",
+          "valueFrom": "$$$SECRET_OPTION_PARAM$$$"
+        }]
+      },
+      "environment": [
+        {
+          "name": "LOGGER_UUID",
+          "value": "$$$LOGGER_UUID$$$"
+        }],
+      "dependsOn": [
+        {
+          "containerName": "firelens",
+          "condition": "HEALTHY"
+        }
+      ]
+    }
+  ]
+}

--- a/agent/functional_tests/testdata/taskdefinitions/firelens-fluentd-fluent-logger-awsvpc/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/firelens-fluentd-fluent-logger-awsvpc/task-definition.json
@@ -1,0 +1,58 @@
+{
+  "family": "ecsftest-firelens-fluentd-fluent-logger-awsvpc",
+  "networkMode": "awsvpc",
+  "taskRoleArn": "$$$TASK_ROLE$$$",
+  "executionRoleArn": "$$$EXECUTION_ROLE$$$",
+  "containerDefinitions": [
+    {
+      "name": "firelens",
+      "image": "127.0.0.1:51670/amazon/firelens-fluentd:latest",
+      "essential": true,
+      "memory": 256,
+      "firelensConfiguration": {
+        "type": "fluentd",
+        "options": {
+          "config-file-type": "file",
+          "config-file-value": "/tmp/local.conf"
+        }
+      },
+      "environment": [
+        {
+          "name": "FLUENTD_OPT",
+          "value": "-v"
+        }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group":"ecs-functional-tests",
+          "awslogs-region":"$$$TEST_REGION$$$",
+          "awslogs-stream-prefix":"firelens-fluentd",
+          "awslogs-multiline-pattern":"^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}"
+        }
+      }
+    },
+    {
+      "name": "logsender",
+      "image": "127.0.0.1:51670/amazon/fluent-logger:latest",
+      "essential": true,
+      "memory": 256,
+      "logConfiguration": {
+        "logDriver": "awsfirelens",
+        "options": {
+          "include-pattern": "pass",
+          "exclude-pattern": "filtered"
+        },
+        "secretOptions": [{
+          "name": "$$$SECRET_OPTION_KEY$$$",
+          "valueFrom": "$$$SECRET_OPTION_PARAM$$$"
+        }]
+      },
+      "environment": [
+        {
+          "name": "LOGGER_UUID",
+          "value": "$$$LOGGER_UUID$$$"
+        }]
+    }
+  ]
+}

--- a/agent/functional_tests/testdata/taskdefinitions/firelens-fluentd-fluent-logger/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/firelens-fluentd-fluent-logger/task-definition.json
@@ -1,0 +1,53 @@
+{
+  "family": "ecsftest-firelens-fluentd-fluent-logger",
+  "networkMode": "bridge",
+  "taskRoleArn": "$$$TASK_ROLE$$$",
+  "executionRoleArn": "$$$EXECUTION_ROLE$$$",
+  "containerDefinitions": [
+    {
+      "name": "firelens",
+      "image": "127.0.0.1:51670/amazon/firelens-fluentd:latest",
+      "essential": true,
+      "memory": 256,
+      "firelensConfiguration": {
+        "type": "fluentd",
+        "options": {
+          "config-file-type": "file",
+          "config-file-value": "/tmp/local.conf"
+        }
+      },
+      "environment": [
+        {
+          "name": "FLUENTD_OPT",
+          "value": "-v"
+        }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group":"ecs-functional-tests",
+          "awslogs-region":"$$$TEST_REGION$$$",
+          "awslogs-stream-prefix":"firelens-fluentd",
+          "awslogs-multiline-pattern":"^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}"
+        }
+      }
+    },
+    {
+      "name": "logsender",
+      "image": "127.0.0.1:51670/amazon/fluent-logger:latest",
+      "essential": true,
+      "memory": 256,
+      "logConfiguration": {
+        "logDriver": "awsfirelens",
+        "options": {
+          "include-pattern": "pass",
+          "exclude-pattern": "filtered"
+        },
+        "secretOptions": [{
+          "name": "$$$SECRET_OPTION_KEY$$$",
+          "valueFrom": "$$$SECRET_OPTION_PARAM$$$"
+        }]
+      }
+    }
+  ]
+}

--- a/misc/fluent-logger/Dockerfile
+++ b/misc/fluent-logger/Dockerfile
@@ -1,0 +1,18 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+FROM golang:1.12
+
+MAINTAINER Amazon Web Services, Inc.
+COPY fluent-logger /
+
+ENTRYPOINT ["/fluent-logger"]

--- a/misc/fluent-logger/Makefile
+++ b/misc/fluent-logger/Makefile
@@ -1,0 +1,25 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+.PHONY: all clean fluent-logger image
+
+all: fluent-logger image
+
+fluent-logger: fluent-logger.go
+	@./build-in-docker
+
+image: fluent-logger
+	docker build -t amazon/fluent-logger:make .
+
+clean:
+	rm -f fluent-logger
+	-docker rmi -f "amazon/fluent-logger:make"

--- a/misc/fluent-logger/build-in-docker
+++ b/misc/fluent-logger/build-in-docker
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+CUR_DIR=$(pwd)
+AGENT_VENDOR_DIR=$(echo $(cd ${CUR_DIR}/../../agent/vendor;pwd))
+
+docker run \
+	-v ${CUR_DIR}:/out \
+	-v ${CUR_DIR}/fluent-logger.go:/in/fluent-logger.go \
+	-v ${CUR_DIR}/go.mod:/in/go.mod\
+	-v ${CUR_DIR}/go.sum:/in/go.sum \
+	-v ${AGENT_VENDOR_DIR}:/gopath/src \
+	-e CGO_ENABLED=0 \
+	-e GO111MODULE=on \
+	-e GOPATH=/go:/gopath \
+	golang:1.12 go build -a -x -ldflags '-s' -o /out/fluent-logger /in/fluent-logger.go

--- a/misc/fluent-logger/fluent-logger.go
+++ b/misc/fluent-logger/fluent-logger.go
@@ -1,0 +1,41 @@
+//Copyright (c) 2013 Tatsuo Kaniwa
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+
+	"github.com/fluent/fluent-logger-golang/fluent"
+)
+
+func main() {
+	port, _ := strconv.ParseInt(os.Getenv("FLUENT_PORT"), 10, 32)
+	uuid := os.Getenv("LOGGER_UUID")
+	tag := "logsender-firelens-" + uuid
+	logger, err := fluent.New(fluent.Config{FluentPort: int(port), FluentHost: os.Getenv("FLUENT_HOST"), Async: true})
+	if err != nil {
+		fmt.Println(err)
+	}
+	defer logger.Close()
+	var data = map[string]string{
+		"log": "pass"}
+	e := logger.Post(tag, data)
+	if e != nil {
+		log.Println("Error while posting log: ", e)
+	}
+}

--- a/scripts/setup-test-registry
+++ b/scripts/setup-test-registry
@@ -63,7 +63,7 @@ for image in "amazon/amazon-ecs-netkitten" "amazon/amazon-ecs-volumes-test" "ama
 				"amazon/amazon-ecs-taskmetadata-validator" "amazon/amazon-ecs-v3-task-endpoint-validator" \
 				"amazon/amazon-ecs-container-metadata-file-validator" "amazon/amazon-ecs-elastic-inference-validator" \
 				"amazon/amazon-appmesh-plugin-validator" "amazon/amazon-ecs-eni-trunking-validator" \
-				"amazon/firelens-fluentd"; do
+				"amazon/firelens-fluentd" "amazon/fluent-logger"; do
   mirror_local_image "${image}:make" "127.0.0.1:51670/${image}:latest"
 done
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Functional test to test fluentd and fluentbit with fluent-logger

### Implementation details
Added image for fluent-logger, for here - https://github.com/fluent/fluent-logger-golang modified to work for the test case.
Added two functional test using the fluent-logger for fluentd and fluentbit

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
