### PR TITLE
Use public ecr for misc/certs debian base image

### DIFF
--- a/misc/certs/Dockerfile
+++ b/misc/certs/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-20210816
+FROM public.ecr.aws/docker/library/debian:stable-20211201-slim
 
 RUN apt-get update &&  \
     apt-get install -y ca-certificates && \

--- a/scripts/ci-ecr
+++ b/scripts/ci-ecr
@@ -1,6 +1,3 @@
 dir=$(dirname "${BASH_SOURCE[0]}")
-GO_VERSION=$(cat "$dir/../GO_VERSION")
-GO_VERSION_WINDOWS=$(cat "$dir/../GO_VERSION_WINDOWS")
 
-IMAGES="gcc:7.3.0
-debian:stable-20210816"
+IMAGES="gcc:7.3.0"


### PR DESCRIPTION
Version number was bumped because public ecr does not have the same
version we were using previously.

Moved to the 'slim' variant since we only use the `ca-certificates` package, 
so we can save about 45MB of space by using the slim variant:

```
% docker images | grep amazon-ecs-agent-cert-source
amazon/amazon-ecs-agent-cert-source     make              fd149aa47f79   5 minutes ago   128MB

% docker images | grep amazon-ecs-agent-cert-source
amazon/amazon-ecs-agent-cert-source     make              09a9717f094a   6 seconds ago   83.7MB
```

Because we run 'apt-get update' and install ca-certificates from the
debian repos, the certificates we are getting in this bumped version
won't change. This was verified by running "make certs" before and after
and diffing the misc/certs/ca-certificates.crt file.

```
% diff misc/certs/ca-certificates.crt misc/certs/ca-certificates.crt.orig
```

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

certs were verified to be identical before and after this change.

New tests cover the changes: no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

NA

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
