### PR TITLE
Fix for the attchmentIndex

### DIFF
--- a/agent/handlers/task_server_setup_test.go
+++ b/agent/handlers/task_server_setup_test.go
@@ -294,6 +294,7 @@ var (
 		ExecutionStoppedAt: aws.Time(now.UTC()),
 		AvailabilityZone:   availabilityzone,
 	}
+	attachmentIndexVar          = attachmentIndex
 	expectedV4ContainerResponse = v4.ContainerResponse{
 		ContainerResponse: &expectedContainerResponse,
 		Networks: []v4.Network{{
@@ -302,7 +303,7 @@ var (
 				IPv4Addresses: []string{eniIPv4Address},
 			},
 			NetworkInterfaceProperties: v4.NetworkInterfaceProperties{
-				AttachmentIndex:          attachmentIndex,
+				AttachmentIndex:          &attachmentIndexVar,
 				IPV4SubnetCIDRBlock:      iPv4SubnetCIDRBlock,
 				MACAddress:               macAddress,
 				PrivateDNSName:           privateDNSName,
@@ -322,7 +323,7 @@ var (
 				IPv4Addresses: []string{bridgeIPAddr},
 			},
 			NetworkInterfaceProperties: v4.NetworkInterfaceProperties{
-				AttachmentIndex:          attachmentIndex,
+				AttachmentIndex:          nil,
 				IPV4SubnetCIDRBlock:      "",
 				MACAddress:               "",
 				PrivateDNSName:           "",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->


### Summary
<!-- What does this pull request do? -->
fix the attachmentIndex since when it is int type, it can't be change to the omitempty. Thus we change it to the int pointer type.
### Implementation details
<!-- How are the changes implemented? -->
change the attachmentIndex to pointer.

- In awsvpc mode, it points to zero value, 

- in bridge/host mode, it become nil.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes:  yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
