### PR TITLE
monitor ExecAgent Processes for Exec-enabled tasks

### DIFF
--- a/agent/api/container/container.go
+++ b/agent/api/container/container.go
@@ -267,7 +267,7 @@ type Container struct {
 	SteadyStateStatusUnsafe *apicontainerstatus.ContainerStatus `json:"SteadyStateStatus,omitempty"`
 
 	// ExecCommandAgentMetadata holds metadata about the exec agent running inside the container (i.e. SSM Agent).
-	ExecCommandAgentMetadata ExecCommandAgentMetadata `json:"execCommandAgentMetadata"`
+	ExecCommandAgentMetadata *ExecCommandAgentMetadata `json:"execCommandAgentMetadata"`
 
 	createdAt  time.Time
 	startedAt  time.Time
@@ -1157,13 +1157,13 @@ func (c *Container) GetTaskARN() string {
 	return c.TaskARNUnsafe
 }
 
-func (c *Container) SetExecCommandAgentMetadata(metadata ExecCommandAgentMetadata) {
+func (c *Container) SetExecCommandAgentMetadata(metadata *ExecCommandAgentMetadata) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	c.ExecCommandAgentMetadata = metadata
 }
 
-func (c *Container) GetExecCommandAgentMetadata() ExecCommandAgentMetadata {
+func (c *Container) GetExecCommandAgentMetadata() *ExecCommandAgentMetadata {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 	return c.ExecCommandAgentMetadata

--- a/agent/api/container/container_test.go
+++ b/agent/api/container/container_test.go
@@ -763,11 +763,13 @@ func TestExecCommandAgentMetadata(t *testing.T) {
 		testPid          = "pid"
 		testDockerExecId = "dockerId"
 	)
-	c := &Container{}
+	c := &Container{
+		ExecCommandAgentMetadata: &ExecCommandAgentMetadata{},
+	}
 	assert.Equal(t, "", c.ExecCommandAgentMetadata.PID)
 	assert.Equal(t, "", c.ExecCommandAgentMetadata.DockerExecID)
 
-	c.SetExecCommandAgentMetadata(ExecCommandAgentMetadata{
+	c.SetExecCommandAgentMetadata(&ExecCommandAgentMetadata{
 		PID:          testPid,
 		DockerExecID: testDockerExecId,
 	})

--- a/agent/dockerclient/dockerapi/errors.go
+++ b/agent/dockerclient/dockerapi/errors.go
@@ -30,6 +30,9 @@ const (
 	CannotDescribeContainerErrorName = "CannotDescribeContainerError"
 	// CannotGetContainerTopErrorName is the name of the top container error.
 	CannotGetContainerTopErrorName = "CannotGetContainerTopError"
+	// TopProcessNotFoundErrorName is the error thrown when the specified pid does
+	// not exist in the container
+	TopProcessNotFoundErrorName = "ps: exit status 1"
 )
 
 // DockerTimeoutError is an error type for describing timeouts

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -3128,3 +3128,280 @@ func TestStartFirelensContainerRetryForContainerIP(t *testing.T) {
 	assert.NoError(t, ret.Error)
 	assert.Equal(t, jsonBaseWithNetwork.NetworkSettings, ret.NetworkSettings)
 }
+
+func TestMonitorExecAgentRunning(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	ctrl, client, _, taskEngine, _, _, _ := mocks(t, ctx, &defaultConfig)
+	defer ctrl.Finish()
+	execAgentPID := "1234"
+	rID := "runtime-ID"
+	resp := &dockercontainer.ContainerTopOKBody{
+		Processes: [][]string{{"root", execAgentPID}},
+	}
+	testCases := []struct {
+		runtimeID                string
+		execCommandAgentMetadata *apicontainer.ExecCommandAgentMetadata
+		execAgentPID             string
+		expectedTopContainerCall bool
+	}{
+		{
+			runtimeID:                rID,
+			execAgentPID:             "",
+			execCommandAgentMetadata: nil,
+			expectedTopContainerCall: false,
+		},
+		{
+			runtimeID:    rID,
+			execAgentPID: execAgentPID,
+			execCommandAgentMetadata: &apicontainer.ExecCommandAgentMetadata{
+				PID: execAgentPID,
+			},
+			expectedTopContainerCall: true,
+		},
+		{
+			runtimeID:    rID,
+			execAgentPID: "",
+			execCommandAgentMetadata: &apicontainer.ExecCommandAgentMetadata{
+				PID: "",
+			},
+			expectedTopContainerCall: false,
+		},
+		{
+			runtimeID:    "",
+			execAgentPID: "",
+			execCommandAgentMetadata: &apicontainer.ExecCommandAgentMetadata{
+				PID: "",
+			},
+			expectedTopContainerCall: false,
+		},
+	}
+	for _, tc := range testCases {
+		testTask := &apitask.Task{
+			Arn: "arn:aws:ecs:region:account-id:task/test-task-arn",
+			Containers: []*apicontainer.Container{
+				{
+					Name:                     "test-container",
+					RuntimeID:                tc.runtimeID,
+					ExecCommandAgentMetadata: tc.execCommandAgentMetadata,
+				},
+			},
+			ExecCommandAgentEnabled: true,
+		}
+		taskEngine.(*DockerTaskEngine).state.AddTask(testTask)
+		if tc.expectedTopContainerCall {
+			client.EXPECT().TopContainer(gomock.Any(), testTask.Containers[0].RuntimeID, 30*time.Second, tc.execAgentPID).Return(resp, nil)
+		}
+		taskEngine.(*DockerTaskEngine).monitorExecAgentRunning(ctx, testTask.Arn, testTask.Containers[0])
+		if testTask.Containers[0].ExecCommandAgentMetadata != nil {
+			assert.Equal(t, tc.execAgentPID, testTask.Containers[0].GetExecCommandAgentMetadata().PID)
+		}
+	}
+}
+
+func TestMonitorExecAgentRunningErrors(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	ctrl, client, _, taskEngine, _, _, _ := mocks(t, ctx, &defaultConfig)
+	defer ctrl.Finish()
+	execAgentPID := "1234"
+	testCases := []struct {
+		arn               string
+		topResponse       *dockercontainer.ContainerTopOKBody
+		topError          error
+		resetExecMetadata bool
+	}{
+		{
+			topResponse:       nil,
+			topError:          &dockerapi.DockerTimeoutError{},
+			resetExecMetadata: false,
+		},
+		{
+			topResponse:       nil,
+			topError:          errors.New(dockerapi.TopProcessNotFoundErrorName),
+			resetExecMetadata: true,
+		},
+		{
+			topResponse: &dockercontainer.ContainerTopOKBody{
+				Processes: [][]string{},
+			},
+			topError:          nil,
+			resetExecMetadata: true,
+		},
+		{
+			topResponse:       nil,
+			topError:          errors.New("no container error"),
+			resetExecMetadata: false,
+		},
+		{
+			topResponse:       nil,
+			topError:          nil,
+			resetExecMetadata: true,
+		},
+	}
+	for _, tc := range testCases {
+		testTask := &apitask.Task{
+			Arn: "arn:aws:ecs:region:account-id:task/test-task-arn",
+			Containers: []*apicontainer.Container{
+				{
+					Name:      "test-container",
+					RuntimeID: "runtime-ID",
+					ExecCommandAgentMetadata: &apicontainer.ExecCommandAgentMetadata{
+						PID: execAgentPID,
+					},
+				},
+			},
+			ExecCommandAgentEnabled: true,
+		}
+		taskEngine.(*DockerTaskEngine).state.AddTask(testTask)
+		client.EXPECT().TopContainer(gomock.Any(), testTask.Containers[0].RuntimeID, 30*time.Second, execAgentPID).Return(tc.topResponse, tc.topError)
+		taskEngine.(*DockerTaskEngine).monitorExecAgentRunning(ctx, testTask.Arn, testTask.Containers[0])
+		if tc.resetExecMetadata {
+			assert.Equal(t, "", testTask.Containers[0].GetExecCommandAgentMetadata().PID)
+		} else {
+			assert.Equal(t, execAgentPID, testTask.Containers[0].GetExecCommandAgentMetadata().PID)
+		}
+	}
+}
+
+func TestMonitorExecAgentProcesses(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	ctrl, client, _, taskEngine, _, _, _ := mocks(t, ctx, &defaultConfig)
+	defer ctrl.Finish()
+	execAgentPID := "1234"
+	resp := &dockercontainer.ContainerTopOKBody{
+		Processes: [][]string{{"root", execAgentPID}},
+	}
+	testTask := &apitask.Task{
+		Arn: "arn:aws:ecs:region:account-id:task/test-task-arn",
+		Containers: []*apicontainer.Container{
+			{
+				Name:      "test-container",
+				RuntimeID: "runtime-ID",
+				ExecCommandAgentMetadata: &apicontainer.ExecCommandAgentMetadata{
+					PID: execAgentPID,
+				},
+			},
+		},
+		ExecCommandAgentEnabled: true,
+	}
+	taskEngine.(*DockerTaskEngine).state.AddTask(testTask)
+	taskEngine.(*DockerTaskEngine).managedTasks[testTask.Arn] = &managedTask{Task: testTask}
+	topCtx, topCancel := context.WithTimeout(context.Background(), time.Second)
+	defer topCancel()
+	client.EXPECT().TopContainer(gomock.Any(), testTask.Containers[0].RuntimeID, 30*time.Second, execAgentPID).DoAndReturn(
+		func(ctx context.Context, containerID string, timeout time.Duration, psArgs ...string) (*dockercontainer.ContainerTopOKBody, error) {
+			defer topCancel()
+			return resp, nil
+		})
+	taskEngine.(*DockerTaskEngine).monitorExecAgentProcesses(ctx)
+	<-topCtx.Done()
+	time.Sleep(5 * time.Millisecond)
+	assert.Equal(t, execAgentPID, testTask.Containers[0].GetExecCommandAgentMetadata().PID)
+}
+
+func TestMonitorExecAgentProcessExecDisabled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	ctrl, _, _, taskEngine, _, _, _ := mocks(t, ctx, &defaultConfig)
+	defer ctrl.Finish()
+	testTask := &apitask.Task{
+		Arn: "arn:aws:ecs:region:account-id:task/test-task-arn",
+		Containers: []*apicontainer.Container{
+			{
+				Name:      "test-container",
+				RuntimeID: "runtime-ID",
+			},
+		},
+		ExecCommandAgentEnabled: false,
+	}
+	taskEngine.(*DockerTaskEngine).state.AddTask(testTask)
+	taskEngine.(*DockerTaskEngine).managedTasks[testTask.Arn] = &managedTask{Task: testTask}
+	taskEngine.(*DockerTaskEngine).monitorExecAgentProcesses(ctx)
+	// absence of top container expect call indicates it shouldn't have been called
+	time.Sleep(10 * time.Millisecond)
+}
+func TestMonitorExecAgentsMultipleContainers(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	ctrl, client, _, taskEngine, _, _, _ := mocks(t, ctx, &defaultConfig)
+	defer ctrl.Finish()
+	execAgentPID1 := "1234"
+	execAgentPID2 := "2345"
+	resp := &dockercontainer.ContainerTopOKBody{
+		Processes: [][]string{{"root", execAgentPID1}},
+	}
+	testTask := &apitask.Task{
+		Arn: "arn:aws:ecs:region:account-id:task/test-task-arn",
+		Containers: []*apicontainer.Container{
+			{
+				Name:      "test-container1",
+				RuntimeID: "runtime-ID1",
+				ExecCommandAgentMetadata: &apicontainer.ExecCommandAgentMetadata{
+					PID: execAgentPID1,
+				},
+			},
+			{
+				Name:      "test-container2",
+				RuntimeID: "runtime-ID2",
+				ExecCommandAgentMetadata: &apicontainer.ExecCommandAgentMetadata{
+					PID: execAgentPID2,
+				},
+			},
+		},
+		ExecCommandAgentEnabled: true,
+	}
+	taskEngine.(*DockerTaskEngine).state.AddTask(testTask)
+	taskEngine.(*DockerTaskEngine).managedTasks[testTask.Arn] = &managedTask{Task: testTask}
+	topCtx, topCancel := context.WithTimeout(context.Background(), time.Second)
+	defer topCancel()
+	client.EXPECT().TopContainer(gomock.Any(), testTask.Containers[0].RuntimeID, 30*time.Second, execAgentPID1).Return(resp, nil)
+	client.EXPECT().TopContainer(gomock.Any(), testTask.Containers[1].RuntimeID, 30*time.Second, execAgentPID2).DoAndReturn(
+		func(ctx context.Context, containerID string, timeout time.Duration, psArgs ...string) (*dockercontainer.ContainerTopOKBody, error) {
+			defer topCancel()
+			return nil, errors.New(dockerapi.TopProcessNotFoundErrorName)
+		})
+	taskEngine.(*DockerTaskEngine).monitorExecAgentProcesses(ctx)
+	<-topCtx.Done()
+	time.Sleep(5 * time.Millisecond)
+	assert.Equal(t, execAgentPID1, testTask.Containers[0].GetExecCommandAgentMetadata().PID)
+	assert.Equal(t, "", testTask.Containers[1].GetExecCommandAgentMetadata().PID)
+}
+
+func TestPeriodicExecAgentsMonitoring(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	ctrl, client, _, taskEngine, _, _, _ := mocks(t, ctx, &defaultConfig)
+	defer ctrl.Finish()
+	execAgentPID := "1234"
+	resp := &dockercontainer.ContainerTopOKBody{
+		Processes: [][]string{{"root", execAgentPID}},
+	}
+	testTask := &apitask.Task{
+		Arn: "arn:aws:ecs:region:account-id:task/test-task-arn",
+		Containers: []*apicontainer.Container{
+			{
+				Name:      "test-container",
+				RuntimeID: "runtime-ID",
+				ExecCommandAgentMetadata: &apicontainer.ExecCommandAgentMetadata{
+					PID: execAgentPID,
+				},
+			},
+		},
+		ExecCommandAgentEnabled: true,
+	}
+	taskEngine.(*DockerTaskEngine).state.AddTask(testTask)
+	taskEngine.(*DockerTaskEngine).managedTasks[testTask.Arn] = &managedTask{Task: testTask}
+	topCtx, topCancel := context.WithTimeout(context.Background(), time.Second)
+	defer topCancel()
+	client.EXPECT().TopContainer(gomock.Any(), testTask.Containers[0].RuntimeID, 30*time.Second, execAgentPID).DoAndReturn(
+		func(ctx context.Context, containerID string, timeout time.Duration, psArgs ...string) (*dockercontainer.ContainerTopOKBody, error) {
+			defer topCancel()
+			return resp, nil
+		}).AnyTimes()
+	go taskEngine.(*DockerTaskEngine).startPeriodicExecAgentsMonitoring(ctx, 2*time.Millisecond)
+	<-topCtx.Done()
+	time.Sleep(5 * time.Millisecond)
+	assert.Equal(t, execAgentPID, testTask.Containers[0].GetExecCommandAgentMetadata().PID)
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Periodic monitoring of ExecAgent Processes for Exec-enabled tasks

### Implementation details
Monitoring of the processes at an interval of 15 minutes. 
Uses docker top of the ExecAgent process ID to check if the process is still running in the container. 
Couple of `TODO`s:
- Trigger the workflow for restarting ExecAgent if its not running 
- Add jitter between different containers' top API calls to avoid stressing Docker 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

### Description for the changelog
N/A

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
