### PR TITLE
Calculate per-sec network metrics for RXBytes and TxBytes

### DIFF
--- a/agent/stats/types.go
+++ b/agent/stats/types.go
@@ -35,14 +35,16 @@ type ContainerStats struct {
 
 // NetworkStats contains the network stats information for a container
 type NetworkStats struct {
-	RxBytes   uint64 `json:"rxBytes"`
-	RxDropped uint64 `json:"rxDropped"`
-	RxErrors  uint64 `json:"rxErrors"`
-	RxPackets uint64 `json:"rxPackets"`
-	TxBytes   uint64 `json:"txBytes"`
-	TxDropped uint64 `json:"txDropped"`
-	TxErrors  uint64 `json:"txErrors"`
-	TxPackets uint64 `json:"txPackets"`
+	RxBytes          uint64  `json:"rxBytes"`
+	RxDropped        uint64  `json:"rxDropped"`
+	RxErrors         uint64  `json:"rxErrors"`
+	RxPackets        uint64  `json:"rxPackets"`
+	TxBytes          uint64  `json:"txBytes"`
+	TxDropped        uint64  `json:"txDropped"`
+	TxErrors         uint64  `json:"txErrors"`
+	TxPackets        uint64  `json:"txPackets"`
+	RxBytesPerSecond float32 `json:"rxBytesPerSecond"`
+	TxBytesPerSecond float32 `json:"txBytesPerSecond"`
 }
 
 // UsageStats abstracts the format in which the queue stores data.

--- a/agent/stats/utils.go
+++ b/agent/stats/utils.go
@@ -43,5 +43,7 @@ func getNetworkStats(dockerStats *types.StatsJSON) *NetworkStats {
 		networkStats.TxErrors += netStats.TxErrors
 		networkStats.TxPackets += netStats.TxPackets
 	}
+	networkStats.RxBytesPerSecond = float32(nan32())
+	networkStats.TxBytesPerSecond = float32(nan32())
 	return networkStats
 }

--- a/agent/stats/utils_test.go
+++ b/agent/stats/utils_test.go
@@ -18,6 +18,7 @@ package stats
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"testing"
 
 	"github.com/docker/docker/api/types"
@@ -78,4 +79,6 @@ func validateNetworkMetrics(t *testing.T, netStats *NetworkStats) {
 	assert.Equal(t, expectedTxPackets, netStats.TxPackets)
 	assert.Equal(t, expectedTxDropped, netStats.TxDropped)
 	assert.Equal(t, expectedTxErrors, netStats.TxErrors)
+	assert.True(t, math.IsNaN(float64(netStats.RxBytesPerSecond)))
+	assert.True(t, math.IsNaN(float64(netStats.TxBytesPerSecond)))
 }

--- a/agent/tcs/model/api/api-2.json
+++ b/agent/tcs/model/api/api-2.json
@@ -205,7 +205,9 @@
         "txBytes":{"shape":"ULongStatsSet"},
         "txDropped":{"shape":"ULongStatsSet"},
         "txErrors":{"shape":"ULongStatsSet"},
-        "txPackets":{"shape":"ULongStatsSet"}
+        "txPackets":{"shape":"ULongStatsSet"},
+        "txBytesPerSecond":{"shape":"CWStatsSet"},
+        "rxBytesPerSecond":{"shape":"CWStatsSet"}
       }
     },
     "PublishHealthRequest":{

--- a/agent/tcs/model/ecstcs/api.go
+++ b/agent/tcs/model/ecstcs/api.go
@@ -285,6 +285,10 @@ type NetworkStatsSet struct {
 	TxErrors *ULongStatsSet `locationName:"txErrors" type:"structure"`
 
 	TxPackets *ULongStatsSet `locationName:"txPackets" type:"structure"`
+
+	RxBytesPerSecond *CWStatsSet `locationName:"rxBytesPerSecond" type:"structure"`
+
+	TxBytesPerSecond *CWStatsSet `locationName:"txBytesPerSecond" type:"structure"`
 }
 
 // String returns the string representation
@@ -338,6 +342,16 @@ func (s *NetworkStatsSet) Validate() error {
 	if s.TxPackets != nil {
 		if err := s.TxPackets.Validate(); err != nil {
 			invalidParams.AddNested("TxPackets", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.RxBytesPerSecond != nil {
+		if err := s.TxPackets.Validate(); err != nil {
+			invalidParams.AddNested("RxBytesPerSecond", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.TxBytesPerSecond != nil {
+		if err := s.TxPackets.Validate(); err != nil {
+			invalidParams.AddNested("TxBytesPerSecond", err.(request.ErrInvalidParams))
 		}
 	}
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Calculate RxBytes/sec and TxBytes/sec metrics for bridge network mode.

### Implementation details
<!-- How are the changes implemented? -->
Added the fields RxBytesPerSecond and TxBytesPerSecond to the existing networkStats struct. The above mentioned network metrics for last stat in the queue will be stored in memory and we will find the difference in value of currentStats and lastStats and divide it with the timeDuration between the 2 stats in seconds.

### Testing
<!-- How was this tested? -->
Started a task which creates network traffic and saw that the calculation was happening as expected.
Added unit test for the same.
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
