### PR TITLE
Use GO_VERSION and GO_VERSION_WINDOWS in Github action workflows

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -7,16 +7,23 @@ jobs:
     name: Linux unit tests
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-go@v2
-      with:
-        go-version: 1.15.4
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
-        path: src/github.com/aws/amazon-ecs-agent
-    - name: make test
-      run: |
-        export GOPATH=$GITHUB_WORKSPACE
-        cd $GITHUB_WORKSPACE/src/github.com/aws/amazon-ecs-agent
-        make test-silent
-        make analyze-cover-profile
+      - uses: actions/checkout@v2
+        with:
+          path: src/github.com/aws/amazon-ecs-agent
+      - name: get GO_VERSION
+        run:  |
+          cd $GITHUB_WORKSPACE/src/github.com/aws/amazon-ecs-agent
+          echo "GO_VERSION=$(cat GO_VERSION)" >> $GITHUB_ENV
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+          path: src/github.com/aws/amazon-ecs-agent
+      - name: make test
+        run: |
+          export GOPATH=$GITHUB_WORKSPACE
+          cd $GITHUB_WORKSPACE/src/github.com/aws/amazon-ecs-agent
+          make test-silent
+          make analyze-cover-profile

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -7,33 +7,47 @@ jobs:
     name: Static Analysis
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-go@v2
-      with:
-        go-version: 1.15.4
-    - uses: actions/checkout@v2
-      with:
-        path: src/github.com/aws/amazon-ecs-agent
-    - name: run static checks
-      run: |
-        export GOPATH=$GITHUB_WORKSPACE
-        export PATH=$PATH:$(go env GOPATH)/bin
-        cd $GITHUB_WORKSPACE/src/github.com/aws/amazon-ecs-agent
-        make get-deps
-        make static-check
+      - uses: actions/checkout@v2
+        with:
+          path: src/github.com/aws/amazon-ecs-agent
+      - name: get GO_VERSION
+        run:  |
+          cd $GITHUB_WORKSPACE/src/github.com/aws/amazon-ecs-agent
+          echo "GO_VERSION=$(cat GO_VERSION)" >> $GITHUB_ENV
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - uses: actions/checkout@v2
+        with:
+          path: src/github.com/aws/amazon-ecs-agent
+      - name: run static checks
+        run: |
+          export GOPATH=$GITHUB_WORKSPACE
+          export PATH=$PATH:$(go env GOPATH)/bin
+          cd $GITHUB_WORKSPACE/src/github.com/aws/amazon-ecs-agent
+          make get-deps
+          make static-check
 
   x-platform-build:
     name: Cross platform build
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-go@v2
-      with:
-        go-version: 1.15.4
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
-        path: src/github.com/aws/amazon-ecs-agent
-    - name: make xplatform-build
-      run: |
-        export GOPATH=$GITHUB_WORKSPACE
-        cd $GITHUB_WORKSPACE/src/github.com/aws/amazon-ecs-agent
-        make xplatform-build
+      - uses: actions/checkout@v2
+        with:
+          path: src/github.com/aws/amazon-ecs-agent
+      - name: get GO_VERSION
+        run:  |
+          cd $GITHUB_WORKSPACE/src/github.com/aws/amazon-ecs-agent
+          echo "GO_VERSION=$(cat GO_VERSION)" >> $GITHUB_ENV
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+          path: src/github.com/aws/amazon-ecs-agent
+      - name: make xplatform-build
+        run: |
+          export GOPATH=$GITHUB_WORKSPACE
+          cd $GITHUB_WORKSPACE/src/github.com/aws/amazon-ecs-agent
+          make xplatform-build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,17 +7,25 @@ jobs:
     name: Windows unit tests
     runs-on: windows-latest
     steps:
-    - uses: actions/setup-go@v2
-      with:
-        go-version: 1.12
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
-        path: src/github.com/aws/amazon-ecs-agent
-    - name: run tests
-      working-directory:
-      run: |
-        $Env:GOPATH = "$Env:GITHUB_WORKSPACE"
-        cd "$Env:GITHUB_WORKSPACE"
-        cd "src/github.com/aws/amazon-ecs-agent"
-        go test -race -tags unit -timeout 40s ./agent/...
+      - uses: actions/checkout@v2
+        with:
+          path: src/github.com/aws/amazon-ecs-agent
+      - name: get GO_VERSION
+        run:  |
+          cd "$Env:GITHUB_WORKSPACE"
+          cd "src/github.com/aws/amazon-ecs-agent"
+          echo "GO_VERSION_WINDOWS=$(type GO_VERSION_WINDOWS)" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION_WINDOWS }}
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+          path: src/github.com/aws/amazon-ecs-agent
+      - name: run tests
+        working-directory:
+        run: |
+          $Env:GOPATH = "$Env:GITHUB_WORKSPACE"
+          cd "$Env:GITHUB_WORKSPACE"
+          cd "src/github.com/aws/amazon-ecs-agent"
+          go test -race -tags unit -timeout 40s ./agent/...


### PR DESCRIPTION
### Summary
This pull request gets `GO_VERSION` and  `GO_VERSION_WINDOWS` defined in the aws/amazon-ecs-agent repo, and use them in Github action workflows to ensure **Linux unit tests**,  **Static Analysis**, **Cross platform build** and **Windows unit tests** are executing with the up-to-date Go version used in Agent.

> Reference - [Workflow commands for GitHub Actions](https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable)
  
### Implementation details
1. Get `GO_VERSION` from the `aws/amazon-ecs-agent/GO_VERSION` file, and save it as a Github environment variable `GITHUB_ENV`.
2. Use the saved `GO_VERSION` from the Github environment variable as the `go-version` to run Linux unit tests, Static Analysis and Cross platform build.
3. Get `GO_VERSION_WINDOWS` from the `aws/amazon-ecs-agent/GO_VERSION_WINDOWS` file, and save it as `GITHUB_ENV`.
4. Use the saved `GO_VERSION_WINDOWS` from the Github environment variable as the `go-version` to run Windows unit tests.

### Testing
Run following checks, and verify Go version from check's details. 
* Linux / Linux unit tests (pull_request) - Go version is `1.15.9`, as defined in the current [GO_VERSION](https://github.com/aws/amazon-ecs-agent/blob/dev/GO_VERSION) file. 
* Static Checks / Static Analysis (pull_request) - Go version is `1.15.9`, as defined in the current [GO_VERSION](https://github.com/aws/amazon-ecs-agent/blob/dev/GO_VERSION) file. 
* Static Checks / Cross platform build (pull_request) - Go version is `1.15.9`, as defined in the current [GO_VERSION](https://github.com/aws/amazon-ecs-agent/blob/dev/GO_VERSION) file. 
* Windows / Windows unit tests (pull_request) - Go version is `1.12`, as defined in the current [GO_VERSION_WINDOWS](https://github.com/aws/amazon-ecs-agent/blob/dev/GO_VERSION_WINDOWS) file. 
  
New tests cover the changes: no

### Description for the changelog
N/A

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
