### PR TITLE
Add instance-level disconnect capability

### DIFF
--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -596,6 +596,7 @@ func environmentConfig() (Config, error) {
 		EnableRuntimeStats:                  parseBooleanDefaultFalseConfig("ECS_ENABLE_RUNTIME_STATS"),
 		ShouldExcludeIPv6PortBinding:        parseBooleanDefaultTrueConfig("ECS_EXCLUDE_IPV6_PORTBINDING"),
 		WarmPoolsSupport:                    parseBooleanDefaultFalseConfig("ECS_WARM_POOLS_CHECK"),
+		DisconnectCapable:                   parseBooleanDefaultFalseConfig("ECS_DISCONNECT_CAPABLE"),
 	}, err
 }
 
@@ -629,7 +630,8 @@ func (cfg *Config) String() string {
 			"DependentContainersPullUpfront: %v, "+
 			"TaskCPUMemLimit: %v, "+
 			"ShouldExcludeIPv6PortBinding: %v, "+
-			"%s",
+			"%s"+
+			"DisconnectCapable : %v",
 		cfg.Cluster,
 		cfg.AWSRegion,
 		cfg.DataDir,
@@ -648,5 +650,6 @@ func (cfg *Config) String() string {
 		cfg.TaskCPUMemLimit,
 		cfg.ShouldExcludeIPv6PortBinding,
 		cfg.platformString(),
+		cfg.DisconnectCapable,
 	)
 }

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -630,8 +630,8 @@ func (cfg *Config) String() string {
 			"DependentContainersPullUpfront: %v, "+
 			"TaskCPUMemLimit: %v, "+
 			"ShouldExcludeIPv6PortBinding: %v, "+
-			"%s"+
-			"DisconnectCapable : %v",
+			"DisconnectCapable : %v"+
+			"%s",
 		cfg.Cluster,
 		cfg.AWSRegion,
 		cfg.DataDir,
@@ -649,7 +649,7 @@ func (cfg *Config) String() string {
 		cfg.DependentContainersPullUpfront,
 		cfg.TaskCPUMemLimit,
 		cfg.ShouldExcludeIPv6PortBinding,
-		cfg.platformString(),
 		cfg.DisconnectCapable,
+		cfg.platformString(),
 	)
 }

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -160,6 +160,7 @@ func TestEnvironmentConfig(t *testing.T) {
 	defer setTestEnv("ECS_ENABLE_RUNTIME_STATS", "true")()
 	defer setTestEnv("ECS_EXCLUDE_IPV6_PORTBINDING", "true")()
 	defer setTestEnv("ECS_WARM_POOLS_CHECK", "false")()
+	defer setTestEnv("ECS_DISCONNECT_CAPABLE", "true")()
 	additionalLocalRoutesJSON := `["1.2.3.4/22","5.6.7.8/32"]`
 	setTestEnv("ECS_AWSVPC_ADDITIONAL_LOCAL_ROUTES", additionalLocalRoutesJSON)
 	setTestEnv("ECS_ENABLE_CONTAINER_METADATA", "true")
@@ -219,6 +220,7 @@ func TestEnvironmentConfig(t *testing.T) {
 	assert.True(t, conf.EnableRuntimeStats.Enabled(), "Wrong value for EnableRuntimeStats")
 	assert.True(t, conf.ShouldExcludeIPv6PortBinding.Enabled(), "Wrong value for ShouldExcludeIPv6PortBinding")
 	assert.False(t, conf.WarmPoolsSupport.Enabled(), "Wrong value for WarmPoolsSupport")
+	assert.True(t, conf.DisconnectCapable.Enabled(), "Wrong value for DisconnectCapable")
 }
 
 func TestTrimWhitespaceWhenCreating(t *testing.T) {

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -358,4 +358,7 @@ type Config struct {
 	// WarmPoolsSupport specifies whether the agent should poll IMDS to check the target lifecycle state for a starting
 	// instance
 	WarmPoolsSupport BooleanDefaultFalse
+
+	// DisconnectCapable specifies whether instance has capability to be disconnected from the control plane
+	DisconnectCapable BooleanDefaultFalse
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Adds instance-level disconnection capability

### Implementation details
<!-- How are the changes implemented? -->
Add ECS_DISCONNECT_CAPABLE in config/config.go

### Testing
<!-- How was this tested? -->
Set ECS_DISCONNECT_CAPABLE in ecs.config and inspected the logs to see if it is enabled

<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->
Yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Feature - Add instance-level disconnection capability ECS_DISCONNECT_CAPABLE

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
