### PR TITLE
Add direction to determine MetricType and delete bind mount as part o…

### DIFF
--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -709,12 +709,22 @@ func (engine *DockerTaskEngine) deleteTask(task *apitask.Task) {
 		}
 	}
 
+	tID := task.GetID()
 	if execcmd.IsExecEnabledTask(task) {
 		// cleanup host exec agent log dirs
-		tID := task.GetID()
 		if err := removeAll(filepath.Join(execcmd.ECSAgentExecLogDir, tID)); err != nil {
 			logger.Warn("Unable to remove ExecAgent host logs for task", logger.Fields{
-				field.TaskID: task.GetID(),
+				field.TaskID: tID,
+				field.Error:  err,
+			})
+		}
+	}
+
+	if task.IsServiceConnectEnabled() {
+		serviceconnectConfig := task.GetServiceConnectRuntimeConfig()
+		if err := removeAll(filepath.Dir(serviceconnectConfig.AdminSocketPath)); err != nil {
+			logger.Warn("Unable to remove service-connect UDS bind mount path for task", logger.Fields{
+				field.TaskID: tID,
 				field.Error:  err,
 			})
 		}

--- a/agent/stats/service_connect_linux_test.go
+++ b/agent/stats/service_connect_linux_test.go
@@ -56,18 +56,19 @@ func TestRetrieveServiceConnectMetrics(t *testing.T) {
 	}{
 		{
 			stats: `# TYPE MetricFamily1 counter
-				MetricFamily1{dimensionA="value1", dimensionB="value2"} 1
+				MetricFamily1{DimensionA="value1", DimensionB="value2", Direction="ingress"} 1
 				# TYPE MetricFamily2 counter
-				MetricFamily2{dimensionB="value2", dimensionA="value1"} 1
+				MetricFamily2{DimensionB="value2", DimensionA="value1", Direction="ingress"} 1
 				`,
 			expectedStats: []*ecstcs.GeneralMetricsWrapper{
 				{
+					MetricType: aws.String("1"),
 					Dimensions: []*ecstcs.Dimension{
 						{
-							Key:   aws.String("dimensionA"),
+							Key:   aws.String("DimensionA"),
 							Value: aws.String("value1"),
 						}, {
-							Key:   aws.String("dimensionB"),
+							Key:   aws.String("DimensionB"),
 							Value: aws.String("value2"),
 						}},
 					GeneralMetrics: []*ecstcs.GeneralMetric{
@@ -87,18 +88,19 @@ func TestRetrieveServiceConnectMetrics(t *testing.T) {
 		},
 		{
 			stats: `# TYPE MetricFamily3 histogram
-				MetricFamily3{dimensionX="value1", dimensionY="value2", le="0.5"} 1
-				MetricFamily3{dimensionX="value1", dimensionY="value2", le="1"} 2
-				MetricFamily3{dimensionX="value1", dimensionY="value2", le="5"} 3
+				MetricFamily3{DimensionX="value1", DimensionY="value2", Direction="egress", le="0.5"} 1
+				MetricFamily3{DimensionX="value1", DimensionY="value2", Direction="egress", le="1"} 2
+				MetricFamily3{DimensionX="value1", DimensionY="value2", Direction="egress", le="5"} 3
 				`,
 			expectedStats: []*ecstcs.GeneralMetricsWrapper{
 				{
+					MetricType: aws.String("2"),
 					Dimensions: []*ecstcs.Dimension{
 						{
-							Key:   aws.String("dimensionX"),
+							Key:   aws.String("DimensionX"),
 							Value: aws.String("value1"),
 						}, {
-							Key:   aws.String("dimensionY"),
+							Key:   aws.String("DimensionY"),
 							Value: aws.String("value2"),
 						}},
 					GeneralMetrics: []*ecstcs.GeneralMetric{


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
* Change 1
Appnet Agent stats endpoint will expose a dimension called Direction which will indicate if a metric is ingress or egress.
We set the value of Direction as Metric Type while sending to TACS

* Change 2
Delete the bind mount path of the service-connect enabled task during task cleanup.


### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes
 
Unit tests cover the change

Ran an appmesh task and checked Metric Type is correctly getting set while forming PublishMetricRequest
Also, checked that after task stopped, during task cleanup, bind mount got deleted



### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
