### PR TITLE
GMSA functional tests

### DIFF
--- a/agent/functional_tests/testdata/taskdefinitions/gmsa-s3/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/gmsa-s3/task-definition.json
@@ -1,0 +1,36 @@
+{
+  "containerDefinitions": [
+    {
+      "entryPoint": [
+        "powershell",
+        "-Command"
+      ],
+      "portMappings": [
+        {
+          "hostPort": 8080,
+          "protocol": "tcp",
+          "containerPort": 80
+        }
+      ],
+      "command": [
+        "New-Item -Path C:\\inetpub\\wwwroot\\index.html -ItemType file -Value '<html> <head> <title>Amazon ECS Sample App</title> <style>body {margin-top: 40px; background-color: #333;} </style> </head><body> <div style=color:white;text-align:center> <h1>Amazon ECS Sample App</h1> <h2>Congratulations!</h2> <p>Your application is now running on a container in Amazon ECS.</p>' -Force ; C:\\ServiceMonitor.exe w3svc"
+      ],
+      "cpu": 512,
+      "environment": [],
+      "mountPoints": [],
+      "dockerSecurityOptions": [
+        "credentialspec:arn:aws:s3:::$$$TEST_S3_BUCKET$$$/gmsa-test-file.json"
+      ],
+      "memory": 768,
+      "volumesFrom": [],
+      "image": "microsoft/iis",
+      "essential": true,
+      "name": "windows_sample_app"
+    }
+  ],
+  "placementConstraints": [],
+  "family": "gmsa-s3-test",
+  "requiresCompatibilities": [],
+  "volumes": [],
+  "executionRoleArn": "$$$EXECUTION_ROLE$$$"
+}

--- a/agent/functional_tests/testdata/taskdefinitions/gmsa-ssm/task-definition.json
+++ b/agent/functional_tests/testdata/taskdefinitions/gmsa-ssm/task-definition.json
@@ -1,0 +1,36 @@
+{
+  "containerDefinitions": [
+    {
+      "entryPoint": [
+        "powershell",
+        "-Command"
+      ],
+      "portMappings": [
+        {
+          "hostPort": 8080,
+          "protocol": "tcp",
+          "containerPort": 80
+        }
+      ],
+      "command": [
+        "New-Item -Path C:\\inetpub\\wwwroot\\index.html -ItemType file -Value '<html> <head> <title>Amazon ECS Sample App</title> <style>body {margin-top: 40px; background-color: #333;} </style> </head><body> <div style=color:white;text-align:center> <h1>Amazon ECS Sample App</h1> <h2>Congratulations!</h2> <p>Your application is now running on a container in Amazon ECS.</p>' -Force ; C:\\ServiceMonitor.exe w3svc"
+      ],
+      "cpu": 512,
+      "environment": [],
+      "mountPoints": [],
+      "dockerSecurityOptions": [
+        "credentialspec:$$$TEST_SSM_ARN$$$"
+      ],
+      "memory": 768,
+      "volumesFrom": [],
+      "image": "microsoft/iis",
+      "essential": true,
+      "name": "windows_sample_app"
+    }
+  ],
+  "placementConstraints": [],
+  "family": "gmsa-ssm-test",
+  "requiresCompatibilities": [],
+  "volumes": [],
+  "executionRoleArn": "$$$EXECUTION_ROLE$$$"
+}

--- a/agent/functional_tests/tests/functionaltests_windows_test.go
+++ b/agent/functional_tests/tests/functionaltests_windows_test.go
@@ -368,7 +368,7 @@ func TestGMSAFile(t *testing.T) {
 	agent := RunAgent(t, &agentOptions)
 	defer agent.Cleanup()
 
-	agent.RequireVersion(">=1.33.0")
+	agent.RequireVersion(">=1.32.1")
 
 	// Setup test gmsa file
 	envProgramData := "ProgramData"
@@ -521,7 +521,7 @@ func TestGMSASSMFile(t *testing.T) {
 	agent := RunAgent(t, &agentOptions)
 	defer agent.Cleanup()
 
-	agent.RequireVersion(">=1.33.0")
+	agent.RequireVersion(">=1.32.1")
 
 	// Setup taskdef
 	tdOverrides := make(map[string]string)
@@ -639,7 +639,7 @@ func TestGMSAS3File(t *testing.T) {
 	agent := RunAgent(t, &agentOptions)
 	defer agent.Cleanup()
 
-	agent.RequireVersion(">=1.33.0")
+	agent.RequireVersion(">=1.32.1")
 
 	// Setup taskdef overrides
 	tdOverrides := make(map[string]string)

--- a/agent/functional_tests/tests/functionaltests_windows_test.go
+++ b/agent/functional_tests/tests/functionaltests_windows_test.go
@@ -506,7 +506,7 @@ func TestGMSASSMFile(t *testing.T) {
 	require.NoError(t, err)
 
 	// Obtain ARN of SSM param
-	gmSAParameterARN := *data.Parameter.ARN
+	gMSASSMParameterARN := *data.Parameter.ARN
 
 	// Setup agent
 	RequireDockerAPIVersion(t, ">=1.40")
@@ -525,9 +525,8 @@ func TestGMSASSMFile(t *testing.T) {
 
 	// Setup taskdef
 	tdOverrides := make(map[string]string)
-	tdOverrides["$$$TEST_REGION$$$"] = aws.StringValue(ECS.Config.Region)
 	tdOverrides["$$$EXECUTION_ROLE$$$"] = executionRole
-	tdOverrides["$$$TEST_SSM_ARN$$$"] = gmSAParameterARN
+	tdOverrides["$$$TEST_SSM_ARN$$$"] = gMSASSMParameterARN
 
 	testTask, err := agent.StartTaskWithTaskDefinitionOverrides(t, "gmsa-ssm", tdOverrides)
 	require.NoError(t, err)
@@ -644,7 +643,6 @@ func TestGMSAS3File(t *testing.T) {
 
 	// Setup taskdef overrides
 	tdOverrides := make(map[string]string)
-	tdOverrides["$$$TEST_REGION$$$"] = aws.StringValue(ECS.Config.Region)
 	tdOverrides["$$$EXECUTION_ROLE$$$"] = executionRole
 	tdOverrides["$$$TEST_S3_BUCKET$$$"] = s3Bucket
 

--- a/agent/functional_tests/tests/functionaltests_windows_test.go
+++ b/agent/functional_tests/tests/functionaltests_windows_test.go
@@ -358,7 +358,7 @@ func TestTwoTasksSharedLocalVolume(t *testing.T) {
 }
 
 func TestGMSAFile(t *testing.T) {
-	RequireDockerAPIVersion(t, ">=1.39")
+	RequireDockerAPIVersion(t, ">=1.37")
 
 	agentOptions := AgentOptions{
 		ExtraEnvironment: map[string]string{
@@ -509,7 +509,7 @@ func TestGMSASSMFile(t *testing.T) {
 	gMSASSMParameterARN := *data.Parameter.ARN
 
 	// Setup agent
-	RequireDockerAPIVersion(t, ">=1.39")
+	RequireDockerAPIVersion(t, ">=1.37")
 
 	agentOptions := AgentOptions{
 		ExtraEnvironment: map[string]string{
@@ -627,7 +627,7 @@ func TestGMSAS3File(t *testing.T) {
 	}
 
 	// Setup agent
-	RequireDockerAPIVersion(t, ">=1.39")
+	RequireDockerAPIVersion(t, ">=1.37")
 
 	agentOptions := AgentOptions{
 		ExtraEnvironment: map[string]string{

--- a/agent/functional_tests/tests/functionaltests_windows_test.go
+++ b/agent/functional_tests/tests/functionaltests_windows_test.go
@@ -30,8 +30,12 @@ import (
 	. "github.com/aws/amazon-ecs-agent/agent/functional_tests/util"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+	"github.com/aws/aws-sdk-go/service/ssm"
 	sdkClient "github.com/docker/docker/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -43,6 +47,7 @@ const (
 	labelsTaskDefinition            = "labels-windows"
 	dockerEndpoint                  = "npipe:////./pipe/docker_engine"
 	dockerEndpointEnvVariable       = "DOCKER_HOST"
+	errCodeAccessDenied             = "AccessDenied"
 )
 
 // TestAWSLogsDriver verifies that container logs are sent to Amazon CloudWatch Logs with awslogs as the log driver
@@ -431,6 +436,250 @@ func TestGMSAFile(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Cleanup the test file
+	err = os.Remove(testCredSpecFilePath)
+	assert.NoError(t, err)
+}
+
+func TestGMSASSMFile(t *testing.T) {
+	// Setup required role
+	if os.Getenv("TEST_DISABLE_EXECUTION_ROLE") == "true" {
+		t.Skip("TEST_DISABLE_EXECUTION_ROLE was set to true")
+	}
+
+	// execution role arn is following the pattern arn:aws:iam::accountId:role/***
+	executionRole := os.Getenv("ECS_FTS_EXECUTION_ROLE")
+	if executionRole == "" {
+		t.Skip("ECS_FTS_EXECUTION_ROLE was not set to run this test")
+	}
+
+	// Setup SSM parameter for gMSA test
+	parameterName := "FunctionalTest-gMSA-SSM"
+	testCredSpecData := `{
+    "CmsPlugins":  [
+                       "ActiveDirectory"
+                   ],
+    "DomainJoinConfig":  {
+                             "Sid":  "S-1-5-21-975084816-3050680612-2826754290",
+                             "MachineAccountName":  "gmsa-acct-test",
+                             "Guid":  "92a07e28-bd9f-4bf3-b1f7-0894815a5257",
+                             "DnsTreeName":  "gmsa.test.com",
+                             "DnsName":  "gmsa.test.com",
+                             "NetBiosName":  "gmsa"
+                         },
+    "ActiveDirectoryConfig":  {
+                                  "GroupManagedServiceAccounts":  [
+                                                                      {
+                                                                          "Name":  "gmsa-acct-test",
+                                                                          "Scope":  "gmsa.test.com"
+                                                                      }
+                                                                  ]
+                              }
+}`
+	region := *ECS.Config.Region
+	ssmClient := ssm.New(session.New(), aws.NewConfig().WithRegion(region))
+	input := &ssm.PutParameterInput{
+		Description: aws.String("Resource created for the ECS Agent Functional Test: TestGMSASSMFile"),
+		Name:        aws.String(parameterName),
+		Value:       aws.String(testCredSpecData),
+		Type:        aws.String("String"),
+	}
+
+	// create parameter in parameter store if it does not exist
+	_, err := ssmClient.PutParameter(input)
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			case ssm.ErrCodeParameterAlreadyExists:
+				t.Logf("Parameter %v already exists in SSM Parameter Store", parameterName)
+				break
+			default:
+				require.NoError(t, err, "SSM PutParameter call failed")
+			}
+		}
+	}
+
+	// read parameter back to obtain ARN
+	paramInput := &ssm.GetParameterInput{
+		Name: aws.String(parameterName),
+	}
+	data, err := ssmClient.GetParameter(paramInput)
+	require.NoError(t, err)
+
+	// Obtain ARN of SSM param
+	gmSAParameterARN := *data.Parameter.ARN
+
+	// Setup agent
+	RequireDockerAPIVersion(t, ">=1.40")
+
+	agentOptions := AgentOptions{
+		ExtraEnvironment: map[string]string{
+			"ZZZ_SKIP_DOMAIN_JOIN_CHECK_NOT_SUPPORTED_IN_PRODUCTION": "true",
+			"ECS_ENGINE_TASK_CLEANUP_WAIT_DURATION":                  "1m",
+		},
+	}
+
+	agent := RunAgent(t, &agentOptions)
+	defer agent.Cleanup()
+
+	agent.RequireVersion(">=1.33.0")
+
+	// Setup taskdef
+	tdOverrides := make(map[string]string)
+	tdOverrides["$$$TEST_REGION$$$"] = aws.StringValue(ECS.Config.Region)
+	tdOverrides["$$$EXECUTION_ROLE$$$"] = executionRole
+	tdOverrides["$$$TEST_SSM_ARN$$$"] = gmSAParameterARN
+
+	testTask, err := agent.StartTaskWithTaskDefinitionOverrides(t, "gmsa-ssm", tdOverrides)
+	require.NoError(t, err)
+
+	// Wait for the container to start
+	testTask.WaitRunning(waitTaskStateChangeDuration)
+	taskID, err := GetTaskID(aws.StringValue(testTask.TaskArn))
+	require.NoError(t, err)
+	assert.NotEmpty(t, taskID)
+
+	// Verify container metadata
+	cid, err := agent.ResolveTaskDockerID(testTask, "windows_sample_app")
+	require.NoError(t, err, "Error resolving docker id for container in task")
+	assert.NotEmpty(t, cid)
+
+	// Setup docker client to validate credentialspec
+	endpoint := utils.DefaultIfBlank(os.Getenv(dockerEndpointEnvVariable), dockerEndpoint)
+	client, _ := sdkClient.NewClientWithOpts(sdkClient.WithHost(endpoint), sdkClient.WithVersion(sdkclientfactory.GetDefaultVersion().String()))
+
+	// credentialspec=file://ssm_c3ce6880-f815-4044-af03-29f934836293_FunctionalTest-gMSA-SSM
+	testCredentialSpecOption := fmt.Sprintf("credentialspec=file://ssm_%s_%s", taskID, parameterName)
+
+	err = verifyContainerCredentialSpec(client, cid, testCredentialSpecOption)
+	assert.NoError(t, err)
+
+	// Stop test task
+	testTask.Stop()
+
+	err = testTask.WaitStopped(waitTaskStateChangeDuration)
+	assert.NoError(t, err)
+
+	// Cleanup the test file
+	testCredSpecFilePath := fmt.Sprintf("C:/ProgramData/docker/credentialspecs/ssm_%s_%s", taskID, parameterName)
+	err = os.Remove(testCredSpecFilePath)
+	assert.NoError(t, err)
+
+	// Cleanup the ssm parameter
+	_, err = ssmClient.DeleteParameter(&ssm.DeleteParameterInput{Name: aws.String(parameterName)})
+	assert.NoError(t, err)
+}
+
+func TestGMSAS3File(t *testing.T) {
+	// Setup required role
+	if os.Getenv("TEST_DISABLE_EXECUTION_ROLE") == "true" {
+		t.Skip("TEST_DISABLE_EXECUTION_ROLE was set to true")
+	}
+
+	// execution role arn is following the pattern arn:aws:iam::accountId:role/***
+	executionRole := os.Getenv("ECS_FTS_EXECUTION_ROLE")
+	if executionRole == "" {
+		t.Skip("ECS_FTS_EXECUTION_ROLE was not set to run this test")
+	}
+
+	// Setup s3 artifact
+	s3Bucket := os.Getenv("ECS_FTEST_S3_BUCKET")
+	s3BucketRegion := os.Getenv("ECS_FTEST_S3_BUCKET_REGION")
+	if s3Bucket == "" || s3BucketRegion == "" {
+		t.Skip("Skipping test as it requires both ECS_FTEST_S3_BUCKET and ECS_FTEST_S3_BUCKET_REGION to be set.")
+	}
+	t.Logf("Using s3 bucket %s in region %s", s3Bucket, s3BucketRegion)
+
+	sessWithRegion := session.Must(session.NewSession(aws.NewConfig().WithRegion(s3BucketRegion)))
+	svc := s3manager.NewUploaderWithClient(s3.New(sessWithRegion))
+
+	testCredSpecData := `{
+    "CmsPlugins":  [
+                       "ActiveDirectory"
+                   ],
+    "DomainJoinConfig":  {
+                             "Sid":  "S-1-5-21-975084816-3050680612-2826754290",
+                             "MachineAccountName":  "gmsa-acct-test",
+                             "Guid":  "92a07e28-bd9f-4bf3-b1f7-0894815a5257",
+                             "DnsTreeName":  "gmsa.test.com",
+                             "DnsName":  "gmsa.test.com",
+                             "NetBiosName":  "gmsa"
+                         },
+    "ActiveDirectoryConfig":  {
+                                  "GroupManagedServiceAccounts":  [
+                                                                      {
+                                                                          "Name":  "gmsa-acct-test",
+                                                                          "Scope":  "gmsa.test.com"
+                                                                      }
+                                                                  ]
+                              }
+}`
+
+	_, err := svc.Upload(&s3manager.UploadInput{
+		Bucket: aws.String(s3Bucket),
+		Key:    aws.String("gmsa-test-file.json"),
+		Body:   strings.NewReader(testCredSpecData),
+	})
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok && aerr.Code() == errCodeAccessDenied {
+			t.Skip("Skipping the test since lacking necessary s3 access permission")
+		} else {
+			t.Fatalf("Unable to upload config file to s3 which is needed for the test: %v", err)
+		}
+	}
+
+	// Setup agent
+	RequireDockerAPIVersion(t, ">=1.40")
+
+	agentOptions := AgentOptions{
+		ExtraEnvironment: map[string]string{
+			"ZZZ_SKIP_DOMAIN_JOIN_CHECK_NOT_SUPPORTED_IN_PRODUCTION": "true",
+			"ECS_ENGINE_TASK_CLEANUP_WAIT_DURATION":                  "1m",
+		},
+	}
+
+	agent := RunAgent(t, &agentOptions)
+	defer agent.Cleanup()
+
+	agent.RequireVersion(">=1.33.0")
+
+	// Setup taskdef overrides
+	tdOverrides := make(map[string]string)
+	tdOverrides["$$$TEST_REGION$$$"] = aws.StringValue(ECS.Config.Region)
+	tdOverrides["$$$EXECUTION_ROLE$$$"] = executionRole
+	tdOverrides["$$$TEST_S3_BUCKET$$$"] = s3Bucket
+
+	testTask, err := agent.StartTaskWithTaskDefinitionOverrides(t, "gmsa-s3", tdOverrides)
+	require.NoError(t, err)
+
+	// Wait for the container to start
+	testTask.WaitRunning(waitTaskStateChangeDuration)
+	taskID, err := GetTaskID(aws.StringValue(testTask.TaskArn))
+	require.NoError(t, err)
+	assert.NotEmpty(t, taskID)
+
+	// Verify container metadata
+	cid, err := agent.ResolveTaskDockerID(testTask, "windows_sample_app")
+	require.NoError(t, err, "Error resolving docker id for container in task")
+	assert.NotEmpty(t, cid)
+
+	// Setup docker client to validate credentialspec
+	endpoint := utils.DefaultIfBlank(os.Getenv(dockerEndpointEnvVariable), dockerEndpoint)
+	client, _ := sdkClient.NewClientWithOpts(sdkClient.WithHost(endpoint), sdkClient.WithVersion(sdkclientfactory.GetDefaultVersion().String()))
+
+	// credentialspec=file://s3_c3ce6880-f815-4044-af03-29f934836293_gmsa-test-file.json
+	testCredentialSpecOption := fmt.Sprintf("credentialspec=file://s3_%s_gmsa-test-file.json", taskID)
+
+	err = verifyContainerCredentialSpec(client, cid, testCredentialSpecOption)
+	assert.NoError(t, err)
+
+	// Stop test task
+	testTask.Stop()
+
+	err = testTask.WaitStopped(waitTaskStateChangeDuration)
+	assert.NoError(t, err)
+
+	// Cleanup the test file
+	testCredSpecFilePath := fmt.Sprintf("C:/ProgramData/docker/credentialspecs/s3_%s_gmsa-test-file.json", taskID)
 	err = os.Remove(testCredSpecFilePath)
 	assert.NoError(t, err)
 }

--- a/agent/functional_tests/tests/functionaltests_windows_test.go
+++ b/agent/functional_tests/tests/functionaltests_windows_test.go
@@ -358,7 +358,7 @@ func TestTwoTasksSharedLocalVolume(t *testing.T) {
 }
 
 func TestGMSAFile(t *testing.T) {
-	RequireDockerAPIVersion(t, ">=1.37")
+	RequireDockerAPIVersion(t, ">=1.24")
 
 	agentOptions := AgentOptions{
 		ExtraEnvironment: map[string]string{
@@ -509,7 +509,7 @@ func TestGMSASSMFile(t *testing.T) {
 	gMSASSMParameterARN := *data.Parameter.ARN
 
 	// Setup agent
-	RequireDockerAPIVersion(t, ">=1.37")
+	RequireDockerAPIVersion(t, ">=1.24")
 
 	agentOptions := AgentOptions{
 		ExtraEnvironment: map[string]string{
@@ -627,7 +627,7 @@ func TestGMSAS3File(t *testing.T) {
 	}
 
 	// Setup agent
-	RequireDockerAPIVersion(t, ">=1.37")
+	RequireDockerAPIVersion(t, ">=1.24")
 
 	agentOptions := AgentOptions{
 		ExtraEnvironment: map[string]string{

--- a/agent/functional_tests/tests/functionaltests_windows_test.go
+++ b/agent/functional_tests/tests/functionaltests_windows_test.go
@@ -358,7 +358,7 @@ func TestTwoTasksSharedLocalVolume(t *testing.T) {
 }
 
 func TestGMSAFile(t *testing.T) {
-	RequireDockerAPIVersion(t, ">=1.40")
+	RequireDockerAPIVersion(t, ">=1.39")
 
 	agentOptions := AgentOptions{
 		ExtraEnvironment: map[string]string{
@@ -509,7 +509,7 @@ func TestGMSASSMFile(t *testing.T) {
 	gMSASSMParameterARN := *data.Parameter.ARN
 
 	// Setup agent
-	RequireDockerAPIVersion(t, ">=1.40")
+	RequireDockerAPIVersion(t, ">=1.39")
 
 	agentOptions := AgentOptions{
 		ExtraEnvironment: map[string]string{
@@ -627,7 +627,7 @@ func TestGMSAS3File(t *testing.T) {
 	}
 
 	// Setup agent
-	RequireDockerAPIVersion(t, ">=1.40")
+	RequireDockerAPIVersion(t, ">=1.39")
 
 	agentOptions := AgentOptions{
 		ExtraEnvironment: map[string]string{


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Adding functional tests for taskresource `credentialspec`
### Implementation details
<!-- How are the changes implemented? -->
Functional tests are implemented using the existing framework. 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

**GMSA-SSM**
```
 go test -tags functional -timeout=60m -v ./agent/functional_tests/tests -run "TestGMSASSMFile"
=== RUN   TestGMSASSMFile
--- PASS: TestGMSASSMFile (20.88s)
    functionaltests_windows_test.go:498: Parameter FunctionalTest-gMSA-SSM already exists in SSM Parameter Store
    utils_windows.go:87: Registry location test_path_1574311733230782000
    utils_windows.go:101: datadir C:\tmp\ecs_integ_testdata248711263\data
    utils_windows.go:109: Created directory C:\tmp\ecs_integ_testdata248711263 to store test data in
    utils.go:178: Found agent metadata: ContainerInstanceArn: arn:aws:ecs:us-west-2:1234567890:container-instance/test/47dbc896c5e94b8db8dd710f3f35b500, Cluster: test, Version: 1.32.1
    utils.go:211: Task definition: gmsa-ssm-test-40a8f970f623327048ac937f5ae467f0:1
    utils.go:231: Started task: arn:aws:ecs:us-west-2:1234567890:task/e782aefc-1c52-4c1f-8eac-c2c51fc3b200
    utils.go:189: Removing test dir for passed test C:\tmp\ecs_integ_testdata248711263
PASS
ok      github.com/aws/amazon-ecs-agent/agent/functional_tests/tests    21.240s
```

**GMSA-S3**
```
 go test -tags functional -timeout=60m -v ./agent/functional_tests/tests -run "TestGMSAS3File"
=== RUN   TestGMSAS3File
--- PASS: TestGMSAS3File (15.68s)
    functionaltests_windows_test.go:594: Using s3 bucket sidvin-gmsa-test in region us-west-2
    utils_windows.go:87: Registry location test_path_1574311851304481300
    utils_windows.go:101: datadir C:\tmp\ecs_integ_testdata933636879\data
    utils_windows.go:109: Created directory C:\tmp\ecs_integ_testdata933636879 to store test data in
    utils.go:178: Found agent metadata: ContainerInstanceArn: arn:aws:ecs:us-west-2:1234567890:container-instance/test/aa4902b6b420475f98554877d906d74e, Cluster: test, Version: 1.32.1
    utils.go:211: Task definition: gmsa-s3-test-a339b11cd59179c8cc073a12863138c1:1
    utils.go:231: Started task: arn:aws:ecs:us-west-2:1234567890:task/215a529d-7ac4-4314-a027-aae39f1c4f6b
    utils.go:189: Removing test dir for passed test C:\tmp\ecs_integ_testdata933636879
PASS
ok      github.com/aws/amazon-ecs-agent/agent/functional_tests/tests    16.003s
```

New tests cover the changes: <!-- yes|no -->
yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
