### PR TITLE
Ubuntu CodeBuild Buildspec log fix

### DIFF
--- a/buildspecs/merge-build.yml
+++ b/buildspecs/merge-build.yml
@@ -23,7 +23,6 @@ phases:
           ;;
         esac
 
-      # Set up proper go version using goenv utility (pre-installed in CodeBuild). Need to use this because default images come with 1.14.x
       - GOVERSION="$(cat GO_VERSION)"
       - GOLANG_TAR="go${GOVERSION}.linux-${architecture}.tar.gz"
 

--- a/buildspecs/pr-build-ubuntu.yml
+++ b/buildspecs/pr-build-ubuntu.yml
@@ -21,6 +21,7 @@ phases:
 
   build:
     commands:
+      - BUILD_LOG="ubuntu_build_${architecture}.log"
       - echo "build_id = $CODEBUILD_LOG_PATH" 2>&1 | tee -a $BUILD_LOG
       - echo "Building agent deb" 2>&1 | tee -a $BUILD_LOG
       - AGENT_VERSION=$(cat VERSION)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Adds ```BUILD_LOG``` variable to ubuntu codebuild buildspec which was missing. This led to build log files not being produced (as this variable was empty). This should be fixed now.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> no test added

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Ubuntu CodeBuild Buildspec log fix

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
