### PR TITLE
Implemented firelens capability advertising and unit tests for windows

### DIFF
--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -239,19 +239,19 @@ func (agent *ecsAgent) capabilities() ([]*ecs.Attribute, error) {
 	capabilities = agent.appendTaskEIACapabilities(capabilities)
 
 	// support aws router capabilities for fluentd
-	capabilities = agent.appendFirelensFluentdCapabilities(capabilities)
+	capabilities = appendNameOnlyAttribute(capabilities, attributePrefix+capabilityFirelensFluentd)
 
 	// support aws router capabilities for fluentbit
-	capabilities = agent.appendFirelensFluentbitCapabilities(capabilities)
+	capabilities = appendNameOnlyAttribute(capabilities, attributePrefix+capabilityFirelensFluentbit)
 
 	// support aws router capabilities for log driver router
-	capabilities = agent.appendFirelensLoggingDriverCapabilities(capabilities)
+	capabilities = appendNameOnlyAttribute(capabilities, capabilityPrefix+capabilityFirelensLoggingDriver)
 
 	// support efs on ecs capabilities
 	capabilities = agent.appendEFSCapabilities(capabilities)
 
 	// support external firelens config
-	capabilities = agent.appendFirelensConfigCapabilities(capabilities)
+	capabilities = appendNameOnlyAttribute(appendNameOnlyAttribute(capabilities, attributePrefix+capabilityFirelensConfigFile), attributePrefix+capabilityFirelensConfigS3)
 
 	// support GMSA capabilities
 	capabilities = agent.appendGMSACapabilities(capabilities)

--- a/agent/app/agent_capability_unix.go
+++ b/agent/app/agent_capability_unix.go
@@ -149,29 +149,12 @@ func (agent *ecsAgent) appendTaskEIACapabilities(capabilities []*ecs.Attribute) 
 	return appendNameOnlyAttribute(capabilities, attributePrefix+taskEIAWithOptimizedCPU)
 }
 
-func (agent *ecsAgent) appendFirelensFluentdCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
-	return appendNameOnlyAttribute(capabilities, attributePrefix+capabilityFirelensFluentd)
-}
-
-func (agent *ecsAgent) appendFirelensFluentbitCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
-	return appendNameOnlyAttribute(capabilities, attributePrefix+capabilityFirelensFluentbit)
-}
-
 func (agent *ecsAgent) appendEFSCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
 	return appendNameOnlyAttribute(capabilities, attributePrefix+capabilityEFS)
 }
 
 func (agent *ecsAgent) appendEFSVolumePluginCapabilities(capabilities []*ecs.Attribute, pluginCapability string) []*ecs.Attribute {
 	return appendNameOnlyAttribute(capabilities, attributePrefix+pluginCapability)
-}
-
-func (agent *ecsAgent) appendFirelensLoggingDriverCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
-	return appendNameOnlyAttribute(capabilities, capabilityPrefix+capabilityFirelensLoggingDriver)
-}
-
-func (agent *ecsAgent) appendFirelensConfigCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
-	capabilities = appendNameOnlyAttribute(capabilities, attributePrefix+capabilityFirelensConfigFile)
-	return appendNameOnlyAttribute(capabilities, attributePrefix+capabilityFirelensConfigS3)
 }
 
 func (agent *ecsAgent) appendGMSACapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {

--- a/agent/app/agent_capability_windows.go
+++ b/agent/app/agent_capability_windows.go
@@ -48,25 +48,8 @@ func (agent *ecsAgent) appendTaskEIACapabilities(capabilities []*ecs.Attribute) 
 	return capabilities
 }
 
-func (agent *ecsAgent) appendFirelensFluentdCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
-	return appendNameOnlyAttribute(capabilities, attributePrefix+capabilityFirelensFluentd)
-}
-
-func (agent *ecsAgent) appendFirelensFluentbitCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
-	return appendNameOnlyAttribute(capabilities, attributePrefix+capabilityFirelensFluentbit)
-}
-
 func (agent *ecsAgent) appendEFSCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
 	return capabilities
-}
-
-func (agent *ecsAgent) appendFirelensLoggingDriverCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
-	return appendNameOnlyAttribute(capabilities, capabilityPrefix+capabilityFirelensLoggingDriver)
-}
-
-func (agent *ecsAgent) appendFirelensConfigCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
-	capabilities = appendNameOnlyAttribute(capabilities, attributePrefix+capabilityFirelensConfigFile)
-	return appendNameOnlyAttribute(capabilities, attributePrefix+capabilityFirelensConfigS3)
 }
 
 func (agent *ecsAgent) appendGMSACapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {

--- a/agent/app/agent_capability_windows.go
+++ b/agent/app/agent_capability_windows.go
@@ -49,11 +49,11 @@ func (agent *ecsAgent) appendTaskEIACapabilities(capabilities []*ecs.Attribute) 
 }
 
 func (agent *ecsAgent) appendFirelensFluentdCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
-	return capabilities
+	return appendNameOnlyAttribute(capabilities, attributePrefix+capabilityFirelensFluentd)
 }
 
 func (agent *ecsAgent) appendFirelensFluentbitCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
-	return capabilities
+	return appendNameOnlyAttribute(capabilities, attributePrefix+capabilityFirelensFluentbit)
 }
 
 func (agent *ecsAgent) appendEFSCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
@@ -61,11 +61,12 @@ func (agent *ecsAgent) appendEFSCapabilities(capabilities []*ecs.Attribute) []*e
 }
 
 func (agent *ecsAgent) appendFirelensLoggingDriverCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
-	return capabilities
+	return appendNameOnlyAttribute(capabilities, capabilityPrefix+capabilityFirelensLoggingDriver)
 }
 
 func (agent *ecsAgent) appendFirelensConfigCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
-	return capabilities
+	capabilities = appendNameOnlyAttribute(capabilities, attributePrefix+capabilityFirelensConfigFile)
+	return appendNameOnlyAttribute(capabilities, attributePrefix+capabilityFirelensConfigS3)
 }
 
 func (agent *ecsAgent) appendGMSACapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {

--- a/agent/app/agent_capability_windows_test.go
+++ b/agent/app/agent_capability_windows_test.go
@@ -226,64 +226,6 @@ func TestSupportedCapabilitiesWindows(t *testing.T) {
 	}
 }
 
-func TestFirelensConfigCapabilitiesWindows(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-	client := mock_dockerapi.NewMockDockerClient(ctrl)
-	cniClient := mock_ecscni.NewMockCNIClient(ctrl)
-	mockMobyPlugins := mock_mobypkgwrapper.NewMockPlugins(ctrl)
-	mockCredentialsProvider := app_mocks.NewMockProvider(ctrl)
-
-	conf := &config.Config{
-		AvailableLoggingDrivers: []dockerclient.LoggingDriver{
-			dockerclient.JSONFileDriver,
-			dockerclient.SyslogDriver,
-			dockerclient.JournaldDriver,
-			dockerclient.GelfDriver,
-			dockerclient.FluentdDriver,
-		},
-		PrivilegedDisabled:         config.BooleanDefaultFalse{Value: config.ExplicitlyDisabled},
-		SELinuxCapable:             config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled},
-		AppArmorCapable:            config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled},
-		TaskENIEnabled:             config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled},
-		AWSVPCBlockInstanceMetdata: config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled},
-		TaskCleanupWaitDuration:    config.DefaultConfig().TaskCleanupWaitDuration,
-	}
-
-	gomock.InOrder(
-		client.EXPECT().SupportedVersions().Return([]dockerclient.DockerVersion{
-			dockerclient.Version_1_17,
-			dockerclient.Version_1_18,
-		}),
-		client.EXPECT().KnownVersions().Return([]dockerclient.DockerVersion{
-			dockerclient.Version_1_17,
-			dockerclient.Version_1_18,
-			dockerclient.Version_1_19,
-		}),
-		mockMobyPlugins.EXPECT().Scan().AnyTimes().Return([]string{}, nil),
-		client.EXPECT().ListPluginsWithFilters(gomock.Any(), gomock.Any(), gomock.Any(),
-			gomock.Any()).AnyTimes().Return([]string{}, nil),
-		cniClient.EXPECT().Version(ecscni.ECSVPCENIPluginExecutable).Return("v1", nil),
-	)
-
-	ctx, cancel := context.WithCancel(context.TODO())
-	// Cancel the context to cancel async routines
-	defer cancel()
-	agent := &ecsAgent{
-		ctx:                ctx,
-		cfg:                conf,
-		dockerClient:       client,
-		cniClient:          cniClient,
-		credentialProvider: aws_credentials.NewCredentials(mockCredentialsProvider),
-		mobyPlugins:        mockMobyPlugins,
-	}
-	capabilities, err := agent.capabilities()
-	assert.NoError(t, err)
-
-	assert.Contains(t, capabilities, &ecs.Attribute{Name: aws.String(attributePrefix + capabilityFirelensConfigFile)})
-	assert.Contains(t, capabilities, &ecs.Attribute{Name: aws.String(attributePrefix + capabilityFirelensConfigS3)})
-}
-
 func TestAppendGMSACapabilities(t *testing.T) {
 	var inputCapabilities []*ecs.Attribute
 	var expectedCapabilities []*ecs.Attribute

--- a/agent/app/agent_capability_windows_test.go
+++ b/agent/app/agent_capability_windows_test.go
@@ -181,6 +181,11 @@ func TestSupportedCapabilitiesWindows(t *testing.T) {
 		attributePrefix + capabilitySecretEnvASM,
 		attributePrefix + capabilitySecretLogDriverASM,
 		attributePrefix + capabilityContainerOrdering,
+		attributePrefix + capabilityFirelensFluentd,
+		attributePrefix + capabilityFirelensFluentbit,
+		capabilityPrefix + capabilityFirelensLoggingDriver,
+		attributePrefix + capabilityFirelensConfigFile,
+		attributePrefix + capabilityFirelensConfigS3,
 		attributePrefix + capabilityFullTaskSync,
 		attributePrefix + capabilityEnvFilesS3,
 		attributePrefix + taskENIBlockInstanceMetadataAttributeSuffix}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Advertises agent capability for firelens fluent logging
### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
Extended the existing unit tests 
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
