### PR TITLE
Bug Fix: fix V4 metadata endpoint displaying network rate metrics for…

### DIFF
--- a/agent/stats/engine.go
+++ b/agent/stats/engine.go
@@ -756,6 +756,7 @@ func (engine *DockerStatsEngine) ContainerDockerStats(taskARN string, containerI
 		return nil, nil, errors.Errorf("stats engine: container not found: %s", containerID)
 	}
 	containerStats := container.statsQueue.GetLastStat()
+	containerNetworkRateStats := container.statsQueue.GetLastNetworkStatPerSec()
 
 	// Insert network stats in container stats
 	task, err := engine.resolver.ResolveTaskByARN(taskARN)
@@ -769,10 +770,11 @@ func (engine *DockerStatsEngine) ContainerDockerStats(taskARN string, containerI
 		if ok {
 			taskNetworkStats := taskStats.StatsQueue.GetLastStat().Networks
 			containerStats.Networks = taskNetworkStats
+			containerNetworkRateStats = taskStats.StatsQueue.GetLastNetworkStatPerSec()
 		} else {
 			seelog.Warnf("Network stats not found for container %s", containerID)
 		}
 	}
 
-	return containerStats, container.statsQueue.GetLastNetworkStatPerSec(), nil
+	return containerStats, containerNetworkRateStats, nil
 }


### PR DESCRIPTION
… awsvpc mode

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This PR fixes a big for V4 metadata endpoint exposing network rate metrics for awsvpc network mode. Initially it was accessing container stats queue. But for awsvpc mode, we should access the task stats queue.

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->


Tested after running a task with awsvpc network mode and checked that v4 metadata endpoint is dispaying the network rate metrics

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
