### PR TITLE
SC attachment fixes; Use network mode from ACS payload

### DIFF
--- a/agent/acs/handler/payload_handler_test.go
+++ b/agent/acs/handler/payload_handler_test.go
@@ -218,9 +218,11 @@ func TestHandlePayloadMessageSaveDataError(t *testing.T) {
 		Arn:                 "t1",
 		DesiredStatusUnsafe: apitaskstatus.TaskRunning,
 		ResourcesMapUnsafe:  make(map[string][]taskresource.TaskResource),
+		NetworkMode:         apitask.BridgeNetworkMode,
 	}
+	expectedTask.GetID() // to set the task setIdOnce (sync.Once) property
 
-	assert.Equal(t, addedTask, expectedTask, "added task is not expected")
+	assert.Equal(t, expectedTask, addedTask, "added task is not expected")
 }
 
 func newTestDataClient(t *testing.T) (data.Client, func()) {
@@ -278,8 +280,10 @@ func TestHandlePayloadMessageAckedWhenTaskAdded(t *testing.T) {
 	expectedTask := &apitask.Task{
 		Arn:                "t1",
 		ResourcesMapUnsafe: make(map[string][]taskresource.TaskResource),
+		NetworkMode:        apitask.BridgeNetworkMode,
 	}
-	assert.Equal(t, addedTask, expectedTask, "received task is not expected")
+	expectedTask.GetID() // to set the task setIdOnce (sync.Once) property
+	assert.Equal(t, expectedTask, addedTask, "received task is not expected")
 }
 
 // TestHandlePayloadMessageCredentialsAckedWhenTaskAdded tests if the handler generates
@@ -455,8 +459,10 @@ func TestPayloadBufferHandler(t *testing.T) {
 	expectedTask := &apitask.Task{
 		Arn:                taskArn,
 		ResourcesMapUnsafe: make(map[string][]taskresource.TaskResource),
+		NetworkMode:        apitask.BridgeNetworkMode,
 	}
-	assert.Equal(t, addedTask, expectedTask, "received task is not expected")
+	expectedTask.GetID() // to set the task setIdOnce (sync.Once) property
+	assert.Equal(t, expectedTask, addedTask, "received task is not expected")
 }
 
 // TestPayloadBufferHandlerWithCredentials tests if the async payloadBufferHandler routine
@@ -687,8 +693,10 @@ func validateTaskAndCredentials(taskCredentialsAck, expectedCredentialsAckForTas
 	expectedTask := &apitask.Task{
 		Arn:                expectedTaskArn,
 		ResourcesMapUnsafe: make(map[string][]taskresource.TaskResource),
+		NetworkMode:        apitask.BridgeNetworkMode,
 	}
 	expectedTask.SetCredentialsID(expectedTaskCredentials.CredentialsID)
+	expectedTask.GetID() // to set the task setIdOnce (sync.Once) property
 
 	if !reflect.DeepEqual(addedTask, expectedTask) {
 		return fmt.Errorf("Mismatch between expected and added tasks, expected: %v, added: %v", expectedTask, addedTask)

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -470,6 +470,8 @@ func (task *Task) initNetworkMode(acsTaskNetworkMode *string) {
 		task.NetworkMode = HostNetworkMode
 	case BridgeNetworkMode, "":
 		task.NetworkMode = BridgeNetworkMode
+	case networkModeNone:
+		task.NetworkMode = networkModeNone
 	default:
 		logger.Warn("Unmapped task network mode", logger.Fields{
 			field.TaskID:      task.GetID(),
@@ -478,7 +480,7 @@ func (task *Task) initNetworkMode(acsTaskNetworkMode *string) {
 	}
 	logger.Info("Task network mode initialized", logger.Fields{
 		field.TaskID:      task.GetID(),
-		field.NetworkMode: aws.StringValue(acsTaskNetworkMode),
+		field.NetworkMode: task.NetworkMode,
 	})
 }
 

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -156,7 +156,7 @@ const (
 	serviceConnectListenerPortMappingEnvVar = "APPNET_LISTENER_PORT_MAPPING"
 	serviceConnectContainerMappingEnvVar    = "APPNET_CONTAINER_IP_MAPPING"
 	// ServiceConnectAttachmentType specifies attachment type for service connect
-	serviceConnectAttachmentType = "ServiceConnect"
+	serviceConnectAttachmentType = "serviceconnectdetail"
 )
 
 // TaskOverrides are the overrides applied to a task
@@ -322,6 +322,8 @@ func TaskFromACS(acsTask *ecsacs.Task, envelope *ecsacs.PayloadMessage) (*Task, 
 	//initialize resources map for task
 	task.ResourcesMapUnsafe = make(map[string][]taskresource.TaskResource)
 
+	task.initNetworkMode(acsTask.NetworkMode)
+
 	// extract and validate attachments
 	if err := handleTaskAttachments(acsTask, task); err != nil {
 		return nil, err
@@ -353,7 +355,6 @@ func (task *Task) PostUnmarshalTask(cfg *config.Config,
 	credentialsManager credentials.Manager, resourceFields *taskresource.ResourceFields,
 	dockerClient dockerapi.DockerClient, ctx context.Context, options ...Option) error {
 
-	task.initNetworkMode()
 	task.adjustForPlatform(cfg)
 
 	// TODO, add rudimentary plugin support and call any plugins that want to
@@ -459,69 +460,36 @@ func (task *Task) PostUnmarshalTask(cfg *config.Config,
 }
 
 // initNetworkMode initializes/infers the network mode for the task and assigns the result to this task's NetworkMode field.
-// This is necessary because ACS doesn't send the actual network mode declared in task def.
-// TODO [SC]: Instead of doing this, it's perhaps better/easier to just ask ACS to send network mode from task definition. Using this in the meantime to avoid being blocked.
-func (task *Task) initNetworkMode() {
-	if len(task.ENIs) > 0 {
+// ACS is streaming down this value with task payload. In case of docker bridge mode task, this value might be left empty
+// as it's the default task network mode.
+func (task *Task) initNetworkMode(acsTaskNetworkMode *string) {
+	switch aws.StringValue(acsTaskNetworkMode) {
+	case AWSVPCNetworkMode:
 		task.NetworkMode = AWSVPCNetworkMode
-		return
+	case HostNetworkMode:
+		task.NetworkMode = HostNetworkMode
+	case BridgeNetworkMode, "":
+		task.NetworkMode = BridgeNetworkMode
+	default:
+		logger.Warn("Unmapped task network mode", logger.Fields{
+			field.TaskID:      task.GetID(),
+			field.NetworkMode: aws.StringValue(acsTaskNetworkMode),
+		})
 	}
-	for _, c := range task.Containers {
-		// ACS sets task def network mode to each and every customer container docker host config, so the presence
-		// of one container with a given network mode is enough to infer the task network mode
-		switch c.GetNetworkModeFromHostConfig() {
-		case BridgeNetworkMode:
-			task.NetworkMode = BridgeNetworkMode
-			return
-		case HostNetworkMode:
-			task.NetworkMode = HostNetworkMode
-			return
-		case "":
-			// the absence of a network mode means the default docker network mode is used, which, for ECS it's bridge.
-			// for future proofing, let's keep inspecting the rest of the containers for this particular case.
-			continue
-		}
-	}
-	// If we reached this part, it means none of the containers has network mode set, which means bridge mode (default)
-	task.NetworkMode = BridgeNetworkMode
+	logger.Info("Task network mode initialized", logger.Fields{
+		field.TaskID:      task.GetID(),
+		field.NetworkMode: aws.StringValue(acsTaskNetworkMode),
+	})
 }
 
 func (task *Task) initServiceConnectResources() error {
-	// TODO [SC]: ServiceConnectConfig will come from ACS. Adding this here for dev/testing purposes only Remove when
-	// ACS model is integrated
-	if task.ServiceConnectConfig == nil {
-		task.ServiceConnectConfig = &serviceconnect.Config{
-			ContainerName: "service-connect",
-		}
-	}
-	// TODO [SC]: End dev/testing purposes
 	if task.IsServiceConnectEnabled() {
-		// TODO [SC]: initDummyServiceConnectConfig is for dev testing only, remove it when final SC model from ACS is in place
-		task.initDummyServiceConnectConfig()
-		// TODO [SC]: End dev/testing purposes
 		if err := task.initServiceConnectEphemeralPorts(); err != nil {
 			return err
 		}
 	}
 	return nil
 }
-
-// TODO [SC]: This is for dev testing only, remove it when final SC model from ACS is in place
-func (task *Task) initDummyServiceConnectConfig() {
-	scContainer := task.GetServiceConnectContainer()
-	if _, ok := scContainer.Environment["SC_CONFIG"]; !ok {
-		// no SC_CONFIG :(
-		return
-	}
-	if err := json.Unmarshal([]byte(scContainer.Environment["SC_CONFIG"]), task.ServiceConnectConfig); err != nil {
-		logger.Error("Error parsing SC_CONFIG", logger.Fields{
-			field.Error: err,
-		})
-		return
-	}
-}
-
-// TODO [SC]: End dev/testing purposes
 
 func (task *Task) initServiceConnectEphemeralPorts() error {
 	var utilizedPorts []uint16
@@ -1356,7 +1324,7 @@ func (task *Task) AddFirelensContainerBindMounts(firelensConfig *apicontainer.Fi
 
 // IsNetworkModeAWSVPC checks if the task is configured to use the AWSVPC task networking feature.
 func (task *Task) IsNetworkModeAWSVPC() bool {
-	return len(task.ENIs) > 0
+	return task.NetworkMode == AWSVPCNetworkMode
 }
 
 // IsNetworkModeBridge checks if the task is configured to use the bridge network mode.

--- a/agent/api/task/task_attachment_handler.go
+++ b/agent/api/task/task_attachment_handler.go
@@ -25,7 +25,7 @@ import (
 // AttachmentHandler defines an interface to handel attachment received from ACS.
 type AttachmentHandler interface {
 	parseAttachment(acsAttachment *ecsacs.Attachment) error
-	validateAttachment(acsTask *ecsacs.Task) error
+	validateAttachment(acsTask *ecsacs.Task, task *Task) error
 }
 
 // ServiceConnectAttachmentHandler defines a service connect type attachment handler.
@@ -56,11 +56,11 @@ func (scAttachment *ServiceConnectAttachmentHandler) parseAttachment(acsAttachme
 }
 
 // attachment validator of service connect attachment handler.
-func (scAttachment *ServiceConnectAttachmentHandler) validateAttachment(acsTask *ecsacs.Task) error {
+func (scAttachment *ServiceConnectAttachmentHandler) validateAttachment(acsTask *ecsacs.Task, task *Task) error {
 	config := scAttachment.scConfig
 	taskContainers := acsTask.Containers
-	networkMode := aws.StringValue(acsTask.NetworkMode)
 	ipv6Enabled := false
+	networkMode := task.NetworkMode
 	if acsTask.ElasticNetworkInterfaces != nil {
 		for _, eni := range acsTask.ElasticNetworkInterfaces {
 			if len(eni.Ipv6Addresses) != 0 {
@@ -99,7 +99,7 @@ func handleTaskAttachments(acsTask *ecsacs.Task, task *Task) error {
 			}
 
 			// validate the service connect config parsed from the service connect attachment
-			if err := scHandler.(*ServiceConnectAttachmentHandler).validateAttachment(acsTask); err != nil {
+			if err := scHandler.(*ServiceConnectAttachmentHandler).validateAttachment(acsTask, task); err != nil {
 				return fmt.Errorf("service connect config validation failed: %w", err)
 			}
 			task.ServiceConnectConfig = scHandler.(*ServiceConnectAttachmentHandler).scConfig

--- a/agent/api/task/task_attachment_handler_test.go
+++ b/agent/api/task/task_attachment_handler_test.go
@@ -175,6 +175,7 @@ func TestHandleTaskAttachmentsWithServiceConnectAttachment(t *testing.T) {
 				NetworkMode: stringToPointer(AWSVPCNetworkMode),
 			}
 			testTask := &Task{}
+			testTask.NetworkMode = AWSVPCNetworkMode
 			err := handleTaskAttachments(testAcsTask, testTask)
 			if tc.shouldReturnError {
 				assert.NotNil(t, err, "Should return error")

--- a/agent/api/task/task_linux_test.go
+++ b/agent/api/task/task_linux_test.go
@@ -102,6 +102,7 @@ func TestAddNetworkResourceProvisioningDependencyWithENI(t *testing.T) {
 				TransitionDependenciesMap: make(map[apicontainerstatus.ContainerStatus]apicontainer.TransitionDependencySet),
 			},
 		},
+		NetworkMode: AWSVPCNetworkMode,
 	}
 	cfg := &config.Config{
 		PauseContainerImageName: "pause-container-image-name",
@@ -130,7 +131,8 @@ func TestAddNetworkResourceProvisioningDependencyWithAppMesh(t *testing.T) {
 		AppMesh: &apiappmesh.AppMesh{
 			ContainerName: proxyName,
 		},
-		ENIs: []*apieni.ENI{{}},
+		ENIs:        []*apieni.ENI{{}},
+		NetworkMode: AWSVPCNetworkMode,
 		Containers: []*apicontainer.Container{
 			{
 				Name:                      "c1",
@@ -176,7 +178,8 @@ func TestAddNetworkResourceProvisioningDependencyWithAppMeshDefaultImage(t *test
 		AppMesh: &apiappmesh.AppMesh{
 			ContainerName: proxyName,
 		},
-		ENIs: []*apieni.ENI{{}},
+		ENIs:        []*apieni.ENI{{}},
+		NetworkMode: AWSVPCNetworkMode,
 		Containers: []*apicontainer.Container{
 			{
 				Name:                      "c1",
@@ -212,7 +215,8 @@ func TestAddNetworkResourceProvisioningDependencyWithAppMeshError(t *testing.T) 
 		AppMesh: &apiappmesh.AppMesh{
 			ContainerName: proxyName,
 		},
-		ENIs: []*apieni.ENI{{}},
+		ENIs:        []*apieni.ENI{{}},
+		NetworkMode: AWSVPCNetworkMode,
 		Containers: []*apicontainer.Container{
 			{
 				Name:                      "c1",
@@ -1283,6 +1287,7 @@ func TestBuildCNIConfigRegularENIWithAppMesh(t *testing.T) {
 	for _, blockIMDS := range []bool{true, false} {
 		t.Run(fmt.Sprintf("When BlockInstanceMetadata is %t", blockIMDS), func(t *testing.T) {
 			testTask := &Task{}
+			testTask.NetworkMode = AWSVPCNetworkMode
 			testTask.AddTaskENI(getTestENI())
 			testTask.SetAppMesh(&appmesh.AppMesh{
 				IgnoredUID:       ignoredUID,
@@ -1333,6 +1338,7 @@ func TestBuildCNIConfigRegularENIWithServiceConnect(t *testing.T) {
 		t.Run(fmt.Sprintf("When BlockInstanceMetadata is %t", blockIMDS), func(t *testing.T) {
 			testTask := &Task{}
 			testTask.AddTaskENI(getTestENI())
+			testTask.NetworkMode = AWSVPCNetworkMode
 			testTask.ServiceConnectConfig = &serviceconnect.Config{
 				ContainerName: scContainerName,
 				IngressConfig: []serviceconnect.IngressConfigEntry{{ListenerPort: scListenerPort}},
@@ -1380,6 +1386,7 @@ func TestBuildCNIConfigTrunkBranchENI(t *testing.T) {
 	for _, blockIMDS := range []bool{true, false} {
 		t.Run(fmt.Sprintf("When BlockInstanceMetadata is %t", blockIMDS), func(t *testing.T) {
 			testTask := &Task{}
+			testTask.NetworkMode = AWSVPCNetworkMode
 			testTask.AddTaskENI(&apieni.ENI{
 				ID:                           "TestBuildCNIConfigTrunkBranchENI",
 				MacAddress:                   mac,

--- a/agent/api/task/task_windows_test.go
+++ b/agent/api/task/task_windows_test.go
@@ -731,6 +731,7 @@ func TestPostUnmarshalTaskWithFSxWindowsFileServerVolumes(t *testing.T) {
 // TestBuildCNIConfig tests if the generated CNI config is correct
 func TestBuildCNIConfig(t *testing.T) {
 	testTask := &Task{}
+	testTask.NetworkMode = AWSVPCNetworkMode
 	testTask.AddTaskENI(&apieni.ENI{
 		ID:                           "TestBuildCNIConfig",
 		MacAddress:                   mac,

--- a/agent/engine/docker_task_engine_linux_test.go
+++ b/agent/engine/docker_task_engine_linux_test.go
@@ -550,6 +550,7 @@ func TestBuildCNIConfigFromTaskContainer(t *testing.T) {
 
 	testTask := testdata.LoadTask("sleep5")
 	testTask.AddTaskENI(mockENI)
+	testTask.NetworkMode = apitask.AWSVPCNetworkMode
 	testTask.SetAppMesh(&appmesh.AppMesh{
 		IgnoredUID:       ignoredUID,
 		ProxyIngressPort: proxyIngressPort,
@@ -627,6 +628,7 @@ func TestTaskWithSteadyStateResourcesProvisioned(t *testing.T) {
 		client.EXPECT().CreateContainer(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(
 			func(ctx interface{}, config *dockercontainer.Config, hostConfig *dockercontainer.HostConfig, containerName string, z time.Duration) {
 				sleepTask.AddTaskENI(mockENI)
+				sleepTask.NetworkMode = apitask.AWSVPCNetworkMode
 				sleepTask.SetAppMesh(&appmesh.AppMesh{
 					IgnoredUID:       ignoredUID,
 					ProxyIngressPort: proxyIngressPort,
@@ -739,6 +741,7 @@ func TestPauseContainerHappyPath(t *testing.T) {
 
 	// Add eni information to the task so the task can add dependency of pause container
 	sleepTask.AddTaskENI(mockENI)
+	sleepTask.NetworkMode = apitask.AWSVPCNetworkMode
 
 	sleepTask.SetAppMesh(&appmesh.AppMesh{
 		IgnoredUID:       ignoredUID,
@@ -1061,6 +1064,7 @@ func TestContainersWithServiceConnect_BridgeMode(t *testing.T) {
 	taskEngine.(*DockerTaskEngine).serviceconnectRelay = &apitask.Task{Arn: "arn::::::/task"}
 	eventStream := make(chan dockerapi.DockerContainerChangeEvent)
 	sleepTask := testdata.LoadTask("sleep5PortMappings")
+	sleepTask.NetworkMode = apitask.BridgeNetworkMode
 	sleepContainer := sleepTask.Containers[0]
 	sleepContainer.TransitionDependenciesMap = make(map[apicontainerstatus.ContainerStatus]apicontainer.TransitionDependencySet)
 

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -1000,6 +1000,7 @@ func TestProvisionContainerResourcesAwsvpcSetPausePIDInVolumeResources(t *testin
 	}
 	testTask.Containers = append(testTask.Containers, pauseContainer)
 	testTask.AddTaskENI(mockENI)
+	testTask.NetworkMode = apitask.AWSVPCNetworkMode
 	volRes := &taskresourcevolume.VolumeResource{}
 	testTask.ResourcesMapUnsafe = map[string][]taskresource.TaskResource{
 		"dockerVolume": {volRes},
@@ -1048,6 +1049,7 @@ func TestProvisionContainerResourcesAwsvpcInspectError(t *testing.T) {
 	}
 	testTask.Containers = append(testTask.Containers, pauseContainer)
 	testTask.AddTaskENI(mockENI)
+	testTask.NetworkMode = apitask.AWSVPCNetworkMode
 	taskEngine.(*DockerTaskEngine).State().AddTask(testTask)
 	taskEngine.(*DockerTaskEngine).State().AddContainer(&apicontainer.DockerContainer{
 		DockerID:   containerID,
@@ -1075,6 +1077,7 @@ func TestProvisionContainerResourcesAwsvpcMissingCNIResponseError(t *testing.T) 
 	}
 	testTask.Containers = append(testTask.Containers, pauseContainer)
 	testTask.AddTaskENI(mockENI)
+	testTask.NetworkMode = apitask.AWSVPCNetworkMode
 	taskEngine.(*DockerTaskEngine).State().AddTask(testTask)
 	taskEngine.(*DockerTaskEngine).State().AddContainer(&apicontainer.DockerContainer{
 		DockerID:   containerID,
@@ -1117,6 +1120,7 @@ func TestStopPauseContainerCleanupCalledAwsvpc(t *testing.T) {
 	}
 	testTask.Containers = append(testTask.Containers, pauseContainer)
 	testTask.AddTaskENI(mockENI)
+	testTask.NetworkMode = apitask.AWSVPCNetworkMode
 	testTask.SetAppMesh(&appmesh.AppMesh{
 		IgnoredUID:       ignoredUID,
 		ProxyIngressPort: proxyIngressPort,
@@ -1182,6 +1186,7 @@ func TestStopPauseContainerCleanupDelayAwsvpc(t *testing.T) {
 	}
 	testTask.Containers = append(testTask.Containers, pauseContainer)
 	testTask.AddTaskENI(mockENI)
+	testTask.NetworkMode = apitask.AWSVPCNetworkMode
 	taskEngine.(*DockerTaskEngine).State().AddTask(testTask)
 	taskEngine.(*DockerTaskEngine).State().AddContainer(&apicontainer.DockerContainer{
 		DockerID:   containerID,
@@ -1234,6 +1239,7 @@ func TestCheckTearDownPauseContainerAwsvpc(t *testing.T) {
 	}
 	testTask.Containers = append(testTask.Containers, pauseContainer)
 	testTask.AddTaskENI(mockENI)
+	testTask.NetworkMode = apitask.AWSVPCNetworkMode
 	testTask.SetAppMesh(&appmesh.AppMesh{
 		IgnoredUID:       ignoredUID,
 		ProxyIngressPort: proxyIngressPort,
@@ -2790,9 +2796,10 @@ func TestCreateContainerAddFirelensLogDriverConfig(t *testing.T) {
 		rawHostConfig, err := json.Marshal(&rawHostConfigInput)
 		require.NoError(t, err)
 		return &apitask.Task{
-			Arn:     taskARN,
-			Version: taskVersion,
-			Family:  taskFamily,
+			Arn:         taskARN,
+			Version:     taskVersion,
+			Family:      taskFamily,
+			NetworkMode: networkMode,
 			Containers: []*apicontainer.Container{
 				{
 					Name: taskName,
@@ -2832,9 +2839,10 @@ func TestCreateContainerAddFirelensLogDriverConfig(t *testing.T) {
 		rawHostConfig, err := json.Marshal(&rawHostConfigInput)
 		require.NoError(t, err)
 		return &apitask.Task{
-			Arn:     taskARN,
-			Version: taskVersion,
-			Family:  taskFamily,
+			Arn:         taskARN,
+			Version:     taskVersion,
+			Family:      taskFamily,
+			NetworkMode: networkMode,
 			ENIs: []*apieni.ENI{
 				{
 					IPV4Addresses: []*apieni.ENIIPV4Address{

--- a/agent/engine/docker_task_engine_windows_test.go
+++ b/agent/engine/docker_task_engine_windows_test.go
@@ -243,6 +243,7 @@ func TestBuildCNIConfigFromTaskContainer(t *testing.T) {
 
 	testTask := testdata.LoadTask("sleep5")
 	testTask.AddTaskENI(mockENI)
+	testTask.NetworkMode = apitask.AWSVPCNetworkMode
 	testTask.SetAppMesh(&appmesh.AppMesh{
 		IgnoredUID:       ignoredUID,
 		ProxyIngressPort: proxyIngressPort,
@@ -322,6 +323,7 @@ func TestTaskWithSteadyStateResourcesProvisioned(t *testing.T) {
 		client.EXPECT().CreateContainer(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(
 			func(ctx interface{}, config *dockercontainer.Config, hostConfig *dockercontainer.HostConfig, containerName string, z time.Duration) {
 				sleepTask.AddTaskENI(mockENI)
+				sleepTask.NetworkMode = apitask.AWSVPCNetworkMode
 				sleepTask.SetAppMesh(&appmesh.AppMesh{
 					IgnoredUID:       ignoredUID,
 					ProxyIngressPort: proxyIngressPort,
@@ -455,6 +457,7 @@ func TestPauseContainerHappyPath(t *testing.T) {
 
 	// Add eni information to the task so the task can add dependency of pause container
 	sleepTask.AddTaskENI(mockENI)
+	sleepTask.NetworkMode = apitask.AWSVPCNetworkMode
 
 	sleepTask.SetAppMesh(&appmesh.AppMesh{
 		IgnoredUID:       ignoredUID,

--- a/agent/handlers/task_server_setup_test.go
+++ b/agent/handlers/task_server_setup_test.go
@@ -127,6 +127,7 @@ var (
 		Version:             version,
 		DesiredStatusUnsafe: apitaskstatus.TaskRunning,
 		KnownStatusUnsafe:   apitaskstatus.TaskRunning,
+		NetworkMode:         apitask.AWSVPCNetworkMode,
 		ENIs: []*apieni.ENI{
 			{
 				IPV4Addresses: []*apieni.ENIIPV4Address{
@@ -153,6 +154,7 @@ var (
 		Version:             version,
 		DesiredStatusUnsafe: apitaskstatus.TaskRunning,
 		KnownStatusUnsafe:   apitaskstatus.TaskStatusNone,
+		NetworkMode:         apitask.AWSVPCNetworkMode,
 		ENIs: []*apieni.ENI{
 			{
 				IPV4Addresses: []*apieni.ENIIPV4Address{

--- a/agent/logger/field/constants.go
+++ b/agent/logger/field/constants.go
@@ -35,4 +35,5 @@ const (
 	Image         = "image"
 	Volume        = "volume"
 	Time          = "time"
+	NetworkMode   = "networkMode"
 )

--- a/agent/stats/engine_test.go
+++ b/agent/stats/engine_test.go
@@ -516,6 +516,7 @@ func testNetworkModeStats(t *testing.T, netMode string, enis []*apieni.ENI, serv
 		Family:            "f1",
 		ENIs:              enis,
 		KnownStatusUnsafe: apitaskstatus.TaskRunning,
+		NetworkMode:       netMode,
 		Containers: []*apicontainer.Container{
 			{Name: "test"},
 			{Name: "test1"},

--- a/agent/stats/engine_test.go
+++ b/agent/stats/engine_test.go
@@ -522,7 +522,6 @@ func testNetworkModeStats(t *testing.T, netMode string, enis []*apieni.ENI, serv
 			{Name: "test1"},
 			{Name: SCContainerName},
 		},
-		NetworkMode: netMode,
 	}
 	if serviceConnectEnabled {
 		t1.ServiceConnectConfig = &serviceconnect.Config{

--- a/agent/stats/engine_unix_test.go
+++ b/agent/stats/engine_unix_test.go
@@ -39,7 +39,7 @@ func TestLinuxTaskNetworkStatsSet(t *testing.T) {
 		NetworkMode string
 		StatsEmpty  bool
 	}{
-		{[]*apieni.ENI{{ID: "ec2Id"}}, "", true},
+		{[]*apieni.ENI{{ID: "ec2Id"}}, "awsvpc", true},
 		{nil, "host", true},
 		{nil, "bridge", false},
 		{nil, "none", true},
@@ -72,6 +72,7 @@ func TestNetworkModeStatsAWSVPCMode(t *testing.T) {
 		Arn:               "t1",
 		Family:            "f1",
 		ENIs:              []*apieni.ENI{{ID: "ec2Id"}},
+		NetworkMode:       apitask.AWSVPCNetworkMode,
 		KnownStatusUnsafe: apitaskstatus.TaskRunning,
 		Containers: []*apicontainer.Container{
 			{Name: "test"},


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This PR updates Service Connect config parsing logic, as well as how ECS Agent retrieves task network mode.

### Implementation details
<!-- How are the changes implemented? -->
1. Update Service Connect attachment property name to be `serviceconnectdetail`
2. ~~Remove the "dummy SC config" initialization used for dev/testing purposes. We can consume it from Task payload now.~~ (Keeping around for a bit longer for testing)
3. Updated `initNetworkMode` method to 
  a. directly using ACS task payload `NetworkMode` field - this same value used to be populated at container level only, but now it's available at task level too. 
  b. when `NetworkMode` is empty, it means the task has default network mode (docker bridge mode)
4. Move `initNetworkMode` ahead of attachment handlers, because the handlers need network mode
5. Inside attachment handler, use the internal `task.NetworkMode` instead of ACS `NetworkMode` (difference is that we have filled in the default/empty case for the former)

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> no - all existing tests are updated

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
SC attachment fixes; Use network mode from ACS payload

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
