### PR TITLE
Improve error log when instance reigstration fails due to bad attributes

### DIFF
--- a/agent/api/container/transport.go
+++ b/agent/api/container/transport.go
@@ -56,7 +56,7 @@ func (tp *TransportProtocol) String() string {
 	case TransportProtocolTCP:
 		return tcp
 	default:
-		seelog.Critical("Unknown TransportProtocol type!")
+		seelog.Criticalf("Unknown TransportProtocol type: %s", *tp)
 		return tcp
 	}
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Addresses https://github.com/aws/amazon-ecs-agent/issues/2981

### Implementation details
The validation of the attributes is done in the back-end. When validation fails, the back end doesn't return an actual error, so the agent actually compares attributes in the request vs attributes in the response, and if any are missing we deduct there was a problem, how ever there's no information as to why. 

However, the information about attribute validation is documented publicly, so we add that information in the log for the customer convenience. 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

UTs suffice

### Description for the changelog
* Improvement of log message displayed when container instance registartion fails due to attribute validation errors.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
