### PR TITLE
Fix honnef.co/go/tools/cmd/staticcheck version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -305,7 +305,7 @@ GOPATH=$(shell go env GOPATH)
 	cd "${GOPATH}/src/github.com/golang/mock/mockgen" && git checkout 1.3.1 && go get ./... && go install ./... && cd -
 	go get golang.org/x/tools/cmd/goimports
 	GO111MODULE=on go get github.com/fzipp/gocyclo/cmd/gocyclo@v0.3.1
-	go get honnef.co/go/tools/cmd/staticcheck
+	GO111MODULE=on go get honnef.co/go/tools/cmd/staticcheck@v0.2.1
 	touch .get-deps-stamp
 
 get-deps: .get-deps-stamp


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This PR fixes the version of staticcheck to `@v0.2.1` to resolve the static check failure provided as follows:
```
go: downloading golang.org/x/tools v0.0.0-20190425150028-36563e24a262
/home/runner/work/amazon-ecs-agent/amazon-ecs-agent/src/github.com/aws/amazon-ecs-agent
go get golang.org/x/tools/cmd/goimports
GO111MODULE=on go get github.com/fzipp/gocyclo/cmd/gocyclo@v0.3.1
go: downloading github.com/fzipp/gocyclo v0.3.1
go get: installing executables with 'go get' in module mode is deprecated.
	Use 'go install pkg@version' instead.
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
go get honnef.co/go/tools/cmd/staticcheck
# honnef.co/go/tools/go/loader
Error: ../../../honnef.co/go/tools/go/loader/loader.go:330:48: err.Line undefined (type config.ParseError has no field or method Line)
make: *** [Makefile:308: .get-deps-stamp] Error 2
Error: Process completed with exit code 2.
```

This error comes from the latest static check  - [Staticcheck 2021.1.2 (v0.2.2)](https://github.com/dominikh/go-tools/releases/tag/2021.1.2); therefore, fix the version at [Staticcheck 2021.1.1 (v0.2.1)](https://github.com/dominikh/go-tools/releases/tag/2021.1.1).

### Implementation details
Fix honnef.co/go/tools/cmd/staticcheck version to `v0.2.1`

### Testing
Static Checks workflow

New tests cover the changes: no

### Description for the changelog
N/A

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
