### PR TITLE
Skip adding network stats for pause containers of Service Connect enabled tasks running in bridge mode

### DIFF
--- a/agent/stats/engine_unix_integ_test.go
+++ b/agent/stats/engine_unix_integ_test.go
@@ -111,7 +111,7 @@ func TestStatsEngineWithServiceConnectMetrics(t *testing.T) {
 			containerChangeEventStream := eventStream("TestStatsEngineWithServiceConnectMetrics")
 			taskEngine := ecsengine.NewTaskEngine(&config.Config{}, nil, nil, containerChangeEventStream,
 				nil, dockerstate.NewTaskEngineState(), nil, nil, nil)
-			testTask := createRunningTask()
+			testTask := createRunningTask("bridge")
 			testTask.ServiceConnectConfig = &serviceconnect.Config{
 				ContainerName: serviceConnectContainerName,
 				RuntimeConfig: serviceconnect.RuntimeConfig{

--- a/agent/stats/engine_unix_test.go
+++ b/agent/stats/engine_unix_test.go
@@ -45,7 +45,7 @@ func TestLinuxTaskNetworkStatsSet(t *testing.T) {
 		{nil, "none", true},
 	}
 	for _, tc := range networkModes {
-		testNetworkModeStats(t, tc.NetworkMode, tc.ENIs, tc.StatsEmpty)
+		testNetworkModeStats(t, tc.NetworkMode, tc.ENIs, false, tc.StatsEmpty)
 	}
 }
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
For bridge mode, if task is Service Connect enabled, we create pause container for each task containers in order to setup necessary network configuration to ensure SC-modeled traffic is correctly proxied through Envoy.

This PR includes a change to skip adding network stats for these pause containers similar to awsvpc pause containers.

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
