### PR TITLE
add envfile as task resource and retrieve from s3

### DIFF
--- a/agent/taskresource/envFiles/envfile.go
+++ b/agent/taskresource/envFiles/envfile.go
@@ -1,0 +1,429 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package envFiles
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	"github.com/aws/amazon-ecs-agent/agent/credentials"
+	"github.com/aws/amazon-ecs-agent/agent/s3"
+	"github.com/aws/amazon-ecs-agent/agent/s3/factory"
+	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
+	"github.com/aws/amazon-ecs-agent/agent/utils/oswrapper"
+	"github.com/cihub/seelog"
+	"github.com/pkg/errors"
+
+	"github.com/aws/amazon-ecs-agent/agent/api/task/status"
+	"github.com/aws/amazon-ecs-agent/agent/taskresource"
+	"github.com/aws/amazon-ecs-agent/agent/utils/ioutilwrapper"
+)
+
+const (
+	ResourceName      = "envfile"
+	envFileDirPath    = "envfiles"
+	envTempFilePrefix = "tmp_env"
+
+	s3DownloadTimeout = 30 * time.Second
+)
+
+// EnvironmentFileResource represents envfile as a task resource
+// these environment files are retrieved from s3
+type EnvironmentFileResource struct {
+	cluster     string
+	taskARN     string
+	region      string
+	resourceDir string // path to store env var files
+
+	// env file related attributes
+	environmentFilesSource []apicontainer.EnvironmentFile // list of env file objects
+
+	executionCredentialsID string
+	credentialsManager     credentials.Manager
+	s3ClientCreator        factory.S3ClientCreator
+	os                     oswrapper.OS
+	ioutil                 ioutilwrapper.IOUtil
+
+	// Fields for the common functionality of task resource. Access to these fields are protected by lock.
+	createdAtUnsafe      time.Time
+	desiredStatusUnsafe  resourcestatus.ResourceStatus
+	knownStatusUnsafe    resourcestatus.ResourceStatus
+	appliedStatusUnsafe  resourcestatus.ResourceStatus
+	statusToTransitions  map[resourcestatus.ResourceStatus]func() error
+	terminalReasonUnsafe string
+	terminalReasonOnce   sync.Once
+	lock                 sync.RWMutex
+}
+
+// NewEnvironmentFileResource creates a new EnvironmentFileResource object
+func NewEnvironmentFileResource(cluster, taskARN, region, dataDir string, credentialsManager credentials.Manager,
+	executionCredentialsID string) (*EnvironmentFileResource, error) {
+	envfileResource := &EnvironmentFileResource{
+		cluster:                cluster,
+		taskARN:                taskARN,
+		region:                 region,
+		os:                     oswrapper.NewOS(),
+		ioutil:                 ioutilwrapper.NewIOUtil(),
+		s3ClientCreator:        factory.NewS3ClientCreator(),
+		executionCredentialsID: executionCredentialsID,
+		credentialsManager:     credentialsManager,
+	}
+
+	taskARNFields := strings.Split(taskARN, "/")
+	taskID := taskARNFields[len(taskARNFields)-1]
+	// we save envfiles to path: /var/lib/ecs/data/envfiles/cluster_name/task_id/${s3filename.env}
+	envfileResource.resourceDir = filepath.Join(dataDir, envFileDirPath, cluster, taskID)
+
+	envfileResource.initStatusToTransition()
+	return envfileResource, nil
+}
+
+// Initialize initializes the EnvironmentFileResource
+func (envfile *EnvironmentFileResource) Initialize(resourceFields *taskresource.ResourceFields,
+	taskKnownStatus status.TaskStatus,
+	taskDesiredStatus status.TaskStatus) {
+	envfile.lock.Lock()
+	defer envfile.lock.Unlock()
+
+	envfile.initStatusToTransition()
+	envfile.credentialsManager = resourceFields.CredentialsManager
+	envfile.s3ClientCreator = factory.NewS3ClientCreator()
+	envfile.os = oswrapper.NewOS()
+	envfile.ioutil = ioutilwrapper.NewIOUtil()
+
+	// if task isn't in 'created' status and desired status is 'running',
+	// reset the resource status to 'NONE' so we always retrieve the data
+	// this is in case agent crashes
+	if taskKnownStatus < status.TaskCreated && taskDesiredStatus <= status.TaskRunning {
+		envfile.SetKnownStatus(resourcestatus.ResourceStatusNone)
+	}
+}
+
+func (envfile *EnvironmentFileResource) initStatusToTransition() {
+	resourceStatusToTransitionFunc := map[resourcestatus.ResourceStatus]func() error{
+		resourcestatus.ResourceStatus(EnvFileCreated): envfile.Create,
+	}
+	envfile.statusToTransitions = resourceStatusToTransitionFunc
+}
+
+// SetDesiredStatus safely sets the desired status of the resource
+func (envfile *EnvironmentFileResource) SetDesiredStatus(status resourcestatus.ResourceStatus) {
+	envfile.lock.Lock()
+	defer envfile.lock.Unlock()
+
+	envfile.desiredStatusUnsafe = status
+}
+
+// GetDesiredStatus safely returns the desired status of the resource
+func (envfile *EnvironmentFileResource) GetDesiredStatus() resourcestatus.ResourceStatus {
+	envfile.lock.RLock()
+	defer envfile.lock.RUnlock()
+
+	return envfile.desiredStatusUnsafe
+}
+
+func (envfile *EnvironmentFileResource) updateAppliedStatusUnsafe(knownStatus resourcestatus.ResourceStatus) {
+	if envfile.appliedStatusUnsafe == resourcestatus.ResourceStatus(EnvFileStatusNone) {
+		return
+	}
+
+	// only apply if resource transition has already finished
+	if envfile.appliedStatusUnsafe <= knownStatus {
+		envfile.appliedStatusUnsafe = resourcestatus.ResourceStatus(EnvFileStatusNone)
+	}
+}
+
+// SetKnownStatus safely sets the currently known status of the resource
+func (envfile *EnvironmentFileResource) SetKnownStatus(status resourcestatus.ResourceStatus) {
+	envfile.lock.Lock()
+	defer envfile.lock.Unlock()
+
+	envfile.knownStatusUnsafe = status
+	envfile.updateAppliedStatusUnsafe(status)
+}
+
+// GetKnownStatus safely returns the currently known status of the resource
+func (envfile *EnvironmentFileResource) GetKnownStatus() resourcestatus.ResourceStatus {
+	envfile.lock.RLock()
+	defer envfile.lock.RUnlock()
+
+	return envfile.knownStatusUnsafe
+}
+
+// SetCreatedAt safely sets the timestamp for the resource's creation time
+func (envfile *EnvironmentFileResource) SetCreatedAt(createdAt time.Time) {
+	if createdAt.IsZero() {
+		return
+	}
+
+	envfile.lock.Lock()
+	defer envfile.lock.Unlock()
+
+	envfile.createdAtUnsafe = createdAt
+}
+
+// GetCreatedAt safely returns the timestamp for the resource's creation time
+func (envfile *EnvironmentFileResource) GetCreatedAt() time.Time {
+	envfile.lock.RLock()
+	defer envfile.lock.RUnlock()
+
+	return envfile.createdAtUnsafe
+}
+
+// GetName returns the name fo the resource
+func (envfile *EnvironmentFileResource) GetName() string {
+	return ResourceName
+}
+
+// DesiredTerminal returns true if the resource's desired status is REMOVED
+func (envfile *EnvironmentFileResource) DesiredTerminal() bool {
+	envfile.lock.RLock()
+	defer envfile.lock.RUnlock()
+
+	return envfile.desiredStatusUnsafe == resourcestatus.ResourceStatus(EnvironmentFileStatus(EnvFileRemoved))
+}
+
+// KnownCreated returns true if the resource's known status is CREATED
+func (envfile *EnvironmentFileResource) KnownCreated() bool {
+	envfile.lock.RLock()
+	defer envfile.lock.RUnlock()
+
+	return envfile.knownStatusUnsafe == resourcestatus.ResourceStatus(EnvFileCreated)
+}
+
+// TerminalStatus returns the last transition state of the resource
+func (envfile *EnvironmentFileResource) TerminalStatus() resourcestatus.ResourceStatus {
+	return resourcestatus.ResourceStatus(EnvFileRemoved)
+}
+
+// NextKnownState returns the state that the resource should
+// progress to based on its `KnownState`
+func (envfile *EnvironmentFileResource) NextKnownState() resourcestatus.ResourceStatus {
+	return envfile.GetKnownStatus() + 1
+}
+
+// ApplyTransition calls the function required to move to the specified status
+func (envfile *EnvironmentFileResource) ApplyTransition(nextState resourcestatus.ResourceStatus) error {
+	transitionFunc, ok := envfile.statusToTransitions[nextState]
+	if !ok {
+		return errors.Errorf("resource [%s]: transition to %s impossible", envfile.GetName(),
+			envfile.StatusString(nextState))
+	}
+	return transitionFunc()
+}
+
+// SteadyState returns the transition state of the resource defined as "ready"
+func (envfile *EnvironmentFileResource) SteadyState() resourcestatus.ResourceStatus {
+	return resourcestatus.ResourceStatus(EnvFileCreated)
+}
+
+// SetAppliedStatus sets the applied status of the resource and returns whether
+// the resource is already in a transition
+func (envfile *EnvironmentFileResource) SetAppliedStatus(status resourcestatus.ResourceStatus) bool {
+	envfile.lock.Lock()
+	defer envfile.lock.Unlock()
+
+	if envfile.appliedStatusUnsafe != resourcestatus.ResourceStatus(EnvFileStatusNone) {
+		// set operation failed, return false
+		return false
+	}
+
+	envfile.appliedStatusUnsafe = status
+	return true
+}
+
+// StatusString returns the string representation of the resource status
+func (envfile *EnvironmentFileResource) StatusString(status resourcestatus.ResourceStatus) string {
+	return EnvironmentFileStatus(status).String()
+}
+
+// GetTerminalReason returns an error string to propagate up through to to
+// state change messages
+func (envfile *EnvironmentFileResource) GetTerminalReason() string {
+	envfile.lock.RLock()
+	defer envfile.lock.RUnlock()
+
+	return envfile.terminalReasonUnsafe
+}
+
+func (envfile *EnvironmentFileResource) setTerminalReason(reason string) {
+	envfile.lock.Lock()
+	defer envfile.lock.Unlock()
+
+	envfile.terminalReasonOnce.Do(func() {
+		seelog.Infof("envfile resource: setting terminal reason for task: [%s]", envfile.taskARN)
+		envfile.terminalReasonUnsafe = reason
+	})
+}
+
+// Create performs resource creation. This retrieves env file contents in parallel
+// from s3 and writes them to disk
+func (envfile *EnvironmentFileResource) Create() error {
+	seelog.Debugf("Creating envfile resource.")
+	// make sure it has the task execution role
+	executionCredentials, ok := envfile.credentialsManager.GetTaskCredentials(envfile.executionCredentialsID)
+	if !ok {
+		err := errors.New("environment file resource: unable to find execution role credentials")
+		envfile.setTerminalReason(err.Error())
+		return err
+	}
+
+	iamCredentials := executionCredentials.GetIAMRoleCredentials()
+	for _, envfileSource := range envfile.environmentFilesSource {
+		// if we support types besides S3 ARN, we will need to add filtering before the below method is called
+
+		err := envfile.downloadEnvfileFromS3(envfileSource.Value, iamCredentials)
+		if err != nil {
+			err = errors.Wrapf(err, "unable to download envfile with ARN %v from s3", envfileSource.Value)
+			envfile.setTerminalReason(err.Error())
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (envfile *EnvironmentFileResource) downloadEnvfileFromS3(envFilePath string, iamCredentials credentials.IAMRoleCredentials) error {
+	bucket, key, err := s3.ParseS3ARN(envFilePath)
+	if err != nil {
+		return errors.Wrapf(err, "unable to parse bucket and key from s3 ARN specified in environmentFile %s", envFilePath)
+	}
+
+	s3Client, err := envfile.s3ClientCreator.NewS3ClientForBucket(bucket, envfile.region, iamCredentials)
+	if err != nil {
+		return errors.Wrapf(err, "unable to initialize s3 client for bucket %s", bucket)
+	}
+
+	seelog.Debugf("Downlading envfile with bucket name %v and key name %v", bucket, key)
+	// we save envfiles to path: /var/lib/ecs/data/envfiles/cluster_name/task_id/${s3filename.env}
+	downloadPath := filepath.Join(envfile.resourceDir, key)
+	err = envfile.writeEnvFile(func(file oswrapper.File) error {
+		return s3.DownloadFile(bucket, key, s3DownloadTimeout, file, s3Client)
+	}, downloadPath)
+
+	if err != nil {
+		return errors.Wrapf(err, "unable to download env file with key %s from bucket %s", key, bucket)
+	}
+
+	seelog.Debugf("Downloaded envfile from s3 and saved to %s", downloadPath)
+	return nil
+}
+
+func (envfile *EnvironmentFileResource) writeEnvFile(writeFunc func(file oswrapper.File) error, fullPathName string) error {
+	// File moves (renaming) are atomic while file writes are not
+	// so we write to a temp file before renaming to actual file
+	// multiple programs calling TempFile will not reference the same file
+	// so this should be ok to be called by multiple go routines
+	tmpFile, err := envfile.ioutil.TempFile(envfile.resourceDir, envTempFilePrefix)
+	if err != nil {
+		seelog.Errorf("Something went wrong trying to create a temp file with prefix %s", envTempFilePrefix)
+		return err
+	}
+	defer tmpFile.Close()
+
+	err = writeFunc(tmpFile)
+	if err != nil {
+		seelog.Errorf("Something went wrong trying to write to tmpFile %s", tmpFile.Name())
+		return err
+	}
+
+	// persist file to disk
+	err = tmpFile.Sync()
+	if err != nil {
+		seelog.Errorf("Something went wrong trying to persist envfile to disk")
+		return err
+	}
+
+	err = envfile.os.Rename(tmpFile.Name(), fullPathName)
+	if err != nil {
+		seelog.Errorf("Something went wrong when trying to rename envfile from %s to %s", tmpFile.Name(), fullPathName)
+		return err
+	}
+
+	return nil
+}
+
+// Cleanup removes env files downloaded for the task
+func (envfile *EnvironmentFileResource) Cleanup() error {
+	// TODO
+	return nil
+}
+
+type environmentFileResourceJSON struct {
+	TaskARN                string                         `json:"taskARN"`
+	CreatedAt              *time.Time                     `json:"createdAt,omitempty"`
+	DesiredStatus          *EnvironmentFileStatus         `json:"desiredStatus"`
+	KnownStatus            *EnvironmentFileStatus         `json:"knownStatus"`
+	EnvironmentFilesSource []apicontainer.EnvironmentFile `json:"environmentFilesSource"`
+	ExecutionCredentialsID string                         `json:"executionCredentialsID"`
+}
+
+// MarshalJSON serializes the EnvironmentFileResource struct to JSON
+func (envfile *EnvironmentFileResource) MarshalJSON() ([]byte, error) {
+	if envfile == nil {
+		return nil, errors.New("envfile resource is nil")
+	}
+	createdAt := envfile.GetCreatedAt()
+	return json.Marshal(environmentFileResourceJSON{
+		TaskARN:   envfile.taskARN,
+		CreatedAt: &createdAt,
+		DesiredStatus: func() *EnvironmentFileStatus {
+			desiredState := envfile.GetDesiredStatus()
+			envfileStatus := EnvironmentFileStatus(desiredState)
+			return &envfileStatus
+		}(),
+		KnownStatus: func() *EnvironmentFileStatus {
+			knownState := envfile.GetKnownStatus()
+			envfileStatus := EnvironmentFileStatus(knownState)
+			return &envfileStatus
+		}(),
+		EnvironmentFilesSource: envfile.environmentFilesSource,
+		ExecutionCredentialsID: envfile.executionCredentialsID,
+	})
+
+}
+
+// UnmarshalJSON deserializes the raw JSON to an EnvironmentFileResource struct
+func (envfile *EnvironmentFileResource) UnmarshalJSON(b []byte) error {
+	envfileJson := environmentFileResourceJSON{}
+
+	if err := json.Unmarshal(b, &envfileJson); err != nil {
+		return err
+	}
+
+	if envfileJson.DesiredStatus != nil {
+		envfile.SetDesiredStatus(resourcestatus.ResourceStatus(*envfileJson.DesiredStatus))
+	}
+
+	if envfileJson.KnownStatus != nil {
+		envfile.SetKnownStatus(resourcestatus.ResourceStatus(*envfileJson.KnownStatus))
+	}
+
+	if envfileJson.CreatedAt != nil && !envfileJson.CreatedAt.IsZero() {
+		envfile.SetCreatedAt(*envfileJson.CreatedAt)
+	}
+
+	if envfileJson.EnvironmentFilesSource != nil {
+		envfile.environmentFilesSource = envfileJson.EnvironmentFilesSource
+	}
+
+	envfile.taskARN = envfileJson.TaskARN
+	envfile.executionCredentialsID = envfileJson.ExecutionCredentialsID
+
+	return nil
+}

--- a/agent/taskresource/envFiles/envfile_test.go
+++ b/agent/taskresource/envFiles/envfile_test.go
@@ -1,0 +1,262 @@
+// +build unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package envFiles
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"testing"
+
+	"github.com/aws/amazon-ecs-agent/agent/api/container"
+	"github.com/aws/amazon-ecs-agent/agent/api/task/status"
+	"github.com/aws/amazon-ecs-agent/agent/credentials"
+	mock_credentials "github.com/aws/amazon-ecs-agent/agent/credentials/mocks"
+	mock_factory "github.com/aws/amazon-ecs-agent/agent/s3/factory/mocks"
+	mock_s3 "github.com/aws/amazon-ecs-agent/agent/s3/mocks"
+	"github.com/aws/amazon-ecs-agent/agent/taskresource"
+	mock_ioutilwrapper "github.com/aws/amazon-ecs-agent/agent/utils/ioutilwrapper/mocks"
+	mock_oswrapper "github.com/aws/amazon-ecs-agent/agent/utils/oswrapper/mocks"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	executionCredentialsID = "exec-creds-id"
+	region                 = "us-west-2"
+	cluster                = "testCluster"
+	taskARN                = "arn:aws:ecs:us-east-2:01234567891011:task/testCluster/abcdef12-34gh-idkl-mno5-pqrst6789"
+	resourceDir            = "resourceDir"
+	iamRoleARN             = "iamRoleARN"
+	accessKeyId            = "accessKey"
+	secretAccessKey        = "secret"
+	s3Bucket               = "s3Bucket"
+	s3Key                  = "s3key"
+	tempFile               = "tmp_file"
+)
+
+func setup(t *testing.T) (*mock_oswrapper.MockOS, *mock_oswrapper.MockFile, *mock_ioutilwrapper.MockIOUtil,
+	*mock_credentials.MockManager, *mock_factory.MockS3ClientCreator, *mock_s3.MockS3Client, func()) {
+	ctrl := gomock.NewController(t)
+
+	mockOS := mock_oswrapper.NewMockOS(ctrl)
+	mockFile := mock_oswrapper.NewMockFile(ctrl)
+	mockIOUtil := mock_ioutilwrapper.NewMockIOUtil(ctrl)
+	mockCredentialsManager := mock_credentials.NewMockManager(ctrl)
+	mockS3ClientCreator := mock_factory.NewMockS3ClientCreator(ctrl)
+	mockS3Client := mock_s3.NewMockS3Client(ctrl)
+
+	return mockOS, mockFile, mockIOUtil, mockCredentialsManager, mockS3ClientCreator, mockS3Client, ctrl.Finish
+}
+
+func newMockEnvfileResource(envfileLocations []container.EnvironmentFile, mockCredentialsManager *mock_credentials.MockManager,
+	mockS3ClientCreator *mock_factory.MockS3ClientCreator,
+	mockOs *mock_oswrapper.MockOS, mockIOUtil *mock_ioutilwrapper.MockIOUtil) *EnvironmentFileResource {
+	return &EnvironmentFileResource{
+		cluster:                cluster,
+		taskARN:                taskARN,
+		region:                 region,
+		resourceDir:            resourceDir,
+		environmentFilesSource: envfileLocations,
+		executionCredentialsID: executionCredentialsID,
+		credentialsManager:     mockCredentialsManager,
+		s3ClientCreator:        mockS3ClientCreator,
+		os:                     mockOs,
+		ioutil:                 mockIOUtil,
+	}
+}
+
+func sampleEnvironmentFile(value, envfileType string) container.EnvironmentFile {
+	return container.EnvironmentFile{
+		Value: value,
+		Type:  envfileType,
+	}
+}
+
+func TestInitializeFileEnvResource(t *testing.T) {
+	_, _, _, mockCredentialsManager, _, _, done := setup(t)
+	defer done()
+	envfiles := []container.EnvironmentFile{
+		sampleEnvironmentFile(fmt.Sprintf("arn:aws:s3:::%s/%s", s3Bucket, s3Key), "s3"),
+	}
+
+	envfileResource := newMockEnvfileResource(envfiles, mockCredentialsManager, nil, nil, nil)
+	envfileResource.Initialize(&taskresource.ResourceFields{
+		ResourceFieldsCommon: &taskresource.ResourceFieldsCommon{
+			CredentialsManager: mockCredentialsManager,
+		},
+	}, status.TaskRunning, status.TaskRunning)
+
+	assert.NotNil(t, envfileResource.statusToTransitions)
+	assert.Equal(t, 1, len(envfileResource.statusToTransitions))
+	assert.NotNil(t, envfileResource.credentialsManager)
+	assert.NotNil(t, envfileResource.s3ClientCreator)
+	assert.NotNil(t, envfileResource.os)
+	assert.NotNil(t, envfileResource.ioutil)
+}
+
+func TestCreateWithEnvVarFile(t *testing.T) {
+	mockOS, mockFile, mockIOUtil, mockCredentialsManager, mockS3ClientCreator, mockS3Client, done := setup(t)
+	defer done()
+	envfiles := []container.EnvironmentFile{
+		sampleEnvironmentFile(fmt.Sprintf("arn:aws:s3:::%s/%s", s3Bucket, s3Key), "s3"),
+	}
+
+	envfileResource := newMockEnvfileResource(envfiles, mockCredentialsManager, mockS3ClientCreator, mockOS, mockIOUtil)
+	creds := credentials.TaskIAMRoleCredentials{
+		ARN: iamRoleARN,
+		IAMRoleCredentials: credentials.IAMRoleCredentials{
+			AccessKeyID:     accessKeyId,
+			SecretAccessKey: secretAccessKey,
+		},
+	}
+
+	gomock.InOrder(
+		mockCredentialsManager.EXPECT().GetTaskCredentials(executionCredentialsID).Return(creds, true),
+		mockS3ClientCreator.EXPECT().NewS3ClientForBucket(s3Bucket, region, creds.IAMRoleCredentials).Return(mockS3Client, nil),
+		// write the env file downloaded from s3
+		mockIOUtil.EXPECT().TempFile(resourceDir, gomock.Any()).Return(mockFile, nil),
+		mockS3Client.EXPECT().DownloadWithContext(gomock.Any(), mockFile, gomock.Any()).Do(
+			func(ctx aws.Context, w io.WriterAt, input *s3.GetObjectInput) {
+				assert.Equal(t, s3Bucket, aws.StringValue(input.Bucket))
+				assert.Equal(t, s3Key, aws.StringValue(input.Key))
+			}).Return(int64(0), nil),
+		mockFile.EXPECT().Sync(),
+		mockFile.EXPECT().Name().Return(tempFile),
+		mockOS.EXPECT().Rename(tempFile, filepath.Join(resourceDir, s3Key)),
+		mockFile.EXPECT().Close(),
+	)
+
+	assert.NoError(t, envfileResource.Create())
+}
+
+func TestCreateWithInvalidS3ARN(t *testing.T) {
+	mockOS, _, mockIOUtil, mockCredentialsManager, mockS3ClientCreator, _, done := setup(t)
+	defer done()
+	envfiles := []container.EnvironmentFile{
+		sampleEnvironmentFile(fmt.Sprintf("arn:aws:s3:::%s", s3Key), "s3"),
+	}
+
+	envfileResource := newMockEnvfileResource(envfiles, mockCredentialsManager, mockS3ClientCreator, mockOS, mockIOUtil)
+	creds := credentials.TaskIAMRoleCredentials{
+		ARN: iamRoleARN,
+		IAMRoleCredentials: credentials.IAMRoleCredentials{
+			AccessKeyID:     accessKeyId,
+			SecretAccessKey: secretAccessKey,
+		},
+	}
+
+	mockCredentialsManager.EXPECT().GetTaskCredentials(executionCredentialsID).Return(creds, true)
+
+	assert.Error(t, envfileResource.Create())
+	assert.NotEmpty(t, envfileResource.terminalReasonUnsafe)
+	assert.Contains(t, envfileResource.GetTerminalReason(), "unable to parse bucket and key from s3 ARN specified in environmentFile")
+}
+
+func TestCreateUnableToRetrieveDataFromS3(t *testing.T) {
+	mockOS, mockFile, mockIOUtil, mockCredentialsManager, mockS3ClientCreator, mockS3Client, done := setup(t)
+	defer done()
+
+	envfiles := []container.EnvironmentFile{
+		sampleEnvironmentFile(fmt.Sprintf("arn:aws:s3:::%s/%s", s3Bucket, s3Key), "s3"),
+	}
+
+	envfileResource := newMockEnvfileResource(envfiles, mockCredentialsManager, mockS3ClientCreator, mockOS, mockIOUtil)
+	creds := credentials.TaskIAMRoleCredentials{
+		ARN: iamRoleARN,
+		IAMRoleCredentials: credentials.IAMRoleCredentials{
+			AccessKeyID:     accessKeyId,
+			SecretAccessKey: secretAccessKey,
+		},
+	}
+
+	gomock.InOrder(
+		mockCredentialsManager.EXPECT().GetTaskCredentials(executionCredentialsID).Return(creds, true),
+		mockS3ClientCreator.EXPECT().NewS3ClientForBucket(s3Bucket, region, creds.IAMRoleCredentials).Return(mockS3Client, nil),
+		mockIOUtil.EXPECT().TempFile(resourceDir, gomock.Any()).Return(mockFile, nil),
+		mockS3Client.EXPECT().DownloadWithContext(gomock.Any(), mockFile, gomock.Any()).Return(int64(0), errors.New("error response")),
+		mockFile.EXPECT().Name().Return(tempFile),
+		mockFile.EXPECT().Close(),
+	)
+
+	assert.Error(t, envfileResource.Create())
+	assert.NotEmpty(t, envfileResource.terminalReasonUnsafe)
+	assert.Contains(t, envfileResource.GetTerminalReason(), "error response")
+}
+
+func TestCreateUnableToCreateTmpFile(t *testing.T) {
+	mockOS, _, mockIOUtil, mockCredentialsManager, mockS3ClientCreator, mockS3Client, done := setup(t)
+	defer done()
+	envfiles := []container.EnvironmentFile{
+		sampleEnvironmentFile(fmt.Sprintf("arn:aws:s3:::%s/%s", s3Bucket, s3Key), "s3"),
+	}
+
+	envfileResource := newMockEnvfileResource(envfiles, mockCredentialsManager, mockS3ClientCreator, mockOS, mockIOUtil)
+	creds := credentials.TaskIAMRoleCredentials{
+		ARN: iamRoleARN,
+		IAMRoleCredentials: credentials.IAMRoleCredentials{
+			AccessKeyID:     accessKeyId,
+			SecretAccessKey: secretAccessKey,
+		},
+	}
+
+	gomock.InOrder(
+		mockCredentialsManager.EXPECT().GetTaskCredentials(executionCredentialsID).Return(creds, true),
+		mockS3ClientCreator.EXPECT().NewS3ClientForBucket(s3Bucket, region, creds.IAMRoleCredentials).Return(mockS3Client, nil),
+		mockIOUtil.EXPECT().TempFile(resourceDir, gomock.Any()).Return(nil, errors.New("error response")),
+	)
+
+	assert.Error(t, envfileResource.Create())
+	assert.NotEmpty(t, envfileResource.terminalReasonUnsafe)
+	assert.Contains(t, envfileResource.GetTerminalReason(), "error response")
+}
+
+func TestCreateRenameFileError(t *testing.T) {
+	mockOS, mockFile, mockIOUtil, mockCredentialsManager, mockS3ClientCreator, mockS3Client, done := setup(t)
+	defer done()
+
+	envfiles := []container.EnvironmentFile{
+		sampleEnvironmentFile(fmt.Sprintf("arn:aws:s3:::%s/%s", s3Bucket, s3Key), "s3"),
+	}
+
+	envfileResource := newMockEnvfileResource(envfiles, mockCredentialsManager, mockS3ClientCreator, mockOS, mockIOUtil)
+	creds := credentials.TaskIAMRoleCredentials{
+		ARN: iamRoleARN,
+		IAMRoleCredentials: credentials.IAMRoleCredentials{
+			AccessKeyID:     accessKeyId,
+			SecretAccessKey: secretAccessKey,
+		},
+	}
+
+	gomock.InOrder(
+		mockCredentialsManager.EXPECT().GetTaskCredentials(executionCredentialsID).Return(creds, true),
+		mockS3ClientCreator.EXPECT().NewS3ClientForBucket(s3Bucket, region, creds.IAMRoleCredentials).Return(mockS3Client, nil),
+		mockIOUtil.EXPECT().TempFile(resourceDir, gomock.Any()).Return(mockFile, nil),
+		mockS3Client.EXPECT().DownloadWithContext(gomock.Any(), mockFile, gomock.Any()).Return(int64(0), nil),
+		mockFile.EXPECT().Sync(),
+		mockFile.EXPECT().Name().Return(tempFile),
+		mockOS.EXPECT().Rename(tempFile, filepath.Join(resourceDir, s3Key)).Return(errors.New("error response")),
+		mockFile.EXPECT().Name().Return(tempFile), // this is for the call made in the logging statement
+		mockFile.EXPECT().Close(),
+	)
+
+	assert.Error(t, envfileResource.Create())
+	assert.NotEmpty(t, envfileResource.terminalReasonUnsafe)
+	assert.Contains(t, envfileResource.GetTerminalReason(), "error response")
+}

--- a/agent/taskresource/envFiles/envfilestatus.go
+++ b/agent/taskresource/envFiles/envfilestatus.go
@@ -1,0 +1,77 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package envFiles
+
+import (
+	"errors"
+	"strings"
+
+	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
+)
+
+type EnvironmentFileStatus resourcestatus.ResourceStatus
+
+const (
+	// EnvFileStatusNone is the zero state of a task resource
+	EnvFileStatusNone EnvironmentFileStatus = iota
+	// EnvFileCreated means the task resource is created
+	EnvFileCreated
+	// EnvFileRemoved means the task resource is cleaned up
+	EnvFileRemoved
+)
+
+var envfileStatusMap = map[string]EnvironmentFileStatus{
+	"NONE":    EnvFileStatusNone,
+	"CREATED": EnvFileCreated,
+	"REMOVED": EnvFileRemoved,
+}
+
+func (envfileStatus EnvironmentFileStatus) String() string {
+	for k, v := range envfileStatusMap {
+		if v == envfileStatus {
+			return k
+		}
+	}
+	return "NONE"
+}
+
+// MarshalJSON overrides the logic for JSON-encoding the ResourceStatus type.
+func (envfileStatus *EnvironmentFileStatus) MarshalJSON() ([]byte, error) {
+	if envfileStatus == nil {
+		return nil, errors.New("envfile resource status is nil")
+	}
+	return []byte(`"` + envfileStatus.String() + `"`), nil
+}
+
+// UnmarshalJSON overrides the logic for parsing the JSON-encoded ResourceStatus data.
+func (envfileStatus *EnvironmentFileStatus) UnmarshalJSON(b []byte) error {
+	if strings.ToLower(string(b)) == "null" {
+		*envfileStatus = EnvFileStatusNone
+		return nil
+	}
+
+	if b[0] != '"' || b[len(b)-1] != '"' {
+		*envfileStatus = EnvFileStatusNone
+		return errors.New("resource status unmarshal: status must be a string or null; Got " + string(b))
+	}
+
+	strStatus := string(b[1 : len(b)-1])
+	stat, ok := envfileStatusMap[strStatus]
+	if !ok {
+		*envfileStatus = EnvFileStatusNone
+		return errors.New("resource status unmarshal: unrecognized status")
+	}
+	*envfileStatus = stat
+	return nil
+}

--- a/agent/taskresource/envFiles/envfilestatus_test.go
+++ b/agent/taskresource/envFiles/envfilestatus_test.go
@@ -1,0 +1,155 @@
+// +build unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package envFiles
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStatusString(t *testing.T) {
+	cases := []struct {
+		Name             string
+		InEnvFileStatus  EnvironmentFileStatus
+		OutEnvFileStatus string
+	}{
+		{
+			Name:             "ToStringEnvFileStatusNone",
+			InEnvFileStatus:  EnvFileStatusNone,
+			OutEnvFileStatus: "NONE",
+		},
+		{
+			Name:             "ToStringEnvFileCreated",
+			InEnvFileStatus:  EnvFileCreated,
+			OutEnvFileStatus: "CREATED",
+		},
+		{
+			Name:             "ToStringEnvFileRemoved",
+			InEnvFileStatus:  EnvFileRemoved,
+			OutEnvFileStatus: "REMOVED",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			assert.Equal(t, c.OutEnvFileStatus, c.InEnvFileStatus.String())
+		})
+	}
+
+}
+
+func TestMarshalNilEnvFileStatus(t *testing.T) {
+	var status *EnvironmentFileStatus
+	bytes, err := status.MarshalJSON()
+
+	assert.Nil(t, bytes)
+	assert.Error(t, err)
+}
+
+func TestMarshalEnvFileStatus(t *testing.T) {
+	cases := []struct {
+		Name             string
+		InEnvFileStatus  EnvironmentFileStatus
+		OutEnvFileStatus string
+	}{
+		{
+			Name:             "MarshallEnvFileStatusNone",
+			InEnvFileStatus:  EnvFileStatusNone,
+			OutEnvFileStatus: "\"NONE\"",
+		},
+		{
+			Name:             "MarshallEnvFileCreated",
+			InEnvFileStatus:  EnvFileCreated,
+			OutEnvFileStatus: "\"CREATED\"",
+		},
+		{
+			Name:             "MarshallEnvFileRemoved",
+			InEnvFileStatus:  EnvFileRemoved,
+			OutEnvFileStatus: "\"REMOVED\"",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			bytes, err := c.InEnvFileStatus.MarshalJSON()
+
+			assert.NoError(t, err)
+			assert.Equal(t, c.OutEnvFileStatus, string(bytes[:]))
+		})
+	}
+}
+
+func TestUnmarshalEnvFileStatus(t *testing.T) {
+	cases := []struct {
+		Name             string
+		InEnvFileStatus  string
+		OutEnvFileStatus EnvironmentFileStatus
+		ShouldError      bool
+	}{
+		{
+			Name:             "UnmarshallEnvFileStatusNone",
+			InEnvFileStatus:  "\"NONE\"",
+			OutEnvFileStatus: EnvFileStatusNone,
+			ShouldError:      false,
+		},
+		{
+			Name:             "UnmarshallEnvFileCreated",
+			InEnvFileStatus:  "\"CREATED\"",
+			OutEnvFileStatus: EnvFileCreated,
+			ShouldError:      false,
+		},
+		{
+			Name:             "UnmarshallEnvFileRemoved",
+			InEnvFileStatus:  "\"REMOVED\"",
+			OutEnvFileStatus: EnvFileRemoved,
+			ShouldError:      false,
+		},
+		{
+			Name:             "UnmarshallEnvFileStatusNull",
+			InEnvFileStatus:  "null",
+			OutEnvFileStatus: EnvFileStatusNone,
+			ShouldError:      false,
+		},
+		{
+			Name:             "UnmarshallEnvFileStatusNonString",
+			InEnvFileStatus:  "123",
+			OutEnvFileStatus: EnvFileStatusNone,
+			ShouldError:      true,
+		},
+		{
+			Name:             "UnmarshallEnvFileStatusUnmappedStatus",
+			InEnvFileStatus:  "\"WEEWOO\"",
+			OutEnvFileStatus: EnvFileStatusNone,
+			ShouldError:      true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			var status EnvironmentFileStatus
+			err := json.Unmarshal([]byte(c.InEnvFileStatus), &status)
+
+			if c.ShouldError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, c.OutEnvFileStatus, status)
+			}
+		})
+	}
+}


### PR DESCRIPTION
and write s3 contents to disk

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Getting this pull request out to get it looked at. Using envfiles as a task resource isn't fully piped through yet. 

### Implementation details
<!-- How are the changes implemented? -->
envfile task resource -> retrieve each specified file from s3 and write contents to disk.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
`make test`

New tests cover the changes: <!-- yes|no --> yes (unit tests)

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Add envfile as task resource

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
