### PR TITLE
Emit the right reason upon exec command start error

### DIFF
--- a/agent/engine/common_test.go
+++ b/agent/engine/common_test.go
@@ -342,6 +342,8 @@ func checkManagedAgentEvents(t *testing.T, expectContainerEvent bool, stateChang
 				// there is currently only ever a single managed agent
 				assert.Equal(t, expectedManagedAgent.Status, managedAgentEvent.Status,
 					"expected managedAgent container state change event did not match actual event")
+				assert.Equal(t, expectedManagedAgent.Reason, managedAgentEvent.Reason,
+					"expected managedAgent container state change event reports the wrong reason")
 				close(waitDone)
 				return
 			}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This fixes a bug where the wrong reason was reported when Exec Command Agent failed to start
### Implementation details
<!-- How are the changes implemented? -->

When Exec Command Agent, set the reason as the error string received by `StartAgent`

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
