### PR TITLE
Change the clusterName for TelemetryNetworkStats Test for distinguishing

### DIFF
--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -1299,7 +1299,7 @@ func (task *Task) updateTaskKnownStatus() (newStatus apitaskstatus.TaskStatus) {
 			containerEarliestKnownStatus.String(), task)
 		return apitaskstatus.TaskStatusNone
 	}
-	seelog.Debugf("api/task: Container with earliest known container is [%s] for task: %s",
+	seelog.Debugf("api/task: Container with earliest known container is %s for task: %s",
 		earliestKnownStatusContainer.String(), task.String())
 	// If the essential container is stopped while other containers may be running
 	// don't update the task status until the other containers are stopped.

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -1299,7 +1299,7 @@ func (task *Task) updateTaskKnownStatus() (newStatus apitaskstatus.TaskStatus) {
 			containerEarliestKnownStatus.String(), task)
 		return apitaskstatus.TaskStatusNone
 	}
-	seelog.Debugf("api/task: Container with earliest known container is %s for task: %s",
+	seelog.Debugf("api/task: Container with earliest known container is %s for the task: %s",
 		earliestKnownStatusContainer.String(), task.String())
 	// If the essential container is stopped while other containers may be running
 	// don't update the task status until the other containers are stopped.

--- a/agent/functional_tests/tests/functionaltests_test.go
+++ b/agent/functional_tests/tests/functionaltests_test.go
@@ -584,7 +584,7 @@ func telemetryNetworkStatsTest(t *testing.T, networkMode string, taskDefinition 
 	// telemetry task requires 2GB of memory (for either linux or windows); requires a bit more to be stable
 	RequireMinimumMemory(t, 2200)
 
-	newClusterName := "ecstest-networkstats-" + uuid.New()
+	newClusterName := "ecstest-networkstats-" + networkMode + "-" + uuid.New()
 	putAccountInsights := ecsapi.PutAccountSettingInput{
 		Name:  aws.String("containerInsights"),
 		Value: aws.String("enabled"),


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
