### PR TITLE
Add GO111MODULE=on to honnef.co staticcheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -355,7 +355,7 @@ get-deps-init:
 	cd "${GOPATH}/src/github.com/golang/mock/mockgen" && git checkout 1.3.1 && go get ./... && go install ./... && cd -
 	GO111MODULE=on go get github.com/fzipp/gocyclo/cmd/gocyclo@v0.3.1
 	go get golang.org/x/tools/cmd/goimports
-	go get honnef.co/go/tools/cmd/staticcheck
+	GO111MODULE=on go get honnef.co/go/tools/cmd/staticcheck@v0.2.1
 
 .amazon-linux-rpm-integrated-done:
 	./scripts/update-version.sh


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Some static checks are failing when creating PRs to this repo. In particular, make get-deps-init step fails, example https://github.com/aws/amazon-ecs-agent/runs/6186432720?check_suite_focus=true#step:6:6
The make target was recently added and the prefix ```GO111MODULE=on``` was missed during the addition. This PR fixes this and makes this step similar to the one in ```get-deps``` target

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Creating a PR and checking the static checks pass (see checks in https://github.com/prateekchaudhry/amazon-ecs-agent/pull/16 , or the checks in this PR)

New tests cover the changes: <!-- yes|no --> No

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
