### PR TITLE
Add a feature to support more IAM Roles in agent

### DIFF
--- a/agent/acs/model/api/api-2.json
+++ b/agent/acs/model/api/api-2.json
@@ -232,7 +232,9 @@
         "startTimeout":{"shape":"Integer"},
         "stopTimeout":{"shape":"Integer"},
         "firelensConfiguration":{"shape":"FirelensConfiguration"},
-        "containerArn":{"shape":"String"}
+        "containerArn":{"shape":"String"},
+        "roleCredentials":{"shape":"IAMRoleCredentials"},
+        "executionRoleCredentials":{"shape":"IAMRoleCredentials"}
       }
     },
     "ContainerCondition":{
@@ -459,8 +461,13 @@
         "taskArn":{"shape":"String"},
         "roleCredentials":{"shape":"IAMRoleCredentials"},
         "roleType":{"shape":"RoleType"},
-        "messageId":{"shape":"String"}
+        "messageId":{"shape":"String"},
+        "containerCredentialsList":{"shape":"StringList"}
       }
+    },
+    "ContainerCredentialsList": {
+      "type":"list",
+      "member":{"shape":"String"}
     },
     "IPv4AddressAssignment":{
       "type":"structure",

--- a/agent/acs/model/ecsacs/api.go
+++ b/agent/acs/model/ecsacs/api.go
@@ -377,6 +377,8 @@ type Container struct {
 
 	Essential *bool `locationName:"essential" type:"boolean"`
 
+	ExecutionRoleCredentials *IAMRoleCredentials `locationName:"executionRoleCredentials" type:"structure"`
+
 	FirelensConfiguration *FirelensConfiguration `locationName:"firelensConfiguration" type:"structure"`
 
 	HealthCheckType *string `locationName:"healthCheckType" type:"string" enum:"HealthCheckType"`
@@ -400,6 +402,8 @@ type Container struct {
 	PortMappings []*PortMapping `locationName:"portMappings" type:"list"`
 
 	RegistryAuthentication *RegistryAuthenticationData `locationName:"registryAuthentication" type:"structure"`
+
+	RoleCredentials *IAMRoleCredentials `locationName:"roleCredentials" type:"structure"`
 
 	Secrets []*Secret `locationName:"secrets" type:"list"`
 
@@ -852,6 +856,8 @@ func (s IAMRoleCredentialsAckRequest) GoString() string {
 
 type IAMRoleCredentialsMessage struct {
 	_ struct{} `type:"structure"`
+
+	ContainerCredentialsList []*string `locationName:"containerCredentialsList" type:"list"`
 
 	MessageId *string `locationName:"messageId" type:"string"`
 
@@ -1391,6 +1397,8 @@ func (s ProxyConfiguration) GoString() string {
 
 type RefreshTaskIAMRoleCredentialsInput struct {
 	_ struct{} `type:"structure"`
+
+	ContainerCredentialsList []*string `locationName:"containerCredentialsList" type:"list"`
 
 	MessageId *string `locationName:"messageId" type:"string"`
 

--- a/agent/api/container/container.go
+++ b/agent/api/container/container.go
@@ -142,6 +142,14 @@ type Container struct {
 	Name string
 	// RuntimeID is the docker id of the container
 	RuntimeID string
+	// CredentialsID is used to set the CredentialsID field for the
+	// IAMRoleCredentials object associated with the container. This id can be
+	// used to look up the credentials for container in the credentials manager
+	CredentialsID string
+	// ExecutionCredentialsID is used to set the ExecutionCredentialsID field for the
+	// IAMRoleCredentials object associated with the container. This id can be
+	// used to look up the credentials for container in the credentials manager
+	ExecutionCredentialsID string
 	// TaskARNUnsafe is the task ARN of the task that the container belongs to. Access should be
 	// protected by lock i.e. via GetTaskARN and SetTaskARN.
 	TaskARNUnsafe string `json:"taskARN"`
@@ -1196,6 +1204,38 @@ func (c *Container) RequireNeuronRuntime() bool {
 
 	_, ok := c.Environment[neuronVisibleDevicesEnvVar]
 	return ok
+}
+
+// SetCredentialsID sets the credentials ID for the container
+func (c *Container) SetCredentialsID(id string) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	c.CredentialsID = id
+}
+
+// GetCredentialsID gets the credentials ID for the container
+func (c *Container) GetCredentialsID() string {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	return c.CredentialsID
+}
+
+// SetExecutionCredentialsID sets the execution credentials ID for the container
+func (c *Container) SetExecutionCredentialsID(id string) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	c.ExecutionCredentialsID = id
+}
+
+// GetExecutionCredentialsID gets the execution credentials ID for the container
+func (c *Container) GetExecutionCredentialsID() string {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	return c.ExecutionCredentialsID
 }
 
 // SetTaskARN sets the task arn of the container.

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -57,6 +57,50 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestGetContainerByArn(t *testing.T) {
+	testTask := &Task{
+		Containers: []*apicontainer.Container{
+			{
+				Name:         "c1",
+				ContainerArn: "arn1",
+			},
+			{
+				Name:         "c2",
+				ContainerArn: "arn2",
+			},
+		},
+	}
+
+	tt := []struct {
+		name                  string
+		arn                   string
+		expectedError         error
+		expectedContainerName string
+	}{
+		{
+			name:                  "happy path",
+			arn:                   "arn2",
+			expectedError:         nil,
+			expectedContainerName: "c2",
+		},
+		{
+			name:                  "wrong arn",
+			arn:                   "arnnotexist",
+			expectedError:         fmt.Errorf("unable to find container with arn arnnotexist"),
+			expectedContainerName: "",
+		},
+	}
+	for _, test := range tt {
+		t.Run(test.name, func(t *testing.T) {
+			container, err := testTask.GetContainerByArn(test.arn)
+			assert.Equal(t, test.expectedError, err, "Error mismatch")
+			if test.expectedError == nil {
+				assert.Equal(t, test.expectedContainerName, container.Name, "Container name mismatch")
+			}
+		})
+	}
+}
+
 func TestDockerConfigPortBinding(t *testing.T) {
 	testTask := &Task{
 		Containers: []*apicontainer.Container{
@@ -497,6 +541,7 @@ func TestGetCredentialsEndpointWhenCredentialsAreSet(t *testing.T) {
 	credentialsManager := mock_credentials.NewMockManager(ctrl)
 
 	credentialsIDInTask := "credsid"
+	containerSpecificCredentialsID := "ccredsid"
 	task := Task{
 		Containers: []*apicontainer.Container{
 			{
@@ -504,8 +549,9 @@ func TestGetCredentialsEndpointWhenCredentialsAreSet(t *testing.T) {
 				Environment: make(map[string]string),
 			},
 			{
-				Name:        "c2",
-				Environment: make(map[string]string),
+				Name:          "c2",
+				Environment:   make(map[string]string),
+				CredentialsID: containerSpecificCredentialsID,
 			}},
 		credentialsID: credentialsIDInTask,
 	}
@@ -513,17 +559,28 @@ func TestGetCredentialsEndpointWhenCredentialsAreSet(t *testing.T) {
 	taskCredentials := credentials.TaskIAMRoleCredentials{
 		IAMRoleCredentials: credentials.IAMRoleCredentials{CredentialsID: "credsid"},
 	}
+	containerCredentials := credentials.ContainerIAMRoleCredentials{
+		IAMRoleCredentials: credentials.IAMRoleCredentials{CredentialsID: "ccredsid"},
+	}
 	credentialsManager.EXPECT().GetTaskCredentials(credentialsIDInTask).Return(taskCredentials, true)
+	credentialsManager.EXPECT().GetContainerCredentials("").Return(credentials.ContainerIAMRoleCredentials{}, false)
+	credentialsManager.EXPECT().GetContainerCredentials(containerSpecificCredentialsID).Return(containerCredentials, true)
 	task.initializeCredentialsEndpoint(credentialsManager)
 
 	// Test if all containers in the task have the environment variable for
-	// credentials endpoint set correctly.
-	for _, container := range task.Containers {
+	// credentials endpoint set correctly and make sure task creds and
+	// container specific creds are different
+	uris := [2]string{"", ""}
+	for iter, container := range task.Containers {
 		env := container.Environment
-		_, exists := env[awsSDKCredentialsRelativeURIPathEnvironmentVariableName]
+		uri, exists := env[awsSDKCredentialsRelativeURIPathEnvironmentVariableName]
+		uris[iter] = uri
 		if !exists {
 			t.Errorf("'%s' environment variable not set for container '%s', env: %v", awsSDKCredentialsRelativeURIPathEnvironmentVariableName, container.Name, env)
 		}
+	}
+	if uris[0] == uris[1] {
+		t.Errorf("container specific credential uri %s is the same as task credential uri %s", uris[1], uris[0])
 	}
 }
 
@@ -746,6 +803,7 @@ func TestPostUnmarshalTaskWithEFSVolumesThatUseECSVolumePlugin(t *testing.T) {
 	}
 	expectedEndpoint := "/v2/credentials/" + credentialsIDInTask
 	credentialsManager.EXPECT().GetTaskCredentials(credentialsIDInTask).Return(taskCredentials, true)
+	credentialsManager.EXPECT().GetContainerCredentials("").Return(credentials.ContainerIAMRoleCredentials{}, false)
 
 	taskFromACS := getACSEFSTask()
 	taskFromACS.RoleCredentials = testCreds

--- a/agent/credentials/interface.go
+++ b/agent/credentials/interface.go
@@ -19,5 +19,8 @@ package credentials
 type Manager interface {
 	SetTaskCredentials(*TaskIAMRoleCredentials) error
 	GetTaskCredentials(string) (TaskIAMRoleCredentials, bool)
+	SetContainerCredentials(*ContainerIAMRoleCredentials) error
+	GetContainerCredentials(string) (ContainerIAMRoleCredentials, bool)
 	RemoveCredentials(string)
+	RemoveContainerCredentials(string)
 }

--- a/agent/credentials/mocks/credentials_mocks.go
+++ b/agent/credentials/mocks/credentials_mocks.go
@@ -48,6 +48,21 @@ func (m *MockManager) EXPECT() *MockManagerMockRecorder {
 	return m.recorder
 }
 
+// GetContainerCredentials mocks base method
+func (m *MockManager) GetContainerCredentials(arg0 string) (credentials.ContainerIAMRoleCredentials, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetContainerCredentials", arg0)
+	ret0, _ := ret[0].(credentials.ContainerIAMRoleCredentials)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// GetContainerCredentials indicates an expected call of GetContainerCredentials
+func (mr *MockManagerMockRecorder) GetContainerCredentials(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContainerCredentials", reflect.TypeOf((*MockManager)(nil).GetContainerCredentials), arg0)
+}
+
 // GetTaskCredentials mocks base method
 func (m *MockManager) GetTaskCredentials(arg0 string) (credentials.TaskIAMRoleCredentials, bool) {
 	m.ctrl.T.Helper()
@@ -63,6 +78,18 @@ func (mr *MockManagerMockRecorder) GetTaskCredentials(arg0 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTaskCredentials", reflect.TypeOf((*MockManager)(nil).GetTaskCredentials), arg0)
 }
 
+// RemoveContainerCredentials mocks base method
+func (m *MockManager) RemoveContainerCredentials(arg0 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "RemoveContainerCredentials", arg0)
+}
+
+// RemoveContainerCredentials indicates an expected call of RemoveContainerCredentials
+func (mr *MockManagerMockRecorder) RemoveContainerCredentials(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveContainerCredentials", reflect.TypeOf((*MockManager)(nil).RemoveContainerCredentials), arg0)
+}
+
 // RemoveCredentials mocks base method
 func (m *MockManager) RemoveCredentials(arg0 string) {
 	m.ctrl.T.Helper()
@@ -73,6 +100,20 @@ func (m *MockManager) RemoveCredentials(arg0 string) {
 func (mr *MockManagerMockRecorder) RemoveCredentials(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveCredentials", reflect.TypeOf((*MockManager)(nil).RemoveCredentials), arg0)
+}
+
+// SetContainerCredentials mocks base method
+func (m *MockManager) SetContainerCredentials(arg0 *credentials.ContainerIAMRoleCredentials) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetContainerCredentials", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetContainerCredentials indicates an expected call of SetContainerCredentials
+func (mr *MockManagerMockRecorder) SetContainerCredentials(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetContainerCredentials", reflect.TypeOf((*MockManager)(nil).SetContainerCredentials), arg0)
 }
 
 // SetTaskCredentials mocks base method

--- a/agent/engine/docker_task_engine_linux_test.go
+++ b/agent/engine/docker_task_engine_linux_test.go
@@ -310,6 +310,7 @@ func TestTaskCPULimitHappyPath(t *testing.T) {
 				IAMRoleCredentials: credentials.IAMRoleCredentials{CredentialsID: "credsid"},
 			}
 			credentialsManager.EXPECT().GetTaskCredentials(credentialsID).Return(roleCredentials, true).AnyTimes()
+			credentialsManager.EXPECT().GetContainerCredentials("").Return(credentials.ContainerIAMRoleCredentials{}, false).AnyTimes()
 			credentialsManager.EXPECT().RemoveCredentials(credentialsID)
 
 			sleepTask := testdata.LoadTask("sleep5")

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -241,6 +241,7 @@ func TestBatchContainerHappyPath(t *testing.T) {
 				IAMRoleCredentials: credentials.IAMRoleCredentials{CredentialsID: "credsid"},
 			}
 			credentialsManager.EXPECT().GetTaskCredentials(credentialsID).Return(roleCredentials, true).AnyTimes()
+			credentialsManager.EXPECT().GetContainerCredentials("").Return(credentials.ContainerIAMRoleCredentials{}, false).AnyTimes()
 			credentialsManager.EXPECT().RemoveCredentials(credentialsID)
 
 			sleepTask := testdata.LoadTask("sleep5")

--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -356,6 +356,12 @@ func (mtask *managedTask) cleanupCredentials() {
 	if taskCredentialsID != "" {
 		mtask.credentialsManager.RemoveCredentials(taskCredentialsID)
 	}
+	for _, container := range mtask.Task.Containers {
+		containerCredentialsId := container.GetCredentialsID()
+		if containerCredentialsId != "" {
+			mtask.credentialsManager.RemoveContainerCredentials(containerCredentialsId)
+		}
+	}
 }
 
 // waitEvent waits for any event to occur. If an event occurs, the appropriate
@@ -1456,6 +1462,13 @@ func (mtask *managedTask) cleanupTask(taskStoppedDuration time.Duration) {
 	logger.Info("Cleaning up task's containers and data", logger.Fields{
 		field.TaskARN: mtask.Arn,
 	})
+
+	for _, container := range mtask.Task.Containers {
+		containerExecutionCredentialsId := container.GetExecutionCredentialsID()
+		if containerExecutionCredentialsId != "" {
+			mtask.credentialsManager.RemoveContainerCredentials(containerExecutionCredentialsId)
+		}
+	}
 
 	// For the duration of this, simply discard any task events; this ensures the
 	// speedy processing of other events for other tasks


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Add a feature to support more IAM roles in agent, including:
1.  accept updated ACS AddTask and RefreshCredentials payload
2. store/update/remove corresponding container specific credentials in agent memory.

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
make release and make test

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Add a feature to support more IAM roles in agent, including:
1.  accept updated ACS AddTask and RefreshCredentials payload
2. store/update/remove corresponding container specific credentials in agent memory.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
