### PR TITLE
Bug fix:Env File Feature would not accept = in value

### DIFF
--- a/agent/taskresource/envFiles/envfile.go
+++ b/agent/taskresource/envFiles/envfile.go
@@ -559,7 +559,7 @@ func (envfile *EnvironmentFileResource) readEnvVarsFromFile(envfilePath string) 
 		}
 		// only read the line that has "="
 		if strings.Contains(line, envVariableDelimiter) {
-			variables := strings.Split(line, "=")
+			variables := strings.SplitN(line, envVariableDelimiter, 2)
 			// verify that there is at least a character on each side
 			if len(variables[0]) > 0 && len(variables[1]) > 0 {
 				envVars[variables[0]] = variables[1]

--- a/agent/taskresource/envFiles/envfile_test.go
+++ b/agent/taskresource/envFiles/envfile_test.go
@@ -313,7 +313,8 @@ func TestReadEnvVarsFromEnvfiles(t *testing.T) {
 	envfileResource := newMockEnvfileResource(envfiles, nil, nil, mockIOUtil)
 	envfileResource.bufio = mockBufio
 
-	envfileContent := "key=value"
+	envfileContentLine1 := "key1=value"
+	envFileContentLine2 := "key2=val1=val2"
 
 	tempOpen := open
 	open = func(name string) (oswrapper.File, error) {
@@ -325,7 +326,9 @@ func TestReadEnvVarsFromEnvfiles(t *testing.T) {
 	gomock.InOrder(
 		mockBufio.EXPECT().NewScanner(mockFile).Return(mockScanner),
 		mockScanner.EXPECT().Scan().Return(true),
-		mockScanner.EXPECT().Text().Return(envfileContent),
+		mockScanner.EXPECT().Text().Return(envfileContentLine1),
+		mockScanner.EXPECT().Scan().Return(true),
+		mockScanner.EXPECT().Text().Return(envFileContentLine2),
 		mockScanner.EXPECT().Scan().Return(false),
 		mockScanner.EXPECT().Err().Return(nil),
 	)
@@ -334,7 +337,8 @@ func TestReadEnvVarsFromEnvfiles(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(envVarsList))
-	assert.Equal(t, "value", envVarsList[0]["key"])
+	assert.Equal(t, "value", envVarsList[0]["key1"])
+	assert.Equal(t, "val1=val2", envVarsList[0]["key2"])
 }
 
 func TestReadEnvVarsCommentFromEnvfiles(t *testing.T) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This pull request fixes a bug where env file feature would not accept "=", which is the delimiter in the values of a env var.
VARIABLE=abc=h would get truncated to VARIABLE=abc

### Implementation details
<!-- How are the changes implemented? -->
Changed the method strings.Split(line, "=") to strings.SplitN(line, "=", 2)
### Testing

 Tested that the env var is correctly getting its value after this change
<!-- How was this tested? -->
<!--


Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
