### PR TITLE
Support buffer limit option in FireLens

### DIFF
--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -117,6 +117,8 @@ const (
 	firelensSocketBindFormat = "%s/data/firelens/%s/socket/:/var/run/"
 	// firelensDriverName is the log driver name for containers that want to use the firelens container to send logs.
 	firelensDriverName = "awsfirelens"
+	// FirelensLogDriverBufferLimitOption is the option for customers who want to specify the buffer limit size in FireLens.
+	FirelensLogDriverBufferLimitOption = "log-driver-buffer-limit"
 
 	// firelensConfigVarFmt specifies the format for firelens config variable name. The first placeholder
 	// is option name. The second placeholder is the index of the container in the task's container list, appended
@@ -1069,6 +1071,9 @@ func (task *Task) collectFirelensLogOptions(containerToLogOptions map[string]map
 				containerToLogOptions[container.Name] = make(map[string]string)
 			}
 			for k, v := range hostConfig.LogConfig.Config {
+				if k == FirelensLogDriverBufferLimitOption {
+					continue
+				}
 				containerToLogOptions[container.Name][k] = v
 			}
 		}

--- a/agent/api/task/task_linux_test.go
+++ b/agent/api/task/task_linux_test.go
@@ -1148,8 +1148,9 @@ func getFirelensTask(t *testing.T) *Task {
 		LogConfig: dockercontainer.LogConfig{
 			Type: firelensDriverName,
 			Config: map[string]string{
-				"key1": "value1",
-				"key2": "value2",
+				"key1":                    "value1",
+				"key2":                    "value2",
+				"log-driver-buffer-limit": "10000",
 			},
 		},
 	}

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -89,6 +89,7 @@ const (
 	dataLogDriverPath           = "/data/firelens/"
 	logDriverAsyncConnect       = "fluentd-async-connect"
 	logDriverSubSecondPrecision = "fluentd-sub-second-precision"
+	logDriverBufferLimit        = "fluentd-buffer-limit"
 	dataLogDriverSocketPath     = "/socket/fluent.sock"
 	socketPathPrefix            = "unix://"
 
@@ -1279,12 +1280,16 @@ func getFirelensLogConfig(task *apitask.Task, container *apicontainer.Container,
 	tag := fmt.Sprintf(fluentTagDockerFormat, container.Name, taskID)
 	fluentd := socketPathPrefix + filepath.Join(cfg.DataDirOnHost, dataLogDriverPath, taskID, dataLogDriverSocketPath)
 	logConfig := hostConfig.LogConfig
+	bufferLimit, bufferLimitExists := logConfig.Config[apitask.FirelensLogDriverBufferLimitOption]
 	logConfig.Type = logDriverTypeFluentd
 	logConfig.Config = make(map[string]string)
 	logConfig.Config[logDriverTag] = tag
 	logConfig.Config[logDriverFluentdAddress] = fluentd
 	logConfig.Config[logDriverAsyncConnect] = strconv.FormatBool(true)
 	logConfig.Config[logDriverSubSecondPrecision] = strconv.FormatBool(true)
+	if bufferLimitExists {
+		logConfig.Config[logDriverBufferLimit] = bufferLimit
+	}
 	seelog.Debugf("Applying firelens log config for container %s: %v", container.Name, logConfig)
 	return logConfig
 }

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -2670,8 +2670,9 @@ func TestCreateContainerAddFirelensLogDriverConfig(t *testing.T) {
 			LogConfig: dockercontainer.LogConfig{
 				Type: logDriverType,
 				Config: map[string]string{
-					"key1": "value1",
-					"key2": "value2",
+					"key1":                    "value1",
+					"key2":                    "value2",
+					"log-driver-buffer-limit": "10000",
 				},
 			},
 		}
@@ -2766,6 +2767,7 @@ func TestCreateContainerAddFirelensLogDriverConfig(t *testing.T) {
 		expectedLogConfigFluentAddress string
 		expectedFluentdAsyncConnect    string
 		expectedSubSecondPrecision     string
+		expectedBufferLimit            string
 		expectedIPAddress              string
 		expectedPort                   string
 	}{
@@ -2776,6 +2778,7 @@ func TestCreateContainerAddFirelensLogDriverConfig(t *testing.T) {
 			expectedLogConfigTag:           taskName + "-firelens-" + taskID,
 			expectedFluentdAsyncConnect:    strconv.FormatBool(true),
 			expectedSubSecondPrecision:     strconv.FormatBool(true),
+			expectedBufferLimit:            "10000",
 			expectedLogConfigFluentAddress: socketPathPrefix + filepath.Join(defaultConfig.DataDirOnHost, dataLogDriverPath, taskID, dataLogDriverSocketPath),
 			expectedIPAddress:              envVarBridgeMode,
 			expectedPort:                   envVarPort,
@@ -2787,6 +2790,7 @@ func TestCreateContainerAddFirelensLogDriverConfig(t *testing.T) {
 			expectedLogConfigTag:           taskName + "-firelens-" + taskID,
 			expectedFluentdAsyncConnect:    strconv.FormatBool(true),
 			expectedSubSecondPrecision:     strconv.FormatBool(true),
+			expectedBufferLimit:            "10000",
 			expectedLogConfigFluentAddress: socketPathPrefix + filepath.Join(defaultConfig.DataDirOnHost, dataLogDriverPath, taskID, dataLogDriverSocketPath),
 			expectedIPAddress:              envVarBridgeMode,
 			expectedPort:                   envVarPort,
@@ -2798,6 +2802,7 @@ func TestCreateContainerAddFirelensLogDriverConfig(t *testing.T) {
 			expectedLogConfigTag:           taskName + "-firelens-" + taskID,
 			expectedFluentdAsyncConnect:    strconv.FormatBool(true),
 			expectedSubSecondPrecision:     strconv.FormatBool(true),
+			expectedBufferLimit:            "",
 			expectedLogConfigFluentAddress: socketPathPrefix + filepath.Join(defaultConfig.DataDirOnHost, dataLogDriverPath, taskID, dataLogDriverSocketPath),
 			expectedIPAddress:              envVarAWSVPCMode,
 			expectedPort:                   envVarPort,
@@ -2823,6 +2828,7 @@ func TestCreateContainerAddFirelensLogDriverConfig(t *testing.T) {
 					assert.Equal(t, tc.expectedLogConfigFluentAddress, hostConfig.LogConfig.Config["fluentd-address"])
 					assert.Equal(t, tc.expectedFluentdAsyncConnect, hostConfig.LogConfig.Config["fluentd-async-connect"])
 					assert.Equal(t, tc.expectedSubSecondPrecision, hostConfig.LogConfig.Config["fluentd-sub-second-precision"])
+					assert.Equal(t, tc.expectedBufferLimit, hostConfig.LogConfig.Config["fluentd-buffer-limit"])
 					assert.Contains(t, config.Env, tc.expectedIPAddress)
 					assert.Contains(t, config.Env, tc.expectedPort)
 				})


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md
-->

### Summary
<!-- What does this pull request do? -->
Provide an entry to configure[fluentd-buffer-limit](https://docs.docker.com/config/containers/logging/fluentd/#fluentd-buffer-limit) in FireLens.
This is being enabled to resolve the following request: https://github.com/aws/containers-roadmap/issues/964

### Implementation details
<!-- How are the changes implemented? -->
Help to configure buffer limit size in fluentD Log Driver
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

- Updated two unit tests and manually tested the feature with `make test`
- The code also passed the end-to-end test on my instance.
Here is my task definition file:
```
"logConfiguration": {
        "logDriver": "awsfirelens",
        "secretOptions": null,
        "options": {
          "log_group_name": "/aws/ecs/containerinsights/$(ecs_cluster)/application",
          "log-driver-buffer-limit": "123456",
          "auto_create_group": "true",
          "log_key": "log",
          "log_stream_prefix": "log_stream_name",
          "region": "us-west-2",
          "Name": "cloudwatch"
        }
```

Result for `docker inspect`:
```
"HostConfig": {
            "Binds": [],
            "ContainerIDFile": "",
            "LogConfig": {
                "Type": "fluentd",
                "Config": {
                    "fluentd-address": "unix:///var/lib/ecs/data/firelens/677a7f0ded6c47709e26665f714e4c76/socket/fluent.sock",
                    "fluentd-async-connect": "true",
                    "fluentd-buffer-limit": "123456",
                    "fluentd-sub-second-precision": "true",
                    "tag": "app-firelens-677a7f0ded6c47709e26665f714e4c76"
                }
            },
```

Also, tested it with no `log-driver-buffer-limit` option:
```
"HostConfig": {
            "Binds": [],
            "ContainerIDFile": "",
            "LogConfig": {
                "Type": "fluentd",
                "Config": {
                    "fluentd-address": "unix:///var/lib/ecs/data/firelens/65b06118b2014ccd9ef92abf5727577d/socket/fluent.sock",
                    "fluentd-async-connect": "true",
                    "fluentd-sub-second-precision": "true",
                    "tag": "app-firelens-65b06118b2014ccd9ef92abf5727577d" 
                }
            },
```

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Feature FluentD: Support for buffer limit size configuration.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
