### PR TITLE
Update the BridgeMode test to be more reliable

### DIFF
--- a/agent/engine/testdata/load.go
+++ b/agent/engine/testdata/load.go
@@ -5,8 +5,10 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
+	"github.com/golang/mock/gomock"
 )
 
 func LoadTask(name string) *apitask.Task {
@@ -20,4 +22,27 @@ func LoadTask(name string) *apitask.Task {
 		panic(err)
 	}
 	return t
+}
+
+type dockerNameSubstr struct {
+	values []string
+}
+
+func (m dockerNameSubstr) Matches(arg interface{}) bool {
+	sarg := arg.(string)
+	for _, s := range m.values {
+		if !strings.Contains(sarg, s) {
+			return false
+		}
+	}
+	return true
+}
+
+// Not used here, but satisfies the Matcher interface.
+func (m dockerNameSubstr) String() string {
+	return strings.Join(m.values, ", ")
+}
+
+func DockerNameSubstr(values ...string) gomock.Matcher {
+	return dockerNameSubstr{values: values}
 }


### PR DESCRIPTION
### Summary
Set all expectations up front before running. Also tie the same operation together
with inOrder since they accept gomock.Any() which means their order isn't guaranteed.

Also if the engine describes the Agent container after start it should return HEALTHY
so that the task container will start.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
