### PR TITLE
Added the changes to safely parse SSM parameters for windows containers.  fixes #2943

### DIFF
--- a/agent/api/task/task_windows_test.go
+++ b/agent/api/task/task_windows_test.go
@@ -19,6 +19,7 @@ package task
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"runtime"
 	"testing"
 
@@ -396,7 +397,7 @@ func TestRequiresCredentialSpecResource(t *testing.T) {
 
 func TestGetAllCredentialSpecRequirements(t *testing.T) {
 	hostConfig := "{\"SecurityOpt\": [\"credentialspec:file://gmsa_gmsa-acct.json\"]}"
-	container := &apicontainer.Container{}
+	container := &apicontainer.Container{Name: "webapp1"}
 	container.DockerConfig.HostConfig = &hostConfig
 
 	task := &Task{
@@ -404,20 +405,20 @@ func TestGetAllCredentialSpecRequirements(t *testing.T) {
 		Containers: []*apicontainer.Container{container},
 	}
 
-	allCredSpecReq := task.getAllCredentialSpecRequirements()
+	credentialSpecContainerMap := task.getAllCredentialSpecRequirements()
 
-	credentialspec := "credentialspec:file://gmsa_gmsa-acct.json"
-	expectedCredSpecReq := []string{credentialspec}
+	credentialspecFileLocation := "credentialspec:file://gmsa_gmsa-acct.json"
+	expectedCredentialSpecContainerMap := map[string]string{credentialspecFileLocation: "webapp1"}
 
-	assert.EqualValues(t, expectedCredSpecReq, allCredSpecReq)
+	assert.True(t, reflect.DeepEqual(expectedCredentialSpecContainerMap, credentialSpecContainerMap))
 }
 
 func TestGetAllCredentialSpecRequirementsWithMultipleContainersUsingSameSpec(t *testing.T) {
 	hostConfig := "{\"SecurityOpt\": [\"credentialspec:file://gmsa_gmsa-acct.json\"]}"
-	c1 := &apicontainer.Container{}
+	c1 := &apicontainer.Container{Name: "webapp1"}
 	c1.DockerConfig.HostConfig = &hostConfig
 
-	c2 := &apicontainer.Container{}
+	c2 := &apicontainer.Container{Name: "webapp2"}
 	c2.DockerConfig.HostConfig = &hostConfig
 
 	task := &Task{
@@ -425,26 +426,26 @@ func TestGetAllCredentialSpecRequirementsWithMultipleContainersUsingSameSpec(t *
 		Containers: []*apicontainer.Container{c1, c2},
 	}
 
-	allCredSpecReq := task.getAllCredentialSpecRequirements()
+	credentialSpecContainerMap := task.getAllCredentialSpecRequirements()
 
-	credentialspec := "credentialspec:file://gmsa_gmsa-acct.json"
-	expectedCredSpecReq := []string{credentialspec}
+	credentialspecFileLocation := "credentialspec:file://gmsa_gmsa-acct.json"
+	expectedCredentialSpecContainerMap := map[string]string{credentialspecFileLocation: "webapp2"}
 
-	assert.Equal(t, len(expectedCredSpecReq), len(allCredSpecReq))
-	assert.EqualValues(t, expectedCredSpecReq, allCredSpecReq)
+	assert.Equal(t, len(expectedCredentialSpecContainerMap), len(credentialSpecContainerMap))
+	assert.True(t, reflect.DeepEqual(expectedCredentialSpecContainerMap, credentialSpecContainerMap))
 }
 
 func TestGetAllCredentialSpecRequirementsWithMultipleContainers(t *testing.T) {
 	hostConfig1 := "{\"SecurityOpt\": [\"credentialspec:file://gmsa_gmsa-acct-1.json\"]}"
 	hostConfig2 := "{\"SecurityOpt\": [\"credentialspec:file://gmsa_gmsa-acct-2.json\"]}"
 
-	c1 := &apicontainer.Container{}
+	c1 := &apicontainer.Container{Name: "webapp1"}
 	c1.DockerConfig.HostConfig = &hostConfig1
 
-	c2 := &apicontainer.Container{}
+	c2 := &apicontainer.Container{Name: "webapp2"}
 	c2.DockerConfig.HostConfig = &hostConfig1
 
-	c3 := &apicontainer.Container{}
+	c3 := &apicontainer.Container{Name: "webapp3"}
 	c3.DockerConfig.HostConfig = &hostConfig2
 
 	task := &Task{
@@ -452,14 +453,14 @@ func TestGetAllCredentialSpecRequirementsWithMultipleContainers(t *testing.T) {
 		Containers: []*apicontainer.Container{c1, c2, c3},
 	}
 
-	allCredSpecReq := task.getAllCredentialSpecRequirements()
+	credentialSpecContainerMap := task.getAllCredentialSpecRequirements()
 
 	credentialspec1 := "credentialspec:file://gmsa_gmsa-acct-1.json"
 	credentialspec2 := "credentialspec:file://gmsa_gmsa-acct-2.json"
 
-	expectedCredSpecReq := []string{credentialspec1, credentialspec2}
+	expectedCredentialSpecContainerMap := map[string]string{credentialspec1: "webapp2", credentialspec2: "webapp3"}
 
-	assert.EqualValues(t, expectedCredSpecReq, allCredSpecReq)
+	assert.True(t, reflect.DeepEqual(expectedCredentialSpecContainerMap, credentialSpecContainerMap))
 }
 
 func TestInitializeAndGetCredentialSpecResource(t *testing.T) {

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -25,11 +25,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
-
-	"github.com/aws/amazon-ecs-agent/agent/logger"
-	"github.com/aws/amazon-ecs-agent/agent/logger/field"
-
 	"github.com/aws/amazon-ecs-agent/agent/api"
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
@@ -47,6 +42,8 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/engine/execcmd"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
+	"github.com/aws/amazon-ecs-agent/agent/logger"
+	"github.com/aws/amazon-ecs-agent/agent/logger/field"
 	"github.com/aws/amazon-ecs-agent/agent/metrics"
 	"github.com/aws/amazon-ecs-agent/agent/statechange"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
@@ -56,9 +53,9 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/utils/retry"
 	utilsync "github.com/aws/amazon-ecs-agent/agent/utils/sync"
 	"github.com/aws/amazon-ecs-agent/agent/utils/ttime"
-	dockercontainer "github.com/docker/docker/api/types/container"
-
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/docker/docker/api/types"
+	dockercontainer "github.com/docker/docker/api/types/container"
 	"github.com/pkg/errors"
 )
 

--- a/agent/engine/docker_task_engine_windows.go
+++ b/agent/engine/docker_task_engine_windows.go
@@ -19,11 +19,10 @@ package engine
 import (
 	"time"
 
-	"github.com/aws/amazon-ecs-agent/agent/logger"
-	"github.com/aws/amazon-ecs-agent/agent/logger/field"
-
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
+	"github.com/aws/amazon-ecs-agent/agent/logger"
+	"github.com/aws/amazon-ecs-agent/agent/logger/field"
 	"github.com/pkg/errors"
 )
 

--- a/agent/engine/docker_task_engine_windows.go
+++ b/agent/engine/docker_task_engine_windows.go
@@ -23,6 +23,7 @@ import (
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	"github.com/aws/amazon-ecs-agent/agent/logger"
 	"github.com/aws/amazon-ecs-agent/agent/logger/field"
+
 	"github.com/pkg/errors"
 )
 

--- a/agent/engine/docker_task_engine_windows_test.go
+++ b/agent/engine/docker_task_engine_windows_test.go
@@ -38,7 +38,6 @@ import (
 	mock_ssm_factory "github.com/aws/amazon-ecs-agent/agent/ssm/factory/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/credentialspec"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/docker/docker/api/types"
 	dockercontainer "github.com/docker/docker/api/types/container"
@@ -134,16 +133,14 @@ func TestCredentialSpecResourceTaskFile(t *testing.T) {
 	ssmClientCreator := mock_ssm_factory.NewMockSSMClientCreator(ctrl)
 	s3ClientCreator := mock_s3_factory.NewMockS3ClientCreator(ctrl)
 
-	credentialSpecReq := []string{credentialspecFile}
-
 	credentialSpecRes, cerr := credentialspec.NewCredentialSpecResource(
 		testTask.Arn,
 		defaultConfig.AWSRegion,
-		credentialSpecReq,
 		credentialsID,
 		credentialsManager,
 		ssmClientCreator,
-		s3ClientCreator)
+		s3ClientCreator,
+		nil)
 	assert.NoError(t, cerr)
 
 	credSpecdata := map[string]string{
@@ -215,16 +212,14 @@ func TestCredentialSpecResourceTaskFileErr(t *testing.T) {
 	ssmClientCreator := mock_ssm_factory.NewMockSSMClientCreator(ctrl)
 	s3ClientCreator := mock_s3_factory.NewMockS3ClientCreator(ctrl)
 
-	credentialSpecReq := []string{credentialspecFile}
-
 	credentialSpecRes, cerr := credentialspec.NewCredentialSpecResource(
 		testTask.Arn,
 		defaultConfig.AWSRegion,
-		credentialSpecReq,
 		credentialsID,
 		credentialsManager,
 		ssmClientCreator,
-		s3ClientCreator)
+		s3ClientCreator,
+		nil)
 	assert.NoError(t, cerr)
 
 	credSpecdata := map[string]string{

--- a/agent/engine/engine_windows_integ_test.go
+++ b/agent/engine/engine_windows_integ_test.go
@@ -50,7 +50,9 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	taskresourcevolume "github.com/aws/amazon-ecs-agent/agent/taskresource/volume"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
+
 	"github.com/aws/aws-sdk-go/aws"
+
 	"github.com/cihub/seelog"
 	"github.com/docker/docker/api/types"
 	sdkClient "github.com/docker/docker/client"

--- a/agent/engine/engine_windows_integ_test.go
+++ b/agent/engine/engine_windows_integ_test.go
@@ -29,12 +29,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
-
-	"github.com/cihub/seelog"
-
-	"github.com/docker/docker/api/types"
-
 	"github.com/aws/amazon-ecs-agent/agent/api"
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
@@ -47,6 +41,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/sdkclientfactory"
 	"github.com/aws/amazon-ecs-agent/agent/ec2"
+	"github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/engine/execcmd"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
@@ -56,6 +51,8 @@ import (
 	taskresourcevolume "github.com/aws/amazon-ecs-agent/agent/taskresource/volume"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/cihub/seelog"
+	"github.com/docker/docker/api/types"
 	sdkClient "github.com/docker/docker/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/agent/engine/engine_windows_integ_test.go
+++ b/agent/engine/engine_windows_integ_test.go
@@ -52,7 +52,6 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 
 	"github.com/aws/aws-sdk-go/aws"
-
 	"github.com/cihub/seelog"
 	"github.com/docker/docker/api/types"
 	sdkClient "github.com/docker/docker/client"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR adds the fixes to safely handle credentialSpec file creation in Windows when the ECS task definition defines a SSM parameter to be used as dockerSecurityOptions. Currently, the agent has the following issues.
1. Handling hierarchical paths in SSM parameters - The current version of the code just extracts the leaf path from the hierarchy and writes a file with that name. This can create a problem on a worker node if two containers require access to an SSM parameter `a/b/c` and `x/y/c`. The current code would just write the single `c` file.
2. Handling long SSM parameter names - SSM parameters in AWS support up to 1011 characters as per the [spec](https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-paramstore-su-create.html). However, Windows only support a max path length of 260 characters and max file length of 255 characters when writing to absolute paths. The current version of the code would encounter an error when the SSM parameter name is long which results in a path longer than 260 characters in windows.

### Implementation details
<!-- How are the changes implemented? -->

In our implementation, we used the concatenated value of `{task_id}{container_name}{ssm_parameter_ARN} ` . The addition of the task_id and container_name add ample jitter to avoid collision within a host and a task for a given credentialSpec. We hashed the concatenated string using the SHA-256 algorithm to generate a digest size of 64 characters. This string was used as the name of the credential file created in the directory `c:\ProgramData\docker\credentialspecs`. Since the digest size is always a fixed length of 64 characters, this mitigates the path length issues in Windows. Also, this does not require us to refactor the deletion of the CredentialSpecs later since all of them are in the root `credentialspecs` folder.

### Testing
<!-- How was this tested? -->

Existing tests were refactored and an additional test was added to handle hierarchical SSM paths. The integration and unit tests were executed for the windows environment.

<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> Yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Bug - Fixed the creation of credentialSpec files in Windows when it is generated via SSM parameters that are hierarchical or the credentialSpec file path length is more than 260 characters.
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
