### PR TITLE
Create container without enabling exec feature if exec bind mounting …

### DIFF
--- a/agent/api/container/container.go
+++ b/agent/api/container/container.go
@@ -124,6 +124,8 @@ type ManagedAgentState struct {
 	LastStartedAt time.Time `json:"lastStartedAt,omitempty"`
 	// Metadata holds metadata about the managed agent
 	Metadata map[string]interface{} `json:"metadata,omitempty"`
+	// InitFailed indicates if exec agent initialization failed
+	InitFailed bool `json:"initFailed,omitempty"`
 }
 
 type ManagedAgent struct {

--- a/agent/engine/execcmd/manager_init_task_linux_test.go
+++ b/agent/engine/execcmd/manager_init_task_linux_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 )
 
 func TestInitializeContainer(t *testing.T) {
@@ -171,6 +172,11 @@ func TestInitializeContainer(t *testing.T) {
 
 				if test.expectedError != nil {
 					assert.Empty(t, hc.Binds)
+					if ma, ok := container.GetManagedAgentByName(ExecuteCommandAgentName); ok {
+						assert.Equal(t, "", ma.ID)
+						assert.True(t, ma.InitFailed)
+						assert.Equal(t, apicontainerstatus.ManagedAgentStopped, ma.Status)
+					}
 					continue
 				}
 

--- a/misc/exec-command-agent-test/build-mock-ssm-agent
+++ b/misc/exec-command-agent-test/build-mock-ssm-agent
@@ -14,8 +14,12 @@
 
 SIMULATED_ECS_AGENT_DEPS_BIN_DIR="/managed-agents/execute-command/bin/1.0.0.0"
 rm -rf ./$SIMULATED_ECS_AGENT_DEPS_BIN_DIR
-mkdir $SIMULATED_ECS_AGENT_DEPS_BIN_DIR # mock version folder for our mock ssm agent binaries
+mkdir -p $SIMULATED_ECS_AGENT_DEPS_BIN_DIR # mock version folder for our mock ssm agent binaries
 CGO_ENABLED=0 go build -tags integration -installsuffix cgo -a -o $SIMULATED_ECS_AGENT_DEPS_BIN_DIR/amazon-ssm-agent ./sleep/
 touch $SIMULATED_ECS_AGENT_DEPS_BIN_DIR/ssm-agent-worker
 touch $SIMULATED_ECS_AGENT_DEPS_BIN_DIR/ssm-session-worker
+SIMULATED_ECS_AGENT_DEPS_CERTS_DIR="/managed-agents/execute-command/certs"
+rm -rf ./$SIMULATED_ECS_AGENT_DEPS_CERTS_DIR
+mkdir -p $SIMULATED_ECS_AGENT_DEPS_CERTS_DIR # mock certs folder for our mock ssm agent
+touch $SIMULATED_ECS_AGENT_DEPS_CERTS_DIR/tls-ca-bundle.pem
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

Initially, if a task is exec enabled but ecs agent somehow fails to bind mount exec related dependencies to the containers in the task, the task would fail as container wont start. This PR solves this problem. It will start the container without enabling exec if exec bind mounting fails for any reason. It will also update Managed agent of the container to STOPPED status and the reason will be the error that we get when bind mount fails. 

When the above case happens, We will not try starting exec agent or restarting exec agent.

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->
Unit tests and integ tests cover the change.

I have tested even if I remove any one of the deps folder, the container starts up anyway. 
```
docker inspect <container-id>

$....
....
....
Mounts: []
...
...
```
### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
