### PR TITLE
Cleanup warning log noise from parsing intentionally unset config

### DIFF
--- a/agent/config/parse.go
+++ b/agent/config/parse.go
@@ -206,8 +206,13 @@ func parseAdditionalLocalRoutes(errs []error) ([]cnitypes.IPNet, []error) {
 
 func parseBooleanDefaultFalseConfig(envVarName string) BooleanDefaultFalse {
 	boolDefaultFalseCofig := BooleanDefaultFalse{Value: NotSet}
-	configString := os.Getenv(envVarName)
-	res, err := strconv.ParseBool(strings.TrimSpace(configString))
+	configString := strings.TrimSpace(os.Getenv(envVarName))
+	if configString == "" {
+		// if intentionally not set, do not add warning log
+		return boolDefaultFalseCofig
+	}
+
+	res, err := strconv.ParseBool(configString)
 	if err == nil {
 		if res {
 			boolDefaultFalseCofig.Value = ExplicitlyEnabled
@@ -222,8 +227,13 @@ func parseBooleanDefaultFalseConfig(envVarName string) BooleanDefaultFalse {
 
 func parseBooleanDefaultTrueConfig(envVarName string) BooleanDefaultTrue {
 	boolDefaultTrueCofig := BooleanDefaultTrue{Value: NotSet}
-	configString := os.Getenv(envVarName)
-	res, err := strconv.ParseBool(strings.TrimSpace(configString))
+	configString := strings.TrimSpace(os.Getenv(envVarName))
+	if configString == "" {
+		// if intentionally not set, do not add warning log
+		return boolDefaultTrueCofig
+	}
+
+	res, err := strconv.ParseBool(configString)
 	if err == nil {
 		if res {
 			boolDefaultTrueCofig.Value = ExplicitlyEnabled


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
do not log warning when parsing intentionally unset config

### Implementation details
early check and return on unset value for boolean configs

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: N/A

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
