### PR TITLE
Add LaunchType and ContainerArn to TMDEv4

### DIFF
--- a/agent/acs/model/api/api-2.json
+++ b/agent/acs/model/api/api-2.json
@@ -229,7 +229,8 @@
         "dependsOn":{"shape":"ContainerDependencies"},
         "startTimeout":{"shape":"Integer"},
         "stopTimeout":{"shape":"Integer"},
-        "firelensConfiguration":{"shape":"FirelensConfiguration"}
+        "firelensConfiguration":{"shape":"FirelensConfiguration"},
+        "containerArn":{"shape":"String"}
       }
     },
     "ContainerCondition":{
@@ -682,7 +683,8 @@
         "associations":{"shape":"Associations"},
         "pidMode":{"shape":"String"},
         "ipcMode":{"shape":"String"},
-        "proxyConfiguration":{"shape":"ProxyConfiguration"}
+        "proxyConfiguration":{"shape":"ProxyConfiguration"},
+        "launchType":{"shape":"String"}
       }
     },
     "TaskList":{

--- a/agent/acs/model/ecsacs/api.go
+++ b/agent/acs/model/ecsacs/api.go
@@ -278,6 +278,8 @@ type Container struct {
 
 	Command []*string `locationName:"command" type:"list"`
 
+	ContainerArn *string `locationName:"containerArn" type:"string"`
+
 	Cpu *int64 `locationName:"cpu" type:"integer"`
 
 	DependsOn []*ContainerDependency `locationName:"dependsOn" type:"list"`
@@ -1297,6 +1299,8 @@ type Task struct {
 	Family *string `locationName:"family" type:"string"`
 
 	IpcMode *string `locationName:"ipcMode" type:"string"`
+
+	LaunchType *string `locationName:"launchType" type:"string"`
 
 	Memory *int64 `locationName:"memory" type:"integer"`
 

--- a/agent/api/container/container.go
+++ b/agent/api/container/container.go
@@ -266,6 +266,9 @@ type Container struct {
 	// the JSON body while saving the state
 	SteadyStateStatusUnsafe *apicontainerstatus.ContainerStatus `json:"SteadyStateStatus,omitempty"`
 
+	// ContainerArn is the Arn of this container.
+	ContainerArn string `json:"ContainerArn,omitempty"`
+
 	createdAt  time.Time
 	startedAt  time.Time
 	finishedAt time.Time

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -259,6 +259,9 @@ type Task struct {
 	// have a value for this). This field should be accessed via GetLocalIPAddress and SetLocalIPAddress.
 	LocalIPAddressUnsafe string `json:"LocalIPAddress,omitempty"`
 
+	// LaunchType is the launch type of this task.
+	LaunchType string `json:"LaunchType,omitempty"`
+
 	// lock is for protecting all fields in the task struct
 	lock sync.RWMutex
 }

--- a/agent/handlers/task_server_setup_test.go
+++ b/agent/handlers/task_server_setup_test.go
@@ -130,6 +130,7 @@ var (
 		PullStartedAtUnsafe:      now,
 		PullStoppedAtUnsafe:      now,
 		ExecutionStoppedAtUnsafe: now,
+		LaunchType:               "EC2",
 	}
 	container = &apicontainer.Container{
 		Name:                containerName,
@@ -140,6 +141,7 @@ var (
 		CPU:                 cpu,
 		Memory:              memory,
 		Type:                apicontainer.ContainerNormal,
+		ContainerArn:        "arn:aws:ecs:ap-northnorth-1:NNN:container/NNNNNNNN-aaaa-4444-bbbb-00000000000",
 		KnownPortBindingsUnsafe: []apicontainer.PortBinding{
 			{
 				ContainerPort: containerPort,
@@ -220,6 +222,7 @@ var (
 		PullStartedAtUnsafe:      now,
 		PullStoppedAtUnsafe:      now,
 		ExecutionStoppedAtUnsafe: now,
+		LaunchType:               "EC2",
 	}
 	container1 = &apicontainer.Container{
 		Name:                containerName,
@@ -297,7 +300,35 @@ var (
 	}
 	attachmentIndexVar          = attachmentIndex
 	expectedV4ContainerResponse = v4.ContainerResponse{
-		ContainerResponse: &expectedContainerResponse,
+		ContainerResponse: &v2.ContainerResponse{
+			ID:            containerID,
+			Name:          containerName,
+			DockerName:    containerName,
+			Image:         imageName,
+			ImageID:       imageID,
+			DesiredStatus: statusRunning,
+			KnownStatus:   statusRunning,
+			ContainerArn:  "arn:aws:ecs:ap-northnorth-1:NNN:container/NNNNNNNN-aaaa-4444-bbbb-00000000000",
+			Limits: v2.LimitsResponse{
+				CPU:    aws.Float64(cpu),
+				Memory: aws.Int64(memory),
+			},
+			Type:   containerType,
+			Labels: labels,
+			Ports: []v1.PortResponse{
+				{
+					ContainerPort: containerPort,
+					Protocol:      containerPortProtocol,
+					HostPort:      containerPort,
+				},
+			},
+			Networks: []containermetadata.Network{
+				{
+					NetworkMode:   utils.NetworkModeAWSVPC,
+					IPv4Addresses: []string{eniIPv4Address},
+				},
+			},
+		},
 		Networks: []v4.Network{{
 			Network: containermetadata.Network{
 				NetworkMode:   utils.NetworkModeAWSVPC,

--- a/agent/handlers/v2/response.go
+++ b/agent/handlers/v2/response.go
@@ -70,6 +70,7 @@ type ContainerResponse struct {
 	Volumes       []v1.VolumeResponse         `json:"Volumes,omitempty"`
 	LogDriver     string                      `json:"LogDriver,omitempty"`
 	LogOptions    map[string]string           `json:"LogOptions,omitempty"`
+	ContainerArn  string                      `json:"ContainerArn,omitempty"`
 }
 
 // LimitsResponse defines the schema for task/cpu limits response
@@ -103,6 +104,9 @@ func NewTaskResponse(
 		DesiredStatus:    task.GetDesiredStatus().String(),
 		KnownStatus:      task.GetKnownStatus().String(),
 		AvailabilityZone: az,
+	}
+	if includeV4Metadata {
+		resp.LaunchType = task.LaunchType
 	}
 
 	taskCPU := task.CPU
@@ -217,6 +221,7 @@ func newContainerResponse(
 	if includeV4Metadata {
 		resp.LogDriver = container.GetLogDriver()
 		resp.LogOptions = container.GetLogOptions()
+		resp.ContainerArn = container.ContainerArn
 	}
 
 	// Write the container health status inside the container

--- a/agent/handlers/v4/response.go
+++ b/agent/handlers/v4/response.go
@@ -19,7 +19,6 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/api"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	"github.com/aws/amazon-ecs-agent/agent/containermetadata"
-	"github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/handlers/utils"
 	v2 "github.com/aws/amazon-ecs-agent/agent/handlers/v2"
@@ -104,8 +103,6 @@ func NewTaskResponse(
 			Networks:          networks,
 		})
 	}
-
-	v2Resp.LaunchType = ecs.LaunchTypeEc2
 
 	return &TaskResponse{
 		TaskResponse: v2Resp,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

ACS will now be providing the task launch type and the container ARN as part of the task payload message.

This PR adds support for these new fields, and exposes them on the v4 task metadata endpoint.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

LaunchType was added to unit test Task objects and ContainerArn was added to the unit test Container objects. Unit tests were written to verify that this data was only returned on the v4 endpoint, not on the others.

New tests cover the changes: no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Add LaunchType and ContainerArn to TMDEv4 

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
