### PR TITLE
Add and use new instancecreds package

### DIFF
--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/aws/amazon-ecs-agent/agent/credentials/instancecreds"
 	"github.com/aws/amazon-ecs-agent/agent/metrics"
 
 	acshandler "github.com/aws/amazon-ecs-agent/agent/acs/handler"
@@ -55,7 +56,6 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/version"
 	"github.com/aws/aws-sdk-go/aws"
 	aws_credentials "github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/defaults"
 	"github.com/cihub/seelog"
 	"github.com/pborman/uuid"
 )
@@ -185,7 +185,7 @@ func newAgent(blackholeEC2Metadata bool, acceptInsecureCert *bool) (agent, error
 		// We instantiate our own credentialProvider for use in acs/tcs. This tries
 		// to mimic roughly the way it's instantiated by the SDK for a default
 		// session.
-		credentialProvider:          defaults.CredChain(defaults.Config(), defaults.Handlers()),
+		credentialProvider:          instancecreds.GetCredentials(),
 		stateManagerFactory:         factory.NewStateManager(),
 		saveableOptionFactory:       factory.NewSaveableOption(),
 		pauseLoader:                 pause.New(),

--- a/agent/credentials/instancecreds/instancecreds.go
+++ b/agent/credentials/instancecreds/instancecreds.go
@@ -1,0 +1,47 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package instancecreds
+
+import (
+	"sync"
+
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/cihub/seelog"
+)
+
+var (
+	credentialChain *credentials.Credentials
+	mu              sync.RWMutex
+)
+
+func GetCredentials() *credentials.Credentials {
+	mu.Lock()
+	if credentialChain == nil {
+		credentialChain = credentials.NewCredentials(&credentials.ChainProvider{
+			VerboseErrors: false,
+			Providers:     defaults.CredProviders(defaults.Config(), defaults.Handlers()),
+		})
+	}
+	mu.Unlock()
+
+	// credentials.Credentials is concurrency-safe, so lock not needed here
+	v, err := credentialChain.Get()
+	if err != nil {
+		seelog.Errorf("Error getting ECS instance credentials from default chain: %s", err)
+	} else {
+		seelog.Infof("Successfully got ECS instance credentials from provider: %s", v.ProviderName)
+	}
+	return credentialChain
+}

--- a/agent/credentials/instancecreds/instancecreds_test.go
+++ b/agent/credentials/instancecreds/instancecreds_test.go
@@ -1,0 +1,91 @@
+// +build unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package instancecreds
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetCredentials(t *testing.T) {
+	credentialChain = nil
+	credsA := GetCredentials()
+	require.NotNil(t, credsA)
+	credsB := GetCredentials()
+	require.NotNil(t, credsB)
+	require.Equal(t, credsA, credsB)
+}
+
+// test that env vars override all other provider types
+func TestGetCredentials_EnvVars(t *testing.T) {
+	credentialChain = nil
+	// unset any env var credentials on system to run this test
+	origAKID := os.Getenv("AWS_ACCESS_KEY_ID")
+	origSecret := os.Getenv("AWS_SECRET_ACCESS_KEY")
+	os.Setenv("AWS_ACCESS_KEY_ID", "TESTKEYID")
+	os.Setenv("AWS_SECRET_ACCESS_KEY", "TESTSECRET")
+	// reset before exiting
+	defer os.Setenv("AWS_ACCESS_KEY_ID", origAKID)
+	defer os.Setenv("AWS_SECRET_ACCESS_KEY", origSecret)
+
+	creds := GetCredentials()
+	require.NotNil(t, creds)
+	v, err := creds.Get()
+	require.NoError(t, err)
+	require.Equal(t, "EnvProvider", v.ProviderName)
+	require.Equal(t, "TESTKEYID", v.AccessKeyID)
+	require.Equal(t, "TESTSECRET", v.SecretAccessKey)
+}
+
+// test that shared credentials file is used when set and env vars are unset
+func TestGetCredentials_SharedCredentialsFile(t *testing.T) {
+	credentialChain = nil
+	// unset any env var credentials to run this test
+	origAKID := os.Getenv("AWS_ACCESS_KEY_ID")
+	origSecret := os.Getenv("AWS_SECRET_ACCESS_KEY")
+	os.Unsetenv("AWS_ACCESS_KEY_ID")
+	os.Unsetenv("AWS_SECRET_ACCESS_KEY")
+	// reset before exiting test
+	defer os.Setenv("AWS_ACCESS_KEY_ID", origAKID)
+	defer os.Setenv("AWS_SECRET_ACCESS_KEY", origSecret)
+
+	// create tmp AWS_SHARED_CREDENTIALS_FILE and use that for this test
+	tmpFile, err := ioutil.TempFile(os.TempDir(), "credentials")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+	text := []byte(`[default]
+aws_access_key_id = TESTFILEKEYID
+aws_secret_access_key = TESTFILESECRET
+`)
+	_, err = tmpFile.Write(text)
+	require.NoError(t, err)
+	origEnv := os.Getenv("AWS_SHARED_CREDENTIALS_FILE")
+	os.Unsetenv("AWS_SHARED_CREDENTIALS_FILE")
+	os.Setenv("AWS_SHARED_CREDENTIALS_FILE", tmpFile.Name())
+	// reset before exiting
+	defer os.Setenv("AWS_SHARED_CREDENTIALS_FILE", origEnv)
+
+	creds := GetCredentials()
+	require.NotNil(t, creds)
+	v, err := creds.Get()
+	require.NoError(t, err)
+	require.Equal(t, "SharedCredentialsProvider", v.ProviderName)
+	require.Equal(t, "TESTFILEKEYID", v.AccessKeyID)
+	require.Equal(t, "TESTFILESECRET", v.SecretAccessKey)
+}

--- a/agent/ec2/ec2_client.go
+++ b/agent/ec2/ec2_client.go
@@ -16,6 +16,7 @@ package ec2
 import (
 	"strings"
 
+	"github.com/aws/amazon-ecs-agent/agent/credentials/instancecreds"
 	"github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -50,9 +51,10 @@ type ClientImpl struct {
 }
 
 func NewClientImpl(awsRegion string) Client {
-	var ec2Config aws.Config
+	ec2Config := aws.NewConfig().WithMaxRetries(clientRetriesNum)
 	ec2Config.Region = aws.String(awsRegion)
-	client := ec2sdk.New(session.New(&ec2Config), aws.NewConfig().WithMaxRetries(clientRetriesNum))
+	ec2Config.Credentials = instancecreds.GetCredentials()
+	client := ec2sdk.New(session.New(), ec2Config)
 	return &ClientImpl{
 		client: client,
 	}

--- a/agent/ec2/ec2_metadata_client.go
+++ b/agent/ec2/ec2_metadata_client.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aws/amazon-ecs-agent/agent/credentials/instancecreds"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -89,9 +90,10 @@ type ec2MetadataClientImpl struct {
 // NewEC2MetadataClient creates an ec2metadata client to retrieve metadata
 func NewEC2MetadataClient(client HttpClient) EC2MetadataClient {
 	if client == nil {
+		config := aws.NewConfig().WithMaxRetries(metadataRetries)
+		config.Credentials = instancecreds.GetCredentials()
 		return &ec2MetadataClientImpl{
-			client: ec2metadata.New(
-				session.New(), aws.NewConfig().WithMaxRetries(metadataRetries)),
+			client: ec2metadata.New(session.New(), config),
 		}
 	} else {
 		return &ec2MetadataClientImpl{client: client}

--- a/agent/ecr/factory.go
+++ b/agent/ecr/factory.go
@@ -21,6 +21,7 @@ import (
 
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	"github.com/aws/amazon-ecs-agent/agent/credentials"
+	"github.com/aws/amazon-ecs-agent/agent/credentials/instancecreds"
 	ecrapi "github.com/aws/amazon-ecs-agent/agent/ecr/model/ecr"
 	"github.com/aws/amazon-ecs-agent/agent/httpclient"
 	"github.com/aws/aws-sdk-go/aws"
@@ -73,6 +74,8 @@ func getClientConfig(httpClient *http.Client, authData *apicontainer.ECRAuthData
 			authData.GetPullCredentials().SecretAccessKey,
 			authData.GetPullCredentials().SessionToken)
 		cfg = cfg.WithCredentials(creds)
+	} else {
+		cfg = cfg.WithCredentials(instancecreds.GetCredentials())
 	}
 
 	return cfg, nil


### PR DESCRIPTION
This is to centralize grabbing our instance credential provider into a
single package. Previous to this change we grabbed instance credentials
in separate places for the ecs, ec2, ecr and ec2 metadata clients. With this
change, all of these clients will use the same instance credential
provider.

The reason for this is that if we want to add any non-default instance
credential providers to the credential chain, then we need to make sure
that all AWS clients are instantiated with the same provider.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
