### PR TITLE
logic to turn disconnectedMode on/off

### DIFF
--- a/agent/acs/handler/acs_handler_test.go
+++ b/agent/acs/handler/acs_handler_test.go
@@ -145,6 +145,12 @@ var testConfig = &config.Config{
 	AcceptInsecureCert: true,
 }
 
+var testConfigDisconnect = &config.Config{
+	Cluster:            "someCluster",
+	AcceptInsecureCert: true,
+	DisconnectCapable:  config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled},
+}
+
 var testCreds = credentials.NewStaticCredentials("test-id", "test-secret", "test-token")
 
 type mockSessionResources struct {
@@ -326,124 +332,78 @@ func TestShouldReconnectWithoutBackoffReturnsFalseForNonEOF(t *testing.T) {
 // TestHandlerReconnectsWithoutBackoffOnEOFError tests if the session handler reconnects
 // to ACS without any delay when the connection is closed with the io.EOF error
 func TestHandlerReconnectsWithoutBackoffOnEOFError(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	taskEngine := mock_engine.NewMockTaskEngine(ctrl)
-	taskEngine.EXPECT().Version().Return("Docker: 1.5.0", nil).AnyTimes()
-
-	ecsClient := mock_api.NewMockECSClient(ctrl)
-	ecsClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(acsURL, nil).AnyTimes()
-
-	ctx, cancel := context.WithCancel(context.Background())
-	taskHandler := eventhandler.NewTaskHandler(ctx, data.NewNoopClient(), nil, nil)
-
-	deregisterInstanceEventStream := eventstream.NewEventStream("DeregisterContainerInstance", ctx)
-	deregisterInstanceEventStream.StartListening()
-
-	mockBackoff := mock_retry.NewMockBackoff(ctrl)
-	mockWsClient := mock_wsclient.NewMockClientServer(ctrl)
-	mockWsClient.EXPECT().SetAnyRequestHandler(gomock.Any()).AnyTimes()
-	mockWsClient.EXPECT().AddRequestHandler(gomock.Any()).AnyTimes()
-	mockWsClient.EXPECT().Close().Return(nil).AnyTimes()
-	gomock.InOrder(
-		mockWsClient.EXPECT().Connect().Return(io.EOF),
-		// The backoff.Reset() method is expected to be invoked when the connection
-		// is closed with io.EOF
-		mockBackoff.EXPECT().Reset(),
-		mockWsClient.EXPECT().Connect().Do(func() {
-			// cancel the context on the 2nd connect attempt, which should stop
-			// the test
-			cancel()
-		}).Return(io.EOF),
-		mockBackoff.EXPECT().Reset().AnyTimes(),
-	)
-	acsSession := session{
-		containerInstanceARN:            "myArn",
-		credentialsProvider:             testCreds,
-		agentConfig:                     testConfig,
-		taskEngine:                      taskEngine,
-		ecsClient:                       ecsClient,
-		deregisterInstanceEventStream:   deregisterInstanceEventStream,
-		dataClient:                      data.NewNoopClient(),
-		taskHandler:                     taskHandler,
-		backoff:                         mockBackoff,
-		ctx:                             ctx,
-		cancel:                          cancel,
-		resources:                       &mockSessionResources{mockWsClient},
-		latestSeqNumTaskManifest:        aws.Int64(10),
-		_heartbeatTimeout:               20 * time.Millisecond,
-		_heartbeatJitter:                10 * time.Millisecond,
-		_inactiveInstanceReconnectDelay: inactiveInstanceReconnectDelay,
+	testCases := []struct {
+		Name   string
+		Config *config.Config
+	}{
+		{
+			Name:   "disconnect capable off",
+			Config: testConfig,
+		},
+		{
+			Name:   "disconnect capable on",
+			Config: testConfigDisconnect,
+		},
 	}
-	go func() {
-		acsSession.Start()
-	}()
+	for _, tc := range testCases {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
 
-	// Wait for context to be cancelled
-	select {
-	case <-ctx.Done():
-	}
-}
+		taskEngine := mock_engine.NewMockTaskEngine(ctrl)
+		taskEngine.EXPECT().Version().Return("Docker: 1.5.0", nil).AnyTimes()
 
-// TestHandlerReconnectsWithoutBackoffOnEOFError tests if the session handler reconnects
-// to ACS after a backoff duration when the connection is closed with non io.EOF error
-func TestHandlerReconnectsWithBackoffOnNonEOFError(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
+		ecsClient := mock_api.NewMockECSClient(ctrl)
+		ecsClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(acsURL, nil).AnyTimes()
 
-	taskEngine := mock_engine.NewMockTaskEngine(ctrl)
-	taskEngine.EXPECT().Version().Return("Docker: 1.5.0", nil).AnyTimes()
+		ctx, cancel := context.WithCancel(context.Background())
+		taskHandler := eventhandler.NewTaskHandler(ctx, data.NewNoopClient(), nil, nil)
 
-	ecsClient := mock_api.NewMockECSClient(ctrl)
-	ecsClient.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(acsURL, nil).AnyTimes()
+		deregisterInstanceEventStream := eventstream.NewEventStream("DeregisterContainerInstance", ctx)
+		deregisterInstanceEventStream.StartListening()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	taskHandler := eventhandler.NewTaskHandler(ctx, data.NewNoopClient(), nil, nil)
+		mockBackoff := mock_retry.NewMockBackoff(ctrl)
+		mockWsClient := mock_wsclient.NewMockClientServer(ctrl)
+		mockWsClient.EXPECT().SetAnyRequestHandler(gomock.Any()).AnyTimes()
+		mockWsClient.EXPECT().AddRequestHandler(gomock.Any()).AnyTimes()
+		mockWsClient.EXPECT().Close().Return(nil).AnyTimes()
+		gomock.InOrder(
+			mockWsClient.EXPECT().Connect().Return(io.EOF),
+			// The backoff.Reset() method is expected to be invoked when the connection
+			// is closed with io.EOF
+			mockBackoff.EXPECT().Reset(),
+			mockWsClient.EXPECT().Connect().Do(func() {
+				// cancel the context on the 2nd connect attempt, which should stop
+				// the test
+				cancel()
+			}).Return(io.EOF),
+			mockBackoff.EXPECT().Reset().AnyTimes(),
+		)
+		acsSession := session{
+			containerInstanceARN:            "myArn",
+			credentialsProvider:             testCreds,
+			agentConfig:                     tc.Config,
+			taskEngine:                      taskEngine,
+			ecsClient:                       ecsClient,
+			deregisterInstanceEventStream:   deregisterInstanceEventStream,
+			dataClient:                      data.NewNoopClient(),
+			taskHandler:                     taskHandler,
+			backoff:                         mockBackoff,
+			ctx:                             ctx,
+			cancel:                          cancel,
+			resources:                       &mockSessionResources{mockWsClient},
+			latestSeqNumTaskManifest:        aws.Int64(10),
+			_heartbeatTimeout:               20 * time.Millisecond,
+			_heartbeatJitter:                10 * time.Millisecond,
+			_inactiveInstanceReconnectDelay: inactiveInstanceReconnectDelay,
+		}
+		go func() {
+			acsSession.Start()
+		}()
 
-	deregisterInstanceEventStream := eventstream.NewEventStream("DeregisterContainerInstance", ctx)
-	deregisterInstanceEventStream.StartListening()
-
-	mockBackoff := mock_retry.NewMockBackoff(ctrl)
-	mockWsClient := mock_wsclient.NewMockClientServer(ctrl)
-	mockWsClient.EXPECT().SetAnyRequestHandler(gomock.Any()).AnyTimes()
-	mockWsClient.EXPECT().AddRequestHandler(gomock.Any()).AnyTimes()
-	mockWsClient.EXPECT().Close().Return(nil).AnyTimes()
-	gomock.InOrder(
-		mockWsClient.EXPECT().Connect().Return(fmt.Errorf("not EOF")),
-		// The backoff.Duration() method is expected to be invoked when
-		// the connection is closed with a non-EOF error code to compute
-		// the backoff. Also, no calls to backoff.Reset() are expected
-		// in this code path.
-		mockBackoff.EXPECT().Duration().Return(time.Millisecond),
-		mockWsClient.EXPECT().Connect().Do(func() {
-			cancel()
-		}).Return(io.EOF),
-		mockBackoff.EXPECT().Reset().AnyTimes(),
-	)
-	acsSession := session{
-		containerInstanceARN:          "myArn",
-		credentialsProvider:           testCreds,
-		agentConfig:                   testConfig,
-		taskEngine:                    taskEngine,
-		ecsClient:                     ecsClient,
-		deregisterInstanceEventStream: deregisterInstanceEventStream,
-		dataClient:                    data.NewNoopClient(),
-		taskHandler:                   taskHandler,
-		backoff:                       mockBackoff,
-		ctx:                           ctx,
-		cancel:                        cancel,
-		resources:                     &mockSessionResources{mockWsClient},
-		_heartbeatTimeout:             20 * time.Millisecond,
-		_heartbeatJitter:              10 * time.Millisecond,
-	}
-	go func() {
-		acsSession.Start()
-	}()
-
-	// Wait for context to be cancelled
-	select {
-	case <-ctx.Done():
+		// Wait for context to be cancelled
+		select {
+		case <-ctx.Done():
+		}
 	}
 }
 

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -195,7 +195,7 @@ var (
 	disconnectMode = DisconnectMode{}
 )
 
-func GetDisconnectModeEnabled() bool {
+func (cfg *Config) GetDisconnectModeEnabled() bool {
 
 	disconnectMode.disconnectModeLock.RLock()
 	defer disconnectMode.disconnectModeLock.RUnlock()
@@ -203,7 +203,7 @@ func GetDisconnectModeEnabled() bool {
 	return disconnectMode.disconnectModeEnabled
 }
 
-func SetDisconnectModeEnabled(desiredDisconnectEnabledStatus bool) {
+func (cfg *Config) SetDisconnectModeEnabled(desiredDisconnectEnabledStatus bool) {
 
 	disconnectMode.disconnectModeLock.Lock()
 	defer disconnectMode.disconnectModeLock.Unlock()

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -34,17 +34,19 @@ import (
 )
 
 func TestDefaultValueOfDisconnectModeEnabled(t *testing.T) {
+	conf := Config{Cluster: "Foo"}
 
-	assert.False(t, GetDisconnectModeEnabled(), "Wrong default value for disconnectModeEnabled, expected value is false")
+	assert.False(t, conf.GetDisconnectModeEnabled(), "Wrong default value for disconnectModeEnabled, expected value is false")
 }
 
 func TestGetAndSetDisconnectModeEnabled(t *testing.T) {
+	conf := Config{Cluster: "Foo"}
 
-	SetDisconnectModeEnabled(true)
-	assert.True(t, GetDisconnectModeEnabled(), "Wrong value for disconnectModeEnabled, expected value is true")
+	conf.SetDisconnectModeEnabled(true)
+	assert.True(t, conf.GetDisconnectModeEnabled(), "Wrong value for disconnectModeEnabled, expected value is true")
 
-	SetDisconnectModeEnabled(false)
-	assert.False(t, GetDisconnectModeEnabled(), "Wrong value for disconnectModeEnabled, expected value is false")
+	conf.SetDisconnectModeEnabled(false)
+	assert.False(t, conf.GetDisconnectModeEnabled(), "Wrong value for disconnectModeEnabled, expected value is false")
 }
 
 func TestMerge(t *testing.T) {


### PR DESCRIPTION
### Summary
Logic to turn disconnected mode on after five minutes of no connection, and to turn off once connection resumes.
Updated config functions to be callable from the ACS Handler.
### Implementation details
In acs_handler.go, lines 237-255 is the main bulk of logic to turn disconnected mode on. Once there is a failure to connect, a 5 minute timer gets started. Within the 5 minutes, the code will attempt to reconnect to ACS every minute. After continuous failure to connect, then disconnection mode is turned on.
In acs_handler.go, lines 404-413, disconnected mode is turned off once connection successfully resumes, and the timer is terminated if it has been initialized.
In config.go, the config is added as one of the inputs to the GetDisconnectionMode() and SetDisconnectionMode() functions so it can be referenced from other files.
### Testing
Tested manually through checking log messages on an EC2 instance while turning internet connection on and off.
Adjusted one unit test for ACS handler to use a config with disconnection capability turned on. This proved that even if disconnection mode is capable, the normal behavior of reconnecting due to EOF error is still functional.
Adjusted unit tests for config by initializing and using a *config as one of the inputs to GetDisconnectionMode() and SetDisconnectionMode() .
### Description for the changelog
Feature - Logic to turn disconnect mode on/off

### Licensing
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.