### PR TITLE
container associations handler and task server setup

### DIFF
--- a/agent/handlers/task_server_setup.go
+++ b/agent/handlers/task_server_setup.go
@@ -146,6 +146,9 @@ func v4HandlersSetup(muxRouter *mux.Router,
 	muxRouter.HandleFunc(v4.TaskWithTagsMetadataPath, v4.TaskMetadataHandler(state, ecsClient, cluster, availabilityZone, containerInstanceArn, true))
 	muxRouter.HandleFunc(v4.ContainerStatsPath, v4.ContainerStatsHandler(state, statsEngine))
 	muxRouter.HandleFunc(v4.TaskStatsPath, v4.TaskStatsHandler(state, statsEngine))
+	muxRouter.HandleFunc(v4.ContainerAssociationsPath, v4.ContainerAssociationsHandler(state))
+	muxRouter.HandleFunc(v4.ContainerAssociationPathWithSlash, v4.ContainerAssociationHandler(state))
+	muxRouter.HandleFunc(v4.ContainerAssociationPath, v4.ContainerAssociationHandler(state))
 }
 
 // ServeTaskHTTPEndpoint serves task/container metadata, task/container stats, and IAM Role Credentials

--- a/agent/handlers/v3/helper.go
+++ b/agent/handlers/v3/helper.go
@@ -51,7 +51,7 @@ func GetContainerIDByRequest(r *http.Request, state dockerstate.TaskEngineState)
 	return dockerID, nil
 }
 
-func getAssociationTypeByRequest(r *http.Request) (string, error) {
+func GetAssociationTypeByRequest(r *http.Request) (string, error) {
 	associationType, ok := utils.GetMuxValueFromRequest(r, associationTypeMuxName)
 	if !ok {
 		return "", errors.New("unable to get association type from request")
@@ -60,7 +60,7 @@ func getAssociationTypeByRequest(r *http.Request) (string, error) {
 	return associationType, nil
 }
 
-func getAssociationNameByRequest(r *http.Request) (string, error) {
+func GetAssociationNameByRequest(r *http.Request) (string, error) {
 	associationType, ok := utils.GetMuxValueFromRequest(r, associationNameMuxName)
 	if !ok {
 		return "", errors.New("unable to get association name from request")

--- a/agent/handlers/v3/response.go
+++ b/agent/handlers/v3/response.go
@@ -23,7 +23,7 @@ type AssociationsResponse struct {
 	Associations []string `json:"Associations"`
 }
 
-func newAssociationsResponse(containerID, taskARN, associationType string, state dockerstate.TaskEngineState) (*AssociationsResponse, error) {
+func NewAssociationsResponse(containerID, taskARN, associationType string, state dockerstate.TaskEngineState) (*AssociationsResponse, error) {
 	dockerContainer, ok := state.ContainerByID(containerID)
 	if !ok {
 		return nil, errors.Errorf("unable to get container name from docker id: %s", containerID)
@@ -47,7 +47,7 @@ func newAssociationsResponse(containerID, taskARN, associationType string, state
 // don't do any decoding base on the encoding, because the only encoding that cp currently sends us is 'identity';
 // we don't explicitly model the value field as a struct because we don't want to let agent's implementation depends
 // on the payload format of the association (i.e. eia device for now)
-func newAssociationResponse(taskARN, associationType, associationName string, state dockerstate.TaskEngineState) (string, error) {
+func NewAssociationResponse(taskARN, associationType, associationName string, state dockerstate.TaskEngineState) (string, error) {
 	task, ok := state.TaskByArn(taskARN)
 	if !ok {
 		return "", errors.Errorf("unable to get task from task arn: %s", taskARN)

--- a/agent/handlers/v3/response_test.go
+++ b/agent/handlers/v3/response_test.go
@@ -79,7 +79,7 @@ func TestContainerAssociationsResponse(t *testing.T) {
 		state.EXPECT().TaskByArn(taskARN).Return(task, true),
 	)
 
-	associationsResponse, err := newAssociationsResponse(dockerID, taskARN, associationType, state)
+	associationsResponse, err := NewAssociationsResponse(dockerID, taskARN, associationType, state)
 	assert.NoError(t, err)
 
 	associationsResponseJSON, err := json.Marshal(associationsResponse)
@@ -97,7 +97,7 @@ func TestContainerAssociationResponse(t *testing.T) {
 
 	state.EXPECT().TaskByArn(taskARN).Return(task, true)
 
-	associationResponse, err := newAssociationResponse(taskARN, associationType, associationName, state)
+	associationResponse, err := NewAssociationResponse(taskARN, associationType, associationName, state)
 	assert.NoError(t, err)
 
 	// the response is expected to be the same as the association value

--- a/agent/handlers/v4/container_association_handler.go
+++ b/agent/handlers/v4/container_association_handler.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -11,12 +11,14 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package v3
+package v4
 
 import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+
+	v3 "github.com/aws/amazon-ecs-agent/agent/handlers/v3"
 
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/handlers/utils"
@@ -31,47 +33,47 @@ const (
 )
 
 var (
-	// Container associations endpoint: /v3/<v3 endpoint id>/<association type>
-	ContainerAssociationsPath = fmt.Sprintf("/v3/%s/associations/%s",
-		utils.ConstructMuxVar(V3EndpointIDMuxName, utils.AnythingButSlashRegEx),
+	// Container associations endpoint: /v4/<v3 endpoint id>/<association type>
+	ContainerAssociationsPath = fmt.Sprintf("/v4/%s/associations/%s",
+		utils.ConstructMuxVar(v3.V3EndpointIDMuxName, utils.AnythingButSlashRegEx),
 		utils.ConstructMuxVar(associationTypeMuxName, utils.AnythingButSlashRegEx))
-	// Container association endpoint: /v3/<v3 endpoint id>/<association type>/<association name>
-	ContainerAssociationPath = fmt.Sprintf("/v3/%s/associations/%s/%s",
-		utils.ConstructMuxVar(V3EndpointIDMuxName, utils.AnythingButSlashRegEx),
+	// Container association endpoint: /v4/<v3 endpoint id>/<association type>/<association name>
+	ContainerAssociationPath = fmt.Sprintf("/v4/%s/associations/%s/%s",
+		utils.ConstructMuxVar(v3.V3EndpointIDMuxName, utils.AnythingButSlashRegEx),
 		utils.ConstructMuxVar(associationTypeMuxName, utils.AnythingButSlashRegEx),
 		utils.ConstructMuxVar(associationNameMuxName, utils.AnythingButEmptyRegEx))
-	// Treat "/v3/<v3 endpoint id>/<association type>/" as a container association endpoint with empty association name (therefore invalid), to be consistent with similar situation in credentials endpoint and v3 metadata endpoint
+	// Treat "/v4/<v3 endpoint id>/<association type>/" as a container association endpoint with empty association name (therefore invalid), to be consistent with similar situation in credentials endpoint and v3 metadata endpoint
 	ContainerAssociationPathWithSlash = ContainerAssociationsPath + "/"
 )
 
 // ContainerAssociationHandler returns the handler method for handling container associations requests.
 func ContainerAssociationsHandler(state dockerstate.TaskEngineState) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		containerID, err := GetContainerIDByRequest(r, state)
+		containerID, err := v3.GetContainerIDByRequest(r, state)
 		if err != nil {
 			responseJSON, _ := json.Marshal(
-				fmt.Sprintf("V3 container associations handler: unable to get container id from request: %s", err.Error()))
+				fmt.Sprintf("V4 container associations handler: unable to get container id from request: %s", err.Error()))
 			utils.WriteJSONToResponse(w, http.StatusBadRequest, responseJSON, utils.RequestTypeContainerAssociations)
 			return
 		}
 
-		taskARN, err := GetTaskARNByRequest(r, state)
+		taskARN, err := v3.GetTaskARNByRequest(r, state)
 		if err != nil {
 			responseJSON, _ := json.Marshal(
-				fmt.Sprintf("V3 container associations handler: unable to get task arn from request: %s", err.Error()))
+				fmt.Sprintf("V4 container associations handler: unable to get task arn from request: %s", err.Error()))
 			utils.WriteJSONToResponse(w, http.StatusBadRequest, responseJSON, utils.RequestTypeContainerAssociations)
 			return
 		}
 
-		associationType, err := GetAssociationTypeByRequest(r)
+		associationType, err := v3.GetAssociationTypeByRequest(r)
 		if err != nil {
 			responseJSON, _ := json.Marshal(
-				fmt.Sprintf("V3 container associations handler: %s", err.Error()))
+				fmt.Sprintf("V4 container associations handler: %s", err.Error()))
 			utils.WriteJSONToResponse(w, http.StatusBadRequest, responseJSON, utils.RequestTypeContainerAssociations)
 			return
 		}
 
-		seelog.Infof("V3 container associations handler: writing response for container '%s' for association type %s", containerID, associationType)
+		seelog.Infof("V4 container associations handler: writing response for container '%s' for association type %s", containerID, associationType)
 
 		writeContainerAssociationsResponse(w, containerID, taskARN, associationType, state)
 	}
@@ -80,38 +82,38 @@ func ContainerAssociationsHandler(state dockerstate.TaskEngineState) func(http.R
 // ContainerAssociationHandler returns the handler method for handling container association requests.
 func ContainerAssociationHandler(state dockerstate.TaskEngineState) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		taskARN, err := GetTaskARNByRequest(r, state)
+		taskARN, err := v3.GetTaskARNByRequest(r, state)
 		if err != nil {
 			responseJSON, _ := json.Marshal(
-				fmt.Sprintf("V3 container associations handler: unable to get task arn from request: %s", err.Error()))
+				fmt.Sprintf("V4 container associations handler: unable to get task arn from request: %s", err.Error()))
 			utils.WriteJSONToResponse(w, http.StatusBadRequest, responseJSON, utils.RequestTypeContainerAssociation)
 			return
 		}
 
-		associationType, err := GetAssociationTypeByRequest(r)
+		associationType, err := v3.GetAssociationTypeByRequest(r)
 		if err != nil {
 			responseJSON, _ := json.Marshal(
-				fmt.Sprintf("V3 container associations handler: %s", err.Error()))
+				fmt.Sprintf("V4 container associations handler: %s", err.Error()))
 			utils.WriteJSONToResponse(w, http.StatusBadRequest, responseJSON, utils.RequestTypeContainerAssociation)
 			return
 		}
 
-		associationName, err := GetAssociationNameByRequest(r)
+		associationName, err := v3.GetAssociationNameByRequest(r)
 		if err != nil {
 			responseJSON, _ := json.Marshal(
-				fmt.Sprintf("V3 container associations handler: %s", err.Error()))
+				fmt.Sprintf("V4 container associations handler: %s", err.Error()))
 			utils.WriteJSONToResponse(w, http.StatusBadRequest, responseJSON, utils.RequestTypeContainerAssociation)
 			return
 		}
 
-		seelog.Infof("V3 container association handler: writing response for association '%s' of type %s", associationName, associationType)
+		seelog.Infof("V4 container association handler: writing response for association '%s' of type %s", associationName, associationType)
 
 		writeContainerAssociationResponse(w, taskARN, associationType, associationName, state)
 	}
 }
 
 func writeContainerAssociationsResponse(w http.ResponseWriter, containerID, taskARN, associationType string, state dockerstate.TaskEngineState) {
-	associationsResponse, err := NewAssociationsResponse(containerID, taskARN, associationType, state)
+	associationsResponse, err := v3.NewAssociationsResponse(containerID, taskARN, associationType, state)
 	if err != nil {
 		errResponseJSON, _ := json.Marshal(fmt.Sprintf("Unable to write container associations response: %s", err.Error()))
 		utils.WriteJSONToResponse(w, http.StatusBadRequest, errResponseJSON, utils.RequestTypeContainerAssociations)
@@ -123,7 +125,7 @@ func writeContainerAssociationsResponse(w http.ResponseWriter, containerID, task
 }
 
 func writeContainerAssociationResponse(w http.ResponseWriter, taskARN, associationType, associationName string, state dockerstate.TaskEngineState) {
-	associationResponse, err := NewAssociationResponse(taskARN, associationType, associationName, state)
+	associationResponse, err := v3.NewAssociationResponse(taskARN, associationType, associationName, state)
 	if err != nil {
 		errResponseJSON, _ := json.Marshal(fmt.Sprintf("Unable to write container association response: %s", err.Error()))
 		utils.WriteJSONToResponse(w, http.StatusBadRequest, errResponseJSON, utils.RequestTypeContainerAssociation)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

- This add the outline for the container associations handlers in v4 which align with v3 endpoint.
- Create v4 endpoint for the container with associations and set up task server. 

### Implementation details
<!-- How are the changes implemented? -->

-  In the association handler file we specify the container association(s) path that users used to query container association(s) for v4.
-  For the container associations info, these only apply to the awsvpc task with elastic-inference set  up.

- Customers curl the paths like:
v4/endpoint-id/associations/elastic-inference
v4/endpoint-id/associations/elastic-inference/(device-id) 

- Example response:

> curl v4/endpoint-id/associations/elastic-inference

```{"Associations":["device_1"]}```

> curl v4/endpoint-id/associations/elastic-inference/(device-id) 
```
{
	"version_2018_04_12": {
		"elasticInferenceAcceleratorId": "eia-8aa24aa24f05423c8bf647de750c24b3",
		"elasticInferenceAcceleratorType": "eia1.large",
		"deviceId": "device_1"
	}
}

```
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes:  yes 

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
