### PR TITLE
api/task: initialize config in hostConfig when it is nil

### DIFF
--- a/agent/api/container/container.go
+++ b/agent/api/container/container.go
@@ -896,7 +896,7 @@ func (c *Container) ShouldCreateWithASMSecret() bool {
 }
 
 // MergeEnvironmentVariables appends additional envVarName:envVarValue pairs to
-// the the container's enviornment values structure
+// the the container's environment values structure
 func (c *Container) MergeEnvironmentVariables(envVars map[string]string) {
 	c.lock.Lock()
 	defer c.lock.Unlock()

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -1357,6 +1357,9 @@ func (task *Task) ApplyExecutionRoleLogsAuth(hostConfig *dockercontainer.HostCon
 		return &apierrors.HostConfigError{Msg: "Unable to get execution role credentials for task"}
 	}
 	credentialsEndpointRelativeURI := executionRoleCredentials.IAMRoleCredentials.GenerateCredentialsEndpointRelativeURI()
+	if hostConfig.LogConfig.Config == nil {
+		hostConfig.LogConfig.Config = map[string]string{}
+	}
 	hostConfig.LogConfig.Config[awslogsCredsEndpointOpt] = credentialsEndpointRelativeURI
 	return nil
 }
@@ -2289,6 +2292,9 @@ func populateContainerSecrets(hostConfig *dockercontainer.HostConfig, container 
 			// Check if all the name and secret value for the log driver do exist
 			// And add the secret value for this log driver into container's HostConfig
 			if hostConfig.LogConfig.Type != "" && logDriverTokenName != "" && logDriverTokenSecretValue != "" {
+				if hostConfig.LogConfig.Config == nil {
+					hostConfig.LogConfig.Config = map[string]string{}
+				}
 				hostConfig.LogConfig.Config[logDriverTokenName] = logDriverTokenSecretValue
 			}
 		}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->
Fix the bug that when Config is nil, agent will panic with error **panic: assignment to entry in nil map**.
The Config attribute in hostConfig can be nil under some situations. For example, if in task definition, for log driver, only secretOptions are specified while options is null. 

### Summary
<!-- What does this pull request do? -->

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
