### PR TITLE
Use go 1.14 and go modules to build amazon-vpc-cni-plugins

### DIFF
--- a/scripts/dockerfiles/Dockerfile.buildVPCCNIPlugins
+++ b/scripts/dockerfiles/Dockerfile.buildVPCCNIPlugins
@@ -11,12 +11,16 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-FROM golang:1.10
+FROM golang:1.14
 MAINTAINER Amazon Web Services, Inc.
 
 ARG GOARCH
 
 ENV GOARCH ${GOARCH}
+
+ENV XDG_CACHE_HOME /tmp
+
+ENV GOFLAGS=-mod=vendor
 
 RUN mkdir -p /go/src/github.com/aws/
 

--- a/scripts/dockerfiles/Dockerfile.buildVPCCNIPlugins
+++ b/scripts/dockerfiles/Dockerfile.buildVPCCNIPlugins
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-FROM golang:1.14
+FROM golang:1.15
 MAINTAINER Amazon Web Services, Inc.
 
 ARG GOARCH


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Modifies scripts/dockerfiles/Dockerfile.buildVPCCNIPlugins to add support for go 1.14 and go modules for amazon-vpc-cni-plugins

### Implementation details
<!-- How are the changes implemented? -->
Pulling from golang:1.14 doker image and passing required golang flags to enable vendoring for go modules.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

make test
make release


New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

* Enhancement - Use go 1.14 and go modules to build amazon-vpc-cni-plugins

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
