### PR TITLE
Cleanup the symantics of ACS Handler

### DIFF
--- a/agent/acs/handler/acs_handler.go
+++ b/agent/acs/handler/acs_handler.go
@@ -203,70 +203,54 @@ func NewSession(
 // Start starts the session. It'll forever keep trying to connect to ACS unless
 // the context is cancelled.
 //
-// If the context is cancelled, Start() would return with the error code returned
-// by the context.
-// If the instance is deregistered, Start() would emit an event to the
-// deregister-instance event stream and sets the connection backoff time to 1 hour.
+// Returns nil always TODO: consider removing error return value completely
 func (acsSession *session) Start() error {
-	// connectToACS channel is used to indicate the intent to connect to ACS
-	// It's processed by the select loop to connect to ACS
-	connectToACS := make(chan struct{}, 1)
-	// This is required to trigger the first connection to ACS. Subsequent
-	// connections are triggered by the handleACSError() method
-	connectToACS <- struct{}{}
+	// Loop continuously until context is closed/cancelled
 	for {
-		select {
-		case <-connectToACS:
-			seelog.Debugf("Received connect to ACS message")
-			// Start a session with ACS
-			acsError := acsSession.startSessionOnce()
-			select {
-			case <-acsSession.ctx.Done():
-				// agent is shutting down, exiting cleanly
-				return nil
-			default:
-			}
-			// Session with ACS was stopped with some error, start processing the error
-			isInactiveInstance := isInactiveInstanceError(acsError)
-			if isInactiveInstance {
-				// If the instance was deregistered, send an event to the event stream
-				// for the same
-				seelog.Debug("Container instance is deregistered, notifying listeners")
-				err := acsSession.deregisterInstanceEventStream.WriteToEventStream(struct{}{})
-				if err != nil {
-					seelog.Debugf("Failed to write to deregister container instance event stream, err: %v", err)
-				}
-			}
-			if shouldReconnectWithoutBackoff(acsError) {
-				// If ACS or agent closed the connection, there's no need to backoff,
-				// reconnect immediately
-				seelog.Infof("ACS Websocket connection closed for a valid reason: %v", acsError)
-				acsSession.backoff.Reset()
-				sendEmptyMessageOnChannel(connectToACS)
-			} else {
-				// Disconnected unexpectedly from ACS, compute backoff duration to
-				// reconnect
-				reconnectDelay := acsSession.computeReconnectDelay(isInactiveInstance)
-				seelog.Infof("Reconnecting to ACS in: %s", reconnectDelay.String())
-				waitComplete := acsSession.waitForDuration(reconnectDelay)
-				if waitComplete {
-					// If the context was not cancelled and we've waited for the
-					// wait duration without any errors, send the message to the channel
-					// to reconnect to ACS
-					seelog.Info("Done waiting; reconnecting to ACS")
-					sendEmptyMessageOnChannel(connectToACS)
-				} else {
-					// Wait was interrupted. We expect the session to close as canceling
-					// the session context is the only way to end up here. Print a message
-					// to indicate the same
-					seelog.Info("Interrupted waiting for reconnect delay to elapse; Expect session to close")
-				}
-			}
-		case <-acsSession.ctx.Done():
-			// agent is shutting down, exiting cleanly
+		seelog.Debugf("Attempting connect to ACS")
+		// Start a session with ACS
+		acsError := acsSession.startSessionOnce()
+
+		// If the session is over check for shutdown first
+		if err := acsSession.ctx.Err(); err != nil {
 			return nil
 		}
 
+		// If ACS closed the connection, reconnect immediately
+		if shouldReconnectWithoutBackoff(acsError) {
+			seelog.Infof("ACS Websocket connection closed for a valid reason: %v", acsError)
+			acsSession.backoff.Reset()
+			continue
+		}
+
+		// Session with ACS was stopped with some error, start processing the error
+		isInactiveInstance := isInactiveInstanceError(acsError)
+		if isInactiveInstance {
+			// If the instance was deregistered, send an event to the event stream
+			// for the same
+			seelog.Debug("Container instance is deregistered, notifying listeners")
+			err := acsSession.deregisterInstanceEventStream.WriteToEventStream(struct{}{})
+			if err != nil {
+				seelog.Debugf("Failed to write to deregister container instance event stream, err: %v", err)
+			}
+		}
+
+		// Disconnected unexpectedly from ACS, compute backoff duration to
+		// reconnect
+		reconnectDelay := acsSession.computeReconnectDelay(isInactiveInstance)
+		seelog.Infof("Reconnecting to ACS in: %s", reconnectDelay.String())
+		waitComplete := acsSession.waitForDuration(reconnectDelay)
+		if !waitComplete {
+			// Wait was interrupted. We expect the session to close as canceling
+			// the session context is the only way to end up here. Print a message
+			// to indicate the same
+			seelog.Info("Interrupted waiting for reconnect delay to elapse; Expect session to close")
+			return nil
+		}
+
+		// If the context was not cancelled and we've waited for the
+		// wait duration without any errors, reconnect to ACS
+		seelog.Info("Done waiting; reconnecting to ACS")
 	}
 }
 
@@ -591,12 +575,4 @@ func shouldReconnectWithoutBackoff(acsError error) bool {
 
 func isInactiveInstanceError(acsError error) bool {
 	return acsError != nil && strings.HasPrefix(acsError.Error(), inactiveInstanceExceptionPrefix)
-}
-
-// sendEmptyMessageOnChannel sends an empty message using a go-routine on the
-// specified channel
-func sendEmptyMessageOnChannel(channel chan<- struct{}) {
-	go func() {
-		channel <- struct{}{}
-	}()
 }


### PR DESCRIPTION
### Summary

The ACS handler was using a channel to support looping, but the
channel was only sent to from the current thread via a go routine
that would just write to the channel.

The rewrite maintains the behavior of always connecting when
disconnected potentially after a retry backoff. However it uses
a simple endless for loop rather than reading from channels to
mimic this straightforward behavior.

The rewrite also adheres to the interface contract on returning
the error from the context if it is Done for any reason other
than cancelled.

### Testing
Added additional tests to validate that all paths reconnect or exit when Context is Error or Cancelled, with appropriate returns. No additional testing outside of Unit/Functional tests.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
