### PR TITLE
Fix bug where pause container was not always cleaned up

### DIFF
--- a/agent/api/container/container.go
+++ b/agent/api/container/container.go
@@ -301,6 +301,10 @@ type Container struct {
 	// ContainerArn is the Arn of this container.
 	ContainerArn string `json:"ContainerArn,omitempty"`
 
+	// ContainerTornDownUnsafe is set to true when we have cleaned up this container. For now this is only used for the
+	// pause container
+	ContainerTornDownUnsafe bool `json:"containerTornDown"`
+
 	createdAt  time.Time
 	startedAt  time.Time
 	finishedAt time.Time
@@ -1307,4 +1311,16 @@ func (c *Container) GetManagedAgentSentStatus(agentName string) apicontainerstat
 	}
 	// we shouldn't get here because we'll always have a valid ManagedAgentName
 	return apicontainerstatus.ManagedAgentStatusNone
+}
+
+func (c *Container) SetContainerTornDown(td bool) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.ContainerTornDownUnsafe = td
+}
+
+func (c *Container) IsContainerTornDown() bool {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.ContainerTornDownUnsafe
 }

--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -236,6 +236,7 @@ func (mtask *managedTask) overseeTask() {
 	logger.Info("Managed task has reached stopped; waiting for container cleanup", logger.Fields{
 		field.TaskARN: mtask.Arn,
 	})
+	mtask.engine.checkTearDownPauseContainer(mtask.Task)
 	mtask.cleanupCredentials()
 	if mtask.StopSequenceNumber != 0 {
 		logger.Debug("Marking done for this sequence", logger.Fields{


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This fixes a bug that can prevent the pause container network to be cleaned up when ECS Agent is restarted due to `dockerd` restarts. Failing to clean the pause container network might cause issues for future tasks to start.

When `dockerd` is restarted, all running containers (along with ECS Agent) are stopped. After `dockerd` and ECS Agent restart successfully, the latter proceeds to stop all the tasks that were running previous to the restart since it realizes the respective containers are no longer running. When this happens, the pause container network is not cleaned up since the workflow is different to the normal operations. 


### Implementation details
<!-- How are the changes implemented? -->

Do a check after the managed tasks is stopped to see if the pause container still needs to be cleaned up. Most of the times the pause container has already been cleaned up by the time the managed task stops, but as mentioned above, there are scenarios where this might not happen. 

Since now we are invoking container cleanup in more than one place (previously it only happened in `stopContainer` method), the operation was made idempotent by storing a flag in the container to indicate whether that container was torn down. 
For now that flag is only used for the pause container, but might be useful for other containers that need explicit teardown in the future.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

There are a number of unit and integration tests that check for proper pause container cleanup. Those tests should still pass since the previous logic is not modified and a few new assertions are added to check if the new tear down flag was set.

In addition, manually tested that pause container network is cleaned under normal circumstances as well as after docker restarts.

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Fix bug where pause container was not always cleaned up
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
