### PR TITLE
Make buildvcs=false conditional on go version

### DIFF
--- a/scripts/build-cni-plugins
+++ b/scripts/build-cni-plugins
@@ -37,6 +37,8 @@ esac
 if [ "$architecture" == "amd64" ]; then export GOARCH=amd64; fi
 if [ "$architecture" == "arm64" ]; then export GOARCH=arm64; fi
 
+goversion=`go version | cut -d' ' -f3 | cut -c 3-`
+
 # this script assumes we've run the get-cni-sources make target to update the cni submodules
 ROOT=$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )
 cd "${ROOT}"
@@ -52,6 +54,12 @@ ln -s "${ROOT}/amazon-vpc-cni-plugins" "${GITPATH}"
 cd ${GITPATH}/amazon-ecs-cni-plugins && GO111MODULE=auto make plugins
 mkdir -p ${ROOT}/misc/plugins && cp -a ./bin/plugins/. ${ROOT}/misc/plugins/
 make clean
-cd ${GITPATH}/amazon-vpc-cni-plugins && GO111MODULE=on GOFLAGS="-mod=vendor -buildvcs=false" make aws-appmesh vpc-branch-eni
+
+# buildvcs=false excludes version control information in golang >= 1.18. This is required for compiling agent with included repositories
+if [[ $goversion < "1.18" ]]; then
+	cd ${GITPATH}/amazon-vpc-cni-plugins && GO111MODULE=on GOFLAGS="-mod=vendor" make aws-appmesh vpc-branch-eni
+else
+	cd ${GITPATH}/amazon-vpc-cni-plugins && GO111MODULE=on GOFLAGS="-mod=vendor -buildvcs=false" make aws-appmesh vpc-branch-eni
+fi
 cp -a ./build/linux_${GOARCH}/. ${ROOT}/misc/plugins/
 make clean


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
For building agent with Go 1.18, ```-buildvcs=false``` was introduced recently in this PR (#3273). While this change makes sure agent builds with Go 1.18, older versions do not recognize this flag, throw error and fail to compile. e.g.

```
go: parsing $GOFLAGS: unknown flag -buildvcs
make[2]: *** [Makefile:115: build/linux_amd64/aws-appmesh] Error 1
```

This PR makes the use of this flag conditioned on the go version installed.
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Tested by building packages with ```make generic-deb-integrated``` and ```make generic-rpm-integrated``` with golang 1.13.x and 1.18.x

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
