### PR TITLE
Send nil for network rate stats when network stats is nil

### DIFF
--- a/agent/stats/engine.go
+++ b/agent/stats/engine.go
@@ -771,6 +771,9 @@ func (engine *DockerStatsEngine) ContainerDockerStats(taskARN string, containerI
 			taskNetworkStats := taskStats.StatsQueue.GetLastStat().Networks
 			containerStats.Networks = taskNetworkStats
 			containerNetworkRateStats = taskStats.StatsQueue.GetLastNetworkStatPerSec()
+			if len(containerStats.Networks) == 0 {
+				containerNetworkRateStats = nil
+			}
 		} else {
 			seelog.Warnf("Network stats not found for container %s", containerID)
 		}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
If network stats is not being sent, then the rate metrics should not be visible.

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

Tested that the metadata endpoint is not displaying any rate stats if networks sent is nil.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
