### PR TITLE
Use different Golang version while building Agent for Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,12 @@ else
 	GOARCH=amd64
 endif
 
+ifeq (${TARGET_OS},windows)
+    GO_VERSION=1.12
+else
+    GO_VERSION=1.15
+endif
+
 all: docker
 
 # Dynamic go build; useful in that it does not have -a so it won't recompile
@@ -47,7 +53,7 @@ xplatform-build:
 
 BUILDER_IMAGE="amazon/amazon-ecs-agent-build:make"
 .builder-image-stamp: scripts/dockerfiles/Dockerfile.build
-	@docker build -f scripts/dockerfiles/Dockerfile.build -t $(BUILDER_IMAGE) .
+	@docker build --build-arg GO_VERSION=$(GO_VERSION) -f scripts/dockerfiles/Dockerfile.build -t $(BUILDER_IMAGE) .
 	touch .builder-image-stamp
 
 # 'build-in-docker' builds the agent within a dockerfile and saves it to the ./out
@@ -71,11 +77,17 @@ docker: certs build-in-docker pause-container-release cni-plugins .out-stamp
 	@docker build -f scripts/dockerfiles/Dockerfile.release -t "amazon/amazon-ecs-agent:make" .
 	@echo "Built Docker image \"amazon/amazon-ecs-agent:make\""
 
+ifeq (${TARGET_OS},windows)
+    BUILD="cleanbuild-${TARGET_OS}"
+else
+    BUILD=cleanbuild
+endif
+
 # 'docker-release' builds the agent from a clean snapshot of the git repo in
 # 'RELEASE' mode
 # TODO: make this idempotent
 docker-release: pause-container-release cni-plugins .out-stamp
-	@docker build -f scripts/dockerfiles/Dockerfile.cleanbuild -t "amazon/amazon-ecs-agent-cleanbuild:make" .
+	@docker build --build-arg GO_VERSION=${GO_VERSION} -f scripts/dockerfiles/Dockerfile.cleanbuild -t "amazon/amazon-ecs-agent-${BUILD}:make" .
 	@docker run --net=none \
 		--env TARGET_OS="${TARGET_OS}" \
 		--env LDFLAGS="-X github.com/aws/amazon-ecs-agent/agent/config.DefaultPauseContainerTag=$(PAUSE_CONTAINER_TAG) \
@@ -84,7 +96,7 @@ docker-release: pause-container-release cni-plugins .out-stamp
 		--volume "$(PWD)/out:/out" \
 		--volume "$(PWD):/src/amazon-ecs-agent" \
 		--rm \
-		"amazon/amazon-ecs-agent-cleanbuild:make"
+		"amazon/amazon-ecs-agent-${BUILD}:make"
 
 # Release packages our agent into a "scratch" based dockerfile
 release: certs docker-release
@@ -181,7 +193,7 @@ get-cni-sources:
 	git submodule update --init --recursive
 
 build-ecs-cni-plugins:
-	@docker build -f scripts/dockerfiles/Dockerfile.buildECSCNIPlugins -t "amazon/amazon-ecs-build-ecs-cni-plugins:make" .
+	@docker build --build-arg GO_VERSION=$(GO_VERSION) -f scripts/dockerfiles/Dockerfile.buildECSCNIPlugins -t "amazon/amazon-ecs-build-ecs-cni-plugins:make" .
 	docker run --rm --net=none \
 		-e GIT_SHORT_HASH=$(shell cd $(ECS_CNI_REPOSITORY_SRC_DIR) && git rev-parse --short=8 HEAD) \
 		-e GIT_PORCELAIN=$(shell cd $(ECS_CNI_REPOSITORY_SRC_DIR) && git status --porcelain 2> /dev/null | wc -l | sed 's/^ *//') \
@@ -192,7 +204,7 @@ build-ecs-cni-plugins:
 	@echo "Built amazon-ecs-cni-plugins successfully."
 
 build-vpc-cni-plugins:
-	@docker build --build-arg GOARCH=$(GOARCH) -f scripts/dockerfiles/Dockerfile.buildVPCCNIPlugins -t "amazon/amazon-ecs-build-vpc-cni-plugins:make" .
+	@docker build --build-arg GOARCH=$(GOARCH) --build-arg GO_VERSION=$(GO_VERSION) -f scripts/dockerfiles/Dockerfile.buildVPCCNIPlugins -t "amazon/amazon-ecs-build-vpc-cni-plugins:make" .
 	docker run --rm --net=none \
 		-e GIT_SHORT_HASH=$(shell cd $(VPC_CNI_REPOSITORY_SRC_DIR) && git rev-parse --short=8 HEAD) \
 		-u "$(USERID)" \
@@ -331,6 +343,7 @@ clean:
 	# ensure docker is running and we can talk to it, abort if not:
 	docker ps > /dev/null
 	-docker rmi $(BUILDER_IMAGE) "amazon/amazon-ecs-agent-cleanbuild:make"
+	-docker rmi $(BUILDER_IMAGE) "amazon/amazon-ecs-agent-cleanbuild-windows:make"
 	rm -f misc/certs/ca-certificates.crt &> /dev/null
 	rm -rf out/
 	-$(MAKE) -C $(ECS_CNI_REPOSITORY_SRC_DIR) clean

--- a/scripts/dockerfiles/Dockerfile.build
+++ b/scripts/dockerfiles/Dockerfile.build
@@ -11,7 +11,8 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-FROM golang:1.12
+ARG GO_VERSION
+FROM golang:${GO_VERSION}
 MAINTAINER Amazon Web Services, Inc.
 
 ENV XDG_CACHE_HOME /tmp

--- a/scripts/dockerfiles/Dockerfile.buildECSCNIPlugins
+++ b/scripts/dockerfiles/Dockerfile.buildECSCNIPlugins
@@ -11,7 +11,8 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-FROM golang:1.15
+ARG GO_VERSION
+FROM golang:${GO_VERSION}
 MAINTAINER Amazon Web Services, Inc.
 
 ENV XDG_CACHE_HOME /tmp

--- a/scripts/dockerfiles/Dockerfile.buildVPCCNIPlugins
+++ b/scripts/dockerfiles/Dockerfile.buildVPCCNIPlugins
@@ -11,7 +11,8 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-FROM golang:1.15
+ARG GO_VERSION
+FROM golang:${GO_VERSION}
 MAINTAINER Amazon Web Services, Inc.
 
 ARG GOARCH

--- a/scripts/dockerfiles/Dockerfile.cleanbuild
+++ b/scripts/dockerfiles/Dockerfile.cleanbuild
@@ -11,7 +11,8 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-FROM golang:1.15
+ARG GO_VERSION
+FROM golang:${GO_VERSION}
 MAINTAINER Amazon Web Services, Inc.
 
 ENV XDG_CACHE_HOME /tmp

--- a/scripts/dockerfiles/Dockerfile.test
+++ b/scripts/dockerfiles/Dockerfile.test
@@ -17,6 +17,7 @@
 # Because the Agent's tests include starting docker containers, it is necessary
 # to have both go and docker available in the testing environment.
 # It's easier to get go, so start with docker-in-docker and add go on top
+
 FROM jpetazzo/dind
 MAINTAINER Amazon Web Services, Inc.
 
@@ -32,7 +33,9 @@ RUN apt-get update && apt-get install -y \
 		--no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*
 
-ENV GOLANG_VERSION 1.15
+ARG GO_VERSION=1.15
+
+ENV GOLANG_VERSION ${GO_VERSION}
 ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
 ENV GOLANG_DOWNLOAD_SHA256 d7d1f1f88ddfe55840712dc1747f37a790cbcaa448f6c9cf51bbe10aa65442f5
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Use different Golang version while building Agent for Windows
### Implementation details
<!-- How are the changes implemented? -->
- In `Makefile`, target `docker-release` is modified to use different dockerfiles based on OS

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Tested the build produced by `make codebuild` on Windows2016. Agent joined the cluster successfully.

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
Bug - Fixed Makefile to use Go1.12 for Agent windows build
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
