### PR TITLE
Update go version to 1.15 in travis.yml, github actions, dockerfiles

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v2
       with:
-        go-version: 1.12
+        go-version: 1.15
     - uses: actions/checkout@v2
       with:
         path: src/github.com/aws/amazon-ecs-agent
@@ -28,7 +28,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v2
       with:
-        go-version: 1.12
+        go-version: 1.15
     - uses: actions/checkout@v2
       with:
         submodules: true
@@ -46,7 +46,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v2
       with:
-        go-version: 1.12
+        go-version: 1.15
     - uses: actions/checkout@v2
       with:
         submodules: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
 language: go
 go_import_path: github.com/aws/amazon-ecs-agent
 sudo: false
-go:
-  - 1.12
 
 matrix:
   include:
     - os: linux
+      go: 1.15
       script:
         - make test
         - make analyze-cover-profile
     - os: windows
+      go: 1.12
       script:
         - go test -v -race -tags unit -coverprofile cover.out -timeout 40s ./agent/...

--- a/agent/api/task/util_test.go
+++ b/agent/api/task/util_test.go
@@ -16,13 +16,14 @@
 package task
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 )
 
 func taskN(n int) *Task {
 	return &Task{
-		Arn: string(n),
+		Arn: fmt.Sprint(n),
 	}
 }
 

--- a/misc/fluent-logger/Dockerfile
+++ b/misc/fluent-logger/Dockerfile
@@ -10,7 +10,7 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-FROM golang:1.12
+FROM golang:1.15
 
 MAINTAINER Amazon Web Services, Inc.
 COPY fluent-logger /

--- a/misc/gremlin/Makefile
+++ b/misc/gremlin/Makefile
@@ -15,7 +15,7 @@
 all: gremlin image
 
 gremlin: gremlin.go
-	docker run -v $(shell pwd):/out -v $(shell pwd)/gremlin.go:/in/gremlin.go -e CGO_ENABLED=0 golang:1.12 go build -a -x -ldflags '-s' -o /out/gremlin /in/gremlin.go
+	docker run -v $(shell pwd):/out -v $(shell pwd)/gremlin.go:/in/gremlin.go -e CGO_ENABLED=0 golang:1.15 go build -a -x -ldflags '-s' -o /out/gremlin /in/gremlin.go
 
 image: gremlin
 	@./docker-image

--- a/misc/netkitten/Makefile
+++ b/misc/netkitten/Makefile
@@ -15,7 +15,7 @@
 all: netkitten image
 
 netkitten:
-	docker run -v $(shell pwd):/out -v $(shell pwd)/netkitten.go:/in/netkitten.go -e CGO_ENABLED=0 golang:1.12 go build -a -installsuffix cgo -ldflags '-s' -o /out/netkitten /in/netkitten.go
+	docker run -v $(shell pwd):/out -v $(shell pwd)/netkitten.go:/in/netkitten.go -e CGO_ENABLED=0 golang:1.15 go build -a -installsuffix cgo -ldflags '-s' -o /out/netkitten /in/netkitten.go
 
 image: netkitten
 	@./docker-image

--- a/scripts/dockerfiles/Dockerfile.buildECSCNIPlugins
+++ b/scripts/dockerfiles/Dockerfile.buildECSCNIPlugins
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-FROM golang:1.12
+FROM golang:1.15
 MAINTAINER Amazon Web Services, Inc.
 
 ENV XDG_CACHE_HOME /tmp

--- a/scripts/dockerfiles/Dockerfile.cleanbuild
+++ b/scripts/dockerfiles/Dockerfile.cleanbuild
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-FROM golang:1.12
+FROM golang:1.15
 MAINTAINER Amazon Web Services, Inc.
 
 ENV XDG_CACHE_HOME /tmp

--- a/scripts/dockerfiles/Dockerfile.test
+++ b/scripts/dockerfiles/Dockerfile.test
@@ -32,7 +32,7 @@ RUN apt-get update && apt-get install -y \
 		--no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*
 
-ENV GOLANG_VERSION 1.12.4
+ENV GOLANG_VERSION 1.15
 ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
 ENV GOLANG_DOWNLOAD_SHA256 d7d1f1f88ddfe55840712dc1747f37a790cbcaa448f6c9cf51bbe10aa65442f5
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Update travis.yml, github actions, dockerfiles to use Go 1.15 for Linux platforms and Go 1.12 for Windows platforms.

Note: Currently integration tests are failing on Windows and once the issue is resolved Agent will be updated to use Go 1.15 for Windows too.

### Implementation details
<!-- How are the changes implemented? -->
Following files are updated:
- .github/workflows/build.yml
- .travis.yml
- agent/api/task/util_test.go
- misc/fluent-logger/Dockerfile
- misc/gremlin/Makefile
- misc/netkitten/Makefile
- scripts/dockerfiles/Dockerfile.buildECSCNIPlugins
- scripts/dockerfiles/Dockerfile.cleanbuild
- scripts/dockerfiles/Dockerfile.test

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enhancement - Use Go 1.15

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
