### PR TITLE
change agent exec log dir, add cleanup to integ test

### DIFF
--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -621,7 +621,7 @@ func (engine *DockerTaskEngine) deleteTask(task *apitask.Task) {
 		if tID, err := task.GetID(); err != nil {
 			seelog.Warnf("Task Engine[%s]: error getting task ID for ExecAgent logs cleanup: %v", task.Arn, err)
 		} else {
-			if err := removeAll(filepath.Join(execcmd.HostLogDir, tID)); err != nil {
+			if err := removeAll(filepath.Join(execcmd.ECSAgentExecLogDir, tID)); err != nil {
 				seelog.Warnf("Task Engine[%s]: unable to remove ExecAgent host logs for task: %v", task.Arn, err)
 			}
 		}

--- a/agent/engine/engine_sudo_linux_integ_test.go
+++ b/agent/engine/engine_sudo_linux_integ_test.go
@@ -16,50 +16,74 @@
 package engine
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/aws/amazon-ecs-agent/agent/api"
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	apitaskstatus "github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/containermetadata"
+	"github.com/aws/amazon-ecs-agent/agent/credentials"
+	"github.com/aws/amazon-ecs-agent/agent/data"
+	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
+	"github.com/aws/amazon-ecs-agent/agent/dockerclient/sdkclientfactory"
+	"github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
+	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
+	"github.com/aws/amazon-ecs-agent/agent/engine/execcmd"
+	"github.com/aws/amazon-ecs-agent/agent/eventstream"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	cgroup "github.com/aws/amazon-ecs-agent/agent/taskresource/cgroup/control"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/firelens"
 	taskresourcevolume "github.com/aws/amazon-ecs-agent/agent/taskresource/volume"
+	"github.com/aws/amazon-ecs-agent/agent/utils"
 	"github.com/aws/amazon-ecs-agent/agent/utils/ioutilwrapper"
+	"github.com/aws/amazon-ecs-agent/agent/utils/retry"
+	"github.com/cihub/seelog"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
+	"github.com/docker/docker/api/types"
 	dockercontainer "github.com/docker/docker/api/types/container"
+	sdkClient "github.com/docker/docker/client"
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+var (
+	endpoint = utils.DefaultIfBlank(os.Getenv(DockerEndpointEnvVariable), DockerDefaultEndpoint)
+)
+
 const (
-	testLogSenderImage = "amazonlinux:2"
-	testFluentbitImage = "amazon/aws-for-fluent-bit:latest"
-	testVolumeImage    = "127.0.0.1:51670/amazon/amazon-ecs-volumes-test:latest"
-	testCluster        = "testCluster"
-	validTaskArnPrefix = "arn:aws:ecs:region:account-id:task/"
-	testDataDir        = "/var/lib/ecs/data/"
-	testDataDirOnHost  = "/var/lib/ecs/"
-	testInstanceID     = "testInstanceID"
-	testTaskDefFamily  = "testFamily"
-	testTaskDefVersion = "1"
-	testECSRegion      = "us-east-1"
-	testLogGroupName   = "test-fluentbit"
-	testLogGroupPrefix = "firelens-fluentbit-"
+	testLogSenderImage           = "amazonlinux:2"
+	testFluentbitImage           = "amazon/aws-for-fluent-bit:latest"
+	testVolumeImage              = "127.0.0.1:51670/amazon/amazon-ecs-volumes-test:latest"
+	testCluster                  = "testCluster"
+	validTaskArnPrefix           = "arn:aws:ecs:region:account-id:task/"
+	testDataDir                  = "/var/lib/ecs/data/"
+	testDataDirOnHost            = "/var/lib/ecs/"
+	testInstanceID               = "testInstanceID"
+	testTaskDefFamily            = "testFamily"
+	testTaskDefVersion           = "1"
+	testECSRegion                = "us-east-1"
+	testLogGroupName             = "test-fluentbit"
+	testLogGroupPrefix           = "firelens-fluentbit-"
+	testExecCommandAgentImage    = "127.0.0.1:51670/amazon/amazon-ecs-exec-command-agent-test:latest"
+	testExecCommandAgentSleepBin = "/sleep"
+	testExecCommandAgentKillBin  = "/kill"
 )
 
 func TestStartStopWithCgroup(t *testing.T) {
@@ -314,4 +338,265 @@ func waitCloudwatchLogs(client *cloudwatchlogs.CloudWatchLogs, params *cloudwatc
 		time.Sleep(time.Second)
 	}
 	return nil, fmt.Errorf("timeout waiting for the logs to be sent to cloud watch logs")
+}
+
+// TestExecCommandAgent validates ExecCommandAgent start and monitor processes. The algorithm to test is as follows:
+// 1. Pre-setup: the make file in ../../misc/exec-command-agent-test will create a special docker sleeper image
+// based on a scratch image. This image simulates a customer image and contains pre-baked /sleep and /kill binaries.
+// /sleep is the main process used to launch the test container; /kill is an application that kills a process running in
+// the container given a PID.
+// The make file will also create a fake amazon-ssm-agent which is a go program that only sleeps for a certain time specified.
+//
+// 2. Setup: Create a new docker task engine with a modified path pointing to our fake amazon-ssm-agent binary
+// 3. Create and start our test task using our test image
+// 4. Wait for the task to start and verify that the expected ExecCommandAgent bind mounts are present in the containers
+// 5. Verify that our fake amazon-ssm-agent was started inside the container using docker top, and retrieve its PID
+// 6. Kill the fake amazon-ssm-agent using the PID retrieved in previous step
+// 7. Verify that the engine restarted our fake amazon-ssm-agent by doing docker top one more time (a new PID should popup)
+func TestExecCommandAgent(t *testing.T) {
+	const (
+		testTaskId        = "exec-command-agent-test-task"
+		testContainerName = "exec-command-agent-test-container"
+		sleepFor          = time.Minute * 2
+	)
+
+	client, err := sdkClient.NewClientWithOpts(sdkClient.WithHost(endpoint), sdkClient.WithVersion(sdkclientfactory.GetDefaultVersion().String()))
+	require.NoError(t, err, "Creating go docker client failed")
+
+	testExecCmdHostBinDir, err := filepath.Abs("../../misc/exec-command-agent-test")
+	require.NoError(t, err)
+
+	taskEngine, done, _ := setupEngineForExecCommandAgent(t, testExecCmdHostBinDir)
+	stateChangeEvents := taskEngine.StateChangeEvents()
+	defer done()
+
+	testTask := createTestExecCommandAgentTask(testTaskId, testContainerName, sleepFor)
+	execAgentLogPath := filepath.Join("/log/exec", testTaskId)
+	err = os.MkdirAll(execAgentLogPath, 0644)
+	require.NoError(t, err, "error creating execAgent log file")
+	_, err = os.Stat(execAgentLogPath)
+	require.NoError(t, err, "execAgent log dir doesn't exist")
+	go taskEngine.AddTask(testTask)
+
+	verifyContainerRunningStateChange(t, taskEngine)
+	verifyTaskRunningStateChange(t, taskEngine)
+
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
+	containerMap, _ := taskEngine.(*DockerTaskEngine).state.ContainerMapByArn(testTask.Arn)
+	cid := containerMap[testTask.Containers[0].Name].DockerID
+
+	verifyExecCmdAgentExpectedMounts(t, ctx, client, testTaskId, cid, testContainerName, testExecCmdHostBinDir)
+	pidA := verifyMockExecCommandAgentIsRunning(t, client, cid)
+	seelog.Infof("Verified mock ExecCommandAgent is running (pidA=%s)", pidA)
+	killMockExecCommandAgent(t, client, cid, pidA)
+	seelog.Infof("kill signal sent to ExecCommandAgent (pidA=%s)", pidA)
+	verifyMockExecCommandAgentIsStopped(t, client, cid, pidA)
+	seelog.Infof("Verified mock ExecCommandAgent was killed (pidA=%s)", pidA)
+	pidB := verifyMockExecCommandAgentIsRunning(t, client, cid)
+	seelog.Infof("Verified mock ExecCommandAgent was restarted (pidB=%s)", pidB)
+	require.NotEqual(t, pidA, pidB, "ExecCommandAgent PID did not change after restart")
+
+	taskUpdate := createTestExecCommandAgentTask(testTaskId, testContainerName, sleepFor)
+	taskUpdate.SetDesiredStatus(apitaskstatus.TaskStopped)
+	go taskEngine.AddTask(taskUpdate)
+
+	ctx, cancel = context.WithTimeout(context.Background(), time.Second*20)
+	go func() {
+		verifyTaskIsStopped(stateChangeEvents, testTask)
+		cancel()
+	}()
+
+	<-ctx.Done()
+	require.NotEqual(t, context.DeadlineExceeded, ctx.Err(), "Timed out waiting for task (%s) to stop", testTaskId)
+	assert.NotNil(t, testTask.Containers[0].GetKnownExitCode(), "No exit code found")
+	taskEngine.(*DockerTaskEngine).deleteTask(testTask)
+	_, err = os.Stat(execAgentLogPath)
+	assert.True(t, os.IsNotExist(err), "execAgent log cleanup failed")
+}
+
+func createTestExecCommandAgentTask(taskId, containerName string, sleepFor time.Duration) *apitask.Task {
+	testTask := createTestTask("arn:aws:ecs:us-west-2:1234567890:task/" + taskId)
+	testTask.ExecCommandAgentEnabledUnsafe = true
+	testTask.PIDMode = ecs.PidModeHost
+	testTask.Containers[0].Name = containerName
+	testTask.Containers[0].Image = testExecCommandAgentImage
+	testTask.Containers[0].Command = []string{testExecCommandAgentSleepBin, "-time=" + sleepFor.String()}
+	return testTask
+}
+
+// setupEngineForExecCommandAgent creates a new TaskEngine with a custom execcmd.Manager that will attempt to read the
+// host binaries from the directory passed as parameter (as opposed to the default directory).
+// Additionally, it overrides the engine's monitorExecAgentsInterval to one second.
+func setupEngineForExecCommandAgent(t *testing.T, hostBinDir string) (TaskEngine, func(), credentials.Manager) {
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
+	skipIntegTestIfApplicable(t)
+
+	cfg := defaultTestConfigIntegTest()
+	sdkClientFactory := sdkclientfactory.NewFactory(ctx, dockerEndpoint)
+	dockerClient, err := dockerapi.NewDockerGoClient(sdkClientFactory, cfg, context.Background())
+	if err != nil {
+		t.Fatalf("Error creating Docker client: %v", err)
+	}
+	credentialsManager := credentials.NewManager()
+	state := dockerstate.NewTaskEngineState()
+	imageManager := NewImageManager(cfg, dockerClient, state)
+	imageManager.SetDataClient(data.NewNoopClient())
+	metadataManager := containermetadata.NewManager(dockerClient, cfg)
+	execCmdMgr := execcmd.NewManagerWithBinDir(hostBinDir)
+
+	taskEngine := NewDockerTaskEngine(cfg, dockerClient, credentialsManager,
+		eventstream.NewEventStream("ENGINEINTEGTEST", context.Background()), imageManager, state, metadataManager,
+		nil, execCmdMgr)
+	taskEngine.monitorExecAgentsInterval = time.Second
+	taskEngine.MustInit(context.TODO())
+	return taskEngine, func() {
+		taskEngine.Shutdown()
+	}, credentialsManager
+}
+
+func verifyExecCmdAgentExpectedMounts(t *testing.T, ctx context.Context, client *sdkClient.Client, testTaskId, containerId, containerName, testExecCmdHostBinDir string) {
+	inspectState, _ := client.ContainerInspect(ctx, containerId)
+	expectedMounts := []struct {
+		source   string
+		dest     string
+		readOnly bool
+	}{
+		{
+			source:   filepath.Join(testExecCmdHostBinDir, execcmd.BinName),
+			dest:     filepath.Join(execcmd.ContainerBinDir, execcmd.BinName),
+			readOnly: true,
+		},
+		{
+			source:   filepath.Join(testExecCmdHostBinDir, execcmd.SessionWorkerBinName),
+			dest:     filepath.Join(execcmd.ContainerBinDir, execcmd.SessionWorkerBinName),
+			readOnly: true,
+		},
+		{
+			source:   execcmd.HostCertFile,
+			dest:     execcmd.ContainerCertFile,
+			readOnly: true,
+		},
+		{
+			source:   filepath.Join(testExecCmdHostBinDir, execcmd.ConfigFileName),
+			dest:     execcmd.ContainerConfigFile,
+			readOnly: true,
+		},
+		{
+			source:   filepath.Join(execcmd.HostLogDir, testTaskId, containerName),
+			dest:     execcmd.ContainerLogDir,
+			readOnly: false,
+		},
+	}
+
+	for _, em := range expectedMounts {
+		var found *types.MountPoint
+		for _, m := range inspectState.Mounts {
+			if m.Source == em.source {
+				found = &m
+				break
+			}
+		}
+		require.NotNil(t, found, "Expected mount point not found (%s)", em.source)
+		require.Equal(t, em.dest, found.Destination, "Destination for mount point (%s) is invalid expected: %s, actual: %s", em.source, em.dest, found.Destination)
+		if em.readOnly {
+			require.Equal(t, "ro", found.Mode, "Destination for mount point (%s) should be read only", em.source)
+		} else {
+			require.True(t, found.RW, "Destination for mount point (%s) should be writable", em.source)
+		}
+		require.Equal(t, "bind", string(found.Type), "Destination for mount point (%s) is not of type bind", em.source)
+	}
+
+	require.Equal(t, len(expectedMounts), len(inspectState.Mounts), "Wrong number of bind mounts detected in container (%s)", containerName)
+}
+
+func verifyMockExecCommandAgentIsRunning(t *testing.T, client *sdkClient.Client, containerId string) string {
+	return verifyMockExecCommandAgentStatus(t, client, containerId, "", true)
+}
+
+func verifyMockExecCommandAgentIsStopped(t *testing.T, client *sdkClient.Client, containerId, pid string) {
+	verifyMockExecCommandAgentStatus(t, client, containerId, pid, false)
+}
+
+func verifyMockExecCommandAgentStatus(t *testing.T, client *sdkClient.Client, containerId, expectedPid string, checkIsRunning bool) string {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+	res := make(chan string, 1)
+	go func() {
+		for {
+			top, err := client.ContainerTop(ctx, containerId, nil)
+			if err != nil {
+				continue
+			}
+			cmdPos := -1
+			pidPos := -1
+			for i, t := range top.Titles {
+				if strings.ToUpper(t) == "CMD" {
+					cmdPos = i
+				}
+				if strings.ToUpper(t) == "PID" {
+					pidPos = i
+				}
+
+			}
+			require.NotEqual(t, -1, cmdPos, "CMD title not found in the container top response")
+			require.NotEqual(t, -1, pidPos, "PID title not found in the container top response")
+			for _, proc := range top.Processes {
+				if proc[cmdPos] == filepath.Join(execcmd.ContainerBinDir, execcmd.BinName) {
+					res <- proc[pidPos]
+					return
+				}
+			}
+
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(retry.AddJitter(time.Second, time.Second*5)):
+			}
+		}
+	}()
+
+	var (
+		isRunning bool
+		pid       string
+	)
+	select {
+	case <-ctx.Done():
+	case r := <-res:
+		if r != "" {
+			pid = r
+			isRunning = true
+			if expectedPid != "" && pid != expectedPid {
+				isRunning = false
+			}
+		}
+
+	}
+	require.Equal(t, checkIsRunning, isRunning, "ExecCmdAgent was not in the desired running-status")
+	return pid
+}
+
+func killMockExecCommandAgent(t *testing.T, client *sdkClient.Client, containerId, pid string) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+	create, err := client.ContainerExecCreate(ctx, containerId, types.ExecConfig{
+		Detach: true,
+		Cmd:    []string{testExecCommandAgentKillBin, "-pid=" + pid},
+	})
+	require.NoError(t, err)
+
+	err = client.ContainerExecStart(ctx, create.ID, types.ExecStartCheck{
+		Detach: true,
+	})
+	require.NoError(t, err)
+}
+
+func verifyTaskRunningStateChange(t *testing.T, taskEngine TaskEngine) {
+	stateChangeEvents := taskEngine.StateChangeEvents()
+	event := <-stateChangeEvents
+	assert.Equal(t, event.(api.TaskStateChange).Status, apitaskstatus.TaskRunning,
+		"Expected task to be RUNNING")
 }

--- a/agent/engine/engine_unix_integ_test.go
+++ b/agent/engine/engine_unix_integ_test.go
@@ -40,44 +40,32 @@ import (
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	apitaskstatus "github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/agent/config"
-	"github.com/aws/amazon-ecs-agent/agent/containermetadata"
-	"github.com/aws/amazon-ecs-agent/agent/credentials"
-	"github.com/aws/amazon-ecs-agent/agent/data"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/sdkclientfactory"
 	"github.com/aws/amazon-ecs-agent/agent/ec2"
-	"github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
-	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
-	"github.com/aws/amazon-ecs-agent/agent/engine/execcmd"
-	"github.com/aws/amazon-ecs-agent/agent/eventstream"
 	"github.com/aws/amazon-ecs-agent/agent/statechange"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	taskresourcevolume "github.com/aws/amazon-ecs-agent/agent/taskresource/volume"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
-	"github.com/aws/amazon-ecs-agent/agent/utils/retry"
 	"github.com/aws/amazon-ecs-agent/agent/utils/ttime"
 	"github.com/aws/aws-sdk-go/aws"
 	sdkClient "github.com/docker/docker/client"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 const (
-	testRegistryHost             = "127.0.0.1:51670"
-	testBusyboxImage             = testRegistryHost + "/busybox:latest"
-	testAuthRegistryHost         = "127.0.0.1:51671"
-	testAuthRegistryImage        = "127.0.0.1:51671/amazon/amazon-ecs-netkitten:latest"
-	testVolumeImage              = "127.0.0.1:51670/amazon/amazon-ecs-volumes-test:latest"
-	testExecCommandAgentImage    = "127.0.0.1:51670/amazon/amazon-ecs-exec-command-agent-test:latest"
-	testExecCommandAgentSleepBin = "/sleep"
-	testExecCommandAgentKillBin  = "/kill"
-	testPIDNamespaceImage        = "127.0.0.1:51670/amazon/amazon-ecs-pid-namespace-test:latest"
-	testIPCNamespaceImage        = "127.0.0.1:51670/amazon/amazon-ecs-ipc-namespace-test:latest"
-	testUbuntuImage              = "127.0.0.1:51670/ubuntu:latest"
-	testFluentdImage             = "127.0.0.1:51670/amazon/fluentd:latest"
-	testAuthUser                 = "user"
-	testAuthPass                 = "swordfish"
+	testRegistryHost      = "127.0.0.1:51670"
+	testBusyboxImage      = testRegistryHost + "/busybox:latest"
+	testAuthRegistryHost  = "127.0.0.1:51671"
+	testAuthRegistryImage = "127.0.0.1:51671/amazon/amazon-ecs-netkitten:latest"
+	testVolumeImage       = "127.0.0.1:51670/amazon/amazon-ecs-volumes-test:latest"
+	testPIDNamespaceImage = "127.0.0.1:51670/amazon/amazon-ecs-pid-namespace-test:latest"
+	testIPCNamespaceImage = "127.0.0.1:51670/amazon/amazon-ecs-ipc-namespace-test:latest"
+	testUbuntuImage       = "127.0.0.1:51670/ubuntu:latest"
+	testFluentdImage      = "127.0.0.1:51670/amazon/fluentd:latest"
+	testAuthUser          = "user"
+	testAuthPass          = "swordfish"
 
 	// Search for the running process
 	testPIDNamespaceCommand         = "if [ `ps ax | grep pidNamespaceTest | grep -vc grep` -gt 0 ]; then exit 1; else exit 2; fi;"
@@ -1601,251 +1589,4 @@ func TestDockerExecAPI(t *testing.T) {
 	}()
 
 	waitFinished(t, finished, testTimeout)
-}
-
-// TestExecCommandAgent validates ExecCommandAgent start and monitor processes. The algorithm to test is as follows:
-// 1. Pre-setup: the make file in ../../misc/exec-command-agent-test will create a special docker sleeper image
-// based on a scratch image. This image simulates a customer image and contains pre-baked /sleep and /kill binaries.
-// /sleep is the main process used to launch the test container; /kill is an application that kills a process running in
-// the container given a PID.
-// The make file will also create a fake amazon-ssm-agent which is a go program that only sleeps for a certain time specified.
-//
-// 2. Setup: Create a new docker task engine with a modified path pointing to our fake amazon-ssm-agent binary
-// 3. Create and start our test task using our test image
-// 4. Wait for the task to start and verify that the expected ExecCommandAgent bind mounts are present in the containers
-// 5. Verify that our fake amazon-ssm-agent was started inside the container using docker top, and retrieve its PID
-// 6. Kill the fake amazon-ssm-agent using the PID retrieved in previous step
-// 7. Verify that the engine restarted our fake amazon-ssm-agent by doing docker top one more time (a new PID should popup)
-func TestExecCommandAgent(t *testing.T) {
-	const (
-		testTaskId        = "exec-command-agent-test-task"
-		testContainerName = "exec-command-agent-test-container"
-		sleepFor          = time.Minute * 2
-	)
-
-	client, err := sdkClient.NewClientWithOpts(sdkClient.WithHost(endpoint), sdkClient.WithVersion(sdkclientfactory.GetDefaultVersion().String()))
-	require.NoError(t, err, "Creating go docker client failed")
-
-	testExecCmdHostBinDir, err := filepath.Abs("../../misc/exec-command-agent-test")
-	require.NoError(t, err)
-
-	taskEngine, done, _ := setupEngineForExecCommandAgent(t, testExecCmdHostBinDir)
-	stateChangeEvents := taskEngine.StateChangeEvents()
-	defer done()
-
-	testTask := createTestExecCommandAgentTask(testTaskId, testContainerName, sleepFor)
-
-	go taskEngine.AddTask(testTask)
-
-	verifyContainerRunningStateChange(t, taskEngine)
-	verifyTaskRunningStateChange(t, taskEngine)
-
-	ctx, cancel := context.WithCancel(context.TODO())
-	defer cancel()
-
-	containerMap, _ := taskEngine.(*DockerTaskEngine).state.ContainerMapByArn(testTask.Arn)
-	cid := containerMap[testTask.Containers[0].Name].DockerID
-
-	verifyExecCmdAgentExpectedMounts(t, ctx, client, testTaskId, cid, testContainerName, testExecCmdHostBinDir)
-	pidA := verifyMockExecCommandAgentIsRunning(t, client, cid)
-	seelog.Infof("Verified mock ExecCommandAgent is running (pidA=%s)", pidA)
-	killMockExecCommandAgent(t, client, cid, pidA)
-	seelog.Infof("kill signal sent to ExecCommandAgent (pidA=%s)", pidA)
-	verifyMockExecCommandAgentIsStopped(t, client, cid, pidA)
-	seelog.Infof("Verified mock ExecCommandAgent was killed (pidA=%s)", pidA)
-	pidB := verifyMockExecCommandAgentIsRunning(t, client, cid)
-	seelog.Infof("Verified mock ExecCommandAgent was restarted (pidB=%s)", pidB)
-	require.NotEqual(t, pidA, pidB, "ExecCommandAgent PID did not change after restart")
-
-	taskUpdate := createTestExecCommandAgentTask(testTaskId, testContainerName, sleepFor)
-	taskUpdate.SetDesiredStatus(apitaskstatus.TaskStopped)
-	go taskEngine.AddTask(taskUpdate)
-
-	ctx, cancel = context.WithTimeout(context.Background(), time.Second*20)
-	go func() {
-		verifyTaskIsStopped(stateChangeEvents, testTask)
-		cancel()
-	}()
-
-	<-ctx.Done()
-	require.NotEqual(t, context.DeadlineExceeded, ctx.Err(), "Timed out waiting for task (%s) to stop", testTaskId)
-	assert.NotNil(t, testTask.Containers[0].GetKnownExitCode(), "No exit code found")
-}
-
-func createTestExecCommandAgentTask(taskId, containerName string, sleepFor time.Duration) *apitask.Task {
-	testTask := createTestTask("arn:aws:ecs:us-west-2:1234567890:task/" + taskId)
-	testTask.ExecCommandAgentEnabledUnsafe = true
-	testTask.PIDMode = ecs.PidModeHost
-	testTask.Containers[0].Name = containerName
-	testTask.Containers[0].Image = testExecCommandAgentImage
-	testTask.Containers[0].Command = []string{testExecCommandAgentSleepBin, "-time=" + sleepFor.String()}
-	return testTask
-}
-
-// setupEngineForExecCommandAgent creates a new TaskEngine with a custom execcmd.Manager that will attempt to read the
-// host binaries from the directory passed as parameter (as opposed to the default directory).
-// Additionally, it overrides the engine's monitorExecAgentsInterval to one second.
-func setupEngineForExecCommandAgent(t *testing.T, hostBinDir string) (TaskEngine, func(), credentials.Manager) {
-	ctx, cancel := context.WithCancel(context.TODO())
-	defer cancel()
-
-	skipIntegTestIfApplicable(t)
-
-	cfg := defaultTestConfigIntegTest()
-	sdkClientFactory := sdkclientfactory.NewFactory(ctx, dockerEndpoint)
-	dockerClient, err := dockerapi.NewDockerGoClient(sdkClientFactory, cfg, context.Background())
-	if err != nil {
-		t.Fatalf("Error creating Docker client: %v", err)
-	}
-	credentialsManager := credentials.NewManager()
-	state := dockerstate.NewTaskEngineState()
-	imageManager := NewImageManager(cfg, dockerClient, state)
-	imageManager.SetDataClient(data.NewNoopClient())
-	metadataManager := containermetadata.NewManager(dockerClient, cfg)
-	execCmdMgr := execcmd.NewManagerWithBinDir(hostBinDir)
-
-	taskEngine := NewDockerTaskEngine(cfg, dockerClient, credentialsManager,
-		eventstream.NewEventStream("ENGINEINTEGTEST", context.Background()), imageManager, state, metadataManager,
-		nil, execCmdMgr)
-	taskEngine.monitorExecAgentsInterval = time.Second
-	taskEngine.MustInit(context.TODO())
-	return taskEngine, func() {
-		taskEngine.Shutdown()
-	}, credentialsManager
-}
-
-func verifyExecCmdAgentExpectedMounts(t *testing.T, ctx context.Context, client *sdkClient.Client, testTaskId, containerId, containerName, testExecCmdHostBinDir string) {
-	inspectState, _ := client.ContainerInspect(ctx, containerId)
-	expectedMounts := []struct {
-		source   string
-		dest     string
-		readOnly bool
-	}{
-		{
-			source:   filepath.Join(testExecCmdHostBinDir, execcmd.BinName),
-			dest:     filepath.Join(execcmd.ContainerBinDir, execcmd.BinName),
-			readOnly: true,
-		},
-		{
-			source:   filepath.Join(testExecCmdHostBinDir, execcmd.SessionWorkerBinName),
-			dest:     filepath.Join(execcmd.ContainerBinDir, execcmd.SessionWorkerBinName),
-			readOnly: true,
-		},
-		{
-			source:   execcmd.HostCertFile,
-			dest:     execcmd.ContainerCertFile,
-			readOnly: true,
-		},
-		{
-			source:   filepath.Join(testExecCmdHostBinDir, execcmd.ConfigFileName),
-			dest:     execcmd.ContainerConfigFile,
-			readOnly: true,
-		},
-		{
-			source:   filepath.Join(execcmd.HostLogDir, testTaskId, containerName),
-			dest:     execcmd.ContainerLogDir,
-			readOnly: false,
-		},
-	}
-
-	for _, em := range expectedMounts {
-		var found *types.MountPoint
-		for _, m := range inspectState.Mounts {
-			if m.Source == em.source {
-				found = &m
-				break
-			}
-		}
-		require.NotNil(t, found, "Expected mount point not found (%s)", em.source)
-		require.Equal(t, em.dest, found.Destination, "Destination for mount point (%s) is invalid expected: %s, actual: %s", em.source, em.dest, found.Destination)
-		if em.readOnly {
-			require.Equal(t, "ro", found.Mode, "Destination for mount point (%s) should be read only", em.source)
-		} else {
-			require.True(t, found.RW, "Destination for mount point (%s) should be writable", em.source)
-		}
-		require.Equal(t, "bind", string(found.Type), "Destination for mount point (%s) is not of type bind", em.source)
-	}
-
-	require.Equal(t, len(expectedMounts), len(inspectState.Mounts), "Wrong number of bind mounts detected in container (%s)", containerName)
-}
-
-func verifyMockExecCommandAgentIsRunning(t *testing.T, client *sdkClient.Client, containerId string) string {
-	return verifyMockExecCommandAgentStatus(t, client, containerId, "", true)
-}
-
-func verifyMockExecCommandAgentIsStopped(t *testing.T, client *sdkClient.Client, containerId, pid string) {
-	verifyMockExecCommandAgentStatus(t, client, containerId, pid, false)
-}
-
-func verifyMockExecCommandAgentStatus(t *testing.T, client *sdkClient.Client, containerId, expectedPid string, checkIsRunning bool) string {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
-	defer cancel()
-	res := make(chan string, 1)
-	go func() {
-		for {
-			top, err := client.ContainerTop(ctx, containerId, nil)
-			if err != nil {
-				continue
-			}
-			cmdPos := -1
-			pidPos := -1
-			for i, t := range top.Titles {
-				if strings.ToUpper(t) == "CMD" {
-					cmdPos = i
-				}
-				if strings.ToUpper(t) == "PID" {
-					pidPos = i
-				}
-
-			}
-			require.NotEqual(t, -1, cmdPos, "CMD title not found in the container top response")
-			require.NotEqual(t, -1, pidPos, "PID title not found in the container top response")
-			for _, proc := range top.Processes {
-				if proc[cmdPos] == filepath.Join(execcmd.ContainerBinDir, execcmd.BinName) {
-					res <- proc[pidPos]
-					return
-				}
-			}
-
-			select {
-			case <-ctx.Done():
-				return
-			case <-time.After(retry.AddJitter(time.Second, time.Second*5)):
-			}
-		}
-	}()
-
-	var (
-		isRunning bool
-		pid       string
-	)
-	select {
-	case <-ctx.Done():
-	case r := <-res:
-		if r != "" {
-			pid = r
-			isRunning = true
-			if expectedPid != "" && pid != expectedPid {
-				isRunning = false
-			}
-		}
-
-	}
-	require.Equal(t, checkIsRunning, isRunning, "ExecCmdAgent was not in the desired running-status")
-	return pid
-}
-
-func killMockExecCommandAgent(t *testing.T, client *sdkClient.Client, containerId, pid string) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
-	defer cancel()
-	create, err := client.ContainerExecCreate(ctx, containerId, types.ExecConfig{
-		Detach: true,
-		Cmd:    []string{testExecCommandAgentKillBin, "-pid=" + pid},
-	})
-	require.NoError(t, err)
-
-	err = client.ContainerExecStart(ctx, create.ID, types.ExecStartCheck{
-		Detach: true,
-	})
-	require.NoError(t, err)
 }

--- a/agent/engine/execcmd/manager_init_task_linux.go
+++ b/agent/engine/execcmd/manager_init_task_linux.go
@@ -36,6 +36,7 @@ const (
 	// TODO: [ecs-exec] decide if this needs to be configurable or put in a specific place in our optimized AMIs
 	HostLogDir          = "/var/log/ecs/exec"
 	ContainerLogDir     = "/var/log/amazon/ssm"
+	ECSAgentExecLogDir  = "/log/exec"
 	HostCertFile        = "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
 	ContainerCertFile   = "/etc/ssl/certs/ca-certificates.crt"
 	ContainerConfigFile = "/etc/amazon/ssm/amazon-ssm-agent.json"

--- a/agent/engine/execcmd/manager_unsupported.go
+++ b/agent/engine/execcmd/manager_unsupported.go
@@ -23,9 +23,9 @@ import (
 )
 
 const (
-	// HostLogDir here is used used while cleaning up exec logs when task exits.
+	// ECSAgentExecLogDir here is used used while cleaning up exec logs when task exits.
 	// When this path is empty, nothing is cleaned up for unsupported platforms.
-	HostLogDir = ""
+	ECSAgentExecLogDir = ""
 )
 
 // Note: exec cmd agent is a linux-only feature, thus implemented here as a no-op.

--- a/agent/engine/task_manager_unix_test.go
+++ b/agent/engine/task_manager_unix_test.go
@@ -429,7 +429,7 @@ func TestCleanupExecEnabledTask(t *testing.T) {
 	}
 	tID, _ := mTask.Task.GetID()
 	removeAll = func(path string) error {
-		assert.Equal(t, fmt.Sprintf("/var/log/ecs/exec/%s", tID), path)
+		assert.Equal(t, fmt.Sprintf("/log/exec/%s", tID), path)
 		return nil
 	}
 	defer func() {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Things in the PR: 
- Change ExecAgent logs dir in Agent from `/var/log/ecs/exec` to `/log/exec` as per https://github.com/aws/amazon-ecs-init/pull/364 ; cleanup code and unit tests are updated accordingly 
- Add cleanup exec logs check to existing `TestExecCommandAgent` integration test
- ~~commit from https://github.com/aws/amazon-ecs-agent/pull/2684 , but it will be removed once that is merged and this branch is rebased.~~

### Implementation details
The integ test creates a dummy exec agent log location for the test task at `/log/exec/task-id`. 
At the end of the test, `deleteTask` is called and it is verified that this exec log directory is removed successfully. 
Creating the exec log dir needs root permission(sudo), so the whole test and its helper methods have been moved from `agent/engine/engine_unix_integ_test.go` to `agent/engine/engine_sudo_linux_integ_test.go` file. 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
```
sudo -E go test -count=1 -v -cover -race -timeout=10m -tags sudo ./agent/engine/... -test.run=TestExecCommandAgent
=== RUN   TestExecCommandAgent
--- PASS: TestExecCommandAgent (4.17s)
```

New tests cover the changes: yes

### Description for the changelog
N/A

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
