### PR TITLE
fsxwindowsfileserver: fixing task concurrency issues

### DIFF
--- a/agent/api/task/task_windows.go
+++ b/agent/api/task/task_windows.go
@@ -225,18 +225,12 @@ func (task *Task) addFSxWindowsFileServerResource(
 	vol *TaskVolume,
 	fsxWindowsFileServerVol *fsxwindowsfileserver.FSxWindowsFileServerVolumeConfig,
 ) error {
-	hostPath, err := utils.FindUnusedDriveLetter()
-	if err != nil {
-		return err
-	}
-
 	fsxwindowsfileserverResource, err := fsxwindowsfileserver.NewFSxWindowsFileServerResource(
 		task.Arn,
 		cfg.AWSRegion,
 		vol.Name,
 		FSxWindowsFileServerVolumeType,
 		fsxWindowsFileServerVol,
-		hostPath,
 		task.ExecutionCredentialsID,
 		credentialsManager,
 		resourceFields.SSMClientCreator,

--- a/agent/api/task/task_windows_test.go
+++ b/agent/api/task/task_windows_test.go
@@ -716,7 +716,7 @@ func TestPostUnmarshalTaskWithFSxWindowsFileServerVolumes(t *testing.T) {
 				"credentialsParameter": "arn",
 				"domain": "test"
 		  	},
-		  "fsxWindowsFileServerHostPath": "Z:\\"
+		  "fsxWindowsFileServerHostPath": ""
 		},
 		"createdAt": "0001-01-01T00:00:00Z",
 		"desiredStatus": "NONE",

--- a/agent/taskresource/fsxwindowsfileserver/fsxwindowsfileserver_windows_test.go
+++ b/agent/taskresource/fsxwindowsfileserver/fsxwindowsfileserver_windows_test.go
@@ -411,7 +411,7 @@ func TestPerformHostMount(t *testing.T) {
 	execCommand = fakeExecCommand
 	defer func() { execCommand = exec.Command }()
 
-	err := fv.performHostMount(`\\amznfsxfp8sdlcw.test.corp.com\share`, hostPath, `test\user`, `pass`)
+	err := fv.performHostMount(`\\amznfsxfp8sdlcw.test.corp.com\share`, `test\user`, `pass`)
 	assert.NoError(t, err)
 }
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This change fixes task concurrency issues with drive letter assignment during ```fsxwindowsfileserver``` task resource initialization.

### Implementation details
<!-- How are the changes implemented? -->
1. Moved drive letter assignment to ```performHostMount``` method. 
2. Added a mutex lock for ```performHostMount()``` method.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

Launched 10 tasks concurrently and each of them gets its own drive letter now.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
