### PR TITLE
Update windows base image versions for integ tests

### DIFF
--- a/scripts/run-integ-tests.ps1
+++ b/scripts/run-integ-tests.ps1
@@ -12,32 +12,23 @@
 # permissions and limitations under the License.
 
 Param (
-  [string]$Platform="windows2016"
+  [string]
+  [ValidateSet("windows2016","windows2019","windows20H2", "windows2022")]
+  $Platform="windows2016"
 )
 
 if ($Platform -like "windows2016") {
-  $BaseImageName="mcr.microsoft.com/windows/servercore@sha256:42be24b8810c861cc1b3fe75c5e99f75061cb45fdbae1de46d151c18cc8e6a9a"
-  $BaseImageNameWithDigest="mcr.microsoft.com/windows/servercore@sha256:42be24b8810c861cc1b3fe75c5e99f75061cb45fdbae1de46d151c18cc8e6a9a"
+  $BaseImageName="mcr.microsoft.com/windows/servercore:ltsc2016"
 } elseif ($Platform -like "windows2019")  {
-  $BaseImageName="mcr.microsoft.com/windows/servercore@sha256:cc6d6da31014dceab4daee8b5a8da4707233f4ef42eaf071e45cee044ac738f4"
-  $BaseImageNameWithDigest="mcr.microsoft.com/windows/servercore@sha256:cc6d6da31014dceab4daee8b5a8da4707233f4ef42eaf071e45cee044ac738f4"
-} elseif ($Platform -like "windows2004")  {
-  $BaseImageName="mcr.microsoft.com/windows/servercore@sha256:057f2a4da3777db6de54c41029439227537e5bf805de3d90b0cfd300ffbf3db0"
-  $BaseImageNameWithDigest="mcr.microsoft.com/windows/servercore@sha256:057f2a4da3777db6de54c41029439227537e5bf805de3d90b0cfd300ffbf3db0"
+  $BaseImageName="mcr.microsoft.com/windows/servercore:ltsc2019"
 } elseif ($Platform -like "windows20h2")  {
-  $BaseImageName="mcr.microsoft.com/windows/servercore@sha256:64ada3cbc39ee8152f45b6e2284e8eb0a9fc14edef5be0f78397f0d1a0879451"
-  $BaseImageNameWithDigest="mcr.microsoft.com/windows/servercore@sha256:64ada3cbc39ee8152f45b6e2284e8eb0a9fc14edef5be0f78397f0d1a0879451"
+  $BaseImageName="mcr.microsoft.com/windows/servercore:20H2"
 } elseif ($Platform -like "windows2022")  {
-  $BaseImageName="mcr.microsoft.com/windows/servercore@sha256:8f756a7fd4fe963cc7dd2c3ad1597327535da8e8f55a7d1932780934efa87e04"
-  $BaseImageNameWithDigest="mcr.microsoft.com/windows/servercore@sha256:8f756a7fd4fe963cc7dd2c3ad1597327535da8e8f55a7d1932780934efa87e04"
+  $BaseImageName="mcr.microsoft.com/windows/servercore:ltsc2022"
 } else {
   echo "Invalid platform parameter"
   exit 1
 }
-
-$ProgramFiles="C:\Program Files\Amazon\ECS"
-$env:BASE_IMAGE_NAME=$BaseImageName
-$env:BASE_IMAGE_NAME_WITH_DIGEST=$BaseImageNameWithDigest
 
 # Prepare windows base image
 $dockerImages = Invoke-Expression "docker images"
@@ -45,6 +36,14 @@ if (-Not ($dockerImages -like "*$BaseImageName*")) {
   Invoke-Expression "docker pull $BaseImageName"
 }
 Invoke-Expression "docker tag $BaseImageName amazon-ecs-ftest-windows-base:make"
+
+$imgDigest = Invoke-Expression "docker image inspect --format `"{{.RepoDigests}}`" $BaseImageName"
+# The template returns an array so its [$BaseImageDigest]. Remove the '[' and ']'
+$imgDigest = $imgDigest.SubString(1, $imgDigest.Length - 2)
+
+$ProgramFiles="C:\Program Files\Amazon\ECS"
+$env:BASE_IMAGE_NAME=$BaseImageName
+$env:BASE_IMAGE_NAME_WITH_DIGEST=$imgDigest
 
 # Ensure that "C:/Program Files/Amazon/ECS" is empty before preparing dependencies.
 Remove-Item -Path "$ProgramFiles\*" -Recurse -Force -ErrorAction:SilentlyContinue


### PR DESCRIPTION
Signed-off-by: Justin Terry <jlterry@amazon.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This updates the windows base images for the integ test so we actually use the latest ones.

### Implementation details
<!-- How are the changes implemented? -->
Pulls them by ltsc tag where applicable.

### Testing
<!-- How was this tested? -->
`.\run-integ-tests.ps1`
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
