### PR TITLE
Adds support for Grafana Loki docker log driver.

### DIFF
--- a/agent/dockerclient/logging_drivers.go
+++ b/agent/dockerclient/logging_drivers.go
@@ -25,6 +25,7 @@ const (
 	SplunklogsDriver LoggingDriver = "splunk"
 	LogentriesDriver LoggingDriver = "logentries"
 	SumoLogicDriver  LoggingDriver = "sumologic"
+	LokiDriver       LoggingDriver = "loki"
 	NoneDriver       LoggingDriver = "none"
 )
 
@@ -38,5 +39,6 @@ var LoggingDriverMinimumVersion = map[LoggingDriver]DockerVersion{
 	SplunklogsDriver: Version_1_22,
 	LogentriesDriver: Version_1_25,
 	SumoLogicDriver:  Version_1_29,
+	LokiDriver:       Version_1_18,
 	NoneDriver:       Version_1_19,
 }


### PR DESCRIPTION
Hello this adds support for the Grafana Loki driver in the ecs agent.

Let me know if there is anything else I need to do.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>
