### PR TITLE
ECS EC2 Windows task networking: Removed redundant checks for DNS server information

### DIFF
--- a/agent/ecscni/netconfig_windows.go
+++ b/agent/ecscni/netconfig_windows.go
@@ -25,12 +25,10 @@ import (
 
 // NewVPCENIPluginConfigForTaskNSSetup is used to create the configuration of vpc-eni plugin for task namespace setup.
 func NewVPCENIPluginConfigForTaskNSSetup(eni *eni.ENI, cfg *Config) (*libcni.NetworkConfig, error) {
+	// Use the DNS server addresses of the instance ENI it would belong in the same VPC as
+	// the task ENI and therefore, have same DNS configuration.
 	dns := types.DNS{
-		Nameservers: eni.DomainNameServers,
-	}
-
-	if len(eni.DomainNameSearchList) == 0 && cfg.InstanceENIDNSServerList != nil {
-		dns.Nameservers = cfg.InstanceENIDNSServerList
+		Nameservers: cfg.InstanceENIDNSServerList,
 	}
 
 	eniConf := VPCENIPluginConfig{


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR removes redundant checks related to DNS server addresses while building CNI plugin config.
We should always use the DNS server addresses of the instance ENI. This is because-

- Both instance and task ENI belong in the same VPC, and therefore have same information.
- During Active Directory domain join, the additional DNS servers would be added to the task ENI, thus enabling it to use gMSA.

### Implementation details
<!-- How are the changes implemented? -->
Removed additional checks.
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
A custom agent binary was tested with the updated changes.

New tests cover the changes: <!-- yes|no -->
No new changes are introduced.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Removed redundant checks for DNS server addresses during CNI plugin config creation.
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
