### PR TITLE
Skip firelens s3 test when lacking s3 access

### DIFF
--- a/agent/functional_tests/tests/functionaltests_unix_test.go
+++ b/agent/functional_tests/tests/functionaltests_unix_test.go
@@ -54,6 +54,7 @@ const (
 	savedStateTaskDefinition        = "nginx"
 	portResContentionTaskDefinition = "busybox-port-5180"
 	labelsTaskDefinition            = "labels"
+	errCodeAccessDenied             = "AccessDenied"
 )
 
 var trunkingInstancePrefixes = []string{"c5.", "m5."}
@@ -1642,7 +1643,13 @@ func TestFirelensWithS3ConfigFluentd(t *testing.T) {
 		Key:    aws.String("testfiles/fluentd.conf"),
 		Body:   strings.NewReader(content),
 	})
-	require.NoError(t, err, "unable to upload config file to s3 which is needed for the test")
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok && aerr.Code() == errCodeAccessDenied {
+			t.Skip("Skipping the test since lacking necessary s3 access permission")
+		} else {
+			t.Fatalf("Unable to upload config file to s3 which is needed for the test: %v", err)
+		}
+	}
 
 	testFirelens(t, "fluentd", "@type", "stdout",
 		getLogSenderMessageFluentd, s3Bucket, false, false)
@@ -1707,7 +1714,13 @@ func TestFirelensWithS3ConfigFluentbit(t *testing.T) {
 		Key:    aws.String("testfiles/fluentbit.conf"),
 		Body:   strings.NewReader(content),
 	})
-	require.NoError(t, err, "unable to upload config file to s3 which is needed for the test")
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok && aerr.Code() == errCodeAccessDenied {
+			t.Skip("Skipping the test since lacking necessary s3 access permission")
+		} else {
+			t.Fatalf("Unable to upload config file to s3 which is needed for the test: %v", err)
+		}
+	}
 
 	testFirelens(t, "fluentbit", "Name", "cloudwatch",
 		getLogSenderMessageFluentbit, s3Bucket, false, false)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Skip firelens s3 tests when lacking s3 access. Our normal CI/qual process will still be able to run the tests, and this is to unblock individual test runner that lacks s3 access to the specified bucket

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

tested with a bucket that the test doesn't have permission to and verified that it skips the test.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
