### PR TITLE
Add Outpost ID to RCI call

### DIFF
--- a/agent/api/ecsclient/client_test.go
+++ b/agent/api/ecsclient/client_test.go
@@ -64,6 +64,7 @@ var (
 		},
 	}
 	containerInstanceTagsMap = map[string]string{
+
 		"my_key1": "my_val1",
 		"my_key2": "my_val2",
 	}
@@ -336,6 +337,7 @@ func TestReRegisterContainerInstance(t *testing.T) {
 	expectedAttributes := map[string]string{
 		"ecs.os-type":           config.OSType,
 		"ecs.availability-zone": "us-west-2b",
+		"ecs.outpost-arn":       "test:arn:outpost",
 	}
 	for i := range fakeCapabilities {
 		expectedAttributes[fakeCapabilities[i]] = ""
@@ -355,8 +357,8 @@ func TestReRegisterContainerInstance(t *testing.T) {
 			resource, ok := findResource(req.TotalResources, "PORTS_UDP")
 			assert.True(t, ok, `Could not find resource "PORTS_UDP"`)
 			assert.Equal(t, "STRINGSET", *resource.Type, `Wrong type for resource "PORTS_UDP"`)
-			// "ecs.os-type" and the 2 that we specified as additionalAttributes
-			assert.Equal(t, 3, len(req.Attributes), "Wrong number of Attributes")
+			// "ecs.os-type", ecs.outpost-arn and the 2 that we specified as additionalAttributes
+			assert.Equal(t, 4, len(req.Attributes), "Wrong number of Attributes")
 			reqAttributes := func() map[string]string {
 				rv := make(map[string]string, len(req.Attributes))
 				for i := range req.Attributes {
@@ -382,7 +384,8 @@ func TestReRegisterContainerInstance(t *testing.T) {
 			nil),
 	)
 
-	arn, availabilityzone, err := client.RegisterContainerInstance("arn:test", capabilities, containerInstanceTags, registrationToken, nil)
+	arn, availabilityzone, err := client.RegisterContainerInstance("arn:test", capabilities,
+		containerInstanceTags, registrationToken, nil, "test:arn:outpost")
 
 	assert.NoError(t, err)
 	assert.Equal(t, "registerArn", arn)
@@ -404,6 +407,7 @@ func TestRegisterContainerInstance(t *testing.T) {
 		"my_custom_attribute":       "Custom_Value1",
 		"my_other_custom_attribute": "Custom_Value2",
 		"ecs.availability-zone":     "us-west-2b",
+		"ecs.outpost-arn":           "test:arn:outpost",
 	}
 	capabilities := buildAttributeList(fakeCapabilities, nil)
 	platformDevices := []*ecs.PlatformDevice{
@@ -434,8 +438,8 @@ func TestRegisterContainerInstance(t *testing.T) {
 			resource, ok := findResource(req.TotalResources, "PORTS_UDP")
 			assert.True(t, ok, `Could not find resource "PORTS_UDP"`)
 			assert.Equal(t, "STRINGSET", *resource.Type, `Wrong type for resource "PORTS_UDP"`)
-			// 3 from expectedAttributes and 2 from additionalAttributes
-			assert.Equal(t, 5, len(req.Attributes), "Wrong number of Attributes")
+			// 3 from expectedAttributes and 3 from additionalAttributes
+			assert.Equal(t, 6, len(req.Attributes), "Wrong number of Attributes")
 			for i := range req.Attributes {
 				if strings.Contains(*req.Attributes[i].Name, "capability") {
 					assert.Contains(t, fakeCapabilities, *req.Attributes[i].Name)
@@ -457,7 +461,8 @@ func TestRegisterContainerInstance(t *testing.T) {
 			nil),
 	)
 
-	arn, availabilityzone, err := client.RegisterContainerInstance("", capabilities, containerInstanceTags, registrationToken, platformDevices)
+	arn, availabilityzone, err := client.RegisterContainerInstance("", capabilities,
+		containerInstanceTags, registrationToken, platformDevices, "test:arn:outpost")
 	assert.NoError(t, err)
 	assert.Equal(t, "registerArn", arn)
 	assert.Equal(t, "us-west-2b", availabilityzone)
@@ -484,6 +489,7 @@ func TestRegisterContainerInstanceNoIID(t *testing.T) {
 		"my_custom_attribute":       "Custom_Value1",
 		"my_other_custom_attribute": "Custom_Value2",
 		"ecs.availability-zone":     "us-west-2b",
+		"ecs.outpost-arn":           "test:arn:outpost",
 	}
 	capabilities := buildAttributeList(fakeCapabilities, nil)
 
@@ -498,8 +504,8 @@ func TestRegisterContainerInstanceNoIID(t *testing.T) {
 			resource, ok := findResource(req.TotalResources, "PORTS_UDP")
 			assert.True(t, ok, `Could not find resource "PORTS_UDP"`)
 			assert.Equal(t, "STRINGSET", *resource.Type, `Wrong type for resource "PORTS_UDP"`)
-			// 3 from expectedAttributes and 2 from additionalAttributes
-			assert.Equal(t, 5, len(req.Attributes), "Wrong number of Attributes")
+			// 3 from expectedAttributes and 3 from additionalAttributes
+			assert.Equal(t, 6, len(req.Attributes), "Wrong number of Attributes")
 			for i := range req.Attributes {
 				if strings.Contains(*req.Attributes[i].Name, "capability") {
 					assert.Contains(t, fakeCapabilities, *req.Attributes[i].Name)
@@ -520,7 +526,8 @@ func TestRegisterContainerInstanceNoIID(t *testing.T) {
 			nil),
 	)
 
-	arn, availabilityzone, err := client.RegisterContainerInstance("", capabilities, containerInstanceTags, registrationToken, nil)
+	arn, availabilityzone, err := client.RegisterContainerInstance("", capabilities,
+		containerInstanceTags, registrationToken, nil, "test:arn:outpost")
 	assert.NoError(t, err)
 	assert.Equal(t, "registerArn", arn)
 	assert.Equal(t, "us-west-2b", availabilityzone)
@@ -547,7 +554,8 @@ func TestRegisterContainerInstanceWithNegativeResource(t *testing.T) {
 		mockEC2Metadata.EXPECT().GetDynamicData(ec2.InstanceIdentityDocumentResource).Return("instanceIdentityDocument", nil),
 		mockEC2Metadata.EXPECT().GetDynamicData(ec2.InstanceIdentityDocumentSignatureResource).Return("signature", nil),
 	)
-	_, _, err := client.RegisterContainerInstance("", nil, nil, "", nil)
+	_, _, err := client.RegisterContainerInstance("", nil, nil,
+		"", nil, "")
 	assert.Error(t, err, "Register resource with negative value should cause registration fail")
 }
 
@@ -577,7 +585,8 @@ func TestRegisterContainerInstanceWithEmptyTags(t *testing.T) {
 			nil),
 	)
 
-	_, _, err := client.RegisterContainerInstance("", nil, make([]*ecs.Tag, 0), "", nil)
+	_, _, err := client.RegisterContainerInstance("", nil, make([]*ecs.Tag, 0),
+		"", nil, "")
 	assert.NoError(t, err)
 }
 
@@ -651,7 +660,8 @@ func TestRegisterBlankCluster(t *testing.T) {
 			nil),
 	)
 
-	arn, availabilityzone, err := client.RegisterContainerInstance("", nil, nil, "", nil)
+	arn, availabilityzone, err := client.RegisterContainerInstance("", nil, nil,
+		"", nil, "")
 	if err != nil {
 		t.Errorf("Should not be an error: %v", err)
 	}
@@ -705,7 +715,8 @@ func TestRegisterBlankClusterNotCreatingClusterWhenErrorNotClusterNotFound(t *te
 			nil),
 	)
 
-	arn, _, err := client.RegisterContainerInstance("", nil, nil, "", nil)
+	arn, _, err := client.RegisterContainerInstance("", nil, nil, "",
+		nil, "")
 	assert.NoError(t, err, "Should not return error")
 	assert.Equal(t, "registerArn", arn, "Wrong arn")
 }

--- a/agent/api/interface.go
+++ b/agent/api/interface.go
@@ -27,7 +27,8 @@ type ECSClient interface {
 	// instance ARN allows a container instance to update its registered
 	// resources.
 	RegisterContainerInstance(existingContainerInstanceArn string,
-		attributes []*ecs.Attribute, tags []*ecs.Tag, registrationToken string, platformDevices []*ecs.PlatformDevice) (string, string, error)
+		attributes []*ecs.Attribute, tags []*ecs.Tag, registrationToken string, platformDevices []*ecs.PlatformDevice,
+		outpostARN string) (string, string, error)
 	// SubmitTaskStateChange sends a state change and returns an error
 	// indicating if it was submitted
 	SubmitTaskStateChange(change TaskStateChange) error

--- a/agent/api/mocks/api_mocks.go
+++ b/agent/api/mocks/api_mocks.go
@@ -261,9 +261,9 @@ func (mr *MockECSClientMockRecorder) GetResourceTags(arg0 interface{}) *gomock.C
 }
 
 // RegisterContainerInstance mocks base method
-func (m *MockECSClient) RegisterContainerInstance(arg0 string, arg1 []*ecs.Attribute, arg2 []*ecs.Tag, arg3 string, arg4 []*ecs.PlatformDevice) (string, string, error) {
+func (m *MockECSClient) RegisterContainerInstance(arg0 string, arg1 []*ecs.Attribute, arg2 []*ecs.Tag, arg3 string, arg4 []*ecs.PlatformDevice, arg5 string) (string, string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RegisterContainerInstance", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "RegisterContainerInstance", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(error)
@@ -271,9 +271,9 @@ func (m *MockECSClient) RegisterContainerInstance(arg0 string, arg1 []*ecs.Attri
 }
 
 // RegisterContainerInstance indicates an expected call of RegisterContainerInstance
-func (mr *MockECSClientMockRecorder) RegisterContainerInstance(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockECSClientMockRecorder) RegisterContainerInstance(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterContainerInstance", reflect.TypeOf((*MockECSClient)(nil).RegisterContainerInstance), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterContainerInstance", reflect.TypeOf((*MockECSClient)(nil).RegisterContainerInstance), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // SubmitAttachmentStateChange mocks base method

--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -435,6 +435,17 @@ func (agent *ecsAgent) getEC2InstanceID() string {
 	return instanceID
 }
 
+// getoutpostARN gets the Outpost ARN from the metadata service
+func (agent *ecsAgent) getoutpostARN() string {
+	outpostARN, err := agent.ec2MetadataClient.OutpostARN()
+	if err != nil {
+		seelog.Warnf(
+			"Unable to obtain Outpost ARN from EC2 Metadata: %v", err)
+		return ""
+	}
+	return outpostARN
+}
+
 // newStateManager creates a new state manager object for the task engine.
 // Rest of the parameters are pointers and it's expected that all of these
 // will be backfilled when state manager's Load() method is invoked
@@ -508,13 +519,16 @@ func (agent *ecsAgent) registerContainerInstance(
 
 	platformDevices := agent.getPlatformDevices()
 
+	outpostARN := agent.getoutpostARN()
+
 	if agent.containerInstanceARN != "" {
 		seelog.Infof("Restored from checkpoint file. I am running as '%s' in cluster '%s'", agent.containerInstanceARN, agent.cfg.Cluster)
-		return agent.reregisterContainerInstance(client, capabilities, tags, uuid.New(), platformDevices)
+		return agent.reregisterContainerInstance(client, capabilities, tags, uuid.New(), platformDevices, outpostARN)
 	}
 
 	seelog.Info("Registering Instance with ECS")
-	containerInstanceArn, availabilityZone, err := client.RegisterContainerInstance("", capabilities, tags, uuid.New(), platformDevices)
+	containerInstanceArn, availabilityZone, err := client.RegisterContainerInstance("",
+		capabilities, tags, uuid.New(), platformDevices, outpostARN)
 	if err != nil {
 		seelog.Errorf("Error registering: %v", err)
 		if retriable, ok := err.(apierrors.Retriable); ok && !retriable.Retry() {
@@ -541,9 +555,11 @@ func (agent *ecsAgent) registerContainerInstance(
 // reregisterContainerInstance registers a container instance that has already been
 // registered with ECS. This is for cases where the ECS Agent is being restored
 // from a check point.
-func (agent *ecsAgent) reregisterContainerInstance(client api.ECSClient,
-	capabilities []*ecs.Attribute, tags []*ecs.Tag, registrationToken string, platformDevices []*ecs.PlatformDevice) error {
-	_, availabilityZone, err := client.RegisterContainerInstance(agent.containerInstanceARN, capabilities, tags, registrationToken, platformDevices)
+func (agent *ecsAgent) reregisterContainerInstance(client api.ECSClient, capabilities []*ecs.Attribute,
+	tags []*ecs.Tag, registrationToken string, platformDevices []*ecs.PlatformDevice, outpostARN string) error {
+	_, availabilityZone, err := client.RegisterContainerInstance(agent.containerInstanceARN, capabilities, tags,
+		registrationToken, platformDevices, outpostARN)
+
 	//set az to agent
 	agent.availabilityZone = availabilityZone
 

--- a/agent/ec2/blackhole_ec2_metadata_client.go
+++ b/agent/ec2/blackhole_ec2_metadata_client.go
@@ -80,3 +80,7 @@ func (blackholeMetadataClient) PublicIPv4Address() (string, error) {
 func (blackholeMetadataClient) SpotInstanceAction() (string, error) {
 	return "", errors.New("blackholed")
 }
+
+func (blackholeMetadataClient) OutpostARN() (string, error) {
+	return "", errors.New("blackholed")
+}

--- a/agent/ec2/ec2_metadata_client.go
+++ b/agent/ec2/ec2_metadata_client.go
@@ -37,6 +37,7 @@ const (
 	InstanceIDResource                        = "instance-id"
 	PrivateIPv4Resource                       = "local-ipv4"
 	PublicIPv4Resource                        = "public-ipv4"
+	OutpostARN                                = "outpost-arn"
 )
 
 const (
@@ -78,6 +79,7 @@ type EC2MetadataClient interface {
 	PrivateIPv4Address() (string, error)
 	PublicIPv4Address() (string, error)
 	SpotInstanceAction() (string, error)
+	OutpostARN() (string, error)
 }
 
 type ec2MetadataClientImpl struct {
@@ -193,4 +195,8 @@ func (c *ec2MetadataClientImpl) PrivateIPv4Address() (string, error) {
 // see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-interruptions.html#using-spot-instances-managing-interruptions
 func (c *ec2MetadataClientImpl) SpotInstanceAction() (string, error) {
 	return c.client.GetMetadata(SpotInstanceActionResource)
+}
+
+func (c *ec2MetadataClientImpl) OutpostARN() (string, error) {
+	return c.client.GetMetadata(OutpostARN)
 }

--- a/agent/ec2/mocks/ec2_mocks.go
+++ b/agent/ec2/mocks/ec2_mocks.go
@@ -156,6 +156,21 @@ func (mr *MockEC2MetadataClientMockRecorder) InstanceIdentityDocument() *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceIdentityDocument", reflect.TypeOf((*MockEC2MetadataClient)(nil).InstanceIdentityDocument))
 }
 
+// OutpostARN mocks base method
+func (m *MockEC2MetadataClient) OutpostARN() (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OutpostARN")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// OutpostARN indicates an expected call of OutpostARN
+func (mr *MockEC2MetadataClientMockRecorder) OutpostARN() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OutpostARN", reflect.TypeOf((*MockEC2MetadataClient)(nil).OutpostARN))
+}
+
 // PrimaryENIMAC mocks base method
 func (m *MockEC2MetadataClient) PrimaryENIMAC() (string, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Pass outpost Arn in RegistrationContainerInstance call. Outpost Arn is fetched using instance metadata. 

Outpost Arn is only passed for outpost instance, for non-outpost instance no change in RCI call. 

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
