### PR TITLE
Pass agent context to subroutines

### DIFF
--- a/agent/eventhandler/handler.go
+++ b/agent/eventhandler/handler.go
@@ -14,6 +14,7 @@
 package eventhandler
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
@@ -24,13 +25,20 @@ import (
 
 // HandleEngineEvents handles state change events from the state change event channel by sending it to
 // responsible event handler
-func HandleEngineEvents(taskEngine engine.TaskEngine, client api.ECSClient, taskHandler *TaskHandler,
+func HandleEngineEvents(
+	ctx context.Context,
+	taskEngine engine.TaskEngine,
+	client api.ECSClient,
+	taskHandler *TaskHandler,
 	attachmentEventHandler *AttachmentEventHandler) {
 	for {
 		stateChangeEvents := taskEngine.StateChangeEvents()
 
 		for stateChangeEvents != nil {
 			select {
+			case <-ctx.Done():
+				seelog.Infof("Exiting the engine event handler.")
+				return
 			case event, ok := <-stateChangeEvents:
 				if !ok {
 					stateChangeEvents = nil

--- a/agent/tcs/handler/handler_test.go
+++ b/agent/tcs/handler/handler_test.go
@@ -133,7 +133,7 @@ func TestStartSession(t *testing.T) {
 
 	deregisterInstanceEventStream := eventstream.NewEventStream("Deregister_Instance", context.Background())
 	// Start a session with the test server.
-	go startSession(server.URL, testCfg, testCreds, &mockStatsEngine{},
+	go startSession(ctx, server.URL, testCfg, testCreds, &mockStatsEngine{},
 		defaultHeartbeatTimeout, defaultHeartbeatJitter,
 		testPublishMetricsInterval, deregisterInstanceEventStream)
 
@@ -197,7 +197,7 @@ func TestSessionConnectionClosedByRemote(t *testing.T) {
 	defer cancel()
 
 	// Start a session with the test server.
-	err = startSession(server.URL, testCfg, testCreds, &mockStatsEngine{},
+	err = startSession(ctx, server.URL, testCfg, testCreds, &mockStatsEngine{},
 		defaultHeartbeatTimeout, defaultHeartbeatJitter,
 		testPublishMetricsInterval, deregisterInstanceEventStream)
 
@@ -234,11 +234,11 @@ func TestConnectionInactiveTimeout(t *testing.T) {
 	deregisterInstanceEventStream.StartListening()
 	defer cancel()
 	// Start a session with the test server.
-	err = startSession(server.URL, testCfg, testCreds, &mockStatsEngine{},
+	err = startSession(ctx, server.URL, testCfg, testCreds, &mockStatsEngine{},
 		50*time.Millisecond, 100*time.Millisecond,
 		testPublishMetricsInterval, deregisterInstanceEventStream)
 	// if we are not blocked here, then the test pass as it will reconnect in StartSession
-	assert.Error(t, err, "Close the connection should cause the tcs client return error")
+	assert.NoError(t, err, "Close the connection should cause the tcs client return error")
 
 	assert.True(t, websocket.IsCloseError(<-serverErr, websocket.CloseAbnormalClosure),
 		"Read from closed connection should produce an io.EOF error")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

Breaking out #2457 into smaller PRs.

This PR does not explicitly cancel the agent's context, but it passes it to more goroutines and fixes some of the waiting and concurrency logic. The routines that it passes to are:

1. spot instance draining poller
2. introspection http endpoint
3. task metadata http endpoint
4. engine event handler
5. tcs handler (already was passing but this change makes it wait and exit correctly when context is cancelled)

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Fix agent top-level context

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
