### PR TITLE
Fix response codes for container metadata and task metadata requests

### DIFF
--- a/agent/handlers/v3/container_metadata_handler.go
+++ b/agent/handlers/v3/container_metadata_handler.go
@@ -39,7 +39,7 @@ func ContainerMetadataHandler(state dockerstate.TaskEngineState) func(http.Respo
 			if e := utils.WriteResponseIfMarshalError(w, err); e != nil {
 				return
 			}
-			utils.WriteJSONToResponse(w, http.StatusBadRequest, responseJSON, utils.RequestTypeContainerMetadata)
+			utils.WriteJSONToResponse(w, http.StatusInternalServerError, responseJSON, utils.RequestTypeContainerMetadata)
 			return
 		}
 		containerResponse, err := GetContainerResponse(containerID, state)
@@ -48,7 +48,7 @@ func ContainerMetadataHandler(state dockerstate.TaskEngineState) func(http.Respo
 			if e := utils.WriteResponseIfMarshalError(w, err); e != nil {
 				return
 			}
-			utils.WriteJSONToResponse(w, http.StatusBadRequest, errResponseJSON, utils.RequestTypeContainerMetadata)
+			utils.WriteJSONToResponse(w, http.StatusInternalServerError, errResponseJSON, utils.RequestTypeContainerMetadata)
 			return
 		}
 		seelog.Infof("V3 container metadata handler: writing response for container '%s'", containerID)
@@ -65,6 +65,7 @@ func ContainerMetadataHandler(state dockerstate.TaskEngineState) func(http.Respo
 func GetContainerResponse(containerID string, state dockerstate.TaskEngineState) (*v2.ContainerResponse, error) {
 	containerResponse, err := v2.NewContainerResponse(containerID, state)
 	if err != nil {
+		seelog.Errorf("Unable to get container metadata for container '%s'", containerID)
 		return nil, errors.Errorf("Unable to generate metadata for container '%s'", containerID)
 	}
 	// fill in network details if not set
@@ -86,6 +87,7 @@ func GetContainerNetworkMetadata(containerID string, state dockerstate.TaskEngin
 	// https://github.com/aws/amazon-ecs-agent/blob/0c8913ba33965cf6ffdd6253fad422458d9346bd/agent/containermetadata/parse_metadata.go#L123
 	settings := dockerContainer.Container.GetNetworkSettings()
 	if settings == nil {
+		seelog.Errorf("unable to get container network response for container '%s'", containerID)
 		return nil, errors.Errorf("Unable to generate network response for container '%s'", containerID)
 	}
 	// This metadata is the information provided in older versions of the API

--- a/agent/handlers/v3/task_metadata_handler.go
+++ b/agent/handlers/v3/task_metadata_handler.go
@@ -45,7 +45,7 @@ func TaskMetadataHandler(state dockerstate.TaskEngineState, ecsClient api.ECSCli
 			if e := utils.WriteResponseIfMarshalError(w, err); e != nil {
 				return
 			}
-			utils.WriteJSONToResponse(w, http.StatusBadRequest, responseJSON, utils.RequestTypeTaskMetadata)
+			utils.WriteJSONToResponse(w, http.StatusInternalServerError, responseJSON, utils.RequestTypeTaskMetadata)
 			return
 		}
 
@@ -57,7 +57,7 @@ func TaskMetadataHandler(state dockerstate.TaskEngineState, ecsClient api.ECSCli
 			if e := utils.WriteResponseIfMarshalError(w, err); e != nil {
 				return
 			}
-			utils.WriteJSONToResponse(w, http.StatusBadRequest, errResponseJSON, utils.RequestTypeTaskMetadata)
+			utils.WriteJSONToResponse(w, http.StatusInternalServerError, errResponseJSON, utils.RequestTypeTaskMetadata)
 			return
 		}
 
@@ -72,7 +72,7 @@ func TaskMetadataHandler(state dockerstate.TaskEngineState, ecsClient api.ECSCli
 					if e := utils.WriteResponseIfMarshalError(w, err); e != nil {
 						return
 					}
-					utils.WriteJSONToResponse(w, http.StatusBadRequest, errResponseJSON, utils.RequestTypeContainerMetadata)
+					utils.WriteJSONToResponse(w, http.StatusInternalServerError, errResponseJSON, utils.RequestTypeContainerMetadata)
 					return
 				}
 				containerResponse.Networks = networks

--- a/agent/handlers/v4/container_metadata_handler.go
+++ b/agent/handlers/v4/container_metadata_handler.go
@@ -39,7 +39,7 @@ func ContainerMetadataHandler(state dockerstate.TaskEngineState) func(http.Respo
 			if e := utils.WriteResponseIfMarshalError(w, err); e != nil {
 				return
 			}
-			utils.WriteJSONToResponse(w, http.StatusBadRequest, responseJSON, utils.RequestTypeContainerMetadata)
+			utils.WriteJSONToResponse(w, http.StatusInternalServerError, responseJSON, utils.RequestTypeContainerMetadata)
 			return
 		}
 		containerResponse, err := GetContainerResponse(containerID, state)
@@ -48,7 +48,7 @@ func ContainerMetadataHandler(state dockerstate.TaskEngineState) func(http.Respo
 			if e := utils.WriteResponseIfMarshalError(w, err); e != nil {
 				return
 			}
-			utils.WriteJSONToResponse(w, http.StatusBadRequest, errResponseJSON, utils.RequestTypeContainerMetadata)
+			utils.WriteJSONToResponse(w, http.StatusInternalServerError, errResponseJSON, utils.RequestTypeContainerMetadata)
 			return
 		}
 		seelog.Infof("V4 container metadata handler: writing response for container '%s'", containerID)
@@ -65,6 +65,7 @@ func ContainerMetadataHandler(state dockerstate.TaskEngineState) func(http.Respo
 func GetContainerResponse(containerID string, state dockerstate.TaskEngineState) (*ContainerResponse, error) {
 	containerResponse, err := NewContainerResponse(containerID, state)
 	if err != nil {
+		seelog.Errorf("Unable to get container metadata for container '%s'", containerID)
 		return nil, errors.Errorf("unable to generate metadata for container '%s'", containerID)
 	}
 
@@ -87,6 +88,7 @@ func GetContainerNetworkMetadata(containerID string, state dockerstate.TaskEngin
 	// https://github.com/aws/amazon-ecs-agent/blob/0c8913ba33965cf6ffdd6253fad422458d9346bd/agent/containermetadata/parse_metadata.go#L123
 	settings := dockerContainer.Container.GetNetworkSettings()
 	if settings == nil {
+		seelog.Errorf("Unable to get container network response for container '%s'", containerID)
 		return nil, errors.Errorf("unable to generate network response for container '%s'", containerID)
 	}
 	// This metadata is the information provided in older versions of the API

--- a/agent/handlers/v4/task_metadata_handler.go
+++ b/agent/handlers/v4/task_metadata_handler.go
@@ -41,7 +41,7 @@ func TaskMetadataHandler(state dockerstate.TaskEngineState, ecsClient api.ECSCli
 			if e := utils.WriteResponseIfMarshalError(w, err); e != nil {
 				return
 			}
-			utils.WriteJSONToResponse(w, http.StatusBadRequest, ResponseJSON, utils.RequestTypeTaskMetadata)
+			utils.WriteJSONToResponse(w, http.StatusInternalServerError, ResponseJSON, utils.RequestTypeTaskMetadata)
 			return
 		}
 
@@ -53,7 +53,7 @@ func TaskMetadataHandler(state dockerstate.TaskEngineState, ecsClient api.ECSCli
 			if e := utils.WriteResponseIfMarshalError(w, err); e != nil {
 				return
 			}
-			utils.WriteJSONToResponse(w, http.StatusBadRequest, errResponseJson, utils.RequestTypeTaskMetadata)
+			utils.WriteJSONToResponse(w, http.StatusInternalServerError, errResponseJson, utils.RequestTypeTaskMetadata)
 			return
 		}
 
@@ -69,7 +69,7 @@ func TaskMetadataHandler(state dockerstate.TaskEngineState, ecsClient api.ECSCli
 					if e := utils.WriteResponseIfMarshalError(w, err); e != nil {
 						return
 					}
-					utils.WriteJSONToResponse(w, http.StatusBadRequest, errResponseJSON, utils.RequestTypeContainerMetadata)
+					utils.WriteJSONToResponse(w, http.StatusInternalServerError, errResponseJSON, utils.RequestTypeContainerMetadata)
 					return
 				}
 				containerResponse.Networks = networks


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Fix response codes for container metadata and task metadata requests in v3 and v4.
For example: If container's network metadata is unavailable, we should return 5xx instead of 400(Bad Request) response code

### Implementation details
<!-- How are the changes implemented? -->
This PR includes following changes to ` agent/handlers`
- ~~In `/utils`- added errors.go to have a Transient error type~~
- In `/v3` and `/v4` - added logging and fixed response code for container and task metadatahandler request

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Manually tested the changes to see if we are 500 response code is returned when container network settings is nil by commenting out https://github.com/aws/amazon-ecs-agent/blob/953af906b5de51f25d4f366bcfb238ae277a7133/agent/engine/docker_task_engine.go#L414.

New tests cover the changes: <!-- yes|no -->no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Bug - Fix response code when container network metadata is unavailable in TMDE
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.