### PR TITLE
Parse boolean value strings in lowercase to avoid problems on case-insensitive platforms like Windows

### DIFF
--- a/agent/config/parse.go
+++ b/agent/config/parse.go
@@ -208,7 +208,7 @@ func parseBooleanDefaultFalseConfig(envVarName string) BooleanDefaultFalse {
 	boolDefaultFalseCofig := BooleanDefaultFalse{Value: NotSet}
 	configString := os.Getenv(envVarName)
 	if configString != "" {
-		err := json.Unmarshal([]byte(configString), &boolDefaultFalseCofig)
+		err := json.Unmarshal([]byte(strings.ToLower(configString)), &boolDefaultFalseCofig)
 		if err != nil {
 			seelog.Warnf("Invalid format for \"%s\", expected a boolean. err %v", envVarName, err)
 		}
@@ -220,7 +220,7 @@ func parseBooleanDefaultTrueConfig(envVarName string) BooleanDefaultTrue {
 	boolDefaultTrueCofig := BooleanDefaultTrue{Value: NotSet}
 	configString := os.Getenv(envVarName)
 	if configString != "" {
-		err := json.Unmarshal([]byte(configString), &boolDefaultTrueCofig)
+		err := json.Unmarshal([]byte(strings.ToLower(configString)), &boolDefaultTrueCofig)
 		if err != nil {
 			seelog.Warnf("Invalid format for \"%s\", expected a boolean. err %v", envVarName, err)
 		}

--- a/agent/config/parse_windows_test.go
+++ b/agent/config/parse_windows_test.go
@@ -28,3 +28,15 @@ func TestParseGMSACapability(t *testing.T) {
 
 	assert.False(t, parseGMSACapability())
 }
+
+func TestParseBooleanEnvVar(t *testing.T) {
+	os.Setenv("EXAMPLE_SETTING", "True")
+	defer os.Unsetenv("EXAMPLE_SETTING")
+
+	assert.True(t, parseBooleanDefaultFalseConfig("EXAMPLE_SETTING"))
+	assert.True(t, parseBooleanDefaultTrueConfig("EXAMPLE_SETTING"))
+
+	os.Setenv("EXAMPLE_SETTING", "False")
+	assert.False(t, parseBooleanDefaultFalseConfig("EXAMPLE_SETTING"))
+	assert.False(t, parseBooleanDefaultTrueConfig("EXAMPLE_SETTING"))
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Lowercases theoretically-boolean values before attempting to unmarshal them from environment variables. This fixes #2571 because in Windows, the setting of an environment variable with the `$TRUE` (or `$True`, or `$true`) value results in the string representation `True`, which cannot be parsed as JSON. This breaks existing deployments of Windows-based agents.

It has the side benefit of allowing Python-style truthy values to be parsed as well.

### Implementation details
Using existing `strings` import with `strings.ToLower` around the value of the environment variable when calling `json.Unmarshal`

### Testing


<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes:  yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Handle non-lowercase settings for Windows boolean environment variables

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
