### PR TITLE
fixing race condition in integ test

### DIFF
--- a/agent/engine/engine_unix_integ_test.go
+++ b/agent/engine/engine_unix_integ_test.go
@@ -972,7 +972,8 @@ func TestDockerCfgAuth(t *testing.T) {
 		cfg.EngineAuthType = ""
 	}()
 
-	testTask := createTestTask("testDockerCfgAuth")
+	testArn := "testDockerCfgAuth"
+	testTask := createTestTask(testArn)
 	testTask.Containers[0].Image = testAuthRegistryImage
 
 	go taskEngine.AddTask(testTask)
@@ -980,9 +981,11 @@ func TestDockerCfgAuth(t *testing.T) {
 	verifyContainerRunningStateChange(t, taskEngine)
 	verifyTaskRunningStateChange(t, taskEngine)
 
-	taskUpdate := *testTask
+	// Create instead of copying the testTask, to avoid race condition.
+	// AddTask idempotently handles update, filtering by Task ARN.
+	taskUpdate := createTestTask(testArn)
 	taskUpdate.SetDesiredStatus(apitaskstatus.TaskStopped)
-	go taskEngine.AddTask(&taskUpdate)
+	go taskEngine.AddTask(taskUpdate)
 
 	verifyContainerStoppedStateChange(t, taskEngine)
 	verifyTaskStoppedStateChange(t, taskEngine)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Fixing race condition in integ test, frequently results in timeout for GPU.

### Implementation details
Fixing error here:
```
WARNING: DATA RACE
...
Previous read at 0x00c421329760 by goroutine 1303:
  github.com/aws/amazon-ecs-agent/agent/engine.TestDockerCfgAuth()
      /opt/amazon-ecs-agent/go/src/github.com/aws/amazon-ecs-agent/agent/engine/engine_unix_integ_test.go:983 +0x861
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:746 +0x16c
```
same fix as https://github.com/aws/amazon-ecs-agent/pull/2382

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes:  N/A

### Description for the changelog
N/A
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
