### PR TITLE
Update load image timeout based on benchmarking

### DIFF
--- a/agent/dockerclient/timeout.go
+++ b/agent/dockerclient/timeout.go
@@ -23,10 +23,14 @@ const (
 	ListImagesTimeout = 10 * time.Minute
 	// LoadImageTimeout is the timeout for the LoadImage API. It's set
 	// to much lower value than pullImageTimeout as it involves loading
-	// image from either a file or STDIN
-	// calls involved.
-	// TODO: Benchmark and re-evaluate this value
-	LoadImageTimeout = 10 * time.Minute
+	// image from either a file or STDIN calls involved.
+	// This value is set based on benchmarking the time of loading the pause container image,
+	// since it's currently only used to load that image. If this is to be used to load any
+	// other image in the future, additional benchmarking will be required.
+	// Per benchmark, 2 min is roughly 4x of the worst case (29s) across 400 image loads on
+	// al1/al2/al2gpu/al2arm with smallest instance type available (t2.nano/a1.medium) and
+	// burst balance = 0.
+	LoadImageTimeout = 2 * time.Minute
 	// RemoveImageTimeout is the timeout for the RemoveImage API.
 	RemoveImageTimeout = 3 * time.Minute
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Update load image timeout based on benchmarking. See [this comment](https://github.com/aws/amazon-ecs-agent/issues/844#issuecomment-551213644) for the benchmarking.

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> n/a

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
