### PR TITLE
initialize networkmode before we validate the payload

### DIFF
--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -322,6 +322,9 @@ func TaskFromACS(acsTask *ecsacs.Task, envelope *ecsacs.PayloadMessage) (*Task, 
 	//initialize resources map for task
 	task.ResourcesMapUnsafe = make(map[string][]taskresource.TaskResource)
 
+	// initialize network mode so service connect validations are accurate
+	task.initNetworkMode()
+
 	// extract and validate attachments
 	if err := handleTaskAttachments(acsTask, task); err != nil {
 		return nil, err

--- a/agent/api/task/task_attachment_handler.go
+++ b/agent/api/task/task_attachment_handler.go
@@ -25,7 +25,7 @@ import (
 // AttachmentHandler defines an interface to handel attachment received from ACS.
 type AttachmentHandler interface {
 	parseAttachment(acsAttachment *ecsacs.Attachment) error
-	validateAttachment(acsTask *ecsacs.Task) error
+	validateAttachment(acsTask *ecsacs.Task, networkMode string) error
 }
 
 // ServiceConnectAttachmentHandler defines a service connect type attachment handler.
@@ -56,10 +56,9 @@ func (scAttachment *ServiceConnectAttachmentHandler) parseAttachment(acsAttachme
 }
 
 // attachment validator of service connect attachment handler.
-func (scAttachment *ServiceConnectAttachmentHandler) validateAttachment(acsTask *ecsacs.Task) error {
+func (scAttachment *ServiceConnectAttachmentHandler) validateAttachment(acsTask *ecsacs.Task, networkMode string) error {
 	config := scAttachment.scConfig
 	taskContainers := acsTask.Containers
-	networkMode := aws.StringValue(acsTask.NetworkMode)
 	ipv6Enabled := false
 	if acsTask.ElasticNetworkInterfaces != nil {
 		for _, eni := range acsTask.ElasticNetworkInterfaces {
@@ -99,7 +98,7 @@ func handleTaskAttachments(acsTask *ecsacs.Task, task *Task) error {
 			}
 
 			// validate the service connect config parsed from the service connect attachment
-			if err := scHandler.(*ServiceConnectAttachmentHandler).validateAttachment(acsTask); err != nil {
+			if err := scHandler.(*ServiceConnectAttachmentHandler).validateAttachment(acsTask, task.NetworkMode); err != nil {
 				return fmt.Errorf("service connect config validation failed: %w", err)
 			}
 			task.ServiceConnectConfig = scHandler.(*ServiceConnectAttachmentHandler).scConfig


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

loosening validation around network mode to include an empty network mode


### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
added a new unit test


### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
