### PR TITLE
On-prem capability/attribute support

### DIFF
--- a/agent/api/ecsclient/client.go
+++ b/agent/api/ecsclient/client.go
@@ -44,6 +44,8 @@ const (
 	pollEndpointCacheTTL    = 20 * time.Minute
 	roundtripTimeout        = 5 * time.Second
 	azAttrName              = "ecs.availability-zone"
+	cpuArchAttrName         = "ecs.cpu-architecture"
+	osTypeAttrName          = "ecs.os-type"
 )
 
 // APIECSClient implements ECSClient
@@ -325,12 +327,21 @@ func validateRegisteredAttributes(expectedAttributes, actualAttributes []*ecs.At
 }
 
 func (client *APIECSClient) getAdditionalAttributes() []*ecs.Attribute {
-	return []*ecs.Attribute{
+	attrs := []*ecs.Attribute{
 		{
-			Name:  aws.String("ecs.os-type"),
+			Name:  aws.String(osTypeAttrName),
 			Value: aws.String(config.OSType),
 		},
 	}
+	// Send cpu arch attribute directly when running on-prem. When running on EC2, this is not needed
+	// since the cpu arch is reported via instance identity doc in that case.
+	if client.config.OnPrem.Enabled() {
+		attrs = append(attrs, &ecs.Attribute{
+			Name:  aws.String(cpuArchAttrName),
+			Value: aws.String(getCPUArch()),
+		})
+	}
+	return attrs
 }
 
 func (client *APIECSClient) getOutpostAttribute(outpostARN string) []*ecs.Attribute {

--- a/agent/api/ecsclient/utils.go
+++ b/agent/api/ecsclient/utils.go
@@ -1,0 +1,30 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ecsclient
+
+import (
+	"runtime"
+)
+
+func getCPUArch() string {
+	arch := runtime.GOARCH
+	// For amd64 and 386, change to x86_64 and i386 to match the value in instance identity doc
+	// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-identity-documents.html.
+	if arch == "amd64" {
+		arch = "x86_64"
+	} else if arch == "386" {
+		arch = "i386"
+	}
+	return arch
+}

--- a/agent/api/ecsclient/utils_amd64_test.go
+++ b/agent/api/ecsclient/utils_amd64_test.go
@@ -1,0 +1,26 @@
+// +build amd64,unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ecsclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetCPUArch(t *testing.T) {
+	assert.Equal(t, "x86_64", getCPUArch())
+}

--- a/agent/api/ecsclient/utils_arm64_test.go
+++ b/agent/api/ecsclient/utils_arm64_test.go
@@ -1,0 +1,26 @@
+// +build arm64,unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ecsclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetCPUArch(t *testing.T) {
+	assert.Equal(t, "arm64", getCPUArch())
+}

--- a/agent/app/agent_capability_test.go
+++ b/agent/app/agent_capability_test.go
@@ -40,48 +40,8 @@ import (
 )
 
 func TestCapabilities(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	client := mock_dockerapi.NewMockDockerClient(ctrl)
-	cniClient := mock_ecscni.NewMockCNIClient(ctrl)
-	mockCredentialsProvider := app_mocks.NewMockProvider(ctrl)
-	mockMobyPlugins := mock_mobypkgwrapper.NewMockPlugins(ctrl)
-	mockPauseLoader := mock_pause.NewMockLoader(ctrl)
-	conf := &config.Config{
-		AvailableLoggingDrivers: []dockerclient.LoggingDriver{
-			dockerclient.JSONFileDriver,
-			dockerclient.SyslogDriver,
-			dockerclient.JournaldDriver,
-			dockerclient.GelfDriver,
-			dockerclient.FluentdDriver,
-		},
-		PrivilegedDisabled:         config.BooleanDefaultFalse{Value: config.ExplicitlyDisabled},
-		SELinuxCapable:             config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled},
-		AppArmorCapable:            config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled},
-		TaskENIEnabled:             config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled},
-		AWSVPCBlockInstanceMetdata: config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled},
-		TaskCleanupWaitDuration:    config.DefaultConfig().TaskCleanupWaitDuration,
-	}
-
-	mockPauseLoader.EXPECT().IsLoaded(gomock.Any()).Return(false, nil).AnyTimes()
-	// Scan() and ListPluginsWithFilters() are tested with
-	// AnyTimes() because they are not called in windows.
-	gomock.InOrder(
-		client.EXPECT().SupportedVersions().Return([]dockerclient.DockerVersion{
-			dockerclient.Version_1_17,
-			dockerclient.Version_1_18,
-		}),
-		client.EXPECT().KnownVersions().Return([]dockerclient.DockerVersion{
-			dockerclient.Version_1_17,
-			dockerclient.Version_1_18,
-			dockerclient.Version_1_19,
-		}),
-		cniClient.EXPECT().Version(ecscni.ECSENIPluginName).Return("v1", nil),
-		mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{}, nil),
-		client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
-			gomock.Any()).AnyTimes().Return([]string{}, nil),
-	)
+	cfg := getCapabilitiesTestConfig()
+	capabilities := getCapabilitiesWithConfig(cfg, t)
 
 	expectedCapabilityNames := []string{
 		capabilityPrefix + "privileged-container",
@@ -119,27 +79,98 @@ func TestCapabilities(t *testing.T) {
 			},
 		}...)
 
-	ctx, cancel := context.WithCancel(context.TODO())
-	// Cancel the context to cancel async routines
-	defer cancel()
-	agent := &ecsAgent{
-		ctx:                ctx,
-		cfg:                conf,
-		dockerClient:       client,
-		cniClient:          cniClient,
-		pauseLoader:        mockPauseLoader,
-		credentialProvider: aws_credentials.NewCredentials(mockCredentialsProvider),
-		mobyPlugins:        mockMobyPlugins,
-	}
-	capabilities, err := agent.capabilities()
-	assert.NoError(t, err)
-
 	for _, expected := range expectedCapabilities {
 		assert.Contains(t, capabilities, &ecs.Attribute{
 			Name:  expected.Name,
 			Value: expected.Value,
 		})
 	}
+}
+
+// Test on-prem capability by checking that when on-prem config is set, on-prem unsupported capabilities aren't
+// added, on-prem specific capabilities are added, and capabilities common for both on-prem and not-on-prem are added.
+func TestCapabilitiesOnPrem(t *testing.T) {
+	cfg := getCapabilitiesTestConfig()
+	capsNotOnPrem := getCapabilitiesWithConfig(cfg, t)
+	cfg.OnPrem = config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled}
+	capsOnPrem := getCapabilitiesWithConfig(cfg, t)
+
+	for _, cap := range onPremUnsupportedCapabilities {
+		assert.NotContains(t, capsOnPrem, &ecs.Attribute{
+			Name: aws.String(cap),
+		})
+	}
+	for _, cap := range onPremSpecificCapabilities {
+		assert.Contains(t, capsOnPrem, &ecs.Attribute{
+			Name: aws.String(cap),
+		})
+	}
+	commonCaps := removeAttributesByNames(capsNotOnPrem, onPremUnsupportedCapabilities)
+	for _, cap := range commonCaps {
+		assert.Contains(t, capsOnPrem, cap)
+	}
+}
+
+func getCapabilitiesTestConfig() *config.Config {
+	return &config.Config{
+		AvailableLoggingDrivers: []dockerclient.LoggingDriver{
+			dockerclient.JSONFileDriver,
+			dockerclient.SyslogDriver,
+			dockerclient.JournaldDriver,
+			dockerclient.GelfDriver,
+			dockerclient.FluentdDriver,
+		},
+		PrivilegedDisabled:         config.BooleanDefaultFalse{Value: config.ExplicitlyDisabled},
+		SELinuxCapable:             config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled},
+		AppArmorCapable:            config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled},
+		TaskENIEnabled:             config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled},
+		AWSVPCBlockInstanceMetdata: config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled},
+		TaskCleanupWaitDuration:    config.DefaultConfig().TaskCleanupWaitDuration,
+	}
+}
+
+func getCapabilitiesWithConfig(cfg *config.Config, t *testing.T) []*ecs.Attribute {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := mock_dockerapi.NewMockDockerClient(ctrl)
+	mockCredentialsProvider := app_mocks.NewMockProvider(ctrl)
+	mockMobyPlugins := mock_mobypkgwrapper.NewMockPlugins(ctrl)
+	mockPauseLoader := mock_pause.NewMockLoader(ctrl)
+	mockCNIClient := mock_ecscni.NewMockCNIClient(ctrl)
+
+	mockPauseLoader.EXPECT().IsLoaded(gomock.Any()).Return(false, nil).AnyTimes()
+	mockCNIClient.EXPECT().Version(ecscni.ECSENIPluginName).Return("v1", nil).AnyTimes()
+	gomock.InOrder(
+		client.EXPECT().SupportedVersions().Return([]dockerclient.DockerVersion{
+			dockerclient.Version_1_17,
+			dockerclient.Version_1_18,
+		}),
+		client.EXPECT().KnownVersions().Return([]dockerclient.DockerVersion{
+			dockerclient.Version_1_17,
+			dockerclient.Version_1_18,
+			dockerclient.Version_1_19,
+		}),
+		mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{}, nil),
+		client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
+			gomock.Any()).AnyTimes().Return([]string{}, nil),
+	)
+
+	ctx, cancel := context.WithCancel(context.TODO())
+	// Cancel the context to cancel async routines
+	defer cancel()
+	agent := &ecsAgent{
+		ctx:                ctx,
+		cfg:                cfg,
+		dockerClient:       client,
+		pauseLoader:        mockPauseLoader,
+		cniClient:          mockCNIClient,
+		credentialProvider: aws_credentials.NewCredentials(mockCredentialsProvider),
+		mobyPlugins:        mockMobyPlugins,
+	}
+	capabilities, err := agent.capabilities()
+	require.NoError(t, err)
+	return capabilities
 }
 
 func TestCapabilitiesECR(t *testing.T) {
@@ -750,4 +781,25 @@ func TestCapabilitesScanPluginsErrorCase(t *testing.T) {
 			assert.Equal(t, aws.StringValue(capability.Name), "ecs.capability.docker-volume-driver.local")
 		}
 	}
+}
+
+func TestAppendAndRemoveAttributes(t *testing.T) {
+	attrs := appendNameOnlyAttribute([]*ecs.Attribute{}, "cap-1")
+	attrs = appendNameOnlyAttribute(attrs, "cap-2")
+	require.Len(t, attrs, 2)
+	assert.Contains(t, attrs, &ecs.Attribute{
+		Name: aws.String("cap-1"),
+	})
+	assert.Contains(t, attrs, &ecs.Attribute{
+		Name: aws.String("cap-2"),
+	})
+
+	attrs = removeAttributesByNames(attrs, []string{"cap-1"})
+	require.Len(t, attrs, 1)
+	assert.NotContains(t, attrs, &ecs.Attribute{
+		Name: aws.String("cap-1"),
+	})
+	assert.Contains(t, attrs, &ecs.Attribute{
+		Name: aws.String("cap-2"),
+	})
 }

--- a/agent/app/agent_capability_unix.go
+++ b/agent/app/agent_capability_unix.go
@@ -124,7 +124,6 @@ func (agent *ecsAgent) appendAppMeshCapabilities(capabilities []*ecs.Attribute) 
 }
 
 func (agent *ecsAgent) appendTaskEIACapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
-
 	capabilities = appendNameOnlyAttribute(capabilities, attributePrefix+taskEIAAttributeSuffix)
 
 	eiaRequiredFlags := []string{AVX, AVX2, SSE41, SSE42}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Add on-prem capability/attribute support.

### Implementation details
<!-- How are the changes implemented? -->
When on-prem config is set:
1. Skip adding capabilities that aren't supported on-prem, this includes: task networking related capabilities, appmesh, EIA;
2. Add on prem capability "ecs.capability.on-prem";
3. Report cpu architecture as an attribute, obtained from Go runtime. Note: for amd64, the ec2 instance identity doc uses "x86_64" but go runtime has amd64 (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-identity-documents.html). So when runtime is amd64, it is reported as x86_64 to be consistent with EC2.

Consolidated few unit tests to reduce duplicate test code.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Added unit test. Built the agent and ran it on prem, verified that unsupported capabilities are not reported and cpu architecture is reported.

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
N/A

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
