### PR TITLE
Wait for agent to exit before exiting test case

### DIFF
--- a/agent/app/agent_unix_test.go
+++ b/agent/app/agent_unix_test.go
@@ -105,7 +105,6 @@ func TestDoStartHappyPath(t *testing.T) {
 	cfg := getTestConfig()
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines
-	defer cancel()
 	agent := &ecsAgent{
 		ctx:                ctx,
 		cfg:                &cfg,
@@ -115,13 +114,20 @@ func TestDoStartHappyPath(t *testing.T) {
 		mobyPlugins:        mockMobyPlugins,
 	}
 
-	go agent.doStart(eventstream.NewEventStream("events", ctx),
-		credentialsManager, state, imageManager, client)
+	var agentW sync.WaitGroup
+	agentW.Add(1)
+	go func() {
+		agent.doStart(eventstream.NewEventStream("events", ctx),
+			credentialsManager, state, imageManager, client)
+		agentW.Done()
+	}()
 
 	// Wait for both DiscoverPollEndpointInput and DiscoverTelemetryEndpoint to be
 	// invoked. These are used as proxies to indicate that acs and tcs handlers'
 	// NewSession call has been invoked
 	discoverEndpointsInvoked.Wait()
+	cancel()
+	agentW.Wait()
 }
 
 func TestDoStartTaskENIHappyPath(t *testing.T) {
@@ -210,7 +216,6 @@ func TestDoStartTaskENIHappyPath(t *testing.T) {
 	cfg.ENITrunkingEnabled = true
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines
-	defer cancel()
 	agent := &ecsAgent{
 		ctx:                ctx,
 		cfg:                &cfg,
@@ -224,13 +229,20 @@ func TestDoStartTaskENIHappyPath(t *testing.T) {
 		mobyPlugins:        mockMobyPlugins,
 	}
 
-	go agent.doStart(eventstream.NewEventStream("events", ctx),
-		credentialsManager, state, imageManager, client)
+	var agentW sync.WaitGroup
+	agentW.Add(1)
+	go func() {
+		agent.doStart(eventstream.NewEventStream("events", ctx),
+			credentialsManager, state, imageManager, client)
+		agentW.Done()
+	}()
 
 	// Wait for both DiscoverPollEndpointInput and DiscoverTelemetryEndpoint to be
 	// invoked. These are used as proxies to indicate that acs and tcs handlers'
 	// NewSession call has been invoked
 	discoverEndpointsInvoked.Wait()
+	cancel()
+	agentW.Wait()
 }
 
 func TestSetVPCSubnetHappyPath(t *testing.T) {
@@ -545,7 +557,6 @@ func TestDoStartCgroupInitHappyPath(t *testing.T) {
 	cfg := config.DefaultConfig()
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines
-	defer cancel()
 	agent := &ecsAgent{
 		ctx:                ctx,
 		cfg:                &cfg,
@@ -558,14 +569,21 @@ func TestDoStartCgroupInitHappyPath(t *testing.T) {
 		},
 	}
 
-	go agent.doStart(eventstream.NewEventStream("events", ctx),
-		credentialsManager, state, imageManager, client)
+	var agentW sync.WaitGroup
+	agentW.Add(1)
+	go func() {
+		agent.doStart(eventstream.NewEventStream("events", ctx),
+			credentialsManager, state, imageManager, client)
+		agentW.Done()
+	}()
 
 	// Wait for both DiscoverPollEndpointInput and DiscoverTelemetryEndpoint to be
 	// invoked. These are used as proxies to indicate that acs and tcs handlers'
 	// NewSession call has been invoked
 
 	discoverEndpointsInvoked.Wait()
+	cancel()
+	agentW.Wait()
 }
 
 func TestDoStartCgroupInitErrorPath(t *testing.T) {
@@ -672,7 +690,6 @@ func TestDoStartGPUManagerHappyPath(t *testing.T) {
 	cfg.GPUSupportEnabled = true
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines
-	defer cancel()
 	agent := &ecsAgent{
 		ctx:                ctx,
 		cfg:                &cfg,
@@ -685,14 +702,21 @@ func TestDoStartGPUManagerHappyPath(t *testing.T) {
 		},
 	}
 
-	go agent.doStart(eventstream.NewEventStream("events", ctx),
-		credentialsManager, state, imageManager, client)
+	var agentW sync.WaitGroup
+	agentW.Add(1)
+	go func() {
+		agent.doStart(eventstream.NewEventStream("events", ctx),
+			credentialsManager, state, imageManager, client)
+		agentW.Done()
+	}()
 
 	// Wait for both DiscoverPollEndpointInput and DiscoverTelemetryEndpoint to be
 	// invoked. These are used as proxies to indicate that acs and tcs handlers'
 	// NewSession call has been invoked
 
 	discoverEndpointsInvoked.Wait()
+	cancel()
+	agentW.Wait()
 }
 
 func TestDoStartGPUManagerInitError(t *testing.T) {


### PR DESCRIPTION
go's test framework can panic if there are logs within a test-case after
the test already exits. This makes sure that the agent exits before the
test exits so that we don't get a false test failure.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
