### PR TITLE
Add ContainerExecInspect to dockerapi

### DIFF
--- a/agent/dockerclient/dockerapi/docker_client.go
+++ b/agent/dockerclient/dockerapi/docker_client.go
@@ -146,6 +146,10 @@ type DockerClient interface {
 	// and a context should be provided for the request.
 	StartContainerExec(ctx context.Context, execID string, timeout time.Duration) error
 
+	// InspectContainerExec returns information about a specific exec process on the docker host. A timeout value
+	// and a context should be provided for the request.
+	InspectContainerExec(ctx context.Context, execID string, timeout time.Duration) (*types.ContainerExecInspect, error)
+
 	// ListContainers returns the set of containers known to the Docker daemon. A timeout value and a context
 	// should be provided for the request.
 	ListContainers(context.Context, bool, time.Duration) ListContainersResponse
@@ -1600,4 +1604,45 @@ func (dg *dockerGoClient) startContainerExec(ctx context.Context, execID string)
 		return &CannotStartContainerExecError{err}
 	}
 	return nil
+}
+
+func (dg *dockerGoClient) InspectContainerExec(ctx context.Context, execID string, timeout time.Duration) (*types.ContainerExecInspect, error) {
+	type inspectContainerExecResponse struct {
+		execInspect *types.ContainerExecInspect
+		err         error
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	defer metrics.MetricsEngineGlobal.RecordDockerMetric("INSPECT_CONTAINER_EXEC")()
+	response := make(chan inspectContainerExecResponse, 1)
+	go func() {
+		execInspectResponse, err := dg.inspectContainerExec(ctx, execID)
+		response <- inspectContainerExecResponse{execInspectResponse, err}
+	}()
+
+	select {
+	case resp := <-response:
+		return resp.execInspect, resp.err
+
+	case <-ctx.Done():
+		err := ctx.Err()
+		if err == context.DeadlineExceeded {
+			return nil, &DockerTimeoutError{timeout, "inspect exec command"}
+		}
+		return nil, &CannotInspectContainerExecError{err}
+	}
+}
+
+func (dg *dockerGoClient) inspectContainerExec(ctx context.Context, containerID string) (*types.ContainerExecInspect, error) {
+	client, err := dg.sdkDockerClient()
+	if err != nil {
+		return nil, err
+	}
+
+	execInspectResponse, err := client.ContainerExecInspect(ctx, containerID)
+	if err != nil {
+		return nil, &CannotInspectContainerExecError{err}
+	}
+	return &execInspectResponse, nil
 }

--- a/agent/dockerclient/dockerapi/errors.go
+++ b/agent/dockerclient/dockerapi/errors.go
@@ -383,3 +383,17 @@ func (err CannotStartContainerExecError) Error() string {
 func (err CannotStartContainerExecError) ErrorName() string {
 	return "CannotStartContainerExecError"
 }
+
+// CannotInspectContainerExecError indicates any error when trying to start an exec process
+type CannotInspectContainerExecError struct {
+	FromError error
+}
+
+func (err CannotInspectContainerExecError) Error() string {
+	return err.FromError.Error()
+}
+
+// ErrorName returns name of the CannotCreateContainerExecError.
+func (err CannotInspectContainerExecError) ErrorName() string {
+	return "CannotInspectContainerExecError"
+}

--- a/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
+++ b/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
@@ -175,6 +175,21 @@ func (mr *MockDockerClientMockRecorder) InspectContainer(arg0, arg1, arg2 interf
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InspectContainer", reflect.TypeOf((*MockDockerClient)(nil).InspectContainer), arg0, arg1, arg2)
 }
 
+// InspectContainerExec mocks base method
+func (m *MockDockerClient) InspectContainerExec(arg0 context.Context, arg1 string, arg2 time.Duration) (*types.ContainerExecInspect, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InspectContainerExec", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*types.ContainerExecInspect)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// InspectContainerExec indicates an expected call of InspectContainerExec
+func (mr *MockDockerClientMockRecorder) InspectContainerExec(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InspectContainerExec", reflect.TypeOf((*MockDockerClient)(nil).InspectContainerExec), arg0, arg1, arg2)
+}
+
 // InspectImage mocks base method
 func (m *MockDockerClient) InspectImage(arg0 string) (*types.ImageInspect, error) {
 	m.ctrl.T.Helper()

--- a/agent/dockerclient/sdkclient/interface.go
+++ b/agent/dockerclient/sdkclient/interface.go
@@ -43,6 +43,7 @@ type Client interface {
 	ContainerStop(ctx context.Context, containerID string, timeout *time.Duration) error
 	ContainerExecCreate(ctx context.Context, container string, config types.ExecConfig) (types.IDResponse, error)
 	ContainerExecStart(ctx context.Context, execID string, config types.ExecStartCheck) error
+	ContainerExecInspect(ctx context.Context, execID string) (types.ContainerExecInspect, error)
 	Events(ctx context.Context, options types.EventsOptions) (<-chan events.Message, <-chan error)
 	ImageImport(ctx context.Context, source types.ImageImportSource, ref string,
 		options types.ImageImportOptions) (io.ReadCloser, error)

--- a/agent/dockerclient/sdkclient/mocks/sdkclient_mocks.go
+++ b/agent/dockerclient/sdkclient/mocks/sdkclient_mocks.go
@@ -100,6 +100,21 @@ func (mr *MockClientMockRecorder) ContainerExecCreate(arg0, arg1, arg2 interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerExecCreate", reflect.TypeOf((*MockClient)(nil).ContainerExecCreate), arg0, arg1, arg2)
 }
 
+// ContainerExecInspect mocks base method
+func (m *MockClient) ContainerExecInspect(arg0 context.Context, arg1 string) (types.ContainerExecInspect, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ContainerExecInspect", arg0, arg1)
+	ret0, _ := ret[0].(types.ContainerExecInspect)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ContainerExecInspect indicates an expected call of ContainerExecInspect
+func (mr *MockClientMockRecorder) ContainerExecInspect(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerExecInspect", reflect.TypeOf((*MockClient)(nil).ContainerExecInspect), arg0, arg1)
+}
+
 // ContainerExecStart mocks base method
 func (m *MockClient) ContainerExecStart(arg0 context.Context, arg1 string, arg2 types.ExecStartCheck) error {
 	m.ctrl.T.Helper()

--- a/agent/dockerclient/timeout.go
+++ b/agent/dockerclient/timeout.go
@@ -40,7 +40,12 @@ const (
 	InspectContainerTimeout = 30 * time.Second
 	// TopContainerTimeout is the timeout for the TopContainer API.
 	TopContainerTimeout = 30 * time.Second
-
+	// ContainerExecCreateTimeout is the timeout for the ContainerExecCreate API.
+	ContainerExecCreateTimeout = 1 * time.Minute
+	// ContainerExecStartTimeout is the timeout for the ContainerExecStart API.
+	ContainerExecStartTimeout = 1 * time.Minute
+	// ContainerExecInspectTimeout is the timeout for the ContainerExecInspect API.
+	ContainerExecInspectTimeout = 1 * time.Minute
 	// StopContainerTimeout is the timeout for the StopContainer API.
 	StopContainerTimeout = 30 * time.Second
 	// RemoveContainerTimeout is the timeout for the RemoveContainer API.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR adds ContainerExecInspect to dockerapi.

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

Unit tests cover the changes.
Also tested manually by creating an exec process, then starting the exec process and inspecting the exec process. I got the following as output
```
execContainerInspectOut: &{ cb638e162123f7eae1cf10e534861b3f50cedda5b5e188d3f5f00cc4b8df5879 true 0 15310}
```

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
