### PR TITLE
bind mount ExecAgent Config file to containers

### DIFF
--- a/agent/api/container/container.go
+++ b/agent/api/container/container.go
@@ -355,6 +355,7 @@ type ExecCommandAgentMetadata struct {
 	StartedAt     time.Time                             `json:"startedAt"`
 	StoppedReason string                                `json:"stoppedReason"`
 	Status        apicontainerstatus.ManagedAgentStatus `json:"execCommandAgentStatus"`
+	SessionLimit  int                                   `json:"sessionLimit"`
 }
 
 func (md *ExecCommandAgentMetadata) String() string {

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -1121,6 +1121,14 @@ func (engine *DockerTaskEngine) createContainer(task *apitask.Task, container *a
 		}
 	}
 
+	if task.IsExecCommandAgentEnabled() {
+		err := engine.execCmdMgr.AddAgentConfigMount(hostConfig, container.GetExecCommandAgentMetadata())
+		if err != nil {
+			herr := &apierrors.HostConfigError{Msg: err.Error()}
+			return dockerapi.DockerContainerMetadata{Error: apierrors.NamedError(herr)}
+		}
+	}
+
 	config, err := task.DockerConfig(container, dockerClientVersion)
 	if err != nil {
 		return dockerapi.DockerContainerMetadata{Error: apierrors.NamedError(err)}

--- a/agent/engine/engine_sudo_linux_integ_test.go
+++ b/agent/engine/engine_sudo_linux_integ_test.go
@@ -394,7 +394,6 @@ func TestExecCommandAgent(t *testing.T) {
 	testConfigFileName, _ := execcmd.GetExecAgentConfigFileName(2)
 	verifyExecCmdAgentExpectedMounts(t, ctx, client, testTaskId, cid, testContainerName, testExecCmdHostBinDir, testConfigFileName)
 	pidA := verifyMockExecCommandAgentIsRunning(t, client, cid)
-	verifyExecAgentRunningStateChange(t, taskEngine)
 	seelog.Infof("Verified mock ExecCommandAgent is running (pidA=%s)", pidA)
 	killMockExecCommandAgent(t, client, cid, pidA)
 	seelog.Infof("kill signal sent to ExecCommandAgent (pidA=%s)", pidA)

--- a/agent/engine/execcmd/manager.go
+++ b/agent/engine/execcmd/manager.go
@@ -21,6 +21,7 @@ import (
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
+	dockercontainer "github.com/docker/docker/api/types/container"
 )
 
 const (
@@ -68,6 +69,7 @@ type Manager interface {
 	InitializeTask(task *apitask.Task) error
 	StartAgent(ctx context.Context, client dockerapi.DockerClient, task *apitask.Task, container *apicontainer.Container, containerId string) error
 	RestartAgentIfStopped(ctx context.Context, client dockerapi.DockerClient, task *apitask.Task, container *apicontainer.Container, containerId string) (RestartStatus, error)
+	AddAgentConfigMount(hostConfig *dockercontainer.HostConfig, execMD apicontainer.ExecCommandAgentMetadata) error
 }
 
 type manager struct {

--- a/agent/engine/execcmd/manager_unsupported.go
+++ b/agent/engine/execcmd/manager_unsupported.go
@@ -20,6 +20,7 @@ import (
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
+	dockercontainer "github.com/docker/docker/api/types/container"
 )
 
 const (
@@ -42,5 +43,10 @@ func (m *manager) StartAgent(ctx context.Context, client dockerapi.DockerClient,
 // exec cmd agent to run upon container start up.
 // Note: exec cmd agent is a linux-only feature, thus implemented here as a no-op.
 func (m *manager) InitializeTask(task *apitask.Task) error {
+	return nil
+}
+
+// AddAgentConfigMount adds the ExecAgentConfigFile to the hostConfig binds
+func (m *manager) AddAgentConfigMount(hostConfig *dockercontainer.HostConfig, execMD apicontainer.ExecCommandAgentMetadata) error {
 	return nil
 }

--- a/agent/engine/execcmd/mocks/execcmd_mocks.go
+++ b/agent/engine/execcmd/mocks/execcmd_mocks.go
@@ -26,6 +26,7 @@ import (
 	task "github.com/aws/amazon-ecs-agent/agent/api/task"
 	dockerapi "github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	execcmd "github.com/aws/amazon-ecs-agent/agent/engine/execcmd"
+	container0 "github.com/docker/docker/api/types/container"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -50,6 +51,20 @@ func NewMockManager(ctrl *gomock.Controller) *MockManager {
 // EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockManager) EXPECT() *MockManagerMockRecorder {
 	return m.recorder
+}
+
+// AddAgentConfigMount mocks base method
+func (m *MockManager) AddAgentConfigMount(arg0 *container0.HostConfig, arg1 container.ExecCommandAgentMetadata) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddAgentConfigMount", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddAgentConfigMount indicates an expected call of AddAgentConfigMount
+func (mr *MockManagerMockRecorder) AddAgentConfigMount(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddAgentConfigMount", reflect.TypeOf((*MockManager)(nil).AddAgentConfigMount), arg0, arg1)
 }
 
 // InitializeTask mocks base method


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Change the implementation of creating a docker volume for config file for the task to mounting config file to individual containers belonging to Exec enabled task.

### Implementation details
- adds a new field `SessionLimit` to ExecAgentMetadata 
- pass the `hostConfig` of container from `createContainer` call to exec manager's new method `AddAgentConfigMount`  to add the config file as bind mount in readOnly mode 
- if `SessionLimit` is <= 0, fall back to default session limit of 2.
- Added/updated new unit tests and exec integ test 
note: this PR does not parse the sessionLimit from ECS service yet.
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

### Description for the changelog
N/A

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
