### PR TITLE
v4 metadata: add network interface properties

### DIFF
--- a/agent/handlers/v4/response.go
+++ b/agent/handlers/v4/response.go
@@ -1,0 +1,187 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package v4
+
+import (
+	"net"
+
+	"github.com/aws/amazon-ecs-agent/agent/api"
+	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
+	"github.com/aws/amazon-ecs-agent/agent/containermetadata"
+	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
+	"github.com/aws/amazon-ecs-agent/agent/handlers/utils"
+	v2 "github.com/aws/amazon-ecs-agent/agent/handlers/v2"
+	"github.com/pkg/errors"
+)
+
+// TaskResponse is the v4 Task response. It augments the v4 Container response
+// with the v2 task response object.
+type TaskResponse struct {
+	*v2.TaskResponse
+	Containers []ContainerResponse `json:"Containers,omitempty"`
+}
+
+// ContainerResponse is the v4 Container response. It augments the v4 Network response
+// with the v2 container response object.
+type ContainerResponse struct {
+	*v2.ContainerResponse
+	Networks []Network `json:"Networks,omitempty"`
+}
+
+// Network is the v4 Network response. It adds a bunch of information about network
+// interface(s) on top of what is supported by v4.
+// See `NetworkInterfaceProperties` for more details.
+type Network struct {
+	containermetadata.Network
+	// NetworkInterfaceProperties specifies additional properties of the network
+	// of the network interface that are exposed via the metadata server.
+	// We currently populate this only for the `awsvpc` networking mode.
+	NetworkInterfaceProperties
+}
+
+// NetworkInterfaceProperties represents additional properties we may want to expose via
+// task metadata about the network interface that's attached to the container/task. We
+// mostly use this to populate data about ENIs for tasks launched with `awsvpc` mode.
+type NetworkInterfaceProperties struct {
+	// AttachmentIndex reflects the `index` specified by the customer (if any)
+	// while creating the task with `awsvpc` mode.
+	AttachmentIndex int `json:"AttachmentIndex"`
+	// IPV4SubnetCIDRBlock is the subnet CIDR netmask associated with network interface.
+	IPV4SubnetCIDRBlock string `json:"IPv4SubnetCIDRBlock,ommitempty"`
+	// MACAddress is the mac address of the network interface.
+	MACAddress string `json:"MACAddress,ommitempty"`
+	// DomainNameServers specifies the nameserver IP addresses for the network interface.
+	DomainNameServers []string `json:"DomainNameServers,omitempty"`
+	// DomainNameSearchList specifies the search list for the domain name lookup for
+	// the network interface.
+	DomainNameSearchList []string `json:"DomainNameSearchList,omitempty"`
+	// PrivateDNSName is the dns name assigned to this network interface.
+	PrivateDNSName string `json:"PrivateDNSName,omitempty"`
+	// SubnetGatewayIPV4Address is the gateway address for the network interface.
+	SubnetGatewayIPV4Address string `json:"SubnetGatewayIpv4Address,ommitempty"`
+}
+
+// NewTaskResponse creates a new v4 response object for the task. It augments v2 task response
+// with additional network interface fields.
+func NewTaskResponse(
+	taskARN string,
+	state dockerstate.TaskEngineState,
+	ecsClient api.ECSClient,
+	cluster string,
+	az string,
+	containerInstanceARN string,
+	propagateTags bool,
+) (*TaskResponse, error) {
+	// Construct the v2 response first.
+	v2Resp, err := v2.NewTaskResponse(taskARN, state, ecsClient, cluster, az,
+		containerInstanceARN, propagateTags)
+	if err != nil {
+		return nil, err
+	}
+	var containers []ContainerResponse
+	// Convert each container response into v4 container response.
+	for _, container := range v2Resp.Containers {
+		networks, err := toV4NetworkResponse(container.Networks, func() (*apitask.Task, bool) {
+			return state.TaskByArn(taskARN)
+		})
+		if err != nil {
+			return nil, err
+		}
+		containers = append(containers, ContainerResponse{
+			ContainerResponse: &container,
+			Networks:          networks,
+		})
+	}
+
+	return &TaskResponse{
+		TaskResponse: v2Resp,
+		Containers:   containers,
+	}, nil
+}
+
+// NewContainerResponse creates a new v4 container response based on container id.  It augments
+// v4 container response with additional network interface fields.
+func NewContainerResponse(
+	containerID string,
+	state dockerstate.TaskEngineState,
+) (*ContainerResponse, error) {
+	// Construct the v2 response first.
+	container, err := v2.NewContainerResponse(containerID, state)
+	if err != nil {
+		return nil, err
+	}
+	// Convert v2 network responses into v4 network responses.
+	networks, err := toV4NetworkResponse(container.Networks, func() (*apitask.Task, bool) {
+		return state.TaskByID(containerID)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &ContainerResponse{
+		ContainerResponse: container,
+		Networks:          networks,
+	}, nil
+}
+
+// toV4NetworkResponse converts v2 network response to v4. Additional fields are only
+// added if the networking mode is 'awsvpc'. The `lookup` function pointer is used to
+// look up the task information in the local state based on the id, which could be
+// either task arn or contianer id.
+func toV4NetworkResponse(
+	networks []containermetadata.Network,
+	lookup func() (*apitask.Task, bool),
+) ([]Network, error) {
+	var resp []Network
+	for _, network := range networks {
+		respNetwork := Network{Network: network}
+		if network.NetworkMode == utils.NetworkModeAWSVPC {
+			task, ok := lookup()
+			if !ok {
+				return nil, errors.New("v4 task response: unable to find task")
+			}
+			props, err := newNetworkInterfaceProperties(task)
+			if err != nil {
+				return nil, err
+			}
+			respNetwork.NetworkInterfaceProperties = props
+		}
+		resp = append(resp, respNetwork)
+	}
+
+	return resp, nil
+}
+
+// newNetworkInterfaceProperties creates the NetworkInterfaceProperties object for a given
+// task.
+func newNetworkInterfaceProperties(task *apitask.Task) (NetworkInterfaceProperties, error) {
+	eni := task.GetPrimaryENI()
+	_, ipv4Net, err := net.ParseCIDR(eni.SubnetGatewayIPV4Address)
+	if err != nil {
+		return NetworkInterfaceProperties{}, errors.Wrapf(err,
+			"v4 metadata response: unable to parse subnet ipv4 address '%s'",
+			eni.SubnetGatewayIPV4Address)
+	}
+	return NetworkInterfaceProperties{
+		// TODO this is hard-coded to `0` for now. Once backend starts populating
+		// `Index` field for an ENI, we should set it as per that. Since we
+		// only support 1 ENI per task anyway, setting it to `0` is acceptable.
+		AttachmentIndex:          0,
+		IPV4SubnetCIDRBlock:      ipv4Net.String(),
+		MACAddress:               eni.MacAddress,
+		DomainNameServers:        eni.DomainNameServers,
+		DomainNameSearchList:     eni.DomainNameSearchList,
+		PrivateDNSName:           eni.PrivateDNSName,
+		SubnetGatewayIPV4Address: eni.SubnetGatewayIPV4Address,
+	}, nil
+}

--- a/agent/handlers/v4/response.go
+++ b/agent/handlers/v4/response.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/agent/handlers/v4/response_test.go
+++ b/agent/handlers/v4/response_test.go
@@ -1,0 +1,147 @@
+// +build unit
+
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package v4
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
+	apieni "github.com/aws/amazon-ecs-agent/agent/api/eni"
+	mock_api "github.com/aws/amazon-ecs-agent/agent/api/mocks"
+	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
+	apitaskstatus "github.com/aws/amazon-ecs-agent/agent/api/task/status"
+	mock_dockerstate "github.com/aws/amazon-ecs-agent/agent/engine/dockerstate/mocks"
+	"github.com/docker/docker/api/types"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	taskARN                  = "t1"
+	cluster                  = "default"
+	family                   = "sleep"
+	version                  = "1"
+	containerID              = "cid"
+	containerName            = "sleepy"
+	imageName                = "busybox"
+	imageID                  = "bUsYbOx"
+	cpu                      = 1024
+	memory                   = 512
+	eniIPv4Address           = "192.168.0.5"
+	subnetGatewayIPV4Address = "192.168.0.1/24"
+	volName                  = "volume1"
+	volSource                = "/var/lib/volume1"
+	volDestination           = "/volume"
+	availabilityZone         = "us-west-2b"
+	containerInstanceArn     = "containerInstance-test"
+)
+
+func TestNewTaskContainerResponses(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	state := mock_dockerstate.NewMockTaskEngineState(ctrl)
+	ecsClient := mock_api.NewMockECSClient(ctrl)
+	now := time.Now()
+	task := &apitask.Task{
+		Arn:                 taskARN,
+		Family:              family,
+		Version:             version,
+		DesiredStatusUnsafe: apitaskstatus.TaskRunning,
+		KnownStatusUnsafe:   apitaskstatus.TaskRunning,
+		ENIs: []*apieni.ENI{
+			{
+				IPV4Addresses: []*apieni.ENIIPV4Address{
+					{
+						Address: eniIPv4Address,
+					},
+				},
+				SubnetGatewayIPV4Address: subnetGatewayIPV4Address,
+			},
+		},
+		CPU:                      cpu,
+		Memory:                   memory,
+		PullStartedAtUnsafe:      now,
+		PullStoppedAtUnsafe:      now,
+		ExecutionStoppedAtUnsafe: now,
+	}
+	container := &apicontainer.Container{
+		Name:                containerName,
+		Image:               imageName,
+		ImageID:             imageID,
+		DesiredStatusUnsafe: apicontainerstatus.ContainerRunning,
+		KnownStatusUnsafe:   apicontainerstatus.ContainerRunning,
+		CPU:                 cpu,
+		Memory:              memory,
+		Type:                apicontainer.ContainerNormal,
+		Ports: []apicontainer.PortBinding{
+			{
+				ContainerPort: 80,
+				Protocol:      apicontainer.TransportProtocolTCP,
+			},
+		},
+		VolumesUnsafe: []types.MountPoint{
+			{
+				Name:        volName,
+				Source:      volSource,
+				Destination: volDestination,
+			},
+		},
+	}
+	created := time.Now()
+	container.SetCreatedAt(created)
+	labels := map[string]string{
+		"foo": "bar",
+	}
+	container.SetLabels(labels)
+	dockerContainer := &apicontainer.DockerContainer{
+		DockerID:   containerID,
+		DockerName: containerName,
+		Container:  container,
+	}
+	containerNameToDockerContainer := map[string]*apicontainer.DockerContainer{
+		taskARN: dockerContainer,
+	}
+	gomock.InOrder(
+		state.EXPECT().TaskByArn(taskARN).Return(task, true),
+		state.EXPECT().ContainerMapByArn(taskARN).Return(containerNameToDockerContainer, true),
+		state.EXPECT().TaskByArn(taskARN).Return(task, true),
+	)
+
+	taskResponse, err := NewTaskResponse(taskARN, state, ecsClient, cluster, availabilityZone, containerInstanceArn, false)
+	require.NoError(t, err)
+	_, err = json.Marshal(taskResponse)
+	require.NoError(t, err)
+	assert.Equal(t, created.UTC().String(), taskResponse.Containers[0].CreatedAt.String())
+	assert.Equal(t, "192.168.0.0/24", taskResponse.Containers[0].Networks[0].IPV4SubnetCIDRBlock)
+	assert.Equal(t, subnetGatewayIPV4Address, taskResponse.Containers[0].Networks[0].SubnetGatewayIPV4Address)
+
+	gomock.InOrder(
+		state.EXPECT().ContainerByID(containerID).Return(dockerContainer, true),
+		state.EXPECT().TaskByID(containerID).Return(task, true).Times(2),
+	)
+	containerResponse, err := NewContainerResponse(containerID, state)
+	require.NoError(t, err)
+	_, err = json.Marshal(containerResponse)
+	require.NoError(t, err)
+	assert.Equal(t, created.UTC().String(), containerResponse.CreatedAt.String())
+	assert.Equal(t, "192.168.0.0/24", containerResponse.Networks[0].IPV4SubnetCIDRBlock)
+	assert.Equal(t, subnetGatewayIPV4Address, containerResponse.Networks[0].SubnetGatewayIPV4Address)
+}

--- a/agent/handlers/v4/task_container_metadata_handler.go
+++ b/agent/handlers/v4/task_container_metadata_handler.go
@@ -1,0 +1,37 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package v4
+
+import "github.com/aws/amazon-ecs-agent/agent/handlers/utils"
+
+const (
+	// metadataContainerIDMuxName is the key that's used in gorilla/mux to get the container ID
+	// for container metadata.
+	metadataContainerIDMuxName = "metadataContainerIDMuxName"
+
+	// TaskMetadataPath specifies the relative URI path for serving task metadata.
+	TaskMetadataPath = "/v4/metadata"
+
+	// TaskWithTagsMetadataPath specifies the relative URI path for serving task metadata with Container Instance and Task Tags.
+	TaskWithTagsMetadataPath = "/v4/metadataWithTags"
+
+	// TaskMetadataPathWithSlash specifies the relative URI path for serving task metadata.
+	TaskMetadataPathWithSlash = TaskMetadataPath + "/"
+
+	// TaskWithTagsMetadataPathWithSlash specifies the relative URI path for serving task metadata with Container Instance and Task Tags.
+	TaskWithTagsMetadataPathWithSlash = TaskWithTagsMetadataPath + "/"
+)
+
+// ContainerMetadataPath specifies the relative URI path for serving container metadata.
+var ContainerMetadataPath = TaskMetadataPathWithSlash + utils.ConstructMuxVar(metadataContainerIDMuxName, utils.AnythingButEmptyRegEx)


### PR DESCRIPTION
### Summary
<!-- What does this pull request do? -->

This adds the initial outline for the v4 task metadata. 

### Implementation details
Currently, this consists of additional fields for network interfaces such as
mac address, dns information, fqdn and attachment index. This is
useful for customers looking to perform additional network setup
on their own for their ENIs.

This PR doesn't create a v4 metadata endpoint yet, it just creates the initial response data structure. There might be additional fields that could added to the v4 metadata.

### Testing
<!-- How was this tested? -->
`make test docker` succeeded on my laptop. 

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

None

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
