### PR TITLE
Ephemeral Port Selection for Service Connect

### DIFF
--- a/agent/api/task/service_connect.go
+++ b/agent/api/task/service_connect.go
@@ -25,7 +25,7 @@ type ServiceConnectConfig struct {
 // StatsConfig is the endpoint where SC stats can be retrieved from.
 type StatsConfig struct {
 	UrlPath string `json:"urlPath,omitempty"`
-	Port    int    `json:"port,omitempty"`
+	Port    uint16 `json:"port,omitempty"`
 }
 
 // IngressConfigEntry is the ingress configuration for a given SC service.
@@ -33,20 +33,24 @@ type IngressConfigEntry struct {
 	// ListenerName is the name of the listener for an SC service.
 	ListenerName string `json:"listenerName"`
 	// ListenerPort is the port where Envoy listens for ingress traffic for a given  SC service.
-	ListenerPort int `json:"listenerPort"`
+	ListenerPort uint16 `json:"listenerPort"`
 	// InterceptPort is only relevant for awsvpc mode. If present, SC CNI Plugin will configure netfilter rules to redirect
 	// traffic destined to this port to ListenerPort.
-	InterceptPort *int `json:"interceptPort,omitempty"`
+	InterceptPort *uint16 `json:"interceptPort,omitempty"`
 	// HostPort is only relevant for bridge network mode non-default case, where SC ingress host port is predefined in
 	// SC Service creation/modification time.
-	HostPort *int `json:"hostPort,omitempty"`
+	HostPort *uint16 `json:"hostPort,omitempty"`
 }
 
 // EgressConfig is the egress configuration for a given SC service.
 type EgressConfig struct {
 	// ListenerName is the name of the listener for SC service with name ServiceName.
 	ListenerName string `json:"listenerName"`
-	VIP          VIP    `json:"vip"`
+	// EgressPort represent the port number Envoy will bind to. This port is selected at random by ECS Agent during
+	// task startup. Port will be in the ephemeral range.
+	ListenerPort uint16 `json:"listenerPort,omitempty"`
+	// VIP is the representation of an SC VIP-CIDR
+	VIP VIP `json:"vip"`
 }
 
 // VIP is the representation of an SC VIP-CIDR

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -343,7 +343,13 @@ func (task *Task) PostUnmarshalTask(cfg *config.Config,
 		}
 	}
 
-	task.initServiceConnectResources()
+	if err := task.initServiceConnectResources(); err != nil {
+		logger.Error("Could not initialize Service Connect resources", logger.Fields{
+			field.TaskID: task.GetID(),
+			field.Error:  err,
+		})
+		return apierrors.NewResourceInitError(task.Arn, err)
+	}
 
 	if err := task.initializeContainerOrderingForVolumes(); err != nil {
 		logger.Error("Could not initialize volumes dependency for container", logger.Fields{
@@ -437,7 +443,7 @@ func (task *Task) PostUnmarshalTask(cfg *config.Config,
 	return nil
 }
 
-func (task *Task) initServiceConnectResources() {
+func (task *Task) initServiceConnectResources() error {
 	// TODO [SC]: ServiceConnectConfig will come from ACS. Adding this here for dev/testing purposes only Remove when
 	// ACS model is integrated
 	if task.ServiceConnectConfig == nil {
@@ -448,8 +454,12 @@ func (task *Task) initServiceConnectResources() {
 	if task.IsServiceConnectEnabled() {
 		// TODO [SC]: initDummyServiceConnectConfig is for dev testing only, remove it when final SC model from ACS is in place
 		task.initDummyServiceConnectConfig()
-		task.configureContainerDependenciesForServiceConnect()
+		task.initServiceConnectContainerDependencies()
+		if err := task.initServiceConnectEphemeralPorts(); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 // TODO [SC]: This is for dev testing only, remove it when final SC model from ACS is in place
@@ -467,7 +477,7 @@ func (task *Task) initDummyServiceConnectConfig() {
 	}
 }
 
-func (task *Task) configureContainerDependenciesForServiceConnect() {
+func (task *Task) initServiceConnectContainerDependencies() {
 	scContainer := task.GetServiceConnectContainer()
 
 	for _, container := range task.Containers {
@@ -477,6 +487,53 @@ func (task *Task) configureContainerDependenciesForServiceConnect() {
 		container.AddContainerDependency(scContainer.Name, ContainerOrderingHealthyCondition)
 		scContainer.BuildContainerDependency(container.Name, apicontainerstatus.ContainerStopped, apicontainerstatus.ContainerStopped)
 	}
+}
+
+func (task *Task) initServiceConnectEphemeralPorts() error {
+	var utilizedPorts []uint16
+	// First determine how many ephemeral ports we need
+	var numEphemeralPortsNeeded int
+	for _, ic := range task.ServiceConnectConfig.IngressConfig {
+		if ic.ListenerPort == 0 { // This means listener port was not sent to us by ACS, signaling the port needs to be ephemeral
+			numEphemeralPortsNeeded++
+		} else {
+			utilizedPorts = append(utilizedPorts, ic.ListenerPort)
+		}
+	}
+
+	// Presently, SC egress port is always ephemeral, but adding this for future-proofing
+	if task.ServiceConnectConfig.EgressConfig.ListenerPort == 0 {
+		numEphemeralPortsNeeded++
+	} else {
+		utilizedPorts = append(utilizedPorts, task.ServiceConnectConfig.EgressConfig.ListenerPort)
+	}
+
+	// Get all exposed ports in the task so that the ephemeral port generator doesn't take those into account in order
+	// to avoid port conflicts.
+	for _, c := range task.Containers {
+		for _, p := range c.Ports {
+			utilizedPorts = append(utilizedPorts, p.ContainerPort)
+		}
+	}
+
+	ephemeralPorts, err := utils.GenerateEphemeralPortNumbers(numEphemeralPortsNeeded, utilizedPorts)
+	if err != nil {
+		return fmt.Errorf("error initializing ports for Service Connect: %w", err)
+	}
+
+	// Assign ephemeral ports
+	var curEphemeralIndex int
+	for i, ic := range task.ServiceConnectConfig.IngressConfig {
+		if ic.ListenerPort == 0 {
+			task.ServiceConnectConfig.IngressConfig[i].ListenerPort = ephemeralPorts[curEphemeralIndex]
+			curEphemeralIndex++
+		}
+	}
+
+	if task.ServiceConnectConfig.EgressConfig.ListenerPort == 0 {
+		task.ServiceConnectConfig.EgressConfig.ListenerPort = ephemeralPorts[curEphemeralIndex]
+	}
+	return nil
 }
 
 // populateTaskARN populates the arn of the task to the containers.

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -57,6 +57,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const serviceConnectContainerTestName = "service-connect"
+
 func TestDockerConfigPortBinding(t *testing.T) {
 	testTask := &Task{
 		Containers: []*apicontainer.Container{
@@ -3559,7 +3561,17 @@ func TestIsServiceConnectEnabled(t *testing.T) {
 }
 
 func TestPostUnmarshalTaskWithServiceConnect(t *testing.T) {
-	const serviceConnectContainerName = "service-connect"
+	const (
+		utilizedPort1 = 33333
+		utilizedPort2 = 44444
+		utilizedPort3 = 55555
+	)
+	utilizedPorts := map[uint16]struct{}{
+		utilizedPort1: {},
+		utilizedPort2: {},
+		utilizedPort3: {},
+	}
+
 	taskFromACS := ecsacs.Task{
 		Arn:           strptr("myArn"),
 		DesiredStatus: strptr("RUNNING"),
@@ -3568,35 +3580,78 @@ func TestPostUnmarshalTaskWithServiceConnect(t *testing.T) {
 		Containers: []*ecsacs.Container{
 			{
 				Name: aws.String("C1"),
+				PortMappings: []*ecsacs.PortMapping{
+					{
+						ContainerPort: aws.Int64(utilizedPort1),
+					},
+				},
 			},
 			{
 				Name: aws.String("C2"),
+				PortMappings: []*ecsacs.PortMapping{
+					{
+						ContainerPort: aws.Int64(utilizedPort2),
+					},
+				},
 			},
 			{
-				Name: aws.String(serviceConnectContainerName),
+				Name: aws.String(serviceConnectContainerTestName),
 			},
 		},
 	}
 	seqNum := int64(42)
 	task, err := TaskFromACS(&taskFromACS, &ecsacs.PayloadMessage{SeqNum: &seqNum})
-	task.ServiceConnectConfig = &ServiceConnectConfig{
-		ContainerName: serviceConnectContainerName,
+	testSCConfig := ServiceConnectConfig{
+		ContainerName: serviceConnectContainerTestName,
+		IngressConfig: []IngressConfigEntry{
+			{
+				ListenerName: "testListener1",
+				ListenerPort: 0, // this one should get ephemeral port after PostUnmarshalTask
+			},
+			{
+				ListenerName: "testListener2",
+				ListenerPort: utilizedPort3, // this one should NOT get ephemeral port after PostUnmarshalTask
+			},
+			{
+				ListenerName: "testListener3",
+				ListenerPort: 0, // this one should get ephemeral port after PostUnmarshalTask
+			},
+		},
+		EgressConfig: EgressConfig{
+			ListenerPort: 0, // Presently this should always get ephemeral port
+		},
 	}
+	originalSCConfig := cloneSCConfig(testSCConfig)
+	task.ServiceConnectConfig = &testSCConfig
 	assert.Nil(t, err, "Should be able to handle acs task")
 	err = task.PostUnmarshalTask(&config.Config{}, nil, nil, nil, nil)
 	assert.NoError(t, err)
 
+	validateServiceConnectContainerOrder(t, task)
+	validateEphemeralPorts(t, task, originalSCConfig, utilizedPorts)
+}
+
+func cloneSCConfig(scConfig ServiceConnectConfig) ServiceConnectConfig {
+	clone := scConfig
+	clone.IngressConfig = nil
+	for _, ic := range scConfig.IngressConfig {
+		clone.IngressConfig = append(clone.IngressConfig, ic)
+	}
+	return clone
+}
+
+func validateServiceConnectContainerOrder(t *testing.T, task *Task) {
 	c1, _ := task.ContainerByName("C1")
 	c2, _ := task.ContainerByName("C2")
-	scC, _ := task.ContainerByName(serviceConnectContainerName)
+	scC, _ := task.ContainerByName(serviceConnectContainerTestName)
 
 	// Check that regular containers have a dependency on SC container becoming HEALTHY
 	assert.NotEmpty(t, c1.DependsOnUnsafe)
-	assert.Equal(t, serviceConnectContainerName, c1.DependsOnUnsafe[0].ContainerName)
+	assert.Equal(t, serviceConnectContainerTestName, c1.DependsOnUnsafe[0].ContainerName)
 	assert.Equal(t, ContainerOrderingHealthyCondition, c1.DependsOnUnsafe[0].Condition)
 
 	assert.NotEmpty(t, c2.DependsOnUnsafe)
-	assert.Equal(t, serviceConnectContainerName, c2.DependsOnUnsafe[0].ContainerName)
+	assert.Equal(t, serviceConnectContainerTestName, c2.DependsOnUnsafe[0].ContainerName)
 	assert.Equal(t, ContainerOrderingHealthyCondition, c2.DependsOnUnsafe[0].Condition)
 
 	// Check that SC container has a stop dependency on regular containers
@@ -3611,4 +3666,41 @@ func TestPostUnmarshalTaskWithServiceConnect(t *testing.T) {
 		ContainerName:   "C2",
 		SatisfiedStatus: apicontainerstatus.ContainerStopped,
 	}, scC.TransitionDependenciesMap[apicontainerstatus.ContainerStopped].ContainerDependencies[1])
+}
+
+func validateEphemeralPorts(t *testing.T, task *Task, originalSCConfig ServiceConnectConfig, utilizedPorts map[uint16]struct{}) {
+	for i, ic := range originalSCConfig.IngressConfig {
+		if ic.ListenerPort == 0 {
+			assignedPort := task.ServiceConnectConfig.IngressConfig[i].ListenerPort
+			_, ok := utilizedPorts[assignedPort]
+			assert.Falsef(t, ok, "An already-utilized port [%d] was assigned to ingress listener: %s", assignedPort, ic.ListenerName)
+			assert.NotZerof(t, assignedPort,
+				"Ephemeral port was not assigned for ingress listener: %s", ic.ListenerName)
+			utilizedPorts[assignedPort] = struct{}{}
+		} else {
+			assert.Equalf(t, ic.ListenerPort, task.ServiceConnectConfig.IngressConfig[i].ListenerPort,
+				"Ingress port incorrectly modified for listener: %s", ic.ListenerName)
+		}
+		assert.Equalf(t, ic.HostPort, task.ServiceConnectConfig.IngressConfig[i].HostPort,
+			"Ingress host port incorrectly modified for listener: %s", ic.ListenerName)
+		assert.Equalf(t, ic.InterceptPort, task.ServiceConnectConfig.IngressConfig[i].InterceptPort,
+			"Ingress intercept port incorrectly modified for listener: %s", ic.ListenerName)
+		assert.Equalf(t, ic.ListenerName, task.ServiceConnectConfig.IngressConfig[i].ListenerName,
+			"Ingress listener name incorrectly modified for listener: %s", ic.ListenerName)
+	}
+	if originalSCConfig.EgressConfig.ListenerPort == 0 {
+		assignedPort := task.ServiceConnectConfig.EgressConfig.ListenerPort
+		_, ok := utilizedPorts[assignedPort]
+		assert.Falsef(t, ok, "An already-utilized port [%d] was assigned to egress listener", assignedPort)
+		assert.NotZero(t, assignedPort,
+			"Ephemeral port was not assigned for egress listener")
+		utilizedPorts[assignedPort] = struct{}{}
+	} else {
+		assert.Equal(t, originalSCConfig.EgressConfig.ListenerPort, task.ServiceConnectConfig.EgressConfig.ListenerPort,
+			"Egress port incorrectly modified for egress listener")
+	}
+	assert.Equalf(t, originalSCConfig.EgressConfig.ListenerName, task.ServiceConnectConfig.EgressConfig.ListenerName,
+		"Egress listener name incorrectly modified")
+	assert.Equalf(t, originalSCConfig.EgressConfig.VIP, task.ServiceConnectConfig.EgressConfig.VIP,
+		"Egress VIP incorrectly modified")
 }

--- a/agent/engine/service_connect/util.go
+++ b/agent/engine/service_connect/util.go
@@ -15,17 +15,8 @@ package serviceconnect
 
 import (
 	"fmt"
-	"math/rand"
-	"time"
 
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
-)
-
-const (
-	// From https://www.kernel.org/doc/html/latest//networking/ip-sysctl.html#ip-variables
-	ephemeralPortMin         = 32768
-	ephemeralPortMax         = 60999
-	maxPortSelectionAttempts = 100
 )
 
 // DNSConfigToDockerExtraHostsFormat converts a DNSConfig to a list of ExtraHost entries that Docker will
@@ -43,32 +34,4 @@ func DNSConfigToDockerExtraHostsFormat(dnsConf apitask.DNSConfig) []string {
 		}
 	}
 	return hosts
-}
-
-// GenerateEphemeralPortNumbers generates a list of n unique port numbers in the 32768-60999 range. The resulting port
-// number list is guaranteed to not include any port number present in "exclude" parameter.
-func GenerateEphemeralPortNumbers(n int, exclude []int) ([]int, error) {
-	toExcludeSet := map[int]struct{}{}
-	for _, e := range exclude {
-		toExcludeSet[e] = struct{}{}
-	}
-	rand.Seed(time.Now().UnixNano())
-
-	var result []int
-	var portSelectionAttempts int
-	for len(result) < n {
-		// The intention of maxPortSelectionAttempts is to avoid a super highly unlikely case where we
-		// keep getting ports that collide, thus creating an infinite loop.
-		if portSelectionAttempts > maxPortSelectionAttempts {
-			return nil, fmt.Errorf("maximum number of attempts to generate unique ports reached")
-		}
-		port := rand.Intn(ephemeralPortMax-ephemeralPortMin+1) + ephemeralPortMin
-		if _, ok := toExcludeSet[port]; ok {
-			portSelectionAttempts++
-			continue
-		}
-		toExcludeSet[port] = struct{}{}
-		result = append(result, port)
-	}
-	return result, nil
 }

--- a/agent/engine/service_connect/util_test.go
+++ b/agent/engine/service_connect/util_test.go
@@ -16,7 +16,9 @@
 package serviceconnect
 
 import (
+	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/api/task"
 	"github.com/stretchr/testify/assert"
@@ -59,5 +61,33 @@ func TestDNSConfigToDockerExtraHostsFormat(t *testing.T) {
 	for _, tc := range tt {
 		res := DNSConfigToDockerExtraHostsFormat(tc.dnsConf)
 		assert.Equal(t, tc.expectedRestult, res, "Wrong docker host config ")
+	}
+}
+
+func TestGenerateEphemeralPortNumbers(t *testing.T) {
+	// This number is just to "stress" this test by increasing the changes of collision, which should not be a problem
+	// in prod, only around a dozen ports will be needed in the worst case.
+	expectedPortsGenerated := 1000
+	var excludePorts []int
+	rand.Seed(time.Now().UnixNano())
+	// Since absolute max containers for a task is 20, let's exclude 40 ports at random, 2 per container
+	// in order to make a somewhat realistic test
+	for i := 0; i < 40; i++ {
+		port := rand.Intn(ephemeralPortMax-ephemeralPortMin+1) + ephemeralPortMin
+		excludePorts = append(excludePorts, port)
+	}
+	toExcludeSet := map[int]struct{}{}
+	for _, e := range excludePorts {
+		toExcludeSet[e] = struct{}{}
+	}
+	ports, err := GenerateEphemeralPortNumbers(expectedPortsGenerated, excludePorts)
+	assert.NoError(t, err)
+	assert.Len(t, ports, expectedPortsGenerated, "Not enough ports generated")
+	for _, port := range ports {
+		_, ok := toExcludeSet[port]
+		assert.False(t, ok, "Port collision detected")
+		assert.Conditionf(t, func() (success bool) {
+			return port >= ephemeralPortMin && port <= ephemeralPortMax
+		}, "Port was generated outside the ephemeral range [%d-%d]", ephemeralPortMin, ephemeralPortMax)
 	}
 }

--- a/agent/engine/service_connect/util_test.go
+++ b/agent/engine/service_connect/util_test.go
@@ -16,9 +16,7 @@
 package serviceconnect
 
 import (
-	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/api/task"
 	"github.com/stretchr/testify/assert"
@@ -61,33 +59,5 @@ func TestDNSConfigToDockerExtraHostsFormat(t *testing.T) {
 	for _, tc := range tt {
 		res := DNSConfigToDockerExtraHostsFormat(tc.dnsConf)
 		assert.Equal(t, tc.expectedRestult, res, "Wrong docker host config ")
-	}
-}
-
-func TestGenerateEphemeralPortNumbers(t *testing.T) {
-	// This number is just to "stress" this test by increasing the changes of collision, which should not be a problem
-	// in prod, only around a dozen ports will be needed in the worst case.
-	expectedPortsGenerated := 1000
-	var excludePorts []int
-	rand.Seed(time.Now().UnixNano())
-	// Since absolute max containers for a task is 20, let's exclude 40 ports at random, 2 per container
-	// in order to make a somewhat realistic test
-	for i := 0; i < 40; i++ {
-		port := rand.Intn(ephemeralPortMax-ephemeralPortMin+1) + ephemeralPortMin
-		excludePorts = append(excludePorts, port)
-	}
-	toExcludeSet := map[int]struct{}{}
-	for _, e := range excludePorts {
-		toExcludeSet[e] = struct{}{}
-	}
-	ports, err := GenerateEphemeralPortNumbers(expectedPortsGenerated, excludePorts)
-	assert.NoError(t, err)
-	assert.Len(t, ports, expectedPortsGenerated, "Not enough ports generated")
-	for _, port := range ports {
-		_, ok := toExcludeSet[port]
-		assert.False(t, ok, "Port collision detected")
-		assert.Conditionf(t, func() (success bool) {
-			return port >= ephemeralPortMin && port <= ephemeralPortMax
-		}, "Port was generated outside the ephemeral range [%d-%d]", ephemeralPortMin, ephemeralPortMax)
 	}
 }

--- a/agent/utils/ephemeral_ports_test.go
+++ b/agent/utils/ephemeral_ports_test.go
@@ -1,0 +1,52 @@
+package utils
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateEphemeralPortNumbers(t *testing.T) {
+	// This number is just to "stress" this test by increasing the changes of collision, which should not be a problem
+	// in prod, only around a dozen ports will be needed in the worst case.
+	expectedPortsGenerated := 1000
+	var reservedPorts []uint16
+	rand.Seed(time.Now().UnixNano())
+	// Since absolute max containers for a task is 20, let's exclude 40 ports at random, 2 per container
+	// in order to make a somewhat realistic test
+	for i := 0; i < 40; i++ {
+		port := uint16(rand.Intn(EphemeralPortMax-EphemeralPortMin+1) + EphemeralPortMin)
+		reservedPorts = append(reservedPorts, port)
+	}
+	toExcludeSet := map[uint16]struct{}{}
+	for _, e := range reservedPorts {
+		toExcludeSet[e] = struct{}{}
+	}
+	ports, err := GenerateEphemeralPortNumbers(expectedPortsGenerated, reservedPorts)
+	assert.NoError(t, err)
+	assert.Len(t, ports, expectedPortsGenerated, "Not enough ports generated")
+	for _, port := range ports {
+		_, ok := toExcludeSet[port]
+		assert.False(t, ok, "Port collision detected")
+		assert.Conditionf(t, func() (success bool) {
+			return port >= EphemeralPortMin && port <= EphemeralPortMax
+		}, "Port was generated outside the ephemeral range [%d-%d]", EphemeralPortMin, EphemeralPortMax)
+	}
+}
+
+func TestGenerateEphemeralPortNumbers_CollisionError(t *testing.T) {
+	randIntFuncTmp := randIntFunc
+	defer func() {
+		randIntFunc = randIntFuncTmp
+	}()
+	// Inject mock rand.Int that always returns the same number in order to test max attempts
+	randIntFunc = func(n int) int {
+		return EphemeralPortMin
+	}
+	ports, err := GenerateEphemeralPortNumbers(100, []uint16{})
+	assert.Nil(t, ports)
+	assert.Error(t, err)
+	assert.Equal(t, "maximum number of attempts to generate unique ports reached", err.Error())
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR assigns ephemeral ports to listeners that explicitly require it. All ports in the task must be unique, these include the ones exposed in task definition.

Note that the ports generated are going to be bound in the task netns, therefore there should be no collisions. As an extra precaution, the SC CNI plugin (future PR) will reserve the ports generated in this PR using [ip_local_reserved_ports](https://www.kernel.org/doc/html/latest/networking/ip-sysctl.html) kernel feature, which should guarantee there won't be  collisions with SC ports.

### Implementation details
<!-- How are the changes implemented? -->
Currently, if `ListenerPort=0` in the `ServiceConnectConfig`, it means an ephemeral port should be assigned to that listener. Nothing else in `ServiceConnectConfig` should be modified. 

A function to generate N ephemeral ports, which excludes reserved/utilized ports is added. This function guarantees that N unique  ephemeral ports (i.e in the 32768-60999 range) will be generated, and that those ports will not collide with the reserved ports passed as an argument.



### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
N/A
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
