### PR TITLE
sync aws-sdk-go version

### DIFF
--- a/agent/Gopkg.lock
+++ b/agent/Gopkg.lock
@@ -540,6 +540,7 @@
     "github.com/aws/aws-sdk-go/aws/session",
     "github.com/aws/aws-sdk-go/aws/signer/v4",
     "github.com/aws/aws-sdk-go/private/model/api",
+    "github.com/aws/aws-sdk-go/private/protocol",
     "github.com/aws/aws-sdk-go/private/protocol/json/jsonutil",
     "github.com/aws/aws-sdk-go/private/protocol/jsonrpc",
     "github.com/aws/aws-sdk-go/private/util",

--- a/agent/Gopkg.toml
+++ b/agent/Gopkg.toml
@@ -27,7 +27,7 @@ required = ["github.com/golang/mock/mockgen/model"]
 
 [[constraint]]
   name = "github.com/aws/aws-sdk-go"
-  version = "1.35.37"
+  version = "v1.36.0"
 
 [[constraint]]
   name = "github.com/cihub/seelog"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
The version that was pulled in by `dep ensure` was actually 1.36.0 (the latest tagged version on that date).  The version was originally malformed in the Gopkg.toml file.  

### Implementation details
I updated the Gopkg.toml file, ran `make get-dep` and `dep ensure` and the only update was to the Gopkg.lock file below.

### Testing
Ran `make gogenerate` then `make test` locally

New tests cover the changes: no

### Description for the changelog
Sync Gopkg.toml with Gopkg.lock

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
