### PR TITLE
Use latest version available in deps bin dir

### DIFF
--- a/agent/engine/engine_sudo_linux_integ_test.go
+++ b/agent/engine/engine_sudo_linux_integ_test.go
@@ -364,8 +364,7 @@ func TestExecCommandAgent(t *testing.T) {
 	client, err := sdkClient.NewClientWithOpts(sdkClient.WithHost(endpoint), sdkClient.WithVersion(sdkclientfactory.GetDefaultVersion().String()))
 	require.NoError(t, err, "Creating go docker client failed")
 
-	testExecCmdHostBinDir, err := filepath.Abs("../../misc/exec-command-agent-test")
-	require.NoError(t, err)
+	testExecCmdHostBinDir := "/managed-agents/execute-command/bin"
 
 	taskEngine, done, _ := setupEngineForExecCommandAgent(t, testExecCmdHostBinDir)
 	stateChangeEvents := taskEngine.StateChangeEvents()
@@ -393,7 +392,7 @@ func TestExecCommandAgent(t *testing.T) {
 
 	// session limit is 2
 	testConfigFileName, _ := execcmd.GetExecAgentConfigFileName(2)
-	verifyExecCmdAgentExpectedMounts(t, ctx, client, testTaskId, cid, testContainerName, testExecCmdHostBinDir, testConfigFileName)
+	verifyExecCmdAgentExpectedMounts(t, ctx, client, testTaskId, cid, testContainerName, testExecCmdHostBinDir+"/1.0.0.0", testConfigFileName)
 	pidA := verifyMockExecCommandAgentIsRunning(t, client, cid)
 	seelog.Infof("Verified mock ExecCommandAgent is running (pidA=%s)", pidA)
 	killMockExecCommandAgent(t, client, cid, pidA)
@@ -456,8 +455,7 @@ func TestManagedAgentEvent(t *testing.T) {
 			client, err := sdkClient.NewClientWithOpts(sdkClient.WithHost(endpoint), sdkClient.WithVersion(sdkclientfactory.GetDefaultVersion().String()))
 			require.NoError(t, err, "Creating go docker client failed")
 
-			testExecCmdHostBinDir, err := filepath.Abs("../../misc/exec-command-agent-test")
-			require.NoError(t, err)
+			testExecCmdHostBinDir := "/managed-agents/execute-command/bin"
 
 			taskEngine, done, _ := setupEngineForExecCommandAgent(t, testExecCmdHostBinDir)
 			defer done()
@@ -551,7 +549,7 @@ const (
 func verifyExecCmdAgentExpectedMounts(t *testing.T,
 	ctx context.Context,
 	client *sdkClient.Client,
-	testTaskId, containerId, containerName, testExecCmdHostBinDir, testConfigFileName string) {
+	testTaskId, containerId, containerName, testExecCmdHostVersionedBinDir, testConfigFileName string) {
 	inspectState, _ := client.ContainerInspect(ctx, containerId)
 
 	expectedMounts := []struct {
@@ -560,17 +558,17 @@ func verifyExecCmdAgentExpectedMounts(t *testing.T,
 		readOnly  bool
 	}{
 		{
-			source:    filepath.Join(testExecCmdHostBinDir, execcmd.SSMAgentBinName),
+			source:    filepath.Join(testExecCmdHostVersionedBinDir, execcmd.SSMAgentBinName),
 			destRegex: filepath.Join(containerDepsPrefixRegex, execcmd.SSMAgentBinName),
 			readOnly:  true,
 		},
 		{
-			source:    filepath.Join(testExecCmdHostBinDir, execcmd.SSMAgentWorkerBinName),
+			source:    filepath.Join(testExecCmdHostVersionedBinDir, execcmd.SSMAgentWorkerBinName),
 			destRegex: filepath.Join(containerDepsPrefixRegex, execcmd.SSMAgentWorkerBinName),
 			readOnly:  true,
 		},
 		{
-			source:    filepath.Join(testExecCmdHostBinDir, execcmd.SessionWorkerBinName),
+			source:    filepath.Join(testExecCmdHostVersionedBinDir, execcmd.SessionWorkerBinName),
 			destRegex: filepath.Join(containerDepsPrefixRegex, execcmd.SessionWorkerBinName),
 			readOnly:  true,
 		},

--- a/agent/engine/execcmd/manager.go
+++ b/agent/engine/execcmd/manager.go
@@ -26,9 +26,7 @@ import (
 
 const (
 	hostExecDepsDir = "/var/lib/ecs/deps/execute-command"
-	// TODO: [ecs-exec]: This version should be dynamic, need to confirm with ssm team what's the exact format so we can always pick the latest
-	ssmBinVersion = "3.0.236.0"
-	HostBinDir    = hostExecDepsDir + "/bin/" + ssmBinVersion
+	HostBinDir      = hostExecDepsDir + "/bin"
 
 	ExecuteCommandAgentName    = "ExecuteCommandAgent"
 	defaultStartRetryTimeout   = time.Minute * 10

--- a/misc/exec-command-agent-test/build-mock-ssm-agent
+++ b/misc/exec-command-agent-test/build-mock-ssm-agent
@@ -12,5 +12,10 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-rm -rf ./amazon-ssm-agent
-CGO_ENABLED=0 go build -tags integration -installsuffix cgo -a -o amazon-ssm-agent ./sleep/
+SIMULATED_ECS_AGENT_DEPS_BIN_DIR="/managed-agents/execute-command/bin/1.0.0.0"
+rm -rf ./$SIMULATED_ECS_AGENT_DEPS_BIN_DIR
+mkdir $SIMULATED_ECS_AGENT_DEPS_BIN_DIR # mock version folder for our mock ssm agent binaries
+CGO_ENABLED=0 go build -tags integration -installsuffix cgo -a -o $SIMULATED_ECS_AGENT_DEPS_BIN_DIR/amazon-ssm-agent ./sleep/
+touch $SIMULATED_ECS_AGENT_DEPS_BIN_DIR/ssm-agent-worker
+touch $SIMULATED_ECS_AGENT_DEPS_BIN_DIR/ssm-session-worker
+


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
`execcmd.InitializeContainer` should grab the latest version available in `/var/lib/ecs/deps/execute-command/bin`

for example, given the following directory structure

```
/var/lib/ecs/deps/execute-command/bin
                                    +---- 1.0.0.0
                                    +---- 2.0.0.0
                                    +---- random-dir
                                    +---- 3.0.236.0                                    
```
it should be inferred that the version to use is `/var/lib/ecs/deps/execute-command/bin/3.0.236.0`

So as long as there's a directory with a valid version and valid dependencies, we grab it; this avoids hard-coding the initial ssm version and future-proofs the ecs agent for ssm version updates.

### Implementation details
<!-- How are the changes implemented? -->

`execcmd.InitializeContainer` will list the directories inside the ecs agent container's `/managed-agents/execute-command/bin` folder. Then create a collection of ssm agent versions by attempting to parse each dir name. Dirs that cannot be parsed into valid versions will be omitted as we can't error out the whole process based on an unexpected file in our bin dir. 
Next, we will sort our list of versions in reverse order and will attempt to find the necessary binaries inside each of the version folders, the first folder that contains the dependencies is our latest valid version that will be mounted into customer's containers.

If no valid versions are found inside `/var/lib/ecs/deps/execute-command/bin/`, we return an error.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

Adapted and ran integ tests and UTs
New tests cover the changes: yes <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
