### PR TITLE
Update port bindings to associated pause containers for service connect bridge mode tasks

### DIFF
--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -1526,10 +1526,10 @@ func (task *Task) addNetworkResourceProvisioningDependencyServiceConnectBridge(c
 	return nil
 }
 
-// getBridgeModePauseContainerForTaskContainer retrieves the associated pause container for a task container (SC container
+// GetBridgeModePauseContainerForTaskContainer retrieves the associated pause container for a task container (SC container
 // or customer-defined containers) in a bridge-mode SC-enabled task.
 // For a container with name "abc", the pause container will always be named "~internal~ecs~pause-abc"
-func (task *Task) getBridgeModePauseContainerForTaskContainer(container *apicontainer.Container) (*apicontainer.Container, error) {
+func (task *Task) GetBridgeModePauseContainerForTaskContainer(container *apicontainer.Container) (*apicontainer.Container, error) {
 	// "~internal~ecs~pause-$TASK_CONTAINER_NAME"
 	pauseContainerName := fmt.Sprintf("%s-%s", NetworkPauseContainerName, container.Name)
 	pauseContainer, ok := task.ContainerByName(pauseContainerName)
@@ -2032,7 +2032,7 @@ func (task *Task) shouldOverrideNetworkModeAwsvpc(container *apicontainer.Contai
 // with container network mode use pause container netns (the "docker run" equivalent option is
 // "--network container:$pause_container_id")
 func (task *Task) shouldOverrideNetworkModeServiceConnectBridge(container *apicontainer.Container, dockerContainerMap map[string]*apicontainer.DockerContainer) (bool, string) {
-	pauseContainer, err := task.getBridgeModePauseContainerForTaskContainer(container)
+	pauseContainer, err := task.GetBridgeModePauseContainerForTaskContainer(container)
 	if err != nil {
 		// This should never be the case and implies a code-bug.
 		logger.Critical("Pause container required per task container for Service Connect task bridge mode, but "+

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -4149,7 +4149,7 @@ func TestPostUnmarshalTaskNetworkModeInference(t *testing.T) {
 
 func TestGetBridgeModePauseContainerForTaskContainer(t *testing.T) {
 	testTask := getTestTaskServiceConnectBridgeMode()
-	container, err := testTask.getBridgeModePauseContainerForTaskContainer(testTask.Containers[0])
+	container, err := testTask.GetBridgeModePauseContainerForTaskContainer(testTask.Containers[0])
 	assert.Nil(t, err)
 	assert.NotNil(t, container)
 	assert.Equal(t, testTask.Containers[1].Name, container.Name)
@@ -4158,7 +4158,7 @@ func TestGetBridgeModePauseContainerForTaskContainer(t *testing.T) {
 func TestGetBridgeModePauseContainerForTaskContainer_NotFound(t *testing.T) {
 	testTask := getTestTaskServiceConnectBridgeMode()
 	testTask.Containers[1].Name = "invalid"
-	_, err := testTask.getBridgeModePauseContainerForTaskContainer(testTask.Containers[0])
+	_, err := testTask.GetBridgeModePauseContainerForTaskContainer(testTask.Containers[0])
 	assert.NotNil(t, err)
 	assert.True(t, strings.Contains(err.Error(), "could not find pause container"))
 }

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -34,6 +34,7 @@ import (
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	apieni "github.com/aws/amazon-ecs-agent/agent/api/eni"
 	apierrors "github.com/aws/amazon-ecs-agent/agent/api/errors"
+	"github.com/aws/amazon-ecs-agent/agent/api/serviceconnect"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	apitaskstatus "github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/agent/asm"
@@ -1980,42 +1981,106 @@ func TestPullStoppedAtWasSetCorrectlyWhenPullFail(t *testing.T) {
 }
 
 func TestSynchronizeContainerStatus(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.TODO())
-	defer cancel()
-	ctrl, client, _, taskEngine, _, imageManager, _, _ := mocks(t, ctx, &defaultConfig)
-	defer ctrl.Finish()
-
-	dockerID := "1234"
-	dockerContainer := &apicontainer.DockerContainer{
-		DockerID:   dockerID,
-		DockerName: "c1",
-		Container:  &apicontainer.Container{},
-	}
-	labels := map[string]string{
+	testContainerName := "c1"
+	testDockerID := "1234"
+	testServiceConnectContainerName := "service-connect"
+	testLabels := map[string]string{
 		"name": "metadata",
 	}
-	volumes := []types.MountPoint{
+	testVolumes := []types.MountPoint{
 		{
 			Name:        "volume",
 			Source:      "/src/vol",
 			Destination: "/vol",
 		},
 	}
-	created := time.Now()
-	gomock.InOrder(
-		client.EXPECT().DescribeContainer(gomock.Any(), dockerID).Return(apicontainerstatus.ContainerRunning,
-			dockerapi.DockerContainerMetadata{
-				Labels:    labels,
-				DockerID:  dockerID,
-				CreatedAt: created,
-				Volumes:   volumes,
-			}),
-		imageManager.EXPECT().RecordContainerReference(dockerContainer.Container),
-	)
-	taskEngine.(*DockerTaskEngine).synchronizeContainerStatus(dockerContainer, nil)
-	assert.Equal(t, created, dockerContainer.Container.GetCreatedAt())
-	assert.Equal(t, labels, dockerContainer.Container.GetLabels())
-	assert.Equal(t, volumes, dockerContainer.Container.GetVolumes())
+	testAppContainer := &apicontainer.Container{
+		Name: testContainerName,
+		Type: apicontainer.ContainerNormal,
+	}
+	testCases := []struct {
+		name                       string
+		serviceConnectEnabled      bool
+		addPauseContainer          bool
+		pauseContainerName         string
+		pauseContainerPortBindings []apicontainer.PortBinding
+		networkMode                string
+	}{
+		{
+			name:                  "Service connect bridge mode with matched pause container",
+			serviceConnectEnabled: true,
+			addPauseContainer:     true,
+			pauseContainerName:    fmt.Sprintf("%s-%s", apitask.NetworkPauseContainerName, testContainerName),
+			pauseContainerPortBindings: []apicontainer.PortBinding{
+				{
+					ContainerPort: 8080,
+				},
+			},
+			networkMode: networkModeBridge,
+		},
+		{
+			name:                  "Default task",
+			serviceConnectEnabled: false,
+			addPauseContainer:     false,
+			networkMode:           networkModeAWSVPC,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.TODO())
+			defer cancel()
+			ctrl, client, _, taskEngine, _, imageManager, _, _ := mocks(t, ctx, &defaultConfig)
+			defer ctrl.Finish()
+
+			testTask := &apitask.Task{
+				Containers:  []*apicontainer.Container{testAppContainer},
+				NetworkMode: tc.networkMode,
+			}
+
+			dockerContainer := &apicontainer.DockerContainer{
+				DockerID:   testDockerID,
+				DockerName: testContainerName,
+				Container:  testAppContainer,
+			}
+			testCreated := time.Now()
+			gomock.InOrder(
+				client.EXPECT().DescribeContainer(gomock.Any(), testDockerID).Return(apicontainerstatus.ContainerRunning,
+					dockerapi.DockerContainerMetadata{
+						Labels:    testLabels,
+						DockerID:  testDockerID,
+						CreatedAt: testCreated,
+						Volumes:   testVolumes,
+					}),
+				imageManager.EXPECT().RecordContainerReference(dockerContainer.Container),
+			)
+
+			if tc.serviceConnectEnabled {
+				testTask.ServiceConnectConfig = &serviceconnect.Config{
+					ContainerName: "service-connect",
+				}
+				scContainer := &apicontainer.Container{
+					Name: testServiceConnectContainerName,
+				}
+				testTask.Containers = append(testTask.Containers, scContainer)
+			}
+			pauseContainer := &apicontainer.Container{}
+			if tc.addPauseContainer {
+				pauseContainer.Name = tc.pauseContainerName
+				pauseContainer.Type = apicontainer.ContainerCNIPause
+				pauseContainer.SetKnownPortBindings(tc.pauseContainerPortBindings)
+				testTask.Containers = append(testTask.Containers, pauseContainer)
+			}
+			taskEngine.(*DockerTaskEngine).synchronizeContainerStatus(dockerContainer, testTask)
+			assert.Equal(t, testCreated, dockerContainer.Container.GetCreatedAt())
+			assert.Equal(t, testLabels, dockerContainer.Container.GetLabels())
+			assert.Equal(t, testVolumes, dockerContainer.Container.GetVolumes())
+
+			if tc.serviceConnectEnabled && tc.addPauseContainer {
+				assert.Equal(t, tc.pauseContainerPortBindings, dockerContainer.Container.GetKnownPortBindings())
+			}
+		})
+	}
 }
 
 // TestHandleDockerHealthEvent tests the docker health event will only cause the


### PR DESCRIPTION
### Summary
As container port mappings are applied to the associated pause container for the bridge-mode ServiceConnect-enabled task, this PR adds logic in `updateContainerMetadata()` to update port mappings for application containers under this scenario. With this change, users will receive the updated port mappings returned through [task metadata endpoints](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint.html).

Find more details and related updates in https://github.com/aws/amazon-ecs-agent/pull/3238.

### Implementation details
1. agent/engine/docker_task_engine.go
* Update container port mappings when the task is` service connect enabled` and `bridge mode`, and the container is `ContainerNormal` type and the container name exist. The container name is required as we will use it to find the associated pause container. 
2. agent/engine/docker_task_engine_test.go
* Update `TestSynchronizeContainerStatus` to test 
  *   Default task (no service connect enabled)
  *  Service connected enabled + bridge mode task
3. agent/api/task/task.go
* Make GetBridgeModePauseContainerForTaskContainer() public

### Testing
New tests cover the changes: yes
#### Unit test
```
--- PASS: TestSynchronizeContainerStatus (0.00s)
    --- PASS: TestSynchronizeContainerStatus/Service_connect_bridge_mode_with_matched_pause_container (0.00s)
    --- PASS: TestSynchronizeContainerStatus/Default_task(0.00s)
```
#### Manual test
1. Run a task definition with a server container,  a testing appnet container and the given pre-definied container port `8080`.
2. Run `docker inspect` on the server container to get [Task Metadata Endpoint version 3  (TMDEv3) and version 4 (TMDEv4) paths](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint.html)
3. Curl the TMDEv3 and TMDEv4 paths to get metadata for the task
* TMDEv3 path: ${ECS_CONTAINER_METADATA_URI}/task
* TMDEv4 path: ${ECS_CONTAINER_METADATA_URI_V4}/task
4. Confirm the port mappings of the server container has been updated to the port mappings that `~internal~ecs~pause-server` contains has. 
  
See an example response from ${ECS_CONTAINER_METADATA_URI_V4}/task as follows:
```
{
    "Cluster": "ServiceConnect",
    ...
    "Containers": [
        {
            "Name": "~internal~ecs~pause-server",
            ...
            "Ports": [
                {
                    "ContainerPort": 8080,
                    "Protocol": "tcp",
                    "HostPort": 49153,
                    "HostIp": "0.0.0.0"
                },
                {
                    "ContainerPort": 8080,
                    "Protocol": "tcp",
                    "HostPort": 49153,
                    "HostIp": "::"
                }
            ],
            "Type": "CNI_PAUSE",
            "Networks": [
                {
                    "NetworkMode": "bridge",
                    "IPv4Addresses": [
                        "172.17.0.2"
                    ]
                }
            ]
        },
        {
            "Name": "~internal~ecs~pause-service-connect",
            ...
            "Ports": [
                {
                    "ContainerPort": 15000,
                    "Protocol": "tcp",
                    "HostPort": 49154,
                    "HostIp": "0.0.0.0"
                },
                {
                    "ContainerPort": 15000,
                    "Protocol": "tcp",
                    "HostPort": 49154,
                    "HostIp": "::"
                }
            ],
            ...
            "Type": "CNI_PAUSE",
            "Networks": [
                {
                    "NetworkMode": "bridge",
                    "IPv4Addresses": [
                        "172.17.0.3"
                    ]
                }
            ]
        },
        {
            "Name": "service-connect",
            ...
            "Ports": [
                {
                    "ContainerPort": 15000,
                    "Protocol": "tcp",
                    "HostPort": 49154,
                    "HostIp": "0.0.0.0"
                },
                {
                    "ContainerPort": 15000,
                    "Protocol": "tcp",
                    "HostPort": 49154,
                    "HostIp": "::"
                }
            ],
            ...
            "Type": "NORMAL",
            ...
        },
        {
            "Name": "server",
            "Ports": [
                {
                    "ContainerPort": 8080,
                    "Protocol": "tcp",
                    "HostPort": 49153,
                    "HostIp": "0.0.0.0"
                },
                {
                    "ContainerPort": 8080,
                    "Protocol": "tcp",
                    "HostPort": 49153,
                    "HostIp": "::"
                }
            ],
            ...
            "Type": "NORMAL",
            ...
        }
    ]
}
```
5. Manually stop and restart ecs service on the host
6. Confirm the same port mappings returned from TMDEv3 and TMDEv4 paths after ECS Agent restart.

### Description for the changelog
Update container's port mappings in TMDE for service connect enabled and bridge mode tasks.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
