### PR TITLE
agent_capability: added checks for SSM plugin and removed cert checks…

### DIFF
--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -97,9 +97,6 @@ var (
 		// ecs agent version 1.39.0 supports bulk loading env vars through environmentFiles in S3
 		capabilityEnvFilesS3,
 	}
-	capabilityExecRequiredCerts = []string{
-		"tls-ca-bundle.pem",
-	}
 	// use empty struct as value type to simulate set
 	capabilityExecInvalidSsmVersions = map[string]struct{}{}
 
@@ -122,6 +119,10 @@ var (
 	externalSpecificCapabilities = []string{
 		attributePrefix + capabilityExternal,
 	}
+
+	capabilityExecRootDir = filepath.Join(capabilityDepsRootDir, capabilityExec)
+	binDir                = filepath.Join(capabilityExecRootDir, capabilityExecBinRelativePath)
+	configDir             = filepath.Join(capabilityExecRootDir, capabilityExecConfigRelativePath)
 )
 
 // capabilities returns the supported capabilities of this agent / docker-client pair.
@@ -378,17 +379,6 @@ func (agent *ecsAgent) appendExecCapabilities(capabilities []*ecs.Attribute) ([]
 	// for an instance to be exec-enabled, it needs resources needed by SSM (binaries, configuration files and certs)
 	// the following bind mounts are defined in ecs-init and added to the ecs-agent container
 
-	capabilityExecRootDir := filepath.Join(capabilityDepsRootDir, capabilityExec)
-	binDir := filepath.Join(capabilityExecRootDir, capabilityExecBinRelativePath)
-	configDir := filepath.Join(capabilityExecRootDir, capabilityExecConfigRelativePath)
-	certsDir := filepath.Join(capabilityExecRootDir, capabilityExecCertsRelativePath)
-
-	// top-level folders, /bin, /config, /certs
-	dependencies := map[string][]string{
-		binDir:    []string{},
-		configDir: []string{},
-		certsDir:  capabilityExecRequiredCerts,
-	}
 	if exists, err := dependenciesExist(dependencies); err != nil || !exists {
 		return capabilities, err
 	}

--- a/agent/app/agent_capability_unix.go
+++ b/agent/app/agent_capability_unix.go
@@ -16,6 +16,7 @@
 package app
 
 import (
+	"path/filepath"
 	"strings"
 
 	"github.com/aws/amazon-ecs-agent/agent/config"
@@ -39,10 +40,21 @@ const (
 )
 
 var (
+	certsDir                    = filepath.Join(capabilityExecRootDir, capabilityExecCertsRelativePath)
+	capabilityExecRequiredCerts = []string{
+		"tls-ca-bundle.pem",
+	}
 	capabilityExecRequiredBinaries = []string{
 		"amazon-ssm-agent",
 		"ssm-agent-worker",
 		"ssm-session-worker",
+	}
+
+	// top-level folders, /bin, /config, /certs
+	dependencies = map[string][]string{
+		binDir:    []string{},
+		configDir: []string{},
+		certsDir:  capabilityExecRequiredCerts,
 	}
 )
 

--- a/agent/app/agent_capability_unspecified.go
+++ b/agent/app/agent_capability_unspecified.go
@@ -32,6 +32,7 @@ const (
 
 var (
 	capabilityExecRequiredBinaries = []string{}
+	dependencies                   = map[string][]string{}
 )
 
 func (agent *ecsAgent) appendVolumeDriverCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {

--- a/agent/app/agent_capability_windows.go
+++ b/agent/app/agent_capability_windows.go
@@ -24,11 +24,26 @@ import (
 )
 
 var (
-	capabilityDepsRootDir          = filepath.Join(config.AmazonECSProgramFiles, "managed-agents")
+	capabilityDepsRootDir  = filepath.Join(config.AmazonECSProgramFiles, "managed-agents")
+	ssmPluginDir           = filepath.Join(config.AmazonProgramFiles, "SSM", "Plugins")
+	sessionManagerShellDir = filepath.Join(ssmPluginDir, "SessionManagerShell")
+	awsCloudWatchDir       = filepath.Join(ssmPluginDir, "awsCloudWatch")
+	awsDomainJoin          = filepath.Join(ssmPluginDir, "awsDomainJoin")
+
 	capabilityExecRequiredBinaries = []string{
 		"amazon-ssm-agent.exe",
 		"ssm-agent-worker.exe",
 		"ssm-session-worker.exe",
+	}
+
+	// top-level folders, /bin, /config, /plugins
+	dependencies = map[string][]string{
+		binDir:                 []string{},
+		configDir:              []string{},
+		ssmPluginDir:           []string{},
+		sessionManagerShellDir: []string{},
+		awsCloudWatchDir:       []string{},
+		awsDomainJoin:          []string{},
 	}
 )
 

--- a/agent/config/config_windows.go
+++ b/agent/config/config_windows.go
@@ -67,6 +67,7 @@ const (
 
 var (
 	envProgramFiles       = utils.DefaultIfBlank(os.Getenv("ProgramFiles"), `C:\Program Files`)
+	AmazonProgramFiles    = filepath.Join(envProgramFiles, "Amazon")
 	AmazonECSProgramFiles = filepath.Join(envProgramFiles, "Amazon", "ECS")
 )
 


### PR DESCRIPTION
… on Windows

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
The windows agent capability checks for the presence of top level SSM plugin folders and removes the checks for certificates. This is because Windows containers use the root certificate authority provided by the EC2 instance

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->

Unit tests passed
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->
yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Feature: execcmd agent init checks for Windows
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
