### PR TITLE
Add method for task engine to load state from boltdb

### DIFF
--- a/agent/engine/data.go
+++ b/agent/engine/data.go
@@ -21,7 +21,101 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 
 	"github.com/cihub/seelog"
+	"github.com/pkg/errors"
 )
+
+// LoadState populates the task engine state with data in db.
+func (engine *DockerTaskEngine) LoadState() error {
+	if err := engine.loadTasks(); err != nil {
+		return err
+	}
+
+	if err := engine.loadContainers(); err != nil {
+		return err
+	}
+
+	if err := engine.loadImageStates(); err != nil {
+		return err
+	}
+
+	return engine.loadENIAttachments()
+}
+
+func (engine *DockerTaskEngine) loadTasks() error {
+	tasks, err := engine.dataClient.GetTasks()
+	if err != nil {
+		return err
+	}
+
+	for _, task := range tasks {
+		engine.state.AddTask(task)
+	}
+	return nil
+}
+
+func (engine *DockerTaskEngine) loadContainers() error {
+	containers, err := engine.dataClient.GetContainers()
+	if err != nil {
+		return err
+	}
+
+	for _, container := range containers {
+		task, ok := engine.state.TaskByArn(container.Container.TaskARN)
+		if !ok {
+			// A task is saved to task table before its containers saved to container table. It is not expected
+			// that we have a container from container table whose task is not in the task table.
+			return errors.Errorf("did not find the task of container %s: %s", container.Container.Name,
+				container.Container.TaskARN)
+		}
+		engine.state.AddContainer(container, task)
+	}
+
+	// Update containers in task from data in container table. It stores more updated data of container
+	// than the task table.
+	tasks := engine.state.AllTasks()
+	for _, task := range tasks {
+		dockerContainers, ok := engine.state.ContainerMapByArn(task.Arn)
+		if !ok {
+			// A task's container map contains containers loaded from container table. It is ok
+			// that there isn't any container in the map, because we first save a container to container table
+			// when finished a transition on it, and before that the container is just stored as part of the task.
+			continue
+		}
+
+		for idx, container := range task.Containers {
+			for _, dockerContainer := range dockerContainers {
+				if container.Name == dockerContainer.Container.Name {
+					task.Containers[idx] = dockerContainer.Container
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (engine *DockerTaskEngine) loadImageStates() error {
+	images, err := engine.dataClient.GetImageStates()
+	if err != nil {
+		return err
+	}
+
+	for _, image := range images {
+		engine.state.AddImageState(image)
+	}
+	return nil
+}
+
+func (engine *DockerTaskEngine) loadENIAttachments() error {
+	eniAttachments, err := engine.dataClient.GetENIAttachments()
+	if err != nil {
+		return err
+	}
+
+	for _, eniAttachment := range eniAttachments {
+		engine.state.AddENIAttachment(eniAttachment)
+	}
+	return nil
+}
 
 func (engine *DockerTaskEngine) saveTaskData(task *apitask.Task) {
 	err := engine.dataClient.SaveTask(task)

--- a/agent/engine/interface.go
+++ b/agent/engine/interface.go
@@ -53,6 +53,9 @@ type TaskEngine interface {
 
 	Version() (string, error)
 
+	// LoadState loads the task engine state with data in db.
+	LoadState() error
+
 	json.Marshaler
 	json.Unmarshaler
 }

--- a/agent/engine/mocks/engine_mocks.go
+++ b/agent/engine/mocks/engine_mocks.go
@@ -122,6 +122,20 @@ func (mr *MockTaskEngineMockRecorder) ListTasks() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTasks", reflect.TypeOf((*MockTaskEngine)(nil).ListTasks))
 }
 
+// LoadState mocks base method
+func (m *MockTaskEngine) LoadState() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LoadState")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// LoadState indicates an expected call of LoadState
+func (mr *MockTaskEngineMockRecorder) LoadState() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadState", reflect.TypeOf((*MockTaskEngine)(nil).LoadState))
+}
+
 // MarshalJSON mocks base method
 func (m *MockTaskEngine) MarshalJSON() ([]byte, error) {
 	m.ctrl.T.Helper()

--- a/agent/stats/common_test.go
+++ b/agent/stats/common_test.go
@@ -329,6 +329,10 @@ func (engine *MockTaskEngine) Version() (string, error) {
 	return "", nil
 }
 
+func (engine *MockTaskEngine) LoadState() error {
+	return nil
+}
+
 func (engine *MockTaskEngine) Capabilities() []*ecs.Attribute {
 	return nil
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Add method for task engine to load state from boltdb. Currently it is unused. Will use it in a later change that implements all the loading logic.

### Implementation details
<!-- How are the changes implemented? -->
Load data from task, container, eni attachment and image table into task engine state.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Currently tested with unit test. Manual test will be done with later change when all the loading logic is added.

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
N/A

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
