### PR TITLE
Gmsa functional test

### DIFF
--- a/agent/functional_tests/testdata/taskdefinitions/gmsa-localfile/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/gmsa-localfile/task-definition.json
@@ -1,0 +1,35 @@
+{
+  "containerDefinitions": [
+    {
+      "entryPoint": [
+        "powershell",
+        "-Command"
+      ],
+      "portMappings": [
+        {
+          "hostPort": 8080,
+          "protocol": "tcp",
+          "containerPort": 80
+        }
+      ],
+      "command": [
+        "New-Item -Path C:\\inetpub\\wwwroot\\index.html -ItemType file -Value '<html> <head> <title>Amazon ECS Sample App</title> <style>body {margin-top: 40px; background-color: #333;} </style> </head><body> <div style=color:white;text-align:center> <h1>Amazon ECS Sample App</h1> <h2>Congratulations!</h2> <p>Your application is now running on a container in Amazon ECS.</p>' -Force ; C:\\ServiceMonitor.exe w3svc"
+      ],
+      "cpu": 512,
+      "environment": [],
+      "mountPoints": [],
+      "dockerSecurityOptions": [
+        "credentialspec:file://test-gmsa.json"
+      ],
+      "memory": 768,
+      "volumesFrom": [],
+      "image": "microsoft/iis",
+      "essential": true,
+      "name": "windows_sample_app"
+    }
+  ],
+  "placementConstraints": [],
+  "family": "gmsa-file-test",
+  "requiresCompatibilities": [],
+  "volumes": []
+}

--- a/agent/functional_tests/tests/functionaltests_windows_test.go
+++ b/agent/functional_tests/tests/functionaltests_windows_test.go
@@ -42,10 +42,8 @@ const (
 	portResContentionTaskDefinition = "port-80-windows"
 	labelsTaskDefinition            = "labels-windows"
 	dockerEndpoint                  = "npipe:////./pipe/docker_engine"
-	DockerEndpointEnvVariable       = "DOCKER_HOST"
+	dockerEndpointEnvVariable       = "DOCKER_HOST"
 )
-
-var endpoint = utils.DefaultIfBlank(os.Getenv(DockerEndpointEnvVariable), dockerEndpoint)
 
 // TestAWSLogsDriver verifies that container logs are sent to Amazon CloudWatch Logs with awslogs as the log driver
 func TestAWSLogsDriver(t *testing.T) {
@@ -355,7 +353,7 @@ func TestTwoTasksSharedLocalVolume(t *testing.T) {
 }
 
 func TestGMSAFile(t *testing.T) {
-	RequireDockerAPIVersion(t, ">=1.30")
+	RequireDockerAPIVersion(t, ">=1.40")
 
 	agentOptions := AgentOptions{
 		ExtraEnvironment: map[string]string{
@@ -365,7 +363,7 @@ func TestGMSAFile(t *testing.T) {
 	agent := RunAgent(t, &agentOptions)
 	defer agent.Cleanup()
 
-	agent.RequireVersion(">=1.26.0")
+	agent.RequireVersion(">=1.33.0")
 
 	// Setup test gmsa file
 	envProgramData := "ProgramData"
@@ -419,6 +417,7 @@ func TestGMSAFile(t *testing.T) {
 	assert.NotEmpty(t, cid)
 
 	// Setup docker client to validate credentialspec
+	endpoint := utils.DefaultIfBlank(os.Getenv(dockerEndpointEnvVariable), dockerEndpoint)
 	client, _ := sdkClient.NewClientWithOpts(sdkClient.WithHost(endpoint), sdkClient.WithVersion(sdkclientfactory.GetDefaultVersion().String()))
 
 	testCredentialSpecOption := "credentialspec=file://test-gmsa.json"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Add functional-test for gMSA

### Implementation details
<!-- How are the changes implemented? -->
Functional test added with local file option.
```
 go test -tags functional -timeout=60m -v ./agent/functional_tests/tests -run "TestGMSAFile"
=== RUN   TestGMSAFile
--- PASS: TestGMSAFile (16.11s)
    utils_windows.go:87: Registry location test_path_1574186472856528400
    utils_windows.go:101: datadir C:\tmp\ecs_integ_testdata744323799\data
    utils_windows.go:109: Created directory C:\tmp\ecs_integ_testdata744323799 to store test data in
    utils.go:178: Found agent metadata: ContainerInstanceArn: arn:aws:ecs:us-west-2:1234567890:container-instance/test/abe0adcf2342482fb1e0e6def53bb575, Cluster: test, Version: 1.32.1
    utils.go:211: Task definition: gmsa-file-test-f70a30ecbdce28007491895a86408ae5:1
    utils.go:231: Started task: arn:aws:ecs:us-west-2:1234567890:task/7c541123-fba5-43ff-a671-0c28ad7d4b4a
    utils.go:189: Removing test dir for passed test C:\tmp\ecs_integ_testdata744323799
PASS
ok      github.com/aws/amazon-ecs-agent/agent/functional_tests/tests    16.398s


```

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->
yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
