### PR TITLE
injecting udev monitor into agent so that it can be mocked out in test

### DIFF
--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -39,6 +39,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/engine"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/eni/pause"
+	"github.com/aws/amazon-ecs-agent/agent/eni/udevwrapper"
 	"github.com/aws/amazon-ecs-agent/agent/eventhandler"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
 	"github.com/aws/amazon-ecs-agent/agent/handlers"
@@ -103,6 +104,7 @@ type ecsAgent struct {
 	stateManagerFactory         factory.StateManager
 	saveableOptionFactory       factory.SaveableOption
 	pauseLoader                 pause.Loader
+	udevMonitor                 udevwrapper.Udev
 	cniClient                   ecscni.CNIClient
 	vpc                         string
 	subnet                      string

--- a/agent/eni/udevwrapper/udev_unsupported.go
+++ b/agent/eni/udevwrapper/udev_unsupported.go
@@ -1,0 +1,31 @@
+// +build !linux
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package udevwrapper
+
+import (
+	"runtime"
+
+	"github.com/pkg/errors"
+)
+
+type Udev interface {
+}
+
+// New returns an UDev Monitor
+func New() (interface{}, error) {
+	return nil, errors.Errorf("udev monitor creation: unsupported platform: %s/%s",
+		runtime.GOOS, runtime.GOARCH)
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Refactored out udevMonitor as a field in agent, to be injected for testing.
Fix for https://github.com/aws/amazon-ecs-agent/issues/2527

### Implementation details
- add udevMonitor field in agent
- only initialize it when Task ENI Dependencies are initialized
- inject mock object for unit test

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: n/a

Consecutive run succeeds:
```
go test -v -tags unit -run "^TestDoStartTaskENIHappyPath$" -count 2 ./agent/app/   
=== RUN   TestDoStartTaskENIHappyPath
level=info time=2020-08-05T21:56:25Z msg="Checkpointing not enabled; a new container instance will be created each time the agent is run" module=agent.go
level=warn time=2020-08-05T21:56:25Z msg="Error getting valid credentials (AKID ): <nil>" module=agent.go
level=info time=2020-08-05T21:56:25Z msg="Event stream events start listening..." module=eventstream.go
level=info time=2020-08-05T21:56:25Z msg="Outpost ARN from EC2 Metadata: " module=agent.go
level=info time=2020-08-05T21:56:25Z msg="Registering Instance with ECS" module=agent.go
level=info time=2020-08-05T21:56:25Z msg="Registration completed successfully. I am running as 'arn' in cluster ''" module=agent.go
level=info time=2020-08-05T21:56:25Z msg="Beginning Polling for updates" module=agent.go
level=info time=2020-08-05T21:56:25Z msg="Event stream DeregisterContainerInstance start listening..." module=eventstream.go
level=info time=2020-08-05T21:56:25Z msg="Establishing a Websocket connection to poll-endpoint/ws?agentHash=%2A1a88cff9&agentVersion=1.42.0&clusterArn=&containerInstanceArn=arn&dockerVersion=DockerVersion%3A+&sendCredentials=true&seqNum=1" module=client.go
level=error time=2020-08-05T21:56:25Z msg="Error connecting to ACS: wsclient: unknown scheme " module=acs_handler.go
level=info time=2020-08-05T21:56:25Z msg="Initializing stats engine" module=engine.go
--- PASS: TestDoStartTaskENIHappyPath (0.00s)
level=info time=2020-08-05T21:56:25Z msg="Reconnecting to ACS in: 282.153551ms" module=acs_handler.go
level=info time=2020-08-05T21:56:25Z msg="Interrupted waiting for reconnect delay to elapse; Expect session to close" module=acs_handler.go
=== RUN   TestDoStartTaskENIHappyPath
level=info time=2020-08-05T21:56:25Z msg="Establishing a Websocket connection to telemetry-endpoint/ws?agentHash=%2A1a88cff9&agentVersion=1.42.0&cluster=&containerInstance=arn&dockerVersion=" module=client.go
level=error time=2020-08-05T21:56:25Z msg="Error connecting to TCS: wsclient: unknown scheme " module=handler.go
level=error time=2020-08-05T21:56:25Z msg="Error: lost websocket connection with ECS Telemetry service (TCS): wsclient: unknown scheme " module=handler.go
level=info time=2020-08-05T21:56:25Z msg="Exiting the engine event handler." module=handler.go
level=info time=2020-08-05T21:56:25Z msg="TaskHandler: Stopping periodic container state change submission ticker" module=task_handler.go
level=info time=2020-08-05T21:56:25Z msg="Event stream DeregisterContainerInstance stopped listening..." module=eventstream.go
level=info time=2020-08-05T21:56:25Z msg="Event stream events stopped listening..." module=eventstream.go
level=info time=2020-08-05T21:56:25Z msg="Checkpointing not enabled; a new container instance will be created each time the agent is run" module=agent.go
level=warn time=2020-08-05T21:56:25Z msg="Error getting valid credentials (AKID ): <nil>" module=agent.go
level=info time=2020-08-05T21:56:25Z msg="Event stream events start listening..." module=eventstream.go
level=info time=2020-08-05T21:56:25Z msg="Outpost ARN from EC2 Metadata: " module=agent.go
level=info time=2020-08-05T21:56:25Z msg="Registering Instance with ECS" module=agent.go
level=info time=2020-08-05T21:56:25Z msg="Registration completed successfully. I am running as 'arn' in cluster ''" module=agent.go
level=info time=2020-08-05T21:56:25Z msg="Beginning Polling for updates" module=agent.go
level=info time=2020-08-05T21:56:25Z msg="Establishing a Websocket connection to poll-endpoint/ws?agentHash=%2A1a88cff9&agentVersion=1.42.0&clusterArn=&containerInstanceArn=arn&dockerVersion=DockerVersion%3A+&sendCredentials=true&seqNum=1" module=client.go
level=error time=2020-08-05T21:56:25Z msg="Error connecting to ACS: wsclient: unknown scheme " module=acs_handler.go
level=info time=2020-08-05T21:56:25Z msg="Reconnecting to ACS in: 285.010051ms" module=acs_handler.go
level=info time=2020-08-05T21:56:25Z msg="Initializing stats engine" module=engine.go
level=info time=2020-08-05T21:56:25Z msg="Establishing a Websocket connection to telemetry-endpoint/ws?agentHash=%2A1a88cff9&agentVersion=1.42.0&cluster=&containerInstance=arn&dockerVersion=" module=client.go
level=info time=2020-08-05T21:56:25Z msg="Event stream DeregisterContainerInstance start listening..." module=eventstream.go
level=error time=2020-08-05T21:56:25Z msg="Error connecting to TCS: wsclient: unknown scheme " module=handler.go
level=info time=2020-08-05T21:56:25Z msg="Event stream DeregisterContainerInstance stopped listening..." module=eventstream.go
--- PASS: TestDoStartTaskENIHappyPath (0.00s)
PASS
level=info time=2020-08-05T21:56:25Z msg="TaskHandler: Stopping periodic container state change submission ticker" module=task_handler.go
level=info time=2020-08-05T21:56:25Z msg="Event stream events stopped listening..." module=eventstream.go
ok  	github.com/aws/amazon-ecs-agent/agent/app	0.014s
```

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
