### PR TITLE
prevents a goroutine from being leaked if a timeout occurs when calling forceCloseConnection

### DIFF
--- a/agent/wsclient/client.go
+++ b/agent/wsclient/client.go
@@ -265,7 +265,7 @@ func (cs *ClientServerImpl) SetReadDeadline(t time.Time) error {
 }
 
 func (cs *ClientServerImpl) forceCloseConnection() {
-	closeChan := make(chan error)
+	closeChan := make(chan error, 1)
 	go func() {
 		closeChan <- cs.Close()
 	}()


### PR DESCRIPTION
### Summary
Fixes potential edge case which could result in a goroutine leak, applies general best practice for working with channels.

A goroutine leak could occur in the following edge case scenario:

In the case that the `case` in https://github.com/aws/amazon-ecs-agent/blob/master/agent/wsclient/client.go#L274-L285 executes first, the function will return and the anonymous goroutine in https://github.com/aws/amazon-ecs-agent/blob/master/agent/wsclient/client.go#L269 would continue to be blocked, causing a goroutine leak. Using a buffered channel prevents this issue.

### Implementation details
Made an unbuffered channel into a buffered channel

### Testing

New tests cover the changes:  no 

### Description for the changelog

bugfix - fix potential goroutine leak when closing websocket connections

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
