### PR TITLE
Sc init appnet agent

### DIFF
--- a/agent/api/task/service_connect.go
+++ b/agent/api/task/service_connect.go
@@ -19,13 +19,12 @@ type ServiceConnectConfig struct {
 	StatsConfig   StatsConfig          `json:"statsConfig"`
 	IngressConfig []IngressConfigEntry `json:"ingressConfig"`
 	EgressConfig  EgressConfig         `json:"egressConfig"`
-	DNSConfig     DNSConfig            `json:"dnsConfig"`
+	DNSConfig     []DNSConfigEntry     `json:"dnsConfig"`
 }
 
 // StatsConfig is the endpoint where SC stats can be retrieved from.
 type StatsConfig struct {
-	UrlPath string `json:"urlPath,omitempty"`
-	Port    uint16 `json:"port,omitempty"`
+	Path string `json:"path"`
 }
 
 // IngressConfigEntry is the ingress configuration for a given SC service.
@@ -56,17 +55,13 @@ type EgressConfig struct {
 // VIP is the representation of an SC VIP-CIDR
 // e.g. 169.254.0.0/16
 type VIP struct {
-	IPV4 string `json:"ipv4,omitempty"`
-	IPV6 string `json:"ipv6,omitempty"`
+	IPV4CIDR string `json:"ipv4Cidr,omitempty"`
+	IPV6CIDR string `json:"ipv6Cidr,omitempty"`
 }
 
-// DNSConfig is a list of DNSConfigEntry's
-type DNSConfig []DNSConfigEntry
-
 // DNSConfigEntry represents a mapping between a VIP in the SC VIP-CIDR and an upstream SC service.
-// e.g. DummySCService.corp.local -> 169.254.1.1
+// e.g. DummySCService.my.corp -> 169.254.1.1
 type DNSConfigEntry struct {
-	HostName    string `json:"hostName"`
-	IPV4Address string `json:"ipv4Address,omitempty"`
-	IPV6Address string `json:"ipv6Address,omitempty"`
+	HostName string `json:"hostName"`
+	Address  string `json:"address"`
 }

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -145,6 +145,8 @@ const (
 	disableIPv6SysctlKey = "net.ipv6.conf.all.disable_ipv6"
 	// sysctlValueOff specifies the value to use to turn off a sysctl setting.
 	sysctlValueOff = "0"
+
+	serviceConnectListenerPortMappingEnvVar = "APPNET_LISTENER_PORT_MAPPING"
 )
 
 // TaskOverrides are the overrides applied to a task
@@ -522,17 +524,29 @@ func (task *Task) initServiceConnectEphemeralPorts() error {
 	}
 
 	// Assign ephemeral ports
+	portMapping := make(map[string]uint16)
 	var curEphemeralIndex int
 	for i, ic := range task.ServiceConnectConfig.IngressConfig {
 		if ic.ListenerPort == 0 {
+			portMapping[ic.ListenerName] = ephemeralPorts[curEphemeralIndex]
 			task.ServiceConnectConfig.IngressConfig[i].ListenerPort = ephemeralPorts[curEphemeralIndex]
 			curEphemeralIndex++
 		}
 	}
 
 	if task.ServiceConnectConfig.EgressConfig.ListenerPort == 0 {
+		portMapping[task.ServiceConnectConfig.EgressConfig.ListenerName] = ephemeralPorts[curEphemeralIndex]
 		task.ServiceConnectConfig.EgressConfig.ListenerPort = ephemeralPorts[curEphemeralIndex]
 	}
+
+	// Add the APPNET_LISTENER_PORT_MAPPING env var for listeners that require it
+	envVars := make(map[string]string)
+	portMappingJson, err := json.Marshal(portMapping)
+	if err != nil {
+		return fmt.Errorf("error injecting required env vars to Service Connect container: %w", err)
+	}
+	envVars[serviceConnectListenerPortMappingEnvVar] = string(portMappingJson)
+	task.GetServiceConnectContainer().MergeEnvironmentVariables(envVars)
 	return nil
 }
 

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -3618,6 +3618,7 @@ func TestPostUnmarshalTaskWithServiceConnect(t *testing.T) {
 			},
 		},
 		EgressConfig: EgressConfig{
+			ListenerName: "testEgressListener",
 			ListenerPort: 0, // Presently this should always get ephemeral port
 		},
 	}
@@ -3629,6 +3630,8 @@ func TestPostUnmarshalTaskWithServiceConnect(t *testing.T) {
 
 	validateServiceConnectContainerOrder(t, task)
 	validateEphemeralPorts(t, task, originalSCConfig, utilizedPorts)
+	validateAppnetEnvVars(t, task)
+
 }
 
 func cloneSCConfig(scConfig ServiceConnectConfig) ServiceConnectConfig {
@@ -3703,4 +3706,24 @@ func validateEphemeralPorts(t *testing.T, task *Task, originalSCConfig ServiceCo
 		"Egress listener name incorrectly modified")
 	assert.Equalf(t, originalSCConfig.EgressConfig.VIP, task.ServiceConnectConfig.EgressConfig.VIP,
 		"Egress VIP incorrectly modified")
+}
+
+func validateAppnetEnvVars(t *testing.T, task *Task) {
+	// Validate the env vars were injected to SC container
+	for _, c := range task.Containers {
+		if c.Name != serviceConnectContainerTestName {
+			continue
+		}
+		portMappingStr := c.Environment["APPNET_LISTENER_PORT_MAPPING"]
+		// TODO [SC]: this map probably needs to change to the real Appnet model when it's ready
+		portMapping := make(map[string]int)
+		err := json.Unmarshal([]byte(portMappingStr), &portMapping)
+		assert.NoError(t, err, "Error parsing APPNET_LISTENER_PORT_MAPPING")
+		listener1 := task.ServiceConnectConfig.IngressConfig[0]
+		listener3 := task.ServiceConnectConfig.IngressConfig[2]
+		egressListener := task.ServiceConnectConfig.EgressConfig
+		assert.Equalf(t, int(listener1.ListenerPort), portMapping[listener1.ListenerName], "Listener-port mapping incorrectly configured for %s", listener1.ListenerName)
+		assert.Equalf(t, int(listener3.ListenerPort), portMapping[listener3.ListenerName], "Listener-port mapping incorrectly configured for %s", listener3.ListenerName)
+		assert.Equalf(t, int(egressListener.ListenerPort), portMapping[egressListener.ListenerName], "Listener-port mapping incorrectly configured for %s", egressListener.ListenerName)
+	}
 }

--- a/agent/engine/docker_task_engine_linux_test.go
+++ b/agent/engine/docker_task_engine_linux_test.go
@@ -883,9 +883,12 @@ func TestPauseContainerWitServiceConnect(t *testing.T) {
 		ContainerName: "service-connect",
 		DNSConfig: []apitask.DNSConfigEntry{
 			{
-				HostName:    "host1.my.corp",
-				IPV4Address: "169.254.1.1",
-				IPV6Address: "ff06::c4",
+				HostName: "host1.my.corp",
+				Address:  "169.254.1.1",
+			},
+			{
+				HostName: "host1.my.corp",
+				Address:  "ff06::c4",
 			},
 		},
 	}

--- a/agent/engine/service_connect/util.go
+++ b/agent/engine/service_connect/util.go
@@ -19,18 +19,14 @@ import (
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 )
 
-// DNSConfigToDockerExtraHostsFormat converts a DNSConfig to a list of ExtraHost entries that Docker will
+// DNSConfigToDockerExtraHostsFormat converts a []DNSConfigEntry slice to a list of ExtraHost entries that Docker will
 // recognize.
-func DNSConfigToDockerExtraHostsFormat(dnsConf apitask.DNSConfig) []string {
+func DNSConfigToDockerExtraHostsFormat(dnsConfigs []apitask.DNSConfigEntry) []string {
 	var hosts []string
-	for _, vipConf := range dnsConf {
-		if len(vipConf.IPV4Address) > 0 {
+	for _, dnsConf := range dnsConfigs {
+		if len(dnsConf.Address) > 0 {
 			hosts = append(hosts,
-				fmt.Sprintf("%s:%s", vipConf.HostName, vipConf.IPV4Address))
-		}
-		if len(vipConf.IPV6Address) > 0 {
-			hosts = append(hosts,
-				fmt.Sprintf("%s:%s", vipConf.HostName, vipConf.IPV6Address))
+				fmt.Sprintf("%s:%s", dnsConf.HostName, dnsConf.Address))
 		}
 	}
 	return hosts

--- a/agent/engine/service_connect/util_test.go
+++ b/agent/engine/service_connect/util_test.go
@@ -24,40 +24,33 @@ import (
 
 func TestDNSConfigToDockerExtraHostsFormat(t *testing.T) {
 	tt := []struct {
-		dnsConf         task.DNSConfig
+		dnsConfigs      []task.DNSConfigEntry
 		expectedRestult []string
 	}{
 		{
-			dnsConf: task.DNSConfig{
+			dnsConfigs: []task.DNSConfigEntry{
 				{
-					HostName:    "my.test.host",
-					IPV4Address: "169.254.1.1",
+					HostName: "my.test.host",
+					Address:  "169.254.1.1",
 				},
 				{
-					HostName:    "my.test.host2",
-					IPV6Address: "ff06::c3",
-				},
-				{
-					HostName:    "my.test.host3",
-					IPV4Address: "169.254.1.2",
-					IPV6Address: "ff06::c4",
+					HostName: "my.test.host2",
+					Address:  "ff06::c3",
 				},
 			},
 			expectedRestult: []string{
 				"my.test.host:169.254.1.1",
 				"my.test.host2:ff06::c3",
-				"my.test.host3:169.254.1.2",
-				"my.test.host3:ff06::c4",
 			},
 		},
 		{
-			dnsConf:         nil,
+			dnsConfigs:      nil,
 			expectedRestult: nil,
 		},
 	}
 
 	for _, tc := range tt {
-		res := DNSConfigToDockerExtraHostsFormat(tc.dnsConf)
+		res := DNSConfigToDockerExtraHostsFormat(tc.dnsConfigs)
 		assert.Equal(t, tc.expectedRestult, res, "Wrong docker host config ")
 	}
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

* Change Service Connect internal model to reflect latest changes made by Appnet
* Inject `APPNET_LISTENER_PORT_MAPPING` with the mapping of listener name to ephemeral port

### Implementation details
We create a `map[string]uint16` to map listener names to ephemeral port, for listeners that required it. The map is then serialized to JSON and injected to the Service Connect container environment variable: `APPNET_LISTENER_PORT_MAPPING`

For example, let's say `listener_1` got ephemeral port `44444`, and `egress_listener` got port `55555`, then the Service Conenct container should see the following env var when it runs:

`APPNET_LISTENER_PORT_MAPPING="{\"listener_1\":44444, \"egress_listener\":55555}"`

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
