### PR TITLE
Address CPU usage metric corner cases

### DIFF
--- a/agent/stats/queue.go
+++ b/agent/stats/queue.go
@@ -26,10 +26,10 @@ import (
 
 const (
 	// BytesInMiB is the number of bytes in a MebiByte.
-	BytesInMiB = 1024 * 1024
+	BytesInMiB                     = 1024 * 1024
+	minimumQueueDatapoints         = 2
+	MaxCPUUsagePerc        float32 = 1024 * 1024
 )
-
-const minimumQueueDatapoints = 2
 
 // Queue abstracts a queue using UsageStats slice.
 type Queue struct {
@@ -92,15 +92,15 @@ func (queue *Queue) add(rawStat *ContainerStats) {
 		// % utilization can be calculated only when queue is non-empty.
 		lastStat := queue.buffer[queueLength-1]
 		timeSinceLastStat := float32(rawStat.timestamp.Sub(lastStat.Timestamp).Nanoseconds())
-		if timeSinceLastStat > 0 {
+		if timeSinceLastStat <= 0 {
+			// if we got a duplicate timestamp, set cpu percentage to the same value as the previous stat
+			seelog.Errorf("Received a docker stat object with duplicate timestamp")
+			stat.CPUUsagePerc = lastStat.CPUUsagePerc
+		} else {
 			cpuUsageSinceLastStat := float32(rawStat.cpuUsage - lastStat.cpuUsage)
 			stat.CPUUsagePerc = 100 * cpuUsageSinceLastStat / timeSinceLastStat
-		} else {
-			// Ignore the stat if the current timestamp is same as the last one. This
-			// results in the value being set as +infinity
-			// float32(1) / float32(0) = +Inf
-			seelog.Debugf("time since last stat is zero. Ignoring cpu stat")
 		}
+
 		if queue.maxSize == queueLength {
 			// Remove first element if queue is full.
 			queue.buffer = queue.buffer[1:queueLength]
@@ -271,6 +271,9 @@ func (queue *Queue) GetRawUsageStats(numStats int) ([]UsageStats, error) {
 }
 
 func getCPUUsagePerc(s *UsageStats) float64 {
+	if s.CPUUsagePerc > MaxCPUUsagePerc {
+		return float64(MaxCPUUsagePerc)
+	}
 	return float64(s.CPUUsagePerc)
 }
 
@@ -343,6 +346,11 @@ func (queue *Queue) getCWStatsSet(f getUsageFloatFunc) (*ecstcs.CWStatsSet, erro
 		sum += thisStat
 	}
 
+	// don't emit metrics when sampleCount == 0
+	if sampleCount == 0 {
+		return nil, fmt.Errorf("Need at least 1 non-NaN data points in queue to calculate CW stats set")
+	}
+
 	return &ecstcs.CWStatsSet{
 		Max:         &max,
 		Min:         &min,
@@ -382,6 +390,11 @@ func (queue *Queue) getULongStatsSet(f getUsageIntFunc) (*ecstcs.ULongStatsSet, 
 		}
 		sum += thisStat
 		sampleCount++
+	}
+
+	// don't emit metrics when sampleCount == 0
+	if sampleCount == 0 {
+		return nil, fmt.Errorf("Need at least 1 non-NaN data points in queue to calculate CW stats set")
 	}
 
 	baseMin, overflowMin := getInt64WithOverflow(min)

--- a/agent/stats/queue_test.go
+++ b/agent/stats/queue_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/tcs/model/ecstcs"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -511,4 +512,99 @@ func TestEnoughDatapointsInBuffer(t *testing.T) {
 	queue.Reset()
 	enoughDataPoints = queue.enoughDatapointsInBuffer()
 	assert.False(t, enoughDataPoints, "Queue is expected to not have enough data points right after RESET")
+}
+
+func TestCPUStatSetFailsWhenSampleCountIsZero(t *testing.T) {
+	timestamps := []time.Time{
+		parseNanoTime("2015-02-12T21:22:05.131117533Z"),
+		parseNanoTime("2015-02-12T21:22:05.131117533Z"),
+	}
+	cpuTimes := []uint64{
+		22400432,
+		116499979,
+	}
+	memoryUtilizationInBytes := []uint64{
+		3649536,
+		3649536,
+	}
+	// create a queue
+	queue := NewQueue(3)
+
+	for i, time := range timestamps {
+		queue.add(&ContainerStats{cpuUsage: cpuTimes[i], memoryUsage: memoryUtilizationInBytes[i], timestamp: time})
+	}
+
+	// if two cpu had identical timestamps,
+	// then there will not be enough valid cpu percentage stats to create
+	// a valid CpuStatsSet, and this function call should fail.
+	_, err := queue.GetCPUStatsSet()
+	require.Error(t, err)
+}
+
+func TestCPUStatsWithIdenticalTimestampsGetSameUsagePercent(t *testing.T) {
+	timestamps := []time.Time{
+		parseNanoTime("2015-02-12T21:22:05.131117000Z"),
+		parseNanoTime("2015-02-12T21:22:05.131117001Z"),
+		parseNanoTime("2015-02-12T21:22:05.131117002Z"),
+		parseNanoTime("2015-02-12T21:22:05.131117002Z"),
+	}
+	cpuTimes := []uint64{
+		0,
+		1,
+		3,
+		4,
+	}
+	memoryUtilizationInBytes := []uint64{
+		3649536,
+		3649536,
+		3649536,
+		3649536,
+	}
+	// create a queue
+	queue := NewQueue(4)
+
+	for i, time := range timestamps {
+		queue.add(&ContainerStats{cpuUsage: cpuTimes[i], memoryUsage: memoryUtilizationInBytes[i], timestamp: time})
+	}
+
+	// if there were three cpu metrics, and two had identical timestamps,
+	// then there will not be enough valid cpu percentage stats to create
+	// a valid CpuStatsSet, and this function call should fail.
+	statSet, err := queue.GetCPUStatsSet()
+	require.NoError(t, err)
+	require.Equal(t, float64(200), *statSet.Max)
+	require.Equal(t, float64(100), *statSet.Min)
+	require.Equal(t, int64(3), *statSet.SampleCount)
+	require.Equal(t, float64(500), *statSet.Sum)
+}
+
+func TestHugeCPUUsagePercentGetsCapped(t *testing.T) {
+	timestamps := []time.Time{
+		parseNanoTime("2015-02-12T21:22:05.131117000Z"),
+		parseNanoTime("2015-02-12T21:22:05.131117001Z"),
+		parseNanoTime("2015-02-12T21:22:05.131117002Z"),
+	}
+	cpuTimes := []uint64{
+		0,
+		1,
+		300000000,
+	}
+	memoryUtilizationInBytes := []uint64{
+		3649536,
+		3649536,
+		3649536,
+	}
+	// create a queue
+	queue := NewQueue(4)
+
+	for i, time := range timestamps {
+		queue.add(&ContainerStats{cpuUsage: cpuTimes[i], memoryUsage: memoryUtilizationInBytes[i], timestamp: time})
+	}
+
+	statSet, err := queue.GetCPUStatsSet()
+	require.NoError(t, err)
+	require.Equal(t, float64(1024*1024), *statSet.Max)
+	require.Equal(t, float64(100), *statSet.Min)
+	require.Equal(t, int64(2), *statSet.SampleCount)
+	require.Equal(t, float64(1024*1024+100), *statSet.Sum)
 }


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This PR changes a few corner cases in the CPU percent metrics handling:

1. Cap cpu usage percent at 1024*1024 to match telemetry codebase
2. If two metrics arrive with identical timestamps, set cpu usage to previous value rather than leaving it at NaN
3. Ensure that we don't emit cloudwatch metrics with sampleCount == 0

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New unit tests were added to cover these changes

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
