### PR TITLE
Add a Mac tester

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -1,0 +1,30 @@
+name: Mac
+
+on: [pull_request]
+
+jobs:
+  unit-tests:
+    name: Mac unit tests
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: src/github.com/aws/amazon-ecs-agent
+      - name: get GO_VERSION
+        run:  |
+          cd $GITHUB_WORKSPACE/src/github.com/aws/amazon-ecs-agent
+          echo "GO_VERSION=$(cat GO_VERSION)" >> $GITHUB_ENV
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+          path: src/github.com/aws/amazon-ecs-agent
+      - name: make test
+        run: |
+          export GOPATH=$GITHUB_WORKSPACE
+          export GO111MODULE=auto
+          cd $GITHUB_WORKSPACE/src/github.com/aws/amazon-ecs-agent
+          make test-silent
+          make analyze-cover-profile


### PR DESCRIPTION
### Summary

Add a Mac tester for GitHub actions, to prevent breakages on Mac.

### Implementation details

`mac.yml` is heavily based on `linux.yml`. The primary difference is that the value of `runs-on` is changed from `ubuntu-latest` to `macos-latest`, as [documented](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners).

### Testing

None

New tests cover the changes: no

### Description for the changelog

Add a Mac tester for GitHub actions.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
