### PR TITLE
add helper methods for creating ExecAgent Config file

### DIFF
--- a/agent/engine/engine_sudo_linux_integ_test.go
+++ b/agent/engine/engine_sudo_linux_integ_test.go
@@ -376,6 +376,9 @@ func TestExecCommandAgent(t *testing.T) {
 	require.NoError(t, err, "error creating execAgent log file")
 	_, err = os.Stat(execAgentLogPath)
 	require.NoError(t, err, "execAgent log dir doesn't exist")
+	err = os.MkdirAll(execcmd.ECSAgentExecConfigDir, 0644)
+	require.NoError(t, err, "error creating execAgent config dir")
+
 	go taskEngine.AddTask(testTask)
 
 	verifyContainerRunningStateChange(t, taskEngine)
@@ -387,7 +390,9 @@ func TestExecCommandAgent(t *testing.T) {
 	containerMap, _ := taskEngine.(*DockerTaskEngine).state.ContainerMapByArn(testTask.Arn)
 	cid := containerMap[testTask.Containers[0].Name].DockerID
 
-	verifyExecCmdAgentExpectedMounts(t, ctx, client, testTaskId, cid, testContainerName, testExecCmdHostBinDir)
+	// session limit is 2
+	testConfigFileName, _ := execcmd.GetExecAgentConfigFileName(2)
+	verifyExecCmdAgentExpectedMounts(t, ctx, client, testTaskId, cid, testContainerName, testExecCmdHostBinDir, testConfigFileName)
 	pidA := verifyMockExecCommandAgentIsRunning(t, client, cid)
 	seelog.Infof("Verified mock ExecCommandAgent is running (pidA=%s)", pidA)
 	killMockExecCommandAgent(t, client, cid, pidA)
@@ -414,6 +419,7 @@ func TestExecCommandAgent(t *testing.T) {
 	taskEngine.(*DockerTaskEngine).deleteTask(testTask)
 	_, err = os.Stat(execAgentLogPath)
 	assert.True(t, os.IsNotExist(err), "execAgent log cleanup failed")
+	os.RemoveAll(execcmd.ECSAgentExecConfigDir)
 }
 
 func createTestExecCommandAgentTask(taskId, containerName string, sleepFor time.Duration) *apitask.Task {
@@ -458,7 +464,10 @@ func setupEngineForExecCommandAgent(t *testing.T, hostBinDir string) (TaskEngine
 	}, credentialsManager
 }
 
-func verifyExecCmdAgentExpectedMounts(t *testing.T, ctx context.Context, client *sdkClient.Client, testTaskId, containerId, containerName, testExecCmdHostBinDir string) {
+func verifyExecCmdAgentExpectedMounts(t *testing.T,
+	ctx context.Context,
+	client *sdkClient.Client,
+	testTaskId, containerId, containerName, testExecCmdHostBinDir, testConfigFileName string) {
 	inspectState, _ := client.ContainerInspect(ctx, containerId)
 	expectedMounts := []struct {
 		source   string
@@ -481,7 +490,7 @@ func verifyExecCmdAgentExpectedMounts(t *testing.T, ctx context.Context, client 
 			readOnly: true,
 		},
 		{
-			source:   filepath.Join(testExecCmdHostBinDir, execcmd.ConfigFileName),
+			source:   filepath.Join(execcmd.HostExecConfigDir, testConfigFileName),
 			dest:     execcmd.ContainerConfigFile,
 			readOnly: true,
 		},

--- a/agent/engine/execcmd/manager_init_task_linux.go
+++ b/agent/engine/execcmd/manager_init_task_linux.go
@@ -51,7 +51,7 @@ const (
 	certVolumeName          = internalNamePrefix + "-tls-cert"
 	configVolumeName        = internalNamePrefix + "-config"
 
-	execCommandDepsDir = "/execute-command"
+	execCommandDepsDir = "/managed-agents/execute-command"
 	execAgentConfigDir = execCommandDepsDir + "/config"
 	// filePerm is the permission for the exec agent config file.
 	filePerm            = 0644
@@ -190,6 +190,7 @@ func getAgentConfigFileName(sessionLimit int) (string, error) {
 	// check if config file exists already
 	configFilePath := filepath.Join(execAgentConfigDir, fmt.Sprintf(execAgentConfigFileNameTemplate, hash))
 	if execAgentConfigFileExists(configFilePath) {
+		// TODO: verify the hash of the existing file contents
 		return configFilePath, nil
 	}
 	// config doesn't exist; create a new one
@@ -202,8 +203,7 @@ func getAgentConfigFileName(sessionLimit int) (string, error) {
 func getExecAgentConfigHash(config string) string {
 	hash := sha256.New()
 	hash.Write([]byte(config))
-	sha := base64.URLEncoding.EncodeToString(hash.Sum(nil))
-	return sha
+	return base64.URLEncoding.EncodeToString(hash.Sum(nil))
 }
 
 var execAgentConfigFileExists = configFileExists

--- a/agent/engine/execcmd/manager_init_task_linux_test.go
+++ b/agent/engine/execcmd/manager_init_task_linux_test.go
@@ -216,7 +216,7 @@ func TestGetExecAgentConfigFileName(t *testing.T) {
 	  }
 	}`
 	sha := getExecAgentConfigHash(execAgentConfig)
-	configFileName := fmt.Sprintf("/execute-command/config/amazon-ssm-agent-%s.json", sha)
+	configFileName := fmt.Sprintf("/managed-agents/execute-command/config/amazon-ssm-agent-%s.json", sha)
 	var tests = []struct {
 		fileExists             bool
 		createConfigFileErr    error

--- a/agent/engine/execcmd/manager_init_task_linux_test.go
+++ b/agent/engine/execcmd/manager_init_task_linux_test.go
@@ -63,6 +63,9 @@ func TestInitializeTask(t *testing.T) {
 			errorExpected:       true,
 		},
 	}
+	defer func() {
+		getExecAgentConfigFileName = getAgentConfigFileName
+	}()
 	for _, test := range tt {
 		// Constants used here are defined in task_unix_test.go and task_windows_test.go
 		taskFromACS := ecsacs.Task{
@@ -98,6 +101,9 @@ func TestInitializeTask(t *testing.T) {
 		}
 
 		execCmdMgr := newTestManager()
+		getExecAgentConfigFileName = func(s int) (string, error) {
+			return ConfigFileName, nil
+		}
 		err = execCmdMgr.InitializeTask(task)
 		if test.errorExpected {
 			require.NotNil(t, err, "An error should be returned for a task with bad name")

--- a/agent/engine/execcmd/manager_init_task_linux_test.go
+++ b/agent/engine/execcmd/manager_init_task_linux_test.go
@@ -64,7 +64,7 @@ func TestInitializeTask(t *testing.T) {
 		},
 	}
 	defer func() {
-		getExecAgentConfigFileName = getAgentConfigFileName
+		GetExecAgentConfigFileName = getAgentConfigFileName
 	}()
 	for _, test := range tt {
 		// Constants used here are defined in task_unix_test.go and task_windows_test.go
@@ -101,7 +101,7 @@ func TestInitializeTask(t *testing.T) {
 		}
 
 		execCmdMgr := newTestManager()
-		getExecAgentConfigFileName = func(s int) (string, error) {
+		GetExecAgentConfigFileName = func(s int) (string, error) {
 			return ConfigFileName, nil
 		}
 		err = execCmdMgr.InitializeTask(task)
@@ -128,7 +128,7 @@ func TestInitializeTask(t *testing.T) {
 		assertTaskVolume(t, task, certVolumeName, HostCertFile)
 
 		// check config file volume
-		assertTaskVolume(t, task, configVolumeName, filepath.Join(HostBinDir, ConfigFileName))
+		assertTaskVolume(t, task, configVolumeName, filepath.Join(HostExecConfigDir, ConfigFileName))
 
 		// Check exec agent log volumes
 		for _, c := range task.Containers {
@@ -216,7 +216,7 @@ func TestGetExecAgentConfigFileName(t *testing.T) {
 	  }
 	}`
 	sha := getExecAgentConfigHash(execAgentConfig)
-	configFileName := fmt.Sprintf("/managed-agents/execute-command/config/amazon-ssm-agent-%s.json", sha)
+	configFileName := fmt.Sprintf("amazon-ssm-agent-%s.json", sha)
 	var tests = []struct {
 		fileExists             bool
 		createConfigFileErr    error
@@ -253,7 +253,7 @@ func TestGetExecAgentConfigFileName(t *testing.T) {
 		createNewExecAgentConfigFile = func(c, f string) error {
 			return tc.createConfigFileErr
 		}
-		fileName, err := getExecAgentConfigFileName(2)
+		fileName, err := GetExecAgentConfigFileName(2)
 		assert.Equal(t, tc.expectedConfigFileName, fileName, "incorrect config file name")
 		assert.Equal(t, tc.expectedError, err)
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
ExecAgent Configuration is unique for the sessions limit parameter. 
Sha-256 hash of the config is calculated and the config file name `amazon-ssm-agent.json` is appended with it. 
If a new agent config request comes in, hash is calculated and checked if the config file already exists. If yes, it is reused else new config file is created. 

### Implementation details
Hash of the config string is calculated at first and base 64 encoding is used with it as a best practice to use it in a file name. 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

### Description for the changelog
N/A

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
