### PR TITLE
Add and save task local ip address in task struct

### DIFF
--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -255,6 +255,11 @@ type Task struct {
 	// NvidiaRuntime is the runtime to pass Nvidia GPU devices to containers
 	NvidiaRuntime string `json:"NvidiaRuntime,omitempty"`
 
+	// LocalIPAddressUnsafe stores the local IP address allocated to the bridge that connects the task network
+	// namespace and the host network namespace, for tasks in awsvpc network mode (tasks in other network mode won't
+	// have a value for this). This field should be accessed via GetLocalIPAddress and SetLocalIPAddress.
+	LocalIPAddressUnsafe string `json:"LocalIPAddress,omitempty"`
+
 	// lock is for protecting all fields in the task struct
 	lock sync.RWMutex
 }
@@ -2678,4 +2683,20 @@ func (task *Task) MergeEnvVarsFromEnvfiles(container *apicontainer.Container) *a
 	}
 
 	return nil
+}
+
+// GetLocalIPAddress returns the local IP address of the task.
+func (task *Task) GetLocalIPAddress() string {
+	task.lock.RLock()
+	defer task.lock.RUnlock()
+
+	return task.LocalIPAddressUnsafe
+}
+
+// SetLocalIPAddress sets the local IP address of the task.
+func (task *Task) SetLocalIPAddress(addr string) {
+	task.lock.Lock()
+	defer task.lock.Unlock()
+
+	task.LocalIPAddressUnsafe = addr
 }

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -1244,6 +1244,8 @@ func (engine *DockerTaskEngine) provisionContainerResources(task *apitask.Task, 
 	taskIP := result.IPs[0].Address.IP.String()
 	seelog.Infof("Task engine [%s]: associated with ip address '%s'", task.Arn, taskIP)
 	engine.state.AddTaskIPAddress(taskIP, task.Arn)
+	task.SetLocalIPAddress(taskIP)
+	engine.saveTaskData(task)
 	return dockerapi.DockerContainerMetadata{
 		DockerID: cniConfig.ContainerID,
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Add and save task local ip address in task struct.

For a task in awsvpc network mode, the task engine state holds a [mapping](https://github.com/aws/amazon-ecs-agent/blob/master/agent/engine/dockerstate/docker_task_engine_state.go#L102) between the task's local ip address and the task, and the mapping is saved as part of the state via state manager. With migration to boltdb, this mapping is not saved. So to maintain this information in boltdb, the ip address is added as a field of the task struct and it is saved as part of the task. When loading the task from boltdb (load will be implemented in a later change), we will look at this field of the task and fill in the ip <-> task mapping in memory.

### Implementation details
<!-- How are the changes implemented? -->
`api/task`: added a new field LocalIPAddressUnsafe to task struct and added getter/setter;
`engine`: set the local ip address when we get it after setting up the task network.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Unit test: modify an existing one to cover the change.
Manually tested by running an awsvpc task and verified the ip is saved.

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
N/A

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
