### PR TITLE
EC2 Task Networking on Windows: Retrieving ENI's name on the instance.

### DIFF
--- a/agent/ecscni/netconfig_windows.go
+++ b/agent/ecscni/netconfig_windows.go
@@ -45,6 +45,7 @@ func NewBridgeNetworkConfigForTaskNSSetup(eni *eni.ENI, cfg *Config) (*libcni.Ne
 
 	eniConf := BridgeForTaskENIConfig{
 		Type:             ECSVPCSharedENIPluginName,
+		ENIName:          eni.GetLinkName(),
 		ENIIPAddress:     eni.GetPrimaryIPv4AddressWithPrefixLength(),
 		ENIMACAddress:    eni.MacAddress,
 		GatewayIPAddress: gateway,

--- a/agent/ecscni/netconfig_windows_test.go
+++ b/agent/ecscni/netconfig_windows_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 const (
+	linkName                = "Ethernet 4"
 	validVPCGatewayCIDR     = "10.0.0.1/24"
 	validVPCGatewayIPv4Addr = "10.0.0.1"
 	invalidVPCGatewayCIDR   = "10.0.0.300/24"
@@ -40,6 +41,7 @@ const (
 func getTaskENI() *apieni.ENI {
 	return &apieni.ENI{
 		ID:                           "TestENI",
+		LinkName:                     linkName,
 		MacAddress:                   mac,
 		InterfaceAssociationProtocol: apieni.DefaultInterfaceAssociationProtocol,
 		SubnetGatewayIPV4Address:     validVPCGatewayCIDR,
@@ -78,6 +80,7 @@ func TestNewBridgeNetworkConfigForTaskNSSetup(t *testing.T) {
 	assert.EqualValues(t, ipv4CIDR, bridgeConfig.IPAddress)
 	assert.EqualValues(t, mac, bridgeConfig.ENIMACAddress)
 	assert.EqualValues(t, validVPCGatewayIPv4Addr, bridgeConfig.GatewayIPAddress)
+	assert.EqualValues(t, linkName, bridgeConfig.ENIName)
 	assert.True(t, bridgeConfig.TaskENIConfig.PauseContainer)
 }
 

--- a/agent/engine/docker_task_engine_windows_test.go
+++ b/agent/engine/docker_task_engine_windows_test.go
@@ -504,34 +504,32 @@ func TestPauseContainerHappyPath(t *testing.T) {
 	dockerClient.EXPECT().CreateContainer(gomock.Any(), gomock.Any(), gomock.Any(),
 		gomock.Any(), gomock.Any()).Return(dockerapi.DockerContainerMetadata{DockerID: sleepContainerID2})
 
-	gomock.InOrder(
-		dockerClient.EXPECT().StartContainer(gomock.Any(), sleepContainerID1, defaultConfig.ContainerStartTimeout).Return(
-			dockerapi.DockerContainerMetadata{DockerID: sleepContainerID1}),
-		dockerClient.EXPECT().InspectContainer(gomock.Any(), gomock.Any(), gomock.Any()).Return(
-			&types.ContainerJSON{
-				ContainerJSONBase: &types.ContainerJSONBase{
-					ID:    sleepContainerID1,
-					State: &types.ContainerState{Pid: containerPid},
-					HostConfig: &dockercontainer.HostConfig{
-						NetworkMode: containerNetNS,
-					},
+	dockerClient.EXPECT().StartContainer(gomock.Any(), sleepContainerID1, defaultConfig.ContainerStartTimeout).Return(
+		dockerapi.DockerContainerMetadata{DockerID: sleepContainerID1})
+	dockerClient.EXPECT().InspectContainer(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		&types.ContainerJSON{
+			ContainerJSONBase: &types.ContainerJSONBase{
+				ID:    sleepContainerID1,
+				State: &types.ContainerState{Pid: containerPid},
+				HostConfig: &dockercontainer.HostConfig{
+					NetworkMode: containerNetNS,
 				},
-			}, nil),
-		cniClient.EXPECT().SetupNS(gomock.Any(), gomock.Any(), gomock.Any()).Return(nsResult, nil),
-		dockerClient.EXPECT().StartContainer(gomock.Any(), sleepContainerID2, defaultConfig.ContainerStartTimeout).Return(
-			dockerapi.DockerContainerMetadata{DockerID: sleepContainerID2}),
-		dockerClient.EXPECT().InspectContainer(gomock.Any(), gomock.Any(), gomock.Any()).Return(
-			&types.ContainerJSON{
-				ContainerJSONBase: &types.ContainerJSONBase{
-					ID:    sleepContainerID2,
-					State: &types.ContainerState{Pid: containerPid},
-					HostConfig: &dockercontainer.HostConfig{
-						NetworkMode: containerNetNS,
-					},
+			},
+		}, nil)
+	cniClient.EXPECT().SetupNS(gomock.Any(), gomock.Any(), gomock.Any()).Return(nsResult, nil)
+	dockerClient.EXPECT().StartContainer(gomock.Any(), sleepContainerID2, defaultConfig.ContainerStartTimeout).Return(
+		dockerapi.DockerContainerMetadata{DockerID: sleepContainerID2})
+	dockerClient.EXPECT().InspectContainer(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		&types.ContainerJSON{
+			ContainerJSONBase: &types.ContainerJSONBase{
+				ID:    sleepContainerID2,
+				State: &types.ContainerState{Pid: containerPid},
+				HostConfig: &dockercontainer.HostConfig{
+					NetworkMode: containerNetNS,
 				},
-			}, nil),
-		cniClient.EXPECT().SetupNS(gomock.Any(), gomock.Any(), gomock.Any()).Return(nsResult, nil),
-	)
+			},
+		}, nil)
+	cniClient.EXPECT().SetupNS(gomock.Any(), gomock.Any(), gomock.Any()).Return(nsResult, nil)
 
 	cleanup := make(chan time.Time)
 	defer close(cleanup)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
ENI's link name on the instance is a mandatory parameter for the CNI plugin.
Therefore, we retrieve the name on the first plugin invocation for a task. The name is stored as part of ENI and is used in subsequent calls.

### Implementation details
<!-- How are the changes implemented? -->
A field `LinkName` has been added in the eni object. 
Additionally a method `GetLinkName` , has been added which returns the link name if it is readily available. If not, then it scans all the interfaces on the instance to find the one which has same MAC address as the ENI.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Unit tests have been added/updated and a custom agent binary was tested.

New tests cover the changes: <!-- yes|no -->
Yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Added ENI's link name field.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
