### PR TITLE
Add managed agent stopped and running event integ test

### DIFF
--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -3229,24 +3229,34 @@ func TestMonitorExecAgentRunning(t *testing.T) {
 		containerStatus                apicontainerstatus.ContainerStatus
 		execCommandAgentState          apicontainer.ManagedAgentState
 		execAgentStatus                apicontainerstatus.ManagedAgentStatus
+		restartStatus                  execcmd.RestartStatus
 		simulateBadContainerId         bool
 		expectedRestartInUnhealthyCall bool
 		expectContainerEvent           bool
 	}{
 		{
 			containerStatus:      apicontainerstatus.ContainerStopped,
-			expectContainerEvent: false,
 			execAgentStatus:      apicontainerstatus.ManagedAgentStopped,
+			restartStatus:        execcmd.NotRestarted,
+			expectContainerEvent: false,
 		},
 		{
 			containerStatus:        apicontainerstatus.ContainerRunning,
 			simulateBadContainerId: true,
-			expectContainerEvent:   false,
 			execAgentStatus:        apicontainerstatus.ManagedAgentStopped,
+			restartStatus:          execcmd.NotRestarted,
+			expectContainerEvent:   false,
 		},
 		{
 			containerStatus:      apicontainerstatus.ContainerRunning,
 			execAgentStatus:      apicontainerstatus.ManagedAgentRunning,
+			restartStatus:        execcmd.NotRestarted,
+			expectContainerEvent: false,
+		},
+		{
+			containerStatus:      apicontainerstatus.ContainerRunning,
+			execAgentStatus:      apicontainerstatus.ManagedAgentRunning,
+			restartStatus:        execcmd.Restarted,
 			expectContainerEvent: true,
 		},
 	}
@@ -3282,10 +3292,12 @@ func TestMonitorExecAgentRunning(t *testing.T) {
 			testTask.Containers[0].RuntimeID = ""
 		}
 		if tc.containerStatus == apicontainerstatus.ContainerRunning && !tc.simulateBadContainerId {
-			execCmdMgr.EXPECT().RestartAgentIfStopped(dockerTaskEngine.ctx, dockerTaskEngine.client, testTask, testTask.Containers[0], testContainerId).
-				Return(execcmd.NotRestarted, nil).
+			execCmdMgr.EXPECT().RestartAgentIfStopped(dockerTaskEngine.ctx, dockerTaskEngine.client, testTask,
+				testTask.Containers[0], testContainerId).
+				Return(tc.restartStatus, nil).
 				Times(1)
 		}
+
 		// check for expected containerEvent in stateChangeEvents
 		waitDone := make(chan struct{})
 		expectedManagedAgent := apicontainer.ManagedAgent{
@@ -3293,6 +3305,7 @@ func TestMonitorExecAgentRunning(t *testing.T) {
 				Status: apicontainerstatus.ManagedAgentRunning,
 			},
 		}
+		// only if we expect restart will we also expect a managed agent container event
 		go checkManagedAgentEvents(t, tc.expectContainerEvent, stateChangeEvents, expectedManagedAgent, waitDone)
 
 		taskEngine.(*DockerTaskEngine).monitorExecAgentRunning(ctx, mTestTask, testTask.Containers[0])
@@ -3304,7 +3317,6 @@ func TestMonitorExecAgentRunning(t *testing.T) {
 			timeout = true
 		}
 		assert.False(t, timeout)
-
 	}
 }
 
@@ -3344,11 +3356,12 @@ func TestMonitorExecAgentProcesses(t *testing.T) {
 	dockerTaskEngine.managedTasks[testTask.Arn] = mTestTask
 	restartCtx, restartCancel := context.WithTimeout(context.Background(), time.Second)
 	defer restartCancel()
+	// return execcmd.Restarted to ensure container event emission
 	execCmdMgr.EXPECT().RestartAgentIfStopped(dockerTaskEngine.ctx, dockerTaskEngine.client, testTask, testTask.Containers[0], testTask.Containers[0].RuntimeID).
 		DoAndReturn(
 			func(ctx context.Context, client dockerapi.DockerClient, task *apitask.Task, container *apicontainer.Container, containerId string) (execcmd.RestartStatus, error) {
 				defer restartCancel()
-				return execcmd.NotRestarted, nil
+				return execcmd.Restarted, nil
 			}).
 		Times(1)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Adds integration test for state change events RUNNING and STOPPED.   Removes redundant container event emission of managed agent RUNNING->RUNNING.

### Implementation details
Added a condition around emitContainerEvent.
Re-used a minimal section of TestExecCommandAgent to test managed agent container event emission for RUNNING and for STOPPED

### Testing
ran 30x to test for flakiness locally:
`sudo -E env "PATH=$PATH" go test -tags sudo -count=1 -v -run="TestManagedAgentEvent" ./agent/engine/...`
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

### Description for the changelog
Add ManagedAgentEvent integration test.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
