### PR TITLE
Add Iptable functionality

### DIFF
--- a/packaging/amazon-linux-ami/ecs.service
+++ b/packaging/amazon-linux-ami/ecs.service
@@ -25,7 +25,9 @@ Restart=on-failure
 RestartPreventExitStatus=5
 RestartSec=10
 EnvironmentFile=-/etc/ecs/ecs.config
-ExecStart=/usr/local/bin/amazon-ecs-agent
+ExecStartPre=/usr/libexec/ipSetup.sh
+ExecStart=/usr/libexec/amazon-ecs-agent
+ExecStopPost=/usr/libexec/ipCleanup.sh
 
 [Install]
 WantedBy=multi-user.target

--- a/packaging/amazon-linux-ami/ipCleanup.sh
+++ b/packaging/amazon-linux-ami/ipCleanup.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -ex
+
+sysctl net.ipv4.conf.default.route_localnet
+sysctl -w net.ipv4.conf.all.route_localnet=0
+iptables -t nat -D PREROUTING -p tcp -d 169.254.170.2 --dport 80 -j DNAT --to-destination 127.0.0.1:51679
+
+if [ -n "${ECS_SKIP_LOCALHOST_TRAFFIC_FILTER}" ]
+then 
+    if [ "${ECS_SKIP_LOCALHOST_TRAFFIC_FILTER}" != "true" ]
+    then
+        iptables -t filter -D INPUT --dst 127.0.0.0/8 ! --src 127.0.0.0/8 -m conntrack ! --ctstate RELATED,ESTABLISHED,DNAT  -j DROP
+    fi
+else
+    iptables -t filter -D INPUT --dst 127.0.0.0/8 ! --src 127.0.0.0/8 -m conntrack ! --ctstate RELATED,ESTABLISHED,DNAT  -j DROP
+fi
+
+iptables -t filter -D INPUT -p tcp -i eth0 --dport 51678 -j DROP
+iptables -t nat -D OUTPUT -p tcp -d 169.254.170.2 --dport 80 -j REDIRECT --to-ports 51679

--- a/packaging/amazon-linux-ami/ipSetup.sh
+++ b/packaging/amazon-linux-ami/ipSetup.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -ex
+
+
+sysctl -w net.ipv4.conf.all.route_localnet=1
+sysctl -e -w net.ipv6.conf.docker0.accept_ra=0
+iptables -t nat -A PREROUTING -p tcp -d 169.254.170.2 --dport 80 -j DNAT --to-destination 127.0.0.1:51679
+
+if [ -n "${ECS_SKIP_LOCALHOST_TRAFFIC_FILTER}" ]
+then 
+    if [ "${ECS_SKIP_LOCALHOST_TRAFFIC_FILTER}" != "true" ]
+    then
+        iptables -t filter -I INPUT --dst 127.0.0.0/8 ! --src 127.0.0.0/8 -m conntrack ! --ctstate RELATED,ESTABLISHED,DNAT -j DROP
+    fi
+else
+    iptables -t filter -I INPUT --dst 127.0.0.0/8 ! --src 127.0.0.0/8 -m conntrack ! --ctstate RELATED,ESTABLISHED,DNAT -j DROP
+fi
+
+if [ -n "${ECS_ALLOW_OFFHOST_INTROSPECTION_ACCESS}" ]
+then
+    if [ "${ECS_ALLOW_OFFHOST_INTROSPECTION_ACCESS}" != "true" ] 
+    then
+        iptables -t filter -I INPUT -p tcp -i eth0 --dport 51678 -j DROP
+    fi
+else
+    iptables -t filter -I INPUT -p tcp -i eth0 --dport 51678 -j DROP
+fi
+
+iptables -t nat -A OUTPUT -p tcp -d 169.254.170.2 --dport 80 -j REDIRECT --to-ports 51679

--- a/packaging/generic-deb/debian/ecs.service
+++ b/packaging/generic-deb/debian/ecs.service
@@ -24,7 +24,9 @@ Restart=on-failure
 RestartPreventExitStatus=5
 RestartSec=10
 EnvironmentFile=-/etc/ecs/ecs.config
-ExecStart=/usr/local/bin/amazon-ecs-agent
+ExecStartPre=/usr/libexec/ipSetup.sh
+ExecStart=/usr/libexec/amazon-ecs-agent
+ExecStopPost=/usr/libexec/ipCleanup.sh
 
 [Install]
 WantedBy=multi-user.target

--- a/packaging/generic-deb/debian/ipCleanup.sh
+++ b/packaging/generic-deb/debian/ipCleanup.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -ex
+
+sysctl net.ipv4.conf.default.route_localnet
+sysctl -w net.ipv4.conf.all.route_localnet=0
+iptables -t nat -D PREROUTING -p tcp -d 169.254.170.2 --dport 80 -j DNAT --to-destination 127.0.0.1:51679
+
+if [ -n "${ECS_SKIP_LOCALHOST_TRAFFIC_FILTER}" ]
+then 
+    if [ "${ECS_SKIP_LOCALHOST_TRAFFIC_FILTER}" != "true" ]
+    then
+        iptables -t filter -D INPUT --dst 127.0.0.0/8 ! --src 127.0.0.0/8 -m conntrack ! --ctstate RELATED,ESTABLISHED,DNAT  -j DROP
+    fi
+else
+    iptables -t filter -D INPUT --dst 127.0.0.0/8 ! --src 127.0.0.0/8 -m conntrack ! --ctstate RELATED,ESTABLISHED,DNAT  -j DROP
+fi
+
+iptables -t filter -D INPUT -p tcp -i eth0 --dport 51678 -j DROP
+iptables -t nat -D OUTPUT -p tcp -d 169.254.170.2 --dport 80 -j REDIRECT --to-ports 51679

--- a/packaging/generic-deb/debian/ipSetup.sh
+++ b/packaging/generic-deb/debian/ipSetup.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -ex
+
+
+sysctl -w net.ipv4.conf.all.route_localnet=1
+sysctl -e -w net.ipv6.conf.docker0.accept_ra=0
+iptables -t nat -A PREROUTING -p tcp -d 169.254.170.2 --dport 80 -j DNAT --to-destination 127.0.0.1:51679
+
+if [ -n "${ECS_SKIP_LOCALHOST_TRAFFIC_FILTER}" ]
+then 
+    if [ "${ECS_SKIP_LOCALHOST_TRAFFIC_FILTER}" != "true" ]
+    then
+        iptables -t filter -I INPUT --dst 127.0.0.0/8 ! --src 127.0.0.0/8 -m conntrack ! --ctstate RELATED,ESTABLISHED,DNAT -j DROP
+    fi
+else
+    iptables -t filter -I INPUT --dst 127.0.0.0/8 ! --src 127.0.0.0/8 -m conntrack ! --ctstate RELATED,ESTABLISHED,DNAT -j DROP
+fi
+
+if [ -n "${ECS_ALLOW_OFFHOST_INTROSPECTION_ACCESS}" ]
+then
+    if [ "${ECS_ALLOW_OFFHOST_INTROSPECTION_ACCESS}" != "true" ] 
+    then
+        iptables -t filter -I INPUT -p tcp -i eth0 --dport 51678 -j DROP
+    fi
+else
+    iptables -t filter -I INPUT -p tcp -i eth0 --dport 51678 -j DROP
+fi
+
+iptables -t nat -A OUTPUT -p tcp -d 169.254.170.2 --dport 80 -j REDIRECT --to-ports 51679

--- a/packaging/generic-rpm/ecs.service
+++ b/packaging/generic-rpm/ecs.service
@@ -24,7 +24,9 @@ Restart=on-failure
 RestartPreventExitStatus=5
 RestartSec=10
 EnvironmentFile=-/etc/ecs/ecs.config
-ExecStart=/usr/local/bin/amazon-ecs-agent
+ExecStartPre=/usr/libexec/ipSetup.sh
+ExecStart=/usr/libexec/amazon-ecs-agent
+ExecStopPost=/usr/libexec/ipCleanup.sh
 
 [Install]
 WantedBy=multi-user.target

--- a/packaging/generic-rpm/ipCleanup.sh
+++ b/packaging/generic-rpm/ipCleanup.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -ex
+
+sysctl net.ipv4.conf.default.route_localnet
+sysctl -w net.ipv4.conf.all.route_localnet=0
+iptables -t nat -D PREROUTING -p tcp -d 169.254.170.2 --dport 80 -j DNAT --to-destination 127.0.0.1:51679
+
+if [ -n "${ECS_SKIP_LOCALHOST_TRAFFIC_FILTER}" ]
+then 
+    if [ "${ECS_SKIP_LOCALHOST_TRAFFIC_FILTER}" != "true" ]
+    then
+        iptables -t filter -D INPUT --dst 127.0.0.0/8 ! --src 127.0.0.0/8 -m conntrack ! --ctstate RELATED,ESTABLISHED,DNAT  -j DROP
+    fi
+else
+    iptables -t filter -D INPUT --dst 127.0.0.0/8 ! --src 127.0.0.0/8 -m conntrack ! --ctstate RELATED,ESTABLISHED,DNAT  -j DROP
+fi
+
+iptables -t filter -D INPUT -p tcp -i eth0 --dport 51678 -j DROP
+iptables -t nat -D OUTPUT -p tcp -d 169.254.170.2 --dport 80 -j REDIRECT --to-ports 51679

--- a/packaging/generic-rpm/ipSetup.sh
+++ b/packaging/generic-rpm/ipSetup.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -ex
+
+
+sysctl -w net.ipv4.conf.all.route_localnet=1
+sysctl -e -w net.ipv6.conf.docker0.accept_ra=0
+iptables -t nat -A PREROUTING -p tcp -d 169.254.170.2 --dport 80 -j DNAT --to-destination 127.0.0.1:51679
+
+if [ -n "${ECS_SKIP_LOCALHOST_TRAFFIC_FILTER}" ]
+then 
+    if [ "${ECS_SKIP_LOCALHOST_TRAFFIC_FILTER}" != "true" ]
+    then
+        iptables -t filter -I INPUT --dst 127.0.0.0/8 ! --src 127.0.0.0/8 -m conntrack ! --ctstate RELATED,ESTABLISHED,DNAT -j DROP
+    fi
+else
+    iptables -t filter -I INPUT --dst 127.0.0.0/8 ! --src 127.0.0.0/8 -m conntrack ! --ctstate RELATED,ESTABLISHED,DNAT -j DROP
+fi
+
+if [ -n "${ECS_ALLOW_OFFHOST_INTROSPECTION_ACCESS}" ]
+then
+    if [ "${ECS_ALLOW_OFFHOST_INTROSPECTION_ACCESS}" != "true" ] 
+    then
+        iptables -t filter -I INPUT -p tcp -i eth0 --dport 51678 -j DROP
+    fi
+else
+    iptables -t filter -I INPUT -p tcp -i eth0 --dport 51678 -j DROP
+fi
+
+iptables -t nat -A OUTPUT -p tcp -d 169.254.170.2 --dport 80 -j REDIRECT --to-ports 51679


### PR DESCRIPTION
### Summary
Adding the bash files for `ExecStartPre` and `ExecStopPost` portions of the ecs.service file. Also, changed the directory or executable files to where system-manages files are supposed to live. 

### Testing
The instance was able to receive tasks properly. Running `sudo iptables -t nat -L` and `sudo iptables -t filter -L` showed all of the rules being properly made and cleaned up as the service would start and stop. This was done when setting `ECS_SKIP_LOCALHOST_TRAFFIC_FILTER` and `ECS_ALLOW_OFFHOST_INTROSPECTION_ACCESS` to both true and false to make sure the rules were being skipped if supposed to.
The iptable scripts and service file were also tested on ubuntu and debian instances and behaved as expected.

### Description for the changelog
Add the iptable scripts and enable in service file.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
