### PR TITLE
Added support for os-family attribute to be advertised by the agent for fine grained task placement

### DIFF
--- a/agent/api/ecsclient/client.go
+++ b/agent/api/ecsclient/client.go
@@ -46,6 +46,7 @@ const (
 	azAttrName              = "ecs.availability-zone"
 	cpuArchAttrName         = "ecs.cpu-architecture"
 	osTypeAttrName          = "ecs.os-type"
+	osFamilyAttrName        = "ecs.os-family"
 )
 
 // APIECSClient implements ECSClient
@@ -331,6 +332,10 @@ func (client *APIECSClient) getAdditionalAttributes() []*ecs.Attribute {
 		{
 			Name:  aws.String(osTypeAttrName),
 			Value: aws.String(config.OSType),
+		},
+		{
+			Name:  aws.String(osFamilyAttrName),
+			Value: aws.String(config.GetOSFamily()),
 		},
 	}
 	// Send cpu arch attribute directly when running on external capacity. When running on EC2, this is not needed

--- a/agent/api/ecsclient/client_test.go
+++ b/agent/api/ecsclient/client_test.go
@@ -381,6 +381,7 @@ func TestRegisterContainerInstance(t *testing.T) {
 			fakeCapabilities := []string{"capability1", "capability2"}
 			expectedAttributes := map[string]string{
 				"ecs.os-type":               config.OSType,
+				"ecs.os-family":             config.GetOSFamily(),
 				"my_custom_attribute":       "Custom_Value1",
 				"my_other_custom_attribute": "Custom_Value2",
 				"ecs.availability-zone":     "us-west-2b",
@@ -418,11 +419,11 @@ func TestRegisterContainerInstance(t *testing.T) {
 			var expectedNumOfAttributes int
 			if !tc.cfg.External.Enabled() {
 				// 2 capability attributes: capability1, capability2
-				// and 4 other attributes: ecs.os-type, ecs.outpost-arn, my_custom_attribute, my_other_custom_attribute.
-				expectedNumOfAttributes = 6
+				// and 5 other attributes: ecs.os-type, ecs.os-family, ecs.outpost-arn, my_custom_attribute, my_other_custom_attribute.
+				expectedNumOfAttributes = 7
 			} else {
 				// One more attribute for external case: ecs.cpu-architecture
-				expectedNumOfAttributes = 7
+				expectedNumOfAttributes = 8
 			}
 
 			gomock.InOrder(
@@ -482,6 +483,7 @@ func TestReRegisterContainerInstance(t *testing.T) {
 	fakeCapabilities := []string{"capability1", "capability2"}
 	expectedAttributes := map[string]string{
 		"ecs.os-type":           config.OSType,
+		"ecs.os-family":         config.GetOSFamily(),
 		"ecs.availability-zone": "us-west-2b",
 		"ecs.outpost-arn":       "test:arn:outpost",
 	}
@@ -503,8 +505,8 @@ func TestReRegisterContainerInstance(t *testing.T) {
 			resource, ok := findResource(req.TotalResources, "PORTS_UDP")
 			assert.True(t, ok, `Could not find resource "PORTS_UDP"`)
 			assert.Equal(t, "STRINGSET", *resource.Type, `Wrong type for resource "PORTS_UDP"`)
-			// "ecs.os-type", ecs.outpost-arn and the 2 that we specified as additionalAttributes
-			assert.Equal(t, 4, len(req.Attributes), "Wrong number of Attributes")
+			// "ecs.os-type", ecs.os-family, ecs.outpost-arn and the 2 that we specified as additionalAttributes
+			assert.Equal(t, 5, len(req.Attributes), "Wrong number of Attributes")
 			reqAttributes := func() map[string]string {
 				rv := make(map[string]string, len(req.Attributes))
 				for i := range req.Attributes {
@@ -572,6 +574,7 @@ func TestRegisterContainerInstanceWithEmptyTags(t *testing.T) {
 
 	expectedAttributes := map[string]string{
 		"ecs.os-type":               config.OSType,
+		"ecs.os-family":             config.GetOSFamily(),
 		"my_custom_attribute":       "Custom_Value1",
 		"my_other_custom_attribute": "Custom_Value2",
 	}
@@ -638,7 +641,8 @@ func TestRegisterBlankCluster(t *testing.T) {
 	client.(*APIECSClient).SetSDK(mc)
 
 	expectedAttributes := map[string]string{
-		"ecs.os-type": config.OSType,
+		"ecs.os-type":   config.OSType,
+		"ecs.os-family": config.GetOSFamily(),
 	}
 	defaultCluster := config.DefaultClusterName
 	gomock.InOrder(
@@ -694,7 +698,8 @@ func TestRegisterBlankClusterNotCreatingClusterWhenErrorNotClusterNotFound(t *te
 	client.(*APIECSClient).SetSDK(mc)
 
 	expectedAttributes := map[string]string{
-		"ecs.os-type": config.OSType,
+		"ecs.os-type":   config.OSType,
+		"ecs.os-family": config.GetOSFamily(),
 	}
 
 	gomock.InOrder(

--- a/agent/config/os_family_windows.go
+++ b/agent/config/os_family_windows.go
@@ -1,0 +1,111 @@
+// +build windows
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package config
+
+import (
+	"fmt"
+
+	"github.com/aws/amazon-ecs-agent/agent/statemanager/dependencies"
+
+	"github.com/cihub/seelog"
+	"github.com/pkg/errors"
+	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/registry"
+)
+
+const (
+	// The os-family for windows is of the format "WINDOWS_SERVER_<Release>_<FULL or CORE>"
+	osFamilyFormat             = "WINDOWS_SERVER_%s_%s"
+	windowsServerCore          = "CORE"
+	windowsServerFull          = "FULL"
+	unsupportedWindowsOSFamily = "windows"
+
+	installationTypeServerCore = "Server Core"
+	installationTypeServer     = "Server"
+
+	ecsWinRegistryRootKey  = registry.LOCAL_MACHINE
+	ecsWinRegistryRootPath = `SOFTWARE\Microsoft\Windows NT\CurrentVersion`
+)
+
+var (
+	winRegistry dependencies.WindowsRegistry
+	// osReleaseFromBuildNumber is the mapping from build number to the Windows release.
+	// Reference- https://docs.microsoft.com/en-us/windows-server/get-started/windows-server-release-info
+	osReleaseFromBuildNumber = map[int]string{
+		14393: "2016",
+		17763: "2019",
+		19041: "2004",
+		19042: "20H2",
+		20348: "2022",
+	}
+	// windowsGetVersionFunc is the method used to obtain information about current Windows version.
+	windowsGetVersionFunc = windows.RtlGetVersion
+)
+
+func init() {
+	winRegistry = dependencies.StdRegistry{}
+}
+
+// getInstallationType returns the installation type as either CORE or FULL.
+func getInstallationType(installationType string) (string, error) {
+	switch installationType {
+	case installationTypeServer:
+		return windowsServerFull, nil
+	case installationTypeServerCore:
+		return windowsServerCore, nil
+	default:
+		return "", errors.Errorf("unsupported installation type: %s", installationType)
+	}
+}
+
+// GetOSFamily returns the operating system family string.
+// On Windows, it would be of the format "WINDOWS_SERVER_<Release>_<FULL or CORE>"
+// In case of any exception this method just returns "windows" as operating system family.
+func GetOSFamily() string {
+	// Find the build number of the os on which agent is running.
+	versionInfo := windowsGetVersionFunc()
+	buildNumber := int(versionInfo.BuildNumber)
+	osRelease, ok := osReleaseFromBuildNumber[buildNumber]
+	if !ok {
+		seelog.Errorf("windows release with build number [%d] is unsupported", buildNumber)
+		return unsupportedWindowsOSFamily
+	}
+
+	// Find the installation type from the Windows registry.
+	key, err := winRegistry.OpenKey(ecsWinRegistryRootKey, ecsWinRegistryRootPath, registry.QUERY_VALUE)
+	if err != nil {
+		seelog.Errorf("unable to open Windows registry key to determine Windows installation type: %v", err)
+		return unsupportedWindowsOSFamily
+	}
+	defer key.Close()
+
+	installationType, _, err := key.GetStringValue("InstallationType")
+	if err != nil {
+		seelog.Errorf("unable to read registry key, InstallationType: %v", err)
+		return unsupportedWindowsOSFamily
+	}
+	iType, err := getInstallationType(installationType)
+	if err != nil {
+		seelog.Errorf("invalid Installation type found: %v", err)
+		return unsupportedWindowsOSFamily
+	}
+
+	// Construct the OSFamily attribute from the OS release and installation type.
+	osFamily := fmt.Sprintf(osFamilyFormat, osRelease, iType)
+	seelog.Debugf("operating system family is: %s", osFamily)
+
+	return osFamily
+}

--- a/agent/config/os_family_windows_test.go
+++ b/agent/config/os_family_windows_test.go
@@ -1,0 +1,193 @@
+// +build windows,unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package config
+
+import (
+	"testing"
+
+	mock_dependencies "github.com/aws/amazon-ecs-agent/agent/statemanager/dependencies/mocks"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/registry"
+)
+
+func fakeWindowsGetVersionFunc(buildNumber int) func() *windows.OsVersionInfoEx {
+	return func() *windows.OsVersionInfoEx {
+		return &windows.OsVersionInfoEx{BuildNumber: uint32(buildNumber)}
+	}
+}
+
+func getMockWindowsRegistryKey(ctrl *gomock.Controller) *mock_dependencies.MockRegistryKey {
+	mockWinRegistry := mock_dependencies.NewMockWindowsRegistry(ctrl)
+	mockKey := mock_dependencies.NewMockRegistryKey(ctrl)
+
+	winRegistry = mockWinRegistry
+	mockWinRegistry.EXPECT().OpenKey(ecsWinRegistryRootKey, ecsWinRegistryRootPath, gomock.Any()).Return(mockKey, nil)
+
+	return mockKey
+}
+
+func TestGetOSFamilyForWS2022Core(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	windowsGetVersionFunc = fakeWindowsGetVersionFunc(20348)
+	mockKey := getMockWindowsRegistryKey(ctrl)
+	gomock.InOrder(
+		mockKey.EXPECT().GetStringValue("InstallationType").Return(`Server Core`, uint32(0), nil),
+		mockKey.EXPECT().Close(),
+	)
+
+	assert.Equal(t, "WINDOWS_SERVER_2022_CORE", GetOSFamily())
+}
+
+func TestGetOSFamilyForWS2022Full(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	windowsGetVersionFunc = fakeWindowsGetVersionFunc(20348)
+	mockKey := getMockWindowsRegistryKey(ctrl)
+	gomock.InOrder(
+		mockKey.EXPECT().GetStringValue("InstallationType").Return(`Server`, uint32(0), nil),
+		mockKey.EXPECT().Close(),
+	)
+
+	assert.Equal(t, "WINDOWS_SERVER_2022_FULL", GetOSFamily())
+}
+
+func TestGetOSFamilyForWS2019Core(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	windowsGetVersionFunc = fakeWindowsGetVersionFunc(17763)
+	mockKey := getMockWindowsRegistryKey(ctrl)
+	gomock.InOrder(
+		mockKey.EXPECT().GetStringValue("InstallationType").Return(`Server Core`, uint32(0), nil),
+		mockKey.EXPECT().Close(),
+	)
+
+	assert.Equal(t, "WINDOWS_SERVER_2019_CORE", GetOSFamily())
+}
+
+func TestGetOSFamilyForWS2019Full(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	windowsGetVersionFunc = fakeWindowsGetVersionFunc(17763)
+	mockKey := getMockWindowsRegistryKey(ctrl)
+	gomock.InOrder(
+		mockKey.EXPECT().GetStringValue("InstallationType").Return(`Server`, uint32(0), nil),
+		mockKey.EXPECT().Close(),
+	)
+
+	assert.Equal(t, "WINDOWS_SERVER_2019_FULL", GetOSFamily())
+}
+
+func TestGetOSFamilyForWS2016Full(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	windowsGetVersionFunc = fakeWindowsGetVersionFunc(14393)
+	mockKey := getMockWindowsRegistryKey(ctrl)
+	gomock.InOrder(
+		mockKey.EXPECT().GetStringValue("InstallationType").Return(`Server`, uint32(0), nil),
+		mockKey.EXPECT().Close(),
+	)
+
+	assert.Equal(t, "WINDOWS_SERVER_2016_FULL", GetOSFamily())
+}
+
+func TestGetOSFamilyForWS2004Core(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	windowsGetVersionFunc = fakeWindowsGetVersionFunc(19041)
+	mockKey := getMockWindowsRegistryKey(ctrl)
+	gomock.InOrder(
+		mockKey.EXPECT().GetStringValue("InstallationType").Return(`Server Core`, uint32(0), nil),
+		mockKey.EXPECT().Close(),
+	)
+
+	assert.Equal(t, "WINDOWS_SERVER_2004_CORE", GetOSFamily())
+}
+
+func TestGetOSFamilyForWS20H2Core(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	windowsGetVersionFunc = fakeWindowsGetVersionFunc(19042)
+	mockKey := getMockWindowsRegistryKey(ctrl)
+	gomock.InOrder(
+		mockKey.EXPECT().GetStringValue("InstallationType").Return(`Server Core`, uint32(0), nil),
+		mockKey.EXPECT().Close(),
+	)
+
+	assert.Equal(t, "WINDOWS_SERVER_20H2_CORE", GetOSFamily())
+}
+
+func TestGetOSFamilyForInvalidBuildNumber(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	windowsGetVersionFunc = fakeWindowsGetVersionFunc(12345)
+	assert.Equal(t, unsupportedWindowsOSFamily, GetOSFamily())
+}
+
+func TestGetOSFamilyForKeyError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	windowsGetVersionFunc = fakeWindowsGetVersionFunc(19042)
+	mockWinRegistry := mock_dependencies.NewMockWindowsRegistry(ctrl)
+	mockKey := mock_dependencies.NewMockRegistryKey(ctrl)
+	winRegistry = mockWinRegistry
+
+	gomock.InOrder(
+		mockWinRegistry.EXPECT().OpenKey(ecsWinRegistryRootKey, ecsWinRegistryRootPath, gomock.Any()).Return(mockKey, registry.ErrNotExist),
+	)
+
+	assert.Equal(t, unsupportedWindowsOSFamily, GetOSFamily())
+}
+
+func TestGetOSFamilyForInstallationTypeNotExistError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	windowsGetVersionFunc = fakeWindowsGetVersionFunc(19042)
+	mockKey := getMockWindowsRegistryKey(ctrl)
+	gomock.InOrder(
+		mockKey.EXPECT().GetStringValue("InstallationType").Return(`Server Core`, uint32(0), registry.ErrNotExist),
+		mockKey.EXPECT().Close(),
+	)
+
+	assert.Equal(t, unsupportedWindowsOSFamily, GetOSFamily())
+}
+
+func TestGetOSFamilyForInvalidInstallationType(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	windowsGetVersionFunc = fakeWindowsGetVersionFunc(19042)
+	mockKey := getMockWindowsRegistryKey(ctrl)
+	gomock.InOrder(
+		mockKey.EXPECT().GetStringValue("InstallationType").Return(`Server Core Invalid`, uint32(0), nil),
+		mockKey.EXPECT().Close(),
+	)
+
+	assert.Equal(t, unsupportedWindowsOSFamily, GetOSFamily())
+}

--- a/agent/config/parse_linux.go
+++ b/agent/config/parse_linux.go
@@ -15,7 +15,10 @@
 
 package config
 
-import "errors"
+import (
+	"errors"
+	"strings"
+)
 
 func parseGMSACapability() bool {
 	return false
@@ -27,4 +30,9 @@ func parseFSxWindowsFileServerCapability() bool {
 
 var IsWindows2016 = func() (bool, error) {
 	return false, errors.New("unsupported platform")
+}
+
+// GetOSFamily returns "LINUX" as operating system family for linux based ecs instances.
+func GetOSFamily() string {
+	return strings.ToUpper(OSType)
 }

--- a/agent/config/parse_unsupported.go
+++ b/agent/config/parse_unsupported.go
@@ -15,7 +15,10 @@
 
 package config
 
-import "errors"
+import (
+	"errors"
+	"strings"
+)
 
 func parseGMSACapability() bool {
 	return false
@@ -27,4 +30,9 @@ func parseFSxWindowsFileServerCapability() bool {
 
 var IsWindows2016 = func() (bool, error) {
 	return false, errors.New("unsupported platform")
+}
+
+// GetOSFamily returns "UNSUPPORTED" as operating system family for non-windows based ecs instances.
+func GetOSFamily() string {
+	return strings.ToUpper(OSType)
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
A new attribute is being introduced in the ECS Control plane called `ecs.os-family` which defines the os family to which the instance belongs. For Linux based instances, the OS family would be advertised as `linux` and for Windows based instances, the attribute would have a value of format - `WINDOWS_SERVER_<Windows Version>_<Installation Type>`

This would allow the customers to achieve fine grained task placement especially in a mixed cluster.

Example- If a cluster runs instances running on different Windows versions, and a task definition specifies the OS family as `WINDOWS_SERVER_2019_FULL` then this task would only be placed on the instances which broadcasted their os-family as `WINDOWS_SERVER_2019_FULL`.

### Implementation details
<!-- How are the changes implemented? -->
A new attribute has been introduced `ecs.os-family`. The values for Linux based instances is `linux`.
For Windows instances, the value can be-
`WINDOWS_SERVER_2019_FULL`, `WINDOWS_SERVER_2019_CORE`, `WINDOWS_SERVER_2016_FULL`, `WINDOWS_SERVER_2022_FULL`, `WINDOWS_SERVER_2022_CORE`, `WINDOWS_SERVER_2004_CORE`,  `WINDOWS_SERVER_20H2_CORE`

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Unit tests have been added and existing tests were updated.
Additionally, custom AMIs with custom agent built from this branch was tested to ensure that the instance can register itself to the cluster.

New tests cover the changes: <!-- yes|no -->
Yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Added support for OS Family to the agent.
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
