### PR TITLE
Add log message when receiving error during cached image inspection

### DIFF
--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -1019,6 +1019,12 @@ func (engine *DockerTaskEngine) imagePullRequired(imagePullBehavior config.Image
 		// by inspecting the image.
 		_, err := engine.client.InspectImage(container.Image)
 		if err != nil {
+			logger.Info("Image inspect returned error, going to pull image for container", logger.Fields{
+				field.TaskID:    taskId,
+				field.Container: container.Name,
+				field.Image:     container.Image,
+				field.Error:     err.Error(),
+			})
 			return true
 		}
 		logger.Info("Found cached image, use it directly for container", logger.Fields{


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
If ENV `ECS_IMAGE_PULL_BEHAVIOR=prefer-cached`, ECS Agent will attempt to use local container image if it exists, and the way we check is through docker client `InspectImage`. The PR adds a log message for when the API call returns an error. 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Add log message when receiving error during cached image inspection

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
