### PR TITLE
omit pause container network metrics

### DIFF
--- a/agent/stats/engine.go
+++ b/agent/stats/engine.go
@@ -697,17 +697,23 @@ func (engine *DockerStatsEngine) taskContainerMetricsUnsafe(taskArn string) ([]*
 				if !taskExistsInTaskStats {
 					return nil, fmt.Errorf("task not found")
 				}
-				networkStats, err := taskStatsMap.StatsQueue.GetNetworkStatsSet()
-				if err != nil {
-					seelog.Warnf("error getting network stats: %v, task: %v", err, taskArn)
+				if dockerContainer, err := engine.resolver.ResolveContainer(dockerID); err != nil {
+					seelog.Debugf("Could not map container ID to container, container: %s, err: %s", dockerID, err)
 				} else {
-					containerMetric.NetworkStatsSet = networkStats
+					// do not add network stats for pause container
+					if dockerContainer.Container.Type != apicontainer.ContainerCNIPause {
+						networkStats, err := taskStatsMap.StatsQueue.GetNetworkStatsSet()
+						if err != nil {
+							seelog.Warnf("error getting network stats: %v, task: %v", err, taskArn)
+						} else {
+							containerMetric.NetworkStatsSet = networkStats
+						}
+					}
 				}
 			}
 		}
 		containerMetrics = append(containerMetrics, containerMetric)
 	}
-
 	return containerMetrics, nil
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
For awsvpc network mode, we obtain the network metrics of the task's network interface and divide that equally among other containers in the task excluding the pause container https://github.com/aws/amazon-ecs-agent/blob/2874131a5f3d1c0908e0f2ebad62e48b8ff5850f/agent/stats/engine.go#L273 

But it was observed that pause container was still included in the final network metrics calculation leading to incorrect total task's network stats. 
This PR fixes it. 

### Implementation details
do not add network stats to the container if its the pause container 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

manual testing: 

before changes:
```
ContainerName: "~internal~ecs~pause",
          CpuStatsSet: {
            Max: 0,
            Min: 0,
            SampleCount: 20,
            Sum: 0
          },
          MemoryStatsSet: {
            Max: 0,
            Min: 0,
            SampleCount: 20,
            Sum: 0
          },
          NetworkStatsSet: {
            RxBytes: {
              Max: 1558,
              Min: 1438,
              OverflowMax: 0,
              OverflowMin: 0,
              OverflowSum: 0,
              SampleCount: 14,
              Sum: 21212
            },
            RxBytesPerSecond: {
              Max: 5.999998092651367,
              Min: 0,
              SampleCount: 13,
              Sum: 11.999961853027344
            },
            RxDropped: {
              Max: 0,
              Min: 0,
              OverflowMax: 0,
              OverflowMin: 0,
              OverflowSum: 0,
              SampleCount: 14,
              Sum: 0
            },
.....
```

after changes:
```
ContainerName: "~internal~ecs~pause",
          CpuStatsSet: {
            Max: 0,
            Min: 0,
            SampleCount: 20,
            Sum: 0
          },
          MemoryStatsSet: {
            Max: 0,
            Min: 0,
            SampleCount: 20,
            Sum: 0
          },
          StorageStatsSet: {
            ReadSizeBytes: {
              Max: 0,
.....
```

New tests cover the changes: yes 

### Description for the changelog
Bug - Fix task's network stats by omitting pause container in the network metrics calculation. 

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
