### PR TITLE
change acs/tcs connection closed log level to info

### DIFF
--- a/agent/acs/handler/acs_handler.go
+++ b/agent/acs/handler/acs_handler.go
@@ -399,7 +399,7 @@ func (acsSession *session) startACSSession(client wsclient.ClientServer) error {
 			if err == nil || err == io.EOF {
 				seelog.Info("ACS Websocket connection closed for a valid reason")
 			} else {
-				seelog.Errorf("Error: lost websocket connection with Agent Communication Service (ACS): %v", err)
+				seelog.Infof("Agent Communication Service (ACS) connection closed: %v", err)
 			}
 			return err
 		}

--- a/agent/tcs/handler/handler.go
+++ b/agent/tcs/handler/handler.go
@@ -82,7 +82,7 @@ func StartSession(params *TelemetrySessionParams, statsEngine stats.Engine) erro
 			seelog.Info("TCS Websocket connection closed for a valid reason")
 			backoff.Reset()
 		} else {
-			seelog.Errorf("Error: lost websocket connection with ECS Telemetry service (TCS): %v", tcsError)
+			seelog.Infof("Connection with ECS Telemetry service (TCS) closed: %v", tcsError)
 			params.time().Sleep(backoff.Duration())
 		}
 		select {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Changing log level of ACS/TACS websocket connection closed to Info from Error. 
This was changed from [info](https://github.com/aws/amazon-ecs-agent/commit/b0260423aa91f583d7d26928d091a12e457cc267) to [error](https://github.com/aws/amazon-ecs-agent/commit/481eefc5c16316093483dddf48788038b22cdf1d) recently. 
This is being noisy in the logs, when agent actually connects back. Example:
```
level=warn time=2021-11-06T01:37:20Z msg="ACS Connection hasn't had any activity for too long; closing connection" module=acs_handler.go
level=error time=2021-11-06T01:37:20Z msg="Error: lost websocket connection with Agent Communication Service (ACS): read tcp 22.173.57.42:43668->54.239.16.66:443: use of closed network connection" module=acs_handler.go
level=info time=2021-11-06T01:37:20Z msg="Reconnecting to ACS in: 279.769714ms" module=acs_handler.go
level=warn time=2021-11-06T01:37:20Z msg="Error disconnecting: write tcp 22.173.57.42:43668->54.239.16.66:443: i/o timeout" module=acs_handler.go
level=info time=2021-11-06T01:37:20Z msg="Disconnected from ACS" module=acs_handler.go
level=info time=2021-11-06T01:37:20Z msg="Done waiting; reconnecting to ACS" module=acs_handler.go
level=info time=2021-11-06T01:37:20Z msg="Establishing a Websocket connection to https://ecs-a-1.us-east-1.amazonaws.com/ws?agentHash=90ccb1d4&agentVersion=1.50.0&clusterArn=ANTM-SYDWEB-API-ECS-prod1&containerInstanceArn=arn%3Aaws%3Aecs%3Aus-east-1%3A644490409399%3Acontainer-instance%2FANTM-SYDWEB-API-ECS-prod1%2F038d247ce9da43aab6d918de2abdf320&dockerVersion=DockerVersion%3A+19.03.13-ce&sendCredentials=false&seqNum=1" module=client.go
level=info time=2021-11-06T01:37:20Z msg="Connected to ACS endpoint" module=acs_handler.go
```

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
