### PR TITLE
The environment variable ECS_PULL_DEPENDENT_CONTAINERS_UPFRONT=false as default

### DIFF
--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -533,7 +533,7 @@ func environmentConfig() (Config, error) {
 		TaskCPUMemLimit:                     parseBooleanDefaultTrueConfig("ECS_ENABLE_TASK_CPU_MEM_LIMIT"),
 		DockerStopTimeout:                   parseDockerStopTimeout(),
 		ContainerStartTimeout:               parseContainerStartTimeout(),
-		DependentContainersPullUpfront:      parseBooleanDefaultTrueConfig("ECS_PULL_DEPENDENT_CONTAINERS_UPFRONT"),
+		DependentContainersPullUpfront:      parseBooleanDefaultFalseConfig("ECS_PULL_DEPENDENT_CONTAINERS_UPFRONT"),
 		ImagePullInactivityTimeout:          parseImagePullInactivityTimeout(),
 		ImagePullTimeout:                    parseEnvVariableDuration("ECS_IMAGE_PULL_TIMEOUT"),
 		CredentialsAuditLogFile:             os.Getenv("ECS_AUDIT_LOGFILE"),

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -145,7 +145,7 @@ func TestEnvironmentConfig(t *testing.T) {
 	defer setTestEnv("ECS_POLL_METRICS", "true")()
 	defer setTestEnv("ECS_POLLING_METRICS_WAIT_DURATION", "10s")()
 	defer setTestEnv("ECS_CGROUP_CPU_PERIOD", "")
-	defer setTestEnv("ECS_PULL_DEPENDENT_CONTAINERS_UPFRONT", "true")
+	defer setTestEnv("ECS_PULL_DEPENDENT_CONTAINERS_UPFRONT", "true")()
 	additionalLocalRoutesJSON := `["1.2.3.4/22","5.6.7.8/32"]`
 	setTestEnv("ECS_AWSVPC_ADDITIONAL_LOCAL_ROUTES", additionalLocalRoutesJSON)
 	setTestEnv("ECS_ENABLE_CONTAINER_METADATA", "true")
@@ -198,7 +198,7 @@ func TestEnvironmentConfig(t *testing.T) {
 	assert.Equal(t, 10*time.Millisecond, conf.CgroupCPUPeriod)
 	assert.False(t, conf.SpotInstanceDrainingEnabled.Enabled())
 	assert.Equal(t, []string{"efsAuth"}, conf.VolumePluginCapabilities)
-	assert.True(t, conf.DependentContainersPullUpfront.Enabled(), "Wrong value for ContainersPullUpfront")
+	assert.True(t, conf.DependentContainersPullUpfront.Enabled(), "Wrong value for DependentContainersPullUpfront")
 }
 
 func TestTrimWhitespaceWhenCreating(t *testing.T) {

--- a/agent/config/config_unix.go
+++ b/agent/config/config_unix.go
@@ -56,7 +56,7 @@ func DefaultConfig() Config {
 		TaskCleanupWaitDuration:             DefaultTaskCleanupWaitDuration,
 		DockerStopTimeout:                   defaultDockerStopTimeout,
 		ContainerStartTimeout:               defaultContainerStartTimeout,
-		DependentContainersPullUpfront:      BooleanDefaultTrue{Value: ExplicitlyEnabled},
+		DependentContainersPullUpfront:      BooleanDefaultFalse{Value: ExplicitlyDisabled},
 		CredentialsAuditLogFile:             defaultCredentialsAuditLogFile,
 		CredentialsAuditLogDisabled:         false,
 		ImageCleanupDisabled:                BooleanDefaultFalse{Value: ExplicitlyDisabled},

--- a/agent/config/config_unix_test.go
+++ b/agent/config/config_unix_test.go
@@ -68,7 +68,7 @@ func TestConfigDefault(t *testing.T) {
 	assert.False(t, cfg.SharedVolumeMatchFullConfig.Enabled(), "Default SharedVolumeMatchFullConfig set incorrectly")
 	assert.Equal(t, defaultCgroupCPUPeriod, cfg.CgroupCPUPeriod, "CFS cpu period set incorrectly")
 	assert.Equal(t, DefaultImagePullTimeout, cfg.ImagePullTimeout, "Default ImagePullTimeout set incorrectly")
-	assert.True(t, cfg.DependentContainersPullUpfront.Enabled(), "Default ContainersPullUpfront set incorrectly")
+	assert.False(t, cfg.DependentContainersPullUpfront.Enabled(), "Default DependentContainersPullUpfront set incorrectly")
 }
 
 // TestConfigFromFile tests the configuration can be read from file

--- a/agent/config/config_windows.go
+++ b/agent/config/config_windows.go
@@ -86,7 +86,7 @@ func DefaultConfig() Config {
 		TaskCleanupWaitDuration:             DefaultTaskCleanupWaitDuration,
 		DockerStopTimeout:                   defaultDockerStopTimeout,
 		ContainerStartTimeout:               defaultContainerStartTimeout,
-		DependentContainersPullUpfront:      BooleanDefaultTrue{Value: ExplicitlyEnabled},
+		DependentContainersPullUpfront:      BooleanDefaultFalse{Value: ExplicitlyDisabled},
 		ImagePullInactivityTimeout:          defaultImagePullInactivityTimeout,
 		ImagePullTimeout:                    DefaultImagePullTimeout,
 		CredentialsAuditLogFile:             filepath.Join(ecsRoot, defaultCredentialsAuditLogFile),

--- a/agent/config/config_windows_test.go
+++ b/agent/config/config_windows_test.go
@@ -61,7 +61,7 @@ func TestConfigDefault(t *testing.T) {
 		"Default TaskMetadataBurstRate is set incorrectly")
 	assert.False(t, cfg.SharedVolumeMatchFullConfig.Enabled(), "Default SharedVolumeMatchFullConfig set incorrectly")
 	assert.Equal(t, DefaultImagePullTimeout, cfg.ImagePullTimeout, "Default ImagePullTimeout set incorrectly")
-	assert.True(t, cfg.DependentContainersPullUpfront.Enabled(), "Default ContainersPullUpfront set incorrectly")
+	assert.False(t, cfg.DependentContainersPullUpfront.Enabled(), "Default DependentContainersPullUpfront set incorrectly")
 }
 
 func TestConfigIAMTaskRolesReserves80(t *testing.T) {

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -112,9 +112,9 @@ type Config struct {
 	// ContainerStartTimeout specifies the amount of time to wait to start a container
 	ContainerStartTimeout time.Duration
 
-	// DependentContainersPullUpfront specifies whether pulling containers upfront should be applied to this agent.
-	// Default true
-	DependentContainersPullUpfront BooleanDefaultTrue
+	// DependentContainersPullUpfront specifies whether pulling images upfront should be applied to this agent.
+	// Default false
+	DependentContainersPullUpfront BooleanDefaultFalse
 
 	// ImagePullInactivityTimeout is here to override the amount of time to wait when pulling and extracting a container
 	ImagePullInactivityTimeout time.Duration

--- a/agent/engine/dependencygraph/graph.go
+++ b/agent/engine/dependencygraph/graph.go
@@ -389,7 +389,7 @@ func containerOrderingDependenciesIsResolved(target *apicontainer.Container,
 	dependsOnContainerKnownStatus := dependsOnContainer.GetKnownStatus()
 
 	// The 'target' container desires to be moved to 'Created' or the 'steady' state.
-	// Allow this only if the environment variable ECS_PULL_DEPENDENT_CONTAINERS_UPFRONT is enabled and the
+	// Allow this only if the environment variable ECS_PULL_DEPENDENT_CONTAINERS_UPFRONT is enabled and
 	// known status of the `target` container state has not reached to 'Pulled' state;
 	if cfg.DependentContainersPullUpfront.Enabled() && targetContainerKnownStatus < apicontainerstatus.ContainerPulled {
 		return true

--- a/agent/engine/dependencygraph/graph_test.go
+++ b/agent/engine/dependencygraph/graph_test.go
@@ -1087,7 +1087,7 @@ func TestContainerOrderingIsResolvedWithDependentContainersPullUpfront(t *testin
 	}
 
 	cfg := config.Config{
-		DependentContainersPullUpfront: config.BooleanDefaultTrue{Value: config.ExplicitlyEnabled},
+		DependentContainersPullUpfront: config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled},
 	}
 	for _, tc := range testcases {
 		t.Run(fmt.Sprintf("DependencyCondition:%s+T:%s+V:%s", tc.DependencyCondition, tc.TargetKnown.String(), tc.DependencyKnown.String()),
@@ -1211,7 +1211,7 @@ func TestContainerOrderingHealthyConditionIsResolvedWithDependentContainersPullU
 		},
 	}
 	cfg := config.Config{
-		DependentContainersPullUpfront: config.BooleanDefaultTrue{Value: config.ExplicitlyEnabled},
+		DependentContainersPullUpfront: config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled},
 	}
 	for _, tc := range testcases {
 		t.Run(fmt.Sprintf("DependencyKnownHealthStatus:%s+T:%s+V:%s", tc.DependencyKnownHealthStatus, tc.TargetKnown.String(), tc.DependencyKnownHealthStatus.String()),

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -1666,7 +1666,7 @@ func TestPullAndUpdateContainerReference(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	cfg := &config.Config{
-		DependentContainersPullUpfront: config.BooleanDefaultTrue{Value: config.ExplicitlyEnabled},
+		DependentContainersPullUpfront: config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled},
 	}
 	ctrl, client, _, privateTaskEngine, _, imageManager, _ := mocks(t, ctx, cfg)
 	defer ctrl.Finish()


### PR DESCRIPTION
### Summary
This PR sets the environment variable `ECS_PULL_DEPENDENT_CONTAINERS_UPFRONT=false` as default to ensure backward compatibility.

When the environment variable is specified to `true`, it allows a container with dependencies to pull images before its dependsOn condition: START/SUCCESS/COMPLETE/HEALTHY in a task definition has been satisfied. If the environment variable is set to `false` or is not specified, the container will only start pulling images right after the dependsOn condition has been fulfilled.

### Implementation details
1. Config DependentContainersPullUpfront is defined as BooleanDefaultFalse in  agent/config/types.go
2. DependentContainersPullUpfront is set to false in agent/config/config.go, and update the corresponding test in agent/config/config_test.go
3.  Assign ExplicitlyDisabled to DependentContainersPullUpfront in agent/config/config_unix.go, update the corresponding test in agent/config/config_unix_test.go
4.  Assign ExplicitlyDisabled to DependentContainersPullUpfront in agent/config/config_windows.go, update the corresponding test in agent/config/config_windows_test.go
5. Update type of DependentContainersPullUpfront in graph_test.go and docker_task_engine_test.go

### Testing
Run tasks with container B depends on container A's START/SUCCESS/COMPLETE/HEALTHY status, and verify results by __ecs-agent.log__ and __TMDEv4 task responses__ when `ECS_PULL_DEPENDENT_CONTAINERS_UPFRONT=true`.

1. dependsOn: __START__ 
Container B starts pulling images before container A reaches to START state, as expected.
    
2. dependsOn: __SUCCESS__
Container B starts pulling images before A exists with exit code 0. After container B completed pulling images, its KnownStatus: PULLED is presented in container A's TMDEv4 task response, as expected.
  
3. dependsOn: __COMPLETE__
Container B starts pulling images before container A exits with exit code. After container B completed pulling images, its KnownStatus: PULLED is presented in container A's TMDEv4 task response, as expected. 

4. dependsOn: __HEALTHY__
Container B starts pulling images before container A reaches to HEALTHY state. After container B completed pulling images, its KnownStatus: PULLED is presented in container A's TMDEv4 task response, as expected.

New tests cover the changes: no

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
