### PR TITLE
Added EFSVolumeConfiguration

### DIFF
--- a/agent/acs/model/api/api-2.json
+++ b/agent/acs/model/api/api-2.json
@@ -304,8 +304,7 @@
       "type":"structure",
       "members":{
         "filesystem":{"shape":"String"},
-        "rootDirectory":{"shape":"String"},
-        "readonly":{"shape":"Boolean"}
+        "rootDirectory":{"shape":"String"}
       }
     },
     "ElasticNetworkInterface":{

--- a/agent/acs/model/api/api-2.json
+++ b/agent/acs/model/api/api-2.json
@@ -303,7 +303,7 @@
     "EFSVolumeConfiguration": {
       "type":"structure",
       "members":{
-        "filesystem":{"shape":"String"},
+        "filesystemId":{"shape":"String"},
         "rootDirectory":{"shape":"String"}
       }
     },
@@ -699,7 +699,8 @@
       "type":"string",
       "enum":[
         "host",
-        "docker"
+        "docker",
+        "efs"
       ]
     }
   }

--- a/agent/acs/model/api/api-2.json
+++ b/agent/acs/model/api/api-2.json
@@ -303,7 +303,7 @@
     "EFSVolumeConfiguration": {
       "type":"structure",
       "members":{
-        "filesystemId":{"shape":"String"},
+        "fileSystemId":{"shape":"String"},
         "rootDirectory":{"shape":"String"}
       }
     },

--- a/agent/acs/model/api/api-2.json
+++ b/agent/acs/model/api/api-2.json
@@ -300,6 +300,14 @@
       }
     },
 
+    "EFSVolumeConfiguration": {
+      "type":"structure",
+      "members":{
+        "filesystem":{"shape":"String"},
+        "rootDirectory":{"shape":"String"},
+        "readonly":{"shape":"Boolean"}
+      }
+    },
     "ElasticNetworkInterface":{
       "type":"structure",
       "members":{
@@ -669,7 +677,8 @@
         "name":{"shape":"String"},
         "type":{"shape":"VolumeType"},
         "host":{"shape":"HostVolumeProperties"},
-        "dockerVolumeConfiguration":{"shape":"DockerVolumeConfiguration"}
+        "dockerVolumeConfiguration":{"shape":"DockerVolumeConfiguration"},
+        "EFSVolumeConfiguration":{"shape":"EFSVolumeConfiguration"}
       }
     },
     "VolumeFrom":{

--- a/agent/acs/model/ecsacs/api.go
+++ b/agent/acs/model/ecsacs/api.go
@@ -413,6 +413,26 @@ func (s ECRAuthData) GoString() string {
 	return s.String()
 }
 
+type EFSVolumeConfiguration struct {
+	_ struct{} `type:"structure"`
+
+	Filesystem *string `locationName:"filesystem" type:"string"`
+
+	Readonly *bool `locationName:"readonly" type:"boolean"`
+
+	RootDirectory *string `locationName:"rootDirectory" type:"string"`
+}
+
+// String returns the string representation
+func (s EFSVolumeConfiguration) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s EFSVolumeConfiguration) GoString() string {
+	return s.String()
+}
+
 type ElasticNetworkInterface struct {
 	_ struct{} `type:"structure"`
 
@@ -1339,6 +1359,8 @@ type Volume struct {
 	_ struct{} `type:"structure"`
 
 	DockerVolumeConfiguration *DockerVolumeConfiguration `locationName:"dockerVolumeConfiguration" type:"structure"`
+
+	EFSVolumeConfiguration *EFSVolumeConfiguration `type:"structure"`
 
 	Host *HostVolumeProperties `locationName:"host" type:"structure"`
 

--- a/agent/acs/model/ecsacs/api.go
+++ b/agent/acs/model/ecsacs/api.go
@@ -416,7 +416,7 @@ func (s ECRAuthData) GoString() string {
 type EFSVolumeConfiguration struct {
 	_ struct{} `type:"structure"`
 
-	Filesystem *string `locationName:"filesystem" type:"string"`
+	FilesystemId *string `locationName:"filesystemId" type:"string"`
 
 	RootDirectory *string `locationName:"rootDirectory" type:"string"`
 }

--- a/agent/acs/model/ecsacs/api.go
+++ b/agent/acs/model/ecsacs/api.go
@@ -418,8 +418,6 @@ type EFSVolumeConfiguration struct {
 
 	Filesystem *string `locationName:"filesystem" type:"string"`
 
-	Readonly *bool `locationName:"readonly" type:"boolean"`
-
 	RootDirectory *string `locationName:"rootDirectory" type:"string"`
 }
 

--- a/agent/acs/model/ecsacs/api.go
+++ b/agent/acs/model/ecsacs/api.go
@@ -416,7 +416,7 @@ func (s ECRAuthData) GoString() string {
 type EFSVolumeConfiguration struct {
 	_ struct{} `type:"structure"`
 
-	FilesystemId *string `locationName:"filesystemId" type:"string"`
+	FileSystemId *string `locationName:"fileSystemId" type:"string"`
 
 	RootDirectory *string `locationName:"rootDirectory" type:"string"`
 }

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -334,6 +334,10 @@ func (task *Task) PostUnmarshalTask(cfg *config.Config,
 	if err != nil {
 		return apierrors.NewResourceInitError(task.Arn, err)
 	}
+	err = task.initializeEFSVolumes(cfg, dockerClient, ctx)
+	if err != nil {
+		return apierrors.NewResourceInitError(task.Arn, err)
+	}
 	if cfg.GPUSupportEnabled {
 		err = task.addGPUResource()
 		if err != nil {
@@ -497,6 +501,65 @@ func (task *Task) initializeDockerVolumes(sharedVolumeMatchFullConfig bool, dock
 			}
 		}
 	}
+	return nil
+}
+
+// initializeEFSVolumes inspects the volume definitions in the task definition.
+// If it finds EFS volumes in the task definition, then it converts it to a docker
+// volume definition.
+func (task *Task) initializeEFSVolumes(cfg *config.Config, dockerClient dockerapi.DockerClient, ctx context.Context) error {
+	for i, vol := range task.Volumes {
+		// No need to do this for non-efs volume, eg: host bind/empty volume
+		if vol.Type != EFSVolumeType {
+			continue
+		}
+
+		efsvol, ok := vol.Volume.(*taskresourcevolume.EFSVolumeConfig)
+		if !ok {
+			return errors.New("task volume: volume configuration does not match the type 'efs'")
+		}
+
+		err := task.addEFSVolumes(ctx, cfg, dockerClient, &task.Volumes[i], efsvol)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// addEFSVolumes converts the EFS task definition into an internal docker 'local' volume
+// mounted with NFS struct and updates container dependency
+func (task *Task) addEFSVolumes(
+	ctx context.Context,
+	cfg *config.Config,
+	dockerClient dockerapi.DockerClient,
+	vol *TaskVolume,
+	efsvol *taskresourcevolume.EFSVolumeConfig,
+) error {
+	ostr := fmt.Sprintf("addr=%s.efs.%s.amazonaws.com,nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport,ro", efsvol.Filesystem, cfg.AWSRegion)
+	devstr := fmt.Sprintf(":%s", efsvol.RootDirectory)
+	volumeResource, err := taskresourcevolume.NewVolumeResource(
+		ctx,
+		vol.Name,
+		task.volumeName(vol.Name),
+		"task",
+		false,
+		"local",
+		map[string]string{
+			"type":   "nfs",
+			"device": devstr,
+			"o":      ostr,
+		},
+		map[string]string{},
+		dockerClient,
+	)
+	if err != nil {
+		return err
+	}
+
+	vol.Volume = &volumeResource.VolumeConfig
+	task.AddResource(resourcetype.DockerVolumeKey, volumeResource)
+	task.updateContainerVolumeDependency(vol.Name)
 	return nil
 }
 

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -544,7 +544,8 @@ func (task *Task) addEFSVolumes(
 	vol *TaskVolume,
 	efsvol *taskresourcevolume.EFSVolumeConfig,
 ) error {
-	ostr := fmt.Sprintf("addr=%s.efs.%s.amazonaws.com,nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport,ro", efsvol.Filesystem, cfg.AWSRegion)
+	// TODO CN and gov partition logic
+	ostr := fmt.Sprintf("addr=%s.efs.%s.amazonaws.com,nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport", efsvol.Filesystem, cfg.AWSRegion)
 	devstr := fmt.Sprintf(":%s", efsvol.RootDirectory)
 	volumeResource, err := taskresourcevolume.NewVolumeResource(
 		ctx,

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -545,6 +545,8 @@ func (task *Task) addEFSVolumes(
 	efsvol *taskresourcevolume.EFSVolumeConfig,
 ) error {
 	// TODO CN and gov partition logic
+	// These are the NFS options recommended by EFS, see:
+	// https://docs.aws.amazon.com/efs/latest/ug/mounting-fs-mount-cmd-general.html
 	ostr := fmt.Sprintf("addr=%s.efs.%s.amazonaws.com,nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport", efsvol.Filesystem, cfg.AWSRegion)
 	devstr := fmt.Sprintf(":%s", efsvol.RootDirectory)
 	volumeResource, err := taskresourcevolume.NewVolumeResource(

--- a/agent/api/task/taskvolume.go
+++ b/agent/api/task/taskvolume.go
@@ -24,6 +24,7 @@ import (
 const (
 	HostVolumeType   = "host"
 	DockerVolumeType = "docker"
+	EFSVolumeType    = "efs"
 )
 
 // TaskVolume is a definition of all the volumes available for containers to
@@ -64,8 +65,10 @@ func (tv *TaskVolume) UnmarshalJSON(b []byte) error {
 		return tv.unmarshalHostVolume(intermediate["host"])
 	case DockerVolumeType:
 		return tv.unmarshalDockerVolume(intermediate["dockerVolumeConfiguration"])
+	case EFSVolumeType:
+		return tv.unmarshalEFSVolume(intermediate["EFSVolumeConfiguration"])
 	default:
-		return errors.Errorf("invalid Volume: type must be docker or host, got %q", tv.Type)
+		return errors.Errorf("unrecognized volume type: %q", tv.Type)
 	}
 }
 
@@ -85,6 +88,8 @@ func (tv *TaskVolume) MarshalJSON() ([]byte, error) {
 		result["dockerVolumeConfiguration"] = tv.Volume
 	case HostVolumeType:
 		result["host"] = tv.Volume
+	case EFSVolumeType:
+		result["EFSVolumeConfiguration"] = tv.Volume
 	default:
 		return nil, errors.Errorf("unrecognized volume type: %q", tv.Type)
 	}
@@ -103,6 +108,20 @@ func (tv *TaskVolume) unmarshalDockerVolume(data json.RawMessage) error {
 	}
 
 	tv.Volume = &dockerVolumeConfig
+	return nil
+}
+
+func (tv *TaskVolume) unmarshalEFSVolume(data json.RawMessage) error {
+	if data == nil {
+		return errors.New("invalid volume: empty volume configuration")
+	}
+	var efsVolumeConfig taskresourcevolume.EFSVolumeConfig
+	err := json.Unmarshal(data, &efsVolumeConfig)
+	if err != nil {
+		return err
+	}
+
+	tv.Volume = &efsVolumeConfig
 	return nil
 }
 

--- a/agent/api/task/taskvolume_test.go
+++ b/agent/api/task/taskvolume_test.go
@@ -68,7 +68,7 @@ func TestMarshalUnmarshalTaskVolumes(t *testing.T) {
 			{Name: "1", Type: HostVolumeType, Volume: &taskresourcevolume.LocalDockerVolume{}},
 			{Name: "2", Type: HostVolumeType, Volume: &taskresourcevolume.FSHostVolume{FSSourcePath: "/path"}},
 			{Name: "3", Type: DockerVolumeType, Volume: &taskresourcevolume.DockerVolumeConfig{Scope: "task", Driver: "local"}},
-			{Name: "4", Type: EFSVolumeType, Volume: &taskresourcevolume.EFSVolumeConfig{Filesystem: "fs-12345", RootDirectory: "/tmp", ReadOnly: true}},
+			{Name: "4", Type: EFSVolumeType, Volume: &taskresourcevolume.EFSVolumeConfig{Filesystem: "fs-12345", RootDirectory: "/tmp"}},
 		},
 	}
 
@@ -206,7 +206,6 @@ func TestInitializeEFSVolume(t *testing.T) {
 				Type: "efs",
 				Volume: &taskresourcevolume.EFSVolumeConfig{
 					Filesystem:    "fs-12345",
-					ReadOnly:      true,
 					RootDirectory: "/my/root/dir",
 				},
 			},
@@ -286,7 +285,6 @@ func TestInitializeEFSVolume_WrongVolumeType(t *testing.T) {
 				Type: "docker",
 				Volume: &taskresourcevolume.EFSVolumeConfig{
 					Filesystem:    "fs-12345",
-					ReadOnly:      true,
 					RootDirectory: "/my/root/dir",
 				},
 			},

--- a/agent/api/task/taskvolume_test.go
+++ b/agent/api/task/taskvolume_test.go
@@ -223,7 +223,7 @@ func TestInitializeEFSVolume(t *testing.T) {
 
 	dockervol, ok := testTask.Volumes[0].Volume.(*taskresourcevolume.DockerVolumeConfig)
 	assert.True(t, ok)
-	assert.Equal(t, "addr=fs-12345.efs.us-west-1.amazonaws.com,nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport,ro", dockervol.DriverOpts["o"])
+	assert.Equal(t, "addr=fs-12345.efs.us-west-1.amazonaws.com,nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport", dockervol.DriverOpts["o"])
 	assert.Equal(t, ":/my/root/dir", dockervol.DriverOpts["device"])
 }
 

--- a/agent/api/task/taskvolume_test.go
+++ b/agent/api/task/taskvolume_test.go
@@ -21,6 +21,7 @@ import (
 
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
+	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	mock_dockerapi "github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
@@ -67,6 +68,7 @@ func TestMarshalUnmarshalTaskVolumes(t *testing.T) {
 			{Name: "1", Type: HostVolumeType, Volume: &taskresourcevolume.LocalDockerVolume{}},
 			{Name: "2", Type: HostVolumeType, Volume: &taskresourcevolume.FSHostVolume{FSSourcePath: "/path"}},
 			{Name: "3", Type: DockerVolumeType, Volume: &taskresourcevolume.DockerVolumeConfig{Scope: "task", Driver: "local"}},
+			{Name: "4", Type: EFSVolumeType, Volume: &taskresourcevolume.EFSVolumeConfig{Filesystem: "fs-12345", RootDirectory: "/tmp", ReadOnly: true}},
 		},
 	}
 
@@ -76,9 +78,9 @@ func TestMarshalUnmarshalTaskVolumes(t *testing.T) {
 	var out Task
 	err = json.Unmarshal(marshal, &out)
 	require.NoError(t, err, "Could not unmarshal task")
-	require.Len(t, out.Volumes, 3, "Incorrect number of volumes")
+	require.Len(t, out.Volumes, 4, "Incorrect number of volumes")
 
-	var v1, v2, v3 TaskVolume
+	var v1, v2, v3, v4 TaskVolume
 
 	for _, v := range out.Volumes {
 		switch v.Name {
@@ -88,6 +90,8 @@ func TestMarshalUnmarshalTaskVolumes(t *testing.T) {
 			v2 = v
 		case "3":
 			v3 = v
+		case "4":
+			v4 = v
 		}
 	}
 
@@ -102,6 +106,11 @@ func TestMarshalUnmarshalTaskVolumes(t *testing.T) {
 	assert.True(t, ok, "incorrect DockerVolumeConfig type")
 	assert.Equal(t, "task", dockerVolume.Scope)
 	assert.Equal(t, "local", dockerVolume.Driver)
+
+	efsVolume, ok := v4.Volume.(*taskresourcevolume.EFSVolumeConfig)
+	assert.True(t, ok, "incorrect EFSVolumeConfig type")
+	assert.Equal(t, "fs-12345", efsVolume.Filesystem)
+	assert.Equal(t, "/tmp", efsVolume.RootDirectory)
 }
 
 func TestInitializeLocalDockerVolume(t *testing.T) {
@@ -171,6 +180,127 @@ func TestInitializeSharedProvisionedVolume(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, testTask.ResourcesMapUnsafe, 0, "no volume resource should be provisioned by agent")
 	assert.Len(t, testTask.Containers[0].TransitionDependenciesMap, 0, "resource already exists")
+}
+
+func TestInitializeEFSVolume(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	dockerClient := mock_dockerapi.NewMockDockerClient(ctrl)
+
+	testTask := &Task{
+		ResourcesMapUnsafe: make(map[string][]taskresource.TaskResource),
+		Containers: []*apicontainer.Container{
+			{
+				MountPoints: []apicontainer.MountPoint{
+					{
+						SourceVolume:  "efs-volume-test",
+						ContainerPath: "/ecs",
+					},
+				},
+				TransitionDependenciesMap: make(map[apicontainerstatus.ContainerStatus]apicontainer.TransitionDependencySet),
+			},
+		},
+		Volumes: []TaskVolume{
+			{
+				Name: "efs-volume-test",
+				Type: "efs",
+				Volume: &taskresourcevolume.EFSVolumeConfig{
+					Filesystem:    "fs-12345",
+					ReadOnly:      true,
+					RootDirectory: "/my/root/dir",
+				},
+			},
+		},
+	}
+
+	cfg := &config.Config{
+		AWSRegion: "us-west-1",
+	}
+	err := testTask.initializeEFSVolumes(cfg, dockerClient, nil)
+
+	assert.NoError(t, err)
+	assert.Len(t, testTask.Volumes, 1)
+
+	dockervol, ok := testTask.Volumes[0].Volume.(*taskresourcevolume.DockerVolumeConfig)
+	assert.True(t, ok)
+	assert.Equal(t, "addr=fs-12345.efs.us-west-1.amazonaws.com,nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport,ro", dockervol.DriverOpts["o"])
+	assert.Equal(t, ":/my/root/dir", dockervol.DriverOpts["device"])
+}
+
+func TestInitializeEFSVolume_WrongVolumeConfig(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	dockerClient := mock_dockerapi.NewMockDockerClient(ctrl)
+
+	testTask := &Task{
+		ResourcesMapUnsafe: make(map[string][]taskresource.TaskResource),
+		Containers: []*apicontainer.Container{
+			{
+				MountPoints: []apicontainer.MountPoint{
+					{
+						SourceVolume:  "efs-volume-test",
+						ContainerPath: "/ecs",
+					},
+				},
+				TransitionDependenciesMap: make(map[apicontainerstatus.ContainerStatus]apicontainer.TransitionDependencySet),
+			},
+		},
+		Volumes: []TaskVolume{
+			{
+				Name:   "efs-volume-test",
+				Type:   "efs",
+				Volume: &taskresourcevolume.DockerVolumeConfig{},
+			},
+		},
+	}
+
+	cfg := &config.Config{
+		AWSRegion: "us-west-1",
+	}
+	err := testTask.initializeEFSVolumes(cfg, dockerClient, nil)
+
+	assert.Error(t, err)
+}
+
+func TestInitializeEFSVolume_WrongVolumeType(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	dockerClient := mock_dockerapi.NewMockDockerClient(ctrl)
+
+	testTask := &Task{
+		ResourcesMapUnsafe: make(map[string][]taskresource.TaskResource),
+		Containers: []*apicontainer.Container{
+			{
+				MountPoints: []apicontainer.MountPoint{
+					{
+						SourceVolume:  "efs-volume-test",
+						ContainerPath: "/ecs",
+					},
+				},
+				TransitionDependenciesMap: make(map[apicontainerstatus.ContainerStatus]apicontainer.TransitionDependencySet),
+			},
+		},
+		Volumes: []TaskVolume{
+			{
+				Name: "efs-volume-test",
+				Type: "docker",
+				Volume: &taskresourcevolume.EFSVolumeConfig{
+					Filesystem:    "fs-12345",
+					ReadOnly:      true,
+					RootDirectory: "/my/root/dir",
+				},
+			},
+		},
+	}
+
+	cfg := &config.Config{
+		AWSRegion: "us-west-1",
+	}
+	err := testTask.initializeEFSVolumes(cfg, dockerClient, nil)
+
+	assert.NoError(t, err)
+	err = testTask.initializeDockerVolumes(true, dockerClient, nil)
+	assert.Error(t, err)
 }
 
 func TestInitializeSharedProvisionedVolumeError(t *testing.T) {

--- a/agent/taskresource/volume/dockervolume.go
+++ b/agent/taskresource/volume/dockervolume.go
@@ -86,7 +86,6 @@ type DockerVolumeConfig struct {
 type EFSVolumeConfig struct {
 	Filesystem    string `json:"filesystem"`
 	RootDirectory string `json:"rootDirectory"`
-	ReadOnly      bool   `json:"readonly"`
 	// DockerVolumeName is internal docker name for this volume.
 	DockerVolumeName string `json:"dockerVolumeName"`
 }

--- a/agent/taskresource/volume/dockervolume.go
+++ b/agent/taskresource/volume/dockervolume.go
@@ -82,6 +82,15 @@ type DockerVolumeConfig struct {
 	DockerVolumeName string `json:"dockerVolumeName"`
 }
 
+// EFSVolumeConfig represents efs volume configuration.
+type EFSVolumeConfig struct {
+	Filesystem    string `json:"filesystem"`
+	RootDirectory string `json:"rootDirectory"`
+	ReadOnly      bool   `json:"readonly"`
+	// DockerVolumeName is internal docker name for this volume.
+	DockerVolumeName string `json:"dockerVolumeName"`
+}
+
 // NewVolumeResource returns a docker volume wrapper object
 func NewVolumeResource(ctx context.Context,
 	name string,
@@ -129,6 +138,11 @@ func (vol *VolumeResource) initStatusToTransitions() {
 	}
 
 	vol.statusToTransitions = statusToTransitions
+}
+
+// Source returns the name of the volume resource which is used as the source of the volume mount
+func (cfg *EFSVolumeConfig) Source() string {
+	return cfg.DockerVolumeName
 }
 
 // Source returns the name of the volume resource which is used as the source of the volume mount


### PR DESCRIPTION
### Summary

This adds support for a new field in the task definition: EFSVolumeConfiguration

For now we only support a minimal version of EFS support that essentially just translates the EFS volume configuration into an NFS docker volume.

In the future we expect to roll out support for EFS-specific features by utilizing the efs-agent to mount the volumes.

### Implementation details

ECS already supports a field `dockerVolumeConfiguration` in the task definition that can be used to mount EFS volumes via NFS (see [here](https://aws.amazon.com/premiumsupport/knowledge-center/ecs-create-docker-volume-efs/)). By utilizing this, we can translate `EFSVolumeConfiguration` into a dockerVolumeConfiguration for basic support of mounting EFS volumes (although without support for EFS-specific features).

The plan is to maintain this "simple mode" mount whenever customers want to mount an EFS volume without utilizing any EFS-specific features. Simple EFS configuration would look something like this:

```json
"EFSVolumeConfiguration": {
    "filesystem": "fs-abcde",
    "rootDirectory": "/mydata",
    "readonly": true
}
```

### Testing

New tests cover the changes: yes

### Description for the changelog

Added support for EFSVolumeConfiguration in task definition

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
