### PR TITLE
add missing mock for capabilities tests

### DIFF
--- a/agent/app/agent_capability_unix_test.go
+++ b/agent/app/agent_capability_unix_test.go
@@ -41,6 +41,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func init() {
+	mockPathExists(false)
+}
+
 func TestVolumeDriverCapabilitiesUnix(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/agent/app/agent_capability_windows_test.go
+++ b/agent/app/agent_capability_windows_test.go
@@ -34,6 +34,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func init() {
+	mockPathExists(false)
+}
+
 func TestVolumeDriverCapabilitiesWindows(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/agent/app/agent_compatibility_linux_test.go
+++ b/agent/app/agent_compatibility_linux_test.go
@@ -32,6 +32,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func init() {
+	mockPathExists(false)
+}
+
 func TestCompatibilityEnabledSuccess(t *testing.T) {
 	ctrl, creds, _, images, _, _, stateManagerFactory, saveableOptionFactory, execCmdMgr := setup(t)
 	defer ctrl.Finish()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
this change adds mock for `agent_capability.pathExists()` to avoid accessing file system in unit test

### Implementation details
add mock for `pathExists()` to avoid accessing file system in unit test

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

this change fixes unit tests that are currently failing

after running integ tests, paths like `/managed-agents/execute-command/bin` are created with `root` permission and when unit tests try to access these files/directories, it would cause a permission error

New tests cover the changes: no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

fix unit tests, add mock

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
