### PR TITLE
Added boltdb implementation to get, update and delete eni attachments

### DIFF
--- a/agent/acs/handler/acs_handler.go
+++ b/agent/acs/handler/acs_handler.go
@@ -285,7 +285,7 @@ func (acsSession *session) startACSSession(client wsclient.ClientServer) error {
 		acsSession.containerInstanceARN,
 		client,
 		acsSession.state,
-		acsSession.stateManager,
+		acsSession.dataClient,
 	)
 	eniAttachHandler.start()
 	defer eniAttachHandler.stop()
@@ -299,7 +299,7 @@ func (acsSession *session) startACSSession(client wsclient.ClientServer) error {
 		acsSession.containerInstanceARN,
 		client,
 		acsSession.state,
-		acsSession.stateManager,
+		acsSession.dataClient,
 	)
 	instanceENIAttachHandler.start()
 	defer instanceENIAttachHandler.stop()

--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -349,7 +349,7 @@ func (agent *ecsAgent) doStart(containerChangeEventStream *eventstream.EventStre
 		deregisterContainerInstanceEventStreamName, agent.ctx)
 	deregisterInstanceEventStream.StartListening()
 	taskHandler := eventhandler.NewTaskHandler(agent.ctx, stateManager, agent.dataClient, state, client)
-	attachmentEventHandler := eventhandler.NewAttachmentEventHandler(agent.ctx, stateManager, client)
+	attachmentEventHandler := eventhandler.NewAttachmentEventHandler(agent.ctx, stateManager, agent.dataClient, client)
 	agent.startAsyncRoutines(containerChangeEventStream, credentialsManager, imageManager,
 		taskEngine, stateManager, deregisterInstanceEventStream, client, taskHandler, attachmentEventHandler, state)
 

--- a/agent/data/eniattachment_client_test.go
+++ b/agent/data/eniattachment_client_test.go
@@ -1,0 +1,76 @@
+// +build unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package data
+
+import (
+	"testing"
+
+	"github.com/aws/amazon-ecs-agent/agent/api/eni"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testAttachmentArn  = "arn:aws:ecs:us-west-2:167933679560:attachment/test-arn"
+	testAttachmentArn2 = "arn:aws:ecs:us-west-2:167933679560:attachment/test-arn2"
+)
+
+func TestManageENIAttachments(t *testing.T) {
+	testClient, cleanup := newTestClient(t)
+	defer cleanup()
+
+	testEniAttachment := &eni.ENIAttachment{
+		AttachmentARN:    testAttachmentArn,
+		AttachStatusSent: false,
+	}
+
+	assert.NoError(t, testClient.SaveENIAttachment(testEniAttachment))
+	testEniAttachment.SetSentStatus()
+	assert.NoError(t, testClient.SaveENIAttachment(testEniAttachment))
+	res, err := testClient.GetENIAttachments()
+	assert.NoError(t, err)
+	assert.Len(t, res, 1)
+	assert.Equal(t, true, res[0].AttachStatusSent)
+	assert.Equal(t, testAttachmentArn, res[0].AttachmentARN)
+
+	testEniAttachment2 := &eni.ENIAttachment{
+		AttachmentARN:    testAttachmentArn2,
+		AttachStatusSent: true,
+	}
+
+	assert.NoError(t, testClient.SaveENIAttachment(testEniAttachment2))
+	res, err = testClient.GetENIAttachments()
+	assert.NoError(t, err)
+	assert.Len(t, res, 2)
+
+	assert.NoError(t, testClient.DeleteENIAttachment("test-arn"))
+	assert.NoError(t, testClient.DeleteENIAttachment("test-arn2"))
+	res, err = testClient.GetENIAttachments()
+	assert.NoError(t, err)
+	assert.Len(t, res, 0)
+}
+
+func TestSaveENIAttachmentInvalidID(t *testing.T) {
+	testClient, cleanup := newTestClient(t)
+	defer cleanup()
+
+	testEniAttachment := &eni.ENIAttachment{
+		AttachmentARN:    "invalid-arn",
+		AttachStatusSent: false,
+	}
+
+	assert.Error(t, testClient.SaveENIAttachment(testEniAttachment))
+}

--- a/agent/engine/data.go
+++ b/agent/engine/data.go
@@ -68,6 +68,23 @@ func (engine *DockerTaskEngine) removeTaskData(task *apitask.Task) {
 	}
 }
 
+func (engine *DockerTaskEngine) removeENIAttachmentData(mac string) {
+	attachmentToRemove, ok := engine.state.ENIByMac(mac)
+	if !ok {
+		seelog.Warnf("Unable to retrieve ENI Attachment for mac address %s: ", mac)
+		return
+	}
+	attachmentId, err := utils.GetENIAttachmentId(attachmentToRemove.AttachmentARN)
+	if err != nil {
+		seelog.Errorf("Failed to get attachment id for %s: %v", attachmentToRemove.AttachmentARN, err)
+	} else {
+		err = engine.dataClient.DeleteENIAttachment(attachmentId)
+		if err != nil {
+			seelog.Errorf("Failed to remove data for eni attachment %s: %v", attachmentId, err)
+		}
+	}
+}
+
 func (imageManager *dockerImageManager) saveImageStateData(imageState *image.ImageState) {
 	err := imageManager.dataClient.SaveImageState(imageState)
 	if err != nil {

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -329,6 +329,7 @@ func (engine *DockerTaskEngine) synchronizeState() {
 			}
 			if !eniAttachment.IsSent() {
 				seelog.Warnf("Timed out waiting for ENI ack; removing ENI attachment record with MAC address: %s", eniAttachment.MACAddress)
+				engine.removeENIAttachmentData(eniAttachment.MACAddress)
 				engine.state.RemoveENIAttachment(eniAttachment.MACAddress)
 			}
 		}
@@ -337,6 +338,7 @@ func (engine *DockerTaskEngine) synchronizeState() {
 			// The only case where we get an error from Initialize is that the attachment has expired. In that case, remove the expired
 			// attachment from state.
 			seelog.Warnf("ENI attachment with mac address %s has expired. Removing it from state.", eniAttachment.MACAddress)
+			engine.removeENIAttachmentData(eniAttachment.MACAddress)
 			engine.state.RemoveENIAttachment(eniAttachment.MACAddress)
 		}
 	}
@@ -573,6 +575,7 @@ func (engine *DockerTaskEngine) deleteTask(task *apitask.Task) {
 		if taskENI.IsStandardENI() {
 			seelog.Debugf("Task engine [%s]: removing eni %s from agent state",
 				task.Arn, taskENI.ID)
+			engine.removeENIAttachmentData(taskENI.MacAddress)
 			engine.state.RemoveENIAttachment(taskENI.MacAddress)
 		} else {
 			seelog.Debugf("Task engine [%s]: skipping removing logical eni %s from agent state",

--- a/agent/engine/task_manager_test.go
+++ b/agent/engine/task_manager_test.go
@@ -1284,6 +1284,7 @@ func TestCleanupTaskENIs(t *testing.T) {
 	mockImageManager.EXPECT().RemoveContainerReferenceFromImageState(container).Return(nil)
 	mockState.EXPECT().RemoveTask(mTask.Task)
 	mockState.EXPECT().RemoveENIAttachment(mac)
+	mockState.EXPECT().ENIByMac(mac)
 	mTask.cleanupTask(taskStoppedDuration)
 }
 

--- a/agent/eventhandler/handler_test.go
+++ b/agent/eventhandler/handler_test.go
@@ -38,7 +38,7 @@ func TestHandleEngineEvent(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	taskHandler := NewTaskHandler(ctx, stateManager, data.NewNoopClient(), dockerstate.NewTaskEngineState(), client)
-	attachmentHandler := NewAttachmentEventHandler(ctx, statemanager.NewNoopStateManager(), client)
+	attachmentHandler := NewAttachmentEventHandler(ctx, statemanager.NewNoopStateManager(), data.NewNoopClient(), client)
 	defer cancel()
 
 	var wg sync.WaitGroup

--- a/agent/utils/utils.go
+++ b/agent/utils/utils.go
@@ -221,3 +221,16 @@ func GetTaskID(taskARN string) (string, error) {
 	}
 	return fields[len(fields)-1], nil
 }
+
+// GetENIAttachmentId retrieves the attachment ID from eni attachment ARN.
+func GetENIAttachmentId(eniAttachmentArn string) (string, error) {
+	_, err := arn.Parse(eniAttachmentArn)
+	if err != nil {
+		return "", errors.Errorf("failed to get eni attachment id: eni attachment arn format invalid: %s", eniAttachmentArn)
+	}
+	fields := strings.Split(eniAttachmentArn, "/")
+	if len(fields) < 2 {
+		return "", errors.Errorf("failed to get eni attachment id: eni attachment arn invalid: %s", eniAttachmentArn)
+	}
+	return fields[len(fields)-1], nil
+}

--- a/agent/utils/utils_test.go
+++ b/agent/utils/utils_test.go
@@ -184,3 +184,13 @@ func TestGetTaskID(t *testing.T) {
 	_, err = GetTaskID("invalid")
 	assert.Error(t, err)
 }
+
+func TestGetENIAttachmentId(t *testing.T) {
+	attachmentArn := "arn:aws:ecs:us-west-2:1234567890:attachment/abc"
+	id, err := GetENIAttachmentId(attachmentArn)
+	require.NoError(t, err)
+	assert.Equal(t, "abc", id)
+
+	_, err = GetENIAttachmentId("invalid")
+	assert.Error(t, err)
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Added boltdb implementation to get, update and delete eni attachments. Updated agent to use data Client instead of state manager to persist eni attachment data

These changes cover the following scenarios
  * save attachment when receive an eni attachment payload from acs;
  * update an eni attachment when the attachment’s attached status is sent;
  * delete eni attachment when a task is reaped; or attachment has expired.

### Implementation details
<!-- How are the changes implemented? -->

 - `acs/handler`: replaced statemanger saver with dataClient to save and delete eni attachments data, updated the tests accordingly
 - `data`: added botldb implementation for SaveENIAttachment, DeleteENIAttachment and GetENIAttachments
- `engine`: added a wrapper method removeENIAttachment to remove eni attachment data if attachment is expired or status is not sent; also when task is deleted
- `eventhandler`: replaced statemanger saver with dataClient to save eni attachments data
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes<!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
