### PR TITLE
update cert mount source

### DIFF
--- a/agent/engine/execcmd/manager_init_task_linux.go
+++ b/agent/engine/execcmd/manager_init_task_linux.go
@@ -53,7 +53,7 @@ const (
 	ContainerLogDir    = "/var/log/amazon/ssm"
 	ECSAgentExecLogDir = "/log/exec"
 
-	HostCertFile            = "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
+	HostCertFile            = "/var/lib/ecs/deps/execute-command/certs/tls-ca-bundle.pem"
 	ContainerCertFileSuffix = "certs/amazon-ssm-agent.crt"
 
 	containerConfigFileName   = "amazon-ssm-agent.json"
@@ -158,7 +158,7 @@ func (m *manager) InitializeContainer(taskId string, container *apicontainer.Con
 
 	// Append TLS cert mount
 	hostConfig.Binds = append(hostConfig.Binds, getReadOnlyBindMountMapping(
-		HostCertFile, // TODO: [ecs-exec] decision pending - review the location of the certs in the host
+		HostCertFile,
 		filepath.Join(containerDepsFolder, ContainerCertFileSuffix)))
 
 	// Add ssm log bind mount

--- a/agent/engine/execcmd/manager_init_task_linux_test.go
+++ b/agent/engine/execcmd/manager_init_task_linux_test.go
@@ -193,7 +193,7 @@ func TestInitializeContainer(t *testing.T) {
 						"/ecs-execute-command-test-UUID/configuration/amazon-ssm-agent.json:ro"})
 
 				assert.Subset(t, hc.Binds, []string{
-					"/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:" +
+					"/var/lib/ecs/deps/execute-command/certs/tls-ca-bundle.pem:" +
 						"/ecs-execute-command-test-UUID/certs/amazon-ssm-agent.crt:ro"})
 
 				assert.Subset(t, hc.Binds, []string{


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

### Implementation details
Update ecs-agent cert source for bind mount.  We made the decision to isolate all execute-command related resources from customer resources on the container instance.  This brings the cert bind-mount source in line with the planned AMI format.

### Testing
built agent and then ecs-init (using latest feature/ecs_exec branch); stopped ecs service and built/replaced the ecs-init rpm then started ecs service up again with the new init/agent.  I was able to successfully start an execute-command-enabled task and execute `/bin/sh` command within that task with the updated mount in place.
Also ran `make test` unit tests.

New tests cover the changes: no

### Description for the changelog
Update cert source mount location.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
