### PR TITLE
Instamojo fix/envfiles deadlock

### DIFF
--- a/agent/taskresource/envFiles/envfile.go
+++ b/agent/taskresource/envFiles/envfile.go
@@ -108,13 +108,13 @@ func (envfile *EnvironmentFileResource) Initialize(resourceFields *taskresource.
 	taskKnownStatus status.TaskStatus,
 	taskDesiredStatus status.TaskStatus) {
 	envfile.lock.Lock()
-	defer envfile.lock.Unlock()
 
 	envfile.initStatusToTransition()
 	envfile.credentialsManager = resourceFields.CredentialsManager
 	envfile.s3ClientCreator = factory.NewS3ClientCreator()
 	envfile.ioutil = ioutilwrapper.NewIOUtil()
 	envfile.bufio = bufiowrapper.NewBufio()
+	envfile.lock.Unlock()
 
 	// if task isn't in 'created' status and desired status is 'running',
 	// reset the resource status to 'NONE' so we always retrieve the data


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Fixes a deadlock scenario when the agent restores the state from its data file and the tasks are using environment files feature

### Implementation details
The issue happens in some particular cases where the system waits indefinitely to lock a lock, which it itself has locked it, and hasn't unlocked yet, resulting in a deadlock.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: no

### Description for the changelog
Bug - Fixed a bug that could cause a deadlock resulting in the agent not functioning as expected

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
