### PR TITLE
container stats: ignore context.Canceled errors

### DIFF
--- a/agent/stats/container.go
+++ b/agent/stats/container.go
@@ -118,8 +118,13 @@ func (container *StatsContainer) processStatsStream() error {
 		case <-container.ctx.Done():
 			return nil
 		case err := <-errC:
-			seelog.Warnf("Error encountered processing metrics stream from docker, this may affect cloudwatch metric accuracy: %s", err)
-			returnError = true
+			select {
+			case <-container.ctx.Done():
+				// ignore error when container.ctx.Done()
+			default:
+				seelog.Warnf("Error encountered processing metrics stream from docker, this may affect cloudwatch metric accuracy: %s", err)
+				returnError = true
+			}
 		case rawStat, ok := <-dockerStats:
 			if !ok {
 				if returnError {


### PR DESCRIPTION
we often receive context.Canceled errors when a container exits during
docker stats collection.

there is a benign race condition where if we process the error first
before processing that the context is "Done", then we will log this
canceled error as a warning message here:
https://github.com/aws/amazon-ecs-agent/blob/5be7aa08bed215a557f48c16d8201ad3db59a9be/agent/stats/container.go#L118-L122

this change ignores these context.Canceled errors so that we don't log
them. This will eliminate log messages that look like this when a
container exits:

level=warn time=2020-12-25T07:51:33Z msg="Error encountered processing metrics stream from docker, this may affect cloudwatch metric accuracy: DockerGoClient: Unable to decode stats for container REDACTED: context canceled" module=container.go

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

Tested by running a large number of tasks with lots of container and task state changes and exits. Before this change I was seeing the log message around 20% of the time that containers exited. After the change I do not see this message.

New tests cover the changes: no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

enhancement: eliminate benign docker stats "context canceled" warning messages from logs

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
