### PR TITLE
Add Release Config JSON CodeBuild and handle ECS-Anywhere installation script in CodePipeline

### DIFF
--- a/build-infrastructure/release-pipeline-stack.yml
+++ b/build-infrastructure/release-pipeline-stack.yml
@@ -47,6 +47,10 @@ Parameters:
     Type: String
     Description: The name of the copy project
     Default: log-puller
+  MakeJSONCodeBuildProjectName:
+    Type: String
+    Description: The name of the release config builder project
+    Default: make-json
   CodeBuildLogGroupName:
     Type: String
     Description: The name of the log group to push build logs to
@@ -628,6 +632,77 @@ Resources:
           Status: ENABLED
           StreamName: !Ref SigningCodeBuildProjectName
 
+  MakeJSONCodeBuildProjectServiceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub 'make-json-codebuild-project-service-role-${AWS::Region}'
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          Effect: Allow
+          Principal:
+            Service: codebuild.amazonaws.com
+          Action: sts:AssumeRole
+      Policies:
+        - PolicyName: codebuild-copy-base-policy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Sid: CloudWatchLogsAccess
+                Effect: Allow
+                Resource:
+                  - !GetAtt CodeBuildLogGroup.Arn
+                  - !Sub '${CodeBuildLogGroup.Arn}:*'
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+              - Sid: ArtifactBucketAccess
+                Effect: Allow
+                Resource:
+                  - !Sub 'arn:aws:s3:::codepipeline-${AWS::Region}-*'
+                Action:
+                  - s3:PutObject
+                  - s3:GetObject
+                  - s3:GetObjectVersion
+                  - s3:GetBucketAcl
+                  - s3:GetBucketLocation
+              - Sid: CodeBuildCreateReportAccess
+                Effect: Allow
+                Resource:
+                  - !Sub 'arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:report-group/${MakeJSONCodeBuildProjectName}-*'
+                Action:
+                  - codebuild:CreateReportGroup
+                  - codebuild:CreateReport
+                  - codebuild:UpdateReport
+                  - codebuild:BatchPutTestCases
+                  - codebuild:BatchPutCodeCoverages
+
+  MakeJSONCodeBuildProject:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Name: !Ref MakeJSONCodeBuildProjectName
+      Description: A CodeBuild project that prepares a release config JSON file
+      ConcurrentBuildLimit: 10
+      ServiceRole: !GetAtt MakeJSONCodeBuildProjectServiceRole.Arn
+      Artifacts:
+        Type: CODEPIPELINE
+      Environment:
+        Type: LINUX_CONTAINER
+        ComputeType: BUILD_GENERAL1_SMALL
+        ImagePullCredentialsType: CODEBUILD
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+      Source:
+        BuildSpec: buildspecs/release-config.yml
+        Type: CODEPIPELINE
+      TimeoutInMinutes: 60
+      QueuedTimeoutInMinutes: 480
+      LogsConfig:
+        CloudWatchLogs:
+          GroupName: !Ref CodeBuildLogGroupName
+          Status: ENABLED
+          StreamName: !Ref MakeJSONCodeBuildProjectName
+
   CopyCodeBuildProjectServiceRole:
     Type: AWS::IAM::Role
     Properties:
@@ -972,6 +1047,7 @@ Resources:
                 # - Commit sha
                 # - AMD tar
                 # - AMD rpm
+                # - ECS Anywhere install script (From AMD Project)
                 # - Ubuntu AMD deb
                 # - Ubuntu ARM deb
                 # - ARM tar
@@ -981,12 +1057,32 @@ Resources:
                 - Name: SignedArtifact
               RunOrder: 1
               Namespace: SigningVariables
+        - Name: ReleaseConfig
+          Actions:
+            - Name: MakeJSON
+              InputArtifacts:
+                - Name: Buildspecs
+                - Name: SignedArtifact
+              ActionTypeId:
+                Category: Build
+                Owner: AWS
+                Version: '1'
+                Provider: CodeBuild
+              Configuration:
+                ProjectName: !Ref MakeJSONCodeBuildProject
+                PrimarySource: Buildspecs
+                EnvironmentVariables: '[{"name":"GIT_COMMIT_SHA","value":"#{SourceVariables.CommitId}","type":"PLAINTEXT"},{"name":"AGENT_VERSION","value":"#{AmdBuildVariables.AGENT_VERSION}","type":"PLAINTEXT"}]'
+              OutputArtifacts:
+                - Name: JSONArtifact
+              RunOrder: 1
+              Namespace: JSONVariables
         - Name: Copy
           Actions:
             - Name: ToS3
               InputArtifacts:
                 - Name: Buildspecs
                 - Name: SignedArtifact
+                - Name: JSONArtifact
               ActionTypeId:
                 Category: Build
                 Owner: AWS

--- a/buildspecs/copy.yml
+++ b/buildspecs/copy.yml
@@ -7,6 +7,9 @@ env:
 phases:
   build:
     commands:
+      # Copy release config
+      - aws s3 cp $CODEBUILD_SRC_DIR_JSONArtifact/agent.json "$RESULTS_BUCKET_URI/$GIT_COMMIT_SHA/agent.json"
+      
       # since the buildspecs are the primary artifacts, we need to change directory
       - cd $CODEBUILD_SRC_DIR_SignedArtifact
       # list the artifacts that are ready to upload

--- a/buildspecs/merge-build.yml
+++ b/buildspecs/merge-build.yml
@@ -6,6 +6,7 @@ env:
     - CODEBUILD_BUILD_ID
     - ECS_AGENT_TAR
     - ECS_AGENT_RPM
+    - AGENT_VERSION
 
 phases:
   install:
@@ -44,9 +45,14 @@ phases:
     commands:
       - echo "Building agent image"
       - AGENT_VERSION=$(cat VERSION)
+      # Read init version from changelog, using this as the source because of possible scenario of '-2', '-3'.. init suffix releases
+      - INIT_VERSION=$(head -n 1 scripts/changelog/CHANGELOG_MASTER)
+      - INIT_VERSION=$(echo $INIT_VERSION | tr -d '[:space:]')
       - ECS_AGENT_TAR="ecs-agent-v${AGENT_VERSION}.tar"
-      - ECS_AGENT_RPM="amazon-ecs-init-${AGENT_VERSION}-1.x86_64.rpm"
+      - ECS_AGENT_RPM="amazon-ecs-init-${INIT_VERSION}.x86_64.rpm"
       - echo $(pwd)
+      - RELEASE_DATE=$(git show -s --format=%cd --date=format:'%Y%m%d')
+      - echo $RELEASE_DATE
 
       # Directory/GOPATH restructuring needed for CodePipeline
       - cd ../..
@@ -56,7 +62,7 @@ phases:
       - export GOPATH=$GOPATH:$(pwd)
       - cd src/github.com/aws/amazon-ecs-agent
 
-      # Build agent tars
+      # Build agent tar and rpm
       - GO111MODULE=auto
       - make dockerfree-agent-image
       - make generic-rpm-integrated
@@ -66,7 +72,7 @@ phases:
       - |
         if [[ $architecture == "arm64" ]] ; then
           mv $ECS_AGENT_TAR "ecs-agent-arm64-v${AGENT_VERSION}.tar"
-          ECS_AGENT_RPM="amazon-ecs-init-${AGENT_VERSION}-1.aarch64.rpm"
+          ECS_AGENT_RPM="amazon-ecs-init-${INIT_VERSION}.aarch64.rpm"
           ECS_AGENT_TAR="ecs-agent-arm64-v${AGENT_VERSION}.tar"
         fi
 
@@ -74,3 +80,4 @@ artifacts:
   files:
     - $ECS_AGENT_TAR
     - $ECS_AGENT_RPM
+    - 'scripts/ecs-anywhere-install.sh'

--- a/buildspecs/pr-build-ubuntu.yml
+++ b/buildspecs/pr-build-ubuntu.yml
@@ -32,7 +32,10 @@ phases:
       - cd ../../../..
       - export GOPATH=$GOPATH:$(pwd)
       - cd src/github.com
-      - mv $GITHUBUSERNAME aws
+      - |
+        if [[ $GITHUBUSERNAME != "aws" ]] ; then
+          mv $GITHUBUSERNAME aws
+        fi
       - cd aws/amazon-ecs-agent
 
       # Building agent deb

--- a/buildspecs/pr-build.yml
+++ b/buildspecs/pr-build.yml
@@ -52,7 +52,10 @@ phases:
       - cd ../../../..
       - export GOPATH=$GOPATH:$(pwd)
       - cd src/github.com
-      - mv $GITHUBUSERNAME aws
+      - |
+        if [[ $GITHUBUSERNAME != "aws" ]] ; then
+          mv $GITHUBUSERNAME aws
+        fi
       - cd aws/amazon-ecs-agent
 
       # Building agent tars

--- a/buildspecs/release-config.yml
+++ b/buildspecs/release-config.yml
@@ -1,0 +1,57 @@
+version: 0.2
+
+env:
+  exported-variables:
+    - CODEBUILD_BUILD_ID
+
+phases:
+  build:
+    commands:
+      - AMD_TAR_FILE_PATH="${CODEBUILD_SRC_DIR_SignedArtifact}/ecs-agent-v${AGENT_VERSION}.tar"
+      - ARM_TAR_FILE_PATH="${CODEBUILD_SRC_DIR_SignedArtifact}/ecs-agent-arm64-v${AGENT_VERSION}.tar"
+      - AMD_TAR_FILE="ecs-agent-v${AGENT_VERSION}.tar"
+      - ARM_TAR_FILE="ecs-agent-arm64-v${AGENT_VERSION}.tar"
+      
+      # Checksum commands output checksum followed by filename
+      # Taking the checksum out explicitly using string length
+      - AMD_MD5_CMD=$(md5sum $AMD_TAR_FILE_PATH)
+      - AMD_MD5_CHECKSUM=${AMD_MD5_CMD::32}
+      - AMD_SHA256_CMD=$(sha256sum $AMD_TAR_FILE_PATH)
+      - AMD_SHA256_CHECKSUM=${AMD_SHA256_CMD::64}
+
+      - ARM_MD5_CMD=$(md5sum $ARM_TAR_FILE_PATH)
+      - ARM_MD5_CHECKSUM=${ARM_MD5_CMD::32}
+      - ARM_SHA256_CMD=$(sha256sum $ARM_TAR_FILE_PATH)
+      - ARM_SHA256_CHECKSUM=${ARM_SHA256_CMD::64}
+
+      - RELEASE_DATE=$(date +'%Y%m%d')
+
+      # Prepare agent.json config file
+      - |
+        cat << EOF > agent.json
+        {
+          "agentReleaseVersion" : "$AGENT_VERSION",
+          "releaseDate" : "$RELEASE_DATE",
+          "agentStagingConfig": {
+            "releaseGitSha": "$GIT_COMMIT_SHA",
+            "gitFarmRepoName": "MadisonContainerAgentExternal",
+            "gitHubRepoName": "aws/amazon-ecs-agent",
+            "gitFarmStageBranch": "v${AGENT_VERSION}-stage",
+            "githubReleaseUrl": ""
+          },
+          "amazonLinux": {
+            "artifactFilename": "${AMD_TAR_FILE}",
+            "md5": "${AMD_MD5_CHECKSUM}",
+            "signature": "${AMD_SHA256_CHECKSUM}"
+          },
+          "amazonLinux2Arm": {
+            "artifactFilename": "${ARM_TAR_FILE}",
+            "md5": "${ARM_MD5_CHECKSUM}",
+            "signature": "${ARM_SHA256_CHECKSUM}"
+          }
+        }
+        EOF
+
+artifacts:
+  files:
+    - agent.json

--- a/buildspecs/signing.yml
+++ b/buildspecs/signing.yml
@@ -52,6 +52,9 @@ phases:
       - source /tmp/functions.sh && sign_file $ECS_AGENT_AMD_TAR
       - cp "$CODEBUILD_SRC_DIR_AmdBuildArtifact/$ECS_AGENT_AMD_RPM" $ECS_AGENT_AMD_RPM
       - source /tmp/functions.sh && sign_file $ECS_AGENT_AMD_RPM
+      # Sign ECS Anywhere Script
+      - cp "$CODEBUILD_SRC_DIR_AmdBuildArtifact/scripts/ecs-anywhere-install.sh" ecs-anywhere-install.sh
+      - source /tmp/functions.sh && sign_file ecs-anywhere-install.sh
       # Sign the arm tar and rpm (this is a secondary source so we have to do some copying)
       - cp "$CODEBUILD_SRC_DIR_ArmBuildArtifact/$ECS_AGENT_ARM_TAR" $ECS_AGENT_ARM_TAR
       - source /tmp/functions.sh && sign_file $ECS_AGENT_ARM_TAR
@@ -82,3 +85,5 @@ artifacts:
     - '$ECS_AGENT_UBUNTU_AMD_DEB.asc'
     - $ECS_AGENT_UBUNTU_ARM_DEB
     - '$ECS_AGENT_UBUNTU_ARM_DEB.asc'
+    - 'ecs-anywhere-install.sh'
+    - 'ecs-anywhere-install.sh.asc'


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
* We build a release config file (agent.json) with every release containing config about ```tar``` files such as agent version and checksums. This PR adds a CodeBuild project and service role to do that. Sample ```agent.json```

```
{
  "agentReleaseVersion" : "1.61.2",
  "releaseDate" : "20220609",
  "agentStagingConfig": {
    "releaseGitSha": "fd2c7b01b4ca538fa8ce3dcaaca18261566698a2",
    "gitFarmRepoName": "MadisonContainerAgentExternal",
    "gitHubRepoName": "aws/amazon-ecs-agent",
    "gitFarmStageBranch": "v1.61.2-stage",
    "githubReleaseUrl": ""
  },
  "amazonLinux": {
    "artifactFilename": "ecs-agent-v1.61.2.tar",
    "md5": "5da11e8f027ea6d14d9deeaa919dae8c",
    "signature": "2be495bda59dc38a95edc4963bed0b8abed2b0d2ce4843c4763e35164c686c5e"
  },
  "amazonLinux2Arm": {
    "artifactFilename": "ecs-agent-arm64-v1.61.2.tar",
    "md5": "54a7d293f3e0d064abaa4fb48ff8eda3",
    "signature": "87074b28d7d39fcbe6e0c045781e47f34af9b9e7aed171c3771bb69fc700474c"
  }
}

```
* We release an ECS-Anywhere installation script with every agent release. Buildspec and CodePipeline CloudFormation for it has been added
* Bug fix: PR creations would not trigger artifacts build when deploying ```codebuild-devbuild-stack.yml```with ```aws``` account because ```mv aws aws``` would fail. This is handled in ```pr-build*``` buildspec files


### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> No new tests added, agent-dev-amd/arm tests in this PR are green, ubuntu builds should be green once ecs-init directory and version is in sync with amazon-ecs-init

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
