### PR TITLE
Avoid duplicate ListTagsForResource API calls

### DIFF
--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -41,6 +41,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/credentials"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
+	"github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
 	"github.com/aws/amazon-ecs-agent/agent/ecscni"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/asmauth"
@@ -266,6 +267,10 @@ type Task struct {
 
 	// LaunchType is the launch type of this task.
 	LaunchType string `json:"LaunchType,omitempty"`
+
+	Tags map[string]string `json:"Tags,omitempty"`
+
+	ContainerInstanceTags map[string]string `json:"ContainerInstanceTags,omitempty"`
 
 	// lock is for protecting all fields in the task struct
 	lock sync.RWMutex
@@ -2720,4 +2725,38 @@ func (task *Task) SetLocalIPAddress(addr string) {
 	defer task.lock.Unlock()
 
 	task.LocalIPAddressUnsafe = addr
+}
+
+func (task *Task) GetTags() map[string]string {
+	task.lock.RLock()
+	defer task.lock.RUnlock()
+
+	return task.Tags
+}
+
+func (task *Task) SetTags(tags []*ecs.Tag) {
+	task.lock.Lock()
+	defer task.lock.Unlock()
+
+	task.Tags = make(map[string]string)
+	for _, tag := range tags {
+		task.Tags[*tag.Key] = *tag.Value
+	}
+}
+
+func (task *Task) GetContainerInstanceTags() map[string]string {
+	task.lock.RLock()
+	defer task.lock.RUnlock()
+
+	return task.ContainerInstanceTags
+}
+
+func (task *Task) SetContainerInstanceTags(tags []*ecs.Tag) {
+	task.lock.Lock()
+	defer task.lock.Unlock()
+
+	task.ContainerInstanceTags = make(map[string]string)
+	for _, tag := range tags {
+		task.ContainerInstanceTags[*tag.Key] = *tag.Value
+	}
 }

--- a/agent/handlers/task_server_setup_test.go
+++ b/agent/handlers/task_server_setup_test.go
@@ -850,6 +850,10 @@ func TestV2TaskWithTagsMetadata(t *testing.T) {
 			err = json.Unmarshal(res, &taskResponse)
 			assert.NoError(t, err)
 			assert.Equal(t, expectedTaskResponseWithTags, taskResponse)
+			assert.Equal(t, expectedContainerInstanceTags, task.ContainerInstanceTags)
+			assert.Equal(t, expectedTaskTags, task.Tags)
+			task.ContainerInstanceTags = nil
+			task.Tags = nil
 		})
 	}
 }
@@ -1123,6 +1127,10 @@ func TestV3TaskMetadataWithTags(t *testing.T) {
 	err = json.Unmarshal(res, &taskResponse)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedTaskResponseWithTags, taskResponse)
+	assert.Equal(t, expectedContainerInstanceTags, task.ContainerInstanceTags)
+	assert.Equal(t, expectedTaskTags, task.Tags)
+	task.ContainerInstanceTags = nil
+	task.Tags = nil
 }
 
 func TestV3ContainerMetadata(t *testing.T) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
