### PR TITLE
retrieve envfiles from s3 concurrently using go routines

### DIFF
--- a/agent/taskresource/envFiles/envfile.go
+++ b/agent/taskresource/envFiles/envfile.go
@@ -15,6 +15,7 @@ package envFiles
 
 import (
 	"encoding/json"
+	"fmt"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -271,7 +272,7 @@ func (envfile *EnvironmentFileResource) setTerminalReason(reason string) {
 	})
 }
 
-// Create performs resource creation. This retrieves env file contents in parallel
+// Create performs resource creation. This retrieves env file contents concurrently
 // from s3 and writes them to disk
 func (envfile *EnvironmentFileResource) Create() error {
 	seelog.Debugf("Creating envfile resource.")
@@ -283,30 +284,48 @@ func (envfile *EnvironmentFileResource) Create() error {
 		return err
 	}
 
+	var wg sync.WaitGroup
+	errorEvents := make(chan error, len(envfile.environmentFilesSource))
+
 	iamCredentials := executionCredentials.GetIAMRoleCredentials()
 	for _, envfileSource := range envfile.environmentFilesSource {
+		wg.Add(1)
 		// if we support types besides S3 ARN, we will need to add filtering before the below method is called
+		// call an additional go routine per env file
+		go envfile.downloadEnvfileFromS3(envfileSource.Value, iamCredentials, &wg, errorEvents)
+	}
 
-		err := envfile.downloadEnvfileFromS3(envfileSource.Value, iamCredentials)
-		if err != nil {
-			err = errors.Wrapf(err, "unable to download envfile with ARN %v from s3", envfileSource.Value)
-			envfile.setTerminalReason(err.Error())
-			return err
+	wg.Wait()
+	close(errorEvents)
+
+	if len(errorEvents) > 0 {
+		var terminalReasons []string
+		for err := range errorEvents {
+			terminalReasons = append(terminalReasons, err.Error())
 		}
+
+		errorString := strings.Join(terminalReasons, ";")
+		envfile.setTerminalReason(errorString)
+		return errors.New(errorString)
 	}
 
 	return nil
 }
 
-func (envfile *EnvironmentFileResource) downloadEnvfileFromS3(envFilePath string, iamCredentials credentials.IAMRoleCredentials) error {
+func (envfile *EnvironmentFileResource) downloadEnvfileFromS3(envFilePath string, iamCredentials credentials.IAMRoleCredentials,
+	wg *sync.WaitGroup, errorEvents chan error) {
+	defer wg.Done()
+
 	bucket, key, err := s3.ParseS3ARN(envFilePath)
 	if err != nil {
-		return errors.Wrapf(err, "unable to parse bucket and key from s3 ARN specified in environmentFile %s", envFilePath)
+		errorEvents <- fmt.Errorf("unable to parse bucket and key from s3 ARN specified in environmentFile %s, error: %v", envFilePath, err)
+		return
 	}
 
 	s3Client, err := envfile.s3ClientCreator.NewS3ClientForBucket(bucket, envfile.region, iamCredentials)
 	if err != nil {
-		return errors.Wrapf(err, "unable to initialize s3 client for bucket %s", bucket)
+		errorEvents <- fmt.Errorf("unable to initialize s3 client for bucket %s, error: %v", bucket, err)
+		return
 	}
 
 	seelog.Debugf("Downlading envfile with bucket name %v and key name %v", bucket, key)
@@ -317,11 +336,11 @@ func (envfile *EnvironmentFileResource) downloadEnvfileFromS3(envFilePath string
 	}, downloadPath)
 
 	if err != nil {
-		return errors.Wrapf(err, "unable to download env file with key %s from bucket %s", key, bucket)
+		errorEvents <- fmt.Errorf("unable to download env file with key %s from bucket %s, error: %v", key, bucket, err)
+		return
 	}
 
 	seelog.Debugf("Downloaded envfile from s3 and saved to %s", downloadPath)
-	return nil
 }
 
 func (envfile *EnvironmentFileResource) writeEnvFile(writeFunc func(file oswrapper.File) error, fullPathName string) error {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This pull request updates how we retrieve envfiles from s3.

### Implementation details
<!-- How are the changes implemented? -->
Each envfile specified will spin up a go routine so that multiple env files can be retrieved in parallel

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> no
`make test` is successful. Yunhee will add a benchmark into test plan.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
N/A

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
