### PR TITLE
Add ManagedAgent changes to SubmitTaskStateChange

### DIFF
--- a/agent/acs/model/api/api-2.json
+++ b/agent/acs/model/api/api-2.json
@@ -219,6 +219,7 @@
         "name":{"shape":"String"},
         "overrides":{"shape":"String"},
         "portMappings":{"shape":"PortMappingList"},
+        "managedAgents":{"shape":"ManagedAgentList"},
         "mountPoints":{"shape":"MountPointList"},
         "volumesFrom":{"shape":"VolumeFromList"},
         "dockerConfig":{"shape":"DockerConfig"},
@@ -495,6 +496,21 @@
         "message":{"shape":"String"}
       },
       "exception":true
+    },
+    "ManagedAgent":{
+      "type":"structure",
+      "members":{
+        "name":{"shape":"ManagedAgentName"},
+        "properties":{"shape":"StringMap"}
+      }
+    },
+    "ManagedAgentList":{
+      "type":"list",
+      "member":{"shape":"ManagedAgent"}
+    },
+    "ManagedAgentName":{
+      "type":"string",
+      "enum":["ExecuteCommandAgent"]
     },
     "FirelensConfiguration":{
       "type":"structure",

--- a/agent/acs/model/ecsacs/api.go
+++ b/agent/acs/model/ecsacs/api.go
@@ -304,6 +304,8 @@ type Container struct {
 
 	LogsAuthStrategy *string `locationName:"logsAuthStrategy" type:"string" enum:"AuthStrategy"`
 
+	ManagedAgents []*ManagedAgent `locationName:"managedAgents" type:"list"`
+
 	Memory *int64 `locationName:"memory" type:"integer"`
 
 	MountPoints []*MountPoint `locationName:"mountPoints" type:"list"`
@@ -844,6 +846,24 @@ func (s InvalidInstanceException) String() string {
 
 // GoString returns the string representation
 func (s InvalidInstanceException) GoString() string {
+	return s.String()
+}
+
+type ManagedAgent struct {
+	_ struct{} `type:"structure"`
+
+	Name *string `locationName:"name" type:"string" enum:"ManagedAgentName"`
+
+	Properties map[string]*string `locationName:"properties" type:"map"`
+}
+
+// String returns the string representation
+func (s ManagedAgent) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ManagedAgent) GoString() string {
 	return s.String()
 }
 

--- a/agent/api/container/container.go
+++ b/agent/api/container/container.go
@@ -112,9 +112,12 @@ type HealthStatus struct {
 
 type ManagedAgentState struct {
 	// ID of this managed agent state
-	ID string `json:"id:omitempty"`
+	ID string `json:"id,omitempty"`
+	// TODO: [ecs-exec] Change variable name from Status to KnownStatus in future PR to avoid noise
 	// Status is the managed agent health status
-	Status apicontainerstatus.ManagedAgentStatus `json:"status:omitempty"`
+	Status apicontainerstatus.ManagedAgentStatus `json:"status,omitempty"`
+	// SentStatus is the managed agent sent status
+	SentStatus apicontainerstatus.ManagedAgentStatus `json:"sentStatus,omitempty"`
 	// Reason is a placeholder for failure messaging
 	Reason string `json:"reason,omitempty"`
 	// LastStartedAt is the timestamp when the status last went from PENDING->RUNNING
@@ -1232,6 +1235,20 @@ func (c *Container) UpdateManagedAgentByName(agentName string, state ManagedAgen
 				Properties:        ma.Properties,
 				ManagedAgentState: state,
 			}
+			return true
+		}
+	}
+	return false
+}
+
+// UpdateManagedAgentSentStatus updates the sent status of the managed agent with the name specified. If the agent is not found,
+// this method returns false.
+func (c *Container) UpdateManagedAgentSentStatus(agentName string, status apicontainerstatus.ManagedAgentStatus) bool {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	for i, ma := range c.ManagedAgentsUnsafe {
+		if ma.Name == agentName {
+			c.ManagedAgentsUnsafe[i].SentStatus = status
 			return true
 		}
 	}

--- a/agent/api/container/container_test.go
+++ b/agent/api/container/container_test.go
@@ -848,3 +848,49 @@ func TestUpdateManagedAgentByName(t *testing.T) {
 		})
 	}
 }
+
+func TestUpdateManagedAgentSentStatus(t *testing.T) {
+	const dummyAgent = "dummyAgent"
+	cases := []struct {
+		name               string
+		agentName          string
+		updateSentStatus   bool
+		sentStatus         apicontainerstatus.ManagedAgentStatus
+		expectedSentStatus apicontainerstatus.ManagedAgentStatus
+	}{
+		{
+			name:               "test nonexistent managed agent",
+			agentName:          "nonexistentAgent",
+			expectedSentStatus: apicontainerstatus.ManagedAgentStatusNone,
+		},
+		{
+			name:               "test managed agent with default (zero) status",
+			agentName:          dummyAgent,
+			expectedSentStatus: apicontainerstatus.ManagedAgentStatusNone,
+		},
+		{
+			name:               "test managed agent with custom status",
+			agentName:          dummyAgent,
+			updateSentStatus:   true,
+			sentStatus:         apicontainerstatus.ManagedAgentRunning,
+			expectedSentStatus: apicontainerstatus.ManagedAgentRunning,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &Container{
+				ManagedAgentsUnsafe: []ManagedAgent{{
+					Name: tc.agentName,
+				}},
+			}
+			before, _ := c.GetManagedAgentByName(tc.agentName)
+			assert.Equal(t, apicontainerstatus.ManagedAgentStatusNone, before.SentStatus)
+			if tc.updateSentStatus {
+				c.UpdateManagedAgentSentStatus(tc.agentName, tc.sentStatus)
+			}
+			after, _ := c.GetManagedAgentByName(tc.agentName)
+			assert.Equal(t, tc.expectedSentStatus, after.SentStatus)
+
+		})
+	}
+}

--- a/agent/ecs_client/model/api/api-2.json
+++ b/agent/ecs_client/model/api/api-2.json
@@ -1546,7 +1546,7 @@
     },
     "ManagedAgentName":{
       "type":"string",
-      "enum":["EXECUTE_COMMAND_AGENT"]
+      "enum":["ExecuteCommandAgent"]
     },
     "ManagedAgentStateChange":{
       "type":"structure",
@@ -1556,7 +1556,8 @@
       ],
       "members":{
         "name":{"shape":"ManagedAgentName"},
-        "status":{"shape":"String"}
+        "status":{"shape":"String"},
+        "reason":{"shape":"String"}
       }
     },
     "ManagedAgentStateChanges":{
@@ -1567,8 +1568,6 @@
       "type":"list",
       "member":{"shape":"ManagedAgent"}
     },
-
-
     "MissingVersionException":{
       "type":"structure",
       "members":{

--- a/agent/ecs_client/model/ecs/api.go
+++ b/agent/ecs_client/model/ecs/api.go
@@ -8850,6 +8850,8 @@ type ManagedAgentStateChange struct {
 	// Name is a required field
 	Name *string `locationName:"name" type:"string" required:"true" enum:"ManagedAgentName"`
 
+	Reason *string `locationName:"reason" type:"string"`
+
 	// Status is a required field
 	Status *string `locationName:"status" type:"string" required:"true"`
 }
@@ -8883,6 +8885,12 @@ func (s *ManagedAgentStateChange) Validate() error {
 // SetName sets the Name field's value.
 func (s *ManagedAgentStateChange) SetName(v string) *ManagedAgentStateChange {
 	s.Name = &v
+	return s
+}
+
+// SetReason sets the Reason field's value.
+func (s *ManagedAgentStateChange) SetReason(v string) *ManagedAgentStateChange {
+	s.Reason = &v
 	return s
 }
 
@@ -12967,7 +12975,7 @@ const (
 
 const (
 	// ManagedAgentNameExecuteCommandAgent is a ManagedAgentName enum value
-	ManagedAgentNameExecuteCommandAgent = "EXECUTE_COMMAND_AGENT"
+	ManagedAgentNameExecuteCommandAgent = "ExecuteCommandAgent"
 )
 
 const (

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -313,10 +313,10 @@ func (engine *DockerTaskEngine) monitorExecAgentRunning(ctx context.Context,
 	status, err := engine.execCmdMgr.RestartAgentIfStopped(ctx, engine.client, task, c, dockerID)
 	if err != nil {
 		seelog.Errorf("Task engine [%s]: Failed to restart ExecCommandAgent Process for container [%s]: %v", task.Arn, dockerID, err)
-		mTask.emitContainerEvent(mTask.Task, c, "")
+		mTask.emitManagedAgentEvent(mTask.Task, c)
 	}
 	if status == execcmd.Restarted {
-		mTask.emitContainerEvent(mTask.Task, c, "")
+		mTask.emitManagedAgentEvent(mTask.Task, c)
 	}
 
 }
@@ -1310,9 +1310,11 @@ func (engine *DockerTaskEngine) startContainer(task *apitask.Task, container *ap
 		}
 		// whether we started or failed to start, we'll want to emit a state change event
 		// redundant state change events like RUNNING->RUNNING are allowed
+		engine.tasksLock.RLock()
 		mTask, ok := engine.managedTasks[task.Arn]
+		engine.tasksLock.RUnlock()
 		if ok {
-			mTask.emitContainerEvent(mTask.Task, container, "")
+			mTask.emitManagedAgentEvent(mTask.Task, container)
 		} else {
 			seelog.Errorf("Task engine [%s]: Failed to update status of ExecCommandAgent Process for container [%s]: managed task not found", task.Arn, container.Name)
 		}

--- a/agent/engine/execcmd/manager.go
+++ b/agent/engine/execcmd/manager.go
@@ -21,6 +21,8 @@ import (
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
+	"github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
+
 	dockercontainer "github.com/docker/docker/api/types/container"
 )
 
@@ -28,7 +30,7 @@ const (
 	hostExecDepsDir = "/var/lib/ecs/deps/execute-command"
 	HostBinDir      = hostExecDepsDir + "/bin"
 
-	ExecuteCommandAgentName    = "ExecuteCommandAgent"
+	ExecuteCommandAgentName    = ecs.ManagedAgentNameExecuteCommandAgent
 	defaultStartRetryTimeout   = time.Minute * 10
 	defaultRetryMinDelay       = time.Second * 1
 	defaultRetryMaxDelay       = time.Second * 30

--- a/agent/engine/execcmd/manager_init_task_linux.go
+++ b/agent/engine/execcmd/manager_init_task_linux.go
@@ -230,7 +230,7 @@ func getSessionWorkersLimit(ma apicontainer.ManagedAgent) int {
 	if ma.Properties == nil { // This means ACS didn't send the limit
 		return limit
 	}
-	limitStr, ok := ma.Properties["SessionWorkersLimit"]
+	limitStr, ok := ma.Properties["sessionLimit"]
 	if !ok { // This also means ACS didn't send the limit
 		return limit
 	}

--- a/agent/engine/execcmd/manager_init_task_linux_test.go
+++ b/agent/engine/execcmd/manager_init_task_linux_test.go
@@ -299,7 +299,7 @@ func TestGetSessionWorkersLimit(t *testing.T) {
 	for _, tc := range tests {
 		ma := apicontainer.ManagedAgent{
 			Properties: map[string]string{
-				"SessionWorkersLimit": strconv.Itoa(tc.sessionLimit),
+				"sessionLimit": strconv.Itoa(tc.sessionLimit),
 			},
 		}
 		limit := getSessionWorkersLimit(ma)

--- a/agent/eventhandler/handler.go
+++ b/agent/eventhandler/handler.go
@@ -57,7 +57,7 @@ func HandleEngineEvents(
 func handleEngineEvent(event statechange.Event, client api.ECSClient, taskHandler *TaskHandler,
 	attachmentEventHandler *AttachmentEventHandler) error {
 	switch event.GetEventType() {
-	case statechange.TaskEvent, statechange.ContainerEvent:
+	case statechange.TaskEvent, statechange.ContainerEvent, statechange.ManagedAgentEvent:
 		return taskHandler.AddStateChangeEvent(event, client)
 	case statechange.AttachmentEvent:
 		return attachmentEventHandler.AddStateChangeEvent(event)

--- a/agent/eventhandler/task_handler_types_test.go
+++ b/agent/eventhandler/task_handler_types_test.go
@@ -125,6 +125,33 @@ func TestShouldTaskEventBeSent(t *testing.T) {
 			shouldBeSent: true,
 		},
 		{
+			// Managed agent state needs to be sent
+			event: newSendableTaskEvent(api.TaskStateChange{
+				Status: apitaskstatus.TaskRunning,
+				Task: &apitask.Task{
+					SentStatusUnsafe: apitaskstatus.TaskRunning,
+				},
+				Containers: []api.ContainerStateChange{
+					{
+						Container: &apicontainer.Container{
+							SentStatusUnsafe:  apicontainerstatus.ContainerRunning,
+							KnownStatusUnsafe: apicontainerstatus.ContainerRunning,
+							ManagedAgentsUnsafe: []apicontainer.ManagedAgent{
+								{
+									Name: "dummyAgent",
+									ManagedAgentState: apicontainer.ManagedAgentState{
+										Status:     apicontainerstatus.ManagedAgentRunning,
+										SentStatus: apicontainerstatus.ManagedAgentCreated,
+									},
+								},
+							},
+						},
+					},
+				},
+			}),
+			shouldBeSent: true,
+		},
+		{
 			// Container state change should be sent regardless of task
 			// status.
 			event: newSendableTaskEvent(api.TaskStateChange{
@@ -255,9 +282,14 @@ func TestSetTaskSentStatus(t *testing.T) {
 	dataClient, cleanup := newTestDataClient(t)
 	defer cleanup()
 
+	testManagedAgent := apicontainer.ManagedAgent{
+		ManagedAgentState: apicontainer.ManagedAgentState{},
+		Name:              "dummyAgent",
+	}
 	testContainer := &apicontainer.Container{
-		Name:          testConainerName,
-		TaskARNUnsafe: testTaskARN,
+		Name:                testConainerName,
+		TaskARNUnsafe:       testTaskARN,
+		ManagedAgentsUnsafe: []apicontainer.ManagedAgent{testManagedAgent},
 	}
 	testTask := &apitask.Task{
 		Arn:        testTaskARN,
@@ -271,6 +303,13 @@ func TestSetTaskSentStatus(t *testing.T) {
 			{
 				Status:    apicontainerstatus.ContainerRunning,
 				Container: testContainer,
+				ManagedAgents: []api.ManagedAgentStateChange{
+					{
+						Name:   "dummyAgent",
+						Status: apicontainerstatus.ManagedAgentRunning,
+						Reason: "reason",
+					},
+				},
 			},
 		},
 	})
@@ -281,6 +320,13 @@ func TestSetTaskSentStatus(t *testing.T) {
 			{
 				Status:    apicontainerstatus.ContainerStopped,
 				Container: testContainer,
+				ManagedAgents: []api.ManagedAgentStateChange{
+					{
+						Name:   "dummyAgent",
+						Status: apicontainerstatus.ManagedAgentStopped,
+						Reason: "reason",
+					},
+				},
 			},
 		},
 	})
@@ -288,9 +334,14 @@ func TestSetTaskSentStatus(t *testing.T) {
 	setTaskChangeSent(taskStoppedStateChange, dataClient)
 	assert.Equal(t, testTask.GetSentStatus(), apitaskstatus.TaskStopped)
 	assert.Equal(t, testContainer.GetSentStatus(), apicontainerstatus.ContainerStopped)
+	updatedManagedAgent, _ := testContainer.GetManagedAgentByName("dummyAgent")
+	assert.Equal(t, apicontainerstatus.ManagedAgentStopped, updatedManagedAgent.SentStatus)
+
 	setTaskChangeSent(taskRunningStateChange, dataClient)
 	assert.Equal(t, testTask.GetSentStatus(), apitaskstatus.TaskStopped)
 	assert.Equal(t, testContainer.GetSentStatus(), apicontainerstatus.ContainerStopped)
+	updatedManagedAgent, _ = testContainer.GetManagedAgentByName("dummyAgent")
+	assert.Equal(t, apicontainerstatus.ManagedAgentStopped, updatedManagedAgent.SentStatus)
 
 	tasks, err := dataClient.GetTasks()
 	require.NoError(t, err)
@@ -301,6 +352,8 @@ func TestSetTaskSentStatus(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, containers, 1)
 	assert.Equal(t, apicontainerstatus.ContainerStopped, containers[0].Container.GetSentStatus())
+	updatedManagedAgent, _ = containers[0].Container.GetManagedAgentByName("dummyAgent")
+	assert.Equal(t, apicontainerstatus.ManagedAgentStopped, updatedManagedAgent.SentStatus)
 }
 
 func TestSetContainerSentStatus(t *testing.T) {

--- a/agent/statechange/statechange.go
+++ b/agent/statechange/statechange.go
@@ -25,6 +25,10 @@ const (
 	// AttachmentEvent is used to define the attachment state transition events
 	// emitted by ENI watcher
 	AttachmentEvent
+
+	// ManagedAgentEvent is used to define the managed agent state transition events
+	// emitted by the engine
+	ManagedAgentEvent
 )
 
 // Event defines the type of state change event
@@ -33,7 +37,6 @@ type EventType int32
 // Event is used to abstract away the two transition event types
 // passed up through a single channel from the the engine
 type Event interface {
-
 	// GetEventType implementations should return one the enums defined above to
 	// identify the type of event being emitted
 	GetEventType() EventType


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR covers the changes required to send managed agent state changes to FE

### Implementation details
<!-- How are the changes implemented? -->
* Added managed agent state change models where appropriate 
* Sending managed agent state changes follows the same pattern used to send container state changes
  * Changes are batched as container state changes inside of a task state change (task state change is the only supported way of sending any state changes)
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

* Did some manual testing to verify that changes are being sent to FE
* Added UTs to cover new code
* Modified/expanded existing UTs where appropriate 

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
