### PR TITLE
remove unused TopContainer API

### DIFF
--- a/agent/dockerclient/dockerapi/docker_client.go
+++ b/agent/dockerclient/dockerapi/docker_client.go
@@ -145,11 +145,6 @@ type DockerClient interface {
 	// provided for the request.
 	InspectContainer(context.Context, string, time.Duration) (*types.ContainerJSON, error)
 
-	// TopContainer returns information about the top processes running in the specified container.  A timeout value and a context
-	// should be provided for the request. The last argument is an optional parameter for passing in 'ps' arguments
-	// as part of the top command.
-	TopContainer(context.Context, string, time.Duration, ...string) (*dockercontainer.ContainerTopOKBody, error)
-
 	// CreateContainerExec creates a new exec configuration to run an exec process with the provided Config. A timeout value
 	// and a context should be provided for the request.
 	CreateContainerExec(ctx context.Context, containerID string, execConfig types.ExecConfig, timeout time.Duration) (*types.IDResponse, error)
@@ -685,45 +680,6 @@ func (dg *dockerGoClient) inspectContainer(ctx context.Context, dockerID string)
 	}
 	containerData, err := client.ContainerInspect(ctx, dockerID)
 	return &containerData, err
-}
-
-func (dg *dockerGoClient) TopContainer(ctx context.Context, dockerID string, timeout time.Duration, psArgs ...string) (*dockercontainer.ContainerTopOKBody, error) {
-	type topResponse struct {
-		top *dockercontainer.ContainerTopOKBody
-		err error
-	}
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-	defer metrics.MetricsEngineGlobal.RecordDockerMetric("TOP_CONTAINER")()
-	// Buffered channel so in the case of timeout it takes one write, never gets
-	// read, and can still be GC'd
-	response := make(chan topResponse, 1)
-	go func() {
-		top, err := dg.topContainer(ctx, dockerID, psArgs...)
-		response <- topResponse{top, err}
-	}()
-
-	// Wait until we get a response or for the 'done' context channel
-	select {
-	case resp := <-response:
-		return resp.top, resp.err
-	case <-ctx.Done():
-		err := ctx.Err()
-		if err == context.DeadlineExceeded {
-			return nil, &DockerTimeoutError{timeout, "listing top"}
-		}
-
-		return nil, &CannotGetContainerTopError{err}
-	}
-}
-
-func (dg *dockerGoClient) topContainer(ctx context.Context, dockerID string, psArgs ...string) (*dockercontainer.ContainerTopOKBody, error) {
-	client, err := dg.sdkDockerClient()
-	if err != nil {
-		return nil, err
-	}
-	topResponse, err := client.ContainerTop(ctx, dockerID, psArgs)
-	return &topResponse, err
 }
 
 func (dg *dockerGoClient) StopContainer(ctx context.Context, dockerID string, timeout time.Duration) DockerContainerMetadata {

--- a/agent/dockerclient/dockerapi/docker_client_test.go
+++ b/agent/dockerclient/dockerapi/docker_client_test.go
@@ -762,39 +762,6 @@ func TestInspectContainer(t *testing.T) {
 	assert.True(t, reflect.DeepEqual(&containerOutput, container))
 }
 
-func TestTopContainerTimeout(t *testing.T) {
-	mockDockerSDK, client, _, _, _, done := dockerClientSetup(t)
-	defer done()
-
-	wait := &sync.WaitGroup{}
-	wait.Add(1)
-	mockDockerSDK.EXPECT().ContainerTop(gomock.Any(), "id", gomock.Any()).Do(func(ctx context.Context, x interface{}, y interface{}) {
-		wait.Wait()
-	}).MaxTimes(1).Return(dockercontainer.ContainerTopOKBody{}, nil)
-
-	ctx, cancel := context.WithCancel(context.TODO())
-	defer cancel()
-	_, err := client.TopContainer(ctx, "id", xContainerShortTimeout)
-	assert.Error(t, err, "Expected error for top timeout")
-	assert.Equal(t, "DockerTimeoutError", err.(apierrors.NamedError).ErrorName())
-	wait.Done()
-}
-
-func TestTopContainer(t *testing.T) {
-	mockDockerSDK, client, _, _, _, done := dockerClientSetup(t)
-	defer done()
-
-	topOutput := dockercontainer.ContainerTopOKBody{}
-	gomock.InOrder(
-		mockDockerSDK.EXPECT().ContainerTop(gomock.Any(), "id", gomock.Any()).Return(topOutput, nil),
-	)
-	ctx, cancel := context.WithCancel(context.TODO())
-	defer cancel()
-	topResponse, err := client.TopContainer(ctx, "id", dockerclient.TopContainerTimeout, "pid")
-	assert.NoError(t, err)
-	assert.Equal(t, &topOutput, topResponse)
-}
-
 func TestContainerEvents(t *testing.T) {
 	mockDockerSDK, client, _, _, _, done := dockerClientSetup(t)
 	defer done()

--- a/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
+++ b/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
@@ -445,26 +445,6 @@ func (mr *MockDockerClientMockRecorder) SystemPing(arg0, arg1 interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SystemPing", reflect.TypeOf((*MockDockerClient)(nil).SystemPing), arg0, arg1)
 }
 
-// TopContainer mocks base method
-func (m *MockDockerClient) TopContainer(arg0 context.Context, arg1 string, arg2 time.Duration, arg3 ...string) (*container0.ContainerTopOKBody, error) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1, arg2}
-	for _, a := range arg3 {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "TopContainer", varargs...)
-	ret0, _ := ret[0].(*container0.ContainerTopOKBody)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// TopContainer indicates an expected call of TopContainer
-func (mr *MockDockerClientMockRecorder) TopContainer(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TopContainer", reflect.TypeOf((*MockDockerClient)(nil).TopContainer), varargs...)
-}
-
 // Version mocks base method
 func (m *MockDockerClient) Version(arg0 context.Context, arg1 time.Duration) (string, error) {
 	m.ctrl.T.Helper()

--- a/agent/dockerclient/timeout.go
+++ b/agent/dockerclient/timeout.go
@@ -35,8 +35,6 @@ const (
 	ListContainersTimeout = 10 * time.Minute
 	// InspectContainerTimeout is the timeout for the InspectContainer API.
 	InspectContainerTimeout = 30 * time.Second
-	// TopContainerTimeout is the timeout for the TopContainer API.
-	TopContainerTimeout = 30 * time.Second
 	// ContainerExecCreateTimeout is the timeout for the ContainerExecCreate API.
 	ContainerExecCreateTimeout = 1 * time.Minute
 	// ContainerExecStartTimeout is the timeout for the ContainerExecStart API.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
While combing though the docker APIs being used, found that docker container top is unused in the code base. 
removing it. 

### Description for the changelog
n/a

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
