### PR TITLE
Add support for Operating System Family

### DIFF
--- a/agent/api/ecsclient/client.go
+++ b/agent/api/ecsclient/client.go
@@ -46,6 +46,7 @@ const (
 	azAttrName              = "ecs.availability-zone"
 	cpuArchAttrName         = "ecs.cpu-architecture"
 	osTypeAttrName          = "ecs.os-type"
+	osFamilyAttrName        = "ecs.os-family"
 )
 
 // APIECSClient implements ECSClient
@@ -327,10 +328,16 @@ func validateRegisteredAttributes(expectedAttributes, actualAttributes []*ecs.At
 }
 
 func (client *APIECSClient) getAdditionalAttributes() []*ecs.Attribute {
+	osFamily := config.GetOperatingSystemFamily()
+	seelog.Infof("Attribute OSFamily:%v", osFamily)
 	attrs := []*ecs.Attribute{
 		{
 			Name:  aws.String(osTypeAttrName),
 			Value: aws.String(config.OSType),
+		},
+		{
+			Name:  aws.String(osFamilyAttrName),
+			Value: aws.String(osFamily),
 		},
 	}
 	// Send cpu arch attribute directly when running on external capacity. When running on EC2, this is not needed

--- a/agent/config/const_windows.go
+++ b/agent/config/const_windows.go
@@ -15,5 +15,24 @@
 
 package config
 
+import "golang.org/x/sys/windows/registry"
+
 // OSType is the type of operating system where agent is running
 const OSType = "windows"
+const (
+	// envSkipDomainJoinCheck is an environment setting that can be used to skip
+	// domain join check validation. This is useful for integration and
+	// functional-tests but should not be set for any non-test use-case.
+	envSkipDomainJoinCheck  = "ZZZ_SKIP_DOMAIN_JOIN_CHECK_NOT_SUPPORTED_IN_PRODUCTION"
+	releaseId2004SAC        = "2004"
+	releaseId1909SAC        = "1909"
+	windowsServer2019       = "Windows Server 2019"
+	windowsServer2016       = "Windows Server 2016"
+	windowsServerDataCenter = "Windows Server Datacenter"
+	installationTypeCore    = "Server Core"
+	installationTypeFull    = "Server"
+	unsupportedWindowsOS    = "windows"
+	osTypeFormat            = "WINDOWS_SERVER_%s_%s"
+	ecsWinRegistryRootKey   = registry.LOCAL_MACHINE
+	ecsWinRegistryRootPath  = `SOFTWARE\Microsoft\Windows NT\CurrentVersion`
+)

--- a/agent/config/parse_linux.go
+++ b/agent/config/parse_linux.go
@@ -22,3 +22,8 @@ func parseGMSACapability() bool {
 func parseFSxWindowsFileServerCapability() bool {
 	return false
 }
+
+// GetOperatingSystemFamily() returns "linux" as operating system family for linux based ecs instances
+func GetOperatingSystemFamily() string {
+	return OSType
+}

--- a/agent/config/parse_unsupported.go
+++ b/agent/config/parse_unsupported.go
@@ -22,3 +22,8 @@ func parseGMSACapability() bool {
 func parseFSxWindowsFileServerCapability() bool {
 	return false
 }
+
+// GetOperatingSystemFamily() returns "unsupported" as operating system family for non windows and non linux based ecs instances
+func GetOperatingSystemFamily() string {
+	return OSType
+}

--- a/agent/config/parse_windows_test.go
+++ b/agent/config/parse_windows_test.go
@@ -19,7 +19,11 @@ import (
 	"os"
 	"testing"
 
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/windows/registry"
+
+	mock_dependencies "github.com/aws/amazon-ecs-agent/agent/statemanager/dependencies/mocks"
 )
 
 func TestParseGMSACapability(t *testing.T) {
@@ -49,4 +53,115 @@ func TestParseFSxWindowsFileServerCapability(t *testing.T) {
 	defer os.Unsetenv("ECS_FSX_WINDOWS_FILE_SERVER_SUPPORTED")
 
 	assert.False(t, parseFSxWindowsFileServerCapability())
+}
+
+func getMockRegistry(controller *gomock.Controller) *mock_dependencies.MockWindowsRegistry {
+	winRegistry := mock_dependencies.NewMockWindowsRegistry(controller)
+	setWinRegistry(winRegistry)
+	return winRegistry
+}
+
+func getMockKey(t *testing.T) *mock_dependencies.MockRegistryKey {
+	ctrl := gomock.NewController(t)
+	winRegistry := getMockRegistry(ctrl)
+	mockKey := mock_dependencies.NewMockRegistryKey(ctrl)
+	winRegistry.EXPECT().OpenKey(ecsWinRegistryRootKey, ecsWinRegistryRootPath, gomock.Any()).Return(mockKey, nil)
+	return mockKey
+}
+
+func TestGetOperatingSystemFamilyForWS2019Core(t *testing.T) {
+	mockKey := getMockKey(t)
+	mockKey.EXPECT().GetStringValue("ProductName").Return(`Windows Server 2019 Datacenter`, uint32(0), nil)
+	mockKey.EXPECT().GetStringValue("InstallationType").Return(`Server Core`, uint32(0), nil)
+	mockKey.EXPECT().GetStringValue("ReleaseId").Return(`1809`, uint32(0), nil)
+	mockKey.EXPECT().Close()
+	assert.Equal(t, "WINDOWS_SERVER_2019_CORE", GetOperatingSystemFamily())
+}
+
+func TestGetOperatingSystemFamilyForWS2019Full(t *testing.T) {
+	mockKey := getMockKey(t)
+	mockKey.EXPECT().GetStringValue("ProductName").Return(`Windows Server 2019 Datacenter`, uint32(0), nil)
+	mockKey.EXPECT().GetStringValue("InstallationType").Return(`Server`, uint32(0), nil)
+	mockKey.EXPECT().GetStringValue("ReleaseId").Return(`1809`, uint32(0), nil)
+	mockKey.EXPECT().Close()
+
+	assert.Equal(t, "WINDOWS_SERVER_2019_FULL", GetOperatingSystemFamily())
+}
+
+func TestGetOperatingSystemFamilyForWS2016Full(t *testing.T) {
+	mockKey := getMockKey(t)
+	mockKey.EXPECT().GetStringValue("ProductName").Return(`Windows Server 2016 Datacenter`, uint32(0), nil)
+	mockKey.EXPECT().GetStringValue("InstallationType").Return(`Server`, uint32(0), nil)
+	mockKey.EXPECT().GetStringValue("ReleaseId").Return(`1607`, uint32(0), nil)
+	mockKey.EXPECT().Close()
+
+	assert.Equal(t, "WINDOWS_SERVER_2016_FULL", GetOperatingSystemFamily())
+}
+
+func TestGetOperatingSystemFamilyForWS2004Core(t *testing.T) {
+	mockKey := getMockKey(t)
+	mockKey.EXPECT().GetStringValue("ProductName").Return(`Windows Server Datacenter`, uint32(0), nil)
+	mockKey.EXPECT().GetStringValue("InstallationType").Return(`Server Core`, uint32(0), nil)
+	mockKey.EXPECT().GetStringValue("ReleaseId").Return(`2004`, uint32(0), nil)
+	mockKey.EXPECT().Close()
+
+	assert.Equal(t, "WINDOWS_SERVER_2004_CORE", GetOperatingSystemFamily())
+}
+
+func TestGetOperatingSystemFamilyForKeyError(t *testing.T) {
+	mockKey := getMockKey(t)
+	winRegistry := getMockRegistry(gomock.NewController(t))
+	winRegistry.EXPECT().OpenKey(ecsWinRegistryRootKey, ecsWinRegistryRootPath, gomock.Any()).Return(mockKey, registry.ErrNotExist)
+	mockKey.EXPECT().Close()
+	assert.Equal(t, unsupportedWindowsOS, GetOperatingSystemFamily())
+}
+
+func TestGetOperatingSystemFamilyForProductNameNotExistError(t *testing.T) {
+	mockKey := getMockKey(t)
+	mockKey.EXPECT().GetStringValue("ProductName").Return("", uint32(0), registry.ErrNotExist)
+
+	mockKey.EXPECT().Close()
+	assert.Equal(t, unsupportedWindowsOS, GetOperatingSystemFamily())
+}
+
+func TestGetOperatingSystemFamilyForInstallationTypeNotExistError(t *testing.T) {
+	mockKey := getMockKey(t)
+	mockKey.EXPECT().GetStringValue("ProductName").Return(`Windows Server Datacenter`, uint32(0), nil)
+	mockKey.EXPECT().GetStringValue("InstallationType").Return(`Server Core`, uint32(0), registry.ErrNotExist)
+	mockKey.EXPECT().Close()
+	assert.Equal(t, unsupportedWindowsOS, GetOperatingSystemFamily())
+}
+
+func TestGetOperatingSystemFamilyForInvalidInstallationType(t *testing.T) {
+	mockKey := getMockKey(t)
+	mockKey.EXPECT().GetStringValue("ProductName").Return(`Windows Server Datacenter`, uint32(0), nil)
+	mockKey.EXPECT().GetStringValue("InstallationType").Return(`Server Core Invalid`, uint32(0), nil)
+	mockKey.EXPECT().Close()
+	assert.Equal(t, unsupportedWindowsOS, GetOperatingSystemFamily())
+}
+
+func TestGetOperatingSystemFamilyForReleaseIdNotExistError(t *testing.T) {
+	mockKey := getMockKey(t)
+	mockKey.EXPECT().GetStringValue("ProductName").Return(`Windows Server Datacenter`, uint32(0), nil)
+	mockKey.EXPECT().GetStringValue("InstallationType").Return(`Server Core`, uint32(0), nil)
+	mockKey.EXPECT().GetStringValue("ReleaseId").Return(`2004`, uint32(0), registry.ErrNotExist)
+	mockKey.EXPECT().Close()
+	assert.Equal(t, unsupportedWindowsOS, GetOperatingSystemFamily())
+}
+
+func TestGetOperatingSystemFamilyForInvalidLTSCReleaseId(t *testing.T) {
+	mockKey := getMockKey(t)
+	mockKey.EXPECT().GetStringValue("ProductName").Return(`Windows Server Datacenter`, uint32(0), nil)
+	mockKey.EXPECT().GetStringValue("InstallationType").Return(`Server Core`, uint32(0), nil)
+	mockKey.EXPECT().GetStringValue("ReleaseId").Return(`2028`, uint32(0), registry.ErrNotExist)
+	mockKey.EXPECT().Close()
+	assert.Equal(t, unsupportedWindowsOS, GetOperatingSystemFamily())
+}
+
+func TestGetOperatingSystemFamilyForInvalidSACReleaseId(t *testing.T) {
+	mockKey := getMockKey(t)
+	mockKey.EXPECT().GetStringValue("ProductName").Return(`Windows Server BadVersion`, uint32(0), nil)
+	mockKey.EXPECT().GetStringValue("InstallationType").Return(`Server Core`, uint32(0), nil)
+	mockKey.EXPECT().Close()
+	assert.Equal(t, unsupportedWindowsOS, GetOperatingSystemFamily())
 }


### PR DESCRIPTION
Summary
Add support for new attribute  ecs.os-family 


Implementation details
Added new ecs attribute ecs.os-family , which will be advertised by the ECS agent while registering with the ECS Cluster. The values for this attribute will look like 
 WINDOWS_SERVER_2019_FULL|WINDOWS_SERVER_2019_CORE|WINDOWS_SERVER_2016_FULL |WINDOWS_SERVER_2016_CORE LINUX  etc.  This is a new attribute getting introduced , so existing linux functionality will not get affected by this change

Testing
Unit tests written for the new changes.
Existing tests were executed
Custom agent built and verified.

Note for external contributors:
make test and make run-integ-tests can run in a Linux development
environment like your laptop. go test -timeout=30s ./agent/... and
.\scripts\run-integ.tests.ps1 can run in a Windows development environment
like your laptop. Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use bot/test label to rerun the automatic tests multiple times.
-->

New tests cover the changes:
Yes.

Description for the changelog
"Add support for new ecs attribute  ecs.os-family "

Licensing
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.