### PR TITLE
Adding support to launch Relay and assign task container images

### DIFF
--- a/agent/acs/update_handler/updater_test.go
+++ b/agent/acs/update_handler/updater_test.go
@@ -128,7 +128,7 @@ func TestPerformUpdateWithUpdatesDisabled(t *testing.T) {
 		Reason:            ptr("Updates are disabled").(*string),
 	}})
 
-	taskEngine := engine.NewTaskEngine(cfg, nil, nil, nil, nil, nil, nil, nil, nil)
+	taskEngine := engine.NewTaskEngine(cfg, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	msg := &ecsacs.PerformUpdateMessage{
 		ClusterArn:           ptr("cluster").(*string),
 		ContainerInstanceArn: ptr("containerInstance").(*string),
@@ -182,7 +182,7 @@ func TestFullUpdateFlow(t *testing.T) {
 
 			require.Equal(t, "update-tar-data", writtenFile.String(), "incorrect data written")
 
-			taskEngine := engine.NewTaskEngine(cfg, nil, nil, nil, nil, nil, nil, nil, nil)
+			taskEngine := engine.NewTaskEngine(cfg, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 			msg := &ecsacs.PerformUpdateMessage{
 				ClusterArn:           ptr("cluster").(*string),
 				ContainerInstanceArn: ptr("containerInstance").(*string),
@@ -250,7 +250,7 @@ func TestUndownloadedUpdate(t *testing.T) {
 		MessageId:         ptr("mid").(*string),
 	}})
 
-	taskEngine := engine.NewTaskEngine(cfg, nil, nil, nil, nil, nil, nil, nil, nil)
+	taskEngine := engine.NewTaskEngine(cfg, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	msg := &ecsacs.PerformUpdateMessage{
 		ClusterArn:           ptr("cluster").(*string),
 		ContainerInstanceArn: ptr("containerInstance").(*string),
@@ -308,7 +308,7 @@ func TestDuplicateUpdateMessagesWithSuccess(t *testing.T) {
 
 	require.Equal(t, "update-tar-data", writtenFile.String(), "incorrect data written")
 
-	taskEngine := engine.NewTaskEngine(cfg, nil, nil, nil, nil, nil, nil, nil, nil)
+	taskEngine := engine.NewTaskEngine(cfg, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	msg := &ecsacs.PerformUpdateMessage{
 		ClusterArn:           ptr("cluster").(*string),
 		ContainerInstanceArn: ptr("containerInstance").(*string),
@@ -377,7 +377,7 @@ func TestDuplicateUpdateMessagesWithFailure(t *testing.T) {
 
 	require.Equal(t, "update-tar-data", writtenFile.String(), "incorrect data written")
 
-	taskEngine := engine.NewTaskEngine(cfg, nil, nil, nil, nil, nil, nil, nil, nil)
+	taskEngine := engine.NewTaskEngine(cfg, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	msg := &ecsacs.PerformUpdateMessage{
 		ClusterArn:           ptr("cluster").(*string),
 		ContainerInstanceArn: ptr("containerInstance").(*string),
@@ -448,7 +448,7 @@ func TestNewerUpdateMessages(t *testing.T) {
 
 	require.Equal(t, "newer-update-tar-data", writtenFile.String(), "incorrect data written")
 
-	taskEngine := engine.NewTaskEngine(cfg, nil, nil, nil, nil, nil, nil, nil, nil)
+	taskEngine := engine.NewTaskEngine(cfg, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	msg := &ecsacs.PerformUpdateMessage{
 		ClusterArn:           ptr("cluster").(*string),
 		ContainerInstanceArn: ptr("containerInstance").(*string),

--- a/agent/api/container/containertype.go
+++ b/agent/api/container/containertype.go
@@ -35,6 +35,10 @@ const (
 	// sharing either PID or IPC resource namespaces. Regardless if one or
 	// both flags are used, only 1 of these containers need to be active
 	ContainerNamespacePause
+
+	// ContainerServiceConnectRelay represents the internal container type
+	// for the relay to share connections to management infrastructure.
+	ContainerServiceConnectRelay
 )
 
 // ContainerType represents the type of the internal container created

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -494,9 +494,11 @@ func (task *Task) initServiceConnectResources() error {
 			ContainerName: "service-connect",
 		}
 	}
+	// TODO [SC]: End dev/testing purposes
 	if task.IsServiceConnectEnabled() {
 		// TODO [SC]: initDummyServiceConnectConfig is for dev testing only, remove it when final SC model from ACS is in place
 		task.initDummyServiceConnectConfig()
+		// TODO [SC]: End dev/testing purposes
 		if err := task.initServiceConnectEphemeralPorts(); err != nil {
 			return err
 		}
@@ -518,6 +520,8 @@ func (task *Task) initDummyServiceConnectConfig() {
 		return
 	}
 }
+
+// TODO [SC]: End dev/testing purposes
 
 func (task *Task) initServiceConnectEphemeralPorts() error {
 	var utilizedPorts []uint16

--- a/agent/app/agent_compatibility_linux_test.go
+++ b/agent/app/agent_compatibility_linux_test.go
@@ -38,7 +38,7 @@ func init() {
 }
 
 func TestCompatibilityEnabledSuccess(t *testing.T) {
-	ctrl, creds, _, images, _, _, stateManagerFactory, saveableOptionFactory, execCmdMgr := setup(t)
+	ctrl, creds, _, images, _, _, stateManagerFactory, saveableOptionFactory, execCmdMgr, serviceConnectLoader := setup(t)
 	defer ctrl.Finish()
 	stateManager := mock_statemanager.NewMockStateManager(ctrl)
 
@@ -65,14 +65,14 @@ func TestCompatibilityEnabledSuccess(t *testing.T) {
 	defer cancel()
 
 	containerChangeEventStream := eventstream.NewEventStream("events", ctx)
-	_, _, err := agent.newTaskEngine(containerChangeEventStream, creds, dockerstate.NewTaskEngineState(), images, execCmdMgr)
+	_, _, err := agent.newTaskEngine(containerChangeEventStream, creds, dockerstate.NewTaskEngineState(), images, execCmdMgr, serviceConnectLoader)
 
 	assert.NoError(t, err)
 	assert.True(t, cfg.TaskCPUMemLimit.Enabled())
 }
 
 func TestCompatibilityNotSetFail(t *testing.T) {
-	ctrl, creds, _, images, _, _, stateManagerFactory, saveableOptionFactory, execCmdMgr := setup(t)
+	ctrl, creds, _, images, _, _, stateManagerFactory, saveableOptionFactory, execCmdMgr, serviceConnectLoader := setup(t)
 	defer ctrl.Finish()
 	stateManager := mock_statemanager.NewMockStateManager(ctrl)
 
@@ -106,14 +106,14 @@ func TestCompatibilityNotSetFail(t *testing.T) {
 	defer cancel()
 
 	containerChangeEventStream := eventstream.NewEventStream("events", ctx)
-	_, _, err := agent.newTaskEngine(containerChangeEventStream, creds, dockerstate.NewTaskEngineState(), images, execCmdMgr)
+	_, _, err := agent.newTaskEngine(containerChangeEventStream, creds, dockerstate.NewTaskEngineState(), images, execCmdMgr, serviceConnectLoader)
 
 	assert.NoError(t, err)
 	assert.False(t, cfg.TaskCPUMemLimit.Enabled())
 }
 
 func TestCompatibilityExplicitlyEnabledFail(t *testing.T) {
-	ctrl, creds, _, images, _, _, stateManagerFactory, saveableOptionFactory, execCmdMgr := setup(t)
+	ctrl, creds, _, images, _, _, stateManagerFactory, saveableOptionFactory, execCmdMgr, serviceConnectLoader := setup(t)
 	defer ctrl.Finish()
 	stateManager := mock_statemanager.NewMockStateManager(ctrl)
 
@@ -147,7 +147,7 @@ func TestCompatibilityExplicitlyEnabledFail(t *testing.T) {
 	defer cancel()
 
 	containerChangeEventStream := eventstream.NewEventStream("events", ctx)
-	_, _, err := agent.newTaskEngine(containerChangeEventStream, creds, dockerstate.NewTaskEngineState(), images, execCmdMgr)
+	_, _, err := agent.newTaskEngine(containerChangeEventStream, creds, dockerstate.NewTaskEngineState(), images, execCmdMgr, serviceConnectLoader)
 
 	assert.Error(t, err)
 }

--- a/agent/app/agent_unix_test.go
+++ b/agent/app/agent_unix_test.go
@@ -65,7 +65,7 @@ func resetGetpid() {
 
 func TestDoStartTaskENIHappyPath(t *testing.T) {
 	ctrl, credentialsManager, _, imageManager, client,
-		dockerClient, _, _, execCmdMgr := setup(t)
+		dockerClient, _, _, execCmdMgr, _ := setup(t)
 	defer ctrl.Finish()
 
 	cniCapabilities := []string{ecscni.CapabilityAWSVPCNetworkingMode}
@@ -425,7 +425,7 @@ func TestInitializeTaskENIDependenciesQueryCNICapabilitiesError(t *testing.T) {
 
 func TestDoStartCgroupInitHappyPath(t *testing.T) {
 	ctrl, credentialsManager, state, imageManager, client,
-		dockerClient, _, _, execCmdMgr := setup(t)
+		dockerClient, _, _, execCmdMgr, _ := setup(t)
 	defer ctrl.Finish()
 	mockCredentialsProvider := app_mocks.NewMockProvider(ctrl)
 	mockControl := mock_control.NewMockControl(ctrl)
@@ -514,7 +514,7 @@ func TestDoStartCgroupInitHappyPath(t *testing.T) {
 
 func TestDoStartCgroupInitErrorPath(t *testing.T) {
 	ctrl, credentialsManager, state, imageManager, client,
-		dockerClient, _, _, execCmdMgr := setup(t)
+		dockerClient, _, _, execCmdMgr, _ := setup(t)
 	defer ctrl.Finish()
 
 	mockCredentialsProvider := app_mocks.NewMockProvider(ctrl)
@@ -562,7 +562,7 @@ func TestDoStartCgroupInitErrorPath(t *testing.T) {
 
 func TestDoStartGPUManagerHappyPath(t *testing.T) {
 	ctrl, credentialsManager, state, imageManager, client,
-		dockerClient, _, _, execCmdMgr := setup(t)
+		dockerClient, _, _, execCmdMgr, _ := setup(t)
 	defer ctrl.Finish()
 	mockCredentialsProvider := app_mocks.NewMockProvider(ctrl)
 	mockGPUManager := mock_gpu.NewMockGPUManager(ctrl)
@@ -669,7 +669,7 @@ func TestDoStartGPUManagerHappyPath(t *testing.T) {
 
 func TestDoStartGPUManagerInitError(t *testing.T) {
 	ctrl, credentialsManager, state, imageManager, client,
-		dockerClient, _, _, execCmdMgr := setup(t)
+		dockerClient, _, _, execCmdMgr, _ := setup(t)
 	defer ctrl.Finish()
 
 	mockCredentialsProvider := app_mocks.NewMockProvider(ctrl)
@@ -715,7 +715,7 @@ func TestDoStartGPUManagerInitError(t *testing.T) {
 
 func TestDoStartTaskENIPauseError(t *testing.T) {
 	ctrl, credentialsManager, state, imageManager, client,
-		dockerClient, _, _, execCmdMgr := setup(t)
+		dockerClient, _, _, execCmdMgr, _ := setup(t)
 	defer ctrl.Finish()
 
 	cniClient := mock_ecscni.NewMockCNIClient(ctrl)

--- a/agent/app/agent_windows_test.go
+++ b/agent/app/agent_windows_test.go
@@ -289,7 +289,7 @@ func TestHandler_Execute_AgentStops(t *testing.T) {
 
 func TestDoStartTaskLimitsFail(t *testing.T) {
 	ctrl, credentialsManager, state, imageManager, client,
-		dockerClient, stateManagerFactory, saveableOptionFactory, execCmdMgr := setup(t)
+		dockerClient, stateManagerFactory, saveableOptionFactory, execCmdMgr, _ := setup(t)
 	defer ctrl.Finish()
 
 	cfg := getTestConfig()

--- a/agent/app/data.go
+++ b/agent/app/data.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/engine/execcmd"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
+	"github.com/aws/amazon-ecs-agent/agent/serviceconnect"
 
 	"github.com/pkg/errors"
 )
@@ -64,11 +65,12 @@ func (agent *ecsAgent) loadData(containerChangeEventStream *eventstream.EventStr
 	credentialsManager credentials.Manager,
 	state dockerstate.TaskEngineState,
 	imageManager engine.ImageManager,
-	execCmdMgr execcmd.Manager) (*savedData, error) {
+	execCmdMgr execcmd.Manager,
+	serviceConnectloader serviceconnect.Loader) (*savedData, error) {
 	s := &savedData{
 		taskEngine: engine.NewTaskEngine(agent.cfg, agent.dockerClient, credentialsManager,
 			containerChangeEventStream, imageManager, state,
-			agent.metadataManager, agent.resourceFields, execCmdMgr),
+			agent.metadataManager, agent.resourceFields, execCmdMgr, serviceConnectloader),
 	}
 	s.taskEngine.SetDataClient(agent.dataClient)
 

--- a/agent/app/data_test.go
+++ b/agent/app/data_test.go
@@ -86,7 +86,7 @@ var (
 
 func TestLoadDataNoPreviousState(t *testing.T) {
 	ctrl, credentialsManager, _, imageManager, _,
-		_, stateManagerFactory, _, execCmdMgr := setup(t)
+		_, stateManagerFactory, _, execCmdMgr, serviceConnectLoader := setup(t)
 	defer ctrl.Finish()
 
 	stateManager, dataClient, cleanup := newTestClient(t)
@@ -114,13 +114,13 @@ func TestLoadDataNoPreviousState(t *testing.T) {
 	}
 
 	_, err := agent.loadData(eventstream.NewEventStream("events", ctx),
-		credentialsManager, dockerstate.NewTaskEngineState(), imageManager, execCmdMgr)
+		credentialsManager, dockerstate.NewTaskEngineState(), imageManager, execCmdMgr, serviceConnectLoader)
 	assert.NoError(t, err)
 }
 
 func TestLoadDataLoadFromBoltDB(t *testing.T) {
 	ctrl, credentialsManager, _, imageManager, _,
-		_, stateManagerFactory, _, execCmdMgr := setup(t)
+		_, stateManagerFactory, _, execCmdMgr, serviceConnectLoader := setup(t)
 	defer ctrl.Finish()
 
 	_, dataClient, cleanup := newTestClient(t)
@@ -144,14 +144,14 @@ func TestLoadDataLoadFromBoltDB(t *testing.T) {
 
 	state := dockerstate.NewTaskEngineState()
 	s, err := agent.loadData(eventstream.NewEventStream("events", ctx),
-		credentialsManager, state, imageManager, execCmdMgr)
+		credentialsManager, state, imageManager, execCmdMgr, serviceConnectLoader)
 	assert.NoError(t, err)
 	checkLoadedData(state, s, t)
 }
 
 func TestLoadDataLoadFromStateFile(t *testing.T) {
 	ctrl, credentialsManager, _, imageManager, _,
-		_, stateManagerFactory, _, execCmdMgr := setup(t)
+		_, stateManagerFactory, _, execCmdMgr, serviceConnectLoader := setup(t)
 	defer ctrl.Finish()
 
 	stateManager, dataClient, cleanup := newTestClient(t)
@@ -182,7 +182,7 @@ func TestLoadDataLoadFromStateFile(t *testing.T) {
 
 	state := dockerstate.NewTaskEngineState()
 	s, err := agent.loadData(eventstream.NewEventStream("events", ctx),
-		credentialsManager, state, imageManager, execCmdMgr)
+		credentialsManager, state, imageManager, execCmdMgr, serviceConnectLoader)
 	assert.NoError(t, err)
 	checkLoadedData(state, s, t)
 

--- a/agent/engine/common_integ_test.go
+++ b/agent/engine/common_integ_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/engine/execcmd"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
+	"github.com/aws/amazon-ecs-agent/agent/serviceconnect"
 	"github.com/aws/amazon-ecs-agent/agent/statechange"
 	log "github.com/cihub/seelog"
 	"github.com/stretchr/testify/assert"
@@ -169,7 +170,7 @@ func setup(cfg *config.Config, state dockerstate.TaskEngineState, t *testing.T) 
 
 	taskEngine := NewDockerTaskEngine(cfg, dockerClient, credentialsManager,
 		eventstream.NewEventStream("ENGINEINTEGTEST", context.Background()), imageManager, state, metadataManager,
-		nil, execcmd.NewManager())
+		nil, execcmd.NewManager(), serviceconnect.New())
 	taskEngine.MustInit(context.TODO())
 	return taskEngine, func() {
 		taskEngine.Shutdown()

--- a/agent/engine/default.go
+++ b/agent/engine/default.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/engine/execcmd"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
+	"github.com/aws/amazon-ecs-agent/agent/serviceconnect"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 )
 
@@ -33,11 +34,12 @@ func NewTaskEngine(cfg *config.Config, client dockerapi.DockerClient,
 	imageManager ImageManager, state dockerstate.TaskEngineState,
 	metadataManager containermetadata.Manager,
 	resourceFields *taskresource.ResourceFields,
-	execCmdMgr execcmd.Manager) TaskEngine {
+	execCmdMgr execcmd.Manager,
+	serviceConnectLoader serviceconnect.Loader) TaskEngine {
 
 	taskEngine := NewDockerTaskEngine(cfg, client, credentialsManager,
 		containerChangeEventStream, imageManager,
-		state, metadataManager, resourceFields, execCmdMgr)
+		state, metadataManager, resourceFields, execCmdMgr, serviceConnectLoader)
 
 	return taskEngine
 }

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -49,6 +49,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/logger"
 	"github.com/aws/amazon-ecs-agent/agent/logger/field"
 	"github.com/aws/amazon-ecs-agent/agent/metrics"
+	"github.com/aws/amazon-ecs-agent/agent/serviceconnect"
 	"github.com/aws/amazon-ecs-agent/agent/statechange"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/credentialspec"
@@ -142,10 +143,11 @@ type DockerTaskEngine struct {
 	events            <-chan dockerapi.DockerContainerChangeEvent
 	stateChangeEvents chan statechange.Event
 
-	client       dockerapi.DockerClient
-	dataClient   data.Client
-	cniClient    ecscni.CNIClient
-	appnetClient api.AppnetClient
+	client               dockerapi.DockerClient
+	dataClient           data.Client
+	cniClient            ecscni.CNIClient
+	appnetClient         api.AppnetClient
+	serviceConnectLoader serviceconnect.Loader
 
 	containerChangeEventStream *eventstream.EventStream
 
@@ -199,7 +201,8 @@ func NewDockerTaskEngine(cfg *config.Config,
 	state dockerstate.TaskEngineState,
 	metadataManager containermetadata.Manager,
 	resourceFields *taskresource.ResourceFields,
-	execCmdMgr execcmd.Manager) *DockerTaskEngine {
+	execCmdMgr execcmd.Manager,
+	serviceConnectLoader serviceconnect.Loader) *DockerTaskEngine {
 	dockerTaskEngine := &DockerTaskEngine{
 		cfg:        cfg,
 		client:     client,
@@ -216,6 +219,7 @@ func NewDockerTaskEngine(cfg *config.Config,
 		imageManager:               imageManager,
 		cniClient:                  ecscni.NewClient(cfg.CNIPluginsPath),
 		appnetClient:               appnet.Client(),
+		serviceConnectLoader:       serviceConnectLoader,
 
 		metadataManager:                   metadataManager,
 		serviceconnectManager:             engineserviceconnect.NewManager(),

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -1299,7 +1299,7 @@ func (engine *DockerTaskEngine) createContainer(task *apitask.Task, container *a
 
 	// Add Service Connect modifications if needed
 	if task.IsServiceConnectEnabled() {
-		err := engine.serviceconnectManager.AugmentTaskContainer(task, container, hostConfig)
+		err := engine.serviceconnectManager.AugmentTaskContainer(task, container, hostConfig, engine.serviceConnectLoader)
 		if err != nil {
 			return dockerapi.DockerContainerMetadata{Error: apierrors.NewNamedError(err)}
 		}

--- a/agent/engine/docker_task_engine_linux_test.go
+++ b/agent/engine/docker_task_engine_linux_test.go
@@ -934,7 +934,7 @@ func TestContainersWithServiceConnect(t *testing.T) {
 	// Pause container will be launched first
 	gomock.InOrder(
 		dockerClient.EXPECT().APIVersion().Return(defaultDockerClientAPIVersion, nil),
-		serviceConnectManager.EXPECT().AugmentTaskContainer(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil),
+		serviceConnectManager.EXPECT().AugmentTaskContainer(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil),
 		dockerClient.EXPECT().CreateContainer(
 			gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(dockerapi.DockerContainerMetadata{DockerID: "pauseContainerID"}),
 		dockerClient.EXPECT().StartContainer(gomock.Any(), pauseContainerID, defaultConfig.ContainerStartTimeout).Return(
@@ -958,7 +958,7 @@ func TestContainersWithServiceConnect(t *testing.T) {
 	imageManager.EXPECT().RecordContainerReference(gomock.Any()).Return(nil).Times(3)
 	imageManager.EXPECT().GetImageStateFromImageName(gomock.Any()).Return(nil, false).Times(3)
 	dockerClient.EXPECT().APIVersion().Return(defaultDockerClientAPIVersion, nil).Times(3)
-	serviceConnectManager.EXPECT().AugmentTaskContainer(gomock.Any(), gomock.Any(), gomock.Any()).Times(3)
+	serviceConnectManager.EXPECT().AugmentTaskContainer(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(3)
 	dockerClient.EXPECT().CreateContainer(gomock.Any(), gomock.Any(), gomock.Any(),
 		gomock.Any(), gomock.Any()).Return(dockerapi.DockerContainerMetadata{DockerID: scContainerID})
 	dockerClient.EXPECT().CreateContainer(gomock.Any(), gomock.Any(), gomock.Any(),
@@ -1111,7 +1111,7 @@ func TestContainersWithServiceConnect_BridgeMode(t *testing.T) {
 	// SCPause.RUNNING (verified in the InOrder block down below)
 
 	// For both pause containers
-	serviceConnectManager.EXPECT().AugmentTaskContainer(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(2)
+	serviceConnectManager.EXPECT().AugmentTaskContainer(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(2)
 	dockerClient.EXPECT().APIVersion().Return(defaultDockerClientAPIVersion, nil).Times(2)
 	dockerClient.EXPECT().CreateContainer(
 		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
@@ -1189,7 +1189,7 @@ func TestContainersWithServiceConnect_BridgeMode(t *testing.T) {
 	imageManager.EXPECT().RecordContainerReference(gomock.Any()).Return(nil).Times(2)
 	imageManager.EXPECT().GetImageStateFromImageName(gomock.Any()).Return(nil, false).Times(2)
 	dockerClient.EXPECT().APIVersion().Return(defaultDockerClientAPIVersion, nil).Times(2)
-	serviceConnectManager.EXPECT().AugmentTaskContainer(gomock.Any(), gomock.Any(), gomock.Any()).Times(2)
+	serviceConnectManager.EXPECT().AugmentTaskContainer(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(2)
 
 	cleanup := make(chan time.Time)
 	defer close(cleanup)

--- a/agent/engine/docker_task_engine_linux_test.go
+++ b/agent/engine/docker_task_engine_linux_test.go
@@ -878,6 +878,7 @@ func TestContainersWithServiceConnect(t *testing.T) {
 	taskEngine.(*DockerTaskEngine).cniClient = cniClient
 	taskEngine.(*DockerTaskEngine).appnetClient = appnetClient
 	taskEngine.(*DockerTaskEngine).taskSteadyStatePollInterval = taskSteadyStatePollInterval
+	taskEngine.(*DockerTaskEngine).serviceconnectRelay = &apitask.Task{Arn: "arn::::::/task"}
 	eventStream := make(chan dockerapi.DockerContainerChangeEvent)
 	sleepTask := testdata.LoadTask("sleep5TwoContainers")
 	sleepTask.NetworkMode = apitask.AWSVPCNetworkMode
@@ -1057,6 +1058,7 @@ func TestContainersWithServiceConnect_BridgeMode(t *testing.T) {
 	cniClient := mock_ecscni.NewMockCNIClient(ctrl)
 	taskEngine.(*DockerTaskEngine).cniClient = cniClient
 	taskEngine.(*DockerTaskEngine).taskSteadyStatePollInterval = taskSteadyStatePollInterval
+	taskEngine.(*DockerTaskEngine).serviceconnectRelay = &apitask.Task{Arn: "arn::::::/task"}
 	eventStream := make(chan dockerapi.DockerContainerChangeEvent)
 	sleepTask := testdata.LoadTask("sleep5PortMappings")
 	sleepContainer := sleepTask.Containers[0]

--- a/agent/engine/docker_task_engine_linux_test.go
+++ b/agent/engine/docker_task_engine_linux_test.go
@@ -26,18 +26,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/containernetworking/cni/pkg/types/current"
-
-	"github.com/docker/docker/api/types/network"
-
-	"github.com/aws/amazon-ecs-agent/agent/api/serviceconnect"
-
-	mock_api "github.com/aws/amazon-ecs-agent/agent/api/mocks"
-
 	"github.com/aws/amazon-ecs-agent/agent/api/appmesh"
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	apieni "github.com/aws/amazon-ecs-agent/agent/api/eni"
+	mock_api "github.com/aws/amazon-ecs-agent/agent/api/mocks"
+	"github.com/aws/amazon-ecs-agent/agent/api/serviceconnect"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	apitaskstatus "github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/agent/config"
@@ -55,11 +49,13 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/ssmsecret"
 	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
 	mock_ioutilwrapper "github.com/aws/amazon-ecs-agent/agent/utils/ioutilwrapper/mocks"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/golang/mock/gomock"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/containernetworking/cni/pkg/types/current"
 	"github.com/docker/docker/api/types"
 	dockercontainer "github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
+	"github.com/golang/mock/gomock"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -83,7 +79,7 @@ func init() {
 func TestResourceContainerProgression(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-	ctrl, client, mockTime, taskEngine, _, imageManager, _, _ := mocks(t, ctx, &defaultConfig)
+	ctrl, client, mockTime, taskEngine, _, imageManager, _, _, _ := mocks(t, ctx, &defaultConfig)
 	defer ctrl.Finish()
 
 	sleepTask := testdata.LoadTask("sleep5")
@@ -252,7 +248,7 @@ func TestDeleteTaskBranchENIEnabled(t *testing.T) {
 func TestResourceContainerProgressionFailure(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-	ctrl, client, mockTime, taskEngine, _, _, _, _ := mocks(t, ctx, &defaultConfig)
+	ctrl, client, mockTime, taskEngine, _, _, _, _, _ := mocks(t, ctx, &defaultConfig)
 	defer ctrl.Finish()
 	sleepTask := testdata.LoadTask("sleep5")
 	sleepContainer := sleepTask.Containers[0]
@@ -309,7 +305,7 @@ func TestTaskCPULimitHappyPath(t *testing.T) {
 			metadataConfig.ContainerMetadataEnabled = config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled}
 			ctx, cancel := context.WithCancel(context.TODO())
 			defer cancel()
-			ctrl, client, mockTime, taskEngine, credentialsManager, imageManager, metadataManager, _ := mocks(
+			ctrl, client, mockTime, taskEngine, credentialsManager, imageManager, metadataManager, _, _ := mocks(
 				t, ctx, &metadataConfig)
 			defer ctrl.Finish()
 
@@ -523,7 +519,7 @@ func TestCreateFirelensContainer(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.TODO())
 			defer cancel()
-			ctrl, client, mockTime, taskEngine, _, _, _, _ := mocks(t, ctx, &defaultConfig)
+			ctrl, client, mockTime, taskEngine, _, _, _, _, _ := mocks(t, ctx, &defaultConfig)
 			defer ctrl.Finish()
 
 			mockTime.EXPECT().Now().AnyTimes()
@@ -549,7 +545,7 @@ func TestBuildCNIConfigFromTaskContainer(t *testing.T) {
 	config := defaultConfig
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-	ctrl, _, _, taskEngine, _, _, _, _ := mocks(t, ctx, &config)
+	ctrl, _, _, taskEngine, _, _, _, _, _ := mocks(t, ctx, &config)
 	defer ctrl.Finish()
 
 	testTask := testdata.LoadTask("sleep5")
@@ -591,7 +587,7 @@ func TestBuildCNIConfigFromTaskContainer(t *testing.T) {
 func TestTaskWithSteadyStateResourcesProvisioned(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-	ctrl, client, mockTime, taskEngine, _, imageManager, _, _ := mocks(t, ctx, &defaultConfig)
+	ctrl, client, mockTime, taskEngine, _, imageManager, _, _, _ := mocks(t, ctx, &defaultConfig)
 	defer ctrl.Finish()
 
 	mockCNIClient := mock_ecscni.NewMockCNIClient(ctrl)
@@ -728,7 +724,7 @@ func TestTaskWithSteadyStateResourcesProvisioned(t *testing.T) {
 func TestPauseContainerHappyPath(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-	ctrl, dockerClient, mockTime, taskEngine, _, imageManager, _, _ := mocks(t, ctx, &defaultConfig)
+	ctrl, dockerClient, mockTime, taskEngine, _, imageManager, _, _, _ := mocks(t, ctx, &defaultConfig)
 	defer ctrl.Finish()
 
 	cniClient := mock_ecscni.NewMockCNIClient(ctrl)
@@ -874,7 +870,7 @@ func TestPauseContainerHappyPath(t *testing.T) {
 func TestContainersWithServiceConnect(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-	ctrl, dockerClient, mockTime, taskEngine, _, imageManager, _, serviceConnectManager := mocks(t, ctx, &defaultConfig)
+	ctrl, dockerClient, mockTime, taskEngine, _, imageManager, _, serviceConnectManager, _ := mocks(t, ctx, &defaultConfig)
 	defer ctrl.Finish()
 
 	cniClient := mock_ecscni.NewMockCNIClient(ctrl)
@@ -1055,7 +1051,7 @@ func TestContainersWithServiceConnect(t *testing.T) {
 func TestContainersWithServiceConnect_BridgeMode(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-	ctrl, dockerClient, mockTime, taskEngine, _, imageManager, _, serviceConnectManager := mocks(t, ctx, &defaultConfig)
+	ctrl, dockerClient, mockTime, taskEngine, _, imageManager, _, serviceConnectManager, _ := mocks(t, ctx, &defaultConfig)
 	defer ctrl.Finish()
 
 	cniClient := mock_ecscni.NewMockCNIClient(ctrl)
@@ -1285,7 +1281,7 @@ func verifyServiceConnectPauseContainerBridgeMode(t *testing.T, ctx interface{},
 func TestProvisionContainerResourcesBridgeModeWithServiceConnect(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-	ctrl, dockerClient, _, taskEngine, _, _, _, _ := mocks(t, ctx, &defaultConfig)
+	ctrl, dockerClient, _, taskEngine, _, _, _, _, _ := mocks(t, ctx, &defaultConfig)
 	defer ctrl.Finish()
 
 	mockCNIClient := mock_ecscni.NewMockCNIClient(ctrl)

--- a/agent/engine/docker_task_engine_windows_test.go
+++ b/agent/engine/docker_task_engine_windows_test.go
@@ -86,7 +86,7 @@ func TestDeleteTask(t *testing.T) {
 func TestCredentialSpecResourceTaskFile(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-	ctrl, client, mockTime, taskEngine, credentialsManager, _, _, _ := mocks(t, ctx, &defaultConfig)
+	ctrl, client, mockTime, taskEngine, credentialsManager, _, _, _, _ := mocks(t, ctx, &defaultConfig)
 	defer ctrl.Finish()
 
 	// metadata required for createContainer workflow validation
@@ -167,7 +167,7 @@ func TestCredentialSpecResourceTaskFile(t *testing.T) {
 func TestCredentialSpecResourceTaskFileErr(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-	ctrl, client, mockTime, taskEngine, credentialsManager, _, _, _ := mocks(t, ctx, &defaultConfig)
+	ctrl, client, mockTime, taskEngine, credentialsManager, _, _, _, _ := mocks(t, ctx, &defaultConfig)
 	defer ctrl.Finish()
 
 	// metadata required for createContainer workflow validation
@@ -243,7 +243,7 @@ func TestBuildCNIConfigFromTaskContainer(t *testing.T) {
 	config := defaultConfig
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-	ctrl, _, _, taskEngine, _, _, _, _ := mocks(t, ctx, &config)
+	ctrl, _, _, taskEngine, _, _, _, _, _ := mocks(t, ctx, &config)
 	defer ctrl.Finish()
 
 	testTask := testdata.LoadTask("sleep5")
@@ -287,7 +287,7 @@ func TestBuildCNIConfigFromTaskContainer(t *testing.T) {
 func TestTaskWithSteadyStateResourcesProvisioned(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-	ctrl, client, mockTime, taskEngine, _, imageManager, _, _ := mocks(t, ctx, &defaultConfig)
+	ctrl, client, mockTime, taskEngine, _, imageManager, _, _, _ := mocks(t, ctx, &defaultConfig)
 	defer ctrl.Finish()
 
 	mockCNIClient := mock_ecscni.NewMockCNIClient(ctrl)
@@ -445,7 +445,7 @@ func TestTaskWithSteadyStateResourcesProvisioned(t *testing.T) {
 func TestPauseContainerHappyPath(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-	ctrl, dockerClient, mockTime, taskEngine, _, imageManager, _, _ := mocks(t, ctx, &defaultConfig)
+	ctrl, dockerClient, mockTime, taskEngine, _, imageManager, _, _, _ := mocks(t, ctx, &defaultConfig)
 	defer ctrl.Finish()
 
 	cniClient := mock_ecscni.NewMockCNIClient(ctrl)

--- a/agent/engine/engine_sudo_linux_integ_test.go
+++ b/agent/engine/engine_sudo_linux_integ_test.go
@@ -62,6 +62,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/engine/execcmd"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
+	"github.com/aws/amazon-ecs-agent/agent/serviceconnect"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	cgroup "github.com/aws/amazon-ecs-agent/agent/taskresource/cgroup/control"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/firelens"
@@ -585,7 +586,7 @@ func setupEngineForExecCommandAgent(t *testing.T, hostBinDir string) (TaskEngine
 
 	taskEngine := NewDockerTaskEngine(cfg, dockerClient, credentialsManager,
 		eventstream.NewEventStream("ENGINEINTEGTEST", context.Background()), imageManager, state, metadataManager,
-		nil, execCmdMgr)
+		nil, execCmdMgr, serviceconnect.New())
 	taskEngine.monitorExecAgentsInterval = time.Second
 	taskEngine.MustInit(context.TODO())
 	return taskEngine, func() {

--- a/agent/engine/engine_windows_integ_test.go
+++ b/agent/engine/engine_windows_integ_test.go
@@ -51,6 +51,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/engine/execcmd"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
 	s3factory "github.com/aws/amazon-ecs-agent/agent/s3/factory"
+	"github.com/aws/amazon-ecs-agent/agent/serviceconnect"
 	ssmfactory "github.com/aws/amazon-ecs-agent/agent/ssm/factory"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	taskresourcevolume "github.com/aws/amazon-ecs-agent/agent/taskresource/volume"
@@ -496,7 +497,7 @@ func setupGMSA(cfg *config.Config, state dockerstate.TaskEngineState, t *testing
 
 	taskEngine := NewDockerTaskEngine(cfg, dockerClient, credentialsManager,
 		eventstream.NewEventStream("ENGINEINTEGTEST", context.Background()), imageManager, state, metadataManager,
-		resourceFields, execcmd.NewManager())
+		resourceFields, execcmd.NewManager(), serviceconnect.New())
 	taskEngine.MustInit(context.TODO())
 	return taskEngine, func() {
 		taskEngine.Shutdown()
@@ -738,7 +739,7 @@ func setupEngineForExecCommandAgent(t *testing.T, hostBinDir string) (TaskEngine
 
 	taskEngine := NewDockerTaskEngine(cfg, dockerClient, credentialsManager,
 		eventstream.NewEventStream("ENGINEINTEGTEST", context.Background()), imageManager, state, metadataManager,
-		nil, execCmdMgr)
+		nil, execCmdMgr, serviceconnect.New())
 	taskEngine.monitorExecAgentsInterval = time.Second
 	taskEngine.MustInit(context.TODO())
 	return taskEngine, func() {

--- a/agent/engine/service_connect/manager.go
+++ b/agent/engine/service_connect/manager.go
@@ -16,6 +16,7 @@ package serviceconnect
 import (
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
+	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/serviceconnect"
 
 	dockercontainer "github.com/docker/docker/api/types/container"
@@ -23,4 +24,6 @@ import (
 
 type Manager interface {
 	AugmentTaskContainer(task *apitask.Task, container *apicontainer.Container, hostConfig *dockercontainer.HostConfig, serviceConnectLoader serviceconnect.Loader) error
+	CreateInstanceTask(config *config.Config, appnetAgentLoader serviceconnect.Loader) (*apitask.Task, error)
+	AugmentInstanceContainer(task *apitask.Task, container *apicontainer.Container, hostConfig *dockercontainer.HostConfig) error
 }

--- a/agent/engine/service_connect/manager.go
+++ b/agent/engine/service_connect/manager.go
@@ -16,10 +16,11 @@ package serviceconnect
 import (
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
+	"github.com/aws/amazon-ecs-agent/agent/serviceconnect"
 
 	dockercontainer "github.com/docker/docker/api/types/container"
 )
 
 type Manager interface {
-	AugmentTaskContainer(task *apitask.Task, container *apicontainer.Container, hostConfig *dockercontainer.HostConfig) error
+	AugmentTaskContainer(task *apitask.Task, container *apicontainer.Container, hostConfig *dockercontainer.HostConfig, serviceConnectLoader serviceconnect.Loader) error
 }

--- a/agent/engine/service_connect/manager_linux.go
+++ b/agent/engine/service_connect/manager_linux.go
@@ -22,21 +22,26 @@ import (
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apiserviceconnect "github.com/aws/amazon-ecs-agent/agent/api/serviceconnect"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
+	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/serviceconnect"
 	dockercontainer "github.com/docker/docker/api/types/container"
 )
 
 const (
 	defaultRelayPathContainer  = "/var/run/ecs/relay/"
-	defaultRelayPathHost       = "/var/run/ecs/service_connect/instance/relay/"
+	defaultRelayPathHost       = "/var/run/ecs/service_connect/relay/"
 	defaultRelayFileName       = "envoy_xds.sock"
-	defaultRelayENV            = "APPMESH_XDS_ENDPOINT"
+	defaultEndpointENV         = "APPMESH_XDS_ENDPOINT"
 	defaultStatusPathContainer = "/var/run/ecs/"
 	// Expected to have task.GetID() appended to form actual host path
 	defaultStatusPathHostRoot = "/var/run/ecs/service_connect/"
 	defaultStatusFileName     = "appnet_admin.sock"
 	defaultStatusENV          = "APPNET_AGENT_ADMIN_UDS_PATH"
 
+	relayEnableENV = "APPNET_ENABLE_RELAY_MODE_FOR_XDS"
+	relayEnableOn  = "1"
+	upstreamENV    = "APPNET_RELAY_LISTENER_UDS_PATH"
+	regionENV      = "AWS_REGION"
 	agentAuthENV   = "ENVOY_ENABLE_IAM_AUTH_FOR_XDS"
 	agentAuthOff   = "0"
 	agentModeENV   = "APPNET_AGENT_ADMIN_MODE"
@@ -56,7 +61,7 @@ type manager struct {
 	// Filename without Path which Relay will create and Envoy in the container will connect to
 	relayFileName string
 	// Environment variable to set on Container with contents of relayPathContainer/relayFileName
-	relayENV string
+	endpointENV string
 	// Path to where statusFileName exists which Envoy in the container will create for status endpoint
 	statusPathContainer string
 	// PathRoot to be appended with TaskID statusPathHostRoot/task.GetID() where statusFileName exists on Host
@@ -77,7 +82,7 @@ func NewManager() Manager {
 		relayPathContainer:  defaultRelayPathContainer,
 		relayPathHost:       defaultRelayPathHost,
 		relayFileName:       defaultRelayFileName,
-		relayENV:            defaultRelayENV,
+		endpointENV:         defaultEndpointENV,
 		statusPathContainer: defaultStatusPathContainer,
 		statusPathHostRoot:  defaultStatusPathHostRoot,
 		statusFileName:      defaultStatusFileName,
@@ -151,10 +156,24 @@ func (m *manager) initAgentDirectoryMounts(taskId string, container *apicontaine
 
 func (m *manager) initAgentEnvironment(container *apicontainer.Container) {
 	scEnv := map[string]string{
-		m.relayENV:   unixRequestPrefix + filepath.Join(m.relayPathContainer, m.relayFileName),
-		m.statusENV:  filepath.Join(m.statusPathContainer, m.statusFileName),
-		agentModeENV: agentModeValue,
-		agentAuthENV: agentAuthOff,
+		m.endpointENV: unixRequestPrefix + filepath.Join(m.relayPathContainer, m.relayFileName),
+		m.statusENV:   filepath.Join(m.statusPathContainer, m.statusFileName),
+		agentModeENV:  agentModeValue,
+		agentAuthENV:  agentAuthOff,
+	}
+
+	container.MergeEnvironmentVariables(scEnv)
+}
+
+func (m *manager) initRelayEnvironment(config *config.Config, container *apicontainer.Container) {
+	scEnv := map[string]string{
+		m.statusENV:    filepath.Join(m.statusPathContainer, m.statusFileName),
+		upstreamENV:    filepath.Join(m.relayPathContainer, m.relayFileName),
+		regionENV:      config.AWSRegion,
+		agentModeENV:   agentModeValue,
+		relayEnableENV: relayEnableOn,
+		// TODO: get programmatically when available
+		m.endpointENV: "ecs-sc-gamma.us-west-2.api.aws",
 	}
 
 	container.MergeEnvironmentVariables(scEnv)
@@ -189,4 +208,43 @@ func (m *manager) AugmentTaskContainer(task *apitask.Task, container *apicontain
 		m.augmentAgentContainer(task, container, hostConfig, serviceConnectLoader)
 	}
 	return err
+}
+
+func (m *manager) CreateInstanceTask(cfg *config.Config, serviceConnectLoader serviceconnect.Loader) (*apitask.Task, error) {
+	imageName, err := serviceConnectLoader.GetLoadedImageName()
+	if err != nil {
+		return nil, err
+	}
+	task := &apitask.Task{
+		Arn: "arn:::::/service-connect-relay",
+		Containers: []*apicontainer.Container{{
+			Name:              "instance-service-connect-relay",
+			Image:             imageName,
+			NetworkModeUnsafe: "host",
+			ContainerArn:      "arn:::::/instance-service-connect-relay",
+			Type:              apicontainer.ContainerServiceConnectRelay,
+		}},
+		LaunchType:  "EC2",
+		NetworkMode: "host",
+	}
+
+	m.initRelayEnvironment(cfg, task.Containers[0])
+
+	return task, nil
+}
+
+func (m *manager) AugmentInstanceContainer(task *apitask.Task, container *apicontainer.Container, hostConfig *dockercontainer.HostConfig) error {
+	adminPath, err := m.initAgentDirectoryMounts("relay", container, hostConfig)
+	if err != nil {
+		return err
+	}
+
+	// Setup runtime configuration
+	var config apiserviceconnect.RuntimeConfig
+	config.AdminSocketPath = adminPath
+	config.StatsRequest = m.adminStatsRequest
+	config.DrainRequest = m.adminDrainRequest
+
+	task.PopulateServiceConnectRuntimeConfig(config)
+	return nil
 }

--- a/agent/engine/service_connect/manager_linux.go
+++ b/agent/engine/service_connect/manager_linux.go
@@ -19,10 +19,10 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/aws/amazon-ecs-agent/agent/api/serviceconnect"
-
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	apiserviceconnect "github.com/aws/amazon-ecs-agent/agent/api/serviceconnect"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
+	"github.com/aws/amazon-ecs-agent/agent/serviceconnect"
 	dockercontainer "github.com/docker/docker/api/types/container"
 )
 
@@ -87,7 +87,7 @@ func NewManager() Manager {
 	}
 }
 
-func (m *manager) augmentAgentContainer(task *apitask.Task, container *apicontainer.Container, hostConfig *dockercontainer.HostConfig) error {
+func (m *manager) augmentAgentContainer(task *apitask.Task, container *apicontainer.Container, hostConfig *dockercontainer.HostConfig, serviceConnectoader serviceconnect.Loader) error {
 	if task.IsNetworkModeBridge() {
 		err := m.initServiceConnectContainerMapping(task, container, hostConfig)
 		if err != nil {
@@ -101,12 +101,13 @@ func (m *manager) augmentAgentContainer(task *apitask.Task, container *apicontai
 	m.initAgentEnvironment(container)
 
 	// Setup runtime configuration
-	var config serviceconnect.RuntimeConfig
+	var config apiserviceconnect.RuntimeConfig
 	config.AdminSocketPath = adminPath
 	config.StatsRequest = m.adminStatsRequest
 	config.DrainRequest = m.adminDrainRequest
 
 	task.PopulateServiceConnectRuntimeConfig(config)
+	container.Image, _ = serviceConnectoader.GetLoadedImageName()
 	return nil
 }
 
@@ -137,7 +138,7 @@ func (m *manager) initAgentDirectoryMounts(taskId string, container *apicontaine
 
 	// Create host directories if they don't exist
 	for _, path := range []string{statusPathHost, m.relayPathHost} {
-		err := mkdirAllAndChown(path, 0700, serviceconnect.AppNetUID, os.Getegid())
+		err := mkdirAllAndChown(path, 0700, apiserviceconnect.AppNetUID, os.Getegid())
 		if err != nil {
 			return "", err
 		}
@@ -166,7 +167,7 @@ func (m *manager) initServiceConnectContainerMapping(task *apitask.Task, contain
 
 // DNSConfigToDockerExtraHostsFormat converts a []DNSConfigEntry slice to a list of ExtraHost entries that Docker will
 // recognize.
-func DNSConfigToDockerExtraHostsFormat(dnsConfigs []serviceconnect.DNSConfigEntry) []string {
+func DNSConfigToDockerExtraHostsFormat(dnsConfigs []apiserviceconnect.DNSConfigEntry) []string {
 	var hosts []string
 	for _, dnsConf := range dnsConfigs {
 		if len(dnsConf.Address) > 0 {
@@ -177,7 +178,7 @@ func DNSConfigToDockerExtraHostsFormat(dnsConfigs []serviceconnect.DNSConfigEntr
 	return hosts
 }
 
-func (m *manager) AugmentTaskContainer(task *apitask.Task, container *apicontainer.Container, hostConfig *dockercontainer.HostConfig) error {
+func (m *manager) AugmentTaskContainer(task *apitask.Task, container *apicontainer.Container, hostConfig *dockercontainer.HostConfig, serviceConnectLoader serviceconnect.Loader) error {
 	var err error
 	// Add SC VIPs to pause container's known hosts
 	if container.Type == apicontainer.ContainerCNIPause {
@@ -185,7 +186,7 @@ func (m *manager) AugmentTaskContainer(task *apitask.Task, container *apicontain
 			DNSConfigToDockerExtraHostsFormat(task.ServiceConnectConfig.DNSConfig)...)
 	}
 	if container == task.GetServiceConnectContainer() {
-		m.augmentAgentContainer(task, container, hostConfig)
+		m.augmentAgentContainer(task, container, hostConfig, serviceConnectLoader)
 	}
 	return err
 }

--- a/agent/engine/service_connect/manager_linux_test_common.go
+++ b/agent/engine/service_connect/manager_linux_test_common.go
@@ -170,7 +170,7 @@ func testAgentContainerModificationsForServiceConnect(t *testing.T, privilegedMo
 		relayPathContainer:  "/not/var/run",
 		relayPathHost:       filepath.Join(tempDir, "relay"),
 		relayFileName:       "relay_file_of_holiness",
-		relayENV:            "ReLaYgOeShErE",
+		endpointENV:         "ReLaYgOeShErE",
 		statusPathContainer: "/some/other/run",
 		statusPathHostRoot:  filepath.Join(tempDir, "status"),
 		statusFileName:      "status_file_of_holiness",

--- a/agent/engine/service_connect/manager_other.go
+++ b/agent/engine/service_connect/manager_other.go
@@ -1,4 +1,5 @@
 //go:build !linux
+// +build !linux
 
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 //
@@ -16,10 +17,11 @@
 package serviceconnect
 
 import (
-	"errors"
+	"fmt"
 
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
+	"github.com/aws/amazon-ecs-agent/agent/serviceconnect"
 	dockercontainer "github.com/docker/docker/api/types/container"
 )
 
@@ -30,6 +32,6 @@ func NewManager() Manager {
 	return &manager{}
 }
 
-func (m *manager) AugmentTaskContainer(task *apitask.Task, container *apicontainer.Container, hostConfig *dockercontainer.HostConfig) error {
-	return errors.New("ServiceConnect is only supported on linux")
+func (m *manager) AugmentTaskContainer(*apitask.Task, *apicontainer.Container, *dockercontainer.HostConfig, serviceconnect.Loader) error {
+	return fmt.Errorf("ServiceConnect is only supported on linux")
 }

--- a/agent/engine/service_connect/manager_other.go
+++ b/agent/engine/service_connect/manager_other.go
@@ -21,6 +21,7 @@ import (
 
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
+	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/serviceconnect"
 	dockercontainer "github.com/docker/docker/api/types/container"
 )
@@ -33,5 +34,11 @@ func NewManager() Manager {
 }
 
 func (m *manager) AugmentTaskContainer(*apitask.Task, *apicontainer.Container, *dockercontainer.HostConfig, serviceconnect.Loader) error {
+	return fmt.Errorf("ServiceConnect is only supported on linux")
+}
+func (m *manager) CreateInstanceTask(config *config.Config, appnetAgentLoader serviceconnect.Loader) (*apitask.Task, error) {
+	return nil, fmt.Errorf("ServiceConnect is only supported on linux")
+}
+func (m *manager) AugmentInstanceContainer(*apitask.Task, *apicontainer.Container, *dockercontainer.HostConfig) error {
 	return fmt.Errorf("ServiceConnect is only supported on linux")
 }

--- a/agent/engine/service_connect/mock/manager.go
+++ b/agent/engine/service_connect/mock/manager.go
@@ -23,6 +23,7 @@ import (
 
 	container "github.com/aws/amazon-ecs-agent/agent/api/container"
 	task "github.com/aws/amazon-ecs-agent/agent/api/task"
+	config "github.com/aws/amazon-ecs-agent/agent/config"
 	serviceconnect "github.com/aws/amazon-ecs-agent/agent/serviceconnect"
 	container0 "github.com/docker/docker/api/types/container"
 	gomock "github.com/golang/mock/gomock"
@@ -51,6 +52,20 @@ func (m *MockManager) EXPECT() *MockManagerMockRecorder {
 	return m.recorder
 }
 
+// AugmentInstanceContainer mocks base method
+func (m *MockManager) AugmentInstanceContainer(arg0 *task.Task, arg1 *container.Container, arg2 *container0.HostConfig) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AugmentInstanceContainer", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AugmentInstanceContainer indicates an expected call of AugmentInstanceContainer
+func (mr *MockManagerMockRecorder) AugmentInstanceContainer(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AugmentInstanceContainer", reflect.TypeOf((*MockManager)(nil).AugmentInstanceContainer), arg0, arg1, arg2)
+}
+
 // AugmentTaskContainer mocks base method
 func (m *MockManager) AugmentTaskContainer(arg0 *task.Task, arg1 *container.Container, arg2 *container0.HostConfig, arg3 serviceconnect.Loader) error {
 	m.ctrl.T.Helper()
@@ -63,4 +78,19 @@ func (m *MockManager) AugmentTaskContainer(arg0 *task.Task, arg1 *container.Cont
 func (mr *MockManagerMockRecorder) AugmentTaskContainer(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AugmentTaskContainer", reflect.TypeOf((*MockManager)(nil).AugmentTaskContainer), arg0, arg1, arg2, arg3)
+}
+
+// CreateInstanceTask mocks base method
+func (m *MockManager) CreateInstanceTask(arg0 *config.Config, arg1 serviceconnect.Loader) (*task.Task, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateInstanceTask", arg0, arg1)
+	ret0, _ := ret[0].(*task.Task)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateInstanceTask indicates an expected call of CreateInstanceTask
+func (mr *MockManagerMockRecorder) CreateInstanceTask(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateInstanceTask", reflect.TypeOf((*MockManager)(nil).CreateInstanceTask), arg0, arg1)
 }

--- a/agent/engine/service_connect/mock/manager.go
+++ b/agent/engine/service_connect/mock/manager.go
@@ -23,6 +23,7 @@ import (
 
 	container "github.com/aws/amazon-ecs-agent/agent/api/container"
 	task "github.com/aws/amazon-ecs-agent/agent/api/task"
+	serviceconnect "github.com/aws/amazon-ecs-agent/agent/serviceconnect"
 	container0 "github.com/docker/docker/api/types/container"
 	gomock "github.com/golang/mock/gomock"
 )
@@ -51,15 +52,15 @@ func (m *MockManager) EXPECT() *MockManagerMockRecorder {
 }
 
 // AugmentTaskContainer mocks base method
-func (m *MockManager) AugmentTaskContainer(arg0 *task.Task, arg1 *container.Container, arg2 *container0.HostConfig) error {
+func (m *MockManager) AugmentTaskContainer(arg0 *task.Task, arg1 *container.Container, arg2 *container0.HostConfig, arg3 serviceconnect.Loader) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AugmentTaskContainer", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "AugmentTaskContainer", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // AugmentTaskContainer indicates an expected call of AugmentTaskContainer
-func (mr *MockManagerMockRecorder) AugmentTaskContainer(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockManagerMockRecorder) AugmentTaskContainer(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AugmentTaskContainer", reflect.TypeOf((*MockManager)(nil).AugmentTaskContainer), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AugmentTaskContainer", reflect.TypeOf((*MockManager)(nil).AugmentTaskContainer), arg0, arg1, arg2, arg3)
 }

--- a/agent/serviceconnect/load.go
+++ b/agent/serviceconnect/load.go
@@ -33,6 +33,7 @@ var (
 type Loader interface {
 	LoadImage(ctx context.Context, dockerClient dockerapi.DockerClient) (*types.ImageInspect, error)
 	IsLoaded(dockerClient dockerapi.DockerClient) (bool, error)
+	GetLoadedImageName() (string, error)
 }
 
 type loader struct {
@@ -51,8 +52,7 @@ func New() Loader {
 }
 
 // This function uses the DockerClient to inspect the image with the given name and tag.
-func getAgentContainerImage(name string, tag string, dockerClient dockerapi.DockerClient) (*types.ImageInspect, error) {
-	imageName := fmt.Sprintf("%s:%s", name, tag)
+func getAgentContainerImage(imageName string, dockerClient dockerapi.DockerClient) (*types.ImageInspect, error) {
 	logger.Debug("Inspecting appnet agent container image:", logger.Fields{
 		field.Image: imageName,
 	})
@@ -67,8 +67,8 @@ func getAgentContainerImage(name string, tag string, dockerClient dockerapi.Dock
 
 // Common function for linux and windows to check if the container appnet Agent image has been loaded
 func (agent *loader) isImageLoaded(dockerClient dockerapi.DockerClient) (bool, error) {
-	image, err := getAgentContainerImage(
-		agent.AgentContainerImageName, agent.AgentContainerTag, dockerClient)
+	imageName, _ := agent.GetLoadedImageName()
+	image, err := getAgentContainerImage(imageName, dockerClient)
 
 	if err != nil {
 		return false, err

--- a/agent/serviceconnect/load_linux.go
+++ b/agent/serviceconnect/load_linux.go
@@ -42,12 +42,16 @@ func (agent *loader) LoadImage(ctx context.Context, dockerClient dockerapi.Docke
 		return nil, err
 	}
 
-	return getAgentContainerImage(
-		agent.AgentContainerImageName, agent.AgentContainerTag, dockerClient)
+	imageName, _ := agent.GetLoadedImageName()
+	return getAgentContainerImage(imageName, dockerClient)
 }
 
 func (agent *loader) IsLoaded(dockerClient dockerapi.DockerClient) (bool, error) {
 	return agent.isImageLoaded(dockerClient)
+}
+
+func (agent *loader) GetLoadedImageName() (string, error) {
+	return fmt.Sprintf("%s:%s", agent.AgentContainerImageName, agent.AgentContainerTag), nil
 }
 
 var open = os.Open

--- a/agent/serviceconnect/load_test.go
+++ b/agent/serviceconnect/load_test.go
@@ -32,8 +32,9 @@ import (
 )
 
 const (
-	agentName = "appnet-agent"
-	agentTag  = "tag"
+	agentImageName = "appnet-agent:testtag"
+	agentName      = "appnet-agent"
+	agentTag       = "testtag"
 )
 
 var defaultConfig = config.DefaultConfig()
@@ -53,10 +54,10 @@ func TestGetAppnetAgentContainerImageInspectImageError(t *testing.T) {
 
 	client, err := dockerapi.NewDockerGoClient(sdkFactory, &defaultConfig, ctx)
 	assert.NoError(t, err)
-	mockDockerSDK.EXPECT().ImageInspectWithRaw(gomock.Any(), agentName+":"+agentTag).Return(
+	mockDockerSDK.EXPECT().ImageInspectWithRaw(gomock.Any(), agentImageName).Return(
 		types.ImageInspect{}, nil, errors.New("error"))
 
-	_, err = getAgentContainerImage(agentName, agentTag, client)
+	_, err = getAgentContainerImage(agentImageName, client)
 	assert.Error(t, err)
 }
 
@@ -75,9 +76,9 @@ func TestGetAgentContainerHappyPath(t *testing.T) {
 
 	client, err := dockerapi.NewDockerGoClient(sdkFactory, &defaultConfig, ctx)
 	assert.NoError(t, err)
-	mockDockerSDK.EXPECT().ImageInspectWithRaw(gomock.Any(), agentName+":"+agentTag).Return(types.ImageInspect{}, nil, nil)
+	mockDockerSDK.EXPECT().ImageInspectWithRaw(gomock.Any(), agentImageName).Return(types.ImageInspect{}, nil, nil)
 
-	_, err = getAgentContainerImage(agentName, agentTag, client)
+	_, err = getAgentContainerImage(agentImageName, client)
 	assert.NoError(t, err)
 }
 

--- a/agent/serviceconnect/load_unsupported.go
+++ b/agent/serviceconnect/load_unsupported.go
@@ -41,3 +41,9 @@ func (*loader) IsLoaded(dockerClient dockerapi.DockerClient) (bool, error) {
 		"appnetAgent container isloaded: unsupported platform: %s/%s",
 		runtime.GOOS, runtime.GOARCH))
 }
+
+func (*loader) GetLoadedImageName() (string, error) {
+	return "", NewUnsupportedPlatformError(fmt.Errorf(
+		"appnetAgent container get image name: unsupported platform: %s/%s",
+		runtime.GOOS, runtime.GOARCH))
+}

--- a/agent/serviceconnect/mocks/load_mocks.go
+++ b/agent/serviceconnect/mocks/load_mocks.go
@@ -50,6 +50,21 @@ func (m *MockLoader) EXPECT() *MockLoaderMockRecorder {
 	return m.recorder
 }
 
+// GetLoadedImageName mocks base method
+func (m *MockLoader) GetLoadedImageName() (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLoadedImageName")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetLoadedImageName indicates an expected call of GetLoadedImageName
+func (mr *MockLoaderMockRecorder) GetLoadedImageName() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLoadedImageName", reflect.TypeOf((*MockLoader)(nil).GetLoadedImageName))
+}
+
 // IsLoaded mocks base method
 func (m *MockLoader) IsLoaded(arg0 dockerapi.DockerClient) (bool, error) {
 	m.ctrl.T.Helper()

--- a/agent/sighandlers/termination_handler_test.go
+++ b/agent/sighandlers/termination_handler_test.go
@@ -46,7 +46,7 @@ func TestFinalSave(t *testing.T) {
 
 	state := dockerstate.NewTaskEngineState()
 	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil,
-		nil, nil, state, nil, nil, nil)
+		nil, nil, state, nil, nil, nil, nil)
 
 	task := &apitask.Task{
 		Arn:     taskARN,

--- a/agent/statemanager/state_manager_test.go
+++ b/agent/statemanager/state_manager_test.go
@@ -45,7 +45,7 @@ func TestLoadsV1DataCorrectly(t *testing.T) {
 	cfg := &config.Config{DataDir: filepath.Join(".", "testdata", "v1", "1")}
 
 	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(),
-		nil, nil, nil)
+		nil, nil, nil, nil)
 	var containerInstanceArn, cluster, savedInstanceID string
 	var sequenceNumber int64
 
@@ -90,7 +90,7 @@ func TestLoadsV13DataCorrectly(t *testing.T) {
 	defer cleanup()
 	cfg := &config.Config{DataDir: filepath.Join(".", "testdata", "v13", "1")}
 
-	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil)
+	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
 	var containerInstanceArn, cluster, savedInstanceID string
 	var sequenceNumber int64
 
@@ -138,7 +138,7 @@ func TestLoadsDataForContainerHealthCheckTask(t *testing.T) {
 	defer cleanup()
 	cfg := &config.Config{DataDir: filepath.Join(".", "testdata", "v10", "container-health-check")}
 
-	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil)
+	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
 	var containerInstanceArn, cluster, savedInstanceID string
 	var sequenceNumber int64
 
@@ -180,7 +180,7 @@ func TestLoadsDataForPrivateRegistryTask(t *testing.T) {
 	defer cleanup()
 	cfg := &config.Config{DataDir: filepath.Join(".", "testdata", "v14", "private-registry")}
 
-	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil)
+	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
 	var containerInstanceArn, cluster, savedInstanceID string
 	var sequenceNumber int64
 
@@ -226,7 +226,7 @@ func TestLoadsDataForSecretsTask(t *testing.T) {
 	require.Nil(t, err, "Failed to set up test")
 	defer cleanup()
 	cfg := &config.Config{DataDir: filepath.Join(".", "testdata", "v17", "secrets")}
-	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil)
+	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
 	var containerInstanceArn, cluster, savedInstanceID string
 	var sequenceNumber int64
 	stateManager, err := statemanager.NewStateManager(cfg,
@@ -264,7 +264,7 @@ func TestLoadsDataForAddingAvailabilityZoneInTask(t *testing.T) {
 	require.Nil(t, err, "Failed to set up test")
 	defer cleanup()
 	cfg := &config.Config{DataDir: filepath.Join(".", "testdata", "v18", "availabilityZone")}
-	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil)
+	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
 	var containerInstanceArn, cluster, savedInstanceID, availabilityZone string
 	var sequenceNumber int64
 	stateManager, err := statemanager.NewStateManager(cfg,
@@ -295,7 +295,7 @@ func TestLoadsDataForASMSecretsTask(t *testing.T) {
 	require.Nil(t, err, "Failed to set up test")
 	defer cleanup()
 	cfg := &config.Config{DataDir: filepath.Join(".", "testdata", "v18", "secrets")}
-	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil)
+	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
 	var containerInstanceArn, cluster, savedInstanceID string
 	var sequenceNumber int64
 	stateManager, err := statemanager.NewStateManager(cfg,
@@ -334,7 +334,7 @@ func TestLoadsDataForContainerOrdering(t *testing.T) {
 	require.Nil(t, err, "Failed to set up test")
 	defer cleanup()
 	cfg := &config.Config{DataDir: filepath.Join(".", "testdata", "v20", "containerOrdering")}
-	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil)
+	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
 	var containerInstanceArn, cluster, savedInstanceID string
 	var sequenceNumber int64
 	stateManager, err := statemanager.NewStateManager(cfg,
@@ -369,7 +369,7 @@ func TestLoadsDataForPerContainerTimeouts(t *testing.T) {
 	require.Nil(t, err, "Failed to set up test")
 	defer cleanup()
 	cfg := &config.Config{DataDir: filepath.Join(".", "testdata", "v20", "perContainerTimeouts")}
-	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil)
+	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
 	var containerInstanceArn, cluster, savedInstanceID string
 	var sequenceNumber int64
 	stateManager, err := statemanager.NewStateManager(cfg,
@@ -404,7 +404,7 @@ func TestLoadsDataForContainerRuntimeID(t *testing.T) {
 	require.Nil(t, err, "Failed to set up test")
 	defer cleanup()
 	cfg := &config.Config{DataDir: filepath.Join(".", "testdata", "v23", "perContainerRuntimeID")}
-	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil)
+	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
 	var containerInstanceArn, cluster, savedInstanceID string
 	var sequenceNumber int64
 	stateManager, err := statemanager.NewStateManager(cfg,
@@ -435,7 +435,7 @@ func TestLoadsDataForContainerImageDigest(t *testing.T) {
 	require.Nil(t, err, "Failed to set up test")
 	defer cleanup()
 	cfg := &config.Config{DataDir: filepath.Join(".", "testdata", "v24", "perContainerImageDigest")}
-	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil)
+	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
 	var containerInstanceArn, cluster, savedInstanceID string
 	var sequenceNumber int64
 	stateManager, err := statemanager.NewStateManager(cfg,
@@ -466,7 +466,7 @@ func TestLoadsDataSeqTaskManifest(t *testing.T) {
 	require.Nil(t, err, "Failed to set up test")
 	defer cleanup()
 	cfg := &config.Config{DataDir: filepath.Join(".", "testdata", "v25", "seqNumTaskManifest")}
-	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil)
+	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
 	var containerInstanceArn, cluster, savedInstanceID string
 	var sequenceNumber, seqNumTaskManifest int64
 	stateManager, err := statemanager.NewStateManager(cfg,
@@ -493,7 +493,7 @@ func TestLoadsDataForEnvFiles(t *testing.T) {
 	require.Nil(t, err, "Failed to set up test")
 	defer cleanup()
 	cfg := &config.Config{DataDir: filepath.Join(".", "testdata", "v28", "environmentFiles")}
-	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil)
+	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
 	var containerInstanceArn, cluster, savedInstanceID string
 	var sequenceNumber int64
 	stateManager, err := statemanager.NewStateManager(cfg,

--- a/agent/statemanager/state_manager_unix_test.go
+++ b/agent/statemanager/state_manager_unix_test.go
@@ -48,7 +48,7 @@ func TestStateManager(t *testing.T) {
 	// Now let's make some state to save
 	containerInstanceArn := ""
 	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(),
-		nil, nil, nil)
+		nil, nil, nil, nil)
 
 	manager, err = statemanager.NewStateManager(cfg, statemanager.AddSaveable("TaskEngine", taskEngine),
 		statemanager.AddSaveable("ContainerInstanceArn", &containerInstanceArn))
@@ -66,7 +66,7 @@ func TestStateManager(t *testing.T) {
 
 	// Now make sure we can load that state sanely
 	loadedTaskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(),
-		nil, nil, nil)
+		nil, nil, nil, nil)
 	var loadedContainerInstanceArn string
 
 	manager, err = statemanager.NewStateManager(cfg, statemanager.AddSaveable("TaskEngine", &loadedTaskEngine),
@@ -111,7 +111,7 @@ func TestLoadsDataForAWSVPCTask(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := &config.Config{DataDir: filepath.Join(".", "testdata", "v11", tc.dir)}
 
-			taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil)
+			taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
 			var containerInstanceArn, cluster, savedInstanceID string
 
 			stateManager, err := statemanager.NewStateManager(cfg,
@@ -150,7 +150,7 @@ func TestLoadsDataForAWSVPCTask(t *testing.T) {
 // verify that the state manager correctly loads gpu related fields in state file
 func TestLoadsDataForGPU(t *testing.T) {
 	cfg := &config.Config{DataDir: filepath.Join(".", "testdata", "v18", "gpu")}
-	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil)
+	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
 	var containerInstanceArn, cluster, savedInstanceID string
 	var sequenceNumber int64
 	stateManager, err := statemanager.NewStateManager(cfg,
@@ -195,7 +195,7 @@ func TestLoadsDataForGPU(t *testing.T) {
 
 func TestLoadsDataForFirelensTask(t *testing.T) {
 	cfg := &config.Config{DataDir: filepath.Join(".", "testdata", "v23", "firelens")}
-	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil)
+	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
 	var containerInstanceArn, cluster, savedInstanceID string
 	var sequenceNumber int64
 	stateManager, err := statemanager.NewStateManager(cfg,
@@ -243,7 +243,7 @@ func TestLoadsDataForFirelensTask(t *testing.T) {
 
 func TestLoadsDataForFirelensTaskWithExternalConfig(t *testing.T) {
 	cfg := &config.Config{DataDir: filepath.Join(".", "testdata", "v24", "firelens")}
-	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil)
+	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
 	var containerInstanceArn, cluster, savedInstanceID string
 	var sequenceNumber int64
 	stateManager, err := statemanager.NewStateManager(cfg,
@@ -297,7 +297,7 @@ func TestLoadsDataForFirelensTaskWithExternalConfig(t *testing.T) {
 
 func TestLoadsDataForEFSGATask(t *testing.T) {
 	cfg := &config.Config{DataDir: filepath.Join(".", "testdata", "v27", "efs")}
-	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil)
+	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
 	var containerInstanceArn, cluster, savedInstanceID string
 	var sequenceNumber int64
 	stateManager, err := statemanager.NewStateManager(cfg,

--- a/agent/statemanager/state_manager_win_test.go
+++ b/agent/statemanager/state_manager_win_test.go
@@ -36,7 +36,7 @@ func TestLoadsDataForGMSATask(t *testing.T) {
 	defer cleanup()
 
 	cfg := &config.Config{DataDir: filepath.Join(".", "testdata", "v26", "gmsa")}
-	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil)
+	taskEngine := engine.NewTaskEngine(&config.Config{}, nil, nil, nil, nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
 	var containerInstanceArn, cluster, savedInstanceID string
 	var sequenceNumber int64
 

--- a/agent/stats/engine_integ_test.go
+++ b/agent/stats/engine_integ_test.go
@@ -83,7 +83,7 @@ func TestStatsEngineWithExistingContainersWithoutHealth(t *testing.T) {
 
 	containerChangeEventStream := eventStream("TestStatsEngineWithExistingContainersWithoutHealth")
 	taskEngine := ecsengine.NewTaskEngine(&config.Config{}, nil, nil, containerChangeEventStream,
-		nil, dockerstate.NewTaskEngineState(), nil, nil, nil)
+		nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
 	testTask := createRunningTask("default")
 	// Populate Tasks and Container map in the engine.
 	dockerTaskEngine := taskEngine.(*ecsengine.DockerTaskEngine)
@@ -142,7 +142,7 @@ func TestStatsEngineWithNewContainersWithoutHealth(t *testing.T) {
 
 	containerChangeEventStream := eventStream("TestStatsEngineWithNewContainers")
 	taskEngine := ecsengine.NewTaskEngine(&config.Config{}, nil, nil, containerChangeEventStream,
-		nil, dockerstate.NewTaskEngineState(), nil, nil, nil)
+		nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
 	testTask := createRunningTask("default")
 	// Populate Tasks and Container map in the engine.
 	dockerTaskEngine := taskEngine.(*ecsengine.DockerTaskEngine)
@@ -220,7 +220,7 @@ func TestStatsEngineWithExistingContainers(t *testing.T) {
 
 	containerChangeEventStream := eventStream("TestStatsEngineWithExistingContainers")
 	taskEngine := ecsengine.NewTaskEngine(&config.Config{}, nil, nil, containerChangeEventStream,
-		nil, dockerstate.NewTaskEngineState(), nil, nil, nil)
+		nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
 	testTask := createRunningTask("bridge")
 	// enable container health check for this container
 	testTask.Containers[0].HealthCheckType = "docker"
@@ -287,7 +287,7 @@ func TestStatsEngineWithNewContainers(t *testing.T) {
 
 	containerChangeEventStream := eventStream("TestStatsEngineWithNewContainers")
 	taskEngine := ecsengine.NewTaskEngine(&config.Config{}, nil, nil, containerChangeEventStream,
-		nil, dockerstate.NewTaskEngineState(), nil, nil, nil)
+		nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
 
 	testTask := createRunningTask("bridge")
 	// enable health check of the container
@@ -369,7 +369,7 @@ func TestStatsEngineWithNewContainersWithPolling(t *testing.T) {
 
 	containerChangeEventStream := eventStream("TestStatsEngineWithNewContainers")
 	taskEngine := ecsengine.NewTaskEngine(&config.Config{}, nil, nil, containerChangeEventStream,
-		nil, dockerstate.NewTaskEngineState(), nil, nil, nil)
+		nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
 
 	testTask := createRunningTask("bridge")
 	// enable health check of the container
@@ -434,7 +434,7 @@ func TestStatsEngineWithNewContainersWithPolling(t *testing.T) {
 func TestStatsEngineWithDockerTaskEngine(t *testing.T) {
 	containerChangeEventStream := eventStream("TestStatsEngineWithDockerTaskEngine")
 	taskEngine := ecsengine.NewTaskEngine(&config.Config{}, nil, nil, containerChangeEventStream,
-		nil, dockerstate.NewTaskEngineState(), nil, nil, nil)
+		nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
 	container, err := createHealthContainer(client)
 	require.NoError(t, err, "creating container failed")
 	ctx, cancel := context.WithCancel(context.TODO())
@@ -518,7 +518,7 @@ func TestStatsEngineWithDockerTaskEngine(t *testing.T) {
 func TestStatsEngineWithDockerTaskEngineMissingRemoveEvent(t *testing.T) {
 	containerChangeEventStream := eventStream("TestStatsEngineWithDockerTaskEngineMissingRemoveEvent")
 	taskEngine := ecsengine.NewTaskEngine(&config.Config{}, nil, nil, containerChangeEventStream,
-		nil, dockerstate.NewTaskEngineState(), nil, nil, nil)
+		nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 
@@ -581,10 +581,10 @@ func TestStatsEngineWithDockerTaskEngineMissingRemoveEvent(t *testing.T) {
 }
 
 func TestStatsEngineWithNetworkStatsDefaultMode(t *testing.T) {
-	testNetworkModeStats(t, "default", false)
+	testNetworkModeStatsInteg(t, "default", false)
 }
 
-func testNetworkModeStats(t *testing.T, networkMode string, statsEmpty bool) {
+func testNetworkModeStatsInteg(t *testing.T, networkMode string, statsEmpty bool) {
 	// Create a new docker stats engine
 	engine := NewDockerStatsEngine(&cfg, dockerClient, eventStream("TestStatsEngineWithNetworkStats"))
 	ctx, cancel := context.WithCancel(context.TODO())
@@ -607,7 +607,7 @@ func testNetworkModeStats(t *testing.T, networkMode string, statsEmpty bool) {
 
 	containerChangeEventStream := eventStream("TestStatsEngineWithNetworkStats")
 	taskEngine := ecsengine.NewTaskEngine(&config.Config{}, nil, nil, containerChangeEventStream,
-		nil, dockerstate.NewTaskEngineState(), nil, nil, nil)
+		nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
 	testTask := createRunningTask(networkMode)
 
 	// Populate Tasks and Container map in the engine.
@@ -688,7 +688,7 @@ func TestStorageStats(t *testing.T) {
 
 	containerChangeEventStream := eventStream("TestStatsEngineWithStorageStats")
 	taskEngine := ecsengine.NewTaskEngine(&config.Config{}, nil, nil, containerChangeEventStream,
-		nil, dockerstate.NewTaskEngineState(), nil, nil, nil)
+		nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
 	testTask := createRunningTask("bridge")
 
 	// Populate Tasks and Container map in the engine.

--- a/agent/stats/engine_unix_integ_test.go
+++ b/agent/stats/engine_unix_integ_test.go
@@ -63,7 +63,7 @@ func TestStatsEngineWithNetworkStatsDifferentModes(t *testing.T) {
 		{"none", true},
 	}
 	for _, tc := range networkModes {
-		testNetworkModeStats(t, tc.NetworkMode, tc.StatsEmpty)
+		testNetworkModeStatsInteg(t, tc.NetworkMode, tc.StatsEmpty)
 	}
 }
 
@@ -110,7 +110,7 @@ func TestStatsEngineWithServiceConnectMetrics(t *testing.T) {
 
 			containerChangeEventStream := eventStream("TestStatsEngineWithServiceConnectMetrics")
 			taskEngine := ecsengine.NewTaskEngine(&config.Config{}, nil, nil, containerChangeEventStream,
-				nil, dockerstate.NewTaskEngineState(), nil, nil, nil)
+				nil, dockerstate.NewTaskEngineState(), nil, nil, nil, nil)
 			testTask := createRunningTask("bridge")
 			testTask.ServiceConnectConfig = &serviceconnect.Config{
 				ContainerName: serviceConnectContainerName,


### PR DESCRIPTION
Summary
This CR finalizes the process of starting a Relay Container and auto assigning images to task containers.

Implementation details
Create a new task with an internal container which is run in host mode on the instance.

Update container images for task containers for service connect.

Licensing
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.