### PR TITLE
Remove state manager usage in task engine

### DIFF
--- a/agent/engine/docker_task_engine_linux_test.go
+++ b/agent/engine/docker_task_engine_linux_test.go
@@ -35,7 +35,6 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	mock_dockerstate "github.com/aws/amazon-ecs-agent/agent/engine/dockerstate/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/engine/testdata"
-	mock_statemanager "github.com/aws/amazon-ecs-agent/agent/statemanager/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/cgroup"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/cgroup/control/mock_control"
@@ -164,11 +163,9 @@ func TestDeleteTask(t *testing.T) {
 	cfg := defaultConfig
 	cfg.TaskCPUMemLimit = config.ExplicitlyEnabled
 	mockState := mock_dockerstate.NewMockTaskEngineState(ctrl)
-	mockSaver := mock_statemanager.NewMockStateManager(ctrl)
 
 	taskEngine := &DockerTaskEngine{
 		state:      mockState,
-		saver:      mockSaver,
 		dataClient: dataClient,
 		cfg:        &cfg,
 	}
@@ -186,7 +183,6 @@ func TestDeleteTask(t *testing.T) {
 		mockState.EXPECT().RemoveTask(task),
 		mockState.EXPECT().ENIByMac(gomock.Any()).Return(attachment, true),
 		mockState.EXPECT().RemoveENIAttachment(mac),
-		mockSaver.EXPECT().Save(),
 	)
 
 	assert.NoError(t, taskEngine.dataClient.SaveENIAttachment(attachment))
@@ -223,11 +219,9 @@ func TestDeleteTaskBranchENIEnabled(t *testing.T) {
 	cfg := defaultConfig
 	cfg.TaskCPUMemLimit = config.ExplicitlyEnabled
 	mockState := mock_dockerstate.NewMockTaskEngineState(ctrl)
-	mockSaver := mock_statemanager.NewMockStateManager(ctrl)
 
 	taskEngine := &DockerTaskEngine{
 		state:      mockState,
-		saver:      mockSaver,
 		cfg:        &cfg,
 		dataClient: data.NewNoopClient(),
 	}
@@ -235,7 +229,6 @@ func TestDeleteTaskBranchENIEnabled(t *testing.T) {
 	gomock.InOrder(
 		mockControl.EXPECT().Remove("cgroupRoot").Return(nil),
 		mockState.EXPECT().RemoveTask(task),
-		mockSaver.EXPECT().Save(),
 	)
 
 	taskEngine.deleteTask(task)

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -54,7 +54,6 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
 	mock_ssm_factory "github.com/aws/amazon-ecs-agent/agent/ssm/factory/mocks"
 	mock_ssmiface "github.com/aws/amazon-ecs-agent/agent/ssm/mocks"
-	mock_statemanager "github.com/aws/amazon-ecs-agent/agent/statemanager/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/asmauth"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/asmsecret"
@@ -698,36 +697,6 @@ func TestStopWithPendingStops(t *testing.T) {
 	pullDone <- true
 	// this means the PullImage is only called once due to the task is stopped before it
 	// gets the pull image lock
-}
-
-func TestCreateContainerForceSave(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.TODO())
-	defer cancel()
-	ctrl, client, _, privateTaskEngine, _, _, _ := mocks(t, ctx, &config.Config{})
-	saver := mock_statemanager.NewMockStateManager(ctrl)
-	defer ctrl.Finish()
-	taskEngine, _ := privateTaskEngine.(*DockerTaskEngine)
-	taskEngine.SetSaver(saver)
-
-	sleepTask := testdata.LoadTask("sleep5")
-	sleepContainer, _ := sleepTask.ContainerByName("sleep5")
-	client.EXPECT().APIVersion().Return(defaultDockerClientAPIVersion, nil).AnyTimes()
-	gomock.InOrder(
-		saver.EXPECT().ForceSave().Do(func() interface{} {
-			task, ok := taskEngine.state.TaskByArn(sleepTask.Arn)
-			assert.True(t, ok, "Expected task with ARN: ", sleepTask.Arn)
-			assert.NotNil(t, task, "Expected task with ARN: ", sleepTask.Arn)
-			_, ok = task.ContainerByName("sleep5")
-			assert.True(t, ok, "Expected container sleep5")
-			return nil
-		}),
-		client.EXPECT().CreateContainer(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()),
-	)
-
-	metadata := taskEngine.createContainer(sleepTask, sleepContainer)
-	if metadata.Error != nil {
-		t.Error("Unexpected error", metadata.Error)
-	}
 }
 
 func TestCreateContainerMetadata(t *testing.T) {
@@ -1502,11 +1471,9 @@ func TestCreateContainerOnAgentRestart(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	ctrl, client, _, privateTaskEngine, _, _, _ := mocks(t, ctx, &config.Config{})
-	saver := mock_statemanager.NewMockStateManager(ctrl)
 	defer ctrl.Finish()
 
 	taskEngine, _ := privateTaskEngine.(*DockerTaskEngine)
-	taskEngine.SetSaver(saver)
 	state := taskEngine.State()
 	sleepTask := testdata.LoadTask("sleep5")
 	sleepContainer, _ := sleepTask.ContainerByName("sleep5")
@@ -1547,8 +1514,6 @@ func TestPullNormalImage(t *testing.T) {
 	ctrl, client, _, privateTaskEngine, _, imageManager, _ := mocks(t, ctx, &config.Config{})
 	defer ctrl.Finish()
 	taskEngine, _ := privateTaskEngine.(*DockerTaskEngine)
-	saver := mock_statemanager.NewMockStateManager(ctrl)
-	taskEngine.SetSaver(saver)
 	taskEngine._time = nil
 	imageName := "image"
 	container := &apicontainer.Container{
@@ -1565,7 +1530,6 @@ func TestPullNormalImage(t *testing.T) {
 	client.EXPECT().PullImage(gomock.Any(), imageName, nil, gomock.Any())
 	imageManager.EXPECT().RecordContainerReference(container)
 	imageManager.EXPECT().GetImageStateFromImageName(imageName).Return(imageState, true)
-	saver.EXPECT().Save()
 	metadata := taskEngine.pullContainer(task, container)
 	assert.Equal(t, dockerapi.DockerContainerMetadata{}, metadata, "expected empty metadata")
 }
@@ -1592,8 +1556,6 @@ func TestPullImageWithImagePullOnceBehavior(t *testing.T) {
 			ctrl, client, _, privateTaskEngine, _, imageManager, _ := mocks(t, ctx, &config.Config{ImagePullBehavior: config.ImagePullOnceBehavior})
 			defer ctrl.Finish()
 			taskEngine, _ := privateTaskEngine.(*DockerTaskEngine)
-			saver := mock_statemanager.NewMockStateManager(ctrl)
-			taskEngine.SetSaver(saver)
 			taskEngine._time = nil
 			imageName := "image"
 			container := &apicontainer.Container{
@@ -1612,7 +1574,6 @@ func TestPullImageWithImagePullOnceBehavior(t *testing.T) {
 			}
 			imageManager.EXPECT().RecordContainerReference(container)
 			imageManager.EXPECT().GetImageStateFromImageName(imageName).Return(imageState, true).Times(2)
-			saver.EXPECT().Save()
 			metadata := taskEngine.pullContainer(task, container)
 			assert.Equal(t, dockerapi.DockerContainerMetadata{}, metadata, "expected empty metadata")
 		})
@@ -1625,8 +1586,6 @@ func TestPullImageWithImagePullPreferCachedBehaviorWithCachedImage(t *testing.T)
 	ctrl, client, _, privateTaskEngine, _, imageManager, _ := mocks(t, ctx, &config.Config{ImagePullBehavior: config.ImagePullPreferCachedBehavior})
 	defer ctrl.Finish()
 	taskEngine, _ := privateTaskEngine.(*DockerTaskEngine)
-	saver := mock_statemanager.NewMockStateManager(ctrl)
-	taskEngine.SetSaver(saver)
 	taskEngine._time = nil
 	imageName := "image"
 	container := &apicontainer.Container{
@@ -1642,7 +1601,6 @@ func TestPullImageWithImagePullPreferCachedBehaviorWithCachedImage(t *testing.T)
 	client.EXPECT().InspectImage(imageName).Return(nil, nil)
 	imageManager.EXPECT().RecordContainerReference(container)
 	imageManager.EXPECT().GetImageStateFromImageName(imageName).Return(imageState, true)
-	saver.EXPECT().Save()
 	metadata := taskEngine.pullContainer(task, container)
 	assert.Equal(t, dockerapi.DockerContainerMetadata{}, metadata, "expected empty metadata")
 }
@@ -1653,8 +1611,6 @@ func TestPullImageWithImagePullPreferCachedBehaviorWithoutCachedImage(t *testing
 	ctrl, client, _, privateTaskEngine, _, imageManager, _ := mocks(t, ctx, &config.Config{ImagePullBehavior: config.ImagePullPreferCachedBehavior})
 	defer ctrl.Finish()
 	taskEngine, _ := privateTaskEngine.(*DockerTaskEngine)
-	saver := mock_statemanager.NewMockStateManager(ctrl)
-	taskEngine.SetSaver(saver)
 	taskEngine._time = nil
 	imageName := "image"
 	container := &apicontainer.Container{
@@ -1671,7 +1627,6 @@ func TestPullImageWithImagePullPreferCachedBehaviorWithoutCachedImage(t *testing
 	client.EXPECT().PullImage(gomock.Any(), imageName, nil, gomock.Any())
 	imageManager.EXPECT().RecordContainerReference(container)
 	imageManager.EXPECT().GetImageStateFromImageName(imageName).Return(imageState, true)
-	saver.EXPECT().Save()
 	metadata := taskEngine.pullContainer(task, container)
 	assert.Equal(t, dockerapi.DockerContainerMetadata{}, metadata, "expected empty metadata")
 }
@@ -1682,8 +1637,6 @@ func TestUpdateContainerReference(t *testing.T) {
 	ctrl, _, _, privateTaskEngine, _, imageManager, _ := mocks(t, ctx, &config.Config{})
 	defer ctrl.Finish()
 	taskEngine, _ := privateTaskEngine.(*DockerTaskEngine)
-	saver := mock_statemanager.NewMockStateManager(ctrl)
-	taskEngine.SetSaver(saver)
 	taskEngine._time = nil
 	imageName := "image"
 	container := &apicontainer.Container{
@@ -1699,7 +1652,6 @@ func TestUpdateContainerReference(t *testing.T) {
 
 	imageManager.EXPECT().RecordContainerReference(container)
 	imageManager.EXPECT().GetImageStateFromImageName(imageName).Return(imageState, true)
-	saver.EXPECT().Save()
 	taskEngine.updateContainerReference(true, container, task.Arn)
 	assert.True(t, imageState.PullSucceeded, "PullSucceeded set to false")
 }
@@ -1715,7 +1667,6 @@ func TestMetadataFileUpdatedAgentRestart(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	ctrl, client, _, privateTaskEngine, _, imageManager, metadataManager := mocks(t, ctx, conf)
-	saver := mock_statemanager.NewMockStateManager(ctrl)
 	defer ctrl.Finish()
 
 	var metadataUpdateWG sync.WaitGroup
@@ -1724,7 +1675,6 @@ func TestMetadataFileUpdatedAgentRestart(t *testing.T) {
 	assert.True(t, taskEngine.cfg.ContainerMetadataEnabled, "ContainerMetadataEnabled set to false.")
 
 	taskEngine._time = nil
-	taskEngine.SetSaver(saver)
 	state := taskEngine.State()
 	task := testdata.LoadTask("sleep5")
 	container, _ := task.ContainerByName("sleep5")
@@ -1741,8 +1691,6 @@ func TestMetadataFileUpdatedAgentRestart(t *testing.T) {
 	client.EXPECT().ContainerEvents(gomock.Any()).Return(eventStream, nil)
 	client.EXPECT().DescribeContainer(gomock.Any(), gomock.Any())
 	imageManager.EXPECT().RecordContainerReference(gomock.Any())
-	saver.EXPECT().Save().AnyTimes()
-	saver.EXPECT().ForceSave().AnyTimes()
 
 	metadataManager.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(
 		func(ctx interface{}, dockerID string, task *apitask.Task, containerName string) {
@@ -1961,7 +1909,6 @@ func TestTaskWaitForHostResourceOnRestart(t *testing.T) {
 	defer cancel()
 	ctrl, client, _, privateTaskEngine, _, imageManager, _ := mocks(t, ctx, conf)
 	defer ctrl.Finish()
-	saver := mock_statemanager.NewMockStateManager(ctrl)
 
 	client.EXPECT().Version(gomock.Any(), gomock.Any()).MaxTimes(1)
 	client.EXPECT().ContainerEvents(gomock.Any()).MaxTimes(1)
@@ -1970,7 +1917,6 @@ func TestTaskWaitForHostResourceOnRestart(t *testing.T) {
 	assert.NoError(t, err)
 
 	taskEngine := privateTaskEngine.(*DockerTaskEngine)
-	taskEngine.saver = saver
 	taskEngine.State().AddTask(taskStoppedByACS)
 	taskEngine.State().AddTask(taskNotStarted)
 	taskEngine.State().AddTask(taskEssentialContainerStopped)
@@ -1997,7 +1943,6 @@ func TestTaskWaitForHostResourceOnRestart(t *testing.T) {
 	}).Times(3)
 	imageManager.EXPECT().RecordContainerReference(gomock.Any()).Times(3)
 
-	saver.EXPECT().Save()
 	// start the two tasks
 	taskEngine.synchronizeState()
 

--- a/agent/engine/docker_task_engine_windows_test.go
+++ b/agent/engine/docker_task_engine_windows_test.go
@@ -23,7 +23,6 @@ import (
 	mock_dockerstate "github.com/aws/amazon-ecs-agent/agent/engine/dockerstate/mocks"
 	mock_s3_factory "github.com/aws/amazon-ecs-agent/agent/s3/factory/mocks"
 	mock_ssm_factory "github.com/aws/amazon-ecs-agent/agent/ssm/factory/mocks"
-	mock_statemanager "github.com/aws/amazon-ecs-agent/agent/statemanager/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/credentialspec"
 
@@ -45,12 +44,10 @@ func TestDeleteTask(t *testing.T) {
 	require.NoError(t, dataClient.SaveTask(task))
 
 	mockState := mock_dockerstate.NewMockTaskEngineState(ctrl)
-	mockSaver := mock_statemanager.NewMockStateManager(ctrl)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	taskEngine := &DockerTaskEngine{
 		state:      mockState,
-		saver:      mockSaver,
 		dataClient: dataClient,
 		cfg:        &defaultConfig,
 		ctx:        ctx,
@@ -58,7 +55,6 @@ func TestDeleteTask(t *testing.T) {
 
 	gomock.InOrder(
 		mockState.EXPECT().RemoveTask(task),
-		mockSaver.EXPECT().Save(),
 	)
 
 	taskEngine.deleteTask(task)

--- a/agent/engine/interface.go
+++ b/agent/engine/interface.go
@@ -21,7 +21,6 @@ import (
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	"github.com/aws/amazon-ecs-agent/agent/data"
 	"github.com/aws/amazon-ecs-agent/agent/statechange"
-	"github.com/aws/amazon-ecs-agent/agent/statemanager"
 )
 
 // TaskEngine is an interface for the DockerTaskEngine
@@ -37,7 +36,6 @@ type TaskEngine interface {
 	// executed. Specifically, it will provide information when they reach
 	// running or stopped, as well as providing portbinding and other metadata
 	StateChangeEvents() chan statechange.Event
-	SetSaver(statemanager.Saver)
 	// SetDataClient sets the data client that is used by the task engine.
 	SetDataClient(data.Client)
 

--- a/agent/engine/mocks/engine_mocks.go
+++ b/agent/engine/mocks/engine_mocks.go
@@ -27,7 +27,6 @@ import (
 	data "github.com/aws/amazon-ecs-agent/agent/data"
 	image "github.com/aws/amazon-ecs-agent/agent/engine/image"
 	statechange "github.com/aws/amazon-ecs-agent/agent/statechange"
-	statemanager "github.com/aws/amazon-ecs-agent/agent/statemanager"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -187,18 +186,6 @@ func (m *MockTaskEngine) SetDataClient(arg0 data.Client) {
 func (mr *MockTaskEngineMockRecorder) SetDataClient(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDataClient", reflect.TypeOf((*MockTaskEngine)(nil).SetDataClient), arg0)
-}
-
-// SetSaver mocks base method
-func (m *MockTaskEngine) SetSaver(arg0 statemanager.Saver) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetSaver", arg0)
-}
-
-// SetSaver indicates an expected call of SetSaver
-func (mr *MockTaskEngineMockRecorder) SetSaver(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSaver", reflect.TypeOf((*MockTaskEngine)(nil).SetSaver), arg0)
 }
 
 // StateChangeEvents mocks base method

--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -33,7 +33,6 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/engine/dependencygraph"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
 	"github.com/aws/amazon-ecs-agent/agent/statechange"
-	"github.com/aws/amazon-ecs-agent/agent/statemanager"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
 	"github.com/aws/amazon-ecs-agent/agent/utils/retry"
@@ -127,7 +126,6 @@ type managedTask struct {
 
 	engine             *DockerTaskEngine
 	cfg                *config.Config
-	saver              statemanager.Saver
 	credentialsManager credentials.Manager
 	cniClient          ecscni.CNIClient
 	taskStopWG         *utilsync.SequentialWaitGroup
@@ -176,7 +174,6 @@ func (engine *DockerTaskEngine) newManagedTask(task *apitask.Task) *managedTask 
 		cfg:                           engine.cfg,
 		stateChangeEvents:             engine.stateChangeEvents,
 		containerChangeEventStream:    engine.containerChangeEventStream,
-		saver:                         engine.saver,
 		credentialsManager:            engine.credentialsManager,
 		cniClient:                     engine.cniClient,
 		taskStopWG:                    engine.taskStopGroup,
@@ -223,16 +220,6 @@ func (mtask *managedTask) overseeTask() {
 				mtask.Arn)
 
 			mtask.progressTask()
-		}
-
-		// If we reach this point, we've changed the task in some way.
-		// Conversely, for it to spin in steady state it will have to have been
-		// loaded in steady state or progressed through here, so saving here should
-		// be sufficient to capture state changes.
-		err := mtask.saver.Save()
-		if err != nil {
-			seelog.Warnf("Managed task [%s]: unable to checkpoint task's states to disk: %v",
-				mtask.Arn, err)
 		}
 
 		if mtask.GetKnownStatus().Terminal() {
@@ -496,7 +483,6 @@ func (mtask *managedTask) handleResourceStateChange(resChange resourceStateChang
 	// at the end.
 	defer mtask.engine.saveTaskData(mtask.Task)
 
-	defer mtask.engine.saver.Save()
 	// Set known status regardless of error so the applied status can be cleared. If there is error,
 	// the known status might be set again below (but that won't affect the applied status anymore).
 	// This follows how container state change is handled.

--- a/agent/engine/task_manager_data_test.go
+++ b/agent/engine/task_manager_data_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
 	"github.com/aws/amazon-ecs-agent/agent/statechange"
-	"github.com/aws/amazon-ecs-agent/agent/statemanager"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
 	resourcetype "github.com/aws/amazon-ecs-agent/agent/taskresource/types"
@@ -286,7 +285,6 @@ func TestHandleResourceStateChangeSaveData(t *testing.T) {
 					DesiredStatusUnsafe: apitaskstatus.TaskRunning,
 				},
 				engine: &DockerTaskEngine{
-					saver:      statemanager.NewNoopStateManager(),
 					dataClient: dataClient,
 				},
 			}

--- a/agent/engine/task_manager_unix_test.go
+++ b/agent/engine/task_manager_unix_test.go
@@ -25,7 +25,6 @@ import (
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	"github.com/aws/amazon-ecs-agent/agent/data"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dependencygraph"
-	mock_statemanager "github.com/aws/amazon-ecs-agent/agent/statemanager/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/cgroup"
 	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
@@ -69,7 +68,6 @@ func TestHandleResourceStateChangeAndSave(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
-			mockSaver := mock_statemanager.NewMockStateManager(ctrl)
 			res := &cgroup.CgroupResource{}
 			res.SetKnownStatus(tc.KnownStatus)
 			mtask := managedTask{
@@ -83,10 +81,6 @@ func TestHandleResourceStateChangeAndSave(t *testing.T) {
 				},
 			}
 			mtask.AddResource("cgroup", res)
-			mtask.engine.SetSaver(mockSaver)
-			gomock.InOrder(
-				mockSaver.EXPECT().Save(),
-			)
 			mtask.handleResourceStateChange(resourceStateChange{
 				res, tc.DesiredKnownStatus, tc.Err,
 			})

--- a/agent/stats/common_test.go
+++ b/agent/stats/common_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
 	"github.com/aws/amazon-ecs-agent/agent/statechange"
-	"github.com/aws/amazon-ecs-agent/agent/statemanager"
 	"github.com/aws/amazon-ecs-agent/agent/tcs/model/ecstcs"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -298,9 +297,6 @@ func (engine *MockTaskEngine) MustInit(ctx context.Context) {
 
 func (engine *MockTaskEngine) StateChangeEvents() chan statechange.Event {
 	return make(chan statechange.Event)
-}
-
-func (engine *MockTaskEngine) SetSaver(statemanager.Saver) {
 }
 
 func (engine *MockTaskEngine) SetDataClient(data.Client) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Remove state manager usage in task engine. Corresponding state persistence logic has been implemented with boltdb.

### Implementation details
<!-- How are the changes implemented? -->
Remove saver field in docker task engine and task manager, and the usage of them.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Manually built agent and tested starting from boltdb, starting from state file and starting fresh.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
N/A

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
