### PR TITLE
Refactor to clearly identify pause container code paths for awsvpc mode

### DIFF
--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -141,6 +141,9 @@ const (
 	// specifies awsvpc type mode for a task
 	AWSVPCNetworkMode = "awsvpc"
 
+	// specifies host type mode for a task
+	HostNetworkMode = "host"
+
 	// disableIPv6SysctlKey specifies the setting that controls whether ipv6 is disabled.
 	disableIPv6SysctlKey = "net.ipv6.conf.all.disable_ipv6"
 	// sysctlValueOff specifies the value to use to turn off a sysctl setting.
@@ -277,7 +280,9 @@ type Task struct {
 	// setIdOnce is used to set the value of this task's id only the first time GetID is invoked
 	setIdOnce sync.Once
 
-	ServiceConnectConfig *ServiceConnectConfig `json:"serviceConnectConfig,omitempty"`
+	ServiceConnectConfig *ServiceConnectConfig `json:"ServiceConnectConfig,omitempty"`
+
+	NetworkMode string `json:"NetworkMode,omitempty"`
 }
 
 // TaskFromACS translates ecsacs.Task to apitask.Task by first marshaling the received
@@ -332,6 +337,9 @@ func (task *Task) initializeVolumes(cfg *config.Config, dockerClient dockerapi.D
 func (task *Task) PostUnmarshalTask(cfg *config.Config,
 	credentialsManager credentials.Manager, resourceFields *taskresource.ResourceFields,
 	dockerClient dockerapi.DockerClient, ctx context.Context, options ...Option) error {
+
+	task.initNetworkMode()
+
 	// TODO, add rudimentary plugin support and call any plugins that want to
 	// hook into this
 	task.adjustForPlatform(cfg)
@@ -443,6 +451,34 @@ func (task *Task) PostUnmarshalTask(cfg *config.Config,
 		}
 	}
 	return nil
+}
+
+// initNetworkMode initializes/infers the network mode for the task and assigns the result to this task's NetworkMode field.
+// This is necessary because ACS doesn't send the actual network mode declared in task def.
+// TODO [SC]: Instead of doing this, it's perhaps better/easier to just ask ACS to send network mode from task definition. Using this in the meantime to avoid being blocked.
+func (task *Task) initNetworkMode() {
+	if len(task.ENIs) > 0 {
+		task.NetworkMode = AWSVPCNetworkMode
+		return
+	}
+	for _, c := range task.Containers {
+		// ACS sets task def network mode to each and every customer container docker host config, so the presence
+		// of one container with a given network mode is enough to infer the task network mode
+		switch c.GetNetworkModeFromHostConfig() {
+		case BridgeNetworkMode:
+			task.NetworkMode = BridgeNetworkMode
+			return
+		case HostNetworkMode:
+			task.NetworkMode = HostNetworkMode
+			return
+		case "":
+			// the absence of a network mode means the default docker network mode is used, which, for ECS it's bridge.
+			// for future proofing, let's keep inspecting the rest of the containers for this particular case.
+			continue
+		}
+	}
+	// If we reached this part, it means none of the containers has network mode set, which means bridge mode (default)
+	task.NetworkMode = BridgeNetworkMode
 }
 
 func (task *Task) initServiceConnectResources() error {
@@ -1325,10 +1361,27 @@ func (task *Task) IsNetworkModeAWSVPC() bool {
 	return len(task.ENIs) > 0
 }
 
+// IsNetworkModeBridge checks if the task is configured to use the bridge network mode.
+func (task *Task) IsNetworkModeBridge() bool {
+	return task.NetworkMode == BridgeNetworkMode
+}
+
+// IsNetworkModeHost checks if the task is configured to use the host network mode.
+func (task *Task) IsNetworkModeHost() bool {
+	return task.NetworkMode == HostNetworkMode
+}
+
 func (task *Task) addNetworkResourceProvisioningDependency(cfg *config.Config) error {
-	if !task.IsNetworkModeAWSVPC() {
-		return nil
+	if task.IsNetworkModeAWSVPC() {
+		return task.addNetworkResourceProvisioningDependencyAwsvpc(cfg)
 	}
+	//else if task.IsNetworkModeBridge() && task.IsServiceConnectEnabled() {
+	//	// TODO [SC]: This is where we would setup a pause container per task container for Service Connect only
+	//}
+	return nil
+}
+
+func (task *Task) addNetworkResourceProvisioningDependencyAwsvpc(cfg *config.Config) error {
 	pauseContainer := apicontainer.NewContainerWithSteadyState(apicontainerstatus.ContainerResourcesProvisioned)
 	pauseContainer.TransitionDependenciesMap = make(map[apicontainerstatus.ContainerStatus]apicontainer.TransitionDependencySet)
 	pauseContainer.Name = NetworkPauseContainerName
@@ -1583,7 +1636,7 @@ func (task *Task) dockerConfig(container *apicontainer.Container, apiVersion doc
 		containerConfig.Labels = make(map[string]string)
 	}
 
-	if container.Type == apicontainer.ContainerCNIPause {
+	if container.Type == apicontainer.ContainerCNIPause && task.IsNetworkModeAWSVPC() {
 		// apply hostname to pause container's docker config
 		return task.applyENIHostname(containerConfig), nil
 	}
@@ -1680,7 +1733,7 @@ func (task *Task) dockerHostConfig(container *apicontainer.Container, dockerCont
 	if ok {
 		hostConfig.NetworkMode = dockercontainer.NetworkMode(networkMode)
 		// Override 'awsvpc' parameters if needed
-		if container.Type == apicontainer.ContainerCNIPause {
+		if container.Type == apicontainer.ContainerCNIPause && task.IsNetworkModeAWSVPC() {
 			// apply ExtraHosts to HostConfig for pause container
 			if hosts := task.generateENIExtraHosts(); hosts != nil {
 				hostConfig.ExtraHosts = append(hostConfig.ExtraHosts, hosts...)
@@ -1773,10 +1826,18 @@ func (task *Task) shouldOverrideNetworkMode(container *apicontainer.Container, d
 	// TODO. We can do an early return here by determining which kind of task it is
 	// Example: Does this task have ENIs in its payload, what is its networking mode etc
 	if container.IsInternal() {
-		// If it's an internal container, set the network mode to none.
+		// If it's an internal container, set the network mode to none for awsvpc, set to bridge if task is using
+		// bridge mode and this is an SC-enabled task.
 		// Currently, internal containers are either for creating empty host
 		// volumes or for creating the 'pause' container. Both of these
 		// only need the network mode to be set to "none"
+		if container.Type == apicontainer.ContainerCNIPause {
+			if task.IsNetworkModeAWSVPC() {
+				return true, networkModeNone
+			} else if task.IsNetworkModeBridge() && task.IsServiceConnectEnabled() {
+				return true, BridgeNetworkMode
+			}
+		}
 		return true, networkModeNone
 	}
 
@@ -1785,10 +1846,17 @@ func (task *Task) shouldOverrideNetworkMode(container *apicontainer.Container, d
 	// when using non docker daemon supported network modes, its existence
 	// indicates the need to configure the network mode outside of supported
 	// network drivers
-	if !task.IsNetworkModeAWSVPC() {
-		return false, ""
+	if task.IsNetworkModeAWSVPC() {
+		return task.shouldOverrideNetworkModeAwsvpc(container, dockerContainerMap)
 	}
+	//else if task.IsNetworkModeBridge() && task.IsServiceConnectEnabled() {
+	//	// TODO [SC]: This is where the logic to override network mode for a customer to join its pause container would go
+	//	// return task.shouldOverrideNetworkModeServiceConnectBridge(container, dockerContainerMap)
+	//}
+	return false, ""
+}
 
+func (task *Task) shouldOverrideNetworkModeAwsvpc(container *apicontainer.Container, dockerContainerMap map[string]*apicontainer.DockerContainer) (bool, string) {
 	pauseContName := ""
 	for _, cont := range task.Containers {
 		if cont.Type == apicontainer.ContainerCNIPause {

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -3727,3 +3727,75 @@ func validateAppnetEnvVars(t *testing.T, task *Task) {
 		assert.Equalf(t, int(egressListener.ListenerPort), portMapping[egressListener.ListenerName], "Listener-port mapping incorrectly configured for %s", egressListener.ListenerName)
 	}
 }
+
+func TestPostUnmarshalTaskNetworkModeInference(t *testing.T) {
+	for _, tc := range []struct {
+		inputNetworkMode        string
+		expectedTaskNetworkMode string
+	}{
+		{
+			inputNetworkMode:        AWSVPCNetworkMode,
+			expectedTaskNetworkMode: AWSVPCNetworkMode,
+		},
+		{
+			inputNetworkMode:        BridgeNetworkMode,
+			expectedTaskNetworkMode: BridgeNetworkMode,
+		},
+		{
+			inputNetworkMode:        "",
+			expectedTaskNetworkMode: BridgeNetworkMode,
+		},
+		{
+			inputNetworkMode:        HostNetworkMode,
+			expectedTaskNetworkMode: HostNetworkMode,
+		},
+	} {
+		taskFromACS := ecsacs.Task{
+			Arn:           strptr("myArn"),
+			DesiredStatus: strptr("RUNNING"),
+			Family:        strptr("myFamily"),
+			Version:       strptr("1"),
+			Containers: []*ecsacs.Container{
+				{
+					Name: aws.String("C1"),
+				},
+				{
+					Name: aws.String("C2"),
+				},
+			},
+		}
+		seqNum := int64(42)
+		task, err := TaskFromACS(&taskFromACS, &ecsacs.PayloadMessage{SeqNum: &seqNum})
+		assert.Nil(t, err, "Should be able to handle acs task")
+
+		// Setup
+		if tc.inputNetworkMode == AWSVPCNetworkMode {
+			// Inject a dummy ENI to signal this is an awsvpc task
+			task.ENIs = []*apieni.ENI{{}}
+		} else if tc.inputNetworkMode != "" {
+			// otherwise, if networkMode is bridge or host, inject it into container's docker host config
+			task.Containers[0].DockerConfig = apicontainer.DockerConfig{
+				HostConfig: aws.String(fmt.Sprintf(
+					`{"NetworkMode":"%s"}`, tc.inputNetworkMode)),
+			}
+		}
+
+		err = task.PostUnmarshalTask(&config.Config{}, nil, nil, nil, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, tc.expectedTaskNetworkMode, task.NetworkMode)
+		switch tc.inputNetworkMode {
+		case AWSVPCNetworkMode:
+			assert.True(t, task.IsNetworkModeAWSVPC())
+			assert.False(t, task.IsNetworkModeBridge())
+			assert.False(t, task.IsNetworkModeHost())
+		case BridgeNetworkMode, "":
+			assert.False(t, task.IsNetworkModeAWSVPC())
+			assert.True(t, task.IsNetworkModeBridge())
+			assert.False(t, task.IsNetworkModeHost())
+		case HostNetworkMode:
+			assert.False(t, task.IsNetworkModeAWSVPC())
+			assert.False(t, task.IsNetworkModeBridge())
+			assert.True(t, task.IsNetworkModeHost())
+		}
+	}
+}

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -1713,9 +1713,9 @@ func (engine *DockerTaskEngine) provisionContainerResources(task *apitask.Task, 
 	}
 }
 
-// checkTearDownPauseContainer idempotently tears down the pause container network when the pause container's known
+// checkTearDownPauseContainerAwsvpc idempotently tears down the pause container network when the pause container's known
 //or desired status is stopped.
-func (engine *DockerTaskEngine) checkTearDownPauseContainer(task *apitask.Task) {
+func (engine *DockerTaskEngine) checkTearDownPauseContainerAwsvpc(task *apitask.Task) {
 	if !task.IsNetworkModeAWSVPC() {
 		return
 	}
@@ -1724,7 +1724,7 @@ func (engine *DockerTaskEngine) checkTearDownPauseContainer(task *apitask.Task) 
 		if container.Type == apicontainer.ContainerCNIPause {
 			// Clean up if the pause container has stopped or will stop
 			if container.KnownTerminal() || container.DesiredTerminal() {
-				err := engine.cleanupPauseContainerNetwork(task, container)
+				err := engine.cleanupPauseContainerNetworkAwsvpc(task, container)
 				if err != nil {
 					logger.Error("Unable to cleanup pause container network namespace", logger.Fields{
 						field.TaskID: task.GetID(),
@@ -1737,8 +1737,8 @@ func (engine *DockerTaskEngine) checkTearDownPauseContainer(task *apitask.Task) 
 	}
 }
 
-// cleanupPauseContainerNetwork will clean up the network namespace of pause container
-func (engine *DockerTaskEngine) cleanupPauseContainerNetwork(task *apitask.Task, container *apicontainer.Container) error {
+// cleanupPauseContainerNetworkAwsvpc will clean up the network namespace of pause container
+func (engine *DockerTaskEngine) cleanupPauseContainerNetworkAwsvpc(task *apitask.Task, container *apicontainer.Container) error {
 	// This operation is idempotent
 	if container.IsContainerTornDown() {
 		return nil
@@ -1843,13 +1843,18 @@ func (engine *DockerTaskEngine) stopContainer(task *apitask.Task, container *api
 
 	// Cleanup the pause container network namespace before stop the container
 	if container.Type == apicontainer.ContainerCNIPause {
-		err := engine.cleanupPauseContainerNetwork(task, container)
-		if err != nil {
-			logger.Error("Unable to cleanup pause container network namespace", logger.Fields{
-				field.TaskID: task.GetID(),
-				field.Error:  err,
-			})
+		if task.IsNetworkModeAWSVPC() {
+			err := engine.cleanupPauseContainerNetworkAwsvpc(task, container)
+			if err != nil {
+				logger.Error("Unable to cleanup pause container network namespace", logger.Fields{
+					field.TaskID: task.GetID(),
+					field.Error:  err,
+				})
+			}
 		}
+		//else if task.IsNetworkModeBridge() && task.IsServiceConnectEnabled() {
+		//	// TODO [SC]: Pause containers in bridge mode also need cleaning up for SC-enabled tasks
+		//}
 	}
 
 	apiTimeoutStopContainer := container.GetStopTimeout()

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -1218,11 +1218,11 @@ func TestCheckTearDownPauseContainer(t *testing.T) {
 		mockCNIClient.EXPECT().CleanupNS(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).MaxTimes(1),
 	)
 
-	taskEngine.(*DockerTaskEngine).checkTearDownPauseContainer(testTask)
+	taskEngine.(*DockerTaskEngine).checkTearDownPauseContainerAwsvpc(testTask)
 	require.True(t, pauseContainer.IsContainerTornDown())
 
 	// Invoke one more time to check for idempotency (mocks configured with maxTimes = 1)
-	taskEngine.(*DockerTaskEngine).checkTearDownPauseContainer(testTask)
+	taskEngine.(*DockerTaskEngine).checkTearDownPauseContainerAwsvpc(testTask)
 }
 
 // TestTaskWithCircularDependency tests the task with containers of which the

--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -239,7 +239,8 @@ func (mtask *managedTask) overseeTask() {
 	logger.Info("Managed task has reached stopped; waiting for container cleanup", logger.Fields{
 		field.TaskID: mtask.GetID(),
 	})
-	mtask.engine.checkTearDownPauseContainer(mtask.Task)
+	mtask.engine.checkTearDownPauseContainerAwsvpc(mtask.Task)
+	// TODO [SC]: We need to also tear down pause containets in bridge mode for SC-enabled tasks
 	mtask.cleanupCredentials()
 	if mtask.StopSequenceNumber != 0 {
 		logger.Debug("Marking done for this sequence", logger.Fields{


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
So far, pause container only exists in awsvpc mode, and code paths where pause container is explicitly used assume this network mode.  This will no longer be the case with the introduction of Service Connect, since SC in bridge network mode will require a pause container per task container. 

This PR just reorganizes code in a way that it's clear which code paths are for awsvpc mode, and which ones are for SC-enabled tasks using bridge network mode. 

### Implementation details
<!-- How are the changes implemented? -->

This is a code reorganization which doesn't alter the existing logic, otherwise UTs, integ, and/or functional tests would fail if something fundamental is changing.

### Testing
UTs, Integ tests, functional tests.
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
N/A
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
