### PR TITLE
Timeout and unit tests for agent healthcheck

### DIFF
--- a/agent/app/healthcheck_test.go
+++ b/agent/app/healthcheck_test.go
@@ -1,0 +1,64 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package app
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHealthcheck_Sunny(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "Hello, client")
+	}))
+	defer ts.Close()
+
+	rc := runHealthcheck(ts.URL, time.Second*2)
+	require.Equal(t, 0, rc)
+}
+
+func TestHealthcheck_InvalidURL2(t *testing.T) {
+	// leading space in url is invalid
+	rc := runHealthcheck("  http://foobar", time.Second*2)
+	require.Equal(t, 1, rc)
+}
+
+func TestHealthcheck_Timeout(t *testing.T) {
+	sema := make(chan int)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-sema
+	}))
+	defer ts.Close()
+
+	rc := runHealthcheck(ts.URL, time.Second*2)
+	require.Equal(t, 1, rc)
+	close(sema)
+}
+
+// we actually pass the healthcheck in the event of a non-200 http status code.
+func TestHealthcheck_404(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte("https://http.cat/404"))
+	}))
+	defer ts.Close()
+
+	rc := runHealthcheck(ts.URL+"/foobar", time.Second*2)
+	require.Equal(t, 0, rc)
+}

--- a/agent/app/run.go
+++ b/agent/app/run.go
@@ -15,6 +15,7 @@ package app
 
 import (
 	"context"
+	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/app/args"
 	"github.com/aws/amazon-ecs-agent/agent/logger"
@@ -39,7 +40,11 @@ func Run(arguments []string) int {
 	} else if *parsedArgs.Version {
 		return version.PrintVersion()
 	} else if *parsedArgs.Healthcheck {
-		return runHealthcheck()
+		// Timeout is purposely set to shorter than the default docker healthcheck
+		// timeout of 30s. This is so that we can catch any http timeout and log the
+		// issue within agent logs.
+		// see https://docs.docker.com/engine/reference/builder/#healthcheck
+		return runHealthcheck("http://localhost:51678/v1/metadata", time.Second*25)
 	}
 
 	logger.SetLevel(*parsedArgs.LogLevel)

--- a/agent/engine/engine_integ_test.go
+++ b/agent/engine/engine_integ_test.go
@@ -424,7 +424,7 @@ func TestSharedAutoprovisionVolume(t *testing.T) {
 	defer done()
 	stateChangeEvents := taskEngine.StateChangeEvents()
 	// Set the task clean up duration to speed up the test
-	taskEngine.(*DockerTaskEngine).cfg.TaskCleanupWaitDuration = 10 * time.Second
+	taskEngine.(*DockerTaskEngine).cfg.TaskCleanupWaitDuration = 1 * time.Second
 
 	testTask, tmpDirectory, err := createVolumeTask("shared", "TestSharedAutoprovisionVolume", "TestSharedAutoprovisionVolume", true)
 	defer os.Remove(tmpDirectory)
@@ -438,7 +438,7 @@ func TestSharedAutoprovisionVolume(t *testing.T) {
 	assert.Equal(t, testTask.ResourcesMapUnsafe["dockerVolume"][0].(*taskresourcevolume.VolumeResource).VolumeConfig.DockerVolumeName, "TestSharedAutoprovisionVolume", "task volume name is not the same as specified in task definition")
 	// Wait for task to be cleaned up
 	testTask.SetSentStatus(apitaskstatus.TaskStopped)
-	waitForTaskCleanup(t, taskEngine, testTask.Arn, 30)
+	waitForTaskCleanup(t, taskEngine, testTask.Arn, 5)
 	client := taskEngine.(*DockerTaskEngine).client
 	response := client.InspectVolume(context.TODO(), "TestSharedAutoprovisionVolume", 1*time.Second)
 	assert.NoError(t, response.Error, "expect shared volume not removed")

--- a/agent/engine/engine_integ_test.go
+++ b/agent/engine/engine_integ_test.go
@@ -424,7 +424,7 @@ func TestSharedAutoprovisionVolume(t *testing.T) {
 	defer done()
 	stateChangeEvents := taskEngine.StateChangeEvents()
 	// Set the task clean up duration to speed up the test
-	taskEngine.(*DockerTaskEngine).cfg.TaskCleanupWaitDuration = 1 * time.Second
+	taskEngine.(*DockerTaskEngine).cfg.TaskCleanupWaitDuration = 10 * time.Second
 
 	testTask, tmpDirectory, err := createVolumeTask("shared", "TestSharedAutoprovisionVolume", "TestSharedAutoprovisionVolume", true)
 	defer os.Remove(tmpDirectory)
@@ -438,7 +438,7 @@ func TestSharedAutoprovisionVolume(t *testing.T) {
 	assert.Equal(t, testTask.ResourcesMapUnsafe["dockerVolume"][0].(*taskresourcevolume.VolumeResource).VolumeConfig.DockerVolumeName, "TestSharedAutoprovisionVolume", "task volume name is not the same as specified in task definition")
 	// Wait for task to be cleaned up
 	testTask.SetSentStatus(apitaskstatus.TaskStopped)
-	waitForTaskCleanup(t, taskEngine, testTask.Arn, 5)
+	waitForTaskCleanup(t, taskEngine, testTask.Arn, 30)
 	client := taskEngine.(*DockerTaskEngine).client
 	response := client.InspectVolume(context.TODO(), "TestSharedAutoprovisionVolume", 1*time.Second)
 	assert.NoError(t, response.Error, "expect shared volume not removed")

--- a/agent/engine/engine_unix_integ_test.go
+++ b/agent/engine/engine_unix_integ_test.go
@@ -172,6 +172,7 @@ func createVolumeTask(scope, arn, volume string, autoprovision bool) (*apitask.T
 		DriverOpts: map[string]string{
 			"device": tmpDirectory,
 			"o":      "bind",
+			"type":   "tmpfs",
 		},
 	}
 	if scope == "shared" {

--- a/agent/taskresource/volume/dockervolume.go
+++ b/agent/taskresource/volume/dockervolume.go
@@ -180,7 +180,7 @@ func (vol *VolumeResource) GetTerminalReason() string {
 
 func (vol *VolumeResource) setTerminalReason(reason string) {
 	vol.terminalReasonOnce.Do(func() {
-		seelog.Infof("Volume Resource [%s]: setting terminal reason for volume resource", vol.Name)
+		seelog.Infof("Volume Resource [%s]: setting terminal reason for volume resource, reason: %s", vol.Name, reason)
 		vol.terminalReason = reason
 	})
 }

--- a/agent/tcs/handler/handler.go
+++ b/agent/tcs/handler/handler.go
@@ -87,6 +87,11 @@ func StartSession(params *TelemetrySessionParams, statsEngine stats.Engine) erro
 			seelog.Errorf("Error: lost websocket connection with ECS Telemetry service (TCS): %v", tcsError)
 			params.time().Sleep(backoff.Duration())
 		}
+		select {
+		case <-params.Ctx.Done():
+			return nil
+		default:
+		}
 	}
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

The docker healthcheck default timeout is 30s. We don't currently set any http timeouts on our internal healthcheck so if the request hangs then we don't log anything in agent or explicitly return a failed healthcheck to docker.

Adding a timeout of 25s means we can timeout in the agent codebase, log the error, and then explicitly return the failed healthcheck error code.

Also did a little refactor to allow adding unit tests.

New tests cover the changes: yes

test output:

```
% go test ./agent/app/. -count=1 -tags unit -v -run=Healthcheck
=== RUN   TestHealthcheck_Sunny
--- PASS: TestHealthcheck_Sunny (0.00s)
=== RUN   TestHealthcheck_InvalidURL2
--- PASS: TestHealthcheck_InvalidURL2 (0.00s)
=== RUN   TestHealthcheck_Timeout
level=error time=2020-04-23T21:51:23Z msg="error creating healthcheck request: parse   http://foobar: first path segment in URL cannot contain colon" module=healthcheck.go
level=error time=2020-04-23T21:51:25Z msg="health check [GET http://127.0.0.1:57227] failed with error: Get http://127.0.0.1:57227: net/http: request canceled (Client.Timeout exceeded while awaiting headers)" module=healthcheck.go
--- PASS: TestHealthcheck_Timeout (2.00s)
=== RUN   TestHealthcheck_404
--- PASS: TestHealthcheck_404 (0.00s)
PASS
ok  	github.com/aws/amazon-ecs-agent/agent/app	2.147s
```

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Log agent healthcheck timeouts.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
