### PR TITLE
Emit ExecCommandAgent stop event when container stops

### DIFF
--- a/agent/api/container/container.go
+++ b/agent/api/container/container.go
@@ -1257,6 +1257,20 @@ func (c *Container) UpdateManagedAgentByName(agentName string, state ManagedAgen
 	return false
 }
 
+// UpdateManagedAgentStatus updates the status of the managed agent with the name specified. If the agent is not found,
+// this method returns false.
+func (c *Container) UpdateManagedAgentStatus(agentName string, status apicontainerstatus.ManagedAgentStatus) bool {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	for i, ma := range c.ManagedAgentsUnsafe {
+		if ma.Name == agentName {
+			c.ManagedAgentsUnsafe[i].Status = status
+			return true
+		}
+	}
+	return false
+}
+
 // UpdateManagedAgentSentStatus updates the sent status of the managed agent with the name specified. If the agent is not found,
 // this method returns false.
 func (c *Container) UpdateManagedAgentSentStatus(agentName string, status apicontainerstatus.ManagedAgentStatus) bool {

--- a/agent/engine/common_test.go
+++ b/agent/engine/common_test.go
@@ -288,7 +288,14 @@ func waitForRunningEvents(t *testing.T, stateChangeEvents <-chan statechange.Eve
 
 // waitForStopEvents waits for a task to emit 'STOPPED' events for a container
 // and the task
-func waitForStopEvents(t *testing.T, stateChangeEvents <-chan statechange.Event, verifyExitCode bool) {
+func waitForStopEvents(t *testing.T, stateChangeEvents <-chan statechange.Event, verifyExitCode, execEnabled bool) {
+	if execEnabled {
+		event := <-stateChangeEvents
+		if masc := event.(api.ManagedAgentStateChange); masc.Status != apicontainerstatus.ManagedAgentStopped {
+			t.Fatal("Expected managed agent to stop first")
+		}
+	}
+
 	event := <-stateChangeEvents
 	if cont := event.(api.ContainerStateChange); cont.Status != apicontainerstatus.ContainerStopped {
 		t.Fatal("Expected container to stop first")

--- a/agent/engine/docker_task_engine_linux_test.go
+++ b/agent/engine/docker_task_engine_linux_test.go
@@ -136,7 +136,7 @@ func TestResourceContainerProgression(t *testing.T) {
 			ExitCode: aws.Int(exitCode),
 		},
 	}
-	waitForStopEvents(t, taskEngine.StateChangeEvents(), true)
+	waitForStopEvents(t, taskEngine.StateChangeEvents(), true, false)
 }
 
 func TestDeleteTask(t *testing.T) {
@@ -270,7 +270,7 @@ func TestResourceContainerProgressionFailure(t *testing.T) {
 	taskEngine.AddTask(sleepTask)
 	cleanup := make(chan time.Time, 1)
 	mockTime.EXPECT().After(gomock.Any()).Return(cleanup).AnyTimes()
-	waitForStopEvents(t, taskEngine.StateChangeEvents(), true)
+	waitForStopEvents(t, taskEngine.StateChangeEvents(), true, false)
 }
 
 func TestTaskCPULimitHappyPath(t *testing.T) {
@@ -378,7 +378,7 @@ func TestTaskCPULimitHappyPath(t *testing.T) {
 			// the cleanup phase. Account for that.
 			client.EXPECT().StopContainer(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 				dockerapi.DockerContainerMetadata{DockerID: containerID}).AnyTimes()
-			waitForStopEvents(t, taskEngine.StateChangeEvents(), true)
+			waitForStopEvents(t, taskEngine.StateChangeEvents(), true, false)
 			// This ensures that managedTask.waitForStopReported makes progress
 			sleepTask.SetSentStatus(apitaskstatus.TaskStopped)
 			// Extra events should not block forever; duplicate acs and docker events are possible


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

For MVP, ExecCommand Agent will stop only when the parent container stops. This PR addresses the use case of emitting the proper managed agent stop event when parent container stops.

### Implementation details
<!-- How are the changes implemented? -->
Sending a , `api.ManagedAgentStateChange` event to the `mtask.stateChangeEvents` channel. Updating UTs accordingly. 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
