### PR TITLE
Rename on-prem to external in code base

### DIFF
--- a/agent/api/ecsclient/client.go
+++ b/agent/api/ecsclient/client.go
@@ -333,9 +333,9 @@ func (client *APIECSClient) getAdditionalAttributes() []*ecs.Attribute {
 			Value: aws.String(config.OSType),
 		},
 	}
-	// Send cpu arch attribute directly when running on-prem. When running on EC2, this is not needed
+	// Send cpu arch attribute directly when running on external capacity. When running on EC2, this is not needed
 	// since the cpu arch is reported via instance identity doc in that case.
-	if client.config.OnPrem.Enabled() {
+	if client.config.External.Enabled() {
 		attrs = append(attrs, &ecs.Attribute{
 			Name:  aws.String(cpuArchAttrName),
 			Value: aws.String(getCPUArch()),

--- a/agent/api/ecsclient/client_test.go
+++ b/agent/api/ecsclient/client_test.go
@@ -349,7 +349,7 @@ func TestRegisterContainerInstance(t *testing.T) {
 				Cluster:   configuredCluster,
 				AWSRegion: "us-west-2",
 				NoIID:     true,
-				OnPrem:    config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled},
+				External:  config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled},
 			},
 		},
 	}
@@ -403,12 +403,12 @@ func TestRegisterContainerInstance(t *testing.T) {
 			}
 
 			var expectedNumOfAttributes int
-			if !tc.cfg.OnPrem.Enabled() {
+			if !tc.cfg.External.Enabled() {
 				// 2 capability attributes: capability1, capability2
 				// and 4 other attributes: ecs.os-type, ecs.outpost-arn, my_custom_attribute, my_other_custom_attribute.
 				expectedNumOfAttributes = 6
 			} else {
-				// One more attribute for on-prem case: ecs.cpu-architecture
+				// One more attribute for external case: ecs.cpu-architecture
 				expectedNumOfAttributes = 7
 			}
 

--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -143,8 +143,8 @@ func newAgent(blackholeEC2Metadata bool, acceptInsecureCert *bool) (agent, error
 	seelog.Infof("Amazon ECS agent Version: %s, Commit: %s", version.Version, version.GitShortHash)
 	seelog.Debugf("Loaded config: %s", cfg.String())
 
-	if cfg.OnPrem.Enabled() {
-		seelog.Info("Running in on-prem mode.")
+	if cfg.External.Enabled() {
+		seelog.Info("Running in external mode.")
 		ec2MetadataClient = ec2.NewBlackholeEC2MetadataClient()
 		cfg.NoIID = true
 	}

--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -61,7 +61,7 @@ const (
 	capabilityEFS                               = "efs"
 	capabilityEFSAuth                           = "efsAuth"
 	capabilityEnvFilesS3                        = "env-files.s3"
-	capabilityOnPrem                            = "on-prem"
+	capabilityExternal                          = "external"
 )
 
 var (
@@ -87,8 +87,8 @@ var (
 		capabilityEnvFilesS3,
 	}
 
-	// List of capabilities that are not supported on-premises.
-	onPremUnsupportedCapabilities = []string{
+	// List of capabilities that are not supported on external capacity.
+	externalUnsupportedCapabilities = []string{
 		attributePrefix + taskENIAttributeSuffix,
 		attributePrefix + cniPluginVersionSuffix,
 		attributePrefix + taskENIIPv6AttributeSuffix,
@@ -98,10 +98,10 @@ var (
 		attributePrefix + taskEIAAttributeSuffix,
 		attributePrefix + taskEIAWithOptimizedCPU,
 	}
-	// List of capabilities that are only supported on-premises. Currently only one but keep as a list
-	// for future proof and also align with onPremUnsupportedCapabilities.
-	onPremSpecificCapabilities = []string{
-		attributePrefix + capabilityOnPrem,
+	// List of capabilities that are only supported on external capaciity. Currently only one but keep as a list
+	// for future proof and also align with externalUnsupportedCapabilities.
+	externalSpecificCapabilities = []string{
+		attributePrefix + capabilityExternal,
 	}
 )
 
@@ -151,7 +151,7 @@ var (
 //    ecs.capability.gmsa
 //    ecs.capability.efsAuth
 //    ecs.capability.env-files.s3
-//    ecs.capability.on-prem
+//    ecs.capability.external
 func (agent *ecsAgent) capabilities() ([]*ecs.Attribute, error) {
 	var capabilities []*ecs.Attribute
 
@@ -236,12 +236,12 @@ func (agent *ecsAgent) capabilities() ([]*ecs.Attribute, error) {
 		capabilities = agent.appendEFSVolumePluginCapabilities(capabilities, cap)
 	}
 
-	if agent.cfg.OnPrem.Enabled() {
-		// Add on-prem specific capability; remove on-prem unsupported capabilities.
-		for _, cap := range onPremSpecificCapabilities {
+	if agent.cfg.External.Enabled() {
+		// Add external specific capability; remove external unsupported capabilities.
+		for _, cap := range externalSpecificCapabilities {
 			capabilities = appendNameOnlyAttribute(capabilities, cap)
 		}
-		capabilities = removeAttributesByNames(capabilities, onPremUnsupportedCapabilities)
+		capabilities = removeAttributesByNames(capabilities, externalUnsupportedCapabilities)
 	}
 
 	return capabilities, nil

--- a/agent/app/agent_capability_test.go
+++ b/agent/app/agent_capability_test.go
@@ -87,27 +87,27 @@ func TestCapabilities(t *testing.T) {
 	}
 }
 
-// Test on-prem capability by checking that when on-prem config is set, on-prem unsupported capabilities aren't
-// added, on-prem specific capabilities are added, and capabilities common for both on-prem and not-on-prem are added.
-func TestCapabilitiesOnPrem(t *testing.T) {
+// Test exteernal capability by checking that when external config is set, capabilities not supported on external capacity
+// aren't added, external specific capabilities are added, and capabilities common for both external and non-external are added.
+func TestCapabilitiesExternal(t *testing.T) {
 	cfg := getCapabilitiesTestConfig()
-	capsNotOnPrem := getCapabilitiesWithConfig(cfg, t)
-	cfg.OnPrem = config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled}
-	capsOnPrem := getCapabilitiesWithConfig(cfg, t)
+	capsNonExternal := getCapabilitiesWithConfig(cfg, t)
+	cfg.External = config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled}
+	capsExternal := getCapabilitiesWithConfig(cfg, t)
 
-	for _, cap := range onPremUnsupportedCapabilities {
-		assert.NotContains(t, capsOnPrem, &ecs.Attribute{
+	for _, cap := range externalUnsupportedCapabilities {
+		assert.NotContains(t, capsExternal, &ecs.Attribute{
 			Name: aws.String(cap),
 		})
 	}
-	for _, cap := range onPremSpecificCapabilities {
-		assert.Contains(t, capsOnPrem, &ecs.Attribute{
+	for _, cap := range externalSpecificCapabilities {
+		assert.Contains(t, capsExternal, &ecs.Attribute{
 			Name: aws.String(cap),
 		})
 	}
-	commonCaps := removeAttributesByNames(capsNotOnPrem, onPremUnsupportedCapabilities)
+	commonCaps := removeAttributesByNames(capsNonExternal, externalUnsupportedCapabilities)
 	for _, cap := range commonCaps {
-		assert.Contains(t, capsOnPrem, cap)
+		assert.Contains(t, capsExternal, cap)
 	}
 }
 

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -226,9 +226,9 @@ func NewConfig(ec2client ec2.EC2MetadataClient) (*Config, error) {
 	}
 	config := &envConfig
 
-	if config.OnPrem.Enabled() {
+	if config.External.Enabled() {
 		if config.AWSRegion == "" {
-			return nil, errors.New("AWS_DEFAULT_REGION has to be set when running on-premises")
+			return nil, errors.New("AWS_DEFAULT_REGION has to be set when running on external capacity")
 		}
 		// Use fake ec2 metadata client if on prem config is set.
 		ec2client = ec2.NewBlackholeEC2MetadataClient()
@@ -578,7 +578,7 @@ func environmentConfig() (Config, error) {
 		SpotInstanceDrainingEnabled:         parseBooleanDefaultFalseConfig("ECS_ENABLE_SPOT_INSTANCE_DRAINING"),
 		GMSACapable:                         parseGMSACapability(),
 		VolumePluginCapabilities:            parseVolumePluginCapabilities(),
-		OnPrem:                              parseBooleanDefaultFalseConfig("ECS_ON_PREM"),
+		External:                            parseBooleanDefaultFalseConfig("ECS_EXTERNAL"),
 	}, err
 }
 

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -808,16 +808,16 @@ func TestTaskMetadataAZDisabled(t *testing.T) {
 	assert.True(t, cfg.TaskMetadataAZDisabled, "Wrong value for TaskMetadataAZDisabled")
 }
 
-func TestOnPremConfig(t *testing.T) {
+func TestExternalConfig(t *testing.T) {
 	defer setTestRegion()()
-	defer setTestEnv("ECS_ON_PREM", "true")()
+	defer setTestEnv("ECS_EXTERNAL", "true")()
 	cfg, err := NewConfig(ec2.NewBlackholeEC2MetadataClient())
 	require.NoError(t, err)
-	assert.True(t, cfg.OnPrem.Enabled())
+	assert.True(t, cfg.External.Enabled())
 }
 
-func TestOnPremConfigMissingRegion(t *testing.T) {
-	defer setTestEnv("ECS_ON_PREM", "true")()
+func TestExternalConfigMissingRegion(t *testing.T) {
+	defer setTestEnv("ECS_EXTERNAL", "true")()
 	_, err := NewConfig(ec2.NewBlackholeEC2MetadataClient())
 	assert.Error(t, err)
 }

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -319,6 +319,6 @@ type Config struct {
 	// VolumePluginCapabilities specifies the capabilities of the ecs volume plugin.
 	VolumePluginCapabilities []string
 
-	// OnPrem specifies whether agent is running in on-premises mode.
-	OnPrem BooleanDefaultFalse
+	// External specifies whether agent is running on external compute capacity (i.e. outside of aws).
+	External BooleanDefaultFalse
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Rename on-prem to external in code base to align with service side naming.

### Implementation details
<!-- How are the changes implemented? -->
1. Change on-prem config from OnPrem to External;
2. Change on-prem config env from ECS_ON_PREM to ECS_EXTERNAL;
3. Change on-prem capability from ecs.capability.on-prem to ecs.capability.external

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Unit test updated. Built the agent, ran it and checked the attributes.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
N/A

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
