### PR TITLE
docker_client: Add missing error handling in getContainerStatsNotStre…

### DIFF
--- a/agent/dockerclient/dockerapi/docker_client.go
+++ b/agent/dockerclient/dockerapi/docker_client.go
@@ -1414,6 +1414,9 @@ func getContainerStatsNotStreamed(client sdkclient.Client, ctx context.Context, 
 	}()
 	select {
 	case resp := <-response:
+		if resp.err != nil {
+			return nil, fmt.Errorf("DockerGoClient: Unable to retrieve stats for container %s: %v", id, resp.err)
+		}
 		decoder := json.NewDecoder(resp.stats.Body)
 		stats := &types.StatsJSON{}
 		err := decoder.Decode(stats)

--- a/agent/dockerclient/dockerapi/docker_client_test.go
+++ b/agent/dockerclient/dockerapi/docker_client_test.go
@@ -1183,6 +1183,19 @@ func TestPollStatsTimeout(t *testing.T) {
 	wait.Done()
 }
 
+func TestPollStatsError(t *testing.T) {
+	shortTimeout := 1 * time.Millisecond
+	mockDockerSDK, _, _, _, _, done := dockerClientSetup(t)
+	defer done()
+	mockDockerSDK.EXPECT().ContainerStats(gomock.Any(), gomock.Any(), false).MaxTimes(1).Return(types.ContainerStats{
+		Body: nil},
+		errors.New("Container stats error"))
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	_, err := getContainerStatsNotStreamed(mockDockerSDK, ctx, "foo", shortTimeout)
+	assert.Error(t, err)
+}
+
 func TestStatsInactivityTimeoutNoHit(t *testing.T) {
 	longInactivityTimeout := 500 * time.Millisecond
 	mockDockerSDK, client, _, _, _, done := dockerClientSetup(t)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR potentially fixes flaky test [TestStatsEngineWithNewContainersWithPolling](http://ttbmacisui.corp.amazon.com/download/?pr=2671&commit=0adac31f237bb8fa0dadf1dcd669df1ecb577438&timestamp=2020-10-13T23:23:28Z&filename=test-output-al2-integ.out). We currently don't handle when ContainerStats() returns error which leads to nil pointer dereference.

This PR is a copy of #2751 which was wrongly merged to a `ecs_exec` feature branch.
### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
`make test` succeeds
New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Bug - Add missing error handling in getContainerStatsNotStreamed
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
