### PR TITLE
Add generic rpm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -297,6 +297,19 @@ GOPATH=$(shell go env GOPATH)
 
 get-deps: .get-deps-stamp
 
+.generic-rpm-done: pause-container-release
+	cp packaging/generic-rpm/ecs-agent.spec ecs-agent.spec
+	cp packaging/generic-rpm/ecs.service ecs.service
+	cp packaging/generic-rpm/amazon-ecs-volume-plugin.service amazon-ecs-volume-plugin.service
+	cp packaging/generic-rpm/amazon-ecs-volume-plugin.socket amazon-ecs-volume-plugin.socket
+	tar -czf ./sources.tgz agent scripts
+	test -e SOURCES || ln -s . SOURCES
+	rpmbuild --undefine=_disable_source_fetch --define "%_topdir $(PWD)" -bb ecs-agent.spec
+	find RPMS/ -type f -exec cp {} . \;
+	touch .rpm-done
+
+generic-rpm: .generic-rpm-done
+
 clean:
 	# ensure docker is running and we can talk to it, abort if not:
 	docker ps > /dev/null
@@ -317,4 +330,22 @@ clean:
 	-rm -rf $(PWD)/bin
 	-rm -rf cover.out
 	-rm -rf coverprofile.out
-
+	-rm -f ecs-agent.spec
+	-rm -f ecs.service
+	-rm -f amazon-ecs-volume-plugin.service
+	-rm -f amazon-ecs-volume-plugin.socket
+	-rm -f ./sources.tgz
+	-rm -f ./amazon-ecs-agent
+	-rm -f ./amazon-ecs-agent-*.rpm
+	-rm -f ./ecs-agent-*.tar
+	-rm -f ./ecs-agent-*.src.rpm
+	-rm -rf ./ecs-agent-*
+	-rm -rf ./BUILDROOT BUILD RPMS SRPMS SOURCES SPECS
+	-rm -rf ./x86_64
+	-rm -f ./amazon-ecs-agent_${VERSION}*
+	-rm -f .srpm-done .rpm-done .generic-rpm-done
+	-rm -f .deb-done
+	-rm -f amazon-ecs-cni-plugins.tar.gz
+	-rm -f amazon-vpc-cni-plugins.tar.gz
+	-rm -rf ../amazon-ecs-cni-plugins
+	-rm -rf ../amazon-vpc-cni-plugins

--- a/README.md
+++ b/README.md
@@ -228,8 +228,11 @@ for production on Linux, but it can be useful for development or easier integrat
 The following commands run the agent outside of Docker:
 
 ```
-make gobuild
-./out/amazon-ecs-agent
+sudo yum install rpm-build
+make generic-rpm
+sudo yum localinstall amazon-ecs-agent-1.53-1.x86_64.rpm
+sudo vi /etc/ecs/ecs.config #add environment variables (ECS_CLUSTER and ECS_DATADIR required)
+sudo systemctl start ecs
 ```
 
 ### Make Targets (on Linux)
@@ -245,6 +248,8 @@ The following targets are available. Each may be run with `make <target>`.
 | `test-in-docker`       | Runs all tests inside a Docker container |
 | `run-integ-tests`      | Runs all integration tests in the `engine` and `stats` packages |
 | `clean`                | Removes build artifacts. *Note: this does not remove Docker images* |
+| `generic-rpm`          | Builds installable rpm package for a containerless agent |
+
 
 ### Standalone (on Windows)
 

--- a/agent/app/agent_unix.go
+++ b/agent/app/agent_unix.go
@@ -48,7 +48,7 @@ const initPID = 1
 var awsVPCCNIPlugins = []string{ecscni.ECSENIPluginName,
 	ecscni.ECSBridgePluginName,
 	ecscni.ECSIPAMPluginName,
-	ecscni.ECSAppMeshPluginName,
+	//ecscni.ECSAppMeshPluginName,
 	ecscni.ECSBranchENIPluginName,
 }
 

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -118,13 +118,13 @@ const (
 	minimumNumImagesToDeletePerCycle = 1
 
 	// defaultCNIPluginsPath is the default path where cni binaries are located
-	defaultCNIPluginsPath = "/amazon-ecs-cni-plugins"
+	defaultCNIPluginsPath = "/usr/libexec"
 
 	// DefaultMinSupportedCNIVersion denotes the minimum version of cni spec required
 	DefaultMinSupportedCNIVersion = "0.3.0"
 
 	// pauseContainerTarball is the path to the pause container tarball
-	pauseContainerTarballPath = "/images/amazon-ecs-pause.tar"
+	pauseContainerTarballPath = "/var/lib/amazon-ecs-pause.tar"
 
 	// DefaultTaskMetadataSteadyStateRate is set as 40. This is arrived from our benchmarking
 	// results where task endpoint can handle 4000 rps effectively. Here, 100 containers
@@ -182,11 +182,11 @@ const (
 var (
 	// DefaultPauseContainerImageName is the name of the pause container image. The linker's
 	// load flags are used to populate this value from the Makefile
-	DefaultPauseContainerImageName = ""
+	DefaultPauseContainerImageName = "amazon/amazon-ecs-pause"
 
 	// DefaultPauseContainerTag is the tag for the pause container image. The linker's load
 	// flags are used to populate this value from the Makefile
-	DefaultPauseContainerTag = ""
+	DefaultPauseContainerTag = "0.1.0"
 )
 
 // Merge merges two config files, preferring the ones on the left. Any nil or

--- a/agent/ecscni/plugin.go
+++ b/agent/ecscni/plugin.go
@@ -36,7 +36,7 @@ const (
 	currentECSCNIVersion      = "2020.09.0"
 	currentECSCNIGitHash      = "55b2ae77ee0bf22321b14f2d4ebbcc04f77322e1"
 	currentVPCCNIGitHash      = "a21d3a41f922e14c19387713df66be3e4ee1e1f6"
-	vpcCNIPluginPath          = "/log/vpc-branch-eni.log"
+	vpcCNIPluginPath          = "/var/log/ecs/vpc-branch-eni.log"
 	vpcCNIPluginInterfaceType = "vlan"
 )
 

--- a/agent/ecscni/types.go
+++ b/agent/ecscni/types.go
@@ -38,7 +38,7 @@ const (
 	ecsSubnet = "169.254.172.0/22"
 
 	// NetnsFormat is used to construct the path to cotainer network namespace
-	NetnsFormat = "/host/proc/%s/ns/net"
+	NetnsFormat = "/proc/%s/ns/net"
 	// ECSIPAMPluginName is the binary of the ipam plugin
 	ECSIPAMPluginName = "ecs-ipam"
 	// ECSBridgePluginName is the binary of the bridge plugin

--- a/agent/utils/license.go
+++ b/agent/utils/license.go
@@ -24,9 +24,9 @@ type LicenseProvider interface {
 type licenseProvider struct{}
 
 const (
-	licenseFile    = "LICENSE"
-	noticeFile     = "NOTICE"
-	thirdPartyFile = "THIRD-PARTY"
+	licenseFile    = "/usr/share/licenses/ecs-agent/LICENSE"
+	noticeFile     = "/usr/share/licenses/ecs-agent/NOTICE"
+	thirdPartyFile = "/usr/share/licenses/ecs-agent/THIRD-PARTY"
 )
 
 var readFile = ioutil.ReadFile

--- a/agent/vendor/github.com/coreos/go-systemd/activation/files.go
+++ b/agent/vendor/github.com/coreos/go-systemd/activation/files.go
@@ -1,0 +1,67 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package activation implements primitives for systemd socket activation.
+package activation
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+const (
+	// listenFdsStart corresponds to `SD_LISTEN_FDS_START`.
+	listenFdsStart = 3
+)
+
+// Files returns a slice containing a `os.File` object for each
+// file descriptor passed to this process via systemd fd-passing protocol.
+//
+// The order of the file descriptors is preserved in the returned slice.
+// `unsetEnv` is typically set to `true` in order to avoid clashes in
+// fd usage and to avoid leaking environment flags to child processes.
+func Files(unsetEnv bool) []*os.File {
+	if unsetEnv {
+		defer os.Unsetenv("LISTEN_PID")
+		defer os.Unsetenv("LISTEN_FDS")
+		defer os.Unsetenv("LISTEN_FDNAMES")
+	}
+
+	pid, err := strconv.Atoi(os.Getenv("LISTEN_PID"))
+	if err != nil || pid != os.Getpid() {
+		return nil
+	}
+
+	nfds, err := strconv.Atoi(os.Getenv("LISTEN_FDS"))
+	if err != nil || nfds == 0 {
+		return nil
+	}
+
+	names := strings.Split(os.Getenv("LISTEN_FDNAMES"), ":")
+
+	files := make([]*os.File, 0, nfds)
+	for fd := listenFdsStart; fd < listenFdsStart+nfds; fd++ {
+		syscall.CloseOnExec(fd)
+		name := "LISTEN_FD_" + strconv.Itoa(fd)
+		offset := fd - listenFdsStart
+		if offset < len(names) && len(names[offset]) > 0 {
+			name = names[offset]
+		}
+		files = append(files, os.NewFile(uintptr(fd), name))
+	}
+
+	return files
+}

--- a/agent/vendor/github.com/coreos/go-systemd/activation/listeners.go
+++ b/agent/vendor/github.com/coreos/go-systemd/activation/listeners.go
@@ -1,0 +1,103 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package activation
+
+import (
+	"crypto/tls"
+	"net"
+)
+
+// Listeners returns a slice containing a net.Listener for each matching socket type
+// passed to this process.
+//
+// The order of the file descriptors is preserved in the returned slice.
+// Nil values are used to fill any gaps. For example if systemd were to return file descriptors
+// corresponding with "udp, tcp, tcp", then the slice would contain {nil, net.Listener, net.Listener}
+func Listeners() ([]net.Listener, error) {
+	files := Files(true)
+	listeners := make([]net.Listener, len(files))
+
+	for i, f := range files {
+		if pc, err := net.FileListener(f); err == nil {
+			listeners[i] = pc
+			f.Close()
+		}
+	}
+	return listeners, nil
+}
+
+// ListenersWithNames maps a listener name to a set of net.Listener instances.
+func ListenersWithNames() (map[string][]net.Listener, error) {
+	files := Files(true)
+	listeners := map[string][]net.Listener{}
+
+	for _, f := range files {
+		if pc, err := net.FileListener(f); err == nil {
+			current, ok := listeners[f.Name()]
+			if !ok {
+				listeners[f.Name()] = []net.Listener{pc}
+			} else {
+				listeners[f.Name()] = append(current, pc)
+			}
+			f.Close()
+		}
+	}
+	return listeners, nil
+}
+
+// TLSListeners returns a slice containing a net.listener for each matching TCP socket type
+// passed to this process.
+// It uses default Listeners func and forces TCP sockets handlers to use TLS based on tlsConfig.
+func TLSListeners(tlsConfig *tls.Config) ([]net.Listener, error) {
+	listeners, err := Listeners()
+
+	if listeners == nil || err != nil {
+		return nil, err
+	}
+
+	if tlsConfig != nil {
+		for i, l := range listeners {
+			// Activate TLS only for TCP sockets
+			if l.Addr().Network() == "tcp" {
+				listeners[i] = tls.NewListener(l, tlsConfig)
+			}
+		}
+	}
+
+	return listeners, err
+}
+
+// TLSListenersWithNames maps a listener name to a net.Listener with
+// the associated TLS configuration.
+func TLSListenersWithNames(tlsConfig *tls.Config) (map[string][]net.Listener, error) {
+	listeners, err := ListenersWithNames()
+
+	if listeners == nil || err != nil {
+		return nil, err
+	}
+
+	if tlsConfig != nil {
+		for _, ll := range listeners {
+			// Activate TLS only for TCP sockets
+			for i, l := range ll {
+				if l.Addr().Network() == "tcp" {
+					ll[i] = tls.NewListener(l, tlsConfig)
+				}
+			}
+		}
+	}
+
+	return listeners, err
+}

--- a/agent/vendor/github.com/coreos/go-systemd/activation/packetconns.go
+++ b/agent/vendor/github.com/coreos/go-systemd/activation/packetconns.go
@@ -1,0 +1,38 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package activation
+
+import (
+	"net"
+)
+
+// PacketConns returns a slice containing a net.PacketConn for each matching socket type
+// passed to this process.
+//
+// The order of the file descriptors is preserved in the returned slice.
+// Nil values are used to fill any gaps. For example if systemd were to return file descriptors
+// corresponding with "udp, tcp, udp", then the slice would contain {net.PacketConn, nil, net.PacketConn}
+func PacketConns() ([]net.PacketConn, error) {
+	files := Files(true)
+	conns := make([]net.PacketConn, len(files))
+
+	for i, f := range files {
+		if pc, err := net.FilePacketConn(f); err == nil {
+			conns[i] = pc
+			f.Close()
+		}
+	}
+	return conns, nil
+}

--- a/agent/vendor/github.com/docker/go-plugins-helpers/LICENSE
+++ b/agent/vendor/github.com/docker/go-plugins-helpers/LICENSE
@@ -1,0 +1,202 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/agent/vendor/github.com/docker/go-plugins-helpers/NOTICE
+++ b/agent/vendor/github.com/docker/go-plugins-helpers/NOTICE
@@ -1,0 +1,19 @@
+Docker
+Copyright 2012-2015 Docker, Inc.
+
+This product includes software developed at Docker, Inc. (https://www.docker.com).
+
+This product contains software (https://github.com/kr/pty) developed
+by Keith Rarick, licensed under the MIT License.
+
+The following is courtesy of our legal counsel:
+
+
+Use and transfer of Docker may be subject to certain restrictions by the
+United States and other governments.
+It is your responsibility to ensure that your use and/or transfer does not
+violate applicable laws.
+
+For more information, please see https://www.bis.doc.gov
+
+See also https://www.apache.org/dev/crypto.html and/or seek legal counsel.

--- a/agent/vendor/github.com/docker/go-plugins-helpers/sdk/encoder.go
+++ b/agent/vendor/github.com/docker/go-plugins-helpers/sdk/encoder.go
@@ -1,0 +1,37 @@
+package sdk
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// DefaultContentTypeV1_1 is the default content type accepted and sent by the plugins.
+const DefaultContentTypeV1_1 = "application/vnd.docker.plugins.v1.1+json"
+
+// DecodeRequest decodes an http request into a given structure.
+func DecodeRequest(w http.ResponseWriter, r *http.Request, req interface{}) (err error) {
+	if err = json.NewDecoder(r.Body).Decode(req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+	}
+	return
+}
+
+// EncodeResponse encodes the given structure into an http response.
+func EncodeResponse(w http.ResponseWriter, res interface{}, err bool) {
+	w.Header().Set("Content-Type", DefaultContentTypeV1_1)
+	if err {
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+	json.NewEncoder(w).Encode(res)
+}
+
+// StreamResponse streams a response object to the client
+func StreamResponse(w http.ResponseWriter, data io.ReadCloser) {
+	w.Header().Set("Content-Type", DefaultContentTypeV1_1)
+	if _, err := copyBuf(w, data); err != nil {
+		fmt.Printf("ERROR in stream: %v\n", err)
+	}
+	data.Close()
+}

--- a/agent/vendor/github.com/docker/go-plugins-helpers/sdk/handler.go
+++ b/agent/vendor/github.com/docker/go-plugins-helpers/sdk/handler.go
@@ -1,0 +1,88 @@
+package sdk
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+)
+
+const activatePath = "/Plugin.Activate"
+
+// Handler is the base to create plugin handlers.
+// It initializes connections and sockets to listen to.
+type Handler struct {
+	mux *http.ServeMux
+}
+
+// NewHandler creates a new Handler with an http mux.
+func NewHandler(manifest string) Handler {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc(activatePath, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", DefaultContentTypeV1_1)
+		fmt.Fprintln(w, manifest)
+	})
+
+	return Handler{mux: mux}
+}
+
+// Serve sets up the handler to serve requests on the passed in listener
+func (h Handler) Serve(l net.Listener) error {
+	server := http.Server{
+		Addr:    l.Addr().String(),
+		Handler: h.mux,
+	}
+	return server.Serve(l)
+}
+
+// ServeTCP makes the handler to listen for request in a given TCP address.
+// It also writes the spec file in the right directory for docker to read.
+// Due to constrains for running Docker in Docker on Windows, data-root directory
+// of docker daemon must be provided. To get default directory, use
+// WindowsDefaultDaemonRootDir() function. On Unix, this parameter is ignored.
+func (h Handler) ServeTCP(pluginName, addr, daemonDir string, tlsConfig *tls.Config) error {
+	l, spec, err := newTCPListener(addr, pluginName, daemonDir, tlsConfig)
+	if err != nil {
+		return err
+	}
+	if spec != "" {
+		defer os.Remove(spec)
+	}
+	return h.Serve(l)
+}
+
+// ServeUnix makes the handler to listen for requests in a unix socket.
+// It also creates the socket file in the right directory for docker to read.
+func (h Handler) ServeUnix(addr string, gid int) error {
+	l, spec, err := newUnixListener(addr, gid)
+	if err != nil {
+		return err
+	}
+	if spec != "" {
+		defer os.Remove(spec)
+	}
+	return h.Serve(l)
+}
+
+// ServeWindows makes the handler to listen for request in a Windows named pipe.
+// It also creates the spec file in the right directory for docker to read.
+// Due to constrains for running Docker in Docker on Windows, data-root directory
+// of docker daemon must be provided. To get default directory, use
+// WindowsDefaultDaemonRootDir() function. On Unix, this parameter is ignored.
+func (h Handler) ServeWindows(addr, pluginName, daemonDir string, pipeConfig *WindowsPipeConfig) error {
+	l, spec, err := newWindowsListener(addr, pluginName, daemonDir, pipeConfig)
+	if err != nil {
+		return err
+	}
+	if spec != "" {
+		defer os.Remove(spec)
+	}
+	return h.Serve(l)
+}
+
+// HandleFunc registers a function to handle a request path with.
+func (h Handler) HandleFunc(path string, fn func(w http.ResponseWriter, r *http.Request)) {
+	h.mux.HandleFunc(path, fn)
+}

--- a/agent/vendor/github.com/docker/go-plugins-helpers/sdk/pool.go
+++ b/agent/vendor/github.com/docker/go-plugins-helpers/sdk/pool.go
@@ -1,0 +1,18 @@
+package sdk
+
+import (
+	"io"
+	"sync"
+)
+
+const buffer32K = 32 * 1024
+
+var buffer32KPool = &sync.Pool{New: func() interface{} { return make([]byte, buffer32K) }}
+
+// copyBuf uses a shared buffer pool with io.CopyBuffer
+func copyBuf(w io.Writer, r io.Reader) (int64, error) {
+	buf := buffer32KPool.Get().([]byte)
+	written, err := io.CopyBuffer(w, r, buf)
+	buffer32KPool.Put(buf)
+	return written, err
+}

--- a/agent/vendor/github.com/docker/go-plugins-helpers/sdk/spec_file_generator.go
+++ b/agent/vendor/github.com/docker/go-plugins-helpers/sdk/spec_file_generator.go
@@ -1,0 +1,58 @@
+package sdk
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+type protocol string
+
+const (
+	protoTCP       protocol = "tcp"
+	protoNamedPipe protocol = "npipe"
+)
+
+// PluginSpecDir returns plugin spec dir in relation to daemon root directory.
+func PluginSpecDir(daemonRoot string) string {
+	return ([]string{filepath.Join(daemonRoot, "plugins")})[0]
+}
+
+// WindowsDefaultDaemonRootDir returns default data directory of docker daemon on Windows.
+func WindowsDefaultDaemonRootDir() string {
+	return filepath.Join(os.Getenv("programdata"), "docker")
+}
+
+func createPluginSpecDirWindows(name, address, daemonRoot string) (string, error) {
+	_, err := os.Stat(daemonRoot)
+	if os.IsNotExist(err) {
+		return "", fmt.Errorf("Deamon root directory must already exist: %s", err)
+	}
+
+	pluginSpecDir := PluginSpecDir(daemonRoot)
+
+	if err := windowsCreateDirectoryWithACL(pluginSpecDir); err != nil {
+		return "", err
+	}
+	return pluginSpecDir, nil
+}
+
+func createPluginSpecDirUnix(name, address string) (string, error) {
+	pluginSpecDir := PluginSpecDir("/etc/docker")
+	if err := os.MkdirAll(pluginSpecDir, 0755); err != nil {
+		return "", err
+	}
+	return pluginSpecDir, nil
+}
+
+func writeSpecFile(name, address, pluginSpecDir string, proto protocol) (string, error) {
+	specFileDir := filepath.Join(pluginSpecDir, name+".spec")
+
+	url := string(proto) + "://" + address
+	if err := ioutil.WriteFile(specFileDir, []byte(url), 0644); err != nil {
+		return "", err
+	}
+
+	return specFileDir, nil
+}

--- a/agent/vendor/github.com/docker/go-plugins-helpers/sdk/tcp_listener.go
+++ b/agent/vendor/github.com/docker/go-plugins-helpers/sdk/tcp_listener.go
@@ -1,0 +1,34 @@
+package sdk
+
+import (
+	"crypto/tls"
+	"net"
+	"runtime"
+
+	"github.com/docker/go-connections/sockets"
+)
+
+func newTCPListener(address, pluginName, daemonDir string, tlsConfig *tls.Config) (net.Listener, string, error) {
+	listener, err := sockets.NewTCPSocket(address, tlsConfig)
+	if err != nil {
+		return nil, "", err
+	}
+
+	addr := listener.Addr().String()
+
+	var specDir string
+	if runtime.GOOS == "windows" {
+		specDir, err = createPluginSpecDirWindows(pluginName, addr, daemonDir)
+	} else {
+		specDir, err = createPluginSpecDirUnix(pluginName, addr)
+	}
+	if err != nil {
+		return nil, "", err
+	}
+
+	specFile, err := writeSpecFile(pluginName, addr, specDir, protoTCP)
+	if err != nil {
+		return nil, "", err
+	}
+	return listener, specFile, nil
+}

--- a/agent/vendor/github.com/docker/go-plugins-helpers/sdk/unix_listener.go
+++ b/agent/vendor/github.com/docker/go-plugins-helpers/sdk/unix_listener.go
@@ -1,0 +1,35 @@
+// +build linux freebsd
+
+package sdk
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+
+	"github.com/docker/go-connections/sockets"
+)
+
+const pluginSockDir = "/run/docker/plugins"
+
+func newUnixListener(pluginName string, gid int) (net.Listener, string, error) {
+	path, err := fullSocketAddress(pluginName)
+	if err != nil {
+		return nil, "", err
+	}
+	listener, err := sockets.NewUnixSocket(path, gid)
+	if err != nil {
+		return nil, "", err
+	}
+	return listener, path, nil
+}
+
+func fullSocketAddress(address string) (string, error) {
+	if err := os.MkdirAll(pluginSockDir, 0755); err != nil {
+		return "", err
+	}
+	if filepath.IsAbs(address) {
+		return address, nil
+	}
+	return filepath.Join(pluginSockDir, address+".sock"), nil
+}

--- a/agent/vendor/github.com/docker/go-plugins-helpers/sdk/unix_listener_nosystemd.go
+++ b/agent/vendor/github.com/docker/go-plugins-helpers/sdk/unix_listener_nosystemd.go
@@ -1,0 +1,10 @@
+// +build linux freebsd
+// +build nosystemd
+
+package sdk
+
+import "net"
+
+func setupSocketActivation() (net.Listener, error) {
+	return nil, nil
+}

--- a/agent/vendor/github.com/docker/go-plugins-helpers/sdk/unix_listener_systemd.go
+++ b/agent/vendor/github.com/docker/go-plugins-helpers/sdk/unix_listener_systemd.go
@@ -1,0 +1,45 @@
+// +build linux freebsd
+// +build !nosystemd
+
+package sdk
+
+import (
+	"fmt"
+	"net"
+	"os"
+
+	"github.com/coreos/go-systemd/activation"
+)
+
+// isRunningSystemd checks whether the host was booted with systemd as its init
+// system. This functions similarly to systemd's `sd_booted(3)`: internally, it
+// checks whether /run/systemd/system/ exists and is a directory.
+// http://www.freedesktop.org/software/systemd/man/sd_booted.html
+//
+// Copied from github.com/coreos/go-systemd/util.IsRunningSystemd
+func isRunningSystemd() bool {
+	fi, err := os.Lstat("/run/systemd/system")
+	if err != nil {
+		return false
+	}
+	return fi.IsDir()
+}
+
+func setupSocketActivation() (net.Listener, error) {
+	if !isRunningSystemd() {
+		return nil, nil
+	}
+	listenFds := activation.Files(false)
+	if len(listenFds) > 1 {
+		return nil, fmt.Errorf("expected only one socket from systemd, got %d", len(listenFds))
+	}
+	var listener net.Listener
+	if len(listenFds) == 1 {
+		l, err := net.FileListener(listenFds[0])
+		if err != nil {
+			return nil, err
+		}
+		listener = l
+	}
+	return listener, nil
+}

--- a/agent/vendor/github.com/docker/go-plugins-helpers/sdk/unix_listener_unsupported.go
+++ b/agent/vendor/github.com/docker/go-plugins-helpers/sdk/unix_listener_unsupported.go
@@ -1,0 +1,16 @@
+// +build !linux,!freebsd
+
+package sdk
+
+import (
+	"errors"
+	"net"
+)
+
+var (
+	errOnlySupportedOnLinuxAndFreeBSD = errors.New("unix socket creation is only supported on Linux and FreeBSD")
+)
+
+func newUnixListener(pluginName string, gid int) (net.Listener, string, error) {
+	return nil, "", errOnlySupportedOnLinuxAndFreeBSD
+}

--- a/agent/vendor/github.com/docker/go-plugins-helpers/sdk/windows_listener.go
+++ b/agent/vendor/github.com/docker/go-plugins-helpers/sdk/windows_listener.go
@@ -1,0 +1,70 @@
+// +build windows
+
+package sdk
+
+import (
+	"net"
+	"os"
+	"syscall"
+	"unsafe"
+
+	"github.com/Microsoft/go-winio"
+)
+
+// Named pipes use Windows Security Descriptor Definition Language to define ACL. Following are
+// some useful definitions.
+const (
+	// This will set permissions for everyone to have full access
+	AllowEveryone = "S:(ML;;NW;;;LW)D:(A;;0x12019f;;;WD)"
+
+	// This will set permissions for Service, System, Adminstrator group and account to have full access
+	AllowServiceSystemAdmin = "D:(A;ID;FA;;;SY)(A;ID;FA;;;BA)(A;ID;FA;;;LA)(A;ID;FA;;;LS)"
+)
+
+func newWindowsListener(address, pluginName, daemonRoot string, pipeConfig *WindowsPipeConfig) (net.Listener, string, error) {
+	winioPipeConfig := winio.PipeConfig{
+		SecurityDescriptor: pipeConfig.SecurityDescriptor,
+		InputBufferSize:    pipeConfig.InBufferSize,
+		OutputBufferSize:   pipeConfig.OutBufferSize,
+	}
+	listener, err := winio.ListenPipe(address, &winioPipeConfig)
+	if err != nil {
+		return nil, "", err
+	}
+
+	addr := listener.Addr().String()
+
+	specDir, err := createPluginSpecDirWindows(pluginName, addr, daemonRoot)
+	if err != nil {
+		return nil, "", err
+	}
+
+	spec, err := writeSpecFile(pluginName, addr, specDir, protoNamedPipe)
+	if err != nil {
+		return nil, "", err
+	}
+	return listener, spec, nil
+}
+
+func windowsCreateDirectoryWithACL(name string) error {
+	sa := syscall.SecurityAttributes{Length: 0}
+	sddl := "D:P(A;OICI;GA;;;BA)(A;OICI;GA;;;SY)"
+	sd, err := winio.SddlToSecurityDescriptor(sddl)
+	if err != nil {
+		return &os.PathError{Op: "mkdir", Path: name, Err: err}
+	}
+	sa.Length = uint32(unsafe.Sizeof(sa))
+	sa.InheritHandle = 1
+	sa.SecurityDescriptor = uintptr(unsafe.Pointer(&sd[0]))
+
+	namep, err := syscall.UTF16PtrFromString(name)
+	if err != nil {
+		return &os.PathError{Op: "mkdir", Path: name, Err: err}
+	}
+
+	e := syscall.CreateDirectory(namep, &sa)
+	if e != nil {
+		return &os.PathError{Op: "mkdir", Path: name, Err: e}
+	}
+	return nil
+}

--- a/agent/vendor/github.com/docker/go-plugins-helpers/sdk/windows_listener_unsupported.go
+++ b/agent/vendor/github.com/docker/go-plugins-helpers/sdk/windows_listener_unsupported.go
@@ -1,0 +1,20 @@
+// +build !windows
+
+package sdk
+
+import (
+	"errors"
+	"net"
+)
+
+var (
+	errOnlySupportedOnWindows = errors.New("named pipe creation is only supported on Windows")
+)
+
+func newWindowsListener(address, pluginName, daemonRoot string, pipeConfig *WindowsPipeConfig) (net.Listener, string, error) {
+	return nil, "", errOnlySupportedOnWindows
+}
+
+func windowsCreateDirectoryWithACL(name string) error {
+	return nil
+}

--- a/agent/vendor/github.com/docker/go-plugins-helpers/sdk/windows_pipe_config.go
+++ b/agent/vendor/github.com/docker/go-plugins-helpers/sdk/windows_pipe_config.go
@@ -1,0 +1,13 @@
+package sdk
+
+// WindowsPipeConfig is a helper structure for configuring named pipe parameters on Windows.
+type WindowsPipeConfig struct {
+	// SecurityDescriptor contains a Windows security descriptor in SDDL format.
+	SecurityDescriptor string
+
+	// InBufferSize in bytes.
+	InBufferSize int32
+
+	// OutBufferSize in bytes.
+	OutBufferSize int32
+}

--- a/agent/vendor/github.com/docker/go-plugins-helpers/volume/README.md
+++ b/agent/vendor/github.com/docker/go-plugins-helpers/volume/README.md
@@ -1,0 +1,36 @@
+# Docker volume extension api.
+
+Go handler to create external volume extensions for Docker.
+
+## Usage
+
+This library is designed to be integrated in your program.
+
+1. Implement the `volume.Driver` interface.
+2. Initialize a `volume.Handler` with your implementation.
+3. Call either `ServeTCP` or `ServeUnix` from the `volume.Handler`.
+
+### Example using TCP sockets:
+
+```go
+  d := MyVolumeDriver{}
+  h := volume.NewHandler(d)
+  h.ServeTCP("test_volume", ":8080")
+```
+
+### Example using Unix sockets:
+
+```go
+  d := MyVolumeDriver{}
+  h := volume.NewHandler(d)
+  u, _ := user.Lookup("root")
+  gid, _ := strconv.Atoi(u.Gid)
+  h.ServeUnix("test_volume", gid)
+```
+
+## Full example plugins
+
+- https://github.com/calavera/docker-volume-glusterfs
+- https://github.com/calavera/docker-volume-keywhiz
+- https://github.com/quobyte/docker-volume
+- https://github.com/NimbleStorage/Nemo

--- a/agent/vendor/github.com/docker/go-plugins-helpers/volume/api.go
+++ b/agent/vendor/github.com/docker/go-plugins-helpers/volume/api.go
@@ -1,0 +1,230 @@
+package volume
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/docker/go-plugins-helpers/sdk"
+)
+
+const (
+	// DefaultDockerRootDirectory is the default directory where volumes will be created.
+	DefaultDockerRootDirectory = "/var/lib/docker-volumes"
+
+	manifest         = `{"Implements": ["VolumeDriver"]}`
+	createPath       = "/VolumeDriver.Create"
+	getPath          = "/VolumeDriver.Get"
+	listPath         = "/VolumeDriver.List"
+	removePath       = "/VolumeDriver.Remove"
+	hostVirtualPath  = "/VolumeDriver.Path"
+	mountPath        = "/VolumeDriver.Mount"
+	unmountPath      = "/VolumeDriver.Unmount"
+	capabilitiesPath = "/VolumeDriver.Capabilities"
+)
+
+// CreateRequest is the structure that docker's requests are deserialized to.
+type CreateRequest struct {
+	Name    string
+	Options map[string]string `json:"Opts,omitempty"`
+}
+
+// RemoveRequest structure for a volume remove request
+type RemoveRequest struct {
+	Name string
+}
+
+// MountRequest structure for a volume mount request
+type MountRequest struct {
+	Name string
+	ID   string
+}
+
+// MountResponse structure for a volume mount response
+type MountResponse struct {
+	Mountpoint string
+}
+
+// UnmountRequest structure for a volume unmount request
+type UnmountRequest struct {
+	Name string
+	ID   string
+}
+
+// PathRequest structure for a volume path request
+type PathRequest struct {
+	Name string
+}
+
+// PathResponse structure for a volume path response
+type PathResponse struct {
+	Mountpoint string
+}
+
+// GetRequest structure for a volume get request
+type GetRequest struct {
+	Name string
+}
+
+// GetResponse structure for a volume get response
+type GetResponse struct {
+	Volume *Volume
+}
+
+// ListResponse structure for a volume list response
+type ListResponse struct {
+	Volumes []*Volume
+}
+
+// CapabilitiesResponse structure for a volume capability response
+type CapabilitiesResponse struct {
+	Capabilities Capability
+}
+
+// Volume represents a volume object for use with `Get` and `List` requests
+type Volume struct {
+	Name       string
+	Mountpoint string                 `json:",omitempty"`
+	CreatedAt  string                 `json:",omitempty"`
+	Status     map[string]interface{} `json:",omitempty"`
+}
+
+// Capability represents the list of capabilities a volume driver can return
+type Capability struct {
+	Scope string
+}
+
+// ErrorResponse is a formatted error message that docker can understand
+type ErrorResponse struct {
+	Err string
+}
+
+// NewErrorResponse creates an ErrorResponse with the provided message
+func NewErrorResponse(msg string) *ErrorResponse {
+	return &ErrorResponse{Err: msg}
+}
+
+// Driver represent the interface a driver must fulfill.
+type Driver interface {
+	Create(*CreateRequest) error
+	List() (*ListResponse, error)
+	Get(*GetRequest) (*GetResponse, error)
+	Remove(*RemoveRequest) error
+	Path(*PathRequest) (*PathResponse, error)
+	Mount(*MountRequest) (*MountResponse, error)
+	Unmount(*UnmountRequest) error
+	Capabilities() *CapabilitiesResponse
+}
+
+// Handler forwards requests and responses between the docker daemon and the plugin.
+type Handler struct {
+	driver Driver
+	sdk.Handler
+}
+
+// NewHandler initializes the request handler with a driver implementation.
+func NewHandler(driver Driver) *Handler {
+	h := &Handler{driver, sdk.NewHandler(manifest)}
+	h.initMux()
+	return h
+}
+
+func (h *Handler) initMux() {
+	h.HandleFunc(createPath, func(w http.ResponseWriter, r *http.Request) {
+		log.Println("Entering go-plugins-helpers createPath")
+		req := &CreateRequest{}
+		err := sdk.DecodeRequest(w, r, req)
+		if err != nil {
+			return
+		}
+		err = h.driver.Create(req)
+		if err != nil {
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
+			return
+		}
+		sdk.EncodeResponse(w, struct{}{}, false)
+	})
+	h.HandleFunc(removePath, func(w http.ResponseWriter, r *http.Request) {
+		log.Println("Entering go-plugins-helpers removePath")
+		req := &RemoveRequest{}
+		err := sdk.DecodeRequest(w, r, req)
+		if err != nil {
+			return
+		}
+		err = h.driver.Remove(req)
+		if err != nil {
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
+			return
+		}
+		sdk.EncodeResponse(w, struct{}{}, false)
+	})
+	h.HandleFunc(mountPath, func(w http.ResponseWriter, r *http.Request) {
+		log.Println("Entering go-plugins-helpers mountPath")
+		req := &MountRequest{}
+		err := sdk.DecodeRequest(w, r, req)
+		if err != nil {
+			return
+		}
+		res, err := h.driver.Mount(req)
+		if err != nil {
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
+			return
+		}
+		sdk.EncodeResponse(w, res, false)
+	})
+	h.HandleFunc(hostVirtualPath, func(w http.ResponseWriter, r *http.Request) {
+		log.Println("Entering go-plugins-helpers hostVirtualPath")
+		req := &PathRequest{}
+		err := sdk.DecodeRequest(w, r, req)
+		if err != nil {
+			return
+		}
+		res, err := h.driver.Path(req)
+		if err != nil {
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
+			return
+		}
+		sdk.EncodeResponse(w, res, false)
+	})
+	h.HandleFunc(getPath, func(w http.ResponseWriter, r *http.Request) {
+		log.Println("Entering go-plugins-helpers getPath")
+		req := &GetRequest{}
+		err := sdk.DecodeRequest(w, r, req)
+		if err != nil {
+			return
+		}
+		res, err := h.driver.Get(req)
+		if err != nil {
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
+			return
+		}
+		sdk.EncodeResponse(w, res, false)
+	})
+	h.HandleFunc(unmountPath, func(w http.ResponseWriter, r *http.Request) {
+		log.Println("Entering go-plugins-helpers unmountPath")
+		req := &UnmountRequest{}
+		err := sdk.DecodeRequest(w, r, req)
+		if err != nil {
+			return
+		}
+		err = h.driver.Unmount(req)
+		if err != nil {
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
+			return
+		}
+		sdk.EncodeResponse(w, struct{}{}, false)
+	})
+	h.HandleFunc(listPath, func(w http.ResponseWriter, r *http.Request) {
+		log.Println("Entering go-plugins-helpers listPath")
+		res, err := h.driver.List()
+		if err != nil {
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
+			return
+		}
+		sdk.EncodeResponse(w, res, false)
+	})
+
+	h.HandleFunc(capabilitiesPath, func(w http.ResponseWriter, r *http.Request) {
+		log.Println("Entering go-plugins-helpers capabilitiesPath")
+		sdk.EncodeResponse(w, h.driver.Capabilities(), false)
+	})
+}

--- a/agent/volumes/amazon-ecs-volume-plugin/plugin.go
+++ b/agent/volumes/amazon-ecs-volume-plugin/plugin.go
@@ -1,0 +1,39 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package main
+
+import (
+	"os"
+	"os/user"
+	"strconv"
+
+	"github.com/aws/amazon-ecs-agent/agent/volumes"
+	"github.com/aws/amazon-ecs-agent/agent/volumes/logger"
+	"github.com/cihub/seelog"
+	"github.com/docker/go-plugins-helpers/volume"
+)
+
+func main() {
+	plugin := volumes.NewAmazonECSVolumePlugin()
+	logger.Setup()
+	defer seelog.Flush()
+	if err := plugin.LoadState(); err != nil {
+		os.Exit(1)
+	}
+	handler := volume.NewHandler(plugin)
+	rootUser, _ := user.Lookup("root")
+	gid, _ := strconv.Atoi(rootUser.Gid)
+	seelog.Info("Starting volume plugin..")
+	handler.ServeUnix("amazon-ecs-volume-plugin", gid)
+}

--- a/agent/volumes/ecs_volume_driver.go
+++ b/agent/volumes/ecs_volume_driver.go
@@ -1,0 +1,115 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package volumes
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/cihub/seelog"
+)
+
+// TODO: might be a good idea to check the mount point with a tool like mountpoint instead of matching error message.
+const notMountedErrMsg = "not mounted"
+
+// ECSVolumeDriver holds mount helper and methods for different Volume Mounts
+type ECSVolumeDriver struct {
+	volumeMounts map[string]*MountHelper
+	lock         sync.RWMutex
+}
+
+// NewECSVolumeDriver initializes fields for volume mounts
+func NewECSVolumeDriver() *ECSVolumeDriver {
+	return &ECSVolumeDriver{
+		volumeMounts: make(map[string]*MountHelper),
+	}
+}
+
+// Setup creates the mount helper
+func (e *ECSVolumeDriver) Setup(name string, v *Volume) {
+	e.lock.Lock()
+	defer e.lock.Unlock()
+
+	if _, ok := e.volumeMounts[name]; ok {
+		seelog.Warnf("Volume %s mount already exists", name)
+	}
+	mnt := setOptions(v.Options)
+
+	mnt.Target = v.Path
+	e.volumeMounts[name] = mnt
+}
+
+// Create implements ECSVolumeDriver's Create volume method
+func (e *ECSVolumeDriver) Create(r *CreateRequest) error {
+	e.lock.Lock()
+	defer e.lock.Unlock()
+
+	if _, ok := e.volumeMounts[r.Name]; ok {
+		return fmt.Errorf("volume already exists")
+	}
+
+	mnt := setOptions(r.Options)
+	mnt.Target = r.Path
+
+	seelog.Infof("Validating create options for volume %s", r.Name)
+	if err := mnt.Validate(); err != nil {
+		return err
+	}
+
+	seelog.Infof("Mounting volume %s of type %s at path %s", r.Name, mnt.MountType, mnt.Target)
+	err := mnt.Mount()
+	if err != nil {
+		return fmt.Errorf("mounting volume failed: %v", err)
+	}
+	e.volumeMounts[r.Name] = mnt
+	return nil
+}
+
+func setOptions(options map[string]string) *MountHelper {
+	mnt := &MountHelper{}
+	for k, v := range options {
+		switch k {
+		case "type":
+			mnt.MountType = v
+		case "o":
+			mnt.Options = v
+		case "device":
+			mnt.Device = v
+		}
+	}
+	return mnt
+}
+
+// Remove implements ECSVolumeDriver's Remove volume method
+func (e *ECSVolumeDriver) Remove(req *RemoveRequest) error {
+	e.lock.Lock()
+	defer e.lock.Unlock()
+	mnt, ok := e.volumeMounts[req.Name]
+	if !ok {
+		return fmt.Errorf("volume not found")
+	}
+	err := mnt.Unmount()
+	if err != nil {
+		if strings.Contains(err.Error(), notMountedErrMsg) {
+			seelog.Infof("Unmounting volume %s failed because it's not mounted.", req.Name)
+			delete(e.volumeMounts, req.Name)
+			return nil
+		}
+		return fmt.Errorf("unmounting volume failed: %v", err)
+	}
+	delete(e.volumeMounts, req.Name)
+	seelog.Infof("Unmounted volume %s successfully.", req.Name)
+	return err
+}

--- a/agent/volumes/ecs_volume_driver_test.go
+++ b/agent/volumes/ecs_volume_driver_test.go
@@ -1,0 +1,179 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package volumes
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVolumeDriverCreateHappyPath(t *testing.T) {
+	e := NewECSVolumeDriver()
+	req := CreateRequest{
+		Name: "vol",
+		Path: VolumeMountPathPrefix + "vol",
+		Options: map[string]string{
+			"type":   "efs",
+			"o":      "tls",
+			"device": "fs-123",
+		},
+	}
+	runMount = func([]string) error {
+		return nil
+	}
+	defer func() {
+		runMount = runMountCommand
+	}()
+	assert.NoError(t, e.Create(&req))
+	assert.Len(t, e.volumeMounts, 1)
+}
+
+func TestVolumeDriverCreateFailure(t *testing.T) {
+	e := NewECSVolumeDriver()
+	req := CreateRequest{
+		Name: "vol",
+		Path: VolumeMountPathPrefix + "vol",
+		Options: map[string]string{
+			"type":   "efs",
+			"o":      "tls",
+			"device": "fs-123",
+		},
+	}
+	runMount = func([]string) error {
+		return errors.New("cannot mount")
+	}
+	defer func() {
+		runMount = runMountCommand
+	}()
+	assert.Error(t, e.Create(&req), "expected error when volume cannot be mounted")
+	assert.Len(t, e.volumeMounts, 0)
+}
+
+func TestCreateVolumeExists(t *testing.T) {
+	e := NewECSVolumeDriver()
+	e.volumeMounts["vol"] = &MountHelper{}
+	req := CreateRequest{
+		Name: "vol",
+		Path: VolumeMountPathPrefix + "vol",
+		Options: map[string]string{
+			"type":   "efs",
+			"o":      "tls",
+			"device": "fs-123",
+		},
+	}
+	assert.Error(t, e.Create(&req))
+	assert.Len(t, e.volumeMounts, 1)
+}
+
+func TestCreateVolumeMissingOption(t *testing.T) {
+	e := NewECSVolumeDriver()
+	req := CreateRequest{
+		Name: "vol",
+		Path: VolumeMountPathPrefix + "vol",
+		Options: map[string]string{
+			"type": "efs",
+			"o":    "tls",
+		},
+	}
+	assert.Error(t, e.Create(&req), "expected error when missing device ID")
+	assert.Len(t, e.volumeMounts, 0)
+}
+
+func TestRemoveVolumeHappyPath(t *testing.T) {
+	e := NewECSVolumeDriver()
+	e.volumeMounts["vol"] = &MountHelper{}
+	req := RemoveRequest{
+		Name: "vol",
+	}
+	lookPath = func(string) (string, error) {
+		return "path", nil
+	}
+	runUnmount = func(string, string) error {
+		return nil
+	}
+	defer func() {
+		lookPath = getPath
+		runUnmount = runUnmountCommand
+	}()
+	assert.NoError(t, e.Remove(&req))
+	assert.Len(t, e.volumeMounts, 0)
+}
+
+func TestRemoveVolumeUnmounted(t *testing.T) {
+	e := NewECSVolumeDriver()
+	e.volumeMounts["vol"] = &MountHelper{}
+	req := RemoveRequest{
+		Name: "vol",
+	}
+	lookPath = func(string) (string, error) {
+		return "path", nil
+	}
+	runUnmount = func(string, string) error {
+		return errors.New("not mounted")
+	}
+	defer func() {
+		lookPath = getPath
+		runUnmount = runUnmountCommand
+	}()
+	assert.NoError(t, e.Remove(&req), "expected no error when unmount failed because of not mounted")
+	assert.Len(t, e.volumeMounts, 0)
+}
+
+func TestRemoveUnmountFailure(t *testing.T) {
+	e := NewECSVolumeDriver()
+	e.volumeMounts["vol"] = &MountHelper{}
+	req := RemoveRequest{
+		Name: "vol",
+	}
+	lookPath = func(string) (string, error) {
+		return "path", nil
+	}
+	runUnmount = func(string, string) error {
+		return errors.New("cannot unmount")
+	}
+	defer func() {
+		lookPath = getPath
+		runUnmount = runUnmountCommand
+	}()
+	assert.Error(t, e.Remove(&req), "expected error when unmount fails")
+	assert.Len(t, e.volumeMounts, 1)
+}
+
+func TestRemoveUnmountNotFound(t *testing.T) {
+	e := NewECSVolumeDriver()
+	e.volumeMounts["vol"] = &MountHelper{}
+	req := RemoveRequest{
+		Name: "vol",
+	}
+	lookPath = func(string) (string, error) {
+		return "", errors.New("unmount binary not found")
+	}
+	defer func() {
+		lookPath = getPath
+	}()
+	assert.Error(t, e.Remove(&req), "expected error when unmount binary not found")
+	assert.Len(t, e.volumeMounts, 1)
+}
+
+func TestRemoveVolumeNotPresent(t *testing.T) {
+	e := NewECSVolumeDriver()
+	e.volumeMounts["vol"] = &MountHelper{}
+	req := RemoveRequest{
+		Name: "vol1",
+	}
+	assert.Error(t, e.Remove(&req), "expected error when volume to remove is not found")
+	assert.Len(t, e.volumeMounts, 1)
+}

--- a/agent/volumes/ecs_volume_plugin.go
+++ b/agent/volumes/ecs_volume_plugin.go
@@ -1,0 +1,350 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package volumes
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/cihub/seelog"
+	"github.com/docker/go-plugins-helpers/volume"
+)
+
+const (
+	// VolumeMountPathPrefix is the host path where amazon ECS plugin's volumes are mounted
+	VolumeMountPathPrefix = "/var/lib/ecs/volumes/"
+	// FilePerm is the file permissions for the host volume mount directory
+	FilePerm          = 0700
+	defaultDriverType = "efs"
+)
+
+// AmazonECSVolumePlugin holds list of volume drivers and volumes information
+type AmazonECSVolumePlugin struct {
+	volumeDrivers map[string]VolumeDriver
+	volumes       map[string]*Volume
+	state         *StateManager
+	lock          sync.RWMutex
+}
+
+// NewAmazonECSVolumePlugin initiates the volume drivers
+func NewAmazonECSVolumePlugin() *AmazonECSVolumePlugin {
+	plugin := &AmazonECSVolumePlugin{
+		volumeDrivers: map[string]VolumeDriver{
+			"efs": NewECSVolumeDriver(),
+		},
+		volumes: make(map[string]*Volume),
+		state:   NewStateManager(),
+	}
+	return plugin
+}
+
+// VolumeDriver contains the methods for volume drivers to implement
+type VolumeDriver interface {
+	Setup(string, *Volume)
+	Create(*CreateRequest) error
+	Remove(*RemoveRequest) error
+}
+
+// Volume holds full details about a volume
+type Volume struct {
+	Type      string
+	Path      string
+	Options   map[string]string
+	CreatedAt string
+}
+
+// CreateRequest holds fields necessary for creating a volume
+type CreateRequest struct {
+	Name    string
+	Path    string
+	Options map[string]string
+}
+
+// RemoveRequest holds fields necessary for removing a volume
+type RemoveRequest struct {
+	Name string
+}
+
+// LoadState loads past state information of the plugin
+func (a *AmazonECSVolumePlugin) LoadState() error {
+	a.lock.Lock()
+	defer a.lock.Unlock()
+	seelog.Info("Loading plugin state information")
+	oldState := &VolumeState{}
+	if !fileExists(PluginStateFileAbsPath) {
+		return nil
+	}
+	if err := a.state.load(oldState); err != nil {
+		seelog.Errorf("Could not load state: %v", err)
+		return fmt.Errorf("could not load plugin state: %v", err)
+	}
+	// empty state file
+	if oldState.Volumes == nil {
+		return nil
+	}
+	for volName, vol := range oldState.Volumes {
+		voldriver, err := a.getVolumeDriver(vol.Type)
+		if err != nil {
+			seelog.Errorf("Could not load state: %v", err)
+			return fmt.Errorf("could not load plugin state: %v", err)
+		}
+		volume := &Volume{
+			Type:      vol.Type,
+			Path:      vol.Path,
+			Options:   vol.Options,
+			CreatedAt: vol.CreatedAt,
+		}
+		a.volumes[volName] = volume
+		voldriver.Setup(volName, volume)
+	}
+	a.state.VolState = oldState
+	return nil
+}
+
+func (a *AmazonECSVolumePlugin) getVolumeDriver(driverType string) (VolumeDriver, error) {
+	if driverType == "" {
+		return a.volumeDrivers[defaultDriverType], nil
+	}
+	if _, ok := a.volumeDrivers[driverType]; !ok {
+		return nil, fmt.Errorf("volume %s type not supported", driverType)
+	}
+	return a.volumeDrivers[driverType], nil
+}
+
+// Create implements Docker volume plugin's Create Method
+func (a *AmazonECSVolumePlugin) Create(r *volume.CreateRequest) error {
+	a.lock.Lock()
+	defer a.lock.Unlock()
+
+	seelog.Infof("Creating new volume %s", r.Name)
+	_, ok := a.volumes[r.Name]
+	if ok {
+		return fmt.Errorf("volume %s already exists", r.Name)
+	}
+
+	// get driver type from options to get the corresponding volume driver
+	var driverType, target string
+	for k, v := range r.Options {
+		switch k {
+		case "type":
+			driverType = v
+		case "target":
+			target = v
+		}
+	}
+	volDriver, err := a.getVolumeDriver(driverType)
+	if err != nil {
+		seelog.Errorf("Volume %s's driver type %s not supported", r.Name, driverType)
+		return err
+	}
+	if volDriver == nil {
+		// this case should not happen normally
+		return fmt.Errorf("no volume driver found for type %s", driverType)
+	}
+
+	if target == "" {
+		seelog.Infof("Creating mount target for new volume %s", r.Name)
+		// create the mount path on the host for the volume to be created
+		target, err = a.GetMountPath(r.Name)
+		if err != nil {
+			seelog.Errorf("Volume %s creation failure: %v", r.Name, err)
+			return err
+		}
+	}
+
+	req := &CreateRequest{
+		Name:    r.Name,
+		Path:    target,
+		Options: r.Options,
+	}
+	err = volDriver.Create(req)
+	if err != nil {
+		seelog.Errorf("Volume %s creation failure: %v", r.Name, err)
+		cErr := a.CleanupMountPath(target)
+		if cErr != nil {
+			seelog.Warnf("Failed to cleanup mount path for volume %s: %v", r.Name, cErr)
+		}
+		return err
+	}
+	seelog.Infof("Volume %s created successfully", r.Name)
+	vol := &Volume{
+		Type:      driverType,
+		Path:      target,
+		Options:   r.Options,
+		CreatedAt: time.Now().Format(time.RFC3339Nano),
+	}
+	// record the volume information
+	a.volumes[r.Name] = vol
+	seelog.Infof("Saving state of new volume %s", r.Name)
+	// save the state of new volume
+	err = a.state.recordVolume(r.Name, vol)
+	if err != nil {
+		seelog.Errorf("Error saving state of new volume %s: %v", r.Name, err)
+	}
+	return nil
+}
+
+// GetMountPath returns the host path where volume will be mounted
+func (a *AmazonECSVolumePlugin) GetMountPath(name string) (string, error) {
+	path := VolumeMountPathPrefix + name
+	err := createMountPath(path)
+	if err != nil {
+		return "", fmt.Errorf("cannot create mount point: %v", err)
+	}
+	return path, nil
+}
+
+var createMountPath = createMountDir
+
+func createMountDir(path string) error {
+	return os.MkdirAll(path, FilePerm)
+}
+
+// CleanupMountPath cleans up the volume's host path
+func (a *AmazonECSVolumePlugin) CleanupMountPath(name string) error {
+	return removeMountPath(name)
+}
+
+var removeMountPath = deleteMountPath
+
+func deleteMountPath(path string) error {
+	return os.Remove(path)
+}
+
+// Mount implements Docker volume plugin's Mount Method
+func (a *AmazonECSVolumePlugin) Mount(r *volume.MountRequest) (*volume.MountResponse, error) {
+	a.lock.RLock()
+	defer a.lock.RUnlock()
+	vol, ok := a.volumes[r.Name]
+	if !ok {
+		seelog.Errorf("Volume %s to mount is not found", r.Name)
+		return nil, fmt.Errorf("volume %s not found", r.Name)
+	}
+	return &volume.MountResponse{Mountpoint: vol.Path}, nil
+}
+
+// Unmount implements Docker volume plugin's Unmount Method
+func (a *AmazonECSVolumePlugin) Unmount(r *volume.UnmountRequest) error {
+	a.lock.RLock()
+	defer a.lock.RUnlock()
+	_, ok := a.volumes[r.Name]
+	if !ok {
+		seelog.Errorf("Volume %s to unmount is not found", r.Name)
+		return fmt.Errorf("volume %s not found", r.Name)
+	}
+	return nil
+}
+
+// Remove implements Docker volume plugin's Remove Method
+func (a *AmazonECSVolumePlugin) Remove(r *volume.RemoveRequest) error {
+	a.lock.Lock()
+	defer a.lock.Unlock()
+	seelog.Infof("Removing volume %s", r.Name)
+	vol, ok := a.volumes[r.Name]
+	if !ok {
+		seelog.Errorf("Volume %s to remove is not found", r.Name)
+		return fmt.Errorf("volume %s not found", r.Name)
+	}
+
+	// get corresponding volume driver to unmount
+	volDriver, err := a.getVolumeDriver(vol.Type)
+	if err != nil {
+		seelog.Errorf("Volume %s removal failure: %s", r.Name, err)
+		return err
+	}
+	if volDriver == nil {
+		// this case should not happen normally
+		return fmt.Errorf("no corresponding volume driver found for type %s", vol.Type)
+	}
+
+	req := &RemoveRequest{
+		Name: r.Name,
+	}
+	err = volDriver.Remove(req)
+	if err != nil {
+		seelog.Errorf("Volume %s removal failure: %v", r.Name, err)
+		return err
+	}
+
+	// remove the volume information
+	delete(a.volumes, r.Name)
+	// cleanup the volume's host mount path
+	err = a.CleanupMountPath(vol.Path)
+	if err != nil {
+		seelog.Errorf("Cleaning mount path failed for volume %s: %v", r.Name, err)
+	}
+	seelog.Infof("Saving state after removing volume %s", r.Name)
+	// remove the state of deleted volume
+	err = a.state.removeVolume(r.Name)
+	if err != nil {
+		seelog.Errorf("Error saving state after removing volume %s: %v", r.Name, err)
+	}
+	return nil
+}
+
+// List implements Docker volume plugin's List Method
+func (a *AmazonECSVolumePlugin) List() (*volume.ListResponse, error) {
+	a.lock.RLock()
+	defer a.lock.RUnlock()
+	vols := make([]*volume.Volume, len(a.volumes))
+	i := 0
+	for volName := range a.volumes {
+		vols[i] = &volume.Volume{
+			Name: volName,
+		}
+		i++
+	}
+	res := &volume.ListResponse{
+		Volumes: vols,
+	}
+	return res, nil
+}
+
+// Get implements Docker volume plugin's Get Method
+func (a *AmazonECSVolumePlugin) Get(r *volume.GetRequest) (*volume.GetResponse, error) {
+	a.lock.RLock()
+	defer a.lock.RUnlock()
+	vol, ok := a.volumes[r.Name]
+	if !ok {
+		return nil, fmt.Errorf("volume %s not found", r.Name)
+	}
+	resp := &volume.Volume{
+		Name:       r.Name,
+		Mountpoint: vol.Path,
+		CreatedAt:  vol.CreatedAt,
+	}
+	seelog.Infof("Returning volume information for %s", resp.Name)
+	return &volume.GetResponse{Volume: resp}, nil
+}
+
+// Path implements Docker volume plugin's Path Method
+func (a *AmazonECSVolumePlugin) Path(r *volume.PathRequest) (*volume.PathResponse, error) {
+	a.lock.RLock()
+	defer a.lock.RUnlock()
+	vol, ok := a.volumes[r.Name]
+	if !ok {
+		seelog.Errorf("Could not find mount path for volume %s", r.Name)
+		return nil, fmt.Errorf("volume %s not found", r.Name)
+	}
+
+	return &volume.PathResponse{Mountpoint: vol.Path}, nil
+}
+
+// Capabilities implements Docker volume plugin's Capabilities Method
+func (a *AmazonECSVolumePlugin) Capabilities() *volume.CapabilitiesResponse {
+	// Note: This is currently not supported
+	return nil
+}

--- a/agent/volumes/ecs_volume_plugin_test.go
+++ b/agent/volumes/ecs_volume_plugin_test.go
@@ -1,0 +1,743 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package volumes
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/docker/go-plugins-helpers/volume"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestVolumeDriver implements VolumeDriver interface for testing
+type TestVolumeDriver struct{}
+
+func NewTestVolumeDriver() *TestVolumeDriver {
+	return &TestVolumeDriver{}
+}
+
+func (t *TestVolumeDriver) Create(r *CreateRequest) error {
+	return nil
+}
+
+func (t *TestVolumeDriver) Remove(r *RemoveRequest) error {
+	return nil
+}
+
+func (t *TestVolumeDriver) Setup(n string, v *Volume) {
+	return
+}
+
+// TestVolumeDriverError implements VolumeDriver interface for testing
+// Returns error for all methods
+type TestVolumeDriverError struct{}
+
+func NewTestVolumeDriverError() *TestVolumeDriverError {
+	return &TestVolumeDriverError{}
+}
+
+func (t *TestVolumeDriverError) Create(r *CreateRequest) error {
+	return errors.New("create error")
+}
+
+func (t *TestVolumeDriverError) Remove(r *RemoveRequest) error {
+	return errors.New("remove error")
+}
+
+func (t *TestVolumeDriverError) Setup(n string, v *Volume) {
+	return
+}
+
+func TestVolumeCreateHappyPath(t *testing.T) {
+	plugin := &AmazonECSVolumePlugin{
+		volumeDrivers: map[string]VolumeDriver{
+			"efs": NewTestVolumeDriver(),
+		},
+		volumes: make(map[string]*Volume),
+		state:   NewStateManager(),
+	}
+	req := &volume.CreateRequest{
+		Name: "vol",
+		Options: map[string]string{
+			"type": "efs",
+		},
+	}
+	createMountPath = func(path string) error {
+		return nil
+	}
+	saveStateToDisk = func(b []byte) error {
+		return nil
+	}
+	defer func() {
+		createMountPath = createMountDir
+		saveStateToDisk = saveState
+	}()
+	err := plugin.Create(req)
+	assert.NoError(t, err, "create volume should be successful")
+	assert.Len(t, plugin.volumes, 1)
+	vol, ok := plugin.volumes["vol"]
+	assert.True(t, ok)
+	assert.Equal(t, "efs", vol.Type)
+	assert.Equal(t, VolumeMountPathPrefix+"vol", vol.Path)
+	assert.NotEmpty(t, vol.CreatedAt)
+	assert.Len(t, plugin.state.VolState.Volumes, 1)
+	volInfo, ok := plugin.state.VolState.Volumes["vol"]
+	assert.True(t, ok)
+	assert.Equal(t, "efs", volInfo.Type)
+	assert.Equal(t, VolumeMountPathPrefix+"vol", volInfo.Path)
+	assert.Equal(t, vol.CreatedAt, volInfo.CreatedAt)
+}
+
+func TestVolumeCreateTargetSpecified(t *testing.T) {
+	plugin := &AmazonECSVolumePlugin{
+		volumeDrivers: map[string]VolumeDriver{
+			"efs": NewTestVolumeDriver(),
+		},
+		volumes: make(map[string]*Volume),
+		state:   NewStateManager(),
+	}
+	req := &volume.CreateRequest{
+		Name: "vol",
+		Options: map[string]string{
+			"type":   "efs",
+			"target": "/foo",
+		},
+	}
+	saveStateToDisk = func(b []byte) error {
+		return nil
+	}
+	defer func() {
+		saveStateToDisk = saveState
+	}()
+	err := plugin.Create(req)
+	assert.NoError(t, err, "create volume should be successful")
+	assert.Len(t, plugin.volumes, 1)
+	vol, ok := plugin.volumes["vol"]
+	assert.True(t, ok)
+	assert.Equal(t, "efs", vol.Type)
+	assert.Equal(t, "/foo", vol.Path)
+	assert.Len(t, plugin.state.VolState.Volumes, 1)
+	volInfo, ok := plugin.state.VolState.Volumes["vol"]
+	assert.True(t, ok)
+	assert.Equal(t, "efs", volInfo.Type)
+	assert.Equal(t, "/foo", volInfo.Path)
+}
+
+func TestVolumeCreateSaveFailure(t *testing.T) {
+	plugin := &AmazonECSVolumePlugin{
+		volumeDrivers: map[string]VolumeDriver{
+			"efs": NewTestVolumeDriver(),
+		},
+		volumes: make(map[string]*Volume),
+		state:   NewStateManager(),
+	}
+	req := &volume.CreateRequest{
+		Name: "vol",
+		Options: map[string]string{
+			"type": "efs",
+		},
+	}
+	createMountPath = func(path string) error {
+		return nil
+	}
+	saveStateToDisk = func(b []byte) error {
+		return errors.New("save to disk failure")
+	}
+	defer func() {
+		createMountPath = createMountDir
+		saveStateToDisk = saveState
+	}()
+	err := plugin.Create(req)
+	assert.NoError(t, err, "create volume successful but save state failed")
+	assert.Len(t, plugin.volumes, 1)
+	vol, ok := plugin.volumes["vol"]
+	assert.True(t, ok)
+	assert.Equal(t, "efs", vol.Type)
+	assert.Equal(t, VolumeMountPathPrefix+"vol", vol.Path)
+	assert.Len(t, plugin.state.VolState.Volumes, 1)
+	volInfo, ok := plugin.state.VolState.Volumes["vol"]
+	assert.True(t, ok)
+	assert.Equal(t, "efs", volInfo.Type)
+	assert.Equal(t, VolumeMountPathPrefix+"vol", volInfo.Path)
+}
+
+func TestVolumeCreateFailure(t *testing.T) {
+	plugin := &AmazonECSVolumePlugin{
+		volumeDrivers: map[string]VolumeDriver{
+			"efs": NewTestVolumeDriverError(),
+		},
+		volumes: make(map[string]*Volume),
+	}
+	req := &volume.CreateRequest{
+		Name: "vol",
+		Options: map[string]string{
+			"type": "efs",
+		},
+	}
+	createMountPath = func(path string) error {
+		return nil
+	}
+
+	var removeInvoked bool
+	removeMountPath = func(path string) error {
+		removeInvoked = true
+		return nil
+	}
+	defer func() {
+		createMountPath = createMountDir
+		removeMountPath = deleteMountPath
+	}()
+	assert.Error(t, plugin.Create(req), "expected error while creating volume")
+	assert.Len(t, plugin.volumes, 0)
+	assert.True(t, removeInvoked)
+}
+
+func TestCreateNoVolumeType(t *testing.T) {
+	plugin := &AmazonECSVolumePlugin{
+		volumeDrivers: map[string]VolumeDriver{
+			"efs": NewTestVolumeDriver(),
+		},
+		volumes: make(map[string]*Volume),
+		state:   NewStateManager(),
+	}
+	req := &volume.CreateRequest{
+		Name: "vol",
+	}
+	createMountPath = func(path string) error {
+		return nil
+	}
+	saveStateToDisk = func(b []byte) error {
+		return nil
+	}
+	defer func() {
+		createMountPath = createMountDir
+		saveStateToDisk = saveState
+	}()
+	assert.NoError(t, plugin.Create(req), "expected no create error when no volume type specified")
+	assert.Len(t, plugin.volumes, 1)
+}
+
+func TestCreateNoDriverFailure(t *testing.T) {
+	plugin := &AmazonECSVolumePlugin{
+		volumeDrivers: map[string]VolumeDriver{},
+		volumes:       make(map[string]*Volume),
+	}
+	req := &volume.CreateRequest{
+		Name: "vol",
+		Options: map[string]string{
+			"type": "efs",
+		},
+	}
+	assert.Error(t, plugin.Create(req), "expected create error when no corresponding volume driver present")
+	assert.Len(t, plugin.volumes, 0)
+}
+
+func TestCreateMountCreationFailure(t *testing.T) {
+	plugin := &AmazonECSVolumePlugin{
+		volumeDrivers: map[string]VolumeDriver{
+			"efs": NewTestVolumeDriverError(),
+		},
+		volumes: make(map[string]*Volume),
+	}
+	req := &volume.CreateRequest{
+		Name: "vol",
+		Options: map[string]string{
+			"type": "efs",
+		},
+	}
+	createMountPath = func(path string) error {
+		return errors.New("cannot create mount path")
+	}
+	defer func() {
+		createMountPath = createMountDir
+	}()
+	assert.Error(t, plugin.Create(req), "expected create error when mount path cannot be created")
+	assert.Len(t, plugin.volumes, 0)
+}
+
+func TestGetMountPathSuccess(t *testing.T) {
+	plugin := &AmazonECSVolumePlugin{
+		volumeDrivers: map[string]VolumeDriver{},
+		volumes:       make(map[string]*Volume),
+	}
+	createMountPath = func(path string) error {
+		return nil
+	}
+	defer func() {
+		createMountPath = createMountDir
+	}()
+	path, err := plugin.GetMountPath("vol")
+	assert.NoError(t, err)
+	assert.Equal(t, VolumeMountPathPrefix+"vol", path)
+}
+
+func TestGetMountPathFailure(t *testing.T) {
+	plugin := &AmazonECSVolumePlugin{
+		volumeDrivers: map[string]VolumeDriver{},
+		volumes:       make(map[string]*Volume),
+	}
+	createMountPath = func(path string) error {
+		return errors.New("cannot create mount path")
+	}
+	defer func() {
+		createMountPath = createMountDir
+	}()
+	path, err := plugin.GetMountPath("vol")
+	assert.Error(t, err, "expected error when mount path cannot be created")
+	assert.Empty(t, path)
+}
+
+func TestCleanMountPathSuccess(t *testing.T) {
+	plugin := &AmazonECSVolumePlugin{
+		volumeDrivers: map[string]VolumeDriver{},
+		volumes:       make(map[string]*Volume),
+	}
+	removeMountPath = func(path string) error {
+		return nil
+	}
+	defer func() {
+		removeMountPath = deleteMountPath
+	}()
+	assert.NoError(t, plugin.CleanupMountPath("vol"))
+}
+
+func TestCleanMountPathFailure(t *testing.T) {
+	plugin := &AmazonECSVolumePlugin{
+		volumeDrivers: map[string]VolumeDriver{},
+		volumes:       make(map[string]*Volume),
+	}
+	removeMountPath = func(path string) error {
+		return errors.New("cannot remove dir")
+	}
+	defer func() {
+		removeMountPath = deleteMountPath
+	}()
+	assert.Error(t, plugin.CleanupMountPath("vol"), "expected error when host mount path cannot be removed")
+}
+
+func TestVolumeMountSuccess(t *testing.T) {
+	volName := "vol"
+	path := VolumeMountPathPrefix + volName
+	vol := &Volume{
+		Path: path,
+	}
+	plugin := &AmazonECSVolumePlugin{
+		volumeDrivers: map[string]VolumeDriver{},
+		volumes: map[string]*Volume{
+			volName: vol,
+		},
+	}
+	req := &volume.MountRequest{Name: volName}
+	res, err := plugin.Mount(req)
+	assert.NoError(t, err)
+	assert.Equal(t, path, res.Mountpoint)
+}
+
+func TestVolumeMountFailure(t *testing.T) {
+	volName := "vol"
+	plugin := &AmazonECSVolumePlugin{
+		volumeDrivers: map[string]VolumeDriver{},
+		volumes:       map[string]*Volume{},
+	}
+	req := &volume.MountRequest{Name: volName}
+	res, err := plugin.Mount(req)
+	assert.Error(t, err)
+	assert.Nil(t, res)
+}
+
+func TestVolumeUnmountSuccess(t *testing.T) {
+	volName := "vol"
+	path := VolumeMountPathPrefix + volName
+	vol := &Volume{
+		Path: path,
+	}
+	plugin := &AmazonECSVolumePlugin{
+		volumeDrivers: map[string]VolumeDriver{},
+		volumes: map[string]*Volume{
+			volName: vol,
+		},
+	}
+	req := &volume.UnmountRequest{Name: volName}
+	assert.NoError(t, plugin.Unmount(req))
+}
+
+func TestVolumeUnmountFailure(t *testing.T) {
+	volName := "vol"
+	plugin := &AmazonECSVolumePlugin{
+		volumeDrivers: map[string]VolumeDriver{},
+		volumes:       map[string]*Volume{},
+	}
+	req := &volume.UnmountRequest{Name: volName}
+	assert.Error(t, plugin.Unmount(req), "expected error when volume to unmount is not present")
+}
+
+func TestVolumeRemoveHappyPath(t *testing.T) {
+	volName := "vol"
+	path := VolumeMountPathPrefix + volName
+	vol := &Volume{
+		Path: path,
+		Type: "efs",
+	}
+	plugin := &AmazonECSVolumePlugin{
+		volumeDrivers: map[string]VolumeDriver{
+			"efs": NewTestVolumeDriver(),
+		},
+		volumes: map[string]*Volume{
+			volName: vol,
+		},
+		state: NewStateManager(),
+	}
+	req := &volume.RemoveRequest{Name: volName}
+	removeMountPath = func(path string) error {
+		return nil
+	}
+	saveStateToDisk = func(b []byte) error {
+		return nil
+	}
+	defer func() {
+		removeMountPath = deleteMountPath
+		saveStateToDisk = saveState
+	}()
+	assert.NoError(t, plugin.Remove(req))
+	assert.Len(t, plugin.volumes, 0)
+	assert.Len(t, plugin.state.VolState.Volumes, 0)
+}
+
+func TestVolumeRemoveFailure(t *testing.T) {
+	volName := "vol"
+	path := VolumeMountPathPrefix + volName
+	vol := &Volume{
+		Path: path,
+		Type: "efs",
+	}
+	plugin := &AmazonECSVolumePlugin{
+		volumeDrivers: map[string]VolumeDriver{
+			"efs": NewTestVolumeDriverError(),
+		},
+		volumes: map[string]*Volume{
+			volName: vol,
+		},
+		state: NewStateManager(),
+	}
+	saveStateToDisk = func(b []byte) error {
+		return nil
+	}
+	defer func() {
+		saveStateToDisk = saveState
+	}()
+	req := &volume.RemoveRequest{Name: volName}
+	assert.Error(t, plugin.Remove(req), "expected error when remove volume fails")
+	assert.Len(t, plugin.volumes, 1)
+}
+
+func TestRemoveVolumeNotFound(t *testing.T) {
+	plugin := &AmazonECSVolumePlugin{
+		volumeDrivers: map[string]VolumeDriver{
+			"efs": NewTestVolumeDriver(),
+		},
+		volumes: map[string]*Volume{},
+		state:   NewStateManager(),
+	}
+	req := &volume.RemoveRequest{Name: "vol"}
+	assert.Error(t, plugin.Remove(req), "expected error when volume to remove is not found")
+}
+
+func TestRemoveVolumeDriverNotFound(t *testing.T) {
+	volName := "vol"
+	path := VolumeMountPathPrefix + volName
+	vol := &Volume{
+		Path: path,
+		Type: "efs",
+	}
+	plugin := &AmazonECSVolumePlugin{
+		volumeDrivers: map[string]VolumeDriver{
+			"xyz": NewTestVolumeDriver(),
+		},
+		volumes: map[string]*Volume{
+			volName: vol,
+		},
+		state: NewStateManager(),
+	}
+	req := &volume.RemoveRequest{Name: volName}
+	assert.Error(t, plugin.Remove(req), "expected error when corresponding volume driver not found")
+}
+
+func TestVolumeRemoveMountPathFailure(t *testing.T) {
+	volName := "vol"
+	path := VolumeMountPathPrefix + volName
+	vol := &Volume{
+		Path: path,
+		Type: "efs",
+	}
+	plugin := &AmazonECSVolumePlugin{
+		volumeDrivers: map[string]VolumeDriver{
+			"efs": NewTestVolumeDriver(),
+		},
+		volumes: map[string]*Volume{
+			volName: vol,
+		},
+		state: NewStateManager(),
+	}
+	req := &volume.RemoveRequest{Name: volName}
+	removeMountPath = func(path string) error {
+		return errors.New("removing path failed")
+	}
+	saveStateToDisk = func(b []byte) error {
+		return nil
+	}
+	defer func() {
+		removeMountPath = deleteMountPath
+		saveStateToDisk = saveState
+	}()
+	assert.NoError(t, plugin.Remove(req))
+	assert.Len(t, plugin.volumes, 0)
+	assert.Len(t, plugin.state.VolState.Volumes, 0)
+}
+
+func TestVolumeRemoveStateSaveFailure(t *testing.T) {
+	volName := "vol"
+	path := VolumeMountPathPrefix + volName
+	vol := &Volume{
+		Path: path,
+		Type: "efs",
+	}
+	plugin := &AmazonECSVolumePlugin{
+		volumeDrivers: map[string]VolumeDriver{
+			"efs": NewTestVolumeDriver(),
+		},
+		volumes: map[string]*Volume{
+			volName: vol,
+		},
+		state: NewStateManager(),
+	}
+	req := &volume.RemoveRequest{Name: volName}
+	removeMountPath = func(path string) error {
+		return nil
+	}
+	saveStateToDisk = func(b []byte) error {
+		return errors.New("save to disk failed")
+	}
+	defer func() {
+		removeMountPath = deleteMountPath
+		saveStateToDisk = saveState
+	}()
+	assert.NoError(t, plugin.Remove(req))
+	assert.Len(t, plugin.volumes, 0)
+	assert.Len(t, plugin.state.VolState.Volumes, 0)
+}
+
+func TestListVolumes(t *testing.T) {
+	vol := &Volume{}
+	plugin := &AmazonECSVolumePlugin{
+		volumeDrivers: map[string]VolumeDriver{},
+		volumes: map[string]*Volume{
+			"vol":  vol,
+			"vol1": vol,
+			"vol2": vol,
+		},
+	}
+	resp, err := plugin.List()
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(resp.Volumes))
+}
+
+func TestGetVolume(t *testing.T) {
+	vol := &Volume{
+		Path:      "/var/lib/ecs/volume/vol",
+		CreatedAt: "2020-01-17T21:20:04Z",
+	}
+	plugin := &AmazonECSVolumePlugin{
+		volumeDrivers: map[string]VolumeDriver{},
+		volumes: map[string]*Volume{
+			"vol":  vol,
+			"vol1": vol,
+			"vol2": vol,
+		},
+	}
+	req := &volume.GetRequest{Name: "vol1"}
+	resp, err := plugin.Get(req)
+	assert.NoError(t, err)
+	assert.Equal(t, "vol1", resp.Volume.Name)
+	assert.Equal(t, vol.Path, resp.Volume.Mountpoint)
+	assert.Equal(t, vol.CreatedAt, resp.Volume.CreatedAt)
+}
+
+func TestGetVolumeError(t *testing.T) {
+	vol := &Volume{}
+	plugin := &AmazonECSVolumePlugin{
+		volumeDrivers: map[string]VolumeDriver{},
+		volumes: map[string]*Volume{
+			"vol":  vol,
+			"vol1": vol,
+			"vol2": vol,
+		},
+	}
+	req := &volume.GetRequest{Name: "vol4"}
+	_, err := plugin.Get(req)
+	assert.Error(t, err, "expected error when volume info is not found")
+}
+
+func TestVolumePath(t *testing.T) {
+	volName := "vol1"
+	path := VolumeMountPathPrefix + volName
+	vol1 := &Volume{
+		Path: path,
+	}
+	plugin := &AmazonECSVolumePlugin{
+		volumeDrivers: map[string]VolumeDriver{},
+		volumes: map[string]*Volume{
+			"vol":   &Volume{},
+			volName: vol1,
+			"vol2":  &Volume{},
+		},
+	}
+	req := &volume.PathRequest{Name: volName}
+	resp, err := plugin.Path(req)
+	assert.NoError(t, err)
+	assert.Equal(t, path, resp.Mountpoint)
+}
+
+func TestVolumePathError(t *testing.T) {
+	vol := &Volume{}
+	plugin := &AmazonECSVolumePlugin{
+		volumeDrivers: map[string]VolumeDriver{},
+		volumes: map[string]*Volume{
+			"vol":  vol,
+			"vol1": vol,
+			"vol2": vol,
+		},
+	}
+	req := &volume.PathRequest{Name: "vol4"}
+	_, err := plugin.Path(req)
+	assert.Error(t, err, "expected error when volume info is not found")
+}
+
+func TestCapabilities(t *testing.T) {
+	plugin := &AmazonECSVolumePlugin{}
+	resp := plugin.Capabilities()
+	assert.Nil(t, resp)
+}
+
+func TestPluginLoadState(t *testing.T) {
+	plugin := &AmazonECSVolumePlugin{
+		volumeDrivers: map[string]VolumeDriver{
+			"efs": NewECSVolumeDriver(),
+		},
+		volumes: make(map[string]*Volume),
+		state:   NewStateManager(),
+	}
+	fileExists = func(path string) bool {
+		return true
+	}
+	readStateFile = func() ([]byte, error) {
+		return []byte(`{"volumes":{"efsVolume":{"type":"efs","path":"/var/lib/ecs/volumes/efsVolume","options":{"device":"fs-123","o":"tls","type":"efs"}}}}`), nil
+	}
+	defer func() {
+		fileExists = checkFile
+		readStateFile = readFile
+	}()
+	assert.NoError(t, plugin.LoadState(), "expected no error when loading state")
+	assert.Len(t, plugin.volumes, 1)
+	vol, ok := plugin.volumes["efsVolume"]
+	assert.True(t, ok)
+	assert.Equal(t, "efs", vol.Type)
+	assert.Equal(t, VolumeMountPathPrefix+"efsVolume", vol.Path)
+	vols := plugin.state.VolState.Volumes
+	assert.Len(t, vols, 1)
+	volInfo, ok := vols["efsVolume"]
+	assert.True(t, ok)
+	assert.Equal(t, "efs", volInfo.Type)
+	assert.Equal(t, VolumeMountPathPrefix+"efsVolume", volInfo.Path)
+}
+
+func TestPluginNoStateFile(t *testing.T) {
+	plugin := &AmazonECSVolumePlugin{
+		state: NewStateManager(),
+	}
+	fileExists = func(path string) bool {
+		return false
+	}
+	defer func() {
+		fileExists = checkFile
+	}()
+	assert.NoError(t, plugin.LoadState())
+}
+
+func TestPluginInvalidState(t *testing.T) {
+	plugin := &AmazonECSVolumePlugin{
+		state: NewStateManager(),
+	}
+	fileExists = func(path string) bool {
+		return true
+	}
+	readStateFile = func() ([]byte, error) {
+		return []byte(`{"junk"}`), nil
+	}
+	defer func() {
+		fileExists = checkFile
+		readStateFile = readFile
+	}()
+	assert.Error(t, plugin.LoadState(), "expected error when loading invalid state")
+}
+
+func TestPluginEmptyState(t *testing.T) {
+	plugin := &AmazonECSVolumePlugin{
+		volumeDrivers: map[string]VolumeDriver{
+			"efs": NewTestVolumeDriver(),
+		},
+		volumes: make(map[string]*Volume),
+		state:   NewStateManager(),
+	}
+	fileExists = func(path string) bool {
+		return true
+	}
+	readStateFile = func() ([]byte, error) {
+		return []byte(`{}`), nil
+	}
+	defer func() {
+		fileExists = checkFile
+		readStateFile = readFile
+	}()
+	assert.NoError(t, plugin.LoadState(), "expected no error when loading empty state")
+	assert.Len(t, plugin.volumes, 0)
+	req := &volume.CreateRequest{
+		Name: "vol",
+		Options: map[string]string{
+			"type": "efs",
+		},
+	}
+	createMountPath = func(path string) error {
+		return nil
+	}
+	saveStateToDisk = func(b []byte) error {
+		return nil
+	}
+	defer func() {
+		createMountPath = createMountDir
+		saveStateToDisk = saveState
+	}()
+	err := plugin.Create(req)
+	assert.NoError(t, err, "create volume should be successful after loading empty state")
+	assert.Len(t, plugin.volumes, 1)
+	vol, ok := plugin.volumes["vol"]
+	assert.True(t, ok)
+	assert.Equal(t, "efs", vol.Type)
+	assert.Equal(t, VolumeMountPathPrefix+"vol", vol.Path)
+	assert.Len(t, plugin.state.VolState.Volumes, 1)
+	volInfo, ok := plugin.state.VolState.Volumes["vol"]
+	assert.True(t, ok)
+	assert.Equal(t, "efs", volInfo.Type)
+	assert.Equal(t, VolumeMountPathPrefix+"vol", volInfo.Path)
+}

--- a/agent/volumes/efs_mount_helper.go
+++ b/agent/volumes/efs_mount_helper.go
@@ -1,0 +1,111 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package volumes
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+const (
+	// MountBinary is the binary name of EFS Mount
+	MountBinary = "mount"
+	// UnmountBinary is the binary name for EFS Unmount
+	UnmountBinary = "umount"
+)
+
+// MountHelper contains fields and methods for mounting and unmounting EFS volumes
+type MountHelper struct {
+	MountType string
+	Device    string
+	Target    string
+	Options   string
+}
+
+// Mount helps mount EFS volumes
+func (m *MountHelper) Mount() error {
+	args := []string{}
+	if m.MountType != "" {
+		args = append(args, "-t", m.MountType)
+	}
+	if m.Options != "" {
+		args = append(args, "-o", m.Options)
+	}
+	args = append(args, m.Device, m.Target)
+	if err := m.Validate(); err != nil {
+		return err
+	}
+	return runMount(args)
+}
+
+var runMount = runMountCommand
+
+func runMountCommand(args []string) error {
+	mountcmd := exec.Command(MountBinary, args...)
+	return runCmd(mountcmd)
+}
+
+// Validate validates fields as part of the mount command
+func (m *MountHelper) Validate() error {
+	requiredFields := []string{}
+	if m.Device == "" {
+		requiredFields = append(requiredFields, "device")
+	}
+	if m.Target == "" {
+		requiredFields = append(requiredFields, "target")
+	}
+	if len(requiredFields) > 0 {
+		return fmt.Errorf("missing required fields: [%s]", strings.Join(requiredFields, ","))
+	}
+	return nil
+}
+
+// Unmount helps unmount EFS volumes
+func (m *MountHelper) Unmount() error {
+	path, err := lookPath(UnmountBinary)
+	if err != nil {
+		return err
+	}
+	return runUnmount(path, m.Target)
+}
+
+var lookPath = getPath
+
+func getPath(binary string) (string, error) {
+	return exec.LookPath(binary)
+}
+
+var runUnmount = runUnmountCommand
+
+func runUnmountCommand(path string, target string) error {
+	// In case of awsvpc network mode, when we unmount the volume, task network namespace has been deleted
+	// and nfs server is no longer reachable, so umount will hang. Hence doing lazy unmount here.
+	umountCmd := exec.Command(path, "-l", target)
+	return runCmd(umountCmd)
+}
+
+var runCmd = runCommand
+
+func runCommand(cmd *exec.Cmd) error {
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err == nil {
+		return err
+	}
+	return errors.New(stderr.String())
+}

--- a/agent/volumes/efs_mount_helper_test.go
+++ b/agent/volumes/efs_mount_helper_test.go
@@ -1,0 +1,108 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package volumes
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEFSMount(t *testing.T) {
+	m := MountHelper{
+		Device: "fs-123",
+		Target: "/var/lib/ecs/volumes/123",
+	}
+	runMount = func([]string) error {
+		return nil
+	}
+	defer func() {
+		runMount = runMountCommand
+	}()
+	assert.NoError(t, m.Mount())
+}
+
+func TestEFSMountFailure(t *testing.T) {
+	m := MountHelper{
+		Device: "xyz",
+		Target: "/var/lib/ecs/volumes/123",
+	}
+	runMount = func([]string) error {
+		return errors.New("mount failure")
+	}
+	defer func() {
+		runMount = runMountCommand
+	}()
+	assert.Error(t, m.Mount())
+}
+
+func TestEFSOptionsValidate(t *testing.T) {
+	m := MountHelper{
+		Device: "fs-123",
+	}
+	assert.Error(t, m.Validate(), "missing target field")
+}
+
+func TestEFSUnmount(t *testing.T) {
+	m := MountHelper{
+		Device: "fs-123",
+		Target: "/var/lib/ecs/volumes/123",
+	}
+	lookPath = func(string) (string, error) {
+		return "/mount", nil
+	}
+	runUnmount = func(path string, target string) error {
+		assert.Equal(t, "/mount", path)
+		assert.Equal(t, "/var/lib/ecs/volumes/123", target)
+		return nil
+	}
+	defer func() {
+		lookPath = getPath
+		runUnmount = runUnmountCommand
+	}()
+	assert.NoError(t, m.Unmount())
+}
+
+func TestEFSNoUnmountBinary(t *testing.T) {
+	m := MountHelper{
+		Device: "fs-123",
+		Target: "/var/lib/ecs/volumes/123",
+	}
+	lookPath = func(string) (string, error) {
+		return "", errors.New("unmount not found")
+	}
+	defer func() {
+		lookPath = getPath
+	}()
+	assert.Error(t, m.Unmount())
+}
+
+func TestEFSUnmountError(t *testing.T) {
+	m := MountHelper{
+		Device: "fs-123",
+		Target: "/var/lib/ecs/volumes/123",
+	}
+	lookPath = func(string) (string, error) {
+		return "/mount", nil
+	}
+	runUnmount = func(path string, target string) error {
+		return errors.New("unmount failure")
+	}
+	defer func() {
+		lookPath = getPath
+		runUnmount = runUnmountCommand
+	}()
+	assert.Error(t, m.Unmount())
+}

--- a/agent/volumes/logger/log.go
+++ b/agent/volumes/logger/log.go
@@ -1,0 +1,89 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package logger
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/cihub/seelog"
+)
+
+const (
+	logFileFormat = "/var/log/ecs/ecs-volume-plugin.log"
+	logLevel      = "info"
+	outputFmt     = "logfmt"
+	rollCount     = 24
+)
+
+type logConfig struct {
+	logfile      string
+	level        string
+	outputFormat string
+	maxRollCount int
+}
+
+// config contains config for seelog logger
+var config *logConfig
+
+// Setup sets the cusotm logging config
+func Setup() {
+	config = &logConfig{
+		logfile:      logFileFormat,
+		level:        logLevel,
+		outputFormat: outputFmt,
+		maxRollCount: rollCount,
+	}
+
+	if err := seelog.RegisterCustomFormatter("VolumePluginLogfmt", logfmtFormatter); err != nil {
+		seelog.Error(err)
+	}
+	reloadConfig()
+}
+
+func logfmtFormatter(params string) seelog.FormatterFunc {
+	return func(message string, level seelog.LogLevel, context seelog.LogContextInterface) interface{} {
+		return fmt.Sprintf(`level=%s time=%s msg=%q
+`, level.String(), context.CallTime().UTC().Format(time.RFC3339), message)
+	}
+}
+
+func reloadConfig() {
+	logger, err := seelog.LoggerFromConfigAsString(seelogConfig())
+	if err == nil {
+		seelog.ReplaceLogger(logger)
+	} else {
+		seelog.Error(err)
+	}
+}
+
+func seelogConfig() string {
+	c := `
+<seelog type="asyncloop" minlevel="` + config.level + `">
+	<outputs formatid="` + config.outputFormat + `">
+		<console />`
+	if config.logfile != "" {
+		c += `
+		<rollingfile filename="` + config.logfile + `" type="date"
+		 datepattern="2006-01-02-15" archivetype="none" maxrolls="` + strconv.Itoa(config.maxRollCount) + `" />`
+	}
+	c += `
+	</outputs>
+	<formats>
+		<format id="logfmt" format="%VolumePluginLogfmt" />
+	</formats>
+</seelog>`
+	return c
+}

--- a/agent/volumes/logger/log_test.go
+++ b/agent/volumes/logger/log_test.go
@@ -1,0 +1,96 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package logger
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cihub/seelog"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLogfmtFormat(t *testing.T) {
+	logfmt := logfmtFormatter("")
+	out := logfmt("This is my log message", seelog.InfoLvl, &LogContextMock{})
+	s, ok := out.(string)
+	assert.True(t, ok)
+	assert.Equal(t, `level=info time=2018-10-01T01:02:03Z msg="This is my log message"
+`, s)
+}
+
+func TestSeelogConfig(t *testing.T) {
+	config = &logConfig{
+		logfile:      "foo.log",
+		level:        logLevel,
+		outputFormat: outputFmt,
+		maxRollCount: 24,
+	}
+	c := seelogConfig()
+	assert.Equal(t, `
+<seelog type="asyncloop" minlevel="info">
+	<outputs formatid="logfmt">
+		<console />
+		<rollingfile filename="foo.log" type="date"
+		 datepattern="2006-01-02-15" archivetype="none" maxrolls="24" />
+	</outputs>
+	<formats>
+		<format id="logfmt" format="%VolumePluginLogfmt" />
+	</formats>
+</seelog>`, c)
+}
+
+type LogContextMock struct{}
+
+// Caller's function name.
+func (l *LogContextMock) Func() string {
+	return ""
+}
+
+// Caller's line number.
+func (l *LogContextMock) Line() int {
+	return 0
+}
+
+// Caller's file short path (in slashed form).
+func (l *LogContextMock) ShortPath() string {
+	return ""
+}
+
+// Caller's file full path (in slashed form).
+func (l *LogContextMock) FullPath() string {
+	return ""
+}
+
+// True if the context is correct and may be used.
+// If false, then an error in context evaluation occurred and
+// all its other data may be corrupted.
+func (l *LogContextMock) IsValid() bool {
+	return true
+}
+
+// Time when log function was called.
+func (l *LogContextMock) CallTime() time.Time {
+	return time.Date(2018, time.October, 1, 1, 2, 3, 0, time.UTC)
+}
+
+// Custom context that can be set by calling logger.SetContext
+func (l *LogContextMock) CustomContext() interface{} {
+	return map[string]string{}
+}
+
+// Caller's file name (without path).
+func (l *LogContextMock) FileName() string {
+	return "mytestmodule.go"
+}

--- a/agent/volumes/state_manager.go
+++ b/agent/volumes/state_manager.go
@@ -1,0 +1,158 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package volumes
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/cihub/seelog"
+)
+
+const (
+	// PluginStatePath is the directory path to the plugin state information
+	// TODO: get this value from an env var
+	PluginStatePath = "/var/lib/ecs/data/"
+	// PluginStateFile contains the state information of the plugin
+	PluginStateFile = "ecs_volume_plugin.json"
+	// PluginStateFileAbsPath is the absolute path of the plugin state file
+	PluginStateFileAbsPath = "/var/lib/ecs/data/ecs_volume_plugin.json"
+)
+
+// StateManager manages the state of the volumes information
+type StateManager struct {
+	VolState *VolumeState
+	lock     sync.Mutex
+}
+
+// VolumeState contains the list of managed volumes
+type VolumeState struct {
+	Volumes map[string]*VolumeInfo `json:"volumes,omitempty"`
+}
+
+// VolumeInfo contains the information of managed volumes
+type VolumeInfo struct {
+	Type      string            `json:"type,omitempty"`
+	Path      string            `json:"path,omitempty"`
+	Options   map[string]string `json:"options,omitempty"`
+	CreatedAt string            `json:"createdAt,omitempty"`
+}
+
+// NewStateManager initializes the state manager of volume plugin
+func NewStateManager() *StateManager {
+	return &StateManager{
+		VolState: &VolumeState{
+			Volumes: make(map[string]*VolumeInfo),
+		},
+	}
+}
+
+func (s *StateManager) recordVolume(volName string, vol *Volume) error {
+	s.VolState.Volumes[volName] = &VolumeInfo{
+		Type:      vol.Type,
+		Path:      vol.Path,
+		Options:   vol.Options,
+		CreatedAt: vol.CreatedAt,
+	}
+	return s.save()
+}
+
+func (s *StateManager) removeVolume(volName string) error {
+	delete(s.VolState.Volumes, volName)
+	return s.save()
+}
+
+// saves volume state to the file at path
+func (s *StateManager) save() error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	b, err := json.MarshalIndent(s.VolState, "", "\t")
+	if err != nil {
+		return fmt.Errorf("marshal data failed: %v", err)
+	}
+	return saveStateToDisk(b)
+}
+
+var saveStateToDisk = saveState
+
+func saveState(b []byte) error {
+	// Make our temp-file on the same volume as our data-file to ensure we can
+	// actually move it atomically; cross-device renaming will error out
+	tmpfile, err := ioutil.TempFile(PluginStatePath, "tmp_ecs_volume_plugin")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %v", err)
+	}
+	_, err = tmpfile.Write(b)
+	if err != nil {
+		return fmt.Errorf("failed to write state to temp file: %v", err)
+	}
+
+	// flush temp state file to disk
+	err = tmpfile.Sync()
+	if err != nil {
+		return fmt.Errorf("error flushing state file: %v", err)
+	}
+
+	err = os.Rename(tmpfile.Name(), filepath.Join(PluginStatePath, PluginStateFile))
+	if err != nil {
+		return fmt.Errorf("could not move data to state file: %v", err)
+	}
+
+	stateDir, err := os.Open(PluginStatePath)
+	if err != nil {
+		return fmt.Errorf("error opening state path: %v", err)
+	}
+
+	// sync directory entry of the new state file to disk
+	err = stateDir.Sync()
+	if err != nil {
+		return fmt.Errorf("error syncing state file directory entry: %v", err)
+	}
+	return nil
+}
+
+var fileExists = checkFile
+
+func checkFile(filename string) bool {
+	_, err := os.Stat(filename)
+	return !os.IsNotExist(err)
+}
+
+// loads the file at path into interface 'a'
+func (s *StateManager) load(a interface{}) error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	b, err := readStateFile()
+	if err != nil {
+		return err
+	}
+	err = json.Unmarshal(b, a)
+	if err != nil {
+		seelog.Criticalf("Could not unmarshal existing state; corrupted data: %v. Please remove statefile at %s", err, PluginStateFileAbsPath)
+		return err
+	}
+	return err
+}
+
+var readStateFile = readFile
+
+func readFile() ([]byte, error) {
+	return ioutil.ReadFile(PluginStateFileAbsPath)
+}

--- a/agent/volumes/state_manager_test.go
+++ b/agent/volumes/state_manager_test.go
@@ -1,0 +1,98 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package volumes
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSaveStateSuccess(t *testing.T) {
+	s := NewStateManager()
+	s.VolState.Volumes["vol"] = &VolumeInfo{
+		Type: "efs",
+		Path: "/vol",
+	}
+	saveStateToDisk = func(b []byte) error {
+		assert.Equal(t, string(`{
+	"volumes": {
+		"vol": {
+			"type": "efs",
+			"path": "/vol"
+		}
+	}
+}`), string(b))
+		return nil
+	}
+	defer func() {
+		saveStateToDisk = saveState
+	}()
+	assert.NoError(t, s.save())
+}
+
+func TestSaveStateToDisk(t *testing.T) {
+	s := NewStateManager()
+	s.VolState.Volumes["vol"] = &VolumeInfo{
+		Type: "efs",
+		Path: "/vol",
+	}
+	saveStateToDisk = func(b []byte) error {
+		return nil
+	}
+	defer func() {
+		saveStateToDisk = saveState
+	}()
+	assert.NoError(t, s.save())
+}
+
+func TestSaveStateToDiskFail(t *testing.T) {
+	s := NewStateManager()
+	s.VolState.Volumes["vol"] = &VolumeInfo{
+		Type: "efs",
+		Path: "/vol",
+	}
+	saveStateToDisk = func(b []byte) error {
+		return errors.New("write to disk failure")
+	}
+	defer func() {
+		saveStateToDisk = saveState
+	}()
+	assert.Error(t, s.save())
+}
+
+func TestLoadStateSuccess(t *testing.T) {
+	s := NewStateManager()
+	oldState := &VolumeState{}
+	readStateFile = func() ([]byte, error) {
+		return []byte(`{"volumes":{"efsVolume":{"type":"efs","options":{"device":"fs-123","o":"tls","type":"efs"}}}}`), nil
+	}
+	defer func() {
+		readStateFile = readFile
+	}()
+	assert.NoError(t, s.load(oldState))
+}
+
+func TestLoadInvalidState(t *testing.T) {
+	s := NewStateManager()
+	oldState := &VolumeState{}
+	readStateFile = func() ([]byte, error) {
+		return []byte(`"junk"`), nil
+	}
+	defer func() {
+		readStateFile = readFile
+	}()
+	assert.Error(t, s.load(oldState))
+}

--- a/packaging/generic-rpm/amazon-ecs-volume-plugin.service
+++ b/packaging/generic-rpm/amazon-ecs-volume-plugin.service
@@ -1,0 +1,27 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the
+# "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License
+
+[Unit]
+Description=Amazon Elastic Container Service Volume Plugin
+After=network.target amazon-ecs-volume-plugin.socket
+Requires=amazon-ecs-volume-plugin.socket
+
+[Service]
+Type=simple
+Restart=on-failure
+RestartSec=10s
+ExecStart=/usr/libexec/amazon-ecs-volume-plugin
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/generic-rpm/amazon-ecs-volume-plugin.socket
+++ b/packaging/generic-rpm/amazon-ecs-volume-plugin.socket
@@ -1,0 +1,23 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the
+# "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License
+
+[Unit]
+Description=Amazon Elastic Container Service Volume Plugin
+PartOf=amazon-ecs-volume-plugin.service
+
+[Socket]
+ListenStream=/var/run/docker/plugins/amazon-ecs-volume-plugin.sock
+
+[Install]
+WantedBy=sockets.target

--- a/packaging/generic-rpm/ecs-agent.spec
+++ b/packaging/generic-rpm/ecs-agent.spec
@@ -1,0 +1,152 @@
+# Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the
+# "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+
+
+%global gobuild_tag generic_rpm
+%global _cachedir %{_localstatedir}/cache
+%global bundled_agent_version %{version}
+%global no_exec_perm 644
+
+%global ecscni_goproject github.com/aws
+%global ecscni_gorepo amazon-ecs-cni-plugins
+%global ecscni_goimport %{ecscni_goproject}/%{ecscni_gorepo}
+%global ecscni_gitrev 55b2ae77ee0bf22321b14f2d4ebbcc04f77322e1
+
+%global vpccni_goproject github.com/aws
+%global vpccni_gorepo amazon-vpc-cni-plugins
+%global vpccni_goimport %{vpccni_goproject}/%{vpccni_gorepo}
+%global vpccni_gitrev a21d3a41f922e14c19387713df66be3e4ee1e1f6
+%global vpccni_gover 1.2
+
+Name:           amazon-ecs-agent
+Version:        1.53
+Release:        1
+License:        Apache 2.0
+Summary:        Amazon Elastic Container Service initialization application
+ExclusiveArch:  x86_64 aarch64
+
+Source0:        sources.tgz
+Source1:        ecs.service
+Source2:        https://%{ecscni_goimport}/archive/%{ecscni_gitrev}/%{ecscni_gorepo}.tar.gz
+Source3:        https://%{vpccni_goimport}/archive/%{vpccni_gitrev}/%{vpccni_gorepo}.tar.gz
+Source4:        amazon-ecs-volume-plugin.service
+Source5:        amazon-ecs-volume-plugin.socket
+
+BuildRequires:  systemd
+Requires:       systemd
+Requires:       iptables
+Requires:       procps
+
+%description
+containerless agent.
+
+%prep
+%setup -c -n amazon-ecs-agent
+
+
+#unpacking the cni plugins
+%setup -T -D -a 2 -q -c -n amazon-ecs-agent/src/github.com/aws
+%setup -T -D -a 3 -q -c -n amazon-ecs-agent/src/github.com/aws
+
+mv %{_builddir}/amazon-ecs-agent/src/github.com/aws/amazon-ecs-cni-plugins* %{_builddir}/amazon-ecs-agent/src/github.com/aws/amazon-ecs-cni-plugins
+mv %{_builddir}/amazon-ecs-agent/src/github.com/aws/amazon-vpc-cni-plugins* %{_builddir}/amazon-ecs-agent/src/github.com/aws/amazon-vpc-cni-plugins
+
+
+%build
+%{_builddir}/amazon-ecs-agent/scripts/build false %{gobuild_tag}
+%{_builddir}/amazon-ecs-agent/scripts/rpm-volumeBuild.sh 
+
+
+# Build the ECS CNI plugins
+export GOPATH=%{_builddir}/amazon-ecs-agent
+
+cd %{_builddir}/amazon-ecs-agent/src/github.com/aws/amazon-ecs-cni-plugins
+LD_ECS_CNI_VERSION="-X github.com/aws/amazon-ecs-cni-plugins/pkg/version.Version=$(cat VERSION)"
+ECS_CNI_HASH="%{ecscni_gitrev}"
+LD_ECS_CNI_SHORT_HASH="-X github.com/aws/amazon-ecs-cni-plugins/pkg/version.GitShortHash=${ECS_CNI_HASH::8}"
+LD_ECS_CNI_PORCELAIN="-X github.com/aws/amazon-ecs-cni-plugins/pkg/version.GitPorcelain=0"
+go build -a \
+  -buildmode=pie \
+  -ldflags "-linkmode=external ${LD_ECS_CNI_VERSION} ${LD_ECS_CNI_SHORT_HASH} ${LD_ECS_CNI_PORCELAIN}" \
+  -o ecs-eni \
+  ./plugins/eni
+go build -a \
+  -buildmode=pie \
+  -ldflags "-linkmode=external ${LD_ECS_CNI_VERSION} ${LD_ECS_CNI_SHORT_HASH} ${LD_ECS_CNI_PORCELAIN}" \
+  -o ecs-ipam \
+  ./plugins/ipam
+go build -a \
+  -buildmode=pie \
+  -ldflags "-linkmode=external ${LD_ECS_CNI_VERSION} ${LD_ECS_CNI_SHORT_HASH} ${LD_ECS_CNI_PORCELAIN}" \
+  -o ecs-bridge \
+  ./plugins/ecs-bridge
+
+cd %{_builddir}/amazon-ecs-agent/src/github.com/aws/amazon-vpc-cni-plugins
+LD_VPC_CNI_VERSION="-X github.com/aws/amazon-vpc-cni-plugins/version.Version=%{vpccni_gover}"
+VPC_CNI_HASH="%{vpccni_gitrev}"
+LD_VPC_CNI_SHORT_HASH="-X github.com/aws/amazon-vpc-cni-plugins/version.GitShortHash=${VPC_CNI_HASH::8}"
+go build -a \
+  -buildmode=pie \
+  -ldflags "-linkmode=external ${LD_VPC_CNI_VERSION} ${LD_VPC_CNI_SHORT_HASH} ${LD_VPC_CNI_PORCELAIN}" \
+  -mod=vendor \
+  -o vpc-branch-eni \
+  ./plugins/vpc-branch-eni
+
+cd ..
+
+
+%install
+install -D %{_builddir}/amazon-ecs-agent/generic_rpm %{buildroot}%{_libexecdir}/amazon-ecs-agent
+install -D %{_builddir}/amazon-ecs-agent/amazon-ecs-volume-plugin %{buildroot}%{_libexecdir}/amazon-ecs-volume-plugin
+install -D %{_topdir}/packaging/generic-rpm/ipSetup.sh %{buildroot}%{_libexecdir}/ipSetup.sh
+install -D %{_topdir}/packaging/generic-rpm/ipCleanup.sh %{buildroot}%{_libexecdir}/ipCleanup.sh
+install -D %{_topdir}/out/amazon-ecs-pause.tar %{buildroot}%{_sharedstatedir}/amazon-ecs-pause.tar
+install -D -p -m 0755 %{_builddir}/amazon-ecs-agent/src/github.com/aws/amazon-ecs-cni-plugins/ecs-bridge %{buildroot}%{_libexecdir}/ecs-bridge
+install -D -p -m 0755 %{_builddir}/amazon-ecs-agent/src/github.com/aws/amazon-ecs-cni-plugins/ecs-eni %{buildroot}%{_libexecdir}/ecs-eni
+install -D -p -m 0755 %{_builddir}/amazon-ecs-agent/src/github.com/aws/amazon-ecs-cni-plugins/ecs-ipam %{buildroot}%{_libexecdir}/ecs-ipam
+install -D -p -m 0755 %{_builddir}/amazon-ecs-agent/src/github.com/aws/amazon-vpc-cni-plugins/vpc-branch-eni %{buildroot}%{_libexecdir}/vpc-branch-eni
+
+mkdir -p %{buildroot}%{_sysconfdir}/ecs
+touch %{buildroot}%{_sysconfdir}/ecs/ecs.config
+touch %{buildroot}%{_sysconfdir}/ecs/ecs.config.json
+
+mkdir -p %{buildroot}%{_sharedstatedir}/ecs/data
+
+install -m %{no_exec_perm} -D %{SOURCE1} $RPM_BUILD_ROOT/%{_unitdir}/ecs.service
+install -m %{no_exec_perm} -D %{SOURCE4} $RPM_BUILD_ROOT/%{_unitdir}/amazon-ecs-volume-plugin.service
+install -m %{no_exec_perm} -D %{SOURCE5} $RPM_BUILD_ROOT/%{_unitdir}/amazon-ecs-volume-plugin.socket
+
+%files
+%{_libexecdir}/amazon-ecs-agent
+%{_libexecdir}/amazon-ecs-volume-plugin
+%{_libexecdir}/ipSetup.sh
+%{_libexecdir}/ipCleanup.sh
+%{_libexecdir}/ecs-bridge
+%{_libexecdir}/ecs-eni
+%{_libexecdir}/ecs-ipam
+%{_libexecdir}/vpc-branch-eni
+%{_sharedstatedir}/amazon-ecs-pause.tar
+%config(noreplace) %ghost %{_sysconfdir}/ecs/ecs.config
+%config(noreplace) %ghost %{_sysconfdir}/ecs/ecs.config.json
+%dir %{_sharedstatedir}/ecs/data
+%{_unitdir}/ecs.service
+%{_unitdir}/amazon-ecs-volume-plugin.service
+%{_unitdir}/amazon-ecs-volume-plugin.socket
+
+%post
+%systemd_post ecs
+
+%postun
+%systemd_postun
+

--- a/scripts/rpm-volumeBuild.sh
+++ b/scripts/rpm-volumeBuild.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the
+# "License"). You may not use this file except in compliance
+#  with the License. A copy of the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+set -ex
+ROOT=$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )
+cd "${ROOT}"
+
+cd ../..
+
+export TOPWD="$(pwd)"
+
+if [ -d "${TOPWD}/.git" ]; then
+    version=$(cat "${TOPWD}/VERSION")
+    git_hash=$(git rev-parse --short=8 HEAD)
+    git_dirty=false
+
+    if [[ "$(git status --porcelain)" != "" ]]; then
+	git_dirty=true
+    fi
+
+    VERSION_FLAG="-X github.com/aws/amazon-ecs-agent/agent/version.Version=${version}"
+    GIT_HASH_FLAG="-X github.com/aws/amazon-ecs-agent/agent/version.GitShortHash=${git_hash}"
+    GIT_DIRTY_FLAG="-X github.com/aws/amazon-ecs-agent/agent/version.GitDirty=${git_dirty}"
+fi
+
+
+CGO_ENABLED=0 go build -ldflags "-s ${VERSION_FLAG} ${GIT_HASH_FLAG} ${GIT_DIRTY_FLAG}" \
+	-o "${ROOT}/amazon-ecs-volume-plugin" "${TOPWD}/agent/volumes/amazon-ecs-volume-plugin"


### PR DESCRIPTION
### Summary
Adding generic-rpm to agent. A new generic-rpm make target will be added to the makefile. This target will produce an install-able rpm file that installs the ECS-Agent as a host-level process managed by systemd. This rpm will include Awsvpc and volume plugin support. 

### Implementation details
There was another target added to the makefile along with the .spec file. 
In order to enable support for the Awsvpc and the volume plugins, appmesh needed to be disabled and the volume files were added to the agent (along with some missing vendor files)

### Testing
All MACIS tests were passed when using an AMI which had the agent installed using the generic-rpm package except for the following:
TestExecSSM -This is due to the ssm dependency volume mounts not being set in the agent (should be coming in future commit)
TestBoltDB -included ssm command which doesn't work due to dependency issue, but boltdb functionality was checked manually
TestTaskIAMRole -test requires ssm
TestExecutionRole -test requires ssm
TestAppmesh -Appmesh was disabled 
TestContainerUpdateContainerAgent -Failed since it is no longer upgrading/downgrading with as a contained agent
TestContainerMetadataFile -`Expected container-metadata-file-validator to exit with 42; actually exited (true) with 1` (This will be looked into more)

### Description for the changelog
Add generic-rpm support

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
