### PR TITLE
Backoff container stats collection when listener fails

### DIFF
--- a/agent/dockerclient/dockerapi/docker_client.go
+++ b/agent/dockerclient/dockerapi/docker_client.go
@@ -1321,11 +1321,12 @@ func (dg *dockerGoClient) Stats(ctx context.Context, id string, inactivityTimeou
 	client, err := dg.sdkDockerClient()
 	if err != nil {
 		cancelRequest()
+		return nil, nil, nil
 	}
 
 	statsC := make(chan *types.StatsJSON)
-	errC := make(chan error)
 	done := make(chan struct{})
+	errC := make(chan error)
 	var resp types.ContainerStats
 
 	if !dg.config.PollMetrics {
@@ -1383,6 +1384,7 @@ func (dg *dockerGoClient) Stats(ctx context.Context, id string, inactivityTimeou
 				resp, err = client.ContainerStats(subCtx, id, stream)
 				if err != nil {
 					errC <- fmt.Errorf("DockerGoClient: Unable to retrieve stats for container %s: %v", id, err)
+					return
 				}
 
 				// Returns a *Decoder and takes in a readCloser
@@ -1391,6 +1393,7 @@ func (dg *dockerGoClient) Stats(ctx context.Context, id string, inactivityTimeou
 				err := decoder.Decode(data)
 				if err != nil {
 					errC <- fmt.Errorf("DockerGoClient: Unable to decode stats for container %s: %v", id, err)
+					return
 				}
 
 				statsC <- data

--- a/agent/dockerclient/dockerapi/docker_client_test.go
+++ b/agent/dockerclient/dockerapi/docker_client_test.go
@@ -1044,10 +1044,10 @@ func TestStatsNormalExit(t *testing.T) {
 	}, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-	stats, err := client.Stats(ctx, "foo", dockerclient.StatsInactivityTimeout)
-	assert.NoError(t, err)
+	stats, _, _ := client.Stats(ctx, "foo", dockerclient.StatsInactivityTimeout)
 	newStat := <-stats
 	waitForStats(t, newStat)
+
 	assert.Equal(t, uint64(50), newStat.MemoryStats.Usage)
 	assert.Equal(t, uint64(100), newStat.CPUStats.SystemUsage)
 }
@@ -1063,9 +1063,9 @@ func TestStatsErrorReading(t *testing.T) {
 	}, errors.New("test error"))
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-	stats, err := client.Stats(ctx, "foo", dockerclient.StatsInactivityTimeout)
-	assert.NoError(t, err)
-	assert.Nil(t, <-stats)
+	_, errC, _ := client.Stats(ctx, "foo", dockerclient.StatsInactivityTimeout)
+
+	assert.Error(t, <-errC)
 }
 
 func TestStatsErrorDecoding(t *testing.T) {
@@ -1079,9 +1079,8 @@ func TestStatsErrorDecoding(t *testing.T) {
 	}, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-	stats, err := client.Stats(ctx, "foo", dockerclient.StatsInactivityTimeout)
-	assert.NoError(t, err)
-	assert.Nil(t, <-stats)
+	_, errC, _ := client.Stats(ctx, "foo", dockerclient.StatsInactivityTimeout)
+	assert.Error(t, <-errC)
 }
 
 func TestStatsClientError(t *testing.T) {
@@ -1094,10 +1093,10 @@ func TestStatsClientError(t *testing.T) {
 	}
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-	_, err := client.Stats(ctx, "foo", dockerclient.StatsInactivityTimeout)
-	if err == nil {
-		t.Fatal("Expected error with nil docker client")
-	}
+	statsC, errC, doneC := client.Stats(ctx, "foo", dockerclient.StatsInactivityTimeout)
+	assert.Nil(t, statsC)
+	assert.Nil(t, errC)
+	assert.Nil(t, doneC)
 }
 
 type mockStream struct {
@@ -1156,11 +1155,8 @@ func TestStatsInactivityTimeout(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-	stats, err := client.Stats(ctx, "foo", shortInactivityTimeout)
-	assert.NoError(t, err)
-	newStat := <-stats
-
-	assert.Nil(t, newStat)
+	_, errC, _ := client.Stats(ctx, "foo", shortInactivityTimeout)
+	assert.Error(t, <-errC)
 }
 
 func TestStatsInactivityTimeoutNoHit(t *testing.T) {
@@ -1176,8 +1172,7 @@ func TestStatsInactivityTimeoutNoHit(t *testing.T) {
 	}, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-	stats, err := client.Stats(ctx, "foo", longInactivityTimeout)
-	assert.NoError(t, err)
+	stats, _, _ := client.Stats(ctx, "foo", longInactivityTimeout)
 	newStat := <-stats
 
 	waitForStats(t, newStat)

--- a/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
+++ b/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
@@ -345,12 +345,13 @@ func (mr *MockDockerClientMockRecorder) StartContainer(arg0, arg1, arg2 interfac
 }
 
 // Stats mocks base method
-func (m *MockDockerClient) Stats(arg0 context.Context, arg1 string, arg2 time.Duration) (<-chan *types.StatsJSON, error) {
+func (m *MockDockerClient) Stats(arg0 context.Context, arg1 string, arg2 time.Duration) (<-chan *types.StatsJSON, <-chan error, <-chan struct{}) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Stats", arg0, arg1, arg2)
 	ret0, _ := ret[0].(<-chan *types.StatsJSON)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(<-chan error)
+	ret2, _ := ret[2].(<-chan struct{})
+	return ret0, ret1, ret2
 }
 
 // Stats indicates an expected call of Stats

--- a/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
+++ b/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
@@ -345,13 +345,12 @@ func (mr *MockDockerClientMockRecorder) StartContainer(arg0, arg1, arg2 interfac
 }
 
 // Stats mocks base method
-func (m *MockDockerClient) Stats(arg0 context.Context, arg1 string, arg2 time.Duration) (<-chan *types.StatsJSON, <-chan error, <-chan struct{}) {
+func (m *MockDockerClient) Stats(arg0 context.Context, arg1 string, arg2 time.Duration) (<-chan *types.StatsJSON, <-chan error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Stats", arg0, arg1, arg2)
 	ret0, _ := ret[0].(<-chan *types.StatsJSON)
 	ret1, _ := ret[1].(<-chan error)
-	ret2, _ := ret[2].(<-chan struct{})
-	return ret0, ret1, ret2
+	return ret0, ret1
 }
 
 // Stats indicates an expected call of Stats

--- a/agent/dockerclient/timeout.go
+++ b/agent/dockerclient/timeout.go
@@ -56,8 +56,11 @@ const (
 	ListPluginsTimeout = 1 * time.Minute
 
 	// StatsInactivityTimeout controls the amount of time we hold open a
-	// connection to the Docker daemon waiting for stats data
-	StatsInactivityTimeout = 10 * time.Second
+	// connection to the Docker daemon waiting for stats data.
+	// We set this a few seconds below our stats publishling interval (20s)
+	// so that we can disconnect and warn the user when metrics reporting
+	// may be impacted. This is usually caused by a over-stressed docker daemon.
+	StatsInactivityTimeout = 18 * time.Second
 
 	// DockerPullBeginTimeout is the timeout from when a 'pull' is called to when
 	// we expect to see output on the pull progress stream. This is to work

--- a/agent/dockerclient/timeout.go
+++ b/agent/dockerclient/timeout.go
@@ -57,7 +57,7 @@ const (
 
 	// StatsInactivityTimeout controls the amount of time we hold open a
 	// connection to the Docker daemon waiting for stats data
-	StatsInactivityTimeout = 5 * time.Second
+	StatsInactivityTimeout = 10 * time.Second
 
 	// DockerPullBeginTimeout is the timeout from when a 'pull' is called to when
 	// we expect to see output on the pull progress stream. This is to work

--- a/agent/ecr/model/ecr/service.go
+++ b/agent/ecr/model/ecr/service.go
@@ -44,7 +44,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "ecr"     // Name of service.
 	EndpointsID = "api.ecr" // ID to lookup a service endpoint with.
-	ServiceID   = "ECR"     // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "ECR"     // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the ECR client with a session.
@@ -52,6 +52,8 @@ const (
 // aws.Config parameter to add your extra config.
 //
 // Example:
+//     mySession := session.Must(session.NewSession())
+//
 //     // Create a ECR client from just a session.
 //     svc := ecr.New(mySession)
 //
@@ -62,11 +64,11 @@ func New(p client.ConfigProvider, cfgs ...*aws.Config) *ECR {
 	if c.SigningNameDerived || len(c.SigningName) == 0 {
 		c.SigningName = "ecr"
 	}
-	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
+	return newClient(*c.Config, c.Handlers, c.PartitionID, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
-func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *ECR {
+func newClient(cfg aws.Config, handlers request.Handlers, partitionID, endpoint, signingRegion, signingName string) *ECR {
 	svc := &ECR{
 		Client: client.New(
 			cfg,
@@ -75,6 +77,7 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				ServiceID:     ServiceID,
 				SigningName:   signingName,
 				SigningRegion: signingRegion,
+				PartitionID:   partitionID,
 				Endpoint:      endpoint,
 				APIVersion:    "2015-09-21",
 				JSONVersion:   "1.1",

--- a/agent/ecs_client/model/ecs/api.go
+++ b/agent/ecs_client/model/ecs/api.go
@@ -1610,10 +1610,12 @@ func (c *ECS) ListClustersPagesWithContext(ctx aws.Context, input *ListClustersI
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*ListClustersOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*ListClustersOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -1759,10 +1761,12 @@ func (c *ECS) ListContainerInstancesPagesWithContext(ctx aws.Context, input *Lis
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*ListContainerInstancesOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*ListContainerInstancesOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -1904,10 +1908,12 @@ func (c *ECS) ListServicesPagesWithContext(ctx aws.Context, input *ListServicesI
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*ListServicesOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*ListServicesOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -2138,10 +2144,12 @@ func (c *ECS) ListTaskDefinitionFamiliesPagesWithContext(ctx aws.Context, input 
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*ListTaskDefinitionFamiliesOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*ListTaskDefinitionFamiliesOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -2281,10 +2289,12 @@ func (c *ECS) ListTaskDefinitionsPagesWithContext(ctx aws.Context, input *ListTa
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*ListTaskDefinitionsOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*ListTaskDefinitionsOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -2435,10 +2445,12 @@ func (c *ECS) ListTasksPagesWithContext(ctx aws.Context, input *ListTasksInput, 
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*ListTasksOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*ListTasksOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 

--- a/agent/ecs_client/model/ecs/service.go
+++ b/agent/ecs_client/model/ecs/service.go
@@ -44,7 +44,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "ecs"       // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "ECS"       // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "ECS"       // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the ECS client with a session.
@@ -52,6 +52,8 @@ const (
 // aws.Config parameter to add your extra config.
 //
 // Example:
+//     mySession := session.Must(session.NewSession())
+//
 //     // Create a ECS client from just a session.
 //     svc := ecs.New(mySession)
 //
@@ -59,11 +61,11 @@ const (
 //     svc := ecs.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *ECS {
 	c := p.ClientConfig(EndpointsID, cfgs...)
-	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
+	return newClient(*c.Config, c.Handlers, c.PartitionID, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
-func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *ECS {
+func newClient(cfg aws.Config, handlers request.Handlers, partitionID, endpoint, signingRegion, signingName string) *ECS {
 	svc := &ECS{
 		Client: client.New(
 			cfg,
@@ -72,6 +74,7 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				ServiceID:     ServiceID,
 				SigningName:   signingName,
 				SigningRegion: signingRegion,
+				PartitionID:   partitionID,
 				Endpoint:      endpoint,
 				APIVersion:    "2014-11-13",
 				JSONVersion:   "1.1",

--- a/agent/eni/pause/mocks/load_mocks.go
+++ b/agent/eni/pause/mocks/load_mocks.go
@@ -51,32 +51,32 @@ func (m *MockLoader) EXPECT() *MockLoaderMockRecorder {
 	return m.recorder
 }
 
-// LoadImage mocks base method
-func (m *MockLoader) LoadImage(ctx context.Context, cfg *config.Config, dockerClient dockerapi.DockerClient) (*types.ImageInspect, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LoadImage", ctx, cfg, dockerClient)
-	ret0, _ := ret[0].(*types.ImageInspect)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// LoadImage indicates an expected call of LoadImage
-func (mr *MockLoaderMockRecorder) LoadImage(ctx, cfg, dockerClient interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadImage", reflect.TypeOf((*MockLoader)(nil).LoadImage), ctx, cfg, dockerClient)
-}
-
 // IsLoaded mocks base method
-func (m *MockLoader) IsLoaded(dockerClient dockerapi.DockerClient) (bool, error) {
+func (m *MockLoader) IsLoaded(arg0 dockerapi.DockerClient) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsLoaded", dockerClient)
+	ret := m.ctrl.Call(m, "IsLoaded", arg0)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // IsLoaded indicates an expected call of IsLoaded
-func (mr *MockLoaderMockRecorder) IsLoaded(dockerClient interface{}) *gomock.Call {
+func (mr *MockLoaderMockRecorder) IsLoaded(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsLoaded", reflect.TypeOf((*MockLoader)(nil).IsLoaded), dockerClient)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsLoaded", reflect.TypeOf((*MockLoader)(nil).IsLoaded), arg0)
+}
+
+// LoadImage mocks base method
+func (m *MockLoader) LoadImage(arg0 context.Context, arg1 *config.Config, arg2 dockerapi.DockerClient) (*types.ImageInspect, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LoadImage", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*types.ImageInspect)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// LoadImage indicates an expected call of LoadImage
+func (mr *MockLoaderMockRecorder) LoadImage(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadImage", reflect.TypeOf((*MockLoader)(nil).LoadImage), arg0, arg1, arg2)
 }

--- a/agent/functional_tests/tests/generated/simpletests_unix/simpletests_generated_unix_test.go
+++ b/agent/functional_tests/tests/generated/simpletests_unix/simpletests_generated_unix_test.go
@@ -1408,7 +1408,7 @@ func TestShmSize(t *testing.T) {
 
 }
 
-// TestSimpleExit Tests that the basic premis of this testing fromwork works (e.g. exit codes go through, etc)
+// TestSimpleExit Tests that the basic premise of this testing fromwork works (e.g. exit codes go through, etc)
 func TestSimpleExit(t *testing.T) {
 
 	// Parallel is opt in because resource constraints could cause test failures

--- a/agent/functional_tests/tests/generated/simpletests_windows/simpletests_generated_windows_test.go
+++ b/agent/functional_tests/tests/generated/simpletests_windows/simpletests_generated_windows_test.go
@@ -367,7 +367,7 @@ func TestHostname(t *testing.T) {
 
 }
 
-// TestSimpleExit Tests that the basic premis of this testing fromwork works (e.g. exit codes go through, etc)
+// TestSimpleExit Tests that the basic premise of this testing fromwork works (e.g. exit codes go through, etc)
 func TestSimpleExit(t *testing.T) {
 
 	// Parallel is opt in because resource constraints could cause test failures

--- a/agent/stats/container.go
+++ b/agent/stats/container.go
@@ -67,7 +67,7 @@ func (container *StatsContainer) StopStatsCollection() {
 
 func (container *StatsContainer) collect() {
 	dockerID := container.containerMetadata.DockerID
-	backoff := retry.NewExponentialBackoff(time.Millisecond*250, time.Second*30, 0.5, 1.5)
+	backoff := retry.NewExponentialBackoff(time.Second*1, time.Second*20, 0.75, 2)
 	for {
 		select {
 		case <-container.ctx.Done():

--- a/agent/stats/container_test.go
+++ b/agent/stats/container_test.go
@@ -58,8 +58,7 @@ func TestContainerStatsCollection(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.TODO())
 	statChan := make(chan *types.StatsJSON)
 	errC := make(chan error)
-	done := make(chan struct{})
-	mockDockerClient.EXPECT().Stats(ctx, dockerID, dockerclient.StatsInactivityTimeout).Return(statChan, errC, done)
+	mockDockerClient.EXPECT().Stats(ctx, dockerID, dockerclient.StatsInactivityTimeout).Return(statChan, errC)
 	go func() {
 		for _, stat := range statsData {
 			// doing this with json makes me sad, but is the easiest way to
@@ -127,6 +126,49 @@ func TestContainerStatsCollection(t *testing.T) {
 	}
 }
 
+func TestContainerStatsCollectionReconnection(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockDockerClient := mock_dockerapi.NewMockDockerClient(ctrl)
+	resolver := mock_resolver.NewMockContainerMetadataResolver(ctrl)
+
+	dockerID := "container1"
+	ctx, cancel := context.WithCancel(context.TODO())
+
+	statChan := make(chan *types.StatsJSON)
+	errChan := make(chan error)
+	go func() { errChan <- fmt.Errorf("test error") }()
+	closedChan := make(chan *types.StatsJSON)
+	close(closedChan)
+
+	mockContainer := &apicontainer.DockerContainer{
+		DockerID: dockerID,
+		Container: &apicontainer.Container{
+			KnownStatusUnsafe: apicontainerstatus.ContainerRunning,
+		},
+	}
+	gomock.InOrder(
+		mockDockerClient.EXPECT().Stats(ctx, dockerID, dockerclient.StatsInactivityTimeout).Return(closedChan, errChan),
+		resolver.EXPECT().ResolveContainer(dockerID).Return(mockContainer, nil),
+		mockDockerClient.EXPECT().Stats(ctx, dockerID, dockerclient.StatsInactivityTimeout).Return(closedChan, nil),
+		resolver.EXPECT().ResolveContainer(dockerID).Return(mockContainer, nil),
+		mockDockerClient.EXPECT().Stats(ctx, dockerID, dockerclient.StatsInactivityTimeout).Return(statChan, nil),
+	)
+
+	container := &StatsContainer{
+		containerMetadata: &ContainerMetadata{
+			DockerID: dockerID,
+		},
+		ctx:      ctx,
+		cancel:   cancel,
+		client:   mockDockerClient,
+		resolver: resolver,
+	}
+	container.StartStatsCollection()
+	time.Sleep(checkPointSleep)
+	container.StopStatsCollection()
+}
+
 func TestContainerStatsCollectionStopsIfContainerIsTerminal(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -137,9 +179,8 @@ func TestContainerStatsCollectionStopsIfContainerIsTerminal(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.TODO())
 
 	closedChan := make(chan *types.StatsJSON)
+	close(closedChan)
 	errC := make(chan error)
-	done := make(chan struct{})
-	close(done)
 
 	statsErr := fmt.Errorf("test error")
 	mockContainer := &apicontainer.DockerContainer{
@@ -149,7 +190,7 @@ func TestContainerStatsCollectionStopsIfContainerIsTerminal(t *testing.T) {
 		},
 	}
 	gomock.InOrder(
-		mockDockerClient.EXPECT().Stats(ctx, dockerID, dockerclient.StatsInactivityTimeout).Return(closedChan, errC, done),
+		mockDockerClient.EXPECT().Stats(ctx, dockerID, dockerclient.StatsInactivityTimeout).Return(closedChan, errC),
 		resolver.EXPECT().ResolveContainer(dockerID).Return(mockContainer, statsErr),
 	)
 

--- a/agent/stats/engine_test.go
+++ b/agent/stats/engine_test.go
@@ -59,8 +59,9 @@ func TestStatsEngineAddRemoveContainers(t *testing.T) {
 		},
 	}, nil)
 	mockStatsChannel := make(chan *types.StatsJSON)
-	defer close(mockStatsChannel)
-	mockDockerClient.EXPECT().Stats(gomock.Any(), gomock.Any(), gomock.Any()).Return(mockStatsChannel, nil).AnyTimes()
+	done := make(chan struct{})
+	defer close(done)
+	mockDockerClient.EXPECT().Stats(gomock.Any(), gomock.Any(), gomock.Any()).Return(mockStatsChannel, nil, done).AnyTimes()
 
 	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestStatsEngineAddRemoveContainers"))
 	ctx, cancel := context.WithCancel(context.TODO())
@@ -187,7 +188,9 @@ func TestStatsEngineMetadataInStatsSets(t *testing.T) {
 			Name: "test",
 		},
 	}, nil)
-	mockDockerClient.EXPECT().Stats(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	done := make(chan struct{})
+	defer close(done)
+	mockDockerClient.EXPECT().Stats(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, done).AnyTimes()
 
 	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestStatsEngineMetadataInStatsSets"))
 	ctx, cancel := context.WithCancel(context.TODO())
@@ -420,7 +423,7 @@ func TestSynchronizeOnRestart(t *testing.T) {
 	})
 	client.EXPECT().Stats(gomock.Any(), containerID, gomock.Any()).Do(func(ctx context.Context, id string, inactivityTimeout time.Duration) {
 		statsStarted <- struct{}{}
-	}).Return(statsChan, nil)
+	}).Return(statsChan, nil, nil)
 
 	resolver.EXPECT().ResolveTask(containerID).Return(&apitask.Task{
 		Arn:               "t1",
@@ -475,7 +478,7 @@ func testNetworkModeStats(t *testing.T, netMode string, enis []*apieni.ENI, empt
 			NetworkModeUnsafe: netMode,
 		},
 	}, nil)
-	mockDockerClient.EXPECT().Stats(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	mockDockerClient.EXPECT().Stats(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, nil).AnyTimes()
 
 	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestTaskNetworkStatsSet"))
 	ctx, cancel := context.WithCancel(context.TODO())

--- a/agent/stats/engine_test.go
+++ b/agent/stats/engine_test.go
@@ -59,9 +59,8 @@ func TestStatsEngineAddRemoveContainers(t *testing.T) {
 		},
 	}, nil)
 	mockStatsChannel := make(chan *types.StatsJSON)
-	done := make(chan struct{})
-	defer close(done)
-	mockDockerClient.EXPECT().Stats(gomock.Any(), gomock.Any(), gomock.Any()).Return(mockStatsChannel, nil, done).AnyTimes()
+	defer close(mockStatsChannel)
+	mockDockerClient.EXPECT().Stats(gomock.Any(), gomock.Any(), gomock.Any()).Return(mockStatsChannel, nil).AnyTimes()
 
 	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestStatsEngineAddRemoveContainers"))
 	ctx, cancel := context.WithCancel(context.TODO())
@@ -188,9 +187,7 @@ func TestStatsEngineMetadataInStatsSets(t *testing.T) {
 			Name: "test",
 		},
 	}, nil)
-	done := make(chan struct{})
-	defer close(done)
-	mockDockerClient.EXPECT().Stats(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, done).AnyTimes()
+	mockDockerClient.EXPECT().Stats(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 
 	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestStatsEngineMetadataInStatsSets"))
 	ctx, cancel := context.WithCancel(context.TODO())
@@ -423,7 +420,7 @@ func TestSynchronizeOnRestart(t *testing.T) {
 	})
 	client.EXPECT().Stats(gomock.Any(), containerID, gomock.Any()).Do(func(ctx context.Context, id string, inactivityTimeout time.Duration) {
 		statsStarted <- struct{}{}
-	}).Return(statsChan, nil, nil)
+	}).Return(statsChan, nil)
 
 	resolver.EXPECT().ResolveTask(containerID).Return(&apitask.Task{
 		Arn:               "t1",
@@ -478,7 +475,7 @@ func testNetworkModeStats(t *testing.T, netMode string, enis []*apieni.ENI, empt
 			NetworkModeUnsafe: netMode,
 		},
 	}, nil)
-	mockDockerClient.EXPECT().Stats(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, nil).AnyTimes()
+	mockDockerClient.EXPECT().Stats(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 
 	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestTaskNetworkStatsSet"))
 	ctx, cancel := context.WithCancel(context.TODO())


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

The purpose of this change is to backoff and jitter when stats collection fails on a container. By default we open a streaming stats listener for each container. If this listener fails, we currently immediately try to open it again for every container.

This can create a situation where stats listeners are failing due to a resource-stressed docker daemon. The agent then exacerbates the situation by spamming the docker daemon with potentially thousands of stats requests in just a few minutes.

This change causes the agent to backoff when the stats listener fails for a container. We are also increasing the timeout on the listener from 5s to 10s as stress testing has shown that waiting longer can sometimes result in getting stats successfully.

### Testing

a single-instance cluster was created with m5.large. 204 tasks were spun up running a simple dd command. At the same time, the [containerd-stress](https://github.com/containerd/containerd/blob/master/cmd/containerd-stress/main.go) tool was run for 30 minutes using the following command:

```
sudo ~/go/bin/containerd-stress --duration 30m --concurrent 24
```

We can then count the number of times that we see the "Unable to decode stats for container" message to see how many times we attempt to open a new stats stream that fails.

Without change:
```
% grep "Unable to decode stats for container" < /var/log/ecs/ecs-agent.log|wc -l
30268
```
With this change:
```
% grep "Unable to decode stats for container" < /var/log/ecs/ecs-agent.log | wc -l
3645
```

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
