### PR TITLE
improve logging for eni attachment issues

### DIFF
--- a/agent/api/eni/eniattachment.go
+++ b/agent/api/eni/eniattachment.go
@@ -143,11 +143,11 @@ func (eni *ENIAttachment) stringUnsafe() string {
 	// skip TaskArn field for instance level eni attachment since it won't have a task arn
 	if eni.AttachmentType == ENIAttachmentTypeInstanceENI {
 		return fmt.Sprintf(
-			"ENI Attachment: attachment=%s;attachmentType=%s;attachmentSent=%t;mac=%s;status=%s;expiresAt=%s",
-			eni.AttachmentARN, eni.AttachmentType, eni.AttachStatusSent, eni.MACAddress, eni.Status.String(), eni.ExpiresAt.String())
+			"ENI Attachment: attachment=%s attachmentType=%s attachmentSent=%t mac=%s status=%s expiresAt=%s",
+			eni.AttachmentARN, eni.AttachmentType, eni.AttachStatusSent, eni.MACAddress, eni.Status.String(), eni.ExpiresAt.Format(time.RFC3339))
 	}
 
 	return fmt.Sprintf(
-		"ENI Attachment: task=%s;attachment=%s;attachmentType=%s;attachmentSent=%t;mac=%s;status=%s;expiresAt=%s",
-		eni.TaskARN, eni.AttachmentARN, eni.AttachmentType, eni.AttachStatusSent, eni.MACAddress, eni.Status.String(), eni.ExpiresAt.String())
+		"ENI Attachment: task=%s attachment=%s attachmentType=%s attachmentSent=%t mac=%s status=%s expiresAt=%s",
+		eni.TaskARN, eni.AttachmentARN, eni.AttachmentType, eni.AttachStatusSent, eni.MACAddress, eni.Status.String(), eni.ExpiresAt.Format(time.RFC3339))
 }

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -321,7 +321,7 @@ func (engine *DockerTaskEngine) synchronizeState() {
 				return
 			}
 			if !eniAttachment.IsSent() {
-				seelog.Warnf("Timed out waiting for ENI ack; removing ENI attachment record with MAC address: %s", eniAttachment.MACAddress)
+				seelog.Warnf("Timed out waiting for ENI ack; removing ENI attachment record %s", eniAttachment.String())
 				engine.removeENIAttachmentData(eniAttachment.MACAddress)
 				engine.state.RemoveENIAttachment(eniAttachment.MACAddress)
 			}
@@ -330,7 +330,7 @@ func (engine *DockerTaskEngine) synchronizeState() {
 		if err != nil {
 			// The only case where we get an error from Initialize is that the attachment has expired. In that case, remove the expired
 			// attachment from state.
-			seelog.Warnf("ENI attachment with mac address %s has expired. Removing it from state.", eniAttachment.MACAddress)
+			seelog.Warnf("ENI attachment has expired. Removing it from state. %s", eniAttachment.String())
 			engine.removeENIAttachmentData(eniAttachment.MACAddress)
 			engine.state.RemoveENIAttachment(eniAttachment.MACAddress)
 		}

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -1872,6 +1872,7 @@ func TestNewTaskTransitionOnRestart(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockTime.EXPECT().Now().AnyTimes()
+	mockTime.EXPECT().After(gomock.Any()).AnyTimes()
 	client.EXPECT().Version(gomock.Any(), gomock.Any()).MaxTimes(1)
 	client.EXPECT().ContainerEvents(gomock.Any()).MaxTimes(1)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

Makes the log messages a bit more readable by removing unecessary semicolons and formats the timestamp to rfc3339. Also adds full eni details whenever available, where previously we were only printing the mac address.

log messages go from this:

```
level=info time=2020-11-02T16:08:49Z msg="Starting ENI ack timer with duration=2m59.99997755s, ENI Attachment: task=arn:aws:ecs:us-west-1:815665286609:task/stage-us-portal-ecs/6e8b2feb312c4e25a5cb2eeda2123c8a;attachment=arn:aws:ecs:us-west-1:815665286609:attachment/86d74d88-de5d-422c-a71f-4411a3a536e8;attachmentType=task-eni;attachmentSent=false;mac=06:5a:98:fe:4f:67;status=NONE;expiresAt=2020-11-02 16:11:49.2183602 +0000 UTC m=+672.840860713" module=eniattachment.go
...
level=warn time=2020-11-02T16:11:49Z msg="Timed out waiting for ENI ack; removing ENI attachment record with MAC address: 06:5a:98:fe:4f:67" module=attach_eni_handler_common.go
```

to this:

```
level=info time=2020-11-02T16:08:49Z msg="Starting ENI ack timer with duration=2m59.99997755s, ENI Attachment: task=arn:aws:ecs:us-west-1:815665286609:task/stage-us-portal-ecs/6e8b2feb312c4e25a5cb2eeda2123c8a attachment=arn:aws:ecs:us-west-1:815665286609:attachment/86d74d88-de5d-422c-a71f-4411a3a536e8 attachmentType=task-eni;attachmentSent=false mac=06:5a:98:fe:4f:67 status=NONE expiresAt=2020-11-02T16:11:49Z" module=eniattachment.go
...
level=warn time=2020-11-02T16:11:49Z msg="Timed out waiting for ENI ack; removing ENI attachment, ENI Attachment: task=arn:aws:ecs:us-west-1:815665286609:task/stage-us-portal-ecs/6e8b2feb312c4e25a5cb2eeda2123c8a attachment=arn:aws:ecs:us-west-1:815665286609:attachment/86d74d88-de5d-422c-a71f-4411a3a536e8 attachmentType=task-eni attachmentSent=false mac=06:5a:98:fe:4f:67 status=NONE expiresAt=2020-11-02T16:11:49Z" module=attach_eni_handler_common.go
```

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

enhancement: more informative eni attachment logs

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
