### PR TITLE
task: update task.GetID() to run with long ARN format

### DIFF
--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -83,7 +83,6 @@ const (
 	ContainerOrderingCreateCondition = "CREATE"
 	ContainerOrderingStartCondition  = "START"
 
-	arnResourceSections  = 2
 	arnResourceDelimiter = "/"
 	// networkModeNone specifies the string used to define the `none` docker networking mode
 	networkModeNone = "none"
@@ -1077,9 +1076,10 @@ func (task *Task) collectFirelensLogEnvOptions(containerToLogOptions map[string]
 // container's host config.
 func (task *Task) AddFirelensContainerBindMounts(firelensConfig *apicontainer.FirelensConfig, hostConfig *dockercontainer.HostConfig,
 	config *config.Config) *apierrors.HostConfigError {
-	// TODO: fix task.GetID(). It's currently incorrect when opted in task long arn format.
-	fields := strings.Split(task.Arn, "/")
-	taskID := fields[len(fields)-1]
+	taskID, err := task.GetID()
+	if err != nil {
+		return &apierrors.HostConfigError{Msg: err.Error()}
+	}
 
 	var configBind, s3ConfigBind, socketBind string
 	switch firelensConfig.Type {
@@ -2241,14 +2241,8 @@ func (task *Task) GetID() (string, error) {
 		return "", errors.Errorf("task get-id: malformed task resource: %s", resource)
 	}
 
-	resourceSplit := strings.SplitN(resource, arnResourceDelimiter, arnResourceSections)
-	if len(resourceSplit) != arnResourceSections {
-		return "", errors.Errorf(
-			"task get-id: invalid task resource split: %s, expected=%d, actual=%d",
-			resource, arnResourceSections, len(resourceSplit))
-	}
-
-	return resourceSplit[1], nil
+	resourceSplit := strings.Split(resource, arnResourceDelimiter)
+	return resourceSplit[len(resourceSplit)-1], nil
 }
 
 // RecordExecutionStoppedAt checks if this is an essential container stopped

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -1595,7 +1595,7 @@ func TestGetIDErrorPaths(t *testing.T) {
 		{"", "EmptyString"},
 		{"invalidArn", "InvalidARN"},
 		{"arn:aws:ecs:region:account-id:task:task-id", "IncorrectSections"},
-		{"arn:aws:ecs:region:account-id:task", "IncorrectResouceSections"},
+		{"arn:aws:ecs:region:account-id:task", "IncorrectResourceSections"},
 	}
 
 	task := Task{}
@@ -1612,12 +1612,21 @@ func TestGetIDErrorPaths(t *testing.T) {
 
 // TestGetIDHappyPath validates the happy path of GetID
 func TestGetIDHappyPath(t *testing.T) {
-	task := Task{
+	taskNormalARN := Task{
 		Arn: "arn:aws:ecs:region:account-id:task/task-id",
 	}
-	taskID, err := task.GetID()
+	taskLongARN := Task{
+		Arn: "arn:aws:ecs:region:account-id:task/cluster-name/task-id",
+	}
+
+	taskID, err := taskNormalARN.GetID()
 	assert.NoError(t, err)
 	assert.Equal(t, "task-id", taskID)
+
+	taskID, err = taskLongARN.GetID()
+	assert.NoError(t, err)
+	assert.Equal(t, "task-id", taskID)
+
 }
 
 // TestTaskGetPrimaryENI tests the eni can be correctly acquired by calling GetTaskPrimaryENI

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -2923,7 +2923,7 @@ func TestCreateContainerAddFirelensLogDriverConfig(t *testing.T) {
 
 func TestCreateFirelensContainerSetFluentdUID(t *testing.T) {
 	testTask := &apitask.Task{
-		Arn: "test-task-arn",
+		Arn: "arn:aws:ecs:region:account-id:task/test-task-arn",
 		Containers: []*apicontainer.Container{
 			{
 				Name: "test-container",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Updates task.GetID() to work with long ARN format (task/\<cluster-name\>/\<task-id\> versus just task/\<task-id\>) and changes
AddFirelensContainerBindMounts to call task.GetID().
### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

Modifies TestGetIDHappyPath to include a path in long ARN format. <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
