### PR TITLE
fix failing static check in dev branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -299,7 +299,7 @@ GOPATH=$(shell go env GOPATH)
 	go get github.com/golang/mock/mockgen
 	cd "${GOPATH}/src/github.com/golang/mock/mockgen" && git checkout 1.3.1 && go get ./... && go install ./... && cd -
 	go get golang.org/x/tools/cmd/goimports
-	go get github.com/fzipp/gocyclo/cmd/gocyclo
+	GO111MODULE=on go get github.com/fzipp/gocyclo/cmd/gocyclo@v0.3.1
 	go get honnef.co/go/tools/cmd/staticcheck
 	touch .get-deps-stamp
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Downgrading gocyclo to fix static check failure (e.g. see https://github.com/aws/amazon-ecs-agent/pull/2958/checks?check_run_id=3128497538). the latest gocyclo requires go 1.16 which we have not upgraded to, so downgrading it for now to unblock test.

This was found and fixed in another pr https://github.com/aws/amazon-ecs-agent/pull/2957. adding the same fix to dev branch to unblock pr in dev branch, since pr 2957 is targeting feature branch.

### Implementation details
<!-- How are the changes implemented? -->
Downgrade gocyclo.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
N/A

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
