### PR TITLE
Register custom logger before it gets used

### DIFF
--- a/agent/logger/log.go
+++ b/agent/logger/log.go
@@ -140,6 +140,13 @@ func init() {
 		MaxRollCount:  DEFAULT_MAX_ROLL_COUNT,
 	}
 
+	if err := seelog.RegisterCustomFormatter("EcsAgentLogfmt", logfmtFormatter); err != nil {
+		seelog.Error(err)
+	}
+	if err := seelog.RegisterCustomFormatter("EcsAgentJson", jsonFormatter); err != nil {
+		seelog.Error(err)
+	}
+
 	SetLevel(os.Getenv(LOGLEVEL_ENV_VAR))
 	if RolloverType := os.Getenv(LOG_ROLLOVER_TYPE_ENV_VAR); RolloverType != "" {
 		Config.RolloverType = RolloverType
@@ -162,13 +169,6 @@ func init() {
 		} else {
 			seelog.Error("Invalid value for "+LOG_MAX_FILE_SIZE_ENV_VAR, err)
 		}
-	}
-
-	if err := seelog.RegisterCustomFormatter("EcsAgentLogfmt", logfmtFormatter); err != nil {
-		seelog.Error(err)
-	}
-	if err := seelog.RegisterCustomFormatter("EcsAgentJson", jsonFormatter); err != nil {
-		seelog.Error(err)
 	}
 
 	registerPlatformLogger()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
When `ECS_LOGLEVEL` is set in Agent config file, healthcheck outputs shows following error -- ` [Error] format error: unrecognized formatter at 1: EcsAgentLogfmt\n"`

It's because when `ECS_LOGLEVEL` is set, logger tries to load `EcsAgentLogFmt` custom formatter before it is initiated. 
`EcsAgentLogFmt` gets loaded here -- https://github.com/aws/amazon-ecs-agent/blob/master/agent/logger/log.go#L97 which is being called by `SetLevel()`  here -- https://github.com/aws/amazon-ecs-agent/blob/master/agent/logger/log.go#L97.

Currently custom formatter is initiated here  -- https://github.com/aws/amazon-ecs-agent/blob/master/agent/logger/log.go#L167

Moving the initiation of custom formatter before `SetLevel` ensure that the formatter is initiated before it is getting loaded.
 
### Implementation details
<!-- How are the changes implemented? -->

### Testing
Steps to reproduce the issue -- 
1. Set `ECS_LOGLEVEL=debug` in /etc/ecs/ecs.config on al2.
2. Restart agent
3. `docker inspect <agent container id>`. Health check shows error `format error: unrecognized formatter at 1: EcsAgentLogfmt\n`


After the change, the health check was passing with `ECS_LOGLEVEL` set and I could see logs getting generated as expected in Agent log directory.

<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

### Description for the changelog
Bug -  Health check output shows error message when ECS_LOGLEVEL is set in Agent config file. 
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
