### PR TITLE
Service Connect - Start task workflow for bridge mode

### DIFF
--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -150,6 +150,7 @@ const (
 	sysctlValueOff = "0"
 
 	serviceConnectListenerPortMappingEnvVar = "APPNET_LISTENER_PORT_MAPPING"
+	serviceConnectContainerMappingEnvVar    = "APPNET_CONTAINER_MAPPING"
 )
 
 // TaskOverrides are the overrides applied to a task
@@ -515,6 +516,13 @@ func (task *Task) initDummyServiceConnectConfig() {
 	}
 }
 
+// initServiceConnectContainerDependencies builds container dependency for regular task containers and SC container, such that
+// - during task start up, a regular container depends on SC container to become Healthy
+// - during task tear down, SC container depends on all regular containers to be stopped first
+// Additionally, for bridge mode task, we have the SC container configure netns for itself as well as for all other task
+// containers. The configuration is done when SC container transitions from RUNNING -> RESOURCES_PROVISIONED. Therefore,
+// - we override steady state status for SC container to be RESOURCES_PROVISIONED (the default is RUNNING)
+// - during task start up, a regular container will also depends on SC Container RESOURCE_PROVISIONED
 func (task *Task) initServiceConnectContainerDependencies() {
 	scContainer := task.GetServiceConnectContainer()
 
@@ -524,6 +532,13 @@ func (task *Task) initServiceConnectContainerDependencies() {
 		}
 		container.AddContainerDependency(scContainer.Name, ContainerOrderingHealthyCondition)
 		scContainer.BuildContainerDependency(container.Name, apicontainerstatus.ContainerStopped, apicontainerstatus.ContainerStopped)
+		if task.IsNetworkModeBridge() {
+			container.BuildContainerDependency(scContainer.Name, apicontainerstatus.ContainerResourcesProvisioned, apicontainerstatus.ContainerCreated)
+		}
+	}
+
+	if task.IsNetworkModeBridge() {
+		scContainer.SetSteadyStateStatusUnsafe(apicontainerstatus.ContainerResourcesProvisioned)
 	}
 }
 
@@ -1374,10 +1389,9 @@ func (task *Task) IsNetworkModeHost() bool {
 func (task *Task) addNetworkResourceProvisioningDependency(cfg *config.Config) error {
 	if task.IsNetworkModeAWSVPC() {
 		return task.addNetworkResourceProvisioningDependencyAwsvpc(cfg)
+	} else if task.IsNetworkModeBridge() && task.IsServiceConnectEnabled() {
+		return task.addNetworkResourceProvisioningDependencyServiceConnectBridge(cfg)
 	}
-	//else if task.IsNetworkModeBridge() && task.IsServiceConnectEnabled() {
-	//	// TODO [SC]: This is where we would setup a pause container per task container for Service Connect only
-	//}
 	return nil
 }
 
@@ -1448,6 +1462,68 @@ func (task *Task) addNetworkResourceProvisioningDependencyAwsvpc(cfg *config.Con
 		}
 	}
 	return nil
+}
+
+// addNetworkResourceProvisioningDependencyServiceConnectBridge creates one pause container per task container
+// except for SC container, and add a dependency for SC container to wait for all pause container running.
+//
+// Unlike AWSVPC pause containers that use CNI plugin for configuring netns when they go from RUNNING ->
+// RESOURCES_PROVISIONED, Bridge mode pause containers will have steady state RUNNING. All netns configuration and
+// CNI invocation will be performed solely by SC container.
+func (task *Task) addNetworkResourceProvisioningDependencyServiceConnectBridge(cfg *config.Config) error {
+	scContainer := task.GetServiceConnectContainer()
+	for _, container := range task.Containers {
+		if container.IsInternal() || container == scContainer {
+			continue
+		}
+		pauseContainer := apicontainer.NewContainerWithSteadyState(apicontainerstatus.ContainerRunning)
+		pauseContainer.TransitionDependenciesMap = make(map[apicontainerstatus.ContainerStatus]apicontainer.TransitionDependencySet)
+		// The pause container name is used internally by task engine but still needs to be unique for every task,
+		// hence we are appending the corresponding application container name (which must already be unique within the task)
+		pauseContainer.Name = fmt.Sprintf("%s-%s", NetworkPauseContainerName, container.Name)
+		pauseContainer.Image = fmt.Sprintf("%s:%s", cfg.PauseContainerImageName, cfg.PauseContainerTag)
+		pauseContainer.Essential = true
+		pauseContainer.Type = apicontainer.ContainerCNIPause
+
+		task.Containers = append(task.Containers, pauseContainer)
+		scContainer.BuildContainerDependency(pauseContainer.Name, apicontainerstatus.ContainerRunning, apicontainerstatus.ContainerCreated)
+		pauseContainer.BuildContainerDependency(scContainer.Name, apicontainerstatus.ContainerStopped, apicontainerstatus.ContainerStopped)
+	}
+	return nil
+}
+
+// getBridgeModePauseContainerForTaskContainer retrieves the associated pause container for a regular task
+// container (customer-defined) in a bridge-mode SC-enabled task.
+// For a container with name "abc", the pause container will always be named "~internal~ecs~pause-abc"
+func (task *Task) getBridgeModePauseContainerForTaskContainer(container *apicontainer.Container) (*apicontainer.Container, error) {
+	// "~internal~ecs~pause-$TASK_CONTAINER_NAME"
+	pauseContainerName := fmt.Sprintf("%s-%s", NetworkPauseContainerName, container.Name)
+	pauseContainer, ok := task.ContainerByName(pauseContainerName)
+	if !ok {
+		return nil, fmt.Errorf("could not find pause container %s for task container %s", pauseContainerName, container.Name)
+	}
+	return pauseContainer, nil
+}
+
+// getBridgeModeTaskContainerForPauseContainer retrieves the associated customer container for a pause
+// container in a bridge-mode SC-enabled task.
+// For a container with name "abc", the pause container will always be named "~internal~ecs~pause-abc"
+func (task *Task) getBridgeModeTaskContainerForPauseContainer(container *apicontainer.Container) (*apicontainer.Container, error) {
+	if container.Type != apicontainer.ContainerCNIPause {
+		return nil, fmt.Errorf("container %s is not a CNI pause container", container.Name)
+	}
+	// pause container name will be something like "~internal~ecs~pause-$TASK_CONTAINER_NAME"
+	// limit the result to 2 substrings as $$TASK_CONTAINER_NAME may also container '-'
+	stringSlice := strings.SplitN(container.Name, "-", 2)
+	if len(stringSlice) < 2 {
+		return nil, fmt.Errorf("SC bridge mode pause container %s does not conform to %s-$TASK_CONTAINER_NAME format", container.Name, NetworkPauseContainerName)
+	}
+	taskContainerName := stringSlice[1]
+	taskContainer, ok := task.ContainerByName(taskContainerName)
+	if !ok {
+		return nil, fmt.Errorf("could not find task container %s for pause container %s", taskContainerName, container.Name)
+	}
+	return taskContainer, nil
 }
 
 func (task *Task) addNamespaceSharingProvisioningDependency(cfg *config.Config) {
@@ -1614,11 +1690,17 @@ func (task *Task) dockerConfig(container *apicontainer.Container, apiVersion doc
 		entryPoint = *container.EntryPoint
 	}
 
+	var exposedPorts nat.PortSet
+	var err error
+	if exposedPorts, err = task.dockerExposedPorts(container); err != nil {
+		return nil, &apierrors.DockerClientConfigError{Msg: "error resolving docker exposed ports for container: " + err.Error()}
+	}
+
 	containerConfig := &dockercontainer.Config{
 		Image:        container.Image,
 		Cmd:          container.Command,
 		Entrypoint:   entryPoint,
-		ExposedPorts: task.dockerExposedPorts(container),
+		ExposedPorts: exposedPorts,
 		Env:          dockerEnv,
 	}
 
@@ -1644,14 +1726,51 @@ func (task *Task) dockerConfig(container *apicontainer.Container, apiVersion doc
 	return containerConfig, nil
 }
 
-func (task *Task) dockerExposedPorts(container *apicontainer.Container) nat.PortSet {
-	dockerExposedPorts := make(map[nat.Port]struct{})
+// dockerExposedPorts returns the container ports that need to be exposed for a container
+// For bridge-mode ServiceConnect-enabled tasks:
+// 1. Pause containers need to expose the port(s) of their associated task container
+// 2. SC container (Appnet Agent) needs to expose all listener ports
+// 3. Other containers (customer-defined task containers) will not expose any ports (already exposed through pause container)
+// For all other tasks, we expose the application container ports.
+func (task *Task) dockerExposedPorts(container *apicontainer.Container) (dockerExposedPorts nat.PortSet, err error) {
+	containerToCheck := container
+	scContainer := task.GetServiceConnectContainer()
+	dockerExposedPorts = make(map[nat.Port]struct{})
 
-	for _, portBinding := range container.Ports {
+	if task.IsServiceConnectEnabled() && task.IsNetworkModeBridge() {
+		if container.Type == apicontainer.ContainerCNIPause {
+			// find the application container associated with this particular pause container, and let pause container
+			// expose the application container port
+			containerToCheck, err = task.getBridgeModeTaskContainerForPauseContainer(container)
+			if err != nil {
+				return nil, err
+			}
+		} else if container == scContainer {
+			// expose ingress listener ports if present
+			for _, ic := range task.ServiceConnectConfig.IngressConfig {
+				dockerPort := nat.Port(strconv.Itoa(int(ic.ListenerPort))) + "/tcp"
+				dockerExposedPorts[dockerPort] = struct{}{}
+			}
+			// expose egress listener port if present
+			ec := task.ServiceConnectConfig.EgressConfig
+			if ec.ListenerName != "" { // it's possible that task does not have an egress listener
+				dockerPort := nat.Port(strconv.Itoa(int(ec.ListenerPort))) + "/tcp"
+				dockerExposedPorts[dockerPort] = struct{}{}
+			}
+			return dockerExposedPorts, nil
+		} else {
+			// This is a customer application container which is launched with "--network container:$pause_container_id"
+			// In such case we don't expose any ports (docker won't allow anyway) because they are exposed by their
+			// pause container instead.
+			return dockerExposedPorts, nil
+		}
+	}
+
+	for _, portBinding := range containerToCheck.Ports {
 		dockerPort := nat.Port(strconv.Itoa(int(portBinding.ContainerPort)) + "/" + portBinding.Protocol.String())
 		dockerExposedPorts[dockerPort] = struct{}{}
 	}
-	return dockerExposedPorts
+	return dockerExposedPorts, nil
 }
 
 // DockerHostConfig construct the configuration recognized by docker
@@ -1689,8 +1808,10 @@ func (task *Task) dockerHostConfig(container *apicontainer.Container, dockerCont
 	if err != nil {
 		return nil, &apierrors.HostConfigError{Msg: err.Error()}
 	}
-
-	dockerPortMap := task.dockerPortMap(container)
+	dockerPortMap, err := task.dockerPortMap(container)
+	if err != nil {
+		return nil, &apierrors.HostConfigError{Msg: fmt.Sprintf("error retrieving docker port map: %+v", err.Error())}
+	}
 
 	volumesFrom, err := task.dockerVolumesFrom(container, dockerContainerMap)
 	if err != nil {
@@ -1848,11 +1969,9 @@ func (task *Task) shouldOverrideNetworkMode(container *apicontainer.Container, d
 	// network drivers
 	if task.IsNetworkModeAWSVPC() {
 		return task.shouldOverrideNetworkModeAwsvpc(container, dockerContainerMap)
+	} else if task.IsNetworkModeBridge() && task.IsServiceConnectEnabled() {
+		return task.shouldOverrideNetworkModeServiceConnectBridge(container, dockerContainerMap)
 	}
-	//else if task.IsNetworkModeBridge() && task.IsServiceConnectEnabled() {
-	//	// TODO [SC]: This is where the logic to override network mode for a customer to join its pause container would go
-	//	// return task.shouldOverrideNetworkModeServiceConnectBridge(container, dockerContainerMap)
-	//}
 	return false, ""
 }
 
@@ -1880,6 +1999,37 @@ func (task *Task) shouldOverrideNetworkModeAwsvpc(container *apicontainer.Contai
 		return false, ""
 	}
 	return true, dockerMappingContainerPrefix + pauseContainer.DockerID
+}
+
+// shouldOverrideNetworkModeServiceConnectBridge checks if a bridge-mode SC task container needs network mode override
+// For non-internal containers in an SC bridge-mode task, each gets a pause container, and should be launched
+// with container network mode use pause container netns (the "docker run" equivalent option is
+// "--network container:$pause_container_id")
+func (task *Task) shouldOverrideNetworkModeServiceConnectBridge(container *apicontainer.Container, dockerContainerMap map[string]*apicontainer.DockerContainer) (bool, string) {
+	if container == task.GetServiceConnectContainer() {
+		return false, "" // SC container will use bridge mode (it doesn't need a pause container)
+	}
+	pauseContainer, err := task.getBridgeModePauseContainerForTaskContainer(container)
+	if err != nil {
+		// This should never be the case and implies a code-bug.
+		logger.Critical("Pause container required per task container for Service Connect task bridge mode, but "+
+			"not found for task container", logger.Fields{
+			field.TaskID:    task.GetID(),
+			field.Container: container.Name,
+		})
+		return false, ""
+	}
+	dockerPauseContainer, ok := dockerContainerMap[pauseContainer.Name]
+	if !ok || dockerPauseContainer == nil {
+		// This should never be the case and implies a code-bug.
+		logger.Critical("Pause container required per task container for Service Connect task bridge mode, but "+
+			"not found in docker container map for task container", logger.Fields{
+			field.TaskID:    task.GetID(),
+			field.Container: container.Name,
+		})
+		return false, ""
+	}
+	return true, dockerMappingContainerPrefix + dockerPauseContainer.DockerID
 }
 
 // overrideDNS overrides a container's host config if the following conditions are
@@ -2110,14 +2260,44 @@ func (task *Task) dockerLinks(container *apicontainer.Container, dockerContainer
 	return dockerLinkArr, nil
 }
 
-func (task *Task) dockerPortMap(container *apicontainer.Container) nat.PortMap {
+func (task *Task) dockerPortMap(container *apicontainer.Container) (nat.PortMap, error) {
 	dockerPortMap := nat.PortMap{}
+	scContainer := task.GetServiceConnectContainer()
+	containerToCheck := container
+	if task.IsServiceConnectEnabled() && task.IsNetworkModeBridge() {
+		if container == scContainer {
+			// create bindings for all ingress listener ports
+			// no need to create binding for egress listener port as it won't be access from host level or from outside
+			for _, ic := range task.ServiceConnectConfig.IngressConfig {
+				dockerPort := nat.Port(strconv.Itoa(int(ic.ListenerPort))) + "/tcp"
+				hostPort := 0           // default bridge-mode SC experience - host port will be an ephemeral port assigned by docker
+				if ic.HostPort != nil { // non-default bridge-mode SC experience - host port specified by customer
+					hostPort = int(*ic.HostPort)
+				}
+				dockerPortMap[dockerPort] = append(dockerPortMap[dockerPort], nat.PortBinding{HostPort: strconv.Itoa(hostPort)})
+			}
+		} else if container.Type == apicontainer.ContainerCNIPause {
+			// we will create bindings for customer task container and let them be published by the associated pause container
+			// Note - for SC bridge mode we do not allow customer to specify a host port for their containers. Additionally,
+			// When an ephemeral host port is assigned, Appnet will NOT proxy traffic to that port
+			taskContainer, err := task.getBridgeModeTaskContainerForPauseContainer(container)
+			if err != nil {
+				return nil, err
+			}
+			containerToCheck = taskContainer
+		} else {
+			// If container is neither SC container nor pause container, it's a regular task container. Its port bindings(s)
+			// are published by the associated pause container, and we leave the map empty here (docker would actually complain
+			// otherwise).
+			return dockerPortMap, nil
+		}
+	}
 
-	for _, portBinding := range container.Ports {
+	for _, portBinding := range containerToCheck.Ports {
 		dockerPort := nat.Port(strconv.Itoa(int(portBinding.ContainerPort)) + "/" + portBinding.Protocol.String())
 		dockerPortMap[dockerPort] = append(dockerPortMap[dockerPort], nat.PortBinding{HostPort: strconv.Itoa(int(portBinding.HostPort))})
 	}
-	return dockerPortMap
+	return dockerPortMap, nil
 }
 
 func (task *Task) dockerVolumesFrom(container *apicontainer.Container, dockerContainerMap map[string]*apicontainer.DockerContainer) ([]string, error) {
@@ -2972,4 +3152,28 @@ func (task *Task) GetServiceConnectContainer() *apicontainer.Container {
 // IsServiceConnectEnabled returns true if Service Connect is enabled for this task.
 func (task *Task) IsServiceConnectEnabled() bool {
 	return task.GetServiceConnectContainer() != nil
+}
+
+// PopulateServiceConnectContainerMappingEnvVar populates APPNET_CONTAINER_MAPPING env var for AppNet Agent container
+// aka SC container
+func (task *Task) PopulateServiceConnectContainerMappingEnvVar() error {
+	envVars := make(map[string]string)
+	containerMapping := make(map[string]string)
+	for _, c := range task.Containers {
+		if c.Type != apicontainer.ContainerCNIPause {
+			continue
+		}
+		taskContainer, err := task.getBridgeModeTaskContainerForPauseContainer(c)
+		if err != nil {
+			return fmt.Errorf("error retrieving task container for pause container %s: %+v", c.Name, err)
+		}
+		containerMapping[taskContainer.Name] = c.GetNetworkSettings().IPAddress
+	}
+	containerMappingJson, err := json.Marshal(containerMapping)
+	if err != nil {
+		return fmt.Errorf("error injecting required env vars APPNET_CONTAINER_MAPPING to Service Connect container: %w", err)
+	}
+	envVars[serviceConnectContainerMappingEnvVar] = string(containerMappingJson)
+	task.GetServiceConnectContainer().MergeEnvironmentVariables(envVars)
+	return nil
 }

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -20,8 +20,12 @@ import (
 	"fmt"
 	"reflect"
 	"runtime"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/docker/go-connections/nat"
 
 	"github.com/aws/amazon-ecs-agent/agent/acs/model/ecsacs"
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
@@ -184,6 +188,185 @@ func TestDockerHostConfigPortBinding(t *testing.T) {
 	assert.True(t, ok, "Could not get port bindings")
 	assert.Equal(t, 1, len(bindings), "Wrong number of bindings")
 	assert.Equal(t, "20", bindings[0].HostPort, "Wrong hostport")
+}
+
+var (
+	SCTaskContainerPort1            uint16 = 8080
+	SCTaskContainerPort2            uint16 = 9090
+	SCIngressListener1ContainerPort uint16 = 15000
+	SCIngressListener2ContainerPort uint16 = 16000
+	SCIngressListener2HostPort      uint16 = 17000
+	SCEgressListenerContainerPort   uint16 = 12345
+	defaultSCProtocol                      = "/tcp"
+)
+
+func getTestTaskServiceConnectBridgeMode() *Task {
+	testTask := &Task{
+		NetworkMode: BridgeNetworkMode,
+		Containers: []*apicontainer.Container{
+			{
+				Name: "C1",
+				Ports: []apicontainer.PortBinding{
+					{SCTaskContainerPort1, 0, "", apicontainer.TransportProtocolTCP},
+					{SCTaskContainerPort2, 0, "", apicontainer.TransportProtocolTCP},
+				},
+				NetworkModeUnsafe: "", // should later be overridden to container mode
+			},
+			{
+				Name:              fmt.Sprintf("%s-%s", NetworkPauseContainerName, "C1"),
+				Type:              apicontainer.ContainerCNIPause,
+				NetworkModeUnsafe: "", // should later be overridden to explicit bridge mode
+			},
+			{
+				Name:              serviceConnectContainerTestName, // port binding is retrieved through listener config
+				NetworkModeUnsafe: "",                              // should not be overridden (implicit bridge mode)
+			},
+		},
+	}
+
+	testTask.ServiceConnectConfig = &ServiceConnectConfig{
+		ContainerName: serviceConnectContainerTestName,
+		IngressConfig: []IngressConfigEntry{
+			{
+				ListenerName: "testListener1", // bridge mode default - ephemeral listener host port
+				ListenerPort: SCIngressListener1ContainerPort,
+			},
+			{
+				ListenerName: "testListener2", // bridge mode non-default - user-specified listener host port
+				ListenerPort: SCIngressListener2ContainerPort,
+				HostPort:     &SCIngressListener2HostPort,
+			},
+		},
+		EgressConfig: EgressConfig{
+			ListenerName: "testEgressListener",
+			ListenerPort: SCEgressListenerContainerPort, // Presently this should always get ephemeral port
+		},
+	}
+	return testTask
+}
+
+func convertSCPort(port uint16) nat.Port {
+	return nat.Port(strconv.Itoa(int(port)) + defaultSCProtocol)
+}
+
+// TestDockerHostConfigSCBridgeMode verifies port bindings and network mode overrides for each
+// container in an SC-enabled bridge mode task. The test task is consisted of the SC container, a regular container,
+// and the pause container associated with it.
+func TestDockerHostConfigSCBridgeMode(t *testing.T) {
+	testTask := getTestTaskServiceConnectBridgeMode()
+	// task container should get empty port binding map and "container" network mode
+	actualConfig, err := testTask.DockerHostConfig(testTask.Containers[0], dockerMap(testTask), defaultDockerClientAPIVersion,
+		&config.Config{})
+	assert.Nil(t, err)
+	assert.NotNil(t, actualConfig)
+	assert.Equal(t, dockercontainer.NetworkMode(fmt.Sprintf("%s-%s", // e.g. "container:dockerid-~internal~ecs~pause-C1"
+		dockerMappingContainerPrefix+dockerIDPrefix+NetworkPauseContainerName, "C1")), actualConfig.NetworkMode)
+	assert.Empty(t, actualConfig.PortBindings, "Task container port binding should be empty")
+
+	// pause container should get port binding map of the task container
+	actualConfig, err = testTask.DockerHostConfig(testTask.Containers[1], dockerMap(testTask), defaultDockerClientAPIVersion,
+		&config.Config{})
+	assert.Nil(t, err)
+	assert.NotNil(t, actualConfig)
+	assert.Equal(t, dockercontainer.NetworkMode(BridgeNetworkMode), actualConfig.NetworkMode)
+	bindings, ok := actualConfig.PortBindings[convertSCPort(SCTaskContainerPort1)]
+	assert.True(t, ok, "Could not get port bindings")
+	assert.Equal(t, 1, len(bindings), "Wrong number of bindings")
+	assert.Equal(t, "0", bindings[0].HostPort, "Wrong hostport")
+	bindings, ok = actualConfig.PortBindings[convertSCPort(SCTaskContainerPort2)]
+	assert.True(t, ok, "Could not get port bindings")
+	assert.Equal(t, 1, len(bindings), "Wrong number of bindings")
+	assert.Equal(t, "0", bindings[0].HostPort, "Wrong hostport")
+
+	// SC container should get port binding map of all ingress listeners
+	actualConfig, err = testTask.DockerHostConfig(testTask.Containers[2], dockerMap(testTask), defaultDockerClientAPIVersion,
+		&config.Config{})
+	assert.Nil(t, err)
+	assert.NotNil(t, actualConfig)
+	assert.Equal(t, dockercontainer.NetworkMode(""), actualConfig.NetworkMode)
+	// SC - ingress listener 1 - default experience
+	bindings, ok = actualConfig.PortBindings[convertSCPort(SCIngressListener1ContainerPort)]
+	assert.True(t, ok, "Could not get port bindings")
+	assert.Equal(t, 1, len(bindings), "Wrong number of bindings")
+	assert.Equal(t, "0", bindings[0].HostPort, "Wrong hostport")
+	// SC - ingress listener 2 - non-default host port
+	bindings, ok = actualConfig.PortBindings[convertSCPort(SCIngressListener2ContainerPort)]
+	assert.True(t, ok, "Could not get port bindings")
+	assert.Equal(t, 1, len(bindings), "Wrong number of bindings")
+	assert.Equal(t, strconv.Itoa(int(SCIngressListener2HostPort)), bindings[0].HostPort, "Wrong hostport")
+	// SC - egress listener - should not have port binding
+	bindings, ok = actualConfig.PortBindings[convertSCPort(SCEgressListenerContainerPort)]
+	assert.False(t, ok, "egress listener has port binding but it shouldn't")
+}
+
+// TestDockerHostConfigSCBridgeMode_getPortBindingFailure verifies that when we can't find the task
+// container associated with the pause container, DockerHostConfig should return failure (from getPortBinding)
+func TestDockerHostConfigSCBridgeMode_getPortBindingFailure(t *testing.T) {
+	testTask := getTestTaskServiceConnectBridgeMode()
+	testTask.Containers[1].Name = "invalid" // make the pause container name invalid such that we can't resolve task container from it
+	_, err := testTask.DockerHostConfig(testTask.Containers[1], dockerMap(testTask), defaultDockerClientAPIVersion,
+		&config.Config{})
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Msg, "error retrieving docker port map"))
+}
+
+// TestDockerContainerConfigSCBridgeMode verifies exposed port configuration for each container
+// in an SC-enabled bridge mode task. The test task is consisted of the SC container, a regular container,
+// and the pause container associated with it.
+func TestDockerContainerConfigSCBridgeMode(t *testing.T) {
+	testTask := getTestTaskServiceConnectBridgeMode()
+
+	// Containers[0] aka user-defined task container should NOT expose any ports (it's done through the associated pause container)
+	actualConfig, err := testTask.DockerConfig(testTask.Containers[0], defaultDockerClientAPIVersion)
+	assert.Nil(t, err)
+	assert.NotNil(t, actualConfig)
+	assert.Empty(t, actualConfig.ExposedPorts)
+
+	// Containers[1] pause container should expose all container ports from the associated user-defined task containers
+	actualConfig, err = testTask.DockerConfig(testTask.Containers[1], defaultDockerClientAPIVersion)
+	assert.Nil(t, err)
+	assert.NotNil(t, actualConfig)
+	assert.NotNil(t, actualConfig.ExposedPorts)
+	assert.Equal(t, 2, len(actualConfig.ExposedPorts))
+	_, ok := actualConfig.ExposedPorts[convertSCPort(SCTaskContainerPort1)]
+	assert.True(t, ok)
+	_, ok = actualConfig.ExposedPorts[convertSCPort(SCTaskContainerPort2)]
+	assert.True(t, ok)
+
+	// Containers[2] aka SC container should expose all container ports from SC ingress and egress listeners
+	actualConfig, err = testTask.DockerConfig(testTask.Containers[2], defaultDockerClientAPIVersion)
+	assert.Nil(t, err)
+	assert.NotNil(t, actualConfig)
+	assert.NotNil(t, actualConfig.ExposedPorts)
+	assert.Equal(t, 3, len(actualConfig.ExposedPorts))
+	_, ok = actualConfig.ExposedPorts[convertSCPort(SCIngressListener1ContainerPort)]
+	assert.True(t, ok)
+	_, ok = actualConfig.ExposedPorts[convertSCPort(SCIngressListener2ContainerPort)]
+	assert.True(t, ok)
+	_, ok = actualConfig.ExposedPorts[convertSCPort(SCEgressListenerContainerPort)]
+	assert.True(t, ok)
+}
+
+func TestDockerContainerConfigSCBridgeMode_getExposedPortsFailure(t *testing.T) {
+	testTask := getTestTaskServiceConnectBridgeMode()
+	testTask.Containers[1].Name = "invalid" // make the pause container name invalid such that we can't resolve task container from it
+	_, err := testTask.DockerConfig(testTask.Containers[1], defaultDockerClientAPIVersion)
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Msg, "error resolving docker exposed ports"))
+}
+
+func TestDockerContainerConfigSCBridgeMode_emptyEgressConfig(t *testing.T) {
+	testTask := getTestTaskServiceConnectBridgeMode()
+	testTask.ServiceConnectConfig.EgressConfig = EgressConfig{}
+	actualConfig, err := testTask.DockerConfig(testTask.Containers[2], defaultDockerClientAPIVersion)
+	assert.Nil(t, err)
+	assert.NotNil(t, actualConfig)
+	assert.NotNil(t, actualConfig.ExposedPorts)
+	assert.Equal(t, 2, len(actualConfig.ExposedPorts))
+	_, ok := actualConfig.ExposedPorts[convertSCPort(SCIngressListener1ContainerPort)]
+	assert.True(t, ok)
+	_, ok = actualConfig.ExposedPorts[convertSCPort(SCIngressListener2ContainerPort)]
+	assert.True(t, ok)
 }
 
 func TestDockerHostConfigVolumesFrom(t *testing.T) {
@@ -3560,7 +3743,7 @@ func TestIsServiceConnectEnabled(t *testing.T) {
 	}
 }
 
-func TestPostUnmarshalTaskWithServiceConnect(t *testing.T) {
+func TestPostUnmarshalTaskWithServiceConnectAWSVPCMode(t *testing.T) {
 	const (
 		utilizedPort1 = 33333
 		utilizedPort2 = 44444
@@ -3578,25 +3761,9 @@ func TestPostUnmarshalTaskWithServiceConnect(t *testing.T) {
 		Family:        strptr("myFamily"),
 		Version:       strptr("1"),
 		Containers: []*ecsacs.Container{
-			{
-				Name: aws.String("C1"),
-				PortMappings: []*ecsacs.PortMapping{
-					{
-						ContainerPort: aws.Int64(utilizedPort1),
-					},
-				},
-			},
-			{
-				Name: aws.String("C2"),
-				PortMappings: []*ecsacs.PortMapping{
-					{
-						ContainerPort: aws.Int64(utilizedPort2),
-					},
-				},
-			},
-			{
-				Name: aws.String(serviceConnectContainerTestName),
-			},
+			containerFromACS("C1", utilizedPort1, 0, AWSVPCNetworkMode),
+			containerFromACS("C2", utilizedPort2, 0, AWSVPCNetworkMode),
+			containerFromACS(serviceConnectContainerTestName, 0, 0, AWSVPCNetworkMode),
 		},
 	}
 	seqNum := int64(42)
@@ -3634,6 +3801,101 @@ func TestPostUnmarshalTaskWithServiceConnect(t *testing.T) {
 
 }
 
+// TestPostUnmarshalTaskWithServiceConnectBridgeMode verifies pause container creation and container dependency/ordering
+// for an SC-enabled bridge mode task. We verify:
+// - regular taskContainer.CREATED depends on SCContainer.RESOURCES_PROVISIONED
+// - regular taskContainer.CREATED depends on SCContainer.HEALTHY
+// - a pause container is created for each regular task container, and has steady state RUNNING
+// - SCContainer.PULLED depends on ALL pauseContainer.RUNNING
+// - SCContainer.STOPPED depends on ALL taskContainer.STOPPED
+// - pauseContainer.STOPPED depends on SCContainer.STOPPED
+func TestPostUnmarshalTaskWithServiceConnectBridgeMode(t *testing.T) {
+	const (
+		utilizedPort1 = 33333
+		utilizedPort2 = 44444
+		listenerPort1 = 15000
+		listenerPort2 = 16000
+		listenerPort3 = 17000
+	)
+	utilizedPorts := map[uint16]struct{}{
+		utilizedPort1: {},
+		utilizedPort2: {},
+		listenerPort1: {},
+		listenerPort2: {},
+		listenerPort3: {},
+	}
+	taskFromACS := ecsacs.Task{
+		Arn:           strptr("myArn"),
+		DesiredStatus: strptr("RUNNING"),
+		Family:        strptr("myFamily"),
+		Version:       strptr("1"),
+		Containers: []*ecsacs.Container{
+			containerFromACS("C1", utilizedPort1, 0, BridgeNetworkMode),
+			containerFromACS("C2", utilizedPort2, 0, BridgeNetworkMode),
+			containerFromACS(serviceConnectContainerTestName, 0, 0, BridgeNetworkMode),
+		},
+	}
+	seqNum := int64(42)
+	task, err := TaskFromACS(&taskFromACS, &ecsacs.PayloadMessage{SeqNum: &seqNum})
+	testSCConfig := ServiceConnectConfig{
+		ContainerName: serviceConnectContainerTestName,
+		IngressConfig: []IngressConfigEntry{
+			{
+				ListenerName: "testListener1",
+				ListenerPort: listenerPort1,
+			},
+			{
+				ListenerName: "testListener2",
+				ListenerPort: listenerPort2,
+			},
+			{
+				ListenerName: "testListener3",
+				ListenerPort: listenerPort3,
+			},
+		},
+		EgressConfig: EgressConfig{
+			ListenerName: "testEgressListener",
+			ListenerPort: 0, // Presently this should always get ephemeral port
+		},
+	}
+	originalSCConfig := cloneSCConfig(testSCConfig)
+	task.ServiceConnectConfig = &testSCConfig
+	assert.Nil(t, err, "Should be able to handle acs task")
+	err = task.PostUnmarshalTask(&config.Config{}, nil, nil, nil, nil)
+	assert.NoError(t, err)
+	validateServiceConnectContainerOrder(t, task)
+	validateEphemeralPorts(t, task, originalSCConfig, utilizedPorts)
+	validateAppnetEnvVars(t, task)
+	validateServiceConnectBridgeModePauseContainer(t, task)
+}
+
+func containerFromACS(name string, containerPort int64, hostPort int64, networkMode string) *ecsacs.Container {
+	var portMapping *ecsacs.PortMapping
+	if containerPort != 0 || hostPort != 0 {
+		portMapping = &ecsacs.PortMapping{}
+		if containerPort != 0 {
+			portMapping.ContainerPort = aws.Int64(containerPort)
+		}
+		if hostPort != 0 {
+			portMapping.HostPort = aws.Int64(hostPort)
+		}
+	}
+
+	container := &ecsacs.Container{
+		Name: aws.String(name),
+		DockerConfig: &ecsacs.DockerConfig{
+			HostConfig: aws.String(fmt.Sprintf(
+				`{"NetworkMode":"%s"}`, networkMode)),
+		},
+	}
+	if portMapping != nil {
+		container.PortMappings = []*ecsacs.PortMapping{
+			portMapping,
+		}
+	}
+	return container
+}
+
 func cloneSCConfig(scConfig ServiceConnectConfig) ServiceConnectConfig {
 	clone := scConfig
 	clone.IngressConfig = nil
@@ -3669,6 +3931,25 @@ func validateServiceConnectContainerOrder(t *testing.T, task *Task) {
 		ContainerName:   "C2",
 		SatisfiedStatus: apicontainerstatus.ContainerStopped,
 	}, scC.TransitionDependenciesMap[apicontainerstatus.ContainerStopped].ContainerDependencies[1])
+
+	// For bridge mode, also check that regular containers CREATED have a dependency on SC container RESOURCES_PROVISIONED
+	if task.IsNetworkModeBridge() {
+		assert.NotEmpty(t, c1.TransitionDependenciesMap)
+		assert.NotNil(t, c1.TransitionDependenciesMap[apicontainerstatus.ContainerCreated])
+		assert.NotEmpty(t, c1.TransitionDependenciesMap[apicontainerstatus.ContainerCreated].ContainerDependencies)
+		assert.Equal(t, apicontainer.ContainerDependency{
+			ContainerName:   serviceConnectContainerTestName,
+			SatisfiedStatus: apicontainerstatus.ContainerResourcesProvisioned,
+		}, c1.TransitionDependenciesMap[apicontainerstatus.ContainerCreated].ContainerDependencies[0])
+
+		assert.NotEmpty(t, c2.TransitionDependenciesMap)
+		assert.NotNil(t, c2.TransitionDependenciesMap[apicontainerstatus.ContainerCreated])
+		assert.NotEmpty(t, c2.TransitionDependenciesMap[apicontainerstatus.ContainerCreated].ContainerDependencies)
+		assert.Equal(t, apicontainer.ContainerDependency{
+			ContainerName:   serviceConnectContainerTestName,
+			SatisfiedStatus: apicontainerstatus.ContainerResourcesProvisioned,
+		}, c2.TransitionDependenciesMap[apicontainerstatus.ContainerCreated].ContainerDependencies[0])
+	}
 }
 
 func validateEphemeralPorts(t *testing.T, task *Task, originalSCConfig ServiceConnectConfig, utilizedPorts map[uint16]struct{}) {
@@ -3719,13 +4000,49 @@ func validateAppnetEnvVars(t *testing.T, task *Task) {
 		portMapping := make(map[string]int)
 		err := json.Unmarshal([]byte(portMappingStr), &portMapping)
 		assert.NoError(t, err, "Error parsing APPNET_LISTENER_PORT_MAPPING")
-		listener1 := task.ServiceConnectConfig.IngressConfig[0]
-		listener3 := task.ServiceConnectConfig.IngressConfig[2]
+		if task.IsNetworkModeAWSVPC() { // ECS Agent only select ephemeral listener ports for default SC AWSVPC tasks
+			listener1 := task.ServiceConnectConfig.IngressConfig[0]
+			listener3 := task.ServiceConnectConfig.IngressConfig[2]
+			assert.Equalf(t, int(listener1.ListenerPort), portMapping[listener1.ListenerName], "Listener-port mapping incorrectly configured for %s", listener1.ListenerName)
+			assert.Equalf(t, int(listener3.ListenerPort), portMapping[listener3.ListenerName], "Listener-port mapping incorrectly configured for %s", listener3.ListenerName)
+		}
 		egressListener := task.ServiceConnectConfig.EgressConfig
-		assert.Equalf(t, int(listener1.ListenerPort), portMapping[listener1.ListenerName], "Listener-port mapping incorrectly configured for %s", listener1.ListenerName)
-		assert.Equalf(t, int(listener3.ListenerPort), portMapping[listener3.ListenerName], "Listener-port mapping incorrectly configured for %s", listener3.ListenerName)
 		assert.Equalf(t, int(egressListener.ListenerPort), portMapping[egressListener.ListenerName], "Listener-port mapping incorrectly configured for %s", egressListener.ListenerName)
 	}
+}
+
+func validateServiceConnectBridgeModePauseContainer(t *testing.T, task *Task) {
+	scC, _ := task.ContainerByName(serviceConnectContainerTestName)
+	p1, ok := task.ContainerByName(fmt.Sprintf("%s-%s", NetworkPauseContainerName, "C1"))
+	assert.True(t, ok)
+	p2, ok := task.ContainerByName(fmt.Sprintf("%s-%s", NetworkPauseContainerName, "C2"))
+	assert.True(t, ok)
+
+	// verify that SCContainer.CREATED depends on PauseContainer.RUNNING
+	assert.NotEmpty(t, scC.TransitionDependenciesMap)
+	assert.NotNil(t, scC.TransitionDependenciesMap[apicontainerstatus.ContainerCreated])
+	containerDependencies := scC.TransitionDependenciesMap[apicontainerstatus.ContainerCreated].ContainerDependencies
+	assert.NotEmpty(t, containerDependencies)
+	assert.Equal(t, p1.Name, containerDependencies[0].ContainerName)
+	assert.Equal(t, apicontainerstatus.ContainerRunning, containerDependencies[0].SatisfiedStatus)
+	assert.Equal(t, p2.Name, containerDependencies[1].ContainerName)
+	assert.Equal(t, apicontainerstatus.ContainerRunning, containerDependencies[1].SatisfiedStatus)
+
+	// verify that PauseContainer.STOPPED depends on SCContainer.STOPPED
+	assert.NotEmpty(t, p1.TransitionDependenciesMap)
+	assert.NotNil(t, p1.TransitionDependenciesMap[apicontainerstatus.ContainerStopped])
+	assert.NotEmpty(t, p1.TransitionDependenciesMap[apicontainerstatus.ContainerStopped].ContainerDependencies)
+	assert.Equal(t, apicontainer.ContainerDependency{
+		ContainerName:   serviceConnectContainerTestName,
+		SatisfiedStatus: apicontainerstatus.ContainerStopped,
+	}, p1.TransitionDependenciesMap[apicontainerstatus.ContainerStopped].ContainerDependencies[0])
+
+	assert.NotEmpty(t, p2.TransitionDependenciesMap)
+	assert.NotNil(t, p2.TransitionDependenciesMap[apicontainerstatus.ContainerStopped])
+	assert.Equal(t, apicontainer.ContainerDependency{
+		ContainerName:   serviceConnectContainerTestName,
+		SatisfiedStatus: apicontainerstatus.ContainerStopped,
+	}, p2.TransitionDependenciesMap[apicontainerstatus.ContainerStopped].ContainerDependencies[0])
 }
 
 func TestPostUnmarshalTaskNetworkModeInference(t *testing.T) {
@@ -3798,4 +4115,49 @@ func TestPostUnmarshalTaskNetworkModeInference(t *testing.T) {
 			assert.True(t, task.IsNetworkModeHost())
 		}
 	}
+}
+
+func TestGetBridgeModePauseContainerForTaskContainer(t *testing.T) {
+	testTask := getTestTaskServiceConnectBridgeMode()
+	container, err := testTask.getBridgeModePauseContainerForTaskContainer(testTask.Containers[0])
+	assert.Nil(t, err)
+	assert.NotNil(t, container)
+	assert.Equal(t, testTask.Containers[1].Name, container.Name)
+}
+
+func TestGetBridgeModePauseContainerForTaskContainer_NotFound(t *testing.T) {
+	testTask := getTestTaskServiceConnectBridgeMode()
+	testTask.Containers[1].Name = "invalid"
+	_, err := testTask.getBridgeModePauseContainerForTaskContainer(testTask.Containers[0])
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "could not find pause container"))
+}
+
+func TestGetBridgeModeTaskContainerForPauseContainer(t *testing.T) {
+	testTask := getTestTaskServiceConnectBridgeMode()
+	// make the service container name include "-" to make sure we can still resolve service container from pause container name correctly
+	serviceContainerName := "service-container-name"
+	testTask.Containers[0].Name = serviceContainerName
+	testTask.Containers[1].Name = fmt.Sprintf("%s-%s", NetworkPauseContainerName, serviceContainerName)
+
+	container, err := testTask.getBridgeModeTaskContainerForPauseContainer(testTask.Containers[1])
+	assert.Nil(t, err)
+	assert.NotNil(t, container)
+	assert.Equal(t, testTask.Containers[0].Name, container.Name)
+}
+
+func TestGetBridgeModeTaskContainerForPauseContainer_InvalidPauseContainerName(t *testing.T) {
+	testTask := getTestTaskServiceConnectBridgeMode()
+	testTask.Containers[1].Name = "invalid"
+	_, err := testTask.getBridgeModeTaskContainerForPauseContainer(testTask.Containers[1])
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "does not conform to ~internal~ecs~pause-$TASK_CONTAINER_NAME format"))
+}
+
+func TestGetBridgeModeTaskContainerForPauseContainer_NotFound(t *testing.T) {
+	testTask := getTestTaskServiceConnectBridgeMode()
+	testTask.Containers[0].Name = "anotherTaskContainer"
+	_, err := testTask.getBridgeModeTaskContainerForPauseContainer(testTask.Containers[1])
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "could not find task container"))
 }

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -1662,6 +1662,11 @@ func (engine *DockerTaskEngine) provisionContainerResources(task *apitask.Task, 
 		}
 	}
 
+	if task.IsServiceConnectEnabled() && task.IsNetworkModeBridge() && container == task.GetServiceConnectContainer() {
+		// TODO [SC]: CNI integration for SC bridge-mode task
+		return dockerapi.MetadataFromContainer(containerInspectOutput)
+	}
+
 	task.SetPausePIDInVolumeResources(strconv.Itoa(containerInspectOutput.State.Pid))
 
 	cniConfig, err := engine.buildCNIConfigFromTaskContainer(task, containerInspectOutput, true)
@@ -1712,9 +1717,7 @@ func (engine *DockerTaskEngine) provisionContainerResources(task *apitask.Task, 
 		}
 	}
 
-	return dockerapi.DockerContainerMetadata{
-		DockerID: cniConfig.ContainerID,
-	}
+	return dockerapi.MetadataFromContainer(containerInspectOutput)
 }
 
 // checkTearDownPauseContainerAwsvpc idempotently tears down the pause container network when the pause container's known

--- a/agent/engine/docker_task_engine_linux_test.go
+++ b/agent/engine/docker_task_engine_linux_test.go
@@ -873,6 +873,7 @@ func TestContainersWithServiceConnect(t *testing.T) {
 	taskEngine.(*DockerTaskEngine).taskSteadyStatePollInterval = taskSteadyStatePollInterval
 	eventStream := make(chan dockerapi.DockerContainerChangeEvent)
 	sleepTask := testdata.LoadTask("sleep5TwoContainers")
+	sleepTask.NetworkMode = apitask.AWSVPCNetworkMode
 	sleepContainer1 := sleepTask.Containers[0]
 	sleepContainer1.TransitionDependenciesMap = make(map[apicontainerstatus.ContainerStatus]apicontainer.TransitionDependencySet)
 	sleepContainer2 := sleepTask.Containers[1]
@@ -977,7 +978,6 @@ func TestContainersWithServiceConnect(t *testing.T) {
 
 	err = taskEngine.Init(ctx)
 	assert.NoError(t, err)
-
 	taskEngine.AddTask(sleepTask)
 	stateChangeEvents := taskEngine.StateChangeEvents()
 	verifyTaskIsRunning(stateChangeEvents, sleepTask)
@@ -1036,4 +1036,200 @@ func TestContainersWithServiceConnect(t *testing.T) {
 	}
 	wg.Wait()
 
+}
+
+// TestContainersWithServiceConnect_BridgeMode verifies the start/stop of a bridge mode SC task
+func TestContainersWithServiceConnect_BridgeMode(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	ctrl, dockerClient, mockTime, taskEngine, _, imageManager, _, serviceConnectManager := mocks(t, ctx, &defaultConfig)
+	defer ctrl.Finish()
+
+	cniClient := mock_ecscni.NewMockCNIClient(ctrl)
+	taskEngine.(*DockerTaskEngine).cniClient = cniClient
+	taskEngine.(*DockerTaskEngine).taskSteadyStatePollInterval = taskSteadyStatePollInterval
+	eventStream := make(chan dockerapi.DockerContainerChangeEvent)
+	sleepTask := testdata.LoadTask("sleep5PortMappings")
+	sleepContainer := sleepTask.Containers[0]
+	sleepContainer.TransitionDependenciesMap = make(map[apicontainerstatus.ContainerStatus]apicontainer.TransitionDependencySet)
+
+	// Inject mock SC config
+	sleepTask.ServiceConnectConfig = &apitask.ServiceConnectConfig{
+		ContainerName: "service-connect",
+		IngressConfig: []apitask.IngressConfigEntry{
+			{
+				ListenerName: "testListener1", // bridge mode default - ephemeral listener host port
+				ListenerPort: 15000,
+			},
+		},
+		EgressConfig: apitask.EgressConfig{
+			ListenerName: "testEgressListener",
+			ListenerPort: 0, // Presently this should always get ephemeral port
+		},
+		DNSConfig: []apitask.DNSConfigEntry{
+			{
+				HostName: "host1.my.corp",
+				Address:  "169.254.1.1",
+			},
+			{
+				HostName: "host1.my.corp",
+				Address:  "ff06::c4",
+			},
+		},
+	}
+
+	// if we create a dockercontainer.Config.Healthcheck variable and marshal it, dockercontainer.Config.Env gets set to empty
+	// and will later override the internal env vars that Agent populates for the container.
+	// In real world, the container env vars in task def are marshaled into container.Environment isntead of docker Config.Env.
+	// it gets merged with internal env vars, and eventually get assigned to docker Config.Env
+	healthCheckString := "{\"Healthcheck\":{\"Test\":[\"echo\",\"ok\"],\"Interval\":1000000,\"Timeout\":1000000000,\"Retries\":1}}"
+	sleepTask.Containers = append(sleepTask.Containers, &apicontainer.Container{
+		Name:                      sleepTask.ServiceConnectConfig.ContainerName,
+		HealthCheckType:           apicontainer.DockerHealthCheckType,
+		DockerConfig:              apicontainer.DockerConfig{Config: aws.String(healthCheckString)},
+		TransitionDependenciesMap: make(map[apicontainerstatus.ContainerStatus]apicontainer.TransitionDependencySet),
+		DesiredStatusUnsafe:       apicontainerstatus.ContainerRunning,
+	})
+
+	dockerClient.EXPECT().ContainerEvents(gomock.Any()).Return(eventStream, nil)
+
+	sleepContainerID := containerID + "1"
+	scContainerID := "serviceConnectID"
+	pauseContainerID := "pauseContainerID"
+
+	// Pause container will be launched first
+	gomock.InOrder(
+		dockerClient.EXPECT().APIVersion().Return(defaultDockerClientAPIVersion, nil),
+		serviceConnectManager.EXPECT().AugmentTaskContainer(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil),
+		dockerClient.EXPECT().CreateContainer(
+			gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(
+			func(ctx interface{}, config *dockercontainer.Config, hostConfig *dockercontainer.HostConfig, y, z interface{}) {
+				verifyServiceConnectPauseContainerBridgeMode(t, ctx, config, hostConfig, y, z)
+			}).Return(dockerapi.DockerContainerMetadata{DockerID: pauseContainerID}),
+		dockerClient.EXPECT().StartContainer(gomock.Any(), pauseContainerID, defaultConfig.ContainerStartTimeout).Return(
+			dockerapi.DockerContainerMetadata{
+				DockerID: pauseContainerID,
+				NetworkSettings: &types.NetworkSettings{
+					DefaultNetworkSettings: types.DefaultNetworkSettings{IPAddress: "1.2.3.4"},
+				}},
+		),
+	)
+
+	// For SC and sleep container - those calls can happen in parallel
+	imageManager.EXPECT().AddAllImageStates(gomock.Any()).AnyTimes()
+	dockerClient.EXPECT().PullImage(gomock.Any(), gomock.Any(), nil, gomock.Any()).Return(dockerapi.DockerContainerMetadata{}).Times(2)
+	imageManager.EXPECT().RecordContainerReference(gomock.Any()).Return(nil).Times(2)
+	imageManager.EXPECT().GetImageStateFromImageName(gomock.Any()).Return(nil, false).Times(2)
+	dockerClient.EXPECT().APIVersion().Return(defaultDockerClientAPIVersion, nil).Times(2)
+	serviceConnectManager.EXPECT().AugmentTaskContainer(gomock.Any(), gomock.Any(), gomock.Any()).Times(2)
+
+	gomock.InOrder(
+		// SC container
+		dockerClient.EXPECT().CreateContainer(
+			gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(
+			func(ctx interface{}, config *dockercontainer.Config, hostConfig *dockercontainer.HostConfig, y, z interface{}) {
+				verifyServiceConnectAppnetContainerBridgeMode(t, ctx, config, hostConfig, y, z)
+			}).Return(dockerapi.DockerContainerMetadata{DockerID: scContainerID}),
+		dockerClient.EXPECT().StartContainer(gomock.Any(), scContainerID, defaultConfig.ContainerStartTimeout).Return(
+			dockerapi.DockerContainerMetadata{DockerID: scContainerID}),
+		dockerClient.EXPECT().InspectContainer(gomock.Any(), scContainerID, gomock.Any()).Return(
+			&types.ContainerJSON{
+				ContainerJSONBase: &types.ContainerJSONBase{
+					ID: scContainerID,
+					State: &types.ContainerState{
+						Pid:    containerPid,
+						Health: &types.Health{Status: types.Healthy},
+					},
+				}}, nil),
+
+		// sleep container should only start after SC
+		dockerClient.EXPECT().CreateContainer(gomock.Any(), gomock.Any(), gomock.Any(),
+			gomock.Any(), gomock.Any()).Return(dockerapi.DockerContainerMetadata{DockerID: sleepContainerID}),
+		dockerClient.EXPECT().StartContainer(gomock.Any(), sleepContainerID, defaultConfig.ContainerStartTimeout).Return(
+			dockerapi.DockerContainerMetadata{DockerID: sleepContainerID}),
+	)
+
+	cleanup := make(chan time.Time)
+	defer close(cleanup)
+	mockTime.EXPECT().Now().Return(time.Now()).MinTimes(1)
+	dockerClient.EXPECT().DescribeContainer(gomock.Any(), scContainerID).AnyTimes()
+	dockerClient.EXPECT().DescribeContainer(gomock.Any(), sleepContainerID).AnyTimes()
+	dockerClient.EXPECT().DescribeContainer(gomock.Any(), pauseContainerID).AnyTimes()
+
+	err := taskEngine.Init(ctx)
+	assert.NoError(t, err)
+	taskEngine.AddTask(sleepTask)
+	stateChangeEvents := taskEngine.StateChangeEvents()
+	verifyTaskIsRunning(stateChangeEvents, sleepTask)
+
+	mockTime.EXPECT().After(gomock.Any()).Return(cleanup).MinTimes(1)
+	// sleep container should stop first, followed by SC container, and finally pause container
+	gomock.InOrder(
+		dockerClient.EXPECT().StopContainer(gomock.Any(), sleepContainerID, gomock.Any()).Return(
+			dockerapi.DockerContainerMetadata{DockerID: sleepContainerID}),
+		dockerClient.EXPECT().StopContainer(gomock.Any(), scContainerID, gomock.Any()).Return(
+			dockerapi.DockerContainerMetadata{DockerID: scContainerID}),
+		dockerClient.EXPECT().StopContainer(gomock.Any(), pauseContainerID, gomock.Any()).Return(
+			dockerapi.DockerContainerMetadata{DockerID: pauseContainerID}),
+	)
+
+	dockerClient.EXPECT().RemoveContainer(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(3)
+	imageManager.EXPECT().RemoveContainerReferenceFromImageState(gomock.Any()).Return(nil).AnyTimes()
+
+	// Set task desired status to STOPPED for triggering container stop sequence
+	sleepTask.DesiredStatusUnsafe = apitaskstatus.TaskStopped
+	sleepTask.UpdateDesiredStatus()
+
+	verifyTaskIsStopped(stateChangeEvents, sleepTask)
+	sleepTask.SetSentStatus(apitaskstatus.TaskStopped)
+	cleanup <- time.Now()
+	for {
+		tasks, _ := taskEngine.(*DockerTaskEngine).ListTasks()
+		if len(tasks) == 0 {
+			break
+		}
+		t.Logf("Found %d tasks in the engine; first task arn: %s", len(tasks), tasks[0].Arn)
+		fmt.Printf("Found %d tasks in the engine; first task arn: %s\n", len(tasks), tasks[0].Arn)
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+func verifyServiceConnectPauseContainerBridgeMode(t *testing.T, ctx interface{}, config *dockercontainer.Config, hostConfig *dockercontainer.HostConfig, y, z interface{}) {
+	name, ok := config.Labels[labelPrefix+"container-name"]
+	assert.True(t, ok)
+	assert.Equal(t, fmt.Sprintf("%s-%s", apitask.NetworkPauseContainerName, "sleep5"), name)
+	// verify host config network mode
+	assert.Equal(t, dockercontainer.NetworkMode(apitask.BridgeNetworkMode), hostConfig.NetworkMode)
+	// verify host config port bindings
+	assert.NotNil(t, hostConfig.PortBindings)
+	assert.Equal(t, 1, len(hostConfig.PortBindings))
+	bindings, ok := hostConfig.PortBindings["8080/tcp"]
+	assert.True(t, ok)
+	assert.Equal(t, 1, len(bindings))
+	assert.Equal(t, "0", bindings[0].HostPort)
+	// verify container config port exposed
+	assert.NotNil(t, config.ExposedPorts)
+	assert.Equal(t, 1, len(config.ExposedPorts))
+	_, ok = config.ExposedPorts["8080/tcp"]
+	assert.True(t, ok)
+}
+
+func verifyServiceConnectAppnetContainerBridgeMode(t *testing.T, ctx interface{}, config *dockercontainer.Config, hostConfig *dockercontainer.HostConfig, y, z interface{}) {
+	name, ok := config.Labels[labelPrefix+"container-name"]
+	assert.True(t, ok)
+	assert.Equal(t, "service-connect", name)
+	// verify host config network mode is "" (aka default bridge network mode)
+	assert.Equal(t, dockercontainer.NetworkMode(""), hostConfig.NetworkMode)
+	// verify host config port bindings
+	assert.NotNil(t, hostConfig.PortBindings)
+	assert.Equal(t, 1, len(hostConfig.PortBindings))
+	bindings, ok := hostConfig.PortBindings["15000/tcp"]
+	assert.True(t, ok)
+	assert.Equal(t, 1, len(bindings))
+	assert.Equal(t, "0", bindings[0].HostPort)
+	// verify container config port exposed
+	assert.NotNil(t, config.ExposedPorts)
+	assert.Equal(t, 2, len(config.ExposedPorts)) // 2 because egress container port is also exposed
+	_, ok = config.ExposedPorts["15000/tcp"]
+	assert.True(t, ok)
 }

--- a/agent/engine/service_connect/manager_linux.go
+++ b/agent/engine/service_connect/manager_linux.go
@@ -68,6 +68,12 @@ func NewManager() Manager {
 }
 
 func (m *manager) initializeAgentContainer(task *apitask.Task, container *apicontainer.Container, hostConfig *dockercontainer.HostConfig) error {
+	if task.IsNetworkModeBridge() {
+		err := m.initServiceConnectContainerMapping(task, container, hostConfig)
+		if err != nil {
+			return err
+		}
+	}
 	return m.initServiceConnectDirectoryMounts(task.GetID(), container, hostConfig)
 }
 
@@ -99,6 +105,11 @@ func (m *manager) initServiceConnectDirectoryMounts(taskId string, container *ap
 
 	container.MergeEnvironmentVariables(scEnv)
 	return nil
+}
+
+func (m *manager) initServiceConnectContainerMapping(task *apitask.Task, container *apicontainer.Container, hostConfig *dockercontainer.HostConfig) error {
+	// TODO [SC] - Move the function here
+	return task.PopulateServiceConnectContainerMappingEnvVar()
 }
 
 // DNSConfigToDockerExtraHostsFormat converts a []DNSConfigEntry slice to a list of ExtraHost entries that Docker will

--- a/agent/engine/testdata/test_tasks/sleep5PortMappings.json
+++ b/agent/engine/testdata/test_tasks/sleep5PortMappings.json
@@ -1,0 +1,42 @@
+{
+  "Arn":"arn:aws:ecs:us-west-2:123456789012:task/12345678-90ab-cdef-1234-56780abcdef1",
+  "Family":"sleep5",
+  "Version":"2",
+  "Containers":
+  [
+    {
+      "Name":"sleep5",
+      "Image":"busybox",
+      "Command":["sleep","5"],
+      "Cpu":10,
+      "Memory":10,
+      "Links":null,
+      "volumesFrom":[],
+      "mountPoints":[],
+      "portMappings":[{
+        "containerPort": 8080,
+        "hostPort": 0,
+        "protocol": "tcp"
+      }],
+      "Essential":true,
+      "EntryPoint":null,
+      "environment":{},
+      "overrides":{"command":null},
+      "desiredStatus":"NONE",
+      "KnownStatus":"NONE",
+      "RunDependencies":null,
+      "IsInternal":false,
+      "AppliedStatus":"NONE",
+      "ApplyingError":null,
+      "SentStatus":"NONE",
+      "KnownExitCode":null,
+      "KnownPortBindingsUnsafe":null,
+      "StatusLock":{}
+    }
+  ],
+  "volumes":[],
+  "DesiredStatus":"RUNNING",
+  "KnownStatus":"NONE",
+  "KnownTime":"0001-01-01T00:00:00Z",
+  "SentStatus":"NONE"
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
* Add pause containers for SC bridge mode task containers and set appropriate container ordering dependencies
* Populate container name->IP mapping env var which will be consumed by Service Connect container (Appnet Agent)
* Update logic for configuring docker host config port bindings for SC bridge mode containers
* Update logic for configuring docker container config exposed ports for SC bridge mode containers

### Implementation details
<!-- How are the changes implemented? -->
For a ServiceConnect-enabled bridge-mode task, we will add a pause container to every customer-defined container. We will also override SC container steady state to be `RESOURCES_PROVISIONED` so that it could configure the netns through CNI plugin (TBA in a future PR)
The container ordering for task start up should look like:
* ServiceConnectContainer.PULLED depends on ALL PauseContainer.RUNNING
* TaskContainer.CREATED depends on ServiceConnectContainer.RESOURCE_PROVISIONED
* TaskContainer.CREATED also on ServiceConnectContainer.Healthy
The container ordering for task stop should look like:
* ServiceConnectContainer.STOPPED depends on ALL TaskContainer.STOPPED
* PauseContainer.STOPPED depends on ServiceConnectConnectContainers.STOPPED

When creating Service Connect container, we also need to populate an env var `APPNET_CONTAINER_MAPPING` that includes mapping from container names to container IPs - this is later used by SC container to configure its listeners. 

In terms of port bindings and port exposing which are also configured as part of `CreateContainer`
1. For SC container (Appnet Agent)
 a. we will create port bindings and expose all ingress listeners because they will be taking traffic from the internet
 b. we will expose all egress listener ports so that that can be reached by other task containers, but we don't need to publish port binding as egress listener will not be taking traffic from outside

2. When creating pause containers, we will exposing/publishing the ports for the actual task containers - we will create port bindings for application container ports and expose both container and host ports (this is to stay consistent with current bridge mode behavior)

3. When creating the actual application containers (customer-defined), we will NOT publish port binding or expose ports for them since this is done by their associated pause container. Also Docker does not allow containers launched with container network mode to publish or expose ports.


### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
