### PR TITLE
retrieve envfile from s3 concurrently

### DIFF
--- a/agent/acs/handler/task_manifest_handler_test.go
+++ b/agent/acs/handler/task_manifest_handler_test.go
@@ -17,6 +17,7 @@ package handler
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/acs/model/ecsacs"
 	"github.com/aws/amazon-ecs-agent/agent/api/task"
@@ -108,6 +109,11 @@ func TestManifestHandlerKillAllTasks(t *testing.T) {
 
 	newTaskManifest.messageBufferTaskManifest <- message
 
+	// mockWSClient.EXPECT().MakeRequest(ackRequested).Times(1) in this test is called by an asynchronous routine.
+	// Sometimes functions execution finishes before a call to this asynchronous routine, this sleep will ensure that
+	// asynchronous routine is called before function ends
+	time.Sleep(2 * time.Second)
+
 	select {
 	case <-newTaskManifest.ctx.Done():
 	}
@@ -198,6 +204,11 @@ func TestManifestHandlerKillFewTasks(t *testing.T) {
 
 	newTaskManifest.messageBufferTaskManifest <- message
 
+	// mockWSClient.EXPECT().MakeRequest(ackRequested).Times(1) in this test is called by an asynchronous routine.
+	// Sometimes functions execution finishes before a call to this asynchronous routine, this sleep will ensure that
+	// asynchronous routine is called before function ends
+	time.Sleep(2 * time.Second)
+
 	select {
 	case <-newTaskManifest.ctx.Done():
 	}
@@ -278,6 +289,11 @@ func TestManifestHandlerKillNoTasks(t *testing.T) {
 	go newTaskManifest.start()
 
 	newTaskManifest.messageBufferTaskManifest <- message
+
+	// mockWSClient.EXPECT().MakeRequest(ackRequested).Times(1) in this test is called by an asynchronous routine.
+	// Sometimes functions execution finishes before a call to this asynchronous routine, this sleep will ensure that
+	// asynchronous routine is called before function ends
+	time.Sleep(2 * time.Second)
 
 	select {
 	case <-newTaskManifest.ctx.Done():
@@ -373,6 +389,11 @@ func TestManifestHandlerDifferentTaskLists(t *testing.T) {
 	go newTaskManifest.start()
 
 	newTaskManifest.messageBufferTaskManifest <- message
+
+	// mockWSClient.EXPECT().MakeRequest(ackRequested).Times(1) in this test is called by an asynchronous routine.
+	// Sometimes functions execution finishes before a call to this asynchronous routine, this sleep will ensure that
+	// asynchronous routine is called before function ends
+	time.Sleep(2 * time.Second)
 
 	select {
 	case <-newTaskManifest.ctx.Done():

--- a/agent/engine/engine_integ_test.go
+++ b/agent/engine/engine_integ_test.go
@@ -507,9 +507,11 @@ func TestLabels(t *testing.T) {
 	assert.EqualValues(t, "", state.Config.Labels["label1"])
 
 	// Kill the existing container now
-	taskUpdate := *testTask
+	// Create instead of copying the testTask, to avoid race condition.
+	// AddTask idempotently handles update, filtering by Task ARN.
+	taskUpdate := createTestTask(testArn)
 	taskUpdate.SetDesiredStatus(apitaskstatus.TaskStopped)
-	go taskEngine.AddTask(&taskUpdate)
+	go taskEngine.AddTask(taskUpdate)
 
 	verifyContainerStoppedStateChange(t, taskEngine)
 	verifyTaskStoppedStateChange(t, taskEngine)
@@ -552,9 +554,11 @@ func TestLogDriverOptions(t *testing.T) {
 	assert.EqualValues(t, containerExpected, state.HostConfig.LogConfig)
 
 	// Kill the existing container now
-	testUpdate := *testTask
-	testUpdate.SetDesiredStatus(apitaskstatus.TaskStopped)
-	go taskEngine.AddTask(&testUpdate)
+	// Create instead of copying the testTask, to avoid race condition.
+	// AddTask idempotently handles update, filtering by Task ARN.
+	taskUpdate := createTestTask(testArn)
+	taskUpdate.SetDesiredStatus(apitaskstatus.TaskStopped)
+	go taskEngine.AddTask(taskUpdate)
 
 	verifyContainerStoppedStateChange(t, taskEngine)
 	verifyTaskStoppedStateChange(t, taskEngine)
@@ -600,9 +604,11 @@ func testNetworkMode(t *testing.T, networkMode string) {
 	assert.Equal(t, networkMode, networks[0], "did not find the expected network mode")
 
 	// Kill the existing container now
-	taskUpdate := *testTask
+	// Create instead of copying the testTask, to avoid race condition.
+	// AddTask idempotently handles update, filtering by Task ARN.
+	taskUpdate := createTestTask(testArn)
 	taskUpdate.SetDesiredStatus(apitaskstatus.TaskStopped)
-	go taskEngine.AddTask(&taskUpdate)
+	go taskEngine.AddTask(taskUpdate)
 
 	verifyContainerStoppedStateChange(t, taskEngine)
 	verifyTaskStoppedStateChange(t, taskEngine)

--- a/agent/taskresource/envFiles/envfile.go
+++ b/agent/taskresource/envFiles/envfile.go
@@ -15,6 +15,7 @@ package envFiles
 
 import (
 	"encoding/json"
+	"fmt"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -271,7 +272,7 @@ func (envfile *EnvironmentFileResource) setTerminalReason(reason string) {
 	})
 }
 
-// Create performs resource creation. This retrieves env file contents in parallel
+// Create performs resource creation. This retrieves env file contents concurrently
 // from s3 and writes them to disk
 func (envfile *EnvironmentFileResource) Create() error {
 	seelog.Debugf("Creating envfile resource.")
@@ -283,30 +284,48 @@ func (envfile *EnvironmentFileResource) Create() error {
 		return err
 	}
 
+	var wg sync.WaitGroup
+	errorEvents := make(chan error, len(envfile.environmentFilesSource))
+
 	iamCredentials := executionCredentials.GetIAMRoleCredentials()
 	for _, envfileSource := range envfile.environmentFilesSource {
+		wg.Add(1)
 		// if we support types besides S3 ARN, we will need to add filtering before the below method is called
+		// call an additional go routine per env file
+		go envfile.downloadEnvfileFromS3(envfileSource.Value, iamCredentials, &wg, errorEvents)
+	}
 
-		err := envfile.downloadEnvfileFromS3(envfileSource.Value, iamCredentials)
-		if err != nil {
-			err = errors.Wrapf(err, "unable to download envfile with ARN %v from s3", envfileSource.Value)
-			envfile.setTerminalReason(err.Error())
-			return err
+	wg.Wait()
+	close(errorEvents)
+
+	if len(errorEvents) > 0 {
+		var terminalReasons []string
+		for err := range errorEvents {
+			terminalReasons = append(terminalReasons, err.Error())
 		}
+
+		errorString := strings.Join(terminalReasons, ";")
+		envfile.setTerminalReason(errorString)
+		return errors.New(errorString)
 	}
 
 	return nil
 }
 
-func (envfile *EnvironmentFileResource) downloadEnvfileFromS3(envFilePath string, iamCredentials credentials.IAMRoleCredentials) error {
+func (envfile *EnvironmentFileResource) downloadEnvfileFromS3(envFilePath string, iamCredentials credentials.IAMRoleCredentials,
+	wg *sync.WaitGroup, errorEvents chan error) {
+	defer wg.Done()
+
 	bucket, key, err := s3.ParseS3ARN(envFilePath)
 	if err != nil {
-		return errors.Wrapf(err, "unable to parse bucket and key from s3 ARN specified in environmentFile %s", envFilePath)
+		errorEvents <- fmt.Errorf("unable to parse bucket and key from s3 ARN specified in environmentFile %s, error: %v", envFilePath, err)
+		return
 	}
 
 	s3Client, err := envfile.s3ClientCreator.NewS3ClientForBucket(bucket, envfile.region, iamCredentials)
 	if err != nil {
-		return errors.Wrapf(err, "unable to initialize s3 client for bucket %s", bucket)
+		errorEvents <- fmt.Errorf("unable to initialize s3 client for bucket %s, error: %v", bucket, err)
+		return
 	}
 
 	seelog.Debugf("Downlading envfile with bucket name %v and key name %v", bucket, key)
@@ -317,11 +336,11 @@ func (envfile *EnvironmentFileResource) downloadEnvfileFromS3(envFilePath string
 	}, downloadPath)
 
 	if err != nil {
-		return errors.Wrapf(err, "unable to download env file with key %s from bucket %s", key, bucket)
+		errorEvents <- fmt.Errorf("unable to download env file with key %s from bucket %s, error: %v", key, bucket, err)
+		return
 	}
 
 	seelog.Debugf("Downloaded envfile from s3 and saved to %s", downloadPath)
-	return nil
 }
 
 func (envfile *EnvironmentFileResource) writeEnvFile(writeFunc func(file oswrapper.File) error, fullPathName string) error {

--- a/scripts/verify-agent-artifacts
+++ b/scripts/verify-agent-artifacts
@@ -1,0 +1,116 @@
+#! /bin/bash
+
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the
+# "License"). You may not use this file except in compliance
+#  with the License. A copy of the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+
+AGENT_VERSION="${1:-}"
+BUCKET_NAME="${2:-}"
+SHA=$(git rev-parse --short HEAD)
+
+usage() {
+	echo "Usage: ${0} AGENT_VERSION BUCKET_NAME"
+}
+
+if [[ $AGENT_VERSION == "" ]]; then
+    usage
+    exit
+fi
+if [[ $BUCKET_NAME == "" ]]; then
+    usage
+    exit
+fi
+
+files="ecs-agent-latest.tar
+ecs-agent-latest.tar.md5
+ecs-agent-latest.tar.json
+ecs-agent-latest.tar.asc
+ecs-agent-v${AGENT_VERSION}.tar
+ecs-agent-v${AGENT_VERSION}.tar.md5
+ecs-agent-v${AGENT_VERSION}.tar.json
+ecs-agent-v${AGENT_VERSION}.tar.asc
+ecs-agent-${SHA}.tar
+ecs-agent-${SHA}.tar.md5
+ecs-agent-${SHA}.tar.json
+ecs-agent-${SHA}.tar.asc
+ecs-agent-windows-latest.zip
+ecs-agent-windows-latest.zip.md5
+ecs-agent-windows-latest.zip.json
+ecs-agent-windows-latest.zip.asc
+ecs-agent-windows-v${AGENT_VERSION}.zip
+ecs-agent-windows-v${AGENT_VERSION}.zip.md5
+ecs-agent-windows-v${AGENT_VERSION}.zip.json
+ecs-agent-windows-v${AGENT_VERSION}.zip.asc
+ecs-agent-windows-${SHA}.zip
+ecs-agent-windows-${SHA}.zip.md5
+ecs-agent-windows-${SHA}.zip.json
+ecs-agent-windows-${SHA}.zip.asc
+ecs-agent-arm64-latest.tar
+ecs-agent-arm64-latest.tar.md5
+ecs-agent-arm64-latest.tar.json
+ecs-agent-arm64-latest.tar.asc
+ecs-agent-arm64-v${AGENT_VERSION}.tar
+ecs-agent-arm64-v${AGENT_VERSION}.tar.md5
+ecs-agent-arm64-v${AGENT_VERSION}.tar.json
+ecs-agent-arm64-v${AGENT_VERSION}.tar.asc
+ecs-agent-arm64-${SHA}.tar
+ecs-agent-arm64-${SHA}.tar.md5
+ecs-agent-arm64-${SHA}.tar.json
+ecs-agent-arm64-${SHA}.tar.asc"
+
+# verify the files actually exist:
+for f in $files; do
+    echo "Verifying file exists: s3://$BUCKET_NAME/$f"
+    output=$(aws s3api head-object --bucket $BUCKET_NAME --key $f)
+    if [ $? != 0 ]; then
+      echo "ERROR file not found: $f"
+   fi
+done
+
+# do basic size-based verification that the content of the 'latest' file matches the version and sha files:
+echo "Verifying contents of s3://$BUCKET_NAME/ecs-agent-latest.tar"
+latest=$(aws s3 ls --summarize s3://$BUCKET_NAME/ecs-agent-latest.tar | tail --lines=2)
+version=$(aws s3 ls --summarize s3://$BUCKET_NAME/ecs-agent-v${AGENT_VERSION}.tar | tail --lines=2)
+sha=$(aws s3 ls --summarize s3://$BUCKET_NAME/ecs-agent-${SHA}.tar | tail --lines=2)
+if [[ "$latest" != "$version" ]]; then
+    echo "ERROR verifying contents of s3://$BUCKET_NAME/ecs-agent-v${AGENT_VERSION}.tar, it is not the same as s3://$BUCKET_NAME/ecs-agent-latest.tar"
+fi
+if [[ "$latest" != "$sha" ]]; then
+    echo "ERROR verifying contents of s3://$BUCKET_NAME/ecs-agent-${SHA}.tar, it is not the same as s3://$BUCKET_NAME/ecs-agent-latest.tar"
+fi
+
+
+# latest windows
+echo "Verifying contents of s3://$BUCKET_NAME/ecs-agent-windows-latest.zip"
+latest=$(aws s3 ls --summarize s3://$BUCKET_NAME/ecs-agent-windows-latest.zip | tail --lines=2)
+version=$(aws s3 ls --summarize s3://$BUCKET_NAME/ecs-agent-windows-v${AGENT_VERSION}.zip | tail --lines=2)
+sha=$(aws s3 ls --summarize s3://$BUCKET_NAME/ecs-agent-windows-${SHA}.zip | tail --lines=2)
+if [[ "$latest" != "$version" ]]; then
+    echo "ERROR verifying contents of s3://$BUCKET_NAME/ecs-agent-windows-v${AGENT_VERSION}.zip, it is not the same as s3://$BUCKET_NAME/ecs-agent-latest.zip"
+fi
+if [[ "$latest" != "$sha" ]]; then
+    echo "ERROR verifying contents of s3://$BUCKET_NAME/ecs-agent-windows-${SHA}.zip, it is not the same as s3://$BUCKET_NAME/ecs-agent-windows-latest.zip"
+fi
+
+
+# latest ARM
+echo "Verifying contents of s3://$BUCKET_NAME/ecs-agent-arm64-latest.tar"
+latest=$(aws s3 ls --summarize s3://$BUCKET_NAME/ecs-agent-arm64-latest.tar | tail --lines=2)
+version=$(aws s3 ls --summarize s3://$BUCKET_NAME/ecs-agent-arm64-v${AGENT_VERSION}.tar | tail --lines=2)
+sha=$(aws s3 ls --summarize s3://$BUCKET_NAME/ecs-agent-arm64-${SHA}.tar | tail --lines=2)
+if [[ "$latest" != "$version" ]]; then
+    echo "ERROR verifying contents of s3://$BUCKET_NAME/ecs-agent-arm64-v${AGENT_VERSION}.tar, it is not the same as s3://$BUCKET_NAME/ecs-agent-arm64-latest.tar"
+fi
+if [[ "$latest" != "$sha" ]]; then
+    echo "ERROR verifying contents of s3://$BUCKET_NAME/ecs-agent-arm64-${SHA}.tar, it is not the same as s3://$BUCKET_NAME/ecs-agent-arm64-latest.tar"
+fi


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This pull request updates how we retrieve envfiles from s3.

### Implementation details
<!-- How are the changes implemented? -->
Each envfile specified will spin up a go routine so that multiple env files can be retrieved in parallel

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> no
`make test` is successful

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
N/A

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
