### PR TITLE
Don't clear stats queue every interval

### DIFF
--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -142,6 +142,10 @@ const (
 	defaultCgroupCPUPeriod = 100 * time.Millisecond
 	maximumCgroupCPUPeriod = 100 * time.Millisecond
 	minimumCgroupCPUPeriod = 8 * time.Millisecond
+
+	// DefaultContainerMetricsPublishInterval is the default interval that we publish
+	// metrics to the ECS telemetry backend (TACS)
+	DefaultContainerMetricsPublishInterval = 20 * time.Second
 )
 
 const (

--- a/agent/stats/common_test.go
+++ b/agent/stats/common_test.go
@@ -41,11 +41,11 @@ import (
 const (
 	// checkPointSleep is the sleep duration in milliseconds between
 	// starting/stopping containers in the test code.
-	checkPointSleep              = 5 * SleepBetweenUsageDataCollection
+	checkPointSleep              = 5 * time.Second
 	testContainerHealthImageName = "amazon/amazon-ecs-containerhealthcheck:make"
 
 	// defaultDockerTimeoutSeconds is the timeout for dialing the docker remote API.
-	defaultDockerTimeoutSeconds = time.Second * 10
+	defaultDockerTimeoutSeconds = 10 * time.Second
 
 	// waitForCleanupSleep is the sleep duration in milliseconds
 	// for the waiting after container cleanup before checking the state of the manager.

--- a/agent/stats/engine.go
+++ b/agent/stats/engine.go
@@ -78,7 +78,7 @@ type DockerStatsEngine struct {
 	cluster                    string
 	containerInstanceArn       string
 	lock                       sync.RWMutex
-	disableMetrics             bool
+	config                     *config.Config
 	containerChangeEventStream *eventstream.EventStream
 	resolver                   resolver.ContainerMetadataResolver
 	// tasksToContainers maps task arns to a map of container ids to StatsContainer objects.
@@ -121,7 +121,7 @@ func NewDockerStatsEngine(cfg *config.Config, client dockerapi.DockerClient, con
 	return &DockerStatsEngine{
 		client:                       client,
 		resolver:                     nil,
-		disableMetrics:               cfg.DisableMetrics,
+		config:                       cfg,
 		tasksToContainers:            make(map[string]map[string]*StatsContainer),
 		tasksToHealthCheckContainers: make(map[string]map[string]*StatsContainer),
 		tasksToDefinitions:           make(map[string]*taskDefinition),
@@ -152,7 +152,7 @@ func (engine *DockerStatsEngine) addAndStartStatsContainer(containerID string) {
 		return
 	}
 
-	if engine.disableMetrics || statsContainer == nil {
+	if engine.config.DisableMetrics || statsContainer == nil {
 		return
 	}
 
@@ -248,7 +248,7 @@ func (engine *DockerStatsEngine) addContainerUnsafe(dockerID string) (*StatsCont
 		return nil, errors.Errorf("stats add container: task is terminal, ignoring container: %s, task: %s", dockerID, task.Arn)
 	}
 
-	statsContainer, err := newStatsContainer(dockerID, engine.client, engine.resolver)
+	statsContainer, err := newStatsContainer(dockerID, engine.client, engine.resolver, engine.config)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not map docker container ID to container, ignoring container: %s", dockerID)
 	}
@@ -257,7 +257,7 @@ func (engine *DockerStatsEngine) addContainerUnsafe(dockerID string) (*StatsCont
 	engine.tasksToDefinitions[task.Arn] = &taskDefinition{family: task.Family, version: task.Version}
 
 	watchStatsContainer := false
-	if !engine.disableMetrics {
+	if !engine.config.DisableMetrics {
 		// Adding container to the map for collecting stats
 		watchStatsContainer = engine.addToStatsContainerMapUnsafe(task.Arn, dockerID, statsContainer, engine.containerMetricsMapUnsafe)
 	}
@@ -366,8 +366,6 @@ func (engine *DockerStatsEngine) GetInstanceMetrics() (*ecstcs.MetricsMetadata, 
 		return nil, nil, EmptyMetricsError
 	}
 
-	// Reset current stats. Retaining older stats results in incorrect utilization stats
-	// until they are removed from the queue.
 	engine.resetStatsUnsafe()
 	return metricsMetadata, taskMetrics, nil
 }
@@ -587,12 +585,6 @@ func (engine *DockerStatsEngine) taskContainerMetricsUnsafe(taskArn string) ([]*
 			continue
 		}
 
-		if !container.statsQueue.enoughDatapointsInBuffer() &&
-			!container.statsQueue.resetThresholdElapsed(queueResetThreshold) {
-			seelog.Debugf("Stats not ready for container %s", dockerID)
-			continue
-		}
-
 		// CPU and Memory are both critical, so skip the container if either of these fail.
 		cpuStatsSet, err := container.statsQueue.GetCPUStatsSet()
 		if err != nil {
@@ -693,7 +685,6 @@ func (engine *DockerStatsEngine) ContainerDockerStats(taskARN string, containerI
 		return nil, errors.Errorf("stats engine: container not found: %s", containerID)
 	}
 	return container.statsQueue.GetLastStat(), nil
-
 }
 
 // newMetricsMetadata creates the singleton metadata object.

--- a/agent/stats/engine_integ_test.go
+++ b/agent/stats/engine_integ_test.go
@@ -398,7 +398,7 @@ func TestStatsEngineWithNewContainersWithPolling(t *testing.T) {
 	assert.NoError(t, err, "failed to write to container change event stream")
 
 	// Wait for the stats collection go routine to start.
-	time.Sleep(10 * SleepBetweenUsageDataCollection)
+	time.Sleep(10 * time.Second)
 	validateInstanceMetrics(t, engine)
 	// Verify the health metrics of container
 	validateTaskHealthMetrics(t, engine)

--- a/agent/stats/engine_test.go
+++ b/agent/stats/engine_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStatsEngineAddRemoveContainers(t *testing.T) {
@@ -119,19 +120,11 @@ func TestStatsEngineAddRemoveContainers(t *testing.T) {
 	}
 
 	err = validateMetricsMetadata(metadata)
-	if err != nil {
-		t.Errorf("Error validating metadata: %v", err)
-	}
-	if len(taskMetrics) != 1 {
-		t.Errorf("Incorrect number of tasks. Expected: 1, got: %d", len(taskMetrics))
-	}
+	require.NoError(t, err)
+	require.Len(t, taskMetrics, 1, "Incorrect number of tasks.")
 	err = validateContainerMetrics(taskMetrics[0].ContainerMetrics, 2)
-	if err != nil {
-		t.Errorf("Error validating container metrics: %v", err)
-	}
-	if *taskMetrics[0].TaskArn != "t1" {
-		t.Errorf("Incorrect task arn. Expected: t1, got: %s", *taskMetrics[0].TaskArn)
-	}
+	require.NoError(t, err)
+	require.Equal(t, "t1", *taskMetrics[0].TaskArn)
 
 	// Ensure that only valid task shows up in metrics.
 	_, err = engine.taskContainerMetricsUnsafe("t2")
@@ -309,7 +302,7 @@ func TestGetTaskHealthMetrics(t *testing.T) {
 
 	containerToStats := make(map[string]*StatsContainer)
 	var err error
-	containerToStats[containerID], err = newStatsContainer(containerID, nil, resolver)
+	containerToStats[containerID], err = newStatsContainer(containerID, nil, resolver, nil)
 	assert.NoError(t, err)
 	engine.tasksToHealthCheckContainers["t1"] = containerToStats
 	engine.tasksToDefinitions["t1"] = &taskDefinition{
@@ -353,7 +346,7 @@ func TestGetTaskHealthMetricsStoppedContainer(t *testing.T) {
 
 	containerToStats := make(map[string]*StatsContainer)
 	var err error
-	containerToStats[containerID], err = newStatsContainer(containerID, nil, resolver)
+	containerToStats[containerID], err = newStatsContainer(containerID, nil, resolver, nil)
 	assert.NoError(t, err)
 	engine.tasksToHealthCheckContainers["t1"] = containerToStats
 	engine.tasksToDefinitions["t1"] = &taskDefinition{

--- a/agent/stats/queue_test.go
+++ b/agent/stats/queue_test.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/tcs/model/ecstcs"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -37,32 +36,33 @@ const (
 	predictableInt64Overflow = math.MaxInt64 / int64(2)
 )
 
+var now time.Time = time.Now()
+
 func getTimestamps() []time.Time {
 	return []time.Time{
-		parseNanoTime("2015-02-12T21:22:05.131117533Z"),
-		parseNanoTime("2015-02-12T21:22:05.232291187Z"),
-		parseNanoTime("2015-02-12T21:22:05.333776335Z"),
-		parseNanoTime("2015-02-12T21:22:05.434753595Z"),
-		parseNanoTime("2015-02-12T21:22:05.535746779Z"),
-		parseNanoTime("2015-02-12T21:22:05.638709495Z"),
-		parseNanoTime("2015-02-12T21:22:05.739985398Z"),
-		parseNanoTime("2015-02-12T21:22:05.840941705Z"),
-		parseNanoTime("2015-02-12T21:22:05.94164351Z"),
-		parseNanoTime("2015-02-12T21:22:06.042625519Z"),
-		parseNanoTime("2015-02-12T21:22:06.143665077Z"),
-		parseNanoTime("2015-02-12T21:22:06.244769169Z"),
-		parseNanoTime("2015-02-12T21:22:06.345847001Z"),
-		parseNanoTime("2015-02-12T21:22:06.447151399Z"),
-		parseNanoTime("2015-02-12T21:22:06.548213586Z"),
-		parseNanoTime("2015-02-12T21:22:06.650013301Z"),
-		parseNanoTime("2015-02-12T21:22:06.751120187Z"),
-		parseNanoTime("2015-02-12T21:22:06.852163377Z"),
-		parseNanoTime("2015-02-12T21:22:06.952980001Z"),
-		parseNanoTime("2015-02-12T21:22:07.054047217Z"),
-		parseNanoTime("2015-02-12T21:22:07.154840095Z"),
-		parseNanoTime("2015-02-12T21:22:07.256075769Z"),
+		now.Add(-time.Millisecond * 2100),
+		now.Add(-time.Millisecond * 2000),
+		now.Add(-time.Millisecond * 1900),
+		now.Add(-time.Millisecond * 1800),
+		now.Add(-time.Millisecond * 1700),
+		now.Add(-time.Millisecond * 1600),
+		now.Add(-time.Millisecond * 1500),
+		now.Add(-time.Millisecond * 1400),
+		now.Add(-time.Millisecond * 1300),
+		now.Add(-time.Millisecond * 1200),
+		now.Add(-time.Millisecond * 1100),
+		now.Add(-time.Millisecond * 1000),
+		now.Add(-time.Millisecond * 900),
+		now.Add(-time.Millisecond * 800),
+		now.Add(-time.Millisecond * 700),
+		now.Add(-time.Millisecond * 600),
+		now.Add(-time.Millisecond * 500),
+		now.Add(-time.Millisecond * 400),
+		now.Add(-time.Millisecond * 300),
+		now.Add(-time.Millisecond * 200),
+		now.Add(-time.Millisecond * 100),
+		now,
 	}
-
 }
 
 func getUintStats() []uint64 {
@@ -135,7 +135,7 @@ func getLargeInt64Stats(size int) []uint64 {
 	return uintStats
 }
 
-func createQueue(size int, predictableHighUtilization bool) *Queue {
+func getContainerStats(predictableHighUtilization bool) []*ContainerStats {
 	timestamps := getTimestamps()
 	cpuTimes := getUintStats()
 	var memoryUtilizationInBytes []uint64
@@ -147,9 +147,9 @@ func createQueue(size int, predictableHighUtilization bool) *Queue {
 		memoryUtilizationInBytes = getRandomMemoryUtilizationInBytes()
 		uintStats = getUintStats()
 	}
-	queue := NewQueue(size)
+	stats := []*ContainerStats{}
 	for i, time := range timestamps {
-		queue.add(&ContainerStats{
+		stats = append(stats, &ContainerStats{
 			cpuUsage:          cpuTimes[i],
 			memoryUsage:       memoryUtilizationInBytes[i],
 			storageReadBytes:  uintStats[i],
@@ -166,7 +166,65 @@ func createQueue(size int, predictableHighUtilization bool) *Queue {
 			},
 			timestamp: time})
 	}
+	return stats
+}
+
+func createQueue(size int, predictableHighUtilization bool) *Queue {
+	stats := getContainerStats(predictableHighUtilization)
+	queue := NewQueue(size)
+	for _, stat := range stats {
+		queue.add(stat)
+	}
 	return queue
+}
+
+func TestQueueReset(t *testing.T) {
+	queue := NewQueue(10)
+	// empty queue should throw errors getting stats sets:
+	_, err := queue.GetCPUStatsSet()
+	require.Error(t, err)
+	_, err = queue.GetMemoryStatsSet()
+	require.Error(t, err)
+	_, err = queue.GetStorageStatsSet()
+	require.Error(t, err)
+	_, err = queue.GetNetworkStatsSet()
+	require.Error(t, err)
+
+	// add some metrics, and getting stats sets should now succeed:
+	stats := getContainerStats(false)
+	for i := 0; i < 4; i++ {
+		queue.add(stats[i])
+	}
+	_, err = queue.GetCPUStatsSet()
+	require.NoError(t, err)
+	_, err = queue.GetMemoryStatsSet()
+	require.NoError(t, err)
+	_, err = queue.GetStorageStatsSet()
+	require.NoError(t, err)
+	_, err = queue.GetNetworkStatsSet()
+	require.NoError(t, err)
+
+	// after resetting the queue, there are no metrics to send and getting stats sets should error again:
+	queue.Reset()
+	_, err = queue.GetCPUStatsSet()
+	require.Error(t, err)
+	_, err = queue.GetMemoryStatsSet()
+	require.Error(t, err)
+	_, err = queue.GetStorageStatsSet()
+	require.Error(t, err)
+	_, err = queue.GetNetworkStatsSet()
+	require.Error(t, err)
+
+	// add single stat to queue and getting stats sets should succeed again:
+	queue.add(stats[4])
+	_, err = queue.GetCPUStatsSet()
+	require.NoError(t, err)
+	_, err = queue.GetMemoryStatsSet()
+	require.NoError(t, err)
+	_, err = queue.GetStorageStatsSet()
+	require.NoError(t, err)
+	_, err = queue.GetNetworkStatsSet()
+	require.NoError(t, err)
 }
 
 func TestQueueAddRemove(t *testing.T) {
@@ -175,113 +233,52 @@ func TestQueueAddRemove(t *testing.T) {
 	// Set predictableHighUtilization to false, expect random values when aggregated.
 	queue := createQueue(queueLength, false)
 	buf := queue.buffer
-	if len(buf) != queueLength {
-		t.Error("Buffer size is incorrect. Expected: 4, Got: ", len(buf))
-	}
+	require.Len(t, buf, queueLength, "Buffer size is incorrect.")
 
 	timestampsIndex := len(timestamps) - len(buf)
 	for i, stat := range buf {
 		if stat.Timestamp != timestamps[timestampsIndex+i] {
-			t.Error("Unexpected value for Stats element in buffer")
+			t.Errorf("Unexpected value for Stats element in buffer. expected %s got %s", timestamps[timestampsIndex+i], stat.Timestamp)
 		}
 	}
 
 	cpuStatsSet, err := queue.GetCPUStatsSet()
-	if err != nil {
-		t.Error("Error getting cpu stats set:", err)
-	}
-	if *cpuStatsSet.Min == math.MaxFloat64 || math.IsNaN(*cpuStatsSet.Min) {
-		t.Error("Min value incorrectly set: ", *cpuStatsSet.Min)
-	}
-	if *cpuStatsSet.Max == -math.MaxFloat64 || math.IsNaN(*cpuStatsSet.Max) {
-		t.Error("Max value incorrectly set: ", *cpuStatsSet.Max)
-	}
-	if *cpuStatsSet.SampleCount != int64(queueLength) {
-		t.Error("Expected samplecount: ", queueLength, " got: ", *cpuStatsSet.SampleCount)
-	}
-	if *cpuStatsSet.Sum == 0 {
-		t.Error("Sum value incorrectly set: ", *cpuStatsSet.Sum)
-	}
+	require.NoError(t, err)
+	require.NotEqual(t, math.MaxFloat64, *cpuStatsSet.Min)
+	require.NotEqual(t, math.NaN(), *cpuStatsSet.Min)
+	require.NotEqual(t, -math.MaxFloat64, *cpuStatsSet.Max)
+	require.NotEqual(t, math.NaN(), *cpuStatsSet.Max)
+	require.Equal(t, int64(queueLength), *cpuStatsSet.SampleCount)
+	require.Equal(t, int(554), int(*cpuStatsSet.Sum))
 
 	memStatsSet, err := queue.GetMemoryStatsSet()
-	if err != nil {
-		t.Error("Error getting memory stats set:", err)
-	}
-	if *memStatsSet.Min == math.MaxFloat64 || math.IsNaN(*memStatsSet.Min) {
-		t.Error("Min value incorrectly set: ", *memStatsSet.Min)
-	}
-	if *memStatsSet.Max == -math.MaxFloat64 || math.IsNaN(*memStatsSet.Max) {
-		t.Error("Max value incorrectly set: ", *memStatsSet.Max)
-	}
-	if *memStatsSet.SampleCount != int64(queueLength) {
-		t.Error("Expected samplecount: ", queueLength, " got: ", *memStatsSet.SampleCount)
-	}
-	if *memStatsSet.Sum == 0 {
-		t.Error("Sum value incorrectly set: ", *memStatsSet.Sum)
-	}
+	require.NoError(t, err)
+	require.NotEqual(t, math.MaxFloat64, *memStatsSet.Min)
+	require.NotEqual(t, math.NaN(), *memStatsSet.Min)
+	require.NotEqual(t, -math.MaxFloat64, *memStatsSet.Max)
+	require.NotEqual(t, math.NaN(), *memStatsSet.Max)
+	require.Equal(t, int64(queueLength), *memStatsSet.SampleCount)
+	require.Equal(t, int(12), int(*memStatsSet.Sum))
 
 	storageStatsSet, err := queue.GetStorageStatsSet()
-	if err != nil {
-		t.Error("Error getting storage stats set:", err)
-	}
+	require.NoError(t, err)
 	// assuming min is initialized to math.MaxUint64 then truncated
 	storageReadStatsSet := storageStatsSet.ReadSizeBytes
-	if *storageReadStatsSet.Min == int64(math.MaxInt64) &&
-		*storageReadStatsSet.OverflowMin == int64(math.MaxInt64) {
-		t.Error("Min value incorrectly set: ", *storageReadStatsSet.Min)
-	}
-	if *storageReadStatsSet.Max == 0 {
-		t.Error("Max value incorrectly set: ", *storageReadStatsSet.Max)
-	}
-	if *storageReadStatsSet.SampleCount != int64(queueLength) {
-		t.Error("Expected samplecount: ", queueLength, " got: ", *storageReadStatsSet.SampleCount)
-	}
-	if *storageReadStatsSet.Sum == 0 {
-		t.Error("Sum value incorrectly set: ", *storageReadStatsSet.Sum)
-	}
+	require.NotEqual(t, math.MaxInt64, *storageReadStatsSet.Min)
+	require.NotEqual(t, math.MaxInt64, *storageReadStatsSet.OverflowMin)
+	require.NotEqual(t, 0, *storageReadStatsSet.Max)
+	require.Equal(t, int64(queueLength), *storageReadStatsSet.SampleCount)
+	require.Equal(t, int64(12467777475), *storageReadStatsSet.Sum)
 
 	storageWriteStatsSet := storageStatsSet.WriteSizeBytes
-	if *storageWriteStatsSet.Min == int64(math.MaxInt64) {
-		t.Error("Min value incorrectly set: ", *storageWriteStatsSet.Min)
-	}
-	if *storageWriteStatsSet.Max == 0 {
-		t.Error("Max value incorrectly set: ", *storageWriteStatsSet.Max)
-	}
-	if *storageWriteStatsSet.SampleCount != int64(queueLength) {
-		t.Error("Expected samplecount: ", queueLength, " got: ", *storageWriteStatsSet.SampleCount)
-	}
-	if *storageWriteStatsSet.Sum == 0 {
-		t.Error("Sum value incorrectly set: ", *storageWriteStatsSet.Sum)
-	}
+	require.NotEqual(t, math.MaxInt64, *storageWriteStatsSet.Min)
+	require.NotEqual(t, 0, *storageWriteStatsSet.Max)
+	require.Equal(t, int64(queueLength), *storageWriteStatsSet.SampleCount)
+	require.Equal(t, int64(12467777475), *storageWriteStatsSet.Sum)
 
 	netStatsSet, err := queue.GetNetworkStatsSet()
-	assert.NoError(t, err, "error getting network stats set")
+	require.NoError(t, err, "error getting network stats set")
 	validateNetStatsSet(t, netStatsSet, queueLength)
-
-	rawUsageStats, err := queue.GetRawUsageStats(2 * queueLength)
-	if err != nil {
-		t.Error("Error getting raw usage stats: ", err)
-	}
-
-	if len(rawUsageStats) != queueLength {
-		t.Error("Expected to get ", queueLength, " raw usage stats. Got: ", len(rawUsageStats))
-	}
-
-	prevRawUsageStats := rawUsageStats[0]
-	for i := 1; i < queueLength; i++ {
-		curRawUsageStats := rawUsageStats[i]
-		if prevRawUsageStats.Timestamp.Before(curRawUsageStats.Timestamp) {
-			t.Error("Raw usage stats not ordered as expected, index: ", i, " prev stat: ", prevRawUsageStats.Timestamp, " current stat: ", curRawUsageStats.Timestamp)
-		}
-		prevRawUsageStats = curRawUsageStats
-	}
-
-	emptyQueue := NewQueue(queueLength)
-	rawUsageStats, err = emptyQueue.GetRawUsageStats(1)
-	if err == nil {
-		t.Error("Empty queue query did not throw an error")
-	}
-
 }
 
 func validateNetStatsSet(t *testing.T, netStats *ecstcs.NetworkStatsSet, queueLen int) {
@@ -354,9 +351,7 @@ func TestQueueAddPredictableHighMemoryUtilization(t *testing.T) {
 	// This lets us compare the computed values against pre-computed expected values
 	queue := createQueue(queueLength, true)
 	buf := queue.buffer
-	if len(buf) != queueLength {
-		t.Error("Buffer size is incorrect. Expected: 4, Got: ", len(buf))
-	}
+	require.Len(t, buf, queueLength, "Buffer size is incorrect.")
 
 	timestampsIndex := len(timestamps) - len(buf)
 	for i, stat := range buf {
@@ -373,20 +368,11 @@ func TestQueueAddPredictableHighMemoryUtilization(t *testing.T) {
 	// Test if both min and max for memory utilization are set to 7035MiB
 	// Also test if sum  == queue length * 7035
 	expectedMemoryUsageInMiB := float64(predictableHighMemoryUtilizationInMiB)
-	if *memStatsSet.Min != expectedMemoryUsageInMiB {
-		t.Errorf("Min value incorrectly set: %.0f, expected: %.0f", *memStatsSet.Min, expectedMemoryUsageInMiB)
-	}
-	if *memStatsSet.Max != expectedMemoryUsageInMiB {
-		t.Errorf("Max value incorrectly set: %.0f, expected: %.0f", *memStatsSet.Max, expectedMemoryUsageInMiB)
-	}
-	if *memStatsSet.SampleCount != int64(queueLength) {
-		t.Errorf("Incorrect samplecount, expected: %d got: %d", queueLength, *memStatsSet.SampleCount)
-	}
-
 	expectedMemoryUsageInMiBSum := expectedMemoryUsageInMiB * float64(queueLength)
-	if *memStatsSet.Sum != expectedMemoryUsageInMiBSum {
-		t.Errorf("Sum value incorrectly set: %.0f, expected %.0f", *memStatsSet.Sum, expectedMemoryUsageInMiBSum)
-	}
+	require.Equal(t, *memStatsSet.Min, expectedMemoryUsageInMiB)
+	require.Equal(t, *memStatsSet.Max, expectedMemoryUsageInMiB)
+	require.Equal(t, *memStatsSet.SampleCount, int64(queueLength))
+	require.Equal(t, *memStatsSet.Sum, expectedMemoryUsageInMiBSum)
 }
 
 // tests just below and just above the threshold (+/- 1) of int64
@@ -410,108 +396,32 @@ func TestUintOverflow(t *testing.T) {
 func TestCpuStatsSetNotSetToInfinity(t *testing.T) {
 	// timestamps will be used to simulate +Inf CPU Usage
 	// timestamps[0] = timestamps[1]
+	now := time.Now()
 	timestamps := []time.Time{
-		parseNanoTime("2015-02-12T21:22:05.131117533Z"),
-		parseNanoTime("2015-02-12T21:22:05.131117533Z"),
-		parseNanoTime("2015-02-12T21:22:05.333776335Z"),
+		now.Add(-time.Microsecond * 1000),
+		now.Add(-time.Microsecond * 1000),
+		now,
 	}
 	cpuTimes := []uint64{
-		22400432,
-		116499979,
-		248503503,
-	}
-	memoryUtilizationInBytes := []uint64{
-		3649536,
-		3649536,
-		3649536,
+		0,
+		10000000,
+		20000000,
 	}
 
 	// Create and add container stats
 	queueLength := 3
 	queue := NewQueue(queueLength)
 	for i, time := range timestamps {
-		queue.add(&ContainerStats{cpuUsage: cpuTimes[i], memoryUsage: memoryUtilizationInBytes[i], timestamp: time})
+		queue.add(&ContainerStats{cpuUsage: cpuTimes[i], memoryUsage: 1024, timestamp: time})
 	}
 	cpuStatsSet, err := queue.GetCPUStatsSet()
 	if err != nil {
 		t.Errorf("Error getting cpu stats set: %v", err)
 	}
-
-	// Compute expected usage by using the 1st and 2nd data point in the input queue
-	// queue.Add should have ignored the 0th item as it has the same timestamp as the
-	// 1st item
-	expectedCpuUsage := 100 * float32(cpuTimes[2]-cpuTimes[1]) / float32(timestamps[2].Nanosecond()-timestamps[1].Nanosecond())
-	max := float32(aws.Float64Value(cpuStatsSet.Max))
-	if max != expectedCpuUsage {
-		t.Errorf("Computed cpuStatsSet.Max (%f) != expected value (%f)", max, expectedCpuUsage)
-	}
-	sum := float32(aws.Float64Value(cpuStatsSet.Sum))
-	if sum != expectedCpuUsage {
-		t.Errorf("Computed cpuStatsSet.Sum (%f) != expected value (%f)", sum, expectedCpuUsage)
-	}
-	min := float32(aws.Float64Value(cpuStatsSet.Min))
-	if min != expectedCpuUsage {
-		t.Errorf("Computed cpuStatsSet.Min (%f) != expected value (%f)", min, expectedCpuUsage)
-	}
-
-	// Expected sample count is 1 and not 2 as one data point would be discarded on
-	// account of invalid timestamp
-	sampleCount := aws.Int64Value(cpuStatsSet.SampleCount)
-	if sampleCount != 1 {
-		t.Errorf("Computed cpuStatsSet.SampleCount (%d) != expected value (%d)", sampleCount, 1)
-	}
-}
-
-func TestResetThresholdElapsed(t *testing.T) {
-	// create a queue
-	queueLength := 3
-	queue := NewQueue(queueLength)
-
-	queue.Reset()
-
-	thresholdElapsed := queue.resetThresholdElapsed(2 * time.Millisecond)
-	assert.False(t, thresholdElapsed, "Queue reset threshold is not expected to elapse right after reset")
-
-	time.Sleep(3 * time.Millisecond)
-	thresholdElapsed = queue.resetThresholdElapsed(2 * time.Millisecond)
-
-	assert.True(t, thresholdElapsed, "Queue reset threshold is expected to elapse after waiting")
-}
-
-func TestEnoughDatapointsInBuffer(t *testing.T) {
-	// timestamps will be used to simulate +Inf CPU Usage
-	// timestamps[0] = timestamps[1]
-	timestamps := []time.Time{
-		parseNanoTime("2015-02-12T21:22:05.131117533Z"),
-		parseNanoTime("2015-02-12T21:22:05.131117533Z"),
-		parseNanoTime("2015-02-12T21:22:05.333776335Z"),
-	}
-	cpuTimes := []uint64{
-		22400432,
-		116499979,
-		248503503,
-	}
-	memoryUtilizationInBytes := []uint64{
-		3649536,
-		3649536,
-		3649536,
-	}
-	// create a queue
-	queueLength := 3
-	queue := NewQueue(queueLength)
-
-	enoughDataPoints := queue.enoughDatapointsInBuffer()
-	assert.False(t, enoughDataPoints, "Queue is expected to not have enough data points right after creation")
-	for i, time := range timestamps {
-		queue.add(&ContainerStats{cpuUsage: cpuTimes[i], memoryUsage: memoryUtilizationInBytes[i], timestamp: time})
-	}
-
-	enoughDataPoints = queue.enoughDatapointsInBuffer()
-	assert.True(t, enoughDataPoints, "Queue is expected to have enough data points when it has more than 2 msgs queued")
-
-	queue.Reset()
-	enoughDataPoints = queue.enoughDatapointsInBuffer()
-	assert.False(t, enoughDataPoints, "Queue is expected to not have enough data points right after RESET")
+	require.Equal(t, float64(1000), *cpuStatsSet.Max)
+	require.Equal(t, float64(1000), *cpuStatsSet.Min)
+	require.Equal(t, float64(1000), *cpuStatsSet.Sum)
+	require.Equal(t, int64(1), *cpuStatsSet.SampleCount)
 }
 
 func TestCPUStatSetFailsWhenSampleCountIsZero(t *testing.T) {
@@ -542,11 +452,12 @@ func TestCPUStatSetFailsWhenSampleCountIsZero(t *testing.T) {
 }
 
 func TestCPUStatsWithIdenticalTimestampsGetSameUsagePercent(t *testing.T) {
+	now := time.Now()
 	timestamps := []time.Time{
-		parseNanoTime("2015-02-12T21:22:05.131117000Z"),
-		parseNanoTime("2015-02-12T21:22:05.131117001Z"),
-		parseNanoTime("2015-02-12T21:22:05.131117002Z"),
-		parseNanoTime("2015-02-12T21:22:05.131117002Z"),
+		now.Add(-time.Nanosecond * 2),
+		now.Add(-time.Nanosecond * 1),
+		now,
+		now,
 	}
 	cpuTimes := []uint64{
 		0,
@@ -554,17 +465,12 @@ func TestCPUStatsWithIdenticalTimestampsGetSameUsagePercent(t *testing.T) {
 		3,
 		4,
 	}
-	memoryUtilizationInBytes := []uint64{
-		3649536,
-		3649536,
-		3649536,
-		3649536,
-	}
+
 	// create a queue
 	queue := NewQueue(4)
 
 	for i, time := range timestamps {
-		queue.add(&ContainerStats{cpuUsage: cpuTimes[i], memoryUsage: memoryUtilizationInBytes[i], timestamp: time})
+		queue.add(&ContainerStats{cpuUsage: cpuTimes[i], memoryUsage: 3649536, timestamp: time})
 	}
 
 	// if there were three cpu metrics, and two had identical timestamps,
@@ -579,26 +485,22 @@ func TestCPUStatsWithIdenticalTimestampsGetSameUsagePercent(t *testing.T) {
 }
 
 func TestHugeCPUUsagePercentDoesntGetCapped(t *testing.T) {
+	now := time.Now()
 	timestamps := []time.Time{
-		parseNanoTime("2015-02-12T21:22:05.131117000Z"),
-		parseNanoTime("2015-02-12T21:22:05.131117001Z"),
-		parseNanoTime("2015-02-12T21:22:05.131117002Z"),
+		now.Add(-time.Nanosecond * 2),
+		now.Add(-time.Nanosecond * 1),
+		now,
 	}
 	cpuTimes := []uint64{
 		0,
 		1,
 		300000000,
 	}
-	memoryUtilizationInBytes := []uint64{
-		3649536,
-		3649536,
-		3649536,
-	}
 	// create a queue
 	queue := NewQueue(4)
 
 	for i, time := range timestamps {
-		queue.add(&ContainerStats{cpuUsage: cpuTimes[i], memoryUsage: memoryUtilizationInBytes[i], timestamp: time})
+		queue.add(&ContainerStats{cpuUsage: cpuTimes[i], memoryUsage: 3649536, timestamp: time})
 	}
 
 	statSet, err := queue.GetCPUStatsSet()

--- a/agent/stats/types.go
+++ b/agent/stats/types.go
@@ -18,6 +18,7 @@ import (
 
 	"context"
 
+	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	"github.com/aws/amazon-ecs-agent/agent/stats/resolver"
 )
@@ -53,6 +54,8 @@ type UsageStats struct {
 	NetworkStats      *NetworkStats `json:"networkStats"`
 	Timestamp         time.Time     `json:"timestamp"`
 	cpuUsage          uint64
+	// sent indicates if the stat has been sent to TACS already.
+	sent bool
 }
 
 // ContainerMetadata contains meta-data information for a container.
@@ -70,6 +73,7 @@ type StatsContainer struct {
 	client            dockerapi.DockerClient
 	statsQueue        *Queue
 	resolver          resolver.ContainerMetadataResolver
+	config            *config.Config
 }
 
 // taskDefinition encapsulates family and version strings for a task definition

--- a/agent/tcs/client/client.go
+++ b/agent/tcs/client/client.go
@@ -153,13 +153,6 @@ func (cs *clientServer) publishMetrics() {
 		return
 	}
 
-	// Publish metrics immediately after we connect and wait for ticks. This makes
-	// sure that there is no data loss when a scheduled metrics publishing fails
-	// due to a connection reset.
-	err := cs.publishMetricsOnce()
-	if err != nil && err != stats.EmptyMetricsError {
-		seelog.Warnf("Error publishing metrics: %v", err)
-	}
 	// don't simply range over the ticker since its channel doesn't ever get closed
 	for {
 		select {

--- a/agent/tcs/handler/handler.go
+++ b/agent/tcs/handler/handler.go
@@ -33,10 +33,6 @@ import (
 )
 
 const (
-	// defaultPublishMetricsInterval is the interval at which utilization
-	// metrics from stats engine are published to the backend.
-	defaultPublishMetricsInterval = 20 * time.Second
-
 	// The maximum time to wait between heartbeats without disconnecting
 	defaultHeartbeatTimeout = 1 * time.Minute
 	defaultHeartbeatJitter  = 1 * time.Minute
@@ -103,7 +99,7 @@ func startTelemetrySession(params *TelemetrySessionParams, statsEngine stats.Eng
 	}
 	url := formatURL(tcsEndpoint, params.Cfg.Cluster, params.ContainerInstanceArn, params.TaskEngine)
 	return startSession(url, params.Cfg, params.CredentialProvider, statsEngine,
-		defaultHeartbeatTimeout, defaultHeartbeatJitter, defaultPublishMetricsInterval,
+		defaultHeartbeatTimeout, defaultHeartbeatJitter, config.DefaultContainerMetricsPublishInterval,
 		params.DeregisterInstanceEventStream)
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This changes our stats queue behavior. Currently we build up docker stats in a buffer, and every 20s we aggregate them, publish them to ECS backend, and then clear the buffer.

This changes to never clearing the buffer (though we set a limit on the max size of the queue). The main reason for this is so that we can still publish metrics to ECS backend with only a single docker stat collected within one publishing interval (20s).

Currently if we only had one docker stat we would have nothing to compare it to and thus wouldnt be able to calculate CPU usage. With this change we can compare it to a stat from the previous ECS backend publish interval.

This means that users will still get metrics in cloudwatch even when docker is returning stats very slowly, or when they've configured polling metrics, and are only collecting one stat per interval (ie, ECS_POLLING_METRICS_WAIT_DURATION is set to anything greater than 10s).

Have also done some cleanup and changed the queue size to be calculated based on the size of the polling interval.

### Testing

All the regular test suites and tested manually on an instance with hundreds of tasks.

Metrics in cloudwatch were verified to be consistent before and after making this change.

Memory usage was tested because of changes to the queue size and clearing behavior. When streaming stats, there was a slight increase in memory usage but it was negligible (on the order of 30MiB on this PR, and 28 MiB on dev branch). When polling for stats there was no difference in memory usage.

New tests cover the changes: no


### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
