### PR TITLE
Show outpost ARN log only when it's available

### DIFF
--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -441,12 +441,12 @@ func (agent *ecsAgent) getEC2InstanceID() string {
 // getoutpostARN gets the Outpost ARN from the metadata service
 func (agent *ecsAgent) getoutpostARN() string {
 	outpostARN, err := agent.ec2MetadataClient.OutpostARN()
-	if err != nil {
-		seelog.Warnf(
-			"Unable to obtain Outpost ARN from EC2 Metadata: %v", err)
-		return ""
+	if err == nil {
+		seelog.Infof(
+			"Outpost ARN from EC2 Metadata: %s", outpostARN)
+		return outpostARN
 	}
-	return outpostARN
+	return ""
 }
 
 // newStateManager creates a new state manager object for the task engine.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Given that most of the instances the Agent runs on is non-outpost, it makes more sense to show the outpost related logs only when the instance is outpost.

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
