### PR TITLE
execcmd manager init task: Windows functionality added

### DIFF
--- a/agent/config/config_windows.go
+++ b/agent/config/config_windows.go
@@ -66,9 +66,14 @@ const (
 )
 
 var (
-	envProgramFiles       = utils.DefaultIfBlank(os.Getenv("ProgramFiles"), `C:\Program Files`)
-	AmazonProgramFiles    = filepath.Join(envProgramFiles, "Amazon")
+	envProgramFiles = utils.DefaultIfBlank(os.Getenv("ProgramFiles"), `C:\Program Files`)
+	envProgramData  = utils.DefaultIfBlank(os.Getenv("ProgramData"), `C:\ProgramData`)
+
+	AmazonProgramFiles = filepath.Join(envProgramFiles, "Amazon")
+	AmazonProgramData  = filepath.Join(envProgramData, "Amazon")
+
 	AmazonECSProgramFiles = filepath.Join(envProgramFiles, "Amazon", "ECS")
+	AmazonECSProgramData  = filepath.Join(AmazonProgramData, "ECS")
 )
 
 // DefaultConfig returns the default configuration for Windows

--- a/agent/engine/execcmd/manager_init_task.go
+++ b/agent/engine/execcmd/manager_init_task.go
@@ -1,0 +1,208 @@
+// +build linux windows
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package execcmd
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
+	dockercontainer "github.com/docker/docker/api/types/container"
+
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	"github.com/pborman/uuid"
+)
+
+const (
+	namelessContainerPrefix = "nameless-container-"
+
+	// filePerm is the permission for the exec agent config file.
+	filePerm            = 0644
+	defaultSessionLimit = 2
+
+	containerConfigFileName = "amazon-ssm-agent.json"
+	ContainerConfigDirName  = "config"
+
+	ExecAgentLogConfigFileName = "seelog.xml"
+)
+
+var (
+	execAgentConfigTemplate = `{
+	"Mgs": {
+		"Region": "",
+		"Endpoint": "",
+		"StopTimeoutMillis": 20000,
+		"SessionWorkersLimit": %d
+	},
+	"Agent": {
+		"Region": "",
+		"OrchestrationRootDir": "",
+		"ContainerMode": true
+	}
+}`
+
+	errExecCommandManagedAgentNotFound = fmt.Errorf("managed agent not found (%s)", ExecuteCommandAgentName)
+)
+
+// InitializeContainer adds the necessary bind mounts in order for the ExecCommandAgent to run properly in the container
+// TODO: [ecs-exec] Should we validate the ssm agent binaries & certs are valid and fail here if they're not? (bind mount will succeed even if files don't exist in host)
+func (m *manager) InitializeContainer(taskId string, container *apicontainer.Container, hostConfig *dockercontainer.HostConfig) (rErr error) {
+	defer func() {
+		if rErr != nil {
+			container.UpdateManagedAgentByName(ExecuteCommandAgentName, apicontainer.ManagedAgentState{
+				InitFailed: true,
+				Status:     apicontainerstatus.ManagedAgentStopped,
+				Reason:     rErr.Error(),
+			})
+		}
+	}()
+	ma, ok := container.GetManagedAgentByName(ExecuteCommandAgentName)
+	if !ok {
+		return errExecCommandManagedAgentNotFound
+	}
+	sessionWorkersLimit := getSessionWorkersLimit(ma)
+	cn := fileSystemSafeContainerName(container)
+	uuid := newUUID()
+
+	latestBinVersionDir, rErr := m.getLatestVersionedHostBinDir()
+	if rErr != nil {
+		return rErr
+	}
+
+	rErr = addRequiredBindMounts(taskId, cn, latestBinVersionDir, uuid, sessionWorkersLimit, hostConfig)
+	if rErr != nil {
+		return rErr
+	}
+
+	container.UpdateManagedAgentByName(ExecuteCommandAgentName, apicontainer.ManagedAgentState{
+		ID: uuid,
+	})
+
+	return nil
+}
+
+func (m *manager) getLatestVersionedHostBinDir() (string, error) {
+	versions, err := retrieveAgentVersions(ecsAgentDepsBinDir)
+	if err != nil {
+		return "", err
+	}
+	sort.Sort(sort.Reverse(byAgentVersion(versions)))
+
+	var latest string
+	for _, v := range versions {
+		vStr := v.String()
+		ecsAgentDepsVersionedBinDir := filepath.Join(ecsAgentDepsBinDir, vStr)
+		if !fileExists(filepath.Join(ecsAgentDepsVersionedBinDir, SSMAgentBinName)) {
+			continue // try falling back to the previous version
+		}
+		// TODO: [ecs-exec] This requirement will be removed for SSM agent V2
+		if !fileExists(filepath.Join(ecsAgentDepsVersionedBinDir, SSMAgentWorkerBinName)) {
+			continue // try falling back to the previous version
+		}
+		if !fileExists(filepath.Join(ecsAgentDepsVersionedBinDir, SessionWorkerBinName)) {
+			continue // try falling back to the previous version
+		}
+		latest = filepath.Join(m.hostBinDir, vStr)
+		break
+	}
+	if latest == "" {
+		return "", fmt.Errorf("no valid versions were found in %s", m.hostBinDir)
+	}
+	return latest, nil
+}
+
+func getReadOnlyBindMountMapping(hostDir, containerDir string) string {
+	return getBindMountMapping(hostDir, containerDir) + ":ro"
+}
+
+func getBindMountMapping(hostDir, containerDir string) string {
+	return hostDir + ":" + containerDir
+}
+
+var newUUID = uuid.New
+
+func fileSystemSafeContainerName(c *apicontainer.Container) string {
+	// Trim leading hyphens since they're not valid directory names
+	cn := strings.TrimLeft(c.Name, "-")
+	if cn == "" {
+		// Fallback name in the extreme case that we end up with an empty string after trimming all leading hyphens.
+		return namelessContainerPrefix + newUUID()
+	}
+	return cn
+}
+
+func getSessionWorkersLimit(ma apicontainer.ManagedAgent) int {
+	// TODO [ecs-exec] : verify that returning the default session limit (2) is ok in case of any errors, misconfiguration
+	limit := defaultSessionLimit
+	if ma.Properties == nil { // This means ACS didn't send the limit
+		return limit
+	}
+	limitStr, ok := ma.Properties["sessionLimit"]
+	if !ok { // This also means ACS didn't send the limit
+		return limit
+	}
+	limit, err := strconv.Atoi(limitStr)
+	if err != nil { // This means ACS send a limit that can't be converted to an int
+		return limit
+	}
+	if limit <= 0 {
+		limit = defaultSessionLimit
+	}
+	return limit
+}
+
+var removeAll = os.RemoveAll
+
+var getFileContent = readFileContent
+
+func readFileContent(filePath string) ([]byte, error) {
+	return ioutil.ReadFile(filePath)
+}
+
+func getExecAgentConfigHash(config string) string {
+	hash := sha256.New()
+	hash.Write([]byte(config))
+	return base64.URLEncoding.EncodeToString(hash.Sum(nil))
+}
+
+var osStat = os.Stat
+
+func fileExists(path string) bool {
+	if fi, err := osStat(path); err == nil {
+		return !fi.IsDir()
+	}
+	return false
+}
+
+func isDir(path string) bool {
+	if fi, err := osStat(path); err == nil {
+		return fi.IsDir()
+	}
+	return false
+}
+
+var createNewExecAgentConfigFile = createNewConfigFile
+
+func createNewConfigFile(config, configFilePath string) error {
+	return ioutil.WriteFile(configFilePath, []byte(config), filePerm)
+}

--- a/agent/engine/execcmd/manager_init_task_linux.go
+++ b/agent/engine/execcmd/manager_init_task_linux.go
@@ -15,26 +15,14 @@
 package execcmd
 
 import (
-	"crypto/sha256"
-	"encoding/base64"
 	"fmt"
-	"io/ioutil"
-	"os"
 	"path/filepath"
-	"sort"
-	"strconv"
 	"strings"
 
 	dockercontainer "github.com/docker/docker/api/types/container"
-	"github.com/pborman/uuid"
-
-	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
-	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 )
 
 const (
-	namelessContainerPrefix = "nameless-container-"
-
 	ecsAgentExecDepsDir = "/managed-agents/execute-command"
 
 	// ecsAgentDepsBinDir is the directory where ECS Agent will read versions of SSM agent
@@ -42,10 +30,6 @@ const (
 	ecsAgentDepsCertsDir = ecsAgentExecDepsDir + "/certs"
 
 	ContainerDepsDirPrefix = "/ecs-execute-command-"
-
-	// filePerm is the permission for the exec agent config file.
-	filePerm            = 0644
-	defaultSessionLimit = 2
 
 	SSMAgentBinName       = "amazon-ssm-agent"
 	SSMAgentWorkerBinName = "ssm-agent-worker"
@@ -58,32 +42,16 @@ const (
 	HostCertFile            = "/var/lib/ecs/deps/execute-command/certs/tls-ca-bundle.pem"
 	ContainerCertFileSuffix = "certs/amazon-ssm-agent.crt"
 
-	containerConfigFileName   = "amazon-ssm-agent.json"
-	ContainerConfigDirName    = "config"
 	ContainerConfigFileSuffix = "configuration/" + containerConfigFileName
 
 	// ECSAgentExecConfigDir is the directory where ECS Agent will write the ExecAgent config files to
 	ECSAgentExecConfigDir = ecsAgentExecDepsDir + "/" + ContainerConfigDirName
 	// HostExecConfigDir is the dir where ExecAgents Config files will live
-	HostExecConfigDir          = hostExecDepsDir + "/" + ContainerConfigDirName
-	ExecAgentLogConfigFileName = "seelog.xml"
-	ContainerLogConfigFile     = "configuration/" + ExecAgentLogConfigFileName
+	HostExecConfigDir      = hostExecDepsDir + "/" + ContainerConfigDirName
+	ContainerLogConfigFile = "configuration/" + ExecAgentLogConfigFileName
 )
 
 var (
-	execAgentConfigTemplate = `{
-	"Mgs": {
-		"Region": "",
-		"Endpoint": "",
-		"StopTimeoutMillis": 20000,
-		"SessionWorkersLimit": %d
-	},
-	"Agent": {
-		"Region": "",
-		"OrchestrationRootDir": "",
-		"ContainerMode": true
-	}
-}`
 	execAgentLogConfigTemplate = `<seelog type="adaptive" mininterval="2000000"
 	maxinterval="100000000" critmsgcount="500" minlevel="info">
 <exceptions>
@@ -107,28 +75,74 @@ var (
 </formats>
 </seelog>`
 	// TODO: [ecs-exec] seelog config needs to be implemented following a similar approach to ss, config
-	execAgentConfigFileNameTemplate    = `amazon-ssm-agent-%s.json`
-	logConfigFileNameTemplate          = `seelog-%s.xml`
-	errExecCommandManagedAgentNotFound = fmt.Errorf("managed agent not found (%s)", ExecuteCommandAgentName)
+	execAgentConfigFileNameTemplate = `amazon-ssm-agent-%s.json`
+	logConfigFileNameTemplate       = `seelog-%s.xml`
 )
 
-// InitializeContainer adds the necessary bind mounts in order for the ExecCommandAgent to run properly in the container
-// TODO: [ecs-exec] Should we validate the ssm agent binaries & certs are valid and fail here if they're not? (bind mount will succeed even if files don't exist in host)
-func (m *manager) InitializeContainer(taskId string, container *apicontainer.Container, hostConfig *dockercontainer.HostConfig) (rErr error) {
-	defer func() {
-		if rErr != nil {
-			container.UpdateManagedAgentByName(ExecuteCommandAgentName, apicontainer.ManagedAgentState{
-				InitFailed: true,
-				Status:     apicontainerstatus.ManagedAgentStopped,
-				Reason:     rErr.Error(),
-			})
-		}
-	}()
-	ma, ok := container.GetManagedAgentByName(ExecuteCommandAgentName)
-	if !ok {
-		return errExecCommandManagedAgentNotFound
+var GetExecAgentLogConfigFile = getAgentLogConfigFile
+
+func getAgentLogConfigFile() (string, error) {
+	hash := getExecAgentConfigHash(execAgentLogConfigTemplate)
+	logConfigFileName := fmt.Sprintf(logConfigFileNameTemplate, hash)
+	// check if config file exists already
+	logConfigFilePath := filepath.Join(ECSAgentExecConfigDir, logConfigFileName)
+	if fileExists(logConfigFilePath) && validConfigExists(logConfigFilePath, hash) {
+		return logConfigFileName, nil
 	}
-	configFile, rErr := GetExecAgentConfigFileName(getSessionWorkersLimit(ma))
+	// check if config file is a dir; if true, remove it
+	if isDir(logConfigFilePath) {
+		if err := removeAll(logConfigFilePath); err != nil {
+			return "", err
+		}
+	}
+	// create new seelog config file
+	if err := createNewExecAgentConfigFile(execAgentLogConfigTemplate, logConfigFilePath); err != nil {
+		return "", err
+	}
+	return logConfigFileName, nil
+}
+
+func validConfigExists(configFilePath, expectedHash string) bool {
+	config, err := getFileContent(configFilePath)
+	if err != nil {
+		return false
+	}
+	hash := getExecAgentConfigHash(string(config))
+	return strings.Compare(expectedHash, hash) == 0
+}
+
+var GetExecAgentConfigFileName = getAgentConfigFileName
+
+func getAgentConfigFileName(sessionLimit int) (string, error) {
+	config := fmt.Sprintf(execAgentConfigTemplate, sessionLimit)
+	hash := getExecAgentConfigHash(config)
+	configFileName := fmt.Sprintf(execAgentConfigFileNameTemplate, hash)
+	// check if config file exists already
+	configFilePath := filepath.Join(ECSAgentExecConfigDir, configFileName)
+	if fileExists(configFilePath) && validConfigExists(configFilePath, hash) {
+		return configFileName, nil
+	}
+	// check if config file is a dir; if true, remove it
+	if isDir(configFilePath) {
+		if err := removeAll(configFilePath); err != nil {
+			return "", err
+		}
+	}
+	// config doesn't exist; create a new one
+	if err := createNewExecAgentConfigFile(config, configFilePath); err != nil {
+		return "", err
+	}
+	return configFileName, nil
+}
+
+func certsExist() bool {
+	return fileExists(filepath.Join(ecsAgentDepsCertsDir, "tls-ca-bundle.pem"))
+}
+
+// This function creates any necessary config directories/files and ensures that
+// the ssm-agent binaries, configs, logs, and plugin is bind mounted
+func addRequiredBindMounts(taskId, cn, latestBinVersionDir, uuid string, sessionWorkersLimit int, hostConfig *dockercontainer.HostConfig) error {
+	configFile, rErr := GetExecAgentConfigFileName(sessionWorkersLimit)
 	if rErr != nil {
 		rErr = fmt.Errorf("could not generate ExecAgent Config File: %v", rErr)
 		return rErr
@@ -138,13 +152,8 @@ func (m *manager) InitializeContainer(taskId string, container *apicontainer.Con
 		rErr = fmt.Errorf("could not generate ExecAgent LogConfig file: %v", rErr)
 		return rErr
 	}
-	uuid := newUUID()
-	containerDepsFolder := ContainerDepsDirPrefix + uuid
 
-	latestBinVersionDir, rErr := m.getLatestVersionedHostBinDir()
-	if rErr != nil {
-		return rErr
-	}
+	containerDepsFolder := ContainerDepsDirPrefix + uuid
 
 	if !certsExist() {
 		rErr = fmt.Errorf("could not find certs")
@@ -180,180 +189,8 @@ func (m *manager) InitializeContainer(taskId string, container *apicontainer.Con
 		filepath.Join(containerDepsFolder, ContainerCertFileSuffix)))
 
 	// Add ssm log bind mount
-	cn := fileSystemSafeContainerName(container)
 	hostConfig.Binds = append(hostConfig.Binds, getBindMountMapping(
 		filepath.Join(HostLogDir, taskId, cn),
 		ContainerLogDir))
-
-	container.UpdateManagedAgentByName(ExecuteCommandAgentName, apicontainer.ManagedAgentState{
-		ID: uuid,
-	})
-
 	return nil
-}
-
-func (m *manager) getLatestVersionedHostBinDir() (string, error) {
-	versions, err := retrieveAgentVersions(ecsAgentDepsBinDir)
-	if err != nil {
-		return "", err
-	}
-	sort.Sort(sort.Reverse(byAgentVersion(versions)))
-
-	var latest string
-	for _, v := range versions {
-		vStr := v.String()
-		ecsAgentDepsVersionedBinDir := filepath.Join(ecsAgentDepsBinDir, vStr)
-		if !fileExists(filepath.Join(ecsAgentDepsVersionedBinDir, SSMAgentBinName)) {
-			continue // try falling back to the previous version
-		}
-		// TODO: [ecs-exec] This requirement will be removed for SSM agent V2
-		if !fileExists(filepath.Join(ecsAgentDepsVersionedBinDir, SSMAgentWorkerBinName)) {
-			continue // try falling back to the previous version
-		}
-		if !fileExists(filepath.Join(ecsAgentDepsVersionedBinDir, SessionWorkerBinName)) {
-			continue // try falling back to the previous version
-		}
-		latest = filepath.Join(m.hostBinDir, vStr)
-		break
-	}
-	if latest == "" {
-		return "", fmt.Errorf("no valid versions were found in %s", m.hostBinDir)
-	}
-	return latest, nil
-}
-
-func getReadOnlyBindMountMapping(hostDir, containerDir string) string {
-	return getBindMountMapping(hostDir, containerDir) + ":ro"
-}
-
-func getBindMountMapping(hostDir, containerDir string) string {
-	return hostDir + ":" + containerDir
-}
-
-var newUUID = uuid.New
-
-func fileSystemSafeContainerName(c *apicontainer.Container) string {
-	// Trim leading hyphens since they're not valid directory names
-	cn := strings.TrimLeft(c.Name, "-")
-	if cn == "" {
-		// Fallback name in the extreme case that we end up with an empty string after trimming all leading hyphens.
-		return namelessContainerPrefix + newUUID()
-	}
-	return cn
-}
-
-func getSessionWorkersLimit(ma apicontainer.ManagedAgent) int {
-	// TODO [ecs-exec] : verify that returning the default session limit (2) is ok in case of any errors, misconfiguration
-	limit := defaultSessionLimit
-	if ma.Properties == nil { // This means ACS didn't send the limit
-		return limit
-	}
-	limitStr, ok := ma.Properties["sessionLimit"]
-	if !ok { // This also means ACS didn't send the limit
-		return limit
-	}
-	limit, err := strconv.Atoi(limitStr)
-	if err != nil { // This means ACS send a limit that can't be converted to an int
-		return limit
-	}
-	if limit <= 0 {
-		limit = defaultSessionLimit
-	}
-	return limit
-}
-
-var GetExecAgentLogConfigFile = getAgentLogConfigFile
-
-func getAgentLogConfigFile() (string, error) {
-	hash := getExecAgentConfigHash(execAgentLogConfigTemplate)
-	logConfigFileName := fmt.Sprintf(logConfigFileNameTemplate, hash)
-	// check if config file exists already
-	logConfigFilePath := filepath.Join(ECSAgentExecConfigDir, logConfigFileName)
-	if fileExists(logConfigFilePath) && validConfigExists(logConfigFilePath, hash) {
-		return logConfigFileName, nil
-	}
-	// check if config file is a dir; if true, remove it
-	if isDir(logConfigFilePath) {
-		if err := removeAll(logConfigFilePath); err != nil {
-			return "", err
-		}
-	}
-	// create new seelog config file
-	if err := createNewExecAgentConfigFile(execAgentLogConfigTemplate, logConfigFilePath); err != nil {
-		return "", err
-	}
-	return logConfigFileName, nil
-}
-
-var removeAll = os.RemoveAll
-
-func validConfigExists(configFilePath, expectedHash string) bool {
-	config, err := getFileContent(configFilePath)
-	if err != nil {
-		return false
-	}
-	hash := getExecAgentConfigHash(string(config))
-	return strings.Compare(expectedHash, hash) == 0
-}
-
-var getFileContent = readFileContent
-
-func readFileContent(filePath string) ([]byte, error) {
-	return ioutil.ReadFile(filePath)
-}
-
-var GetExecAgentConfigFileName = getAgentConfigFileName
-
-func getAgentConfigFileName(sessionLimit int) (string, error) {
-	config := fmt.Sprintf(execAgentConfigTemplate, sessionLimit)
-	hash := getExecAgentConfigHash(config)
-	configFileName := fmt.Sprintf(execAgentConfigFileNameTemplate, hash)
-	// check if config file exists already
-	configFilePath := filepath.Join(ECSAgentExecConfigDir, configFileName)
-	if fileExists(configFilePath) && validConfigExists(configFilePath, hash) {
-		return configFileName, nil
-	}
-	// check if config file is a dir; if true, remove it
-	if isDir(configFilePath) {
-		if err := removeAll(configFilePath); err != nil {
-			return "", err
-		}
-	}
-	// config doesn't exist; create a new one
-	if err := createNewExecAgentConfigFile(config, configFilePath); err != nil {
-		return "", err
-	}
-	return configFileName, nil
-}
-
-func getExecAgentConfigHash(config string) string {
-	hash := sha256.New()
-	hash.Write([]byte(config))
-	return base64.URLEncoding.EncodeToString(hash.Sum(nil))
-}
-
-var osStat = os.Stat
-
-func fileExists(path string) bool {
-	if fi, err := osStat(path); err == nil {
-		return !fi.IsDir()
-	}
-	return false
-}
-
-func isDir(path string) bool {
-	if fi, err := osStat(path); err == nil {
-		return fi.IsDir()
-	}
-	return false
-}
-
-var createNewExecAgentConfigFile = createNewConfigFile
-
-func createNewConfigFile(config, configFilePath string) error {
-	return ioutil.WriteFile(configFilePath, []byte(config), filePerm)
-}
-
-func certsExist() bool {
-	return fileExists(filepath.Join(ecsAgentDepsCertsDir, "tls-ca-bundle.pem"))
 }

--- a/agent/engine/execcmd/manager_init_task_linux_test.go
+++ b/agent/engine/execcmd/manager_init_task_linux_test.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"strconv"
 	"testing"
 
 	dockercontainer "github.com/docker/docker/api/types/container"
@@ -306,39 +305,6 @@ func TestGetExecAgentConfigFileName(t *testing.T) {
 		fileName, err := GetExecAgentConfigFileName(2)
 		assert.Equal(t, tc.expectedConfigFileName, fileName, "incorrect config file name")
 		assert.Equal(t, tc.expectedError, err)
-	}
-}
-
-func TestGetSessionWorkersLimit(t *testing.T) {
-	var tests = []struct {
-		sessionLimit  int
-		expectedLimit int
-	}{
-		{
-			sessionLimit:  -2,
-			expectedLimit: 2,
-		},
-		{
-			sessionLimit:  0,
-			expectedLimit: 2,
-		},
-		{
-			sessionLimit:  1,
-			expectedLimit: 1,
-		},
-		{
-			sessionLimit:  2,
-			expectedLimit: 2,
-		},
-	}
-	for _, tc := range tests {
-		ma := apicontainer.ManagedAgent{
-			Properties: map[string]string{
-				"sessionLimit": strconv.Itoa(tc.sessionLimit),
-			},
-		}
-		limit := getSessionWorkersLimit(ma)
-		assert.Equal(t, tc.expectedLimit, limit)
 	}
 }
 

--- a/agent/engine/execcmd/manager_init_task_test.go
+++ b/agent/engine/execcmd/manager_init_task_test.go
@@ -1,0 +1,57 @@
+// +build unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package execcmd
+
+import (
+	"strconv"
+	"testing"
+
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetSessionWorkersLimit(t *testing.T) {
+	var tests = []struct {
+		sessionLimit  int
+		expectedLimit int
+	}{
+		{
+			sessionLimit:  -2,
+			expectedLimit: 2,
+		},
+		{
+			sessionLimit:  0,
+			expectedLimit: 2,
+		},
+		{
+			sessionLimit:  1,
+			expectedLimit: 1,
+		},
+		{
+			sessionLimit:  2,
+			expectedLimit: 2,
+		},
+	}
+	for _, tc := range tests {
+		ma := apicontainer.ManagedAgent{
+			Properties: map[string]string{
+				"sessionLimit": strconv.Itoa(tc.sessionLimit),
+			},
+		}
+		limit := getSessionWorkersLimit(ma)
+		assert.Equal(t, tc.expectedLimit, limit)
+	}
+}

--- a/agent/engine/execcmd/manager_init_task_windows.go
+++ b/agent/engine/execcmd/manager_init_task_windows.go
@@ -16,18 +16,173 @@
 package execcmd
 
 import (
-	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/aws/amazon-ecs-agent/agent/config"
 	dockercontainer "github.com/docker/docker/api/types/container"
 )
 
 const (
-	// ECSAgentExecLogDir here is used used while cleaning up exec logs when task exits.
-	// When this path is empty, nothing is cleaned up for unsupported platforms.
-	ECSAgentExecLogDir = ""
+	folderPerm = 0755
 )
 
-// InitializeContainer adds the necessary bind mounts in order for the ExecCommandAgent to run properly in the container
-// Note: exec cmd agent is a linux feature, thus implemented here as a no-op.
-func (m *manager) InitializeContainer(taskId string, container *apicontainer.Container, hostConfig *dockercontainer.HostConfig) error {
+var (
+	ecsAgentExecDepsDir = config.AmazonECSProgramFiles + "\\managed-agents\\execute-command"
+
+	// ecsAgentDepsBinDir is the directory where ECS Agent will read versions of SSM agent
+	ecsAgentDepsBinDir = ecsAgentExecDepsDir + "\\bin"
+
+	containerDepsFolder = "C:\\Program Files\\Amazon\\SSM"
+
+	SSMAgentBinName       = "amazon-ssm-agent.exe"
+	SSMAgentWorkerBinName = "ssm-agent-worker.exe"
+	SessionWorkerBinName  = "ssm-session-worker.exe"
+
+	HostLogDir      = config.AmazonECSProgramData + "\\exec"
+	ContainerLogDir = config.AmazonProgramData + "\\SSM"
+
+	SSMPluginDir = "C:\\Program Files\\Amazon\\SSM\\Plugins"
+	// since ecs agent windows is not running in a container, the agent and host log dirs are the same
+	ECSAgentExecLogDir = config.AmazonECSProgramData + "\\exec"
+
+	// ECSAgentExecConfigDir is the directory where ECS Agent will write the ExecAgent config files to
+	ECSAgentExecConfigDir = ecsAgentExecDepsDir + "\\" + ContainerConfigDirName
+	// HostExecConfigDir is the dir where ExecAgents Config files will live
+	HostExecConfigDir = hostExecDepsDir + "\\" + ContainerConfigDirName
+
+	configFiles = []string{
+		"amazon-ssm-agent.json",
+		"seelog.xml",
+	}
+
+	execAgentLogConfigTemplate = `<!--amazon-ssm-agent uses seelog logging -->
+<!--Seelog has github wiki pages, which contain detailed how-tos references: https://github.com/cihub/seelog/wiki -->
+<!--Seelog examples can be found here: https://github.com/cihub/seelog-examples -->
+<seelog type="adaptive" mininterval="2000000" maxinterval="100000000" critmsgcount="500" minlevel="info">
+    <exceptions>
+        <exception filepattern="test*" minlevel="error"/>
+    </exceptions>
+    <outputs formatid="fmtinfo">
+        <console formatid="fmtinfo"/>
+        <rollingfile type="size" filename="C:\ProgramData\Amazon\SSM\Logs\amazon-ssm-agent.log" maxsize="30000000" maxrolls="5"/>
+        <filter levels="error,critical" formatid="fmterror">
+            <rollingfile type="size" filename="C:\ProgramData\Amazon\SSM\Logs\errors.log" maxsize="10000000" maxrolls="5"/>
+        </filter>
+    </outputs>
+    <formats>
+        <format id="fmterror" format="%Date %Time %LEVEL [%FuncShort @ %File.%Line] %Msg%n"/>
+        <format id="fmtdebug" format="%Date %Time %LEVEL [%FuncShort @ %File.%Line] %Msg%n"/>
+        <format id="fmtinfo" format="%Date %Time %LEVEL %Msg%n"/>
+    </formats>
+</seelog>`
+)
+
+var GetExecAgentConfigDir = getAgentConfigDir
+
+// Retrieves cached config dir, creates new one if needed
+func getAgentConfigDir(sessionLimit int) (string, error) {
+	agentConfig := fmt.Sprintf(execAgentConfigTemplate, sessionLimit)
+	hash := getExecAgentConfigHash(agentConfig + execAgentLogConfigTemplate)
+	// check if cached config dir exists already
+	configDirPath := filepath.Join(ECSAgentExecConfigDir, hash)
+	if isDir(configDirPath) && validConfigDirExists(configDirPath, hash) {
+		return hash, nil
+	}
+	// check if config dir is a file; if true, remove it
+	if fileExists(configDirPath) {
+		if err := removeAll(configDirPath); err != nil {
+			return "", err
+		}
+	}
+	// create new config dir
+	if err := createNewExecAgentConfigDir(agentConfig, configDirPath); err != nil {
+		return "", err
+	}
+	return hash, nil
+}
+
+var createNewExecAgentConfigDir = createNewConfigDir
+
+var mkdirAll = os.MkdirAll
+
+func createNewConfigDir(agentConfig, configDirPath string) error {
+	// make top level config directory
+	err := mkdirAll(configDirPath, folderPerm)
+	if err != nil {
+		return err
+	}
+
+	// make individual config files
+	agentConfigFilePath := filepath.Join(configDirPath, containerConfigFileName)
+	err = createNewExecAgentConfigFile(agentConfigFilePath, agentConfig)
+	if err != nil {
+		return err
+	}
+
+	logConfigFilePath := filepath.Join(configDirPath, ExecAgentLogConfigFileName)
+	err = createNewExecAgentConfigFile(logConfigFilePath, execAgentLogConfigTemplate)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validConfigDirExists(configDirPath, expectedHash string) bool {
+	// check that each config file exists and create a hash of their summed contents
+	contentSum := ""
+	for _, file := range configFiles {
+		if isDir(filepath.Join(configDirPath, file)) {
+			return false
+		}
+		config, err := getFileContent(filepath.Join(configDirPath, file))
+		if err != nil {
+			return false
+		}
+		contentSum += string(config)
+	}
+
+	hash := getExecAgentConfigHash(contentSum)
+	return strings.Compare(expectedHash, hash) == 0
+}
+
+// This function creates any necessary config directories/files and ensures that
+// the ssm-agent binaries, configs, logs, and plugin is bind mounted
+func addRequiredBindMounts(taskId, cn, latestBinVersionDir, uuid string, sessionWorkersLimit int, hostConfig *dockercontainer.HostConfig) error {
+	// In windows host mounts are not created automatically, so need to create
+	rErr := os.MkdirAll(filepath.Join(HostLogDir, taskId, cn), folderPerm)
+	if rErr != nil {
+		return rErr
+	}
+
+	configDirHash, rErr := GetExecAgentConfigDir(sessionWorkersLimit)
+	if rErr != nil {
+		rErr = fmt.Errorf("could not generate ExecAgent Config dir: %v", rErr)
+		return rErr
+	}
+
+	// Add ssm binary mount
+	hostConfig.Binds = append(hostConfig.Binds, getReadOnlyBindMountMapping(
+		latestBinVersionDir,
+		containerDepsFolder))
+
+	// Add ssm configuration dir mount
+	hostConfig.Binds = append(hostConfig.Binds, getReadOnlyBindMountMapping(
+		filepath.Join(ECSAgentExecConfigDir, configDirHash),
+		filepath.Join(containerDepsFolder, "configuration")))
+
+	// Add ssm log bind mount
+	hostConfig.Binds = append(hostConfig.Binds, getBindMountMapping(
+		filepath.Join(HostLogDir, taskId, cn),
+		ContainerLogDir))
+
+	// add ssm plugin bind mount (needed for execcmd windows)
+	hostConfig.Binds = append(hostConfig.Binds, getBindMountMapping(
+		SSMPluginDir,
+		SSMPluginDir))
+
 	return nil
 }

--- a/agent/engine/execcmd/manager_init_task_windows_test.go
+++ b/agent/engine/execcmd/manager_init_task_windows_test.go
@@ -1,0 +1,260 @@
+// +build windows,unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package execcmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInitializeContainer(t *testing.T) {}
+
+func TestGetExecAgentConfigDir(t *testing.T) {
+	hash := getExecAgentConfigHash(fmt.Sprintf(execAgentConfigTemplate, 2) + execAgentLogConfigTemplate)
+
+	var tests = []struct {
+		expectedDir                string
+		expectedError              error
+		execAgentConfigDirExist    bool
+		configDirIsFile            bool
+		removeFileErr              error
+		existingLogConfigReadErr   error
+		existingLogConfig          string
+		logConfigIsDir             bool
+		existingAgentConfigReadErr error
+		existingAgentConfig        string
+		agentConfigIsDir           bool
+		createNewConfigDirError    error
+		createNewConfigFileError   error
+	}{
+		{
+			expectedDir:             hash,
+			expectedError:           nil,
+			execAgentConfigDirExist: true,
+			existingLogConfig:       execAgentLogConfigTemplate,
+			existingAgentConfig:     fmt.Sprintf(execAgentConfigTemplate, 2),
+		},
+		{
+			expectedDir:             hash,
+			expectedError:           nil,
+			execAgentConfigDirExist: false,
+			existingLogConfig:       execAgentLogConfigTemplate,
+			existingAgentConfig:     fmt.Sprintf(execAgentConfigTemplate, 2),
+		},
+		{
+			expectedDir:             hash,
+			expectedError:           nil,
+			execAgentConfigDirExist: true,
+			existingLogConfig:       "junk",
+			existingAgentConfig:     fmt.Sprintf(execAgentConfigTemplate, 2),
+		},
+		{
+			expectedDir:              hash,
+			expectedError:            nil,
+			execAgentConfigDirExist:  true,
+			existingLogConfigReadErr: errors.New("read file error"),
+			existingLogConfig:        "",
+			existingAgentConfig:      fmt.Sprintf(execAgentConfigTemplate, 2),
+		},
+		{
+			expectedDir:                hash,
+			expectedError:              nil,
+			execAgentConfigDirExist:    true,
+			existingLogConfig:          execAgentLogConfigTemplate,
+			existingAgentConfigReadErr: errors.New("read file error"),
+			existingAgentConfig:        "",
+		},
+		{
+			expectedDir:             hash,
+			expectedError:           nil,
+			execAgentConfigDirExist: true,
+			configDirIsFile:         true,
+			existingLogConfig:       execAgentLogConfigTemplate,
+			existingAgentConfig:     fmt.Sprintf(execAgentConfigTemplate, 2),
+		},
+		{
+			expectedDir:              "",
+			expectedError:            errors.New("create file error"),
+			execAgentConfigDirExist:  false,
+			createNewConfigFileError: errors.New("create file error"),
+		},
+		{
+			expectedDir:             "",
+			expectedError:           errors.New("create dir error"),
+			execAgentConfigDirExist: false,
+			createNewConfigDirError: errors.New("create dir error"),
+		},
+		// todo: need to fix
+		{
+			expectedDir:             "",
+			expectedError:           errors.New("remove file error"),
+			execAgentConfigDirExist: true,
+			configDirIsFile:         true,
+			removeFileErr:           errors.New("remove file error"),
+		},
+
+		// todo: add the is_dir flags
+	}
+	defer func() {
+		osStat = os.Stat
+		getFileContent = readFileContent
+		createNewExecAgentConfigFile = createNewConfigFile
+		removeAll = os.RemoveAll
+		mkdirAll = os.MkdirAll
+	}()
+
+	for _, tc := range tests {
+		osStat = func(name string) (os.FileInfo, error) {
+			if filepath.Base(name) == "amazon-ssm-agent.json" {
+				return &mockFileInfo{name: "", isDir: tc.agentConfigIsDir}, nil
+			} else if filepath.Base(name) == "seelog.xml" {
+				return &mockFileInfo{name: "", isDir: tc.logConfigIsDir}, nil
+			} else { // this is the case for the top level \config\hash folder
+				if tc.execAgentConfigDirExist {
+					return &mockFileInfo{name: "", isDir: !tc.configDirIsFile}, nil
+				}
+				return &mockFileInfo{}, errors.New("no such file")
+			}
+
+		}
+		removeAll = func(name string) error {
+			return tc.removeFileErr
+		}
+		getFileContent = func(path string) ([]byte, error) {
+			if filepath.Base(path) == "amazon-ssm-agent.json" {
+				return []byte(tc.existingAgentConfig), tc.existingAgentConfigReadErr
+			}
+
+			if filepath.Base(path) == "seelog.xml" {
+				return []byte(tc.existingLogConfig), tc.existingLogConfigReadErr
+			}
+			return nil, nil
+		}
+		createNewExecAgentConfigFile = func(c, f string) error {
+			return tc.createNewConfigFileError
+		}
+
+		mkdirAll = func(path string, perm os.FileMode) error {
+			return tc.createNewConfigDirError
+		}
+		configDir, err := GetExecAgentConfigDir(2)
+		assert.Equal(t, tc.expectedDir, configDir)
+		assert.Equal(t, tc.expectedError, err)
+	}
+
+}
+
+func TestGetValidConfigDirExists(t *testing.T) {
+	var tests = []struct {
+		isValid                    bool
+		existingLogConfigReadErr   error
+		existingLogConfig          string
+		existingLogConfigIsDir     bool
+		existingAgentConfigReadErr error
+		existingAgentConfig        string
+		existingAgentConfigIsDir   bool
+	}{
+		{
+			isValid:                    true,
+			existingLogConfigReadErr:   nil,
+			existingLogConfig:          execAgentLogConfigTemplate,
+			existingAgentConfigReadErr: nil,
+			existingAgentConfig:        fmt.Sprintf(execAgentConfigTemplate, 2),
+		},
+		{
+			isValid:                    false,
+			existingLogConfigReadErr:   nil,
+			existingLogConfig:          execAgentLogConfigTemplate,
+			existingAgentConfigReadErr: nil,
+			existingAgentConfig:        fmt.Sprintf(execAgentConfigTemplate, 3),
+		},
+		{
+			isValid:                    false,
+			existingLogConfigReadErr:   nil,
+			existingLogConfig:          "junk",
+			existingAgentConfigReadErr: nil,
+			existingAgentConfig:        fmt.Sprintf(execAgentConfigTemplate, 2),
+		},
+		{
+			isValid:                    false,
+			existingLogConfigReadErr:   errors.New("read file error"),
+			existingLogConfig:          "",
+			existingAgentConfigReadErr: nil,
+			existingAgentConfig:        fmt.Sprintf(execAgentConfigTemplate, 2),
+		},
+		{
+			isValid:                    false,
+			existingLogConfigReadErr:   nil,
+			existingLogConfig:          execAgentLogConfigTemplate,
+			existingAgentConfigReadErr: errors.New("read file error"),
+			existingAgentConfig:        "",
+		},
+		{
+			isValid:                    false,
+			existingLogConfigReadErr:   nil,
+			existingLogConfig:          execAgentLogConfigTemplate,
+			existingLogConfigIsDir:     true,
+			existingAgentConfigReadErr: nil,
+			existingAgentConfig:        fmt.Sprintf(execAgentConfigTemplate, 2),
+		},
+		{
+			isValid:                    false,
+			existingLogConfigReadErr:   nil,
+			existingLogConfig:          execAgentLogConfigTemplate,
+			existingAgentConfigReadErr: nil,
+			existingAgentConfig:        fmt.Sprintf(execAgentConfigTemplate, 2),
+			existingAgentConfigIsDir:   true,
+		},
+	}
+	defer func() {
+		getFileContent = readFileContent
+		osStat = os.Stat
+	}()
+	configDirPath := "C:\\configpath"
+	for _, tc := range tests {
+		getFileContent = func(path string) ([]byte, error) {
+			// amazon-ssm-agent.json
+			if path == filepath.Join(configDirPath, containerConfigFileName) {
+				return []byte(tc.existingAgentConfig), tc.existingAgentConfigReadErr
+			}
+
+			// seelog.xml
+			if path == filepath.Join(configDirPath, ExecAgentLogConfigFileName) {
+				return []byte(tc.existingLogConfig), tc.existingLogConfigReadErr
+			}
+
+			return nil, nil
+		}
+
+		osStat = func(path string) (os.FileInfo, error) {
+			if filepath.Base(path) == "amazon-ssm-agent.json" {
+				return &mockFileInfo{name: "", isDir: tc.existingAgentConfigIsDir}, nil
+			}
+
+			if filepath.Base(path) == "seelog.xml" {
+				return &mockFileInfo{name: "", isDir: tc.existingLogConfigIsDir}, nil
+			}
+
+			return &mockFileInfo{}, errors.New("no such file")
+		}
+		assert.Equal(t, tc.isValid, validConfigDirExists(configDirPath, getExecAgentConfigHash(fmt.Sprintf(execAgentConfigTemplate, 2)+execAgentLogConfigTemplate)))
+	}
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This pull request implements the ECS agent init_task functionality so that the SSM agent has the necessary bind mounts and binaries to run. 


### Implementation details
<!-- How are the changes implemented? -->
The common variables are pulled into the manager_init_task.go file and then the Linux code is kept in its file. The windows file is where the bulk of the new implementation is. Mainly, Windows stores its configs in a different way since it cannot bind mount files (This is a [limitation](https://github.com/moby/moby/issues/30555) of docker windows). In addition, we need to bind mount the SSM plugins since the windows agent needs those. Because the dirs are bind mounted, they will be cached on a directory level (by concatenating the contents of the dir and hashing them), on Linux this is done in a file level. Lastly, when mounting in Windows host file paths/folders are not automatically created by Docker so they need to be manually created before mounting. 

### Testing
<!-- How was this tested? -->
unit tests
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes <!-- yes|no -->
integ tests will be in following PR
### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
