### PR TITLE
Fix missing region error when using Firelens external config.

### DIFF
--- a/agent/s3/factory/factory.go
+++ b/agent/s3/factory/factory.go
@@ -28,7 +28,8 @@ import (
 )
 
 const (
-	roundtripTimeout = 5 * time.Second
+	bucketLocationDefault = "us-east-1"
+	roundtripTimeout      = 5 * time.Second
 )
 
 type S3ClientCreator interface {
@@ -68,6 +69,9 @@ func getRegionFromBucket(svc *s3.S3, bucket string) (string, error) {
 	result, err := svc.GetBucketLocation(input)
 	if err != nil {
 		return "", err
+	}
+	if result.LocationConstraint == nil { // GetBucketLocation returns nil for bucket in us-east-1.
+		return bucketLocationDefault, nil
 	}
 
 	return aws.StringValue(result.LocationConstraint), nil


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Closes https://github.com/aws/amazon-ecs-agent/issues/2354.

When fetching firelens config from S3 bucket, S3's GetBucketLocation API is used to determine the region of the bucket. This API returns null for bucket in us-east-1, so we set an empty string as region of the download client, and subsequent download fails.

Fix by returning us-east-1 as region instead of empty string when the API returns null.

I didn't see this behavior of GetBucketLocation documented anywhere so I double check a few buckets in other standard regions and BJS/ZHY, seems like only us-east-1 bucket returns null.

### Implementation details
<!-- How are the changes implemented? -->
See above.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

Reproduced the issue, and verified that it's fixed by this pr.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Fixed a bug where Firelens container could not use config file from S3 bucket in us-east-1.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
