### PR TITLE
Add buildvcs=false for go 1.18 builds

### DIFF
--- a/scripts/build-cni-plugins
+++ b/scripts/build-cni-plugins
@@ -52,6 +52,6 @@ ln -s "${ROOT}/amazon-vpc-cni-plugins" "${GITPATH}"
 cd ${GITPATH}/amazon-ecs-cni-plugins && GO111MODULE=auto make plugins
 mkdir -p ${ROOT}/misc/plugins && cp -a ./bin/plugins/. ${ROOT}/misc/plugins/
 make clean
-cd ${GITPATH}/amazon-vpc-cni-plugins && GO111MODULE=on GOFLAGS="-mod=vendor" make aws-appmesh vpc-branch-eni
+cd ${GITPATH}/amazon-vpc-cni-plugins && GO111MODULE=on GOFLAGS="-mod=vendor -buildvcs=false" make aws-appmesh vpc-branch-eni
 cp -a ./build/linux_${GOARCH}/. ${ROOT}/misc/plugins/
 make clean


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
In order to build with 1.18, we need to update the vpc-cni-plugins to skip the vcs check which is a default auto behavior as of go 1.18:
```
go version
The go command now embeds version control information in binaries. It includes the currently checked-out revision, commit time, and a flag indicating whether edited or untracked files are present. Version control information is embedded if the go command is invoked in a directory within a Git, Mercurial, Fossil, or Bazaar repository, and the main package and its containing main module are in the same repository. This information may be omitted using the flag `-buildvcs=false`.
```
because we are building the cni-plugins from our submodule, we run into a failure with this default behavior:
```
[9:54 AM] error obtaining VCS status: exit status 128
        Use -buildvcs=false to disable VCS stamping.
make[1]: *** [build/linux_amd64/aws-appmesh] Error 1
make[1]: Leaving directory `/home/ec2-user/go/src/github.com/aws/amazon-ecs-agent/BUILD/amazon-ecs-init-1.61.3/amazon-vpc-cni-plugins'
error: Bad exit status from /var/tmp/rpm-tmp.bORv1l (%build)
```

### Implementation details
adding the `-buildvcs=false` flag to the vpc-cni-plugins build step of our script only.

### Testing
```
...
+ cd /home/ec2-user/go/src/github.com/aws/amazon-ecs-agent/BUILD
+ cd amazon-ecs-init-1.61.3
+ /usr/bin/rm -rf /home/ec2-user/go/src/github.com/aws/amazon-ecs-agent/BUILDROOT/amazon-ecs-init-1.61.3-1.x86_64
+ exit 0
find RPMS/ -type f -exec cp {} . \;
touch .generic-rpm-integrated-done
```
New tests cover the changes: no

### Description for the changelog
Disable vcs check for vpc-cni-plugin to build with go 1.18.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
