### PR TITLE
Integ test fixups

### DIFF
--- a/agent/engine/docker_image_manager_integ_test.go
+++ b/agent/engine/docker_image_manager_integ_test.go
@@ -18,7 +18,6 @@
 package engine
 
 import (
-	"container/list"
 	"context"
 	"errors"
 	"fmt"
@@ -632,29 +631,29 @@ func verifyTaskIsCleanedUp(taskName string, taskEngine TaskEngine) error {
 }
 
 func verifyImagesAreRemoved(imageManager *dockerImageManager, imageIDs ...string) error {
-	imagesNotRemovedList := list.New()
+	imagesNotRemovedList := []string{}
 	for _, imageID := range imageIDs {
-		_, ok := imageManager.getImageState(imageID)
+		imageState, ok := imageManager.getImageState(imageID)
 		if ok {
-			imagesNotRemovedList.PushFront(imageID)
+			imagesNotRemovedList = append(imagesNotRemovedList, imageState.Image.String())
 		}
 	}
-	if imagesNotRemovedList.Len() > 0 {
-		return fmt.Errorf("Image states still exist for: %v", imagesNotRemovedList)
+	if len(imagesNotRemovedList) > 0 {
+		return fmt.Errorf("Image states still exist for: %s", imagesNotRemovedList)
 	}
 	return nil
 }
 
 func verifyImagesAreNotRemoved(imageManager *dockerImageManager, imageIDs ...string) error {
-	imagesRemovedList := list.New()
+	imagesRemovedList := []string{}
 	for _, imageID := range imageIDs {
-		_, ok := imageManager.getImageState(imageID)
+		imageState, ok := imageManager.getImageState(imageID)
 		if !ok {
-			imagesRemovedList.PushFront(imageID)
+			imagesRemovedList = append(imagesRemovedList, imageState.Image.String())
 		}
 	}
-	if imagesRemovedList.Len() > 0 {
-		return fmt.Errorf("Could not find images: %v in ImageManager", imagesRemovedList)
+	if len(imagesRemovedList) > 0 {
+		return fmt.Errorf("Could not find images: %s in ImageManager", imagesRemovedList)
 	}
 	return nil
 }

--- a/agent/engine/docker_image_manager_integ_test.go
+++ b/agent/engine/docker_image_manager_integ_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime"
 	"testing"
 	"time"
 
@@ -54,6 +55,11 @@ const (
 //  e. Image has not passed the ‘hasNoAssociatedContainers’ criteria.
 //  f. Ensure that that if not eligible, image is not deleted from the instance and image reference in ImageManager is not removed.
 func TestIntegImageCleanupHappyCase(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip(`Skipping this test because of error: level=error time=2020-05-27T20:20:03Z msg="Error removing` +
+			` Image amazon/image-cleanup-test-image2:make - Error response from daemon: hcsshim::GetComputeSystems:` +
+			` The requested compute system operation is not valid in the current state." module=log.go`)
+	}
 	cfg := defaultTestConfigIntegTest()
 	cfg.TaskCleanupWaitDuration = 5 * time.Second
 

--- a/agent/engine/engine_integ_test.go
+++ b/agent/engine/engine_integ_test.go
@@ -637,9 +637,10 @@ func TestTaskCleanup(t *testing.T) {
 	_, err = client.ContainerInspect(ctx, cid)
 	assert.NoError(t, err, "Inspect should work")
 
-	testUpdate := *testTask
-	testUpdate.SetDesiredStatus(apitaskstatus.TaskStopped)
-	go taskEngine.AddTask(&testUpdate)
+	// Create instead of copying the testTask, to avoid race condition.
+	taskUpdate := createTestTask(testArn)
+	taskUpdate.SetDesiredStatus(apitaskstatus.TaskStopped)
+	go taskEngine.AddTask(taskUpdate)
 	verifyContainerStoppedStateChange(t, taskEngine)
 	verifyTaskStoppedStateChange(t, taskEngine)
 

--- a/agent/engine/engine_unix_integ_test.go
+++ b/agent/engine/engine_unix_integ_test.go
@@ -49,7 +49,6 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/utils/ttime"
 	"github.com/aws/aws-sdk-go/aws"
 	sdkClient "github.com/docker/docker/client"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -273,25 +272,25 @@ func TestHostPIDNamespaceSharingInSingleTask(t *testing.T) {
 	testEvents := InitEventCollection(taskEngine)
 
 	err := VerifyTaskStatus(apitaskstatus.TaskRunning, testTask.Arn, testEvents, t)
-	assert.NoError(t, err, "Not verified task running")
-	assert.Equal(t, "host", testTask.PIDMode)
+	require.NoError(t, err, "Not verified task running")
+	require.Equal(t, "host", testTask.PIDMode)
 	//Wait for container1 and container2 to go down
 	err = VerifyContainerStatus(apicontainerstatus.ContainerStopped, testTask.Arn+":container1", testEvents, t)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = VerifyContainerStatus(apicontainerstatus.ContainerStopped, testTask.Arn+":container2", testEvents, t)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	//Manually stop container0
 	cont0, _ := testTask.ContainerByName("container0")
 	taskEngine.(*DockerTaskEngine).stopContainer(testTask, cont0)
 
 	err = VerifyTaskStatus(apitaskstatus.TaskStopped, testTask.Arn, testEvents, t)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	cont1, _ := testTask.ContainerByName("container1")
-	assert.Equal(t, testPIDNamespaceProcessFound, *(cont1.GetKnownExitCode()), "container1 could not see NamespaceTest process")
+	require.Equal(t, testPIDNamespaceProcessFound, *(cont1.GetKnownExitCode()), "container1 could not see NamespaceTest process")
 	cont2, _ := testTask.ContainerByName("container2")
-	assert.Equal(t, testPIDNamespaceProcessFound, *(cont2.GetKnownExitCode()), "container2 could not see NamespaceTest process")
+	require.Equal(t, testPIDNamespaceProcessFound, *(cont2.GetKnownExitCode()), "container2 could not see NamespaceTest process")
 }
 
 // This Test starts an executable in a container in Task1 sharing the PID namespace with Host.
@@ -326,36 +325,36 @@ func TestHostPIDNamespaceSharingInMultipleTasks(t *testing.T) {
 	// Run Task with Process attached
 	go taskEngine.AddTask(testTaskWithProcess)
 	err := VerifyTaskStatus(apitaskstatus.TaskRunning, testTaskWithProcess.Arn, testEvents, t)
-	assert.NoError(t, err)
-	assert.Equal(t, "host", testTaskWithProcess.PIDMode)
+	require.NoError(t, err)
+	require.Equal(t, "host", testTaskWithProcess.PIDMode)
 	// Wait for container1 and container2 to go down
 	err = VerifyContainerStatus(apicontainerstatus.ContainerStopped, testTaskWithProcess.Arn+":container1", testEvents, t)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = VerifyContainerStatus(apicontainerstatus.ContainerStopped, testTaskWithProcess.Arn+":container2", testEvents, t)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	cont1, _ := testTaskWithProcess.ContainerByName("container1")
-	assert.Equal(t, testPIDNamespaceProcessFound, *(cont1.GetKnownExitCode()), "container1 could not see NamespaceTest process")
+	require.Equal(t, testPIDNamespaceProcessFound, *(cont1.GetKnownExitCode()), "container1 could not see NamespaceTest process")
 	cont2, _ := testTaskWithProcess.ContainerByName("container2")
-	assert.Equal(t, testPIDNamespaceProcessFound, *(cont2.GetKnownExitCode()), "container2 could not see NamespaceTest process")
+	require.Equal(t, testPIDNamespaceProcessFound, *(cont2.GetKnownExitCode()), "container2 could not see NamespaceTest process")
 
 	// Run Task without Process attached
 	go taskEngine.AddTask(testTaskWithoutProcess)
 	err = VerifyTaskStatus(apitaskstatus.TaskRunning, testTaskWithoutProcess.Arn, testEvents, t)
-	assert.NoError(t, err)
-	assert.Equal(t, "host", testTaskWithoutProcess.PIDMode)
+	require.NoError(t, err)
+	require.Equal(t, "host", testTaskWithoutProcess.PIDMode)
 	// Wait for container0 to go down
 	err = VerifyContainerStatus(apicontainerstatus.ContainerStopped, testTaskWithoutProcess.Arn+":container0", testEvents, t)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = VerifyTaskStatus(apitaskstatus.TaskStopped, testTaskWithoutProcess.Arn, testEvents, t)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	cont0, _ := testTaskWithoutProcess.ContainerByName("container0")
-	assert.Equal(t, testPIDNamespaceProcessFound, *(cont0.GetKnownExitCode()), "container0 could not see NamespaceTest process, but should be able to.")
+	require.Equal(t, testPIDNamespaceProcessFound, *(cont0.GetKnownExitCode()), "container0 could not see NamespaceTest process, but should be able to.")
 
 	// Test is complete, can stop container with process
 	cont, _ := testTaskWithProcess.ContainerByName("container0")
 	taskEngine.(*DockerTaskEngine).stopContainer(testTaskWithProcess, cont)
 	err = VerifyTaskStatus(apitaskstatus.TaskStopped, testTaskWithProcess.Arn, testEvents, t)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 // This Test starts an executable in a container in Task1 with the PID namespace within the Task.
@@ -391,35 +390,35 @@ func TestTaskPIDNamespaceSharingInMultipleTasks(t *testing.T) {
 	// Run Task with Process attached
 	go taskEngine.AddTask(testTaskWithProcess)
 	err := VerifyTaskStatus(apitaskstatus.TaskRunning, testTaskWithProcess.Arn, testEvents, t)
-	assert.NoError(t, err)
-	assert.Equal(t, "task", testTaskWithProcess.PIDMode)
+	require.NoError(t, err)
+	require.Equal(t, "task", testTaskWithProcess.PIDMode)
 	// Wait for container1 and container2 to go down
 	err = VerifyContainerStatus(apicontainerstatus.ContainerStopped, testTaskWithProcess.Arn+":container1", testEvents, t)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = VerifyContainerStatus(apicontainerstatus.ContainerStopped, testTaskWithProcess.Arn+":container2", testEvents, t)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	cont1, _ := testTaskWithProcess.ContainerByName("container1")
-	assert.Equal(t, testPIDNamespaceProcessFound, *(cont1.GetKnownExitCode()), "container1 could not see NamespaceTest process")
+	require.Equal(t, testPIDNamespaceProcessFound, *(cont1.GetKnownExitCode()), "container1 could not see NamespaceTest process")
 	cont2, _ := testTaskWithProcess.ContainerByName("container2")
-	assert.Equal(t, testPIDNamespaceProcessFound, *(cont2.GetKnownExitCode()), "container2 could not see NamespaceTest process")
+	require.Equal(t, testPIDNamespaceProcessFound, *(cont2.GetKnownExitCode()), "container2 could not see NamespaceTest process")
 
 	// Run Task without Process attached
 	go taskEngine.AddTask(testTaskWithoutProcess)
 	err = VerifyTaskStatus(apitaskstatus.TaskRunning, testTaskWithoutProcess.Arn, testEvents, t)
-	assert.NoError(t, err)
-	assert.Equal(t, "task", testTaskWithoutProcess.PIDMode)
+	require.NoError(t, err)
+	require.Equal(t, "task", testTaskWithoutProcess.PIDMode)
 	// Wait for container0 to go down
 	err = VerifyContainerStatus(apicontainerstatus.ContainerStopped, testTaskWithoutProcess.Arn+":container0", testEvents, t)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Manually stop the Pause container and verify if TaskWithoutProcess has stopped
 	pauseCont, _ := testTaskWithoutProcess.ContainerByName(apitask.NamespacePauseContainerName)
 	taskEngine.(*DockerTaskEngine).stopContainer(testTaskWithoutProcess, pauseCont)
 	err = VerifyTaskStatus(apitaskstatus.TaskStopped, testTaskWithoutProcess.Arn, testEvents, t)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	cont0, _ := testTaskWithoutProcess.ContainerByName("container0")
-	assert.Equal(t, testPIDNamespaceProcessNotFound, *(cont0.GetKnownExitCode()), "container0 could see NamespaceTest process, but shouldn't be able to.")
+	require.Equal(t, testPIDNamespaceProcessNotFound, *(cont0.GetKnownExitCode()), "container0 could see NamespaceTest process, but shouldn't be able to.")
 
 	// Test is complete, can stop container with process
 	cont, _ := testTaskWithProcess.ContainerByName("container0")
@@ -428,7 +427,7 @@ func TestTaskPIDNamespaceSharingInMultipleTasks(t *testing.T) {
 	pauseCont, _ = testTaskWithProcess.ContainerByName(apitask.NamespacePauseContainerName)
 	taskEngine.(*DockerTaskEngine).stopContainer(testTaskWithProcess, pauseCont)
 	err = VerifyTaskStatus(apitaskstatus.TaskStopped, testTaskWithProcess.Arn, testEvents, t)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 // This Test creates an IPC semaphore on one docker container.
@@ -444,24 +443,24 @@ func TestHostIPCNamespaceSharingInSingleTask(t *testing.T) {
 
 	go taskEngine.AddTask(testTask)
 	err := VerifyTaskStatus(apitaskstatus.TaskRunning, testTask.Arn, testEvents, t)
-	assert.NoError(t, err)
-	assert.Equal(t, "host", testTask.IPCMode)
+	require.NoError(t, err)
+	require.Equal(t, "host", testTask.IPCMode)
 
 	//Wait for container1 and container2 to go down
 	err = VerifyContainerStatus(apicontainerstatus.ContainerStopped, testTask.Arn+":container1", testEvents, t)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = VerifyContainerStatus(apicontainerstatus.ContainerStopped, testTask.Arn+":container2", testEvents, t)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	//Manually stop container0
 	cont0, _ := testTask.ContainerByName("container0")
 	taskEngine.(*DockerTaskEngine).stopContainer(testTask, cont0)
 
 	err = VerifyTaskStatus(apitaskstatus.TaskStopped, testTask.Arn, testEvents, t)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	cont1, _ := testTask.ContainerByName("container1")
-	assert.Equal(t, testIPCNamespaceResourceFound, *(cont1.GetKnownExitCode()), "container1 could not see IPC Semaphore")
+	require.Equal(t, testIPCNamespaceResourceFound, *(cont1.GetKnownExitCode()), "container1 could not see IPC Semaphore")
 	cont2, _ := testTask.ContainerByName("container2")
-	assert.Equal(t, testIPCNamespaceResourceFound, *(cont2.GetKnownExitCode()), "container2 could not see IPC Semaphore")
+	require.Equal(t, testIPCNamespaceResourceFound, *(cont2.GetKnownExitCode()), "container2 could not see IPC Semaphore")
 }
 
 // This Test creates an IPC Semaphore in a container in TaskWithResource sharing the IPC namespace with Host.
@@ -496,36 +495,36 @@ func TestHostIPCNamespaceSharingInMultipleTasks(t *testing.T) {
 	// Run Task with IPC Semaphore attached
 	go taskEngine.AddTask(testTaskWithResource)
 	err := VerifyTaskStatus(apitaskstatus.TaskRunning, testTaskWithResource.Arn, testEvents, t)
-	assert.NoError(t, err)
-	assert.Equal(t, "host", testTaskWithResource.IPCMode)
+	require.NoError(t, err)
+	require.Equal(t, "host", testTaskWithResource.IPCMode)
 	// Wait for container1 and container2 to go down
 	err = VerifyContainerStatus(apicontainerstatus.ContainerStopped, testTaskWithResource.Arn+":container1", testEvents, t)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = VerifyContainerStatus(apicontainerstatus.ContainerStopped, testTaskWithResource.Arn+":container2", testEvents, t)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	cont1, _ := testTaskWithResource.ContainerByName("container1")
-	assert.Equal(t, testIPCNamespaceResourceFound, *(cont1.GetKnownExitCode()), "container1 could not see IPC Semaphore")
+	require.Equal(t, testIPCNamespaceResourceFound, *(cont1.GetKnownExitCode()), "container1 could not see IPC Semaphore")
 	cont2, _ := testTaskWithResource.ContainerByName("container2")
-	assert.Equal(t, testIPCNamespaceResourceFound, *(cont2.GetKnownExitCode()), "container2 could not see IPC Semaphore")
+	require.Equal(t, testIPCNamespaceResourceFound, *(cont2.GetKnownExitCode()), "container2 could not see IPC Semaphore")
 
 	// Run Task with IPC Semaphore attached
 	go taskEngine.AddTask(testTaskWithoutResource)
 	err = VerifyTaskStatus(apitaskstatus.TaskRunning, testTaskWithoutResource.Arn, testEvents, t)
-	assert.NoError(t, err)
-	assert.Equal(t, "host", testTaskWithoutResource.IPCMode)
+	require.NoError(t, err)
+	require.Equal(t, "host", testTaskWithoutResource.IPCMode)
 	// Wait for container0 to go down
 	err = VerifyContainerStatus(apicontainerstatus.ContainerStopped, testTaskWithoutResource.Arn+":container0", testEvents, t)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = VerifyTaskStatus(apitaskstatus.TaskStopped, testTaskWithoutResource.Arn, testEvents, t)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	cont0, _ := testTaskWithoutResource.ContainerByName("container0")
-	assert.Equal(t, testIPCNamespaceResourceFound, *(cont0.GetKnownExitCode()), "container0 could not see IPC Semaphore, but should be able to.")
+	require.Equal(t, testIPCNamespaceResourceFound, *(cont0.GetKnownExitCode()), "container0 could not see IPC Semaphore, but should be able to.")
 
 	// Test is complete, can stop container with process
 	cont, _ := testTaskWithResource.ContainerByName("container0")
 	taskEngine.(*DockerTaskEngine).stopContainer(testTaskWithResource, cont)
 	err = VerifyTaskStatus(apitaskstatus.TaskStopped, testTaskWithResource.Arn, testEvents, t)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 // This Test creates an IPC Semaphore in a container in TaskWithResource with the IPC namespace within the Task.
@@ -561,35 +560,35 @@ func TestTaskIPCNamespaceSharingInMultipleTasks(t *testing.T) {
 	// Run Task with Semaphore
 	go taskEngine.AddTask(testTaskWithResource)
 	err := VerifyTaskStatus(apitaskstatus.TaskRunning, testTaskWithResource.Arn, testEvents, t)
-	assert.NoError(t, err)
-	assert.Equal(t, "task", testTaskWithResource.IPCMode)
+	require.NoError(t, err)
+	require.Equal(t, "task", testTaskWithResource.IPCMode)
 	// Wait for container1 and container2 to go down
 	err = VerifyContainerStatus(apicontainerstatus.ContainerStopped, testTaskWithResource.Arn+":container1", testEvents, t)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = VerifyContainerStatus(apicontainerstatus.ContainerStopped, testTaskWithResource.Arn+":container2", testEvents, t)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	cont1, _ := testTaskWithResource.ContainerByName("container1")
-	assert.Equal(t, testIPCNamespaceResourceFound, *(cont1.GetKnownExitCode()), "container1 could not see IPC Semaphore")
+	require.Equal(t, testIPCNamespaceResourceFound, *(cont1.GetKnownExitCode()), "container1 could not see IPC Semaphore")
 	cont2, _ := testTaskWithResource.ContainerByName("container2")
-	assert.Equal(t, testIPCNamespaceResourceFound, *(cont2.GetKnownExitCode()), "container2 could not see IPC Semaphore")
+	require.Equal(t, testIPCNamespaceResourceFound, *(cont2.GetKnownExitCode()), "container2 could not see IPC Semaphore")
 
 	// Run Task without Semaphore
 	go taskEngine.AddTask(testTaskWithoutResource)
 	err = VerifyTaskStatus(apitaskstatus.TaskRunning, testTaskWithoutResource.Arn, testEvents, t)
-	assert.NoError(t, err)
-	assert.Equal(t, "task", testTaskWithoutResource.IPCMode)
+	require.NoError(t, err)
+	require.Equal(t, "task", testTaskWithoutResource.IPCMode)
 	// Wait for container0 to go down
 	err = VerifyContainerStatus(apicontainerstatus.ContainerStopped, testTaskWithoutResource.Arn+":container0", testEvents, t)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Manually stop the Pause container and verify if TaskWithoutResource has stopped
 	pauseCont, _ := testTaskWithoutResource.ContainerByName(apitask.NamespacePauseContainerName)
 	taskEngine.(*DockerTaskEngine).stopContainer(testTaskWithoutResource, pauseCont)
 	err = VerifyTaskStatus(apitaskstatus.TaskStopped, testTaskWithoutResource.Arn, testEvents, t)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	cont0, _ := testTaskWithoutResource.ContainerByName("container0")
-	assert.Equal(t, testIPCNamespaceResourceNotFound, *(cont0.GetKnownExitCode()), "container0 could see IPC Semaphore, but shouldn't be able to.")
+	require.Equal(t, testIPCNamespaceResourceNotFound, *(cont0.GetKnownExitCode()), "container0 could see IPC Semaphore, but shouldn't be able to.")
 
 	// Test is complete, can stop container with semaphore
 	cont, _ := testTaskWithResource.ContainerByName("container0")
@@ -598,7 +597,7 @@ func TestTaskIPCNamespaceSharingInMultipleTasks(t *testing.T) {
 	pauseCont, _ = testTaskWithResource.ContainerByName(apitask.NamespacePauseContainerName)
 	taskEngine.(*DockerTaskEngine).stopContainer(testTaskWithResource, pauseCont)
 	err = VerifyTaskStatus(apitaskstatus.TaskStopped, testTaskWithResource.Arn, testEvents, t)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 // TestStartStopUnpulledImage ensures that an unpulled image is successfully
@@ -661,14 +660,14 @@ func TestPortForward(t *testing.T) {
 
 	time.Sleep(waitForDockerDuration) // wait for Docker
 	_, err = net.DialTimeout("tcp", fmt.Sprintf("%s:%d", localhost, port1), dialTimeout)
-	assert.Error(t, err, "Did not expect to be able to dial %s:%d but didn't get error", localhost, port1)
+	require.Error(t, err, "Did not expect to be able to dial %s:%d but didn't get error", localhost, port1)
 
 	// Kill the existing container now to make the test run more quickly.
 	containerMap, _ := taskEngine.(*DockerTaskEngine).state.ContainerMapByArn(testTask.Arn)
 	cid := containerMap[testTask.Containers[0].Name].DockerID
 	client, _ := sdkClient.NewClientWithOpts(sdkClient.WithHost(endpoint), sdkClient.WithVersion(sdkclientfactory.GetDefaultVersion().String()))
 	err = client.ContainerKill(context.TODO(), cid, "SIGKILL")
-	assert.NoError(t, err, "Could not kill container", err)
+	require.NoError(t, err, "Could not kill container", err)
 
 	verifyTaskIsStopped(stateChangeEvents, testTask)
 
@@ -792,7 +791,7 @@ func TestDynamicPortForward(t *testing.T) {
 	go taskEngine.AddTask(testTask)
 
 	event := <-stateChangeEvents
-	assert.Equal(t, event.(api.ContainerStateChange).Status, apicontainerstatus.ContainerRunning, "Expected container to be RUNNING")
+	require.Equal(t, event.(api.ContainerStateChange).Status, apicontainerstatus.ContainerRunning, "Expected container to be RUNNING")
 
 	portBindings := event.(api.ContainerStateChange).PortBindings
 
@@ -845,7 +844,7 @@ func TestMultipleDynamicPortForward(t *testing.T) {
 	go taskEngine.AddTask(testTask)
 
 	event := <-stateChangeEvents
-	assert.Equal(t, event.(api.ContainerStateChange).Status, apicontainerstatus.ContainerRunning, "Expected container to be RUNNING")
+	require.Equal(t, event.(api.ContainerStateChange).Status, apicontainerstatus.ContainerRunning, "Expected container to be RUNNING")
 
 	portBindings := event.(api.ContainerStateChange).PortBindings
 
@@ -1026,7 +1025,7 @@ func TestDockerCfgAuth(t *testing.T) {
 		}
 		return nil
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestVolumesFromRO(t *testing.T) {
@@ -1112,7 +1111,7 @@ func TestInitOOMEvent(t *testing.T) {
 	verifyTaskRunningStateChange(t, taskEngine)
 
 	event := <-stateChangeEvents
-	assert.Equal(t, event.(api.ContainerStateChange).Status, apicontainerstatus.ContainerStopped, "Expected container to be STOPPED")
+	require.Equal(t, event.(api.ContainerStateChange).Status, apicontainerstatus.ContainerStopped, "Expected container to be STOPPED")
 
 	// hold on to the container stopped event, will need to check exit code
 	contEvent := event.(api.ContainerStateChange)
@@ -1169,7 +1168,7 @@ func TestSignalEvent(t *testing.T) {
 	cid := containerMap[testTask.Containers[0].Name].DockerID
 	client, _ := sdkClient.NewClientWithOpts(sdkClient.WithHost(endpoint), sdkClient.WithVersion(sdkclientfactory.GetDefaultVersion().String()))
 	err := client.ContainerKill(context.TODO(), cid, "SIGUSR1")
-	assert.NoError(t, err, "Could not signal container", err)
+	require.NoError(t, err, "Could not signal container", err)
 
 	// Verify the container has not stopped
 	time.Sleep(2 * time.Second)
@@ -1273,8 +1272,8 @@ func TestTaskLevelVolume(t *testing.T) {
 
 	verifyTaskIsRunning(stateChangeEvents, testTask)
 	verifyTaskIsStopped(stateChangeEvents, testTask)
-	assert.Equal(t, *testTask.Containers[0].GetKnownExitCode(), 0)
-	assert.NotEqual(t, testTask.ResourcesMapUnsafe["dockerVolume"][0].(*taskresourcevolume.VolumeResource).VolumeConfig.Source(), "TestTaskLevelVolume", "task volume name is the same as specified in task definition")
+	require.Equal(t, *testTask.Containers[0].GetKnownExitCode(), 0)
+	require.NotEqual(t, testTask.ResourcesMapUnsafe["dockerVolume"][0].(*taskresourcevolume.VolumeResource).VolumeConfig.Source(), "TestTaskLevelVolume", "task volume name is the same as specified in task definition")
 
 	client := taskEngine.(*DockerTaskEngine).client
 	client.RemoveVolume(context.TODO(), "TestTaskLevelVolume", 5*time.Second)
@@ -1301,8 +1300,8 @@ func TestSwapConfigurationTask(t *testing.T) {
 	containerMap, _ := taskEngine.(*DockerTaskEngine).state.ContainerMapByArn(testTask.Arn)
 	cid := containerMap[testTask.Containers[0].Name].DockerID
 	state, _ := client.ContainerInspect(ctx, cid)
-	assert.EqualValues(t, 314572800, state.HostConfig.MemorySwap)
-	assert.EqualValues(t, 90, *state.HostConfig.MemorySwappiness)
+	require.EqualValues(t, 314572800, state.HostConfig.MemorySwap)
+	require.EqualValues(t, 90, *state.HostConfig.MemorySwappiness)
 
 	// Kill the existing container now
 	taskUpdate := *testTask
@@ -1349,14 +1348,14 @@ func TestGPUAssociationTask(t *testing.T) {
 	go taskEngine.AddTask(testTask)
 
 	verifyTaskIsRunning(stateChangeEvents, testTask)
-	assert.Equal(t, []string{"0"}, container.GPUIDs)
-	assert.Equal(t, "0", container.Environment[apitask.NvidiaVisibleDevicesEnvVar])
+	require.Equal(t, []string{"0"}, container.GPUIDs)
+	require.Equal(t, "0", container.Environment[apitask.NvidiaVisibleDevicesEnvVar])
 
 	containerMap, _ := taskEngine.(*DockerTaskEngine).state.ContainerMapByArn(testTask.Arn)
 	cid := containerMap[testTask.Containers[0].Name].DockerID
 	state, _ := client.ContainerInspect(ctx, cid)
-	assert.Equal(t, testTask.NvidiaRuntime, state.HostConfig.Runtime)
-	assert.Contains(t, state.Config.Env, "NVIDIA_VISIBLE_DEVICES=0")
+	require.Equal(t, testTask.NvidiaRuntime, state.HostConfig.Runtime)
+	require.Contains(t, state.Config.Env, "NVIDIA_VISIBLE_DEVICES=0")
 
 	taskUpdate := *testTask
 	taskUpdate.SetDesiredStatus(apitaskstatus.TaskStopped)
@@ -1428,7 +1427,7 @@ func TestMemoryOverCommit(t *testing.T) {
 	cid := containerMap[testTask.Containers[0].Name].DockerID
 	state, _ := client.ContainerInspect(ctx, cid)
 
-	assert.EqualValues(t, memoryReservation*1024*1024, state.HostConfig.MemoryReservation)
+	require.EqualValues(t, memoryReservation*1024*1024, state.HostConfig.MemoryReservation)
 
 	// Kill the existing container now
 	testUpdate := *testTask
@@ -1520,8 +1519,8 @@ func TestFluentdTag(t *testing.T) {
 
 	// Verify the log file existed and also the content contains the expected format
 	err = utils.SearchStrInDir(logdir, "ecsfts", "hello, this is fluentd integration test")
-	assert.NoError(t, err, "failed to find the content in the fluent log file")
+	require.NoError(t, err, "failed to find the content in the fluent log file")
 
 	err = utils.SearchStrInDir(logdir, "ecsfts", logTag)
-	assert.NoError(t, err, "failed to find the log tag specified in the task definition")
+	require.NoError(t, err, "failed to find the log tag specified in the task definition")
 }

--- a/agent/engine/engine_unix_integ_test.go
+++ b/agent/engine/engine_unix_integ_test.go
@@ -711,9 +711,9 @@ func TestPortForward(t *testing.T) {
 	}
 
 	// Stop the existing container now
-	taskUpdate := *testTask
+	taskUpdate := createTestTask(testArn)
 	taskUpdate.SetDesiredStatus(apitaskstatus.TaskStopped)
-	go taskEngine.AddTask(&taskUpdate)
+	go taskEngine.AddTask(taskUpdate)
 	verifyTaskIsStopped(stateChangeEvents, testTask)
 }
 
@@ -767,9 +767,9 @@ func TestMultiplePortForwards(t *testing.T) {
 	}
 	t.Log("Read second container")
 
-	taskUpdate := *testTask
+	taskUpdate := createTestTask(testArn)
 	taskUpdate.SetDesiredStatus(apitaskstatus.TaskStopped)
-	go taskEngine.AddTask(&taskUpdate)
+	go taskEngine.AddTask(taskUpdate)
 	verifyTaskIsStopped(stateChangeEvents, testTask)
 }
 
@@ -822,9 +822,9 @@ func TestDynamicPortForward(t *testing.T) {
 	}
 
 	// Kill the existing container now
-	taskUpdate := *testTask
+	taskUpdate := createTestTask(testArn)
 	taskUpdate.SetDesiredStatus(apitaskstatus.TaskStopped)
-	go taskEngine.AddTask(&taskUpdate)
+	go taskEngine.AddTask(taskUpdate)
 	verifyTaskIsStopped(stateChangeEvents, testTask)
 }
 
@@ -893,9 +893,9 @@ func TestMultipleDynamicPortForward(t *testing.T) {
 	}
 
 	// Kill the existing container now
-	taskUpdate := *testTask
+	taskUpdate := createTestTask(testArn)
 	taskUpdate.SetDesiredStatus(apitaskstatus.TaskStopped)
-	go taskEngine.AddTask(&taskUpdate)
+	go taskEngine.AddTask(taskUpdate)
 	verifyTaskIsStopped(stateChangeEvents, testTask)
 }
 
@@ -907,7 +907,8 @@ func TestLinking(t *testing.T) {
 	taskEngine, done, _ := setupWithDefaultConfig(t)
 	defer done()
 
-	testTask := createTestTask("TestLinking")
+	testArn := "TestLinking"
+	testTask := createTestTask(testArn)
 	testTask.Containers = append(testTask.Containers, createTestContainer())
 	testTask.Containers[0].Command = []string{"-l=80", "-serve", "hello linker"}
 	testTask.Containers[0].Name = "linkee"
@@ -950,9 +951,9 @@ func TestLinking(t *testing.T) {
 		t.Error("Got response: " + string(response) + " instead of 'hello linker'")
 	}
 
-	taskUpdate := *testTask
+	taskUpdate := createTestTask(testArn)
 	taskUpdate.SetDesiredStatus(apitaskstatus.TaskStopped)
-	go taskEngine.AddTask(&taskUpdate)
+	go taskEngine.AddTask(taskUpdate)
 
 	verifyTaskIsStopped(stateChangeEvents, testTask)
 }
@@ -1150,7 +1151,8 @@ func TestSignalEvent(t *testing.T) {
 
 	stateChangeEvents := taskEngine.StateChangeEvents()
 
-	testTask := createTestTask("signaltest")
+	testArn := "signaltest"
+	testTask := createTestTask(testArn)
 	testTask.Containers[0].Image = testBusyboxImage
 	testTask.Containers[0].Command = []string{
 		"sh",
@@ -1189,9 +1191,9 @@ check_events:
 	}
 
 	// Stop the container now
-	taskUpdate := *testTask
+	taskUpdate := createTestTask(testArn)
 	taskUpdate.SetDesiredStatus(apitaskstatus.TaskStopped)
-	go taskEngine.AddTask(&taskUpdate)
+	go taskEngine.AddTask(taskUpdate)
 
 	verifyContainerStoppedStateChange(t, taskEngine)
 	verifyTaskStoppedStateChange(t, taskEngine)
@@ -1304,9 +1306,9 @@ func TestSwapConfigurationTask(t *testing.T) {
 	require.EqualValues(t, 90, *state.HostConfig.MemorySwappiness)
 
 	// Kill the existing container now
-	taskUpdate := *testTask
+	taskUpdate := createTestTask(testArn)
 	taskUpdate.SetDesiredStatus(apitaskstatus.TaskStopped)
-	go taskEngine.AddTask(&taskUpdate)
+	go taskEngine.AddTask(taskUpdate)
 
 	verifyContainerStoppedStateChange(t, taskEngine)
 	verifyTaskStoppedStateChange(t, taskEngine)
@@ -1357,9 +1359,9 @@ func TestGPUAssociationTask(t *testing.T) {
 	require.Equal(t, testTask.NvidiaRuntime, state.HostConfig.Runtime)
 	require.Contains(t, state.Config.Env, "NVIDIA_VISIBLE_DEVICES=0")
 
-	taskUpdate := *testTask
+	taskUpdate := createTestGPUTask()
 	taskUpdate.SetDesiredStatus(apitaskstatus.TaskStopped)
-	go taskEngine.AddTask(&taskUpdate)
+	go taskEngine.AddTask(taskUpdate)
 	verifyTaskIsStopped(stateChangeEvents, testTask)
 }
 
@@ -1430,9 +1432,9 @@ func TestMemoryOverCommit(t *testing.T) {
 	require.EqualValues(t, memoryReservation*1024*1024, state.HostConfig.MemoryReservation)
 
 	// Kill the existing container now
-	testUpdate := *testTask
+	testUpdate := createTestTask(testArn)
 	testUpdate.SetDesiredStatus(apitaskstatus.TaskStopped)
-	go taskEngine.AddTask(&testUpdate)
+	go taskEngine.AddTask(testUpdate)
 
 	verifyContainerStoppedStateChange(t, taskEngine)
 	verifyTaskStoppedStateChange(t, taskEngine)
@@ -1508,9 +1510,9 @@ func TestFluentdTag(t *testing.T) {
 	state, _ := client.ContainerInspect(ctx, cid)
 
 	// Kill the fluentd driver task
-	testUpdate := *testTaskFleuntdDriver
+	testUpdate := createTestTask("testFleuntdDriver")
 	testUpdate.SetDesiredStatus(apitaskstatus.TaskStopped)
-	go taskEngine.AddTask(&testUpdate)
+	go taskEngine.AddTask(testUpdate)
 	verifyContainerStoppedStateChange(t, taskEngine)
 	verifyTaskStoppedStateChange(t, taskEngine)
 

--- a/agent/engine/engine_windows_integ_test.go
+++ b/agent/engine/engine_windows_integ_test.go
@@ -344,9 +344,9 @@ func TestPortForward(t *testing.T) {
 	assert.Equal(t, string(response), serverContent, "got response: "+string(response)+" instead of ", serverContent)
 
 	// Stop the existing container now
-	taskUpdate := *testTask
+	taskUpdate := createTestTask(testArn)
 	taskUpdate.SetDesiredStatus(apitaskstatus.TaskStopped)
-	go taskEngine.AddTask(&taskUpdate)
+	go taskEngine.AddTask(taskUpdate)
 	verifyTaskIsStopped(stateChangeEvents, testTask)
 }
 
@@ -403,9 +403,9 @@ func TestMultiplePortForwards(t *testing.T) {
 	assert.Equal(t, string(response), serverContent+"2", "got response: "+string(response)+" instead of "+serverContent+"2")
 	t.Log("Read second container")
 
-	taskUpdate := *testTask
+	taskUpdate := createTestTask(testArn)
 	taskUpdate.SetDesiredStatus(apitaskstatus.TaskStopped)
-	go taskEngine.AddTask(&taskUpdate)
+	go taskEngine.AddTask(taskUpdate)
 	verifyTaskIsStopped(stateChangeEvents, testTask)
 }
 
@@ -459,9 +459,9 @@ func TestDynamicPortForward(t *testing.T) {
 	assert.Equal(t, string(response), serverContent, "got response: "+string(response)+" instead of %s", serverContent)
 
 	// Kill the existing container now
-	taskUpdate := *testTask
+	taskUpdate := createTestTask(testArn)
 	taskUpdate.SetDesiredStatus(apitaskstatus.TaskStopped)
-	go taskEngine.AddTask(&taskUpdate)
+	go taskEngine.AddTask(taskUpdate)
 	verifyTaskIsStopped(stateChangeEvents, testTask)
 }
 
@@ -518,9 +518,9 @@ func TestMultipleDynamicPortForward(t *testing.T) {
 	assert.Equal(t, string(response), serverContent, "got response: "+string(response)+" instead of %s", serverContent)
 
 	// Kill the existing container now
-	taskUpdate := *testTask
+	taskUpdate := createTestTask(testArn)
 	taskUpdate.SetDesiredStatus(apitaskstatus.TaskStopped)
-	go taskEngine.AddTask(&taskUpdate)
+	go taskEngine.AddTask(taskUpdate)
 	verifyTaskIsStopped(stateChangeEvents, testTask)
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

1. Change asserts to require in integ tests. Some integ tests can hang waiting for information that will never arrive if previous steps of the test failed. Using 'require' instead of assert means the test will fail early.
2. Copy all test tasks in integ tests to avoid data races.
3. Image manager integ tests were logging the pointer address to a list, change that to log the actual list of relevant strings.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
