### PR TITLE
Added boltdb implementation to get, update and delete image state; Updated ImageManager to use data Client

### DIFF
--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -341,7 +341,7 @@ func (agent *ecsAgent) doStart(containerChangeEventStream *eventstream.EventStre
 	// Begin listening to the docker daemon and saving changes
 	taskEngine.SetSaver(stateManager)
 	taskEngine.SetDataClient(agent.dataClient)
-	imageManager.SetSaver(stateManager)
+	imageManager.SetDataClient(agent.dataClient)
 	taskEngine.MustInit(agent.ctx)
 
 	// Start back ground routines, including the telemetry session

--- a/agent/app/agent_test.go
+++ b/agent/app/agent_test.go
@@ -386,7 +386,7 @@ func TestDoStartHappyPath(t *testing.T) {
 		containermetadata.EXPECT().SetAvailabilityZone(availabilityZone),
 		containermetadata.EXPECT().SetHostPrivateIPv4Address(hostPrivateIPv4Address),
 		containermetadata.EXPECT().SetHostPublicIPv4Address(hostPublicIPv4Address),
-		imageManager.EXPECT().SetSaver(gomock.Any()),
+		imageManager.EXPECT().SetDataClient(gomock.Any()),
 		dockerClient.EXPECT().ContainerEvents(gomock.Any()),
 		state.EXPECT().AllImageStates().Return(nil),
 		state.EXPECT().AllENIAttachments().Return(nil),

--- a/agent/app/agent_unix_test.go
+++ b/agent/app/agent_unix_test.go
@@ -134,7 +134,7 @@ func TestDoStartTaskENIHappyPath(t *testing.T) {
 				assert.True(t, vpcFound)
 				assert.True(t, subnetFound)
 			}).Return("arn", "", nil),
-		imageManager.EXPECT().SetSaver(gomock.Any()),
+		imageManager.EXPECT().SetDataClient(gomock.Any()),
 		dockerClient.EXPECT().ContainerEvents(gomock.Any()).Return(containerChangeEvents, nil),
 		state.EXPECT().AllImageStates().Return(nil),
 		state.EXPECT().AllENIAttachments().Return(nil),
@@ -440,7 +440,7 @@ func TestDoStartCgroupInitHappyPath(t *testing.T) {
 			gomock.Any()).Return([]string{}, nil),
 		client.EXPECT().RegisterContainerInstance(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
 			gomock.Any(), gomock.Any()).Return("arn", "", nil),
-		imageManager.EXPECT().SetSaver(gomock.Any()),
+		imageManager.EXPECT().SetDataClient(gomock.Any()),
 		dockerClient.EXPECT().ContainerEvents(gomock.Any()).Return(containerChangeEvents, nil),
 		state.EXPECT().AllImageStates().Return(nil),
 		state.EXPECT().AllENIAttachments().Return(nil),
@@ -586,7 +586,7 @@ func TestDoStartGPUManagerHappyPath(t *testing.T) {
 		mockGPUManager.EXPECT().GetDevices().Return(devices),
 		client.EXPECT().RegisterContainerInstance(gomock.Any(), gomock.Any(), gomock.Any(),
 			gomock.Any(), devices, gomock.Any()).Return("arn", "", nil),
-		imageManager.EXPECT().SetSaver(gomock.Any()),
+		imageManager.EXPECT().SetDataClient(gomock.Any()),
 		dockerClient.EXPECT().ContainerEvents(gomock.Any()).Return(containerChangeEvents, nil),
 		state.EXPECT().AllImageStates().Return(nil),
 		state.EXPECT().AllENIAttachments().Return(nil),

--- a/agent/data/imagestate_client.go
+++ b/agent/data/imagestate_client.go
@@ -14,20 +14,44 @@
 package data
 
 import (
+	"encoding/json"
+
 	"github.com/aws/amazon-ecs-agent/agent/engine/image"
+
+	"github.com/boltdb/bolt"
+	"github.com/pkg/errors"
 )
 
 func (c *client) SaveImageState(img *image.ImageState) error {
-	// TODO: implementation
-	return nil
+	id := img.GetImageID()
+	if id == "" {
+		return errors.New("failed to generate database image id")
+	}
+	return c.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(imagesBucketName))
+		return putObject(b, id, img)
+	})
 }
 
 func (c *client) DeleteImageState(id string) error {
-	// TODO: implementation
-	return nil
+	return c.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(imagesBucketName))
+		return b.Delete([]byte(id))
+	})
 }
 
 func (c *client) GetImageStates() ([]*image.ImageState, error) {
-	// TODO: implementation
-	return nil, nil
+	var imageStates []*image.ImageState
+	err := c.db.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket([]byte(imagesBucketName))
+		return walk(bucket, func(id string, data []byte) error {
+			imageState := image.ImageState{}
+			if err := json.Unmarshal(data, &imageState); err != nil {
+				return err
+			}
+			imageStates = append(imageStates, &imageState)
+			return nil
+		})
+	})
+	return imageStates, err
 }

--- a/agent/data/imagestate_client_test.go
+++ b/agent/data/imagestate_client_test.go
@@ -1,0 +1,72 @@
+// +build unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package data
+
+import (
+	"testing"
+
+	"github.com/aws/amazon-ecs-agent/agent/engine/image"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testImageId    = "test-id"
+	testImageId2   = "test-id2"
+	testImageName  = "testName"
+	testImageName2 = "testName2"
+)
+
+func TestManageImageStates(t *testing.T) {
+	testClient, cleanup := newTestClient(t)
+	defer cleanup()
+
+	testImageState := &image.ImageState{
+		Image: &image.Image{
+			ImageID: testImageId,
+			Names:   []string{testImageName},
+		},
+		PullSucceeded: false,
+	}
+
+	assert.NoError(t, testClient.SaveImageState(testImageState))
+	testImageState.SetPullSucceeded(true)
+	assert.NoError(t, testClient.SaveImageState(testImageState))
+	res, err := testClient.GetImageStates()
+	assert.NoError(t, err)
+	assert.Len(t, res, 1)
+	assert.Equal(t, true, res[0].PullSucceeded)
+	assert.Equal(t, testImageId, res[0].Image.ImageID)
+	assert.Equal(t, testImageName, res[0].Image.Names[0])
+
+	testImageState2 := &image.ImageState{
+		Image: &image.Image{
+			ImageID: testImageId2,
+			Names:   []string{testImageName2},
+		},
+		PullSucceeded: false,
+	}
+	assert.NoError(t, testClient.SaveImageState(testImageState2))
+	res, err = testClient.GetImageStates()
+	assert.NoError(t, err)
+	assert.Len(t, res, 2)
+
+	assert.NoError(t, testClient.DeleteImageState(testImageId))
+	assert.NoError(t, testClient.DeleteImageState(testImageId2))
+	res, err = testClient.GetImageStates()
+	assert.NoError(t, err)
+	assert.Len(t, res, 0)
+}

--- a/agent/engine/common_integ_test.go
+++ b/agent/engine/common_integ_test.go
@@ -33,13 +33,13 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/containermetadata"
 	"github.com/aws/amazon-ecs-agent/agent/credentials"
+	"github.com/aws/amazon-ecs-agent/agent/data"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/sdkclientfactory"
 	"github.com/aws/amazon-ecs-agent/agent/ec2"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
 	"github.com/aws/amazon-ecs-agent/agent/statechange"
-	"github.com/aws/amazon-ecs-agent/agent/statemanager"
 	log "github.com/cihub/seelog"
 	"github.com/stretchr/testify/assert"
 )
@@ -145,7 +145,7 @@ func setup(cfg *config.Config, state dockerstate.TaskEngineState, t *testing.T) 
 		state = dockerstate.NewTaskEngineState()
 	}
 	imageManager := NewImageManager(cfg, dockerClient, state)
-	imageManager.SetSaver(statemanager.NewNoopStateManager())
+	imageManager.SetDataClient(data.NewNoopClient())
 	metadataManager := containermetadata.NewManager(dockerClient, cfg)
 
 	taskEngine := NewDockerTaskEngine(cfg, dockerClient, credentialsManager,

--- a/agent/engine/data.go
+++ b/agent/engine/data.go
@@ -17,6 +17,7 @@ import (
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	"github.com/aws/amazon-ecs-agent/agent/data"
+	"github.com/aws/amazon-ecs-agent/agent/engine/image"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 
 	"github.com/cihub/seelog"
@@ -64,5 +65,19 @@ func (engine *DockerTaskEngine) removeTaskData(task *apitask.Task) {
 		if err != nil {
 			seelog.Errorf("Failed to remove data for container %s: %v", c.Name, err)
 		}
+	}
+}
+
+func (imageManager *dockerImageManager) saveImageStateData(imageState *image.ImageState) {
+	err := imageManager.dataClient.SaveImageState(imageState)
+	if err != nil {
+		seelog.Errorf("Failed to save data for image state: %s, %v", imageState.GetImageID(), err)
+	}
+}
+
+func (imageManager *dockerImageManager) removeImageStateData(imageId string) {
+	err := imageManager.dataClient.DeleteImageState(imageId)
+	if err != nil {
+		seelog.Errorf("Failed to remove data for image state: %s, %v", imageId, err)
 	}
 }

--- a/agent/engine/docker_image_manager.go
+++ b/agent/engine/docker_image_manager.go
@@ -25,11 +25,11 @@ import (
 
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/data"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/engine/image"
-	"github.com/aws/amazon-ecs-agent/agent/statemanager"
 	"github.com/cihub/seelog"
 )
 
@@ -45,7 +45,7 @@ type ImageManager interface {
 	AddAllImageStates(imageStates []*image.ImageState)
 	GetImageStateFromImageName(containerImageName string) (*image.ImageState, bool)
 	StartImageCleanupProcess(ctx context.Context)
-	SetSaver(stateManager statemanager.Saver)
+	SetDataClient(dataClient data.Client)
 }
 
 // dockerImageManager accounts all the images and their states in the instance.
@@ -53,10 +53,10 @@ type ImageManager interface {
 type dockerImageManager struct {
 	imageStates                        []*image.ImageState
 	client                             dockerapi.DockerClient
+	dataClient                         data.Client
 	updateLock                         sync.RWMutex
 	imageCleanupTicker                 *time.Ticker
 	state                              dockerstate.TaskEngineState
-	saver                              statemanager.Saver
 	imageStatesConsideredForDeletion   map[string]*image.ImageState
 	minimumAgeBeforeDeletion           time.Duration
 	numImagesToDelete                  int
@@ -89,8 +89,9 @@ func NewImageManager(cfg *config.Config, client dockerapi.DockerClient, state do
 	}
 }
 
-func (imageManager *dockerImageManager) SetSaver(stateManager statemanager.Saver) {
-	imageManager.saver = stateManager
+// SetDataClient sets the saver that is used by the ImageManager.
+func (imageManager *dockerImageManager) SetDataClient(dataClient data.Client) {
+	imageManager.dataClient = dataClient
 }
 
 func (imageManager *dockerImageManager) AddAllImageStates(imageStates []*image.ImageState) {
@@ -109,8 +110,6 @@ func (imageManager *dockerImageManager) GetImageStatesCount() int {
 
 // RecordContainerReference adds container reference to the corresponding imageState object
 func (imageManager *dockerImageManager) RecordContainerReference(container *apicontainer.Container) error {
-	// the image state has been updated, save the new state
-	defer imageManager.saver.ForceSave()
 	// On agent restart, container ID was retrieved from agent state file
 	// TODO add setter and getter for modifying this
 	if container.ImageID != "" {
@@ -175,6 +174,7 @@ func (imageManager *dockerImageManager) addContainerReferenceToExistingImageStat
 	imageState, ok := imageManager.getImageState(container.ImageID)
 	if ok {
 		imageState.UpdateImageState(container)
+		imageManager.saveImageStateData(imageState)
 	}
 	return ok
 }
@@ -188,6 +188,7 @@ func (imageManager *dockerImageManager) addContainerReferenceToNewImageState(con
 	imageState, ok := imageManager.getImageState(container.ImageID)
 	if ok {
 		imageState.UpdateImageState(container)
+		imageManager.saveImageStateData(imageState)
 	} else {
 		sourceImage := &image.Image{
 			ImageID: container.ImageID,
@@ -205,8 +206,6 @@ func (imageManager *dockerImageManager) addContainerReferenceToNewImageState(con
 
 // RemoveContainerReferenceFromImageState removes container reference from the corresponding imageState object
 func (imageManager *dockerImageManager) RemoveContainerReferenceFromImageState(container *apicontainer.Container) error {
-	// the image state has been updated, save the new state
-	defer imageManager.saver.ForceSave()
 	// this lock is for reading image states and finding the one that the container belongs to
 	imageManager.updateLock.RLock()
 	defer imageManager.updateLock.RUnlock()
@@ -220,11 +219,18 @@ func (imageManager *dockerImageManager) RemoveContainerReferenceFromImageState(c
 		return fmt.Errorf("Cannot find image state for the container to be removed")
 	}
 	// Found matching ImageState
-	return imageState.RemoveContainerReference(container)
+	err := imageState.RemoveContainerReference(container)
+	if err != nil {
+		return err
+	}
+	imageManager.saveImageStateData(imageState)
+	return nil
 }
 
 func (imageManager *dockerImageManager) addImageState(imageState *image.ImageState) {
 	imageManager.imageStates = append(imageManager.imageStates, imageState)
+	imageManager.saveImageStateData(imageState)
+
 }
 
 // getAllImageStates returns the list of imageStates in the instance
@@ -249,6 +255,7 @@ func (imageManager *dockerImageManager) removeImageState(imageStateToBeRemoved *
 			// Image State found; hence remove it
 			seelog.Infof("Removing Image State: [%s] from Image Manager", imageState.String())
 			imageManager.imageStates = append(imageManager.imageStates[:i], imageManager.imageStates[i+1:]...)
+			imageManager.removeImageStateData(imageState.Image.ImageID)
 			return
 		}
 	}
@@ -309,7 +316,9 @@ func (imageManager *dockerImageManager) removeExistingImageNameOfDifferentID(con
 	for _, imageState := range imageManager.getAllImageStates() {
 		// image with same name pulled in the instance. Untag the already existing image name
 		if imageState.Image.ImageID != inspectedImageID {
-			imageState.RemoveImageName(containerImageName)
+			if imageNameRemoved := imageState.RemoveImageName(containerImageName); imageNameRemoved {
+				imageManager.saveImageStateData(imageState)
+			}
 		}
 	}
 }
@@ -641,7 +650,6 @@ func (imageManager *dockerImageManager) deleteImage(ctx context.Context, imageID
 		delete(imageManager.imageStatesConsideredForDeletion, imageState.Image.ImageID)
 		imageManager.removeImageState(imageState)
 		imageManager.state.RemoveImageState(imageState)
-		imageManager.saver.Save()
 	}
 }
 

--- a/agent/engine/docker_image_manager_data_test.go
+++ b/agent/engine/docker_image_manager_data_test.go
@@ -1,0 +1,124 @@
+// +build unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package engine
+
+import (
+	"testing"
+
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	"github.com/aws/amazon-ecs-agent/agent/engine/image"
+
+	"github.com/stretchr/testify/assert"
+)
+
+/*
+This file contains unit tests that specifically check the data persisting behavior of the image manager
+*/
+
+const (
+	testImageID   = "test-id"
+	testImageID2  = "test-id2"
+	testImageName = "test-name"
+)
+
+var (
+	testImageStateData = &image.ImageState{
+		Image: &image.Image{
+			ImageID: testImageID,
+		},
+	}
+	testContainerData = &apicontainer.Container{
+		Name:    testContainerName,
+		ImageID: testImageID,
+	}
+)
+
+func TestAddImageStateSaveData(t *testing.T) {
+	dataClient, cleanup := newTestDataClient(t)
+	defer cleanup()
+
+	imageManager := &dockerImageManager{
+		dataClient: dataClient,
+	}
+
+	imageManager.addImageState(testImageStateData)
+	imageStates, err := dataClient.GetImageStates()
+	assert.NoError(t, err)
+	assert.Len(t, imageStates, 1)
+}
+
+func TestAddContainerReferenceToNewImageStateSaveData(t *testing.T) {
+	dataClient, cleanup := newTestDataClient(t)
+	defer cleanup()
+
+	imageManager := &dockerImageManager{
+		dataClient: dataClient,
+	}
+
+	imageManager.addContainerReferenceToNewImageState(testContainerData, 0)
+	imageStates, err := dataClient.GetImageStates()
+	assert.NoError(t, err)
+	assert.Len(t, imageStates, 1)
+}
+
+func TestAddContainerReferenceToExistingImageStateSaveData(t *testing.T) {
+	dataClient, cleanup := newTestDataClient(t)
+	defer cleanup()
+
+	imageManager := &dockerImageManager{
+		dataClient: dataClient,
+	}
+	imageManager.imageStates = append(imageManager.imageStates, testImageStateData)
+	imageManager.addContainerReferenceToExistingImageState(testContainerData)
+	imageStates, err := dataClient.GetImageStates()
+	assert.NoError(t, err)
+	assert.Len(t, imageStates, 1)
+}
+
+func TestRemoveExistingImageNameOfDifferentID(t *testing.T) {
+	dataClient, cleanup := newTestDataClient(t)
+	defer cleanup()
+
+	imageManager := &dockerImageManager{
+		dataClient: dataClient,
+	}
+
+	testImageStateData.Image.Names = []string{testImageName}
+	imageManager.addImageState(testImageStateData)
+	imageStates, err := dataClient.GetImageStates()
+	assert.Len(t, imageStates[0].Image.Names, 1)
+
+	imageManager.removeExistingImageNameOfDifferentID(testImageName, testImageID2)
+	imageStates, err = dataClient.GetImageStates()
+	assert.NoError(t, err)
+	assert.Len(t, imageStates, 1)
+	assert.Len(t, imageStates[0].Image.Names, 0)
+}
+
+func TestRemoveImageStateSaveData(t *testing.T) {
+	dataClient, cleanup := newTestDataClient(t)
+	defer cleanup()
+
+	imageManager := &dockerImageManager{
+		dataClient: dataClient,
+	}
+
+	imageManager.addImageState(testImageStateData)
+	imageManager.removeImageStateData(testImageID)
+	imageStates, err := dataClient.GetImageStates()
+	assert.NoError(t, err)
+	assert.Len(t, imageStates, 0)
+}

--- a/agent/engine/docker_image_manager_integ_test.go
+++ b/agent/engine/docker_image_manager_integ_test.go
@@ -29,9 +29,9 @@ import (
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	apitaskstatus "github.com/aws/amazon-ecs-agent/agent/api/task/status"
+	"github.com/aws/amazon-ecs-agent/agent/data"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/sdkclientfactory"
-	"github.com/aws/amazon-ecs-agent/agent/statemanager"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
@@ -70,7 +70,7 @@ func TestIntegImageCleanupHappyCase(t *testing.T) {
 	taskEngine, done, _ := setup(cfg, nil, t)
 
 	imageManager := taskEngine.(*DockerTaskEngine).imageManager.(*dockerImageManager)
-	imageManager.SetSaver(statemanager.NewNoopStateManager())
+	imageManager.SetDataClient(data.NewNoopClient())
 
 	defer func() {
 		done()
@@ -177,7 +177,7 @@ func TestIntegImageCleanupThreshold(t *testing.T) {
 	taskEngine, done, _ := setup(cfg, nil, t)
 
 	imageManager := taskEngine.(*DockerTaskEngine).imageManager.(*dockerImageManager)
-	imageManager.SetSaver(statemanager.NewNoopStateManager())
+	imageManager.SetDataClient(data.NewNoopClient())
 
 	defer func() {
 		done()
@@ -295,7 +295,7 @@ func TestImageWithSameNameAndDifferentID(t *testing.T) {
 	require.NoError(t, err, "Creating SDK docker client failed")
 
 	imageManager := taskEngine.(*DockerTaskEngine).imageManager.(*dockerImageManager)
-	imageManager.SetSaver(statemanager.NewNoopStateManager())
+	imageManager.SetDataClient(data.NewNoopClient())
 
 	stateChangeEvents := taskEngine.StateChangeEvents()
 
@@ -435,7 +435,7 @@ func TestImageWithSameIDAndDifferentNames(t *testing.T) {
 	require.NoError(t, err, "Creating docker client failed")
 
 	imageManager := taskEngine.(*DockerTaskEngine).imageManager.(*dockerImageManager)
-	imageManager.SetSaver(statemanager.NewNoopStateManager())
+	imageManager.SetDataClient(data.NewNoopClient())
 
 	stateChangeEvents := taskEngine.StateChangeEvents()
 

--- a/agent/engine/engine_windows_integ_test.go
+++ b/agent/engine/engine_windows_integ_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/containermetadata"
 	"github.com/aws/amazon-ecs-agent/agent/credentials"
+	"github.com/aws/amazon-ecs-agent/agent/data"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/sdkclientfactory"
 	"github.com/aws/amazon-ecs-agent/agent/ec2"
@@ -43,7 +44,6 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
 	s3factory "github.com/aws/amazon-ecs-agent/agent/s3/factory"
 	ssmfactory "github.com/aws/amazon-ecs-agent/agent/ssm/factory"
-	"github.com/aws/amazon-ecs-agent/agent/statemanager"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	taskresourcevolume "github.com/aws/amazon-ecs-agent/agent/taskresource/volume"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
@@ -731,7 +731,7 @@ func setupGMSA(cfg *config.Config, state dockerstate.TaskEngineState, t *testing
 		state = dockerstate.NewTaskEngineState()
 	}
 	imageManager := NewImageManager(cfg, dockerClient, state)
-	imageManager.SetSaver(statemanager.NewNoopStateManager())
+	imageManager.SetDataClient(data.NewNoopClient())
 	metadataManager := containermetadata.NewManager(dockerClient, cfg)
 
 	resourceFields := &taskresource.ResourceFields{

--- a/agent/engine/image/types.go
+++ b/agent/engine/image/types.go
@@ -69,6 +69,13 @@ func (imageState *ImageState) AddImageName(imageName string) {
 	}
 }
 
+// GetImageID returns id of image
+func (imageState *ImageState) GetImageID() string {
+	imageState.lock.RLock()
+	defer imageState.lock.RUnlock()
+	return imageState.Image.ImageID
+}
+
 // GetImageNamesCount returns number of image names
 func (imageState *ImageState) GetImageNamesCount() int {
 	imageState.lock.RLock()
@@ -88,14 +95,16 @@ func (imageState *ImageState) UpdateImageState(container *apicontainer.Container
 }
 
 // RemoveImageName removes image name from image state
-func (imageState *ImageState) RemoveImageName(containerImageName string) {
+func (imageState *ImageState) RemoveImageName(containerImageName string) bool {
 	imageState.lock.Lock()
 	defer imageState.lock.Unlock()
 	for i, imageName := range imageState.Image.Names {
 		if imageName == containerImageName {
 			imageState.Image.Names = append(imageState.Image.Names[:i], imageState.Image.Names[i+1:]...)
+			return true
 		}
 	}
+	return false
 }
 
 // HasImageName returns true if image state contains the containerImageName

--- a/agent/engine/mocks/engine_mocks.go
+++ b/agent/engine/mocks/engine_mocks.go
@@ -294,16 +294,16 @@ func (mr *MockImageManagerMockRecorder) RemoveContainerReferenceFromImageState(a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveContainerReferenceFromImageState", reflect.TypeOf((*MockImageManager)(nil).RemoveContainerReferenceFromImageState), arg0)
 }
 
-// SetSaver mocks base method
-func (m *MockImageManager) SetSaver(arg0 statemanager.Saver) {
+// SetDataClient mocks base method
+func (m *MockImageManager) SetDataClient(arg0 data.Client) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetSaver", arg0)
+	m.ctrl.Call(m, "SetDataClient", arg0)
 }
 
-// SetSaver indicates an expected call of SetSaver
-func (mr *MockImageManagerMockRecorder) SetSaver(arg0 interface{}) *gomock.Call {
+// SetDataClient indicates an expected call of SetDataClient
+func (mr *MockImageManagerMockRecorder) SetDataClient(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSaver", reflect.TypeOf((*MockImageManager)(nil).SetSaver), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDataClient", reflect.TypeOf((*MockImageManager)(nil).SetDataClient), arg0)
 }
 
 // StartImageCleanupProcess mocks base method


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Added boltdb implementation to get, update and delete image state. Updated ImageManager to use data Client instead of state manager to persist image states.

These changes cover the following scenarios
- A new image is being used for a container that we manage;
- In container pull step, add container reference to image (to track container usage of image);
- When container is removed, remove container reference of image;
- When no container is using the image and it has reached our image cleanup threshold.

### Implementation details
<!-- How are the changes implemented? -->
Following changes were made 
- `app`: replaced statemanger saver in agent.go with dataClient, updated the tests accordingly
- `data`: added botldb implementation for SaveImageState, DeleteImageState and GetImageStates
- `engine`: 
    - `docker_image_manager.go`: 
       - added SetDataClient method, used to set ImageManager.dataClient
       - save imageState to botldb on addContainerReferenceToExistingImageState, addContainerReferenceToNewImageState, RemoveContainerReference, addImageState or removeExistingImageNameOfDifferentID
       - delete imageState from doltdb on removeImageState
   - `docker_task_engine.go`: save image state on updateContainerReference
   - `image/types`: added GetImageID method to retrieve image ID
   - `mocks/engine_mocks.go`: updated ImageManager mock methods


### Testing
<!-- How was this tested? -->
`make test` passes. Manually tested
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
