### PR TITLE
Refactor to start execute command agent at container level

### DIFF
--- a/agent/api/container/container.go
+++ b/agent/api/container/container.go
@@ -1216,8 +1216,8 @@ func (c *Container) GetManagedAgentByName(agentName string) (ManagedAgent, bool)
 }
 
 // UpdateManagedAgentByName updates the state of the managed agent with the name specified. If the agent is not found,
-// no action is taken.
-func (c *Container) UpdateManagedAgentByName(agentName string, state ManagedAgentState) {
+// this method returns false.
+func (c *Container) UpdateManagedAgentByName(agentName string, state ManagedAgentState) bool {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	for i, ma := range c.ManagedAgentsUnsafe {
@@ -1228,7 +1228,8 @@ func (c *Container) UpdateManagedAgentByName(agentName string, state ManagedAgen
 				Properties:        ma.Properties,
 				ManagedAgentState: state,
 			}
-			break
+			return true
 		}
 	}
+	return false
 }

--- a/agent/api/container/container.go
+++ b/agent/api/container/container.go
@@ -80,9 +80,6 @@ const (
 
 	// neuronVisibleDevicesEnvVar is the env which indicates that the container wants to use inferentia devices.
 	neuronVisibleDevicesEnvVar = "AWS_NEURON_VISIBLE_DEVICES"
-
-	// executeCommandAgent is the only available ManagedAgent type
-	executeCommandAgentName = "EXECUTE_COMMAND_AGENT"
 )
 
 // DockerConfig represents additional metadata about a container to run. It's
@@ -109,15 +106,25 @@ type HealthStatus struct {
 	Output string `json:"output,omitempty"`
 }
 
-type ManagedAgent struct {
+type ManagedAgentState struct {
+	// ID of this managed agent state
+	ID string `json:"id:omitempty"`
 	// Status is the managed agent health status
 	Status apicontainerstatus.ManagedAgentStatus `json:"status:omitempty"`
-	// Name is always executeCommandAgent (until a new agent type is introduced)
-	Name string `json:"name,omitempty"`
 	// Reason is a placeholder for failure messaging
 	Reason string `json:"reason,omitempty"`
 	// LastStartedAt is the timestamp when the status last went from PENDING->RUNNING
 	LastStartedAt time.Time `json:"lastStartedAt,omitempty"`
+	// Metadata holds metadata about the managed agent
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
+}
+
+type ManagedAgent struct {
+	ManagedAgentState
+	// Name is the name of this managed agent. This name is streamed down from ACS.
+	Name string `json:"name,omitempty"`
+	// Properties of this managed agent. Properties are streamed down from ACS.
+	Properties map[string]string `json:"properties,omitempty"`
 }
 
 // Container is the internal representation of a container in the ECS agent
@@ -290,9 +297,6 @@ type Container struct {
 	finishedAt time.Time
 
 	labels map[string]string
-
-	// ExecCommandAgentMetadata holds metadata about the exec agent running inside the container (i.e. SSM Agent).
-	ExecCommandAgentMetadata ExecCommandAgentMetadata `json:"execCommandAgentMetadata"`
 }
 
 type DependsOn struct {
@@ -345,22 +349,6 @@ type Secret struct {
 	Type          string `json:"type"`
 	Provider      string `json:"provider"`
 	Target        string `json:"target"`
-}
-
-// ExecCommandAgentMetadata holds metadata about the exec agent running inside the container (i.e. SSM Agent).
-type ExecCommandAgentMetadata struct {
-	PID           string                                `json:"pid"`
-	DockerExecID  string                                `json:"dockerExecId"`
-	CMD           string                                `json:"cmd"`
-	StartedAt     time.Time                             `json:"startedAt"`
-	StoppedReason string                                `json:"stoppedReason"`
-	Status        apicontainerstatus.ManagedAgentStatus `json:"execCommandAgentStatus"`
-	SessionLimit  int                                   `json:"sessionLimit"`
-}
-
-func (md *ExecCommandAgentMetadata) String() string {
-	return fmt.Sprintf("[PID: %s, CMD: %s, StartedAt: %s, StoppedReason: %s]",
-		md.PID, md.CMD, md.StartedAt, md.StoppedReason)
 }
 
 // GetSecretResourceCacheKey returns the key required to access the secret
@@ -703,28 +691,10 @@ func (c *Container) GetKnownPortBindings() []PortBinding {
 	return c.KnownPortBindingsUnsafe
 }
 
-// GetKnownManagedAgents is a convenience method to format the
-// ExecuteCommandAgent to meet the expectations of ContainerStateChange
-// This returns an initialized array of ManagedAgents if none are reporting
-// Else an array of knownManagedAgents
-func (c *Container) GetKnownManagedAgents() []ManagedAgent {
-	execCommandAgentMetadata := c.GetExecCommandAgentMetadata()
-
-	c.lock.Lock()
-	defer c.lock.Unlock()
-	// for now we will reset the managed agents every time.
-	c.ManagedAgentsUnsafe = []ManagedAgent{}
-	if execCommandAgentMetadata.Status.ShouldReportToBackend() {
-		// LastStartedAt will only exist for ManagedAgents
-		// that have been started at least once
-		knownManagedAgent := ManagedAgent{
-			Status:        execCommandAgentMetadata.Status,
-			Name:          executeCommandAgentName,
-			LastStartedAt: execCommandAgentMetadata.StartedAt,
-			Reason:        execCommandAgentMetadata.StoppedReason,
-		}
-		c.ManagedAgentsUnsafe = append(c.ManagedAgentsUnsafe, knownManagedAgent)
-	}
+// GetManagedAgents returns the managed agents configured for this container
+func (c *Container) GetManagedAgents() []ManagedAgent {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
 	return c.ManagedAgentsUnsafe
 }
 
@@ -1231,14 +1201,34 @@ func (c *Container) GetTaskARN() string {
 	return c.TaskARNUnsafe
 }
 
-func (c *Container) SetExecCommandAgentMetadata(metadata ExecCommandAgentMetadata) {
-	c.lock.Lock()
-	defer c.lock.Unlock()
-	c.ExecCommandAgentMetadata = metadata
-}
-
-func (c *Container) GetExecCommandAgentMetadata() ExecCommandAgentMetadata {
+// GetManagedAgentByName retrieves the managed agent with the name specified and a boolean indicating whether an agent
+// was found or not.
+// note: a zero value for ManagedAgent if the name is not known to this container.
+func (c *Container) GetManagedAgentByName(agentName string) (ManagedAgent, bool) {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.ExecCommandAgentMetadata
+	for _, ma := range c.ManagedAgentsUnsafe {
+		if ma.Name == agentName {
+			return ma, true
+		}
+	}
+	return ManagedAgent{}, false
+}
+
+// UpdateManagedAgentByName updates the state of the managed agent with the name specified. If the agent is not found,
+// no action is taken.
+func (c *Container) UpdateManagedAgentByName(agentName string, state ManagedAgentState) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	for i, ma := range c.ManagedAgentsUnsafe {
+		if ma.Name == agentName {
+			// It's necessary to clone the whole ManagedAgent struct
+			c.ManagedAgentsUnsafe[i] = ManagedAgent{
+				Name:              ma.Name,
+				Properties:        ma.Properties,
+				ManagedAgentState: state,
+			}
+			break
+		}
+	}
 }

--- a/agent/api/statechange.go
+++ b/agent/api/statechange.go
@@ -138,10 +138,6 @@ func NewContainerStateChangeEvent(task *apitask.Task, cont *apicontainer.Contain
 			contKnownStatus.String(), cont.Name, task.Arn)
 	}
 
-	// for now this will only ever be an array of ManagedAgent type
-	// with either 0 (empty but initialized) or 1 executeCommandAgent ManagedAgents
-	managedAgents := cont.GetKnownManagedAgents()
-
 	if reason == "" && cont.ApplyingError != nil {
 		reason = cont.ApplyingError.Error()
 	}
@@ -152,7 +148,7 @@ func NewContainerStateChangeEvent(task *apitask.Task, cont *apicontainer.Contain
 		Status:        contKnownStatus.BackendStatus(cont.GetSteadyStateStatus()),
 		ExitCode:      cont.GetKnownExitCode(),
 		PortBindings:  cont.GetKnownPortBindings(),
-		ManagedAgents: managedAgents,
+		ManagedAgents: cont.GetManagedAgents(),
 		ImageDigest:   cont.GetImageDigest(),
 		Reason:        reason,
 		Container:     cont,

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -267,9 +267,6 @@ type Task struct {
 	// LaunchType is the launch type of this task.
 	LaunchType string `json:"LaunchType,omitempty"`
 
-	// TODO: [ecs-exec] Wire this to the actual model when control plane changes are ready
-	ExecCommandAgentEnabledUnsafe bool `json:"ExecCommandAgentEnabled"`
-
 	// lock is for protecting all fields in the task struct
 	lock sync.RWMutex
 }
@@ -2721,10 +2718,4 @@ func (task *Task) SetLocalIPAddress(addr string) {
 	defer task.lock.Unlock()
 
 	task.LocalIPAddressUnsafe = addr
-}
-
-func (task *Task) IsExecCommandAgentEnabled() bool {
-	task.lock.Lock()
-	defer task.lock.Unlock()
-	return task.ExecCommandAgentEnabledUnsafe
 }

--- a/agent/api/task/taskvolume_test.go
+++ b/agent/api/task/taskvolume_test.go
@@ -122,8 +122,7 @@ func TestMarshalTaskVolumesEFS(t *testing.T) {
 		"executionCredentialsID": "",
 		"ENI": null,
 		"AppMesh": null,
-		"PlatformFields": %s,
-		"ExecCommandAgentEnabled": false
+		"PlatformFields": %s
 	  }`
 	if runtime.GOOS == "windows" {
 		// windows task defs have a special 'cpu/memory unbounded' field added.

--- a/agent/engine/common_test.go
+++ b/agent/engine/common_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	mock_dockerapi "github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi/mocks"
+	"github.com/aws/amazon-ecs-agent/agent/engine/execcmd"
 	mock_engine "github.com/aws/amazon-ecs-agent/agent/engine/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/statechange"
 	mock_ttime "github.com/aws/amazon-ecs-agent/agent/utils/ttime/mocks"
@@ -344,5 +345,15 @@ func checkManagedAgentEvents(t *testing.T, expectContainerEvent bool, stateChang
 	} else {
 		assert.Empty(t, stateChangeEvents, "expected empty stateChangeEvents channel, but found an event")
 		close(waitDone)
+	}
+}
+
+func enableExecCommandAgentForContainer(container *apicontainer.Container, state apicontainer.ManagedAgentState) {
+	container.ManagedAgentsUnsafe = []apicontainer.ManagedAgent{
+		{
+			Name:              execcmd.ExecuteCommandAgentName,
+			Properties:        make(map[string]string),
+			ManagedAgentState: state,
+		},
 	}
 }

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -281,11 +281,14 @@ func (engine *DockerTaskEngine) monitorExecAgentProcesses(ctx context.Context) {
 	defer engine.tasksLock.RUnlock()
 	for _, mTask := range engine.managedTasks {
 		task := mTask.Task
-		if !task.IsExecCommandAgentEnabled() || task.GetKnownStatus() != apitaskstatus.TaskRunning {
+
+		if task.GetKnownStatus() != apitaskstatus.TaskRunning {
 			continue
 		}
 		for _, c := range task.Containers {
-			go engine.monitorExecAgentRunning(ctx, mTask, c)
+			if execcmd.IsExecEnabledContainer(c) {
+				go engine.monitorExecAgentRunning(ctx, mTask, c)
+			}
 		}
 	}
 }
@@ -616,7 +619,7 @@ func (engine *DockerTaskEngine) deleteTask(task *apitask.Task) {
 		}
 	}
 
-	if task.IsExecCommandAgentEnabled() {
+	if execcmd.IsExecEnabledTask(task) {
 		// cleanup host exec agent log dirs
 		if tID, err := task.GetID(); err != nil {
 			seelog.Warnf("Task Engine[%s]: error getting task ID for ExecAgent logs cleanup: %v", task.Arn, err)
@@ -770,7 +773,7 @@ func (engine *DockerTaskEngine) StateChangeEvents() chan statechange.Event {
 func (engine *DockerTaskEngine) AddTask(task *apitask.Task) {
 	defer metrics.MetricsEngineGlobal.RecordTaskEngineMetric("ADD_TASK")()
 	err := task.PostUnmarshalTask(engine.cfg, engine.credentialsManager,
-		engine.resourceFields, engine.client, engine.ctx, engine.initializeExecCmdAgentForTask)
+		engine.resourceFields, engine.client, engine.ctx)
 	if err != nil {
 		seelog.Errorf("Task engine [%s]: unable to add task to the engine: %v", task.Arn, err)
 		task.SetKnownStatus(apitaskstatus.TaskStopped)
@@ -1121,8 +1124,13 @@ func (engine *DockerTaskEngine) createContainer(task *apitask.Task, container *a
 		}
 	}
 
-	if task.IsExecCommandAgentEnabled() {
-		err := engine.execCmdMgr.AddAgentConfigMount(hostConfig, container.GetExecCommandAgentMetadata())
+	if execcmd.IsExecEnabledContainer(container) {
+		tId, err := task.GetID()
+		if err != nil {
+			herr := &apierrors.HostConfigError{Msg: err.Error()}
+			return dockerapi.DockerContainerMetadata{Error: apierrors.NamedError(herr)}
+		}
+		err = engine.execCmdMgr.InitializeContainer(tId, container, hostConfig)
 		if err != nil {
 			herr := &apierrors.HostConfigError{Msg: err.Error()}
 			return dockerapi.DockerContainerMetadata{Error: apierrors.NamedError(herr)}
@@ -1288,7 +1296,7 @@ func (engine *DockerTaskEngine) startContainer(task *apitask.Task, container *ap
 
 		}
 	}
-	if task.IsExecCommandAgentEnabled() {
+	if execcmd.IsExecEnabledContainer(container) {
 		if err := engine.execCmdMgr.StartAgent(engine.ctx, engine.client, task, container, dockerID); err != nil {
 			seelog.Errorf("Task engine [%s]: Failed to start ExecCommandAgent Process for container [%s]: %v", task.Arn, container.Name, err)
 		}
@@ -1586,15 +1594,4 @@ func (engine *DockerTaskEngine) getDockerID(task *apitask.Task, container *apico
 		return dockerContainer.DockerName, nil
 	}
 	return dockerContainer.DockerID, nil
-}
-
-func (engine *DockerTaskEngine) initializeExecCmdAgentForTask(task *apitask.Task) error {
-	if !task.IsExecCommandAgentEnabled() {
-		return nil
-	}
-	if err := engine.execCmdMgr.InitializeTask(task); err != nil {
-		seelog.Errorf("Task [%s]: could not initialize ExecCommandAgent: %v", task.Arn, err)
-		return err
-	}
-	return nil
 }

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -243,7 +243,9 @@ func TestBatchContainerHappyPath(t *testing.T) {
 			credentialsManager.EXPECT().RemoveCredentials(credentialsID)
 
 			sleepTask := testdata.LoadTask("sleep5")
-			sleepTask.ExecCommandAgentEnabledUnsafe = tc.execCommandAgentEnabled
+			if tc.execCommandAgentEnabled && len(sleepTask.Containers) > 0 {
+				enableExecCommandAgentForContainer(sleepTask.Containers[0], apicontainer.ManagedAgentState{})
+			}
 			sleepTask.SetCredentialsID(credentialsID)
 			eventStream := make(chan dockerapi.DockerContainerChangeEvent)
 			// containerEventsWG is used to force the test to wait until the container created and started
@@ -267,10 +269,9 @@ func TestBatchContainerHappyPath(t *testing.T) {
 							gomock.Any()).Return(tc.metadataUpdateError)
 
 						if tc.execCommandAgentEnabled {
-							execCmdMgr.EXPECT().InitializeTask(sleepTask).Times(1)
+							execCmdMgr.EXPECT().InitializeContainer(gomock.Any(), container, gomock.Any()).Times(1)
 							// TODO: [ecs-exec] validate call control plane to report ExecCommandAgent SUCCESS/FAIL here
 							execCmdMgr.EXPECT().StartAgent(gomock.Any(), client, sleepTask, sleepTask.Containers[0], containerID)
-							execCmdMgr.EXPECT().AddAgentConfigMount(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 						}
 					})
 			}
@@ -3164,15 +3165,16 @@ func TestStartExecAgent(t *testing.T) {
 					Name:              "test-container",
 					RuntimeID:         testContainerId,
 					KnownStatusUnsafe: apicontainerstatus.ContainerStopped,
-					ExecCommandAgentMetadata: apicontainer.ExecCommandAgentMetadata{
-						StartedAt: nowTime,
-						Status:    tc.execAgentStatus,
-					},
 				},
 			},
-			ExecCommandAgentEnabledUnsafe: tc.execCommandAgentEnabled,
 		}
 
+		if tc.execCommandAgentEnabled {
+			enableExecCommandAgentForContainer(testTask.Containers[0], apicontainer.ManagedAgentState{
+				LastStartedAt: nowTime,
+				Status:        tc.execAgentStatus,
+			})
+		}
 		mTestTask := &managedTask{
 			Task:              testTask,
 			engine:            dockerTaskEngine,
@@ -3186,14 +3188,16 @@ func TestStartExecAgent(t *testing.T) {
 		// check for expected containerEvent in stateChangeEvents
 		waitDone := make(chan struct{})
 		expectedManagedAgent := apicontainer.ManagedAgent{
-			Status: apicontainerstatus.ManagedAgentRunning,
+			ManagedAgentState: apicontainer.ManagedAgentState{
+				Status: apicontainerstatus.ManagedAgentRunning,
+			},
 		}
 		go checkManagedAgentEvents(t, tc.expectContainerEvent, stateChangeEvents, expectedManagedAgent, waitDone)
 
 		client.EXPECT().StartContainer(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 			dockerapi.DockerContainerMetadata{DockerID: containerID}).AnyTimes()
 		if tc.execCommandAgentEnabled {
-			execCmdMgr.EXPECT().InitializeTask(testTask).AnyTimes()
+			execCmdMgr.EXPECT().InitializeContainer(gomock.Any(), testTask.Containers[0], gomock.Any()).AnyTimes()
 			execCmdMgr.EXPECT().StartAgent(gomock.Any(), client, testTask, testTask.Containers[0], testContainerId).AnyTimes()
 		}
 		ret := taskEngine.(*DockerTaskEngine).startContainer(testTask, testTask.Containers[0])
@@ -3223,7 +3227,7 @@ func TestMonitorExecAgentRunning(t *testing.T) {
 	)
 	testCases := []struct {
 		containerStatus                apicontainerstatus.ContainerStatus
-		execCommandAgentMetadata       apicontainer.ExecCommandAgentMetadata
+		execCommandAgentState          apicontainer.ManagedAgentState
 		execAgentStatus                apicontainerstatus.ManagedAgentStatus
 		simulateBadContainerId         bool
 		expectedRestartInUnhealthyCall bool
@@ -3253,17 +3257,17 @@ func TestMonitorExecAgentRunning(t *testing.T) {
 			Arn: "arn:aws:ecs:region:account-id:task/test-task-arn",
 			Containers: []*apicontainer.Container{
 				{
-					Name:      "test-container",
-					RuntimeID: testContainerId,
-					ExecCommandAgentMetadata: apicontainer.ExecCommandAgentMetadata{
-						StartedAt: nowTime,
-						Status:    tc.execAgentStatus,
-					},
-
+					Name:              "test-container",
+					RuntimeID:         testContainerId,
 					KnownStatusUnsafe: tc.containerStatus,
 				},
 			},
 		}
+
+		enableExecCommandAgentForContainer(testTask.Containers[0], apicontainer.ManagedAgentState{
+			LastStartedAt: nowTime,
+			Status:        tc.execAgentStatus,
+		})
 
 		mTestTask := &managedTask{
 			Task:              testTask,
@@ -3285,7 +3289,9 @@ func TestMonitorExecAgentRunning(t *testing.T) {
 		// check for expected containerEvent in stateChangeEvents
 		waitDone := make(chan struct{})
 		expectedManagedAgent := apicontainer.ManagedAgent{
-			Status: apicontainerstatus.ManagedAgentRunning,
+			ManagedAgentState: apicontainer.ManagedAgentState{
+				Status: apicontainerstatus.ManagedAgentRunning,
+			},
 		}
 		go checkManagedAgentEvents(t, tc.expectContainerEvent, stateChangeEvents, expectedManagedAgent, waitDone)
 
@@ -3317,18 +3323,17 @@ func TestMonitorExecAgentProcesses(t *testing.T) {
 		Arn: "arn:aws:ecs:region:account-id:task/test-task-arn",
 		Containers: []*apicontainer.Container{
 			{
-				Name:      "test-container",
-				RuntimeID: "runtime-ID",
-				ExecCommandAgentMetadata: apicontainer.ExecCommandAgentMetadata{
-					StartedAt: nowTime,
-					Status:    apicontainerstatus.ManagedAgentRunning,
-				},
+				Name:              "test-container",
+				RuntimeID:         "runtime-ID",
 				KnownStatusUnsafe: apicontainerstatus.ContainerRunning,
 			},
 		},
-		KnownStatusUnsafe:             apitaskstatus.TaskRunning,
-		ExecCommandAgentEnabledUnsafe: true,
+		KnownStatusUnsafe: apitaskstatus.TaskRunning,
 	}
+	enableExecCommandAgentForContainer(testTask.Containers[0], apicontainer.ManagedAgentState{
+		LastStartedAt: nowTime,
+		Status:        apicontainerstatus.ManagedAgentRunning,
+	})
 	mTestTask := &managedTask{
 		Task:              testTask,
 		engine:            dockerTaskEngine,
@@ -3350,9 +3355,11 @@ func TestMonitorExecAgentProcesses(t *testing.T) {
 	expectContainerEvent := true
 	waitDone := make(chan struct{})
 	expectedManagedAgent := apicontainer.ManagedAgent{
-		Status:        apicontainerstatus.ManagedAgentRunning,
-		Name:          "EXECUTE_COMMAND_AGENT",
-		LastStartedAt: nowTime,
+		Name: execcmd.ExecuteCommandAgentName,
+		ManagedAgentState: apicontainer.ManagedAgentState{
+			Status:        apicontainerstatus.ManagedAgentRunning,
+			LastStartedAt: nowTime,
+		},
 	}
 
 	go checkManagedAgentEvents(t, expectContainerEvent, stateChangeEvents, expectedManagedAgent, waitDone)
@@ -3402,8 +3409,10 @@ func TestMonitorExecAgentProcessExecDisabled(t *testing.T) {
 					KnownStatusUnsafe: apicontainerstatus.ContainerRunning,
 				},
 			},
-			ExecCommandAgentEnabledUnsafe: test.execCommandAgentEnabled,
-			KnownStatusUnsafe:             test.taskStatus,
+			KnownStatusUnsafe: test.taskStatus,
+		}
+		if test.execCommandAgentEnabled {
+			enableExecCommandAgentForContainer(testTask.Containers[0], apicontainer.ManagedAgentState{})
 		}
 		dockerTaskEngine.state.AddTask(testTask)
 		dockerTaskEngine.managedTasks[testTask.Arn] = &managedTask{Task: testTask}
@@ -3437,8 +3446,11 @@ func TestMonitorExecAgentsMultipleContainers(t *testing.T) {
 				KnownStatusUnsafe: apicontainerstatus.ContainerRunning,
 			},
 		},
-		ExecCommandAgentEnabledUnsafe: true,
-		KnownStatusUnsafe:             apitaskstatus.TaskRunning,
+		KnownStatusUnsafe: apitaskstatus.TaskRunning,
+	}
+
+	for _, c := range testTask.Containers {
+		enableExecCommandAgentForContainer(c, apicontainer.ManagedAgentState{})
 	}
 
 	mTestTask := &managedTask{
@@ -3498,13 +3510,13 @@ func TestPeriodicExecAgentsMonitoring(t *testing.T) {
 			{
 				Name:      "test-container",
 				RuntimeID: "runtime-ID",
-				ExecCommandAgentMetadata: apicontainer.ExecCommandAgentMetadata{
-					PID: execAgentPID,
-				},
 			},
 		},
-		ExecCommandAgentEnabledUnsafe: true,
 	}
+	enableExecCommandAgentForContainer(testTask.Containers[0], apicontainer.ManagedAgentState{
+		Metadata: map[string]interface{}{
+			"PID": execAgentPID,
+		}})
 	taskEngine.(*DockerTaskEngine).monitorExecAgentsInterval = 2 * time.Millisecond
 	taskEngine.(*DockerTaskEngine).state.AddTask(testTask)
 	taskEngine.(*DockerTaskEngine).managedTasks[testTask.Arn] = &managedTask{Task: testTask}
@@ -3518,7 +3530,10 @@ func TestPeriodicExecAgentsMonitoring(t *testing.T) {
 	go taskEngine.(*DockerTaskEngine).startPeriodicExecAgentsMonitoring(ctx)
 	<-topCtx.Done()
 	time.Sleep(5 * time.Millisecond)
-	assert.Equal(t, execAgentPID, testTask.Containers[0].GetExecCommandAgentMetadata().PID)
+	execCmdAgent, ok := testTask.Containers[0].GetManagedAgentByName(execcmd.ExecuteCommandAgentName)
+	assert.True(t, ok)
+	execMD := execcmd.MapToAgentMetadata(execCmdAgent.Metadata)
+	assert.Equal(t, execAgentPID, execMD.PID)
 }
 
 func TestCreateContainerWithExecAgent(t *testing.T) {
@@ -3546,9 +3561,9 @@ func TestCreateContainerWithExecAgent(t *testing.T) {
 			execCmdMgr := mock_execcmdagent.NewMockManager(ctrl)
 			taskEngine.execCmdMgr = execCmdMgr
 			sleepTask := testdata.LoadTask("sleep5")
-			sleepTask.ExecCommandAgentEnabledUnsafe = true
 			sleepContainer, _ := sleepTask.ContainerByName("sleep5")
-			execCmdMgr.EXPECT().AddAgentConfigMount(gomock.Any(), gomock.Any()).Return(tc.error)
+			enableExecCommandAgentForContainer(sleepContainer, apicontainer.ManagedAgentState{})
+			execCmdMgr.EXPECT().InitializeContainer(gomock.Any(), sleepContainer, gomock.Any()).Return(tc.error)
 			client.EXPECT().APIVersion().Return(defaultDockerClientAPIVersion, nil)
 			if tc.error == nil {
 				client.EXPECT().CreateContainer(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())

--- a/agent/engine/execcmd/manager_init_task_linux.go
+++ b/agent/engine/execcmd/manager_init_task_linux.go
@@ -63,18 +63,19 @@ const (
 )
 
 var (
-	execAgentConfigTemplate = `
+	execAgentConfigTemplate = `{
 	"Agent": {
-	  "Region": "",
-	  "OrchestrationRootDir": "",
-	  "ContainerMode": true,
-	  "Mgs": {
 		"Region": "",
-		"Endpoint": "",
-		"StopTimeoutMillis": 20000,
-		"SessionWorkersLimit": %d
-	  }
-	}`
+		"OrchestrationRootDir": "",
+		"ContainerMode": true,
+		"Mgs": {
+			"Region": "",
+			"Endpoint": "",
+			"StopTimeoutMillis": 20000,
+			"SessionWorkersLimit": %d
+		}
+	}
+}`
 	// TODO: [ecs-exec] seelog config needs to be implemented following a similar approach to ss, config
 	execAgentConfigFileNameTemplate    = `amazon-ssm-agent-%s.json`
 	errExecCommandManagedAgentNotFound = fmt.Errorf("managed agent not found (%s)", ExecuteCommandAgentName)

--- a/agent/engine/execcmd/manager_init_task_linux_test.go
+++ b/agent/engine/execcmd/manager_init_task_linux_test.go
@@ -132,18 +132,19 @@ func TestInitializeContainer(t *testing.T) {
 }
 
 func TestGetExecAgentConfigFileName(t *testing.T) {
-	execAgentConfig := `
+	execAgentConfig := `{
 	"Agent": {
-	  "Region": "",
-	  "OrchestrationRootDir": "",
-	  "ContainerMode": true,
-	  "Mgs": {
 		"Region": "",
-		"Endpoint": "",
-		"StopTimeoutMillis": 20000,
-		"SessionWorkersLimit": 2
-	  }
-	}`
+		"OrchestrationRootDir": "",
+		"ContainerMode": true,
+		"Mgs": {
+			"Region": "",
+			"Endpoint": "",
+			"StopTimeoutMillis": 20000,
+			"SessionWorkersLimit": 2
+		}
+	}
+}`
 	sha := getExecAgentConfigHash(execAgentConfig)
 	configFileName := fmt.Sprintf("amazon-ssm-agent-%s.json", sha)
 	var tests = []struct {

--- a/agent/engine/execcmd/manager_test.go
+++ b/agent/engine/execcmd/manager_test.go
@@ -17,6 +17,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 )
 
 func TestNewManager(t *testing.T) {
@@ -36,4 +39,67 @@ func TestNewManagerWithBinDir(t *testing.T) {
 	assert.Equal(t, defaultRetryMinDelay, m.retryMinDelay)
 	assert.Equal(t, defaultRetryMaxDelay, m.retryMaxDelay)
 	assert.Equal(t, defaultStartRetryTimeout, m.startRetryTimeout)
+}
+
+func TestIsExecEnabledTask(t *testing.T) {
+	var tests = []struct {
+		name                string
+		agentName           string
+		expectedExecEnabled bool
+	}{
+		{
+			name:      "test task not exec enabled when no exec command managed agent is present",
+			agentName: "randomAgent",
+		},
+		{
+			name:                "test task not exec enabled when no exec command managed agent is present",
+			agentName:           "ExecuteCommandAgent",
+			expectedExecEnabled: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			task := &apitask.Task{
+				Containers: []*apicontainer.Container{{
+					ManagedAgentsUnsafe: []apicontainer.ManagedAgent{
+						{
+							Name: tc.agentName,
+						}}},
+				},
+			}
+			enabled := IsExecEnabledTask(task)
+			assert.Equal(t, tc.expectedExecEnabled, enabled)
+		})
+	}
+}
+
+func TestExecEnabledContainer(t *testing.T) {
+
+	var tests = []struct {
+		name                string
+		agentName           string
+		expectedExecEnabled bool
+	}{
+		{
+			name:      "test container not exec enabled when no exec command managed agent is present",
+			agentName: "randomAgent",
+		},
+		{
+			name:                "test container not exec enabled when no exec command managed agent is present",
+			agentName:           "ExecuteCommandAgent",
+			expectedExecEnabled: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			container := &apicontainer.Container{
+				ManagedAgentsUnsafe: []apicontainer.ManagedAgent{
+					{
+						Name: tc.agentName,
+					}},
+			}
+			enabled := IsExecEnabledContainer(container)
+			assert.Equal(t, tc.expectedExecEnabled, enabled)
+		})
+	}
 }

--- a/agent/engine/execcmd/manager_unsupported.go
+++ b/agent/engine/execcmd/manager_unsupported.go
@@ -39,14 +39,8 @@ func (m *manager) StartAgent(ctx context.Context, client dockerapi.DockerClient,
 	return nil
 }
 
-// InitializeTask adds the necessary volumes and mount points in all of the task containers in order for the
-// exec cmd agent to run upon container start up.
+// InitializeContainer adds the necessary bind mounts in order for the ExecCommandAgent to run properly in the container
 // Note: exec cmd agent is a linux-only feature, thus implemented here as a no-op.
-func (m *manager) InitializeTask(task *apitask.Task) error {
-	return nil
-}
-
-// AddAgentConfigMount adds the ExecAgentConfigFile to the hostConfig binds
-func (m *manager) AddAgentConfigMount(hostConfig *dockercontainer.HostConfig, execMD apicontainer.ExecCommandAgentMetadata) error {
+func (m *manager) InitializeContainer(taskId string, container *apicontainer.Container, hostConfig *dockercontainer.HostConfig) error {
 	return nil
 }

--- a/agent/engine/execcmd/metadata.go
+++ b/agent/engine/execcmd/metadata.go
@@ -1,0 +1,35 @@
+package execcmd
+
+import (
+	"fmt"
+)
+
+// AgentMetadata holds metadata about the exec agent running inside the container (i.e. SSM Agent).
+type AgentMetadata struct {
+	PID          string `json:"PID"`
+	DockerExecID string `json:"DockerExecID"`
+	CMD          string `json:"CMD"`
+}
+
+func (md *AgentMetadata) String() string {
+	return fmt.Sprintf("[PID: %s, DockerExecId: %s, CMD: %s]", md.PID, md.DockerExecID, md.CMD)
+}
+
+func (md *AgentMetadata) ToMap() map[string]interface{} {
+	return map[string]interface{}{
+		"PID":          md.PID,
+		"DockerExecID": md.DockerExecID,
+		"CMD":          md.CMD,
+	}
+}
+
+func MapToAgentMetadata(md map[string]interface{}) AgentMetadata {
+	var execMD AgentMetadata
+	if md == nil {
+		return execMD
+	}
+	execMD.PID, _ = md["PID"].(string)
+	execMD.DockerExecID, _ = md["DockerExecID"].(string)
+	execMD.CMD, _ = md["CMD"].(string)
+	return execMD
+}

--- a/agent/engine/execcmd/mocks/execcmd_mocks.go
+++ b/agent/engine/execcmd/mocks/execcmd_mocks.go
@@ -53,32 +53,18 @@ func (m *MockManager) EXPECT() *MockManagerMockRecorder {
 	return m.recorder
 }
 
-// AddAgentConfigMount mocks base method
-func (m *MockManager) AddAgentConfigMount(arg0 *container0.HostConfig, arg1 container.ExecCommandAgentMetadata) error {
+// InitializeContainer mocks base method
+func (m *MockManager) InitializeContainer(arg0 string, arg1 *container.Container, arg2 *container0.HostConfig) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddAgentConfigMount", arg0, arg1)
+	ret := m.ctrl.Call(m, "InitializeContainer", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// AddAgentConfigMount indicates an expected call of AddAgentConfigMount
-func (mr *MockManagerMockRecorder) AddAgentConfigMount(arg0, arg1 interface{}) *gomock.Call {
+// InitializeContainer indicates an expected call of InitializeContainer
+func (mr *MockManagerMockRecorder) InitializeContainer(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddAgentConfigMount", reflect.TypeOf((*MockManager)(nil).AddAgentConfigMount), arg0, arg1)
-}
-
-// InitializeTask mocks base method
-func (m *MockManager) InitializeTask(arg0 *task.Task) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InitializeTask", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// InitializeTask indicates an expected call of InitializeTask
-func (mr *MockManagerMockRecorder) InitializeTask(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitializeTask", reflect.TypeOf((*MockManager)(nil).InitializeTask), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitializeContainer", reflect.TypeOf((*MockManager)(nil).InitializeContainer), arg0, arg1, arg2)
 }
 
 // RestartAgentIfStopped mocks base method

--- a/agent/engine/task_manager_unix_test.go
+++ b/agent/engine/task_manager_unix_test.go
@@ -420,10 +420,11 @@ func TestCleanupExecEnabledTask(t *testing.T) {
 		resourceStateChangeEvent: make(chan resourceStateChange),
 		cfg:                      taskEngine.cfg,
 	}
-	mTask.Task.ExecCommandAgentEnabledUnsafe = true
+	container := mTask.Containers[0]
+	enableExecCommandAgentForContainer(container, apicontainer.ManagedAgentState{})
 	mTask.SetKnownStatus(apitaskstatus.TaskStopped)
 	mTask.SetSentStatus(apitaskstatus.TaskStopped)
-	container := mTask.Containers[0]
+
 	dockerContainer := &apicontainer.DockerContainer{
 		DockerName: "dockerContainer",
 	}

--- a/agent/statemanager/state_manager.go
+++ b/agent/statemanager/state_manager.go
@@ -115,7 +115,7 @@ const (
 	//	 a) Add 'authorizationConfig', 'transitEncryption' and 'transitEncryptionPort' to 'taskresource.volume.EFSVolumeConfig'
 	//	 b) Add 'pauseContainerPID' field to 'taskresource.volume.VolumeResource'
 	// 28) Add 'envfile' field to 'resources'
-	// 29) Add 'ExecCommandAgentMetadata' field to 'apicontainer.Container'
+	// 29) Add 'ManagedAgentsUnsafe' field to 'apicontainer.Container'
 
 	ECSDataVersion = 29
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR is a refactor of ExecuteCommandAgent in order to do operations at the container level since ACS streams exec command data at the container level.

This refactor doesn't make any major changes in logic, but it merely reorganizes the code and adapts UTs/Integ tests accordingly.

### Implementation details
<!-- How are the changes implemented? -->
* Remove `ExecCommandAgentMetadata` from container; now the metadata is part of the ExecuteCommandAgent `ManagedAgent`.
* `ManagedAgent` now reflects the ACS model
* Replace `InitializeTask` from `InitializeContainer`. Bindmounts happen now in `createContainer` and no shared volumes are created for container deps.
* Using the latest agreed-upon paths for the dependency bindmounts

### Testing
<!-- How was this tested? -->
* Made sure UTs still pass and reflect expectations
* Made sure integ tests pass and reflect expectations
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
