### PR TITLE
check the validity of exec agent config

### DIFF
--- a/agent/engine/execcmd/manager_init_task_linux.go
+++ b/agent/engine/execcmd/manager_init_task_linux.go
@@ -251,7 +251,7 @@ func getAgentLogConfigFile() (string, error) {
 	logConfigFileName := fmt.Sprintf(logConfigFileNameTemplate, hash)
 	// check if config file exists already
 	logConfigFilePath := filepath.Join(ECSAgentExecConfigDir, logConfigFileName)
-	if fileExists(logConfigFilePath) && validLogConfigExists(logConfigFilePath, hash) {
+	if fileExists(logConfigFilePath) && validConfigExists(logConfigFilePath, hash) {
 		return logConfigFileName, nil
 	}
 	// create new seelog config file
@@ -261,7 +261,7 @@ func getAgentLogConfigFile() (string, error) {
 	return logConfigFileName, nil
 }
 
-func validLogConfigExists(configFilePath, expectedHash string) bool {
+func validConfigExists(configFilePath, expectedHash string) bool {
 	config, err := getFileContent(configFilePath)
 	if err != nil {
 		return false
@@ -284,8 +284,7 @@ func getAgentConfigFileName(sessionLimit int) (string, error) {
 	configFileName := fmt.Sprintf(execAgentConfigFileNameTemplate, hash)
 	// check if config file exists already
 	configFilePath := filepath.Join(ECSAgentExecConfigDir, configFileName)
-	if fileExists(configFilePath) {
-		// TODO: verify the hash of the existing file contents
+	if fileExists(configFilePath) && validConfigExists(configFilePath, hash) {
 		return configFileName, nil
 	}
 	// config doesn't exist; create a new one

--- a/agent/engine/execcmd/manager_init_task_linux_test.go
+++ b/agent/engine/execcmd/manager_init_task_linux_test.go
@@ -382,7 +382,7 @@ func TestGetExecAgentLogConfigFile(t *testing.T) {
 	}
 }
 
-func TestGetValidLogConfigExists(t *testing.T) {
+func TestGetValidConfigExists(t *testing.T) {
 	var tests = []struct {
 		isValid                  bool
 		existingLogConfigReadErr error
@@ -411,6 +411,6 @@ func TestGetValidLogConfigExists(t *testing.T) {
 		getFileContent = func(path string) ([]byte, error) {
 			return []byte(tc.existingLogConfig), tc.existingLogConfigReadErr
 		}
-		assert.Equal(t, tc.isValid, validLogConfigExists("configpath", getExecAgentConfigHash(execAgentLogConfigTemplate)))
+		assert.Equal(t, tc.isValid, validConfigExists("configpath", getExecAgentConfigHash(execAgentLogConfigTemplate)))
 	}
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
do the same hash comparison check as exec agent log config for the agent config. 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
