### PR TITLE
Close unclosed response bodies

### DIFF
--- a/agent/app/healthcheck.go
+++ b/agent/app/healthcheck.go
@@ -26,15 +26,16 @@ func runHealthcheck(url string, timeout time.Duration) int {
 	client := &http.Client{
 		Timeout: timeout,
 	}
-	r, err := http.NewRequest("GET", url, nil)
+	r, err := http.NewRequest("HEAD", url, nil)
 	if err != nil {
 		seelog.Errorf("error creating healthcheck request: %v", err)
 		return exitcodes.ExitError
 	}
-	_, err = client.Do(r)
+	resp, err := client.Do(r)
 	if err != nil {
-		seelog.Errorf("health check [GET %s] failed with error: %v", url, err)
+		seelog.Errorf("health check [HEAD %s] failed with error: %v", url, err)
 		return exitcodes.ExitError
 	}
+	resp.Body.Close()
 	return exitcodes.ExitSuccess
 }

--- a/agent/app/healthcheck_test.go
+++ b/agent/app/healthcheck_test.go
@@ -62,3 +62,16 @@ func TestHealthcheck_404(t *testing.T) {
 	rc := runHealthcheck(ts.URL+"/foobar", time.Second*2)
 	require.Equal(t, 0, rc)
 }
+
+var brc int
+
+func BenchmarkHealthcheck(b *testing.B) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "hello")
+	}))
+	defer ts.Close()
+
+	for n := 0; n < b.N; n++ {
+		brc = runHealthcheck(ts.URL, time.Second*1)
+	}
+}

--- a/agent/dockerclient/dockerapi/docker_client.go
+++ b/agent/dockerclient/dockerapi/docker_client.go
@@ -1408,6 +1408,7 @@ func getContainerStatsNotStreamed(client sdkclient.Client, ctx context.Context, 
 	if err != nil {
 		return nil, fmt.Errorf("DockerGoClient: Unable to retrieve stats for container %s: %v", id, err)
 	}
+	defer resp.Body.Close()
 
 	decoder := json.NewDecoder(resp.Body)
 	stats := &types.StatsJSON{}


### PR DESCRIPTION
These response bodies need to be closed in order to reuse the underlying
tcp connections in Go.

I have also changed the healthcheck GET request to a HEAD request
because it doesn't have any use for the data contained in the GET, so
might as well not get it in the first place.

wrote a small benchmark test to show the improvement in time and
allocations with this change:

dev branch:
```
$ go test ./agent/app/. -bench=Healthcheck -benchmem
goos: darwin
goarch: amd64
pkg: github.com/aws/amazon-ecs-agent/agent/app
BenchmarkHealthcheck-4              3280            782405 ns/op           16996 B/op        119 allocs/op
PASS
ok      github.com/aws/amazon-ecs-agent/agent/app       5.393s
```

this branch:
```
$ go test ./agent/app/. -bench=Healthcheck -benchmem
goos: darwin
goarch: amd64
pkg: github.com/aws/amazon-ecs-agent/agent/app
BenchmarkHealthcheck-4             15004             75400 ns/op            4303 B/op         55 allocs/op
PASS
ok      github.com/aws/amazon-ecs-agent/agent/app       3.980s
```


### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
