### PR TITLE
Publish firelens v2 container status message to TACS

### DIFF
--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -1166,10 +1166,13 @@ func (task *Task) AddFirelensContainerBindMounts(firelensConfig *apicontainer.Fi
 			socketBind := fmt.Sprintf(firelensV2SocketBindFormat, config.DataDirOnHost, taskID)
 			hostConfig.Binds = append(hostConfig.Binds, socketBind)
 		}
-		statusMsgBind := fmt.Sprintf(firelensV2StatusMessageBindFormat, config.DataDirOnHost, taskID, containerName,
-			firelensConfig.StatusMessageReportingPath)
-		hostConfig.Binds = append(hostConfig.Binds, statusMsgBind)
-
+		if firelensConfig.StatusMessageReportingPath != "" {
+			statusMsgBind := fmt.Sprintf(firelensV2StatusMessageBindFormat, config.DataDirOnHost, taskID, containerName,
+				firelensConfig.StatusMessageReportingPath)
+			hostConfig.Binds = append(hostConfig.Binds, statusMsgBind)
+		} else {
+			return &apierrors.HostConfigError{Msg: "status message reporting path is empty in firelens v2 configuration"}
+		}
 		return nil
 	}
 

--- a/agent/stats/utils_unix.go
+++ b/agent/stats/utils_unix.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/cihub/seelog"
 	"github.com/docker/docker/api/types"
+
+	"github.com/aws/amazon-ecs-agent/agent/utils"
 )
 
 // dockerStatsToContainerStats returns a new object of the ContainerStats object from docker stats.
@@ -65,4 +67,13 @@ func getStorageStats(dockerStats *types.StatsJSON) (uint64, uint64) {
 		}
 	}
 	return storageReadBytes, storageWriteBytes
+}
+
+func getStatusMessageReportingPath(dataDirOnHost, taskARN, containerName string) (string, error) {
+	taskID, err := utils.GetTaskID(taskARN)
+	if err != nil {
+		return "", err
+	}
+	statusMessageFilePath := fmt.Sprintf(firelensV2StatusMessageFilePathFormat, dataDirOnHost, taskID, containerName, firelensV2StatusMessageFileName)
+	return statusMessageFilePath, nil
 }

--- a/agent/stats/utils_unix_test.go
+++ b/agent/stats/utils_unix_test.go
@@ -57,3 +57,11 @@ func TestDockerStatsToContainerStatsEmptyCpuUsageGeneratesError(t *testing.T) {
 	err := validateDockerStats(dockerStat)
 	assert.Error(t, err, "expected error converting container stats with empty PercpuUsage")
 }
+
+func TestGetStatusMessageReportingPath(t *testing.T) {
+	var testDataDirOnHost, testContainerName, testTaskARN = "/testDir", "testContainer", "arn:aws:ecs:us-west-2:1234567890:task/test-cluster/abc"
+	expectedStatusMessageFilePath := "/testDir/data/telemetry/abc/status-message/testContainer/status-message"
+	statusMessageFilePath, err := getStatusMessageReportingPath(testDataDirOnHost, testTaskARN, testContainerName)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedStatusMessageFilePath, statusMessageFilePath, "unexpected value for statusMessageFilePath", statusMessageFilePath)
+}

--- a/agent/stats/utils_windows.go
+++ b/agent/stats/utils_windows.go
@@ -43,3 +43,8 @@ func validateDockerStats(dockerStats *types.StatsJSON) error {
 	}
 	return nil
 }
+
+// firelens v2 is currently not supported for windows
+func getStatusMessageReportingPath(dataDirOnHost, taskARN, containerName string) (string, error) {
+	return "", nil
+}

--- a/agent/tcs/model/api/api-2.json
+++ b/agent/tcs/model/api/api-2.json
@@ -131,6 +131,7 @@
       "type":"structure",
       "members":{
         "containerName":{"shape":"String"},
+        "statusMessage": {"shape":"String"},
         "healthStatus":{"shape":"HealthStatus"},
         "statusSince":{"shape":"Timestamp"}
       }

--- a/agent/tcs/model/ecstcs/api.go
+++ b/agent/tcs/model/ecstcs/api.go
@@ -140,6 +140,8 @@ type ContainerHealth struct {
 
 	HealthStatus *string `locationName:"healthStatus" type:"string" enum:"HealthStatus"`
 
+	StatusMessage *string `locationName:"statusMessage" type:"string"`
+
 	StatusSince *time.Time `locationName:"statusSince" type:"timestamp"`
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR includes changes to publish status message of firelens v2 containers to TACS in `PublishHealthRequests`.

### Implementation details
<!-- How are the changes implemented? -->
- `agent/api/task/` - updated the status message bind format for firelens v2 container host config; updated `AddFirelensContainerBindMounts()` to return error if firelens v2 config's "StatusMessageReportingPath" is empty string;  updated tests accordingly.
- `agent/stats/` - added getContainerStatusMessage() function to read status message of fireless v2 container and a helper function to return status message file path.  Status message is omitted while publishing container health request  to  TACS for non firelens v2 containers.
- `agent/tcs/`:  updated ContainerHealth structure in tcs model with statusMessage field 

**TODO**: Publish status message just once after the firelens v2 container is marked as stopped.
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
