### PR TITLE
Increase unit-test ENI attachment timeout to 1000ms

### DIFF
--- a/agent/acs/handler/attach_task_eni_handler_test.go
+++ b/agent/acs/handler/attach_task_eni_handler_test.go
@@ -35,7 +35,7 @@ import (
 const (
 	eniMessageId      = "123"
 	randomMAC         = "00:0a:95:9d:68:16"
-	waitTimeoutMillis = 100
+	waitTimeoutMillis = 1000
 )
 
 // TestAttachENIMessageWithNoMessageId checks the validator against an


### PR DESCRIPTION
This is occasionally causing test failures, especially on windows

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
