### PR TITLE
Update linked agent version to use built agent

### DIFF
--- a/agent-container/agent-manifest.json
+++ b/agent-container/agent-manifest.json
@@ -1,1 +1,1 @@
-[{"Config":"config.json","RepoTags":["amazon/amazon-ecs-agent:~~agentversion~~"],"Layers":["rootfs/layer.tar"]}]
+[{"Config":"config.json","RepoTags":["amazon/amazon-ecs-agent:latest"],"Layers":["rootfs/layer.tar"]}]

--- a/packaging/amazon-linux-ami-integrated/ecs-init.spec
+++ b/packaging/amazon-linux-ami-integrated/ecs-init.spec
@@ -21,7 +21,6 @@
 %global gobuild_tag %{nil}
 %endif
 %global _cachedir %{_localstatedir}/cache
-%global bundled_agent_version %{version}
 %global no_exec_perm 644
 %global debug_package %{nil}
 %global agent_image ecs-agent-v%{version}.tar
@@ -178,7 +177,7 @@ touch %{buildroot}%{_sysconfdir}/ecs/ecs.config.json
 # Configure ecs-init to reload the bundled ECS container agent image.
 mkdir -p %{buildroot}%{_cachedir}/ecs
 echo 2 > %{buildroot}%{_cachedir}/ecs/state
-install -m %{no_exec_perm} %{agent_image} %{buildroot}%{_cachedir}/ecs/ecs-agent.tar
+install -m %{no_exec_perm} %{agent_image} %{buildroot}%{_cachedir}/ecs/
 
 mkdir -p %{buildroot}%{_sharedstatedir}/ecs/data
 
@@ -197,7 +196,8 @@ install -m %{no_exec_perm} -D %{SOURCE5} %{buildroot}%{_sysconfdir}/init/amazon-
 %{_libexecdir}/amazon-ecs-volume-plugin
 %config(noreplace) %ghost %{_sysconfdir}/ecs/ecs.config
 %config(noreplace) %ghost %{_sysconfdir}/ecs/ecs.config.json
-%{_cachedir}/ecs/ecs-agent.tar
+%ghost %{_cachedir}/ecs/ecs-agent.tar
+%{_cachedir}/ecs/%{basename:%{agent_image}}
 %{_cachedir}/ecs/state
 %dir %{_sharedstatedir}/ecs/data
 
@@ -211,7 +211,7 @@ install -m %{no_exec_perm} -D %{SOURCE5} %{buildroot}%{_sysconfdir}/init/amazon-
 %endif
 
 %post
-# Symlink the bundled ECS Agent at loadable path.
+# symlink the built ecs-agent image at a loadable path
 ln -sf %{basename:%{agent_image}} %{_cachedir}/ecs/ecs-agent.tar
 %if %{with systemd}
 %systemd_post ecs

--- a/packaging/generic-rpm-integrated/amazon-ecs-init.spec
+++ b/packaging/generic-rpm-integrated/amazon-ecs-init.spec
@@ -14,7 +14,6 @@
 
 %global gobuild_tag generic_rpm
 %global _cachedir %{_localstatedir}/cache
-%global bundled_agent_version %{version}
 %global no_exec_perm 644
 %global debug_package %{nil}
 %global agent_image ecs-agent-v%{version}.tar
@@ -65,7 +64,6 @@ touch %{buildroot}%{_sysconfdir}/ecs/ecs.config.json
 # Configure ecs-init to reload the bundled ECS container agent image.
 mkdir -p %{buildroot}%{_cachedir}/ecs
 echo 2 > %{buildroot}%{_cachedir}/ecs/state
-# Add a bundled ECS container agent image
 install -m %{no_exec_perm} %{agent_image} %{buildroot}%{_cachedir}/ecs/
 
 mkdir -p %{buildroot}%{_sharedstatedir}/ecs/data


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
There are a few details that I'd missed in the build:
- The agent container needs to be tagged `latest`
- The built image needs to be named based on its version
- The build image needs to be linked.

### Implementation details
I built and tested the `make amazon-linux-rpm-integrated` target in a fresh ecs-optimized AL2 instance.  I am able to start the new agent container and connect to my cluster.  I am also able to run `docker history <agent image ID>` and see that the ecs rpm's included image is the dockerfree image with a single layer and all expected configuration.

New tests cover the changes: no

### Description for the changelog
Update linked agent version to use built agent.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
