### PR TITLE
Update fluentd container to 1.14, use ECR

### DIFF
--- a/misc/fluentd/Dockerfile
+++ b/misc/fluentd/Dockerfile
@@ -1,3 +1,3 @@
-FROM fluent/fluentd:v1.11.5-1.0
+FROM public.ecr.aws/docker/library/fluentd:v1.14.0-1.0
 
 COPY fluent.conf /fluentd/etc/

--- a/scripts/ci-ecr
+++ b/scripts/ci-ecr
@@ -3,5 +3,4 @@ GO_VERSION=$(cat "$dir/../GO_VERSION")
 GO_VERSION_WINDOWS=$(cat "$dir/../GO_VERSION_WINDOWS")
 
 IMAGES="gcc:7.3.0
-debian:stable-20210816
-fluent/fluentd:v1.11.5-1.0"
+debian:stable-20210816"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

change the fluentd integration test container from `fluent/fluentd:v1.11.5-1.0` to `public.ecr.aws/docker/library/fluentd:v1.14.0-1.0`

Version number `v1.11.5-1.0` was bumped because public ecr's official docker library doesn't have this version available. 

This is to remove another dockerhub container from our build/test process so that it doesn't need to be replicated and maintained in our private ECR.


### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

functional test suite

New tests cover the changes: no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

NA

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
