### PR TITLE
Adding runtime configuration to ServiceConnect block

### DIFF
--- a/agent/api/task/service_connect.go
+++ b/agent/api/task/service_connect.go
@@ -16,15 +16,22 @@ package task
 // ServiceConnectConfig represents the Service Connect configuration for a task.
 type ServiceConnectConfig struct {
 	ContainerName string               `json:"containerName"`
-	StatsConfig   StatsConfig          `json:"statsConfig"`
 	IngressConfig []IngressConfigEntry `json:"ingressConfig"`
 	EgressConfig  EgressConfig         `json:"egressConfig"`
 	DNSConfig     []DNSConfigEntry     `json:"dnsConfig"`
+
+	// Admin configuration for operating with AppNet Agent
+	RuntimeConfig RuntimeConfig `json:"runtimeConfig"`
 }
 
-// StatsConfig is the endpoint where SC stats can be retrieved from.
-type StatsConfig struct {
-	Path string `json:"path"`
+// RuntimeConfig contains the runtime information for administering AppNet Agent
+type RuntimeConfig struct {
+	// Host path for the administration socket
+	AdminSocketPath string
+	// HTTP Path + Params to get statistical information
+	StatsRequest string
+	// HTTP Path + Params to drain ServiceConnect connections
+	DrainRequest string
 }
 
 // IngressConfigEntry is the ingress configuration for a given SC service.

--- a/agent/api/task/service_connect.go
+++ b/agent/api/task/service_connect.go
@@ -27,11 +27,11 @@ type ServiceConnectConfig struct {
 // RuntimeConfig contains the runtime information for administering AppNet Agent
 type RuntimeConfig struct {
 	// Host path for the administration socket
-	AdminSocketPath string
+	AdminSocketPath string `json:"adminSocketPath"`
 	// HTTP Path + Params to get statistical information
-	StatsRequest string
+	StatsRequest string `json:"statsRequest"`
 	// HTTP Path + Params to drain ServiceConnect connections
-	DrainRequest string
+	DrainRequest string `json:"drainRequest"`
 }
 
 // IngressConfigEntry is the ingress configuration for a given SC service.

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -3177,3 +3177,17 @@ func (task *Task) PopulateServiceConnectContainerMappingEnvVar() error {
 	task.GetServiceConnectContainer().MergeEnvironmentVariables(envVars)
 	return nil
 }
+
+func (task *Task) PopulateServiceConnectRuntimeConfig(serviceConnectConfig RuntimeConfig) {
+	task.lock.Lock()
+	defer task.lock.Unlock()
+
+	task.ServiceConnectConfig.RuntimeConfig = serviceConnectConfig
+}
+
+func (task *Task) GetServiceConnectRuntimeConfig() RuntimeConfig {
+	task.lock.RLock()
+	defer task.lock.RUnlock()
+
+	return task.ServiceConnectConfig.RuntimeConfig
+}

--- a/agent/engine/service_connect/manager_linux.go
+++ b/agent/engine/service_connect/manager_linux.go
@@ -33,6 +33,8 @@ const (
 	defaultStatusPathHostRoot = "/var/run/ecs/service_connect/"
 	defaultStatusFileName     = "appnet_admin.sock"
 	defaultStatusENV          = "APPNET_AGENT_UDS_PATH"
+	defaultAdminStatsRequest  = "/stats/prometheus?usedonly&filter=metrics_extension&delta"
+	defaultAdminDrainRequest  = "/drain-connections"
 )
 
 type manager struct {
@@ -52,6 +54,11 @@ type manager struct {
 	statusFileName string
 	// Environment variable to set on Container with contents of statusPathContainer/statusFileName
 	statusENV string
+
+	// Http path + params to make a statistics request of AppNetAgent
+	adminStatsRequest string
+	// Http path + params to make a drain request of AppNetAgent
+	adminDrainRequest string
 }
 
 func NewManager() Manager {
@@ -64,24 +71,37 @@ func NewManager() Manager {
 		statusPathHostRoot:  defaultStatusPathHostRoot,
 		statusFileName:      defaultStatusFileName,
 		statusENV:           defaultStatusENV,
+
+		adminStatsRequest: defaultAdminStatsRequest,
+		adminDrainRequest: defaultAdminDrainRequest,
 	}
 }
 
-func (m *manager) initializeAgentContainer(task *apitask.Task, container *apicontainer.Container, hostConfig *dockercontainer.HostConfig) error {
+func (m *manager) augmentAgentContainer(task *apitask.Task, container *apicontainer.Container, hostConfig *dockercontainer.HostConfig) error {
 	if task.IsNetworkModeBridge() {
 		err := m.initServiceConnectContainerMapping(task, container, hostConfig)
 		if err != nil {
 			return err
 		}
 	}
-	return m.initServiceConnectDirectoryMounts(task.GetID(), container, hostConfig)
+	adminPath, err := m.initAgentDirectoryMounts(task.GetID(), container, hostConfig)
+	if err != nil {
+		return err
+	}
+	m.initAgentEnvironment(container)
+
+	// Setup runtime configuration
+	task.ServiceConnectConfig.RuntimeConfig.AdminSocketPath = adminPath
+	task.ServiceConnectConfig.RuntimeConfig.StatsRequest = m.adminStatsRequest
+	task.ServiceConnectConfig.RuntimeConfig.DrainRequest = m.adminDrainRequest
+	return nil
 }
 
 func getBindMountMapping(hostDir, containerDir string) string {
 	return hostDir + ":" + containerDir
 }
 
-func (m *manager) initServiceConnectDirectoryMounts(taskId string, container *apicontainer.Container, hostConfig *dockercontainer.HostConfig) error {
+func (m *manager) initAgentDirectoryMounts(taskId string, container *apicontainer.Container, hostConfig *dockercontainer.HostConfig) (string, error) {
 	statusPathHost := filepath.Join(m.statusPathHostRoot, taskId)
 
 	// Create host directories if they don't exist
@@ -91,20 +111,22 @@ func (m *manager) initServiceConnectDirectoryMounts(taskId string, container *ap
 			err = os.MkdirAll(path, 0770)
 		}
 		if err != nil {
-			return err
+			return "", err
 		}
 	}
 
 	hostConfig.Binds = append(hostConfig.Binds, getBindMountMapping(statusPathHost, m.statusPathContainer))
 	hostConfig.Binds = append(hostConfig.Binds, getBindMountMapping(m.relayPathHost, m.relayPathContainer))
+	return filepath.Join(statusPathHost, m.relayFileName), nil
+}
 
+func (m *manager) initAgentEnvironment(container *apicontainer.Container) {
 	scEnv := map[string]string{
 		m.relayENV:  filepath.Join(m.relayPathContainer, m.relayFileName),
 		m.statusENV: filepath.Join(m.statusPathContainer, m.statusFileName),
 	}
 
 	container.MergeEnvironmentVariables(scEnv)
-	return nil
 }
 
 func (m *manager) initServiceConnectContainerMapping(task *apitask.Task, container *apicontainer.Container, hostConfig *dockercontainer.HostConfig) error {
@@ -133,7 +155,7 @@ func (m *manager) AugmentTaskContainer(task *apitask.Task, container *apicontain
 			DNSConfigToDockerExtraHostsFormat(task.ServiceConnectConfig.DNSConfig)...)
 	}
 	if container == task.GetServiceConnectContainer() {
-		m.initializeAgentContainer(task, container, hostConfig)
+		m.augmentAgentContainer(task, container, hostConfig)
 	}
 	return err
 }

--- a/agent/engine/service_connect/manager_linux.go
+++ b/agent/engine/service_connect/manager_linux.go
@@ -91,9 +91,12 @@ func (m *manager) augmentAgentContainer(task *apitask.Task, container *apicontai
 	m.initAgentEnvironment(container)
 
 	// Setup runtime configuration
-	task.ServiceConnectConfig.RuntimeConfig.AdminSocketPath = adminPath
-	task.ServiceConnectConfig.RuntimeConfig.StatsRequest = m.adminStatsRequest
-	task.ServiceConnectConfig.RuntimeConfig.DrainRequest = m.adminDrainRequest
+	var config apitask.RuntimeConfig
+	config.AdminSocketPath = adminPath
+	config.StatsRequest = m.adminStatsRequest
+	config.DrainRequest = m.adminDrainRequest
+
+	task.PopulateServiceConnectRuntimeConfig(config)
 	return nil
 }
 

--- a/agent/engine/service_connect/manager_linux.go
+++ b/agent/engine/service_connect/manager_linux.go
@@ -34,7 +34,7 @@ const (
 	defaultStatusFileName     = "appnet_admin.sock"
 	defaultStatusENV          = "APPNET_AGENT_UDS_PATH"
 	defaultAdminStatsRequest  = "/stats/prometheus?usedonly&filter=metrics_extension&delta"
-	defaultAdminDrainRequest  = "/drain-connections"
+	defaultAdminDrainRequest  = "/drain_listeners?inboundonly"
 )
 
 type manager struct {

--- a/agent/engine/service_connect/manager_linux_test.go
+++ b/agent/engine/service_connect/manager_linux_test.go
@@ -247,4 +247,9 @@ func TestAgentContainerModificationsForServiceConnect(t *testing.T) {
 	assert.Equal(t, scTask.ServiceConnectConfig.RuntimeConfig.AdminSocketPath, fmt.Sprintf("%s/status/%s/%s", tempDir, scTask.GetID(), "relay_file_of_holiness"))
 	assert.Equal(t, scTask.ServiceConnectConfig.RuntimeConfig.StatsRequest, "/give?stats")
 	assert.Equal(t, scTask.ServiceConnectConfig.RuntimeConfig.DrainRequest, "/do?drain")
+
+	config := scTask.GetServiceConnectRuntimeConfig()
+	assert.Equal(t, config.AdminSocketPath, fmt.Sprintf("%s/status/%s/%s", tempDir, scTask.GetID(), "relay_file_of_holiness"))
+	assert.Equal(t, config.StatsRequest, "/give?stats")
+	assert.Equal(t, config.DrainRequest, "/do?drain")
 }

--- a/agent/engine/service_connect/manager_linux_test.go
+++ b/agent/engine/service_connect/manager_linux_test.go
@@ -228,6 +228,8 @@ func TestAgentContainerModificationsForServiceConnect(t *testing.T) {
 		statusPathHostRoot:  filepath.Join(tempDir, "status"),
 		statusFileName:      "status_file_of_holiness",
 		statusENV:           "StAtUsGoEsHeRe",
+		adminStatsRequest:   "/give?stats",
+		adminDrainRequest:   "/do?drain",
 	}
 
 	for _, tc := range testcases {
@@ -239,6 +241,10 @@ func TestAgentContainerModificationsForServiceConnect(t *testing.T) {
 			}
 			assert.Equal(t, tc.expectedBinds, hostConfig.Binds)
 			assert.Equal(t, tc.expectedENV, tc.container.Environment)
+
 		})
 	}
+	assert.Equal(t, scTask.ServiceConnectConfig.RuntimeConfig.AdminSocketPath, fmt.Sprintf("%s/status/%s/%s", tempDir, scTask.GetID(), "relay_file_of_holiness"))
+	assert.Equal(t, scTask.ServiceConnectConfig.RuntimeConfig.StatsRequest, "/give?stats")
+	assert.Equal(t, scTask.ServiceConnectConfig.RuntimeConfig.DrainRequest, "/do?drain")
 }


### PR DESCRIPTION
### Summary
Creating a runtime information block for operating with a ServiceConnect Task's AppNet Agent

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
