### PR TITLE
EC2 task networking for Windows: Enable Task IAM roles/Task metadata

### DIFF
--- a/agent/api/task/task_windows.go
+++ b/agent/api/task/task_windows.go
@@ -283,7 +283,15 @@ func (task *Task) BuildCNIConfig(includeIPAMConfig bool, cniConfig *ecscni.Confi
 		})
 	}
 
-	// TODO: Build configuration for second invocation of plugin to setup ecs-bridge
+	// Create the vpc-eni plugin configuration to setup ecs-bridge endpoint in the task namespace.
+	netconf, err = ecscni.NewVPCENIPluginConfigForECSBridgeSetup(cniConfig)
+	if err != nil {
+		return nil, err
+	}
+	cniConfig.NetworkConfigs = append(cniConfig.NetworkConfigs, &ecscni.NetworkConfig{
+		IfName:           ecscni.ECSBridgeNetworkName,
+		CNINetworkConfig: netconf,
+	})
 
 	return cniConfig, nil
 }

--- a/agent/ecscni/netconfig_windows.go
+++ b/agent/ecscni/netconfig_windows.go
@@ -58,6 +58,23 @@ func NewVPCENIPluginConfigForTaskNSSetup(eni *eni.ENI, cfg *Config) (*libcni.Net
 	return networkConfig, nil
 }
 
+// NewVPCENIPluginConfigForECSBridgeSetup creates the configuration required by vpc-eni plugin to setup ecs-bridge endpoint for the task.
+func NewVPCENIPluginConfigForECSBridgeSetup(cfg *Config) (*libcni.NetworkConfig, error) {
+	bridgeConf := VPCENIPluginConfig{
+		Type:               ECSVPCENIPluginName,
+		NoInfraContainer:   false,
+		UseExistingNetwork: true,
+	}
+
+	networkConfig, err := newNetworkConfig(bridgeConf, ECSVPCENIPluginExecutable, cfg.MinSupportedCNIVersion)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create vpc-eni plugin configuration for setting up ecs-bridge endpoint of the task")
+	}
+
+	networkConfig.Network.Name = ECSBridgeNetworkName
+	return networkConfig, nil
+}
+
 // constructDNSFromVPCCIDR is used to construct DNS server from the primary ipv4 cidr of the vpc.
 func constructDNSFromVPCCIDR(vpcCIDR *net.IPNet) ([]string, error) {
 	// The DNS server maps to a reserved IP address at the base of the VPC IPv4 network rage plus 2

--- a/agent/ecscni/netconfig_windows_test.go
+++ b/agent/ecscni/netconfig_windows_test.go
@@ -83,6 +83,22 @@ func TestNewVPCENIPluginConfigForTaskNSSetup(t *testing.T) {
 	assert.False(t, netConfig.NoInfraContainer)
 }
 
+// TestNewVPCENIPluginConfigForECSBridgeSetup tests the generated configuration for ecs-bridge setup.
+func TestNewVPCENIPluginConfigForECSBridgeSetup(t *testing.T) {
+	cniConfig := getCNIConfig()
+	config, err := NewVPCENIPluginConfigForECSBridgeSetup(cniConfig)
+
+	netConfig := &VPCENIPluginConfig{}
+	json.Unmarshal(config.Bytes, netConfig)
+
+	assert.NoError(t, err)
+	assert.EqualValues(t, ECSVPCENIPluginExecutable, config.Network.Type)
+	assert.EqualValues(t, cniMinSupportedVersion, config.Network.CNIVersion)
+	assert.EqualValues(t, ECSBridgeNetworkName, config.Network.Name)
+	assert.True(t, netConfig.UseExistingNetwork)
+	assert.False(t, netConfig.NoInfraContainer)
+}
+
 // TestConstructDNSFromVPCCIDRSuccess tests if the dns is constructed properly from the given vpc's primary cidr
 func TestConstructDNSFromVPCCIDRSuccess(t *testing.T) {
 	_, cidr, _ := net.ParseCIDR(vpcCIDR)

--- a/agent/ecscni/plugin_windows.go
+++ b/agent/ecscni/plugin_windows.go
@@ -19,7 +19,10 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
+
+	cnitypes "github.com/containernetworking/cni/pkg/types"
 
 	"github.com/aws/amazon-ecs-agent/agent/utils/retry"
 
@@ -38,29 +41,31 @@ var (
 )
 
 // setupNS is the called by SetupNS to setup the task namespace by invoking ADD for given CNI configurations.
-// For Windows, we will retry the setup on Windows before conceding error.
+// For Windows, we will retry the setup before conceding error.
 func (client *cniClient) setupNS(ctx context.Context, cfg *Config) (*current.Result, error) {
 	var result *current.Result
 	var err error
 	backoff := retry.NewExponentialBackoff(setupNSBackoffMin, setupNSBackoffMax,
 		setupNSBackoffJitter, setupNSBackoffMultiple)
 
-	for count := 1; count < setupNSMaxRetryCount; count++ {
-		result, err = client.setupNSOnce(ctx, cfg)
+	for count := 0; count < setupNSMaxRetryCount; count++ {
+		result, err = client.doSetupNS(ctx, cfg)
 		if err == nil {
 			return result, nil
 		}
-		if count < setupNSMaxRetryCount {
+		if count < setupNSMaxRetryCount-1 {
 			time.Sleep(backoff.Duration())
 		}
+		seelog.Errorf("[ECSCNI] Namespace setup failed due to error: %v. Retry count is %d.", err, count)
 	}
 	return nil, err
 }
 
-// setupNSOnce invokes the CNI plugins to setup the task network namespace.
-func (client *cniClient) setupNSOnce(ctx context.Context, cfg *Config) (*current.Result, error) {
+// doSetupNS invokes the CNI plugins to setup the task network namespace.
+func (client *cniClient) doSetupNS(ctx context.Context, cfg *Config) (*current.Result, error) {
 	seelog.Debugf("[ECSCNI] Setting up the container namespace %s", cfg.ContainerID)
 
+	var ecsBridgeResult cnitypes.Result
 	runtimeConfig := libcni.RuntimeConf{
 		ContainerID: cfg.ContainerID,
 		NetNS:       cfg.ContainerNetNS,
@@ -74,9 +79,15 @@ func (client *cniClient) setupNSOnce(ctx context.Context, cfg *Config) (*current
 			cniNetworkConfig.Network.Type,
 			cfg.ContainerID)
 		runtimeConfig.IfName = networkConfig.IfName
-		_, err := client.libcni.AddNetwork(ctx, cniNetworkConfig, &runtimeConfig)
+		result, err := client.libcni.AddNetwork(ctx, cniNetworkConfig, &runtimeConfig)
 		if err != nil {
 			return nil, errors.Wrap(err, "add network failed")
+		}
+
+		// We save the result from ecs-bridge setup invocation of the plugin.
+		if strings.EqualFold(ECSBridgeNetworkName, cniNetworkConfig.Network.Name) &&
+			cniNetworkConfig.Network.Type == ECSVPCENIPluginExecutable {
+			ecsBridgeResult = result
 		}
 
 		seelog.Debugf("[ECSCNI] Completed adding network %s type %s in the container namespace %s",
@@ -87,7 +98,20 @@ func (client *cniClient) setupNSOnce(ctx context.Context, cfg *Config) (*current
 
 	seelog.Debugf("[ECSCNI] Completed setting up the container namespace: %s", cfg.ContainerID)
 
-	return nil, nil
+	if _, err := ecsBridgeResult.GetAsVersion(currentCNISpec); err != nil {
+		seelog.Warnf("[ECSCNI] Unable to convert result to spec version %s; error: %v; result is of version: %s",
+			currentCNISpec, err, ecsBridgeResult.Version())
+		return nil, err
+	}
+	var curResult *current.Result
+	curResult, ok := ecsBridgeResult.(*current.Result)
+	if !ok {
+		return nil, errors.Errorf(
+			"cni setup: unable to convert result to expected version '%s'",
+			ecsBridgeResult.String())
+	}
+
+	return curResult, nil
 }
 
 // ReleaseIPResource marks the ip available in the ipam db

--- a/agent/ecscni/types_windows.go
+++ b/agent/ecscni/types_windows.go
@@ -26,11 +26,14 @@ const (
 	ECSVPCENIPluginName = "vpc-eni"
 	// ECSVPCENIPluginExecutable is the name of vpc-eni executable.
 	ECSVPCENIPluginExecutable = "vpc-eni.exe"
-	setupNSBackoffMin         = time.Second
-	setupNSBackoffMax         = time.Second * 3
-	setupNSBackoffJitter      = 0.2
-	setupNSBackoffMultiple    = 1.3
-	setupNSMaxRetryCount      = 3
+	// ECSBridgeNetworkName is the name of the HNS network used as ecs-bridge.
+	ECSBridgeNetworkName = "nat"
+	// Constants for creating backoff while retrying setupNS.
+	setupNSBackoffMin      = time.Second * 2
+	setupNSBackoffMax      = time.Second * 6
+	setupNSBackoffJitter   = 0.2
+	setupNSBackoffMultiple = 1.3
+	setupNSMaxRetryCount   = 3
 )
 
 // VPCENIPluginConfig contains all the information required to invoke the vpc-eni plugin.

--- a/agent/ecscni/types_windows.go
+++ b/agent/ecscni/types_windows.go
@@ -15,13 +15,22 @@
 
 package ecscni
 
-import "github.com/containernetworking/cni/pkg/types"
+import (
+	"time"
+
+	"github.com/containernetworking/cni/pkg/types"
+)
 
 const (
 	// ECSVPCENIPluginName is the name of the vpc-eni plugin.
 	ECSVPCENIPluginName = "vpc-eni"
 	// ECSVPCENIPluginExecutable is the name of vpc-eni executable.
 	ECSVPCENIPluginExecutable = "vpc-eni.exe"
+	setupNSBackoffMin         = time.Second
+	setupNSBackoffMax         = time.Second * 3
+	setupNSBackoffJitter      = 0.2
+	setupNSBackoffMultiple    = 1.3
+	setupNSMaxRetryCount      = 3
 )
 
 // VPCENIPluginConfig contains all the information required to invoke the vpc-eni plugin.

--- a/agent/engine/docker_task_engine_windows_test.go
+++ b/agent/engine/docker_task_engine_windows_test.go
@@ -274,9 +274,10 @@ func TestBuildCNIConfigFromTaskContainer(t *testing.T) {
 	assert.Equal(t, strconv.Itoa(containerPid), cniConfig.ContainerPID)
 	assert.Equal(t, containerNetNS, cniConfig.ContainerNetNS)
 	assert.Equal(t, mac, cniConfig.ID, "ID should be set to the mac of eni")
-	// We expect 1 NetworkConfig objects in the cni Config wrapper object:
-	// Bridge for Task ENI
-	require.Len(t, cniConfig.NetworkConfigs, 1)
+	// We expect 2 NetworkConfig objects in the cni Config wrapper object:
+	// Config for task ns setup.
+	// Config for ecs-bridge setup for the task.
+	require.Len(t, cniConfig.NetworkConfigs, 2)
 }
 
 // TestTaskWithSteadyStateResourcesProvisioned tests container and task transitions


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
The changes in this PR create a new endpoint into the task namespace to enable task iam roles/task metadata.

Additionally, we have added logic for retrying the network setup if it fails in the first attempt.
This is because on Windows, HNS might not be able to bound itself to the adapter in the first instance especially if the call is made immediately after the adapter was attached to the instance.

### Implementation details
<!-- How are the changes implemented? -->
The changes were implemented by creating the appropriate methods where required for creating new cni plugin configuration.

The retry logic for setting up namespace involves creating an exponential backoff and using it to make the goroutine sleep before retrying.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
The changes were tested using a custom agent binary as well as using unit tests.

New tests cover the changes: <!-- yes|no -->
Yes
### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enabling task iam roles and task metadata for the task launched using awsvpc network mode in Windows.
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
