### PR TITLE
Fix potential goroutine leaks

### DIFF
--- a/agent/acs/client/acs_client_test.go
+++ b/agent/acs/client/acs_client_test.go
@@ -347,9 +347,9 @@ func testCS(conn *mock_wsconn.MockWebsocketConn) wsclient.ClientServer {
 
 // TODO: replace with gomock
 func startMockAcsServer(t *testing.T, closeWS <-chan bool) (*httptest.Server, chan<- string, <-chan string, <-chan error, error) {
-	serverChan := make(chan string)
-	requestsChan := make(chan string)
-	errChan := make(chan error)
+	serverChan := make(chan string, 1)
+	requestsChan := make(chan string, 1)
+	errChan := make(chan error, 1)
 
 	upgrader := websocket.Upgrader{ReadBufferSize: 1024, WriteBufferSize: 1024}
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/agent/acs/handler/acs_handler.go
+++ b/agent/acs/handler/acs_handler.go
@@ -196,12 +196,10 @@ func NewSession(
 func (acsSession *session) Start() error {
 	// connectToACS channel is used to indicate the intent to connect to ACS
 	// It's processed by the select loop to connect to ACS
-	connectToACS := make(chan struct{})
+	connectToACS := make(chan struct{}, 1)
 	// This is required to trigger the first connection to ACS. Subsequent
 	// connections are triggered by the handleACSError() method
-	go func() {
-		connectToACS <- struct{}{}
-	}()
+	connectToACS <- struct{}{}
 	for {
 		select {
 		case <-connectToACS:

--- a/agent/tcs/handler/handler.go
+++ b/agent/tcs/handler/handler.go
@@ -143,7 +143,7 @@ func startSession(
 	client.AddRequestHandler(ackPublishHealthMetricHandler(timer))
 	client.AddRequestHandler(ackPublishInstanceStatusHandler(timer))
 	client.SetAnyRequestHandler(anyMessageHandler(client))
-	serveC := make(chan error)
+	serveC := make(chan error, 1)
 	go func() {
 		serveC <- client.Serve()
 	}()


### PR DESCRIPTION
### Summary

This fixes potential minor goroutine leaks.

### Implementation details

Sending to an unbuffered channel without a `select` and without a guarantee that something
will receive from that channel, is a recipe for a goroutine leak.
Make the channel buffered to avoid the issue.

Also, with a buffered channel, there is no no need to spin up a new goroutine just to send a
dummy object into it. Instead, just send right after channel creation.

### Testing

```bash
cd agent
go test -tags unit ./acs/...
go test -tags unit ./tcs/...
```

New tests cover the changes: no

### Description for the changelog

Fix potential goroutine leaks

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
