### PR TITLE
execcmd: fix compilation errors on mac

### DIFF
--- a/agent/engine/execcmd/manager_init_task_test.go
+++ b/agent/engine/execcmd/manager_init_task_test.go
@@ -1,4 +1,4 @@
-//go:build unit
+//go:build linux || windows
 
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 //

--- a/agent/engine/execcmd/manager_init_task_test.go
+++ b/agent/engine/execcmd/manager_init_task_test.go
@@ -1,4 +1,4 @@
-//go:build linux || windows
+//go:build (linux || windows) && unit
 
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 //

--- a/agent/engine/execcmd/manager_start_test.go
+++ b/agent/engine/execcmd/manager_start_test.go
@@ -1,4 +1,4 @@
-//go:build unit
+//go:build linux || windows
 
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 //

--- a/agent/engine/execcmd/manager_start_test.go
+++ b/agent/engine/execcmd/manager_start_test.go
@@ -1,4 +1,4 @@
-//go:build linux || windows
+//go:build (linux || windows) && unit
 
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 //


### PR DESCRIPTION
### Summary

This PR fixes compilation errors in `agent/engine/execcmd` package on Mac.

### Implementation details

`manager_start.go` is implemented only for linux and windows, however
`manager_start_test.go` and `manager_init_task_test.go` currently are not
limited to those OSes. In particular, the don't compile on Mac.

Update their build tags to require `linux || windows` too.

### Testing

```
cd agent
go test -tags unit ./engine/execcmd/
```

New tests cover the changes: no

### Description for the changelog

Fix compilation errors in execcmd package on Mac.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
