### PR TITLE
Allow task metadata endpoint to return response when certain container doesn't have network metadata 

### DIFF
--- a/agent/handlers/v4/container_metadata_handler.go
+++ b/agent/handlers/v4/container_metadata_handler.go
@@ -88,7 +88,6 @@ func GetContainerNetworkMetadata(containerID string, state dockerstate.TaskEngin
 	// https://github.com/aws/amazon-ecs-agent/blob/0c8913ba33965cf6ffdd6253fad422458d9346bd/agent/containermetadata/parse_metadata.go#L123
 	settings := dockerContainer.Container.GetNetworkSettings()
 	if settings == nil {
-		seelog.Errorf("Unable to get container network response for container '%s'", containerID)
 		return nil, errors.Errorf("unable to generate network response for container '%s'", containerID)
 	}
 	// This metadata is the information provided in older versions of the API

--- a/agent/handlers/v4/task_metadata_handler.go
+++ b/agent/handlers/v4/task_metadata_handler.go
@@ -65,12 +65,7 @@ func TaskMetadataHandler(state dockerstate.TaskEngineState, ecsClient api.ECSCli
 			for _, containerResponse := range taskResponse.Containers {
 				networks, err := GetContainerNetworkMetadata(containerResponse.ID, state)
 				if err != nil {
-					errResponseJSON, err := json.Marshal(err.Error())
-					if e := utils.WriteResponseIfMarshalError(w, err); e != nil {
-						return
-					}
-					utils.WriteJSONToResponse(w, http.StatusInternalServerError, errResponseJSON, utils.RequestTypeContainerMetadata)
-					return
+					seelog.Warnf("Error retrieving network metadata for container %s - %s", containerResponse.ID, err)
 				}
 				containerResponse.Networks = networks
 				responses = append(responses, containerResponse)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Allow task metadata endpoint to return successful response when certain container doesn't have network metadata.

Currently, when one of the containers in a task doesn't have network metadata available, every container in the task gets error when calling task metadata endpoint. This is not ideal because a container does not have network metadata when:
(1) it's in the process of being created (we add it to our state, but it doesn't have network metadata yet), and sometime it takes time for docker to create a container;
(2) we times out inspecting the container, causing its network metadata to be unavailable (empty).

When we hit either of the two cases above, the task metadata endpoint becomes unavailable for every container because we return error when one of the container in the task misses network metadata.

This pull request made a change such that we don't return error in that case for v4 task metadata (for backward compatibility concern this is not added to v3).

### Implementation details
<!-- How are the changes implemented? -->
Basically add back https://github.com/aws/amazon-ecs-agent/pull/2719 and add a unit test.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Added unit test.

For manual test, hard to directly test this because it's covering an edge/failure case, so i added some test code in agent to return error for network metadata https://github.com/fenxiong/amazon-ecs-agent/commit/8a4e91252140943a2cc0be870f0ba733195382d2, built the agent with that, ran a task, and verified that we logged a warning, but task metadata endpoint is still available for the task:
```
level=warn time=2020-11-30T23:47:05Z msg="Error retrieving network metadata for container 8e8dc44164f85864408f44a95ce6be959350ac53c21ebf1775635aaeb6d77d12 - test error" module=task_metadata_handler.go
```
```
bash-4.2# curl ${ECS_CONTAINER_METADATA_URI_V4}/task | jq ".TaskARN"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2201    0  2201    0     0  2149k      0 --:--:-- --:--:-- --:--:-- 2149k
"arn:aws:ecs:us-west-2:xxx:task/test-meta-al2/xxx"
```

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enhancement - Allow v4 task metadata endpoint to return successful response when some container in the task is missing network metadata

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
