### PR TITLE
specfile and script updates for integrated init/agent build

### DIFF
--- a/agent-container/agent-manifest.json
+++ b/agent-container/agent-manifest.json
@@ -1,1 +1,1 @@
-[{"Config":"config.json","RepoTags":["amazon/amazon-ecs-agent:~~agentversion~~"],"Layers":["rootfs/layer.tar"]}]
+[{"Config":"config.json","RepoTags":["amazon/amazon-ecs-agent:~~agentversion~~", "amazon/amazon-ecs-agent:latest"],"Layers":["rootfs/layer.tar"]}]

--- a/packaging/amazon-linux-ami-integrated/amazon-ecs-volume-plugin.conf
+++ b/packaging/amazon-linux-ami-integrated/amazon-ecs-volume-plugin.conf
@@ -1,0 +1,22 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the
+# "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+
+description "Amazon Elastic Container Service Volume Plugin"
+author "Amazon Web Services"
+start on stopped rc RUNLEVEL=[345]
+
+respawn
+respawn limit 10 15
+
+exec /usr/libexec/amazon-ecs-volume-plugin

--- a/packaging/amazon-linux-ami-integrated/amazon-ecs-volume-plugin.service
+++ b/packaging/amazon-linux-ami-integrated/amazon-ecs-volume-plugin.service
@@ -1,0 +1,27 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the
+# "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License
+
+[Unit]
+Description=Amazon Elastic Container Service Volume Plugin
+After=network.target amazon-ecs-volume-plugin.socket
+Requires=amazon-ecs-volume-plugin.socket
+
+[Service]
+Type=simple
+Restart=on-failure
+RestartSec=10s
+ExecStart=/usr/libexec/amazon-ecs-volume-plugin
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/amazon-linux-ami-integrated/amazon-ecs-volume-plugin.socket
+++ b/packaging/amazon-linux-ami-integrated/amazon-ecs-volume-plugin.socket
@@ -1,0 +1,23 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the
+# "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License
+
+[Unit]
+Description=Amazon Elastic Container Service Volume Plugin
+PartOf=amazon-ecs-volume-plugin.service
+
+[Socket]
+ListenStream=/var/run/docker/plugins/amazon-ecs-volume-plugin.sock
+
+[Install]
+WantedBy=sockets.target

--- a/packaging/amazon-linux-ami-integrated/ecs-init.spec
+++ b/packaging/amazon-linux-ami-integrated/ecs-init.spec
@@ -1,0 +1,167 @@
+# Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the
+# "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+
+%bcond_with systemd # without
+%global running_semaphore %{_localstatedir}/run/ecs-init.was-running
+
+%global _cachedir %{_localstatedir}/cache
+%global no_exec_perm 644
+%global agent_image ecs-agent-v%{version}.tar
+
+Name:           ecs-init
+Version:        1.51.0
+Release:        1%{?dist}
+License:        Apache 2.0
+Summary:        Amazon Elastic Container Service initialization application
+# TODO: add back aarch64
+ExclusiveArch:  x86_64
+ 
+Source0:        sources-with-agent.tgz
+Source1:        ecs.conf
+Source2:        ecs.service
+Source3:        amazon-ecs-volume-plugin.service
+Source4:        amazon-ecs-volume-plugin.socket
+Source5:        amazon-ecs-volume-plugin.conf
+
+BuildRequires:  golang >= 1.7
+BuildRequires:  glibc-static
+%if %{with systemd}
+BuildRequires:  systemd
+Requires:       systemd
+%else
+Requires:       upstart
+%endif
+Requires:       iptables
+Requires:       docker >= 17.06.2ce
+Requires:       procps
+
+%description
+ecs-init supports the initialization and supervision of the Amazon ECS
+container agent, including configuration of cgroups, iptables, and
+required routes among its preparation steps.
+
+%prep
+%setup -c
+
+%build
+./scripts/build-pause
+./scripts/get-host-certs
+./scripts/build-cni-plugins
+./scripts/build true "" false true
+./scripts/build-agent-image
+./scripts/gobuild.sh
+
+%install
+install -D amazon-ecs-init %{buildroot}%{_libexecdir}/amazon-ecs-init
+install -D amazon-ecs-volume-plugin %{buildroot}%{_libexecdir}/amazon-ecs-volume-plugin
+install -m %{no_exec_perm} -D scripts/amazon-ecs-init.1 %{buildroot}%{_mandir}/man1/amazon-ecs-init.1
+
+mkdir -p %{buildroot}%{_sysconfdir}/ecs
+touch %{buildroot}%{_sysconfdir}/ecs/ecs.config
+touch %{buildroot}%{_sysconfdir}/ecs/ecs.config.json
+
+# Configure ecs-init to load the built ECS container agent image
+mkdir -p %{buildroot}%{_cachedir}/ecs
+echo 1 > %{buildroot}%{_cachedir}/ecs/state
+install -m %{no_exec_perm} %{agent_image} %{buildroot}%{_cachedir}/ecs/ecs-agent.tar
+
+mkdir -p %{buildroot}%{_sharedstatedir}/ecs/data
+
+%if %{with systemd}
+install -m %{no_exec_perm} -D %{SOURCE2} $RPM_BUILD_ROOT/%{_unitdir}/ecs.service
+install -m %{no_exec_perm} -D %{SOURCE3} $RPM_BUILD_ROOT/%{_unitdir}/amazon-ecs-volume-plugin.service
+install -m %{no_exec_perm} -D %{SOURCE4} $RPM_BUILD_ROOT/%{_unitdir}/amazon-ecs-volume-plugin.socket
+%else
+install -m %{no_exec_perm} -D %{SOURCE1} %{buildroot}%{_sysconfdir}/init/ecs.conf
+install -m %{no_exec_perm} -D %{SOURCE5} %{buildroot}%{_sysconfdir}/init/amazon-ecs-volume-plugin.conf
+%endif
+
+%files
+%{_libexecdir}/amazon-ecs-init
+%{_mandir}/man1/amazon-ecs-init.1*
+%{_libexecdir}/amazon-ecs-volume-plugin
+%config(noreplace) %ghost %{_sysconfdir}/ecs/ecs.config
+%config(noreplace) %ghost %{_sysconfdir}/ecs/ecs.config.json
+%{_cachedir}/ecs/ecs-agent.tar
+%{_cachedir}/ecs/state
+%dir %{_sharedstatedir}/ecs/data
+
+%if %{with systemd}
+%{_unitdir}/ecs.service
+%{_unitdir}/amazon-ecs-volume-plugin.service
+%{_unitdir}/amazon-ecs-volume-plugin.socket
+%else
+%{_sysconfdir}/init/ecs.conf
+%{_sysconfdir}/init/amazon-ecs-volume-plugin.conf
+%endif
+
+%post
+%if %{with systemd}
+%systemd_post ecs
+%systemd_post amazon-ecs-volume-plugin.service
+
+%postun
+%systemd_postun
+%systemd_postun_with_restart amazon-ecs-volume-plugin
+
+%else
+%triggerun -- docker
+# record whether or not our service was running when docker is upgraded
+ecs_status=$(/sbin/status ecs 2>/dev/null || :)
+if grep -qF "start/" <<< "${ecs_status}"; then
+	/sbin/stop ecs >/dev/null 2>&1 || :
+	if [ "$1" -ge 1 ]; then
+		# write semaphore if this package is still installed
+		touch %{running_semaphore} >/dev/null 2>&1 || :
+	fi
+fi
+
+%triggerpostun -- docker
+# ensures that ecs-init is restarted after docker or ecs-init is upgraded
+if [ "$1" -ge 1 ] && [ -e %{running_semaphore} ]; then
+	/sbin/start ecs >/dev/null 2>&1 || :
+	rm %{running_semaphore} >/dev/null 2>&1 ||:
+fi
+
+%postun
+# record whether or not our service was running when ecs-init is upgraded
+ecs_status=$(/sbin/status ecs 2>/dev/null || :)
+if grep -qF "start/" <<< "${ecs_status}"; then
+	/sbin/stop ecs >/dev/null 2>&1 || :
+	if [ "$1" -ge 1 ]; then
+		# write semaphore if this package is upgraded
+		touch %{running_semaphore} >/dev/null 2>&1 || :
+	fi
+fi
+# remove semaphore if this package is erased
+if [ "$1" -eq 0 ]; then
+	rm %{running_semaphore} >/dev/null 2>&1 || :
+fi
+
+%triggerun -- ecs-init <= 1.0-3
+# handle old ecs-init package that does not properly stop
+ecs_status=$(/sbin/status ecs 2>/dev/null || :)
+if grep -qF "start/" <<< "${ecs_status}"; then
+	/sbin/stop ecs >/dev/null 2>&1 || :
+	touch %{running_semaphore} >/dev/null 2>&1 || :
+fi
+
+%posttrans
+# ensure that we restart after the transaction
+if [ -e %{running_semaphore} ]; then
+	/sbin/start ecs >/dev/null 2>&1 || :
+	rm %{running_semaphore} >/dev/null 2>&1 || :
+fi
+%endif
+

--- a/packaging/amazon-linux-ami-integrated/ecs.conf
+++ b/packaging/amazon-linux-ami-integrated/ecs.conf
@@ -1,0 +1,22 @@
+# Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the
+# "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+
+description "Amazon Elastic Container Service init"
+author "Amazon Web Services"
+start on stopped rc RUNLEVEL=[345]
+
+pre-start exec /usr/libexec/amazon-ecs-init pre-start
+exec /usr/libexec/amazon-ecs-init start
+pre-stop exec /usr/libexec/amazon-ecs-init pre-stop
+post-stop exec /usr/libexec/amazon-ecs-init post-stop

--- a/packaging/amazon-linux-ami-integrated/ecs.service
+++ b/packaging/amazon-linux-ami-integrated/ecs.service
@@ -1,0 +1,34 @@
+# Copyright 2014-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the
+# "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+
+[Unit]
+Description=Amazon Elastic Container Service - container agent
+Documentation=https://aws.amazon.com/documentation/ecs/
+Requires=docker.service
+After=docker.service
+After=cloud-final.service
+
+[Service]
+Type=simple
+Restart=on-failure
+RestartPreventExitStatus=5
+RestartSec=10s
+EnvironmentFile=-/etc/ecs/ecs.config
+ExecStartPre=/usr/libexec/amazon-ecs-init pre-start
+ExecStart=/usr/libexec/amazon-ecs-init start
+ExecStop=/usr/libexec/amazon-ecs-init stop
+ExecStopPost=/usr/libexec/amazon-ecs-init post-stop
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/amazon-linux-ami/ecs-init.spec
+++ b/packaging/amazon-linux-ami/ecs-init.spec
@@ -49,6 +49,7 @@ Source5:        amazon-ecs-volume-plugin.conf
 Source6:        amazon-ecs-volume-plugin.service
 Source7:        amazon-ecs-volume-plugin.socket
 
+BuildRequires:  golang >= 1.7
 %if %{with systemd}
 BuildRequires:  systemd
 Requires:       systemd

--- a/scripts/build
+++ b/scripts/build
@@ -35,6 +35,15 @@ PAUSE_CONTAINER_TARBALL="amazon-ecs-pause.tar"
 ROOT=$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )
 cd "${ROOT}"
 
+export GO111MODULE="auto"
+export BUILDDIR="$(mktemp -d)"
+export GOPATH="${ROOT}/agent/:${BUILDDIR}"
+export SRCPATH="${BUILDDIR}/src/github.com/aws/amazon-ecs-agent"
+
+mkdir -p "${SRCPATH}"
+ln -s "${ROOT}/agent" "${SRCPATH}"
+cd "${SRCPATH}/agent"
+
 if [[ "${version_gen}" == "true" ]]; then
   # Versioning stuff. We run the generator to setup the version and then always
   # restore ourselves to a clean state
@@ -67,3 +76,5 @@ fi
 if [[ -n "${output_directory}" ]]; then
   mv $build_exe "${output_directory}"
 fi
+
+rm -r "${BUILDDIR}"

--- a/scripts/build-cni-plugins
+++ b/scripts/build-cni-plugins
@@ -13,19 +13,25 @@
 # permissions and limitations under the License.
 
 # this script builds the ecs/vpc cni plugins from the submodules
-# by copying them out of agent into their expected location in the
-# gopath
-
 set -ex
 
+# this script assumes we've run the get-cni-sources make target to update the cni submodules
 ROOT=$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )
 cd "${ROOT}"
-# copy submodules to expected go build path github.com/aws/amazon-ecs-cni-plugins
-cp -r amazon-ecs-cni-plugins ../amazon-ecs-cni-plugins
-cp -r amazon-vpc-cni-plugins ../amazon-vpc-cni-plugins
-cd ../amazon-ecs-cni-plugins && GO111MODULE=auto make plugins
-mkdir -p ../amazon-ecs-agent/misc/plugins && cp -a ./bin/plugins/. ../amazon-ecs-agent/misc/plugins/
+
+export BUILDDIR="$(mktemp -d)"
+export GITPATH="${BUILDDIR}/src/github.com/aws"
+export GOPATH="${BUILDDIR}"
+
+mkdir -p "${GITPATH}"
+ln -s "${ROOT}/amazon-ecs-cni-plugins" "${GITPATH}"
+ln -s "${ROOT}/amazon-vpc-cni-plugins" "${GITPATH}"
+
+cd ${GITPATH}/amazon-ecs-cni-plugins && GO111MODULE=auto make plugins
+mkdir -p ${ROOT}/misc/plugins && cp -a ./bin/plugins/. ${ROOT}/misc/plugins/
 make clean
-cd ../amazon-vpc-cni-plugins && GO111MODULE=auto make build
-cp -a ./build/linux_amd64/. ../amazon-ecs-agent/misc/plugins/
+cd ${GITPATH}/amazon-vpc-cni-plugins && GO111MODULE=off BUILD_FLAGS="-tags disablekubeapi" make all-binaries
+cp -a ./build/linux_amd64/. ${ROOT}/misc/plugins/
 make clean
+
+rm -r "${BUILDDIR}"


### PR DESCRIPTION
### Summary
Create a new specfile and update scripts so that a legacy integrated init/agent rpm build works.

### Implementation details
Changes include: 
#### Makefile 
- targets for building rpm with agent using the new spec file
    - sources target includes much more than current init sources target and depends on get-cni-sources

#### Spec File (copied from amazon-linux-ami/ecs-init specfile)
- added buildRequires for `glibc-static` (required for building pause)
- use the dockerless build scripts
- install the agent tar from the build into the cache directory and reflect in the state file that a cached version of the agent is available
- removed s3 agent sources and the setting up/linking of those
- only built for x86_64 (but need to support arm soon)
- removed changelog, and provides statements
- removed some al2 specific logic since this is for the legacy branch

#### Scripts
agent and cni plugins build scripts
- building in build directory symlinked to directories based on expected structure
- setting GOPATH
- (agent) setting go modules to auto
- (plugins) turning go modules off, using the "disablekubeapi" build tag, and only building the binaries without running unit tests when building amazon-vpc-cni-plugins 

### Testing
- Built rpm witih make target `make rpm-with-agent` (commenting out BuildRequires golang >= 1.7)
- Built in internal rpm build system
- Built ami with the rpm using the amazon-ecs-ami package ([with slight modifications](https://github.com/lydiafilipe/amazon-ecs-ami/commit/dc61cd5c887f0e7b428a7b2d841b0588b81ecbae)) and used it in launching instances, added instance to cluster and ran tasks

### Description for the changelog
specfile and script updates for integrated init/agent build

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
