### PR TITLE
TMDEv4 changes for service lens

### DIFF
--- a/agent/acs/model/api/api-2.json
+++ b/agent/acs/model/api/api-2.json
@@ -229,7 +229,8 @@
         "dependsOn":{"shape":"ContainerDependencies"},
         "startTimeout":{"shape":"Integer"},
         "stopTimeout":{"shape":"Integer"},
-        "firelensConfiguration":{"shape":"FirelensConfiguration"}
+        "firelensConfiguration":{"shape":"FirelensConfiguration"},
+        "containerArn":{"shape":"String"}
       }
     },
     "ContainerCondition":{
@@ -682,7 +683,8 @@
         "associations":{"shape":"Associations"},
         "pidMode":{"shape":"String"},
         "ipcMode":{"shape":"String"},
-        "proxyConfiguration":{"shape":"ProxyConfiguration"}
+        "proxyConfiguration":{"shape":"ProxyConfiguration"},
+        "launchType":{"shape":"String"}
       }
     },
     "TaskList":{

--- a/agent/acs/model/ecsacs/api.go
+++ b/agent/acs/model/ecsacs/api.go
@@ -278,6 +278,8 @@ type Container struct {
 
 	Command []*string `locationName:"command" type:"list"`
 
+	ContainerArn *string `locationName:"containerArn" type:"string"`
+
 	Cpu *int64 `locationName:"cpu" type:"integer"`
 
 	DependsOn []*ContainerDependency `locationName:"dependsOn" type:"list"`
@@ -1297,6 +1299,8 @@ type Task struct {
 	Family *string `locationName:"family" type:"string"`
 
 	IpcMode *string `locationName:"ipcMode" type:"string"`
+
+	LaunchType *string `locationName:"launchType" type:"string"`
 
 	Memory *int64 `locationName:"memory" type:"integer"`
 

--- a/agent/api/container/container.go
+++ b/agent/api/container/container.go
@@ -266,6 +266,9 @@ type Container struct {
 	// the JSON body while saving the state
 	SteadyStateStatusUnsafe *apicontainerstatus.ContainerStatus `json:"SteadyStateStatus,omitempty"`
 
+	// ContainerArn is the Arn of this container.
+	ContainerArn string `json:"ContainerArn,omitempty"`
+
 	createdAt  time.Time
 	startedAt  time.Time
 	finishedAt time.Time

--- a/agent/api/container/container.go
+++ b/agent/api/container/container.go
@@ -1072,11 +1072,31 @@ func (c *Container) GetLogDriver() string {
 	hostConfig := &dockercontainer.HostConfig{}
 	err := json.Unmarshal([]byte(*c.DockerConfig.HostConfig), hostConfig)
 	if err != nil {
-		seelog.Warnf("Encountered error when trying to get log driver for container %s: %v", err)
+		seelog.Warnf("Encountered error when trying to get log driver for container %s: %v", c.RuntimeID, err)
 		return ""
 	}
 
 	return hostConfig.LogConfig.Type
+}
+
+// GetLogOptions gets the log 'options' map passed into the task definition.
+// see https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_LogConfiguration.html
+func (c *Container) GetLogOptions() map[string]string {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	if c.DockerConfig.HostConfig == nil {
+		return map[string]string{}
+	}
+
+	hostConfig := &dockercontainer.HostConfig{}
+	err := json.Unmarshal([]byte(*c.DockerConfig.HostConfig), hostConfig)
+	if err != nil {
+		seelog.Warnf("Encountered error when trying to get log configuration for container %s: %v", c.RuntimeID, err)
+		return map[string]string{}
+	}
+
+	return hostConfig.LogConfig.Config
 }
 
 // GetNetworkModeFromHostConfig returns the network mode used by the container from the host config .
@@ -1092,7 +1112,7 @@ func (c *Container) GetNetworkModeFromHostConfig() string {
 	// TODO return error to differentiate between error and default mode .
 	err := json.Unmarshal([]byte(*c.DockerConfig.HostConfig), hostConfig)
 	if err != nil {
-		seelog.Warnf("Encountered error when trying to get network mode for container %s: %v", err)
+		seelog.Warnf("Encountered error when trying to get network mode for container %s: %v", c.RuntimeID, err)
 		return ""
 	}
 

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -259,6 +259,9 @@ type Task struct {
 	// have a value for this). This field should be accessed via GetLocalIPAddress and SetLocalIPAddress.
 	LocalIPAddressUnsafe string `json:"LocalIPAddress,omitempty"`
 
+	// LaunchType is the launch type of this task.
+	LaunchType string `json:"LaunchType,omitempty"`
+
 	// lock is for protecting all fields in the task struct
 	lock sync.RWMutex
 }

--- a/agent/handlers/task_server_setup_test.go
+++ b/agent/handlers/task_server_setup_test.go
@@ -308,7 +308,7 @@ var (
 			ImageID:       imageID,
 			DesiredStatus: statusRunning,
 			KnownStatus:   statusRunning,
-			ContainerArn:  "arn:aws:ecs:ap-northnorth-1:NNN:container/NNNNNNNN-aaaa-4444-bbbb-00000000000",
+			ContainerARN:  "arn:aws:ecs:ap-northnorth-1:NNN:container/NNNNNNNN-aaaa-4444-bbbb-00000000000",
 			Limits: v2.LimitsResponse{
 				CPU:    aws.Float64(cpu),
 				Memory: aws.Int64(memory),

--- a/agent/handlers/task_server_setup_test.go
+++ b/agent/handlers/task_server_setup_test.go
@@ -130,6 +130,7 @@ var (
 		PullStartedAtUnsafe:      now,
 		PullStoppedAtUnsafe:      now,
 		ExecutionStoppedAtUnsafe: now,
+		LaunchType:               "EC2",
 	}
 	container = &apicontainer.Container{
 		Name:                containerName,
@@ -140,6 +141,7 @@ var (
 		CPU:                 cpu,
 		Memory:              memory,
 		Type:                apicontainer.ContainerNormal,
+		ContainerArn:        "arn:aws:ecs:ap-northnorth-1:NNN:container/NNNNNNNN-aaaa-4444-bbbb-00000000000",
 		KnownPortBindingsUnsafe: []apicontainer.PortBinding{
 			{
 				ContainerPort: containerPort,
@@ -220,6 +222,7 @@ var (
 		PullStartedAtUnsafe:      now,
 		PullStoppedAtUnsafe:      now,
 		ExecutionStoppedAtUnsafe: now,
+		LaunchType:               "EC2",
 	}
 	container1 = &apicontainer.Container{
 		Name:                containerName,
@@ -297,7 +300,35 @@ var (
 	}
 	attachmentIndexVar          = attachmentIndex
 	expectedV4ContainerResponse = v4.ContainerResponse{
-		ContainerResponse: &expectedContainerResponse,
+		ContainerResponse: &v2.ContainerResponse{
+			ID:            containerID,
+			Name:          containerName,
+			DockerName:    containerName,
+			Image:         imageName,
+			ImageID:       imageID,
+			DesiredStatus: statusRunning,
+			KnownStatus:   statusRunning,
+			ContainerArn:  "arn:aws:ecs:ap-northnorth-1:NNN:container/NNNNNNNN-aaaa-4444-bbbb-00000000000",
+			Limits: v2.LimitsResponse{
+				CPU:    aws.Float64(cpu),
+				Memory: aws.Int64(memory),
+			},
+			Type:   containerType,
+			Labels: labels,
+			Ports: []v1.PortResponse{
+				{
+					ContainerPort: containerPort,
+					Protocol:      containerPortProtocol,
+					HostPort:      containerPort,
+				},
+			},
+			Networks: []containermetadata.Network{
+				{
+					NetworkMode:   utils.NetworkModeAWSVPC,
+					IPv4Addresses: []string{eniIPv4Address},
+				},
+			},
+		},
 		Networks: []v4.Network{{
 			Network: containermetadata.Network{
 				NetworkMode:   utils.NetworkModeAWSVPC,

--- a/agent/handlers/task_server_setup_test.go
+++ b/agent/handlers/task_server_setup_test.go
@@ -313,8 +313,25 @@ var (
 		},
 	}
 	expectedV4TaskResponse = v4.TaskResponse{
-		TaskResponse: &expectedTaskResponse,
-		Containers:   []v4.ContainerResponse{expectedV4ContainerResponse},
+		TaskResponse: &v2.TaskResponse{
+			Cluster:       clusterName,
+			TaskARN:       taskARN,
+			Family:        family,
+			Revision:      version,
+			DesiredStatus: statusRunning,
+			KnownStatus:   statusRunning,
+			Containers:    []v2.ContainerResponse{expectedContainerResponse},
+			Limits: &v2.LimitsResponse{
+				CPU:    aws.Float64(cpu),
+				Memory: aws.Int64(memory),
+			},
+			PullStartedAt:      aws.Time(now.UTC()),
+			PullStoppedAt:      aws.Time(now.UTC()),
+			ExecutionStoppedAt: aws.Time(now.UTC()),
+			AvailabilityZone:   availabilityzone,
+			LaunchType:         "EC2",
+		},
+		Containers: []v4.ContainerResponse{expectedV4ContainerResponse},
 	}
 	expectedV4BridgeContainerResponse = v4.ContainerResponse{
 		ContainerResponse: &expectedBridgeContainerResponse,
@@ -333,8 +350,25 @@ var (
 		},
 	}
 	expectedV4BridgeTaskResponse = v4.TaskResponse{
-		TaskResponse: &expectedBridgeTaskResponse,
-		Containers:   []v4.ContainerResponse{expectedV4BridgeContainerResponse},
+		TaskResponse: &v2.TaskResponse{
+			Cluster:       clusterName,
+			TaskARN:       taskARN,
+			Family:        family,
+			Revision:      version,
+			DesiredStatus: statusRunning,
+			KnownStatus:   statusRunning,
+			Containers:    []v2.ContainerResponse{expectedBridgeContainerResponse},
+			Limits: &v2.LimitsResponse{
+				CPU:    aws.Float64(cpu),
+				Memory: aws.Int64(memory),
+			},
+			PullStartedAt:      aws.Time(now.UTC()),
+			PullStoppedAt:      aws.Time(now.UTC()),
+			ExecutionStoppedAt: aws.Time(now.UTC()),
+			AvailabilityZone:   availabilityzone,
+			LaunchType:         "EC2",
+		},
+		Containers: []v4.ContainerResponse{expectedV4BridgeContainerResponse},
 	}
 )
 

--- a/agent/handlers/v2/response.go
+++ b/agent/handlers/v2/response.go
@@ -70,6 +70,7 @@ type ContainerResponse struct {
 	Volumes       []v1.VolumeResponse         `json:"Volumes,omitempty"`
 	LogDriver     string                      `json:"LogDriver,omitempty"`
 	LogOptions    map[string]string           `json:"LogOptions,omitempty"`
+	ContainerArn  string                      `json:"ContainerArn,omitempty"`
 }
 
 // LimitsResponse defines the schema for task/cpu limits response
@@ -103,6 +104,9 @@ func NewTaskResponse(
 		DesiredStatus:    task.GetDesiredStatus().String(),
 		KnownStatus:      task.GetKnownStatus().String(),
 		AvailabilityZone: az,
+	}
+	if includeV4Metadata {
+		resp.LaunchType = task.LaunchType
 	}
 
 	taskCPU := task.CPU
@@ -217,6 +221,7 @@ func newContainerResponse(
 	if includeV4Metadata {
 		resp.LogDriver = container.GetLogDriver()
 		resp.LogOptions = container.GetLogOptions()
+		resp.ContainerArn = container.ContainerArn
 	}
 
 	// Write the container health status inside the container

--- a/agent/handlers/v2/response.go
+++ b/agent/handlers/v2/response.go
@@ -70,7 +70,7 @@ type ContainerResponse struct {
 	Volumes       []v1.VolumeResponse         `json:"Volumes,omitempty"`
 	LogDriver     string                      `json:"LogDriver,omitempty"`
 	LogOptions    map[string]string           `json:"LogOptions,omitempty"`
-	ContainerArn  string                      `json:"ContainerArn,omitempty"`
+	ContainerARN  string                      `json:"ContainerARN,omitempty"`
 }
 
 // LimitsResponse defines the schema for task/cpu limits response
@@ -221,7 +221,7 @@ func newContainerResponse(
 	if includeV4Metadata {
 		resp.LogDriver = container.GetLogDriver()
 		resp.LogOptions = container.GetLogOptions()
-		resp.ContainerArn = container.ContainerArn
+		resp.ContainerARN = container.ContainerArn
 	}
 
 	// Write the container health status inside the container

--- a/agent/handlers/v2/response_test.go
+++ b/agent/handlers/v2/response_test.go
@@ -123,11 +123,115 @@ func TestTaskResponse(t *testing.T) {
 		state.EXPECT().ContainerMapByArn(taskARN).Return(containerNameToDockerContainer, true),
 	)
 
-	taskResponse, err := NewTaskResponse(taskARN, state, ecsClient, cluster, availabilityZone, containerInstanceArn, false)
+	taskResponse, err := NewTaskResponse(taskARN, state, ecsClient, cluster, availabilityZone, containerInstanceArn, false, false)
 	assert.NoError(t, err)
 	_, err = json.Marshal(taskResponse)
 	assert.NoError(t, err)
 	assert.Equal(t, created.UTC().String(), taskResponse.Containers[0].CreatedAt.String())
+	// LaunchType should not be populated
+	assert.Equal(t, "", taskResponse.LaunchType)
+	// Log driver and Log options should not be populated
+	assert.Equal(t, "", taskResponse.Containers[0].LogDriver)
+	assert.Len(t, taskResponse.Containers[0].LogOptions, 0)
+
+	gomock.InOrder(
+		state.EXPECT().TaskByArn(taskARN).Return(task, true),
+		state.EXPECT().ContainerMapByArn(taskARN).Return(containerNameToDockerContainer, true),
+	)
+	// verify that 'v4' response without log driver or options returns blank fields as well
+	taskResponse, err = NewTaskResponse(taskARN, state, ecsClient, cluster, availabilityZone, containerInstanceArn, false, true)
+	assert.NoError(t, err)
+	_, err = json.Marshal(taskResponse)
+	assert.NoError(t, err)
+	// LaunchType should not be populated
+	assert.Equal(t, "", taskResponse.LaunchType)
+	// Log driver and Log options should not be populated
+	assert.Equal(t, "", taskResponse.Containers[0].LogDriver)
+	assert.Len(t, taskResponse.Containers[0].LogOptions, 0)
+}
+
+func TestTaskResponseWithV4Metadata(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	state := mock_dockerstate.NewMockTaskEngineState(ctrl)
+	ecsClient := mock_api.NewMockECSClient(ctrl)
+	now := time.Now()
+	task := &apitask.Task{
+		Arn:                 taskARN,
+		Family:              family,
+		Version:             version,
+		DesiredStatusUnsafe: apitaskstatus.TaskRunning,
+		KnownStatusUnsafe:   apitaskstatus.TaskRunning,
+		ENIs: []*apieni.ENI{
+			{
+				IPV4Addresses: []*apieni.ENIIPV4Address{
+					{
+						Address: eniIPv4Address,
+					},
+				},
+			},
+		},
+		CPU:                      cpu,
+		Memory:                   memory,
+		PullStartedAtUnsafe:      now,
+		PullStoppedAtUnsafe:      now,
+		ExecutionStoppedAtUnsafe: now,
+	}
+	container := &apicontainer.Container{
+		Name:                containerName,
+		Image:               imageName,
+		ImageID:             imageID,
+		DesiredStatusUnsafe: apicontainerstatus.ContainerRunning,
+		KnownStatusUnsafe:   apicontainerstatus.ContainerRunning,
+		CPU:                 cpu,
+		Memory:              memory,
+		Type:                apicontainer.ContainerNormal,
+		Ports: []apicontainer.PortBinding{
+			{
+				ContainerPort: 80,
+				Protocol:      apicontainer.TransportProtocolTCP,
+			},
+		},
+		VolumesUnsafe: []types.MountPoint{
+			{
+				Name:        volName,
+				Source:      volSource,
+				Destination: volDestination,
+			},
+		},
+		DockerConfig: apicontainer.DockerConfig{
+			HostConfig: aws.String(`{"LogConfig":{"Type":"awslogs","Config":{"awslogs-group":"myLogGroup"}}}`),
+		},
+	}
+	created := time.Now()
+	container.SetCreatedAt(created)
+	labels := map[string]string{
+		"foo": "bar",
+	}
+	container.SetLabels(labels)
+	containerNameToDockerContainer := map[string]*apicontainer.DockerContainer{
+		taskARN: {
+			DockerID:   containerID,
+			DockerName: containerName,
+			Container:  container,
+		},
+	}
+	gomock.InOrder(
+		state.EXPECT().TaskByArn(taskARN).Return(task, true),
+		state.EXPECT().ContainerMapByArn(taskARN).Return(containerNameToDockerContainer, true),
+	)
+
+	taskResponse, err := NewTaskResponse(taskARN, state, ecsClient, cluster, availabilityZone, containerInstanceArn, false, true)
+	assert.NoError(t, err)
+	_, err = json.Marshal(taskResponse)
+	assert.NoError(t, err)
+	assert.Equal(t, created.UTC().String(), taskResponse.Containers[0].CreatedAt.String())
+	// LaunchType is populated by the v4 handler
+	assert.Equal(t, "", taskResponse.LaunchType)
+	// Log driver and config should be populated
+	assert.Equal(t, "awslogs", taskResponse.Containers[0].LogDriver)
+	assert.Equal(t, map[string]string{"awslogs-group": "myLogGroup"}, taskResponse.Containers[0].LogOptions)
 }
 
 func TestContainerResponse(t *testing.T) {
@@ -207,7 +311,7 @@ func TestContainerResponse(t *testing.T) {
 				state.EXPECT().TaskByID(containerID).Return(task, true),
 			)
 
-			containerResponse, err := NewContainerResponse(containerID, state)
+			containerResponse, err := NewContainerResponse(containerID, state, false)
 			assert.NoError(t, err)
 			assert.Equal(t, containerResponse.Health == nil, tc.result)
 			_, err = json.Marshal(containerResponse)
@@ -344,7 +448,7 @@ func TestTaskResponseMarshal(t *testing.T) {
 		}, nil),
 	)
 
-	taskResponse, err := NewTaskResponse(taskARN, state, ecsClient, cluster, availabilityZone, containerInstanceArn, true)
+	taskResponse, err := NewTaskResponse(taskARN, state, ecsClient, cluster, availabilityZone, containerInstanceArn, true, false)
 	assert.NoError(t, err)
 
 	taskResponseJSON, err := json.Marshal(taskResponse)
@@ -448,7 +552,7 @@ func TestContainerResponseMarshal(t *testing.T) {
 		state.EXPECT().TaskByID(containerID).Return(task, true),
 	)
 
-	containerResponse, err := NewContainerResponse(containerID, state)
+	containerResponse, err := NewContainerResponse(containerID, state, false)
 	assert.NoError(t, err)
 
 	containerResponseJSON, err := json.Marshal(containerResponse)

--- a/agent/handlers/v2/task_container_metadata_handler.go
+++ b/agent/handlers/v2/task_container_metadata_handler.go
@@ -71,7 +71,7 @@ func TaskContainerMetadataHandler(state dockerstate.TaskEngineState, ecsClient a
 
 // WriteContainerMetadataResponse writes the container metadata to response writer.
 func WriteContainerMetadataResponse(w http.ResponseWriter, containerID string, state dockerstate.TaskEngineState) {
-	containerResponse, err := NewContainerResponse(containerID, state)
+	containerResponse, err := NewContainerResponse(containerID, state, false)
 	if err != nil {
 		errResponseJSON, err := json.Marshal("Unable to generate metadata for container '" + containerID + "'")
 		if e := utils.WriteResponseIfMarshalError(w, err); e != nil {
@@ -91,7 +91,7 @@ func WriteContainerMetadataResponse(w http.ResponseWriter, containerID string, s
 // WriteTaskMetadataResponse writes the task metadata to response writer.
 func WriteTaskMetadataResponse(w http.ResponseWriter, taskARN string, cluster string, state dockerstate.TaskEngineState, ecsClient api.ECSClient, az, containerInstanceArn string, propagateTags bool) {
 	// Generate a response for the task
-	taskResponse, err := NewTaskResponse(taskARN, state, ecsClient, cluster, az, containerInstanceArn, propagateTags)
+	taskResponse, err := NewTaskResponse(taskARN, state, ecsClient, cluster, az, containerInstanceArn, propagateTags, false)
 	if err != nil {
 		errResponseJSON, err := json.Marshal("Unable to generate metadata for task: '" + taskARN + "'")
 		if e := utils.WriteResponseIfMarshalError(w, err); e != nil {

--- a/agent/handlers/v3/container_metadata_handler.go
+++ b/agent/handlers/v3/container_metadata_handler.go
@@ -63,7 +63,7 @@ func ContainerMetadataHandler(state dockerstate.TaskEngineState) func(http.Respo
 
 // GetContainerResponse gets container response for v3 metadata
 func GetContainerResponse(containerID string, state dockerstate.TaskEngineState) (*v2.ContainerResponse, error) {
-	containerResponse, err := v2.NewContainerResponse(containerID, state)
+	containerResponse, err := v2.NewContainerResponse(containerID, state, false)
 	if err != nil {
 		seelog.Errorf("Unable to get container metadata for container '%s'", containerID)
 		return nil, errors.Errorf("Unable to generate metadata for container '%s'", containerID)

--- a/agent/handlers/v3/task_metadata_handler.go
+++ b/agent/handlers/v3/task_metadata_handler.go
@@ -51,7 +51,7 @@ func TaskMetadataHandler(state dockerstate.TaskEngineState, ecsClient api.ECSCli
 
 		seelog.Infof("V3 task metadata handler: writing response for task '%s'", taskARN)
 
-		taskResponse, err := v2.NewTaskResponse(taskARN, state, ecsClient, cluster, az, containerInstanceArn, propagateTags)
+		taskResponse, err := v2.NewTaskResponse(taskARN, state, ecsClient, cluster, az, containerInstanceArn, propagateTags, false)
 		if err != nil {
 			errResponseJSON, err := json.Marshal("Unable to generate metadata for task: '" + taskARN + "'")
 			if e := utils.WriteResponseIfMarshalError(w, err); e != nil {

--- a/agent/handlers/v4/response.go
+++ b/agent/handlers/v4/response.go
@@ -19,7 +19,6 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/api"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	"github.com/aws/amazon-ecs-agent/agent/containermetadata"
-	"github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/handlers/utils"
 	v2 "github.com/aws/amazon-ecs-agent/agent/handlers/v2"
@@ -104,8 +103,6 @@ func NewTaskResponse(
 			Networks:          networks,
 		})
 	}
-
-	v2Resp.LaunchType = ecs.LaunchTypeEc2
 
 	return &TaskResponse{
 		TaskResponse: v2Resp,

--- a/agent/handlers/v4/response.go
+++ b/agent/handlers/v4/response.go
@@ -19,6 +19,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/api"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	"github.com/aws/amazon-ecs-agent/agent/containermetadata"
+	"github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/handlers/utils"
 	v2 "github.com/aws/amazon-ecs-agent/agent/handlers/v2"
@@ -85,7 +86,7 @@ func NewTaskResponse(
 ) (*TaskResponse, error) {
 	// Construct the v2 response first.
 	v2Resp, err := v2.NewTaskResponse(taskARN, state, ecsClient, cluster, az,
-		containerInstanceARN, propagateTags)
+		containerInstanceARN, propagateTags, true)
 	if err != nil {
 		return nil, err
 	}
@@ -104,6 +105,8 @@ func NewTaskResponse(
 		})
 	}
 
+	v2Resp.LaunchType = ecs.LaunchTypeEc2
+
 	return &TaskResponse{
 		TaskResponse: v2Resp,
 		Containers:   containers,
@@ -117,7 +120,7 @@ func NewContainerResponse(
 	state dockerstate.TaskEngineState,
 ) (*ContainerResponse, error) {
 	// Construct the v2 response first.
-	container, err := v2.NewContainerResponse(containerID, state)
+	container, err := v2.NewContainerResponse(containerID, state, true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Summary
<!-- What does this pull request do? -->

Merge feature branch of TMDEv4 changes for service lens

This is a combination of two PRs: https://github.com/aws/amazon-ecs-agent/pull/2586 and https://github.com/aws/amazon-ecs-agent/pull/2620


This change adds metadata to the [Task metadata endpoint v4](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v4.html)

Below is a diff of the added information when querying the /task endpoint (`${ECS_CONTAINER_METADATA_URI_V4}/task`). There will be a follow-up PR to add ContainerArn, which will need to be provided by the ECS backend.

```diff
{
  "Cluster": "usw2",
  "TaskARN": "arn:aws:ecs:us-west-2:NNNN:task/NNNN/NNNN",
  "Family": "NNNN",
  "Revision": "4",
  "DesiredStatus": "RUNNING",
  "KnownStatus": "RUNNING",
  "Limits": {
    "CPU": 0.25,
    "Memory": 256
  },
  "PullStartedAt": "2020-08-21T18:18:05.845370929Z",
  "PullStoppedAt": "2020-08-21T18:18:06.561130985Z",
  "AvailabilityZone": "us-west-2a",
+ "LaunchType": "EC2",
  "Containers": [
    {
      "DockerId": "NNNN",
      "Name": "main",
      "DockerName": "ecs-NNNN-NNNN",
      "Image": "NNNN.dkr.ecr.us-west-2.amazonaws.com/NNNN:NNNN",
      "ImageID": "sha256:NNNN",
      "Labels": {
        "com.amazonaws.ecs.cluster": "NNNN",
        "com.amazonaws.ecs.container-name": "main",
        "com.amazonaws.ecs.task-arn": "arn:aws:ecs:us-west-2:NNNN:task/NNNN/NNNN",
        "com.amazonaws.ecs.task-definition-family": "NNNN",
        "com.amazonaws.ecs.task-definition-version": "4"
      },
      "DesiredStatus": "RUNNING",
      "KnownStatus": "RUNNING",
      "Limits": {
        "CPU": 256,
        "Memory": 0
      },
      "CreatedAt": "2020-08-21T18:18:06.576462775Z",
      "StartedAt": "2020-08-21T18:18:07.397380758Z",
      "Type": "NORMAL",
+     "ContainerARN": "arn:aws:ecs:us-west-2:NNNN:task/NNNN/NNNN",
+     "LogDriver": "awslogs",
+     "LogOptions": {
+       "awslogs-group": "NNNN-cluster",
+       "awslogs-region": "us-west-2",
+       "awslogs-stream": "auto-ecs/main/NNNN"
+     },
      "Networks": [
        {
          "NetworkMode": "host",
          "IPv4Addresses": [
            ""
          ]
        }
      ]
    }
  ]
}
```

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

ECS metadata for AWS service lens and x-ray

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
