### PR TITLE
Fix race condition in test

### DIFF
--- a/agent/engine/docker_task_engine_linux_test.go
+++ b/agent/engine/docker_task_engine_linux_test.go
@@ -1204,8 +1204,7 @@ func TestContainersWithServiceConnect_BridgeMode(t *testing.T) {
 	imageManager.EXPECT().RemoveContainerReferenceFromImageState(gomock.Any()).Return(nil).AnyTimes()
 
 	// Set task desired status to STOPPED for triggering container stop sequence
-	sleepTask.DesiredStatusUnsafe = apitaskstatus.TaskStopped
-	sleepTask.UpdateDesiredStatus()
+	sleepTask.SetDesiredStatus(apitaskstatus.TaskStopped)
 
 	verifyTaskIsStopped(stateChangeEvents, sleepTask)
 	sleepTask.SetSentStatus(apitaskstatus.TaskStopped)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Use a safe setter to update task desired status when driving bridge mode unit test. 


### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Use a safe setter to update task desired status when driving bridge mode unit test. 
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
