### PR TITLE
Stop container bug fix

### DIFF
--- a/agent/dockerclient/dockerapi/docker_client.go
+++ b/agent/dockerclient/dockerapi/docker_client.go
@@ -753,7 +753,11 @@ func (dg *dockerGoClient) stopContainer(ctx context.Context, dockerID string, ti
 	metadata := dg.containerMetadata(ctx, dockerID)
 	if err != nil {
 		seelog.Errorf("DockerGoClient: error stopping container ID=%s: %v", dockerID, err)
-		if metadata.Error == nil {
+		if metadata.Error != nil {
+			// Wrap metadata.Error in CannotStopContainerError in order to make the whole stopContainer operation
+			// retryable.
+			metadata.Error = CannotStopContainerError{metadata.Error}
+		} else {
 			if strings.Contains(err.Error(), "No such container") {
 				err = NoSuchContainerError{dockerID}
 			}

--- a/agent/dockerclient/dockerapi/docker_client_test.go
+++ b/agent/dockerclient/dockerapi/docker_client_test.go
@@ -1008,6 +1008,34 @@ func TestDockerVersion(t *testing.T) {
 	assert.Equal(t, "1.6.0", str, "Got unexpected version string: "+str)
 }
 
+func TestSystemPing(t *testing.T) {
+	mockDockerSDK, client, _, _, _, done := dockerClientSetup(t)
+	defer done()
+
+	mockDockerSDK.EXPECT().Ping(gomock.Any()).Return(types.Ping{APIVersion: "test_docker_api"}, nil)
+
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	pingResponse := client.SystemPing(ctx, dockerclient.InfoTimeout)
+
+	assert.NoError(t, pingResponse.Error)
+	assert.Equal(t, "test_docker_api", pingResponse.Response.APIVersion)
+}
+
+func TestSystemPingError(t *testing.T) {
+	mockDockerSDK, client, _, _, _, done := dockerClientSetup(t)
+	defer done()
+
+	mockDockerSDK.EXPECT().Ping(gomock.Any()).Return(types.Ping{}, errors.New("test error"))
+
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	pingResponse := client.SystemPing(ctx, dockerclient.InfoTimeout)
+
+	assert.Error(t, pingResponse.Error)
+	assert.Nil(t, pingResponse.Response)
+}
+
 func TestDockerInfo(t *testing.T) {
 	mockDockerSDK, client, _, _, _, done := dockerClientSetup(t)
 	defer done()

--- a/agent/dockerclient/dockerapi/errors.go
+++ b/agent/dockerclient/dockerapi/errors.go
@@ -50,6 +50,12 @@ func (err *DockerTimeoutError) Error() string {
 // ErrorName returns the name of the error
 func (err *DockerTimeoutError) ErrorName() string { return DockerTimeoutErrorName }
 
+// IsRetriableError returns a boolean indicating whether the call that
+// generated the error can be retried.
+func (err DockerTimeoutError) IsRetriableError() bool {
+	return true
+}
+
 // OutOfMemoryError is a type for errors caused by running out of memory
 type OutOfMemoryError struct{}
 

--- a/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
+++ b/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
@@ -431,6 +431,20 @@ func (mr *MockDockerClientMockRecorder) SupportedVersions() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SupportedVersions", reflect.TypeOf((*MockDockerClient)(nil).SupportedVersions))
 }
 
+// SystemPing mocks base method
+func (m *MockDockerClient) SystemPing(arg0 context.Context, arg1 time.Duration) dockerapi.PingResponse {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SystemPing", arg0, arg1)
+	ret0, _ := ret[0].(dockerapi.PingResponse)
+	return ret0
+}
+
+// SystemPing indicates an expected call of SystemPing
+func (mr *MockDockerClientMockRecorder) SystemPing(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SystemPing", reflect.TypeOf((*MockDockerClient)(nil).SystemPing), arg0, arg1)
+}
+
 // TopContainer mocks base method
 func (m *MockDockerClient) TopContainer(arg0 context.Context, arg1 string, arg2 time.Duration, arg3 ...string) (*container0.ContainerTopOKBody, error) {
 	m.ctrl.T.Helper()

--- a/agent/dockerclient/dockerapi/types.go
+++ b/agent/dockerclient/dockerapi/types.go
@@ -97,6 +97,11 @@ type ListImagesResponse struct {
 	Error error
 }
 
+type PingResponse struct {
+	Response *types.Ping
+	Error    error
+}
+
 // VolumeResponse wrapper for CreateVolume and InspectVolume
 // TODO Remove type when migration is complete
 type VolumeResponse struct {

--- a/agent/engine/task_manager_test.go
+++ b/agent/engine/task_manager_test.go
@@ -84,8 +84,8 @@ func TestHandleEventError(t *testing.T) {
 				FromError: errors.New(""),
 			},
 			ExpectedContainerKnownStatusSet: true,
-			ExpectedContainerKnownStatus:    apicontainerstatus.ContainerRunning,
-			ExpectedOK:                      false,
+			ExpectedContainerKnownStatus:    apicontainerstatus.ContainerStopped,
+			ExpectedOK:                      true,
 		},
 		{
 			Name:                        "Unretriable error with Stop",
@@ -187,6 +187,15 @@ func TestHandleEventError(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			client := mock_dockerapi.NewMockDockerClient(ctrl)
+
+			if tc.EventStatus == apicontainerstatus.ContainerStopped {
+				client.EXPECT().SystemPing(gomock.Any(), gomock.Any()).Return(dockerapi.PingResponse{}).
+					Times(1)
+			}
+
 			container := &apicontainer.Container{
 				KnownStatusUnsafe: tc.CurrentContainerKnownStatus,
 			}
@@ -203,8 +212,9 @@ func TestHandleEventError(t *testing.T) {
 				Task: &apitask.Task{
 					Arn: "task1",
 				},
-				engine: &DockerTaskEngine{},
-				cfg:    &config.Config{ImagePullBehavior: tc.ImagePullBehavior},
+				engine:       &DockerTaskEngine{},
+				cfg:          &config.Config{ImagePullBehavior: tc.ImagePullBehavior},
+				dockerClient: client,
 			}
 			ok := mtask.handleEventError(containerChange, tc.CurrentContainerKnownStatus)
 			assert.Equal(t, tc.ExpectedOK, ok, "to proceed")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
There is an edge that can't prevent to correctly stop containers if the docker daemon crashes in the middle of stopping a task. This PR addresses this scenario.

### Implementation details

**Current behavior:** 
1. Stop request is received from ACS
2. Agent begins the task stop process, sending a `StopContainer` request to Docker
3. Docker panics while trying to stop the container due to a bug in fluentd log driver (to be fixed upstream). 
4. The ongoing `StopContainer` request initiated in `#2` is aborted because Docker crashes
5. The agent interprets the error in `#4` as a non-retryable error and marks the container as `STOPPED`, but the container is still in Docker's internal state (i.e. not stopped as far as Docker concerns)
6. ECS Agent restarts because Docker has crashed (notice ECS Agent doesn't stop at the same time than Docker, but a few seconds afterwards)
7. Upon ECS Agent restart, the task is marked as `STOPPED` (because `#5`)

In the end, the agent thinks that the task is `STOPPED`, but Docker **sometimes** doesn't actually finish cleaning up the container from its internal state, since it crashes before being able to. 
Aside of being a resource leak, this situation can create further complications, such as network port conflicts.

**New Behavior:**
1. Stop request is received from ACS
2. Agent begins the task stop process, sending a `StopContainer` request to Docker
3. Docker panics while trying to stop the container due to a bug in fluentd log driver (to be fixed upstream)
4. The ongoing `StopContainer` request initiated in `#2` is aborted because Docker crashes
5. **If the error from `#2` is retryable, retry up to 5 times** 
6. **If all retries are exhausted, mark the container as `STOPPED` \*only\* if Docker is responsive**
7. ECS Agent restarts because Docker has crashed (notice ECS Agent doesn't stop at the same time than Docker, but a few seconds afterwards)
8. **Upon ECS Agent restart, the task engine syncs its state with Docker and continues the stop process (because the container's known status is still `RUNNING`)**
9. **ECS Agent picks up where it left off and the container is marked as `STOPPED`**

Essentially, the flaw was to mark the container as `STOPPED` when the `StopContainer` was aborted due to Docker crashing. When this happens, the error will be something like `connection rest by peer`, or `EOF`. The reason we are doing `SystemPing` is that the mentioned errors can happen legitimately for reasons other than Docker crashing. We only want to ignore `StopContainer` errors  when Docker is unresponsive (even after all the retries were exhausted).

### Testing
* Modified/Added relevant UTs
* Tested on my dev account that:
  * Agent DOESN'T mark container as `STOPPED` after 5 max retries when Docker us unresponsive
  * Agent marks the container as `STOPPED` after 5 max attempts, only if Docker is also responding (i.e. `SystemPing` is successful)
  * Container transitions to `STOPPED` when there are no `StopContainer` errors (happy path)

The above tests should guarantee backwards compatibility and only alter the case when task is stopping and Docker has crashed.

New tests cover the changes: yes

### Description for the changelog
* Fix bug that could incorrectly mark a task as `STOPPED` when Docker crashed while stopping a container

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
