### PR TITLE
Add ExecAgent bind mounts to all containers of exec-enabled tasks

### DIFF
--- a/agent/api/container/container.go
+++ b/agent/api/container/container.go
@@ -266,6 +266,9 @@ type Container struct {
 	// the JSON body while saving the state
 	SteadyStateStatusUnsafe *apicontainerstatus.ContainerStatus `json:"SteadyStateStatus,omitempty"`
 
+	// ExecCommandAgentMetadata holds metadata about the exec agent running inside the container (i.e. SSM Agent).
+	ExecCommandAgentMetadata ExecCommandAgentMetadata `json:"execCommandAgentMetadata"`
+
 	createdAt  time.Time
 	startedAt  time.Time
 	finishedAt time.Time
@@ -323,6 +326,12 @@ type Secret struct {
 	Type          string `json:"type"`
 	Provider      string `json:"provider"`
 	Target        string `json:"target"`
+}
+
+// ExecCommandAgentMetadata holds metadata about the exec agent running inside the container (i.e. SSM Agent).
+type ExecCommandAgentMetadata struct {
+	PID          string `json:"pid"`
+	DockerExecID string `json:"dockerExecId"`
 }
 
 // GetSecretResourceCacheKey returns the key required to access the secret
@@ -1146,4 +1155,16 @@ func (c *Container) GetTaskARN() string {
 	defer c.lock.RUnlock()
 
 	return c.TaskARNUnsafe
+}
+
+func (c *Container) SetExecCommandAgentMetadata(metadata ExecCommandAgentMetadata) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.ExecCommandAgentMetadata = metadata
+}
+
+func (c *Container) GetExecCommandAgentMetadata() ExecCommandAgentMetadata {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.ExecCommandAgentMetadata
 }

--- a/agent/api/container/container_test.go
+++ b/agent/api/container/container_test.go
@@ -757,3 +757,25 @@ func TestRequireNeuronRuntime(t *testing.T) {
 	}
 	assert.True(t, c.RequireNeuronRuntime())
 }
+
+func TestExecCommandAgentMetadata(t *testing.T) {
+	const (
+		testPid          = "pid"
+		testDockerExecId = "dockerId"
+	)
+	c := &Container{}
+	assert.Equal(t, "", c.ExecCommandAgentMetadata.PID)
+	assert.Equal(t, "", c.ExecCommandAgentMetadata.DockerExecID)
+
+	c.SetExecCommandAgentMetadata(ExecCommandAgentMetadata{
+		PID:          testPid,
+		DockerExecID: testDockerExecId,
+	})
+
+	assert.Equal(t, testPid, c.ExecCommandAgentMetadata.PID)
+	assert.Equal(t, testDockerExecId, c.ExecCommandAgentMetadata.DockerExecID)
+
+	md := c.GetExecCommandAgentMetadata()
+	assert.Equal(t, testPid, md.PID)
+	assert.Equal(t, testDockerExecId, md.DockerExecID)
+}

--- a/agent/api/task/json.go
+++ b/agent/api/task/json.go
@@ -22,9 +22,9 @@ import (
 type jTask Task
 
 // MarshalJSON wraps Go's marshalling logic with a necessary read lock.
-func (t *Task) MarshalJSON() ([]byte, error) {
-	t.lock.RLock()
-	defer t.lock.RUnlock()
+func (task *Task) MarshalJSON() ([]byte, error) {
+	task.lock.RLock()
+	defer task.lock.RUnlock()
 
-	return json.Marshal((*jTask)(t))
+	return json.Marshal((*jTask)(task))
 }

--- a/agent/api/task/task_linux.go
+++ b/agent/api/task/task_linux.go
@@ -16,19 +16,26 @@
 package task
 
 import (
+	"fmt"
+	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/credentials"
+	"github.com/aws/amazon-ecs-agent/agent/logger"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/cgroup"
 	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
 	resourcetype "github.com/aws/amazon-ecs-agent/agent/taskresource/types"
+	taskresourcevolume "github.com/aws/amazon-ecs-agent/agent/taskresource/volume"
 	"github.com/cihub/seelog"
 	dockercontainer "github.com/docker/docker/api/types/container"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pborman/uuid"
 	"github.com/pkg/errors"
 )
 
@@ -40,6 +47,24 @@ const (
 
 	minimumCPUPercent = 0
 	bytesPerMegabyte  = 1024 * 1024
+
+	internalExecCommandAgentNamePrefix          = "internal-execute-command-agent"
+	internalExecCommandAgentLogVolumeNamePrefix = internalExecCommandAgentNamePrefix + "-log"
+	internalExecCommandAgentCertVolumeName      = internalExecCommandAgentNamePrefix + "-tls-cert"
+
+	// TODO: [ecs-exec] decide if this needs to be configurable or put in a specific place in our optimized AMIs
+	execCommandAgentHostBinDir           = "/home/ec2-user/ssm-agent/linux_amd64"
+	execCommandAgentBinName              = "amazon-ssm-agent"
+	execCommandAgentSessionWorkerBinName = "ssm-session-worker"
+	execCommandAgentSessionLoggerBinName = "ssm-session-logger"
+
+	// TODO: [ecs-exec] decide if this needs to be configurable or put in a specific place in our optimized AMIs
+	execCommandAgentContainerLogDir   = "/var/log/amazon/ssm"
+	execCommandAgentContainerBinDir   = "/usr/bin"
+	execCommandAgentHostCertFile      = "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
+	execCommandAgentContainerCertFile = "/etc/ssl/certs/ca-certificates.crt"
+
+	execCommandAgentNamelessContainerPrefix = "nameless-container-"
 )
 
 // PlatformFields consists of fields specific to Linux for a task
@@ -233,4 +258,91 @@ func (task *Task) initializeCredentialSpecResource(config *config.Config, creden
 // GetCredentialSpecResource retrieves credentialspec resource from resource map
 func (task *Task) GetCredentialSpecResource() ([]taskresource.TaskResource, bool) {
 	return []taskresource.TaskResource{}, false
+}
+
+// initializeExecCommandAgentResources specifies the necessary volumes and mount points in all of the task containers in order for the
+// exec agent to run upon container start.
+func (task *Task) initializeExecCommandAgentResources(cfg *config.Config) error {
+	if !task.IsExecCommandAgentEnabled() {
+		return nil
+	}
+
+	tId, err := task.GetID()
+	if err != nil {
+		return err
+	}
+
+	execCommandAgentBinNames := []string{execCommandAgentBinName, execCommandAgentSessionWorkerBinName, execCommandAgentSessionLoggerBinName}
+
+	// Append an internal volume for each of the exec agent binary names
+	for _, bn := range execCommandAgentBinNames {
+		task.Volumes = append(task.Volumes,
+			TaskVolume{
+				Type: HostVolumeType,
+				Name: buildVolumeNameForExecCommandAgentBinary(bn),
+				Volume: &taskresourcevolume.FSHostVolume{
+					FSSourcePath: filepath.Join(execCommandAgentHostBinDir, bn),
+				},
+			})
+	}
+
+	// Append certificates volume
+	task.Volumes = append(task.Volumes,
+		TaskVolume{
+			Type: HostVolumeType,
+			Name: internalExecCommandAgentCertVolumeName,
+			Volume: &taskresourcevolume.FSHostVolume{
+				FSSourcePath: execCommandAgentHostCertFile,
+			},
+		})
+
+	// Add log volumes and mount points to all containers in this task
+	for _, c := range task.Containers {
+		lvn := fmt.Sprintf("%s-%s-%s", internalExecCommandAgentLogVolumeNamePrefix, tId, c.Name)
+		cn := buildContainerNameForExecCommandAgentBinary(c)
+		task.Volumes = append(task.Volumes, TaskVolume{
+			Type: HostVolumeType,
+			Name: lvn,
+			Volume: &taskresourcevolume.FSHostVolume{
+				FSSourcePath: filepath.Join(filepath.Dir(os.Getenv(logger.LOGFILE_ENV_VAR)), tId, cn),
+			},
+		})
+
+		c.MountPoints = append(c.MountPoints,
+			apicontainer.MountPoint{
+				SourceVolume:  lvn,
+				ContainerPath: execCommandAgentContainerLogDir,
+				ReadOnly:      false,
+			},
+			apicontainer.MountPoint{
+				SourceVolume:  internalExecCommandAgentCertVolumeName,
+				ContainerPath: execCommandAgentContainerCertFile,
+				ReadOnly:      true,
+			},
+		)
+
+		for _, bn := range execCommandAgentBinNames {
+			c.MountPoints = append(c.MountPoints,
+				apicontainer.MountPoint{
+					SourceVolume:  buildVolumeNameForExecCommandAgentBinary(bn),
+					ContainerPath: filepath.Join(execCommandAgentContainerBinDir, bn),
+					ReadOnly:      true,
+				})
+		}
+	}
+	return nil
+}
+
+func buildVolumeNameForExecCommandAgentBinary(binaryName string) string {
+	return fmt.Sprintf("%s-%s", internalExecCommandAgentNamePrefix, binaryName)
+}
+
+func buildContainerNameForExecCommandAgentBinary(c *apicontainer.Container) string {
+	// Trim leading hyphens since they're not valid directory names
+	cn := strings.TrimLeft(c.Name, "-")
+	if cn == "" {
+		// Fallback name in the extreme case that we end up with an empty string after trimming all leading hyphens.
+		return execCommandAgentNamelessContainerPrefix + uuid.New()
+	}
+	return cn
 }

--- a/agent/api/task/task_unsupported.go
+++ b/agent/api/task/task_unsupported.go
@@ -76,3 +76,10 @@ func (task *Task) initializeCredentialSpecResource(config *config.Config, creden
 func (task *Task) GetCredentialSpecResource() ([]taskresource.TaskResource, bool) {
 	return []taskresource.TaskResource{}, false
 }
+
+// initializeExecCommandAgentResources specifies the necessary volumes and mount points in all of the task containers in order for the
+// exec agent to run upon container start.
+// Note: exec feature is a linux-only feature, thus implemented here as a no-op.
+func (task *Task) initializeExecCommandAgentResources(cfg *config.Config) error {
+	return nil
+}

--- a/agent/api/task/task_windows.go
+++ b/agent/api/task/task_windows.go
@@ -213,3 +213,10 @@ func (task *Task) GetCredentialSpecResource() ([]taskresource.TaskResource, bool
 	res, ok := task.ResourcesMapUnsafe[credentialspec.ResourceName]
 	return res, ok
 }
+
+// initializeExecCommandAgentResources specifies the necessary volumes and mount points in all of the task containers in order for the
+// exec agent to run upon container start.
+// Note: exec feature is a linux-only feature, thus implemented here as a no-op.
+func (task *Task) initializeExecCommandAgentResources(cfg *config.Config) error {
+	return nil
+}

--- a/agent/api/task/taskvolume_test.go
+++ b/agent/api/task/taskvolume_test.go
@@ -122,7 +122,8 @@ func TestMarshalTaskVolumesEFS(t *testing.T) {
 		"executionCredentialsID": "",
 		"ENI": null,
 		"AppMesh": null,
-		"PlatformFields": %s
+		"PlatformFields": %s,
+		"ExecCommandAgentEnabled": false
 	  }`
 	if runtime.GOOS == "windows" {
 		// windows task defs have a special 'cpu/memory unbounded' field added.

--- a/agent/config/config_windows.go
+++ b/agent/config/config_windows.go
@@ -26,6 +26,7 @@ import (
 const (
 	// AgentCredentialsAddress is used to serve the credentials for tasks.
 	AgentCredentialsAddress = "127.0.0.1"
+
 	// defaultAuditLogFile specifies the default audit log filename
 	defaultCredentialsAuditLogFile = `log\audit.log`
 	// When using IAM roles for tasks on Windows, the credential proxy consumes port 80


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This adds the necessary volumes and bind mounts to enable exec agent for all the containers of an exec-enabled task. 

### Implementation details
<!-- How are the changes implemented? -->
Most task initialization happens in the task.PostUnmarshalTask method. This is where I added the initialization steps for exec agent.

By appending the required volumes to the task and the mount points to the task containers, we get persistence of these exec agent volumes for free, as part of the regular operation of the agent, just like any other volumes associated with the task.

The directory for the exec agent log volumes can be configured via a new configuration parameter called `ECS_EXEC_AGENT_LOG_DIR` (which defaults to `/var/log/ecs/exec`). Logs for exec agent are stored in individual directories within `ECS_EXEC_AGENT_LOG_DIR`; the name of this directory is the taskId plus the container name (e.g. `/var/log/ecs/exec/cc1330bb-58a2-4eb3-aef0-c85740a7f22a-scratchsleeper`). **This is different than the specification in the DP design doc**. This is because the DP design doc says the container's runtime id should be used for the directory name, but it's a chicken and egg problem because to know the runtime id we need to run the container, but before running it, we need to bindmount the directory, so it's not possible to have a bind mount with the runtime id, this is the reason I use `task id+container name`.

Finally, some changes in this CR are not definitive, but I added TODOs where appropriate in order to keep iterating on the code. 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes<!-- yes|no -->

Aside from UTs, I tested this code manually by starting a task with two containers in a personal container instance where I have temporary static ssm agent binaries.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
