### PR TITLE
keep order of envfiles when reading from disk

### DIFF
--- a/agent/taskresource/envFiles/envfile.go
+++ b/agent/taskresource/envFiles/envfile.go
@@ -59,8 +59,7 @@ type EnvironmentFileResource struct {
 	containerName string
 
 	// env file related attributes
-	environmentFilesSource   []apicontainer.EnvironmentFile // list of env file objects
-	environmentFilesLocation []string                       // list of the paths of where env files are downloaded
+	environmentFilesSource []apicontainer.EnvironmentFile // list of env file objects
 
 	executionCredentialsID string
 	credentialsManager     credentials.Manager
@@ -339,20 +338,6 @@ func (envfile *EnvironmentFileResource) createEnvfileDirectory(bucket, key strin
 	return nil
 }
 
-func (envfile *EnvironmentFileResource) addToEnvironmentFilesLocation(downloadPath string) {
-	envfile.lock.Lock()
-	defer envfile.lock.Unlock()
-
-	envfile.environmentFilesLocation = append(envfile.environmentFilesLocation, downloadPath)
-}
-
-func (envfile *EnvironmentFileResource) getenvironmentFilesLocation() []string {
-	envfile.lock.RLock()
-	defer envfile.lock.RUnlock()
-
-	return envfile.environmentFilesLocation
-}
-
 func (envfile *EnvironmentFileResource) downloadEnvfileFromS3(envFilePath string, iamCredentials credentials.IAMRoleCredentials,
 	wg *sync.WaitGroup, errorEvents chan error) {
 	defer wg.Done()
@@ -378,7 +363,6 @@ func (envfile *EnvironmentFileResource) downloadEnvfileFromS3(envFilePath string
 	seelog.Debugf("Downloading envfile with bucket name %v and key name %v", bucket, key)
 	// we save envfiles to path: /var/lib/ecs/data/envfiles/cluster_name/task_id/${s3bucketname}/${s3filename.env}
 	downloadPath := filepath.Join(envfile.resourceDir, bucket, key)
-	envfile.addToEnvironmentFilesLocation(downloadPath)
 	err = envfile.writeEnvFile(func(file oswrapper.File) error {
 		return s3.DownloadFile(bucket, key, s3DownloadTimeout, file, s3Client)
 	}, downloadPath)
@@ -437,14 +421,13 @@ func (envfile *EnvironmentFileResource) Cleanup() error {
 }
 
 type environmentFileResourceJSON struct {
-	TaskARN                  string                         `json:"taskARN"`
-	ContainerName            string                         `json:"containerName"`
-	CreatedAt                *time.Time                     `json:"createdAt,omitempty"`
-	DesiredStatus            *EnvironmentFileStatus         `json:"desiredStatus"`
-	KnownStatus              *EnvironmentFileStatus         `json:"knownStatus"`
-	EnvironmentFilesSource   []apicontainer.EnvironmentFile `json:"environmentFilesSource"`
-	EnvironmentFilesLocation []string                       `json:"environmentFilesLocation"`
-	ExecutionCredentialsID   string                         `json:"executionCredentialsID"`
+	TaskARN                string                         `json:"taskARN"`
+	ContainerName          string                         `json:"containerName"`
+	CreatedAt              *time.Time                     `json:"createdAt,omitempty"`
+	DesiredStatus          *EnvironmentFileStatus         `json:"desiredStatus"`
+	KnownStatus            *EnvironmentFileStatus         `json:"knownStatus"`
+	EnvironmentFilesSource []apicontainer.EnvironmentFile `json:"environmentFilesSource"`
+	ExecutionCredentialsID string                         `json:"executionCredentialsID"`
 }
 
 // MarshalJSON serializes the EnvironmentFileResource struct to JSON
@@ -467,9 +450,8 @@ func (envfile *EnvironmentFileResource) MarshalJSON() ([]byte, error) {
 			envfileStatus := EnvironmentFileStatus(knownState)
 			return &envfileStatus
 		}(),
-		EnvironmentFilesSource:   envfile.environmentFilesSource,
-		EnvironmentFilesLocation: envfile.environmentFilesLocation,
-		ExecutionCredentialsID:   envfile.executionCredentialsID,
+		EnvironmentFilesSource: envfile.environmentFilesSource,
+		ExecutionCredentialsID: envfile.executionCredentialsID,
 	})
 
 }
@@ -498,10 +480,6 @@ func (envfile *EnvironmentFileResource) UnmarshalJSON(b []byte) error {
 		envfile.environmentFilesSource = envfileJson.EnvironmentFilesSource
 	}
 
-	if envfileJson.EnvironmentFilesLocation != nil {
-		envfile.environmentFilesLocation = envfileJson.EnvironmentFilesLocation
-	}
-
 	envfile.taskARN = envfileJson.TaskARN
 	envfile.containerName = envfileJson.ContainerName
 	envfile.executionCredentialsID = envfileJson.ExecutionCredentialsID
@@ -514,11 +492,33 @@ func (envfile *EnvironmentFileResource) GetContainerName() string {
 	return envfile.containerName
 }
 
+// this method converts EnvironmentFile objects into the path that it would've been downloaded at
+// and returns the list
+func (envfile *EnvironmentFileResource) convertEnvfileToPath() ([]string, error) {
+	var envfileLocations []string
+
+	for _, envfileObj := range envfile.environmentFilesSource {
+		bucket, key, err := s3.ParseS3ARN(envfileObj.Value)
+		if err != nil {
+			seelog.Errorf("unable to parse bucket and key from s3 ARN specified in environmentFile %s", envfileObj.Value)
+			return nil, err
+		}
+
+		downloadPath := filepath.Join(envfile.resourceDir, bucket, key)
+		envfileLocations = append(envfileLocations, downloadPath)
+	}
+
+	return envfileLocations, nil
+}
+
 // ReadEnvVarsFromEnvFiles reads the environment files that have been downloaded
 // and puts them into a list of maps
 func (envfile *EnvironmentFileResource) ReadEnvVarsFromEnvfiles() ([]map[string]string, error) {
 	var envVarsPerEnvfile []map[string]string
-	envfileLocations := envfile.getenvironmentFilesLocation()
+	envfileLocations, err := envfile.convertEnvfileToPath()
+	if err != nil {
+		return nil, err
+	}
 
 	for _, envfilePath := range envfileLocations {
 		envVars, err := envfile.readEnvVarsFromFile(envfilePath)

--- a/agent/taskresource/envFiles/envfile_test.go
+++ b/agent/taskresource/envFiles/envfile_test.go
@@ -67,21 +67,20 @@ func setup(t *testing.T) (*mock_oswrapper.MockOS, *mock_oswrapper.MockFile, *moc
 	return mockOS, mockFile, mockIOUtil, mockCredentialsManager, mockS3ClientCreator, mockS3Client, ctrl.Finish
 }
 
-func newMockEnvfileResource(envfileLocations []container.EnvironmentFile, downloadedEnvfilePaths []string, mockCredentialsManager *mock_credentials.MockManager,
+func newMockEnvfileResource(envfileLocations []container.EnvironmentFile, mockCredentialsManager *mock_credentials.MockManager,
 	mockS3ClientCreator *mock_factory.MockS3ClientCreator,
 	mockOs *mock_oswrapper.MockOS, mockIOUtil *mock_ioutilwrapper.MockIOUtil) *EnvironmentFileResource {
 	return &EnvironmentFileResource{
-		cluster:                  cluster,
-		taskARN:                  taskARN,
-		region:                   region,
-		resourceDir:              resourceDir,
-		environmentFilesSource:   envfileLocations,
-		environmentFilesLocation: downloadedEnvfilePaths,
-		executionCredentialsID:   executionCredentialsID,
-		credentialsManager:       mockCredentialsManager,
-		s3ClientCreator:          mockS3ClientCreator,
-		os:                       mockOs,
-		ioutil:                   mockIOUtil,
+		cluster:                cluster,
+		taskARN:                taskARN,
+		region:                 region,
+		resourceDir:            resourceDir,
+		environmentFilesSource: envfileLocations,
+		executionCredentialsID: executionCredentialsID,
+		credentialsManager:     mockCredentialsManager,
+		s3ClientCreator:        mockS3ClientCreator,
+		os:                     mockOs,
+		ioutil:                 mockIOUtil,
 	}
 }
 
@@ -99,7 +98,7 @@ func TestInitializeFileEnvResource(t *testing.T) {
 		sampleEnvironmentFile(fmt.Sprintf("arn:aws:s3:::%s/%s", s3Bucket, s3Key), "s3"),
 	}
 
-	envfileResource := newMockEnvfileResource(envfiles, nil, mockCredentialsManager, nil, nil, nil)
+	envfileResource := newMockEnvfileResource(envfiles, mockCredentialsManager, nil, nil, nil)
 	envfileResource.Initialize(&taskresource.ResourceFields{
 		ResourceFieldsCommon: &taskresource.ResourceFieldsCommon{
 			CredentialsManager: mockCredentialsManager,
@@ -121,7 +120,7 @@ func TestCreateWithEnvVarFile(t *testing.T) {
 		sampleEnvironmentFile(fmt.Sprintf("arn:aws:s3:::%s/%s", s3Bucket, s3Key), "s3"),
 	}
 
-	envfileResource := newMockEnvfileResource(envfiles, nil, mockCredentialsManager, mockS3ClientCreator, mockOS, mockIOUtil)
+	envfileResource := newMockEnvfileResource(envfiles, mockCredentialsManager, mockS3ClientCreator, mockOS, mockIOUtil)
 	creds := credentials.TaskIAMRoleCredentials{
 		ARN: iamRoleARN,
 		IAMRoleCredentials: credentials.IAMRoleCredentials{
@@ -158,7 +157,7 @@ func TestCreateWithInvalidS3ARN(t *testing.T) {
 		sampleEnvironmentFile(fmt.Sprintf("arn:aws:s3:::%s", s3Key), "s3"),
 	}
 
-	envfileResource := newMockEnvfileResource(envfiles, nil, mockCredentialsManager, mockS3ClientCreator, mockOS, mockIOUtil)
+	envfileResource := newMockEnvfileResource(envfiles, mockCredentialsManager, mockS3ClientCreator, mockOS, mockIOUtil)
 	creds := credentials.TaskIAMRoleCredentials{
 		ARN: iamRoleARN,
 		IAMRoleCredentials: credentials.IAMRoleCredentials{
@@ -182,7 +181,7 @@ func TestCreateUnableToRetrieveDataFromS3(t *testing.T) {
 		sampleEnvironmentFile(fmt.Sprintf("arn:aws:s3:::%s/%s", s3Bucket, s3Key), "s3"),
 	}
 
-	envfileResource := newMockEnvfileResource(envfiles, nil, mockCredentialsManager, mockS3ClientCreator, mockOS, mockIOUtil)
+	envfileResource := newMockEnvfileResource(envfiles, mockCredentialsManager, mockS3ClientCreator, mockOS, mockIOUtil)
 	creds := credentials.TaskIAMRoleCredentials{
 		ARN: iamRoleARN,
 		IAMRoleCredentials: credentials.IAMRoleCredentials{
@@ -214,7 +213,7 @@ func TestCreateUnableToCreateTmpFile(t *testing.T) {
 		sampleEnvironmentFile(fmt.Sprintf("arn:aws:s3:::%s/%s", s3Bucket, s3Key), "s3"),
 	}
 
-	envfileResource := newMockEnvfileResource(envfiles, nil, mockCredentialsManager, mockS3ClientCreator, mockOS, mockIOUtil)
+	envfileResource := newMockEnvfileResource(envfiles, mockCredentialsManager, mockS3ClientCreator, mockOS, mockIOUtil)
 	creds := credentials.TaskIAMRoleCredentials{
 		ARN: iamRoleARN,
 		IAMRoleCredentials: credentials.IAMRoleCredentials{
@@ -244,7 +243,7 @@ func TestCreateRenameFileError(t *testing.T) {
 		sampleEnvironmentFile(fmt.Sprintf("arn:aws:s3:::%s/%s", s3Bucket, s3Key), "s3"),
 	}
 
-	envfileResource := newMockEnvfileResource(envfiles, nil, mockCredentialsManager, mockS3ClientCreator, mockOS, mockIOUtil)
+	envfileResource := newMockEnvfileResource(envfiles, mockCredentialsManager, mockS3ClientCreator, mockOS, mockIOUtil)
 	creds := credentials.TaskIAMRoleCredentials{
 		ARN: iamRoleARN,
 		IAMRoleCredentials: credentials.IAMRoleCredentials{
@@ -280,7 +279,7 @@ func TestEnvFileCleanupSuccess(t *testing.T) {
 		sampleEnvironmentFile(fmt.Sprintf("arn:aws:s3:::%s/%s", s3Bucket, s3Key), "s3"),
 	}
 
-	envfileResource := newMockEnvfileResource(envfiles, nil, mockCredentialsManager, mockS3ClientCreator, mockOS, mockIOUtil)
+	envfileResource := newMockEnvfileResource(envfiles, mockCredentialsManager, mockS3ClientCreator, mockOS, mockIOUtil)
 
 	mockOS.EXPECT().RemoveAll(resourceDir).Return(nil)
 
@@ -295,7 +294,7 @@ func TestEnvFileCleanupResourceDirRemoveFail(t *testing.T) {
 		sampleEnvironmentFile(fmt.Sprintf("arn:aws:s3:::%s/%s", s3Bucket, s3Key), "s3"),
 	}
 
-	envfileResource := newMockEnvfileResource(envfiles, nil, mockCredentialsManager, mockS3ClientCreator, mockOS, mockIOUtil)
+	envfileResource := newMockEnvfileResource(envfiles, mockCredentialsManager, mockS3ClientCreator, mockOS, mockIOUtil)
 
 	mockOS.EXPECT().RemoveAll(resourceDir).Return(errors.New("error response"))
 
@@ -314,12 +313,10 @@ func TestReadEnvVarsFromEnvfiles(t *testing.T) {
 		sampleEnvironmentFile(fmt.Sprintf("arn:aws:s3:::%s/%s", s3Bucket, s3Key), "s3"),
 	}
 
-	downloadedEnvfilePath := fmt.Sprintf("/data/%s", s3Key)
-	envfileResource := newMockEnvfileResource(envfiles, []string{downloadedEnvfilePath},
-		nil, nil, mockOS, mockIOUtil)
+	downloadedEnvfilePath := filepath.Join(resourceDir, s3Bucket, s3Key)
+	envfileResource := newMockEnvfileResource(envfiles, nil, nil, mockOS, mockIOUtil)
 	envfileResource.bufio = mockBufio
 
-	assert.Equal(t, 1, len(envfileResource.environmentFilesLocation))
 	envfileContent := "key=value"
 	gomock.InOrder(
 		mockOS.EXPECT().Open(downloadedEnvfilePath).Return(mockFile, nil),
@@ -350,12 +347,10 @@ func TestReadEnvVarsCommentFromEnvfiles(t *testing.T) {
 		sampleEnvironmentFile(fmt.Sprintf("arn:aws:s3:::%s/%s", s3Bucket, s3Key), "s3"),
 	}
 
-	downloadedEnvfilePath := fmt.Sprintf("/data/%s", s3Key)
-	envfileResource := newMockEnvfileResource(envfiles, []string{downloadedEnvfilePath},
-		nil, nil, mockOS, mockIOUtil)
+	downloadedEnvfilePath := filepath.Join(resourceDir, s3Bucket, s3Key)
+	envfileResource := newMockEnvfileResource(envfiles, nil, nil, mockOS, mockIOUtil)
 	envfileResource.bufio = mockBufio
 
-	assert.Equal(t, 1, len(envfileResource.environmentFilesLocation))
 	envfileContentComment := "# some comment here"
 	gomock.InOrder(
 		mockOS.EXPECT().Open(downloadedEnvfilePath).Return(mockFile, nil),
@@ -385,12 +380,10 @@ func TestReadEnvVarsInvalidFromEnvfiles(t *testing.T) {
 		sampleEnvironmentFile(fmt.Sprintf("arn:aws:s3:::%s/%s", s3Bucket, s3Key), "s3"),
 	}
 
-	downloadedEnvfilePath := fmt.Sprintf("/data/%s", s3Key)
-	envfileResource := newMockEnvfileResource(envfiles, []string{downloadedEnvfilePath},
-		nil, nil, mockOS, mockIOUtil)
+	downloadedEnvfilePath := filepath.Join(resourceDir, s3Bucket, s3Key)
+	envfileResource := newMockEnvfileResource(envfiles, nil, nil, mockOS, mockIOUtil)
 	envfileResource.bufio = mockBufio
 
-	assert.Equal(t, 1, len(envfileResource.environmentFilesLocation))
 	envfileContentInvalid := "=value"
 	gomock.InOrder(
 		mockOS.EXPECT().Open(downloadedEnvfilePath).Return(mockFile, nil),
@@ -416,9 +409,8 @@ func TestReadEnvVarsUnableToReadEnvfile(t *testing.T) {
 		sampleEnvironmentFile(fmt.Sprintf("arn:aws:s3:::%s/%s", s3Bucket, s3Key), "s3"),
 	}
 
-	downloadedEnvfilePath := fmt.Sprintf("/data/%s", s3Key)
-	envfileResource := newMockEnvfileResource(envfiles, []string{downloadedEnvfilePath},
-		nil, nil, mockOS, mockIOUtil)
+	downloadedEnvfilePath := filepath.Join(resourceDir, s3Bucket, s3Key)
+	envfileResource := newMockEnvfileResource(envfiles, nil, nil, mockOS, mockIOUtil)
 
 	mockOS.EXPECT().Open(downloadedEnvfilePath).Return(nil, errors.New("error response"))
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
this commit makes sure that the order in which envfiles are passed in from task def is followed. 

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
`make test` is successful, ran task successfully with precedence on agent built with these changes

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
