### PR TITLE
Add resourceMap to container and use Container Execution Role to pull secret data

### DIFF
--- a/agent/api/task/task_linux_test.go
+++ b/agent/api/task/task_linux_test.go
@@ -1146,6 +1146,19 @@ func TestPopulateSecretLogOptionsToFirelensContainer(t *testing.T) {
 	assert.Equal(t, "secret-val", task.Containers[1].Environment["secret-name_0"])
 }
 
+func TestPopulateSecretLogOptionsToFirelensContainerWithContainerCredentials(t *testing.T) {
+	task := getFirelensTask(t)
+	task.Containers[1].ExecutionCredentialsID = "credentials id"
+	task.Containers[1].ResourcesMapUnsafe = make(map[string][]taskresource.TaskResource)
+	ssmRes := &ssmsecret.SSMSecretResource{}
+	ssmRes.SetCachedSecretValue("secret-value-from_us-west-2", "secret-val")
+	task.Containers[1].AddResource(ssmsecret.ResourceName, ssmRes)
+
+	assert.Nil(t, task.PopulateSecretLogOptionsToFirelensContainer(task.Containers[1]))
+	assert.Len(t, task.Containers[1].Environment, 2)
+	assert.Equal(t, "secret-val", task.Containers[1].Environment["secret-name_0"])
+}
+
 func TestCollectLogDriverSecretData(t *testing.T) {
 	ssmRes := &ssmsecret.SSMSecretResource{}
 	ssmRes.SetCachedSecretValue("secret-value-from_us-west-2", "secret-val")

--- a/agent/api/task/task_windows_test.go
+++ b/agent/api/task/task_windows_test.go
@@ -101,6 +101,7 @@ func TestPostUnmarshalWindowsCanonicalPaths(t *testing.T) {
 						SourceVolume:  "sourceVolume",
 					},
 				},
+				ResourcesMapUnsafe:        make(map[string][]taskresource.TaskResource),
 				TransitionDependenciesMap: make(map[containerstatus.ContainerStatus]containerresource.TransitionDependencySet),
 			},
 		},

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -1804,7 +1804,7 @@ func TestTaskUseExecutionRolePullPrivateRegistryImage(t *testing.T) {
 	requiredASMResources := []*containerresource.ASMAuthData{asmAuthData}
 	asmClientCreator := mock_asm_factory.NewMockClientCreator(ctrl)
 	asmAuthRes := asmauth.NewASMAuthResource(testTask.Arn, requiredASMResources,
-		credentialsID, credentialsManager, asmClientCreator)
+		credentialsID, false, credentialsManager, asmClientCreator)
 	testTask.ResourcesMapUnsafe = map[string][]taskresource.TaskResource{
 		asmauth.ResourceName: {asmAuthRes},
 	}
@@ -2683,6 +2683,7 @@ func TestTaskSecretsEnvironmentVariables(t *testing.T) {
 				testTask.Arn,
 				ssmRequirements,
 				credentialsID,
+				false,
 				credentialsManager,
 				ssmClientCreator)
 
@@ -2698,6 +2699,7 @@ func TestTaskSecretsEnvironmentVariables(t *testing.T) {
 				testTask.Arn,
 				asmRequirements,
 				credentialsID,
+				false,
 				credentialsManager,
 				asmClientCreator)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR includes changes to add resourceMap to container and use Container Execution Role to pull secret data from these resources. Also if populate container secret data using container execution role.


### Implementation details
<!-- How are the changes implemented? -->
- `agent/api/container/container.go`:  
         - added ResourcesMapUnsafe to container structure to support container level resources like ASMAuth, SSMSecrets and ASMSecrets which can be retrieved by using container execution iam role.
         - added few methods like AddResources(), GetResources(), etc..to store and retrieve the above mentioned secret data.
- `agent/api/task/task.go`:  In case containers contains execution credentials id:
            - updated initializeASMAuthResource(), initializeSSMSecretResource() and initializeASMSecretResource() to initialize resources in container that depend on these resources.
            - updated  PopulateASMAuthData(), PopulateSecrets() and PopulateSecretLogOptionsToFirelensContainer() to use resources stored in container for secret data.
 - `agent/taskresource`: updated initialization in NewASMAuthResource(), NewASMSecretResource() and NewSSMSecretResource() to support using container execution iam role to retrieve secrets.

**Note**: Changes required in taskManager will be added in a separate PR.
### Testing
<!-- How was this tested? -->
make test
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
