### PR TITLE
Updating Makefile after the switch to using Go Modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,26 +118,23 @@ ifneq (${BUILD_PLATFORM},aarch64)
 endif
 
 test:
-	${GOTEST} -tags unit -coverprofile cover.out -timeout=60s ./agent/...
-	go tool cover -func cover.out > coverprofile.out
+	@cd agent && $(MAKE) test
 
 test-silent:
-	$(eval VERBOSE=)
-	${GOTEST} -tags unit -coverprofile cover.out -timeout=60s ./agent/...
-	go tool cover -func cover.out > coverprofile.out
+	@cd agent && $(MAKE) test-silent
 
 .PHONY: analyze-cover-profile
-analyze-cover-profile: coverprofile.out
+analyze-cover-profile: ./agent/coverprofile.out
 	./scripts/analyze-cover-profile
 
 run-integ-tests: test-registry gremlin container-health-check-image run-sudo-tests
-	ECS_LOGLEVEL=debug ${GOTEST} -tags integration -timeout=30m ./agent/...
+	@cd agent && ECS_LOGLEVEL=debug GO111MODULE=on ${GOTEST} -tags integration -timeout=30m ./...
 
 run-sudo-tests:
-	sudo -E ${GOTEST} -tags sudo -timeout=10m ./agent/...
+	@cd agent && sudo -E GO111MODULE=on ${GOTEST} -tags sudo -timeout=10m ./...
 
 benchmark-test:
-	go test -run=XX -bench=. ./agent/...
+	@cd agent && $(MAKE) benchmark-test
 
 
 .PHONY: build-image-for-ecr upload-images replicate-images
@@ -316,6 +313,6 @@ clean:
 	-rm -f .builder-image-stamp
 	-rm -f .out-stamp
 	-rm -rf $(PWD)/bin
-	-rm -rf cover.out
-	-rm -rf coverprofile.out
+	-rm -rf ./agent/cover.out
+	-rm -rf ./agent/coverprofile.out
 

--- a/agent/Makefile
+++ b/agent/Makefile
@@ -1,3 +1,11 @@
+BUILD_PLATFORM:=$(shell uname -m)
+
+ifeq (${BUILD_PLATFORM},aarch64)
+	GOARCH=arm64
+else
+	GOARCH=amd64
+endif
+
 .PHONY: gomodule-on
 gomodule-on:
 	GO111MODULE=on
@@ -50,3 +58,35 @@ static-check: gomodule-on gocyclo govet importcheck gogenerate-check
 	# depracation checks have been left out for now; removing their warnings requires error handling for newer suggested APIs, changes in function signatures and their usages.
 	# https://github.com/dominikh/go-tools/tree/master/cmd/staticcheck
 	staticcheck -tests=false -checks "inherit,-ST*,-SA1019" ./...
+
+# 'go' may not be on the $PATH for sudo tests
+GO_EXECUTABLE=$(shell command -v go 2> /dev/null)
+
+# VERBOSE includes the options that make the test opt loud
+VERBOSE=-v -cover
+
+# -count=1 runs the test without using the build cache.  The build cache can
+# provide false positives when running integ tests, so we err on the side of
+# caution. See `go help test`
+# unit tests include the coverage profile
+GOTEST=${GO_EXECUTABLE} test -count=1 ${VERBOSE}
+
+# -race sometimes causes compile issues on Arm
+ifneq (${BUILD_PLATFORM},aarch64)
+	GOTEST += -race
+endif
+
+.PHONY: test
+test: gomodule-on
+	${GOTEST} -tags unit -coverprofile cover.out -timeout=60s ./...
+	go tool cover -func cover.out > coverprofile.out
+
+.PHONY: test-silent
+test-silent: gomodule-on
+	$(eval VERBOSE=)
+	${GOTEST} -tags unit -coverprofile cover.out -timeout=60s ./...
+	go tool cover -func cover.out > coverprofile.out
+
+.PHONY: benchmark-test
+benchmark-test: gomodule-on
+	go test -run=XX -bench=. ./...

--- a/scripts/analyze-cover-profile
+++ b/scripts/analyze-cover-profile
@@ -15,7 +15,7 @@ MINIMUM_TEST_COVERAGE = 73.8
 # github.com/aws/amazon-ecs-agent/agent/wsclient/types.go:57:						GetRecognizedTypes				100.0%
 # total:													(statements)					73.8%
 
-with open("coverprofile.out") as f:
+with open("./agent/coverprofile.out") as f:
     for line in f:
         if line.startswith("total:"):
             splitline = line.split()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Updating Makefile after the switch to using Go Modules
### Implementation details
<!-- How are the changes implemented? -->
Updated the following targets in makefile
- `test`
- `test-silent`
- `analyze-cover-profile`
- `run-integ-tests`
-  `run-sudo-tests`
- `benchmark-test`

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Tested these make targets locally 

New tests cover the changes: <!-- yes|no -->
### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
