### PR TITLE
Refactor and fix inactivity timeout unit tests

### DIFF
--- a/agent/dockerclient/dockerapi/inactivity_timeout_handler.go
+++ b/agent/dockerclient/dockerapi/inactivity_timeout_handler.go
@@ -38,23 +38,33 @@ func (p *proxyReader) Read(data []byte) (int, error) {
 // the downloaded files. This only causes noticeable impact with large files, but we should investigate improving this.
 func handleInactivityTimeout(reader io.ReadCloser, timeout time.Duration, cancelRequest func(), canceled *uint32) (io.ReadCloser, chan<- struct{}) {
 	done := make(chan struct{})
-	proxyReader := &proxyReader{ReadCloser: reader}
-	go func() {
-		var lastCallCount uint64
-		for {
-			select {
-			case <-time.After(timeout):
-			case <-done:
-				return
-			}
-			curCallCount := proxyReader.callCount()
-			if curCallCount == lastCallCount {
-				atomic.AddUint32(canceled, 1)
-				cancelRequest()
-				return
-			}
-			lastCallCount = curCallCount
-		}
-	}()
-	return proxyReader, done
+	pReader := &proxyReader{ReadCloser: reader}
+	go checkInactivityTimeout(pReader, timeout, cancelRequest, canceled, done)
+	return pReader, done
+}
+
+// checkInactivityTimeout checks whether there's new read activity in the proxyReader as recorded by its call count, in every interval
+// as specified by the timeout argument. It returns either when there's no new read activity in an interval (in that case the
+// 'canceled' flag is marked to 1 to indicate that), or when it's canceled (via the 'done' channel).
+func checkInactivityTimeout(pr *proxyReader, timeout time.Duration, cancelRequest func(), canceled *uint32, done chan struct{}) {
+	var lastCallCount uint64
+	finished := false
+	for !finished {
+		lastCallCount, finished = checkReadActivityOnce(pr, timeout, cancelRequest, canceled, done, lastCallCount)
+	}
+}
+
+func checkReadActivityOnce(pr *proxyReader, timeout time.Duration, cancelRequest func(), canceled *uint32, done chan struct{}, lastCallCount uint64) (uint64, bool) {
+	select {
+	case <-time.After(timeout):
+	case <-done:
+		return lastCallCount, true
+	}
+	curCallCount := pr.callCount()
+	if curCallCount == lastCallCount {
+		atomic.AddUint32(canceled, 1)
+		cancelRequest()
+		return lastCallCount, true
+	}
+	return curCallCount, false
 }

--- a/agent/dockerclient/dockerapi/inactivity_timeout_handler_test.go
+++ b/agent/dockerclient/dockerapi/inactivity_timeout_handler_test.go
@@ -1,0 +1,76 @@
+// +build unit
+
+// Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package dockerapi
+
+import (
+	"io/ioutil"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testTimeout = 100 * time.Millisecond
+)
+
+func TestCheckInactivityTimeout(t *testing.T) {
+	pReader := &proxyReader{ReadCloser: ioutil.NopCloser(strings.NewReader("test"))}
+	pReader.calls = 0
+	var canceled uint32
+	var cancelRequestInvoked bool
+	done := make(chan struct{})
+	checkInactivityTimeout(pReader, testTimeout, func() {
+		cancelRequestInvoked = true
+	}, &canceled, done)
+	assert.True(t, cancelRequestInvoked)
+	assert.Equal(t, uint32(1), canceled)
+}
+
+func TestCheckReadActivityOnce(t *testing.T) {
+	testCases := []struct {
+		name            string
+		readerCallCount uint64
+		expectCallCount uint64
+		expectFinish    bool
+	}{
+		{
+			name:            "Test check read activity with new read activity",
+			readerCallCount: 1,
+			expectCallCount: 1,
+			expectFinish:    false,
+		},
+		{
+			name:            "Test check read activity without new read activity",
+			readerCallCount: 0,
+			expectCallCount: 0,
+			expectFinish:    true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pReader := &proxyReader{ReadCloser: ioutil.NopCloser(strings.NewReader("test"))}
+			pReader.calls = tc.readerCallCount
+			var canceled uint32
+			done := make(chan struct{})
+			callCount, finished := checkReadActivityOnce(pReader, testTimeout, func() {}, &canceled, done, 0)
+			assert.Equal(t, tc.expectCallCount, callCount)
+			assert.Equal(t, tc.expectFinish, finished)
+		})
+	}
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Address https://github.com/aws/amazon-ecs-agent/issues/2246. Previously, the inactivity timeout unit tests `TestPullImageInactivityTimeout` and `TestStatsInactivityTimeout` were relying on timing of a separate goroutine, which is why they are flakey. This PR does some refactor and make the tests deterministic.

### Implementation details
<!-- How are the changes implemented? -->
(1) Make the original `handleInactivityTimeout ` function swappable in order to allow related docker client unit tests to be deterministic. It is made as a field of dockerGoClient rather than a package level var because the latter causes data race in unit test when i swap it with test function.
(2) Since `handleInactivityTimeout` is swapped and untested in docker client unit test, refactor and add its own unit tests in inactivity_timeout_handler_test.go

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
