### PR TITLE
TMDEv4: change ContainerArn to ContainerARN for consistency with TaskARN

### DIFF
--- a/agent/handlers/task_server_setup_test.go
+++ b/agent/handlers/task_server_setup_test.go
@@ -308,7 +308,7 @@ var (
 			ImageID:       imageID,
 			DesiredStatus: statusRunning,
 			KnownStatus:   statusRunning,
-			ContainerArn:  "arn:aws:ecs:ap-northnorth-1:NNN:container/NNNNNNNN-aaaa-4444-bbbb-00000000000",
+			ContainerARN:  "arn:aws:ecs:ap-northnorth-1:NNN:container/NNNNNNNN-aaaa-4444-bbbb-00000000000",
 			Limits: v2.LimitsResponse{
 				CPU:    aws.Float64(cpu),
 				Memory: aws.Int64(memory),

--- a/agent/handlers/v2/response.go
+++ b/agent/handlers/v2/response.go
@@ -70,7 +70,7 @@ type ContainerResponse struct {
 	Volumes       []v1.VolumeResponse         `json:"Volumes,omitempty"`
 	LogDriver     string                      `json:"LogDriver,omitempty"`
 	LogOptions    map[string]string           `json:"LogOptions,omitempty"`
-	ContainerArn  string                      `json:"ContainerArn,omitempty"`
+	ContainerARN  string                      `json:"ContainerARN,omitempty"`
 }
 
 // LimitsResponse defines the schema for task/cpu limits response
@@ -221,7 +221,7 @@ func newContainerResponse(
 	if includeV4Metadata {
 		resp.LogDriver = container.GetLogDriver()
 		resp.LogOptions = container.GetLogOptions()
-		resp.ContainerArn = container.ContainerArn
+		resp.ContainerARN = container.ContainerArn
 	}
 
 	// Write the container health status inside the container


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

NOTE: this is merging to feature branch of an unlaunched feature

Changes the new Container ARN field in TMDEv4 from ContainerArn to ContainerARN, in order to be consistent with the existing TaskARN field.

Example diff output of TMDEv4 below: 

```diff
 {
   "Cluster": "baz",
   "TaskARN": "arn:aws:ecs:ap-east-1:00000000:task/0000-0000-0000-0000-0000000",
   "Family": "foo",
   "Revision": "2",
   "DesiredStatus": "RUNNING",
   "KnownStatus": "CREATED",
   "Limits": {
     "CPU": 0.25,
     "Memory": 256
   },
   "PullStartedAt": "2020-09-10T17:52:36.101885548Z",
   "PullStoppedAt": "2020-09-10T17:52:36.490860581Z",
   "AvailabilityZone": "ap-east-1a",
   "LaunchType": "EC2",
   "Containers": [
     {
       "DockerId": "NNNN",
       "Name": "main",
       "Image": "00000000000.dkr.ecr.ap-east-1.amazonaws.com/foo:bar",
       "ImageID": "sha256:NNN",
       "Labels": {},
       "DesiredStatus": "RUNNING",
       "KnownStatus": "CREATED",
       "Limits": {
         "CPU": 256,
         "Memory": 0
       },
       "Type": "NORMAL",
-      "ContainerArn": "arn:aws:ecs:ap-east-1:0000000000:container/0000-0000-0000-000000",
+      "ContainerARN": "arn:aws:ecs:ap-east-1:0000000000:container/0000-0000-0000-000000",
       "Networks": [
         {
           "NetworkMode": "host",
           "IPv4Addresses": [
             ""
           ]
         }
       ]
     }
   ]
 }
```

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
