### PR TITLE
Don't log error when ECS_VOLUME_PLUGIN_CAPABILITIES is empty

### DIFF
--- a/agent/config/parse.go
+++ b/agent/config/parse.go
@@ -122,6 +122,9 @@ func parseAvailableLoggingDrivers() []dockerclient.LoggingDriver {
 
 func parseVolumePluginCapabilities() []string {
 	capsFromEnv := os.Getenv("ECS_VOLUME_PLUGIN_CAPABILITIES")
+	if capsFromEnv == "" {
+		return []string{}
+	}
 	capsDecoder := json.NewDecoder(strings.NewReader(capsFromEnv))
 	var caps []string
 	err := capsDecoder.Decode(&caps)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Currently agent logs a warning when ECS_VOLUME_PLUGIN_CAPABILITIES env is empty.
```
level=warn time=2020-03-26T20:04:49Z msg="Invalid format for \"ECS_VOLUME_PLUGIN_CAPABILITIES\", expected a json list of string. error: EOF" module=parse.go
```
This is because empty string is not a valid json and we were trying to parse it. Fixed by skipping the parsing when this env is empty.

### Implementation details
<!-- How are the changes implemented? -->
Modify logic of parseVolumePluginCapabilities.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
TBD
New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
N/A

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
