### PR TITLE
Remove TestPortForward

### DIFF
--- a/agent/engine/engine_unix_integ_test.go
+++ b/agent/engine/engine_unix_integ_test.go
@@ -660,6 +660,7 @@ func TestPortForward(t *testing.T) {
 
 	time.Sleep(waitForDockerDuration) // wait for Docker
 	_, err = net.DialTimeout("tcp", fmt.Sprintf("%s:%d", localhost, port1), dialTimeout)
+
 	require.Error(t, err, "Did not expect to be able to dial %s:%d but didn't get error", localhost, port1)
 
 	// Kill the existing container now to make the test run more quickly.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This test verifies that when a container publishes a port using `-p` , the port can be accessed by the host and if the container doesn't publish the port, it cannot be accessed from the host. The assumption that the port is not accessible when not published by the container is not true. To verify the same, I ran the following two commands --

- docker run -p 24687:24687 amazon/amazon-ecs-netkitten:make -l=24687 -serve "serving content"
- docker run amazon/amazon-ecs-netkitten:make -l=24687 -serve "serving content" 

In both the cases, I was able to access the `container-ip-addr:24687` from the host. 

### Implementation details
Remove TestPortForward

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
