### PR TITLE
Sync managed agent sent status

### DIFF
--- a/agent/api/container/container.go
+++ b/agent/api/container/container.go
@@ -1270,3 +1270,27 @@ func (c *Container) UpdateManagedAgentSentStatus(agentName string, status apicon
 	}
 	return false
 }
+
+func (c *Container) GetManagedAgentStatus(agentName string) apicontainerstatus.ManagedAgentStatus {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	for i, ma := range c.ManagedAgentsUnsafe {
+		if ma.Name == agentName {
+			return c.ManagedAgentsUnsafe[i].Status
+		}
+	}
+	// we shouldn't get here because we'll always have a valid ManagedAgentName
+	return apicontainerstatus.ManagedAgentStatusNone
+}
+
+func (c *Container) GetManagedAgentSentStatus(agentName string) apicontainerstatus.ManagedAgentStatus {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	for i, ma := range c.ManagedAgentsUnsafe {
+		if ma.Name == agentName {
+			return c.ManagedAgentsUnsafe[i].SentStatus
+		}
+	}
+	// we shouldn't get here because we'll always have a valid ManagedAgentName
+	return apicontainerstatus.ManagedAgentStatusNone
+}

--- a/agent/api/container/container_test.go
+++ b/agent/api/container/container_test.go
@@ -554,6 +554,34 @@ func TestGetManagedAgents(t *testing.T) {
 	assert.Equal(t, expectedManagedAgent, container.GetManagedAgents()[0])
 }
 
+func TestGetManagedAgentStatus(t *testing.T) {
+	container := Container{}
+	assert.Equal(t, apicontainerstatus.ManagedAgentStatusNone, container.GetManagedAgentStatus("dummyAgent"))
+
+	expectedManagedAgent := ManagedAgent{
+		Name: "dummyAgent",
+		ManagedAgentState: ManagedAgentState{
+			Status: apicontainerstatus.ManagedAgentCreated,
+		},
+	}
+	container.ManagedAgentsUnsafe = []ManagedAgent{expectedManagedAgent}
+	assert.Equal(t, apicontainerstatus.ManagedAgentCreated, container.GetManagedAgentStatus("dummyAgent"))
+}
+
+func TestGetManagedAgentSentStatus(t *testing.T) {
+	container := Container{}
+	assert.Equal(t, apicontainerstatus.ManagedAgentStatusNone, container.GetManagedAgentSentStatus("dummyAgent"))
+
+	expectedManagedAgent := ManagedAgent{
+		Name: "dummyAgent",
+		ManagedAgentState: ManagedAgentState{
+			SentStatus: apicontainerstatus.ManagedAgentCreated,
+		},
+	}
+	container.ManagedAgentsUnsafe = []ManagedAgent{expectedManagedAgent}
+	assert.Equal(t, apicontainerstatus.ManagedAgentCreated, container.GetManagedAgentSentStatus("dummyAgent"))
+}
+
 func TestDependsOnContainer(t *testing.T) {
 	testCases := []struct {
 		name          string

--- a/agent/api/ecsclient/client.go
+++ b/agent/api/ecsclient/client.go
@@ -428,7 +428,7 @@ func trimString(inputString string, maxLen int) string {
 func (client *APIECSClient) buildManagedAgentStateChangePayload(change api.ManagedAgentStateChange) *ecs.ManagedAgentStateChange {
 	if !change.Status.ShouldReportToBackend() {
 		seelog.Warnf("Not submitting unsupported managed agent state %s for container %s in task %s",
-			change.Status.String(), change.ContainerName, change.TaskArn)
+			change.Status.String(), change.Container.Name, change.TaskArn)
 		return nil
 	}
 	var trimmedReason *string
@@ -437,7 +437,7 @@ func (client *APIECSClient) buildManagedAgentStateChangePayload(change api.Manag
 	}
 	return &ecs.ManagedAgentStateChange{
 		ManagedAgentName: aws.String(change.Name),
-		ContainerName:    aws.String(change.ContainerName),
+		ContainerName:    aws.String(change.Container.Name),
 		Status:           aws.String(change.Status.String()),
 		Reason:           trimmedReason,
 	}

--- a/agent/api/statechange.go
+++ b/agent/api/statechange.go
@@ -59,8 +59,9 @@ type ManagedAgentStateChange struct {
 	TaskArn string
 	// Name is the name of the managed agent
 	Name string
-	// ContainerName is the name of the managed agent's container
-	ContainerName string
+	// Container is a pointer to the container involved in the state change that gives the event handler a hook into
+	// storing what status was sent.  This is used to ensure the same event is handled only once.
+	Container *apicontainer.Container
 	// Status is the status of the managed agent
 	Status apicontainerstatus.ManagedAgentStatus
 	// Reason indicates an error in a managed agent state chage
@@ -188,11 +189,11 @@ func NewManagedAgentChangeEvent(task *apitask.Task, cont *apicontainer.Container
 	}
 
 	event = ManagedAgentStateChange{
-		TaskArn:       task.Arn,
-		Name:          managedAgent.Name,
-		ContainerName: cont.Name,
-		Status:        managedAgent.Status,
-		Reason:        reason,
+		TaskArn:   task.Arn,
+		Name:      managedAgent.Name,
+		Container: cont,
+		Status:    managedAgent.Status,
+		Reason:    reason,
 	}
 
 	return event, nil
@@ -225,7 +226,7 @@ func (c *ContainerStateChange) String() string {
 
 // String returns a human readable string representation of ManagedAgentStateChange
 func (m *ManagedAgentStateChange) String() string {
-	res := fmt.Sprintf("%s %s -> %s", m.TaskArn, m.Name, m.Status.String())
+	res := fmt.Sprintf("%s %s %s -> %s", m.TaskArn, m.Container.Name, m.Name, m.Status.String())
 	if m.Reason != "" {
 		res += ", Reason " + m.Reason
 	}

--- a/agent/api/statechange_test.go
+++ b/agent/api/statechange_test.go
@@ -237,23 +237,23 @@ func TestNewManagedAgentChangeEvent(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
+		testContainer := apicontainer.Container{
+			Name:                "c1",
+			ManagedAgentsUnsafe: tc.managedAgents,
+		}
+		testContainers := []*apicontainer.Container{&testContainer}
 		t.Run(tc.name, func(t *testing.T) {
 
 			task := &apitask.Task{
-				Arn: "arn:123",
-				Containers: []*apicontainer.Container{
-					{
-						Name:                "c1",
-						ManagedAgentsUnsafe: tc.managedAgents,
-					},
-				}}
-
+				Arn:        "arn:123",
+				Containers: testContainers,
+			}
 			expectedEvent := ManagedAgentStateChange{
-				TaskArn:       "arn:123",
-				Name:          execcmd.ExecuteCommandAgentName,
-				ContainerName: "c1",
-				Status:        apicontainerstatus.ManagedAgentRunning,
-				Reason:        "test",
+				TaskArn:   "arn:123",
+				Name:      execcmd.ExecuteCommandAgentName,
+				Container: &testContainer,
+				Status:    apicontainerstatus.ManagedAgentRunning,
+				Reason:    "test",
 			}
 
 			event, err := NewManagedAgentChangeEvent(task, task.Containers[0], execcmd.ExecuteCommandAgentName, "test")

--- a/agent/eventhandler/task_handler_test.go
+++ b/agent/eventhandler/task_handler_test.go
@@ -350,7 +350,7 @@ func containerEvent(arn string) statechange.Event {
 }
 
 func managedAgentEvent(arn string) statechange.Event {
-	return api.ManagedAgentStateChange{TaskArn: arn, Name: "ExecAgent", Status: apicontainerstatus.ManagedAgentRunning}
+	return api.ManagedAgentStateChange{TaskArn: arn, Container: &apicontainer.Container{}, Name: "ExecAgent", Status: apicontainerstatus.ManagedAgentRunning}
 }
 
 func containerEventStopped(arn string) statechange.Event {

--- a/agent/eventhandler/task_handler_types_test.go
+++ b/agent/eventhandler/task_handler_types_test.go
@@ -144,8 +144,8 @@ func TestShouldTaskEventBeSent(t *testing.T) {
 			shouldBeSent: true,
 		},
 		{
-			// ManagedAgent state change should be sent regardless of task
-			// status.
+			// ManagedAgent state change should be sent if SentStatus is != Status
+			// regardless of task status
 			event: newSendableTaskEvent(api.TaskStateChange{
 				Status: apitaskstatus.TaskStatusNone,
 				Task: &apitask.Task{
@@ -153,17 +153,86 @@ func TestShouldTaskEventBeSent(t *testing.T) {
 				},
 				ManagedAgents: []api.ManagedAgentStateChange{
 					{
-						TaskArn:       "test_task_arn",
-						Name:          "test_agent",
-						ContainerName: "test_container",
-						Status:        apicontainerstatus.ManagedAgentStatusNone,
-						Reason:        "test_reason",
+						TaskArn: "test_task_arn",
+						Name:    "test_agent",
+						Container: &apicontainer.Container{
+							ManagedAgentsUnsafe: []apicontainer.ManagedAgent{
+								{
+									Name: "test_agent",
+									ManagedAgentState: apicontainer.ManagedAgentState{
+										Status:     apicontainerstatus.ManagedAgentRunning,
+										SentStatus: apicontainerstatus.ManagedAgentStatusNone,
+									},
+								},
+							},
+						},
+						Status: apicontainerstatus.ManagedAgentStatusNone,
+						Reason: "test_reason",
 					},
 				},
 			}),
 			shouldBeSent: true,
 		},
-
+		{
+			// ManagedAgent state change should be sent if SentStatus is != Status
+			// regardless of task status
+			event: newSendableTaskEvent(api.TaskStateChange{
+				Status: apitaskstatus.TaskStatusNone,
+				Task: &apitask.Task{
+					SentStatusUnsafe: apitaskstatus.TaskStatusNone,
+				},
+				ManagedAgents: []api.ManagedAgentStateChange{
+					{
+						TaskArn: "test_task_arn",
+						Name:    "test_agent",
+						Container: &apicontainer.Container{
+							ManagedAgentsUnsafe: []apicontainer.ManagedAgent{
+								{
+									Name: "test_agent",
+									ManagedAgentState: apicontainer.ManagedAgentState{
+										Status:     apicontainerstatus.ManagedAgentRunning,
+										SentStatus: apicontainerstatus.ManagedAgentStopped,
+									},
+								},
+							},
+						},
+						Status: apicontainerstatus.ManagedAgentStatusNone,
+						Reason: "test_reason",
+					},
+				},
+			}),
+			shouldBeSent: true,
+		},
+		{
+			// ManagedAgent state change should not be sent if SentStatus is == Status
+			// regardless of task status
+			event: newSendableTaskEvent(api.TaskStateChange{
+				Status: apitaskstatus.TaskStatusNone,
+				Task: &apitask.Task{
+					SentStatusUnsafe: apitaskstatus.TaskStatusNone,
+				},
+				ManagedAgents: []api.ManagedAgentStateChange{
+					{
+						TaskArn: "test_task_arn",
+						Name:    "test_agent",
+						Container: &apicontainer.Container{
+							ManagedAgentsUnsafe: []apicontainer.ManagedAgent{
+								{
+									Name: "test_agent",
+									ManagedAgentState: apicontainer.ManagedAgentState{
+										Status:     apicontainerstatus.ManagedAgentRunning,
+										SentStatus: apicontainerstatus.ManagedAgentRunning,
+									},
+								},
+							},
+						},
+						Status: apicontainerstatus.ManagedAgentStatusNone,
+						Reason: "test_reason",
+					},
+				},
+			}),
+			shouldBeSent: false,
+		},
 		{
 			// All states sent, nothing to send
 			event: newSendableTaskEvent(api.TaskStateChange{
@@ -299,6 +368,14 @@ func TestSetTaskSentStatus(t *testing.T) {
 				Container: testContainer,
 			},
 		},
+		ManagedAgents: []api.ManagedAgentStateChange{
+			{
+				TaskArn:   testTaskARN,
+				Name:      "dummyAgent",
+				Container: testContainer,
+				Status:    apicontainerstatus.ManagedAgentRunning,
+			},
+		},
 	})
 	taskStoppedStateChange := newSendableTaskEvent(api.TaskStateChange{
 		Status: apitaskstatus.TaskStopped,
@@ -309,21 +386,29 @@ func TestSetTaskSentStatus(t *testing.T) {
 				Container: testContainer,
 			},
 		},
+		ManagedAgents: []api.ManagedAgentStateChange{
+			{
+				TaskArn:   testTaskARN,
+				Name:      "dummyAgent",
+				Container: testContainer,
+				Status:    apicontainerstatus.ManagedAgentStopped,
+			},
+		},
 	})
 
 	setTaskChangeSent(taskStoppedStateChange, dataClient)
 	assert.Equal(t, testTask.GetSentStatus(), apitaskstatus.TaskStopped)
 	assert.Equal(t, testContainer.GetSentStatus(), apicontainerstatus.ContainerStopped)
 
-	// TODO update managed agent sent status
-	//updatedManagedAgent, _ := testContainer.GetManagedAgentByName("dummyAgent")
-	//assert.Equal(t, apicontainerstatus.ManagedAgentStopped, updatedManagedAgent.SentStatus)
+	updatedManagedAgent, _ := testContainer.GetManagedAgentByName("dummyAgent")
+	assert.Equal(t, apicontainerstatus.ManagedAgentStopped, updatedManagedAgent.SentStatus)
 
 	setTaskChangeSent(taskRunningStateChange, dataClient)
 	assert.Equal(t, testTask.GetSentStatus(), apitaskstatus.TaskStopped)
 	assert.Equal(t, testContainer.GetSentStatus(), apicontainerstatus.ContainerStopped)
-	//updatedManagedAgent, _ = testContainer.GetManagedAgentByName("dummyAgent")
-	//assert.Equal(t, apicontainerstatus.ManagedAgentStopped, updatedManagedAgent.SentStatus)
+
+	updatedManagedAgent, _ = testContainer.GetManagedAgentByName("dummyAgent")
+	assert.Equal(t, apicontainerstatus.ManagedAgentRunning, updatedManagedAgent.SentStatus)
 
 	tasks, err := dataClient.GetTasks()
 	require.NoError(t, err)
@@ -334,8 +419,8 @@ func TestSetTaskSentStatus(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, containers, 1)
 	assert.Equal(t, apicontainerstatus.ContainerStopped, containers[0].Container.GetSentStatus())
-	//updatedManagedAgent, _ = containers[0].Container.GetManagedAgentByName("dummyAgent")
-	//assert.Equal(t, apicontainerstatus.ManagedAgentStopped, updatedManagedAgent.SentStatus)
+	updatedManagedAgent, _ = containers[0].Container.GetManagedAgentByName("dummyAgent")
+	assert.Equal(t, apicontainerstatus.ManagedAgentRunning, updatedManagedAgent.SentStatus)
 }
 
 func TestSetContainerSentStatus(t *testing.T) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This change will update the ManagedAgentStatus.SentStatus for sent managed agents.

### Implementation details
Followed the update pattern of batched Container events included in Task state change events.

### Testing
Updated/Added tests; ran `make test` successfully.
Built ecs-agent and tested in gamma with an execute-command enabled task.  see a running ExecuteCommandAgent:
```
                    "managedAgents": [
                        {
                            "reason": "Execute Command Agent started",
                            "lastStatus": "RUNNING",
                            "lastStartedAt": 1608318983.965,
                            "name": "ExecuteCommandAgent"
                        }
                    ],
```
also to be sure we're actually caling the `updateManagedAgentSentStatus()` I updated to echo managed agent status and sent status in agent/eventhandler/task_handler_types.go:
```
        for _, managedAgentStateChange := range event.taskChange.ManagedAgents {
                container := managedAgentStateChange.Container
                managedAgentName := managedAgentStateChange.Name
                unsentStatus := container.GetManagedAgentStatus(managedAgentName)
                sentStatus := container.GetManagedAgentSentStatus(managedAgentName)
                seelog.Infof("should send: containerStatus: %v | sentStatus: %v", unsentStatus, sentStatus)
                updateManagedAgentSentStatus(container, managedAgentName, managedAgentStateChange.Status, dataClient)
        }
```
and after starting exec-enabled task I see in the ecs-agent log:
```
level=info time=2020-12-18T20:37:51Z msg="should send: containerStatus: RUNNING | sentStatus: NONE" module=task_handler_types.go
```

New tests cover the changes: yes

### Description for the changelog
Sync ManagedAgent SentStatus.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
