### PR TITLE
Integrate with ECS Volume Plugin for EFS volume

### DIFF
--- a/agent/acs/model/api/api-2.json
+++ b/agent/acs/model/api/api-2.json
@@ -306,12 +306,28 @@
         "DISABLED"
       ]
     },
-    "EFSVolumeConfiguration": {
+    "EFSAuthorizationConfig":{
+      "type":"structure",
+      "members":{
+        "accessPointId":{"shape":"String"},
+        "iam":{"shape":"EFSAuthorizationConfigIAM"}
+      }
+    },
+    "EFSAuthorizationConfigIAM":{
+      "type":"string",
+      "enum":[
+        "ENABLED",
+        "DISABLED"
+      ]
+    },
+    "EFSVolumeConfiguration":{
       "type":"structure",
       "members":{
         "fileSystemId":{"shape":"String"},
         "rootDirectory":{"shape":"String"},
-        "transitEncryption":{"shape":"EFSTransitEncryption"}
+        "transitEncryption":{"shape":"EFSTransitEncryption"},
+        "transitEncryptionPort":{"shape":"Integer"},
+        "authorizationConfig":{"shape":"EFSAuthorizationConfig"}
       }
     },
     "ElasticNetworkInterface":{

--- a/agent/acs/model/ecsacs/api.go
+++ b/agent/acs/model/ecsacs/api.go
@@ -415,14 +415,36 @@ func (s ECRAuthData) GoString() string {
 	return s.String()
 }
 
+type EFSAuthorizationConfig struct {
+	_ struct{} `type:"structure"`
+
+	AccessPointId *string `locationName:"accessPointId" type:"string"`
+
+	Iam *string `locationName:"iam" type:"string" enum:"EFSAuthorizationConfigIAM"`
+}
+
+// String returns the string representation
+func (s EFSAuthorizationConfig) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s EFSAuthorizationConfig) GoString() string {
+	return s.String()
+}
+
 type EFSVolumeConfiguration struct {
 	_ struct{} `type:"structure"`
+
+	AuthorizationConfig *EFSAuthorizationConfig `locationName:"authorizationConfig" type:"structure"`
 
 	FileSystemId *string `locationName:"fileSystemId" type:"string"`
 
 	RootDirectory *string `locationName:"rootDirectory" type:"string"`
 
 	TransitEncryption *string `locationName:"transitEncryption" type:"string" enum:"EFSTransitEncryption"`
+
+	TransitEncryptionPort *int64 `locationName:"transitEncryptionPort" type:"integer"`
 }
 
 // String returns the string representation

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -1239,13 +1239,6 @@ func (task *Task) addNamespaceSharingProvisioningDependency(cfg *config.Config) 
 		container.BuildContainerDependency(NamespacePauseContainerName, apicontainerstatus.ContainerRunning, apicontainerstatus.ContainerPulled)
 		namespacePauseContainer.BuildContainerDependency(container.Name, apicontainerstatus.ContainerStopped, apicontainerstatus.ContainerStopped)
 	}
-
-	for _, resource := range task.GetResources() {
-		if resource.DependOnTaskNetwork() {
-			seelog.Debugf("Task [%s]: adding namespace pause container dependency to resource [%s]", task.Arn, resource.GetName())
-			resource.BuildContainerDependency(NamespacePauseContainerName, apicontainerstatus.ContainerRunning, resourcestatus.ResourceStatus(taskresourcevolume.VolumeCreated))
-		}
-	}
 }
 
 // ContainerByName returns the *Container for the given name

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -45,7 +45,6 @@ import (
 	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
 	taskresourcevolume "github.com/aws/amazon-ecs-agent/agent/taskresource/volume"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
-	"github.com/aws/amazon-ecs-agent/agent/utils/ttime"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/asmsecret"
@@ -58,33 +57,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-const (
-	dockerIDPrefix    = "dockerid-"
-	secretKeyWest1    = "/test/secretName_us-west-2"
-	secKeyLogDriver   = "/test/secretName1_us-west-1"
-	asmSecretKeyWest1 = "arn:aws:secretsmanager:us-west-2:11111:secret:/test/secretName_us-west-2"
-	ipv4              = "10.0.0.1"
-	mac               = "1.2.3.4"
-	ipv6              = "f0:234:23"
-	ignoredUID        = "1337"
-	proxyIngressPort  = "15000"
-	proxyEgressPort   = "15001"
-	appPort           = "9000"
-	egressIgnoredIP   = "169.254.169.254"
-)
-
-var defaultDockerClientAPIVersion = dockerclient.Version_1_17
-
-func strptr(s string) *string { return &s }
-
-func dockerMap(task *Task) map[string]*apicontainer.DockerContainer {
-	m := make(map[string]*apicontainer.DockerContainer)
-	for _, container := range task.Containers {
-		m[container.Name] = &apicontainer.DockerContainer{DockerID: dockerIDPrefix + container.Name, DockerName: "dockername-" + container.Name, Container: container}
-	}
-	return m
-}
 
 func TestDockerConfigPortBinding(t *testing.T) {
 	testTask := &Task{
@@ -691,36 +663,7 @@ func TestPostUnmarshalTaskWithDockerVolumes(t *testing.T) {
 // Test that the PostUnmarshal function properly changes EfsVolumeConfiguration
 // task definitions into a dockerVolumeConfiguration task resource.
 func TestPostUnmarshalTaskWithEFSVolumes(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	dockerClient := mock_dockerapi.NewMockDockerClient(ctrl)
-	dockerClient.EXPECT().InspectVolume(gomock.Any(), gomock.Any(), gomock.Any()).Return(dockerapi.SDKVolumeResponse{DockerVolume: &types.Volume{}})
-	taskFromACS := ecsacs.Task{
-		Arn:           strptr("myArn"),
-		DesiredStatus: strptr("RUNNING"),
-		Family:        strptr("myFamily"),
-		Version:       strptr("1"),
-		Containers: []*ecsacs.Container{
-			{
-				Name: strptr("myName1"),
-				MountPoints: []*ecsacs.MountPoint{
-					{
-						ContainerPath: strptr("/some/path"),
-						SourceVolume:  strptr("efsvolume"),
-					},
-				},
-			},
-		},
-		Volumes: []*ecsacs.Volume{
-			{
-				Name: strptr("efsvolume"),
-				Type: strptr("efs"),
-				EfsVolumeConfiguration: &ecsacs.EFSVolumeConfiguration{
-					FileSystemId:  strptr("fs-12345"),
-					RootDirectory: strptr("/tmp"),
-				},
-			},
-		},
-	}
+	taskFromACS := getACSEFSTask()
 	seqNum := int64(42)
 
 	testCases := map[string]string{
@@ -731,12 +674,12 @@ func TestPostUnmarshalTaskWithEFSVolumes(t *testing.T) {
 	}
 	for region, expectedHostname := range testCases {
 		t.Run(region, func(t *testing.T) {
-			task, err := TaskFromACS(&taskFromACS, &ecsacs.PayloadMessage{SeqNum: &seqNum})
+			task, err := TaskFromACS(taskFromACS, &ecsacs.PayloadMessage{SeqNum: &seqNum})
 			assert.Nil(t, err, "Should be able to handle acs task")
 			assert.Equal(t, 1, len(task.Containers)) // before PostUnmarshalTask
 			cfg := config.Config{}
 			cfg.AWSRegion = region
-			task.PostUnmarshalTask(&cfg, nil, nil, dockerClient, nil)
+			require.NoError(t, task.PostUnmarshalTask(&cfg, nil, nil, nil, nil))
 			assert.Equal(t, 1, len(task.Containers), "Should match the number of containers as before PostUnmarshalTask")
 			assert.Equal(t, 1, len(task.Volumes), "Should have 1 volume")
 			taskVol := task.Volumes[0]
@@ -771,6 +714,63 @@ func TestPostUnmarshalTaskWithEFSVolumes(t *testing.T) {
 	  }`, expectedHostname, dockerVolName), string(b))
 		})
 	}
+}
+
+func TestPostUnmarshalTaskWithEFSVolumesThatUseECSVolumePlugin(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	testCreds := getACSIAMRoleCredentials()
+	credentialsIDInTask := aws.StringValue(testCreds.CredentialsId)
+	credentialsManager := mock_credentials.NewMockManager(ctrl)
+	taskCredentials := credentials.TaskIAMRoleCredentials{
+		IAMRoleCredentials: credentials.IAMRoleCredentials{CredentialsID: credentialsIDInTask},
+	}
+	expectedEndpoint := "/v2/credentials/" + credentialsIDInTask
+	credentialsManager.EXPECT().GetTaskCredentials(credentialsIDInTask).Return(taskCredentials, true)
+
+	taskFromACS := getACSEFSTask()
+	taskFromACS.RoleCredentials = testCreds
+	seqNum := int64(42)
+	task, err := TaskFromACS(taskFromACS, &ecsacs.PayloadMessage{SeqNum: &seqNum})
+	assert.Nil(t, err, "Should be able to handle acs task")
+	assert.Equal(t, 1, len(task.Containers))
+	task.SetCredentialsID(aws.StringValue(testCreds.CredentialsId))
+
+	cfg := &config.Config{}
+	cfg.VolumePluginCapabilities = []string{"efsAuth"}
+	require.NoError(t, task.PostUnmarshalTask(cfg, credentialsManager, nil, nil, nil))
+	assert.Equal(t, 1, len(task.Containers), "Should match the number of containers as before PostUnmarshalTask")
+	assert.Equal(t, 1, len(task.Volumes), "Should have 1 volume")
+	taskVol := task.Volumes[0]
+	assert.Equal(t, "efsvolume", taskVol.Name)
+	assert.Equal(t, "efs", taskVol.Type)
+
+	resources := task.GetResources()
+	assert.Len(t, resources, 1)
+	vol, ok := resources[0].(*taskresourcevolume.VolumeResource)
+	require.True(t, ok)
+	dockerVolName := vol.VolumeConfig.DockerVolumeName
+	b, err := json.Marshal(resources[0])
+	require.NoError(t, err)
+	assert.JSONEq(t, fmt.Sprintf(`{
+		"name": "efsvolume",
+		"dockerVolumeConfiguration": {
+		  "scope": "task",
+		  "autoprovision": false,
+		  "mountPoint": "",
+		  "driver": "amazon-ecs-volume-plugin",
+		  "driverOpts": {
+			"device": "fs-12345:/tmp",
+			"o": "tls,tlsport=12345,iam,awscredsuri=%s,accesspoint=fsap-123",
+			"type": "efs"
+		  },
+		  "labels": {},
+		  "dockerVolumeName": "%s"
+		},
+		"createdAt": "0001-01-01T00:00:00Z",
+		"desiredStatus": "NONE",
+		"knownStatus": "NONE"
+	  }`, expectedEndpoint, dockerVolName), string(b))
 }
 
 func TestInitializeContainersV3MetadataEndpoint(t *testing.T) {
@@ -1072,8 +1072,6 @@ func TestAddNamespaceSharingProvisioningDependency(t *testing.T) {
 }
 
 func TestTaskFromACS(t *testing.T) {
-	testTime := ttime.Now().Truncate(1 * time.Second).Format(time.RFC3339)
-
 	intptr := func(i int64) *int64 {
 		return &i
 	}
@@ -1170,16 +1168,9 @@ func TestTaskFromACS(t *testing.T) {
 				Type: strptr("elastic-inference"),
 			},
 		},
-		RoleCredentials: &ecsacs.IAMRoleCredentials{
-			CredentialsId:   strptr("credsId"),
-			AccessKeyId:     strptr("keyId"),
-			Expiration:      strptr(testTime),
-			RoleArn:         strptr("roleArn"),
-			SecretAccessKey: strptr("OhhSecret"),
-			SessionToken:    strptr("sessionToken"),
-		},
-		Cpu:    floatptr(2.0),
-		Memory: intptr(512),
+		RoleCredentials: getACSIAMRoleCredentials(),
+		Cpu:             floatptr(2.0),
+		Memory:          intptr(512),
 	}
 	expectedTask := &Task{
 		Arn:                 "myArn",

--- a/agent/api/task/task_test_utils.go
+++ b/agent/api/task/task_test_utils.go
@@ -1,0 +1,142 @@
+// +build unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package task
+
+import (
+	"time"
+
+	"github.com/aws/amazon-ecs-agent/agent/acs/model/ecsacs"
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
+	"github.com/aws/amazon-ecs-agent/agent/dockerclient"
+	"github.com/aws/amazon-ecs-agent/agent/taskresource"
+	taskresourcevolume "github.com/aws/amazon-ecs-agent/agent/taskresource/volume"
+	"github.com/aws/amazon-ecs-agent/agent/utils/ttime"
+
+	"github.com/aws/aws-sdk-go/aws"
+)
+
+const (
+	dockerIDPrefix    = "dockerid-"
+	secretKeyWest1    = "/test/secretName_us-west-2"
+	secKeyLogDriver   = "/test/secretName1_us-west-1"
+	asmSecretKeyWest1 = "arn:aws:secretsmanager:us-west-2:11111:secret:/test/secretName_us-west-2"
+	ipv4              = "10.0.0.1"
+	mac               = "1.2.3.4"
+	ipv6              = "f0:234:23"
+	ignoredUID        = "1337"
+	proxyIngressPort  = "15000"
+	proxyEgressPort   = "15001"
+	appPort           = "9000"
+	egressIgnoredIP   = "169.254.169.254"
+)
+
+var defaultDockerClientAPIVersion = dockerclient.Version_1_17
+
+func strptr(s string) *string { return &s }
+
+func dockerMap(task *Task) map[string]*apicontainer.DockerContainer {
+	m := make(map[string]*apicontainer.DockerContainer)
+	for _, container := range task.Containers {
+		m[container.Name] = &apicontainer.DockerContainer{DockerID: dockerIDPrefix + container.Name, DockerName: "dockername-" + container.Name, Container: container}
+	}
+	return m
+}
+
+func getACSIAMRoleCredentials() *ecsacs.IAMRoleCredentials {
+	testTime := ttime.Now().Truncate(1 * time.Second).Format(time.RFC3339)
+	return &ecsacs.IAMRoleCredentials{
+		CredentialsId:   strptr("credsId"),
+		AccessKeyId:     strptr("keyId"),
+		Expiration:      strptr(testTime),
+		RoleArn:         strptr("roleArn"),
+		SecretAccessKey: strptr("OhhSecret"),
+		SessionToken:    strptr("sessionToken"),
+	}
+}
+
+func getACSEFSTask() *ecsacs.Task {
+	return &ecsacs.Task{
+		Arn:           strptr("myArn"),
+		DesiredStatus: strptr("RUNNING"),
+		Family:        strptr("myFamily"),
+		Version:       strptr("1"),
+		Containers: []*ecsacs.Container{
+			{
+				Name: strptr("myName1"),
+				MountPoints: []*ecsacs.MountPoint{
+					{
+						ContainerPath: strptr("/some/path"),
+						SourceVolume:  strptr("efsvolume"),
+					},
+				},
+			},
+		},
+		Volumes: []*ecsacs.Volume{
+			{
+				Name: strptr("efsvolume"),
+				Type: strptr("efs"),
+				EfsVolumeConfiguration: &ecsacs.EFSVolumeConfiguration{
+					AuthorizationConfig: &ecsacs.EFSAuthorizationConfig{
+						Iam:           strptr("ENABLED"),
+						AccessPointId: strptr("fsap-123"),
+					},
+					FileSystemId:          strptr("fs-12345"),
+					RootDirectory:         strptr("/tmp"),
+					TransitEncryption:     strptr("ENABLED"),
+					TransitEncryptionPort: aws.Int64(12345),
+				},
+			},
+		},
+	}
+}
+
+func getEFSTask() *Task {
+	return &Task{
+		ResourcesMapUnsafe: make(map[string][]taskresource.TaskResource),
+		Containers: []*apicontainer.Container{
+			{
+				MountPoints: []apicontainer.MountPoint{
+					{
+						SourceVolume:  "efs-volume-test",
+						ContainerPath: "/ecs",
+					},
+				},
+				TransitionDependenciesMap: make(map[apicontainerstatus.ContainerStatus]apicontainer.TransitionDependencySet),
+			},
+		},
+		Volumes: []TaskVolume{
+			{
+				Name:   "efs-volume-test",
+				Type:   "efs",
+				Volume: getEFSVolumeConfig(),
+			},
+		},
+	}
+}
+
+func getEFSVolumeConfig() *taskresourcevolume.EFSVolumeConfig {
+	return &taskresourcevolume.EFSVolumeConfig{
+		AuthConfig: taskresourcevolume.EFSAuthConfig{
+			Iam:           "ENABLED",
+			AccessPointId: "fsap-123",
+		},
+		FileSystemID:          "fs-12345",
+		RootDirectory:         "/my/root/dir",
+		TransitEncryption:     "ENABLED",
+		TransitEncryptionPort: 12345,
+	}
+}

--- a/agent/api/task/taskvolume.go
+++ b/agent/api/task/taskvolume.go
@@ -16,7 +16,11 @@ package task
 import (
 	"encoding/json"
 
+	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/taskresource"
+	taskresourcetypes "github.com/aws/amazon-ecs-agent/agent/taskresource/types"
 	taskresourcevolume "github.com/aws/amazon-ecs-agent/agent/taskresource/volume"
+
 	"github.com/cihub/seelog"
 	"github.com/pkg/errors"
 )
@@ -25,6 +29,8 @@ const (
 	HostVolumeType   = "host"
 	DockerVolumeType = "docker"
 	EFSVolumeType    = "efs"
+
+	efsVolumePluginCapability = "efsAuth"
 )
 
 // TaskVolume is a definition of all the volumes available for containers to
@@ -147,4 +153,34 @@ func (tv *TaskVolume) unmarshalHostVolume(data json.RawMessage) error {
 		tv.Volume = &hostvolume
 	}
 	return nil
+}
+
+// getEFSVolumeDriverName returns the driver name for creating the EFS volume.
+func getEFSVolumeDriverName(cfg *config.Config) string {
+	if taskresourcevolume.UseECSVolumePlugin(cfg) {
+		return taskresourcevolume.ECSVolumePlugin
+	}
+	return taskresourcevolume.DockerLocalDriverName
+}
+
+// getDockerVolumeResource retrieves docker volume resource from task resource map.
+func (task *Task) getDockerVolumeResource() ([]taskresource.TaskResource, bool) {
+	task.lock.RLock()
+	defer task.lock.RUnlock()
+
+	res, ok := task.ResourcesMapUnsafe[taskresourcetypes.DockerVolumeKey]
+	return res, ok
+}
+
+// SetPausePIDInVolumeResources sets the pause container pid field in each volume resource.
+func (task *Task) SetPausePIDInVolumeResources(pid string) {
+	resources, ok := task.getDockerVolumeResource()
+	if !ok {
+		return
+	}
+
+	for _, res := range resources {
+		volRes := res.(*taskresourcevolume.VolumeResource)
+		volRes.SetPauseContainerPID(pid)
+	}
 }

--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -206,7 +206,9 @@ func (agent *ecsAgent) capabilities() ([]*ecs.Attribute, error) {
 	capabilities = agent.appendGMSACapabilities(capabilities)
 
 	// support efs auth on ecs capabilities
-	capabilities = agent.appendEFSAuthCapabilities(capabilities)
+	for _, cap := range agent.cfg.VolumePluginCapabilities {
+		capabilities = agent.appendEFSVolumePluginCapabilities(capabilities, cap)
+	}
 
 	return capabilities, nil
 }

--- a/agent/app/agent_capability_unix.go
+++ b/agent/app/agent_capability_unix.go
@@ -162,8 +162,8 @@ func (agent *ecsAgent) appendEFSCapabilities(capabilities []*ecs.Attribute) []*e
 	return appendNameOnlyAttribute(capabilities, attributePrefix+capabilityEFS)
 }
 
-func (agent *ecsAgent) appendEFSAuthCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
-	return appendNameOnlyAttribute(capabilities, attributePrefix+capabilityEFSAuth)
+func (agent *ecsAgent) appendEFSVolumePluginCapabilities(capabilities []*ecs.Attribute, pluginCapability string) []*ecs.Attribute {
+	return appendNameOnlyAttribute(capabilities, attributePrefix+pluginCapability)
 }
 
 func (agent *ecsAgent) appendFirelensLoggingDriverCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {

--- a/agent/app/agent_capability_unix_test.go
+++ b/agent/app/agent_capability_unix_test.go
@@ -839,7 +839,7 @@ func resetOpenFile() {
 	utils.OpenFile = os.Open
 }
 
-func TestAWSLoggingDriverAndLogRouterCapabilitiesUnix(t *testing.T) {
+func TestCapabilitiesUnix(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	client := mock_dockerapi.NewMockDockerClient(ctrl)
@@ -847,7 +847,8 @@ func TestAWSLoggingDriverAndLogRouterCapabilitiesUnix(t *testing.T) {
 	mockCredentialsProvider := app_mocks.NewMockProvider(ctrl)
 	mockPauseLoader := mock_pause.NewMockLoader(ctrl)
 	conf := &config.Config{
-		PrivilegedDisabled: true,
+		PrivilegedDisabled:       true,
+		VolumePluginCapabilities: []string{capabilityEFSAuth},
 	}
 
 	mockPauseLoader.EXPECT().IsLoaded(gomock.Any()).Return(true, nil)

--- a/agent/app/agent_capability_unspecified.go
+++ b/agent/app/agent_capability_unspecified.go
@@ -110,6 +110,6 @@ func (agent *ecsAgent) appendGMSACapabilities(capabilities []*ecs.Attribute) []*
 	return capabilities
 }
 
-func (agent *ecsAgent) appendEFSAuthCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
+func (agent *ecsAgent) appendEFSVolumePluginCapabilities(capabilities []*ecs.Attribute, pluginCapability string) []*ecs.Attribute {
 	return capabilities
 }

--- a/agent/app/agent_capability_windows.go
+++ b/agent/app/agent_capability_windows.go
@@ -73,6 +73,6 @@ func (agent *ecsAgent) appendGMSACapabilities(capabilities []*ecs.Attribute) []*
 	return capabilities
 }
 
-func (agent *ecsAgent) appendEFSAuthCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
+func (agent *ecsAgent) appendEFSVolumePluginCapabilities(capabilities []*ecs.Attribute, pluginCapability string) []*ecs.Attribute {
 	return capabilities
 }

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -552,6 +552,7 @@ func environmentConfig() (Config, error) {
 		CgroupCPUPeriod:                     parseCgroupCPUPeriod(),
 		SpotInstanceDrainingEnabled:         utils.ParseBool(os.Getenv("ECS_ENABLE_SPOT_INSTANCE_DRAINING"), false),
 		GMSACapable:                         parseGMSACapability(),
+		VolumePluginCapabilities:            parseVolumePluginCapabilities(),
 	}, err
 }
 

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -124,6 +124,7 @@ func TestEnvironmentConfig(t *testing.T) {
 	setTestEnv("ECS_ENABLE_CONTAINER_METADATA", "true")
 	setTestEnv("ECS_HOST_DATA_DIR", "/etc/ecs/")
 	setTestEnv("ECS_CGROUP_CPU_PERIOD", "10ms")
+	setTestEnv("ECS_VOLUME_PLUGIN_CAPABILITIES", "[\"efsAuth\"]")
 
 	conf, err := environmentConfig()
 	assert.NoError(t, err)
@@ -169,6 +170,7 @@ func TestEnvironmentConfig(t *testing.T) {
 	assert.True(t, conf.TaskMetadataAZDisabled, "Wrong value for TaskMetadataAZDisabled")
 	assert.Equal(t, 10*time.Millisecond, conf.CgroupCPUPeriod)
 	assert.False(t, conf.SpotInstanceDrainingEnabled)
+	assert.Equal(t, []string{"efsAuth"}, conf.VolumePluginCapabilities)
 }
 
 func TestTrimWhitespaceWhenCreating(t *testing.T) {

--- a/agent/config/parse.go
+++ b/agent/config/parse.go
@@ -120,6 +120,17 @@ func parseAvailableLoggingDrivers() []dockerclient.LoggingDriver {
 	return availableLoggingDrivers
 }
 
+func parseVolumePluginCapabilities() []string {
+	capsFromEnv := os.Getenv("ECS_VOLUME_PLUGIN_CAPABILITIES")
+	capsDecoder := json.NewDecoder(strings.NewReader(capsFromEnv))
+	var caps []string
+	err := capsDecoder.Decode(&caps)
+	if err != nil {
+		seelog.Warnf("Invalid format for \"ECS_VOLUME_PLUGIN_CAPABILITIES\", expected a json list of string. error: %v", err)
+	}
+	return caps
+}
+
 func parseNumImagesToDeletePerCycle() int {
 	numImagesToDeletePerCycleEnvVal := os.Getenv("ECS_NUM_IMAGES_DELETE_PER_CYCLE")
 	numImagesToDeletePerCycle, err := strconv.Atoi(numImagesToDeletePerCycleEnvVal)

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -309,4 +309,7 @@ type Config struct {
 	// GMSACapable is the config option to indicate if gMSA is supported.
 	// It should be enabled by default only if the container instance is part of a valid active directory domain.
 	GMSACapable bool
+
+	// VolumePluginCapabilities specifies the capabilities of the ecs volume plugin.
+	VolumePluginCapabilities []string
 }

--- a/agent/engine/dependencygraph/graph.go
+++ b/agent/engine/dependencygraph/graph.go
@@ -57,6 +57,11 @@ var (
 	// ErrResourceDependencyNotResolved is when the container's dependencies
 	// on task resources are not resolved
 	ErrResourceDependencyNotResolved = errors.New("dependency graph: dependency on resources not resolved")
+	// ResourcePastDesiredStatusErr is the error where the task resource known status is bigger than desired status
+	ResourcePastDesiredStatusErr = errors.New("task resource transition: task resource status is equal or greater than desired status")
+	// ErrContainerDependencyNotResolvedForResource is when the resource's dependencies
+	// on other containers are not resolved
+	ErrContainerDependencyNotResolvedForResource = errors.New("dependency graph: resource's dependency on containers not resolved")
 )
 
 // ValidDependencies takes a task and verifies that it is possible to allow all
@@ -156,6 +161,44 @@ func DependenciesAreResolved(target *apicontainer.Container,
 	}
 
 	return nil, nil
+}
+
+// TaskResourceDependenciesAreResolved validates that the `target` resource can be
+// transitioned given the current known state of the containers in `by`. If
+// this function returns true, `target` should be technically able to transit
+// without issues.
+// Transitions are between known statuses (whether the resource can move to
+// the next known status), not desired statuses; the desired status typically
+// is either CREATED or REMOVED.
+func TaskResourceDependenciesAreResolved(target taskresource.TaskResource,
+	by []*apicontainer.Container) error {
+
+	nameMap := make(map[string]*apicontainer.Container)
+	for _, cont := range by {
+		nameMap[cont.Name] = cont
+	}
+
+	if !verifyContainerDependenciesResolvedForResource(target, nameMap) {
+		return ErrContainerDependencyNotResolvedForResource
+	}
+
+	return nil
+}
+
+func verifyContainerDependenciesResolvedForResource(target taskresource.TaskResource, existingContainers map[string]*apicontainer.Container) bool {
+	targetNext := target.GetKnownStatus() + 1
+	// For task resource without dependency map, containerDependencies will just be nil
+	containerDependencies := target.GetContainerDependencies(targetNext)
+	for _, containerDependency := range containerDependencies {
+		dep, exists := existingContainers[containerDependency.ContainerName]
+		if !exists {
+			return false
+		}
+		if dep.GetKnownStatus() < containerDependency.SatisfiedStatus {
+			return false
+		}
+	}
+	return true
 }
 
 func linksToContainerNames(links []string) []string {

--- a/agent/engine/dependencygraph/graph.go
+++ b/agent/engine/dependencygraph/graph.go
@@ -186,7 +186,7 @@ func TaskResourceDependenciesAreResolved(target taskresource.TaskResource,
 }
 
 func verifyContainerDependenciesResolvedForResource(target taskresource.TaskResource, existingContainers map[string]*apicontainer.Container) bool {
-	targetNext := target.GetKnownStatus() + 1
+	targetNext := target.NextKnownState()
 	// For task resource without dependency map, containerDependencies will just be nil
 	containerDependencies := target.GetContainerDependencies(targetNext)
 	for _, containerDependency := range containerDependencies {

--- a/agent/engine/dependencygraph/graph_test.go
+++ b/agent/engine/dependencygraph/graph_test.go
@@ -662,7 +662,7 @@ func TestVerifyTransitionDependenciesResolvedForResource(t *testing.T) {
 				},
 			}
 			gomock.InOrder(
-				mockResource.EXPECT().GetKnownStatus().Return(tc.TargetKnown),
+				mockResource.EXPECT().NextKnownState().Return(tc.TargetNext),
 				mockResource.EXPECT().GetContainerDependencies(tc.TargetNext).Return(containerDep),
 			)
 			resolved := TaskResourceDependenciesAreResolved(mockResource, containers)
@@ -693,7 +693,7 @@ func TestResourceTransitionDependencyNotFound(t *testing.T) {
 		con,
 	}
 	gomock.InOrder(
-		mockResource.EXPECT().GetKnownStatus().Return(resourcestatus.ResourceStatus(1)),
+		mockResource.EXPECT().NextKnownState().Return(resourcestatus.ResourceStatus(2)),
 		mockResource.EXPECT().GetContainerDependencies(resourcestatus.ResourceStatus(2)).Return(containerDep),
 	)
 	resolved := TaskResourceDependenciesAreResolved(mockResource, existingContainers)
@@ -713,7 +713,7 @@ func TestResourceTransitionDependencyNoDependency(t *testing.T) {
 		con,
 	}
 	gomock.InOrder(
-		mockResource.EXPECT().GetKnownStatus().Return(resourcestatus.ResourceStatus(1)),
+		mockResource.EXPECT().NextKnownState().Return(resourcestatus.ResourceStatus(2)),
 		mockResource.EXPECT().GetContainerDependencies(resourcestatus.ResourceStatus(2)).Return(nil),
 	)
 	assert.Nil(t, TaskResourceDependenciesAreResolved(mockResource, existingContainers))

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -531,10 +531,6 @@ func (engine *DockerTaskEngine) sweepTask(task *apitask.Task) {
 
 func (engine *DockerTaskEngine) deleteTask(task *apitask.Task) {
 	for _, resource := range task.GetResources() {
-		// Resource already cleaned up if depends on task network, so skip cleanup here
-		if resource.DependOnTaskNetwork() {
-			continue
-		}
 		err := resource.Cleanup()
 		if err != nil {
 			seelog.Warnf("Task engine [%s]: unable to cleanup resource %s: %v",

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -531,6 +531,10 @@ func (engine *DockerTaskEngine) sweepTask(task *apitask.Task) {
 
 func (engine *DockerTaskEngine) deleteTask(task *apitask.Task) {
 	for _, resource := range task.GetResources() {
+		// Resource already cleaned up if depends on task network, so skip cleanup here
+		if resource.DependOnTaskNetwork() {
+			continue
+		}
 		err := resource.Cleanup()
 		if err != nil {
 			seelog.Warnf("Task engine [%s]: unable to cleanup resource %s: %v",

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -48,7 +48,6 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/ecscni"
 	mock_ecscni "github.com/aws/amazon-ecs-agent/agent/ecscni/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
-	mock_dockerstate "github.com/aws/amazon-ecs-agent/agent/engine/dockerstate/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/engine/image"
 	mock_engine "github.com/aws/amazon-ecs-agent/agent/engine/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/engine/testdata"
@@ -3085,37 +3084,4 @@ func TestStartFirelensContainerRetryForContainerIP(t *testing.T) {
 	ret := taskEngine.(*DockerTaskEngine).startContainer(testTask, testTask.Containers[1])
 	assert.NoError(t, ret.Error)
 	assert.Equal(t, jsonBaseWithNetwork.NetworkSettings, ret.NetworkSettings)
-}
-
-func TestDeleteTaskWithResourceDependOnTaskNetwork(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	ctx, cancel := context.WithCancel(context.TODO())
-	defer cancel()
-
-	//efsRes := efs.NewEFSResource(taskArn, "efsVolume", ctx, nil, false, "", "", nil, false, "", "")
-	volRes, _ := taskresourcevolume.NewVolumeResource(ctx, "volume", apitask.EFSVolumeType, "dockerVol", "scope",
-		false, "driver", nil, nil, nil)
-
-	task := &apitask.Task{
-		Arn: taskArn,
-	}
-	task.ResourcesMapUnsafe = make(map[string][]taskresource.TaskResource)
-	task.AddResource(volRes.Name, volRes)
-	cfg := defaultConfig
-	mockState := mock_dockerstate.NewMockTaskEngineState(ctrl)
-	mockSaver := mock_statemanager.NewMockStateManager(ctrl)
-
-	taskEngine := &DockerTaskEngine{
-		state: mockState,
-		saver: mockSaver,
-		cfg:   &cfg,
-	}
-
-	gomock.InOrder(
-		mockState.EXPECT().RemoveTask(task),
-		mockSaver.EXPECT().Save(),
-	)
-	taskEngine.deleteTask(task)
 }

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/ecscni"
 	mock_ecscni "github.com/aws/amazon-ecs-agent/agent/ecscni/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
+	mock_dockerstate "github.com/aws/amazon-ecs-agent/agent/engine/dockerstate/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/engine/image"
 	mock_engine "github.com/aws/amazon-ecs-agent/agent/engine/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/engine/testdata"
@@ -100,6 +101,7 @@ const (
 	networkBridgeIP             = "bridgeIP"
 	networkModeBridge           = "bridge"
 	networkModeAWSVPC           = "awsvpc"
+	taskArn                     = "task1"
 )
 
 var (
@@ -3083,4 +3085,37 @@ func TestStartFirelensContainerRetryForContainerIP(t *testing.T) {
 	ret := taskEngine.(*DockerTaskEngine).startContainer(testTask, testTask.Containers[1])
 	assert.NoError(t, ret.Error)
 	assert.Equal(t, jsonBaseWithNetwork.NetworkSettings, ret.NetworkSettings)
+}
+
+func TestDeleteTaskWithResourceDependOnTaskNetwork(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
+	//efsRes := efs.NewEFSResource(taskArn, "efsVolume", ctx, nil, false, "", "", nil, false, "", "")
+	volRes, _ := taskresourcevolume.NewVolumeResource(ctx, "volume", apitask.EFSVolumeType, "dockerVol", "scope",
+		false, "driver", nil, nil, nil)
+
+	task := &apitask.Task{
+		Arn: taskArn,
+	}
+	task.ResourcesMapUnsafe = make(map[string][]taskresource.TaskResource)
+	task.AddResource(volRes.Name, volRes)
+	cfg := defaultConfig
+	mockState := mock_dockerstate.NewMockTaskEngineState(ctrl)
+	mockSaver := mock_statemanager.NewMockStateManager(ctrl)
+
+	taskEngine := &DockerTaskEngine{
+		state: mockState,
+		saver: mockSaver,
+		cfg:   &cfg,
+	}
+
+	gomock.InOrder(
+		mockState.EXPECT().RemoveTask(task),
+		mockSaver.EXPECT().Save(),
+	)
+	taskEngine.deleteTask(task)
 }

--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -99,6 +99,8 @@ type resourceTransition struct {
 	// actionRequired indicates if the transition function needs to be called for
 	// the transition to be complete
 	actionRequired bool
+	// reason represents the error blocks transition
+	reason error
 }
 
 // managedTask is a type that is meant to manage the lifecycle of a task.
@@ -484,6 +486,7 @@ func (mtask *managedTask) handleResourceStateChange(resChange resourceStateChang
 			mtask.Arn, res.GetName())
 		mtask.SetDesiredStatus(apitaskstatus.TaskStopped)
 		mtask.Task.SetTerminalReason(res.GetTerminalReason())
+		res.UpdateAppliedStatus(resourcestatus.ResourceStatusNone)
 		mtask.engine.saver.Save()
 	}
 }
@@ -898,6 +901,7 @@ func (mtask *managedTask) startResourceTransitions(transitionFunc resourceTransi
 	for _, res := range mtask.GetResources() {
 		knownStatus := res.GetKnownStatus()
 		desiredStatus := res.GetDesiredStatus()
+		seelog.Debugf("Desired status is %s", desiredStatus)
 		if knownStatus >= desiredStatus {
 			seelog.Debugf("Managed task [%s]: resource [%s] has already transitioned to or beyond the desired status %s; current known is %s",
 				mtask.Arn, res.GetName(), res.StatusString(desiredStatus), res.StatusString(knownStatus))
@@ -1045,16 +1049,81 @@ func (mtask *managedTask) containerNextState(container *apicontainer.Container) 
 	}
 }
 
+// resourceNextState determines the next state a resource should go to.
+// It returns a transition struct including the information:
+// * resource state it should transition to,
+// * string presentation of the resource state
+// * a bool indicating whether any action is required
+// * an error indicating why this transition can't happen
+//
+// Next status is determined by whether the known and desired statuses are
+// equal, the next numerically greater (iota-wise) status, and whether
+// dependencies are fully resolved.
 func (mtask *managedTask) resourceNextState(resource taskresource.TaskResource) *resourceTransition {
-	if resource.DesiredTerminal() {
-		nextState := resource.TerminalStatus()
+	resKnownStatus := resource.GetKnownStatus()
+	resDesiredStatus := resource.GetDesiredStatus()
+
+	if resKnownStatus == resDesiredStatus {
+		seelog.Debugf("Managed task [%s]: task resource [%s] at desired status: %s",
+			mtask.Arn, resource.GetName(), resource.StatusString(resDesiredStatus))
+
+		// Set nextState to ResourceStatusNone, so the knownState will not be updated
 		return &resourceTransition{
-			nextState:      nextState,
-			status:         resource.StatusString(nextState),
-			actionRequired: false, // since resource cleanup will be done while sweeping task
+			nextState:      resourcestatus.ResourceStatusNone,
+			status:         resource.StatusString(resourcestatus.ResourceStatusNone),
+			actionRequired: false,
+			reason:         dependencygraph.ResourcePastDesiredStatusErr,
 		}
 	}
-	nextState := resource.NextKnownState()
+
+	if resKnownStatus > resDesiredStatus {
+		seelog.Debugf("Managed task [%s]: task resource [%s] has already transitioned beyond desired status(%s): %s",
+			mtask.Arn, resource.GetName(), resource.StatusString(resDesiredStatus), resource.StatusString(resKnownStatus))
+		return &resourceTransition{
+			nextState:      resourcestatus.ResourceStatusNone,
+			status:         resource.StatusString(resourcestatus.ResourceStatusNone),
+			actionRequired: false,
+			reason:         dependencygraph.ResourcePastDesiredStatusErr,
+		}
+	}
+	if err := dependencygraph.TaskResourceDependenciesAreResolved(resource, mtask.Containers); err != nil {
+		seelog.Debugf("Managed task [%s]: can't apply state to resource [%s] yet due to unresolved dependencies: %v",
+			mtask.Arn, resource.GetName(), err)
+		return &resourceTransition{
+			nextState:      resourcestatus.ResourceStatusNone,
+			status:         resource.StatusString(resourcestatus.ResourceStatusNone),
+			actionRequired: false,
+			reason:         err,
+		}
+	}
+
+	var nextState resourcestatus.ResourceStatus
+	if resource.DesiredTerminal() {
+		nextState := resource.TerminalStatus()
+		if !resource.KnownCreated() {
+			// If the resource's creation is in progress, we will not transit resource state before
+			// it finishes. Otherwise, the resource may not be cleaned up.
+			if resource.GetAppliedStatus() == resourcestatus.ResourceCreated {
+				nextState = resourcestatus.ResourceStatusNone
+			}
+			seelog.Debugf("set next state to %s", resource.StatusString(nextState))
+			return &resourceTransition{
+				nextState:      nextState,
+				status:         resource.StatusString(nextState),
+				actionRequired: false,
+			}
+		}
+		// If the resource does not have dependency on task network, it will be cleaned up while sweeping task
+		if !resource.DependOnTaskNetwork() {
+			return &resourceTransition{
+				nextState:      nextState,
+				status:         resource.StatusString(nextState),
+				actionRequired: false,
+			}
+		}
+	}
+	nextState = resource.NextKnownState()
+	seelog.Debugf("Resource next state is %s", nextState)
 	return &resourceTransition{
 		nextState:      nextState,
 		status:         resource.StatusString(nextState),

--- a/agent/engine/task_manager_test.go
+++ b/agent/engine/task_manager_test.go
@@ -1074,6 +1074,7 @@ func TestCleanupTask(t *testing.T) {
 	mockState.EXPECT().RemoveTask(mTask.Task)
 	mockResource.EXPECT().Cleanup()
 	mockResource.EXPECT().GetName()
+	mockResource.EXPECT().DependOnTaskNetwork().Return(false)
 	mTask.cleanupTask(taskStoppedDuration)
 }
 
@@ -1448,6 +1449,7 @@ func TestCleanupTaskWithResourceHappyPath(t *testing.T) {
 	mockState.EXPECT().RemoveTask(mTask.Task)
 	mockResource.EXPECT().GetName()
 	mockResource.EXPECT().Cleanup().Return(nil)
+	mockResource.EXPECT().DependOnTaskNetwork().Return(false)
 	mTask.cleanupTask(taskStoppedDuration)
 }
 
@@ -1510,6 +1512,7 @@ func TestCleanupTaskWithResourceErrorPath(t *testing.T) {
 	mockState.EXPECT().RemoveTask(mTask.Task)
 	mockResource.EXPECT().GetName()
 	mockResource.EXPECT().Cleanup().Return(errors.New("cleanup error"))
+	mockResource.EXPECT().DependOnTaskNetwork().Return(false)
 	mTask.cleanupTask(taskStoppedDuration)
 }
 

--- a/agent/engine/task_manager_test.go
+++ b/agent/engine/task_manager_test.go
@@ -1074,7 +1074,6 @@ func TestCleanupTask(t *testing.T) {
 	mockState.EXPECT().RemoveTask(mTask.Task)
 	mockResource.EXPECT().Cleanup()
 	mockResource.EXPECT().GetName()
-	mockResource.EXPECT().DependOnTaskNetwork().Return(false)
 	mTask.cleanupTask(taskStoppedDuration)
 }
 
@@ -1449,7 +1448,6 @@ func TestCleanupTaskWithResourceHappyPath(t *testing.T) {
 	mockState.EXPECT().RemoveTask(mTask.Task)
 	mockResource.EXPECT().GetName()
 	mockResource.EXPECT().Cleanup().Return(nil)
-	mockResource.EXPECT().DependOnTaskNetwork().Return(false)
 	mTask.cleanupTask(taskStoppedDuration)
 }
 
@@ -1512,7 +1510,6 @@ func TestCleanupTaskWithResourceErrorPath(t *testing.T) {
 	mockState.EXPECT().RemoveTask(mTask.Task)
 	mockResource.EXPECT().GetName()
 	mockResource.EXPECT().Cleanup().Return(errors.New("cleanup error"))
-	mockResource.EXPECT().DependOnTaskNetwork().Return(false)
 	mTask.cleanupTask(taskStoppedDuration)
 }
 

--- a/agent/engine/task_manager_unix_test.go
+++ b/agent/engine/task_manager_unix_test.go
@@ -281,47 +281,6 @@ func TestStartResourceTransitionsEmpty(t *testing.T) {
 	}
 }
 
-// TestEFSResourceNextState uses EFS as an example of task resource with dependency on task network
-func TestEFSVolumeResourceNextState(t *testing.T) {
-	testCases := []struct {
-		Name             string
-		ResKnownStatus   resourcestatus.ResourceStatus
-		ResAppliedStatus resourcestatus.ResourceStatus
-		ResDesiredStatus resourcestatus.ResourceStatus
-		NextState        resourcestatus.ResourceStatus
-		ActionRequired   bool
-	}{
-		// None => Created
-		{"none to created", resourcestatus.ResourceStatus(volume.VolumeStatusNone), resourcestatus.ResourceStatus(volume.VolumeStatusNone), resourcestatus.ResourceStatus(volume.VolumeCreated), resourcestatus.ResourceStatus(volume.VolumeCreated), true},
-		// None => Removed, applied status is None
-		{"none to removed", resourcestatus.ResourceStatus(volume.VolumeStatusNone), resourcestatus.ResourceStatus(volume.VolumeStatusNone), resourcestatus.ResourceStatus(volume.VolumeRemoved), resourcestatus.ResourceStatus(volume.VolumeRemoved), false},
-		// None => Removed, applied status is Created
-		{"none to removed, applied created", resourcestatus.ResourceStatus(volume.VolumeStatusNone), resourcestatus.ResourceStatus(volume.VolumeCreated), resourcestatus.ResourceStatus(volume.VolumeRemoved), resourcestatus.ResourceStatus(volume.VolumeStatusNone), false},
-		// Created => Created
-		{"created to created", resourcestatus.ResourceStatus(volume.VolumeCreated), resourcestatus.ResourceStatus(volume.VolumeStatusNone), resourcestatus.ResourceStatus(volume.VolumeCreated), resourcestatus.ResourceStatus(volume.VolumeStatusNone), false},
-		// Created => Removed
-		{"created to removed", resourcestatus.ResourceStatus(volume.VolumeCreated), resourcestatus.ResourceStatus(volume.VolumeStatusNone), resourcestatus.ResourceStatus(volume.VolumeRemoved), resourcestatus.ResourceStatus(volume.VolumeRemoved), true},
-		// Removed => Created
-		{"removed to created", resourcestatus.ResourceStatus(volume.VolumeRemoved), resourcestatus.ResourceStatus(volume.VolumeStatusNone), resourcestatus.ResourceStatus(volume.VolumeCreated), resourcestatus.ResourceStatus(volume.VolumeStatusNone), false},
-	}
-	for _, tc := range testCases {
-		t.Run(tc.Name, func(t *testing.T) {
-			res := volume.VolumeResource{
-				VolumeType: apitask.EFSVolumeType,
-			}
-			res.SetKnownStatus(tc.ResKnownStatus)
-			res.SetDesiredStatus(tc.ResDesiredStatus)
-			res.SetAppliedStatus(tc.ResAppliedStatus)
-			mtask := managedTask{
-				Task: &apitask.Task{},
-			}
-			transition := mtask.resourceNextState(&res)
-			assert.Equal(t, tc.NextState, transition.nextState)
-			assert.Equal(t, tc.ActionRequired, transition.actionRequired)
-		})
-	}
-}
-
 //TestEFSNextStateWithTransitionDependencies verifies the dependencies are resolved correctly for task resource
 func TestEFSVolumeNextStateWithTransitionDependencies(t *testing.T) {
 	testCases := []struct {
@@ -367,7 +326,7 @@ func TestEFSVolumeNextStateWithTransitionDependencies(t *testing.T) {
 			dependencyCurrentStatus:      apicontainerstatus.ContainerStopped,
 			dependencySatisfiedStatus:    apicontainerstatus.ContainerStopped,
 			expectedResourceStatus:       resourcestatus.ResourceStatus(volume.VolumeRemoved),
-			expectedTransitionActionable: true,
+			expectedTransitionActionable: false,
 		},
 		// NONE -> REMOVED transition is allowed and not actionable
 		{

--- a/agent/engine/task_manager_unix_test.go
+++ b/agent/engine/task_manager_unix_test.go
@@ -21,10 +21,14 @@ import (
 	"sync"
 	"testing"
 
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
+	"github.com/aws/amazon-ecs-agent/agent/engine/dependencygraph"
 	mock_statemanager "github.com/aws/amazon-ecs-agent/agent/statemanager/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/cgroup"
 	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
+	"github.com/aws/amazon-ecs-agent/agent/taskresource/volume"
 	"github.com/golang/mock/gomock"
 
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
@@ -273,6 +277,150 @@ func TestStartResourceTransitionsEmpty(t *testing.T) {
 				})
 			assert.Equal(t, tc.CanTransition, canTransition)
 			assert.Empty(t, transitions)
+		})
+	}
+}
+
+// TestEFSResourceNextState uses EFS as an example of task resource with dependency on task network
+func TestEFSVolumeResourceNextState(t *testing.T) {
+	testCases := []struct {
+		Name             string
+		ResKnownStatus   resourcestatus.ResourceStatus
+		ResAppliedStatus resourcestatus.ResourceStatus
+		ResDesiredStatus resourcestatus.ResourceStatus
+		NextState        resourcestatus.ResourceStatus
+		ActionRequired   bool
+	}{
+		// None => Created
+		{"none to created", resourcestatus.ResourceStatus(volume.VolumeStatusNone), resourcestatus.ResourceStatus(volume.VolumeStatusNone), resourcestatus.ResourceStatus(volume.VolumeCreated), resourcestatus.ResourceStatus(volume.VolumeCreated), true},
+		// None => Removed, applied status is None
+		{"none to removed", resourcestatus.ResourceStatus(volume.VolumeStatusNone), resourcestatus.ResourceStatus(volume.VolumeStatusNone), resourcestatus.ResourceStatus(volume.VolumeRemoved), resourcestatus.ResourceStatus(volume.VolumeRemoved), false},
+		// None => Removed, applied status is Created
+		{"none to removed, applied created", resourcestatus.ResourceStatus(volume.VolumeStatusNone), resourcestatus.ResourceStatus(volume.VolumeCreated), resourcestatus.ResourceStatus(volume.VolumeRemoved), resourcestatus.ResourceStatus(volume.VolumeStatusNone), false},
+		// Created => Created
+		{"created to created", resourcestatus.ResourceStatus(volume.VolumeCreated), resourcestatus.ResourceStatus(volume.VolumeStatusNone), resourcestatus.ResourceStatus(volume.VolumeCreated), resourcestatus.ResourceStatus(volume.VolumeStatusNone), false},
+		// Created => Removed
+		{"created to removed", resourcestatus.ResourceStatus(volume.VolumeCreated), resourcestatus.ResourceStatus(volume.VolumeStatusNone), resourcestatus.ResourceStatus(volume.VolumeRemoved), resourcestatus.ResourceStatus(volume.VolumeRemoved), true},
+		// Removed => Created
+		{"removed to created", resourcestatus.ResourceStatus(volume.VolumeRemoved), resourcestatus.ResourceStatus(volume.VolumeStatusNone), resourcestatus.ResourceStatus(volume.VolumeCreated), resourcestatus.ResourceStatus(volume.VolumeStatusNone), false},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			res := volume.VolumeResource{
+				VolumeType: apitask.EFSVolumeType,
+			}
+			res.SetKnownStatus(tc.ResKnownStatus)
+			res.SetDesiredStatus(tc.ResDesiredStatus)
+			res.SetAppliedStatus(tc.ResAppliedStatus)
+			mtask := managedTask{
+				Task: &apitask.Task{},
+			}
+			transition := mtask.resourceNextState(&res)
+			assert.Equal(t, tc.NextState, transition.nextState)
+			assert.Equal(t, tc.ActionRequired, transition.actionRequired)
+		})
+	}
+}
+
+//TestEFSNextStateWithTransitionDependencies verifies the dependencies are resolved correctly for task resource
+func TestEFSVolumeNextStateWithTransitionDependencies(t *testing.T) {
+	testCases := []struct {
+		name                         string
+		resCurrentStatus             resourcestatus.ResourceStatus
+		resDesiredStatus             resourcestatus.ResourceStatus
+		resDependentStatus           resourcestatus.ResourceStatus
+		dependencyCurrentStatus      apicontainerstatus.ContainerStatus
+		dependencySatisfiedStatus    apicontainerstatus.ContainerStatus
+		expectedResourceStatus       resourcestatus.ResourceStatus
+		expectedTransitionActionable bool
+		reason                       error
+	}{
+		// NONE -> CREATED transition is not allowed and not actionable
+		{
+			name:                         "created depends on resourceProvisioned, dependency is none",
+			resCurrentStatus:             resourcestatus.ResourceStatus(volume.VolumeStatusNone),
+			resDesiredStatus:             resourcestatus.ResourceStatus(volume.VolumeCreated),
+			resDependentStatus:           resourcestatus.ResourceStatus(volume.VolumeCreated),
+			dependencyCurrentStatus:      apicontainerstatus.ContainerStatusNone,
+			dependencySatisfiedStatus:    apicontainerstatus.ContainerResourcesProvisioned,
+			expectedResourceStatus:       resourcestatus.ResourceStatus(volume.VolumeStatusNone),
+			expectedTransitionActionable: false,
+			reason:                       dependencygraph.ErrContainerDependencyNotResolvedForResource,
+		},
+		// NONE -> CREATED transition is allowed and actionable
+		{
+			name:                         "created depends on resourceProvisioned, dependency is resourceProvisioned",
+			resCurrentStatus:             resourcestatus.ResourceStatus(volume.VolumeStatusNone),
+			resDesiredStatus:             resourcestatus.ResourceStatus(volume.VolumeCreated),
+			resDependentStatus:           resourcestatus.ResourceStatus(volume.VolumeCreated),
+			dependencyCurrentStatus:      apicontainerstatus.ContainerResourcesProvisioned,
+			dependencySatisfiedStatus:    apicontainerstatus.ContainerResourcesProvisioned,
+			expectedResourceStatus:       resourcestatus.ResourceStatus(volume.VolumeCreated),
+			expectedTransitionActionable: true,
+		},
+		// CREATED -> REMOVED transition is allowed and actionable
+		{
+			name:                         "removed depends on stopped, dependency is stopped",
+			resCurrentStatus:             resourcestatus.ResourceStatus(volume.VolumeCreated),
+			resDesiredStatus:             resourcestatus.ResourceStatus(volume.VolumeRemoved),
+			resDependentStatus:           resourcestatus.ResourceStatus(volume.VolumeRemoved),
+			dependencyCurrentStatus:      apicontainerstatus.ContainerStopped,
+			dependencySatisfiedStatus:    apicontainerstatus.ContainerStopped,
+			expectedResourceStatus:       resourcestatus.ResourceStatus(volume.VolumeRemoved),
+			expectedTransitionActionable: true,
+		},
+		// NONE -> REMOVED transition is allowed and not actionable
+		{
+			name:                         "created depends on created, desired is stopped, dependency is created",
+			resCurrentStatus:             resourcestatus.ResourceStatus(volume.VolumeStatusNone),
+			resDesiredStatus:             resourcestatus.ResourceStatus(volume.VolumeRemoved),
+			resDependentStatus:           resourcestatus.ResourceStatus(volume.VolumeCreated),
+			dependencyCurrentStatus:      apicontainerstatus.ContainerCreated,
+			dependencySatisfiedStatus:    apicontainerstatus.ContainerCreated,
+			expectedResourceStatus:       resourcestatus.ResourceStatus(volume.VolumeRemoved),
+			expectedTransitionActionable: false,
+		},
+		// NONE -> REMOVED transition is not allowed and not actionable
+		{
+			name:                         "created depends on created, desired is stopped, dependency is none",
+			resCurrentStatus:             resourcestatus.ResourceStatus(volume.VolumeStatusNone),
+			resDesiredStatus:             resourcestatus.ResourceStatus(volume.VolumeRemoved),
+			resDependentStatus:           resourcestatus.ResourceStatus(volume.VolumeCreated),
+			dependencyCurrentStatus:      apicontainerstatus.ContainerStatusNone,
+			dependencySatisfiedStatus:    apicontainerstatus.ContainerCreated,
+			expectedResourceStatus:       resourcestatus.ResourceStatus(volume.VolumeStatusNone),
+			expectedTransitionActionable: false,
+			reason:                       dependencygraph.ErrContainerDependencyNotResolvedForResource,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.TODO())
+			defer cancel()
+			res, _ := volume.NewVolumeResource(ctx, "task1", apitask.EFSVolumeType, "volume1", "", false, "", nil, nil, nil)
+			dependencyName := "dependency"
+			dependency := &apicontainer.Container{
+				Name:              dependencyName,
+				KnownStatusUnsafe: tc.dependencyCurrentStatus,
+			}
+			res.BuildContainerDependency(dependencyName, tc.dependencySatisfiedStatus, tc.resDependentStatus)
+
+			res.SetKnownStatus(tc.resCurrentStatus)
+			res.SetDesiredStatus(tc.resDesiredStatus)
+			mtask := managedTask{
+				Task: &apitask.Task{
+					Containers: []*apicontainer.Container{
+						dependency,
+					},
+				},
+			}
+			transition := mtask.resourceNextState(res)
+			assert.Equal(t, tc.expectedResourceStatus, transition.nextState,
+				"Expected next state [%s] != Retrieved next state [%s]",
+				res.StatusString(tc.expectedResourceStatus), res.StatusString(transition.nextState))
+			assert.Equal(t, tc.expectedTransitionActionable, transition.actionRequired, "transition actionable")
+			assert.Equal(t, tc.reason, transition.reason, "transition possible")
 		})
 	}
 }

--- a/agent/statemanager/state_manager.go
+++ b/agent/statemanager/state_manager.go
@@ -98,8 +98,11 @@ const (
 	//     firelens task resource.
 	// 25) Add `seqNumTaskManifest` int field
 	// 26) Add 'credentialspec' field to 'resources'
+	// 27)
+	//	 a) Add 'authorizationConfig', 'transitEncryption' and 'transitEncryptionPort' to 'taskresource.volume.EFSVolumeConfig'
+	//	 b) Add 'pauseContainerPID' field to 'taskresource.volume.VolumeResource'
 
-	ECSDataVersion = 26
+	ECSDataVersion = 27
 
 	// ecsDataFile specifies the filename in the ECS_DATADIR
 	ecsDataFile = "ecs_agent_data.json"

--- a/agent/statemanager/testdata/v27/efs/ecs_agent_data.json
+++ b/agent/statemanager/testdata/v27/efs/ecs_agent_data.json
@@ -1,0 +1,424 @@
+{
+  "Data": {
+    "Cluster": "test-efs-creds",
+    "ContainerInstanceArn": "arn:aws:ecs:us-west-2:1234567890:container-instance/test-efs-creds/xxx",
+    "EC2InstanceID": "i-xxx",
+    "TaskEngine": {
+      "ENIAttachments": [
+        {
+          "attachSent": true,
+          "attachmentArn": "arn:aws:ecs:us-west-2:1234567890:attachment/xxx",
+          "attachmentType": "task-eni",
+          "expiresAt": "2020-02-20T01:56:56.489789117Z",
+          "macAddress": "02:99:ec:49:83:44",
+          "status": 1,
+          "taskArn": "arn:aws:ecs:us-west-2:1234567890:task/test-efs-creds/xxx"
+        }
+      ],
+      "IPToTask": {
+        "169.254.172.2": "arn:aws:ecs:us-west-2:1234567890:task/test-efs-creds/xxx"
+      },
+      "IdToContainer": {
+        "xxx": {
+          "Container": {
+            "ApplyingError": null,
+            "Command": null,
+            "Cpu": 0,
+            "EntryPoint": null,
+            "Essential": true,
+            "GPUIDs": null,
+            "Image": "amazon/amazon-ecs-pause:0.1.0",
+            "ImageDigest": "",
+            "ImageID": "",
+            "IsInternal": "CNI_PAUSE",
+            "KnownExitCode": null,
+            "KnownPortBindings": null,
+            "KnownStatus": "RESOURCES_PROVISIONED",
+            "Links": null,
+            "LogsAuthStrategy": "",
+            "Memory": 0,
+            "Name": "~internal~ecs~pause",
+            "RunDependencies": null,
+            "RuntimeID": "xxx",
+            "SentStatus": "NONE",
+            "StartTimeout": 0,
+            "SteadyStateStatus": "RESOURCES_PROVISIONED",
+            "StopTimeout": 0,
+            "TransitionDependencySet": {
+              "5": {
+                "ContainerDependencies": [
+                  {
+                    "ContainerName": "sleep",
+                    "SatisfiedStatus": "STOPPED"
+                  }
+                ],
+                "ResourceDependencies": [
+                  {
+                    "Name": "efs-html",
+                    "RequiredStatus": 2
+                  }
+                ]
+              }
+            },
+            "V3EndpointID": "",
+            "desiredStatus": "RESOURCES_PROVISIONED",
+            "dockerConfig": {
+              "config": null,
+              "hostConfig": null,
+              "version": null
+            },
+            "environment": null,
+            "firelensConfiguration": null,
+            "metadataFileUpdated": false,
+            "mountPoints": null,
+            "overrides": {
+              "command": null
+            },
+            "portMappings": null,
+            "registryAuthentication": null,
+            "secrets": null,
+            "volumesFrom": null
+          },
+          "DockerId": "xxx",
+          "DockerName": "ecs-test-efs-creds-ap-awsvpc-2-internalecspause-xxx"
+        },
+        "xxx": {
+          "Container": {
+            "ApplyingError": null,
+            "Command": [
+              "sh",
+              "-c",
+              "sleep infinity"
+            ],
+            "Cpu": 0,
+            "EntryPoint": null,
+            "Essential": true,
+            "GPUIDs": null,
+            "Image": "busybox:latest",
+            "ImageDigest": "",
+            "ImageID": "sha256:6d5fcfe5ff170471fcc3c8b47631d6d71202a1fd44cf3c147e50c8de21cf0648",
+            "IsInternal": "NORMAL",
+            "KnownExitCode": null,
+            "KnownPortBindings": null,
+            "KnownStatus": "RUNNING",
+            "Links": null,
+            "LogsAuthStrategy": "",
+            "Memory": 128,
+            "Name": "sleep",
+            "RunDependencies": null,
+            "RuntimeID": "xxx",
+            "SentStatus": "RUNNING",
+            "StartTimeout": 0,
+            "StopTimeout": 0,
+            "TransitionDependencySet": {
+              "1": {
+                "ContainerDependencies": [
+                  {
+                    "ContainerName": "~internal~ecs~pause",
+                    "SatisfiedStatus": "RESOURCES_PROVISIONED"
+                  }
+                ],
+                "ResourceDependencies": [
+                  {
+                    "Name": "cgroup",
+                    "RequiredStatus": 1
+                  },
+                  {
+                    "Name": "efs-html",
+                    "RequiredStatus": 1
+                  }
+                ]
+              }
+            },
+            "V3EndpointID": "xxx",
+            "desiredStatus": "RUNNING",
+            "dockerConfig": {
+              "config": "{}",
+              "hostConfig": "{\"NetworkMode\":\"awsvpc\",\"CapAdd\":[],\"CapDrop\":[]}",
+              "version": "1.25"
+            },
+            "environment": {
+              "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI": "/v2/credentials/xxx",
+              "AWS_EXECUTION_ENV": "AWS_ECS_EC2",
+              "ECS_CONTAINER_METADATA_URI": "http://169.254.170.2/v3/xxx"
+            },
+            "firelensConfiguration": null,
+            "metadataFileUpdated": false,
+            "mountPoints": [
+              {
+                "containerPath": "/tmp/test",
+                "readOnly": false,
+                "sourceVolume": "efs-html"
+              }
+            ],
+            "overrides": {
+              "command": null
+            },
+            "portMappings": null,
+            "registryAuthentication": null,
+            "secrets": null,
+            "volumesFrom": []
+          },
+          "DockerId": "xxx",
+          "DockerName": "ecs-test-efs-creds-ap-awsvpc-2-sleep-xxx"
+        }
+      },
+      "IdToTask": {
+        "xxx": "arn:aws:ecs:us-west-2:1234567890:task/test-efs-creds/xxx",
+        "xxx": "arn:aws:ecs:us-west-2:1234567890:task/test-efs-creds/xxx"
+      },
+      "ImageStates": [
+        {
+          "Image": {
+            "ImageID": "sha256:6d5fcfe5ff170471fcc3c8b47631d6d71202a1fd44cf3c147e50c8de21cf0648",
+            "Names": [
+              "busybox:latest"
+            ],
+            "Size": 1219782
+          },
+          "LastUsedAt": "2020-02-20T01:54:04.88572636Z",
+          "PullSucceeded": true,
+          "PulledAt": "2020-02-20T01:54:04.885724524Z"
+        }
+      ],
+      "Tasks": [
+        {
+          "AppMesh": null,
+          "Arn": "arn:aws:ecs:us-west-2:1234567890:task/test-efs-creds/xxx",
+          "Containers": [
+            {
+              "ApplyingError": null,
+              "Command": [
+                "sh",
+                "-c",
+                "sleep infinity"
+              ],
+              "Cpu": 0,
+              "EntryPoint": null,
+              "Essential": true,
+              "GPUIDs": null,
+              "Image": "busybox:latest",
+              "ImageDigest": "",
+              "ImageID": "sha256:6d5fcfe5ff170471fcc3c8b47631d6d71202a1fd44cf3c147e50c8de21cf0648",
+              "IsInternal": "NORMAL",
+              "KnownExitCode": null,
+              "KnownPortBindings": null,
+              "KnownStatus": "RUNNING",
+              "Links": null,
+              "LogsAuthStrategy": "",
+              "Memory": 128,
+              "Name": "sleep",
+              "RunDependencies": null,
+              "RuntimeID": "xxx",
+              "SentStatus": "RUNNING",
+              "StartTimeout": 0,
+              "StopTimeout": 0,
+              "TransitionDependencySet": {
+                "1": {
+                  "ContainerDependencies": [
+                    {
+                      "ContainerName": "~internal~ecs~pause",
+                      "SatisfiedStatus": "RESOURCES_PROVISIONED"
+                    }
+                  ],
+                  "ResourceDependencies": [
+                    {
+                      "Name": "cgroup",
+                      "RequiredStatus": 1
+                    },
+                    {
+                      "Name": "efs-html",
+                      "RequiredStatus": 1
+                    }
+                  ]
+                }
+              },
+              "V3EndpointID": "xxx",
+              "desiredStatus": "RUNNING",
+              "dockerConfig": {
+                "config": "{}",
+                "hostConfig": "{\"NetworkMode\":\"awsvpc\",\"CapAdd\":[],\"CapDrop\":[]}",
+                "version": "1.25"
+              },
+              "environment": {
+                "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI": "/v2/credentials/xxx",
+                "AWS_EXECUTION_ENV": "AWS_ECS_EC2",
+                "ECS_CONTAINER_METADATA_URI": "http://169.254.170.2/v3/xxx"
+              },
+              "firelensConfiguration": null,
+              "metadataFileUpdated": false,
+              "mountPoints": [
+                {
+                  "containerPath": "/tmp/test",
+                  "readOnly": false,
+                  "sourceVolume": "efs-html"
+                }
+              ],
+              "overrides": {
+                "command": null
+              },
+              "portMappings": null,
+              "registryAuthentication": null,
+              "secrets": null,
+              "volumesFrom": []
+            },
+            {
+              "ApplyingError": null,
+              "Command": null,
+              "Cpu": 0,
+              "EntryPoint": null,
+              "Essential": true,
+              "GPUIDs": null,
+              "Image": "amazon/amazon-ecs-pause:0.1.0",
+              "ImageDigest": "",
+              "ImageID": "",
+              "IsInternal": "CNI_PAUSE",
+              "KnownExitCode": null,
+              "KnownPortBindings": null,
+              "KnownStatus": "RESOURCES_PROVISIONED",
+              "Links": null,
+              "LogsAuthStrategy": "",
+              "Memory": 0,
+              "Name": "~internal~ecs~pause",
+              "RunDependencies": null,
+              "RuntimeID": "xxx",
+              "SentStatus": "NONE",
+              "StartTimeout": 0,
+              "SteadyStateStatus": "RESOURCES_PROVISIONED",
+              "StopTimeout": 0,
+              "TransitionDependencySet": {
+                "5": {
+                  "ContainerDependencies": [
+                    {
+                      "ContainerName": "sleep",
+                      "SatisfiedStatus": "STOPPED"
+                    }
+                  ],
+                  "ResourceDependencies": [
+                    {
+                      "Name": "efs-html",
+                      "RequiredStatus": 2
+                    }
+                  ]
+                }
+              },
+              "V3EndpointID": "",
+              "desiredStatus": "RESOURCES_PROVISIONED",
+              "dockerConfig": {
+                "config": null,
+                "hostConfig": null,
+                "version": null
+              },
+              "environment": null,
+              "firelensConfiguration": null,
+              "metadataFileUpdated": false,
+              "mountPoints": null,
+              "overrides": {
+                "command": null
+              },
+              "portMappings": null,
+              "registryAuthentication": null,
+              "secrets": null,
+              "volumesFrom": null
+            }
+          ],
+          "DesiredStatus": "RUNNING",
+          "ENI": [
+            {
+              "IPV4Addresses": [
+                {
+                  "Address": "172.31.23.80",
+                  "Primary": true
+                }
+              ],
+              "IPV6Addresses": null,
+              "InterfaceAssociationProtocol": "default",
+              "InterfaceVlanProperties": {
+                "TrunkInterfaceMacAddress": "",
+                "VlanID": ""
+              },
+              "MacAddress": "02:99:ec:49:83:44",
+              "PrivateDNSName": "ip-172-31-23-80.us-west-2.compute.internal",
+              "SubnetGatewayIPV4Address": "172.31.16.1/20",
+              "ec2Id": "eni-07113203d7c904702"
+            }
+          ],
+          "ExecutionStoppedAt": "0001-01-01T00:00:00Z",
+          "Family": "test-efs-creds-ap-awsvpc",
+          "KnownStatus": "RUNNING",
+          "KnownTime": "2020-02-20T01:54:05.363137128Z",
+          "MemoryCPULimitsEnabled": true,
+          "PlatformFields": {},
+          "PullStartedAt": "2020-02-20T01:54:03.576860185Z",
+          "PullStoppedAt": "2020-02-20T01:54:04.88978339Z",
+          "SentStatus": "RUNNING",
+          "StartSequenceNumber": 5,
+          "StopSequenceNumber": 0,
+          "Version": "2",
+          "associations": [],
+          "executionCredentialsID": "",
+          "resources": {
+            "cgroup": [
+              {
+                "cgroupMountPath": "/sys/fs/cgroup",
+                "cgroupRoot": "/ecs/test-efs-creds/xxx",
+                "createdAt": "0001-01-01T00:00:00Z",
+                "desiredStatus": "CREATED",
+                "knownStatus": "CREATED",
+                "resourceSpec": {
+                  "cpu": {
+                    "shares": 2
+                  }
+                }
+              }
+            ],
+            "dockerVolume": [
+              {
+                "createdAt": "0001-01-01T00:00:00Z",
+                "desiredStatus": "CREATED",
+                "dockerVolumeConfiguration": {
+                  "autoprovision": false,
+                  "dockerVolumeName": "ecs-test-efs-creds-ap-awsvpc-2-efs-html-xxx",
+                  "driver": "amazon-ecs-volume-plugin",
+                  "driverOpts": {
+                    "device": "fs-xxx:/",
+                    "o": "tls,tlsport=20050,iam,awscredsuri=/v2/credentials/xxx,accesspoint=fsap-xxx,netns=/proc/123/ns/net",
+                    "type": "efs"
+                  },
+                  "labels": {},
+                  "mountPoint": "mpabs",
+                  "scope": "task"
+                },
+                "knownStatus": "CREATED",
+                "name": "efs-html",
+                "pauseContainerPID": "123"
+              }
+            ]
+          },
+          "volumes": [
+            {
+              "efsVolumeConfiguration": {
+                "autoprovision": false,
+                "dockerVolumeName": "ecs-test-efs-creds-ap-awsvpc-2-efs-html-xxx",
+                "driver": "amazon-ecs-volume-plugin",
+                "driverOpts": {
+                  "device": "fs-xxx:/",
+                  "o": "tls,tlsport=20050,iam,awscredsuri=/v2/credentials/xxx,accesspoint=fsap-xxx,netns=/proc/123/ns/net",
+                  "type": "efs"
+                },
+                "labels": {},
+                "mountPoint": "mpabc",
+                "scope": "task"
+              },
+              "name": "efs-html",
+              "type": "efs"
+            }
+          ]
+        }
+      ]
+    },
+    "availabilityZone": "us-west-2b",
+    "latestSeqNumberTaskManifest": 5
+  },
+  "Version": 27
+}

--- a/agent/taskresource/asmauth/asmauth.go
+++ b/agent/taskresource/asmauth/asmauth.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	"github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/agent/asm"
 	"github.com/aws/amazon-ecs-agent/agent/asm/factory"
@@ -33,8 +34,7 @@ import (
 
 const (
 	// ResourceName is the name of the ASM auth resource
-	ResourceName              = "asm-auth"
-	resourceProvisioningError = "TaskResourceError: Agent could not create task's platform resources"
+	ResourceName = "asm-auth"
 )
 
 // ASMAuthResource represents private registry credentials as a task resource.
@@ -407,4 +407,33 @@ func (auth *ASMAuthResource) UnmarshalJSON(b []byte) error {
 	auth.executionCredentialsID = temp.ExecutionCredentialsID
 
 	return nil
+}
+
+// GetAppliedStatus safely returns the currently applied status of the resource
+func (auth *ASMAuthResource) GetAppliedStatus() resourcestatus.ResourceStatus {
+	auth.lock.RLock()
+	defer auth.lock.RUnlock()
+
+	return auth.appliedStatus
+}
+
+func (auth *ASMAuthResource) DependOnTaskNetwork() bool {
+	return false
+}
+
+func (auth *ASMAuthResource) BuildContainerDependency(containerName string, satisfied apicontainerstatus.ContainerStatus,
+	dependent resourcestatus.ResourceStatus) error {
+	return errors.New("Not implemented")
+}
+
+func (auth *ASMAuthResource) GetContainerDependencies(dependent resourcestatus.ResourceStatus) []apicontainer.ContainerDependency {
+	return nil
+}
+
+// UpdateAppliedStatus safely updates the applied status of the resource
+func (auth *ASMAuthResource) UpdateAppliedStatus(status resourcestatus.ResourceStatus) {
+	auth.lock.RLock()
+	defer auth.lock.RUnlock()
+
+	auth.appliedStatus = status
 }

--- a/agent/taskresource/asmauth/asmauth.go
+++ b/agent/taskresource/asmauth/asmauth.go
@@ -422,18 +422,9 @@ func (auth *ASMAuthResource) DependOnTaskNetwork() bool {
 }
 
 func (auth *ASMAuthResource) BuildContainerDependency(containerName string, satisfied apicontainerstatus.ContainerStatus,
-	dependent resourcestatus.ResourceStatus) error {
-	return errors.New("Not implemented")
+	dependent resourcestatus.ResourceStatus) {
 }
 
 func (auth *ASMAuthResource) GetContainerDependencies(dependent resourcestatus.ResourceStatus) []apicontainer.ContainerDependency {
 	return nil
-}
-
-// UpdateAppliedStatus safely updates the applied status of the resource
-func (auth *ASMAuthResource) UpdateAppliedStatus(status resourcestatus.ResourceStatus) {
-	auth.lock.RLock()
-	defer auth.lock.RUnlock()
-
-	auth.appliedStatus = status
 }

--- a/agent/taskresource/asmsecret/asmsecret.go
+++ b/agent/taskresource/asmsecret/asmsecret.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pkg/errors"
 
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	"github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/agent/asm"
 	"github.com/aws/amazon-ecs-agent/agent/asm/factory"
@@ -512,4 +513,33 @@ func (secret *ASMSecretResource) UnmarshalJSON(b []byte) error {
 	secret.executionCredentialsID = temp.ExecutionCredentialsID
 
 	return nil
+}
+
+// GetAppliedStatus safely returns the currently applied status of the resource
+func (secret *ASMSecretResource) GetAppliedStatus() resourcestatus.ResourceStatus {
+	secret.lock.RLock()
+	defer secret.lock.RUnlock()
+
+	return secret.appliedStatus
+}
+
+func (secret *ASMSecretResource) DependOnTaskNetwork() bool {
+	return false
+}
+
+func (secret *ASMSecretResource) BuildContainerDependency(containerName string, satisfied apicontainerstatus.ContainerStatus,
+	dependent resourcestatus.ResourceStatus) error {
+	return errors.New("Not implemented")
+}
+
+func (secret *ASMSecretResource) GetContainerDependencies(dependent resourcestatus.ResourceStatus) []apicontainer.ContainerDependency {
+	return nil
+}
+
+// UpdateAppliedStatus safely updates the applied status of the resource
+func (secret *ASMSecretResource) UpdateAppliedStatus(status resourcestatus.ResourceStatus) {
+	secret.lock.RLock()
+	defer secret.lock.RUnlock()
+
+	secret.appliedStatus = status
 }

--- a/agent/taskresource/asmsecret/asmsecret.go
+++ b/agent/taskresource/asmsecret/asmsecret.go
@@ -528,18 +528,9 @@ func (secret *ASMSecretResource) DependOnTaskNetwork() bool {
 }
 
 func (secret *ASMSecretResource) BuildContainerDependency(containerName string, satisfied apicontainerstatus.ContainerStatus,
-	dependent resourcestatus.ResourceStatus) error {
-	return errors.New("Not implemented")
+	dependent resourcestatus.ResourceStatus) {
 }
 
 func (secret *ASMSecretResource) GetContainerDependencies(dependent resourcestatus.ResourceStatus) []apicontainer.ContainerDependency {
 	return nil
-}
-
-// UpdateAppliedStatus safely updates the applied status of the resource
-func (secret *ASMSecretResource) UpdateAppliedStatus(status resourcestatus.ResourceStatus) {
-	secret.lock.RLock()
-	defer secret.lock.RUnlock()
-
-	secret.appliedStatus = status
 }

--- a/agent/taskresource/cgroup/cgroup.go
+++ b/agent/taskresource/cgroup/cgroup.go
@@ -22,6 +22,8 @@ import (
 	"sync"
 	"time"
 
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	"github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	control "github.com/aws/amazon-ecs-agent/agent/taskresource/cgroup/control"
@@ -208,6 +210,22 @@ func (cgroup *CgroupResource) SetAppliedStatus(status resourcestatus.ResourceSta
 	return true
 }
 
+// GetAppliedStatus safely returns the currently applied status of the resource
+func (cgroup *CgroupResource) GetAppliedStatus() resourcestatus.ResourceStatus {
+	cgroup.lock.RLock()
+	defer cgroup.lock.RUnlock()
+
+	return cgroup.appliedStatus
+}
+
+// UpdateAppliedStatus safely updates the applied status of the resource
+func (cgroup *CgroupResource) UpdateAppliedStatus(status resourcestatus.ResourceStatus) {
+	cgroup.lock.RLock()
+	defer cgroup.lock.RUnlock()
+
+	cgroup.appliedStatus = status
+}
+
 // GetKnownStatus safely returns the currently known status of the task
 func (cgroup *CgroupResource) GetKnownStatus() resourcestatus.ResourceStatus {
 	cgroup.lock.RLock()
@@ -370,4 +388,17 @@ func (cgroup *CgroupResource) Initialize(resourceFields *taskresource.ResourceFi
 	cgroup.initializeResourceStatusToTransitionFunction()
 	cgroup.ioutil = resourceFields.IOUtil
 	cgroup.control = resourceFields.Control
+}
+
+func (cgroup *CgroupResource) DependOnTaskNetwork() bool {
+	return false
+}
+
+func (cgroup *CgroupResource) BuildContainerDependency(containerName string, satisfied apicontainerstatus.ContainerStatus,
+	dependent resourcestatus.ResourceStatus) error {
+	return errors.New("Not implemented")
+}
+
+func (cgroup *CgroupResource) GetContainerDependencies(dependent resourcestatus.ResourceStatus) []apicontainer.ContainerDependency {
+	return nil
 }

--- a/agent/taskresource/cgroup/cgroup.go
+++ b/agent/taskresource/cgroup/cgroup.go
@@ -218,14 +218,6 @@ func (cgroup *CgroupResource) GetAppliedStatus() resourcestatus.ResourceStatus {
 	return cgroup.appliedStatus
 }
 
-// UpdateAppliedStatus safely updates the applied status of the resource
-func (cgroup *CgroupResource) UpdateAppliedStatus(status resourcestatus.ResourceStatus) {
-	cgroup.lock.RLock()
-	defer cgroup.lock.RUnlock()
-
-	cgroup.appliedStatus = status
-}
-
 // GetKnownStatus safely returns the currently known status of the task
 func (cgroup *CgroupResource) GetKnownStatus() resourcestatus.ResourceStatus {
 	cgroup.lock.RLock()
@@ -395,8 +387,7 @@ func (cgroup *CgroupResource) DependOnTaskNetwork() bool {
 }
 
 func (cgroup *CgroupResource) BuildContainerDependency(containerName string, satisfied apicontainerstatus.ContainerStatus,
-	dependent resourcestatus.ResourceStatus) error {
-	return errors.New("Not implemented")
+	dependent resourcestatus.ResourceStatus) {
 }
 
 func (cgroup *CgroupResource) GetContainerDependencies(dependent resourcestatus.ResourceStatus) []apicontainer.ContainerDependency {

--- a/agent/taskresource/cgroup/cgroup_unsupported.go
+++ b/agent/taskresource/cgroup/cgroup_unsupported.go
@@ -18,6 +18,8 @@ import (
 	"errors"
 	"time"
 
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	"github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
@@ -84,6 +86,14 @@ func (c *CgroupResource) GetKnownStatus() resourcestatus.ResourceStatus {
 	return resourcestatus.ResourceStatusNone
 }
 
+// UpdateAppliedStatus safely updates the applied status of the resource
+func (c *CgroupResource) UpdateAppliedStatus(status resourcestatus.ResourceStatus) {}
+
+// GetAppliedStatus safely returns the currently applied status of the resource
+func (c *CgroupResource) GetAppliedStatus() resourcestatus.ResourceStatus {
+	return resourcestatus.ResourceStatusNone
+}
+
 // SetCreatedAt sets the timestamp for resource's creation time
 func (c *CgroupResource) SetCreatedAt(createdAt time.Time) {}
 
@@ -125,4 +135,17 @@ func (c *CgroupResource) UnmarshalJSON(b []byte) error {
 func (cgroup *CgroupResource) Initialize(resourceFields *taskresource.ResourceFields,
 	taskKnownStatus status.TaskStatus,
 	taskDesiredStatus status.TaskStatus) {
+}
+
+func (cgroup *CgroupResource) DependOnTaskNetwork() bool {
+	return false
+}
+
+func (cgroup *CgroupResource) BuildContainerDependency(containerName string, satisfied apicontainerstatus.ContainerStatus,
+	dependent resourcestatus.ResourceStatus) error {
+	return errors.New("Not implemented")
+}
+
+func (cgroup *CgroupResource) GetContainerDependencies(dependent resourcestatus.ResourceStatus) []apicontainer.ContainerDependency {
+	return nil
 }

--- a/agent/taskresource/cgroup/cgroup_unsupported.go
+++ b/agent/taskresource/cgroup/cgroup_unsupported.go
@@ -86,9 +86,6 @@ func (c *CgroupResource) GetKnownStatus() resourcestatus.ResourceStatus {
 	return resourcestatus.ResourceStatusNone
 }
 
-// UpdateAppliedStatus safely updates the applied status of the resource
-func (c *CgroupResource) UpdateAppliedStatus(status resourcestatus.ResourceStatus) {}
-
 // GetAppliedStatus safely returns the currently applied status of the resource
 func (c *CgroupResource) GetAppliedStatus() resourcestatus.ResourceStatus {
 	return resourcestatus.ResourceStatusNone
@@ -142,8 +139,7 @@ func (cgroup *CgroupResource) DependOnTaskNetwork() bool {
 }
 
 func (cgroup *CgroupResource) BuildContainerDependency(containerName string, satisfied apicontainerstatus.ContainerStatus,
-	dependent resourcestatus.ResourceStatus) error {
-	return errors.New("Not implemented")
+	dependent resourcestatus.ResourceStatus) {
 }
 
 func (cgroup *CgroupResource) GetContainerDependencies(dependent resourcestatus.ResourceStatus) []apicontainer.ContainerDependency {

--- a/agent/taskresource/credentialspec/credentialspec_unsupported.go
+++ b/agent/taskresource/credentialspec/credentialspec_unsupported.go
@@ -18,6 +18,8 @@ package credentialspec
 import (
 	"time"
 
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	"github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/agent/credentials"
 	s3factory "github.com/aws/amazon-ecs-agent/agent/s3/factory"
@@ -152,4 +154,26 @@ func (cs *CredentialSpecResource) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON deserialises the raw JSON to a CredentialSpecResourceJSON struct
 func (cs *CredentialSpecResource) UnmarshalJSON(b []byte) error {
 	return errors.New("not implemented")
+}
+
+// GetAppliedStatus safely returns the currently applied status of the resource
+func (cs *CredentialSpecResource) GetAppliedStatus() resourcestatus.ResourceStatus {
+	return resourcestatus.ResourceStatusNone
+}
+
+func (cs *CredentialSpecResource) DependOnTaskNetwork() bool {
+	return false
+}
+
+func (cs *CredentialSpecResource) BuildContainerDependency(containerName string, satisfied apicontainerstatus.ContainerStatus,
+	dependent resourcestatus.ResourceStatus) error {
+	return errors.New("Not implemented")
+}
+
+func (cs *CredentialSpecResource) GetContainerDependencies(dependent resourcestatus.ResourceStatus) []apicontainer.ContainerDependency {
+	return nil
+}
+
+// UpdateAppliedStatus safely updates the applied status of the resource
+func (cs *CredentialSpecResource) UpdateAppliedStatus(status resourcestatus.ResourceStatus) {
 }

--- a/agent/taskresource/credentialspec/credentialspec_unsupported.go
+++ b/agent/taskresource/credentialspec/credentialspec_unsupported.go
@@ -166,14 +166,9 @@ func (cs *CredentialSpecResource) DependOnTaskNetwork() bool {
 }
 
 func (cs *CredentialSpecResource) BuildContainerDependency(containerName string, satisfied apicontainerstatus.ContainerStatus,
-	dependent resourcestatus.ResourceStatus) error {
-	return errors.New("Not implemented")
+	dependent resourcestatus.ResourceStatus) {
 }
 
 func (cs *CredentialSpecResource) GetContainerDependencies(dependent resourcestatus.ResourceStatus) []apicontainer.ContainerDependency {
 	return nil
-}
-
-// UpdateAppliedStatus safely updates the applied status of the resource
-func (cs *CredentialSpecResource) UpdateAppliedStatus(status resourcestatus.ResourceStatus) {
 }

--- a/agent/taskresource/credentialspec/credentialspec_windows.go
+++ b/agent/taskresource/credentialspec/credentialspec_windows.go
@@ -24,6 +24,8 @@ import (
 	"sync"
 	"time"
 
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	"github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/agent/credentials"
 	"github.com/aws/amazon-ecs-agent/agent/s3"
@@ -629,4 +631,26 @@ func (cs *CredentialSpecResource) setCredentialSpecResourceLocation() error {
 	}
 
 	return nil
+}
+
+// GetAppliedStatus safely returns the currently applied status of the resource
+func (cs *CredentialSpecResource) GetAppliedStatus() resourcestatus.ResourceStatus {
+	return resourcestatus.ResourceStatusNone
+}
+
+func (cs *CredentialSpecResource) DependOnTaskNetwork() bool {
+	return false
+}
+
+func (cs *CredentialSpecResource) BuildContainerDependency(containerName string, satisfied apicontainerstatus.ContainerStatus,
+	dependent resourcestatus.ResourceStatus) error {
+	return errors.New("Not implemented")
+}
+
+func (cs *CredentialSpecResource) GetContainerDependencies(dependent resourcestatus.ResourceStatus) []apicontainer.ContainerDependency {
+	return nil
+}
+
+// UpdateAppliedStatus safely updates the applied status of the resource
+func (cs *CredentialSpecResource) UpdateAppliedStatus(status resourcestatus.ResourceStatus) {
 }

--- a/agent/taskresource/credentialspec/credentialspec_windows.go
+++ b/agent/taskresource/credentialspec/credentialspec_windows.go
@@ -643,14 +643,9 @@ func (cs *CredentialSpecResource) DependOnTaskNetwork() bool {
 }
 
 func (cs *CredentialSpecResource) BuildContainerDependency(containerName string, satisfied apicontainerstatus.ContainerStatus,
-	dependent resourcestatus.ResourceStatus) error {
-	return errors.New("Not implemented")
+	dependent resourcestatus.ResourceStatus) {
 }
 
 func (cs *CredentialSpecResource) GetContainerDependencies(dependent resourcestatus.ResourceStatus) []apicontainer.ContainerDependency {
 	return nil
-}
-
-// UpdateAppliedStatus safely updates the applied status of the resource
-func (cs *CredentialSpecResource) UpdateAppliedStatus(status resourcestatus.ResourceStatus) {
 }

--- a/agent/taskresource/firelens/firelens_unimplemented.go
+++ b/agent/taskresource/firelens/firelens_unimplemented.go
@@ -158,9 +158,6 @@ func (firelens *FirelensResource) Initialize(resourceFields *taskresource.Resour
 	taskDesiredStatus status.TaskStatus) {
 }
 
-// UpdateAppliedStatus safely updates the applied status of the resource
-func (firelens *FirelensResource) UpdateAppliedStatus(status resourcestatus.ResourceStatus) {}
-
 // GetAppliedStatus safely returns the currently applied status of the resource
 func (firelens *FirelensResource) GetAppliedStatus() resourcestatus.ResourceStatus {
 	return resourcestatus.ResourceStatusNone
@@ -171,8 +168,7 @@ func (firelens *FirelensResource) DependOnTaskNetwork() bool {
 }
 
 func (firelens *FirelensResource) BuildContainerDependency(containerName string, satisfied apicontainerstatus.ContainerStatus,
-	dependent resourcestatus.ResourceStatus) error {
-	return errors.New("Not implemented")
+	dependent resourcestatus.ResourceStatus) {
 }
 
 func (firelens *FirelensResource) GetContainerDependencies(dependent resourcestatus.ResourceStatus) []apicontainer.ContainerDependency {

--- a/agent/taskresource/firelens/firelens_unimplemented.go
+++ b/agent/taskresource/firelens/firelens_unimplemented.go
@@ -19,6 +19,8 @@ import (
 	"errors"
 	"time"
 
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	"github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/agent/credentials"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
@@ -154,4 +156,25 @@ func (firelens *FirelensResource) UnmarshalJSON(b []byte) error {
 func (firelens *FirelensResource) Initialize(resourceFields *taskresource.ResourceFields,
 	taskKnownStatus status.TaskStatus,
 	taskDesiredStatus status.TaskStatus) {
+}
+
+// UpdateAppliedStatus safely updates the applied status of the resource
+func (firelens *FirelensResource) UpdateAppliedStatus(status resourcestatus.ResourceStatus) {}
+
+// GetAppliedStatus safely returns the currently applied status of the resource
+func (firelens *FirelensResource) GetAppliedStatus() resourcestatus.ResourceStatus {
+	return resourcestatus.ResourceStatusNone
+}
+
+func (firelens *FirelensResource) DependOnTaskNetwork() bool {
+	return false
+}
+
+func (firelens *FirelensResource) BuildContainerDependency(containerName string, satisfied apicontainerstatus.ContainerStatus,
+	dependent resourcestatus.ResourceStatus) error {
+	return errors.New("Not implemented")
+}
+
+func (firelens *FirelensResource) GetContainerDependencies(dependent resourcestatus.ResourceStatus) []apicontainer.ContainerDependency {
+	return nil
 }

--- a/agent/taskresource/firelens/firelens_unix.go
+++ b/agent/taskresource/firelens/firelens_unix.go
@@ -26,6 +26,8 @@ import (
 	"github.com/cihub/seelog"
 	"github.com/pkg/errors"
 
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	"github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/agent/credentials"
 	"github.com/aws/amazon-ecs-agent/agent/s3"
@@ -549,4 +551,22 @@ func (firelens *FirelensResource) Cleanup() error {
 
 	seelog.Infof("Removed firelens resource directory at %s", firelens.resourceDir)
 	return nil
+}
+
+func (firelens *FirelensResource) DependOnTaskNetwork() bool {
+	return false
+}
+
+func (firelens *FirelensResource) BuildContainerDependency(containerName string, satisfied apicontainerstatus.ContainerStatus,
+	dependent resourcestatus.ResourceStatus) error {
+	return errors.New("Not implemented")
+}
+
+func (firelens *FirelensResource) GetContainerDependencies(dependent resourcestatus.ResourceStatus) []apicontainer.ContainerDependency {
+	return nil
+}
+
+// UpdateAppliedStatus safely updates the applied status of the resource
+func (firelens *FirelensResource) UpdateAppliedStatus(status resourcestatus.ResourceStatus) {
+	firelens.SetAppliedStatus(status)
 }

--- a/agent/taskresource/firelens/firelens_unix.go
+++ b/agent/taskresource/firelens/firelens_unix.go
@@ -558,15 +558,9 @@ func (firelens *FirelensResource) DependOnTaskNetwork() bool {
 }
 
 func (firelens *FirelensResource) BuildContainerDependency(containerName string, satisfied apicontainerstatus.ContainerStatus,
-	dependent resourcestatus.ResourceStatus) error {
-	return errors.New("Not implemented")
+	dependent resourcestatus.ResourceStatus) {
 }
 
 func (firelens *FirelensResource) GetContainerDependencies(dependent resourcestatus.ResourceStatus) []apicontainer.ContainerDependency {
 	return nil
-}
-
-// UpdateAppliedStatus safely updates the applied status of the resource
-func (firelens *FirelensResource) UpdateAppliedStatus(status resourcestatus.ResourceStatus) {
-	firelens.SetAppliedStatus(status)
 }

--- a/agent/taskresource/interface.go
+++ b/agent/taskresource/interface.go
@@ -58,8 +58,6 @@ type TaskResource interface {
 	// SetAppliedStatus sets the applied status of resource and returns whether
 	// the resource is already in a transition
 	SetAppliedStatus(status resourcestatus.ResourceStatus) bool
-	// UpdateAppliedStatus directly updates the applied status of resource
-	UpdateAppliedStatus(status resourcestatus.ResourceStatus)
 	// GetAppliedStatus gets the applied status of resource
 	GetAppliedStatus() resourcestatus.ResourceStatus
 	// StatusString returns the string of the resource status
@@ -73,7 +71,7 @@ type TaskResource interface {
 	GetContainerDependencies(resourcestatus.ResourceStatus) []apicontainer.ContainerDependency
 	// BuildContainerDependency adds a new dependency container and its satisfied status
 	BuildContainerDependency(containerName string, satisfied apicontainerstatus.ContainerStatus,
-		dependent resourcestatus.ResourceStatus) error
+		dependent resourcestatus.ResourceStatus)
 	// Initialize will initialze the resource fields of the resource
 	Initialize(res *ResourceFields,
 		taskKnownStatus apitaskstatus.TaskStatus, taskDesiredStatus apitaskstatus.TaskStatus)

--- a/agent/taskresource/interface.go
+++ b/agent/taskresource/interface.go
@@ -17,6 +17,8 @@ import (
 	"encoding/json"
 	"time"
 
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	apitaskstatus "github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
 )
@@ -56,15 +58,38 @@ type TaskResource interface {
 	// SetAppliedStatus sets the applied status of resource and returns whether
 	// the resource is already in a transition
 	SetAppliedStatus(status resourcestatus.ResourceStatus) bool
+	// UpdateAppliedStatus directly updates the applied status of resource
+	UpdateAppliedStatus(status resourcestatus.ResourceStatus)
+	// GetAppliedStatus gets the applied status of resource
+	GetAppliedStatus() resourcestatus.ResourceStatus
 	// StatusString returns the string of the resource status
 	StatusString(status resourcestatus.ResourceStatus) string
 	// GetTerminalReason returns string describing why the resource failed to
 	// provision
 	GetTerminalReason() string
+	// DependOnTaskNetwork shows whether the resource creation needs task network setup beforehand
+	DependOnTaskNetwork() bool
+	// GetContainerDependencies returns dependent containers for a status
+	GetContainerDependencies(resourcestatus.ResourceStatus) []apicontainer.ContainerDependency
+	// BuildContainerDependency adds a new dependency container and its satisfied status
+	BuildContainerDependency(containerName string, satisfied apicontainerstatus.ContainerStatus,
+		dependent resourcestatus.ResourceStatus) error
 	// Initialize will initialze the resource fields of the resource
 	Initialize(res *ResourceFields,
 		taskKnownStatus apitaskstatus.TaskStatus, taskDesiredStatus apitaskstatus.TaskStatus)
 
 	json.Marshaler
 	json.Unmarshaler
+}
+
+// TransitionDependenciesMap is a map of the dependent resource status to other
+// dependencies that must be satisfied.
+type TransitionDependenciesMap map[resourcestatus.ResourceStatus]TransitionDependencySet
+
+// TransitionDependencySet contains dependencies that impact transitions of
+// resources.
+type TransitionDependencySet struct {
+	// ContainerDependencies is the set of containers on which a transition is
+	// dependent.
+	ContainerDependencies []apicontainer.ContainerDependency `json:"ContainerDependencies"`
 }

--- a/agent/taskresource/mocks/taskresource_mocks.go
+++ b/agent/taskresource/mocks/taskresource_mocks.go
@@ -22,9 +22,11 @@ import (
 	reflect "reflect"
 	time "time"
 
-	status "github.com/aws/amazon-ecs-agent/agent/api/task/status"
+	container "github.com/aws/amazon-ecs-agent/agent/api/container"
+	status "github.com/aws/amazon-ecs-agent/agent/api/container/status"
+	status0 "github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	taskresource "github.com/aws/amazon-ecs-agent/agent/taskresource"
-	status0 "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
+	status1 "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -52,8 +54,7 @@ func (m *MockTaskResource) EXPECT() *MockTaskResourceMockRecorder {
 }
 
 // ApplyTransition mocks base method
-func (m *MockTaskResource) ApplyTransition(arg0 status0.ResourceStatus) error {
-	m.ctrl.T.Helper()
+func (m *MockTaskResource) ApplyTransition(arg0 status1.ResourceStatus) error {
 	ret := m.ctrl.Call(m, "ApplyTransition", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -61,13 +62,23 @@ func (m *MockTaskResource) ApplyTransition(arg0 status0.ResourceStatus) error {
 
 // ApplyTransition indicates an expected call of ApplyTransition
 func (mr *MockTaskResourceMockRecorder) ApplyTransition(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyTransition", reflect.TypeOf((*MockTaskResource)(nil).ApplyTransition), arg0)
+}
+
+// BuildContainerDependency mocks base method
+func (m *MockTaskResource) BuildContainerDependency(arg0 string, arg1 status.ContainerStatus, arg2 status1.ResourceStatus) error {
+	ret := m.ctrl.Call(m, "BuildContainerDependency", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BuildContainerDependency indicates an expected call of BuildContainerDependency
+func (mr *MockTaskResourceMockRecorder) BuildContainerDependency(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildContainerDependency", reflect.TypeOf((*MockTaskResource)(nil).BuildContainerDependency), arg0, arg1, arg2)
 }
 
 // Cleanup mocks base method
 func (m *MockTaskResource) Cleanup() error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Cleanup")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -75,13 +86,11 @@ func (m *MockTaskResource) Cleanup() error {
 
 // Cleanup indicates an expected call of Cleanup
 func (mr *MockTaskResourceMockRecorder) Cleanup() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Cleanup", reflect.TypeOf((*MockTaskResource)(nil).Cleanup))
 }
 
 // Create mocks base method
 func (m *MockTaskResource) Create() error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -89,13 +98,23 @@ func (m *MockTaskResource) Create() error {
 
 // Create indicates an expected call of Create
 func (mr *MockTaskResourceMockRecorder) Create() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockTaskResource)(nil).Create))
+}
+
+// DependOnTaskNetwork mocks base method
+func (m *MockTaskResource) DependOnTaskNetwork() bool {
+	ret := m.ctrl.Call(m, "DependOnTaskNetwork")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// DependOnTaskNetwork indicates an expected call of DependOnTaskNetwork
+func (mr *MockTaskResourceMockRecorder) DependOnTaskNetwork() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DependOnTaskNetwork", reflect.TypeOf((*MockTaskResource)(nil).DependOnTaskNetwork))
 }
 
 // DesiredTerminal mocks base method
 func (m *MockTaskResource) DesiredTerminal() bool {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DesiredTerminal")
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -103,13 +122,35 @@ func (m *MockTaskResource) DesiredTerminal() bool {
 
 // DesiredTerminal indicates an expected call of DesiredTerminal
 func (mr *MockTaskResourceMockRecorder) DesiredTerminal() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DesiredTerminal", reflect.TypeOf((*MockTaskResource)(nil).DesiredTerminal))
+}
+
+// GetAppliedStatus mocks base method
+func (m *MockTaskResource) GetAppliedStatus() status1.ResourceStatus {
+	ret := m.ctrl.Call(m, "GetAppliedStatus")
+	ret0, _ := ret[0].(status1.ResourceStatus)
+	return ret0
+}
+
+// GetAppliedStatus indicates an expected call of GetAppliedStatus
+func (mr *MockTaskResourceMockRecorder) GetAppliedStatus() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAppliedStatus", reflect.TypeOf((*MockTaskResource)(nil).GetAppliedStatus))
+}
+
+// GetContainerDependencies mocks base method
+func (m *MockTaskResource) GetContainerDependencies(arg0 status1.ResourceStatus) []container.ContainerDependency {
+	ret := m.ctrl.Call(m, "GetContainerDependencies", arg0)
+	ret0, _ := ret[0].([]container.ContainerDependency)
+	return ret0
+}
+
+// GetContainerDependencies indicates an expected call of GetContainerDependencies
+func (mr *MockTaskResourceMockRecorder) GetContainerDependencies(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContainerDependencies", reflect.TypeOf((*MockTaskResource)(nil).GetContainerDependencies), arg0)
 }
 
 // GetCreatedAt mocks base method
 func (m *MockTaskResource) GetCreatedAt() time.Time {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCreatedAt")
 	ret0, _ := ret[0].(time.Time)
 	return ret0
@@ -117,41 +158,35 @@ func (m *MockTaskResource) GetCreatedAt() time.Time {
 
 // GetCreatedAt indicates an expected call of GetCreatedAt
 func (mr *MockTaskResourceMockRecorder) GetCreatedAt() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCreatedAt", reflect.TypeOf((*MockTaskResource)(nil).GetCreatedAt))
 }
 
 // GetDesiredStatus mocks base method
-func (m *MockTaskResource) GetDesiredStatus() status0.ResourceStatus {
-	m.ctrl.T.Helper()
+func (m *MockTaskResource) GetDesiredStatus() status1.ResourceStatus {
 	ret := m.ctrl.Call(m, "GetDesiredStatus")
-	ret0, _ := ret[0].(status0.ResourceStatus)
+	ret0, _ := ret[0].(status1.ResourceStatus)
 	return ret0
 }
 
 // GetDesiredStatus indicates an expected call of GetDesiredStatus
 func (mr *MockTaskResourceMockRecorder) GetDesiredStatus() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDesiredStatus", reflect.TypeOf((*MockTaskResource)(nil).GetDesiredStatus))
 }
 
 // GetKnownStatus mocks base method
-func (m *MockTaskResource) GetKnownStatus() status0.ResourceStatus {
-	m.ctrl.T.Helper()
+func (m *MockTaskResource) GetKnownStatus() status1.ResourceStatus {
 	ret := m.ctrl.Call(m, "GetKnownStatus")
-	ret0, _ := ret[0].(status0.ResourceStatus)
+	ret0, _ := ret[0].(status1.ResourceStatus)
 	return ret0
 }
 
 // GetKnownStatus indicates an expected call of GetKnownStatus
 func (mr *MockTaskResourceMockRecorder) GetKnownStatus() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKnownStatus", reflect.TypeOf((*MockTaskResource)(nil).GetKnownStatus))
 }
 
 // GetName mocks base method
 func (m *MockTaskResource) GetName() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetName")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -159,13 +194,11 @@ func (m *MockTaskResource) GetName() string {
 
 // GetName indicates an expected call of GetName
 func (mr *MockTaskResourceMockRecorder) GetName() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetName", reflect.TypeOf((*MockTaskResource)(nil).GetName))
 }
 
 // GetTerminalReason mocks base method
 func (m *MockTaskResource) GetTerminalReason() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTerminalReason")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -173,25 +206,21 @@ func (m *MockTaskResource) GetTerminalReason() string {
 
 // GetTerminalReason indicates an expected call of GetTerminalReason
 func (mr *MockTaskResourceMockRecorder) GetTerminalReason() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTerminalReason", reflect.TypeOf((*MockTaskResource)(nil).GetTerminalReason))
 }
 
 // Initialize mocks base method
-func (m *MockTaskResource) Initialize(arg0 *taskresource.ResourceFields, arg1, arg2 status.TaskStatus) {
-	m.ctrl.T.Helper()
+func (m *MockTaskResource) Initialize(arg0 *taskresource.ResourceFields, arg1, arg2 status0.TaskStatus) {
 	m.ctrl.Call(m, "Initialize", arg0, arg1, arg2)
 }
 
 // Initialize indicates an expected call of Initialize
 func (mr *MockTaskResourceMockRecorder) Initialize(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Initialize", reflect.TypeOf((*MockTaskResource)(nil).Initialize), arg0, arg1, arg2)
 }
 
 // KnownCreated mocks base method
 func (m *MockTaskResource) KnownCreated() bool {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "KnownCreated")
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -199,13 +228,11 @@ func (m *MockTaskResource) KnownCreated() bool {
 
 // KnownCreated indicates an expected call of KnownCreated
 func (mr *MockTaskResourceMockRecorder) KnownCreated() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KnownCreated", reflect.TypeOf((*MockTaskResource)(nil).KnownCreated))
 }
 
 // MarshalJSON mocks base method
 func (m *MockTaskResource) MarshalJSON() ([]byte, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MarshalJSON")
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
@@ -214,27 +241,23 @@ func (m *MockTaskResource) MarshalJSON() ([]byte, error) {
 
 // MarshalJSON indicates an expected call of MarshalJSON
 func (mr *MockTaskResourceMockRecorder) MarshalJSON() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarshalJSON", reflect.TypeOf((*MockTaskResource)(nil).MarshalJSON))
 }
 
 // NextKnownState mocks base method
-func (m *MockTaskResource) NextKnownState() status0.ResourceStatus {
-	m.ctrl.T.Helper()
+func (m *MockTaskResource) NextKnownState() status1.ResourceStatus {
 	ret := m.ctrl.Call(m, "NextKnownState")
-	ret0, _ := ret[0].(status0.ResourceStatus)
+	ret0, _ := ret[0].(status1.ResourceStatus)
 	return ret0
 }
 
 // NextKnownState indicates an expected call of NextKnownState
 func (mr *MockTaskResourceMockRecorder) NextKnownState() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NextKnownState", reflect.TypeOf((*MockTaskResource)(nil).NextKnownState))
 }
 
 // SetAppliedStatus mocks base method
-func (m *MockTaskResource) SetAppliedStatus(arg0 status0.ResourceStatus) bool {
-	m.ctrl.T.Helper()
+func (m *MockTaskResource) SetAppliedStatus(arg0 status1.ResourceStatus) bool {
 	ret := m.ctrl.Call(m, "SetAppliedStatus", arg0)
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -242,49 +265,41 @@ func (m *MockTaskResource) SetAppliedStatus(arg0 status0.ResourceStatus) bool {
 
 // SetAppliedStatus indicates an expected call of SetAppliedStatus
 func (mr *MockTaskResourceMockRecorder) SetAppliedStatus(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAppliedStatus", reflect.TypeOf((*MockTaskResource)(nil).SetAppliedStatus), arg0)
 }
 
 // SetCreatedAt mocks base method
 func (m *MockTaskResource) SetCreatedAt(arg0 time.Time) {
-	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetCreatedAt", arg0)
 }
 
 // SetCreatedAt indicates an expected call of SetCreatedAt
 func (mr *MockTaskResourceMockRecorder) SetCreatedAt(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCreatedAt", reflect.TypeOf((*MockTaskResource)(nil).SetCreatedAt), arg0)
 }
 
 // SetDesiredStatus mocks base method
-func (m *MockTaskResource) SetDesiredStatus(arg0 status0.ResourceStatus) {
-	m.ctrl.T.Helper()
+func (m *MockTaskResource) SetDesiredStatus(arg0 status1.ResourceStatus) {
 	m.ctrl.Call(m, "SetDesiredStatus", arg0)
 }
 
 // SetDesiredStatus indicates an expected call of SetDesiredStatus
 func (mr *MockTaskResourceMockRecorder) SetDesiredStatus(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDesiredStatus", reflect.TypeOf((*MockTaskResource)(nil).SetDesiredStatus), arg0)
 }
 
 // SetKnownStatus mocks base method
-func (m *MockTaskResource) SetKnownStatus(arg0 status0.ResourceStatus) {
-	m.ctrl.T.Helper()
+func (m *MockTaskResource) SetKnownStatus(arg0 status1.ResourceStatus) {
 	m.ctrl.Call(m, "SetKnownStatus", arg0)
 }
 
 // SetKnownStatus indicates an expected call of SetKnownStatus
 func (mr *MockTaskResourceMockRecorder) SetKnownStatus(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetKnownStatus", reflect.TypeOf((*MockTaskResource)(nil).SetKnownStatus), arg0)
 }
 
 // StatusString mocks base method
-func (m *MockTaskResource) StatusString(arg0 status0.ResourceStatus) string {
-	m.ctrl.T.Helper()
+func (m *MockTaskResource) StatusString(arg0 status1.ResourceStatus) string {
 	ret := m.ctrl.Call(m, "StatusString", arg0)
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -292,41 +307,35 @@ func (m *MockTaskResource) StatusString(arg0 status0.ResourceStatus) string {
 
 // StatusString indicates an expected call of StatusString
 func (mr *MockTaskResourceMockRecorder) StatusString(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StatusString", reflect.TypeOf((*MockTaskResource)(nil).StatusString), arg0)
 }
 
 // SteadyState mocks base method
-func (m *MockTaskResource) SteadyState() status0.ResourceStatus {
-	m.ctrl.T.Helper()
+func (m *MockTaskResource) SteadyState() status1.ResourceStatus {
 	ret := m.ctrl.Call(m, "SteadyState")
-	ret0, _ := ret[0].(status0.ResourceStatus)
+	ret0, _ := ret[0].(status1.ResourceStatus)
 	return ret0
 }
 
 // SteadyState indicates an expected call of SteadyState
 func (mr *MockTaskResourceMockRecorder) SteadyState() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SteadyState", reflect.TypeOf((*MockTaskResource)(nil).SteadyState))
 }
 
 // TerminalStatus mocks base method
-func (m *MockTaskResource) TerminalStatus() status0.ResourceStatus {
-	m.ctrl.T.Helper()
+func (m *MockTaskResource) TerminalStatus() status1.ResourceStatus {
 	ret := m.ctrl.Call(m, "TerminalStatus")
-	ret0, _ := ret[0].(status0.ResourceStatus)
+	ret0, _ := ret[0].(status1.ResourceStatus)
 	return ret0
 }
 
 // TerminalStatus indicates an expected call of TerminalStatus
 func (mr *MockTaskResourceMockRecorder) TerminalStatus() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TerminalStatus", reflect.TypeOf((*MockTaskResource)(nil).TerminalStatus))
 }
 
 // UnmarshalJSON mocks base method
 func (m *MockTaskResource) UnmarshalJSON(arg0 []byte) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UnmarshalJSON", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -334,6 +343,15 @@ func (m *MockTaskResource) UnmarshalJSON(arg0 []byte) error {
 
 // UnmarshalJSON indicates an expected call of UnmarshalJSON
 func (mr *MockTaskResourceMockRecorder) UnmarshalJSON(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnmarshalJSON", reflect.TypeOf((*MockTaskResource)(nil).UnmarshalJSON), arg0)
+}
+
+// UpdateAppliedStatus mocks base method
+func (m *MockTaskResource) UpdateAppliedStatus(arg0 status1.ResourceStatus) {
+	m.ctrl.Call(m, "UpdateAppliedStatus", arg0)
+}
+
+// UpdateAppliedStatus indicates an expected call of UpdateAppliedStatus
+func (mr *MockTaskResourceMockRecorder) UpdateAppliedStatus(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAppliedStatus", reflect.TypeOf((*MockTaskResource)(nil).UpdateAppliedStatus), arg0)
 }

--- a/agent/taskresource/mocks/taskresource_mocks.go
+++ b/agent/taskresource/mocks/taskresource_mocks.go
@@ -55,6 +55,7 @@ func (m *MockTaskResource) EXPECT() *MockTaskResourceMockRecorder {
 
 // ApplyTransition mocks base method
 func (m *MockTaskResource) ApplyTransition(arg0 status1.ResourceStatus) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ApplyTransition", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -62,23 +63,25 @@ func (m *MockTaskResource) ApplyTransition(arg0 status1.ResourceStatus) error {
 
 // ApplyTransition indicates an expected call of ApplyTransition
 func (mr *MockTaskResourceMockRecorder) ApplyTransition(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyTransition", reflect.TypeOf((*MockTaskResource)(nil).ApplyTransition), arg0)
 }
 
 // BuildContainerDependency mocks base method
-func (m *MockTaskResource) BuildContainerDependency(arg0 string, arg1 status.ContainerStatus, arg2 status1.ResourceStatus) error {
-	ret := m.ctrl.Call(m, "BuildContainerDependency", arg0, arg1, arg2)
-	ret0, _ := ret[0].(error)
-	return ret0
+func (m *MockTaskResource) BuildContainerDependency(arg0 string, arg1 status.ContainerStatus, arg2 status1.ResourceStatus) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "BuildContainerDependency", arg0, arg1, arg2)
 }
 
 // BuildContainerDependency indicates an expected call of BuildContainerDependency
 func (mr *MockTaskResourceMockRecorder) BuildContainerDependency(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildContainerDependency", reflect.TypeOf((*MockTaskResource)(nil).BuildContainerDependency), arg0, arg1, arg2)
 }
 
 // Cleanup mocks base method
 func (m *MockTaskResource) Cleanup() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Cleanup")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -86,11 +89,13 @@ func (m *MockTaskResource) Cleanup() error {
 
 // Cleanup indicates an expected call of Cleanup
 func (mr *MockTaskResourceMockRecorder) Cleanup() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Cleanup", reflect.TypeOf((*MockTaskResource)(nil).Cleanup))
 }
 
 // Create mocks base method
 func (m *MockTaskResource) Create() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -98,11 +103,13 @@ func (m *MockTaskResource) Create() error {
 
 // Create indicates an expected call of Create
 func (mr *MockTaskResourceMockRecorder) Create() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockTaskResource)(nil).Create))
 }
 
 // DependOnTaskNetwork mocks base method
 func (m *MockTaskResource) DependOnTaskNetwork() bool {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DependOnTaskNetwork")
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -110,11 +117,13 @@ func (m *MockTaskResource) DependOnTaskNetwork() bool {
 
 // DependOnTaskNetwork indicates an expected call of DependOnTaskNetwork
 func (mr *MockTaskResourceMockRecorder) DependOnTaskNetwork() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DependOnTaskNetwork", reflect.TypeOf((*MockTaskResource)(nil).DependOnTaskNetwork))
 }
 
 // DesiredTerminal mocks base method
 func (m *MockTaskResource) DesiredTerminal() bool {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DesiredTerminal")
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -122,11 +131,13 @@ func (m *MockTaskResource) DesiredTerminal() bool {
 
 // DesiredTerminal indicates an expected call of DesiredTerminal
 func (mr *MockTaskResourceMockRecorder) DesiredTerminal() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DesiredTerminal", reflect.TypeOf((*MockTaskResource)(nil).DesiredTerminal))
 }
 
 // GetAppliedStatus mocks base method
 func (m *MockTaskResource) GetAppliedStatus() status1.ResourceStatus {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAppliedStatus")
 	ret0, _ := ret[0].(status1.ResourceStatus)
 	return ret0
@@ -134,11 +145,13 @@ func (m *MockTaskResource) GetAppliedStatus() status1.ResourceStatus {
 
 // GetAppliedStatus indicates an expected call of GetAppliedStatus
 func (mr *MockTaskResourceMockRecorder) GetAppliedStatus() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAppliedStatus", reflect.TypeOf((*MockTaskResource)(nil).GetAppliedStatus))
 }
 
 // GetContainerDependencies mocks base method
 func (m *MockTaskResource) GetContainerDependencies(arg0 status1.ResourceStatus) []container.ContainerDependency {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetContainerDependencies", arg0)
 	ret0, _ := ret[0].([]container.ContainerDependency)
 	return ret0
@@ -146,11 +159,13 @@ func (m *MockTaskResource) GetContainerDependencies(arg0 status1.ResourceStatus)
 
 // GetContainerDependencies indicates an expected call of GetContainerDependencies
 func (mr *MockTaskResourceMockRecorder) GetContainerDependencies(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContainerDependencies", reflect.TypeOf((*MockTaskResource)(nil).GetContainerDependencies), arg0)
 }
 
 // GetCreatedAt mocks base method
 func (m *MockTaskResource) GetCreatedAt() time.Time {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCreatedAt")
 	ret0, _ := ret[0].(time.Time)
 	return ret0
@@ -158,11 +173,13 @@ func (m *MockTaskResource) GetCreatedAt() time.Time {
 
 // GetCreatedAt indicates an expected call of GetCreatedAt
 func (mr *MockTaskResourceMockRecorder) GetCreatedAt() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCreatedAt", reflect.TypeOf((*MockTaskResource)(nil).GetCreatedAt))
 }
 
 // GetDesiredStatus mocks base method
 func (m *MockTaskResource) GetDesiredStatus() status1.ResourceStatus {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDesiredStatus")
 	ret0, _ := ret[0].(status1.ResourceStatus)
 	return ret0
@@ -170,11 +187,13 @@ func (m *MockTaskResource) GetDesiredStatus() status1.ResourceStatus {
 
 // GetDesiredStatus indicates an expected call of GetDesiredStatus
 func (mr *MockTaskResourceMockRecorder) GetDesiredStatus() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDesiredStatus", reflect.TypeOf((*MockTaskResource)(nil).GetDesiredStatus))
 }
 
 // GetKnownStatus mocks base method
 func (m *MockTaskResource) GetKnownStatus() status1.ResourceStatus {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetKnownStatus")
 	ret0, _ := ret[0].(status1.ResourceStatus)
 	return ret0
@@ -182,11 +201,13 @@ func (m *MockTaskResource) GetKnownStatus() status1.ResourceStatus {
 
 // GetKnownStatus indicates an expected call of GetKnownStatus
 func (mr *MockTaskResourceMockRecorder) GetKnownStatus() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKnownStatus", reflect.TypeOf((*MockTaskResource)(nil).GetKnownStatus))
 }
 
 // GetName mocks base method
 func (m *MockTaskResource) GetName() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetName")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -194,11 +215,13 @@ func (m *MockTaskResource) GetName() string {
 
 // GetName indicates an expected call of GetName
 func (mr *MockTaskResourceMockRecorder) GetName() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetName", reflect.TypeOf((*MockTaskResource)(nil).GetName))
 }
 
 // GetTerminalReason mocks base method
 func (m *MockTaskResource) GetTerminalReason() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTerminalReason")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -206,21 +229,25 @@ func (m *MockTaskResource) GetTerminalReason() string {
 
 // GetTerminalReason indicates an expected call of GetTerminalReason
 func (mr *MockTaskResourceMockRecorder) GetTerminalReason() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTerminalReason", reflect.TypeOf((*MockTaskResource)(nil).GetTerminalReason))
 }
 
 // Initialize mocks base method
 func (m *MockTaskResource) Initialize(arg0 *taskresource.ResourceFields, arg1, arg2 status0.TaskStatus) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Initialize", arg0, arg1, arg2)
 }
 
 // Initialize indicates an expected call of Initialize
 func (mr *MockTaskResourceMockRecorder) Initialize(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Initialize", reflect.TypeOf((*MockTaskResource)(nil).Initialize), arg0, arg1, arg2)
 }
 
 // KnownCreated mocks base method
 func (m *MockTaskResource) KnownCreated() bool {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "KnownCreated")
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -228,11 +255,13 @@ func (m *MockTaskResource) KnownCreated() bool {
 
 // KnownCreated indicates an expected call of KnownCreated
 func (mr *MockTaskResourceMockRecorder) KnownCreated() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KnownCreated", reflect.TypeOf((*MockTaskResource)(nil).KnownCreated))
 }
 
 // MarshalJSON mocks base method
 func (m *MockTaskResource) MarshalJSON() ([]byte, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MarshalJSON")
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
@@ -241,11 +270,13 @@ func (m *MockTaskResource) MarshalJSON() ([]byte, error) {
 
 // MarshalJSON indicates an expected call of MarshalJSON
 func (mr *MockTaskResourceMockRecorder) MarshalJSON() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarshalJSON", reflect.TypeOf((*MockTaskResource)(nil).MarshalJSON))
 }
 
 // NextKnownState mocks base method
 func (m *MockTaskResource) NextKnownState() status1.ResourceStatus {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NextKnownState")
 	ret0, _ := ret[0].(status1.ResourceStatus)
 	return ret0
@@ -253,11 +284,13 @@ func (m *MockTaskResource) NextKnownState() status1.ResourceStatus {
 
 // NextKnownState indicates an expected call of NextKnownState
 func (mr *MockTaskResourceMockRecorder) NextKnownState() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NextKnownState", reflect.TypeOf((*MockTaskResource)(nil).NextKnownState))
 }
 
 // SetAppliedStatus mocks base method
 func (m *MockTaskResource) SetAppliedStatus(arg0 status1.ResourceStatus) bool {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetAppliedStatus", arg0)
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -265,41 +298,49 @@ func (m *MockTaskResource) SetAppliedStatus(arg0 status1.ResourceStatus) bool {
 
 // SetAppliedStatus indicates an expected call of SetAppliedStatus
 func (mr *MockTaskResourceMockRecorder) SetAppliedStatus(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAppliedStatus", reflect.TypeOf((*MockTaskResource)(nil).SetAppliedStatus), arg0)
 }
 
 // SetCreatedAt mocks base method
 func (m *MockTaskResource) SetCreatedAt(arg0 time.Time) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetCreatedAt", arg0)
 }
 
 // SetCreatedAt indicates an expected call of SetCreatedAt
 func (mr *MockTaskResourceMockRecorder) SetCreatedAt(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCreatedAt", reflect.TypeOf((*MockTaskResource)(nil).SetCreatedAt), arg0)
 }
 
 // SetDesiredStatus mocks base method
 func (m *MockTaskResource) SetDesiredStatus(arg0 status1.ResourceStatus) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetDesiredStatus", arg0)
 }
 
 // SetDesiredStatus indicates an expected call of SetDesiredStatus
 func (mr *MockTaskResourceMockRecorder) SetDesiredStatus(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDesiredStatus", reflect.TypeOf((*MockTaskResource)(nil).SetDesiredStatus), arg0)
 }
 
 // SetKnownStatus mocks base method
 func (m *MockTaskResource) SetKnownStatus(arg0 status1.ResourceStatus) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetKnownStatus", arg0)
 }
 
 // SetKnownStatus indicates an expected call of SetKnownStatus
 func (mr *MockTaskResourceMockRecorder) SetKnownStatus(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetKnownStatus", reflect.TypeOf((*MockTaskResource)(nil).SetKnownStatus), arg0)
 }
 
 // StatusString mocks base method
 func (m *MockTaskResource) StatusString(arg0 status1.ResourceStatus) string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StatusString", arg0)
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -307,11 +348,13 @@ func (m *MockTaskResource) StatusString(arg0 status1.ResourceStatus) string {
 
 // StatusString indicates an expected call of StatusString
 func (mr *MockTaskResourceMockRecorder) StatusString(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StatusString", reflect.TypeOf((*MockTaskResource)(nil).StatusString), arg0)
 }
 
 // SteadyState mocks base method
 func (m *MockTaskResource) SteadyState() status1.ResourceStatus {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SteadyState")
 	ret0, _ := ret[0].(status1.ResourceStatus)
 	return ret0
@@ -319,11 +362,13 @@ func (m *MockTaskResource) SteadyState() status1.ResourceStatus {
 
 // SteadyState indicates an expected call of SteadyState
 func (mr *MockTaskResourceMockRecorder) SteadyState() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SteadyState", reflect.TypeOf((*MockTaskResource)(nil).SteadyState))
 }
 
 // TerminalStatus mocks base method
 func (m *MockTaskResource) TerminalStatus() status1.ResourceStatus {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TerminalStatus")
 	ret0, _ := ret[0].(status1.ResourceStatus)
 	return ret0
@@ -331,11 +376,13 @@ func (m *MockTaskResource) TerminalStatus() status1.ResourceStatus {
 
 // TerminalStatus indicates an expected call of TerminalStatus
 func (mr *MockTaskResourceMockRecorder) TerminalStatus() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TerminalStatus", reflect.TypeOf((*MockTaskResource)(nil).TerminalStatus))
 }
 
 // UnmarshalJSON mocks base method
 func (m *MockTaskResource) UnmarshalJSON(arg0 []byte) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UnmarshalJSON", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -343,15 +390,6 @@ func (m *MockTaskResource) UnmarshalJSON(arg0 []byte) error {
 
 // UnmarshalJSON indicates an expected call of UnmarshalJSON
 func (mr *MockTaskResourceMockRecorder) UnmarshalJSON(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnmarshalJSON", reflect.TypeOf((*MockTaskResource)(nil).UnmarshalJSON), arg0)
-}
-
-// UpdateAppliedStatus mocks base method
-func (m *MockTaskResource) UpdateAppliedStatus(arg0 status1.ResourceStatus) {
-	m.ctrl.Call(m, "UpdateAppliedStatus", arg0)
-}
-
-// UpdateAppliedStatus indicates an expected call of UpdateAppliedStatus
-func (mr *MockTaskResourceMockRecorder) UpdateAppliedStatus(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAppliedStatus", reflect.TypeOf((*MockTaskResource)(nil).UpdateAppliedStatus), arg0)
 }

--- a/agent/taskresource/ssmsecret/ssmsecret.go
+++ b/agent/taskresource/ssmsecret/ssmsecret.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pkg/errors"
 
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	"github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/agent/credentials"
 	"github.com/aws/amazon-ecs-agent/agent/ssm"
@@ -478,4 +479,33 @@ func (secret *SSMSecretResource) UnmarshalJSON(b []byte) error {
 	secret.executionCredentialsID = temp.ExecutionCredentialsID
 
 	return nil
+}
+
+// GetAppliedStatus safely returns the currently applied status of the resource
+func (secret *SSMSecretResource) GetAppliedStatus() resourcestatus.ResourceStatus {
+	secret.lock.RLock()
+	defer secret.lock.RUnlock()
+
+	return secret.appliedStatus
+}
+
+func (secret *SSMSecretResource) DependOnTaskNetwork() bool {
+	return false
+}
+
+func (secret *SSMSecretResource) BuildContainerDependency(containerName string, satisfied apicontainerstatus.ContainerStatus,
+	dependent resourcestatus.ResourceStatus) error {
+	return errors.New("Not implemented")
+}
+
+func (secret *SSMSecretResource) GetContainerDependencies(dependent resourcestatus.ResourceStatus) []apicontainer.ContainerDependency {
+	return nil
+}
+
+// UpdateAppliedStatus safely updates the applied status of the resource
+func (secret *SSMSecretResource) UpdateAppliedStatus(status resourcestatus.ResourceStatus) {
+	secret.lock.RLock()
+	defer secret.lock.RUnlock()
+
+	secret.appliedStatus = status
 }

--- a/agent/taskresource/ssmsecret/ssmsecret.go
+++ b/agent/taskresource/ssmsecret/ssmsecret.go
@@ -494,18 +494,9 @@ func (secret *SSMSecretResource) DependOnTaskNetwork() bool {
 }
 
 func (secret *SSMSecretResource) BuildContainerDependency(containerName string, satisfied apicontainerstatus.ContainerStatus,
-	dependent resourcestatus.ResourceStatus) error {
-	return errors.New("Not implemented")
+	dependent resourcestatus.ResourceStatus) {
 }
 
 func (secret *SSMSecretResource) GetContainerDependencies(dependent resourcestatus.ResourceStatus) []apicontainer.ContainerDependency {
 	return nil
-}
-
-// UpdateAppliedStatus safely updates the applied status of the resource
-func (secret *SSMSecretResource) UpdateAppliedStatus(status resourcestatus.ResourceStatus) {
-	secret.lock.RLock()
-	defer secret.lock.RUnlock()
-
-	secret.appliedStatus = status
 }

--- a/agent/taskresource/volume/dockervolume.go
+++ b/agent/taskresource/volume/dockervolume.go
@@ -211,6 +211,7 @@ func (vol *VolumeResource) SetKnownStatus(status resourcestatus.ResourceStatus) 
 	defer vol.lock.Unlock()
 
 	vol.knownStatusUnsafe = status
+	vol.updateAppliedStatusUnsafe(status)
 }
 
 // GetKnownStatus safely returns the currently known status of the task
@@ -418,24 +419,16 @@ func (vol *VolumeResource) GetAppliedStatus() resourcestatus.ResourceStatus {
 	return vol.appliedStatusUnsafe
 }
 
-// UpdateAppliedStatus safely updates the applied status of the resource
-func (vol *VolumeResource) UpdateAppliedStatus(status resourcestatus.ResourceStatus) {
-	vol.lock.RLock()
-	defer vol.lock.RUnlock()
-
-	vol.appliedStatusUnsafe = status
-}
-
 // DependOnTaskNetwork shows whether the resource creation needs task network setup beforehand
 func (vol *VolumeResource) DependOnTaskNetwork() bool {
 	return vol.VolumeType == EFSVolumeType
 }
 
 func (vol *VolumeResource) BuildContainerDependency(containerName string, satisfied apicontainerstatus.ContainerStatus,
-	dependent resourcestatus.ResourceStatus) error {
+	dependent resourcestatus.ResourceStatus) {
 	// No op for non-EFS volume type
 	if vol.VolumeType != EFSVolumeType {
-		return nil
+		return
 	}
 
 	contDep := apicontainer.ContainerDependency{
@@ -448,7 +441,6 @@ func (vol *VolumeResource) BuildContainerDependency(containerName string, satisf
 	deps := vol.transitionDependenciesMap[dependent]
 	deps.ContainerDependencies = append(deps.ContainerDependencies, contDep)
 	vol.transitionDependenciesMap[dependent] = deps
-	return nil
 }
 
 func (vol *VolumeResource) GetContainerDependencies(dependent resourcestatus.ResourceStatus) []apicontainer.ContainerDependency {

--- a/agent/taskresource/volume/dockervolume_efs.go
+++ b/agent/taskresource/volume/dockervolume_efs.go
@@ -1,0 +1,128 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package volume
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/aws/amazon-ecs-agent/agent/config"
+
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/cihub/seelog"
+)
+
+const (
+	// ECSVolumePlugin is the driver name of the ECS volume plugin.
+	ECSVolumePlugin = "amazon-ecs-volume-plugin"
+	// DockerLocalDriverName is the name of Docker's local volume driver.
+	DockerLocalDriverName = "local"
+
+	efsVolumePluginDriverType = "efs"
+	efsLocalDriverType        = "nfs"
+
+	// Capability injected by the ecs volume plugin via ECS_VOLUME_PLUGIN_CAPABILITIES.
+	efsVolumePluginCapability = "efsAuth"
+
+	// Enums used by acs's api-2.json model.
+	efsIAMAuthEnabled           = "ENABLED"
+	efsTransitEncryptionEnabled = "ENABLED"
+)
+
+// EFSVolumeConfig represents efs volume configuration.
+type EFSVolumeConfig struct {
+	AuthConfig            EFSAuthConfig `json:"authorizationConfig,omitempty"`
+	FileSystemID          string        `json:"fileSystemId,omitempty"`
+	RootDirectory         string        `json:"rootDirectory,omitempty"`
+	TransitEncryption     string        `json:"transitEncryption,omitempty"`
+	TransitEncryptionPort int64         `json:"transitEncryptionPort,omitempty"`
+	// DockerVolumeName is internal docker name for this volume.
+	DockerVolumeName string `json:"dockerVolumeName"`
+}
+
+// EFSAuthConfig contains auth config for an efs volume.
+type EFSAuthConfig struct {
+	AccessPointId string `json:"accessPointId,omitempty"`
+	Iam           string `json:"iam,omitempty"`
+}
+
+// GetDriverOptions returns the driver options for creating an EFS volume.
+func GetDriverOptions(cfg *config.Config, efsVolCfg *EFSVolumeConfig, credsRelativeURI string) map[string]string {
+	if UseECSVolumePlugin(cfg) {
+		return efsVolCfg.getVolumePluginDriverOptions(credsRelativeURI)
+	}
+	return efsVolCfg.getDockerLocalDriverOptions(cfg)
+}
+
+// UseECSVolumePlugin checks whether we should use the ECS volume plugin.
+func UseECSVolumePlugin(cfg *config.Config) bool {
+	for _, cap := range cfg.VolumePluginCapabilities {
+		if cap == efsVolumePluginCapability {
+			return true
+		}
+	}
+	return false
+}
+
+// GetDockerLocalDriverOptions returns the options for creating an EFS volume using Docker's local volume driver.
+func (efsVolCfg *EFSVolumeConfig) getDockerLocalDriverOptions(cfg *config.Config) map[string]string {
+	domain := getDomainForPartition(cfg.AWSRegion)
+	// These are the NFS options recommended by EFS, see:
+	// https://docs.aws.amazon.com/efs/latest/ug/mounting-fs-mount-cmd-general.html
+	ostr := fmt.Sprintf("addr=%s.efs.%s.%s,nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport", efsVolCfg.FileSystemID, cfg.AWSRegion, domain)
+	devstr := fmt.Sprintf(":%s", efsVolCfg.RootDirectory)
+	return map[string]string{
+		"type":   efsLocalDriverType,
+		"device": devstr,
+		"o":      ostr,
+	}
+}
+
+// GetEFSDriverOptions returns the options for creating an EFS volume using the ECS volume plugin.
+func (efsVolCfg *EFSVolumeConfig) getVolumePluginDriverOptions(credsRelativeURI string) map[string]string {
+	device := efsVolCfg.FileSystemID
+	if efsVolCfg.RootDirectory != "" {
+		device = fmt.Sprintf("%s:%s", device, efsVolCfg.RootDirectory)
+	}
+
+	mntOpt := NewVolumeMountOptions()
+	if efsVolCfg.TransitEncryption == efsTransitEncryptionEnabled {
+		mntOpt.AddOption("tls", "")
+	}
+	if efsVolCfg.TransitEncryptionPort != 0 {
+		mntOpt.AddOption("tlsport", strconv.Itoa(int(efsVolCfg.TransitEncryptionPort)))
+	}
+	if efsVolCfg.AuthConfig.Iam == efsIAMAuthEnabled {
+		mntOpt.AddOption("iam", "")
+		mntOpt.AddOption("awscredsuri", credsRelativeURI)
+	}
+	if efsVolCfg.AuthConfig.AccessPointId != "" {
+		mntOpt.AddOption("accesspoint", efsVolCfg.AuthConfig.AccessPointId)
+	}
+	options := map[string]string{
+		"type":   efsVolumePluginDriverType,
+		"device": device,
+		"o":      mntOpt.String(),
+	}
+	return options
+}
+
+func getDomainForPartition(region string) string {
+	partition, ok := endpoints.PartitionForRegion(endpoints.DefaultPartitions(), region)
+	if !ok {
+		seelog.Warnf("No partition resolved for region (%s). Using AWS default (%s)", region, endpoints.AwsPartition().DNSSuffix())
+		return endpoints.AwsPartition().DNSSuffix()
+	}
+	return partition.DNSSuffix()
+}

--- a/agent/taskresource/volume/dockervolume_efs_test.go
+++ b/agent/taskresource/volume/dockervolume_efs_test.go
@@ -1,0 +1,95 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package volume
+
+import (
+	"testing"
+
+	"github.com/aws/amazon-ecs-agent/agent/config"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func getTestEFSVolCfg() *EFSVolumeConfig {
+	return &EFSVolumeConfig{
+		AuthConfig: EFSAuthConfig{
+			AccessPointId: "test-ap",
+			Iam:           "ENABLED",
+		},
+		FileSystemID:          "fs-123",
+		RootDirectory:         "/test",
+		TransitEncryption:     "ENABLED",
+		TransitEncryptionPort: int64(123),
+		DockerVolumeName:      "test-vol",
+	}
+}
+
+func TestGetEFSDriverOptions_UseLocalVolumeDriver(t *testing.T) {
+	cfg := &config.Config{
+		AWSRegion: "us-west-1",
+	}
+	efsVolCfg := getTestEFSVolCfg()
+	credsURI := "/v2/creds-id"
+	options := GetDriverOptions(cfg, efsVolCfg, credsURI)
+	assert.Equal(t, "nfs", options["type"])
+	assert.Equal(t, "addr=fs-123.efs.us-west-1.amazonaws.com,nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport", options["o"])
+	assert.Equal(t, ":/test", options["device"])
+}
+
+func TestGetEFSDriverOptions_UseECSVolumePlugin(t *testing.T) {
+	cfg := &config.Config{
+		VolumePluginCapabilities: []string{"efsAuth"},
+	}
+	efsVolCfg := getTestEFSVolCfg()
+	credsURI := "/v2/creds-id"
+	options := GetDriverOptions(cfg, efsVolCfg, credsURI)
+	assert.Equal(t, "efs", options["type"])
+	assert.Equal(t, "tls,tlsport=123,iam,awscredsuri=/v2/creds-id,accesspoint=test-ap", options["o"])
+	assert.Equal(t, "fs-123:/test", options["device"])
+}
+
+func TestUseVolumePlugin(t *testing.T) {
+	cfg := &config.Config{
+		VolumePluginCapabilities: []string{"efsAuth"},
+	}
+	assert.True(t, UseECSVolumePlugin(cfg))
+	assert.False(t, UseECSVolumePlugin(&config.Config{}))
+}
+
+func TestGetDockerLocalDriverOptions(t *testing.T) {
+	efsVolCfg := getTestEFSVolCfg()
+	cfg := &config.Config{
+		AWSRegion: "us-west-2",
+	}
+	options := efsVolCfg.getDockerLocalDriverOptions(cfg)
+	require.Contains(t, options, "type")
+	require.Contains(t, options, "device")
+	require.Contains(t, options, "o")
+	assert.Equal(t, "nfs", options["type"])
+	assert.Equal(t, ":/test", options["device"])
+	assert.Equal(t, "addr=fs-123.efs.us-west-2.amazonaws.com,nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport",
+		options["o"])
+}
+
+func TestGetVolumePluginDriverOptions(t *testing.T) {
+	efsVolCfg := getTestEFSVolCfg()
+	options := efsVolCfg.getVolumePluginDriverOptions("/v2/abc")
+	require.Contains(t, options, "type")
+	require.Contains(t, options, "device")
+	require.Contains(t, options, "o")
+	assert.Equal(t, "efs", options["type"])
+	assert.Equal(t, "fs-123:/test", options["device"])
+	assert.Equal(t, "tls,tlsport=123,iam,awscredsuri=/v2/abc,accesspoint=test-ap", options["o"])
+}

--- a/agent/taskresource/volume/dockervolume_test.go
+++ b/agent/taskresource/volume/dockervolume_test.go
@@ -285,8 +285,7 @@ func TestEFSVolumeBuildContainerDependency(t *testing.T) {
 	testRes, _ := NewVolumeResource(nil, "volume", "efs", "dockerVolume",
 		"", false, "", nil, nil, nil)
 
-	assert.NoError(t, testRes.BuildContainerDependency("PauseContainer", apicontainerstatus.ContainerCreated, resourcestatus.ResourceStatus(VolumeCreated)))
-
+	testRes.BuildContainerDependency("PauseContainer", apicontainerstatus.ContainerCreated, resourcestatus.ResourceStatus(VolumeCreated))
 	contDep := testRes.GetContainerDependencies(resourcestatus.ResourceStatus(VolumeCreated))
 	assert.NotNil(t, contDep)
 

--- a/agent/taskresource/volume/mountoptions.go
+++ b/agent/taskresource/volume/mountoptions.go
@@ -1,0 +1,58 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package volume
+
+import (
+	"strings"
+)
+
+const mntOptSep = ","
+
+// VolumeMountOptions contains a list of mount options for mounting a volume.
+// This struct exists mainly to make serializing/deserializing a list of options easier.
+type VolumeMountOptions struct {
+	opts []string
+}
+
+// NewVolumeMountOptions returns a new VolumeMountOptions with options from argument.
+func NewVolumeMountOptions(opts ...string) *VolumeMountOptions {
+	return &VolumeMountOptions{
+		opts: opts,
+	}
+}
+
+// NewVolumeMountOptionsFromString returns a new VolumeMountOptions with options from argument.
+func NewVolumeMountOptionsFromString(s string) *VolumeMountOptions {
+	opts := []string{}
+	if s != "" { // s == "" needs to be dealt with specially because it ends up with an empty option string.
+		opts = strings.Split(s, mntOptSep)
+	}
+	return &VolumeMountOptions{
+		opts: opts,
+	}
+}
+
+// String serializes a list of options joined by comma.
+func (mo *VolumeMountOptions) String() string {
+	return strings.Join(mo.opts, mntOptSep)
+}
+
+// AddOption adds a new option to the option list.
+func (mo *VolumeMountOptions) AddOption(key, val string) {
+	opt := key
+	if val != "" {
+		opt = opt + "=" + val
+	}
+	mo.opts = append(mo.opts, opt)
+}

--- a/agent/taskresource/volume/mountoptions_test.go
+++ b/agent/taskresource/volume/mountoptions_test.go
@@ -1,0 +1,42 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package volume
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewVolumeMountOptions(t *testing.T) {
+	assert.Equal(t, []string{"a", "b=c"}, NewVolumeMountOptions("a", "b=c").opts)
+}
+
+func TestNewVolumeMountOptionsFromString(t *testing.T) {
+	assert.Equal(t, []string{"a", "b=c"}, NewVolumeMountOptionsFromString("a,b=c").opts)
+	assert.Equal(t, []string{}, NewVolumeMountOptionsFromString("").opts)
+}
+
+func TestString(t *testing.T) {
+	assert.Equal(t, "a", NewVolumeMountOptions("a").String())
+	assert.Equal(t, "a,b=c", NewVolumeMountOptions("a", "b=c").String())
+}
+
+func TestAddOption(t *testing.T) {
+	mntOpts := NewVolumeMountOptions()
+	mntOpts.AddOption("a", "")
+	assert.Equal(t, []string{"a"}, mntOpts.opts)
+	mntOpts.AddOption("b", "c")
+	assert.Equal(t, []string{"a", "b=c"}, mntOpts.opts)
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->
Note: this PR is on top of https://github.com/aws/amazon-ecs-agent/pull/2367. First two commits belong to that PR.

### Summary
<!-- What does this pull request do? -->
Integrate with ECS Volume Plugin for EFS volume. This adds support to:
(1) Specify transit encryption for an efs volume;
(2) Specify transit encryption port for an efs volume used by the stunnel created by efs mount helper when transit encryption enabled;
(3) Specify IAM authentication so access of the efs volume is controlled by task role;
(4) Specify access point for an efs volume.

### Implementation details
<!-- How are the changes implemented? -->
* `api/acs`: Update acs model for new fields in efs volume.

* `agent/taskresource`: Code changes for the volume task resource to use information from the task to invoke the ecs volume plugin to create the EFS volume, with transit encryption, transit encryption port, iam, network namespace supported.
  - Transit encryption, transit encryption port and iam are supported via passing options to mount helper constructed from task payload. Options are constructed when the volume task resource is initialized during PostUnmarshalTask.
  - To support mounting EFS in task network namespace for task in awsvpc network mode, the task network namespace handle is passed as another option to the mount helper. The pause container pid is saved in the volume task resource when pause container is transitioning to RESOURCE_PROVISION, and the pid is persisted to state file.
  - Refactor EFS related logic into a separate file for readability.


* `api/task`, `api/container`: Initialize the updated volume task resource with efs volume information from task payload. Extract and refactor some of the common logic in task_test.go to a separate file task_test_utils.go for readability.

* `agent/engine`: update to populate pause container pid to volume resource.

* `agent/app`, `agent/config`: Add volume plugin capabilties based on the value specifies in ECS_VOLUME_PLUGIN_CAPABILITIES env.

* `agent/statemanager`: update state file with new efs changes

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Unit tests added.

Manually ran task and verified the following:
* IAM auth: deny write access in task role -> not able to write to the efs volume from container; not denying ->  able to write;
* Transit encryption: when transit encryption is enabled in task def, efs mount helper starts stunnel to encrypt traffic. when port is specified, stunnel uses the specified port;
* Network namespace: when launching an efs task in awsvpc network mode, mount happens in task's network namespace. When limiting the targeting EFS filesystem to only allow access from the security group of the task, mount is still successful and functional

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
TBD

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
