### PR TITLE
Save all state to boltdb in termination handler

### DIFF
--- a/agent/acs/handler/acs_handler.go
+++ b/agent/acs/handler/acs_handler.go
@@ -340,7 +340,7 @@ func (acsSession *session) startACSSession(client wsclient.ClientServer) error {
 	// Ignore heartbeat messages; anyMessageHandler gets 'em
 	client.AddRequestHandler(func(*ecsacs.HeartbeatMessage) {})
 
-	updater.AddAgentUpdateHandlers(client, cfg, acsSession.stateManager, acsSession.taskEngine)
+	updater.AddAgentUpdateHandlers(client, cfg, acsSession.state, acsSession.dataClient, acsSession.taskEngine)
 
 	err := client.Connect()
 	if err != nil {

--- a/agent/acs/update_handler/updater_test.go
+++ b/agent/acs/update_handler/updater_test.go
@@ -26,18 +26,19 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
 	"github.com/aws/amazon-ecs-agent/agent/acs/model/ecsacs"
 	mock_io "github.com/aws/amazon-ecs-agent/agent/acs/update_handler/mock"
 	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/data"
 	"github.com/aws/amazon-ecs-agent/agent/engine"
+	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/httpclient"
 	mock_http "github.com/aws/amazon-ecs-agent/agent/httpclient/mock"
-	"github.com/aws/amazon-ecs-agent/agent/statemanager"
 	mock_client "github.com/aws/amazon-ecs-agent/agent/wsclient/mock"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func ptr(i interface{}) interface{} {
@@ -137,7 +138,7 @@ func TestPerformUpdateWithUpdatesDisabled(t *testing.T) {
 		},
 	}
 
-	u.performUpdateHandler(statemanager.NewNoopStateManager(), taskEngine)(msg)
+	u.performUpdateHandler(dockerstate.NewTaskEngineState(), data.NewNoopClient(), taskEngine)(msg)
 }
 
 func TestFullUpdateFlow(t *testing.T) {
@@ -191,7 +192,7 @@ func TestFullUpdateFlow(t *testing.T) {
 				},
 			}
 
-			u.performUpdateHandler(statemanager.NewNoopStateManager(), taskEngine)(msg)
+			u.performUpdateHandler(dockerstate.NewTaskEngineState(), data.NewNoopClient(), taskEngine)(msg)
 		})
 	}
 }
@@ -255,7 +256,7 @@ func TestUndownloadedUpdate(t *testing.T) {
 		MessageId:            ptr("mid").(*string),
 	}
 
-	u.performUpdateHandler(statemanager.NewNoopStateManager(), taskEngine)(msg)
+	u.performUpdateHandler(dockerstate.NewTaskEngineState(), data.NewNoopClient(), taskEngine)(msg)
 }
 
 func TestDuplicateUpdateMessagesWithSuccess(t *testing.T) {
@@ -317,7 +318,7 @@ func TestDuplicateUpdateMessagesWithSuccess(t *testing.T) {
 		},
 	}
 
-	u.performUpdateHandler(statemanager.NewNoopStateManager(), taskEngine)(msg)
+	u.performUpdateHandler(dockerstate.NewTaskEngineState(), data.NewNoopClient(), taskEngine)(msg)
 }
 
 func TestDuplicateUpdateMessagesWithFailure(t *testing.T) {
@@ -386,7 +387,7 @@ func TestDuplicateUpdateMessagesWithFailure(t *testing.T) {
 		},
 	}
 
-	u.performUpdateHandler(statemanager.NewNoopStateManager(), taskEngine)(msg)
+	u.performUpdateHandler(dockerstate.NewTaskEngineState(), data.NewNoopClient(), taskEngine)(msg)
 }
 
 func TestNewerUpdateMessages(t *testing.T) {
@@ -457,7 +458,7 @@ func TestNewerUpdateMessages(t *testing.T) {
 		},
 	}
 
-	u.performUpdateHandler(statemanager.NewNoopStateManager(), taskEngine)(msg)
+	u.performUpdateHandler(dockerstate.NewTaskEngineState(), data.NewNoopClient(), taskEngine)(msg)
 }
 
 func TestValidationError(t *testing.T) {

--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -639,7 +639,7 @@ func (agent *ecsAgent) startAsyncRoutines(
 		go agent.startSpotInstanceDrainingPoller(agent.ctx, client)
 	}
 
-	go agent.terminationHandler(stateManager, taskEngine, agent.cancel)
+	go agent.terminationHandler(state, agent.dataClient, taskEngine, agent.cancel)
 
 	// Agent introspection api
 	go handlers.ServeIntrospectionHTTPEndpoint(agent.ctx, &agent.containerInstanceARN, taskEngine, agent.cfg)

--- a/agent/app/agent_test.go
+++ b/agent/app/agent_test.go
@@ -25,8 +25,6 @@ import (
 	"sync"
 	"testing"
 
-	mock_pause "github.com/aws/amazon-ecs-agent/agent/eni/pause/mocks"
-
 	apierrors "github.com/aws/amazon-ecs-agent/agent/api/errors"
 	mock_api "github.com/aws/amazon-ecs-agent/agent/api/mocks"
 	mock_factory "github.com/aws/amazon-ecs-agent/agent/app/factory/mocks"
@@ -41,8 +39,10 @@ import (
 	mock_ec2 "github.com/aws/amazon-ecs-agent/agent/ec2/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
 	"github.com/aws/amazon-ecs-agent/agent/engine"
+	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	mock_dockerstate "github.com/aws/amazon-ecs-agent/agent/engine/dockerstate/mocks"
 	mock_engine "github.com/aws/amazon-ecs-agent/agent/engine/mocks"
+	mock_pause "github.com/aws/amazon-ecs-agent/agent/eni/pause/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
 	"github.com/aws/amazon-ecs-agent/agent/sighandlers/exitcodes"
 	"github.com/aws/amazon-ecs-agent/agent/statemanager"
@@ -404,15 +404,16 @@ func TestDoStartHappyPath(t *testing.T) {
 
 	// Cancel the context to cancel async routines
 	agent := &ecsAgent{
-		ctx:                   ctx,
-		cfg:                   &cfg,
-		dockerClient:          dockerClient,
-		dataClient:            dataClient,
-		pauseLoader:           mockPauseLoader,
-		credentialProvider:    aws_credentials.NewCredentials(mockCredentialsProvider),
-		mobyPlugins:           mockMobyPlugins,
-		metadataManager:       containermetadata,
-		terminationHandler:    func(saver statemanager.Saver, taskEngine engine.TaskEngine, cancel context.CancelFunc) {},
+		ctx:                ctx,
+		cfg:                &cfg,
+		dockerClient:       dockerClient,
+		dataClient:         dataClient,
+		pauseLoader:        mockPauseLoader,
+		credentialProvider: aws_credentials.NewCredentials(mockCredentialsProvider),
+		mobyPlugins:        mockMobyPlugins,
+		metadataManager:    containermetadata,
+		terminationHandler: func(taskEngineState dockerstate.TaskEngineState, dataClient data.Client, taskEngine engine.TaskEngine, cancel context.CancelFunc) {
+		},
 		stateManagerFactory:   stateManagerFactory,
 		ec2MetadataClient:     ec2MetadataClient,
 		saveableOptionFactory: saveableOptionFactory,

--- a/agent/app/agent_unix_test.go
+++ b/agent/app/agent_unix_test.go
@@ -24,22 +24,24 @@ import (
 
 	app_mocks "github.com/aws/amazon-ecs-agent/agent/app/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/data"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	mock_ec2 "github.com/aws/amazon-ecs-agent/agent/ec2/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
 	"github.com/aws/amazon-ecs-agent/agent/ecscni"
 	mock_ecscni "github.com/aws/amazon-ecs-agent/agent/ecscni/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/engine"
+	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	mock_dockerstate "github.com/aws/amazon-ecs-agent/agent/engine/dockerstate/mocks"
 	mock_engine "github.com/aws/amazon-ecs-agent/agent/engine/mocks"
 	mock_pause "github.com/aws/amazon-ecs-agent/agent/eni/pause/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
 	mock_gpu "github.com/aws/amazon-ecs-agent/agent/gpu/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/sighandlers/exitcodes"
-	"github.com/aws/amazon-ecs-agent/agent/statemanager"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/cgroup/control/mock_control"
 	mock_mobypkgwrapper "github.com/aws/amazon-ecs-agent/agent/utils/mobypkgwrapper/mocks"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -154,8 +156,9 @@ func TestDoStartTaskENIHappyPath(t *testing.T) {
 		pauseLoader:        mockPauseLoader,
 		cniClient:          cniClient,
 		ec2MetadataClient:  mockMetadata,
-		terminationHandler: func(saver statemanager.Saver, taskEngine engine.TaskEngine, cancel context.CancelFunc) {},
-		mobyPlugins:        mockMobyPlugins,
+		terminationHandler: func(state dockerstate.TaskEngineState, dataClient data.Client, taskEngine engine.TaskEngine, cancel context.CancelFunc) {
+		},
+		mobyPlugins: mockMobyPlugins,
 	}
 
 	getPid = func() int {
@@ -469,9 +472,10 @@ func TestDoStartCgroupInitHappyPath(t *testing.T) {
 		credentialProvider: credentials.NewCredentials(mockCredentialsProvider),
 		pauseLoader:        mockPauseLoader,
 		dockerClient:       dockerClient,
-		terminationHandler: func(saver statemanager.Saver, taskEngine engine.TaskEngine, cancel context.CancelFunc) {},
-		mobyPlugins:        mockMobyPlugins,
-		ec2MetadataClient:  ec2MetadataClient,
+		terminationHandler: func(state dockerstate.TaskEngineState, dataClient data.Client, taskEngine engine.TaskEngine, cancel context.CancelFunc) {
+		},
+		mobyPlugins:       mockMobyPlugins,
+		ec2MetadataClient: ec2MetadataClient,
 		resourceFields: &taskresource.ResourceFields{
 			Control: mockControl,
 		},
@@ -526,7 +530,8 @@ func TestDoStartCgroupInitErrorPath(t *testing.T) {
 		credentialProvider: credentials.NewCredentials(mockCredentialsProvider),
 		dockerClient:       dockerClient,
 		pauseLoader:        mockPauseLoader,
-		terminationHandler: func(saver statemanager.Saver, taskEngine engine.TaskEngine, cancel context.CancelFunc) {},
+		terminationHandler: func(state dockerstate.TaskEngineState, dataClient data.Client, taskEngine engine.TaskEngine, cancel context.CancelFunc) {
+		},
 		resourceFields: &taskresource.ResourceFields{
 			Control: mockControl,
 		},
@@ -616,9 +621,10 @@ func TestDoStartGPUManagerHappyPath(t *testing.T) {
 		credentialProvider: credentials.NewCredentials(mockCredentialsProvider),
 		dockerClient:       dockerClient,
 		pauseLoader:        mockPauseLoader,
-		terminationHandler: func(saver statemanager.Saver, taskEngine engine.TaskEngine, cancel context.CancelFunc) {},
-		mobyPlugins:        mockMobyPlugins,
-		ec2MetadataClient:  ec2MetadataClient,
+		terminationHandler: func(state dockerstate.TaskEngineState, dataClient data.Client, taskEngine engine.TaskEngine, cancel context.CancelFunc) {
+		},
+		mobyPlugins:       mockMobyPlugins,
+		ec2MetadataClient: ec2MetadataClient,
 		resourceFields: &taskresource.ResourceFields{
 			NvidiaGPUManager: mockGPUManager,
 		},
@@ -671,7 +677,8 @@ func TestDoStartGPUManagerInitError(t *testing.T) {
 		credentialProvider: credentials.NewCredentials(mockCredentialsProvider),
 		dockerClient:       dockerClient,
 		pauseLoader:        mockPauseLoader,
-		terminationHandler: func(saver statemanager.Saver, taskEngine engine.TaskEngine, cancel context.CancelFunc) {},
+		terminationHandler: func(state dockerstate.TaskEngineState, dataClient data.Client, taskEngine engine.TaskEngine, cancel context.CancelFunc) {
+		},
 		resourceFields: &taskresource.ResourceFields{
 			NvidiaGPUManager: mockGPUManager,
 		},
@@ -719,8 +726,9 @@ func TestDoStartTaskENIPauseError(t *testing.T) {
 		pauseLoader:        mockPauseLoader,
 		cniClient:          cniClient,
 		ec2MetadataClient:  mockMetadata,
-		terminationHandler: func(saver statemanager.Saver, taskEngine engine.TaskEngine, cancel context.CancelFunc) {},
-		mobyPlugins:        mockMobyPlugins,
+		terminationHandler: func(state dockerstate.TaskEngineState, dataClient data.Client, taskEngine engine.TaskEngine, cancel context.CancelFunc) {
+		},
+		mobyPlugins: mockMobyPlugins,
 	}
 
 	status := agent.doStart(eventstream.NewEventStream("events", ctx),

--- a/agent/engine/data.go
+++ b/agent/engine/data.go
@@ -88,13 +88,13 @@ func (engine *DockerTaskEngine) removeENIAttachmentData(mac string) {
 func (imageManager *dockerImageManager) saveImageStateData(imageState *image.ImageState) {
 	err := imageManager.dataClient.SaveImageState(imageState)
 	if err != nil {
-		seelog.Errorf("Failed to save data for image state: %s, %v", imageState.GetImageID(), err)
+		seelog.Errorf("Failed to save data for image state %s:, %v", imageState.GetImageID(), err)
 	}
 }
 
 func (imageManager *dockerImageManager) removeImageStateData(imageId string) {
 	err := imageManager.dataClient.DeleteImageState(imageId)
 	if err != nil {
-		seelog.Errorf("Failed to remove data for image state: %s, %v", imageId, err)
+		seelog.Errorf("Failed to remove data for image state %s:, %v", imageId, err)
 	}
 }

--- a/agent/sighandlers/termination_handler.go
+++ b/agent/sighandlers/termination_handler.go
@@ -27,9 +27,10 @@ import (
 	"time"
 
 	apierrors "github.com/aws/amazon-ecs-agent/agent/api/errors"
+	"github.com/aws/amazon-ecs-agent/agent/data"
 	"github.com/aws/amazon-ecs-agent/agent/engine"
+	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/sighandlers/exitcodes"
-	"github.com/aws/amazon-ecs-agent/agent/statemanager"
 
 	"github.com/cihub/seelog"
 )
@@ -40,10 +41,10 @@ const (
 )
 
 // TerminationHandler defines a handler used for terminating the agent
-type TerminationHandler func(saver statemanager.Saver, taskEngine engine.TaskEngine, cancel context.CancelFunc)
+type TerminationHandler func(state dockerstate.TaskEngineState, dataClient data.Client, taskEngine engine.TaskEngine, cancel context.CancelFunc)
 
 // StartDefaultTerminationHandler defines a default termination handler suitable for running in a process
-func StartDefaultTerminationHandler(saver statemanager.Saver, taskEngine engine.TaskEngine, cancel context.CancelFunc) {
+func StartDefaultTerminationHandler(state dockerstate.TaskEngineState, dataClient data.Client, taskEngine engine.TaskEngine, cancel context.CancelFunc) {
 	// when we receive a termination signal, first save the state, then
 	// cancel the agent's context so other goroutines can exit cleanly.
 	signalC := make(chan os.Signal, 2)
@@ -52,7 +53,7 @@ func StartDefaultTerminationHandler(saver statemanager.Saver, taskEngine engine.
 	sig := <-signalC
 	seelog.Infof("Agent received termination signal: %s", sig.String())
 
-	err := FinalSave(saver, taskEngine)
+	err := FinalSave(state, dataClient, taskEngine)
 	if err != nil {
 		seelog.Criticalf("Error saving state before final shutdown: %v", err)
 		// Terminal because it's a sigterm; the user doesn't want it to restart
@@ -65,7 +66,7 @@ func StartDefaultTerminationHandler(saver statemanager.Saver, taskEngine engine.
 // exiting, in order to flush tasks to disk. It waits a short timeout for state
 // to settle if necessary. If unable to reach a steady-state and save within
 // this short timeout, it returns an error
-func FinalSave(saver statemanager.Saver, taskEngine engine.TaskEngine) error {
+func FinalSave(state dockerstate.TaskEngineState, dataClient data.Client, taskEngine engine.TaskEngine) error {
 	engineDisabled := make(chan error)
 
 	disableTimer := time.AfterFunc(engineDisableTimeout, func() {
@@ -87,8 +88,9 @@ func FinalSave(saver statemanager.Saver, taskEngine engine.TaskEngine) error {
 	})
 	go func() {
 		seelog.Debug("Saving state before shutting down")
-		stateSaved <- saver.ForceSave()
+		saveStateAll(state, dataClient)
 		saveTimer.Stop()
+		stateSaved <- nil
 	}()
 
 	saveErr := <-stateSaved
@@ -97,4 +99,38 @@ func FinalSave(saver statemanager.Saver, taskEngine engine.TaskEngine) error {
 		return apierrors.NewMultiError(disableErr, saveErr)
 	}
 	return nil
+}
+
+func saveStateAll(state dockerstate.TaskEngineState, dataClient data.Client) {
+	// save all tasks state data
+	for _, task := range state.AllTasks() {
+		if err := dataClient.SaveTask(task); err != nil {
+			seelog.Errorf("Failed to save data for task %s: %v", task.Arn, err)
+		}
+	}
+
+	// save all container and docker container state data
+	for _, containerId := range state.GetAllContainerIDs() {
+		container, ok := state.ContainerByID(containerId)
+		if !ok {
+			seelog.Errorf("Unable to find container for %s", containerId)
+		}
+		if err := dataClient.SaveDockerContainer(container); err != nil {
+			seelog.Errorf("Failed to save data for docker container %s: %v", container.Container.Name, err)
+		}
+	}
+
+	// save all image state data
+	for _, imageState := range state.AllImageStates() {
+		if err := dataClient.SaveImageState(imageState); err != nil {
+			seelog.Errorf("Failed to save data for image state %s:, %v", imageState.GetImageID(), err)
+		}
+	}
+
+	// save all eni attachment data
+	for _, eniAttachment := range state.AllENIAttachments() {
+		if err := dataClient.SaveENIAttachment(eniAttachment); err != nil {
+			seelog.Errorf("Failed to save data for eni attachment %s: %v", eniAttachment.AttachmentARN, err)
+		}
+	}
 }

--- a/agent/sighandlers/termination_handler_test.go
+++ b/agent/sighandlers/termination_handler_test.go
@@ -1,0 +1,113 @@
+// +build unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sighandlers
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	apieni "github.com/aws/amazon-ecs-agent/agent/api/eni"
+	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
+	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/data"
+	"github.com/aws/amazon-ecs-agent/agent/engine"
+	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
+	"github.com/aws/amazon-ecs-agent/agent/engine/image"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	imageId          = "test-imageId"
+	taskARN          = "arn:aws:ecs:region:account-id:task/task-id"
+	eniAttachmentArn = "arn:aws:ecs:us-west-2:1234567890:attachment/abc"
+)
+
+func TestFinalSave(t *testing.T) {
+	dataClient, cleanup := newTestDataClient(t)
+	defer cleanup()
+
+	state := dockerstate.NewTaskEngineState()
+	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil,
+		nil, nil, state, nil, nil)
+
+	task := &apitask.Task{
+		Arn:     taskARN,
+		Family:  "test",
+		Version: "1",
+	}
+
+	dockerContainer := &apicontainer.DockerContainer{
+		DockerID:   "docker-id",
+		DockerName: "docker-name",
+		Container: &apicontainer.Container{
+			Name:    "container-name",
+			TaskARN: taskARN,
+		},
+	}
+
+	eniAttachment := &apieni.ENIAttachment{
+		TaskARN:          taskARN,
+		AttachmentARN:    eniAttachmentArn,
+		AttachStatusSent: false,
+	}
+	imageState := &image.ImageState{
+		Image: &image.Image{
+			ImageID: imageId,
+		},
+		PullSucceeded: false,
+	}
+
+	state.AddTask(task)
+	state.AddContainer(dockerContainer, task)
+	state.AddImageState(imageState)
+	state.AddENIAttachment(eniAttachment)
+
+	assert.NoError(t, FinalSave(state, dataClient, taskEngine))
+
+	// check if all states are saved to db on FinalSave
+	tasks, err := dataClient.GetTasks()
+	assert.NoError(t, err)
+	assert.Len(t, tasks, 1)
+
+	dockerContainers, err := dataClient.GetContainers()
+	assert.NoError(t, err)
+	assert.Len(t, dockerContainers, 1)
+
+	attachments, err := dataClient.GetENIAttachments()
+	assert.NoError(t, err)
+	assert.Len(t, attachments, 1)
+
+	imageStates, err := dataClient.GetImageStates()
+	assert.NoError(t, err)
+	assert.Len(t, imageStates, 1)
+}
+
+func newTestDataClient(t *testing.T) (data.Client, func()) {
+	testDir, err := ioutil.TempDir("", "termination_handler_unit_test")
+	require.NoError(t, err)
+
+	testClient, err := data.NewWithSetup(testDir)
+
+	cleanup := func() {
+		require.NoError(t, testClient.Close())
+		require.NoError(t, os.RemoveAll(testDir))
+	}
+	return testClient, cleanup
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Save all state to boltdb before agent exits in termination handler
### Implementation details
<!-- How are the changes implemented? -->
 `signalhandlers/termination_handlers`: In FinalSave, using saveStateAll to save the states to boltdb instead of statemanager.
Updated function calls and tests in `acs` and `app` accordignly
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes
`make test` passes and manually tested too
### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
