### PR TITLE
Switch back to latest Firelens image in test and update the test

### DIFF
--- a/agent/api/container/container.go
+++ b/agent/api/container/container.go
@@ -55,8 +55,6 @@ const (
 	// variable in containers' config, which can be used by the containers to access the
 	// v3 metadata endpoint
 	MetadataURIEnvironmentVariableName = "ECS_CONTAINER_METADATA_URI"
-	// MetadataURIFormat defines the URI format for v3 metadata endpoint
-	MetadataURIFormat = "http://169.254.170.2/v3/%s"
 
 	// MetadataURIEnvVarNameV4 defines the name of the environment
 	// variable in containers' config, which can be used by the containers to access the
@@ -80,6 +78,12 @@ const (
 
 	// neuronVisibleDevicesEnvVar is the env which indicates that the container wants to use inferentia devices.
 	neuronVisibleDevicesEnvVar = "AWS_NEURON_VISIBLE_DEVICES"
+)
+
+var (
+	// MetadataURIFormat defines the URI format for v3 metadata endpoint. Made as a var to be able to
+	// overwrite it in test.
+	MetadataURIFormat = "http://169.254.170.2/v3/%s"
 )
 
 // DockerConfig represents additional metadata about a container to run. It's

--- a/agent/engine/engine_sudo_linux_integ_test.go
+++ b/agent/engine/engine_sudo_linux_integ_test.go
@@ -19,6 +19,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -30,6 +34,7 @@ import (
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	apitaskstatus "github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/ec2"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	cgroup "github.com/aws/amazon-ecs-agent/agent/taskresource/cgroup/control"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/firelens"
@@ -48,7 +53,7 @@ import (
 
 const (
 	testLogSenderImage = "amazonlinux:2"
-	testFluentbitImage = "amazon/aws-for-fluent-bit:2.7.0"
+	testFluentbitImage = "amazon/aws-for-fluent-bit:latest"
 	testVolumeImage    = "127.0.0.1:51670/amazon/amazon-ecs-volumes-test:latest"
 	testCluster        = "testCluster"
 	validTaskArnPrefix = "arn:aws:ecs:region:account-id:task/"
@@ -60,6 +65,12 @@ const (
 	testECSRegion      = "us-east-1"
 	testLogGroupName   = "test-fluentbit"
 	testLogGroupPrefix = "firelens-fluentbit-"
+)
+
+var (
+	mockTaskMeatadataHandler = http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.Write([]byte(`{"TaskARN": "arn:aws:ecs:region:account-id:task/task-id"}`))
+	})
 )
 
 func TestStartStopWithCgroup(t *testing.T) {
@@ -164,6 +175,20 @@ func TestFirelensFluentbit(t *testing.T) {
 	taskEngine, done, _ := setup(cfg, nil, t)
 	defer done()
 
+	// Mock task metadata server as the firelens container needs to access it.
+	// Note that the listener has to be overwritten here, because the default one from httptest.NewServer
+	// only listens to localhost and isn't reachable from container running in bridge network mode.
+	l, err := net.Listen("tcp", ":0")
+	require.NoError(t, err)
+	server := httptest.NewUnstartedServer(mockTaskMeatadataHandler)
+	server.Listener = l
+	server.Start()
+	defer server.Close()
+
+	port := getPortFromAddr(t, server.URL)
+	serverURL := fmt.Sprintf("http://%s:%s", getHostPrivateIP(t, ec2.NewEC2MetadataClient(nil)), port)
+	defer setV3MetadataURLFormat(serverURL + "/v3/%s")()
+
 	testTask := createFirelensTask(t)
 	taskEngine.(*DockerTaskEngine).resourceFields = &taskresource.ResourceFields{
 		ResourceFieldsCommon: &taskresource.ResourceFieldsCommon{
@@ -174,7 +199,7 @@ func TestFirelensFluentbit(t *testing.T) {
 	testEvents := InitEventCollection(taskEngine)
 
 	//Verify logsender container is running
-	err := VerifyContainerStatus(apicontainerstatus.ContainerRunning, testTask.Arn+":logsender", testEvents, t)
+	err = VerifyContainerStatus(apicontainerstatus.ContainerRunning, testTask.Arn+":logsender", testEvents, t)
 	assert.NoError(t, err, "Verify logsender container is running")
 
 	//Verify firelens container is running
@@ -236,6 +261,31 @@ func TestFirelensFluentbit(t *testing.T) {
 	// Make sure all the resource is cleaned up
 	_, err = ioutil.ReadDir(filepath.Join(testDataDir, "firelens", testTask.Arn))
 	assert.Error(t, err)
+}
+
+// getPortFromAddr returns the port part of an address in format "http://<addr>:<port>".
+func getPortFromAddr(t *testing.T, addr string) string {
+	u, err := url.Parse(addr)
+	require.NoErrorf(t, err, "unable to parse address: %s", addr)
+	_, port, err := net.SplitHostPort(u.Host)
+	require.NoErrorf(t, err, "unable to get port from address: %s", addr)
+	return port
+}
+
+// getHostPrivateIP returns the host's private IP.
+func getHostPrivateIP(t *testing.T, ec2MetadataClient ec2.EC2MetadataClient) string {
+	ip, err := ec2MetadataClient.PrivateIPv4Address()
+	require.NoError(t, err)
+	return ip
+}
+
+// setV3MetadataURLFormat sets the container metadata URI format and returns a function to set it back.
+func setV3MetadataURLFormat(fmt string) func() {
+	backup := apicontainer.MetadataURIFormat
+	apicontainer.MetadataURIFormat = fmt
+	return func() {
+		apicontainer.MetadataURIFormat = backup
+	}
 }
 
 func createFirelensTask(t *testing.T) *apitask.Task {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Switch back to latest Firelens image in test and update the test to work with it.

Previously, the version was pinned to 2.7.0 because 2.9.0 breaks the integ test `TestFirelensFluentbit`. The failure was caused by https://github.com/aws/amazon-cloudwatch-logs-for-fluent-bit/pull/115 which adds a dependency between Firelens and the agent's task metadata endpoint, while the integ test does not start or mock the task metadata server.

This change fixed the test by mocking the task metadata endpoint, and switch the image version back to latest, so that we can continue verify the feature with latest version of dependency.

### Implementation details
<!-- How are the changes implemented? -->
Add logic in `TestFirelensFluentbit` test to:
* Start a test server with `httptest` to mock task metadata endpoint;
* Overwrite container's v3 task metadata endpoint to be the mock server's address.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Fixing an existing test. Ran the test locally and it passed. Result can be verified by pull request checks. 

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
N/A

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
