### PR TITLE
Disable Execcmd on Win2016

### DIFF
--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -100,8 +100,9 @@ var (
 	// use empty struct as value type to simulate set
 	capabilityExecInvalidSsmVersions = map[string]struct{}{}
 
-	pathExists        = defaultPathExists
-	getSubDirectories = defaultGetSubDirectories
+	pathExists              = defaultPathExists
+	getSubDirectories       = defaultGetSubDirectories
+	isPlatformExecSupported = defaultIsPlatformExecSupported
 
 	// List of capabilities that are not supported on external capacity.
 	externalUnsupportedCapabilities = []string{
@@ -376,6 +377,12 @@ func (agent *ecsAgent) appendTaskENICapabilities(capabilities []*ecs.Attribute) 
 }
 
 func (agent *ecsAgent) appendExecCapabilities(capabilities []*ecs.Attribute) ([]*ecs.Attribute, error) {
+
+	// Only Windows 2019 and above are supported, all Linux supported
+	if platformSupported, err := isPlatformExecSupported(); err != nil || !platformSupported {
+		return capabilities, err
+	}
+
 	// for an instance to be exec-enabled, it needs resources needed by SSM (binaries, configuration files and certs)
 	// the following bind mounts are defined in ecs-init and added to the ecs-agent container
 

--- a/agent/app/agent_capability_test.go
+++ b/agent/app/agent_capability_test.go
@@ -875,6 +875,7 @@ func TestCapabilitiesExecuteCommand(t *testing.T) {
 		getSubDirectories        func(path string) ([]string, error)
 		invalidSsmVersions       map[string]struct{}
 		shouldHaveExecCapability bool
+		osPlatformNotSupported   bool
 	}{
 		{
 			name:                     "execute-command capability should not be added if any required file is not found",
@@ -914,6 +915,13 @@ func TestCapabilitiesExecuteCommand(t *testing.T) {
 			getSubDirectories:        func(path string) ([]string, error) { return []string{"3.0.236.0", "3.1.23.0"}, nil },
 			shouldHaveExecCapability: true,
 		},
+		{
+			name:                     "execute-command capability should not be added if os platform is not supported",
+			pathExists:               func(path string, shouldBeDirectory bool) (bool, error) { return true, nil },
+			getSubDirectories:        func(path string) ([]string, error) { return []string{"3.0.236.0"}, nil },
+			osPlatformNotSupported:   true,
+			shouldHaveExecCapability: false,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -921,10 +929,12 @@ func TestCapabilitiesExecuteCommand(t *testing.T) {
 			getSubDirectories = tc.getSubDirectories
 			oCapabilityExecInvalidSsmVersions := capabilityExecInvalidSsmVersions
 			capabilityExecInvalidSsmVersions = tc.invalidSsmVersions
+			isPlatformExecSupported = func() (bool, error) { return !tc.osPlatformNotSupported, nil }
 			defer func() {
 				mockPathExists(false)
 				getSubDirectories = defaultGetSubDirectories
 				capabilityExecInvalidSsmVersions = oCapabilityExecInvalidSsmVersions
+				isPlatformExecSupported = defaultIsPlatformExecSupported
 			}()
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()

--- a/agent/app/agent_capability_unix.go
+++ b/agent/app/agent_capability_unix.go
@@ -206,3 +206,7 @@ func (agent *ecsAgent) appendIPv6Capability(capabilities []*ecs.Attribute) []*ec
 func (agent *ecsAgent) appendFSxWindowsFileServerCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
 	return capabilities
 }
+
+func defaultIsPlatformExecSupported() (bool, error) {
+	return true, nil
+}

--- a/agent/app/agent_capability_unspecified.go
+++ b/agent/app/agent_capability_unspecified.go
@@ -130,3 +130,7 @@ func (agent *ecsAgent) appendIPv6Capability(capabilities []*ecs.Attribute) []*ec
 func (agent *ecsAgent) appendFSxWindowsFileServerCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
 	return capabilities
 }
+
+func defaultIsPlatformExecSupported() (bool, error) {
+	return false, nil
+}

--- a/agent/app/agent_capability_windows.go
+++ b/agent/app/agent_capability_windows.go
@@ -115,3 +115,12 @@ func (agent *ecsAgent) appendFSxWindowsFileServerCapabilities(capabilities []*ec
 
 	return capabilities
 }
+
+var isWindows2016 = config.IsWindows2016
+
+func defaultIsPlatformExecSupported() (bool, error) {
+	if windows2016, err := isWindows2016(); err != nil || windows2016 {
+		return false, err
+	}
+	return true, nil
+}

--- a/agent/config/parse_windows.go
+++ b/agent/config/parse_windows.go
@@ -131,7 +131,7 @@ func parseGMSACapability() bool {
 // parseFSxWindowsFileServerCapability is used to determine if fsxWindowsFileServer support can be enabled
 func parseFSxWindowsFileServerCapability() bool {
 	// fsxwindowsfileserver is not supported on Windows 2016 and non-domain-joined container instances
-	status, err := isWindows2016()
+	status, err := IsWindows2016()
 	if err != nil || status == true {
 		return false
 	}
@@ -179,9 +179,9 @@ func isDomainJoined() (bool, error) {
 	return status == syscall.NetSetupDomainName, nil
 }
 
-// isWindows2016 is used to check if container instance is versioned Windows 2016
+// IsWindows2016 is used to check if container instance is versioned Windows 2016
 // Reference: https://godoc.org/golang.org/x/sys/windows/registry
-var isWindows2016 = func() (bool, error) {
+var IsWindows2016 = func() (bool, error) {
 	key, err := winRegistry.OpenKey(ecsWinRegistryRootKey, ecsWinRegistryRootPath, registry.QUERY_VALUE)
 
 	if err != nil {

--- a/agent/config/parse_windows_test.go
+++ b/agent/config/parse_windows_test.go
@@ -47,11 +47,15 @@ func TestParseBooleanEnvVar(t *testing.T) {
 }
 
 func TestParseFSxWindowsFileServerCapability(t *testing.T) {
-	isWindows2016 = func() (bool, error) {
+	oIsWindows2016 := IsWindows2016
+	IsWindows2016 = func() (bool, error) {
 		return false, nil
 	}
 	os.Setenv("ECS_FSX_WINDOWS_FILE_SERVER_SUPPORTED", "False")
-	defer os.Unsetenv("ECS_FSX_WINDOWS_FILE_SERVER_SUPPORTED")
+	defer func() {
+		os.Unsetenv("ECS_FSX_WINDOWS_FILE_SERVER_SUPPORTED")
+		IsWindows2016 = oIsWindows2016
+	}()
 
 	assert.False(t, parseFSxWindowsFileServerCapability())
 }

--- a/agent/engine/execcmd/manager_init_task_windows.go
+++ b/agent/engine/execcmd/manager_init_task_windows.go
@@ -117,13 +117,13 @@ func createNewConfigDir(agentConfig, configDirPath string) error {
 
 	// make individual config files
 	agentConfigFilePath := filepath.Join(configDirPath, containerConfigFileName)
-	err = createNewExecAgentConfigFile(agentConfigFilePath, agentConfig)
+	err = createNewExecAgentConfigFile(agentConfig, agentConfigFilePath)
 	if err != nil {
 		return err
 	}
 
 	logConfigFilePath := filepath.Join(configDirPath, ExecAgentLogConfigFileName)
-	err = createNewExecAgentConfigFile(logConfigFilePath, execAgentLogConfigTemplate)
+	err = createNewExecAgentConfigFile(execAgentLogConfigTemplate, logConfigFilePath)
 	if err != nil {
 		return err
 	}

--- a/agent/engine/execcmd/manager_init_task_windows.go
+++ b/agent/engine/execcmd/manager_init_task_windows.go
@@ -35,7 +35,7 @@ var (
 	// ecsAgentDepsBinDir is the directory where ECS Agent will read versions of SSM agent
 	ecsAgentDepsBinDir = ecsAgentExecDepsDir + "\\bin"
 
-	containerDepsFolder = "C:\\Program Files\\Amazon\\SSM"
+	ContainerDepsFolder = config.AmazonProgramFiles + "\\SSM"
 
 	SSMAgentBinName       = "amazon-ssm-agent.exe"
 	SSMAgentWorkerBinName = "ssm-agent-worker.exe"
@@ -44,7 +44,7 @@ var (
 	HostLogDir      = config.AmazonECSProgramData + "\\exec"
 	ContainerLogDir = config.AmazonProgramData + "\\SSM"
 
-	SSMPluginDir = "C:\\Program Files\\Amazon\\SSM\\Plugins"
+	SSMPluginDir = config.AmazonProgramFiles + "\\SSM\\Plugins"
 	// since ecs agent windows is not running in a container, the agent and host log dirs are the same
 	ECSAgentExecLogDir = config.AmazonECSProgramData + "\\exec"
 
@@ -167,12 +167,12 @@ func addRequiredBindMounts(taskId, cn, latestBinVersionDir, uuid string, session
 	// Add ssm binary mount
 	hostConfig.Binds = append(hostConfig.Binds, getReadOnlyBindMountMapping(
 		latestBinVersionDir,
-		containerDepsFolder))
+		ContainerDepsFolder))
 
 	// Add ssm configuration dir mount
 	hostConfig.Binds = append(hostConfig.Binds, getReadOnlyBindMountMapping(
 		filepath.Join(ECSAgentExecConfigDir, configDirHash),
-		filepath.Join(containerDepsFolder, "configuration")))
+		filepath.Join(ContainerDepsFolder, "configuration")))
 
 	// Add ssm log bind mount
 	hostConfig.Binds = append(hostConfig.Binds, getBindMountMapping(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR explicitly disables the agent execcmd capability if the underlying EC2 host is 2016

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
This was unit tested and created new ones to specifically isolate the behavior
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->
yes
### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
