### PR TITLE
ECS EC2 task networking for Windows: Making endpoint name format consistent with the vpc-eni plugin

### DIFF
--- a/agent/ecscni/namespace_helper_windows.go
+++ b/agent/ecscni/namespace_helper_windows.go
@@ -43,7 +43,7 @@ const (
 	// ecsBridgeEndpointNameFormat is the name format of the ecs-bridge endpoint in the task namespace.
 	ecsBridgeEndpointNameFormat = "%s-ep-%s"
 	// taskPrimaryEndpointNameFormat is the name format of the primary endpoint in the task namespace.
-	taskPrimaryEndpointNameFormat = "%s-br-%s-ep-%s"
+	taskPrimaryEndpointNameFormat = "%sbr%s-ep-%s"
 	// blockIMDSFirewallRuleNameFormat is the format of firewall rule name for blocking IMDS from task namespace.
 	blockIMDSFirewallRuleNameFormat = "Disable IMDS for %s"
 	// ecsBridgeRouteAddCmdFormat is the format of command for adding route entry through ECS Bridge.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
The naming convention of the endpoints was incorrect. This PR is for fixing this bug.

### Implementation details
<!-- How are the changes implemented? -->
The format of the endpoint name has been updated to its correct value.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
A custom binary was tested.

New tests cover the changes: <!-- yes|no -->
No new changes have been introduced.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Fixed the bug for inconsistent endpoint naming convention.
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
