### PR TITLE
Enable V4 task metadata endpoint to display network rate stats

### DIFF
--- a/agent/handlers/task_server_setup_test.go
+++ b/agent/handlers/task_server_setup_test.go
@@ -728,7 +728,7 @@ func TestV2ContainerStats(t *testing.T) {
 	dockerStats.NumProcs = 2
 	gomock.InOrder(
 		state.EXPECT().GetTaskByIPAddress(remoteIP).Return(taskARN, true),
-		statsEngine.EXPECT().ContainerDockerStats(taskARN, containerID).Return(dockerStats, stats.NetworkStatsPerSec{}, nil),
+		statsEngine.EXPECT().ContainerDockerStats(taskARN, containerID).Return(dockerStats, &stats.NetworkStatsPerSec{}, nil),
 	)
 	server := taskServerSetup(credentials.NewManager(), auditLog, state, ecsClient, clusterName, statsEngine,
 		config.DefaultTaskMetadataSteadyStateRate, config.DefaultTaskMetadataBurstRate, "", containerInstanceArn)
@@ -777,7 +777,7 @@ func TestV2TaskStats(t *testing.T) {
 			gomock.InOrder(
 				state.EXPECT().GetTaskByIPAddress(remoteIP).Return(taskARN, true),
 				state.EXPECT().ContainerMapByArn(taskARN).Return(containerMap, true),
-				statsEngine.EXPECT().ContainerDockerStats(taskARN, containerID).Return(dockerStats, stats.NetworkStatsPerSec{}, nil),
+				statsEngine.EXPECT().ContainerDockerStats(taskARN, containerID).Return(dockerStats, &stats.NetworkStatsPerSec{}, nil),
 			)
 			server := taskServerSetup(credentials.NewManager(), auditLog, state, ecsClient, clusterName, statsEngine,
 				config.DefaultTaskMetadataSteadyStateRate, config.DefaultTaskMetadataBurstRate, "", containerInstanceArn)
@@ -1006,7 +1006,7 @@ func TestV3TaskStats(t *testing.T) {
 	gomock.InOrder(
 		state.EXPECT().TaskARNByV3EndpointID(v3EndpointID).Return(taskARN, true),
 		state.EXPECT().ContainerMapByArn(taskARN).Return(containerMap, true),
-		statsEngine.EXPECT().ContainerDockerStats(taskARN, containerID).Return(dockerStats, stats.NetworkStatsPerSec{}, nil),
+		statsEngine.EXPECT().ContainerDockerStats(taskARN, containerID).Return(dockerStats, &stats.NetworkStatsPerSec{}, nil),
 	)
 	server := taskServerSetup(credentials.NewManager(), auditLog, state, ecsClient, clusterName, statsEngine,
 		config.DefaultTaskMetadataSteadyStateRate, config.DefaultTaskMetadataBurstRate, "", containerInstanceArn)
@@ -1039,7 +1039,7 @@ func TestV3ContainerStats(t *testing.T) {
 	gomock.InOrder(
 		state.EXPECT().TaskARNByV3EndpointID(v3EndpointID).Return(taskARN, true),
 		state.EXPECT().DockerIDByV3EndpointID(v3EndpointID).Return(containerID, true),
-		statsEngine.EXPECT().ContainerDockerStats(taskARN, containerID).Return(dockerStats, stats.NetworkStatsPerSec{}, nil),
+		statsEngine.EXPECT().ContainerDockerStats(taskARN, containerID).Return(dockerStats, &stats.NetworkStatsPerSec{}, nil),
 	)
 	server := taskServerSetup(credentials.NewManager(), auditLog, state, ecsClient, clusterName, statsEngine,
 		config.DefaultTaskMetadataSteadyStateRate, config.DefaultTaskMetadataBurstRate, "", containerInstanceArn)
@@ -1338,7 +1338,7 @@ func TestV4TaskStats(t *testing.T) {
 	gomock.InOrder(
 		state.EXPECT().TaskARNByV3EndpointID(v3EndpointID).Return(taskARN, true),
 		state.EXPECT().ContainerMapByArn(taskARN).Return(containerMap, true),
-		statsEngine.EXPECT().ContainerDockerStats(taskARN, containerID).Return(dockerStats, stats.NetworkStatsPerSec{}, nil),
+		statsEngine.EXPECT().ContainerDockerStats(taskARN, containerID).Return(dockerStats, &stats.NetworkStatsPerSec{}, nil),
 	)
 	server := taskServerSetup(credentials.NewManager(), auditLog, state, ecsClient, clusterName, statsEngine,
 		config.DefaultTaskMetadataSteadyStateRate, config.DefaultTaskMetadataBurstRate, "", containerInstanceArn)
@@ -1371,7 +1371,7 @@ func TestV4ContainerStats(t *testing.T) {
 	gomock.InOrder(
 		state.EXPECT().TaskARNByV3EndpointID(v3EndpointID).Return(taskARN, true),
 		state.EXPECT().DockerIDByV3EndpointID(v3EndpointID).Return(containerID, true),
-		statsEngine.EXPECT().ContainerDockerStats(taskARN, containerID).Return(dockerStats, stats.NetworkStatsPerSec{}, nil),
+		statsEngine.EXPECT().ContainerDockerStats(taskARN, containerID).Return(dockerStats, &stats.NetworkStatsPerSec{}, nil),
 	)
 	server := taskServerSetup(credentials.NewManager(), auditLog, state, ecsClient, clusterName, statsEngine,
 		config.DefaultTaskMetadataSteadyStateRate, config.DefaultTaskMetadataBurstRate, "", containerInstanceArn)

--- a/agent/handlers/task_server_setup_test.go
+++ b/agent/handlers/task_server_setup_test.go
@@ -44,6 +44,7 @@ import (
 	v3 "github.com/aws/amazon-ecs-agent/agent/handlers/v3"
 	v4 "github.com/aws/amazon-ecs-agent/agent/handlers/v4"
 	mock_audit "github.com/aws/amazon-ecs-agent/agent/logger/audit/mocks"
+	"github.com/aws/amazon-ecs-agent/agent/stats"
 	mock_stats "github.com/aws/amazon-ecs-agent/agent/stats/mock"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/docker/docker/api/types"
@@ -727,7 +728,7 @@ func TestV2ContainerStats(t *testing.T) {
 	dockerStats.NumProcs = 2
 	gomock.InOrder(
 		state.EXPECT().GetTaskByIPAddress(remoteIP).Return(taskARN, true),
-		statsEngine.EXPECT().ContainerDockerStats(taskARN, containerID).Return(dockerStats, nil),
+		statsEngine.EXPECT().ContainerDockerStats(taskARN, containerID).Return(dockerStats, stats.NetworkStatsPerSec{}, nil),
 	)
 	server := taskServerSetup(credentials.NewManager(), auditLog, state, ecsClient, clusterName, statsEngine,
 		config.DefaultTaskMetadataSteadyStateRate, config.DefaultTaskMetadataBurstRate, "", containerInstanceArn)
@@ -776,7 +777,7 @@ func TestV2TaskStats(t *testing.T) {
 			gomock.InOrder(
 				state.EXPECT().GetTaskByIPAddress(remoteIP).Return(taskARN, true),
 				state.EXPECT().ContainerMapByArn(taskARN).Return(containerMap, true),
-				statsEngine.EXPECT().ContainerDockerStats(taskARN, containerID).Return(dockerStats, nil),
+				statsEngine.EXPECT().ContainerDockerStats(taskARN, containerID).Return(dockerStats, stats.NetworkStatsPerSec{}, nil),
 			)
 			server := taskServerSetup(credentials.NewManager(), auditLog, state, ecsClient, clusterName, statsEngine,
 				config.DefaultTaskMetadataSteadyStateRate, config.DefaultTaskMetadataBurstRate, "", containerInstanceArn)
@@ -1005,7 +1006,7 @@ func TestV3TaskStats(t *testing.T) {
 	gomock.InOrder(
 		state.EXPECT().TaskARNByV3EndpointID(v3EndpointID).Return(taskARN, true),
 		state.EXPECT().ContainerMapByArn(taskARN).Return(containerMap, true),
-		statsEngine.EXPECT().ContainerDockerStats(taskARN, containerID).Return(dockerStats, nil),
+		statsEngine.EXPECT().ContainerDockerStats(taskARN, containerID).Return(dockerStats, stats.NetworkStatsPerSec{}, nil),
 	)
 	server := taskServerSetup(credentials.NewManager(), auditLog, state, ecsClient, clusterName, statsEngine,
 		config.DefaultTaskMetadataSteadyStateRate, config.DefaultTaskMetadataBurstRate, "", containerInstanceArn)
@@ -1038,7 +1039,7 @@ func TestV3ContainerStats(t *testing.T) {
 	gomock.InOrder(
 		state.EXPECT().TaskARNByV3EndpointID(v3EndpointID).Return(taskARN, true),
 		state.EXPECT().DockerIDByV3EndpointID(v3EndpointID).Return(containerID, true),
-		statsEngine.EXPECT().ContainerDockerStats(taskARN, containerID).Return(dockerStats, nil),
+		statsEngine.EXPECT().ContainerDockerStats(taskARN, containerID).Return(dockerStats, stats.NetworkStatsPerSec{}, nil),
 	)
 	server := taskServerSetup(credentials.NewManager(), auditLog, state, ecsClient, clusterName, statsEngine,
 		config.DefaultTaskMetadataSteadyStateRate, config.DefaultTaskMetadataBurstRate, "", containerInstanceArn)
@@ -1337,7 +1338,7 @@ func TestV4TaskStats(t *testing.T) {
 	gomock.InOrder(
 		state.EXPECT().TaskARNByV3EndpointID(v3EndpointID).Return(taskARN, true),
 		state.EXPECT().ContainerMapByArn(taskARN).Return(containerMap, true),
-		statsEngine.EXPECT().ContainerDockerStats(taskARN, containerID).Return(dockerStats, nil),
+		statsEngine.EXPECT().ContainerDockerStats(taskARN, containerID).Return(dockerStats, stats.NetworkStatsPerSec{}, nil),
 	)
 	server := taskServerSetup(credentials.NewManager(), auditLog, state, ecsClient, clusterName, statsEngine,
 		config.DefaultTaskMetadataSteadyStateRate, config.DefaultTaskMetadataBurstRate, "", containerInstanceArn)
@@ -1370,7 +1371,7 @@ func TestV4ContainerStats(t *testing.T) {
 	gomock.InOrder(
 		state.EXPECT().TaskARNByV3EndpointID(v3EndpointID).Return(taskARN, true),
 		state.EXPECT().DockerIDByV3EndpointID(v3EndpointID).Return(containerID, true),
-		statsEngine.EXPECT().ContainerDockerStats(taskARN, containerID).Return(dockerStats, nil),
+		statsEngine.EXPECT().ContainerDockerStats(taskARN, containerID).Return(dockerStats, stats.NetworkStatsPerSec{}, nil),
 	)
 	server := taskServerSetup(credentials.NewManager(), auditLog, state, ecsClient, clusterName, statsEngine,
 		config.DefaultTaskMetadataSteadyStateRate, config.DefaultTaskMetadataBurstRate, "", containerInstanceArn)

--- a/agent/handlers/v2/stats_response_test.go
+++ b/agent/handlers/v2/stats_response_test.go
@@ -18,6 +18,8 @@ package v2
 import (
 	"testing"
 
+	"github.com/aws/amazon-ecs-agent/agent/stats"
+
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	mock_dockerstate "github.com/aws/amazon-ecs-agent/agent/engine/dockerstate/mocks"
 	mock_stats "github.com/aws/amazon-ecs-agent/agent/stats/mock"
@@ -42,7 +44,7 @@ func TestTaskStatsResponseSuccess(t *testing.T) {
 	}
 	gomock.InOrder(
 		state.EXPECT().ContainerMapByArn(taskARN).Return(containerMap, true),
-		statsEngine.EXPECT().ContainerDockerStats(taskARN, containerID).Return(dockerStats, nil),
+		statsEngine.EXPECT().ContainerDockerStats(taskARN, containerID).Return(dockerStats, stats.NetworkStatsPerSec{}, nil),
 	)
 
 	resp, err := NewTaskStatsResponse(taskARN, state, statsEngine)

--- a/agent/handlers/v2/stats_response_test.go
+++ b/agent/handlers/v2/stats_response_test.go
@@ -44,7 +44,7 @@ func TestTaskStatsResponseSuccess(t *testing.T) {
 	}
 	gomock.InOrder(
 		state.EXPECT().ContainerMapByArn(taskARN).Return(containerMap, true),
-		statsEngine.EXPECT().ContainerDockerStats(taskARN, containerID).Return(dockerStats, stats.NetworkStatsPerSec{}, nil),
+		statsEngine.EXPECT().ContainerDockerStats(taskARN, containerID).Return(dockerStats, &stats.NetworkStatsPerSec{}, nil),
 	)
 
 	resp, err := NewTaskStatsResponse(taskARN, state, statsEngine)

--- a/agent/handlers/v2/task_container_stats_handler.go
+++ b/agent/handlers/v2/task_container_stats_handler.go
@@ -92,7 +92,7 @@ func WriteContainerStatsResponse(w http.ResponseWriter,
 	taskARN string,
 	containerID string,
 	statsEngine stats.Engine) {
-	dockerStats, err := statsEngine.ContainerDockerStats(taskARN, containerID)
+	dockerStats, _, err := statsEngine.ContainerDockerStats(taskARN, containerID)
 	if err != nil {
 		errResponseJSON, err := json.Marshal("Unable to get container stats for: " + containerID)
 		if e := utils.WriteResponseIfMarshalError(w, err); e != nil {

--- a/agent/handlers/v4/stats_response.go
+++ b/agent/handlers/v4/stats_response.go
@@ -25,7 +25,7 @@ import (
 // with the docker stats.
 type StatsResponse struct {
 	*types.StatsJSON
-	Network_rate_stats stats.NetworkStatsPerSec `json:"network_rate_stats,omitempty"`
+	Network_rate_stats *stats.NetworkStatsPerSec `json:"network_rate_stats,omitempty"`
 }
 
 // NewV4TaskStatsResponse returns a new v4 task stats response object

--- a/agent/stats/engine.go
+++ b/agent/stats/engine.go
@@ -66,7 +66,7 @@ type DockerContainerMetadataResolver struct {
 // defined to make testing easier.
 type Engine interface {
 	GetInstanceMetrics() (*ecstcs.MetricsMetadata, []*ecstcs.TaskMetric, error)
-	ContainerDockerStats(taskARN string, containerID string) (*types.StatsJSON, error)
+	ContainerDockerStats(taskARN string, containerID string) (*types.StatsJSON, NetworkStatsPerSec, error)
 	GetTaskHealthMetrics() (*ecstcs.HealthMetadata, []*ecstcs.TaskHealth, error)
 }
 
@@ -740,27 +740,27 @@ func (engine *DockerStatsEngine) resetStatsUnsafe() {
 }
 
 // ContainerDockerStats returns the last stored raw docker stats object for a container
-func (engine *DockerStatsEngine) ContainerDockerStats(taskARN string, containerID string) (*types.StatsJSON, error) {
+func (engine *DockerStatsEngine) ContainerDockerStats(taskARN string, containerID string) (*types.StatsJSON, NetworkStatsPerSec, error) {
 	engine.lock.RLock()
 	defer engine.lock.RUnlock()
 
 	containerIDToStatsContainer, ok := engine.tasksToContainers[taskARN]
 	taskToTaskStats := engine.taskToTaskStats
 	if !ok {
-		return nil, errors.Errorf("stats engine: task '%s' for container '%s' not found",
+		return nil, NetworkStatsPerSec{}, errors.Errorf("stats engine: task '%s' for container '%s' not found",
 			taskARN, containerID)
 	}
 
 	container, ok := containerIDToStatsContainer[containerID]
 	if !ok {
-		return nil, errors.Errorf("stats engine: container not found: %s", containerID)
+		return nil, NetworkStatsPerSec{}, errors.Errorf("stats engine: container not found: %s", containerID)
 	}
 	containerStats := container.statsQueue.GetLastStat()
 
 	// Insert network stats in container stats
 	task, err := engine.resolver.ResolveTaskByARN(taskARN)
 	if err != nil {
-		return nil, errors.Errorf("stats engine: task '%s' not found",
+		return nil, NetworkStatsPerSec{}, errors.Errorf("stats engine: task '%s' not found",
 			taskARN)
 	}
 
@@ -774,5 +774,5 @@ func (engine *DockerStatsEngine) ContainerDockerStats(taskARN string, containerI
 		}
 	}
 
-	return containerStats, nil
+	return containerStats, container.statsQueue.GetLastNetworkStatPerSec(), nil
 }

--- a/agent/stats/engine_test.go
+++ b/agent/stats/engine_test.go
@@ -224,7 +224,7 @@ func TestStatsEngineMetadataInStatsSets(t *testing.T) {
 		t.Errorf("Error validating metadata: %v", err)
 	}
 
-	dockerStat, err := engine.ContainerDockerStats("t1", "c1")
+	dockerStat, _, err := engine.ContainerDockerStats("t1", "c1")
 	assert.NoError(t, err)
 	assert.Equal(t, ts2, dockerStat.Read)
 

--- a/agent/stats/mock/engine.go
+++ b/agent/stats/mock/engine.go
@@ -51,11 +51,11 @@ func (m *MockEngine) EXPECT() *MockEngineMockRecorder {
 }
 
 // ContainerDockerStats mocks base method
-func (m *MockEngine) ContainerDockerStats(arg0, arg1 string) (*types.StatsJSON, stats.NetworkStatsPerSec, error) {
+func (m *MockEngine) ContainerDockerStats(arg0, arg1 string) (*types.StatsJSON, *stats.NetworkStatsPerSec, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContainerDockerStats", arg0, arg1)
 	ret0, _ := ret[0].(*types.StatsJSON)
-	ret1, _ := ret[1].(stats.NetworkStatsPerSec)
+	ret1, _ := ret[1].(*stats.NetworkStatsPerSec)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }

--- a/agent/stats/mock/engine.go
+++ b/agent/stats/mock/engine.go
@@ -21,6 +21,7 @@ package mock_stats
 import (
 	reflect "reflect"
 
+	"github.com/aws/amazon-ecs-agent/agent/stats"
 	ecstcs "github.com/aws/amazon-ecs-agent/agent/tcs/model/ecstcs"
 	types "github.com/docker/docker/api/types"
 	gomock "github.com/golang/mock/gomock"
@@ -50,12 +51,13 @@ func (m *MockEngine) EXPECT() *MockEngineMockRecorder {
 }
 
 // ContainerDockerStats mocks base method
-func (m *MockEngine) ContainerDockerStats(arg0, arg1 string) (*types.StatsJSON, error) {
+func (m *MockEngine) ContainerDockerStats(arg0, arg1 string) (*types.StatsJSON, stats.NetworkStatsPerSec, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContainerDockerStats", arg0, arg1)
 	ret0, _ := ret[0].(*types.StatsJSON)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(stats.NetworkStatsPerSec)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // ContainerDockerStats indicates an expected call of ContainerDockerStats

--- a/agent/stats/queue.go
+++ b/agent/stats/queue.go
@@ -36,7 +36,7 @@ type Queue struct {
 	buffer                []UsageStats
 	maxSize               int
 	lastStat              *types.StatsJSON
-	lastNetworkStatPerSec NetworkStatsPerSec
+	lastNetworkStatPerSec *NetworkStatsPerSec
 	lock                  sync.RWMutex
 }
 
@@ -129,7 +129,7 @@ func (queue *Queue) add(rawStat *ContainerStats) {
 		}
 
 		if stat.NetworkStats != nil {
-			networkStatPerSec := NetworkStatsPerSec{
+			networkStatPerSec := &NetworkStatsPerSec{
 				RxBytesPerSecond: stat.NetworkStats.RxBytesPerSecond,
 				TxBytesPerSecond: stat.NetworkStats.TxBytesPerSecond,
 			}
@@ -148,7 +148,7 @@ func (queue *Queue) GetLastStat() *types.StatsJSON {
 	return queue.lastStat
 }
 
-func (queue *Queue) GetLastNetworkStatPerSec() NetworkStatsPerSec {
+func (queue *Queue) GetLastNetworkStatPerSec() *NetworkStatsPerSec {
 	queue.lock.RLock()
 	defer queue.lock.RUnlock()
 

--- a/agent/stats/types.go
+++ b/agent/stats/types.go
@@ -92,3 +92,8 @@ type taskDefinition struct {
 	family  string
 	version string
 }
+
+type NetworkStatsPerSec struct {
+	RxBytesPerSecond float32 `json:"rx_bytes_per_sec"`
+	TxBytesPerSecond float32 `json:"tx_bytes_per_sec"`
+}

--- a/agent/tcs/client/client_test.go
+++ b/agent/tcs/client/client_test.go
@@ -56,8 +56,8 @@ func (*mockStatsEngine) GetInstanceMetrics() (*ecstcs.MetricsMetadata, []*ecstcs
 	return nil, nil, fmt.Errorf("uninitialized")
 }
 
-func (*mockStatsEngine) ContainerDockerStats(taskARN string, id string) (*types.StatsJSON, stats.NetworkStatsPerSec, error) {
-	return nil, stats.NetworkStatsPerSec{}, fmt.Errorf("not implemented")
+func (*mockStatsEngine) ContainerDockerStats(taskARN string, id string) (*types.StatsJSON, *stats.NetworkStatsPerSec, error) {
+	return nil, nil, fmt.Errorf("not implemented")
 }
 
 func (*mockStatsEngine) GetTaskHealthMetrics() (*ecstcs.HealthMetadata, []*ecstcs.TaskHealth, error) {
@@ -70,8 +70,8 @@ func (*emptyStatsEngine) GetInstanceMetrics() (*ecstcs.MetricsMetadata, []*ecstc
 	return nil, nil, fmt.Errorf("empty stats")
 }
 
-func (*emptyStatsEngine) ContainerDockerStats(taskARN string, id string) (*types.StatsJSON, stats.NetworkStatsPerSec, error) {
-	return nil, stats.NetworkStatsPerSec{}, fmt.Errorf("not implemented")
+func (*emptyStatsEngine) ContainerDockerStats(taskARN string, id string) (*types.StatsJSON, *stats.NetworkStatsPerSec, error) {
+	return nil, nil, fmt.Errorf("not implemented")
 }
 
 func (*emptyStatsEngine) GetTaskHealthMetrics() (*ecstcs.HealthMetadata, []*ecstcs.TaskHealth, error) {
@@ -90,8 +90,8 @@ func (*idleStatsEngine) GetInstanceMetrics() (*ecstcs.MetricsMetadata, []*ecstcs
 	return metadata, []*ecstcs.TaskMetric{}, nil
 }
 
-func (*idleStatsEngine) ContainerDockerStats(taskARN string, id string) (*types.StatsJSON, stats.NetworkStatsPerSec, error) {
-	return nil, stats.NetworkStatsPerSec{}, fmt.Errorf("not implemented")
+func (*idleStatsEngine) ContainerDockerStats(taskARN string, id string) (*types.StatsJSON, *stats.NetworkStatsPerSec, error) {
+	return nil, nil, fmt.Errorf("not implemented")
 }
 
 func (*idleStatsEngine) GetTaskHealthMetrics() (*ecstcs.HealthMetadata, []*ecstcs.TaskHealth, error) {
@@ -118,8 +118,8 @@ func (engine *nonIdleStatsEngine) GetInstanceMetrics() (*ecstcs.MetricsMetadata,
 	return metadata, taskMetrics, nil
 }
 
-func (*nonIdleStatsEngine) ContainerDockerStats(taskARN string, id string) (*types.StatsJSON, stats.NetworkStatsPerSec, error) {
-	return nil, stats.NetworkStatsPerSec{}, fmt.Errorf("not implemented")
+func (*nonIdleStatsEngine) ContainerDockerStats(taskARN string, id string) (*types.StatsJSON, *stats.NetworkStatsPerSec, error) {
+	return nil, nil, fmt.Errorf("not implemented")
 }
 
 func (*nonIdleStatsEngine) GetTaskHealthMetrics() (*ecstcs.HealthMetadata, []*ecstcs.TaskHealth, error) {

--- a/agent/tcs/client/client_test.go
+++ b/agent/tcs/client/client_test.go
@@ -56,8 +56,8 @@ func (*mockStatsEngine) GetInstanceMetrics() (*ecstcs.MetricsMetadata, []*ecstcs
 	return nil, nil, fmt.Errorf("uninitialized")
 }
 
-func (*mockStatsEngine) ContainerDockerStats(taskARN string, id string) (*types.StatsJSON, error) {
-	return nil, fmt.Errorf("not implemented")
+func (*mockStatsEngine) ContainerDockerStats(taskARN string, id string) (*types.StatsJSON, stats.NetworkStatsPerSec, error) {
+	return nil, stats.NetworkStatsPerSec{}, fmt.Errorf("not implemented")
 }
 
 func (*mockStatsEngine) GetTaskHealthMetrics() (*ecstcs.HealthMetadata, []*ecstcs.TaskHealth, error) {
@@ -70,8 +70,8 @@ func (*emptyStatsEngine) GetInstanceMetrics() (*ecstcs.MetricsMetadata, []*ecstc
 	return nil, nil, fmt.Errorf("empty stats")
 }
 
-func (*emptyStatsEngine) ContainerDockerStats(taskARN string, id string) (*types.StatsJSON, error) {
-	return nil, fmt.Errorf("not implemented")
+func (*emptyStatsEngine) ContainerDockerStats(taskARN string, id string) (*types.StatsJSON, stats.NetworkStatsPerSec, error) {
+	return nil, stats.NetworkStatsPerSec{}, fmt.Errorf("not implemented")
 }
 
 func (*emptyStatsEngine) GetTaskHealthMetrics() (*ecstcs.HealthMetadata, []*ecstcs.TaskHealth, error) {
@@ -90,8 +90,8 @@ func (*idleStatsEngine) GetInstanceMetrics() (*ecstcs.MetricsMetadata, []*ecstcs
 	return metadata, []*ecstcs.TaskMetric{}, nil
 }
 
-func (*idleStatsEngine) ContainerDockerStats(taskARN string, id string) (*types.StatsJSON, error) {
-	return nil, fmt.Errorf("not implemented")
+func (*idleStatsEngine) ContainerDockerStats(taskARN string, id string) (*types.StatsJSON, stats.NetworkStatsPerSec, error) {
+	return nil, stats.NetworkStatsPerSec{}, fmt.Errorf("not implemented")
 }
 
 func (*idleStatsEngine) GetTaskHealthMetrics() (*ecstcs.HealthMetadata, []*ecstcs.TaskHealth, error) {
@@ -118,8 +118,8 @@ func (engine *nonIdleStatsEngine) GetInstanceMetrics() (*ecstcs.MetricsMetadata,
 	return metadata, taskMetrics, nil
 }
 
-func (*nonIdleStatsEngine) ContainerDockerStats(taskARN string, id string) (*types.StatsJSON, error) {
-	return nil, fmt.Errorf("not implemented")
+func (*nonIdleStatsEngine) ContainerDockerStats(taskARN string, id string) (*types.StatsJSON, stats.NetworkStatsPerSec, error) {
+	return nil, stats.NetworkStatsPerSec{}, fmt.Errorf("not implemented")
 }
 
 func (*nonIdleStatsEngine) GetTaskHealthMetrics() (*ecstcs.HealthMetadata, []*ecstcs.TaskHealth, error) {

--- a/agent/tcs/handler/handler_test.go
+++ b/agent/tcs/handler/handler_test.go
@@ -68,8 +68,8 @@ func (*mockStatsEngine) GetInstanceMetrics() (*ecstcs.MetricsMetadata, []*ecstcs
 	return req.Metadata, req.TaskMetrics, nil
 }
 
-func (*mockStatsEngine) ContainerDockerStats(taskARN string, id string) (*types.StatsJSON, stats.NetworkStatsPerSec, error) {
-	return nil, stats.NetworkStatsPerSec{}, fmt.Errorf("not implemented")
+func (*mockStatsEngine) ContainerDockerStats(taskARN string, id string) (*types.StatsJSON, *stats.NetworkStatsPerSec, error) {
+	return nil, nil, fmt.Errorf("not implemented")
 }
 
 func (*mockStatsEngine) GetTaskHealthMetrics() (*ecstcs.HealthMetadata, []*ecstcs.TaskHealth, error) {

--- a/agent/tcs/handler/handler_test.go
+++ b/agent/tcs/handler/handler_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	mock_engine "github.com/aws/amazon-ecs-agent/agent/engine/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
+	"github.com/aws/amazon-ecs-agent/agent/stats"
 	tcsclient "github.com/aws/amazon-ecs-agent/agent/tcs/client"
 	"github.com/aws/amazon-ecs-agent/agent/tcs/model/ecstcs"
 	"github.com/aws/amazon-ecs-agent/agent/version"
@@ -67,8 +68,8 @@ func (*mockStatsEngine) GetInstanceMetrics() (*ecstcs.MetricsMetadata, []*ecstcs
 	return req.Metadata, req.TaskMetrics, nil
 }
 
-func (*mockStatsEngine) ContainerDockerStats(taskARN string, id string) (*types.StatsJSON, error) {
-	return nil, fmt.Errorf("not implemented")
+func (*mockStatsEngine) ContainerDockerStats(taskARN string, id string) (*types.StatsJSON, stats.NetworkStatsPerSec, error) {
+	return nil, stats.NetworkStatsPerSec{}, fmt.Errorf("not implemented")
 }
 
 func (*mockStatsEngine) GetTaskHealthMetrics() (*ecstcs.HealthMetadata, []*ecstcs.TaskHealth, error) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR enables the v4 task metadata endpoint to expose the network rate stats for the containers.

The format will be something like below
```
{
    "da4b0c663fa9b304c0bccedfa8006205afbabd63e7909ec70f73774cd33c0efd": {
        "read": "2020-06-17T21:45:26.381091349Z",
        "preread": "2020-06-17T21:45:25.379063801Z",
        "pids_stats": {
            "current": 1
        },
        "blkio_stats": {...},
        "num_procs": 0,
        "storage_stats": {},
        "cpu_stats": {
            "cpu_usage": {
                "total_usage": 174832868,
                "percpu_usage": [156053246, 18779622],
                "usage_in_kernelmode": 0,
                "usage_in_usermode": 160000000
            },
            "system_cpu_usage": 1514113580000000,
            "online_cpus": 2,
            "throttling_data": {...}
        },
        "precpu_stats": {
            "cpu_usage": {
                "total_usage": 174832868,
                "percpu_usage": [156053246, 18779622],
                "usage_in_kernelmode": 0,
                "usage_in_usermode": 160000000
            },
            "system_cpu_usage": 1514111560000000,
            "online_cpus": 2,
            "throttling_data": {...}
        },
        "memory_stats": {
            "usage": 622592,
            "max_usage": 6328320,
            "stats: {...},
            "limit": 536870912
        },
        "name": "/ecs-test-eni-trunking-sleep-long-bridge-1-container1-c692caa8accfaa805700",
        "id": "da4b0c663fa9b304c0bccedfa8006205afbabd63e7909ec70f73774cd33c0efd",
        "networks": {
            "eth0": {
                "rx_bytes": 14626,
                "rx_packets": 207,
                .
                .
                }
            }      
        },
        "network_rate_stats": {
            {
               "rx_bytes_per_sec": 10,
               "tx_bytes_per_sec": 55
            }
        }
 }
```
This change appends the field network_rate_stats to the docker stats.

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--



Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

Unit tests cover the change.

ManualTest:
Started a task and curl-ed the V4 metadata endpoint and checked that the network_rate_stats is correctly getting populated

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
