### PR TITLE
Replace squid proxy functional test with unit test

### DIFF
--- a/agent/httpclient/httpclient_test.go
+++ b/agent/httpclient/httpclient_test.go
@@ -17,6 +17,8 @@ package httpclient
 
 import (
 	"net/http"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -29,4 +31,18 @@ func TestNewHttpClient(t *testing.T) {
 	transport := expectedResult.Transport.(*ecsRoundTripper)
 	assert.Equal(t, cipher.SupportedCipherSuites, transport.transport.(*http.Transport).TLSClientConfig.CipherSuites)
 	assert.Equal(t, true, transport.transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify)
+}
+
+func TestNewHttpClientProxy(t *testing.T) {
+	proxy_url := "127.0.0.1:1234"
+	// Set Proxy
+	os.Setenv("HTTP_PROXY", proxy_url)
+	defer os.Unsetenv("HTTP_PROXY")
+
+	client := New(time.Duration(10*time.Second), true)
+	_, err := client.Get("http://www.amazon.com")
+	// Client won't be able to connect because we have given a arbitrary proxy
+	assert.Error(t, err)
+	// Error message should contain the proxy url which shows that client tried to use the proxy url to connect
+	assert.True(t, strings.Contains(err.Error(), proxy_url), "proxy url not found in: %s", err.Error())
 }

--- a/agent/wsclient/client_test.go
+++ b/agent/wsclient/client_test.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -47,6 +48,17 @@ const dockerEndpoint = "/var/run/docker.sock"
 // TestSetReadDeadline* tests
 func (cs *ClientServerImpl) Close() error {
 	return cs.Disconnect()
+}
+
+func TestClientProxy(t *testing.T) {
+	proxy_url := "127.0.0.1:1234"
+	os.Setenv("HTTP_PROXY", proxy_url)
+	defer os.Unsetenv("HTTP_PROXY")
+
+	cs := getClientServer("http://www.amazon.com")
+	err := cs.Connect()
+	assert.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), proxy_url), "proxy not found: %s", err.Error())
 }
 
 // TestConcurrentWritesDontPanic will force a panic in the websocket library if


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
~~Replace `TestSquidProxy` functional test with~~ Add Unit tests to test that agent is using the proxies when flags(_HTTP_PROXY_, _HTTPS_PROXY_) are set. 


~~#### Why is unit tests sufficient to test what a functional test was doing?~~

~~`TestSquidProxy` functional test does the following~~
~~1. Start a squid proxy container.~~
~~2. Start agent container with _HTTP_PROXY_ set so that all the requests made by agent goes through the proxy.~~
~~3. Scrape the logs in squid proxy container to verify that the requests in agent container actually went through the proxy.~~

~~By replacing the functional test with unit tests, we are testing part -2, that is,  Agent is able to pick up the proxy address that is set via _HTTP_PROXY_ flag and makes request using the proxy address. We are skipping the part -1 and part - 3 which is not required to ensure that agent is able to use HTTP proxy for making requests.~~
### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
