### PR TITLE
docker task manager: dont send to closed channels

### DIFF
--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -659,8 +659,7 @@ func (engine *DockerTaskEngine) handleDockerEvent(event dockerapi.DockerContaine
 
 	engine.tasksLock.RLock()
 	managedTask, ok := engine.managedTasks[task.Arn]
-	// hold the lock until the message is sent so we don't send on a closed channel
-	defer engine.tasksLock.RUnlock()
+	engine.tasksLock.RUnlock()
 	if !ok {
 		seelog.Criticalf("Task engine: could not find managed task [%s] corresponding to a docker event: %s",
 			task.Arn, event.String())

--- a/agent/engine/task_manager_test.go
+++ b/agent/engine/task_manager_test.go
@@ -754,6 +754,7 @@ func TestStartContainerTransitionsInvokesHandleContainerChange(t *testing.T) {
 		stateChangeEvents:          stateChangeEvents,
 		containerChangeEventStream: containerChangeEventStream,
 		dockerMessages:             make(chan dockerContainerChange),
+		ctx:                        context.TODO(),
 	}
 
 	eventsGenerated := sync.WaitGroup{}
@@ -878,6 +879,7 @@ func TestOnContainersUnableToTransitionStateForDesiredStoppedTask(t *testing.T) 
 			stateChangeEvents: stateChangeEvents,
 		},
 		stateChangeEvents: stateChangeEvents,
+		ctx:               context.TODO(),
 	}
 	eventsGenerated := sync.WaitGroup{}
 	eventsGenerated.Add(1)
@@ -908,6 +910,7 @@ func TestOnContainersUnableToTransitionStateForDesiredRunningTask(t *testing.T) 
 			},
 			DesiredStatusUnsafe: apitaskstatus.TaskRunning,
 		},
+		ctx: context.TODO(),
 	}
 
 	task.handleContainersUnableToTransitionState()
@@ -1524,6 +1527,7 @@ func TestHandleContainerChangeUpdateContainerHealth(t *testing.T) {
 		Task:                       testdata.LoadTask("sleep5TaskCgroup"),
 		containerChangeEventStream: containerChangeEventStream,
 		stateChangeEvents:          make(chan statechange.Event),
+		ctx:                        context.TODO(),
 	}
 	// Discard all the statechange events
 	defer discardEvents(mTask.stateChangeEvents)()
@@ -1565,6 +1569,7 @@ func TestHandleContainerChangeUpdateMetadataRedundant(t *testing.T) {
 		Task:                       testdata.LoadTask("sleep5TaskCgroup"),
 		containerChangeEventStream: containerChangeEventStream,
 		stateChangeEvents:          make(chan statechange.Event),
+		ctx:                        context.TODO(),
 	}
 	// Discard all the statechange events
 	defer discardEvents(mTask.stateChangeEvents)()
@@ -1635,6 +1640,7 @@ func TestWaitForResourceTransition(t *testing.T) {
 		Task: &apitask.Task{
 			ResourcesMapUnsafe: make(map[string][]taskresource.TaskResource),
 		},
+		ctx: context.TODO(),
 	}
 	transition := make(chan struct{}, 1)
 	transitionChangeResource := make(chan string, 1)
@@ -1665,6 +1671,7 @@ func TestApplyResourceStateHappyPath(t *testing.T) {
 			Arn:                "arn",
 			ResourcesMapUnsafe: make(map[string][]taskresource.TaskResource),
 		},
+		ctx: context.TODO(),
 	}
 	gomock.InOrder(
 		mockResource.EXPECT().GetName(),
@@ -1702,6 +1709,7 @@ func TestApplyResourceStateFailures(t *testing.T) {
 					Arn:                "arn",
 					ResourcesMapUnsafe: make(map[string][]taskresource.TaskResource),
 				},
+				ctx: context.TODO(),
 			}
 			gomock.InOrder(
 				mockResource.EXPECT().GetName(),


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

Go channels do not need to be closed as a cleanup procedure. In fact, channels that are used to send data to will panic if they are closed and data is attempted to be sent (as we do in this case).

The only reason to close a channel in Go is to signal that it is closed to receivers of the channel. In the case of these channels we are not waiting on a closed channel signal.

see https://groups.google.com/forum/#!msg/golang-nuts/pZwdYRGxCIk/qpbHxRRPJdUJ

This change also uses a select statement when sending data on channels, to make sure that it doesn't hang when the manager's context has been cancelled.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
