### PR TITLE
Filter out ipv6 port forwards when an ipv6 default route doesn't exist

### DIFF
--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -329,4 +329,7 @@ type Config struct {
 	// FSxWindowsFileServerCapable is the config option to indicate if fsxWindowsFileServer is supported.
 	// It should be enabled by default only if the container instance is part of a valid active directory domain.
 	FSxWindowsFileServerCapable bool
+
+	// MissingIPv6DefaultRoute indicates if the agent sees a IPv6 default route
+	MissingIPv6DefaultRoute bool
 }


### PR DESCRIPTION
edit: Didn't intend to open this yet.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.