### PR TITLE
Steady state poll interval jitter

### DIFF
--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -152,7 +152,8 @@ type DockerTaskEngine struct {
 	// This is set to defaultTaskSteadyStatePollInterval in production code.
 	// This can be used by tests that are looking to ensure that the steady state
 	// verification logic gets executed to set it to a low interval
-	taskSteadyStatePollInterval time.Duration
+	taskSteadyStatePollInterval       time.Duration
+	taskSteadyStatePollIntervalJitter time.Duration
 
 	resourceFields *taskresource.ResourceFields
 
@@ -190,10 +191,11 @@ func NewDockerTaskEngine(cfg *config.Config,
 		imageManager:               imageManager,
 		cniClient:                  ecscni.NewClient(cfg.CNIPluginsPath),
 
-		metadataManager:             metadataManager,
-		taskSteadyStatePollInterval: defaultTaskSteadyStatePollInterval,
-		resourceFields:              resourceFields,
-		handleDelay:                 time.Sleep,
+		metadataManager:                   metadataManager,
+		taskSteadyStatePollInterval:       defaultTaskSteadyStatePollInterval,
+		taskSteadyStatePollIntervalJitter: defaultTaskSteadyStatePollIntervalJitter,
+		resourceFields:                    resourceFields,
+		handleDelay:                       time.Sleep,
 	}
 
 	dockerTaskEngine.initializeContainerStatusToTransitionFunction()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

When the agent is restarted, all tasks are added back into it's internal task manager all at once. If these are "steady state" tasks, then they will all hit the steady state poll interval at the same time, resulting in a docker DescribeContainer call for every container running on the instance.

This change adds a jitter to this so that we don't query docker for every container's state all at the same time.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results. Also, once
you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

Was run on a container instance with 256 tasks, in addition to all unit/integ/func tests.

New tests cover the changes: no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
