### PR TITLE
Add ManagedAgent To container state change event

### DIFF
--- a/agent/api/container/status/managedagentstatus.go
+++ b/agent/api/container/status/managedagentstatus.go
@@ -1,0 +1,109 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package status
+
+import (
+	"errors"
+	"strings"
+)
+
+const (
+	// ManagedAgentStatusNone is the zero state of a managed agent
+	ManagedAgentStatusNone ManagedAgentStatus = iota
+	// ManagedAgentCreated represents a managed agent which has dependencies in place
+	ManagedAgentCreated
+	// ManagedAgentRunning represents a managed agent that has started sucessfully
+	ManagedAgentRunning
+	// ManagedAgentStopped represents a managed agent that has stopped
+	ManagedAgentStopped
+)
+
+// ManagedAgentStatus is an enumeration of valid states in the managed agent lifecycle
+type ManagedAgentStatus int32
+
+var managedAgentStatusMap = map[string]ManagedAgentStatus{
+	"NONE":    ManagedAgentStatusNone,
+	"CREATED": ManagedAgentCreated,
+	"RUNNING": ManagedAgentRunning,
+	"STOPPED": ManagedAgentStopped,
+}
+
+// String returns a human readable string representation of this object
+func (mas ManagedAgentStatus) String() string {
+	for k, v := range managedAgentStatusMap {
+		if v == mas {
+			return k
+		}
+	}
+	return "NONE"
+}
+
+// Terminal returns true if the managed agent status is STOPPED
+func (mas ManagedAgentStatus) Terminal() bool {
+	return mas == ManagedAgentStopped
+}
+
+// IsRunning returns true if the managed agent status is either RUNNING
+func (mas ManagedAgentStatus) IsRunning() bool {
+	return mas == ManagedAgentRunning
+}
+
+// BackendStatus maps the internal managedAgent status in the agent to that in the backend
+// This exists to force the status to be one of PENDING|RUNNING}|STOPPED
+func (mas ManagedAgentStatus) BackendStatus() string {
+	switch mas {
+	case ManagedAgentRunning:
+		return mas.String()
+	case ManagedAgentStopped:
+		return mas.String()
+	}
+	return "PENDING"
+}
+
+// ShouldReportToBackend returns true if the managedAgent status is recognized as a
+// valid state by ECS. Note that not all managedAgent statuses are recognized by ECS
+// or map to ECS states
+// For now we expect PENDING/RUNNING/STOPPED as valid states
+// we should only skip events that have ManagedAgentStatusNone
+func (mas ManagedAgentStatus) ShouldReportToBackend() bool {
+	return mas == ManagedAgentCreated || mas == ManagedAgentRunning || mas == ManagedAgentStopped
+}
+
+// UnmarshalJSON overrides the logic for parsing the JSON-encoded ManagedAgentStatus data
+func (mas *ManagedAgentStatus) UnmarshalJSON(b []byte) error {
+	if strings.ToLower(string(b)) == "null" {
+		*mas = ManagedAgentStatusNone
+		return nil
+	}
+	if b[0] != '"' || b[len(b)-1] != '"' {
+		*mas = ManagedAgentStatusNone
+		return errors.New("managed agent status unmarshal: status must be a string or null; Got " + string(b))
+	}
+
+	stat, ok := managedAgentStatusMap[string(b[1:len(b)-1])]
+	if !ok {
+		*mas = ManagedAgentStatusNone
+		return errors.New("managed agent status unmarshal: unrecognized status")
+	}
+	*mas = stat
+	return nil
+}
+
+// MarshalJSON overrides the logic for JSON-encoding the ManagedAgentStatus type
+func (mas *ManagedAgentStatus) MarshalJSON() ([]byte, error) {
+	if mas == nil {
+		return nil, nil
+	}
+	return []byte(`"` + mas.String() + `"`), nil
+}

--- a/agent/api/container/status/managedagentstatus_test.go
+++ b/agent/api/container/status/managedagentstatus_test.go
@@ -1,0 +1,95 @@
+// +build unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package status
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTerminal(t *testing.T) {
+	terminalStatus := ManagedAgentStopped
+	runningStatus := ManagedAgentRunning
+	assert.True(t, terminalStatus.Terminal())
+	assert.False(t, runningStatus.Terminal())
+}
+
+func TestIsRunning(t *testing.T) {
+	terminalStatus := ManagedAgentStopped
+	runningStatus := ManagedAgentRunning
+	assert.True(t, runningStatus.IsRunning())
+	assert.False(t, terminalStatus.IsRunning())
+}
+
+func TestShouldReportManagedAgentStatusToBackend(t *testing.T) {
+	// We should not report ManagedAgentStatusNone
+	var managedAgentStatus ManagedAgentStatus
+	assert.Equal(t, false, managedAgentStatus.ShouldReportToBackend())
+	// We should report ManagedAgentCreated (ie PENDING)
+	managedAgentStatus = ManagedAgentCreated
+	assert.Equal(t, true, managedAgentStatus.ShouldReportToBackend())
+	// We should report ManagedAgentRunning (ie RUNNING)
+	managedAgentStatus = ManagedAgentRunning
+	assert.Equal(t, true, managedAgentStatus.ShouldReportToBackend())
+	// We should report ManagedAgentStooped (ie STOPPED)
+	managedAgentStatus = ManagedAgentStopped
+	assert.Equal(t, true, managedAgentStatus.ShouldReportToBackend())
+}
+
+func TestManagedAgentBackendStatus(t *testing.T) {
+	// BackendStatus is "PENDING" when managedAgent status is ManagedAgentStatusNone
+	var managedAgentStatus ManagedAgentStatus
+	assert.Equal(t, "PENDING", managedAgentStatus.BackendStatus())
+
+	managedAgentStatus = ManagedAgentCreated
+	// BackendStatus is "PENDING" when managedAgent status is ManagedAgentCreated
+	assert.Equal(t, "PENDING", managedAgentStatus.BackendStatus())
+
+	managedAgentStatus = ManagedAgentRunning
+	// BackendStatus is "RUNNING" when managedAgent status is ManagedAgentRunning
+	assert.Equal(t, "RUNNING", managedAgentStatus.BackendStatus())
+
+	// BackendStatus is "STOPPED" when managedAgent status is ManagedAgentStopped
+	managedAgentStatus = ManagedAgentStopped
+	assert.Equal(t, "STOPPED", managedAgentStatus.BackendStatus())
+}
+
+type testManagedAgentStatus struct {
+	SomeStatus ManagedAgentStatus `json:"status"`
+}
+
+func TestUnmarshalManagedAgentStatus(t *testing.T) {
+	status := ManagedAgentStatusNone
+
+	err := json.Unmarshal([]byte(`"RUNNING"`), &status)
+	if err != nil {
+		t.Error(err)
+	}
+	if status != ManagedAgentRunning {
+		t.Error("RUNNING should unmarshal to RUNNING, not " + status.String())
+	}
+
+	var test testManagedAgentStatus
+	err = json.Unmarshal([]byte(`{"status":"STOPPED"}`), &test)
+	if err != nil {
+		t.Error(err)
+	}
+	if test.SomeStatus != ManagedAgentStopped {
+		t.Error("STOPPED should unmarshal to STOPPED, not " + test.SomeStatus.String())
+	}
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This adds the ManagedAgent to the container state change events that we emit. 
Currently we only have a single ManagedAgent -- the ExecuteCommandAgent.  I've hard coded this in a few places.
The acceptable statuses for a ManagedAgent are `PENDING|RUNNING|STOPPED`, but we have a few extra statuses that we can track inside the agent -- namely `CREATED` (which should mark the time between the bind-mount and the ExecuteCommandAgent process actually starting) and `NONE` for the empty status.  
I've tried to follow existing patterns as closely as possible. 

### Implementation details
I've added the `ManagedAgentStatus` struct with an enum of acceptable statuses.
This is cooked into the `ManagedAgent` struct.
I've built and updated the backend api model based on latest changes in dev.
the `GetKnownManagedAgents()` function will create an array of 0 or 1 ManagedAgents to be passed in the container state change events.
Next step will be to wire this in via the `emitContainerEvent()` function in the task_manager

### Testing
<!-- How was this tested? -->
I added unit tests to test functions up through `GetKnownManagedAgents()` function.  Ran all unit/integ tests locally and they passed.

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Add ManagedAgent to container state change event.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
