### PR TITLE
Add generic-deb-integrated make target and recipe

### DIFF
--- a/packaging/generic-deb-integrated/debian/rules
+++ b/packaging/generic-deb-integrated/debian/rules
@@ -1,14 +1,21 @@
 #!/usr/bin/make -f
 # -*- makefile -*-
+#  version is the "init version"
 VERSION := $(shell dpkg-parsechangelog -S Version)
+# agent_version replaces the `-` with a space then takes the first "word" in the resulting "list"
+# this essentially removes the version suffix `-1` using the limited makefile syntax
+AGENT_VERSION := $(word 1, $(subst -, ,$(VERSION)))
 
-# Uncomment this to turn on verbose mode.
 export DH_VERBOSE=1
 
 %:
 	dh $@
 
 override_dh_auto_build:
+	./scripts/get-host-certs
+	./scripts/build-cni-plugins
+	./scripts/build-integrated true "" false true
+	./scripts/build-agent-image
 	./scripts/gobuild.sh debian
 
 clean:
@@ -16,7 +23,7 @@ clean:
 	rm -f amazon-ecs-init
 
 override_dh_auto_install:
-	cp ecs-agent.tar debian/amazon-ecs-init/var/cache/ecs/ecs-agent-v${VERSION}.tar
+	cp ./ecs-agent-v${AGENT_VERSION}.tar debian/amazon-ecs-init/var/cache/ecs/ecs-agent-v${VERSION}.tar
 	echo "2" >debian/amazon-ecs-init/var/cache/ecs/state
 	ln -s "/var/cache/ecs/ecs-agent-v${VERSION}.tar" debian/amazon-ecs-init/var/cache/ecs/ecs-agent.tar
 	dh_installsystemd --no-start --no-enable --name=ecs

--- a/packaging/generic-deb-integrated/debian/source/include-binaries
+++ b/packaging/generic-deb-integrated/debian/source/include-binaries
@@ -1,1 +1,2 @@
-ecs-agent.tar
+misc/pause-container/pause-image-tar-files/amazon-ecs-pause-arm64.tar
+misc/pause-container/pause-image-tar-files/amazon-ecs-pause-amd64.tar

--- a/packaging/generic-deb-integrated/debian/source/options
+++ b/packaging/generic-deb-integrated/debian/source/options
@@ -1,0 +1,4 @@
+# Automatically add upstream changes to the quilt overlay.
+# http://manpages.ubuntu.com/manpages/trusty/man1/dpkg-source.1.html
+# This supports reusing the orig.tar.gz for debian increments.
+auto-commit

--- a/packaging/generic-rpm-integrated/amazon-ecs-init.spec
+++ b/packaging/generic-rpm-integrated/amazon-ecs-init.spec
@@ -31,7 +31,6 @@ Source2:        amazon-ecs-volume-plugin.service
 Source3:        amazon-ecs-volume-plugin.socket
 
 BuildRequires:  systemd
-BuildRequires:	glibc-static
 Requires:       systemd
 Requires:       iptables
 Requires:       procps
@@ -45,7 +44,6 @@ required routes among its preparation steps.
 %setup -c
 
 %build
-./scripts/build-pause
 ./scripts/get-host-certs
 ./scripts/build-cni-plugins
 ./scripts/build-integrated true "" false true

--- a/scripts/gobuild.sh
+++ b/scripts/gobuild.sh
@@ -17,6 +17,7 @@ set -e
 export TOPWD="$(pwd)"
 export BUILDDIR="$(mktemp -d)"
 export SRCPATH="${BUILDDIR}/src/github.com/aws/amazon-ecs-agent"
+export GOPATH="${TOPWD}:${BUILDDIR}"
 export GO111MODULE="auto"
 
 if [ -d "${TOPWD}/.git" ]; then


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Add the `generic-deb-integrated` Debian recipe for ECS Anywhere which builds ECS without relying on Docker.  This also has various updates to support the rpm builds as well as changes to the `make clean` target to support build environments without Docker.

### Implementation details
The Debian changes were built directly on an Ubuntu EC2 instance without Docker available.  The RPM changes were built on an AL2 EC2 instance with Docker available.  Each recipe calls the same scripts that the specific make targets call, so the individual built artifacts that we vend match those built into the deb/rpm.  (This also helps with debugging issues.)

This PR also pulls in the original build targets (`deb` and `generic-rpm`) from ECS Init with minor updates to support the integration into ECS Agent repo.  These targets were also tested on their respective OS-es.

### Testing
Each of the builds was tested on EC2 instances and also in our CodeBuild stages of our CodePipelines.  The resulting deb/rpm were each installed and tested to be able to register and to run a task.

New tests cover the changes: no

### Description for the changelog
Add updated Debian debuild files to support a dockerfree end-to-end build process. 

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
