### PR TITLE
Support Dockerfile HEALTHCHECK of agent

### DIFF
--- a/agent/app/args/flag.go
+++ b/agent/app/args/flag.go
@@ -23,6 +23,7 @@ const (
 	licenseUsage             = "Print the LICENSE and NOTICE files and exit"
 	blacholeEC2MetadataUsage = "Blackhole the EC2 Metadata requests. Setting this option can cause the ECS Agent to fail to work properly.  We do not recommend setting this option"
 	windowsServiceUsage      = "Run the ECS agent as a Windows Service"
+	healthcheckServiceUsage  = "Run the agent healthcheck"
 
 	versionFlagName              = "version"
 	logLevelFlagName             = "loglevel"
@@ -31,6 +32,7 @@ const (
 	licenseFlagName              = "license"
 	blackholeEC2MetadataFlagName = "blackhole-ec2-metadata"
 	windowsServiceFlagName       = "windows-service"
+	healthCheckFlagName          = "healthcheck"
 )
 
 // Args wraps various ECS Agent arguments
@@ -51,6 +53,8 @@ type Args struct {
 	ECSAttributes *bool
 	// WindowsService indicates that the agent should run as a Windows service
 	WindowsService *bool
+	// Healthcheck indicates that agent should run healthcheck
+	Healthcheck *bool
 }
 
 // New creates a new Args object from the argument list
@@ -65,6 +69,7 @@ func New(arguments []string) (*Args, error) {
 		BlackholeEC2Metadata: flagset.Bool(blackholeEC2MetadataFlagName, false, blacholeEC2MetadataUsage),
 		ECSAttributes:        flagset.Bool(ecsAttributesFlagName, false, ecsAttributesUsage),
 		WindowsService:       flagset.Bool(windowsServiceFlagName, false, windowsServiceUsage),
+		Healthcheck:          flagset.Bool(healthCheckFlagName, false, healthcheckServiceUsage),
 	}
 
 	err := flagset.Parse(arguments)

--- a/agent/app/healthcheck.go
+++ b/agent/app/healthcheck.go
@@ -1,0 +1,31 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package app
+
+import (
+	"net/http"
+
+	"github.com/aws/amazon-ecs-agent/agent/sighandlers/exitcodes"
+	"github.com/cihub/seelog"
+)
+
+// runHealthcheck runs the Agent's healthcheck
+func runHealthcheck() int {
+	_, err := http.Get("http://localhost:51678/v1/metadata")
+	if err != nil {
+		seelog.Warnf("Health check failed with error: %v", err)
+		return exitcodes.ExitError
+	}
+	return exitcodes.ExitSuccess
+}

--- a/agent/app/run.go
+++ b/agent/app/run.go
@@ -38,6 +38,8 @@ func Run(arguments []string) int {
 		return printLicense()
 	} else if *parsedArgs.Version {
 		return version.PrintVersion()
+	} else if *parsedArgs.Healthcheck {
+		return runHealthcheck()
 	}
 
 	logger.SetLevel(*parsedArgs.LogLevel)

--- a/scripts/dockerfiles/Dockerfile.release
+++ b/scripts/dockerfiles/Dockerfile.release
@@ -28,4 +28,7 @@ COPY out/cni-plugins /amazon-ecs-cni-plugins
 COPY misc/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 EXPOSE 51678 51679
+
+HEALTHCHECK CMD ["/agent", "--healthcheck"]
+
 ENTRYPOINT ["/agent"]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Address #800. Previously, ECS does not have a Healthcheck directive for itself. This PR add the healthcheck in the dockerfile to enable detect the health status of ECS agent.
### Implementation details
<!-- How are the changes implemented? -->
Enable ECS agent healthcheck flag 
Add the healthcheck command in the dockerfile. 
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->


### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
