### PR TITLE
Fix gMSA locks

### DIFF
--- a/agent/taskresource/credentialspec/credentialspec_windows.go
+++ b/agent/taskresource/credentialspec/credentialspec_windows.go
@@ -77,7 +77,10 @@ type CredentialSpecResource struct {
 	// * key := credentialspec:s3ARN, value := credentialspec=file://CredentialSpecResourceLocation/s3_taskARN_fileName.json
 	// * key := credentialspec:ssmARN, value := credentialspec=file://CredentialSpecResourceLocation/ssm_taskARN_param.json
 	CredSpecMap map[string]string
-	// datalock should protect the CredSpecMap
+	// datalock should protect the credentialspec data
+	// updateCredSpecMapping() and GetDesiredStatus() could potentially deadlock
+	// if they depend on the same mutex. However, the credential spec data can be
+	// updated independently to prevent lock contention.
 	datalock sync.RWMutex
 
 	// lock is used for fields that are accessed and updated concurrently


### PR DESCRIPTION


Signed-off-by: Vinothkumar Siddharth <sidvin@amazon.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This patch decouples the credentialspec status and data locks.


### Implementation details
<!-- How are the changes implemented? -->
The datalock would protect access to the credential spec resources.
The other lock would be used for all other transitions.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->
No 

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
