### PR TITLE
EC2 Task Networking on Windows: Behavior change of cleanupNS and increased CNI setup time limits

### DIFF
--- a/agent/api/task/task_windows.go
+++ b/agent/api/task/task_windows.go
@@ -278,7 +278,7 @@ func (task *Task) BuildCNIConfig(includeIPAMConfig bool, cniConfig *ecscni.Confi
 
 		// IfName is expected by the plugin but is not used.
 		cniConfig.NetworkConfigs = append(cniConfig.NetworkConfigs, &ecscni.NetworkConfig{
-			IfName:           eni.GetLinkName(),
+			IfName:           eni.ID,
 			CNINetworkConfig: netconf,
 		})
 	}

--- a/agent/ecscni/plugin.go
+++ b/agent/ecscni/plugin.go
@@ -19,9 +19,11 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/logger"
+	"github.com/cihub/seelog"
 	"github.com/containernetworking/cni/libcni"
 	"github.com/containernetworking/cni/pkg/types/current"
 	"github.com/pkg/errors"
@@ -45,6 +47,27 @@ type CNIClient interface {
 	ReleaseIPResource(context.Context, *Config, time.Duration) error
 }
 
+// cniGuard is the mutex interface for CNI Client.
+// It is actively used only on Windows due to limitations of hcsshim.
+// It is used to serialize the cleanupNS calls when multiple tasks are stopped at the same time.
+// During setupNS, we use retries for better task startup performance.
+type cniGuard interface {
+	lock()
+	unlock()
+}
+
+// cniClient is the client to call plugin and setup the network
+type cniClient struct {
+	pluginsPath string
+	libcni      libcni.CNI
+	guard       cniGuard
+}
+
+// guard is the client to call lock and unlock methods on the mutex.
+type guard struct {
+	mutex *sync.Mutex
+}
+
 // NewClient creates a client of ecscni which is used to invoke the plugin
 func NewClient(pluginsPath string) CNIClient {
 	libcniConfig := &libcni.CNIConfig{
@@ -54,6 +77,7 @@ func NewClient(pluginsPath string) CNIClient {
 	cniClient := &cniClient{
 		pluginsPath: pluginsPath,
 		libcni:      libcniConfig,
+		guard:       newCNIGuard(),
 	}
 	cniClient.init()
 	return cniClient
@@ -89,6 +113,46 @@ func (client *cniClient) CleanupNS(
 	defer cancel()
 
 	return client.cleanupNS(ctx, cfg)
+}
+
+// cleanupNS is called by CleanupNS to cleanup the task namespace by invoking DEL for given CNI configurations
+func (client *cniClient) cleanupNS(ctx context.Context, cfg *Config) error {
+	client.guard.lock()
+	defer client.guard.unlock()
+
+	seelog.Debugf("[ECSCNI] Cleaning up the container namespace %s", cfg.ContainerID)
+
+	runtimeConfig := libcni.RuntimeConf{
+		ContainerID: cfg.ContainerID,
+		NetNS:       cfg.ContainerNetNS,
+	}
+
+	var delError error
+	// Execute all CNI network configurations serially, in the reverse order.
+	for i := len(cfg.NetworkConfigs) - 1; i >= 0; i-- {
+		networkConfig := cfg.NetworkConfigs[i]
+		cniNetworkConfig := networkConfig.CNINetworkConfig
+		seelog.Debugf("[ECSCNI] Deleting network %s type %s in the container namespace %s",
+			cniNetworkConfig.Network.Name,
+			cniNetworkConfig.Network.Type,
+			cfg.ContainerID)
+		runtimeConfig.IfName = networkConfig.IfName
+		err := client.libcni.DelNetwork(ctx, cniNetworkConfig, &runtimeConfig)
+		if err != nil {
+			// In case of error, continue cleanup as much as possible before conceding error.
+			seelog.Errorf("Delete network failed: %v", err)
+			delError = errors.Wrapf(err, "delete network failed")
+		}
+
+		seelog.Debugf("[ECSCNI] Completed deleting network %s type %s in the container namespace %s",
+			cniNetworkConfig.Network.Name,
+			cniNetworkConfig.Network.Type,
+			cfg.ContainerID)
+	}
+
+	seelog.Debugf("[ECSCNI] Completed cleaning up the container namespace %s", cfg.ContainerID)
+
+	return delError
 }
 
 // Version returns the version of the plugin
@@ -146,4 +210,16 @@ func (client *cniClient) Capabilities(name string) ([]string, error) {
 	}
 
 	return capabilities.Capabilities, nil
+}
+
+func (cniGuard *guard) lock() {
+	if cniGuard.mutex != nil {
+		cniGuard.mutex.Lock()
+	}
+}
+
+func (cniGuard *guard) unlock() {
+	if cniGuard.mutex != nil {
+		cniGuard.mutex.Unlock()
+	}
 }

--- a/agent/ecscni/plugin_linux.go
+++ b/agent/ecscni/plugin_linux.go
@@ -39,6 +39,12 @@ const (
 	vpcCNIPluginPath = "/log/vpc-branch-eni.log"
 )
 
+// cniClient is the client to call plugin and setup the network.
+type cniClient struct {
+	pluginsPath string
+	libcni      libcni.CNI
+}
+
 // setupNS is the called by SetupNS to setup the task namespace by invoking ADD for given CNI configurations
 func (client *cniClient) setupNS(ctx context.Context, cfg *Config) (*current.Result, error) {
 	seelog.Debugf("[ECSCNI] Setting up the container namespace %s", cfg.ContainerID)
@@ -89,6 +95,40 @@ func (client *cniClient) setupNS(ctx context.Context, cfg *Config) (*current.Res
 	}
 
 	return curResult, nil
+}
+
+// cleanupNS is called by CleanupNS to cleanup the task namespace by invoking DEL for given CNI configurations.
+func (client *cniClient) cleanupNS(ctx context.Context, cfg *Config) error {
+	seelog.Debugf("[ECSCNI] Cleaning up the container namespace %s", cfg.ContainerID)
+
+	runtimeConfig := libcni.RuntimeConf{
+		ContainerID: cfg.ContainerID,
+		NetNS:       cfg.ContainerNetNS,
+	}
+
+	// Execute all CNI network configurations serially, in the reverse order.
+	for i := len(cfg.NetworkConfigs) - 1; i >= 0; i-- {
+		networkConfig := cfg.NetworkConfigs[i]
+		cniNetworkConfig := networkConfig.CNINetworkConfig
+		seelog.Debugf("[ECSCNI] Deleting network %s type %s in the container namespace %s",
+			cniNetworkConfig.Network.Name,
+			cniNetworkConfig.Network.Type,
+			cfg.ContainerID)
+		runtimeConfig.IfName = networkConfig.IfName
+		err := client.libcni.DelNetwork(ctx, cniNetworkConfig, &runtimeConfig)
+		if err != nil {
+			return errors.Wrap(err, "delete network failed")
+		}
+
+		seelog.Debugf("[ECSCNI] Completed deleting network %s type %s in the container namespace %s",
+			cniNetworkConfig.Network.Name,
+			cniNetworkConfig.Network.Type,
+			cfg.ContainerID)
+	}
+
+	seelog.Debugf("[ECSCNI] Completed cleaning up the container namespace %s", cfg.ContainerID)
+
+	return nil
 }
 
 // ReleaseIPResource marks the ip available in the ipam db

--- a/agent/ecscni/plugin_linux.go
+++ b/agent/ecscni/plugin_linux.go
@@ -39,10 +39,12 @@ const (
 	vpcCNIPluginPath = "/log/vpc-branch-eni.log"
 )
 
-// cniClient is the client to call plugin and setup the network.
-type cniClient struct {
-	pluginsPath string
-	libcni      libcni.CNI
+// newCNIGuard returns a new instance of CNI guard for the CNI client.
+// It is supported only on Windows.
+func newCNIGuard() cniGuard {
+	return &guard{
+		mutex: nil,
+	}
 }
 
 // setupNS is the called by SetupNS to setup the task namespace by invoking ADD for given CNI configurations
@@ -95,40 +97,6 @@ func (client *cniClient) setupNS(ctx context.Context, cfg *Config) (*current.Res
 	}
 
 	return curResult, nil
-}
-
-// cleanupNS is called by CleanupNS to cleanup the task namespace by invoking DEL for given CNI configurations.
-func (client *cniClient) cleanupNS(ctx context.Context, cfg *Config) error {
-	seelog.Debugf("[ECSCNI] Cleaning up the container namespace %s", cfg.ContainerID)
-
-	runtimeConfig := libcni.RuntimeConf{
-		ContainerID: cfg.ContainerID,
-		NetNS:       cfg.ContainerNetNS,
-	}
-
-	// Execute all CNI network configurations serially, in the reverse order.
-	for i := len(cfg.NetworkConfigs) - 1; i >= 0; i-- {
-		networkConfig := cfg.NetworkConfigs[i]
-		cniNetworkConfig := networkConfig.CNINetworkConfig
-		seelog.Debugf("[ECSCNI] Deleting network %s type %s in the container namespace %s",
-			cniNetworkConfig.Network.Name,
-			cniNetworkConfig.Network.Type,
-			cfg.ContainerID)
-		runtimeConfig.IfName = networkConfig.IfName
-		err := client.libcni.DelNetwork(ctx, cniNetworkConfig, &runtimeConfig)
-		if err != nil {
-			return errors.Wrap(err, "delete network failed")
-		}
-
-		seelog.Debugf("[ECSCNI] Completed deleting network %s type %s in the container namespace %s",
-			cniNetworkConfig.Network.Name,
-			cniNetworkConfig.Network.Type,
-			cfg.ContainerID)
-	}
-
-	seelog.Debugf("[ECSCNI] Completed cleaning up the container namespace %s", cfg.ContainerID)
-
-	return nil
 }
 
 // ReleaseIPResource marks the ip available in the ipam db

--- a/agent/ecscni/plugin_unsupported.go
+++ b/agent/ecscni/plugin_unsupported.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/containernetworking/cni/libcni"
 	"github.com/containernetworking/cni/pkg/types/current"
 )
 
@@ -28,12 +29,23 @@ const (
 	vpcCNIPluginPath = "/log/vpc-branch-eni.log"
 )
 
+// cniClient is the client to call plugin and setup the network
+type cniClient struct {
+	pluginsPath string
+	libcni      libcni.CNI
+}
+
 type cniPluginVersion struct{}
 
 // setupNS is the called by SetupNS to setup the task namespace by invoking ADD for given CNI configurations
 // On unsupported platforms, we will return an error
 func (client *cniClient) setupNS(ctx context.Context, cfg *Config) (*current.Result, error) {
 	return nil, errors.New("unsupported platform")
+}
+
+// cleanupNS is called by CleanupNS to cleanup the task namespace by invoking DEL for given CNI configurations.
+func (client *cniClient) cleanupNS(ctx context.Context, cfg *Config) error {
+	return errors.New("unsupported platform")
 }
 
 // ReleaseIPResource marks the ip available in the ipam db

--- a/agent/ecscni/plugin_unsupported.go
+++ b/agent/ecscni/plugin_unsupported.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"time"
 
-	"github.com/containernetworking/cni/libcni"
 	"github.com/containernetworking/cni/pkg/types/current"
 )
 
@@ -29,10 +28,12 @@ const (
 	vpcCNIPluginPath = "/log/vpc-branch-eni.log"
 )
 
-// cniClient is the client to call plugin and setup the network
-type cniClient struct {
-	pluginsPath string
-	libcni      libcni.CNI
+// newCNIGuard returns a new instance of CNI guard for the CNI client.
+// It is supported only on Windows.
+func newCNIGuard() cniGuard {
+	return &guard{
+		mutex: nil,
+	}
 }
 
 type cniPluginVersion struct{}
@@ -41,11 +42,6 @@ type cniPluginVersion struct{}
 // On unsupported platforms, we will return an error
 func (client *cniClient) setupNS(ctx context.Context, cfg *Config) (*current.Result, error) {
 	return nil, errors.New("unsupported platform")
-}
-
-// cleanupNS is called by CleanupNS to cleanup the task namespace by invoking DEL for given CNI configurations.
-func (client *cniClient) cleanupNS(ctx context.Context, cfg *Config) error {
-	return errors.New("unsupported platform")
 }
 
 // ReleaseIPResource marks the ip available in the ipam db

--- a/agent/ecscni/plugin_windows.go
+++ b/agent/ecscni/plugin_windows.go
@@ -41,11 +41,11 @@ var (
 		"Amazon", "ECS", "log", "vpc-eni.log")
 )
 
-// cniClient is the client to call plugin and setup the network.
-type cniClient struct {
-	pluginsPath string
-	libcni      libcni.CNI
-	guard       sync.Mutex
+// newCNIGuard returns a new instance of CNI guard for the CNI client.
+func newCNIGuard() cniGuard {
+	return &guard{
+		mutex: &sync.Mutex{},
+	}
 }
 
 // setupNS is the called by SetupNS to setup the task namespace by invoking ADD for given CNI configurations.
@@ -120,46 +120,6 @@ func (client *cniClient) doSetupNS(ctx context.Context, cfg *Config) (*current.R
 	}
 
 	return curResult, nil
-}
-
-// cleanupNS is called by CleanupNS to cleanup the task namespace by invoking DEL for given CNI configurations.
-func (client *cniClient) cleanupNS(ctx context.Context, cfg *Config) error {
-	client.guard.Lock()
-	defer client.guard.Unlock()
-
-	seelog.Debugf("[ECSCNI] Cleaning up the container namespace %s", cfg.ContainerID)
-
-	runtimeConfig := libcni.RuntimeConf{
-		ContainerID: cfg.ContainerID,
-		NetNS:       cfg.ContainerNetNS,
-	}
-
-	var delError error = nil
-	// Execute all CNI network configurations serially, in the reverse order.
-	for i := len(cfg.NetworkConfigs) - 1; i >= 0; i-- {
-		networkConfig := cfg.NetworkConfigs[i]
-		cniNetworkConfig := networkConfig.CNINetworkConfig
-		seelog.Debugf("[ECSCNI] Deleting network %s type %s in the container namespace %s",
-			cniNetworkConfig.Network.Name,
-			cniNetworkConfig.Network.Type,
-			cfg.ContainerID)
-		runtimeConfig.IfName = networkConfig.IfName
-		err := client.libcni.DelNetwork(ctx, cniNetworkConfig, &runtimeConfig)
-		if err != nil {
-			// In case of error, continue cleanup as much as possible before conceding error.
-			seelog.Errorf("Delete network failed: %v", err)
-			delError = errors.Wrapf(err, "delete network failed")
-		}
-
-		seelog.Debugf("[ECSCNI] Completed deleting network %s type %s in the container namespace %s",
-			cniNetworkConfig.Network.Name,
-			cniNetworkConfig.Network.Type,
-			cfg.ContainerID)
-	}
-
-	seelog.Debugf("[ECSCNI] Completed cleaning up the container namespace %s", cfg.ContainerID)
-
-	return delError
 }
 
 // ReleaseIPResource marks the ip available in the ipam db

--- a/agent/ecscni/plugin_windows_test.go
+++ b/agent/ecscni/plugin_windows_test.go
@@ -175,7 +175,7 @@ func TestCleanupNSTimeout(t *testing.T) {
 	// This will be called for both the endpoints.
 	libcniClient.EXPECT().DelNetwork(gomock.Any(), gomock.Any(), gomock.Any()).Do(
 		func(x interface{}, y interface{}, z interface{}) {
-		}).Return(errors.New("timeout")).MaxTimes(1)
+		}).Return(errors.New("timeout")).MaxTimes(2)
 
 	ctx, cancel := context.WithTimeout(context.TODO(), 1*time.Millisecond)
 	defer cancel()

--- a/agent/ecscni/types_windows.go
+++ b/agent/ecscni/types_windows.go
@@ -29,8 +29,8 @@ const (
 	// ECSBridgeNetworkName is the name of the HNS network used as ecs-bridge.
 	ECSBridgeNetworkName = "nat"
 	// Constants for creating backoff while retrying setupNS.
-	setupNSBackoffMin      = time.Second * 2
-	setupNSBackoffMax      = time.Second * 6
+	setupNSBackoffMin      = time.Second * 4
+	setupNSBackoffMax      = time.Minute
 	setupNSBackoffJitter   = 0.2
 	setupNSBackoffMultiple = 1.3
 	setupNSMaxRetryCount   = 3

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -69,8 +69,6 @@ const (
 	labelTaskDefinitionFamily          = labelPrefix + "task-definition-family"
 	labelTaskDefinitionVersion         = labelPrefix + "task-definition-version"
 	labelCluster                       = labelPrefix + "cluster"
-	cniSetupTimeout                    = 1 * time.Minute
-	cniCleanupTimeout                  = 30 * time.Second
 	minGetIPBridgeTimeout              = time.Second
 	maxGetIPBridgeTimeout              = 10 * time.Second
 	getIPBridgeRetryJitterMultiplier   = 0.2

--- a/agent/engine/docker_task_engine_linux.go
+++ b/agent/engine/docker_task_engine_linux.go
@@ -16,8 +16,16 @@
 package engine
 
 import (
+	"time"
+
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
+)
+
+const (
+	// Constants for CNI timeout during setup and cleanup.
+	cniSetupTimeout   = 1 * time.Minute
+	cniCleanupTimeout = 30 * time.Second
 )
 
 // updateTaskENIDependencies updates the task's dependencies for awsvpc networking mode.

--- a/agent/engine/docker_task_engine_unsupported.go
+++ b/agent/engine/docker_task_engine_unsupported.go
@@ -16,8 +16,16 @@
 package engine
 
 import (
+	"time"
+
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
+)
+
+const (
+	// Constants for CNI timeout during setup and cleanup.
+	cniSetupTimeout   = 1 * time.Minute
+	cniCleanupTimeout = 30 * time.Second
 )
 
 // updateTaskENIDependencies updates the task's dependencies for awsvpc networking mode.

--- a/agent/engine/docker_task_engine_unsupported.go
+++ b/agent/engine/docker_task_engine_unsupported.go
@@ -24,8 +24,8 @@ import (
 
 const (
 	// Constants for CNI timeout during setup and cleanup.
-	cniSetupTimeout   = 1 * time.Minute
-	cniCleanupTimeout = 30 * time.Second
+	cniSetupTimeout   = time.Duration(0)
+	cniCleanupTimeout = time.Duration(0)
 )
 
 // updateTaskENIDependencies updates the task's dependencies for awsvpc networking mode.

--- a/agent/engine/docker_task_engine_windows.go
+++ b/agent/engine/docker_task_engine_windows.go
@@ -16,10 +16,18 @@
 package engine
 
 import (
+	"time"
+
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	"github.com/cihub/seelog"
 	"github.com/pkg/errors"
+)
+
+const (
+	// Constants for CNI timeout during setup and cleanup on Windows.
+	cniSetupTimeout   = 3 * time.Minute
+	cniCleanupTimeout = 2 * time.Minute
 )
 
 func (engine *DockerTaskEngine) updateTaskENIDependencies(task *apitask.Task) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Following tasks have been accomplished in this PR-

- Segregate cleanupNS method into Linux and Windows specific files.
- Differences in Windows implementation as compared to Linux one are-
     1. The cleanup method is protected by a mutex. This is done because hcsshim does not allow parallel API invocations and therefore, the calls must be serialized.
     2. In case of error during one of the CNI plugin invocations, do not return an error immediately. Try to cleanup as much as possible before conceding error.
- CNI setup and cleanup time for Windows has been increased. This is required because CNI plugin calls might be retried or serialized.
- A minor test case from watcher package has been improved to avoid random test failures.


### Implementation details
<!-- How are the changes implemented? -->
Linux and Windows implementations have been segregated and necessary changes are implemented in the Windows implementation of the method.
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
The changes were tested using custom agent binary.

New tests cover the changes: <!-- yes|no -->
Yes
### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Behavior change of cleanupNS and increased CNI setup time limits
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
