### PR TITLE
Check for nil pointer in unit test - TestSendsEventsInvalidParametersEventsRemoved

### DIFF
--- a/agent/eventhandler/task_handler_test.go
+++ b/agent/eventhandler/task_handler_test.go
@@ -126,10 +126,14 @@ func TestSendsEventsInvalidParametersEventsRemoved(t *testing.T) {
 	handler.AddStateChangeEvent(taskEvent, client)
 
 	wg.Wait()
-	// Require the lock to wait for submitFirstEvent to be finished
-	handler.tasksToEvents[taskARN].lock.Lock()
-	assert.Equal(t, 0, handler.tasksToEvents[taskARN].events.Len())
-	handler.tasksToEvents[taskARN].lock.Unlock()
+	/* If removeTaskEvents acquires lock before the following block is executed,
+	there will not be any entry for the taskARN in handler.tasksToEvents
+	*/
+	if handler.tasksToEvents[taskARN] != nil {
+		handler.tasksToEvents[taskARN].lock.Lock()
+		assert.Equal(t, 0, handler.tasksToEvents[taskARN].events.Len())
+		handler.tasksToEvents[taskARN].lock.Unlock()
+	}
 }
 
 func TestSendsEventsConcurrentLimit(t *testing.T) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
In `TestSendsEventsInvalidParametersEventsRemoved`, we call `AddStateChangeEvent` and then acquire lock on `handler.tasksToEvents[taskARN]` to verify if length of task queue is zero. However, it is possible that `removeTaskEvents` will acquire the lock first and delete the taskARN from `handler.tasksToEvents` map. This results in a nil pointer dereference while executing the test. We fix this by checking if `handler.tasksToEvents[taskARN]` is nil before accessing `handler.tasksToEvents[taskARN].lock`

### Implementation details
<!-- How are the changes implemented? -->
add a condition `if handler.tasksToEvents[taskARN] != nil` enclosing `handler.tasksToEvents[taskARN].lock.Lock()`


### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->
Not applicable

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
