### PR TITLE
Introduce pulled containers and ECS_PULL_DEPENDENT_CONTAINERS_UPFRONT

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ additional details on each available environment variable.
 | `ECS_DISABLE_METRICS`     | &lt;true &#124; false&gt;  | Whether to disable metrics gathering for tasks. | false | true |
 | `ECS_POLL_METRICS`     | &lt;true &#124; false&gt;  | Whether to poll or stream when gathering metrics for tasks. This defaulted to `false` previous to agent version 1.40.0. WARNING: setting this to false on an instance with many containers can result in very high CPU utilization by the agent, dockerd, and containerd. | `true` | `true` |
 | `ECS_POLLING_METRICS_WAIT_DURATION` | 10s | Time to wait between polling for metrics for a task. Not used when ECS_POLL_METRICS is false. Maximum value is 20s and minimum value is 5s. If user sets above maximum it will be set to max, and if below minimum it will be set to min. | 10s | 10s |
+| `ECS_PULL_DEPENDENT_CONTAINERS_UPFRONT` | &lt;true &#124; false&gt; | Whether to pull images of dependent containers before the dependsOn condition has been satisfied. | true | true |
 | `ECS_RESERVED_MEMORY` | 32 | Memory, in MiB, to reserve for use by things other than containers managed by Amazon ECS. | 0 | 0 |
 | `ECS_AVAILABLE_LOGGING_DRIVERS` | `["awslogs","fluentd","gelf","json-file","journald","logentries","splunk","syslog"]` | Which logging drivers are available on the container instance. | `["json-file","none"]` | `["json-file","none"]` |
 | `ECS_DISABLE_PRIVILEGED` | `true` | Whether launching privileged containers is disabled on the container instance. | `false` | `false` |

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -533,6 +533,7 @@ func environmentConfig() (Config, error) {
 		TaskCPUMemLimit:                     parseBooleanDefaultTrueConfig("ECS_ENABLE_TASK_CPU_MEM_LIMIT"),
 		DockerStopTimeout:                   parseDockerStopTimeout(),
 		ContainerStartTimeout:               parseContainerStartTimeout(),
+		DependentContainersPullUpfront:      parseBooleanDefaultTrueConfig("ECS_PULL_DEPENDENT_CONTAINERS_UPFRONT"),
 		ImagePullInactivityTimeout:          parseImagePullInactivityTimeout(),
 		ImagePullTimeout:                    parseEnvVariableDuration("ECS_IMAGE_PULL_TIMEOUT"),
 		CredentialsAuditLogFile:             os.Getenv("ECS_AUDIT_LOGFILE"),
@@ -600,6 +601,7 @@ func (cfg *Config) String() string {
 			"TaskCleanupWaitDuration: %v, "+
 			"DockerStopTimeout: %v, "+
 			"ContainerStartTimeout: %v, "+
+			"DependentContainersPullUpfront: %v, "+
 			"TaskCPUMemLimit: %v, "+
 			"%s",
 		cfg.Cluster,
@@ -615,6 +617,7 @@ func (cfg *Config) String() string {
 		cfg.TaskCleanupWaitDuration,
 		cfg.DockerStopTimeout,
 		cfg.ContainerStartTimeout,
+		cfg.DependentContainersPullUpfront,
 		cfg.TaskCPUMemLimit,
 		cfg.platformString(),
 	)

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -145,6 +145,7 @@ func TestEnvironmentConfig(t *testing.T) {
 	defer setTestEnv("ECS_POLL_METRICS", "true")()
 	defer setTestEnv("ECS_POLLING_METRICS_WAIT_DURATION", "10s")()
 	defer setTestEnv("ECS_CGROUP_CPU_PERIOD", "")
+	defer setTestEnv("ECS_PULL_DEPENDENT_CONTAINERS_UPFRONT", "true")
 	additionalLocalRoutesJSON := `["1.2.3.4/22","5.6.7.8/32"]`
 	setTestEnv("ECS_AWSVPC_ADDITIONAL_LOCAL_ROUTES", additionalLocalRoutesJSON)
 	setTestEnv("ECS_ENABLE_CONTAINER_METADATA", "true")
@@ -197,6 +198,7 @@ func TestEnvironmentConfig(t *testing.T) {
 	assert.Equal(t, 10*time.Millisecond, conf.CgroupCPUPeriod)
 	assert.False(t, conf.SpotInstanceDrainingEnabled.Enabled())
 	assert.Equal(t, []string{"efsAuth"}, conf.VolumePluginCapabilities)
+	assert.True(t, conf.DependentContainersPullUpfront.Enabled(), "Wrong value for ContainersPullUpfront")
 }
 
 func TestTrimWhitespaceWhenCreating(t *testing.T) {

--- a/agent/config/config_unix.go
+++ b/agent/config/config_unix.go
@@ -56,6 +56,7 @@ func DefaultConfig() Config {
 		TaskCleanupWaitDuration:             DefaultTaskCleanupWaitDuration,
 		DockerStopTimeout:                   defaultDockerStopTimeout,
 		ContainerStartTimeout:               defaultContainerStartTimeout,
+		DependentContainersPullUpfront:      BooleanDefaultTrue{Value: ExplicitlyEnabled},
 		CredentialsAuditLogFile:             defaultCredentialsAuditLogFile,
 		CredentialsAuditLogDisabled:         false,
 		ImageCleanupDisabled:                BooleanDefaultFalse{Value: ExplicitlyDisabled},

--- a/agent/config/config_unix_test.go
+++ b/agent/config/config_unix_test.go
@@ -68,6 +68,7 @@ func TestConfigDefault(t *testing.T) {
 	assert.False(t, cfg.SharedVolumeMatchFullConfig.Enabled(), "Default SharedVolumeMatchFullConfig set incorrectly")
 	assert.Equal(t, defaultCgroupCPUPeriod, cfg.CgroupCPUPeriod, "CFS cpu period set incorrectly")
 	assert.Equal(t, DefaultImagePullTimeout, cfg.ImagePullTimeout, "Default ImagePullTimeout set incorrectly")
+	assert.True(t, cfg.DependentContainersPullUpfront.Enabled(), "Default ContainersPullUpfront set incorrectly")
 }
 
 // TestConfigFromFile tests the configuration can be read from file

--- a/agent/config/config_windows.go
+++ b/agent/config/config_windows.go
@@ -86,6 +86,7 @@ func DefaultConfig() Config {
 		TaskCleanupWaitDuration:             DefaultTaskCleanupWaitDuration,
 		DockerStopTimeout:                   defaultDockerStopTimeout,
 		ContainerStartTimeout:               defaultContainerStartTimeout,
+		DependentContainersPullUpfront:      BooleanDefaultTrue{Value: ExplicitlyEnabled},
 		ImagePullInactivityTimeout:          defaultImagePullInactivityTimeout,
 		ImagePullTimeout:                    DefaultImagePullTimeout,
 		CredentialsAuditLogFile:             filepath.Join(ecsRoot, defaultCredentialsAuditLogFile),

--- a/agent/config/config_windows_test.go
+++ b/agent/config/config_windows_test.go
@@ -61,6 +61,7 @@ func TestConfigDefault(t *testing.T) {
 		"Default TaskMetadataBurstRate is set incorrectly")
 	assert.False(t, cfg.SharedVolumeMatchFullConfig.Enabled(), "Default SharedVolumeMatchFullConfig set incorrectly")
 	assert.Equal(t, DefaultImagePullTimeout, cfg.ImagePullTimeout, "Default ImagePullTimeout set incorrectly")
+	assert.True(t, cfg.DependentContainersPullUpfront.Enabled(), "Default ContainersPullUpfront set incorrectly")
 }
 
 func TestConfigIAMTaskRolesReserves80(t *testing.T) {

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -112,6 +112,10 @@ type Config struct {
 	// ContainerStartTimeout specifies the amount of time to wait to start a container
 	ContainerStartTimeout time.Duration
 
+	// DependentContainersPullUpfront specifies whether pulling containers upfront should be applied to this agent.
+	// Default true
+	DependentContainersPullUpfront BooleanDefaultTrue
+
 	// ImagePullInactivityTimeout is here to override the amount of time to wait when pulling and extracting a container
 	ImagePullInactivityTimeout time.Duration
 

--- a/agent/engine/dependencygraph/graph.go
+++ b/agent/engine/dependencygraph/graph.go
@@ -21,6 +21,7 @@ import (
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
+	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/credentials"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	log "github.com/cihub/seelog"
@@ -67,7 +68,7 @@ var (
 // ValidDependencies takes a task and verifies that it is possible to allow all
 // containers within it to reach the desired status by proceeding in some
 // order.
-func ValidDependencies(task *apitask.Task) bool {
+func ValidDependencies(task *apitask.Task, cfg *config.Config) bool {
 	unresolved := make([]*apicontainer.Container, len(task.Containers))
 	resolved := make([]*apicontainer.Container, 0, len(task.Containers))
 
@@ -76,7 +77,7 @@ func ValidDependencies(task *apitask.Task) bool {
 OuterLoop:
 	for len(unresolved) > 0 {
 		for i, tryResolve := range unresolved {
-			if dependenciesCanBeResolved(tryResolve, resolved) {
+			if dependenciesCanBeResolved(tryResolve, resolved, cfg) {
 				resolved = append(resolved, tryResolve)
 				unresolved = append(unresolved[:i], unresolved[i+1:]...)
 				// Break out of the inner loop now that we modified the slice
@@ -99,13 +100,13 @@ OuterLoop:
 // This function is used for verifying that a state should be resolvable, not
 // for actually deciding what to do. `DependenciesAreResolved` should be used for
 // that purpose instead.
-func dependenciesCanBeResolved(target *apicontainer.Container, by []*apicontainer.Container) bool {
+func dependenciesCanBeResolved(target *apicontainer.Container, by []*apicontainer.Container, cfg *config.Config) bool {
 	nameMap := make(map[string]*apicontainer.Container)
 	for _, cont := range by {
 		nameMap[cont.Name] = cont
 	}
 
-	if _, err := verifyContainerOrderingStatusResolvable(target, nameMap, containerOrderingDependenciesCanResolve); err != nil {
+	if _, err := verifyContainerOrderingStatusResolvable(target, nameMap, cfg, containerOrderingDependenciesCanResolve); err != nil {
 		return false
 	}
 	return verifyStatusResolvable(target, nameMap, target.SteadyStateDependencies, onSteadyStateCanResolve)
@@ -122,7 +123,8 @@ func DependenciesAreResolved(target *apicontainer.Container,
 	by []*apicontainer.Container,
 	id string,
 	manager credentials.Manager,
-	resources []taskresource.TaskResource) (*apicontainer.DependsOn, error) {
+	resources []taskresource.TaskResource,
+	cfg *config.Config) (*apicontainer.DependsOn, error) {
 	if !executionCredentialsResolved(target, id, manager) {
 		return nil, CredentialsNotResolvedErr
 	}
@@ -141,7 +143,7 @@ func DependenciesAreResolved(target *apicontainer.Container,
 		resourcesMap[resource.GetName()] = resource
 	}
 
-	if blocked, err := verifyContainerOrderingStatusResolvable(target, nameMap, containerOrderingDependenciesIsResolved); err != nil {
+	if blocked, err := verifyContainerOrderingStatusResolvable(target, nameMap, cfg, containerOrderingDependenciesIsResolved); err != nil {
 		return blocked, err
 	}
 
@@ -242,7 +244,7 @@ func verifyStatusResolvable(target *apicontainer.Container, existingContainers m
 // (map from name to container). The `resolves` function passed should return true if the named container is resolved.
 
 func verifyContainerOrderingStatusResolvable(target *apicontainer.Container, existingContainers map[string]*apicontainer.Container,
-	resolves func(*apicontainer.Container, *apicontainer.Container, string) bool) (*apicontainer.DependsOn, error) {
+	cfg *config.Config, resolves func(*apicontainer.Container, *apicontainer.Container, string, *config.Config) bool) (*apicontainer.DependsOn, error) {
 
 	targetGoal := target.GetDesiredStatus()
 	targetKnown := target.GetKnownStatus()
@@ -277,7 +279,7 @@ func verifyContainerOrderingStatusResolvable(target *apicontainer.Container, exi
 			return nil, fmt.Errorf("dependency graph: failed to resolve container ordering dependency [%v] for target [%v] as dependency did not exit successfully.", dependencyContainer, target)
 		}
 
-		if !resolves(target, dependencyContainer, dependency.Condition) {
+		if !resolves(target, dependencyContainer, dependency.Condition, cfg) {
 			blockedDependency = &dependency
 		}
 	}
@@ -332,7 +334,8 @@ func verifyResourceDependenciesResolved(target *apicontainer.Container, existing
 
 func containerOrderingDependenciesCanResolve(target *apicontainer.Container,
 	dependsOnContainer *apicontainer.Container,
-	dependsOnStatus string) bool {
+	dependsOnStatus string,
+	cfg *config.Config) bool {
 
 	targetDesiredStatus := target.GetDesiredStatus()
 	dependsOnContainerDesiredStatus := dependsOnContainer.GetDesiredStatus()
@@ -378,10 +381,19 @@ func containerOrderingDependenciesCanResolve(target *apicontainer.Container,
 
 func containerOrderingDependenciesIsResolved(target *apicontainer.Container,
 	dependsOnContainer *apicontainer.Container,
-	dependsOnStatus string) bool {
+	dependsOnStatus string,
+	cfg *config.Config) bool {
 
 	targetDesiredStatus := target.GetDesiredStatus()
+	targetContainerKnownStatus := target.GetKnownStatus()
 	dependsOnContainerKnownStatus := dependsOnContainer.GetKnownStatus()
+
+	// The 'target' container desires to be moved to 'Created' or the 'steady' state.
+	// Allow this only if the environment variable ECS_PULL_DEPENDENT_CONTAINERS_UPFRONT is enabled and the
+	// known status of the `target` container state has not reached to 'Pulled' state;
+	if cfg.DependentContainersPullUpfront.Enabled() && targetContainerKnownStatus < apicontainerstatus.ContainerPulled {
+		return true
+	}
 
 	switch dependsOnStatus {
 	case createCondition:

--- a/agent/engine/dependencygraph/graph_test.go
+++ b/agent/engine/dependencygraph/graph_test.go
@@ -23,6 +23,7 @@ import (
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
+	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	mock_taskresource "github.com/aws/amazon-ecs-agent/agent/taskresource/mocks"
 	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
@@ -58,7 +59,8 @@ func createdContainer(name string, dependsOn []apicontainer.DependsOn, steadySta
 func TestValidDependencies(t *testing.T) {
 	// Empty task
 	task := &apitask.Task{}
-	resolveable := ValidDependencies(task)
+	cfg := config.Config{}
+	resolveable := ValidDependencies(task, &cfg)
 	assert.True(t, resolveable, "The zero dependency graph should resolve")
 
 	task = &apitask.Task{
@@ -69,7 +71,7 @@ func TestValidDependencies(t *testing.T) {
 			},
 		},
 	}
-	resolveable = ValidDependencies(task)
+	resolveable = ValidDependencies(task, &cfg)
 	assert.True(t, resolveable, "One container should resolve trivially")
 
 	// Webserver stack
@@ -86,7 +88,7 @@ func TestValidDependencies(t *testing.T) {
 		},
 	}
 
-	resolveable = ValidDependencies(task)
+	resolveable = ValidDependencies(task, &cfg)
 	assert.True(t, resolveable, "The webserver group should resolve just fine")
 }
 
@@ -98,7 +100,8 @@ func TestValidDependenciesWithCycles(t *testing.T) {
 			steadyStateContainer("b", []apicontainer.DependsOn{{ContainerName: "a", Condition: createCondition}}, apicontainerstatus.ContainerRunning, apicontainerstatus.ContainerRunning),
 		},
 	}
-	resolveable := ValidDependencies(task)
+	cfg := config.Config{}
+	resolveable := ValidDependencies(task, &cfg)
 	assert.False(t, resolveable, "Cycle should not be resolveable")
 }
 
@@ -109,7 +112,8 @@ func TestValidDependenciesWithUnresolvedReference(t *testing.T) {
 			steadyStateContainer("php", []apicontainer.DependsOn{{ContainerName: "db", Condition: createCondition}}, apicontainerstatus.ContainerRunning, apicontainerstatus.ContainerRunning),
 		},
 	}
-	resolveable := ValidDependencies(task)
+	cfg := config.Config{}
+	resolveable := ValidDependencies(task, &cfg)
 	assert.False(t, resolveable, "Nonexistent reference shouldn't resolve")
 }
 
@@ -122,7 +126,8 @@ func TestDependenciesAreResolvedWhenSteadyStateIsRunning(t *testing.T) {
 			},
 		},
 	}
-	_, err := DependenciesAreResolved(task.Containers[0], task.Containers, "", nil, nil)
+	cfg := config.Config{}
+	_, err := DependenciesAreResolved(task.Containers[0], task.Containers, "", nil, nil, &cfg)
 	assert.NoError(t, err, "One container should resolve trivially")
 
 	// Webserver stack
@@ -139,28 +144,28 @@ func TestDependenciesAreResolvedWhenSteadyStateIsRunning(t *testing.T) {
 		},
 	}
 
-	_, err = DependenciesAreResolved(php, task.Containers, "", nil, nil)
+	_, err = DependenciesAreResolved(php, task.Containers, "", nil, nil, &cfg)
 	assert.Error(t, err, "Shouldn't be resolved; db isn't running")
 
-	_, err = DependenciesAreResolved(db, task.Containers, "", nil, nil)
+	_, err = DependenciesAreResolved(db, task.Containers, "", nil, nil, &cfg)
 	assert.Error(t, err, "Shouldn't be resolved; dbdatavolume isn't created")
 
-	_, err = DependenciesAreResolved(dbdata, task.Containers, "", nil, nil)
+	_, err = DependenciesAreResolved(dbdata, task.Containers, "", nil, nil, &cfg)
 	assert.NoError(t, err, "data volume with no deps should resolve")
 
 	dbdata.SetKnownStatus(apicontainerstatus.ContainerCreated)
-	_, err = DependenciesAreResolved(php, task.Containers, "", nil, nil)
+	_, err = DependenciesAreResolved(php, task.Containers, "", nil, nil, &cfg)
 	assert.Error(t, err, "Php shouldn't run, db is not created")
 
 	db.SetKnownStatus(apicontainerstatus.ContainerCreated)
-	_, err = DependenciesAreResolved(php, task.Containers, "", nil, nil)
+	_, err = DependenciesAreResolved(php, task.Containers, "", nil, nil, &cfg)
 	assert.Error(t, err, "Php shouldn't run, db is not running")
 
-	_, err = DependenciesAreResolved(db, task.Containers, "", nil, nil)
+	_, err = DependenciesAreResolved(db, task.Containers, "", nil, nil, &cfg)
 	assert.NoError(t, err, "db should be resolved, dbdata volume is Created")
 	db.SetKnownStatus(apicontainerstatus.ContainerRunning)
 
-	_, err = DependenciesAreResolved(php, task.Containers, "", nil, nil)
+	_, err = DependenciesAreResolved(php, task.Containers, "", nil, nil, &cfg)
 	assert.NoError(t, err, "Php should resolve")
 }
 
@@ -176,19 +181,20 @@ func TestRunDependencies(t *testing.T) {
 		SteadyStateDependencies: []string{"a"},
 	}
 	task := &apitask.Task{Containers: []*apicontainer.Container{c1, c2}}
-	_, err := DependenciesAreResolved(c2, task.Containers, "", nil, nil)
+	cfg := config.Config{}
+	_, err := DependenciesAreResolved(c2, task.Containers, "", nil, nil, &cfg)
 	assert.Error(t, err, "Dependencies should not be resolved")
 
 	task.Containers[1].SetDesiredStatus(apicontainerstatus.ContainerRunning)
-	_, err = DependenciesAreResolved(c2, task.Containers, "", nil, nil)
+	_, err = DependenciesAreResolved(c2, task.Containers, "", nil, nil, &cfg)
 	assert.Error(t, err, "Dependencies should not be resolved")
 
 	task.Containers[0].SetKnownStatus(apicontainerstatus.ContainerRunning)
-	_, err = DependenciesAreResolved(c2, task.Containers, "", nil, nil)
+	_, err = DependenciesAreResolved(c2, task.Containers, "", nil, nil, &cfg)
 	assert.NoError(t, err, "Dependencies should be resolved")
 
 	task.Containers[1].SetDesiredStatus(apicontainerstatus.ContainerCreated)
-	_, err = DependenciesAreResolved(c1, task.Containers, "", nil, nil)
+	_, err = DependenciesAreResolved(c1, task.Containers, "", nil, nil, &cfg)
 	assert.NoError(t, err, "Dependencies should be resolved")
 }
 
@@ -209,17 +215,19 @@ func TestRunDependenciesWhenSteadyStateIsResourcesProvisionedForOneContainer(t *
 		},
 	}
 
+	cfg := config.Config{}
+
 	// Add a dependency on the pause container for all containers in the webserver stack
 	for _, container := range task.Containers {
 		if container.Name == "pause" {
 			continue
 		}
 		container.SteadyStateDependencies = []string{"pause"}
-		_, err := DependenciesAreResolved(container, task.Containers, "", nil, nil)
+		_, err := DependenciesAreResolved(container, task.Containers, "", nil, nil, &cfg)
 		assert.Error(t, err, "Shouldn't be resolved; pause isn't running")
 	}
 
-	_, err := DependenciesAreResolved(pause, task.Containers, "", nil, nil)
+	_, err := DependenciesAreResolved(pause, task.Containers, "", nil, nil, &cfg)
 	assert.NoError(t, err, "Pause container's dependencies should be resolved")
 
 	// Transition pause container to RUNNING
@@ -233,13 +241,13 @@ func TestRunDependenciesWhenSteadyStateIsResourcesProvisionedForOneContainer(t *
 		}
 		// Assert that dependencies remain unresolved until the pause container reaches
 		// RESOURCES_PROVISIONED
-		_, err = DependenciesAreResolved(container, task.Containers, "", nil, nil)
+		_, err = DependenciesAreResolved(container, task.Containers, "", nil, nil, &cfg)
 		assert.Error(t, err, "Shouldn't be resolved; pause isn't running")
 	}
 	pause.KnownStatusUnsafe = apicontainerstatus.ContainerResourcesProvisioned
 	// Dependecies should be resolved now that the 'pause' container has
 	// transitioned into RESOURCES_PROVISIONED
-	_, err = DependenciesAreResolved(php, task.Containers, "", nil, nil)
+	_, err = DependenciesAreResolved(php, task.Containers, "", nil, nil, &cfg)
 	assert.NoError(t, err, "Php should resolve")
 }
 
@@ -841,9 +849,10 @@ func TestContainerOrderingCanResolve(t *testing.T) {
 			Resolvable:          true,
 		},
 	}
+	cfg := config.Config{}
 	for _, tc := range testcases {
 		t.Run(fmt.Sprintf("T:%s+V:%s", tc.TargetDesired.String(), tc.DependencyDesired.String()),
-			assertContainerOrderingCanResolve(containerOrderingDependenciesCanResolve, tc.TargetDesired, tc.DependencyDesired, tc.DependencyKnown, tc.DependencyCondition, tc.ExitCode, tc.Resolvable))
+			assertContainerOrderingCanResolve(containerOrderingDependenciesCanResolve, tc.TargetDesired, tc.DependencyDesired, tc.DependencyKnown, tc.DependencyCondition, tc.ExitCode, tc.Resolvable, &cfg))
 	}
 }
 
@@ -956,13 +965,152 @@ func TestContainerOrderingIsResolved(t *testing.T) {
 			Resolved:            false,
 		},
 	}
+	cfg := config.Config{}
 	for _, tc := range testcases {
 		t.Run(fmt.Sprintf("T:%s+V:%s", tc.TargetDesired.String(), tc.DependencyKnown.String()),
-			assertContainerOrderingResolved(containerOrderingDependenciesIsResolved, tc.TargetDesired, tc.DependencyKnown, tc.DependencyCondition, tc.ExitCode, tc.Resolved))
+			assertContainerOrderingResolved(containerOrderingDependenciesIsResolved, tc.TargetDesired, tc.DependencyKnown, tc.DependencyCondition, tc.ExitCode, tc.Resolved, &cfg))
 	}
 }
 
-func assertContainerOrderingCanResolve(f func(target *apicontainer.Container, dep *apicontainer.Container, depCond string) bool, targetDesired, depDesired, depKnown apicontainerstatus.ContainerStatus, depCond string, exitcode int, expectedResolvable bool) func(t *testing.T) {
+func TestContainerOrderingIsResolvedWithDependentContainersPullUpfront(t *testing.T) {
+	testcases := []struct {
+		TargetKnown         apicontainerstatus.ContainerStatus
+		DependencyKnown     apicontainerstatus.ContainerStatus
+		DependencyCondition string
+		Resolved            bool
+		ExitCode            int
+	}{
+		{
+			TargetKnown:         apicontainerstatus.ContainerStatusNone,
+			DependencyKnown:     apicontainerstatus.ContainerStatusNone,
+			DependencyCondition: startCondition,
+			Resolved:            true,
+		},
+		{
+			TargetKnown:         apicontainerstatus.ContainerStatusNone,
+			DependencyKnown:     apicontainerstatus.ContainerPulled,
+			DependencyCondition: startCondition,
+			Resolved:            true,
+		},
+		{
+			TargetKnown:         apicontainerstatus.ContainerStatusNone,
+			DependencyKnown:     apicontainerstatus.ContainerStopped,
+			DependencyCondition: startCondition,
+			Resolved:            true,
+		},
+		{
+			TargetKnown:         apicontainerstatus.ContainerCreated,
+			DependencyKnown:     apicontainerstatus.ContainerStatusNone,
+			DependencyCondition: startCondition,
+			Resolved:            false,
+		},
+		{
+			TargetKnown:         apicontainerstatus.ContainerStatusNone,
+			DependencyKnown:     apicontainerstatus.ContainerStatusNone,
+			DependencyCondition: successCondition,
+			Resolved:            true,
+		},
+		{
+			TargetKnown:         apicontainerstatus.ContainerStatusNone,
+			DependencyKnown:     apicontainerstatus.ContainerPulled,
+			DependencyCondition: successCondition,
+			Resolved:            true,
+		},
+		{
+			TargetKnown:         apicontainerstatus.ContainerStatusNone,
+			DependencyKnown:     apicontainerstatus.ContainerCreated,
+			DependencyCondition: successCondition,
+			Resolved:            true,
+		},
+		{
+			TargetKnown:         apicontainerstatus.ContainerStatusNone,
+			DependencyKnown:     apicontainerstatus.ContainerRunning,
+			DependencyCondition: successCondition,
+			Resolved:            true,
+		},
+		{
+			TargetKnown:         apicontainerstatus.ContainerStatusNone,
+			DependencyKnown:     apicontainerstatus.ContainerStopped,
+			ExitCode:            1,
+			DependencyCondition: successCondition,
+			Resolved:            true,
+		},
+		{
+			TargetKnown:         apicontainerstatus.ContainerPulled,
+			DependencyKnown:     apicontainerstatus.ContainerStatusNone,
+			DependencyCondition: successCondition,
+			Resolved:            false,
+		},
+		{
+			TargetKnown:         apicontainerstatus.ContainerPulled,
+			DependencyKnown:     apicontainerstatus.ContainerStopped,
+			ExitCode:            1,
+			DependencyCondition: successCondition,
+			Resolved:            false,
+		},
+		{
+			TargetKnown:         apicontainerstatus.ContainerStatusNone,
+			DependencyKnown:     apicontainerstatus.ContainerStatusNone,
+			DependencyCondition: completeCondition,
+			Resolved:            true,
+		},
+		{
+			TargetKnown:         apicontainerstatus.ContainerStatusNone,
+			DependencyKnown:     apicontainerstatus.ContainerPulled,
+			DependencyCondition: completeCondition,
+			Resolved:            true,
+		},
+		{
+			TargetKnown:         apicontainerstatus.ContainerStatusNone,
+			DependencyKnown:     apicontainerstatus.ContainerCreated,
+			DependencyCondition: completeCondition,
+			Resolved:            true,
+		},
+		{
+			TargetKnown:         apicontainerstatus.ContainerStatusNone,
+			DependencyKnown:     apicontainerstatus.ContainerRunning,
+			DependencyCondition: completeCondition,
+			Resolved:            true,
+		},
+		{
+			TargetKnown:         apicontainerstatus.ContainerStatusNone,
+			DependencyKnown:     apicontainerstatus.ContainerStopped,
+			DependencyCondition: completeCondition,
+			Resolved:            true,
+		},
+		{
+			TargetKnown:         apicontainerstatus.ContainerPulled,
+			DependencyKnown:     apicontainerstatus.ContainerStatusNone,
+			DependencyCondition: completeCondition,
+			Resolved:            false,
+		},
+	}
+
+	cfg := config.Config{
+		DependentContainersPullUpfront: config.BooleanDefaultTrue{Value: config.ExplicitlyEnabled},
+	}
+	for _, tc := range testcases {
+		t.Run(fmt.Sprintf("DependencyCondition:%s+T:%s+V:%s", tc.DependencyCondition, tc.TargetKnown.String(), tc.DependencyKnown.String()),
+			assertContainerTargetOrderingResolved(containerOrderingDependenciesIsResolved, tc.TargetKnown, tc.DependencyKnown, tc.DependencyCondition, tc.ExitCode, tc.Resolved, &cfg))
+	}
+}
+
+func assertContainerTargetOrderingResolved(f func(target *apicontainer.Container, dep *apicontainer.Container, depCond string, cfg *config.Config) bool, targetKnown, depKnown apicontainerstatus.ContainerStatus, depCond string, exitcode int, expectedResolvable bool, cfg *config.Config) func(t *testing.T) {
+	return func(t *testing.T) {
+		target := &apicontainer.Container{
+			KnownStatusUnsafe: targetKnown,
+		}
+		dep := &apicontainer.Container{
+			KnownStatusUnsafe:   depKnown,
+			KnownExitCodeUnsafe: aws.Int(exitcode),
+		}
+
+		resolvable := f(target, dep, depCond, cfg)
+		assert.Equal(t, expectedResolvable, resolvable)
+	}
+}
+
+func assertContainerOrderingCanResolve(f func(target *apicontainer.Container, dep *apicontainer.Container, depCond string, cfg *config.Config) bool, targetDesired, depDesired, depKnown apicontainerstatus.ContainerStatus, depCond string, exitcode int, expectedResolvable bool, cfg *config.Config) func(t *testing.T) {
 	return func(t *testing.T) {
 		target := &apicontainer.Container{
 			DesiredStatusUnsafe: targetDesired,
@@ -972,12 +1120,12 @@ func assertContainerOrderingCanResolve(f func(target *apicontainer.Container, de
 			KnownStatusUnsafe:   depKnown,
 			KnownExitCodeUnsafe: aws.Int(exitcode),
 		}
-		resolvable := f(target, dep, depCond)
+		resolvable := f(target, dep, depCond, cfg)
 		assert.Equal(t, expectedResolvable, resolvable)
 	}
 }
 
-func assertContainerOrderingResolved(f func(target *apicontainer.Container, dep *apicontainer.Container, depCond string) bool, targetDesired, depKnown apicontainerstatus.ContainerStatus, depCond string, exitcode int, expectedResolved bool) func(t *testing.T) {
+func assertContainerOrderingResolved(f func(target *apicontainer.Container, dep *apicontainer.Container, depCond string, cfg *config.Config) bool, targetDesired, depKnown apicontainerstatus.ContainerStatus, depCond string, exitcode int, expectedResolved bool, cfg *config.Config) func(t *testing.T) {
 	return func(t *testing.T) {
 		target := &apicontainer.Container{
 			DesiredStatusUnsafe: targetDesired,
@@ -986,7 +1134,7 @@ func assertContainerOrderingResolved(f func(target *apicontainer.Container, dep 
 			KnownStatusUnsafe:   depKnown,
 			KnownExitCodeUnsafe: aws.Int(exitcode),
 		}
-		resolved := f(target, dep, depCond)
+		resolved := f(target, dep, depCond, cfg)
 		assert.Equal(t, expectedResolved, resolved)
 	}
 }
@@ -994,6 +1142,7 @@ func assertContainerOrderingResolved(f func(target *apicontainer.Container, dep 
 func TestContainerOrderingHealthyConditionIsResolved(t *testing.T) {
 	testcases := []struct {
 		TargetDesired                 apicontainerstatus.ContainerStatus
+		TargetKnown                   apicontainerstatus.ContainerStatus
 		DependencyKnownHealthStatus   apicontainerstatus.ContainerHealthStatus
 		HealthCheckType               string
 		DependencyKnownHealthExitCode int
@@ -1020,16 +1169,61 @@ func TestContainerOrderingHealthyConditionIsResolved(t *testing.T) {
 			Resolved:      false,
 		},
 	}
+	cfg := config.Config{}
 	for _, tc := range testcases {
-		t.Run(fmt.Sprintf("T:%s+V:%s", tc.TargetDesired.String(), tc.DependencyKnownHealthStatus.String()),
-			assertContainerOrderingHealthyConditionResolved(containerOrderingDependenciesIsResolved, tc.TargetDesired, tc.DependencyKnownHealthStatus, tc.HealthCheckType, tc.DependencyKnownHealthExitCode, tc.DependencyCondition, tc.Resolved))
+		t.Run(fmt.Sprintf("DependencyKnownHealthStatus:%s+T:%s+V:%s", tc.DependencyKnownHealthStatus, tc.TargetDesired.String(), tc.DependencyKnownHealthStatus.String()),
+			assertContainerOrderingHealthyConditionResolved(containerOrderingDependenciesIsResolved, tc.TargetDesired, tc.TargetKnown, tc.DependencyKnownHealthStatus, tc.HealthCheckType, tc.DependencyKnownHealthExitCode, tc.DependencyCondition, tc.Resolved, &cfg))
 	}
 }
 
-func assertContainerOrderingHealthyConditionResolved(f func(target *apicontainer.Container, dep *apicontainer.Container, depCond string) bool, targetDesired apicontainerstatus.ContainerStatus, depHealthKnown apicontainerstatus.ContainerHealthStatus, healthCheckEnabled string, depHealthKnownExitCode int, depCond string, expectedResolved bool) func(t *testing.T) {
+func TestContainerOrderingHealthyConditionIsResolvedWithDependentContainersPullUpfront(t *testing.T) {
+	testcases := []struct {
+		TargetDesired                 apicontainerstatus.ContainerStatus
+		TargetKnown                   apicontainerstatus.ContainerStatus
+		DependencyKnownHealthStatus   apicontainerstatus.ContainerHealthStatus
+		HealthCheckType               string
+		DependencyKnownHealthExitCode int
+		DependencyCondition           string
+		Resolved                      bool
+	}{
+		{
+			TargetKnown:                 apicontainerstatus.ContainerStatusNone,
+			DependencyKnownHealthStatus: apicontainerstatus.ContainerHealthy,
+			HealthCheckType:             "docker",
+			DependencyCondition:         healthyCondition,
+			Resolved:                    true,
+		},
+		{
+			TargetKnown:                   apicontainerstatus.ContainerStatusNone,
+			DependencyKnownHealthStatus:   apicontainerstatus.ContainerUnhealthy,
+			HealthCheckType:               "docker",
+			DependencyKnownHealthExitCode: 1,
+			DependencyCondition:           healthyCondition,
+			Resolved:                      true,
+		},
+		{
+			TargetKnown:                   apicontainerstatus.ContainerPulled,
+			DependencyKnownHealthStatus:   apicontainerstatus.ContainerUnhealthy,
+			HealthCheckType:               "docker",
+			DependencyKnownHealthExitCode: 1,
+			DependencyCondition:           healthyCondition,
+			Resolved:                      false,
+		},
+	}
+	cfg := config.Config{
+		DependentContainersPullUpfront: config.BooleanDefaultTrue{Value: config.ExplicitlyEnabled},
+	}
+	for _, tc := range testcases {
+		t.Run(fmt.Sprintf("DependencyKnownHealthStatus:%s+T:%s+V:%s", tc.DependencyKnownHealthStatus, tc.TargetKnown.String(), tc.DependencyKnownHealthStatus.String()),
+			assertContainerOrderingHealthyConditionResolved(containerOrderingDependenciesIsResolved, tc.TargetDesired, tc.TargetKnown, tc.DependencyKnownHealthStatus, tc.HealthCheckType, tc.DependencyKnownHealthExitCode, tc.DependencyCondition, tc.Resolved, &cfg))
+	}
+}
+
+func assertContainerOrderingHealthyConditionResolved(f func(target *apicontainer.Container, dep *apicontainer.Container, depCond string, cfg *config.Config) bool, targetDesired apicontainerstatus.ContainerStatus, targetKnown apicontainerstatus.ContainerStatus, depHealthKnown apicontainerstatus.ContainerHealthStatus, healthCheckEnabled string, depHealthKnownExitCode int, depCond string, expectedResolved bool, cfg *config.Config) func(t *testing.T) {
 	return func(t *testing.T) {
 		target := &apicontainer.Container{
 			DesiredStatusUnsafe: targetDesired,
+			KnownStatusUnsafe:   targetKnown,
 		}
 		dep := &apicontainer.Container{
 			Health: apicontainer.HealthStatus{
@@ -1038,7 +1232,7 @@ func assertContainerOrderingHealthyConditionResolved(f func(target *apicontainer
 			},
 			HealthCheckType: healthCheckEnabled,
 		}
-		resolved := f(target, dep, depCond)
+		resolved := f(target, dep, depCond, cfg)
 		assert.Equal(t, expectedResolved, resolved)
 	}
 }

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -710,7 +710,7 @@ func (engine *DockerTaskEngine) AddTask(task *apitask.Task) {
 		task.UpdateDesiredStatus()
 
 		engine.state.AddTask(task)
-		if dependencygraph.ValidDependencies(task) {
+		if dependencygraph.ValidDependencies(task, engine.cfg) {
 			engine.startTask(task)
 		} else {
 			seelog.Errorf("Task engine [%s]: unable to progress task with circular dependencies", task.Arn)
@@ -873,6 +873,12 @@ func (engine *DockerTaskEngine) pullAndUpdateContainerReference(task *apitask.Ta
 		return metadata
 	}
 	pullSucceeded := metadata.Error == nil
+	if pullSucceeded {
+		dockerContainer := &apicontainer.DockerContainer{
+			Container: container,
+		}
+		engine.state.AddPulledContainer(dockerContainer, task)
+	}
 	engine.updateContainerReference(pullSucceeded, container, task.Arn)
 	return metadata
 }

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -1660,6 +1660,44 @@ func TestUpdateContainerReference(t *testing.T) {
 	assert.True(t, imageState.PullSucceeded, "PullSucceeded set to false")
 }
 
+// TestPullAndUpdateContainerReference checks whether a container is added to task engine state when
+// pullSucceeded and DependentContainersPullUpfront is enabled.
+func TestPullAndUpdateContainerReference(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	cfg := &config.Config{
+		DependentContainersPullUpfront: config.BooleanDefaultTrue{Value: config.ExplicitlyEnabled},
+	}
+	ctrl, client, _, privateTaskEngine, _, imageManager, _ := mocks(t, ctx, cfg)
+	defer ctrl.Finish()
+
+	taskEngine, _ := privateTaskEngine.(*DockerTaskEngine)
+	taskEngine._time = nil
+	imageName := "image"
+	taskArn := "taskArn"
+	container := &apicontainer.Container{
+		Type:  apicontainer.ContainerNormal,
+		Image: imageName,
+	}
+	task := &apitask.Task{
+		Arn:        taskArn,
+		Containers: []*apicontainer.Container{container},
+	}
+	imageState := &image.ImageState{
+		Image: &image.Image{ImageID: "id"},
+	}
+
+	client.EXPECT().PullImage(gomock.Any(), imageName, gomock.Any(), gomock.Any())
+	imageManager.EXPECT().RecordContainerReference(container)
+	imageManager.EXPECT().GetImageStateFromImageName(imageName).Return(imageState, true)
+	metadata := taskEngine.pullAndUpdateContainerReference(task, container)
+	pulledContainersMap, ok := taskEngine.State().PulledContainerMapByArn(taskArn)
+	require.True(t, ok, "no container found in the agent state")
+	require.Len(t, pulledContainersMap, 1)
+	assert.True(t, imageState.PullSucceeded, "PullSucceeded set to false")
+	assert.Equal(t, dockerapi.DockerContainerMetadata{}, metadata, "expected empty metadata")
+}
+
 // TestMetadataFileUpdatedAgentRestart checks whether metadataManager.Update(...) is
 // invoked in the path DockerTaskEngine.Init() -> .synchronizeState() -> .updateMetadataFile(...)
 // for the following case:

--- a/agent/engine/dockerstate/mocks/dockerstate_mocks.go
+++ b/agent/engine/dockerstate/mocks/dockerstate_mocks.go
@@ -87,6 +87,18 @@ func (mr *MockTaskEngineStateMockRecorder) AddImageState(arg0 interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddImageState", reflect.TypeOf((*MockTaskEngineState)(nil).AddImageState), arg0)
 }
 
+// AddPulledContainer mocks base method
+func (m *MockTaskEngineState) AddPulledContainer(arg0 *container.DockerContainer, arg1 *task.Task) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "AddPulledContainer", arg0, arg1)
+}
+
+// AddPulledContainer indicates an expected call of AddPulledContainer
+func (mr *MockTaskEngineStateMockRecorder) AddPulledContainer(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddPulledContainer", reflect.TypeOf((*MockTaskEngineState)(nil).AddPulledContainer), arg0, arg1)
+}
+
 // AddTask mocks base method
 func (m *MockTaskEngineState) AddTask(arg0 *task.Task) {
 	m.ctrl.T.Helper()
@@ -270,6 +282,21 @@ func (m *MockTaskEngineState) MarshalJSON() ([]byte, error) {
 func (mr *MockTaskEngineStateMockRecorder) MarshalJSON() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarshalJSON", reflect.TypeOf((*MockTaskEngineState)(nil).MarshalJSON))
+}
+
+// PulledContainerMapByArn mocks base method
+func (m *MockTaskEngineState) PulledContainerMapByArn(arg0 string) (map[string]*container.DockerContainer, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PulledContainerMapByArn", arg0)
+	ret0, _ := ret[0].(map[string]*container.DockerContainer)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// PulledContainerMapByArn indicates an expected call of PulledContainerMapByArn
+func (mr *MockTaskEngineStateMockRecorder) PulledContainerMapByArn(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PulledContainerMapByArn", reflect.TypeOf((*MockTaskEngineState)(nil).PulledContainerMapByArn), arg0)
 }
 
 // RemoveENIAttachment mocks base method

--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -1021,7 +1021,7 @@ func (mtask *managedTask) containerNextState(container *apicontainer.Container) 
 		}
 	}
 	if blocked, err := dependencygraph.DependenciesAreResolved(container, mtask.Containers,
-		mtask.Task.GetExecutionCredentialsID(), mtask.credentialsManager, mtask.GetResources()); err != nil {
+		mtask.Task.GetExecutionCredentialsID(), mtask.credentialsManager, mtask.GetResources(), mtask.cfg); err != nil {
 		seelog.Debugf("Managed task [%s]: can't apply state to container [%s (Runtime ID: %s)] yet due to unresolved dependencies: %v",
 			mtask.Arn, container.Name, container.GetRuntimeID(), err)
 		return &containerTransition{

--- a/agent/handlers/task_server_setup_test.go
+++ b/agent/handlers/task_server_setup_test.go
@@ -61,11 +61,14 @@ const (
 	version                    = "1"
 	containerID                = "cid"
 	containerName              = "sleepy"
+	pulledContainerName        = "pulled"
 	imageName                  = "busybox"
 	imageID                    = "bUsYbOx"
 	cpu                        = 1024
 	memory                     = 512
 	statusRunning              = "RUNNING"
+	statusPulled               = "PULLED"
+	statusNone                 = "NONE"
 	containerType              = "NORMAL"
 	containerPort              = 80
 	containerPortProtocol      = "tcp"
@@ -106,6 +109,15 @@ var (
 		Name: associationName,
 		Type: associationType,
 	}
+	pulledAssociation = apitask.Association{
+		Containers: []string{containerName, pulledContainerName},
+		Content: apitask.EncodedString{
+			Encoding: associationEncoding,
+			Value:    associationValue,
+		},
+		Name: associationName,
+		Type: associationType,
+	}
 	task = &apitask.Task{
 		Arn:                 taskARN,
 		Associations:        []apitask.Association{association},
@@ -113,6 +125,32 @@ var (
 		Version:             version,
 		DesiredStatusUnsafe: apitaskstatus.TaskRunning,
 		KnownStatusUnsafe:   apitaskstatus.TaskRunning,
+		ENIs: []*apieni.ENI{
+			{
+				IPV4Addresses: []*apieni.ENIIPV4Address{
+					{
+						Address: eniIPv4Address,
+					},
+				},
+				MacAddress:               macAddress,
+				PrivateDNSName:           privateDNSName,
+				SubnetGatewayIPV4Address: subnetGatewayIpv4Address,
+			},
+		},
+		CPU:                      cpu,
+		Memory:                   memory,
+		PullStartedAtUnsafe:      now,
+		PullStoppedAtUnsafe:      now,
+		ExecutionStoppedAtUnsafe: now,
+		LaunchType:               "EC2",
+	}
+	pulledTask = &apitask.Task{
+		Arn:                 taskARN,
+		Associations:        []apitask.Association{pulledAssociation},
+		Family:              family,
+		Version:             version,
+		DesiredStatusUnsafe: apitaskstatus.TaskRunning,
+		KnownStatusUnsafe:   apitaskstatus.TaskStatusNone,
 		ENIs: []*apieni.ENI{
 			{
 				IPV4Addresses: []*apieni.ENIIPV4Address{
@@ -149,13 +187,30 @@ var (
 			},
 		},
 	}
+	pulledContainer = &apicontainer.Container{
+		Name:                pulledContainerName,
+		Image:               imageName,
+		ImageID:             imageID,
+		DesiredStatusUnsafe: apicontainerstatus.ContainerRunning,
+		KnownStatusUnsafe:   apicontainerstatus.ContainerPulled,
+		CPU:                 cpu,
+		Memory:              memory,
+		Type:                apicontainer.ContainerNormal,
+		ContainerArn:        "arn:aws:ecs:ap-northnorth-1:NNN:container/NNNNNNNN-aaaa-4444-bbbb-00000000000",
+	}
 	dockerContainer = &apicontainer.DockerContainer{
 		DockerID:   containerID,
 		DockerName: containerName,
 		Container:  container,
 	}
+	pulledDockerContainer = &apicontainer.DockerContainer{
+		Container: pulledContainer,
+	}
 	containerNameToDockerContainer = map[string]*apicontainer.DockerContainer{
 		taskARN: dockerContainer,
+	}
+	pulledContainerNameToDockerContainer = map[string]*apicontainer.DockerContainer{
+		taskARN: pulledDockerContainer,
 	}
 	labels = map[string]string{
 		"foo": "bar",
@@ -187,6 +242,18 @@ var (
 				IPv4Addresses: []string{eniIPv4Address},
 			},
 		},
+	}
+	expectedPulledContainerResponse = v2.ContainerResponse{
+		Name:          pulledContainerName,
+		Image:         imageName,
+		ImageID:       imageID,
+		DesiredStatus: statusRunning,
+		KnownStatus:   statusPulled,
+		Limits: v2.LimitsResponse{
+			CPU:    aws.Float64(cpu),
+			Memory: aws.Int64(memory),
+		},
+		Type: containerType,
 	}
 	expectedTaskResponse = v2.TaskResponse{
 		Cluster:       clusterName,
@@ -343,6 +410,21 @@ var (
 			}},
 		},
 	}
+	expectedV4PulledContainerResponse = v4.ContainerResponse{
+		ContainerResponse: &v2.ContainerResponse{
+			Name:          pulledContainerName,
+			Image:         imageName,
+			ImageID:       imageID,
+			DesiredStatus: statusRunning,
+			KnownStatus:   statusPulled,
+			ContainerARN:  "arn:aws:ecs:ap-northnorth-1:NNN:container/NNNNNNNN-aaaa-4444-bbbb-00000000000",
+			Limits: v2.LimitsResponse{
+				CPU:    aws.Float64(cpu),
+				Memory: aws.Int64(memory),
+			},
+			Type: containerType,
+		},
+	}
 	expectedV4TaskResponse = v4.TaskResponse{
 		TaskResponse: &v2.TaskResponse{
 			Cluster:       clusterName,
@@ -363,6 +445,27 @@ var (
 			LaunchType:         "EC2",
 		},
 		Containers: []v4.ContainerResponse{expectedV4ContainerResponse},
+	}
+	expectedV4PulledTaskResponse = v4.TaskResponse{
+		TaskResponse: &v2.TaskResponse{
+			Cluster:       clusterName,
+			TaskARN:       taskARN,
+			Family:        family,
+			Revision:      version,
+			DesiredStatus: statusRunning,
+			KnownStatus:   statusNone,
+			Containers:    []v2.ContainerResponse{expectedContainerResponse, expectedPulledContainerResponse},
+			Limits: &v2.LimitsResponse{
+				CPU:    aws.Float64(cpu),
+				Memory: aws.Int64(memory),
+			},
+			PullStartedAt:      aws.Time(now.UTC()),
+			PullStoppedAt:      aws.Time(now.UTC()),
+			ExecutionStoppedAt: aws.Time(now.UTC()),
+			AvailabilityZone:   availabilityzone,
+			LaunchType:         "EC2",
+		},
+		Containers: []v4.ContainerResponse{expectedV4ContainerResponse, expectedV4PulledContainerResponse},
 	}
 	expectedV4BridgeContainerResponse = v4.ContainerResponse{
 		ContainerResponse: &expectedBridgeContainerResponse,
@@ -1189,6 +1292,7 @@ func TestV4TaskMetadata(t *testing.T) {
 		state.EXPECT().TaskByArn(taskARN).Return(task, true).AnyTimes(),
 		state.EXPECT().ContainerMapByArn(taskARN).Return(containerNameToDockerContainer, true),
 		state.EXPECT().TaskByArn(taskARN).Return(task, true).AnyTimes(),
+		state.EXPECT().PulledContainerMapByArn(taskARN).Return(nil, true),
 	)
 	server := taskServerSetup(credentials.NewManager(), auditLog, state, ecsClient, clusterName, statsEngine,
 		config.DefaultTaskMetadataSteadyStateRate, config.DefaultTaskMetadataBurstRate, availabilityzone, containerInstanceArn)
@@ -1205,6 +1309,38 @@ func TestV4TaskMetadata(t *testing.T) {
 	expectedV4TaskResponse.TaskResponse.Containers = nil
 	expectedV4ContainerResponse.ContainerResponse.Networks = nil
 	assert.Equal(t, expectedV4TaskResponse, taskResponse)
+}
+
+func TestV4TaskMetadataWithPulledContainers(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	state := mock_dockerstate.NewMockTaskEngineState(ctrl)
+	auditLog := mock_audit.NewMockAuditLogger(ctrl)
+	statsEngine := mock_stats.NewMockEngine(ctrl)
+	ecsClient := mock_api.NewMockECSClient(ctrl)
+
+	gomock.InOrder(
+		state.EXPECT().TaskARNByV3EndpointID(v3EndpointID).Return(taskARN, true),
+		state.EXPECT().TaskByArn(taskARN).Return(pulledTask, true).AnyTimes(),
+		state.EXPECT().ContainerMapByArn(taskARN).Return(containerNameToDockerContainer, true),
+		state.EXPECT().TaskByArn(taskARN).Return(pulledTask, true).AnyTimes(),
+		state.EXPECT().PulledContainerMapByArn(taskARN).Return(pulledContainerNameToDockerContainer, true),
+	)
+	server := taskServerSetup(credentials.NewManager(), auditLog, state, ecsClient, clusterName, statsEngine,
+		config.DefaultTaskMetadataSteadyStateRate, config.DefaultTaskMetadataBurstRate, availabilityzone, containerInstanceArn)
+	recorder := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", v4BasePath+v3EndpointID+"/task", nil)
+	server.Handler.ServeHTTP(recorder, req)
+	res, err := ioutil.ReadAll(recorder.Body)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	var taskResponse v4.TaskResponse
+	err = json.Unmarshal(res, &taskResponse)
+	assert.NoError(t, err)
+	expectedV4PulledTaskResponse.TaskResponse.Containers = nil
+	expectedV4ContainerResponse.ContainerResponse.Networks = nil
+	assert.Equal(t, expectedV4PulledTaskResponse, taskResponse)
 }
 
 func TestV4ContainerMetadata(t *testing.T) {
@@ -1298,6 +1434,7 @@ func TestV4TaskMetadataWithTags(t *testing.T) {
 			},
 		}, nil),
 		state.EXPECT().TaskByArn(taskARN).Return(task, true).AnyTimes(),
+		state.EXPECT().PulledContainerMapByArn(taskARN).Return(nil, true),
 	)
 	server := taskServerSetup(credentials.NewManager(), auditLog, state, ecsClient, clusterName, statsEngine,
 		config.DefaultTaskMetadataSteadyStateRate, config.DefaultTaskMetadataBurstRate, availabilityzone, containerInstanceArn)
@@ -1331,6 +1468,7 @@ func TestV4BridgeTaskMetadata(t *testing.T) {
 		state.EXPECT().ContainerMapByArn(taskARN).Return(containerNameToBridgeContainer, true),
 		state.EXPECT().TaskByArn(taskARN).Return(bridgeTask, true),
 		state.EXPECT().ContainerByID(containerID).Return(bridgeContainer, true),
+		state.EXPECT().PulledContainerMapByArn(taskARN).Return(nil, true),
 	)
 
 	server := taskServerSetup(credentials.NewManager(), auditLog, state, ecsClient, clusterName, statsEngine,

--- a/agent/handlers/v2/response.go
+++ b/agent/handlers/v2/response.go
@@ -139,7 +139,7 @@ func NewTaskResponse(
 	}
 
 	for _, dockerContainer := range containerNameToDockerContainer {
-		containerResponse := newContainerResponse(dockerContainer, task.GetPrimaryENI(), state, includeV4Metadata)
+		containerResponse := NewContainerResponse(dockerContainer, task.GetPrimaryENI(), includeV4Metadata)
 		resp.Containers = append(resp.Containers, containerResponse)
 	}
 
@@ -172,8 +172,9 @@ func propagateTagsToMetadata(state dockerstate.TaskEngineState, ecsClient api.EC
 	}
 }
 
-// NewContainerResponse creates a new container response based on container id
-func NewContainerResponse(
+// NewContainerResponseFromState creates a new container response based on container id
+// TODO: remove includeV4Metadata from NewContainerResponseFromState/NewContainerResponse
+func NewContainerResponseFromState(
 	containerID string,
 	state dockerstate.TaskEngineState,
 	includeV4Metadata bool,
@@ -189,14 +190,15 @@ func NewContainerResponse(
 			"v2 container response: unable to find task for container '%s'", containerID)
 	}
 
-	resp := newContainerResponse(dockerContainer, task.GetPrimaryENI(), state, includeV4Metadata)
+	resp := NewContainerResponse(dockerContainer, task.GetPrimaryENI(), includeV4Metadata)
 	return &resp, nil
 }
 
-func newContainerResponse(
+// NewContainerResponse creates a new container response
+// TODO: remove includeV4Metadata from NewContainerResponse
+func NewContainerResponse(
 	dockerContainer *apicontainer.DockerContainer,
 	eni *apieni.ENI,
-	state dockerstate.TaskEngineState,
 	includeV4Metadata bool,
 ) ContainerResponse {
 	container := dockerContainer.Container

--- a/agent/handlers/v2/response_test.go
+++ b/agent/handlers/v2/response_test.go
@@ -311,7 +311,7 @@ func TestContainerResponse(t *testing.T) {
 				state.EXPECT().TaskByID(containerID).Return(task, true),
 			)
 
-			containerResponse, err := NewContainerResponse(containerID, state, false)
+			containerResponse, err := NewContainerResponseFromState(containerID, state, false)
 			assert.NoError(t, err)
 			assert.Equal(t, containerResponse.Health == nil, tc.result)
 			_, err = json.Marshal(containerResponse)
@@ -552,7 +552,7 @@ func TestContainerResponseMarshal(t *testing.T) {
 		state.EXPECT().TaskByID(containerID).Return(task, true),
 	)
 
-	containerResponse, err := NewContainerResponse(containerID, state, false)
+	containerResponse, err := NewContainerResponseFromState(containerID, state, false)
 	assert.NoError(t, err)
 
 	containerResponseJSON, err := json.Marshal(containerResponse)

--- a/agent/handlers/v2/task_container_metadata_handler.go
+++ b/agent/handlers/v2/task_container_metadata_handler.go
@@ -71,7 +71,7 @@ func TaskContainerMetadataHandler(state dockerstate.TaskEngineState, ecsClient a
 
 // WriteContainerMetadataResponse writes the container metadata to response writer.
 func WriteContainerMetadataResponse(w http.ResponseWriter, containerID string, state dockerstate.TaskEngineState) {
-	containerResponse, err := NewContainerResponse(containerID, state, false)
+	containerResponse, err := NewContainerResponseFromState(containerID, state, false)
 	if err != nil {
 		errResponseJSON, err := json.Marshal("Unable to generate metadata for container '" + containerID + "'")
 		if e := utils.WriteResponseIfMarshalError(w, err); e != nil {

--- a/agent/handlers/v3/container_metadata_handler.go
+++ b/agent/handlers/v3/container_metadata_handler.go
@@ -63,7 +63,7 @@ func ContainerMetadataHandler(state dockerstate.TaskEngineState) func(http.Respo
 
 // GetContainerResponse gets container response for v3 metadata
 func GetContainerResponse(containerID string, state dockerstate.TaskEngineState) (*v2.ContainerResponse, error) {
-	containerResponse, err := v2.NewContainerResponse(containerID, state, false)
+	containerResponse, err := v2.NewContainerResponseFromState(containerID, state, false)
 	if err != nil {
 		seelog.Errorf("Unable to get container metadata for container '%s'", containerID)
 		return nil, errors.Errorf("Unable to generate metadata for container '%s'", containerID)

--- a/agent/handlers/v4/response.go
+++ b/agent/handlers/v4/response.go
@@ -15,6 +15,8 @@ package v4
 
 import (
 	"github.com/aws/amazon-ecs-agent/agent/api"
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	apieni "github.com/aws/amazon-ecs-agent/agent/api/eni"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	"github.com/aws/amazon-ecs-agent/agent/containermetadata"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
@@ -117,7 +119,7 @@ func NewContainerResponse(
 	state dockerstate.TaskEngineState,
 ) (*ContainerResponse, error) {
 	// Construct the v2 response first.
-	container, err := v2.NewContainerResponse(containerID, state, true)
+	container, err := v2.NewContainerResponseFromState(containerID, state, true)
 	if err != nil {
 		return nil, err
 	}
@@ -186,4 +188,16 @@ func newNetworkInterfaceProperties(task *apitask.Task) (NetworkInterfaceProperti
 		PrivateDNSName:           eni.PrivateDNSName,
 		SubnetGatewayIPV4Address: eni.SubnetGatewayIPV4Address,
 	}, nil
+}
+
+// NewPulledContainerResponse creates a new v4 container response for a pulled container.
+// It augments v4 container response with an additional empty network interface field.
+func NewPulledContainerResponse(
+	dockerContainer *apicontainer.DockerContainer,
+	eni *apieni.ENI,
+) ContainerResponse {
+	resp := v2.NewContainerResponse(dockerContainer, eni, true)
+	return ContainerResponse{
+		ContainerResponse: &resp,
+	}
 }

--- a/agent/handlers/v4/task_metadata_handler.go
+++ b/agent/handlers/v4/task_metadata_handler.go
@@ -78,6 +78,14 @@ func TaskMetadataHandler(state dockerstate.TaskEngineState, ecsClient api.ECSCli
 			taskResponse.Containers = responses
 		}
 
+		pulledContainers, _ := state.PulledContainerMapByArn(task.Arn)
+		// Convert each pulled container into v4 container response
+		// and append pulled containers to taskResponse.Containers
+		for _, dockerContainer := range pulledContainers {
+			taskResponse.Containers = append(taskResponse.Containers,
+				NewPulledContainerResponse(dockerContainer, task.GetPrimaryENI()))
+		}
+
 		responseJSON, err := json.Marshal(taskResponse)
 		if e := utils.WriteResponseIfMarshalError(w, err); e != nil {
 			return


### PR DESCRIPTION
### Summary
This PR introduces a new state:  __pulled containers__ to docker task engine state, and a new environment variable __ECS_PULL_DEPENDENT_CONTAINERS_UPFRONT__ to Agent.

The environment variable's default value is true, and it allows dependent containers start pulling images before the dependsOn condition: START/SUCCESS/COMPLETE/HEALTHY in a task definition has been satisfied. If the environment variable is set to false, dependent containers will only start pulling images when the dependsOn condition has been fulfilled.

Containers have completed pulling images process and have known status __PULLED__ are defined as pulled containers. These containers can be retrieved from Task Metadata Endpoint version 4 (TMDEv4) path `${ECS_CONTAINER_METADATA_URI_V4}/task`. 
  
In the following example, there are 2 containers: A and B. Container B is a __target__ container, and container A is a __dependsOn__ container. When ECS_PULL_DEPENDENT_CONTAINERS_UPFRONT is true, container B starts pulling images before container A fulfills SUCCESS condition; container B is stored in a pulled container map after it succeed in pulling images, and later is removed from the pulled container map when it reaches to CREATED status. In addition, while container B has known status PULLED, it will be included in task metadata retrieved from container A.
  
```
The dependsOn container - container  A
"dependsOn": null
"command": [
    "sh",
    "-c",
    "sleep 300"
]
```
```
The target container - container B
"dependsOn": [
    {
        "containerName": "A",
        "condition": "SUCCESS"
    }
]

"command": [
    "sh",
    "-c",
    "sleep 100"
]
```

### Implementation details

- Define Config.DependentContainersPullUpfront type in types.go to specify whether pull containers in parallel should be applied to this agent.
- Convert the reading environment variable ECS_PULL_DEPENDENT_CONTAINERS_UPFRONT to Config.DependentContainersPullUpfront type in config.go, and set its default value to true in config_unix.go and config_windows.go
- Pass the config from function containerNextState in /agent/engine/task_manager.go -> function DependenciesAreResolved in /agent/engine/dependencygraph/graph.go -> function containerOrderingDependenciesIsResolved in /agent/engine/dependencygraph/graph.go  
- Allow the target container to be moved to created or the steady state if the config has Config.DependentContainersPullUpfront enabled, and known status of the target container has not reached to pulled state
- Add the target container to a pulled container map in docker task engine state when pullSucceeded  is met and the config has Config.DependentContainersPullUpfront enabled in function pullAndUpdateContainerReference
- Build a pulled container response with an empty network metadata from TMDEv4, as network metadata may not be presented for the pulled container yet
- Remove a pulled container from the pulled container map in docker task engine state when it transits to created state
- Remove pulled containers associated with a task ARN from the pulled container map when function RemoveTask is called


### Testing
Manual test:
Run tasks with container B depends on container A's START/SUCCESS/COMPLETE/HEALTHY status, and verify results by __ecs-agent.log__ and __TMDEv4 task responses__ when ECS_PULL_DEPENDENT_CONTAINERS_UPFRONT is set to true or is not specified. Results are shown below.

1. dependsOn: __START__ 
Container B starts pulling images before container A reaches to START state, as follows 
```
level=info time=2020-11-10T22: 05: 49Z msg="Task engine: pulling image for container A concurrently" module=docker_task_engine.go
level=info time=2020-11-10T22: 05: 49Z msg="Task engine: pulling image for container B concurrently" module=docker_task_engine.go
level=info time=2020-11-10T22: 05: 49Z msg="Task engine: finished pulling image for container B" module=docker_task_engine.go
```

2. dependsOn: __SUCCESS__
Container B starts pulling images before A exists with exit code 0. After container B completed pulling images, its KnownStatus: PULLED can be found in container A's TMDEv4 task response, as follows 
```
$ curl {Container A's ECS_CONTAINER_METADATA_URI_V4}/task
{
    ...
    "KnownStatus": "NONE",
    "Containers": [
        {
            "DockerId": "DockerId",
            "Name": "NetworkContainer",
            "DockerName": "DockerName",
            "Image": "Image",
            "ImageID": "ImageID",
            "Labels": {...},
            "DesiredStatus": "RUNNING",
            "KnownStatus": "RUNNING",
            "Limits": {},
            "CreatedAt": "CreatedAt",
            "StartedAt": "StartedAt",
            "Type": "NORMAL",
            "Volumes": [...],
            "ContainerARN": "ContainerARN",
            "Networks": [...]
        },
        {
            "DockerId": "",
            **"Name": "CustomerContainer",**
            "DockerName": "",
            "Image": "Image",
            "ImageID": "ImageID",
            "DesiredStatus": "RUNNING",
            **"KnownStatus": "PULLED",**
             "Limits": {...},
            "Type": "NORMAL",
            "ContainerARN": "ContainerARN"
        }
    ]
}
```
Container B reaches to CREATED and RUNNING state after container A exited with exit code 0, and it's TMDEv4 task response is provided as follows 
```
{
    ...
    "KnownStatus": "RUNNING",
    "Containers": [
        {
            "DockerId": "DockerId",
            "Name": "CustomerContainer",
            "DockerName": "DockerName",
            "Image": "Image",
            "ImageID": "ImageID",
            "Labels": {},
            "DesiredStatus": "RUNNING",
            "KnownStatus": "RUNNING",
            "Limits": {...},
            "CreatedAt": "CreatedAt",
            "StartedAt": "StartedAt",
            "Type": "NORMAL",
            "Networks": [...],
            "Volumes": [...]
        },
        {
            "DockerId": "DockerId",
            "Name": "NetworkContainer",
            "DockerName": "DockerName",
            "Image": "Image",
            "ImageID": "ImageID",
            "Labels": {...},
            "DesiredStatus": "RUNNING",
            "KnownStatus": "STOPPED",
            "ExitCode": 0,
            "Limits": {...},
            "CreatedAt": "CreatedAt",
            "StartedAt": "StartedAt",
            "FinishedAt":"FinishedAt"
            "Type": "NORMAL",
            "Volumes": [...],
            "ContainerARN": "ContainerARN",
            "Networks": [...]
            "Volumes": [...]
        }
    ]
}
```
3. dependsOn: __COMPLETE__
Container B starts pulling images before container A exits with exit code. After container B completed pulling images, its KnownStatus: PULLED can be found in container A's TMDEv4 task response, as follows 
```
$ curl {Container A's ECS_CONTAINER_METADATA_URI_V4}/task
{
    ...
    "KnownStatus": "NONE",
    "Containers": [
        {
            "DockerId": "DockerId",
            "Name": "NetworkContainer",
            "DockerName": "DockerName",
            "Image": "Image",
            "ImageID": "ImageID",
            "Labels": {...},
            "DesiredStatus": "RUNNING",
            "KnownStatus": "RUNNING",
            "Limits": {...},
            "CreatedAt": "CreatedAt",
            "StartedAt": "StartedAt",
            "Type": "NORMAL",
            "Volumes": [...],
            "ContainerARN": "ContainerARN",
            "Networks": [...]
        },
        {
            "DockerId": "",
            **"Name": "CustomerContainer",**
            "DockerName": "",
            "Image": "Image",
            "ImageID": "ImageID",
            "DesiredStatus": "RUNNING",
            **"KnownStatus": "PULLED",**
            "Limits": {...},
            "Type": "NORMAL",
            "ContainerARN": "ContainerARN",
        }
    ]
}
```
Container B reaches to CREATED and RUNNING state after container A exited with exit code 0, and it's TMDEv4 task response is the same as the response shown in dependsOn: __SUCCESS__

4. dependsOn: __HEALTHY__
Container B starts pulling images before container A reaches to HEALTHY state. After container B completed pulling images, its KnownStatus: PULLED can be found in container A's TMDEv4 task response, as follows 
```
$ curl {Container A's ECS_CONTAINER_METADATA_URI_V4}/task
{
    ...
    "KnownStatus": "NONE",
    "Containers": [
        {
            "DockerId": "DockerId",
            "Name": "NetworkContainer",
            "DockerName": "DockerName",
            "Image": "Image",
            "ImageID": "ImageID",
            "Labels": {...},
            "DesiredStatus": "RUNNING",
            "KnownStatus": "RUNNING",
            "Limits": {...},
            "CreatedAt": "CreatedAt",
            "StartedAt": "StartedAt",
            "Type": "NORMAL",
            "Health": {
                **"status": "UNHEALTHY",**
                ...
            },
            "Volumes": [...],
            "ContainerARN": "ContainerARN",
            "Networks": [...]
        },
        {
            "DockerId": "",
            **"Name": "CustomerContainer",**
            "DockerName": "",
            "Image": "Image",
            "ImageID": "ImageID",
            "DesiredStatus": "RUNNING",
            **"KnownStatus": "PULLED",**
            "Limits": {...},
            "Type": "NORMAL",
            "ContainerARN": "ContainerARN",
        }
    ]
}
```
  
New tests cover the changes: yes

- TestContainerOrderingIsResolvedWithDependentContainersPullUpfront
- TestContainerOrderingHealthyConditionIsResolvedWithDependentContainersPullUpfront
- TestPullAndUpdateContainerReference
- TestAddPulledContainer
- TestPulledContainerToAddContainer
- TestCreateDockerTaskEngineState (Update)
- TestRemoveTask(Update)
- TestEnvironmentConfig(Update)
- TestConfigDefault(Update) 
- TestV4TaskMetadataWithPulledContainers
  
### Description for the changelog
N/A
  
### Licensing
  
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
