### PR TITLE
generate and mount seelog config file to exec containers

### DIFF
--- a/agent/engine/engine_sudo_linux_integ_test.go
+++ b/agent/engine/engine_sudo_linux_integ_test.go
@@ -442,7 +442,8 @@ func TestExecCommandAgent(t *testing.T) {
 
 	// session limit is 2
 	testConfigFileName, _ := execcmd.GetExecAgentConfigFileName(2)
-	verifyExecCmdAgentExpectedMounts(t, ctx, client, testTaskId, cid, testContainerName, testExecCmdHostBinDir+"/1.0.0.0", testConfigFileName)
+	testLogConfigFileName, _ := execcmd.GetExecAgentLogConfigFile()
+	verifyExecCmdAgentExpectedMounts(t, ctx, client, testTaskId, cid, testContainerName, testExecCmdHostBinDir+"/1.0.0.0", testConfigFileName, testLogConfigFileName)
 	pidA := verifyMockExecCommandAgentIsRunning(t, client, cid)
 	seelog.Infof("Verified mock ExecCommandAgent is running (pidA=%s)", pidA)
 	killMockExecCommandAgent(t, client, cid, pidA)
@@ -599,7 +600,7 @@ const (
 func verifyExecCmdAgentExpectedMounts(t *testing.T,
 	ctx context.Context,
 	client *sdkClient.Client,
-	testTaskId, containerId, containerName, testExecCmdHostVersionedBinDir, testConfigFileName string) {
+	testTaskId, containerId, containerName, testExecCmdHostVersionedBinDir, testConfigFileName, testLogConfigFileName string) {
 	inspectState, _ := client.ContainerInspect(ctx, containerId)
 
 	expectedMounts := []struct {
@@ -630,6 +631,11 @@ func verifyExecCmdAgentExpectedMounts(t *testing.T,
 		{
 			source:    filepath.Join(execcmd.HostExecConfigDir, testConfigFileName),
 			destRegex: filepath.Join(containerDepsPrefixRegex, execcmd.ContainerConfigFileSuffix),
+			readOnly:  true,
+		},
+		{
+			source:    filepath.Join(execcmd.HostExecConfigDir, testLogConfigFileName),
+			destRegex: filepath.Join(containerDepsPrefixRegex, execcmd.ContainerLogConfigFile),
 			readOnly:  true,
 		},
 		{


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This generates static seelog config file for exec agent if its not already present. If present, it checks the validity of the seelog config content. 
This file is then bind mounted to the exec enabled containers. 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

### Description for the changelog
N/A

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
