### PR TITLE
Add ecs-agent container healthcheck localhost ip override env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ additional details on each available environment variable.
 | `ECS_ENABLE_TASK_CPU_MEM_LIMIT` | `true` | Whether to enable task-level cpu and memory limits | `true` | `false` |
 | `ECS_CGROUP_PATH` | `/sys/fs/cgroup` | The root cgroup path that is expected by the ECS agent. This is the path that accessible from the agent mount. | `/sys/fs/cgroup` | Not applicable |
 | `ECS_CGROUP_CPU_PERIOD` | `10ms` | CGroups CPU period for task level limits. This value should be between 8ms to 100ms | `100ms` | Not applicable |
+| `ECS_AGENT_HEALTHCHECK_HOST` | `localhost` | Override for the ecs-agent container's healthcheck localhost ip address| `localhost` | `localhost` |
 | `ECS_ENABLE_CPU_UNBOUNDED_WINDOWS_WORKAROUND` | `true` | When `true`, ECS will allow CPU unbounded(CPU=`0`) tasks to run along with CPU bounded tasks in Windows. | Not applicable | `false` |
 | `ECS_ENABLE_MEMORY_UNBOUNDED_WINDOWS_WORKAROUND` | `true` | When `true`, ECS will ignore the memory reservation parameter (soft limit) to run along with memory bounded tasks in Windows. To run a memory unbounded task, omit the memory hard limit and set any memory reservation, it will be ignored. | Not applicable | `false` |
 | `ECS_TASK_METADATA_RPS_LIMIT` | `100,150` | Comma separated integer values for steady state and burst throttle limits for task metadata endpoint | `40,60` | `40,60` |


### PR DESCRIPTION
### Summary
This change allows IP configuration for the ecs-agent container's docker healthcheck localhost IP to address a specific case where the customer has overridden the `localhost` ip explicitly.  

### Implementation details
Currently, as the agent container is launched in host network mode, when the localhost inside the scratch-based agent container does not resolve to that the same IP, the agent container healthcheck will always return 'unhealthy'.
This change allows the localhost IP to be explicitly set to either the host localhost ip (usually 127.0.0.1) or otherwise based on DNS resolution requirements.

### Testing
I built the agent and tested the following manually:
start agent the environment variable unset -- agent container became healthy
set ECS_AGENT_HEALTHCHECK_HOST=localhost -- agent container became healthy
set ECS_AGENT_HEALTHCHECK_HOST=127.0.0.1 -- agent container became healthy
set ECS_AGENT_HEALTHCHECK_HOST=80.80.80.80 -- agent container became unhealthy.

New tests cover the changes: no

### Description for the changelog
Add configurable agent healthcheck localhost ip env var.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
