### PR TITLE
GMSA Integration [WIP]

### DIFF
--- a/agent/api/container/container_unix.go
+++ b/agent/api/container/container_unix.go
@@ -15,8 +15,22 @@
 
 package container
 
+import (
+	"github.com/pkg/errors"
+)
+
 const (
 	// DockerContainerMinimumMemoryInBytes is the minimum amount of
 	// memory to be allocated to a docker container
 	DockerContainerMinimumMemoryInBytes = 4 * 1024 * 1024 // 4MB
 )
+
+// RequiresCredentialSpec checks if container needs a credentialspec resource
+func (c *Container) RequiresCredentialSpec() bool {
+	return false
+}
+
+// GetCredentialSpec is used to retrieve the current credentialspec resource
+func (c *Container) GetCredentialSpec() (string, error) {
+	return "", errors.New("unsupported platform")
+}

--- a/agent/api/container/container_windows.go
+++ b/agent/api/container/container_windows.go
@@ -15,8 +15,75 @@
 
 package container
 
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/cihub/seelog"
+	dockercontainer "github.com/docker/docker/api/types/container"
+	"github.com/pkg/errors"
+)
+
 const (
 	// DockerContainerMinimumMemoryInBytes is the minimum amount of
 	// memory to be allocated to a docker container
 	DockerContainerMinimumMemoryInBytes = 256 * 1024 * 1024 // 256MB
 )
+
+// RequiresCredentialSpec checks if container needs a credentialspec resource
+func (c *Container) RequiresCredentialSpec() bool {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	if c.DockerConfig.HostConfig == nil {
+		return false
+	}
+
+	hostConfig := &dockercontainer.HostConfig{}
+	err := json.Unmarshal([]byte(*c.DockerConfig.HostConfig), hostConfig)
+	if err != nil {
+		seelog.Warnf("Encountered error when trying to get hostConfig for container %s: %v", err)
+		return false
+	}
+
+	if len(hostConfig.SecurityOpt) == 0 {
+		return false
+	}
+
+	for _, opt := range hostConfig.SecurityOpt {
+		if strings.HasPrefix(opt, "credentialspec") {
+			return true
+		}
+	}
+
+	return false
+}
+
+// GetCredentialSpec is used to retrieve the current credentialspec resource
+func (c *Container) GetCredentialSpec() (string, error) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	if c.DockerConfig.HostConfig == nil {
+		return "", errors.New("empty container hostConfig")
+	}
+
+	hostConfig := &dockercontainer.HostConfig{}
+	err := json.Unmarshal([]byte(*c.DockerConfig.HostConfig), hostConfig)
+	if err != nil {
+		seelog.Warnf("Encountered error when trying to get hostConfig for container %s: %v", err)
+		return "", errors.New("unable to unmarshal container hostConfig")
+	}
+
+	if len(hostConfig.SecurityOpt) == 0 {
+		return "", errors.New("unable to find container security options")
+	}
+
+	for _, opt := range hostConfig.SecurityOpt {
+		if strings.HasPrefix(opt, "credentialspec") {
+			return opt, nil
+		}
+	}
+
+	return "", errors.New("unable to obtain credentialspec")
+}

--- a/agent/api/container/container_windows_test.go
+++ b/agent/api/container/container_windows_test.go
@@ -1,0 +1,138 @@
+// +build windows,unit
+
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package container
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRequiresCredentialSpec(t *testing.T) {
+	getContainer := func(hostConfig string) *Container {
+		c := &Container{
+			Name: "c",
+		}
+		c.DockerConfig.HostConfig = &hostConfig
+		return c
+	}
+
+	testCases := []struct {
+		name           string
+		container      *Container
+		expectedOutput bool
+	}{
+		{
+			name:           "hostconfig_nil",
+			container:      &Container{},
+			expectedOutput: false,
+		},
+		{
+			name:           "invalid_case",
+			container:      getContainer("invalid"),
+			expectedOutput: false,
+		},
+		{
+			name:           "empty_sec_opt",
+			container:      getContainer("{\"NetworkMode\":\"bridge\"}"),
+			expectedOutput: false,
+		},
+		{
+			name:           "missing_credentialspec",
+			container:      getContainer("{\"SecurityOpt\": [\"invalid-sec-opt\"]}"),
+			expectedOutput: false,
+		},
+		{
+			name:           "valid_credentialspec",
+			container:      getContainer("{\"SecurityOpt\": [\"credentialspec:file://gmsa_gmsa-acct.json\"]}"),
+			expectedOutput: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectedOutput, tc.container.RequiresCredentialSpec())
+		})
+	}
+}
+
+func TestGetCredentialSpecErr(t *testing.T) {
+	getContainer := func(hostConfig string) *Container {
+		c := &Container{
+			Name: "c",
+		}
+		c.DockerConfig.HostConfig = &hostConfig
+		return c
+	}
+
+	testCases := []struct {
+		name                 string
+		container            *Container
+		expectedOutputString string
+		expectedErrorString  string
+	}{
+		{
+			name:                 "hostconfig_nil",
+			container:            &Container{},
+			expectedOutputString: "",
+			expectedErrorString:  "empty container hostConfig",
+		},
+		{
+			name:                 "invalid_case",
+			container:            getContainer("invalid"),
+			expectedOutputString: "",
+			expectedErrorString:  "unable to unmarshal container hostConfig",
+		},
+		{
+			name:                 "empty_sec_opt",
+			container:            getContainer("{\"NetworkMode\":\"bridge\"}"),
+			expectedOutputString: "",
+			expectedErrorString:  "unable to find container security options",
+		},
+		{
+			name:                 "missing_credentialspec",
+			container:            getContainer("{\"SecurityOpt\": [\"invalid-sec-opt\"]}"),
+			expectedOutputString: "",
+			expectedErrorString:  "unable to obtain credentialspec",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			expectedOutputStr, err := tc.container.GetCredentialSpec()
+			assert.Equal(t, tc.expectedOutputString, expectedOutputStr)
+			assert.EqualError(t, err, tc.expectedErrorString)
+		})
+	}
+}
+
+func TestGetCredentialSpecHappyPath(t *testing.T) {
+	getContainer := func(hostConfig string) *Container {
+		c := &Container{
+			Name: "c",
+		}
+		c.DockerConfig.HostConfig = &hostConfig
+		return c
+	}
+
+	c := getContainer("{\"SecurityOpt\": [\"credentialspec:file://gmsa_gmsa-acct.json\"]}")
+
+	expectedCredentialSpec := "credentialspec:file://gmsa_gmsa-acct.json"
+
+	credentialspec, err := c.GetCredentialSpec()
+	assert.NoError(t, err)
+	assert.EqualValues(t, expectedCredentialSpec, credentialspec)
+}

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -359,6 +359,15 @@ func (task *Task) PostUnmarshalTask(cfg *config.Config,
 			return err
 		}
 	}
+
+	if task.requiresCredentialSpecResource() {
+		err = task.initializeCredentialSpecResource(cfg, credentialsManager, resourceFields)
+		if err != nil {
+			seelog.Errorf("Task [%s]: could not initialize credentialspec resource: %v", task.Arn, err)
+			return apierrors.NewResourceInitError(task.Arn, err)
+		}
+	}
+
 	return nil
 }
 

--- a/agent/api/task/task_linux.go
+++ b/agent/api/task/task_linux.go
@@ -19,8 +19,10 @@ import (
 	"path/filepath"
 	"time"
 
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/credentials"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/cgroup"
 	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
@@ -216,4 +218,26 @@ func (task *Task) dockerCPUShares(containerCPU uint) int64 {
 		return 2
 	}
 	return int64(containerCPU)
+}
+
+// requiresCredentialSpecResource returns true if at least one container in the task
+// needs a valid credentialspec resource
+func (task *Task) requiresCredentialSpecResource() bool {
+	return false
+}
+
+// initializeCredentialSpecResource builds the resource dependency map for the credentialspec resource
+func (task *Task) initializeCredentialSpecResource(config *config.Config, credentialsManager credentials.Manager,
+	resourceFields *taskresource.ResourceFields) {
+	return
+}
+
+// getAllCredentialSpecRequirements is used to build all the credential spec requirements for the task
+func (task *Task) getAllCredentialSpecRequirements() map[string][]*apicontainer.Container {
+	return nil
+}
+
+// GetCredentialSpecResource retrieves credentialspec resource from resource map
+func (task *Task) GetCredentialSpecResource() ([]taskresource.TaskResource, bool) {
+	return []taskresource.TaskResource{}, false
 }

--- a/agent/api/task/task_unsupported.go
+++ b/agent/api/task/task_unsupported.go
@@ -18,7 +18,9 @@ package task
 import (
 	"time"
 
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/credentials"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	"github.com/cihub/seelog"
 	dockercontainer "github.com/docker/docker/api/types/container"
@@ -64,4 +66,26 @@ func (task *Task) dockerCPUShares(containerCPU uint) int64 {
 		return 2
 	}
 	return int64(containerCPU)
+}
+
+// requiresCredentialSpecResource returns true if at least one container in the task
+// needs a valid credentialspec resource
+func (task *Task) requiresCredentialSpecResource() bool {
+	return false
+}
+
+// initializeCredentialSpecResource builds the resource dependency map for the credentialspec resource
+func (task *Task) initializeCredentialSpecResource(config *config.Config, credentialsManager credentials.Manager,
+	resourceFields *taskresource.ResourceFields) error {
+	return nil
+}
+
+// getAllCredentialSpecRequirements is used to build all the credential spec requirements for the task
+func (task *Task) getAllCredentialSpecRequirements() map[string][]*apicontainer.Container {
+	return nil
+}
+
+// GetCredentialSpecResource retrieves credentialspec resource from resource map
+func (task *Task) GetCredentialSpecResource() ([]taskresource.TaskResource, bool) {
+	return []taskresource.TaskResource{}, false
 }

--- a/agent/api/task/task_windows.go
+++ b/agent/api/task/task_windows.go
@@ -23,8 +23,13 @@ import (
 	"strings"
 	"time"
 
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/credentials"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
+	"github.com/aws/amazon-ecs-agent/agent/taskresource/credentialspec"
+	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
 	taskresourcevolume "github.com/aws/amazon-ecs-agent/agent/taskresource/volume"
 	"github.com/cihub/seelog"
 	dockercontainer "github.com/docker/docker/api/types/container"
@@ -149,4 +154,63 @@ func (task *Task) dockerCPUShares(containerCPU uint) int64 {
 
 func (task *Task) initializeCgroupResourceSpec(cgroupPath string, cGroupCPUPeriod time.Duration, resourceFields *taskresource.ResourceFields) error {
 	return errors.New("unsupported platform")
+}
+
+// requiresCredentialSpecResource returns true if at least one container in the task
+// needs a valid credentialspec resource
+func (task *Task) requiresCredentialSpecResource() bool {
+	for _, container := range task.Containers {
+		if container.RequiresCredentialSpec() {
+			return true
+		}
+	}
+	return false
+}
+
+// initializeCredentialSpecResource builds the resource dependency map for the credentialspec resource
+func (task *Task) initializeCredentialSpecResource(config *config.Config, credentialsManager credentials.Manager,
+	resourceFields *taskresource.ResourceFields) error {
+	credentialspecResource, err := credentialspec.NewCredentialSpecResource(task.Arn, config.AWSRegion, task.getAllCredentialSpecRequirements(),
+		task.ExecutionCredentialsID, credentialsManager, resourceFields.SSMClientCreator, resourceFields.S3ClientCreator)
+	if err != nil {
+		return err
+	}
+
+	task.AddResource(credentialspec.ResourceName, credentialspecResource)
+
+	// for every container that needs credential spec vending, it needs to wait for all credential spec resources
+	for _, container := range task.Containers {
+		if container.RequiresCredentialSpec() {
+			container.BuildResourceDependency(credentialspecResource.GetName(),
+				resourcestatus.ResourceStatus(credentialspec.CredentialSpecCreated),
+				apicontainerstatus.ContainerCreated)
+		}
+	}
+
+	return nil
+}
+
+// getAllCredentialSpecRequirements is used to build all the credential spec requirements for the task
+func (task *Task) getAllCredentialSpecRequirements() map[string][]*apicontainer.Container {
+	reqs := map[string][]*apicontainer.Container{}
+
+	for _, container := range task.Containers {
+		if container.RequiresCredentialSpec() {
+			credentialSpec, err := container.GetCredentialSpec()
+			if err == nil && credentialSpec != "" {
+				reqs[credentialSpec] = append(reqs[credentialSpec], container)
+			}
+		}
+	}
+
+	return reqs
+}
+
+// GetCredentialSpecResource retrieves credentialspec resource from resource map
+func (task *Task) GetCredentialSpecResource() ([]taskresource.TaskResource, bool) {
+	task.lock.RLock()
+	defer task.lock.RUnlock()
+
+	res, ok := task.ResourcesMapUnsafe[credentialspec.ResourceName]
+	return res, ok
 }

--- a/agent/api/task/task_windows_test.go
+++ b/agent/api/task/task_windows_test.go
@@ -26,11 +26,19 @@ import (
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	apitaskstatus "github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/taskresource"
+	"github.com/aws/amazon-ecs-agent/agent/taskresource/credentialspec"
+	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
 	taskresourcevolume "github.com/aws/amazon-ecs-agent/agent/taskresource/volume"
+	"github.com/golang/mock/gomock"
 
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient"
 	dockercontainer "github.com/docker/docker/api/types/container"
 	"github.com/stretchr/testify/assert"
+
+	mock_credentials "github.com/aws/amazon-ecs-agent/agent/credentials/mocks"
+	mock_s3_factory "github.com/aws/amazon-ecs-agent/agent/s3/factory/mocks"
+	mock_ssm_factory "github.com/aws/amazon-ecs-agent/agent/ssm/factory/mocks"
 )
 
 const (
@@ -330,4 +338,121 @@ func TestGetCanonicalPath(t *testing.T) {
 			assert.Equal(t, result, tc.expectedResult)
 		})
 	}
+}
+
+func TestRequiresCredentialSpecResource(t *testing.T) {
+	container1 := &apicontainer.Container{}
+	task1 := &Task{
+		Arn:        "test",
+		Containers: []*apicontainer.Container{container1},
+	}
+
+	hostConfig := "{\"SecurityOpt\": [\"credentialspec:file://gmsa_gmsa-acct.json\"]}"
+	container2 := &apicontainer.Container{}
+	container2.DockerConfig.HostConfig = &hostConfig
+	task2 := &Task{
+		Arn:        "test",
+		Containers: []*apicontainer.Container{container2},
+	}
+
+	testCases := []struct {
+		name           string
+		task           *Task
+		expectedOutput bool
+	}{
+		{
+			name:           "missing_credentialspec",
+			task:           task1,
+			expectedOutput: false,
+		},
+		{
+			name:           "valid_credentialspec",
+			task:           task2,
+			expectedOutput: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectedOutput, tc.task.requiresCredentialSpecResource())
+		})
+	}
+
+}
+
+func TestGetAllCredentialSpecRequirements(t *testing.T) {
+	hostConfig := "{\"SecurityOpt\": [\"credentialspec:file://gmsa_gmsa-acct.json\"]}"
+	container := &apicontainer.Container{}
+	container.DockerConfig.HostConfig = &hostConfig
+
+	task := &Task{
+		Arn:        "test",
+		Containers: []*apicontainer.Container{container},
+	}
+
+	allCredSpecReq := task.getAllCredentialSpecRequirements()
+
+	credentialspec := "credentialspec:file://gmsa_gmsa-acct.json"
+	expectedCredSpecReq := map[string][]*apicontainer.Container{}
+	expectedCredSpecReq[credentialspec] = append(expectedCredSpecReq[credentialspec], container)
+
+	assert.EqualValues(t, expectedCredSpecReq, allCredSpecReq)
+}
+
+func TestInitializeAndGetCredentialSpecResource(t *testing.T) {
+	hostConfig := "{\"SecurityOpt\": [\"credentialspec:file://gmsa_gmsa-acct.json\"]}"
+	container := &apicontainer.Container{
+		Name:                      "myName",
+		TransitionDependenciesMap: make(map[apicontainerstatus.ContainerStatus]apicontainer.TransitionDependencySet),
+	}
+	container.DockerConfig.HostConfig = &hostConfig
+
+	task := &Task{
+		Arn:                "test",
+		Containers:         []*apicontainer.Container{container},
+		ResourcesMapUnsafe: make(map[string][]taskresource.TaskResource),
+	}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	cfg := &config.Config{
+		AWSRegion: "test-aws-region",
+	}
+
+	credentialsManager := mock_credentials.NewMockManager(ctrl)
+	ssmClientCreator := mock_ssm_factory.NewMockSSMClientCreator(ctrl)
+	s3ClientCreator := mock_s3_factory.NewMockS3ClientCreator(ctrl)
+
+	resFields := &taskresource.ResourceFields{
+		ResourceFieldsCommon: &taskresource.ResourceFieldsCommon{
+			SSMClientCreator:   ssmClientCreator,
+			S3ClientCreator:    s3ClientCreator,
+			CredentialsManager: credentialsManager,
+		},
+	}
+
+	task.initializeCredentialSpecResource(cfg, credentialsManager, resFields)
+
+	resourceDep := apicontainer.ResourceDependency{
+		Name:           credentialspec.ResourceName,
+		RequiredStatus: resourcestatus.ResourceStatus(credentialspec.CredentialSpecCreated),
+	}
+
+	assert.Equal(t, resourceDep, task.Containers[0].TransitionDependenciesMap[apicontainerstatus.ContainerCreated].ResourceDependencies[0])
+
+	_, ok := task.GetCredentialSpecResource()
+	assert.True(t, ok)
+}
+
+func TestGetCredentialSpecResource(t *testing.T) {
+	credentialspecResource := &credentialspec.CredentialSpecResource{}
+	task := &Task{
+		ResourcesMapUnsafe: make(map[string][]taskresource.TaskResource),
+	}
+	task.AddResource(credentialspec.ResourceName, credentialspecResource)
+
+	credentialspecTaskResource, ok := task.GetCredentialSpecResource()
+	assert.True(t, ok)
+	assert.NotEmpty(t, credentialspecTaskResource)
 }

--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -56,6 +56,7 @@ const (
 	capabilityFirelensConfigFile                = "firelens.options.config.file"
 	capabilityFirelensConfigS3                  = "firelens.options.config.s3"
 	capabilityFullTaskSync                      = "full-sync"
+	capabilityGMSA                              = "gMSA"
 )
 
 // capabilities returns the supported capabilities of this agent / docker-client pair.
@@ -99,7 +100,7 @@ const (
 //    com.amazonaws.ecs.capability.logging-driver.awsfirelens
 //    ecs.capability.firelens.options.config.file
 //    ecs.capability.firelens.options.config.s3
-// 	  ecs.capability.full-sync
+//    ecs.capability.gMSA
 func (agent *ecsAgent) capabilities() ([]*ecs.Attribute, error) {
 	var capabilities []*ecs.Attribute
 
@@ -168,9 +169,6 @@ func (agent *ecsAgent) capabilities() ([]*ecs.Attribute, error) {
 	// support container ordering in agent
 	capabilities = appendNameOnlyAttribute(capabilities, attributePrefix+capabilityContainerOrdering)
 
-	// support full task sync
-	capabilities = appendNameOnlyAttribute(capabilities, attributePrefix+capabilityFullTaskSync)
-
 	// ecs agent version 1.22.0 supports sharing PID namespaces and IPC resource namespaces
 	// with host EC2 instance and among containers within the task
 	capabilities = agent.appendPIDAndIPCNamespaceSharingCapabilities(capabilities)
@@ -192,6 +190,10 @@ func (agent *ecsAgent) capabilities() ([]*ecs.Attribute, error) {
 
 	// support external firelens config
 	capabilities = agent.appendFirelensConfigCapabilities(capabilities)
+
+	if agent.cfg.GMSACapable {
+		capabilities = agent.appendGMSACapabilities(capabilities)
+	}
 
 	return capabilities, nil
 }

--- a/agent/app/agent_capability_unix.go
+++ b/agent/app/agent_capability_unix.go
@@ -161,3 +161,7 @@ func (agent *ecsAgent) appendFirelensConfigCapabilities(capabilities []*ecs.Attr
 	capabilities = appendNameOnlyAttribute(capabilities, attributePrefix+capabilityFirelensConfigFile)
 	return appendNameOnlyAttribute(capabilities, attributePrefix+capabilityFirelensConfigS3)
 }
+
+func (agent *ecsAgent) appendGMSACapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
+	return capabilities
+}

--- a/agent/app/agent_capability_unspecified.go
+++ b/agent/app/agent_capability_unspecified.go
@@ -101,3 +101,7 @@ func (agent *ecsAgent) appendFirelensLoggingDriverCapabilities(capabilities []*e
 func (agent *ecsAgent) appendFirelensConfigCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
 	return capabilities
 }
+
+func (agent *ecsAgent) appendGMSACapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
+	return capabilities
+}

--- a/agent/app/agent_capability_windows.go
+++ b/agent/app/agent_capability_windows.go
@@ -60,3 +60,7 @@ func (agent *ecsAgent) appendFirelensLoggingDriverCapabilities(capabilities []*e
 func (agent *ecsAgent) appendFirelensConfigCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
 	return capabilities
 }
+
+func (agent *ecsAgent) appendGMSACapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
+	return appendNameOnlyAttribute(capabilities, attributePrefix+capabilityGMSA)
+}

--- a/agent/app/agent_unix.go
+++ b/agent/app/agent_unix.go
@@ -29,7 +29,9 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/eni/udevwrapper"
 	"github.com/aws/amazon-ecs-agent/agent/eni/watcher"
 	"github.com/aws/amazon-ecs-agent/agent/gpu"
+	s3factory "github.com/aws/amazon-ecs-agent/agent/s3/factory"
 	ssmfactory "github.com/aws/amazon-ecs-agent/agent/ssm/factory"
+
 	"github.com/aws/amazon-ecs-agent/agent/statechange"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	cgroup "github.com/aws/amazon-ecs-agent/agent/taskresource/cgroup/control"
@@ -211,6 +213,7 @@ func (agent *ecsAgent) initializeResourceFields(credentialsManager credentials.M
 			IOUtil:             ioutilwrapper.NewIOUtil(),
 			ASMClientCreator:   asmfactory.NewClientCreator(),
 			SSMClientCreator:   ssmfactory.NewSSMClientCreator(),
+			S3ClientCreator:    s3factory.NewS3ClientCreator(),
 			CredentialsManager: credentialsManager,
 			EC2InstanceID:      agent.getEC2InstanceID(),
 		},

--- a/agent/app/agent_windows.go
+++ b/agent/app/agent_windows.go
@@ -26,6 +26,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
 	"github.com/aws/amazon-ecs-agent/agent/engine"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
+	s3factory "github.com/aws/amazon-ecs-agent/agent/s3/factory"
 	"github.com/aws/amazon-ecs-agent/agent/sighandlers"
 	"github.com/aws/amazon-ecs-agent/agent/sighandlers/exitcodes"
 	ssmfactory "github.com/aws/amazon-ecs-agent/agent/ssm/factory"
@@ -257,6 +258,7 @@ func (agent *ecsAgent) initializeResourceFields(credentialsManager credentials.M
 		ResourceFieldsCommon: &taskresource.ResourceFieldsCommon{
 			ASMClientCreator:   asmfactory.NewClientCreator(),
 			SSMClientCreator:   ssmfactory.NewSSMClientCreator(),
+			S3ClientCreator:    s3factory.NewS3ClientCreator(),
 			CredentialsManager: credentialsManager,
 		},
 		Ctx:          agent.ctx,

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -551,6 +551,7 @@ func environmentConfig() (Config, error) {
 		TaskMetadataAZDisabled:              utils.ParseBool(os.Getenv("ECS_DISABLE_TASK_METADATA_AZ"), false),
 		CgroupCPUPeriod:                     parseCgroupCPUPeriod(),
 		SpotInstanceDrainingEnabled:         utils.ParseBool(os.Getenv("ECS_ENABLE_SPOT_INSTANCE_DRAINING"), false),
+		GMSACapable:                         parseGMSACapability(),
 	}, err
 }
 

--- a/agent/config/config_unix.go
+++ b/agent/config/config_unix.go
@@ -82,6 +82,7 @@ func DefaultConfig() Config {
 		PollingMetricsWaitDuration:          DefaultPollingMetricsWaitDuration,
 		NvidiaRuntime:                       DefaultNvidiaRuntime,
 		CgroupCPUPeriod:                     defaultCgroupCPUPeriod,
+		GMSACapable:                         false,
 	}
 }
 

--- a/agent/config/config_windows.go
+++ b/agent/config/config_windows.go
@@ -103,6 +103,7 @@ func DefaultConfig() Config {
 		SharedVolumeMatchFullConfig:         false, //only requiring shared volumes to match on name, which is default docker behavior
 		PollMetrics:                         false,
 		PollingMetricsWaitDuration:          DefaultPollingMetricsWaitDuration,
+		GMSACapable:                         true,
 	}
 }
 

--- a/agent/config/parse_unsupported.go
+++ b/agent/config/parse_unsupported.go
@@ -1,0 +1,20 @@
+// +build !windows
+
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	httpaws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package config
+
+func parseGMSACapability() bool {
+	return false
+}

--- a/agent/config/parse_windows.go
+++ b/agent/config/parse_windows.go
@@ -1,0 +1,55 @@
+// +build windows
+
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package config
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+
+	"github.com/aws/amazon-ecs-agent/agent/utils"
+)
+
+// parseGMSACapability is used to determine if gMSA support can be enabled
+func parseGMSACapability() bool {
+	envStatus := utils.ParseBool(os.Getenv("ECS_GMSA_SUPPORTED"), true)
+	if envStatus {
+		// If gMSA feature is explicitly enabled, check if container instance is domain joined.
+		// If container instance is not domain joined, explicitly disable feature configuration.
+		status, err := isDomainJoined()
+		if err != nil || status != true {
+			return false
+		}
+	}
+
+	return true
+}
+
+// isDomainJoined is used to validate if container instance is part of a valid active directory.
+// Reference: https://golang.org/src/os/user/lookup_windows.go
+func isDomainJoined() (bool, error) {
+	var domain *uint16
+	var status uint32
+
+	err := syscall.NetGetJoinInformation(nil, &domain, &status)
+	if err != nil {
+		return false, err
+	}
+
+	syscall.NetApiBufferFree((*byte)(unsafe.Pointer(domain)))
+
+	return status == syscall.NetSetupDomainName, nil
+}

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -305,4 +305,8 @@ type Config struct {
 	// Defaults to false.
 	// see https://docs.aws.amazon.com/AmazonECS/latest/developerguide/container-instance-draining.html
 	SpotInstanceDrainingEnabled bool
+
+	// GMSACapable is the config option to indicate if gMSA is supported.
+	// It should be enabled by default only if the container instance is part of a valid active directory domain.
+	GMSACapable bool
 }

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -43,6 +43,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/statechange"
 	"github.com/aws/amazon-ecs-agent/agent/statemanager"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
+	"github.com/aws/amazon-ecs-agent/agent/taskresource/credentialspec"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/firelens"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 	"github.com/aws/amazon-ecs-agent/agent/utils/retry"
@@ -976,6 +977,41 @@ func (engine *DockerTaskEngine) createContainer(task *apitask.Task, container *a
 
 		if err != nil {
 			return dockerapi.DockerContainerMetadata{Error: apierrors.NamedError(err)}
+		}
+	}
+
+	// Populate credentialspec resource
+	if container.RequiresCredentialSpec() {
+		seelog.Infof("Obtained container %s with credentialspec resource requirement.", container.Name)
+		var credSpecResource *credentialspec.CredentialSpecResource
+		resource, ok := task.GetCredentialSpecResource()
+		if !ok {
+			okErr := &apierrors.DockerClientConfigError{Msg: "unable to fetch task credentialspec resource"}
+			return dockerapi.DockerContainerMetadata{Error: apierrors.NamedError(okErr)}
+		}
+
+		// Setup credentialSpec resource object for injection
+		credSpecResource = resource[0].(*credentialspec.CredentialSpecResource)
+
+		containerCredSpec, err := container.GetCredentialSpec()
+		if err != nil && containerCredSpec != "" {
+			desiredCredSpecInjection, err := credSpecResource.GetTargetMapping(containerCredSpec)
+			if err != nil || desiredCredSpecInjection == "" {
+				missingErr := &apierrors.DockerClientConfigError{Msg: "unable to fetch valid credentialspec mapping"}
+				return dockerapi.DockerContainerMetadata{Error: apierrors.NamedError(missingErr)}
+			}
+
+			// Inject containers' hostConfig.SecurityOpt with the credentialspec resource
+			seelog.Infof("Injecting container %s with credentialspec %s.", container.Name, desiredCredSpecInjection)
+			if len(hostConfig.SecurityOpt) == 0 {
+				hostConfig.SecurityOpt = []string{desiredCredSpecInjection}
+			} else {
+				hostConfig.SecurityOpt = append(hostConfig.SecurityOpt, desiredCredSpecInjection)
+			}
+
+		} else {
+			emptyErr := &apierrors.DockerClientConfigError{Msg: "unable to fetch valid credentialspec"}
+			return dockerapi.DockerContainerMetadata{Error: apierrors.NamedError(emptyErr)}
 		}
 	}
 

--- a/agent/ssm/ssm.go
+++ b/agent/ssm/ssm.go
@@ -43,6 +43,28 @@ func GetSecretsFromSSM(names []string, client SSMClient) (map[string]string, err
 	return extractSSMValues(out)
 }
 
+// TODO: Refactor GetSecretsFromSSM to parameterize `WithDecryption`
+// GetParametersFromSSM makes the api call to the AWS SSM parameter store to
+// retrieve parameter value in batches
+func GetParametersFromSSM(names []string, client SSMClient) (map[string]string, error) {
+	var paramNames []*string
+	for _, name := range names {
+		paramNames = append(paramNames, aws.String(name))
+	}
+
+	in := &ssm.GetParametersInput{
+		Names:          paramNames,
+		WithDecryption: aws.Bool(false),
+	}
+
+	out, err := client.GetParameters(in)
+	if err != nil {
+		return nil, err
+	}
+
+	return extractSSMValues(out)
+}
+
 func extractSSMValues(out *ssm.GetParametersOutput) (map[string]string, error) {
 	if out == nil {
 		return nil, errors.New(

--- a/agent/taskresource/credentialspec/credentialspec_unsupported.go
+++ b/agent/taskresource/credentialspec/credentialspec_unsupported.go
@@ -1,0 +1,156 @@
+// +build !windows
+
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package credentialspec
+
+import (
+	"time"
+
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	"github.com/aws/amazon-ecs-agent/agent/api/task/status"
+	"github.com/aws/amazon-ecs-agent/agent/credentials"
+	s3factory "github.com/aws/amazon-ecs-agent/agent/s3/factory"
+	ssmfactory "github.com/aws/amazon-ecs-agent/agent/ssm/factory"
+	"github.com/aws/amazon-ecs-agent/agent/taskresource"
+	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
+	"github.com/pkg/errors"
+)
+
+// CredentialSpecResource is the abstraction for credentialspec resources
+type CredentialSpecResource struct {
+}
+
+// NewCredentialSpecResource creates a new CredentialSpecResource object
+func NewCredentialSpecResource(taskARN, region string,
+	credentialSpecs map[string][]*apicontainer.Container,
+	executionCredentialsID string,
+	credentialsManager credentials.Manager,
+	ssmClientCreator ssmfactory.SSMClientCreator,
+	s3ClientCreator s3factory.S3ClientCreator) *CredentialSpecResource {
+	return nil
+}
+
+func (cs *CredentialSpecResource) Initialize(resourceFields *taskresource.ResourceFields,
+	taskKnownStatus status.TaskStatus,
+	taskDesiredStatus status.TaskStatus) {
+}
+
+// GetTerminalReason returns an error string to propagate up through to task
+// state change messages
+func (cs *CredentialSpecResource) GetTerminalReason() string {
+	return "undefined"
+}
+
+// GetDesiredStatus safely returns the desired status of the task
+func (cs *CredentialSpecResource) GetDesiredStatus() resourcestatus.ResourceStatus {
+	return resourcestatus.ResourceStatusNone
+}
+
+// SetDesiredStatus safely sets the desired status of the resource
+func (cs *CredentialSpecResource) SetDesiredStatus(status resourcestatus.ResourceStatus) {
+}
+
+// DesiredTerminal returns true if the credentialspec's desired status is REMOVED
+func (cs *CredentialSpecResource) DesiredTerminal() bool {
+	return false
+}
+
+// KnownCreated returns true if the credentialspec's known status is CREATED
+func (cs *CredentialSpecResource) KnownCreated() bool {
+	return false
+}
+
+// TerminalStatus returns the last transition state of credentialspec
+func (cs *CredentialSpecResource) TerminalStatus() resourcestatus.ResourceStatus {
+	return resourcestatus.ResourceStatusNone
+}
+
+// NextKnownState returns the state that the resource should
+// progress to based on its `KnownState`.
+func (cs *CredentialSpecResource) NextKnownState() resourcestatus.ResourceStatus {
+	return resourcestatus.ResourceStatusNone
+}
+
+// ApplyTransition calls the function required to move to the specified status
+func (cs *CredentialSpecResource) ApplyTransition(nextState resourcestatus.ResourceStatus) error {
+	return errors.New("not implemented")
+}
+
+// SteadyState returns the transition state of the resource defined as "ready"
+func (cs *CredentialSpecResource) SteadyState() resourcestatus.ResourceStatus {
+	return resourcestatus.ResourceStatusNone
+}
+
+// SetKnownStatus safely sets the currently known status of the resource
+func (cs *CredentialSpecResource) SetKnownStatus(status resourcestatus.ResourceStatus) {
+}
+
+// updateAppliedStatusUnsafe updates the resource transitioning status
+func (cs *CredentialSpecResource) updateAppliedStatusUnsafe(knownStatus resourcestatus.ResourceStatus) {
+}
+
+// SetAppliedStatus sets the applied status of resource and returns whether
+// the resource is already in a transition
+func (cs *CredentialSpecResource) SetAppliedStatus(status resourcestatus.ResourceStatus) bool {
+	return false
+}
+
+// GetKnownStatus safely returns the currently known status of the task
+func (cs *CredentialSpecResource) GetKnownStatus() resourcestatus.ResourceStatus {
+	return resourcestatus.ResourceStatusNone
+}
+
+// StatusString returns the string of the cgroup resource status
+func (cs *CredentialSpecResource) StatusString(status resourcestatus.ResourceStatus) string {
+	return "undefined"
+}
+
+// SetCreatedAt sets the timestamp for resource's creation time
+func (cs *CredentialSpecResource) SetCreatedAt(createdAt time.Time) {
+}
+
+// GetCreatedAt sets the timestamp for resource's creation time
+func (cs *CredentialSpecResource) GetCreatedAt() time.Time {
+	return time.Time{}
+}
+
+// GetName safely returns the name of the resource
+func (cs *CredentialSpecResource) GetName() string {
+	return "undefined"
+}
+
+// Create is used to create all the credentialspec resources for a given task
+func (cs *CredentialSpecResource) Create() error {
+	return errors.New("not implemented")
+}
+
+func (cs *CredentialSpecResource) GetTargetMapping(credSpecInput string) (string, error) {
+	return "", errors.New("not implemented")
+}
+
+// Cleanup removes the credentialspec created for the task
+func (cs *CredentialSpecResource) Cleanup() error {
+	return errors.New("not implemented")
+}
+
+// MarshalJSON serialises the CredentialSpecResourceJSON struct to JSON
+func (cs *CredentialSpecResource) MarshalJSON() ([]byte, error) {
+	return nil, errors.New("not implemented")
+}
+
+// UnmarshalJSON deserialises the raw JSON to a CredentialSpecResourceJSON struct
+func (cs *CredentialSpecResource) UnmarshalJSON(b []byte) error {
+	return errors.New("not implemented")
+}

--- a/agent/taskresource/credentialspec/credentialspec_windows.go
+++ b/agent/taskresource/credentialspec/credentialspec_windows.go
@@ -1,0 +1,600 @@
+// +build windows
+
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package credentialspec
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	"github.com/aws/amazon-ecs-agent/agent/api/task/status"
+	"github.com/aws/amazon-ecs-agent/agent/credentials"
+	"github.com/aws/amazon-ecs-agent/agent/s3"
+	s3factory "github.com/aws/amazon-ecs-agent/agent/s3/factory"
+	"github.com/aws/amazon-ecs-agent/agent/ssm"
+	ssmfactory "github.com/aws/amazon-ecs-agent/agent/ssm/factory"
+	"github.com/aws/amazon-ecs-agent/agent/taskresource"
+	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
+	"github.com/aws/amazon-ecs-agent/agent/utils/ioutilwrapper"
+	"github.com/aws/amazon-ecs-agent/agent/utils/oswrapper"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/cihub/seelog"
+	"github.com/pkg/errors"
+)
+
+// CredentialSpecResource is the abstraction for credentialspec resources
+type CredentialSpecResource struct {
+	taskARN string
+	region  string
+
+	credentialsManager     credentials.Manager
+	executionCredentialsID string
+
+	ioutil ioutilwrapper.IOUtil
+	os     oswrapper.OS
+
+	createdAt           time.Time
+	desiredStatusUnsafe resourcestatus.ResourceStatus
+	knownStatusUnsafe   resourcestatus.ResourceStatus
+	// appliedStatus is the status that has been "applied" (e.g., we've called some
+	// operation such as 'Create' on the resource) but we don't yet know that the
+	// application was successful, which may then change the known status. This is
+	// used while progressing resource states in progressTask() of task manager
+	appliedStatus                      resourcestatus.ResourceStatus
+	resourceStatusToTransitionFunction map[resourcestatus.ResourceStatus]func() error
+
+	// terminalReason should be set for resource creation failures. This ensures
+	// the resource object carries some context for why provisioning failed.
+	terminalReason     string
+	terminalReasonOnce sync.Once
+
+	// ssmClientCreator is a factory interface that creates new SSM clients. This is
+	// needed mostly for testing.
+	ssmClientCreator ssmfactory.SSMClientCreator
+
+	// s3ClientCreator is a factory interface that creates new S3 clients. This is
+	// needed mostly for testing.
+	s3ClientCreator s3factory.S3ClientCreator
+
+	// credentialSpecResourceLocation is the location for all the tasks' credentialspec artifacts
+	credentialSpecResourceLocation string
+
+	// required for processing credentialspecs, key is input credentialspec
+	// Example key := credentialspec:file://credentialspec.json
+	requiredCredentialSpecs map[string][]*apicontainer.Container
+
+	// map to transform credentialspec values, key is a input credentialspec
+	// Examples:
+	// * key := credentialspec:file://credentialspec.json, value := credentialspec=file://credentialspec.json
+	// * key := credentialspec:s3ARN, value := credentialspec=file://CredentialSpecResourceLocation/s3_taskARN_fileName.json
+	// * key := credentialspec:ssmARN, value := credentialspec=file://CredentialSpecResourceLocation/ssm_taskARN_param.json
+	credSpecMap map[string]string
+
+	// lock is used for fields that are accessed and updated concurrently
+	lock sync.RWMutex
+}
+
+// NewCredentialSpecResource creates a new CredentialSpecResource object
+func NewCredentialSpecResource(taskARN, region string,
+	credentialSpecs map[string][]*apicontainer.Container,
+	executionCredentialsID string,
+	credentialsManager credentials.Manager,
+	ssmClientCreator ssmfactory.SSMClientCreator,
+	s3ClientCreator s3factory.S3ClientCreator) (*CredentialSpecResource, error) {
+
+	s := &CredentialSpecResource{
+		taskARN:                 taskARN,
+		region:                  region,
+		requiredCredentialSpecs: credentialSpecs,
+		credentialsManager:      credentialsManager,
+		executionCredentialsID:  executionCredentialsID,
+		ssmClientCreator:        ssmClientCreator,
+		s3ClientCreator:         s3ClientCreator,
+		credSpecMap:             make(map[string]string),
+	}
+
+	err := s.setCredentialSpecResourceLocation()
+	if err != nil {
+		return nil, err
+	}
+
+	s.initStatusToTransition()
+	return s, nil
+}
+
+func (cs *CredentialSpecResource) initStatusToTransition() {
+	resourceStatusToTransitionFunction := map[resourcestatus.ResourceStatus]func() error{
+		resourcestatus.ResourceStatus(CredentialSpecCreated): cs.Create,
+	}
+	cs.resourceStatusToTransitionFunction = resourceStatusToTransitionFunction
+}
+
+func (cs *CredentialSpecResource) Initialize(resourceFields *taskresource.ResourceFields,
+	taskKnownStatus status.TaskStatus,
+	taskDesiredStatus status.TaskStatus) {
+	cs.initStatusToTransition()
+	cs.credentialsManager = resourceFields.CredentialsManager
+	cs.ssmClientCreator = resourceFields.SSMClientCreator
+	cs.s3ClientCreator = resourceFields.S3ClientCreator
+
+	// if task hasn't turn to 'created' status, and it's desire status is 'running'
+	// the resource status needs to be reset to 'NONE' status so the cs value
+	// will be retrieved again
+	if taskKnownStatus < status.TaskCreated &&
+		taskDesiredStatus <= status.TaskRunning {
+		cs.SetKnownStatus(resourcestatus.ResourceStatusNone)
+	}
+}
+
+// GetTerminalReason returns an error string to propagate up through to task
+// state change messages
+func (cs *CredentialSpecResource) GetTerminalReason() string {
+	return cs.terminalReason
+}
+
+func (cs *CredentialSpecResource) setTerminalReason(reason string) {
+	cs.terminalReasonOnce.Do(func() {
+		seelog.Infof("credentialspec resource: setting terminal reason for credentialspec resource in task: [%s]", cs.taskARN)
+		cs.terminalReason = reason
+	})
+}
+
+// GetDesiredStatus safely returns the desired status of the task
+func (cs *CredentialSpecResource) GetDesiredStatus() resourcestatus.ResourceStatus {
+	cs.lock.RLock()
+	defer cs.lock.RUnlock()
+
+	return cs.desiredStatusUnsafe
+}
+
+// SetDesiredStatus safely sets the desired status of the resource
+func (cs *CredentialSpecResource) SetDesiredStatus(status resourcestatus.ResourceStatus) {
+	cs.lock.Lock()
+	defer cs.lock.Unlock()
+
+	cs.desiredStatusUnsafe = status
+}
+
+// DesiredTerminal returns true if the credentialspec's desired status is REMOVED
+func (cs *CredentialSpecResource) DesiredTerminal() bool {
+	cs.lock.RLock()
+	defer cs.lock.RUnlock()
+
+	return cs.desiredStatusUnsafe == resourcestatus.ResourceStatus(CredentialSpecRemoved)
+}
+
+// KnownCreated returns true if the credentialspec's known status is CREATED
+func (cs *CredentialSpecResource) KnownCreated() bool {
+	cs.lock.RLock()
+	defer cs.lock.RUnlock()
+
+	return cs.knownStatusUnsafe == resourcestatus.ResourceStatus(CredentialSpecCreated)
+}
+
+// TerminalStatus returns the last transition state of credentialspec
+func (cs *CredentialSpecResource) TerminalStatus() resourcestatus.ResourceStatus {
+	return resourcestatus.ResourceStatus(CredentialSpecRemoved)
+}
+
+// NextKnownState returns the state that the resource should
+// progress to based on its `KnownState`.
+func (cs *CredentialSpecResource) NextKnownState() resourcestatus.ResourceStatus {
+	return cs.GetKnownStatus() + 1
+}
+
+// ApplyTransition calls the function required to move to the specified status
+func (cs *CredentialSpecResource) ApplyTransition(nextState resourcestatus.ResourceStatus) error {
+	cs.lock.Lock()
+	defer cs.lock.Unlock()
+
+	transitionFunc, ok := cs.resourceStatusToTransitionFunction[nextState]
+	if !ok {
+		err := errors.Errorf("resource [%s]: transition to %s impossible", cs.GetName(),
+			cs.StatusString(nextState))
+		cs.setTerminalReason(err.Error())
+		return err
+	}
+
+	return transitionFunc()
+}
+
+// SteadyState returns the transition state of the resource defined as "ready"
+func (cs *CredentialSpecResource) SteadyState() resourcestatus.ResourceStatus {
+	return resourcestatus.ResourceStatus(CredentialSpecCreated)
+}
+
+// SetKnownStatus safely sets the currently known status of the resource
+func (cs *CredentialSpecResource) SetKnownStatus(status resourcestatus.ResourceStatus) {
+	cs.lock.Lock()
+	defer cs.lock.Unlock()
+
+	cs.knownStatusUnsafe = status
+	cs.updateAppliedStatusUnsafe(status)
+}
+
+// updateAppliedStatusUnsafe updates the resource transitioning status
+func (cs *CredentialSpecResource) updateAppliedStatusUnsafe(knownStatus resourcestatus.ResourceStatus) {
+	if cs.appliedStatus == resourcestatus.ResourceStatus(CredentialSpecStatusNone) {
+		return
+	}
+
+	// Check if the resource transition has already finished
+	if cs.appliedStatus <= knownStatus {
+		cs.appliedStatus = resourcestatus.ResourceStatus(CredentialSpecStatusNone)
+	}
+}
+
+// SetAppliedStatus sets the applied status of resource and returns whether
+// the resource is already in a transition
+func (cs *CredentialSpecResource) SetAppliedStatus(status resourcestatus.ResourceStatus) bool {
+	cs.lock.Lock()
+	defer cs.lock.Unlock()
+
+	if cs.appliedStatus != resourcestatus.ResourceStatus(CredentialSpecStatusNone) {
+		// return false to indicate the set operation failed
+		return false
+	}
+
+	cs.appliedStatus = status
+	return true
+}
+
+// GetKnownStatus safely returns the currently known status of the task
+func (cs *CredentialSpecResource) GetKnownStatus() resourcestatus.ResourceStatus {
+	cs.lock.RLock()
+	defer cs.lock.RUnlock()
+
+	return cs.knownStatusUnsafe
+}
+
+// StatusString returns the string of the cgroup resource status
+func (cs *CredentialSpecResource) StatusString(status resourcestatus.ResourceStatus) string {
+	return CredentialSpecStatus(status).String()
+}
+
+// SetCreatedAt sets the timestamp for resource's creation time
+func (cs *CredentialSpecResource) SetCreatedAt(createdAt time.Time) {
+	if createdAt.IsZero() {
+		return
+	}
+	cs.lock.Lock()
+	defer cs.lock.Unlock()
+
+	cs.createdAt = createdAt
+}
+
+// GetCreatedAt sets the timestamp for resource's creation time
+func (cs *CredentialSpecResource) GetCreatedAt() time.Time {
+	cs.lock.RLock()
+	defer cs.lock.RUnlock()
+
+	return cs.createdAt
+}
+
+// getRequiredCredentialSpecs returns the requiredCredentialSpecs field of credentialspec task resource
+func (cs *CredentialSpecResource) getRequiredCredentialSpecs() map[string][]*apicontainer.Container {
+	cs.lock.RLock()
+	defer cs.lock.RUnlock()
+
+	return cs.requiredCredentialSpecs
+}
+
+// getExecutionCredentialsID returns the execution role's credential ID
+func (cs *CredentialSpecResource) getExecutionCredentialsID() string {
+	cs.lock.RLock()
+	defer cs.lock.RUnlock()
+
+	return cs.executionCredentialsID
+}
+
+// GetName safely returns the name of the resource
+func (cs *CredentialSpecResource) GetName() string {
+	cs.lock.RLock()
+	defer cs.lock.RUnlock()
+
+	return ResourceName
+}
+
+// Create is used to create all the credentialspec resources for a given task
+func (cs *CredentialSpecResource) Create() error {
+	// To fail fast, check execution role first
+	executionCredentials, ok := cs.credentialsManager.GetTaskCredentials(cs.getExecutionCredentialsID())
+	if !ok {
+		// No need to log here. managedTask.applyResourceState already does that
+		err := errors.New("credentialspec resource: unable to find execution role credentials")
+		cs.setTerminalReason(err.Error())
+		return err
+	}
+	iamCredentials := executionCredentials.GetIAMRoleCredentials()
+
+	for credSpecStr, _ := range cs.requiredCredentialSpecs {
+		credSpecSplit := strings.SplitAfterN(credSpecStr, "credentialspec:", 2)
+		credSpecValue := credSpecSplit[1]
+
+		if strings.HasPrefix(credSpecValue, "file://") {
+			return cs.handleCredentialspecFile(credSpecStr)
+		}
+
+		parsedARN, err := arn.Parse(credSpecValue)
+		if err != nil {
+			cs.setTerminalReason(err.Error())
+			return err
+		}
+
+		parsedARNService := parsedARN.Service
+		if parsedARNService == "s3" {
+			return cs.handleS3CredentialspecFile(credSpecStr, credSpecValue, iamCredentials)
+		} else if parsedARNService == "ssm" {
+			return cs.handleSSMCredentialspecFile(credSpecStr, credSpecValue, iamCredentials)
+		} else {
+			err := errors.New("unsupported credentialspec ARN, only s3/ssm ARNs are valid")
+			cs.setTerminalReason(err.Error())
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (cs *CredentialSpecResource) handleCredentialspecFile(credentialspec string) error {
+	credSpecSplit := strings.SplitAfterN(credentialspec, "credentialspec:", 2)
+	credSpecFile := credSpecSplit[1]
+
+	if !strings.HasPrefix(credSpecFile, "file://") {
+		return errors.New("invalid credentialspec file specification")
+	}
+
+	dockerHostconfigSecOptCredSpec := strings.Replace(credentialspec, "credentialspec:", "credentialspec=", 1)
+	cs.updateCredSpecMapping(credentialspec, dockerHostconfigSecOptCredSpec)
+
+	return nil
+}
+
+func (cs *CredentialSpecResource) handleS3CredentialspecFile(originalCredentialspec, credentialspecS3ARN string, iamCredentials credentials.IAMRoleCredentials) error {
+	parsedARN, err := arn.Parse(credentialspecS3ARN)
+	if err != nil {
+		cs.setTerminalReason(err.Error())
+		return err
+	}
+
+	bucket, key, err := s3.ParseS3ARN(credentialspecS3ARN)
+	if err != nil {
+		cs.setTerminalReason(err.Error())
+		return err
+	}
+
+	s3Client, err := cs.s3ClientCreator.NewS3ClientForBucket(bucket, cs.region, iamCredentials)
+	if err != nil {
+		cs.setTerminalReason(err.Error())
+		return err
+	}
+
+	resourceBase := filepath.Base(parsedARN.Resource)
+	localCredSpecFilePath := fmt.Sprintf("%s/s3_%s_%s.json", cs.credentialSpecResourceLocation, cs.taskARN, resourceBase)
+
+	err = cs.writeS3File(func(file oswrapper.File) error {
+		return s3.DownloadFile(bucket, key, s3DownloadTimeout, file, s3Client)
+	}, localCredSpecFilePath)
+	if err != nil {
+		cs.setTerminalReason(err.Error())
+		return err
+	}
+
+	dockerHostconfigSecOptCredSpec := fmt.Sprintf("credentialspec=file://%s", localCredSpecFilePath)
+	cs.updateCredSpecMapping(originalCredentialspec, dockerHostconfigSecOptCredSpec)
+
+	return nil
+}
+
+func (cs *CredentialSpecResource) handleSSMCredentialspecFile(originalCredentialspec, credentialspecSSMARN string, iamCredentials credentials.IAMRoleCredentials) error {
+	parsedARN, err := arn.Parse(credentialspecSSMARN)
+	if err != nil {
+		cs.setTerminalReason(err.Error())
+		return err
+	}
+
+	ssmClient := cs.ssmClientCreator.NewSSMClient(cs.region, iamCredentials)
+
+	ssmParam := filepath.Base(parsedARN.Resource)
+	ssmParams := []string{ssmParam}
+
+	ssmParamMap, err := ssm.GetParametersFromSSM(ssmParams, ssmClient)
+	if err != nil {
+		cs.setTerminalReason(err.Error())
+		return err
+	}
+
+	ssmParamData := ssmParamMap[ssmParam]
+
+	localCredSpecFilePath := fmt.Sprintf("%s/ssm_%s_%s.json", cs.credentialSpecResourceLocation, cs.taskARN, ssmParam)
+
+	err = cs.writeSSMFile(ssmParamData, localCredSpecFilePath)
+	if err != nil {
+		cs.setTerminalReason(err.Error())
+		return err
+	}
+
+	dockerHostconfigSecOptCredSpec := fmt.Sprintf("credentialspec=file://%s", localCredSpecFilePath)
+	cs.updateCredSpecMapping(originalCredentialspec, dockerHostconfigSecOptCredSpec)
+
+	return nil
+}
+
+func (cs *CredentialSpecResource) writeS3File(writeFunc func(file oswrapper.File) error, filePath string) error {
+	temp, err := cs.ioutil.TempFile(cs.credentialSpecResourceLocation, tempFileName)
+	if err != nil {
+		return err
+	}
+	defer temp.Close()
+
+	err = writeFunc(temp)
+	if err != nil {
+		return err
+	}
+
+	err = temp.Chmod(os.FileMode(filePerm))
+	if err != nil {
+		return err
+	}
+
+	// Persist the file to disk.
+	err = temp.Sync()
+	if err != nil {
+		return err
+	}
+
+	err = cs.os.Rename(temp.Name(), filePath)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (cs *CredentialSpecResource) writeSSMFile(ssmParamData, filePath string) error {
+	return cs.ioutil.WriteFile(filePath, []byte(ssmParamData), filePerm)
+}
+
+func (cs *CredentialSpecResource) getCredSpecMap() map[string]string {
+	cs.lock.RLock()
+	defer cs.lock.RUnlock()
+
+	return cs.credSpecMap
+}
+
+func (cs *CredentialSpecResource) GetTargetMapping(credSpecInput string) (string, error) {
+	cs.lock.RLock()
+	defer cs.lock.RUnlock()
+
+	targetCredSpecMapping, ok := cs.credSpecMap[credSpecInput]
+	if !ok {
+		return "", errors.New("unable to obtain credentialspec mapping")
+	}
+
+	return targetCredSpecMapping, nil
+}
+
+func (cs *CredentialSpecResource) updateCredSpecMapping(credSpecInput, targetCredSpec string) {
+	cs.lock.Lock()
+	defer cs.lock.Unlock()
+
+	cs.credSpecMap[credSpecInput] = targetCredSpec
+}
+
+// Cleanup removes the credentialspec created for the task
+func (cs *CredentialSpecResource) Cleanup() error {
+	cs.clearCredentialSpec()
+	return nil
+}
+
+// clearCredentialSpec cycles through the collection of credentialspec data and
+// removes them from the task
+func (cs *CredentialSpecResource) clearCredentialSpec() {
+	cs.lock.Lock()
+	defer cs.lock.Unlock()
+
+	for key := range cs.credSpecMap {
+		// TODO: Cleanup file on container instance (optional)
+		delete(cs.credSpecMap, key)
+	}
+}
+
+// CredentialSpecResourceJSON is the json representation of the credentialspec resource
+type CredentialSpecResourceJSON struct {
+	TaskARN                 string                               `json:"taskARN"`
+	CreatedAt               *time.Time                           `json:"createdAt,omitempty"`
+	DesiredStatus           *CredentialSpecStatus                `json:"desiredStatus"`
+	KnownStatus             *CredentialSpecStatus                `json:"knownStatus"`
+	RequiredCredentialSpecs map[string][]*apicontainer.Container `json:"credentialSpecResources"`
+	CredSpecMap             map[string]string                    `json:"credSpecMap"`
+	ExecutionCredentialsID  string                               `json:"executionCredentialsID"`
+}
+
+// MarshalJSON serialises the CredentialSpecResourceJSON struct to JSON
+func (cs *CredentialSpecResource) MarshalJSON() ([]byte, error) {
+	if cs == nil {
+		return nil, errors.New("credential specresource is nil")
+	}
+	createdAt := cs.GetCreatedAt()
+	return json.Marshal(CredentialSpecResourceJSON{
+		TaskARN:   cs.taskARN,
+		CreatedAt: &createdAt,
+		DesiredStatus: func() *CredentialSpecStatus {
+			desiredState := cs.GetDesiredStatus()
+			s := CredentialSpecStatus(desiredState)
+			return &s
+		}(),
+		KnownStatus: func() *CredentialSpecStatus {
+			knownState := cs.GetKnownStatus()
+			s := CredentialSpecStatus(knownState)
+			return &s
+		}(),
+		RequiredCredentialSpecs: cs.getRequiredCredentialSpecs(),
+		CredSpecMap:             cs.getCredSpecMap(),
+		ExecutionCredentialsID:  cs.getExecutionCredentialsID(),
+	})
+}
+
+// UnmarshalJSON deserialises the raw JSON to a CredentialSpecResourceJSON struct
+func (cs *CredentialSpecResource) UnmarshalJSON(b []byte) error {
+	temp := CredentialSpecResourceJSON{}
+
+	if err := json.Unmarshal(b, &temp); err != nil {
+		return err
+	}
+
+	if temp.DesiredStatus != nil {
+		cs.SetDesiredStatus(resourcestatus.ResourceStatus(*temp.DesiredStatus))
+	}
+	if temp.KnownStatus != nil {
+		cs.SetKnownStatus(resourcestatus.ResourceStatus(*temp.KnownStatus))
+	}
+	if temp.CreatedAt != nil && !temp.CreatedAt.IsZero() {
+		cs.SetCreatedAt(*temp.CreatedAt)
+	}
+	if temp.RequiredCredentialSpecs != nil {
+		cs.requiredCredentialSpecs = temp.RequiredCredentialSpecs
+	}
+	cs.taskARN = temp.TaskARN
+	cs.executionCredentialsID = temp.ExecutionCredentialsID
+
+	return nil
+}
+
+func (cs *CredentialSpecResource) setCredentialSpecResourceLocation() error {
+	// TODO: Use registry
+	// This should always be available on Windows instances
+	appDataDir := os.Getenv("APPDATA")
+	if appDataDir != "" {
+		cs.credentialSpecResourceLocation = appDataDir
+	} else {
+		tempDir := os.Getenv("TEMP")
+		if tempDir != "" {
+			cs.credentialSpecResourceLocation = tempDir
+		}
+	}
+
+	if cs.credentialSpecResourceLocation == "" {
+		return errors.New("credentialspec resource location not available")
+	}
+
+	return nil
+}

--- a/agent/taskresource/credentialspec/credentialspec_windows_test.go
+++ b/agent/taskresource/credentialspec/credentialspec_windows_test.go
@@ -1,0 +1,110 @@
+// +build windows,unit
+
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package credentialspec
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	apitaskstatus "github.com/aws/amazon-ecs-agent/agent/api/task/status"
+	mock_credentials "github.com/aws/amazon-ecs-agent/agent/credentials/mocks"
+	mock_s3_factory "github.com/aws/amazon-ecs-agent/agent/s3/factory/mocks"
+	mock_factory "github.com/aws/amazon-ecs-agent/agent/ssm/factory/mocks"
+	"github.com/aws/amazon-ecs-agent/agent/taskresource"
+	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
+)
+
+const (
+	taskARN                = "task1"
+	executionCredentialsID = "exec-creds-id"
+)
+
+func TestClearCredentialSpecData(t *testing.T) {
+	credSpecMapData := map[string]string{
+		"credentialspec:file://localfilePath.json": "credentialspec:file://localfilePath.json",
+		"credentialspec:s3ARN":                     "credentialspec=file://ResourceDir/s3_taskARN_fileName.json",
+		"credentialspec:ssmARN":                    "credentialspec=file://ResourceDir/ssm_taskARN_fileName.json",
+	}
+
+	credspecRes := &CredentialSpecResource{
+		credSpecMap: credSpecMapData,
+	}
+
+	err := credspecRes.Cleanup()
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(credspecRes.credSpecMap))
+}
+
+func TestInitialize(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	credentialsManager := mock_credentials.NewMockManager(ctrl)
+	ssmClientCreator := mock_factory.NewMockSSMClientCreator(ctrl)
+	s3ClientCreator := mock_s3_factory.NewMockS3ClientCreator(ctrl)
+	credspecRes := &CredentialSpecResource{
+		knownStatusUnsafe:   resourcestatus.ResourceCreated,
+		desiredStatusUnsafe: resourcestatus.ResourceCreated,
+	}
+	credspecRes.Initialize(&taskresource.ResourceFields{
+		ResourceFieldsCommon: &taskresource.ResourceFieldsCommon{
+			SSMClientCreator:   ssmClientCreator,
+			S3ClientCreator:    s3ClientCreator,
+			CredentialsManager: credentialsManager,
+		},
+	}, apitaskstatus.TaskStatusNone, apitaskstatus.TaskRunning)
+	assert.Equal(t, resourcestatus.ResourceStatusNone, credspecRes.GetKnownStatus())
+	assert.Equal(t, resourcestatus.ResourceCreated, credspecRes.GetDesiredStatus())
+
+}
+
+func TestMarshalUnmarshalJSON(t *testing.T) {
+	requiredCredentialSpecs := make(map[string][]*apicontainer.Container)
+	testCredSpec := "credentialspec:file://test.json"
+	testContainer := &apicontainer.Container{
+		Name: "test-container",
+	}
+
+	requiredCredentialSpecs[testCredSpec] = append(requiredCredentialSpecs[testCredSpec], testContainer)
+
+	credspecIn := &CredentialSpecResource{
+		taskARN:                 taskARN,
+		executionCredentialsID:  executionCredentialsID,
+		createdAt:               time.Now(),
+		knownStatusUnsafe:       resourcestatus.ResourceCreated,
+		desiredStatusUnsafe:     resourcestatus.ResourceCreated,
+		requiredCredentialSpecs: requiredCredentialSpecs,
+	}
+
+	bytes, err := json.Marshal(credspecIn)
+	require.NoError(t, err)
+
+	credSpecOut := &CredentialSpecResource{}
+	err = json.Unmarshal(bytes, credSpecOut)
+	require.NoError(t, err)
+	assert.Equal(t, credspecIn.taskARN, credSpecOut.taskARN)
+	assert.WithinDuration(t, credspecIn.createdAt, credSpecOut.createdAt, time.Microsecond)
+	assert.Equal(t, credspecIn.desiredStatusUnsafe, credSpecOut.desiredStatusUnsafe)
+	assert.Equal(t, credspecIn.knownStatusUnsafe, credSpecOut.knownStatusUnsafe)
+	assert.Equal(t, credspecIn.executionCredentialsID, credSpecOut.executionCredentialsID)
+	assert.Equal(t, len(credspecIn.requiredCredentialSpecs), len(credSpecOut.requiredCredentialSpecs))
+}

--- a/agent/taskresource/credentialspec/credentialspecstatus.go
+++ b/agent/taskresource/credentialspec/credentialspecstatus.go
@@ -1,0 +1,78 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package credentialspec
+
+import (
+	"errors"
+	"strings"
+
+	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
+)
+
+type CredentialSpecStatus resourcestatus.ResourceStatus
+
+const (
+	// is the zero state of a task resource
+	CredentialSpecStatusNone CredentialSpecStatus = iota
+	// represents a task resource which has been created
+	CredentialSpecCreated
+	// represents a task resource which has been cleaned up
+	CredentialSpecRemoved
+)
+
+var CredentialSpecStatusMap = map[string]CredentialSpecStatus{
+	"NONE":    CredentialSpecStatusNone,
+	"CREATED": CredentialSpecCreated,
+	"REMOVED": CredentialSpecRemoved,
+}
+
+// StatusString returns a human readable string representation of this object
+func (cs CredentialSpecStatus) String() string {
+	for k, v := range CredentialSpecStatusMap {
+		if v == cs {
+			return k
+		}
+	}
+	return "NONE"
+}
+
+// MarshalJSON overrides the logic for JSON-encoding the ResourceStatus type
+func (cs *CredentialSpecStatus) MarshalJSON() ([]byte, error) {
+	if cs == nil {
+		return nil, errors.New("credentialspec resource status is nil")
+	}
+	return []byte(`"` + cs.String() + `"`), nil
+}
+
+// UnmarshalJSON overrides the logic for parsing the JSON-encoded ResourceStatus data
+func (cs *CredentialSpecStatus) UnmarshalJSON(b []byte) error {
+	if strings.ToLower(string(b)) == "null" {
+		*cs = CredentialSpecStatusNone
+		return nil
+	}
+
+	if b[0] != '"' || b[len(b)-1] != '"' {
+		*cs = CredentialSpecStatusNone
+		return errors.New("resource status unmarshal: status must be a string or null; Got " + string(b))
+	}
+
+	strStatus := string(b[1 : len(b)-1])
+	stat, ok := CredentialSpecStatusMap[strStatus]
+	if !ok {
+		*cs = CredentialSpecStatusNone
+		return errors.New("resource status unmarshal: unrecognized status")
+	}
+	*cs = stat
+	return nil
+}

--- a/agent/taskresource/credentialspec/credentialspecstatus_test.go
+++ b/agent/taskresource/credentialspec/credentialspecstatus_test.go
@@ -1,0 +1,155 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package credentialspec
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStatusString(t *testing.T) {
+	cases := []struct {
+		Name                    string
+		InCredentialSpecStatus  CredentialSpecStatus
+		OutCredentialSpecStatus string
+	}{
+		{
+			Name:                    "ToStringCredentialSpecStatusNone",
+			InCredentialSpecStatus:  CredentialSpecStatusNone,
+			OutCredentialSpecStatus: "NONE",
+		},
+		{
+			Name:                    "ToStringCredentialSpecCreated",
+			InCredentialSpecStatus:  CredentialSpecCreated,
+			OutCredentialSpecStatus: "CREATED",
+		},
+		{
+			Name:                    "ToStringCredentialSpecRemoved",
+			InCredentialSpecStatus:  CredentialSpecRemoved,
+			OutCredentialSpecStatus: "REMOVED",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			assert.Equal(t, c.OutCredentialSpecStatus, c.InCredentialSpecStatus.String())
+		})
+	}
+}
+
+func TestMarshalNilCredentialSpecStatus(t *testing.T) {
+	var status *CredentialSpecStatus
+	bytes, err := status.MarshalJSON()
+
+	assert.Nil(t, bytes)
+	assert.Error(t, err)
+}
+
+func TestMarshalCredentialSpecStatus(t *testing.T) {
+	cases := []struct {
+		Name                    string
+		InCredentialSpecStatus  CredentialSpecStatus
+		OutCredentialSpecStatus string
+	}{
+		{
+			Name:                    "ToStringCredentialSpecStatusNone",
+			InCredentialSpecStatus:  CredentialSpecStatusNone,
+			OutCredentialSpecStatus: "\"NONE\"",
+		},
+		{
+			Name:                    "ToStringCredentialSpecCreated",
+			InCredentialSpecStatus:  CredentialSpecCreated,
+			OutCredentialSpecStatus: "\"CREATED\"",
+		},
+		{
+			Name:                    "ToStringCredentialSpecRemoved",
+			InCredentialSpecStatus:  CredentialSpecRemoved,
+			OutCredentialSpecStatus: "\"REMOVED\"",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			bytes, err := c.InCredentialSpecStatus.MarshalJSON()
+
+			assert.NoError(t, err)
+			assert.Equal(t, c.OutCredentialSpecStatus, string(bytes[:]))
+		})
+	}
+
+}
+
+func TestUnmarshalSSMSecretStatus(t *testing.T) {
+	cases := []struct {
+		Name                    string
+		InCredentialSpecStatus  string
+		OutCredentialSpecStatus CredentialSpecStatus
+		ShouldError             bool
+	}{
+		{
+			Name:                    "UnmarshallCredentialSpecStatusNoneNone",
+			InCredentialSpecStatus:  "\"NONE\"",
+			OutCredentialSpecStatus: CredentialSpecStatusNone,
+			ShouldError:             false,
+		},
+		{
+			Name:                    "UnmarshallCredentialSpecCreated",
+			InCredentialSpecStatus:  "\"CREATED\"",
+			OutCredentialSpecStatus: CredentialSpecCreated,
+			ShouldError:             false,
+		},
+		{
+			Name:                    "UnmarshallCredentialSpecRemoved",
+			InCredentialSpecStatus:  "\"REMOVED\"",
+			OutCredentialSpecStatus: CredentialSpecRemoved,
+			ShouldError:             false,
+		},
+		{
+			Name:                    "UnmarshallCredentialSpecStatusNull",
+			InCredentialSpecStatus:  "null",
+			OutCredentialSpecStatus: CredentialSpecStatusNone,
+			ShouldError:             false,
+		},
+		{
+			Name:                    "UnmarshallCredentialSpecStatusNonString",
+			InCredentialSpecStatus:  "1",
+			OutCredentialSpecStatus: CredentialSpecStatusNone,
+			ShouldError:             true,
+		},
+		{
+			Name:                    "UnmarshallCredentialSpecUnmappedStatus",
+			InCredentialSpecStatus:  "\"LOL\"",
+			OutCredentialSpecStatus: CredentialSpecStatusNone,
+			ShouldError:             true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+
+			var status CredentialSpecStatus
+			err := json.Unmarshal([]byte(c.InCredentialSpecStatus), &status)
+
+			if c.ShouldError {
+				assert.Error(t, err)
+			} else {
+
+				assert.NoError(t, err)
+				assert.Equal(t, c.OutCredentialSpecStatus, status)
+			}
+		})
+	}
+}

--- a/agent/taskresource/credentialspec/types.go
+++ b/agent/taskresource/credentialspec/types.go
@@ -1,0 +1,28 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package credentialspec
+
+import "time"
+
+const (
+	// ResourceName is the name of the credentialspec resource
+	ResourceName = "credentialspec"
+
+	tempFileName = "temp_file"
+
+	// filePerm is the permission for the credentialspec file.
+	filePerm = 0755
+
+	s3DownloadTimeout = 30 * time.Second
+)

--- a/agent/taskresource/types/types.go
+++ b/agent/taskresource/types/types.go
@@ -21,6 +21,7 @@ import (
 	asmauthres "github.com/aws/amazon-ecs-agent/agent/taskresource/asmauth"
 	asmsecretres "github.com/aws/amazon-ecs-agent/agent/taskresource/asmsecret"
 	cgroupres "github.com/aws/amazon-ecs-agent/agent/taskresource/cgroup"
+	"github.com/aws/amazon-ecs-agent/agent/taskresource/credentialspec"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/firelens"
 	ssmsecretres "github.com/aws/amazon-ecs-agent/agent/taskresource/ssmsecret"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/volume"
@@ -39,6 +40,8 @@ const (
 	ASMSecretKey = asmsecretres.ResourceName
 	// FirelensKey is the string used in resources map to represent firelens resource
 	FirelensKey = firelens.ResourceName
+	// CredentialSpecKey is the string used in resources map to represent credentialspec resource
+	CredentialSpecKey = credentialspec.ResourceName
 )
 
 // ResourcesMap represents the map of resource type to the corresponding resource
@@ -76,6 +79,8 @@ func unmarshalResource(key string, value json.RawMessage, result map[string][]ta
 		return unmarshalASMSecretKey(key, value, result)
 	case FirelensKey:
 		return unmarshalFirelensKey(key, value, result)
+	case CredentialSpecKey:
+		return unmarshalCredentialSpecKey(key, value, result)
 	default:
 		return errors.New("Unsupported resource type")
 	}
@@ -183,6 +188,24 @@ func unmarshalFirelensKey(key string, value json.RawMessage, result map[string][
 			return err
 		}
 
+		result[key] = append(result[key], res)
+	}
+	return nil
+}
+
+func unmarshalCredentialSpecKey(key string, value json.RawMessage, result map[string][]taskresource.TaskResource) error {
+	var credentialSpecs []json.RawMessage
+	err := json.Unmarshal(value, &credentialSpecs)
+	if err != nil {
+		return err
+	}
+
+	for _, credSpec := range credentialSpecs {
+		res := &credentialspec.CredentialSpecResource{}
+		err := res.UnmarshalJSON(credSpec)
+		if err != nil {
+			return err
+		}
 		result[key] = append(result[key], res)
 	}
 	return nil

--- a/agent/taskresource/types_common.go
+++ b/agent/taskresource/types_common.go
@@ -16,6 +16,7 @@ package taskresource
 import (
 	asmfactory "github.com/aws/amazon-ecs-agent/agent/asm/factory"
 	"github.com/aws/amazon-ecs-agent/agent/credentials"
+	s3factory "github.com/aws/amazon-ecs-agent/agent/s3/factory"
 	ssmfactory "github.com/aws/amazon-ecs-agent/agent/ssm/factory"
 	"github.com/aws/amazon-ecs-agent/agent/utils/ioutilwrapper"
 )
@@ -24,6 +25,7 @@ type ResourceFieldsCommon struct {
 	IOUtil             ioutilwrapper.IOUtil
 	ASMClientCreator   asmfactory.ClientCreator
 	SSMClientCreator   ssmfactory.SSMClientCreator
+	S3ClientCreator    s3factory.S3ClientCreator
 	CredentialsManager credentials.Manager
 	EC2InstanceID      string
 }


### PR DESCRIPTION
This patch introduces a new task level resource called credentialspec.
During task unmarshal, a task level dependency is established.

The credentialspec option is injected into the containers' hostConfig
prior to creation using the runtime interface.

Signed-off-by: Vinothkumar Siddharth <sidvin@amazon.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
