### PR TITLE
Run ssm-agent as root user

### DIFF
--- a/agent/engine/engine_unix_integ_test.go
+++ b/agent/engine/engine_unix_integ_test.go
@@ -1001,6 +1001,7 @@ func TestDockerExecAPI(t *testing.T) {
 		A,
 	}
 	execConfig := types.ExecConfig{
+		User:   "0",
 		Detach: true,
 		Cmd:    []string{"ls"},
 	}

--- a/agent/engine/execcmd/manager_start_linux.go
+++ b/agent/engine/execcmd/manager_start_linux.go
@@ -152,6 +152,7 @@ func (m *manager) doStartAgent(ctx context.Context, client dockerapi.DockerClien
 	execAgentCmdBinDir := ContainerDepsDirPrefix + ma.ID
 	execAgentCmd := filepath.Join(execAgentCmdBinDir, SSMAgentBinName)
 	execCfg := types.ExecConfig{
+		User:   "0",
 		Detach: true,
 		Cmd:    []string{execAgentCmd},
 	}

--- a/agent/engine/execcmd/manager_start_linux_test.go
+++ b/agent/engine/execcmd/manager_start_linux_test.go
@@ -176,6 +176,7 @@ func TestStartAgent(t *testing.T) {
 			}
 			if test.expectCreateContainerExec {
 				execCfg := types.ExecConfig{
+					User:   "0",
 					Detach: true,
 					Cmd:    []string{"/ecs-execute-command-test-uid/amazon-ssm-agent"},
 				}
@@ -259,6 +260,7 @@ func TestIdempotentStartAgent(t *testing.T) {
 	}
 
 	execCfg := types.ExecConfig{
+		User:   "0",
 		Detach: true,
 		Cmd:    []string{"/ecs-execute-command-test-uid/amazon-ssm-agent"},
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This PR runs ssm-agent inside exec-enabled container as root user.
Before this change, a task definiton like below where a user is mentioned, would not be able to start the ssm-agent inside container. This happens because ssm-agent needs to runAs root user.

```
{
  "family": "exec-task",
  "containerDefinitions": [
    {
      "image": "busybox",
      "user": "1337",
      "name": "sleepy",
      "cpu": 80,
      "memory": 80,
      "command": [
        "sh",
        "-c",
        "sleep 3000"
      ],
      "essential": true
    }
  ],
  "taskRoleArn": "arn:aws:iam::****:role/ExecTaskRole"
}
```
### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Unit tests cover the change.

I tested that with this change, ssm agent could succesfully start and I could start a session on the container

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
