### PR TITLE
Add logic in WriteJSONToResponse to log errors in ECS agent log

### DIFF
--- a/agent/handlers/utils/helpers.go
+++ b/agent/handlers/utils/helpers.go
@@ -80,6 +80,10 @@ func WriteJSONToResponse(w http.ResponseWriter, httpStatusCode int, responseJSON
 			"Unable to write %s json response message to ResponseWriter",
 			requestType)
 	}
+
+	if httpStatusCode >= 400 && httpStatusCode <= 599 {
+		seelog.Errorf("HTTP response status code is '%d', request type is: %s, and response in JSON is %s", httpStatusCode, requestType, string(responseJSON))
+	}
 }
 
 // WriteResponseIfMarshalError checks the 'err' response of the json.Marshal function.


### PR DESCRIPTION
### Summary
This PR adds logic to propagate responses of requests to the Amazon ECS Container Agent Log when an error occurs.

### Implementation details
This PR includes the following change in agent/handlers/utils/helpers.go:  
- Added logic in `WriteJSONToResponse` function to propagate HTTP response status codes, request types and responses in JSON to the Amazon ECS Container Agent Log when the response status code is 4xx client error or 5xx server error.

### Testing

- Manually tested the changes with following Task Metadata Endpoint (TMDE) version 3 and 4 paths, and get returned JSON responses.

1. ${ECS_CONTAINER_METADATA_URI}
2. ${ECS_CONTAINER_METADATA_URI}/task
3. ${ECS_CONTAINER_METADATA_URI}/stats
4. ${ECS_CONTAINER_METADATA_URI}/task/stats
    
- Manually tested the changes when HTTP response status code 500 occurs, and verified the HTTP response status code, the request type and responses are successfully propagated to Amazon ECS Container Agent Log.
 
- This change is not covered by new tests

### Description for the changelog
Improvement - Propagate responses to the Amazon ECS Container Agent Log when an error occurs

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
