### PR TITLE
Revert "Add Host IP to port response for v2 container response"

### DIFF
--- a/agent/handlers/v1/response.go
+++ b/agent/handlers/v1/response.go
@@ -67,7 +67,6 @@ type PortResponse struct {
 	ContainerPort uint16 `json:"ContainerPort,omitempty"`
 	Protocol      string `json:"Protocol,omitempty"`
 	HostPort      uint16 `json:"HostPort,omitempty"`
-	HostIp        string `json:"HostIp,omitempty"`
 }
 
 // NewTaskResponse creates a TaskResponse for a task.

--- a/agent/handlers/v2/response.go
+++ b/agent/handlers/v2/response.go
@@ -275,7 +275,6 @@ func NewContainerResponse(
 		port := v1.PortResponse{
 			ContainerPort: binding.ContainerPort,
 			Protocol:      binding.Protocol.String(),
-			HostIp:        binding.BindIP,
 		}
 		if eni == nil {
 			port.HostPort = binding.HostPort

--- a/agent/handlers/v2/response_test.go
+++ b/agent/handlers/v2/response_test.go
@@ -346,7 +346,6 @@ func TestTaskResponseMarshal(t *testing.T) {
 						"HostPort":      float64(80),
 						"ContainerPort": float64(80),
 						"Protocol":      "tcp",
-						"HostIp":        "0.0.0.0",
 					},
 				},
 				"DesiredStatus": "NONE",
@@ -405,7 +404,6 @@ func TestTaskResponseMarshal(t *testing.T) {
 			{
 				ContainerPort: 80,
 				Protocol:      apicontainer.TransportProtocolTCP,
-				BindIP:        "0.0.0.0",
 			},
 		},
 	}
@@ -477,7 +475,6 @@ func TestContainerResponseMarshal(t *testing.T) {
 				"ContainerPort": float64(80),
 				"Protocol":      "tcp",
 				"HostPort":      float64(80),
-				"HostIp":        "0.0.0.0",
 			},
 		},
 		"Labels": map[string]interface{}{
@@ -527,7 +524,6 @@ func TestContainerResponseMarshal(t *testing.T) {
 			{
 				ContainerPort: 80,
 				Protocol:      apicontainer.TransportProtocolTCP,
-				BindIP:        "0.0.0.0",
 			},
 		},
 	}


### PR DESCRIPTION
This reverts commit f0647b2eb5f8e88dbb965e094e8a4bc83be4f894.

reverting this commit for now so that we can make this change only for TMDE v4.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
