### PR TITLE
removed building the pause container because we already have that built

### DIFF
--- a/packaging/amazon-linux-ami-integrated/ecs-agent.spec
+++ b/packaging/amazon-linux-ami-integrated/ecs-agent.spec
@@ -160,7 +160,6 @@ required routes among its preparation steps.
 
 %build
 # each of these should build for arm and amd arch
-./scripts/build-pause
 ./scripts/get-host-certs
 ./scripts/build-cni-plugins
 ./scripts/build-integrated true "" false true
@@ -715,4 +714,3 @@ fi
 
 * Mon Dec 15 2014 Samuel Karp <skarp@amazon.com> - 0.2-1
 - Naive update functionality
-


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
- don't build the pause container because we already build that

### Implementation details
<!-- How are the changes implemented? -->
- removed the pause container script from the `ecs-agent` spec file

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
- ran the packaging script
- tested with package builder

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
fix: skip pause container build because we have it built

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
