### PR TITLE
check at least 1 ssm version is valid instead of checking all versions

### DIFF
--- a/agent/app/agent_capability_test.go
+++ b/agent/app/agent_capability_test.go
@@ -810,9 +810,22 @@ func TestCapabilitiesExecuteCommand(t *testing.T) {
 			shouldHaveExecCapability: false,
 		},
 		{
+			name:                     "execute-command capability should not be added if there are directroies exist but have no valid ssm version exist",
+			pathExists:               func(path string, shouldBeDirectory bool) (bool, error) { return true, nil },
+			getSubDirectories:        func(path string) ([]string, error) { return []string{"3.0.236.0", "3.1.23.0"}, nil },
+			invalidSsmVersions:       map[string]struct{}{"3.0.236.0": struct{}{}, "3.1.23.0": struct{}{}},
+			shouldHaveExecCapability: false,
+		},
+		{
 			name:                     "execute-command capability should be added if requirements are met",
 			pathExists:               func(path string, shouldBeDirectory bool) (bool, error) { return true, nil },
 			getSubDirectories:        func(path string) ([]string, error) { return []string{"3.0.236.0"}, nil },
+			shouldHaveExecCapability: true,
+		},
+		{
+			name:                     "execute-command capability should be added if have valid ssm version exists",
+			pathExists:               func(path string, shouldBeDirectory bool) (bool, error) { return true, nil },
+			getSubDirectories:        func(path string) ([]string, error) { return []string{"3.0.236.0", "3.1.23.0"}, nil },
 			shouldHaveExecCapability: true,
 		},
 	}


### PR DESCRIPTION
… to advertise exec-enable.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

Previously we check that all ssm version should be valid and when user add a new ssm version folder which is empty, the exec-capability doesn't shows up.  

This PR solve the case when customer try to add another ssm version in the `/var/lib/ecs/deps/execute-command/bin/`.  We already have a valid ssm version, with this new folder added,  the exec-capability should still exists. 

### Implementation details
<!-- How are the changes implemented? -->
Add a new check to find in the dependencies map that we have a least one valid ssm version exists. When we add a new ssm version folder (maybe empty), the exec attribute should still shows up and available to use. 
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

```
manual test:
aws ecs describe-container-instances  . . .:
capabilities:
{
...
"name": "ecs.capability.execute-command" 
...
}

previously:
exec-attribute  is not there 

currently:
exec-attribute still shows up

sudo mkdir `new version of ssm`
aws ecs describe-container-instances  . . .:
{
...
"name": "ecs.capability.execute-command" 
...
}

```
### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
