### PR TITLE
Remove unnecessary db saves and use batch for db update

### DIFF
--- a/agent/data/container_client.go
+++ b/agent/data/container_client.go
@@ -29,7 +29,7 @@ func (c *client) SaveDockerContainer(container *apicontainer.DockerContainer) er
 	if err != nil {
 		return errors.Wrap(err, "failed to generate database id")
 	}
-	return c.db.Update(func(tx *bolt.Tx) error {
+	return c.db.Batch(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte(containersBucketName))
 		return putObject(b, id, container)
 	})
@@ -49,7 +49,7 @@ func (c *client) SaveContainer(container *apicontainer.Container) error {
 		dockerContainer = &apicontainer.DockerContainer{}
 	}
 	dockerContainer.Container = container
-	return c.db.Update(func(tx *bolt.Tx) error {
+	return c.db.Batch(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte(containersBucketName))
 		return putObject(b, id, dockerContainer)
 	})
@@ -65,7 +65,7 @@ func (c *client) getDockerContainer(id string) (*apicontainer.DockerContainer, e
 
 // DeleteContainer deletes a container from the container bucket.
 func (c *client) DeleteContainer(id string) error {
-	return c.db.Update(func(tx *bolt.Tx) error {
+	return c.db.Batch(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte(containersBucketName))
 		return b.Delete([]byte(id))
 	})

--- a/agent/data/eniattachment_client.go
+++ b/agent/data/eniattachment_client.go
@@ -28,14 +28,14 @@ func (c *client) SaveENIAttachment(eni *apieni.ENIAttachment) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to generate database id")
 	}
-	return c.db.Update(func(tx *bolt.Tx) error {
+	return c.db.Batch(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte(eniAttachmentsBucketName))
 		return putObject(b, id, eni)
 	})
 }
 
 func (c *client) DeleteENIAttachment(id string) error {
-	return c.db.Update(func(tx *bolt.Tx) error {
+	return c.db.Batch(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte(eniAttachmentsBucketName))
 		return b.Delete([]byte(id))
 	})

--- a/agent/data/imagestate_client.go
+++ b/agent/data/imagestate_client.go
@@ -27,14 +27,14 @@ func (c *client) SaveImageState(img *image.ImageState) error {
 	if id == "" {
 		return errors.New("failed to generate database image id")
 	}
-	return c.db.Update(func(tx *bolt.Tx) error {
+	return c.db.Batch(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte(imagesBucketName))
 		return putObject(b, id, img)
 	})
 }
 
 func (c *client) DeleteImageState(id string) error {
-	return c.db.Update(func(tx *bolt.Tx) error {
+	return c.db.Batch(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte(imagesBucketName))
 		return b.Delete([]byte(id))
 	})

--- a/agent/data/metadata_client.go
+++ b/agent/data/metadata_client.go
@@ -27,7 +27,7 @@ const (
 )
 
 func (c *client) SaveMetadata(key, val string) error {
-	return c.db.Update(func(tx *bolt.Tx) error {
+	return c.db.Batch(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte(metadataBucketName))
 		return putObject(b, key, val)
 	})

--- a/agent/data/task_client.go
+++ b/agent/data/task_client.go
@@ -29,7 +29,7 @@ func (c *client) SaveTask(task *apitask.Task) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to generate database id")
 	}
-	return c.db.Update(func(tx *bolt.Tx) error {
+	return c.db.Batch(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte(tasksBucketName))
 		return putObject(b, id, task)
 	})
@@ -37,7 +37,7 @@ func (c *client) SaveTask(task *apitask.Task) error {
 
 // DeleteTask deletes a task from the task bucket.
 func (c *client) DeleteTask(id string) error {
-	return c.db.Update(func(tx *bolt.Tx) error {
+	return c.db.Batch(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte(tasksBucketName))
 		return b.Delete([]byte(id))
 	})

--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -414,7 +414,6 @@ func (mtask *managedTask) handleContainerChange(containerChange dockerContainerC
 		// Only update container metadata when status stays RUNNING
 		if event.Status == containerKnownStatus && event.Status == apicontainerstatus.ContainerRunning {
 			updateContainerMetadata(&event.DockerContainerMetadata, container, mtask.Task)
-			mtask.engine.saveContainerData(container)
 		}
 		return
 	}

--- a/agent/engine/task_manager_data_test.go
+++ b/agent/engine/task_manager_data_test.go
@@ -126,15 +126,7 @@ func TestHandleContainerStateChangeSaveData(t *testing.T) {
 			shouldSaveContainer: true,
 		},
 		{
-			name:                "redundant container state change with metadata update is saved",
-			knownState:          apicontainerstatus.ContainerRunning,
-			nextState:           apicontainerstatus.ContainerRunning,
-			taskKnownState:      apitaskstatus.TaskRunning,
-			taskDesiredState:    apitaskstatus.TaskRunning,
-			shouldSaveContainer: true,
-		},
-		{
-			name:             "redundant container state change without metadata update is not saved",
+			name:             "redundant container state change is not saved",
 			knownState:       apicontainerstatus.ContainerCreated,
 			nextState:        apicontainerstatus.ContainerCreated,
 			taskKnownState:   apitaskstatus.TaskCreated,

--- a/agent/sighandlers/termination_handler.go
+++ b/agent/sighandlers/termination_handler.go
@@ -32,6 +32,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/sighandlers/exitcodes"
 
+	"github.com/boltdb/bolt"
 	"github.com/cihub/seelog"
 )
 
@@ -133,4 +134,6 @@ func saveStateAll(state dockerstate.TaskEngineState, dataClient data.Client) {
 			seelog.Errorf("Failed to save data for eni attachment %s: %v", eniAttachment.AttachmentARN, err)
 		}
 	}
+	// Wait to ensure data is saved.
+	time.Sleep(bolt.DefaultMaxBatchDelay)
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Some changes to improve/address issues found in load testing:
1. Remove a few unnecessary db saves for task, container and image;
2. and use batch for db update. per [boltdb doc](https://godoc.org/github.com/boltdb/bolt#DB.Batch), Batch is similar to update except they can be batched, and that the transaction needs to be idempotent (which is true for our case). Per my testing switching to Batch help reduce write ops by 10-20% in load test.

### Implementation details
<!-- How are the changes implemented? -->
* In task manager, remove SaveContainer call when handling redundant container change. I thought we need to save it when metadata is updated, but we don't because when the agent restarts, it will inspect every container it has and get its latest metadata anyway: https://github.com/aws/amazon-ecs-agent/blob/master/agent/engine/docker_task_engine.go#L429-L431
* In updateContainerReference, avoid an extra image save when its state didn't change;
* In acs payload handler, skip saving task if its desired status is stopped, since the task is already in db in that case;
* Switch db.Update call to db.Batch in data client implementation;
* In termination handler, add a wait to wait for batch to complete (which is 10ms so seems fine to me).

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Updated existing unit tests. Manually tested it in load test.

New tests cover the changes: <!-- yes|no --> no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
N/A

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.