### PR TITLE
Integrate with Service Connect bridge-mode CNI plugin

### DIFF
--- a/agent/api/serviceconnect/service_connect.go
+++ b/agent/api/serviceconnect/service_connect.go
@@ -24,6 +24,8 @@ type Config struct {
 
 	// Admin configuration for operating with AppNet Agent
 	RuntimeConfig RuntimeConfig `json:"runtimeConfig"`
+	// NetworkConfig contains additional network information for setting up task network namespace
+	NetworkConfig NetworkConfig `json:"networkConfig"`
 }
 
 // RuntimeConfig contains the runtime information for administering AppNet Agent
@@ -34,8 +36,6 @@ type RuntimeConfig struct {
 	StatsRequest string `json:"statsRequest"`
 	// HTTP Path + Params to drain ServiceConnect connections
 	DrainRequest string `json:"drainRequest"`
-	// SC pause container IP address - used for bridge-mode CNI configuration
-	PauseContainerIPConfig *PauseContainerIPConfig `json:"pauseContainerIPConfig,omitempty"`
 }
 
 // IngressConfigEntry is the ingress configuration for a given SC service.
@@ -77,7 +77,9 @@ type DNSConfigEntry struct {
 	Address  string `json:"address"`
 }
 
-type PauseContainerIPConfig struct {
-	IPv4Addr string `json:"ipv4Addr,omitempty"`
-	IPv6Addr string `json:"ipv6Addr,omitempty"`
+// NetworkConfig contains additional network information for setting up task network namespace.
+// This includes SC pause container IP address - used for bridge-mode CNI configuration
+type NetworkConfig struct {
+	SCPauseIPv4Addr string `json:"scPauseIPv4Addr,omitempty"`
+	SCPauseIPv6Addr string `json:"scPauseIPv6Addr,omitempty"`
 }

--- a/agent/api/serviceconnect/service_connect.go
+++ b/agent/api/serviceconnect/service_connect.go
@@ -34,6 +34,8 @@ type RuntimeConfig struct {
 	StatsRequest string `json:"statsRequest"`
 	// HTTP Path + Params to drain ServiceConnect connections
 	DrainRequest string `json:"drainRequest"`
+	// SC pause container IP address - used for bridge-mode CNI configuration
+	PauseContainerIPConfig *PauseContainerIPConfig `json:"pauseContainerIPConfig,omitempty"`
 }
 
 // IngressConfigEntry is the ingress configuration for a given SC service.
@@ -73,4 +75,9 @@ type VIP struct {
 type DNSConfigEntry struct {
 	HostName string `json:"hostName"`
 	Address  string `json:"address"`
+}
+
+type PauseContainerIPConfig struct {
+	IPv4Addr string `json:"ipv4Addr,omitempty"`
+	IPv6Addr string `json:"ipv6Addr,omitempty"`
 }

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -3174,7 +3174,7 @@ func (task *Task) IsContainerServiceConnectPause(containerName string) bool {
 	if scContainer == nil {
 		return false
 	}
-	scPauseName := fmt.Sprintf("%s-%s", NetworkPauseContainerName, scContainer.Name)
+	scPauseName := fmt.Sprintf(ServiceConnectPauseContainerNameFormat, scContainer.Name)
 	return containerName == scPauseName
 }
 
@@ -3215,15 +3215,14 @@ func (task *Task) PopulateServiceConnectRuntimeConfig(serviceConnectConfig servi
 }
 
 // PopulateServiceConnectPauseIPConfig is called once we've started SC pause container and retrieved its container IPs.
-func (task *Task) PopulateServiceConnectPauseIPConfig(IPv4Addr, IPv6Addr string) {
+func (task *Task) PopulateServiceConnectNetworkConfig(ipv4Addr string, ipv6Addr string) {
 	task.lock.Lock()
 	defer task.lock.Unlock()
 
-	task.ServiceConnectConfig.RuntimeConfig.PauseContainerIPConfig =
-		&serviceconnect.PauseContainerIPConfig{
-			IPv4Addr: IPv4Addr,
-			IPv6Addr: IPv6Addr,
-		}
+	task.ServiceConnectConfig.NetworkConfig = serviceconnect.NetworkConfig{
+		SCPauseIPv4Addr: ipv4Addr,
+		SCPauseIPv6Addr: ipv6Addr,
+	}
 }
 
 func (task *Task) GetServiceConnectRuntimeConfig() serviceconnect.RuntimeConfig {
@@ -3231,6 +3230,13 @@ func (task *Task) GetServiceConnectRuntimeConfig() serviceconnect.RuntimeConfig 
 	defer task.lock.RUnlock()
 
 	return task.ServiceConnectConfig.RuntimeConfig
+}
+
+func (task *Task) GetServiceConnectNetworkConfig() serviceconnect.NetworkConfig {
+	task.lock.RLock()
+	defer task.lock.RUnlock()
+
+	return task.ServiceConnectConfig.NetworkConfig
 }
 
 func (task *Task) SetServiceConnectConnectionDraining(draining bool) {

--- a/agent/api/task/task_linux.go
+++ b/agent/api/task/task_linux.go
@@ -369,16 +369,13 @@ func (task *Task) BuildCNIConfigBridgeMode(cniConfig *ecscni.Config, containerNa
 	var ifName string
 	var err error
 
-	scPauseIPConfig := task.GetServiceConnectRuntimeConfig().PauseContainerIPConfig
-	if scPauseIPConfig == nil {
-		return nil, fmt.Errorf("failed to build CNI Bridge SC config - SC PauseContainerIPConfig cannot be nil")
-	}
+	scNetworkConfig := task.GetServiceConnectNetworkConfig()
 	ifName, netconf, err = ecscni.NewServiceConnectNetworkConfig(
 		task.ServiceConnectConfig,
 		ecscni.TPROXY,
 		!task.IsContainerServiceConnectPause(containerName),
-		scPauseIPConfig.IPv4Addr != "",
-		scPauseIPConfig.IPv6Addr != "",
+		scNetworkConfig.SCPauseIPv4Addr != "",
+		scNetworkConfig.SCPauseIPv6Addr != "",
 		cniConfig)
 	if err != nil {
 		return nil, err

--- a/agent/api/task/task_linux_test.go
+++ b/agent/api/task/task_linux_test.go
@@ -19,8 +19,11 @@ package task
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/aws/amazon-ecs-agent/agent/api/serviceconnect"
 
 	"github.com/aws/amazon-ecs-agent/agent/api/appmesh"
 	apiappmesh "github.com/aws/amazon-ecs-agent/agent/api/appmesh"
@@ -67,6 +70,16 @@ const (
 	testExecutionCredentialsID = "testExecutionCredentialsID"
 
 	defaultCPUPeriod = 100 * time.Millisecond // 100ms
+
+	scContainerName      = "service-connect"
+	scEgressListenerPort = 12345
+	scInterceptPort      = 8080
+	scListenerPort       = 15000
+	scPauseIPv4          = "172.0.0.2"
+)
+
+var (
+	scPauseContainerName = fmt.Sprintf("%s-%s", NetworkPauseContainerName, scContainerName)
 )
 
 func TestAddNetworkResourceProvisioningDependencyNop(t *testing.T) {
@@ -1283,7 +1296,7 @@ func TestBuildCNIConfigRegularENIWithAppMesh(t *testing.T) {
 					egressIgnoredIP,
 				},
 			})
-			cniConfig, err := testTask.BuildCNIConfig(true, &ecscni.Config{
+			cniConfig, err := testTask.BuildCNIConfigAwsvpc(true, &ecscni.Config{
 				BlockInstanceMetadata: blockIMDS,
 			})
 			assert.NoError(t, err)
@@ -1316,6 +1329,54 @@ func TestBuildCNIConfigRegularENIWithAppMesh(t *testing.T) {
 	}
 }
 
+func TestBuildCNIConfigRegularENIWithServiceConnect(t *testing.T) {
+	for _, blockIMDS := range []bool{true, false} {
+		t.Run(fmt.Sprintf("When BlockInstanceMetadata is %t", blockIMDS), func(t *testing.T) {
+			testTask := &Task{}
+			testTask.AddTaskENI(getTestENI())
+			testTask.ServiceConnectConfig = &serviceconnect.Config{
+				ContainerName: scContainerName,
+				IngressConfig: []serviceconnect.IngressConfigEntry{{ListenerPort: scListenerPort}},
+				EgressConfig:  &serviceconnect.EgressConfig{ListenerPort: scEgressListenerPort},
+			}
+			testTask.Containers = []*apicontainer.Container{{Name: "service-connect"}}
+
+			cniConfig, err := testTask.BuildCNIConfigAwsvpc(true, &ecscni.Config{
+				BlockInstanceMetadata: blockIMDS,
+			})
+			assert.NoError(t, err)
+			// We expect 3 NetworkConfig objects in the cni Config wrapper object:
+			// ENI, Bridge and ServiceConnect
+			require.Len(t, cniConfig.NetworkConfigs, 3)
+			// The first one should be for the ENI.
+			var eniConfig ecscni.ENIConfig
+			err = json.Unmarshal(cniConfig.NetworkConfigs[0].CNINetworkConfig.Bytes, &eniConfig)
+			require.NoError(t, err)
+			assert.Equal(t, mac, eniConfig.MACAddress, eniConfig)
+			assert.Equal(t, []string{ipv4 + ipv4Block, ipv6 + ipv6Block}, eniConfig.IPAddresses)
+			assert.Equal(t, []string{ipv4Gateway}, eniConfig.GatewayIPAddresses)
+			assert.Equal(t, blockIMDS, eniConfig.BlockInstanceMetadata)
+			// The second one should be for the Bridge.
+			var bridgeConfig ecscni.BridgeConfig
+			err = json.Unmarshal(cniConfig.NetworkConfigs[1].CNINetworkConfig.Bytes, &bridgeConfig)
+			require.NoError(t, err)
+			assert.Equal(t, "ecs-bridge", bridgeConfig.BridgeName)
+			// The third one should be for ServiceConnect.
+			var scConfig ecscni.ServiceConnectConfig
+			err = json.Unmarshal(cniConfig.NetworkConfigs[2].CNINetworkConfig.Bytes, &scConfig)
+			require.NoError(t, err)
+			assert.Equal(t, 1, len(scConfig.IngressConfig))
+			assert.Equal(t, uint16(scListenerPort), scConfig.IngressConfig[0].ListenerPort)
+			assert.NotNil(t, scConfig.EgressConfig)
+			assert.Equal(t, string(ecscni.NAT), scConfig.EgressConfig.RedirectMode)
+			assert.Equal(t, uint16(scEgressListenerPort), scConfig.EgressConfig.ListenerPort)
+			assert.Nil(t, scConfig.EgressConfig.RedirectIP) // AWSVPC mode task should not include RedirectIP
+			assert.True(t, scConfig.EnableIPv4)
+			assert.True(t, scConfig.EnableIPv6)
+		})
+	}
+}
+
 func TestBuildCNIConfigTrunkBranchENI(t *testing.T) {
 	for _, blockIMDS := range []bool{true, false} {
 		t.Run(fmt.Sprintf("When BlockInstanceMetadata is %t", blockIMDS), func(t *testing.T) {
@@ -1342,7 +1403,7 @@ func TestBuildCNIConfigTrunkBranchENI(t *testing.T) {
 				},
 			})
 
-			cniConfig, err := testTask.BuildCNIConfig(true, &ecscni.Config{
+			cniConfig, err := testTask.BuildCNIConfigAwsvpc(true, &ecscni.Config{
 				BlockInstanceMetadata: blockIMDS,
 			})
 			assert.NoError(t, err)
@@ -1364,6 +1425,74 @@ func TestBuildCNIConfigTrunkBranchENI(t *testing.T) {
 			err = json.Unmarshal(cniConfig.NetworkConfigs[1].CNINetworkConfig.Bytes, &bridgeConfig)
 			require.NoError(t, err)
 			assert.Equal(t, "ecs-bridge", bridgeConfig.BridgeName)
+		})
+	}
+}
+
+func TestBuildCNIBridgeModeWithServiceConnect(t *testing.T) {
+	for _, containerName := range []string{"other-pause", scPauseContainerName} {
+		t.Run(fmt.Sprintf("When container name is %s", containerName), func(t *testing.T) {
+			testTask := &Task{}
+			testTask.NetworkMode = BridgeNetworkMode
+			testTask.ServiceConnectConfig = &serviceconnect.Config{
+				ContainerName: scContainerName,
+				IngressConfig: []serviceconnect.IngressConfigEntry{{ListenerPort: scListenerPort}},
+				EgressConfig:  &serviceconnect.EgressConfig{ListenerPort: scEgressListenerPort},
+				RuntimeConfig: serviceconnect.RuntimeConfig{
+					PauseContainerIPConfig: &serviceconnect.PauseContainerIPConfig{
+						IPv4Addr: scPauseIPv4,
+						IPv6Addr: "",
+					},
+				},
+			}
+			testTask.Containers = []*apicontainer.Container{{Name: scContainerName}}
+
+			cniConfig := &ecscni.Config{}
+			cniConfig, err := testTask.BuildCNIConfigBridgeMode(cniConfig, containerName)
+			assert.NoError(t, err)
+			// We expect 1 NetworkConfig objects in the cni Config wrapper object which is ServiceConnect
+			require.Len(t, cniConfig.NetworkConfigs, 1)
+			// The first one should be for the ENI.
+			var scConfig ecscni.ServiceConnectConfig
+			err = json.Unmarshal(cniConfig.NetworkConfigs[0].CNINetworkConfig.Bytes, &scConfig)
+			require.NoError(t, err)
+			assert.Equal(t, 1, len(scConfig.IngressConfig))
+			assert.Equal(t, uint16(scListenerPort), scConfig.IngressConfig[0].ListenerPort)
+			assert.NotNil(t, scConfig.EgressConfig)
+			assert.Equal(t, string(ecscni.TPROXY), scConfig.EgressConfig.RedirectMode)
+			if containerName != scPauseContainerName {
+				// Should only include redirect IPs if container is an application pause container
+				assert.Equal(t, uint16(0), scConfig.EgressConfig.ListenerPort)
+				assert.Equal(t, scPauseIPv4, scConfig.EgressConfig.RedirectIP.IPv4)
+				assert.Equal(t, "", scConfig.EgressConfig.RedirectIP.IPv6)
+			} else {
+				// SC pause container should not include redirect IP in CNI config
+				assert.Equal(t, uint16(scEgressListenerPort), scConfig.EgressConfig.ListenerPort)
+				assert.Nil(t, scConfig.EgressConfig.RedirectIP)
+			}
+			assert.True(t, scConfig.EnableIPv4)
+			assert.False(t, scConfig.EnableIPv6)
+		})
+	}
+}
+
+func TestBuildCNIBridgeModeWithServiceConnect_missingPauseIPConfig(t *testing.T) {
+	for _, containerName := range []string{"other-pause", scPauseContainerName} {
+		t.Run(fmt.Sprintf("When container name is %s", containerName), func(t *testing.T) {
+			testTask := &Task{}
+			testTask.NetworkMode = BridgeNetworkMode
+			testTask.ServiceConnectConfig = &serviceconnect.Config{
+				ContainerName: scContainerName,
+				IngressConfig: []serviceconnect.IngressConfigEntry{{ListenerPort: scListenerPort}},
+				EgressConfig:  &serviceconnect.EgressConfig{ListenerPort: scEgressListenerPort},
+			}
+			testTask.Containers = []*apicontainer.Container{{Name: scContainerName}}
+
+			cniConfig := &ecscni.Config{}
+			cniConfig, err := testTask.BuildCNIConfigBridgeMode(cniConfig, containerName)
+			assert.NotNil(t, err)
+			assert.True(t, strings.Contains(err.Error(), "SC PauseContainerIPConfig cannot be nil"))
+			assert.Nil(t, cniConfig)
 		})
 	}
 }

--- a/agent/api/task/task_linux_test.go
+++ b/agent/api/task/task_linux_test.go
@@ -19,7 +19,6 @@ package task
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -1438,11 +1437,9 @@ func TestBuildCNIBridgeModeWithServiceConnect(t *testing.T) {
 				ContainerName: scContainerName,
 				IngressConfig: []serviceconnect.IngressConfigEntry{{ListenerPort: scListenerPort}},
 				EgressConfig:  &serviceconnect.EgressConfig{ListenerPort: scEgressListenerPort},
-				RuntimeConfig: serviceconnect.RuntimeConfig{
-					PauseContainerIPConfig: &serviceconnect.PauseContainerIPConfig{
-						IPv4Addr: scPauseIPv4,
-						IPv6Addr: "",
-					},
+				NetworkConfig: serviceconnect.NetworkConfig{
+					SCPauseIPv4Addr: scPauseIPv4,
+					SCPauseIPv6Addr: "",
 				},
 			}
 			testTask.Containers = []*apicontainer.Container{{Name: scContainerName}}
@@ -1472,27 +1469,6 @@ func TestBuildCNIBridgeModeWithServiceConnect(t *testing.T) {
 			}
 			assert.True(t, scConfig.EnableIPv4)
 			assert.False(t, scConfig.EnableIPv6)
-		})
-	}
-}
-
-func TestBuildCNIBridgeModeWithServiceConnect_missingPauseIPConfig(t *testing.T) {
-	for _, containerName := range []string{"other-pause", scPauseContainerName} {
-		t.Run(fmt.Sprintf("When container name is %s", containerName), func(t *testing.T) {
-			testTask := &Task{}
-			testTask.NetworkMode = BridgeNetworkMode
-			testTask.ServiceConnectConfig = &serviceconnect.Config{
-				ContainerName: scContainerName,
-				IngressConfig: []serviceconnect.IngressConfigEntry{{ListenerPort: scListenerPort}},
-				EgressConfig:  &serviceconnect.EgressConfig{ListenerPort: scEgressListenerPort},
-			}
-			testTask.Containers = []*apicontainer.Container{{Name: scContainerName}}
-
-			cniConfig := &ecscni.Config{}
-			cniConfig, err := testTask.BuildCNIConfigBridgeMode(cniConfig, containerName)
-			assert.NotNil(t, err)
-			assert.True(t, strings.Contains(err.Error(), "SC PauseContainerIPConfig cannot be nil"))
-			assert.Nil(t, cniConfig)
 		})
 	}
 }

--- a/agent/api/task/task_linux_test.go
+++ b/agent/api/task/task_linux_test.go
@@ -79,7 +79,7 @@ const (
 )
 
 var (
-	scPauseContainerName = fmt.Sprintf("%s-%s", NetworkPauseContainerName, scContainerName)
+	scPauseContainerName = fmt.Sprintf(ServiceConnectPauseContainerNameFormat, scContainerName)
 )
 
 func TestAddNetworkResourceProvisioningDependencyNop(t *testing.T) {
@@ -1339,7 +1339,7 @@ func TestBuildCNIConfigRegularENIWithServiceConnect(t *testing.T) {
 				IngressConfig: []serviceconnect.IngressConfigEntry{{ListenerPort: scListenerPort}},
 				EgressConfig:  &serviceconnect.EgressConfig{ListenerPort: scEgressListenerPort},
 			}
-			testTask.Containers = []*apicontainer.Container{{Name: "service-connect"}}
+			testTask.Containers = []*apicontainer.Container{{Name: scContainerName}}
 
 			cniConfig, err := testTask.BuildCNIConfigAwsvpc(true, &ecscni.Config{
 				BlockInstanceMetadata: blockIMDS,

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -4178,7 +4178,7 @@ func TestGetBridgeModeTaskContainerForPauseContainer(t *testing.T) {
 	testTask.Containers[0].Name = serviceContainerName
 	testTask.Containers[1].Name = fmt.Sprintf("%s-%s", NetworkPauseContainerName, serviceContainerName)
 
-	container, err := testTask.getBridgeModeTaskContainerForPauseContainer(testTask.Containers[1])
+	container, err := testTask.GetBridgeModeTaskContainerForPauseContainer(testTask.Containers[1])
 	assert.Nil(t, err)
 	assert.NotNil(t, container)
 	assert.Equal(t, testTask.Containers[0].Name, container.Name)
@@ -4187,7 +4187,7 @@ func TestGetBridgeModeTaskContainerForPauseContainer(t *testing.T) {
 func TestGetBridgeModeTaskContainerForPauseContainer_InvalidPauseContainerName(t *testing.T) {
 	testTask := getTestTaskServiceConnectBridgeMode()
 	testTask.Containers[1].Name = "invalid"
-	_, err := testTask.getBridgeModeTaskContainerForPauseContainer(testTask.Containers[1])
+	_, err := testTask.GetBridgeModeTaskContainerForPauseContainer(testTask.Containers[1])
 	assert.NotNil(t, err)
 	assert.True(t, strings.Contains(err.Error(), "does not conform to ~internal~ecs~pause-$TASK_CONTAINER_NAME format"))
 }
@@ -4195,7 +4195,7 @@ func TestGetBridgeModeTaskContainerForPauseContainer_InvalidPauseContainerName(t
 func TestGetBridgeModeTaskContainerForPauseContainer_NotFound(t *testing.T) {
 	testTask := getTestTaskServiceConnectBridgeMode()
 	testTask.Containers[0].Name = "anotherTaskContainer"
-	_, err := testTask.getBridgeModeTaskContainerForPauseContainer(testTask.Containers[1])
+	_, err := testTask.GetBridgeModeTaskContainerForPauseContainer(testTask.Containers[1])
 	assert.NotNil(t, err)
 	assert.True(t, strings.Contains(err.Error(), "could not find task container"))
 }

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -4178,7 +4178,7 @@ func TestGetBridgeModeTaskContainerForPauseContainer(t *testing.T) {
 	testTask.Containers[0].Name = serviceContainerName
 	testTask.Containers[1].Name = fmt.Sprintf("%s-%s", NetworkPauseContainerName, serviceContainerName)
 
-	container, err := testTask.GetBridgeModeTaskContainerForPauseContainer(testTask.Containers[1])
+	container, err := testTask.getBridgeModeTaskContainerForPauseContainer(testTask.Containers[1])
 	assert.Nil(t, err)
 	assert.NotNil(t, container)
 	assert.Equal(t, testTask.Containers[0].Name, container.Name)
@@ -4187,7 +4187,7 @@ func TestGetBridgeModeTaskContainerForPauseContainer(t *testing.T) {
 func TestGetBridgeModeTaskContainerForPauseContainer_InvalidPauseContainerName(t *testing.T) {
 	testTask := getTestTaskServiceConnectBridgeMode()
 	testTask.Containers[1].Name = "invalid"
-	_, err := testTask.GetBridgeModeTaskContainerForPauseContainer(testTask.Containers[1])
+	_, err := testTask.getBridgeModeTaskContainerForPauseContainer(testTask.Containers[1])
 	assert.NotNil(t, err)
 	assert.True(t, strings.Contains(err.Error(), "does not conform to ~internal~ecs~pause-$TASK_CONTAINER_NAME format"))
 }
@@ -4195,7 +4195,7 @@ func TestGetBridgeModeTaskContainerForPauseContainer_InvalidPauseContainerName(t
 func TestGetBridgeModeTaskContainerForPauseContainer_NotFound(t *testing.T) {
 	testTask := getTestTaskServiceConnectBridgeMode()
 	testTask.Containers[0].Name = "anotherTaskContainer"
-	_, err := testTask.GetBridgeModeTaskContainerForPauseContainer(testTask.Containers[1])
+	_, err := testTask.getBridgeModeTaskContainerForPauseContainer(testTask.Containers[1])
 	assert.NotNil(t, err)
 	assert.True(t, strings.Contains(err.Error(), "could not find task container"))
 }

--- a/agent/api/task/task_unsupported.go
+++ b/agent/api/task/task_unsupported.go
@@ -106,8 +106,13 @@ func (task *Task) initializeFSxWindowsFileServerResource(cfg *config.Config, cre
 	return errors.New("task with FSx for Windows File Server volumes is only supported on Windows container instance")
 }
 
-// BuildCNIConfig builds the configuration for the CNI plugins
+// BuildCNIConfigAwsvpc builds the configuration for the CNI plugins
 // On unsupported platforms, we will not support this functionality
-func (task *Task) BuildCNIConfig(includeIPAMConfig bool, cniConfig *ecscni.Config) (*ecscni.Config, error) {
+func (task *Task) BuildCNIConfigAwsvpc(includeIPAMConfig bool, cniConfig *ecscni.Config) (*ecscni.Config, error) {
+	return nil, errors.New("unsupported platform")
+}
+
+// BuildCNIConfigBridgeMode builds a list of CNI network configurations for a task in docker bridge mode.
+func (task *Task) BuildCNIConfigBridgeMode(cniConfig *ecscni.Config, containerName string) (*ecscni.Config, error) {
 	return nil, errors.New("unsupported platform")
 }

--- a/agent/api/task/task_windows.go
+++ b/agent/api/task/task_windows.go
@@ -263,8 +263,8 @@ func (task *Task) addFSxWindowsFileServerResource(
 	return nil
 }
 
-// BuildCNIConfig builds a list of CNI network configurations for the task.
-func (task *Task) BuildCNIConfig(includeIPAMConfig bool, cniConfig *ecscni.Config) (*ecscni.Config, error) {
+// BuildCNIConfigAwsvpc builds a list of CNI network configurations for the task.
+func (task *Task) BuildCNIConfigAwsvpc(includeIPAMConfig bool, cniConfig *ecscni.Config) (*ecscni.Config, error) {
 	if !task.IsNetworkModeAWSVPC() {
 		return nil, errors.New("task config: task network mode is not awsvpc")
 	}
@@ -307,4 +307,9 @@ func (task *Task) BuildCNIConfig(includeIPAMConfig bool, cniConfig *ecscni.Confi
 	})
 
 	return cniConfig, nil
+}
+
+// BuildCNIConfigBridgeMode builds a list of CNI network configurations for a task in docker bridge mode.
+func (task *Task) BuildCNIConfigBridgeMode(cniConfig *ecscni.Config, containerName string) (*ecscni.Config, error) {
+	return nil, errors.New("unsupported platform")
 }

--- a/agent/api/task/task_windows_test.go
+++ b/agent/api/task/task_windows_test.go
@@ -743,7 +743,7 @@ func TestBuildCNIConfig(t *testing.T) {
 		},
 	})
 
-	cniConfig, err := testTask.BuildCNIConfig(true, &ecscni.Config{
+	cniConfig, err := testTask.BuildCNIConfigAwsvpc(true, &ecscni.Config{
 		MinSupportedCNIVersion: "latest",
 	})
 	assert.NoError(t, err)

--- a/agent/ecscni/netconfig_linux.go
+++ b/agent/ecscni/netconfig_linux.go
@@ -176,6 +176,8 @@ func NewAppMeshConfig(appMesh *appmesh.AppMesh, cfg *Config) (string, *libcni.Ne
 // NewServiceConnectNetworkConfig creates a new ServiceConnect CNI network configuration
 func NewServiceConnectNetworkConfig(
 	scConfig *serviceconnect.Config,
+	redirectMode RedirectMode,
+	shouldIncludeRedirectIP bool,
 	enableIPv4, enableIPv6 bool,
 	cfg *Config) (string, *libcni.NetworkConfig, error) {
 	var ingressConfig []IngressConfigJSONEntry
@@ -192,11 +194,36 @@ func NewServiceConnectNetworkConfig(
 	var egressConfig *EgressConfigJSON
 	if scConfig.EgressConfig != nil {
 		egressConfig = &EgressConfigJSON{
-			ListenerPort: scConfig.EgressConfig.ListenerPort,
+			RedirectMode: string(redirectMode),
 			VIP: VIPConfigJSON{
 				IPv4CIDR: scConfig.EgressConfig.VIP.IPV4CIDR,
 				IPv6CIDR: scConfig.EgressConfig.VIP.IPV6CIDR,
 			},
+		}
+		switch redirectMode {
+		case NAT:
+			// NAT redirect mode is for awsvpc tasks, where the one and only pause container netns will have a NAT redirect rule.
+			egressConfig.ListenerPort = scConfig.EgressConfig.ListenerPort
+		case TPROXY: // bridge
+			// TPROXY redirect mode is used for bridge-mode tasks. There are two use cases:
+			// 1. SC pause container netns will set up TPROXY that requires the Egress port
+			// 2. Other task pause container netns will add a route for traffic destined for SC VIP-CIDR to go to SC container.
+			//    In that case the configuration requires the SC (pause) container IP.
+			if shouldIncludeRedirectIP {
+				scPauseIPConfig := scConfig.RuntimeConfig.PauseContainerIPConfig
+				if scPauseIPConfig == nil {
+					return "", nil, fmt.Errorf("NewServiceConnectNetworkConfig: SC pause container IP config cannot be nil")
+				}
+				egressConfig.RedirectIP = &RedirectIPJson{
+					IPv4: scPauseIPConfig.IPv4Addr,
+					IPv6: scPauseIPConfig.IPv6Addr,
+				}
+			} else {
+				// for sc pause container, pass egress listener port for setting up tproxy
+				egressConfig.ListenerPort = scConfig.EgressConfig.ListenerPort
+			}
+		default:
+			return "", nil, fmt.Errorf("NewServiceConnectNetworkConfig: unknown redirect mode %s", string(redirectMode))
 		}
 	}
 
@@ -212,6 +239,5 @@ func NewServiceConnectNetworkConfig(
 	if err != nil {
 		return "", nil, fmt.Errorf("NewServiceConnectNetworkConfig: construct the service connect network configuration failed: %w", err)
 	}
-
 	return defaultServiceConnectIfName, networkConfig, nil
 }

--- a/agent/ecscni/netconfig_linux.go
+++ b/agent/ecscni/netconfig_linux.go
@@ -178,7 +178,8 @@ func NewServiceConnectNetworkConfig(
 	scConfig *serviceconnect.Config,
 	redirectMode RedirectMode,
 	shouldIncludeRedirectIP bool,
-	enableIPv4, enableIPv6 bool,
+	enableIPv4 bool,
+	enableIPv6 bool,
 	cfg *Config) (string, *libcni.NetworkConfig, error) {
 	var ingressConfig []IngressConfigJSONEntry
 	for _, ic := range scConfig.IngressConfig {

--- a/agent/ecscni/netconfig_linux.go
+++ b/agent/ecscni/netconfig_linux.go
@@ -211,13 +211,10 @@ func NewServiceConnectNetworkConfig(
 			// 2. Other task pause container netns will add a route for traffic destined for SC VIP-CIDR to go to SC container.
 			//    In that case the configuration requires the SC (pause) container IP.
 			if shouldIncludeRedirectIP {
-				scPauseIPConfig := scConfig.RuntimeConfig.PauseContainerIPConfig
-				if scPauseIPConfig == nil {
-					return "", nil, fmt.Errorf("NewServiceConnectNetworkConfig: SC pause container IP config cannot be nil")
-				}
+				scNetworkConfig := scConfig.NetworkConfig
 				egressConfig.RedirectIP = &RedirectIPJson{
-					IPv4: scPauseIPConfig.IPv4Addr,
-					IPv6: scPauseIPConfig.IPv6Addr,
+					IPv4: scNetworkConfig.SCPauseIPv4Addr,
+					IPv6: scNetworkConfig.SCPauseIPv6Addr,
 				}
 			} else {
 				// for sc pause container, pass egress listener port for setting up tproxy

--- a/agent/ecscni/plugin_linux.go
+++ b/agent/ecscni/plugin_linux.go
@@ -71,15 +71,16 @@ func (client *cniClient) setupNS(ctx context.Context, cfg *Config) (*current.Res
 		if cniNetworkConfig.Network.Type == ECSBridgePluginName {
 			bridgeResult = result
 		}
-
 		seelog.Debugf("[ECSCNI] Completed adding network %s type %s in the container namespace %s",
 			cniNetworkConfig.Network.Name,
 			cniNetworkConfig.Network.Type,
 			cfg.ContainerID)
 	}
 
-	seelog.Debugf("[ECSCNI] Completed setting up the container namespace: %s", bridgeResult.String())
-
+	if bridgeResult == nil {
+		// Not every netns setup involves ECS Bridge Plugin
+		return nil, nil
+	}
 	if _, err := bridgeResult.GetAsVersion(currentCNISpec); err != nil {
 		seelog.Warnf("[ECSCNI] Unable to convert result to spec version %s; error: %v; result is of version: %s",
 			currentCNISpec, err, bridgeResult.Version())

--- a/agent/ecscni/plugin_linux_test.go
+++ b/agent/ecscni/plugin_linux_test.go
@@ -302,11 +302,10 @@ func defaultTestServiceConnectConfig() *serviceconnect.Config {
 			},
 		},
 		DNSConfig: nil,
-		RuntimeConfig: serviceconnect.RuntimeConfig{
-			PauseContainerIPConfig: &serviceconnect.PauseContainerIPConfig{
-				IPv4Addr: testSCPauseIPv4Addr,
-				IPv6Addr: testSCPauseIPv6Addr,
-			}},
+		NetworkConfig: serviceconnect.NetworkConfig{
+			SCPauseIPv4Addr: testSCPauseIPv4Addr,
+			SCPauseIPv6Addr: testSCPauseIPv6Addr,
+		},
 	}
 }
 

--- a/agent/ecscni/plugin_test.go
+++ b/agent/ecscni/plugin_test.go
@@ -30,7 +30,7 @@ const (
 	// ECSCNIVersion, ECSCNIGitHash, VPCCNIGitHash needs to be updated every time CNI plugin is updated.
 	currentECSCNIVersion = "2020.09.0"
 	currentECSCNIGitHash = "55b2ae77ee0bf22321b14f2d4ebbcc04f77322e1"
-	currentVPCCNIGitHash = "c3a89823446f312edfbed8375a0394773e39f807"
+	currentVPCCNIGitHash = "24d6bd87707d1b1801086fc507ebab8d32067412"
 )
 
 // Asserts that CNI plugin version matches the expected version

--- a/agent/ecscni/types_linux.go
+++ b/agent/ecscni/types_linux.go
@@ -191,13 +191,29 @@ type IngressConfigJSONEntry struct {
 	InterceptPort uint16 `json:"interceptPort,omitempty"`
 }
 
+// RedirectMode defines the type of redirection of traffic to be used.
+type RedirectMode string
+
+const (
+	NAT    RedirectMode = "nat"
+	TPROXY RedirectMode = "tproxy"
+)
+
 // EgressConfig defines the egress network config in JSON format for the ecs-serviceconnect CNI plugin.
 type EgressConfigJSON struct {
-	ListenerPort uint16        `json:"listenerPort"`
-	VIP          VIPConfigJSON `json:"vip"`
+	ListenerPort uint16          `json:"listenerPort"`
+	RedirectIP   *RedirectIPJson `json:"redirectIP"`
+	RedirectMode string          `json:"redirectMode"`
+	VIP          VIPConfigJSON   `json:"vip"`
 }
 
-// vipConfig defines the EgressVIP network config in JSON format for the ecs-serviceconnect CNI plugin.
+// RedirectIPJson defines the IP to be redirected in JSON format for the ecs-serviceconnect CNI plugin.
+type RedirectIPJson struct {
+	IPv4 string `json:"ipv4,omitempty"`
+	IPv6 string `json:"ipv6,omitempty"`
+}
+
+// VIPConfigJSON defines the EgressVIP network config in JSON format for the ecs-serviceconnect CNI plugin.
 type VIPConfigJSON struct {
 	IPv4CIDR string `json:"ipv4Cidr,omitempty"`
 	IPv6CIDR string `json:"ipv6Cidr,omitempty"`

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -1690,7 +1690,7 @@ func (engine *DockerTaskEngine) startContainer(task *apitask.Task, container *ap
 				},
 			}
 		}
-		task.PopulateServiceConnectPauseIPConfig(ipv4Addr, ipv6Addr)
+		task.PopulateServiceConnectNetworkConfig(ipv4Addr, ipv6Addr)
 	}
 
 	return dockerContainerMD

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -1681,6 +1681,11 @@ func (engine *DockerTaskEngine) startContainer(task *apitask.Task, container *ap
 		}
 	}
 
+	if task.IsServiceConnectEnabled() && task.IsNetworkModeBridge() && task.IsContainerServiceConnectPause(container.Name) {
+		ipv4Addr, ipv6Addr := getBridgeModeContainerIP(dockerContainerMD.NetworkSettings)
+		task.PopulateServiceConnectPauseIPConfig(ipv4Addr, ipv6Addr)
+	}
+
 	return dockerContainerMD
 }
 
@@ -1689,29 +1694,33 @@ func (engine *DockerTaskEngine) provisionContainerResources(task *apitask.Task, 
 		field.TaskID:    task.GetID(),
 		field.Container: container.Name,
 	})
+	if task.IsNetworkModeAWSVPC() {
+		return engine.provisionContainerResourcesAwsvpc(task, container)
+	} else if task.IsNetworkModeBridge() {
+		return engine.provisionContainerResourcesBridgeMode(task, container)
+	}
+	return dockerapi.DockerContainerMetadata{}
+}
+
+func (engine *DockerTaskEngine) provisionContainerResourcesAwsvpc(task *apitask.Task, container *apicontainer.Container) dockerapi.DockerContainerMetadata {
 	containerInspectOutput, err := engine.inspectContainer(task, container)
 	if err != nil {
 		return dockerapi.DockerContainerMetadata{
 			Error: ContainerNetworkingError{
-				fromError: errors.Wrap(err,
-					"container resource provisioning: cannot setup task network namespace due to error inspecting pause container"),
+				fromError: fmt.Errorf(
+					"container resource provisioning: cannot setup task network namespace due to error inspecting pause container: %+v", err),
 			},
 		}
 	}
 
-	if task.IsServiceConnectEnabled() && task.IsNetworkModeBridge() {
-		// TODO [SC]: CNI integration for SC bridge-mode task (need branching to handle SC pause and task container pause)
-		return dockerapi.MetadataFromContainer(containerInspectOutput)
-	}
-
 	task.SetPausePIDInVolumeResources(strconv.Itoa(containerInspectOutput.State.Pid))
 
-	cniConfig, err := engine.buildCNIConfigFromTaskContainer(task, containerInspectOutput, true)
+	cniConfig, err := engine.buildCNIConfigFromTaskContainerAwsvpc(task, containerInspectOutput, true)
 	if err != nil {
 		return dockerapi.DockerContainerMetadata{
 			Error: ContainerNetworkingError{
-				fromError: errors.Wrap(err,
-					"container resource provisioning: unable to build cni configuration"),
+				fromError: fmt.Errorf(
+					"container resource provisioning: unable to build cni configuration, %+v", err),
 			},
 		}
 	}
@@ -1725,8 +1734,19 @@ func (engine *DockerTaskEngine) provisionContainerResources(task *apitask.Task, 
 		})
 		return dockerapi.DockerContainerMetadata{
 			DockerID: cniConfig.ContainerID,
-			Error: ContainerNetworkingError{errors.Wrap(err,
-				"container resource provisioning: failed to setup network namespace")},
+			Error: ContainerNetworkingError{fmt.Errorf(
+				"container resource provisioning: failed to setup network namespace: %+v", err)},
+		}
+	}
+
+	if result == nil {
+		logger.Error("Expect non-empty result from network namespace setup", logger.Fields{
+			field.TaskID: task.GetID(),
+		})
+		return dockerapi.DockerContainerMetadata{
+			DockerID: cniConfig.ContainerID,
+			Error: ContainerNetworkingError{fmt.Errorf(
+				"container resource provisioning: empty result from network namespace setup")},
 		}
 	}
 
@@ -1749,18 +1769,67 @@ func (engine *DockerTaskEngine) provisionContainerResources(task *apitask.Task, 
 		})
 		return dockerapi.DockerContainerMetadata{
 			DockerID: cniConfig.ContainerID,
-			Error: ContainerNetworkingError{errors.Wrapf(err,
-				"container resource provisioning: failed to setup network namespace")},
+			Error: ContainerNetworkingError{fmt.Errorf(
+				"container resource provisioning: failed to setup network namespace: %+v", err)},
 		}
 	}
 
 	return dockerapi.MetadataFromContainer(containerInspectOutput)
 }
 
-// checkTearDownPauseContainerAwsvpc idempotently tears down the pause container network when the pause container's known
+func (engine *DockerTaskEngine) provisionContainerResourcesBridgeMode(task *apitask.Task, container *apicontainer.Container) dockerapi.DockerContainerMetadata {
+	if !task.IsServiceConnectEnabled() || container.Type != apicontainer.ContainerCNIPause {
+		return dockerapi.DockerContainerMetadata{
+			Error: ContainerNetworkingError{fromError: fmt.Errorf(
+				"container resource provisioning bridge mode: cannot setup netns - only valid for SC-enabled task pause container"),
+			},
+		}
+	}
+
+	containerInspectOutput, err := engine.inspectContainer(task, container)
+	if err != nil || containerInspectOutput == nil {
+		return dockerapi.DockerContainerMetadata{
+			Error: ContainerNetworkingError{fromError: fmt.Errorf(
+				"container resource provisioning bridge mode: cannot setup netns - error inspecting container %s: %+v", container.Name, err),
+			},
+		}
+	}
+
+	cniConfig, err := engine.buildCNIConfigFromTaskContainerBridgeMode(task, containerInspectOutput, container.Name)
+	if err != nil {
+		return dockerapi.DockerContainerMetadata{
+			Error: ContainerNetworkingError{fromError: fmt.Errorf(
+				"container resource provisioning bridge mode: unable to build cni configuration for container %s: %+v", container.Name, err),
+			},
+		}
+	}
+
+	// Invoke the libcni to config the network namespace for the container
+	_, err = engine.cniClient.SetupNS(engine.ctx, cniConfig, cniSetupTimeout)
+
+	if err != nil {
+		logger.Error("Unable to configure pause container namespace", logger.Fields{
+			field.TaskID:    task.GetID(),
+			field.Container: container.Name,
+			field.Error:     err,
+		})
+		return dockerapi.DockerContainerMetadata{
+			DockerID: cniConfig.ContainerID,
+			Error:    ContainerNetworkingError{fmt.Errorf("container resource provisioning: failed to setup network namespace: %+v", err)},
+		}
+	}
+
+	logger.Info("Successfully configured pause netns", logger.Fields{
+		field.TaskID:    task.GetID(),
+		field.Container: container.Name,
+	})
+	return dockerapi.MetadataFromContainer(containerInspectOutput)
+}
+
+// checkTearDownPauseContainer idempotently tears down the pause container network when the pause container's known
 //or desired status is stopped.
-func (engine *DockerTaskEngine) checkTearDownPauseContainerAwsvpc(task *apitask.Task) {
-	if !task.IsNetworkModeAWSVPC() {
+func (engine *DockerTaskEngine) checkTearDownPauseContainer(task *apitask.Task) {
+	if !task.IsNetworkModeAWSVPC() || (task.IsNetworkModeBridge() && !task.IsServiceConnectEnabled()) {
 		return
 	}
 	for _, container := range task.Containers {
@@ -1768,7 +1837,7 @@ func (engine *DockerTaskEngine) checkTearDownPauseContainerAwsvpc(task *apitask.
 		if container.Type == apicontainer.ContainerCNIPause {
 			// Clean up if the pause container has stopped or will stop
 			if container.KnownTerminal() || container.DesiredTerminal() {
-				err := engine.cleanupPauseContainerNetworkAwsvpc(task, container)
+				err := engine.cleanupPauseContainerNetwork(task, container)
 				if err != nil {
 					logger.Error("Unable to cleanup pause container network namespace", logger.Fields{
 						field.TaskID: task.GetID(),
@@ -1781,8 +1850,8 @@ func (engine *DockerTaskEngine) checkTearDownPauseContainerAwsvpc(task *apitask.
 	}
 }
 
-// cleanupPauseContainerNetworkAwsvpc will clean up the network namespace of pause container
-func (engine *DockerTaskEngine) cleanupPauseContainerNetworkAwsvpc(task *apitask.Task, container *apicontainer.Container) error {
+// cleanupPauseContainerNetwork will clean up the network namespace of pause container
+func (engine *DockerTaskEngine) cleanupPauseContainerNetwork(task *apitask.Task, container *apicontainer.Container) error {
 	// This operation is idempotent
 	if container.IsContainerTornDown() {
 		return nil
@@ -1790,8 +1859,9 @@ func (engine *DockerTaskEngine) cleanupPauseContainerNetworkAwsvpc(task *apitask
 	delay := time.Duration(engine.cfg.ENIPauseContainerCleanupDelaySeconds) * time.Second
 	if engine.handleDelay != nil && delay > 0 {
 		logger.Info("Waiting before cleaning up pause container", logger.Fields{
-			field.TaskID: task.GetID(),
-			"wait":       delay.String(),
+			field.TaskID:    task.GetID(),
+			field.Container: container.Name,
+			"wait":          delay.String(),
 		})
 		engine.handleDelay(delay)
 	}
@@ -1801,9 +1871,19 @@ func (engine *DockerTaskEngine) cleanupPauseContainerNetworkAwsvpc(task *apitask
 	}
 
 	logger.Info("Cleaning up the network namespace", logger.Fields{
-		field.TaskID: task.GetID(),
+		field.TaskID:    task.GetID(),
+		field.Container: container.Name,
 	})
-	cniConfig, err := engine.buildCNIConfigFromTaskContainer(task, containerInspectOutput, false)
+
+	var cniConfig *ecscni.Config
+	if task.IsNetworkModeAWSVPC() {
+		cniConfig, err = engine.buildCNIConfigFromTaskContainerAwsvpc(task, containerInspectOutput, false)
+	} else if task.IsNetworkModeBridge() && task.IsServiceConnectEnabled() {
+		cniConfig, err = engine.buildCNIConfigFromTaskContainerBridgeMode(task, containerInspectOutput, container.Name)
+	} else {
+		return nil
+	}
+
 	if err != nil {
 		return errors.Wrapf(err,
 			"engine: failed cleanup task network namespace, task: %s", task.String())
@@ -1816,13 +1896,14 @@ func (engine *DockerTaskEngine) cleanupPauseContainerNetworkAwsvpc(task *apitask
 
 	container.SetContainerTornDown(true)
 	logger.Info("Cleaned pause container network namespace", logger.Fields{
-		field.TaskID: task.GetID(),
+		field.TaskID:    task.GetID(),
+		field.Container: container.Name,
 	})
 	return nil
 }
 
-// buildCNIConfigFromTaskContainer builds a CNI config for the task and container.
-func (engine *DockerTaskEngine) buildCNIConfigFromTaskContainer(
+// buildCNIConfigFromTaskContainerAwsvpc builds a CNI config for the task and container in AWSVPC mode.
+func (engine *DockerTaskEngine) buildCNIConfigFromTaskContainerAwsvpc(
 	task *apitask.Task,
 	containerInspectOutput *types.ContainerJSON,
 	includeIPAMConfig bool) (*ecscni.Config, error) {
@@ -1854,7 +1935,25 @@ func (engine *DockerTaskEngine) buildCNIConfigFromTaskContainer(
 		return nil, errors.New("engine: failed to build cni configuration from the task due to invalid container network namespace")
 	}
 
-	cniConfig, err := task.BuildCNIConfig(includeIPAMConfig, cniConfig)
+	cniConfig, err := task.BuildCNIConfigAwsvpc(includeIPAMConfig, cniConfig)
+	if err != nil {
+		return nil, errors.Wrapf(err, "engine: failed to build cni configuration from task")
+	}
+
+	return cniConfig, nil
+}
+
+// buildCNIConfigFromTaskContainerBridgeMode builds a CNI config for the task and container in docker bridge mode.
+func (engine *DockerTaskEngine) buildCNIConfigFromTaskContainerBridgeMode(
+	task *apitask.Task, containerInspectOutput *types.ContainerJSON, containerName string) (*ecscni.Config, error) {
+
+	containerPid := strconv.Itoa(containerInspectOutput.State.Pid)
+	cniConfig := &ecscni.Config{
+		MinSupportedCNIVersion: config.DefaultMinSupportedCNIVersion,
+		ContainerPID:           containerPid,
+		ContainerID:            containerInspectOutput.ID,
+	}
+	cniConfig, err := task.BuildCNIConfigBridgeMode(cniConfig, containerName)
 	if err != nil {
 		return nil, errors.Wrapf(err, "engine: failed to build cni configuration from task")
 	}
@@ -1882,6 +1981,9 @@ func (engine *DockerTaskEngine) stopContainer(task *apitask.Task, container *api
 			})
 		} else {
 			task.SetServiceConnectConnectionDraining(true)
+			logger.Debug("Successfully sent drain signal to Appnet Agent", logger.Fields{
+				field.TaskID: task.GetID(),
+			})
 		}
 	}
 
@@ -1900,18 +2002,16 @@ func (engine *DockerTaskEngine) stopContainer(task *apitask.Task, container *api
 
 	// Cleanup the pause container network namespace before stop the container
 	if container.Type == apicontainer.ContainerCNIPause {
-		if task.IsNetworkModeAWSVPC() {
-			err := engine.cleanupPauseContainerNetworkAwsvpc(task, container)
+		if task.IsNetworkModeAWSVPC() || (task.IsNetworkModeBridge() && task.IsServiceConnectEnabled()) {
+			err := engine.cleanupPauseContainerNetwork(task, container)
 			if err != nil {
 				logger.Error("Unable to cleanup pause container network namespace", logger.Fields{
-					field.TaskID: task.GetID(),
-					field.Error:  err,
+					field.TaskID:    task.GetID(),
+					field.Container: container.Name,
+					field.Error:     err,
 				})
 			}
 		}
-		//else if task.IsNetworkModeBridge() && task.IsServiceConnectEnabled() {
-		//	// TODO [SC]: Pause containers in bridge mode also need cleaning up for SC-enabled tasks
-		//}
 	}
 
 	apiTimeoutStopContainer := container.GetStopTimeout()
@@ -2104,6 +2204,16 @@ func getContainerHostIP(networkSettings *types.NetworkSettings) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+func getBridgeModeContainerIP(networkSettings *types.NetworkSettings) (string, string) {
+	if networkSettings != nil &&
+		networkSettings.Networks != nil &&
+		networkSettings.Networks[apitask.BridgeNetworkMode] != nil {
+		return networkSettings.Networks[apitask.BridgeNetworkMode].IPAddress,
+			networkSettings.Networks[apitask.BridgeNetworkMode].GlobalIPv6Address
+	}
+	return "", ""
 }
 
 func (engine *DockerTaskEngine) getDockerID(task *apitask.Task, container *apicontainer.Container) (string, error) {

--- a/agent/engine/docker_task_engine_linux_test.go
+++ b/agent/engine/docker_task_engine_linux_test.go
@@ -1313,11 +1313,9 @@ func TestProvisionContainerResourcesBridgeModeWithServiceConnect(t *testing.T) {
 		ContainerName: serviceConnectContainerName,
 		IngressConfig: []serviceconnect.IngressConfigEntry{{ListenerPort: 11111}},
 		EgressConfig:  &serviceconnect.EgressConfig{ListenerPort: 22222},
-		RuntimeConfig: serviceconnect.RuntimeConfig{
-			PauseContainerIPConfig: &serviceconnect.PauseContainerIPConfig{
-				IPv4Addr: "172.0.0.1",
-				IPv6Addr: "",
-			},
+		NetworkConfig: serviceconnect.NetworkConfig{
+			SCPauseIPv4Addr: "172.0.0.1",
+			SCPauseIPv6Addr: "",
 		},
 	}
 	taskEngine.(*DockerTaskEngine).State().AddTask(testTask)

--- a/agent/engine/docker_task_engine_linux_test.go
+++ b/agent/engine/docker_task_engine_linux_test.go
@@ -1281,3 +1281,83 @@ func verifyServiceConnectPauseContainerBridgeMode(t *testing.T, ctx interface{},
 	_, ok = config.ExposedPorts["15000/tcp"]
 	assert.True(t, ok)
 }
+
+func TestProvisionContainerResourcesBridgeModeWithServiceConnect(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	ctrl, dockerClient, _, taskEngine, _, _, _, _ := mocks(t, ctx, &defaultConfig)
+	defer ctrl.Finish()
+
+	mockCNIClient := mock_ecscni.NewMockCNIClient(ctrl)
+	taskEngine.(*DockerTaskEngine).cniClient = mockCNIClient
+	testTask := testdata.LoadTask("sleep5PortMappings")
+	testTask.NetworkMode = apitask.BridgeNetworkMode
+
+	// append SC pause, application container pause, SC container
+	scContainer := &apicontainer.Container{
+		Name: serviceConnectContainerName,
+		Type: apicontainer.ContainerNormal,
+	}
+	scPauseContainer := &apicontainer.Container{
+		Name: fmt.Sprintf("%s-%s", apitask.NetworkPauseContainerName, serviceConnectContainerName),
+		Type: apicontainer.ContainerCNIPause,
+	}
+	appPauseContainer := &apicontainer.Container{
+		Name: fmt.Sprintf("%s-%s", apitask.NetworkPauseContainerName, "sleep5"),
+		Type: apicontainer.ContainerCNIPause,
+	}
+	testTask.Containers = append(testTask.Containers, scContainer, scPauseContainer, appPauseContainer)
+
+	// add task SC config
+	testTask.ServiceConnectConfig = &serviceconnect.Config{
+		ContainerName: serviceConnectContainerName,
+		IngressConfig: []serviceconnect.IngressConfigEntry{{ListenerPort: 11111}},
+		EgressConfig:  &serviceconnect.EgressConfig{ListenerPort: 22222},
+		RuntimeConfig: serviceconnect.RuntimeConfig{
+			PauseContainerIPConfig: &serviceconnect.PauseContainerIPConfig{
+				IPv4Addr: "172.0.0.1",
+				IPv6Addr: "",
+			},
+		},
+	}
+	taskEngine.(*DockerTaskEngine).State().AddTask(testTask)
+	taskEngine.(*DockerTaskEngine).State().AddContainer(&apicontainer.DockerContainer{
+		DockerID:   containerID,
+		DockerName: dockerContainerName,
+		Container:  scContainer,
+	}, testTask)
+	taskEngine.(*DockerTaskEngine).State().AddContainer(&apicontainer.DockerContainer{
+		DockerID:   containerID + scPauseContainer.Name,
+		DockerName: dockerContainerName + scPauseContainer.Name,
+		Container:  scPauseContainer,
+	}, testTask)
+	taskEngine.(*DockerTaskEngine).State().AddContainer(&apicontainer.DockerContainer{
+		DockerID:   containerID + appPauseContainer.Name,
+		DockerName: dockerContainerName + appPauseContainer.Name,
+		Container:  appPauseContainer,
+	}, testTask)
+
+	for _, cont := range []*apicontainer.Container{scPauseContainer, appPauseContainer} {
+		gomock.InOrder(
+			dockerClient.EXPECT().InspectContainer(gomock.Any(), containerID+cont.Name, gomock.Any()).Return(&types.ContainerJSON{
+				ContainerJSONBase: &types.ContainerJSONBase{
+					ID:    containerID + cont.Name,
+					State: &types.ContainerState{Pid: containerPid},
+					HostConfig: &dockercontainer.HostConfig{
+						NetworkMode: apitask.BridgeNetworkMode,
+					},
+				},
+			}, nil),
+			mockCNIClient.EXPECT().SetupNS(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+				func(ctx context.Context, cfg *ecscni.Config, timeout time.Duration) (*current.Result, error) {
+					assert.Equal(t, 1, len(cfg.NetworkConfigs))
+					var scNetworkConfig ecscni.ServiceConnectConfig
+					err := json.Unmarshal(cfg.NetworkConfigs[0].CNINetworkConfig.Bytes, &scNetworkConfig)
+					assert.NoError(t, err, "unmarshal ServiceConnect network config")
+					assert.Equal(t, string(ecscni.TPROXY), scNetworkConfig.EgressConfig.RedirectMode)
+					return nil, nil
+				}),
+		)
+		require.Nil(t, taskEngine.(*DockerTaskEngine).provisionContainerResources(testTask, cont).Error)
+	}
+}

--- a/agent/engine/docker_task_engine_windows.go
+++ b/agent/engine/docker_task_engine_windows.go
@@ -47,7 +47,7 @@ func (engine *DockerTaskEngine) invokePluginsForContainer(task *apitask.Task, co
 		return errors.Wrapf(err, "error occurred while inspecting container %v", container.Name)
 	}
 
-	cniConfig, err := engine.buildCNIConfigFromTaskContainer(task, containerInspectOutput, false)
+	cniConfig, err := engine.buildCNIConfigFromTaskContainerAwsvpc(task, containerInspectOutput, false)
 	if err != nil {
 		return errors.Wrap(err, "unable to build cni configuration")
 	}

--- a/agent/engine/docker_task_engine_windows_test.go
+++ b/agent/engine/docker_task_engine_windows_test.go
@@ -269,7 +269,7 @@ func TestBuildCNIConfigFromTaskContainer(t *testing.T) {
 		},
 	}
 
-	cniConfig, err := taskEngine.(*DockerTaskEngine).buildCNIConfigFromTaskContainer(testTask, containerInspectOutput, true)
+	cniConfig, err := taskEngine.(*DockerTaskEngine).buildCNIConfigFromTaskContainerAwsvpc(testTask, containerInspectOutput, true)
 	assert.NoError(t, err)
 	assert.Equal(t, containerID, cniConfig.ContainerID)
 	assert.Equal(t, strconv.Itoa(containerPid), cniConfig.ContainerPID)

--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -239,7 +239,7 @@ func (mtask *managedTask) overseeTask() {
 	logger.Info("Managed task has reached stopped; waiting for container cleanup", logger.Fields{
 		field.TaskID: mtask.GetID(),
 	})
-	mtask.engine.checkTearDownPauseContainerAwsvpc(mtask.Task)
+	mtask.engine.checkTearDownPauseContainer(mtask.Task)
 	// TODO [SC]: We need to also tear down pause containets in bridge mode for SC-enabled tasks
 	mtask.cleanupCredentials()
 	if mtask.StopSequenceNumber != 0 {
@@ -754,7 +754,7 @@ func (mtask *managedTask) releaseIPInIPAM() {
 		field.TaskID: mtask.GetID(),
 	})
 
-	cfg, err := mtask.BuildCNIConfig(true, &ecscni.Config{
+	cfg, err := mtask.BuildCNIConfigAwsvpc(true, &ecscni.Config{
 		MinSupportedCNIVersion: config.DefaultMinSupportedCNIVersion,
 	})
 	if err != nil {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
ServiceConnect-enabled tasks require network namespace configurations that are performed by a new CNI plugin. This PR integrates with the new CNI plugin `ecs-serviceconnect` for bridge-mode tasks.

### Implementation details
<!-- How are the changes implemented? -->
In the previous PR https://github.com/aws/amazon-ecs-agent/pull/3255 where we integrated with SC CNI plugin for awsvpc tasks we've already added new SC CNI config models. 

In this PR, a new `RedirectMode` CNI config parameter is introduced. The value will be `NAT` and `TPROXY` for awsvpc and bridge-mode tasks respectively. Additionally, a `RedirectIP` field is introduced for further distinguishing one of the two scenarios for bridge mode netns setup.

For bridge-mode SC-enabled tasks, one pause container will be created for each task container, including both appnet and customer container. Depending on CNI configuration parameters the plugin will do one of two things
1. If `EgressConfig.RedirectIP` is included, create an IP route to redirect traffic destined to SC VIPs to the specified redirect IP (which will be AppNet container IP). **This is the configuration for customer pause containers.**
2. If `EgressConfig.ListenerPort` is included, set up a TPROXY. **This is the configuration for AppNet pause containers.**

In order for other task pause containers to be able to access AppNet container IP (i.e. the `RedirectIP`) during their netns setup. A `PauseContainerIPConfig` property is added to service connect `NetworkConfig`. The IP addresses will be populated once AppNet pause container is started.

TODO - Update engine `TestContainersWithServiceConnect_BridgeMode` test to be more reliable (https://github.com/aws/amazon-ecs-agent/pull/3262)

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Integrate with Service Connect bridge-mode CNI plugin

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
