### PR TITLE
fix format string for ecs-init logging

### DIFF
--- a/ecs-init/engine/engine.go
+++ b/ecs-init/engine/engine.go
@@ -139,7 +139,7 @@ func (e *Engine) PreStart() error {
 	if err != nil {
 		return engineError("could not check Docker for Agent image presence", err)
 	}
-	log.Infof("pre-start: ecs agent container image loaded presence: %s", imageLoaded)
+	log.Infof("pre-start: ecs agent container image loaded presence: %t", imageLoaded)
 
 	switch e.downloader.AgentCacheStatus() {
 	// Uncached, go get the Agent.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

fix format string for ecs-init log.

### Implementation details
<!-- How are the changes implemented? -->

using "%t" instead of "%s".

Currently, ecs init outputs a following log

```
 [INFO] pre-start: ecs agent container image loaded presence: %!s(bool=true)
```

`docker.IsAgentImageLoaded()` returns bool but using "%s" for logging.

https://github.com/aws/amazon-ecs-agent/blob/dev/ecs-init/engine/engine.go#L142

ecs-init repository has same issue. If ecs-init repository requires fix, please let me know.
https://github.com/aws/amazon-ecs-init/blob/master/ecs-init/engine/engine.go#L142

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

- fix format string for ecs-init logging

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.