### PR TITLE
Upgrading the amazon-vpc-cni plugins submodule

### DIFF
--- a/agent/ecscni/namespace_helper_windows.go
+++ b/agent/ecscni/namespace_helper_windows.go
@@ -100,7 +100,11 @@ func (nsHelper *helper) ConfigureTaskNamespaceRouting(ctx context.Context, taskE
 	}
 
 	// Invoke the generated commands inside the task namespace.
-	err := nsHelper.invokeCommandsInsideContainer(ctx, config.ContainerID, commands, " && ")
+	// On Windows 2004 and 20H2, there are a few stdout messages which leads to the failure of the tasks.
+	// By using &, we ensure that the commands are executed irrespectively. In case of error, the
+	// other commands can be executed (all commands are independent of each other) and the error would be
+	// reported to agent. Since the agent will kill the task, execution of other commands is immaterial.
+	err := nsHelper.invokeCommandsInsideContainer(ctx, config.ContainerID, commands, " & ")
 	if err != nil {
 		return errors.Wrapf(err, "failed to execute commands inside task namespace")
 	}

--- a/agent/ecscni/namespace_helper_windows_test.go
+++ b/agent/ecscni/namespace_helper_windows_test.go
@@ -96,7 +96,7 @@ func TestConfigureTaskNamespaceRouting(t *testing.T) {
 				cmd4 = fmt.Sprintf(windowsRouteAddCmdFormat, imdsEndpointIPAddress, taskEPName)
 			}
 			cmd5 := fmt.Sprintf(windowsRouteAddCmdFormat, "10.0.0.0/24", bridgeEpName)
-			finalCmd := strings.Join([]string{cmd1, cmd2, cmd3, cmd4, cmd5}, " && ")
+			finalCmd := strings.Join([]string{cmd1, cmd2, cmd3, cmd4, cmd5}, " & ")
 
 			gomock.InOrder(
 				dockerClient.EXPECT().CreateContainerExec(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(

--- a/agent/ecscni/plugin_test.go
+++ b/agent/ecscni/plugin_test.go
@@ -29,7 +29,7 @@ const (
 	// ECSCNIVersion, ECSCNIGitHash, VPCCNIGitHash needs to be updated every time CNI plugin is updated.
 	currentECSCNIVersion = "2020.09.0"
 	currentECSCNIGitHash = "55b2ae77ee0bf22321b14f2d4ebbcc04f77322e1"
-	currentVPCCNIGitHash = "941c5280e8a3329194cd78454454332610333822"
+	currentVPCCNIGitHash = "a8d6ad919d27fa15ec1744b51051b22d77b5c26c"
 )
 
 // Asserts that CNI plugin version matches the expected version


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR is for updating the `amazon-vpc-cni` plugins submodule to the latest commit. These changes address a bug on Windows Server 20H2 and Windows Server 2004 platforms.

One additional change is to use - `&` instead of `&&` during commands execution inside pause container. This ensures that all commands are executed and the erroneous ones are reported back.
This also addresses an issue on Windows Server 2004 and Windows Server 20H2.

### Implementation details
<!-- How are the changes implemented? -->
The git submodule hash was updated and the relevant files added.
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
A custom binary was tested on all supported Windows platforms.
New tests cover the changes: <!-- yes|no -->
No new changes are added.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Upgrading the amazon-vpc-cni submodule.
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
