### PR TITLE
Change amazon dockerhub images to public.ecr.aws, replace gcr ref

### DIFF
--- a/agent/engine/engine_sudo_linux_integ_test.go
+++ b/agent/engine/engine_sudo_linux_integ_test.go
@@ -74,8 +74,8 @@ var (
 )
 
 const (
-	testLogSenderImage           = "amazonlinux:2.0.20200722.0"
-	testFluentbitImage           = "amazon/aws-for-fluent-bit:2.9.0"
+	testLogSenderImage           = "public.ecr.aws/amazonlinux/amazonlinux:2.0.20210126.0"
+	testFluentbitImage           = "public.ecr.aws/aws-observability/aws-for-fluent-bit:2.10.1"
 	testVolumeImage              = "127.0.0.1:51670/amazon/amazon-ecs-volumes-test:latest"
 	testCluster                  = "testCluster"
 	validTaskArnPrefix           = "arn:aws:ecs:region:account-id:task/"

--- a/agent/engine/engine_unix_integ_test.go
+++ b/agent/engine/engine_unix_integ_test.go
@@ -196,7 +196,7 @@ func TestStartStopUnpulledImage(t *testing.T) {
 // TestStartStopUnpulledImageDigest ensures that an unpulled image with
 // specified digest is successfully pulled, run, and stopped via docker.
 func TestStartStopUnpulledImageDigest(t *testing.T) {
-	imageDigest := "gcr.io/distroless/python3@sha256:5a82acd4e6ece3978aa58b931699166b1e19e2d3121fceb9238b6356ea5bebaa"
+	imageDigest := "public.ecr.aws/amazonlinux/amazonlinux@sha256:1b6599b4846a765106350130125e2480f6c1cb7791df0ce3e59410362f311259"
 	taskEngine, done, _ := setupWithDefaultConfig(t)
 	defer done()
 	// Ensure this image isn't pulled by deleting it

--- a/scripts/ci-ecr
+++ b/scripts/ci-ecr
@@ -1,11 +1,11 @@
 dir=$(dirname "${BASH_SOURCE[0]}")
 GO_VERSION=$(cat "$dir/../GO_VERSION")
+GO_VERSION_WINDOWS=$(cat "$dir/../GO_VERSION_WINDOWS")
 
 IMAGES="registry:2.7.0
 golang:$GO_VERSION
+golang:$GO_VERSION_WINDOWS
 gcc:7.3.0
 busybox:1.32.0
-amazonlinux:2.0.20200722.0
-amazon/aws-for-fluent-bit:2.9.0
 debian:stable-20201012
 fluent/fluentd:v1.11.5-1.0"


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

change amazon-owned container images from dockerhub to public.ecr.aws

change gcr container image to public.ecr.aws amazonlinux image.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

NA

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
