### PR TITLE
migrating more boolean configs to BooleanDefault*

### DIFF
--- a/agent/acs/update_handler/updater.go
+++ b/agent/acs/update_handler/updater.go
@@ -104,7 +104,7 @@ func (u *updater) stageUpdateHandler() func(req *ecsacs.StageUpdateMessage) {
 			u.reset()
 		}
 
-		if !u.config.UpdatesEnabled {
+		if !u.config.UpdatesEnabled.Enabled() {
 			nack("Updates are disabled")
 			return
 		}
@@ -223,7 +223,7 @@ func (u *updater) performUpdateHandler(saver statemanager.Saver, taskEngine engi
 
 		seelog.Debug("Got perform update request")
 
-		if !u.config.UpdatesEnabled {
+		if !u.config.UpdatesEnabled.Enabled() {
 			reason := "Updates are disabled"
 			seelog.Errorf("Nacking PerformUpdate; reason: %s", reason)
 			u.acs.MakeRequest(&ecsacs.NackRequest{

--- a/agent/acs/update_handler/updater_test.go
+++ b/agent/acs/update_handler/updater_test.go
@@ -49,7 +49,7 @@ func ptr(i interface{}) interface{} {
 func mocks(t *testing.T, cfg *config.Config) (*updater, *gomock.Controller, *config.Config, *mock_client.MockClientServer, *mock_http.MockRoundTripper) {
 	if cfg == nil {
 		cfg = &config.Config{
-			UpdatesEnabled:    true,
+			UpdatesEnabled:    config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled},
 			UpdateDownloadDir: filepath.Clean("/tmp/test/"),
 		}
 	}
@@ -90,7 +90,7 @@ func mockOS() func() {
 }
 func TestStageUpdateWithUpdatesDisabled(t *testing.T) {
 	u, ctrl, _, mockacs, _ := mocks(t, &config.Config{
-		UpdatesEnabled: false,
+		UpdatesEnabled: config.BooleanDefaultFalse{Value: config.ExplicitlyDisabled},
 	})
 	defer ctrl.Finish()
 
@@ -115,7 +115,7 @@ func TestStageUpdateWithUpdatesDisabled(t *testing.T) {
 
 func TestPerformUpdateWithUpdatesDisabled(t *testing.T) {
 	u, ctrl, cfg, mockacs, _ := mocks(t, &config.Config{
-		UpdatesEnabled: false,
+		UpdatesEnabled: config.BooleanDefaultFalse{Value: config.ExplicitlyDisabled},
 	})
 	defer ctrl.Finish()
 

--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -343,7 +343,7 @@ func (agent *ecsAgent) newTaskEngine(containerChangeEventStream *eventstream.Eve
 
 	containerChangeEventStream.StartListening()
 
-	if !agent.cfg.Checkpoint {
+	if !agent.cfg.Checkpoint.Enabled() {
 		seelog.Info("Checkpointing not enabled; a new container instance will be created each time the agent is run")
 		return engine.NewTaskEngine(agent.cfg, agent.dockerClient, credentialsManager,
 			containerChangeEventStream, imageManager, state,
@@ -471,7 +471,7 @@ func (agent *ecsAgent) newStateManager(
 	savedInstanceID *string,
 	availabilityZone *string, latestSeqNumberTaskManifest *int64) (statemanager.StateManager, error) {
 
-	if !agent.cfg.Checkpoint {
+	if !agent.cfg.Checkpoint.Enabled() {
 		return statemanager.NewNoopStateManager(), nil
 	}
 

--- a/agent/app/agent_capability_unix.go
+++ b/agent/app/agent_capability_unix.go
@@ -88,7 +88,7 @@ func (agent *ecsAgent) appendNvidiaDriverVersionAttribute(capabilities []*ecs.At
 }
 
 func (agent *ecsAgent) appendENITrunkingCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
-	if !agent.cfg.ENITrunkingEnabled {
+	if !agent.cfg.ENITrunkingEnabled.Enabled() {
 		return capabilities
 	}
 	capabilities = appendNameOnlyAttribute(capabilities, attributePrefix+taskENITrunkingAttributeSuffix)

--- a/agent/app/agent_capability_unix_test.go
+++ b/agent/app/agent_capability_unix_test.go
@@ -285,7 +285,7 @@ func TestENITrunkingCapabilitiesUnix(t *testing.T) {
 	conf := &config.Config{
 		PrivilegedDisabled: true,
 		TaskENIEnabled:     true,
-		ENITrunkingEnabled: true,
+		ENITrunkingEnabled: config.BooleanDefaultTrue{Value: config.ExplicitlyEnabled},
 	}
 
 	mockPauseLoader.EXPECT().IsLoaded(gomock.Any()).Return(true, nil)
@@ -368,7 +368,7 @@ func TestNoENITrunkingCapabilitiesUnix(t *testing.T) {
 	conf := &config.Config{
 		PrivilegedDisabled: true,
 		TaskENIEnabled:     true,
-		ENITrunkingEnabled: false,
+		ENITrunkingEnabled: config.BooleanDefaultTrue{Value: config.ExplicitlyDisabled},
 	}
 
 	mockPauseLoader.EXPECT().IsLoaded(gomock.Any()).Return(true, nil)

--- a/agent/app/agent_compatibility_linux_test.go
+++ b/agent/app/agent_compatibility_linux_test.go
@@ -35,7 +35,7 @@ func TestCompatibilityEnabledSuccess(t *testing.T) {
 	stateManager := mock_statemanager.NewMockStateManager(ctrl)
 
 	cfg := getTestConfig()
-	cfg.Checkpoint = true
+	cfg.Checkpoint = config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled}
 	cfg.TaskCPUMemLimit = config.BooleanDefaultTrue{Value: config.NotSet}
 
 	agent := &ecsAgent{
@@ -69,7 +69,7 @@ func TestCompatibilityNotSetFail(t *testing.T) {
 	stateManager := mock_statemanager.NewMockStateManager(ctrl)
 
 	cfg := getTestConfig()
-	cfg.Checkpoint = true
+	cfg.Checkpoint = config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled}
 	cfg.TaskCPUMemLimit = config.BooleanDefaultTrue{Value: config.NotSet}
 
 	agent := &ecsAgent{
@@ -101,8 +101,8 @@ func TestCompatibilityExplicitlyEnabledFail(t *testing.T) {
 	stateManager := mock_statemanager.NewMockStateManager(ctrl)
 
 	cfg := getTestConfig()
-	cfg.Checkpoint = true
-	cfg.TaskCPUMemLimit.Value = config.ExplicitlyEnabled
+	cfg.Checkpoint = config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled}
+	cfg.TaskCPUMemLimit = config.BooleanDefaultTrue{Value: config.ExplicitlyEnabled}
 
 	agent := &ecsAgent{
 		cfg:                   &cfg,

--- a/agent/app/agent_test.go
+++ b/agent/app/agent_test.go
@@ -101,7 +101,7 @@ func TestDoStartMinimumSupportedDockerVersionTerminal(t *testing.T) {
 	)
 
 	cfg := getTestConfig()
-	cfg.Checkpoint = true
+	cfg.Checkpoint = config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled}
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines
 	defer cancel()
@@ -127,7 +127,7 @@ func TestDoStartMinimumSupportedDockerVersionError(t *testing.T) {
 	)
 
 	cfg := getTestConfig()
-	cfg.Checkpoint = true
+	cfg.Checkpoint = config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled}
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines
 	defer cancel()
@@ -165,7 +165,7 @@ func TestDoStartNewTaskEngineError(t *testing.T) {
 	)
 
 	cfg := getTestConfig()
-	cfg.Checkpoint = true
+	cfg.Checkpoint = config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled}
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines
 	defer cancel()
@@ -214,7 +214,7 @@ func TestDoStartNewStateManagerError(t *testing.T) {
 	)
 
 	cfg := getTestConfig()
-	cfg.Checkpoint = true
+	cfg.Checkpoint = config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled}
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines
 	defer cancel()
@@ -419,7 +419,7 @@ func TestNewTaskEngineRestoreFromCheckpointNoEC2InstanceIDToLoadHappyPath(t *tes
 	mockPauseLoader.EXPECT().IsLoaded(gomock.Any()).Return(false, nil).AnyTimes()
 	mockPauseLoader.EXPECT().LoadImage(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 	cfg := getTestConfig()
-	cfg.Checkpoint = true
+	cfg.Checkpoint = config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled}
 	expectedInstanceID := "inst-1"
 	gomock.InOrder(
 		saveableOptionFactory.EXPECT().AddSaveable("ContainerInstanceArn", gomock.Any()).Do(
@@ -471,7 +471,7 @@ func TestNewTaskEngineRestoreFromCheckpointPreviousEC2InstanceIDLoadedHappyPath(
 	mockPauseLoader.EXPECT().IsLoaded(gomock.Any()).Return(false, nil).AnyTimes()
 	mockPauseLoader.EXPECT().LoadImage(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 	cfg := getTestConfig()
-	cfg.Checkpoint = true
+	cfg.Checkpoint = config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled}
 	expectedInstanceID := "inst-1"
 
 	gomock.InOrder(
@@ -535,7 +535,7 @@ func TestNewTaskEngineRestoreFromCheckpointClusterIDMismatch(t *testing.T) {
 	mockPauseLoader.EXPECT().IsLoaded(gomock.Any()).Return(false, nil).AnyTimes()
 	mockPauseLoader.EXPECT().LoadImage(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 	cfg := getTestConfig()
-	cfg.Checkpoint = true
+	cfg.Checkpoint = config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled}
 	cfg.Cluster = "default"
 	ec2InstanceID := "inst-1"
 
@@ -588,7 +588,7 @@ func TestNewTaskEngineRestoreFromCheckpointNewStateManagerError(t *testing.T) {
 	defer ctrl.Finish()
 
 	cfg := getTestConfig()
-	cfg.Checkpoint = true
+	cfg.Checkpoint = config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled}
 
 	mockPauseLoader := mock_pause.NewMockLoader(ctrl)
 	mockPauseLoader.EXPECT().IsLoaded(gomock.Any()).Return(false, nil).AnyTimes()
@@ -630,7 +630,7 @@ func TestNewTaskEngineRestoreFromCheckpointStateLoadError(t *testing.T) {
 
 	stateManager := mock_statemanager.NewMockStateManager(ctrl)
 	cfg := getTestConfig()
-	cfg.Checkpoint = true
+	cfg.Checkpoint = config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled}
 	mockPauseLoader := mock_pause.NewMockLoader(ctrl)
 
 	mockPauseLoader.EXPECT().IsLoaded(gomock.Any()).Return(false, nil).AnyTimes()
@@ -672,7 +672,7 @@ func TestNewTaskEngineRestoreFromCheckpoint(t *testing.T) {
 
 	ec2MetadataClient := mock_ec2.NewMockEC2MetadataClient(ctrl)
 	cfg := getTestConfig()
-	cfg.Checkpoint = true
+	cfg.Checkpoint = config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled}
 	expectedInstanceID := "inst-1"
 	mockPauseLoader := mock_pause.NewMockLoader(ctrl)
 

--- a/agent/app/agent_unix.go
+++ b/agent/app/agent_unix.go
@@ -146,7 +146,7 @@ func (agent *ecsAgent) verifyCNIPluginsCapabilities() error {
 	// Check if we can get capabilities from each plugin
 	for _, plugin := range awsVPCCNIPlugins {
 		// skip verifying branch cni plugin if eni trunking is not enabled
-		if plugin == ecscni.ECSBranchENIPluginName && agent.cfg != nil && !agent.cfg.ENITrunkingEnabled {
+		if plugin == ecscni.ECSBranchENIPluginName && agent.cfg != nil && !agent.cfg.ENITrunkingEnabled.Enabled() {
 			continue
 		}
 

--- a/agent/app/agent_unix_test.go
+++ b/agent/app/agent_unix_test.go
@@ -224,7 +224,7 @@ func TestDoStartTaskENIHappyPath(t *testing.T) {
 
 	cfg := getTestConfig()
 	cfg.TaskENIEnabled = true
-	cfg.ENITrunkingEnabled = true
+	cfg.ENITrunkingEnabled = config.BooleanDefaultTrue{Value: config.ExplicitlyEnabled}
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines
 	agent := &ecsAgent{
@@ -357,7 +357,7 @@ func TestQueryCNIPluginsCapabilitiesHappyPath(t *testing.T) {
 	agent := &ecsAgent{
 		cniClient: cniClient,
 		cfg: &config.Config{
-			ENITrunkingEnabled: true,
+			ENITrunkingEnabled: config.BooleanDefaultTrue{Value: config.ExplicitlyEnabled},
 		},
 	}
 	assert.NoError(t, agent.verifyCNIPluginsCapabilities())
@@ -790,7 +790,7 @@ func TestDoStartTaskENIPauseError(t *testing.T) {
 
 	cfg := getTestConfig()
 	cfg.TaskENIEnabled = true
-	cfg.ENITrunkingEnabled = true
+	cfg.ENITrunkingEnabled = config.BooleanDefaultTrue{Value: config.ExplicitlyEnabled}
 	ctx, _ := context.WithCancel(context.TODO())
 	agent := &ecsAgent{
 		ctx:                ctx,

--- a/agent/app/agent_windows_test.go
+++ b/agent/app/agent_windows_test.go
@@ -278,7 +278,7 @@ func TestDoStartTaskLimitsFail(t *testing.T) {
 	defer ctrl.Finish()
 
 	cfg := getTestConfig()
-	cfg.Checkpoint = true
+	cfg.Checkpoint = config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled}
 	cfg.TaskCPUMemLimit.Value = config.ExplicitlyEnabled
 	ctx, cancel := context.WithCancel(context.TODO())
 	// Cancel the context to cancel async routines

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -516,7 +516,7 @@ func environmentConfig() (Config, error) {
 		Checkpoint:                          parseCheckpoint(dataDir),
 		EngineAuthType:                      os.Getenv("ECS_ENGINE_AUTH_TYPE"),
 		EngineAuthData:                      NewSensitiveRawMessage([]byte(os.Getenv("ECS_ENGINE_AUTH_DATA"))),
-		UpdatesEnabled:                      utils.ParseBool(os.Getenv("ECS_UPDATES_ENABLED"), false),
+		UpdatesEnabled:                      parseBooleanDefaultFalseConfig("ECS_UPDATES_ENABLED"),
 		UpdateDownloadDir:                   os.Getenv("ECS_UPDATE_DOWNLOAD_DIR"),
 		DisableMetrics:                      utils.ParseBool(os.Getenv("ECS_DISABLE_METRICS"), false),
 		ReservedMemory:                      parseEnvVariableUint16("ECS_RESERVED_MEMORY"),

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -271,21 +271,21 @@ func TestDefaultPollMetricsWithoutECSDataDir(t *testing.T) {
 func TestDefaultCheckpointWithoutECSDataDir(t *testing.T) {
 	conf, err := environmentConfig()
 	assert.NoError(t, err)
-	assert.False(t, conf.Checkpoint)
+	assert.False(t, conf.Checkpoint.Enabled())
 }
 
 func TestDefaultCheckpointWithECSDataDir(t *testing.T) {
 	defer setTestEnv("ECS_DATADIR", "/some/dir")()
 	conf, err := environmentConfig()
 	assert.NoError(t, err)
-	assert.True(t, conf.Checkpoint)
+	assert.True(t, conf.Checkpoint.Enabled())
 }
 
 func TestCheckpointWithoutECSDataDir(t *testing.T) {
 	defer setTestEnv("ECS_CHECKPOINT", "true")()
 	conf, err := environmentConfig()
 	assert.NoError(t, err)
-	assert.True(t, conf.Checkpoint)
+	assert.True(t, conf.Checkpoint.Enabled())
 }
 
 func TestInvalidFormatDockerStopTimeout(t *testing.T) {

--- a/agent/config/config_unix.go
+++ b/agent/config/config_unix.go
@@ -93,7 +93,7 @@ func (cfg *Config) platformOverrides() {
 	}
 
 	if cfg.TaskENIEnabled { // when task networking is enabled, eni trunking is enabled by default
-		cfg.ENITrunkingEnabled = utils.ParseBool(os.Getenv("ECS_ENABLE_HIGH_DENSITY_ENI"), true)
+		cfg.ENITrunkingEnabled = parseBooleanDefaultTrueConfig("ECS_ENABLE_HIGH_DENSITY_ENI")
 	}
 }
 

--- a/agent/config/config_unix_test.go
+++ b/agent/config/config_unix_test.go
@@ -201,7 +201,7 @@ func TestENITrunkingEnabled(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg.platformOverrides()
-	assert.True(t, cfg.ENITrunkingEnabled, "ENI trunking should be enabled")
+	assert.True(t, cfg.ENITrunkingEnabled.Enabled(), "ENI trunking should be enabled")
 }
 
 // TestENITrunkingDisabled tests that when task networking is enabled, eni trunking can be disabled
@@ -213,7 +213,7 @@ func TestENITrunkingDisabled(t *testing.T) {
 
 	defer setTestEnv("ECS_ENABLE_HIGH_DENSITY_ENI", "false")()
 	cfg.platformOverrides()
-	assert.False(t, cfg.ENITrunkingEnabled, "ENI trunking should be disabled")
+	assert.False(t, cfg.ENITrunkingEnabled.Enabled(), "ENI trunking should be disabled")
 }
 
 // setupFileConfiguration create a temp file store the configuration

--- a/agent/config/parse.go
+++ b/agent/config/parse.go
@@ -23,20 +23,23 @@ import (
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient"
-	"github.com/aws/amazon-ecs-agent/agent/utils"
 	"github.com/cihub/seelog"
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 )
 
-func parseCheckpoint(dataDir string) bool {
-	var checkPoint bool
+func parseCheckpoint(dataDir string) BooleanDefaultFalse {
+	checkPoint := parseBooleanDefaultFalseConfig("ECS_CHECKPOINT")
 	if dataDir != "" {
 		// if we have a directory to checkpoint to, default it to be on
-		checkPoint = utils.ParseBool(os.Getenv("ECS_CHECKPOINT"), true)
+		if checkPoint.Value == NotSet {
+			checkPoint.Value = ExplicitlyEnabled
+		}
 	} else {
 		// if the directory is not set, default to checkpointing off for
 		// backwards compatibility
-		checkPoint = utils.ParseBool(os.Getenv("ECS_CHECKPOINT"), false)
+		if checkPoint.Value == NotSet {
+			checkPoint.Value = ExplicitlyDisabled
+		}
 	}
 	return checkPoint
 }

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -161,7 +161,7 @@ type Config struct {
 
 	// ENITrunkingEnabled specifies if the Agent is enabled to launch awsvpc
 	// task with ENI Trunking
-	ENITrunkingEnabled bool
+	ENITrunkingEnabled BooleanDefaultTrue
 
 	// ImageCleanupDisabled specifies whether the Agent will periodically perform
 	// automated image cleanup

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -68,7 +68,7 @@ type Config struct {
 	// Checkpoint configures whether data should be periodically to a checkpoint
 	// file, in DataDir, such that on instance or agent restarts it will resume
 	// as the same ContainerInstance. It defaults to false.
-	Checkpoint bool
+	Checkpoint BooleanDefaultFalse
 
 	// EngineAuthType configures what type of data is in EngineAuthData.
 	// Supported types, right now, can be found in the dockerauth package: https://godoc.org/github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerauth

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -79,7 +79,7 @@ type Config struct {
 
 	// UpdatesEnabled specifies whether updates should be applied to this agent.
 	// Default true
-	UpdatesEnabled bool
+	UpdatesEnabled BooleanDefaultFalse
 	// UpdateDownloadDir specifies where new agent versions should be placed
 	// within the container in order for the external updating process to
 	// correctly handle them.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
migrating more boolean configs to use new type:
config.ENITrunkingEnabled (ECS_ENABLE_HIGH_DENSITY_ENI) to BooleanDefaultTrue
config.Checkpoint (ECS_CHECKPOINT) to BooleanDefaultFalse
config.UpdatesEnabled (ECS_UPDATES_ENABLED) to BooleanDefaultFalse

### Implementation details
in place refactoring

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Existing tests have been updated to use the new type 

New tests cover the changes: N/A

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
