### PR TITLE
Buildspec GoLang, GOPATH bug fixe; Remove glibc-static

### DIFF
--- a/buildspecs/merge-build.yml
+++ b/buildspecs/merge-build.yml
@@ -21,26 +21,40 @@ phases:
           ;;
         esac
 
+      # Set up proper go version using goenv utility (pre-installed in CodeBuild). Need to use this because default images come with 1.14.x
       - GOVERSION="$(cat GO_VERSION)"
       - GOLANG_TAR="go${GOVERSION}.linux-${architecture}.tar.gz"
 
       # Need to install GOLANG explicitly as required versions do not come preinstalled
+      # Remove existing go installation and install downloaded binaries
+      - rm -rf /root/.goenv/
       - wget -O /tmp/${GOLANG_TAR} https://storage.googleapis.com/golang/${GOLANG_TAR}
       - tar -C /usr/local -xzf /tmp/${GOLANG_TAR}
-      - go version
 
-      # glibc-static required for dockerfree make method
-      - echo "Install glibc-static for dockerfree make method"
-      - yum -y install glibc-static
+      # Set appropriate environment variables
+      - export GOROOT=/usr/local/go
+      - export GOPATH=$HOME/go
+      - export GOBIN=$GOPATH/bin
+      - export PATH=$PATH:$GOROOT/bin:$GOBIN
+      - which go
+      - go version
 
   build:
     commands:
-      - go version
       - echo Building agent image
       - AGENT_VERSION=$(cat VERSION)
       - ECS_AGENT_TAR="ecs-agent-v${AGENT_VERSION}.tar"
       - echo $(pwd)
 
+      # Directory/GOPATH restructuring needed for CodePipeline
+      - cd ../..
+      - GITHUBUSERNAME=$(ls)
+      - mkdir -p src/github.com/
+      - mv $GITHUBUSERNAME src/github.com/aws
+      - export GOPATH=$GOPATH:$(pwd)
+      - cd src/github.com/aws/amazon-ecs-agent
+
+      # Build agent tars
       - GO111MODULE=auto
       - make dockerfree-agent-image
       # Rename artifacts for architecture

--- a/buildspecs/pr-build.yml
+++ b/buildspecs/pr-build.yml
@@ -8,29 +8,35 @@ env:
 phases:
   install:
     commands:
-       - architecture=""
-       # Same buildspec for different architectures - detect the architecture here and rename the artifacts accordingly
-       - case $(uname -m) in
+      - architecture=""
+      # Same buildspec for different architectures - detect the architecture here and rename the artifacts accordingly
+      - case $(uname -m) in
            x86_64)
              architecture="amd64"
            ;;
            aarch64)
              architecture="arm64"
            ;;
-         esac
+        esac
 
-       - GOVERSION="$(cat GO_VERSION)"
-       - BUILD_LOG="build_${architecture}.log"
-       - GOLANG_TAR="go${GOVERSION}.linux-${architecture}.tar.gz"
+      # Set up proper go version using goenv utility (pre-installed in CodeBuild). Need to use this because default images come with 1.14.x
+      - GOVERSION="$(cat GO_VERSION)"
+      - BUILD_LOG="build_${architecture}.log"
+      - GOLANG_TAR="go${GOVERSION}.linux-${architecture}.tar.gz"
 
-       # Need to install GOLANG explicitly as required versions do not come preinstalled
-       - wget -O /tmp/${GOLANG_TAR} https://storage.googleapis.com/golang/${GOLANG_TAR} 2>&1 | tee $BUILD_LOG
-       - tar -C /usr/local -xzf /tmp/${GOLANG_TAR} 2>&1 | tee -a $BUILD_LOG
-       - go version
+      # Need to install GOLANG explicitly as required versions do not come preinstalled
+      # Remove existing go installation and install downloaded binaries
+      - rm -rf /root/.goenv/
+      - wget -O /tmp/${GOLANG_TAR} https://storage.googleapis.com/golang/${GOLANG_TAR} | tee $BUILD_LOG
+      - tar -C /usr/local -xzf /tmp/${GOLANG_TAR} | tee -a $BUILD_LOG
 
-       # glibc-static required for dockerfree make method
-       - echo "Install glibc-static for dockerfree make method" | tee -a $BUILD_LOG
-       - yum -y install glibc-static 2>&1 | tee -a $BUILD_LOG
+      # Set appropriate environment variables
+      - export GOROOT=/usr/local/go
+      - export GOPATH=$HOME/go
+      - export GOBIN=$GOPATH/bin
+      - export PATH=$PATH:$GOROOT/bin:$GOBIN
+      - which go | tee -a $BUILD_LOG
+      - go version | tee -a $BUILD_LOG
 
   build:
     commands:
@@ -41,11 +47,14 @@ phases:
       - ECS_AGENT_TAR="ecs-agent-v${AGENT_VERSION}.tar"
       - echo $(pwd) 2>&1 | tee -a $BUILD_LOG
 
-      # Path readjustment for codebuild testing with fork - may not needed when deploying with main account
-      - cd ../..
+      # Path readjustment for codebuild testing with fork and setting GOPATH appropriately
+      - cd ../../../..
+      - export GOPATH=$GOPATH:$(pwd)
+      - cd src/github.com
       - mv $GITHUBUSERNAME aws
       - cd aws/amazon-ecs-agent
 
+      # Building agent tars
       - GO111MODULE=auto
       - make dockerfree-agent-image 2>&1 | tee -a $BUILD_LOG
       # Rename artifacts for architecture


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
- GoLang was not being installed properly. Now uninstall the previous installation and set the Go environment appropriately to use the Go version specified in the GO_VERSION file
- Remove glibc-static as pause container is pre-built now
- Path re-adjustment for CodePipeline

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> No new tests, tested by manual builds

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
