### PR TITLE
Revert v4 update

### DIFF
--- a/agent/handlers/v4/container_metadata_handler.go
+++ b/agent/handlers/v4/container_metadata_handler.go
@@ -88,6 +88,7 @@ func GetContainerNetworkMetadata(containerID string, state dockerstate.TaskEngin
 	// https://github.com/aws/amazon-ecs-agent/blob/0c8913ba33965cf6ffdd6253fad422458d9346bd/agent/containermetadata/parse_metadata.go#L123
 	settings := dockerContainer.Container.GetNetworkSettings()
 	if settings == nil {
+		seelog.Errorf("Unable to get container network response for container '%s'", containerID)
 		return nil, errors.Errorf("unable to generate network response for container '%s'", containerID)
 	}
 	// This metadata is the information provided in older versions of the API

--- a/agent/handlers/v4/task_metadata_handler.go
+++ b/agent/handlers/v4/task_metadata_handler.go
@@ -65,7 +65,12 @@ func TaskMetadataHandler(state dockerstate.TaskEngineState, ecsClient api.ECSCli
 			for _, containerResponse := range taskResponse.Containers {
 				networks, err := GetContainerNetworkMetadata(containerResponse.ID, state)
 				if err != nil {
-					seelog.Warnf("Error retrieving network metadata for container %s - %s", containerResponse.ID, err)
+					errResponseJSON, err := json.Marshal(err.Error())
+					if e := utils.WriteResponseIfMarshalError(w, err); e != nil {
+						return
+					}
+					utils.WriteJSONToResponse(w, http.StatusInternalServerError, errResponseJSON, utils.RequestTypeContainerMetadata)
+					return
 				}
 				containerResponse.Networks = networks
 				responses = append(responses, containerResponse)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
reverts changes to v4 endpoint behavior.
We decided that this is desired, but it should be accompanied by tests to affirm the expected output.

### Implementation details
git revert of the commit shas

### Testing
ran `make test`

New tests cover the changes: no

### Description for the changelog
revert V4 endpoint network change.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
