### PR TITLE
ECS agent to acknowledge server heartbeat messages

### DIFF
--- a/agent/acs/client/acs_client_types.go
+++ b/agent/acs/client/acs_client_types.go
@@ -30,6 +30,7 @@ func init() {
 	// the .json model or the generated struct names.
 	acsRecognizedTypes = []interface{}{
 		ecsacs.HeartbeatMessage{},
+		ecsacs.HeartbeatAckRequest{},
 		ecsacs.PayloadMessage{},
 		ecsacs.CloseMessage{},
 		ecsacs.AckRequest{},

--- a/agent/acs/handler/heartbeat_handler.go
+++ b/agent/acs/handler/heartbeat_handler.go
@@ -1,0 +1,118 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package handler
+
+import (
+	"context"
+
+	"github.com/aws/amazon-ecs-agent/agent/acs/model/ecsacs"
+	"github.com/aws/amazon-ecs-agent/agent/wsclient"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/cihub/seelog"
+)
+
+// heartbeatHandler handles heartbeat messages from ACS
+type heartbeatHandler struct {
+	heartbeatMessageBuffer    chan *ecsacs.HeartbeatMessage
+	heartbeatAckMessageBuffer chan *ecsacs.HeartbeatAckRequest
+	ctx                       context.Context
+	cancel                    context.CancelFunc
+	acsClient                 wsclient.ClientServer
+}
+
+// newHeartbeatHandler returns an instance of the heartbeatHandler struct
+func newHeartbeatHandler(ctx context.Context,
+	acsClient wsclient.ClientServer) heartbeatHandler {
+
+	// Create a cancelable context from the parent context
+	derivedContext, cancel := context.WithCancel(ctx)
+	return heartbeatHandler{
+		heartbeatMessageBuffer:    make(chan *ecsacs.HeartbeatMessage),
+		heartbeatAckMessageBuffer: make(chan *ecsacs.HeartbeatAckRequest),
+		ctx:                       derivedContext,
+		cancel:                    cancel,
+		acsClient:                 acsClient,
+	}
+}
+
+// handlerFunc returns a function to enqueue requests onto the buffer
+func (heartbeatHandler *heartbeatHandler) handlerFunc() func(message *ecsacs.HeartbeatMessage) {
+	return func(message *ecsacs.HeartbeatMessage) {
+		heartbeatHandler.heartbeatMessageBuffer <- message
+	}
+}
+
+// start() invokes go routines to handle receive and respond to heartbeats
+func (heartbeatHandler *heartbeatHandler) start() {
+	go heartbeatHandler.handleHeartbeatMessage()
+	go heartbeatHandler.sendHeartbeatAck()
+}
+
+func (heartbeatHandler *heartbeatHandler) handleHeartbeatMessage() {
+	for {
+		select {
+		case message := <-heartbeatHandler.heartbeatMessageBuffer:
+			if err := heartbeatHandler.handleSingleHeartbeatMessage(message); err != nil {
+				seelog.Warnf("Unable to handle heartbeat message [%s]: %s", message.String(), err)
+			}
+		case <-heartbeatHandler.ctx.Done():
+			return
+		}
+	}
+}
+
+func (heartbeatHandler *heartbeatHandler) handleSingleHeartbeatMessage(message *ecsacs.HeartbeatMessage) error {
+	// Agent currently has no other action hooked to heartbeat messages, except simple ack
+	go func() {
+		response := &ecsacs.HeartbeatAckRequest{
+			MessageId: message.MessageId,
+		}
+		heartbeatHandler.heartbeatAckMessageBuffer <- response
+	}()
+	return nil
+}
+
+func (heartbeatHandler *heartbeatHandler) sendHeartbeatAck() {
+	for {
+		select {
+		case ack := <-heartbeatHandler.heartbeatAckMessageBuffer:
+			heartbeatHandler.sendSingleHeartbeatAck(ack)
+		case <-heartbeatHandler.ctx.Done():
+			return
+		}
+	}
+}
+
+func (heartbeatHandler *heartbeatHandler) sendSingleHeartbeatAck(ack *ecsacs.HeartbeatAckRequest) {
+	err := heartbeatHandler.acsClient.MakeRequest(ack)
+	if err != nil {
+		seelog.Warnf("Error acknowledging server heartbeat, message id: %s, error: %s", aws.StringValue(ack.MessageId), err)
+	}
+}
+
+// stop() cancels the context being used by this handler, which stops the go routines started by 'start()'
+func (heartbeatHandler *heartbeatHandler) stop() {
+	heartbeatHandler.cancel()
+}
+
+// clearAcks drains the ack request channel
+func (heartbeatHandler *heartbeatHandler) clearAcks() {
+	for {
+		select {
+		case <-heartbeatHandler.heartbeatAckMessageBuffer:
+		default:
+			return
+		}
+	}
+}

--- a/agent/acs/handler/heartbeat_handler_test.go
+++ b/agent/acs/handler/heartbeat_handler_test.go
@@ -1,0 +1,104 @@
+// +build unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package handler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/amazon-ecs-agent/agent/acs/model/ecsacs"
+	mock_wsclient "github.com/aws/amazon-ecs-agent/agent/wsclient/mock"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	heartbeatMessageId = "heartbeatMessageId"
+)
+
+func TestAckHeartbeatMessage(t *testing.T) {
+	heartbeatReceived := &ecsacs.HeartbeatMessage{
+		MessageId: aws.String(heartbeatMessageId),
+		Healthy:   aws.Bool(true),
+	}
+
+	heartbeatAckExpected := &ecsacs.HeartbeatAckRequest{
+		MessageId: aws.String(heartbeatMessageId),
+	}
+
+	validateHeartbeatAck(t, heartbeatReceived, heartbeatAckExpected)
+}
+
+func TestAckHeartbeatMessageNotHealthy(t *testing.T) {
+	heartbeatReceived := &ecsacs.HeartbeatMessage{
+		MessageId: aws.String(heartbeatMessageId),
+		// ECS Agent currently ignores this field so we expect no behavior change
+		Healthy: aws.Bool(false),
+	}
+
+	heartbeatAckExpected := &ecsacs.HeartbeatAckRequest{
+		MessageId: aws.String(heartbeatMessageId),
+	}
+
+	validateHeartbeatAck(t, heartbeatReceived, heartbeatAckExpected)
+}
+
+func TestAckHeartbeatMessageWithoutMessageId(t *testing.T) {
+	heartbeatReceived := &ecsacs.HeartbeatMessage{
+		Healthy: aws.Bool(true),
+	}
+
+	heartbeatAckExpected := &ecsacs.HeartbeatAckRequest{
+		MessageId: nil,
+	}
+
+	validateHeartbeatAck(t, heartbeatReceived, heartbeatAckExpected)
+}
+
+func TestAckHeartbeatMessageEmpty(t *testing.T) {
+	heartbeatReceived := &ecsacs.HeartbeatMessage{}
+
+	heartbeatAckExpected := &ecsacs.HeartbeatAckRequest{
+		MessageId: nil,
+	}
+
+	validateHeartbeatAck(t, heartbeatReceived, heartbeatAckExpected)
+}
+
+func validateHeartbeatAck(t *testing.T, heartbeatReceived *ecsacs.HeartbeatMessage, heartbeatAckExpected *ecsacs.HeartbeatAckRequest) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var heartbeatAckSent *ecsacs.HeartbeatAckRequest
+
+	mockWsClient := mock_wsclient.NewMockClientServer(ctrl)
+	mockWsClient.EXPECT().MakeRequest(gomock.Any()).Do(func(message *ecsacs.HeartbeatAckRequest) {
+		heartbeatAckSent = message
+		cancel()
+	}).Times(1)
+
+	handler := newHeartbeatHandler(ctx, mockWsClient)
+	go handler.sendHeartbeatAck()
+
+	handler.handleSingleHeartbeatMessage(heartbeatReceived)
+
+	// wait till we get an ack from heartbeatAckMessageBuffer
+	<-ctx.Done()
+
+	require.Equal(t, heartbeatAckExpected, heartbeatAckSent)
+}

--- a/agent/acs/model/api/api-2.json
+++ b/agent/acs/model/api/api-2.json
@@ -47,7 +47,8 @@
         "requestUri":"/"
       },
       "input":{"shape":"HeartbeatMessage"},
-      "documentation":"Heartbeat is a periodic message that informs the agent all is well."
+      "output":{"shape":"HeartbeatAckRequest"},
+      "documentation":"Heartbeat is a periodic message between the Agent and ECS backend to keep the connection alive."
     },
     "Payload":{
       "name":"Payload",
@@ -417,7 +418,14 @@
     "HeartbeatMessage":{
       "type":"structure",
       "members":{
-        "healthy":{"shape":"Boolean"}
+        "healthy":{"shape":"Boolean"},
+        "messageId":{"shape":"String"}
+      }
+    },
+    "HeartbeatAckRequest":{
+      "type":"structure",
+      "members":{
+        "messageId":{"shape":"String"}
       }
     },
     "HostVolumeProperties":{

--- a/agent/acs/model/ecsacs/api.go
+++ b/agent/acs/model/ecsacs/api.go
@@ -720,10 +720,28 @@ func (s FirelensConfiguration) GoString() string {
 	return s.String()
 }
 
+type HeartbeatAckRequest struct {
+	_ struct{} `type:"structure"`
+
+	MessageId *string `locationName:"messageId" type:"string"`
+}
+
+// String returns the string representation
+func (s HeartbeatAckRequest) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s HeartbeatAckRequest) GoString() string {
+	return s.String()
+}
+
 type HeartbeatInput struct {
 	_ struct{} `type:"structure"`
 
 	Healthy *bool `locationName:"healthy" type:"boolean"`
+
+	MessageId *string `locationName:"messageId" type:"string"`
 }
 
 // String returns the string representation
@@ -740,6 +758,8 @@ type HeartbeatMessage struct {
 	_ struct{} `type:"structure"`
 
 	Healthy *bool `locationName:"healthy" type:"boolean"`
+
+	MessageId *string `locationName:"messageId" type:"string"`
 }
 
 // String returns the string representation
@@ -754,6 +774,8 @@ func (s HeartbeatMessage) GoString() string {
 
 type HeartbeatOutput struct {
 	_ struct{} `type:"structure"`
+
+	MessageId *string `locationName:"messageId" type:"string"`
 }
 
 // String returns the string representation


### PR DESCRIPTION
### Summary

This PR adds the support for ECS agent to acknowledge server heartbeat messages. This would help both ECS agent and ECS backend server to detect stale socket connections, then take proactive actions to handle it.

### Implementation details

ECS server will soon start to actively clean up stale connections if ECS agent is not acknowledging heartbeat messages. Since such change is backward-incompatible, a new `protocolVersion` is introduced for ECS agent to control the behavior from client side when establishing the WebSocket connection.

If the version is set as 2, then the ECS agent must acknowledge all server heartbeats. Null protocol version is treated as 1.

### Testing

```
make test
make release
```

Manually tested the change by building the agent, connect to ECS, then inspect ECS backend logs:

- Positive case: connection is healthy when protocol version = 2 and heartbeats are being acked
- Negative case: ECS will cut the connection if protocol version = 2 but heartbeat acks are missing

New tests cover the changes: yes

### Description for the changelog

Enhancement - Add support for ECS agent to acknowledge server heartbeat messages

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
