### PR TITLE
Add test runner (Doctor) and basic docker ping Healthcheck

### DIFF
--- a/agent/acs/handler/acs_handler.go
+++ b/agent/acs/handler/acs_handler.go
@@ -336,7 +336,8 @@ func (acsSession *session) startACSSession(client wsclient.ClientServer) error {
 	client.AddRequestHandler(payloadHandler.handlerFunc())
 
 	// Add HeartbeatHandler to acknowledge ACS heartbeats
-	heartbeatHandler := newHeartbeatHandler(acsSession.ctx, client)
+	// TODO add healthcheck-specific acs heartbeat handler
+	heartbeatHandler := newHeartbeatHandler(acsSession.ctx, client, acsSession.taskEngine)
 	defer heartbeatHandler.clearAcks()
 	heartbeatHandler.start()
 	defer heartbeatHandler.stop()

--- a/agent/acs/handler/heartbeat_handler_test.go
+++ b/agent/acs/handler/heartbeat_handler_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/aws/amazon-ecs-agent/agent/acs/model/ecsacs"
+	mock_engine "github.com/aws/amazon-ecs-agent/agent/engine/mocks"
 	mock_wsclient "github.com/aws/amazon-ecs-agent/agent/wsclient/mock"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/golang/mock/gomock"
@@ -81,6 +82,7 @@ func TestAckHeartbeatMessageEmpty(t *testing.T) {
 
 func validateHeartbeatAck(t *testing.T, heartbeatReceived *ecsacs.HeartbeatMessage, heartbeatAckExpected *ecsacs.HeartbeatAckRequest) {
 	ctrl := gomock.NewController(t)
+	taskEngine := mock_engine.NewMockTaskEngine(ctrl)
 	defer ctrl.Finish()
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -92,7 +94,8 @@ func validateHeartbeatAck(t *testing.T, heartbeatReceived *ecsacs.HeartbeatMessa
 		cancel()
 	}).Times(1)
 
-	handler := newHeartbeatHandler(ctx, mockWsClient)
+	handler := newHeartbeatHandler(ctx, mockWsClient, taskEngine)
+
 	go handler.sendHeartbeatAck()
 
 	handler.handleSingleHeartbeatMessage(heartbeatReceived)

--- a/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
+++ b/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
@@ -431,6 +431,20 @@ func (mr *MockDockerClientMockRecorder) SupportedVersions() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SupportedVersions", reflect.TypeOf((*MockDockerClient)(nil).SupportedVersions))
 }
 
+// SystemPing mocks base method
+func (m *MockDockerClient) SystemPing(arg0 context.Context, arg1 time.Duration) dockerapi.PingResponse {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SystemPing", arg0, arg1)
+	ret0, _ := ret[0].(dockerapi.PingResponse)
+	return ret0
+}
+
+// SystemPing indicates an expected call of SystemPing
+func (mr *MockDockerClientMockRecorder) SystemPing(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SystemPing", reflect.TypeOf((*MockDockerClient)(nil).SystemPing), arg0, arg1)
+}
+
 // TopContainer mocks base method
 func (m *MockDockerClient) TopContainer(arg0 context.Context, arg1 string, arg2 time.Duration, arg3 ...string) (*container0.ContainerTopOKBody, error) {
 	m.ctrl.T.Helper()

--- a/agent/dockerclient/dockerapi/types.go
+++ b/agent/dockerclient/dockerapi/types.go
@@ -97,6 +97,11 @@ type ListImagesResponse struct {
 	Error error
 }
 
+type PingResponse struct {
+	Response *types.Ping
+	Error    error
+}
+
 // VolumeResponse wrapper for CreateVolume and InspectVolume
 // TODO Remove type when migration is complete
 type VolumeResponse struct {

--- a/agent/doctor/doctor.go
+++ b/agent/doctor/doctor.go
@@ -1,0 +1,62 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//      http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package doctor
+
+import (
+	"sync"
+
+	"github.com/cihub/seelog"
+)
+
+type Doctor struct {
+	healthchecks []Healthcheck
+	lock         sync.RWMutex
+}
+
+func NewDoctor(healthchecks []Healthcheck) (*Doctor, error) {
+	newDoctor := &Doctor{
+		healthchecks: []Healthcheck{},
+	}
+	for _, hc := range healthchecks {
+		newDoctor.AddHealthcheck(hc)
+	}
+	return newDoctor, nil
+}
+
+func (doc *Doctor) AddHealthcheck(healthcheck Healthcheck) {
+	doc.lock.Lock()
+	defer doc.lock.Unlock()
+
+	doc.healthchecks = append(doc.healthchecks, healthcheck)
+}
+
+func (doc *Doctor) RunHealthchecks() bool {
+	doc.lock.RLock()
+	defer doc.lock.RUnlock()
+	allChecksResult := []bool{}
+	for _, healthcheck := range doc.healthchecks {
+		res := healthcheck.RunCheck()
+		seelog.Debugf("instance healthcheck result: %v", res)
+		allChecksResult = append(allChecksResult, res)
+	}
+	return doc.allRight(allChecksResult)
+}
+
+func (doc *Doctor) allRight(checksResult []bool) bool {
+	overallResult := true
+	for _, checkResult := range checksResult {
+		overallResult = overallResult && checkResult
+	}
+	return overallResult
+}

--- a/agent/doctor/doctor_test.go
+++ b/agent/doctor/doctor_test.go
@@ -1,0 +1,152 @@
+// +build unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package doctor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type trueHealthcheck struct{}
+
+func (tc *trueHealthcheck) RunCheck() bool { return true }
+func (tc *trueHealthcheck) GetHealthcheckStatus() HealthcheckStatus {
+	return HealthcheckStatusInitializing
+}
+func (tc *trueHealthcheck) GetHealthcheckTime() time.Time {
+	return time.Date(1974, time.May, 19, 1, 2, 3, 4, time.UTC)
+}
+
+type falseHealthcheck struct{}
+
+func (fc *falseHealthcheck) RunCheck() bool { return false }
+func (fc *falseHealthcheck) GetHealthcheckStatus() HealthcheckStatus {
+	return HealthcheckStatusInitializing
+}
+func (fc *falseHealthcheck) GetHealthcheckTime() time.Time {
+	return time.Date(1974, time.May, 19, 1, 2, 3, 4, time.UTC)
+}
+
+func TestNewDoctor(t *testing.T) {
+	trueCheck := &trueHealthcheck{}
+	falseCheck := &falseHealthcheck{}
+
+	healthchecks := []Healthcheck{trueCheck, falseCheck}
+	newDoctor, _ := NewDoctor(healthchecks)
+	assert.Len(t, newDoctor.healthchecks, 2)
+}
+
+type testHealthcheck struct {
+	testName string
+}
+
+func (thc *testHealthcheck) RunCheck() bool {
+	return true
+}
+
+func (thc *testHealthcheck) GetHealthcheckStatus() HealthcheckStatus {
+	return HealthcheckStatusOk
+}
+
+func (thc *testHealthcheck) GetHealthcheckTime() time.Time {
+	return time.Date(1974, time.May, 19, 1, 2, 3, 4, time.UTC)
+}
+
+func TestAddHealthcheck(t *testing.T) {
+	newDoctor := Doctor{}
+	assert.Len(t, newDoctor.healthchecks, 0)
+	newTestHealthcheck := &testHealthcheck{testName: "testAddHealthcheck"}
+	newDoctor.AddHealthcheck(newTestHealthcheck)
+	assert.Len(t, newDoctor.healthchecks, 1)
+}
+
+func TestRunHealthchecks(t *testing.T) {
+	trueCheck := &trueHealthcheck{}
+	falseCheck := &falseHealthcheck{}
+
+	testcases := []struct {
+		name           string
+		checks         []Healthcheck
+		expectedResult bool
+	}{
+		{
+			name:           "empty checks",
+			checks:         []Healthcheck{},
+			expectedResult: true,
+		},
+		{
+			name:           "all true checks",
+			checks:         []Healthcheck{trueCheck},
+			expectedResult: true,
+		},
+		{
+			name:           "all false checks",
+			checks:         []Healthcheck{falseCheck},
+			expectedResult: false,
+		},
+		{
+			name:           "mixed checks",
+			checks:         []Healthcheck{trueCheck, falseCheck},
+			expectedResult: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			newDoctor, _ := NewDoctor(tc.checks)
+			overallResult := newDoctor.RunHealthchecks()
+			assert.Equal(t, overallResult, tc.expectedResult)
+		})
+	}
+}
+
+func TestAllRight(t *testing.T) {
+	testcases := []struct {
+		name             string
+		testChecksResult []bool
+		expectedResult   bool
+	}{
+		{
+			name:             "empty checks",
+			testChecksResult: []bool{},
+			expectedResult:   true,
+		},
+		{
+			name:             "all true checks",
+			testChecksResult: []bool{true, true},
+			expectedResult:   true,
+		},
+		{
+			name:             "all false checks",
+			testChecksResult: []bool{false, false},
+			expectedResult:   false,
+		},
+		{
+			name:             "mixed checks",
+			testChecksResult: []bool{true, false},
+			expectedResult:   false,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			newDoctor := Doctor{}
+			overallResult := newDoctor.allRight(tc.testChecksResult)
+			assert.Equal(t, overallResult, tc.expectedResult)
+		})
+	}
+}

--- a/agent/doctor/healthcheck.go
+++ b/agent/doctor/healthcheck.go
@@ -1,0 +1,70 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//      http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package doctor
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
+	"github.com/cihub/seelog"
+)
+
+type Healthcheck interface {
+	GetHealthcheckStatus() HealthcheckStatus
+	GetHealthcheckTime() time.Time
+	RunCheck() bool
+}
+
+type dockerRuntimeHealthcheck struct {
+	// Status is the container health status
+	LatestCheckStatus HealthcheckStatus `json:"latestStatus,omitempty"`
+	// Since is the timestamp when container health status changed
+	LatestCheckTime time.Time `json:"latestStatusTime,omitempty"`
+	// Status is the container health status
+	LastCheckStatus HealthcheckStatus `json:"lastStatus,omitempty"`
+	// Since is the timestamp when container health status changed
+	LastCheckTime time.Time `json:"lastStatusTime,omitempty"`
+	client        dockerapi.DockerClient
+	lock          sync.RWMutex
+}
+
+func NewDockerRuntimeHealthcheck(client dockerapi.DockerClient) *dockerRuntimeHealthcheck {
+	return &dockerRuntimeHealthcheck{
+		client:            client,
+		LatestCheckStatus: HealthcheckStatusInitializing,
+		LatestCheckTime:   time.Now(),
+		LastCheckStatus:   HealthcheckStatusInitializing,
+		LastCheckTime:     time.Now(),
+	}
+}
+
+func (dhc *dockerRuntimeHealthcheck) RunCheck() bool {
+	healthcheckResponse := dhc.client.SystemPing(context.TODO(), time.Second*2)
+	seelog.Infof("container runtime healthcheck response: %v", healthcheckResponse)
+	return true
+}
+
+func (dhc *dockerRuntimeHealthcheck) GetHealthcheckStatus() HealthcheckStatus {
+	dhc.lock.RLock()
+	defer dhc.lock.RUnlock()
+	return dhc.LatestCheckStatus
+}
+
+func (dhc *dockerRuntimeHealthcheck) GetHealthcheckTime() time.Time {
+	dhc.lock.RLock()
+	defer dhc.lock.RUnlock()
+	return dhc.LatestCheckTime
+}

--- a/agent/doctor/healthcheckstatus.go
+++ b/agent/doctor/healthcheckstatus.go
@@ -1,0 +1,81 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package doctor
+
+import (
+	"errors"
+	"strings"
+)
+
+const (
+	// HealthcheckStatusInitializing is the zero state of a healthcheck status
+	HealthcheckStatusInitializing HealthcheckStatus = iota
+	// HealthcheckStatusOk represents a healthcheck with a true/success result
+	HealthcheckStatusOk
+	// HealthcheckStatusImpaired represents a healthcheck with a false/fail result
+	HealthcheckStatusImpaired
+)
+
+// HealthcheckStatus is an enumeration of possible instance statuses
+type HealthcheckStatus int32
+
+var healthcheckStatusMap = map[string]HealthcheckStatus{
+	"INITIALIZING": HealthcheckStatusInitializing,
+	"OK":           HealthcheckStatusOk,
+	"IMPAIRED":     HealthcheckStatusImpaired,
+}
+
+// String returns a human readable string representation of this object
+func (hs HealthcheckStatus) String() string {
+	for k, v := range healthcheckStatusMap {
+		if v == hs {
+			return k
+		}
+	}
+	// we shouldn't see this
+	return "NONE"
+}
+
+// Ok returns true if the Healthcheck status is OK or INITIALIZING
+func (hs HealthcheckStatus) Ok() bool {
+	return hs == HealthcheckStatusOk || hs == HealthcheckStatusInitializing
+}
+
+// UnmarshalJSON overrides the logic for parsing the JSON-encoded HealthcheckStatus data
+func (hs *HealthcheckStatus) UnmarshalJSON(b []byte) error {
+	if strings.ToLower(string(b)) == "null" {
+		*hs = HealthcheckStatusInitializing
+		return nil
+	}
+	if b[0] != '"' || b[len(b)-1] != '"' {
+		*hs = HealthcheckStatusInitializing
+		return errors.New("healthcheck status unmarshal: status must be a string or null; Got " + string(b))
+	}
+
+	stat, ok := healthcheckStatusMap[string(b[1:len(b)-1])]
+	if !ok {
+		*hs = HealthcheckStatusInitializing
+		return errors.New("healthcheck status unmarshal: unrecognized status")
+	}
+	*hs = stat
+	return nil
+}
+
+// MarshalJSON overrides the logic for JSON-encoding the HealthcheckStatus type
+func (hs *HealthcheckStatus) MarshalJSON() ([]byte, error) {
+	if hs == nil {
+		return nil, nil
+	}
+	return []byte(`"` + hs.String() + `"`), nil
+}

--- a/agent/doctor/healthcheckstatus_test.go
+++ b/agent/doctor/healthcheckstatus_test.go
@@ -1,0 +1,57 @@
+// +build unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package doctor
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOk(t *testing.T) {
+	initializingStatus := HealthcheckStatusInitializing
+	okStatus := HealthcheckStatusOk
+	impairedStatus := HealthcheckStatusImpaired
+	assert.True(t, initializingStatus.Ok())
+	assert.True(t, okStatus.Ok())
+	assert.False(t, impairedStatus.Ok())
+}
+
+type testHealthcheckStatus struct {
+	SomeStatus HealthcheckStatus `json:"status"`
+}
+
+func TestUnmarshalHealthcheckStatus(t *testing.T) {
+	status := HealthcheckStatusInitializing
+
+	err := json.Unmarshal([]byte(`"INITIALIZING"`), &status)
+	if err != nil {
+		t.Error(err)
+	}
+	if status != HealthcheckStatusInitializing {
+		t.Error("INITIALIZING should unmarshal to INITIALIZING, not " + status.String())
+	}
+
+	var test testHealthcheckStatus
+	err = json.Unmarshal([]byte(`{"status":"IMPAIRED"}`), &test)
+	if err != nil {
+		t.Error(err)
+	}
+	if test.SomeStatus != HealthcheckStatusImpaired {
+		t.Error("IMPAIRED should unmarshal to IMPAIRED, not " + test.SomeStatus.String())
+	}
+}

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -353,6 +353,10 @@ func (engine *DockerTaskEngine) SetDataClient(client data.Client) {
 	engine.dataClient = client
 }
 
+func (engine *DockerTaskEngine) TaskEngineClient() dockerapi.DockerClient {
+	return engine.client
+}
+
 // Shutdown makes a best-effort attempt to cleanup after the task engine.
 // This should not be relied on for anything more complicated than testing.
 func (engine *DockerTaskEngine) Shutdown() {

--- a/agent/engine/interface.go
+++ b/agent/engine/interface.go
@@ -20,6 +20,7 @@ import (
 
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	"github.com/aws/amazon-ecs-agent/agent/data"
+	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	"github.com/aws/amazon-ecs-agent/agent/statechange"
 )
 
@@ -50,6 +51,7 @@ type TaskEngine interface {
 	GetTaskByArn(string) (*apitask.Task, bool)
 
 	Version() (string, error)
+	TaskEngineClient() dockerapi.DockerClient
 
 	// LoadState loads the task engine state with data in db.
 	LoadState() error

--- a/agent/engine/mocks/engine_mocks.go
+++ b/agent/engine/mocks/engine_mocks.go
@@ -25,6 +25,7 @@ import (
 	container "github.com/aws/amazon-ecs-agent/agent/api/container"
 	task "github.com/aws/amazon-ecs-agent/agent/api/task"
 	data "github.com/aws/amazon-ecs-agent/agent/data"
+	dockerapi "github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	image "github.com/aws/amazon-ecs-agent/agent/engine/image"
 	statechange "github.com/aws/amazon-ecs-agent/agent/statechange"
 	gomock "github.com/golang/mock/gomock"
@@ -200,6 +201,20 @@ func (m *MockTaskEngine) StateChangeEvents() chan statechange.Event {
 func (mr *MockTaskEngineMockRecorder) StateChangeEvents() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateChangeEvents", reflect.TypeOf((*MockTaskEngine)(nil).StateChangeEvents))
+}
+
+// TaskEngineClient mocks base method
+func (m *MockTaskEngine) TaskEngineClient() dockerapi.DockerClient {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TaskEngineClient")
+	ret0, _ := ret[0].(dockerapi.DockerClient)
+	return ret0
+}
+
+// TaskEngineClient indicates an expected call of TaskEngineClient
+func (mr *MockTaskEngineMockRecorder) TaskEngineClient() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TaskEngineClient", reflect.TypeOf((*MockTaskEngine)(nil).TaskEngineClient))
 }
 
 // UnmarshalJSON mocks base method

--- a/agent/stats/common_test.go
+++ b/agent/stats/common_test.go
@@ -23,6 +23,7 @@ import (
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/data"
+	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	"github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
 	"github.com/aws/amazon-ecs-agent/agent/statechange"
@@ -303,6 +304,10 @@ func (engine *MockTaskEngine) SetDataClient(data.Client) {
 }
 
 func (engine *MockTaskEngine) AddTask(*apitask.Task) {
+}
+
+func (engine *MockTaskEngine) TaskEngineClient() dockerapi.DockerClient {
+	return nil
 }
 
 func (engine *MockTaskEngine) ListTasks() ([]*apitask.Task, error) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Add healthcheck runner (Doctor) and Healthcheck; update acs heartbeat handler to trigger a *basic* docker ping healthcheck.

### Implementation details
Please note:
This PR is meant to only add the Doctor.  It has a basic docker ping for demo purposes only.  
As the first commit to the `feature/instance-health` branch, it's meant as a framework to build into.
Next will be a PR to add the true Container Runtime check, including setting check status and timestamps
Following that will be a PR to aggregate the healthcheck statuses into a message to send to TACS.
Then there will be the actual message sending. 

So this is NOT everything.  It's just the Doctor.
 
The Doctor keeps track of an array of Healthchecks (where Healthcheck is an interface).  It exposes the RunTests() method to trigger each of these checks.
The Healthchecks will contain their current and last status as well as timestamps for each; the Doctor will read these to create its ultimate healthcheck message to send on to TACS.

### Testing
built agent and ran to see the healthchecks appear in `/var/log/ecs/ecs-agent.log`:
```
level=info time=2021-05-11T17:26:37Z msg="Received heartbeat from ACS" module=healthcheck.go
level=info time=2021-05-11T17:26:37Z msg="healthcheck response: {0xc0005ec800 <nil>}" module=healthcheck.go
level=info time=2021-05-11T17:26:37Z msg="healthcheck result: true" module=doctor.go
```
also added basic unit tests and ran them:
```
[ec2-user@ip-172-31-32-159 agent]$ go test -count=1 -v -tags unit ./doctor/
=== RUN   TestNewDoctor
--- PASS: TestNewDoctor (0.00s)
=== RUN   TestAddHealthcheck
--- PASS: TestAddHealthcheck (0.00s)
=== RUN   TestOk
--- PASS: TestOk (0.00s)
=== RUN   TestUnmarshalHealthcheckStatus
--- PASS: TestUnmarshalHealthcheckStatus (0.00s)
PASS
```
I'll add more detailed tests once we have more detailed Healthchecks.
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

### Description for the changelog
Add test runner (Doctor) and basic docker ping Healthcheck.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
