### PR TITLE
add env ECS_CONTAINER_METADATA_URI_V4 in V4

### DIFF
--- a/agent/api/container/container.go
+++ b/agent/api/container/container.go
@@ -58,6 +58,14 @@ const (
 	// MetadataURIFormat defines the URI format for v3 metadata endpoint
 	MetadataURIFormat = "http://169.254.170.2/v3/%s"
 
+	// MetadataURIEnvVarNameV4 defines the name of the environment
+	// variable in containers' config, which can be used by the containers to access the
+	// v4 metadata endpoint
+	MetadataURIEnvVarNameV4 = "ECS_CONTAINER_METADATA_URI_V4"
+
+	// MetadataURIFormat defines the URI format for v4 metadata endpoint
+	MetadataURIFormatV4 = "http://169.254.170.2/v4/%s"
+
 	// SecretProviderSSM is to show secret provider being SSM
 	SecretProviderSSM = "ssm"
 
@@ -855,6 +863,20 @@ func (c *Container) InjectV3MetadataEndpoint() {
 
 	c.Environment[MetadataURIEnvironmentVariableName] =
 		fmt.Sprintf(MetadataURIFormat, c.V3EndpointID)
+}
+
+// InjectV4MetadataEndpoint injects the v4 metadata endpoint as an environment variable for a container
+func (c *Container) InjectV4MetadataEndpoint() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	// don't assume that the environment variable map has been initialized by others
+	if c.Environment == nil {
+		c.Environment = make(map[string]string)
+	}
+
+	c.Environment[MetadataURIEnvVarNameV4] =
+		fmt.Sprintf(MetadataURIFormatV4, c.V3EndpointID)
 }
 
 // ShouldCreateWithSSMSecret returns true if this container needs to get secret

--- a/agent/api/container/container_test.go
+++ b/agent/api/container/container_test.go
@@ -269,6 +269,17 @@ func TestInjectV3MetadataEndpoint(t *testing.T) {
 		fmt.Sprintf(MetadataURIFormat, "myV3EndpointID"))
 }
 
+func TestInjectV4MetadataEndpoint(t *testing.T) {
+	container := Container{
+		V3EndpointID: "EndpointID",
+	}
+	container.InjectV4MetadataEndpoint()
+
+	assert.NotNil(t, container.Environment)
+	assert.Equal(t, container.Environment[MetadataURIEnvVarNameV4],
+		fmt.Sprintf(MetadataURIFormatV4, "EndpointID"))
+}
+
 func TestShouldCreateWithSSMSecret(t *testing.T) {
 	cases := []struct {
 		in  Container

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -792,6 +792,25 @@ func TestInitializeContainersV3MetadataEndpoint(t *testing.T) {
 		fmt.Sprintf(apicontainer.MetadataURIFormat, "new-uuid"))
 }
 
+func TestInitializeContainersV4MetadataEndpoint(t *testing.T) {
+	task := Task{
+		Containers: []*apicontainer.Container{
+			{
+				Name:        "c1",
+				Environment: make(map[string]string),
+			},
+		},
+	}
+	container := task.Containers[0]
+
+	task.initializeContainersV4MetadataEndpoint(utils.NewStaticUUIDProvider("new-uuid"))
+
+	// Test if the v3 endpoint id is set and the endpoint is injected to env
+	assert.Equal(t, container.GetV3EndpointID(), "new-uuid")
+	assert.Equal(t, container.Environment[apicontainer.MetadataURIEnvVarNameV4],
+		fmt.Sprintf(apicontainer.MetadataURIFormatV4, "new-uuid"))
+}
+
 func TestPostUnmarshalTaskWithLocalVolumes(t *testing.T) {
 	// Constants used here are defined in task_unix_test.go and task_windows_test.go
 	taskFromACS := ecsacs.Task{

--- a/agent/api/task/task_windows_test.go
+++ b/agent/api/task/task_windows_test.go
@@ -113,7 +113,7 @@ func TestPostUnmarshalWindowsCanonicalPaths(t *testing.T) {
 	task.PostUnmarshalTask(&cfg, nil, nil, nil, nil)
 
 	for _, container := range task.Containers { // remove v3 endpoint from each container because it's randomly generated
-		removeV3EndpointConfig(container)
+		removeV3andV4EndpointConfig(container)
 	}
 	assert.Equal(t, expectedTask.Containers, task.Containers, "Containers should be equal")
 	assert.Equal(t, expectedTask.Volumes, task.Volumes, "Volumes should be equal")
@@ -121,10 +121,11 @@ func TestPostUnmarshalWindowsCanonicalPaths(t *testing.T) {
 
 // removeV3EndpointConfig removes the v3 endpoint id and the injected env for a container
 // so that checking all other fields can be easier
-func removeV3EndpointConfig(container *apicontainer.Container) {
+func removeV3andV4EndpointConfig(container *apicontainer.Container) {
 	container.SetV3EndpointID("")
 	if container.Environment != nil {
 		delete(container.Environment, apicontainer.MetadataURIEnvironmentVariableName)
+		delete(container.Environment, apicontainer.MetadataURIEnvVarNameV4)
 	}
 	if len(container.Environment) == 0 {
 		container.Environment = nil

--- a/agent/engine/common_test.go
+++ b/agent/engine/common_test.go
@@ -161,6 +161,8 @@ func validateContainerRunWorkflow(t *testing.T,
 		container.SetV3EndpointID(v3EndpointID)
 		metadataEndpointEnvValue := fmt.Sprintf(apicontainer.MetadataURIFormat, v3EndpointID)
 		dockerConfig.Env = append(dockerConfig.Env, "ECS_CONTAINER_METADATA_URI="+metadataEndpointEnvValue)
+		metadataEndpointEnvValueV4 := fmt.Sprintf(apicontainer.MetadataURIFormatV4, v3EndpointID)
+		dockerConfig.Env = append(dockerConfig.Env, "ECS_CONTAINER_METADATA_URI_V4="+metadataEndpointEnvValueV4)
 	}
 	// Container config should get updated with this during CreateContainer
 	dockerConfig.Labels["com.amazonaws.ecs.task-arn"] = task.Arn


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
we decide to add ECS_CONTAINER_METADATA_URI_V4 -> points to 169.254.170.2/v4/endpointID into each container to let customers switch from v3 to v4 to fetch networkInterfaceProperty for awsvpc task.
### Implementation details
<!-- How are the changes implemented? -->
Inject ECS_CONTAINER_METADATA_URI_V4 in each container so that users can switch to the new one, we decide also keep v3 ECS_CONTAINER_METADATA_URI so that customers can use the previous one if they want.
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
