### PR TITLE
add check for execute-command capability and populate attribute if applicable

### DIFF
--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -374,15 +374,12 @@ func (agent *ecsAgent) appendExecCapabilities(capabilities []*ecs.Attribute) ([]
 	if err != nil {
 		return capabilities, err
 	}
-	// use raw string for regular expression
+	// use raw string for regular expression to avoid escaping backslash (\)
 	var validSsmVersion = regexp.MustCompile(`^\d+(\.\d+)*$`)
 	for _, binFolder := range binFolders {
-		// exclude directories that don't conform to valid ssm versions
-		matched := validSsmVersion.Match([]byte(binFolder))
-		if !matched {
+		if matched := validSsmVersion.Match([]byte(binFolder)); !matched {
 			continue
 		}
-		// exclude ssm version in deny-list
 		if _, found := capabilityExecInvalidSsmVersions[binFolder]; found {
 			continue
 		}

--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -103,6 +103,8 @@ var (
 	capabilityExecRequiredCerts = []string{
 		"tls-ca-bundle.pem",
 	}
+	// use empty struct as value type to simulate set
+	capabilityExecInvalidSsmVersions = map[string]struct{}{}
 
 	pathExists        = defaultPathExists
 	getSubDirectories = defaultGetSubDirectories
@@ -378,6 +380,10 @@ func (agent *ecsAgent) appendExecCapabilities(capabilities []*ecs.Attribute) ([]
 		// exclude directories that don't conform to valid ssm versions
 		matched := validSsmVersion.Match([]byte(binFolder))
 		if !matched {
+			continue
+		}
+		// exclude ssm version in deny-list
+		if _, found := capabilityExecInvalidSsmVersions[binFolder]; found {
 			continue
 		}
 

--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -17,6 +17,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"regexp"
 
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient"
@@ -371,7 +372,15 @@ func (agent *ecsAgent) appendExecCapabilities(capabilities []*ecs.Attribute) ([]
 	if err != nil {
 		return capabilities, err
 	}
+	// use raw string for regular expression
+	var validSsmVersion = regexp.MustCompile(`^\d+(\.\d+)*$`)
 	for _, binFolder := range binFolders {
+		// exclude directories that don't conform to valid ssm versions
+		matched := validSsmVersion.Match([]byte(binFolder))
+		if !matched {
+			continue
+		}
+
 		// check for the same set of binaries for all versions for now
 		// change this if future versions of ssm agent require different binaries
 		versionSubDirectory := filepath.Join(binDir, binFolder)

--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -93,11 +93,11 @@ var (
 		// ecs agent version 1.39.0 supports bulk loading env vars through environmentFiles in S3
 		capabilityEnvFilesS3,
 	}
-	capabilityExecuteCommandRequiredBinaries = []string{
+	capabilityExecRequiredBinaries = []string{
 		"amazon-ssm-agent",
 		"ssm-session-worker",
 	}
-	capabilityExecuteCommandRequiredCerts = []string{
+	capabilityExecRequiredCerts = []string{
 		"tls-ca-bundle.pem",
 	}
 
@@ -346,15 +346,15 @@ func (agent *ecsAgent) appendExecCapabilities(capabilities []*ecs.Attribute) ([]
 	// for an instance to be exec-enabled, it needs resources needed by SSM (binaries, configuration files and certs)
 	// the following bind mounts are defined in ecs-init and added to the ecs-agent container
 
-	capabilityExecuteCommandRootDir := filepath.Join(capabilityDepsRootDir, capabilityExec)
-	binDir := filepath.Join(capabilityExecuteCommandRootDir, capabilityExecBinRelativePath)
-	configDir := filepath.Join(capabilityExecuteCommandRootDir, capabilityExecConfigRelativePath)
-	certsDir := filepath.Join(capabilityExecuteCommandRootDir, capabilityExecCertsRelativePath)
+	capabilityExecRootDir := filepath.Join(capabilityDepsRootDir, capabilityExec)
+	binDir := filepath.Join(capabilityExecRootDir, capabilityExecBinRelativePath)
+	configDir := filepath.Join(capabilityExecRootDir, capabilityExecConfigRelativePath)
+	certsDir := filepath.Join(capabilityExecRootDir, capabilityExecCertsRelativePath)
 
 	dependencies := map[string][]string{
-		binDir:    capabilityExecuteCommandRequiredBinaries,
+		binDir:    capabilityExecRequiredBinaries,
 		configDir: []string{},
-		certsDir:  capabilityExecuteCommandRequiredCerts,
+		certsDir:  capabilityExecRequiredCerts,
 	}
 
 	for directory, files := range dependencies {

--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -64,11 +64,11 @@ const (
 	capabilityEFS                               = "efs"
 	capabilityEFSAuth                           = "efsAuth"
 	capabilityEnvFilesS3                        = "env-files.s3"
-	capabilityExecuteCommand                    = "execute-command"
-	capabilityDepsRootDir                       = "/capabilities"
-	capabilityExecuteCommandBinRelativePath     = "bin"
-	capabilityExecuteCommandConfigRelativePath  = "config"
-	capabilityExecuteCommandCertsRelativePath   = "certs"
+	capabilityExec                              = "execute-command"
+	capabilityDepsRootDir                       = "/managed-agents"
+	capabilityExecBinRelativePath               = "bin"
+	capabilityExecConfigRelativePath            = "config"
+	capabilityExecCertsRelativePath             = "certs"
 )
 
 var (
@@ -346,10 +346,10 @@ func (agent *ecsAgent) appendExecCapabilities(capabilities []*ecs.Attribute) ([]
 	// for an instance to be exec-enabled, it needs resources needed by SSM (binaries, configuration files and certs)
 	// the following bind mounts are defined in ecs-init and added to the ecs-agent container
 
-	capabilityExecuteCommandRootDir := filepath.Join(capabilityDepsRootDir, capabilityExecuteCommand)
-	binDir := filepath.Join(capabilityExecuteCommandRootDir, capabilityExecuteCommandBinRelativePath)
-	configDir := filepath.Join(capabilityExecuteCommandRootDir, capabilityExecuteCommandConfigRelativePath)
-	certsDir := filepath.Join(capabilityExecuteCommandRootDir, capabilityExecuteCommandCertsRelativePath)
+	capabilityExecuteCommandRootDir := filepath.Join(capabilityDepsRootDir, capabilityExec)
+	binDir := filepath.Join(capabilityExecuteCommandRootDir, capabilityExecBinRelativePath)
+	configDir := filepath.Join(capabilityExecuteCommandRootDir, capabilityExecConfigRelativePath)
+	certsDir := filepath.Join(capabilityExecuteCommandRootDir, capabilityExecCertsRelativePath)
 
 	dependencies := map[string][]string{
 		binDir:    capabilityExecuteCommandRequiredBinaries,
@@ -370,7 +370,7 @@ func (agent *ecsAgent) appendExecCapabilities(capabilities []*ecs.Attribute) ([]
 		}
 	}
 
-	return appendNameOnlyAttribute(capabilities, attributePrefix+capabilityExecuteCommand), nil
+	return appendNameOnlyAttribute(capabilities, attributePrefix+capabilityExec), nil
 }
 
 func defaultPathExists(path string, shouldBeDirectory bool) (bool, error) {

--- a/agent/app/agent_capability_test.go
+++ b/agent/app/agent_capability_test.go
@@ -779,6 +779,7 @@ func TestCapabilitiesExecuteCommand(t *testing.T) {
 		name                     string
 		pathExists               func(string, bool) (bool, error)
 		getSubDirectories        func(path string) ([]string, error)
+		invalidSsmVersions       map[string]struct{}
 		shouldHaveExecCapability bool
 	}{
 		{
@@ -796,7 +797,8 @@ func TestCapabilitiesExecuteCommand(t *testing.T) {
 		{
 			name:                     "execute-command capability should not be added if no valid ssm versions are found",
 			pathExists:               func(path string, shouldBeDirectory bool) (bool, error) { return true, nil },
-			getSubDirectories:        func(path string) ([]string, error) { return []string{"some_folder"}, nil },
+			getSubDirectories:        func(path string) ([]string, error) { return []string{"2.0.0.0", "some_folder"}, nil },
+			invalidSsmVersions:       map[string]struct{}{"2.0.0.0": struct{}{}},
 			shouldHaveExecCapability: false,
 		},
 		{
@@ -810,9 +812,12 @@ func TestCapabilitiesExecuteCommand(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			pathExists = tc.pathExists
 			getSubDirectories = tc.getSubDirectories
+			oCapabilityExecInvalidSsmVersions := capabilityExecInvalidSsmVersions
+			capabilityExecInvalidSsmVersions = tc.invalidSsmVersions
 			defer func() {
 				pathExists = defaultPathExists
 				getSubDirectories = defaultGetSubDirectories
+				capabilityExecInvalidSsmVersions = oCapabilityExecInvalidSsmVersions
 			}()
 
 			ctrl := gomock.NewController(t)


### PR DESCRIPTION
### Summary

This is part of the change for ecs-agent to detect if an EC2 instance is `exec-enabled`, in other words, if the instance has the `execute-command` capability. Related change in [amazon-ecs-init](https://github.com/aws/amazon-ecs-init): https://github.com/aws/amazon-ecs-init/pull/363

With dependencies for SSM bind mounted to the ecs-agent container, ecs-agent is responsible for checking if all required files exist. Those would include:

* SSM agent binaries
* SSM agent configuration directory (ecs-agent needs to write files into this directory)
* certs files for SSM agent

### Implementation details

Dependencies for the `execute-command` capability are bind mounted in the following structure:

```
/capabilities/execute-command/
|-- bin
    |-- amazon-ssm-agent
    |-- ssm-session-worker
|-- config
|-- certs
    |-- tls-ca-bundle.pem
```

### Testing

Manual test:

start ecs-agent container with the `--ecs-attributes` flag and check if the new capability is added

New tests cover the changes: yes

* `TestCapabilitesExecuteCommand`
* `TestDefaultPathExistsd`

### Description for the changelog

check SSM dependencies bind mounted to the agent container and add capability if applicable

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
