### PR TITLE
add task cluster arn

### DIFF
--- a/agent/acs/handler/task_manifest_handler_test.go
+++ b/agent/acs/handler/task_manifest_handler_test.go
@@ -60,8 +60,8 @@ func TestManifestHandlerKillAllTasks(t *testing.T) {
 
 	//Task that needs to be stopped, sent back by agent
 	taskIdentifierFinal := []*ecsacs.TaskIdentifier{
-		{DesiredStatus: aws.String(apitaskstatus.TaskStoppedString), TaskArn: aws.String("arn1")},
-		{DesiredStatus: aws.String(apitaskstatus.TaskStoppedString), TaskArn: aws.String("arn2")},
+		{DesiredStatus: aws.String(apitaskstatus.TaskStoppedString), TaskArn: aws.String("arn1"), TaskClusterArn: aws.String(cluster)},
+		{DesiredStatus: aws.String(apitaskstatus.TaskStoppedString), TaskArn: aws.String("arn2"), TaskClusterArn: aws.String(cluster)},
 	}
 
 	taskStopVerificationMessage := &ecsacs.TaskStopVerificationMessage{
@@ -100,7 +100,7 @@ func TestManifestHandlerKillAllTasks(t *testing.T) {
 		ClusterArn:           aws.String(cluster),
 		ContainerInstanceArn: aws.String(containerInstanceArn),
 		Tasks: []*ecsacs.TaskIdentifier{
-			{DesiredStatus: aws.String("STOPPED"), TaskArn: aws.String("arn-long")},
+			{DesiredStatus: aws.String("STOPPED"), TaskArn: aws.String("arn-long"), TaskClusterArn: aws.String(cluster)},
 		},
 		Timeline: aws.Int64(12),
 	}
@@ -150,8 +150,8 @@ func TestManifestHandlerKillFewTasks(t *testing.T) {
 
 	//Task that needs to be stopped, sent back by agent
 	taskIdentifierFinal := []*ecsacs.TaskIdentifier{
-		{DesiredStatus: aws.String(apitaskstatus.TaskStoppedString), TaskArn: aws.String("arn2")},
-		{DesiredStatus: aws.String(apitaskstatus.TaskStoppedString), TaskArn: aws.String("arn3")},
+		{DesiredStatus: aws.String(apitaskstatus.TaskStoppedString), TaskArn: aws.String("arn2"), TaskClusterArn: aws.String(cluster)},
+		{DesiredStatus: aws.String(apitaskstatus.TaskStoppedString), TaskArn: aws.String("arn3"), TaskClusterArn: aws.String(cluster)},
 	}
 
 	taskStopVerificationMessage := &ecsacs.TaskStopVerificationMessage{
@@ -189,12 +189,14 @@ func TestManifestHandlerKillFewTasks(t *testing.T) {
 		ContainerInstanceArn: aws.String(containerInstanceArn),
 		Tasks: []*ecsacs.TaskIdentifier{
 			{
-				DesiredStatus: aws.String(apitaskstatus.TaskRunningString),
-				TaskArn:       aws.String("arn1"),
+				DesiredStatus:  aws.String(apitaskstatus.TaskRunningString),
+				TaskArn:        aws.String("arn1"),
+				TaskClusterArn: aws.String(cluster),
 			},
 			{
-				DesiredStatus: aws.String(apitaskstatus.TaskStoppedString),
-				TaskArn:       aws.String("arn2"),
+				DesiredStatus:  aws.String(apitaskstatus.TaskStoppedString),
+				TaskArn:        aws.String("arn2"),
+				TaskClusterArn: aws.String(cluster),
 			},
 		},
 		Timeline: aws.Int64(12),
@@ -331,20 +333,21 @@ func TestManifestHandlerDifferentTaskLists(t *testing.T) {
 
 	// tasks that suppose to be running
 	taskIdentifierInitial := ecsacs.TaskIdentifier{
-		DesiredStatus: aws.String(apitaskstatus.TaskStoppedString),
-		TaskArn:       aws.String("arn1"),
+		DesiredStatus:  aws.String(apitaskstatus.TaskStoppedString),
+		TaskArn:        aws.String("arn1"),
+		TaskClusterArn: aws.String(cluster),
 	}
 
 	//Task that needs to be stopped, sent back by agent
 	taskIdentifierAckFinal := []*ecsacs.TaskIdentifier{
-		{DesiredStatus: aws.String(apitaskstatus.TaskRunningString), TaskArn: aws.String("arn1")},
-		{DesiredStatus: aws.String(apitaskstatus.TaskStoppedString), TaskArn: aws.String("arn2")},
+		{DesiredStatus: aws.String(apitaskstatus.TaskRunningString), TaskArn: aws.String("arn1"), TaskClusterArn: aws.String(cluster)},
+		{DesiredStatus: aws.String(apitaskstatus.TaskStoppedString), TaskArn: aws.String("arn2"), TaskClusterArn: aws.String(cluster)},
 	}
 
 	//Task that needs to be stopped, sent back by agent
 	taskIdentifierMessage := []*ecsacs.TaskIdentifier{
-		{DesiredStatus: aws.String(apitaskstatus.TaskStoppedString), TaskArn: aws.String("arn1")},
-		{DesiredStatus: aws.String(apitaskstatus.TaskStoppedString), TaskArn: aws.String("arn2")},
+		{DesiredStatus: aws.String(apitaskstatus.TaskStoppedString), TaskArn: aws.String("arn1"), TaskClusterArn: aws.String(cluster)},
+		{DesiredStatus: aws.String(apitaskstatus.TaskStoppedString), TaskArn: aws.String("arn2"), TaskClusterArn: aws.String(cluster)},
 	}
 
 	taskStopVerificationMessage := &ecsacs.TaskStopVerificationMessage{
@@ -479,7 +482,7 @@ func TestCompareTasksDifferentTasks(t *testing.T) {
 		{Arn: "arn1", DesiredStatusUnsafe: apitaskstatus.TaskRunning},
 	}
 
-	compareTaskList := compareTasks(receivedTaskList, taskList)
+	compareTaskList := compareTasks(receivedTaskList, taskList, "test-cluster-arn")
 
 	assert.Equal(t, 2, len(compareTaskList))
 }
@@ -501,7 +504,7 @@ func TestCompareTasksSameTasks(t *testing.T) {
 		{Arn: "arn1", DesiredStatusUnsafe: apitaskstatus.TaskRunning},
 	}
 
-	compareTaskList := compareTasks(receivedTaskList, taskList)
+	compareTaskList := compareTasks(receivedTaskList, taskList, "test-cluster-arn")
 
 	assert.Equal(t, 0, len(compareTaskList))
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Currently ACS receives a `TaskStopVerificationMessage` from Agent. `TaskIdentifier` which is a part of this message contains `taskarn` and `desiredstatus`. Task's `ClusterArn` should also be part of this message which is currently not.

This PR adds Task's `ClusterArn` to `TaskStopVerificationMessage`. 


### Implementation details
<!-- How are the changes implemented? -->

### Testing
How was this tested? 

Manually tested that clusterARN is being sent in TaskIdentifier.

```
level=info time=2020-07-21T21:25:14Z msg="Tasks --> [{\n  DesiredStatus: \"STOPPED\",\n  TaskArn: \"arn:aws:ecs:us-west-2:694464167470:task/d1a684ae-3794-4c3e-a042-4af2f328856b\",\n  TaskClusterArn: \"arn:aws:ecs:us-west-2:694464167470:cluster/metrics-test-gamma\"\n}]" module=task_manifest_handler.go
```
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
