### PR TITLE
Implement task resource container dependency

### DIFF
--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -463,7 +463,7 @@ func (task *Task) initializeDockerLocalVolumes(dockerClient dockerapi.DockerClie
 		vol, _ := task.HostVolumeByName(volumeName)
 		// BUG(samuelkarp) On Windows, volumes with names that differ only by case will collide
 		scope := taskresourcevolume.TaskScope
-		localVolume, err := taskresourcevolume.NewVolumeResource(ctx, volumeName,
+		localVolume, err := taskresourcevolume.NewVolumeResource(ctx, volumeName, HostVolumeType,
 			vol.Source(), scope, false,
 			taskresourcevolume.DockerLocalVolumeDriver,
 			make(map[string]string), make(map[string]string), dockerClient)
@@ -549,6 +549,7 @@ func (task *Task) addEFSVolumes(
 	volumeResource, err := taskresourcevolume.NewVolumeResource(
 		ctx,
 		vol.Name,
+		EFSVolumeType,
 		task.volumeName(vol.Name),
 		"task",
 		false,
@@ -579,6 +580,7 @@ func (task *Task) addTaskScopedVolumes(ctx context.Context, dockerClient dockera
 	volumeResource, err := taskresourcevolume.NewVolumeResource(
 		ctx,
 		vol.Name,
+		DockerVolumeType,
 		task.volumeName(vol.Name),
 		volumeConfig.Scope, volumeConfig.Autoprovision,
 		volumeConfig.Driver, volumeConfig.DriverOpts,
@@ -623,6 +625,7 @@ func (task *Task) addSharedVolumes(SharedVolumeMatchFullConfig bool, ctx context
 		volumeResource, err := taskresourcevolume.NewVolumeResource(
 			ctx,
 			vol.Name,
+			DockerVolumeType,
 			vol.Name,
 			volumeConfig.Scope, volumeConfig.Autoprovision,
 			volumeConfig.Driver, volumeConfig.DriverOpts,
@@ -1205,6 +1208,13 @@ func (task *Task) addNetworkResourceProvisioningDependency(cfg *config.Config) e
 		container.BuildContainerDependency(NetworkPauseContainerName, apicontainerstatus.ContainerResourcesProvisioned, apicontainerstatus.ContainerPulled)
 		pauseContainer.BuildContainerDependency(container.Name, apicontainerstatus.ContainerStopped, apicontainerstatus.ContainerStopped)
 	}
+
+	for _, resource := range task.GetResources() {
+		if resource.DependOnTaskNetwork() {
+			seelog.Debugf("Task [%s]: adding network pause container dependency to resource [%s]", task.Arn, resource.GetName())
+			resource.BuildContainerDependency(NetworkPauseContainerName, apicontainerstatus.ContainerResourcesProvisioned, resourcestatus.ResourceStatus(taskresourcevolume.VolumeCreated))
+		}
+	}
 	return nil
 }
 
@@ -1227,6 +1237,13 @@ func (task *Task) addNamespaceSharingProvisioningDependency(cfg *config.Config) 
 		}
 		container.BuildContainerDependency(NamespacePauseContainerName, apicontainerstatus.ContainerRunning, apicontainerstatus.ContainerPulled)
 		namespacePauseContainer.BuildContainerDependency(container.Name, apicontainerstatus.ContainerStopped, apicontainerstatus.ContainerStopped)
+	}
+
+	for _, resource := range task.GetResources() {
+		if resource.DependOnTaskNetwork() {
+			seelog.Debugf("Task [%s]: adding namespace pause container dependency to resource [%s]", task.Arn, resource.GetName())
+			resource.BuildContainerDependency(NamespacePauseContainerName, apicontainerstatus.ContainerRunning, resourcestatus.ResourceStatus(taskresourcevolume.VolumeCreated))
+		}
 	}
 }
 

--- a/agent/engine/dependencygraph/graph.go
+++ b/agent/engine/dependencygraph/graph.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -57,6 +57,11 @@ var (
 	// ErrResourceDependencyNotResolved is when the container's dependencies
 	// on task resources are not resolved
 	ErrResourceDependencyNotResolved = errors.New("dependency graph: dependency on resources not resolved")
+	// ResourcePastDesiredStatusErr is the error where the task resource known status is bigger than desired status
+	ResourcePastDesiredStatusErr = errors.New("task resource transition: task resource status is equal or greater than desired status")
+	// ErrContainerDependencyNotResolvedForResource is when the resource's dependencies
+	// on other containers are not resolved
+	ErrContainerDependencyNotResolvedForResource = errors.New("dependency graph: resource's dependency on containers not resolved")
 )
 
 // ValidDependencies takes a task and verifies that it is possible to allow all
@@ -156,6 +161,44 @@ func DependenciesAreResolved(target *apicontainer.Container,
 	}
 
 	return nil, nil
+}
+
+// TaskResourceDependenciesAreResolved validates that the `target` resource can be
+// transitioned given the current known state of the containers in `by`. If
+// this function returns true, `target` should be technically able to transit
+// without issues.
+// Transitions are between known statuses (whether the resource can move to
+// the next known status), not desired statuses; the desired status typically
+// is either CREATED or REMOVED.
+func TaskResourceDependenciesAreResolved(target taskresource.TaskResource,
+	by []*apicontainer.Container) error {
+
+	nameMap := make(map[string]*apicontainer.Container)
+	for _, cont := range by {
+		nameMap[cont.Name] = cont
+	}
+
+	if !verifyContainerDependenciesResolvedForResource(target, nameMap) {
+		return ErrContainerDependencyNotResolvedForResource
+	}
+
+	return nil
+}
+
+func verifyContainerDependenciesResolvedForResource(target taskresource.TaskResource, existingContainers map[string]*apicontainer.Container) bool {
+	targetNext := target.GetKnownStatus() + 1
+	// For task resource without dependency map, containerDependencies will just be nil
+	containerDependencies := target.GetContainerDependencies(targetNext)
+	for _, containerDependency := range containerDependencies {
+		dep, exists := existingContainers[containerDependency.ContainerName]
+		if !exists {
+			return false
+		}
+		if dep.GetKnownStatus() < containerDependency.SatisfiedStatus {
+			return false
+		}
+	}
+	return true
 }
 
 func linksToContainerNames(links []string) []string {

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -531,6 +531,10 @@ func (engine *DockerTaskEngine) sweepTask(task *apitask.Task) {
 
 func (engine *DockerTaskEngine) deleteTask(task *apitask.Task) {
 	for _, resource := range task.GetResources() {
+		// Resource already cleaned up if depends on task network, so skip cleanup here
+		if resource.DependOnTaskNetwork() {
+			continue
+		}
 		err := resource.Cleanup()
 		if err != nil {
 			seelog.Warnf("Task engine [%s]: unable to cleanup resource %s: %v",

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/ecscni"
 	mock_ecscni "github.com/aws/amazon-ecs-agent/agent/ecscni/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
+	mock_dockerstate "github.com/aws/amazon-ecs-agent/agent/engine/dockerstate/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/engine/image"
 	mock_engine "github.com/aws/amazon-ecs-agent/agent/engine/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/engine/testdata"
@@ -100,6 +101,7 @@ const (
 	networkBridgeIP             = "bridgeIP"
 	networkModeBridge           = "bridge"
 	networkModeAWSVPC           = "awsvpc"
+	taskArn                     = "task1"
 )
 
 var (
@@ -3083,4 +3085,37 @@ func TestStartFirelensContainerRetryForContainerIP(t *testing.T) {
 	ret := taskEngine.(*DockerTaskEngine).startContainer(testTask, testTask.Containers[1])
 	assert.NoError(t, ret.Error)
 	assert.Equal(t, jsonBaseWithNetwork.NetworkSettings, ret.NetworkSettings)
+}
+
+func TestDeleteTaskWithResourceDependOnTaskNetwork(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
+	//efsRes := efs.NewEFSResource(taskArn, "efsVolume", ctx, nil, false, "", "", nil, false, "", "")
+	volRes, _ := taskresourcevolume.NewVolumeResource(ctx, "volume", apitask.EFSVolumeType, "dockerVol", "scope",
+		false, "driver", nil, nil, nil)
+
+	task := &apitask.Task{
+		Arn: taskArn,
+	}
+	task.ResourcesMapUnsafe = make(map[string][]taskresource.TaskResource)
+	task.AddResource(volRes.Name, volRes)
+	cfg := defaultConfig
+	mockState := mock_dockerstate.NewMockTaskEngineState(ctrl)
+	mockSaver := mock_statemanager.NewMockStateManager(ctrl)
+
+	taskEngine := &DockerTaskEngine{
+		state: mockState,
+		saver: mockSaver,
+		cfg:   &cfg,
+	}
+
+	gomock.InOrder(
+		mockState.EXPECT().RemoveTask(task),
+		mockSaver.EXPECT().Save(),
+	)
+	taskEngine.deleteTask(task)
 }

--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -99,6 +99,8 @@ type resourceTransition struct {
 	// actionRequired indicates if the transition function needs to be called for
 	// the transition to be complete
 	actionRequired bool
+	// reason represents the error blocks transition
+	reason error
 }
 
 // managedTask is a type that is meant to manage the lifecycle of a task.
@@ -484,6 +486,7 @@ func (mtask *managedTask) handleResourceStateChange(resChange resourceStateChang
 			mtask.Arn, res.GetName())
 		mtask.SetDesiredStatus(apitaskstatus.TaskStopped)
 		mtask.Task.SetTerminalReason(res.GetTerminalReason())
+		res.UpdateAppliedStatus(resourcestatus.ResourceStatusNone)
 		mtask.engine.saver.Save()
 	}
 }
@@ -898,6 +901,7 @@ func (mtask *managedTask) startResourceTransitions(transitionFunc resourceTransi
 	for _, res := range mtask.GetResources() {
 		knownStatus := res.GetKnownStatus()
 		desiredStatus := res.GetDesiredStatus()
+		seelog.Debugf("Desired status is %s", desiredStatus)
 		if knownStatus >= desiredStatus {
 			seelog.Debugf("Managed task [%s]: resource [%s] has already transitioned to or beyond the desired status %s; current known is %s",
 				mtask.Arn, res.GetName(), res.StatusString(desiredStatus), res.StatusString(knownStatus))
@@ -1045,16 +1049,81 @@ func (mtask *managedTask) containerNextState(container *apicontainer.Container) 
 	}
 }
 
+// resourceNextState determines the next state a resource should go to.
+// It returns a transition struct including the information:
+// * resource state it should transition to,
+// * string presentation of the resource state
+// * a bool indicating whether any action is required
+// * an error indicating why this transition can't happen
+//
+// Next status is determined by whether the known and desired statuses are
+// equal, the next numerically greater (iota-wise) status, and whether
+// dependencies are fully resolved.
 func (mtask *managedTask) resourceNextState(resource taskresource.TaskResource) *resourceTransition {
-	if resource.DesiredTerminal() {
-		nextState := resource.TerminalStatus()
+	resKnownStatus := resource.GetKnownStatus()
+	resDesiredStatus := resource.GetDesiredStatus()
+
+	if resKnownStatus == resDesiredStatus {
+		seelog.Debugf("Managed task [%s]: task resource [%s] at desired status: %s",
+			mtask.Arn, resource.GetName(), resource.StatusString(resDesiredStatus))
+
+		// Set nextState to ResourceStatusNone, so the knownState will not be updated
 		return &resourceTransition{
-			nextState:      nextState,
-			status:         resource.StatusString(nextState),
-			actionRequired: false, // since resource cleanup will be done while sweeping task
+			nextState:      resourcestatus.ResourceStatusNone,
+			status:         resource.StatusString(resourcestatus.ResourceStatusNone),
+			actionRequired: false,
+			reason:         dependencygraph.ResourcePastDesiredStatusErr,
 		}
 	}
-	nextState := resource.NextKnownState()
+
+	if resKnownStatus > resDesiredStatus {
+		seelog.Debugf("Managed task [%s]: task resource [%s] has already transitioned beyond desired status(%s): %s",
+			mtask.Arn, resource.GetName(), resource.StatusString(resDesiredStatus), resource.StatusString(resKnownStatus))
+		return &resourceTransition{
+			nextState:      resourcestatus.ResourceStatusNone,
+			status:         resource.StatusString(resourcestatus.ResourceStatusNone),
+			actionRequired: false,
+			reason:         dependencygraph.ResourcePastDesiredStatusErr,
+		}
+	}
+	if err := dependencygraph.TaskResourceDependenciesAreResolved(resource, mtask.Containers); err != nil {
+		seelog.Debugf("Managed task [%s]: can't apply state to resource [%s] yet due to unresolved dependencies: %v",
+			mtask.Arn, resource.GetName(), err)
+		return &resourceTransition{
+			nextState:      resourcestatus.ResourceStatusNone,
+			status:         resource.StatusString(resourcestatus.ResourceStatusNone),
+			actionRequired: false,
+			reason:         err,
+		}
+	}
+
+	var nextState resourcestatus.ResourceStatus
+	if resource.DesiredTerminal() {
+		nextState := resource.TerminalStatus()
+		if !resource.KnownCreated() {
+			// If the resource's creation is in progress, we will not transit resource state before
+			// it finishes. Otherwise, the resource may not be cleaned up.
+			if resource.GetAppliedStatus() == resourcestatus.ResourceCreated {
+				nextState = resourcestatus.ResourceStatusNone
+			}
+			seelog.Debugf("set next state to %s", resource.StatusString(nextState))
+			return &resourceTransition{
+				nextState:      nextState,
+				status:         resource.StatusString(nextState),
+				actionRequired: false,
+			}
+		}
+		// If the resource does not have dependency on task network, it will be cleaned up while sweeping task
+		if !resource.DependOnTaskNetwork() {
+			return &resourceTransition{
+				nextState:      nextState,
+				status:         resource.StatusString(nextState),
+				actionRequired: false,
+			}
+		}
+	}
+	nextState = resource.NextKnownState()
+	seelog.Debugf("Resource next state is %s", nextState)
 	return &resourceTransition{
 		nextState:      nextState,
 		status:         resource.StatusString(nextState),

--- a/agent/engine/task_manager_test.go
+++ b/agent/engine/task_manager_test.go
@@ -1074,6 +1074,7 @@ func TestCleanupTask(t *testing.T) {
 	mockState.EXPECT().RemoveTask(mTask.Task)
 	mockResource.EXPECT().Cleanup()
 	mockResource.EXPECT().GetName()
+	mockResource.EXPECT().DependOnTaskNetwork().Return(false)
 	mTask.cleanupTask(taskStoppedDuration)
 }
 
@@ -1448,6 +1449,7 @@ func TestCleanupTaskWithResourceHappyPath(t *testing.T) {
 	mockState.EXPECT().RemoveTask(mTask.Task)
 	mockResource.EXPECT().GetName()
 	mockResource.EXPECT().Cleanup().Return(nil)
+	mockResource.EXPECT().DependOnTaskNetwork().Return(false)
 	mTask.cleanupTask(taskStoppedDuration)
 }
 
@@ -1510,6 +1512,7 @@ func TestCleanupTaskWithResourceErrorPath(t *testing.T) {
 	mockState.EXPECT().RemoveTask(mTask.Task)
 	mockResource.EXPECT().GetName()
 	mockResource.EXPECT().Cleanup().Return(errors.New("cleanup error"))
+	mockResource.EXPECT().DependOnTaskNetwork().Return(false)
 	mTask.cleanupTask(taskStoppedDuration)
 }
 

--- a/agent/engine/task_manager_unix_test.go
+++ b/agent/engine/task_manager_unix_test.go
@@ -21,10 +21,14 @@ import (
 	"sync"
 	"testing"
 
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
+	"github.com/aws/amazon-ecs-agent/agent/engine/dependencygraph"
 	mock_statemanager "github.com/aws/amazon-ecs-agent/agent/statemanager/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/cgroup"
 	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
+	"github.com/aws/amazon-ecs-agent/agent/taskresource/volume"
 	"github.com/golang/mock/gomock"
 
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
@@ -273,6 +277,150 @@ func TestStartResourceTransitionsEmpty(t *testing.T) {
 				})
 			assert.Equal(t, tc.CanTransition, canTransition)
 			assert.Empty(t, transitions)
+		})
+	}
+}
+
+// TestEFSResourceNextState uses EFS as an example of task resource with dependency on task network
+func TestEFSVolumeResourceNextState(t *testing.T) {
+	testCases := []struct {
+		Name             string
+		ResKnownStatus   resourcestatus.ResourceStatus
+		ResAppliedStatus resourcestatus.ResourceStatus
+		ResDesiredStatus resourcestatus.ResourceStatus
+		NextState        resourcestatus.ResourceStatus
+		ActionRequired   bool
+	}{
+		// None => Created
+		{"none to created", resourcestatus.ResourceStatus(volume.VolumeStatusNone), resourcestatus.ResourceStatus(volume.VolumeStatusNone), resourcestatus.ResourceStatus(volume.VolumeCreated), resourcestatus.ResourceStatus(volume.VolumeCreated), true},
+		// None => Removed, applied status is None
+		{"none to removed", resourcestatus.ResourceStatus(volume.VolumeStatusNone), resourcestatus.ResourceStatus(volume.VolumeStatusNone), resourcestatus.ResourceStatus(volume.VolumeRemoved), resourcestatus.ResourceStatus(volume.VolumeRemoved), false},
+		// None => Removed, applied status is Created
+		{"none to removed, applied created", resourcestatus.ResourceStatus(volume.VolumeStatusNone), resourcestatus.ResourceStatus(volume.VolumeCreated), resourcestatus.ResourceStatus(volume.VolumeRemoved), resourcestatus.ResourceStatus(volume.VolumeStatusNone), false},
+		// Created => Created
+		{"created to created", resourcestatus.ResourceStatus(volume.VolumeCreated), resourcestatus.ResourceStatus(volume.VolumeStatusNone), resourcestatus.ResourceStatus(volume.VolumeCreated), resourcestatus.ResourceStatus(volume.VolumeStatusNone), false},
+		// Created => Removed
+		{"created to removed", resourcestatus.ResourceStatus(volume.VolumeCreated), resourcestatus.ResourceStatus(volume.VolumeStatusNone), resourcestatus.ResourceStatus(volume.VolumeRemoved), resourcestatus.ResourceStatus(volume.VolumeRemoved), true},
+		// Removed => Created
+		{"removed to created", resourcestatus.ResourceStatus(volume.VolumeRemoved), resourcestatus.ResourceStatus(volume.VolumeStatusNone), resourcestatus.ResourceStatus(volume.VolumeCreated), resourcestatus.ResourceStatus(volume.VolumeStatusNone), false},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			res := volume.VolumeResource{
+				VolumeType: apitask.EFSVolumeType,
+			}
+			res.SetKnownStatus(tc.ResKnownStatus)
+			res.SetDesiredStatus(tc.ResDesiredStatus)
+			res.SetAppliedStatus(tc.ResAppliedStatus)
+			mtask := managedTask{
+				Task: &apitask.Task{},
+			}
+			transition := mtask.resourceNextState(&res)
+			assert.Equal(t, tc.NextState, transition.nextState)
+			assert.Equal(t, tc.ActionRequired, transition.actionRequired)
+		})
+	}
+}
+
+//TestEFSNextStateWithTransitionDependencies verifies the dependencies are resolved correctly for task resource
+func TestEFSVolumeNextStateWithTransitionDependencies(t *testing.T) {
+	testCases := []struct {
+		name                         string
+		resCurrentStatus             resourcestatus.ResourceStatus
+		resDesiredStatus             resourcestatus.ResourceStatus
+		resDependentStatus           resourcestatus.ResourceStatus
+		dependencyCurrentStatus      apicontainerstatus.ContainerStatus
+		dependencySatisfiedStatus    apicontainerstatus.ContainerStatus
+		expectedResourceStatus       resourcestatus.ResourceStatus
+		expectedTransitionActionable bool
+		reason                       error
+	}{
+		// NONE -> CREATED transition is not allowed and not actionable
+		{
+			name:                         "created depends on resourceProvisioned, dependency is none",
+			resCurrentStatus:             resourcestatus.ResourceStatus(volume.VolumeStatusNone),
+			resDesiredStatus:             resourcestatus.ResourceStatus(volume.VolumeCreated),
+			resDependentStatus:           resourcestatus.ResourceStatus(volume.VolumeCreated),
+			dependencyCurrentStatus:      apicontainerstatus.ContainerStatusNone,
+			dependencySatisfiedStatus:    apicontainerstatus.ContainerResourcesProvisioned,
+			expectedResourceStatus:       resourcestatus.ResourceStatus(volume.VolumeStatusNone),
+			expectedTransitionActionable: false,
+			reason:                       dependencygraph.ErrContainerDependencyNotResolvedForResource,
+		},
+		// NONE -> CREATED transition is allowed and actionable
+		{
+			name:                         "created depends on resourceProvisioned, dependency is resourceProvisioned",
+			resCurrentStatus:             resourcestatus.ResourceStatus(volume.VolumeStatusNone),
+			resDesiredStatus:             resourcestatus.ResourceStatus(volume.VolumeCreated),
+			resDependentStatus:           resourcestatus.ResourceStatus(volume.VolumeCreated),
+			dependencyCurrentStatus:      apicontainerstatus.ContainerResourcesProvisioned,
+			dependencySatisfiedStatus:    apicontainerstatus.ContainerResourcesProvisioned,
+			expectedResourceStatus:       resourcestatus.ResourceStatus(volume.VolumeCreated),
+			expectedTransitionActionable: true,
+		},
+		// CREATED -> REMOVED transition is allowed and actionable
+		{
+			name:                         "removed depends on stopped, dependency is stopped",
+			resCurrentStatus:             resourcestatus.ResourceStatus(volume.VolumeCreated),
+			resDesiredStatus:             resourcestatus.ResourceStatus(volume.VolumeRemoved),
+			resDependentStatus:           resourcestatus.ResourceStatus(volume.VolumeRemoved),
+			dependencyCurrentStatus:      apicontainerstatus.ContainerStopped,
+			dependencySatisfiedStatus:    apicontainerstatus.ContainerStopped,
+			expectedResourceStatus:       resourcestatus.ResourceStatus(volume.VolumeRemoved),
+			expectedTransitionActionable: true,
+		},
+		// NONE -> REMOVED transition is allowed and not actionable
+		{
+			name:                         "created depends on created, desired is stopped, dependency is created",
+			resCurrentStatus:             resourcestatus.ResourceStatus(volume.VolumeStatusNone),
+			resDesiredStatus:             resourcestatus.ResourceStatus(volume.VolumeRemoved),
+			resDependentStatus:           resourcestatus.ResourceStatus(volume.VolumeCreated),
+			dependencyCurrentStatus:      apicontainerstatus.ContainerCreated,
+			dependencySatisfiedStatus:    apicontainerstatus.ContainerCreated,
+			expectedResourceStatus:       resourcestatus.ResourceStatus(volume.VolumeRemoved),
+			expectedTransitionActionable: false,
+		},
+		// NONE -> REMOVED transition is not allowed and not actionable
+		{
+			name:                         "created depends on created, desired is stopped, dependency is none",
+			resCurrentStatus:             resourcestatus.ResourceStatus(volume.VolumeStatusNone),
+			resDesiredStatus:             resourcestatus.ResourceStatus(volume.VolumeRemoved),
+			resDependentStatus:           resourcestatus.ResourceStatus(volume.VolumeCreated),
+			dependencyCurrentStatus:      apicontainerstatus.ContainerStatusNone,
+			dependencySatisfiedStatus:    apicontainerstatus.ContainerCreated,
+			expectedResourceStatus:       resourcestatus.ResourceStatus(volume.VolumeStatusNone),
+			expectedTransitionActionable: false,
+			reason:                       dependencygraph.ErrContainerDependencyNotResolvedForResource,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.TODO())
+			defer cancel()
+			res, _ := volume.NewVolumeResource(ctx, "task1", apitask.EFSVolumeType, "volume1", "", false, "", nil, nil, nil)
+			dependencyName := "dependency"
+			dependency := &apicontainer.Container{
+				Name:              dependencyName,
+				KnownStatusUnsafe: tc.dependencyCurrentStatus,
+			}
+			res.BuildContainerDependency(dependencyName, tc.dependencySatisfiedStatus, tc.resDependentStatus)
+
+			res.SetKnownStatus(tc.resCurrentStatus)
+			res.SetDesiredStatus(tc.resDesiredStatus)
+			mtask := managedTask{
+				Task: &apitask.Task{
+					Containers: []*apicontainer.Container{
+						dependency,
+					},
+				},
+			}
+			transition := mtask.resourceNextState(res)
+			assert.Equal(t, tc.expectedResourceStatus, transition.nextState,
+				"Expected next state [%s] != Retrieved next state [%s]",
+				res.StatusString(tc.expectedResourceStatus), res.StatusString(transition.nextState))
+			assert.Equal(t, tc.expectedTransitionActionable, transition.actionRequired, "transition actionable")
+			assert.Equal(t, tc.reason, transition.reason, "transition possible")
 		})
 	}
 }

--- a/agent/taskresource/asmauth/asmauth.go
+++ b/agent/taskresource/asmauth/asmauth.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	"github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/agent/asm"
 	"github.com/aws/amazon-ecs-agent/agent/asm/factory"
@@ -33,8 +34,7 @@ import (
 
 const (
 	// ResourceName is the name of the ASM auth resource
-	ResourceName              = "asm-auth"
-	resourceProvisioningError = "TaskResourceError: Agent could not create task's platform resources"
+	ResourceName = "asm-auth"
 )
 
 // ASMAuthResource represents private registry credentials as a task resource.
@@ -407,4 +407,33 @@ func (auth *ASMAuthResource) UnmarshalJSON(b []byte) error {
 	auth.executionCredentialsID = temp.ExecutionCredentialsID
 
 	return nil
+}
+
+// GetAppliedStatus safely returns the currently applied status of the resource
+func (auth *ASMAuthResource) GetAppliedStatus() resourcestatus.ResourceStatus {
+	auth.lock.RLock()
+	defer auth.lock.RUnlock()
+
+	return auth.appliedStatus
+}
+
+func (auth *ASMAuthResource) DependOnTaskNetwork() bool {
+	return false
+}
+
+func (auth *ASMAuthResource) BuildContainerDependency(containerName string, satisfied apicontainerstatus.ContainerStatus,
+	dependent resourcestatus.ResourceStatus) error {
+	return errors.New("Not implemented")
+}
+
+func (auth *ASMAuthResource) GetContainerDependencies(dependent resourcestatus.ResourceStatus) []apicontainer.ContainerDependency {
+	return nil
+}
+
+// UpdateAppliedStatus safely updates the applied status of the resource
+func (auth *ASMAuthResource) UpdateAppliedStatus(status resourcestatus.ResourceStatus) {
+	auth.lock.RLock()
+	defer auth.lock.RUnlock()
+
+	auth.appliedStatus = status
 }

--- a/agent/taskresource/asmsecret/asmsecret.go
+++ b/agent/taskresource/asmsecret/asmsecret.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -24,6 +24,7 @@ import (
 	"github.com/pkg/errors"
 
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	"github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/agent/asm"
 	"github.com/aws/amazon-ecs-agent/agent/asm/factory"
@@ -436,4 +437,33 @@ func (secret *ASMSecretResource) UnmarshalJSON(b []byte) error {
 	secret.executionCredentialsID = temp.ExecutionCredentialsID
 
 	return nil
+}
+
+// GetAppliedStatus safely returns the currently applied status of the resource
+func (secret *ASMSecretResource) GetAppliedStatus() resourcestatus.ResourceStatus {
+	secret.lock.RLock()
+	defer secret.lock.RUnlock()
+
+	return secret.appliedStatus
+}
+
+func (secret *ASMSecretResource) DependOnTaskNetwork() bool {
+	return false
+}
+
+func (secret *ASMSecretResource) BuildContainerDependency(containerName string, satisfied apicontainerstatus.ContainerStatus,
+	dependent resourcestatus.ResourceStatus) error {
+	return errors.New("Not implemented")
+}
+
+func (secret *ASMSecretResource) GetContainerDependencies(dependent resourcestatus.ResourceStatus) []apicontainer.ContainerDependency {
+	return nil
+}
+
+// UpdateAppliedStatus safely updates the applied status of the resource
+func (secret *ASMSecretResource) UpdateAppliedStatus(status resourcestatus.ResourceStatus) {
+	secret.lock.RLock()
+	defer secret.lock.RUnlock()
+
+	secret.appliedStatus = status
 }

--- a/agent/taskresource/cgroup/cgroup.go
+++ b/agent/taskresource/cgroup/cgroup.go
@@ -22,6 +22,8 @@ import (
 	"sync"
 	"time"
 
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	"github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	control "github.com/aws/amazon-ecs-agent/agent/taskresource/cgroup/control"
@@ -208,6 +210,22 @@ func (cgroup *CgroupResource) SetAppliedStatus(status resourcestatus.ResourceSta
 	return true
 }
 
+// GetAppliedStatus safely returns the currently applied status of the resource
+func (cgroup *CgroupResource) GetAppliedStatus() resourcestatus.ResourceStatus {
+	cgroup.lock.RLock()
+	defer cgroup.lock.RUnlock()
+
+	return cgroup.appliedStatus
+}
+
+// UpdateAppliedStatus safely updates the applied status of the resource
+func (cgroup *CgroupResource) UpdateAppliedStatus(status resourcestatus.ResourceStatus) {
+	cgroup.lock.RLock()
+	defer cgroup.lock.RUnlock()
+
+	cgroup.appliedStatus = status
+}
+
 // GetKnownStatus safely returns the currently known status of the task
 func (cgroup *CgroupResource) GetKnownStatus() resourcestatus.ResourceStatus {
 	cgroup.lock.RLock()
@@ -370,4 +388,17 @@ func (cgroup *CgroupResource) Initialize(resourceFields *taskresource.ResourceFi
 	cgroup.initializeResourceStatusToTransitionFunction()
 	cgroup.ioutil = resourceFields.IOUtil
 	cgroup.control = resourceFields.Control
+}
+
+func (cgroup *CgroupResource) DependOnTaskNetwork() bool {
+	return false
+}
+
+func (cgroup *CgroupResource) BuildContainerDependency(containerName string, satisfied apicontainerstatus.ContainerStatus,
+	dependent resourcestatus.ResourceStatus) error {
+	return errors.New("Not implemented")
+}
+
+func (cgroup *CgroupResource) GetContainerDependencies(dependent resourcestatus.ResourceStatus) []apicontainer.ContainerDependency {
+	return nil
 }

--- a/agent/taskresource/cgroup/cgroup_unsupported.go
+++ b/agent/taskresource/cgroup/cgroup_unsupported.go
@@ -18,6 +18,8 @@ import (
 	"errors"
 	"time"
 
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	"github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
@@ -84,6 +86,14 @@ func (c *CgroupResource) GetKnownStatus() resourcestatus.ResourceStatus {
 	return resourcestatus.ResourceStatusNone
 }
 
+// UpdateAppliedStatus safely updates the applied status of the resource
+func (c *CgroupResource) UpdateAppliedStatus(status resourcestatus.ResourceStatus) {}
+
+// GetAppliedStatus safely returns the currently applied status of the resource
+func (c *CgroupResource) GetAppliedStatus() resourcestatus.ResourceStatus {
+	return resourcestatus.ResourceStatusNone
+}
+
 // SetCreatedAt sets the timestamp for resource's creation time
 func (c *CgroupResource) SetCreatedAt(createdAt time.Time) {}
 
@@ -125,4 +135,17 @@ func (c *CgroupResource) UnmarshalJSON(b []byte) error {
 func (cgroup *CgroupResource) Initialize(resourceFields *taskresource.ResourceFields,
 	taskKnownStatus status.TaskStatus,
 	taskDesiredStatus status.TaskStatus) {
+}
+
+func (cgroup *CgroupResource) DependOnTaskNetwork() bool {
+	return false
+}
+
+func (cgroup *CgroupResource) BuildContainerDependency(containerName string, satisfied apicontainerstatus.ContainerStatus,
+	dependent resourcestatus.ResourceStatus) error {
+	return errors.New("Not implemented")
+}
+
+func (cgroup *CgroupResource) GetContainerDependencies(dependent resourcestatus.ResourceStatus) []apicontainer.ContainerDependency {
+	return nil
 }

--- a/agent/taskresource/credentialspec/credentialspec_unsupported.go
+++ b/agent/taskresource/credentialspec/credentialspec_unsupported.go
@@ -18,6 +18,8 @@ package credentialspec
 import (
 	"time"
 
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	"github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/agent/credentials"
 	s3factory "github.com/aws/amazon-ecs-agent/agent/s3/factory"
@@ -152,4 +154,26 @@ func (cs *CredentialSpecResource) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON deserialises the raw JSON to a CredentialSpecResourceJSON struct
 func (cs *CredentialSpecResource) UnmarshalJSON(b []byte) error {
 	return errors.New("not implemented")
+}
+
+// GetAppliedStatus safely returns the currently applied status of the resource
+func (cs *CredentialSpecResource) GetAppliedStatus() resourcestatus.ResourceStatus {
+	return resourcestatus.ResourceStatusNone
+}
+
+func (cs *CredentialSpecResource) DependOnTaskNetwork() bool {
+	return false
+}
+
+func (cs *CredentialSpecResource) BuildContainerDependency(containerName string, satisfied apicontainerstatus.ContainerStatus,
+	dependent resourcestatus.ResourceStatus) error {
+	return errors.New("Not implemented")
+}
+
+func (cs *CredentialSpecResource) GetContainerDependencies(dependent resourcestatus.ResourceStatus) []apicontainer.ContainerDependency {
+	return nil
+}
+
+// UpdateAppliedStatus safely updates the applied status of the resource
+func (cs *CredentialSpecResource) UpdateAppliedStatus(status resourcestatus.ResourceStatus) {
 }

--- a/agent/taskresource/credentialspec/credentialspec_windows.go
+++ b/agent/taskresource/credentialspec/credentialspec_windows.go
@@ -24,6 +24,8 @@ import (
 	"sync"
 	"time"
 
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	"github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/agent/credentials"
 	"github.com/aws/amazon-ecs-agent/agent/s3"
@@ -629,4 +631,26 @@ func (cs *CredentialSpecResource) setCredentialSpecResourceLocation() error {
 	}
 
 	return nil
+}
+
+// GetAppliedStatus safely returns the currently applied status of the resource
+func (cs *CredentialSpecResource) GetAppliedStatus() resourcestatus.ResourceStatus {
+	return resourcestatus.ResourceStatusNone
+}
+
+func (cs *CredentialSpecResource) DependOnTaskNetwork() bool {
+	return false
+}
+
+func (cs *CredentialSpecResource) BuildContainerDependency(containerName string, satisfied apicontainerstatus.ContainerStatus,
+	dependent resourcestatus.ResourceStatus) error {
+	return errors.New("Not implemented")
+}
+
+func (cs *CredentialSpecResource) GetContainerDependencies(dependent resourcestatus.ResourceStatus) []apicontainer.ContainerDependency {
+	return nil
+}
+
+// UpdateAppliedStatus safely updates the applied status of the resource
+func (cs *CredentialSpecResource) UpdateAppliedStatus(status resourcestatus.ResourceStatus) {
 }

--- a/agent/taskresource/firelens/firelens_unimplemented.go
+++ b/agent/taskresource/firelens/firelens_unimplemented.go
@@ -19,6 +19,8 @@ import (
 	"errors"
 	"time"
 
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	"github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/agent/credentials"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
@@ -154,4 +156,25 @@ func (firelens *FirelensResource) UnmarshalJSON(b []byte) error {
 func (firelens *FirelensResource) Initialize(resourceFields *taskresource.ResourceFields,
 	taskKnownStatus status.TaskStatus,
 	taskDesiredStatus status.TaskStatus) {
+}
+
+// UpdateAppliedStatus safely updates the applied status of the resource
+func (firelens *FirelensResource) UpdateAppliedStatus(status resourcestatus.ResourceStatus) {}
+
+// GetAppliedStatus safely returns the currently applied status of the resource
+func (firelens *FirelensResource) GetAppliedStatus() resourcestatus.ResourceStatus {
+	return resourcestatus.ResourceStatusNone
+}
+
+func (firelens *FirelensResource) DependOnTaskNetwork() bool {
+	return false
+}
+
+func (firelens *FirelensResource) BuildContainerDependency(containerName string, satisfied apicontainerstatus.ContainerStatus,
+	dependent resourcestatus.ResourceStatus) error {
+	return errors.New("Not implemented")
+}
+
+func (firelens *FirelensResource) GetContainerDependencies(dependent resourcestatus.ResourceStatus) []apicontainer.ContainerDependency {
+	return nil
 }

--- a/agent/taskresource/firelens/firelens_unix.go
+++ b/agent/taskresource/firelens/firelens_unix.go
@@ -26,6 +26,8 @@ import (
 	"github.com/cihub/seelog"
 	"github.com/pkg/errors"
 
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	"github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/agent/credentials"
 	"github.com/aws/amazon-ecs-agent/agent/s3"
@@ -549,4 +551,22 @@ func (firelens *FirelensResource) Cleanup() error {
 
 	seelog.Infof("Removed firelens resource directory at %s", firelens.resourceDir)
 	return nil
+}
+
+func (firelens *FirelensResource) DependOnTaskNetwork() bool {
+	return false
+}
+
+func (firelens *FirelensResource) BuildContainerDependency(containerName string, satisfied apicontainerstatus.ContainerStatus,
+	dependent resourcestatus.ResourceStatus) error {
+	return errors.New("Not implemented")
+}
+
+func (firelens *FirelensResource) GetContainerDependencies(dependent resourcestatus.ResourceStatus) []apicontainer.ContainerDependency {
+	return nil
+}
+
+// UpdateAppliedStatus safely updates the applied status of the resource
+func (firelens *FirelensResource) UpdateAppliedStatus(status resourcestatus.ResourceStatus) {
+	firelens.SetAppliedStatus(status)
 }

--- a/agent/taskresource/interface.go
+++ b/agent/taskresource/interface.go
@@ -1,4 +1,4 @@
-// Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2014-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -17,6 +17,8 @@ import (
 	"encoding/json"
 	"time"
 
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	apitaskstatus "github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
 )
@@ -56,15 +58,38 @@ type TaskResource interface {
 	// SetAppliedStatus sets the applied status of resource and returns whether
 	// the resource is already in a transition
 	SetAppliedStatus(status resourcestatus.ResourceStatus) bool
+	// UpdateAppliedStatus directly updates the applied status of resource
+	UpdateAppliedStatus(status resourcestatus.ResourceStatus)
+	// GetAppliedStatus gets the applied status of resource
+	GetAppliedStatus() resourcestatus.ResourceStatus
 	// StatusString returns the string of the resource status
 	StatusString(status resourcestatus.ResourceStatus) string
 	// GetTerminalReason returns string describing why the resource failed to
 	// provision
 	GetTerminalReason() string
+	// DependOnTaskNetwork shows whether the resource creation needs task network setup beforehand
+	DependOnTaskNetwork() bool
+	// GetContainerDependencies returns dependent containers for a status
+	GetContainerDependencies(resourcestatus.ResourceStatus) []apicontainer.ContainerDependency
+	// BuildContainerDependency adds a new dependency container and its satisfied status
+	BuildContainerDependency(containerName string, satisfied apicontainerstatus.ContainerStatus,
+		dependent resourcestatus.ResourceStatus) error
 	// Initialize will initialze the resource fields of the resource
 	Initialize(res *ResourceFields,
 		taskKnownStatus apitaskstatus.TaskStatus, taskDesiredStatus apitaskstatus.TaskStatus)
 
 	json.Marshaler
 	json.Unmarshaler
+}
+
+// TransitionDependenciesMap is a map of the dependent resource status to other
+// dependencies that must be satisfied.
+type TransitionDependenciesMap map[resourcestatus.ResourceStatus]TransitionDependencySet
+
+// TransitionDependencySet contains dependencies that impact transitions of
+// resources.
+type TransitionDependencySet struct {
+	// ContainerDependencies is the set of containers on which a transition is
+	// dependent.
+	ContainerDependencies []apicontainer.ContainerDependency `json:"ContainerDependencies"`
 }

--- a/agent/taskresource/mocks/taskresource_mocks.go
+++ b/agent/taskresource/mocks/taskresource_mocks.go
@@ -1,4 +1,4 @@
-// Copyright 2015-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -22,9 +22,11 @@ import (
 	reflect "reflect"
 	time "time"
 
-	status "github.com/aws/amazon-ecs-agent/agent/api/task/status"
+	container "github.com/aws/amazon-ecs-agent/agent/api/container"
+	status "github.com/aws/amazon-ecs-agent/agent/api/container/status"
+	status0 "github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	taskresource "github.com/aws/amazon-ecs-agent/agent/taskresource"
-	status0 "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
+	status1 "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -52,8 +54,7 @@ func (m *MockTaskResource) EXPECT() *MockTaskResourceMockRecorder {
 }
 
 // ApplyTransition mocks base method
-func (m *MockTaskResource) ApplyTransition(arg0 status0.ResourceStatus) error {
-	m.ctrl.T.Helper()
+func (m *MockTaskResource) ApplyTransition(arg0 status1.ResourceStatus) error {
 	ret := m.ctrl.Call(m, "ApplyTransition", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -61,13 +62,23 @@ func (m *MockTaskResource) ApplyTransition(arg0 status0.ResourceStatus) error {
 
 // ApplyTransition indicates an expected call of ApplyTransition
 func (mr *MockTaskResourceMockRecorder) ApplyTransition(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyTransition", reflect.TypeOf((*MockTaskResource)(nil).ApplyTransition), arg0)
+}
+
+// BuildContainerDependency mocks base method
+func (m *MockTaskResource) BuildContainerDependency(arg0 string, arg1 status.ContainerStatus, arg2 status1.ResourceStatus) error {
+	ret := m.ctrl.Call(m, "BuildContainerDependency", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BuildContainerDependency indicates an expected call of BuildContainerDependency
+func (mr *MockTaskResourceMockRecorder) BuildContainerDependency(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildContainerDependency", reflect.TypeOf((*MockTaskResource)(nil).BuildContainerDependency), arg0, arg1, arg2)
 }
 
 // Cleanup mocks base method
 func (m *MockTaskResource) Cleanup() error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Cleanup")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -75,13 +86,11 @@ func (m *MockTaskResource) Cleanup() error {
 
 // Cleanup indicates an expected call of Cleanup
 func (mr *MockTaskResourceMockRecorder) Cleanup() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Cleanup", reflect.TypeOf((*MockTaskResource)(nil).Cleanup))
 }
 
 // Create mocks base method
 func (m *MockTaskResource) Create() error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -89,13 +98,23 @@ func (m *MockTaskResource) Create() error {
 
 // Create indicates an expected call of Create
 func (mr *MockTaskResourceMockRecorder) Create() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockTaskResource)(nil).Create))
+}
+
+// DependOnTaskNetwork mocks base method
+func (m *MockTaskResource) DependOnTaskNetwork() bool {
+	ret := m.ctrl.Call(m, "DependOnTaskNetwork")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// DependOnTaskNetwork indicates an expected call of DependOnTaskNetwork
+func (mr *MockTaskResourceMockRecorder) DependOnTaskNetwork() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DependOnTaskNetwork", reflect.TypeOf((*MockTaskResource)(nil).DependOnTaskNetwork))
 }
 
 // DesiredTerminal mocks base method
 func (m *MockTaskResource) DesiredTerminal() bool {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DesiredTerminal")
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -103,13 +122,35 @@ func (m *MockTaskResource) DesiredTerminal() bool {
 
 // DesiredTerminal indicates an expected call of DesiredTerminal
 func (mr *MockTaskResourceMockRecorder) DesiredTerminal() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DesiredTerminal", reflect.TypeOf((*MockTaskResource)(nil).DesiredTerminal))
+}
+
+// GetAppliedStatus mocks base method
+func (m *MockTaskResource) GetAppliedStatus() status1.ResourceStatus {
+	ret := m.ctrl.Call(m, "GetAppliedStatus")
+	ret0, _ := ret[0].(status1.ResourceStatus)
+	return ret0
+}
+
+// GetAppliedStatus indicates an expected call of GetAppliedStatus
+func (mr *MockTaskResourceMockRecorder) GetAppliedStatus() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAppliedStatus", reflect.TypeOf((*MockTaskResource)(nil).GetAppliedStatus))
+}
+
+// GetContainerDependencies mocks base method
+func (m *MockTaskResource) GetContainerDependencies(arg0 status1.ResourceStatus) []container.ContainerDependency {
+	ret := m.ctrl.Call(m, "GetContainerDependencies", arg0)
+	ret0, _ := ret[0].([]container.ContainerDependency)
+	return ret0
+}
+
+// GetContainerDependencies indicates an expected call of GetContainerDependencies
+func (mr *MockTaskResourceMockRecorder) GetContainerDependencies(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContainerDependencies", reflect.TypeOf((*MockTaskResource)(nil).GetContainerDependencies), arg0)
 }
 
 // GetCreatedAt mocks base method
 func (m *MockTaskResource) GetCreatedAt() time.Time {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCreatedAt")
 	ret0, _ := ret[0].(time.Time)
 	return ret0
@@ -117,41 +158,35 @@ func (m *MockTaskResource) GetCreatedAt() time.Time {
 
 // GetCreatedAt indicates an expected call of GetCreatedAt
 func (mr *MockTaskResourceMockRecorder) GetCreatedAt() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCreatedAt", reflect.TypeOf((*MockTaskResource)(nil).GetCreatedAt))
 }
 
 // GetDesiredStatus mocks base method
-func (m *MockTaskResource) GetDesiredStatus() status0.ResourceStatus {
-	m.ctrl.T.Helper()
+func (m *MockTaskResource) GetDesiredStatus() status1.ResourceStatus {
 	ret := m.ctrl.Call(m, "GetDesiredStatus")
-	ret0, _ := ret[0].(status0.ResourceStatus)
+	ret0, _ := ret[0].(status1.ResourceStatus)
 	return ret0
 }
 
 // GetDesiredStatus indicates an expected call of GetDesiredStatus
 func (mr *MockTaskResourceMockRecorder) GetDesiredStatus() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDesiredStatus", reflect.TypeOf((*MockTaskResource)(nil).GetDesiredStatus))
 }
 
 // GetKnownStatus mocks base method
-func (m *MockTaskResource) GetKnownStatus() status0.ResourceStatus {
-	m.ctrl.T.Helper()
+func (m *MockTaskResource) GetKnownStatus() status1.ResourceStatus {
 	ret := m.ctrl.Call(m, "GetKnownStatus")
-	ret0, _ := ret[0].(status0.ResourceStatus)
+	ret0, _ := ret[0].(status1.ResourceStatus)
 	return ret0
 }
 
 // GetKnownStatus indicates an expected call of GetKnownStatus
 func (mr *MockTaskResourceMockRecorder) GetKnownStatus() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKnownStatus", reflect.TypeOf((*MockTaskResource)(nil).GetKnownStatus))
 }
 
 // GetName mocks base method
 func (m *MockTaskResource) GetName() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetName")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -159,13 +194,11 @@ func (m *MockTaskResource) GetName() string {
 
 // GetName indicates an expected call of GetName
 func (mr *MockTaskResourceMockRecorder) GetName() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetName", reflect.TypeOf((*MockTaskResource)(nil).GetName))
 }
 
 // GetTerminalReason mocks base method
 func (m *MockTaskResource) GetTerminalReason() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTerminalReason")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -173,25 +206,21 @@ func (m *MockTaskResource) GetTerminalReason() string {
 
 // GetTerminalReason indicates an expected call of GetTerminalReason
 func (mr *MockTaskResourceMockRecorder) GetTerminalReason() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTerminalReason", reflect.TypeOf((*MockTaskResource)(nil).GetTerminalReason))
 }
 
 // Initialize mocks base method
-func (m *MockTaskResource) Initialize(arg0 *taskresource.ResourceFields, arg1, arg2 status.TaskStatus) {
-	m.ctrl.T.Helper()
+func (m *MockTaskResource) Initialize(arg0 *taskresource.ResourceFields, arg1, arg2 status0.TaskStatus) {
 	m.ctrl.Call(m, "Initialize", arg0, arg1, arg2)
 }
 
 // Initialize indicates an expected call of Initialize
 func (mr *MockTaskResourceMockRecorder) Initialize(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Initialize", reflect.TypeOf((*MockTaskResource)(nil).Initialize), arg0, arg1, arg2)
 }
 
 // KnownCreated mocks base method
 func (m *MockTaskResource) KnownCreated() bool {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "KnownCreated")
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -199,13 +228,11 @@ func (m *MockTaskResource) KnownCreated() bool {
 
 // KnownCreated indicates an expected call of KnownCreated
 func (mr *MockTaskResourceMockRecorder) KnownCreated() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KnownCreated", reflect.TypeOf((*MockTaskResource)(nil).KnownCreated))
 }
 
 // MarshalJSON mocks base method
 func (m *MockTaskResource) MarshalJSON() ([]byte, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MarshalJSON")
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
@@ -214,27 +241,23 @@ func (m *MockTaskResource) MarshalJSON() ([]byte, error) {
 
 // MarshalJSON indicates an expected call of MarshalJSON
 func (mr *MockTaskResourceMockRecorder) MarshalJSON() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarshalJSON", reflect.TypeOf((*MockTaskResource)(nil).MarshalJSON))
 }
 
 // NextKnownState mocks base method
-func (m *MockTaskResource) NextKnownState() status0.ResourceStatus {
-	m.ctrl.T.Helper()
+func (m *MockTaskResource) NextKnownState() status1.ResourceStatus {
 	ret := m.ctrl.Call(m, "NextKnownState")
-	ret0, _ := ret[0].(status0.ResourceStatus)
+	ret0, _ := ret[0].(status1.ResourceStatus)
 	return ret0
 }
 
 // NextKnownState indicates an expected call of NextKnownState
 func (mr *MockTaskResourceMockRecorder) NextKnownState() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NextKnownState", reflect.TypeOf((*MockTaskResource)(nil).NextKnownState))
 }
 
 // SetAppliedStatus mocks base method
-func (m *MockTaskResource) SetAppliedStatus(arg0 status0.ResourceStatus) bool {
-	m.ctrl.T.Helper()
+func (m *MockTaskResource) SetAppliedStatus(arg0 status1.ResourceStatus) bool {
 	ret := m.ctrl.Call(m, "SetAppliedStatus", arg0)
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -242,49 +265,41 @@ func (m *MockTaskResource) SetAppliedStatus(arg0 status0.ResourceStatus) bool {
 
 // SetAppliedStatus indicates an expected call of SetAppliedStatus
 func (mr *MockTaskResourceMockRecorder) SetAppliedStatus(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAppliedStatus", reflect.TypeOf((*MockTaskResource)(nil).SetAppliedStatus), arg0)
 }
 
 // SetCreatedAt mocks base method
 func (m *MockTaskResource) SetCreatedAt(arg0 time.Time) {
-	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetCreatedAt", arg0)
 }
 
 // SetCreatedAt indicates an expected call of SetCreatedAt
 func (mr *MockTaskResourceMockRecorder) SetCreatedAt(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCreatedAt", reflect.TypeOf((*MockTaskResource)(nil).SetCreatedAt), arg0)
 }
 
 // SetDesiredStatus mocks base method
-func (m *MockTaskResource) SetDesiredStatus(arg0 status0.ResourceStatus) {
-	m.ctrl.T.Helper()
+func (m *MockTaskResource) SetDesiredStatus(arg0 status1.ResourceStatus) {
 	m.ctrl.Call(m, "SetDesiredStatus", arg0)
 }
 
 // SetDesiredStatus indicates an expected call of SetDesiredStatus
 func (mr *MockTaskResourceMockRecorder) SetDesiredStatus(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDesiredStatus", reflect.TypeOf((*MockTaskResource)(nil).SetDesiredStatus), arg0)
 }
 
 // SetKnownStatus mocks base method
-func (m *MockTaskResource) SetKnownStatus(arg0 status0.ResourceStatus) {
-	m.ctrl.T.Helper()
+func (m *MockTaskResource) SetKnownStatus(arg0 status1.ResourceStatus) {
 	m.ctrl.Call(m, "SetKnownStatus", arg0)
 }
 
 // SetKnownStatus indicates an expected call of SetKnownStatus
 func (mr *MockTaskResourceMockRecorder) SetKnownStatus(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetKnownStatus", reflect.TypeOf((*MockTaskResource)(nil).SetKnownStatus), arg0)
 }
 
 // StatusString mocks base method
-func (m *MockTaskResource) StatusString(arg0 status0.ResourceStatus) string {
-	m.ctrl.T.Helper()
+func (m *MockTaskResource) StatusString(arg0 status1.ResourceStatus) string {
 	ret := m.ctrl.Call(m, "StatusString", arg0)
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -292,41 +307,35 @@ func (m *MockTaskResource) StatusString(arg0 status0.ResourceStatus) string {
 
 // StatusString indicates an expected call of StatusString
 func (mr *MockTaskResourceMockRecorder) StatusString(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StatusString", reflect.TypeOf((*MockTaskResource)(nil).StatusString), arg0)
 }
 
 // SteadyState mocks base method
-func (m *MockTaskResource) SteadyState() status0.ResourceStatus {
-	m.ctrl.T.Helper()
+func (m *MockTaskResource) SteadyState() status1.ResourceStatus {
 	ret := m.ctrl.Call(m, "SteadyState")
-	ret0, _ := ret[0].(status0.ResourceStatus)
+	ret0, _ := ret[0].(status1.ResourceStatus)
 	return ret0
 }
 
 // SteadyState indicates an expected call of SteadyState
 func (mr *MockTaskResourceMockRecorder) SteadyState() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SteadyState", reflect.TypeOf((*MockTaskResource)(nil).SteadyState))
 }
 
 // TerminalStatus mocks base method
-func (m *MockTaskResource) TerminalStatus() status0.ResourceStatus {
-	m.ctrl.T.Helper()
+func (m *MockTaskResource) TerminalStatus() status1.ResourceStatus {
 	ret := m.ctrl.Call(m, "TerminalStatus")
-	ret0, _ := ret[0].(status0.ResourceStatus)
+	ret0, _ := ret[0].(status1.ResourceStatus)
 	return ret0
 }
 
 // TerminalStatus indicates an expected call of TerminalStatus
 func (mr *MockTaskResourceMockRecorder) TerminalStatus() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TerminalStatus", reflect.TypeOf((*MockTaskResource)(nil).TerminalStatus))
 }
 
 // UnmarshalJSON mocks base method
 func (m *MockTaskResource) UnmarshalJSON(arg0 []byte) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UnmarshalJSON", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -334,6 +343,15 @@ func (m *MockTaskResource) UnmarshalJSON(arg0 []byte) error {
 
 // UnmarshalJSON indicates an expected call of UnmarshalJSON
 func (mr *MockTaskResourceMockRecorder) UnmarshalJSON(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnmarshalJSON", reflect.TypeOf((*MockTaskResource)(nil).UnmarshalJSON), arg0)
+}
+
+// UpdateAppliedStatus mocks base method
+func (m *MockTaskResource) UpdateAppliedStatus(arg0 status1.ResourceStatus) {
+	m.ctrl.Call(m, "UpdateAppliedStatus", arg0)
+}
+
+// UpdateAppliedStatus indicates an expected call of UpdateAppliedStatus
+func (mr *MockTaskResourceMockRecorder) UpdateAppliedStatus(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAppliedStatus", reflect.TypeOf((*MockTaskResource)(nil).UpdateAppliedStatus), arg0)
 }

--- a/agent/taskresource/ssmsecret/ssmsecret.go
+++ b/agent/taskresource/ssmsecret/ssmsecret.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pkg/errors"
 
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	"github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/agent/credentials"
 	"github.com/aws/amazon-ecs-agent/agent/ssm"
@@ -478,4 +479,33 @@ func (secret *SSMSecretResource) UnmarshalJSON(b []byte) error {
 	secret.executionCredentialsID = temp.ExecutionCredentialsID
 
 	return nil
+}
+
+// GetAppliedStatus safely returns the currently applied status of the resource
+func (secret *SSMSecretResource) GetAppliedStatus() resourcestatus.ResourceStatus {
+	secret.lock.RLock()
+	defer secret.lock.RUnlock()
+
+	return secret.appliedStatus
+}
+
+func (secret *SSMSecretResource) DependOnTaskNetwork() bool {
+	return false
+}
+
+func (secret *SSMSecretResource) BuildContainerDependency(containerName string, satisfied apicontainerstatus.ContainerStatus,
+	dependent resourcestatus.ResourceStatus) error {
+	return errors.New("Not implemented")
+}
+
+func (secret *SSMSecretResource) GetContainerDependencies(dependent resourcestatus.ResourceStatus) []apicontainer.ContainerDependency {
+	return nil
+}
+
+// UpdateAppliedStatus safely updates the applied status of the resource
+func (secret *SSMSecretResource) UpdateAppliedStatus(status resourcestatus.ResourceStatus) {
+	secret.lock.RLock()
+	defer secret.lock.RUnlock()
+
+	secret.appliedStatus = status
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Implemented dependency logic so that EFS type volume task resource wait for pause container to be finished.

### TODO
1. Cleanup logic
2. Aggregate plugin required input
3. Functional tests

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes

Verified by mock aws vpc mode on agent. Some key logs that verified dependency is working as expected.
```
2020-01-02T23:44:25Z [DEBUG] Task [xxxx]: adding network pause container dependency to resource [task-efs-shared]
2020-01-02T23:44:25Z [DEBUG] Managed task [xxxx]: can't apply state to resource [task-efs-shared] yet due to unresolved dependencies: dependency graph: resource's dependency on containers not resolved
2020-01-02T23:44:26Z [DEBUG] Managed task [xxxx]: container [~internal~ecs~pause] at desired status: RESOURCES_PROVISIONED
2020-01-02T23:44:26Z [INFO] Managed task [xxxx]: transitioned resource [task-efs-shared] to [CREATED]
2020-01-02T23:44:26Z [INFO] Managed task [xxxx]: got resource [task-efs-shared] event: [CREATED]
```

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
