### PR TITLE
Agent changes for mounted volume migration path

### DIFF
--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -643,7 +643,7 @@ func (engine *DockerTaskEngine) deleteTask(task *apitask.Task) {
 		if tID, err := task.GetID(); err != nil {
 			seelog.Warnf("Task Engine[%s]: error getting task ID for ExecAgent logs cleanup: %v", task.Arn, err)
 		} else {
-			if err := removeAll(filepath.Join(execcmd.ECSAgentExecLogDir, tID)); err != nil {
+			if err := removeAll(filepath.Join(execcmd.HostLogDir, tID)); err != nil {
 				seelog.Warnf("Task Engine[%s]: unable to remove ExecAgent host logs for task: %v", task.Arn, err)
 			}
 		}

--- a/agent/engine/engine_sudo_linux_integ_test.go
+++ b/agent/engine/engine_sudo_linux_integ_test.go
@@ -421,7 +421,7 @@ func TestExecCommandAgent(t *testing.T) {
 	defer done()
 
 	testTask := createTestExecCommandAgentTask(testTaskId, testContainerName, sleepFor)
-	execAgentLogPath := filepath.Join("/log/exec", testTaskId)
+	execAgentLogPath := filepath.Join("/var/log/ecs/exec", testTaskId)
 	err = os.MkdirAll(execAgentLogPath, 0644)
 	require.NoError(t, err, "error creating execAgent log file")
 	_, err = os.Stat(execAgentLogPath)
@@ -512,7 +512,7 @@ func TestManagedAgentEvent(t *testing.T) {
 			defer done()
 
 			testTask := createTestExecCommandAgentTask(testTaskId, testContainerName, time.Minute*tc.ManagedAgentLifetime)
-			execAgentLogPath := filepath.Join("/log/exec", testTaskId)
+			execAgentLogPath := filepath.Join("/var/log/ecs/exec", testTaskId)
 			err = os.MkdirAll(execAgentLogPath, 0644)
 			require.NoError(t, err, "error creating execAgent log file")
 			_, err = os.Stat(execAgentLogPath)

--- a/agent/engine/execcmd/manager_init_task_linux.go
+++ b/agent/engine/execcmd/manager_init_task_linux.go
@@ -51,9 +51,8 @@ const (
 	SSMAgentWorkerBinName = "ssm-agent-worker"
 	SessionWorkerBinName  = "ssm-session-worker"
 
-	HostLogDir         = "/var/log/ecs/exec"
-	ContainerLogDir    = "/var/log/amazon/ssm"
-	ECSAgentExecLogDir = "/log/exec"
+	HostLogDir      = "/var/log/ecs/exec"
+	ContainerLogDir = "/var/log/amazon/ssm"
 
 	HostCertFile            = "/var/lib/ecs/deps/execute-command/certs/tls-ca-bundle.pem"
 	ContainerCertFileSuffix = "certs/amazon-ssm-agent.crt"

--- a/agent/engine/execcmd/manager_unsupported.go
+++ b/agent/engine/execcmd/manager_unsupported.go
@@ -24,9 +24,9 @@ import (
 )
 
 const (
-	// ECSAgentExecLogDir here is used used while cleaning up exec logs when task exits.
+	// HostLogDir here is used used while cleaning up exec logs when task exits.
 	// When this path is empty, nothing is cleaned up for unsupported platforms.
-	ECSAgentExecLogDir = ""
+	HostLogDir = ""
 )
 
 // Note: exec cmd agent is a linux-only feature, thus implemented here as a no-op.

--- a/agent/engine/task_manager_unix_test.go
+++ b/agent/engine/task_manager_unix_test.go
@@ -430,7 +430,7 @@ func TestCleanupExecEnabledTask(t *testing.T) {
 	}
 	tID, _ := mTask.Task.GetID()
 	removeAll = func(path string) error {
-		assert.Equal(t, fmt.Sprintf("/log/exec/%s", tID), path)
+		assert.Equal(t, fmt.Sprintf("/var/log/ecs/exec/%s", tID), path)
 		return nil
 	}
 	defer func() {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This pull request changes the directory in which ECSAgentExecLogDir is the same path as HostLogDir since agent will be running on the host as a process
### Implementation details
<!-- How are the changes implemented? -->
ECSAgentExecLogDir is redefined in manager_init_task_linux.go and the path is changed in the TestCleanupExecEnabledTask test in task_manager_unix_test.go
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
it was tested by running make test and making sure everything passed properly
New tests cover the changes: <!-- yes|no -->
yes
### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
