### PR TITLE
Instance Health: error message handling

### DIFF
--- a/agent/metrics/instancehealth/instancehealth.go
+++ b/agent/metrics/instancehealth/instancehealth.go
@@ -1,7 +1,8 @@
 package instancehealth
 
 import (
-	"fmt"
+	"strings"
+	"sync"
 	"sync/atomic"
 
 	"github.com/aws/amazon-ecs-agent/agent/api/errors"
@@ -11,8 +12,11 @@ import (
 type genericMetric struct {
 	calls        int64
 	errors       int64
-	errorMessage atomic.Value
+	errorMessage string
+	mu           sync.Mutex
 }
+
+const MinimumSampleCount int64 = 10
 
 var DockerMetric *genericMetric
 
@@ -26,16 +30,28 @@ func (gc *genericMetric) IncrementCallCount() {
 
 func (gc *genericMetric) RecordError(errorMessage errors.NamedError) {
 	atomic.AddInt64(&gc.errors, 1)
-	gc.errorMessage.Store(errorMessage.ErrorName() + ": " + errorMessage.Error())
+	atomic.AddInt64(&gc.calls, 1)
+	newMsg := errorMessage.ErrorName() + ": " + errorMessage.Error() + " -- "
+	gc.mu.Lock()
+	if !strings.Contains(gc.errorMessage, newMsg) {
+		gc.errorMessage = gc.errorMessage + newMsg
+	}
+	gc.mu.Unlock()
 }
 
-func (gc *genericMetric) GetErrorMessage() string {
-	errMsg := fmt.Sprintf("%v", gc.errorMessage.Load())
-	return errMsg
+func (gc *genericMetric) GetAndResetErrorMessage() string {
+	gc.mu.Lock()
+	msg := gc.errorMessage
+	gc.errorMessage = ""
+	gc.mu.Unlock()
+	return msg
 }
 
-func (gc *genericMetric) GetAndResetCount() (int64, int64) {
-	callCount := atomic.SwapInt64(&gc.calls, 0)
-	errorCount := atomic.SwapInt64(&gc.errors, 0)
-	return callCount, errorCount
+func (gc *genericMetric) GetAndResetCount() (callCount int64, errCount int64, ok bool) {
+	if atomic.LoadInt64(&gc.calls) < MinimumSampleCount {
+		return 0, 0, false
+	}
+	callCount = atomic.SwapInt64(&gc.calls, 0)
+	errCount = atomic.SwapInt64(&gc.errors, 0)
+	return callCount, errCount, true
 }

--- a/agent/metrics/instancehealth/instancehealth_test.go
+++ b/agent/metrics/instancehealth/instancehealth_test.go
@@ -44,16 +44,16 @@ func TestMetricsCollection(t *testing.T) {
 	testError := &testNamedError{errors.New("TestMetricsCollection")}
 
 	var wg sync.WaitGroup
-	wg.Add(10)
+	wg.Add(int(MinimumSampleCount) * 2)
 
 	//go routine simulates metric collection
-	for i := 0; i < 5; i++ {
+	for i := 0; i < int(MinimumSampleCount); i++ {
 		go func() {
 			defer wg.Done()
 			defer testDockerMetric.IncrementCallCount()
 		}()
 	}
-	for i := 0; i < 5; i++ {
+	for i := 0; i < int(MinimumSampleCount); i++ {
 		go func() {
 			defer wg.Done()
 			defer testDockerMetric.RecordError(testError)
@@ -61,44 +61,63 @@ func TestMetricsCollection(t *testing.T) {
 	}
 	wg.Wait()
 
-	expectedCallCount := int64(5)
-	expectedErrorCount := int64(5)
-	expectedErrorMessage := "TestNamedError: TestMetricsCollection"
+	expectedCallCount := MinimumSampleCount * 2
+	expectedErrorCount := MinimumSampleCount
+	expectedErrorMessage := "TestNamedError: TestMetricsCollection -- "
 
-	actualCallCount, actualErrorCount := testDockerMetric.GetAndResetCount()
-
+	actualCallCount, actualErrorCount, ok := testDockerMetric.GetAndResetCount()
+	assert.True(t, ok)
 	assert.Equal(t, expectedCallCount, actualCallCount)
 	assert.Equal(t, expectedErrorCount, actualErrorCount)
-	assert.Equal(t, expectedErrorMessage, testDockerMetric.GetErrorMessage())
+	assert.Equal(t, expectedErrorMessage, testDockerMetric.GetAndResetErrorMessage())
+}
+
+func TestMetricsCollection_InsufficientSampleCount(t *testing.T) {
+	testDockerMetric := &genericMetric{}
+	testError := &testNamedError{errors.New("TestMetricsCollection")}
+
+	// only two errors are not enough samples
+	testDockerMetric.IncrementCallCount()
+	testDockerMetric.RecordError(testError)
+
+	_, _, ok := testDockerMetric.GetAndResetCount()
+
+	assert.False(t, ok)
 }
 
 func TestResetCount(t *testing.T) {
 	testDockerMetric := &genericMetric{}
 	testError := &testNamedError{errors.New("TestResetCount")}
 
-	var wg sync.WaitGroup
-	wg.Add(10)
-
-	// go routine simulates metric collection
-	for i := 0; i < 5; i++ {
-		go func() {
-			defer wg.Done()
-			defer testDockerMetric.IncrementCallCount()
-		}()
+	for i := 0; i < int(MinimumSampleCount); i++ {
+		testDockerMetric.RecordError(testError)
 	}
-	for i := 0; i < 5; i++ {
-		go func() {
-			defer wg.Done()
-			defer testDockerMetric.RecordError(testError)
-		}()
-	}
-	wg.Wait()
 
 	// Reset the counter
-	testDockerMetric.GetAndResetCount()
+	callCount, errCount, ok := testDockerMetric.GetAndResetCount()
+	assert.Equal(t, int64(MinimumSampleCount), callCount)
+	assert.Equal(t, int64(MinimumSampleCount), errCount)
+	assert.True(t, ok)
+	assert.Equal(t, "TestNamedError: TestResetCount -- ", testDockerMetric.GetAndResetErrorMessage())
+}
 
-	expectedDockerMetric := &genericMetric{}
-	expectedDockerMetric.errorMessage.Store("TestNamedError: TestResetCount")
+// error message should remove duplicate messages and accumulate non-duplicate messages
+func TestErrorMessage(t *testing.T) {
+	testDockerMetric := &genericMetric{}
+	testErrorA := &testNamedError{errors.New("docker error for container A")}
+	testErrorB := &testNamedError{errors.New("docker error for container B")}
 
-	assert.Equal(t, expectedDockerMetric, testDockerMetric, "Reset instance health counter failed")
+	for i := 0; i < int(MinimumSampleCount); i++ {
+		testDockerMetric.RecordError(testErrorA)
+	}
+	for i := 0; i < 5; i++ {
+		testDockerMetric.RecordError(testErrorB)
+	}
+
+	// Reset the counter
+	callCount, errCount, ok := testDockerMetric.GetAndResetCount()
+	assert.Equal(t, int64(MinimumSampleCount+5), callCount)
+	assert.Equal(t, int64(MinimumSampleCount+5), errCount)
+	assert.True(t, ok)
+	assert.Equal(t, "TestNamedError: docker error for container A -- TestNamedError: docker error for container B -- ", testDockerMetric.GetAndResetErrorMessage())
 }

--- a/agent/metrics/instancehealth/interface.go
+++ b/agent/metrics/instancehealth/interface.go
@@ -15,9 +15,11 @@ type InstanceHealth interface {
 	// Records the error message and increments the API's error count
 	RecordError(errors.NamedError)
 
-	//  Returns the error message
-	GetErrorMessage() string
+	//  Returns the error message and resets to empty
+	GetAndResetErrorMessage() string
 
 	// This function returns API call and error count resets their count
-	GetAndResetCount() (int64, int64)
+	// Returns false if there have been less than 10 calls recorded because
+	// this represents an insufficient number of samples.
+	GetAndResetCount() (callCount int64, errCount int64, ok bool)
 }

--- a/agent/tcs/handler/handler.go
+++ b/agent/tcs/handler/handler.go
@@ -37,7 +37,7 @@ const (
 	// defaultPublishMetricsInterval is the interval at which utilization
 	// metrics from stats engine are published to the backend.
 	defaultPublishMetricsInterval               = 20 * time.Second
-	defaultPublishInstanceHealthMetricsInterval = 3 * time.Minute
+	defaultPublishInstanceHealthMetricsInterval = 1 * time.Minute
 	// The maximum time to wait between heartbeats without disconnecting
 	defaultHeartbeatTimeout = 1 * time.Minute
 	defaultHeartbeatJitter  = 1 * time.Minute


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

1. Changes error message handling to accumulate errors that occurred in an interval (but also deduplicate). This is so we can see all unique errors that happened when there were multiple within an interval.
2. Changes the error message getter function to reset the message so that we don't see error messages from a previous interval.
3. Set a minimum sample count (10) needed for clearing and publishing instance health metrics. This is so that if we have a period of sparse metrics, we will eventually accumulate enough samples to make a valid metric.
4. Reduce publishing interval from 3 to 1 minute.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
