### PR TITLE
Build VPC CNI plugin without using vendor directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,9 +222,10 @@ build-ecs-cni-plugins:
 
 build-vpc-cni-plugins:
 	@docker build --build-arg GOARCH=$(GOARCH) --build-arg GO_VERSION=$(GO_VERSION) -f $(VPC_CNI_REPOSITORY_DOCKER_FILE) -t "amazon/amazon-ecs-build-vpc-cni-plugins:make" .
-	docker run --rm --net=none \
-		-e GO111MODULE=off \
+	docker run --rm --net=host \
+		-e GO111MODULE=auto \
 		-e GIT_SHORT_HASH=$(shell cd $(VPC_CNI_REPOSITORY_SRC_DIR) && git rev-parse --short=8 HEAD) \
+		-e GIT_TAG=$(shell cd $(VPC_CNI_REPOSITORY_SRC_DIR) && git describe --tags --always --dirty) \
 		-u "$(USERID)" \
 		-v "$(PWD)/out/amazon-vpc-cni-plugins:/go/src/github.com/aws/amazon-vpc-cni-plugins/build/${TARGET_OS}_$(GOARCH)" \
 		-v "$(VPC_CNI_REPOSITORY_SRC_DIR):/go/src/github.com/aws/amazon-vpc-cni-plugins" \

--- a/scripts/dockerfiles/Dockerfile.buildVPCCNIPlugins
+++ b/scripts/dockerfiles/Dockerfile.buildVPCCNIPlugins
@@ -21,7 +21,7 @@ ENV GOARCH ${GOARCH}
 
 ENV XDG_CACHE_HOME /tmp
 
-ENV GOFLAGS=-mod=vendor
+ENV GOPROXY https://proxy.golang.org|direct
 
 RUN mkdir -p /go/src/github.com/aws/
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
We use aws-vpc-cni-plugin [repo](https://github.com/aws/amazon-vpc-cni-plugins) as a submodule. Currently when building the plugins we use the dependencies in the repo's vendor directory by specifying `-mod=vendor` build flag. This requires that the repo maintains an up-to-date vendor directory. 

However, since the repo has migrated to use go modules, the vendor directory is not automatically updated, and is currently out-of-sync with the actual dependency versions in go.mod file. This PR removes the `-mod=vendor` flag so that `go build` will download the dependencies directly, and we are no longer vulnerable to out-of-sync vendored deps.


### Implementation details
<!-- How are the changes implemented? -->
- Remove `-mod=vendor` flag for the build
- Add `GOPROXY=https://proxy.golang.org|direct` env var for the build to download dependency packages. By default, `GOPROXY="https://proxy.golang.org,direct"`. `go` will interpret it as a comma-separated list, and try the next candidate in case of 404 or 410 error. We want to use '|' instead, so that regardless of the error (such as when `proxy.golang.org` domain is blocked), the next candidate will always be tried. 
- Add `GIT_TAG` env var to be consumed by the [build](https://github.com/aws/amazon-vpc-cni-plugins/blob/master/Makefile#L26). Currently resolving git tag throws error because the docker work directory during submodule build is not a git directory so we can't run git commands there.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Ran `make cni-plugins` and verified output `Built all cni plugins successfully.`

New tests cover the changes: <!-- yes|no --> no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Buid VPC CNI plugin without using vendor directory

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
