### PR TITLE
validate exec agent container start state change event

### DIFF
--- a/agent/engine/common_integ_test.go
+++ b/agent/engine/common_integ_test.go
@@ -117,6 +117,17 @@ func verifyContainerRunningStateChangeWithRuntimeID(t *testing.T, taskEngine Tas
 		"Expected container runtimeID should not empty")
 }
 
+func verifyExecAgentRunningStateChange(t *testing.T, taskEngine TaskEngine) {
+	stateChangeEvents := taskEngine.StateChangeEvents()
+	event := <-stateChangeEvents
+	containerEvent := event.(api.ContainerStateChange)
+	assert.NotEmpty(t, containerEvent.ManagedAgents, "Expected exec-agent event has no managed agents")
+	if containerEvent.ManagedAgents != nil {
+		assert.Equal(t, apicontainerstatus.ManagedAgentRunning, containerEvent.ManagedAgents[0].Status,
+			"expected managedAgent container state change event did not match actual event")
+	}
+}
+
 func verifyContainerStoppedStateChange(t *testing.T, taskEngine TaskEngine) {
 	stateChangeEvents := taskEngine.StateChangeEvents()
 	event := <-stateChangeEvents

--- a/agent/engine/engine_sudo_linux_integ_test.go
+++ b/agent/engine/engine_sudo_linux_integ_test.go
@@ -389,6 +389,7 @@ func TestExecCommandAgent(t *testing.T) {
 
 	verifyExecCmdAgentExpectedMounts(t, ctx, client, testTaskId, cid, testContainerName, testExecCmdHostBinDir)
 	pidA := verifyMockExecCommandAgentIsRunning(t, client, cid)
+	verifyExecAgentRunningStateChange(t, taskEngine)
 	seelog.Infof("Verified mock ExecCommandAgent is running (pidA=%s)", pidA)
 	killMockExecCommandAgent(t, client, cid, pidA)
 	seelog.Infof("kill signal sent to ExecCommandAgent (pidA=%s)", pidA)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Add validation of container state change start event for exec agent start.  

### Implementation details
Followed the pattern for other event validations in our integ tests.  `verifyContainerRunningStateChange` and `verifyContainerRunningStateChangeWithRuntimeID`.  I call the validation directly following `verifyMockExecCommandAgentIsRunning` to be sure we should expect such an event.

### Testing
I ran this test 30x to check for flakiness using:
`for run in {1..30}; do sudo -E env "PATH=$PATH"  go test -tags sudo -count=1 -v -run="TestExecCommandAgent" ./agent/engine/...; done`
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

### Description for the changelog
Add exec command start container event validation.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
