### PR TITLE
Remove the constraint of queue data points

### DIFF
--- a/agent/stats/queue.go
+++ b/agent/stats/queue.go
@@ -29,7 +29,7 @@ const (
 	BytesInMiB = 1024 * 1024
 )
 
-const minimumQueueDatapoints = 2
+const minimumQueueDatapoints = 1
 
 // Queue abstracts a queue using UsageStats slice.
 type Queue struct {
@@ -319,9 +319,9 @@ func (queue *Queue) getCWStatsSet(f getUsageFloatFunc) (*ecstcs.CWStatsSet, erro
 	defer queue.lock.Unlock()
 
 	queueLength := len(queue.buffer)
-	if queueLength < 2 {
-		// Need at least 2 data points to calculate this.
-		return nil, fmt.Errorf("Need at least 2 data points in queue to calculate CW stats set")
+	if queueLength < 1 {
+		// Need at least 1 data points to calculate this.
+		return nil, fmt.Errorf("Need at least 1 data points in the queue to calculate int stats")
 	}
 
 	var min, max, sum float64
@@ -360,9 +360,9 @@ func (queue *Queue) getULongStatsSet(f getUsageIntFunc) (*ecstcs.ULongStatsSet, 
 	defer queue.lock.Unlock()
 
 	queueLength := len(queue.buffer)
-	if queueLength < 2 {
-		// Need at least 2 data points to calculate this.
-		return nil, fmt.Errorf("Need at least 2 data points in the queue to calculate int stats")
+	if queueLength < 1 {
+		// Need at least 1 data points to calculate this.
+		return nil, fmt.Errorf("Need at least 1 data points in the queue to calculate int stats")
 	}
 
 	var min, max, sum uint64


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Currently, this is how agent works:
1. By default, the interval for agent to publish metrics to TACS is 20s, and current default poll docker container stats interval is 15s.
2. After agent polls container stats, it will send dp to a queue. We need at least two dps in the queue to calculate the data sent to TACS: https://github.com/aws/amazon-ecs-agent/blob/master/agent/stats/engine.go#L597.
3. Agent does not send the task metrics to TACS if there is no data related to this task.
4. TACS uses task metrics to decide which tasks are running on the instance and uses this to calculate reservation data.
Thus, if **ECS_POLL_METRICS** is enabled and if the interval is gt/eq 10s, sometimes there will not be enough dp in the queue so that the task metrics will not be sent to TACS even the task exists on the instance. The reservation metrics is not accurate under this situation.

### Implementation details
<!-- How are the changes implemented? -->
1. Updated the constraint that the queue needs at least two dps before processing it. Considering TACS side will aggregate all dps within 1 min, changing the constraint will not affect the accuracy of CW metrics. 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
We have functional tests to verify the CW metrics for CPU/memory utilization. The pr passed all these tests. Also, I did manually test to verify that the CPU/memory reservation metrics is correct when poll metrics is enabled. Besides, I also verify the network I/O and storage I/O metrics matches the number on the instance.

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
