### PR TITLE
Add method to get eni primary ipv4 address.

### DIFF
--- a/agent/api/eni/eni.go
+++ b/agent/api/eni/eni.go
@@ -99,18 +99,23 @@ func (eni *ENI) GetIPV6Addresses() []string {
 	return addresses
 }
 
-// GetPrimaryIPv4AddressWithPrefixLength returns the primary IPv4 address assigned to the ENI with
-// its subnet prefix length.
-func (eni *ENI) GetPrimaryIPv4AddressWithPrefixLength() string {
+// GetPrimaryIPv4Address returns the primary IPv4 address assigned to the ENI.
+func (eni *ENI) GetPrimaryIPv4Address() string {
 	var primaryAddr string
 	for _, addr := range eni.IPV4Addresses {
 		if addr.Primary {
-			primaryAddr = addr.Address + "/" + eni.GetIPv4SubnetPrefixLength()
+			primaryAddr = addr.Address
 			break
 		}
 	}
 
 	return primaryAddr
+}
+
+// GetPrimaryIPv4AddressWithPrefixLength returns the primary IPv4 address assigned to the ENI with
+// its subnet prefix length.
+func (eni *ENI) GetPrimaryIPv4AddressWithPrefixLength() string {
+	return eni.GetPrimaryIPv4Address() + "/" + eni.GetIPv4SubnetPrefixLength()
 }
 
 // GetIPAddressesWithPrefixLength returns the list of all IP addresses assigned to the ENI with

--- a/agent/api/eni/eni_test.go
+++ b/agent/api/eni/eni_test.go
@@ -101,6 +101,14 @@ func TestGetIPV6Addresses(t *testing.T) {
 	assert.Equal(t, []string{ipv6Addr}, testENI.GetIPV6Addresses())
 }
 
+func TestGetPrimaryIPv4Address(t *testing.T) {
+	assert.Equal(t, ipv4Addr, testENI.GetPrimaryIPv4Address())
+}
+
+func TestGetPrimaryIPv4AddressWithPrefixLength(t *testing.T) {
+	assert.Equal(t, ipv4AddrWithPrefixLength, testENI.GetPrimaryIPv4AddressWithPrefixLength())
+}
+
 func TestGetIPAddressesWithPrefixLength(t *testing.T) {
 	assert.Equal(t, []string{ipv4AddrWithPrefixLength, ipv6AddrWithPrefixLength}, testENI.GetIPAddressesWithPrefixLength())
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Add method to get eni primary ipv4 address, needed by fargate.

### Implementation details
<!-- How are the changes implemented? -->
Add method to get eni primary ipv4 address.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Unit test added.

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
N/A

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
