### PR TITLE
Implement task/container related methods for boltdb data client

### DIFF
--- a/agent/api/container/container.go
+++ b/agent/api/container/container.go
@@ -112,6 +112,8 @@ type Container struct {
 	Name string
 	// RuntimeID is the docker id of the container
 	RuntimeID string
+	// TaskARN is the task ARN of the task that the container belongs to.
+	TaskARN string
 	// DependsOnUnsafe is the field which specifies the ordering for container startup and shutdown.
 	DependsOnUnsafe []DependsOn `json:"dependsOn,omitempty"`
 	// V3EndpointID is a container identifier used to construct v3 metadata endpoint; it's unique among
@@ -1120,6 +1122,7 @@ func (c *Container) GetEnvironmentFiles() []EnvironmentFile {
 	return c.EnvironmentFiles
 }
 
+// RequireNeuronRuntime checks if the container needs to use the neuron runtime.
 func (c *Container) RequireNeuronRuntime() bool {
 	c.lock.RLock()
 	defer c.lock.RUnlock()

--- a/agent/data/client_test.go
+++ b/agent/data/client_test.go
@@ -1,0 +1,53 @@
+// +build unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package data
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/boltdb/bolt"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestClient(t *testing.T) (Client, func()) {
+	testDir, err := ioutil.TempDir("", "agent_data_unit_test")
+	require.NoError(t, err)
+
+	testDB, err := bolt.Open(filepath.Join(testDir, dbName), dbMode, nil)
+	require.NoError(t, err)
+	require.NoError(t, testDB.Update(func(tx *bolt.Tx) error {
+		for _, b := range buckets {
+			_, err = tx.CreateBucketIfNotExists([]byte(b))
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}))
+	testClient := &client{
+		db: testDB,
+	}
+
+	cleanup := func() {
+		require.NoError(t, testClient.Close())
+		require.NoError(t, os.RemoveAll(testDir))
+	}
+	return testClient, cleanup
+}

--- a/agent/data/container_client_test.go
+++ b/agent/data/container_client_test.go
@@ -1,0 +1,90 @@
+// +build unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package data
+
+import (
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
+
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testDockerID       = "test-docker-id"
+	testDockerName     = "test-docker-name"
+	testContainerName  = "test-name"
+	testContainerName2 = "test-name-2"
+)
+
+func TestManageContainers(t *testing.T) {
+	testClient, cleanup := newTestClient(t)
+	defer cleanup()
+
+	// Test saving a container with SaveDockerContainer and updating it with SaveContainer.
+	testDockerContainer := &apicontainer.DockerContainer{
+		DockerID:   testDockerID,
+		DockerName: testDockerName,
+		Container: &apicontainer.Container{
+			Name:    testContainerName,
+			TaskARN: testTaskArn,
+		},
+	}
+	require.NoError(t, testClient.SaveDockerContainer(testDockerContainer))
+	testDockerContainer.Container.SetKnownStatus(apicontainerstatus.ContainerRunning)
+	require.NoError(t, testClient.SaveContainer(testDockerContainer.Container))
+	res, err := testClient.GetContainers()
+	require.NoError(t, err)
+	assert.Len(t, res, 1)
+	assert.Equal(t, apicontainerstatus.ContainerRunning, res[0].Container.GetKnownStatus())
+	assert.Equal(t, testDockerID, res[0].DockerID)
+	assert.Equal(t, testDockerName, res[0].DockerName)
+
+	// Test saving a container with SaveContainer.
+	testContainer := &apicontainer.Container{
+		Name:    testContainerName2,
+		TaskARN: testTaskArn,
+	}
+	require.NoError(t, testClient.SaveContainer(testContainer))
+	res, err = testClient.GetContainers()
+	require.NoError(t, err)
+	assert.Len(t, res, 2)
+
+	// Test deleting containers.
+	require.NoError(t, testClient.DeleteContainer("abc-test-name"))
+	require.NoError(t, testClient.DeleteContainer("abc-test-name-2"))
+	res, err = testClient.GetContainers()
+	require.NoError(t, err)
+	assert.Len(t, res, 0)
+}
+
+func TestSaveContainerInvalidID(t *testing.T) {
+	testClient, cleanup := newTestClient(t)
+	defer cleanup()
+
+	testDockerContainer := &apicontainer.DockerContainer{
+		DockerID:   testDockerID,
+		DockerName: testDockerName,
+		Container: &apicontainer.Container{
+			Name:    testContainerName,
+			TaskARN: "invalid-arn",
+		},
+	}
+	assert.Error(t, testClient.SaveDockerContainer(testDockerContainer))
+	assert.Error(t, testClient.SaveContainer(testDockerContainer.Container))
+}

--- a/agent/data/helpers.go
+++ b/agent/data/helpers.go
@@ -1,0 +1,63 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package data
+
+import (
+	"encoding/json"
+
+	"github.com/boltdb/bolt"
+	"github.com/pkg/errors"
+)
+
+func putObject(bucket *bolt.Bucket, key string, obj interface{}) error {
+	keyBytes := []byte(key)
+	data, err := json.Marshal(obj)
+	if err != nil {
+		return errors.Wrapf(err, "failed to marshal object with key %q", key)
+	}
+
+	if err := bucket.Put(keyBytes, data); err != nil {
+		return errors.Wrapf(err, "failed to insert object with key %q", key)
+	}
+
+	return nil
+}
+
+func getObject(tx *bolt.Tx, bucketName, id string, out interface{}) error {
+	bucket := tx.Bucket([]byte(bucketName))
+	data := bucket.Get([]byte(id))
+	if data == nil {
+		return errors.Errorf("object %s not found in bucket %s", id, bucketName)
+	}
+
+	if out != nil {
+		if err := json.Unmarshal(data, out); err != nil {
+			return errors.Wrapf(err, "failed to unmarshal object with key %q", id)
+		}
+	}
+
+	return nil
+}
+
+func walk(bucket *bolt.Bucket, callback func(id string, data []byte) error) error {
+	cursor := bucket.Cursor()
+
+	for id, data := cursor.First(); id != nil; id, data = cursor.Next() {
+		if err := callback(string(id), data); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/agent/data/helpers_test.go
+++ b/agent/data/helpers_test.go
@@ -1,0 +1,93 @@
+// +build unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package data
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/boltdb/bolt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testBucketName = "test"
+)
+
+type testObjType struct {
+	Key string
+	Val string
+}
+
+func setupHelpersTest(t *testing.T) (*bolt.DB, func()) {
+	testDir, err := ioutil.TempDir("", "agent_data_unit_test")
+	require.NoError(t, err)
+	db, err := bolt.Open(filepath.Join(testDir, dbName), dbMode, nil)
+	require.NoError(t, err)
+	require.NoError(t, db.Update(func(tx *bolt.Tx) error {
+		_, err := tx.CreateBucket([]byte(testBucketName))
+		return err
+	}))
+
+	return db, func() {
+		require.NoError(t, db.Close())
+		require.NoError(t, os.RemoveAll(testDir))
+	}
+}
+
+func TestHelpers(t *testing.T) {
+	db, cleanup := setupHelpersTest(t)
+	defer cleanup()
+
+	testObj := &testObjType{
+		Key: "key",
+		Val: "test",
+	}
+
+	require.NoError(t, db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(testBucketName))
+		return putObject(b, testObj.Key, testObj)
+	}))
+
+	assert.Error(t, db.Update(func(tx *bolt.Tx) error {
+		return getObject(tx, testBucketName, "xx", &testObjType{})
+	}))
+
+	res := &testObjType{}
+	assert.NoError(t, db.Update(func(tx *bolt.Tx) error {
+		return getObject(tx, testBucketName, testObj.Key, res)
+	}))
+	assert.Equal(t, testObj.Val, res.Val)
+
+	var resArr []*testObjType
+	require.NoError(t, db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(testBucketName))
+		return walk(b, func(id string, data []byte) error {
+			obj := &testObjType{}
+			if err := json.Unmarshal(data, &obj); err != nil {
+				return err
+			}
+			resArr = append(resArr, obj)
+			return nil
+		})
+	}))
+	assert.Len(t, resArr, 1)
+	assert.Equal(t, testObj.Val, resArr[0].Val)
+}

--- a/agent/data/task_client_test.go
+++ b/agent/data/task_client_test.go
@@ -1,0 +1,57 @@
+// +build unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package data
+
+import (
+	"testing"
+
+	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testTaskArn = "arn:aws:ecs:us-west-2:1234567890:task/test-cluster/abc"
+)
+
+func TestManageTask(t *testing.T) {
+	testClient, cleanup := newTestClient(t)
+	defer cleanup()
+	testTask := &apitask.Task{
+		Arn: testTaskArn,
+	}
+
+	require.NoError(t, testClient.SaveTask(testTask))
+	res, err := testClient.GetTasks()
+	require.NoError(t, err)
+	assert.Len(t, res, 1)
+
+	require.NoError(t, testClient.DeleteTask("abc"))
+	res, err = testClient.GetTasks()
+	require.NoError(t, err)
+	assert.Len(t, res, 0)
+}
+
+func TestSaveTaskInvalidID(t *testing.T) {
+	testClient, cleanup := newTestClient(t)
+	defer cleanup()
+
+	testTask := &apitask.Task{
+		Arn: "invalid-arn",
+	}
+	assert.Error(t, testClient.SaveTask(testTask))
+}

--- a/agent/utils/utils.go
+++ b/agent/utils/utils.go
@@ -28,7 +28,10 @@ import (
 
 	"github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+
+	"github.com/pkg/errors"
 )
 
 func DefaultIfBlank(str string, default_value string) string {
@@ -204,4 +207,17 @@ func SearchStrInDir(dir, filePrefix, content string) error {
 	}
 
 	return nil
+}
+
+// GetTaskID retrieves the task ID from task ARN.
+func GetTaskID(taskARN string) (string, error) {
+	_, err := arn.Parse(taskARN)
+	if err != nil {
+		return "", errors.Errorf("failed to get task id: task arn format invalid: %s", taskARN)
+	}
+	fields := strings.Split(taskARN, "/")
+	if len(fields) < 2 {
+		return "", errors.Errorf("failed to get task id: task arn format invalid: %s", taskARN)
+	}
+	return fields[len(fields)-1], nil
 }

--- a/agent/utils/utils_test.go
+++ b/agent/utils/utils_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDefaultIfBlank(t *testing.T) {
@@ -172,4 +173,14 @@ func TestMapToTags(t *testing.T) {
 
 func TestNilMapToTags(t *testing.T) {
 	assert.Zero(t, len(MapToTags(nil)))
+}
+
+func TestGetTaskID(t *testing.T) {
+	taskARN := "arn:aws:ecs:us-west-2:1234567890:task/test-cluster/abc"
+	id, err := GetTaskID(taskARN)
+	require.NoError(t, err)
+	assert.Equal(t, "abc", id)
+
+	_, err = GetTaskID("invalid")
+	assert.Error(t, err)
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->
### Summary
<!-- What does this pull request do? -->
Implemented task/container related methods for boltdb data client.

### Implementation details
<!-- How are the changes implemented? -->
* data: implemented SaveContainer, SaveDockerContainer, DelContainer, GetContainers, SaveTask, DelTask, GetTasks. Added a few helper functions to cover common boltdb interaction.
* api/container: added a new field TaskARN to allow easier generation of key when saving a container to db. This field will be populated with correct value in PostUnmarshalTask in a later code change (when actually using the interface).
* utils: added a helper function to get task id from task arn.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Unit tests added.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
N/A

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
