### PR TITLE
Paginate service connect telemetry data

### DIFF
--- a/agent/stats/common_test.go
+++ b/agent/stats/common_test.go
@@ -142,7 +142,7 @@ func (resolver *IntegContainerMetadataResolver) ResolveContainer(containerID str
 }
 
 func validateInstanceMetrics(t *testing.T, engine *DockerStatsEngine) {
-	metadata, taskMetrics, err := engine.GetInstanceMetrics()
+	metadata, taskMetrics, err := engine.GetInstanceMetrics(false)
 	assert.NoError(t, err, "gettting instance metrics failed")
 	assert.NoError(t, validateMetricsMetadata(metadata), "validating metadata failed")
 	assert.Len(t, taskMetrics, 1, "incorrect number of tasks")
@@ -178,7 +178,7 @@ func validateContainerMetrics(containerMetrics []*ecstcs.ContainerMetric, expect
 }
 
 func validateIdleContainerMetrics(t *testing.T, engine *DockerStatsEngine) {
-	metadata, taskMetrics, err := engine.GetInstanceMetrics()
+	metadata, taskMetrics, err := engine.GetInstanceMetrics(false)
 	assert.NoError(t, err, "getting instance metrics failed")
 	assert.NoError(t, validateMetricsMetadata(metadata), "validating metadata failed")
 

--- a/agent/stats/engine_integ_test.go
+++ b/agent/stats/engine_integ_test.go
@@ -567,7 +567,7 @@ func TestStatsEngineWithDockerTaskEngineMissingRemoveEvent(t *testing.T) {
 	time.Sleep(checkPointSleep)
 
 	// Simulate tcs client invoking GetInstanceMetrics.
-	_, _, err = statsEngine.GetInstanceMetrics()
+	_, _, err = statsEngine.GetInstanceMetrics(false)
 	assert.Error(t, err, "expect error 'no task metrics tp report' when getting instance metrics")
 
 	// Should not contain any metrics after cleanup.
@@ -632,7 +632,7 @@ func testNetworkModeStats(t *testing.T, networkMode string, statsEmpty bool) {
 
 	// Wait for the stats collection go routine to start.
 	time.Sleep(checkPointSleep)
-	_, taskMetrics, err := engine.GetInstanceMetrics()
+	_, taskMetrics, err := engine.GetInstanceMetrics(false)
 	assert.NoError(t, err, "getting instance metrics failed")
 	taskMetric := taskMetrics[0]
 	for _, containerMetric := range taskMetric.ContainerMetrics {
@@ -712,7 +712,7 @@ func TestStorageStats(t *testing.T) {
 
 	// Wait for the stats collection go routine to start.
 	time.Sleep(checkPointSleep)
-	_, taskMetrics, err := engine.GetInstanceMetrics()
+	_, taskMetrics, err := engine.GetInstanceMetrics(false)
 	assert.NoError(t, err, "getting instance metrics failed")
 	taskMetric := taskMetrics[0]
 	for _, containerMetric := range taskMetric.ContainerMetrics {

--- a/agent/stats/engine_test.go
+++ b/agent/stats/engine_test.go
@@ -115,7 +115,7 @@ func TestStatsEngineAddRemoveContainers(t *testing.T) {
 		t.Errorf("Error validating container metrics: %v", err)
 	}
 
-	metadata, taskMetrics, err := engine.GetInstanceMetrics()
+	metadata, taskMetrics, err := engine.GetInstanceMetrics(false)
 	if err != nil {
 		t.Errorf("Error gettting instance metrics: %v", err)
 	}
@@ -152,7 +152,7 @@ func TestStatsEngineAddRemoveContainers(t *testing.T) {
 		t.Error("Container c3 not found in engine")
 	}
 
-	_, _, err = engine.GetInstanceMetrics()
+	_, _, err = engine.GetInstanceMetrics(false)
 	if err == nil {
 		t.Error("Expected non-empty error for empty stats.")
 	}
@@ -206,7 +206,7 @@ func TestStatsEngineMetadataInStatsSets(t *testing.T) {
 			statsContainer.statsQueue.setLastStat(dockerStats[i])
 		}
 	}
-	metadata, taskMetrics, err := engine.GetInstanceMetrics()
+	metadata, taskMetrics, err := engine.GetInstanceMetrics(false)
 	if err != nil {
 		t.Errorf("Error gettting instance metrics: %v", err)
 	}
@@ -513,7 +513,7 @@ func testNetworkModeStats(t *testing.T, netMode string, enis []*apieni.ENI, empt
 			statsContainer.statsQueue.setLastStat(dockerStats[i])
 		}
 	}
-	_, taskMetrics, err := engine.GetInstanceMetrics()
+	_, taskMetrics, err := engine.GetInstanceMetrics(false)
 	assert.NoError(t, err)
 	assert.Len(t, taskMetrics, 1)
 	for _, containerMetric := range taskMetrics[0].ContainerMetrics {

--- a/agent/stats/engine_unix_test.go
+++ b/agent/stats/engine_unix_test.go
@@ -113,7 +113,7 @@ func TestNetworkModeStatsAWSVPCMode(t *testing.T) {
 			taskContainers.StatsQueue.add(containerStats[i])
 		}
 	}
-	_, taskMetrics, err := engine.GetInstanceMetrics()
+	_, taskMetrics, err := engine.GetInstanceMetrics(false)
 	assert.NoError(t, err)
 	assert.Len(t, taskMetrics, 1)
 	for _, containerMetric := range taskMetrics[0].ContainerMetrics {

--- a/agent/stats/mock/engine.go
+++ b/agent/stats/mock/engine.go
@@ -67,9 +67,9 @@ func (mr *MockEngineMockRecorder) ContainerDockerStats(arg0, arg1 interface{}) *
 }
 
 // GetInstanceMetrics mocks base method
-func (m *MockEngine) GetInstanceMetrics() (*ecstcs.MetricsMetadata, []*ecstcs.TaskMetric, error) {
+func (m *MockEngine) GetInstanceMetrics(arg0 bool) (*ecstcs.MetricsMetadata, []*ecstcs.TaskMetric, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetInstanceMetrics")
+	ret := m.ctrl.Call(m, "GetInstanceMetrics", arg0)
 	ret0, _ := ret[0].(*ecstcs.MetricsMetadata)
 	ret1, _ := ret[1].([]*ecstcs.TaskMetric)
 	ret2, _ := ret[2].(error)
@@ -77,9 +77,9 @@ func (m *MockEngine) GetInstanceMetrics() (*ecstcs.MetricsMetadata, []*ecstcs.Ta
 }
 
 // GetInstanceMetrics indicates an expected call of GetInstanceMetrics
-func (mr *MockEngineMockRecorder) GetInstanceMetrics() *gomock.Call {
+func (mr *MockEngineMockRecorder) GetInstanceMetrics(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstanceMetrics", reflect.TypeOf((*MockEngine)(nil).GetInstanceMetrics))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstanceMetrics", reflect.TypeOf((*MockEngine)(nil).GetInstanceMetrics), arg0)
 }
 
 // GetServiceConnectStats mocks base method

--- a/agent/tcs/client/client_test.go
+++ b/agent/tcs/client/client_test.go
@@ -23,6 +23,7 @@ package tcsclient
 
 import (
 	"fmt"
+	"math/rand"
 	"strconv"
 	"testing"
 	"time"
@@ -42,11 +43,12 @@ import (
 )
 
 const (
-	testPublishMetricsInterval = 1 * time.Second
-	testMessageId              = "testMessageId"
-	testCluster                = "default"
-	testContainerInstance      = "containerInstance"
-	rwTimeout                  = time.Second
+	testPublishMetricsInterval        = 1 * time.Second
+	testMessageId                     = "testMessageId"
+	testCluster                       = "default"
+	testContainerInstance             = "containerInstance"
+	rwTimeout                         = time.Second
+	testPublishMetricRequestSizeLimit = 1024
 )
 
 const (
@@ -104,7 +106,7 @@ var emptyDoctor, _ = doctor.NewDoctor([]doctor.Healthcheck{}, "test-cluster", "t
 
 type mockStatsEngine struct{}
 
-func (*mockStatsEngine) GetInstanceMetrics() (*ecstcs.MetricsMetadata, []*ecstcs.TaskMetric, error) {
+func (*mockStatsEngine) GetInstanceMetrics(includeServiceConnectStats bool) (*ecstcs.MetricsMetadata, []*ecstcs.TaskMetric, error) {
 	return nil, nil, fmt.Errorf("uninitialized")
 }
 
@@ -122,7 +124,7 @@ func (*mockStatsEngine) GetServiceConnectStats() error {
 
 type emptyStatsEngine struct{}
 
-func (*emptyStatsEngine) GetInstanceMetrics() (*ecstcs.MetricsMetadata, []*ecstcs.TaskMetric, error) {
+func (*emptyStatsEngine) GetInstanceMetrics(includeServiceConnectStats bool) (*ecstcs.MetricsMetadata, []*ecstcs.TaskMetric, error) {
 	return nil, nil, fmt.Errorf("empty stats")
 }
 
@@ -140,7 +142,7 @@ func (*emptyStatsEngine) GetServiceConnectStats() error {
 
 type idleStatsEngine struct{}
 
-func (*idleStatsEngine) GetInstanceMetrics() (*ecstcs.MetricsMetadata, []*ecstcs.TaskMetric, error) {
+func (*idleStatsEngine) GetInstanceMetrics(includeServiceConnectStats bool) (*ecstcs.MetricsMetadata, []*ecstcs.TaskMetric, error) {
 	metadata := &ecstcs.MetricsMetadata{
 		Cluster:           aws.String(testCluster),
 		ContainerInstance: aws.String(testContainerInstance),
@@ -166,7 +168,7 @@ type nonIdleStatsEngine struct {
 	numTasks int
 }
 
-func (engine *nonIdleStatsEngine) GetInstanceMetrics() (*ecstcs.MetricsMetadata, []*ecstcs.TaskMetric, error) {
+func (engine *nonIdleStatsEngine) GetInstanceMetrics(includeServiceConnectStats bool) (*ecstcs.MetricsMetadata, []*ecstcs.TaskMetric, error) {
 	metadata := &ecstcs.MetricsMetadata{
 		Cluster:           aws.String(testCluster),
 		ContainerInstance: aws.String(testContainerInstance),
@@ -196,6 +198,99 @@ func (*nonIdleStatsEngine) GetServiceConnectStats() error {
 
 func newNonIdleStatsEngine(numTasks int) *nonIdleStatsEngine {
 	return &nonIdleStatsEngine{numTasks: numTasks}
+}
+
+type serviceConnectStatsEngine struct {
+	numTasks int
+}
+
+func (engine *serviceConnectStatsEngine) GetInstanceMetrics(includeServiceConnectStats bool) (*ecstcs.MetricsMetadata, []*ecstcs.TaskMetric, error) {
+	metadata := &ecstcs.MetricsMetadata{
+		Cluster:           aws.String(testCluster),
+		ContainerInstance: aws.String(testContainerInstance),
+		Idle:              aws.Bool(false),
+		MessageId:         aws.String(testMessageId),
+	}
+	var taskMetrics []*ecstcs.TaskMetric
+	var i int64
+	var fval float64
+	fval = rand.Float64()
+	var ival int64
+	ival = rand.Int63n(10)
+	for i = 0; int(i) < engine.numTasks; i++ {
+		taskArn := "task/" + strconv.FormatInt(i, 10)
+		taskMetric := ecstcs.TaskMetric{
+			TaskArn: &taskArn,
+			ContainerMetrics: []*ecstcs.ContainerMetric{
+				{
+					CpuStatsSet: &ecstcs.CWStatsSet{
+						Max:         &fval,
+						Min:         &fval,
+						SampleCount: &ival,
+						Sum:         &fval,
+					},
+					MemoryStatsSet: &ecstcs.CWStatsSet{
+						Max:         &fval,
+						Min:         &fval,
+						SampleCount: &ival,
+						Sum:         &fval,
+					},
+				},
+			},
+		}
+		if includeServiceConnectStats {
+			var serviceConnectMetrics []*ecstcs.GeneralMetricsWrapper
+			var generalMetrics []*ecstcs.GeneralMetric
+			metricType := "2"
+			dimensionKey := "ClusterName"
+			dimentsionValue := "TestClusterName"
+			metricName := "HTTPCode_Target_2XX_Count"
+			metricValue := 3.0
+			var metricCount int64 = 1
+
+			// generate a task metric with size more than testPublishMetricRequestSizeLimit i.e 1kB
+			generalMetric := ecstcs.GeneralMetric{
+				MetricName:   &metricName,
+				MetricValues: []*float64{&metricValue},
+				MetricCounts: []*int64{&metricCount},
+			}
+			generalMetrics = append(generalMetrics, &generalMetric)
+			generalMetrics = append(generalMetrics, &generalMetric)
+			generalMetrics = append(generalMetrics, &generalMetric)
+			generalMetrics = append(generalMetrics, &generalMetric)
+			generalMetricsWrapper := ecstcs.GeneralMetricsWrapper{
+				MetricType: &metricType,
+				Dimensions: []*ecstcs.Dimension{
+					{
+						Key:   &dimensionKey,
+						Value: &dimentsionValue,
+					},
+				},
+				GeneralMetrics: generalMetrics,
+			}
+			serviceConnectMetrics = append(serviceConnectMetrics, &generalMetricsWrapper)
+			serviceConnectMetrics = append(serviceConnectMetrics, &generalMetricsWrapper)
+			taskMetric.ServiceConnectMetricsWrapper = serviceConnectMetrics
+		}
+		taskMetrics = append(taskMetrics, &taskMetric)
+	}
+	return metadata, taskMetrics, nil
+}
+
+func (*serviceConnectStatsEngine) ContainerDockerStats(taskARN string, id string) (*types.StatsJSON, *stats.NetworkStatsPerSec, error) {
+	return nil, nil, fmt.Errorf("not implemented")
+}
+
+func (*serviceConnectStatsEngine) GetTaskHealthMetrics() (*ecstcs.HealthMetadata, []*ecstcs.TaskHealth, error) {
+	return nil, nil, nil
+}
+
+func (*serviceConnectStatsEngine) GetServiceConnectStats() error {
+	return nil
+}
+
+func newServiceConnectStatsEngine(numTasks int) *serviceConnectStatsEngine {
+	return &serviceConnectStatsEngine{numTasks: numTasks}
 }
 
 func TestPayloadHandlerCalled(t *testing.T) {
@@ -250,7 +345,7 @@ func TestPublishMetricsOnceEmptyStatsError(t *testing.T) {
 	cs := clientServer{
 		statsEngine: &emptyStatsEngine{},
 	}
-	err := cs.publishMetricsOnce()
+	err := cs.publishMetricsOnce(false)
 
 	assert.Error(t, err, "Failed: expecting publishMerticOnce return err ")
 }
@@ -259,7 +354,7 @@ func TestPublishOnceIdleStatsEngine(t *testing.T) {
 	cs := clientServer{
 		statsEngine: &idleStatsEngine{},
 	}
-	requests, err := cs.metricsToPublishMetricRequests()
+	requests, err := cs.metricsToPublishMetricRequests(false)
 	if err != nil {
 		t.Fatal("Error creating publishmetricrequests: ", err)
 	}
@@ -280,7 +375,7 @@ func TestPublishOnceNonIdleStatsEngine(t *testing.T) {
 	cs := clientServer{
 		statsEngine: newNonIdleStatsEngine(numTasks),
 	}
-	requests, err := cs.metricsToPublishMetricRequests()
+	requests, err := cs.metricsToPublishMetricRequests(false)
 	if err != nil {
 		t.Fatal("Error creating publishmetricrequests: ", err)
 	}
@@ -306,6 +401,67 @@ func TestPublishOnceNonIdleStatsEngine(t *testing.T) {
 		if *request.Metadata.Fin {
 			t.Errorf("Fin set to true in request %d/%d", i, (expectedRequests - 1))
 		}
+	}
+}
+
+func TestPublishServiceConnectStatsEngine(t *testing.T) {
+	tempLimit := publishMetricRequestSizeLimit
+	publishMetricRequestSizeLimit = testPublishMetricRequestSizeLimit
+	defer func() {
+		publishMetricRequestSizeLimit = tempLimit
+	}()
+
+	testCases := []struct {
+		name             string
+		numTasks         int
+		expectedRequests int
+	}{
+		{
+			name:             "publish metrics requests with under 10 tasks with service connect stats",
+			numTasks:         3,
+			expectedRequests: 6,
+		},
+		{
+			name:             "publish metrics requests with more than 10 tasks with service connect stats",
+			numTasks:         20,
+			expectedRequests: 40,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cs := clientServer{
+				statsEngine: newServiceConnectStatsEngine(tc.numTasks),
+			}
+			requests, err := cs.metricsToPublishMetricRequests(true)
+			if err != nil {
+				t.Fatal("Error creating publishmetricrequests: ", err)
+			}
+
+			taskArns := make(map[string]bool)
+			for _, request := range requests {
+				for _, taskMetric := range request.TaskMetrics {
+					_, exists := taskArns[*taskMetric.TaskArn]
+					// if it is first part of task metric or a complete task metric being sent in this request
+					// validate that ContainerMetrics is not empty
+					if !exists {
+						assert.NotEmpty(t, taskMetric.ContainerMetrics, "Expected Container metrics to be not empty")
+					} else {
+						// task metric with remaining service connect metrics being sent in the next request
+						// validate that ContainerMetrics is empty
+						assert.Empty(t, taskMetric.ContainerMetrics, "Expected Container metrics to be empty, got %d", len(taskMetric.ContainerMetrics))
+					}
+					taskArns[*taskMetric.TaskArn] = true
+				}
+			}
+			assert.Equal(t, tc.expectedRequests, len(requests), "Wrong number of requests generated")
+			lastRequest := requests[tc.expectedRequests-1]
+			assert.True(t, *lastRequest.Metadata.Fin, "Fin not set to true in last request")
+			requests = requests[:(tc.expectedRequests - 1)]
+			for i, request := range requests {
+				assert.False(t, *request.Metadata.Fin, "Fin set to true in request %d/%d", i, (tc.expectedRequests - 1))
+			}
+		})
 	}
 }
 

--- a/agent/tcs/handler/handler_test.go
+++ b/agent/tcs/handler/handler_test.go
@@ -66,7 +66,7 @@ var testCfg = &config.Config{
 
 var emptyDoctor, _ = doctor.NewDoctor([]doctor.Healthcheck{}, "test-cluster", "this:is:an:instance:arn")
 
-func (*mockStatsEngine) GetInstanceMetrics() (*ecstcs.MetricsMetadata, []*ecstcs.TaskMetric, error) {
+func (*mockStatsEngine) GetInstanceMetrics(includeServiceConnectStats bool) (*ecstcs.MetricsMetadata, []*ecstcs.TaskMetric, error) {
 	req := createPublishMetricsRequest()
 	return req.Metadata, req.TaskMetrics, nil
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR includes changes to publish service connect stats in `PublishMetricsAPI` payload that we currently send to the TACS.

### Implementation details
<!-- How are the changes implemented? -->
- `agent/tcs/client`:
     -  Updated `publishMetrics()` to publish Service Connect metrics every 60s. Currently task metrics are published at 20s interval therefore Service Connect metrics will included in Task metrics every 3rd publish request send to TACS if task is SC enabled.
     -  The message size for publish request is capped at 10 tasks or at 1 MB
     -  Added `serviceConnectMetricsToPublishMetricRequests` method  loops over all service connect metrics for a given task metric.  Each service connect metric is added to the publish metrics request being to the TACS as long as the request size is under 1 MB. If adding a service connect metric to request exceeds the 1MB limit , then the SC metric will be added to a new request with other Task metadata `ClusterArn` , `TaskArn`,  `TaskDefinitionFamily`, `TaskDefinitionVersion`

**TODO**:  `GetInstanceMetrics()` will be updated to retrieve and update TaskMetric with service connect stats in the upcoming PR.

Previous TACS Payload change PR - https://github.com/aws/amazon-ecs-agent/pull/3162

### Testing
<!-- How was this tested? -->
`make test`

<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
