### PR TITLE
Remove noisy log entries

### DIFF
--- a/agent/eventhandler/task_handler.go
+++ b/agent/eventhandler/task_handler.go
@@ -261,13 +261,13 @@ func (handler *TaskHandler) taskStateChangesToSend() []api.TaskStateChange {
 
 // batchContainerEventUnsafe collects container state change events for a given task arn
 func (handler *TaskHandler) batchContainerEventUnsafe(event api.ContainerStateChange) {
-	seelog.Infof("TaskHandler: batching container event: %s", event.String())
+	seelog.Debugf("TaskHandler: batching container event: %s", event.String())
 	handler.tasksToContainerStates[event.TaskArn] = append(handler.tasksToContainerStates[event.TaskArn], event)
 }
 
 // batchManagedAgentEventUnsafe collects managed agent state change events for a given task arn
 func (handler *TaskHandler) batchManagedAgentEventUnsafe(event api.ManagedAgentStateChange) {
-	seelog.Infof("TaskHandler: batching managed agent event: %s", event.String())
+	seelog.Debugf("TaskHandler: batching managed agent event: %s", event.String())
 	handler.tasksToManagedAgentStates[event.TaskArn] = append(handler.tasksToManagedAgentStates[event.TaskArn], event)
 }
 
@@ -366,7 +366,7 @@ func (taskEvents *taskSendableEvents) sendChange(change *sendableEvent,
 	defer taskEvents.lock.Unlock()
 
 	// Add event to the queue
-	seelog.Infof("TaskHandler: Adding event: %s", change.toString())
+	seelog.Debugf("TaskHandler: Adding event: %s", change.toString())
 	taskEvents.events.PushBack(change)
 
 	if !taskEvents.sending {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Improve ECS agent log readability by changing some of the most noisy log entries to `debug` level. These logs don't add much value (if at all) when debugging issues, oftentimes making it difficult for devs to follow what's happening at runtime.

### Testing

Manual verification. UTs & Integ Tests still pass.

### Description for the changelog
* Remove noisy log entries from agent logs

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
