### PR TITLE
add IPv6SubnetCIDRBlock for awsvpc task in task metadata

### DIFF
--- a/agent/handlers/v4/response.go
+++ b/agent/handlers/v4/response.go
@@ -14,8 +14,6 @@
 package v4
 
 import (
-	"net"
-
 	"github.com/aws/amazon-ecs-agent/agent/api"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	"github.com/aws/amazon-ecs-agent/agent/containermetadata"
@@ -168,12 +166,6 @@ func toV4NetworkResponse(
 // task.
 func newNetworkInterfaceProperties(task *apitask.Task) (NetworkInterfaceProperties, error) {
 	eni := task.GetPrimaryENI()
-	_, ipv4Net, err := net.ParseCIDR(eni.SubnetGatewayIPV4Address)
-	if err != nil {
-		return NetworkInterfaceProperties{}, errors.Wrapf(err,
-			"v4 metadata response: unable to parse subnet ipv4 address '%s'",
-			eni.SubnetGatewayIPV4Address)
-	}
 
 	var attachmentIndexPtr *int
 	if task.IsNetworkModeAWSVPC() {
@@ -186,7 +178,8 @@ func newNetworkInterfaceProperties(task *apitask.Task) (NetworkInterfaceProperti
 		// `Index` field for an ENI, we should set it as per that. Since we
 		// only support 1 ENI per task anyway, setting it to `0` is acceptable
 		AttachmentIndex:          attachmentIndexPtr,
-		IPV4SubnetCIDRBlock:      ipv4Net.String(),
+		IPV4SubnetCIDRBlock:      eni.GetIPv4SubnetCIDRBlock(),
+		IPv6SubnetCIDRBlock:      eni.GetIPv6SubnetCIDRBlock(),
 		MACAddress:               eni.MacAddress,
 		DomainNameServers:        eni.DomainNameServers,
 		DomainNameSearchList:     eni.DomainNameSearchList,

--- a/agent/handlers/v4/response_test.go
+++ b/agent/handlers/v4/response_test.go
@@ -45,6 +45,9 @@ const (
 	cpu                      = 1024
 	memory                   = 512
 	eniIPv4Address           = "192.168.0.5"
+	ipv4SubnetCIDRBlock      = "192.168.0.0/24"
+	eniIPv6Address           = "2600:1f18:619e:f900:8467:78b2:81c4:207d"
+	ipv6SubnetCIDRBlock      = "2600:1f18:619e:f900::/64"
 	subnetGatewayIPV4Address = "192.168.0.1/24"
 	volName                  = "volume1"
 	volSource                = "/var/lib/volume1"
@@ -71,6 +74,11 @@ func TestNewTaskContainerResponses(t *testing.T) {
 				IPV4Addresses: []*apieni.ENIIPV4Address{
 					{
 						Address: eniIPv4Address,
+					},
+				},
+				IPV6Addresses: []*apieni.ENIIPV6Address{
+					{
+						Address: eniIPv6Address,
 					},
 				},
 				SubnetGatewayIPV4Address: subnetGatewayIPV4Address,
@@ -130,7 +138,9 @@ func TestNewTaskContainerResponses(t *testing.T) {
 	_, err = json.Marshal(taskResponse)
 	require.NoError(t, err)
 	assert.Equal(t, created.UTC().String(), taskResponse.Containers[0].CreatedAt.String())
-	assert.Equal(t, "192.168.0.0/24", taskResponse.Containers[0].Networks[0].IPV4SubnetCIDRBlock)
+	assert.Equal(t, ipv4SubnetCIDRBlock, taskResponse.Containers[0].Networks[0].IPV4SubnetCIDRBlock)
+	assert.Equal(t, eniIPv6Address, taskResponse.Containers[0].Networks[0].IPv6Addresses[0])
+	assert.Equal(t, ipv6SubnetCIDRBlock, taskResponse.Containers[0].Networks[0].IPv6SubnetCIDRBlock)
 	assert.Equal(t, subnetGatewayIPV4Address, taskResponse.Containers[0].Networks[0].SubnetGatewayIPV4Address)
 
 	gomock.InOrder(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
add IPv6SubnetCIDRBlock for awsvpc task in v4 task metadata endpoint. 
### Implementation details
<!-- How are the changes implemented? -->
add IPv6SubnetCIDRBlock field in the NetworkInterfaceProperties in the task response. 
the sample output looks like: 
```
# curl $ECS_CONTAINER_METADATA_URI_V4  
  "DockerId": "24839d2d1f3a4e68d3ffb653aa5f7f83c5a51c71b8ae906289ab4910a36b8e6a",
  "Name": "container_1",
  "DockerName": "ecs-test-ipv6-manual-nc-1-container1-a285bfd6caa0a2879001",
  "Image": "nginx:latest",
  "ImageID": "sha256:4bb46517cac397bdb0bab6eba09b0e1f8e90ddd17cf99662997c3253531136f8",
  "Labels": {
    "com.amazonaws.ecs.cluster": "default",
    "com.amazonaws.ecs.container-name": "container_1",
    "com.amazonaws.ecs.task-arn": "arn:aws:ecs:us-east-1:984736093387:task/5f1dd5f6-ce11-46ff-b66e-deb9c19acd2e",
    "com.amazonaws.ecs.task-definition-family": "test-ipv6-manual-nc",
    "com.amazonaws.ecs.task-definition-version": "1"
  },
  "DesiredStatus": "RUNNING",
  "KnownStatus": "RUNNING",
  "Limits": {
    "CPU": 100,
    "Memory": 512
  },
  "CreatedAt": "2020-08-27T06:19:40.872815389Z",
  "StartedAt": "2020-08-27T06:19:42.113141252Z",
  "Type": "NORMAL",
  "Networks": [
    {
      "NetworkMode": "awsvpc",
      "IPv4Addresses": [
        "10.0.0.181"
      ],
      "IPv6Addresses": [
        "2600:1f18:619e:f900:8467:78b2:81c4:207d"
      ],
      "AttachmentIndex": 0,
      "MACAddress": "06:77:30:25:b8:63",
      "IPv4SubnetCIDRBlock": "10.0.0.0/24",
      "IPv6SubnetCIDRBlock": "2600:1f18:619e:f900::/64",
      "SubnetGatewayIpv4Address": "10.0.0.1/24"
    }
  ]
}
```
### Testing
<!-- How was this tested? -->
curl  Ipv4 address: 10.0.0.181
curl Ipv6 address : "http://\[2600:1f18:619e:f900:8467:78b2:81c4:207d\]/"
both successfully with the following messages:
```
curl "http://\[2600:1f18:619e:f900:8467:78b2:81c4:207d\]/"
<!DOCTYPE html>
<html>
<head>
<title>Welcome to nginx!</title>
<style>
    body {
        width: 35em;
        margin: 0 auto;
        font-family: Tahoma, Verdana, Arial, sans-serif;
    }
</style>
</head>
<body>
<h1>Welcome to nginx!</h1>
<p>If you see this page, the nginx web server is successfully installed and
working. Further configuration is required.</p>

<p>For online documentation and support please refer to
<a href="http://nginx.org/">nginx.org</a>.<br/>
Commercial support is available at
<a href="http://nginx.com/">nginx.com</a>.</p>

<p><em>Thank you for using nginx.</em></p>
</body>
</html>

```

<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
