### PR TITLE
Acquire read lock when marshalling container/task.

### DIFF
--- a/agent/api/container/json.go
+++ b/agent/api/container/json.go
@@ -1,0 +1,17 @@
+package container
+
+import (
+	"encoding/json"
+)
+
+// In order to override the MarshalJSON method while still using Go's marshalling logic inside, an alias type
+// is needed to avoid infinite recursion.
+type jContainer Container
+
+// MarshalJSON wraps Go's marshalling logic with a necessary read lock.
+func (c *Container) MarshalJSON() ([]byte, error) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	return json.Marshal((*jContainer)(c))
+}

--- a/agent/api/container/json.go
+++ b/agent/api/container/json.go
@@ -1,3 +1,16 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
 package container
 
 import (

--- a/agent/api/task/json.go
+++ b/agent/api/task/json.go
@@ -1,0 +1,17 @@
+package task
+
+import (
+	"encoding/json"
+)
+
+// In order to override the MarshalJSON method while still using Go's marshalling logic inside, an alias type
+// is needed to avoid infinite recursion.
+type jTask Task
+
+// MarshalJSON wraps Go's marshalling logic with a necessary read lock.
+func (t *Task) MarshalJSON() ([]byte, error) {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+
+	return json.Marshal((*jTask)(t))
+}

--- a/agent/api/task/json.go
+++ b/agent/api/task/json.go
@@ -1,3 +1,16 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
 package task
 
 import (


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Acquire read lock when marshalling container/task. Without acquiring the lock the agent can crash due to concurrent access.

For example, when we are modifying the fields in container/task, there can be another goroutine invoking [ForceSave](https://github.com/aws/amazon-ecs-agent/blob/master/agent/statemanager/state_manager.go#L253) to save the state, which calls the marshal method, and if the marshalling doesn't acquire the read lock, the program will crash even if the other goroutine acquires the write lock before modifying the field. See Testing section for an example.

### Implementation details
<!-- How are the changes implemented? -->
Wraps container and task's MarshalJSON method with read lock.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
For unit test, rely on existing statemanager unit test since this PR just adds the lock.

For manual test, this isn't easily reproducible, but it can be reproduced by intentionally invoking task.PopulateSecrets many times (see [this](https://github.com/fenxiong/amazon-ecs-agent/commit/c0d0a82485d04aed1e036ba8fc279a2c36315005)) in the code, and run a task that uses secret, and without the fix the agent will crash like the following:
```
...
2019-12-02T22:01:58Z [INFO] Task engine [arn:aws:ecs:us-west-2:xxx:task/test-exec/xxx]: creating container: xxx
2019-12-02T22:01:58Z [INFO] Populate secrets 10000 times!
fatal error: concurrent map iteration and map write
...
```

I was able to verify that the issue is fixed with this commit.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
