### PR TITLE
publish status message once after firelens v2 container stops

### DIFF
--- a/agent/api/container/container.go
+++ b/agent/api/container/container.go
@@ -1192,6 +1192,17 @@ func (c *Container) GetFirelensConfig() *FirelensConfig {
 	return c.FirelensConfig
 }
 
+// GetFirelensVersion returns the container's firelens version.
+func (c *Container) GetFirelensVersion() string {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	if c.FirelensConfig != nil {
+		return c.FirelensConfig.Version
+	}
+	return ""
+}
+
 // GetEnvironmentFiles returns the container's environment files.
 func (c *Container) GetEnvironmentFiles() []EnvironmentFile {
 	c.lock.RLock()

--- a/agent/stats/common_test.go
+++ b/agent/stats/common_test.go
@@ -55,6 +55,8 @@ const (
 	taskDefinitionFamily  = "docker-gremlin"
 	taskDefinitionVersion = "1"
 	containerName         = "gremlin-container"
+
+	firelensV2TaskArn = "arn:aws:ecs:us-west-2:1234567890:task/test-cluster/abc"
 )
 
 var (

--- a/agent/stats/container.go
+++ b/agent/stats/container.go
@@ -36,9 +36,10 @@ func newStatsContainer(dockerID string, client dockerapi.DockerClient, resolver 
 	ctx, cancel := context.WithCancel(context.Background())
 	return &StatsContainer{
 		containerMetadata: &ContainerMetadata{
-			DockerID:    dockerID,
-			Name:        dockerContainer.Container.Name,
-			NetworkMode: dockerContainer.Container.GetNetworkMode(),
+			DockerID:        dockerID,
+			Name:            dockerContainer.Container.Name,
+			NetworkMode:     dockerContainer.Container.GetNetworkMode(),
+			FirelensVersion: dockerContainer.Container.GetFirelensVersion(),
 		},
 		ctx:      ctx,
 		cancel:   cancel,

--- a/agent/stats/engine_unix_test.go
+++ b/agent/stats/engine_unix_test.go
@@ -135,13 +135,11 @@ func TestGetContainerStatusMessage(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	testContainer := &apicontainer.DockerContainer{
-		DockerID: "123",
-		Container: &apicontainer.Container{
-			Name: "firelens_v2_container",
-			FirelensConfig: &apicontainer.FirelensConfig{
-				Version: "v2",
-			},
+	testContainer := &StatsContainer{
+		containerMetadata: &ContainerMetadata{
+			DockerID:        "123",
+			Name:            "firelens_v2_container",
+			FirelensVersion: "v2",
 		},
 	}
 

--- a/agent/stats/types.go
+++ b/agent/stats/types.go
@@ -62,9 +62,10 @@ type UsageStats struct {
 
 // ContainerMetadata contains meta-data information for a container.
 type ContainerMetadata struct {
-	DockerID    string `json:"-"`
-	Name        string `json:"-"`
-	NetworkMode string `json:"-"`
+	DockerID        string `json:"-"`
+	Name            string `json:"-"`
+	NetworkMode     string `json:"-"`
+	FirelensVersion string `json:"-"`
 }
 
 // TaskMetadata contains meta-data information for a task.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR includes changes to publish status message once after firelens v2 container stops.

### Implementation details
<!-- How are the changes implemented? -->
- `agent/api/container/container.go`: added a function to retrieve firelens version of a container.
- `agent/stats/container.go`: added a field to specify firelens version in `ContainerMetadata` of `StatsContainer` struct.
- `agent/stats/engine.go`: updated the `getTaskHealthUnsafe()` method to send status message after container is marked as stopped. Also updated `getContainerStatusMessage()` input parameter from ***apicontainer.DockerContainer** to ***StatsContainer** so that firelens version can be fetched after agent stops tracking a stopped container.
- `agent/stats/engine_test.go`: added tests to cover the changes.
- `agent/stats/engine_test.go`: updated `TestGetContainerStatusMessage` test accordingly.
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
`make test`
New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
