### PR TITLE
Save task and container data to boltdb

### DIFF
--- a/agent/acs/handler/acs_handler.go
+++ b/agent/acs/handler/acs_handler.go
@@ -29,6 +29,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/api"
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	rolecredentials "github.com/aws/amazon-ecs-agent/agent/credentials"
+	"github.com/aws/amazon-ecs-agent/agent/data"
 	"github.com/aws/amazon-ecs-agent/agent/engine"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/eventhandler"
@@ -84,6 +85,7 @@ type session struct {
 	ecsClient                       api.ECSClient
 	state                           dockerstate.TaskEngineState
 	stateManager                    statemanager.StateManager
+	dataClient                      data.Client
 	credentialsManager              rolecredentials.Manager
 	taskHandler                     *eventhandler.TaskHandler
 	ctx                             context.Context
@@ -142,6 +144,7 @@ func NewSession(ctx context.Context,
 	ecsClient api.ECSClient,
 	taskEngineState dockerstate.TaskEngineState,
 	stateManager statemanager.StateManager,
+	dataClient data.Client,
 	taskEngine engine.TaskEngine,
 	credentialsManager rolecredentials.Manager,
 	taskHandler *eventhandler.TaskHandler, latestSeqNumTaskManifest *int64) Session {
@@ -158,6 +161,7 @@ func NewSession(ctx context.Context,
 		ecsClient:                       ecsClient,
 		state:                           taskEngineState,
 		stateManager:                    stateManager,
+		dataClient:                      dataClient,
 		taskEngine:                      taskEngine,
 		credentialsManager:              credentialsManager,
 		taskHandler:                     taskHandler,
@@ -322,6 +326,7 @@ func (acsSession *session) startACSSession(client wsclient.ClientServer) error {
 		acsSession.containerInstanceARN,
 		client,
 		acsSession.stateManager,
+		acsSession.dataClient,
 		refreshCredsHandler,
 		acsSession.credentialsManager,
 		acsSession.taskHandler, acsSession.latestSeqNumTaskManifest)

--- a/agent/acs/handler/acs_handler_test.go
+++ b/agent/acs/handler/acs_handler_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	rolecredentials "github.com/aws/amazon-ecs-agent/agent/credentials"
 	mock_credentials "github.com/aws/amazon-ecs-agent/agent/credentials/mocks"
+	"github.com/aws/amazon-ecs-agent/agent/data"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	mock_engine "github.com/aws/amazon-ecs-agent/agent/engine/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/eventhandler"
@@ -192,7 +193,7 @@ func TestHandlerReconnectsOnConnectErrors(t *testing.T) {
 
 	stateManager := statemanager.NewNoopStateManager()
 	ctx, cancel := context.WithCancel(context.Background())
-	taskHandler := eventhandler.NewTaskHandler(ctx, stateManager, nil, nil)
+	taskHandler := eventhandler.NewTaskHandler(ctx, stateManager, data.NewNoopClient(), nil, nil)
 
 	mockWsClient := mock_wsclient.NewMockClientServer(ctrl)
 	mockWsClient.EXPECT().SetAnyRequestHandler(gomock.Any()).AnyTimes()
@@ -216,6 +217,7 @@ func TestHandlerReconnectsOnConnectErrors(t *testing.T) {
 		taskEngine:           taskEngine,
 		ecsClient:            ecsClient,
 		stateManager:         stateManager,
+		dataClient:           data.NewNoopClient(),
 		taskHandler:          taskHandler,
 		backoff:              retry.NewExponentialBackoff(connectionBackoffMin, connectionBackoffMax, connectionBackoffJitter, connectionBackoffMultiplier),
 		ctx:                  ctx,
@@ -331,7 +333,7 @@ func TestHandlerReconnectsWithoutBackoffOnEOFError(t *testing.T) {
 
 	stateManager := statemanager.NewNoopStateManager()
 	ctx, cancel := context.WithCancel(context.Background())
-	taskHandler := eventhandler.NewTaskHandler(ctx, stateManager, nil, nil)
+	taskHandler := eventhandler.NewTaskHandler(ctx, stateManager, data.NewNoopClient(), nil, nil)
 
 	deregisterInstanceEventStream := eventstream.NewEventStream("DeregisterContainerInstance", ctx)
 	deregisterInstanceEventStream.StartListening()
@@ -361,6 +363,7 @@ func TestHandlerReconnectsWithoutBackoffOnEOFError(t *testing.T) {
 		ecsClient:                       ecsClient,
 		deregisterInstanceEventStream:   deregisterInstanceEventStream,
 		stateManager:                    stateManager,
+		dataClient:                      data.NewNoopClient(),
 		taskHandler:                     taskHandler,
 		backoff:                         mockBackoff,
 		ctx:                             ctx,
@@ -395,7 +398,7 @@ func TestHandlerReconnectsWithBackoffOnNonEOFError(t *testing.T) {
 
 	stateManager := statemanager.NewNoopStateManager()
 	ctx, cancel := context.WithCancel(context.Background())
-	taskHandler := eventhandler.NewTaskHandler(ctx, stateManager, nil, nil)
+	taskHandler := eventhandler.NewTaskHandler(ctx, stateManager, data.NewNoopClient(), nil, nil)
 
 	deregisterInstanceEventStream := eventstream.NewEventStream("DeregisterContainerInstance", ctx)
 	deregisterInstanceEventStream.StartListening()
@@ -425,6 +428,7 @@ func TestHandlerReconnectsWithBackoffOnNonEOFError(t *testing.T) {
 		ecsClient:                     ecsClient,
 		deregisterInstanceEventStream: deregisterInstanceEventStream,
 		stateManager:                  stateManager,
+		dataClient:                    data.NewNoopClient(),
 		taskHandler:                   taskHandler,
 		backoff:                       mockBackoff,
 		ctx:                           ctx,
@@ -457,7 +461,7 @@ func TestHandlerGeneratesDeregisteredInstanceEvent(t *testing.T) {
 
 	stateManager := statemanager.NewNoopStateManager()
 	ctx, cancel := context.WithCancel(context.Background())
-	taskHandler := eventhandler.NewTaskHandler(ctx, stateManager, nil, nil)
+	taskHandler := eventhandler.NewTaskHandler(ctx, stateManager, data.NewNoopClient(), nil, nil)
 
 	deregisterInstanceEventStream := eventstream.NewEventStream("DeregisterContainerInstance", ctx)
 
@@ -484,6 +488,7 @@ func TestHandlerGeneratesDeregisteredInstanceEvent(t *testing.T) {
 		ecsClient:                       ecsClient,
 		deregisterInstanceEventStream:   deregisterInstanceEventStream,
 		stateManager:                    stateManager,
+		dataClient:                      data.NewNoopClient(),
 		taskHandler:                     taskHandler,
 		backoff:                         retry.NewExponentialBackoff(connectionBackoffMin, connectionBackoffMax, connectionBackoffJitter, connectionBackoffMultiplier),
 		ctx:                             ctx,
@@ -517,7 +522,7 @@ func TestHandlerReconnectDelayForInactiveInstanceError(t *testing.T) {
 
 	stateManager := statemanager.NewNoopStateManager()
 	ctx, cancel := context.WithCancel(context.Background())
-	taskHandler := eventhandler.NewTaskHandler(ctx, stateManager, nil, nil)
+	taskHandler := eventhandler.NewTaskHandler(ctx, stateManager, data.NewNoopClient(), nil, nil)
 
 	deregisterInstanceEventStream := eventstream.NewEventStream("DeregisterContainerInstance", ctx)
 	deregisterInstanceEventStream.StartListening()
@@ -553,6 +558,7 @@ func TestHandlerReconnectDelayForInactiveInstanceError(t *testing.T) {
 		ecsClient:                       ecsClient,
 		deregisterInstanceEventStream:   deregisterInstanceEventStream,
 		stateManager:                    stateManager,
+		dataClient:                      data.NewNoopClient(),
 		taskHandler:                     taskHandler,
 		backoff:                         retry.NewExponentialBackoff(connectionBackoffMin, connectionBackoffMax, connectionBackoffJitter, connectionBackoffMultiplier),
 		ctx:                             ctx,
@@ -585,7 +591,7 @@ func TestHandlerReconnectsOnServeErrors(t *testing.T) {
 
 	stateManager := statemanager.NewNoopStateManager()
 	ctx, cancel := context.WithCancel(context.Background())
-	taskHandler := eventhandler.NewTaskHandler(ctx, stateManager, nil, nil)
+	taskHandler := eventhandler.NewTaskHandler(ctx, stateManager, data.NewNoopClient(), nil, nil)
 
 	mockWsClient := mock_wsclient.NewMockClientServer(ctrl)
 	mockWsClient.EXPECT().SetAnyRequestHandler(gomock.Any()).AnyTimes()
@@ -610,6 +616,7 @@ func TestHandlerReconnectsOnServeErrors(t *testing.T) {
 		taskEngine:           taskEngine,
 		ecsClient:            ecsClient,
 		stateManager:         stateManager,
+		dataClient:           data.NewNoopClient(),
 		taskHandler:          taskHandler,
 		backoff:              retry.NewExponentialBackoff(connectionBackoffMin, connectionBackoffMax, connectionBackoffJitter, connectionBackoffMultiplier),
 		ctx:                  ctx,
@@ -641,7 +648,7 @@ func TestHandlerStopsWhenContextIsCancelled(t *testing.T) {
 
 	stateManager := statemanager.NewNoopStateManager()
 	ctx, cancel := context.WithCancel(context.Background())
-	taskHandler := eventhandler.NewTaskHandler(ctx, stateManager, nil, nil)
+	taskHandler := eventhandler.NewTaskHandler(ctx, stateManager, data.NewNoopClient(), nil, nil)
 
 	mockWsClient := mock_wsclient.NewMockClientServer(ctrl)
 	mockWsClient.EXPECT().SetAnyRequestHandler(gomock.Any()).AnyTimes()
@@ -661,6 +668,7 @@ func TestHandlerStopsWhenContextIsCancelled(t *testing.T) {
 		taskEngine:           taskEngine,
 		ecsClient:            ecsClient,
 		stateManager:         stateManager,
+		dataClient:           data.NewNoopClient(),
 		taskHandler:          taskHandler,
 		backoff:              retry.NewExponentialBackoff(connectionBackoffMin, connectionBackoffMax, connectionBackoffJitter, connectionBackoffMultiplier),
 		ctx:                  ctx,
@@ -690,7 +698,7 @@ func TestHandlerReconnectsOnDiscoverPollEndpointError(t *testing.T) {
 	ecsClient := mock_api.NewMockECSClient(ctrl)
 	stateManager := statemanager.NewNoopStateManager()
 	ctx, cancel := context.WithCancel(context.Background())
-	taskHandler := eventhandler.NewTaskHandler(ctx, stateManager, nil, nil)
+	taskHandler := eventhandler.NewTaskHandler(ctx, stateManager, data.NewNoopClient(), nil, nil)
 
 	mockWsClient := mock_wsclient.NewMockClientServer(ctrl)
 	mockWsClient.EXPECT().SetAnyRequestHandler(gomock.Any()).AnyTimes()
@@ -715,6 +723,7 @@ func TestHandlerReconnectsOnDiscoverPollEndpointError(t *testing.T) {
 		taskEngine:           taskEngine,
 		ecsClient:            ecsClient,
 		stateManager:         stateManager,
+		dataClient:           data.NewNoopClient(),
 		taskHandler:          taskHandler,
 		backoff:              retry.NewExponentialBackoff(connectionBackoffMin, connectionBackoffMax, connectionBackoffJitter, connectionBackoffMultiplier),
 		ctx:                  ctx,
@@ -758,7 +767,7 @@ func TestConnectionIsClosedOnIdle(t *testing.T) {
 	ecsClient := mock_api.NewMockECSClient(ctrl)
 	stateManager := statemanager.NewNoopStateManager()
 	ctx, cancel := context.WithCancel(context.Background())
-	taskHandler := eventhandler.NewTaskHandler(ctx, stateManager, nil, nil)
+	taskHandler := eventhandler.NewTaskHandler(ctx, stateManager, data.NewNoopClient(), nil, nil)
 	defer cancel()
 
 	wait := sync.WaitGroup{}
@@ -787,6 +796,7 @@ func TestConnectionIsClosedOnIdle(t *testing.T) {
 		taskEngine:           taskEngine,
 		ecsClient:            ecsClient,
 		stateManager:         stateManager,
+		dataClient:           data.NewNoopClient(),
 		taskHandler:          taskHandler,
 		ctx:                  context.Background(),
 		backoff:              retry.NewExponentialBackoff(connectionBackoffMin, connectionBackoffMax, connectionBackoffJitter, connectionBackoffMultiplier),
@@ -808,7 +818,7 @@ func TestHandlerDoesntLeakGoroutines(t *testing.T) {
 	ecsClient := mock_api.NewMockECSClient(ctrl)
 	stateManager := statemanager.NewNoopStateManager()
 	ctx, cancel := context.WithCancel(context.Background())
-	taskHandler := eventhandler.NewTaskHandler(ctx, stateManager, nil, nil)
+	taskHandler := eventhandler.NewTaskHandler(ctx, stateManager, data.NewNoopClient(), nil, nil)
 
 	closeWS := make(chan bool)
 	server, serverIn, requests, errs, err := startMockAcsServer(t, closeWS)
@@ -841,6 +851,7 @@ func TestHandlerDoesntLeakGoroutines(t *testing.T) {
 			taskEngine:               taskEngine,
 			ecsClient:                ecsClient,
 			stateManager:             stateManager,
+			dataClient:               data.NewNoopClient(),
 			taskHandler:              taskHandler,
 			ctx:                      ctx,
 			_heartbeatTimeout:        1 * time.Second,
@@ -893,7 +904,7 @@ func TestStartSessionHandlesRefreshCredentialsMessages(t *testing.T) {
 	ecsClient := mock_api.NewMockECSClient(ctrl)
 	stateManager := statemanager.NewNoopStateManager()
 	ctx, cancel := context.WithCancel(context.Background())
-	taskHandler := eventhandler.NewTaskHandler(ctx, stateManager, nil, nil)
+	taskHandler := eventhandler.NewTaskHandler(ctx, stateManager, data.NewNoopClient(), nil, nil)
 	closeWS := make(chan bool)
 	server, serverIn, requestsChan, errChan, err := startMockAcsServer(t, closeWS)
 	if err != nil {
@@ -928,6 +939,7 @@ func TestStartSessionHandlesRefreshCredentialsMessages(t *testing.T) {
 			ecsClient,
 			dockerstate.NewTaskEngineState(),
 			stateManager,
+			data.NewNoopClient(),
 			taskEngine,
 			credentialsManager,
 			taskHandler, &latestSeqNumberTaskManifest,
@@ -1015,7 +1027,7 @@ func TestHandlerReconnectsCorrectlySetsSendCredentialsURLParameter(t *testing.T)
 	ecsClient := mock_api.NewMockECSClient(ctrl)
 	stateManager := statemanager.NewNoopStateManager()
 	ctx, cancel := context.WithCancel(context.Background())
-	taskHandler := eventhandler.NewTaskHandler(ctx, stateManager, nil, nil)
+	taskHandler := eventhandler.NewTaskHandler(ctx, stateManager, data.NewNoopClient(), nil, nil)
 
 	mockWsClient := mock_wsclient.NewMockClientServer(ctrl)
 
@@ -1044,6 +1056,7 @@ func TestHandlerReconnectsCorrectlySetsSendCredentialsURLParameter(t *testing.T)
 		taskEngine:           taskEngine,
 		ecsClient:            ecsClient,
 		stateManager:         stateManager,
+		dataClient:           data.NewNoopClient(),
 		taskHandler:          taskHandler,
 		ctx:                  ctx,
 		resources:            resources,

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -2252,7 +2252,7 @@ func TestPostUnmarshalTaskASMDockerAuth(t *testing.T) {
 	}
 
 	task := &Task{
-		Arn:                "test",
+		Arn:                testTaskARN,
 		ResourcesMapUnsafe: make(map[string][]taskresource.TaskResource),
 		Containers:         []*apicontainer.Container{container},
 	}
@@ -2291,7 +2291,7 @@ func TestPostUnmarshalTaskSecret(t *testing.T) {
 	}
 
 	task := &Task{
-		Arn:                "test",
+		Arn:                testTaskARN,
 		ResourcesMapUnsafe: make(map[string][]taskresource.TaskResource),
 		Containers:         []*apicontainer.Container{container},
 	}
@@ -2330,7 +2330,7 @@ func TestPostUnmarshalTaskASMSecret(t *testing.T) {
 	}
 
 	task := &Task{
-		Arn:                "test",
+		Arn:                testTaskARN,
 		ResourcesMapUnsafe: make(map[string][]taskresource.TaskResource),
 		Containers:         []*apicontainer.Container{container},
 	}
@@ -3387,7 +3387,7 @@ func TestPostUnmarshalTaskEnvfiles(t *testing.T) {
 	}
 
 	task := &Task{
-		Arn:                "testArn",
+		Arn:                testTaskARN,
 		ResourcesMapUnsafe: make(map[string][]taskresource.TaskResource),
 		Containers:         []*apicontainer.Container{container},
 	}
@@ -3486,4 +3486,17 @@ func requireEnvfiles(task *Task) bool {
 		}
 	}
 	return false
+}
+
+func TestPopulateTaskARN(t *testing.T) {
+	task := &Task{
+		Arn: testTaskARN,
+		Containers: []*apicontainer.Container{
+			{
+				Name: "test",
+			},
+		},
+	}
+	task.populateTaskARN()
+	assert.Equal(t, task.Arn, task.Containers[0].TaskARN)
 }

--- a/agent/api/task/task_test_utils.go
+++ b/agent/api/task/task_test_utils.go
@@ -42,6 +42,7 @@ const (
 	proxyEgressPort   = "15001"
 	appPort           = "9000"
 	egressIgnoredIP   = "169.254.169.254"
+	testTaskARN       = "arn:aws:ecs:us-west-2:1234567890:task/test-cluster/abc"
 )
 
 var defaultDockerClientAPIVersion = dockerclient.Version_1_17
@@ -70,7 +71,7 @@ func getACSIAMRoleCredentials() *ecsacs.IAMRoleCredentials {
 
 func getACSEFSTask() *ecsacs.Task {
 	return &ecsacs.Task{
-		Arn:           strptr("myArn"),
+		Arn:           strptr(testTaskARN),
 		DesiredStatus: strptr("RUNNING"),
 		Family:        strptr("myFamily"),
 		Version:       strptr("1"),

--- a/agent/api/task/task_windows_test.go
+++ b/agent/api/task/task_windows_test.go
@@ -84,7 +84,8 @@ func TestPostUnmarshalWindowsCanonicalPaths(t *testing.T) {
 		Version:             "1",
 		Containers: []*apicontainer.Container{
 			{
-				Name: "myName",
+				Name:    "myName",
+				TaskARN: "myArn",
 				MountPoints: []apicontainer.MountPoint{
 					{
 						ContainerPath: `c:\container\path`,

--- a/agent/data/container_client.go
+++ b/agent/data/container_client.go
@@ -25,7 +25,7 @@ import (
 
 // SaveDockerContainer saves a docker container to the container bucket.
 func (c *client) SaveDockerContainer(container *apicontainer.DockerContainer) error {
-	id, err := getContainerID(container.Container)
+	id, err := GetContainerID(container.Container)
 	if err != nil {
 		return errors.Wrap(err, "failed to generate database id")
 	}
@@ -39,7 +39,7 @@ func (c *client) SaveDockerContainer(container *apicontainer.DockerContainer) er
 // apicontainer.DockerContainer exists, this updates the Container part of it; otherwise, a new
 // apicontainer.DockerContainer is created and saved.
 func (c *client) SaveContainer(container *apicontainer.Container) error {
-	id, err := getContainerID(container)
+	id, err := GetContainerID(container)
 	if err != nil {
 		return errors.Wrap(err, "failed to generate database id")
 	}
@@ -88,8 +88,8 @@ func (c *client) GetContainers() ([]*apicontainer.DockerContainer, error) {
 	return containers, err
 }
 
-// getContainerID returns a unique ID for a container to use as key when saving to DB.
-func getContainerID(c *apicontainer.Container) (string, error) {
+// GetContainerID returns a unique ID for a container to use as key when saving to DB.
+func GetContainerID(c *apicontainer.Container) (string, error) {
 	taskID, err := utils.GetTaskID(c.TaskARN)
 	if err != nil {
 		return "", err

--- a/agent/data/container_client_test.go
+++ b/agent/data/container_client_test.go
@@ -88,3 +88,17 @@ func TestSaveContainerInvalidID(t *testing.T) {
 	assert.Error(t, testClient.SaveDockerContainer(testDockerContainer))
 	assert.Error(t, testClient.SaveContainer(testDockerContainer.Container))
 }
+
+func TestGetContainerID(t *testing.T) {
+	c := &apicontainer.Container{
+		TaskARN: testTaskArn,
+		Name:    testContainerName,
+	}
+	id, err := GetContainerID(c)
+	require.NoError(t, err)
+	assert.Equal(t, "abc-test-name", id)
+
+	c.TaskARN = "invalid"
+	_, err = GetContainerID(c)
+	assert.Error(t, err)
+}

--- a/agent/data/noop_client.go
+++ b/agent/data/noop_client.go
@@ -1,0 +1,93 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package data
+
+import (
+	"github.com/aws/amazon-ecs-agent/agent/api/container"
+	"github.com/aws/amazon-ecs-agent/agent/api/eni"
+	"github.com/aws/amazon-ecs-agent/agent/api/task"
+	"github.com/aws/amazon-ecs-agent/agent/engine/image"
+)
+
+type noopClient struct{}
+
+// NewNoopClient returns a client that implements the data interface with no-op. It is used
+// by the agent when ECS_CHECKPOINT is set to false, and is also used in testing.
+func NewNoopClient() Client {
+	return &noopClient{}
+}
+
+func (c *noopClient) SaveContainer(*container.Container) error {
+	return nil
+}
+
+func (c *noopClient) SaveDockerContainer(*container.DockerContainer) error {
+	return nil
+}
+
+func (c *noopClient) DeleteContainer(string) error {
+	return nil
+}
+
+func (c *noopClient) GetContainers() ([]*container.DockerContainer, error) {
+	return nil, nil
+}
+
+func (c *noopClient) SaveTask(*task.Task) error {
+	return nil
+}
+
+func (c *noopClient) DeleteTask(string) error {
+	return nil
+}
+
+func (c *noopClient) GetTasks() ([]*task.Task, error) {
+	return nil, nil
+}
+
+func (c *noopClient) SaveImageState(*image.ImageState) error {
+	return nil
+}
+
+func (c *noopClient) DeleteImageState(string) error {
+	return nil
+}
+
+func (c *noopClient) GetImageStates() ([]*image.ImageState, error) {
+	return nil, nil
+}
+
+func (c *noopClient) SaveENIAttachment(*eni.ENIAttachment) error {
+	return nil
+}
+
+func (c *noopClient) DeleteENIAttachment(string) error {
+	return nil
+}
+
+func (c *noopClient) GetENIAttachments() ([]*eni.ENIAttachment, error) {
+	return nil, nil
+}
+
+func (c *noopClient) SaveMetadata(string, string) error {
+	return nil
+}
+
+func (c *noopClient) GetMetadata(string) (string, error) {
+	return "", nil
+}
+
+func (c *noopClient) Close() error {
+	return nil
+}

--- a/agent/engine/data.go
+++ b/agent/engine/data.go
@@ -1,0 +1,68 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package engine
+
+import (
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
+	"github.com/aws/amazon-ecs-agent/agent/data"
+	"github.com/aws/amazon-ecs-agent/agent/utils"
+
+	"github.com/cihub/seelog"
+)
+
+func (engine *DockerTaskEngine) saveTaskData(task *apitask.Task) {
+	err := engine.dataClient.SaveTask(task)
+	if err != nil {
+		seelog.Errorf("Failed to save data for task %s: %v", task.Arn, err)
+	}
+}
+
+func (engine *DockerTaskEngine) saveContainerData(container *apicontainer.Container) {
+	err := engine.dataClient.SaveContainer(container)
+	if err != nil {
+		seelog.Errorf("Failed to save data for container %s: %v", container.Name, err)
+	}
+}
+
+func (engine *DockerTaskEngine) saveDockerContainerData(container *apicontainer.DockerContainer) {
+	err := engine.dataClient.SaveDockerContainer(container)
+	if err != nil {
+		seelog.Errorf("Failed to save data for docker container %s: %v", container.Container.Name, err)
+	}
+}
+
+func (engine *DockerTaskEngine) removeTaskData(task *apitask.Task) {
+	id, err := utils.GetTaskID(task.Arn)
+	if err != nil {
+		seelog.Errorf("Failed to get task id from task ARN %s: %v", task.Arn, err)
+		return
+	}
+	err = engine.dataClient.DeleteTask(id)
+	if err != nil {
+		seelog.Errorf("Failed to remove data for task %s: %v", task.Arn, err)
+	}
+
+	for _, c := range task.Containers {
+		id, err := data.GetContainerID(c)
+		if err != nil {
+			seelog.Errorf("Failed to get container id from container %s: %v", c.Name, err)
+			continue
+		}
+		err = engine.dataClient.DeleteContainer(id)
+		if err != nil {
+			seelog.Errorf("Failed to remove data for container %s: %v", c.Name, err)
+		}
+	}
+}

--- a/agent/engine/data_test.go
+++ b/agent/engine/data_test.go
@@ -1,0 +1,104 @@
+// +build unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package engine
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
+	"github.com/aws/amazon-ecs-agent/agent/data"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testContainerName = "test-name"
+)
+
+var (
+	testContainer = &apicontainer.Container{
+		Name:    testContainerName,
+		TaskARN: testTaskARN,
+	}
+	testTask = &apitask.Task{
+		Arn:        testTaskARN,
+		Containers: []*apicontainer.Container{testContainer},
+	}
+)
+
+func newTestDataClient(t *testing.T) (data.Client, func()) {
+	testDir, err := ioutil.TempDir("", "agent_engine_unit_test")
+	require.NoError(t, err)
+
+	testClient, err := data.NewWithSetup(testDir)
+
+	cleanup := func() {
+		require.NoError(t, testClient.Close())
+		require.NoError(t, os.RemoveAll(testDir))
+	}
+	return testClient, cleanup
+}
+
+func TestSaveAndRemoveTaskData(t *testing.T) {
+	dataClient, cleanup := newTestDataClient(t)
+	defer cleanup()
+
+	engine := &DockerTaskEngine{
+		dataClient: dataClient,
+	}
+	engine.saveTaskData(testTask)
+	tasks, err := dataClient.GetTasks()
+	require.NoError(t, err)
+	assert.Len(t, tasks, 1)
+
+	engine.removeTaskData(testTask)
+	tasks, err = dataClient.GetTasks()
+	require.NoError(t, err)
+	assert.Len(t, tasks, 0)
+}
+
+func TestSaveContainerData(t *testing.T) {
+	dataClient, cleanup := newTestDataClient(t)
+	defer cleanup()
+
+	engine := &DockerTaskEngine{
+		dataClient: dataClient,
+	}
+	engine.saveContainerData(testContainer)
+	containers, err := dataClient.GetContainers()
+	require.NoError(t, err)
+	assert.Len(t, containers, 1)
+}
+
+func TestSaveDockerContainerData(t *testing.T) {
+	dataClient, cleanup := newTestDataClient(t)
+	defer cleanup()
+
+	engine := &DockerTaskEngine{
+		dataClient: dataClient,
+	}
+	engine.saveDockerContainerData(&apicontainer.DockerContainer{
+		DockerName: "test-docker-name",
+		Container:  testContainer,
+	})
+	containers, err := dataClient.GetContainers()
+	require.NoError(t, err)
+	assert.Len(t, containers, 1)
+}

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -100,7 +100,7 @@ const (
 	networkBridgeIP             = "bridgeIP"
 	networkModeBridge           = "bridge"
 	networkModeAWSVPC           = "awsvpc"
-	taskArn                     = "task1"
+	testTaskARN                 = "arn:aws:ecs:region:account-id:task/task-id"
 )
 
 var (

--- a/agent/engine/interface.go
+++ b/agent/engine/interface.go
@@ -19,6 +19,7 @@ import (
 	"context"
 
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
+	"github.com/aws/amazon-ecs-agent/agent/data"
 	"github.com/aws/amazon-ecs-agent/agent/statechange"
 	"github.com/aws/amazon-ecs-agent/agent/statemanager"
 )
@@ -37,6 +38,8 @@ type TaskEngine interface {
 	// running or stopped, as well as providing portbinding and other metadata
 	StateChangeEvents() chan statechange.Event
 	SetSaver(statemanager.Saver)
+	// SetDataClient sets the data client that is used by the task engine.
+	SetDataClient(data.Client)
 
 	// AddTask adds a new task to the task engine and manages its container's
 	// lifecycle. If it returns an error, the task was not added.

--- a/agent/engine/mocks/engine_mocks.go
+++ b/agent/engine/mocks/engine_mocks.go
@@ -24,6 +24,7 @@ import (
 
 	container "github.com/aws/amazon-ecs-agent/agent/api/container"
 	task "github.com/aws/amazon-ecs-agent/agent/api/task"
+	data "github.com/aws/amazon-ecs-agent/agent/data"
 	image "github.com/aws/amazon-ecs-agent/agent/engine/image"
 	statechange "github.com/aws/amazon-ecs-agent/agent/statechange"
 	statemanager "github.com/aws/amazon-ecs-agent/agent/statemanager"
@@ -146,6 +147,18 @@ func (m *MockTaskEngine) MustInit(arg0 context.Context) {
 func (mr *MockTaskEngineMockRecorder) MustInit(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MustInit", reflect.TypeOf((*MockTaskEngine)(nil).MustInit), arg0)
+}
+
+// SetDataClient mocks base method
+func (m *MockTaskEngine) SetDataClient(arg0 data.Client) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetDataClient", arg0)
+}
+
+// SetDataClient indicates an expected call of SetDataClient
+func (mr *MockTaskEngineMockRecorder) SetDataClient(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDataClient", reflect.TypeOf((*MockTaskEngine)(nil).SetDataClient), arg0)
 }
 
 // SetSaver mocks base method

--- a/agent/engine/task_manager_data_test.go
+++ b/agent/engine/task_manager_data_test.go
@@ -1,0 +1,316 @@
+// +build unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package engine
+
+import (
+	"context"
+	"testing"
+
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
+	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
+	apitaskstatus "github.com/aws/amazon-ecs-agent/agent/api/task/status"
+	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
+	"github.com/aws/amazon-ecs-agent/agent/eventstream"
+	"github.com/aws/amazon-ecs-agent/agent/statechange"
+	"github.com/aws/amazon-ecs-agent/agent/statemanager"
+	"github.com/aws/amazon-ecs-agent/agent/taskresource"
+	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
+	resourcetype "github.com/aws/amazon-ecs-agent/agent/taskresource/types"
+	"github.com/aws/amazon-ecs-agent/agent/taskresource/volume"
+	utilsync "github.com/aws/amazon-ecs-agent/agent/utils/sync"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+/*
+This file contains unit tests that specifically check the data persisting behavior of the task manager.
+*/
+
+const (
+	dataTestVolumeName     = "test-vol"
+	dataTestContainerName1 = "test-name-1"
+	dataTestContainerName2 = "test-name-2"
+)
+
+var (
+	testErr = errors.New("test error")
+)
+
+func TestHandleDesiredStatusChangeSaveData(t *testing.T) {
+	testCases := []struct {
+		name                string
+		desiredStatus       apitaskstatus.TaskStatus
+		targetDesiredStatus apitaskstatus.TaskStatus
+		shouldSave          bool
+	}{
+		{
+			name:                "non-redundant desired status change is saved",
+			desiredStatus:       apitaskstatus.TaskRunning,
+			targetDesiredStatus: apitaskstatus.TaskStopped,
+			shouldSave:          true,
+		},
+		{
+			name:                "redundant desired status change is saved",
+			desiredStatus:       apitaskstatus.TaskStopped,
+			targetDesiredStatus: apitaskstatus.TaskStopped,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dataClient, cleanup := newTestDataClient(t)
+			defer cleanup()
+
+			mtask := managedTask{
+				Task: &apitask.Task{
+					Arn:                 testTaskARN,
+					DesiredStatusUnsafe: tc.desiredStatus,
+				},
+				engine: &DockerTaskEngine{
+					dataClient: dataClient,
+				},
+				taskStopWG: utilsync.NewSequentialWaitGroup(),
+			}
+			mtask.handleDesiredStatusChange(tc.targetDesiredStatus, int64(1))
+			tasks, err := dataClient.GetTasks()
+			require.NoError(t, err)
+			if tc.shouldSave {
+				assert.Len(t, tasks, 1)
+			} else {
+				assert.Len(t, tasks, 0)
+			}
+		})
+	}
+}
+
+func TestHandleContainerStateChangeSaveData(t *testing.T) {
+	testCases := []struct {
+		name                string
+		knownState          apicontainerstatus.ContainerStatus
+		nextState           apicontainerstatus.ContainerStatus
+		taskKnownState      apitaskstatus.TaskStatus
+		taskDesiredState    apitaskstatus.TaskStatus
+		err                 error
+		shouldSaveContainer bool
+	}{
+		{
+			name:                "non-redundant container state change is saved",
+			knownState:          apicontainerstatus.ContainerCreated,
+			nextState:           apicontainerstatus.ContainerRunning,
+			taskKnownState:      apitaskstatus.TaskCreated,
+			taskDesiredState:    apitaskstatus.TaskRunning,
+			shouldSaveContainer: true,
+		},
+		{
+			name:                "non-redundant container state change with error is saved",
+			knownState:          apicontainerstatus.ContainerPulled,
+			nextState:           apicontainerstatus.ContainerCreated,
+			taskKnownState:      apitaskstatus.TaskPulled,
+			taskDesiredState:    apitaskstatus.TaskCreated,
+			err:                 testErr,
+			shouldSaveContainer: true,
+		},
+		{
+			name:                "redundant container state change with metadata update is saved",
+			knownState:          apicontainerstatus.ContainerRunning,
+			nextState:           apicontainerstatus.ContainerRunning,
+			taskKnownState:      apitaskstatus.TaskRunning,
+			taskDesiredState:    apitaskstatus.TaskRunning,
+			shouldSaveContainer: true,
+		},
+		{
+			name:             "redundant container state change without metadata update is not saved",
+			knownState:       apicontainerstatus.ContainerCreated,
+			nextState:        apicontainerstatus.ContainerCreated,
+			taskKnownState:   apitaskstatus.TaskCreated,
+			taskDesiredState: apitaskstatus.TaskCreated,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			eventStreamName := "TestHandleContainerStateChangeSaveData"
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			containerChangeEventStream := eventstream.NewEventStream(eventStreamName, ctx)
+			containerChangeEventStream.StartListening()
+
+			dataClient, cleanup := newTestDataClient(t)
+			defer cleanup()
+
+			mTask := managedTask{
+				Task: &apitask.Task{
+					Arn:                 testTaskARN,
+					DesiredStatusUnsafe: tc.taskDesiredState,
+					KnownStatusUnsafe:   tc.taskKnownState,
+					Containers: []*apicontainer.Container{
+						newTestContainer(dataTestContainerName1, tc.knownState, tc.nextState),
+						newTestContainer(dataTestContainerName2, tc.knownState, tc.nextState),
+					},
+				},
+				engine: &DockerTaskEngine{
+					dataClient: dataClient,
+				},
+				ctx:                        context.TODO(),
+				containerChangeEventStream: containerChangeEventStream,
+				stateChangeEvents:          make(chan statechange.Event),
+			}
+			defer discardEvents(mTask.stateChangeEvents)()
+
+			containerChange := dockerContainerChange{
+				container: mTask.Containers[0],
+				event: dockerapi.DockerContainerChangeEvent{
+					Status:                  tc.nextState,
+					DockerContainerMetadata: dockerapi.DockerContainerMetadata{},
+				},
+			}
+			mTask.handleContainerChange(containerChange)
+			containers, err := dataClient.GetContainers()
+			require.NoError(t, err)
+			if tc.shouldSaveContainer {
+				assert.Len(t, containers, 1)
+			} else {
+				assert.Len(t, containers, 0)
+			}
+
+			// All test cases in this test are made such that the container state change is not
+			// causing task state change. Check that the task is not saved in these case.
+			tasks, err := dataClient.GetTasks()
+			assert.Len(t, tasks, 0)
+		})
+	}
+}
+
+func TestHandleContainerChangeWithTaskStateChangeSaveData(t *testing.T) {
+	eventStreamName := "TestHandleContainerChangeWithTaskStateChangeSaveData"
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	containerChangeEventStream := eventstream.NewEventStream(eventStreamName, ctx)
+	containerChangeEventStream.StartListening()
+
+	dataClient, cleanup := newTestDataClient(t)
+	defer cleanup()
+
+	mTask := managedTask{
+		Task: &apitask.Task{
+			Arn:                 testTaskARN,
+			DesiredStatusUnsafe: apitaskstatus.TaskRunning,
+			KnownStatusUnsafe:   apitaskstatus.TaskCreated,
+			Containers: []*apicontainer.Container{
+				newTestContainer(dataTestContainerName1, apicontainerstatus.ContainerCreated,
+					apicontainerstatus.ContainerRunning),
+			},
+		},
+		engine: &DockerTaskEngine{
+			dataClient: dataClient,
+		},
+		ctx:                        context.TODO(),
+		containerChangeEventStream: containerChangeEventStream,
+		stateChangeEvents:          make(chan statechange.Event),
+	}
+	defer discardEvents(mTask.stateChangeEvents)()
+
+	containerChange := dockerContainerChange{
+		container: mTask.Containers[0],
+		event: dockerapi.DockerContainerChangeEvent{
+			Status:                  apicontainerstatus.ContainerRunning,
+			DockerContainerMetadata: dockerapi.DockerContainerMetadata{},
+		},
+	}
+	mTask.handleContainerChange(containerChange)
+	containers, err := dataClient.GetContainers()
+	require.NoError(t, err)
+	assert.Len(t, containers, 1)
+
+	tasks, err := dataClient.GetTasks()
+	assert.Len(t, tasks, 1)
+}
+
+func TestHandleResourceStateChangeSaveData(t *testing.T) {
+	testCases := []struct {
+		name       string
+		knownState resourcestatus.ResourceStatus
+		nextState  resourcestatus.ResourceStatus
+		err        error
+		shouldSave bool
+	}{
+		{
+			name:       "non-redundant resource state change is saved",
+			knownState: resourcestatus.ResourceStatus(volume.VolumeStatusNone),
+			nextState:  resourcestatus.ResourceStatus(volume.VolumeCreated),
+			shouldSave: true,
+		},
+		{
+			name:       "redundant resource state change is not saved",
+			knownState: resourcestatus.ResourceStatus(volume.VolumeCreated),
+			nextState:  resourcestatus.ResourceStatus(volume.VolumeCreated),
+		},
+		{
+			name:       "non-redundant resource state change with error is saved",
+			shouldSave: true,
+			knownState: resourcestatus.ResourceStatus(volume.VolumeStatusNone),
+			nextState:  resourcestatus.ResourceStatus(volume.VolumeCreated),
+			err:        testErr,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dataClient, cleanup := newTestDataClient(t)
+			defer cleanup()
+
+			res := &volume.VolumeResource{Name: dataTestVolumeName}
+			res.SetKnownStatus(tc.knownState)
+			mTask := managedTask{
+				Task: &apitask.Task{
+					Arn:                 testTaskARN,
+					ResourcesMapUnsafe:  make(map[string][]taskresource.TaskResource),
+					DesiredStatusUnsafe: apitaskstatus.TaskRunning,
+				},
+				engine: &DockerTaskEngine{
+					saver:      statemanager.NewNoopStateManager(),
+					dataClient: dataClient,
+				},
+			}
+			mTask.AddResource(resourcetype.DockerVolumeKey, res)
+			mTask.handleResourceStateChange(resourceStateChange{
+				res, tc.nextState, tc.err,
+			})
+
+			tasks, err := dataClient.GetTasks()
+			require.NoError(t, err)
+			if tc.shouldSave {
+				assert.Len(t, tasks, 1)
+			} else {
+				assert.Len(t, tasks, 0)
+			}
+		})
+	}
+}
+
+func newTestContainer(name string, knownStatus, desiredStatus apicontainerstatus.ContainerStatus) *apicontainer.Container {
+	return &apicontainer.Container{
+		Name:                name,
+		TaskARN:             testTaskARN,
+		KnownStatusUnsafe:   knownStatus,
+		DesiredStatusUnsafe: desiredStatus,
+	}
+}

--- a/agent/engine/task_manager_test.go
+++ b/agent/engine/task_manager_test.go
@@ -38,6 +38,7 @@ import (
 	apitaskstatus "github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/credentials"
+	"github.com/aws/amazon-ecs-agent/agent/data"
 	mock_dockerapi "github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dependencygraph"
 	mock_dockerstate "github.com/aws/amazon-ecs-agent/agent/engine/dockerstate/mocks"
@@ -750,6 +751,7 @@ func TestStartContainerTransitionsInvokesHandleContainerChange(t *testing.T) {
 		engine: &DockerTaskEngine{
 			containerChangeEventStream: containerChangeEventStream,
 			stateChangeEvents:          stateChangeEvents,
+			dataClient:                 data.NewNoopClient(),
 		},
 		stateChangeEvents:          stateChangeEvents,
 		containerChangeEventStream: containerChangeEventStream,
@@ -910,6 +912,9 @@ func TestOnContainersUnableToTransitionStateForDesiredRunningTask(t *testing.T) 
 			},
 			DesiredStatusUnsafe: apitaskstatus.TaskRunning,
 		},
+		engine: &DockerTaskEngine{
+			dataClient: data.NewNoopClient(),
+		},
 		ctx: context.TODO(),
 	}
 
@@ -1035,6 +1040,7 @@ func TestCleanupTask(t *testing.T) {
 		ctx:          ctx,
 		cfg:          &cfg,
 		saver:        statemanager.NewNoopStateManager(),
+		dataClient:   data.NewNoopClient(),
 		state:        mockState,
 		client:       mockClient,
 		imageManager: mockImageManager,
@@ -1096,6 +1102,7 @@ func TestCleanupTaskWaitsForStoppedSent(t *testing.T) {
 		ctx:          ctx,
 		cfg:          &cfg,
 		saver:        statemanager.NewNoopStateManager(),
+		dataClient:   data.NewNoopClient(),
 		state:        mockState,
 		client:       mockClient,
 		imageManager: mockImageManager,
@@ -1165,6 +1172,7 @@ func TestCleanupTaskGivesUpIfWaitingTooLong(t *testing.T) {
 		ctx:          ctx,
 		cfg:          &cfg,
 		saver:        statemanager.NewNoopStateManager(),
+		dataClient:   data.NewNoopClient(),
 		state:        mockState,
 		client:       mockClient,
 		imageManager: mockImageManager,
@@ -1220,6 +1228,7 @@ func TestCleanupTaskENIs(t *testing.T) {
 		ctx:          ctx,
 		cfg:          &cfg,
 		saver:        statemanager.NewNoopStateManager(),
+		dataClient:   data.NewNoopClient(),
 		state:        mockState,
 		client:       mockClient,
 		imageManager: mockImageManager,
@@ -1350,6 +1359,7 @@ func TestCleanupTaskWithInvalidInterval(t *testing.T) {
 		ctx:          ctx,
 		cfg:          &cfg,
 		saver:        statemanager.NewNoopStateManager(),
+		dataClient:   data.NewNoopClient(),
 		state:        mockState,
 		client:       mockClient,
 		imageManager: mockImageManager,
@@ -1408,6 +1418,7 @@ func TestCleanupTaskWithResourceHappyPath(t *testing.T) {
 		ctx:          ctx,
 		cfg:          &cfg,
 		saver:        statemanager.NewNoopStateManager(),
+		dataClient:   data.NewNoopClient(),
 		state:        mockState,
 		client:       mockClient,
 		imageManager: mockImageManager,
@@ -1470,6 +1481,7 @@ func TestCleanupTaskWithResourceErrorPath(t *testing.T) {
 		ctx:          ctx,
 		cfg:          &cfg,
 		saver:        statemanager.NewNoopStateManager(),
+		dataClient:   data.NewNoopClient(),
 		state:        mockState,
 		client:       mockClient,
 		imageManager: mockImageManager,
@@ -1528,6 +1540,9 @@ func TestHandleContainerChangeUpdateContainerHealth(t *testing.T) {
 		containerChangeEventStream: containerChangeEventStream,
 		stateChangeEvents:          make(chan statechange.Event),
 		ctx:                        context.TODO(),
+		engine: &DockerTaskEngine{
+			dataClient: data.NewNoopClient(),
+		},
 	}
 	// Discard all the statechange events
 	defer discardEvents(mTask.stateChangeEvents)()
@@ -1570,6 +1585,9 @@ func TestHandleContainerChangeUpdateMetadataRedundant(t *testing.T) {
 		containerChangeEventStream: containerChangeEventStream,
 		stateChangeEvents:          make(chan statechange.Event),
 		ctx:                        context.TODO(),
+		engine: &DockerTaskEngine{
+			dataClient: data.NewNoopClient(),
+		},
 	}
 	// Discard all the statechange events
 	defer discardEvents(mTask.stateChangeEvents)()
@@ -1762,7 +1780,9 @@ func TestHandleVolumeResourceStateChangeAndSave(t *testing.T) {
 					ResourcesMapUnsafe:  make(map[string][]taskresource.TaskResource),
 					DesiredStatusUnsafe: apitaskstatus.TaskRunning,
 				},
-				engine: &DockerTaskEngine{},
+				engine: &DockerTaskEngine{
+					dataClient: data.NewNoopClient(),
+				},
 			}
 			mtask.AddResource(volumeName, res)
 			mtask.engine.SetSaver(mockSaver)

--- a/agent/engine/task_manager_unix_test.go
+++ b/agent/engine/task_manager_unix_test.go
@@ -23,6 +23,7 @@ import (
 
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
+	"github.com/aws/amazon-ecs-agent/agent/data"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dependencygraph"
 	mock_statemanager "github.com/aws/amazon-ecs-agent/agent/statemanager/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
@@ -77,7 +78,9 @@ func TestHandleResourceStateChangeAndSave(t *testing.T) {
 					ResourcesMapUnsafe:  make(map[string][]taskresource.TaskResource),
 					DesiredStatusUnsafe: apitaskstatus.TaskRunning,
 				},
-				engine: &DockerTaskEngine{},
+				engine: &DockerTaskEngine{
+					dataClient: data.NewNoopClient(),
+				},
 			}
 			mtask.AddResource("cgroup", res)
 			mtask.engine.SetSaver(mockSaver)

--- a/agent/eventhandler/handler_test.go
+++ b/agent/eventhandler/handler_test.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
 	mock_api "github.com/aws/amazon-ecs-agent/agent/api/mocks"
+	"github.com/aws/amazon-ecs-agent/agent/data"
+	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/statemanager"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -35,7 +37,7 @@ func TestHandleEngineEvent(t *testing.T) {
 	stateManager := statemanager.NewNoopStateManager()
 
 	ctx, cancel := context.WithCancel(context.Background())
-	taskHandler := NewTaskHandler(ctx, stateManager, nil, client)
+	taskHandler := NewTaskHandler(ctx, stateManager, data.NewNoopClient(), dockerstate.NewTaskEngineState(), client)
 	attachmentHandler := NewAttachmentEventHandler(ctx, statemanager.NewNoopStateManager(), client)
 	defer cancel()
 

--- a/agent/eventhandler/task_handler.go
+++ b/agent/eventhandler/task_handler.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
 	apitaskstatus "github.com/aws/amazon-ecs-agent/agent/api/task/status"
+	"github.com/aws/amazon-ecs-agent/agent/data"
 	"github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/metrics"
@@ -69,6 +70,10 @@ type TaskHandler struct {
 	// changes to a task or container's SentStatus
 	stateSaver statemanager.Saver
 
+	// dataClient is used to save changes to database, mainly to save
+	// changes of a task or container's SentStatus.
+	dataClient data.Client
+
 	// min and max drain events frequency refer to the range of
 	// time over which a call to SubmitTaskStateChange is made.
 	// The actual duration is randomly distributed between these
@@ -101,6 +106,7 @@ type taskSendableEvents struct {
 // NewTaskHandler returns a pointer to TaskHandler
 func NewTaskHandler(ctx context.Context,
 	stateManager statemanager.Saver,
+	dataClient data.Client,
 	state dockerstate.TaskEngineState,
 	client api.ECSClient) *TaskHandler {
 	// Create a handler and start the periodic event drain loop
@@ -110,6 +116,7 @@ func NewTaskHandler(ctx context.Context,
 		submitSemaphore:         utils.NewSemaphore(concurrentEventCalls),
 		tasksToContainerStates:  make(map[string][]api.ContainerStateChange),
 		stateSaver:              stateManager,
+		dataClient:              dataClient,
 		state:                   state,
 		client:                  client,
 		minDrainEventsFrequency: minDrainEventsFrequency,
@@ -355,18 +362,18 @@ func (taskEvents *taskSendableEvents) submitFirstEvent(handler *TaskHandler, bac
 
 	if event.containerShouldBeSent() {
 		if err := event.send(sendContainerStatusToECS, setContainerChangeSent, "container",
-			handler.client, eventToSubmit, handler.stateSaver, backoff, taskEvents); err != nil {
+			handler.client, eventToSubmit, handler.stateSaver, handler.dataClient, backoff, taskEvents); err != nil {
 			return false, err
 		}
 	} else if event.taskShouldBeSent() {
 		if err := event.send(sendTaskStatusToECS, setTaskChangeSent, "task",
-			handler.client, eventToSubmit, handler.stateSaver, backoff, taskEvents); err != nil {
+			handler.client, eventToSubmit, handler.stateSaver, handler.dataClient, backoff, taskEvents); err != nil {
 			handleInvalidParamException(err, taskEvents.events, eventToSubmit)
 			return false, err
 		}
 	} else if event.taskAttachmentShouldBeSent() {
 		if err := event.send(sendTaskStatusToECS, setTaskAttachmentSent, "task attachment",
-			handler.client, eventToSubmit, handler.stateSaver, backoff, taskEvents); err != nil {
+			handler.client, eventToSubmit, handler.stateSaver, handler.dataClient, backoff, taskEvents); err != nil {
 			handleInvalidParamException(err, taskEvents.events, eventToSubmit)
 			return false, err
 		}

--- a/agent/stats/common_test.go
+++ b/agent/stats/common_test.go
@@ -22,6 +22,7 @@ import (
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/data"
 	"github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
 	"github.com/aws/amazon-ecs-agent/agent/statechange"
@@ -300,6 +301,9 @@ func (engine *MockTaskEngine) StateChangeEvents() chan statechange.Event {
 }
 
 func (engine *MockTaskEngine) SetSaver(statemanager.Saver) {
+}
+
+func (engine *MockTaskEngine) SetDataClient(data.Client) {
 }
 
 func (engine *MockTaskEngine) AddTask(*apitask.Task) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Save task and container data to boltdb with the boltdb client. Existing usage of state manager is not removed and will be removed in a separate change to reduce the amount of changes made at once.

Changes in this PR are intended to cover all the scenarios where we want to save task and container.

### Implementation details
<!-- How are the changes implemented? -->
Changes are made in following packages:
* `acs/handler`: save task to boltdb after adding the task to task engine;
* `api/task`: populate task arn to container in PostUnmarshalTask. this is used to generate database key when saving the container;
* `app/agent`: initialize boltdb data client and pass it to task engine, acs handler and event handler;
* `data`: added a no-op client which is used in testing and when ECS_CHECKPOINT is set to false;
* `engine`:
  - added a file data.go which covers interaction with boltdb;  - added a file data.go which covers interaction with boltdb;
  - task engine: remove task and containers data from database when cleaning up the task; added a method SetDataClient to set the client similar to how the state manager was set;
  - task manager: save task to boltdb when its desired/known status changes and when resource known status changes; save container to boltdb when its desired/known status changes and when updating its metadata. these are done in handleDesiredStatusChange, handleContainerChange and handleResourceStateChange in task_manager.go;
* `eventhandler`: save task/container in boltdb after updating their sent status.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Unit tests added. Manually tested by running a task and checked that the task and container are saved in the db.

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
N/A

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
