### PR TITLE
Instance Health: error message handling

### DIFF
--- a/agent/metrics/instancehealth/interface.go
+++ b/agent/metrics/instancehealth/interface.go
@@ -15,9 +15,11 @@ type InstanceHealth interface {
 	// Records the error message and increments the API's error count
 	RecordError(errors.NamedError)
 
-	//  Returns the error message
-	GetErrorMessage() string
+	//  Returns the error message and resets to empty
+	GetAndResetErrorMessage() string
 
 	// This function returns API call and error count resets their count
-	GetAndResetCount() (int64, int64)
+	// Returns false if there have been less than 10 calls recorded because
+	// this represents an insufficient number of samples.
+	GetAndResetCount() (callCount int64, errCount int64, ok bool)
 }


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

1. Changes error message handling to accumulate errors that occurred in an interval (but also deduplicate). This is so we can see all unique errors that happened when there were multiple within an interval.
2. Changes the error message getter function to reset the message so that we don't see error messages from a previous interval.
3. Set a minimum sample count (10) needed for clearing and publishing instance health metrics. This is so that if we have a period of sparse metrics, we will eventually accumulate enough samples to make a valid metric.
4. Reduce publishing interval from 3 to 1 minute.


### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
