### PR TITLE
Add ps arguments to docker top to pass in process ID

### DIFF
--- a/agent/dockerclient/dockerapi/docker_client.go
+++ b/agent/dockerclient/dockerapi/docker_client.go
@@ -134,8 +134,9 @@ type DockerClient interface {
 	InspectContainer(context.Context, string, time.Duration) (*types.ContainerJSON, error)
 
 	// TopContainer returns information about the top processes running in the specified container.  A timeout value and a context
-	// should be provided for the request.
-	TopContainer(context.Context, string, time.Duration) (*dockercontainer.ContainerTopOKBody, error)
+	// should be provided for the request. The last argument is an optional parameter for passing in 'ps' arguments
+	// as part of the top command.
+	TopContainer(context.Context, string, time.Duration, ...string) (*dockercontainer.ContainerTopOKBody, error)
 
 	// ListContainers returns the set of containers known to the Docker daemon. A timeout value and a context
 	// should be provided for the request.
@@ -658,7 +659,7 @@ func (dg *dockerGoClient) inspectContainer(ctx context.Context, dockerID string)
 	return &containerData, err
 }
 
-func (dg *dockerGoClient) TopContainer(ctx context.Context, dockerID string, timeout time.Duration) (*dockercontainer.ContainerTopOKBody, error) {
+func (dg *dockerGoClient) TopContainer(ctx context.Context, dockerID string, timeout time.Duration, psArgs ...string) (*dockercontainer.ContainerTopOKBody, error) {
 	type topResponse struct {
 		top *dockercontainer.ContainerTopOKBody
 		err error
@@ -670,7 +671,7 @@ func (dg *dockerGoClient) TopContainer(ctx context.Context, dockerID string, tim
 	// read, and can still be GC'd
 	response := make(chan topResponse, 1)
 	go func() {
-		top, err := dg.topContainer(ctx, dockerID)
+		top, err := dg.topContainer(ctx, dockerID, psArgs...)
 		response <- topResponse{top, err}
 	}()
 
@@ -688,12 +689,12 @@ func (dg *dockerGoClient) TopContainer(ctx context.Context, dockerID string, tim
 	}
 }
 
-func (dg *dockerGoClient) topContainer(ctx context.Context, dockerID string) (*dockercontainer.ContainerTopOKBody, error) {
+func (dg *dockerGoClient) topContainer(ctx context.Context, dockerID string, psArgs ...string) (*dockercontainer.ContainerTopOKBody, error) {
 	client, err := dg.sdkDockerClient()
 	if err != nil {
 		return nil, err
 	}
-	topResponse, err := client.ContainerTop(ctx, dockerID, []string{})
+	topResponse, err := client.ContainerTop(ctx, dockerID, psArgs)
 	return &topResponse, err
 }
 

--- a/agent/dockerclient/dockerapi/docker_client_test.go
+++ b/agent/dockerclient/dockerapi/docker_client_test.go
@@ -634,7 +634,7 @@ func TestTopContainer(t *testing.T) {
 	)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-	topResponse, err := client.TopContainer(ctx, "id", dockerclient.TopContainerTimeout)
+	topResponse, err := client.TopContainer(ctx, "id", dockerclient.TopContainerTimeout, "pid")
 	assert.NoError(t, err)
 	assert.Equal(t, &topOutput, topResponse)
 }

--- a/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
+++ b/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
@@ -388,18 +388,23 @@ func (mr *MockDockerClientMockRecorder) SupportedVersions() *gomock.Call {
 }
 
 // TopContainer mocks base method
-func (m *MockDockerClient) TopContainer(arg0 context.Context, arg1 string, arg2 time.Duration) (*container0.ContainerTopOKBody, error) {
+func (m *MockDockerClient) TopContainer(arg0 context.Context, arg1 string, arg2 time.Duration, arg3 ...string) (*container0.ContainerTopOKBody, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TopContainer", arg0, arg1, arg2)
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "TopContainer", varargs...)
 	ret0, _ := ret[0].(*container0.ContainerTopOKBody)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // TopContainer indicates an expected call of TopContainer
-func (mr *MockDockerClientMockRecorder) TopContainer(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockDockerClientMockRecorder) TopContainer(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TopContainer", reflect.TypeOf((*MockDockerClient)(nil).TopContainer), arg0, arg1, arg2)
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TopContainer", reflect.TypeOf((*MockDockerClient)(nil).TopContainer), varargs...)
 }
 
 // Version mocks base method


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
[Docker top API](https://godoc.org/github.com/docker/docker/client#Client.ContainerTop) takes in ps arguments as `[]string` 
Adding the same in engine so we can pass in process ID to check if exec process is running. 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

### Description for the changelog
N/A

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
