### PR TITLE
ECS EC2 task networking for Windows: Data validation for CNI Plugin invocation config

### DIFF
--- a/agent/ecscni/netconfig_windows_test.go
+++ b/agent/ecscni/netconfig_windows_test.go
@@ -30,9 +30,9 @@ const (
 	validDNSServer          = "10.0.0.2"
 	ipv4                    = "10.0.0.120"
 	ipv4CIDR                = "10.0.0.120/24"
-	vpcCIDR                 = "10.0.0.0/16"
 	mac                     = "02:7b:64:49:b1:40"
 	cniMinSupportedVersion  = "1.0.0"
+	invalidMACAddress       = "12:34;56-78"
 )
 
 func getTaskENI() *apieni.ENI {
@@ -79,6 +79,17 @@ func TestNewVPCENIPluginConfigForTaskNSSetup(t *testing.T) {
 	assert.EqualValues(t, []string{validVPCGatewayIPv4Addr}, netConfig.GatewayIPAddresses)
 	assert.EqualValues(t, linkName, netConfig.ENIName)
 	assert.False(t, netConfig.UseExistingNetwork)
+}
+
+func TestNewVPCENIPluginConfigForTaskNSSetupFailure(t *testing.T) {
+	cniConfig := getCNIConfig()
+	taskENI := getTaskENI()
+	taskENI.MacAddress = invalidMACAddress
+
+	config, err := NewVPCENIPluginConfigForTaskNSSetup(taskENI, cniConfig)
+
+	assert.Nil(t, config)
+	assert.Error(t, err)
 }
 
 // TestNewVPCENIPluginConfigForECSBridgeSetup tests the generated configuration for ecs-bridge setup.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
The changes introduced in this PR validates the data for any special characters and length before the same is used for invoking the CNI plugins.
### Implementation details
<!-- How are the changes implemented? -->
A regex is created of valid characters and is matched against the characters in the data. Additionally, the length of the data is also validated.

The length of the data in this case can be at max 18 characters which is the length of longest IP Address in CIDR format.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Unit tests were executed and a custom binary was also tested.
New tests cover the changes: <!-- yes|no -->
Yes
### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Data validation for CNI plugin input parameters.
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
