### PR TITLE
inject host values to app containers that use firelens v2

### DIFF
--- a/agent/acs/model/api/api-2.json
+++ b/agent/acs/model/api/api-2.json
@@ -532,6 +532,7 @@
       "members":{
         "type":{"shape":"FirelensConfigurationType"},
         "options":{"shape":"FirelensConfigurationOptionsMap"},
+        "firelensConfigurationMode": {"shape":"FirelensConfigurationMode"},
         "version": {"shape":"String"},
         "collectStdoutLogs":{"shape":"Boolean"},
         "statusMessageReportingPath":{"shape":"String"}
@@ -548,6 +549,13 @@
       "type":"map",
       "key":{"shape":"String"},
       "value":{"shape":"String"}
+    },
+    "FirelensConfigurationMode": {
+      "type":"string",
+      "enum":[
+        "telemetry",
+        "security"
+      ]
     },
     "Long":{"type":"long"},
     "MountPoint":{

--- a/agent/acs/model/ecsacs/api.go
+++ b/agent/acs/model/ecsacs/api.go
@@ -711,6 +711,8 @@ type FirelensConfiguration struct {
 
 	CollectStdoutLogs *bool `locationName:"collectStdoutLogs" type:"boolean"`
 
+	FirelensConfigurationMode *string `locationName:"firelensConfigurationMode" type:"string" enum:"FirelensConfigurationMode"`
+
 	Options map[string]*string `locationName:"options" type:"map"`
 
 	StatusMessageReportingPath *string `locationName:"statusMessageReportingPath" type:"string"`

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -999,6 +999,26 @@ func (task *Task) GetFirelensContainers() []*apicontainer.Container {
 	return firelensContainers
 }
 
+func (task *Task) HasFirelensv2FluentBitCollector() bool {
+	for _, container := range task.Containers {
+		if container.FirelensConfig != nil && container.FirelensConfig.Version == "v2" &&
+			container.FirelensConfig.Type == firelens.FirelensConfigTypeAWSFluentbitCollector {
+			return true
+		}
+	}
+	return false
+}
+
+func (task *Task) HasFirelensv2OpenTelemetryCollector() bool {
+	for _, container := range task.Containers {
+		if container.FirelensConfig != nil && container.FirelensConfig.Version == "v2" &&
+			container.FirelensConfig.Type == firelens.FirelensConfigTypeAWSOtelCollector {
+			return true
+		}
+	}
+	return false
+}
+
 // initializeFirelensResource initializes the firelens task resource and adds it as a dependency of the
 // firelens container.
 func (task *Task) initializeFirelensResource(config *config.Config, resourceFields *taskresource.ResourceFields,

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -3967,3 +3967,52 @@ func TestPostUnmarshalTaskWithOptions(t *testing.T) {
 	task.PostUnmarshalTask(&config.Config{}, nil, nil, nil, nil, opt, opt)
 	assert.Equal(t, 2, numCalls)
 }
+
+func TestTask_HasFirelensv2FluentBitCollector(t *testing.T) {
+	container := &apicontainer.Container{
+		Name: "containerName",
+		FirelensConfig: &containerresource.FirelensConfig{
+			Version: "v2",
+			Type:    "opentelemetry",
+		},
+	}
+	container1 := &apicontainer.Container{
+		Name: "containerName",
+		FirelensConfig: &containerresource.FirelensConfig{
+			Version: "v2",
+			Type:    "fluentbit",
+		},
+	}
+
+	task := &Task{
+		Arn:        "testArn",
+		Containers: []*apicontainer.Container{container, container1},
+	}
+
+	assert.True(t, task.HasFirelensv2FluentBitCollector())
+}
+
+func TestTask_HasFirelensv2OpenTelemetryCollector(t *testing.T) {
+	container := &apicontainer.Container{
+		Name: "containerName",
+		FirelensConfig: &containerresource.FirelensConfig{
+			Version: "v2",
+			Type:    "fluentbit",
+		},
+	}
+
+	container1 := &apicontainer.Container{
+		Name: "containerName",
+		FirelensConfig: &containerresource.FirelensConfig{
+			Version: "v2",
+			Type:    "opentelemetry",
+		},
+	}
+
+	task := &Task{
+		Arn:        "testArn",
+		Containers: []*apicontainer.Container{container, container1},
+	}
+
+	assert.True(t, task.HasFirelensv2OpenTelemetryCollector())
+}

--- a/agent/containerresource/types.go
+++ b/agent/containerresource/types.go
@@ -34,6 +34,7 @@ type FirelensConfig struct {
 	Version                    string            `json:"version"`
 	CollectStdoutLogs          bool              `json:"collectStdoutLogs,omitempty"`
 	StatusMessageReportingPath string            `json:"statusMessageReportingPath,omitempty"`
+	FirelensConfigurationMode  string            `json:"firelensConfigurationMode,omitempty"`
 	Options                    map[string]string `json:"options"`
 }
 

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -3701,3 +3701,60 @@ func TestCreateContainerWithExecAgent(t *testing.T) {
 		})
 	}
 }
+
+func TestGetFirelensEnvironmentVariables(t *testing.T) {
+	hostValue := "127.0.0.1"
+	testcases := []struct {
+		name            string
+		firelensType    string
+		firelensVersion string
+		expectedEnvVars map[string]string
+	}{
+		{
+			name:            "firelens v1",
+			firelensType:    "fluentd",
+			firelensVersion: "v1",
+			expectedEnvVars: map[string]string{
+				"FLUENT_HOST": hostValue,
+			},
+		},
+		{
+			name:            "firelens v2",
+			firelensType:    "fluentbit",
+			firelensVersion: "v2",
+			expectedEnvVars: map[string]string{
+				"FLUENT_HOST": hostValue,
+			},
+		},
+		{
+			name:            "firelens v2",
+			firelensType:    "opentelemetry",
+			firelensVersion: "v2",
+			expectedEnvVars: map[string]string{
+				"OPEN_TELEMETRY_HOST": hostValue,
+			},
+		},
+	}
+
+	getContainer := func(firelensVersion, firelensType string) apicontainer.Container {
+		return apicontainer.Container{
+			Name: "test-container",
+			FirelensConfig: &containerresource.FirelensConfig{
+				Type:    firelensType,
+				Version: firelensVersion,
+			},
+		}
+	}
+
+	for _, tc := range testcases {
+		envVars := make(map[string]string)
+		container := getContainer(tc.firelensVersion, tc.firelensType)
+		task := &apitask.Task{
+			Containers: []*apicontainer.Container{&container},
+		}
+
+		setFirelensEnvironmentVariables(task, &container, tc.firelensVersion, envVars, hostValue)
+		assert.Equal(t, tc.expectedEnvVars, envVars)
+
+	}
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR includes changes to inject hostname values to all the app containers that use firelens v2. Hostname values are required for observability use cases, logs, metrics, or traces are often sent over the network from an SDK(like OTEL, X-Ray, Log4j) in the app container, to the collector container.

Firelens v1 behaviour where we inject `FLUENT_HOST` and `FLUENT_PORT` environment variables is unchanged.

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
`make test`
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
