### PR TITLE
fix unit test failure

### DIFF
--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -3168,7 +3168,7 @@ func TestStartExecAgent(t *testing.T) {
 					},
 				},
 			},
-			ExecCommandAgentEnabled: tc.execCommandAgentEnabled,
+			ExecCommandAgentEnabledUnsafe: tc.execCommandAgentEnabled,
 		}
 
 		mTestTask := &managedTask{


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
In https://github.com/aws/amazon-ecs-agent/pull/2678, `ExecCommandAgentEnabled` was changed to `ExecCommandAgentEnabledUnsafe`. fixing this in a test that was added in a different PR.  

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

### Description for the changelog
N/A

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
