### PR TITLE
Add service files and packaging directories

### DIFF
--- a/packaging/amazon-linux-ami/ecs.service
+++ b/packaging/amazon-linux-ami/ecs.service
@@ -1,0 +1,31 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the
+# "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+
+[Unit]
+Description=Amazon Elastic Container Service - container agent
+Documentation=https://github.com/aws/amazon-ecs-agent
+Requires=docker.service
+After=docker.service
+After=cloud-final.service
+
+[Service]
+Type=simple
+Restart=on-failure
+RestartPreventExitStatus=5
+RestartSec=10
+EnvironmentFile=-/etc/ecs/ecs.config
+ExecStart=/usr/local/bin/amazon-ecs-agent
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/generic-deb/debian/ecs.service
+++ b/packaging/generic-deb/debian/ecs.service
@@ -1,0 +1,31 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the
+# "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+
+[Unit]
+Description=Amazon Elastic Container Service - container agent
+Documentation=https://github.com/aws/amazon-ecs-agent
+Requires=docker.service
+After=docker.service
+After=cloud-final.service
+
+[Service]
+Type=simple
+Restart=on-failure
+RestartPreventExitStatus=5
+RestartSec=10
+EnvironmentFile=-/etc/ecs/ecs.config
+ExecStart=/usr/local/bin/amazon-ecs-agent
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/generic-deb/debian/ecs.service
+++ b/packaging/generic-deb/debian/ecs.service
@@ -17,7 +17,6 @@ Description=Amazon Elastic Container Service - container agent
 Documentation=https://github.com/aws/amazon-ecs-agent
 Requires=docker.service
 After=docker.service
-After=cloud-final.service
 
 [Service]
 Type=simple

--- a/packaging/generic-rpm/ecs.service
+++ b/packaging/generic-rpm/ecs.service
@@ -1,0 +1,31 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the
+# "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+
+[Unit]
+Description=Amazon Elastic Container Service - container agent
+Documentation=https://github.com/aws/amazon-ecs-agent
+Requires=docker.service
+After=docker.service
+After=cloud-final.service
+
+[Service]
+Type=simple
+Restart=on-failure
+RestartPreventExitStatus=5
+RestartSec=10
+EnvironmentFile=-/etc/ecs/ecs.config
+ExecStart=/usr/local/bin/amazon-ecs-agent
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/generic-rpm/ecs.service
+++ b/packaging/generic-rpm/ecs.service
@@ -17,7 +17,6 @@ Description=Amazon Elastic Container Service - container agent
 Documentation=https://github.com/aws/amazon-ecs-agent
 Requires=docker.service
 After=docker.service
-After=cloud-final.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
### Summary

Adding the service file and setting up packaging directories. ExecStartPre and ExecStopPost which sets up and clens up the IPTables will need to be added into the service file after the bash files are complete for those.

### Testing

Manual testing- created service on instance and agent was able to properly access environment file and set itself up properly. I then started and enabled the service. The instance appeared on the intended cluster and remained there after the instance was rebooted through the console as well as when the agent was stopped and restarted through the instance. 
Then, I assigned a long running task to the instance which was functioning properly. I then did the same restarting methods. `Docker ps` revealed that there were no duplicate task containers and the task survived the restarts.


### Description for the changelog

Add service files and packaging directories

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
