### PR TITLE
[WIP] Add custom context to logs

### DIFF
--- a/agent/acs/handler/acs_handler_test.go
+++ b/agent/acs/handler/acs_handler_test.go
@@ -868,7 +868,7 @@ func TestHandlerDoesntLeakGoroutines(t *testing.T) {
 
 	// The number of goroutines finishing in the MockACSServer will affect
 	// the result unless we wait here.
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(250 * time.Millisecond)
 	afterGoroutines := runtime.NumGoroutine()
 
 	t.Logf("Goroutines after 1 and after %v acs messages: %v and %v", timesConnected, beforeGoroutines, afterGoroutines)

--- a/agent/api/container/container.go
+++ b/agent/api/container/container.go
@@ -1001,7 +1001,7 @@ func (c *Container) GetLogDriver() string {
 	hostConfig := &dockercontainer.HostConfig{}
 	err := json.Unmarshal([]byte(*c.DockerConfig.HostConfig), hostConfig)
 	if err != nil {
-		seelog.Warnf("Encountered error when trying to get log driver for container %s: %v", err)
+		seelog.Warnf("Encountered error when trying to get log driver for container %s: %v", c.String(), err)
 		return ""
 	}
 
@@ -1021,7 +1021,7 @@ func (c *Container) GetNetworkModeFromHostConfig() string {
 	// TODO return error to differentiate between error and default mode .
 	err := json.Unmarshal([]byte(*c.DockerConfig.HostConfig), hostConfig)
 	if err != nil {
-		seelog.Warnf("Encountered error when trying to get network mode for container %s: %v", err)
+		seelog.Warnf("Encountered error when trying to get network mode for container %s: %v", c.String(), err)
 		return ""
 	}
 

--- a/agent/api/task/json.go
+++ b/agent/api/task/json.go
@@ -28,3 +28,13 @@ func (t *Task) MarshalJSON() ([]byte, error) {
 
 	return json.Marshal((*jTask)(t))
 }
+
+// UnmarshalJSON wraps Go's unmarshalling logic to guarantee that the logger gets created
+func (t *Task) UnmarshalJSON(data []byte) error {
+	err := json.Unmarshal(data, (*jTask)(t))
+	if err != nil {
+		return err
+	}
+	t.initLog()
+	return nil
+}

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -24,6 +24,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/aws/amazon-ecs-agent/agent/logger"
 	"github.com/aws/amazon-ecs-agent/agent/utils/ttime"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
@@ -253,6 +254,9 @@ type Task struct {
 
 	// lock is for protecting all fields in the task struct
 	lock sync.RWMutex
+
+	// log is a custom logger with extra context specific to the task struct
+	log seelog.LoggerInterface
 }
 
 // TaskFromACS translates ecsacs.Task to apitask.Task by first marshaling the received
@@ -282,7 +286,19 @@ func TaskFromACS(acsTask *ecsacs.Task, envelope *ecsacs.PayloadMessage) (*Task, 
 
 	//initialize resources map for task
 	task.ResourcesMapUnsafe = make(map[string][]taskresource.TaskResource)
+	task.initLog()
 	return task, nil
+}
+
+func (task *Task) initLog() {
+	if task.log == nil {
+		task.log = logger.InitLogger()
+		task.log.SetContext(map[string]string{
+			"taskARN":     task.Arn,
+			"taskFamily":  task.Family,
+			"taskVersion": task.Version,
+		})
+	}
 }
 
 func (task *Task) initializeVolumes(cfg *config.Config, dockerClient dockerapi.DockerClient, ctx context.Context) error {
@@ -309,21 +325,22 @@ func (task *Task) PostUnmarshalTask(cfg *config.Config,
 	dockerClient dockerapi.DockerClient, ctx context.Context) error {
 	// TODO, add rudimentary plugin support and call any plugins that want to
 	// hook into this
+	task.initLog()
 	task.adjustForPlatform(cfg)
 	if task.MemoryCPULimitsEnabled {
 		if err := task.initializeCgroupResourceSpec(cfg.CgroupPath, cfg.CgroupCPUPeriod, resourceFields); err != nil {
-			seelog.Errorf("Task [%s]: could not intialize resource: %v", task.Arn, err)
+			task.log.Errorf("could not intialize resource: %v", err)
 			return apierrors.NewResourceInitError(task.Arn, err)
 		}
 	}
 
 	if err := task.initializeContainerOrderingForVolumes(); err != nil {
-		seelog.Errorf("Task [%s]: could not initialize volumes dependency for container: %v", task.Arn, err)
+		task.log.Errorf("could not initialize volumes dependency for container: %v", err)
 		return apierrors.NewResourceInitError(task.Arn, err)
 	}
 
 	if err := task.initializeContainerOrderingForLinks(); err != nil {
-		seelog.Errorf("Task [%s]: could not initialize links dependency for container: %v", task.Arn, err)
+		task.log.Errorf("could not initialize links dependency for container: %v", err)
 		return apierrors.NewResourceInitError(task.Arn, err)
 	}
 
@@ -344,14 +361,14 @@ func (task *Task) PostUnmarshalTask(cfg *config.Config,
 	}
 
 	if err := task.addGPUResource(cfg); err != nil {
-		seelog.Errorf("Task [%s]: could not initialize GPU associations: %v", task.Arn, err)
+		task.log.Errorf("could not initialize GPU associations: %v", err)
 		return apierrors.NewResourceInitError(task.Arn, err)
 	}
 
 	task.initializeCredentialsEndpoint(credentialsManager)
 	task.initializeContainersV3MetadataEndpoint(utils.NewDynamicUUIDProvider())
 	if err := task.addNetworkResourceProvisioningDependency(cfg); err != nil {
-		seelog.Errorf("Task [%s]: could not provision network resource: %v", task.Arn, err)
+		task.log.Errorf("could not provision network resource: %v", err)
 		return apierrors.NewResourceInitError(task.Arn, err)
 	}
 	// Adds necessary Pause containers for sharing PID or IPC namespaces
@@ -363,7 +380,7 @@ func (task *Task) PostUnmarshalTask(cfg *config.Config,
 
 	if task.requiresCredentialSpecResource() {
 		if err := task.initializeCredentialSpecResource(cfg, credentialsManager, resourceFields); err != nil {
-			seelog.Errorf("Task [%s]: could not initialize credentialspec resource: %v", task.Arn, err)
+			task.log.Errorf("could not initialize credentialspec resource: %v", err)
 			return apierrors.NewResourceInitError(task.Arn, err)
 		}
 	}
@@ -619,7 +636,7 @@ func (task *Task) addSharedVolumes(SharedVolumeMatchFullConfig bool, ctx context
 			return volumeMetadata.Error
 		}
 
-		seelog.Infof("initialize volume: Task [%s]: non-autoprovisioned volume not found, adding to task resource %q", task.Arn, vol.Name)
+		task.log.Infof("initialize volume: non-autoprovisioned volume not found, adding to task resource %q", vol.Name)
 		// this resource should be created by agent
 		volumeResource, err := taskresourcevolume.NewVolumeResource(
 			ctx,
@@ -637,22 +654,22 @@ func (task *Task) addSharedVolumes(SharedVolumeMatchFullConfig bool, ctx context
 		return nil
 	}
 
-	seelog.Infof("initialize volume: Task [%s]: volume [%s] already exists", task.Arn, volumeConfig.DockerVolumeName)
+	task.log.Infof("initialize volume: volume [%s] already exists", volumeConfig.DockerVolumeName)
 	if !SharedVolumeMatchFullConfig {
-		seelog.Infof("initialize volume: Task [%s]: ECS_SHARED_VOLUME_MATCH_FULL_CONFIG is set to false and volume with name [%s] is found", task.Arn, volumeConfig.DockerVolumeName)
+		task.log.Infof("initialize volume: ECS_SHARED_VOLUME_MATCH_FULL_CONFIG is set to false and volume with name [%s] is found", volumeConfig.DockerVolumeName)
 		return nil
 	}
 
 	// validate all the volume metadata fields match to the configuration
 	if len(volumeMetadata.DockerVolume.Labels) == 0 && len(volumeMetadata.DockerVolume.Labels) == len(volumeConfig.Labels) {
-		seelog.Infof("labels are both empty or null: Task [%s]: volume [%s]", task.Arn, volumeConfig.DockerVolumeName)
+		task.log.Infof("labels are both empty or null: volume [%s]", volumeConfig.DockerVolumeName)
 	} else if !reflect.DeepEqual(volumeMetadata.DockerVolume.Labels, volumeConfig.Labels) {
 		return errors.Errorf("intialize volume: non-autoprovisioned volume does not match existing volume labels: existing: %v, expected: %v",
 			volumeMetadata.DockerVolume.Labels, volumeConfig.Labels)
 	}
 
 	if len(volumeMetadata.DockerVolume.Options) == 0 && len(volumeMetadata.DockerVolume.Options) == len(volumeConfig.DriverOpts) {
-		seelog.Infof("driver options are both empty or null: Task [%s]: volume [%s]", task.Arn, volumeConfig.DockerVolumeName)
+		task.log.Infof("driver options are both empty or null: volume [%s]", volumeConfig.DockerVolumeName)
 	} else if !reflect.DeepEqual(volumeMetadata.DockerVolume.Options, volumeConfig.DriverOpts) {
 		return errors.Errorf("initialize volume: non-autoprovisioned volume does not match existing volume options: existing: %v, expected: %v",
 			volumeMetadata.DockerVolume.Options, volumeConfig.DriverOpts)
@@ -689,7 +706,7 @@ func (task *Task) initializeCredentialsEndpoint(credentialsManager credentials.M
 		// the id. This should never happen as the payload handler sets
 		// credentialsId for the task after adding credentials to the
 		// credentials manager
-		seelog.Errorf("Unable to get credentials for task: %s", task.Arn)
+		task.log.Errorf("Unable to get credentials for task")
 		return
 	}
 
@@ -953,7 +970,7 @@ func (task *Task) addFirelensContainerDependency() error {
 	if firelensContainer.HasContainerDependencies() {
 		// If firelens container has any container dependency, we don't add internal container dependency that depends
 		// on it in order to be safe (otherwise we need to deal with circular dependency).
-		seelog.Warnf("Not adding container dependency to let firelens container %s start first, because it has dependency on other containers.", firelensContainer.Name)
+		task.log.Warnf("Not adding container dependency to let firelens container %s start first, because it has dependency on other containers.", firelensContainer.Name)
 		return nil
 	}
 
@@ -977,7 +994,7 @@ func (task *Task) addFirelensContainerDependency() error {
 			// If there's no dependency between the app container and the firelens container, make firelens container
 			// start first to be the default behavior by adding a START container depdendency.
 			if !container.DependsOnContainer(firelensContainer.Name) {
-				seelog.Infof("Adding a START container dependency on firelens container %s for container %s",
+				task.log.Infof("Adding a START container dependency on firelens container %s for container %s",
 					firelensContainer.Name, container.Name)
 				container.AddContainerDependency(firelensContainer.Name, ContainerOrderingStartCondition)
 			}
@@ -1278,7 +1295,7 @@ func (task *Task) UpdateMountPoints(cont *apicontainer.Container, vols []types.M
 // there was no change
 // Invariant: task known status is the minimum of container known status
 func (task *Task) updateTaskKnownStatus() (newStatus apitaskstatus.TaskStatus) {
-	seelog.Debugf("api/task: Updating task's known status, task: %s", task.String())
+	task.log.Debugf("api/task: Updating task's known status")
 	// Set to a large 'impossible' status that can't be the min
 	containerEarliestKnownStatus := apicontainerstatus.ContainerZombie
 	var earliestKnownStatusContainer *apicontainer.Container
@@ -1294,19 +1311,17 @@ func (task *Task) updateTaskKnownStatus() (newStatus apitaskstatus.TaskStatus) {
 		}
 	}
 	if earliestKnownStatusContainer == nil {
-		seelog.Criticalf(
-			"Impossible state found while updating tasks's known status, earliest state recorded as %s for task [%v]",
-			containerEarliestKnownStatus.String(), task)
+		task.log.Criticalf(
+			"Impossible state found while updating tasks's known status, earliest state recorded as %s",
+			containerEarliestKnownStatus.String())
 		return apitaskstatus.TaskStatusNone
 	}
-	seelog.Debugf("api/task: Container with earliest known container is [%s] for task: %s",
-		earliestKnownStatusContainer.String(), task.String())
+	task.log.Debugf("api/task: Container with earliest known container is [%s]",
+		earliestKnownStatusContainer.String())
 	// If the essential container is stopped while other containers may be running
 	// don't update the task status until the other containers are stopped.
 	if earliestKnownStatusContainer.IsKnownSteadyState() && essentialContainerStopped {
-		seelog.Debugf(
-			"Essential container is stopped while other containers are running, not updating task status for task: %s",
-			task.String())
+		task.log.Debugf("Essential container is stopped while other containers are running, not updating task status")
 		return apitaskstatus.TaskStatusNone
 	}
 	// We can't rely on earliest container known status alone for determining if the
@@ -1315,8 +1330,8 @@ func (task *Task) updateTaskKnownStatus() (newStatus apitaskstatus.TaskStatus) {
 	// statuses and compute the min of this
 	earliestKnownTaskStatus := task.getEarliestKnownTaskStatusForContainers()
 	if task.GetKnownStatus() < earliestKnownTaskStatus {
-		seelog.Infof("api/task: Updating task's known status to: %s, task: %s",
-			earliestKnownTaskStatus.String(), task.String())
+		task.log.Infof("api/task: Updating task's known status to: %s",
+			earliestKnownTaskStatus.String())
 		task.SetKnownStatus(earliestKnownTaskStatus)
 		return task.GetKnownStatus()
 	}
@@ -1327,7 +1342,7 @@ func (task *Task) updateTaskKnownStatus() (newStatus apitaskstatus.TaskStatus) {
 // based on the known statuses of all containers in the task
 func (task *Task) getEarliestKnownTaskStatusForContainers() apitaskstatus.TaskStatus {
 	if len(task.Containers) == 0 {
-		seelog.Criticalf("No containers in the task: %s", task.String())
+		task.log.Criticalf("No containers in the task")
 		return apitaskstatus.TaskStatusNone
 	}
 	// Set earliest container status to an impossible to reach 'high' task status
@@ -1462,7 +1477,7 @@ func (task *Task) dockerHostConfig(container *apicontainer.Container, dockerCont
 		if task.NvidiaRuntime == "" {
 			return nil, &apierrors.HostConfigError{Msg: "Runtime is not set for GPU containers"}
 		}
-		seelog.Debugf("Setting runtime as %s for container %s", task.NvidiaRuntime, container.Name)
+		task.log.Debugf("Setting runtime as %s for container %s", task.NvidiaRuntime, container.Name)
 		hostConfig.Runtime = task.NvidiaRuntime
 	}
 
@@ -1512,8 +1527,8 @@ func (task *Task) getDockerResources(container *apicontainer.Container) dockerco
 	// Convert MB to B and set Memory
 	dockerMem := int64(container.Memory * 1024 * 1024)
 	if dockerMem != 0 && dockerMem < apicontainer.DockerContainerMinimumMemoryInBytes {
-		seelog.Warnf("Task %s container %s memory setting is too low, increasing to %d bytes",
-			task.Arn, container.Name, apicontainer.DockerContainerMinimumMemoryInBytes)
+		task.log.Warnf("container %s memory setting is too low, increasing to %d bytes",
+			container.Name, apicontainer.DockerContainerMinimumMemoryInBytes)
 		dockerMem = apicontainer.DockerContainerMinimumMemoryInBytes
 	}
 	// Set CPUShares
@@ -1556,14 +1571,14 @@ func (task *Task) shouldOverrideNetworkMode(container *apicontainer.Container, d
 		}
 	}
 	if pauseContName == "" {
-		seelog.Critical("Pause container required, but not found in the task: %s", task.String())
+		task.log.Critical("Pause container required, but not found in the task")
 		return false, ""
 	}
 	pauseContainer, ok := dockerContainerMap[pauseContName]
 	if !ok || pauseContainer == nil {
 		// This should never be the case and implies a code-bug.
-		seelog.Criticalf("Pause container required, but not found in container map for container: [%s] in task: %s",
-			container.String(), task.String())
+		task.log.Criticalf("Pause container required, but not found in container map for container: [%s]",
+			container.String())
 		return false, ""
 	}
 	return true, dockerMappingContainerPrefix + pauseContainer.DockerID
@@ -1645,14 +1660,14 @@ func (task *Task) shouldOverridePIDMode(container *apicontainer.Container, docke
 	case pidModeTask:
 		pauseCont, ok := task.ContainerByName(NamespacePauseContainerName)
 		if !ok {
-			seelog.Criticalf("Namespace Pause container not found in the task: %s; Setting Task's Desired Status to Stopped", task.Arn)
+			task.log.Criticalf("Namespace Pause container not found in the task; Setting Task's Desired Status to Stopped")
 			task.SetDesiredStatus(apitaskstatus.TaskStopped)
 			return false, ""
 		}
 		pauseDockerID, ok := dockerContainerMap[pauseCont.Name]
 		if !ok || pauseDockerID == nil {
 			// Docker container shouldn't be nil or not exist if the Container definition within task exists; implies code-bug
-			seelog.Criticalf("Namespace Pause docker container not found in the task: %s; Setting Task's Desired Status to Stopped", task.Arn)
+			task.log.Criticalf("Namespace Pause docker container not found in the task; Setting Task's Desired Status to Stopped")
 			task.SetDesiredStatus(apitaskstatus.TaskStopped)
 			return false, ""
 		}
@@ -1698,14 +1713,14 @@ func (task *Task) shouldOverrideIPCMode(container *apicontainer.Container, docke
 	case ipcModeTask:
 		pauseCont, ok := task.ContainerByName(NamespacePauseContainerName)
 		if !ok {
-			seelog.Criticalf("Namespace Pause container not found in the task: %s; Setting Task's Desired Status to Stopped", task.Arn)
+			task.log.Criticalf("Namespace Pause container not found in the task; Setting Task's Desired Status to Stopped")
 			task.SetDesiredStatus(apitaskstatus.TaskStopped)
 			return false, ""
 		}
 		pauseDockerID, ok := dockerContainerMap[pauseCont.Name]
 		if !ok || pauseDockerID == nil {
 			// Docker container shouldn't be nill or not exist if the Container definition within task exists; implies code-bug
-			seelog.Criticalf("Namespace Pause container not found in the task: %s; Setting Task's Desired Status to Stopped", task.Arn)
+			task.log.Criticalf("Namespace Pause container not found in the task; Setting Task's Desired Status to Stopped")
 			task.SetDesiredStatus(apitaskstatus.TaskStopped)
 			return false, ""
 		}
@@ -1764,8 +1779,8 @@ func (task *Task) dockerLinks(container *apicontainer.Container, dockerContainer
 		if len(linkParts) == 2 {
 			linkAlias = linkParts[1]
 		} else {
-			seelog.Warnf("Link name [%s] found with no linkalias for container: [%s] in task: [%s]",
-				linkName, container.String(), task.String())
+			task.log.Warnf("Link name [%s] found with no linkalias for container: [%s]",
+				linkName, container.String())
 			linkAlias = linkName
 		}
 
@@ -1824,9 +1839,9 @@ func (task *Task) dockerHostBinds(container *apicontainer.Container) ([]string, 
 		}
 
 		if hv.Source() == "" || mountPoint.ContainerPath == "" {
-			seelog.Errorf(
-				"Unable to resolve volume mounts for container [%s]; invalid path: [%s]; [%s] -> [%s] in task: [%s]",
-				container.Name, mountPoint.SourceVolume, hv.Source(), mountPoint.ContainerPath, task.String())
+			task.log.Errorf(
+				"Unable to resolve volume mounts for container [%s]; invalid path: [%s]; [%s] -> [%s]",
+				container.Name, mountPoint.SourceVolume, hv.Source(), mountPoint.ContainerPath)
 			return []string{}, errors.Errorf("Unable to resolve volume mounts; invalid path: %s %s; %s -> %s",
 				container.Name, mountPoint.SourceVolume, hv.Source(), mountPoint.ContainerPath)
 		}
@@ -1863,14 +1878,13 @@ func (task *Task) UpdateDesiredStatus() {
 // updateTaskDesiredStatusUnsafe determines what status the task should properly be at based on the containers' statuses
 // Invariant: task desired status must be stopped if any essential container is stopped
 func (task *Task) updateTaskDesiredStatusUnsafe() {
-	seelog.Debugf("Updating task: [%s]", task.stringUnsafe())
+	task.log.Debugf("Updating task")
 
 	// A task's desired status is stopped if any essential container is stopped
 	// Otherwise, the task's desired status is unchanged (typically running, but no need to change)
 	for _, cont := range task.Containers {
 		if cont.Essential && (cont.KnownTerminal() || cont.DesiredTerminal()) {
-			seelog.Infof("api/task: Updating task desired status to stopped because of container: [%s]; task: [%s]",
-				cont.Name, task.stringUnsafe())
+			task.log.Infof("api/task: Updating task desired status to stopped because of container: [%s]", cont.Name)
 			task.DesiredStatusUnsafe = apitaskstatus.TaskStopped
 		}
 	}
@@ -2204,8 +2218,8 @@ func (task *Task) RecordExecutionStoppedAt(container *apicontainer.Container) {
 		// ExecutionStoppedAt was already recorded. Nothing to left to do here
 		return
 	}
-	seelog.Infof("Task [%s]: recording execution stopped time. Essential container [%s] stopped at: %s",
-		task.Arn, container.Name, now.String())
+	task.log.Infof("recording execution stopped time. Essential container [%s] stopped at: %s",
+		container.Name, now.String())
 }
 
 // GetResources returns the list of task resources from ResourcesMap
@@ -2234,9 +2248,9 @@ func (task *Task) AddResource(resourceType string, resource taskresource.TaskRes
 // SetTerminalReason sets the terminalReason string and this can only be set
 // once per the task's lifecycle. This field does not accept updates.
 func (task *Task) SetTerminalReason(reason string) {
-	seelog.Infof("Task [%s]: attempting to set terminal reason for task [%s]", task.Arn, reason)
+	task.log.Infof("attempting to set terminal reason for task [%s]", reason)
 	task.terminalReasonOnce.Do(func() {
-		seelog.Infof("Task [%s]: setting terminal reason for task [%s]", task.Arn, reason)
+		task.log.Infof("setting terminal reason for task [%s]", reason)
 
 		// Converts the first letter of terminal reason into capital letter
 		words := strings.Fields(reason)

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -259,6 +259,16 @@ type Task struct {
 	log seelog.LoggerInterface
 }
 
+func NewTask(taskARN, taskFamily, taskVersion string) *Task {
+	t := Task{
+		Arn:     taskARN,
+		Family:  taskFamily,
+		Version: taskVersion,
+	}
+	t.initLog()
+	return &t
+}
+
 // TaskFromACS translates ecsacs.Task to apitask.Task by first marshaling the received
 // ecsacs.Task to json and unmarshaling it as apitask.Task
 func TaskFromACS(acsTask *ecsacs.Task, envelope *ecsacs.PayloadMessage) (*Task, error) {
@@ -1295,6 +1305,7 @@ func (task *Task) UpdateMountPoints(cont *apicontainer.Container, vols []types.M
 // there was no change
 // Invariant: task known status is the minimum of container known status
 func (task *Task) updateTaskKnownStatus() (newStatus apitaskstatus.TaskStatus) {
+	task.initLog()
 	task.log.Debugf("api/task: Updating task's known status")
 	// Set to a large 'impossible' status that can't be the min
 	containerEarliestKnownStatus := apicontainerstatus.ContainerZombie
@@ -1878,6 +1889,7 @@ func (task *Task) UpdateDesiredStatus() {
 // updateTaskDesiredStatusUnsafe determines what status the task should properly be at based on the containers' statuses
 // Invariant: task desired status must be stopped if any essential container is stopped
 func (task *Task) updateTaskDesiredStatusUnsafe() {
+	task.initLog()
 	task.log.Debugf("Updating task")
 
 	// A task's desired status is stopped if any essential container is stopped
@@ -2248,6 +2260,7 @@ func (task *Task) AddResource(resourceType string, resource taskresource.TaskRes
 // SetTerminalReason sets the terminalReason string and this can only be set
 // once per the task's lifecycle. This field does not accept updates.
 func (task *Task) SetTerminalReason(reason string) {
+	task.initLog()
 	task.log.Infof("attempting to set terminal reason for task [%s]", reason)
 	task.terminalReasonOnce.Do(func() {
 		task.log.Infof("setting terminal reason for task [%s]", reason)

--- a/agent/api/task/task_linux_test.go
+++ b/agent/api/task/task_linux_test.go
@@ -1150,7 +1150,7 @@ func getFirelensTask(t *testing.T) *Task {
 	rawHostConfig, err := json.Marshal(&rawHostConfigInput)
 	require.NoError(t, err)
 
-	return &Task{
+	task := &Task{
 		Arn:                    validTaskArn,
 		Family:                 testTaskDefFamily,
 		Version:                testTaskDefVersion,
@@ -1191,4 +1191,6 @@ func getFirelensTask(t *testing.T) *Task {
 			},
 		},
 	}
+	task.initLog()
+	return task
 }

--- a/agent/api/task/task_windows_test.go
+++ b/agent/api/task/task_windows_test.go
@@ -26,6 +26,7 @@ import (
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	apitaskstatus "github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/logger"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/credentialspec"
 	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
@@ -184,6 +185,7 @@ func TestDockerHostConfigRawConfigMerging(t *testing.T) {
 				Name: "c2",
 			},
 		},
+		log: logger.InitLogger(),
 	}
 
 	hostConfig, configErr := testTask.DockerHostConfig(testTask.Containers[0], dockerMap(testTask), minDockerClientAPIVersion)
@@ -255,6 +257,7 @@ func TestCPUPercentBasedOnUnboundedEnabled(t *testing.T) {
 				PlatformFields: PlatformFields{
 					CpuUnbounded: tc.cpuUnbounded,
 				},
+				log: logger.InitLogger(),
 			}
 
 			hostconfig, err := testTask.DockerHostConfig(testTask.Containers[0], dockerMap(testTask), minDockerClientAPIVersion)
@@ -293,6 +296,7 @@ func TestWindowsMemoryReservationOption(t *testing.T) {
 		PlatformFields: PlatformFields{
 			MemoryUnbounded: false,
 		},
+		log: logger.InitLogger(),
 	}
 
 	// With MemoryUnbounded set to false, MemoryReservation is not overridden
@@ -353,6 +357,7 @@ func TestRequiresCredentialSpecResource(t *testing.T) {
 	task2 := &Task{
 		Arn:        "test",
 		Containers: []*apicontainer.Container{container2},
+		log:        logger.InitLogger(),
 	}
 
 	testCases := []struct {
@@ -409,6 +414,7 @@ func TestGetAllCredentialSpecRequirementsWithMultipleContainersUsingSameSpec(t *
 	task := &Task{
 		Arn:        "test",
 		Containers: []*apicontainer.Container{c1, c2},
+		log:        logger.InitLogger(),
 	}
 
 	allCredSpecReq := task.getAllCredentialSpecRequirements()
@@ -436,6 +442,7 @@ func TestGetAllCredentialSpecRequirementsWithMultipleContainers(t *testing.T) {
 	task := &Task{
 		Arn:        "test",
 		Containers: []*apicontainer.Container{c1, c2, c3},
+		log:        logger.InitLogger(),
 	}
 
 	allCredSpecReq := task.getAllCredentialSpecRequirements()
@@ -460,6 +467,7 @@ func TestInitializeAndGetCredentialSpecResource(t *testing.T) {
 		Arn:                "test",
 		Containers:         []*apicontainer.Container{container},
 		ResourcesMapUnsafe: make(map[string][]taskresource.TaskResource),
+		log:                logger.InitLogger(),
 	}
 
 	ctrl := gomock.NewController(t)
@@ -498,6 +506,7 @@ func TestGetCredentialSpecResource(t *testing.T) {
 	credentialspecResource := &credentialspec.CredentialSpecResource{}
 	task := &Task{
 		ResourcesMapUnsafe: make(map[string][]taskresource.TaskResource),
+		log:                logger.InitLogger(),
 	}
 	task.AddResource(credentialspec.ResourceName, credentialspecResource)
 

--- a/agent/api/task/taskvolume_test.go
+++ b/agent/api/task/taskvolume_test.go
@@ -516,6 +516,7 @@ func TestInitializeSharedNonProvisionedVolumeValidateNameOnly(t *testing.T) {
 			},
 		},
 	}
+	testTask.initLog()
 
 	// Expect the volume already exists on the instance
 	dockerClient.EXPECT().InspectVolume(gomock.Any(), gomock.Any(), gomock.Any()).Return(dockerapi.SDKVolumeResponse{
@@ -561,6 +562,7 @@ func TestInitializeSharedAutoprovisionVolumeNotFoundError(t *testing.T) {
 			},
 		},
 	}
+	testTask.initLog()
 
 	dockerClient.EXPECT().InspectVolume(gomock.Any(), gomock.Any(), gomock.Any()).Return(dockerapi.SDKVolumeResponse{Error: errors.New("not found")})
 	err := testTask.initializeDockerVolumes(sharedVolumeMatchFullConfig, dockerClient, nil)
@@ -599,6 +601,7 @@ func TestInitializeSharedAutoprovisionVolumeNotMatchError(t *testing.T) {
 			},
 		},
 	}
+	testTask.initLog()
 
 	dockerClient.EXPECT().InspectVolume(gomock.Any(), gomock.Any(), gomock.Any()).Return(dockerapi.SDKVolumeResponse{
 		DockerVolume: &types.Volume{
@@ -639,6 +642,7 @@ func TestInitializeSharedAutoprovisionVolumeTimeout(t *testing.T) {
 			},
 		},
 	}
+	testTask.initLog()
 
 	dockerClient.EXPECT().InspectVolume(gomock.Any(), gomock.Any(), gomock.Any()).Return(dockerapi.SDKVolumeResponse{
 		Error: &dockerapi.DockerTimeoutError{},
@@ -672,6 +676,7 @@ func TestInitializeTaskVolume(t *testing.T) {
 			},
 		},
 	}
+	testTask.initLog()
 
 	err := testTask.initializeDockerVolumes(sharedVolumeMatchFullConfig, nil, nil)
 	assert.NoError(t, err)

--- a/agent/dockerclient/dockerapi/types.go
+++ b/agent/dockerclient/dockerapi/types.go
@@ -153,3 +153,15 @@ func (event *DockerContainerChangeEvent) String() string {
 
 	return res
 }
+
+// String returns a short human readable string of the container change event
+func (event *DockerContainerChangeEvent) ShortString() string {
+	res := fmt.Sprintf("event type: %s, event container status: %s, docker ID: %s",
+		event.Type.String(), event.Status.String(), event.DockerID)
+
+	if event.ExitCode != nil {
+		res += fmt.Sprintf(", ExitCode: %d", aws.IntValue(event.ExitCode))
+	}
+
+	return res
+}

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -1392,7 +1392,7 @@ func (engine *DockerTaskEngine) applyContainerState(task *apitask.Task, containe
 	}
 	metadata := transitionFunction(task, container)
 	if metadata.Error != nil {
-		seelog.Infof("Task engine [%s]: error transitioning container [%s] to [%s]: %v",
+		seelog.Errorf("Task engine [%s]: error transitioning container [%s] to [%s]: %v",
 			task.Arn, container.Name, nextState.String(), metadata.Error)
 	} else {
 		seelog.Debugf("Task engine [%s]: transitioned container [%s] to [%s]",

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -2750,35 +2750,32 @@ func TestCreateContainerAddFirelensLogDriverConfig(t *testing.T) {
 		}
 		rawHostConfig, err := json.Marshal(&rawHostConfigInput)
 		require.NoError(t, err)
-		return &apitask.Task{
-			Arn:     taskARN,
-			Version: taskVersion,
-			Family:  taskFamily,
-			Containers: []*apicontainer.Container{
-				{
-					Name: taskName,
-					DockerConfig: apicontainer.DockerConfig{
-						HostConfig: func() *string {
-							s := string(rawHostConfig)
-							return &s
-						}(),
-					},
-					NetworkModeUnsafe: networkMode,
+		task := apitask.NewTask(taskARN, taskFamily, taskVersion)
+		task.Containers = []*apicontainer.Container{
+			{
+				Name: taskName,
+				DockerConfig: apicontainer.DockerConfig{
+					HostConfig: func() *string {
+						s := string(rawHostConfig)
+						return &s
+					}(),
 				},
-				{
-					Name: "test-container",
-					FirelensConfig: &apicontainer.FirelensConfig{
-						Type: "fluentd",
-					},
-					NetworkModeUnsafe: networkMode,
-					NetworkSettingsUnsafe: &types.NetworkSettings{
-						DefaultNetworkSettings: types.DefaultNetworkSettings{
-							IPAddress: bridgeIPAddr,
-						},
+				NetworkModeUnsafe: networkMode,
+			},
+			{
+				Name: "test-container",
+				FirelensConfig: &apicontainer.FirelensConfig{
+					Type: "fluentd",
+				},
+				NetworkModeUnsafe: networkMode,
+				NetworkSettingsUnsafe: &types.NetworkSettings{
+					DefaultNetworkSettings: types.DefaultNetworkSettings{
+						IPAddress: bridgeIPAddr,
 					},
 				},
 			},
 		}
+		return task
 	}
 	getTaskWithENI := func(logDriverType string, networkMode string) *apitask.Task {
 		rawHostConfigInput := dockercontainer.HostConfig{
@@ -2792,44 +2789,41 @@ func TestCreateContainerAddFirelensLogDriverConfig(t *testing.T) {
 		}
 		rawHostConfig, err := json.Marshal(&rawHostConfigInput)
 		require.NoError(t, err)
-		return &apitask.Task{
-			Arn:     taskARN,
-			Version: taskVersion,
-			Family:  taskFamily,
-			ENIs: []*apieni.ENI{
-				{
-					IPV4Addresses: []*apieni.ENIIPV4Address{
-						{
-							Address: eniIPv4Address,
-						},
-					},
-				},
-			},
-			Containers: []*apicontainer.Container{
-				{
-					Name: taskName,
-					DockerConfig: apicontainer.DockerConfig{
-						HostConfig: func() *string {
-							s := string(rawHostConfig)
-							return &s
-						}(),
-					},
-					NetworkModeUnsafe: networkMode,
-				},
-				{
-					Name: "test-container",
-					FirelensConfig: &apicontainer.FirelensConfig{
-						Type: "fluentd",
-					},
-					NetworkModeUnsafe: networkMode,
-					NetworkSettingsUnsafe: &types.NetworkSettings{
-						DefaultNetworkSettings: types.DefaultNetworkSettings{
-							IPAddress: bridgeIPAddr,
-						},
+		task := apitask.NewTask(taskARN, taskFamily, taskVersion)
+		task.ENIs = []*apieni.ENI{
+			{
+				IPV4Addresses: []*apieni.ENIIPV4Address{
+					{
+						Address: eniIPv4Address,
 					},
 				},
 			},
 		}
+		task.Containers = []*apicontainer.Container{
+			{
+				Name: taskName,
+				DockerConfig: apicontainer.DockerConfig{
+					HostConfig: func() *string {
+						s := string(rawHostConfig)
+						return &s
+					}(),
+				},
+				NetworkModeUnsafe: networkMode,
+			},
+			{
+				Name: "test-container",
+				FirelensConfig: &apicontainer.FirelensConfig{
+					Type: "fluentd",
+				},
+				NetworkModeUnsafe: networkMode,
+				NetworkSettingsUnsafe: &types.NetworkSettings{
+					DefaultNetworkSettings: types.DefaultNetworkSettings{
+						IPAddress: bridgeIPAddr,
+					},
+				},
+			},
+		}
+		return task
 	}
 	testCases := []struct {
 		name                           string

--- a/agent/engine/task_manager_unix_test.go
+++ b/agent/engine/task_manager_unix_test.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/aws/amazon-ecs-agent/agent/logger"
 	mock_statemanager "github.com/aws/amazon-ecs-agent/agent/statemanager/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/cgroup"
@@ -74,6 +75,7 @@ func TestHandleResourceStateChangeAndSave(t *testing.T) {
 					DesiredStatusUnsafe: apitaskstatus.TaskRunning,
 				},
 				engine: &DockerTaskEngine{},
+				log:    logger.InitLogger(),
 			}
 			mtask.AddResource("cgroup", res)
 			mtask.engine.SetSaver(mockSaver)
@@ -125,6 +127,7 @@ func TestHandleResourceStateChangeNoSave(t *testing.T) {
 					ResourcesMapUnsafe:  make(map[string][]taskresource.TaskResource),
 					DesiredStatusUnsafe: apitaskstatus.TaskRunning,
 				},
+				log: logger.InitLogger(),
 			}
 			mtask.AddResource("cgroup", res)
 			mtask.handleResourceStateChange(resourceStateChange{
@@ -166,6 +169,7 @@ func TestResourceNextState(t *testing.T) {
 			res.SetDesiredStatus(tc.ResDesiredStatus)
 			mtask := managedTask{
 				Task: &apitask.Task{},
+				log:  logger.InitLogger(),
 			}
 			transition := mtask.resourceNextState(&res)
 			assert.Equal(t, tc.NextState, transition.nextState)
@@ -265,6 +269,7 @@ func TestStartResourceTransitionsEmpty(t *testing.T) {
 				},
 				ctx:                      ctx,
 				resourceStateChangeEvent: make(chan resourceStateChange),
+				log:                      logger.InitLogger(),
 			}
 			mtask.Task.AddResource("cgroup", res)
 			canTransition, transitions := mtask.startResourceTransitions(

--- a/agent/logger/log.go
+++ b/agent/logger/log.go
@@ -84,8 +84,13 @@ func jsonFormatter(params string) seelog.FormatterFunc {
 }
 
 func seelogConfig() string {
+	// seelog type=sync is being used because we create separate loggers for structs
+	// with custom context. seelog's asyncloop logger would create a separate
+	// goroutine for each struct, so we want to avoid runaway goroutines by using
+	// a sync logger.
+	// see https://github.com/cihub/seelog/wiki/Logger-types-reference
 	c := `
-<seelog type="asyncloop" minlevel="` + Config.level + `">
+<seelog type="sync" minlevel="` + Config.level + `">
 	<outputs formatid="` + Config.outputFormat + `">
 		<console />`
 	c += platformLogConfig()
@@ -148,12 +153,7 @@ func InitLogger() seelog.LoggerInterface {
 }
 
 func reloadMainConfig() {
-	logger, err := seelog.LoggerFromConfigAsString(seelogConfig())
-	if err == nil {
-		seelog.ReplaceLogger(logger)
-	} else {
-		seelog.Error(err)
-	}
+	seelog.ReplaceLogger(InitLogger())
 }
 
 func init() {

--- a/agent/logger/log_test.go
+++ b/agent/logger/log_test.go
@@ -115,7 +115,7 @@ func TestSeelogConfig_Default(t *testing.T) {
 	}
 	c := seelogConfig()
 	require.Equal(t, `
-<seelog type="asyncloop" minlevel="info">
+<seelog type="sync" minlevel="info">
 	<outputs formatid="logfmt">
 		<console />
 		<rollingfile filename="foo.log" type="date"
@@ -139,7 +139,7 @@ func TestSeelogConfig_DebugLevel(t *testing.T) {
 	}
 	c := seelogConfig()
 	require.Equal(t, `
-<seelog type="asyncloop" minlevel="debug">
+<seelog type="sync" minlevel="debug">
 	<outputs formatid="logfmt">
 		<console />
 		<rollingfile filename="foo.log" type="date"
@@ -163,7 +163,7 @@ func TestSeelogConfig_SizeRollover(t *testing.T) {
 	}
 	c := seelogConfig()
 	require.Equal(t, `
-<seelog type="asyncloop" minlevel="info">
+<seelog type="sync" minlevel="info">
 	<outputs formatid="logfmt">
 		<console />
 		<rollingfile filename="foo.log" type="size"
@@ -187,7 +187,7 @@ func TestSeelogConfig_SizeRolloverFileSizeChange(t *testing.T) {
 	}
 	c := seelogConfig()
 	require.Equal(t, `
-<seelog type="asyncloop" minlevel="info">
+<seelog type="sync" minlevel="info">
 	<outputs formatid="logfmt">
 		<console />
 		<rollingfile filename="foo.log" type="size"
@@ -211,7 +211,7 @@ func TestSeelogConfig_SizeRolloverRollCountChange(t *testing.T) {
 	}
 	c := seelogConfig()
 	require.Equal(t, `
-<seelog type="asyncloop" minlevel="info">
+<seelog type="sync" minlevel="info">
 	<outputs formatid="logfmt">
 		<console />
 		<rollingfile filename="foo.log" type="size"
@@ -235,7 +235,7 @@ func TestSeelogConfig_JSONOutput(t *testing.T) {
 	}
 	c := seelogConfig()
 	require.Equal(t, `
-<seelog type="asyncloop" minlevel="info">
+<seelog type="sync" minlevel="info">
 	<outputs formatid="json">
 		<console />
 		<rollingfile filename="foo.log" type="date"

--- a/agent/taskresource/cgroup/cgroup.go
+++ b/agent/taskresource/cgroup/cgroup.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/api/task/status"
+	"github.com/aws/amazon-ecs-agent/agent/logger"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	control "github.com/aws/amazon-ecs-agent/agent/taskresource/cgroup/control"
 	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
@@ -64,6 +65,8 @@ type CgroupResource struct {
 	statusToTransitions map[resourcestatus.ResourceStatus]func() error
 	// lock is used for fields that are accessed and updated concurrently
 	lock sync.RWMutex
+	// log is a custom logger with extra context specific to the cgroup struct
+	log seelog.LoggerInterface
 }
 
 // NewCgroupResource is used to return an object that implements the Resource interface
@@ -82,7 +85,20 @@ func NewCgroupResource(taskARN string,
 		resourceSpec:    resourceSpec,
 	}
 	c.initializeResourceStatusToTransitionFunction()
+	c.initLog()
 	return c
+}
+
+func (cgroup *CgroupResource) initLog() {
+	if cgroup.log == nil {
+		cgroup.log = logger.InitLogger()
+		cgroup.log.SetContext(map[string]string{
+			"taskARN":         cgroup.taskARN,
+			"cgroupRoot":      cgroup.cgroupRoot,
+			"cgroupMountPath": cgroup.cgroupMountPath,
+			"resourceName":    resourceName,
+		})
+	}
 }
 
 // GetTerminalReason returns an error string to propagate up through to task
@@ -159,8 +175,7 @@ func (cgroup *CgroupResource) NextKnownState() resourcestatus.ResourceStatus {
 func (cgroup *CgroupResource) ApplyTransition(nextState resourcestatus.ResourceStatus) error {
 	transitionFunc, ok := cgroup.statusToTransitions[nextState]
 	if !ok {
-		seelog.Errorf("Cgroup Resource [%s]: unsupported desired state transition [%s]: %s",
-			cgroup.taskARN, cgroup.GetName(), cgroup.StatusString(nextState))
+		cgroup.log.Errorf("unsupported desired state transition %s", cgroup.StatusString(nextState))
 		return errors.Errorf("resource [%s]: transition to %s impossible", cgroup.GetName(),
 			cgroup.StatusString(nextState))
 	}
@@ -244,7 +259,7 @@ func (cgroup *CgroupResource) GetCreatedAt() time.Time {
 func (cgroup *CgroupResource) Create() error {
 	err := cgroup.setupTaskCgroup()
 	if err != nil {
-		seelog.Criticalf("Cgroup resource [%s]: unable to setup cgroup root: %v", cgroup.taskARN, err)
+		cgroup.log.Errorf("unable to setup cgroup root: %v", err)
 		return err
 	}
 	return nil
@@ -252,10 +267,10 @@ func (cgroup *CgroupResource) Create() error {
 
 func (cgroup *CgroupResource) setupTaskCgroup() error {
 	cgroupRoot := cgroup.cgroupRoot
-	seelog.Debugf("Cgroup resource [%s]: setting up cgroup at: %s", cgroup.taskARN, cgroupRoot)
+	cgroup.log.Info("setting up cgroup")
 
 	if cgroup.control.Exists(cgroupRoot) {
-		seelog.Debugf("Cgroup resource [%s]: cgroup at %s already exists, skipping creation", cgroup.taskARN, cgroupRoot)
+		cgroup.log.Infof("cgroup at root already exists, skipping creation")
 		return nil
 	}
 
@@ -285,7 +300,7 @@ func (cgroup *CgroupResource) Cleanup() error {
 	// Explicitly handle cgroup deleted error
 	if err != nil {
 		if err == cgroups.ErrCgroupDeleted {
-			seelog.Warnf("Cgroup at %s has already been removed: %v", cgroup.cgroupRoot, err)
+			cgroup.log.Warnf("Cgroup at root has already been removed: %v", err)
 			return nil
 		}
 		return errors.Wrapf(err, "resource: cleanup cgroup: unable to remove cgroup at %s", cgroup.cgroupRoot)
@@ -343,6 +358,7 @@ func (cgroup *CgroupResource) UnmarshalJSON(b []byte) error {
 	if temp.KnownStatus != nil {
 		cgroup.SetKnownStatus(resourcestatus.ResourceStatus(*temp.KnownStatus))
 	}
+	cgroup.initLog()
 	return nil
 }
 

--- a/agent/taskresource/firelens/firelens_unix.go
+++ b/agent/taskresource/firelens/firelens_unix.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/agent/credentials"
+	"github.com/aws/amazon-ecs-agent/agent/logger"
 	"github.com/aws/amazon-ecs-agent/agent/s3"
 	"github.com/aws/amazon-ecs-agent/agent/s3/factory"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
@@ -90,6 +91,8 @@ type FirelensResource struct {
 	terminalReason      string
 	terminalReasonOnce  sync.Once
 	lock                sync.RWMutex
+	// log is a custom logger with extra context specific to the firelens struct
+	log seelog.LoggerInterface
 }
 
 // NewFirelensResource returns a new FirelensResource.
@@ -122,7 +125,19 @@ func NewFirelensResource(cluster, taskARN, taskDefinition, ec2InstanceID, dataDi
 	}
 
 	firelensResource.initStatusToTransition()
+	firelensResource.initLog()
 	return firelensResource, nil
+}
+
+func (firelens *FirelensResource) initLog() {
+	if firelens.log == nil {
+		firelens.log = logger.InitLogger()
+		firelens.log.SetContext(map[string]string{
+			"taskARN":      firelens.taskARN,
+			"configType":   firelens.firelensConfigType,
+			"resourceName": ResourceName,
+		})
+	}
 }
 
 func (firelens *FirelensResource) parseOptions(options map[string]string) error {
@@ -130,7 +145,7 @@ func (firelens *FirelensResource) parseOptions(options map[string]string) error 
 		val := options[ecsLogMetadataEnableOption]
 		b, err := strconv.ParseBool(val)
 		if err != nil {
-			seelog.Warnf("Invalid value for firelens container option %s was specified: %s. Ignoring it.", ecsLogMetadataEnableOption, val)
+			firelens.log.Warnf("Invalid value for firelens container option %s was specified: %s. Ignoring it.", ecsLogMetadataEnableOption, val)
 		} else {
 			firelens.ecsMetadataEnabled = b
 		}
@@ -217,6 +232,7 @@ func (firelens *FirelensResource) Initialize(resourceFields *taskresource.Resour
 	firelens.ioutil = ioutilwrapper.NewIOUtil()
 	firelens.s3ClientCreator = factory.NewS3ClientCreator()
 	firelens.credentialsManager = resourceFields.CredentialsManager
+	firelens.initLog()
 }
 
 // GetNetworkMode returns the network mode of the task.
@@ -246,7 +262,7 @@ func (firelens *FirelensResource) DesiredTerminal() bool {
 
 func (firelens *FirelensResource) setTerminalReason(reason string) {
 	firelens.terminalReasonOnce.Do(func() {
-		seelog.Infof("firelens resource: setting terminal reason for task: [%s]", firelens.taskARN)
+		firelens.log.Infof("firelens resource: setting terminal reason")
 		firelens.terminalReason = reason
 	})
 }
@@ -473,7 +489,7 @@ func (firelens *FirelensResource) generateConfigFile() error {
 		return errors.Wrapf(err, "unable to generate firelens config file")
 	}
 
-	seelog.Infof("Generated firelens config file at: %s", confFilePath)
+	firelens.log.Infof("Generated firelens config file at: %s", confFilePath)
 	return nil
 }
 
@@ -504,7 +520,7 @@ func (firelens *FirelensResource) downloadConfigFromS3() error {
 		return errors.Wrapf(err, "unable to download s3 config %s from bucket %s", key, bucket)
 	}
 
-	seelog.Debugf("Downloaded firelens config file from s3 and saved to: %s", confFilePath)
+	firelens.log.Debugf("Downloaded firelens config file from s3 and saved to: %s", confFilePath)
 	return nil
 }
 
@@ -547,6 +563,6 @@ func (firelens *FirelensResource) Cleanup() error {
 		return fmt.Errorf("unable to remove firelens resource directory %s: %v", firelens.resourceDir, err)
 	}
 
-	seelog.Infof("Removed firelens resource directory at %s", firelens.resourceDir)
+	firelens.log.Infof("Removed firelens resource directory at %s", firelens.resourceDir)
 	return nil
 }

--- a/agent/taskresource/firelens/firelens_unix_test.go
+++ b/agent/taskresource/firelens/firelens_unix_test.go
@@ -83,7 +83,7 @@ func setup(t *testing.T) (*mock_oswrapper.MockOS, *mock_oswrapper.MockFile, *moc
 func newMockFirelensResource(firelensConfigType, networkMode string, lopOptions map[string]string, mockOS *mock_oswrapper.MockOS,
 	mockIOUtil *mock_ioutilwrapper.MockIOUtil, mockCredentialsManager *mock_credentials.MockManager,
 	mockS3ClientCreator *mock_factory.MockS3ClientCreator) *FirelensResource {
-	return &FirelensResource{
+	f := &FirelensResource{
 		cluster:            testCluster,
 		taskARN:            testTaskARN,
 		taskDefinition:     testTaskDefinition,
@@ -101,6 +101,8 @@ func newMockFirelensResource(firelensConfigType, networkMode string, lopOptions 
 		ioutil:                 mockIOUtil,
 		s3ClientCreator:        mockS3ClientCreator,
 	}
+	f.initLog()
+	return f
 }
 
 func TestParseOptions(t *testing.T) {

--- a/agent/taskresource/firelens/firelensconfig_unix.go
+++ b/agent/taskresource/firelens/firelensconfig_unix.go
@@ -17,7 +17,6 @@ package firelens
 import (
 	"fmt"
 
-	"github.com/cihub/seelog"
 	"github.com/pkg/errors"
 
 	generator "github.com/awslabs/go-config-generator-for-fluentd-and-fluentbit"
@@ -195,7 +194,7 @@ func (firelens *FirelensResource) generateConfig() (generator.FluentConfig, erro
 		}
 		config.AddExternalConfig(s3ConfPath, generator.AfterFilters)
 	}
-	seelog.Infof("Included external firelens config file at: %s", firelens.externalConfigValue)
+	firelens.log.Infof("Included external firelens config file at: %s", firelens.externalConfigValue)
 
 	return config, nil
 }

--- a/agent/taskresource/firelens/json_unix.go
+++ b/agent/taskresource/firelens/json_unix.go
@@ -121,5 +121,7 @@ func (firelens *FirelensResource) UnmarshalJSON(b []byte) error {
 	firelens.appliedStatusUnsafe = resourcestatus.ResourceStatus(*temp.AppliedStatus)
 	firelens.networkMode = temp.NetworkMode
 
+	firelens.initLog()
+
 	return nil
 }


### PR DESCRIPTION
### Summary

addresses https://github.com/aws/amazon-ecs-agent/issues/2284

1. added ability to create custom loggers for structs and add custom context
2. implements custom loggers for a few selected structs: Task, managedTask, VolumeResource, CgroupResource, and FirelensResource
3. a bit of log cleanup (Info->Error corrections, etc.)

### Implementation details
<!-- How are the changes implemented? -->

### Testing

unit tests were updated and overall logging change manual tests were executed.

New tests cover the changes: yes

### Description for the changelog

Custom loggers for structs with consistent context

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
