### PR TITLE
cleanup ExecAgent host logs for exec tasks

### DIFF
--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -268,7 +268,7 @@ type Task struct {
 	LaunchType string `json:"LaunchType,omitempty"`
 
 	// TODO: [ecs-exec] Wire this to the actual model when control plane changes are ready
-	ExecCommandAgentEnabled bool `json:"ExecCommandAgentEnabled"`
+	ExecCommandAgentEnabledUnsafe bool `json:"ExecCommandAgentEnabled"`
 
 	// lock is for protecting all fields in the task struct
 	lock sync.RWMutex
@@ -2726,5 +2726,5 @@ func (task *Task) SetLocalIPAddress(addr string) {
 func (task *Task) IsExecCommandAgentEnabled() bool {
 	task.lock.Lock()
 	defer task.lock.Unlock()
-	return task.ExecCommandAgentEnabled
+	return task.ExecCommandAgentEnabledUnsafe
 }

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -614,7 +614,7 @@ func (engine *DockerTaskEngine) deleteTask(task *apitask.Task) {
 		}
 	}
 
-	if task.ExecCommandAgentEnabled {
+	if task.IsExecCommandAgentEnabled() {
 		// cleanup host exec agent log dirs
 		if tID, err := task.GetID(); err != nil {
 			seelog.Warnf("Task Engine[%s]: error getting task ID for ExecAgent logs cleanup: %v", task.Arn, err)

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -242,7 +242,7 @@ func TestBatchContainerHappyPath(t *testing.T) {
 			credentialsManager.EXPECT().RemoveCredentials(credentialsID)
 
 			sleepTask := testdata.LoadTask("sleep5")
-			sleepTask.ExecCommandAgentEnabled = tc.execCommandAgentEnabled
+			sleepTask.ExecCommandAgentEnabledUnsafe = tc.execCommandAgentEnabled
 			sleepTask.SetCredentialsID(credentialsID)
 			eventStream := make(chan dockerapi.DockerContainerChangeEvent)
 			// containerEventsWG is used to force the test to wait until the container created and started
@@ -3198,8 +3198,8 @@ func TestMonitorExecAgentProcesses(t *testing.T) {
 				KnownStatusUnsafe: apicontainerstatus.ContainerRunning,
 			},
 		},
-		KnownStatusUnsafe:       apitaskstatus.TaskRunning,
-		ExecCommandAgentEnabled: true,
+		KnownStatusUnsafe:             apitaskstatus.TaskRunning,
+		ExecCommandAgentEnabledUnsafe: true,
 	}
 	dockerTaskEngine.state.AddTask(testTask)
 	dockerTaskEngine.managedTasks[testTask.Arn] = &managedTask{Task: testTask}
@@ -3248,8 +3248,8 @@ func TestMonitorExecAgentProcessExecDisabled(t *testing.T) {
 					KnownStatusUnsafe: apicontainerstatus.ContainerRunning,
 				},
 			},
-			ExecCommandAgentEnabled: test.execCommandAgentEnabled,
-			KnownStatusUnsafe:       test.taskStatus,
+			ExecCommandAgentEnabledUnsafe: test.execCommandAgentEnabled,
+			KnownStatusUnsafe:             test.taskStatus,
 		}
 		dockerTaskEngine.state.AddTask(testTask)
 		dockerTaskEngine.managedTasks[testTask.Arn] = &managedTask{Task: testTask}
@@ -3281,8 +3281,8 @@ func TestMonitorExecAgentsMultipleContainers(t *testing.T) {
 				KnownStatusUnsafe: apicontainerstatus.ContainerRunning,
 			},
 		},
-		ExecCommandAgentEnabled: true,
-		KnownStatusUnsafe:       apitaskstatus.TaskRunning,
+		ExecCommandAgentEnabledUnsafe: true,
+		KnownStatusUnsafe:             apitaskstatus.TaskRunning,
 	}
 	dockerTaskEngine.state.AddTask(testTask)
 	dockerTaskEngine.managedTasks[testTask.Arn] = &managedTask{Task: testTask}
@@ -3337,7 +3337,7 @@ func TestPeriodicExecAgentsMonitoring(t *testing.T) {
 				},
 			},
 		},
-		ExecCommandAgentEnabled: true,
+		ExecCommandAgentEnabledUnsafe: true,
 	}
 	taskEngine.(*DockerTaskEngine).monitorExecAgentsInterval = 2 * time.Millisecond
 	taskEngine.(*DockerTaskEngine).state.AddTask(testTask)

--- a/agent/engine/engine_unix_integ_test.go
+++ b/agent/engine/engine_unix_integ_test.go
@@ -1674,7 +1674,7 @@ func TestExecCommandAgent(t *testing.T) {
 
 func createTestExecCommandAgentTask(taskId, containerName string, sleepFor time.Duration) *apitask.Task {
 	testTask := createTestTask("arn:aws:ecs:us-west-2:1234567890:task/" + taskId)
-	testTask.ExecCommandAgentEnabled = true
+	testTask.ExecCommandAgentEnabledUnsafe = true
 	testTask.PIDMode = ecs.PidModeHost
 	testTask.Containers[0].Name = containerName
 	testTask.Containers[0].Image = testExecCommandAgentImage

--- a/agent/engine/execcmd/manager_init_task_linux_test.go
+++ b/agent/engine/execcmd/manager_init_task_linux_test.go
@@ -88,8 +88,8 @@ func TestInitializeTask(t *testing.T) {
 		task, err := apitask.TaskFromACS(&taskFromACS, &ecsacs.PayloadMessage{SeqNum: &seqNum})
 		require.Nil(t, err, "Should be able to handle acs task")
 
-		assert.Equal(t, 4, len(task.Containers))        // before PostUnmarshalTask
-		task.ExecCommandAgentEnabled = test.execEnabled // TODO: [ecs-exec] remove this statement once ecsacs model is complete with ecs exec stuff
+		assert.Equal(t, 4, len(task.Containers))              // before PostUnmarshalTask
+		task.ExecCommandAgentEnabledUnsafe = test.execEnabled // TODO: [ecs-exec] remove this statement once ecsacs model is complete with ecs exec stuff
 		require.Equal(t, test.execEnabled, task.IsExecCommandAgentEnabled(), "task.IsExecCommandAgentEnabled() returned an unexpected value")
 
 		if !test.execEnabled {

--- a/agent/engine/execcmd/manager_start_linux_test.go
+++ b/agent/engine/execcmd/manager_start_linux_test.go
@@ -119,9 +119,9 @@ func TestStartAgent(t *testing.T) {
 	}
 	for _, test := range tt {
 		testTask := &apitask.Task{
-			Arn:                     "taskArn:aws:ecs:region:account-id:task/test-task-taskArn",
-			Containers:              test.containers,
-			ExecCommandAgentEnabled: test.execEnabled,
+			Arn:                           "taskArn:aws:ecs:region:account-id:task/test-task-taskArn",
+			Containers:                    test.containers,
+			ExecCommandAgentEnabledUnsafe: test.execEnabled,
 		}
 
 		times := maxRetries
@@ -195,7 +195,7 @@ func TestIdempotentStartAgent(t *testing.T) {
 		Containers: []*apicontainer.Container{{
 			RuntimeID: "123",
 		}},
-		ExecCommandAgentEnabled: true,
+		ExecCommandAgentEnabledUnsafe: true,
 	}
 
 	execCfg := types.ExecConfig{
@@ -305,7 +305,7 @@ func TestRestartAgentIfStopped(t *testing.T) {
 				RuntimeID:                testContainerId,
 				ExecCommandAgentMetadata: test.execCmdMD,
 			}},
-			ExecCommandAgentEnabled: test.execEnabled,
+			ExecCommandAgentEnabledUnsafe: test.execEnabled,
 		}
 
 		if test.execEnabled && test.execCmdMD != nil {

--- a/agent/engine/execcmd/manager_unsupported.go
+++ b/agent/engine/execcmd/manager_unsupported.go
@@ -23,7 +23,8 @@ import (
 )
 
 const (
-	// HostLogDir in unsupported platforms for exec is empty
+	// HostLogDir here is used used while cleaning up exec logs when task exits.
+	// When this path is empty, nothing is cleaned up for unsupported platforms.
 	HostLogDir = ""
 )
 

--- a/agent/engine/execcmd/manager_unsupported.go
+++ b/agent/engine/execcmd/manager_unsupported.go
@@ -22,6 +22,11 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 )
 
+const (
+	// HostLogDir in unsupported platforms for exec is empty
+	HostLogDir = ""
+)
+
 // Note: exec cmd agent is a linux-only feature, thus implemented here as a no-op.
 func (m *manager) RestartAgentIfStopped(ctx context.Context, client dockerapi.DockerClient, task *apitask.Task, container *apicontainer.Container, containerId string) (RestartStatus, error) {
 	return NotRestarted, nil

--- a/agent/engine/task_manager_unix_test.go
+++ b/agent/engine/task_manager_unix_test.go
@@ -420,7 +420,7 @@ func TestCleanupExecEnabledTask(t *testing.T) {
 		resourceStateChangeEvent: make(chan resourceStateChange),
 		cfg:                      taskEngine.cfg,
 	}
-	mTask.Task.ExecCommandAgentEnabled = true
+	mTask.Task.ExecCommandAgentEnabledUnsafe = true
 	mTask.SetKnownStatus(apitaskstatus.TaskStopped)
 	mTask.SetSentStatus(apitaskstatus.TaskStopped)
 	container := mTask.Containers[0]

--- a/agent/engine/task_manager_unix_test.go
+++ b/agent/engine/task_manager_unix_test.go
@@ -18,17 +18,25 @@ package engine
 import (
 	"context"
 	"errors"
+	"fmt"
+	"os"
 	"sync"
 	"testing"
+	"time"
 
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	"github.com/aws/amazon-ecs-agent/agent/data"
+	mock_dockerapi "github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dependencygraph"
+	mock_dockerstate "github.com/aws/amazon-ecs-agent/agent/engine/dockerstate/mocks"
+	mock_engine "github.com/aws/amazon-ecs-agent/agent/engine/mocks"
+	"github.com/aws/amazon-ecs-agent/agent/engine/testdata"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/cgroup"
 	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/volume"
+	mock_ttime "github.com/aws/amazon-ecs-agent/agent/utils/ttime/mocks"
 	"github.com/golang/mock/gomock"
 
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
@@ -379,4 +387,68 @@ func TestEFSVolumeNextStateWithTransitionDependencies(t *testing.T) {
 			assert.Equal(t, tc.reason, transition.reason, "transition possible")
 		})
 	}
+}
+
+func TestCleanupExecEnabledTask(t *testing.T) {
+	cfg := getTestConfig()
+	ctrl := gomock.NewController(t)
+	mockTime := mock_ttime.NewMockTime(ctrl)
+	mockState := mock_dockerstate.NewMockTaskEngineState(ctrl)
+	mockClient := mock_dockerapi.NewMockDockerClient(ctrl)
+	mockImageManager := mock_engine.NewMockImageManager(ctrl)
+	defer ctrl.Finish()
+
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
+	taskEngine := &DockerTaskEngine{
+		ctx:          ctx,
+		cfg:          &cfg,
+		dataClient:   data.NewNoopClient(),
+		state:        mockState,
+		client:       mockClient,
+		imageManager: mockImageManager,
+	}
+	mTask := &managedTask{
+		ctx:                      ctx,
+		cancel:                   cancel,
+		Task:                     testdata.LoadTask("sleep5"),
+		_time:                    mockTime,
+		engine:                   taskEngine,
+		acsMessages:              make(chan acsTransition),
+		dockerMessages:           make(chan dockerContainerChange),
+		resourceStateChangeEvent: make(chan resourceStateChange),
+		cfg:                      taskEngine.cfg,
+	}
+	mTask.Task.ExecCommandAgentEnabled = true
+	mTask.SetKnownStatus(apitaskstatus.TaskStopped)
+	mTask.SetSentStatus(apitaskstatus.TaskStopped)
+	container := mTask.Containers[0]
+	dockerContainer := &apicontainer.DockerContainer{
+		DockerName: "dockerContainer",
+	}
+	tID, _ := mTask.Task.GetID()
+	removeAll = func(path string) error {
+		assert.Equal(t, fmt.Sprintf("/var/log/ecs/exec/%s", tID), path)
+		return nil
+	}
+	defer func() {
+		removeAll = os.RemoveAll
+	}()
+	// Expectations for triggering cleanup
+	now := mTask.GetKnownStatusTime()
+	taskStoppedDuration := 1 * time.Minute
+	mockTime.EXPECT().Now().Return(now).AnyTimes()
+	cleanupTimeTrigger := make(chan time.Time)
+	mockTime.EXPECT().After(gomock.Any()).Return(cleanupTimeTrigger)
+	go func() {
+		cleanupTimeTrigger <- now
+	}()
+
+	// Expectations to verify that the task gets removed
+	mockState.EXPECT().ContainerMapByArn(mTask.Arn).Return(map[string]*apicontainer.DockerContainer{container.Name: dockerContainer}, true)
+	mockClient.EXPECT().RemoveContainer(gomock.Any(), dockerContainer.DockerName, gomock.Any()).Return(nil)
+	mockImageManager.EXPECT().RemoveContainerReferenceFromImageState(container).Return(nil)
+	mockState.EXPECT().RemoveTask(mTask.Task)
+	mTask.cleanupTask(taskStoppedDuration)
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
The exec log dir is bind-mounted to agent container. 
ECS Agent will create a unique log path for each container in the exec enabled task on bind mounting to exec container
This path will be cleaned up once the task is stopped
`TODO`: revise the path once we know where the execAgent log dir will be mounted inside agent container. 

### Implementation details
Do a best effort to remove the exec log dir of the task and its children (each container's log destination) 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
