### PR TITLE
envfile: initialize bufio and add location to statefile properly

### DIFF
--- a/agent/taskresource/envFiles/envfile.go
+++ b/agent/taskresource/envFiles/envfile.go
@@ -91,6 +91,7 @@ func NewEnvironmentFileResource(cluster, taskARN, region, dataDir, containerName
 		environmentFilesSource: envfiles,
 		os:                     oswrapper.NewOS(),
 		ioutil:                 ioutilwrapper.NewIOUtil(),
+		bufio:                  bufiowrapper.NewBufio(),
 		s3ClientCreator:        factory.NewS3ClientCreator(),
 		executionCredentialsID: executionCredentialsID,
 		credentialsManager:     credentialsManager,
@@ -117,6 +118,7 @@ func (envfile *EnvironmentFileResource) Initialize(resourceFields *taskresource.
 	envfile.s3ClientCreator = factory.NewS3ClientCreator()
 	envfile.os = oswrapper.NewOS()
 	envfile.ioutil = ioutilwrapper.NewIOUtil()
+	envfile.bufio = bufiowrapper.NewBufio()
 
 	// if task isn't in 'created' status and desired status is 'running',
 	// reset the resource status to 'NONE' so we always retrieve the data
@@ -465,8 +467,9 @@ func (envfile *EnvironmentFileResource) MarshalJSON() ([]byte, error) {
 			envfileStatus := EnvironmentFileStatus(knownState)
 			return &envfileStatus
 		}(),
-		EnvironmentFilesSource: envfile.environmentFilesSource,
-		ExecutionCredentialsID: envfile.executionCredentialsID,
+		EnvironmentFilesSource:   envfile.environmentFilesSource,
+		EnvironmentFilesLocation: envfile.environmentFilesLocation,
+		ExecutionCredentialsID:   envfile.executionCredentialsID,
 	})
 
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
fixes some minor mistakes with envfiles

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
`make test` is fine, built agent with these changes and able to run tasks successfully

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
