### PR TITLE
Fix Telemetry model to include per second network stats metrics

### DIFF
--- a/agent/tcs/model/api/api-2.json
+++ b/agent/tcs/model/api/api-2.json
@@ -198,16 +198,16 @@
     "NetworkStatsSet":{
       "type":"structure",
       "members":{
+        "rxBytesPerSecond":{"shape":"UDoubleCWStatsSet"},
         "rxBytes":{"shape":"ULongStatsSet"},
         "rxDropped":{"shape":"ULongStatsSet"},
         "rxErrors":{"shape":"ULongStatsSet"},
         "rxPackets":{"shape":"ULongStatsSet"},
+        "txBytesPerSecond":{"shape":"UDoubleCWStatsSet"},
         "txBytes":{"shape":"ULongStatsSet"},
         "txDropped":{"shape":"ULongStatsSet"},
         "txErrors":{"shape":"ULongStatsSet"},
-        "txPackets":{"shape":"ULongStatsSet"},
-        "txBytesPerSecond":{"shape":"CWStatsSet"},
-        "rxBytesPerSecond":{"shape":"CWStatsSet"}
+        "txPackets":{"shape":"ULongStatsSet"}
       }
     },
     "PublishHealthRequest":{
@@ -289,6 +289,25 @@
       "max":10
     },
     "Timestamp":{"type":"timestamp"},
+    "UDouble":{
+      "type":"double",
+      "min":0
+    },
+    "UDoubleCWStatsSet":{
+      "type":"structure",
+      "required":[
+        "min",
+        "max",
+        "sampleCount",
+        "sum"
+      ],
+      "members":{
+        "min":{"shape":"UDouble"},
+        "max":{"shape":"UDouble"},
+        "sampleCount":{"shape":"UInteger"},
+        "sum":{"shape":"UDouble"}
+      }
+    },
     "UInteger":{
       "type":"integer",
       "min":0

--- a/agent/tcs/model/ecstcs/api.go
+++ b/agent/tcs/model/ecstcs/api.go
@@ -272,6 +272,8 @@ type NetworkStatsSet struct {
 
 	RxBytes *ULongStatsSet `locationName:"rxBytes" type:"structure"`
 
+	RxBytesPerSecond *UDoubleCWStatsSet `locationName:"rxBytesPerSecond" type:"structure"`
+
 	RxDropped *ULongStatsSet `locationName:"rxDropped" type:"structure"`
 
 	RxErrors *ULongStatsSet `locationName:"rxErrors" type:"structure"`
@@ -280,15 +282,13 @@ type NetworkStatsSet struct {
 
 	TxBytes *ULongStatsSet `locationName:"txBytes" type:"structure"`
 
+	TxBytesPerSecond *UDoubleCWStatsSet `locationName:"txBytesPerSecond" type:"structure"`
+
 	TxDropped *ULongStatsSet `locationName:"txDropped" type:"structure"`
 
 	TxErrors *ULongStatsSet `locationName:"txErrors" type:"structure"`
 
 	TxPackets *ULongStatsSet `locationName:"txPackets" type:"structure"`
-
-	RxBytesPerSecond *CWStatsSet `locationName:"rxBytesPerSecond" type:"structure"`
-
-	TxBytesPerSecond *CWStatsSet `locationName:"txBytesPerSecond" type:"structure"`
 }
 
 // String returns the string representation
@@ -307,6 +307,11 @@ func (s *NetworkStatsSet) Validate() error {
 	if s.RxBytes != nil {
 		if err := s.RxBytes.Validate(); err != nil {
 			invalidParams.AddNested("RxBytes", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.RxBytesPerSecond != nil {
+		if err := s.RxBytesPerSecond.Validate(); err != nil {
+			invalidParams.AddNested("RxBytesPerSecond", err.(request.ErrInvalidParams))
 		}
 	}
 	if s.RxDropped != nil {
@@ -329,6 +334,11 @@ func (s *NetworkStatsSet) Validate() error {
 			invalidParams.AddNested("TxBytes", err.(request.ErrInvalidParams))
 		}
 	}
+	if s.TxBytesPerSecond != nil {
+		if err := s.TxBytesPerSecond.Validate(); err != nil {
+			invalidParams.AddNested("TxBytesPerSecond", err.(request.ErrInvalidParams))
+		}
+	}
 	if s.TxDropped != nil {
 		if err := s.TxDropped.Validate(); err != nil {
 			invalidParams.AddNested("TxDropped", err.(request.ErrInvalidParams))
@@ -342,16 +352,6 @@ func (s *NetworkStatsSet) Validate() error {
 	if s.TxPackets != nil {
 		if err := s.TxPackets.Validate(); err != nil {
 			invalidParams.AddNested("TxPackets", err.(request.ErrInvalidParams))
-		}
-	}
-	if s.RxBytesPerSecond != nil {
-		if err := s.TxPackets.Validate(); err != nil {
-			invalidParams.AddNested("RxBytesPerSecond", err.(request.ErrInvalidParams))
-		}
-	}
-	if s.TxBytesPerSecond != nil {
-		if err := s.TxPackets.Validate(); err != nil {
-			invalidParams.AddNested("TxBytesPerSecond", err.(request.ErrInvalidParams))
 		}
 	}
 
@@ -687,6 +687,54 @@ func (s *TaskMetric) Validate() error {
 				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "ContainerMetrics", i), err.(request.ErrInvalidParams))
 			}
 		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+type UDoubleCWStatsSet struct {
+	_ struct{} `type:"structure"`
+
+	// Max is a required field
+	Max *float64 `locationName:"max" type:"double" required:"true"`
+
+	// Min is a required field
+	Min *float64 `locationName:"min" type:"double" required:"true"`
+
+	// SampleCount is a required field
+	SampleCount *int64 `locationName:"sampleCount" type:"integer" required:"true"`
+
+	// Sum is a required field
+	Sum *float64 `locationName:"sum" type:"double" required:"true"`
+}
+
+// String returns the string representation
+func (s UDoubleCWStatsSet) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UDoubleCWStatsSet) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UDoubleCWStatsSet) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UDoubleCWStatsSet"}
+	if s.Max == nil {
+		invalidParams.Add(request.NewErrParamRequired("Max"))
+	}
+	if s.Min == nil {
+		invalidParams.Add(request.NewErrParamRequired("Min"))
+	}
+	if s.SampleCount == nil {
+		invalidParams.Add(request.NewErrParamRequired("SampleCount"))
+	}
+	if s.Sum == nil {
+		invalidParams.Add(request.NewErrParamRequired("Sum"))
 	}
 
 	if invalidParams.Len() > 0 {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This PR fixes the telemetry model for Network stats per sec metrics.

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
