### PR TITLE
fix final loose dockerhub pulls from build and integ tests

### DIFF
--- a/misc/fluentd/Makefile
+++ b/misc/fluentd/Makefile
@@ -2,4 +2,4 @@
 .PHONY: all
 
 all:
-	docker build -t amazon/fluentd:make -f Dockerfile .
+	@./build

--- a/misc/fluentd/build
+++ b/misc/fluentd/build
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -ex
+
+# the fluent/fluentd container is only available on x86 and tests are only run there:
+# https://hub.docker.com/r/fluent/fluentd
+if [[ "$(uname -m)" == "x86_64" ]]; then
+    docker build -t amazon/fluentd:make -f Dockerfile .
+fi

--- a/scripts/setup-test-registry
+++ b/scripts/setup-test-registry
@@ -14,7 +14,7 @@
 
 # Run a local registry on the 'well known' port 51670 if it is not running.
 # Also push images we will need to it.
-set -e
+set -ex
 
 REGISTRY_IMAGE="registry:2.7.0"
 
@@ -29,12 +29,8 @@ docker stop "$REGISTRY_CONTAINER_NAME" || true && docker rm "$REGISTRY_CONTAINER
 
 echo "Running $REGISTRY_CONTAINER_NAME"
 docker run -d --name="$REGISTRY_CONTAINER_NAME" -e SETTINGS_FLAVOR=local -p "127.0.0.1:51670:5000" "${REGISTRY_IMAGE}"
-
-# Make sure our images are pushed to it
-mirror_image() {
-  docker pull $1
-  mirror_local_image $@
-}
+# give the registry some seconds to get ready for pushes
+sleep 7
 
 mirror_local_image() {
   echo "Mirroring $1"
@@ -45,14 +41,18 @@ mirror_local_image() {
 
 for image in "amazon/amazon-ecs-netkitten" "amazon/amazon-ecs-volumes-test" \
 				"amazon/image-cleanup-test-image1" "amazon/image-cleanup-test-image2" \
-				"amazon/image-cleanup-test-image3" "amazon/fluentd"; do
+				"amazon/image-cleanup-test-image3" ; do
   mirror_local_image "${image}:make" "127.0.0.1:51670/${image}:latest"
 done
+
+if [[ "$(uname -m)" == "x86_64" ]]; then
+    mirror_local_image "amazon/fluentd:make" "127.0.0.1:51670/amazon/fluentd:latest"
+fi
 
 # Remove the tag so this image can be deleted successfully in the docker image cleanup integ tests
 docker rmi amazon/image-cleanup-test-image1:make amazon/image-cleanup-test-image2:make amazon/image-cleanup-test-image3:make
 
-mirror_image busybox:1.32.0 "127.0.0.1:51670/busybox:latest"
+mirror_local_image busybox:1.32.0 "127.0.0.1:51670/busybox:latest"
 
 # create a context folder used by docker build. It will only have a file
 # full of random bits so that the parallel pull images are different.

--- a/scripts/upload-images
+++ b/scripts/upload-images
@@ -17,6 +17,12 @@
 
 set -ex
 
+# This script is being skipped because it is part of a deprecated codebuild
+# path. Since it relies on pulling from dockerhub, it could fail our build steps
+# even though it is not necessary. This script can be deleted completely when
+# our github hook code is deprecated.
+exit 0
+
 NAMESPACE="linux"
 REGION=$1
 REPOSITORY=$2


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This is a follow-up to https://github.com/aws/amazon-ecs-agent/pull/2720

After running tests with dockerhub throttling active we have discovered a couple more places where we were pulling dockerhub images.

Specifically, when doing a `FROM` statement within a Dockerfile, no pull request goes to dockerhub if the image is already present locally. However, `docker pull` always pulls at least a manifest from dockerhub, which is subject to throttling. So this PR removes one `docker pull` in setting up the test registry.

It also short-circuits upload-images because this script is essentially deprecated. We can't yet remove it as it's still referenced in internal step functions, but once we deprecate that stack we can remove.

Lastly, on arm we need to avoid trying to build misc/fluentd. The base image of this (fluent/fluentd) doesnt exist for arm, and so we don't have it in ECR. This means that when we try to build it we will request a manifest from dockerhub, which can again be throttled. 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

not applicable

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
