### PR TITLE
save and load pulled containers state

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ additional details on each available environment variable.
 | `ECS_DISABLE_METRICS`     | &lt;true &#124; false&gt;  | Whether to disable metrics gathering for tasks. | false | true |
 | `ECS_POLL_METRICS`     | &lt;true &#124; false&gt;  | Whether to poll or stream when gathering metrics for tasks. This defaulted to `false` previous to agent version 1.40.0. WARNING: setting this to false on an instance with many containers can result in very high CPU utilization by the agent, dockerd, and containerd. | `true` | `true` |
 | `ECS_POLLING_METRICS_WAIT_DURATION` | 10s | Time to wait between polling for metrics for a task. Not used when ECS_POLL_METRICS is false. Maximum value is 20s and minimum value is 5s. If user sets above maximum it will be set to max, and if below minimum it will be set to min. | 10s | 10s |
+| `ECS_PULL_DEPENDENT_CONTAINER_PARALLEL` | &lt;true &#124; false&gt; | Whether to pull images of dependent containers, even though dependsOn condition has not been satisfied yet. | false | false |
 | `ECS_RESERVED_MEMORY` | 32 | Memory, in MiB, to reserve for use by things other than containers managed by Amazon ECS. | 0 | 0 |
 | `ECS_AVAILABLE_LOGGING_DRIVERS` | `["awslogs","fluentd","gelf","json-file","journald","logentries","splunk","syslog"]` | Which logging drivers are available on the container instance. | `["json-file","none"]` | `["json-file","none"]` |
 | `ECS_DISABLE_PRIVILEGED` | `true` | Whether launching privileged containers is disabled on the container instance. | `false` | `false` |

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -533,6 +533,7 @@ func environmentConfig() (Config, error) {
 		TaskCPUMemLimit:                     parseBooleanDefaultTrueConfig("ECS_ENABLE_TASK_CPU_MEM_LIMIT"),
 		DockerStopTimeout:                   parseDockerStopTimeout(),
 		ContainerStartTimeout:               parseContainerStartTimeout(),
+		ContainerPullInParallel:             parseBooleanDefaultFalseConfig("ECS_PULL_DEPENDENT_CONTAINER_PARALLEL"),
 		ImagePullInactivityTimeout:          parseImagePullInactivityTimeout(),
 		ImagePullTimeout:                    parseEnvVariableDuration("ECS_IMAGE_PULL_TIMEOUT"),
 		CredentialsAuditLogFile:             os.Getenv("ECS_AUDIT_LOGFILE"),
@@ -600,6 +601,7 @@ func (cfg *Config) String() string {
 			"TaskCleanupWaitDuration: %v, "+
 			"DockerStopTimeout: %v, "+
 			"ContainerStartTimeout: %v, "+
+			"ContainerPullInParallel: %v, "+
 			"TaskCPUMemLimit: %v, "+
 			"%s",
 		cfg.Cluster,
@@ -615,6 +617,7 @@ func (cfg *Config) String() string {
 		cfg.TaskCleanupWaitDuration,
 		cfg.DockerStopTimeout,
 		cfg.ContainerStartTimeout,
+		cfg.ContainerPullInParallel,
 		cfg.TaskCPUMemLimit,
 		cfg.platformString(),
 	)

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -145,6 +145,7 @@ func TestEnvironmentConfig(t *testing.T) {
 	defer setTestEnv("ECS_POLL_METRICS", "true")()
 	defer setTestEnv("ECS_POLLING_METRICS_WAIT_DURATION", "10s")()
 	defer setTestEnv("ECS_CGROUP_CPU_PERIOD", "")
+	defer setTestEnv("ECS_PULL_DEPENDENT_CONTAINER_PARALLEL", "true")()
 	additionalLocalRoutesJSON := `["1.2.3.4/22","5.6.7.8/32"]`
 	setTestEnv("ECS_AWSVPC_ADDITIONAL_LOCAL_ROUTES", additionalLocalRoutesJSON)
 	setTestEnv("ECS_ENABLE_CONTAINER_METADATA", "true")
@@ -197,6 +198,7 @@ func TestEnvironmentConfig(t *testing.T) {
 	assert.Equal(t, 10*time.Millisecond, conf.CgroupCPUPeriod)
 	assert.False(t, conf.SpotInstanceDrainingEnabled.Enabled())
 	assert.Equal(t, []string{"efsAuth"}, conf.VolumePluginCapabilities)
+	assert.True(t, conf.ContainerPullInParallel.Enabled(), "Wrong value for ContainerPullInParallel")
 }
 
 func TestTrimWhitespaceWhenCreating(t *testing.T) {

--- a/agent/config/config_unix.go
+++ b/agent/config/config_unix.go
@@ -56,6 +56,7 @@ func DefaultConfig() Config {
 		TaskCleanupWaitDuration:             DefaultTaskCleanupWaitDuration,
 		DockerStopTimeout:                   defaultDockerStopTimeout,
 		ContainerStartTimeout:               defaultContainerStartTimeout,
+		ContainerPullInParallel:             BooleanDefaultFalse{Value: ExplicitlyDisabled},
 		CredentialsAuditLogFile:             defaultCredentialsAuditLogFile,
 		CredentialsAuditLogDisabled:         false,
 		ImageCleanupDisabled:                BooleanDefaultFalse{Value: ExplicitlyDisabled},

--- a/agent/config/config_unix_test.go
+++ b/agent/config/config_unix_test.go
@@ -68,6 +68,7 @@ func TestConfigDefault(t *testing.T) {
 	assert.False(t, cfg.SharedVolumeMatchFullConfig.Enabled(), "Default SharedVolumeMatchFullConfig set incorrectly")
 	assert.Equal(t, defaultCgroupCPUPeriod, cfg.CgroupCPUPeriod, "CFS cpu period set incorrectly")
 	assert.Equal(t, DefaultImagePullTimeout, cfg.ImagePullTimeout, "Default ImagePullTimeout set incorrectly")
+	assert.False(t, cfg.ContainerPullInParallel.Enabled(), "Default ContainerPullInParallel set incorrectly")
 }
 
 // TestConfigFromFile tests the configuration can be read from file

--- a/agent/config/config_windows.go
+++ b/agent/config/config_windows.go
@@ -86,6 +86,7 @@ func DefaultConfig() Config {
 		TaskCleanupWaitDuration:             DefaultTaskCleanupWaitDuration,
 		DockerStopTimeout:                   defaultDockerStopTimeout,
 		ContainerStartTimeout:               defaultContainerStartTimeout,
+		ContainerPullInParallel:             BooleanDefaultFalse{Value: ExplicitlyDisabled},
 		ImagePullInactivityTimeout:          defaultImagePullInactivityTimeout,
 		ImagePullTimeout:                    DefaultImagePullTimeout,
 		CredentialsAuditLogFile:             filepath.Join(ecsRoot, defaultCredentialsAuditLogFile),

--- a/agent/config/config_windows_test.go
+++ b/agent/config/config_windows_test.go
@@ -61,6 +61,7 @@ func TestConfigDefault(t *testing.T) {
 		"Default TaskMetadataBurstRate is set incorrectly")
 	assert.False(t, cfg.SharedVolumeMatchFullConfig.Enabled(), "Default SharedVolumeMatchFullConfig set incorrectly")
 	assert.Equal(t, DefaultImagePullTimeout, cfg.ImagePullTimeout, "Default ImagePullTimeout set incorrectly")
+	assert.False(t, cfg.ContainerPullInParallel.Enabled(), "Default ContainerPullInParallel set incorrectly")
 }
 
 func TestConfigIAMTaskRolesReserves80(t *testing.T) {

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -112,6 +112,10 @@ type Config struct {
 	// ContainerStartTimeout specifies the amount of time to wait to start a container
 	ContainerStartTimeout time.Duration
 
+	// ContainerPullInParallel specifies whether pull containers in parallel should be applied to this agent.
+	// Default false
+	ContainerPullInParallel BooleanDefaultFalse
+
 	// ImagePullInactivityTimeout is here to override the amount of time to wait when pulling and extracting a container
 	ImagePullInactivityTimeout time.Duration
 

--- a/agent/data/client.go
+++ b/agent/data/client.go
@@ -29,11 +29,12 @@ const (
 	dbName = "agent.db"
 	dbMode = 0600
 
-	containersBucketName     = "containers"
-	tasksBucketName          = "tasks"
-	imagesBucketName         = "images"
-	eniAttachmentsBucketName = "eniattachments"
-	metadataBucketName       = "metadata"
+	containersBucketName       = "containers"
+	pulledContainersBucketName = "pulledcontainers"
+	tasksBucketName            = "tasks"
+	imagesBucketName           = "images"
+	eniAttachmentsBucketName   = "eniattachments"
+	metadataBucketName         = "metadata"
 )
 
 var (
@@ -43,6 +44,7 @@ var (
 	buckets = []string{
 		imagesBucketName,
 		containersBucketName,
+		pulledContainersBucketName,
 		tasksBucketName,
 		eniAttachmentsBucketName,
 		metadataBucketName,
@@ -53,6 +55,8 @@ var (
 type Client interface {
 	// SaveContainer saves the data of a container.
 	SaveContainer(*container.Container) error
+	// SavePulledContainer saves the data of a pulled container.
+	SavePulledContainer(*container.Container) error
 	// SaveDockerContainer saves the data of a docker container.
 	// We have both SaveContainer and SaveDockerContainer so that a caller who doesn't have docker information
 	// of the container can save container with SaveContainer, while a caller who wants to save the docker
@@ -60,8 +64,12 @@ type Client interface {
 	SaveDockerContainer(*container.DockerContainer) error
 	// DeleteContainer deletes the data of a container.
 	DeleteContainer(string) error
+	// DeleteContainer deletes the data of a pulled container.
+	DeletePulledContainer(string) error
 	// GetContainers gets the data of all the containers.
 	GetContainers() ([]*container.DockerContainer, error)
+	// GetPulledContainers gets the data of all the pulled containers.
+	GetPulledContainers() ([]*container.DockerContainer, error)
 
 	// SaveTask saves the data of a task.
 	SaveTask(*task.Task) error

--- a/agent/data/container_client.go
+++ b/agent/data/container_client.go
@@ -55,6 +55,23 @@ func (c *client) SaveContainer(container *apicontainer.Container) error {
 	})
 }
 
+func (c *client) SavePulledContainer(container *apicontainer.Container) error {
+	id, err := GetContainerID(container)
+	if err != nil {
+		return errors.Wrap(err, "failed to generate database id")
+	}
+
+	dockerContainer, err := c.getDockerContainer(id)
+	if err != nil {
+		dockerContainer = &apicontainer.DockerContainer{}
+	}
+	dockerContainer.Container = container
+	return c.db.Batch(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(pulledContainersBucketName))
+		return putObject(b, id, dockerContainer)
+	})
+}
+
 func (c *client) getDockerContainer(id string) (*apicontainer.DockerContainer, error) {
 	container := &apicontainer.DockerContainer{}
 	err := c.db.View(func(tx *bolt.Tx) error {
@@ -71,11 +88,36 @@ func (c *client) DeleteContainer(id string) error {
 	})
 }
 
+// DeletePulledContainer deletes a pulled container from the container bucket.
+func (c *client) DeletePulledContainer(id string) error {
+	return c.db.Batch(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(pulledContainersBucketName))
+		return b.Delete([]byte(id))
+	})
+}
+
 // GetContainers returns all the containers in the container bucket.
 func (c *client) GetContainers() ([]*apicontainer.DockerContainer, error) {
 	var containers []*apicontainer.DockerContainer
 	err := c.db.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket([]byte(containersBucketName))
+		return walk(bucket, func(id string, data []byte) error {
+			container := apicontainer.DockerContainer{}
+			if err := json.Unmarshal(data, &container); err != nil {
+				return err
+			}
+			containers = append(containers, &container)
+			return nil
+		})
+	})
+	return containers, err
+}
+
+// GetPulledContainers returns all the pulled containers in the container bucket.
+func (c *client) GetPulledContainers() ([]*apicontainer.DockerContainer, error) {
+	var containers []*apicontainer.DockerContainer
+	err := c.db.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket([]byte(pulledContainersBucketName))
 		return walk(bucket, func(id string, data []byte) error {
 			container := apicontainer.DockerContainer{}
 			if err := json.Unmarshal(data, &container); err != nil {

--- a/agent/data/noop_client.go
+++ b/agent/data/noop_client.go
@@ -32,6 +32,10 @@ func (c *noopClient) SaveContainer(*container.Container) error {
 	return nil
 }
 
+func (c *noopClient) SavePulledContainer(*container.Container) error {
+	return nil
+}
+
 func (c *noopClient) SaveDockerContainer(*container.DockerContainer) error {
 	return nil
 }
@@ -40,7 +44,15 @@ func (c *noopClient) DeleteContainer(string) error {
 	return nil
 }
 
+func (c *noopClient) DeletePulledContainer(string) error {
+	return nil
+}
+
 func (c *noopClient) GetContainers() ([]*container.DockerContainer, error) {
+	return nil, nil
+}
+
+func (c *noopClient) GetPulledContainers() ([]*container.DockerContainer, error) {
 	return nil, nil
 }
 

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -878,6 +878,7 @@ func (engine *DockerTaskEngine) pullAndUpdateContainerReference(task *apitask.Ta
 			Container: container,
 		}
 		engine.state.AddPulledContainer(dockerContainer, task)
+		engine.savePulledContainerData(container)
 	}
 	engine.updateContainerReference(pullSucceeded, container, task.Arn)
 	return metadata
@@ -1108,6 +1109,12 @@ func (engine *DockerTaskEngine) createContainer(task *apitask.Task, container *a
 			Container:  container}
 		engine.state.AddContainer(dockerContainer, task)
 		engine.saveDockerContainerData(dockerContainer)
+		id, err := data.GetContainerID(container)
+		if err != nil {
+			seelog.Errorf("Failed to get container id from container %s: %v", container.Name, err)
+		} else {
+			engine.dataClient.DeletePulledContainer(id)
+		}
 	}
 	container.SetLabels(config.Labels)
 	seelog.Infof("Task engine [%s]: created docker container for task: %s -> %s, took %s",

--- a/agent/engine/dockerstate/docker_task_engine_state.go
+++ b/agent/engine/dockerstate/docker_task_engine_state.go
@@ -40,6 +40,8 @@ type TaskEngineState interface {
 	ContainerByID(id string) (*apicontainer.DockerContainer, bool)
 	// ContainerMapByArn returns a map of containers belonging to a particular task ARN
 	ContainerMapByArn(arn string) (map[string]*apicontainer.DockerContainer, bool)
+	// PulledContainerMapByArn returns a map of pulled containers belonging to a particular task ARN
+	PulledContainerMapByArn(arn string) (map[string]*apicontainer.DockerContainer, bool)
 	// TaskByShortID retrieves the task of a given docker short container id
 	TaskByShortID(cid string) ([]*apitask.Task, bool)
 	// TaskByID returns an apitask.Task for a given container ID
@@ -48,6 +50,8 @@ type TaskEngineState interface {
 	TaskByArn(arn string) (*apitask.Task, bool)
 	// AddTask adds a task to the state to be stored
 	AddTask(task *apitask.Task)
+	// AddPulledContainer adds a pulled container to the state to be stored for a given task
+	AddPulledContainer(container *apicontainer.DockerContainer, task *apitask.Task)
 	// AddContainer adds a container to the state to be stored for a given task
 	AddContainer(container *apicontainer.DockerContainer, task *apitask.Task)
 	// AddImageState adds an image.ImageState to be stored
@@ -98,6 +102,7 @@ type DockerTaskEngineState struct {
 	tasks                  map[string]*apitask.Task                            // taskarn -> apitask.Task
 	idToTask               map[string]string                                   // DockerId -> taskarn
 	taskToID               map[string]map[string]*apicontainer.DockerContainer // taskarn -> (containername -> c.DockerContainer)
+	taskToPulledContainer  map[string]map[string]*apicontainer.DockerContainer // taskarn -> (containername -> c.DockerContainer)
 	idToContainer          map[string]*apicontainer.DockerContainer            // DockerId -> c.DockerContainer
 	eniAttachments         map[string]*apieni.ENIAttachment                    // ENIMac -> apieni.ENIAttachment
 	imageStates            map[string]*image.ImageState
@@ -124,6 +129,7 @@ func (state *DockerTaskEngineState) initializeDockerTaskEngineState() {
 	state.tasks = make(map[string]*apitask.Task)
 	state.idToTask = make(map[string]string)
 	state.taskToID = make(map[string]map[string]*apicontainer.DockerContainer)
+	state.taskToPulledContainer = make(map[string]map[string]*apicontainer.DockerContainer)
 	state.idToContainer = make(map[string]*apicontainer.DockerContainer)
 	state.imageStates = make(map[string]*image.ImageState)
 	state.eniAttachments = make(map[string]*apieni.ENIAttachment)
@@ -271,6 +277,25 @@ func (state *DockerTaskEngineState) ContainerMapByArn(arn string) (map[string]*a
 	return ret, ok
 }
 
+// PulledContainerMapByArn returns a map of pulled containers belonging to a particular task ARN
+func (state *DockerTaskEngineState) PulledContainerMapByArn(arn string) (map[string]*apicontainer.DockerContainer, bool) {
+	state.lock.RLock()
+	defer state.lock.RUnlock()
+
+	ret, ok := state.taskToPulledContainer[arn]
+
+	// Copy the map to avoid data race
+	if ok {
+		mc := make(map[string]*apicontainer.DockerContainer)
+		for k, v := range ret {
+			mc[k] = v
+		}
+		return mc, ok
+	}
+
+	return ret, ok
+}
+
 // TaskByShortID retrieves the task of a given docker short container id
 func (state *DockerTaskEngineState) TaskByShortID(cid string) ([]*apitask.Task, bool) {
 	containerIDs := state.GetAllContainerIDs()
@@ -318,6 +343,29 @@ func (state *DockerTaskEngineState) AddTask(task *apitask.Task) {
 	state.tasks[task.Arn] = task
 }
 
+// AddPulledContainer adds a pulled container to the state
+func (state *DockerTaskEngineState) AddPulledContainer(container *apicontainer.DockerContainer, task *apitask.Task) {
+	state.lock.Lock()
+	defer state.lock.Unlock()
+	if task == nil || container == nil {
+		seelog.Critical("AddPulledContainer called with nil task/container")
+		return
+	}
+
+	_, exists := state.tasks[task.Arn]
+	if !exists {
+		seelog.Debug("AddPulledContainer called with unknown task; adding", "arn", task.Arn)
+		state.tasks[task.Arn] = task
+	}
+
+	existingMap, exists := state.taskToPulledContainer[task.Arn]
+	if !exists {
+		existingMap = make(map[string]*apicontainer.DockerContainer, len(task.Containers))
+		state.taskToPulledContainer[task.Arn] = existingMap
+	}
+	existingMap[container.Container.Name] = container
+}
+
 // AddContainer adds a container to the state.
 // If the container has been added with only a name and no docker-id, this
 // updates the state to include the docker id
@@ -333,6 +381,16 @@ func (state *DockerTaskEngineState) AddContainer(container *apicontainer.DockerC
 	if !exists {
 		seelog.Debug("AddContainer called with unknown task; adding", "arn", task.Arn)
 		state.tasks[task.Arn] = task
+	}
+
+	_, pulledExist := state.taskToPulledContainer[task.Arn]
+	if pulledExist {
+		seelog.Debug("Delete a pulled container named %s from the pulled container map associated with the task ARN %s since AddContainer is called",
+			container.Container.Name, task.Arn)
+		delete(state.taskToPulledContainer[task.Arn], container.Container.Name)
+		if len(state.taskToPulledContainer[task.Arn]) == 0 {
+			delete(state.taskToPulledContainer, task.Arn)
+		}
 	}
 
 	state.storeIDToContainerTaskUnsafe(container, task)
@@ -397,6 +455,7 @@ func (state *DockerTaskEngineState) RemoveTask(task *apitask.Task) {
 		// remove v3 endpoint mappings
 		state.removeV3EndpointIDToTaskContainerUnsafe(dockerContainer.Container.V3EndpointID)
 	}
+	delete(state.taskToPulledContainer, task.Arn)
 }
 
 // taskToIPUnsafe gets the ip address for a given task arn

--- a/agent/engine/dockerstate/mocks/dockerstate_mocks.go
+++ b/agent/engine/dockerstate/mocks/dockerstate_mocks.go
@@ -57,10 +57,22 @@ func (m *MockTaskEngineState) AddContainer(arg0 *container.DockerContainer, arg1
 	m.ctrl.Call(m, "AddContainer", arg0, arg1)
 }
 
+// AddPulledContainer mocks base method
+func (m *MockTaskEngineState) AddPulledContainer(arg0 *container.DockerContainer, arg1 *task.Task) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "AddPulledContainer", arg0, arg1)
+}
+
 // AddContainer indicates an expected call of AddContainer
 func (mr *MockTaskEngineStateMockRecorder) AddContainer(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddContainer", reflect.TypeOf((*MockTaskEngineState)(nil).AddContainer), arg0, arg1)
+}
+
+// AddPulledContainer indicates an expected call of AddPulledContainer
+func (mr *MockTaskEngineStateMockRecorder) AddPulledContainer(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddPulledContainer", reflect.TypeOf((*MockTaskEngineState)(nil).AddPulledContainer), arg0, arg1)
 }
 
 // AddENIAttachment mocks base method
@@ -172,6 +184,21 @@ func (mr *MockTaskEngineStateMockRecorder) ContainerByID(arg0 interface{}) *gomo
 func (m *MockTaskEngineState) ContainerMapByArn(arg0 string) (map[string]*container.DockerContainer, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContainerMapByArn", arg0)
+	ret0, _ := ret[0].(map[string]*container.DockerContainer)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// PulledContainerMapByArn indicates an expected call of PulledContainerMapByArn
+func (mr *MockTaskEngineStateMockRecorder) PulledContainerMapByArn(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PulledContainerMapByArn", reflect.TypeOf((*MockTaskEngineState)(nil).PulledContainerMapByArn), arg0)
+}
+
+// PulledContainerMapByArn mocks base method
+func (m *MockTaskEngineState) PulledContainerMapByArn(arg0 string) (map[string]*container.DockerContainer, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PulledContainerMapByArn", arg0)
 	ret0, _ := ret[0].(map[string]*container.DockerContainer)
 	ret1, _ := ret[1].(bool)
 	return ret0, ret1

--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -1021,7 +1021,7 @@ func (mtask *managedTask) containerNextState(container *apicontainer.Container) 
 		}
 	}
 	if blocked, err := dependencygraph.DependenciesAreResolved(container, mtask.Containers,
-		mtask.Task.GetExecutionCredentialsID(), mtask.credentialsManager, mtask.GetResources()); err != nil {
+		mtask.Task.GetExecutionCredentialsID(), mtask.credentialsManager, mtask.GetResources(), mtask.cfg); err != nil {
 		seelog.Debugf("Managed task [%s]: can't apply state to container [%s (Runtime ID: %s)] yet due to unresolved dependencies: %v",
 			mtask.Arn, container.Name, container.GetRuntimeID(), err)
 		return &containerTransition{

--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -419,7 +419,12 @@ func (mtask *managedTask) handleContainerChange(containerChange dockerContainerC
 	}
 
 	// Container has progressed its status if we reach here. Make sure to save it to database.
-	defer mtask.engine.saveContainerData(container)
+	defer func() {
+		mtask.engine.saveContainerData(container)
+		if container.GetKnownStatus() == apicontainerstatus.ContainerPulled {
+			mtask.engine.savePulledContainerData(container)
+		}
+	}()
 
 	// Update the container to be known
 	currentKnownStatus := containerKnownStatus

--- a/agent/engine/task_manager_test.go
+++ b/agent/engine/task_manager_test.go
@@ -1064,6 +1064,7 @@ func TestCleanupTask(t *testing.T) {
 
 	// Expectations to verify that the task gets removed
 	mockState.EXPECT().ContainerMapByArn(mTask.Arn).Return(map[string]*apicontainer.DockerContainer{container.Name: dockerContainer}, true)
+	mockState.EXPECT().PulledContainerMapByArn(mTask.Arn).Return(map[string]*apicontainer.DockerContainer{container.Name: dockerContainer}, true)
 	mockClient.EXPECT().RemoveContainer(gomock.Any(), dockerContainer.DockerName, gomock.Any()).Return(nil)
 	mockImageManager.EXPECT().RemoveContainerReferenceFromImageState(container).Return(nil)
 	mockState.EXPECT().RemoveTask(mTask.Task)
@@ -1133,6 +1134,8 @@ func TestCleanupTaskWaitsForStoppedSent(t *testing.T) {
 
 	// Expectations to verify that the task gets removed
 	mockState.EXPECT().ContainerMapByArn(mTask.Arn).Return(
+		map[string]*apicontainer.DockerContainer{container.Name: dockerContainer}, true)
+	mockState.EXPECT().PulledContainerMapByArn(mTask.Arn).Return(
 		map[string]*apicontainer.DockerContainer{container.Name: dockerContainer}, true)
 	mockClient.EXPECT().RemoveContainer(gomock.Any(), dockerContainer.DockerName, gomock.Any()).Return(nil)
 	mockImageManager.EXPECT().RemoveContainerReferenceFromImageState(container).Return(nil)
@@ -1260,6 +1263,7 @@ func TestCleanupTaskENIs(t *testing.T) {
 
 	// Expectations to verify that the task gets removed
 	mockState.EXPECT().ContainerMapByArn(mTask.Arn).Return(map[string]*apicontainer.DockerContainer{container.Name: dockerContainer}, true)
+	mockState.EXPECT().PulledContainerMapByArn(mTask.Arn).Return(map[string]*apicontainer.DockerContainer{container.Name: dockerContainer}, true)
 	mockClient.EXPECT().RemoveContainer(gomock.Any(), dockerContainer.DockerName, gomock.Any()).Return(nil)
 	mockImageManager.EXPECT().RemoveContainerReferenceFromImageState(container).Return(nil)
 	mockState.EXPECT().RemoveTask(mTask.Task)
@@ -1375,6 +1379,7 @@ func TestCleanupTaskWithInvalidInterval(t *testing.T) {
 
 	// Expectations to verify that the task gets removed
 	mockState.EXPECT().ContainerMapByArn(mTask.Arn).Return(map[string]*apicontainer.DockerContainer{container.Name: dockerContainer}, true)
+	mockState.EXPECT().PulledContainerMapByArn(mTask.Arn).Return(map[string]*apicontainer.DockerContainer{container.Name: dockerContainer}, true)
 	mockClient.EXPECT().RemoveContainer(gomock.Any(), dockerContainer.DockerName, gomock.Any()).Return(nil)
 	mockImageManager.EXPECT().RemoveContainerReferenceFromImageState(container).Return(nil)
 	mockState.EXPECT().RemoveTask(mTask.Task)
@@ -1434,6 +1439,7 @@ func TestCleanupTaskWithResourceHappyPath(t *testing.T) {
 
 	// Expectations to verify that the task gets removed
 	mockState.EXPECT().ContainerMapByArn(mTask.Arn).Return(map[string]*apicontainer.DockerContainer{container.Name: dockerContainer}, true)
+	mockState.EXPECT().PulledContainerMapByArn(mTask.Arn).Return(map[string]*apicontainer.DockerContainer{container.Name: dockerContainer}, true)
 	mockClient.EXPECT().RemoveContainer(gomock.Any(), dockerContainer.DockerName, gomock.Any()).Return(nil)
 	mockImageManager.EXPECT().RemoveContainerReferenceFromImageState(container).Return(nil)
 	mockState.EXPECT().RemoveTask(mTask.Task)
@@ -1495,6 +1501,7 @@ func TestCleanupTaskWithResourceErrorPath(t *testing.T) {
 
 	// Expectations to verify that the task gets removed
 	mockState.EXPECT().ContainerMapByArn(mTask.Arn).Return(map[string]*apicontainer.DockerContainer{container.Name: dockerContainer}, true)
+	mockState.EXPECT().PulledContainerMapByArn(mTask.Arn).Return(map[string]*apicontainer.DockerContainer{container.Name: dockerContainer}, true)
 	mockClient.EXPECT().RemoveContainer(gomock.Any(), dockerContainer.DockerName, gomock.Any()).Return(nil)
 	mockImageManager.EXPECT().RemoveContainerReferenceFromImageState(container).Return(nil)
 	mockState.EXPECT().RemoveTask(mTask.Task)

--- a/agent/handlers/v2/response.go
+++ b/agent/handlers/v2/response.go
@@ -139,7 +139,7 @@ func NewTaskResponse(
 	}
 
 	for _, dockerContainer := range containerNameToDockerContainer {
-		containerResponse := newContainerResponse(dockerContainer, task.GetPrimaryENI(), state, includeV4Metadata)
+		containerResponse := NewContainerResponse(dockerContainer, task.GetPrimaryENI(), includeV4Metadata)
 		resp.Containers = append(resp.Containers, containerResponse)
 	}
 
@@ -172,8 +172,9 @@ func propagateTagsToMetadata(state dockerstate.TaskEngineState, ecsClient api.EC
 	}
 }
 
-// NewContainerResponse creates a new container response based on container id
-func NewContainerResponse(
+// NewContainerResponseFromState creates a new container response based on container id
+// TODO: remove includeV4Metadata from NewContainerResponseFromState/NewContainerResponse
+func NewContainerResponseFromState(
 	containerID string,
 	state dockerstate.TaskEngineState,
 	includeV4Metadata bool,
@@ -189,14 +190,15 @@ func NewContainerResponse(
 			"v2 container response: unable to find task for container '%s'", containerID)
 	}
 
-	resp := newContainerResponse(dockerContainer, task.GetPrimaryENI(), state, includeV4Metadata)
+	resp := NewContainerResponse(dockerContainer, task.GetPrimaryENI(), includeV4Metadata)
 	return &resp, nil
 }
 
-func newContainerResponse(
+// NewContainerResponse creates a new container response
+// TODO: remove includeV4Metadata from NewContainerResponse
+func NewContainerResponse(
 	dockerContainer *apicontainer.DockerContainer,
 	eni *apieni.ENI,
-	state dockerstate.TaskEngineState,
 	includeV4Metadata bool,
 ) ContainerResponse {
 	container := dockerContainer.Container

--- a/agent/handlers/v2/response_test.go
+++ b/agent/handlers/v2/response_test.go
@@ -311,7 +311,7 @@ func TestContainerResponse(t *testing.T) {
 				state.EXPECT().TaskByID(containerID).Return(task, true),
 			)
 
-			containerResponse, err := NewContainerResponse(containerID, state, false)
+			containerResponse, err := NewContainerResponseFromState(containerID, state, false)
 			assert.NoError(t, err)
 			assert.Equal(t, containerResponse.Health == nil, tc.result)
 			_, err = json.Marshal(containerResponse)
@@ -552,7 +552,7 @@ func TestContainerResponseMarshal(t *testing.T) {
 		state.EXPECT().TaskByID(containerID).Return(task, true),
 	)
 
-	containerResponse, err := NewContainerResponse(containerID, state, false)
+	containerResponse, err := NewContainerResponseFromState(containerID, state, false)
 	assert.NoError(t, err)
 
 	containerResponseJSON, err := json.Marshal(containerResponse)

--- a/agent/handlers/v2/task_container_metadata_handler.go
+++ b/agent/handlers/v2/task_container_metadata_handler.go
@@ -71,7 +71,7 @@ func TaskContainerMetadataHandler(state dockerstate.TaskEngineState, ecsClient a
 
 // WriteContainerMetadataResponse writes the container metadata to response writer.
 func WriteContainerMetadataResponse(w http.ResponseWriter, containerID string, state dockerstate.TaskEngineState) {
-	containerResponse, err := NewContainerResponse(containerID, state, false)
+	containerResponse, err := NewContainerResponseFromState(containerID, state, false)
 	if err != nil {
 		errResponseJSON, err := json.Marshal("Unable to generate metadata for container '" + containerID + "'")
 		if e := utils.WriteResponseIfMarshalError(w, err); e != nil {

--- a/agent/handlers/v3/container_metadata_handler.go
+++ b/agent/handlers/v3/container_metadata_handler.go
@@ -63,7 +63,7 @@ func ContainerMetadataHandler(state dockerstate.TaskEngineState) func(http.Respo
 
 // GetContainerResponse gets container response for v3 metadata
 func GetContainerResponse(containerID string, state dockerstate.TaskEngineState) (*v2.ContainerResponse, error) {
-	containerResponse, err := v2.NewContainerResponse(containerID, state, false)
+	containerResponse, err := v2.NewContainerResponseFromState(containerID, state, false)
 	if err != nil {
 		seelog.Errorf("Unable to get container metadata for container '%s'", containerID)
 		return nil, errors.Errorf("Unable to generate metadata for container '%s'", containerID)

--- a/agent/handlers/v4/response.go
+++ b/agent/handlers/v4/response.go
@@ -15,6 +15,8 @@ package v4
 
 import (
 	"github.com/aws/amazon-ecs-agent/agent/api"
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	apieni "github.com/aws/amazon-ecs-agent/agent/api/eni"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	"github.com/aws/amazon-ecs-agent/agent/containermetadata"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
@@ -117,7 +119,7 @@ func NewContainerResponse(
 	state dockerstate.TaskEngineState,
 ) (*ContainerResponse, error) {
 	// Construct the v2 response first.
-	container, err := v2.NewContainerResponse(containerID, state, true)
+	container, err := v2.NewContainerResponseFromState(containerID, state, true)
 	if err != nil {
 		return nil, err
 	}
@@ -186,4 +188,17 @@ func newNetworkInterfaceProperties(task *apitask.Task) (NetworkInterfaceProperti
 		PrivateDNSName:           eni.PrivateDNSName,
 		SubnetGatewayIPV4Address: eni.SubnetGatewayIPV4Address,
 	}, nil
+}
+
+// NewPulledContainerResponse creates a new v4 container response for a pulled container.
+// It augments v4 container response with an additional empty network interface field.
+func NewPulledContainerResponse(
+	dockerContainer *apicontainer.DockerContainer,
+	eni *apieni.ENI,
+) ContainerResponse {
+	resp := v2.NewContainerResponse(dockerContainer, eni, true)
+	return ContainerResponse{
+		ContainerResponse: &resp,
+		Networks:          []Network{},
+	}
 }

--- a/agent/handlers/v4/task_metadata_handler.go
+++ b/agent/handlers/v4/task_metadata_handler.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
+	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/handlers/utils"
 	v3 "github.com/aws/amazon-ecs-agent/agent/handlers/v3"
@@ -63,6 +64,9 @@ func TaskMetadataHandler(state dockerstate.TaskEngineState, ecsClient api.ECSCli
 			// fill in non-awsvpc network details for container responses here
 			responses := make([]ContainerResponse, 0)
 			for _, containerResponse := range taskResponse.Containers {
+				if containerResponse.KnownStatus == apicontainerstatus.ContainerPulled.String() && containerResponse.ID == "" {
+					continue
+				}
 				networks, err := GetContainerNetworkMetadata(containerResponse.ID, state)
 				if err != nil {
 					errResponseJSON, err := json.Marshal(err.Error())

--- a/agent/handlers/v4/task_metadata_handler.go
+++ b/agent/handlers/v4/task_metadata_handler.go
@@ -78,6 +78,16 @@ func TaskMetadataHandler(state dockerstate.TaskEngineState, ecsClient api.ECSCli
 			taskResponse.Containers = responses
 		}
 
+		pulledContainers, ok := state.PulledContainerMapByArn(task.Arn)
+		// Append pulled containers to containers in task response
+		if ok {
+			// Convert each pulled container into v4 container response
+			for _, dockerContainer := range pulledContainers {
+				pulledContainerResp := NewPulledContainerResponse(dockerContainer, task.GetPrimaryENI())
+				taskResponse.Containers = append(taskResponse.Containers, pulledContainerResp)
+			}
+		}
+
 		responseJSON, err := json.Marshal(taskResponse)
 		if e := utils.WriteResponseIfMarshalError(w, err); e != nil {
 			return


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This PR is a continuation of https://github.com/aws/amazon-ecs-agent/pull/2716 . So please review only the 2nd commit. 

- saves and loads the new pulled containers state to and from agent's boltdb state. 
- It also removes it from state when container moves to `CREATED` state. The removal is also attempted when task is stopped, in case containers didn't move to `CREATED` before moving to `STOPPED` state.
- updates the already added pulled container state when known status of container is updated to `PULLED`

### Implementation details
- Add a new bucket named `pulledcontainers` in boltdb state 
- Introduce methods `SavePulledContainer`, `DeletePulledContainer`, `GetPulledContainers` in data client for saving, removing and loading data from boltdb
- update the already added pulled container state when known status of container is updated to `PULLED` in `managedTask.handleContainerChange` method.
- today pulled containers are added to containers table in agent state here https://github.com/aws/amazon-ecs-agent/blob/1489adfaec05c559ea4e1490774d1f86261cf936/agent/engine/task_manager.go#L422 As a result, when agent restarts, the pulled container is added to non-pulled containers state, which then is attempted to obtain network metadata here https://github.com/aws/amazon-ecs-agent/blob/84321fcb15787f1d3a3f8aed80002d6d7d080ec6/agent/handlers/v4/container_metadata_handler.go#L74 and fails here https://github.com/aws/amazon-ecs-agent/blob/84321fcb15787f1d3a3f8aed80002d6d7d080ec6/agent/handlers/v4/container_metadata_handler.go#L85 
Fixed that in this PR, by skipping if container's known states is `PULLED` and container ID is empty. 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->
- Unit tests yet to be updated 
- Manual testing done: 
TMDE V4 response:
```
curl ${ECS_CONTAINER_METADATA_URI_V4}/task
{"Cluster":"pull-state","TaskARN":"arn:aws:ecs:us-west-2:074626758757:task/pull-state/2f355c277e1d4bbdb6cfe8da557b98fb","Family":"dep-check","Revision":"1","DesiredStatus":"RUNNING","KnownStatus":"NONE","PullStartedAt":"2020-11-11T14:56:03.500537906Z","PullStoppedAt":"2020-11-11T14:56:04.87932092Z","AvailabilityZone":"us-west-2a","LaunchType":"EC2","Containers":[{"DockerId":"5e733312cebf2b606e9a41af031f42a596d5a025ae34a407d359c9a6d95b7f30","Name":"network","DockerName":"ecs-dep-check-1-network-daebabb79381aea78901","Image":"ubuntu","ImageID":"sha256:d70eaf7277eada08fca944de400e7e4dd97b1262c06ed2b1011500caa4decaf1","Labels":{"com.amazonaws.ecs.cluster":"pull-state","com.amazonaws.ecs.container-name":"network","com.amazonaws.ecs.task-arn":"arn:aws:ecs:us-west-2:074626758757:task/pull-state/2f355c277e1d4bbdb6cfe8da557b98fb","com.amazonaws.ecs.task-definition-family":"dep-check","com.amazonaws.ecs.task-definition-version":"1"},"DesiredStatus":"RUNNING","KnownStatus":"RUNNING","Limits":{"CPU":0,"Memory":512},"CreatedAt":"2020-11-11T14:56:04.777143666Z","StartedAt":"2020-11-11T14:56:05.421289274Z","Type":"NORMAL","ContainerARN":"arn:aws:ecs:us-west-2:074626758757:container/fb246e8e-4dab-4c3a-b7f6-f753c1ee1b30","Networks":[{"NetworkMode":"bridge","IPv4Addresses":["172.17.0.2"]}]},{"DockerId":"","Name":"customer","DockerName":"","Image":"amazonlinux:latest","ImageID":"sha256:ba2cc467a2bce7ffc9e2d6e38a87f6ec89c1c93bc83ff575e8021bb592f9ad2e","DesiredStatus":"RUNNING","KnownStatus":"PULLED","Limits":{"CPU":0,"Memory":512},"Type":"NORMAL","ContainerARN":"arn:aws:ecs:us-west-2:074626758757:container/7a400635-6cd2-4158-974d-bfab9885abab"}]} 
``` 
Restart agent now 
TMDE response after agent restart (pulled container is still seen)
```
{"Cluster":"pull-state","TaskARN":"arn:aws:ecs:us-west-2:074626758757:task/pull-state/2f355c277e1d4bbdb6cfe8da557b98fb","Family":"dep-check","Revision":"1","DesiredStatus":"RUNNING","KnownStatus":"NONE","PullStartedAt":"2020-11-11T14:56:03.500537906Z","PullStoppedAt":"2020-11-11T14:56:04.87932092Z","AvailabilityZone":"us-west-2a","LaunchType":"EC2","Containers":[{"DockerId":"5e733312cebf2b606e9a41af031f42a596d5a025ae34a407d359c9a6d95b7f30","Name":"network","DockerName":"ecs-dep-check-1-network-daebabb79381aea78901","Image":"ubuntu","ImageID":"sha256:d70eaf7277eada08fca944de400e7e4dd97b1262c06ed2b1011500caa4decaf1","Labels":{"com.amazonaws.ecs.cluster":"pull-state","com.amazonaws.ecs.container-name":"network","com.amazonaws.ecs.task-arn":"arn:aws:ecs:us-west-2:074626758757:task/pull-state/2f355c277e1d4bbdb6cfe8da557b98fb","com.amazonaws.ecs.task-definition-family":"dep-check","com.amazonaws.ecs.task-definition-version":"1"},"DesiredStatus":"RUNNING","KnownStatus":"RUNNING","Limits":{"CPU":0,"Memory":512},"CreatedAt":"2020-11-11T14:56:04.777143666Z","StartedAt":"2020-11-11T14:56:05.421289274Z","Type":"NORMAL","ContainerARN":"arn:aws:ecs:us-west-2:074626758757:container/fb246e8e-4dab-4c3a-b7f6-f753c1ee1b30","Networks":[{"NetworkMode":"bridge","IPv4Addresses":["172.17.0.2"]}]},{"DockerId":"","Name":"customer","DockerName":"","Image":"amazonlinux:latest","ImageID":"sha256:ba2cc467a2bce7ffc9e2d6e38a87f6ec89c1c93bc83ff575e8021bb592f9ad2e","DesiredStatus":"RUNNING","KnownStatus":"PULLED","Limits":{"CPU":0,"Memory":512},"Type":"NORMAL","ContainerARN":"arn:aws:ecs:us-west-2:074626758757:container/7a400635-6cd2-4158-974d-bfab9885abab"}]}
```
example of `agent.db` with pulled container added:
```
| Path: pulledcontainers → ea86e60a718745eb850fd6afefa4eb1f-customer
| Key: ea86e60a718745eb850fd6afefa4eb1f-customer
| Value:
| {
|   "Container": {
|     "ApplyingError": null,
|     "Command": [
|       "sleep 100"
|     ],
|     "ContainerArn": "arn:aws:ecs:us-west-2:074626758757:contai....
….
….
|     "KnownStatus": "PULLED",
```
once container moves to created:
```
| Path: pulledcontainers
| Buckets: 0
| Pairs: 0
```

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
