### PR TITLE
Add Host IP to port response for v4 container response

### DIFF
--- a/agent/handlers/v1/response.go
+++ b/agent/handlers/v1/response.go
@@ -67,6 +67,7 @@ type PortResponse struct {
 	ContainerPort uint16 `json:"ContainerPort,omitempty"`
 	Protocol      string `json:"Protocol,omitempty"`
 	HostPort      uint16 `json:"HostPort,omitempty"`
+	HostIp        string `json:"HostIp,omitempty"`
 }
 
 // NewTaskResponse creates a TaskResponse for a task.

--- a/agent/handlers/v2/response.go
+++ b/agent/handlers/v2/response.go
@@ -281,6 +281,9 @@ func NewContainerResponse(
 		} else {
 			port.HostPort = port.ContainerPort
 		}
+		if includeV4Metadata {
+			port.HostIp = binding.BindIP
+		}
 
 		resp.Ports = append(resp.Ports, port)
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Currently there is no way to identify ipv4 ports vs ipv6 ports from Task metadata endpoint v4. This PR includes changes to add Host IP to port response for Task metadata endpoint v4

Related to issue - https://github.com/aws/amazon-ecs-agent/issues/3096
### Implementation details
<!-- How are the changes implemented? -->
- `agent/handlers/v1/response.go` : updated PortResponse struct to include HostIp field.
- `agent/handlers/v2/response.go` : added HostIp to container response if `includeV4Metadata` flag is set
-  `agent/handlers/v2/response_test.go`:  updated TestContainerResponseMarshal() test to check if containerResponse for  includes  HostIp when `includeV4Metadata` is set

### Testing
<!-- How was this tested? -->
Tested this change by running a task with container port mappings configured on a IPv6 enabled instance and see the following response for `curl ${ECS_CONTAINER_METADATA_URI_V4:-}/task | jq `
```
{
  "Cluster": "default",
  ...
  "Containers": [
    {
      "DockerId": "502ec633cc68f7e7ebdc00ae9b0c1f7ef730a0a9b3dc747107e5cfd91a42fb11",
      "Name": "server",
      "DockerName": "ecs-nginx-server-3-server-84f9f8dbe4879a8e8801",
      "Image": "nginx:latest",
      "ImageID": "sha256:c316d5a335a5cf324b0dc83b3da82d7608724769f6454f6d9a621f3ec2534a5a",
      "Ports": [
        {
          "ContainerPort": 8888,
          "Protocol": "tcp",
          "HostPort": 49825,
          "HostIp": "0.0.0.0"
        },
        {
          "ContainerPort": 8888,
          "Protocol": "tcp",
          "HostPort": 49825,
          "HostIp": "::"
        },
        {
          "ContainerPort": 8888,
          "Protocol": "tcp",
          "HostPort": 49832,
          "HostIp": "0.0.0.0"
        },
        {
          "ContainerPort": 8888,
          "Protocol": "tcp",
          "HostPort": 49832,
          "HostIp": "::"
        }
      ],
      ...
}
```

Container response with v2 ` curl  ${ECS_CONTAINER_METADATA_URI:-}/task | jq`
```
{
  "Cluster": "default",
   ...
  "Containers": [
    {
      "DockerId": "502ec633cc68f7e7ebdc00ae9b0c1f7ef730a0a9b3dc747107e5cfd91a42fb11",
      "Name": "server",
      "DockerName": "ecs-nginx-server-3-server-84f9f8dbe4879a8e8801",
      "Image": "nginx:latest",
      "ImageID": "sha256:c316d5a335a5cf324b0dc83b3da82d7608724769f6454f6d9a621f3ec2534a5a",
      "Ports": [
        {
          "ContainerPort": 8888,
          "Protocol": "tcp",
          "HostPort": 49825
        },
        {
          "ContainerPort": 8888,
          "Protocol": "tcp",
          "HostPort": 49825
        },
        {
          "ContainerPort": 8888,
          "Protocol": "tcp",
          "HostPort": 49832
        },
        {
          "ContainerPort": 8888,
          "Protocol": "tcp",
          "HostPort": 49832
        }
      ],
...
}
``` 
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
