### PR TITLE
Revert "save RCI client token to agent state"

### DIFF
--- a/agent/app/agent_test.go
+++ b/agent/app/agent_test.go
@@ -709,9 +709,8 @@ func TestNewTaskEngineRestoreFromCheckpoint(t *testing.T) {
 		containerInstanceARN:     agent.containerInstanceARN,
 		ec2InstanceID:            instanceID,
 		latestTaskManifestSeqNum: *agent.latestSeqNumberTaskManifest,
-		registrationToken:        agent.registrationToken,
 	}
-	checkLoadedData(state, s, true, t)
+	checkLoadedData(state, s, t)
 }
 
 func TestSetClusterInConfigMismatch(t *testing.T) {

--- a/agent/app/data.go
+++ b/agent/app/data.go
@@ -39,7 +39,6 @@ type savedData struct {
 	containerInstanceARN     string
 	ec2InstanceID            string
 	latestTaskManifestSeqNum int64
-	registrationToken        string
 }
 
 // loadData loads data from previous checkpoint file, if any, with backward compatibility preserved. It first tries to
@@ -133,10 +132,6 @@ func (agent *ecsAgent) loadDataFromBoltDB(s *savedData) error {
 			return errors.Wrapf(err, "failed to convert saved task manifest sequence number to int64: %s", seqNumStr)
 		}
 	}
-	s.registrationToken, err = agent.loadMetadata(data.RegistrationTokenKey)
-	if err != nil {
-		return err
-	}
 	return nil
 }
 
@@ -181,11 +176,6 @@ func (agent *ecsAgent) saveDataToBoltDB(s *savedData) error {
 	if err := agent.dataClient.SaveMetadata(data.TaskManifestSeqNumKey,
 		strconv.FormatInt(s.latestTaskManifestSeqNum, 10)); err != nil {
 		return err
-	}
-	if s.registrationToken != "" {
-		if err := agent.dataClient.SaveMetadata(data.RegistrationTokenKey, s.registrationToken); err != nil {
-			return err
-		}
 	}
 
 	return nil

--- a/agent/app/data_test.go
+++ b/agent/app/data_test.go
@@ -52,7 +52,6 @@ const (
 	testAvailabilityZone            = "test-az"
 	testAgentVersion                = "1.40.0"
 	testLatestSeqNumberTaskManifest = int64(1)
-	testRegistrationToken           = "test-reg-token"
 )
 
 var (
@@ -146,7 +145,7 @@ func TestLoadDataLoadFromBoltDB(t *testing.T) {
 	s, err := agent.loadData(eventstream.NewEventStream("events", ctx),
 		credentialsManager, state, imageManager)
 	assert.NoError(t, err)
-	checkLoadedData(state, s, true, t)
+	checkLoadedData(state, s, t)
 }
 
 func TestLoadDataLoadFromStateFile(t *testing.T) {
@@ -184,7 +183,7 @@ func TestLoadDataLoadFromStateFile(t *testing.T) {
 	s, err := agent.loadData(eventstream.NewEventStream("events", ctx),
 		credentialsManager, state, imageManager)
 	assert.NoError(t, err)
-	checkLoadedData(state, s, false, t)
+	checkLoadedData(state, s, t)
 
 	// Also verify that the data in the state file has been migrated to boltdb.
 	tasks, err := dataClient.GetTasks()
@@ -201,7 +200,7 @@ func TestLoadDataLoadFromStateFile(t *testing.T) {
 	assert.Len(t, eniAttachments, 1)
 }
 
-func checkLoadedData(state dockerstate.TaskEngineState, s *savedData, boltdbOnly bool, t *testing.T) {
+func checkLoadedData(state dockerstate.TaskEngineState, s *savedData, t *testing.T) {
 	_, ok := state.TaskByArn(testTaskARN)
 	assert.True(t, ok)
 	_, ok = state.ContainerByID(testDockerID)
@@ -213,9 +212,6 @@ func checkLoadedData(state dockerstate.TaskEngineState, s *savedData, boltdbOnly
 	assert.Equal(t, testContainerInstanceARN, s.containerInstanceARN)
 	assert.Equal(t, testEC2InstanceID, s.ec2InstanceID)
 	assert.Equal(t, testLatestSeqNumberTaskManifest, s.latestTaskManifestSeqNum)
-	if boltdbOnly {
-		assert.Equal(t, testRegistrationToken, s.registrationToken)
-	}
 }
 
 func newTestClient(t *testing.T) (statemanager.StateManager, data.Client, func()) {
@@ -261,7 +257,6 @@ func populateBoltDB(dataClient data.Client, t *testing.T) {
 	require.NoError(t, dataClient.SaveMetadata(data.ContainerInstanceARNKey, testContainerInstanceARN))
 	require.NoError(t, dataClient.SaveMetadata(data.EC2InstanceIDKey, testEC2InstanceID))
 	require.NoError(t, dataClient.SaveMetadata(data.TaskManifestSeqNumKey, strconv.FormatInt(testLatestSeqNumberTaskManifest, 10)))
-	require.NoError(t, dataClient.SaveMetadata(data.RegistrationTokenKey, testRegistrationToken))
 }
 
 func getTestEngineState() dockerstate.TaskEngineState {

--- a/agent/data/metadata_client.go
+++ b/agent/data/metadata_client.go
@@ -24,7 +24,6 @@ const (
 	ContainerInstanceARNKey = "container-instance-arn"
 	EC2InstanceIDKey        = "ec2-instance-id"
 	TaskManifestSeqNumKey   = "task-manifest-seq-num"
-	RegistrationTokenKey    = "registration-token"
 )
 
 func (c *client) SaveMetadata(key, val string) error {


### PR DESCRIPTION
This reverts commit e21488b2ea41f792abe73aee840289069f80e139.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
