### PR TITLE
change ports response from Ports to KnownPortBindings

### DIFF
--- a/agent/handlers/task_server_setup_test.go
+++ b/agent/handlers/task_server_setup_test.go
@@ -139,7 +139,7 @@ var (
 		CPU:                 cpu,
 		Memory:              memory,
 		Type:                apicontainer.ContainerNormal,
-		Ports: []apicontainer.PortBinding{
+		KnownPortBindingsUnsafe: []apicontainer.PortBinding{
 			{
 				ContainerPort: containerPort,
 				Protocol:      apicontainer.TransportProtocolTCP,
@@ -229,7 +229,7 @@ var (
 		CPU:                 cpu,
 		Memory:              memory,
 		Type:                apicontainer.ContainerNormal,
-		Ports: []apicontainer.PortBinding{
+		KnownPortBindingsUnsafe: []apicontainer.PortBinding{
 			{
 				ContainerPort: containerPort,
 				Protocol:      apicontainer.TransportProtocolTCP,

--- a/agent/handlers/v2/response.go
+++ b/agent/handlers/v2/response.go
@@ -220,7 +220,7 @@ func newContainerResponse(dockerContainer *apicontainer.DockerContainer,
 		resp.FinishedAt = &finishedAt
 	}
 
-	for _, binding := range container.Ports {
+	for _, binding := range container.GetKnownPortBindings() {
 		port := v1.PortResponse{
 			ContainerPort: binding.ContainerPort,
 			Protocol:      binding.Protocol.String(),

--- a/agent/handlers/v2/response_test.go
+++ b/agent/handlers/v2/response_test.go
@@ -294,7 +294,7 @@ func TestTaskResponseMarshal(t *testing.T) {
 		V3EndpointID: "",
 		Image:        imageName,
 		ImageID:      imageID,
-		Ports: []apicontainer.PortBinding{
+		KnownPortBindingsUnsafe: []apicontainer.PortBinding{
 			{
 				ContainerPort: 80,
 				Protocol:      apicontainer.TransportProtocolTCP,
@@ -414,7 +414,7 @@ func TestContainerResponseMarshal(t *testing.T) {
 			Status: apicontainerstatus.ContainerHealthy,
 			Since:  aws.Time(timeRFC3339),
 		},
-		Ports: []apicontainer.PortBinding{
+		KnownPortBindingsUnsafe: []apicontainer.PortBinding{
 			{
 				ContainerPort: 80,
 				Protocol:      apicontainer.TransportProtocolTCP,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
addresses https://github.com/aws/amazon-ecs-agent/issues/2476 

### Implementation details
when host port is set to 0 in task def for bridge mode, the same is used as part of http metadata response to the container. 
Changing this to use the updated port bindings retrieved from docker. 
Metadata file uses the port bindings from docker as well. 

### Testing
manual testing: 
after the change
```
# curl $ECS_CONTAINER_METADATA_URI_V4/task | grep HostPort
                    "HostPort": 32774,
```
before the change 
```
# curl $ECS_CONTAINER_METADATA_URI_V4/task | grep HostPort
#
```
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
