### PR TITLE
add TopContainer to dockerapi

### DIFF
--- a/agent/dockerclient/dockerapi/errors.go
+++ b/agent/dockerclient/dockerapi/errors.go
@@ -28,6 +28,8 @@ const (
 	CannotStartContainerErrorName = "CannotStartContainerError"
 	// CannotDescribeContainerErrorName is the name of describe container error.
 	CannotDescribeContainerErrorName = "CannotDescribeContainerError"
+	// CannotGetContainerTopErrorName is the name of the top container error.
+	CannotGetContainerTopErrorName = "CannotGetContainerTopError"
 )
 
 // DockerTimeoutError is an error type for describing timeouts
@@ -218,6 +220,20 @@ func (err CannotInspectContainerError) Error() string {
 // ErrorName returns name of the CannotInspectContainerError
 func (err CannotInspectContainerError) ErrorName() string {
 	return CannotInspectContainerErrorName
+}
+
+// CannotGetContainerTopError indicates any error when trying to get container top processes
+type CannotGetContainerTopError struct {
+	FromError error
+}
+
+func (err CannotGetContainerTopError) Error() string {
+	return err.FromError.Error()
+}
+
+// ErrorName returns name of the CannotGetContainerTopError
+func (err CannotGetContainerTopError) ErrorName() string {
+	return CannotGetContainerTopErrorName
 }
 
 // CannotRemoveContainerError indicates any error when trying to remove a container

--- a/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
+++ b/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
@@ -387,6 +387,21 @@ func (mr *MockDockerClientMockRecorder) SupportedVersions() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SupportedVersions", reflect.TypeOf((*MockDockerClient)(nil).SupportedVersions))
 }
 
+// TopContainer mocks base method
+func (m *MockDockerClient) TopContainer(arg0 context.Context, arg1 string, arg2 time.Duration) (*container0.ContainerTopOKBody, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TopContainer", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*container0.ContainerTopOKBody)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// TopContainer indicates an expected call of TopContainer
+func (mr *MockDockerClientMockRecorder) TopContainer(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TopContainer", reflect.TypeOf((*MockDockerClient)(nil).TopContainer), arg0, arg1, arg2)
+}
+
 // Version mocks base method
 func (m *MockDockerClient) Version(arg0 context.Context, arg1 time.Duration) (string, error) {
 	m.ctrl.T.Helper()

--- a/agent/dockerclient/sdkclient/interface.go
+++ b/agent/dockerclient/sdkclient/interface.go
@@ -36,6 +36,7 @@ type Client interface {
 		networkingConfig *network.NetworkingConfig, containerName string) (container.ContainerCreateCreatedBody, error)
 	ContainerInspect(ctx context.Context, containerID string) (types.ContainerJSON, error)
 	ContainerList(ctx context.Context, options types.ContainerListOptions) ([]types.Container, error)
+	ContainerTop(ctx context.Context, containerID string, arguments []string) (container.ContainerTopOKBody, error)
 	ContainerRemove(ctx context.Context, containerID string, options types.ContainerRemoveOptions) error
 	ContainerStart(ctx context.Context, containerID string, options types.ContainerStartOptions) error
 	ContainerStats(ctx context.Context, containerID string, stream bool) (types.ContainerStats, error)

--- a/agent/dockerclient/sdkclient/mocks/sdkclient_mocks.go
+++ b/agent/dockerclient/sdkclient/mocks/sdkclient_mocks.go
@@ -172,6 +172,21 @@ func (mr *MockClientMockRecorder) ContainerStop(arg0, arg1, arg2 interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerStop", reflect.TypeOf((*MockClient)(nil).ContainerStop), arg0, arg1, arg2)
 }
 
+// ContainerTop mocks base method
+func (m *MockClient) ContainerTop(arg0 context.Context, arg1 string, arg2 []string) (container.ContainerTopOKBody, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ContainerTop", arg0, arg1, arg2)
+	ret0, _ := ret[0].(container.ContainerTopOKBody)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ContainerTop indicates an expected call of ContainerTop
+func (mr *MockClientMockRecorder) ContainerTop(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerTop", reflect.TypeOf((*MockClient)(nil).ContainerTop), arg0, arg1, arg2)
+}
+
 // Events mocks base method
 func (m *MockClient) Events(arg0 context.Context, arg1 types.EventsOptions) (<-chan events.Message, <-chan error) {
 	m.ctrl.T.Helper()

--- a/agent/dockerclient/timeout.go
+++ b/agent/dockerclient/timeout.go
@@ -38,6 +38,9 @@ const (
 	ListContainersTimeout = 10 * time.Minute
 	// InspectContainerTimeout is the timeout for the InspectContainer API.
 	InspectContainerTimeout = 30 * time.Second
+	// TopContainerTimeout is the timeout for the TopContainer API.
+	TopContainerTimeout = 30 * time.Second
+
 	// StopContainerTimeout is the timeout for the StopContainer API.
 	StopContainerTimeout = 30 * time.Second
 	// RemoveContainerTimeout is the timeout for the RemoveContainer API.

--- a/agent/stats/task_linux_test.go
+++ b/agent/stats/task_linux_test.go
@@ -21,13 +21,12 @@ import (
 	"testing"
 	"time"
 
-	mock_nswrapper "github.com/aws/amazon-ecs-agent/agent/utils/nswrapper/mocks"
-
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	apitaskstatus "github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	mock_netlink "github.com/aws/amazon-ecs-agent/agent/eni/netlinkwrapper/mocks"
 	mock_resolver "github.com/aws/amazon-ecs-agent/agent/stats/resolver/mock"
+	mock_nswrapper "github.com/aws/amazon-ecs-agent/agent/utils/nswrapper/mocks"
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This adds the `TopContainer` function to the dockerapi -- this is essentially `docker top`.
The naming (`TopContainer` as opposed to `ContainerTop`) is to be inline with the convention in the dockerapi which differentiates it from the core Docker `ContainerTop` function.

### Implementation details
The changes follow the existing pattern to add the function to the dockerapi interface for mocking, add specific timeout and error, as well as tweak the `TopContainer` function signature to use default configuration and allow for a timeout to be set.

### Testing
I've added unit tests, following the convention in docker_client_test
I tested manually by adding a call to `TopDocker` with a print statement in the task engine code then running a task with via the console and again via integration tests.  I was able to exercise the new function to get the following output for a simple healthcheck container:
```
&{[[root 6759 6725 0 19:21 ? 00:00:00 sh -c trap "exit 0" SIGTERM SIGINT; while true; do sleep 1; done] [root 6799 6759 0 19:21 ? 00:00:00 sleep 1]] [UID PID PPID C STIME TTY TIME CMD]}
```

Note: integration tests for this and for `docker exec` functionality will be a separate PR.

New tests cover the changes: yes

### Description for the changelog
Add `TopDocker` command to dockerapi

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
