### PR TITLE
Check task network device before querying network stats

### DIFF
--- a/agent/stats/engine.go
+++ b/agent/stats/engine.go
@@ -179,8 +179,16 @@ func (engine *DockerStatsEngine) addAndStartStatsContainer(containerID string) {
 	if err != nil {
 		return
 	}
+
+	dockerContainer, errResolveContainer := engine.resolver.ResolveContainer(containerID)
+	if errResolveContainer != nil {
+		seelog.Debugf("Could not map container ID to container, container: %s, err: %s", containerID, err)
+		return
+	}
+
 	if task.IsNetworkModeAWSVPC() {
-		if statsTaskContainer != nil {
+		// Start stats collector only for pause container
+		if statsTaskContainer != nil && dockerContainer.Container.Type == apicontainer.ContainerCNIPause {
 			statsTaskContainer.StartStatsCollection()
 		} else {
 			seelog.Debugf("stats task container is nil, cannot start task stats collection")

--- a/agent/stats/engine_test.go
+++ b/agent/stats/engine_test.go
@@ -429,7 +429,7 @@ func TestSynchronizeOnRestart(t *testing.T) {
 		Container: &apicontainer.Container{
 			HealthCheckType: "docker",
 		},
-	}, nil).Times(2)
+	}, nil).Times(3)
 	err := engine.synchronizeState()
 	assert.NoError(t, err)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
- `StartStatsCollection` was being called for every container in a task, it should be called only once for every task.
- Task network device name was being fetched only at the beginning of collection of stats, it might be possible that the devices has not been attached to the container yet, instead the check is done everytime before querying for the task.


### Implementation details
<!-- How are the changes implemented? -->

### Testing
 How was this tested?

Tested manually that `startStatsCollection` is called only once for pause container for an AWSVPC task. Also, Tested manually that device name is not none by running an AWSVPC task. Before this change, I could see instances of device name being none.

As a result of these two changes, I am able to consistently see right `rx_bytes_per_sec` when using v4 taskmeta data endpoint, before this change,  `rx_bytes_per_sec` in lot of instances.

<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
