### PR TITLE
Sub-path support for SSM ARNs being used for credentialspec configuration

### DIFF
--- a/agent/taskresource/credentialspec/credentialspec_windows.go
+++ b/agent/taskresource/credentialspec/credentialspec_windows.go
@@ -445,8 +445,8 @@ func (cs *CredentialSpecResource) handleSSMCredentialspecFile(originalCredential
 
 	ssmClient := cs.ssmClientCreator.NewSSMClient(cs.region, iamCredentials)
 
-	ssmParam := filepath.Base(parsedARN.Resource)
-	ssmParams := []string{ssmParam}
+	ssmParam := strings.SplitAfterN(parsedARN.Resource, "parameter", 2) 
+	ssmParams := []string{ssmParam[1]}
 
 	ssmParamMap, err := ssm.GetParametersFromSSM(ssmParams, ssmClient)
 	if err != nil {
@@ -460,7 +460,8 @@ func (cs *CredentialSpecResource) handleSSMCredentialspecFile(originalCredential
 	if length < 2 {
 		return errors.New("Failed to retrieve taskId from taskArn.")
 	}
-	localCredSpecFilePath := fmt.Sprintf("%s\\ssm_%v_%s", cs.credentialSpecResourceLocation, taskArnSplit[length-1], ssmParam)
+	ssmParamSanitizedFileName := strings.Replace(ssmParam[1], "/", "_")
+	localCredSpecFilePath := fmt.Sprintf("%s\\ssm_%v%s", cs.credentialSpecResourceLocation, taskArnSplit[length-1], ssmParamSanitizedFileName)
 	err = cs.writeSSMFile(ssmParamData, localCredSpecFilePath)
 	if err != nil {
 		cs.setTerminalReason(err.Error())

--- a/agent/taskresource/credentialspec/credentialspec_windows_test.go
+++ b/agent/taskresource/credentialspec/credentialspec_windows_test.go
@@ -209,9 +209,9 @@ func TestHandleSSMCredentialspecFile(t *testing.T) {
 		CredentialsID: "test-cred-id",
 	}
 
-	credentialSpecSSMARN := "arn:aws:ssm:us-west-2:123456789012:parameter/test"
-	ssmCredentialSpec := "credentialspec:arn:aws:ssm:us-west-2:123456789012:parameter/test"
-	expectedFileCredentialSpec := "credentialspec=file://ssm_12345-678901234-56789_test"
+	credentialSpecSSMARN := "arn:aws:ssm:us-west-2:123456789012:parameter/subpath/test"
+	ssmCredentialSpec := "credentialspec:arn:aws:ssm:us-west-2:123456789012:parameter/subpath/test"
+	expectedFileCredentialSpec := "credentialspec=file://ssm_12345-678901234-56789_subpath_test"
 
 	requiredCredSpec := []string{ssmCredentialSpec}
 


### PR DESCRIPTION
### Summary
In reference to https://github.com/aws/amazon-ecs-agent/issues/2943, This PR aims to enable support for SSM parameter ARNs that have parameter names that include more than one sub-path.

### Implementation details
This is achieved by splitting the parsed ARNs resource string to extract the full path of the SSM parameter, rather than passing it through `filepath.Base()`. This is needed because `filepath.Base()` will take a parameter called `/test/gmsatest` and return `gmsatest`. That value is then passed to SSM and will return an exception because that's not the actual path of the SSM parameter.

It's also worth mentioning that this now makes the file name include the whole parameter path, which in theory, could possibly be longer than windows file name limit (I'm not sure on either windows limit or ssm parameter path limit). If we are concerned with that, we can just set `ssmParamSanitizedFileName` to the original value of `filepath.Base(parsedARN.Resource)` as the task ID is part of the name, so we shouldn't have to worry about file uniqueness.

### Testing
I was actually having issues running either `make test` or `make test-in-docker` so I cant actually run these tests locally. I would appreciate any assistance you can provide as to how to get that working so I can run the test I modified.

New tests cover the changes: yes (they should)

### Description for the changelog
- enables support for SSM parameter ARNs that contain multi-level parameter paths

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
