### PR TITLE
Fix an edge case for container ordering success condition

### DIFF
--- a/agent/engine/dependencygraph/graph_test.go
+++ b/agent/engine/dependencygraph/graph_test.go
@@ -808,6 +808,14 @@ func TestContainerOrderingCanResolve(t *testing.T) {
 		},
 		{
 			TargetDesired:       apicontainerstatus.ContainerRunning,
+			DependencyKnown:     apicontainerstatus.ContainerRunning,
+			DependencyDesired:   apicontainerstatus.ContainerStopped,
+			ExitCode:            0,
+			DependencyCondition: successCondition,
+			Resolvable:          true,
+		},
+		{
+			TargetDesired:       apicontainerstatus.ContainerRunning,
 			DependencyKnown:     apicontainerstatus.ContainerStopped,
 			ExitCode:            0,
 			DependencyCondition: successCondition,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Fix an edge case for container ordering success condition.

Currently, if a container being depended on success condition has a non-empty exit code while its status is running, the task is marked as failed. However, under sufficient load (100+ containers), when running a container that exits quickly, Docker can send container running event along with the exit code, so in that case we will store the exit code of the container while its status is still RUNNING. This causes the agent to fail the task when such container is depended on by others with success condition:
```
...
level=debug time=2020-03-20T18:05:41Z msg="Managed task [arn:aws:ecs:us-west-2:xxx:task/test-efs-order/xxx]: can't apply state to container [reader] yet due to unresolved dependencies: dependency graph: failed to resolve container ordering dependency [writer(busybox) (RUNNING->RUNNING) - Exit: 0] for target [reader(busybox) (NONE->RUNNING)] as dependency did not exit successfully." module=task_manager.go
level=critical time=2020-03-20T18:05:41Z msg="Managed task [arn:aws:ecs:us-west-2:xxx:task/test-efs-order/xxx]: task in a bad state; it's not steadystate but no containers want to transition" module=task_manager.go
```

Fixing this case by not failing the success condition check unless the dependent container is both stopped and has a non-successful exit code.

### Implementation details
<!-- How are the changes implemented? -->
Adjust logic in dependency graph to reflect changes described above.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Added a test case in unit test. Manually reproduced the issue with around 100 tasks that has a fast exiting container and a container depends on it with success condition, and verified that this change fixes the issue.

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Fix an edge case that can cause task failed to start when using container ordering success condition.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
