### PR TITLE
Minor updates for bootstrapping AppNet Relay task/container

### DIFF
--- a/agent/api/ecsclient/client_test.go
+++ b/agent/api/ecsclient/client_test.go
@@ -792,7 +792,7 @@ func TestDiscoverServiceConnectEndpointError(t *testing.T) {
 	mc.EXPECT().DiscoverPollEndpoint(gomock.Any()).Return(nil, fmt.Errorf("Error getting endpoint"))
 	_, err := client.DiscoverServiceConnectEndpoint("containerInstance")
 	if err == nil {
-		t.Error("Expected error getting service conneect endpoint, didn't get any")
+		t.Error("Expected error getting service connect endpoint, didn't get any")
 	}
 }
 

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -975,6 +975,7 @@ func (engine *DockerTaskEngine) AddTask(task *apitask.Task) {
 				return
 			}
 			engine.AddTask(engine.serviceconnectRelay)
+			logger.Info("docker_task_engine: Added AppNet Relay task to engine")
 		}
 	}
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
A few minor updates for bootstrapping AppNet Relay task/container.

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> no

Tested starting an SC task E2E and verified:
- Relay image load and SC capability registration
- Relay task/container started successfully
- SC task/container started successfully and able to communicate with control plane via relay


### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
