### PR TITLE
Added a minimal ECR image for the signing build environment

### DIFF
--- a/build-infrastructure/Dockerfile.signer
+++ b/build-infrastructure/Dockerfile.signer
@@ -1,0 +1,14 @@
+# Pull from Public ECR because less likely to get throttled
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+
+# Assign a build tag because if we ever run into issues with
+# this image, we'll be able to look back at the image tag
+# and figure out what went wrong
+# To build this image, run
+# docker run -t <your_repo>:<tag_you_want> --build-arg builddate=$(date +%Y%m%d) .
+# For reference date +%Y%m%d outputs today's date in YYYYMMDD format
+# We also tag this image with the same tag in ECR
+ARG builddate
+ENV ECS_AGENT_SIGNING_IMAGE_TAG="build-${builddate}"
+
+RUN yum install -y awscli gpg jq

--- a/build-infrastructure/minimal-signing-build-stack.yml
+++ b/build-infrastructure/minimal-signing-build-stack.yml
@@ -223,7 +223,7 @@ Resources:
       Targets:
         - Arn: !GetAtt ImageCodeBuildProject.Arn
           Id: !Sub 'codebuild-target-${PeriodicBuildTriggerName}'
-          RoleArn: !GetAtt ImageCodeBuildProjectServiceRole.Arn
+          RoleArn: !GetAtt ImageBuildPeriodicTriggerRole.Arn
 
 Outputs:
   EcrRepositoryUri:

--- a/build-infrastructure/minimal-signing-build-stack.yml
+++ b/build-infrastructure/minimal-signing-build-stack.yml
@@ -1,0 +1,233 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Description: A template that creates a minimal signing CodeBuild environment and stores it in ECR
+
+Parameters:
+  SignerImageRepositoryName:
+    Type: String
+    Description: the name of the ECR repository to upload the signer image to
+    Default: ecs-agent-signer
+  RepositoryImageRententionPeriodInDays:
+    Type: Number
+    Default: 180
+  ImageCodeBuildProjectName:
+    Type: String
+    Description: the name of the CodeBuild project that builds the signing Docker image
+    Default: ecs-agent-signer-image-build
+  DockerBuildLogsGroupName:
+    Type: String
+    Description: The name of the log group to store the signing Docker image logs in
+    Default: signer-image-build-logs
+  CodeStarConnectionArn:
+    Type: String
+    Description: The ARN of the connection to use to connect to GitHub
+  GitHubRepositoryUrl:
+    Type: String
+    Description: The repository to pull the Dockerfile from so that we can build the signer image
+    Default: https://github.com/aws/amazon-ecs-agent
+  GitHubBranchName:
+    Type: String
+    Description: The branch to use from the repository mentioned above
+    Default: master
+  ImageBuildFrequencyCronExpression:
+    Type: String
+    Description: A cron expression to periodically build the signing image, can be left blank to disable periodic builds. See https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html
+    Default: 30 10 ? * 4 *
+  PeriodicBuildTriggerName:
+    Type: String
+    Description: The name of the CloudWatch Event rule, ignored if ImageBuildFrequencyCronExpression is blank
+    Default: PeriodicallyTriggerSigningImageBuild
+  LogGroupRetentionPeriodInDays:
+    Type: Number
+    Description: The number of days to retain cloudwatch logs
+    Default: 180
+    AllowedValues:
+      - 1
+      - 3
+      - 5
+      - 7
+      - 14
+      - 30
+      - 60
+      - 90
+      - 120
+      - 150
+      - 180
+      - 365
+      - 400
+      - 545
+      - 731
+      - 1827
+      - 3653
+
+Conditions:
+  GeneratePeriodicTrigger:
+    !Not [!Equals [!Ref 'ImageBuildFrequencyCronExpression', '']]
+
+Resources:
+  DockerBuildLogsGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Ref DockerBuildLogsGroupName
+      RetentionInDays: !Ref LogGroupRetentionPeriodInDays
+
+  SignerImageRepository:
+    Type: AWS::ECR::Repository
+    Properties:
+      RepositoryName: !Ref SignerImageRepositoryName
+      ImageTagMutability: MUTABLE
+      LifecyclePolicy:
+        LifecyclePolicyText: !Sub |
+          {
+            "rules": [
+              {
+                "rulePriority": 1,
+                "description": "Only keep build-yyyymmdd images for ${RepositoryImageRententionPeriodInDays} days",
+                "selection": {
+                  "countType": "sinceImagePushed",
+                  "countUnit": "days",
+                  "countNumber": ${RepositoryImageRententionPeriodInDays},
+                  "tagStatus": "tagged",
+                  "tagPrefixList": [
+                    "build"
+                  ]
+                },
+                "action": {
+                  "type": "expire"
+                }
+              }
+            ]
+          }
+
+  ImageCodeBuildProjectServiceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub 'image-codebuild-project-service-role-${AWS::Region}'
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          Effect: Allow
+          Principal:
+            Service: codebuild.amazonaws.com
+          Action: sts:AssumeRole
+      Policies:
+        - PolicyName: codebuild-image-build-base-policy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Sid: EcrPushImageAccess
+                Effect: Allow
+                Action:
+                  - ecr:CompleteLayerUpload
+                  - ecr:UploadLayerPart
+                  - ecr:InitiateLayerUpload
+                  - ecr:BatchCheckLayerAvailability
+                  - ecr:PutImage
+                Resource: !GetAtt SignerImageRepository.Arn
+              - Sid: EcrGetAuthTokenAccess
+                Effect: Allow
+                Action:
+                  - ecr:GetAuthorizationToken
+                Resource: '*'
+              - Sid: CodeBuildCodeStarConnectionAccess
+                Effect: Allow
+                Resource:
+                  - !Ref CodeStarConnectionArn
+                Action:
+                  - codestar-connections:UseConnection
+              - Sid: CloudWatchLogsAccess
+                Effect: Allow
+                Resource:
+                  - !GetAtt DockerBuildLogsGroup.Arn
+                  - !Sub '${DockerBuildLogsGroup.Arn}:*'
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+              - Sid: CodeBuildCreateReportAccess
+                Effect: Allow
+                Resource:
+                  - !Sub 'arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:report-group/${ImageCodeBuildProjectName}-*'
+                Action:
+                  - codebuild:CreateReportGroup
+                  - codebuild:CreateReport
+                  - codebuild:UpdateReport
+                  - codebuild:BatchPutTestCases
+                  - codebuild:BatchPutCodeCoverages
+
+  ImageCodeBuildProject:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Name: !Ref ImageCodeBuildProjectName
+      Description: A CodeBuild project that signs artifacts that were built earlier
+      ConcurrentBuildLimit: 10
+      ServiceRole: !GetAtt ImageCodeBuildProjectServiceRole.Arn
+      Artifacts:
+        Type: NO_ARTIFACTS
+      Environment:
+        Type: LINUX_CONTAINER
+        ComputeType: BUILD_GENERAL1_SMALL
+        ImagePullCredentialsType: CODEBUILD
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+        PrivilegedMode: true
+        EnvironmentVariables:
+          - Name: SIGNER_ECR_REPO
+            Type: PLAINTEXT
+            Value: !GetAtt SignerImageRepository.RepositoryUri
+      Source:
+        BuildSpec: buildspecs/signing-image-build.yml
+        Type: GITHUB
+        Location: !Ref GitHubRepositoryUrl
+        GitSubmodulesConfig:
+          FetchSubmodules: true
+      SourceVersion: !Ref GitHubBranchName
+      TimeoutInMinutes: 60
+      QueuedTimeoutInMinutes: 480
+      LogsConfig:
+        CloudWatchLogs:
+          GroupName: !Ref DockerBuildLogsGroupName
+          Status: ENABLED
+          StreamName: !Ref ImageCodeBuildProjectName
+
+  ImageBuildPeriodicTriggerRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub 'image-periodic-trigger-service-role-${AWS::Region}'
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: events.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: build-event-trigger-base-policy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Sid: CodeBuildStartBuildAccess
+                Effect: Allow
+                Action:
+                  - codebuild:StartBuild
+                Resource: !GetAtt ImageCodeBuildProject.Arn
+
+  PeriodicBuildTrigger:
+    Condition: GeneratePeriodicTrigger
+    Type: AWS::Events::Rule
+    Properties:
+      Description: Trigger the image build periodically based on a cron expression
+      Name: !Ref PeriodicBuildTriggerName
+      RoleArn: !GetAtt ImageBuildPeriodicTriggerRole.Arn
+      ScheduleExpression: !Sub 'cron(${ImageBuildFrequencyCronExpression})'
+      State: ENABLED
+      Targets:
+        - Arn: !GetAtt ImageCodeBuildProject.Arn
+          Id: !Sub 'codebuild-target-${PeriodicBuildTriggerName}'
+          RoleArn: !GetAtt ImageCodeBuildProjectServiceRole.Arn
+
+Outputs:
+  EcrRepositoryUri:
+    Description: The URI of the Agent Signer image ECR repository
+    Value: !GetAtt SignerImageRepository.RepositoryUri
+    Export:
+      Name: !Sub '${AWS::StackName}-${AWS::Region}-SignerImageEcrRepositoryUri'

--- a/build-infrastructure/release-pipeline-stack.yml
+++ b/build-infrastructure/release-pipeline-stack.yml
@@ -27,6 +27,14 @@ Parameters:
     Type: String
     Description: The name of the signing project
     Default: artifact-sign
+  SigningCodeBuildProjectCustomImageUri:
+    Type: String
+    Description: A custom ECR image to use with the signing project, can be left blank to use the default Codebuild image
+    Default: ''
+  SigningCodeBuildProjectCustomImageRepositoryArn:
+    Type: String
+    Description: The ARN of the ECR repository where the custom image is stored, ignored if SigningCodeBuildProjectCustomImageUri is blank
+    Default: ''
   CopyCodeBuildProjectName:
     Type: String
     Description: The name of the copy project
@@ -85,6 +93,10 @@ Parameters:
   PassphraseArn:
     Type: String
     Description: The ARN of the passphrase
+
+Conditions:
+  UseCustomSigningImage:
+    !Not [!Equals [!Ref 'SigningCodeBuildProjectCustomImageUri', '']]
 
 Resources:
   CodeBuildLogGroup:
@@ -471,6 +483,30 @@ Resources:
                 Resource:
                   - !Ref SecretKeyArn
                   - !Ref PassphraseArn
+        - !If
+          - UseCustomSigningImage
+          - PolicyName: codebuild-custom-ecr-image-policy
+            PolicyDocument:
+              Version: 2012-10-17
+              Statement:
+                - Sid: EcrGetAuthTokenAccess
+                  Effect: Allow
+                  Action:
+                    - ecr:GetAuthorizationToken
+                  Resource: '*'
+                - Sid: EcrImageAccess
+                  Effect: Allow
+                  Action:
+                    - ecr:BatchCheckLayerAvailability
+                    - ecr:GetDownloadUrlForLayer
+                    - ecr:BatchGetImage
+                    - ecr:PutImage
+                    - ecr:InitiateLayerUpload
+                    - ecr:UploadLayerPart
+                    - ecr:CompleteLayerUpload
+                  Resource:
+                    - !Ref SigningCodeBuildProjectCustomImageRepositoryArn
+          - !Ref AWS::NoValue
 
   SigningCodeBuildProject:
     Type: AWS::CodeBuild::Project
@@ -484,8 +520,14 @@ Resources:
       Environment:
         Type: LINUX_CONTAINER
         ComputeType: BUILD_GENERAL1_SMALL
-        ImagePullCredentialsType: CODEBUILD
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+        ImagePullCredentialsType: !If
+          - UseCustomSigningImage
+          - SERVICE_ROLE
+          - CODEBUILD
+        Image: !If
+          - UseCustomSigningImage
+          - !Ref SigningCodeBuildProjectCustomImageUri
+          - aws/codebuild/amazonlinux2-x86_64-standard:3.0
         EnvironmentVariables:
           - Name: PASSPHRASE
             Type: SECRETS_MANAGER

--- a/buildspecs/signing-image-build.yml
+++ b/buildspecs/signing-image-build.yml
@@ -1,0 +1,21 @@
+version: 0.2
+
+phases:
+  pre_build:
+    commands:
+      - BUILD_DATE=$(date +%Y%m%d)
+      - $(aws --region $AWS_REGION ecr get-login --no-include-email)
+  build:
+    commands:
+      # Go into the right folder
+      - cd build-infrastructure
+      - echo "Building ecs-agent-signer version $BUILD_DATE"
+      # build the image dictated by the Dockerfile.signer file
+      - docker build -f Dockerfile.signer -t ecs-agent-signer:latest --build-arg builddate=$BUILD_DATE .
+      # Tag the built image with latest as well as the build date
+      - echo "Tagging and pushing Docker image to ECR"
+      - docker tag ecs-agent-signer:latest $SIGNER_ECR_REPO:latest
+      - docker tag ecs-agent-signer:latest $SIGNER_ECR_REPO:build-$BUILD_DATE
+      # push the image to ECR
+      - docker push $SIGNER_ECR_REPO:latest
+      - docker push $SIGNER_ECR_REPO:build-$BUILD_DATE


### PR DESCRIPTION
### Summary
Infrastructure and dockerfile for a minimal signing build environment

### Implementation details
- a new stack that uses CodeBuild to build an image that we can use as the signing build environment
- a dockerfile that specifies only the tooling we need rather than the general purpose build environment that CodeBuild offers by default
- option to use a periodic trigger to build the signing build environment image using EventBridge
- a lifecycle policy to keep ECR images around long enough for us to have a reference to be able to debug but not long enough that they sit around increasing cost
- an option to specify a custom docker image as the signing build environment in `release-pipeline-stack.yml`


### Testing

- built the stack 3 ways
  - stack with all the defaults - no custom image and no periodic trigger
  - stack with custom image and no periodic trigger
  - stack with custom image and periodic trigger

New tests cover the changes: N/A

### Description for the changelog
Feature - custom minimal image for the signer stage in pipeline

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
