### PR TITLE
Fix windows eventlog log format

### DIFF
--- a/agent/logger/eventlog_windows.go
+++ b/agent/logger/eventlog_windows.go
@@ -63,7 +63,8 @@ func registerPlatformLogger() {
 
 // platformLogConfig exposes log configuration for the event log receiver
 func platformLogConfig() string {
-	return `<custom name="wineventlog" formatid="windows" />`
+	return `
+		<custom name="wineventlog" formatid="windows" />`
 }
 
 // ReceiveMessage receives a log line from seelog and emits it to the Windows event log

--- a/agent/logger/log.go
+++ b/agent/logger/log.go
@@ -96,6 +96,7 @@ func seelogConfig() string {
 	<formats>
 		<format id="logfmt" format="%EcsAgentLogfmt" />
 		<format id="json" format="%EcsAgentJson" />
+		<format id="windows" format="%Msg" />
 	</formats>
 </seelog>`
 	return c

--- a/agent/logger/log_windows_test.go
+++ b/agent/logger/log_windows_test.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build windows
 
 // Copyright 2014-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
@@ -71,6 +71,7 @@ func TestSeelogConfig_Default(t *testing.T) {
 <seelog type="asyncloop" minlevel="info">
 	<outputs formatid="logfmt">
 		<console />
+		<custom name="wineventlog" formatid="windows" />
 		<rollingfile filename="foo.log" type="date"
 		 datepattern="2006-01-02-15" archivetype="none" maxrolls="24" />
 	</outputs>
@@ -96,6 +97,7 @@ func TestSeelogConfig_DebugLevel(t *testing.T) {
 <seelog type="asyncloop" minlevel="debug">
 	<outputs formatid="logfmt">
 		<console />
+		<custom name="wineventlog" formatid="windows" />
 		<rollingfile filename="foo.log" type="date"
 		 datepattern="2006-01-02-15" archivetype="none" maxrolls="24" />
 	</outputs>
@@ -121,6 +123,7 @@ func TestSeelogConfig_SizeRollover(t *testing.T) {
 <seelog type="asyncloop" minlevel="info">
 	<outputs formatid="logfmt">
 		<console />
+		<custom name="wineventlog" formatid="windows" />
 		<rollingfile filename="foo.log" type="size"
 		 maxsize="10000000" archivetype="none" maxrolls="24" />
 	</outputs>
@@ -146,6 +149,7 @@ func TestSeelogConfig_SizeRolloverFileSizeChange(t *testing.T) {
 <seelog type="asyncloop" minlevel="info">
 	<outputs formatid="logfmt">
 		<console />
+		<custom name="wineventlog" formatid="windows" />
 		<rollingfile filename="foo.log" type="size"
 		 maxsize="15000000" archivetype="none" maxrolls="24" />
 	</outputs>
@@ -171,6 +175,7 @@ func TestSeelogConfig_SizeRolloverRollCountChange(t *testing.T) {
 <seelog type="asyncloop" minlevel="info">
 	<outputs formatid="logfmt">
 		<console />
+		<custom name="wineventlog" formatid="windows" />
 		<rollingfile filename="foo.log" type="size"
 		 maxsize="15000000" archivetype="none" maxrolls="10" />
 	</outputs>
@@ -196,6 +201,7 @@ func TestSeelogConfig_JSONOutput(t *testing.T) {
 <seelog type="asyncloop" minlevel="info">
 	<outputs formatid="json">
 		<console />
+		<custom name="wineventlog" formatid="windows" />
 		<rollingfile filename="foo.log" type="date"
 		 datepattern="2006-01-02-15" archivetype="none" maxrolls="10" />
 	</outputs>


### PR DESCRIPTION
closes #2346

This line: `<format id="windows" format="%Msg" />` was mistakenly removed in an intermediary commit during work on our logging changes. It was then re-added but the commit that added it back in was reverted to fix an unrelated bug (see https://github.com/aws/amazon-ecs-agent/pull/2337)

This change adds this line back into our seelog config and adds windows unit tests to prevent this happening in the future.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
