### PR TITLE
Initialize ENI ack timer if needed upon restart

### DIFF
--- a/agent/app/agent_test.go
+++ b/agent/app/agent_test.go
@@ -346,6 +346,7 @@ func TestDoStartRegisterAvailabilityZone(t *testing.T) {
 		imageManager.EXPECT().SetSaver(gomock.Any()),
 		dockerClient.EXPECT().ContainerEvents(gomock.Any()),
 		state.EXPECT().AllImageStates().Return(nil),
+		state.EXPECT().AllENIAttachments().Return(nil),
 		state.EXPECT().AllTasks().Return(nil),
 	)
 

--- a/agent/app/agent_unix_test.go
+++ b/agent/app/agent_unix_test.go
@@ -99,6 +99,7 @@ func TestDoStartHappyPath(t *testing.T) {
 		imageManager.EXPECT().SetSaver(gomock.Any()),
 		dockerClient.EXPECT().ContainerEvents(gomock.Any()).Return(containerChangeEvents, nil),
 		state.EXPECT().AllImageStates().Return(nil),
+		state.EXPECT().AllENIAttachments().Return(nil),
 		state.EXPECT().AllTasks().Return(nil),
 	)
 
@@ -208,6 +209,7 @@ func TestDoStartTaskENIHappyPath(t *testing.T) {
 		imageManager.EXPECT().SetSaver(gomock.Any()),
 		dockerClient.EXPECT().ContainerEvents(gomock.Any()).Return(containerChangeEvents, nil),
 		state.EXPECT().AllImageStates().Return(nil),
+		state.EXPECT().AllENIAttachments().Return(nil),
 		state.EXPECT().AllTasks().Return(nil),
 	)
 
@@ -538,6 +540,7 @@ func TestDoStartCgroupInitHappyPath(t *testing.T) {
 		imageManager.EXPECT().SetSaver(gomock.Any()),
 		dockerClient.EXPECT().ContainerEvents(gomock.Any()).Return(containerChangeEvents, nil),
 		state.EXPECT().AllImageStates().Return(nil),
+		state.EXPECT().AllENIAttachments().Return(nil),
 		state.EXPECT().AllTasks().Return(nil),
 		client.EXPECT().DiscoverPollEndpoint(gomock.Any()).Do(func(x interface{}) {
 			// Ensures that the test waits until acs session has bee started
@@ -670,6 +673,7 @@ func TestDoStartGPUManagerHappyPath(t *testing.T) {
 		imageManager.EXPECT().SetSaver(gomock.Any()),
 		dockerClient.EXPECT().ContainerEvents(gomock.Any()).Return(containerChangeEvents, nil),
 		state.EXPECT().AllImageStates().Return(nil),
+		state.EXPECT().AllENIAttachments().Return(nil),
 		state.EXPECT().AllTasks().Return(nil),
 		client.EXPECT().DiscoverPollEndpoint(gomock.Any()).Do(func(x interface{}) {
 			// Ensures that the test waits until acs session has been started

--- a/agent/engine/dockerstate/docker_task_engine_state.go
+++ b/agent/engine/dockerstate/docker_task_engine_state.go
@@ -33,6 +33,8 @@ var log = logger.ForModule("dockerstate")
 type TaskEngineState interface {
 	// AllTasks returns all of the tasks
 	AllTasks() []*apitask.Task
+	// AllENIAttachments returns all of the eni attachments
+	AllENIAttachments() []*apieni.ENIAttachment
 	// AllImageStates returns all of the image.ImageStates
 	AllImageStates() []*image.ImageState
 	// GetAllContainerIDs returns all of the Container Ids

--- a/agent/engine/dockerstate/mocks/dockerstate_mocks.go
+++ b/agent/engine/dockerstate/mocks/dockerstate_mocks.go
@@ -111,6 +111,20 @@ func (mr *MockTaskEngineStateMockRecorder) AddTaskIPAddress(arg0, arg1 interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddTaskIPAddress", reflect.TypeOf((*MockTaskEngineState)(nil).AddTaskIPAddress), arg0, arg1)
 }
 
+// AllENIAttachments mocks base method
+func (m *MockTaskEngineState) AllENIAttachments() []*eni.ENIAttachment {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AllENIAttachments")
+	ret0, _ := ret[0].([]*eni.ENIAttachment)
+	return ret0
+}
+
+// AllENIAttachments indicates an expected call of AllENIAttachments
+func (mr *MockTaskEngineStateMockRecorder) AllENIAttachments() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllENIAttachments", reflect.TypeOf((*MockTaskEngineState)(nil).AllENIAttachments))
+}
+
 // AllImageStates mocks base method
 func (m *MockTaskEngineState) AllImageStates() []*image.ImageState {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Fix https://github.com/aws/amazon-ecs-agent/issues/2193. Previously, the ack timer of each ENI attachment is not initialized upon agent restarts. If agent is stopped and started after an ENI attachment is added to state but before it's acked, we will end up with one of these: (1) If the attachment has not expired, the agent will ack the attachment status, and will crash on NPE while attempting to stop the ack timer after the ack (which is likely what happened in https://github.com/aws/amazon-ecs-agent/issues/2193#issue-490536198); (2) If the attachment has expired, the ENI attachment is left in agent state (since the task will not start in that case, we won't be removing it during task cleanup). This commit fixes the two situations by attempting to initialize the ack timer upon restart, so that - (1) if the attachment has not expired, the ack timer will be initialized so that we won't get NPE when acking it; (2) if the attachment has expired, it gets removed from agent state.

### Implementation details
<!-- How are the changes implemented? -->
This is implemented in a similar way as how we deal with uninitialized fields for task resource. Add an Initialize method on ENI attachment which initializes the ack timer, and call it in engine.synchronizeState which is called upon agent restarts.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes

Added unit tests. Manually tested the following situations:

* Situation 1: Stop agent after ENI attachment is added to state, but before it's acked; restart agent before ENI attachment has expired.
Before fix: agent panics on nil pointer reference when attempting to ack ENI attached status; After fix: agent successfully acks ENI attached status.

* Situation 2: Stop agent after ENI attachment is added to state, but before it's acked; restart agent after ENI attachment has expired.
Before fix: ENI ack timer is not started, but ENI attachment is left in agent state; After fix: ENI ack timer is not started, and ENI attachment is removed from state after agent starts.

* Situation 3: Stop agent after ENI attachment is added to state and acked; restart agent.
Before fix: ENI ack timer is not started, and ENI attachment is removed during task cleanup; After fix: we already had expected behavior in this case, verified that this is maintained.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
