### PR TITLE
fixing agent path vulnerability on windows

### DIFF
--- a/misc/windows-deploy/Install-ECSAgent.ps1
+++ b/misc/windows-deploy/Install-ECSAgent.ps1
@@ -99,7 +99,7 @@ Process {
     try {
         $ServiceParams = @{
             Name = "$($Script:ServiceName)";
-            BinaryPathName = "$($ECS_EXE) -windows-service";
+            BinaryPathName = "`"$($ECS_EXE)`" -windows-service";
             DisplayName = "Amazon ECS";
             Description = "The $($Script:ServiceName) service runs the Amazon ECS agent";
             DependsOn = 'Docker';


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
The ```Install-ECSAgent.ps1``` creates a new service entry for the ECS Agent in the Windows service registry.

### Implementation details
<!-- How are the changes implemented? -->
Old Value:
```
PS C:\Program Files\Amazon\ECS> Get-WmiObject win32_service | ?{$_.Name -like '*AmazonECS*'} | select Name, PathName

Name      PathName
----      --------
AmazonECS C:\Program Files\Amazon\ECS\amazon-ecs-agent.exe -windows-service
```

Expected: 
```
PS C:\Program Files\Amazon\ECS> Get-WmiObject win32_service | ?{$_.Name -like '*AmazonECS*'} | select Name, PathName

Name      PathName
----      --------
AmazonECS "C:\Program Files\Amazon\ECS\amazon-ecs-agent.exe" -windows-service
```
### Testing
<!-- How was this tested? -->
I deleted the service, ran ```Install-ECSAgent.ps1``` script followed by ```Initialize-ECSAgent``` to re-register the agent. The agent registered as a service, joined the cluster and I also ran some tasks.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
