### PR TITLE
Integrate with Service Connect AWSVPC CNI plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,9 +222,10 @@ build-ecs-cni-plugins:
 
 build-vpc-cni-plugins:
 	@docker build --build-arg GOARCH=$(GOARCH) --build-arg GO_VERSION=$(GO_VERSION) -f $(VPC_CNI_REPOSITORY_DOCKER_FILE) -t "amazon/amazon-ecs-build-vpc-cni-plugins:make" .
-	docker run --rm --net=none \
-		-e GO111MODULE=off \
+	docker run --rm --net=host \
+		-e GO111MODULE=auto \
 		-e GIT_SHORT_HASH=$(shell cd $(VPC_CNI_REPOSITORY_SRC_DIR) && git rev-parse --short=8 HEAD) \
+		-e GIT_TAG=$(shell cd $(VPC_CNI_REPOSITORY_SRC_DIR) && git describe --tags --always --dirty) \
 		-u "$(USERID)" \
 		-v "$(PWD)/out/amazon-vpc-cni-plugins:/go/src/github.com/aws/amazon-vpc-cni-plugins/build/${TARGET_OS}_$(GOARCH)" \
 		-v "$(VPC_CNI_REPOSITORY_SRC_DIR):/go/src/github.com/aws/amazon-vpc-cni-plugins" \

--- a/Makefile
+++ b/Makefile
@@ -222,8 +222,8 @@ build-ecs-cni-plugins:
 
 build-vpc-cni-plugins:
 	@docker build --build-arg GOARCH=$(GOARCH) --build-arg GO_VERSION=$(GO_VERSION) -f $(VPC_CNI_REPOSITORY_DOCKER_FILE) -t "amazon/amazon-ecs-build-vpc-cni-plugins:make" .
-	docker run --rm --net=host \
-		-e GO111MODULE=auto \
+	docker run --rm --net=none \
+		-e GO111MODULE=off \
 		-e GIT_SHORT_HASH=$(shell cd $(VPC_CNI_REPOSITORY_SRC_DIR) && git rev-parse --short=8 HEAD) \
 		-e GIT_TAG=$(shell cd $(VPC_CNI_REPOSITORY_SRC_DIR) && git describe --tags --always --dirty) \
 		-u "$(USERID)" \

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -2113,6 +2113,14 @@ func (task *Task) generateENIExtraHosts() []string {
 	return extraHosts
 }
 
+func (task *Task) shouldEnableIPv4() bool {
+	eni := task.GetPrimaryENI()
+	if eni == nil {
+		return false
+	}
+	return len(eni.GetIPV4Addresses()) > 0
+}
+
 func (task *Task) shouldEnableIPv6() bool {
 	eni := task.GetPrimaryENI()
 	if eni == nil {

--- a/agent/api/task/task_linux.go
+++ b/agent/api/task/task_linux.go
@@ -335,6 +335,22 @@ func (task *Task) BuildCNIConfig(includeIPAMConfig bool, cniConfig *ecscni.Confi
 		})
 	}
 
+	// Build a CNI network configuration for ServiceConnect-enabled task in AWSVPC mode
+	if task.IsServiceConnectEnabled() {
+		ifName, netconf, err = ecscni.NewServiceConnectNetworkConfig(
+			task.ServiceConnectConfig,
+			task.shouldEnableIPv4(),
+			task.shouldEnableIPv6(),
+			cniConfig)
+		if err != nil {
+			return nil, err
+		}
+		cniConfig.NetworkConfigs = append(cniConfig.NetworkConfigs, &ecscni.NetworkConfig{
+			IfName:           ifName,
+			CNINetworkConfig: netconf,
+		})
+	}
+
 	cniConfig.ContainerNetNS = fmt.Sprintf(ecscni.NetnsFormat, cniConfig.ContainerPID)
 
 	return cniConfig, nil

--- a/agent/ecscni/netconfig.go
+++ b/agent/ecscni/netconfig.go
@@ -16,7 +16,8 @@ package ecscni
 import (
 	"encoding/json"
 
-	"github.com/cihub/seelog"
+	"github.com/aws/amazon-ecs-agent/agent/logger"
+
 	"github.com/containernetworking/cni/libcni"
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 )
@@ -25,7 +26,11 @@ import (
 func newNetworkConfig(netcfg interface{}, plugin string, cniVersion string) (*libcni.NetworkConfig, error) {
 	configBytes, err := json.Marshal(netcfg)
 	if err != nil {
-		seelog.Errorf("[ECSCNI] Marshal configuration for plugin %s failed, error: %v", plugin, err)
+		logger.Error("[ECSCNI] Marshal configuration failed", logger.Fields{
+			"netcfg":     netcfg,
+			"plugin":     plugin,
+			"cniVersion": cniVersion,
+		})
 		return nil, err
 	}
 

--- a/agent/ecscni/netconfig_linux.go
+++ b/agent/ecscni/netconfig_linux.go
@@ -19,6 +19,8 @@ package ecscni
 import (
 	"net"
 
+	"github.com/aws/amazon-ecs-agent/agent/api/serviceconnect"
+
 	"github.com/aws/amazon-ecs-agent/agent/api/appmesh"
 	"github.com/aws/amazon-ecs-agent/agent/api/eni"
 
@@ -169,4 +171,47 @@ func NewAppMeshConfig(appMesh *appmesh.AppMesh, cfg *Config) (string, *libcni.Ne
 	}
 
 	return defaultAppMeshIfName, networkConfig, nil
+}
+
+// NewServiceConnectNetworkConfig creates a new ServiceConnect CNI network configuration
+func NewServiceConnectNetworkConfig(
+	scConfig *serviceconnect.Config,
+	enableIPv4, enableIPv6 bool,
+	cfg *Config) (string, *libcni.NetworkConfig, error) {
+	var ingressConfig []IngressConfigJSONEntry
+	for _, ic := range scConfig.IngressConfig {
+		newEntry := IngressConfigJSONEntry{
+			ListenerPort: ic.ListenerPort,
+		}
+		if ic.InterceptPort != nil {
+			newEntry.InterceptPort = *ic.InterceptPort
+		}
+		ingressConfig = append(ingressConfig, newEntry)
+	}
+
+	var egressConfig *EgressConfigJSON
+	if scConfig.EgressConfig != nil {
+		egressConfig = &EgressConfigJSON{
+			ListenerPort: scConfig.EgressConfig.ListenerPort,
+			VIP: VIPConfigJSON{
+				IPv4CIDR: scConfig.EgressConfig.VIP.IPV4CIDR,
+				IPv6CIDR: scConfig.EgressConfig.VIP.IPV6CIDR,
+			},
+		}
+	}
+
+	scNetworkConfig := ServiceConnectConfig{
+		Name:          ECSServiceConnectPluginName,
+		Type:          ECSServiceConnectPluginName,
+		IngressConfig: ingressConfig,
+		EgressConfig:  egressConfig,
+		EnableIPv4:    enableIPv4,
+		EnableIPv6:    enableIPv6,
+	}
+	networkConfig, err := newNetworkConfig(scNetworkConfig, ECSServiceConnectPluginName, cfg.MinSupportedCNIVersion)
+	if err != nil {
+		return "", nil, errors.Wrap(err, "NewServiceConnectNetworkConfig: construct the service connect network configuration failed")
+	}
+
+	return defaultServiceConnectIfName, networkConfig, nil
 }

--- a/agent/ecscni/netconfig_linux.go
+++ b/agent/ecscni/netconfig_linux.go
@@ -17,6 +17,7 @@
 package ecscni
 
 import (
+	"fmt"
 	"net"
 
 	"github.com/aws/amazon-ecs-agent/agent/api/serviceconnect"
@@ -27,7 +28,6 @@ import (
 	"github.com/cihub/seelog"
 	"github.com/containernetworking/cni/libcni"
 	cnitypes "github.com/containernetworking/cni/pkg/types"
-	"github.com/pkg/errors"
 )
 
 // NewBridgeNetworkConfig creates the config of bridge for ADD command, where
@@ -48,7 +48,7 @@ func NewBridgeNetworkConfig(cfg *Config, includeIPAM bool) (string, *libcni.Netw
 	if includeIPAM {
 		ipamConfig, err := newIPAMConfig(cfg)
 		if err != nil {
-			return "", nil, errors.Wrap(err, "NewBridgeNetworkConfig: create ipam configuration failed")
+			return "", nil, fmt.Errorf("NewBridgeNetworkConfig: create ipam configuration failed: %w", err)
 		}
 
 		bridgeConfig.IPAM = ipamConfig
@@ -56,7 +56,7 @@ func NewBridgeNetworkConfig(cfg *Config, includeIPAM bool) (string, *libcni.Netw
 
 	networkConfig, err := newNetworkConfig(bridgeConfig, ECSBridgePluginName, cfg.MinSupportedCNIVersion)
 	if err != nil {
-		return "", nil, errors.Wrap(err, "NewBridgeNetworkConfig: construct bridge and ipam network configuration failed")
+		return "", nil, fmt.Errorf("NewBridgeNetworkConfig: construct bridge and ipam network configuration failed: %w", err)
 	}
 
 	return defaultVethName, networkConfig, nil
@@ -66,7 +66,7 @@ func NewBridgeNetworkConfig(cfg *Config, includeIPAM bool) (string, *libcni.Netw
 func NewIPAMNetworkConfig(cfg *Config) (string, *libcni.NetworkConfig, error) {
 	ipamConfig, err := newIPAMConfig(cfg)
 	if err != nil {
-		return defaultVethName, nil, errors.Wrap(err, "NewIPAMNetworkConfig: create ipam network configuration failed")
+		return defaultVethName, nil, fmt.Errorf("NewIPAMNetworkConfig: create ipam network configuration failed: %w", err)
 	}
 
 	ipamNetworkConfig := IPAMNetworkConfig{
@@ -77,7 +77,7 @@ func NewIPAMNetworkConfig(cfg *Config) (string, *libcni.NetworkConfig, error) {
 
 	networkConfig, err := newNetworkConfig(ipamNetworkConfig, ECSIPAMPluginName, cfg.MinSupportedCNIVersion)
 	if err != nil {
-		return "", nil, errors.Wrap(err, "NewIPAMNetworkConfig: construct ipam network configuration failed")
+		return "", nil, fmt.Errorf("NewIPAMNetworkConfig: construct ipam network configuration failed: %w", err)
 	}
 
 	return defaultVethName, networkConfig, nil
@@ -125,7 +125,7 @@ func NewENINetworkConfig(eni *eni.ENI, cfg *Config) (string, *libcni.NetworkConf
 
 	networkConfig, err := newNetworkConfig(eniConf, ECSENIPluginName, cfg.MinSupportedCNIVersion)
 	if err != nil {
-		return "", nil, errors.Wrap(err, "cni config: failed to create configuration")
+		return "", nil, fmt.Errorf("cni config: failed to create configuration: %w", err)
 	}
 
 	return defaultENIName, networkConfig, nil
@@ -146,7 +146,7 @@ func NewBranchENINetworkConfig(eni *eni.ENI, cfg *Config) (string, *libcni.Netwo
 
 	networkConfig, err := newNetworkConfig(eniConf, ECSBranchENIPluginName, cfg.MinSupportedCNIVersion)
 	if err != nil {
-		return "", nil, errors.Wrap(err, "NewBranchENINetworkConfig: construct the eni network configuration failed")
+		return "", nil, fmt.Errorf("NewBranchENINetworkConfig: construct the eni network configuration failed: %w", err)
 	}
 
 	return defaultENIName, networkConfig, nil
@@ -167,7 +167,7 @@ func NewAppMeshConfig(appMesh *appmesh.AppMesh, cfg *Config) (string, *libcni.Ne
 
 	networkConfig, err := newNetworkConfig(appMeshConfig, ECSAppMeshPluginName, cfg.MinSupportedCNIVersion)
 	if err != nil {
-		return "", nil, errors.Wrap(err, "NewAppMeshConfig: construct the app mesh network configuration failed")
+		return "", nil, fmt.Errorf("NewAppMeshConfig: construct the app mesh network configuration failed: %w", err)
 	}
 
 	return defaultAppMeshIfName, networkConfig, nil
@@ -210,7 +210,7 @@ func NewServiceConnectNetworkConfig(
 	}
 	networkConfig, err := newNetworkConfig(scNetworkConfig, ECSServiceConnectPluginName, cfg.MinSupportedCNIVersion)
 	if err != nil {
-		return "", nil, errors.Wrap(err, "NewServiceConnectNetworkConfig: construct the service connect network configuration failed")
+		return "", nil, fmt.Errorf("NewServiceConnectNetworkConfig: construct the service connect network configuration failed: %w", err)
 	}
 
 	return defaultServiceConnectIfName, networkConfig, nil

--- a/agent/ecscni/plugin_linux_test.go
+++ b/agent/ecscni/plugin_linux_test.go
@@ -25,6 +25,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/amazon-ecs-agent/agent/api/serviceconnect"
+
 	"github.com/aws/amazon-ecs-agent/agent/api/appmesh"
 	"github.com/aws/amazon-ecs-agent/agent/api/eni"
 	mock_libcni "github.com/aws/amazon-ecs-agent/agent/ecscni/mocks_libcni"
@@ -232,6 +234,74 @@ func appMeshNetworkConfig(config *Config) *NetworkConfig {
 	return &NetworkConfig{CNINetworkConfig: appMeshNetworkConfig}
 }
 
+func TestSetupNSServiceConnectEnabled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ecscniClient := NewClient("")
+	libcniClient := mock_libcni.NewMockCNI(ctrl)
+	ecscniClient.(*cniClient).libcni = libcniClient
+
+	additionalRoutesJson := `["169.254.172.1/32", "10.11.12.13/32"]`
+	var additionalRoutes []cnitypes.IPNet
+	err := json.Unmarshal([]byte(additionalRoutesJson), &additionalRoutes)
+	assert.NoError(t, err)
+
+	gomock.InOrder(
+		// ENI plugin was called first
+		libcniClient.EXPECT().AddNetwork(gomock.Any(), gomock.Any(), gomock.Any()).Return(&current.Result{}, nil).Do(
+			func(ctx context.Context, net *libcni.NetworkConfig, rt *libcni.RuntimeConf) {
+				assert.Equal(t, ECSENIPluginName, net.Network.Type, "first plugin should be eni")
+			}),
+		// Bridge plugin was called second
+		libcniClient.EXPECT().AddNetwork(gomock.Any(), gomock.Any(), gomock.Any()).Return(&current.Result{}, nil).Do(
+			func(ctx context.Context, net *libcni.NetworkConfig, rt *libcni.RuntimeConf) {
+				assert.Equal(t, ECSBridgePluginName, net.Network.Type, "second plugin should be bridge")
+				var bridgeConfig BridgeConfig
+				err := json.Unmarshal(net.Bytes, &bridgeConfig)
+				assert.NoError(t, err, "unmarshal BridgeConfig")
+				assert.Len(t, bridgeConfig.IPAM.IPV4Routes, 3, "default route plus two extra routes")
+			}),
+		// ServiceConnect plugin was called third
+		libcniClient.EXPECT().AddNetwork(gomock.Any(), gomock.Any(), gomock.Any()).Return(&current.Result{}, nil).Do(
+			func(ctx context.Context, net *libcni.NetworkConfig, rt *libcni.RuntimeConf) {
+				assert.Equal(t, ECSServiceConnectPluginName, net.Network.Type, "third plugin should be service connect")
+			}),
+	)
+	config := &Config{
+		AdditionalLocalRoutes: additionalRoutes,
+		NetworkConfigs:        []*NetworkConfig{},
+	}
+	config.NetworkConfigs = append(config.NetworkConfigs, eniNetworkConfig(config))
+	config.NetworkConfigs = append(config.NetworkConfigs, bridgeConfigWithIPAM(config))
+	config.NetworkConfigs = append(config.NetworkConfigs, serviceConnectNetworkConfig(config))
+	_, err = ecscniClient.SetupNS(context.TODO(), config, time.Second)
+	assert.NoError(t, err)
+}
+
+func serviceConnectNetworkConfig(config *Config) *NetworkConfig {
+	_, serviceConnectNetworkConfig, _ := NewServiceConnectNetworkConfig(defaultTestServiceConnectConfig(), true, false, config)
+	return &NetworkConfig{CNINetworkConfig: serviceConnectNetworkConfig}
+}
+
+func defaultTestServiceConnectConfig() *serviceconnect.Config {
+	return &serviceconnect.Config{
+		IngressConfig: []serviceconnect.IngressConfigEntry{{
+			ListenerName: "test ingress listener",
+			ListenerPort: 11111,
+		}},
+		EgressConfig: &serviceconnect.EgressConfig{
+			ListenerName: "test egress listener",
+			ListenerPort: 22222,
+			VIP: serviceconnect.VIP{
+				IPV4CIDR: "169.254.0.0/16",
+			},
+		},
+		DNSConfig:     nil,
+		RuntimeConfig: serviceconnect.RuntimeConfig{},
+	}
+}
+
 func TestSetupNSTimeout(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -344,6 +414,27 @@ func TestCleanupNSAppMeshEnabled(t *testing.T) {
 	config.NetworkConfigs = append(config.NetworkConfigs, bridgeConfigWithIPAM(config))
 	config.NetworkConfigs = append(config.NetworkConfigs, appMeshNetworkConfig(config))
 	err = ecscniClient.CleanupNS(context.TODO(), config, time.Second)
+	assert.NoError(t, err)
+}
+
+func TestCleanupNSServiceConnectEnabled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ecscniClient := NewClient("")
+	libcniClient := mock_libcni.NewMockCNI(ctrl)
+	ecscniClient.(*cniClient).libcni = libcniClient
+
+	// This will be called for both bridge and eni plugin
+	libcniClient.EXPECT().DelNetwork(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(3)
+
+	config := &Config{
+		NetworkConfigs: []*NetworkConfig{},
+	}
+	config.NetworkConfigs = append(config.NetworkConfigs, eniNetworkConfig(config))
+	config.NetworkConfigs = append(config.NetworkConfigs, bridgeConfigWithIPAM(config))
+	config.NetworkConfigs = append(config.NetworkConfigs, serviceConnectNetworkConfig(config))
+	err := ecscniClient.CleanupNS(context.TODO(), config, time.Second)
 	assert.NoError(t, err)
 }
 
@@ -555,6 +646,91 @@ func TestConstructIPAMNetworkConfig(t *testing.T) {
 	}
 	expectedConfigBytes, _ := json.Marshal(expectedConfig)
 	assert.Equal(t, expectedConfigBytes, networkConfig.Bytes)
+}
+
+func TestConstructServiceConnectNetworkConfig(t *testing.T) {
+	config := defaultTestServiceConnectConfig()
+	scIfName, netConfig, err := NewServiceConnectNetworkConfig(config, true, false, &Config{})
+	require.NoError(t, err, "Failed to construct service connect network config")
+	assert.Equal(t, defaultServiceConnectIfName, scIfName)
+
+	var scNetworkConfig ServiceConnectConfig
+	err = json.Unmarshal(netConfig.Bytes, &scNetworkConfig)
+	assert.NoError(t, err, "unmarshal ServiceConnect network config")
+	assert.Equal(t, 1, len(scNetworkConfig.IngressConfig))
+	assert.Equal(t, uint16(11111), scNetworkConfig.IngressConfig[0].ListenerPort)
+	assert.Equal(t, uint16(0), scNetworkConfig.IngressConfig[0].InterceptPort)
+	assert.NotNil(t, scNetworkConfig.EgressConfig)
+	assert.Equal(t, uint16(22222), scNetworkConfig.EgressConfig.ListenerPort)
+	assert.Equal(t, "169.254.0.0/16", scNetworkConfig.EgressConfig.VIP.IPv4CIDR)
+	assert.Equal(t, "", scNetworkConfig.EgressConfig.VIP.IPv6CIDR)
+	assert.Equal(t, true, scNetworkConfig.EnableIPv4)
+	assert.Equal(t, false, scNetworkConfig.EnableIPv6)
+}
+
+func TestConstructServiceConnectNetworkConfig_EmptyEgress(t *testing.T) {
+	config := defaultTestServiceConnectConfig()
+	config.EgressConfig = nil
+	scIfName, netConfig, err := NewServiceConnectNetworkConfig(config, true, true, &Config{})
+	require.NoError(t, err, "Failed to construct service connect network config")
+	assert.Equal(t, defaultServiceConnectIfName, scIfName)
+
+	var scNetworkConfig ServiceConnectConfig
+	err = json.Unmarshal(netConfig.Bytes, &scNetworkConfig)
+	assert.NoError(t, err, "unmarshal ServiceConnect network config")
+	assert.Equal(t, 1, len(scNetworkConfig.IngressConfig))
+	assert.Equal(t, uint16(11111), scNetworkConfig.IngressConfig[0].ListenerPort)
+	assert.Equal(t, uint16(0), scNetworkConfig.IngressConfig[0].InterceptPort)
+	assert.Nil(t, scNetworkConfig.EgressConfig)
+	assert.Equal(t, true, scNetworkConfig.EnableIPv4)
+	assert.Equal(t, true, scNetworkConfig.EnableIPv6)
+}
+
+func TestConstructServiceConnectNetworkConfig_MultipleIngress(t *testing.T) {
+	config := defaultTestServiceConnectConfig()
+	interceptPort := uint16(44444)
+	config.IngressConfig = append(config.IngressConfig, serviceconnect.IngressConfigEntry{
+		ListenerName:  "test listener 2",
+		ListenerPort:  uint16(33333),
+		InterceptPort: &interceptPort,
+	})
+	scIfName, netConfig, err := NewServiceConnectNetworkConfig(config, true, true, &Config{})
+	require.NoError(t, err, "Failed to construct service connect network config")
+	assert.Equal(t, defaultServiceConnectIfName, scIfName)
+
+	var scNetworkConfig ServiceConnectConfig
+	err = json.Unmarshal(netConfig.Bytes, &scNetworkConfig)
+	assert.NoError(t, err, "unmarshal ServiceConnect network config")
+	assert.Equal(t, 2, len(scNetworkConfig.IngressConfig))
+	assert.Equal(t, uint16(11111), scNetworkConfig.IngressConfig[0].ListenerPort)
+	assert.Equal(t, uint16(0), scNetworkConfig.IngressConfig[0].InterceptPort)
+	assert.Equal(t, uint16(33333), scNetworkConfig.IngressConfig[1].ListenerPort)
+	assert.Equal(t, uint16(44444), scNetworkConfig.IngressConfig[1].InterceptPort)
+	assert.NotNil(t, scNetworkConfig.EgressConfig)
+	assert.Equal(t, uint16(22222), scNetworkConfig.EgressConfig.ListenerPort)
+	assert.Equal(t, "169.254.0.0/16", scNetworkConfig.EgressConfig.VIP.IPv4CIDR)
+	assert.Equal(t, "", scNetworkConfig.EgressConfig.VIP.IPv6CIDR)
+	assert.Equal(t, true, scNetworkConfig.EnableIPv4)
+	assert.Equal(t, true, scNetworkConfig.EnableIPv6)
+}
+
+func TestConstructServiceConnectNetworkConfig_EmptyIngress(t *testing.T) {
+	config := defaultTestServiceConnectConfig()
+	config.IngressConfig = []serviceconnect.IngressConfigEntry{}
+	scIfName, netConfig, err := NewServiceConnectNetworkConfig(config, true, false, &Config{})
+	require.NoError(t, err, "Failed to construct service connect network config")
+	assert.Equal(t, defaultServiceConnectIfName, scIfName)
+
+	var scNetworkConfig ServiceConnectConfig
+	err = json.Unmarshal(netConfig.Bytes, &scNetworkConfig)
+	assert.NoError(t, err, "unmarshal ServiceConnect network config")
+	assert.Equal(t, 0, len(scNetworkConfig.IngressConfig))
+	assert.NotNil(t, scNetworkConfig.EgressConfig)
+	assert.Equal(t, uint16(22222), scNetworkConfig.EgressConfig.ListenerPort)
+	assert.Equal(t, "169.254.0.0/16", scNetworkConfig.EgressConfig.VIP.IPv4CIDR)
+	assert.Equal(t, "", scNetworkConfig.EgressConfig.VIP.IPv6CIDR)
+	assert.Equal(t, true, scNetworkConfig.EnableIPv4)
+	assert.Equal(t, false, scNetworkConfig.EnableIPv6)
 }
 
 // TestConstructBridgeNetworkConfigWithIPAM tests createBridgeNetworkConfigWithIPAM

--- a/agent/ecscni/plugin_linux_test.go
+++ b/agent/ecscni/plugin_linux_test.go
@@ -49,6 +49,8 @@ const (
 	eniSubnetGatewayIPV4AddressWithoutBlockSize = "172.31.1.1"
 	trunkENIMACAddress                          = "02:7b:64:49:b2:40"
 	branchENIVLANID                             = "42"
+	testIngressListenerPort                     = uint16(11111)
+	testEgressConfigListenerPort                = uint16(22222)
 )
 
 func TestSetupNS(t *testing.T) {
@@ -288,11 +290,11 @@ func defaultTestServiceConnectConfig() *serviceconnect.Config {
 	return &serviceconnect.Config{
 		IngressConfig: []serviceconnect.IngressConfigEntry{{
 			ListenerName: "test ingress listener",
-			ListenerPort: 11111,
+			ListenerPort: testIngressListenerPort,
 		}},
 		EgressConfig: &serviceconnect.EgressConfig{
 			ListenerName: "test egress listener",
-			ListenerPort: 22222,
+			ListenerPort: testEgressConfigListenerPort,
 			VIP: serviceconnect.VIP{
 				IPV4CIDR: "169.254.0.0/16",
 			},
@@ -658,10 +660,10 @@ func TestConstructServiceConnectNetworkConfig(t *testing.T) {
 	err = json.Unmarshal(netConfig.Bytes, &scNetworkConfig)
 	assert.NoError(t, err, "unmarshal ServiceConnect network config")
 	assert.Equal(t, 1, len(scNetworkConfig.IngressConfig))
-	assert.Equal(t, uint16(11111), scNetworkConfig.IngressConfig[0].ListenerPort)
+	assert.Equal(t, testIngressListenerPort, scNetworkConfig.IngressConfig[0].ListenerPort)
 	assert.Equal(t, uint16(0), scNetworkConfig.IngressConfig[0].InterceptPort)
 	assert.NotNil(t, scNetworkConfig.EgressConfig)
-	assert.Equal(t, uint16(22222), scNetworkConfig.EgressConfig.ListenerPort)
+	assert.Equal(t, testEgressConfigListenerPort, scNetworkConfig.EgressConfig.ListenerPort)
 	assert.Equal(t, "169.254.0.0/16", scNetworkConfig.EgressConfig.VIP.IPv4CIDR)
 	assert.Equal(t, "", scNetworkConfig.EgressConfig.VIP.IPv6CIDR)
 	assert.Equal(t, true, scNetworkConfig.EnableIPv4)
@@ -679,7 +681,7 @@ func TestConstructServiceConnectNetworkConfig_EmptyEgress(t *testing.T) {
 	err = json.Unmarshal(netConfig.Bytes, &scNetworkConfig)
 	assert.NoError(t, err, "unmarshal ServiceConnect network config")
 	assert.Equal(t, 1, len(scNetworkConfig.IngressConfig))
-	assert.Equal(t, uint16(11111), scNetworkConfig.IngressConfig[0].ListenerPort)
+	assert.Equal(t, testIngressListenerPort, scNetworkConfig.IngressConfig[0].ListenerPort)
 	assert.Equal(t, uint16(0), scNetworkConfig.IngressConfig[0].InterceptPort)
 	assert.Nil(t, scNetworkConfig.EgressConfig)
 	assert.Equal(t, true, scNetworkConfig.EnableIPv4)
@@ -702,12 +704,12 @@ func TestConstructServiceConnectNetworkConfig_MultipleIngress(t *testing.T) {
 	err = json.Unmarshal(netConfig.Bytes, &scNetworkConfig)
 	assert.NoError(t, err, "unmarshal ServiceConnect network config")
 	assert.Equal(t, 2, len(scNetworkConfig.IngressConfig))
-	assert.Equal(t, uint16(11111), scNetworkConfig.IngressConfig[0].ListenerPort)
+	assert.Equal(t, testIngressListenerPort, scNetworkConfig.IngressConfig[0].ListenerPort)
 	assert.Equal(t, uint16(0), scNetworkConfig.IngressConfig[0].InterceptPort)
 	assert.Equal(t, uint16(33333), scNetworkConfig.IngressConfig[1].ListenerPort)
 	assert.Equal(t, uint16(44444), scNetworkConfig.IngressConfig[1].InterceptPort)
 	assert.NotNil(t, scNetworkConfig.EgressConfig)
-	assert.Equal(t, uint16(22222), scNetworkConfig.EgressConfig.ListenerPort)
+	assert.Equal(t, testEgressConfigListenerPort, scNetworkConfig.EgressConfig.ListenerPort)
 	assert.Equal(t, "169.254.0.0/16", scNetworkConfig.EgressConfig.VIP.IPv4CIDR)
 	assert.Equal(t, "", scNetworkConfig.EgressConfig.VIP.IPv6CIDR)
 	assert.Equal(t, true, scNetworkConfig.EnableIPv4)
@@ -726,7 +728,7 @@ func TestConstructServiceConnectNetworkConfig_EmptyIngress(t *testing.T) {
 	assert.NoError(t, err, "unmarshal ServiceConnect network config")
 	assert.Equal(t, 0, len(scNetworkConfig.IngressConfig))
 	assert.NotNil(t, scNetworkConfig.EgressConfig)
-	assert.Equal(t, uint16(22222), scNetworkConfig.EgressConfig.ListenerPort)
+	assert.Equal(t, testEgressConfigListenerPort, scNetworkConfig.EgressConfig.ListenerPort)
 	assert.Equal(t, "169.254.0.0/16", scNetworkConfig.EgressConfig.VIP.IPv4CIDR)
 	assert.Equal(t, "", scNetworkConfig.EgressConfig.VIP.IPv6CIDR)
 	assert.Equal(t, true, scNetworkConfig.EnableIPv4)

--- a/agent/ecscni/plugin_test.go
+++ b/agent/ecscni/plugin_test.go
@@ -30,7 +30,7 @@ const (
 	// ECSCNIVersion, ECSCNIGitHash, VPCCNIGitHash needs to be updated every time CNI plugin is updated.
 	currentECSCNIVersion = "2020.09.0"
 	currentECSCNIGitHash = "55b2ae77ee0bf22321b14f2d4ebbcc04f77322e1"
-	currentVPCCNIGitHash = "dfdef10bd0a241dcd17e152a8b559fdaf59be47f"
+	currentVPCCNIGitHash = "c3a89823446f312edfbed8375a0394773e39f807"
 )
 
 // Asserts that CNI plugin version matches the expected version

--- a/agent/ecscni/plugin_test.go
+++ b/agent/ecscni/plugin_test.go
@@ -30,7 +30,7 @@ const (
 	// ECSCNIVersion, ECSCNIGitHash, VPCCNIGitHash needs to be updated every time CNI plugin is updated.
 	currentECSCNIVersion = "2020.09.0"
 	currentECSCNIGitHash = "55b2ae77ee0bf22321b14f2d4ebbcc04f77322e1"
-	currentVPCCNIGitHash = "199bfc65cced4951cbb6a38e6e828afa8c2b023c"
+	currentVPCCNIGitHash = "dfdef10bd0a241dcd17e152a8b559fdaf59be47f"
 )
 
 // Asserts that CNI plugin version matches the expected version

--- a/agent/ecscni/types_linux.go
+++ b/agent/ecscni/types_linux.go
@@ -29,11 +29,10 @@ const (
 	// defaultAppMeshIfName is the default name of app mesh to setup iptable rules
 	// for app mesh container. IfName is mandatory field to invoke CNI plugin.
 	defaultAppMeshIfName = "aws-appmesh"
-	// defaultServiceConnectIfName is the default ifname used for invoking SC CNI plugin.
-	// IfName is a mandatory field to invoke any CNI plugin. For tasks in awsvpc mode, the network configuration
-	// does not need the ifname so this is simply a placeholder. For tasks in bridge mode, the configuration does
-	// require the ifname, and we use "eth0" because that's the default interface for docker bridge container network.
-	defaultServiceConnectIfName = "eth0"
+	// defaultServiceConnectIfName is the default ifname used for invoking ServiceConnect CNI plugin.
+	// Even though the actual SC netns configuration does not require IfName, we still need to pass in a placeholder
+	// value because IfName is a mandatory field to invoke any CNI plugin.
+	defaultServiceConnectIfName = "ecs-serviceconnect"
 	// ECSIPAMPluginName is the binary of the ipam plugin
 	ECSIPAMPluginName = "ecs-ipam"
 	// ECSBridgePluginName is the binary of the bridge plugin

--- a/agent/ecscni/types_linux.go
+++ b/agent/ecscni/types_linux.go
@@ -29,6 +29,9 @@ const (
 	// defaultAppMeshIfName is the default name of app mesh to setup iptable rules
 	// for app mesh container. IfName is mandatory field to invoke CNI plugin.
 	defaultAppMeshIfName = "aws-appmesh"
+	// defaultServiceConnectIfName is the default ifname used for invoking SC CNI plugin.
+	// IfName is a mandatory field to invoke any CNI plugin. But it's not actually used in this case.
+	defaultServiceConnectIfName = "ecs-serviceconnect"
 	// ECSIPAMPluginName is the binary of the ipam plugin
 	ECSIPAMPluginName = "ecs-ipam"
 	// ECSBridgePluginName is the binary of the bridge plugin
@@ -39,6 +42,8 @@ const (
 	ECSAppMeshPluginName = "aws-appmesh"
 	// ECSBranchENIPluginName is the binary of the branch-eni plugin
 	ECSBranchENIPluginName = "vpc-branch-eni"
+	// ECSServiceConnectPluginName is the binary of the service connect plugin
+	ECSServiceConnectPluginName = "ecs-serviceconnect"
 	// NetnsFormat is used to construct the path to cotainer network namespace
 	NetnsFormat = "/host/proc/%s/ns/net"
 )
@@ -159,4 +164,40 @@ type BranchENIConfig struct {
 	BlockInstanceMetadata bool `json:"blockInstanceMetadata"`
 	// InterfaceType is the type of the interface to connect the branch ENI to
 	InterfaceType string `json:"interfaceType,omitempty"`
+}
+
+type ServiceConnectConfig struct {
+	// CNIVersion is the CNI spec version to use
+	CNIVersion string `json:"cniVersion,omitempty"`
+	// Name is the CNI network name
+	Name string `json:"name,omitempty"`
+	// Type is the CNI plugin name
+	Type string `json:"type,omitempty"`
+
+	// IngressConfig (optional) specifies the netfilter rules to be set for incoming requests.
+	IngressConfig []IngressConfigJSONEntry `json:"ingressConfig,omitempty"`
+	// EgressConfig (optional) specifies the netfilter rules to be set for outgoing requests.
+	EgressConfig *EgressConfigJSON `json:"egressConfig,omitempty"`
+	// EnableIPv4 (optional) specifies whether to set the rules in IPV4 table. Default value is false.
+	EnableIPv4 bool `json:"enableIPv4,omitempty"`
+	// EnableIPv6 (optional) specifies whether to set the rules in IPV6 table. Default value is false.
+	EnableIPv6 bool `json:"enableIPv6,omitempty"`
+}
+
+// IngressConfig defines the ingress network config in JSON format for the ecs-serviceconnect CNI plugin.
+type IngressConfigJSONEntry struct {
+	ListenerPort  uint16 `json:"listenerPort"`
+	InterceptPort uint16 `json:"interceptPort,omitempty"`
+}
+
+// EgressConfig defines the egress network config in JSON format for the ecs-serviceconnect CNI plugin.
+type EgressConfigJSON struct {
+	ListenerPort uint16        `json:"listenerPort"`
+	VIP          VIPConfigJSON `json:"vip"`
+}
+
+// vipConfig defines the EgressVIP network config in JSON format for the ecs-serviceconnect CNI plugin.
+type VIPConfigJSON struct {
+	IPv4CIDR string `json:"ipv4Cidr,omitempty"`
+	IPv6CIDR string `json:"ipv6Cidr,omitempty"`
 }

--- a/agent/ecscni/types_linux.go
+++ b/agent/ecscni/types_linux.go
@@ -30,8 +30,10 @@ const (
 	// for app mesh container. IfName is mandatory field to invoke CNI plugin.
 	defaultAppMeshIfName = "aws-appmesh"
 	// defaultServiceConnectIfName is the default ifname used for invoking SC CNI plugin.
-	// IfName is a mandatory field to invoke any CNI plugin. But it's not actually used in this case.
-	defaultServiceConnectIfName = "ecs-serviceconnect"
+	// IfName is a mandatory field to invoke any CNI plugin. For tasks in awsvpc mode, the network configuration
+	// does not need the ifname so this is simply a placeholder. For tasks in bridge mode, the configuration does
+	// require the ifname, and we use "eth0" because that's the default interface for docker bridge container network.
+	defaultServiceConnectIfName = "eth0"
 	// ECSIPAMPluginName is the binary of the ipam plugin
 	ECSIPAMPluginName = "ecs-ipam"
 	// ECSBridgePluginName is the binary of the bridge plugin

--- a/scripts/dockerfiles/Dockerfile.buildVPCCNIPlugins
+++ b/scripts/dockerfiles/Dockerfile.buildVPCCNIPlugins
@@ -27,4 +27,4 @@ RUN mkdir -p /go/src/github.com/aws/
 
 WORKDIR /go/src/github.com/aws/amazon-vpc-cni-plugins
 
-CMD ["make", "aws-appmesh", "vpc-branch-eni"]
+CMD ["make", "aws-appmesh", "vpc-branch-eni", "ecs-serviceconnect"]

--- a/scripts/dockerfiles/Dockerfile.buildVPCCNIPlugins
+++ b/scripts/dockerfiles/Dockerfile.buildVPCCNIPlugins
@@ -19,7 +19,8 @@ ARG GOARCH
 
 ENV GOARCH ${GOARCH}
 ENV XDG_CACHE_HOME /tmp
-ENV GOPROXY https://proxy.golang.org|direct
+
+ENV GOFLAGS=-mod=vendor
 
 RUN mkdir -p /go/src/github.com/aws/
 

--- a/scripts/dockerfiles/Dockerfile.buildVPCCNIPlugins
+++ b/scripts/dockerfiles/Dockerfile.buildVPCCNIPlugins
@@ -18,10 +18,8 @@ MAINTAINER Amazon Web Services, Inc.
 ARG GOARCH
 
 ENV GOARCH ${GOARCH}
-
 ENV XDG_CACHE_HOME /tmp
-
-ENV GOFLAGS=-mod=vendor
+ENV GOPROXY https://proxy.golang.org|direct
 
 RUN mkdir -p /go/src/github.com/aws/
 

--- a/scripts/dockerfiles/Dockerfile.buildWindowsVPCCNIPlugins
+++ b/scripts/dockerfiles/Dockerfile.buildWindowsVPCCNIPlugins
@@ -19,6 +19,8 @@ ARG GOARCH
 
 ENV GOARCH ${GOARCH}
 ENV GOOS windows
+ENV XDG_CACHE_HOME /tmp
+ENV GOPROXY https://proxy.golang.org|direct
 
 RUN mkdir -p /go/src/github.com/aws/
 

--- a/scripts/dockerfiles/Dockerfile.buildWindowsVPCCNIPlugins
+++ b/scripts/dockerfiles/Dockerfile.buildWindowsVPCCNIPlugins
@@ -19,8 +19,6 @@ ARG GOARCH
 
 ENV GOARCH ${GOARCH}
 ENV GOOS windows
-ENV XDG_CACHE_HOME /tmp
-ENV GOPROXY https://proxy.golang.org|direct
 
 RUN mkdir -p /go/src/github.com/aws/
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
ServiceConnect-enabled tasks require network namespace configurations that are performed by a new CNI plugin. This PR integrates with the new CNI plugin `ecs-serviceconnect` for AWSVPC mode. 


### Implementation details
<!-- How are the changes implemented? -->
If a task is AWSVPC mode and SC-enabled, build and append ServiceConnect network configuration such that the `ecs-serviceconnect` CNI plugin will be invoked with the supplied information. 

The configuration includes:
- ingress and egress info which comes from task payload (except the ephemeral ports which are selected by Agent)
- flags to indicate whether task is IPv4- and/or IPv6-enabled

The PR also upgrades the submodule commit for `amazon-vpc-cni-plugins` to pick up the new SC plugin.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes

Built test Agent and ran a test SC task - verified netns configuration for both default and non-default SC experience in AWSVPC network mode.

For CNI plugin build, ran `make cni-plugins` for both `TARGET_OS=linux` and `TARGET_OS=windows` - verified all CNI plugins were built successfully.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Integrate with Service Connect AWSVPC CNI plugin

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
