### PR TITLE
Fix exec command agent config

### DIFF
--- a/agent/engine/execcmd/manager_init_task_linux.go
+++ b/agent/engine/execcmd/manager_init_task_linux.go
@@ -68,16 +68,16 @@ const (
 
 var (
 	execAgentConfigTemplate = `{
+	"Mgs": {
+		"Region": "",
+		"Endpoint": "",
+		"StopTimeoutMillis": 20000,
+		"SessionWorkersLimit": %d
+	},
 	"Agent": {
 		"Region": "",
 		"OrchestrationRootDir": "",
-		"ContainerMode": true,
-		"Mgs": {
-			"Region": "",
-			"Endpoint": "",
-			"StopTimeoutMillis": 20000,
-			"SessionWorkersLimit": %d
-		}
+		"ContainerMode": true
 	}
 }`
 	// TODO: [ecs-exec] seelog config needs to be implemented following a similar approach to ss, config

--- a/agent/engine/execcmd/manager_init_task_linux_test.go
+++ b/agent/engine/execcmd/manager_init_task_linux_test.go
@@ -198,16 +198,16 @@ func TestInitializeContainer(t *testing.T) {
 
 func TestGetExecAgentConfigFileName(t *testing.T) {
 	execAgentConfig := `{
+	"Mgs": {
+		"Region": "",
+		"Endpoint": "",
+		"StopTimeoutMillis": 20000,
+		"SessionWorkersLimit": 2
+	},
 	"Agent": {
 		"Region": "",
 		"OrchestrationRootDir": "",
-		"ContainerMode": true,
-		"Mgs": {
-			"Region": "",
-			"Endpoint": "",
-			"StopTimeoutMillis": 20000,
-			"SessionWorkersLimit": 2
-		}
+		"ContainerMode": true
 	}
 }`
 	sha := getExecAgentConfigHash(execAgentConfig)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

SSM agent config was incorrect. This PR fixes it by extracting the `Mgs` field to the root config.

### Implementation details
<!-- How are the changes implemented? -->
Extracting the `Mgs` field to the root config.
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes<!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
