### PR TITLE
Fix agent top-level context

### DIFF
--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -94,6 +94,7 @@ type agent interface {
 // the newAgent() method
 type ecsAgent struct {
 	ctx                         context.Context
+	cancel                      context.CancelFunc
 	ec2MetadataClient           ec2.EC2MetadataClient
 	ec2Client                   ec2.Client
 	cfg                         *config.Config
@@ -117,11 +118,8 @@ type ecsAgent struct {
 }
 
 // newAgent returns a new ecsAgent object, but does not start anything
-func newAgent(
-	ctx context.Context,
-	blackholeEC2Metadata bool,
-	acceptInsecureCert *bool) (agent, error) {
-
+func newAgent(blackholeEC2Metadata bool, acceptInsecureCert *bool) (agent, error) {
+	ctx, cancel := context.WithCancel(context.Background())
 	ec2MetadataClient := ec2.NewEC2MetadataClient(nil)
 	if blackholeEC2Metadata {
 		ec2MetadataClient = ec2.NewBlackholeEC2MetadataClient()
@@ -133,6 +131,7 @@ func newAgent(
 		// All required config values can be inferred from EC2 Metadata,
 		// so this error could be transient.
 		seelog.Criticalf("Error loading config: %v", err)
+		cancel()
 		return nil, err
 	}
 	cfg.AcceptInsecureCert = aws.BoolValue(acceptInsecureCert)
@@ -148,6 +147,7 @@ func newAgent(
 	if err != nil {
 		// This is also non terminal in the current config
 		seelog.Criticalf("Error creating Docker client: %v", err)
+		cancel()
 		return nil, err
 	}
 
@@ -162,6 +162,7 @@ func newAgent(
 	initialSeqNumber := int64(-1)
 	return &ecsAgent{
 		ctx:               ctx,
+		cancel:            cancel,
 		ec2MetadataClient: ec2MetadataClient,
 		ec2Client:         ec2Client,
 		cfg:               cfg,
@@ -616,26 +617,26 @@ func (agent *ecsAgent) startAsyncRoutines(
 
 	// Start automatic spot instance draining poller routine
 	if agent.cfg.SpotInstanceDrainingEnabled {
-		go agent.startSpotInstanceDrainingPoller(client)
+		go agent.startSpotInstanceDrainingPoller(agent.ctx, client)
 	}
 
-	go agent.terminationHandler(stateManager, taskEngine)
+	go agent.terminationHandler(stateManager, taskEngine, agent.cancel)
 
 	// Agent introspection api
-	go handlers.ServeIntrospectionHTTPEndpoint(&agent.containerInstanceARN, taskEngine, agent.cfg)
+	go handlers.ServeIntrospectionHTTPEndpoint(agent.ctx, &agent.containerInstanceARN, taskEngine, agent.cfg)
 
 	statsEngine := stats.NewDockerStatsEngine(agent.cfg, agent.dockerClient, containerChangeEventStream)
 
 	// Start serving the endpoint to fetch IAM Role credentials and other task metadata
 	if agent.cfg.TaskMetadataAZDisabled {
 		// send empty availability zone
-		go handlers.ServeTaskHTTPEndpoint(credentialsManager, state, client, agent.containerInstanceARN, agent.cfg, statsEngine, "")
+		go handlers.ServeTaskHTTPEndpoint(agent.ctx, credentialsManager, state, client, agent.containerInstanceARN, agent.cfg, statsEngine, "")
 	} else {
-		go handlers.ServeTaskHTTPEndpoint(credentialsManager, state, client, agent.containerInstanceARN, agent.cfg, statsEngine, agent.availabilityZone)
+		go handlers.ServeTaskHTTPEndpoint(agent.ctx, credentialsManager, state, client, agent.containerInstanceARN, agent.cfg, statsEngine, agent.availabilityZone)
 	}
 
 	// Start sending events to the backend
-	go eventhandler.HandleEngineEvents(taskEngine, client, taskHandler, attachmentEventHandler)
+	go eventhandler.HandleEngineEvents(agent.ctx, taskEngine, client, taskHandler, attachmentEventHandler)
 
 	telemetrySessionParams := tcshandler.TelemetrySessionParams{
 		Ctx:                           agent.ctx,
@@ -652,9 +653,14 @@ func (agent *ecsAgent) startAsyncRoutines(
 	go tcshandler.StartMetricsSession(&telemetrySessionParams)
 }
 
-func (agent *ecsAgent) startSpotInstanceDrainingPoller(client api.ECSClient) {
+func (agent *ecsAgent) startSpotInstanceDrainingPoller(ctx context.Context, client api.ECSClient) {
 	for !agent.spotInstanceDrainingPoller(client) {
-		time.Sleep(time.Second)
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			time.Sleep(time.Second)
+		}
 	}
 }
 
@@ -725,8 +731,7 @@ func (agent *ecsAgent) startACSSession(
 		seelog.Criticalf("Unretriable error starting communicating with ACS: %v", err)
 		return exitcodes.ExitTerminal
 	}
-	seelog.Critical("ACS Session handler should never exit")
-	return exitcodes.ExitError
+	return exitcodes.ExitSuccess
 }
 
 // validateRequiredVersion validates docker version.

--- a/agent/app/agent_integ_test.go
+++ b/agent/app/agent_integ_test.go
@@ -15,7 +15,6 @@
 package app
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -25,11 +24,10 @@ import (
 )
 
 func TestNewAgent(t *testing.T) {
-	ctx := context.TODO()
 	os.Setenv("AWS_DEFAULT_REGION", "us-west-2")
 	defer os.Unsetenv("AWS_DEFAULT_REGION")
 
-	agent, err := newAgent(ctx, true, aws.Bool(true))
+	agent, err := newAgent(true, aws.Bool(true))
 
 	assert.NoError(t, err)
 	// printECSAttributes should ensure that agent's cfg is set with

--- a/agent/app/agent_test.go
+++ b/agent/app/agent_test.go
@@ -391,7 +391,7 @@ func TestDoStartRegisterAvailabilityZone(t *testing.T) {
 		credentialProvider: aws_credentials.NewCredentials(mockCredentialsProvider),
 		mobyPlugins:        mockMobyPlugins,
 		metadataManager:    containermetadata,
-		terminationHandler: func(saver statemanager.Saver, taskEngine engine.TaskEngine) {},
+		terminationHandler: func(saver statemanager.Saver, taskEngine engine.TaskEngine, cancel context.CancelFunc) {},
 		ec2MetadataClient:  ec2MetadataClient,
 	}
 

--- a/agent/app/agent_unix_test.go
+++ b/agent/app/agent_unix_test.go
@@ -113,7 +113,7 @@ func TestDoStartHappyPath(t *testing.T) {
 		credentialProvider: credentials.NewCredentials(mockCredentialsProvider),
 		dockerClient:       dockerClient,
 		pauseLoader:        mockPauseLoader,
-		terminationHandler: func(saver statemanager.Saver, taskEngine engine.TaskEngine) {},
+		terminationHandler: func(saver statemanager.Saver, taskEngine engine.TaskEngine, cancel context.CancelFunc) {},
 		mobyPlugins:        mockMobyPlugins,
 		ec2MetadataClient:  ec2MetadataClient,
 	}
@@ -234,7 +234,7 @@ func TestDoStartTaskENIHappyPath(t *testing.T) {
 		cniClient:          cniClient,
 		os:                 mockOS,
 		ec2MetadataClient:  mockMetadata,
-		terminationHandler: func(saver statemanager.Saver, taskEngine engine.TaskEngine) {},
+		terminationHandler: func(saver statemanager.Saver, taskEngine engine.TaskEngine, cancel context.CancelFunc) {},
 		mobyPlugins:        mockMobyPlugins,
 	}
 
@@ -537,7 +537,7 @@ func TestDoStartCgroupInitHappyPath(t *testing.T) {
 		credentialProvider: credentials.NewCredentials(mockCredentialsProvider),
 		pauseLoader:        mockPauseLoader,
 		dockerClient:       dockerClient,
-		terminationHandler: func(saver statemanager.Saver, taskEngine engine.TaskEngine) {},
+		terminationHandler: func(saver statemanager.Saver, taskEngine engine.TaskEngine, cancel context.CancelFunc) {},
 		mobyPlugins:        mockMobyPlugins,
 		ec2MetadataClient:  ec2MetadataClient,
 		resourceFields: &taskresource.ResourceFields{
@@ -594,7 +594,7 @@ func TestDoStartCgroupInitErrorPath(t *testing.T) {
 		credentialProvider: credentials.NewCredentials(mockCredentialsProvider),
 		dockerClient:       dockerClient,
 		pauseLoader:        mockPauseLoader,
-		terminationHandler: func(saver statemanager.Saver, taskEngine engine.TaskEngine) {},
+		terminationHandler: func(saver statemanager.Saver, taskEngine engine.TaskEngine, cancel context.CancelFunc) {},
 		resourceFields: &taskresource.ResourceFields{
 			Control: mockControl,
 		},
@@ -684,7 +684,7 @@ func TestDoStartGPUManagerHappyPath(t *testing.T) {
 		credentialProvider: credentials.NewCredentials(mockCredentialsProvider),
 		dockerClient:       dockerClient,
 		pauseLoader:        mockPauseLoader,
-		terminationHandler: func(saver statemanager.Saver, taskEngine engine.TaskEngine) {},
+		terminationHandler: func(saver statemanager.Saver, taskEngine engine.TaskEngine, cancel context.CancelFunc) {},
 		mobyPlugins:        mockMobyPlugins,
 		ec2MetadataClient:  ec2MetadataClient,
 		resourceFields: &taskresource.ResourceFields{
@@ -739,7 +739,7 @@ func TestDoStartGPUManagerInitError(t *testing.T) {
 		credentialProvider: credentials.NewCredentials(mockCredentialsProvider),
 		dockerClient:       dockerClient,
 		pauseLoader:        mockPauseLoader,
-		terminationHandler: func(saver statemanager.Saver, taskEngine engine.TaskEngine) {},
+		terminationHandler: func(saver statemanager.Saver, taskEngine engine.TaskEngine, cancel context.CancelFunc) {},
 		resourceFields: &taskresource.ResourceFields{
 			NvidiaGPUManager: mockGPUManager,
 		},
@@ -789,7 +789,7 @@ func TestDoStartTaskENIPauseError(t *testing.T) {
 		cniClient:          cniClient,
 		os:                 mockOS,
 		ec2MetadataClient:  mockMetadata,
-		terminationHandler: func(saver statemanager.Saver, taskEngine engine.TaskEngine) {},
+		terminationHandler: func(saver statemanager.Saver, taskEngine engine.TaskEngine, cancel context.CancelFunc) {},
 		mobyPlugins:        mockMobyPlugins,
 	}
 

--- a/agent/app/agent_windows.go
+++ b/agent/app/agent_windows.go
@@ -154,7 +154,7 @@ func (h *handler) runAgent(ctx context.Context) uint32 {
 	agentCtx, cancel := context.WithCancel(ctx)
 	indicator := newTermHandlerIndicator()
 
-	terminationHandler := func(saver statemanager.Saver, taskEngine engine.TaskEngine) {
+	terminationHandler := func(saver statemanager.Saver, taskEngine engine.TaskEngine, cancel context.CancelFunc) {
 		// We're using a custom indicator to record that the handler is scheduled to be executed (has been invoked) and
 		// to determine whether it should run (we skip when the agent engine has already exited).  After recording to
 		// the indicator that the handler has been invoked, we wait on the context.  When we wake up, we determine

--- a/agent/app/agent_windows_test.go
+++ b/agent/app/agent_windows_test.go
@@ -105,16 +105,16 @@ func TestHandler_RunAgent_ForceSaveWithTerminationHandler(t *testing.T) {
 
 	agent := &mockAgent{}
 
+	ctx, cancel := context.WithCancel(context.TODO())
 	done := make(chan struct{})
 	defer func() { done <- struct{}{} }()
 	startFunc := func() int {
-		go agent.terminationHandler(stateManager, taskEngine)
+		go agent.terminationHandler(stateManager, taskEngine, cancel)
 		<-done // block until after the test ends so that we can test that runAgent returns when cancelled
 		return 0
 	}
 	agent.startFunc = startFunc
 	handler := &handler{agent}
-	ctx, cancel := context.WithCancel(context.TODO())
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
@@ -200,10 +200,11 @@ func TestHandler_Execute_WindowsStops(t *testing.T) {
 
 	agent := &mockAgent{}
 
+	_, cancel := context.WithCancel(context.TODO())
 	done := make(chan struct{})
 	defer func() { done <- struct{}{} }()
 	startFunc := func() int {
-		go agent.terminationHandler(stateManager, taskEngine)
+		go agent.terminationHandler(stateManager, taskEngine, cancel)
 		<-done // block until after the test ends so that we can test that Execute returns when Stopped
 		return 0
 	}

--- a/agent/app/run.go
+++ b/agent/app/run.go
@@ -14,7 +14,6 @@
 package app
 
 import (
-	"context"
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/app/args"
@@ -50,9 +49,7 @@ func Run(arguments []string) int {
 	logger.SetLevel(*parsedArgs.LogLevel)
 
 	// Create an Agent object
-	agent, err := newAgent(context.Background(),
-		aws.BoolValue(parsedArgs.BlackholeEC2Metadata),
-		parsedArgs.AcceptInsecureCert)
+	agent, err := newAgent(aws.BoolValue(parsedArgs.BlackholeEC2Metadata), parsedArgs.AcceptInsecureCert)
 	if err != nil {
 		// Failure to initialize either the docker client or the EC2 metadata
 		// service client are non terminal errors as they could be transient

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -233,10 +233,8 @@ func (engine *DockerTaskEngine) MarshalJSON() ([]byte, error) {
 // and operate normally.
 // This function must be called before any other function, except serializing and deserializing, can succeed without error.
 func (engine *DockerTaskEngine) Init(ctx context.Context) error {
-	// TODO, pass in a a context from main from background so that other things can stop us, not just the tests
 	derivedCtx, cancel := context.WithCancel(ctx)
 	engine.stopEngine = cancel
-
 	engine.ctx = derivedCtx
 
 	// Open the event stream before we sync state so that e.g. if a container

--- a/agent/eventhandler/handler.go
+++ b/agent/eventhandler/handler.go
@@ -14,6 +14,7 @@
 package eventhandler
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
@@ -24,13 +25,20 @@ import (
 
 // HandleEngineEvents handles state change events from the state change event channel by sending it to
 // responsible event handler
-func HandleEngineEvents(taskEngine engine.TaskEngine, client api.ECSClient, taskHandler *TaskHandler,
+func HandleEngineEvents(
+	ctx context.Context,
+	taskEngine engine.TaskEngine,
+	client api.ECSClient,
+	taskHandler *TaskHandler,
 	attachmentEventHandler *AttachmentEventHandler) {
 	for {
 		stateChangeEvents := taskEngine.StateChangeEvents()
 
 		for stateChangeEvents != nil {
 			select {
+			case <-ctx.Done():
+				seelog.Infof("Exiting the engine event handler.")
+				return
 			case event, ok := <-stateChangeEvents:
 				if !ok {
 					stateChangeEvents = nil

--- a/agent/sighandlers/termination_handler.go
+++ b/agent/sighandlers/termination_handler.go
@@ -19,6 +19,7 @@
 package sighandlers
 
 import (
+	"context"
 	"errors"
 	"os"
 	"os/signal"
@@ -27,7 +28,6 @@ import (
 
 	apierrors "github.com/aws/amazon-ecs-agent/agent/api/errors"
 	"github.com/aws/amazon-ecs-agent/agent/engine"
-	"github.com/aws/amazon-ecs-agent/agent/sighandlers/exitcodes"
 	"github.com/aws/amazon-ecs-agent/agent/statemanager"
 
 	"github.com/cihub/seelog"
@@ -39,23 +39,23 @@ const (
 )
 
 // TerminationHandler defines a handler used for terminating the agent
-type TerminationHandler func(saver statemanager.Saver, taskEngine engine.TaskEngine)
+type TerminationHandler func(saver statemanager.Saver, taskEngine engine.TaskEngine, cancel context.CancelFunc)
 
 // StartDefaultTerminationHandler defines a default termination handler suitable for running in a process
-func StartDefaultTerminationHandler(saver statemanager.Saver, taskEngine engine.TaskEngine) {
-	signalChannel := make(chan os.Signal, 2)
-	signal.Notify(signalChannel, os.Interrupt, syscall.SIGTERM)
+func StartDefaultTerminationHandler(saver statemanager.Saver, taskEngine engine.TaskEngine, cancel context.CancelFunc) {
+	// when we receive a termination signal, first save the state, then
+	// cancel the agent's context so other goroutines can exit cleanly.
+	signalC := make(chan os.Signal, 2)
+	signal.Notify(signalC, os.Interrupt, syscall.SIGTERM)
 
-	sig := <-signalChannel
-	seelog.Debugf("Termination handler received termination signal: %s", sig.String())
+	sig := <-signalC
+	seelog.Infof("Agent received termination signal: %s", sig.String())
+	cancel()
 
 	err := FinalSave(saver, taskEngine)
 	if err != nil {
 		seelog.Criticalf("Error saving state before final shutdown: %v", err)
-		// Terminal because it's a sigterm; the user doesn't want it to restart
-		os.Exit(exitcodes.ExitTerminal)
 	}
-	os.Exit(exitcodes.ExitSuccess)
 }
 
 // FinalSave should be called immediately before exiting, and only before

--- a/agent/tcs/handler/handler_test.go
+++ b/agent/tcs/handler/handler_test.go
@@ -133,7 +133,7 @@ func TestStartSession(t *testing.T) {
 
 	deregisterInstanceEventStream := eventstream.NewEventStream("Deregister_Instance", context.Background())
 	// Start a session with the test server.
-	go startSession(server.URL, testCfg, testCreds, &mockStatsEngine{},
+	go startSession(ctx, server.URL, testCfg, testCreds, &mockStatsEngine{},
 		defaultHeartbeatTimeout, defaultHeartbeatJitter,
 		testPublishMetricsInterval, deregisterInstanceEventStream)
 
@@ -197,7 +197,7 @@ func TestSessionConnectionClosedByRemote(t *testing.T) {
 	defer cancel()
 
 	// Start a session with the test server.
-	err = startSession(server.URL, testCfg, testCreds, &mockStatsEngine{},
+	err = startSession(ctx, server.URL, testCfg, testCreds, &mockStatsEngine{},
 		defaultHeartbeatTimeout, defaultHeartbeatJitter,
 		testPublishMetricsInterval, deregisterInstanceEventStream)
 
@@ -234,11 +234,11 @@ func TestConnectionInactiveTimeout(t *testing.T) {
 	deregisterInstanceEventStream.StartListening()
 	defer cancel()
 	// Start a session with the test server.
-	err = startSession(server.URL, testCfg, testCreds, &mockStatsEngine{},
+	err = startSession(ctx, server.URL, testCfg, testCreds, &mockStatsEngine{},
 		50*time.Millisecond, 100*time.Millisecond,
 		testPublishMetricsInterval, deregisterInstanceEventStream)
 	// if we are not blocked here, then the test pass as it will reconnect in StartSession
-	assert.Error(t, err, "Close the connection should cause the tcs client return error")
+	assert.NoError(t, err, "Close the connection should cause the tcs client return error")
 
 	assert.True(t, websocket.IsCloseError(<-serverErr, websocket.CloseAbnormalClosure),
 		"Read from closed connection should produce an io.EOF error")


### PR DESCRIPTION
When we create a new agent, we add a background context to the top-level object.
This context never exits, cancels, or times out.
There are some places in our code, however, that reference this context as if expecting it to exit cleanly.

this change fixes this by:
1. when creating the context, create it with a cancel function and add
this to the agent object.
2. pass this cancel function into the agent signal handler, so that the
context is cancelled when we receive a shutdown signal.
3. audit some of our async goroutines and other code that relied on the
agent context to make sure it was waiting/exiting properly.
4. pass agent context into some goroutines that were not previously
waiting on it, but should be.

agent logs on stop before this change:
```
level=info time=2020-05-20T18:49:49Z msg="Saving state!" module=state_manager.go
```

agent logs on stop after this change:
```
level=info time=2020-05-20T21:43:39Z msg="Agent received termination signal: terminated" module=termination_handler.go
level=info time=2020-05-20T21:43:39Z msg="Saving state!" module=state_manager.go
level=info time=2020-05-20T21:43:39Z msg="Exiting the engine event handler." module=handler.go
level=info time=2020-05-20T21:43:39Z msg="TaskHandler: Stopping periodic container state change submission ticker" module=task_handler.go
level=info time=2020-05-20T21:43:39Z msg="TCS Websocket connection closed for a valid reason" module=handler.go
level=info time=2020-05-20T21:43:39Z msg="TCS session exited cleanly." module=handler.go
level=info time=2020-05-20T21:43:39Z msg="Event stream DeregisterContainerInstance stopped listening..." module=eventstream.go
level=info time=2020-05-20T21:43:39Z msg="Event stream ContainerChange stopped listening..." module=eventstream.go
level=info time=2020-05-20T21:43:39Z msg="Stopping udev event handler" module=watcher_linux.go
level=info time=2020-05-20T21:43:39Z msg="ACS session exited cleanly." module=acs_handler.go
```

task and container managers will also exit when running tasks, resulting in logs like this:
```
level=info time=2020-05-26T22:08:11Z msg="Managed task [arn:aws:ecs:us-east-1:XXXX:task/XXXX]: agent task manager exiting." module=task_manager.go
level=info time=2020-05-26T22:08:11Z msg="Container [XXXX]: Stopping stats collection" module=container.go
```

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Testing

This was tested with the race detector while running 0, 50, and 250 tasks on a single instance.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
