### PR TITLE
replace 'Execute Command Agent' with 'ExecuteCommandAgent'

### DIFF
--- a/agent/api/statechange.go
+++ b/agent/api/statechange.go
@@ -182,7 +182,7 @@ func NewManagedAgentChangeEvent(task *apitask.Task, cont *apicontainer.Container
 	var event = ManagedAgentStateChange{}
 	managedAgent, ok := cont.GetManagedAgentByName(managedAgentName)
 	if !ok {
-		return event, errors.Errorf("No execute command agent available in container: %v", cont.Name)
+		return event, errors.Errorf("No ExecuteCommandAgent available in container: %v", cont.Name)
 	}
 	if !managedAgent.Status.ShouldReportToBackend() {
 		return event, errors.Errorf("create managed agent state change event: status not recognized by ECS: %v", managedAgent.Status)

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -315,10 +315,10 @@ func (engine *DockerTaskEngine) monitorExecAgentRunning(ctx context.Context,
 	status, err := engine.execCmdMgr.RestartAgentIfStopped(ctx, engine.client, task, c, dockerID)
 	if err != nil {
 		seelog.Errorf("Task engine [%s]: Failed to restart ExecCommandAgent Process for container [%s]: %v", task.Arn, dockerID, err)
-		mTask.emitManagedAgentEvent(mTask.Task, c, execcmd.ExecuteCommandAgentName, "Execute Command Agent cannot be restarted")
+		mTask.emitManagedAgentEvent(mTask.Task, c, execcmd.ExecuteCommandAgentName, "ExecuteCommandAgent cannot be restarted")
 	}
 	if status == execcmd.Restarted {
-		mTask.emitManagedAgentEvent(mTask.Task, c, execcmd.ExecuteCommandAgentName, "Execute Command Agent restarted")
+		mTask.emitManagedAgentEvent(mTask.Task, c, execcmd.ExecuteCommandAgentName, "ExecuteCommandAgent restarted")
 	}
 
 }
@@ -1149,7 +1149,7 @@ func (engine *DockerTaskEngine) createContainer(task *apitask.Task, container *a
 			mTask, ok := engine.managedTasks[task.Arn]
 			engine.tasksLock.RUnlock()
 			if ok {
-				mTask.emitManagedAgentEvent(mTask.Task, container, execcmd.ExecuteCommandAgentName, fmt.Sprintf("Execute Command Agent Initialization failed - %v", err))
+				mTask.emitManagedAgentEvent(mTask.Task, container, execcmd.ExecuteCommandAgentName, fmt.Sprintf("ExecuteCommandAgent Initialization failed - %v", err))
 			} else {
 				seelog.Errorf("Task engine [%s]: Failed to update status of ExecCommandAgent Process for container [%s]: managed task not found", task.Arn, container.Name)
 			}
@@ -1317,7 +1317,7 @@ func (engine *DockerTaskEngine) startContainer(task *apitask.Task, container *ap
 	}
 	if execcmd.IsExecEnabledContainer(container) {
 		if ma, _ := container.GetManagedAgentByName(execcmd.ExecuteCommandAgentName); !ma.InitFailed {
-			reason := "Execute Command Agent started"
+			reason := "ExecuteCommandAgent started"
 			if err := engine.execCmdMgr.StartAgent(engine.ctx, engine.client, task, container, dockerID); err != nil {
 				reason = err.Error()
 				seelog.Errorf("Task engine [%s]: Failed to start ExecCommandAgent Process for container [%s]: %v", task.Arn, container.Name, err)

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -3244,7 +3244,7 @@ func TestStartExecAgent(t *testing.T) {
 		waitDone := make(chan struct{})
 		var reason string
 		if tc.expectContainerEvent {
-			reason = "Execute Command Agent started"
+			reason = "ExecuteCommandAgent started"
 		}
 		if tc.execAgentStartError != nil {
 			reason = tc.execAgentStartError.Error()
@@ -3371,7 +3371,7 @@ func TestMonitorExecAgentRunning(t *testing.T) {
 		expectedManagedAgent := apicontainer.ManagedAgent{
 			ManagedAgentState: apicontainer.ManagedAgentState{
 				Status: apicontainerstatus.ManagedAgentRunning,
-				Reason: "Execute Command Agent restarted",
+				Reason: "ExecuteCommandAgent restarted",
 			},
 		}
 		// only if we expect restart will we also expect a managed agent container event
@@ -3462,7 +3462,7 @@ func TestMonitorExecAgentProcesses(t *testing.T) {
 			Name: execcmd.ExecuteCommandAgentName,
 			ManagedAgentState: apicontainer.ManagedAgentState{
 				Status:        tc.execAgentStatus,
-				Reason:        "Execute Command Agent restarted",
+				Reason:        "ExecuteCommandAgent restarted",
 				LastStartedAt: nowTime,
 			},
 		}
@@ -3695,7 +3695,7 @@ func TestCreateContainerWithExecAgent(t *testing.T) {
 			waitDone := make(chan struct{})
 			var reason string
 			if tc.error != nil {
-				reason = fmt.Sprintf("Execute Command Agent Initialization failed - %v", tc.error)
+				reason = fmt.Sprintf("ExecuteCommandAgent Initialization failed - %v", tc.error)
 			}
 			expectedManagedAgent := apicontainer.ManagedAgent{
 				ManagedAgentState: apicontainer.ManagedAgentState{

--- a/agent/engine/execcmd/manager_start_linux.go
+++ b/agent/engine/execcmd/manager_start_linux.go
@@ -165,13 +165,13 @@ func (m *manager) doStartAgent(ctx context.Context, client dockerapi.DockerClien
 
 	err = client.StartContainerExec(ctx, execRes.ID, dockerclient.ContainerExecStartTimeout)
 	if err != nil {
-		return newMD, StartError{error: fmt.Errorf("unable to start Execute Command Agent [pre-start]: %v", err), retryable: true}
+		return newMD, StartError{error: fmt.Errorf("unable to start ExecuteCommandAgent [pre-start]: %v", err), retryable: true}
 	}
 	seelog.Debugf("Task engine [%s]: sent ExecCommandAgent start signal for container: %s ->  docker exec id: %s", task.Arn, containerId, execRes.ID)
 
 	inspect, err := client.InspectContainerExec(ctx, execRes.ID, dockerclient.ContainerExecInspectTimeout)
 	if err != nil {
-		return newMD, StartError{error: fmt.Errorf("unable to start Execute Command Agent [inspect]: %v", err), retryable: true}
+		return newMD, StartError{error: fmt.Errorf("unable to start ExecuteCommandAgent [inspect]: %v", err), retryable: true}
 	}
 	seelog.Debugf("Task engine [%s]: inspect ExecCommandAgent for container: %s -> pid: %d, exitCode: %d, running:%v, err:%v",
 		task.Arn, containerId, inspect.Pid, inspect.ExitCode, inspect.Running, err)

--- a/agent/engine/execcmd/manager_start_linux_test.go
+++ b/agent/engine/execcmd/manager_start_linux_test.go
@@ -103,7 +103,7 @@ func TestStartAgent(t *testing.T) {
 			expectStartContainerExec: true,
 			expectedStatus:           apicontainerstatus.ManagedAgentStopped,
 			startContainerExecErr:    mockError,
-			expectedError:            StartError{error: fmt.Errorf("unable to start Execute Command Agent [pre-start]: %v", mockError), retryable: true},
+			expectedError:            StartError{error: fmt.Errorf("unable to start ExecuteCommandAgent [pre-start]: %v", mockError), retryable: true},
 			expectedStartTime:        zeroTime,
 		},
 		{
@@ -119,7 +119,7 @@ func TestStartAgent(t *testing.T) {
 			expectInspectContainerExec: true,
 			expectedStatus:             apicontainerstatus.ManagedAgentStopped,
 			inspectContainerExecErr:    mockError,
-			expectedError:              StartError{error: fmt.Errorf("unable to start Execute Command Agent [inspect]: %v", mockError), retryable: true},
+			expectedError:              StartError{error: fmt.Errorf("unable to start ExecuteCommandAgent [inspect]: %v", mockError), retryable: true},
 			expectedStartTime:          zeroTime,
 		},
 		{


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
We have been using Execute Command Agent and ExecuteCommandAgent interchangeably. 
eg. 
```
"managedAgents": [
                        {
                            "lastStartedAt": "2021-01-07T17:36:31.644000+05:30",
                            "name": "ExecuteCommandAgent",
                            "reason": "Execute Command Agent started",
                            "lastStatus": "RUNNING"
                        }
], 

```
Making it all consistent to ExecuteCommandAgent

### Implementation details
s/Execute Command Agent/ExecuteCommandAgent/g

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: no

### Description for the changelog
N/A

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
