### PR TITLE
Add SC pause container and update container dependency ordering

### DIFF
--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -519,26 +519,14 @@ func (task *Task) initDummyServiceConnectConfig() {
 // initServiceConnectContainerDependencies builds container dependency for regular task containers and SC container, such that
 // - during task start up, a regular container depends on SC container to become Healthy
 // - during task tear down, SC container depends on all regular containers to be stopped first
-// Additionally, for bridge mode task, we have the SC container configure netns for itself as well as for all other task
-// containers. The configuration is done when SC container transitions from RUNNING -> RESOURCES_PROVISIONED. Therefore,
-// - we override steady state status for SC container to be RESOURCES_PROVISIONED (the default is RUNNING)
-// - during task start up, a regular container will also depends on SC Container RESOURCE_PROVISIONED
 func (task *Task) initServiceConnectContainerDependencies() {
 	scContainer := task.GetServiceConnectContainer()
-
 	for _, container := range task.Containers {
 		if container.IsInternal() || container == scContainer {
 			continue
 		}
 		container.AddContainerDependency(scContainer.Name, ContainerOrderingHealthyCondition)
 		scContainer.BuildContainerDependency(container.Name, apicontainerstatus.ContainerStopped, apicontainerstatus.ContainerStopped)
-		if task.IsNetworkModeBridge() {
-			container.BuildContainerDependency(scContainer.Name, apicontainerstatus.ContainerResourcesProvisioned, apicontainerstatus.ContainerCreated)
-		}
-	}
-
-	if task.IsNetworkModeBridge() {
-		scContainer.SetSteadyStateStatusUnsafe(apicontainerstatus.ContainerResourcesProvisioned)
 	}
 }
 
@@ -1465,18 +1453,18 @@ func (task *Task) addNetworkResourceProvisioningDependencyAwsvpc(cfg *config.Con
 }
 
 // addNetworkResourceProvisioningDependencyServiceConnectBridge creates one pause container per task container
-// except for SC container, and add a dependency for SC container to wait for all pause container running.
+// including SC container, and add a dependency for SC container to wait for all pause container RESOURCES_PROVISIONED.
 //
-// Unlike AWSVPC pause containers that use CNI plugin for configuring netns when they go from RUNNING ->
-// RESOURCES_PROVISIONED, Bridge mode pause containers will have steady state RUNNING. All netns configuration and
-// CNI invocation will be performed solely by SC container.
+// SC pause container will use CNI plugin for configuring tproxy, while other pause container(s) will configure ip route
+// to send SC traffic to SC container
 func (task *Task) addNetworkResourceProvisioningDependencyServiceConnectBridge(cfg *config.Config) error {
 	scContainer := task.GetServiceConnectContainer()
+	var scPauseContainer *apicontainer.Container
 	for _, container := range task.Containers {
-		if container.IsInternal() || container == scContainer {
+		if container.IsInternal() {
 			continue
 		}
-		pauseContainer := apicontainer.NewContainerWithSteadyState(apicontainerstatus.ContainerRunning)
+		pauseContainer := apicontainer.NewContainerWithSteadyState(apicontainerstatus.ContainerResourcesProvisioned)
 		pauseContainer.TransitionDependenciesMap = make(map[apicontainerstatus.ContainerStatus]apicontainer.TransitionDependencySet)
 		// The pause container name is used internally by task engine but still needs to be unique for every task,
 		// hence we are appending the corresponding application container name (which must already be unique within the task)
@@ -1486,14 +1474,27 @@ func (task *Task) addNetworkResourceProvisioningDependencyServiceConnectBridge(c
 		pauseContainer.Type = apicontainer.ContainerCNIPause
 
 		task.Containers = append(task.Containers, pauseContainer)
-		scContainer.BuildContainerDependency(pauseContainer.Name, apicontainerstatus.ContainerRunning, apicontainerstatus.ContainerCreated)
+		// SC container CREATED will depend on ALL pause containers RESOURCES_PROVISIONED
+		scContainer.BuildContainerDependency(pauseContainer.Name, apicontainerstatus.ContainerResourcesProvisioned, apicontainerstatus.ContainerCreated)
 		pauseContainer.BuildContainerDependency(scContainer.Name, apicontainerstatus.ContainerStopped, apicontainerstatus.ContainerStopped)
+		if container == scContainer {
+			scPauseContainer = pauseContainer
+		}
+	}
+
+	// All other task pause container RESOURCES_PROVISIONED depends on SC pause container RUNNING because task pause container
+	// CNI plugin invocation needs the IP of SC pause container (to send SC traffic to)
+	for _, container := range task.Containers {
+		if container.Type != apicontainer.ContainerCNIPause || container == scPauseContainer {
+			continue
+		}
+		container.BuildContainerDependency(scPauseContainer.Name, apicontainerstatus.ContainerRunning, apicontainerstatus.ContainerResourcesProvisioned)
 	}
 	return nil
 }
 
-// getBridgeModePauseContainerForTaskContainer retrieves the associated pause container for a regular task
-// container (customer-defined) in a bridge-mode SC-enabled task.
+// getBridgeModePauseContainerForTaskContainer retrieves the associated pause container for a task container (SC container
+// or customer-defined containers) in a bridge-mode SC-enabled task.
 // For a container with name "abc", the pause container will always be named "~internal~ecs~pause-abc"
 func (task *Task) getBridgeModePauseContainerForTaskContainer(container *apicontainer.Container) (*apicontainer.Container, error) {
 	// "~internal~ecs~pause-$TASK_CONTAINER_NAME"
@@ -1505,15 +1506,13 @@ func (task *Task) getBridgeModePauseContainerForTaskContainer(container *apicont
 	return pauseContainer, nil
 }
 
-// getBridgeModeTaskContainerForPauseContainer retrieves the associated customer container for a pause
-// container in a bridge-mode SC-enabled task.
+// getBridgeModeTaskContainerForPauseContainer retrieves the associated task container for a pause container in a bridge-mode SC-enabled task.
 // For a container with name "abc", the pause container will always be named "~internal~ecs~pause-abc"
 func (task *Task) getBridgeModeTaskContainerForPauseContainer(container *apicontainer.Container) (*apicontainer.Container, error) {
 	if container.Type != apicontainer.ContainerCNIPause {
 		return nil, fmt.Errorf("container %s is not a CNI pause container", container.Name)
 	}
-	// pause container name will be something like "~internal~ecs~pause-$TASK_CONTAINER_NAME"
-	// limit the result to 2 substrings as $$TASK_CONTAINER_NAME may also container '-'
+	// limit the result to 2 substrings as $TASK_CONTAINER_NAME may also container '-'
 	stringSlice := strings.SplitN(container.Name, "-", 2)
 	if len(stringSlice) < 2 {
 		return nil, fmt.Errorf("SC bridge mode pause container %s does not conform to %s-$TASK_CONTAINER_NAME format", container.Name, NetworkPauseContainerName)
@@ -1727,11 +1726,12 @@ func (task *Task) dockerConfig(container *apicontainer.Container, apiVersion doc
 }
 
 // dockerExposedPorts returns the container ports that need to be exposed for a container
-// For bridge-mode ServiceConnect-enabled tasks:
-// 1. Pause containers need to expose the port(s) of their associated task container
-// 2. SC container (Appnet Agent) needs to expose all listener ports
-// 3. Other containers (customer-defined task containers) will not expose any ports (already exposed through pause container)
-// For all other tasks, we expose the application container ports.
+// 1. For bridge-mode ServiceConnect-enabled tasks:
+//   1a. Pause containers need to expose the port(s) for their associated task container. In particular, SC pause container
+// needs to expose all listener ports for SC container
+//   1b. Other containers (customer-defined task containers as well as SC container) will not expose any ports as they are
+// already exposed through pause container
+// 2. For all other tasks, we expose the application container ports.
 func (task *Task) dockerExposedPorts(container *apicontainer.Container) (dockerExposedPorts nat.PortSet, err error) {
 	containerToCheck := container
 	scContainer := task.GetServiceConnectContainer()
@@ -1739,27 +1739,27 @@ func (task *Task) dockerExposedPorts(container *apicontainer.Container) (dockerE
 
 	if task.IsServiceConnectEnabled() && task.IsNetworkModeBridge() {
 		if container.Type == apicontainer.ContainerCNIPause {
-			// find the application container associated with this particular pause container, and let pause container
+			// find the task container associated with this particular pause container, and let pause container
 			// expose the application container port
 			containerToCheck, err = task.getBridgeModeTaskContainerForPauseContainer(container)
 			if err != nil {
 				return nil, err
 			}
-		} else if container == scContainer {
-			// expose ingress listener ports if present
-			for _, ic := range task.ServiceConnectConfig.IngressConfig {
-				dockerPort := nat.Port(strconv.Itoa(int(ic.ListenerPort))) + "/tcp"
-				dockerExposedPorts[dockerPort] = struct{}{}
+			// if the associated task container is SC container, expose all its ingress and egress listener ports if present
+			if containerToCheck == scContainer {
+				for _, ic := range task.ServiceConnectConfig.IngressConfig {
+					dockerPort := nat.Port(strconv.Itoa(int(ic.ListenerPort))) + "/tcp"
+					dockerExposedPorts[dockerPort] = struct{}{}
+				}
+				ec := task.ServiceConnectConfig.EgressConfig
+				if ec.ListenerName != "" { // it's possible that task does not have an egress listener
+					dockerPort := nat.Port(strconv.Itoa(int(ec.ListenerPort))) + "/tcp"
+					dockerExposedPorts[dockerPort] = struct{}{}
+				}
+				return dockerExposedPorts, nil
 			}
-			// expose egress listener port if present
-			ec := task.ServiceConnectConfig.EgressConfig
-			if ec.ListenerName != "" { // it's possible that task does not have an egress listener
-				dockerPort := nat.Port(strconv.Itoa(int(ec.ListenerPort))) + "/tcp"
-				dockerExposedPorts[dockerPort] = struct{}{}
-			}
-			return dockerExposedPorts, nil
 		} else {
-			// This is a customer application container which is launched with "--network container:$pause_container_id"
+			// This is a task container which is launched with "--network container:$pause_container_id"
 			// In such case we don't expose any ports (docker won't allow anyway) because they are exposed by their
 			// pause container instead.
 			return dockerExposedPorts, nil
@@ -2006,9 +2006,6 @@ func (task *Task) shouldOverrideNetworkModeAwsvpc(container *apicontainer.Contai
 // with container network mode use pause container netns (the "docker run" equivalent option is
 // "--network container:$pause_container_id")
 func (task *Task) shouldOverrideNetworkModeServiceConnectBridge(container *apicontainer.Container, dockerContainerMap map[string]*apicontainer.DockerContainer) (bool, string) {
-	if container == task.GetServiceConnectContainer() {
-		return false, "" // SC container will use bridge mode (it doesn't need a pause container)
-	}
 	pauseContainer, err := task.getBridgeModePauseContainerForTaskContainer(container)
 	if err != nil {
 		// This should never be the case and implies a code-bug.
@@ -2265,24 +2262,27 @@ func (task *Task) dockerPortMap(container *apicontainer.Container) (nat.PortMap,
 	scContainer := task.GetServiceConnectContainer()
 	containerToCheck := container
 	if task.IsServiceConnectEnabled() && task.IsNetworkModeBridge() {
-		if container == scContainer {
-			// create bindings for all ingress listener ports
-			// no need to create binding for egress listener port as it won't be access from host level or from outside
-			for _, ic := range task.ServiceConnectConfig.IngressConfig {
-				dockerPort := nat.Port(strconv.Itoa(int(ic.ListenerPort))) + "/tcp"
-				hostPort := 0           // default bridge-mode SC experience - host port will be an ephemeral port assigned by docker
-				if ic.HostPort != nil { // non-default bridge-mode SC experience - host port specified by customer
-					hostPort = int(*ic.HostPort)
-				}
-				dockerPortMap[dockerPort] = append(dockerPortMap[dockerPort], nat.PortBinding{HostPort: strconv.Itoa(hostPort)})
-			}
-		} else if container.Type == apicontainer.ContainerCNIPause {
-			// we will create bindings for customer task container and let them be published by the associated pause container
+		if container.Type == apicontainer.ContainerCNIPause {
+			// we will create bindings for task containers (including both customer containers and SC Appnet container)
+			// and let them be published by the associated pause container.
 			// Note - for SC bridge mode we do not allow customer to specify a host port for their containers. Additionally,
 			// When an ephemeral host port is assigned, Appnet will NOT proxy traffic to that port
 			taskContainer, err := task.getBridgeModeTaskContainerForPauseContainer(container)
 			if err != nil {
 				return nil, err
+			}
+			if taskContainer == scContainer {
+				// create bindings for all ingress listener ports
+				// no need to create binding for egress listener port as it won't be access from host level or from outside
+				for _, ic := range task.ServiceConnectConfig.IngressConfig {
+					dockerPort := nat.Port(strconv.Itoa(int(ic.ListenerPort))) + "/tcp"
+					hostPort := 0           // default bridge-mode SC experience - host port will be an ephemeral port assigned by docker
+					if ic.HostPort != nil { // non-default bridge-mode SC experience - host port specified by customer
+						hostPort = int(*ic.HostPort)
+					}
+					dockerPortMap[dockerPort] = append(dockerPortMap[dockerPort], nat.PortBinding{HostPort: strconv.Itoa(hostPort)})
+				}
+				return dockerPortMap, nil
 			}
 			containerToCheck = taskContainer
 		} else {

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -218,8 +218,13 @@ func getTestTaskServiceConnectBridgeMode() *Task {
 				NetworkModeUnsafe: "", // should later be overridden to explicit bridge mode
 			},
 			{
-				Name:              serviceConnectContainerTestName, // port binding is retrieved through listener config
-				NetworkModeUnsafe: "",                              // should not be overridden (implicit bridge mode)
+				Name:              serviceConnectContainerTestName, // port binding is retrieved through listener config and published by pause container
+				NetworkModeUnsafe: "",                              // should later be overridden to container mode
+			},
+			{
+				Name:              fmt.Sprintf("%s-%s", NetworkPauseContainerName, serviceConnectContainerTestName),
+				Type:              apicontainer.ContainerCNIPause,
+				NetworkModeUnsafe: "", // should later be overridden to explicit bridge mode
 			},
 		},
 	}
@@ -251,10 +256,10 @@ func convertSCPort(port uint16) nat.Port {
 
 // TestDockerHostConfigSCBridgeMode verifies port bindings and network mode overrides for each
 // container in an SC-enabled bridge mode task. The test task is consisted of the SC container, a regular container,
-// and the pause container associated with it.
+// and two pause containers associated with each.
 func TestDockerHostConfigSCBridgeMode(t *testing.T) {
 	testTask := getTestTaskServiceConnectBridgeMode()
-	// task container should get empty port binding map and "container" network mode
+	// task container and SC container should both get empty port binding map and "container" network mode
 	actualConfig, err := testTask.DockerHostConfig(testTask.Containers[0], dockerMap(testTask), defaultDockerClientAPIVersion,
 		&config.Config{})
 	assert.Nil(t, err)
@@ -263,7 +268,15 @@ func TestDockerHostConfigSCBridgeMode(t *testing.T) {
 		dockerMappingContainerPrefix+dockerIDPrefix+NetworkPauseContainerName, "C1")), actualConfig.NetworkMode)
 	assert.Empty(t, actualConfig.PortBindings, "Task container port binding should be empty")
 
-	// pause container should get port binding map of the task container
+	actualConfig, err = testTask.DockerHostConfig(testTask.Containers[2], dockerMap(testTask), defaultDockerClientAPIVersion,
+		&config.Config{})
+	assert.Nil(t, err)
+	assert.NotNil(t, actualConfig)
+	assert.Equal(t, dockercontainer.NetworkMode(fmt.Sprintf("%s-%s", // e.g. "container:dockerid-~internal~ecs~pause-C1"
+		dockerMappingContainerPrefix+dockerIDPrefix+NetworkPauseContainerName, serviceConnectContainerTestName)), actualConfig.NetworkMode)
+	assert.Empty(t, actualConfig.PortBindings, "SC container port binding should be empty")
+
+	// task pause container should get port binding map of the task container
 	actualConfig, err = testTask.DockerHostConfig(testTask.Containers[1], dockerMap(testTask), defaultDockerClientAPIVersion,
 		&config.Config{})
 	assert.Nil(t, err)
@@ -278,12 +291,12 @@ func TestDockerHostConfigSCBridgeMode(t *testing.T) {
 	assert.Equal(t, 1, len(bindings), "Wrong number of bindings")
 	assert.Equal(t, "0", bindings[0].HostPort, "Wrong hostport")
 
-	// SC container should get port binding map of all ingress listeners
-	actualConfig, err = testTask.DockerHostConfig(testTask.Containers[2], dockerMap(testTask), defaultDockerClientAPIVersion,
+	// SC pause container should get port binding map of all ingress listeners
+	actualConfig, err = testTask.DockerHostConfig(testTask.Containers[3], dockerMap(testTask), defaultDockerClientAPIVersion,
 		&config.Config{})
 	assert.Nil(t, err)
 	assert.NotNil(t, actualConfig)
-	assert.Equal(t, dockercontainer.NetworkMode(""), actualConfig.NetworkMode)
+	assert.Equal(t, dockercontainer.NetworkMode(BridgeNetworkMode), actualConfig.NetworkMode)
 	// SC - ingress listener 1 - default experience
 	bindings, ok = actualConfig.PortBindings[convertSCPort(SCIngressListener1ContainerPort)]
 	assert.True(t, ok, "Could not get port bindings")
@@ -312,7 +325,7 @@ func TestDockerHostConfigSCBridgeMode_getPortBindingFailure(t *testing.T) {
 
 // TestDockerContainerConfigSCBridgeMode verifies exposed port configuration for each container
 // in an SC-enabled bridge mode task. The test task is consisted of the SC container, a regular container,
-// and the pause container associated with it.
+// and two pause container associated with each of them.
 func TestDockerContainerConfigSCBridgeMode(t *testing.T) {
 	testTask := getTestTaskServiceConnectBridgeMode()
 
@@ -322,7 +335,13 @@ func TestDockerContainerConfigSCBridgeMode(t *testing.T) {
 	assert.NotNil(t, actualConfig)
 	assert.Empty(t, actualConfig.ExposedPorts)
 
-	// Containers[1] pause container should expose all container ports from the associated user-defined task containers
+	// Containers[2] aka SC container should NOT expose any ports (it's done through the associated pause container)
+	actualConfig, err = testTask.DockerConfig(testTask.Containers[2], defaultDockerClientAPIVersion)
+	assert.Nil(t, err)
+	assert.NotNil(t, actualConfig)
+	assert.Empty(t, actualConfig.ExposedPorts)
+
+	// Containers[1] aka task pause container should expose all container ports from the associated user-defined task containers
 	actualConfig, err = testTask.DockerConfig(testTask.Containers[1], defaultDockerClientAPIVersion)
 	assert.Nil(t, err)
 	assert.NotNil(t, actualConfig)
@@ -333,8 +352,8 @@ func TestDockerContainerConfigSCBridgeMode(t *testing.T) {
 	_, ok = actualConfig.ExposedPorts[convertSCPort(SCTaskContainerPort2)]
 	assert.True(t, ok)
 
-	// Containers[2] aka SC container should expose all container ports from SC ingress and egress listeners
-	actualConfig, err = testTask.DockerConfig(testTask.Containers[2], defaultDockerClientAPIVersion)
+	// Containers[3] aka SC pause container should expose all container ports from SC ingress and egress listeners
+	actualConfig, err = testTask.DockerConfig(testTask.Containers[3], defaultDockerClientAPIVersion)
 	assert.Nil(t, err)
 	assert.NotNil(t, actualConfig)
 	assert.NotNil(t, actualConfig.ExposedPorts)
@@ -358,7 +377,7 @@ func TestDockerContainerConfigSCBridgeMode_getExposedPortsFailure(t *testing.T) 
 func TestDockerContainerConfigSCBridgeMode_emptyEgressConfig(t *testing.T) {
 	testTask := getTestTaskServiceConnectBridgeMode()
 	testTask.ServiceConnectConfig.EgressConfig = EgressConfig{}
-	actualConfig, err := testTask.DockerConfig(testTask.Containers[2], defaultDockerClientAPIVersion)
+	actualConfig, err := testTask.DockerConfig(testTask.Containers[3], defaultDockerClientAPIVersion)
 	assert.Nil(t, err)
 	assert.NotNil(t, actualConfig)
 	assert.NotNil(t, actualConfig.ExposedPorts)
@@ -3794,6 +3813,7 @@ func TestPostUnmarshalTaskWithServiceConnectAWSVPCMode(t *testing.T) {
 	assert.Nil(t, err, "Should be able to handle acs task")
 	err = task.PostUnmarshalTask(&config.Config{}, nil, nil, nil, nil)
 	assert.NoError(t, err)
+	task.NetworkMode = AWSVPCNetworkMode
 
 	validateServiceConnectContainerOrder(t, task)
 	validateEphemeralPorts(t, task, originalSCConfig, utilizedPorts)
@@ -3931,25 +3951,6 @@ func validateServiceConnectContainerOrder(t *testing.T, task *Task) {
 		ContainerName:   "C2",
 		SatisfiedStatus: apicontainerstatus.ContainerStopped,
 	}, scC.TransitionDependenciesMap[apicontainerstatus.ContainerStopped].ContainerDependencies[1])
-
-	// For bridge mode, also check that regular containers CREATED have a dependency on SC container RESOURCES_PROVISIONED
-	if task.IsNetworkModeBridge() {
-		assert.NotEmpty(t, c1.TransitionDependenciesMap)
-		assert.NotNil(t, c1.TransitionDependenciesMap[apicontainerstatus.ContainerCreated])
-		assert.NotEmpty(t, c1.TransitionDependenciesMap[apicontainerstatus.ContainerCreated].ContainerDependencies)
-		assert.Equal(t, apicontainer.ContainerDependency{
-			ContainerName:   serviceConnectContainerTestName,
-			SatisfiedStatus: apicontainerstatus.ContainerResourcesProvisioned,
-		}, c1.TransitionDependenciesMap[apicontainerstatus.ContainerCreated].ContainerDependencies[0])
-
-		assert.NotEmpty(t, c2.TransitionDependenciesMap)
-		assert.NotNil(t, c2.TransitionDependenciesMap[apicontainerstatus.ContainerCreated])
-		assert.NotEmpty(t, c2.TransitionDependenciesMap[apicontainerstatus.ContainerCreated].ContainerDependencies)
-		assert.Equal(t, apicontainer.ContainerDependency{
-			ContainerName:   serviceConnectContainerTestName,
-			SatisfiedStatus: apicontainerstatus.ContainerResourcesProvisioned,
-		}, c2.TransitionDependenciesMap[apicontainerstatus.ContainerCreated].ContainerDependencies[0])
-	}
 }
 
 func validateEphemeralPorts(t *testing.T, task *Task, originalSCConfig ServiceConnectConfig, utilizedPorts map[uint16]struct{}) {
@@ -4013,36 +4014,47 @@ func validateAppnetEnvVars(t *testing.T, task *Task) {
 
 func validateServiceConnectBridgeModePauseContainer(t *testing.T, task *Task) {
 	scC, _ := task.ContainerByName(serviceConnectContainerTestName)
+	scPauseC, ok := task.ContainerByName(fmt.Sprintf("%s-%s", NetworkPauseContainerName, serviceConnectContainerTestName))
+	assert.True(t, ok)
 	p1, ok := task.ContainerByName(fmt.Sprintf("%s-%s", NetworkPauseContainerName, "C1"))
 	assert.True(t, ok)
 	p2, ok := task.ContainerByName(fmt.Sprintf("%s-%s", NetworkPauseContainerName, "C2"))
 	assert.True(t, ok)
+	pauseContainers := [...]*apicontainer.Container{p1, p2, scPauseC}
 
-	// verify that SCContainer.CREATED depends on PauseContainer.RUNNING
+	// verify that SCContainer.CREATED depends on ALL PauseContainer.RESOURCES_PROVISIONED, and dthat
+	// ALL PauseContainer.STOPPED depends on SCContainer.STOPPED
 	assert.NotEmpty(t, scC.TransitionDependenciesMap)
 	assert.NotNil(t, scC.TransitionDependenciesMap[apicontainerstatus.ContainerCreated])
 	containerDependencies := scC.TransitionDependenciesMap[apicontainerstatus.ContainerCreated].ContainerDependencies
-	assert.NotEmpty(t, containerDependencies)
-	assert.Equal(t, p1.Name, containerDependencies[0].ContainerName)
-	assert.Equal(t, apicontainerstatus.ContainerRunning, containerDependencies[0].SatisfiedStatus)
-	assert.Equal(t, p2.Name, containerDependencies[1].ContainerName)
-	assert.Equal(t, apicontainerstatus.ContainerRunning, containerDependencies[1].SatisfiedStatus)
+	assert.Equal(t, len(pauseContainers), len(containerDependencies))
+	for i, pc := range pauseContainers {
+		assert.Equal(t, pc.Name, containerDependencies[i].ContainerName)
+		assert.Equal(t, apicontainerstatus.ContainerResourcesProvisioned, containerDependencies[i].SatisfiedStatus)
 
-	// verify that PauseContainer.STOPPED depends on SCContainer.STOPPED
-	assert.NotEmpty(t, p1.TransitionDependenciesMap)
-	assert.NotNil(t, p1.TransitionDependenciesMap[apicontainerstatus.ContainerStopped])
-	assert.NotEmpty(t, p1.TransitionDependenciesMap[apicontainerstatus.ContainerStopped].ContainerDependencies)
-	assert.Equal(t, apicontainer.ContainerDependency{
-		ContainerName:   serviceConnectContainerTestName,
-		SatisfiedStatus: apicontainerstatus.ContainerStopped,
-	}, p1.TransitionDependenciesMap[apicontainerstatus.ContainerStopped].ContainerDependencies[0])
+		assert.NotEmpty(t, pc.TransitionDependenciesMap)
+		assert.NotNil(t, pc.TransitionDependenciesMap[apicontainerstatus.ContainerStopped])
+		assert.NotEmpty(t, pc.TransitionDependenciesMap[apicontainerstatus.ContainerStopped].ContainerDependencies)
+		assert.Equal(t, apicontainer.ContainerDependency{
+			ContainerName:   serviceConnectContainerTestName,
+			SatisfiedStatus: apicontainerstatus.ContainerStopped,
+		}, pc.TransitionDependenciesMap[apicontainerstatus.ContainerStopped].ContainerDependencies[0])
+	}
 
-	assert.NotEmpty(t, p2.TransitionDependenciesMap)
-	assert.NotNil(t, p2.TransitionDependenciesMap[apicontainerstatus.ContainerStopped])
+	// verify that taskPauseContainer.RESOURCES_PROVISIONED depends on SCPauseContainer.RUNNING
+	assert.NotNil(t, p1.TransitionDependenciesMap[apicontainerstatus.ContainerResourcesProvisioned])
+	assert.NotEmpty(t, p1.TransitionDependenciesMap[apicontainerstatus.ContainerResourcesProvisioned].ContainerDependencies)
 	assert.Equal(t, apicontainer.ContainerDependency{
-		ContainerName:   serviceConnectContainerTestName,
-		SatisfiedStatus: apicontainerstatus.ContainerStopped,
-	}, p2.TransitionDependenciesMap[apicontainerstatus.ContainerStopped].ContainerDependencies[0])
+		ContainerName:   scPauseC.Name,
+		SatisfiedStatus: apicontainerstatus.ContainerRunning,
+	}, p1.TransitionDependenciesMap[apicontainerstatus.ContainerResourcesProvisioned].ContainerDependencies[0])
+
+	assert.NotNil(t, p2.TransitionDependenciesMap[apicontainerstatus.ContainerResourcesProvisioned])
+	assert.NotEmpty(t, p2.TransitionDependenciesMap[apicontainerstatus.ContainerResourcesProvisioned].ContainerDependencies)
+	assert.Equal(t, apicontainer.ContainerDependency{
+		ContainerName:   scPauseC.Name,
+		SatisfiedStatus: apicontainerstatus.ContainerRunning,
+	}, p2.TransitionDependenciesMap[apicontainerstatus.ContainerResourcesProvisioned].ContainerDependencies[0])
 }
 
 func TestPostUnmarshalTaskNetworkModeInference(t *testing.T) {

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -1662,8 +1662,8 @@ func (engine *DockerTaskEngine) provisionContainerResources(task *apitask.Task, 
 		}
 	}
 
-	if task.IsServiceConnectEnabled() && task.IsNetworkModeBridge() && container == task.GetServiceConnectContainer() {
-		// TODO [SC]: CNI integration for SC bridge-mode task
+	if task.IsServiceConnectEnabled() && task.IsNetworkModeBridge() {
+		// TODO [SC]: CNI integration for SC bridge-mode task (need branching to handle SC pause and task container pause)
 		return dockerapi.MetadataFromContainer(containerInspectOutput)
 	}
 

--- a/agent/engine/docker_task_engine_linux_test.go
+++ b/agent/engine/docker_task_engine_linux_test.go
@@ -1095,25 +1095,50 @@ func TestContainersWithServiceConnect_BridgeMode(t *testing.T) {
 
 	sleepContainerID := containerID + "1"
 	scContainerID := "serviceConnectID"
-	pauseContainerID := "pauseContainerID"
+	sleepPauseContainerID := "sleepPauseContainerID"
+	scPauseContainerID := "pauseContainerID"
 
-	// Pause container will be launched first
+	// For sleep pause and SC pause container, they can start in parallel except sleepPause.RESOURCES_PROVISIONED depends on
+	// SCPause.RUNNING
+	// sleep pause container expected calls
+	dockerClient.EXPECT().APIVersion().Return(defaultDockerClientAPIVersion, nil)
+	serviceConnectManager.EXPECT().AugmentTaskContainer(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	dockerClient.EXPECT().CreateContainer(
+		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(
+		func(ctx interface{}, config *dockercontainer.Config, hostConfig *dockercontainer.HostConfig, y, z interface{}) {
+			verifyServiceConnectSleepPauseContainerBridgeMode(t, ctx, config, hostConfig, y, z)
+		}).Return(dockerapi.DockerContainerMetadata{DockerID: sleepPauseContainerID})
+	dockerClient.EXPECT().StartContainer(gomock.Any(), sleepPauseContainerID, defaultConfig.ContainerStartTimeout).Return(
+		dockerapi.DockerContainerMetadata{
+			DockerID: sleepPauseContainerID,
+			NetworkSettings: &types.NetworkSettings{
+				DefaultNetworkSettings: types.DefaultNetworkSettings{IPAddress: "1.2.3.4"},
+			}},
+	)
+
+	// SC pause container expected calls
+	dockerClient.EXPECT().APIVersion().Return(defaultDockerClientAPIVersion, nil)
+	serviceConnectManager.EXPECT().AugmentTaskContainer(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	dockerClient.EXPECT().CreateContainer(
+		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(
+		func(ctx interface{}, config *dockercontainer.Config, hostConfig *dockercontainer.HostConfig, y, z interface{}) {
+			verifyServiceConnectPauseContainerBridgeMode(t, ctx, config, hostConfig, y, z)
+		}).Return(dockerapi.DockerContainerMetadata{DockerID: scPauseContainerID})
+
+	// sleepPause.RESOURCES_PROVISIONED depends on SCPause.RUNNING
 	gomock.InOrder(
-		dockerClient.EXPECT().APIVersion().Return(defaultDockerClientAPIVersion, nil),
-		serviceConnectManager.EXPECT().AugmentTaskContainer(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil),
-		dockerClient.EXPECT().CreateContainer(
-			gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(
-			func(ctx interface{}, config *dockercontainer.Config, hostConfig *dockercontainer.HostConfig, y, z interface{}) {
-				verifyServiceConnectPauseContainerBridgeMode(t, ctx, config, hostConfig, y, z)
-			}).Return(dockerapi.DockerContainerMetadata{DockerID: pauseContainerID}),
-		dockerClient.EXPECT().StartContainer(gomock.Any(), pauseContainerID, defaultConfig.ContainerStartTimeout).Return(
+		dockerClient.EXPECT().StartContainer(gomock.Any(), scPauseContainerID, defaultConfig.ContainerStartTimeout).Return(
 			dockerapi.DockerContainerMetadata{
-				DockerID: pauseContainerID,
+				DockerID: scPauseContainerID,
 				NetworkSettings: &types.NetworkSettings{
-					DefaultNetworkSettings: types.DefaultNetworkSettings{IPAddress: "1.2.3.4"},
+					DefaultNetworkSettings: types.DefaultNetworkSettings{IPAddress: "1.2.3.5"},
 				}},
 		),
+		dockerClient.EXPECT().InspectContainer(gomock.Any(), sleepPauseContainerID, gomock.Any()).Return(
+			&types.ContainerJSON{ContainerJSONBase: &types.ContainerJSONBase{ID: sleepPauseContainerID}}, nil),
 	)
+	dockerClient.EXPECT().InspectContainer(gomock.Any(), scPauseContainerID, gomock.Any()).Return(
+		&types.ContainerJSON{ContainerJSONBase: &types.ContainerJSONBase{ID: scPauseContainerID}}, nil)
 
 	// For SC and sleep container - those calls can happen in parallel
 	imageManager.EXPECT().AddAllImageStates(gomock.Any()).AnyTimes()
@@ -1126,23 +1151,14 @@ func TestContainersWithServiceConnect_BridgeMode(t *testing.T) {
 	gomock.InOrder(
 		// SC container
 		dockerClient.EXPECT().CreateContainer(
-			gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(
-			func(ctx interface{}, config *dockercontainer.Config, hostConfig *dockercontainer.HostConfig, y, z interface{}) {
-				verifyServiceConnectAppnetContainerBridgeMode(t, ctx, config, hostConfig, y, z)
-			}).Return(dockerapi.DockerContainerMetadata{DockerID: scContainerID}),
+			gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(dockerapi.DockerContainerMetadata{DockerID: scContainerID}),
 		dockerClient.EXPECT().StartContainer(gomock.Any(), scContainerID, defaultConfig.ContainerStartTimeout).Return(
-			dockerapi.DockerContainerMetadata{DockerID: scContainerID}),
-		dockerClient.EXPECT().InspectContainer(gomock.Any(), scContainerID, gomock.Any()).Return(
-			&types.ContainerJSON{
-				ContainerJSONBase: &types.ContainerJSONBase{
-					ID: scContainerID,
-					State: &types.ContainerState{
-						Pid:    containerPid,
-						Health: &types.Health{Status: types.Healthy},
-					},
-				}}, nil),
+			dockerapi.DockerContainerMetadata{
+				DockerID: scContainerID,
+				Health:   apicontainer.HealthStatus{Status: apicontainerstatus.ContainerHealthy},
+			}),
 
-		// sleep container should only start after SC
+		// sleep container should only start after SC container
 		dockerClient.EXPECT().CreateContainer(gomock.Any(), gomock.Any(), gomock.Any(),
 			gomock.Any(), gomock.Any()).Return(dockerapi.DockerContainerMetadata{DockerID: sleepContainerID}),
 		dockerClient.EXPECT().StartContainer(gomock.Any(), sleepContainerID, defaultConfig.ContainerStartTimeout).Return(
@@ -1154,7 +1170,8 @@ func TestContainersWithServiceConnect_BridgeMode(t *testing.T) {
 	mockTime.EXPECT().Now().Return(time.Now()).MinTimes(1)
 	dockerClient.EXPECT().DescribeContainer(gomock.Any(), scContainerID).AnyTimes()
 	dockerClient.EXPECT().DescribeContainer(gomock.Any(), sleepContainerID).AnyTimes()
-	dockerClient.EXPECT().DescribeContainer(gomock.Any(), pauseContainerID).AnyTimes()
+	dockerClient.EXPECT().DescribeContainer(gomock.Any(), scPauseContainerID).AnyTimes()
+	dockerClient.EXPECT().DescribeContainer(gomock.Any(), sleepPauseContainerID).AnyTimes()
 
 	err := taskEngine.Init(ctx)
 	assert.NoError(t, err)
@@ -1163,17 +1180,19 @@ func TestContainersWithServiceConnect_BridgeMode(t *testing.T) {
 	verifyTaskIsRunning(stateChangeEvents, sleepTask)
 
 	mockTime.EXPECT().After(gomock.Any()).Return(cleanup).MinTimes(1)
-	// sleep container should stop first, followed by SC container, and finally pause container
+	// sleep container should stop first, followed by SC container, and finally pause containers
 	gomock.InOrder(
 		dockerClient.EXPECT().StopContainer(gomock.Any(), sleepContainerID, gomock.Any()).Return(
 			dockerapi.DockerContainerMetadata{DockerID: sleepContainerID}),
 		dockerClient.EXPECT().StopContainer(gomock.Any(), scContainerID, gomock.Any()).Return(
 			dockerapi.DockerContainerMetadata{DockerID: scContainerID}),
-		dockerClient.EXPECT().StopContainer(gomock.Any(), pauseContainerID, gomock.Any()).Return(
-			dockerapi.DockerContainerMetadata{DockerID: pauseContainerID}),
 	)
+	dockerClient.EXPECT().StopContainer(gomock.Any(), scPauseContainerID, gomock.Any()).Return(
+		dockerapi.DockerContainerMetadata{DockerID: scPauseContainerID})
+	dockerClient.EXPECT().StopContainer(gomock.Any(), sleepPauseContainerID, gomock.Any()).Return(
+		dockerapi.DockerContainerMetadata{DockerID: sleepPauseContainerID})
 
-	dockerClient.EXPECT().RemoveContainer(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(3)
+	dockerClient.EXPECT().RemoveContainer(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(4)
 	imageManager.EXPECT().RemoveContainerReferenceFromImageState(gomock.Any()).Return(nil).AnyTimes()
 
 	// Set task desired status to STOPPED for triggering container stop sequence
@@ -1194,7 +1213,7 @@ func TestContainersWithServiceConnect_BridgeMode(t *testing.T) {
 	}
 }
 
-func verifyServiceConnectPauseContainerBridgeMode(t *testing.T, ctx interface{}, config *dockercontainer.Config, hostConfig *dockercontainer.HostConfig, y, z interface{}) {
+func verifyServiceConnectSleepPauseContainerBridgeMode(t *testing.T, ctx interface{}, config *dockercontainer.Config, hostConfig *dockercontainer.HostConfig, y, z interface{}) {
 	name, ok := config.Labels[labelPrefix+"container-name"]
 	assert.True(t, ok)
 	assert.Equal(t, fmt.Sprintf("%s-%s", apitask.NetworkPauseContainerName, "sleep5"), name)
@@ -1214,12 +1233,12 @@ func verifyServiceConnectPauseContainerBridgeMode(t *testing.T, ctx interface{},
 	assert.True(t, ok)
 }
 
-func verifyServiceConnectAppnetContainerBridgeMode(t *testing.T, ctx interface{}, config *dockercontainer.Config, hostConfig *dockercontainer.HostConfig, y, z interface{}) {
+func verifyServiceConnectPauseContainerBridgeMode(t *testing.T, ctx interface{}, config *dockercontainer.Config, hostConfig *dockercontainer.HostConfig, y, z interface{}) {
 	name, ok := config.Labels[labelPrefix+"container-name"]
 	assert.True(t, ok)
-	assert.Equal(t, "service-connect", name)
-	// verify host config network mode is "" (aka default bridge network mode)
-	assert.Equal(t, dockercontainer.NetworkMode(""), hostConfig.NetworkMode)
+	assert.Equal(t, fmt.Sprintf("%s-%s", apitask.NetworkPauseContainerName, "service-connect"), name)
+	// verify host config network mode
+	assert.Equal(t, dockercontainer.NetworkMode(apitask.BridgeNetworkMode), hostConfig.NetworkMode)
 	// verify host config port bindings
 	assert.NotNil(t, hostConfig.PortBindings)
 	assert.Equal(t, 1, len(hostConfig.PortBindings))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Use pause container for SC container, and let each pause container invoke CNI plugin individually. This way the behavior is more consistent with how CNI plugins are expected to be used (configure single netns at a time). SC pause container will be setting up TPROXY, where as other task pause containers will have an IP route added to direct traffic destined to SC_VIPs to SC container.

### Implementation details
<!-- How are the changes implemented? -->

For container ordering:
* SC pause container has no dependency during task start up
* Task pause container `RESOURCES_PROVISIONED`  depends on SC pause container `RUNNING` (since CNI plugin needs SC pause container IP for adding IP route)
* SC container `CREATED` depends on ALL pause container `RESOURCES_PROVISIONED`
* Task container `CREATED`  depends on SC container `HEALTHY`

Currently, SC container docker port mapping and exposed ports are configured with the SC container itself. But now that we've introduced a pause container for it, the above configurations will be done through pause container. 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Add SC pause container and update container dependency ordering

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
