### PR TITLE
Envfile cleanup logic and unit tests, including oswrapper changes

### DIFF
--- a/agent/taskresource/envFiles/envfile.go
+++ b/agent/taskresource/envFiles/envfile.go
@@ -15,6 +15,7 @@ package envFiles
 
 import (
 	"encoding/json"
+	"fmt"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -38,6 +39,7 @@ const (
 	ResourceName      = "envfile"
 	envFileDirPath    = "envfiles"
 	envTempFilePrefix = "tmp_env"
+	envFileExtension  = ".env"
 
 	s3DownloadTimeout = 30 * time.Second
 )
@@ -358,9 +360,14 @@ func (envfile *EnvironmentFileResource) writeEnvFile(writeFunc func(file oswrapp
 	return nil
 }
 
-// Cleanup removes env files downloaded for the task
+// Cleanup removes env file directory for the task
 func (envfile *EnvironmentFileResource) Cleanup() error {
-	// TODO
+	err := envfile.os.RemoveAll(envfile.resourceDir)
+	if err != nil {
+		return fmt.Errorf("unable to remove envfile resource directory %s: %v", envfile.resourceDir, err)
+	}
+
+	seelog.Infof("Removed envfile resource directory at %s", envfile.resourceDir)
 	return nil
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
- Implementation of envfile.Cleanup 
- unit tests added


### Implementation details
Because the resource directory path includes `envfiles` and `task_id` (/var/lib/ecs/data/envfiles/cluster_name/task_id/${s3filename.env}), any .env file under the directory is candidate for task cleanup, so I did not match name by name.  

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: Yes, new unit tests added

### Description for the changelog
N/A
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
