### PR TITLE
adding s3EnvFiles capability

### DIFF
--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -59,6 +59,7 @@ const (
 	capabilityGMSA                              = "gmsa"
 	capabilityEFS                               = "efs"
 	capabilityEFSAuth                           = "efsAuth"
+	capabilityS3EnvFiles                        = "s3EnvFiles"
 )
 
 // capabilities returns the supported capabilities of this agent / docker-client pair.
@@ -106,6 +107,7 @@ const (
 //    ecs.capability.full-sync
 //    ecs.capability.gmsa
 //    ecs.capability.efsAuth
+//    ecs.capability.s3EnvFiles
 func (agent *ecsAgent) capabilities() ([]*ecs.Attribute, error) {
 	var capabilities []*ecs.Attribute
 
@@ -176,6 +178,9 @@ func (agent *ecsAgent) capabilities() ([]*ecs.Attribute, error) {
 
 	// support full task sync
 	capabilities = appendNameOnlyAttribute(capabilities, attributePrefix+capabilityFullTaskSync)
+
+	// ecs agent version 1.39.0 supports bulk loading env vars through environmentFiles
+	capabilities = appendNameOnlyAttribute(capabilities, attributePrefix+capabilityS3EnvFiles)
 
 	// ecs agent version 1.22.0 supports sharing PID namespaces and IPC resource namespaces
 	// with host EC2 instance and among containers within the task

--- a/agent/app/agent_capability_test.go
+++ b/agent/app/agent_capability_test.go
@@ -137,6 +137,9 @@ func TestCapabilities(t *testing.T) {
 			{
 				Name: aws.String(attributePrefix + capabilityFullTaskSync),
 			},
+			{
+				Name: aws.String(attributePrefix + capabilityS3EnvFiles),
+			},
 		}...)
 
 	ctx, cancel := context.WithCancel(context.TODO())

--- a/agent/app/agent_capability_unix_test.go
+++ b/agent/app/agent_capability_unix_test.go
@@ -542,6 +542,9 @@ func TestPIDAndIPCNamespaceSharingCapabilitiesUnix(t *testing.T) {
 				Name: aws.String(attributePrefix + capabilityFullTaskSync),
 			},
 			{
+				Name: aws.String(attributePrefix + capabilityS3EnvFiles),
+			},
+			{
 				Name: aws.String(attributePrefix + capabiltyPIDAndIPCNamespaceSharing),
 			},
 		}...)
@@ -629,6 +632,9 @@ func TestPIDAndIPCNamespaceSharingCapabilitiesNoPauseContainer(t *testing.T) {
 			{
 				Name: aws.String(attributePrefix + capabilityFullTaskSync),
 			},
+			{
+				Name: aws.String(attributePrefix + capabilityS3EnvFiles),
+			},
 		}...)
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines
@@ -713,6 +719,9 @@ func TestAppMeshCapabilitiesUnix(t *testing.T) {
 			},
 			{
 				Name: aws.String(attributePrefix + capabilityFullTaskSync),
+			},
+			{
+				Name: aws.String(attributePrefix + capabilityS3EnvFiles),
 			},
 			{
 				Name: aws.String(attributePrefix + capabiltyPIDAndIPCNamespaceSharing),
@@ -923,6 +932,9 @@ func TestCapabilitiesUnix(t *testing.T) {
 			},
 			{
 				Name: aws.String(capabilityPrefix + capabilityFirelensLoggingDriver),
+			},
+			{
+				Name: aws.String(attributePrefix + capabilityS3EnvFiles),
 			},
 		}...)
 	ctx, cancel := context.WithCancel(context.TODO())

--- a/agent/app/agent_capability_windows_test.go
+++ b/agent/app/agent_capability_windows_test.go
@@ -213,6 +213,9 @@ func TestSupportedCapabilitiesWindows(t *testing.T) {
 			{
 				Name: aws.String(attributePrefix + capabilityFullTaskSync),
 			},
+			{
+				Name: aws.String(attributePrefix + capabilityS3EnvFiles),
+			},
 		}...)
 
 	ctx, cancel := context.WithCancel(context.TODO())


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
adding s3EnvFiles capability

### Implementation details
adding s3EnvFiles capability as name only attribute

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: existing tests updated to include the new attribute

### Description for the changelog
N/A
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
