### PR TITLE
Exec stsc add

### DIFF
--- a/agent/engine/execcmd/manager.go
+++ b/agent/engine/execcmd/manager.go
@@ -93,3 +93,7 @@ func NewManagerWithBinDir(hostBinDir string) *manager {
 	m.hostBinDir = hostBinDir
 	return m
 }
+
+func (m *manager) isAgentStarted(execMD apicontainer.ExecCommandAgentMetadata) bool {
+	return !execMD.StartedAt.IsZero()
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This adds state updates to the exec command manager, and emits a container event for the monitoring of the exec command in the docker task engine.

### Implementation details
Exec Command agent status is tracked in the container.  I added fields to the ExecCommandAgentMetadata, but kept the actual agent status directly in the container itself.  (This might migrate to the Metadata in future, but it breaks a whole lot of tests so I'd prefer to leave it where it is for now.)
Via the execcmd manager, the docker task engine will update the container and metadata state with the `StartedAt` time as well as the reason for any error (`StoppedReason`-> `ManagedAgent.Reason`).  
The docker task engine will emit the container event during its monitoring cycle.

### Testing
Ran All unit tests locally and updated in place.
I'm letting MACIS run the rest and will update as necessary.


New tests cover the changes: yes

### Description for the changelog
Update Execute Command Agent state and emit container events for that state.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
