### PR TITLE
integ tests: port forwarding

### DIFF
--- a/agent/engine/common_test.go
+++ b/agent/engine/common_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"reflect"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -48,7 +49,15 @@ const (
 
 var (
 	defaultDockerClientAPIVersion = dockerclient.Version_1_17
+	// some unassigned ports to use for tests
+	// see https://www.speedguide.net/port.php?port=24685
+	unassignedPort int32 = 24685
 )
+
+// getUnassignedPort returns a NEW unassigned port each time it's called.
+func getUnassignedPort() uint16 {
+	return uint16(atomic.AddInt32(&unassignedPort, 1))
+}
 
 func discardEvents(from interface{}) func() {
 	done := make(chan bool)

--- a/agent/engine/engine_integ_test.go
+++ b/agent/engine/engine_integ_test.go
@@ -47,8 +47,6 @@ import (
 const (
 	testDockerStopTimeout  = 5 * time.Second
 	credentialsIDIntegTest = "credsid"
-	containerPortOne       = 24751
-	containerPortTwo       = 24752
 	serverContent          = "ecs test container"
 	dialTimeout            = 200 * time.Millisecond
 	localhost              = "127.0.0.1"


### PR DESCRIPTION
always verify that the task is stopped at the end of every test, in case
unrelated state change events are received that may trigger a test to
exit before it has been cleaned up.

also get a new port for each test to avoid potential collisions.
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
