### PR TITLE
Binding metadata directory in Z mode for selinux enabled docker

### DIFF
--- a/agent/containermetadata/manager.go
+++ b/agent/containermetadata/manager.go
@@ -42,7 +42,7 @@ type Manager interface {
 	SetAvailabilityZone(string)
 	SetHostPrivateIPv4Address(string)
 	SetHostPublicIPv4Address(string)
-	Create(*dockercontainer.Config, *dockercontainer.HostConfig, *apitask.Task, string) error
+	Create(*dockercontainer.Config, *dockercontainer.HostConfig, *apitask.Task, string, []string) error
 	Update(context.Context, string, *apitask.Task, string) error
 	Clean(string) error
 }
@@ -113,7 +113,8 @@ func (manager *metadataManager) SetHostPublicIPv4Address(ipv4address string) {
 // Create creates the metadata file and adds the metadata directory to
 // the container's mounted host volumes
 // Pointer hostConfig is modified directly so there is risk of concurrency errors.
-func (manager *metadataManager) Create(config *dockercontainer.Config, hostConfig *dockercontainer.HostConfig, task *apitask.Task, containerName string) error {
+func (manager *metadataManager) Create(config *dockercontainer.Config, hostConfig *dockercontainer.HostConfig,
+	task *apitask.Task, containerName string, dockerSecurityOptions []string) error {
 	// Create task and container directories if they do not yet exist
 	metadataDirectoryPath, err := getMetadataFilePath(task.Arn, containerName, manager.dataDir)
 	// Stop metadata creation if path is malformed for any reason
@@ -135,7 +136,7 @@ func (manager *metadataManager) Create(config *dockercontainer.Config, hostConfi
 
 	// Add the directory of this container's metadata to the container's mount binds
 	// Then add the destination directory as an environment variable in the container $METADATA
-	binds, env := createBindsEnv(hostConfig.Binds, config.Env, manager.dataDirOnHost, metadataDirectoryPath)
+	binds, env := createBindsEnv(hostConfig.Binds, config.Env, manager.dataDirOnHost, metadataDirectoryPath, dockerSecurityOptions)
 	config.Env = env
 	hostConfig.Binds = binds
 	return nil

--- a/agent/containermetadata/manager_test.go
+++ b/agent/containermetadata/manager_test.go
@@ -102,9 +102,10 @@ func TestCreateMalformedFilepath(t *testing.T) {
 	mockTaskARN := invalidTaskARN
 	mockTask := &apitask.Task{Arn: mockTaskARN}
 	mockContainerName := containerName
+	mockDockerSecurityOptions := types.Info{SecurityOptions: make([]string, 0)}.SecurityOptions
 
 	newManager := &metadataManager{}
-	err := newManager.Create(nil, nil, mockTask, mockContainerName)
+	err := newManager.Create(nil, nil, mockTask, mockContainerName, mockDockerSecurityOptions)
 	assert.Error(t, err)
 }
 
@@ -116,6 +117,7 @@ func TestCreateMkdirAllFail(t *testing.T) {
 	mockTaskARN := validTaskARN
 	mockTask := &apitask.Task{Arn: mockTaskARN}
 	mockContainerName := containerName
+	mockDockerSecurityOptions := types.Info{SecurityOptions: make([]string, 0)}.SecurityOptions
 
 	gomock.InOrder(
 		mockOS.EXPECT().MkdirAll(gomock.Any(), gomock.Any()).Return(errors.New("err")),
@@ -124,7 +126,7 @@ func TestCreateMkdirAllFail(t *testing.T) {
 	newManager := &metadataManager{
 		osWrap: mockOS,
 	}
-	err := newManager.Create(nil, nil, mockTask, mockContainerName)
+	err := newManager.Create(nil, nil, mockTask, mockContainerName, mockDockerSecurityOptions)
 	assert.Error(t, err)
 }
 

--- a/agent/containermetadata/manager_unix_test.go
+++ b/agent/containermetadata/manager_unix_test.go
@@ -38,6 +38,7 @@ func TestCreate(t *testing.T) {
 	mockContainerName := containerName
 	mockConfig := &dockercontainer.Config{Env: make([]string, 0)}
 	mockHostConfig := &dockercontainer.HostConfig{Binds: make([]string, 0)}
+	mockDockerSecurityOptions := types.Info{SecurityOptions: make([]string, 0)}.SecurityOptions
 
 	gomock.InOrder(
 		mockOS.EXPECT().MkdirAll(gomock.Any(), gomock.Any()).Return(nil),
@@ -53,7 +54,7 @@ func TestCreate(t *testing.T) {
 		osWrap:     mockOS,
 		ioutilWrap: mockIOUtil,
 	}
-	err := newManager.Create(mockConfig, mockHostConfig, mockTask, mockContainerName)
+	err := newManager.Create(mockConfig, mockHostConfig, mockTask, mockContainerName, mockDockerSecurityOptions)
 
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(mockConfig.Env), "Unexpected number of environment variables in config")

--- a/agent/containermetadata/manager_windows_test.go
+++ b/agent/containermetadata/manager_windows_test.go
@@ -38,6 +38,7 @@ func TestCreate(t *testing.T) {
 	mockContainerName := containerName
 	mockConfig := &dockercontainer.Config{Env: make([]string, 0)}
 	mockHostConfig := &dockercontainer.HostConfig{Binds: make([]string, 0)}
+	mockDockerSecurityOptions := types.Info{SecurityOptions: make([]string, 0)}.SecurityOptions
 
 	gomock.InOrder(
 		mockOS.EXPECT().MkdirAll(gomock.Any(), gomock.Any()).Return(nil),
@@ -50,7 +51,7 @@ func TestCreate(t *testing.T) {
 	newManager := &metadataManager{
 		osWrap: mockOS,
 	}
-	err := newManager.Create(mockConfig, mockHostConfig, mockTask, mockContainerName)
+	err := newManager.Create(mockConfig, mockHostConfig, mockTask, mockContainerName, mockDockerSecurityOptions)
 
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(mockConfig.Env), "Unexpected number of environment variables in config")

--- a/agent/containermetadata/mocks/containermetadata_mocks.go
+++ b/agent/containermetadata/mocks/containermetadata_mocks.go
@@ -67,17 +67,17 @@ func (mr *MockManagerMockRecorder) Clean(arg0 interface{}) *gomock.Call {
 }
 
 // Create mocks base method
-func (m *MockManager) Create(arg0 *container.Config, arg1 *container.HostConfig, arg2 *task.Task, arg3 string) error {
+func (m *MockManager) Create(arg0 *container.Config, arg1 *container.HostConfig, arg2 *task.Task, arg3 string, arg4 []string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Create", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "Create", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Create indicates an expected call of Create
-func (mr *MockManagerMockRecorder) Create(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockManagerMockRecorder) Create(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockManager)(nil).Create), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockManager)(nil).Create), arg0, arg1, arg2, arg3, arg4)
 }
 
 // SetAvailabilityZone mocks base method

--- a/agent/containermetadata/write_metadata_unix.go
+++ b/agent/containermetadata/write_metadata_unix.go
@@ -22,20 +22,34 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/utils/ioutilwrapper"
 	"github.com/aws/amazon-ecs-agent/agent/utils/oswrapper"
 
+	"github.com/cihub/seelog"
 	"github.com/pborman/uuid"
 )
 
 const (
-	mountPoint = "/opt/ecs/metadata"
-	tempFile   = "temp_metadata_file"
+	mountPoint            = "/opt/ecs/metadata"
+	tempFile              = "temp_metadata_file"
+	bindMode              = "Z"
+	selinuxSecurityOption = "selinux"
 )
 
 // createBindsEnv will do the appropriate formatting to add a new mount in a container's HostConfig
 // and add the metadata file path as an environment variable ECS_CONTAINER_METADATA_FILE
 // We add an additional uuid to the path to ensure it does not conflict with user mounts
-func createBindsEnv(binds []string, env []string, dataDirOnHost string, metadataDirectoryPath string) ([]string, []string) {
+func createBindsEnv(binds []string, env []string, dataDirOnHost string, metadataDirectoryPath string, dockerSecurityOptions []string) ([]string, []string) {
+	selinuxEnabled := false
+	for _, option := range dockerSecurityOptions {
+		if option == selinuxSecurityOption {
+			selinuxEnabled = true
+		}
+	}
+
 	randID := uuid.New()
 	instanceBind := fmt.Sprintf(`%s/%s:%s/%s`, dataDirOnHost, metadataDirectoryPath, mountPoint, randID)
+	if selinuxEnabled {
+		seelog.Info("Selinux is enabled on docker, mounting data directory in Z mode")
+		instanceBind = fmt.Sprintf(`%s:%s`, instanceBind, bindMode)
+	}
 	metadataEnvVariable := fmt.Sprintf("%s=%s/%s/%s", metadataEnvironmentVariable, mountPoint, randID, metadataFile)
 	binds = append(binds, instanceBind)
 	env = append(env, metadataEnvVariable)

--- a/agent/containermetadata/write_metadata_unix_test.go
+++ b/agent/containermetadata/write_metadata_unix_test.go
@@ -17,6 +17,7 @@ package containermetadata
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -89,4 +90,41 @@ func TestWriteChmodFail(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Equal(t, expectErrorMessage, err.Error())
+}
+
+func TestCreateBindEnv(t *testing.T) {
+	mockBinds := []string{}
+	mockEnv := []string{}
+	mockDataDirOnHost := ""
+	mockMetadataDirectoryPath := ""
+	expectedBindMode := fmt.Sprintf(`:%s`, bindMode)
+
+	testcases := []struct {
+		name            string
+		securityOptions []string
+		selinuxEnabled  bool
+	}{
+		{
+			name:            "Selinux Enabled Bind Mode",
+			securityOptions: []string{"selinux"},
+			selinuxEnabled:  true,
+		},
+		{
+			name:            "Selinux Disabled Bind Mode",
+			securityOptions: []string{""},
+			selinuxEnabled:  false,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			binds, _ := createBindsEnv(mockBinds, mockEnv, mockDataDirOnHost, mockMetadataDirectoryPath, tc.securityOptions)
+			actualBindMode := binds[0][len(binds[0])-2:]
+			if tc.selinuxEnabled {
+				assert.Equal(t, expectedBindMode, actualBindMode)
+			} else {
+				assert.NotEqual(t, expectedBindMode, actualBindMode)
+			}
+		})
+	}
 }

--- a/agent/containermetadata/write_metadata_windows.go
+++ b/agent/containermetadata/write_metadata_windows.go
@@ -32,7 +32,7 @@ const (
 
 // createBindsEnv will do the appropriate formatting to add a new mount in a container's HostConfig
 // and add the metadata file path as an environment variable ECS_CONTAINER_METADATA_FILE
-func createBindsEnv(binds []string, env []string, dataDirOnHost string, metadataDirectoryPath string) ([]string, []string) {
+func createBindsEnv(binds []string, env []string, dataDirOnHost string, metadataDirectoryPath string, dockerSecurityOptions []string) ([]string, []string) {
 	randID := uuid.New()
 	instanceBind := fmt.Sprintf(`%s:%s\%s`, metadataDirectoryPath, mountPoint, randID)
 	metadataEnvVariable := fmt.Sprintf(`%s=%s\%s\%s`, metadataEnvironmentVariable, mountPoint, randID, metadataFile)

--- a/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
+++ b/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
@@ -130,6 +130,21 @@ func (mr *MockDockerClientMockRecorder) DescribeContainer(arg0, arg1 interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeContainer", reflect.TypeOf((*MockDockerClient)(nil).DescribeContainer), arg0, arg1)
 }
 
+// Info mocks base method
+func (m *MockDockerClient) Info(arg0 context.Context, arg1 time.Duration) (types.Info, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Info", arg0, arg1)
+	ret0, _ := ret[0].(types.Info)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Info indicates an expected call of Info
+func (mr *MockDockerClientMockRecorder) Info(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Info", reflect.TypeOf((*MockDockerClient)(nil).Info), arg0, arg1)
+}
+
 // InspectContainer mocks base method
 func (m *MockDockerClient) InspectContainer(arg0 context.Context, arg1 string, arg2 time.Duration) (*types.ContainerJSON, error) {
 	m.ctrl.T.Helper()

--- a/agent/dockerclient/sdkclient/interface.go
+++ b/agent/dockerclient/sdkclient/interface.go
@@ -55,4 +55,5 @@ type Client interface {
 	VolumeInspect(ctx context.Context, volumeID string) (types.Volume, error)
 	VolumeRemove(ctx context.Context, volumeID string, force bool) error
 	ServerVersion(ctx context.Context) (types.Version, error)
+	Info(ctx context.Context) (types.Info, error)
 }

--- a/agent/dockerclient/sdkclient/mocks/sdkclient_mocks.go
+++ b/agent/dockerclient/sdkclient/mocks/sdkclient_mocks.go
@@ -278,6 +278,21 @@ func (mr *MockClientMockRecorder) ImageRemove(arg0, arg1, arg2 interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImageRemove", reflect.TypeOf((*MockClient)(nil).ImageRemove), arg0, arg1, arg2)
 }
 
+// Info mocks base method
+func (m *MockClient) Info(arg0 context.Context) (types.Info, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Info", arg0)
+	ret0, _ := ret[0].(types.Info)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Info indicates an expected call of Info
+func (mr *MockClientMockRecorder) Info(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Info", reflect.TypeOf((*MockClient)(nil).Info), arg0)
+}
+
 // Ping mocks base method
 func (m *MockClient) Ping(arg0 context.Context) (types.Ping, error) {
 	m.ctrl.T.Helper()

--- a/agent/dockerclient/timeout.go
+++ b/agent/dockerclient/timeout.go
@@ -66,4 +66,7 @@ const (
 
 	// VersionTimeout is the timeout for the Version API
 	VersionTimeout = 10 * time.Second
+
+	// InfoTimeout is the timeout for the Info API
+	InfoTimeout = 10 * time.Second
 )

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -1016,7 +1016,12 @@ func (engine *DockerTaskEngine) createContainer(task *apitask.Task, container *a
 	// Create metadata directory and file then populate it with common metadata of all containers of this task
 	// Afterwards add this directory to the container's mounts if file creation was successful
 	if engine.cfg.ContainerMetadataEnabled && !container.IsInternal() {
-		mderr := engine.metadataManager.Create(config, hostConfig, task, container.Name)
+		info, infoErr := engine.client.Info(engine.ctx, dockerclient.InfoTimeout)
+		if infoErr != nil {
+			seelog.Warnf("Task engine [%s]: unable to get docker info : %v",
+				task.Arn, infoErr)
+		}
+		mderr := engine.metadataManager.Create(config, hostConfig, task, container.Name, info.SecurityOptions)
 		if mderr != nil {
 			seelog.Warnf("Task engine [%s]: unable to create metadata for container %s: %v",
 				task.Arn, container.Name, mderr)

--- a/agent/engine/docker_task_engine_linux_test.go
+++ b/agent/engine/docker_task_engine_linux_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/golang/mock/gomock"
 
+	"github.com/docker/docker/api/types"
 	dockercontainer "github.com/docker/docker/api/types/container"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
@@ -329,12 +330,14 @@ func TestTaskCPULimitHappyPath(t *testing.T) {
 					client, &roleCredentials, &containerEventsWG,
 					eventStream, containerName, func() {
 						metadataManager.EXPECT().Create(gomock.Any(), gomock.Any(),
-							gomock.Any(), gomock.Any()).Return(tc.metadataCreateError)
+							gomock.Any(), gomock.Any(), gomock.Any()).Return(tc.metadataCreateError)
 						metadataManager.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any(),
 							gomock.Any()).Return(tc.metadataUpdateError)
 					})
 			}
 
+			client.EXPECT().Info(gomock.Any(), gomock.Any()).Return(
+				types.Info{}, nil)
 			addTaskToEngine(t, ctx, taskEngine, sleepTask, mockTime, &containerEventsWG)
 			cleanup := make(chan time.Time, 1)
 			defer close(cleanup)

--- a/agent/stats/common_test.go
+++ b/agent/stats/common_test.go
@@ -29,6 +29,8 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/tcs/model/ecstcs"
 
 	"github.com/aws/aws-sdk-go/aws"
+
+	"github.com/docker/docker/api/types"
 	dockercontainer "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 	sdkClient "github.com/docker/docker/client"
@@ -322,4 +324,8 @@ func (engine *MockTaskEngine) Capabilities() []*ecs.Attribute {
 }
 
 func (engine *MockTaskEngine) Disable() {
+}
+
+func (engine *MockTaskEngine) Info() (types.Info, error) {
+	return types.Info{}, nil
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This change fixes the issue - https://github.com/aws/amazon-ecs-agent/issues/1113 by enabling read access to the metadata files from container processes. 

### Implementation details
- Added Info API to DockerClient interface to obtain Docker's SecurityOptions information.
- If the SecurityOptions contains selinux, we mount the metadata directory in Z mode.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
