### PR TITLE
Bug Fix - Check the size of container metrics size when the container instance runs a mix of SC enabled and not enabled tasks

### DIFF
--- a/agent/stats/engine.go
+++ b/agent/stats/engine.go
@@ -465,17 +465,13 @@ func (engine *DockerStatsEngine) GetInstanceMetrics(includeServiceConnectStats b
 		}
 
 		if includeServiceConnectStats {
-			serviceConnectStats, ok := engine.taskToServiceConnectStats[taskArn]
-			if !ok {
-				seelog.Debugf("task '%s' is not registered to collect service connect metrics", taskArn)
-				continue
-			}
-			if !serviceConnectStats.HasStatsBeenSent() {
-				taskMetric.ServiceConnectMetricsWrapper = serviceConnectStats.GetStats()
-				serviceConnectStats.SetStatsSent(true)
+			if serviceConnectStats, ok := engine.taskToServiceConnectStats[taskArn]; ok {
+				if !serviceConnectStats.HasStatsBeenSent() {
+					taskMetric.ServiceConnectMetricsWrapper = serviceConnectStats.GetStats()
+					serviceConnectStats.SetStatsSent(true)
+				}
 			}
 		}
-
 		taskMetrics = append(taskMetrics, taskMetric)
 	}
 

--- a/agent/stats/engine_test.go
+++ b/agent/stats/engine_test.go
@@ -127,6 +127,36 @@ func TestStatsEngineAddRemoveContainers(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "t1", *taskMetrics[0].TaskArn)
 
+	for _, statsContainer := range containers {
+		assert.Equal(t, name, statsContainer.containerMetadata.Name)
+		assert.Equal(t, networkMode, statsContainer.containerMetadata.NetworkMode)
+		for _, fakeContainerStats := range createFakeContainerStats() {
+			statsContainer.statsQueue.add(fakeContainerStats)
+		}
+	}
+
+	// Ensure task shows up in metrics.
+	containerMetrics, err = engine.taskContainerMetricsUnsafe("t1")
+	if err != nil {
+		t.Errorf("Error getting container metrics: %v", err)
+	}
+	err = validateContainerMetrics(containerMetrics, 2)
+	if err != nil {
+		t.Errorf("Error validating container metrics: %v", err)
+	}
+
+	metadata, taskMetrics, err = engine.GetInstanceMetrics(true)
+	if err != nil {
+		t.Errorf("Error gettting instance metrics: %v", err)
+	}
+
+	err = validateMetricsMetadata(metadata)
+	require.NoError(t, err)
+	require.Len(t, taskMetrics, 1, "Incorrect number of tasks.")
+	err = validateContainerMetrics(taskMetrics[0].ContainerMetrics, 2)
+	require.NoError(t, err)
+	require.Equal(t, "t1", *taskMetrics[0].TaskArn)
+
 	// Ensure that only valid task shows up in metrics.
 	_, err = engine.taskContainerMetricsUnsafe("t2")
 	if err == nil {


### PR DESCRIPTION
Check the size of container metrics size when the container when the container instance runs a mix of SC enabled and not enabled tasks

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This PR fixes 2 bugs
Bug 1: For non service connect enabled tasks, we were not adding docker metrics for that task. This is addressed in [agent/stats/engine.go]

Bug 2: When a container instance will run a combination of service connect and non service connect tasks, for non SC tasks, we were not checking if the docker metrics exceeded the frame size limit. This check needs to be done for SC tasks also.

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

Manual tests: Tested by running an appmesh app that if for a task, container metrics exceeded size, we are creating a new request to send them. Also tested that for non SC tasks, docker metrics are correctly getting added.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
