### PR TITLE
removed the ecs init spec from sources.tgz

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -357,7 +357,6 @@ get-deps-init:
 
 amazon-linux-sources.tgz:
 	./scripts/update-version.sh
-	cp packaging/amazon-linux-ami-integrated/ecs-init.spec ecs-init.spec
 	cp packaging/amazon-linux-ami-integrated/ecs-agent.spec ecs-agent.spec
 	cp packaging/amazon-linux-ami-integrated/ecs.conf ecs.conf
 	cp packaging/amazon-linux-ami-integrated/ecs.service ecs.service

--- a/packaging/amazon-linux-ami-integrated/ecs-agent.spec
+++ b/packaging/amazon-linux-ami-integrated/ecs-agent.spec
@@ -26,7 +26,7 @@
 %global agent_image ecs-agent-v%{version}.tar
 
 Name:           ecs-init
-Version:        1.60.0
+Version:        1.61.3
 Release:        1%{?dist}
 License:        Apache 2.0
 Summary:        Amazon Elastic Container Service initialization application

--- a/packaging/amazon-linux-ami-integrated/ecs-agent.spec
+++ b/packaging/amazon-linux-ami-integrated/ecs-agent.spec
@@ -40,7 +40,7 @@ Source4:        amazon-ecs-volume-plugin.socket
 Source5:        amazon-ecs-volume-plugin.conf
 
 # TODO need to update this once golang 1.17.x is available in Koji
-BuildRequires:  golang >= 1.13.0, golang < 1.16.15
+BuildRequires:  golang >= 1.18.0
 %if %{with systemd}
 BuildRequires:  systemd
 Requires:       systemd


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Remove the `ecs-init.spec` from the sources command because that file doesn't exist anymore

### Implementation details
<!-- How are the changes implemented? -->
Single line change to the makefile target

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
ran the makefile command, it worked without failing

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Bug - fixed the sources.tgz make target to account for removed file

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
