### PR TITLE
Add additional field in return from DiscoverPollEndpoint

### DIFF
--- a/agent/ecs_client/model/api/api-2.json
+++ b/agent/ecs_client/model/api/api-2.json
@@ -1148,6 +1148,7 @@
       "type":"structure",
       "members":{
         "endpoint":{"shape":"String"},
+        "serviceConnectEndpoint":{"shape": "String"},
         "telemetryEndpoint":{"shape":"String"}
       }
     },

--- a/agent/ecs_client/model/api/docs-2.json
+++ b/agent/ecs_client/model/api/docs-2.json
@@ -1141,6 +1141,7 @@
         "DiscoverPollEndpointRequest$containerInstance": "<p>The container instance ID or full ARN of the container instance. The ARN contains the <code>arn:aws:ecs</code> namespace, followed by the Region of the container instance, the AWS account ID of the container instance owner, the <code>container-instance</code> namespace, and then the container instance ID. For example, <code>arn:aws:ecs:<i>region</i>:<i>aws_account_id</i>:container-instance/<i>container_instance_ID</i> </code>.</p>",
         "DiscoverPollEndpointRequest$cluster": "<p>The short name or full Amazon Resource Name (ARN) of the cluster that the container instance belongs to.</p>",
         "DiscoverPollEndpointResponse$endpoint": "<p>The endpoint for the Amazon ECS agent to poll.</p>",
+        "DiscoverPollEndpointResponse$serviceConnectEndpoint": "<p>The endpoint for the ServiceConnect Relay to connect to.</p>",
         "DiscoverPollEndpointResponse$telemetryEndpoint": "<p>The telemetry endpoint for the Amazon ECS agent.</p>",
         "DockerLabelsMap$key": null,
         "DockerLabelsMap$value": null,

--- a/agent/ecs_client/model/ecs/api.go
+++ b/agent/ecs_client/model/ecs/api.go
@@ -7404,6 +7404,9 @@ type DiscoverPollEndpointOutput struct {
 	// The endpoint for the Amazon ECS agent to poll.
 	Endpoint *string `locationName:"endpoint" type:"string"`
 
+	// The endpoint for the ServiceConnect Relay to connect to.
+	ServiceConnectEndpoint *string `locationName:"serviceConnectEndpoint" type:"string"`
+
 	// The telemetry endpoint for the Amazon ECS agent.
 	TelemetryEndpoint *string `locationName:"telemetryEndpoint" type:"string"`
 }
@@ -7421,6 +7424,12 @@ func (s DiscoverPollEndpointOutput) GoString() string {
 // SetEndpoint sets the Endpoint field's value.
 func (s *DiscoverPollEndpointOutput) SetEndpoint(v string) *DiscoverPollEndpointOutput {
 	s.Endpoint = &v
+	return s
+}
+
+// SetServiceConnectEndpoint sets the ServiceConnectEndpoint field's value.
+func (s *DiscoverPollEndpointOutput) SetServiceConnectEndpoint(v string) *DiscoverPollEndpointOutput {
+	s.ServiceConnectEndpoint = &v
 	return s
 }
 


### PR DESCRIPTION
### Summary
Update the model to include the new ServiceConnect endpoint provided by DiscoverPollEndpoint

### Implementation details
Simply adding the field to support parsing.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
