### PR TITLE
Add GPU support for external instance using nvidia-container-runtime

### DIFF
--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -1560,27 +1560,20 @@ func (task *Task) getDockerResources(container *apicontainer.Container, cfg *con
 			task.Arn, container.Name, apicontainer.DockerContainerMinimumMemoryInBytes)
 		dockerMem = apicontainer.DockerContainerMinimumMemoryInBytes
 	}
-	resources := dockercontainer.Resources{}
 	// Set CPUShares
 	cpuShare := task.dockerCPUShares(container.CPU)
+	resources := dockercontainer.Resources{
+		Memory:    dockerMem,
+		CPUShares: cpuShare,
+	}
 	if cfg.External.Enabled() && cfg.GPUSupportEnabled {
 		deviceRequest := dockercontainer.DeviceRequest{
 			Capabilities: [][]string{[]string{"gpu"}},
 			DeviceIDs:    container.GPUIDs,
 		}
-		resources = dockercontainer.Resources{
-			Memory:         dockerMem,
-			CPUShares:      cpuShare,
-			DeviceRequests: []dockercontainer.DeviceRequest{deviceRequest},
-		}
-		return resources
-	} else {
-		resources = dockercontainer.Resources{
-			Memory:    dockerMem,
-			CPUShares: cpuShare,
-		}
-		return resources
+		resources.DeviceRequests = []dockercontainer.DeviceRequest{deviceRequest}
 	}
+	return resources
 }
 
 // shouldOverrideNetworkMode returns true if the network mode of the container needs

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -462,8 +462,8 @@ func (task *Task) addGPUResource(cfg *config.Config) error {
 		// For internal instances, GPU IDs are handled by env var
 		if !cfg.External.Enabled() {
 			task.populateGPUEnvironmentVariables()
+			task.NvidiaRuntime = cfg.NvidiaRuntime
 		}
-		task.NvidiaRuntime = cfg.NvidiaRuntime
 	}
 	return nil
 }
@@ -1535,10 +1535,10 @@ func (task *Task) dockerHostConfig(container *apicontainer.Container, dockerCont
 func (task *Task) overrideContainerRuntime(container *apicontainer.Container, hostCfg *dockercontainer.HostConfig,
 	cfg *config.Config) *apierrors.HostConfigError {
 	if task.isGPUEnabled() && task.shouldRequireNvidiaRuntime(container) {
-		if task.NvidiaRuntime == "" {
-			return &apierrors.HostConfigError{Msg: "Runtime is not set for GPU containers"}
-		}
 		if !cfg.External.Enabled() {
+			if task.NvidiaRuntime == "" {
+				return &apierrors.HostConfigError{Msg: "Runtime is not set for GPU containers"}
+			}
 			seelog.Debugf("Setting runtime as %s for container %s", task.NvidiaRuntime, container.Name)
 			hostCfg.Runtime = task.NvidiaRuntime
 		}

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -458,7 +458,7 @@ func (task *Task) addGPUResource(cfg *config.Config) error {
 				container.GPUIDs = append(container.GPUIDs, association.Name)
 			}
 		}
-		task.populateGPUEnvironmentVariables()
+		//task.populateGPUEnvironmentVariables()
 		task.NvidiaRuntime = cfg.NvidiaRuntime
 	}
 	return nil
@@ -1535,7 +1535,7 @@ func (task *Task) overrideContainerRuntime(container *apicontainer.Container, ho
 			return &apierrors.HostConfigError{Msg: "Runtime is not set for GPU containers"}
 		}
 		seelog.Debugf("Setting runtime as %s for container %s", task.NvidiaRuntime, container.Name)
-		hostCfg.Runtime = task.NvidiaRuntime
+		//hostCfg.Runtime = task.NvidiaRuntime
 	}
 
 	if cfg.InferentiaSupportEnabled && container.RequireNeuronRuntime() {
@@ -1554,11 +1554,16 @@ func (task *Task) getDockerResources(container *apicontainer.Container) dockerco
 			task.Arn, container.Name, apicontainer.DockerContainerMinimumMemoryInBytes)
 		dockerMem = apicontainer.DockerContainerMinimumMemoryInBytes
 	}
+	deviceRequest := dockercontainer.DeviceRequest{
+		Capabilities: [][]string{[]string{"gpu"}},
+		DeviceIDs:    container.GPUIDs,
+	}
 	// Set CPUShares
 	cpuShare := task.dockerCPUShares(container.CPU)
 	resources := dockercontainer.Resources{
-		Memory:    dockerMem,
-		CPUShares: cpuShare,
+		Memory:         dockerMem,
+		CPUShares:      cpuShare,
+		DeviceRequests: []dockercontainer.DeviceRequest{deviceRequest},
 	}
 	return resources
 }

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -1538,8 +1538,8 @@ func (task *Task) overrideContainerRuntime(container *apicontainer.Container, ho
 		if task.NvidiaRuntime == "" {
 			return &apierrors.HostConfigError{Msg: "Runtime is not set for GPU containers"}
 		}
-		seelog.Debugf("Setting runtime as %s for container %s", task.NvidiaRuntime, container.Name)
 		if !cfg.External.Enabled() {
+			seelog.Debugf("Setting runtime as %s for container %s", task.NvidiaRuntime, container.Name)
 			hostCfg.Runtime = task.NvidiaRuntime
 		}
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This change adds the ability to handle GPU tasks for external instances. For external instances, GPU support will rely on nvidia-container-runtime package, for which the support has been added in this PR. For internal instances, the behavior is unchanged.

### Implementation details
<!-- How are the changes implemented? -->
- For external instance, use [DeviceRequest](https://pkg.go.dev/github.com/docker/docker@v20.10.8+incompatible/api/types/container#DeviceRequest) struct to carry GPU IDs for using nvidia-container-runtime
- For internal instance, the environment variable NVIDIA_VISIBLE_DEVICES will continue to carry GPU IDs (unchanged behavior, continue to use default runtime)

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
- Manually tested changes running GPU tasks on external and internal instances
- Added unit tests to verify GPU IDs are properly populated for internal and external instances.
- Verified using 'make test'

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Add support for GPU tasks for external instances
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
