### PR TITLE
Cancel agent's top-level context on exit

### DIFF
--- a/agent/app/agent_integ_test.go
+++ b/agent/app/agent_integ_test.go
@@ -15,7 +15,6 @@
 package app
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -25,11 +24,10 @@ import (
 )
 
 func TestNewAgent(t *testing.T) {
-	ctx := context.TODO()
 	os.Setenv("AWS_DEFAULT_REGION", "us-west-2")
 	defer os.Unsetenv("AWS_DEFAULT_REGION")
 
-	agent, err := newAgent(ctx, true, aws.Bool(true))
+	agent, err := newAgent(true, aws.Bool(true))
 
 	assert.NoError(t, err)
 	// printECSAttributes should ensure that agent's cfg is set with

--- a/agent/app/agent_test.go
+++ b/agent/app/agent_test.go
@@ -391,7 +391,7 @@ func TestDoStartRegisterAvailabilityZone(t *testing.T) {
 		credentialProvider: aws_credentials.NewCredentials(mockCredentialsProvider),
 		mobyPlugins:        mockMobyPlugins,
 		metadataManager:    containermetadata,
-		terminationHandler: func(saver statemanager.Saver, taskEngine engine.TaskEngine) {},
+		terminationHandler: func(saver statemanager.Saver, taskEngine engine.TaskEngine, cancel context.CancelFunc) {},
 		ec2MetadataClient:  ec2MetadataClient,
 	}
 

--- a/agent/app/agent_unix_test.go
+++ b/agent/app/agent_unix_test.go
@@ -117,7 +117,7 @@ func TestDoStartHappyPath(t *testing.T) {
 		credentialProvider: credentials.NewCredentials(mockCredentialsProvider),
 		dockerClient:       dockerClient,
 		pauseLoader:        mockPauseLoader,
-		terminationHandler: func(saver statemanager.Saver, taskEngine engine.TaskEngine) {},
+		terminationHandler: func(saver statemanager.Saver, taskEngine engine.TaskEngine, cancel context.CancelFunc) {},
 		mobyPlugins:        mockMobyPlugins,
 		ec2MetadataClient:  ec2MetadataClient,
 	}
@@ -235,7 +235,7 @@ func TestDoStartTaskENIHappyPath(t *testing.T) {
 		pauseLoader:        mockPauseLoader,
 		cniClient:          cniClient,
 		ec2MetadataClient:  mockMetadata,
-		terminationHandler: func(saver statemanager.Saver, taskEngine engine.TaskEngine) {},
+		terminationHandler: func(saver statemanager.Saver, taskEngine engine.TaskEngine, cancel context.CancelFunc) {},
 		mobyPlugins:        mockMobyPlugins,
 	}
 
@@ -550,7 +550,7 @@ func TestDoStartCgroupInitHappyPath(t *testing.T) {
 		credentialProvider: credentials.NewCredentials(mockCredentialsProvider),
 		pauseLoader:        mockPauseLoader,
 		dockerClient:       dockerClient,
-		terminationHandler: func(saver statemanager.Saver, taskEngine engine.TaskEngine) {},
+		terminationHandler: func(saver statemanager.Saver, taskEngine engine.TaskEngine, cancel context.CancelFunc) {},
 		mobyPlugins:        mockMobyPlugins,
 		ec2MetadataClient:  ec2MetadataClient,
 		resourceFields: &taskresource.ResourceFields{
@@ -607,7 +607,7 @@ func TestDoStartCgroupInitErrorPath(t *testing.T) {
 		credentialProvider: credentials.NewCredentials(mockCredentialsProvider),
 		dockerClient:       dockerClient,
 		pauseLoader:        mockPauseLoader,
-		terminationHandler: func(saver statemanager.Saver, taskEngine engine.TaskEngine) {},
+		terminationHandler: func(saver statemanager.Saver, taskEngine engine.TaskEngine, cancel context.CancelFunc) {},
 		resourceFields: &taskresource.ResourceFields{
 			Control: mockControl,
 		},
@@ -697,7 +697,7 @@ func TestDoStartGPUManagerHappyPath(t *testing.T) {
 		credentialProvider: credentials.NewCredentials(mockCredentialsProvider),
 		dockerClient:       dockerClient,
 		pauseLoader:        mockPauseLoader,
-		terminationHandler: func(saver statemanager.Saver, taskEngine engine.TaskEngine) {},
+		terminationHandler: func(saver statemanager.Saver, taskEngine engine.TaskEngine, cancel context.CancelFunc) {},
 		mobyPlugins:        mockMobyPlugins,
 		ec2MetadataClient:  ec2MetadataClient,
 		resourceFields: &taskresource.ResourceFields{
@@ -752,7 +752,7 @@ func TestDoStartGPUManagerInitError(t *testing.T) {
 		credentialProvider: credentials.NewCredentials(mockCredentialsProvider),
 		dockerClient:       dockerClient,
 		pauseLoader:        mockPauseLoader,
-		terminationHandler: func(saver statemanager.Saver, taskEngine engine.TaskEngine) {},
+		terminationHandler: func(saver statemanager.Saver, taskEngine engine.TaskEngine, cancel context.CancelFunc) {},
 		resourceFields: &taskresource.ResourceFields{
 			NvidiaGPUManager: mockGPUManager,
 		},
@@ -800,7 +800,7 @@ func TestDoStartTaskENIPauseError(t *testing.T) {
 		pauseLoader:        mockPauseLoader,
 		cniClient:          cniClient,
 		ec2MetadataClient:  mockMetadata,
-		terminationHandler: func(saver statemanager.Saver, taskEngine engine.TaskEngine) {},
+		terminationHandler: func(saver statemanager.Saver, taskEngine engine.TaskEngine, cancel context.CancelFunc) {},
 		mobyPlugins:        mockMobyPlugins,
 	}
 

--- a/agent/app/agent_windows.go
+++ b/agent/app/agent_windows.go
@@ -154,7 +154,7 @@ func (h *handler) runAgent(ctx context.Context) uint32 {
 	agentCtx, cancel := context.WithCancel(ctx)
 	indicator := newTermHandlerIndicator()
 
-	terminationHandler := func(saver statemanager.Saver, taskEngine engine.TaskEngine) {
+	terminationHandler := func(saver statemanager.Saver, taskEngine engine.TaskEngine, cancel context.CancelFunc) {
 		// We're using a custom indicator to record that the handler is scheduled to be executed (has been invoked) and
 		// to determine whether it should run (we skip when the agent engine has already exited).  After recording to
 		// the indicator that the handler has been invoked, we wait on the context.  When we wake up, we determine

--- a/agent/app/agent_windows_test.go
+++ b/agent/app/agent_windows_test.go
@@ -105,16 +105,16 @@ func TestHandler_RunAgent_ForceSaveWithTerminationHandler(t *testing.T) {
 
 	agent := &mockAgent{}
 
+	ctx, cancel := context.WithCancel(context.TODO())
 	done := make(chan struct{})
 	defer func() { done <- struct{}{} }()
 	startFunc := func() int {
-		go agent.terminationHandler(stateManager, taskEngine)
+		go agent.terminationHandler(stateManager, taskEngine, cancel)
 		<-done // block until after the test ends so that we can test that runAgent returns when cancelled
 		return 0
 	}
 	agent.startFunc = startFunc
 	handler := &handler{agent}
-	ctx, cancel := context.WithCancel(context.TODO())
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
@@ -200,10 +200,11 @@ func TestHandler_Execute_WindowsStops(t *testing.T) {
 
 	agent := &mockAgent{}
 
+	_, cancel := context.WithCancel(context.TODO())
 	done := make(chan struct{})
 	defer func() { done <- struct{}{} }()
 	startFunc := func() int {
-		go agent.terminationHandler(stateManager, taskEngine)
+		go agent.terminationHandler(stateManager, taskEngine, cancel)
 		<-done // block until after the test ends so that we can test that Execute returns when Stopped
 		return 0
 	}

--- a/agent/app/run.go
+++ b/agent/app/run.go
@@ -14,7 +14,6 @@
 package app
 
 import (
-	"context"
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/app/args"
@@ -50,9 +49,7 @@ func Run(arguments []string) int {
 	logger.SetLevel(*parsedArgs.LogLevel)
 
 	// Create an Agent object
-	agent, err := newAgent(context.Background(),
-		aws.BoolValue(parsedArgs.BlackholeEC2Metadata),
-		parsedArgs.AcceptInsecureCert)
+	agent, err := newAgent(aws.BoolValue(parsedArgs.BlackholeEC2Metadata), parsedArgs.AcceptInsecureCert)
 	if err != nil {
 		// Failure to initialize either the docker client or the EC2 metadata
 		// service client are non terminal errors as they could be transient

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -233,10 +233,8 @@ func (engine *DockerTaskEngine) MarshalJSON() ([]byte, error) {
 // and operate normally.
 // This function must be called before any other function, except serializing and deserializing, can succeed without error.
 func (engine *DockerTaskEngine) Init(ctx context.Context) error {
-	// TODO, pass in a a context from main from background so that other things can stop us, not just the tests
 	derivedCtx, cancel := context.WithCancel(ctx)
 	engine.stopEngine = cancel
-
 	engine.ctx = derivedCtx
 
 	// Open the event stream before we sync state so that e.g. if a container


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

Breaking out #2457 into smaller PRs.

This PR cancels agent's top-level context when agent receives a termination signal.

Instead of saving state and then doing a hard os.Exit on receiving a termination signal, we now cancel the context and save state, relying on the ACS handler to exit gracefully which ultimately exits the agent in the main program here: https://github.com/aws/amazon-ecs-agent/blob/master/agent/agent.go#L29

The benefit of this approach is that it allows defer statements and other cleanup tasks to run, when os.Exit is called no defer statements are run.

agent logs on stop before this change:
```
level=info time=2020-05-20T18:49:49Z msg="Saving state!" module=state_manager.go
```

agent logs on stop after this change (graceful exits from goroutines):
```
level=info time=2020-05-20T21:43:39Z msg="Agent received termination signal: terminated" module=termination_handler.go
level=info time=2020-05-20T21:43:39Z msg="Saving state!" module=state_manager.go
level=info time=2020-05-20T21:43:39Z msg="Exiting the engine event handler." module=handler.go
level=info time=2020-05-20T21:43:39Z msg="TaskHandler: Stopping periodic container state change submission ticker" module=task_handler.go
level=info time=2020-05-20T21:43:39Z msg="TCS Websocket connection closed for a valid reason" module=handler.go
level=info time=2020-05-20T21:43:39Z msg="TCS session exited cleanly." module=handler.go
level=info time=2020-05-20T21:43:39Z msg="Event stream DeregisterContainerInstance stopped listening..." module=eventstream.go
level=info time=2020-05-20T21:43:39Z msg="Event stream ContainerChange stopped listening..." module=eventstream.go
level=info time=2020-05-20T21:43:39Z msg="Stopping udev event handler" module=watcher_linux.go
level=info time=2020-05-20T21:43:39Z msg="ACS session exited cleanly." module=acs_handler.go
```

task and container managers will also exit when running tasks, resulting in logs like this:
```
level=info time=2020-05-26T22:08:11Z msg="Managed task [arn:aws:ecs:us-east-1:XXXX:task/XXXX]: agent task manager exiting." module=task_manager.go
level=info time=2020-05-26T22:08:11Z msg="Container [XXXX]: Stopping stats collection" module=container.go
```

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Fix agent top-level context

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
