### PR TITLE
[ECS Windows] Support for standalone agent build script after Golang 1.17 update and integration test fix

### DIFF
--- a/scripts/build_agent.ps1
+++ b/scripts/build_agent.ps1
@@ -13,11 +13,14 @@
 #
 # Standalone Amazon ECS Container Agent for Windows may be built by using this script
 
+$cwd = (pwd).Path
+
 $pauseImageName = "amazon/amazon-ecs-pause"
 $pauseImageTag = "0.1.0"
 
 $build_exe = "../amazon-ecs-agent.exe"
 $ldflag = "-X github.com/aws/amazon-ecs-agent/agent/config.DefaultPauseContainerTag=$pauseImageTag -X github.com/aws/amazon-ecs-agent/agent/config.DefaultPauseContainerImageName=$pauseImageName"
 
-
-go build -ldflags "$ldflag" -o $build_exe ../agent/
+cd ../agent/
+go build -ldflags "$ldflag" -o $build_exe .
+cd "$cwd"

--- a/scripts/run-integ-tests.ps1
+++ b/scripts/run-integ-tests.ps1
@@ -35,6 +35,7 @@ if ($Platform -like "windows2016") {
   exit 1
 }
 
+$ProgramFiles="C:\Program Files\Amazon\ECS"
 $env:BASE_IMAGE_NAME=$BaseImageName
 $env:BASE_IMAGE_NAME_WITH_DIGEST=$BaseImageNameWithDigest
 
@@ -44,6 +45,9 @@ if (-Not ($dockerImages -like "*$BaseImageName*")) {
   Invoke-Expression "docker pull $BaseImageName"
 }
 Invoke-Expression "docker tag $BaseImageName amazon-ecs-ftest-windows-base:make"
+
+# Ensure that "C:/Program Files/Amazon/ECS" is empty before preparing dependencies.
+Remove-Item -Path "$ProgramFiles\*" -Recurse -Force -ErrorAction:SilentlyContinue
 
 # Prepare dependencies
 Invoke-Expression "${PSScriptRoot}\..\misc\volumes-test\build.ps1"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
In order to build the Windows binaries, we need to be present inside the `agent` folder before running the `go build` command. This change adds that support.

Additionally, we also remove any residual artifacts from `C:/Program Files/Amazon/ECS` since they are interfering with the integration tests.

### Implementation details
<!-- How are the changes implemented? -->
For the standalone agent build support-
- Save the current working directory
- Change the directory to `agent`
- Run the build command
- Change the directory to the older saved one

For integration test fix-
- Added a powershell command to remove any residual artifacts from bin folder.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
The binary was built using this script

New tests cover the changes: <!-- yes|no -->
NA
### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Support for standalone agent build script after Golang 1.17 update
Integration test fix by removing residual artifacts from bin folder
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
