### PR TITLE
Introduce ErrorResponse to TMDEv4 taskWithTags responses

### DIFF
--- a/agent/handlers/v2/response.go
+++ b/agent/handlers/v2/response.go
@@ -16,6 +16,8 @@ package v2
 import (
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws/awserr"
+
 	"github.com/aws/amazon-ecs-agent/agent/api"
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apieni "github.com/aws/amazon-ecs-agent/agent/api/eni"
@@ -45,6 +47,7 @@ type TaskResponse struct {
 	TaskTags              map[string]string   `json:"TaskTags,omitempty"`
 	ContainerInstanceTags map[string]string   `json:"ContainerInstanceTags,omitempty"`
 	LaunchType            string              `json:"LaunchType,omitempty"`
+	Errors                []ErrorResponse     `json:"Errors,omitempty"`
 }
 
 // ContainerResponse defines the schema for the container response
@@ -78,6 +81,17 @@ type ContainerResponse struct {
 type LimitsResponse struct {
 	CPU    *float64 `json:"CPU,omitempty"`
 	Memory *int64   `json:"Memory,omitempty"`
+}
+
+// ErrorResponse defined the schema for error response
+// JSON object
+type ErrorResponse struct {
+	ErrorField   string `json:"ErrorField,omitempty"`
+	ErrorCode    string `json:"ErrorCode,omitempty"`
+	ErrorMessage string `json:"ErrorMessage,omitempty"`
+	StatusCode   int    `json:"StatusCode,omitempty"`
+	RequestId    string `json:"RequestId,omitempty"`
+	ResourceARN  string `json:"ResourceARN,omitempty"`
 }
 
 // NewTaskResponse creates a new response object for the task
@@ -144,21 +158,23 @@ func NewTaskResponse(
 	}
 
 	if propagateTags {
-		propagateTagsToMetadata(state, ecsClient, containerInstanceArn, taskARN, resp)
+		propagateTagsToMetadata(ecsClient, containerInstanceArn, taskARN, resp, includeV4Metadata)
 	}
 
 	return resp, nil
 }
 
-func propagateTagsToMetadata(state dockerstate.TaskEngineState, ecsClient api.ECSClient, containerInstanceArn, taskARN string, resp *TaskResponse) {
-	containerInstanceTags, err := ecsClient.GetResourceTags(containerInstanceArn)
+// propagateTagsToMetadata retrieves container instance and task tags from ECS
+func propagateTagsToMetadata(ecsClient api.ECSClient, containerInstanceARN, taskARN string, resp *TaskResponse, includeV4Metadata bool) {
+	containerInstanceTags, err := ecsClient.GetResourceTags(containerInstanceARN)
+
 	if err == nil {
 		resp.ContainerInstanceTags = make(map[string]string)
 		for _, tag := range containerInstanceTags {
 			resp.ContainerInstanceTags[*tag.Key] = *tag.Value
 		}
 	} else {
-		seelog.Errorf("Could not get container instance tags for %s: %s", containerInstanceArn, err.Error())
+		metadataErrorHandling(resp, err, "ContainerInstanceTags", containerInstanceARN, includeV4Metadata)
 	}
 
 	taskTags, err := ecsClient.GetResourceTags(taskARN)
@@ -168,7 +184,7 @@ func propagateTagsToMetadata(state dockerstate.TaskEngineState, ecsClient api.EC
 			resp.TaskTags[*tag.Key] = *tag.Value
 		}
 	} else {
-		seelog.Errorf("Could not get task tags for %s: %s", taskARN, err.Error())
+		metadataErrorHandling(resp, err, "TaskTags", taskARN, includeV4Metadata)
 	}
 }
 
@@ -271,4 +287,34 @@ func NewContainerResponse(
 
 	resp.Volumes = v1.NewVolumesResponse(dockerContainer)
 	return resp
+}
+
+// metadataErrorHandling writes an error to the logger, and append an error response
+// to V4 metadata endpoint task response
+func metadataErrorHandling(resp *TaskResponse, err error, field, resourceARN string, includeV4Metadata bool) {
+	seelog.Errorf("Task Metadata error: unable to get '%s' for '%s': %s", field, resourceARN, err.Error())
+	if includeV4Metadata {
+		errResp := newErrorResponse(err, field, resourceARN)
+		resp.Errors = append(resp.Errors, *errResp)
+	}
+}
+
+// newErrorResponse creates a new error response
+func newErrorResponse(err error, field, resourceARN string) *ErrorResponse {
+	errResp := &ErrorResponse{
+		ErrorField:   field,
+		ErrorMessage: err.Error(),
+		ResourceARN:  resourceARN,
+	}
+
+	if awsErr, ok := err.(awserr.Error); ok {
+		errResp.ErrorCode = awsErr.Code()
+		errResp.ErrorMessage = awsErr.Message()
+		if reqErr, ok := err.(awserr.RequestFailure); ok {
+			errResp.StatusCode = reqErr.StatusCode()
+			errResp.RequestId = reqErr.RequestID()
+		}
+	}
+
+	return errResp
 }

--- a/agent/handlers/v2/response_test.go
+++ b/agent/handlers/v2/response_test.go
@@ -30,8 +30,10 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
 	mock_dockerstate "github.com/aws/amazon-ecs-agent/agent/engine/dockerstate/mocks"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/docker/docker/api/types"
 	"github.com/golang/mock/gomock"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -561,4 +563,105 @@ func TestContainerResponseMarshal(t *testing.T) {
 	containerResponseMap := make(map[string]interface{})
 	json.Unmarshal(containerResponseJSON, &containerResponseMap)
 	assert.Equal(t, expectedContainerResponseMap, containerResponseMap)
+}
+
+func TestTaskResponseWithV4TagsError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	state := mock_dockerstate.NewMockTaskEngineState(ctrl)
+	ecsClient := mock_api.NewMockECSClient(ctrl)
+	now := time.Now()
+	task := &apitask.Task{
+		Arn:                 taskARN,
+		Family:              family,
+		Version:             version,
+		DesiredStatusUnsafe: apitaskstatus.TaskRunning,
+		KnownStatusUnsafe:   apitaskstatus.TaskRunning,
+		ENIs: []*apieni.ENI{
+			{
+				IPV4Addresses: []*apieni.ENIIPV4Address{
+					{
+						Address: eniIPv4Address,
+					},
+				},
+			},
+		},
+		CPU:                      cpu,
+		Memory:                   memory,
+		PullStartedAtUnsafe:      now,
+		PullStoppedAtUnsafe:      now,
+		ExecutionStoppedAtUnsafe: now,
+	}
+	container := &apicontainer.Container{
+		Name:                containerName,
+		Image:               imageName,
+		ImageID:             imageID,
+		DesiredStatusUnsafe: apicontainerstatus.ContainerRunning,
+		KnownStatusUnsafe:   apicontainerstatus.ContainerRunning,
+		CPU:                 cpu,
+		Memory:              memory,
+		Type:                apicontainer.ContainerNormal,
+		Ports: []apicontainer.PortBinding{
+			{
+				ContainerPort: 80,
+				Protocol:      apicontainer.TransportProtocolTCP,
+			},
+		},
+		VolumesUnsafe: []types.MountPoint{
+			{
+				Name:        volName,
+				Source:      volSource,
+				Destination: volDestination,
+			},
+		},
+		DockerConfig: apicontainer.DockerConfig{
+			HostConfig: aws.String(`{"LogConfig":{"Type":"awslogs","Config":{"awslogs-group":"myLogGroup"}}}`),
+		},
+	}
+	created := time.Now()
+	container.SetCreatedAt(created)
+	labels := map[string]string{
+		"foo": "bar",
+	}
+	container.SetLabels(labels)
+	containerNameToDockerContainer := map[string]*apicontainer.DockerContainer{
+		taskARN: {
+			DockerID:   containerID,
+			DockerName: containerName,
+			Container:  container,
+		},
+	}
+
+	errCode := "ThrottlingException"
+	errMessage := "Rate exceeded"
+	errStatusCode := 400
+	containerTagsRequestId := "cef9da77-aee7-431d-84d5-f92b2d342c51"
+	taskTagsRequestId := "45dbbc67-0c60-4248-855e-14fdf4c11870"
+	containerTagsErr := awserr.NewRequestFailure(awserr.Error(awserr.New(errCode, errMessage, errors.New(""))), errStatusCode, containerTagsRequestId)
+	taskTagsError := awserr.NewRequestFailure(awserr.Error(awserr.New(errCode, errMessage, errors.New(""))), errStatusCode, taskTagsRequestId)
+
+	gomock.InOrder(
+		state.EXPECT().TaskByArn(taskARN).Return(task, true),
+		state.EXPECT().ContainerMapByArn(taskARN).Return(containerNameToDockerContainer, true),
+		ecsClient.EXPECT().GetResourceTags(containerInstanceArn).Return(nil, containerTagsErr),
+		ecsClient.EXPECT().GetResourceTags(taskARN).Return(nil, taskTagsError),
+	)
+
+	taskWithTagsResponse, err := NewTaskResponse(taskARN, state, ecsClient, cluster, availabilityZone, containerInstanceArn, true, true)
+	assert.NoError(t, err)
+	_, err = json.Marshal(taskWithTagsResponse)
+	assert.NoError(t, err)
+	assert.Equal(t, taskWithTagsResponse.Errors[0].ErrorField, "ContainerInstanceTags")
+	assert.Equal(t, taskWithTagsResponse.Errors[0].ErrorCode, errCode)
+	assert.Equal(t, taskWithTagsResponse.Errors[0].ErrorMessage, errMessage)
+	assert.Equal(t, taskWithTagsResponse.Errors[0].StatusCode, errStatusCode)
+	assert.Equal(t, taskWithTagsResponse.Errors[0].RequestId, containerTagsRequestId)
+	assert.Equal(t, taskWithTagsResponse.Errors[0].ResourceARN, containerInstanceArn)
+	assert.Equal(t, taskWithTagsResponse.Errors[1].ErrorField, "TaskTags")
+	assert.Equal(t, taskWithTagsResponse.Errors[1].ErrorCode, errCode)
+	assert.Equal(t, taskWithTagsResponse.Errors[1].ErrorMessage, errMessage)
+	assert.Equal(t, taskWithTagsResponse.Errors[1].StatusCode, errStatusCode)
+	assert.Equal(t, taskWithTagsResponse.Errors[1].RequestId, taskTagsRequestId)
+	assert.Equal(t, taskWithTagsResponse.Errors[1].ResourceARN, taskARN)
 }


### PR DESCRIPTION
### Summary
This PR adds a new type `ErrorResponse` into the task metadata endpoint version 4 (TMDEv4) taskWithTags responses.  When the path `{ECS_CONTAINER_METADATA_URI_V4}/taskWithTag` is queried, Agent writes a json response with task metadata, task and container instance tags that can be retrieved from `ECS ListTagsForResource API`, and errors returned from the ECS API.

To date, Agent shows a partial/no list of tags in TMDEv2/v3/v4 taskWithTags responses if it cannot get a complete list of tags from ECS. As no error code, error message or status code is mentioned in responses, it hinders customers from differentiating whether there is no task/container tag, or an exception has been encountered. To resolve this issue, An ErrorResponse with an error field, an error code, an error message, a status code, a request ID and a resources ARN is introduced to TMDEv4 taskWithTags responses.

### Implementation details
1. Define ErrorResponse, the schema for an error response json object, and make it be part of the TaskResponse  
2. Pass the boolean flag `includeV4Metadata` to function `propagateTagsToMetadata` 
3. Append ErrorResponses to the TaskResponse if `includeV4Metadata` is true and an ErrorResponse exists
4. Define function `newErrorResponse` to return a new ErrorResponse object based on the error and the resource ARN
5. Define function `metadataErrorHandling` to format errors for ecs-agent.log, and call function `newErrorResponse` for TMDEv4 
  
### Testing
#### Unit tests
New tests cover the changes: yes
A new unit test TestTaskResponseWithV4TagsError is added to cover this change.
```
=== RUN   TestTaskResponseWithV4TagsError
1610057606730023000 [Error] V2 response: unable to get 'ContainerInstanceTags' for 'containerInstance-test': ThrottlingException: Rate exceeded status code: 400, request id: cef9da77-aee7-431d-84d5-f92b2d342c51
caused by: 
1610057606730063000 [Error] V2 response: unable to get 'TaskTags' for 't1': ThrottlingException: Rate exceeded status code: 400, request id: 45dbbc67-0c60-4248-855e-14fdf4c11870
caused by: 
--- PASS: TestTaskResponseWithV4TagsError (0.00s)
PASS
ok      github.com/aws/amazon-ecs-agent/agent/handlers/v2       0.832s
```

#### Manual tests
__TMDEv4 taskWithTags__
  
1. Response when no exception is hit
```
{
   "Cluster":"default",
   "TaskARN":"xxx",
   ...
   "TaskTags":{
      "SleeppyKey":"SleeppyValue",
      "SleepyKey":"SleepyValue",
      "SleepyKeyy":"SleepyValueee",
      "SleepyyKey":"SleepyyValue",
      "aws:ecs:clusterName":"default"
   },
   "ContainerInstanceTags":{
      "tag_key":"tag_value"
   },
   "LaunchType":"EC2",
   "Containers":[{...}]
}
```

2. Response when `ThrottlingException` is encountered for `TaskTags`  
```
{
   "Cluster":"default",
   "TaskARN":"xxx",
   "ContainerInstanceTags":{
      "tag_key":"tag_value"
   },
   "LaunchType":"EC2",
   "Errors":[
      {
         "ErrorField":"TaskTags",
         "ErrorCode":"ThrottlingException",
         "ErrorMessage":"Rate exceeded",
         "StatusCode":400,
         "RequestId":"xxx",
         "ResourceARN":"taskARN"
      }
   ],
   "Containers":[{...}]
}
```
ecs-agent.log
```
level=info time=xxx msg="V4 taskMetadata handler: Writing response for task 'taskARN'" module=task_metadata_handler.go
level=error time=xxx msg="Task Metadata error: unable to get 'TaskTags' for 'taskARN': ThrottlingException: Rate exceeded\n\tstatus code: 400, request id: xxx" module=response.go
```
  
3. Response when `AccessDeniedException` is encountered for both `ContainerInstanceTags` and `TaskTags`  
```
{
   "Cluster":"default",
   "TaskARN":"xxx",
   ...
   "LaunchType":"EC2",
   "Errors":[
      {
         "ErrorField":"ContainerInstanceTags",
         "ErrorCode":"AccessDeniedException",
         "ErrorMessage":"User: iamARN is not authorized to perform: ecs:ListTagsForResource on resource: containerInstanceARN",
         "StatusCode":400,
         "RequestId":"xxx",
         "ResourceARN":"containerInstanceARN"
      },
      {
         "ErrorField":"TaskTags",
         "ErrorCode":"AccessDeniedException",
         "ErrorMessage":"User: iamARN is not authorized to perform: ecs:ListTagsForResource on resource: taskARN",
         "StatusCode":400,
         "RequestId":"xxx",
         "ResourceARN":"taskARN"
      }
   ],
   "Containers":[{...}]
}
```
  
ecs-agent.log
```
level=info time=xxx msg="V4 taskMetadata handler: Writing response for task 'taskARN'" module=task_metadata_handler.go
level=error time=xxx msg="Task Metadata error: unable to get 'ContainerInstanceTags' for 'containerInstanceARN': AccessDeniedException: User: iamARN is not authorized to perform: ecs:ListTagsForResource on resource: containerInstanceARN" module=response.go
level=error time=xxx msg="Task Metadata error: unable to get 'TaskTags' for 'taskARN': AccessDeniedException: User: iamARN is not authorized to perform: ecs:ListTagsForResource on resource: taskARN" module=response.go
```
  
4. Response when `InvalidParameterException ` is encountered  for `TaskTags`   
```
{
   "Cluster":"default",
   "TaskARN":"xxx",
   ...
   "ContainerInstanceTags":{
      "tag_key":"tag_value"
   },
   "LaunchType":"EC2",
   "Errors":[
      {
         "ErrorField":"TaskTags",
         "ErrorCode":"InvalidParameterException",
         "ErrorMessage":"The specified task is stopped. Specify a running task and try again.",
         "StatusCode":400,
         "RequestId":"xxx",
         "ResourceARN":"taskARN"
      }
   ],
   "Containers":[{...}]
}
```
  
ecs-agent.log
```
level=info time=xxx msg="V4 taskMetadata handler: Writing response for task 'taskARN'" module=task_metadata_handler.go
level=error time=xxx msg="Task Metadata error: unable to get 'TaskTags' for 'taskARN': InvalidParameterException: The specified task is stopped. Specify a running task and try again." module=response.go
```
  
5. Response when a `non-awserr` is encountered  
```
{
   "Cluster":"default",
   "TaskARN":"xxx",
   ...
   "ContainerInstanceTags":{
      "tag_key":"tag_value"
   },
   "LaunchType":"EC2",
   "Errors":[
      {
         "ErrorField":"TaskTags",
         "ErrorMessage":"This is a non-awserr for testing: unable to find TaskTags for 'taskARN'",
         "ResourceARN":"taskARN"
      }
   ],
   "Containers":[{...}]
}
```
  
ecs-agent.log
```
level=info time=xxx msg="V4 taskMetadata handler: Writing response for task 'taskARN'" module=task_metadata_handler.go
level=error time=xxx msg="Task Metadata error: unable to get 'TaskTags' for 'taskARN': This is a non-awserr for testing: unable to find TaskTags for 'taskARN'" module=response.go
```    
  
__TMDEv3 taskWithTags__
  
1. Response when no exception is hit
```
{
   "Cluster":"default",
   "TaskARN":"xxx",
   ...
   "Containers":[{...}]
   ... 
   "TaskTags":{
      "SleeppyKey":"SleeppyValue",
      "SleepyKey":"SleepyValue",
      "SleepyKeyy":"SleepyValueee",
      "SleepyyKey":"SleepyyValue",
      "aws:ecs:clusterName":"default"
   },
   "ContainerInstanceTags":{
      "tag_key":"tag_value"
   }
}
```
  
2. ecs-agent.log when `ThrottlingException` is encountered  for `ContainerInstanceTags`  
```
level=info time=xxx msg="V3 task metadata handler: writing response for task 'taskARN'" module=task_metadata_handler.go
level=error time=xxx msg="Task Metadata error: unable to get 'ContainerInstanceTags' for 'containerInstanceARN': ThrottlingException: Rate exceeded\n\tstatus code: 400, request id: xxx" module=response.go
```
  
3. ecs-agent.log when `AccessDeniedException` is encountered  for both `ContainerInstanceTags` and `TaskTags`  
```
level=info time=xxx msg="V3 task metadata handler: writing response for task 'taskARN'" module=task_metadata_handler.go
level=error time=xxx msg="Task Metadata error: unable to get 'ContainerInstanceTags' for 'containerInstanceARN': AccessDeniedException: User: iamARN is not authorized to perform: ecs:ListTagsForResource on resource: containerInstanceARN" module=response.go
level=error time=xxx msg="Task Metadata error: unable to get 'TaskTags' for 'taskARN': AccessDeniedException: User:iamARN is not authorized to perform: ecs:ListTagsForResource on resource: taskARN" module=response.go
```
  
4. ecs-agent.log when `InvalidParameterException ` is encountered  for `TaskTags` 
```
level=info time=xxx msg="V3 task metadata handler: writing response for task 'taskARN'" module=task_metadata_handler.go
level=error time=xxx msg="Task Metadata error: unable to get 'TaskTags' for 'taskARN': InvalidParameterException: The specified task is stopped. Specify a running task and try again." module=response.go
```
  
5. ecs-agent.log when a `non-awserr` is encountered  
```
level=info time=xxx msg="V3 task metadata handler: writing response for task 'taskARN'" module=task_metadata_handler.go
level=error time=xxx msg="Task Metadata error: unable to get 'TaskTags' for 'taskARN': This is a non-awserr for testing: unable to find TaskTags for 'taskARN'" module=response.go
```
  
### Description for the changelog

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
