### PR TITLE
Windows Task Networking : CNI plugin build changes

### DIFF
--- a/scripts/dockerfiles/Dockerfile.buildWindowsVPCCNIPlugins
+++ b/scripts/dockerfiles/Dockerfile.buildWindowsVPCCNIPlugins
@@ -1,0 +1,27 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+FROM golang:1.10
+MAINTAINER Amazon Web Services, Inc.
+
+ARG GOARCH
+
+ENV GOARCH ${GOARCH}
+ENV GOOS windows
+ENV BUILD_FLAGS "-tags disablekubeapi"
+
+RUN mkdir -p /go/src/github.com/aws/
+
+WORKDIR /go/src/github.com/aws/amazon-vpc-cni-plugins
+
+CMD ["make", "vpc-shared-eni"]

--- a/scripts/local-save
+++ b/scripts/local-save
@@ -30,8 +30,15 @@ stage_windows() {
 
 	cp out/amazon-ecs-agent.exe "${ziproot}"
 	cp -v misc/windows-deploy/*.ps1 "${ziproot}"
+
+	if [[ -f "${buildroot}/out/cni-plugins/vpc-shared-eni" ]]
+	then
+	  mkdir "${ziproot}/cni"
+	  mv "${buildroot}/out/cni-plugins/vpc-shared-eni" "${ziproot}/cni/vpc-shared-eni.exe"
+	fi
+
 	pushd "${ziproot}"
-	zip "${zipfile}" *
+	zip -r "${zipfile}" *
 	cp "${zipfile}.zip" "${buildroot}/out/ecs-agent-windows.zip"
 	popd
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
In order to setup the task namespace with the task ENI, we need to use "vpc-shared-eni" plugin.
This plugin is included in vpc-cni-plugin repository which is included as a git submodule in ECS-Agent.

We will be building the CNI plugin for Windows and packaging them along with ecs-agent binary.

### Implementation details
<!-- How are the changes implemented? -->
In order to build the correct plugins as required by each platform, we will be passing the docker file corresponding to that platform.
The Dockerfile for Windows include all the flags which are required for building the plugin.
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
The changes were tested by running "make codebuild" on a Linux instance

New tests cover the changes: <!-- yes|no -->
No new tests are required.
### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
CNI plugin build changes
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
