### PR TITLE
Introduce a new environment variable ECS_EXCLUDE_IPV6_PORTBINDING

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,8 @@ additional details on each available environment variable.
 | `ECS_ENABLE_AWSLOGS_EXECUTIONROLE_OVERRIDE` | `true` | Whether to enable awslogs log driver to authenticate via credentials of task execution IAM role. Needs to be true if you want to use awslogs log driver in a task that has task execution IAM role specified. When using the ecs-init RPM with version equal or later than V1.16.0-1, this env is set to true by default. | `false` | `false` |
 | `ECS_FSX_WINDOWS_FILE_SERVER_SUPPORTED` | `true` | Whether FSx for Windows File Server volume type is supported on the container instance. This variable is only supported on agent versions 1.47.0 and later. | `false` | `true` |
 | `ECS_ENABLE_RUNTIME_STATS` | `true` | Determines if [pprof](https://pkg.go.dev/net/http/pprof) is enabled for the agent. If enabled, the different profiles can be accessed through the agent's introspection port (e.g. `curl http://localhost:51678/debug/pprof/heap > heap.pprof`). In addition, agent's [runtime stats](https://pkg.go.dev/runtime#ReadMemStats) are logged to `/var/log/ecs/runtime-stats.log` file. | `false` | `false` |
-
+| `ECS_EXCLUDE_IPV6_PORTBINDING` | `true` | Determines if agent should exclude IPv6 port binding using default network mode. If enabled, IPv6 port binding will be filtered out, and the response of DescribeTasks API call will not show tasks' IPv6 port bindings, but it is still included in Task metadata endpoint. | `true` | `true` |
+  
 ### Persistence
 
 When you run the Amazon ECS Container Agent in production, its `datadir` should be persisted between runs of the Docker

--- a/agent/api/ecsclient/client_test.go
+++ b/agent/api/ecsclient/client_test.go
@@ -84,9 +84,10 @@ func NewMockClient(ctrl *gomock.Controller,
 
 	return NewMockClientWithConfig(ctrl, ec2Metadata, additionalAttributes,
 		&config.Config{
-			Cluster:            configuredCluster,
-			AWSRegion:          "us-east-1",
-			InstanceAttributes: additionalAttributes,
+			Cluster:                      configuredCluster,
+			AWSRegion:                    "us-east-1",
+			InstanceAttributes:           additionalAttributes,
+			ShouldExcludeIPv6PortBinding: config.BooleanDefaultTrue{Value: config.ExplicitlyEnabled},
 		})
 }
 

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -591,6 +591,7 @@ func environmentConfig() (Config, error) {
 		FSxWindowsFileServerCapable:         parseFSxWindowsFileServerCapability(),
 		External:                            parseBooleanDefaultFalseConfig("ECS_EXTERNAL"),
 		EnableRuntimeStats:                  parseBooleanDefaultFalseConfig("ECS_ENABLE_RUNTIME_STATS"),
+		ShouldExcludeIPv6PortBinding:        parseBooleanDefaultTrueConfig("ECS_EXCLUDE_IPV6_PORTBINDING"),
 	}, err
 }
 
@@ -623,6 +624,7 @@ func (cfg *Config) String() string {
 			"ContainerCreateTimeout: %v, "+
 			"DependentContainersPullUpfront: %v, "+
 			"TaskCPUMemLimit: %v, "+
+			"ShouldExcludeIPv6PortBinding: %v, "+
 			"%s",
 		cfg.Cluster,
 		cfg.AWSRegion,
@@ -640,6 +642,7 @@ func (cfg *Config) String() string {
 		cfg.ContainerCreateTimeout,
 		cfg.DependentContainersPullUpfront,
 		cfg.TaskCPUMemLimit,
+		cfg.ShouldExcludeIPv6PortBinding,
 		cfg.platformString(),
 	)
 }

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -157,6 +157,7 @@ func TestEnvironmentConfig(t *testing.T) {
 	defer setTestEnv("ECS_CGROUP_CPU_PERIOD", "")
 	defer setTestEnv("ECS_PULL_DEPENDENT_CONTAINERS_UPFRONT", "true")()
 	defer setTestEnv("ECS_ENABLE_RUNTIME_STATS", "true")()
+	defer setTestEnv("ECS_EXCLUDE_IPV6_PORTBINDING", "true")()
 	additionalLocalRoutesJSON := `["1.2.3.4/22","5.6.7.8/32"]`
 	setTestEnv("ECS_AWSVPC_ADDITIONAL_LOCAL_ROUTES", additionalLocalRoutesJSON)
 	setTestEnv("ECS_ENABLE_CONTAINER_METADATA", "true")
@@ -214,6 +215,7 @@ func TestEnvironmentConfig(t *testing.T) {
 	assert.Equal(t, []string{"efsAuth"}, conf.VolumePluginCapabilities)
 	assert.True(t, conf.DependentContainersPullUpfront.Enabled(), "Wrong value for DependentContainersPullUpfront")
 	assert.True(t, conf.EnableRuntimeStats.Enabled(), "Wrong value for EnableRuntimeStats")
+	assert.True(t, conf.ShouldExcludeIPv6PortBinding.Enabled(), "Wrong value for ShouldExcludeIPv6PortBinding")
 }
 
 func TestTrimWhitespaceWhenCreating(t *testing.T) {

--- a/agent/config/config_unix.go
+++ b/agent/config/config_unix.go
@@ -97,6 +97,7 @@ func DefaultConfig() Config {
 		FSxWindowsFileServerCapable:         false,
 		RuntimeStatsLogFile:                 defaultRuntimeStatsLogFile,
 		EnableRuntimeStats:                  BooleanDefaultFalse{Value: NotSet},
+		ShouldExcludeIPv6PortBinding:        BooleanDefaultTrue{Value: ExplicitlyEnabled},
 	}
 }
 

--- a/agent/config/config_unix_test.go
+++ b/agent/config/config_unix_test.go
@@ -72,6 +72,7 @@ func TestConfigDefault(t *testing.T) {
 	assert.False(t, cfg.DependentContainersPullUpfront.Enabled(), "Default DependentContainersPullUpfront set incorrectly")
 	assert.False(t, cfg.PollMetrics.Enabled(), "ECS_POLL_METRICS default should be false")
 	assert.False(t, cfg.EnableRuntimeStats.Enabled(), "Default EnableRuntimeStats set incorrectly")
+	assert.True(t, cfg.ShouldExcludeIPv6PortBinding.Enabled(), "Default ShouldExcludeIPv6PortBinding set incorrectly")
 }
 
 // TestConfigFromFile tests the configuration can be read from file

--- a/agent/config/config_windows.go
+++ b/agent/config/config_windows.go
@@ -136,6 +136,7 @@ func DefaultConfig() Config {
 		CNIPluginsPath:                      filepath.Join(ecsBinaryDir, defaultCNIPluginDirName),
 		RuntimeStatsLogFile:                 filepath.Join(ecsRoot, defaultRuntimeStatsLogFile),
 		EnableRuntimeStats:                  BooleanDefaultFalse{Value: NotSet},
+		ShouldExcludeIPv6PortBinding:        BooleanDefaultTrue{Value: ExplicitlyEnabled},
 	}
 }
 

--- a/agent/config/config_windows_test.go
+++ b/agent/config/config_windows_test.go
@@ -69,6 +69,7 @@ func TestConfigDefault(t *testing.T) {
 	assert.Equal(t, DefaultImagePullTimeout, cfg.ImagePullTimeout, "Default ImagePullTimeout set incorrectly")
 	assert.False(t, cfg.DependentContainersPullUpfront.Enabled(), "Default DependentContainersPullUpfront set incorrectly")
 	assert.False(t, cfg.EnableRuntimeStats.Enabled(), "Default EnableRuntimeStats set incorrectly")
+	assert.True(t, cfg.ShouldExcludeIPv6PortBinding.Enabled(), "Default ShouldExcludeIPv6PortBinding set incorrectly")
 }
 
 func TestConfigIAMTaskRolesReserves80(t *testing.T) {

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -349,4 +349,9 @@ type Config struct {
 	// EnableRuntimeStats specifies if pprof should be enabled through the agent introspection port. By default, this configuration
 	// is set to false and can be overridden by means of the ECS_ENABLE_RUNTIME_STATS environment variable.
 	EnableRuntimeStats BooleanDefaultFalse
+
+	// ShouldExcludeIPv6PortBinding specifies whether agent should exclude IPv6 port bindings reported from docker. This configuration
+	// is set to true by default, and can be overridden by the ECS_EXCLUDE_IPV6_PORTBINDING environment variable. This is a workaround
+	// for docker's bug as detailed in https://github.com/aws/amazon-ecs-agent/issues/2870.
+	ShouldExcludeIPv6PortBinding BooleanDefaultTrue
 }


### PR DESCRIPTION
### Summary
A behavioral change in docker container port binding, where both IPv4 and IPv6 bindings will be exposed starting from Docker version 20.10.6, is reported in following issues and PR:
* https://github.com/aws/amazon-ecs-agent/issues/2870
* https://github.com/aws/amazon-ecs-agent/pull/2855
* https://github.com/aws/containers-roadmap/issues/1377
* https://github.com/moby/moby/issues/42442
* https://github.com/moby/moby/issues/42375
  
To mitigate this issue, this PR introduces a new agent environment variable `ECS_EXCLUDE_IPV6_PORTBINDING` to filter out IPv6 port bindings for default network mode tasks. This config variable is `true` by default, which means the IPv6 port bindings will be filtered out in the [Container State Change Payload](https://github.com/aws/amazon-ecs-agent/blob/225bc3a556bd2d1759ab27b23f54e7e68086c9f0/agent/api/ecsclient/client.go#L457). To include IPv6 port bindings, set `ECS_EXCLUDE_IPV6_PORTBINDING=false`  in the `/etc/ecs/ecs.config` file and then restart the agent.  

No change is made on the metadata. Customers can still find both IPv4 and IPv6 port bindings from the [task metadata endpoint](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint.html) even when `ECS_EXCLUDE_IPV6_PORTBINDING=true`. This raw data, which is retrieved from `docker inspect`,  is kept for further debug operation.

### Implementation details
1.  Add a new type `ShouldExcludeIPv6PortBinding`   and a config variable `ECS_EXCLUDE_IPV6_PORTBINDING` to agent and is `true` by default.
2. Update README with the new config variable `ECS_EXCLUDE_IPV6_PORTBINDING`.
2.  Filter out IPv6 port bindings while building the container state change payload if `ShouldExcludeIPv6PortBinding` is true.
3.  Update unit tests with the new config.

### Testing
Following two docker versions are used for testing:
* Docker version 20.10.4, which dose not have the behavioral change.
* Docker version 20.10.7, which exposes both IPv4 and IPv6 port bindings. 
  
Manual test cases:
__Steps:__
1. Run a Task to launch a docker container using the nginx docker image under the bridge network mode, and define the container port mappings in the task definition. 
```
      "portMappings": [
        {
          "hostPort": 0,
          "protocol": "tcp",
          "containerPort": 80
        }
```
2. Run `docker ps` and `docker inspect` to get the docker container port mappings.
3. Get metadata for the task by curl [${ECS_CONTAINER_METADATA_URI_V4}/task](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v4.html).
4. Run AWS CLI [describe-tasks](https://docs.aws.amazon.com/cli/latest/reference/ecs/describe-tasks.html) to verify the port binding. 
  
Results of each test case are listed as follows:
  
1. Docker version 20.10.4 and ECS_EXCLUDE_IPV6_PORTBINDING is not set.
2. Docker version 20.10.4 and ECS_EXCLUDE_IPV6_PORTBINDING is set to `true`.
3. Docker version 20.10.4 and ECS_EXCLUDE_IPV6_PORTBINDING is set to `false`.  
   
Test cases 1-3 have the same responses.
* No IPv6 port binding is found in the nginx docker container. 
* The response of AWS CLI describe-tasks command shows only IPv4 port binding in the container.
```
 "networkBindings": [
    {
        "protocol": "tcp", 
         "bindIP": "0.0.0.0", 
         "containerPort": 80, 
         "hostPort": 49155
    }
],
```
* The response of {ECS_CONTAINER_METADATA_URI_V4}/task does not contains IPv6 port binding info.
  
4. Docker version 20.10.7 and ECS_EXCLUDE_IPV6_PORTBINDING is not set.
5. Docker version 20.10.7 and ECS_EXCLUDE_IPV6_PORTBINDING is set to `true`.
  
Test cases 4-5 have the same responses.
* No IPv6 port binding in the nginx docker container 
```
        "NetworkSettings": {
            "Bridge": "",
            "LinkLocalIPv6Address": "",
            "LinkLocalIPv6PrefixLen": 0,
            "Ports": {
                "80/tcp": [
                    {
                        "HostIp": "0.0.0.0",
                        "HostPort": "49154"
                    }
                ]
            },
          ...
        }
```
* The response of AWS CLI describe-tasks command shows only IPv4 port binding in the container
```
"networkBindings": [
    {
        "protocol": "tcp", 
        "bindIP": "0.0.0.0", 
        "containerPort": 80, 
         "hostPort": 49154
    }
],
```
* The response of {ECS_CONTAINER_METADATA_URI_V4}/task contains both IPv4 and IPv6 port bindings info.
  
6. Docker version 20.10.7 and ECS_EXCLUDE_IPV6_PORTBINDING is set to `false`.
* An IPv6 port binding is found in the nginx docker container 
```
        "NetworkSettings": {
            "Bridge": "",
            "LinkLocalIPv6Address": "",
            "LinkLocalIPv6PrefixLen": 0,
            "Ports": {
                "80/tcp": [
                    {
                        "HostIp": "0.0.0.0",
                        "HostPort": "49155"
                    },
                    {
                        "HostIp": "::",
                        "HostPort": "49155"
                    }
                ]
            },
          ...
        }
```
* The response of AWS CLI describe-tasks command shows both IPv4 and IPv6 port bindings in the container
```
"networkBindings": [
    {
        "protocol": "tcp", 
        "bindIP": "0.0.0.0", 
        "containerPort": 80, 
         "hostPort": 49155
    }, 
    {
        "protocol": "tcp", 
        "bindIP": "::", 
        "containerPort": 80, 
        "hostPort": 49155
    }
],
```
* The response of {ECS_CONTAINER_METADATA_URI_V4}/task contains both IPv4 and IPv6 port bindings info.
  
7.  `awsvpc` and `host` network mode   
* No behavioral change, comparing with agent version 1.55.2, is found while running a task with `awsvpc` and `host` mode 
  
New tests cover the changes: no, but existing config unit tests are updated. 
  
### Description for the changelog
Enhancement -  Introduce a new environment variable `ECS_EXCLUDE_IPV6_PORTBINDING`, which is `true` by default. When this filter is enabled, the response of [DescribeTasks](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_DescribeTasks.html#API_DescribeTasks_ResponseSyntax)   API call will not show the IPv6 port bindings for default network mode tasks, but it is still included in the [Task metadata](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint.html) endpoint. This is a workaround for docker's bug as detailed in https://github.com/aws/amazon-ecs-agent/issues/2870.
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
