### PR TITLE
Add util functions to determine latest ExecuteCommandAgent version

### DIFF
--- a/agent/engine/execcmd/agent_version.go
+++ b/agent/engine/execcmd/agent_version.go
@@ -1,0 +1,82 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package execcmd
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+)
+
+// TODO: Remove this later, just doing it do make static checks happy about these utils not being invoked anywhere
+func init() {
+	determineLatestVersion([]string{"1.1.1.1"})
+}
+
+const (
+	versionDelimiter  = "."
+	badInputReturn    = -999
+	badFormatErrorStr = "invalid version format"
+)
+
+// compareAgentVersion compares two versions, returning -1 if v1 < v2, 0 if v1 == v2, and 1 if v1 > v2.
+// The version must have only integers representing major, minor, patch, and reserved; delimited by dots (e.g. "1.2.3.4").
+// An error is returned if any of the versions passed as parameter is malformed.
+// example:
+// compareAgentVersion("3.0.236.0", "3.0.237.0") returns -1, nil
+// compareAgentVersion("3.0.236.0", "3.0.236.0") returns 0, nil
+// compareAgentVersion("3.0.237.0", "3.0.236.0") returns 1, nil
+// compareAgentVersion("a.b.c.d", "3.0.236.0") returns -999, error
+func compareAgentVersion(v1Str, v2Str string) (int, error) {
+	v1Arr := strings.Split(v1Str, versionDelimiter)
+	v2Arr := strings.Split(v2Str, versionDelimiter)
+
+	if len(v1Arr) != len(v2Arr) {
+		return badInputReturn, errors.New(badFormatErrorStr)
+	}
+	for i := 0; i < len(v1Arr); i++ {
+		v1Int, err := strconv.ParseUint(v1Arr[i], 10, 32)
+		if err != nil {
+			return badInputReturn, errors.New(badFormatErrorStr)
+		}
+		v2Int, err := strconv.ParseUint(v2Arr[i], 10, 32)
+		if err != nil {
+			return badInputReturn, errors.New(badFormatErrorStr)
+		}
+
+		if v1Int < v2Int {
+			return -1, nil
+		} else if v1Int > v2Int {
+			return 1, nil
+		}
+	}
+	return 0, nil
+}
+
+func determineLatestVersion(versions []string) (string, error) {
+	if len(versions) == 0 {
+		return "", errors.New("no versions to compare were provided")
+	}
+	latest := "0.0.0.0"
+	for _, v := range versions {
+		comp, err := compareAgentVersion(v, latest)
+		if err != nil {
+			return "", err
+		}
+		if comp > 0 {
+			latest = v
+		}
+	}
+	return latest, nil
+}

--- a/agent/engine/execcmd/agent_version_test.go
+++ b/agent/engine/execcmd/agent_version_test.go
@@ -1,0 +1,122 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package execcmd
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCompareAgentVersion(t *testing.T) {
+	tt := []struct {
+		name        string
+		v1, v2      string
+		res         int
+		errExpected bool
+	}{
+		{
+			"v1 < v2", "3.0.236.0", "3.0.237.0", -1, false,
+		},
+		{
+			"v1 == v2", "3.0.236.0", "3.0.236.0", 0, false,
+		},
+		{
+			"v1 > v2", "3.0.237.0", "3.0.236.0", 1, false,
+		},
+		{
+			"negative v1", "-1.0.0.0", "3.0.236.0", badInputReturn, true,
+		},
+		{
+			"negative v2", "3.0.236.0", "-1.0.0.0", badInputReturn, true,
+		},
+		{
+			"invalid v1", "a.b.c.d", "3.0.236.0", badInputReturn, true,
+		},
+		{
+			"invalid v2", "3.0.236.0", "a.b.c.d", badInputReturn, true,
+		},
+		{
+			"missing elements v1", "3.0.236", "1.1.1.1", badInputReturn, true,
+		},
+		{
+			"missing elements v2", "1.1.1.1", "3.0.236", badInputReturn, true,
+		},
+		{
+			"blank v1", "", "1.1.1.1", badInputReturn, true,
+		},
+		{
+			"blank v2", "1.1.1.1", "", badInputReturn, true,
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := compareAgentVersion(tc.v1, tc.v2)
+			if tc.errExpected {
+				assert.Error(t, err, "Error was expected")
+			} else {
+				assert.NoError(t, err, "Error was NOT expected")
+			}
+			assert.Equal(t, tc.res, res)
+		})
+	}
+}
+
+func TestDetermineLatestVersion(t *testing.T) {
+	tt := []struct {
+		name            string
+		versions        []string
+		expectedVersion string
+		expectedError   error
+	}{
+		{
+			name:          "no versions",
+			versions:      nil,
+			expectedError: errors.New("no versions to compare were provided"),
+		},
+		{
+			name:          "empty versions",
+			versions:      []string{},
+			expectedError: errors.New("no versions to compare were provided"),
+		},
+		{
+			name:          "bad version",
+			versions:      []string{"1"},
+			expectedError: errors.New("invalid version format"),
+		},
+		{
+			name:            "single version",
+			versions:        []string{"3.0.236.0"},
+			expectedVersion: "3.0.236.0",
+		},
+		{
+			name:            "multiple version same value",
+			versions:        []string{"3.0.236.0", "3.0.236.0"},
+			expectedVersion: "3.0.236.0",
+		},
+		{
+			name:            "multiple version diff values",
+			versions:        []string{"2.0.1.0", "3.0.236.0", "1.1.1.1", "0.0.0.0"},
+			expectedVersion: "3.0.236.0",
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			v, err := determineLatestVersion(tc.versions)
+			assert.Equal(t, tc.expectedError, err)
+			assert.Equal(t, tc.expectedVersion, v)
+		})
+	}
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Add util functions to determine latest ExecuteCommandAgent version
### Implementation details
<!-- How are the changes implemented? -->
Add util functions to determine latest ExecuteCommandAgent version
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes<!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
