### PR TITLE
Retry to rename files on error as os.Rename calls are prone to failure on Windows

### DIFF
--- a/agent/utils/retry/exponential_backoff.go
+++ b/agent/utils/retry/exponential_backoff.go
@@ -28,7 +28,7 @@ type ExponentialBackoff struct {
 	mu             sync.Mutex
 }
 
-// NewSimpleBackoff creates a Backoff which ranges from min to max increasing by
+// NewExponentialBackoff creates a Backoff which ranges from min to max increasing by
 // multiple each time. (t = start * multiple * n for the nth iteration)
 // It also adds (and yes, the jitter is always added, never
 // subtracted) a random amount of jitter up to jitterMultiple percent (that is,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Retry to rename files on error as os.Rename calls are prone to failure on Windows.

Similar issues: https://github.com/golang/go/issues/32188

### Implementation details
<!-- How are the changes implemented? -->
- `agent/taskresource/envFiles/envfile.go` - modified to retry the call os.Rename on error
- `agent/utils/retry/exponential_backoff.go` - corrected the function name in the comment

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
`make test` passes
New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enhancement - Retry os.Rename() on error

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.