### PR TITLE
Populate TaskMetric with service connect stats

### DIFF
--- a/agent/stats/mock/engine.go
+++ b/agent/stats/mock/engine.go
@@ -82,20 +82,6 @@ func (mr *MockEngineMockRecorder) GetInstanceMetrics(arg0 interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstanceMetrics", reflect.TypeOf((*MockEngine)(nil).GetInstanceMetrics), arg0)
 }
 
-// GetServiceConnectStats mocks base method
-func (m *MockEngine) GetServiceConnectStats() error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetServiceConnectStats")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// GetServiceConnectStats indicates an expected call of GetServiceConnectStats
-func (mr *MockEngineMockRecorder) GetServiceConnectStats() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceConnectStats", reflect.TypeOf((*MockEngine)(nil).GetServiceConnectStats))
-}
-
 // GetTaskHealthMetrics mocks base method
 func (m *MockEngine) GetTaskHealthMetrics() (*ecstcs.HealthMetadata, []*ecstcs.TaskHealth, error) {
 	m.ctrl.T.Helper()

--- a/agent/stats/service_connect_linux.go
+++ b/agent/stats/service_connect_linux.go
@@ -48,6 +48,7 @@ func newServiceConnectStats() (*ServiceConnectStats, error) {
 	return &ServiceConnectStats{}, nil
 }
 
+// TODO [SC]: Add retries on failure to retrieve service connect stats
 func (sc *ServiceConnectStats) retrieveServiceConnectStats(task *apitask.Task) {
 	var ipAddress string
 	if task.IsNetworkModeAWSVPC() {

--- a/agent/stats/service_connect_unspecified.go
+++ b/agent/stats/service_connect_unspecified.go
@@ -32,3 +32,7 @@ func newServiceConnectStats() (*ServiceConnectStats, error) {
 
 func (sc *ServiceConnectStats) retrieveServiceConnectStats(task *apitask.Task) {
 }
+
+func (sc *ServiceConnectStats) GetStats() []*ecstcs.GeneralMetricsWrapper {
+	return nil
+}

--- a/agent/tcs/client/client_test.go
+++ b/agent/tcs/client/client_test.go
@@ -118,10 +118,6 @@ func (*mockStatsEngine) GetTaskHealthMetrics() (*ecstcs.HealthMetadata, []*ecstc
 	return nil, nil, nil
 }
 
-func (*mockStatsEngine) GetServiceConnectStats() error {
-	return nil
-}
-
 type emptyStatsEngine struct{}
 
 func (*emptyStatsEngine) GetInstanceMetrics(includeServiceConnectStats bool) (*ecstcs.MetricsMetadata, []*ecstcs.TaskMetric, error) {
@@ -134,10 +130,6 @@ func (*emptyStatsEngine) ContainerDockerStats(taskARN string, id string) (*types
 
 func (*emptyStatsEngine) GetTaskHealthMetrics() (*ecstcs.HealthMetadata, []*ecstcs.TaskHealth, error) {
 	return nil, nil, nil
-}
-
-func (*emptyStatsEngine) GetServiceConnectStats() error {
-	return nil
 }
 
 type idleStatsEngine struct{}
@@ -158,10 +150,6 @@ func (*idleStatsEngine) ContainerDockerStats(taskARN string, id string) (*types.
 
 func (*idleStatsEngine) GetTaskHealthMetrics() (*ecstcs.HealthMetadata, []*ecstcs.TaskHealth, error) {
 	return nil, nil, nil
-}
-
-func (*idleStatsEngine) GetServiceConnectStats() error {
-	return nil
 }
 
 type nonIdleStatsEngine struct {
@@ -190,10 +178,6 @@ func (*nonIdleStatsEngine) ContainerDockerStats(taskARN string, id string) (*typ
 
 func (*nonIdleStatsEngine) GetTaskHealthMetrics() (*ecstcs.HealthMetadata, []*ecstcs.TaskHealth, error) {
 	return nil, nil, nil
-}
-
-func (*nonIdleStatsEngine) GetServiceConnectStats() error {
-	return nil
 }
 
 func newNonIdleStatsEngine(numTasks int) *nonIdleStatsEngine {
@@ -283,10 +267,6 @@ func (*serviceConnectStatsEngine) ContainerDockerStats(taskARN string, id string
 
 func (*serviceConnectStatsEngine) GetTaskHealthMetrics() (*ecstcs.HealthMetadata, []*ecstcs.TaskHealth, error) {
 	return nil, nil, nil
-}
-
-func (*serviceConnectStatsEngine) GetServiceConnectStats() error {
-	return nil
 }
 
 func newServiceConnectStatsEngine(numTasks int) *serviceConnectStatsEngine {

--- a/agent/tcs/handler/handler_test.go
+++ b/agent/tcs/handler/handler_test.go
@@ -79,10 +79,6 @@ func (*mockStatsEngine) GetTaskHealthMetrics() (*ecstcs.HealthMetadata, []*ecstc
 	return nil, nil, nil
 }
 
-func (*mockStatsEngine) GetServiceConnectStats() error {
-	return nil
-}
-
 // TestDisableMetrics tests the StartMetricsSession will return immediately if
 // the metrics was disabled
 func TestDisableMetrics(t *testing.T) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR includes small refactor on where the service connect metrics are gathered to be sent to TACS `PublishMetrics` API request.

### Implementation details
<!-- How are the changes implemented? -->
1. Updated `GetServiceConnectStats()` to be private since this method is not being exported.
2. Updated `GetInstanceMetrics()` to use `getServiceConnectStats()` to and initialize TaskMetric with service connect metrics data.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> No

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
