### PR TITLE
add jitter between monitoring exec agents for containers

### DIFF
--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -3132,6 +3132,7 @@ func TestMonitorExecAgentRunning(t *testing.T) {
 	dockerTaskEngine := taskEngine.(*DockerTaskEngine)
 	execCmdMgr := mock_execcmdagent.NewMockManager(ctrl)
 	dockerTaskEngine.execCmdMgr = execCmdMgr
+	dockerTaskEngine.monitorExecAgentsInterval = 2 * time.Millisecond
 	defer ctrl.Finish()
 	const (
 		testContainerId = "123"
@@ -3186,6 +3187,7 @@ func TestMonitorExecAgentProcesses(t *testing.T) {
 	dockerTaskEngine := taskEngine.(*DockerTaskEngine)
 	execCmdMgr := mock_execcmdagent.NewMockManager(ctrl)
 	dockerTaskEngine.execCmdMgr = execCmdMgr
+	dockerTaskEngine.monitorExecAgentsInterval = 2 * time.Millisecond
 	defer ctrl.Finish()
 	testTask := &apitask.Task{
 		Arn: "arn:aws:ecs:region:account-id:task/test-task-arn",
@@ -3263,6 +3265,7 @@ func TestMonitorExecAgentsMultipleContainers(t *testing.T) {
 	dockerTaskEngine := taskEngine.(*DockerTaskEngine)
 	execCmdMgr := mock_execcmdagent.NewMockManager(ctrl)
 	dockerTaskEngine.execCmdMgr = execCmdMgr
+	dockerTaskEngine.monitorExecAgentsInterval = 2 * time.Millisecond
 	defer ctrl.Finish()
 	testTask := &apitask.Task{
 		Arn: "arn:aws:ecs:region:account-id:task/test-task-arn",

--- a/agent/engine/execcmd/manager_start_linux.go
+++ b/agent/engine/execcmd/manager_start_linux.go
@@ -46,7 +46,7 @@ func (m *manager) RestartAgentIfStopped(ctx context.Context, client dockerapi.Do
 		return NotRestarted, nil
 	}
 	res, err := m.inspectExecAgentProcess(ctx, client, execMD)
-	if err != nil {
+	if err != nil || res == nil {
 		// We don't want to report InspectContainerExec errors, just that we don't know what the status of the agent is
 		return Unknown, nil
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Monitoring for exec agent processes is done for tasks that have exec enabled every 15 minutes. To make sure all the exec containers do not synchronize on calling the inspect / restart agent docker API(thereby stressing docker), adding a jitter with a max sleep time of half of monitor interval for the containers. 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

### Description for the changelog
N/A

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
