### PR TITLE
update v4 metadata to return network despite nil

### DIFF
--- a/agent/handlers/v4/task_metadata_handler.go
+++ b/agent/handlers/v4/task_metadata_handler.go
@@ -65,12 +65,7 @@ func TaskMetadataHandler(state dockerstate.TaskEngineState, ecsClient api.ECSCli
 			for _, containerResponse := range taskResponse.Containers {
 				networks, err := GetContainerNetworkMetadata(containerResponse.ID, state)
 				if err != nil {
-					errResponseJSON, err := json.Marshal(err.Error())
-					if e := utils.WriteResponseIfMarshalError(w, err); e != nil {
-						return
-					}
-					utils.WriteJSONToResponse(w, http.StatusInternalServerError, errResponseJSON, utils.RequestTypeContainerMetadata)
-					return
+					seelog.Warnf("Error retrieving network metadata for container %s - %s", containerResponse.ID, err)
 				}
 				containerResponse.Networks = networks
 				responses = append(responses, containerResponse)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This updates the v4 metadata endpoint to return network metadata for all available.  Previously we threw a `http.StatusInternalServerError` (500) in the case of any container in the task not having available network metadata.  

### Implementation details
removed Error cases for individual missing metadata and added a `Warn` log level entry.

### Testing
make gogenerate 
make test
(will update integ/functional tests as necessary given automated tests)

New tests cover the changes: no

### Description for the changelog
Update v4 metadata to return network despite nil

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
