### PR TITLE
Introduce jitter for task cleanup wait duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,8 @@ additional details on each available environment variable.
 | `ECS_DISABLE_PRIVILEGED` | `true` | Whether launching privileged containers is disabled on the container instance. | `false` | `false` |
 | `ECS_SELINUX_CAPABLE` | `true` | Whether SELinux is available on the container instance. | `false` | `false` |
 | `ECS_APPARMOR_CAPABLE` | `true` | Whether AppArmor is available on the container instance. | `false` | `false` |
-| `ECS_ENGINE_TASK_CLEANUP_WAIT_DURATION` | 10m | Time to wait to delete containers for a stopped task. If set to less than 1 minute, the value is ignored.  | 3h | 3h |
+| `ECS_ENGINE_TASK_CLEANUP_WAIT_DURATION` | 10m | Default time to wait to delete containers for a stopped task (see also `ECS_ENGINE_TASK_CLEANUP_WAIT_DURATION_JITTER`). If set to less than 1 minute, the value is ignored.  | 3h | 3h |
+| `ECS_ENGINE_TASK_CLEANUP_WAIT_DURATION_JITTER` | 1h | Jitter value for the task engine cleanup wait duration. When specified, the actual cleanup wait duration time for each task will be the duration specified in `ECS_ENGINE_TASK_CLEANUP_WAIT_DURATION` plus a random duration between 0 and the jitter duration. | blank | blank |
 | `ECS_CONTAINER_STOP_TIMEOUT` | 10m | Instance scoped configuration for time to wait for the container to exit normally before being forcibly killed. | 30s | 30s |
 | `ECS_CONTAINER_START_TIMEOUT` | 10m | Timeout before giving up on starting a container. | 3m | 8m |
 | `ECS_CONTAINER_CREATE_TIMEOUT` | 10m | Timeout before giving up on creating a container. Minimum value is 1m. If user sets a value below minimum it will be set to min. | 4m | 4m |

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -542,6 +542,7 @@ func environmentConfig() (Config, error) {
 		SELinuxCapable:                      parseBooleanDefaultFalseConfig("ECS_SELINUX_CAPABLE"),
 		AppArmorCapable:                     parseBooleanDefaultFalseConfig("ECS_APPARMOR_CAPABLE"),
 		TaskCleanupWaitDuration:             parseEnvVariableDuration("ECS_ENGINE_TASK_CLEANUP_WAIT_DURATION"),
+		TaskCleanupWaitDurationJitter:       parseEnvVariableDuration("ECS_ENGINE_TASK_CLEANUP_WAIT_DURATION_JITTER"),
 		TaskENIEnabled:                      parseBooleanDefaultFalseConfig("ECS_ENABLE_TASK_ENI"),
 		TaskIAMRoleEnabled:                  parseBooleanDefaultFalseConfig("ECS_ENABLE_TASK_IAM_ROLE"),
 		DeleteNonECSImagesEnabled:           parseBooleanDefaultFalseConfig("ECS_ENABLE_UNTRACKED_IMAGE_CLEANUP"),

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -114,6 +114,13 @@ func TestGetRegionWithNoIID(t *testing.T) {
 }
 
 func TestEnvironmentConfig(t *testing.T) {
+	const (
+		testTaskCleanupWaitDurationStr       = "90s"
+		testTaskCleanupWaitDurationJitterStr = "1m"
+		testTaskCleanupWaitDuration          = 90 * time.Second
+		testTaskCleanupWaitDurationJitter    = time.Minute
+	)
+
 	defer setTestRegion()()
 	defer setTestEnv("ECS_CLUSTER", "myCluster")()
 	defer setTestEnv("ECS_RESERVED_PORTS_UDP", "[42,99]")()
@@ -126,7 +133,8 @@ func TestEnvironmentConfig(t *testing.T) {
 	defer setTestEnv("ECS_SELINUX_CAPABLE", "true")()
 	defer setTestEnv("ECS_APPARMOR_CAPABLE", "true")()
 	defer setTestEnv("ECS_DISABLE_PRIVILEGED", "true")()
-	defer setTestEnv("ECS_ENGINE_TASK_CLEANUP_WAIT_DURATION", "90s")()
+	defer setTestEnv("ECS_ENGINE_TASK_CLEANUP_WAIT_DURATION", testTaskCleanupWaitDurationStr)()
+	defer setTestEnv("ECS_ENGINE_TASK_CLEANUP_WAIT_DURATION_JITTER", testTaskCleanupWaitDurationJitterStr)()
 	defer setTestEnv("ECS_ENABLE_TASK_IAM_ROLE", "true")()
 	defer setTestEnv("ECS_ENABLE_UNTRACKED_IMAGE_CLEANUP", "true")()
 	defer setTestEnv("ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST", "true")()
@@ -187,7 +195,8 @@ func TestEnvironmentConfig(t *testing.T) {
 	assert.Equal(t, ImagePullAlwaysBehavior, conf.ImagePullBehavior)
 	assert.Equal(t, "testing", conf.InstanceAttributes["my_attribute"])
 	assert.Equal(t, "testing", conf.ContainerInstanceTags["my_tag"])
-	assert.Equal(t, (90 * time.Second), conf.TaskCleanupWaitDuration)
+	assert.Equal(t, testTaskCleanupWaitDuration, conf.TaskCleanupWaitDuration)
+	assert.Equal(t, testTaskCleanupWaitDurationJitter, conf.TaskCleanupWaitDurationJitter)
 	serializedAdditionalLocalRoutesJSON, err := json.Marshal(conf.AWSVPCAdditionalLocalRoutes)
 	assert.NoError(t, err, "should marshal additional local routes")
 	assert.Equal(t, additionalLocalRoutesJSON, string(serializedAdditionalLocalRoutesJSON))

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -145,6 +145,12 @@ type Config struct {
 	// until cleanup of task resources is started.
 	TaskCleanupWaitDuration time.Duration
 
+	// TaskCleanupWaitDurationJitter specifies a jitter for task cleanup wait duration.
+	// When specified to a non-zero duration (default is zero), the task cleanup wait duration for each task
+	// will be a random duration between [TaskCleanupWaitDuration, TaskCleanupWaitDuration +
+	// TaskCleanupWaitDurationJitter].
+	TaskCleanupWaitDurationJitter time.Duration
+
 	// TaskIAMRoleEnabled specifies if the Agent is capable of launching
 	// tasks with IAM Roles.
 	TaskIAMRoleEnabled BooleanDefaultFalse

--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -250,7 +250,7 @@ func (mtask *managedTask) overseeTask() {
 	}
 	// TODO: make this idempotent on agent restart
 	go mtask.releaseIPInIPAM()
-	mtask.cleanupTask(mtask.cfg.TaskCleanupWaitDuration)
+	mtask.cleanupTask(retry.AddJitter(mtask.cfg.TaskCleanupWaitDuration, mtask.cfg.TaskCleanupWaitDurationJitter))
 }
 
 // shouldExit checks if the task manager should exit, as the agent is exiting.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Closes https://github.com/aws/amazon-ecs-agent/issues/2968.

Introduce jitter for task cleanup wait duration. Configurable via ECS_ENGINE_TASK_CLEANUP_WAIT_DURATION_JITTER environment variable. The purpose of introducing this is to address the use case where a large number of tasks are stopped at the same time. Without the jitter, the cleanup for all those tasks also happen at roughly the same time, which can generate a lot of work that could impact the tasks that are running at the time of such cleanup. With the jitter, each task will be cleaned up at different time, avoiding the aforementioned impact.

### Implementation details
<!-- How are the changes implemented? -->
Added a new config field for the jitter. Use it in task manager to calculate the cleanup duration with jitter.

The default value of the jitter is an empty duration, so won't change existing behavior when the new env is not specified.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Added unit test. Manually tested successfully with the following:
(1) ecs.config set with jitter:
```
ECS_ENGINE_TASK_CLEANUP_WAIT_DURATION=1m
ECS_ENGINE_TASK_CLEANUP_WAIT_DURATION_JITTER=2m
```
launched 10 tasks that all stop at the same time. verified the tasks get cleaned up at different random time between 1m-3m after the tasks stopped:
```
cat /var/log/ecs/ecs-agent.log | grep "Cleaning up"
level=info time=2021-07-30T20:46:22Z msg="Cleaning up task's containers and data" taskARN="arn:aws:ecs:us-west-2:xx:task/test-jitter/xx"
level=info time=2021-07-30T20:46:31Z msg="Cleaning up task's containers and data" taskARN="arn:aws:ecs:us-west-2:xx:task/test-jitter/xx"
level=info time=2021-07-30T20:46:49Z msg="Cleaning up task's containers and data" taskARN="arn:aws:ecs:us-west-2:xx:task/test-jitter/xx"
level=info time=2021-07-30T20:46:50Z msg="Cleaning up task's containers and data" taskARN="arn:aws:ecs:us-west-2:xx:task/test-jitter/xx"
level=info time=2021-07-30T20:46:53Z msg="Cleaning up task's containers and data" taskARN="arn:aws:ecs:us-west-2:xx:task/test-jitter/xx"
level=info time=2021-07-30T20:47:46Z msg="Cleaning up task's containers and data" taskARN="arn:aws:ecs:us-west-2:xx:task/test-jitter/xx"
level=info time=2021-07-30T20:47:48Z msg="Cleaning up task's containers and data" taskARN="arn:aws:ecs:us-west-2:xx:task/test-jitter/xx"
level=info time=2021-07-30T20:47:56Z msg="Cleaning up task's containers and data" taskARN="arn:aws:ecs:us-west-2:xx:task/test-jitter/xx"
level=info time=2021-07-30T20:48:16Z msg="Cleaning up task's containers and data" taskARN="arn:aws:ecs:us-west-2:xx:task/test-jitter/xx"
level=info time=2021-07-30T20:48:19Z msg="Cleaning up task's containers and data" taskARN="arn:aws:ecs:us-west-2:xx:task/test-jitter/xx"
```
(2) ecs.config set without jitter:
```
ECS_ENGINE_TASK_CLEANUP_WAIT_DURATION=1m
```
and try the same again. the tasks are roughly cleaned up at the same time:
```
level=info time=2021-07-30T20:51:03Z msg="Cleaning up task's containers and data" taskARN="arn:aws:ecs:us-west-2:xx:task/test-jitter/xx"
level=info time=2021-07-30T20:51:03Z msg="Cleaning up task's containers and data" taskARN="arn:aws:ecs:us-west-2:xx:task/test-jitter/xx"
level=info time=2021-07-30T20:51:03Z msg="Cleaning up task's containers and data" taskARN="arn:aws:ecs:us-west-2:xx:task/test-jitter/xx"
level=info time=2021-07-30T20:51:03Z msg="Cleaning up task's containers and data" taskARN="arn:aws:ecs:us-west-2:xx:task/test-jitter/xx"
level=info time=2021-07-30T20:51:03Z msg="Cleaning up task's containers and data" taskARN="arn:aws:ecs:us-west-2:xx:task/test-jitter/xx"
level=info time=2021-07-30T20:51:03Z msg="Cleaning up task's containers and data" taskARN="arn:aws:ecs:us-west-2:xx:task/test-jitter/xx"
level=info time=2021-07-30T20:51:03Z msg="Cleaning up task's containers and data" taskARN="arn:aws:ecs:us-west-2:xx:task/test-jitter/xx"
level=info time=2021-07-30T20:51:03Z msg="Cleaning up task's containers and data" taskARN="arn:aws:ecs:us-west-2:xx:task/test-jitter/xx"
level=info time=2021-07-30T20:51:03Z msg="Cleaning up task's containers and data" taskARN="arn:aws:ecs:us-west-2:xx:task/test-jitter/xx"
level=info time=2021-07-30T20:51:04Z msg="Cleaning up task's containers and data" taskARN="arn:aws:ecs:us-west-2:xx:task/test-jitter/xx"
```

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enhancement - Introduce optional jitter for task cleanup wait duration, configurable via `ECS_ENGINE_TASK_CLEANUP_WAIT_DURATION_JITTER` environment variable. In use case where there are large number of tasks being stopped at the same time, specifying this jitter can help avoid all the task cleanup happening at the same time (the latter could add pressure to the instance and as a result affect running tasks).

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
