### PR TITLE
Make PublishServiceConnectTickerInterval a property of statsEngine instead of TCS websocket client

### DIFF
--- a/agent/stats/mock/engine.go
+++ b/agent/stats/mock/engine.go
@@ -82,6 +82,20 @@ func (mr *MockEngineMockRecorder) GetInstanceMetrics(arg0 interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstanceMetrics", reflect.TypeOf((*MockEngine)(nil).GetInstanceMetrics), arg0)
 }
 
+// GetPublishServiceConnectTickerInterval mocks base method
+func (m *MockEngine) GetPublishServiceConnectTickerInterval() int32 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPublishServiceConnectTickerInterval")
+	ret0, _ := ret[0].(int32)
+	return ret0
+}
+
+// GetPublishServiceConnectTickerInterval indicates an expected call of GetPublishServiceConnectTickerInterval
+func (mr *MockEngineMockRecorder) GetPublishServiceConnectTickerInterval() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPublishServiceConnectTickerInterval", reflect.TypeOf((*MockEngine)(nil).GetPublishServiceConnectTickerInterval))
+}
+
 // GetTaskHealthMetrics mocks base method
 func (m *MockEngine) GetTaskHealthMetrics() (*ecstcs.HealthMetadata, []*ecstcs.TaskHealth, error) {
 	m.ctrl.T.Helper()
@@ -96,4 +110,16 @@ func (m *MockEngine) GetTaskHealthMetrics() (*ecstcs.HealthMetadata, []*ecstcs.T
 func (mr *MockEngineMockRecorder) GetTaskHealthMetrics() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTaskHealthMetrics", reflect.TypeOf((*MockEngine)(nil).GetTaskHealthMetrics))
+}
+
+// SetPublishServiceConnectTickerInterval mocks base method
+func (m *MockEngine) SetPublishServiceConnectTickerInterval(arg0 int32) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetPublishServiceConnectTickerInterval", arg0)
+}
+
+// SetPublishServiceConnectTickerInterval indicates an expected call of SetPublishServiceConnectTickerInterval
+func (mr *MockEngineMockRecorder) SetPublishServiceConnectTickerInterval(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetPublishServiceConnectTickerInterval", reflect.TypeOf((*MockEngine)(nil).SetPublishServiceConnectTickerInterval), arg0)
 }

--- a/agent/tcs/client/client_test.go
+++ b/agent/tcs/client/client_test.go
@@ -119,6 +119,14 @@ func (*mockStatsEngine) GetTaskHealthMetrics() (*ecstcs.HealthMetadata, []*ecstc
 	return nil, nil, nil
 }
 
+func (*mockStatsEngine) GetPublishServiceConnectTickerInterval() int32 {
+	return 0
+}
+
+func (*mockStatsEngine) SetPublishServiceConnectTickerInterval(counter int32) {
+	return
+}
+
 type emptyStatsEngine struct{}
 
 func (*emptyStatsEngine) GetInstanceMetrics(includeServiceConnectStats bool) (*ecstcs.MetricsMetadata, []*ecstcs.TaskMetric, error) {
@@ -131,6 +139,14 @@ func (*emptyStatsEngine) ContainerDockerStats(taskARN string, id string) (*types
 
 func (*emptyStatsEngine) GetTaskHealthMetrics() (*ecstcs.HealthMetadata, []*ecstcs.TaskHealth, error) {
 	return nil, nil, nil
+}
+
+func (*emptyStatsEngine) GetPublishServiceConnectTickerInterval() int32 {
+	return 0
+}
+
+func (*emptyStatsEngine) SetPublishServiceConnectTickerInterval(counter int32) {
+	return
 }
 
 type idleStatsEngine struct{}
@@ -151,6 +167,14 @@ func (*idleStatsEngine) ContainerDockerStats(taskARN string, id string) (*types.
 
 func (*idleStatsEngine) GetTaskHealthMetrics() (*ecstcs.HealthMetadata, []*ecstcs.TaskHealth, error) {
 	return nil, nil, nil
+}
+
+func (*idleStatsEngine) GetPublishServiceConnectTickerInterval() int32 {
+	return 0
+}
+
+func (*idleStatsEngine) SetPublishServiceConnectTickerInterval(counter int32) {
+	return
 }
 
 type nonIdleStatsEngine struct {
@@ -179,6 +203,14 @@ func (*nonIdleStatsEngine) ContainerDockerStats(taskARN string, id string) (*typ
 
 func (*nonIdleStatsEngine) GetTaskHealthMetrics() (*ecstcs.HealthMetadata, []*ecstcs.TaskHealth, error) {
 	return nil, nil, nil
+}
+
+func (*nonIdleStatsEngine) GetPublishServiceConnectTickerInterval() int32 {
+	return 0
+}
+
+func (*nonIdleStatsEngine) SetPublishServiceConnectTickerInterval(counter int32) {
+	return
 }
 
 func newNonIdleStatsEngine(numTasks int) *nonIdleStatsEngine {
@@ -268,6 +300,14 @@ func (*serviceConnectStatsEngine) ContainerDockerStats(taskARN string, id string
 
 func (*serviceConnectStatsEngine) GetTaskHealthMetrics() (*ecstcs.HealthMetadata, []*ecstcs.TaskHealth, error) {
 	return nil, nil, nil
+}
+
+func (*serviceConnectStatsEngine) GetPublishServiceConnectTickerInterval() int32 {
+	return 0
+}
+
+func (*serviceConnectStatsEngine) SetPublishServiceConnectTickerInterval(counter int32) {
+	return
 }
 
 func newServiceConnectStatsEngine(numTasks int) *serviceConnectStatsEngine {

--- a/agent/tcs/handler/handler_test.go
+++ b/agent/tcs/handler/handler_test.go
@@ -80,6 +80,14 @@ func (*mockStatsEngine) GetTaskHealthMetrics() (*ecstcs.HealthMetadata, []*ecstc
 	return nil, nil, nil
 }
 
+func (*mockStatsEngine) GetPublishServiceConnectTickerInterval() int32 {
+	return 0
+}
+
+func (*mockStatsEngine) SetPublishServiceConnectTickerInterval(counter int32) {
+	return
+}
+
 // TestDisableMetrics tests the StartMetricsSession will return immediately if
 // the metrics was disabled
 func TestDisableMetrics(t *testing.T) {


### PR DESCRIPTION
…

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

ECS agent sends Docker stats for tasks every 20 seconds and with Service Connect feature , it will send Service Connect metrics every 60 seconds. There is a counter which increases every time we send metrics to TACS, i.e. every 20seconds. When the counter reaches to 3, we send SC metrics, as it completes 60 seconds. Initially the counter was an attribute of the TCS websocket connection client

TACS closes the websocket connection to ECS agent every now and then randomly and ECS agent reconnects immediately with a new TCS websocket connection client. Suppose, the counter was 2 when the connection was closed. ECS agent would have sent SC metrics in the next 20s interval had the connection been active. But, since the connection was closed, the counter would be reset to 0. Again, ECS agent would wait for 60s, to send SC metrics. This showed some gaps in metrics. 

That is why, this PR makes the counter a part of the statsEngine object instead of it being a part of TCS websocket connection client. statsEngine exists throughout the lifecycle of the agent. That is why when the connection is resumed, the counter will be what it was when. the connection got closed

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

Manually tested that the gaps have reduced.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
