### PR TITLE
Add basic GraphQL TMDE types and resolvers

### DIFF
--- a/agent/handlers/gql/schema.go
+++ b/agent/handlers/gql/schema.go
@@ -14,12 +14,22 @@
 package gql
 
 import (
+	"time"
+
 	"github.com/aws/amazon-ecs-agent/agent/api"
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/handlers/utils"
+	v2 "github.com/aws/amazon-ecs-agent/agent/handlers/v2"
 	v3 "github.com/aws/amazon-ecs-agent/agent/handlers/v3"
+
 	"github.com/aws/amazon-ecs-agent/agent/stats"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/graphql-go/graphql"
+	"github.com/graphql-go/graphql/language/ast"
+	"github.com/graphql-go/graphql/language/kinds"
+	"github.com/pkg/errors"
 )
 
 var ContainerMetadataPath = "/graphql/" + utils.ConstructMuxVar(v3.V3EndpointIDMuxName, utils.AnythingButSlashRegEx)
@@ -32,11 +42,147 @@ func CreateSchema(
 	availabilityZone string,
 	containerInstanceArn string) (graphql.Schema, error) {
 
-	// Create GraphQL Schema with 'Container' Query, which resolves to the dockerID
+	var containerType = graphql.NewObject(graphql.ObjectConfig{
+		Name: "Container",
+		Fields: graphql.Fields{
+			"DockerId": &graphql.Field{
+				Type: graphql.String,
+			},
+			"Name": &graphql.Field{
+				Type:    graphql.String,
+				Resolve: containerNameResolver,
+			},
+			"DockerName": &graphql.Field{
+				Type: graphql.String,
+			},
+			"Image": &graphql.Field{
+				Type:    graphql.String,
+				Resolve: containerImageResolver,
+			},
+			"ImageID": &graphql.Field{
+				Type:    graphql.String,
+				Resolve: containerImageIDResolver,
+			},
+			"Labels": &graphql.Field{
+				Type:    JSON,
+				Resolve: containerLabelsResolver,
+			},
+			"DesiredStatus": &graphql.Field{
+				Type:    graphql.String,
+				Resolve: containerDesiredStatusResolver,
+			},
+			"KnownStatus": &graphql.Field{
+				Type:    graphql.String,
+				Resolve: contaienrKnownStatusResolver,
+			},
+			"Limits": &graphql.Field{
+				Type:    JSON,
+				Resolve: containerLimitsResolver,
+			},
+			"ExitCode": &graphql.Field{
+				Type:    graphql.Int,
+				Resolve: exitCodeResolver,
+			},
+			"CreatedAt": &graphql.Field{
+				Type:    graphql.String,
+				Resolve: containerCreatedAtResolver,
+			},
+			"StartedAt": &graphql.Field{
+				Type:    graphql.String,
+				Resolve: containerStartedAtResolver,
+			},
+			"FinishedAt": &graphql.Field{
+				Type:    graphql.String,
+				Resolve: containerFinishedAtResolver,
+			},
+			"Type": &graphql.Field{
+				Type:    graphql.String,
+				Resolve: containerTypeResolver,
+			},
+			"LogDriver": &graphql.Field{
+				Type:    graphql.String,
+				Resolve: logDriverResolver,
+			},
+			"LogOptions": &graphql.Field{
+				Type:    JSON,
+				Resolve: logOptionsResolver,
+			},
+			"ContainerARN": &graphql.Field{
+				Type:    graphql.String,
+				Resolve: containerARNResolver,
+			},
+		},
+	})
+
+	var taskType = graphql.NewObject(graphql.ObjectConfig{
+		Name: "Task",
+		Fields: graphql.Fields{
+			"Cluster": &graphql.Field{
+				Type: graphql.String,
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					return cluster, nil
+				},
+			},
+			"TaskARN": &graphql.Field{
+				Type:    graphql.String,
+				Resolve: taskARNResolver,
+			},
+			"Family": &graphql.Field{
+				Type: graphql.String,
+			},
+			"Revision": &graphql.Field{
+				Type:    graphql.String,
+				Resolve: taskRevisionResolver,
+			},
+			"DesiredStatus": &graphql.Field{
+				Type:    graphql.String,
+				Resolve: taskDesiredStatusResolver,
+			},
+			"KnownStatus": &graphql.Field{
+				Type:    graphql.String,
+				Resolve: taskKnownStatusResolver,
+			},
+			"Limits": &graphql.Field{
+				Type:    JSON,
+				Resolve: taskLimitsResolver,
+			},
+			"PullStartedAt": &graphql.Field{
+				Type:    graphql.String,
+				Resolve: taskPullStartedResolver,
+			},
+			"PullStoppedAt": &graphql.Field{
+				Type:    graphql.String,
+				Resolve: taskPullStoppedResolver,
+			},
+			"ExecutionStoppedAt": &graphql.Field{
+				Type:    graphql.String,
+				Resolve: taskExecutionStoppedResolver,
+			},
+			"AvailabilityZone": &graphql.Field{
+				Type: graphql.String,
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					return availabilityZone, nil
+				},
+			},
+			"LaunchType": &graphql.Field{
+				Type: graphql.String,
+			},
+			"Containers": &graphql.Field{
+				Type:    graphql.NewList(containerType),
+				Resolve: taskContainersResolver(state),
+			},
+		},
+	})
+
+	// Create GraphQL Schema
 	fields := graphql.Fields{
 		"Container": &graphql.Field{
-			Type:    graphql.String,
-			Resolve: dockerIDResolver,
+			Type:    containerType,
+			Resolve: containerResolver,
+		},
+		"Task": &graphql.Field{
+			Type:    taskType,
+			Resolve: taskResolver,
 		},
 	}
 	rootQuery := graphql.ObjectConfig{Name: "RootQuery", Fields: fields}
@@ -45,11 +191,260 @@ func CreateSchema(
 	return graphql.NewSchema(schemaConfig)
 }
 
-func dockerIDResolver(p graphql.ResolveParams) (interface{}, error) {
-	dockerID, ok := p.Context.Value(DockerID).(string)
+func containerResolver(p graphql.ResolveParams) (interface{}, error) {
+	dockerContainer, ok := p.Context.Value(Container).(*apicontainer.DockerContainer)
+	if !ok {
+		return nil, errors.Errorf("Could not cast to container")
+	}
+
+	return dockerContainer, nil
+}
+
+func containerNameResolver(p graphql.ResolveParams) (interface{}, error) {
+	dockerContainer, ok := p.Context.Value(Container).(*apicontainer.DockerContainer)
 	if !ok {
 		return "", nil
 	}
-
-	return dockerID, nil
+	return dockerContainer.Container.Name, nil
 }
+
+func containerImageResolver(p graphql.ResolveParams) (interface{}, error) {
+	dockerContainer, ok := p.Source.(*apicontainer.DockerContainer)
+	if !ok {
+		return "", nil
+	}
+	return dockerContainer.Container.Image, nil
+}
+
+func containerImageIDResolver(p graphql.ResolveParams) (interface{}, error) {
+	dockerContainer, ok := p.Source.(*apicontainer.DockerContainer)
+	if !ok {
+		return "", nil
+	}
+	return dockerContainer.Container.ImageID, nil
+}
+
+func containerLabelsResolver(p graphql.ResolveParams) (interface{}, error) {
+	if dockerContainer, ok := p.Source.(*apicontainer.DockerContainer); ok {
+		return dockerContainer.Container.GetLabels(), nil
+	}
+	return nil, nil
+}
+
+func containerDesiredStatusResolver(p graphql.ResolveParams) (interface{}, error) {
+	if dockerContainer, ok := p.Source.(*apicontainer.DockerContainer); ok {
+		return dockerContainer.Container.GetDesiredStatus().String(), nil
+	}
+	return nil, nil
+}
+
+func contaienrKnownStatusResolver(p graphql.ResolveParams) (interface{}, error) {
+	if dockerContainer, ok := p.Source.(*apicontainer.DockerContainer); ok {
+		return dockerContainer.Container.GetKnownStatus().String(), nil
+	}
+	return nil, nil
+}
+
+func containerLimitsResolver(p graphql.ResolveParams) (interface{}, error) {
+	if dockerContainer, ok := p.Source.(*apicontainer.DockerContainer); ok {
+		container := dockerContainer.Container
+		containerCPU := v2.GetContainerCPULimit(container)
+		return v2.LimitsResponse{
+			CPU:    containerCPU,
+			Memory: aws.Int64(int64(container.Memory)),
+		}, nil
+	}
+	return nil, nil
+}
+
+// Container Field Resolvers
+func exitCodeResolver(p graphql.ResolveParams) (interface{}, error) {
+	if dockerContainer, ok := p.Source.(*apicontainer.DockerContainer); ok {
+		return dockerContainer.Container.GetKnownExitCode(), nil
+	}
+	return nil, nil
+}
+
+func containerCreatedAtResolver(p graphql.ResolveParams) (interface{}, error) {
+	if dockerContainer, ok := p.Source.(*apicontainer.DockerContainer); ok {
+		return dockerContainer.Container.GetCreatedAt().UTC().Format(time.RFC3339Nano), nil
+	}
+	return nil, nil
+}
+
+func containerStartedAtResolver(p graphql.ResolveParams) (interface{}, error) {
+	if dockerContainer, ok := p.Source.(*apicontainer.DockerContainer); ok {
+		return dockerContainer.Container.GetStartedAt().UTC().Format(time.RFC3339Nano), nil
+	}
+	return nil, nil
+}
+
+func containerFinishedAtResolver(p graphql.ResolveParams) (interface{}, error) {
+	if dockerContainer, ok := p.Source.(*apicontainer.DockerContainer); ok {
+		return dockerContainer.Container.GetFinishedAt().UTC().Format(time.RFC3339Nano), nil
+	}
+	return nil, nil
+}
+
+func containerTypeResolver(p graphql.ResolveParams) (interface{}, error) {
+	if dockerContainer, ok := p.Source.(*apicontainer.DockerContainer); ok {
+		return dockerContainer.Container.Type.String(), nil
+	}
+	return nil, nil
+}
+
+func logDriverResolver(p graphql.ResolveParams) (interface{}, error) {
+	if dockerContainer, ok := p.Source.(*apicontainer.DockerContainer); ok {
+		return dockerContainer.Container.GetLogDriver(), nil
+	}
+	return nil, nil
+}
+
+func logOptionsResolver(p graphql.ResolveParams) (interface{}, error) {
+	if dockerContainer, ok := p.Source.(*apicontainer.DockerContainer); ok {
+		return dockerContainer.Container.GetLogOptions(), nil
+	}
+	return nil, nil
+}
+
+func containerARNResolver(p graphql.ResolveParams) (interface{}, error) {
+	if dockerContainer, ok := p.Source.(*apicontainer.DockerContainer); ok {
+		return dockerContainer.Container.ContainerArn, nil
+	}
+	return nil, nil
+}
+
+// Task Field Resolvers
+func taskResolver(p graphql.ResolveParams) (interface{}, error) {
+	task, ok := p.Context.Value(Task).(*apitask.Task)
+	if !ok {
+		return nil, errors.New("Could not cast to task")
+	}
+
+	return task, nil
+}
+func taskARNResolver(p graphql.ResolveParams) (interface{}, error) {
+	if task, ok := p.Source.(*apitask.Task); ok {
+		return task.Arn, nil
+	}
+	return nil, nil
+}
+
+func taskRevisionResolver(p graphql.ResolveParams) (interface{}, error) {
+	if task, ok := p.Source.(*apitask.Task); ok {
+		return task.Version, nil
+	}
+	return nil, nil
+}
+
+func taskDesiredStatusResolver(p graphql.ResolveParams) (interface{}, error) {
+	if task, ok := p.Source.(*apitask.Task); ok {
+		return task.GetDesiredStatus().String(), nil
+	}
+	return nil, nil
+}
+
+func taskKnownStatusResolver(p graphql.ResolveParams) (interface{}, error) {
+	if task, ok := p.Source.(*apitask.Task); ok {
+		return task.GetKnownStatus().String(), nil
+	}
+	return nil, nil
+}
+
+func taskLimitsResolver(p graphql.ResolveParams) (interface{}, error) {
+	if task, ok := p.Source.(*apitask.Task); ok {
+		taskCPU := task.CPU
+		taskMemory := task.Memory
+		if taskCPU != 0 || taskMemory != 0 {
+			taskLimits := v2.GetTaskLimits(taskCPU, taskMemory)
+			return taskLimits, nil
+		}
+		return nil, nil
+	}
+	return nil, nil
+}
+
+func taskPullStartedResolver(p graphql.ResolveParams) (interface{}, error) {
+	if task, ok := p.Source.(*apitask.Task); ok {
+		return aws.Time(task.GetPullStartedAt().UTC()).Format(time.RFC3339Nano), nil
+	}
+	return nil, nil
+}
+
+func taskPullStoppedResolver(p graphql.ResolveParams) (interface{}, error) {
+	if task, ok := p.Source.(*apitask.Task); ok {
+		return aws.Time(task.GetPullStoppedAt().UTC()).Format(time.RFC3339Nano), nil
+	}
+	return nil, nil
+}
+
+func taskExecutionStoppedResolver(p graphql.ResolveParams) (interface{}, error) {
+	if task, ok := p.Source.(*apitask.Task); ok {
+		return aws.Time(task.GetExecutionStoppedAt().UTC()).Format(time.RFC3339Nano), nil
+	}
+	return nil, nil
+}
+
+func taskContainersResolver(state dockerstate.TaskEngineState) func(p graphql.ResolveParams) (interface{}, error) {
+	return func(p graphql.ResolveParams) (interface{}, error) {
+		if task, ok := p.Source.(*apitask.Task); ok {
+			containerNameToDockerContainer, ok := state.ContainerMapByArn(task.Arn)
+			if !ok {
+				return "", errors.Errorf("Unable to get container name mapping for task %v",
+					task.Arn)
+			}
+			resp := []*apicontainer.DockerContainer{}
+			for _, dockerContainer := range containerNameToDockerContainer {
+				resp = append(resp, dockerContainer)
+			}
+			return resp, nil
+		}
+		return nil, nil
+	}
+}
+
+// Adapted from https://github.com/graphql-go/graphql/issues/298
+// Creates Custom JSON Scalar Type
+func parseLiteral(astValue ast.Value) interface{} {
+	kind := astValue.GetKind()
+
+	switch kind {
+	case kinds.StringValue:
+		return astValue.GetValue()
+	case kinds.BooleanValue:
+		return astValue.GetValue()
+	case kinds.IntValue:
+		return astValue.GetValue()
+	case kinds.FloatValue:
+		return astValue.GetValue()
+	case kinds.ObjectValue:
+		obj := make(map[string]interface{})
+		for _, v := range astValue.GetValue().([]*ast.ObjectField) {
+			obj[v.Name.Value] = parseLiteral(v.Value)
+		}
+		return obj
+	case kinds.ListValue:
+		list := make([]interface{}, 0)
+		for _, v := range astValue.GetValue().([]ast.Value) {
+			list = append(list, parseLiteral(v))
+		}
+		return list
+	default:
+		return nil
+	}
+}
+
+// Addapted From https://github.com/graphql-go/graphql/issues/298
+var JSON = graphql.NewScalar(
+	graphql.ScalarConfig{
+		Name:        "JSON",
+		Description: "The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf)",
+		Serialize: func(value interface{}) interface{} {
+			return value
+		},
+		ParseValue: func(value interface{}) interface{} {
+			return value
+		},
+		ParseLiteral: parseLiteral,
+	},
+)

--- a/agent/handlers/gql/schema_test.go
+++ b/agent/handlers/gql/schema_test.go
@@ -1,0 +1,319 @@
+package gql
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
+	apieni "github.com/aws/amazon-ecs-agent/agent/api/eni"
+	mock_api "github.com/aws/amazon-ecs-agent/agent/api/mocks"
+	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
+	apitaskstatus "github.com/aws/amazon-ecs-agent/agent/api/task/status"
+	mock_dockerstate "github.com/aws/amazon-ecs-agent/agent/engine/dockerstate/mocks"
+	v2 "github.com/aws/amazon-ecs-agent/agent/handlers/v2"
+	v4 "github.com/aws/amazon-ecs-agent/agent/handlers/v4"
+	mock_stats "github.com/aws/amazon-ecs-agent/agent/stats/mock"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/docker/docker/api/types"
+	"github.com/golang/mock/gomock"
+	"github.com/graphql-go/graphql"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	clusterName              = "default"
+	taskARN                  = "t1"
+	cluster                  = "default"
+	family                   = "sleep"
+	version                  = "1"
+	containerID              = "cid"
+	containerName            = "sleepy"
+	imageName                = "busybox"
+	imageID                  = "bUsYbOx"
+	containerType            = "NORMAL"
+	cpu                      = 1024
+	memory                   = 512
+	statusRunning            = "RUNNING"
+	eniIPv4Address           = "192.168.0.5"
+	ipv4SubnetCIDRBlock      = "192.168.0.0/24"
+	eniIPv6Address           = "2600:1f18:619e:f900:8467:78b2:81c4:207d"
+	ipv6SubnetCIDRBlock      = "2600:1f18:619e:f900::/64"
+	subnetGatewayIPV4Address = "192.168.0.1/24"
+	volName                  = "volume1"
+	volSource                = "/var/lib/volume1"
+	volDestination           = "/volume"
+	availabilityZone         = "us-west-2b"
+	containerInstanceArn     = "containerInstance-test"
+)
+
+type gqlTask struct {
+	*v4.TaskResponse
+}
+type gqlContainer struct {
+	*v4.ContainerResponse
+}
+
+type gqlData struct {
+	Container *gqlContainer `json:"Container,omitempty"`
+	Task      *gqlTask      `json:"Task,omitempty"`
+}
+
+type gqlResponse struct {
+	Data   *gqlData `json:"data"`
+	Errors string   `json:"errors,omitempty"`
+}
+
+var (
+	labels = map[string]string{
+		"foo": "bar",
+	}
+	now             = time.Now().UTC()
+	exitCode        = 0
+	containerFields = v4.ContainerResponse{
+		ContainerResponse: &v2.ContainerResponse{
+			ID:            containerID,
+			Name:          containerName,
+			DockerName:    containerName,
+			Image:         imageName,
+			ImageID:       imageID,
+			DesiredStatus: statusRunning,
+			KnownStatus:   statusRunning,
+			ContainerARN:  "arn:aws:ecs:ap-northnorth-1:NNN:container/NNNNNNNN-aaaa-4444-bbbb-00000000000",
+			Limits: v2.LimitsResponse{
+				CPU:    aws.Float64(cpu),
+				Memory: aws.Int64(memory),
+			},
+			CreatedAt:  &now,
+			StartedAt:  &now,
+			FinishedAt: &now,
+			ExitCode:   &exitCode,
+			Type:       containerType,
+			LogDriver:  "",
+			LogOptions: map[string]string{},
+			Labels:     labels,
+		},
+	}
+	expectedContainerResponse = gqlResponse{
+		Data: &gqlData{
+			Container: &gqlContainer{
+				&containerFields,
+			},
+		},
+	}
+	expectedTaskResponse = gqlResponse{
+		Data: &gqlData{
+			Task: &gqlTask{
+				&v4.TaskResponse{
+					TaskResponse: &v2.TaskResponse{
+						Cluster:       clusterName,
+						TaskARN:       taskARN,
+						Family:        family,
+						Revision:      version,
+						DesiredStatus: statusRunning,
+						KnownStatus:   statusRunning,
+						Limits: &v2.LimitsResponse{
+							CPU:    aws.Float64(cpu),
+							Memory: aws.Int64(memory),
+						},
+						PullStartedAt:      aws.Time(now.UTC()),
+						PullStoppedAt:      aws.Time(now.UTC()),
+						ExecutionStoppedAt: aws.Time(now.UTC()),
+						AvailabilityZone:   availabilityZone,
+						LaunchType:         "EC2",
+					},
+					Containers: []v4.ContainerResponse{containerFields},
+				},
+			},
+		},
+	}
+	expectedFailedContainerTaskResponse = gqlResponse{
+		Errors: "Unable to get container name mapping for task " + taskARN,
+	}
+	expectedFailedContainerCTXResponse = gqlResponse{
+		Errors: "Could not cast to container",
+	}
+	expectedFailedTaskCTXResponse = gqlResponse{
+		Errors: "Could not cast to task",
+	}
+	containerQueryGQL = "{Container{DockerId,Name,DockerName,KnownStatus,DesiredStatus,CreatedAt,StartedAt,FinishedAt,ExitCode,Image,ImageID,Labels,Type,LogDriver,LogOptions,Limits,ContainerARN}}"
+	taskQueryGQL      = "{Task{Cluster,TaskARN,Family,Revision,DesiredStatus,KnownStatus,Limits,PullStartedAt,PullStoppedAt,ExecutionStoppedAt,AvailabilityZone,LaunchType,Containers{DockerId,Name,DockerName,KnownStatus,DesiredStatus,CreatedAt,StartedAt,FinishedAt,ExitCode,Image,ImageID,Labels,Type,LogDriver,LogOptions,Limits,ContainerARN}}}"
+)
+
+func TestCreateSchema(t *testing.T) {
+	task := &apitask.Task{
+		Arn:                 taskARN,
+		Family:              family,
+		Version:             version,
+		DesiredStatusUnsafe: apitaskstatus.TaskRunning,
+		KnownStatusUnsafe:   apitaskstatus.TaskRunning,
+		ENIs: []*apieni.ENI{
+			{
+				IPV4Addresses: []*apieni.ENIIPV4Address{
+					{
+						Address: eniIPv4Address,
+					},
+				},
+				IPV6Addresses: []*apieni.ENIIPV6Address{
+					{
+						Address: eniIPv6Address,
+					},
+				},
+				SubnetGatewayIPV4Address: subnetGatewayIPV4Address,
+			},
+		},
+		CPU:                      cpu,
+		Memory:                   memory,
+		PullStartedAtUnsafe:      now,
+		PullStoppedAtUnsafe:      now,
+		ExecutionStoppedAtUnsafe: now,
+		LaunchType:               "EC2",
+	}
+	container := &apicontainer.Container{
+		Name:                containerName,
+		Image:               imageName,
+		ImageID:             imageID,
+		DesiredStatusUnsafe: apicontainerstatus.ContainerRunning,
+		KnownStatusUnsafe:   apicontainerstatus.ContainerRunning,
+		CPU:                 cpu,
+		Memory:              memory,
+		Type:                apicontainer.ContainerNormal,
+		ContainerArn:        "arn:aws:ecs:ap-northnorth-1:NNN:container/NNNNNNNN-aaaa-4444-bbbb-00000000000",
+		Ports: []apicontainer.PortBinding{
+			{
+				ContainerPort: 80,
+				Protocol:      apicontainer.TransportProtocolTCP,
+			},
+		},
+		VolumesUnsafe: []types.MountPoint{
+			{
+				Name:        volName,
+				Source:      volSource,
+				Destination: volDestination,
+			},
+		},
+	}
+	container.SetCreatedAt(now)
+	container.SetStartedAt(now)
+	container.SetFinishedAt(now)
+	container.SetKnownExitCode(&exitCode)
+	labels := map[string]string{
+		"foo": "bar",
+	}
+	container.SetLabels(labels)
+	dockerContainer := &apicontainer.DockerContainer{
+		DockerID:   containerID,
+		DockerName: containerName,
+		Container:  container,
+	}
+	containerNameToDockerContainer := map[string]*apicontainer.DockerContainer{
+		taskARN: dockerContainer,
+	}
+
+	testCases := []struct {
+		name               string
+		query              string
+		taskContainerError bool
+		containerCTXError  bool
+		taskCTXError       bool
+		expectedResponse   gqlResponse
+	}{
+		{
+			name:               "Conainer Query",
+			query:              containerQueryGQL,
+			taskContainerError: false,
+			containerCTXError:  false,
+			taskCTXError:       false,
+			expectedResponse:   expectedContainerResponse,
+		},
+		{
+			name:               "Task Query",
+			query:              taskQueryGQL,
+			taskContainerError: false,
+			containerCTXError:  false,
+			taskCTXError:       false,
+			expectedResponse:   expectedTaskResponse,
+		},
+		{
+			name:               "No Container Task Query",
+			query:              taskQueryGQL,
+			taskContainerError: true,
+			containerCTXError:  false,
+			taskCTXError:       false,
+			expectedResponse:   expectedFailedContainerTaskResponse,
+		},
+		{
+			name:               "Get Container ctx Error",
+			query:              containerQueryGQL,
+			taskContainerError: false,
+			containerCTXError:  true,
+			taskCTXError:       false,
+			expectedResponse:   expectedFailedContainerCTXResponse,
+		},
+		{
+			name:               "Get Task ctx Error",
+			query:              taskQueryGQL,
+			taskContainerError: false,
+			containerCTXError:  false,
+			taskCTXError:       true,
+			expectedResponse:   expectedFailedTaskCTXResponse,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			state := mock_dockerstate.NewMockTaskEngineState(ctrl)
+			ecsClient := mock_api.NewMockECSClient(ctrl)
+			statsEngine := mock_stats.NewMockEngine(ctrl)
+
+			schema, err := CreateSchema(state, ecsClient, statsEngine, cluster, availabilityZone, containerInstanceArn)
+			assert.NoError(t, err)
+			var ctx context.Context
+			if tc.containerCTXError {
+				ctx = context.WithValue(context.Background(), Container, "container")
+			} else if tc.taskCTXError {
+				ctx = context.WithValue(context.Background(), Task, "task")
+			} else {
+				ctx = context.WithValue(context.Background(), Container, dockerContainer)
+				ctx = context.WithValue(ctx, Task, task)
+			}
+
+			if tc.taskContainerError {
+				state.EXPECT().ContainerMapByArn(taskARN).Return(nil, false)
+			} else {
+				state.EXPECT().ContainerMapByArn(taskARN).Return(containerNameToDockerContainer, true).AnyTimes()
+			}
+			params := graphql.Params{
+				Schema:        schema,
+				RequestString: tc.query,
+				Context:       ctx,
+			}
+			res := graphql.Do(params)
+			if tc.taskContainerError {
+				assert.Equal(t, tc.expectedResponse.Errors, res.Errors[0].Message)
+				return
+			}
+			if tc.containerCTXError {
+				assert.Equal(t, tc.expectedResponse.Errors, res.Errors[0].Message)
+				return
+			}
+			if tc.taskCTXError {
+				assert.Equal(t, tc.expectedResponse.Errors, res.Errors[0].Message)
+				return
+			}
+
+			// Marshal GraphQL response then unmarshal into the expected response struct
+			// in order to test whether the response fields are correct
+			var response gqlResponse
+			result, err := json.Marshal(res)
+			assert.NoError(t, err)
+			err = json.Unmarshal(result, &response)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedResponse, response)
+		})
+	}
+}

--- a/agent/handlers/gql/types.go
+++ b/agent/handlers/gql/types.go
@@ -16,5 +16,6 @@ package gql
 type ContextKey int
 
 const (
-	DockerID ContextKey = iota
+	Container ContextKey = iota
+	Task      ContextKey = iota
 )


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Adds basic Schema fields with simple resolver functions to the `schema.go` file. This includes all fields except container tags, task tags, networks, and stats. It introduces the `taskType` and `containerType` objects. The two queries currently implemented are `Container` and `Task` which resolve to the container querying the endpoint and the task that container is running, respectively.
### Implementation details
<!-- How are the changes implemented? -->
The current container and task are fetched while serving the request then passed to the `http.request` in context. The `schema.go` file defines `taskType` and `containerType`. The resolver functions are all defined for each field in each type. Note that if a field is named exactly the same as defined by the corresponding struct (i.e. `apitask.Task` and `apicontainer.DockerContainer`), the resolver considered "trivial" and do not need to be defined. 

A custom GraphQL scalar type, `JSON` was also created in order to resolve fields like `Labels` because it resolves to a mapping. Note that mappings are not a default GraphQL scalar type.
### Testing
<!-- How was this tested? -->
A new `schema_test.go` file was created to test individual resolvers. Additional test cases were also added to `task_server_setup_test.go` as well.
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->
yes
### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Add basic GraphQL TMDE types and resolvers

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
