### PR TITLE
Fix some flaky unit tests

### DIFF
--- a/agent/acs/handler/acs_handler_test.go
+++ b/agent/acs/handler/acs_handler_test.go
@@ -814,6 +814,8 @@ func TestHandlerDoesntLeakGoroutines(t *testing.T) {
 			select {
 			case <-requests:
 			case <-errs:
+			case <-ctx.Done():
+				return
 			}
 		}
 	}()
@@ -862,7 +864,7 @@ func TestHandlerDoesntLeakGoroutines(t *testing.T) {
 
 	// The number of goroutines finishing in the MockACSServer will affect
 	// the result unless we wait here.
-	time.Sleep(1 * time.Second)
+	time.Sleep(2 * time.Second)
 	afterGoroutines := runtime.NumGoroutine()
 
 	t.Logf("Goroutines after 1 and after %v acs messages: %v and %v", timesConnected, beforeGoroutines, afterGoroutines)

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -861,7 +861,7 @@ func TestTaskTransitionWhenStopContainerReturnsUnretriableError(t *testing.T) {
 			// event.
 			client.EXPECT().StopContainer(gomock.Any(), containerID, gomock.Any()).Return(dockerapi.DockerContainerMetadata{
 				Error: dockerapi.CannotStopContainerError{dockerapi.NoSuchContainerError{}},
-			}).MaxTimes(1),
+			}).MinTimes(1),
 			client.EXPECT().SystemPing(gomock.Any(), gomock.Any()).
 				Return(dockerapi.PingResponse{}).
 				Times(1),
@@ -947,6 +947,7 @@ func TestGetTaskByArn(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockTime.EXPECT().Now().Return(time.Now()).AnyTimes()
+	mockTime.EXPECT().After(gomock.Any()).AnyTimes()
 	eventStream := make(chan dockerapi.DockerContainerChangeEvent)
 	client.EXPECT().ContainerEvents(gomock.Any()).Return(eventStream, nil)
 	imageManager.EXPECT().AddAllImageStates(gomock.Any()).AnyTimes()
@@ -2351,6 +2352,7 @@ func TestSynchronizeENIAttachment(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockTime.EXPECT().Now().AnyTimes()
+	mockTime.EXPECT().After(gomock.Any()).AnyTimes()
 	client.EXPECT().Version(gomock.Any(), gomock.Any()).MaxTimes(1)
 	client.EXPECT().ContainerEvents(gomock.Any()).MaxTimes(1)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
A few UTs are flaky because some go routines invoke `time.After` after the mock controller has finished. 

### Implementation details
<!-- How are the changes implemented? -->
Add `mockTime.After().AnyTimes()`. For now this will fix the flakiness, but ideally it would be better to avoid spawning go routines in the UT. Not doing that now since that would imply a considerable refactor.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
