### PR TITLE
Feature/ecs exec windows integ tests

### DIFF
--- a/agent/engine/engine_windows_integ_test.go
+++ b/agent/engine/engine_windows_integ_test.go
@@ -679,11 +679,20 @@ func TestManagedAgentEvent(t *testing.T) {
 			assert.False(t, timeout)
 
 			if tc.ShouldBeRunning {
-				containerMap, _ := taskEngine.(*DockerTaskEngine).state.ContainerMapByArn(testTask.Arn)
-				cid := containerMap[testTask.Containers[0].Name].DockerID
-				// Kill the existing container now
-				err = client.ContainerKill(context.TODO(), cid, "SIGKILL")
-				assert.NoError(t, err, "Could not kill container")
+				stateChangeEvents := taskEngine.StateChangeEvents()
+				taskUpdate := createTestExecCommandAgentTask(testTaskId, testContainerName, time.Minute*tc.ManagedAgentLifetime)
+				taskUpdate.SetDesiredStatus(apitaskstatus.TaskStopped)
+				go taskEngine.AddTask(taskUpdate)
+
+				ctx, cancel := context.WithTimeout(context.Background(), time.Second*20)
+				go func() {
+					verifyTaskIsStopped(stateChangeEvents, testTask)
+					cancel()
+				}()
+
+				<-ctx.Done()
+				require.NotEqual(t, context.DeadlineExceeded, ctx.Err(), "Timed out waiting for task (%s) to stop", testTaskId)
+				assert.NotNil(t, testTask.Containers[0].GetKnownExitCode(), "No exit code found")
 			}
 
 			taskEngine.(*DockerTaskEngine).deleteTask(testTask)

--- a/agent/engine/execcmd/manager_init_task_windows.go
+++ b/agent/engine/execcmd/manager_init_task_windows.go
@@ -180,7 +180,7 @@ func addRequiredBindMounts(taskId, cn, latestBinVersionDir, uuid string, session
 		ContainerLogDir))
 
 	// add ssm plugin bind mount (needed for execcmd windows)
-	hostConfig.Binds = append(hostConfig.Binds, getBindMountMapping(
+	hostConfig.Binds = append(hostConfig.Binds, getReadOnlyBindMountMapping(
 		SSMPluginDir,
 		SSMPluginDir))
 

--- a/misc/exec-command-agent-test/build.ps1
+++ b/misc/exec-command-agent-test/build.ps1
@@ -1,0 +1,44 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# create the container image used to run execcmd integ tests
+docker build -t "amazon/amazon-ecs-exec-command-agent-windows-test:make" -f "${PSScriptRoot}/windows.dockerfile" ${PSScriptRoot}
+
+$SIMULATED_ECS_AGENT_DEPS_BIN_DIR="C:\Program Files\Amazon\ECS\managed-agents\execute-command\bin\1.0.0.0"
+Remove-Item -Path $SIMULATED_ECS_AGENT_DEPS_BIN_DIR -Recurse -Force -ErrorAction SilentlyContinue
+New-Item -Path $SIMULATED_ECS_AGENT_DEPS_BIN_DIR -ItemType Directory -Force
+go build -tags integration -installsuffix cgo -a -o $SIMULATED_ECS_AGENT_DEPS_BIN_DIR\amazon-ssm-agent.exe ${PSScriptRoot}\sleep\
+New-Item -Path $SIMULATED_ECS_AGENT_DEPS_BIN_DIR\ssm-agent-worker.exe -ItemType File -Force
+New-Item -Path $SIMULATED_ECS_AGENT_DEPS_BIN_DIR\ssm-session-worker.exe -ItemType File -Force
+
+# Dont want to destroy local development environments plugin folder
+$SIMULATED_SSM_PLUGINS_DIR="C:\Program Files\Amazon\SSM\Plugins"
+if(!(Test-Path -path $SIMULATED_SSM_PLUGINS_DIR))
+{
+    New-Item -Path $SIMULATED_SSM_PLUGINS_DIR -ItemType directory -Force
+}
+
+if(!(Test-Path -path $SIMULATED_SSM_PLUGINS_DIR\SessionManagerShell))
+{
+    New-Item -Path $SIMULATED_SSM_PLUGINS_DIR\SessionManagerShell -ItemType directory -Force
+}
+
+if(!(Test-Path -path $SIMULATED_SSM_PLUGINS_DIR\awsCloudWatch))
+{
+    New-Item -Path $SIMULATED_SSM_PLUGINS_DIR\awsCloudWatch -ItemType directory -Force
+}
+
+if(!(Test-Path -path $SIMULATED_SSM_PLUGINS_DIR\awsDomainJoin))
+{
+    New-Item -Path $SIMULATED_SSM_PLUGINS_DIR\awsDomainJoin -ItemType directory -Force
+}

--- a/misc/exec-command-agent-test/sleep/main.go
+++ b/misc/exec-command-agent-test/sleep/main.go
@@ -1,4 +1,4 @@
-// +build !windows,integration
+// +build integration
 
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 //

--- a/misc/exec-command-agent-test/windows.dockerfile
+++ b/misc/exec-command-agent-test/windows.dockerfile
@@ -1,0 +1,13 @@
+# escape=`
+
+FROM golang:1.12 as build-env
+MAINTAINER Amazon Web Services, Inc.
+
+# There is dockerfile documentation on how to treat windows paths
+WORKDIR C:\Users\Administrator\go\src\sleep
+COPY ./sleep C:/Users/Administrator/go/src/sleep
+RUN go build -tags integration -installsuffix cgo -a -o C:/Users/Administrator/go/src/sleep/sleep.exe .
+
+FROM amazon-ecs-ftest-windows-base:make
+MAINTAINER Amazon Web Services, Inc.
+COPY --from=build-env C:/Users/Administrator/go/src/sleep/sleep.exe C:/

--- a/scripts/run-integ-tests.ps1
+++ b/scripts/run-integ-tests.ps1
@@ -42,6 +42,7 @@ Invoke-Expression "${PSScriptRoot}\..\misc\image-cleanup-test-images\build.ps1"
 Invoke-Expression "${PSScriptRoot}\..\misc\stats-windows\build.ps1"
 Invoke-Expression "${PSScriptRoot}\..\misc\container-health-windows\build.ps1"
 Invoke-Expression "${PSScriptRoot}\..\misc\netkitten\build.ps1"
+Invoke-Expression "${PSScriptRoot}\..\misc\exec-command-agent-test\build.ps1"
 
 # Run the tests
 $cwd = (pwd).Path


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This creates the integ tests for the feature execcmd windows

### Implementation details
<!-- How are the changes implemented? -->
The tests are implemented the same way as Linux file engine-sudo-linux-integ-test.go

The tests will only run on 2019 and above. 2016 not supported
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->
yes
### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
