### PR TITLE
delete container resource when delete task

### DIFF
--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -649,6 +649,19 @@ func (engine *DockerTaskEngine) deleteTask(task *apitask.Task) {
 		}
 	}
 
+	for _, container := range task.Containers {
+		for _, resource := range container.GetResources() {
+			err := resource.Cleanup()
+			if err != nil {
+				seelog.Warnf("Task engine [%s]/[%s]: unable to cleanup resource %s: %v",
+					task.Arn, container.Name, resource.GetName(), err)
+			} else {
+				seelog.Infof("Task engine [%s]/[%s]: resource %s cleanup complete",
+					task.Arn, container.Name, resource.GetName())
+			}
+		}
+	}
+
 	if execcmd.IsExecEnabledTask(task) {
 		// cleanup host exec agent log dirs
 		if tID, err := task.GetID(); err != nil {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Delete container resources when delete task

### Implementation details
<!-- How are the changes implemented? -->
loop through all containers and delete resources while delete task

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
