### PR TITLE
Create sdkClientFactory only once for engine integration tests

### DIFF
--- a/agent/engine/common_integ_test.go
+++ b/agent/engine/common_integ_test.go
@@ -44,6 +44,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var (
+	sdkClientFactory sdkclientfactory.Factory
+)
+
+func init() {
+	sdkClientFactory = sdkclientfactory.NewFactory(context.TODO(), dockerEndpoint)
+}
+
 func defaultTestConfigIntegTest() *config.Config {
 	cfg, _ := config.NewConfig(ec2.NewBlackholeEC2MetadataClient())
 	cfg.TaskCPUMemLimit.Value = config.ExplicitlyDisabled
@@ -125,17 +133,12 @@ func verifyContainerStoppedStateChangeWithRuntimeID(t *testing.T, taskEngine Tas
 }
 
 func setup(cfg *config.Config, state dockerstate.TaskEngineState, t *testing.T) (TaskEngine, func(), credentials.Manager) {
-	ctx, cancel := context.WithCancel(context.TODO())
-	defer cancel()
-
 	if os.Getenv("ECS_SKIP_ENGINE_INTEG_TEST") != "" {
 		t.Skip("ECS_SKIP_ENGINE_INTEG_TEST")
 	}
 	if !isDockerRunning() {
 		t.Skip("Docker not running")
 	}
-
-	sdkClientFactory := sdkclientfactory.NewFactory(ctx, dockerEndpoint)
 	dockerClient, err := dockerapi.NewDockerGoClient(sdkClientFactory, cfg, context.Background())
 	if err != nil {
 		t.Fatalf("Error creating Docker client: %v", err)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Recently, running integration tests had become problematic due to `too many open files` errors. This PR fixes the issue.

After running locally, I see around only 57 files open at any time while engine integ tests are running, from a previous value of 1000+

This change can have the potential benefit of making integ tests more efficient, since `dockerd` won't have hundreds/thousands of connections open concurrently.

### Implementation details
<!-- How are the changes implemented? -->
 I traced the source of open files to the creation of a new sdkClientFactory every time a new integ test ran. This caused all docker API calls to open new connections, which are cached (and not reused) by default.

By creating the factory only once in the `init` function of the `common_integ_test` file, only a fixed number of docker clients are created at initialization time (as opposed to every time the `setup` is invoked).

### Testing
Ran engine integ tests in my personal AL2 box and observed how the number of open connections to docker is dramatically less after this change.
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
