### PR TITLE
EC2 task networking for Windows: Build vpc-eni plugin 

### DIFF
--- a/agent/stats/queue.go
+++ b/agent/stats/queue.go
@@ -100,7 +100,7 @@ func (queue *Queue) add(rawStat *ContainerStats) {
 			// if we got a duplicate timestamp, set cpu percentage to the same value as the previous stat
 			seelog.Errorf("Received a docker stat object with duplicate timestamp")
 			stat.CPUUsagePerc = lastStat.CPUUsagePerc
-			if stat.NetworkStats != nil {
+			if stat.NetworkStats != nil && lastStat.NetworkStats != nil {
 				stat.NetworkStats.RxBytesPerSecond = lastStat.NetworkStats.RxBytesPerSecond
 				stat.NetworkStats.TxBytesPerSecond = lastStat.NetworkStats.TxBytesPerSecond
 			}
@@ -109,7 +109,7 @@ func (queue *Queue) add(rawStat *ContainerStats) {
 			stat.CPUUsagePerc = 100 * cpuUsageSinceLastStat / timeSinceLastStat
 
 			//calculate per second Network metrics
-			if stat.NetworkStats != nil {
+			if stat.NetworkStats != nil && lastStat.NetworkStats != nil {
 				rxBytesSinceLastStat := float32(stat.NetworkStats.RxBytes - lastStat.NetworkStats.RxBytes)
 				txBytesSinceLastStat := float32(stat.NetworkStats.TxBytes - lastStat.NetworkStats.TxBytes)
 				stat.NetworkStats.RxBytesPerSecond = NanoSecToSec * (rxBytesSinceLastStat / timeSinceLastStat)

--- a/scripts/dockerfiles/Dockerfile.buildWindowsVPCCNIPlugins
+++ b/scripts/dockerfiles/Dockerfile.buildWindowsVPCCNIPlugins
@@ -19,10 +19,9 @@ ARG GOARCH
 
 ENV GOARCH ${GOARCH}
 ENV GOOS windows
-ENV BUILD_FLAGS "-tags disablekubeapi"
 
 RUN mkdir -p /go/src/github.com/aws/
 
 WORKDIR /go/src/github.com/aws/amazon-vpc-cni-plugins
 
-CMD ["make", "vpc-shared-eni"]
+CMD ["make", "vpc-eni"]

--- a/scripts/local-save
+++ b/scripts/local-save
@@ -31,10 +31,10 @@ stage_windows() {
 	cp out/amazon-ecs-agent.exe "${ziproot}"
 	cp -v misc/windows-deploy/*.ps1 "${ziproot}"
 
-	if [[ -f "${buildroot}/out/cni-plugins/vpc-shared-eni" ]]
+	if [[ -f "${buildroot}/out/cni-plugins/vpc-eni" ]]
 	then
 	  mkdir "${ziproot}/cni"
-	  mv "${buildroot}/out/cni-plugins/vpc-shared-eni" "${ziproot}/cni/vpc-shared-eni.exe"
+	  mv "${buildroot}/out/cni-plugins/vpc-eni" "${ziproot}/cni/vpc-eni.exe"
 	fi
 
 	pushd "${ziproot}"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
The primary changes made in this PR are-

- Build `vpc-eni` CNI plugin for Windows
- Bug fix: Pause container sends nil network stats initially (when no network is present) which can cause the agent to crash and restart.

### Implementation details
<!-- How are the changes implemented? -->

- Invoke make command for `vpc-eni` CNI plugin
- Add a nil check for the objects

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
A custom binary was built and tested.

New tests cover the changes: <!-- yes|no -->
No new functionality has been added

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Build `vpc-eni` CNI plugin for Windows task networking.
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
