### PR TITLE
Route awslogs using container execution credentials if presented

### DIFF
--- a/agent/acs/handler/payload_handler.go
+++ b/agent/acs/handler/payload_handler.go
@@ -217,7 +217,7 @@ func (payloadHandler *payloadRequestHandler) addPayloadTasks(payload *ecsacs.Pay
 			apiTask.SetCredentialsID(taskIAMRoleCredentials.CredentialsID)
 		}
 
-		err = payloadHandler.updateContainerCredentials(payload, apiTask, task)
+		err = payloadHandler.updateContainerCredentials(apiTask, task)
 		if err != nil {
 			payloadHandler.handleUnrecognizedTask(task, err, payload)
 			allTasksOK = false
@@ -283,7 +283,7 @@ func (payloadHandler *payloadRequestHandler) addPayloadTasks(payload *ecsacs.Pay
 }
 
 // updateContainerCredentials add container specific credentials from ACS payload to credentials manager and set credentials id for containers
-func (payloadHandler *payloadRequestHandler) updateContainerCredentials(payload *ecsacs.PayloadMessage, apiTask *apitask.Task, task *ecsacs.Task) error {
+func (payloadHandler *payloadRequestHandler) updateContainerCredentials(apiTask *apitask.Task, task *ecsacs.Task) error {
 	var err error
 	for _, container := range task.Containers {
 		var apiContainer *apicontainer.Container

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -1079,7 +1079,7 @@ func (engine *DockerTaskEngine) createContainer(task *apitask.Task, container *a
 	}
 
 	if container.AWSLogAuthExecutionRole() {
-		err := task.ApplyExecutionRoleLogsAuth(hostConfig, engine.credentialsManager)
+		err := task.ApplyExecutionRoleLogsAuth(hostConfig, engine.credentialsManager, container)
 		if err != nil {
 			return dockerapi.DockerContainerMetadata{Error: apierrors.NamedError(err)}
 		}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
use container execution credentials as the first option for routing awslogs to cloudwatch in hostconfig + a minor fix of previous change (remove an unused argument)

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
make test

New tests cover the changes: <!-- yes|no -->
yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
use container execution credentials as the first option for routing awslogs to cloudwatch in hostconfig, backed up by existing task execution credentials

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
