### PR TITLE
Fixing task def for port contention test, to use correct field

### DIFF
--- a/agent/functional_tests/testdata/taskdefinitions/busybox-port-5180/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/busybox-port-5180/task-definition.json
@@ -3,7 +3,7 @@
   "containerDefinitions": [{
     "image": "127.0.0.1:51670/busybox:latest",
     "name": "sleep",
-    "portBindings": [{
+    "portMappings": [{
       "containerPort": 80,
       "hostPort": 5180
     }],

--- a/agent/functional_tests/testdata/taskdefinitions/port-80-windows/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/port-80-windows/task-definition.json
@@ -3,7 +3,7 @@
   "containerDefinitions": [{
     "image": "amazon/amazon-ecs-listen80",
     "name": "sleep",
-    "portBindings": [{
+    "portMappings": [{
       "containerPort": 80,
       "hostPort": 5180
     }],


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
"portBindings" isn't a supported field in task definition. Existing task defs just drops the port settings and hence is not testing the correct scenario. 

### Implementation details
fix test task definition to use the correct field.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: no, existing test should still pass.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
