### PR TITLE
Modify Windows OS family types to support platform version in task definitions

### DIFF
--- a/agent/api/ecsclient/client.go
+++ b/agent/api/ecsclient/client.go
@@ -325,10 +325,12 @@ func validateRegisteredAttributes(expectedAttributes, actualAttributes []*ecs.At
 }
 
 func (client *APIECSClient) getAdditionalAttributes() []*ecs.Attribute {
+	osFamilyStr := config.GetOSFamilyType()
+	seelog.Infof("Server OSFamily string: %s", osFamilyStr)
 	return []*ecs.Attribute{
 		{
 			Name:  aws.String("ecs.os-type"),
-			Value: aws.String(config.OSType),
+			Value: aws.String(osFamilyStr),
 		},
 	}
 }

--- a/agent/api/ecsclient/client_test.go
+++ b/agent/api/ecsclient/client_test.go
@@ -347,7 +347,7 @@ func TestReRegisterContainerInstance(t *testing.T) {
 
 	fakeCapabilities := []string{"capability1", "capability2"}
 	expectedAttributes := map[string]string{
-		"ecs.os-type":           config.OSType,
+		"ecs.os-type":           config.GetOSFamilyType(),
 		"ecs.availability-zone": "us-west-2b",
 		"ecs.outpost-arn":       "test:arn:outpost",
 	}
@@ -415,7 +415,7 @@ func TestRegisterContainerInstance(t *testing.T) {
 
 	fakeCapabilities := []string{"capability1", "capability2"}
 	expectedAttributes := map[string]string{
-		"ecs.os-type":               config.OSType,
+		"ecs.os-type":               config.GetOSFamilyType(),
 		"my_custom_attribute":       "Custom_Value1",
 		"my_other_custom_attribute": "Custom_Value2",
 		"ecs.availability-zone":     "us-west-2b",
@@ -497,7 +497,7 @@ func TestRegisterContainerInstanceNoIID(t *testing.T) {
 
 	fakeCapabilities := []string{"capability1", "capability2"}
 	expectedAttributes := map[string]string{
-		"ecs.os-type":               config.OSType,
+		"ecs.os-type":               config.GetOSFamilyType(),
 		"my_custom_attribute":       "Custom_Value1",
 		"my_other_custom_attribute": "Custom_Value2",
 		"ecs.availability-zone":     "us-west-2b",
@@ -578,7 +578,7 @@ func TestRegisterContainerInstanceWithEmptyTags(t *testing.T) {
 	client, mc, _ := NewMockClient(mockCtrl, mockEC2Metadata, nil)
 
 	expectedAttributes := map[string]string{
-		"ecs.os-type":               config.OSType,
+		"ecs.os-type":               config.GetOSFamilyType(),
 		"my_custom_attribute":       "Custom_Value1",
 		"my_other_custom_attribute": "Custom_Value2",
 	}
@@ -645,7 +645,7 @@ func TestRegisterBlankCluster(t *testing.T) {
 	client.(*APIECSClient).SetSDK(mc)
 
 	expectedAttributes := map[string]string{
-		"ecs.os-type": config.OSType,
+		"ecs.os-type": config.GetOSFamilyType(),
 	}
 	defaultCluster := config.DefaultClusterName
 	gomock.InOrder(
@@ -701,7 +701,7 @@ func TestRegisterBlankClusterNotCreatingClusterWhenErrorNotClusterNotFound(t *te
 	client.(*APIECSClient).SetSDK(mc)
 
 	expectedAttributes := map[string]string{
-		"ecs.os-type": config.OSType,
+		"ecs.os-type": config.GetOSFamilyType(),
 	}
 
 	gomock.InOrder(

--- a/agent/config/parse_linux.go
+++ b/agent/config/parse_linux.go
@@ -22,3 +22,7 @@ func parseGMSACapability() bool {
 func parseFSxWindowsFileServerCapability() bool {
 	return false
 }
+
+func GetOSFamilyType() string {
+	return OSType
+}

--- a/agent/config/parse_unsupported.go
+++ b/agent/config/parse_unsupported.go
@@ -22,3 +22,7 @@ func parseGMSACapability() bool {
 func parseFSxWindowsFileServerCapability() bool {
 	return false
 }
+
+func GetOSFamilyType() string {
+	return OSType
+}

--- a/agent/config/parse_windows.go
+++ b/agent/config/parse_windows.go
@@ -16,15 +16,15 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"strings"
 	"syscall"
 	"unsafe"
 
-	"golang.org/x/sys/windows/registry"
-
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 	"github.com/cihub/seelog"
+	"golang.org/x/sys/windows/registry"
 )
 
 const (
@@ -32,6 +32,16 @@ const (
 	// domain join check validation. This is useful for integration and
 	// functional-tests but should not be set for any non-test use-case.
 	envSkipDomainJoinCheck = "ZZZ_SKIP_DOMAIN_JOIN_CHECK_NOT_SUPPORTED_IN_PRODUCTION"
+
+	// The following constants are used to generate Windows OS family types
+	ReleaseId2004SAC          = "2004"
+	ReleaseId1909SAC          = "1909"
+	Windows_Server_2019       = "Windows Server 2019"
+	Windows_Server_2016       = "Windows Server 2016"
+	Windows_Server_DataCenter = "Windows Server Datacenter"
+	InstallationTypeCore      = "Server Core"
+	InstallationTypeFull      = "Server"
+	UnknownOSType             = "unknown"
 )
 
 // parseGMSACapability is used to determine if gMSA support can be enabled
@@ -112,4 +122,62 @@ var isWindows2016 = func() (bool, error) {
 	}
 
 	return false, nil
+}
+
+func getInstallationType(installationType string) (string, error) {
+	if strings.Compare(installationType, InstallationTypeFull) == 0 {
+		return "FULL", nil
+	} else if strings.Compare(installationType, InstallationTypeCore) == 0 {
+		return "CORE", nil
+	} else {
+		err := seelog.Errorf("Invalid Installation type")
+		return "", err
+	}
+}
+
+func GetOSFamilyType() string {
+	osTypeFormat := "WINDOWS_SERVER_%s_%s"
+	key, err := registry.OpenKey(registry.LOCAL_MACHINE, `SOFTWARE\Microsoft\Windows NT\CurrentVersion`, registry.QUERY_VALUE)
+	if err != nil {
+		seelog.Errorf("Unable to open Windows registry key to determine Windows version: %v", err)
+		return UnknownOSType
+	}
+	defer key.Close()
+
+	productName, _, err := key.GetStringValue("ProductName")
+	if err != nil {
+		seelog.Errorf("Unable to read registry key, ProductName: %v", err)
+		return UnknownOSType
+	}
+	installationType, _, err := key.GetStringValue("InstallationType")
+	if err != nil {
+		seelog.Errorf("Unable to read registry key, InstallationType: %v", err)
+		return UnknownOSType
+	}
+	iType, err := getInstallationType(installationType)
+	if err != nil {
+		seelog.Errorf("Invalid Installation type found: %v", err)
+		return UnknownOSType
+	}
+	releaseId, _, err := key.GetStringValue("ReleaseId")
+	if err != nil {
+		seelog.Errorf("Unable to read registry key, ReleaseId: %v", err)
+		return UnknownOSType
+	}
+
+	if strings.HasPrefix(productName, Windows_Server_2019) {
+		osTypeFormat = fmt.Sprintf(osTypeFormat, "2019", iType)
+	} else if strings.HasPrefix(productName, Windows_Server_2016) {
+		osTypeFormat = fmt.Sprintf(osTypeFormat, "2016", iType)
+	} else if strings.HasPrefix(productName, Windows_Server_DataCenter) {
+		if strings.Compare(releaseId, ReleaseId2004SAC) == 0 {
+			osTypeFormat = fmt.Sprintf(osTypeFormat, ReleaseId2004SAC, iType)
+		} else if strings.Compare(releaseId, ReleaseId1909SAC) == 0 {
+			osTypeFormat = fmt.Sprintf(osTypeFormat, ReleaseId1909SAC, iType)
+		}
+	} else {
+		seelog.Errorf("Invalid productName found in the registry with value: %v", productName)
+		return UnknownOSType
+	}
+	return osTypeFormat
 }

--- a/agent/config/parse_windows_test.go
+++ b/agent/config/parse_windows_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/windows/registry"
 )
 
 func TestParseGMSACapability(t *testing.T) {
@@ -49,4 +50,28 @@ func TestParseFSxWindowsFileServerCapability(t *testing.T) {
 	defer os.Unsetenv("ECS_FSX_WINDOWS_FILE_SERVER_SUPPORTED")
 
 	assert.False(t, parseFSxWindowsFileServerCapability())
+}
+
+func TestGetOSFamilyType(t *testing.T) {
+	key, _ := registry.OpenKey(registry.LOCAL_MACHINE, `SOFTWARE\Microsoft\Windows NT\CurrentVersion`, registry.WRITE)
+	defer key.Close()
+	key.SetStringValue("ProductName", "Windows Server 2019 Datacenter")
+	key.SetStringValue("InstallationType", "Server Core")
+	key.SetStringValue("ReleaseId", "1809")
+	assert.Equal(t, "WINDOWS_SERVER_2019_CORE", GetOSFamilyType())
+
+	key.SetStringValue("ProductName", "Windows Server Datacenter")
+	key.SetStringValue("InstallationType", "Server Core")
+	key.SetStringValue("ReleaseId", "2004")
+	assert.Equal(t, "WINDOWS_SERVER_2004_CORE", GetOSFamilyType())
+
+	key.SetStringValue("ProductName", "Windows Server 2016 Datacenter")
+	key.SetStringValue("InstallationType", "Server")
+	key.SetStringValue("ReleaseId", "1607")
+	assert.Equal(t, "WINDOWS_SERVER_2016_FULL", GetOSFamilyType())
+
+	key.SetStringValue("ProductName", "Windows Server 2019 Datacenter")
+	key.SetStringValue("InstallationType", "Server")
+	key.SetStringValue("ReleaseId", "1809")
+	assert.Equal(t, "WINDOWS_SERVER_2019_FULL", GetOSFamilyType())
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This is currently an internal change of generating the correct Windows OS family types, which will be reflected to front end and PV support in task definitions once other changes are made.

### Implementation details
<!-- How are the changes implemented? -->
A shared API GetOSFamilyType() is defined in config package to generate Windows OS family types strings. It does not have impact on Linux by keeping its original behavior.

### Testing
<!-- How was this tested? -->
Windows binary has been built for the changes. It is being tested on ECS clusters with all supported OS family types. The ECS service is running fine and the log info shows the expected Windows OS family type strings.

<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: No

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Feature - Modify Windows OS family types to support platform version in task definitions.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
