### PR TITLE
Give up trying to stop container if max timeouts are reached

### DIFF
--- a/agent/engine/task_manager_test.go
+++ b/agent/engine/task_manager_test.go
@@ -73,8 +73,8 @@ func TestHandleEventError(t *testing.T) {
 			CurrentContainerKnownStatus:     apicontainerstatus.ContainerRunning,
 			Error:                           &dockerapi.DockerTimeoutError{},
 			ExpectedContainerKnownStatusSet: true,
-			ExpectedContainerKnownStatus:    apicontainerstatus.ContainerRunning,
-			ExpectedOK:                      false,
+			ExpectedContainerKnownStatus:    apicontainerstatus.ContainerStopped,
+			ExpectedOK:                      true,
 		},
 		{
 			Name:                        "Retriable error with stop",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Docker sometimes deadlocks when trying to stop a container (see [PR](https://github.com/moby/moby/pull/41588)). This has caused a number of issues so far.

To provide a work around, we give up after a number of failed stopContainer attempts (timeouts). If the max attempts are reached, we mark the container as stopped anyways, allowing the task to continue its course instead of being stuck indefinitely.
It has been observed that when this problem occurs (happens sparsely but consistently), the container process actually stops, so this change should be safe.

### Implementation details
* Retry a max number of times with back off when stop container timeouts occur
* The relevant UT was explicitly ending the task in a hacky way. Had this hacky way been absent, we would have realized that repeated timeouts cause the task to hang for ever. That has been fixed by removing the hack. Not we just expect the task to end normally after the max attempts are reached.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

Simulated docker stop container deadlock in an EC2 instance and verified that the task transitions to `STOPPED` after 3 timed out attempts to stop the container. See the logs below for the sequence of events during the test.

```bash
level=info time=2021-05-20T01:53:24Z msg="Task engine [...]: stopping container [angelar-test-container]" module=docker_task_engine.go
.
.
.
level=warn time=2021-05-20T01:59:35Z msg="Unable to stop container after 3 attempts timed out; giving up and marking container as stopped" module=docker_task_engine.go
level=debug time=2021-05-20T01:59:35Z msg="Task engine [...]: transitioned container [angelar-test-container (Runtime ID: ...)] to [STOPPED]" module=docker_task_engine.go
.
.
.
level=info time=2021-05-20T01:59:35Z msg="Task engine [...]: stopping container [~internal~ecs~pause]" module=docker_task_engine.go
.
.
.
level=warn time=2021-05-20T02:07:08Z msg="Unable to stop container after 3 attempts timed out; giving up and marking container as stopped" module=docker_task_engine.go
level=debug time=2021-05-20T02:07:08Z msg="Task engine [...]: transitioned container [~internal~ecs~pause (Runtime ID: ...)] to [STOPPED]" module=docker_task_engine.go
.
.
.
level=info time=2021-05-20T02:07:08Z msg="Managed task has reached stopped; waiting for container cleanup" taskARN="..."
```

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
* Bug: Fixes a bug where a task can be stuck in `RUNNING` indefinitely when a container can't be stopped due to an unresolved docker [bug](https://github.com/moby/moby/issues/41587) (see also the open [PR](https://github.com/moby/moby/pull/41588) in moby to fix the bug).
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
