### PR TITLE
Apply minimumCPUShare to both task and container CPU shares

### DIFF
--- a/agent/api/task/task_linux.go
+++ b/agent/api/task/task_linux.go
@@ -148,16 +148,11 @@ func (task *Task) buildImplicitLinuxCPUSpec() specs.LinuxCPU {
 	// aggregate container CPU shares when present
 	var taskCPUShares uint64
 	for _, container := range task.Containers {
-		if container.CPU > 0 {
+		if container.CPU < minimumCPUShare {
+			taskCPUShares += minimumCPUShare
+		} else {
 			taskCPUShares += uint64(container.CPU)
 		}
-	}
-
-	// If there are are no CPU limits at task or container level,
-	// default task CPU shares
-	if taskCPUShares == 0 {
-		// Set default CPU shares
-		taskCPUShares = minimumCPUShare
 	}
 
 	return specs.LinuxCPU{

--- a/agent/api/task/task_linux_test.go
+++ b/agent/api/task/task_linux_test.go
@@ -342,6 +342,31 @@ func TestBuildLinuxResourceSpecWithoutTaskCPUWithContainerCPULimits(t *testing.T
 	assert.EqualValues(t, expectedLinuxResourceSpec, linuxResourceSpec)
 }
 
+// TestBuildLinuxResourceSpecWithoutTaskCPUWithLessThanMinimumContainerCPULimits validates behavior of CPU Shares
+// when container CPU share is 1 (less than the current minimumCPUShare which is 2)
+func TestBuildLinuxResourceSpecWithoutTaskCPUWithLessThanMinimumContainerCPULimits(t *testing.T) {
+	task := &Task{
+		Arn: validTaskArn,
+		Containers: []*apicontainer.Container{
+			{
+				Name: "C1",
+				CPU:  uint(1),
+			},
+		},
+	}
+	expectedCPUShares := uint64(2)
+	expectedLinuxResourceSpec := specs.LinuxResources{
+		CPU: &specs.LinuxCPU{
+			Shares: &expectedCPUShares,
+		},
+	}
+
+	linuxResourceSpec, err := task.BuildLinuxResourceSpec(defaultCPUPeriod)
+
+	assert.NoError(t, err)
+	assert.EqualValues(t, expectedLinuxResourceSpec, linuxResourceSpec)
+}
+
 // TestBuildLinuxResourceSpecInvalidMem validates the linux resource spec builder
 func TestBuildLinuxResourceSpecInvalidMem(t *testing.T) {
 	taskMemoryLimit := int64(taskMemoryLimit)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
`taskCPUShares` is used when creating task cgroup spec. We have a `minimumCPUShare` (equals 2) but it currently applies to [container CPU shares](https://github.com/aws/amazon-ecs-agent/blob/6f6e351b3b266984e257a88042f73ef4b9469d6b/agent/api/task/task_unsupported.go#L53) only (more context under `cpu` section of the API [doc](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ContainerDefinition.html)). 

This value should be applicable to task CPU share as well for the following reasons:
1. We sum up container CPU shares and add that to task CPU share. Because a task must have at least one container, and the container CPU share will be >= 2, then task CPU share should naturally be >= 2.
2. Cgroupv2 requires CPU share to be >= 2 due to this [conversion](https://github.com/aws/amazon-ecs-agent/blob/6f6e351b3b266984e257a88042f73ef4b9469d6b/agent/api/task/task_unsupported.go#L53) from CPU shares to CPU weight. This is where the conversion happens in the `containerd/cgroups` [library](https://github.com/containerd/cgroups/blob/d5e6fc31636bab60490f78e24e36d79eb50cbd69/v2/utils.go#L171-L174) that we use.

### Implementation details
<!-- How are the changes implemented? -->
When add each container CPU share to task CPU share, use `minimumCPUShare` if container CPU share is less than that. 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: unit test

Additional manual testing: applied this commit to the [cgroupv2 branch](https://github.com/aws/amazon-ecs-agent/pull/3127), started Agent on an AL2022 instance where cgroupv2 is enabled, and verified that task with container cpu share equals 1 can be started. 

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Apply minimumCPUShare to both task and container CPU shares

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
