### PR TITLE
Integrates with Service Connect CNI plugin

### DIFF
--- a/agent/api/appnet/client_linux.go
+++ b/agent/api/appnet/client_linux.go
@@ -23,7 +23,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/aws/amazon-ecs-agent/agent/api/task"
+	"github.com/aws/amazon-ecs-agent/agent/api/serviceconnect"
+
 	"github.com/aws/amazon-ecs-agent/agent/logger"
 	"github.com/aws/amazon-ecs-agent/agent/logger/field"
 	"github.com/aws/amazon-ecs-agent/agent/utils/retry"
@@ -65,7 +66,7 @@ var udsHttpClient = http.Client{
 
 // GetStats invokes Appnet Agent's stats API to retrieve ServiceConnect stats in prometheus format. This function expects
 // an Appnet-Agent-hosted HTTP server listening on the UDS path passed in config.
-func (cl *client) GetStats(config task.RuntimeConfig) (map[string]*prometheus.MetricFamily, error) {
+func (cl *client) GetStats(config serviceconnect.RuntimeConfig) (map[string]*prometheus.MetricFamily, error) {
 	resp, err := performAppnetRequest(http.MethodGet, config.AdminSocketPath, config.StatsRequest)
 	if err != nil {
 		return nil, err
@@ -76,7 +77,7 @@ func (cl *client) GetStats(config task.RuntimeConfig) (map[string]*prometheus.Me
 
 // DrainInboundConnections invokes Appnet Agent's drain_listeners API which starts draining ServiceConnect inbound connections.
 // This function expects an Appnet-agent-hosted HTTP server listening on the UDS path passed in config.
-func (cl *client) DrainInboundConnections(config task.RuntimeConfig) error {
+func (cl *client) DrainInboundConnections(config serviceconnect.RuntimeConfig) error {
 	return retry.RetryNWithBackoff(oneSecondBackoffNoJitter, 3, func() error {
 		resp, err := performAppnetRequest(http.MethodGet, config.AdminSocketPath, config.DrainRequest)
 		if err != nil {

--- a/agent/api/appnet/client_linux_test.go
+++ b/agent/api/appnet/client_linux_test.go
@@ -23,7 +23,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/aws/amazon-ecs-agent/agent/api/task"
+	"github.com/aws/amazon-ecs-agent/agent/api/serviceconnect"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/gorilla/mux"
 	prometheus "github.com/prometheus/client_model/go"
@@ -178,7 +179,7 @@ func TestGetStats(t *testing.T) {
 			t.Cleanup(func() {
 				ts.Close()
 			})
-			stats, err := Client().GetStats(task.RuntimeConfig{AdminSocketPath: tc.udsPath, StatsRequest: testStatsUrl, DrainRequest: testDrainUrl})
+			stats, err := Client().GetStats(serviceconnect.RuntimeConfig{AdminSocketPath: tc.udsPath, StatsRequest: testStatsUrl, DrainRequest: testDrainUrl})
 			assert.Equal(t, tc.expectedResult, stats)
 			if tc.isErrorExpected {
 				assert.Error(t, err)
@@ -221,7 +222,7 @@ func TestDrainInboundConnections(t *testing.T) {
 			t.Cleanup(func() {
 				ts.Close()
 			})
-			err := Client().DrainInboundConnections(task.RuntimeConfig{AdminSocketPath: tc.udsPath, StatsRequest: testStatsUrl, DrainRequest: testDrainUrl})
+			err := Client().DrainInboundConnections(serviceconnect.RuntimeConfig{AdminSocketPath: tc.udsPath, StatsRequest: testStatsUrl, DrainRequest: testDrainUrl})
 			if tc.isErrorExpected {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), tc.expectedErrorContains)

--- a/agent/api/appnet/client_other.go
+++ b/agent/api/appnet/client_other.go
@@ -18,14 +18,15 @@ package appnet
 import (
 	"fmt"
 
-	"github.com/aws/amazon-ecs-agent/agent/api/task"
+	"github.com/aws/amazon-ecs-agent/agent/api/serviceconnect"
+
 	prometheus "github.com/prometheus/client_model/go"
 )
 
-func (cl *client) GetStats(config task.RuntimeConfig) (map[string]*prometheus.MetricFamily, error) {
+func (cl *client) GetStats(config serviceconnect.RuntimeConfig) (map[string]*prometheus.MetricFamily, error) {
 	return nil, fmt.Errorf("appnet client: GetStats is not supported in this platform")
 }
 
-func (cl *client) DrainInboundConnections(config task.RuntimeConfig) error {
+func (cl *client) DrainInboundConnections(config serviceconnect.RuntimeConfig) error {
 	return fmt.Errorf("appnet client: DrainInboundConnections is not supported in this platform")
 }

--- a/agent/api/interface.go
+++ b/agent/api/interface.go
@@ -14,7 +14,7 @@
 package api
 
 import (
-	"github.com/aws/amazon-ecs-agent/agent/api/task"
+	"github.com/aws/amazon-ecs-agent/agent/api/serviceconnect"
 	"github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
 	prometheus "github.com/prometheus/client_model/go"
 )
@@ -77,6 +77,6 @@ type ECSSubmitStateSDK interface {
 // AppnetClient is an interface with customized Appnet client that
 // implements the GetStats and DrainInboundConnections
 type AppnetClient interface {
-	GetStats(config task.RuntimeConfig) (map[string]*prometheus.MetricFamily, error)
-	DrainInboundConnections(config task.RuntimeConfig) error
+	GetStats(config serviceconnect.RuntimeConfig) (map[string]*prometheus.MetricFamily, error)
+	DrainInboundConnections(config serviceconnect.RuntimeConfig) error
 }

--- a/agent/api/mocks/api_mocks.go
+++ b/agent/api/mocks/api_mocks.go
@@ -22,7 +22,7 @@ import (
 	reflect "reflect"
 
 	api "github.com/aws/amazon-ecs-agent/agent/api"
-	task "github.com/aws/amazon-ecs-agent/agent/api/task"
+	serviceconnect "github.com/aws/amazon-ecs-agent/agent/api/serviceconnect"
 	ecs "github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
 	gomock "github.com/golang/mock/gomock"
 	go0 "github.com/prometheus/client_model/go"
@@ -358,7 +358,7 @@ func (m *MockAppnetClient) EXPECT() *MockAppnetClientMockRecorder {
 }
 
 // DrainInboundConnections mocks base method
-func (m *MockAppnetClient) DrainInboundConnections(arg0 task.RuntimeConfig) error {
+func (m *MockAppnetClient) DrainInboundConnections(arg0 serviceconnect.RuntimeConfig) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DrainInboundConnections", arg0)
 	ret0, _ := ret[0].(error)
@@ -372,7 +372,7 @@ func (mr *MockAppnetClientMockRecorder) DrainInboundConnections(arg0 interface{}
 }
 
 // GetStats mocks base method
-func (m *MockAppnetClient) GetStats(arg0 task.RuntimeConfig) (map[string]*go0.MetricFamily, error) {
+func (m *MockAppnetClient) GetStats(arg0 serviceconnect.RuntimeConfig) (map[string]*go0.MetricFamily, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetStats", arg0)
 	ret0, _ := ret[0].(map[string]*go0.MetricFamily)

--- a/agent/api/serviceconnect/service_connect.go
+++ b/agent/api/serviceconnect/service_connect.go
@@ -11,10 +11,10 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package task
+package serviceconnect
 
-// ServiceConnectConfig represents the Service Connect configuration for a task.
-type ServiceConnectConfig struct {
+// Config represents the Service Connect configuration for a task.
+type Config struct {
 	ContainerName string               `json:"containerName"`
 	IngressConfig []IngressConfigEntry `json:"ingressConfig,omitempty"`
 	EgressConfig  *EgressConfig        `json:"egressConfig,omitempty"`

--- a/agent/api/serviceconnect/service_connect_attachment_parser.go
+++ b/agent/api/serviceconnect/service_connect_attachment_parser.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package task
+package serviceconnect
 
 import (
 	"encoding/json"
@@ -23,34 +23,34 @@ import (
 )
 
 const (
-	// serviceConnectAttachmentType specifies attachment type for service connect
-	serviceConnectAttachmentType = "ServiceConnect"
-	// serviceConnectConfigKey specifies the key maps to the service connect config in attachment properties
-	serviceConnectConfigKey = "ServiceConnectConfig"
-	// serviceConnectContainerNameKey specifies the key maps to the service connect container name in attachment properties
-	serviceConnectContainerNameKey = "ContainerName"
+	// ServiceConnectAttachmentType specifies attachment type for service connect
+	ServiceConnectAttachmentType = "ServiceConnect"
+	// ServiceConnectConfigKey specifies the key maps to the service connect config in attachment properties
+	ServiceConnectConfigKey = "Config"
+	// ServiceConnectContainerNameKey specifies the key maps to the service connect container name in attachment properties
+	ServiceConnectContainerNameKey = "ContainerName"
 	keyValidationMsgFormat         = `missing service connect config required key(s) in the attachment: found service connect config key: %t, found service connect container name key: %t`
 )
 
 // ParseServiceConnectAttachment parses the service connect container name and service connect config value
 // from the given attachment.
-func ParseServiceConnectAttachment(scAttachment *ecsacs.Attachment) (*ServiceConnectConfig, error) {
-	scConfigValue := &ServiceConnectConfig{}
+func ParseServiceConnectAttachment(scAttachment *ecsacs.Attachment) (*Config, error) {
+	scConfigValue := &Config{}
 	containerName := ""
 	foundSCConfigKey := false
 	foundSCContainerNameKey := false
 
 	for _, property := range scAttachment.AttachmentProperties {
 		switch aws.StringValue(property.Name) {
-		case serviceConnectConfigKey:
+		case ServiceConnectConfigKey:
 			foundSCConfigKey = true
 			// extract service connect config value from the attachment property,
-			// and translate the attachment property value to ServiceConnectConfig
+			// and translate the attachment property value to Config
 			data := aws.StringValue(property.Value)
 			if err := json.Unmarshal([]byte(data), scConfigValue); err != nil {
 				return nil, fmt.Errorf("failed to unmarshal service connect attachment property value: %w", err)
 			}
-		case serviceConnectContainerNameKey:
+		case ServiceConnectContainerNameKey:
 			foundSCContainerNameKey = true
 			// extract service connect container name from the attachment property
 			containerName = aws.StringValue(property.Value)

--- a/agent/api/serviceconnect/service_connect_attachment_parser_test.go
+++ b/agent/api/serviceconnect/service_connect_attachment_parser_test.go
@@ -13,7 +13,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package task
+package serviceconnect
 
 import (
 	"fmt"
@@ -72,6 +72,8 @@ func initServiceConnectConfValue() {
 	testBridgeDefaultEmptyIngressSCConfig = constructTestServiceConnectConfig(BridgeNetworkMode, false, true, false, false)
 	testBridgeDefaultEmptyEgressSCConfig = constructTestServiceConnectConfig(BridgeNetworkMode, false, false, true, false)
 }
+
+func strptr(s string) *string { return &s }
 
 // constructTestServiceConnectConfig returns service connect config value as string based on the passed values.
 func constructTestServiceConnectConfig(networkMode string, override, emptyIngress, emptyEgress, ipv6Enabled bool) string {
@@ -141,16 +143,16 @@ func getTestACSAttachments(attachmentProperties []*ecsacs.AttachmentProperty) *e
 	return &ecsacs.Attachment{
 		AttachmentArn:        strptr("attachmentArn"),
 		AttachmentProperties: attachmentProperties,
-		AttachmentType:       strptr(serviceConnectAttachmentType),
+		AttachmentType:       strptr(ServiceConnectAttachmentType),
 	}
 }
 
-// getExpectedTestServiceConnectConfig returns *ServiceConnectConfig based on given parameters.
+// getExpectedTestServiceConnectConfig returns *Config based on given parameters.
 func getExpectedTestServiceConnectConfig(scContainerName string,
 	scIngressConfig []IngressConfigEntry,
 	scEgressConfig *EgressConfig,
-	scDNSConfig []DNSConfigEntry) *ServiceConnectConfig {
-	return &ServiceConnectConfig{
+	scDNSConfig []DNSConfigEntry) *Config {
+	return &Config{
 		ContainerName: scContainerName,
 		IngressConfig: scIngressConfig,
 		EgressConfig:  scEgressConfig,
@@ -160,7 +162,7 @@ func getExpectedTestServiceConnectConfig(scContainerName string,
 
 func TestParseServiceConnectAttachment(t *testing.T) {
 	initServiceConnectConfValue()
-	testSCContainerNameAttachmentProperty := getTestACSAttachmentProperty(serviceConnectContainerNameKey, testServiceConnectContainerName)
+	testSCContainerNameAttachmentProperty := getTestACSAttachmentProperty(ServiceConnectContainerNameKey, testServiceConnectContainerName)
 	tt := []struct {
 		testName                 string
 		testSCAttachmentProperty *ecsacs.AttachmentProperty
@@ -170,7 +172,7 @@ func TestParseServiceConnectAttachment(t *testing.T) {
 	}{
 		{
 			testName:                 "AWSVPC default case",
-			testSCAttachmentProperty: getTestACSAttachmentProperty(serviceConnectConfigKey, testAwsVpcDefaultSCConfig),
+			testSCAttachmentProperty: getTestACSAttachmentProperty(ServiceConnectConfigKey, testAwsVpcDefaultSCConfig),
 			expectedIngressConfig: []IngressConfigEntry{
 				{
 					InterceptPort: testAwsVpcDefaultInterceptPort,
@@ -193,7 +195,7 @@ func TestParseServiceConnectAttachment(t *testing.T) {
 		},
 		{
 			testName:                 "AWSVPC default case with IPv6 enabled",
-			testSCAttachmentProperty: getTestACSAttachmentProperty(serviceConnectConfigKey, testAwsVpcDefaultIPv6EnabledSCConfig),
+			testSCAttachmentProperty: getTestACSAttachmentProperty(ServiceConnectConfigKey, testAwsVpcDefaultIPv6EnabledSCConfig),
 			expectedIngressConfig: []IngressConfigEntry{
 				{
 					InterceptPort: testAwsVpcDefaultInterceptPort,
@@ -216,7 +218,7 @@ func TestParseServiceConnectAttachment(t *testing.T) {
 		},
 		{
 			testName:                 "AWSVPC override case",
-			testSCAttachmentProperty: getTestACSAttachmentProperty(serviceConnectConfigKey, testAwsVpcOverrideSCConfig),
+			testSCAttachmentProperty: getTestACSAttachmentProperty(ServiceConnectConfigKey, testAwsVpcOverrideSCConfig),
 			expectedIngressConfig: []IngressConfigEntry{
 				{
 					ListenerPort: testListenerPort,
@@ -238,7 +240,7 @@ func TestParseServiceConnectAttachment(t *testing.T) {
 		},
 		{
 			testName:                 "AWSVPC override case with IPv6 enabled",
-			testSCAttachmentProperty: getTestACSAttachmentProperty(serviceConnectConfigKey, testAwsVpcOverrideIPv6EnabledSCConfig),
+			testSCAttachmentProperty: getTestACSAttachmentProperty(ServiceConnectConfigKey, testAwsVpcOverrideIPv6EnabledSCConfig),
 			expectedIngressConfig: []IngressConfigEntry{
 				{
 					ListenerPort: testListenerPort,
@@ -260,7 +262,7 @@ func TestParseServiceConnectAttachment(t *testing.T) {
 		},
 		{
 			testName:                 "Bridge default case",
-			testSCAttachmentProperty: getTestACSAttachmentProperty(serviceConnectConfigKey, testBridgeDefaultSCConfig),
+			testSCAttachmentProperty: getTestACSAttachmentProperty(ServiceConnectConfigKey, testBridgeDefaultSCConfig),
 			expectedIngressConfig: []IngressConfigEntry{
 				{
 					ListenerPort: testBridgeDefaultListenerPort,
@@ -282,7 +284,7 @@ func TestParseServiceConnectAttachment(t *testing.T) {
 		},
 		{
 			testName:                 "Bridge default case with no ingress config",
-			testSCAttachmentProperty: getTestACSAttachmentProperty(serviceConnectConfigKey, testBridgeDefaultEmptyIngressSCConfig),
+			testSCAttachmentProperty: getTestACSAttachmentProperty(ServiceConnectConfigKey, testBridgeDefaultEmptyIngressSCConfig),
 			expectedEgressConfig: &EgressConfig{
 				ListenerName: testOutboundListenerName,
 				VIP: VIP{
@@ -299,7 +301,7 @@ func TestParseServiceConnectAttachment(t *testing.T) {
 		},
 		{
 			testName:                 "Bridge default case with no egress config and dns config",
-			testSCAttachmentProperty: getTestACSAttachmentProperty(serviceConnectConfigKey, testBridgeDefaultEmptyEgressSCConfig),
+			testSCAttachmentProperty: getTestACSAttachmentProperty(ServiceConnectConfigKey, testBridgeDefaultEmptyEgressSCConfig),
 			expectedIngressConfig: []IngressConfigEntry{
 				{
 					ListenerPort: testBridgeDefaultListenerPort,
@@ -326,7 +328,7 @@ func TestParseServiceConnectAttachment(t *testing.T) {
 
 func TestParseServiceConnectAttachmentWithError(t *testing.T) {
 	initServiceConnectConfValue()
-	testSCAttachmentProperty := getTestACSAttachmentProperty(serviceConnectConfigKey, testAwsVpcDefaultSCConfig)
+	testSCAttachmentProperty := getTestACSAttachmentProperty(ServiceConnectConfigKey, testAwsVpcDefaultSCConfig)
 	tt := []struct {
 		testName                    string
 		testSCContainerName         string
@@ -341,8 +343,8 @@ func TestParseServiceConnectAttachmentWithError(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.testName, func(t *testing.T) {
-			testSCAttachmentProperty = getTestACSAttachmentProperty(serviceConnectConfigKey, tc.testAttachmentPropertyValue)
-			testSCContainerNameAttachmentProperty := getTestACSAttachmentProperty(serviceConnectContainerNameKey, tc.testSCContainerName)
+			testSCAttachmentProperty = getTestACSAttachmentProperty(ServiceConnectConfigKey, tc.testAttachmentPropertyValue)
+			testSCContainerNameAttachmentProperty := getTestACSAttachmentProperty(ServiceConnectContainerNameKey, tc.testSCContainerName)
 			testAttachmentProperties := []*ecsacs.AttachmentProperty{testSCAttachmentProperty}
 			testAttachmentProperties = append(testAttachmentProperties, testSCContainerNameAttachmentProperty)
 			testSCAttachment := getTestACSAttachments(testAttachmentProperties)

--- a/agent/api/serviceconnect/service_connect_validator.go
+++ b/agent/api/serviceconnect/service_connect_validator.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package task
+package serviceconnect
 
 import (
 	"fmt"
@@ -24,6 +24,8 @@ import (
 )
 
 const (
+	BridgeNetworkMode         = "bridge"
+	AWSVPCNetworkMode         = "awsvpc"
 	invalidEgressConfigFormat = `no service connect %s in the egress config. %s`
 	portCollisionFormat       = `%s port collision detected in the ingress config with the %s port=%d, and listener name=%s`
 	invalidIngressPortFormat  = `the %s port=%d in the ingress config is not valid: %w`
@@ -295,7 +297,7 @@ func validatePort(port uint16) error {
 }
 
 // ValidateSCConfig validates service connect container name, config, egress config, and ingress config.
-func ValidateServiceConnectConfig(scConfig *ServiceConnectConfig,
+func ValidateServiceConnectConfig(scConfig *Config,
 	taskContainers []*ecsacs.Container,
 	taskNetworkMode string,
 	ipv6Enabled bool) error {

--- a/agent/api/serviceconnect/service_connect_validator_test.go
+++ b/agent/api/serviceconnect/service_connect_validator_test.go
@@ -13,7 +13,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package task
+package serviceconnect
 
 import (
 	"testing"
@@ -37,13 +37,13 @@ var (
 	}
 )
 
-// getTestServiceConnectConfig returns *ServiceConnectConfig based on given parameters.
+// getTestServiceConnectConfig returns *Config based on given parameters.
 func getTestServiceConnectConfig(
 	scContainerName string,
 	scEgressConfig *EgressConfig,
 	scDnsConfig []DNSConfigEntry,
-	scIngressConfig []IngressConfigEntry) *ServiceConnectConfig {
-	return &ServiceConnectConfig{
+	scIngressConfig []IngressConfigEntry) *Config {
+	return &Config{
 		ContainerName: scContainerName,
 		IngressConfig: scIngressConfig,
 		EgressConfig:  scEgressConfig,

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -24,6 +24,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/aws/amazon-ecs-agent/agent/api/serviceconnect"
+
 	"github.com/aws/amazon-ecs-agent/agent/logger"
 	"github.com/aws/amazon-ecs-agent/agent/logger/field"
 	"github.com/aws/amazon-ecs-agent/agent/utils/ttime"
@@ -281,7 +283,7 @@ type Task struct {
 	// setIdOnce is used to set the value of this task's id only the first time GetID is invoked
 	setIdOnce sync.Once
 
-	ServiceConnectConfig *ServiceConnectConfig `json:"ServiceConnectConfig,omitempty"`
+	ServiceConnectConfig *serviceconnect.Config `json:"Config,omitempty"`
 
 	ServiceConnectConnectionDrainingUnsafe bool `json:"ServiceConnectConnectionDraining,omitempty"`
 
@@ -329,10 +331,10 @@ func TaskFromACS(acsTask *ecsacs.Task, envelope *ecsacs.PayloadMessage) (*Task, 
 }
 
 // getServiceConnectConfig returns service connect conifg from the service connect type attachment if it exists.
-func getServiceConnectConfig(acsTask *ecsacs.Task) (*ServiceConnectConfig, error) {
+func getServiceConnectConfig(acsTask *ecsacs.Task) (*serviceconnect.Config, error) {
 	var scAttachment *ecsacs.Attachment
 	for _, attachment := range acsTask.Attachments {
-		if aws.StringValue(attachment.AttachmentType) == serviceConnectAttachmentType {
+		if aws.StringValue(attachment.AttachmentType) == serviceconnect.ServiceConnectAttachmentType {
 			scAttachment = attachment
 			break
 		}
@@ -352,13 +354,13 @@ func getServiceConnectConfig(acsTask *ecsacs.Task) (*ServiceConnectConfig, error
 		}
 
 		// parse service connect from the attachment value
-		scConfig, err := ParseServiceConnectAttachment(scAttachment)
+		scConfig, err := serviceconnect.ParseServiceConnectAttachment(scAttachment)
 		if err != nil {
 			return nil, fmt.Errorf("error parsing service connect config value from the service connect attachment: %w", err)
 		}
 
 		// validate service connect config
-		if err := ValidateServiceConnectConfig(scConfig, acsTask.Containers, networkMode, ipv6Enabled); err != nil {
+		if err := serviceconnect.ValidateServiceConnectConfig(scConfig, acsTask.Containers, networkMode, ipv6Enabled); err != nil {
 			return nil, fmt.Errorf("service connect config validation failed: %w", err)
 		}
 
@@ -525,10 +527,10 @@ func (task *Task) initNetworkMode() {
 }
 
 func (task *Task) initServiceConnectResources() error {
-	// TODO [SC]: ServiceConnectConfig will come from ACS. Adding this here for dev/testing purposes only Remove when
+	// TODO [SC]: Config will come from ACS. Adding this here for dev/testing purposes only Remove when
 	// ACS model is integrated
 	if task.ServiceConnectConfig == nil {
-		task.ServiceConnectConfig = &ServiceConnectConfig{
+		task.ServiceConnectConfig = &serviceconnect.Config{
 			ContainerName: "service-connect",
 		}
 	}
@@ -2109,6 +2111,14 @@ func (task *Task) generateENIExtraHosts() []string {
 	return extraHosts
 }
 
+func (task *Task) shouldEnableIPv4() bool {
+	eni := task.GetPrimaryENI()
+	if eni == nil {
+		return false
+	}
+	return len(eni.GetIPV4Addresses()) > 0
+}
+
 func (task *Task) shouldEnableIPv6() bool {
 	eni := task.GetPrimaryENI()
 	if eni == nil {
@@ -3220,14 +3230,14 @@ func (task *Task) PopulateServiceConnectContainerMappingEnvVar() error {
 	return nil
 }
 
-func (task *Task) PopulateServiceConnectRuntimeConfig(serviceConnectConfig RuntimeConfig) {
+func (task *Task) PopulateServiceConnectRuntimeConfig(serviceConnectConfig serviceconnect.RuntimeConfig) {
 	task.lock.Lock()
 	defer task.lock.Unlock()
 
 	task.ServiceConnectConfig.RuntimeConfig = serviceConnectConfig
 }
 
-func (task *Task) GetServiceConnectRuntimeConfig() RuntimeConfig {
+func (task *Task) GetServiceConnectRuntimeConfig() serviceconnect.RuntimeConfig {
 	task.lock.RLock()
 	defer task.lock.RUnlock()
 

--- a/agent/api/task/task_linux.go
+++ b/agent/api/task/task_linux.go
@@ -339,6 +339,22 @@ func (task *Task) BuildCNIConfig(includeIPAMConfig bool, cniConfig *ecscni.Confi
 		})
 	}
 
+	// Build a CNI network configuration for ServiceConnect-enabled task in AWSVPC mode
+	if task.IsServiceConnectEnabled() {
+		ifName, netconf, err = ecscni.NewServiceConnectNetworkConfig(
+			task.ServiceConnectConfig,
+			task.shouldEnableIPv4(),
+			task.shouldEnableIPv6(),
+			cniConfig)
+		if err != nil {
+			return nil, err
+		}
+		cniConfig.NetworkConfigs = append(cniConfig.NetworkConfigs, &ecscni.NetworkConfig{
+			IfName:           ifName,
+			CNINetworkConfig: netconf,
+		})
+	}
+
 	cniConfig.ContainerNetNS = fmt.Sprintf(ecscni.NetnsFormat, cniConfig.ContainerPID)
 
 	return cniConfig, nil

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -26,6 +26,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/amazon-ecs-agent/agent/api/serviceconnect"
+
 	"github.com/docker/go-connections/nat"
 
 	"github.com/aws/amazon-ecs-agent/agent/acs/model/ecsacs"
@@ -62,7 +64,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const serviceConnectContainerTestName = "service-connect"
+const (
+	serviceConnectContainerTestName = "service-connect"
+	testHostName                    = "testHostName"
+	testOutboundListenerName        = "testOutboundListener"
+	testIPv4Address                 = "172.31.21.40"
+	testIPv6Address                 = "abcd:dcba:1234:4321::"
+	testIPv4Cidr                    = "127.255.0.0/16"
+	testIPv6Cidr                    = "2002::1234:abcd:ffff:c0a8:101/64"
+)
+
+var (
+	testListenerPort              = uint16(8080)
+	testBridgeDefaultListenerPort = uint16(15000)
+)
 
 func TestDockerConfigPortBinding(t *testing.T) {
 	testTask := &Task{
@@ -230,9 +245,9 @@ func getTestTaskServiceConnectBridgeMode() *Task {
 		},
 	}
 
-	testTask.ServiceConnectConfig = &ServiceConnectConfig{
+	testTask.ServiceConnectConfig = &serviceconnect.Config{
 		ContainerName: serviceConnectContainerTestName,
-		IngressConfig: []IngressConfigEntry{
+		IngressConfig: []serviceconnect.IngressConfigEntry{
 			{
 				ListenerName: "testListener1", // bridge mode default - ephemeral listener host port
 				ListenerPort: SCIngressListener1ContainerPort,
@@ -243,7 +258,7 @@ func getTestTaskServiceConnectBridgeMode() *Task {
 				HostPort:     &SCIngressListener2HostPort,
 			},
 		},
-		EgressConfig: &EgressConfig{
+		EgressConfig: &serviceconnect.EgressConfig{
 			ListenerName: "testEgressListener",
 			ListenerPort: SCEgressListenerContainerPort, // Presently this should always get ephemeral port
 		},
@@ -3690,13 +3705,13 @@ func TestGetServiceConnectContainer(t *testing.T) {
 		Name: serviceConnectContainerName,
 	}
 	tt := []struct {
-		scConfig *ServiceConnectConfig
+		scConfig *serviceconnect.Config
 	}{
 		{
 			scConfig: nil,
 		},
 		{
-			scConfig: &ServiceConnectConfig{
+			scConfig: &serviceconnect.Config{
 				ContainerName: serviceConnectContainerName,
 			},
 		},
@@ -3720,7 +3735,7 @@ func TestGetServiceConnectContainer(t *testing.T) {
 func TestIsServiceConnectEnabled(t *testing.T) {
 	const serviceConnectContainerName = "service-connect"
 	tt := []struct {
-		scConfig          *ServiceConnectConfig
+		scConfig          *serviceconnect.Config
 		scContainer       *apicontainer.Container
 		expectedSCEnabled bool
 	}{
@@ -3730,7 +3745,7 @@ func TestIsServiceConnectEnabled(t *testing.T) {
 			expectedSCEnabled: false,
 		},
 		{
-			scConfig: &ServiceConnectConfig{
+			scConfig: &serviceconnect.Config{
 				ContainerName: serviceConnectContainerName,
 			},
 			scContainer:       nil,
@@ -3744,7 +3759,7 @@ func TestIsServiceConnectEnabled(t *testing.T) {
 			expectedSCEnabled: false,
 		},
 		{
-			scConfig: &ServiceConnectConfig{
+			scConfig: &serviceconnect.Config{
 				ContainerName: serviceConnectContainerName,
 			},
 			scContainer: &apicontainer.Container{
@@ -3790,9 +3805,9 @@ func TestPostUnmarshalTaskWithServiceConnectAWSVPCMode(t *testing.T) {
 	}
 	seqNum := int64(42)
 	task, err := TaskFromACS(&taskFromACS, &ecsacs.PayloadMessage{SeqNum: &seqNum})
-	testSCConfig := ServiceConnectConfig{
+	testSCConfig := serviceconnect.Config{
 		ContainerName: serviceConnectContainerTestName,
-		IngressConfig: []IngressConfigEntry{
+		IngressConfig: []serviceconnect.IngressConfigEntry{
 			{
 				ListenerName: "testListener1",
 				ListenerPort: 0, // this one should get ephemeral port after PostUnmarshalTask
@@ -3806,7 +3821,7 @@ func TestPostUnmarshalTaskWithServiceConnectAWSVPCMode(t *testing.T) {
 				ListenerPort: 0, // this one should get ephemeral port after PostUnmarshalTask
 			},
 		},
-		EgressConfig: &EgressConfig{
+		EgressConfig: &serviceconnect.EgressConfig{
 			ListenerName: "testEgressListener",
 			ListenerPort: 0, // Presently this should always get ephemeral port
 		},
@@ -3860,9 +3875,9 @@ func TestPostUnmarshalTaskWithServiceConnectBridgeMode(t *testing.T) {
 	}
 	seqNum := int64(42)
 	task, err := TaskFromACS(&taskFromACS, &ecsacs.PayloadMessage{SeqNum: &seqNum})
-	testSCConfig := ServiceConnectConfig{
+	testSCConfig := serviceconnect.Config{
 		ContainerName: serviceConnectContainerTestName,
-		IngressConfig: []IngressConfigEntry{
+		IngressConfig: []serviceconnect.IngressConfigEntry{
 			{
 				ListenerName: "testListener1",
 				ListenerPort: listenerPort1,
@@ -3876,7 +3891,7 @@ func TestPostUnmarshalTaskWithServiceConnectBridgeMode(t *testing.T) {
 				ListenerPort: listenerPort3,
 			},
 		},
-		EgressConfig: &EgressConfig{
+		EgressConfig: &serviceconnect.EgressConfig{
 			ListenerName: "testEgressListener",
 			ListenerPort: 0, // Presently this should always get ephemeral port
 		},
@@ -3919,7 +3934,7 @@ func containerFromACS(name string, containerPort int64, hostPort int64, networkM
 	return container
 }
 
-func cloneSCConfig(scConfig ServiceConnectConfig) ServiceConnectConfig {
+func cloneSCConfig(scConfig serviceconnect.Config) serviceconnect.Config {
 	clone := scConfig
 	clone.IngressConfig = nil
 	for _, ic := range scConfig.IngressConfig {
@@ -3956,7 +3971,7 @@ func validateServiceConnectContainerOrder(t *testing.T, task *Task) {
 	}, scC.TransitionDependenciesMap[apicontainerstatus.ContainerStopped].ContainerDependencies[1])
 }
 
-func validateEphemeralPorts(t *testing.T, task *Task, originalSCConfig ServiceConnectConfig, utilizedPorts map[uint16]struct{}) {
+func validateEphemeralPorts(t *testing.T, task *Task, originalSCConfig serviceconnect.Config, utilizedPorts map[uint16]struct{}) {
 	for i, ic := range originalSCConfig.IngressConfig {
 		if ic.ListenerPort == 0 {
 			assignedPort := task.ServiceConnectConfig.IngressConfig[i].ListenerPort
@@ -4184,7 +4199,7 @@ func TestTaskServiceConnectAttachment(t *testing.T) {
 		testElasticNetworkInterface *ecsacs.ElasticNetworkInterface
 		testNetworkMode             string
 		testSCConfigValue           string
-		testExpectedSCConfig        *ServiceConnectConfig
+		testExpectedSCConfig        *serviceconnect.Config
 	}{
 		{
 			testName: "Bridge default case",
@@ -4198,21 +4213,21 @@ func TestTaskServiceConnectAttachment(t *testing.T) {
 			},
 			testNetworkMode:   BridgeNetworkMode,
 			testSCConfigValue: "{\"egressConfig\":{\"listenerName\":\"testOutboundListener\",\"vip\":{\"ipv4Cidr\":\"127.255.0.0/16\",\"ipv6Cidr\":\"\"}},\"dnsConfig\":[{\"hostname\":\"testHostName\",\"address\":\"172.31.21.40\"}],\"ingressConfig\":[{\"listenerPort\":15000}]}",
-			testExpectedSCConfig: &ServiceConnectConfig{
+			testExpectedSCConfig: &serviceconnect.Config{
 				ContainerName: serviceConnectContainerTestName,
-				IngressConfig: []IngressConfigEntry{
+				IngressConfig: []serviceconnect.IngressConfigEntry{
 					{
 						ListenerPort: testBridgeDefaultListenerPort,
 					},
 				},
-				EgressConfig: &EgressConfig{
+				EgressConfig: &serviceconnect.EgressConfig{
 					ListenerName: testOutboundListenerName,
-					VIP: VIP{
+					VIP: serviceconnect.VIP{
 						IPV4CIDR: testIPv4Cidr,
 						IPV6CIDR: "",
 					},
 				},
-				DNSConfig: []DNSConfigEntry{
+				DNSConfig: []serviceconnect.DNSConfigEntry{
 					{
 						HostName: testHostName,
 						Address:  testIPv4Address,
@@ -4231,21 +4246,21 @@ func TestTaskServiceConnectAttachment(t *testing.T) {
 			},
 			testNetworkMode:   AWSVPCNetworkMode,
 			testSCConfigValue: "{\"egressConfig\":{\"listenerName\":\"testOutboundListener\",\"vip\":{\"ipv4Cidr\":\"127.255.0.0/16\",\"ipv6Cidr\":\"2002::1234:abcd:ffff:c0a8:101/64\"}},\"dnsConfig\":[{\"hostname\":\"testHostName\",\"address\":\"abcd:dcba:1234:4321::\"}],\"ingressConfig\":[{\"listenerPort\":8080}]}",
-			testExpectedSCConfig: &ServiceConnectConfig{
+			testExpectedSCConfig: &serviceconnect.Config{
 				ContainerName: serviceConnectContainerTestName,
-				IngressConfig: []IngressConfigEntry{
+				IngressConfig: []serviceconnect.IngressConfigEntry{
 					{
 						ListenerPort: testListenerPort,
 					},
 				},
-				EgressConfig: &EgressConfig{
+				EgressConfig: &serviceconnect.EgressConfig{
 					ListenerName: testOutboundListenerName,
-					VIP: VIP{
+					VIP: serviceconnect.VIP{
 						IPV4CIDR: testIPv4Cidr,
 						IPV6CIDR: testIPv6Cidr,
 					},
 				},
-				DNSConfig: []DNSConfigEntry{
+				DNSConfig: []serviceconnect.DNSConfigEntry{
 					{
 						HostName: testHostName,
 						Address:  testIPv6Address,
@@ -4272,15 +4287,15 @@ func TestTaskServiceConnectAttachment(t *testing.T) {
 						AttachmentArn: strptr("attachmentArn"),
 						AttachmentProperties: []*ecsacs.AttachmentProperty{
 							{
-								Name:  strptr(serviceConnectConfigKey),
+								Name:  strptr(serviceconnect.ServiceConnectConfigKey),
 								Value: strptr(tc.testSCConfigValue),
 							},
 							{
-								Name:  strptr(serviceConnectContainerNameKey),
+								Name:  strptr(serviceconnect.ServiceConnectContainerNameKey),
 								Value: strptr(serviceConnectContainerTestName),
 							},
 						},
-						AttachmentType: strptr(serviceConnectAttachmentType),
+						AttachmentType: strptr(serviceconnect.ServiceConnectAttachmentType),
 					},
 				},
 				NetworkMode: strptr(tc.testNetworkMode),

--- a/agent/ecscni/plugin_linux_test.go
+++ b/agent/ecscni/plugin_linux_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/amazon-ecs-agent/agent/api/serviceconnect"
+
 	"github.com/aws/amazon-ecs-agent/agent/api/appmesh"
 	"github.com/aws/amazon-ecs-agent/agent/api/eni"
 	mock_libcni "github.com/aws/amazon-ecs-agent/agent/ecscni/mocks_libcni"
@@ -231,6 +233,74 @@ func appMeshNetworkConfig(config *Config) *NetworkConfig {
 	return &NetworkConfig{CNINetworkConfig: appMeshNetworkConfig}
 }
 
+func TestSetupNSServiceConnectEnabled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ecscniClient := NewClient("")
+	libcniClient := mock_libcni.NewMockCNI(ctrl)
+	ecscniClient.(*cniClient).libcni = libcniClient
+
+	additionalRoutesJson := `["169.254.172.1/32", "10.11.12.13/32"]`
+	var additionalRoutes []cnitypes.IPNet
+	err := json.Unmarshal([]byte(additionalRoutesJson), &additionalRoutes)
+	assert.NoError(t, err)
+
+	gomock.InOrder(
+		// ENI plugin was called first
+		libcniClient.EXPECT().AddNetwork(gomock.Any(), gomock.Any(), gomock.Any()).Return(&current.Result{}, nil).Do(
+			func(ctx context.Context, net *libcni.NetworkConfig, rt *libcni.RuntimeConf) {
+				assert.Equal(t, ECSENIPluginName, net.Network.Type, "first plugin should be eni")
+			}),
+		// Bridge plugin was called second
+		libcniClient.EXPECT().AddNetwork(gomock.Any(), gomock.Any(), gomock.Any()).Return(&current.Result{}, nil).Do(
+			func(ctx context.Context, net *libcni.NetworkConfig, rt *libcni.RuntimeConf) {
+				assert.Equal(t, ECSBridgePluginName, net.Network.Type, "second plugin should be bridge")
+				var bridgeConfig BridgeConfig
+				err := json.Unmarshal(net.Bytes, &bridgeConfig)
+				assert.NoError(t, err, "unmarshal BridgeConfig")
+				assert.Len(t, bridgeConfig.IPAM.IPV4Routes, 3, "default route plus two extra routes")
+			}),
+		// ServiceConnect plugin was called third
+		libcniClient.EXPECT().AddNetwork(gomock.Any(), gomock.Any(), gomock.Any()).Return(&current.Result{}, nil).Do(
+			func(ctx context.Context, net *libcni.NetworkConfig, rt *libcni.RuntimeConf) {
+				assert.Equal(t, ECSServiceConnectPluginName, net.Network.Type, "third plugin should be service connect")
+			}),
+	)
+	config := &Config{
+		AdditionalLocalRoutes: additionalRoutes,
+		NetworkConfigs:        []*NetworkConfig{},
+	}
+	config.NetworkConfigs = append(config.NetworkConfigs, eniNetworkConfig(config))
+	config.NetworkConfigs = append(config.NetworkConfigs, bridgeConfigWithIPAM(config))
+	config.NetworkConfigs = append(config.NetworkConfigs, serviceConnectNetworkConfig(config))
+	_, err = ecscniClient.SetupNS(context.TODO(), config, time.Second)
+	assert.NoError(t, err)
+}
+
+func serviceConnectNetworkConfig(config *Config) *NetworkConfig {
+	_, serviceConnectNetworkConfig, _ := NewServiceConnectNetworkConfig(defaultTestServiceConnectConfig(), true, false, config)
+	return &NetworkConfig{CNINetworkConfig: serviceConnectNetworkConfig}
+}
+
+func defaultTestServiceConnectConfig() *serviceconnect.Config {
+	return &serviceconnect.Config{
+		IngressConfig: []serviceconnect.IngressConfigEntry{{
+			ListenerName: "test ingress listener",
+			ListenerPort: 11111,
+		}},
+		EgressConfig: &serviceconnect.EgressConfig{
+			ListenerName: "test egress listener",
+			ListenerPort: 22222,
+			VIP: serviceconnect.VIP{
+				IPV4CIDR: "169.254.0.0/16",
+			},
+		},
+		DNSConfig:     nil,
+		RuntimeConfig: serviceconnect.RuntimeConfig{},
+	}
+}
+
 func TestSetupNSTimeout(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -343,6 +413,27 @@ func TestCleanupNSAppMeshEnabled(t *testing.T) {
 	config.NetworkConfigs = append(config.NetworkConfigs, bridgeConfigWithIPAM(config))
 	config.NetworkConfigs = append(config.NetworkConfigs, appMeshNetworkConfig(config))
 	err = ecscniClient.CleanupNS(context.TODO(), config, time.Second)
+	assert.NoError(t, err)
+}
+
+func TestCleanupNSServiceConnectEnabled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ecscniClient := NewClient("")
+	libcniClient := mock_libcni.NewMockCNI(ctrl)
+	ecscniClient.(*cniClient).libcni = libcniClient
+
+	// This will be called for both bridge and eni plugin
+	libcniClient.EXPECT().DelNetwork(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(3)
+
+	config := &Config{
+		NetworkConfigs: []*NetworkConfig{},
+	}
+	config.NetworkConfigs = append(config.NetworkConfigs, eniNetworkConfig(config))
+	config.NetworkConfigs = append(config.NetworkConfigs, bridgeConfigWithIPAM(config))
+	config.NetworkConfigs = append(config.NetworkConfigs, serviceConnectNetworkConfig(config))
+	err := ecscniClient.CleanupNS(context.TODO(), config, time.Second)
 	assert.NoError(t, err)
 }
 
@@ -554,6 +645,91 @@ func TestConstructIPAMNetworkConfig(t *testing.T) {
 	}
 	expectedConfigBytes, _ := json.Marshal(expectedConfig)
 	assert.Equal(t, expectedConfigBytes, networkConfig.Bytes)
+}
+
+func TestConstructServiceConnectNetworkConfig(t *testing.T) {
+	config := defaultTestServiceConnectConfig()
+	scIfName, netConfig, err := NewServiceConnectNetworkConfig(config, true, false, &Config{})
+	require.NoError(t, err, "Failed to construct service connect network config")
+	assert.Equal(t, defaultServiceConnectIfName, scIfName)
+
+	var scNetworkConfig ServiceConnectConfig
+	err = json.Unmarshal(netConfig.Bytes, &scNetworkConfig)
+	assert.NoError(t, err, "unmarshal ServiceConnect network config")
+	assert.Equal(t, 1, len(scNetworkConfig.IngressConfig))
+	assert.Equal(t, uint16(11111), scNetworkConfig.IngressConfig[0].ListenerPort)
+	assert.Equal(t, uint16(0), scNetworkConfig.IngressConfig[0].InterceptPort)
+	assert.NotNil(t, scNetworkConfig.EgressConfig)
+	assert.Equal(t, uint16(22222), scNetworkConfig.EgressConfig.ListenerPort)
+	assert.Equal(t, "169.254.0.0/16", scNetworkConfig.EgressConfig.VIP.IPv4CIDR)
+	assert.Equal(t, "", scNetworkConfig.EgressConfig.VIP.IPv6CIDR)
+	assert.Equal(t, true, scNetworkConfig.EnableIPv4)
+	assert.Equal(t, false, scNetworkConfig.EnableIPv6)
+}
+
+func TestConstructServiceConnectNetworkConfig_EmptyEgress(t *testing.T) {
+	config := defaultTestServiceConnectConfig()
+	config.EgressConfig = nil
+	scIfName, netConfig, err := NewServiceConnectNetworkConfig(config, true, true, &Config{})
+	require.NoError(t, err, "Failed to construct service connect network config")
+	assert.Equal(t, defaultServiceConnectIfName, scIfName)
+
+	var scNetworkConfig ServiceConnectConfig
+	err = json.Unmarshal(netConfig.Bytes, &scNetworkConfig)
+	assert.NoError(t, err, "unmarshal ServiceConnect network config")
+	assert.Equal(t, 1, len(scNetworkConfig.IngressConfig))
+	assert.Equal(t, uint16(11111), scNetworkConfig.IngressConfig[0].ListenerPort)
+	assert.Equal(t, uint16(0), scNetworkConfig.IngressConfig[0].InterceptPort)
+	assert.Nil(t, scNetworkConfig.EgressConfig)
+	assert.Equal(t, true, scNetworkConfig.EnableIPv4)
+	assert.Equal(t, true, scNetworkConfig.EnableIPv6)
+}
+
+func TestConstructServiceConnectNetworkConfig_MultipleIngress(t *testing.T) {
+	config := defaultTestServiceConnectConfig()
+	interceptPort := uint16(44444)
+	config.IngressConfig = append(config.IngressConfig, serviceconnect.IngressConfigEntry{
+		ListenerName:  "test listener 2",
+		ListenerPort:  uint16(33333),
+		InterceptPort: &interceptPort,
+	})
+	scIfName, netConfig, err := NewServiceConnectNetworkConfig(config, true, true, &Config{})
+	require.NoError(t, err, "Failed to construct service connect network config")
+	assert.Equal(t, defaultServiceConnectIfName, scIfName)
+
+	var scNetworkConfig ServiceConnectConfig
+	err = json.Unmarshal(netConfig.Bytes, &scNetworkConfig)
+	assert.NoError(t, err, "unmarshal ServiceConnect network config")
+	assert.Equal(t, 2, len(scNetworkConfig.IngressConfig))
+	assert.Equal(t, uint16(11111), scNetworkConfig.IngressConfig[0].ListenerPort)
+	assert.Equal(t, uint16(0), scNetworkConfig.IngressConfig[0].InterceptPort)
+	assert.Equal(t, uint16(33333), scNetworkConfig.IngressConfig[1].ListenerPort)
+	assert.Equal(t, uint16(44444), scNetworkConfig.IngressConfig[1].InterceptPort)
+	assert.NotNil(t, scNetworkConfig.EgressConfig)
+	assert.Equal(t, uint16(22222), scNetworkConfig.EgressConfig.ListenerPort)
+	assert.Equal(t, "169.254.0.0/16", scNetworkConfig.EgressConfig.VIP.IPv4CIDR)
+	assert.Equal(t, "", scNetworkConfig.EgressConfig.VIP.IPv6CIDR)
+	assert.Equal(t, true, scNetworkConfig.EnableIPv4)
+	assert.Equal(t, true, scNetworkConfig.EnableIPv6)
+}
+
+func TestConstructServiceConnectNetworkConfig_EmptyIngress(t *testing.T) {
+	config := defaultTestServiceConnectConfig()
+	config.IngressConfig = []serviceconnect.IngressConfigEntry{}
+	scIfName, netConfig, err := NewServiceConnectNetworkConfig(config, true, false, &Config{})
+	require.NoError(t, err, "Failed to construct service connect network config")
+	assert.Equal(t, defaultServiceConnectIfName, scIfName)
+
+	var scNetworkConfig ServiceConnectConfig
+	err = json.Unmarshal(netConfig.Bytes, &scNetworkConfig)
+	assert.NoError(t, err, "unmarshal ServiceConnect network config")
+	assert.Equal(t, 0, len(scNetworkConfig.IngressConfig))
+	assert.NotNil(t, scNetworkConfig.EgressConfig)
+	assert.Equal(t, uint16(22222), scNetworkConfig.EgressConfig.ListenerPort)
+	assert.Equal(t, "169.254.0.0/16", scNetworkConfig.EgressConfig.VIP.IPv4CIDR)
+	assert.Equal(t, "", scNetworkConfig.EgressConfig.VIP.IPv6CIDR)
+	assert.Equal(t, true, scNetworkConfig.EnableIPv4)
+	assert.Equal(t, false, scNetworkConfig.EnableIPv6)
 }
 
 // TestConstructBridgeNetworkConfigWithIPAM tests createBridgeNetworkConfigWithIPAM

--- a/agent/ecscni/plugin_test.go
+++ b/agent/ecscni/plugin_test.go
@@ -29,7 +29,7 @@ const (
 	// ECSCNIVersion, ECSCNIGitHash, VPCCNIGitHash needs to be updated every time CNI plugin is updated.
 	currentECSCNIVersion = "2020.09.0"
 	currentECSCNIGitHash = "55b2ae77ee0bf22321b14f2d4ebbcc04f77322e1"
-	currentVPCCNIGitHash = "199bfc65cced4951cbb6a38e6e828afa8c2b023c"
+	currentVPCCNIGitHash = "dfdef10bd0a241dcd17e152a8b559fdaf59be47f"
 )
 
 // Asserts that CNI plugin version matches the expected version

--- a/agent/ecscni/types_linux.go
+++ b/agent/ecscni/types_linux.go
@@ -28,6 +28,9 @@ const (
 	// defaultAppMeshIfName is the default name of app mesh to setup iptable rules
 	// for app mesh container. IfName is mandatory field to invoke CNI plugin.
 	defaultAppMeshIfName = "aws-appmesh"
+	// defaultAppMeshIfName is mandatory field to invoke CNI plugin. But it's not
+	// actually used as the CNI plugin is not creating a new interface.
+	defaultServiceConnectIfName = "ecs-serviceconnect"
 	// ECSIPAMPluginName is the binary of the ipam plugin
 	ECSIPAMPluginName = "ecs-ipam"
 	// ECSBridgePluginName is the binary of the bridge plugin
@@ -38,6 +41,8 @@ const (
 	ECSAppMeshPluginName = "aws-appmesh"
 	// ECSBranchENIPluginName is the binary of the branch-eni plugin
 	ECSBranchENIPluginName = "vpc-branch-eni"
+	// ECSServiceConnectPluginName is the binary of the service connect plugin
+	ECSServiceConnectPluginName = "ecs-serviceconnect"
 	// NetnsFormat is used to construct the path to cotainer network namespace
 	NetnsFormat = "/host/proc/%s/ns/net"
 )
@@ -158,4 +163,40 @@ type BranchENIConfig struct {
 	BlockInstanceMetadata bool `json:"blockInstanceMetadata"`
 	// InterfaceType is the type of the interface to connect the branch ENI to
 	InterfaceType string `json:"interfaceType,omitempty"`
+}
+
+type ServiceConnectConfig struct {
+	// CNIVersion is the CNI spec version to use
+	CNIVersion string `json:"cniVersion,omitempty"`
+	// Name is the CNI network name
+	Name string `json:"name,omitempty"`
+	// Type is the CNI plugin name
+	Type string `json:"type,omitempty"`
+
+	// IngressConfig (optional) specifies the netfilter rules to be set for incoming requests.
+	IngressConfig []IngressConfigJSONEntry `json:"ingressConfig,omitempty"`
+	// EgressConfig (optional) specifies the netfilter rules to be set for outgoing requests.
+	EgressConfig *EgressConfigJSON `json:"egressConfig,omitempty"`
+	// EnableIPv4 (optional) specifies whether to set the rules in IPV4 table. Default value is false.
+	EnableIPv4 bool `json:"enableIPv4,omitempty"`
+	// EnableIPv6 (optional) specifies whether to set the rules in IPV6 table. Default value is false.
+	EnableIPv6 bool `json:"enableIPv6,omitempty"`
+}
+
+// IngressConfig defines the ingress network config in JSON format for the ecs-serviceconnect CNI plugin.
+type IngressConfigJSONEntry struct {
+	ListenerPort  uint16 `json:"listenerPort"`
+	InterceptPort uint16 `json:"interceptPort,omitempty"`
+}
+
+// EgressConfig defines the egress network config in JSON format for the ecs-serviceconnect CNI plugin.
+type EgressConfigJSON struct {
+	ListenerPort uint16        `json:"listenerPort"`
+	VIP          VIPConfigJSON `json:"vip"`
+}
+
+// vipConfig defines the EgressVIP network config in JSON format for the ecs-serviceconnect CNI plugin.
+type VIPConfigJSON struct {
+	IPv4CIDR string `json:"ipv4Cidr,omitempty"`
+	IPv6CIDR string `json:"ipv6Cidr,omitempty"`
 }

--- a/agent/engine/docker_task_engine_linux_test.go
+++ b/agent/engine/docker_task_engine_linux_test.go
@@ -25,6 +25,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/amazon-ecs-agent/agent/api/serviceconnect"
+
 	mock_api "github.com/aws/amazon-ecs-agent/agent/api/mocks"
 
 	"github.com/aws/amazon-ecs-agent/agent/api/appmesh"
@@ -884,9 +886,9 @@ func TestContainersWithServiceConnect(t *testing.T) {
 	sleepContainer2.TransitionDependenciesMap = make(map[apicontainerstatus.ContainerStatus]apicontainer.TransitionDependencySet)
 
 	// Inject mock SC config
-	sleepTask.ServiceConnectConfig = &apitask.ServiceConnectConfig{
+	sleepTask.ServiceConnectConfig = &serviceconnect.Config{
 		ContainerName: "service-connect",
-		DNSConfig: []apitask.DNSConfigEntry{
+		DNSConfig: []serviceconnect.DNSConfigEntry{
 			{
 				HostName: "host1.my.corp",
 				Address:  "169.254.1.1",
@@ -1060,19 +1062,19 @@ func TestContainersWithServiceConnect_BridgeMode(t *testing.T) {
 	sleepContainer.TransitionDependenciesMap = make(map[apicontainerstatus.ContainerStatus]apicontainer.TransitionDependencySet)
 
 	// Inject mock SC config
-	sleepTask.ServiceConnectConfig = &apitask.ServiceConnectConfig{
+	sleepTask.ServiceConnectConfig = &serviceconnect.Config{
 		ContainerName: "service-connect",
-		IngressConfig: []apitask.IngressConfigEntry{
+		IngressConfig: []serviceconnect.IngressConfigEntry{
 			{
 				ListenerName: "testListener1", // bridge mode default - ephemeral listener host port
 				ListenerPort: 15000,
 			},
 		},
-		EgressConfig: &apitask.EgressConfig{
+		EgressConfig: &serviceconnect.EgressConfig{
 			ListenerName: "testEgressListener",
 			ListenerPort: 0, // Presently this should always get ephemeral port
 		},
-		DNSConfig: []apitask.DNSConfigEntry{
+		DNSConfig: []serviceconnect.DNSConfigEntry{
 			{
 				HostName: "host1.my.corp",
 				Address:  "169.254.1.1",

--- a/agent/engine/service_connect/manager_linux.go
+++ b/agent/engine/service_connect/manager_linux.go
@@ -19,6 +19,8 @@ import (
 	"path/filepath"
 	"syscall"
 
+	"github.com/aws/amazon-ecs-agent/agent/api/serviceconnect"
+
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	dockercontainer "github.com/docker/docker/api/types/container"
@@ -99,7 +101,7 @@ func (m *manager) augmentAgentContainer(task *apitask.Task, container *apicontai
 	m.initAgentEnvironment(container)
 
 	// Setup runtime configuration
-	var config apitask.RuntimeConfig
+	var config serviceconnect.RuntimeConfig
 	config.AdminSocketPath = adminPath
 	config.StatsRequest = m.adminStatsRequest
 	config.DrainRequest = m.adminDrainRequest
@@ -151,7 +153,7 @@ func (m *manager) initServiceConnectContainerMapping(task *apitask.Task, contain
 
 // DNSConfigToDockerExtraHostsFormat converts a []DNSConfigEntry slice to a list of ExtraHost entries that Docker will
 // recognize.
-func DNSConfigToDockerExtraHostsFormat(dnsConfigs []apitask.DNSConfigEntry) []string {
+func DNSConfigToDockerExtraHostsFormat(dnsConfigs []serviceconnect.DNSConfigEntry) []string {
 	var hosts []string
 	for _, dnsConf := range dnsConfigs {
 		if len(dnsConf.Address) > 0 {

--- a/agent/engine/service_connect/manager_linux_test.go
+++ b/agent/engine/service_connect/manager_linux_test.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/amazon-ecs-agent/agent/api/serviceconnect"
+
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	apieni "github.com/aws/amazon-ecs-agent/agent/api/eni"
@@ -64,11 +66,11 @@ var (
 
 func TestDNSConfigToDockerExtraHostsFormat(t *testing.T) {
 	tt := []struct {
-		dnsConfigs      []task.DNSConfigEntry
+		dnsConfigs      []serviceconnect.DNSConfigEntry
 		expectedRestult []string
 	}{
 		{
-			dnsConfigs: []task.DNSConfigEntry{
+			dnsConfigs: []serviceconnect.DNSConfigEntry{
 				{
 					HostName: "my.test.host",
 					Address:  "169.254.1.1",
@@ -98,9 +100,9 @@ func TestDNSConfigToDockerExtraHostsFormat(t *testing.T) {
 func getAWSVPCTask(t *testing.T) (*apitask.Task, *apicontainer.Container, *apicontainer.Container) {
 	sleepTask := testdata.LoadTask("sleep5TwoContainers")
 
-	sleepTask.ServiceConnectConfig = &apitask.ServiceConnectConfig{
+	sleepTask.ServiceConnectConfig = &serviceconnect.Config{
 		ContainerName: "service-connect",
-		DNSConfig: []apitask.DNSConfigEntry{
+		DNSConfig: []serviceconnect.DNSConfigEntry{
 			{
 				HostName: "host1.my.corp",
 				Address:  "169.254.1.1",

--- a/agent/stats/service_connect_linux_test.go
+++ b/agent/stats/service_connect_linux_test.go
@@ -24,6 +24,8 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/aws/amazon-ecs-agent/agent/api/serviceconnect"
+
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apieni "github.com/aws/amazon-ecs-agent/agent/api/eni"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
@@ -44,8 +46,8 @@ func TestRetrieveServiceConnectMetrics(t *testing.T) {
 			{Name: "test"},
 		},
 		LocalIPAddressUnsafe: "127.0.0.1",
-		ServiceConnectConfig: &apitask.ServiceConnectConfig{
-			RuntimeConfig: apitask.RuntimeConfig{
+		ServiceConnectConfig: &serviceconnect.Config{
+			RuntimeConfig: serviceconnect.RuntimeConfig{
 				AdminSocketPath: "/tmp/appnet_admin.sock",
 				StatsRequest:    "http://myhost/get/them/stats",
 			},

--- a/scripts/dockerfiles/Dockerfile.buildVPCCNIPlugins
+++ b/scripts/dockerfiles/Dockerfile.buildVPCCNIPlugins
@@ -27,4 +27,4 @@ RUN mkdir -p /go/src/github.com/aws/
 
 WORKDIR /go/src/github.com/aws/amazon-vpc-cni-plugins
 
-CMD ["make", "aws-appmesh", "vpc-branch-eni"]
+CMD ["make", "aws-appmesh", "vpc-branch-eni", "ecs-serviceconnect"]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
ServiceConnect-enabled tasks require network namespace configurations that are performed by a new CNI plugin. This PR integrates with the new CNI plugin for AWSVPC mode. 

This PR also moves `ServiceConnectConfig` model and its relevant parsing/validation logic into a separate `serviceconnect` package (originally under `task` package) to avoid a circular import between `task` and `ecscni` package, when both need to reference SCConfig.

### Implementation details
<!-- How are the changes implemented? -->
If a task is AWSVPC mode and SC-enabled, build and append ServiceConnect network configuration such that the `ecs-serviceconnect` CNI plugin will be executed with the supplied information. 

The configuration includes:
- ingress and egress info which comes from task payload (except the ephemeral ports which are selected by Agent)
- flags to indicate whether task is IPv4- and/or IPv6-enabled

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes

Used the Agent image for a test SC task and verified iptables rule configuration.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Integrates with Service Connect CNI plugin

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
