### PR TITLE
Support docker daemon with minAPIVersion > 1.21

### DIFF
--- a/agent/dockerclient/versions.go
+++ b/agent/dockerclient/versions.go
@@ -32,6 +32,15 @@ const (
 	Version_1_30 DockerVersion = "1.30"
 	Version_1_31 DockerVersion = "1.31"
 	Version_1_32 DockerVersion = "1.32"
+	Version_1_33 DockerVersion = "1.33"
+	Version_1_34 DockerVersion = "1.34"
+	Version_1_35 DockerVersion = "1.35"
+	Version_1_36 DockerVersion = "1.36"
+	Version_1_37 DockerVersion = "1.37"
+	Version_1_38 DockerVersion = "1.38"
+	Version_1_39 DockerVersion = "1.39"
+	Version_1_40 DockerVersion = "1.40"
+	Version_1_41 DockerVersion = "1.41"
 )
 
 func (d DockerVersion) String() string {
@@ -58,5 +67,14 @@ func GetKnownAPIVersions() []DockerVersion {
 		Version_1_30,
 		Version_1_31,
 		Version_1_32,
+		Version_1_33,
+		Version_1_34,
+		Version_1_35,
+		Version_1_36,
+		Version_1_37,
+		Version_1_38,
+		Version_1_39,
+		Version_1_40,
+		Version_1_41,
 	}
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This PR addresses the issue that current ECS Agent is not able to start if Docker daemon minimum API version is higher than 1.21 (issue #2927)

Currently when starting Agent, we hard-code a check to make sure that docker API version 1.21 is supported. This won't work if Docker daemon has minimum API version higher than 1.21. The reason why we check for 1.21 is that, minimum docker engine version supported by Agent is 1.9.0, which supports maximum API version 1.21 (see https://docs.docker.com/engine/api/#api-version-matrix). Therefore, if we are able to find a supported API version == 1.21, that implies the docker version is at least 1.9.0. However, as long as there is any supported API version >= 1.21, we will get the same guarantee.

Another issue is that Agent specifies a default API version, and is currently not taking into account that this version might not be supported by Daemon (which has higher minimum). We should take whichever has higher API version in this case.

### Implementation details
- Updated `verifyRequiredDockerVersion` to return success as long as there is a supported Docker API version (by both Agent and Daemon) that is >= 1.21, instead of strictly looking for a supported version == 1.21
- Updated `GetDefaultClient()` to return API client with min(Agent default API version, Docker Daemon min API version) instead of let it solely depend on Agent default.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Updates Agent to support Docker daemon with minimum API version higher than 1.21. Fixes Agent issue #2927 

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
