### PR TITLE
Check that gogenerate does not generate a diff in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ matrix:
       script:
         - make get-deps
         - make static-check
+        - make gogenerate-check
         - make test
         - make analyze-cover-profile
         - make xplatform-build

--- a/Makefile
+++ b/Makefile
@@ -282,6 +282,11 @@ importcheck:
 	$(eval DIFFS:=$(shell goimports -l $(GOFMTFILES)))
 	@if [ -n "$(DIFFS)" ]; then echo "Files incorrectly formatted. Fix formatting by running goimports:"; echo "$(DIFFS)"; exit 1; fi
 
+.PHONY: gogenerate-check
+gogenerate-check: gogenerate
+	# check that gogenerate does not generate a diff.
+	git diff --exit-code
+
 .PHONY: static-check
 static-check: gocyclo govet importcheck
 	# use default checks of staticcheck tool, except style checks (-ST*) and depracation checks (-SA1019)
@@ -293,9 +298,11 @@ static-check: gocyclo govet importcheck
 goimports:
 	goimports -w $(GOFMTFILES)
 
+GOPATH=$(shell go env GOPATH)
 .get-deps-stamp:
 	go get golang.org/x/tools/cmd/cover
 	go get github.com/golang/mock/mockgen
+	cd "${GOPATH}/src/github.com/golang/mock/mockgen" && git checkout 1.3.1 && go get ./... && go install ./...
 	go get golang.org/x/tools/cmd/goimports
 	go get github.com/fzipp/gocyclo
 	go get honnef.co/go/tools/cmd/staticcheck


### PR DESCRIPTION
and install mockgen 1.3.1 automatically in get-deps make target

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
