### PR TITLE
added a condition that matches the source arn in all the trust policies

### DIFF
--- a/build-infrastructure/codebuild-devbuild-stack.yml
+++ b/build-infrastructure/codebuild-devbuild-stack.yml
@@ -245,6 +245,9 @@ Resources:
             Principal:
               Service: codebuild.amazonaws.com
             Action: 'sts:AssumeRole'
+            Condition:
+              ArnEquals:
+                'aws:SourceArn': !Sub 'arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:project/${BuildProjectName}-amd'
       Description: Service role, allow access to CW and S3
       Path: /
       Policies:
@@ -253,8 +256,8 @@ Resources:
             Statement:
               - Effect: Allow
                 Resource:
-                  - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${BuildProjectName}-amd"
-                  - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${BuildProjectName}-amd:*"
+                  - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${BuildProjectName}-amd'
+                  - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${BuildProjectName}-amd:*'
                 Action:
                   - 'logs:CreateLogGroup'
                   - 'logs:CreateLogStream'
@@ -288,6 +291,9 @@ Resources:
             Principal:
               Service: codebuild.amazonaws.com
             Action: 'sts:AssumeRole'
+            Condition:
+              ArnEquals:
+                'aws:SourceArn': !Sub 'arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:project/${BuildProjectName}-ubuntu-amd'
       Description: Service role, allow access to CW and S3
       Path: /
       Policies:
@@ -296,8 +302,8 @@ Resources:
             Statement:
               - Effect: Allow
                 Resource:
-                  - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${BuildProjectName}-ubuntu-amd"
-                  - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${BuildProjectName}-ubuntu-amd:*"
+                  - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${BuildProjectName}-ubuntu-amd'
+                  - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${BuildProjectName}-ubuntu-amd:*'
                 Action:
                   - 'logs:CreateLogGroup'
                   - 'logs:CreateLogStream'
@@ -331,6 +337,9 @@ Resources:
             Principal:
               Service: codebuild.amazonaws.com
             Action: 'sts:AssumeRole'
+            Condition:
+              ArnEquals:
+                'aws:SourceArn': !Sub 'arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:project/${BuildProjectName}-arm'
       Description: Service role, allow access to CW and S3
       Path: /
       Policies:
@@ -339,8 +348,8 @@ Resources:
             Statement:
               - Effect: Allow
                 Resource:
-                  - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${BuildProjectName}-arm"
-                  - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${BuildProjectName}-arm:*"
+                  - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${BuildProjectName}-arm'
+                  - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${BuildProjectName}-arm:*'
                 Action:
                   - 'logs:CreateLogGroup'
                   - 'logs:CreateLogStream'
@@ -374,6 +383,9 @@ Resources:
             Principal:
               Service: codebuild.amazonaws.com
             Action: 'sts:AssumeRole'
+            Condition:
+              ArnEquals:
+                'aws:SourceArn': !Sub 'arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:project/${BuildProjectName}-ubuntu-arm'
       Description: Service role, allow access to CW and S3
       Path: /
       Policies:
@@ -382,8 +394,8 @@ Resources:
             Statement:
               - Effect: Allow
                 Resource:
-                  - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${BuildProjectName}-ubuntu-arm"
-                  - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${BuildProjectName}-ubuntu-arm:*"
+                  - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${BuildProjectName}-ubuntu-arm'
+                  - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${BuildProjectName}-ubuntu-arm:*'
                 Action:
                   - 'logs:CreateLogGroup'
                   - 'logs:CreateLogStream'

--- a/build-infrastructure/minimal-signing-build-stack.yml
+++ b/build-infrastructure/minimal-signing-build-stack.yml
@@ -7,7 +7,7 @@ Parameters:
     Type: String
     Description: the name of the ECR repository to upload the signer image to
     Default: ecs-agent-signer
-  RepositoryImageRententionPeriodInDays:
+  RepositoryImageRetentionPeriodInDays:
     Type: Number
     Default: 180
   ImageCodeBuildProjectName:
@@ -82,11 +82,11 @@ Resources:
             "rules": [
               {
                 "rulePriority": 1,
-                "description": "Only keep build-yyyymmdd images for ${RepositoryImageRententionPeriodInDays} days",
+                "description": "Only keep build-yyyymmdd images for ${RepositoryImageRetentionPeriodInDays} days",
                 "selection": {
                   "countType": "sinceImagePushed",
                   "countUnit": "days",
-                  "countNumber": ${RepositoryImageRententionPeriodInDays},
+                  "countNumber": ${RepositoryImageRetentionPeriodInDays},
                   "tagStatus": "tagged",
                   "tagPrefixList": [
                     "build"
@@ -110,6 +110,9 @@ Resources:
           Principal:
             Service: codebuild.amazonaws.com
           Action: sts:AssumeRole
+          Condition:
+            ArnEquals:
+              'aws:SourceArn': !Sub 'arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:project/${ImageCodeBuildProjectName}'
       Policies:
         - PolicyName: codebuild-image-build-base-policy
           PolicyDocument:
@@ -200,6 +203,9 @@ Resources:
             Principal:
               Service: events.amazonaws.com
             Action: sts:AssumeRole
+            Condition:
+              ArnEquals:
+                'aws:SourceArn': !Sub 'arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/${PeriodicBuildTriggerName}'
       Policies:
         - PolicyName: build-event-trigger-base-policy
           PolicyDocument:

--- a/build-infrastructure/release-pipeline-stack.yml
+++ b/build-infrastructure/release-pipeline-stack.yml
@@ -134,6 +134,9 @@ Resources:
           Principal:
             Service: codebuild.amazonaws.com
           Action: sts:AssumeRole
+          Condition:
+            ArnEquals:
+              'aws:SourceArn': !Sub 'arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:project/${BuildspecsExtractCodeBuildProjectName}'
       Policies:
         - PolicyName: codebuild-buildspec-extract-base-policy
           PolicyDocument:
@@ -212,6 +215,9 @@ Resources:
           Principal:
             Service: codebuild.amazonaws.com
           Action: sts:AssumeRole
+          Condition:
+            ArnEquals:
+              'aws:SourceArn': !Sub 'arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:project/${AmdBuildCodeBuildProjectName}'
       Policies:
         - PolicyName: amd-codebuild-build-base-policy
           PolicyDocument:
@@ -253,6 +259,32 @@ Resources:
                   - codebuild:BatchPutTestCases
                   - codebuild:BatchPutCodeCoverages
 
+  AmdBuildCodeBuildProject:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Artifacts:
+        Type: CODEPIPELINE
+      ConcurrentBuildLimit: 10
+      Description: CodeBuild project to build the ECS Agent Docker image tarball and RPM
+      Environment:
+        ComputeType: BUILD_GENERAL1_SMALL
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+        ImagePullCredentialsType: CODEBUILD
+        PrivilegedMode: false
+        Type: LINUX_CONTAINER
+      LogsConfig:
+        CloudWatchLogs:
+          GroupName: !Ref CodeBuildLogGroupName
+          Status: ENABLED
+          StreamName: !Ref AmdBuildCodeBuildProjectName
+      Name: !Ref AmdBuildCodeBuildProjectName
+      QueuedTimeoutInMinutes: 60
+      ServiceRole: !Ref AmdBuildCodeBuildProjectServiceRole
+      Source:
+        BuildSpec: buildspecs/merge-build.yml
+        Type: CODEPIPELINE
+      TimeoutInMinutes: 60
+
   UbuntuAmdBuildCodeBuildProjectServiceRole:
     Type: AWS::IAM::Role
     Properties:
@@ -264,6 +296,9 @@ Resources:
           Principal:
             Service: codebuild.amazonaws.com
           Action: sts:AssumeRole
+          Condition:
+            ArnEquals:
+              'aws:SourceArn': !Sub 'arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:project/${UbuntuAmdBuildCodeBuildProjectName}'
       Policies:
         - PolicyName: ubuntu-codebuild-build-base-policy
           PolicyDocument:
@@ -305,6 +340,32 @@ Resources:
                   - codebuild:BatchPutTestCases
                   - codebuild:BatchPutCodeCoverages
 
+  UbuntuAmdBuildCodeBuildProject:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Artifacts:
+        Type: CODEPIPELINE
+      ConcurrentBuildLimit: 10
+      Description: CodeBuild project running an Ubuntu docker image to build the ECS Agent deb packages
+      Environment:
+        ComputeType: BUILD_GENERAL1_SMALL
+        Image: 'public.ecr.aws/lts/ubuntu:20.04'
+        ImagePullCredentialsType: CODEBUILD
+        PrivilegedMode: false
+        Type: LINUX_CONTAINER
+      LogsConfig:
+        CloudWatchLogs:
+          GroupName: !Ref CodeBuildLogGroupName
+          Status: ENABLED
+          StreamName: !Ref UbuntuAmdBuildCodeBuildProjectName
+      Name: !Ref UbuntuAmdBuildCodeBuildProjectName
+      QueuedTimeoutInMinutes: 60
+      ServiceRole: !Ref UbuntuAmdBuildCodeBuildProjectServiceRole
+      Source:
+        BuildSpec: buildspecs/merge-build-ubuntu.yml
+        Type: CODEPIPELINE
+      TimeoutInMinutes: 60
+
   UbuntuArmBuildCodeBuildProjectServiceRole:
     Type: AWS::IAM::Role
     Properties:
@@ -316,6 +377,9 @@ Resources:
           Principal:
             Service: codebuild.amazonaws.com
           Action: sts:AssumeRole
+          Condition:
+            ArnEquals:
+              'aws:SourceArn': !Sub 'arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:project/${UbuntuArmBuildCodeBuildProjectName}'
       Policies:
         - PolicyName: ubuntu-codebuild-build-base-policy
           PolicyDocument:
@@ -383,58 +447,6 @@ Resources:
         Type: CODEPIPELINE
       TimeoutInMinutes: 60
 
-  AmdBuildCodeBuildProject:
-    Type: AWS::CodeBuild::Project
-    Properties:
-      Artifacts:
-        Type: CODEPIPELINE
-      ConcurrentBuildLimit: 10
-      Description: CodeBuild project to build the ECS Agent Docker image tarball and RPM
-      Environment:
-        ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
-        ImagePullCredentialsType: CODEBUILD
-        PrivilegedMode: false
-        Type: LINUX_CONTAINER
-      LogsConfig:
-        CloudWatchLogs:
-          GroupName: !Ref CodeBuildLogGroupName
-          Status: ENABLED
-          StreamName: !Ref AmdBuildCodeBuildProjectName
-      Name: !Ref AmdBuildCodeBuildProjectName
-      QueuedTimeoutInMinutes: 60
-      ServiceRole: !Ref AmdBuildCodeBuildProjectServiceRole
-      Source:
-        BuildSpec: buildspecs/merge-build.yml
-        Type: CODEPIPELINE
-      TimeoutInMinutes: 60
-
-  UbuntuAmdBuildCodeBuildProject:
-    Type: AWS::CodeBuild::Project
-    Properties:
-      Artifacts:
-        Type: CODEPIPELINE
-      ConcurrentBuildLimit: 10
-      Description: CodeBuild project running an Ubuntu docker image to build the ECS Agent deb packages
-      Environment:
-        ComputeType: BUILD_GENERAL1_SMALL
-        Image: 'public.ecr.aws/lts/ubuntu:20.04'
-        ImagePullCredentialsType: CODEBUILD
-        PrivilegedMode: false
-        Type: LINUX_CONTAINER
-      LogsConfig:
-        CloudWatchLogs:
-          GroupName: !Ref CodeBuildLogGroupName
-          Status: ENABLED
-          StreamName: !Ref UbuntuAmdBuildCodeBuildProjectName
-      Name: !Ref UbuntuAmdBuildCodeBuildProjectName
-      QueuedTimeoutInMinutes: 60
-      ServiceRole: !Ref UbuntuAmdBuildCodeBuildProjectServiceRole
-      Source:
-        BuildSpec: buildspecs/merge-build-ubuntu.yml
-        Type: CODEPIPELINE
-      TimeoutInMinutes: 60
-
   ArmBuildCodeBuildProjectServiceRole:
     Type: AWS::IAM::Role
     Properties:
@@ -446,6 +458,9 @@ Resources:
           Principal:
             Service: codebuild.amazonaws.com
           Action: sts:AssumeRole
+          Condition:
+            ArnEquals:
+              'aws:SourceArn': !Sub 'arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:project/${ArmBuildCodeBuildProjectName}'
       Policies:
         - PolicyName: arm-codebuild-build-base-policy
           PolicyDocument:
@@ -524,6 +539,9 @@ Resources:
           Principal:
             Service: codebuild.amazonaws.com
           Action: sts:AssumeRole
+          Condition:
+            ArnEquals:
+              'aws:SourceArn': !Sub 'arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:project/${SigningCodeBuildProjectName}'
       Policies:
         - PolicyName: codebuild-signing-base-policy
           PolicyDocument:
@@ -643,6 +661,9 @@ Resources:
           Principal:
             Service: codebuild.amazonaws.com
           Action: sts:AssumeRole
+          Condition:
+            ArnEquals:
+              'aws:SourceArn': !Sub 'arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:project/${MakeJSONCodeBuildProjectName}'
       Policies:
         - PolicyName: codebuild-copy-base-policy
           PolicyDocument:
@@ -714,6 +735,9 @@ Resources:
           Principal:
             Service: codebuild.amazonaws.com
           Action: sts:AssumeRole
+          Condition:
+            ArnEquals:
+              'aws:SourceArn': !Sub 'arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:project/${CopyCodeBuildProjectName}'
       Policies:
         - PolicyName: codebuild-copy-base-policy
           PolicyDocument:
@@ -795,6 +819,9 @@ Resources:
           Principal:
             Service: codebuild.amazonaws.com
           Action: sts:AssumeRole
+          Condition:
+            ArnEquals:
+              'aws:SourceArn': !Sub 'arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:project/${LogsPullerCodeBuildProjectName}'
       Policies:
         - PolicyName: codebuild-logs-puller-base-policy
           PolicyDocument:
@@ -885,6 +912,9 @@ Resources:
           Principal:
             Service: codepipeline.amazonaws.com
           Action: sts:AssumeRole
+          Condition:
+            ArnEquals:
+              'aws:SourceArn': !Sub 'arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:${BuildAndSignCodePipelineName}'
       Policies:
         - PolicyName: build-and-sign-codepipeline-base-policy
           PolicyDocument:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Adds source ARN matching conditions to all the trust policies

### Implementation details
<!-- How are the changes implemented? -->
Trust policies can have a `Condition` key which is a dictionary of matcher to property and value. We use `ArnEquals` (stricter than `StringEquals`) as the matcher and we match against `aws:SourceArn`. 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
- Created a stack
- Ran the project

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Fix - added source ARN conditions to build infrastructure trust policies

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
