### PR TITLE
Set UID and proper directory permission for AppNet task container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,6 +169,9 @@ run-integ-tests: test-registry gremlin container-health-check-image run-sudo-tes
 run-sudo-tests:
 	sudo -E ${GOTEST} -tags sudo -timeout=10m ./agent/...
 
+run-sudo-unit-tests:
+	sudo -E ${GOTEST} -tags 'sudo_unit' -timeout=60s ./agent/...
+
 benchmark-test:
 	go test -run=XX -bench=. ./agent/...
 

--- a/agent/api/serviceconnect/service_connect.go
+++ b/agent/api/serviceconnect/service_connect.go
@@ -13,6 +13,8 @@
 
 package serviceconnect
 
+const AppNetUID = 1337
+
 // Config represents the Service Connect configuration for a task.
 type Config struct {
 	ContainerName string               `json:"containerName"`

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -1736,6 +1736,11 @@ func (task *Task) dockerConfig(container *apicontainer.Container, apiVersion doc
 		Env:          dockerEnv,
 	}
 
+	// TODO [SC] - Move this as well as 'dockerExposedPorts' SC-specific logic into a separate file
+	if task.IsServiceConnectEnabled() && container == task.GetServiceConnectContainer() {
+		containerConfig.User = strconv.Itoa(serviceconnect.AppNetUID)
+	}
+
 	if container.DockerConfig.Config != nil {
 		if err := json.Unmarshal([]byte(aws.StringValue(container.DockerConfig.Config)), &containerConfig); err != nil {
 			return nil, &apierrors.DockerClientConfigError{Msg: "Unable decode given docker config: " + err.Error()}

--- a/agent/engine/service_connect/manager_linux_prvileged_test.go
+++ b/agent/engine/service_connect/manager_linux_prvileged_test.go
@@ -1,0 +1,10 @@
+//go:build linux && sudo_unit
+// +build linux,sudo_unit
+
+package serviceconnect
+
+import "testing"
+
+func TestAgentContainerModificationsForServiceConnect_Privileged(t *testing.T) {
+	testAgentContainerModificationsForServiceConnect(t, true)
+}

--- a/agent/engine/service_connect/manager_linux_test.go
+++ b/agent/engine/service_connect/manager_linux_test.go
@@ -17,51 +17,13 @@
 package serviceconnect
 
 import (
-	"encoding/json"
-	"fmt"
-	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/aws/amazon-ecs-agent/agent/api/serviceconnect"
 
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
-	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
-	apieni "github.com/aws/amazon-ecs-agent/agent/api/eni"
-	"github.com/aws/amazon-ecs-agent/agent/api/task"
-	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
-	"github.com/aws/amazon-ecs-agent/agent/config"
-	"github.com/aws/amazon-ecs-agent/agent/engine/testdata"
-	"github.com/aws/aws-sdk-go/aws"
 	dockercontainer "github.com/docker/docker/api/types/container"
 	"github.com/stretchr/testify/assert"
-)
-
-const (
-	ipv4        = "10.0.0.1"
-	gatewayIPv4 = "10.0.0.2/20"
-	mac         = "1.2.3.4"
-	ipv6        = "f0:234:23"
-)
-
-var (
-	cfg     config.Config
-	mockENI = &apieni.ENI{
-		ID: "eni-id",
-		IPV4Addresses: []*apieni.ENIIPV4Address{
-			{
-				Primary: true,
-				Address: ipv4,
-			},
-		},
-		MacAddress: mac,
-		IPV6Addresses: []*apieni.ENIIPV6Address{
-			{
-				Address: ipv6,
-			},
-		},
-		SubnetGatewayIPV4Address: gatewayIPv4,
-	}
 )
 
 func TestDNSConfigToDockerExtraHostsFormat(t *testing.T) {
@@ -95,57 +57,6 @@ func TestDNSConfigToDockerExtraHostsFormat(t *testing.T) {
 		res := DNSConfigToDockerExtraHostsFormat(tc.dnsConfigs)
 		assert.Equal(t, tc.expectedRestult, res, "Wrong docker host config ")
 	}
-}
-
-func getAWSVPCTask(t *testing.T) (*apitask.Task, *apicontainer.Container, *apicontainer.Container) {
-	sleepTask := testdata.LoadTask("sleep5TwoContainers")
-
-	sleepTask.ServiceConnectConfig = &serviceconnect.Config{
-		ContainerName: "service-connect",
-		DNSConfig: []serviceconnect.DNSConfigEntry{
-			{
-				HostName: "host1.my.corp",
-				Address:  "169.254.1.1",
-			},
-			{
-				HostName: "host1.my.corp",
-				Address:  "ff06::c4",
-			},
-		},
-	}
-	dockerConfig := dockercontainer.Config{
-		Healthcheck: &dockercontainer.HealthConfig{
-			Test:     []string{"echo", "ok"},
-			Interval: time.Millisecond,
-			Timeout:  time.Second,
-			Retries:  1,
-		},
-	}
-
-	pauseContainer := apicontainer.NewContainerWithSteadyState(apicontainerstatus.ContainerResourcesProvisioned)
-	pauseContainer.TransitionDependenciesMap = make(map[apicontainerstatus.ContainerStatus]apicontainer.TransitionDependencySet)
-	pauseContainer.Name = task.NetworkPauseContainerName
-	pauseContainer.Image = fmt.Sprintf("%s:%s", cfg.PauseContainerImageName, cfg.PauseContainerTag)
-	pauseContainer.Essential = true
-	pauseContainer.Type = apicontainer.ContainerCNIPause
-
-	rawConfig, err := json.Marshal(&dockerConfig)
-	if err != nil {
-		t.Fatal(err)
-	}
-	serviceConnectContainer := &apicontainer.Container{
-		Name:            sleepTask.ServiceConnectConfig.ContainerName,
-		HealthCheckType: apicontainer.DockerHealthCheckType,
-		DockerConfig: apicontainer.DockerConfig{
-			Config: aws.String(string(rawConfig)),
-		},
-		TransitionDependenciesMap: make(map[apicontainerstatus.ContainerStatus]apicontainer.TransitionDependencySet),
-	}
-	sleepTask.Containers = append(sleepTask.Containers, serviceConnectContainer)
-
-	// Add eni information to the task so the task can add dependency of pause container
-	sleepTask.AddTaskENI(mockENI)
-	return sleepTask, pauseContainer, serviceConnectContainer
 }
 
 func TestPauseContainerModificationsForServiceConnect(t *testing.T) {
@@ -188,72 +99,6 @@ func TestPauseContainerModificationsForServiceConnect(t *testing.T) {
 	}
 }
 
-func TestAgentContainerModificationsForServiceConnect(t *testing.T) {
-	scTask, _, serviceConnectContainer := getAWSVPCTask(t)
-
-	tempDir := t.TempDir()
-	expectedBinds := []string{
-		fmt.Sprintf("%s/status/%s:%s", tempDir, scTask.GetID(), "/some/other/run"),
-		fmt.Sprintf("%s:%s", tempDir, "/not/var/run"),
-	}
-	expectedENVs := map[string]string{
-		"ReLaYgOeShErE":                 "unix:///not/var/run/relay_file_of_holiness",
-		"StAtUsGoEsHeRe":                "/some/other/run/status_file_of_holiness",
-		"APPNET_AGENT_ADMIN_MODE":       "uds",
-		"ENVOY_ENABLE_IAM_AUTH_FOR_XDS": "0",
-	}
-
-	type testCase struct {
-		name          string
-		container     *apicontainer.Container
-		expectedENV   map[string]string
-		expectedBinds []string
-	}
-	testcases := []testCase{
-		{
-			name:          "Service connect container has extra binds/ENV",
-			container:     serviceConnectContainer,
-			expectedENV:   expectedENVs,
-			expectedBinds: expectedBinds,
-		},
-	}
-	// Add test cases for other containers expecting no modifications
-	for _, container := range scTask.Containers {
-		if container != serviceConnectContainer {
-			testcases = append(testcases, testCase{name: container.Name, container: container, expectedENV: map[string]string{}})
-		}
-	}
-	scManager := &manager{
-		relayPathContainer:  "/not/var/run",
-		relayPathHost:       tempDir,
-		relayFileName:       "relay_file_of_holiness",
-		relayENV:            "ReLaYgOeShErE",
-		statusPathContainer: "/some/other/run",
-		statusPathHostRoot:  filepath.Join(tempDir, "status"),
-		statusFileName:      "status_file_of_holiness",
-		statusENV:           "StAtUsGoEsHeRe",
-		adminStatsRequest:   "/give?stats",
-		adminDrainRequest:   "/do?drain",
-	}
-
-	for _, tc := range testcases {
-		t.Run(tc.name, func(t *testing.T) {
-			hostConfig := &dockercontainer.HostConfig{}
-			err := scManager.AugmentTaskContainer(scTask, tc.container, hostConfig)
-			if err != nil {
-				t.Fatal(err)
-			}
-			assert.Equal(t, tc.expectedBinds, hostConfig.Binds)
-			assert.Equal(t, tc.expectedENV, tc.container.Environment)
-
-		})
-	}
-	assert.Equal(t, scTask.ServiceConnectConfig.RuntimeConfig.AdminSocketPath, fmt.Sprintf("%s/status/%s/%s", tempDir, scTask.GetID(), "status_file_of_holiness"))
-	assert.Equal(t, scTask.ServiceConnectConfig.RuntimeConfig.StatsRequest, "/give?stats")
-	assert.Equal(t, scTask.ServiceConnectConfig.RuntimeConfig.DrainRequest, "/do?drain")
-
-	config := scTask.GetServiceConnectRuntimeConfig()
-	assert.Equal(t, config.AdminSocketPath, fmt.Sprintf("%s/status/%s/%s", tempDir, scTask.GetID(), "status_file_of_holiness"))
-	assert.Equal(t, config.StatsRequest, "/give?stats")
-	assert.Equal(t, config.DrainRequest, "/do?drain")
+func TestAgentContainerModificationsForServiceConnect_NonPrivileged(t *testing.T) {
+	testAgentContainerModificationsForServiceConnect(t, false)
 }

--- a/agent/engine/service_connect/manager_linux_test_common.go
+++ b/agent/engine/service_connect/manager_linux_test_common.go
@@ -1,0 +1,203 @@
+//go:build linux && (unit || sudo_unit)
+// +build linux
+// +build unit sudo_unit
+
+package serviceconnect
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	apieni "github.com/aws/amazon-ecs-agent/agent/api/eni"
+	"github.com/aws/amazon-ecs-agent/agent/config"
+
+	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
+	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
+	"github.com/aws/amazon-ecs-agent/agent/engine/testdata"
+	"github.com/aws/aws-sdk-go/aws"
+
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	"github.com/aws/amazon-ecs-agent/agent/api/serviceconnect"
+	dockercontainer "github.com/docker/docker/api/types/container"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	ipv4        = "10.0.0.1"
+	gatewayIPv4 = "10.0.0.2/20"
+	mac         = "1.2.3.4"
+	ipv6        = "f0:234:23"
+)
+
+var (
+	cfg     config.Config
+	mockENI = &apieni.ENI{
+		ID: "eni-id",
+		IPV4Addresses: []*apieni.ENIIPV4Address{
+			{
+				Primary: true,
+				Address: ipv4,
+			},
+		},
+		MacAddress: mac,
+		IPV6Addresses: []*apieni.ENIIPV6Address{
+			{
+				Address: ipv6,
+			},
+		},
+		SubnetGatewayIPV4Address: gatewayIPv4,
+	}
+)
+
+func mockMkdirAllAndChown(path string, perm fs.FileMode, uid, gid int) error {
+	return nil
+}
+
+func getAWSVPCTask(t *testing.T) (*apitask.Task, *apicontainer.Container, *apicontainer.Container) {
+	sleepTask := testdata.LoadTask("sleep5TwoContainers")
+
+	sleepTask.ServiceConnectConfig = &serviceconnect.Config{
+		ContainerName: "service-connect",
+		DNSConfig: []serviceconnect.DNSConfigEntry{
+			{
+				HostName: "host1.my.corp",
+				Address:  "169.254.1.1",
+			},
+			{
+				HostName: "host1.my.corp",
+				Address:  "ff06::c4",
+			},
+		},
+	}
+	dockerConfig := dockercontainer.Config{
+		Healthcheck: &dockercontainer.HealthConfig{
+			Test:     []string{"echo", "ok"},
+			Interval: time.Millisecond,
+			Timeout:  time.Second,
+			Retries:  1,
+		},
+	}
+
+	pauseContainer := apicontainer.NewContainerWithSteadyState(apicontainerstatus.ContainerResourcesProvisioned)
+	pauseContainer.TransitionDependenciesMap = make(map[apicontainerstatus.ContainerStatus]apicontainer.TransitionDependencySet)
+	pauseContainer.Name = apitask.NetworkPauseContainerName
+	pauseContainer.Image = fmt.Sprintf("%s:%s", cfg.PauseContainerImageName, cfg.PauseContainerTag)
+	pauseContainer.Essential = true
+	pauseContainer.Type = apicontainer.ContainerCNIPause
+
+	rawConfig, err := json.Marshal(&dockerConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serviceConnectContainer := &apicontainer.Container{
+		Name:            sleepTask.ServiceConnectConfig.ContainerName,
+		HealthCheckType: apicontainer.DockerHealthCheckType,
+		DockerConfig: apicontainer.DockerConfig{
+			Config: aws.String(string(rawConfig)),
+		},
+		TransitionDependenciesMap: make(map[apicontainerstatus.ContainerStatus]apicontainer.TransitionDependencySet),
+	}
+	sleepTask.Containers = append(sleepTask.Containers, serviceConnectContainer)
+
+	// Add eni information to the task so the task can add dependency of pause container
+	sleepTask.AddTaskENI(mockENI)
+	return sleepTask, pauseContainer, serviceConnectContainer
+}
+
+func testAgentContainerModificationsForServiceConnect(t *testing.T, privilegedMode bool) {
+	backupMkdirAllAndChown := mkdirAllAndChown
+	tempDir := t.TempDir()
+	if !privilegedMode {
+		mkdirAllAndChown = mockMkdirAllAndChown
+	}
+	defer func() {
+		mkdirAllAndChown = backupMkdirAllAndChown
+		os.RemoveAll(tempDir)
+	}()
+	scTask, _, serviceConnectContainer := getAWSVPCTask(t)
+
+	expectedBinds := []string{
+		fmt.Sprintf("%s/status/%s:%s", tempDir, scTask.GetID(), "/some/other/run"),
+		fmt.Sprintf("%s/relay:%s", tempDir, "/not/var/run"),
+	}
+	expectedENVs := map[string]string{
+		"ReLaYgOeShErE":                 "unix:///not/var/run/relay_file_of_holiness",
+		"StAtUsGoEsHeRe":                "/some/other/run/status_file_of_holiness",
+		"APPNET_AGENT_ADMIN_MODE":       "uds",
+		"ENVOY_ENABLE_IAM_AUTH_FOR_XDS": "0",
+	}
+
+	type testCase struct {
+		name                 string
+		container            *apicontainer.Container
+		expectedENV          map[string]string
+		expectedBinds        []string
+		expectedBindDirPerm  string
+		expectedBindDirOwner uint32
+	}
+	testcases := []testCase{
+		{
+			name:                 "Service connect container has extra binds/ENV",
+			container:            serviceConnectContainer,
+			expectedENV:          expectedENVs,
+			expectedBinds:        expectedBinds,
+			expectedBindDirPerm:  fs.FileMode(0700).String(),
+			expectedBindDirOwner: serviceconnect.AppNetUID,
+		},
+	}
+	// Add test cases for other containers expecting no modifications
+	for _, container := range scTask.Containers {
+		if container != serviceConnectContainer {
+			testcases = append(testcases, testCase{name: container.Name, container: container, expectedENV: map[string]string{}})
+		}
+	}
+	scManager := &manager{
+		relayPathContainer:  "/not/var/run",
+		relayPathHost:       filepath.Join(tempDir, "relay"),
+		relayFileName:       "relay_file_of_holiness",
+		relayENV:            "ReLaYgOeShErE",
+		statusPathContainer: "/some/other/run",
+		statusPathHostRoot:  filepath.Join(tempDir, "status"),
+		statusFileName:      "status_file_of_holiness",
+		statusENV:           "StAtUsGoEsHeRe",
+		adminStatsRequest:   "/give?stats",
+		adminDrainRequest:   "/do?drain",
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			hostConfig := &dockercontainer.HostConfig{}
+			err := scManager.AugmentTaskContainer(scTask, tc.container, hostConfig)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assert.Equal(t, tc.expectedBinds, hostConfig.Binds)
+			assert.Equal(t, tc.expectedENV, tc.container.Environment)
+			if privilegedMode {
+				for _, bind := range hostConfig.Binds {
+					hostDir := strings.Split(bind, ":")[0]
+					dirStat, err := os.Stat(hostDir)
+					assert.NoError(t, err)
+					assert.Equal(t, tc.expectedBindDirPerm, dirStat.Mode().Perm().String(),
+						fmt.Sprintf("directory %s should have mode %s", hostDir, tc.expectedBindDirPerm))
+					assert.Equal(t, tc.expectedBindDirOwner, dirStat.Sys().(*syscall.Stat_t).Uid)
+				}
+			}
+		})
+	}
+	assert.Equal(t, scTask.ServiceConnectConfig.RuntimeConfig.AdminSocketPath, fmt.Sprintf("%s/status/%s/%s", tempDir, scTask.GetID(), "status_file_of_holiness"))
+	assert.Equal(t, scTask.ServiceConnectConfig.RuntimeConfig.StatsRequest, "/give?stats")
+	assert.Equal(t, scTask.ServiceConnectConfig.RuntimeConfig.DrainRequest, "/do?drain")
+
+	config := scTask.GetServiceConnectRuntimeConfig()
+	assert.Equal(t, config.AdminSocketPath, fmt.Sprintf("%s/status/%s/%s", tempDir, scTask.GetID(), "status_file_of_holiness"))
+	assert.Equal(t, config.StatsRequest, "/give?stats")
+	assert.Equal(t, config.DrainRequest, "/do?drain")
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
By default docker container run as root. This PR enables ECS Agent to run AppNet task container as non-root user 

### Implementation details
<!-- How are the changes implemented? -->
When creating container config, we can specify the `User` [option](https://docs.docker.com/engine/reference/run/#user) to start the container with. Here we'll be using a `uid` of `1337`, which is chosen arbitrarily. 

Because AppNet container will need `rwx` permissions on the mounted directories (where AppNet will create admin socket file), we are going to make user `1337` the directory owner and assign permission `700` to the directory.

Prerequisite - Running as non-root, AppNet container needs to be able to preserve `CAP_NET_ADMIN` for Envoy process, which is needed in bridge-mode tproxy configuration. The capability is dropped from Envoy process's effective capability set by default. https://man7.org/linux/man-pages/man7/capabilities.7.html

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes

Refactored existing unit test to take in a flag for determining whether to set UID and run chmod. The flag will be true if test is run in privileged mode.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Set UID and proper directory permission for AppNet task container

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
