### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/agent/acs/handler/attach_eni_handler_common_test.go
+++ b/agent/acs/handler/attach_eni_handler_common_test.go
@@ -46,8 +46,7 @@ func testENIAckTimeout(t *testing.T, attachmentType string) {
 	defer ctrl.Finish()
 
 	taskEngineState := dockerstate.NewTaskEngineState()
-	dataClient, cleanup := newTestDataClient(t)
-	defer cleanup()
+	dataClient := newTestDataClient(t)
 
 	expiresAt := time.Now().Add(time.Millisecond * waitTimeoutMillis)
 	err := addENIAttachmentToState(attachmentType, attachmentArn, taskArn, randomMAC, expiresAt, taskEngineState, dataClient)
@@ -110,8 +109,7 @@ func testHandleENIAttachment(t *testing.T, attachmentType, taskArn string) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	dataClient, cleanup := newTestDataClient(t)
-	defer cleanup()
+	dataClient := newTestDataClient(t)
 
 	taskEngineState := dockerstate.NewTaskEngineState()
 	expiresAt := time.Now().Add(time.Millisecond * waitTimeoutMillis)

--- a/agent/acs/handler/task_manifest_handler_test.go
+++ b/agent/acs/handler/task_manifest_handler_test.go
@@ -50,8 +50,7 @@ func TestManifestHandlerKillAllTasks(t *testing.T) {
 	ctx := context.TODO()
 	mockWSClient := mock_wsclient.NewMockClientServer(ctrl)
 
-	dataClient, cleanup := newTestDataClient(t)
-	defer cleanup()
+	dataClient := newTestDataClient(t)
 
 	newTaskManifest := newTaskManifestHandler(ctx, cluster, containerInstanceArn, mockWSClient,
 		dataClient, taskEngine, aws.Int64(11))
@@ -145,8 +144,7 @@ func TestManifestHandlerKillFewTasks(t *testing.T) {
 	ctx := context.TODO()
 	mockWSClient := mock_wsclient.NewMockClientServer(ctrl)
 
-	dataClient, cleanup := newTestDataClient(t)
-	defer cleanup()
+	dataClient := newTestDataClient(t)
 
 	newTaskManifest := newTaskManifestHandler(ctx, cluster, containerInstanceArn, mockWSClient,
 		dataClient, taskEngine, aws.Int64(11))
@@ -249,8 +247,7 @@ func TestManifestHandlerKillNoTasks(t *testing.T) {
 	ctx := context.TODO()
 	mockWSClient := mock_wsclient.NewMockClientServer(ctrl)
 
-	dataClient, cleanup := newTestDataClient(t)
-	defer cleanup()
+	dataClient := newTestDataClient(t)
 
 	newTaskManifest := newTaskManifestHandler(ctx, cluster, containerInstanceArn, mockWSClient,
 		dataClient, taskEngine, aws.Int64(11))
@@ -339,8 +336,7 @@ func TestManifestHandlerDifferentTaskLists(t *testing.T) {
 	ctx := context.TODO()
 	mockWSClient := mock_wsclient.NewMockClientServer(ctrl)
 
-	dataClient, cleanup := newTestDataClient(t)
-	defer cleanup()
+	dataClient := newTestDataClient(t)
 
 	newTaskManifest := newTaskManifestHandler(ctx, cluster, containerInstanceArn, mockWSClient,
 		dataClient, taskEngine, aws.Int64(11))
@@ -433,8 +429,7 @@ func TestManifestHandlerDifferentTaskLists(t *testing.T) {
 }
 
 func TestManifestHandlerSequenceNumbers(t *testing.T) {
-	dataClient, cleanup := newTestDataClient(t)
-	defer cleanup()
+	dataClient := newTestDataClient(t)
 
 	testcases := []struct {
 		name                string

--- a/agent/app/agent_capability_test.go
+++ b/agent/app/agent_capability_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -40,10 +39,6 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-)
-
-const (
-	testTempDirPrefix = "agent-capability-test-"
 )
 
 func init() {
@@ -1279,20 +1274,17 @@ func TestCapabilitiesNoServiceConnect(t *testing.T) {
 }
 
 func TestDefaultGetSubDirectories(t *testing.T) {
-	rootDir, err := ioutil.TempDir(os.TempDir(), testTempDirPrefix)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(rootDir)
+	rootDir := t.TempDir()
 
 	subDir, err := ioutil.TempDir(rootDir, "dir")
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = ioutil.TempFile(rootDir, "file")
+	file, err := ioutil.TempFile(rootDir, "file")
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer require.NoError(t, file.Close())
 	notExistingPath := filepath.Join(rootDir, "not-existing")
 
 	testCases := []struct {
@@ -1331,16 +1323,13 @@ func TestDefaultGetSubDirectories(t *testing.T) {
 }
 
 func TestDefaultPathExistsd(t *testing.T) {
-	rootDir, err := ioutil.TempDir(os.TempDir(), testTempDirPrefix)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(rootDir)
+	rootDir := t.TempDir()
 
 	file, err := ioutil.TempFile(rootDir, "file")
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer require.NoError(t, file.Close())
 	notExistingPath := filepath.Join(rootDir, "not-existing")
 	testCases := []struct {
 		name              string

--- a/agent/app/agent_compatibility_linux_test.go
+++ b/agent/app/agent_compatibility_linux_test.go
@@ -80,8 +80,7 @@ func TestCompatibilityNotSetFail(t *testing.T) {
 	cfg.Checkpoint = config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled}
 	cfg.TaskCPUMemLimit = config.BooleanDefaultTrue{Value: config.NotSet}
 
-	dataClient, cleanup := newTestDataClient(t)
-	defer cleanup()
+	dataClient := newTestDataClient(t)
 	populateBoltDB(dataClient, t)
 
 	// Put a bad task in previously saved state.
@@ -121,8 +120,7 @@ func TestCompatibilityExplicitlyEnabledFail(t *testing.T) {
 	cfg.Checkpoint = config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled}
 	cfg.TaskCPUMemLimit = config.BooleanDefaultTrue{Value: config.ExplicitlyEnabled}
 
-	dataClient, cleanup := newTestDataClient(t)
-	defer cleanup()
+	dataClient := newTestDataClient(t)
 	populateBoltDB(dataClient, t)
 
 	// Put a bad task in previously saved state.

--- a/agent/data/client_test.go
+++ b/agent/data/client_test.go
@@ -17,8 +17,6 @@
 package data
 
 import (
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -26,9 +24,8 @@ import (
 	bolt "go.etcd.io/bbolt"
 )
 
-func newTestClient(t *testing.T) (Client, func()) {
-	testDir, err := ioutil.TempDir("", "agent_data_unit_test")
-	require.NoError(t, err)
+func newTestClient(t *testing.T) Client {
+	testDir := t.TempDir()
 
 	testDB, err := bolt.Open(filepath.Join(testDir, dbName), dbMode, nil)
 	require.NoError(t, err)
@@ -46,9 +43,8 @@ func newTestClient(t *testing.T) (Client, func()) {
 		db: testDB,
 	}
 
-	cleanup := func() {
+	t.Cleanup(func() {
 		require.NoError(t, testClient.Close())
-		require.NoError(t, os.RemoveAll(testDir))
-	}
-	return testClient, cleanup
+	})
+	return testClient
 }

--- a/agent/data/container_client_test.go
+++ b/agent/data/container_client_test.go
@@ -34,8 +34,7 @@ const (
 )
 
 func TestManageContainers(t *testing.T) {
-	testClient, cleanup := newTestClient(t)
-	defer cleanup()
+	testClient := newTestClient(t)
 
 	// Test saving a container with SaveDockerContainer and updating it with SaveContainer.
 	testDockerContainer := &apicontainer.DockerContainer{
@@ -75,8 +74,7 @@ func TestManageContainers(t *testing.T) {
 }
 
 func TestSaveContainerInvalidID(t *testing.T) {
-	testClient, cleanup := newTestClient(t)
-	defer cleanup()
+	testClient := newTestClient(t)
 
 	testDockerContainer := &apicontainer.DockerContainer{
 		DockerID:   testDockerID,

--- a/agent/data/eniattachment_client_test.go
+++ b/agent/data/eniattachment_client_test.go
@@ -30,8 +30,7 @@ const (
 )
 
 func TestManageENIAttachments(t *testing.T) {
-	testClient, cleanup := newTestClient(t)
-	defer cleanup()
+	testClient := newTestClient(t)
 
 	testEniAttachment := &eni.ENIAttachment{
 		AttachmentARN:    testAttachmentArn,
@@ -65,8 +64,7 @@ func TestManageENIAttachments(t *testing.T) {
 }
 
 func TestSaveENIAttachmentInvalidID(t *testing.T) {
-	testClient, cleanup := newTestClient(t)
-	defer cleanup()
+	testClient := newTestClient(t)
 
 	testEniAttachment := &eni.ENIAttachment{
 		AttachmentARN:    "invalid-arn",

--- a/agent/data/helpers_test.go
+++ b/agent/data/helpers_test.go
@@ -18,8 +18,6 @@ package data
 
 import (
 	"encoding/json"
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -37,9 +35,8 @@ type testObjType struct {
 	Val string
 }
 
-func setupHelpersTest(t *testing.T) (*bolt.DB, func()) {
-	testDir, err := ioutil.TempDir("", "agent_data_unit_test")
-	require.NoError(t, err)
+func setupHelpersTest(t *testing.T) *bolt.DB {
+	testDir := t.TempDir()
 	db, err := bolt.Open(filepath.Join(testDir, dbName), dbMode, nil)
 	require.NoError(t, err)
 	require.NoError(t, db.Update(func(tx *bolt.Tx) error {
@@ -47,15 +44,15 @@ func setupHelpersTest(t *testing.T) (*bolt.DB, func()) {
 		return err
 	}))
 
-	return db, func() {
+	t.Cleanup(func() {
 		require.NoError(t, db.Close())
-		require.NoError(t, os.RemoveAll(testDir))
-	}
+	})
+
+	return db
 }
 
 func TestHelpers(t *testing.T) {
-	db, cleanup := setupHelpersTest(t)
-	defer cleanup()
+	db := setupHelpersTest(t)
 
 	testObj := &testObjType{
 		Key: "key",

--- a/agent/data/imagestate_client_test.go
+++ b/agent/data/imagestate_client_test.go
@@ -32,8 +32,7 @@ const (
 )
 
 func TestManageImageStates(t *testing.T) {
-	testClient, cleanup := newTestClient(t)
-	defer cleanup()
+	testClient := newTestClient(t)
 
 	testImageState := &image.ImageState{
 		Image: &image.Image{

--- a/agent/data/metadata_client_test.go
+++ b/agent/data/metadata_client_test.go
@@ -29,8 +29,7 @@ const (
 )
 
 func TestManageMetadata(t *testing.T) {
-	testClient, cleanup := newTestClient(t)
-	defer cleanup()
+	testClient := newTestClient(t)
 
 	require.NoError(t, testClient.SaveMetadata(testKey, testVal))
 

--- a/agent/data/task_client_test.go
+++ b/agent/data/task_client_test.go
@@ -30,8 +30,8 @@ const (
 )
 
 func TestManageTask(t *testing.T) {
-	testClient, cleanup := newTestClient(t)
-	defer cleanup()
+	testClient := newTestClient(t)
+
 	testTask := &apitask.Task{
 		Arn: testTaskArn,
 	}
@@ -48,8 +48,7 @@ func TestManageTask(t *testing.T) {
 }
 
 func TestSaveTaskInvalidID(t *testing.T) {
-	testClient, cleanup := newTestClient(t)
-	defer cleanup()
+	testClient := newTestClient(t)
 
 	testTask := &apitask.Task{
 		Arn: "invalid-arn",

--- a/agent/engine/common_integ_test.go
+++ b/agent/engine/common_integ_test.go
@@ -19,12 +19,9 @@ package engine
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/require"
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
@@ -74,8 +71,7 @@ func createTestTask(arn string) *apitask.Task {
 
 func setupIntegTestLogs(t *testing.T) string {
 	// Create a directory for storing test logs.
-	testLogDir, err := ioutil.TempDir("", "ecs-integ-test")
-	require.NoError(t, err, "Unable to create directory for storing test logs")
+	testLogDir := t.TempDir()
 
 	logger, err := log.LoggerFromConfigAsString(loggerConfigIntegrationTest(testLogDir))
 	assert.NoError(t, err, "initialisation failed")

--- a/agent/engine/data_test.go
+++ b/agent/engine/data_test.go
@@ -17,8 +17,6 @@
 package engine
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
@@ -85,22 +83,20 @@ var (
 	}
 )
 
-func newTestDataClient(t *testing.T) (data.Client, func()) {
-	testDir, err := ioutil.TempDir("", "agent_engine_unit_test")
-	require.NoError(t, err)
+func newTestDataClient(t *testing.T) data.Client {
+	testDir := t.TempDir()
 
 	testClient, err := data.NewWithSetup(testDir)
+	require.NoError(t, err)
 
-	cleanup := func() {
+	t.Cleanup(func() {
 		require.NoError(t, testClient.Close())
-		require.NoError(t, os.RemoveAll(testDir))
-	}
-	return testClient, cleanup
+	})
+	return testClient
 }
 
 func TestLoadState(t *testing.T) {
-	dataClient, cleanup := newTestDataClient(t)
-	defer cleanup()
+	dataClient := newTestDataClient(t)
 
 	engine := &DockerTaskEngine{
 		state:      dockerstate.NewTaskEngineState(),
@@ -137,8 +133,7 @@ func TestLoadState(t *testing.T) {
 }
 
 func TestSaveState(t *testing.T) {
-	dataClient, cleanup := newTestDataClient(t)
-	defer cleanup()
+	dataClient := newTestDataClient(t)
 
 	engine := &DockerTaskEngine{
 		state:      dockerstate.NewTaskEngineState(),
@@ -168,8 +163,7 @@ func TestSaveState(t *testing.T) {
 }
 
 func TestSaveStateEnsureBoltDBCompatibility(t *testing.T) {
-	dataClient, cleanup := newTestDataClient(t)
-	defer cleanup()
+	dataClient := newTestDataClient(t)
 
 	engine := &DockerTaskEngine{
 		state:      dockerstate.NewTaskEngineState(),
@@ -206,8 +200,7 @@ func TestSaveStateEnsureBoltDBCompatibility(t *testing.T) {
 }
 
 func TestSaveAndRemoveTaskData(t *testing.T) {
-	dataClient, cleanup := newTestDataClient(t)
-	defer cleanup()
+	dataClient := newTestDataClient(t)
 
 	engine := &DockerTaskEngine{
 		dataClient: dataClient,
@@ -224,8 +217,7 @@ func TestSaveAndRemoveTaskData(t *testing.T) {
 }
 
 func TestSaveContainerData(t *testing.T) {
-	dataClient, cleanup := newTestDataClient(t)
-	defer cleanup()
+	dataClient := newTestDataClient(t)
 
 	engine := &DockerTaskEngine{
 		dataClient: dataClient,
@@ -237,8 +229,7 @@ func TestSaveContainerData(t *testing.T) {
 }
 
 func TestSaveDockerContainerData(t *testing.T) {
-	dataClient, cleanup := newTestDataClient(t)
-	defer cleanup()
+	dataClient := newTestDataClient(t)
 
 	engine := &DockerTaskEngine{
 		dataClient: dataClient,
@@ -253,8 +244,7 @@ func TestSaveDockerContainerData(t *testing.T) {
 }
 
 func TestSaveAndRemoveImageStateData(t *testing.T) {
-	dataClient, cleanup := newTestDataClient(t)
-	defer cleanup()
+	dataClient := newTestDataClient(t)
 
 	imageManager := &dockerImageManager{
 		dataClient: dataClient,
@@ -271,8 +261,7 @@ func TestSaveAndRemoveImageStateData(t *testing.T) {
 }
 
 func TestRemoveENIAttachmentData(t *testing.T) {
-	dataClient, cleanup := newTestDataClient(t)
-	defer cleanup()
+	dataClient := newTestDataClient(t)
 
 	engine := &DockerTaskEngine{
 		state:      dockerstate.NewTaskEngineState(),

--- a/agent/engine/docker_image_manager_data_test.go
+++ b/agent/engine/docker_image_manager_data_test.go
@@ -48,8 +48,7 @@ var (
 )
 
 func TestAddImageStateSaveData(t *testing.T) {
-	dataClient, cleanup := newTestDataClient(t)
-	defer cleanup()
+	dataClient := newTestDataClient(t)
 
 	imageManager := &dockerImageManager{
 		dataClient: dataClient,
@@ -62,8 +61,7 @@ func TestAddImageStateSaveData(t *testing.T) {
 }
 
 func TestAddContainerReferenceToNewImageStateSaveData(t *testing.T) {
-	dataClient, cleanup := newTestDataClient(t)
-	defer cleanup()
+	dataClient := newTestDataClient(t)
 
 	imageManager := &dockerImageManager{
 		dataClient: dataClient,
@@ -76,8 +74,7 @@ func TestAddContainerReferenceToNewImageStateSaveData(t *testing.T) {
 }
 
 func TestAddContainerReferenceToExistingImageStateSaveData(t *testing.T) {
-	dataClient, cleanup := newTestDataClient(t)
-	defer cleanup()
+	dataClient := newTestDataClient(t)
 
 	imageManager := &dockerImageManager{
 		dataClient: dataClient,
@@ -90,8 +87,7 @@ func TestAddContainerReferenceToExistingImageStateSaveData(t *testing.T) {
 }
 
 func TestRemoveExistingImageNameOfDifferentID(t *testing.T) {
-	dataClient, cleanup := newTestDataClient(t)
-	defer cleanup()
+	dataClient := newTestDataClient(t)
 
 	imageManager := &dockerImageManager{
 		dataClient: dataClient,
@@ -110,8 +106,7 @@ func TestRemoveExistingImageNameOfDifferentID(t *testing.T) {
 }
 
 func TestRemoveImageStateSaveData(t *testing.T) {
-	dataClient, cleanup := newTestDataClient(t)
-	defer cleanup()
+	dataClient := newTestDataClient(t)
 
 	imageManager := &dockerImageManager{
 		dataClient: dataClient,

--- a/agent/engine/docker_task_engine_linux_test.go
+++ b/agent/engine/docker_task_engine_linux_test.go
@@ -154,8 +154,7 @@ func TestDeleteTask(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	dataClient, cleanup := newTestDataClient(t)
-	defer cleanup()
+	dataClient := newTestDataClient(t)
 
 	mockControl := mock_control.NewMockControl(ctrl)
 	cgroupResource := cgroup.NewCgroupResource("", mockControl, nil, "cgroupRoot", "", specs.LinuxResources{})

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -606,8 +606,7 @@ func TestCreateContainerSaveDockerIDAndName(t *testing.T) {
 	defer cancel()
 	ctrl, client, _, privateTaskEngine, _, _, _, _ := mocks(t, ctx, &defaultConfig)
 	defer ctrl.Finish()
-	dataClient, cleanup := newTestDataClient(t)
-	defer cleanup()
+	dataClient := newTestDataClient(t)
 
 	taskEngine, _ := privateTaskEngine.(*DockerTaskEngine)
 	taskEngine.SetDataClient(dataClient)
@@ -984,8 +983,7 @@ func TestProvisionContainerResourcesAwsvpcSetPausePIDInVolumeResources(t *testin
 	ctrl, dockerClient, _, taskEngine, _, _, _, _ := mocks(t, ctx, &defaultConfig)
 	defer ctrl.Finish()
 
-	dataClient, cleanup := newTestDataClient(t)
-	defer cleanup()
+	dataClient := newTestDataClient(t)
 	taskEngine.SetDataClient(dataClient)
 
 	mockNamespaceHelper := mock_ecscni.NewMockNamespaceHelper(ctrl)
@@ -2504,8 +2502,7 @@ func TestSynchronizeENIAttachmentRemoveData(t *testing.T) {
 	ctrl, client, _, taskEngine, _, _, _, _ := mocks(t, ctx, &defaultConfig)
 	defer ctrl.Finish()
 
-	dataClient, cleanup := newTestDataClient(t)
-	defer cleanup()
+	dataClient := newTestDataClient(t)
 
 	client.EXPECT().ContainerEvents(gomock.Any()).MaxTimes(1)
 

--- a/agent/engine/docker_task_engine_windows_test.go
+++ b/agent/engine/docker_task_engine_windows_test.go
@@ -54,8 +54,7 @@ func TestDeleteTask(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	dataClient, cleanup := newTestDataClient(t)
-	defer cleanup()
+	dataClient := newTestDataClient(t)
 
 	task := &apitask.Task{
 		Arn: testTaskARN,

--- a/agent/engine/engine_integ_test.go
+++ b/agent/engine/engine_integ_test.go
@@ -197,8 +197,7 @@ func TestHostVolumeMount(t *testing.T) {
 	taskEngine, done, _ := setupWithDefaultConfig(t)
 	defer done()
 
-	tmpPath, _ := ioutil.TempDir("", "ecs_volume_test")
-	defer os.RemoveAll(tmpPath)
+	tmpPath := t.TempDir()
 	ioutil.WriteFile(filepath.Join(tmpPath, "test-file"), []byte("test-data"), 0644)
 
 	testTask := createTestHostVolumeMountTask(tmpPath)
@@ -426,8 +425,7 @@ func TestSharedAutoprovisionVolume(t *testing.T) {
 	// Set the task clean up duration to speed up the test
 	taskEngine.(*DockerTaskEngine).cfg.TaskCleanupWaitDuration = 1 * time.Second
 
-	testTask, tmpDirectory, err := createVolumeTask("shared", "TestSharedAutoprovisionVolume", "TestSharedAutoprovisionVolume", true)
-	defer os.Remove(tmpDirectory)
+	testTask, err := createVolumeTask(t, "shared", "TestSharedAutoprovisionVolume", "TestSharedAutoprovisionVolume", true)
 	require.NoError(t, err, "creating test task failed")
 
 	go taskEngine.AddTask(testTask)
@@ -454,8 +452,7 @@ func TestSharedDoNotAutoprovisionVolume(t *testing.T) {
 	// Set the task clean up duration to speed up the test
 	taskEngine.(*DockerTaskEngine).cfg.TaskCleanupWaitDuration = 1 * time.Second
 
-	testTask, tmpDirectory, err := createVolumeTask("shared", "TestSharedDoNotAutoprovisionVolume", "TestSharedDoNotAutoprovisionVolume", false)
-	defer os.Remove(tmpDirectory)
+	testTask, err := createVolumeTask(t, "shared", "TestSharedDoNotAutoprovisionVolume", "TestSharedDoNotAutoprovisionVolume", false)
 	require.NoError(t, err, "creating test task failed")
 
 	// creating volume to simulate previously provisioned volume

--- a/agent/engine/task_manager_data_test.go
+++ b/agent/engine/task_manager_data_test.go
@@ -74,8 +74,7 @@ func TestHandleDesiredStatusChangeSaveData(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			dataClient, cleanup := newTestDataClient(t)
-			defer cleanup()
+			dataClient := newTestDataClient(t)
 
 			mtask := managedTask{
 				Task: &apitask.Task{
@@ -144,8 +143,7 @@ func TestHandleContainerStateChangeSaveData(t *testing.T) {
 			containerChangeEventStream := eventstream.NewEventStream(eventStreamName, ctx)
 			containerChangeEventStream.StartListening()
 
-			dataClient, cleanup := newTestDataClient(t)
-			defer cleanup()
+			dataClient := newTestDataClient(t)
 
 			mTask := managedTask{
 				Task: &apitask.Task{
@@ -198,8 +196,7 @@ func TestHandleContainerChangeWithTaskStateChangeSaveData(t *testing.T) {
 	containerChangeEventStream := eventstream.NewEventStream(eventStreamName, ctx)
 	containerChangeEventStream.StartListening()
 
-	dataClient, cleanup := newTestDataClient(t)
-	defer cleanup()
+	dataClient := newTestDataClient(t)
 
 	mTask := managedTask{
 		Task: &apitask.Task{
@@ -266,8 +263,7 @@ func TestHandleResourceStateChangeSaveData(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			dataClient, cleanup := newTestDataClient(t)
-			defer cleanup()
+			dataClient := newTestDataClient(t)
 
 			res := &volume.VolumeResource{Name: dataTestVolumeName}
 			res.SetKnownStatus(tc.knownState)

--- a/agent/eventhandler/attachment_handler_test.go
+++ b/agent/eventhandler/attachment_handler_test.go
@@ -86,8 +86,7 @@ func TestSendAttachmentEventRetries(t *testing.T) {
 	}
 	assert.NoError(t, attachmentEvent.Attachment.StartTimer(timeoutFunc))
 
-	dataClient, cleanup := newTestDataClient(t)
-	defer cleanup()
+	dataClient := newTestDataClient(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	handler := NewAttachmentEventHandler(ctx, dataClient, client)
 	// use smaller backoff value for unit test
@@ -163,8 +162,7 @@ func TestSubmitAttachmentEventSucceeds(t *testing.T) {
 	defer ctrl.Finish()
 	client := mock_api.NewMockECSClient(ctrl)
 
-	dataClient, cleanup := newTestDataClient(t)
-	defer cleanup()
+	dataClient := newTestDataClient(t)
 
 	attachmentEvent := attachmentEvent(attachmentARN)
 

--- a/agent/eventhandler/task_handler_types_test.go
+++ b/agent/eventhandler/task_handler_types_test.go
@@ -18,8 +18,6 @@ package eventhandler
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
 	"testing"
 	"time"
 
@@ -343,8 +341,7 @@ func TestShouldTaskAttachmentEventBeSent(t *testing.T) {
 }
 
 func TestSetTaskSentStatus(t *testing.T) {
-	dataClient, cleanup := newTestDataClient(t)
-	defer cleanup()
+	dataClient := newTestDataClient(t)
 
 	testManagedAgent := apicontainer.ManagedAgent{
 		ManagedAgentState: apicontainer.ManagedAgentState{},
@@ -425,8 +422,7 @@ func TestSetTaskSentStatus(t *testing.T) {
 }
 
 func TestSetContainerSentStatus(t *testing.T) {
-	dataClient, cleanup := newTestDataClient(t)
-	defer cleanup()
+	dataClient := newTestDataClient(t)
 
 	testContainer := &apicontainer.Container{
 		Name:          testConainerName,
@@ -454,8 +450,7 @@ func TestSetContainerSentStatus(t *testing.T) {
 }
 
 func TestSetAttachmentSentStatus(t *testing.T) {
-	dataClient, cleanup := newTestDataClient(t)
-	defer cleanup()
+	dataClient := newTestDataClient(t)
 
 	testAttachment := &apieni.ENIAttachment{
 		AttachStatusSent: true,
@@ -474,15 +469,14 @@ func TestSetAttachmentSentStatus(t *testing.T) {
 	assert.True(t, atts[0].IsSent())
 }
 
-func newTestDataClient(t *testing.T) (data.Client, func()) {
-	testDir, err := ioutil.TempDir("", "agent_eventhandler_unit_test")
-	require.NoError(t, err)
+func newTestDataClient(t *testing.T) data.Client {
+	testDir := t.TempDir()
 
 	testClient, err := data.NewWithSetup(testDir)
+	require.NoError(t, err)
 
-	cleanup := func() {
+	t.Cleanup(func() {
 		require.NoError(t, testClient.Close())
-		require.NoError(t, os.RemoveAll(testDir))
-	}
-	return testClient, cleanup
+	})
+	return testClient
 }

--- a/agent/sighandlers/termination_handler_test.go
+++ b/agent/sighandlers/termination_handler_test.go
@@ -17,8 +17,6 @@
 package sighandlers
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
@@ -41,8 +39,7 @@ var (
 )
 
 func TestFinalSave(t *testing.T) {
-	dataClient, cleanup := newTestDataClient(t)
-	defer cleanup()
+	dataClient := newTestDataClient(t)
 
 	state := dockerstate.NewTaskEngineState()
 	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil,
@@ -100,15 +97,14 @@ func TestFinalSave(t *testing.T) {
 	assert.Len(t, imageStates, 1)
 }
 
-func newTestDataClient(t *testing.T) (data.Client, func()) {
-	testDir, err := ioutil.TempDir("", "termination_handler_unit_test")
-	require.NoError(t, err)
+func newTestDataClient(t *testing.T) data.Client {
+	testDir := t.TempDir()
 
 	testClient, err := data.NewWithSetup(testDir)
+	require.NoError(t, err)
 
-	cleanup := func() {
+	t.Cleanup(func() {
 		require.NoError(t, testClient.Close())
-		require.NoError(t, os.RemoveAll(testDir))
-	}
-	return testClient, cleanup
+	})
+	return testClient
 }

--- a/agent/statemanager/state_manager_unix_test.go
+++ b/agent/statemanager/state_manager_unix_test.go
@@ -16,7 +16,6 @@
 package statemanager_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -35,9 +34,7 @@ import (
 )
 
 func TestStateManager(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("/tmp", "ecs_statemanager_test")
-	assert.Nil(t, err)
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 	cfg := &config.Config{DataDir: tmpDir}
 	manager, err := statemanager.NewStateManager(cfg)
 	assert.Nil(t, err, "Error loading manager")

--- a/ecs-init/docker/docker_test.go
+++ b/ecs-init/docker/docker_test.go
@@ -33,8 +33,6 @@ import (
 // Note: Change this value every time when a new bind mount is added to
 // agent for the tests to pass
 const (
-	testTempDirPrefix = "init-docker-test-"
-
 	expectedAgentBindsUnspecifiedPlatform = 20
 	expectedAgentBindsSuseUbuntuPlatform  = 18
 )
@@ -924,16 +922,15 @@ func TestGetCapabilityExecBinds(t *testing.T) {
 }
 
 func TestDefaultIsPathValid(t *testing.T) {
-	rootDir, err := os.MkdirTemp(os.TempDir(), testTempDirPrefix)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(rootDir)
+	rootDir := t.TempDir()
 
 	file, err := os.CreateTemp(rootDir, "file")
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() {
+		assert.NoError(t, file.Close())
+	})
 	notExistingPath := filepath.Join(rootDir, "not-existing")
 	testCases := []struct {
 		name              string


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

A testing cleanup. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

This PR also refactor several cleanup logic by using `t.Cleanup` instead of `defer`.

Reference: https://pkg.go.dev/testing#T.TempDir
Reference: https://pkg.go.dev/testing#T.Cleanup

### Implementation details
<!-- How are the changes implemented? -->

- Replaces `ioutil.TempDir` with `t.TempDir`
- Setup function such as `newTestDataClient(t *testing.T)` no longer returns a `cleanup func()`. It now uses `t.Cleanup` to handle the cleanup when the test finishes.

### Testing
`make test` and `make run-integ-tests` on Linux machine.

<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Enhancement - Use `T.TempDir` to create temporary test directory

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
