### PR TITLE
Add Host IP to port response for v2 container response

### DIFF
--- a/agent/handlers/v1/response.go
+++ b/agent/handlers/v1/response.go
@@ -67,6 +67,7 @@ type PortResponse struct {
 	ContainerPort uint16 `json:"ContainerPort,omitempty"`
 	Protocol      string `json:"Protocol,omitempty"`
 	HostPort      uint16 `json:"HostPort,omitempty"`
+	HostIp        string `json:"HostIp,omitempty"`
 }
 
 // NewTaskResponse creates a TaskResponse for a task.

--- a/agent/handlers/v2/response.go
+++ b/agent/handlers/v2/response.go
@@ -275,6 +275,7 @@ func NewContainerResponse(
 		port := v1.PortResponse{
 			ContainerPort: binding.ContainerPort,
 			Protocol:      binding.Protocol.String(),
+			HostIp:        binding.BindIP,
 		}
 		if eni == nil {
 			port.HostPort = binding.HostPort

--- a/agent/handlers/v2/response_test.go
+++ b/agent/handlers/v2/response_test.go
@@ -346,6 +346,7 @@ func TestTaskResponseMarshal(t *testing.T) {
 						"HostPort":      float64(80),
 						"ContainerPort": float64(80),
 						"Protocol":      "tcp",
+						"HostIp":        "0.0.0.0",
 					},
 				},
 				"DesiredStatus": "NONE",
@@ -404,6 +405,7 @@ func TestTaskResponseMarshal(t *testing.T) {
 			{
 				ContainerPort: 80,
 				Protocol:      apicontainer.TransportProtocolTCP,
+				BindIP:        "0.0.0.0",
 			},
 		},
 	}
@@ -475,6 +477,7 @@ func TestContainerResponseMarshal(t *testing.T) {
 				"ContainerPort": float64(80),
 				"Protocol":      "tcp",
 				"HostPort":      float64(80),
+				"HostIp":        "0.0.0.0",
 			},
 		},
 		"Labels": map[string]interface{}{
@@ -524,6 +527,7 @@ func TestContainerResponseMarshal(t *testing.T) {
 			{
 				ContainerPort: 80,
 				Protocol:      apicontainer.TransportProtocolTCP,
+				BindIP:        "0.0.0.0",
 			},
 		},
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Currently there is no way to identify ipv4 ports vs ipv6 ports from Task metadata endpoint v4. This PR includes changes to add Host IP to port response for Task metadata endpoint v2 onwards.

Related to issue - https://github.com/aws/amazon-ecs-agent/issues/3096
### Implementation details
<!-- How are the changes implemented? -->
- `agent/handlers/v1/response.go` : update PortResponse struct to include HostIp field.
- `agent/handlers/v2/response.go` : add HostIp to container response and update tests accordingly.

### Testing
<!-- How was this tested? -->
Tested this change by running a task with container port mappings configured on a IPv6 enabled instance and see the following response for `curl ${ECS_CONTAINER_METADATA_URI_V4}/task `
```
{
  "Cluster": "default",
  ...
  "Containers": [
    {
      "DockerId": "be27aa9a7e8905edd8aea8cb17e428255dc365bd3f729ae02eeff0c6fd96aba6",
      "Name": "server",
      "DockerName": "ecs-nginx-server-3-server-f096d1ccbfb2bda87a00",      "Image": "nginx:latest",      "ImageID": "sha256:605c77e624ddb75e6110f997c58876baa13f8754486b461117934b24a9dc3a85",      "Ports": [        {
          "ContainerPort": 8888,
          "Protocol": "tcp",          
         "HostPort": 49825,          
         "HostIP": "0.0.0.0"        
         },        
        {          
      "ContainerPort": 8888,
          "Protocol": "tcp",
          "HostPort": 49825,
          "HostIP": "::"
        },
        {
          "ContainerPort": 8888,
          "Protocol": "tcp",
          "HostPort": 49832,          
         "HostIP": "0.0.0.0"
        },
        { 
         "ContainerPort": 8888,
          "Protocol": "tcp",
          "HostPort": 49832,
          "HostIP": "::"
        }
      ],
      ...
}
```
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
