### PR TITLE
Logging tweaks for clarity and level consistency

### DIFF
--- a/agent/acs/handler/acs_handler.go
+++ b/agent/acs/handler/acs_handler.go
@@ -372,7 +372,11 @@ func (acsSession *session) startACSSession(client wsclient.ClientServer) error {
 			// Stop receiving and sending messages from and to ACS when
 			// client.Serve returns an error. This can happen when the
 			// the connection is closed by ACS or the agent
-			seelog.Infof("ACS connection closed: %v", err)
+			if err == nil || err == io.EOF {
+				seelog.Info("ACS Websocket connection closed for a valid reason")
+			} else {
+				seelog.Errorf("Error: lost websocket connection with Agent Communication Service (ACS): %v", err)
+			}
 			return err
 		}
 	}

--- a/agent/api/statechange.go
+++ b/agent/api/statechange.go
@@ -24,7 +24,6 @@ import (
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	apitaskstatus "github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/agent/statechange"
-	"github.com/pkg/errors"
 
 	"github.com/aws/aws-sdk-go/aws"
 )
@@ -89,19 +88,30 @@ type AttachmentStateChange struct {
 	Attachment *apieni.ENIAttachment
 }
 
+// SkippableStateChange is an error used to indicate that this state change can be omitted
+type SkippableStateChange struct {
+	s string
+}
+
+func (e SkippableStateChange) Error() string {
+	return e.s
+}
+
 // NewTaskStateChangeEvent creates a new task state change event
+// returns error type api.SkippableStateChange if the state change doesn't need
+// to be sent to the ECS backend.
 func NewTaskStateChangeEvent(task *apitask.Task, reason string) (TaskStateChange, error) {
 	var event TaskStateChange
 	taskKnownStatus := task.GetKnownStatus()
 	if !taskKnownStatus.BackendRecognized() {
-		return event, errors.Errorf(
-			"create task state change event api: status not recognized by ECS: %v",
-			taskKnownStatus)
+		return event, SkippableStateChange{
+			fmt.Sprintf("create task state change event api: status not recognized by ECS: %v", taskKnownStatus),
+		}
 	}
 	if task.GetSentStatus() >= taskKnownStatus {
-		return event, errors.Errorf(
-			"create task state change event api: status [%s] already sent",
-			taskKnownStatus.String())
+		return event, SkippableStateChange{
+			fmt.Sprintf("create task state change event api: status [%s] already sent", taskKnownStatus.String()),
+		}
 	}
 
 	event = TaskStateChange{
@@ -117,23 +127,25 @@ func NewTaskStateChangeEvent(task *apitask.Task, reason string) (TaskStateChange
 }
 
 // NewContainerStateChangeEvent creates a new container state change event
+// returns error type api.SkippableStateChange if the state change doesn't need
+// to be sent to the ECS backend.
 func NewContainerStateChangeEvent(task *apitask.Task, cont *apicontainer.Container, reason string) (ContainerStateChange, error) {
 	var event ContainerStateChange
 	contKnownStatus := cont.GetKnownStatus()
 	if !contKnownStatus.ShouldReportToBackend(cont.GetSteadyStateStatus()) {
-		return event, errors.Errorf(
-			"create container state change event api: status not recognized by ECS: %v",
-			contKnownStatus)
+		return event, SkippableStateChange{
+			fmt.Sprintf("create container state change event api: status not recognized by ECS: %v", contKnownStatus),
+		}
 	}
 	if cont.IsInternal() {
-		return event, errors.Errorf(
-			"create container state change event api: internal container: %s",
-			cont.Name)
+		return event, SkippableStateChange{
+			fmt.Sprintf("create container state change event api: internal container: %s", cont.Name),
+		}
 	}
 	if cont.GetSentStatus() >= contKnownStatus {
-		return event, errors.Errorf(
-			"create container state change event api: status [%s] already sent for container %s, task %s",
-			contKnownStatus.String(), cont.Name, task.Arn)
+		return event, SkippableStateChange{
+			fmt.Sprintf("create container state change event api: status [%s] already sent for container %s, task %s", contKnownStatus.String(), cont.Name, task.Arn),
+		}
 	}
 
 	if reason == "" && cont.ApplyingError != nil {

--- a/agent/dockerclient/dockerapi/docker_client.go
+++ b/agent/dockerclient/dockerapi/docker_client.go
@@ -314,7 +314,7 @@ func (dg *dockerGoClient) PullImage(ctx context.Context, image string,
 			func() error {
 				err := dg.pullImage(ctx, image, authData)
 				if err != nil {
-					seelog.Warnf("DockerGoClient: failed to pull image %s: %s", image, err.Error())
+					seelog.Errorf("DockerGoClient: failed to pull image %s: [%s] %s", image, err.ErrorName(), err.Error())
 				}
 				return err
 			})
@@ -695,7 +695,7 @@ func (dg *dockerGoClient) stopContainer(ctx context.Context, dockerID string, ti
 	err = client.ContainerStop(ctx, dockerID, &timeout)
 	metadata := dg.containerMetadata(ctx, dockerID)
 	if err != nil {
-		seelog.Infof("DockerGoClient: error stopping container %s: %v", dockerID, err)
+		seelog.Errorf("DockerGoClient: error stopping container %s: %v", dockerID, err)
 		if metadata.Error == nil {
 			if strings.Contains(err.Error(), "No such container") {
 				err = NoSuchContainerError{dockerID}

--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -504,18 +504,13 @@ func (mtask *managedTask) emitResourceChange(change resourceStateChange) {
 func (mtask *managedTask) emitTaskEvent(task *apitask.Task, reason string) {
 	event, err := api.NewTaskStateChangeEvent(task, reason)
 	if err != nil {
-		if _, ok := err.(api.SkippableStateChange); ok {
-			seelog.Debugf("Managed task [%s]: skipping emitting event for task [%s]: %v",
-				task.Arn, reason, err)
-			return
-		}
-		seelog.Errorf("Managed task [%s]: error emitting event for task [%s]: %v",
+		seelog.Debugf("Managed task [%s]: skipping emitting event for task [%s]: %v",
 			task.Arn, reason, err)
 		return
 	}
 	seelog.Infof("Managed task [%s]: sending task change event [%s]", mtask.Arn, event.String())
 	mtask.stateChangeEvents <- event
-	seelog.Debugf("Managed task [%s]: sent task change event [%s]", mtask.Arn, event.String())
+	seelog.Infof("Managed task [%s]: sent task change event [%s]", mtask.Arn, event.String())
 }
 
 // emitContainerEvent passes a given event up through the containerEvents channel if necessary.
@@ -523,12 +518,7 @@ func (mtask *managedTask) emitTaskEvent(task *apitask.Task, reason string) {
 func (mtask *managedTask) emitContainerEvent(task *apitask.Task, cont *apicontainer.Container, reason string) {
 	event, err := api.NewContainerStateChangeEvent(task, cont, reason)
 	if err != nil {
-		if _, ok := err.(api.SkippableStateChange); ok {
-			seelog.Debugf("Managed task [%s]: skipping emitting event for container [%s]: %v",
-				task.Arn, cont.Name, err)
-			return
-		}
-		seelog.Errorf("Managed task [%s]: error emitting event for container [%s]: %v",
+		seelog.Debugf("Managed task [%s]: skipping emitting event for container [%s]: %v",
 			task.Arn, cont.Name, err)
 		return
 	}
@@ -536,7 +526,7 @@ func (mtask *managedTask) emitContainerEvent(task *apitask.Task, cont *apicontai
 	seelog.Infof("Managed task [%s]: sending container change event [%s]: %s",
 		mtask.Arn, cont.Name, event.String())
 	mtask.stateChangeEvents <- event
-	seelog.Debugf("Managed task [%s]: sent container change event [%s]: %s",
+	seelog.Infof("Managed task [%s]: sent container change event [%s]: %s",
 		mtask.Arn, cont.Name, event.String())
 }
 

--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -504,13 +504,18 @@ func (mtask *managedTask) emitResourceChange(change resourceStateChange) {
 func (mtask *managedTask) emitTaskEvent(task *apitask.Task, reason string) {
 	event, err := api.NewTaskStateChangeEvent(task, reason)
 	if err != nil {
-		seelog.Infof("Managed task [%s]: unable to create task state change event [%s]: %v",
+		if _, ok := err.(api.SkippableStateChange); ok {
+			seelog.Debugf("Managed task [%s]: skipping emitting event for task [%s]: %v",
+				task.Arn, reason, err)
+			return
+		}
+		seelog.Errorf("Managed task [%s]: error emitting event for task [%s]: %v",
 			task.Arn, reason, err)
 		return
 	}
 	seelog.Infof("Managed task [%s]: sending task change event [%s]", mtask.Arn, event.String())
 	mtask.stateChangeEvents <- event
-	seelog.Infof("Managed task [%s]: sent task change event [%s]", mtask.Arn, event.String())
+	seelog.Debugf("Managed task [%s]: sent task change event [%s]", mtask.Arn, event.String())
 }
 
 // emitContainerEvent passes a given event up through the containerEvents channel if necessary.
@@ -518,7 +523,12 @@ func (mtask *managedTask) emitTaskEvent(task *apitask.Task, reason string) {
 func (mtask *managedTask) emitContainerEvent(task *apitask.Task, cont *apicontainer.Container, reason string) {
 	event, err := api.NewContainerStateChangeEvent(task, cont, reason)
 	if err != nil {
-		seelog.Infof("Managed task [%s]: unable to create state change event for container [%s]: %v",
+		if _, ok := err.(api.SkippableStateChange); ok {
+			seelog.Debugf("Managed task [%s]: skipping emitting event for container [%s]: %v",
+				task.Arn, cont.Name, err)
+			return
+		}
+		seelog.Errorf("Managed task [%s]: error emitting event for container [%s]: %v",
 			task.Arn, cont.Name, err)
 		return
 	}
@@ -526,7 +536,7 @@ func (mtask *managedTask) emitContainerEvent(task *apitask.Task, cont *apicontai
 	seelog.Infof("Managed task [%s]: sending container change event [%s]: %s",
 		mtask.Arn, cont.Name, event.String())
 	mtask.stateChangeEvents <- event
-	seelog.Infof("Managed task [%s]: sent container change event [%s]: %s",
+	seelog.Debugf("Managed task [%s]: sent container change event [%s]: %s",
 		mtask.Arn, cont.Name, event.String())
 }
 

--- a/agent/stats/engine.go
+++ b/agent/stats/engine.go
@@ -596,12 +596,12 @@ func (engine *DockerStatsEngine) taskContainerMetricsUnsafe(taskArn string) ([]*
 		// CPU and Memory are both critical, so skip the container if either of these fail.
 		cpuStatsSet, err := container.statsQueue.GetCPUStatsSet()
 		if err != nil {
-			seelog.Warnf("Error getting cpu stats, skipping container, err: %v, container: %v", err, dockerID)
+			seelog.Infof("cloudwatch metrics for container %v not collected, reason (cpu): %v", dockerID, err)
 			continue
 		}
 		memoryStatsSet, err := container.statsQueue.GetMemoryStatsSet()
 		if err != nil {
-			seelog.Warnf("Error getting memory stats, skipping container, err: %v, container: %v", err, dockerID)
+			seelog.Infof("cloudwatch metrics for container %v not collected, reason (memory): %v", dockerID, err)
 			continue
 		}
 		containerMetric := &ecstcs.ContainerMetric{

--- a/agent/tcs/handler/handler.go
+++ b/agent/tcs/handler/handler.go
@@ -84,7 +84,7 @@ func StartSession(params *TelemetrySessionParams, statsEngine stats.Engine) erro
 			seelog.Info("TCS Websocket connection closed for a valid reason")
 			backoff.Reset()
 		} else {
-			seelog.Infof("Error from tcs; backing off: %v", tcsError)
+			seelog.Errorf("Error: lost websocket connection with ECS Telemetry service (TCS): %v", tcsError)
 			params.time().Sleep(backoff.Duration())
 		}
 	}

--- a/agent/wsclient/client.go
+++ b/agent/wsclient/client.go
@@ -387,7 +387,7 @@ func (cs *ClientServerImpl) ConsumeMessages() error {
 
 		default:
 			// Unexpected error occurred
-			seelog.Errorf("Error getting message from ws backend: error: [%v], messageType: [%v] ",
+			seelog.Debugf("Error getting message from ws backend: error: [%v], messageType: [%v] ",
 				err, messageType)
 			return err
 		}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

# Logging fixups/tweaks

### 1
<!-- What does this pull request do? -->

When the agent loses it's websocket connections, it prints a cryptic ERROR message for ACS, and a slightly better INFO message about TCS, like below:

```
2020-03-12T14:59:50Z [ERROR] Error getting message from ws backend: error: [websocket: close 1002 (protocol error): Channel long idle: No message is received, close the channel], messageType: [-1] 
2020-03-12T14:59:50Z [INFO] Error from tcs; backing off: websocket: close 1002 (protocol error): Channel long idle: No message is received, close the channel
```

We should change these log messages so that:
1. the TCS log message is an ERROR not INFO
2. the ACS log message more clearly states that the agent has lost it's ACS connection, rather than a generic 'ws' connection.

### 2

When `docker stop` fails, we should print an error message, not an INFO:

```
2020-03-12T15:01:17Z [INFO] DockerGoClient: error stopping container XXXXXXXXXXXXXX97c9031fad0abd04e1c17d658f9dd5cd7dXXXXXXXXXXXXXXXX: Cannot connect to the Docker daemon at npipe:////./pipe/docker_engine. Is the docker daemon running?
```

### 3

When TCS stats start up, it is normal for there to not be enough data to send stats. However, we log this WARN/error message that is actually just expected behavior:

```
2020-03-12T14:59:35Z [WARN] Error getting cpu stats, err: Need at least 2 data points in queue to calculate CW stats set, container: XXXXXXXXXXXXXX97c9031fad0abd04e1c17d658f9dd5cd7dXXXXXXXXXXXXXXXX
```

We should log this as an INFO message and not include "error" in the message. Possibly we might even want this to be a DEBUG message.

### 4 

When we have a 'skippable' state change event, we return an error from an internal function and then log it as if we ecountered a problem. We should distinguish between 'skippable' state changes and actual errors in this function so that we dont log lots of messages like this for no reason:

```
level=info time=2020-03-23T18:17:36Z msg="Managed task [arn.../foo]: unable to create state change event for container [foobar]: create container state change event api: status not recognized by ECS: NONE" module=task_manager.go
```

### 5

when pulling an image fails we log a WARN message, this should be changed to ERROR:

```
level=warn time=2020-03-22T23:58:42Z msg="DockerGoClient: failed to pull image 1111111111111.dkr.ecr.us-west-1.amazonaws.com/brazil/bloom:1.0.200000.0: context canceled" module=docker_client.go
```

Also 'context cancelled' in this instance probably means that the pull timed-out, so we should check if we can explicitly log that a timeout occured here so it's more clear what happened.

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
