### PR TITLE
Connect to stats endpoint for service connect enabled tasks

### DIFF
--- a/agent/stats/mock/engine.go
+++ b/agent/stats/mock/engine.go
@@ -82,6 +82,20 @@ func (mr *MockEngineMockRecorder) GetInstanceMetrics() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstanceMetrics", reflect.TypeOf((*MockEngine)(nil).GetInstanceMetrics))
 }
 
+// GetServiceConnectStats mocks base method
+func (m *MockEngine) GetServiceConnectStats() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetServiceConnectStats")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// GetServiceConnectStats indicates an expected call of GetServiceConnectStats
+func (mr *MockEngineMockRecorder) GetServiceConnectStats() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceConnectStats", reflect.TypeOf((*MockEngine)(nil).GetServiceConnectStats))
+}
+
 // GetTaskHealthMetrics mocks base method
 func (m *MockEngine) GetTaskHealthMetrics() (*ecstcs.HealthMetadata, []*ecstcs.TaskHealth, error) {
 	m.ctrl.T.Helper()

--- a/agent/stats/service_connect_linux.go
+++ b/agent/stats/service_connect_linux.go
@@ -1,0 +1,91 @@
+//go:build linux
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package stats
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+
+	"github.com/cihub/seelog"
+
+	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
+)
+
+const (
+	statsURLPath      = ":9901/stats/prometheus"
+	bridgeNetworkMode = "bridge"
+)
+
+type ServiceConnectStats struct {
+	//TODO [SC]: Change the type of Service Connect stats when it is defined.
+	stats string
+	lock  sync.RWMutex
+}
+
+func newServiceConnectStats() (*ServiceConnectStats, error) {
+	return &ServiceConnectStats{}, nil
+}
+
+func (sc *ServiceConnectStats) retrieveServiceConnectStats(task *apitask.Task) {
+	var ipAddress string
+	if task.IsNetworkModeAWSVPC() {
+		ipAddress = task.GetLocalIPAddress()
+	} else {
+		for _, container := range task.Containers {
+			// TODO [SC]: Implement a proper check for appnet agent container when it is defined
+			if strings.Contains(container.Name, "envoy") &&
+				(container.GetNetworkModeFromHostConfig() == "" || container.GetNetworkModeFromHostConfig() == bridgeNetworkMode) {
+				network := *container.GetNetworkSettings()
+				networkSettings := network.DefaultNetworkSettings
+				ipAddress = networkSettings.IPAddress
+				break
+			}
+		}
+	}
+	// TODO [SC]: Replace the stats url when it is defined
+	statsEndpoint, _ := url.Parse(fmt.Sprintf("http://" + ipAddress + statsURLPath))
+	resp, err := http.Get(statsEndpoint.String())
+	if err != nil {
+		seelog.Errorf("Could not connect to service connect stats endpoint for task %s: %v", task.Arn, err)
+		return
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		seelog.Errorf("Could not read metrics from service connect stats endpoint for task %s: %v", task.Arn, err)
+		return
+	}
+
+	sc.setStats(string(body))
+}
+
+func (sc *ServiceConnectStats) setStats(stats string) {
+	sc.lock.Lock()
+	defer sc.lock.Unlock()
+
+	sc.stats = stats
+}
+
+func (sc *ServiceConnectStats) GetStats() string {
+	sc.lock.RLock()
+	defer sc.lock.RUnlock()
+
+	return sc.stats
+}

--- a/agent/stats/service_connect_linux_test.go
+++ b/agent/stats/service_connect_linux_test.go
@@ -1,0 +1,68 @@
+//go:build linux && unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package stats
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	apieni "github.com/aws/amazon-ecs-agent/agent/api/eni"
+	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
+	apitaskstatus "github.com/aws/amazon-ecs-agent/agent/api/task/status"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRetrieveServiceConnectMetrics(t *testing.T) {
+
+	t1 := &apitask.Task{
+		Arn:               "t1",
+		Family:            "f1",
+		ENIs:              []*apieni.ENI{{ID: "ec2Id"}},
+		KnownStatusUnsafe: apitaskstatus.TaskRunning,
+		Containers: []*apicontainer.Container{
+			{Name: "test"},
+		},
+		LocalIPAddressUnsafe: "127.0.0.1",
+	}
+
+	// Set up a mock http sever on the statsUrlpath
+	statsMockurl := "127.0.0.1:9901"
+	r := mux.NewRouter()
+	r.HandleFunc("/stats/prometheus", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "Service Connect Stats")
+	}))
+
+	ts := httptest.NewUnstartedServer(r)
+
+	l, err := net.Listen("tcp", statsMockurl)
+	if err != nil {
+		fmt.Printf("%v", err)
+	}
+	ts.Listener.Close()
+	ts.Listener = l
+	ts.Start()
+	defer ts.Close()
+
+	serviceConnectStats := &ServiceConnectStats{}
+	serviceConnectStats.retrieveServiceConnectStats(t1)
+
+	assert.Equal(t, "Service Connect Stats\n", serviceConnectStats.GetStats())
+}

--- a/agent/stats/service_connect_unspecified.go
+++ b/agent/stats/service_connect_unspecified.go
@@ -1,0 +1,34 @@
+//go:build !linux
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package stats
+
+import (
+	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
+	"github.com/pkg/errors"
+)
+
+type ServiceConnectStats struct {
+	//TODO Change the type of Service Connect stats when it is defined.
+	stats string
+	sent  bool
+}
+
+func newServiceConnectStats() (*ServiceConnectStats, error) {
+	return nil, errors.New("Unsupported platform")
+}
+
+func (sc *ServiceConnectStats) retrieveServiceConnectStats(task *apitask.Task) {
+}

--- a/agent/tcs/client/client_test.go
+++ b/agent/tcs/client/client_test.go
@@ -116,6 +116,10 @@ func (*mockStatsEngine) GetTaskHealthMetrics() (*ecstcs.HealthMetadata, []*ecstc
 	return nil, nil, nil
 }
 
+func (*mockStatsEngine) GetServiceConnectStats() error {
+	return nil
+}
+
 type emptyStatsEngine struct{}
 
 func (*emptyStatsEngine) GetInstanceMetrics() (*ecstcs.MetricsMetadata, []*ecstcs.TaskMetric, error) {
@@ -128,6 +132,10 @@ func (*emptyStatsEngine) ContainerDockerStats(taskARN string, id string) (*types
 
 func (*emptyStatsEngine) GetTaskHealthMetrics() (*ecstcs.HealthMetadata, []*ecstcs.TaskHealth, error) {
 	return nil, nil, nil
+}
+
+func (*emptyStatsEngine) GetServiceConnectStats() error {
+	return nil
 }
 
 type idleStatsEngine struct{}
@@ -148,6 +156,10 @@ func (*idleStatsEngine) ContainerDockerStats(taskARN string, id string) (*types.
 
 func (*idleStatsEngine) GetTaskHealthMetrics() (*ecstcs.HealthMetadata, []*ecstcs.TaskHealth, error) {
 	return nil, nil, nil
+}
+
+func (*idleStatsEngine) GetServiceConnectStats() error {
+	return nil
 }
 
 type nonIdleStatsEngine struct {
@@ -177,6 +189,11 @@ func (*nonIdleStatsEngine) ContainerDockerStats(taskARN string, id string) (*typ
 func (*nonIdleStatsEngine) GetTaskHealthMetrics() (*ecstcs.HealthMetadata, []*ecstcs.TaskHealth, error) {
 	return nil, nil, nil
 }
+
+func (*nonIdleStatsEngine) GetServiceConnectStats() error {
+	return nil
+}
+
 func newNonIdleStatsEngine(numTasks int) *nonIdleStatsEngine {
 	return &nonIdleStatsEngine{numTasks: numTasks}
 }

--- a/agent/tcs/handler/handler_test.go
+++ b/agent/tcs/handler/handler_test.go
@@ -79,6 +79,10 @@ func (*mockStatsEngine) GetTaskHealthMetrics() (*ecstcs.HealthMetadata, []*ecstc
 	return nil, nil, nil
 }
 
+func (*mockStatsEngine) GetServiceConnectStats() error {
+	return nil
+}
+
 // TestDisableMetrics tests the StartMetricsSession will return immediately if
 // the metrics was disabled
 func TestDisableMetrics(t *testing.T) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This implements the functionality of ECS agent connecting to the stats endpoint exposed by the Appnet agent. For AWSVPC mode, we will use the IP of the ecs-bridge to connect to the endpoint. For Bridge mode, we will use the IP of the appnet agent container. For now, we have considered the envoy container as the appnet agent container.

### Implementation details
<!-- How are the changes implemented? -->

in stats/engine.go -> We maintain a map where we correlate every task with a service connect stats object. Whenever we start a task, the task gets added to this map.
in stats/service_connect_linux.go -> We actually connect to the stats endpoint to get the data. The structure of the stats data has not yet been implemented and will be implemented in subsequent PR. For now, it is a simple string.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

Unit tests cover the change

Manual test:
* AWSVPC Mode: Ran an Appmesh task, and tested that we are able to hit the stats endpoint
* Bridge Mode: Ran a dummy envoy container along with an application container. tested that we are able to hit the stats endpoint

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Feature - Connect to stats endpoint for service connect metrics

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
