### PR TITLE
Refactoring Conditional to BooleanDefaultTrue

### DIFF
--- a/agent/api/task/task_linux_test.go
+++ b/agent/api/task/task_linux_test.go
@@ -568,7 +568,7 @@ func TestPostUnmarshalWithCPULimitsFail(t *testing.T) {
 		ResourcesMapUnsafe: make(map[string][]taskresource.TaskResource),
 	}
 	cfg := config.Config{
-		TaskCPUMemLimit: config.ExplicitlyEnabled,
+		TaskCPUMemLimit: config.BooleanDefaultTrue{Value: config.ExplicitlyEnabled},
 	}
 	assert.Error(t, task.PostUnmarshalTask(&cfg, nil, nil, nil, nil))
 	assert.Equal(t, 0, len(task.GetResources()))

--- a/agent/api/task/task_windows_test.go
+++ b/agent/api/task/task_windows_test.go
@@ -109,7 +109,7 @@ func TestPostUnmarshalWindowsCanonicalPaths(t *testing.T) {
 	seqNum := int64(42)
 	task, err := TaskFromACS(&taskFromAcs, &ecsacs.PayloadMessage{SeqNum: &seqNum})
 	assert.Nil(t, err, "Should be able to handle acs task")
-	cfg := config.Config{TaskCPUMemLimit: config.ExplicitlyDisabled}
+	cfg := config.Config{TaskCPUMemLimit: config.BooleanDefaultTrue{Value: config.ExplicitlyDisabled}}
 	task.PostUnmarshalTask(&cfg, nil, nil, nil, nil)
 
 	for _, container := range task.Containers { // remove v3 endpoint from each container because it's randomly generated

--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -275,13 +275,13 @@ func (agent *ecsAgent) appendTaskCPUMemLimitCapabilities(capabilities []*ecs.Att
 	if agent.cfg.TaskCPUMemLimit.Enabled() {
 		if _, ok := supportedVersions[dockerclient.Version_1_22]; ok {
 			capabilities = appendNameOnlyAttribute(capabilities, attributePrefix+capabilityTaskCPUMemLimit)
-		} else if agent.cfg.TaskCPUMemLimit == config.ExplicitlyEnabled {
+		} else if agent.cfg.TaskCPUMemLimit.Value == config.ExplicitlyEnabled {
 			// explicitly enabled -- return an error because we cannot fulfil an explicit request
 			return nil, errors.New("engine: Task CPU + Mem limit cannot be enabled due to unsupported Docker version")
 		} else {
 			// implicitly enabled -- don't register the capability, but degrade gracefully
 			seelog.Warn("Task CPU + Mem Limit disabled due to unsupported Docker version. API version 1.22 or greater is required.")
-			agent.cfg.TaskCPUMemLimit = config.ExplicitlyDisabled
+			agent.cfg.TaskCPUMemLimit.Value = config.ExplicitlyDisabled
 		}
 	}
 	return capabilities, nil

--- a/agent/app/agent_capability_test.go
+++ b/agent/app/agent_capability_test.go
@@ -486,7 +486,7 @@ func TestCapabilitiesExecutionRoleAWSLogs(t *testing.T) {
 func TestCapabilitiesTaskResourceLimit(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
-	conf := &config.Config{TaskCPUMemLimit: config.ExplicitlyEnabled}
+	conf := &config.Config{TaskCPUMemLimit: config.BooleanDefaultTrue{Value: config.ExplicitlyEnabled}}
 
 	client := mock_dockerapi.NewMockDockerClient(ctrl)
 	versionList := []dockerclient.DockerVersion{dockerclient.Version_1_22}
@@ -529,7 +529,7 @@ func TestCapabilitiesTaskResourceLimit(t *testing.T) {
 func TestCapabilitesTaskResourceLimitDisabledByMissingDockerVersion(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
-	conf := &config.Config{TaskCPUMemLimit: config.DefaultEnabled}
+	conf := &config.Config{TaskCPUMemLimit: config.BooleanDefaultTrue{Value: config.NotSet}}
 
 	client := mock_dockerapi.NewMockDockerClient(ctrl)
 	versionList := []dockerclient.DockerVersion{dockerclient.Version_1_19}
@@ -572,7 +572,7 @@ func TestCapabilitesTaskResourceLimitDisabledByMissingDockerVersion(t *testing.T
 func TestCapabilitesTaskResourceLimitErrorCase(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
-	conf := &config.Config{TaskCPUMemLimit: config.ExplicitlyEnabled}
+	conf := &config.Config{TaskCPUMemLimit: config.BooleanDefaultTrue{Value: config.ExplicitlyEnabled}}
 
 	client := mock_dockerapi.NewMockDockerClient(ctrl)
 	versionList := []dockerclient.DockerVersion{dockerclient.Version_1_19}

--- a/agent/app/agent_compatibility_linux.go
+++ b/agent/app/agent_compatibility_linux.go
@@ -52,12 +52,12 @@ func (agent *ecsAgent) checkCompatibility(engine engine.TaskEngine) error {
 		return nil
 	}
 
-	if agent.cfg.TaskCPUMemLimit == config.ExplicitlyEnabled {
+	if agent.cfg.TaskCPUMemLimit.Value == config.ExplicitlyEnabled {
 		return errors.New("App: unable to load old tasks because TaskCPUMemLimits setting is incompatible with old state.")
 	}
 
 	seelog.Warn("App: disabling TaskCPUMemLimit.")
-	agent.cfg.TaskCPUMemLimit = config.ExplicitlyDisabled
+	agent.cfg.TaskCPUMemLimit.Value = config.ExplicitlyDisabled
 
 	return nil
 }

--- a/agent/app/agent_compatibility_linux_test.go
+++ b/agent/app/agent_compatibility_linux_test.go
@@ -36,7 +36,7 @@ func TestCompatibilityEnabledSuccess(t *testing.T) {
 
 	cfg := getTestConfig()
 	cfg.Checkpoint = true
-	cfg.TaskCPUMemLimit = config.DefaultEnabled
+	cfg.TaskCPUMemLimit = config.BooleanDefaultTrue{Value: config.NotSet}
 
 	agent := &ecsAgent{
 		cfg:                   &cfg,
@@ -63,14 +63,14 @@ func TestCompatibilityEnabledSuccess(t *testing.T) {
 	assert.True(t, cfg.TaskCPUMemLimit.Enabled())
 }
 
-func TestCompatibilityDefaultEnabledFail(t *testing.T) {
+func TestCompatibilityNotSetFail(t *testing.T) {
 	ctrl, creds, state, images, _, _, stateManagerFactory, saveableOptionFactory := setup(t)
 	defer ctrl.Finish()
 	stateManager := mock_statemanager.NewMockStateManager(ctrl)
 
 	cfg := getTestConfig()
 	cfg.Checkpoint = true
-	cfg.TaskCPUMemLimit = config.DefaultEnabled
+	cfg.TaskCPUMemLimit = config.BooleanDefaultTrue{Value: config.NotSet}
 
 	agent := &ecsAgent{
 		cfg:                   &cfg,
@@ -102,7 +102,7 @@ func TestCompatibilityExplicitlyEnabledFail(t *testing.T) {
 
 	cfg := getTestConfig()
 	cfg.Checkpoint = true
-	cfg.TaskCPUMemLimit = config.ExplicitlyEnabled
+	cfg.TaskCPUMemLimit.Value = config.ExplicitlyEnabled
 
 	agent := &ecsAgent{
 		cfg:                   &cfg,

--- a/agent/app/agent_test.go
+++ b/agent/app/agent_test.go
@@ -259,7 +259,7 @@ func TestDoStartRegisterContainerInstanceErrorTerminal(t *testing.T) {
 	mockEC2Metadata.EXPECT().OutpostARN().Return("", nil)
 
 	cfg := getTestConfig()
-	cfg.TaskCPUMemLimit = config.ExplicitlyDisabled
+	cfg.TaskCPUMemLimit.Value = config.ExplicitlyDisabled
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines
 	defer cancel()
@@ -1421,6 +1421,6 @@ func TestSpotInstanceActionCheck_NoInstanceActionYet(t *testing.T) {
 
 func getTestConfig() config.Config {
 	cfg := config.DefaultConfig()
-	cfg.TaskCPUMemLimit = config.ExplicitlyDisabled
+	cfg.TaskCPUMemLimit.Value = config.ExplicitlyDisabled
 	return cfg
 }

--- a/agent/app/agent_unix.go
+++ b/agent/app/agent_unix.go
@@ -219,11 +219,11 @@ func (agent *ecsAgent) cgroupInit() error {
 	if err == nil {
 		return nil
 	}
-	if agent.cfg.TaskCPUMemLimit == config.ExplicitlyEnabled {
+	if agent.cfg.TaskCPUMemLimit.Value == config.ExplicitlyEnabled {
 		return errors.Wrapf(err, "unable to setup '/ecs' cgroup")
 	}
 	seelog.Warnf("Disabling TaskCPUMemLimit because agent is unabled to setup '/ecs' cgroup: %v", err)
-	agent.cfg.TaskCPUMemLimit = config.ExplicitlyDisabled
+	agent.cfg.TaskCPUMemLimit.Value = config.ExplicitlyDisabled
 	return nil
 }
 

--- a/agent/app/agent_unix_test.go
+++ b/agent/app/agent_unix_test.go
@@ -596,7 +596,7 @@ func TestDoStartCgroupInitErrorPath(t *testing.T) {
 	mockControl.EXPECT().Init().Return(errors.New("test error"))
 
 	cfg := getTestConfig()
-	cfg.TaskCPUMemLimit = config.ExplicitlyEnabled
+	cfg.TaskCPUMemLimit.Value = config.ExplicitlyEnabled
 
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines

--- a/agent/app/agent_windows_test.go
+++ b/agent/app/agent_windows_test.go
@@ -279,7 +279,7 @@ func TestDoStartTaskLimitsFail(t *testing.T) {
 
 	cfg := getTestConfig()
 	cfg.Checkpoint = true
-	cfg.TaskCPUMemLimit = config.ExplicitlyEnabled
+	cfg.TaskCPUMemLimit.Value = config.ExplicitlyEnabled
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines
 	defer cancel()

--- a/agent/config/conditional.go
+++ b/agent/config/conditional.go
@@ -24,17 +24,21 @@ const (
 	_ Conditional = iota
 	ExplicitlyEnabled
 	ExplicitlyDisabled
-	DefaultEnabled
+	NotSet
 )
 
+type BooleanDefaultTrue struct {
+	Value Conditional
+}
+
 // Enabled is a convenience function for when consumers don't care if the value is implicit or explicit
-func (b Conditional) Enabled() bool {
-	return b == ExplicitlyEnabled || b == DefaultEnabled
+func (b BooleanDefaultTrue) Enabled() bool {
+	return b.Value == ExplicitlyEnabled || b.Value == NotSet
 }
 
 // MarshalJSON is used to serialize the type to json, per the Marshaller interface
-func (b Conditional) MarshalJSON() ([]byte, error) {
-	switch b {
+func (b BooleanDefaultTrue) MarshalJSON() ([]byte, error) {
+	switch b.Value {
 	case ExplicitlyEnabled:
 		return json.Marshal(true)
 	case ExplicitlyDisabled:
@@ -45,7 +49,7 @@ func (b Conditional) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON is used to deserialize json types into Conditional, per the Unmarshaller interface
-func (b *Conditional) UnmarshalJSON(jsonData []byte) error {
+func (b *BooleanDefaultTrue) UnmarshalJSON(jsonData []byte) error {
 	jsonString := string(jsonData)
 	jsonBool, err := strconv.ParseBool(jsonString)
 	if err != nil && jsonString != "null" {
@@ -53,11 +57,11 @@ func (b *Conditional) UnmarshalJSON(jsonData []byte) error {
 	}
 
 	if jsonString == "" || jsonString == "null" {
-		*b = DefaultEnabled
+		b.Value = NotSet
 	} else if jsonBool {
-		*b = ExplicitlyEnabled
+		b.Value = ExplicitlyEnabled
 	} else {
-		*b = ExplicitlyDisabled
+		b.Value = ExplicitlyDisabled
 	}
 
 	return nil

--- a/agent/config/conditional_test.go
+++ b/agent/config/conditional_test.go
@@ -22,32 +22,32 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestConditional(t *testing.T) {
-	x := DefaultEnabled
-	y := ExplicitlyEnabled
-	z := ExplicitlyDisabled
+func TestBooleanDefaultTrue(t *testing.T) {
+	x := BooleanDefaultTrue{Value: NotSet}
+	y := BooleanDefaultTrue{Value: ExplicitlyEnabled}
+	z := BooleanDefaultTrue{Value: ExplicitlyDisabled}
 
-	assert.True(t, x.Enabled(), "DefaultEnabled is enabled")
+	assert.True(t, x.Enabled(), "NotSet is enabled")
 	assert.True(t, y.Enabled(), "ExplicitlyEnabled is enabled")
 	assert.False(t, z.Enabled(), "ExplicitlyDisabled is not enabled")
 }
 
-func TestConditionalImplements(t *testing.T) {
-	assert.Implements(t, (*json.Marshaler)(nil), (Conditional)(1))
-	assert.Implements(t, (*json.Unmarshaler)(nil), (*Conditional)(nil))
+func TestBooleanDefaultTrueImplements(t *testing.T) {
+	assert.Implements(t, (*json.Marshaler)(nil), BooleanDefaultTrue{Value: NotSet})
+	assert.Implements(t, (*json.Unmarshaler)(nil), (*BooleanDefaultTrue)(nil))
 }
 
 // main conversion cases for Conditional marshalling
 var cases = []struct {
-	defaultBool Conditional
+	defaultBool BooleanDefaultTrue
 	bytes       []byte
 }{
-	{ExplicitlyEnabled, []byte("true")},
-	{ExplicitlyDisabled, []byte("false")},
-	{DefaultEnabled, []byte("null")},
+	{BooleanDefaultTrue{Value: ExplicitlyEnabled}, []byte("true")},
+	{BooleanDefaultTrue{Value: ExplicitlyDisabled}, []byte("false")},
+	{BooleanDefaultTrue{Value: NotSet}, []byte("null")},
 }
 
-func TestConditionalMarshal(t *testing.T) {
+func TestBooleanDefaultTrueMarshal(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(string(tc.bytes), func(t *testing.T) {
 			m, err := json.Marshal(tc.defaultBool)
@@ -57,10 +57,10 @@ func TestConditionalMarshal(t *testing.T) {
 	}
 }
 
-func TestConditionalUnmarshal(t *testing.T) {
+func TestBooleanDefaultTrueUnmarshal(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(string(tc.bytes), func(t *testing.T) {
-			var target Conditional
+			var target BooleanDefaultTrue
 			err := json.Unmarshal(tc.bytes, &target)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.defaultBool, target)

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -588,7 +588,7 @@ func TestTaskResourceLimitsOverride(t *testing.T) {
 	cfg, err := NewConfig(ec2.NewBlackholeEC2MetadataClient())
 	assert.NoError(t, err)
 	assert.False(t, cfg.TaskCPUMemLimit.Enabled(), "Task cpu and memory limits should be overridden to false")
-	assert.Equal(t, ExplicitlyDisabled, cfg.TaskCPUMemLimit, "Task cpu and memory limits should be explicitly set")
+	assert.Equal(t, ExplicitlyDisabled, cfg.TaskCPUMemLimit.Value, "Task cpu and memory limits should be explicitly set")
 }
 
 func TestAWSVPCBlockInstanceMetadata(t *testing.T) {

--- a/agent/config/config_unix.go
+++ b/agent/config/config_unix.go
@@ -71,7 +71,7 @@ func DefaultConfig() Config {
 		PauseContainerTag:                   DefaultPauseContainerTag,
 		AWSVPCBlockInstanceMetdata:          false,
 		ContainerMetadataEnabled:            false,
-		TaskCPUMemLimit:                     DefaultEnabled,
+		TaskCPUMemLimit:                     BooleanDefaultTrue{Value: NotSet},
 		CgroupPath:                          defaultCgroupPath,
 		TaskMetadataSteadyStateRate:         DefaultTaskMetadataSteadyStateRate,
 		TaskMetadataBurstRate:               DefaultTaskMetadataBurstRate,

--- a/agent/config/config_unix_test.go
+++ b/agent/config/config_unix_test.go
@@ -50,7 +50,7 @@ func TestConfigDefault(t *testing.T) {
 	assert.False(t, cfg.TaskENIEnabled, "TaskENIEnabled set incorrectly")
 	assert.False(t, cfg.TaskIAMRoleEnabled, "TaskIAMRoleEnabled set incorrectly")
 	assert.False(t, cfg.TaskIAMRoleEnabledForNetworkHost, "TaskIAMRoleEnabledForNetworkHost set incorrectly")
-	assert.Equal(t, DefaultEnabled, cfg.TaskCPUMemLimit, "TaskCPUMemLimit should be DefaultEnabled")
+	assert.Equal(t, NotSet, cfg.TaskCPUMemLimit.Value, "TaskCPUMemLimit should be NotSet")
 	assert.False(t, cfg.CredentialsAuditLogDisabled, "CredentialsAuditLogDisabled set incorrectly")
 	assert.Equal(t, defaultCredentialsAuditLogFile, cfg.CredentialsAuditLogFile, "CredentialsAuditLogFile is set incorrectly")
 	assert.False(t, cfg.ImageCleanupDisabled, "ImageCleanupDisabled default is set incorrectly")
@@ -121,7 +121,7 @@ func TestConfigFromFile(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, expectedLocalRoute.IP, cfg.AWSVPCAdditionalLocalRoutes[0].IP, "should match expected route IP")
 	assert.Equal(t, expectedLocalRoute.Mask, cfg.AWSVPCAdditionalLocalRoutes[0].Mask, "should match expected route Mask")
-	assert.Equal(t, ExplicitlyEnabled, cfg.TaskCPUMemLimit, "TaskCPUMemLimit should be explicitly enabled")
+	assert.Equal(t, ExplicitlyEnabled, cfg.TaskCPUMemLimit.Value, "TaskCPUMemLimit should be explicitly enabled")
 }
 
 // TestDockerAuthMergeFromFile tests docker auth read from file correctly after merge

--- a/agent/config/config_windows.go
+++ b/agent/config/config_windows.go
@@ -96,7 +96,7 @@ func DefaultConfig() Config {
 		NumImagesToDeletePerCycle:           DefaultNumImagesToDeletePerCycle,
 		NumNonECSContainersToDeletePerCycle: DefaultNumNonECSContainersToDeletePerCycle,
 		ContainerMetadataEnabled:            false,
-		TaskCPUMemLimit:                     ExplicitlyDisabled,
+		TaskCPUMemLimit:                     BooleanDefaultTrue{Value: ExplicitlyDisabled},
 		PlatformVariables:                   platformVariables,
 		TaskMetadataSteadyStateRate:         DefaultTaskMetadataSteadyStateRate,
 		TaskMetadataBurstRate:               DefaultTaskMetadataBurstRate,
@@ -118,7 +118,7 @@ func (cfg *Config) platformOverrides() {
 	}
 
 	// ensure TaskResourceLimit is disabled
-	cfg.TaskCPUMemLimit = ExplicitlyDisabled
+	cfg.TaskCPUMemLimit.Value = ExplicitlyDisabled
 
 	cpuUnbounded := utils.ParseBool(os.Getenv("ECS_ENABLE_CPU_UNBOUNDED_WINDOWS_WORKAROUND"), false)
 	memoryUnbounded := utils.ParseBool(os.Getenv("ECS_ENABLE_MEMORY_UNBOUNDED_WINDOWS_WORKAROUND"), false)

--- a/agent/config/parse.go
+++ b/agent/config/parse.go
@@ -201,17 +201,17 @@ func parseAdditionalLocalRoutes(errs []error) ([]cnitypes.IPNet, []error) {
 	return additionalLocalRoutes, errs
 }
 
-func parseTaskCPUMemLimitEnabled() Conditional {
-	var taskCPUMemLimitEnabled Conditional
+func parseTaskCPUMemLimitEnabled() BooleanDefaultTrue {
+	taskCPUMemLimitEnabled := BooleanDefaultTrue{Value: NotSet}
 	taskCPUMemLimitConfigString := os.Getenv("ECS_ENABLE_TASK_CPU_MEM_LIMIT")
 
 	// We only want to set taskCPUMemLimit if it is explicitly set to true or false.
 	// We can do this by checking against the ParseBool default
 	if taskCPUMemLimitConfigString != "" {
 		if utils.ParseBool(taskCPUMemLimitConfigString, false) {
-			taskCPUMemLimitEnabled = ExplicitlyEnabled
+			taskCPUMemLimitEnabled.Value = ExplicitlyEnabled
 		} else {
-			taskCPUMemLimitEnabled = ExplicitlyDisabled
+			taskCPUMemLimitEnabled.Value = ExplicitlyDisabled
 		}
 	}
 	return taskCPUMemLimitEnabled

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -143,7 +143,7 @@ type Config struct {
 	DeleteNonECSImagesEnabled bool
 
 	// TaskCPUMemLimit specifies if Agent can launch a task with a hierarchical cgroup
-	TaskCPUMemLimit Conditional
+	TaskCPUMemLimit BooleanDefaultTrue
 
 	// CredentialsAuditLogFile specifies the path/filename of the audit log.
 	CredentialsAuditLogFile string

--- a/agent/engine/common_integ_test.go
+++ b/agent/engine/common_integ_test.go
@@ -46,7 +46,7 @@ import (
 
 func defaultTestConfigIntegTest() *config.Config {
 	cfg, _ := config.NewConfig(ec2.NewBlackholeEC2MetadataClient())
-	cfg.TaskCPUMemLimit = config.ExplicitlyDisabled
+	cfg.TaskCPUMemLimit.Value = config.ExplicitlyDisabled
 	cfg.ImagePullBehavior = config.ImagePullPreferCachedBehavior
 	return cfg
 }

--- a/agent/engine/docker_task_engine_linux_test.go
+++ b/agent/engine/docker_task_engine_linux_test.go
@@ -62,7 +62,7 @@ const (
 
 func init() {
 	defaultConfig = config.DefaultConfig()
-	defaultConfig.TaskCPUMemLimit = config.ExplicitlyDisabled
+	defaultConfig.TaskCPUMemLimit.Value = config.ExplicitlyDisabled
 }
 
 // TestResourceContainerProgression tests the container progression based on a
@@ -156,7 +156,7 @@ func TestDeleteTask(t *testing.T) {
 	task.ResourcesMapUnsafe = make(map[string][]taskresource.TaskResource)
 	task.AddResource("cgroup", cgroupResource)
 	cfg := defaultConfig
-	cfg.TaskCPUMemLimit = config.ExplicitlyEnabled
+	cfg.TaskCPUMemLimit.Value = config.ExplicitlyEnabled
 	mockState := mock_dockerstate.NewMockTaskEngineState(ctrl)
 	mockSaver := mock_statemanager.NewMockStateManager(ctrl)
 
@@ -193,7 +193,7 @@ func TestDeleteTaskBranchENIEnabled(t *testing.T) {
 	task.ResourcesMapUnsafe = make(map[string][]taskresource.TaskResource)
 	task.AddResource("cgroup", cgroupResource)
 	cfg := defaultConfig
-	cfg.TaskCPUMemLimit = config.ExplicitlyEnabled
+	cfg.TaskCPUMemLimit.Value = config.ExplicitlyEnabled
 	mockState := mock_dockerstate.NewMockTaskEngineState(ctrl)
 	mockSaver := mock_statemanager.NewMockStateManager(ctrl)
 
@@ -257,14 +257,14 @@ func TestTaskCPULimitHappyPath(t *testing.T) {
 		metadataCreateError error
 		metadataUpdateError error
 		metadataCleanError  error
-		taskCPULimit        config.Conditional
+		taskCPULimit        config.BooleanDefaultTrue
 	}{
 		{
 			name:                "Task CPU Limit Succeeds",
 			metadataCreateError: nil,
 			metadataUpdateError: nil,
 			metadataCleanError:  nil,
-			taskCPULimit:        config.ExplicitlyEnabled,
+			taskCPULimit:        config.BooleanDefaultTrue{Value: config.ExplicitlyEnabled},
 		},
 	}
 

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -136,7 +136,7 @@ var (
 
 func init() {
 	defaultConfig = config.DefaultConfig()
-	defaultConfig.TaskCPUMemLimit = config.ExplicitlyDisabled
+	defaultConfig.TaskCPUMemLimit.Value = config.ExplicitlyDisabled
 }
 
 func getCreatedContainerName() string {
@@ -212,7 +212,7 @@ func TestBatchContainerHappyPath(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			metadataConfig := defaultConfig
-			metadataConfig.TaskCPUMemLimit = tc.taskCPULimit
+			metadataConfig.TaskCPUMemLimit.Value = tc.taskCPULimit
 			metadataConfig.ContainerMetadataEnabled = true
 			ctx, cancel := context.WithCancel(context.TODO())
 			defer cancel()
@@ -1399,7 +1399,7 @@ func TestStopPauseContainerCleanupDelay(t *testing.T) {
 	defer cancel()
 
 	cfg := config.DefaultConfig()
-	cfg.TaskCPUMemLimit = config.ExplicitlyDisabled
+	cfg.TaskCPUMemLimit.Value = config.ExplicitlyDisabled
 	cfg.ENIPauseContainerCleanupDelaySeconds = expectedDelaySeconds
 
 	delayedChan := make(chan time.Duration, 1)

--- a/agent/engine/engine_sudo_linux_integ_test.go
+++ b/agent/engine/engine_sudo_linux_integ_test.go
@@ -65,7 +65,7 @@ const (
 func TestStartStopWithCgroup(t *testing.T) {
 	cfg := defaultTestConfigIntegTest()
 	cfg.TaskCleanupWaitDuration = 1 * time.Second
-	cfg.TaskCPUMemLimit = config.ExplicitlyEnabled
+	cfg.TaskCPUMemLimit.Value = config.ExplicitlyEnabled
 	cfg.CgroupPath = "/cgroup"
 
 	taskEngine, done, _ := setup(cfg, nil, t)

--- a/agent/engine/engine_windows_integ_test.go
+++ b/agent/engine/engine_windows_integ_test.go
@@ -701,7 +701,7 @@ func TestGMSATaskFile(t *testing.T) {
 
 func defaultTestConfigIntegTestGMSA() *config.Config {
 	cfg, _ := config.NewConfig(ec2.NewBlackholeEC2MetadataClient())
-	cfg.TaskCPUMemLimit = config.ExplicitlyDisabled
+	cfg.TaskCPUMemLimit.Value = config.ExplicitlyDisabled
 	cfg.ImagePullBehavior = config.ImagePullPreferCachedBehavior
 
 	cfg.GMSACapable = true

--- a/agent/engine/task_manager_test.go
+++ b/agent/engine/task_manager_test.go
@@ -1401,7 +1401,7 @@ func TestCleanupTaskWithResourceHappyPath(t *testing.T) {
 	defer ctrl.Finish()
 
 	cfg := getTestConfig()
-	cfg.TaskCPUMemLimit = config.ExplicitlyEnabled
+	cfg.TaskCPUMemLimit.Value = config.ExplicitlyEnabled
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	taskEngine := &DockerTaskEngine{
@@ -1463,7 +1463,7 @@ func TestCleanupTaskWithResourceErrorPath(t *testing.T) {
 	defer ctrl.Finish()
 
 	cfg := getTestConfig()
-	cfg.TaskCPUMemLimit = config.ExplicitlyEnabled
+	cfg.TaskCPUMemLimit.Value = config.ExplicitlyEnabled
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	taskEngine := &DockerTaskEngine{
@@ -1971,7 +1971,7 @@ func TestStartVolumeResourceTransitionsEmpty(t *testing.T) {
 
 func getTestConfig() config.Config {
 	cfg := config.DefaultConfig()
-	cfg.TaskCPUMemLimit = config.ExplicitlyDisabled
+	cfg.TaskCPUMemLimit.Value = config.ExplicitlyDisabled
 	return cfg
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Refactoring Conditional to BooleanDefaultTrue, replacing "DefaultTrue" to "NotSet", so that default false values can be supported.  
This is the first step in fixing the boolean config merge bug; I'll implement BooleanDefaultFalse next and apply it to one boolean config + test, and after that we need to migrate all boolean configs to use either of BooleanDefaultTrue or BooleanDefaultFalse instead of just boolean. I'm breaking down these to have reasonably sized PRs. 

### Implementation details
Replaced DefaultTrue with NotSet, and moved interpretation of NotSet value to a new wrapper struct BooleanDefaultTrue. With this, BooleanDefaultFalse can be implemented to use the same enum values but apply different defaulting logic to the not set boolean config.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
