### PR TITLE
Avoid ECS Agent start error when awsfirelens is specified in ECS_AVAI…

### DIFF
--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -311,6 +311,10 @@ func (cfg *Config) validateAndOverrideBounds() error {
 	}
 	var badDrivers []string
 	for _, driver := range cfg.AvailableLoggingDrivers {
+		// Don't classify awsfirelens as a bad driver
+		if driver == dockerclient.AWSFirelensDriver {
+			continue
+		}
 		_, ok := dockerclient.LoggingDriverMinimumVersion[driver]
 		if !ok {
 			badDrivers = append(badDrivers, string(driver))

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -264,6 +264,13 @@ func TestInvalidLoggingDriver(t *testing.T) {
 	assert.Error(t, conf.validateAndOverrideBounds(), "Should be error with invalid-logging-driver")
 }
 
+func TestAwsFirelensLoggingDriver(t *testing.T) {
+	conf := DefaultConfig()
+	conf.AWSRegion = "us-west-2"
+	conf.AvailableLoggingDrivers = []dockerclient.LoggingDriver{"awsfirelens"}
+	assert.NoError(t, conf.validateAndOverrideBounds(), "awsfirelens is a valid logging driver, no error was expected")
+}
+
 func TestDefaultPollMetricsWithoutECSDataDir(t *testing.T) {
 	conf, err := environmentConfig()
 	assert.NoError(t, err)

--- a/agent/dockerclient/logging_drivers.go
+++ b/agent/dockerclient/logging_drivers.go
@@ -16,16 +16,17 @@ package dockerclient
 type LoggingDriver string
 
 const (
-	JSONFileDriver   LoggingDriver = "json-file"
-	SyslogDriver     LoggingDriver = "syslog"
-	JournaldDriver   LoggingDriver = "journald"
-	GelfDriver       LoggingDriver = "gelf"
-	FluentdDriver    LoggingDriver = "fluentd"
-	AWSLogsDriver    LoggingDriver = "awslogs"
-	SplunklogsDriver LoggingDriver = "splunk"
-	LogentriesDriver LoggingDriver = "logentries"
-	SumoLogicDriver  LoggingDriver = "sumologic"
-	NoneDriver       LoggingDriver = "none"
+	JSONFileDriver    LoggingDriver = "json-file"
+	SyslogDriver      LoggingDriver = "syslog"
+	JournaldDriver    LoggingDriver = "journald"
+	GelfDriver        LoggingDriver = "gelf"
+	FluentdDriver     LoggingDriver = "fluentd"
+	AWSLogsDriver     LoggingDriver = "awslogs"
+	SplunklogsDriver  LoggingDriver = "splunk"
+	LogentriesDriver  LoggingDriver = "logentries"
+	SumoLogicDriver   LoggingDriver = "sumologic"
+	NoneDriver        LoggingDriver = "none"
+	AWSFirelensDriver LoggingDriver = "awsfirelens"
 )
 
 var LoggingDriverMinimumVersion = map[LoggingDriver]DockerVersion{


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This small change addresses https://github.com/aws/amazon-ecs-agent/issues/2736

This is a bug since awsfirelens is a valid logging driver, its presence in `ECS_AVAILABLE_LOGGING_DRIVERS` should not prevent ECS Agent from starting.

### Implementation details
<!-- How are the changes implemented? -->
Ignoring awsfirelens if present in  ECS_AVAILABLE_LOGGING_DRIVERS when Agent is determining bad drivers
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
* Fixed bug that prevented ECS Agent start when "awsfirelens" was included in `ECS_AVAILABLE_LOGGING_DRIVERS`
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
