### PR TITLE
Parse service connect stats

### DIFF
--- a/agent/stats/service_connect_linux.go
+++ b/agent/stats/service_connect_linux.go
@@ -17,15 +17,20 @@ package stats
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
+	"math"
 	"net/http"
 	"net/url"
+	"sort"
 	"strings"
 	"sync"
 
-	"github.com/cihub/seelog"
-
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
+	"github.com/aws/amazon-ecs-agent/agent/logger"
+	"github.com/aws/amazon-ecs-agent/agent/logger/field"
+	"github.com/aws/amazon-ecs-agent/agent/tcs/model/ecstcs"
+	prometheus "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
 )
 
 const (
@@ -34,8 +39,8 @@ const (
 )
 
 type ServiceConnectStats struct {
-	//TODO [SC]: Change the type of Service Connect stats when it is defined.
-	stats string
+	stats []*ecstcs.GeneralMetricsWrapper
+	sent  bool
 	lock  sync.RWMutex
 }
 
@@ -63,29 +68,208 @@ func (sc *ServiceConnectStats) retrieveServiceConnectStats(task *apitask.Task) {
 	statsEndpoint, _ := url.Parse(fmt.Sprintf("http://" + ipAddress + statsURLPath))
 	resp, err := http.Get(statsEndpoint.String())
 	if err != nil {
-		seelog.Errorf("Could not connect to service connect stats endpoint for task %s: %v", task.Arn, err)
+		logger.Error("Could not connect to service connect stats endpoint for task", logger.Fields{
+			field.TaskID: task.GetID(),
+			field.Error:  err,
+		})
 		return
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	statsCollectedList, err := parseStats(resp.Body, task.GetID())
 	if err != nil {
-		seelog.Errorf("Could not read metrics from service connect stats endpoint for task %s: %v", task.Arn, err)
+		logger.Error("Error parsing service-connect stats", logger.Fields{
+			field.TaskID: task.GetID(),
+			field.Error:  err,
+		})
 		return
 	}
-
-	sc.setStats(string(body))
+	sc.resetStats()
+	sc.setStats(statsCollectedList)
 }
 
-func (sc *ServiceConnectStats) setStats(stats string) {
+func parseStats(rawStats io.Reader, taskId string) ([]*ecstcs.GeneralMetricsWrapper, error) {
+	statsMap := make(map[string]*ecstcs.GeneralMetricsWrapper)
+	mf, err := parseServiceConnectStats(rawStats)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, v := range mf {
+		for _, metric := range v.Metric {
+			var metricValues []*float64
+			var metricCounts []*int64
+			metricCountForCountersAndGauges := int64(1)
+			// Get Metric values and counts
+			switch v.GetType() {
+			case prometheus.MetricType_COUNTER:
+				metricValues = append(metricValues, metric.Counter.Value)
+				// MetricCount for Counter will always be [1]
+				metricCounts = append(metricCounts, &metricCountForCountersAndGauges)
+			case prometheus.MetricType_GAUGE:
+				metricValues = append(metricValues, metric.Gauge.Value)
+				// MetricCount for Gauge will always be [1]
+				metricCounts = append(metricCounts, &metricCountForCountersAndGauges)
+			case prometheus.MetricType_HISTOGRAM:
+				for _, bucket := range metric.Histogram.Bucket {
+					// We do not want to add the metricValue if it is +Inf
+					if math.IsInf(bucket.GetUpperBound(), 0) {
+						continue
+					}
+					metricValues = append(metricValues, bucket.UpperBound)
+
+					// Prometheus histogram CumulativeCount is type *uint64, TACS wants *int64.
+					var metricCount int64
+					if bucket.GetCumulativeCount() <= uint64(math.MaxInt64) {
+						metricCount = int64(bucket.GetCumulativeCount())
+					} else {
+						metricCount = math.MaxInt64
+						logger.Warn("Service Connect histogram metric is emitting a value larger than max int64", logger.Fields{
+							field.TaskID:            taskId,
+							"metric":                v.Type.String(),
+							"bucketCumulativeCount": bucket.GetCumulativeCount(),
+						})
+					}
+					metricCounts = append(metricCounts, &metricCount)
+				}
+				metricCounts = convertHistogramMetricCounts(metricCounts)
+			default:
+				logger.Warn("Service connect stats received invalid Metric type", logger.Fields{
+					field.TaskID: taskId,
+					"metric":     v.Type.String(),
+				})
+				continue
+			}
+
+			generalMetric := &ecstcs.GeneralMetric{}
+			generalMetric.MetricName = v.Name
+			generalMetric.MetricValues = metricValues
+			generalMetric.MetricCounts = metricCounts
+
+			// Get metric dimensions
+			var dimensions []*ecstcs.Dimension
+			if metric.Label != nil {
+				for _, d := range metric.Label {
+					// TODO [SC]: New stats endpoint will surface a new dimension which indicates what is the MetricType.
+					dimension := &ecstcs.Dimension{
+						Key:   d.Name,
+						Value: d.Value,
+					}
+					dimensions = append(dimensions, dimension)
+				}
+			}
+
+			dimensionAsString := sortAndConvertDimensionsintoStrings(dimensions)
+
+			if generalMetricsWrapper, ok := statsMap[dimensionAsString]; !ok {
+				// Dimension does not exist in statsMap, add it to the statsMap
+				generalMetricsList := []*ecstcs.GeneralMetric{generalMetric}
+				generalMetricsWrapper = &ecstcs.GeneralMetricsWrapper{
+					Dimensions:     dimensions,
+					GeneralMetrics: generalMetricsList,
+				}
+				statsMap[dimensionAsString] = generalMetricsWrapper
+			} else {
+				// Add this metric to the metric list for the already existing dimesion
+				generalMetricsWrapper.GeneralMetrics = append(generalMetricsWrapper.GeneralMetrics, generalMetric)
+			}
+		}
+	}
+
+	statsCollectedList := []*ecstcs.GeneralMetricsWrapper{}
+	for _, gm := range statsMap {
+		statsCollectedList = append(statsCollectedList, gm)
+	}
+
+	return statsCollectedList, nil
+}
+
+func (sc *ServiceConnectStats) setStats(stats []*ecstcs.GeneralMetricsWrapper) {
 	sc.lock.Lock()
 	defer sc.lock.Unlock()
 
 	sc.stats = stats
 }
 
-func (sc *ServiceConnectStats) GetStats() string {
+func (sc *ServiceConnectStats) GetStats() []*ecstcs.GeneralMetricsWrapper {
 	sc.lock.RLock()
 	defer sc.lock.RUnlock()
 
 	return sc.stats
+}
+
+func (sc *ServiceConnectStats) SetStatsSent(sent bool) {
+	sc.lock.Lock()
+	defer sc.lock.Unlock()
+
+	sc.sent = sent
+}
+
+func (sc *ServiceConnectStats) HasStatsBeenSent() bool {
+	sc.lock.RLock()
+	defer sc.lock.RUnlock()
+
+	return sc.sent
+}
+
+func (sc *ServiceConnectStats) resetStats() {
+	sc.lock.Lock()
+	defer sc.lock.Unlock()
+
+	sc.stats = nil
+	sc.sent = false
+}
+
+/* This method parses stats in prometheus format and converts it to prometheus client model. RawStats looks like below
+=====================================================
+TYPE MetricFamily1 counter
+MetricFamily1{dimensionA=value1, dimensionB=value2} 1
+
+# TYPE MetricFamily3 gauge
+MetricFamily3{dimensionA=value1, dimensionB=value2} 3
+
+# TYPE MetricFamily2 histogram
+MetricFamily2{dimensionX=value1, dimensionY=value2, le=0.5} 1
+MetricFamily2{dimensionX=value1, dimensionY=value2, le=1} 2
+MetricFamily2{dimensionX=value1, dimensionY=value2, le=5} 3
+*/
+
+func parseServiceConnectStats(rawStats io.Reader) (map[string]*prometheus.MetricFamily, error) {
+	var parser expfmt.TextParser
+	stats, err := parser.TextToMetricFamilies(rawStats)
+	if err != nil {
+		return nil, err
+	}
+	return stats, nil
+}
+
+// CloudWatch accepts the histogram buckets in a disjoint manner while the prometheus emits these values in a cumulative way.
+// This method performs that conversion
+func convertHistogramMetricCounts(metricCounts []*int64) []*int64 {
+	prevCount := *metricCounts[0]
+	for i := 1; i < len(metricCounts); i++ {
+		prevCount, *metricCounts[i] = *metricCounts[i], *metricCounts[i]-prevCount
+	}
+	return metricCounts
+}
+
+// This method sorts the dimensions according to the keyName.
+// This helps to check if a dimension set already has a set of general metrics associated with it.
+// Sorting helps us to take order of the dimension list into consideration.
+// It then converts dimensions into strings. This is because we cannot
+// have a slice as keys in maps
+func sortAndConvertDimensionsintoStrings(dimension []*ecstcs.Dimension) string {
+	sort.Slice(dimension, func(i, j int) bool {
+		return *dimension[i].Key < *dimension[j].Key
+	})
+
+	return convertDimensionsintoStrings(dimension)
+}
+
+func convertDimensionsintoStrings(dimension []*ecstcs.Dimension) string {
+	var sb strings.Builder
+	for _, d := range dimension {
+		sb.WriteString(*d.Key)
+		sb.WriteString(*d.Value)
+	}
+	return sb.String()
 }

--- a/agent/stats/service_connect_linux_test.go
+++ b/agent/stats/service_connect_linux_test.go
@@ -20,18 +20,20 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"testing"
 
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apieni "github.com/aws/amazon-ecs-agent/agent/api/eni"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	apitaskstatus "github.com/aws/amazon-ecs-agent/agent/api/task/status"
+	"github.com/aws/amazon-ecs-agent/agent/tcs/model/ecstcs"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestRetrieveServiceConnectMetrics(t *testing.T) {
-
 	t1 := &apitask.Task{
 		Arn:               "t1",
 		Family:            "f1",
@@ -43,26 +45,101 @@ func TestRetrieveServiceConnectMetrics(t *testing.T) {
 		LocalIPAddressUnsafe: "127.0.0.1",
 	}
 
-	// Set up a mock http sever on the statsUrlpath
-	statsMockurl := "127.0.0.1:9901"
-	r := mux.NewRouter()
-	r.HandleFunc("/stats/prometheus", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, "Service Connect Stats")
-	}))
-
-	ts := httptest.NewUnstartedServer(r)
-
-	l, err := net.Listen("tcp", statsMockurl)
-	if err != nil {
-		fmt.Printf("%v", err)
+	var tests = []struct {
+		stats         string
+		expectedStats []*ecstcs.GeneralMetricsWrapper
+	}{
+		{
+			stats: `# TYPE MetricFamily1 counter
+				MetricFamily1{dimensionA="value1", dimensionB="value2"} 1
+				# TYPE MetricFamily2 counter
+				MetricFamily2{dimensionB="value2", dimensionA="value1"} 1
+				`,
+			expectedStats: []*ecstcs.GeneralMetricsWrapper{
+				{
+					Dimensions: []*ecstcs.Dimension{
+						{
+							Key:   aws.String("dimensionA"),
+							Value: aws.String("value1"),
+						}, {
+							Key:   aws.String("dimensionB"),
+							Value: aws.String("value2"),
+						}},
+					GeneralMetrics: []*ecstcs.GeneralMetric{
+						{
+							MetricCounts: []*int64{aws.Int64(1)},
+							MetricName:   aws.String("MetricFamily1"),
+							MetricValues: []*float64{aws.Float64(1)},
+						},
+						{
+							MetricCounts: []*int64{aws.Int64(1)},
+							MetricName:   aws.String("MetricFamily2"),
+							MetricValues: []*float64{aws.Float64(1)},
+						},
+					},
+				},
+			},
+		},
+		{
+			stats: `# TYPE MetricFamily3 histogram
+				MetricFamily3{dimensionX="value1", dimensionY="value2", le="0.5"} 1
+				MetricFamily3{dimensionX="value1", dimensionY="value2", le="1"} 2
+				MetricFamily3{dimensionX="value1", dimensionY="value2", le="5"} 3
+				`,
+			expectedStats: []*ecstcs.GeneralMetricsWrapper{
+				{
+					Dimensions: []*ecstcs.Dimension{
+						{
+							Key:   aws.String("dimensionX"),
+							Value: aws.String("value1"),
+						}, {
+							Key:   aws.String("dimensionY"),
+							Value: aws.String("value2"),
+						}},
+					GeneralMetrics: []*ecstcs.GeneralMetric{
+						{
+							MetricCounts: []*int64{aws.Int64(1), aws.Int64(1), aws.Int64(1)},
+							MetricName:   aws.String("MetricFamily3"),
+							MetricValues: []*float64{aws.Float64(0.5), aws.Float64(1), aws.Float64(5)},
+						},
+					},
+				},
+			},
+		},
 	}
-	ts.Listener.Close()
-	ts.Listener = l
-	ts.Start()
-	defer ts.Close()
 
-	serviceConnectStats := &ServiceConnectStats{}
-	serviceConnectStats.retrieveServiceConnectStats(t1)
+	for _, test := range tests {
+		// Set up a mock http sever on the statsUrlpath
+		statsMockurl := "127.0.0.1:9901"
+		r := mux.NewRouter()
+		r.HandleFunc("/stats/prometheus", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintf(w, "%v", test.stats)
+		}))
 
-	assert.Equal(t, "Service Connect Stats\n", serviceConnectStats.GetStats())
+		ts := httptest.NewUnstartedServer(r)
+
+		l, err := net.Listen("tcp", statsMockurl)
+		if err != nil {
+			fmt.Printf("%v", err)
+		}
+		ts.Listener.Close()
+		ts.Listener = l
+		ts.Start()
+
+		serviceConnectStats := &ServiceConnectStats{}
+		serviceConnectStats.retrieveServiceConnectStats(t1)
+
+		sortMetrics(serviceConnectStats.GetStats())
+		sortMetrics(test.expectedStats)
+		assert.Equal(t, test.expectedStats, serviceConnectStats.GetStats())
+		ts.Close()
+	}
+}
+
+func sortMetrics(metricList []*ecstcs.GeneralMetricsWrapper) {
+	for _, metric := range metricList {
+		sort.Slice(metric.GeneralMetrics, func(i, j int) bool {
+			return *metric.GeneralMetrics[i].MetricName < *metric.GeneralMetrics[j].MetricName
+		})
+	}
 }

--- a/agent/stats/service_connect_unspecified.go
+++ b/agent/stats/service_connect_unspecified.go
@@ -17,12 +17,12 @@ package stats
 
 import (
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
+	"github.com/aws/amazon-ecs-agent/agent/tcs/model/ecstcs"
 	"github.com/pkg/errors"
 )
 
 type ServiceConnectStats struct {
-	//TODO Change the type of Service Connect stats when it is defined.
-	stats string
+	stats []*ecstcs.GeneralMetricsWrapper
 	sent  bool
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This PR parses the stats received from stats endpoint from prometheus to TACS format.


Example prometheus format
```
# TYPE MetricFamily1 counter
MetricFamily1{dimensionA=value1, dimensionB=value2} 1

# TYPE MetricFamily3 gauge
MetricFamily3{dimensionA=value1, dimensionB=value2} 3

# TYPE MetricFamily2 histogram
MetricFamily2{dimensionX=value1, dimensionY=value2, le=0.5} 1
MetricFamily2{dimensionX=value1, dimensionY=value2, le=1} 2
MetricFamily2{dimensionX=value1, dimensionY=value2, le=5} 3
```

Data for the above received in TACS end should be something like below
```
[]*ecstcs.GeneralMetricsWrapper{
		{
			Dimensions: []*ecstcs.Dimension{
				{
					Key:   aws.String("dimensionA"),
					Value: aws.String("value1"),
				}, {
					Key:   aws.String("dimensionB"),
					Value: aws.String("value2"),
				}},
			GeneralMetrics: []*ecstcs.GeneralMetric{
				{
					MetricCounts: []*int64{aws.Int64(1)},
					MetricName:   aws.String("MetricFamily1"),
					MetricValues: []*float64{aws.Float64(1)},
				},
				{
					MetricCounts: []*int64{aws.Int64(1)},
					MetricName:   aws.String("MetricFamily3"),
					MetricValues: []*float64{aws.Float64(3)},
				},
			},
		},
		{
			Dimensions: []*ecstcs.Dimension{
				{
					Key:   aws.String("dimensionX"),
					Value: aws.String("value1"),
				}, {
					Key:   aws.String("dimensionY"),
					Value: aws.String("value2"),
				}},
			GeneralMetrics: []*ecstcs.GeneralMetric{
				{
					MetricCounts: []*int64{aws.Int64(1), aws.Int64(1), aws.Int64(1)},
					MetricName:   aws.String("MetricFamily2"),
					MetricValues: []*float64{aws.Float64(0.5), aws.Float64(1), aws.Float64(5)},
				},
			},
		},
	}
```

Things to look out for:
1. Group metrics according to same dimension
2. CloudWatch accepts the histogram buckets in a disjoint manner while the prometheus emits these values in a cumulative way. So we need to convert them and make it suitable for Cloudwatch

### Implementation details
<!-- How are the changes implemented? -->

Method parseServiceConnectStats - converts stats from prometheus format into prometheus client model. https://github.com/prometheus/client_model/blob/master/go/metrics.pb.go#L599

Method convertHistogramMetricCounts - CloudWatch accepts the histogram buckets in a disjoint manner while the prometheus emits these values in a cumulative way. This method performs that conversion

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes

Ran an Appmesh task, saw that stats are getting parsed properly

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
