### PR TITLE
Avoid making checkpoint config Explicitlydisabled when ECS_DATADIR is…

### DIFF
--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -285,6 +285,7 @@ func TestDefaultCheckpointWithoutECSDataDir(t *testing.T) {
 	conf, err := environmentConfig()
 	assert.NoError(t, err)
 	assert.False(t, conf.Checkpoint.Enabled())
+	assert.Equal(t, NotSet, conf.Checkpoint.Value)
 }
 
 func TestDefaultCheckpointWithECSDataDir(t *testing.T) {

--- a/agent/config/parse.go
+++ b/agent/config/parse.go
@@ -34,12 +34,6 @@ func parseCheckpoint(dataDir string) BooleanDefaultFalse {
 		if checkPoint.Value == NotSet {
 			checkPoint.Value = ExplicitlyEnabled
 		}
-	} else {
-		// if the directory is not set, default to checkpointing off for
-		// backwards compatibility
-		if checkPoint.Value == NotSet {
-			checkPoint.Value = ExplicitlyDisabled
-		}
 	}
 	return checkPoint
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Fixes https://github.com/aws/amazon-ecs-agent/issues/2850

There was a bug in`parseCheckpoint`, which incorrectly set the `Checkpoint` config as `ExplicitlyDisabled` when the data directory config was not set. This prevented the `Checkpoint` config to be overridden by other configuration methods, such as configuration file. Please refer to https://github.com/aws/amazon-ecs-agent/issues/2850 for more details

### Implementation details
<!-- How are the changes implemented? -->
Remove the incorrect assignation of `ExplicitlyDisabled`
### Testing
Tested in personal account that the checkpoint is picked up correctly after this change. Made sure it's backwards compatible.
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
* Fixes https://github.com/aws/amazon-ecs-agent/issues/2850
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
