### PR TITLE
save RCI client token to agent state

### DIFF
--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -117,6 +117,7 @@ type ecsAgent struct {
 	resourceFields              *taskresource.ResourceFields
 	availabilityZone            string
 	latestSeqNumberTaskManifest *int64
+	registrationToken           string
 }
 
 // newAgent returns a new ecsAgent object, but does not start anything
@@ -402,7 +403,7 @@ func (agent *ecsAgent) newTaskEngine(containerChangeEventStream *eventstream.Eve
 	agent.containerInstanceARN = savedData.containerInstanceARN
 	agent.availabilityZone = savedData.availabilityZone
 	agent.latestSeqNumberTaskManifest = &savedData.latestTaskManifestSeqNum
-
+	agent.registrationToken = savedData.registrationToken
 	return savedData.taskEngine, currentEC2InstanceID, nil
 }
 
@@ -473,7 +474,8 @@ func (agent *ecsAgent) newStateManager(
 	cluster *string,
 	containerInstanceArn *string,
 	savedInstanceID *string,
-	availabilityZone *string, latestSeqNumberTaskManifest *int64) (statemanager.StateManager, error) {
+	availabilityZone *string,
+	latestSeqNumberTaskManifest *int64) (statemanager.StateManager, error) {
 	if !agent.cfg.Checkpoint.Enabled() {
 		return statemanager.NewNoopStateManager(), nil
 	}
@@ -537,15 +539,20 @@ func (agent *ecsAgent) registerContainerInstance(
 	platformDevices := agent.getPlatformDevices()
 
 	outpostARN := agent.getoutpostARN()
-
+	if agent.registrationToken == "" {
+		agent.registrationToken = uuid.New()
+		if agent.cfg.Checkpoint.Enabled() {
+			agent.saveMetadata(data.RegistrationTokenKey, agent.registrationToken)
+		}
+	}
 	if agent.containerInstanceARN != "" {
 		seelog.Infof("Restored from checkpoint file. I am running as '%s' in cluster '%s'", agent.containerInstanceARN, agent.cfg.Cluster)
-		return agent.reregisterContainerInstance(client, capabilities, tags, uuid.New(), platformDevices, outpostARN)
+		return agent.reregisterContainerInstance(client, capabilities, tags, agent.registrationToken, platformDevices, outpostARN)
 	}
 
 	seelog.Info("Registering Instance with ECS")
 	containerInstanceArn, availabilityZone, err := client.RegisterContainerInstance("",
-		capabilities, tags, uuid.New(), platformDevices, outpostARN)
+		capabilities, tags, agent.registrationToken, platformDevices, outpostARN)
 	if err != nil {
 		seelog.Errorf("Error registering: %v", err)
 		if retriable, ok := err.(apierrors.Retriable); ok && !retriable.Retry() {

--- a/agent/app/agent_test.go
+++ b/agent/app/agent_test.go
@@ -709,8 +709,9 @@ func TestNewTaskEngineRestoreFromCheckpoint(t *testing.T) {
 		containerInstanceARN:     agent.containerInstanceARN,
 		ec2InstanceID:            instanceID,
 		latestTaskManifestSeqNum: *agent.latestSeqNumberTaskManifest,
+		registrationToken:        agent.registrationToken,
 	}
-	checkLoadedData(state, s, t)
+	checkLoadedData(state, s, true, t)
 }
 
 func TestSetClusterInConfigMismatch(t *testing.T) {

--- a/agent/app/data_test.go
+++ b/agent/app/data_test.go
@@ -52,6 +52,7 @@ const (
 	testAvailabilityZone            = "test-az"
 	testAgentVersion                = "1.40.0"
 	testLatestSeqNumberTaskManifest = int64(1)
+	testRegistrationToken           = "test-reg-token"
 )
 
 var (
@@ -145,7 +146,7 @@ func TestLoadDataLoadFromBoltDB(t *testing.T) {
 	s, err := agent.loadData(eventstream.NewEventStream("events", ctx),
 		credentialsManager, state, imageManager)
 	assert.NoError(t, err)
-	checkLoadedData(state, s, t)
+	checkLoadedData(state, s, true, t)
 }
 
 func TestLoadDataLoadFromStateFile(t *testing.T) {
@@ -183,7 +184,7 @@ func TestLoadDataLoadFromStateFile(t *testing.T) {
 	s, err := agent.loadData(eventstream.NewEventStream("events", ctx),
 		credentialsManager, state, imageManager)
 	assert.NoError(t, err)
-	checkLoadedData(state, s, t)
+	checkLoadedData(state, s, false, t)
 
 	// Also verify that the data in the state file has been migrated to boltdb.
 	tasks, err := dataClient.GetTasks()
@@ -200,7 +201,7 @@ func TestLoadDataLoadFromStateFile(t *testing.T) {
 	assert.Len(t, eniAttachments, 1)
 }
 
-func checkLoadedData(state dockerstate.TaskEngineState, s *savedData, t *testing.T) {
+func checkLoadedData(state dockerstate.TaskEngineState, s *savedData, boltdbOnly bool, t *testing.T) {
 	_, ok := state.TaskByArn(testTaskARN)
 	assert.True(t, ok)
 	_, ok = state.ContainerByID(testDockerID)
@@ -212,6 +213,9 @@ func checkLoadedData(state dockerstate.TaskEngineState, s *savedData, t *testing
 	assert.Equal(t, testContainerInstanceARN, s.containerInstanceARN)
 	assert.Equal(t, testEC2InstanceID, s.ec2InstanceID)
 	assert.Equal(t, testLatestSeqNumberTaskManifest, s.latestTaskManifestSeqNum)
+	if boltdbOnly {
+		assert.Equal(t, testRegistrationToken, s.registrationToken)
+	}
 }
 
 func newTestClient(t *testing.T) (statemanager.StateManager, data.Client, func()) {
@@ -257,6 +261,7 @@ func populateBoltDB(dataClient data.Client, t *testing.T) {
 	require.NoError(t, dataClient.SaveMetadata(data.ContainerInstanceARNKey, testContainerInstanceARN))
 	require.NoError(t, dataClient.SaveMetadata(data.EC2InstanceIDKey, testEC2InstanceID))
 	require.NoError(t, dataClient.SaveMetadata(data.TaskManifestSeqNumKey, strconv.FormatInt(testLatestSeqNumberTaskManifest, 10)))
+	require.NoError(t, dataClient.SaveMetadata(data.RegistrationTokenKey, testRegistrationToken))
 }
 
 func getTestEngineState() dockerstate.TaskEngineState {

--- a/agent/data/metadata_client.go
+++ b/agent/data/metadata_client.go
@@ -24,6 +24,7 @@ const (
 	ContainerInstanceARNKey = "container-instance-arn"
 	EC2InstanceIDKey        = "ec2-instance-id"
 	TaskManifestSeqNumKey   = "task-manifest-seq-num"
+	RegistrationTokenKey    = "registration-token"
 )
 
 func (c *client) SaveMetadata(key, val string) error {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Adding Register Container Instance's client /registration token to agent state (boltdb only) 
This is so that ECS service registers using the same container instance ARN for the container instance that issues quick back to back RCI requests. 

### Implementation details
Saving new registration token key and value to boltDB 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

Manually tested by removing the container instance ARN from boltdb state. Restarted agent and received the same container instance ARN as before. 

### Description for the changelog
Fix a bug where agent persists RCI client token to avoid being registered as different container instance ARNs. 

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
