### PR TITLE
add select model updates from autogenerated model

### DIFF
--- a/agent/ecs_client/model/api/api-2.json
+++ b/agent/ecs_client/model/api/api-2.json
@@ -731,6 +731,7 @@
         "networkBindings":{"shape":"NetworkBindings"},
         "networkInterfaces":{"shape":"NetworkInterfaces"},
         "healthStatus":{"shape":"HealthStatus"},
+        "managedAgents":{"shape":"ManagedAgents"},
         "firelensConfiguration":{"shape":"FirelensConfiguration"}
       }
     },
@@ -860,10 +861,11 @@
       "type":"structure",
       "members":{
         "containerName":{"shape":"String"},
-        "imageDigest":{"shape": "String"},
-        "runtimeId":{"shape": "String"},
+        "imageDigest":{"shape":"String"},
+        "runtimeId":{"shape":"String"},
         "exitCode":{"shape":"BoxedInteger"},
         "networkBindings":{"shape":"NetworkBindings"},
+        "managedAgents":{"shape":"ManagedAgentStateChanges"},
         "reason":{"shape":"String"},
         "status":{"shape":"String"}
       }
@@ -1533,6 +1535,40 @@
       "value":{"shape":"String"}
     },
     "Long":{"type":"long"},
+    "ManagedAgent":{
+      "type":"structure",
+      "members":{
+        "lastStartedAt":{"shape":"Timestamp"},
+        "name":{"shape":"ManagedAgentName"},
+        "reason":{"shape":"String"},
+        "lastStatus":{"shape":"String"}
+      }
+    },
+    "ManagedAgentName":{
+      "type":"string",
+      "enum":["EXECUTE_COMMAND_AGENT"]
+    },
+    "ManagedAgentStateChange":{
+      "type":"structure",
+      "required":[
+        "name",
+        "status"
+      ],
+      "members":{
+        "name":{"shape":"ManagedAgentName"},
+        "status":{"shape":"String"}
+      }
+    },
+    "ManagedAgentStateChanges":{
+      "type":"list",
+      "member":{"shape":"ManagedAgentStateChange"}
+    },
+    "ManagedAgents":{
+      "type":"list",
+      "member":{"shape":"ManagedAgent"}
+    },
+
+
     "MissingVersionException":{
       "type":"structure",
       "members":{
@@ -2057,11 +2093,12 @@
         "cluster":{"shape":"String"},
         "task":{"shape":"String"},
         "containerName":{"shape":"String"},
-        "runtimeId":{"shape": "String"},
+        "runtimeId":{"shape":"String"},
         "status":{"shape":"String"},
         "exitCode":{"shape":"BoxedInteger"},
         "reason":{"shape":"String"},
-        "networkBindings":{"shape":"NetworkBindings"}
+        "networkBindings":{"shape":"NetworkBindings"},
+        "managedAgents":{"shape":"ManagedAgentStateChanges"}
       }
     },
     "SubmitContainerStateChangeResponse":{

--- a/agent/ecs_client/model/ecs/api.go
+++ b/agent/ecs_client/model/ecs/api.go
@@ -4200,6 +4200,8 @@ type Container struct {
 	// The last known status of the container.
 	LastStatus *string `locationName:"lastStatus" type:"string"`
 
+	ManagedAgents []*ManagedAgent `locationName:"managedAgents" type:"list"`
+
 	// The name of the container.
 	Name *string `locationName:"name" type:"string"`
 
@@ -4262,6 +4264,12 @@ func (s *Container) SetImageDigest(v string) *Container {
 // SetLastStatus sets the LastStatus field's value.
 func (s *Container) SetLastStatus(v string) *Container {
 	s.LastStatus = &v
+	return s
+}
+
+// SetManagedAgents sets the ManagedAgents field's value.
+func (s *Container) SetManagedAgents(v []*ManagedAgent) *Container {
+	s.ManagedAgents = v
 	return s
 }
 
@@ -5400,6 +5408,8 @@ type ContainerStateChange struct {
 
 	ImageDigest *string `locationName:"imageDigest" type:"string"`
 
+	ManagedAgents []*ManagedAgentStateChange `locationName:"managedAgents" type:"list"`
+
 	// Any network bindings associated with the container.
 	NetworkBindings []*NetworkBinding `locationName:"networkBindings" type:"list"`
 
@@ -5422,6 +5432,26 @@ func (s ContainerStateChange) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ContainerStateChange) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ContainerStateChange"}
+	if s.ManagedAgents != nil {
+		for i, v := range s.ManagedAgents {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "ManagedAgents", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // SetContainerName sets the ContainerName field's value.
 func (s *ContainerStateChange) SetContainerName(v string) *ContainerStateChange {
 	s.ContainerName = &v
@@ -5437,6 +5467,12 @@ func (s *ContainerStateChange) SetExitCode(v int64) *ContainerStateChange {
 // SetImageDigest sets the ImageDigest field's value.
 func (s *ContainerStateChange) SetImageDigest(v string) *ContainerStateChange {
 	s.ImageDigest = &v
+	return s
+}
+
+// SetManagedAgents sets the ManagedAgents field's value.
+func (s *ContainerStateChange) SetManagedAgents(v []*ManagedAgentStateChange) *ContainerStateChange {
+	s.ManagedAgents = v
 	return s
 }
 
@@ -8762,6 +8798,100 @@ func (s *LogConfiguration) SetSecretOptions(v []*Secret) *LogConfiguration {
 	return s
 }
 
+type ManagedAgent struct {
+	_ struct{} `type:"structure"`
+
+	LastStartedAt *time.Time `locationName:"lastStartedAt" type:"timestamp"`
+
+	LastStatus *string `locationName:"lastStatus" type:"string"`
+
+	Name *string `locationName:"name" type:"string" enum:"ManagedAgentName"`
+
+	Reason *string `locationName:"reason" type:"string"`
+}
+
+// String returns the string representation
+func (s ManagedAgent) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ManagedAgent) GoString() string {
+	return s.String()
+}
+
+// SetLastStartedAt sets the LastStartedAt field's value.
+func (s *ManagedAgent) SetLastStartedAt(v time.Time) *ManagedAgent {
+	s.LastStartedAt = &v
+	return s
+}
+
+// SetLastStatus sets the LastStatus field's value.
+func (s *ManagedAgent) SetLastStatus(v string) *ManagedAgent {
+	s.LastStatus = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *ManagedAgent) SetName(v string) *ManagedAgent {
+	s.Name = &v
+	return s
+}
+
+// SetReason sets the Reason field's value.
+func (s *ManagedAgent) SetReason(v string) *ManagedAgent {
+	s.Reason = &v
+	return s
+}
+
+type ManagedAgentStateChange struct {
+	_ struct{} `type:"structure"`
+
+	// Name is a required field
+	Name *string `locationName:"name" type:"string" required:"true" enum:"ManagedAgentName"`
+
+	// Status is a required field
+	Status *string `locationName:"status" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s ManagedAgentStateChange) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ManagedAgentStateChange) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ManagedAgentStateChange) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ManagedAgentStateChange"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Status == nil {
+		invalidParams.Add(request.NewErrParamRequired("Status"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetName sets the Name field's value.
+func (s *ManagedAgentStateChange) SetName(v string) *ManagedAgentStateChange {
+	s.Name = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *ManagedAgentStateChange) SetStatus(v string) *ManagedAgentStateChange {
+	s.Status = &v
+	return s
+}
+
 // Details on a volume mount point that is used in a container definition.
 type MountPoint struct {
 	_ struct{} `type:"structure"`
@@ -10968,6 +11098,8 @@ type SubmitContainerStateChangeInput struct {
 	// The exit code returned for the state change request.
 	ExitCode *int64 `locationName:"exitCode" type:"integer"`
 
+	ManagedAgents []*ManagedAgentStateChange `locationName:"managedAgents" type:"list"`
+
 	// The network bindings of the container.
 	NetworkBindings []*NetworkBinding `locationName:"networkBindings" type:"list"`
 
@@ -10994,6 +11126,26 @@ func (s SubmitContainerStateChangeInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SubmitContainerStateChangeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SubmitContainerStateChangeInput"}
+	if s.ManagedAgents != nil {
+		for i, v := range s.ManagedAgents {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "ManagedAgents", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // SetCluster sets the Cluster field's value.
 func (s *SubmitContainerStateChangeInput) SetCluster(v string) *SubmitContainerStateChangeInput {
 	s.Cluster = &v
@@ -11009,6 +11161,12 @@ func (s *SubmitContainerStateChangeInput) SetContainerName(v string) *SubmitCont
 // SetExitCode sets the ExitCode field's value.
 func (s *SubmitContainerStateChangeInput) SetExitCode(v int64) *SubmitContainerStateChangeInput {
 	s.ExitCode = &v
+	return s
+}
+
+// SetManagedAgents sets the ManagedAgents field's value.
+func (s *SubmitContainerStateChangeInput) SetManagedAgents(v []*ManagedAgentStateChange) *SubmitContainerStateChangeInput {
+	s.ManagedAgents = v
 	return s
 }
 
@@ -11117,6 +11275,16 @@ func (s *SubmitTaskStateChangeInput) Validate() error {
 			}
 			if err := v.Validate(); err != nil {
 				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Attachments", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+	if s.Containers != nil {
+		for i, v := range s.Containers {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Containers", i), err.(request.ErrInvalidParams))
 			}
 		}
 	}
@@ -12795,6 +12963,11 @@ const (
 
 	// LogDriverAwsfirelens is a LogDriver enum value
 	LogDriverAwsfirelens = "awsfirelens"
+)
+
+const (
+	// ManagedAgentNameExecuteCommandAgent is a ManagedAgentName enum value
+	ManagedAgentNameExecuteCommandAgent = "EXECUTE_COMMAND_AGENT"
 )
 
 const (


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This adds the latest approved changes to the FE model. It includes ManagedAgentStateChange model updates.

### Implementation details
This used an automated build process to generate the model from our latest internal (execute-command specific branch) changes.  I manually copied the relevant objects in from the automated model output.  I ran `make gogenerate` to update the api.go file

### Testing
ran `make gogenerate` and `make test`

New tests cover the changes: no

### Description for the changelog
Add execute-command api model specific.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
