### PR TITLE
Building with codesuite stacks, buildspecs, mini readme

### DIFF
--- a/build-infrastructure/README.md
+++ b/build-infrastructure/README.md
@@ -1,0 +1,56 @@
+# Building the ECS Agent using AWS CodeSuite
+
+## Prerequisites
+
+There are some things you need to get this going
+
+1. Your favorite AWS region
+1. A GPG key stored in AWS Secrets Manager
+1. A passphrase for the aforementioned GPG key, also stored on AWS Secrets Manager
+1. A codestar github connection
+1. A final artifacts bucket
+
+## How to get the key and the connection
+
+Generate and export a key for yourself by running the following commands.
+
+```shell
+gpg --full-generate-key
+gpg --output private.gpg --armor --export-secret-key <email>
+```
+
+A couple of things to keep in mind. If you're using Amazon Linux, it comes with a slightly older `gpg` executable so it doesn't _yet_ support ECC keys; best bet is to pick RSA 4096-bit. You will also need a passphrase for the key because it's better security.
+
+You will then have to import this key into secrets manager. To set expectations, plaintext in the context of creating secrets means unstructured (non JSON formatted) data, rather than unencrypted data. Be sure to pick plaintext and just paste the contents of the key into the textbox without JSON encoding it. Secrets Manager encourages the use of JSON structured data but it is not required. You will also need to create a Secrets Manager secret for the passphrase the same way as above.
+
+As for the codestar connection, you can generate one of those by logging into the AWS Console, going to any of the CodeSuite services, clicking on the Settings left nav item and clicking connections. And then clicking the new button. You'll need the ARN of that connection.
+
+## Release pipeline
+
+Grab the `release-pipeline-stack.yml` file and either upload it to CloudFormation or paste it in the CloudFormation designer and create a stack. The stack will ask you for some of the information that you've created above and will generate the following resources
+
+1. A CloudWatch Logs group for the whole CodePipeline
+1. An S3 bucket used to move artifacts between the CodePipeline stages
+1. A builder CodeBuild project and corresponding IAM role
+1. A signer CodeBuild project and corresponding IAM role
+1. A copier CodeBuild project and corresponding IAM role
+1. A CodePipeline to pull these all together and corresponding IAM role
+
+Once the stack is successful, by default, the project is configured to use `buildspecs/<stage>.yml` as the CodeBuild buildspec file but you can change that by manually editing the buildspec for each CodeBuild project or putting the buildspec files in this repository in a `buildspecs` folder in the root of the repository you're building.
+
+The directory structure that is expected is as follows,
+
+```
+buildspecs/
+|- build.yml
+|- signing.yml
+|- copy.yml
+```
+
+Everything else is already set up for you.
+
+## Secrets Manager access logs
+
+There is a separate template called `audit-logs-stack.yml` that contains audit logging for the key stored in AWS Secrets Manager. You can use CloudTrail to find the `GetSecretValue` events using the Event Name filter or using `secretsmanager.amazonaws.com` as the Event Source. This applies for the last 90 days.
+
+The events also get delivered to CloudWatch Logs to act as an archive for the last 180 days by default but can be configured to keep those events around for longer if necessary.

--- a/build-infrastructure/audit-logs-stack.yml
+++ b/build-infrastructure/audit-logs-stack.yml
@@ -54,13 +54,16 @@ Resources:
       PolicyDocument:
         Version: 2012-10-17
         Statement:
-          - Sid: CloudTrailBucketAclAccess
+          - Sid: AWSCloudTrailAclCheck20150319
             Effect: Allow
             Principal:
               Service: cloudtrail.amazonaws.com
             Action: s3:GetBucketAcl
-            Resource: !Sub "cloudtrail-audit-logs-bucket-${AWS::AccountId}"
-          - Sid: CloudTrailBucketWriteAccess
+            Resource: !Sub "arn:aws:s3:::audit-logs-bucket-${AWS::AccountId}"
+            Condition:
+              StringEquals:
+                AWS:SourceArn: !Sub "arn:aws:cloudtrail:${AWS::Region}:${AWS::AccountId}:trail/${KeyAccessTrailName}"
+          - Sid: AWSCloudTrailWrite20150319
             Effect: Allow
             Principal:
               Service: cloudtrail.amazonaws.com
@@ -69,7 +72,7 @@ Resources:
             Condition:
               StringEquals:
                 s3:x-amz-acl: bucket-owner-full-control
-                aws:SourceArn: !Sub "arn:aws:cloudtrail:${AWS::Region}:${AWS::AccountId}:trail/${KeyAccessTrailName}"
+                AWS:SourceArn: !Sub "arn:aws:cloudtrail:${AWS::Region}:${AWS::AccountId}:trail/${KeyAccessTrailName}"
 
   KeyAccessCloudTrailCloudWatchLogsRole:
     Type: AWS::IAM::Role

--- a/build-infrastructure/audit-logs-stack.yml
+++ b/build-infrastructure/audit-logs-stack.yml
@@ -1,0 +1,118 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Description: A template that creates an audit log and associated logs and buckets
+
+Parameters:
+  KeyAccessTrailName:
+    Type: String
+    Description: The name of the CloudWatch Trail that stores the audit logs
+    Default: key-access-trail
+  KeyAccessAuditLogGroupName:
+    Type: String
+    Description: The name of the log group to push audit logs to
+    Default: key-access-logs
+  LogGroupRetentionPeriodInDays:
+    Type: Number
+    Description: The number of days to retain cloudwatch logs
+    Default: 180
+    AllowedValues:
+      - 1
+      - 3
+      - 5
+      - 7
+      - 14
+      - 30
+      - 60
+      - 90
+      - 120
+      - 150
+      - 180
+      - 365
+      - 400
+      - 545
+      - 731
+      - 1827
+      - 3653
+
+Resources:
+  KeyAccessAuditLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Ref KeyAccessAuditLogGroupName
+      RetentionInDays: !Ref LogGroupRetentionPeriodInDays
+
+  AuditLogsBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub "audit-logs-bucket-${AWS::AccountId}"
+
+  AuditLogsBucketPolicy:
+    DependsOn: AuditLogsBucket
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Sub "audit-logs-bucket-${AWS::AccountId}"
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: CloudTrailBucketAclAccess
+            Effect: Allow
+            Principal:
+              Service: cloudtrail.amazonaws.com
+            Action: s3:GetBucketAcl
+            Resource: !Sub "cloudtrail-audit-logs-bucket-${AWS::AccountId}"
+          - Sid: CloudTrailBucketWriteAccess
+            Effect: Allow
+            Principal:
+              Service: cloudtrail.amazonaws.com
+            Action: s3:PutObject
+            Resource: !Sub "arn:aws:s3:::audit-logs-bucket-${AWS::AccountId}/AWSLogs/${AWS::AccountId}/*"
+            Condition:
+              StringEquals:
+                s3:x-amz-acl: bucket-owner-full-control
+                aws:SourceArn: !Sub "arn:aws:cloudtrail:${AWS::Region}:${AWS::AccountId}:trail/${KeyAccessTrailName}"
+
+  KeyAccessCloudTrailCloudWatchLogsRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "key-access-cloudtrail-service-role-${AWS::Region}"
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          Effect: Allow
+          Principal:
+            Service: cloudtrail.amazonaws.com
+          Action: sts:AssumeRole
+      Policies:
+        - PolicyName: cloudtail-audit-log-base-policy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Sid: CloudTrailLogStreamAccess
+                Effect: Allow
+                Action:
+                  - logs:CreateLogStream
+                Resource:
+                  - !GetAtt KeyAccessAuditLogGroup.Arn
+                  - !Sub "${KeyAccessAuditLogGroup.Arn}:*"
+              - Sid: CloudTrailLogStreamEventAccess
+                Effect: Allow
+                Action:
+                  - logs:PutLogEvents
+                Resource:
+                  - !GetAtt KeyAccessAuditLogGroup.Arn
+                  - !Sub "${KeyAccessAuditLogGroup.Arn}:*"
+
+  KeyAccessCloudTrailAuditLog:
+    DependsOn:
+      - AuditLogsBucketPolicy
+      - AuditLogsBucket
+    Type: AWS::CloudTrail::Trail
+    Properties:
+      CloudWatchLogsLogGroupArn: !GetAtt KeyAccessAuditLogGroup.Arn
+      CloudWatchLogsRoleArn: !GetAtt KeyAccessCloudTrailCloudWatchLogsRole.Arn
+      EnableLogFileValidation: true
+      IncludeGlobalServiceEvents: true
+      IsLogging: true
+      IsMultiRegionTrail: true
+      TrailName: !Ref KeyAccessTrailName
+      S3BucketName: !Sub "audit-logs-bucket-${AWS::AccountId}"

--- a/build-infrastructure/release-pipeline-stack.yml
+++ b/build-infrastructure/release-pipeline-stack.yml
@@ -237,7 +237,7 @@ Resources:
           - Name: PASSPHRASE
             Type: SECRETS_MANAGER
             Value: !Ref PassphraseArn
-          - Name: SECRET_KEY_ARN
+          - Name: PRIVATE_KEY_ARN
             Type: PLAINTEXT
             Value: !Ref SecretKeyArn
       Source:
@@ -401,6 +401,7 @@ Resources:
                 ConnectionArn: !Ref CodeStarConnectionArn
                 FullRepositoryId: !Ref GithubFullRepoName
                 BranchName: !Ref GithubBranchName
+                OutputArtifactFormat: CODEBUILD_CLONE_REF
               OutputArtifacts:
                 - Name: SourceArtifact
               RunOrder: 1

--- a/build-infrastructure/release-pipeline-stack.yml
+++ b/build-infrastructure/release-pipeline-stack.yml
@@ -1,0 +1,453 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Description: A template that brings up a code pipeline that builds and signs artifacts
+
+Parameters:
+  BuildAndSignCodePipelineName:
+    Type: String
+    Description: The name of the code pipeline
+    Default: artifact-build-sign-pipeline
+  BuildCodeBuildProjectName:
+    Type: String
+    Description: The name of the build project
+    Default: artifact-build
+  SigningCodeBuildProjectName:
+    Type: String
+    Description: The name of the signing project
+    Default: artifact-sign
+  CopyCodeBuildProjectName:
+    Type: String
+    Description: The name of the copy project
+    Default: artifact-copy
+  CodeBuildLogGroupName:
+    Type: String
+    Description: The name of the log group to push build logs to
+    Default: build-and-sign-logs
+  LogGroupRetentionPeriodInDays:
+    Type: Number
+    Description: The number of days to retain cloudwatch logs
+    Default: 180
+    AllowedValues:
+      - 1
+      - 3
+      - 5
+      - 7
+      - 14
+      - 30
+      - 60
+      - 90
+      - 120
+      - 150
+      - 180
+      - 365
+      - 400
+      - 545
+      - 731
+      - 1827
+      - 3653
+  ReleaseArtifactsBucketArn:
+    Type: String
+    Description: The ARN of the bucket where things land at the end, this is assumed to already exist
+  ReleaseArtifactsBucketS3Uri:
+    Type: String
+    Description: The URI of the bucket where things land at the end, this is assumed to already exist
+  CodeStarConnectionArn:
+    Type: String
+    Description: The ARN of the connection to use to connect to GitHub
+  GithubFullRepoName:
+    Type: String
+    Description: The name of the repository that we want to use
+  GithubBranchName:
+    Type: String
+    Description: The name of the branch to use to build
+  SecretKeyArn:
+    Type: String
+    Description: The ARN of the secret key
+  PassphraseArn:
+    Type: String
+    Description: The ARN of the passphrase
+
+Resources:
+  CodeBuildLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Ref CodeBuildLogGroupName
+      RetentionInDays: !Ref LogGroupRetentionPeriodInDays
+
+  BuildAndSignCodePipelineArtifactBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub "codepipeline-${AWS::Region}-${AWS::AccountId}-artifacts"
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+
+  BuildCodeBuildProjectServiceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "build-codebuild-project-service-role-${AWS::Region}"
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          Effect: Allow
+          Principal:
+            Service: codebuild.amazonaws.com
+          Action: sts:AssumeRole
+      Policies:
+        - PolicyName: codebuild-build-base-policy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Sid: CloudWatchLogsAccess
+                Effect: Allow
+                Resource:
+                  - !GetAtt CodeBuildLogGroup.Arn
+                  - !Sub "${CodeBuildLogGroup.Arn}:*"
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+              - Sid: ArtifactBucketAccess
+                Effect: Allow
+                Resource:
+                  - !Sub "arn:aws:s3:::codepipeline-${AWS::Region}-*"
+                Action:
+                  - s3:PutObject
+                  - s3:GetObject
+                  - s3:GetObjectVersion
+                  - s3:GetBucketAcl
+                  - s3:GetBucketLocation
+              - Sid: CodeBuildCodeStarConnectionAccess
+                Effect: Allow
+                Resource:
+                  - !Ref CodeStarConnectionArn
+                Action:
+                  - codestar-connections:UseConnection
+              - Sid: CodeBuildCreateReportAccess
+                Effect: Allow
+                Resource:
+                  - !Sub "arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:report-group/${BuildCodeBuildProjectName}-*"
+                Action:
+                  - codebuild:CreateReportGroup
+                  - codebuild:CreateReport
+                  - codebuild:UpdateReport
+                  - codebuild:BatchPutTestCases
+                  - codebuild:BatchPutCodeCoverages
+
+  BuildCodeBuildProject:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Artifacts:
+        Type: CODEPIPELINE
+      ConcurrentBuildLimit: 10
+      Description: A sample agent build on pr
+      Environment:
+        ComputeType: BUILD_GENERAL1_SMALL
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+        ImagePullCredentialsType: CODEBUILD
+        PrivilegedMode: true
+        Type: LINUX_CONTAINER
+      LogsConfig:
+        CloudWatchLogs:
+          GroupName: !Ref CodeBuildLogGroupName
+          Status: ENABLED
+          StreamName: build
+      Name: !Ref BuildCodeBuildProjectName
+      QueuedTimeoutInMinutes: 60
+      ServiceRole: !Ref BuildCodeBuildProjectServiceRole
+      Source:
+        BuildSpec: buildspecs/build.yml
+        Type: CODEPIPELINE
+      TimeoutInMinutes: 60
+
+  SigningCodeBuildProjectServiceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "signing-codebuild-project-service-role-${AWS::Region}"
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          Effect: Allow
+          Principal:
+            Service: codebuild.amazonaws.com
+          Action: sts:AssumeRole
+      Policies:
+        - PolicyName: codebuild-signing-base-policy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Sid: CloudWatchLogsAccess
+                Effect: Allow
+                Resource:
+                  - !GetAtt CodeBuildLogGroup.Arn
+                  - !Sub "${CodeBuildLogGroup.Arn}:*"
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+              - Sid: ArtifactBucketAccess
+                Effect: Allow
+                Resource:
+                  - !Sub "arn:aws:s3:::codepipeline-${AWS::Region}-*"
+                Action:
+                  - s3:PutObject
+                  - s3:GetObject
+                  - s3:GetObjectVersion
+                  - s3:GetBucketAcl
+                  - s3:GetBucketLocation
+              - Sid: CodeBuildCreateReportAccess
+                Effect: Allow
+                Resource:
+                  - !Sub "arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:report-group/${SigningCodeBuildProjectName}-*"
+                Action:
+                  - codebuild:CreateReportGroup
+                  - codebuild:CreateReport
+                  - codebuild:UpdateReport
+                  - codebuild:BatchPutTestCases
+                  - codebuild:BatchPutCodeCoverages
+        - PolicyName: codebuild-secretsmanager-policy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Sid: SecretsManagerAccess
+                Effect: Allow
+                Action:
+                  - secretsmanager:GetSecretValue
+                Resource:
+                  - !Ref SecretKeyArn
+                  - !Ref PassphraseArn
+
+  SigningCodeBuildProject:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Name: !Ref SigningCodeBuildProjectName
+      Description: A CodeBuild project that signs given artifacts
+      ConcurrentBuildLimit: 10
+      ServiceRole: !GetAtt SigningCodeBuildProjectServiceRole.Arn
+      Artifacts:
+        Type: CODEPIPELINE
+      Environment:
+        Type: LINUX_CONTAINER
+        ComputeType: BUILD_GENERAL1_SMALL
+        ImagePullCredentialsType: CODEBUILD
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+        EnvironmentVariables:
+          - Name: PASSPHRASE
+            Type: SECRETS_MANAGER
+            Value: !Ref PassphraseArn
+          - Name: SECRET_KEY_ARN
+            Type: PLAINTEXT
+            Value: !Ref SecretKeyArn
+      Source:
+        BuildSpec: buildspecs/signing.yml
+        Type: CODEPIPELINE
+      TimeoutInMinutes: 60
+      QueuedTimeoutInMinutes: 480
+      LogsConfig:
+        CloudWatchLogs:
+          GroupName: !Ref CodeBuildLogGroupName
+          Status: ENABLED
+          StreamName: signing
+
+  CopyCodeBuildProjectServiceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "copy-codebuild-project-service-role-${AWS::Region}"
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          Effect: Allow
+          Principal:
+            Service: codebuild.amazonaws.com
+          Action: sts:AssumeRole
+      Policies:
+        - PolicyName: codebuild-copy-base-policy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Sid: CloudWatchLogsAccess
+                Effect: Allow
+                Resource:
+                  - !GetAtt CodeBuildLogGroup.Arn
+                  - !Sub "${CodeBuildLogGroup.Arn}:*"
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+              - Sid: ArtifactBucketAccess
+                Effect: Allow
+                Resource:
+                  - !Sub "arn:aws:s3:::codepipeline-${AWS::Region}-*"
+                Action:
+                  - s3:PutObject
+                  - s3:GetObject
+                  - s3:GetObjectVersion
+                  - s3:GetBucketAcl
+                  - s3:GetBucketLocation
+              - Sid: ResultsBucketAccess
+                Effect: Allow
+                Resource:
+                  - !Ref ReleaseArtifactsBucketArn
+                  - !Sub "${ReleaseArtifactsBucketArn}/*"
+                Action: s3:*
+              - Sid: CodeBuildCreateReportAccess
+                Effect: Allow
+                Resource:
+                  - !Sub "arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:report-group/${CopyCodeBuildProjectName}-*"
+                Action:
+                  - codebuild:CreateReportGroup
+                  - codebuild:CreateReport
+                  - codebuild:UpdateReport
+                  - codebuild:BatchPutTestCases
+                  - codebuild:BatchPutCodeCoverages
+
+  CopyCodeBuildProject:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Name: !Ref CopyCodeBuildProjectName
+      Description: A CodeBuild project that copies given artifacts
+      ConcurrentBuildLimit: 10
+      ServiceRole: !GetAtt CopyCodeBuildProjectServiceRole.Arn
+      Artifacts:
+        Type: CODEPIPELINE
+      Environment:
+        Type: LINUX_CONTAINER
+        ComputeType: BUILD_GENERAL1_SMALL
+        ImagePullCredentialsType: CODEBUILD
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+        EnvironmentVariables:
+          - Name: RESULTS_BUCKET_URI
+            Type: PLAINTEXT
+            Value: !Ref ReleaseArtifactsBucketS3Uri
+      Source:
+        BuildSpec: buildspecs/copy.yml
+        Type: CODEPIPELINE
+      TimeoutInMinutes: 60
+      QueuedTimeoutInMinutes: 480
+      LogsConfig:
+        CloudWatchLogs:
+          GroupName: !Ref CodeBuildLogGroupName
+          Status: ENABLED
+          StreamName: copy
+
+  BuildAndSignCodePipelineServiceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "build-and-sign-codepipeline-service-role-${AWS::Region}"
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          Effect: Allow
+          Principal:
+            Service: codepipeline.amazonaws.com
+          Action: sts:AssumeRole
+      Policies:
+        - PolicyName: build-and-sign-codepipeline-base-policy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Sid: CodePipelinePassRoleAccess
+                Effect: Allow
+                Resource: "*"
+                Action:
+                  - iam:PassRole
+                Condition:
+                  StringEqualsIfExists:
+                    iam:PassedToService:
+                      - cloudformation.amazonaws.com
+                      - elasticbeanstalk.amazonaws.com
+                      - ec2.amazonaws.com
+                      - ecs-tasks.amazonaws.com
+              - Sid: CodePipelineGithubConnectionsAccess
+                Effect: Allow
+                Resource: "*"
+                Action:
+                  - codestar-connections:UseConnection
+              - Sid: CodePipelineReadAndWriteToS3Access
+                Effect: Allow
+                Resource: "*"
+                Action:
+                  - s3:*
+              - Sid: CodePipelineCodeBuildAccess
+                Effect: Allow
+                Resource: "*"
+                Action:
+                  - codebuild:BatchGetBuilds
+                  - codebuild:StartBuild
+                  - codebuild:BatchGetBuildBatches
+                  - codebuild:StartBuildBatch
+
+  BuildAndSignCodePipeline:
+    Type: AWS::CodePipeline::Pipeline
+    Properties:
+      Name: !Ref BuildAndSignCodePipelineName
+      RoleArn: !GetAtt BuildAndSignCodePipelineServiceRole.Arn
+      ArtifactStore:
+        Type: S3
+        Location: !Sub "codepipeline-${AWS::Region}-${AWS::AccountId}-artifacts"
+      Stages:
+        - Name: Source
+          Actions:
+            - Name: Github
+              InputArtifacts: []
+              ActionTypeId:
+                Category: Source
+                Owner: AWS
+                Version: "1"
+                Provider: CodeStarSourceConnection
+              Configuration:
+                ConnectionArn: !Ref CodeStarConnectionArn
+                FullRepositoryId: !Ref GithubFullRepoName
+                BranchName: !Ref GithubBranchName
+              OutputArtifacts:
+                - Name: SourceArtifact
+              RunOrder: 1
+              Namespace: SourceVariables
+        - Name: Build
+          Actions:
+            - Name: Make
+              InputArtifacts:
+                - Name: SourceArtifact
+              ActionTypeId:
+                Category: Build
+                Owner: AWS
+                Version: "1"
+                Provider: CodeBuild
+              Configuration:
+                ProjectName: !Ref BuildCodeBuildProject
+                EnvironmentVariables: '[{"name":"GIT_COMMIT_SHA","value":"#{SourceVariables.CommitId}","type":"PLAINTEXT"}]'
+              OutputArtifacts:
+                - Name: BuildArtifact
+              RunOrder: 1
+        - Name: Sign
+          Actions:
+            - Name: GPG
+              InputArtifacts:
+                - Name: BuildArtifact
+              ActionTypeId:
+                Category: Build
+                Owner: AWS
+                Version: "1"
+                Provider: CodeBuild
+              Configuration:
+                ProjectName: !Ref SigningCodeBuildProject
+                EnvironmentVariables: '[{"name":"GIT_COMMIT_SHA","value":"#{SourceVariables.CommitId}","type":"PLAINTEXT"}]'
+              OutputArtifacts:
+                - Name: SignedArtifact
+              RunOrder: 1
+        - Name: Copy
+          Actions:
+            - Name: ToS3
+              InputArtifacts:
+                - Name: SignedArtifact
+              ActionTypeId:
+                Category: Build
+                Owner: AWS
+                Version: "1"
+                Provider: CodeBuild
+              Configuration:
+                ProjectName: !Ref CopyCodeBuildProject
+                EnvironmentVariables: '[{"name":"GIT_COMMIT_SHA","value":"#{SourceVariables.CommitId}","type":"PLAINTEXT"}]'
+              RunOrder: 1

--- a/buildspecs/build.yml
+++ b/buildspecs/build.yml
@@ -1,0 +1,20 @@
+version: 0.2
+
+env:
+  git-credential-helper: yes
+  variables:
+    ECS_AGENT_IMAGE: amazon/amazon-ecs-agent:latest
+    ECS_AGENT_TAR: ecs-agent.tar
+
+phases:
+  build:
+    commands:
+      - echo Building agent image
+      - make release
+  post_build:
+    commands:
+      - echo Saving image $ECS_AGENT_IMAGE to tar $ECS_AGENT_TAR
+      - docker save $ECS_AGENT_IMAGE > $ECS_AGENT_TAR
+artifacts:
+  files:
+    - $ECS_AGENT_TAR

--- a/buildspecs/copy.yml
+++ b/buildspecs/copy.yml
@@ -1,0 +1,13 @@
+version: 0.2
+
+env:
+  variables:
+    ECS_AGENT_TAR: ecs-agent.tar
+    ECS_AGENT_TAR_SIGNATURE: ecs-agent.tar.asc
+
+phases:
+  build:
+    commands:
+      # copy the artifacts out to the results bucket
+      - aws s3 cp $ECS_AGENT_TAR "${RESULTS_BUCKET_URI}/${GIT_COMMIT_SHA}/${ECS_AGENT_TAR}"
+      - aws s3 cp $ECS_AGENT_TAR_SIGNATURE "${RESULTS_BUCKET_URI}/${GIT_COMMIT_SHA}/${ECS_AGENT_TAR_SIGNATURE}"

--- a/buildspecs/signing.yml
+++ b/buildspecs/signing.yml
@@ -1,0 +1,34 @@
+version: 0.2
+
+# About this buildspec
+# It derives the region from AWS_REGION which the AWS CLI is automatically programmed
+# to do so we don't set a region specifically.
+# $PASSPHRASE gets pulled from secretsmanager because codebuild can pull secrets from secretsmanager
+# as an integration point. This does require the codebuild role to have proper permissions.
+# $PRIVATE_KEY_ARN is pulled from the environment as well. This is something that will probably
+# be specified by the CloudFormation template that this becomes a part of.
+
+env:
+  variables:
+    ECS_AGENT_TAR: ecs-agent.tar
+    ECS_AGENT_TAR_SIGNATURE: ecs-agent.tar.asc
+
+phases:
+  build:
+    commands:
+      # Get the private key from secrets manager, jq parse it, turn it into raw output, pipe to file
+      - aws secretsmanager get-secret-value --secret-id $PRIVATE_KEY_ARN | jq -r '.SecretString' > private.gpg
+      # import the key into the keychain, the private key comes with the public key built in
+      - gpg --allow-secret-key-import --import private.gpg
+      # remove the private key file because we don't want it to be packaged with the artifacts
+      - rm private.gpg
+      # Echo some status
+      - echo "Signing $ECS_AGENT_TAR"
+      # Sign the file
+      - gpg --detach-sign --batch --passphrase $PASSPHRASE --armor --output $ECS_AGENT_TAR_SIGNATURE $ECS_AGENT_TAR
+      # Echo some more status
+      - echo "Signed $ECS_AGENT_TAR"
+artifacts:
+  files:
+    - $ECS_AGENT_TAR
+    - $ECS_AGENT_TAR_SIGNATURE


### PR DESCRIPTION
### Summary
Enables building with AWS CodeSuite products

### Implementation details
- a cloudformation stack for the release pipeline
- uses codepipeline and codebuild
- a cloudformation stack to create audit logs for the secrets manager key
- buildspecs for each stage of the pipeline

### Testing
- manual stack creation and pipeline execution in own AWS account

New tests cover the changes: no, it's not a code change, just an infrastructure change

### Description for the changelog
Feature - enable building with AWS CodeBuild and CodePipeline

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
