### PR TITLE
adding check to validate default config file path for Windows

### DIFF
--- a/agent/Gopkg.lock
+++ b/agent/Gopkg.lock
@@ -309,6 +309,14 @@
   version = "v1.2.0"
 
 [[projects]]
+  branch = "master"
+  digest = "1:0795133a65ff7ee9109d570ba36fe54616e947a4089456422ed4556cdde4c598"
+  name = "github.com/hectane/go-acl"
+  packages = ["api"]
+  pruneopts = "UT"
+  revision = "da78bae5fc95895d8855ed8c5b1505b10e254450"
+
+[[projects]]
   digest = "1:bb81097a5b62634f3e9fec1014657855610c82d19b9a40c17612e32651e35dca"
   name = "github.com/jmespath/go-jmespath"
   packages = ["."]
@@ -577,6 +585,7 @@
     "github.com/golang/mock/mockgen/model",
     "github.com/gorilla/mux",
     "github.com/gorilla/websocket",
+    "github.com/hectane/go-acl/api",
     "github.com/opencontainers/runtime-spec/specs-go",
     "github.com/pborman/uuid",
     "github.com/pkg/errors",

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -437,8 +437,11 @@ func (cfg *Config) complete() bool {
 }
 
 func fileConfig() (Config, error) {
-	fileName := utils.DefaultIfBlank(os.Getenv("ECS_AGENT_CONFIG_FILE_PATH"), defaultConfigFileName)
 	cfg := Config{}
+	fileName, err := getConfigFileName()
+	if err != nil {
+		return cfg, nil
+	}
 
 	file, err := os.Open(fileName)
 	if err != nil {

--- a/agent/config/config_unix.go
+++ b/agent/config/config_unix.go
@@ -117,3 +117,7 @@ func (cfg *Config) platformString() string {
 	}
 	return ""
 }
+
+func getConfigFileName() (string, error) {
+	return utils.DefaultIfBlank(os.Getenv("ECS_AGENT_CONFIG_FILE_PATH"), defaultConfigFileName), nil
+}

--- a/agent/config/config_windows.go
+++ b/agent/config/config_windows.go
@@ -19,8 +19,13 @@ import (
 	"path/filepath"
 	"time"
 
+	"golang.org/x/sys/windows"
+
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
+
+	"github.com/cihub/seelog"
+	"github.com/hectane/go-acl/api"
 )
 
 const (
@@ -55,6 +60,9 @@ const (
 	minimumContainerCreateTimeout = 1 * time.Minute
 	// default image pull inactivity time is extra time needed on container extraction
 	defaultImagePullInactivityTimeout = 3 * time.Minute
+	// adminSid is the security ID for the admin group on Windows
+	// Reference: https://docs.microsoft.com/en-us/troubleshoot/windows-server/identity/security-identifiers-in-windows
+	adminSid = "S-1-5-32-544"
 )
 
 // DefaultConfig returns the default configuration for Windows
@@ -143,4 +151,66 @@ func (cfg *Config) platformOverrides() {
 // to string for debugging
 func (cfg *Config) platformString() string {
 	return ""
+}
+
+var getNamedSecurityInfo = api.GetNamedSecurityInfo
+
+// validateConfigFile checks if the config file owner is an admin
+// Reference: https://github.com/hectane/go-acl#using-the-api-directly
+func validateConfigFile(configFileName string) (bool, error) {
+	var (
+		Sid    *windows.SID
+		handle windows.Handle
+	)
+	err := getNamedSecurityInfo(
+		configFileName,
+		api.SE_FILE_OBJECT,
+		api.OWNER_SECURITY_INFORMATION,
+		&Sid,
+		nil,
+		nil,
+		nil,
+		&handle,
+	)
+	if err != nil {
+		return false, err
+	}
+	defer windows.LocalFree(handle)
+
+	id, err := Sid.String()
+	if err != nil {
+		return false, err
+	}
+
+	if id == adminSid {
+		return true, nil
+	}
+	seelog.Debugf("Non-admin cfg file owner with SID: %v, skip merging into agent config", id)
+	return false, nil
+}
+
+var osStat = os.Stat
+
+func getConfigFileName() (string, error) {
+	fileName := os.Getenv("ECS_AGENT_CONFIG_FILE_PATH")
+	// validate the config file only if above env var is not set
+	if len(fileName) == 0 {
+		fileName = defaultConfigFileName
+		// check if the default config file exists before validating it
+		_, err := osStat(fileName)
+		if err != nil {
+			return "", err
+		}
+
+		isValidFile, err := validateConfigFile(fileName)
+		if err != nil {
+			seelog.Errorf("Unable to validate cfg file: %v, err: %v", fileName, err)
+			return "", err
+		}
+		if !isValidFile {
+			seelog.Error("Invalid cfg file")
+			return "", err
+		}
+	}
+	return fileName, nil
 }

--- a/agent/vendor/github.com/hectane/go-acl/LICENSE.txt
+++ b/agent/vendor/github.com/hectane/go-acl/LICENSE.txt
@@ -1,0 +1,9 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Nathan Osman
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/agent/vendor/github.com/hectane/go-acl/api/acl.go
+++ b/agent/vendor/github.com/hectane/go-acl/api/acl.go
@@ -1,0 +1,98 @@
+//+build windows
+
+package api
+
+import (
+	"golang.org/x/sys/windows"
+
+	"unsafe"
+)
+
+// https://msdn.microsoft.com/en-us/library/windows/desktop/aa379284.aspx
+const (
+	NO_MULTIPLE_TRUSTEE = iota
+	TRUSTEE_IS_IMPERSONATE
+)
+
+// https://msdn.microsoft.com/en-us/library/windows/desktop/aa379638.aspx
+const (
+	TRUSTEE_IS_SID = iota
+	TRUSTEE_IS_NAME
+	TRUSTEE_BAD_FORM
+	TRUSTEE_IS_OBJECTS_AND_SID
+	TRUSTEE_IS_OBJECTS_AND_NAME
+)
+
+// https://msdn.microsoft.com/en-us/library/windows/desktop/aa379639.aspx
+const (
+	TRUSTEE_IS_UNKNOWN = iota
+	TRUSTEE_IS_USER
+	TRUSTEE_IS_GROUP
+	TRUSTEE_IS_DOMAIN
+	TRUSTEE_IS_ALIAS
+	TRUSTEE_IS_WELL_KNOWN_GROUP
+	TRUSTEE_IS_DELETED
+	TRUSTEE_IS_INVALID
+	TRUSTEE_IS_COMPUTER
+)
+
+// https://msdn.microsoft.com/en-us/library/windows/desktop/aa374899.aspx
+const (
+	NOT_USED_ACCESS = iota
+	GRANT_ACCESS
+	SET_ACCESS
+	DENY_ACCESS
+	REVOKE_ACCESS
+	SET_AUDIT_SUCCESS
+	SET_AUDIT_FAILURE
+)
+
+// https://msdn.microsoft.com/en-us/library/windows/desktop/aa446627.aspx
+const (
+	NO_INHERITANCE                     = 0x0
+	SUB_OBJECTS_ONLY_INHERIT           = 0x1
+	SUB_CONTAINERS_ONLY_INHERIT        = 0x2
+	SUB_CONTAINERS_AND_OBJECTS_INHERIT = 0x3
+	INHERIT_NO_PROPAGATE               = 0x4
+	INHERIT_ONLY                       = 0x8
+
+	OBJECT_INHERIT_ACE       = 0x1
+	CONTAINER_INHERIT_ACE    = 0x2
+	NO_PROPAGATE_INHERIT_ACE = 0x4
+	INHERIT_ONLY_ACE         = 0x8
+)
+
+var (
+	procSetEntriesInAclW = advapi32.MustFindProc("SetEntriesInAclW")
+)
+
+// https://msdn.microsoft.com/en-us/library/windows/desktop/aa379636.aspx
+type Trustee struct {
+	MultipleTrustee          *Trustee
+	MultipleTrusteeOperation int32
+	TrusteeForm              int32
+	TrusteeType              int32
+	Name                     *uint16
+}
+
+// https://msdn.microsoft.com/en-us/library/windows/desktop/aa446627.aspx
+type ExplicitAccess struct {
+	AccessPermissions uint32
+	AccessMode        int32
+	Inheritance       uint32
+	Trustee           Trustee
+}
+
+// https://msdn.microsoft.com/en-us/library/windows/desktop/aa379576.aspx
+func SetEntriesInAcl(entries []ExplicitAccess, oldAcl windows.Handle, newAcl *windows.Handle) error {
+	ret, _, err := procSetEntriesInAclW.Call(
+		uintptr(len(entries)),
+		uintptr(unsafe.Pointer(&entries[0])),
+		uintptr(oldAcl),
+		uintptr(unsafe.Pointer(newAcl)),
+	)
+	if ret != 0 {
+		return err
+	}
+	return nil
+}

--- a/agent/vendor/github.com/hectane/go-acl/api/api.go
+++ b/agent/vendor/github.com/hectane/go-acl/api/api.go
@@ -1,0 +1,10 @@
+//+build windows
+
+// Windows API functions for manipulating ACLs.
+package api
+
+import (
+	"golang.org/x/sys/windows"
+)
+
+var advapi32 = windows.MustLoadDLL("advapi32.dll")

--- a/agent/vendor/github.com/hectane/go-acl/api/posix.go
+++ b/agent/vendor/github.com/hectane/go-acl/api/posix.go
@@ -1,0 +1,3 @@
+//+build !windows
+
+package api

--- a/agent/vendor/github.com/hectane/go-acl/api/secinfo.go
+++ b/agent/vendor/github.com/hectane/go-acl/api/secinfo.go
@@ -1,0 +1,84 @@
+//+build windows
+
+package api
+
+import (
+	"golang.org/x/sys/windows"
+
+	"unsafe"
+)
+
+// https://msdn.microsoft.com/en-us/library/windows/desktop/aa379593.aspx
+const (
+	SE_UNKNOWN_OBJECT_TYPE = iota
+	SE_FILE_OBJECT
+	SE_SERVICE
+	SE_PRINTER
+	SE_REGISTRY_KEY
+	SE_LMSHARE
+	SE_KERNEL_OBJECT
+	SE_WINDOW_OBJECT
+	SE_DS_OBJECT
+	SE_DS_OBJECT_ALL
+	SE_PROVIDER_DEFINED_OBJECT
+	SE_WMIGUID_OBJECT
+	SE_REGISTRY_WOW64_32KEY
+)
+
+// https://msdn.microsoft.com/en-us/library/windows/desktop/aa379573.aspx
+const (
+	OWNER_SECURITY_INFORMATION               = 0x00001
+	GROUP_SECURITY_INFORMATION               = 0x00002
+	DACL_SECURITY_INFORMATION                = 0x00004
+	SACL_SECURITY_INFORMATION                = 0x00008
+	LABEL_SECURITY_INFORMATION               = 0x00010
+	ATTRIBUTE_SECURITY_INFORMATION           = 0x00020
+	SCOPE_SECURITY_INFORMATION               = 0x00040
+	PROCESS_TRUST_LABEL_SECURITY_INFORMATION = 0x00080
+	BACKUP_SECURITY_INFORMATION              = 0x10000
+
+	PROTECTED_DACL_SECURITY_INFORMATION   = 0x80000000
+	PROTECTED_SACL_SECURITY_INFORMATION   = 0x40000000
+	UNPROTECTED_DACL_SECURITY_INFORMATION = 0x20000000
+	UNPROTECTED_SACL_SECURITY_INFORMATION = 0x10000000
+)
+
+var (
+	procGetNamedSecurityInfoW = advapi32.MustFindProc("GetNamedSecurityInfoW")
+	procSetNamedSecurityInfoW = advapi32.MustFindProc("SetNamedSecurityInfoW")
+)
+
+// https://msdn.microsoft.com/en-us/library/windows/desktop/aa446645.aspx
+func GetNamedSecurityInfo(objectName string, objectType int32, secInfo uint32, owner, group **windows.SID, dacl, sacl, secDesc *windows.Handle) error {
+	ret, _, err := procGetNamedSecurityInfoW.Call(
+		uintptr(unsafe.Pointer(windows.StringToUTF16Ptr(objectName))),
+		uintptr(objectType),
+		uintptr(secInfo),
+		uintptr(unsafe.Pointer(owner)),
+		uintptr(unsafe.Pointer(group)),
+		uintptr(unsafe.Pointer(dacl)),
+		uintptr(unsafe.Pointer(sacl)),
+		uintptr(unsafe.Pointer(secDesc)),
+	)
+	if ret != 0 {
+		return err
+	}
+	return nil
+}
+
+// https://msdn.microsoft.com/en-us/library/windows/desktop/aa379579.aspx
+func SetNamedSecurityInfo(objectName string, objectType int32, secInfo uint32, owner, group *windows.SID, dacl, sacl windows.Handle) error {
+	ret, _, err := procSetNamedSecurityInfoW.Call(
+		uintptr(unsafe.Pointer(windows.StringToUTF16Ptr(objectName))),
+		uintptr(objectType),
+		uintptr(secInfo),
+		uintptr(unsafe.Pointer(owner)),
+		uintptr(unsafe.Pointer(group)),
+		uintptr(dacl),
+		uintptr(sacl),
+	)
+	if ret != 0 {
+		return err
+	}
+	return nil
+}

--- a/agent/vendor/github.com/hectane/go-acl/api/sid.go
+++ b/agent/vendor/github.com/hectane/go-acl/api/sid.go
@@ -1,0 +1,131 @@
+//+build windows
+
+package api
+
+import (
+	"golang.org/x/sys/windows"
+
+	"unsafe"
+)
+
+// https://msdn.microsoft.com/en-us/library/windows/desktop/ee207397.aspx
+const (
+	SECURITY_MAX_SID_SIZE = 68
+)
+
+// https://msdn.microsoft.com/en-us/library/windows/desktop/aa379650.aspx
+const (
+	WinNullSid                                  = 0
+	WinWorldSid                                 = 1
+	WinLocalSid                                 = 2
+	WinCreatorOwnerSid                          = 3
+	WinCreatorGroupSid                          = 4
+	WinCreatorOwnerServerSid                    = 5
+	WinCreatorGroupServerSid                    = 6
+	WinNtAuthoritySid                           = 7
+	WinDialupSid                                = 8
+	WinNetworkSid                               = 9
+	WinBatchSid                                 = 10
+	WinInteractiveSid                           = 11
+	WinServiceSid                               = 12
+	WinAnonymousSid                             = 13
+	WinProxySid                                 = 14
+	WinEnterpriseControllersSid                 = 15
+	WinSelfSid                                  = 16
+	WinAuthenticatedUserSid                     = 17
+	WinRestrictedCodeSid                        = 18
+	WinTerminalServerSid                        = 19
+	WinRemoteLogonIdSid                         = 20
+	WinLogonIdsSid                              = 21
+	WinLocalSystemSid                           = 22
+	WinLocalServiceSid                          = 23
+	WinNetworkServiceSid                        = 24
+	WinBuiltinDomainSid                         = 25
+	WinBuiltinAdministratorsSid                 = 26
+	WinBuiltinUsersSid                          = 27
+	WinBuiltinGuestsSid                         = 28
+	WinBuiltinPowerUsersSid                     = 29
+	WinBuiltinAccountOperatorsSid               = 30
+	WinBuiltinSystemOperatorsSid                = 31
+	WinBuiltinPrintOperatorsSid                 = 32
+	WinBuiltinBackupOperatorsSid                = 33
+	WinBuiltinReplicatorSid                     = 34
+	WinBuiltinPreWindows2000CompatibleAccessSid = 35
+	WinBuiltinRemoteDesktopUsersSid             = 36
+	WinBuiltinNetworkConfigurationOperatorsSid  = 37
+	WinAccountAdministratorSid                  = 38
+	WinAccountGuestSid                          = 39
+	WinAccountKrbtgtSid                         = 40
+	WinAccountDomainAdminsSid                   = 41
+	WinAccountDomainUsersSid                    = 42
+	WinAccountDomainGuestsSid                   = 43
+	WinAccountComputersSid                      = 44
+	WinAccountControllersSid                    = 45
+	WinAccountCertAdminsSid                     = 46
+	WinAccountSchemaAdminsSid                   = 47
+	WinAccountEnterpriseAdminsSid               = 48
+	WinAccountPolicyAdminsSid                   = 49
+	WinAccountRasAndIasServersSid               = 50
+	WinNTLMAuthenticationSid                    = 51
+	WinDigestAuthenticationSid                  = 52
+	WinSChannelAuthenticationSid                = 53
+	WinThisOrganizationSid                      = 54
+	WinOtherOrganizationSid                     = 55
+	WinBuiltinIncomingForestTrustBuildersSid    = 56
+	WinBuiltinPerfMonitoringUsersSid            = 57
+	WinBuiltinPerfLoggingUsersSid               = 58
+	WinBuiltinAuthorizationAccessSid            = 59
+	WinBuiltinTerminalServerLicenseServersSid   = 60
+	WinBuiltinDCOMUsersSid                      = 61
+	WinBuiltinIUsersSid                         = 62
+	WinIUserSid                                 = 63
+	WinBuiltinCryptoOperatorsSid                = 64
+	WinUntrustedLabelSid                        = 65
+	WinLowLabelSid                              = 66
+	WinMediumLabelSid                           = 67
+	WinHighLabelSid                             = 68
+	WinSystemLabelSid                           = 69
+	WinWriteRestrictedCodeSid                   = 70
+	WinCreatorOwnerRightsSid                    = 71
+	WinCacheablePrincipalsGroupSid              = 72
+	WinNonCacheablePrincipalsGroupSid           = 73
+	WinEnterpriseReadonlyControllersSid         = 74
+	WinAccountReadonlyControllersSid            = 75
+	WinBuiltinEventLogReadersGroup              = 76
+	WinNewEnterpriseReadonlyControllersSid      = 77
+	WinBuiltinCertSvcDComAccessGroup            = 78
+	WinMediumPlusLabelSid                       = 79
+	WinLocalLogonSid                            = 80
+	WinConsoleLogonSid                          = 81
+	WinThisOrganizationCertificateSid           = 82
+	WinApplicationPackageAuthoritySid           = 83
+	WinBuiltinAnyPackageSid                     = 84
+	WinCapabilityInternetClientSid              = 85
+	WinCapabilityInternetClientServerSid        = 86
+	WinCapabilityPrivateNetworkClientServerSid  = 87
+	WinCapabilityPicturesLibrarySid             = 88
+	WinCapabilityVideosLibrarySid               = 89
+	WinCapabilityMusicLibrarySid                = 90
+	WinCapabilityDocumentsLibrarySid            = 91
+	WinCapabilitySharedUserCertificatesSid      = 92
+	WinCapabilityEnterpriseAuthenticationSid    = 93
+	WinCapabilityRemovableStorageSid            = 94
+)
+
+var (
+	procCreateWellKnownSid = advapi32.MustFindProc("CreateWellKnownSid")
+)
+
+// https://msdn.microsoft.com/en-us/library/windows/desktop/aa446585.aspx
+func CreateWellKnownSid(sidType int32, sidDomain, sid *windows.SID, sidLen *uint32) error {
+	ret, _, err := procCreateWellKnownSid.Call(
+		uintptr(sidType),
+		uintptr(unsafe.Pointer(sidDomain)),
+		uintptr(unsafe.Pointer(sid)),
+		uintptr(unsafe.Pointer(sidLen)),
+	)
+	if ret == 0 {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
### Summary
<!-- What does this pull request do? -->
The PR adds a check to validate the default agent config file path on Windows. 

Currently, the default config file path on Windows is ```"C:/etc/ecs_container_agent/config.json"```. We're adding a check to validate whether the admin has created the config file or not. Note that this check is not done if the env ```ECS_AGENT_CONFIG_FILE_PATH``` is set, since it overrides the default config file.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
