### PR TITLE
Connect to stats endpoint through UDS

### DIFF
--- a/agent/engine/service_connect/manager_linux_test.go
+++ b/agent/engine/service_connect/manager_linux_test.go
@@ -244,12 +244,12 @@ func TestAgentContainerModificationsForServiceConnect(t *testing.T) {
 
 		})
 	}
-	assert.Equal(t, scTask.ServiceConnectConfig.RuntimeConfig.AdminSocketPath, fmt.Sprintf("%s/status/%s/%s", tempDir, scTask.GetID(), "relay_file_of_holiness"))
+	assert.Equal(t, scTask.ServiceConnectConfig.RuntimeConfig.AdminSocketPath, fmt.Sprintf("%s/status/%s/%s", tempDir, scTask.GetID(), "status_file_of_holiness"))
 	assert.Equal(t, scTask.ServiceConnectConfig.RuntimeConfig.StatsRequest, "/give?stats")
 	assert.Equal(t, scTask.ServiceConnectConfig.RuntimeConfig.DrainRequest, "/do?drain")
 
 	config := scTask.GetServiceConnectRuntimeConfig()
-	assert.Equal(t, config.AdminSocketPath, fmt.Sprintf("%s/status/%s/%s", tempDir, scTask.GetID(), "relay_file_of_holiness"))
+	assert.Equal(t, config.AdminSocketPath, fmt.Sprintf("%s/status/%s/%s", tempDir, scTask.GetID(), "status_file_of_holiness"))
 	assert.Equal(t, config.StatsRequest, "/give?stats")
 	assert.Equal(t, config.DrainRequest, "/do?drain")
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This PR adds the implementation for connecting to stats endpoint through unix domain socket specific to each task.

### Implementation details
<!-- How are the changes implemented? -->

* stats endpoint has been changed to the one that has been finalized
* UDS Path specific to each task is being referenced while retrieving stats for a task

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> Yes


Unit tests cover the change

Ran Appmesh tasks with the appnet agent image as envoy and successfully retrieved service-connect stats


### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
