### PR TITLE
Fix credentialspec cleanup

### DIFF
--- a/agent/taskresource/credentialspec/credentialspec_windows.go
+++ b/agent/taskresource/credentialspec/credentialspec_windows.go
@@ -529,9 +529,15 @@ func (cs *CredentialSpecResource) clearCredentialSpec() {
 			seelog.Debugf("Skipping cleanup of local credentialspec file option: %s", key)
 			continue
 		}
-		credSpecSplit := strings.SplitAfterN(value, "credentialspec=", 2)
+		// Split credentialspec to obtain local file-name
+		credSpecSplit := strings.SplitAfterN(value, "credentialspec=file://", 2)
+		if len(credSpecSplit) != 2 {
+			seelog.Warnf("Unable to parse target credentialspec: %s", value)
+			continue
+		}
 		localCredentialSpecFile := credSpecSplit[1]
-		err := cs.os.Remove(localCredentialSpecFile)
+		localCredentialSpecFilePath := filepath.Join(cs.credentialSpecResourceLocation, localCredentialSpecFile)
+		err := cs.os.Remove(localCredentialSpecFilePath)
 		if err != nil {
 			seelog.Warnf("Unable to clear local credential spec file %s for task %s", localCredentialSpecFile, cs.taskARN)
 		}

--- a/agent/taskresource/credentialspec/credentialspec_windows_test.go
+++ b/agent/taskresource/credentialspec/credentialspec_windows_test.go
@@ -68,10 +68,10 @@ func TestClearCredentialSpecDataHappyPath(t *testing.T) {
 
 	expectedS3FilePath := filepath.Join(credentialSpecResourceLocation, "s3_taskARN_fileName.json")
 	expectedSSMFilePath := filepath.Join(credentialSpecResourceLocation, "ssm_taskARN_fileName.json")
-	gomock.InOrder(
-		mockOS.EXPECT().Remove(expectedS3FilePath).Return(nil),
-		mockOS.EXPECT().Remove(expectedSSMFilePath).Return(nil),
-	)
+
+	// Mock returns for test
+	mockOS.EXPECT().Remove(expectedS3FilePath).Return(nil)
+	mockOS.EXPECT().Remove(expectedSSMFilePath).Return(nil)
 
 	err := credspecRes.Cleanup()
 	assert.NoError(t, err)
@@ -86,7 +86,6 @@ func TestClearCredentialSpecDataErr(t *testing.T) {
 
 	credSpecMapData := map[string]string{
 		"credentialspec:file://localfilePath.json": "credentialspec=file://localfilePath.json",
-		"credentialspec:s3ARN":                     "credentialspec=file://s3_taskARN_fileName.json",
 		"credentialspec:ssmARN":                    "credentialspec=file://ssm_taskARN_fileName.json",
 	}
 
@@ -97,12 +96,10 @@ func TestClearCredentialSpecDataErr(t *testing.T) {
 		credentialSpecResourceLocation: credentialSpecResourceLocation,
 	}
 
-	expectedS3FilePath := filepath.Join(credentialSpecResourceLocation, "s3_taskARN_fileName.json")
 	expectedSSMFilePath := filepath.Join(credentialSpecResourceLocation, "ssm_taskARN_fileName.json")
-	gomock.InOrder(
-		mockOS.EXPECT().Remove(expectedS3FilePath).Return(nil),
-		mockOS.EXPECT().Remove(expectedSSMFilePath).Return(errors.New("test-error")),
-	)
+
+	// Mock returns for test
+	mockOS.EXPECT().Remove(expectedSSMFilePath).Return(errors.New("test-error"))
 
 	err := credspecRes.Cleanup()
 	assert.NoError(t, err)

--- a/agent/taskresource/credentialspec/credentialspec_windows_test.go
+++ b/agent/taskresource/credentialspec/credentialspec_windows_test.go
@@ -17,6 +17,7 @@ package credentialspec
 
 import (
 	"encoding/json"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -58,13 +59,18 @@ func TestClearCredentialSpecDataHappyPath(t *testing.T) {
 		"credentialspec:ssmARN":                    "credentialspec=file://ssm_taskARN_fileName.json",
 	}
 
+	credentialSpecResourceLocation := "C:/ProgramData/docker/credentialspecs/"
 	credspecRes := &CredentialSpecResource{
-		CredSpecMap: credSpecMapData,
-		os:          mockOS,
+		CredSpecMap:                    credSpecMapData,
+		os:                             mockOS,
+		credentialSpecResourceLocation: credentialSpecResourceLocation,
 	}
 
+	expectedS3FilePath := filepath.Join(credentialSpecResourceLocation, "s3_taskARN_fileName.json")
+	expectedSSMFilePath := filepath.Join(credentialSpecResourceLocation, "ssm_taskARN_fileName.json")
 	gomock.InOrder(
-		mockOS.EXPECT().Remove(gomock.Any()).Return(nil).AnyTimes(),
+		mockOS.EXPECT().Remove(expectedS3FilePath).Return(nil),
+		mockOS.EXPECT().Remove(expectedSSMFilePath).Return(nil),
 	)
 
 	err := credspecRes.Cleanup()
@@ -84,14 +90,18 @@ func TestClearCredentialSpecDataErr(t *testing.T) {
 		"credentialspec:ssmARN":                    "credentialspec=file://ssm_taskARN_fileName.json",
 	}
 
+	credentialSpecResourceLocation := "C:/ProgramData/docker/credentialspecs/"
 	credspecRes := &CredentialSpecResource{
-		CredSpecMap: credSpecMapData,
-		os:          mockOS,
+		CredSpecMap:                    credSpecMapData,
+		os:                             mockOS,
+		credentialSpecResourceLocation: credentialSpecResourceLocation,
 	}
 
+	expectedS3FilePath := filepath.Join(credentialSpecResourceLocation, "s3_taskARN_fileName.json")
+	expectedSSMFilePath := filepath.Join(credentialSpecResourceLocation, "ssm_taskARN_fileName.json")
 	gomock.InOrder(
-		mockOS.EXPECT().Remove(gomock.Any()).Return(nil).Times(1),
-		mockOS.EXPECT().Remove(gomock.Any()).Return(errors.New("test error")),
+		mockOS.EXPECT().Remove(expectedS3FilePath).Return(nil),
+		mockOS.EXPECT().Remove(expectedSSMFilePath).Return(errors.New("test-error")),
 	)
 
 	err := credspecRes.Cleanup()

--- a/agent/taskresource/credentialspec/credentialspec_windows_test.go
+++ b/agent/taskresource/credentialspec/credentialspec_windows_test.go
@@ -54,8 +54,8 @@ func TestClearCredentialSpecDataHappyPath(t *testing.T) {
 
 	credSpecMapData := map[string]string{
 		"credentialspec:file://localfilePath.json": "credentialspec=file://localfilePath.json",
-		"credentialspec:s3ARN":                     "credentialspec=file://ResourceDir/s3_taskARN_fileName.json",
-		"credentialspec:ssmARN":                    "credentialspec=file://ResourceDir/ssm_taskARN_fileName.json",
+		"credentialspec:s3ARN":                     "credentialspec=file://s3_taskARN_fileName.json",
+		"credentialspec:ssmARN":                    "credentialspec=file://ssm_taskARN_fileName.json",
 	}
 
 	credspecRes := &CredentialSpecResource{
@@ -80,8 +80,8 @@ func TestClearCredentialSpecDataErr(t *testing.T) {
 
 	credSpecMapData := map[string]string{
 		"credentialspec:file://localfilePath.json": "credentialspec=file://localfilePath.json",
-		"credentialspec:s3ARN":                     "credentialspec=file://ResourceDir/s3_taskARN_fileName.json",
-		"credentialspec:ssmARN":                    "credentialspec=file://ResourceDir/ssm_taskARN_fileName.json",
+		"credentialspec:s3ARN":                     "credentialspec=file://s3_taskARN_fileName.json",
+		"credentialspec:ssmARN":                    "credentialspec=file://ssm_taskARN_fileName.json",
 	}
 
 	credspecRes := &CredentialSpecResource{


### PR DESCRIPTION
Signed-off-by: Vinothkumar Siddharth <sidvin@amazon.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Fix credentialspec cleanup

### Implementation details
<!-- How are the changes implemented? -->
Fix credentialspec cleanup by passing path to file. 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->
no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
