### PR TITLE
Introduce an environment variable ECS_PULL_DEPENDENT_CONTAINER_PARALLEL

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ additional details on each available environment variable.
 | `ECS_DISABLE_METRICS`     | &lt;true &#124; false&gt;  | Whether to disable metrics gathering for tasks. | false | true |
 | `ECS_POLL_METRICS`     | &lt;true &#124; false&gt;  | Whether to poll or stream when gathering metrics for tasks. This defaulted to `false` previous to agent version 1.40.0. WARNING: setting this to false on an instance with many containers can result in very high CPU utilization by the agent, dockerd, and containerd. | `true` | `true` |
 | `ECS_POLLING_METRICS_WAIT_DURATION` | 10s | Time to wait between polling for metrics for a task. Not used when ECS_POLL_METRICS is false. Maximum value is 20s and minimum value is 5s. If user sets above maximum it will be set to max, and if below minimum it will be set to min. | 10s | 10s |
+| `ECS_PULL_DEPENDENT_CONTAINER_PARALLEL` | &lt;true &#124; false&gt; | Whether to pull images of dependent containers, even though dependsOn condition has not been satisfied yet. | false | false |
 | `ECS_RESERVED_MEMORY` | 32 | Memory, in MiB, to reserve for use by things other than containers managed by Amazon ECS. | 0 | 0 |
 | `ECS_AVAILABLE_LOGGING_DRIVERS` | `["awslogs","fluentd","gelf","json-file","journald","logentries","splunk","syslog"]` | Which logging drivers are available on the container instance. | `["json-file","none"]` | `["json-file","none"]` |
 | `ECS_DISABLE_PRIVILEGED` | `true` | Whether launching privileged containers is disabled on the container instance. | `false` | `false` |

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -533,6 +533,7 @@ func environmentConfig() (Config, error) {
 		TaskCPUMemLimit:                     parseBooleanDefaultTrueConfig("ECS_ENABLE_TASK_CPU_MEM_LIMIT"),
 		DockerStopTimeout:                   parseDockerStopTimeout(),
 		ContainerStartTimeout:               parseContainerStartTimeout(),
+		ContainerPullInParallel:             parseBooleanDefaultFalseConfig("ECS_PULL_DEPENDENT_CONTAINER_PARALLEL"),
 		ImagePullInactivityTimeout:          parseImagePullInactivityTimeout(),
 		ImagePullTimeout:                    parseEnvVariableDuration("ECS_IMAGE_PULL_TIMEOUT"),
 		CredentialsAuditLogFile:             os.Getenv("ECS_AUDIT_LOGFILE"),
@@ -600,6 +601,7 @@ func (cfg *Config) String() string {
 			"TaskCleanupWaitDuration: %v, "+
 			"DockerStopTimeout: %v, "+
 			"ContainerStartTimeout: %v, "+
+			"ContainerPullInParallel: %v, "+
 			"TaskCPUMemLimit: %v, "+
 			"%s",
 		cfg.Cluster,
@@ -615,6 +617,7 @@ func (cfg *Config) String() string {
 		cfg.TaskCleanupWaitDuration,
 		cfg.DockerStopTimeout,
 		cfg.ContainerStartTimeout,
+		cfg.ContainerPullInParallel,
 		cfg.TaskCPUMemLimit,
 		cfg.platformString(),
 	)

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -145,6 +145,7 @@ func TestEnvironmentConfig(t *testing.T) {
 	defer setTestEnv("ECS_POLL_METRICS", "true")()
 	defer setTestEnv("ECS_POLLING_METRICS_WAIT_DURATION", "10s")()
 	defer setTestEnv("ECS_CGROUP_CPU_PERIOD", "")
+	defer setTestEnv("ECS_PULL_DEPENDENT_CONTAINER_PARALLEL", "true")()
 	additionalLocalRoutesJSON := `["1.2.3.4/22","5.6.7.8/32"]`
 	setTestEnv("ECS_AWSVPC_ADDITIONAL_LOCAL_ROUTES", additionalLocalRoutesJSON)
 	setTestEnv("ECS_ENABLE_CONTAINER_METADATA", "true")
@@ -197,6 +198,7 @@ func TestEnvironmentConfig(t *testing.T) {
 	assert.Equal(t, 10*time.Millisecond, conf.CgroupCPUPeriod)
 	assert.False(t, conf.SpotInstanceDrainingEnabled.Enabled())
 	assert.Equal(t, []string{"efsAuth"}, conf.VolumePluginCapabilities)
+	assert.True(t, conf.ContainerPullInParallel.Enabled(), "Wrong value for ContainerPullInParallel")
 }
 
 func TestTrimWhitespaceWhenCreating(t *testing.T) {

--- a/agent/config/config_unix.go
+++ b/agent/config/config_unix.go
@@ -56,6 +56,7 @@ func DefaultConfig() Config {
 		TaskCleanupWaitDuration:             DefaultTaskCleanupWaitDuration,
 		DockerStopTimeout:                   defaultDockerStopTimeout,
 		ContainerStartTimeout:               defaultContainerStartTimeout,
+		ContainerPullInParallel:             BooleanDefaultFalse{Value: ExplicitlyDisabled},
 		CredentialsAuditLogFile:             defaultCredentialsAuditLogFile,
 		CredentialsAuditLogDisabled:         false,
 		ImageCleanupDisabled:                BooleanDefaultFalse{Value: ExplicitlyDisabled},

--- a/agent/config/config_unix_test.go
+++ b/agent/config/config_unix_test.go
@@ -68,6 +68,7 @@ func TestConfigDefault(t *testing.T) {
 	assert.False(t, cfg.SharedVolumeMatchFullConfig.Enabled(), "Default SharedVolumeMatchFullConfig set incorrectly")
 	assert.Equal(t, defaultCgroupCPUPeriod, cfg.CgroupCPUPeriod, "CFS cpu period set incorrectly")
 	assert.Equal(t, DefaultImagePullTimeout, cfg.ImagePullTimeout, "Default ImagePullTimeout set incorrectly")
+	assert.False(t, cfg.ContainerPullInParallel.Enabled(), "Default ContainerPullInParallel set incorrectly")
 }
 
 // TestConfigFromFile tests the configuration can be read from file

--- a/agent/config/config_windows.go
+++ b/agent/config/config_windows.go
@@ -86,6 +86,7 @@ func DefaultConfig() Config {
 		TaskCleanupWaitDuration:             DefaultTaskCleanupWaitDuration,
 		DockerStopTimeout:                   defaultDockerStopTimeout,
 		ContainerStartTimeout:               defaultContainerStartTimeout,
+		ContainerPullInParallel:             BooleanDefaultFalse{Value: ExplicitlyDisabled},
 		ImagePullInactivityTimeout:          defaultImagePullInactivityTimeout,
 		ImagePullTimeout:                    DefaultImagePullTimeout,
 		CredentialsAuditLogFile:             filepath.Join(ecsRoot, defaultCredentialsAuditLogFile),

--- a/agent/config/config_windows_test.go
+++ b/agent/config/config_windows_test.go
@@ -61,6 +61,7 @@ func TestConfigDefault(t *testing.T) {
 		"Default TaskMetadataBurstRate is set incorrectly")
 	assert.False(t, cfg.SharedVolumeMatchFullConfig.Enabled(), "Default SharedVolumeMatchFullConfig set incorrectly")
 	assert.Equal(t, DefaultImagePullTimeout, cfg.ImagePullTimeout, "Default ImagePullTimeout set incorrectly")
+	assert.False(t, cfg.ContainerPullInParallel.Enabled(), "Default ContainerPullInParallel set incorrectly")
 }
 
 func TestConfigIAMTaskRolesReserves80(t *testing.T) {

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -112,6 +112,10 @@ type Config struct {
 	// ContainerStartTimeout specifies the amount of time to wait to start a container
 	ContainerStartTimeout time.Duration
 
+	// ContainerPullInParallel specifies whether pull containers in parallel should be applied to this agent.
+	// Default false
+	ContainerPullInParallel BooleanDefaultFalse
+
 	// ImagePullInactivityTimeout is here to override the amount of time to wait when pulling and extracting a container
 	ImagePullInactivityTimeout time.Duration
 

--- a/agent/engine/dependencygraph/graph_test.go
+++ b/agent/engine/dependencygraph/graph_test.go
@@ -23,6 +23,7 @@ import (
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
+	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	mock_taskresource "github.com/aws/amazon-ecs-agent/agent/taskresource/mocks"
 	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
@@ -58,7 +59,8 @@ func createdContainer(name string, dependsOn []apicontainer.DependsOn, steadySta
 func TestValidDependencies(t *testing.T) {
 	// Empty task
 	task := &apitask.Task{}
-	resolveable := ValidDependencies(task)
+	cfg := config.Config{}
+	resolveable := ValidDependencies(task, &cfg)
 	assert.True(t, resolveable, "The zero dependency graph should resolve")
 
 	task = &apitask.Task{
@@ -69,7 +71,7 @@ func TestValidDependencies(t *testing.T) {
 			},
 		},
 	}
-	resolveable = ValidDependencies(task)
+	resolveable = ValidDependencies(task, &cfg)
 	assert.True(t, resolveable, "One container should resolve trivially")
 
 	// Webserver stack
@@ -86,7 +88,7 @@ func TestValidDependencies(t *testing.T) {
 		},
 	}
 
-	resolveable = ValidDependencies(task)
+	resolveable = ValidDependencies(task, &cfg)
 	assert.True(t, resolveable, "The webserver group should resolve just fine")
 }
 
@@ -98,7 +100,8 @@ func TestValidDependenciesWithCycles(t *testing.T) {
 			steadyStateContainer("b", []apicontainer.DependsOn{{ContainerName: "a", Condition: createCondition}}, apicontainerstatus.ContainerRunning, apicontainerstatus.ContainerRunning),
 		},
 	}
-	resolveable := ValidDependencies(task)
+	cfg := config.Config{}
+	resolveable := ValidDependencies(task, &cfg)
 	assert.False(t, resolveable, "Cycle should not be resolveable")
 }
 
@@ -109,7 +112,8 @@ func TestValidDependenciesWithUnresolvedReference(t *testing.T) {
 			steadyStateContainer("php", []apicontainer.DependsOn{{ContainerName: "db", Condition: createCondition}}, apicontainerstatus.ContainerRunning, apicontainerstatus.ContainerRunning),
 		},
 	}
-	resolveable := ValidDependencies(task)
+	cfg := config.Config{}
+	resolveable := ValidDependencies(task, &cfg)
 	assert.False(t, resolveable, "Nonexistent reference shouldn't resolve")
 }
 
@@ -122,7 +126,8 @@ func TestDependenciesAreResolvedWhenSteadyStateIsRunning(t *testing.T) {
 			},
 		},
 	}
-	_, err := DependenciesAreResolved(task.Containers[0], task.Containers, "", nil, nil)
+	cfg := config.Config{}
+	_, err := DependenciesAreResolved(task.Containers[0], task.Containers, "", nil, nil, &cfg)
 	assert.NoError(t, err, "One container should resolve trivially")
 
 	// Webserver stack
@@ -139,28 +144,28 @@ func TestDependenciesAreResolvedWhenSteadyStateIsRunning(t *testing.T) {
 		},
 	}
 
-	_, err = DependenciesAreResolved(php, task.Containers, "", nil, nil)
+	_, err = DependenciesAreResolved(php, task.Containers, "", nil, nil, &cfg)
 	assert.Error(t, err, "Shouldn't be resolved; db isn't running")
 
-	_, err = DependenciesAreResolved(db, task.Containers, "", nil, nil)
+	_, err = DependenciesAreResolved(db, task.Containers, "", nil, nil, &cfg)
 	assert.Error(t, err, "Shouldn't be resolved; dbdatavolume isn't created")
 
-	_, err = DependenciesAreResolved(dbdata, task.Containers, "", nil, nil)
+	_, err = DependenciesAreResolved(dbdata, task.Containers, "", nil, nil, &cfg)
 	assert.NoError(t, err, "data volume with no deps should resolve")
 
 	dbdata.SetKnownStatus(apicontainerstatus.ContainerCreated)
-	_, err = DependenciesAreResolved(php, task.Containers, "", nil, nil)
+	_, err = DependenciesAreResolved(php, task.Containers, "", nil, nil, &cfg)
 	assert.Error(t, err, "Php shouldn't run, db is not created")
 
 	db.SetKnownStatus(apicontainerstatus.ContainerCreated)
-	_, err = DependenciesAreResolved(php, task.Containers, "", nil, nil)
+	_, err = DependenciesAreResolved(php, task.Containers, "", nil, nil, &cfg)
 	assert.Error(t, err, "Php shouldn't run, db is not running")
 
-	_, err = DependenciesAreResolved(db, task.Containers, "", nil, nil)
+	_, err = DependenciesAreResolved(db, task.Containers, "", nil, nil, &cfg)
 	assert.NoError(t, err, "db should be resolved, dbdata volume is Created")
 	db.SetKnownStatus(apicontainerstatus.ContainerRunning)
 
-	_, err = DependenciesAreResolved(php, task.Containers, "", nil, nil)
+	_, err = DependenciesAreResolved(php, task.Containers, "", nil, nil, &cfg)
 	assert.NoError(t, err, "Php should resolve")
 }
 
@@ -176,19 +181,20 @@ func TestRunDependencies(t *testing.T) {
 		SteadyStateDependencies: []string{"a"},
 	}
 	task := &apitask.Task{Containers: []*apicontainer.Container{c1, c2}}
-	_, err := DependenciesAreResolved(c2, task.Containers, "", nil, nil)
+	cfg := config.Config{}
+	_, err := DependenciesAreResolved(c2, task.Containers, "", nil, nil, &cfg)
 	assert.Error(t, err, "Dependencies should not be resolved")
 
 	task.Containers[1].SetDesiredStatus(apicontainerstatus.ContainerRunning)
-	_, err = DependenciesAreResolved(c2, task.Containers, "", nil, nil)
+	_, err = DependenciesAreResolved(c2, task.Containers, "", nil, nil, &cfg)
 	assert.Error(t, err, "Dependencies should not be resolved")
 
 	task.Containers[0].SetKnownStatus(apicontainerstatus.ContainerRunning)
-	_, err = DependenciesAreResolved(c2, task.Containers, "", nil, nil)
+	_, err = DependenciesAreResolved(c2, task.Containers, "", nil, nil, &cfg)
 	assert.NoError(t, err, "Dependencies should be resolved")
 
 	task.Containers[1].SetDesiredStatus(apicontainerstatus.ContainerCreated)
-	_, err = DependenciesAreResolved(c1, task.Containers, "", nil, nil)
+	_, err = DependenciesAreResolved(c1, task.Containers, "", nil, nil, &cfg)
 	assert.NoError(t, err, "Dependencies should be resolved")
 }
 
@@ -209,17 +215,19 @@ func TestRunDependenciesWhenSteadyStateIsResourcesProvisionedForOneContainer(t *
 		},
 	}
 
+	cfg := config.Config{}
+
 	// Add a dependency on the pause container for all containers in the webserver stack
 	for _, container := range task.Containers {
 		if container.Name == "pause" {
 			continue
 		}
 		container.SteadyStateDependencies = []string{"pause"}
-		_, err := DependenciesAreResolved(container, task.Containers, "", nil, nil)
+		_, err := DependenciesAreResolved(container, task.Containers, "", nil, nil, &cfg)
 		assert.Error(t, err, "Shouldn't be resolved; pause isn't running")
 	}
 
-	_, err := DependenciesAreResolved(pause, task.Containers, "", nil, nil)
+	_, err := DependenciesAreResolved(pause, task.Containers, "", nil, nil, &cfg)
 	assert.NoError(t, err, "Pause container's dependencies should be resolved")
 
 	// Transition pause container to RUNNING
@@ -233,13 +241,13 @@ func TestRunDependenciesWhenSteadyStateIsResourcesProvisionedForOneContainer(t *
 		}
 		// Assert that dependencies remain unresolved until the pause container reaches
 		// RESOURCES_PROVISIONED
-		_, err = DependenciesAreResolved(container, task.Containers, "", nil, nil)
+		_, err = DependenciesAreResolved(container, task.Containers, "", nil, nil, &cfg)
 		assert.Error(t, err, "Shouldn't be resolved; pause isn't running")
 	}
 	pause.KnownStatusUnsafe = apicontainerstatus.ContainerResourcesProvisioned
 	// Dependecies should be resolved now that the 'pause' container has
 	// transitioned into RESOURCES_PROVISIONED
-	_, err = DependenciesAreResolved(php, task.Containers, "", nil, nil)
+	_, err = DependenciesAreResolved(php, task.Containers, "", nil, nil, &cfg)
 	assert.NoError(t, err, "Php should resolve")
 }
 
@@ -841,9 +849,10 @@ func TestContainerOrderingCanResolve(t *testing.T) {
 			Resolvable:          true,
 		},
 	}
+	cfg := config.Config{}
 	for _, tc := range testcases {
 		t.Run(fmt.Sprintf("T:%s+V:%s", tc.TargetDesired.String(), tc.DependencyDesired.String()),
-			assertContainerOrderingCanResolve(containerOrderingDependenciesCanResolve, tc.TargetDesired, tc.DependencyDesired, tc.DependencyKnown, tc.DependencyCondition, tc.ExitCode, tc.Resolvable))
+			assertContainerOrderingCanResolve(containerOrderingDependenciesCanResolve, tc.TargetDesired, tc.DependencyDesired, tc.DependencyKnown, tc.DependencyCondition, tc.ExitCode, tc.Resolvable, &cfg))
 	}
 }
 
@@ -956,13 +965,151 @@ func TestContainerOrderingIsResolved(t *testing.T) {
 			Resolved:            false,
 		},
 	}
+	cfg := config.Config{}
 	for _, tc := range testcases {
 		t.Run(fmt.Sprintf("T:%s+V:%s", tc.TargetDesired.String(), tc.DependencyKnown.String()),
-			assertContainerOrderingResolved(containerOrderingDependenciesIsResolved, tc.TargetDesired, tc.DependencyKnown, tc.DependencyCondition, tc.ExitCode, tc.Resolved))
+			assertContainerOrderingResolved(containerOrderingDependenciesIsResolved, tc.TargetDesired, tc.DependencyKnown, tc.DependencyCondition, tc.ExitCode, tc.Resolved, &cfg))
 	}
 }
 
-func assertContainerOrderingCanResolve(f func(target *apicontainer.Container, dep *apicontainer.Container, depCond string) bool, targetDesired, depDesired, depKnown apicontainerstatus.ContainerStatus, depCond string, exitcode int, expectedResolvable bool) func(t *testing.T) {
+func TestContainerOrderingIsResolvedWithContainerPullInParallel(t *testing.T) {
+	testcases := []struct {
+		TargetKnown         apicontainerstatus.ContainerStatus
+		DependencyKnown     apicontainerstatus.ContainerStatus
+		DependencyCondition string
+		Resolved            bool
+		ExitCode            int
+	}{
+		{
+			TargetKnown:         apicontainerstatus.ContainerStatusNone,
+			DependencyKnown:     apicontainerstatus.ContainerStatusNone,
+			DependencyCondition: startCondition,
+			Resolved:            true,
+		},
+		{
+			TargetKnown:         apicontainerstatus.ContainerStatusNone,
+			DependencyKnown:     apicontainerstatus.ContainerPulled,
+			DependencyCondition: startCondition,
+			Resolved:            true,
+		},
+		{
+			TargetKnown:         apicontainerstatus.ContainerStatusNone,
+			DependencyKnown:     apicontainerstatus.ContainerStopped,
+			DependencyCondition: startCondition,
+			Resolved:            true,
+		},
+		{
+			TargetKnown:         apicontainerstatus.ContainerCreated,
+			DependencyKnown:     apicontainerstatus.ContainerStatusNone,
+			DependencyCondition: startCondition,
+			Resolved:            false,
+		},
+		{
+			TargetKnown:         apicontainerstatus.ContainerStatusNone,
+			DependencyKnown:     apicontainerstatus.ContainerStatusNone,
+			DependencyCondition: successCondition,
+			Resolved:            true,
+		},
+		{
+			TargetKnown:         apicontainerstatus.ContainerStatusNone,
+			DependencyKnown:     apicontainerstatus.ContainerPulled,
+			DependencyCondition: successCondition,
+			Resolved:            true,
+		},
+		{
+			TargetKnown:         apicontainerstatus.ContainerStatusNone,
+			DependencyKnown:     apicontainerstatus.ContainerCreated,
+			DependencyCondition: successCondition,
+			Resolved:            true,
+		},
+		{
+			TargetKnown:         apicontainerstatus.ContainerStatusNone,
+			DependencyKnown:     apicontainerstatus.ContainerRunning,
+			DependencyCondition: successCondition,
+			Resolved:            true,
+		},
+		{
+			TargetKnown:         apicontainerstatus.ContainerStatusNone,
+			DependencyKnown:     apicontainerstatus.ContainerStopped,
+			ExitCode:            1,
+			DependencyCondition: successCondition,
+			Resolved:            true,
+		},
+		{
+			TargetKnown:         apicontainerstatus.ContainerPulled,
+			DependencyKnown:     apicontainerstatus.ContainerStatusNone,
+			DependencyCondition: successCondition,
+			Resolved:            false,
+		},
+		{
+			TargetKnown:         apicontainerstatus.ContainerPulled,
+			DependencyKnown:     apicontainerstatus.ContainerStopped,
+			ExitCode:            1,
+			DependencyCondition: successCondition,
+			Resolved:            false,
+		},
+		{
+			TargetKnown:         apicontainerstatus.ContainerStatusNone,
+			DependencyKnown:     apicontainerstatus.ContainerStatusNone,
+			DependencyCondition: completeCondition,
+			Resolved:            true,
+		},
+		{
+			TargetKnown:         apicontainerstatus.ContainerStatusNone,
+			DependencyKnown:     apicontainerstatus.ContainerPulled,
+			DependencyCondition: completeCondition,
+			Resolved:            true,
+		},
+		{
+			TargetKnown:         apicontainerstatus.ContainerStatusNone,
+			DependencyKnown:     apicontainerstatus.ContainerCreated,
+			DependencyCondition: completeCondition,
+			Resolved:            true,
+		},
+		{
+			TargetKnown:         apicontainerstatus.ContainerStatusNone,
+			DependencyKnown:     apicontainerstatus.ContainerRunning,
+			DependencyCondition: completeCondition,
+			Resolved:            true,
+		},
+		{
+			TargetKnown:         apicontainerstatus.ContainerStatusNone,
+			DependencyKnown:     apicontainerstatus.ContainerStopped,
+			DependencyCondition: completeCondition,
+			Resolved:            true,
+		},
+		{
+			TargetKnown:         apicontainerstatus.ContainerPulled,
+			DependencyKnown:     apicontainerstatus.ContainerStatusNone,
+			DependencyCondition: completeCondition,
+			Resolved:            false,
+		},
+	}
+	cfg := config.Config{
+		ContainerPullInParallel: config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled},
+	}
+	for _, tc := range testcases {
+		t.Run(fmt.Sprintf("DependencyCondition:%s+T:%s+V:%s", tc.DependencyCondition, tc.TargetKnown.String(), tc.DependencyKnown.String()),
+			assertContainerTargetOrderingResolved(containerOrderingDependenciesIsResolved, tc.TargetKnown, tc.DependencyKnown, tc.DependencyCondition, tc.ExitCode, tc.Resolved, &cfg))
+	}
+}
+
+func assertContainerTargetOrderingResolved(f func(target *apicontainer.Container, dep *apicontainer.Container, depCond string, cfg *config.Config) bool, targetKnown, depKnown apicontainerstatus.ContainerStatus, depCond string, exitcode int, expectedResolvable bool, cfg *config.Config) func(t *testing.T) {
+	return func(t *testing.T) {
+		target := &apicontainer.Container{
+			KnownStatusUnsafe: targetKnown,
+		}
+		dep := &apicontainer.Container{
+			KnownStatusUnsafe:   depKnown,
+			KnownExitCodeUnsafe: aws.Int(exitcode),
+		}
+
+		resolvable := f(target, dep, depCond, cfg)
+		assert.Equal(t, expectedResolvable, resolvable)
+	}
+}
+
+func assertContainerOrderingCanResolve(f func(target *apicontainer.Container, dep *apicontainer.Container, depCond string, cfg *config.Config) bool, targetDesired, depDesired, depKnown apicontainerstatus.ContainerStatus, depCond string, exitcode int, expectedResolvable bool, cfg *config.Config) func(t *testing.T) {
 	return func(t *testing.T) {
 		target := &apicontainer.Container{
 			DesiredStatusUnsafe: targetDesired,
@@ -972,12 +1119,13 @@ func assertContainerOrderingCanResolve(f func(target *apicontainer.Container, de
 			KnownStatusUnsafe:   depKnown,
 			KnownExitCodeUnsafe: aws.Int(exitcode),
 		}
-		resolvable := f(target, dep, depCond)
+
+		resolvable := f(target, dep, depCond, cfg)
 		assert.Equal(t, expectedResolvable, resolvable)
 	}
 }
 
-func assertContainerOrderingResolved(f func(target *apicontainer.Container, dep *apicontainer.Container, depCond string) bool, targetDesired, depKnown apicontainerstatus.ContainerStatus, depCond string, exitcode int, expectedResolved bool) func(t *testing.T) {
+func assertContainerOrderingResolved(f func(target *apicontainer.Container, dep *apicontainer.Container, depCond string, cfg *config.Config) bool, targetDesired, depKnown apicontainerstatus.ContainerStatus, depCond string, exitcode int, expectedResolved bool, cfg *config.Config) func(t *testing.T) {
 	return func(t *testing.T) {
 		target := &apicontainer.Container{
 			DesiredStatusUnsafe: targetDesired,
@@ -986,7 +1134,7 @@ func assertContainerOrderingResolved(f func(target *apicontainer.Container, dep 
 			KnownStatusUnsafe:   depKnown,
 			KnownExitCodeUnsafe: aws.Int(exitcode),
 		}
-		resolved := f(target, dep, depCond)
+		resolved := f(target, dep, depCond, cfg)
 		assert.Equal(t, expectedResolved, resolved)
 	}
 }
@@ -994,6 +1142,7 @@ func assertContainerOrderingResolved(f func(target *apicontainer.Container, dep 
 func TestContainerOrderingHealthyConditionIsResolved(t *testing.T) {
 	testcases := []struct {
 		TargetDesired                 apicontainerstatus.ContainerStatus
+		TargetKnown                   apicontainerstatus.ContainerStatus
 		DependencyKnownHealthStatus   apicontainerstatus.ContainerHealthStatus
 		HealthCheckType               string
 		DependencyKnownHealthExitCode int
@@ -1020,16 +1169,61 @@ func TestContainerOrderingHealthyConditionIsResolved(t *testing.T) {
 			Resolved:      false,
 		},
 	}
+	cfg := config.Config{}
 	for _, tc := range testcases {
-		t.Run(fmt.Sprintf("T:%s+V:%s", tc.TargetDesired.String(), tc.DependencyKnownHealthStatus.String()),
-			assertContainerOrderingHealthyConditionResolved(containerOrderingDependenciesIsResolved, tc.TargetDesired, tc.DependencyKnownHealthStatus, tc.HealthCheckType, tc.DependencyKnownHealthExitCode, tc.DependencyCondition, tc.Resolved))
+		t.Run(fmt.Sprintf("DependencyKnownHealthStatus:%s+T:%s+V:%s", tc.DependencyKnownHealthStatus, tc.TargetDesired.String(), tc.DependencyKnownHealthStatus.String()),
+			assertContainerOrderingHealthyConditionResolved(containerOrderingDependenciesIsResolved, tc.TargetDesired, tc.TargetKnown, tc.DependencyKnownHealthStatus, tc.HealthCheckType, tc.DependencyKnownHealthExitCode, tc.DependencyCondition, tc.Resolved, &cfg))
 	}
 }
 
-func assertContainerOrderingHealthyConditionResolved(f func(target *apicontainer.Container, dep *apicontainer.Container, depCond string) bool, targetDesired apicontainerstatus.ContainerStatus, depHealthKnown apicontainerstatus.ContainerHealthStatus, healthCheckEnabled string, depHealthKnownExitCode int, depCond string, expectedResolved bool) func(t *testing.T) {
+func TestContainerOrderingHealthyConditionIsResolvedWithContainerPullInParallel(t *testing.T) {
+	testcases := []struct {
+		TargetDesired                 apicontainerstatus.ContainerStatus
+		TargetKnown                   apicontainerstatus.ContainerStatus
+		DependencyKnownHealthStatus   apicontainerstatus.ContainerHealthStatus
+		HealthCheckType               string
+		DependencyKnownHealthExitCode int
+		DependencyCondition           string
+		Resolved                      bool
+	}{
+		{
+			TargetKnown:                 apicontainerstatus.ContainerStatusNone,
+			DependencyKnownHealthStatus: apicontainerstatus.ContainerHealthy,
+			HealthCheckType:             "docker",
+			DependencyCondition:         healthyCondition,
+			Resolved:                    true,
+		},
+		{
+			TargetKnown:                   apicontainerstatus.ContainerStatusNone,
+			DependencyKnownHealthStatus:   apicontainerstatus.ContainerUnhealthy,
+			HealthCheckType:               "docker",
+			DependencyKnownHealthExitCode: 1,
+			DependencyCondition:           healthyCondition,
+			Resolved:                      true,
+		},
+		{
+			TargetKnown:                   apicontainerstatus.ContainerPulled,
+			DependencyKnownHealthStatus:   apicontainerstatus.ContainerUnhealthy,
+			HealthCheckType:               "docker",
+			DependencyKnownHealthExitCode: 1,
+			DependencyCondition:           healthyCondition,
+			Resolved:                      false,
+		},
+	}
+	cfg := config.Config{
+		ContainerPullInParallel: config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled},
+	}
+	for _, tc := range testcases {
+		t.Run(fmt.Sprintf("DependencyKnownHealthStatus:%s+T:%s+V:%s", tc.DependencyKnownHealthStatus, tc.TargetKnown.String(), tc.DependencyKnownHealthStatus.String()),
+			assertContainerOrderingHealthyConditionResolved(containerOrderingDependenciesIsResolved, tc.TargetDesired, tc.TargetKnown, tc.DependencyKnownHealthStatus, tc.HealthCheckType, tc.DependencyKnownHealthExitCode, tc.DependencyCondition, tc.Resolved, &cfg))
+	}
+}
+
+func assertContainerOrderingHealthyConditionResolved(f func(target *apicontainer.Container, dep *apicontainer.Container, depCond string, cfg *config.Config) bool, targetDesired apicontainerstatus.ContainerStatus, targetKnown apicontainerstatus.ContainerStatus, depHealthKnown apicontainerstatus.ContainerHealthStatus, healthCheckEnabled string, depHealthKnownExitCode int, depCond string, expectedResolved bool, cfg *config.Config) func(t *testing.T) {
 	return func(t *testing.T) {
 		target := &apicontainer.Container{
 			DesiredStatusUnsafe: targetDesired,
+			KnownStatusUnsafe:   targetKnown,
 		}
 		dep := &apicontainer.Container{
 			Health: apicontainer.HealthStatus{
@@ -1038,7 +1232,7 @@ func assertContainerOrderingHealthyConditionResolved(f func(target *apicontainer
 			},
 			HealthCheckType: healthCheckEnabled,
 		}
-		resolved := f(target, dep, depCond)
+		resolved := f(target, dep, depCond, cfg)
 		assert.Equal(t, expectedResolved, resolved)
 	}
 }

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -710,7 +710,7 @@ func (engine *DockerTaskEngine) AddTask(task *apitask.Task) {
 		task.UpdateDesiredStatus()
 
 		engine.state.AddTask(task)
-		if dependencygraph.ValidDependencies(task) {
+		if dependencygraph.ValidDependencies(task, engine.cfg) {
 			engine.startTask(task)
 		} else {
 			seelog.Errorf("Task engine [%s]: unable to progress task with circular dependencies", task.Arn)
@@ -873,6 +873,12 @@ func (engine *DockerTaskEngine) pullAndUpdateContainerReference(task *apitask.Ta
 		return metadata
 	}
 	pullSucceeded := metadata.Error == nil
+	if pullSucceeded && engine.cfg.ContainerPullInParallel.Enabled() {
+		dockerContainer := &apicontainer.DockerContainer{
+			Container: container,
+		}
+		engine.state.AddContainer(dockerContainer, task)
+	}
 	engine.updateContainerReference(pullSucceeded, container, task.Arn)
 	return metadata
 }

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -1660,6 +1660,44 @@ func TestUpdateContainerReference(t *testing.T) {
 	assert.True(t, imageState.PullSucceeded, "PullSucceeded set to false")
 }
 
+// TestPullAndUpdateContainerReference checks whether a container is added to task engine state when
+// PullSucceeded of the image is fulfilled and ContainerPullInParallel is enabled.
+func TestPullAndUpdateContainerReference(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	cfg := &config.Config{
+		ContainerPullInParallel: config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled},
+	}
+	ctrl, client, _, privateTaskEngine, _, imageManager, _ := mocks(t, ctx, cfg)
+	defer ctrl.Finish()
+
+	taskEngine, _ := privateTaskEngine.(*DockerTaskEngine)
+	taskEngine._time = nil
+	imageName := "image"
+	taskArn := "taskArn"
+	container := &apicontainer.Container{
+		Type:  apicontainer.ContainerNormal,
+		Image: imageName,
+	}
+	task := &apitask.Task{
+		Arn:        taskArn,
+		Containers: []*apicontainer.Container{container},
+	}
+	imageState := &image.ImageState{
+		Image: &image.Image{ImageID: "id"},
+	}
+
+	client.EXPECT().PullImage(gomock.Any(), imageName, gomock.Any(), gomock.Any())
+	imageManager.EXPECT().RecordContainerReference(container)
+	imageManager.EXPECT().GetImageStateFromImageName(imageName).Return(imageState, true)
+	metadata := taskEngine.pullAndUpdateContainerReference(task, container)
+	containersMap, ok := taskEngine.State().ContainerMapByArn(taskArn)
+	require.True(t, ok, "no container found in the agent state")
+	require.Len(t, containersMap, 1)
+	assert.True(t, imageState.PullSucceeded, "PullSucceeded set to false")
+	assert.Equal(t, dockerapi.DockerContainerMetadata{}, metadata, "expected empty metadata")
+}
+
 // TestMetadataFileUpdatedAgentRestart checks whether metadataManager.Update(...) is
 // invoked in the path DockerTaskEngine.Init() -> .synchronizeState() -> .updateMetadataFile(...)
 // for the following case:

--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -1021,7 +1021,7 @@ func (mtask *managedTask) containerNextState(container *apicontainer.Container) 
 		}
 	}
 	if blocked, err := dependencygraph.DependenciesAreResolved(container, mtask.Containers,
-		mtask.Task.GetExecutionCredentialsID(), mtask.credentialsManager, mtask.GetResources()); err != nil {
+		mtask.Task.GetExecutionCredentialsID(), mtask.credentialsManager, mtask.GetResources(), mtask.cfg); err != nil {
 		seelog.Debugf("Managed task [%s]: can't apply state to container [%s (Runtime ID: %s)] yet due to unresolved dependencies: %v",
 			mtask.Arn, container.Name, container.GetRuntimeID(), err)
 		return &containerTransition{

--- a/agent/handlers/v3/container_metadata_handler.go
+++ b/agent/handlers/v3/container_metadata_handler.go
@@ -80,8 +80,9 @@ func GetContainerResponse(containerID string, state dockerstate.TaskEngineState)
 // GetContainerNetworkMetadata returns the network metadata for the container
 func GetContainerNetworkMetadata(containerID string, state dockerstate.TaskEngineState) ([]containermetadata.Network, error) {
 	dockerContainer, ok := state.ContainerByID(containerID)
+	// For the container in the 'Pulled' state, no error will be returned as network metadata may not be presented yet
 	if !ok {
-		return nil, errors.Errorf("Unable to find container '%s'", containerID)
+		return []containermetadata.Network{}, nil
 	}
 	// the logic here has been reused from
 	// https://github.com/aws/amazon-ecs-agent/blob/0c8913ba33965cf6ffdd6253fad422458d9346bd/agent/containermetadata/parse_metadata.go#L123

--- a/agent/handlers/v4/container_metadata_handler.go
+++ b/agent/handlers/v4/container_metadata_handler.go
@@ -81,8 +81,9 @@ func GetContainerResponse(containerID string, state dockerstate.TaskEngineState)
 // GetContainerNetworkMetadata returns the network metadata for the container
 func GetContainerNetworkMetadata(containerID string, state dockerstate.TaskEngineState) ([]Network, error) {
 	dockerContainer, ok := state.ContainerByID(containerID)
+	// For the container in the 'Pulled' state, no error will be returned as network metadata may not be presented yet
 	if !ok {
-		return nil, errors.Errorf("unable to find container '%s'", containerID)
+		return []Network{}, nil
 	}
 	// the logic here has been reused from
 	// https://github.com/aws/amazon-ecs-agent/blob/0c8913ba33965cf6ffdd6253fad422458d9346bd/agent/containermetadata/parse_metadata.go#L123


### PR DESCRIPTION
### Summary
This PR introduces a new environment variable __ECS_PULL_DEPENDENT_CONTAINER_PARALLEL__ in agent with default value set to __false__. If the variable is specified to __true__, pull images process of dependent containers will start, even though the __dependsOn condition: START/SUCCESS/COMPLETE/HEALTHY__ in a task definition has not been satisfied.  
  
In the following example, there are 2 containers: A and B. Container B is a __target__ container, and container A is a __dependsOn__ container. If __ECS_PULL_DEPENDENT_CONTAINER_PARALLEL = true__, container B starts pull images process before container A fulfilled SUCCESS condition; if the environment variable is not specified, or is set to false, container B starts pull images process only when container A reaches to SUCCESS condition.
  
```
The dependsOn container - container  A
"dependsOn": null
"command": [
    "sh",
    "-c",
    "sleep 300"
]
```
```
The target container - container B
"dependsOn": [
    {
        "containerName": "A",
        "condition": "SUCCESS"
    }
]

"command": [
    "sh",
    "-c",
    "sleep 100"
]
```

### Implementation details

- Define _Config.ContainerPullInParallel_ type in _types.go_ to specify whether pull containers in parallel should be applied to this agent.
- Convert the reading environment variable ECS_PULL_DEPENDENT_CONTAINER_PARALLEL to _Config.ContainerPullInParallel_ type in _config.go_, and set its default value to __false__ in _config_unix.go_ and _config_windows.go_
- Pass the config from function containerNextState in _/agent/engine/task_manager.go_ -> function DependenciesAreResolved in _/agent/engine/dependencygraph/graph.go_ -> function containerOrderingDependenciesIsResolved in _/agent/engine/dependencygraph/graph.go_  
- Allow the target container to be moved to created or the steady state if the config has _Config.ContainerPullInParallel_ enabled, and the known status of the target container has not reached to _PULLED_ state
- Add the target container to engine state when __pullSucceeded__ and the config has __Config.ContainerPullInParallel enabled__ in _docker_task_engine.go_
- Return an empty network metadata for the containers in __PULLED__ state, handled by Task Metadata Endpoint (TMDE) version 3 and 4, as network metadata may not be presented yet.


### Testing
Manual test:
Set __ECS_PULL_DEPENDENT_CONTAINER_PARALLEL=false/true__,  run task definitions with __dependsOn condition: START/SUCCESS/COMPLETE/HEALTHY__, verify test results from __ecs-agent.log__ and __TMDE V3 and V4 task responses__. Test results are shown below.

1. dependsOn: __START__
- Set to false : container B will not start pull images process if container A has not reached to START state
- Set to true: container B starts pull images process before container A reaches to START state
```
level=info time=T05:43:36Z msg="Task engine: finished pulling image for container B 
level=info time=T05:43:36Z msg="Managed task: Container [name=B runtimeID=]: handling container change event [PULLED]
level=info time=T05:43:54Z msg="Task engine: error transitioning container [A (Runtime ID: )] to [PULLED]: Error 
```

2. dependsOn: __SUCCESS__
- Set to false: container B starts pull images process after container A exits with exit code 0
- Set to true: container B starts pull images process before A exits with exit code 0. And container B `KnownStatus: PULLED` can be found in container A's TMDE V4 task responses, as follows 
```
$ curl {Container A's ECS_CONTAINER_METADATA_URI_V4}/task
{
    "Containers": [
        {
            "DockerId": "DockerId",
            "Name": "A",
             "DockerName": "DockerName",
            "KnownStatus": "RUNNING",
            "CreatedAt": "2020-11-06xxxx",
            "StartedAt": "2020-11-06xxxx",
            "Networks": [...]
        },
        {
            "DockerId": "",
            "Name": "B",
            "DockerName": "",
            "KnownStatus": "PULLED",
        }
    ]
}
```

3. dependsOn: __COMPLETE__
- Set to false: container B starts pull images process after container A exits with exit code
- Set to true: container B starts pull images process before A exits with exit code. And container B `KnownStatus: PULLED` can be found in container A's TMDE V4 task responses, as follows
```
$ curl {Container A's ECS_CONTAINER_METADATA_URI_V4}/task
{
    "Containers": [
        {
            "DockerId": "DockerId",
            "Name": "A",
            "DockerName": "DockerName",
            "KnownStatus": "RUNNING",
            "CreatedAt": "2020-11-06xxxx",
            "StartedAt": "2020-11-06xxxx",
             "Networks": [...]
        },
        {
            "DockerId": "",
            "Name": "B",
            "DockerName": "",
            "KnownStatus": "PULLED",
        }
    ]
}
```

4. dependsOn: __HEALTHY__
- Set to false: container B will not start pull image process if container A has not reached to HEALTHY state
- Set to true: container B starts pull images process before container A reaches to HEALTHY state. And container B `KnownStatus: PULLED` can be found in container A's TMDE V4 task responses, as follows
```
$ curl {Container A's ECS_CONTAINER_METADATA_URI_V4}/task
{
   "Containers": [
        {
            "DockerId": "DockerId",
            "Name": "A",
            "DockerName": "DockerName",
            "KnownStatus": "RUNNING",
            "CreatedAt": "2020-11-06xxxx",
            "StartedAt": "2020-11-06xxxx",
            "Health": { "status": "UNHEALTHY",.. },
            "Networks": [...]
        },
        {
            "DockerId": "",
            "Name": "B",
            "DockerName": "",
            "KnownStatus": "PULLED",
        }
    ]
}
```
  
New tests cover the changes: yes

- TestContainerOrderingIsResolvedWithContainerPullInParallel: an unit test to verify function _containerOrderingDependenciesIsResolved_ in _graph.go_
- TestContainerOrderingHealthyConditionIsResolvedWithContainerPullInParallel: an unit test to verify function _containerOrderingDependenciesIsResolved_ in _graph.go_
- TestPullAndUpdateContainerReference: an unit test to verify function _pullAndUpdateContainerReference_ in _docker_task_engine.go_
- Value of ContainerPullInParallel is tested in _config_windows_test.go_, _config_unix_test.go_ and _config_test.go_
  
### Description for the changelog
N/A
  
### Licensing
  
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
