### PR TITLE
Cleanup config files paths if they are dirs

### DIFF
--- a/agent/engine/execcmd/manager_init_task_linux.go
+++ b/agent/engine/execcmd/manager_init_task_linux.go
@@ -254,12 +254,20 @@ func getAgentLogConfigFile() (string, error) {
 	if fileExists(logConfigFilePath) && validConfigExists(logConfigFilePath, hash) {
 		return logConfigFileName, nil
 	}
+	// check if config file is a dir; if true, remove it
+	if isDir(logConfigFilePath) {
+		if err := removeAll(logConfigFilePath); err != nil {
+			return "", err
+		}
+	}
 	// create new seelog config file
 	if err := createNewExecAgentConfigFile(execAgentLogConfigTemplate, logConfigFilePath); err != nil {
 		return "", err
 	}
 	return logConfigFileName, nil
 }
+
+var removeAll = os.RemoveAll
 
 func validConfigExists(configFilePath, expectedHash string) bool {
 	config, err := getFileContent(configFilePath)
@@ -287,6 +295,12 @@ func getAgentConfigFileName(sessionLimit int) (string, error) {
 	if fileExists(configFilePath) && validConfigExists(configFilePath, hash) {
 		return configFileName, nil
 	}
+	// check if config file is a dir; if true, remove it
+	if isDir(configFilePath) {
+		if err := removeAll(configFilePath); err != nil {
+			return "", err
+		}
+	}
 	// config doesn't exist; create a new one
 	if err := createNewExecAgentConfigFile(config, configFilePath); err != nil {
 		return "", err
@@ -305,6 +319,13 @@ var osStat = os.Stat
 func fileExists(path string) bool {
 	if fi, err := osStat(path); err == nil {
 		return !fi.IsDir()
+	}
+	return false
+}
+
+func isDir(path string) bool {
+	if fi, err := osStat(path); err == nil {
+		return fi.IsDir()
 	}
 	return false
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
addresses https://github.com/aws/amazon-ecs-agent/pull/2733#discussion_r525575933

### Implementation details
If the config file path is a directory, remove the whole directory and its contents. 
If unable to remove, return an error

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

### Description for the changelog
N/A

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
