### PR TITLE
Remove usage of state manager in acs and event handler

### DIFF
--- a/agent/acs/handler/acs_handler.go
+++ b/agent/acs/handler/acs_handler.go
@@ -34,7 +34,6 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/eventhandler"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
-	"github.com/aws/amazon-ecs-agent/agent/statemanager"
 	"github.com/aws/amazon-ecs-agent/agent/utils/retry"
 	"github.com/aws/amazon-ecs-agent/agent/utils/ttime"
 	"github.com/aws/amazon-ecs-agent/agent/version"
@@ -84,7 +83,6 @@ type session struct {
 	taskEngine                      engine.TaskEngine
 	ecsClient                       api.ECSClient
 	state                           dockerstate.TaskEngineState
-	stateManager                    statemanager.StateManager
 	dataClient                      data.Client
 	credentialsManager              rolecredentials.Manager
 	taskHandler                     *eventhandler.TaskHandler
@@ -143,7 +141,6 @@ func NewSession(ctx context.Context,
 	credentialsProvider *credentials.Credentials,
 	ecsClient api.ECSClient,
 	taskEngineState dockerstate.TaskEngineState,
-	stateManager statemanager.StateManager,
 	dataClient data.Client,
 	taskEngine engine.TaskEngine,
 	credentialsManager rolecredentials.Manager,
@@ -160,7 +157,6 @@ func NewSession(ctx context.Context,
 		credentialsProvider:             credentialsProvider,
 		ecsClient:                       ecsClient,
 		state:                           taskEngineState,
-		stateManager:                    stateManager,
 		dataClient:                      dataClient,
 		taskEngine:                      taskEngine,
 		credentialsManager:              credentialsManager,
@@ -308,7 +304,7 @@ func (acsSession *session) startACSSession(client wsclient.ClientServer) error {
 
 	// Add TaskManifestHandler
 	taskManifestHandler := newTaskManifestHandler(acsSession.ctx, cfg.Cluster, acsSession.containerInstanceARN,
-		client, acsSession.stateManager, acsSession.dataClient, acsSession.taskEngine, acsSession.latestSeqNumTaskManifest)
+		client, acsSession.dataClient, acsSession.taskEngine, acsSession.latestSeqNumTaskManifest)
 
 	defer taskManifestHandler.clearAcks()
 	taskManifestHandler.start()
@@ -325,7 +321,6 @@ func (acsSession *session) startACSSession(client wsclient.ClientServer) error {
 		cfg.Cluster,
 		acsSession.containerInstanceARN,
 		client,
-		acsSession.stateManager,
 		acsSession.dataClient,
 		refreshCredsHandler,
 		acsSession.credentialsManager,

--- a/agent/acs/handler/acs_handler_test.go
+++ b/agent/acs/handler/acs_handler_test.go
@@ -41,7 +41,6 @@ import (
 	mock_engine "github.com/aws/amazon-ecs-agent/agent/engine/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/eventhandler"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
-	"github.com/aws/amazon-ecs-agent/agent/statemanager"
 
 	"github.com/aws/amazon-ecs-agent/agent/utils/retry"
 	mock_retry "github.com/aws/amazon-ecs-agent/agent/utils/retry/mock"
@@ -191,9 +190,8 @@ func TestHandlerReconnectsOnConnectErrors(t *testing.T) {
 	ecsClient := mock_api.NewMockECSClient(ctrl)
 	ecsClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(acsURL, nil).AnyTimes()
 
-	stateManager := statemanager.NewNoopStateManager()
 	ctx, cancel := context.WithCancel(context.Background())
-	taskHandler := eventhandler.NewTaskHandler(ctx, stateManager, data.NewNoopClient(), nil, nil)
+	taskHandler := eventhandler.NewTaskHandler(ctx, data.NewNoopClient(), nil, nil)
 
 	mockWsClient := mock_wsclient.NewMockClientServer(ctrl)
 	mockWsClient.EXPECT().SetAnyRequestHandler(gomock.Any()).AnyTimes()
@@ -216,7 +214,6 @@ func TestHandlerReconnectsOnConnectErrors(t *testing.T) {
 		agentConfig:          testConfig,
 		taskEngine:           taskEngine,
 		ecsClient:            ecsClient,
-		stateManager:         stateManager,
 		dataClient:           data.NewNoopClient(),
 		taskHandler:          taskHandler,
 		backoff:              retry.NewExponentialBackoff(connectionBackoffMin, connectionBackoffMax, connectionBackoffJitter, connectionBackoffMultiplier),
@@ -331,9 +328,8 @@ func TestHandlerReconnectsWithoutBackoffOnEOFError(t *testing.T) {
 	ecsClient := mock_api.NewMockECSClient(ctrl)
 	ecsClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(acsURL, nil).AnyTimes()
 
-	stateManager := statemanager.NewNoopStateManager()
 	ctx, cancel := context.WithCancel(context.Background())
-	taskHandler := eventhandler.NewTaskHandler(ctx, stateManager, data.NewNoopClient(), nil, nil)
+	taskHandler := eventhandler.NewTaskHandler(ctx, data.NewNoopClient(), nil, nil)
 
 	deregisterInstanceEventStream := eventstream.NewEventStream("DeregisterContainerInstance", ctx)
 	deregisterInstanceEventStream.StartListening()
@@ -362,7 +358,6 @@ func TestHandlerReconnectsWithoutBackoffOnEOFError(t *testing.T) {
 		taskEngine:                      taskEngine,
 		ecsClient:                       ecsClient,
 		deregisterInstanceEventStream:   deregisterInstanceEventStream,
-		stateManager:                    stateManager,
 		dataClient:                      data.NewNoopClient(),
 		taskHandler:                     taskHandler,
 		backoff:                         mockBackoff,
@@ -396,9 +391,8 @@ func TestHandlerReconnectsWithBackoffOnNonEOFError(t *testing.T) {
 	ecsClient := mock_api.NewMockECSClient(ctrl)
 	ecsClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(acsURL, nil).AnyTimes()
 
-	stateManager := statemanager.NewNoopStateManager()
 	ctx, cancel := context.WithCancel(context.Background())
-	taskHandler := eventhandler.NewTaskHandler(ctx, stateManager, data.NewNoopClient(), nil, nil)
+	taskHandler := eventhandler.NewTaskHandler(ctx, data.NewNoopClient(), nil, nil)
 
 	deregisterInstanceEventStream := eventstream.NewEventStream("DeregisterContainerInstance", ctx)
 	deregisterInstanceEventStream.StartListening()
@@ -427,7 +421,6 @@ func TestHandlerReconnectsWithBackoffOnNonEOFError(t *testing.T) {
 		taskEngine:                    taskEngine,
 		ecsClient:                     ecsClient,
 		deregisterInstanceEventStream: deregisterInstanceEventStream,
-		stateManager:                  stateManager,
 		dataClient:                    data.NewNoopClient(),
 		taskHandler:                   taskHandler,
 		backoff:                       mockBackoff,
@@ -459,9 +452,8 @@ func TestHandlerGeneratesDeregisteredInstanceEvent(t *testing.T) {
 	ecsClient := mock_api.NewMockECSClient(ctrl)
 	ecsClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(acsURL, nil).AnyTimes()
 
-	stateManager := statemanager.NewNoopStateManager()
 	ctx, cancel := context.WithCancel(context.Background())
-	taskHandler := eventhandler.NewTaskHandler(ctx, stateManager, data.NewNoopClient(), nil, nil)
+	taskHandler := eventhandler.NewTaskHandler(ctx, data.NewNoopClient(), nil, nil)
 
 	deregisterInstanceEventStream := eventstream.NewEventStream("DeregisterContainerInstance", ctx)
 
@@ -487,7 +479,6 @@ func TestHandlerGeneratesDeregisteredInstanceEvent(t *testing.T) {
 		taskEngine:                      taskEngine,
 		ecsClient:                       ecsClient,
 		deregisterInstanceEventStream:   deregisterInstanceEventStream,
-		stateManager:                    stateManager,
 		dataClient:                      data.NewNoopClient(),
 		taskHandler:                     taskHandler,
 		backoff:                         retry.NewExponentialBackoff(connectionBackoffMin, connectionBackoffMax, connectionBackoffJitter, connectionBackoffMultiplier),
@@ -520,9 +511,8 @@ func TestHandlerReconnectDelayForInactiveInstanceError(t *testing.T) {
 	ecsClient := mock_api.NewMockECSClient(ctrl)
 	ecsClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(acsURL, nil).AnyTimes()
 
-	stateManager := statemanager.NewNoopStateManager()
 	ctx, cancel := context.WithCancel(context.Background())
-	taskHandler := eventhandler.NewTaskHandler(ctx, stateManager, data.NewNoopClient(), nil, nil)
+	taskHandler := eventhandler.NewTaskHandler(ctx, data.NewNoopClient(), nil, nil)
 
 	deregisterInstanceEventStream := eventstream.NewEventStream("DeregisterContainerInstance", ctx)
 	deregisterInstanceEventStream.StartListening()
@@ -557,7 +547,6 @@ func TestHandlerReconnectDelayForInactiveInstanceError(t *testing.T) {
 		taskEngine:                      taskEngine,
 		ecsClient:                       ecsClient,
 		deregisterInstanceEventStream:   deregisterInstanceEventStream,
-		stateManager:                    stateManager,
 		dataClient:                      data.NewNoopClient(),
 		taskHandler:                     taskHandler,
 		backoff:                         retry.NewExponentialBackoff(connectionBackoffMin, connectionBackoffMax, connectionBackoffJitter, connectionBackoffMultiplier),
@@ -589,9 +578,8 @@ func TestHandlerReconnectsOnServeErrors(t *testing.T) {
 	ecsClient := mock_api.NewMockECSClient(ctrl)
 	ecsClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(acsURL, nil).AnyTimes()
 
-	stateManager := statemanager.NewNoopStateManager()
 	ctx, cancel := context.WithCancel(context.Background())
-	taskHandler := eventhandler.NewTaskHandler(ctx, stateManager, data.NewNoopClient(), nil, nil)
+	taskHandler := eventhandler.NewTaskHandler(ctx, data.NewNoopClient(), nil, nil)
 
 	mockWsClient := mock_wsclient.NewMockClientServer(ctrl)
 	mockWsClient.EXPECT().SetAnyRequestHandler(gomock.Any()).AnyTimes()
@@ -615,7 +603,6 @@ func TestHandlerReconnectsOnServeErrors(t *testing.T) {
 		agentConfig:          testConfig,
 		taskEngine:           taskEngine,
 		ecsClient:            ecsClient,
-		stateManager:         stateManager,
 		dataClient:           data.NewNoopClient(),
 		taskHandler:          taskHandler,
 		backoff:              retry.NewExponentialBackoff(connectionBackoffMin, connectionBackoffMax, connectionBackoffJitter, connectionBackoffMultiplier),
@@ -646,9 +633,8 @@ func TestHandlerStopsWhenContextIsCancelled(t *testing.T) {
 	ecsClient := mock_api.NewMockECSClient(ctrl)
 	ecsClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(acsURL, nil).AnyTimes()
 
-	stateManager := statemanager.NewNoopStateManager()
 	ctx, cancel := context.WithCancel(context.Background())
-	taskHandler := eventhandler.NewTaskHandler(ctx, stateManager, data.NewNoopClient(), nil, nil)
+	taskHandler := eventhandler.NewTaskHandler(ctx, data.NewNoopClient(), nil, nil)
 
 	mockWsClient := mock_wsclient.NewMockClientServer(ctrl)
 	mockWsClient.EXPECT().SetAnyRequestHandler(gomock.Any()).AnyTimes()
@@ -667,7 +653,6 @@ func TestHandlerStopsWhenContextIsCancelled(t *testing.T) {
 		agentConfig:          testConfig,
 		taskEngine:           taskEngine,
 		ecsClient:            ecsClient,
-		stateManager:         stateManager,
 		dataClient:           data.NewNoopClient(),
 		taskHandler:          taskHandler,
 		backoff:              retry.NewExponentialBackoff(connectionBackoffMin, connectionBackoffMax, connectionBackoffJitter, connectionBackoffMultiplier),
@@ -696,9 +681,8 @@ func TestHandlerReconnectsOnDiscoverPollEndpointError(t *testing.T) {
 	taskEngine.EXPECT().Version().Return("Docker: 1.5.0", nil).AnyTimes()
 
 	ecsClient := mock_api.NewMockECSClient(ctrl)
-	stateManager := statemanager.NewNoopStateManager()
 	ctx, cancel := context.WithCancel(context.Background())
-	taskHandler := eventhandler.NewTaskHandler(ctx, stateManager, data.NewNoopClient(), nil, nil)
+	taskHandler := eventhandler.NewTaskHandler(ctx, data.NewNoopClient(), nil, nil)
 
 	mockWsClient := mock_wsclient.NewMockClientServer(ctrl)
 	mockWsClient.EXPECT().SetAnyRequestHandler(gomock.Any()).AnyTimes()
@@ -722,7 +706,6 @@ func TestHandlerReconnectsOnDiscoverPollEndpointError(t *testing.T) {
 		agentConfig:          testConfig,
 		taskEngine:           taskEngine,
 		ecsClient:            ecsClient,
-		stateManager:         stateManager,
 		dataClient:           data.NewNoopClient(),
 		taskHandler:          taskHandler,
 		backoff:              retry.NewExponentialBackoff(connectionBackoffMin, connectionBackoffMax, connectionBackoffJitter, connectionBackoffMultiplier),
@@ -765,9 +748,8 @@ func TestConnectionIsClosedOnIdle(t *testing.T) {
 	taskEngine.EXPECT().Version().Return("Docker: 1.5.0", nil).AnyTimes()
 
 	ecsClient := mock_api.NewMockECSClient(ctrl)
-	stateManager := statemanager.NewNoopStateManager()
 	ctx, cancel := context.WithCancel(context.Background())
-	taskHandler := eventhandler.NewTaskHandler(ctx, stateManager, data.NewNoopClient(), nil, nil)
+	taskHandler := eventhandler.NewTaskHandler(ctx, data.NewNoopClient(), nil, nil)
 	defer cancel()
 
 	wait := sync.WaitGroup{}
@@ -795,7 +777,6 @@ func TestConnectionIsClosedOnIdle(t *testing.T) {
 		agentConfig:          testConfig,
 		taskEngine:           taskEngine,
 		ecsClient:            ecsClient,
-		stateManager:         stateManager,
 		dataClient:           data.NewNoopClient(),
 		taskHandler:          taskHandler,
 		ctx:                  context.Background(),
@@ -816,9 +797,8 @@ func TestHandlerDoesntLeakGoroutines(t *testing.T) {
 	defer ctrl.Finish()
 	taskEngine := mock_engine.NewMockTaskEngine(ctrl)
 	ecsClient := mock_api.NewMockECSClient(ctrl)
-	stateManager := statemanager.NewNoopStateManager()
 	ctx, cancel := context.WithCancel(context.Background())
-	taskHandler := eventhandler.NewTaskHandler(ctx, stateManager, data.NewNoopClient(), nil, nil)
+	taskHandler := eventhandler.NewTaskHandler(ctx, data.NewNoopClient(), nil, nil)
 
 	closeWS := make(chan bool)
 	server, serverIn, requests, errs, err := startMockAcsServer(t, closeWS)
@@ -850,7 +830,6 @@ func TestHandlerDoesntLeakGoroutines(t *testing.T) {
 			agentConfig:              testConfig,
 			taskEngine:               taskEngine,
 			ecsClient:                ecsClient,
-			stateManager:             stateManager,
 			dataClient:               data.NewNoopClient(),
 			taskHandler:              taskHandler,
 			ctx:                      ctx,
@@ -902,9 +881,8 @@ func TestStartSessionHandlesRefreshCredentialsMessages(t *testing.T) {
 	defer ctrl.Finish()
 	taskEngine := mock_engine.NewMockTaskEngine(ctrl)
 	ecsClient := mock_api.NewMockECSClient(ctrl)
-	stateManager := statemanager.NewNoopStateManager()
 	ctx, cancel := context.WithCancel(context.Background())
-	taskHandler := eventhandler.NewTaskHandler(ctx, stateManager, data.NewNoopClient(), nil, nil)
+	taskHandler := eventhandler.NewTaskHandler(ctx, data.NewNoopClient(), nil, nil)
 	closeWS := make(chan bool)
 	server, serverIn, requestsChan, errChan, err := startMockAcsServer(t, closeWS)
 	if err != nil {
@@ -938,7 +916,6 @@ func TestStartSessionHandlesRefreshCredentialsMessages(t *testing.T) {
 			testCreds,
 			ecsClient,
 			dockerstate.NewTaskEngineState(),
-			stateManager,
 			data.NewNoopClient(),
 			taskEngine,
 			credentialsManager,
@@ -1025,9 +1002,8 @@ func TestHandlerReconnectsCorrectlySetsSendCredentialsURLParameter(t *testing.T)
 	defer ctrl.Finish()
 	taskEngine := mock_engine.NewMockTaskEngine(ctrl)
 	ecsClient := mock_api.NewMockECSClient(ctrl)
-	stateManager := statemanager.NewNoopStateManager()
 	ctx, cancel := context.WithCancel(context.Background())
-	taskHandler := eventhandler.NewTaskHandler(ctx, stateManager, data.NewNoopClient(), nil, nil)
+	taskHandler := eventhandler.NewTaskHandler(ctx, data.NewNoopClient(), nil, nil)
 
 	mockWsClient := mock_wsclient.NewMockClientServer(ctrl)
 
@@ -1055,7 +1031,6 @@ func TestHandlerReconnectsCorrectlySetsSendCredentialsURLParameter(t *testing.T)
 		agentConfig:          testConfig,
 		taskEngine:           taskEngine,
 		ecsClient:            ecsClient,
-		stateManager:         stateManager,
 		dataClient:           data.NewNoopClient(),
 		taskHandler:          taskHandler,
 		ctx:                  ctx,

--- a/agent/api/eni/eni_test.go
+++ b/agent/api/eni/eni_test.go
@@ -29,6 +29,63 @@ const (
 	customSearchDomain = "us-west-2.compute.internal"
 )
 
+var (
+	testENI = &ENI{
+		ID:                           "eni-123",
+		InterfaceAssociationProtocol: DefaultInterfaceAssociationProtocol,
+		IPV4Addresses: []*ENIIPV4Address{
+			{
+				Primary: true,
+				Address: "1.2.3.4",
+			},
+		},
+		IPV6Addresses: []*ENIIPV6Address{
+			{
+				Address: "abcd:dcba:1234:4321::",
+			},
+		},
+	}
+)
+
+func TestIsStandardENI(t *testing.T) {
+	testCases := []struct {
+		protocol   string
+		isStandard bool
+	}{
+		{
+			protocol:   "",
+			isStandard: true,
+		},
+		{
+			protocol:   DefaultInterfaceAssociationProtocol,
+			isStandard: true,
+		},
+		{
+			protocol:   VLANInterfaceAssociationProtocol,
+			isStandard: false,
+		},
+		{
+			protocol:   "invalid",
+			isStandard: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.protocol, func(t *testing.T) {
+			eni := &ENI{
+				InterfaceAssociationProtocol: tc.protocol,
+			}
+			assert.Equal(t, tc.isStandard, eni.IsStandardENI())
+		})
+	}
+
+}
+
+func TestENIToString(t *testing.T) {
+	expectedStr := `eni id:eni-123, mac: , hostname: , ipv4addresses: [1.2.3.4], ipv6addresses: [abcd:dcba:1234:4321::], dns: [], dns search: [], gateway ipv4: [][]`
+	assert.Equal(t, expectedStr, testENI.String())
+}
+
 // TestENIFromACS tests the eni information was correctly read from the acs
 func TestENIFromACS(t *testing.T) {
 	acsENI := &ecsacs.ElasticNetworkInterface{

--- a/agent/api/eni/enistatus_test.go
+++ b/agent/api/eni/enistatus_test.go
@@ -1,0 +1,78 @@
+// +build unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package eni
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStatusToString(t *testing.T) {
+	testCases := []struct {
+		status ENIAttachmentStatus
+		str    string
+	}{
+		{
+			status: ENIAttachmentNone,
+			str:    "NONE",
+		},
+		{
+			status: ENIAttached,
+			str:    "ATTACHED",
+		},
+		{
+			status: ENIDetached,
+			str:    "DETACHED",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.str, func(t *testing.T) {
+			assert.Equal(t, tc.str, (&tc.status).String())
+		})
+	}
+}
+
+func TestShouldSend(t *testing.T) {
+	testCases := []struct {
+		name       string
+		status     ENIAttachmentStatus
+		shouldSend bool
+	}{
+		{
+			name:       "NONE",
+			status:     ENIAttachmentNone,
+			shouldSend: false,
+		},
+		{
+			name:       "ATTACHED",
+			status:     ENIAttached,
+			shouldSend: true,
+		},
+		{
+			name:       "DETACHED",
+			status:     ENIDetached,
+			shouldSend: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.shouldSend, (&tc.status).ShouldSend())
+		})
+	}
+}

--- a/agent/eventhandler/attachment_handler.go
+++ b/agent/eventhandler/attachment_handler.go
@@ -22,7 +22,6 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/api"
 	"github.com/aws/amazon-ecs-agent/agent/data"
 	"github.com/aws/amazon-ecs-agent/agent/statechange"
-	"github.com/aws/amazon-ecs-agent/agent/statemanager"
 	"github.com/aws/amazon-ecs-agent/agent/utils/retry"
 	"github.com/cihub/seelog"
 )
@@ -30,10 +29,6 @@ import (
 // AttachmentEventHandler is a handler that is responsible for submitting attachment state change events
 // to backend
 type AttachmentEventHandler struct {
-	// stateSaver is a statemanager which may be used to save any
-	// changes to an attachment's SentStatus
-	stateSaver statemanager.Saver
-
 	// backoff is the backoff object used in submitting attachment state change
 	backoff retry.Backoff
 
@@ -56,10 +51,6 @@ type attachmentHandler struct {
 	// attachmentARN is the arn of the attachment that the attachmentHandler is handling
 	attachmentARN string
 
-	// stateSaver is a statemanager which may be used to save any
-	// changes to an attachment's SentStatus
-	stateSaver statemanager.Saver
-
 	// dataClient is used to save any changes to an attachment's SentStatus
 	dataClient data.Client
 
@@ -75,12 +66,10 @@ type attachmentHandler struct {
 
 // NewAttachmentEventHandler returns a new AttachmentEventHandler object
 func NewAttachmentEventHandler(ctx context.Context,
-	stateSaver statemanager.Saver,
 	dataClient data.Client,
 	client api.ECSClient) *AttachmentEventHandler {
 	return &AttachmentEventHandler{
 		ctx:                    ctx,
-		stateSaver:             stateSaver,
 		client:                 client,
 		dataClient:             dataClient,
 		attachmentARNToHandler: make(map[string]*attachmentHandler),
@@ -108,7 +97,6 @@ func (eventHandler *AttachmentEventHandler) AddStateChangeEvent(change statechan
 	if _, ok := eventHandler.attachmentARNToHandler[attachmentARN]; !ok {
 		eventHandler.attachmentARNToHandler[attachmentARN] = &attachmentHandler{
 			attachmentARN: attachmentARN,
-			stateSaver:    eventHandler.stateSaver,
 			dataClient:    eventHandler.dataClient,
 			client:        eventHandler.client,
 			ctx:           eventHandler.ctx,

--- a/agent/eventhandler/handler_test.go
+++ b/agent/eventhandler/handler_test.go
@@ -24,7 +24,6 @@ import (
 	mock_api "github.com/aws/amazon-ecs-agent/agent/api/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/data"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
-	"github.com/aws/amazon-ecs-agent/agent/statemanager"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 )
@@ -34,11 +33,10 @@ func TestHandleEngineEvent(t *testing.T) {
 	defer ctrl.Finish()
 
 	client := mock_api.NewMockECSClient(ctrl)
-	stateManager := statemanager.NewNoopStateManager()
 
 	ctx, cancel := context.WithCancel(context.Background())
-	taskHandler := NewTaskHandler(ctx, stateManager, data.NewNoopClient(), dockerstate.NewTaskEngineState(), client)
-	attachmentHandler := NewAttachmentEventHandler(ctx, statemanager.NewNoopStateManager(), data.NewNoopClient(), client)
+	taskHandler := NewTaskHandler(ctx, data.NewNoopClient(), dockerstate.NewTaskEngineState(), client)
+	attachmentHandler := NewAttachmentEventHandler(ctx, data.NewNoopClient(), client)
 	defer cancel()
 
 	var wg sync.WaitGroup

--- a/agent/eventhandler/task_handler.go
+++ b/agent/eventhandler/task_handler.go
@@ -28,7 +28,6 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/metrics"
 	"github.com/aws/amazon-ecs-agent/agent/statechange"
-	"github.com/aws/amazon-ecs-agent/agent/statemanager"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 	"github.com/aws/amazon-ecs-agent/agent/utils/retry"
 	"github.com/cihub/seelog"
@@ -66,10 +65,6 @@ type TaskHandler struct {
 	// * tasksToContainerStates
 	lock sync.RWMutex
 
-	// stateSaver is a statemanager which may be used to save any
-	// changes to a task or container's SentStatus
-	stateSaver statemanager.Saver
-
 	// dataClient is used to save changes to database, mainly to save
 	// changes of a task or container's SentStatus.
 	dataClient data.Client
@@ -105,7 +100,6 @@ type taskSendableEvents struct {
 
 // NewTaskHandler returns a pointer to TaskHandler
 func NewTaskHandler(ctx context.Context,
-	stateManager statemanager.Saver,
 	dataClient data.Client,
 	state dockerstate.TaskEngineState,
 	client api.ECSClient) *TaskHandler {
@@ -115,7 +109,6 @@ func NewTaskHandler(ctx context.Context,
 		tasksToEvents:           make(map[string]*taskSendableEvents),
 		submitSemaphore:         utils.NewSemaphore(concurrentEventCalls),
 		tasksToContainerStates:  make(map[string][]api.ContainerStateChange),
-		stateSaver:              stateManager,
 		dataClient:              dataClient,
 		state:                   state,
 		client:                  client,
@@ -362,18 +355,18 @@ func (taskEvents *taskSendableEvents) submitFirstEvent(handler *TaskHandler, bac
 
 	if event.containerShouldBeSent() {
 		if err := event.send(sendContainerStatusToECS, setContainerChangeSent, "container",
-			handler.client, eventToSubmit, handler.stateSaver, handler.dataClient, backoff, taskEvents); err != nil {
+			handler.client, eventToSubmit, handler.dataClient, backoff, taskEvents); err != nil {
 			return false, err
 		}
 	} else if event.taskShouldBeSent() {
 		if err := event.send(sendTaskStatusToECS, setTaskChangeSent, "task",
-			handler.client, eventToSubmit, handler.stateSaver, handler.dataClient, backoff, taskEvents); err != nil {
+			handler.client, eventToSubmit, handler.dataClient, backoff, taskEvents); err != nil {
 			handleInvalidParamException(err, taskEvents.events, eventToSubmit)
 			return false, err
 		}
 	} else if event.taskAttachmentShouldBeSent() {
 		if err := event.send(sendTaskStatusToECS, setTaskAttachmentSent, "task attachment",
-			handler.client, eventToSubmit, handler.stateSaver, handler.dataClient, backoff, taskEvents); err != nil {
+			handler.client, eventToSubmit, handler.dataClient, backoff, taskEvents); err != nil {
 			handleInvalidParamException(err, taskEvents.events, eventToSubmit)
 			return false, err
 		}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Remove usages of state manager in acs and event handler. Also added logic to save attachment sent status when its part of task state change. Only remaining part that uses state manager to save state is the engine package, which will be cleaned up in a separate change.

### Implementation details
<!-- How are the changes implemented? -->
* `acs/handler`: remove reference of state manager in source code and test; updated few test cases to make sure we have same coverage with data client;
* `api/eni`: added more unit tests to meet coverage; other changes lower coverage by 0.1% which seems to be unavoidable result of the refactoring, so adding more tests here.
* `eventhandler`: remove usage of state manager;  added logic to save attachment sent status when its part of task state change;
* `app`: remove usage of state manager except when loading previous data.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Unit tests added/updated. Manually built the agent and tested:
(1) agent starts from fresh state;
(2) agent starts from state in boltdb;
(3) agent starts from state in state file.

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
N/A

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
