### PR TITLE
removes redundant log statement

### DIFF
--- a/agent/handlers/v4/container_metadata_handler.go
+++ b/agent/handlers/v4/container_metadata_handler.go
@@ -88,7 +88,6 @@ func GetContainerNetworkMetadata(containerID string, state dockerstate.TaskEngin
 	// https://github.com/aws/amazon-ecs-agent/blob/0c8913ba33965cf6ffdd6253fad422458d9346bd/agent/containermetadata/parse_metadata.go#L123
 	settings := dockerContainer.Container.GetNetworkSettings()
 	if settings == nil {
-		seelog.Errorf("Unable to get container network response for container '%s'", containerID)
 		return nil, errors.Errorf("unable to generate network response for container '%s'", containerID)
 	}
 	// This metadata is the information provided in older versions of the API


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
In https://github.com/aws/amazon-ecs-agent/pull/2719 there is a new log statement added for missing container network metadata which renders this log statement redundant.  @sparrc noted it in the above PR but I overlooked this comment. 

### Implementation details
removed a redundant log line

### Testing
ran `make test`
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
