### PR TITLE
envfiles: remove sync call since we don't actually need to flush data…

### DIFF
--- a/agent/taskresource/envFiles/envfile_test.go
+++ b/agent/taskresource/envFiles/envfile_test.go
@@ -143,7 +143,7 @@ func TestCreateWithEnvVarFile(t *testing.T) {
 				assert.Equal(t, s3Bucket, aws.StringValue(input.Bucket))
 				assert.Equal(t, s3Key, aws.StringValue(input.Key))
 			}).Return(int64(0), nil),
-		mockFile.EXPECT().Sync(),
+		mockFile.EXPECT().Close(),
 		mockFile.EXPECT().Name().Return(tempFile),
 		mockOS.EXPECT().Rename(tempFile, filepath.Join(resourceDir, s3Bucket, s3Key)),
 		mockFile.EXPECT().Close(),
@@ -261,7 +261,7 @@ func TestCreateRenameFileError(t *testing.T) {
 		mockOS.EXPECT().MkdirAll(envDirectories, os.ModePerm),
 		mockIOUtil.EXPECT().TempFile(resourceDir, gomock.Any()).Return(mockFile, nil),
 		mockS3Client.EXPECT().DownloadWithContext(gomock.Any(), mockFile, gomock.Any()).Return(int64(0), nil),
-		mockFile.EXPECT().Sync(),
+		mockFile.EXPECT().Close(),
 		mockFile.EXPECT().Name().Return(tempFile),
 		mockOS.EXPECT().Rename(tempFile, filepath.Join(resourceDir, s3Bucket, s3Key)).Return(errors.New("error response")),
 		mockFile.EXPECT().Name().Return(tempFile), // this is for the call made in the logging statement


### PR DESCRIPTION
… to disk, close file manually before rename

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This commit removes the .Sync call we make to flush files to disk - we don't actually need to flush data to disk in case the instance under agent crashes. In such a case, for environment files, the task resource would be created again anyway. This commit also calls .Close on the temporary file instead of deferring the close because windows was having issues with the file being open in another process during rename .

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
`make test` successful, changes off forked branch tested against both AL2 and windows MACIS functional tests

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
