### PR TITLE
rename attribute for s3 envfile for extensibility

### DIFF
--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -59,7 +59,7 @@ const (
 	capabilityGMSA                              = "gmsa"
 	capabilityEFS                               = "efs"
 	capabilityEFSAuth                           = "efsAuth"
-	capabilityS3EnvFiles                        = "s3EnvFiles"
+	capabilityEnvFilesS3                        = "env-files.s3"
 )
 
 // capabilities returns the supported capabilities of this agent / docker-client pair.
@@ -107,7 +107,7 @@ const (
 //    ecs.capability.full-sync
 //    ecs.capability.gmsa
 //    ecs.capability.efsAuth
-//    ecs.capability.s3EnvFiles
+//    ecs.capability.env-files.s3
 func (agent *ecsAgent) capabilities() ([]*ecs.Attribute, error) {
 	var capabilities []*ecs.Attribute
 
@@ -179,8 +179,8 @@ func (agent *ecsAgent) capabilities() ([]*ecs.Attribute, error) {
 	// support full task sync
 	capabilities = appendNameOnlyAttribute(capabilities, attributePrefix+capabilityFullTaskSync)
 
-	// ecs agent version 1.39.0 supports bulk loading env vars through environmentFiles
-	capabilities = appendNameOnlyAttribute(capabilities, attributePrefix+capabilityS3EnvFiles)
+	// ecs agent version 1.39.0 supports bulk loading env vars through environmentFiles in S3
+	capabilities = appendNameOnlyAttribute(capabilities, attributePrefix+capabilityEnvFilesS3)
 
 	// ecs agent version 1.22.0 supports sharing PID namespaces and IPC resource namespaces
 	// with host EC2 instance and among containers within the task

--- a/agent/app/agent_capability_test.go
+++ b/agent/app/agent_capability_test.go
@@ -138,7 +138,7 @@ func TestCapabilities(t *testing.T) {
 				Name: aws.String(attributePrefix + capabilityFullTaskSync),
 			},
 			{
-				Name: aws.String(attributePrefix + capabilityS3EnvFiles),
+				Name: aws.String(attributePrefix + capabilityEnvFilesS3),
 			},
 		}...)
 

--- a/agent/app/agent_capability_unix_test.go
+++ b/agent/app/agent_capability_unix_test.go
@@ -542,7 +542,7 @@ func TestPIDAndIPCNamespaceSharingCapabilitiesUnix(t *testing.T) {
 				Name: aws.String(attributePrefix + capabilityFullTaskSync),
 			},
 			{
-				Name: aws.String(attributePrefix + capabilityS3EnvFiles),
+				Name: aws.String(attributePrefix + capabilityEnvFilesS3),
 			},
 			{
 				Name: aws.String(attributePrefix + capabiltyPIDAndIPCNamespaceSharing),
@@ -633,7 +633,7 @@ func TestPIDAndIPCNamespaceSharingCapabilitiesNoPauseContainer(t *testing.T) {
 				Name: aws.String(attributePrefix + capabilityFullTaskSync),
 			},
 			{
-				Name: aws.String(attributePrefix + capabilityS3EnvFiles),
+				Name: aws.String(attributePrefix + capabilityEnvFilesS3),
 			},
 		}...)
 	ctx, cancel := context.WithCancel(context.TODO())
@@ -721,7 +721,7 @@ func TestAppMeshCapabilitiesUnix(t *testing.T) {
 				Name: aws.String(attributePrefix + capabilityFullTaskSync),
 			},
 			{
-				Name: aws.String(attributePrefix + capabilityS3EnvFiles),
+				Name: aws.String(attributePrefix + capabilityEnvFilesS3),
 			},
 			{
 				Name: aws.String(attributePrefix + capabiltyPIDAndIPCNamespaceSharing),
@@ -934,7 +934,7 @@ func TestCapabilitiesUnix(t *testing.T) {
 				Name: aws.String(capabilityPrefix + capabilityFirelensLoggingDriver),
 			},
 			{
-				Name: aws.String(attributePrefix + capabilityS3EnvFiles),
+				Name: aws.String(attributePrefix + capabilityEnvFilesS3),
 			},
 		}...)
 	ctx, cancel := context.WithCancel(context.TODO())

--- a/agent/app/agent_capability_windows_test.go
+++ b/agent/app/agent_capability_windows_test.go
@@ -214,7 +214,7 @@ func TestSupportedCapabilitiesWindows(t *testing.T) {
 				Name: aws.String(attributePrefix + capabilityFullTaskSync),
 			},
 			{
-				Name: aws.String(attributePrefix + capabilityS3EnvFiles),
+				Name: aws.String(attributePrefix + capabilityEnvFilesS3),
 			},
 		}...)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
rename new instance attribute added for s3 env file


### Implementation details
- "s3EnvFile" -> "env-file.S3"
- capabilityS3EnvFiles -> capabilityEnvFilesS3

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: No, existing tests covers the name change.

### Description for the changelog
N/A
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
