### PR TITLE
Add rotating shared credentials provider

### DIFF
--- a/agent/credentials/instancecreds/instancecreds.go
+++ b/agent/credentials/instancecreds/instancecreds.go
@@ -16,6 +16,7 @@ package instancecreds
 import (
 	"sync"
 
+	"github.com/aws/amazon-ecs-agent/agent/credentials/providers"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/defaults"
 	"github.com/cihub/seelog"
@@ -23,15 +24,24 @@ import (
 
 var (
 	credentialChain *credentials.Credentials
-	mu              sync.RWMutex
+	mu              sync.Mutex
 )
 
+// GetCredentials returns the instance credentials chain. This is the default chain
+// credentials plus the "rotating shared credentials provider", so credentials will
+// be checked in this order:
+//    1. Env vars (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY).
+//    2. Shared credentials file (https://docs.aws.amazon.com/ses/latest/DeveloperGuide/create-shared-credentials-file.html) (file at ~/.aws/credentials containing access key id and secret access key).
+//    3. EC2 role credentials. This is an IAM role that the user specifies when they launch their EC2 container instance (ie ecsInstanceRole (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/instance_IAM_role.html)).
+//    4. Rotating shared credentials file located at /rotatingcreds/credentials
 func GetCredentials() *credentials.Credentials {
 	mu.Lock()
 	if credentialChain == nil {
+		credProviders := defaults.CredProviders(defaults.Config(), defaults.Handlers())
+		credProviders = append(credProviders, providers.NewRotatingSharedCredentialsProvider())
 		credentialChain = credentials.NewCredentials(&credentials.ChainProvider{
 			VerboseErrors: false,
-			Providers:     defaults.CredProviders(defaults.Config(), defaults.Handlers()),
+			Providers:     credProviders,
 		})
 	}
 	mu.Unlock()

--- a/agent/credentials/providers/rotating_shared_credentials_provider.go
+++ b/agent/credentials/providers/rotating_shared_credentials_provider.go
@@ -1,0 +1,75 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package providers
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/cihub/seelog"
+)
+
+const (
+	// defaultRotationInterval is how frequently to expire and re-retrieve the credentials from file.
+	defaultRotationInterval = time.Minute
+	// defaultFilename is the default location of the credentials file within the container.
+	defaultFilename = "/rotatingcreds/credentials"
+	// RotatingSharedCredentialsProviderName is the name of this provider
+	RotatingSharedCredentialsProviderName = "RotatingSharedCredentialsProvider"
+)
+
+// RotatingSharedCredentialsProvider is a provider that retrieves credentials via the
+// shared credentials provider, and adds the functionality of expiring and re-retrieving
+// those credentials from the file.
+type RotatingSharedCredentialsProvider struct {
+	credentials.Expiry
+
+	RotationInterval          time.Duration
+	sharedCredentialsProvider *credentials.SharedCredentialsProvider
+}
+
+// NewRotatingSharedCredentials returns a rotating shared credentials provider
+// with default values set.
+func NewRotatingSharedCredentialsProvider() *RotatingSharedCredentialsProvider {
+	return &RotatingSharedCredentialsProvider{
+		RotationInterval: defaultRotationInterval,
+		sharedCredentialsProvider: &credentials.SharedCredentialsProvider{
+			Filename: defaultFilename,
+			Profile:  "default",
+		},
+	}
+}
+
+// Retrieve will use the given filename and profile and retrieve AWS credentials.
+func (p *RotatingSharedCredentialsProvider) Retrieve() (credentials.Value, error) {
+	v, err := p.sharedCredentialsProvider.Retrieve()
+	v.ProviderName = RotatingSharedCredentialsProviderName
+	if err != nil {
+		return v, err
+	}
+	p.SetExpiration(time.Now().Add(p.RotationInterval), 0)
+	seelog.Infof("Successfully got instance credentials from file %s. %s",
+		p.sharedCredentialsProvider.Filename, credValueToString(v))
+	return v, err
+}
+
+func credValueToString(v credentials.Value) string {
+	akid := ""
+	// only print last 4 chars if it's less than half the full AKID
+	if len(v.AccessKeyID) > 8 {
+		akid = v.AccessKeyID[len(v.AccessKeyID)-4:]
+	}
+	return fmt.Sprintf("Provider: %s. Access Key ID XXXX%s", v.ProviderName, akid)
+}

--- a/agent/credentials/providers/rotating_shared_credentials_provider_test.go
+++ b/agent/credentials/providers/rotating_shared_credentials_provider_test.go
@@ -1,0 +1,197 @@
+// +build unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package providers
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRotatingSharedCredentialsProvider(t *testing.T) {
+	p := NewRotatingSharedCredentialsProvider()
+	require.Equal(t, time.Minute, p.RotationInterval)
+	require.Equal(t, "default", p.sharedCredentialsProvider.Profile)
+	require.Equal(t, "/rotatingcreds/credentials", p.sharedCredentialsProvider.Filename)
+}
+
+func TestRotatingSharedCredentialsProvider_RetrieveFail_BadPath(t *testing.T) {
+	p := NewRotatingSharedCredentialsProvider()
+	p.sharedCredentialsProvider.Filename = "/foo/bar/baz/bad/path"
+	v, err := p.Retrieve()
+	require.Error(t, err)
+	require.Equal(t, RotatingSharedCredentialsProviderName, v.ProviderName)
+}
+
+func TestRotatingSharedCredentialsProvider_RetrieveFail_BadProfile(t *testing.T) {
+	// create tmp credentials file and use that for this test
+	tmpFile, err := ioutil.TempFile(os.TempDir(), "credentials")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+	text := []byte(`[thisProfileDoesntExist]
+aws_access_key_id = TESTFILEKEYID
+aws_secret_access_key = TESTFILESECRET
+`)
+	_, err = tmpFile.Write(text)
+	require.NoError(t, err)
+
+	p := NewRotatingSharedCredentialsProvider()
+	p.sharedCredentialsProvider.Filename = tmpFile.Name()
+	v, err := p.Retrieve()
+	require.Error(t, err)
+	require.Equal(t, RotatingSharedCredentialsProviderName, v.ProviderName)
+}
+
+func TestRotatingSharedCredentialsProvider_Retrieve(t *testing.T) {
+	// create tmp credentials file and use that for this test
+	tmpFile, err := ioutil.TempFile(os.TempDir(), "credentials")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+	text := []byte(`[default]
+aws_access_key_id = TESTFILEKEYID
+aws_secret_access_key = TESTFILESECRET
+`)
+	_, err = tmpFile.Write(text)
+	require.NoError(t, err)
+
+	p := NewRotatingSharedCredentialsProvider()
+	p.sharedCredentialsProvider.Filename = tmpFile.Name()
+	v, err := p.Retrieve()
+	require.NoError(t, err)
+	require.Equal(t, RotatingSharedCredentialsProviderName, v.ProviderName)
+	require.Equal(t, "TESTFILEKEYID", v.AccessKeyID)
+	require.Equal(t, "TESTFILESECRET", v.SecretAccessKey)
+}
+
+func TestRotatingSharedCredentialsProvider_Retrieve_ShortSecrets(t *testing.T) {
+	// create tmp credentials file and use that for this test
+	tmpFile, err := ioutil.TempFile(os.TempDir(), "credentials")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+	text := []byte(`[default]
+aws_access_key_id = A
+aws_secret_access_key = B
+`)
+	_, err = tmpFile.Write(text)
+	require.NoError(t, err)
+
+	p := NewRotatingSharedCredentialsProvider()
+	p.sharedCredentialsProvider.Filename = tmpFile.Name()
+	v, err := p.Retrieve()
+	require.NoError(t, err)
+	require.Equal(t, RotatingSharedCredentialsProviderName, v.ProviderName)
+	require.Equal(t, "A", v.AccessKeyID)
+	require.Equal(t, "B", v.SecretAccessKey)
+}
+
+func TestRotatingSharedCredentialsProvider_RetrieveAndRefresh(t *testing.T) {
+	// create tmp credentials file and use that for this test
+	tmpFile, err := ioutil.TempFile(os.TempDir(), "credentials")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+	text := []byte(`[default]
+aws_access_key_id = TESTFILEKEYID1
+aws_secret_access_key = TESTFILESECRET1
+`)
+	_, err = tmpFile.Write(text)
+	require.NoError(t, err)
+
+	p := NewRotatingSharedCredentialsProvider()
+	p.sharedCredentialsProvider.Filename = tmpFile.Name()
+	p.RotationInterval = time.Second * 1
+	v, err := p.Retrieve()
+	require.NoError(t, err)
+	require.Equal(t, RotatingSharedCredentialsProviderName, v.ProviderName)
+	require.Equal(t, "TESTFILEKEYID1", v.AccessKeyID)
+	require.Equal(t, "TESTFILESECRET1", v.SecretAccessKey)
+	for i := 0; i < 10; i++ {
+		if p.IsExpired() {
+			break
+		}
+		time.Sleep(time.Second * 1)
+	}
+	require.True(t, p.IsExpired(), "Credentials should be expired by now")
+
+	// overwrite the credentials file and expect to receive the new creds
+	text2 := []byte(`[default]
+aws_access_key_id = TESTFILEKEYID2
+aws_secret_access_key = TESTFILESECRET2
+`)
+	_, err = tmpFile.WriteAt(text2, 0)
+	require.NoError(t, err)
+	v, err = p.Retrieve()
+	require.Equal(t, RotatingSharedCredentialsProviderName, v.ProviderName)
+	require.Equal(t, "TESTFILEKEYID2", v.AccessKeyID)
+	require.Equal(t, "TESTFILESECRET2", v.SecretAccessKey)
+}
+
+// TestRotatingSharedCredentialsProvider_CredentialsCaching tests that our Provider
+// interface operates correctly within the credentials.Credentials struct, which
+// does caching on top of the Provider interface
+func TestRotatingSharedCredentialsProvider_CredentialsCaching(t *testing.T) {
+	// create tmp credentials file and use that for this test
+	tmpFile, err := ioutil.TempFile(os.TempDir(), "credentials")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+	text := []byte(`[default]
+aws_access_key_id = TESTFILEKEYID1
+aws_secret_access_key = TESTFILESECRET1
+`)
+	_, err = tmpFile.Write(text)
+	require.NoError(t, err)
+
+	p := NewRotatingSharedCredentialsProvider()
+	p.sharedCredentialsProvider.Filename = tmpFile.Name()
+	// set hour-long expiration for this test so we can test expiration functionality
+	p.RotationInterval = time.Hour
+	creds := credentials.NewCredentials(p)
+	v, err := creds.Get()
+	require.NoError(t, err)
+	require.Equal(t, RotatingSharedCredentialsProviderName, v.ProviderName)
+	require.Equal(t, "TESTFILEKEYID1", v.AccessKeyID)
+	require.Equal(t, "TESTFILESECRET1", v.SecretAccessKey)
+
+	ts, err := creds.ExpiresAt()
+	require.NoError(t, err)
+	d := time.Until(ts)
+	require.True(t, d > time.Minute*45, "Expected expiration time of creds to be more than 45 minutes in future, was %s", d)
+
+	// overwrite cred file and verify that old values still cached
+	text2 := []byte(`[default]
+aws_access_key_id = TESTFILEKEYID2
+aws_secret_access_key = TESTFILESECRET2
+	`)
+	_, err = tmpFile.WriteAt(text2, 0)
+	require.NoError(t, err)
+	v, err = creds.Get()
+	require.NoError(t, err)
+	require.Equal(t, RotatingSharedCredentialsProviderName, v.ProviderName)
+	require.Equal(t, "TESTFILEKEYID1", v.AccessKeyID)
+	require.Equal(t, "TESTFILESECRET1", v.SecretAccessKey)
+
+	// manually expire the creds
+	creds.Expire()
+	// should have new values
+	v, err = creds.Get()
+	require.NoError(t, err)
+	require.Equal(t, RotatingSharedCredentialsProviderName, v.ProviderName)
+	require.Equal(t, "TESTFILEKEYID2", v.AccessKeyID)
+	require.Equal(t, "TESTFILESECRET2", v.SecretAccessKey)
+}


### PR DESCRIPTION
For on-prem, we can assume that every instance will be managed by AWS Systems Manager (SSM). SSM will provide the agent with instance credentials in a file located at /root/.aws/credentials. That file contains credentials that are good for 60 minutes, and are rotated every 30 minutes (this is so that there is overlap to avoid race conditions, where the “old” credentials are still usable for some time after rotation). The format of this file will be the same as the [AWS shared credentials file](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/create-shared-credentials-file.html).

While the AWS SDK supports retrieving credentials from the shared credentials file (via AWS_SHARED_CREDENTIALS_FILE env var), it does not support refreshing credentials when they expire. Because of this, the agent needs it’s own credential provider that parses the shared credentials file and refreshes it every 60 seconds to check for newer creds.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Added a rotating shared credentials file instance credential provider

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
