### PR TITLE
EC2 task networking on Windows: Implementation change for blocking IMDS

### DIFF
--- a/agent/ecscni/mocks/namespace_helper_mocks.go
+++ b/agent/ecscni/mocks/namespace_helper_mocks.go
@@ -51,34 +51,6 @@ func (m *MockNamespaceHelper) EXPECT() *MockNamespaceHelperMockRecorder {
 	return m.recorder
 }
 
-// ConfigureFirewallForTaskNSCleanup mocks base method
-func (m *MockNamespaceHelper) ConfigureFirewallForTaskNSCleanup(arg0 *eni.ENI, arg1 *ecscni.Config) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConfigureFirewallForTaskNSCleanup", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ConfigureFirewallForTaskNSCleanup indicates an expected call of ConfigureFirewallForTaskNSCleanup
-func (mr *MockNamespaceHelperMockRecorder) ConfigureFirewallForTaskNSCleanup(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfigureFirewallForTaskNSCleanup", reflect.TypeOf((*MockNamespaceHelper)(nil).ConfigureFirewallForTaskNSCleanup), arg0, arg1)
-}
-
-// ConfigureFirewallForTaskNSSetup mocks base method
-func (m *MockNamespaceHelper) ConfigureFirewallForTaskNSSetup(arg0 *eni.ENI, arg1 *ecscni.Config) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConfigureFirewallForTaskNSSetup", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ConfigureFirewallForTaskNSSetup indicates an expected call of ConfigureFirewallForTaskNSSetup
-func (mr *MockNamespaceHelperMockRecorder) ConfigureFirewallForTaskNSSetup(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfigureFirewallForTaskNSSetup", reflect.TypeOf((*MockNamespaceHelper)(nil).ConfigureFirewallForTaskNSSetup), arg0, arg1)
-}
-
 // ConfigureTaskNamespaceRouting mocks base method
 func (m *MockNamespaceHelper) ConfigureTaskNamespaceRouting(arg0 context.Context, arg1 *eni.ENI, arg2 *ecscni.Config, arg3 *current.Result) error {
 	m.ctrl.T.Helper()

--- a/agent/ecscni/namespace_helper.go
+++ b/agent/ecscni/namespace_helper.go
@@ -21,25 +21,19 @@ import (
 	"github.com/containernetworking/cni/pkg/types/current"
 )
 
-// execCmdExecutorFnType is the method signature for execCmdExecutorFn.
-type execCmdExecutorFnType func(commands []string, separator string) error
-
 // NamespaceHelper defines the methods for performing additional actions to setup/clean the task namespace.
 // Task namespace in awsvpc network mode is configured using pause container which is the first container
 // launched for the task. These commands are executed inside that container.
 type NamespaceHelper interface {
 	ConfigureTaskNamespaceRouting(ctx context.Context, taskENI *apieni.ENI, config *Config, result *current.Result) error
-	ConfigureFirewallForTaskNSSetup(taskENI *apieni.ENI, config *Config) error
-	ConfigureFirewallForTaskNSCleanup(taskENI *apieni.ENI, config *Config) error
 }
 
 // helper is the client for executing methods of NamespaceHelper interface.
 type helper struct {
-	dockerClient    dockerapi.DockerClient
-	execCmdExecutor execCmdExecutorFnType
+	dockerClient dockerapi.DockerClient
 }
 
 // NewNamespaceHelper returns a new instance of NamespaceHelper interface.
 func NewNamespaceHelper(client dockerapi.DockerClient) NamespaceHelper {
-	return &helper{dockerClient: client, execCmdExecutor: execCmdExecutorFn}
+	return &helper{dockerClient: client}
 }

--- a/agent/ecscni/namespace_helper_linux.go
+++ b/agent/ecscni/namespace_helper_linux.go
@@ -22,22 +22,8 @@ import (
 	"github.com/containernetworking/cni/pkg/types/current"
 )
 
-var execCmdExecutorFn execCmdExecutorFnType = nil
-
 // ConfigureTaskNamespaceRouting executes the commands required for setting up appropriate routing inside task namespace.
 // This is applicable only for Windows.
 func (nsHelper *helper) ConfigureTaskNamespaceRouting(ctx context.Context, taskENI *apieni.ENI, config *Config, result *current.Result) error {
-	return nil
-}
-
-// ConfigureFirewallForTaskNSSetup executes the commands, if required, to setup firewall rules for disabling IMDS access from task.
-// This is applicable only for Windows.
-func (nsHelper *helper) ConfigureFirewallForTaskNSSetup(taskENI *apieni.ENI, config *Config) error {
-	return nil
-}
-
-// ConfigureFirewallForTaskNSCleanup executes the commands, if required, to cleanup the firewall rules created during setup.
-// This is applicable only for Windows.
-func (nsHelper *helper) ConfigureFirewallForTaskNSCleanup(taskENI *apieni.ENI, config *Config) error {
 	return nil
 }

--- a/agent/ecscni/namespace_helper_unsupported.go
+++ b/agent/ecscni/namespace_helper_unsupported.go
@@ -22,22 +22,8 @@ import (
 	"github.com/containernetworking/cni/pkg/types/current"
 )
 
-var execCmdExecutorFn execCmdExecutorFnType = nil
-
 // ConfigureTaskNamespaceRouting executes the commands required for setting up appropriate routing inside task namespace.
 // This is applicable only for Windows.
 func (nsHelper *helper) ConfigureTaskNamespaceRouting(ctx context.Context, taskENI *apieni.ENI, config *Config, result *current.Result) error {
-	return nil
-}
-
-// ConfigureFirewallForTaskNSSetup executes the commands, if required, to setup firewall rules for disabling IMDS access from task.
-// This is applicable only for Windows.
-func (nsHelper *helper) ConfigureFirewallForTaskNSSetup(taskENI *apieni.ENI, config *Config) error {
-	return nil
-}
-
-// ConfigureFirewallForTaskNSCleanup executes the commands, if required, to cleanup the firewall rules created during setup.
-// This is applicable only for Windows.
-func (nsHelper *helper) ConfigureFirewallForTaskNSCleanup(taskENI *apieni.ENI, config *Config) error {
 	return nil
 }

--- a/agent/ecscni/namespace_helper_windows_test.go
+++ b/agent/ecscni/namespace_helper_windows_test.go
@@ -51,51 +51,76 @@ func getECSBridgeResult() *current.Result {
 }
 
 func TestConfigureTaskNamespaceRouting(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	ctx, cancel := context.WithCancel(context.TODO())
-	defer cancel()
+	var tests = []struct {
+		name      string
+		blockIMDS bool
+	}{
+		{
+			name:      "DisabledIMDS",
+			blockIMDS: true,
+		},
+		{
+			name:      "EnabledIMDS",
+			blockIMDS: false,
+		},
+	}
 
-	dockerClient := mock_dockerapi.NewMockDockerClient(ctrl)
-	cniConig := getCNIConfig()
-	taskENI := getTaskENI()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			ctx, cancel := context.WithCancel(context.TODO())
+			defer cancel()
 
-	cniConig.AdditionalLocalRoutes = append(cniConig.AdditionalLocalRoutes, cnitypes.IPNet{
-		IP:   net.ParseIP("10.0.0.0"),
-		Mask: net.CIDRMask(24, 32),
-	})
+			dockerClient := mock_dockerapi.NewMockDockerClient(ctrl)
+			taskENI := getTaskENI()
+			cniConfig := getCNIConfig()
+			cniConfig.BlockInstanceMetadata = tt.blockIMDS
 
-	bridgeEpName := fmt.Sprintf(ecsBridgeEndpointNameFormat, ECSBridgeNetworkName, containerID)
-	taskEpId := strings.Replace(strings.ToLower(taskENI.MacAddress), ":", "", -1)
-	taskEPName := fmt.Sprintf(taskPrimaryEndpointNameFormat, TaskHNSNetworkNamePrefix, taskEpId, containerID)
+			cniConfig.AdditionalLocalRoutes = append(cniConfig.AdditionalLocalRoutes, cnitypes.IPNet{
+				IP:   net.ParseIP("10.0.0.0"),
+				Mask: net.CIDRMask(24, 32),
+			})
 
-	cmd1 := fmt.Sprintf(windowsRouteDeleteCmdFormat, windowsDefaultRoute, bridgeEpName)
-	cmd2 := fmt.Sprintf(windowsRouteDeleteCmdFormat, "10.0.0.0/24", bridgeEpName)
-	cmd3 := fmt.Sprintf(windowsRouteAddCmdFormat, credentialsEndpointRoute, bridgeEpName)
-	cmd4 := fmt.Sprintf(windowsRouteAddCmdFormat, imdsEndpointIPAddress, taskEPName)
-	cmd5 := fmt.Sprintf(windowsRouteAddCmdFormat, "10.0.0.0/24", bridgeEpName)
-	finalCmd := strings.Join([]string{cmd1, cmd2, cmd3, cmd4, cmd5}, " && ")
+			bridgeEpName := fmt.Sprintf(ecsBridgeEndpointNameFormat, ECSBridgeNetworkName, containerID)
+			taskEpId := strings.Replace(strings.ToLower(taskENI.MacAddress), ":", "", -1)
+			taskEPName := fmt.Sprintf(taskPrimaryEndpointNameFormat, TaskHNSNetworkNamePrefix, taskEpId, containerID)
 
-	gomock.InOrder(
-		dockerClient.EXPECT().CreateContainerExec(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(
-			func(_ context.Context, container string, execConfig types.ExecConfig, _ time.Duration) {
-				assert.Equal(t, container, containerID)
-				assert.Len(t, execConfig.Cmd, 3)
-				assert.Equal(t, execConfig.Cmd[2], finalCmd)
-				assert.Equal(t, execConfig.User, containerAdminUser)
-			}).Return(&types.IDResponse{ID: containerExecID}, nil),
-		dockerClient.EXPECT().StartContainerExec(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(
-			func(_ context.Context, execID string, execStartCheck types.ExecStartCheck, _ time.Duration) {
-				assert.Equal(t, execID, containerExecID)
-				assert.False(t, execStartCheck.Detach)
-			}).Return(nil),
-		dockerClient.EXPECT().InspectContainerExec(gomock.Any(), gomock.Any(), gomock.Any()).Return(
-			&types.ContainerExecInspect{
-				ExitCode: 0,
-				Running:  false,
-			}, nil),
-	)
+			cmd1 := fmt.Sprintf(windowsRouteDeleteCmdFormat, windowsDefaultRoute, bridgeEpName)
+			cmd2 := fmt.Sprintf(windowsRouteDeleteCmdFormat, "10.0.0.0/24", bridgeEpName)
+			cmd3 := fmt.Sprintf(windowsRouteAddCmdFormat, credentialsEndpointRoute, bridgeEpName)
 
-	nsHelper := NewNamespaceHelper(dockerClient)
-	err := nsHelper.ConfigureTaskNamespaceRouting(ctx, taskENI, cniConig, getECSBridgeResult())
-	assert.NoError(t, err)
+			var cmd4 string
+			if cniConfig.BlockInstanceMetadata {
+				cmd4 = fmt.Sprintf(windowsRouteAddCmdFormat, imdsEndpointIPAddress, loopbackInterfaceName)
+			} else {
+				cmd4 = fmt.Sprintf(windowsRouteAddCmdFormat, imdsEndpointIPAddress, taskEPName)
+			}
+			cmd5 := fmt.Sprintf(windowsRouteAddCmdFormat, "10.0.0.0/24", bridgeEpName)
+			finalCmd := strings.Join([]string{cmd1, cmd2, cmd3, cmd4, cmd5}, " && ")
+
+			gomock.InOrder(
+				dockerClient.EXPECT().CreateContainerExec(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(
+					func(_ context.Context, container string, execConfig types.ExecConfig, _ time.Duration) {
+						assert.Equal(t, container, containerID)
+						assert.Len(t, execConfig.Cmd, 3)
+						assert.Equal(t, execConfig.Cmd[2], finalCmd)
+						assert.Equal(t, execConfig.User, containerAdminUser)
+					}).Return(&types.IDResponse{ID: containerExecID}, nil),
+				dockerClient.EXPECT().StartContainerExec(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(
+					func(_ context.Context, execID string, execStartCheck types.ExecStartCheck, _ time.Duration) {
+						assert.Equal(t, execID, containerExecID)
+						assert.False(t, execStartCheck.Detach)
+					}).Return(nil),
+				dockerClient.EXPECT().InspectContainerExec(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					&types.ContainerExecInspect{
+						ExitCode: 0,
+						Running:  false,
+					}, nil),
+			)
+
+			nsHelper := NewNamespaceHelper(dockerClient)
+			err := nsHelper.ConfigureTaskNamespaceRouting(ctx, taskENI, cniConfig, getECSBridgeResult())
+			assert.NoError(t, err)
+		})
+	}
 }

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -1443,18 +1443,6 @@ func (engine *DockerTaskEngine) provisionContainerResources(task *apitask.Task, 
 		}
 	}
 
-	// Invoke additional commands, if required, to configure the firewall for disabling IMDS access from task.
-	err = engine.namespaceHelper.ConfigureFirewallForTaskNSSetup(task.GetPrimaryENI(), cniConfig)
-	if err != nil {
-		seelog.Errorf("Task engine [%s]: unable to configure pause container namespace: %v",
-			task.Arn, err)
-		return dockerapi.DockerContainerMetadata{
-			DockerID: cniConfig.ContainerID,
-			Error: ContainerNetworkingError{errors.Wrapf(err,
-				"container resource provisioning: failed to setup network namespace")},
-		}
-	}
-
 	return dockerapi.DockerContainerMetadata{
 		DockerID: cniConfig.ContainerID,
 	}
@@ -1505,12 +1493,6 @@ func (engine *DockerTaskEngine) cleanupPauseContainerNetwork(task *apitask.Task,
 	}
 
 	err = engine.cniClient.CleanupNS(engine.ctx, cniConfig, cniCleanupTimeout)
-	if err != nil {
-		return err
-	}
-
-	// Invoke additional command, if required, to cleanup the firewall rule created during ns setup.
-	err = engine.namespaceHelper.ConfigureFirewallForTaskNSCleanup(task.GetPrimaryENI(), cniConfig)
 	if err != nil {
 		return err
 	}

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -1038,7 +1038,6 @@ func TestProvisionContainerResourcesSetPausePIDInVolumeResources(t *testing.T) {
 		}, nil),
 		mockCNIClient.EXPECT().SetupNS(gomock.Any(), gomock.Any(), gomock.Any()).Return(nsResult, nil),
 		mockNamespaceHelper.EXPECT().ConfigureTaskNamespaceRouting(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil),
-		mockNamespaceHelper.EXPECT().ConfigureFirewallForTaskNSSetup(gomock.Any(), gomock.Any()).Return(nil),
 	)
 
 	require.Nil(t, taskEngine.(*DockerTaskEngine).provisionContainerResources(testTask, pauseContainer).Error)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Earlier, we were creating Windows Firewall rules for blocking the IMDS access to the tasks. With this change, instead of creating a firewall rule, we will create a blackhole route in the task namespace for IMDS.

### Implementation details
<!-- How are the changes implemented? -->
The original methods of creating and deleting firewall rules have been removed.
In place of those, a new command is created to be run inside the task namespace which loops back the request sent to IMDS endpoint.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
The changes were tested using unit tests as well as a custom binary was tested.
New tests cover the changes: <!-- yes|no -->
Yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Changed implementation method for blocking IMDS access to the tasks.
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
