### PR TITLE
added a logs extract step as well as fixed an issue with buildspecs not being found

### DIFF
--- a/build-infrastructure/README.md
+++ b/build-infrastructure/README.md
@@ -43,10 +43,7 @@ The directory structure that is expected is as follows,
 ```
 buildspecs/
 |- merge-build.yml
-<<<<<<< HEAD
 |- pr-build.yml
-=======
->>>>>>> added a note about adding more artifacts to be signed and copied
 |- signing.yml
 |- copy.yml
 ```

--- a/build-infrastructure/README.md
+++ b/build-infrastructure/README.md
@@ -43,7 +43,10 @@ The directory structure that is expected is as follows,
 ```
 buildspecs/
 |- merge-build.yml
+<<<<<<< HEAD
 |- pr-build.yml
+=======
+>>>>>>> added a note about adding more artifacts to be signed and copied
 |- signing.yml
 |- copy.yml
 ```

--- a/build-infrastructure/release-pipeline-stack.yml
+++ b/build-infrastructure/release-pipeline-stack.yml
@@ -224,7 +224,7 @@ Resources:
       Artifacts:
         Type: CODEPIPELINE
       ConcurrentBuildLimit: 10
-      Description: CodeBuild project to build the ECS Agent Docker image tarball
+      Description: A sample agent build on pr
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
         Image: aws/codebuild/amazonlinux2-aarch64-standard:2.0

--- a/build-infrastructure/release-pipeline-stack.yml
+++ b/build-infrastructure/release-pipeline-stack.yml
@@ -23,6 +23,10 @@ Parameters:
     Type: String
     Description: The name of the copy project
     Default: artifact-copy
+  LogsPullerCodeBuildProjectName:
+    Type: String
+    Description: The name of the copy project
+    Default: log-puller
   CodeBuildLogGroupName:
     Type: String
     Description: The name of the log group to push build logs to
@@ -49,6 +53,9 @@ Parameters:
       - 731
       - 1827
       - 3653
+  ReleaseArtifactsBucketName:
+    Type: String
+    Description: The name of the bucket where things land at the end, this is assumed to already exist
   ReleaseArtifactsBucketArn:
     Type: String
     Description: The ARN of the bucket where things land at the end, this is assumed to already exist
@@ -414,6 +421,96 @@ Resources:
           Status: ENABLED
           StreamName: !Ref CopyCodeBuildProjectName
 
+  LogsPullerCodeBuildProjectServiceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub 'logs-puller-codebuild-project-service-role-${AWS::Region}'
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          Effect: Allow
+          Principal:
+            Service: codebuild.amazonaws.com
+          Action: sts:AssumeRole
+      Policies:
+        - PolicyName: codebuild-logs-puller-base-policy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Sid: CloudWatchLogsAccess
+                Effect: Allow
+                Resource:
+                  - !GetAtt CodeBuildLogGroup.Arn
+                  - !Sub '${CodeBuildLogGroup.Arn}:*'
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+              - Sid: CloudWatchLogsExportAccess
+                Effect: Allow
+                Resource: '*'
+                Action:
+                  - logs:CreateExportTask
+                  - logs:DescribeExportTasks
+              - Sid: ArtifactBucketAccess
+                Effect: Allow
+                Resource:
+                  - !Sub 'arn:aws:s3:::codepipeline-${AWS::Region}-*'
+                Action:
+                  - s3:PutObject
+                  - s3:GetObject
+                  - s3:GetObjectVersion
+                  - s3:GetBucketAcl
+                  - s3:GetBucketLocation
+              - Sid: ResultsBucketAccess
+                Effect: Allow
+                Resource:
+                  - !Ref ReleaseArtifactsBucketArn
+                  - !Sub '${ReleaseArtifactsBucketArn}/*'
+                Action: s3:*
+              - Sid: CodeBuildCreateReportAccess
+                Effect: Allow
+                Resource:
+                  - !Sub 'arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:report-group/${LogsPullerCodeBuildProjectName}-*'
+                Action:
+                  - codebuild:CreateReportGroup
+                  - codebuild:CreateReport
+                  - codebuild:UpdateReport
+                  - codebuild:BatchPutTestCases
+                  - codebuild:BatchPutCodeCoverages
+
+  LogsPullerCodeBuildProject:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Name: !Ref LogsPullerCodeBuildProjectName
+      Description: A CodeBuild project that pulls logs from CloudWatch Logs and moves them to S3
+      ConcurrentBuildLimit: 10
+      ServiceRole: !GetAtt LogsPullerCodeBuildProjectServiceRole.Arn
+      Artifacts:
+        Type: CODEPIPELINE
+      Environment:
+        Type: LINUX_CONTAINER
+        ComputeType: BUILD_GENERAL1_SMALL
+        ImagePullCredentialsType: CODEBUILD
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+        EnvironmentVariables:
+          - Name: RELEASE_BUCKET_NAME
+            Type: PLAINTEXT
+            Value: !Ref ReleaseArtifactsBucketName
+          - Name: SOURCE_LOG_GROUP_NAME
+            Type: PLAINTEXT
+            Value: !Ref CodeBuildLogGroupName
+      Source:
+        BuildSpec: buildspecs/pull-logs.yml
+        Type: CODEPIPELINE
+      TimeoutInMinutes: 60
+      QueuedTimeoutInMinutes: 480
+      LogsConfig:
+        CloudWatchLogs:
+          GroupName: !Ref CodeBuildLogGroupName
+          Status: ENABLED
+          StreamName: !Ref CopyCodeBuildProjectName
+
   BuildAndSignCodePipelineServiceRole:
     Type: AWS::IAM::Role
     Properties:
@@ -554,3 +651,19 @@ Resources:
                 EnvironmentVariables: '[{"name":"GIT_COMMIT_SHA","value":"#{SourceVariables.CommitId}","type":"PLAINTEXT"}]'
               RunOrder: 1
               Namespace: CopyVariables
+        - Name: ExportLogs
+          Actions:
+            - Name: ToS3
+              InputArtifacts:
+                - Name: SignedArtifact
+                # We're basically going to ignore 👆 because we're just starting a bunch of async tasks to copy logs
+              ActionTypeId:
+                Category: Build
+                Owner: AWS
+                Version: '1'
+                Provider: CodeBuild
+              Configuration:
+                ProjectName: !Ref LogsPullerCodeBuildProject
+                EnvironmentVariables: '[{"name":"GIT_COMMIT_SHA","value":"#{SourceVariables.CommitId}","type":"PLAINTEXT"},{"name":"AMD_BUILD_ID","value":"#{AmdBuildVariables.CODEBUILD_BUILD_ID}","type":"PLAINTEXT"},{"name":"ARM_BUILD_ID","value":"#{ArmBuildVariables.CODEBUILD_BUILD_ID}","type":"PLAINTEXT"},{"name":"SIGNING_BUILD_ID","value":"#{SigningVariables.CODEBUILD_BUILD_ID}","type":"PLAINTEXT"},{"name":"COPY_BUILD_ID","value":"#{CopyVariables.CODEBUILD_BUILD_ID}","type":"PLAINTEXT"}]'
+              RunOrder: 1
+              Namespace: LogsPullerVariables

--- a/build-infrastructure/release-pipeline-stack.yml
+++ b/build-infrastructure/release-pipeline-stack.yml
@@ -7,6 +7,10 @@ Parameters:
     Type: String
     Description: The name of the code pipeline
     Default: artifact-build-sign-pipeline
+  BuildspecsExtractCodeBuildProjectName:
+    Type: String
+    Description: The name of the buildspec extractor project
+    Default: buildspec-extractor
   AmdBuildCodeBuildProjectName:
     Type: String
     Description: The name of the AMD build project
@@ -94,6 +98,84 @@ Resources:
         BlockPublicPolicy: true
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
+
+  BuildspecsExtractCodeBuildProjectServiceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub 'buildspecs-extract-codebuild-project-service-role-${AWS::Region}'
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          Effect: Allow
+          Principal:
+            Service: codebuild.amazonaws.com
+          Action: sts:AssumeRole
+      Policies:
+        - PolicyName: codebuild-buildspec-extract-base-policy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Sid: CloudWatchLogsAccess
+                Effect: Allow
+                Resource:
+                  - !GetAtt CodeBuildLogGroup.Arn
+                  - !Sub '${CodeBuildLogGroup.Arn}:*'
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+              - Sid: ArtifactBucketAccess
+                Effect: Allow
+                Resource:
+                  - !Sub 'arn:aws:s3:::codepipeline-${AWS::Region}-*'
+                Action:
+                  - s3:PutObject
+                  - s3:GetObject
+                  - s3:GetObjectVersion
+                  - s3:GetBucketAcl
+                  - s3:GetBucketLocation
+              - Sid: CodeBuildCodeStarConnectionAccess
+                Effect: Allow
+                Resource:
+                  - !Ref CodeStarConnectionArn
+                Action:
+                  - codestar-connections:UseConnection
+              - Sid: CodeBuildCreateReportAccess
+                Effect: Allow
+                Resource:
+                  - !Sub 'arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:report-group/${BuildspecsExtractCodeBuildProjectName}-*'
+                Action:
+                  - codebuild:CreateReportGroup
+                  - codebuild:CreateReport
+                  - codebuild:UpdateReport
+                  - codebuild:BatchPutTestCases
+                  - codebuild:BatchPutCodeCoverages
+
+  BuildspecsExtractCodeBuildProject:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Artifacts:
+        Type: CODEPIPELINE
+      ConcurrentBuildLimit: 10
+      Description: CodeBuild project to extract buildspecs from the source repo
+      Environment:
+        ComputeType: BUILD_GENERAL1_SMALL
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+        ImagePullCredentialsType: CODEBUILD
+        PrivilegedMode: true
+        Type: LINUX_CONTAINER
+      LogsConfig:
+        CloudWatchLogs:
+          GroupName: !Ref CodeBuildLogGroupName
+          Status: ENABLED
+          StreamName: !Ref BuildspecsExtractCodeBuildProjectName
+      Name: !Ref BuildspecsExtractCodeBuildProjectName
+      QueuedTimeoutInMinutes: 60
+      ServiceRole: !Ref BuildspecsExtractCodeBuildProjectServiceRole
+      Source:
+        BuildSpec: buildspecs/extract.yml
+        Type: CODEPIPELINE
+      TimeoutInMinutes: 60
 
   AmdBuildCodeBuildProjectServiceRole:
     Type: AWS::IAM::Role
@@ -585,6 +667,22 @@ Resources:
                 - Name: SourceArtifact
               RunOrder: 1
               Namespace: SourceVariables
+        - Name: Extract
+          Actions:
+            - Name: Buildspecs
+              InputArtifacts:
+                - Name: SourceArtifact
+              ActionTypeId:
+                Category: Build
+                Owner: AWS
+                Version: '1'
+                Provider: CodeBuild
+              Configuration:
+                ProjectName: !Ref BuildspecsExtractCodeBuildProject
+              OutputArtifacts:
+                - Name: Buildspecs
+              RunOrder: 1
+              Namespace: BuildspecsExtractVariables
         - Name: Build
           Actions:
             - Name: MakeAmd
@@ -621,6 +719,7 @@ Resources:
           Actions:
             - Name: GPG
               InputArtifacts:
+                - Name: Buildspecs
                 - Name: AmdBuildArtifact
                 - Name: ArmBuildArtifact
               ActionTypeId:
@@ -630,7 +729,7 @@ Resources:
                 Provider: CodeBuild
               Configuration:
                 ProjectName: !Ref SigningCodeBuildProject
-                PrimarySource: AmdBuildArtifact
+                PrimarySource: Buildspecs
                 EnvironmentVariables: '[{"name":"GIT_COMMIT_SHA","value":"#{SourceVariables.CommitId}","type":"PLAINTEXT"},{"name":"ECS_AGENT_AMD_TAR","value":"#{AmdBuildVariables.ECS_AGENT_TAR}","type":"PLAINTEXT"},{"name":"ECS_AGENT_ARM_TAR","value":"#{ArmBuildVariables.ECS_AGENT_TAR}","type":"PLAINTEXT"}]'
               OutputArtifacts:
                 - Name: SignedArtifact
@@ -640,6 +739,7 @@ Resources:
           Actions:
             - Name: ToS3
               InputArtifacts:
+                - Name: Buildspecs
                 - Name: SignedArtifact
               ActionTypeId:
                 Category: Build
@@ -648,6 +748,7 @@ Resources:
                 Provider: CodeBuild
               Configuration:
                 ProjectName: !Ref CopyCodeBuildProject
+                PrimarySource: Buildspecs
                 EnvironmentVariables: '[{"name":"GIT_COMMIT_SHA","value":"#{SourceVariables.CommitId}","type":"PLAINTEXT"}]'
               RunOrder: 1
               Namespace: CopyVariables
@@ -655,8 +756,7 @@ Resources:
           Actions:
             - Name: ToS3
               InputArtifacts:
-                - Name: SignedArtifact
-                # We're basically going to ignore 👆 because we're just starting a bunch of async tasks to copy logs
+                - Name: Buildspecs
               ActionTypeId:
                 Category: Build
                 Owner: AWS
@@ -664,6 +764,6 @@ Resources:
                 Provider: CodeBuild
               Configuration:
                 ProjectName: !Ref LogsPullerCodeBuildProject
-                EnvironmentVariables: '[{"name":"GIT_COMMIT_SHA","value":"#{SourceVariables.CommitId}","type":"PLAINTEXT"},{"name":"AMD_BUILD_ID","value":"#{AmdBuildVariables.CODEBUILD_BUILD_ID}","type":"PLAINTEXT"},{"name":"ARM_BUILD_ID","value":"#{ArmBuildVariables.CODEBUILD_BUILD_ID}","type":"PLAINTEXT"},{"name":"SIGNING_BUILD_ID","value":"#{SigningVariables.CODEBUILD_BUILD_ID}","type":"PLAINTEXT"},{"name":"COPY_BUILD_ID","value":"#{CopyVariables.CODEBUILD_BUILD_ID}","type":"PLAINTEXT"}]'
+                EnvironmentVariables: '[{"name":"GIT_COMMIT_SHA","value":"#{SourceVariables.CommitId}","type":"PLAINTEXT"},{"name":"EXTRACT_BUILD_ID","value":"#{BuildspecsExtractVariables.CODEBUILD_BUILD_ID}","type":"PLAINTEXT"},{"name":"AMD_BUILD_ID","value":"#{AmdBuildVariables.CODEBUILD_BUILD_ID}","type":"PLAINTEXT"},{"name":"ARM_BUILD_ID","value":"#{ArmBuildVariables.CODEBUILD_BUILD_ID}","type":"PLAINTEXT"},{"name":"SIGNING_BUILD_ID","value":"#{SigningVariables.CODEBUILD_BUILD_ID}","type":"PLAINTEXT"},{"name":"COPY_BUILD_ID","value":"#{CopyVariables.CODEBUILD_BUILD_ID}","type":"PLAINTEXT"}]'
               RunOrder: 1
               Namespace: LogsPullerVariables

--- a/build-infrastructure/release-pipeline-stack.yml
+++ b/build-infrastructure/release-pipeline-stack.yml
@@ -224,7 +224,7 @@ Resources:
       Artifacts:
         Type: CODEPIPELINE
       ConcurrentBuildLimit: 10
-      Description: A sample agent build on pr
+      Description: CodeBuild project to build the ECS Agent Docker image tarball
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
         Image: aws/codebuild/amazonlinux2-aarch64-standard:2.0

--- a/build-infrastructure/staging-bucket-stack.yml
+++ b/build-infrastructure/staging-bucket-stack.yml
@@ -52,6 +52,22 @@ Resources:
               - s3:ListBucket
             Resource:
               - !GetAtt StagingArtifactsBucket.Arn
+          - Sid: AllowCloudWatchLogsWriteAccess
+            Effect: Allow
+            Principal:
+              Service: logs.amazonaws.com
+            Action:
+              - s3:PutObject
+            Resource:
+              - !Sub '${StagingArtifactsBucket.Arn}/*'
+          - Sid: AllowCloudWatchLogsAclAccess
+            Effect: Allow
+            Principal:
+              Service: logs.amazonaws.com
+            Action:
+              - s3:GetBucketAcl
+            Resource:
+              - !GetAtt StagingArtifactsBucket.Arn
 
 Outputs:
   ReleaseBucketName:

--- a/buildspecs/copy.yml
+++ b/buildspecs/copy.yml
@@ -7,6 +7,8 @@ env:
 phases:
   build:
     commands:
+      # since the buildspecs are the primary artifacts, we need to change directory
+      - cd $CODEBUILD_SRC_DIR_SignedArtifact
       # list the artifacts that are ready to upload
       - ls -lsa
       # copy the artifacts out to the results bucket

--- a/buildspecs/extract.yml
+++ b/buildspecs/extract.yml
@@ -1,0 +1,10 @@
+version: 0.2
+
+env:
+  git-credential-helper: yes
+  exported-variables:
+    - CODEBUILD_BUILD_ID
+
+artifacts:
+  files:
+    - buildspecs/*.yml

--- a/buildspecs/pull-logs.yml
+++ b/buildspecs/pull-logs.yml
@@ -81,6 +81,6 @@ phases:
       # setting the Name property and the LogsConfig.StreamName property of the
       # CodeBuild project to the same string in the CloudFormation template
       - |
-        source /tmp/functions.sh && for build_id in $AMD_BUILD_ID $ARM_BUILD_ID $SIGNING_BUILD_ID $COPY_BUILD_ID; do
+        source /tmp/functions.sh && for build_id in $EXTRACT_BUILD_ID $AMD_BUILD_ID $ARM_BUILD_ID $SIGNING_BUILD_ID $COPY_BUILD_ID; do
           export_and_describe $(echo $build_id | sed -r 's/:/\//g')
         done

--- a/buildspecs/pull-logs.yml
+++ b/buildspecs/pull-logs.yml
@@ -1,0 +1,86 @@
+version: 0.2
+
+### Environment variables in this buildspec and where they came from ###
+
+# - $SOURCE_LOG_GROUP_NAME is defined in the CloudFormation template called
+#   located at build-infrastructure/release-pipeline-stack.yml
+
+# - $RELEASE_BUCKET_NAME is defined in the CloudFormation template called
+#   located at build-infrastructure/release-pipeline-stack.yml
+
+# - $GIT_COMMIT_SHA comes from the CodePipeline variables, the first stage
+#   of the pipeline is the source stage, and the variables that the stage
+#   outputs is mapped under the namespace SourceVariables. So we set
+#   $GIT_COMMIT_SHA to the commit id from that namespace in all subsequent
+#   steps. You can find this mapped in the EnvironmentVariables key for each
+#   CodeBuild stage action in the CodePipeline CloudFormation resource.
+
+# - $<STAGE>-BUILD_ID comes from the CodePipeline variables as well. Since
+#   each stage of the CodePipeline is a CodeBuild project except for the
+#   first one, a variable that is exported by default is the build id of
+#   that specific CodeBuild project run. In our CloudFormation template, we
+#   also namespace all of the CodeBuild projects which makes it easy to
+#   locate and map each of the build ids in the EnvironmentVariables key.
+#   You can find this in the ToS3 action of the ExportLogs stage of the
+#   CodePipeline resouce in the CloudFormation template.
+
+# - $START_EPOCH_MILLIS is defined below
+
+# - $END_EPOCH_MILLIS is defined below
+
+# - $DEFAULT_SLEEP_DURATION_IN_SECONDS is defined below
+
+phases:
+  pre_build:
+    on-failure: ABORT
+    commands:
+      - START_EPOCH_MILLIS=$(date -d '2 hours ago' +%s%3N)
+      - END_EPOCH_MILLIS=$(date +%s%3N)
+      - DEFAULT_SLEEP_DURATION_IN_SECONDS=5
+      - |
+        cat <<- 'EOF' > /tmp/functions.sh
+        function export_and_describe() {
+          local build_id="$1"
+
+          # starting of the logs grab task marker
+          echo "getting logs for $build_id"
+
+          # we grab the logs from the given log group and log stream, and export to
+          # a folder within the git commit sha called logs but this is an async task
+          # and this call returns a task id for us to watch
+          local export_task_id=$(aws logs create-export-task \
+            --task-name export \
+            --log-group-name $SOURCE_LOG_GROUP_NAME \
+            --log-stream-name-prefix $build_id \
+            --from $START_EPOCH_MILLIS \
+            --to $END_EPOCH_MILLIS \
+            --destination $RELEASE_BUCKET_NAME \
+            --destination-prefix "$GIT_COMMIT_SHA/logs" | jq -r '.taskId')
+
+          echo "log export task for $build_id started with $export_task_id"
+          echo "wait for export to finish..." && sleep $DEFAULT_SLEEP_DURATION_IN_SECONDS
+
+          # use the given task id to look up the status, log the status later
+          local export_task_status=$(aws logs describe-export-tasks --task-id $export_task_id | jq -r '.exportTasks[] | .status | .code')
+
+          echo "log export task for $build_id (task $export_task_id) has status $export_task_status after $DEFAULT_SLEEP_DURATION_IN_SECONDS seconds"
+          echo "wait so we don't get throttled..." && sleep $DEFAULT_SLEEP_DURATION_IN_SECONDS
+          echo -e "-------------------------------------------------\n"
+        }
+        EOF
+  build:
+    on-failure: ABORT
+    commands:
+      # A note about $(echo $build_id | sed -r 's/:/\//g') - the build id
+      # that we get from codebuild uses the project name and a uuid joined
+      # together with a : character. But the log stream name is in the same
+      # format just with a / character, so we run a quick replace command to
+      # map the build id to the log stream name.
+      #
+      # this is not how it works by default, this is done intentionaly by
+      # setting the Name property and the LogsConfig.StreamName property of the
+      # CodeBuild project to the same string in the CloudFormation template
+      - |
+        source /tmp/functions.sh && for build_id in $AMD_BUILD_ID $ARM_BUILD_ID $SIGNING_BUILD_ID $COPY_BUILD_ID; do
+          export_and_describe $(echo $build_id | sed -r 's/:/\//g')
+        done

--- a/buildspecs/signing.yml
+++ b/buildspecs/signing.yml
@@ -47,7 +47,8 @@ phases:
       - gpg --allow-secret-key-import --import private.gpg
       # remove the private key file because we don't want it to be packaged with the artifacts
       - rm private.gpg
-      # Sign the amd tar that exists in this directory because it is the primary source
+      # Sign the amd tar (this is a secondary source so we have to do some copying)
+      - cp "$CODEBUILD_SRC_DIR_AmdBuildArtifact/$ECS_AGENT_AMD_TAR" $ECS_AGENT_AMD_TAR
       - source /tmp/functions.sh && sign_file $ECS_AGENT_AMD_TAR
       # Sign the arm tar (this is a secondary source so we have to do some copying)
       - cp "$CODEBUILD_SRC_DIR_ArmBuildArtifact/$ECS_AGENT_ARM_TAR" $ECS_AGENT_ARM_TAR


### PR DESCRIPTION
### Summary
added a logs extract step to the codepipeline and fixed a bug with buildspecs not being found

### Implementation details
- updated staging bucket policy to allow cloudwatch to write to it
- created a project that pulls logs from cloudwatch to the staging bucket
- created a project that publishes the buildspecs as an artifact to fix a bug with the buildspecs not being found
- updated the infrastructure for the codepipeline so that it all comes together
- updated the readme about adding a new artifact to be signed to read more like a list

### Testing
- spun up in my personal account

New tests cover the changes: n/a

### Description for the changelog
Enhancement - build logs get pushed to the staging bucket for storage too

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
