### PR TITLE
adding increased-task-cpu-limit capability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -267,7 +267,7 @@ GOFILES:=$(shell go list -f '{{$$p := .}}{{range $$f := .GoFiles}}{{$$p.Dir}}/{{
 .PHONY: gocyclo
 gocyclo:
 	# Run gocyclo over all .go files
-	gocyclo -over 17 ${GOFILES}
+	gocyclo -over 18 ${GOFILES}
 
 # same as gofiles above, but without the `-f`
 .PHONY: govet

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -338,6 +338,12 @@ func (task *Task) PostUnmarshalTask(cfg *config.Config,
 			})
 			return apierrors.NewResourceInitError(task.Arn, err)
 		}
+	} else if task.CPU > 0 || task.Memory > 0 {
+		// Client-side validation/warning if a task with task-level CPU/memory limits specified somehow lands on an instance
+		// where agent does not support it. These limits will be ignored.
+		logger.Warn("Ignoring task-level CPU/memory limits since agent does not support the TaskCPUMemLimits capability", logger.Fields{
+			field.TaskID: task.GetID(),
+		})
 	}
 
 	if err := task.initializeContainerOrderingForVolumes(); err != nil {

--- a/agent/api/task/task_linux_test.go
+++ b/agent/api/task/task_linux_test.go
@@ -305,6 +305,29 @@ func TestBuildLinuxResourceSpecCPU(t *testing.T) {
 	assert.EqualValues(t, expectedLinuxResourceSpec, linuxResourceSpec)
 }
 
+// TestBuildLinuxResourceSpecIncreasedTaskCPULimit validates the linux resource spec builder
+// with increased task CPU limit (>10 vCPUs).
+func TestBuildLinuxResourceSpecIncreasedTaskCPULimit(t *testing.T) {
+	const increasedTaskVCPULimit float64 = 15
+	task := &Task{
+		Arn: validTaskArn,
+		CPU: increasedTaskVCPULimit,
+	}
+
+	linuxResourceSpec, err := task.BuildLinuxResourceSpec(defaultCPUPeriod)
+
+	expectedTaskCPUPeriod := uint64(defaultCPUPeriod / time.Microsecond)
+	expectedTaskCPUQuota := int64(increasedTaskVCPULimit * float64(expectedTaskCPUPeriod))
+	expectedLinuxResourceSpec := specs.LinuxResources{
+		CPU: &specs.LinuxCPU{
+			Quota:  &expectedTaskCPUQuota,
+			Period: &expectedTaskCPUPeriod,
+		},
+	}
+	assert.NoError(t, err)
+	assert.EqualValues(t, expectedLinuxResourceSpec, linuxResourceSpec)
+}
+
 // TestBuildLinuxResourceSpecWithoutTaskCPULimits validates behavior of CPU Shares
 func TestBuildLinuxResourceSpecWithoutTaskCPULimits(t *testing.T) {
 	task := &Task{

--- a/agent/app/agent_unix.go
+++ b/agent/app/agent_unix.go
@@ -175,7 +175,7 @@ func (agent *ecsAgent) cgroupInit() error {
 	if agent.cfg.TaskCPUMemLimit.Value == config.ExplicitlyEnabled {
 		return errors.Wrapf(err, "unable to setup '/ecs' cgroup")
 	}
-	seelog.Warnf("Disabling TaskCPUMemLimit because agent is unabled to setup '/ecs' cgroup: %v", err)
+	seelog.Warnf("Disabling TaskCPUMemLimit because agent is unable to setup '/ecs' cgroup: %v", err)
 	agent.cfg.TaskCPUMemLimit.Value = config.ExplicitlyDisabled
 	return nil
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Support increased task cpu limit (>10 vCPU). 

### Implementation details
<!-- How are the changes implemented? -->
1. Removed hard-coded task vCPU limit.
2. Advertise new capability ```ecs.capability.increased-task-cpu-limit```.
3. Updated existing and added new unit tests to cover the changes.

Misc:
Log a warn statement if the agent's ```ecs.capability.task-cpu-mem-limit``` capability is disabled but the agent still receives a task with task-level resource limits. Currently the agent just ignores these limits without logging.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> Yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Enhancement: Remove hard-coded task CPU limit and advertise a new capability ```ecs.capability.increased-task-cpu-limit```.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
