### PR TITLE
Add Container runtime check and messaging mechanism

### DIFF
--- a/agent/acs/handler/acs_handler.go
+++ b/agent/acs/handler/acs_handler.go
@@ -29,6 +29,8 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	rolecredentials "github.com/aws/amazon-ecs-agent/agent/credentials"
 	"github.com/aws/amazon-ecs-agent/agent/data"
+	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
+	"github.com/aws/amazon-ecs-agent/agent/doctor"
 	"github.com/aws/amazon-ecs-agent/agent/engine"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/eventhandler"
@@ -84,6 +86,7 @@ type session struct {
 	agentConfig                     *config.Config
 	deregisterInstanceEventStream   *eventstream.EventStream
 	taskEngine                      engine.TaskEngine
+	dockerClient                    dockerapi.DockerClient
 	ecsClient                       api.ECSClient
 	state                           dockerstate.TaskEngineState
 	dataClient                      data.Client
@@ -94,6 +97,7 @@ type session struct {
 	backoff                         retry.Backoff
 	resources                       sessionResources
 	latestSeqNumTaskManifest        *int64
+	doctor                          *doctor.Doctor
 	_heartbeatTimeout               time.Duration
 	_heartbeatJitter                time.Duration
 	_inactiveInstanceReconnectDelay time.Duration
@@ -137,17 +141,22 @@ type sessionState interface {
 }
 
 // NewSession creates a new Session object
-func NewSession(ctx context.Context,
+func NewSession(
+	ctx context.Context,
 	config *config.Config,
 	deregisterInstanceEventStream *eventstream.EventStream,
-	containerInstanceArn string,
+	containerInstanceARN string,
 	credentialsProvider *credentials.Credentials,
+	dockerClient dockerapi.DockerClient,
 	ecsClient api.ECSClient,
 	taskEngineState dockerstate.TaskEngineState,
 	dataClient data.Client,
 	taskEngine engine.TaskEngine,
 	credentialsManager rolecredentials.Manager,
-	taskHandler *eventhandler.TaskHandler, latestSeqNumTaskManifest *int64) Session {
+	taskHandler *eventhandler.TaskHandler,
+	latestSeqNumTaskManifest *int64,
+	doctor *doctor.Doctor,
+) Session {
 	resources := newSessionResources(credentialsProvider)
 	backoff := retry.NewExponentialBackoff(connectionBackoffMin, connectionBackoffMax,
 		connectionBackoffJitter, connectionBackoffMultiplier)
@@ -156,9 +165,10 @@ func NewSession(ctx context.Context,
 	return &session{
 		agentConfig:                     config,
 		deregisterInstanceEventStream:   deregisterInstanceEventStream,
-		containerInstanceARN:            containerInstanceArn,
+		containerInstanceARN:            containerInstanceARN,
 		credentialsProvider:             credentialsProvider,
 		ecsClient:                       ecsClient,
+		dockerClient:                    dockerClient,
 		state:                           taskEngineState,
 		dataClient:                      dataClient,
 		taskEngine:                      taskEngine,
@@ -169,6 +179,7 @@ func NewSession(ctx context.Context,
 		backoff:                         backoff,
 		resources:                       resources,
 		latestSeqNumTaskManifest:        latestSeqNumTaskManifest,
+		doctor:                          doctor,
 		_heartbeatTimeout:               heartbeatTimeout,
 		_heartbeatJitter:                heartbeatJitter,
 		_inactiveInstanceReconnectDelay: inactiveInstanceReconnectDelay,
@@ -335,8 +346,7 @@ func (acsSession *session) startACSSession(client wsclient.ClientServer) error {
 
 	client.AddRequestHandler(payloadHandler.handlerFunc())
 
-	// Add HeartbeatHandler to acknowledge ACS heartbeats
-	heartbeatHandler := newHeartbeatHandler(acsSession.ctx, client)
+	heartbeatHandler := newHeartbeatHandler(acsSession.ctx, client, acsSession.doctor)
 	defer heartbeatHandler.clearAcks()
 	heartbeatHandler.start()
 	defer heartbeatHandler.stop()

--- a/agent/acs/handler/heartbeat_handler_test.go
+++ b/agent/acs/handler/heartbeat_handler_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 
 	"github.com/aws/amazon-ecs-agent/agent/acs/model/ecsacs"
+	mock_dockerapi "github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi/mocks"
+	"github.com/aws/amazon-ecs-agent/agent/doctor"
 	mock_wsclient "github.com/aws/amazon-ecs-agent/agent/wsclient/mock"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/golang/mock/gomock"
@@ -92,7 +94,14 @@ func validateHeartbeatAck(t *testing.T, heartbeatReceived *ecsacs.HeartbeatMessa
 		cancel()
 	}).Times(1)
 
-	handler := newHeartbeatHandler(ctx, mockWsClient)
+	dockerClient := mock_dockerapi.NewMockDockerClient(ctrl)
+	dockerClient.EXPECT().SystemPing(gomock.Any(), gomock.Any()).AnyTimes()
+
+	emptyHealthchecksList := []doctor.Healthcheck{}
+	emptyDoctor, _ := doctor.NewDoctor(emptyHealthchecksList, "testCluster", "this:is:an:instance:arn")
+
+	handler := newHeartbeatHandler(ctx, mockWsClient, emptyDoctor)
+
 	go handler.sendHeartbeatAck()
 
 	handler.handleSingleHeartbeatMessage(heartbeatReceived)

--- a/agent/dockerclient/dockerapi/docker_client.go
+++ b/agent/dockerclient/dockerapi/docker_client.go
@@ -569,6 +569,7 @@ func (dg *dockerGoClient) createContainer(ctx context.Context,
 	config *dockercontainer.Config,
 	hostConfig *dockercontainer.HostConfig,
 	name string) DockerContainerMetadata {
+
 	client, err := dg.sdkDockerClient()
 	if err != nil {
 		return DockerContainerMetadata{Error: CannotGetDockerClientError{version: dg.version, err: err}}
@@ -610,8 +611,8 @@ func (dg *dockerGoClient) startContainer(ctx context.Context, id string) DockerC
 	if err != nil {
 		return DockerContainerMetadata{Error: CannotGetDockerClientError{version: dg.version, err: err}}
 	}
-
 	err = client.ContainerStart(ctx, id, types.ContainerStartOptions{})
+
 	metadata := dg.containerMetadata(ctx, id)
 	if err != nil {
 		metadata.Error = CannotStartContainerError{err}

--- a/agent/doctor/docker_runtime_healthcheck.go
+++ b/agent/doctor/docker_runtime_healthcheck.go
@@ -1,0 +1,120 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//      http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package doctor
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
+	"github.com/cihub/seelog"
+)
+
+const systemPingTimeout = time.Second * 2
+
+type dockerRuntimeHealthcheck struct {
+	// HealthcheckType is the reported healthcheck type
+	HealthcheckType string `json:"HealthcheckType,omitempty"`
+	// Status is the container health status
+	Status HealthcheckStatus `json:"HealthcheckStatus,omitempty"`
+	// Timestamp is the timestamp when container health status changed
+	TimeStamp time.Time `json:"TimeStamp,omitempty"`
+	// StatusChangeTime is the latest time the health status changed
+	StatusChangeTime time.Time `json:"StatusChangeTime,omitempty"`
+
+	// LastStatus is the last container health status
+	LastStatus HealthcheckStatus `json:"LastStatus,omitempty"`
+	// LastTimeStamp is the timestamp of last container health status
+	LastTimeStamp time.Time `json:"LastTimeStamp,omitempty"`
+
+	client dockerapi.DockerClient
+	lock   sync.RWMutex
+}
+
+func NewDockerRuntimeHealthcheck(client dockerapi.DockerClient) *dockerRuntimeHealthcheck {
+	nowTime := time.Now()
+	return &dockerRuntimeHealthcheck{
+		HealthcheckType:  HealthcheckTypeContainerRuntime,
+		Status:           HealthcheckStatusInitializing,
+		TimeStamp:        nowTime,
+		StatusChangeTime: nowTime,
+		client:           client,
+	}
+}
+
+func (dhc *dockerRuntimeHealthcheck) RunCheck() HealthcheckStatus {
+	// TODO pass in context as an argument
+	res := dhc.client.SystemPing(context.TODO(), systemPingTimeout)
+	resultStatus := HealthcheckStatusOk
+	if res.Error != nil {
+		seelog.Infof("[DockerRuntimeHealthcheck] Docker Ping failed with error: %v", res.Error)
+		resultStatus = HealthcheckStatusImpaired
+	}
+	dhc.SetHealthcheckStatus(resultStatus)
+	return resultStatus
+}
+
+func (dhc *dockerRuntimeHealthcheck) SetHealthcheckStatus(healthStatus HealthcheckStatus) {
+	dhc.lock.Lock()
+	defer dhc.lock.Unlock()
+	nowTime := time.Now()
+	// if the status has changed, update status change timestamp
+	if dhc.Status != healthStatus {
+		dhc.StatusChangeTime = nowTime
+	}
+	// track previous status
+	dhc.LastStatus = dhc.Status
+	dhc.LastTimeStamp = dhc.TimeStamp
+
+	// update latest status
+	dhc.Status = healthStatus
+	dhc.TimeStamp = nowTime
+}
+
+func (dhc *dockerRuntimeHealthcheck) GetHealthcheckType() string {
+	dhc.lock.RLock()
+	defer dhc.lock.RUnlock()
+	return dhc.HealthcheckType
+}
+
+func (dhc *dockerRuntimeHealthcheck) GetHealthcheckStatus() HealthcheckStatus {
+	dhc.lock.RLock()
+	defer dhc.lock.RUnlock()
+	return dhc.Status
+}
+
+func (dhc *dockerRuntimeHealthcheck) GetHealthcheckTime() time.Time {
+	dhc.lock.RLock()
+	defer dhc.lock.RUnlock()
+	return dhc.TimeStamp
+}
+
+func (dhc *dockerRuntimeHealthcheck) GetStatusChangeTime() time.Time {
+	dhc.lock.RLock()
+	defer dhc.lock.RUnlock()
+	return dhc.StatusChangeTime
+}
+
+func (dhc *dockerRuntimeHealthcheck) GetLastHealthcheckStatus() HealthcheckStatus {
+	dhc.lock.RLock()
+	defer dhc.lock.RUnlock()
+	return dhc.LastStatus
+}
+
+func (dhc *dockerRuntimeHealthcheck) GetLastHealthcheckTime() time.Time {
+	dhc.lock.RLock()
+	defer dhc.lock.RUnlock()
+	return dhc.LastTimeStamp
+}

--- a/agent/doctor/docker_runtime_healthcheck_test.go
+++ b/agent/doctor/docker_runtime_healthcheck_test.go
@@ -1,0 +1,99 @@
+package doctor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
+	mock_dockerapi "github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi/mocks"
+	"github.com/docker/docker/api/types"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewDockerRuntimeHealthCheck(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockDockerClient := mock_dockerapi.NewMockDockerClient(ctrl)
+	dockerRuntimeHealthCheck := NewDockerRuntimeHealthcheck(mockDockerClient)
+	assert.Equal(t, HealthcheckStatusInitializing, dockerRuntimeHealthCheck.Status)
+}
+
+func TestRunCheck(t *testing.T) {
+	testcases := []struct {
+		name               string
+		dockerPingResponse *dockerapi.PingResponse
+		expectedStatus     HealthcheckStatus
+		expectedLastStatus HealthcheckStatus
+	}{
+		{
+			name: "empty checks",
+			dockerPingResponse: &dockerapi.PingResponse{
+				Response: &types.Ping{APIVersion: "test_api_version"},
+				Error:    nil,
+			},
+			expectedStatus:     HealthcheckStatusOk,
+			expectedLastStatus: HealthcheckStatusInitializing,
+		},
+		{
+			name: "all true checks",
+			dockerPingResponse: &dockerapi.PingResponse{
+				Response: nil,
+				Error:    &dockerapi.DockerTimeoutError{},
+			},
+			expectedStatus:     HealthcheckStatusImpaired,
+			expectedLastStatus: HealthcheckStatusInitializing,
+		},
+	}
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	dockerClient := mock_dockerapi.NewMockDockerClient(ctrl)
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			dockerRuntimeHealthCheck := NewDockerRuntimeHealthcheck(dockerClient)
+			dockerClient.EXPECT().SystemPing(gomock.Any(), gomock.Any()).Return(*tc.dockerPingResponse)
+			dockerRuntimeHealthCheck.RunCheck()
+			assert.Equal(t, tc.expectedStatus, dockerRuntimeHealthCheck.Status)
+			assert.Equal(t, tc.expectedLastStatus, dockerRuntimeHealthCheck.LastStatus)
+
+		})
+	}
+}
+
+func TestSetHealthCheckStatus(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	dockerClient := mock_dockerapi.NewMockDockerClient(ctrl)
+	dockerRuntimeHealthCheck := NewDockerRuntimeHealthcheck(dockerClient)
+	healthCheckStatus := HealthcheckStatusOk
+	dockerRuntimeHealthCheck.SetHealthcheckStatus(healthCheckStatus)
+	assert.Equal(t, HealthcheckStatusOk, dockerRuntimeHealthCheck.Status)
+}
+
+func TestSetHealthcheckStatusChange(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	dockerClient := mock_dockerapi.NewMockDockerClient(ctrl)
+	dockerRuntimeHealthcheck := NewDockerRuntimeHealthcheck(dockerClient)
+
+	// we should start in initializing status
+	assert.Equal(t, HealthcheckStatusInitializing, dockerRuntimeHealthcheck.Status)
+	initializationChangeTime := dockerRuntimeHealthcheck.GetStatusChangeTime()
+
+	// we update to initializing again; our StatusChangeTime remains the same
+	dockerRuntimeHealthcheck.SetHealthcheckStatus(HealthcheckStatusInitializing)
+	updateChangeTime := dockerRuntimeHealthcheck.GetStatusChangeTime()
+	assert.Equal(t, HealthcheckStatusInitializing, dockerRuntimeHealthcheck.Status)
+	assert.Equal(t, initializationChangeTime, updateChangeTime)
+
+	// add a sleep so we know time has elapsed between the initial status and status change time
+	time.Sleep(1 * time.Millisecond)
+
+	// change status.  This should change the update time too
+	dockerRuntimeHealthcheck.SetHealthcheckStatus(HealthcheckStatusOk)
+	assert.Equal(t, HealthcheckStatusOk, dockerRuntimeHealthcheck.Status)
+	okChangeTime := dockerRuntimeHealthcheck.GetStatusChangeTime()
+	// have we updated our change time?
+	assert.True(t, okChangeTime.After(initializationChangeTime))
+}

--- a/agent/doctor/doctor.go
+++ b/agent/doctor/doctor.go
@@ -1,0 +1,127 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//      http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package doctor
+
+import (
+	"sync"
+
+	"github.com/cihub/seelog"
+	"github.com/pkg/errors"
+)
+
+var (
+	// EmptyHealthcheckError indicates an error when there are no healthcheck metrics to report
+	EmptyHealthcheckError = errors.New("No instance healthcheck status metrics to report")
+)
+
+type Doctor struct {
+	healthchecks         []Healthcheck
+	lock                 sync.RWMutex
+	cluster              string
+	containerInstanceArn string
+	statusReported       bool
+}
+
+func NewDoctor(healthchecks []Healthcheck, cluster string, containerInstanceArn string) (*Doctor, error) {
+	newDoctor := &Doctor{
+		healthchecks:         []Healthcheck{},
+		cluster:              cluster,
+		containerInstanceArn: containerInstanceArn,
+		statusReported:       false,
+	}
+	for _, hc := range healthchecks {
+		newDoctor.AddHealthcheck(hc)
+	}
+	return newDoctor, nil
+}
+
+// GetCluster returns the cluster that was provided to the doctor while
+// being initialized
+func (doc *Doctor) GetCluster() string {
+	doc.lock.RLock()
+	defer doc.lock.RUnlock()
+
+	return doc.cluster
+}
+
+// GetContainerInstanceArn returns the container instance arn that was
+// provided to the doctor while being initialized
+func (doc *Doctor) GetContainerInstanceArn() string {
+	doc.lock.RLock()
+	defer doc.lock.RUnlock()
+
+	return doc.containerInstanceArn
+}
+
+// SetStatusReported tells the doctor that we have already reported the
+// current status of the healthchecks to the backend
+func (doc *Doctor) SetStatusReported(statusReported bool) {
+	doc.lock.Lock()
+	defer doc.lock.Unlock()
+
+	doc.statusReported = statusReported
+}
+
+// HasStatusBeenReported returns whether we have already sent the current
+// state of the healthchecks to the backend or not
+func (doc *Doctor) HasStatusBeenReported() bool {
+	doc.lock.RLock()
+	defer doc.lock.RUnlock()
+
+	return doc.statusReported
+}
+
+// AddHealthcheck adds a healthcheck to the list of healthchecks that the
+// doctor will run every time doctor.RunHealthchecks() is called
+func (doc *Doctor) AddHealthcheck(healthcheck Healthcheck) {
+	doc.lock.Lock()
+	defer doc.lock.Unlock()
+	doc.healthchecks = append(doc.healthchecks, healthcheck)
+}
+
+// RunHealthchecks runs every healthcheck that the doctor knows about and
+// returns a cumulative result; true if they all pass, false otherwise
+func (doc *Doctor) RunHealthchecks() bool {
+	doc.lock.Lock()
+	defer doc.lock.Unlock()
+	allChecksResult := []HealthcheckStatus{}
+
+	for _, healthcheck := range doc.healthchecks {
+		res := healthcheck.RunCheck()
+		seelog.Debugf("instance healthcheck result: %v", res)
+		allChecksResult = append(allChecksResult, res)
+	}
+
+	doc.statusReported = false
+	return doc.allRight(allChecksResult)
+}
+
+// GetHealthchecks returns a copy of list of healthchecks that the
+// doctor is holding internally.
+func (doc *Doctor) GetHealthchecks() *[]Healthcheck {
+	doc.lock.RLock()
+	defer doc.lock.RUnlock()
+
+	healthcheckCopy := make([]Healthcheck, len(doc.healthchecks))
+	copy(healthcheckCopy, doc.healthchecks)
+	return &healthcheckCopy
+}
+
+func (doc *Doctor) allRight(checksResult []HealthcheckStatus) bool {
+	overallResult := true
+	for _, checkResult := range checksResult {
+		overallResult = overallResult && checkResult.Ok()
+	}
+	return overallResult
+}

--- a/agent/doctor/doctor_test.go
+++ b/agent/doctor/doctor_test.go
@@ -1,0 +1,195 @@
+//go:build unit
+// +build unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package doctor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	TEST_CLUSTER      = "test-cluster"
+	TEST_INSTANCE_ARN = "test-instance-arn"
+)
+
+type trueHealthcheck struct{}
+
+func (tc *trueHealthcheck) RunCheck() HealthcheckStatus                   { return HealthcheckStatusOk }
+func (tc *trueHealthcheck) SetHealthcheckStatus(status HealthcheckStatus) {}
+func (tc *trueHealthcheck) GetHealthcheckType() string                    { return HealthcheckTypeAgent }
+func (tc *trueHealthcheck) GetHealthcheckStatus() HealthcheckStatus {
+	return HealthcheckStatusInitializing
+}
+func (tc *trueHealthcheck) GetLastHealthcheckStatus() HealthcheckStatus {
+	return HealthcheckStatusInitializing
+}
+func (tc *trueHealthcheck) GetHealthcheckTime() time.Time {
+	return time.Date(1974, time.May, 19, 1, 2, 3, 4, time.UTC)
+}
+func (tc *trueHealthcheck) GetStatusChangeTime() time.Time {
+	return time.Date(1974, time.May, 19, 1, 2, 3, 4, time.UTC)
+}
+func (tc *trueHealthcheck) GetLastHealthcheckTime() time.Time {
+	return time.Date(1974, time.May, 19, 1, 2, 3, 4, time.UTC)
+}
+
+type falseHealthcheck struct{}
+
+func (fc *falseHealthcheck) RunCheck() HealthcheckStatus                   { return HealthcheckStatusImpaired }
+func (fc *falseHealthcheck) SetHealthcheckStatus(status HealthcheckStatus) {}
+func (fc *falseHealthcheck) GetHealthcheckType() string                    { return HealthcheckTypeAgent }
+func (fc *falseHealthcheck) GetHealthcheckStatus() HealthcheckStatus {
+	return HealthcheckStatusInitializing
+}
+func (fc *falseHealthcheck) GetLastHealthcheckStatus() HealthcheckStatus {
+	return HealthcheckStatusInitializing
+}
+func (fc *falseHealthcheck) GetHealthcheckTime() time.Time {
+	return time.Date(1974, time.May, 19, 1, 2, 3, 4, time.UTC)
+}
+func (fc *falseHealthcheck) GetStatusChangeTime() time.Time {
+	return time.Date(1974, time.May, 19, 1, 2, 3, 4, time.UTC)
+}
+func (fc *falseHealthcheck) GetLastHealthcheckTime() time.Time {
+	return time.Date(1974, time.May, 19, 1, 2, 3, 4, time.UTC)
+}
+
+func TestNewDoctor(t *testing.T) {
+	trueCheck := &trueHealthcheck{}
+	falseCheck := &falseHealthcheck{}
+	healthchecks := []Healthcheck{trueCheck, falseCheck}
+	newDoctor, _ := NewDoctor(healthchecks, TEST_CLUSTER, TEST_INSTANCE_ARN)
+	assert.Len(t, newDoctor.healthchecks, 2)
+}
+
+func TestAddHealthcheck(t *testing.T) {
+	newDoctor := Doctor{}
+	assert.Len(t, newDoctor.healthchecks, 0)
+	newTestHealthcheck := &trueHealthcheck{}
+	newDoctor.AddHealthcheck(newTestHealthcheck)
+	assert.Len(t, newDoctor.healthchecks, 1)
+}
+
+func TestGetCluster(t *testing.T) {
+	clusterName := "test-cluster"
+	newDoctor := Doctor{cluster: clusterName}
+	assert.Equal(t, newDoctor.GetCluster(), clusterName)
+}
+
+func TestGetContainerInstanceArn(t *testing.T) {
+	containerInstanceArn := "this:is:a:test:container:instance:arn"
+	newDoctor := Doctor{containerInstanceArn: containerInstanceArn}
+	assert.Equal(t, newDoctor.GetContainerInstanceArn(), containerInstanceArn)
+}
+
+func TestSetStatusReported(t *testing.T) {
+	newDoctor := Doctor{}
+	assert.Equal(t, newDoctor.HasStatusBeenReported(), false)
+	newDoctor.SetStatusReported(true)
+	assert.Equal(t, newDoctor.HasStatusBeenReported(), true)
+}
+
+func TestRunHealthchecks(t *testing.T) {
+	trueCheck := &trueHealthcheck{}
+	falseCheck := &falseHealthcheck{}
+
+	testcases := []struct {
+		name           string
+		checks         []Healthcheck
+		expectedResult bool
+	}{
+		{
+			name:           "empty checks",
+			checks:         []Healthcheck{},
+			expectedResult: true,
+		},
+		{
+			name:           "all true checks",
+			checks:         []Healthcheck{trueCheck},
+			expectedResult: true,
+		},
+		{
+			name:           "all false checks",
+			checks:         []Healthcheck{falseCheck},
+			expectedResult: false,
+		},
+		{
+			name:           "mixed checks",
+			checks:         []Healthcheck{trueCheck, falseCheck},
+			expectedResult: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			newDoctor, _ := NewDoctor(tc.checks, TEST_CLUSTER, TEST_INSTANCE_ARN)
+			overallResult := newDoctor.RunHealthchecks()
+			assert.Equal(t, overallResult, tc.expectedResult)
+		})
+	}
+}
+
+func TestGetHealthchecks(t *testing.T) {
+	trueCheck := &trueHealthcheck{}
+	falseCheck := &falseHealthcheck{}
+
+	newDoctor := Doctor{healthchecks: []Healthcheck{trueCheck, trueCheck}}
+	gottenChecks := newDoctor.GetHealthchecks()
+	assert.Len(t, *gottenChecks, 2)
+
+	regottenChecks := newDoctor.GetHealthchecks()
+	(*regottenChecks)[1] = falseCheck
+	assert.NotEqual(t, (*gottenChecks)[1], (*regottenChecks)[1])
+}
+
+func TestAllRight(t *testing.T) {
+	testcases := []struct {
+		name             string
+		testChecksResult []HealthcheckStatus
+		expectedResult   bool
+	}{
+		{
+			name:             "empty checks",
+			testChecksResult: []HealthcheckStatus{},
+			expectedResult:   true,
+		},
+		{
+			name:             "all true checks",
+			testChecksResult: []HealthcheckStatus{HealthcheckStatusOk, HealthcheckStatusOk},
+			expectedResult:   true,
+		},
+		{
+			name:             "all false checks",
+			testChecksResult: []HealthcheckStatus{HealthcheckStatusImpaired, HealthcheckStatusImpaired},
+			expectedResult:   false,
+		},
+		{
+			name:             "mixed checks",
+			testChecksResult: []HealthcheckStatus{HealthcheckStatusOk, HealthcheckStatusImpaired},
+			expectedResult:   false,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			newDoctor := Doctor{}
+			overallResult := newDoctor.allRight(tc.testChecksResult)
+			assert.Equal(t, overallResult, tc.expectedResult)
+		})
+	}
+}

--- a/agent/doctor/healthcheck.go
+++ b/agent/doctor/healthcheck.go
@@ -1,0 +1,34 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//      http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package doctor
+
+import (
+	"time"
+)
+
+const (
+	HealthcheckTypeContainerRuntime = "ContainerRuntime"
+	HealthcheckTypeAgent            = "Agent"
+)
+
+type Healthcheck interface {
+	GetHealthcheckType() string
+	GetHealthcheckStatus() HealthcheckStatus
+	GetHealthcheckTime() time.Time
+	GetStatusChangeTime() time.Time
+	GetLastHealthcheckStatus() HealthcheckStatus
+	GetLastHealthcheckTime() time.Time
+	RunCheck() HealthcheckStatus
+	SetHealthcheckStatus(status HealthcheckStatus)
+}

--- a/agent/doctor/healthcheckstatus.go
+++ b/agent/doctor/healthcheckstatus.go
@@ -1,0 +1,81 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package doctor
+
+import (
+	"errors"
+	"strings"
+)
+
+const (
+	// HealthcheckStatusInitializing is the zero state of a healthcheck status
+	HealthcheckStatusInitializing HealthcheckStatus = iota
+	// HealthcheckStatusOk represents a healthcheck with a true/success result
+	HealthcheckStatusOk
+	// HealthcheckStatusImpaired represents a healthcheck with a false/fail result
+	HealthcheckStatusImpaired
+)
+
+// HealthcheckStatus is an enumeration of possible instance statuses
+type HealthcheckStatus int32
+
+var healthcheckStatusMap = map[string]HealthcheckStatus{
+	"INITIALIZING": HealthcheckStatusInitializing,
+	"OK":           HealthcheckStatusOk,
+	"IMPAIRED":     HealthcheckStatusImpaired,
+}
+
+// String returns a human readable string representation of this object
+func (hs HealthcheckStatus) String() string {
+	for k, v := range healthcheckStatusMap {
+		if v == hs {
+			return k
+		}
+	}
+	// we shouldn't see this
+	return "NONE"
+}
+
+// Ok returns true if the Healthcheck status is OK or INITIALIZING
+func (hs HealthcheckStatus) Ok() bool {
+	return hs == HealthcheckStatusOk || hs == HealthcheckStatusInitializing
+}
+
+// UnmarshalJSON overrides the logic for parsing the JSON-encoded HealthcheckStatus data
+func (hs *HealthcheckStatus) UnmarshalJSON(b []byte) error {
+	if strings.ToLower(string(b)) == "null" {
+		*hs = HealthcheckStatusInitializing
+		return nil
+	}
+	if b[0] != '"' || b[len(b)-1] != '"' {
+		*hs = HealthcheckStatusInitializing
+		return errors.New("healthcheck status unmarshal: status must be a string or null; Got " + string(b))
+	}
+
+	stat, ok := healthcheckStatusMap[string(b[1:len(b)-1])]
+	if !ok {
+		*hs = HealthcheckStatusInitializing
+		return errors.New("healthcheck status unmarshal: unrecognized status")
+	}
+	*hs = stat
+	return nil
+}
+
+// MarshalJSON overrides the logic for JSON-encoding the HealthcheckStatus type
+func (hs *HealthcheckStatus) MarshalJSON() ([]byte, error) {
+	if hs == nil {
+		return nil, nil
+	}
+	return []byte(`"` + hs.String() + `"`), nil
+}

--- a/agent/doctor/healthcheckstatus_test.go
+++ b/agent/doctor/healthcheckstatus_test.go
@@ -1,0 +1,58 @@
+//go:build unit
+// +build unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package doctor
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOk(t *testing.T) {
+	initializingStatus := HealthcheckStatusInitializing
+	okStatus := HealthcheckStatusOk
+	impairedStatus := HealthcheckStatusImpaired
+	assert.True(t, initializingStatus.Ok())
+	assert.True(t, okStatus.Ok())
+	assert.False(t, impairedStatus.Ok())
+}
+
+type testHealthcheckStatus struct {
+	SomeStatus HealthcheckStatus `json:"status"`
+}
+
+func TestUnmarshalHealthcheckStatus(t *testing.T) {
+	status := HealthcheckStatusInitializing
+
+	err := json.Unmarshal([]byte(`"INITIALIZING"`), &status)
+	if err != nil {
+		t.Error(err)
+	}
+	if status != HealthcheckStatusInitializing {
+		t.Error("INITIALIZING should unmarshal to INITIALIZING, not " + status.String())
+	}
+
+	var test testHealthcheckStatus
+	err = json.Unmarshal([]byte(`{"status":"IMPAIRED"}`), &test)
+	if err != nil {
+		t.Error(err)
+	}
+	if test.SomeStatus != HealthcheckStatusImpaired {
+		t.Error("IMPAIRED should unmarshal to IMPAIRED, not " + test.SomeStatus.String())
+	}
+}

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -369,6 +369,10 @@ func (engine *DockerTaskEngine) SetDataClient(client data.Client) {
 	engine.dataClient = client
 }
 
+func (engine *DockerTaskEngine) Context() context.Context {
+	return engine.ctx
+}
+
 // Shutdown makes a best-effort attempt to cleanup after the task engine.
 // This should not be relied on for anything more complicated than testing.
 func (engine *DockerTaskEngine) Shutdown() {

--- a/agent/eventhandler/handler.go
+++ b/agent/eventhandler/handler.go
@@ -25,12 +25,9 @@ import (
 
 // HandleEngineEvents handles state change events from the state change event channel by sending it to
 // responsible event handler
-func HandleEngineEvents(
-	ctx context.Context,
-	taskEngine engine.TaskEngine,
-	client api.ECSClient,
-	taskHandler *TaskHandler,
-	attachmentEventHandler *AttachmentEventHandler) {
+func HandleEngineEvents(ctx context.Context, taskEngine engine.TaskEngine, client api.ECSClient,
+	taskHandler *TaskHandler, attachmentEventHandler *AttachmentEventHandler) {
+
 	for {
 		stateChangeEvents := taskEngine.StateChangeEvents()
 

--- a/agent/stats/engine.go
+++ b/agent/stats/engine.go
@@ -583,7 +583,8 @@ func (engine *DockerStatsEngine) handleDockerEvents(events ...interface{}) error
 		case apicontainerstatus.ContainerStopped:
 			engine.removeContainer(dockerContainerChangeEvent.DockerID)
 		default:
-			seelog.Debugf("Ignoring event for container, id: %s, status: %d", dockerContainerChangeEvent.DockerID, dockerContainerChangeEvent.Status)
+			seelog.Debugf("Ignoring event for container, id: %s, status: %d",
+				dockerContainerChangeEvent.DockerID, dockerContainerChangeEvent.Status)
 		}
 	}
 

--- a/agent/tcs/client/client.go
+++ b/agent/tcs/client/client.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/doctor"
 	"github.com/aws/amazon-ecs-agent/agent/stats"
 	"github.com/aws/amazon-ecs-agent/agent/tcs/model/ecstcs"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
@@ -29,6 +30,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/cihub/seelog"
+	"github.com/pborman/uuid"
 )
 
 const (
@@ -41,13 +43,15 @@ const (
 
 // clientServer implements wsclient.ClientServer interface for metrics backend.
 type clientServer struct {
-	statsEngine            stats.Engine
-	publishTicker          *time.Ticker
-	publishHealthTicker    *time.Ticker
-	ctx                    context.Context
-	cancel                 context.CancelFunc
-	disableResourceMetrics bool
-	publishMetricsInterval time.Duration
+	statsEngine              stats.Engine
+	doctor                   *doctor.Doctor
+	publishTicker            *time.Ticker
+	publishHealthTicker      *time.Ticker
+	pullInstanceStatusTicker *time.Ticker
+	ctx                      context.Context
+	cancel                   context.CancelFunc
+	disableResourceMetrics   bool
+	publishMetricsInterval   time.Duration
 	wsclient.ClientServerImpl
 }
 
@@ -60,12 +64,16 @@ func New(url string,
 	statsEngine stats.Engine,
 	publishMetricsInterval time.Duration,
 	rwTimeout time.Duration,
-	disableResourceMetrics bool) wsclient.ClientServer {
+	disableResourceMetrics bool,
+	doctor *doctor.Doctor,
+) wsclient.ClientServer {
 	cs := &clientServer{
-		statsEngine:            statsEngine,
-		publishTicker:          nil,
-		publishHealthTicker:    nil,
-		publishMetricsInterval: publishMetricsInterval,
+		statsEngine:              statsEngine,
+		doctor:                   doctor,
+		publishTicker:            nil,
+		publishHealthTicker:      nil,
+		pullInstanceStatusTicker: nil,
+		publishMetricsInterval:   publishMetricsInterval,
 	}
 	cs.URL = url
 	cs.AgentConfig = cfg
@@ -97,11 +105,14 @@ func (cs *clientServer) Serve() error {
 	// Start the timer function to publish metrics to the backend.
 	cs.publishTicker = time.NewTicker(cs.publishMetricsInterval)
 	cs.publishHealthTicker = time.NewTicker(cs.publishMetricsInterval)
+	cs.pullInstanceStatusTicker = time.NewTicker(cs.publishMetricsInterval)
 
 	if !cs.disableResourceMetrics {
 		go cs.publishMetrics()
 	}
 	go cs.publishHealthMetrics()
+
+	go cs.publishInstanceStatus()
 
 	return cs.ConsumeMessages()
 }
@@ -113,6 +124,9 @@ func (cs *clientServer) Close() error {
 	}
 	if cs.publishHealthTicker != nil {
 		cs.publishHealthTicker.Stop()
+	}
+	if cs.pullInstanceStatusTicker != nil {
+		cs.pullInstanceStatusTicker.Stop()
 	}
 
 	cs.cancel()
@@ -344,4 +358,102 @@ func copyTaskHealthMetrics(from []*ecstcs.TaskHealth) []*ecstcs.TaskHealth {
 	to := make([]*ecstcs.TaskHealth, len(from))
 	copy(to, from)
 	return to
+}
+
+// publishInstanceStatus queries the doctor.Doctor instance contained within cs,
+// converts the healthcheck results to an InstanceStatusRequest and then sends it
+// to the backend
+func (cs *clientServer) publishInstanceStatus() {
+	// Note to disambiguate between health metrics and instance statuses
+	//
+	// Instance status checks are performed by the Doctor class in the doctor module
+	// but the code calls them Healthchecks. They are named such because they denote
+	// that the container runtime (Docker) is healthy and communicating with the
+	// ECS Agent. Container instance statuses, which this function handles,
+	// pertain to the status of this container instance.
+	//
+	// Health metrics are specific to the tasks that are running on this particular
+	// container instance. Health metrics, which the publishHealthMetrics function
+	// handles, pertain to the health of the tasks that are running on this
+	// container instance.
+	if cs.pullInstanceStatusTicker == nil {
+		seelog.Debug("Skipping publishing container instance statuses. Publish ticker is uninitialized")
+		return
+	}
+
+	for {
+		select {
+		case <-cs.pullInstanceStatusTicker.C:
+			if !cs.doctor.HasStatusBeenReported() {
+				err := cs.publishInstanceStatusOnce()
+				if err != nil {
+					seelog.Warnf("Unable to publish instance status: %v", err)
+				} else {
+					cs.doctor.SetStatusReported(true)
+				}
+			} else {
+				seelog.Debug("Skipping publishing container instance status message that was already sent")
+			}
+		case <-cs.ctx.Done():
+			return
+		}
+	}
+}
+
+// publishInstanceStatusOnce gets called on a ticker to pull instance status
+// from the doctor instance contained within cs and sned that information to
+// the backend
+func (cs *clientServer) publishInstanceStatusOnce() error {
+	// Get the list of health request to send to backend.
+	request, err := cs.getPublishInstanceStatusRequest()
+	if err != nil {
+		return err
+	}
+
+	// Make the publish instance status request to the backend.
+	err = cs.MakeRequest(request)
+	if err != nil {
+		return err
+	}
+
+	cs.doctor.SetStatusReported(true)
+
+	return nil
+}
+
+// GetPublishInstanceStatusRequest will get all healthcheck statuses and generate
+// a sendable PublishInstanceStatusRequest
+func (cs *clientServer) getPublishInstanceStatusRequest() (*ecstcs.PublishInstanceStatusRequest, error) {
+	metadata := &ecstcs.InstanceStatusMetadata{
+		Cluster:           aws.String(cs.doctor.GetCluster()),
+		ContainerInstance: aws.String(cs.doctor.GetContainerInstanceArn()),
+		RequestId:         aws.String(uuid.NewRandom().String()),
+	}
+	instanceStatuses := cs.getInstanceStatuses()
+	if instanceStatuses == nil {
+		return nil, doctor.EmptyHealthcheckError
+	}
+
+	return &ecstcs.PublishInstanceStatusRequest{
+		Metadata:  metadata,
+		Statuses:  instanceStatuses,
+		Timestamp: aws.Time(time.Now()),
+	}, nil
+}
+
+// getInstanceStatuses returns a list of instance statuses converted from what
+// the doctor knows about the registered healthchecks
+func (cs *clientServer) getInstanceStatuses() []*ecstcs.InstanceStatus {
+	var instanceStatuses []*ecstcs.InstanceStatus
+
+	for _, healthcheck := range *cs.doctor.GetHealthchecks() {
+		instanceStatus := &ecstcs.InstanceStatus{
+			LastStatusChange: aws.Time(healthcheck.GetStatusChangeTime()),
+			LastUpdated:      aws.Time(healthcheck.GetLastHealthcheckTime()),
+			Status:           aws.String(healthcheck.GetHealthcheckStatus().String()),
+			Type:             aws.String(healthcheck.GetHealthcheckType()),
+		}
+		instanceStatuses = append(instanceStatuses, instanceStatus)
+	}
+	return instanceStatuses
 }

--- a/agent/tcs/client/client_types.go
+++ b/agent/tcs/client/client_types.go
@@ -46,6 +46,8 @@ func init() {
 		ecstcs.BadRequestException{},
 		ecstcs.ResourceValidationException{},
 		ecstcs.InvalidParameterException{},
+		ecstcs.AckPublishInstanceStatus{},
+		ecstcs.PublishInstanceStatusRequest{},
 	}
 }
 

--- a/agent/tcs/handler/types.go
+++ b/agent/tcs/handler/types.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
 	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/doctor"
 	"github.com/aws/amazon-ecs-agent/agent/engine"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
 	"github.com/aws/amazon-ecs-agent/agent/stats"
@@ -39,6 +40,7 @@ type TelemetrySessionParams struct {
 	ECSClient                     api.ECSClient
 	TaskEngine                    engine.TaskEngine
 	StatsEngine                   *stats.DockerStatsEngine
+	Doctor                        *doctor.Doctor
 	_time                         ttime.Time
 	_timeOnce                     sync.Once
 }

--- a/agent/tcs/model/api/api-2.json
+++ b/agent/tcs/model/api/api-2.json
@@ -42,7 +42,36 @@
         },
         {
           "shape":"ServerException",
+          "exception":true,
+          "fault":true
+        }
+      ]
+    },
+    "PublishInstanceStatus":{
+      "name":"PublishInstanceStatus",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"PublishInstanceStatusRequest"},
+      "output":{"shape":"AckPublishInstanceStatus"},
+      "errors":[
+        {
+          "shape":"BadRequestException",
           "exception":true
+        },
+        {
+          "shape":"ResourceValidationException",
+          "exception":true
+        },
+        {
+          "shape":"InvalidParameterException",
+          "exception":true
+        },
+        {
+          "shape":"ServerException",
+          "exception":true,
+          "fault":true
         }
       ]
     },
@@ -69,7 +98,8 @@
         },
         {
           "shape":"ServerException",
-          "exception":true
+          "exception":true,
+          "fault":true
         }
       ]
     },
@@ -92,13 +122,20 @@
         },
         {
           "shape":"ServerException",
-          "exception":true
+          "exception":true,
+          "fault":true
         }
       ]
     }
   },
   "shapes":{
     "AckPublishHealth":{
+      "type":"structure",
+      "members":{
+        "message":{"shape":"String"}
+      }
+    },
+    "AckPublishInstanceStatus":{
       "type":"structure",
       "members":{
         "message":{"shape":"String"}
@@ -178,6 +215,36 @@
         "healthy":{"shape":"Boolean"}
       }
     },
+    "InstanceHealthcheckStatus":{
+      "type":"string",
+      "enum":[
+        "OK",
+        "IMPAIRED",
+        "INSUFFICIENT_DATA",
+        "INITIALIZING"
+      ]
+    },
+    "InstanceStatus":{
+      "type":"structure",
+      "members":{
+        "type":{"shape":"String"},
+        "status":{"shape":"InstanceHealthcheckStatus"},
+        "lastUpdated":{"shape":"Timestamp"},
+        "lastStatusChange":{"shape":"Timestamp"}
+      }
+    },
+    "InstanceStatusMetadata":{
+      "type":"structure",
+      "members":{
+        "cluster":{"shape":"String"},
+        "containerInstance":{"shape":"String"},
+        "requestId":{"shape":"String"}
+      }
+    },
+    "InstanceStatuses":{
+      "type":"list",
+      "member":{"shape":"InstanceStatus"}
+    },
     "InvalidParameterException":{
       "type":"structure",
       "members":{
@@ -218,6 +285,14 @@
         "timestamp":{"shape":"Timestamp"}
       }
     },
+    "PublishInstanceStatusRequest":{
+      "type":"structure",
+      "members":{
+        "metadata":{"shape":"InstanceStatusMetadata"},
+        "statuses":{"shape":"InstanceStatuses"},
+        "timestamp":{"shape":"Timestamp"}
+      }
+    },
     "PublishMetricsRequest":{
       "type":"structure",
       "members":{
@@ -238,7 +313,8 @@
       "members":{
         "message":{"shape":"String"}
       },
-      "exception":true
+      "exception":true,
+      "fault":true
     },
     "StartTelemetrySessionRequest":{
       "type":"structure",
@@ -265,6 +341,7 @@
       "type":"structure",
       "members":{
         "taskArn":{"shape":"String"},
+        "clusterArn":{"shape":"String"},
         "taskDefinitionFamily":{"shape":"String"},
         "taskDefinitionVersion":{"shape":"String"},
         "containers":{"shape":"ContainerHealths"}
@@ -278,6 +355,7 @@
       "type":"structure",
       "members":{
         "taskArn":{"shape":"String"},
+        "clusterArn":{"shape":"String"},
         "taskDefinitionFamily":{"shape":"String"},
         "taskDefinitionVersion":{"shape":"String"},
         "containerMetrics":{"shape":"ContainerMetrics"}

--- a/agent/tcs/model/ecstcs/api.go
+++ b/agent/tcs/model/ecstcs/api.go
@@ -40,6 +40,22 @@ func (s AckPublishHealth) GoString() string {
 	return s.String()
 }
 
+type AckPublishInstanceStatus struct {
+	_ struct{} `type:"structure"`
+
+	Message *string `locationName:"message" type:"string"`
+}
+
+// String returns the string representation
+func (s AckPublishInstanceStatus) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AckPublishInstanceStatus) GoString() string {
+	return s.String()
+}
+
 type AckPublishMetric struct {
 	_ struct{} `type:"structure"`
 
@@ -264,6 +280,48 @@ func (s HeartbeatOutput) String() string {
 
 // GoString returns the string representation
 func (s HeartbeatOutput) GoString() string {
+	return s.String()
+}
+
+type InstanceStatus struct {
+	_ struct{} `type:"structure"`
+
+	LastStatusChange *time.Time `locationName:"lastStatusChange" type:"timestamp"`
+
+	LastUpdated *time.Time `locationName:"lastUpdated" type:"timestamp"`
+
+	Status *string `locationName:"status" type:"string" enum:"InstanceHealthcheckStatus"`
+
+	Type *string `locationName:"type" type:"string"`
+}
+
+// String returns the string representation
+func (s InstanceStatus) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s InstanceStatus) GoString() string {
+	return s.String()
+}
+
+type InstanceStatusMetadata struct {
+	_ struct{} `type:"structure"`
+
+	Cluster *string `locationName:"cluster" type:"string"`
+
+	ContainerInstance *string `locationName:"containerInstance" type:"string"`
+
+	RequestId *string `locationName:"requestId" type:"string"`
+}
+
+// String returns the string representation
+func (s InstanceStatusMetadata) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s InstanceStatusMetadata) GoString() string {
 	return s.String()
 }
 
@@ -493,6 +551,62 @@ func (s PublishHealthRequest) String() string {
 
 // GoString returns the string representation
 func (s PublishHealthRequest) GoString() string {
+	return s.String()
+}
+
+type PublishInstanceStatusInput struct {
+	_ struct{} `type:"structure"`
+
+	Metadata *InstanceStatusMetadata `locationName:"metadata" type:"structure"`
+
+	Statuses []*InstanceStatus `locationName:"statuses" type:"list"`
+
+	Timestamp *time.Time `locationName:"timestamp" type:"timestamp"`
+}
+
+// String returns the string representation
+func (s PublishInstanceStatusInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PublishInstanceStatusInput) GoString() string {
+	return s.String()
+}
+
+type PublishInstanceStatusOutput struct {
+	_ struct{} `type:"structure"`
+
+	Message *string `locationName:"message" type:"string"`
+}
+
+// String returns the string representation
+func (s PublishInstanceStatusOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PublishInstanceStatusOutput) GoString() string {
+	return s.String()
+}
+
+type PublishInstanceStatusRequest struct {
+	_ struct{} `type:"structure"`
+
+	Metadata *InstanceStatusMetadata `locationName:"metadata" type:"structure"`
+
+	Statuses []*InstanceStatus `locationName:"statuses" type:"list"`
+
+	Timestamp *time.Time `locationName:"timestamp" type:"timestamp"`
+}
+
+// String returns the string representation
+func (s PublishInstanceStatusRequest) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PublishInstanceStatusRequest) GoString() string {
 	return s.String()
 }
 
@@ -791,6 +905,8 @@ func (s *StorageStatsSet) Validate() error {
 type TaskHealth struct {
 	_ struct{} `type:"structure"`
 
+	ClusterArn *string `locationName:"clusterArn" type:"string"`
+
 	Containers []*ContainerHealth `locationName:"containers" type:"list"`
 
 	TaskArn *string `locationName:"taskArn" type:"string"`
@@ -812,6 +928,8 @@ func (s TaskHealth) GoString() string {
 
 type TaskMetric struct {
 	_ struct{} `type:"structure"`
+
+	ClusterArn *string `locationName:"clusterArn" type:"string"`
 
 	ContainerMetrics []*ContainerMetric `locationName:"containerMetrics" type:"list"`
 


### PR DESCRIPTION
We'll be merging this feature branch soon!  running all tests on the rebase/squash against latest dev.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Merge feature/instance-health branch

### Implementation details
Changes have individually been reviewed.

### Testing
Tests cover changes.
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Add instance health status feature.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
