### PR TITLE
Add ContainerExecStart to dockerapi

### DIFF
--- a/agent/dockerclient/dockerapi/docker_client.go
+++ b/agent/dockerclient/dockerapi/docker_client.go
@@ -142,6 +142,10 @@ type DockerClient interface {
 	// and a context should be provided for the request.
 	CreateContainerExec(ctx context.Context, containerID string, execConfig types.ExecConfig, timeout time.Duration) (*types.IDResponse, error)
 
+	// StartContainerExec starts an exec process already created in the docker host. A timeout value
+	// and a context should be provided for the request.
+	StartContainerExec(ctx context.Context, execID string, timeout time.Duration) error
+
 	// ListContainers returns the set of containers known to the Docker daemon. A timeout value and a context
 	// should be provided for the request.
 	ListContainers(context.Context, bool, time.Duration) ListContainersResponse
@@ -1555,4 +1559,45 @@ func (dg *dockerGoClient) createContainerExec(ctx context.Context, containerID s
 		return nil, &CannotCreateContainerExecError{err}
 	}
 	return &execIDResponse, nil
+}
+
+func (dg *dockerGoClient) StartContainerExec(ctx context.Context, execID string, timeout time.Duration) error {
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	defer metrics.MetricsEngineGlobal.RecordDockerMetric("START_CONTAINER_EXEC")()
+	response := make(chan error, 1)
+	go func() {
+		err := dg.startContainerExec(ctx, execID)
+		response <- err
+	}()
+
+	select {
+	case resp := <-response:
+		return resp
+	case <-ctx.Done():
+		err := ctx.Err()
+		if err == context.DeadlineExceeded {
+			return &DockerTimeoutError{timeout, "start exec command"}
+		}
+		return &CannotStartContainerExecError{err}
+	}
+}
+
+func (dg *dockerGoClient) startContainerExec(ctx context.Context, execID string) error {
+	client, err := dg.sdkDockerClient()
+	if err != nil {
+		return err
+	}
+
+	execStartCheck := types.ExecStartCheck{
+		Detach: true,
+		Tty:    false,
+	}
+
+	err = client.ContainerExecStart(ctx, execID, execStartCheck)
+	if err != nil {
+		return &CannotStartContainerExecError{err}
+	}
+	return nil
 }

--- a/agent/dockerclient/dockerapi/errors.go
+++ b/agent/dockerclient/dockerapi/errors.go
@@ -369,3 +369,17 @@ func (err CannotCreateContainerExecError) Error() string {
 func (err CannotCreateContainerExecError) ErrorName() string {
 	return "CannotCreateContainerExecError"
 }
+
+// CannotStartContainerExecError indicates any error when trying to start an exec process
+type CannotStartContainerExecError struct {
+	FromError error
+}
+
+func (err CannotStartContainerExecError) Error() string {
+	return err.FromError.Error()
+}
+
+// ErrorName returns name of the CannotCreateContainerExecError.
+func (err CannotStartContainerExecError) ErrorName() string {
+	return "CannotStartContainerExecError"
+}

--- a/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
+++ b/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
@@ -359,6 +359,20 @@ func (mr *MockDockerClientMockRecorder) StartContainer(arg0, arg1, arg2 interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartContainer", reflect.TypeOf((*MockDockerClient)(nil).StartContainer), arg0, arg1, arg2)
 }
 
+// StartContainerExec mocks base method
+func (m *MockDockerClient) StartContainerExec(arg0 context.Context, arg1 string, arg2 time.Duration) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StartContainerExec", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// StartContainerExec indicates an expected call of StartContainerExec
+func (mr *MockDockerClientMockRecorder) StartContainerExec(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartContainerExec", reflect.TypeOf((*MockDockerClient)(nil).StartContainerExec), arg0, arg1, arg2)
+}
+
 // Stats mocks base method
 func (m *MockDockerClient) Stats(arg0 context.Context, arg1 string, arg2 time.Duration) (<-chan *types.StatsJSON, <-chan error) {
 	m.ctrl.T.Helper()

--- a/agent/dockerclient/sdkclient/interface.go
+++ b/agent/dockerclient/sdkclient/interface.go
@@ -42,6 +42,7 @@ type Client interface {
 	ContainerStats(ctx context.Context, containerID string, stream bool) (types.ContainerStats, error)
 	ContainerStop(ctx context.Context, containerID string, timeout *time.Duration) error
 	ContainerExecCreate(ctx context.Context, container string, config types.ExecConfig) (types.IDResponse, error)
+	ContainerExecStart(ctx context.Context, execID string, config types.ExecStartCheck) error
 	Events(ctx context.Context, options types.EventsOptions) (<-chan events.Message, <-chan error)
 	ImageImport(ctx context.Context, source types.ImageImportSource, ref string,
 		options types.ImageImportOptions) (io.ReadCloser, error)

--- a/agent/dockerclient/sdkclient/mocks/sdkclient_mocks.go
+++ b/agent/dockerclient/sdkclient/mocks/sdkclient_mocks.go
@@ -100,6 +100,20 @@ func (mr *MockClientMockRecorder) ContainerExecCreate(arg0, arg1, arg2 interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerExecCreate", reflect.TypeOf((*MockClient)(nil).ContainerExecCreate), arg0, arg1, arg2)
 }
 
+// ContainerExecStart mocks base method
+func (m *MockClient) ContainerExecStart(arg0 context.Context, arg1 string, arg2 types.ExecStartCheck) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ContainerExecStart", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ContainerExecStart indicates an expected call of ContainerExecStart
+func (mr *MockClientMockRecorder) ContainerExecStart(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerExecStart", reflect.TypeOf((*MockClient)(nil).ContainerExecStart), arg0, arg1, arg2)
+}
+
 // ContainerInspect mocks base method
 func (m *MockClient) ContainerInspect(arg0 context.Context, arg1 string) (types.ContainerJSON, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This PR adds the API ContainerExecStart(https://godoc.org/github.com/docker/docker/client#Client.ContainerExecStart) to the dockerapi.

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

Unit tests cover the changes.
Also tested manually that the StartContainerExec returned no error when I passed exceID returned by CreateContainerExec API.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Feature: Add ContainerExecStart to dockerapi
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
