### PR TITLE
[WIP] emit event when container stops

### DIFF
--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -1144,7 +1144,7 @@ func (engine *DockerTaskEngine) createContainer(task *apitask.Task, container *a
 		if err != nil {
 			seelog.Warnf("Exec Agent initialization: %v . Continuing to start container without enabling exec feature.", err)
 
-			// Emit a managedagent state chnage event if exec agent initialization fails
+			// Emit a managedagent state change event if exec agent initialization fails
 			engine.tasksLock.RLock()
 			mTask, ok := engine.managedTasks[task.Arn]
 			engine.tasksLock.RUnlock()

--- a/agent/engine/docker_task_engine_linux_test.go
+++ b/agent/engine/docker_task_engine_linux_test.go
@@ -136,7 +136,7 @@ func TestResourceContainerProgression(t *testing.T) {
 			ExitCode: aws.Int(exitCode),
 		},
 	}
-	waitForStopEvents(t, taskEngine.StateChangeEvents(), true)
+	waitForStopEvents(t, taskEngine.StateChangeEvents(), true, false)
 }
 
 func TestDeleteTask(t *testing.T) {
@@ -270,7 +270,7 @@ func TestResourceContainerProgressionFailure(t *testing.T) {
 	taskEngine.AddTask(sleepTask)
 	cleanup := make(chan time.Time, 1)
 	mockTime.EXPECT().After(gomock.Any()).Return(cleanup).AnyTimes()
-	waitForStopEvents(t, taskEngine.StateChangeEvents(), true)
+	waitForStopEvents(t, taskEngine.StateChangeEvents(), true, false)
 }
 
 func TestTaskCPULimitHappyPath(t *testing.T) {
@@ -378,7 +378,7 @@ func TestTaskCPULimitHappyPath(t *testing.T) {
 			// the cleanup phase. Account for that.
 			client.EXPECT().StopContainer(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 				dockerapi.DockerContainerMetadata{DockerID: containerID}).AnyTimes()
-			waitForStopEvents(t, taskEngine.StateChangeEvents(), true)
+			waitForStopEvents(t, taskEngine.StateChangeEvents(), true, false)
 			// This ensures that managedTask.waitForStopReported makes progress
 			sleepTask.SetSentStatus(apitaskstatus.TaskStopped)
 			// Extra events should not block forever; duplicate acs and docker events are possible


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
