### PR TITLE
Collect and publish Service Connect metrics even when metrics gathering for tasks is explicitly disabled

### DIFF
--- a/agent/tcs/client/client.go
+++ b/agent/tcs/client/client.go
@@ -116,9 +116,8 @@ func (cs *clientServer) Serve() error {
 	cs.publishHealthTicker = time.NewTicker(cs.publishMetricsInterval)
 	cs.pullInstanceStatusTicker = time.NewTicker(cs.publishMetricsInterval)
 
-	if !cs.disableResourceMetrics {
-		go cs.publishMetrics()
-	}
+	go cs.publishMetrics()
+
 	go cs.publishHealthMetrics()
 
 	go cs.publishInstanceStatus()
@@ -188,9 +187,11 @@ func (cs *clientServer) publishMetrics() {
 				metricCounter = 0
 			}
 			cs.statsEngine.SetPublishServiceConnectTickerInterval(metricCounter)
-			err := cs.publishMetricsOnce(includeServiceConnectStats)
-			if err != nil {
-				seelog.Warnf("Error publishing metrics: %v", err)
+			if !cs.disableResourceMetrics || includeServiceConnectStats {
+				err := cs.publishMetricsOnce(includeServiceConnectStats)
+				if err != nil {
+					seelog.Warnf("Error publishing metrics: %v", err)
+				}
 			}
 		case <-cs.ctx.Done():
 			return


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Currently Service Connect metrics are collected and published to TACS when env var `ECS_DISABLE_METRICS` is false. For Service Connect enabled tasks, the expected behaviour is to publish metrics related to Service Connect by default and this PR includes changes to fix this bug.
### Implementation details
<!-- How are the changes implemented? -->
- agent/stats/engine.go - 
     - In TACS request, `Idle` attribute is set to true only when there are no container metrics or service connect metrics to be sent to TACS.
     - Update to collect SC metrics when `ECS_DISABLE_METRICS` is set and `engine.taskToServiceConnectStats` is not empty.
- agent/tcs/client/client.go - Invoke publishMetrics() irrespective of `ECS_DISABLE_METRICS` value.
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> Yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
