### PR TITLE
ENI timeout fix

### DIFF
--- a/agent/eni/watcher/watcher_linux.go
+++ b/agent/eni/watcher/watcher_linux.go
@@ -51,7 +51,7 @@ const (
 	// when looking for ENI in agent's state. If for whatever reason, the message
 	// from ACS is received after the ENI has been attached to the instance, this
 	// timeout duration will be used to wait for ENI message to be sent from ACS
-	sendENIStateChangeRetryTimeout = 3 * time.Second
+	sendENIStateChangeRetryTimeout = 6 * time.Second
 
 	// sendENIStateChangeBackoffMin specifies minimum value for backoff when
 	// waiting for attachment message from ACS


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
On some nitro instances, udev event from kernel when the ENI is attached happens before we get the ENI payload from ACS which causes a delay in time taken by Agent to acknowledge that ENI is attached.

 By increasing the timeout from 3sec to 6sec, Agent will wait longer for message from ACS after udev event is received, this will reduce the overall time taken by Agent to acknowledge that ENI is attached. 
 
### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
