### PR TITLE
Issue a stop when start container failed with EOF error

### DIFF
--- a/agent/dockerclient/dockerapi/errors.go
+++ b/agent/dockerclient/dockerapi/errors.go
@@ -24,6 +24,8 @@ const (
 	DockerTimeoutErrorName = "DockerTimeoutError"
 	// CannotInspectContainerErrorName is the name of container inspect error.
 	CannotInspectContainerErrorName = "CannotInspectContainerError"
+	// CannotStartContainerErrorName is the name of container start error.
+	CannotStartContainerErrorName = "CannotStartContainerError"
 	// CannotDescribeContainerErrorName is the name of describe container error.
 	CannotDescribeContainerErrorName = "CannotDescribeContainerError"
 )
@@ -201,7 +203,7 @@ func (err CannotStartContainerError) Error() string {
 
 // ErrorName returns name of the CannotStartContainerError
 func (err CannotStartContainerError) ErrorName() string {
-	return "CannotStartContainerError"
+	return CannotStartContainerErrorName
 }
 
 // CannotInspectContainerError indicates any error when trying to inspect a container

--- a/agent/engine/task_manager_test.go
+++ b/agent/engine/task_manager_test.go
@@ -140,6 +140,18 @@ func TestHandleEventError(t *testing.T) {
 			ExpectedOK:                            false,
 		},
 		{
+			Name:                        "Start failed with EOF error",
+			EventStatus:                 apicontainerstatus.ContainerRunning,
+			CurrentContainerKnownStatus: apicontainerstatus.ContainerCreated,
+			Error: &dockerapi.CannotStartContainerError{
+				FromError: errors.New("error during connect: Post http://%2Fvar%2Frun%2Fdocker.sock/v1.19/containers/containerid/start: EOF"),
+			},
+			ExpectedContainerKnownStatusSet:       true,
+			ExpectedContainerKnownStatus:          apicontainerstatus.ContainerCreated,
+			ExpectedContainerDesiredStatusStopped: true,
+			ExpectedOK:                            false,
+		},
+		{
 			Name:                        "Inspect failed during create",
 			EventStatus:                 apicontainerstatus.ContainerCreated,
 			CurrentContainerKnownStatus: apicontainerstatus.ContainerPulled,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Fix https://github.com/aws/amazon-ecs-agent/issues/1708. When start container failed with EOF, there's a chance that the container is started anyway, so issue a stop for the container in that case.

### Implementation details
<!-- How are the changes implemented? -->
The stop is issued in `handleEventErroor`, in the same way as how we issue a stop when start container times out. I can't find a typed error from Docker or golang for this, so check is based on the error string.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Unit test added. Manually tested by injecting the error in docker client and verified that the container is forced to stop.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
