### PR TITLE
Add capability for awsfirelens log driver buffer limit option

### DIFF
--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -30,48 +30,49 @@ import (
 
 const (
 	// capabilityPrefix is deprecated. For new capabilities, use attributePrefix.
-	capabilityPrefix                            = "com.amazonaws.ecs.capability."
-	attributePrefix                             = "ecs.capability."
-	capabilityTaskIAMRole                       = "task-iam-role"
-	capabilityTaskIAMRoleNetHost                = "task-iam-role-network-host"
-	taskENIAttributeSuffix                      = "task-eni"
-	taskENIIPv6AttributeSuffix                  = "task-eni.ipv6"
-	taskENIBlockInstanceMetadataAttributeSuffix = "task-eni-block-instance-metadata"
-	appMeshAttributeSuffix                      = "aws-appmesh"
-	cniPluginVersionSuffix                      = "cni-plugin-version"
-	capabilityTaskCPUMemLimit                   = "task-cpu-mem-limit"
-	capabilityDockerPluginInfix                 = "docker-plugin."
-	attributeSeparator                          = "."
-	capabilityPrivateRegistryAuthASM            = "private-registry-authentication.secretsmanager"
-	capabilitySecretEnvSSM                      = "secrets.ssm.environment-variables"
-	capabilitySecretEnvASM                      = "secrets.asm.environment-variables"
-	capabilitySecretLogDriverSSM                = "secrets.ssm.bootstrap.log-driver"
-	capabilitySecretLogDriverASM                = "secrets.asm.bootstrap.log-driver"
-	capabiltyPIDAndIPCNamespaceSharing          = "pid-ipc-namespace-sharing"
-	capabilityNvidiaDriverVersionInfix          = "nvidia-driver-version."
-	capabilityECREndpoint                       = "ecr-endpoint"
-	capabilityContainerOrdering                 = "container-ordering"
-	taskEIAAttributeSuffix                      = "task-eia"
-	taskEIAWithOptimizedCPU                     = "task-eia.optimized-cpu"
-	taskENITrunkingAttributeSuffix              = "task-eni-trunking"
-	branchCNIPluginVersionSuffix                = "branch-cni-plugin-version"
-	capabilityFirelensFluentd                   = "firelens.fluentd"
-	capabilityFirelensFluentbit                 = "firelens.fluentbit"
-	capabilityFirelensLoggingDriver             = "logging-driver.awsfirelens"
-	capabilityFirelensConfigFile                = "firelens.options.config.file"
-	capabilityFirelensConfigS3                  = "firelens.options.config.s3"
-	capabilityFullTaskSync                      = "full-sync"
-	capabilityGMSA                              = "gmsa"
-	capabilityEFS                               = "efs"
-	capabilityEFSAuth                           = "efsAuth"
-	capabilityEnvFilesS3                        = "env-files.s3"
-	capabilityFSxWindowsFileServer              = "fsxWindowsFileServer"
-	capabilityExec                              = "execute-command"
-	capabilityDepsRootDir                       = "/managed-agents"
-	capabilityExecBinRelativePath               = "bin"
-	capabilityExecConfigRelativePath            = "config"
-	capabilityExecCertsRelativePath             = "certs"
-	capabilityExternal                          = "external"
+	capabilityPrefix                                       = "com.amazonaws.ecs.capability."
+	attributePrefix                                        = "ecs.capability."
+	capabilityTaskIAMRole                                  = "task-iam-role"
+	capabilityTaskIAMRoleNetHost                           = "task-iam-role-network-host"
+	taskENIAttributeSuffix                                 = "task-eni"
+	taskENIIPv6AttributeSuffix                             = "task-eni.ipv6"
+	taskENIBlockInstanceMetadataAttributeSuffix            = "task-eni-block-instance-metadata"
+	appMeshAttributeSuffix                                 = "aws-appmesh"
+	cniPluginVersionSuffix                                 = "cni-plugin-version"
+	capabilityTaskCPUMemLimit                              = "task-cpu-mem-limit"
+	capabilityDockerPluginInfix                            = "docker-plugin."
+	attributeSeparator                                     = "."
+	capabilityPrivateRegistryAuthASM                       = "private-registry-authentication.secretsmanager"
+	capabilitySecretEnvSSM                                 = "secrets.ssm.environment-variables"
+	capabilitySecretEnvASM                                 = "secrets.asm.environment-variables"
+	capabilitySecretLogDriverSSM                           = "secrets.ssm.bootstrap.log-driver"
+	capabilitySecretLogDriverASM                           = "secrets.asm.bootstrap.log-driver"
+	capabiltyPIDAndIPCNamespaceSharing                     = "pid-ipc-namespace-sharing"
+	capabilityNvidiaDriverVersionInfix                     = "nvidia-driver-version."
+	capabilityECREndpoint                                  = "ecr-endpoint"
+	capabilityContainerOrdering                            = "container-ordering"
+	taskEIAAttributeSuffix                                 = "task-eia"
+	taskEIAWithOptimizedCPU                                = "task-eia.optimized-cpu"
+	taskENITrunkingAttributeSuffix                         = "task-eni-trunking"
+	branchCNIPluginVersionSuffix                           = "branch-cni-plugin-version"
+	capabilityFirelensFluentd                              = "firelens.fluentd"
+	capabilityFirelensFluentbit                            = "firelens.fluentbit"
+	capabilityFirelensLoggingDriver                        = "logging-driver.awsfirelens"
+	capabilityFireLensLoggingDriverConfigBufferLimitSuffix = ".log-driver-buffer-limit"
+	capabilityFirelensConfigFile                           = "firelens.options.config.file"
+	capabilityFirelensConfigS3                             = "firelens.options.config.s3"
+	capabilityFullTaskSync                                 = "full-sync"
+	capabilityGMSA                                         = "gmsa"
+	capabilityEFS                                          = "efs"
+	capabilityEFSAuth                                      = "efsAuth"
+	capabilityEnvFilesS3                                   = "env-files.s3"
+	capabilityFSxWindowsFileServer                         = "fsxWindowsFileServer"
+	capabilityExec                                         = "execute-command"
+	capabilityDepsRootDir                                  = "/managed-agents"
+	capabilityExecBinRelativePath                          = "bin"
+	capabilityExecConfigRelativePath                       = "config"
+	capabilityExecCertsRelativePath                        = "certs"
+	capabilityExternal                                     = "external"
 )
 
 var (
@@ -168,6 +169,7 @@ var (
 //    ecs.capability.firelens.fluentbit
 //    ecs.capability.efs
 //    com.amazonaws.ecs.capability.logging-driver.awsfirelens
+//    ecs.capability.logging-driver.awsfirelens.log-driver-buffer-limit
 //    ecs.capability.firelens.options.config.file
 //    ecs.capability.firelens.options.config.s3
 //    ecs.capability.full-sync
@@ -246,6 +248,9 @@ func (agent *ecsAgent) capabilities() ([]*ecs.Attribute, error) {
 
 	// support aws router capabilities for log driver router
 	capabilities = agent.appendFirelensLoggingDriverCapabilities(capabilities)
+
+	// support aws router capabilities for log driver router config
+	capabilities = agent.appendFirelensLoggingDriverConfigCapabilities(capabilities)
 
 	// support efs on ecs capabilities
 	capabilities = agent.appendEFSCapabilities(capabilities)

--- a/agent/app/agent_capability_unix.go
+++ b/agent/app/agent_capability_unix.go
@@ -169,6 +169,10 @@ func (agent *ecsAgent) appendFirelensLoggingDriverCapabilities(capabilities []*e
 	return appendNameOnlyAttribute(capabilities, capabilityPrefix+capabilityFirelensLoggingDriver)
 }
 
+func (agent *ecsAgent) appendFirelensLoggingDriverConfigCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
+	return appendNameOnlyAttribute(capabilities, attributePrefix+capabilityFirelensLoggingDriver+capabilityFireLensLoggingDriverConfigBufferLimitSuffix)
+}
+
 func (agent *ecsAgent) appendFirelensConfigCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
 	capabilities = appendNameOnlyAttribute(capabilities, attributePrefix+capabilityFirelensConfigFile)
 	return appendNameOnlyAttribute(capabilities, attributePrefix+capabilityFirelensConfigS3)

--- a/agent/app/agent_capability_unix_test.go
+++ b/agent/app/agent_capability_unix_test.go
@@ -779,6 +779,7 @@ func TestCapabilitiesUnix(t *testing.T) {
 		attributePrefix + capabilityEFS,
 		attributePrefix + capabilityEFSAuth,
 		capabilityPrefix + capabilityFirelensLoggingDriver,
+		attributePrefix + capabilityFirelensLoggingDriver + capabilityFireLensLoggingDriverConfigBufferLimitSuffix,
 		attributePrefix + capabilityEnvFilesS3,
 	}
 

--- a/agent/app/agent_capability_unspecified.go
+++ b/agent/app/agent_capability_unspecified.go
@@ -103,6 +103,10 @@ func (agent *ecsAgent) appendFirelensLoggingDriverCapabilities(capabilities []*e
 	return capabilities
 }
 
+func (agent *ecsAgent) appendFirelensLoggingDriverConfigCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
+	return capabilities
+}
+
 func (agent *ecsAgent) appendFirelensConfigCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
 	return capabilities
 }

--- a/agent/app/agent_capability_windows.go
+++ b/agent/app/agent_capability_windows.go
@@ -64,6 +64,10 @@ func (agent *ecsAgent) appendFirelensLoggingDriverCapabilities(capabilities []*e
 	return capabilities
 }
 
+func (agent *ecsAgent) appendFirelensLoggingDriverConfigCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
+	return capabilities
+}
+
 func (agent *ecsAgent) appendFirelensConfigCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
 	return capabilities
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Add capability for awsfirelens log driver buffer limit option. This is the capability check for [this feature](https://github.com/aws/amazon-ecs-agent/commit/0df0593d31ed07a5a83a7a09a89e8a942ae820de)

### Implementation details
<!-- How are the changes implemented? -->
According to internal added attribute, broadcast the capability in EC2 agent.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

`make release && make test`

Also performed an end-to end test for this change. Build the agent & run a task. Here is the output by running command `ecs describe-container-instances` (part of the output): 
```
{
   "name": "com.amazonaws.ecs.capability.logging-driver.fluentd"
}, 
{
    "name": "ecs.capability.firelens.options.config.file"
}, 
{
     "name": "ecs.capability.logging-driver.awsfirelens.log-driver-buffer-limit"
}, 
{
       "name": "ecs.availability-zone", 
        "value": "us-east-1e"
},
```

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
