### PR TITLE
[ECS Windows] Fix for the integration tests required for ECS Exec on Windows

### DIFF
--- a/misc/exec-command-agent-test/build.ps1
+++ b/misc/exec-command-agent-test/build.ps1
@@ -11,13 +11,16 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+go env -w GO111MODULE=off
+go build -tags integration -o ${PSScriptRoot}\sleep.exe ${PSScriptRoot}\sleep\
+
 # create the container image used to run execcmd integ tests
 docker build -t "amazon/amazon-ecs-exec-command-agent-windows-test:make" -f "${PSScriptRoot}/windows.dockerfile" ${PSScriptRoot}
 
 $SIMULATED_ECS_AGENT_DEPS_BIN_DIR="C:\Program Files\Amazon\ECS\managed-agents\execute-command\bin\1.0.0.0"
 Remove-Item -Path $SIMULATED_ECS_AGENT_DEPS_BIN_DIR -Recurse -Force -ErrorAction SilentlyContinue
 New-Item -Path $SIMULATED_ECS_AGENT_DEPS_BIN_DIR -ItemType Directory -Force
-go build -tags integration -installsuffix cgo -a -o $SIMULATED_ECS_AGENT_DEPS_BIN_DIR\amazon-ssm-agent.exe ${PSScriptRoot}\sleep\
+Move-Item -Path ${PSScriptRoot}\sleep.exe -Destination $SIMULATED_ECS_AGENT_DEPS_BIN_DIR\amazon-ssm-agent.exe
 New-Item -Path $SIMULATED_ECS_AGENT_DEPS_BIN_DIR\ssm-agent-worker.exe -ItemType File -Force
 New-Item -Path $SIMULATED_ECS_AGENT_DEPS_BIN_DIR\ssm-session-worker.exe -ItemType File -Force
 
@@ -42,3 +45,6 @@ if(!(Test-Path -path $SIMULATED_SSM_PLUGINS_DIR\awsDomainJoin))
 {
     New-Item -Path $SIMULATED_SSM_PLUGINS_DIR\awsDomainJoin -ItemType directory -Force
 }
+
+# Set the Go Modules to auto once we have built the binaries.
+go env -w GO111MODULE=auto

--- a/misc/exec-command-agent-test/windows.dockerfile
+++ b/misc/exec-command-agent-test/windows.dockerfile
@@ -1,13 +1,18 @@
-# escape=`
-
-FROM golang:1.12 as build-env
-MAINTAINER Amazon Web Services, Inc.
-
-# There is dockerfile documentation on how to treat windows paths
-WORKDIR C:\Users\Administrator\go\src\sleep
-COPY ./sleep C:/Users/Administrator/go/src/sleep
-RUN go build -tags integration -installsuffix cgo -a -o C:/Users/Administrator/go/src/sleep/sleep.exe .
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License
 
 FROM amazon-ecs-ftest-windows-base:make
+
 MAINTAINER Amazon Web Services, Inc.
-COPY --from=build-env C:/Users/Administrator/go/src/sleep/sleep.exe C:/
+
+ADD sleep.exe C:/sleep.exe


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
After the recent Golang upgrade of Windows to 1.17, we need to make few changes in the integration test setup. 
This change fixes the following issues-
- Golang base image is Windows release specific and is not scalable. The change introduced here ensures that the correct base image is being used instead of the generic golang image. Also, we will build the binary and then copy it to the container image.
- We need to disable Go Modules in order to build the helper binary for ECS Exec Windows. We enable Go Modules at the end of the script.

### Implementation details
<!-- How are the changes implemented? -->
The changes have been made in the `dockerfile` and `build` script.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
The integration tests were ran on Windows Server 2022 and Windows Server 2019 instances.

New tests cover the changes: <!-- yes|no -->
NA

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Fix for the integration tests required for ECS Exec on Windows
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
