### PR TITLE
Modify Windows OS family types to support platform version in task definitions

### DIFF
--- a/agent/api/ecsclient/client.go
+++ b/agent/api/ecsclient/client.go
@@ -325,10 +325,12 @@ func validateRegisteredAttributes(expectedAttributes, actualAttributes []*ecs.At
 }
 
 func (client *APIECSClient) getAdditionalAttributes() []*ecs.Attribute {
+	osFamilyStr := config.GetWindowsOSFamilyType()
+	seelog.Infof("Server OSFamily string: %s", osFamilyStr)
 	return []*ecs.Attribute{
 		{
 			Name:  aws.String("ecs.os-type"),
-			Value: aws.String(config.OSType),
+			Value: aws.String(osFamilyStr),
 		},
 	}
 }

--- a/agent/config/parse_linux.go
+++ b/agent/config/parse_linux.go
@@ -22,3 +22,7 @@ func parseGMSACapability() bool {
 func parseFSxWindowsFileServerCapability() bool {
 	return false
 }
+
+func GetWindowsOSFamilyType() string {
+	return config.OSType
+}

--- a/agent/config/parse_unsupported.go
+++ b/agent/config/parse_unsupported.go
@@ -22,3 +22,7 @@ func parseGMSACapability() bool {
 func parseFSxWindowsFileServerCapability() bool {
 	return false
 }
+
+func GetWindowsOSFamilyType() string {
+	return config.OSType
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This is currently an internal change of generating the correct Windows OS family types, which will be reflected to front end and PV support in task definitions once other changes are made.

### Implementation details
<!-- How are the changes implemented? -->
A shared API GetWindowsOSFamilyType() is defined in config package to generate Windows OS family types strings. It does not have impact on Linux by keeping its original behavior.

### Testing
<!-- How was this tested? -->
Windows binary has been built for the changes. It is being tested on ECS clusters with all supported OS family types. The ECS service is running fine and the log info shows the expected Windows OS family type strings.

<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Feature - Modify Windows OS family types to support platform version in task definitions.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
