### PR TITLE
engine: skip some tests on Mac

### DIFF
--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -188,6 +189,12 @@ func mockSetupNSResult() *current.Result {
 				Address: *ip,
 			},
 		},
+	}
+}
+
+func ensureCNISupportsPlatform(t *testing.T) {
+	if runtime.GOOS != "linux" && runtime.GOOS != "windows" {
+		t.Skipf("CNI config building is unsupported on this platform")
 	}
 }
 
@@ -971,6 +978,7 @@ func TestGetTaskByArn(t *testing.T) {
 }
 
 func TestProvisionContainerResourcesSetPausePIDInVolumeResources(t *testing.T) {
+	ensureCNISupportsPlatform(t)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	ctrl, dockerClient, _, taskEngine, _, _, _ := mocks(t, ctx, &defaultConfig)
@@ -1055,6 +1063,7 @@ func TestProvisionContainerResourcesInspectError(t *testing.T) {
 // TestStopPauseContainerCleanupCalled tests when stopping the pause container
 // its network namespace should be cleaned up first
 func TestStopPauseContainerCleanupCalled(t *testing.T) {
+	ensureCNISupportsPlatform(t)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	ctrl, dockerClient, _, taskEngine, _, _, _ := mocks(t, ctx, &defaultConfig)
@@ -1112,6 +1121,7 @@ func TestStopPauseContainerCleanupCalled(t *testing.T) {
 // TestStopPauseContainerCleanupCalled tests when stopping the pause container
 // its network namespace should be cleaned up first
 func TestStopPauseContainerCleanupDelay(t *testing.T) {
+	ensureCNISupportsPlatform(t)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 
@@ -1172,6 +1182,7 @@ func TestStopPauseContainerCleanupDelay(t *testing.T) {
 
 // TestCheckTearDownPauseContainer that the pause container teardown works and is idempotent
 func TestCheckTearDownPauseContainer(t *testing.T) {
+	ensureCNISupportsPlatform(t)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	ctrl, dockerClient, _, taskEngine, _, _, _ := mocks(t, ctx, &defaultConfig)


### PR DESCRIPTION
### Summary

Building a CNI configuration is supported only on Linux and Windows. On other platforms, it fails with "unsupported platform": 
https://github.com/aws/amazon-ecs-agent/blob/05730614021c70c7f39d7cc00264aaffc5b5b0d3/agent/api/task/task_unsupported.go#L96-L100

However, 3 tests in `engine` package that rely on CNI are not skipped on other platforms. 

### Implementation details

Skip the impacted tests by checking `GOOS` in runtime. Do not use build tags because there are other tests in the same
file that pass.

### Testing

```
cd agent
go test -tags unit ./engine
```

New tests cover the changes: no

### Description for the changelog

engine: skip some tests on Mac

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
