### PR TITLE
Generate PublishInstanceStatus message and import tacs model

### DIFF
--- a/agent/acs/handler/acs_handler_test.go
+++ b/agent/acs/handler/acs_handler_test.go
@@ -38,6 +38,7 @@ import (
 	rolecredentials "github.com/aws/amazon-ecs-agent/agent/credentials"
 	mock_credentials "github.com/aws/amazon-ecs-agent/agent/credentials/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/data"
+	mock_dockerapi "github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	mock_engine "github.com/aws/amazon-ecs-agent/agent/engine/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/eventhandler"
@@ -800,6 +801,7 @@ func TestHandlerDoesntLeakGoroutines(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	taskEngine := mock_engine.NewMockTaskEngine(ctrl)
+	dockerClient := mock_dockerapi.NewMockDockerClient(ctrl)
 	ecsClient := mock_api.NewMockECSClient(ctrl)
 	ctx, cancel := context.WithCancel(context.Background())
 	taskHandler := eventhandler.NewTaskHandler(ctx, data.NewNoopClient(), nil, nil)
@@ -824,6 +826,7 @@ func TestHandlerDoesntLeakGoroutines(t *testing.T) {
 	})
 	taskEngine.EXPECT().Version().Return("Docker: 1.5.0", nil).AnyTimes()
 	taskEngine.EXPECT().AddTask(gomock.Any()).AnyTimes()
+	dockerClient.EXPECT().SystemPing(gomock.Any(), gomock.Any()).AnyTimes()
 
 	ended := make(chan bool, 1)
 	go func() {
@@ -833,6 +836,7 @@ func TestHandlerDoesntLeakGoroutines(t *testing.T) {
 			credentialsProvider:      testCreds,
 			agentConfig:              testConfig,
 			taskEngine:               taskEngine,
+			dockerClient:             dockerClient,
 			ecsClient:                ecsClient,
 			dataClient:               data.NewNoopClient(),
 			taskHandler:              taskHandler,
@@ -909,6 +913,7 @@ func TestStartSessionHandlesRefreshCredentialsMessages(t *testing.T) {
 	taskEngine.EXPECT().Version().Return("Docker: 1.5.0", nil).AnyTimes()
 
 	credentialsManager := mock_credentials.NewMockManager(ctrl)
+	dockerClient := mock_dockerapi.NewMockDockerClient(ctrl)
 
 	latestSeqNumberTaskManifest := int64(10)
 	ended := make(chan bool, 1)
@@ -918,6 +923,7 @@ func TestStartSessionHandlesRefreshCredentialsMessages(t *testing.T) {
 			nil,
 			"myArn",
 			testCreds,
+			dockerClient,
 			ecsClient,
 			dockerstate.NewTaskEngineState(),
 			data.NewNoopClient(),
@@ -1010,11 +1016,12 @@ func TestHandlerReconnectsCorrectlySetsSendCredentialsURLParameter(t *testing.T)
 	taskHandler := eventhandler.NewTaskHandler(ctx, data.NewNoopClient(), nil, nil)
 
 	mockWsClient := mock_wsclient.NewMockClientServer(ctrl)
-
 	mockWsClient.EXPECT().SetAnyRequestHandler(gomock.Any()).AnyTimes()
 	mockWsClient.EXPECT().AddRequestHandler(gomock.Any()).AnyTimes()
 	mockWsClient.EXPECT().Close().Return(nil).AnyTimes()
 	mockWsClient.EXPECT().Serve().Return(io.EOF).AnyTimes()
+
+	dockerClient := mock_dockerapi.NewMockDockerClient(ctrl)
 	resources := newSessionResources(testCreds)
 	gomock.InOrder(
 		// When the websocket client connects to ACS for the first
@@ -1034,6 +1041,7 @@ func TestHandlerReconnectsCorrectlySetsSendCredentialsURLParameter(t *testing.T)
 		credentialsProvider:  testCreds,
 		agentConfig:          testConfig,
 		taskEngine:           taskEngine,
+		dockerClient:         dockerClient,
 		ecsClient:            ecsClient,
 		dataClient:           data.NewNoopClient(),
 		taskHandler:          taskHandler,

--- a/agent/acs/handler/heartbeat_handler_test.go
+++ b/agent/acs/handler/heartbeat_handler_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/aws/amazon-ecs-agent/agent/acs/model/ecsacs"
-	mock_engine "github.com/aws/amazon-ecs-agent/agent/engine/mocks"
+	mock_dockerapi "github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi/mocks"
 	mock_wsclient "github.com/aws/amazon-ecs-agent/agent/wsclient/mock"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/golang/mock/gomock"
@@ -82,7 +82,6 @@ func TestAckHeartbeatMessageEmpty(t *testing.T) {
 
 func validateHeartbeatAck(t *testing.T, heartbeatReceived *ecsacs.HeartbeatMessage, heartbeatAckExpected *ecsacs.HeartbeatAckRequest) {
 	ctrl := gomock.NewController(t)
-	taskEngine := mock_engine.NewMockTaskEngine(ctrl)
 	defer ctrl.Finish()
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -94,7 +93,10 @@ func validateHeartbeatAck(t *testing.T, heartbeatReceived *ecsacs.HeartbeatMessa
 		cancel()
 	}).Times(1)
 
-	handler := newHeartbeatHandler(ctx, mockWsClient, taskEngine)
+	dockerClient := mock_dockerapi.NewMockDockerClient(ctrl)
+	dockerClient.EXPECT().SystemPing(gomock.Any(), gomock.Any()).AnyTimes()
+
+	handler := newHeartbeatHandler(ctx, mockWsClient, dockerClient, "testCluster", "testARN")
 
 	go handler.sendHeartbeatAck()
 

--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -739,6 +739,7 @@ func (agent *ecsAgent) startACSSession(
 		deregisterInstanceEventStream,
 		agent.containerInstanceARN,
 		agent.credentialProvider,
+		agent.dockerClient,
 		client,
 		state,
 		agent.dataClient,

--- a/agent/doctor/doctor_test.go
+++ b/agent/doctor/doctor_test.go
@@ -19,12 +19,22 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/amazon-ecs-agent/agent/tcs/model/ecstcs"
+
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/stretchr/testify/assert"
+)
+
+const (
+	TEST_CLUSTER      = "test-cluster"
+	TEST_INSTANCE_ARN = "test-instance-arn"
 )
 
 type trueHealthcheck struct{}
 
-func (tc *trueHealthcheck) RunCheck() HealthcheckStatus { return HealthcheckStatusOk }
+func (tc *trueHealthcheck) RunCheck() HealthcheckStatus                   { return HealthcheckStatusOk }
+func (tc *trueHealthcheck) SetHealthcheckStatus(status HealthcheckStatus) {}
+func (tc *trueHealthcheck) GetHealthcheckType() string                    { return HealthcheckTypeAgent }
 func (tc *trueHealthcheck) GetHealthcheckStatus() HealthcheckStatus {
 	return HealthcheckStatusInitializing
 }
@@ -34,64 +44,46 @@ func (tc *trueHealthcheck) GetLastHealthcheckStatus() HealthcheckStatus {
 func (tc *trueHealthcheck) GetHealthcheckTime() time.Time {
 	return time.Date(1974, time.May, 19, 1, 2, 3, 4, time.UTC)
 }
+func (tc *trueHealthcheck) GetStatusChangeTime() time.Time {
+	return time.Date(1974, time.May, 19, 1, 2, 3, 4, time.UTC)
+}
 func (tc *trueHealthcheck) GetLastHealthcheckTime() time.Time {
 	return time.Date(1974, time.May, 19, 1, 2, 3, 4, time.UTC)
 }
-func (tc *trueHealthcheck) SetHealthcheckStatus(status HealthcheckStatus) {}
 
 type falseHealthcheck struct{}
 
-func (fc *falseHealthcheck) RunCheck() HealthcheckStatus { return HealthcheckStatusImpaired }
+func (fc *falseHealthcheck) RunCheck() HealthcheckStatus                   { return HealthcheckStatusImpaired }
+func (fc *falseHealthcheck) SetHealthcheckStatus(status HealthcheckStatus) {}
+func (fc *falseHealthcheck) GetHealthcheckType() string                    { return HealthcheckTypeAgent }
 func (fc *falseHealthcheck) GetHealthcheckStatus() HealthcheckStatus {
+	return HealthcheckStatusInitializing
+}
+func (fc *falseHealthcheck) GetLastHealthcheckStatus() HealthcheckStatus {
 	return HealthcheckStatusInitializing
 }
 func (fc *falseHealthcheck) GetHealthcheckTime() time.Time {
 	return time.Date(1974, time.May, 19, 1, 2, 3, 4, time.UTC)
 }
-func (tc *falseHealthcheck) GetLastHealthcheckStatus() HealthcheckStatus {
-	return HealthcheckStatusInitializing
-}
-func (tc *falseHealthcheck) GetLastHealthcheckTime() time.Time {
+func (fc *falseHealthcheck) GetStatusChangeTime() time.Time {
 	return time.Date(1974, time.May, 19, 1, 2, 3, 4, time.UTC)
 }
-func (tc *falseHealthcheck) SetHealthcheckStatus(status HealthcheckStatus) {}
+func (fc *falseHealthcheck) GetLastHealthcheckTime() time.Time {
+	return time.Date(1974, time.May, 19, 1, 2, 3, 4, time.UTC)
+}
 
 func TestNewDoctor(t *testing.T) {
 	trueCheck := &trueHealthcheck{}
 	falseCheck := &falseHealthcheck{}
 	healthchecks := []Healthcheck{trueCheck, falseCheck}
-	newDoctor, _ := NewDoctor(healthchecks)
+	newDoctor, _ := NewDoctor(healthchecks, TEST_CLUSTER, TEST_INSTANCE_ARN)
 	assert.Len(t, newDoctor.healthchecks, 2)
 }
-
-type testHealthcheck struct {
-	testName string
-}
-
-func (thc *testHealthcheck) RunCheck() HealthcheckStatus {
-	return HealthcheckStatusOk
-}
-
-func (thc *testHealthcheck) GetHealthcheckStatus() HealthcheckStatus {
-	return HealthcheckStatusOk
-}
-
-func (thc *testHealthcheck) GetHealthcheckTime() time.Time {
-	return time.Date(1974, time.May, 19, 1, 2, 3, 4, time.UTC)
-}
-
-func (tc *testHealthcheck) GetLastHealthcheckStatus() HealthcheckStatus {
-	return HealthcheckStatusInitializing
-}
-func (tc *testHealthcheck) GetLastHealthcheckTime() time.Time {
-	return time.Date(1974, time.May, 19, 1, 2, 3, 4, time.UTC)
-}
-func (tc *testHealthcheck) SetHealthcheckStatus(status HealthcheckStatus) {}
 
 func TestAddHealthcheck(t *testing.T) {
 	newDoctor := Doctor{}
 	assert.Len(t, newDoctor.healthchecks, 0)
-	newTestHealthcheck := &testHealthcheck{testName: "testAddHealthcheck"}
+	newTestHealthcheck := &trueHealthcheck{}
 	newDoctor.AddHealthcheck(newTestHealthcheck)
 	assert.Len(t, newDoctor.healthchecks, 1)
 }
@@ -129,7 +121,7 @@ func TestRunHealthchecks(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			newDoctor, _ := NewDoctor(tc.checks)
+			newDoctor, _ := NewDoctor(tc.checks, TEST_CLUSTER, TEST_INSTANCE_ARN)
 			overallResult := newDoctor.RunHealthchecks()
 			assert.Equal(t, overallResult, tc.expectedResult)
 		})
@@ -168,6 +160,133 @@ func TestAllRight(t *testing.T) {
 			newDoctor := Doctor{}
 			overallResult := newDoctor.allRight(tc.testChecksResult)
 			assert.Equal(t, overallResult, tc.expectedResult)
+		})
+	}
+}
+
+func TestGetInstanceStatuses(t *testing.T) {
+	trueCheck := &trueHealthcheck{}
+	falseCheck := &falseHealthcheck{}
+	trueStatus := &ecstcs.InstanceStatus{
+		LastStatusChange: aws.Time(trueCheck.GetStatusChangeTime()),
+		LastUpdated:      aws.Time(trueCheck.GetLastHealthcheckTime()),
+		Status:           aws.String(trueCheck.GetHealthcheckStatus().String()),
+		Type:             aws.String(trueCheck.GetHealthcheckType()),
+	}
+	falseStatus := &ecstcs.InstanceStatus{
+		LastStatusChange: aws.Time(falseCheck.GetStatusChangeTime()),
+		LastUpdated:      aws.Time(falseCheck.GetLastHealthcheckTime()),
+		Status:           aws.String(falseCheck.GetHealthcheckStatus().String()),
+		Type:             aws.String(falseCheck.GetHealthcheckType()),
+	}
+
+	testcases := []struct {
+		name           string
+		checks         []Healthcheck
+		expectedResult []*ecstcs.InstanceStatus
+	}{
+		{
+			name:           "empty checks",
+			checks:         []Healthcheck{},
+			expectedResult: nil,
+		},
+		{
+			name:           "all true checks",
+			checks:         []Healthcheck{trueCheck},
+			expectedResult: []*ecstcs.InstanceStatus{trueStatus},
+		},
+		{
+			name:           "all false checks",
+			checks:         []Healthcheck{falseCheck},
+			expectedResult: []*ecstcs.InstanceStatus{falseStatus},
+		},
+		{
+			name:           "mixed checks",
+			checks:         []Healthcheck{trueCheck, falseCheck},
+			expectedResult: []*ecstcs.InstanceStatus{trueStatus, falseStatus},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			newDoctor, _ := NewDoctor(tc.checks, TEST_CLUSTER, TEST_INSTANCE_ARN)
+			newDoctor.RunHealthchecks()
+			instanceStatuses := newDoctor.getInstanceStatuses()
+			assert.Equal(t, instanceStatuses, tc.expectedResult)
+		})
+	}
+}
+
+func TestGetPublishInstanceStatusRequest(t *testing.T) {
+	trueCheck := &trueHealthcheck{}
+	falseCheck := &falseHealthcheck{}
+	trueStatus := &ecstcs.InstanceStatus{
+		LastStatusChange: aws.Time(trueCheck.GetStatusChangeTime()),
+		LastUpdated:      aws.Time(trueCheck.GetLastHealthcheckTime()),
+		Status:           aws.String(trueCheck.GetHealthcheckStatus().String()),
+		Type:             aws.String(trueCheck.GetHealthcheckType()),
+	}
+	falseStatus := &ecstcs.InstanceStatus{
+		LastStatusChange: aws.Time(falseCheck.GetStatusChangeTime()),
+		LastUpdated:      aws.Time(falseCheck.GetLastHealthcheckTime()),
+		Status:           aws.String(falseCheck.GetHealthcheckStatus().String()),
+		Type:             aws.String(falseCheck.GetHealthcheckType()),
+	}
+
+	testcases := []struct {
+		name             string
+		checks           []Healthcheck
+		expectedStatuses []*ecstcs.InstanceStatus
+	}{
+		{
+			name:             "empty checks",
+			checks:           []Healthcheck{},
+			expectedStatuses: nil,
+		},
+		{
+			name:             "all true checks",
+			checks:           []Healthcheck{trueCheck},
+			expectedStatuses: []*ecstcs.InstanceStatus{trueStatus},
+		},
+		{
+			name:             "all false checks",
+			checks:           []Healthcheck{falseCheck},
+			expectedStatuses: []*ecstcs.InstanceStatus{falseStatus},
+		},
+		{
+			name:             "mixed checks",
+			checks:           []Healthcheck{trueCheck, falseCheck},
+			expectedStatuses: []*ecstcs.InstanceStatus{trueStatus, falseStatus},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			newDoctor, _ := NewDoctor(tc.checks, TEST_CLUSTER, TEST_INSTANCE_ARN)
+			newDoctor.RunHealthchecks()
+
+			// note: setting RequestId and Timestamp to nil so I can make the comparison
+			metadata := &ecstcs.InstanceStatusMetadata{
+				Cluster:           aws.String(TEST_CLUSTER),
+				ContainerInstance: aws.String(TEST_INSTANCE_ARN),
+				RequestId:         nil,
+			}
+
+			testResult, err := newDoctor.GetPublishInstanceStatusRequest()
+
+			if tc.expectedStatuses != nil {
+				expectedResult := &ecstcs.PublishInstanceStatusRequest{
+					Metadata:  metadata,
+					Statuses:  tc.expectedStatuses,
+					Timestamp: nil,
+				}
+				// note: setting RequestId and Timestamp to nil so I can make the comparison
+				testResult.Timestamp = nil
+				testResult.Metadata.RequestId = nil
+				assert.Equal(t, testResult, expectedResult)
+			} else {
+				assert.Error(t, err, "Test failed")
+			}
 		})
 	}
 }

--- a/agent/doctor/healthcheck.go
+++ b/agent/doctor/healthcheck.go
@@ -1,0 +1,34 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//      http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package doctor
+
+import (
+	"time"
+)
+
+const (
+	HealthcheckTypeContainerRuntime = "ContainerRuntime"
+	HealthcheckTypeAgent            = "Agent"
+)
+
+type Healthcheck interface {
+	GetHealthcheckType() string
+	GetHealthcheckStatus() HealthcheckStatus
+	GetHealthcheckTime() time.Time
+	GetStatusChangeTime() time.Time
+	GetLastHealthcheckStatus() HealthcheckStatus
+	GetLastHealthcheckTime() time.Time
+	RunCheck() HealthcheckStatus
+	SetHealthcheckStatus(status HealthcheckStatus)
+}

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -353,10 +353,6 @@ func (engine *DockerTaskEngine) SetDataClient(client data.Client) {
 	engine.dataClient = client
 }
 
-func (engine *DockerTaskEngine) TaskEngineClient() dockerapi.DockerClient {
-	return engine.client
-}
-
 func (engine *DockerTaskEngine) Context() context.Context {
 	return engine.ctx
 }

--- a/agent/engine/interface.go
+++ b/agent/engine/interface.go
@@ -20,7 +20,6 @@ import (
 
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	"github.com/aws/amazon-ecs-agent/agent/data"
-	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	"github.com/aws/amazon-ecs-agent/agent/statechange"
 )
 
@@ -51,7 +50,6 @@ type TaskEngine interface {
 	GetTaskByArn(string) (*apitask.Task, bool)
 
 	Version() (string, error)
-	TaskEngineClient() dockerapi.DockerClient
 
 	// LoadState loads the task engine state with data in db.
 	LoadState() error

--- a/agent/engine/mocks/engine_mocks.go
+++ b/agent/engine/mocks/engine_mocks.go
@@ -25,7 +25,6 @@ import (
 	container "github.com/aws/amazon-ecs-agent/agent/api/container"
 	task "github.com/aws/amazon-ecs-agent/agent/api/task"
 	data "github.com/aws/amazon-ecs-agent/agent/data"
-	dockerapi "github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	image "github.com/aws/amazon-ecs-agent/agent/engine/image"
 	statechange "github.com/aws/amazon-ecs-agent/agent/statechange"
 	gomock "github.com/golang/mock/gomock"
@@ -201,20 +200,6 @@ func (m *MockTaskEngine) StateChangeEvents() chan statechange.Event {
 func (mr *MockTaskEngineMockRecorder) StateChangeEvents() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateChangeEvents", reflect.TypeOf((*MockTaskEngine)(nil).StateChangeEvents))
-}
-
-// TaskEngineClient mocks base method
-func (m *MockTaskEngine) TaskEngineClient() dockerapi.DockerClient {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TaskEngineClient")
-	ret0, _ := ret[0].(dockerapi.DockerClient)
-	return ret0
-}
-
-// TaskEngineClient indicates an expected call of TaskEngineClient
-func (mr *MockTaskEngineMockRecorder) TaskEngineClient() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TaskEngineClient", reflect.TypeOf((*MockTaskEngine)(nil).TaskEngineClient))
 }
 
 // UnmarshalJSON mocks base method

--- a/agent/stats/common_test.go
+++ b/agent/stats/common_test.go
@@ -23,7 +23,6 @@ import (
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/data"
-	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	"github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
 	"github.com/aws/amazon-ecs-agent/agent/statechange"
@@ -304,10 +303,6 @@ func (engine *MockTaskEngine) SetDataClient(data.Client) {
 }
 
 func (engine *MockTaskEngine) AddTask(*apitask.Task) {
-}
-
-func (engine *MockTaskEngine) TaskEngineClient() dockerapi.DockerClient {
-	return nil
 }
 
 func (engine *MockTaskEngine) ListTasks() ([]*apitask.Task, error) {

--- a/agent/tcs/model/api/api-2.json
+++ b/agent/tcs/model/api/api-2.json
@@ -42,7 +42,36 @@
         },
         {
           "shape":"ServerException",
+          "exception":true,
+          "fault":true
+        }
+      ]
+    },
+    "PublishInstanceStatus":{
+      "name":"PublishInstanceStatus",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"PublishInstanceStatusRequest"},
+      "output":{"shape":"AckPublishInstanceStatus"},
+      "errors":[
+        {
+          "shape":"BadRequestException",
           "exception":true
+        },
+        {
+          "shape":"ResourceValidationException",
+          "exception":true
+        },
+        {
+          "shape":"InvalidParameterException",
+          "exception":true
+        },
+        {
+          "shape":"ServerException",
+          "exception":true,
+          "fault":true
         }
       ]
     },
@@ -69,7 +98,8 @@
         },
         {
           "shape":"ServerException",
-          "exception":true
+          "exception":true,
+          "fault":true
         }
       ]
     },
@@ -92,13 +122,20 @@
         },
         {
           "shape":"ServerException",
-          "exception":true
+          "exception":true,
+          "fault":true
         }
       ]
     }
   },
   "shapes":{
     "AckPublishHealth":{
+      "type":"structure",
+      "members":{
+        "message":{"shape":"String"}
+      }
+    },
+    "AckPublishInstanceStatus":{
       "type":"structure",
       "members":{
         "message":{"shape":"String"}
@@ -178,6 +215,36 @@
         "healthy":{"shape":"Boolean"}
       }
     },
+    "InstanceHealthcheckStatus":{
+      "type":"string",
+      "enum":[
+        "OK",
+        "IMPAIRED",
+        "INSUFFICIENT_DATA",
+        "INITIALIZING"
+      ]
+    },
+    "InstanceStatus":{
+      "type":"structure",
+      "members":{
+        "type":{"shape":"String"},
+        "status":{"shape":"InstanceHealthcheckStatus"},
+        "lastUpdated":{"shape":"Timestamp"},
+        "lastStatusChange":{"shape":"Timestamp"}
+      }
+    },
+    "InstanceStatusMetadata":{
+      "type":"structure",
+      "members":{
+        "cluster":{"shape":"String"},
+        "containerInstance":{"shape":"String"},
+        "requestId":{"shape":"String"}
+      }
+    },
+    "InstanceStatuses":{
+      "type":"list",
+      "member":{"shape":"InstanceStatus"}
+    },
     "InvalidParameterException":{
       "type":"structure",
       "members":{
@@ -218,6 +285,14 @@
         "timestamp":{"shape":"Timestamp"}
       }
     },
+    "PublishInstanceStatusRequest":{
+      "type":"structure",
+      "members":{
+        "metadata":{"shape":"InstanceStatusMetadata"},
+        "statuses":{"shape":"InstanceStatuses"},
+        "timestamp":{"shape":"Timestamp"}
+      }
+    },
     "PublishMetricsRequest":{
       "type":"structure",
       "members":{
@@ -238,7 +313,8 @@
       "members":{
         "message":{"shape":"String"}
       },
-      "exception":true
+      "exception":true,
+      "fault":true
     },
     "StartTelemetrySessionRequest":{
       "type":"structure",
@@ -265,6 +341,7 @@
       "type":"structure",
       "members":{
         "taskArn":{"shape":"String"},
+        "clusterArn":{"shape":"String"},
         "taskDefinitionFamily":{"shape":"String"},
         "taskDefinitionVersion":{"shape":"String"},
         "containers":{"shape":"ContainerHealths"}
@@ -278,6 +355,7 @@
       "type":"structure",
       "members":{
         "taskArn":{"shape":"String"},
+        "clusterArn":{"shape":"String"},
         "taskDefinitionFamily":{"shape":"String"},
         "taskDefinitionVersion":{"shape":"String"},
         "containerMetrics":{"shape":"ContainerMetrics"}

--- a/agent/tcs/model/ecstcs/api.go
+++ b/agent/tcs/model/ecstcs/api.go
@@ -40,6 +40,22 @@ func (s AckPublishHealth) GoString() string {
 	return s.String()
 }
 
+type AckPublishInstanceStatus struct {
+	_ struct{} `type:"structure"`
+
+	Message *string `locationName:"message" type:"string"`
+}
+
+// String returns the string representation
+func (s AckPublishInstanceStatus) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AckPublishInstanceStatus) GoString() string {
+	return s.String()
+}
+
 type AckPublishMetric struct {
 	_ struct{} `type:"structure"`
 
@@ -264,6 +280,48 @@ func (s HeartbeatOutput) String() string {
 
 // GoString returns the string representation
 func (s HeartbeatOutput) GoString() string {
+	return s.String()
+}
+
+type InstanceStatus struct {
+	_ struct{} `type:"structure"`
+
+	LastStatusChange *time.Time `locationName:"lastStatusChange" type:"timestamp"`
+
+	LastUpdated *time.Time `locationName:"lastUpdated" type:"timestamp"`
+
+	Status *string `locationName:"status" type:"string" enum:"InstanceHealthcheckStatus"`
+
+	Type *string `locationName:"type" type:"string"`
+}
+
+// String returns the string representation
+func (s InstanceStatus) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s InstanceStatus) GoString() string {
+	return s.String()
+}
+
+type InstanceStatusMetadata struct {
+	_ struct{} `type:"structure"`
+
+	Cluster *string `locationName:"cluster" type:"string"`
+
+	ContainerInstance *string `locationName:"containerInstance" type:"string"`
+
+	RequestId *string `locationName:"requestId" type:"string"`
+}
+
+// String returns the string representation
+func (s InstanceStatusMetadata) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s InstanceStatusMetadata) GoString() string {
 	return s.String()
 }
 
@@ -493,6 +551,62 @@ func (s PublishHealthRequest) String() string {
 
 // GoString returns the string representation
 func (s PublishHealthRequest) GoString() string {
+	return s.String()
+}
+
+type PublishInstanceStatusInput struct {
+	_ struct{} `type:"structure"`
+
+	Metadata *InstanceStatusMetadata `locationName:"metadata" type:"structure"`
+
+	Statuses []*InstanceStatus `locationName:"statuses" type:"list"`
+
+	Timestamp *time.Time `locationName:"timestamp" type:"timestamp"`
+}
+
+// String returns the string representation
+func (s PublishInstanceStatusInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PublishInstanceStatusInput) GoString() string {
+	return s.String()
+}
+
+type PublishInstanceStatusOutput struct {
+	_ struct{} `type:"structure"`
+
+	Message *string `locationName:"message" type:"string"`
+}
+
+// String returns the string representation
+func (s PublishInstanceStatusOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PublishInstanceStatusOutput) GoString() string {
+	return s.String()
+}
+
+type PublishInstanceStatusRequest struct {
+	_ struct{} `type:"structure"`
+
+	Metadata *InstanceStatusMetadata `locationName:"metadata" type:"structure"`
+
+	Statuses []*InstanceStatus `locationName:"statuses" type:"list"`
+
+	Timestamp *time.Time `locationName:"timestamp" type:"timestamp"`
+}
+
+// String returns the string representation
+func (s PublishInstanceStatusRequest) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PublishInstanceStatusRequest) GoString() string {
 	return s.String()
 }
 
@@ -791,6 +905,8 @@ func (s *StorageStatsSet) Validate() error {
 type TaskHealth struct {
 	_ struct{} `type:"structure"`
 
+	ClusterArn *string `locationName:"clusterArn" type:"string"`
+
 	Containers []*ContainerHealth `locationName:"containers" type:"list"`
 
 	TaskArn *string `locationName:"taskArn" type:"string"`
@@ -812,6 +928,8 @@ func (s TaskHealth) GoString() string {
 
 type TaskMetric struct {
 	_ struct{} `type:"structure"`
+
+	ClusterArn *string `locationName:"clusterArn" type:"string"`
 
 	ContainerMetrics []*ContainerMetric `locationName:"containerMetrics" type:"list"`
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Add `GetPublishInstanceStatusMessage` and necessary wiring to fill up these messages.  It also imports the latest tacs model changes specific to instance-health.

### Implementation details
`GetPublishInstanceStatusMessage` uses a helper function `getInstanceStatuses` to collect the individual statuses.  If there are no instance statuses available, the helper will return nil and `GetPublishInstanceStatusMessage will return an error.
The tacs model changes were generated from the control-plane model using an automated process.  The actual code in agent was built with `make gogenerate`.

A sample message from the agent logs during manual testing:
```
{
    Metadata: {
        Cluster: "execDemo",
        ContainerInstance: "arn:aws:ecs:us-west-2:<accountID>:container-instance/execDemo/<arn>",
        RequestId: "d0bf7597-ee7c-4fce-b8e7-3fce648a5db6"
    },
    StatusChecks: [
        {
            LastStatusChange: 2021-06-0722: 50: 22.297344909+0000UTCm=+29.129781563,
            LastUpdated: 2021-06-0722: 49: 53.722331035+0000UTCm=+0.554767847,
            Status: "OK",
            Type: "ContainerRuntime"
        }
    ],
    Timestamp: 2021-06-0722: 50: 22.297377973+0000UTCm=+29.129814760
}
```

### Testing
Tested on an ECS Optimized AL2 instance with the commented-out docker runtime heartbeat trigger code enabled.  I was able to see messages generated for each heartbeat.  
Since the metadata has the cluster, I also tested statefulness by stopping the agent and restarting to see that it continues to print the correct cluster.  I then stopped the ecs-agent and deregistered the container instance, and deleted the state file.  I then changed the ecs.config to point to a new cluster.  When I restarted the agent, the PublishInstanceStatus messages' metadata reflected the cluster update.
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

### Description for the changelog
Add GetPublishInstanceStatusMessage and import tacs model.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
