### PR TITLE
task engine: centralize getting docker ID, check it's not blank

### DIFF
--- a/agent/dockerclient/dockerapi/docker_client.go
+++ b/agent/dockerclient/dockerapi/docker_client.go
@@ -687,7 +687,7 @@ func (dg *dockerGoClient) stopContainer(ctx context.Context, dockerID string, ti
 	err = client.ContainerStop(ctx, dockerID, &timeout)
 	metadata := dg.containerMetadata(ctx, dockerID)
 	if err != nil {
-		seelog.Errorf("DockerGoClient: error stopping container %s: %v", dockerID, err)
+		seelog.Errorf("DockerGoClient: error stopping container ID=%s: %v", dockerID, err)
 		if metadata.Error == nil {
 			if strings.Contains(err.Error(), "No such container") {
 				err = NoSuchContainerError{dockerID}

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -487,17 +487,12 @@ func (engine *DockerTaskEngine) synchronizeContainerStatus(container *apicontain
 // their state to the managed task's container channel.
 func (engine *DockerTaskEngine) checkTaskState(task *apitask.Task) {
 	defer metrics.MetricsEngineGlobal.RecordTaskEngineMetric("CHECK_TASK_STATE")()
-	taskContainers, ok := engine.state.ContainerMapByArn(task.Arn)
-	if !ok {
-		seelog.Warnf("Task engine [%s]: could not check task state; no task in state", task.Arn)
-		return
-	}
 	for _, container := range task.Containers {
-		dockerContainer, ok := taskContainers[container.Name]
-		if !ok {
+		dockerID, err := engine.getDockerID(task, container)
+		if err != nil {
 			continue
 		}
-		status, metadata := engine.client.DescribeContainer(engine.ctx, dockerContainer.DockerID)
+		status, metadata := engine.client.DescribeContainer(engine.ctx, dockerID)
 		engine.tasksLock.RLock()
 		managedTask, ok := engine.managedTasks[task.Arn]
 		engine.tasksLock.RUnlock()
@@ -1136,25 +1131,17 @@ func (engine *DockerTaskEngine) startContainer(task *apitask.Task, container *ap
 		client = client.WithVersion(dockerclient.DockerVersion(*container.DockerConfig.Version))
 	}
 
-	containerMap, ok := engine.state.ContainerMapByArn(task.Arn)
-	if !ok {
+	dockerID, err := engine.getDockerID(task, container)
+	if err != nil {
 		return dockerapi.DockerContainerMetadata{
 			Error: dockerapi.CannotStartContainerError{
-				FromError: errors.Errorf("Container belongs to unrecognized task %s", task.Arn),
+				FromError: err,
 			},
 		}
 	}
 
-	dockerContainer, ok := containerMap[container.Name]
-	if !ok {
-		return dockerapi.DockerContainerMetadata{
-			Error: dockerapi.CannotStartContainerError{
-				FromError: errors.Errorf("Container not recorded as created"),
-			},
-		}
-	}
 	startContainerBegin := time.Now()
-	dockerContainerMD := client.StartContainer(engine.ctx, dockerContainer.DockerID, engine.cfg.ContainerStartTimeout)
+	dockerContainerMD := client.StartContainer(engine.ctx, dockerID, engine.cfg.ContainerStartTimeout)
 
 	// Get metadata through container inspection and available task information then write this to the metadata file
 	// Performs this in the background to avoid delaying container start
@@ -1164,7 +1151,7 @@ func (engine *DockerTaskEngine) startContainer(task *apitask.Task, container *ap
 		engine.cfg.ContainerMetadataEnabled.Enabled() &&
 		!container.IsInternal() {
 		go func() {
-			err := engine.metadataManager.Update(engine.ctx, dockerContainer.DockerID, task, container.Name)
+			err := engine.metadataManager.Update(engine.ctx, dockerID, task, container.Name)
 			if err != nil {
 				seelog.Warnf("Task engine [%s]: failed to update metadata file for container %s: %v",
 					task.Arn, container.Name, err)
@@ -1217,7 +1204,7 @@ func (engine *DockerTaskEngine) startContainer(task *apitask.Task, container *ap
 func (engine *DockerTaskEngine) provisionContainerResources(task *apitask.Task, container *apicontainer.Container) dockerapi.DockerContainerMetadata {
 	seelog.Infof("Task engine [%s]: setting up container resources for container [%s]",
 		task.Arn, container.Name)
-	containerInspectOutput, err := engine.inspectContainerByName(task.Arn, container.Name)
+	containerInspectOutput, err := engine.inspectContainer(task, container)
 	if err != nil {
 		return dockerapi.DockerContainerMetadata{
 			Error: ContainerNetworkingError{
@@ -1268,7 +1255,7 @@ func (engine *DockerTaskEngine) cleanupPauseContainerNetwork(task *apitask.Task,
 		seelog.Infof("Task engine [%s]: waiting %s before cleaning up pause container.", task.Arn, delay)
 		engine.handleDelay(delay)
 	}
-	containerInspectOutput, err := engine.inspectContainerByName(task.Arn, container.Name)
+	containerInspectOutput, err := engine.inspectContainer(task, container)
 	if err != nil {
 		return errors.Wrap(err, "engine: cannot cleanup task network namespace due to error inspecting pause container")
 	}
@@ -1312,40 +1299,24 @@ func (engine *DockerTaskEngine) buildCNIConfigFromTaskContainer(
 	return cniConfig, nil
 }
 
-func (engine *DockerTaskEngine) inspectContainerByName(taskArn, containerName string) (*types.ContainerJSON, error) {
-	containers, ok := engine.state.ContainerMapByArn(taskArn)
-	if !ok {
-		return nil, errors.New("engine: failed to find the pause container, no containers in the task")
+func (engine *DockerTaskEngine) inspectContainer(task *apitask.Task, container *apicontainer.Container) (*types.ContainerJSON, error) {
+	dockerID, err := engine.getDockerID(task, container)
+	if err != nil {
+		return nil, err
 	}
 
-	pauseContainer, ok := containers[containerName]
-	if !ok {
-		return nil, errors.New("engine: failed to find the pause container")
-	}
-	containerInspectOutput, err := engine.client.InspectContainer(
-		engine.ctx,
-		pauseContainer.DockerName,
-		dockerclient.InspectContainerTimeout,
-	)
-
-	return containerInspectOutput, err
+	return engine.client.InspectContainer(engine.ctx, dockerID, dockerclient.InspectContainerTimeout)
 }
 
 func (engine *DockerTaskEngine) stopContainer(task *apitask.Task, container *apicontainer.Container) dockerapi.DockerContainerMetadata {
 	seelog.Infof("Task engine [%s]: stopping container [%s]", task.Arn, container.Name)
-	containerMap, ok := engine.state.ContainerMapByArn(task.Arn)
-	if !ok {
+
+	dockerID, err := engine.getDockerID(task, container)
+	if err != nil {
 		return dockerapi.DockerContainerMetadata{
 			Error: dockerapi.CannotStopContainerError{
-				FromError: errors.Errorf("Container belongs to unrecognized task %s", task.Arn),
+				FromError: err,
 			},
-		}
-	}
-
-	dockerContainer, ok := containerMap[container.Name]
-	if !ok {
-		return dockerapi.DockerContainerMetadata{
-			Error: dockerapi.CannotStopContainerError{FromError: errors.Errorf("Container not recorded as created")},
 		}
 	}
 
@@ -1364,23 +1335,18 @@ func (engine *DockerTaskEngine) stopContainer(task *apitask.Task, container *api
 		apiTimeoutStopContainer = engine.cfg.DockerStopTimeout
 	}
 
-	return engine.client.StopContainer(engine.ctx, dockerContainer.DockerID, apiTimeoutStopContainer)
+	return engine.client.StopContainer(engine.ctx, dockerID, apiTimeoutStopContainer)
 }
 
 func (engine *DockerTaskEngine) removeContainer(task *apitask.Task, container *apicontainer.Container) error {
 	seelog.Infof("Task engine [%s]: removing container: %s", task.Arn, container.Name)
-	containerMap, ok := engine.state.ContainerMapByArn(task.Arn)
 
-	if !ok {
-		return errors.New("No such task: " + task.Arn)
+	dockerID, err := engine.getDockerID(task, container)
+	if err != nil {
+		return err
 	}
 
-	dockerContainer, ok := containerMap[container.Name]
-	if !ok {
-		return errors.New("No container named '" + container.Name + "' created in " + task.Arn)
-	}
-
-	return engine.client.RemoveContainer(engine.ctx, dockerContainer.DockerName, dockerclient.RemoveContainerTimeout)
+	return engine.client.RemoveContainer(engine.ctx, dockerID, dockerclient.RemoveContainerTimeout)
 }
 
 // updateTaskUnsafe determines if a new transition needs to be applied to the
@@ -1496,4 +1462,25 @@ func getContainerHostIP(networkSettings *types.NetworkSettings) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+func (engine *DockerTaskEngine) getDockerID(task *apitask.Task, container *apicontainer.Container) (string, error) {
+	runtimeID := container.GetRuntimeID()
+	if runtimeID != "" {
+		return runtimeID, nil
+	}
+	containerMap, ok := engine.state.ContainerMapByArn(task.Arn)
+	if !ok {
+		return "", errors.Errorf("container name=%s belongs to unrecognized task taskArn=%s", container.Name, task.Arn)
+	}
+
+	dockerContainer, ok := containerMap[container.Name]
+	if !ok {
+		return "", errors.Errorf("container name=%s not recognized by agent", container.Name)
+	}
+
+	if dockerContainer.DockerID == "" {
+		return dockerContainer.DockerName, nil
+	}
+	return dockerContainer.DockerID, nil
 }

--- a/agent/engine/docker_task_engine_linux_test.go
+++ b/agent/engine/docker_task_engine_linux_test.go
@@ -402,7 +402,7 @@ func TestTaskCPULimitHappyPath(t *testing.T) {
 			// Expect a bunch of steady state 'poll' describes when we trigger cleanup
 			client.EXPECT().RemoveContainer(gomock.Any(), gomock.Any(), gomock.Any()).Do(
 				func(ctx interface{}, removedContainerName string, timeout time.Duration) {
-					assert.Equal(t, getCreatedContainerName(), removedContainerName,
+					assert.Equal(t, containerID, removedContainerName,
 						"Container name mismatch")
 				}).Return(nil)
 

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -287,7 +287,7 @@ func TestBatchContainerHappyPath(t *testing.T) {
 			// Expect a bunch of steady state 'poll' describes when we trigger cleanup
 			client.EXPECT().RemoveContainer(gomock.Any(), gomock.Any(), gomock.Any()).Do(
 				func(ctx interface{}, removedContainerName string, timeout time.Duration) {
-					assert.Equal(t, getCreatedContainerName(), removedContainerName,
+					assert.Equal(t, containerID, removedContainerName,
 						"Container name mismatch")
 				}).Return(nil)
 
@@ -494,7 +494,7 @@ func TestRemoveEvents(t *testing.T) {
 
 	client.EXPECT().RemoveContainer(gomock.Any(), gomock.Any(), gomock.Any()).Do(
 		func(ctx interface{}, removedContainerName string, timeout time.Duration) {
-			assert.Equal(t, getCreatedContainerName(), removedContainerName,
+			assert.Equal(t, containerID, removedContainerName,
 				"Container name mismatch")
 
 			// Emit a couple of events for the task before cleanup finishes. This forces
@@ -634,7 +634,7 @@ func TestSteadyStatePoll(t *testing.T) {
 	cleanup := make(chan time.Time)
 	defer close(cleanup)
 	testTime.EXPECT().After(gomock.Any()).Return(cleanup).MinTimes(1)
-	client.EXPECT().RemoveContainer(gomock.Any(), dockerContainer.DockerName, dockerclient.RemoveContainerTimeout).Return(nil)
+	client.EXPECT().RemoveContainer(gomock.Any(), dockerContainer.DockerID, dockerclient.RemoveContainerTimeout).Return(nil)
 	imageManager.EXPECT().RemoveContainerReferenceFromImageState(gomock.Any()).Return(nil)
 
 	waitForStopEvents(t, taskEngine.StateChangeEvents(), false)
@@ -1259,7 +1259,7 @@ func TestProvisionContainerResources(t *testing.T) {
 	}, testTask)
 
 	gomock.InOrder(
-		dockerClient.EXPECT().InspectContainer(gomock.Any(), dockerContainerName, gomock.Any()).Return(&types.ContainerJSON{
+		dockerClient.EXPECT().InspectContainer(gomock.Any(), containerID, gomock.Any()).Return(&types.ContainerJSON{
 			ContainerJSONBase: &types.ContainerJSONBase{
 				ID:    containerID,
 				State: &types.ContainerState{Pid: containerPid},
@@ -1298,7 +1298,7 @@ func TestProvisionContainerResourcesInspectError(t *testing.T) {
 		Container:  pauseContainer,
 	}, testTask)
 
-	dockerClient.EXPECT().InspectContainer(gomock.Any(), dockerContainerName, gomock.Any()).Return(nil, errors.New("test error"))
+	dockerClient.EXPECT().InspectContainer(gomock.Any(), containerID, gomock.Any()).Return(nil, errors.New("test error"))
 
 	assert.NotNil(t, taskEngine.(*DockerTaskEngine).provisionContainerResources(testTask, pauseContainer).Error)
 }
@@ -1353,7 +1353,7 @@ func TestStopPauseContainerCleanupCalled(t *testing.T) {
 	}, testTask)
 
 	gomock.InOrder(
-		dockerClient.EXPECT().InspectContainer(gomock.Any(), dockerContainerName, gomock.Any()).Return(&types.ContainerJSON{
+		dockerClient.EXPECT().InspectContainer(gomock.Any(), containerID, gomock.Any()).Return(&types.ContainerJSON{
 			ContainerJSONBase: &types.ContainerJSONBase{
 				ID:    containerID,
 				State: &types.ContainerState{Pid: containerPid},
@@ -1416,7 +1416,7 @@ func TestStopPauseContainerCleanupDelay(t *testing.T) {
 	}, testTask)
 
 	gomock.InOrder(
-		dockerClient.EXPECT().InspectContainer(gomock.Any(), dockerContainerName, gomock.Any()).Return(&types.ContainerJSON{
+		dockerClient.EXPECT().InspectContainer(gomock.Any(), containerID, gomock.Any()).Return(&types.ContainerJSON{
 			ContainerJSONBase: &types.ContainerJSONBase{
 				ID:    containerID,
 				State: &types.ContainerState{Pid: containerPid},
@@ -1478,7 +1478,7 @@ func TestCreateContainerOnAgentRestart(t *testing.T) {
 	sleepTask := testdata.LoadTask("sleep5")
 	sleepContainer, _ := sleepTask.ContainerByName("sleep5")
 	// Store the generated container name to state
-	state.AddContainer(&apicontainer.DockerContainer{DockerName: "docker_container_name", Container: sleepContainer}, sleepTask)
+	state.AddContainer(&apicontainer.DockerContainer{DockerID: "dockerID", DockerName: "docker_container_name", Container: sleepContainer}, sleepTask)
 
 	gomock.InOrder(
 		client.EXPECT().APIVersion().Return(defaultDockerClientAPIVersion, nil),
@@ -3006,7 +3006,7 @@ func TestGetBridgeIP(t *testing.T) {
 
 func TestStartFirelensContainerRetryForContainerIP(t *testing.T) {
 	dockerMetaDataWithoutNetworkSettings := dockerapi.DockerContainerMetadata{
-		DockerID: dockerContainerName,
+		DockerID: containerID,
 		Volumes: []types.MountPoint{
 			{
 				Name:        "volume",
@@ -3080,17 +3080,18 @@ func TestStartFirelensContainerRetryForContainerIP(t *testing.T) {
 	taskEngine.(*DockerTaskEngine).state.AddTask(testTask)
 	taskEngine.(*DockerTaskEngine).state.AddContainer(&apicontainer.DockerContainer{
 		Container:  testTask.Containers[1],
-		DockerName: "dockerContainerName",
+		DockerName: dockerContainerName,
+		DockerID:   containerID,
 	}, testTask)
 
 	client.EXPECT().APIVersion().Return(defaultDockerClientAPIVersion, nil).AnyTimes()
 	client.EXPECT().StartContainer(gomock.Any(), gomock.Any(), gomock.Any()).Return(dockerMetaDataWithoutNetworkSettings).AnyTimes()
 	gomock.InOrder(
-		client.EXPECT().InspectContainer(gomock.Any(), dockerContainerName, gomock.Any()).
+		client.EXPECT().InspectContainer(gomock.Any(), containerID, gomock.Any()).
 			Return(jsonBaseWithoutNetwork, nil),
-		client.EXPECT().InspectContainer(gomock.Any(), dockerContainerName, gomock.Any()).
+		client.EXPECT().InspectContainer(gomock.Any(), containerID, gomock.Any()).
 			Return(jsonBaseWithoutNetwork, nil),
-		client.EXPECT().InspectContainer(gomock.Any(), dockerContainerName, gomock.Any()).
+		client.EXPECT().InspectContainer(gomock.Any(), containerID, gomock.Any()).
 			Return(jsonBaseWithNetwork, nil),
 	)
 	ret := taskEngine.(*DockerTaskEngine).startContainer(testTask, testTask.Containers[1])


### PR DESCRIPTION
# Summary
<!-- What does this pull request do? -->

In 5 different places we were mapping from our internal apicontainer object to the dockercontainer object in order to obtain the docker ID, though never in exactly the same way. This centralizes it into a single function (getDockerID) that also tries to first just grab the dockerID from the apicontainer object if it exists.

Will also fallback to the DockerName attribute on the dockercontainer obj if DockerID doesnt exist.


New tests cover the changes: no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
