### PR TITLE
Lower task cleanup duration

### DIFF
--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -92,7 +92,7 @@ const (
 
 	// minimumTaskCleanupWaitDuration specifies the minimum duration to wait before cleaning up
 	// a task's container. This is used to enforce sane values for the config.TaskCleanupWaitDuration field.
-	minimumTaskCleanupWaitDuration = 1 * time.Minute
+	minimumTaskCleanupWaitDuration = time.Second
 
 	// minimumImagePullInactivityTimeout specifies the minimum amount of time for that an image can be
 	// 'stuck' in the pull / unpack step. Very small values are unsafe and lead to high failure rate.

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -493,7 +493,7 @@ func TestValidFormatParseEnvVariableDuration(t *testing.T) {
 
 func TestInvalidTaskCleanupTimeoutOverridesToThreeHours(t *testing.T) {
 	defer setTestRegion()()
-	setTestEnv("ECS_ENGINE_TASK_CLEANUP_WAIT_DURATION", "1s")
+	setTestEnv("ECS_ENGINE_TASK_CLEANUP_WAIT_DURATION", "1ms")
 	cfg, err := NewConfig(ec2.NewBlackholeEC2MetadataClient())
 	assert.NoError(t, err)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary

Lower minimum task clean up duration from one minute to one second. 

This could help mitigate https://github.com/aws/amazon-ecs-agent/issues/2810 

### Testing
UTs, Integ & functinal  tests

### Description for the changelog
* Lower task cleanup duration
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
