### PR TITLE
refactoring - agent capabilities

### DIFF
--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -62,6 +62,28 @@ const (
 	capabilityEnvFilesS3                        = "env-files.s3"
 )
 
+var nameOnlyAttributes = []string{
+	// ecs agent version 1.19.0 supports private registry authentication using
+	// aws secrets manager
+	capabilityPrivateRegistryAuthASM,
+	// ecs agent version 1.22.0 supports ecs secrets integrating with aws systems manager
+	capabilitySecretEnvSSM,
+	// ecs agent version 1.27.0 supports ecs secrets for logging drivers
+	capabilitySecretLogDriverSSM,
+	// support ecr endpoint override
+	capabilityECREndpoint,
+	// ecs agent version 1.23.0 supports ecs secrets integrating with aws secrets manager
+	capabilitySecretEnvASM,
+	// ecs agent version 1.27.0 supports ecs secrets for logging drivers
+	capabilitySecretLogDriverASM,
+	// support container ordering in agent
+	capabilityContainerOrdering,
+	// support full task sync
+	capabilityFullTaskSync,
+	// ecs agent version 1.39.0 supports bulk loading env vars through environmentFiles in S3
+	capabilityEnvFilesS3,
+}
+
 // capabilities returns the supported capabilities of this agent / docker-client pair.
 // Currently, the following capabilities are possible:
 //
@@ -111,6 +133,10 @@ const (
 func (agent *ecsAgent) capabilities() ([]*ecs.Attribute, error) {
 	var capabilities []*ecs.Attribute
 
+	for _, cap := range nameOnlyAttributes {
+		capabilities = appendNameOnlyAttribute(capabilities, attributePrefix+cap)
+	}
+
 	if !agent.cfg.PrivilegedDisabled {
 		capabilities = appendNameOnlyAttribute(capabilities, capabilityPrefix+"privileged-container")
 	}
@@ -151,36 +177,9 @@ func (agent *ecsAgent) capabilities() ([]*ecs.Attribute, error) {
 
 	capabilities = agent.appendVolumeDriverCapabilities(capabilities)
 
-	// ecs agent version 1.19.0 supports private registry authentication using
-	// aws secrets manager
-	capabilities = appendNameOnlyAttribute(capabilities, attributePrefix+capabilityPrivateRegistryAuthASM)
-
-	// ecs agent version 1.22.0 supports ecs secrets integrating with aws systems manager
-	capabilities = appendNameOnlyAttribute(capabilities, attributePrefix+capabilitySecretEnvSSM)
-
-	// ecs agent version 1.27.0 supports ecs secrets for logging drivers
-	capabilities = appendNameOnlyAttribute(capabilities, attributePrefix+capabilitySecretLogDriverSSM)
-
 	if agent.cfg.GPUSupportEnabled {
 		capabilities = agent.appendNvidiaDriverVersionAttribute(capabilities)
 	}
-	// support ecr endpoint override
-	capabilities = appendNameOnlyAttribute(capabilities, attributePrefix+capabilityECREndpoint)
-
-	// ecs agent version 1.23.0 supports ecs secrets integrating with aws secrets manager
-	capabilities = appendNameOnlyAttribute(capabilities, attributePrefix+capabilitySecretEnvASM)
-
-	// ecs agent version 1.27.0 supports ecs secrets for logging drivers
-	capabilities = appendNameOnlyAttribute(capabilities, attributePrefix+capabilitySecretLogDriverASM)
-
-	// support container ordering in agent
-	capabilities = appendNameOnlyAttribute(capabilities, attributePrefix+capabilityContainerOrdering)
-
-	// support full task sync
-	capabilities = appendNameOnlyAttribute(capabilities, attributePrefix+capabilityFullTaskSync)
-
-	// ecs agent version 1.39.0 supports bulk loading env vars through environmentFiles in S3
-	capabilities = appendNameOnlyAttribute(capabilities, attributePrefix+capabilityEnvFilesS3)
 
 	// ecs agent version 1.22.0 supports sharing PID namespaces and IPC resource namespaces
 	// with host EC2 instance and among containers within the task

--- a/agent/app/agent_capability_unix_test.go
+++ b/agent/app/agent_capability_unix_test.go
@@ -85,15 +85,20 @@ func TestVolumeDriverCapabilitiesUnix(t *testing.T) {
 	)
 
 	expectedCapabilityNames := []string{
-		"com.amazonaws.ecs.capability.privileged-container",
-		"com.amazonaws.ecs.capability.docker-remote-api.1.17",
-		"com.amazonaws.ecs.capability.docker-remote-api.1.18",
-		"com.amazonaws.ecs.capability.logging-driver.json-file",
-		"com.amazonaws.ecs.capability.logging-driver.syslog",
-		"com.amazonaws.ecs.capability.logging-driver.journald",
-		"com.amazonaws.ecs.capability.selinux",
-		"com.amazonaws.ecs.capability.apparmor",
-		attributePrefix + taskENIAttributeSuffix,
+		capabilityPrefix + "privileged-container",
+		capabilityPrefix + "docker-remote-api.1.17",
+		capabilityPrefix + "docker-remote-api.1.18",
+		capabilityPrefix + "logging-driver.json-file",
+		capabilityPrefix + "logging-driver.syslog",
+		capabilityPrefix + "logging-driver.journald",
+		capabilityPrefix + "selinux",
+		capabilityPrefix + "apparmor",
+		attributePrefix + "docker-plugin.local",
+		attributePrefix + "docker-plugin.fancyvolumedriver",
+		attributePrefix + "docker-plugin.coolvolumedriver",
+		attributePrefix + "docker-plugin.volumedriver",
+		attributePrefix + "docker-plugin.volumedriver.latest",
+		attributePrefix + taskENIBlockInstanceMetadataAttributeSuffix,
 	}
 
 	var expectedCapabilities []*ecs.Attribute
@@ -106,24 +111,6 @@ func TestVolumeDriverCapabilitiesUnix(t *testing.T) {
 			{
 				Name:  aws.String(attributePrefix + cniPluginVersionSuffix),
 				Value: aws.String("v1"),
-			},
-			{
-				Name: aws.String(attributePrefix + taskENIBlockInstanceMetadataAttributeSuffix),
-			},
-			{
-				Name: aws.String("ecs.capability.docker-plugin.local"),
-			},
-			{
-				Name: aws.String(attributePrefix + "docker-plugin.fancyvolumedriver"),
-			},
-			{
-				Name: aws.String(attributePrefix + "docker-plugin.coolvolumedriver"),
-			},
-			{
-				Name: aws.String(attributePrefix + "docker-plugin.volumedriver"),
-			},
-			{
-				Name: aws.String(attributePrefix + "docker-plugin.volumedriver.latest"),
 			},
 		}...)
 
@@ -142,9 +129,11 @@ func TestVolumeDriverCapabilitiesUnix(t *testing.T) {
 	capabilities, err := agent.capabilities()
 	assert.NoError(t, err)
 
-	for i, expected := range expectedCapabilities {
-		assert.Equal(t, aws.StringValue(expected.Name), aws.StringValue(capabilities[i].Name))
-		assert.Equal(t, aws.StringValue(expected.Value), aws.StringValue(capabilities[i].Value))
+	for _, expected := range expectedCapabilities {
+		assert.Contains(t, capabilities, &ecs.Attribute{
+			Name:  expected.Name,
+			Value: expected.Value,
+		})
 	}
 }
 
@@ -175,7 +164,13 @@ func TestNvidiaDriverCapabilitiesUnix(t *testing.T) {
 	)
 
 	expectedCapabilityNames := []string{
-		"com.amazonaws.ecs.capability.docker-remote-api.1.17",
+		capabilityPrefix + "docker-remote-api.1.17",
+		attributePrefix + "docker-plugin.local",
+		attributePrefix + capabilityPrivateRegistryAuthASM,
+		attributePrefix + capabilitySecretEnvSSM,
+		attributePrefix + capabilitySecretLogDriverSSM,
+		// nvidia driver version capability
+		attributePrefix + "nvidia-driver-version.396.44",
 	}
 
 	var expectedCapabilities []*ecs.Attribute
@@ -183,26 +178,6 @@ func TestNvidiaDriverCapabilitiesUnix(t *testing.T) {
 		expectedCapabilities = append(expectedCapabilities,
 			&ecs.Attribute{Name: aws.String(name)})
 	}
-	expectedCapabilities = append(expectedCapabilities,
-		[]*ecs.Attribute{
-			// linux specific capabilities
-			{
-				Name: aws.String("ecs.capability.docker-plugin.local"),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilityPrivateRegistryAuthASM),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilitySecretEnvSSM),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilitySecretLogDriverSSM),
-			},
-			// nvidia driver version capability
-			{
-				Name: aws.String(attributePrefix + "nvidia-driver-version.396.44"),
-			},
-		}...)
 
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines
@@ -223,9 +198,11 @@ func TestNvidiaDriverCapabilitiesUnix(t *testing.T) {
 	capabilities, err := agent.capabilities()
 	assert.NoError(t, err)
 
-	for i, expected := range expectedCapabilities {
-		assert.Equal(t, aws.StringValue(expected.Name), aws.StringValue(capabilities[i].Name))
-		assert.Equal(t, aws.StringValue(expected.Value), aws.StringValue(capabilities[i].Value))
+	for _, expected := range expectedCapabilities {
+		assert.Contains(t, capabilities, &ecs.Attribute{
+			Name:  expected.Name,
+			Value: expected.Value,
+		})
 	}
 }
 
@@ -256,7 +233,11 @@ func TestEmptyNvidiaDriverCapabilitiesUnix(t *testing.T) {
 	)
 
 	expectedCapabilityNames := []string{
-		"com.amazonaws.ecs.capability.docker-remote-api.1.17",
+		capabilityPrefix + "docker-remote-api.1.17",
+		attributePrefix + "docker-plugin.local",
+		attributePrefix + capabilityPrivateRegistryAuthASM,
+		attributePrefix + capabilitySecretEnvSSM,
+		attributePrefix + capabilitySecretLogDriverSSM,
 	}
 
 	var expectedCapabilities []*ecs.Attribute
@@ -264,23 +245,6 @@ func TestEmptyNvidiaDriverCapabilitiesUnix(t *testing.T) {
 		expectedCapabilities = append(expectedCapabilities,
 			&ecs.Attribute{Name: aws.String(name)})
 	}
-	expectedCapabilities = append(expectedCapabilities,
-		[]*ecs.Attribute{
-			// linux specific capabilities
-
-			{
-				Name: aws.String("ecs.capability.docker-plugin.local"),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilityPrivateRegistryAuthASM),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilitySecretEnvSSM),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilitySecretLogDriverSSM),
-			},
-		}...)
 
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines
@@ -301,9 +265,11 @@ func TestEmptyNvidiaDriverCapabilitiesUnix(t *testing.T) {
 	capabilities, err := agent.capabilities()
 	assert.NoError(t, err)
 
-	for i, expected := range expectedCapabilities {
-		assert.Equal(t, aws.StringValue(expected.Name), aws.StringValue(capabilities[i].Name))
-		assert.Equal(t, aws.StringValue(expected.Value), aws.StringValue(capabilities[i].Value))
+	for _, expected := range expectedCapabilities {
+		assert.Contains(t, capabilities, &ecs.Attribute{
+			Name:  expected.Name,
+			Value: expected.Value,
+		})
 	}
 }
 
@@ -338,8 +304,14 @@ func TestENITrunkingCapabilitiesUnix(t *testing.T) {
 	)
 
 	expectedCapabilityNames := []string{
-		"com.amazonaws.ecs.capability.docker-remote-api.1.17",
+		capabilityPrefix + "docker-remote-api.1.17",
+		attributePrefix + "docker-plugin.local",
 		attributePrefix + taskENIAttributeSuffix,
+		attributePrefix + taskENITrunkingAttributeSuffix,
+		attributePrefix + taskENITrunkingAttributeSuffix,
+		attributePrefix + capabilityPrivateRegistryAuthASM,
+		attributePrefix + capabilitySecretEnvSSM,
+		attributePrefix + capabilitySecretLogDriverSSM,
 	}
 
 	var expectedCapabilities []*ecs.Attribute
@@ -355,23 +327,8 @@ func TestENITrunkingCapabilitiesUnix(t *testing.T) {
 				Value: aws.String("v1"),
 			},
 			{
-				Name: aws.String(attributePrefix + taskENITrunkingAttributeSuffix),
-			},
-			{
 				Name:  aws.String(attributePrefix + branchCNIPluginVersionSuffix),
 				Value: aws.String("v2"),
-			},
-			{
-				Name: aws.String("ecs.capability.docker-plugin.local"),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilityPrivateRegistryAuthASM),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilitySecretEnvSSM),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilitySecretLogDriverSSM),
 			},
 		}...)
 
@@ -390,10 +347,13 @@ func TestENITrunkingCapabilitiesUnix(t *testing.T) {
 	capabilities, err := agent.capabilities()
 	assert.NoError(t, err)
 
-	for i, expected := range expectedCapabilities {
-		assert.Equal(t, aws.StringValue(expected.Name), aws.StringValue(capabilities[i].Name))
-		assert.Equal(t, aws.StringValue(expected.Value), aws.StringValue(capabilities[i].Value))
+	for _, expected := range expectedCapabilities {
+		assert.Contains(t, capabilities, &ecs.Attribute{
+			Name:  expected.Name,
+			Value: expected.Value,
+		})
 	}
+
 }
 
 func TestNoENITrunkingCapabilitiesUnix(t *testing.T) {
@@ -426,10 +386,13 @@ func TestNoENITrunkingCapabilitiesUnix(t *testing.T) {
 	)
 
 	expectedCapabilityNames := []string{
-		"com.amazonaws.ecs.capability.docker-remote-api.1.17",
+		capabilityPrefix + "docker-remote-api.1.17",
+		attributePrefix + "docker-plugin.local",
 		attributePrefix + taskENIAttributeSuffix,
+		attributePrefix + capabilityPrivateRegistryAuthASM,
+		attributePrefix + capabilitySecretEnvSSM,
+		attributePrefix + capabilitySecretLogDriverSSM,
 	}
-
 	var expectedCapabilities []*ecs.Attribute
 	for _, name := range expectedCapabilityNames {
 		expectedCapabilities = append(expectedCapabilities,
@@ -441,18 +404,6 @@ func TestNoENITrunkingCapabilitiesUnix(t *testing.T) {
 			{
 				Name:  aws.String(attributePrefix + cniPluginVersionSuffix),
 				Value: aws.String("v1"),
-			},
-			{
-				Name: aws.String("ecs.capability.docker-plugin.local"),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilityPrivateRegistryAuthASM),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilitySecretEnvSSM),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilitySecretLogDriverSSM),
 			},
 		}...)
 
@@ -471,9 +422,11 @@ func TestNoENITrunkingCapabilitiesUnix(t *testing.T) {
 	capabilities, err := agent.capabilities()
 	assert.NoError(t, err)
 
-	for i, expected := range expectedCapabilities {
-		assert.Equal(t, aws.StringValue(expected.Name), aws.StringValue(capabilities[i].Name))
-		assert.Equal(t, aws.StringValue(expected.Value), aws.StringValue(capabilities[i].Value))
+	for _, expected := range expectedCapabilities {
+		assert.Contains(t, capabilities, &ecs.Attribute{
+			Name:  expected.Name,
+			Value: expected.Value,
+		})
 	}
 }
 
@@ -503,7 +456,18 @@ func TestPIDAndIPCNamespaceSharingCapabilitiesUnix(t *testing.T) {
 	)
 
 	expectedCapabilityNames := []string{
-		"com.amazonaws.ecs.capability.docker-remote-api.1.17",
+		capabilityPrefix + "docker-remote-api.1.17",
+		attributePrefix + "docker-plugin.local",
+		attributePrefix + capabilityPrivateRegistryAuthASM,
+		attributePrefix + capabilitySecretEnvSSM,
+		attributePrefix + capabilitySecretLogDriverSSM,
+		attributePrefix + capabilityECREndpoint,
+		attributePrefix + capabilitySecretEnvASM,
+		attributePrefix + capabilitySecretLogDriverASM,
+		attributePrefix + capabilityContainerOrdering,
+		attributePrefix + capabilityFullTaskSync,
+		attributePrefix + capabilityEnvFilesS3,
+		attributePrefix + capabiltyPIDAndIPCNamespaceSharing,
 	}
 
 	var expectedCapabilities []*ecs.Attribute
@@ -511,43 +475,6 @@ func TestPIDAndIPCNamespaceSharingCapabilitiesUnix(t *testing.T) {
 		expectedCapabilities = append(expectedCapabilities,
 			&ecs.Attribute{Name: aws.String(name)})
 	}
-	expectedCapabilities = append(expectedCapabilities,
-		[]*ecs.Attribute{
-			// linux specific capabilities
-			{
-				Name: aws.String("ecs.capability.docker-plugin.local"),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilityPrivateRegistryAuthASM),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilitySecretEnvSSM),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilitySecretLogDriverSSM),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilityECREndpoint),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilitySecretEnvASM),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilitySecretLogDriverASM),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilityContainerOrdering),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilityFullTaskSync),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilityEnvFilesS3),
-			},
-			{
-				Name: aws.String(attributePrefix + capabiltyPIDAndIPCNamespaceSharing),
-			},
-		}...)
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines
 	defer cancel()
@@ -562,9 +489,11 @@ func TestPIDAndIPCNamespaceSharingCapabilitiesUnix(t *testing.T) {
 	capabilities, err := agent.capabilities()
 	assert.NoError(t, err)
 
-	for i, expected := range expectedCapabilities {
-		assert.Equal(t, aws.StringValue(expected.Name), aws.StringValue(capabilities[i].Name))
-		assert.Equal(t, aws.StringValue(expected.Value), aws.StringValue(capabilities[i].Value))
+	for _, expected := range expectedCapabilities {
+		assert.Contains(t, capabilities, &ecs.Attribute{
+			Name:  expected.Name,
+			Value: expected.Value,
+		})
 	}
 }
 
@@ -594,7 +523,17 @@ func TestPIDAndIPCNamespaceSharingCapabilitiesNoPauseContainer(t *testing.T) {
 	)
 
 	expectedCapabilityNames := []string{
-		"com.amazonaws.ecs.capability.docker-remote-api.1.17",
+		capabilityPrefix + "docker-remote-api.1.17",
+		attributePrefix + "docker-plugin.local",
+		attributePrefix + capabilityPrivateRegistryAuthASM,
+		attributePrefix + capabilitySecretEnvSSM,
+		attributePrefix + capabilitySecretLogDriverSSM,
+		attributePrefix + capabilityECREndpoint,
+		attributePrefix + capabilitySecretEnvASM,
+		attributePrefix + capabilitySecretLogDriverASM,
+		attributePrefix + capabilityContainerOrdering,
+		attributePrefix + capabilityFullTaskSync,
+		attributePrefix + capabilityEnvFilesS3,
 	}
 
 	var expectedCapabilities []*ecs.Attribute
@@ -602,40 +541,6 @@ func TestPIDAndIPCNamespaceSharingCapabilitiesNoPauseContainer(t *testing.T) {
 		expectedCapabilities = append(expectedCapabilities,
 			&ecs.Attribute{Name: aws.String(name)})
 	}
-	expectedCapabilities = append(expectedCapabilities,
-		[]*ecs.Attribute{
-			// linux specific capabilities
-			{
-				Name: aws.String("ecs.capability.docker-plugin.local"),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilityPrivateRegistryAuthASM),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilitySecretEnvSSM),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilitySecretLogDriverSSM),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilityECREndpoint),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilitySecretEnvASM),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilitySecretLogDriverASM),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilityContainerOrdering),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilityFullTaskSync),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilityEnvFilesS3),
-			},
-		}...)
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines
 	defer cancel()
@@ -650,9 +555,11 @@ func TestPIDAndIPCNamespaceSharingCapabilitiesNoPauseContainer(t *testing.T) {
 	capabilities, err := agent.capabilities()
 	assert.NoError(t, err)
 
-	for i, expected := range expectedCapabilities {
-		assert.Equal(t, aws.StringValue(expected.Name), aws.StringValue(capabilities[i].Name))
-		assert.Equal(t, aws.StringValue(expected.Value), aws.StringValue(capabilities[i].Value))
+	for _, expected := range expectedCapabilities {
+		assert.Contains(t, capabilities, &ecs.Attribute{
+			Name:  expected.Name,
+			Value: expected.Value,
+		})
 	}
 }
 
@@ -682,7 +589,19 @@ func TestAppMeshCapabilitiesUnix(t *testing.T) {
 	)
 
 	expectedCapabilityNames := []string{
-		"com.amazonaws.ecs.capability.docker-remote-api.1.17",
+		capabilityPrefix + "docker-remote-api.1.17",
+		attributePrefix + "docker-plugin.local",
+		attributePrefix + capabilityPrivateRegistryAuthASM,
+		attributePrefix + capabilitySecretEnvSSM,
+		attributePrefix + capabilitySecretLogDriverSSM,
+		attributePrefix + capabilityECREndpoint,
+		attributePrefix + capabilitySecretEnvASM,
+		attributePrefix + capabilitySecretLogDriverASM,
+		attributePrefix + capabilityContainerOrdering,
+		attributePrefix + capabilityFullTaskSync,
+		attributePrefix + capabilityEnvFilesS3,
+		attributePrefix + capabiltyPIDAndIPCNamespaceSharing,
+		attributePrefix + appMeshAttributeSuffix,
 	}
 
 	var expectedCapabilities []*ecs.Attribute
@@ -690,46 +609,7 @@ func TestAppMeshCapabilitiesUnix(t *testing.T) {
 		expectedCapabilities = append(expectedCapabilities,
 			&ecs.Attribute{Name: aws.String(name)})
 	}
-	expectedCapabilities = append(expectedCapabilities,
-		[]*ecs.Attribute{
-			// linux specific capabilities
-			{
-				Name: aws.String("ecs.capability.docker-plugin.local"),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilityPrivateRegistryAuthASM),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilitySecretEnvSSM),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilitySecretLogDriverSSM),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilityECREndpoint),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilitySecretEnvASM),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilitySecretLogDriverASM),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilityContainerOrdering),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilityFullTaskSync),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilityEnvFilesS3),
-			},
-			{
-				Name: aws.String(attributePrefix + capabiltyPIDAndIPCNamespaceSharing),
-			},
-			{
-				Name: aws.String(attributePrefix + appMeshAttributeSuffix),
-			},
-		}...)
+
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines
 	defer cancel()
@@ -744,9 +624,11 @@ func TestAppMeshCapabilitiesUnix(t *testing.T) {
 	capabilities, err := agent.capabilities()
 	assert.NoError(t, err)
 
-	for i, expected := range expectedCapabilities {
-		assert.Equal(t, aws.StringValue(expected.Name), aws.StringValue(capabilities[i].Name))
-		assert.Equal(t, aws.StringValue(expected.Value), aws.StringValue(capabilities[i].Value))
+	for _, expected := range expectedCapabilities {
+		assert.Contains(t, capabilities, &ecs.Attribute{
+			Name:  expected.Name,
+			Value: expected.Value,
+		})
 	}
 }
 
@@ -874,7 +756,24 @@ func TestCapabilitiesUnix(t *testing.T) {
 	)
 
 	expectedCapabilityNames := []string{
-		"com.amazonaws.ecs.capability.docker-remote-api.1.17",
+		capabilityPrefix + "docker-remote-api.1.17",
+		attributePrefix + "docker-plugin.local",
+		attributePrefix + capabilityPrivateRegistryAuthASM,
+		attributePrefix + capabilitySecretEnvSSM,
+		attributePrefix + capabilitySecretLogDriverSSM,
+		attributePrefix + capabilityECREndpoint,
+		attributePrefix + capabilitySecretEnvASM,
+		attributePrefix + capabilitySecretLogDriverASM,
+		attributePrefix + capabilityContainerOrdering,
+		attributePrefix + capabiltyPIDAndIPCNamespaceSharing,
+		attributePrefix + appMeshAttributeSuffix,
+		attributePrefix + taskEIAAttributeSuffix,
+		attributePrefix + capabilityFirelensFluentd,
+		attributePrefix + capabilityFirelensFluentbit,
+		attributePrefix + capabilityEFS,
+		attributePrefix + capabilityEFSAuth,
+		capabilityPrefix + capabilityFirelensLoggingDriver,
+		attributePrefix + capabilityEnvFilesS3,
 	}
 
 	var expectedCapabilities []*ecs.Attribute
@@ -882,61 +781,6 @@ func TestCapabilitiesUnix(t *testing.T) {
 		expectedCapabilities = append(expectedCapabilities,
 			&ecs.Attribute{Name: aws.String(name)})
 	}
-	expectedCapabilities = append(expectedCapabilities,
-		[]*ecs.Attribute{
-			// linux specific capabilities
-			{
-				Name: aws.String("ecs.capability.docker-plugin.local"),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilityPrivateRegistryAuthASM),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilitySecretEnvSSM),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilitySecretLogDriverSSM),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilityECREndpoint),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilitySecretEnvASM),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilitySecretLogDriverASM),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilityContainerOrdering),
-			},
-			{
-				Name: aws.String(attributePrefix + capabiltyPIDAndIPCNamespaceSharing),
-			},
-			{
-				Name: aws.String(attributePrefix + appMeshAttributeSuffix),
-			},
-			{
-				Name: aws.String(attributePrefix + taskEIAAttributeSuffix),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilityFirelensFluentd),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilityFirelensFluentbit),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilityEFS),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilityEFSAuth),
-			},
-			{
-				Name: aws.String(capabilityPrefix + capabilityFirelensLoggingDriver),
-			},
-			{
-				Name: aws.String(attributePrefix + capabilityEnvFilesS3),
-			},
-		}...)
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines
 	defer cancel()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Refactored name-only attributes of agent capabilities to reduce code duplication. 
This also removes order sensitivity while adding new attributes and in unit testing 

### Implementation details
<!-- How are the changes implemented? -->
- In agent_capability.go, moved all the name-only attributes to an array instead to reduce code.
- Updated unit tests accordingly 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
