### PR TITLE
Explicitly initialize seelog

### DIFF
--- a/agent/logger/log.go
+++ b/agent/logger/log.go
@@ -181,7 +181,9 @@ func init() {
 		MaxFileSizeMB: DEFAULT_MAX_FILE_SIZE,
 		MaxRollCount:  DEFAULT_MAX_ROLL_COUNT,
 	}
+}
 
+func InitSeelog() {
 	if err := seelog.RegisterCustomFormatter("EcsAgentLogfmt", logfmtFormatter); err != nil {
 		seelog.Error(err)
 	}

--- a/agent/logger/log_init_test.go
+++ b/agent/logger/log_init_test.go
@@ -1,3 +1,5 @@
+// +build unit integration
+
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
@@ -11,22 +13,11 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package main
-
-import (
-	"math/rand"
-	"os"
-	"time"
-
-	"github.com/aws/amazon-ecs-agent/agent/app"
-	"github.com/aws/amazon-ecs-agent/agent/logger"
-)
+package logger
 
 func init() {
-	rand.Seed(time.Now().UnixNano())
-}
-
-func main() {
-	logger.InitSeelog()
-	os.Exit(app.Run(os.Args[1:]))
+	// We don't want to call InitSeelog automatically (e.g. calling it from init())
+	// because some internal clients use ECS Agent as a library.
+	// However we want to call InitSeelog automatically from all tests.
+	InitSeelog()
 }


### PR DESCRIPTION
# Summary
<!-- What does this pull request do? -->

The logger package's initialization logic is init() which will be
exected by loading the package.

However some of our programs are using the agent as a library and
haven't configured seelog beforehand. Due to that, loading the package
logs

```
1600397429848419666 [Error] node must have children
```
which breaks the programs.

I think it would be safer to do less on init() and explictly
initialize the logger from the agent's main().

### Implementation details
<!-- How are the changes implemented? -->

Renamed logger.init() to logger.Init() and called the renamed/exported function from the agent's main().

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
