### PR TITLE
Add the "<filter></filter>" only when logfile environment Variable is set

### DIFF
--- a/agent/logger/log.go
+++ b/agent/logger/log.go
@@ -86,9 +86,10 @@ func seelogConfig() string {
 			<console />`
 	c += platformLogConfig()
 	c += `
-		</filter>
-		<filter levels="` + getLevelList(Config.instanceLevel) + `">`
+		</filter>`
 	if Config.logfile != "" {
+		c += `
+		<filter levels="` + getLevelList(Config.instanceLevel) + `">`
 		if Config.RolloverType == "size" {
 			c += `
 			<rollingfile filename="` + Config.logfile + `" type="size"
@@ -98,9 +99,10 @@ func seelogConfig() string {
 			<rollingfile filename="` + Config.logfile + `" type="date"
 			 datepattern="2006-01-02-15" archivetype="none" maxrolls="` + strconv.Itoa(Config.MaxRollCount) + `" />`
 		}
+		c += `
+		</filter>`
 	}
 	c += `
-		</filter>
 	</outputs>
 	<formats>
 		<format id="logfmt" format="%EcsAgentLogfmt" />

--- a/agent/logger/log_unix_test.go
+++ b/agent/logger/log_unix_test.go
@@ -52,6 +52,31 @@ func TestSeelogConfig_Default(t *testing.T) {
 </seelog>`, c)
 }
 
+func TestSeelogConfig_WithoutLogFile(t *testing.T) {
+	Config = &logConfig{
+		driverLevel:   DEFAULT_LOGLEVEL,
+		instanceLevel: DEFAULT_LOGLEVEL,
+		RolloverType:  DEFAULT_ROLLOVER_TYPE,
+		outputFormat:  DEFAULT_OUTPUT_FORMAT,
+		MaxFileSizeMB: DEFAULT_MAX_FILE_SIZE,
+		MaxRollCount:  DEFAULT_MAX_ROLL_COUNT,
+	}
+	c := seelogConfig()
+	require.Equal(t, `
+<seelog type="asyncloop">
+	<outputs formatid="logfmt">
+		<filter levels="info,warn,error,critical">
+			<console />
+		</filter>
+	</outputs>
+	<formats>
+		<format id="logfmt" format="%EcsAgentLogfmt" />
+		<format id="json" format="%EcsAgentJson" />
+		<format id="windows" format="%Msg" />
+	</formats>
+</seelog>`, c)
+}
+
 func TestSeelogConfig_DebugLevel(t *testing.T) {
 	Config = &logConfig{
 		logfile:       "foo.log",

--- a/agent/logger/log_windows_test.go
+++ b/agent/logger/log_windows_test.go
@@ -53,6 +53,32 @@ func TestSeelogConfigWindows_Default(t *testing.T) {
 </seelog>`, c)
 }
 
+func TestSeelogConfigWindows_WithoutLogFile(t *testing.T) {
+	Config = &logConfig{
+		driverLevel:   DEFAULT_LOGLEVEL,
+		instanceLevel: DEFAULT_LOGLEVEL,
+		RolloverType:  DEFAULT_ROLLOVER_TYPE,
+		outputFormat:  DEFAULT_OUTPUT_FORMAT,
+		MaxFileSizeMB: DEFAULT_MAX_FILE_SIZE,
+		MaxRollCount:  DEFAULT_MAX_ROLL_COUNT,
+	}
+	c := seelogConfig()
+	require.Equal(t, `
+<seelog type="asyncloop">
+	<outputs formatid="logfmt">
+		<filter levels="info,warn,error,critical">
+			<console />
+			<custom name="wineventlog" formatid="windows" />
+		</filter>
+	</outputs>
+	<formats>
+		<format id="logfmt" format="%EcsAgentLogfmt" />
+		<format id="json" format="%EcsAgentJson" />
+		<format id="windows" format="%Msg" />
+	</formats>
+</seelog>`, c)
+}
+
 func TestSeelogConfigWindows_DebugLevel(t *testing.T) {
 	Config = &logConfig{
 		logfile:       "foo.log",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR fixes the empty (filter)(/filter) when ECS_LOGFILE is not set by ecs-init. This would cause certain environment variables related to agent logging to not have their expected behaviour when the user is not using ECS optimized AMI. 
This issue is mentioned in https://github.com/aws/amazon-ecs-agent/issues/2591

Problem:

For example, 
```
$ docker run -e ECS_LOG_OUTPUT_FORMAT=json amazon/amazon-ecs-agent:v1.44.0
1598513604929243900 [Error] node must have children
```
This error is caused because ecs agent is receiving empty (filter)(/filter) when ECS_LOGFILE is not set by ecs-init.

However, when the below is run, everything is fine.
```
docker run -e ECS_LOG_OUTPUT_FORMAT=json --env=ECS_LOGFILE=/log/ecs-agent.log amazon/amazon-ecs-agent:v1.44.0
{"level": "info", "time": "2020-08-28T21:08:40Z", "msg": "Loading configuration", "module": "agent.go"}
```

### Implementation details
<!-- How are the changes implemented? -->

This PR adds the filter block only when ECS_LOGFILE is present as env var. Otherwise it is not added

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

Unit tests cover the changes
Manual test:

```
[ec2-user@ip-172-31-3-170 ~]$ docker run -e ECS_LOG_OUTPUT_FORMAT=json amazon/amazon-ecs-agent:latest
{"level": "info", "time": "2020-08-28T22:24:32Z", "msg": "Loading configuration", "module": "agent.go"}
```

Also tested that the /var/log/ecs/ecs-agent.log file also got populated in json format when ECS_LOG_OUTPUT_FORMAT=json is mentioned ecs.config file
### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
