### PR TITLE
eni watcher: change unmanaged eni error log level to debug

### DIFF
--- a/agent/eni/watcher/watcher_linux.go
+++ b/agent/eni/watcher/watcher_linux.go
@@ -192,9 +192,11 @@ func (udevWatcher *UdevWatcher) reconcileOnce() error {
 			// skip logging status sent error as it's redundant and doesn't really indicate a problem
 			if strings.Contains(err.Error(), eniStatusSentMsg) {
 				continue
+			} else if _, ok := err.(*unmanagedENIError); ok {
+				log.Debugf("Udev watcher reconciliation: unable to send state change: %v", err)
+			} else {
+				log.Warnf("Udev watcher reconciliation: unable to send state change: %v", err)
 			}
-
-			log.Warnf("Udev watcher reconciliation: unable to send state change: %v", err)
 		}
 	}
 	return nil


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
eni watcher: change unmanaged eni error log level to debug. This log is only useful for debug purpose under an edge case, and if customers attached their own ENI to the instance, this log will appear every 30 seconds like what's observed in https://github.com/aws/amazon-ecs-agent/issues/1683, so logging it as warning is confusing. Changing it to debug log.

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

tested attaching a static eni and the log is on debug level.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
