### PR TITLE
Stop container when dependencies are non-resolvable

### DIFF
--- a/agent/engine/dependencygraph/graph.go
+++ b/agent/engine/dependencygraph/graph.go
@@ -47,23 +47,39 @@ const (
 var (
 	// CredentialsNotResolvedErr is the error where a container needs to wait for
 	// credentials before it can process by agent
-	CredentialsNotResolvedErr = errors.New("dependency graph: container execution credentials not available")
+	CredentialsNotResolvedErr = &DependencyError{err: errors.New("dependency graph: container execution credentials not available")}
 	// DependentContainerNotResolvedErr is the error where a dependent container isn't in expected state
-	DependentContainerNotResolvedErr = errors.New("dependency graph: dependent container not in expected state")
+	DependentContainerNotResolvedErr = &DependencyError{err: errors.New("dependency graph: dependent container not in expected state")}
 	// ContainerPastDesiredStatusErr is the error where the container status is bigger than desired status
-	ContainerPastDesiredStatusErr = errors.New("container transition: container status is equal or greater than desired status")
+	ContainerPastDesiredStatusErr = &DependencyError{err: errors.New("container transition: container status is equal or greater than desired status")}
 	// ErrContainerDependencyNotResolved is when the container's dependencies
 	// on other containers are not resolved
-	ErrContainerDependencyNotResolved = errors.New("dependency graph: dependency on containers not resolved")
+	ErrContainerDependencyNotResolved = &DependencyError{err: errors.New("dependency graph: dependency on containers not resolved")}
 	// ErrResourceDependencyNotResolved is when the container's dependencies
 	// on task resources are not resolved
-	ErrResourceDependencyNotResolved = errors.New("dependency graph: dependency on resources not resolved")
+	ErrResourceDependencyNotResolved = &DependencyError{err: errors.New("dependency graph: dependency on resources not resolved")}
 	// ResourcePastDesiredStatusErr is the error where the task resource known status is bigger than desired status
-	ResourcePastDesiredStatusErr = errors.New("task resource transition: task resource status is equal or greater than desired status")
+	ResourcePastDesiredStatusErr = &DependencyError{err: errors.New("task resource transition: task resource status is equal or greater than desired status")}
 	// ErrContainerDependencyNotResolvedForResource is when the resource's dependencies
 	// on other containers are not resolved
-	ErrContainerDependencyNotResolvedForResource = errors.New("dependency graph: resource's dependency on containers not resolved")
+	ErrContainerDependencyNotResolvedForResource = &DependencyError{err: errors.New("dependency graph: resource's dependency on containers not resolved")}
 )
+
+// DependencyError represents an error of a container dependency. These errors can be either terminal or non-terminal.
+// Terminal dependency errors indicate that a given dependency can never be fulfilled (e.g. a container with a SUCCESS
+// dependency has stopped with an exit code other than zero).
+type DependencyError struct {
+	err        error
+	isTerminal bool
+}
+
+func (de *DependencyError) Error() string {
+	return de.err.Error()
+}
+
+func (de *DependencyError) IsTerminal() bool {
+	return de.isTerminal
+}
 
 // ValidDependencies takes a task and verifies that it is possible to allow all
 // containers within it to reach the desired status by proceeding in some
@@ -124,7 +140,7 @@ func DependenciesAreResolved(target *apicontainer.Container,
 	id string,
 	manager credentials.Manager,
 	resources []taskresource.TaskResource,
-	cfg *config.Config) (*apicontainer.DependsOn, error) {
+	cfg *config.Config) (*apicontainer.DependsOn, *DependencyError) {
 	if !executionCredentialsResolved(target, id, manager) {
 		return nil, CredentialsNotResolvedErr
 	}
@@ -244,7 +260,7 @@ func verifyStatusResolvable(target *apicontainer.Container, existingContainers m
 // (map from name to container). The `resolves` function passed should return true if the named container is resolved.
 
 func verifyContainerOrderingStatusResolvable(target *apicontainer.Container, existingContainers map[string]*apicontainer.Container,
-	cfg *config.Config, resolves func(*apicontainer.Container, *apicontainer.Container, string, *config.Config) bool) (*apicontainer.DependsOn, error) {
+	cfg *config.Config, resolves func(*apicontainer.Container, *apicontainer.Container, string, *config.Config) bool) (*apicontainer.DependsOn, *DependencyError) {
 
 	targetGoal := target.GetDesiredStatus()
 	targetKnown := target.GetKnownStatus()
@@ -260,7 +276,7 @@ func verifyContainerOrderingStatusResolvable(target *apicontainer.Container, exi
 	for _, dependency := range targetDependencies {
 		dependencyContainer, ok := existingContainers[dependency.ContainerName]
 		if !ok {
-			return nil, fmt.Errorf("dependency graph: container ordering dependency [%v] for target [%v] does not exist.", dependencyContainer, target)
+			return nil, &DependencyError{err: fmt.Errorf("dependency graph: container ordering dependency [%v] for target [%v] does not exist.", dependencyContainer, target), isTerminal: true}
 		}
 
 		// We want to check whether the dependency container has timed out only if target has not been created yet.
@@ -268,7 +284,7 @@ func verifyContainerOrderingStatusResolvable(target *apicontainer.Container, exi
 		// However, if dependency container has already stopped, then it cannot time out.
 		if targetKnown < apicontainerstatus.ContainerCreated && dependencyContainer.GetKnownStatus() != apicontainerstatus.ContainerStopped {
 			if hasDependencyTimedOut(dependencyContainer, dependency.Condition) {
-				return nil, fmt.Errorf("dependency graph: container ordering dependency [%v] for target [%v] has timed out.", dependencyContainer, target)
+				return nil, &DependencyError{err: fmt.Errorf("dependency graph: container ordering dependency [%v] for target [%v] has timed out.", dependencyContainer, target), isTerminal: true}
 			}
 		}
 
@@ -276,13 +292,13 @@ func verifyContainerOrderingStatusResolvable(target *apicontainer.Container, exi
 		// can then never progress to its desired state when the dependency condition is 'SUCCESS'
 		if dependency.Condition == successCondition && dependencyContainer.GetKnownStatus() == apicontainerstatus.ContainerStopped &&
 			!hasDependencyStoppedSuccessfully(dependencyContainer) {
-			return nil, fmt.Errorf("dependency graph: failed to resolve container ordering dependency [%v] for target [%v] as dependency did not exit successfully.", dependencyContainer, target)
+			return nil, &DependencyError{err: fmt.Errorf("dependency graph: failed to resolve container ordering dependency [%v] for target [%v] as dependency did not exit successfully.", dependencyContainer, target), isTerminal: true}
 		}
 
 		// For any of the dependency conditions - START/COMPLETE/SUCCESS/HEALTHY, if the dependency container has
 		// not started and will not start in the future, this dependency can never be resolved.
 		if dependencyContainer.HasNotAndWillNotStart() {
-			return nil, fmt.Errorf("dependency graph: failed to resolve container ordering dependency [%v] for target [%v] because dependency will never start", dependencyContainer, target)
+			return nil, &DependencyError{err: fmt.Errorf("dependency graph: failed to resolve container ordering dependency [%v] for target [%v] because dependency will never start", dependencyContainer, target), isTerminal: true}
 		}
 
 		if !resolves(target, dependencyContainer, dependency.Condition, cfg) {
@@ -290,14 +306,14 @@ func verifyContainerOrderingStatusResolvable(target *apicontainer.Container, exi
 		}
 	}
 	if blockedDependency != nil {
-		return blockedDependency, fmt.Errorf("dependency graph: failed to resolve the container ordering dependency [%v] for target [%v]", blockedDependency, target)
+		return blockedDependency, &DependencyError{err: fmt.Errorf("dependency graph: failed to resolve the container ordering dependency [%v] for target [%v]", blockedDependency, target)}
 	}
 	return nil, nil
 }
 
 func verifyTransitionDependenciesResolved(target *apicontainer.Container,
 	existingContainers map[string]*apicontainer.Container,
-	existingResources map[string]taskresource.TaskResource) error {
+	existingResources map[string]taskresource.TaskResource) *DependencyError {
 
 	if !verifyContainerDependenciesResolved(target, existingContainers) {
 		return ErrContainerDependencyNotResolved
@@ -471,7 +487,7 @@ func verifyContainerOrderingStatus(dependsOnContainer *apicontainer.Container) b
 		dependsOnContainerDesiredStatus == dependsOnContainer.GetSteadyStateStatus()
 }
 
-func verifyShutdownOrder(target *apicontainer.Container, existingContainers map[string]*apicontainer.Container) error {
+func verifyShutdownOrder(target *apicontainer.Container, existingContainers map[string]*apicontainer.Container) *DependencyError {
 	// We considered adding this to the task state, but this will be at most 45 loops,
 	// so we err'd on the side of having less state.
 	missingShutdownDependencies := []string{}
@@ -493,8 +509,8 @@ func verifyShutdownOrder(target *apicontainer.Container, existingContainers map[
 		return nil
 	}
 
-	return fmt.Errorf("dependency graph: target %s needs other containers stopped before it can stop: [%s]",
-		target.Name, strings.Join(missingShutdownDependencies, "], ["))
+	return &DependencyError{err: fmt.Errorf("dependency graph: target %s needs other containers stopped before it can stop: [%s]",
+		target.Name, strings.Join(missingShutdownDependencies, "], ["))}
 }
 
 func onSteadyStateCanResolve(target *apicontainer.Container, run *apicontainer.Container) bool {

--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -1410,21 +1410,13 @@ func (mtask *managedTask) handleContainersUnableToTransitionState() {
 	} else {
 		// If we end up here, it means containers are not able to transition anymore; maybe because of dependencies that
 		// are unable to start. Therefore, if there are essential containers that haven't started yet, we need to
-		// stop the task since they are not going to start anymore.
+		// stop the task since they are not going to start.
 		stopTask := false
-		containersRunning := 0
 		for _, c := range mtask.Containers {
 			if c.IsEssential() && !c.IsKnownSteadyState() {
 				stopTask = true
 				break
 			}
-			if c.IsKnownSteadyState() {
-				containersRunning++
-			}
-		}
-
-		if containersRunning == 0 {
-			stopTask = true
 		}
 
 		if stopTask {

--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -1003,17 +1003,6 @@ func (mtask *managedTask) progressTask() {
 
 	blockedByOrderingDependencies := len(blockedDependencies) > 0
 
-	logger.Info(">>>>>atLeastOneTransitionStarted", logger.Fields{
-		"value": atLeastOneTransitionStarted,
-	})
-
-	for _, b := range blockedDependencies {
-		logger.Info(">>>>>blocked on ", logger.Fields{
-			"container": b.ContainerName,
-			"condition": b.Condition,
-		})
-	}
-
 	// If no transitions happened and we aren't blocked by ordering dependencies, then we are possibly in a state where
 	// its impossible for containers to move forward. We will do an additional check to see if we are waiting for ACS
 	// execution credentials. If not, then we will abort the task progression.
@@ -1143,6 +1132,10 @@ func (mtask *managedTask) startContainerTransitions(transitionFunc containerTran
 }
 
 func (mtask *managedTask) handleTerminalDependencyError(container *apicontainer.Container, error dependencygraph.DependencyError) {
+	logger.Error("Terminal error detected during transition; marking container as stopped", logger.Fields{
+		field.Container: container.Name,
+		field.Error:     error.Error(),
+	})
 	container.SetDesiredStatus(apicontainerstatus.ContainerStopped)
 	exitCode := 143
 	container.SetKnownExitCode(&exitCode)

--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -87,7 +87,7 @@ type containerTransition struct {
 	nextState      apicontainerstatus.ContainerStatus
 	actionRequired bool
 	blockedOn      *apicontainer.DependsOn
-	reason         error
+	reason         *dependencygraph.DependencyError
 }
 
 // resourceTransition defines the struct for a resource to transition.
@@ -1003,6 +1003,17 @@ func (mtask *managedTask) progressTask() {
 
 	blockedByOrderingDependencies := len(blockedDependencies) > 0
 
+	logger.Info(">>>>>atLeastOneTransitionStarted", logger.Fields{
+		"value": atLeastOneTransitionStarted,
+	})
+
+	for _, b := range blockedDependencies {
+		logger.Info(">>>>>blocked on ", logger.Fields{
+			"container": b.ContainerName,
+			"condition": b.Condition,
+		})
+	}
+
 	// If no transitions happened and we aren't blocked by ordering dependencies, then we are possibly in a state where
 	// its impossible for containers to move forward. We will do an additional check to see if we are waiting for ACS
 	// execution credentials. If not, then we will abort the task progression.
@@ -1088,6 +1099,9 @@ func (mtask *managedTask) startContainerTransitions(transitionFunc containerTran
 	for _, cont := range mtask.Containers {
 		transition := mtask.containerNextState(cont)
 		if transition.reason != nil {
+			if transition.reason.IsTerminal() {
+				mtask.handleTerminalDependencyError(cont, transition.reason)
+			}
 			// container can't be transitioned
 			reasons = append(reasons, transition.reason)
 			if transition.blockedOn != nil {
@@ -1126,6 +1140,27 @@ func (mtask *managedTask) startContainerTransitions(transitionFunc containerTran
 	}
 
 	return anyCanTransition, blocked, transitions, reasons
+}
+
+func (mtask *managedTask) handleTerminalDependencyError(container *apicontainer.Container, error *dependencygraph.DependencyError) {
+	container.SetDesiredStatus(apicontainerstatus.ContainerStopped)
+	exitCode := 143
+	container.SetKnownExitCode(&exitCode)
+	// Change container status to STOPPED with exit code 143. This exit code is what docker reports when
+	// a container receives SIGTERM. In this case it's technically not true that we send SIGTERM because the
+	// container didn't even start, but we have to report an error and 143 seems the most appropriate.
+	go func(cont *apicontainer.Container) {
+		mtask.dockerMessages <- dockerContainerChange{
+			container: cont,
+			event: dockerapi.DockerContainerChangeEvent{
+				Status: apicontainerstatus.ContainerStopped,
+				DockerContainerMetadata: dockerapi.DockerContainerMetadata{
+					Error:    dockerapi.CannotStartContainerError{FromError: error},
+					ExitCode: &exitCode,
+				},
+			},
+		}
+	}(container)
 }
 
 // startResourceTransitions steps through each resource in the task and calls
@@ -1370,10 +1405,6 @@ func (mtask *managedTask) resourceNextState(resource taskresource.TaskResource) 
 }
 
 func (mtask *managedTask) handleContainersUnableToTransitionState() {
-	logger.Critical("Task in a bad state; it's not steady state but no containers want to transition", logger.Fields{
-		field.TaskID: mtask.GetID(),
-	})
-
 	if mtask.GetDesiredStatus().Terminal() {
 		// Ack, really bad. We want it to stop but the containers don't think
 		// that's possible. let's just break out and hope for the best!
@@ -1384,10 +1415,23 @@ func (mtask *managedTask) handleContainersUnableToTransitionState() {
 		mtask.emitTaskEvent(mtask.Task, taskUnableToTransitionToStoppedReason)
 		// TODO we should probably panic here
 	} else {
-		logger.Critical("Moving task to stopped due to bad state", logger.Fields{
-			field.TaskID: mtask.GetID(),
-		})
-		mtask.handleDesiredStatusChange(apitaskstatus.TaskStopped, 0)
+		// If we end up here, it means containers are not able to transition anymore; maybe because of dependencies that
+		// are unable to start. Therefore, if there are essential containers that haven't started yet, we need to
+		// stop the task since they are not going to start anymore.
+		stopTask := false
+		for _, c := range mtask.Containers {
+			if c.IsEssential() && !c.IsKnownSteadyState() {
+				stopTask = true
+				break
+			}
+		}
+
+		if stopTask {
+			logger.Critical("Task in a bad state; it's not steady state but no containers want to transition", logger.Fields{
+				field.TaskID: mtask.GetID(),
+			})
+			mtask.handleDesiredStatusChange(apitaskstatus.TaskStopped, 0)
+		}
 	}
 }
 

--- a/agent/engine/task_manager_test.go
+++ b/agent/engine/task_manager_test.go
@@ -240,7 +240,7 @@ func TestContainerNextState(t *testing.T) {
 		containerDesiredStatus       apicontainerstatus.ContainerStatus
 		expectedContainerStatus      apicontainerstatus.ContainerStatus
 		expectedTransitionActionable bool
-		reason                       error
+		reason                       dependencygraph.DependencyError
 	}{
 		// NONE -> RUNNING transition is allowed and actionable, when desired is Running
 		// The expected next status is Pulled
@@ -928,8 +928,8 @@ func TestOnContainersUnableToTransitionStateForDesiredRunningTask(t *testing.T) 
 	}
 
 	task.handleContainersUnableToTransitionState()
-	assert.Equal(t, task.GetDesiredStatus(), apitaskstatus.TaskStopped)
-	assert.Equal(t, task.Containers[0].GetDesiredStatus(), apicontainerstatus.ContainerStopped)
+	assert.Equal(t, apitaskstatus.TaskStopped, task.GetDesiredStatus())
+	assert.Equal(t, apicontainerstatus.ContainerStopped, task.Containers[0].GetDesiredStatus())
 }
 
 // TODO: Test progressContainers workflow

--- a/agent/engine/task_manager_test.go
+++ b/agent/engine/task_manager_test.go
@@ -19,10 +19,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
 
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

Addresses https://github.com/aws/amazon-ecs-agent/issues/2579 where a task can be stuck in `PENDING`  for ever when container dependencies cannot be fulfilled.

### Implementation details
<!-- How are the changes implemented? -->

Adding the concept of terminal dependency error to detect cases where container dependencies can never succeed. When a terminal dependency error is detected, we simply forcefully stop the container with the "bad" dependencies. 

This new behavior triggers a chain reaction that eventually stops the task if an essential container has terminal dependency errors. If essential containers don't have terminal dependency errors, then the task is allowed to start.

Containers that are forcefully stopped are marked with exitCode `143`. This is the code docker assigns when a container receives `SIGTERM`. Although we technically don't send `SIGTERM` to containers stopped due to terminal dependency errors, this exit code is the closest to reality. However, customers will be able to see a text description of the exact error when this edge case is hit.

For example (from AWS console): 


Status reason | CannotStartContainerError:  dependency graph: failed to resolve container ordering dependency  [container-1(public.ecr.aws/u5s6c6g2/just-sleep) (STOPPED->RUNNING) -  Exit: 1] for target [container-2(public.ecr.aws/u5s6c6g2/just-sleep)  (NONE->RUNNING)] as dep
-- | --
143
["/sleep","10"]



### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Bug - Fix an [issue](https://github.com/aws/amazon-ecs-agent/issues/2579) where a task can be stuck in `PENDING` for ever when container dependencies can never be fulfilled. 

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
