### PR TITLE
Consistently use a subdirectory for managed agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ ecs-agent-*.tar
 /ecs.service
 *.log
 *.DS_Store
+misc/exec-command-agent-test/managed-agents
+.run

--- a/agent/engine/engine_sudo_linux_integ_test.go
+++ b/agent/engine/engine_sudo_linux_integ_test.go
@@ -415,7 +415,7 @@ func TestExecCommandAgent(t *testing.T) {
 	client, err := sdkClient.NewClientWithOpts(sdkClient.WithHost(endpoint), sdkClient.WithVersion(sdkclientfactory.GetDefaultVersion().String()))
 	require.NoError(t, err, "Creating go docker client failed")
 
-	testExecCmdHostBinDir := "/managed-agents/execute-command/bin"
+	testExecCmdHostBinDir := "misc/exec-command-agent-test/managed-agents/execute-command/bin"
 
 	taskEngine, done, _ := setupEngineForExecCommandAgent(t, testExecCmdHostBinDir)
 	stateChangeEvents := taskEngine.StateChangeEvents()

--- a/misc/exec-command-agent-test/build-mock-ssm-agent
+++ b/misc/exec-command-agent-test/build-mock-ssm-agent
@@ -14,12 +14,12 @@
 
 SIMULATED_ECS_AGENT_DEPS_BIN_DIR="/managed-agents/execute-command/bin/1.0.0.0"
 rm -rf ./$SIMULATED_ECS_AGENT_DEPS_BIN_DIR
-mkdir -p $SIMULATED_ECS_AGENT_DEPS_BIN_DIR # mock version folder for our mock ssm agent binaries
-CGO_ENABLED=0 go build -tags integration -installsuffix cgo -a -o $SIMULATED_ECS_AGENT_DEPS_BIN_DIR/amazon-ssm-agent ./sleep/
-touch $SIMULATED_ECS_AGENT_DEPS_BIN_DIR/ssm-agent-worker
-touch $SIMULATED_ECS_AGENT_DEPS_BIN_DIR/ssm-session-worker
+mkdir -p ./$SIMULATED_ECS_AGENT_DEPS_BIN_DIR # mock version folder for our mock ssm agent binaries
+CGO_ENABLED=0 go build -tags integration -installsuffix cgo -a -o ./$SIMULATED_ECS_AGENT_DEPS_BIN_DIR/amazon-ssm-agent ./sleep/
+touch ./$SIMULATED_ECS_AGENT_DEPS_BIN_DIR/ssm-agent-worker
+touch ./$SIMULATED_ECS_AGENT_DEPS_BIN_DIR/ssm-session-worker
 SIMULATED_ECS_AGENT_DEPS_CERTS_DIR="/managed-agents/execute-command/certs"
 rm -rf ./$SIMULATED_ECS_AGENT_DEPS_CERTS_DIR
-mkdir -p $SIMULATED_ECS_AGENT_DEPS_CERTS_DIR # mock certs folder for our mock ssm agent
-touch $SIMULATED_ECS_AGENT_DEPS_CERTS_DIR/tls-ca-bundle.pem
+mkdir -p ./$SIMULATED_ECS_AGENT_DEPS_CERTS_DIR # mock certs folder for our mock ssm agent
+touch ./$SIMULATED_ECS_AGENT_DEPS_CERTS_DIR/tls-ca-bundle.pem
 


### PR DESCRIPTION
In the test cases for Exec it inconsistently uses relative and absolute
paths. Consolidate on relative to allow desktop runs


### Summary
Change where local resources are placed to allow for desktop integ test running.

### Testing
`make run-integ-tests`

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
