### PR TITLE
Consolidate Service Connect Loader into Service Connect Manager

### DIFF
--- a/agent/app/agent_compatibility_linux_test.go
+++ b/agent/app/agent_compatibility_linux_test.go
@@ -38,7 +38,7 @@ func init() {
 }
 
 func TestCompatibilityEnabledSuccess(t *testing.T) {
-	ctrl, creds, _, images, _, _, stateManagerFactory, saveableOptionFactory, execCmdMgr, serviceConnectLoader := setup(t)
+	ctrl, creds, _, images, _, _, stateManagerFactory, saveableOptionFactory, execCmdMgr, serviceConnectManager := setup(t)
 	defer ctrl.Finish()
 	stateManager := mock_statemanager.NewMockStateManager(ctrl)
 
@@ -65,14 +65,14 @@ func TestCompatibilityEnabledSuccess(t *testing.T) {
 	defer cancel()
 
 	containerChangeEventStream := eventstream.NewEventStream("events", ctx)
-	_, _, err := agent.newTaskEngine(containerChangeEventStream, creds, dockerstate.NewTaskEngineState(), images, execCmdMgr, serviceConnectLoader)
+	_, _, err := agent.newTaskEngine(containerChangeEventStream, creds, dockerstate.NewTaskEngineState(), images, execCmdMgr, serviceConnectManager)
 
 	assert.NoError(t, err)
 	assert.True(t, cfg.TaskCPUMemLimit.Enabled())
 }
 
 func TestCompatibilityNotSetFail(t *testing.T) {
-	ctrl, creds, _, images, _, _, stateManagerFactory, saveableOptionFactory, execCmdMgr, serviceConnectLoader := setup(t)
+	ctrl, creds, _, images, _, _, stateManagerFactory, saveableOptionFactory, execCmdMgr, serviceConnectManager := setup(t)
 	defer ctrl.Finish()
 	stateManager := mock_statemanager.NewMockStateManager(ctrl)
 
@@ -106,14 +106,14 @@ func TestCompatibilityNotSetFail(t *testing.T) {
 	defer cancel()
 
 	containerChangeEventStream := eventstream.NewEventStream("events", ctx)
-	_, _, err := agent.newTaskEngine(containerChangeEventStream, creds, dockerstate.NewTaskEngineState(), images, execCmdMgr, serviceConnectLoader)
+	_, _, err := agent.newTaskEngine(containerChangeEventStream, creds, dockerstate.NewTaskEngineState(), images, execCmdMgr, serviceConnectManager)
 
 	assert.NoError(t, err)
 	assert.False(t, cfg.TaskCPUMemLimit.Enabled())
 }
 
 func TestCompatibilityExplicitlyEnabledFail(t *testing.T) {
-	ctrl, creds, _, images, _, _, stateManagerFactory, saveableOptionFactory, execCmdMgr, serviceConnectLoader := setup(t)
+	ctrl, creds, _, images, _, _, stateManagerFactory, saveableOptionFactory, execCmdMgr, serviceConnectManager := setup(t)
 	defer ctrl.Finish()
 	stateManager := mock_statemanager.NewMockStateManager(ctrl)
 
@@ -147,7 +147,7 @@ func TestCompatibilityExplicitlyEnabledFail(t *testing.T) {
 	defer cancel()
 
 	containerChangeEventStream := eventstream.NewEventStream("events", ctx)
-	_, _, err := agent.newTaskEngine(containerChangeEventStream, creds, dockerstate.NewTaskEngineState(), images, execCmdMgr, serviceConnectLoader)
+	_, _, err := agent.newTaskEngine(containerChangeEventStream, creds, dockerstate.NewTaskEngineState(), images, execCmdMgr, serviceConnectManager)
 
 	assert.Error(t, err)
 }

--- a/agent/app/agent_test.go
+++ b/agent/app/agent_test.go
@@ -45,6 +45,7 @@ import (
 	mock_dockerstate "github.com/aws/amazon-ecs-agent/agent/engine/dockerstate/mocks"
 	mock_execcmdagent "github.com/aws/amazon-ecs-agent/agent/engine/execcmd/mocks"
 	mock_engine "github.com/aws/amazon-ecs-agent/agent/engine/mocks"
+	mock_engineserviceconnect "github.com/aws/amazon-ecs-agent/agent/engine/serviceconnect/mock"
 	mock_pause "github.com/aws/amazon-ecs-agent/agent/eni/pause/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
 	mock_serviceconnect "github.com/aws/amazon-ecs-agent/agent/serviceconnect/mocks"
@@ -90,7 +91,7 @@ func setup(t *testing.T) (*gomock.Controller,
 	*mock_factory.MockStateManager,
 	*mock_factory.MockSaveableOption,
 	*mock_execcmdagent.MockManager,
-	*mock_serviceconnect.MockLoader) {
+	*mock_engineserviceconnect.MockManager) {
 
 	ctrl := gomock.NewController(t)
 
@@ -103,7 +104,7 @@ func setup(t *testing.T) (*gomock.Controller,
 		mock_factory.NewMockStateManager(ctrl),
 		mock_factory.NewMockSaveableOption(ctrl),
 		mock_execcmdagent.NewMockManager(ctrl),
-		mock_serviceconnect.NewMockLoader(ctrl)
+		mock_engineserviceconnect.NewMockManager(ctrl)
 }
 
 func TestDoStartMinimumSupportedDockerVersionTerminal(t *testing.T) {

--- a/agent/app/data.go
+++ b/agent/app/data.go
@@ -22,8 +22,8 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/engine"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/engine/execcmd"
+	"github.com/aws/amazon-ecs-agent/agent/engine/serviceconnect"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
-	"github.com/aws/amazon-ecs-agent/agent/serviceconnect"
 
 	"github.com/pkg/errors"
 )
@@ -66,11 +66,11 @@ func (agent *ecsAgent) loadData(containerChangeEventStream *eventstream.EventStr
 	state dockerstate.TaskEngineState,
 	imageManager engine.ImageManager,
 	execCmdMgr execcmd.Manager,
-	serviceConnectloader serviceconnect.Loader) (*savedData, error) {
+	serviceConnectManager serviceconnect.Manager) (*savedData, error) {
 	s := &savedData{
 		taskEngine: engine.NewTaskEngine(agent.cfg, agent.dockerClient, credentialsManager,
 			containerChangeEventStream, imageManager, state,
-			agent.metadataManager, agent.resourceFields, execCmdMgr, serviceConnectloader),
+			agent.metadataManager, agent.resourceFields, execCmdMgr, serviceConnectManager),
 	}
 	s.taskEngine.SetDataClient(agent.dataClient)
 

--- a/agent/engine/common_integ_test.go
+++ b/agent/engine/common_integ_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/ec2"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/engine/execcmd"
+	engineserviceconnect "github.com/aws/amazon-ecs-agent/agent/engine/serviceconnect"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
 	"github.com/aws/amazon-ecs-agent/agent/serviceconnect"
 	"github.com/aws/amazon-ecs-agent/agent/statechange"
@@ -170,7 +171,7 @@ func setup(cfg *config.Config, state dockerstate.TaskEngineState, t *testing.T) 
 
 	taskEngine := NewDockerTaskEngine(cfg, dockerClient, credentialsManager,
 		eventstream.NewEventStream("ENGINEINTEGTEST", context.Background()), imageManager, state, metadataManager,
-		nil, execcmd.NewManager(), serviceconnect.New())
+		nil, execcmd.NewManager(), engineserviceconnect.NewManager(serviceconnect.New()))
 	taskEngine.MustInit(context.TODO())
 	return taskEngine, func() {
 		taskEngine.Shutdown()

--- a/agent/engine/default.go
+++ b/agent/engine/default.go
@@ -22,8 +22,8 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/engine/execcmd"
+	"github.com/aws/amazon-ecs-agent/agent/engine/serviceconnect"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
-	"github.com/aws/amazon-ecs-agent/agent/serviceconnect"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 )
 
@@ -35,11 +35,11 @@ func NewTaskEngine(cfg *config.Config, client dockerapi.DockerClient,
 	metadataManager containermetadata.Manager,
 	resourceFields *taskresource.ResourceFields,
 	execCmdMgr execcmd.Manager,
-	serviceConnectLoader serviceconnect.Loader) TaskEngine {
+	serviceConnectManager serviceconnect.Manager) TaskEngine {
 
 	taskEngine := NewDockerTaskEngine(cfg, client, credentialsManager,
 		containerChangeEventStream, imageManager,
-		state, metadataManager, resourceFields, execCmdMgr, serviceConnectLoader)
+		state, metadataManager, resourceFields, execCmdMgr, serviceConnectManager)
 
 	return taskEngine
 }

--- a/agent/engine/docker_task_engine_linux_test.go
+++ b/agent/engine/docker_task_engine_linux_test.go
@@ -79,7 +79,7 @@ func init() {
 func TestResourceContainerProgression(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-	ctrl, client, mockTime, taskEngine, _, imageManager, _, _, _ := mocks(t, ctx, &defaultConfig)
+	ctrl, client, mockTime, taskEngine, _, imageManager, _, _ := mocks(t, ctx, &defaultConfig)
 	defer ctrl.Finish()
 
 	sleepTask := testdata.LoadTask("sleep5")
@@ -248,7 +248,7 @@ func TestDeleteTaskBranchENIEnabled(t *testing.T) {
 func TestResourceContainerProgressionFailure(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-	ctrl, client, mockTime, taskEngine, _, _, _, _, _ := mocks(t, ctx, &defaultConfig)
+	ctrl, client, mockTime, taskEngine, _, _, _, _ := mocks(t, ctx, &defaultConfig)
 	defer ctrl.Finish()
 	sleepTask := testdata.LoadTask("sleep5")
 	sleepContainer := sleepTask.Containers[0]
@@ -305,7 +305,7 @@ func TestTaskCPULimitHappyPath(t *testing.T) {
 			metadataConfig.ContainerMetadataEnabled = config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled}
 			ctx, cancel := context.WithCancel(context.TODO())
 			defer cancel()
-			ctrl, client, mockTime, taskEngine, credentialsManager, imageManager, metadataManager, _, _ := mocks(
+			ctrl, client, mockTime, taskEngine, credentialsManager, imageManager, metadataManager, _ := mocks(
 				t, ctx, &metadataConfig)
 			defer ctrl.Finish()
 
@@ -519,7 +519,7 @@ func TestCreateFirelensContainer(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.TODO())
 			defer cancel()
-			ctrl, client, mockTime, taskEngine, _, _, _, _, _ := mocks(t, ctx, &defaultConfig)
+			ctrl, client, mockTime, taskEngine, _, _, _, _ := mocks(t, ctx, &defaultConfig)
 			defer ctrl.Finish()
 
 			mockTime.EXPECT().Now().AnyTimes()
@@ -545,7 +545,7 @@ func TestBuildCNIConfigFromTaskContainer(t *testing.T) {
 	config := defaultConfig
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-	ctrl, _, _, taskEngine, _, _, _, _, _ := mocks(t, ctx, &config)
+	ctrl, _, _, taskEngine, _, _, _, _ := mocks(t, ctx, &config)
 	defer ctrl.Finish()
 
 	testTask := testdata.LoadTask("sleep5")
@@ -587,7 +587,7 @@ func TestBuildCNIConfigFromTaskContainer(t *testing.T) {
 func TestTaskWithSteadyStateResourcesProvisioned(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-	ctrl, client, mockTime, taskEngine, _, imageManager, _, _, _ := mocks(t, ctx, &defaultConfig)
+	ctrl, client, mockTime, taskEngine, _, imageManager, _, _ := mocks(t, ctx, &defaultConfig)
 	defer ctrl.Finish()
 
 	mockCNIClient := mock_ecscni.NewMockCNIClient(ctrl)
@@ -724,7 +724,7 @@ func TestTaskWithSteadyStateResourcesProvisioned(t *testing.T) {
 func TestPauseContainerHappyPath(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-	ctrl, dockerClient, mockTime, taskEngine, _, imageManager, _, _, _ := mocks(t, ctx, &defaultConfig)
+	ctrl, dockerClient, mockTime, taskEngine, _, imageManager, _, _ := mocks(t, ctx, &defaultConfig)
 	defer ctrl.Finish()
 
 	cniClient := mock_ecscni.NewMockCNIClient(ctrl)
@@ -870,7 +870,7 @@ func TestPauseContainerHappyPath(t *testing.T) {
 func TestContainersWithServiceConnect(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-	ctrl, dockerClient, mockTime, taskEngine, _, imageManager, _, serviceConnectManager, _ := mocks(t, ctx, &defaultConfig)
+	ctrl, dockerClient, mockTime, taskEngine, _, imageManager, _, serviceConnectManager := mocks(t, ctx, &defaultConfig)
 	defer ctrl.Finish()
 
 	cniClient := mock_ecscni.NewMockCNIClient(ctrl)
@@ -935,7 +935,7 @@ func TestContainersWithServiceConnect(t *testing.T) {
 	// Pause container will be launched first
 	gomock.InOrder(
 		dockerClient.EXPECT().APIVersion().Return(defaultDockerClientAPIVersion, nil),
-		serviceConnectManager.EXPECT().AugmentTaskContainer(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil),
+		serviceConnectManager.EXPECT().AugmentTaskContainer(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil),
 		dockerClient.EXPECT().CreateContainer(
 			gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(dockerapi.DockerContainerMetadata{DockerID: "pauseContainerID"}),
 		dockerClient.EXPECT().StartContainer(gomock.Any(), pauseContainerID, defaultConfig.ContainerStartTimeout).Return(
@@ -959,7 +959,7 @@ func TestContainersWithServiceConnect(t *testing.T) {
 	imageManager.EXPECT().RecordContainerReference(gomock.Any()).Return(nil).Times(3)
 	imageManager.EXPECT().GetImageStateFromImageName(gomock.Any()).Return(nil, false).Times(3)
 	dockerClient.EXPECT().APIVersion().Return(defaultDockerClientAPIVersion, nil).Times(3)
-	serviceConnectManager.EXPECT().AugmentTaskContainer(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(3)
+	serviceConnectManager.EXPECT().AugmentTaskContainer(gomock.Any(), gomock.Any(), gomock.Any()).Times(3)
 	dockerClient.EXPECT().CreateContainer(gomock.Any(), gomock.Any(), gomock.Any(),
 		gomock.Any(), gomock.Any()).Return(dockerapi.DockerContainerMetadata{DockerID: scContainerID})
 	dockerClient.EXPECT().CreateContainer(gomock.Any(), gomock.Any(), gomock.Any(),
@@ -1052,7 +1052,7 @@ func TestContainersWithServiceConnect(t *testing.T) {
 func TestContainersWithServiceConnect_BridgeMode(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-	ctrl, dockerClient, mockTime, taskEngine, _, imageManager, _, serviceConnectManager, _ := mocks(t, ctx, &defaultConfig)
+	ctrl, dockerClient, mockTime, taskEngine, _, imageManager, _, serviceConnectManager := mocks(t, ctx, &defaultConfig)
 	defer ctrl.Finish()
 
 	cniClient := mock_ecscni.NewMockCNIClient(ctrl)
@@ -1113,7 +1113,7 @@ func TestContainersWithServiceConnect_BridgeMode(t *testing.T) {
 	// SCPause.RUNNING (verified in the InOrder block down below)
 
 	// For both pause containers
-	serviceConnectManager.EXPECT().AugmentTaskContainer(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(2)
+	serviceConnectManager.EXPECT().AugmentTaskContainer(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(2)
 	dockerClient.EXPECT().APIVersion().Return(defaultDockerClientAPIVersion, nil).Times(2)
 	dockerClient.EXPECT().CreateContainer(
 		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
@@ -1191,7 +1191,7 @@ func TestContainersWithServiceConnect_BridgeMode(t *testing.T) {
 	imageManager.EXPECT().RecordContainerReference(gomock.Any()).Return(nil).Times(2)
 	imageManager.EXPECT().GetImageStateFromImageName(gomock.Any()).Return(nil, false).Times(2)
 	dockerClient.EXPECT().APIVersion().Return(defaultDockerClientAPIVersion, nil).Times(2)
-	serviceConnectManager.EXPECT().AugmentTaskContainer(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(2)
+	serviceConnectManager.EXPECT().AugmentTaskContainer(gomock.Any(), gomock.Any(), gomock.Any()).Times(2)
 
 	cleanup := make(chan time.Time)
 	defer close(cleanup)
@@ -1283,7 +1283,7 @@ func verifyServiceConnectPauseContainerBridgeMode(t *testing.T, ctx interface{},
 func TestProvisionContainerResourcesBridgeModeWithServiceConnect(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-	ctrl, dockerClient, _, taskEngine, _, _, _, _, _ := mocks(t, ctx, &defaultConfig)
+	ctrl, dockerClient, _, taskEngine, _, _, _, _ := mocks(t, ctx, &defaultConfig)
 	defer ctrl.Finish()
 
 	mockCNIClient := mock_ecscni.NewMockCNIClient(ctrl)

--- a/agent/engine/docker_task_engine_windows_test.go
+++ b/agent/engine/docker_task_engine_windows_test.go
@@ -86,7 +86,7 @@ func TestDeleteTask(t *testing.T) {
 func TestCredentialSpecResourceTaskFile(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-	ctrl, client, mockTime, taskEngine, credentialsManager, _, _, _, _ := mocks(t, ctx, &defaultConfig)
+	ctrl, client, mockTime, taskEngine, credentialsManager, _, _, _ := mocks(t, ctx, &defaultConfig)
 	defer ctrl.Finish()
 
 	// metadata required for createContainer workflow validation
@@ -167,7 +167,7 @@ func TestCredentialSpecResourceTaskFile(t *testing.T) {
 func TestCredentialSpecResourceTaskFileErr(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-	ctrl, client, mockTime, taskEngine, credentialsManager, _, _, _, _ := mocks(t, ctx, &defaultConfig)
+	ctrl, client, mockTime, taskEngine, credentialsManager, _, _, _ := mocks(t, ctx, &defaultConfig)
 	defer ctrl.Finish()
 
 	// metadata required for createContainer workflow validation
@@ -243,7 +243,7 @@ func TestBuildCNIConfigFromTaskContainer(t *testing.T) {
 	config := defaultConfig
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-	ctrl, _, _, taskEngine, _, _, _, _, _ := mocks(t, ctx, &config)
+	ctrl, _, _, taskEngine, _, _, _, _ := mocks(t, ctx, &config)
 	defer ctrl.Finish()
 
 	testTask := testdata.LoadTask("sleep5")
@@ -287,7 +287,7 @@ func TestBuildCNIConfigFromTaskContainer(t *testing.T) {
 func TestTaskWithSteadyStateResourcesProvisioned(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-	ctrl, client, mockTime, taskEngine, _, imageManager, _, _, _ := mocks(t, ctx, &defaultConfig)
+	ctrl, client, mockTime, taskEngine, _, imageManager, _, _ := mocks(t, ctx, &defaultConfig)
 	defer ctrl.Finish()
 
 	mockCNIClient := mock_ecscni.NewMockCNIClient(ctrl)
@@ -445,7 +445,7 @@ func TestTaskWithSteadyStateResourcesProvisioned(t *testing.T) {
 func TestPauseContainerHappyPath(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-	ctrl, dockerClient, mockTime, taskEngine, _, imageManager, _, _, _ := mocks(t, ctx, &defaultConfig)
+	ctrl, dockerClient, mockTime, taskEngine, _, imageManager, _, _ := mocks(t, ctx, &defaultConfig)
 	defer ctrl.Finish()
 
 	cniClient := mock_ecscni.NewMockCNIClient(ctrl)

--- a/agent/engine/engine_sudo_linux_integ_test.go
+++ b/agent/engine/engine_sudo_linux_integ_test.go
@@ -61,6 +61,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/engine/execcmd"
+	engineserviceconnect "github.com/aws/amazon-ecs-agent/agent/engine/serviceconnect"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
 	"github.com/aws/amazon-ecs-agent/agent/serviceconnect"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
@@ -586,7 +587,7 @@ func setupEngineForExecCommandAgent(t *testing.T, hostBinDir string) (TaskEngine
 
 	taskEngine := NewDockerTaskEngine(cfg, dockerClient, credentialsManager,
 		eventstream.NewEventStream("ENGINEINTEGTEST", context.Background()), imageManager, state, metadataManager,
-		nil, execCmdMgr, serviceconnect.New())
+		nil, execCmdMgr, engineserviceconnect.NewManager(serviceconnect.New()))
 	taskEngine.monitorExecAgentsInterval = time.Second
 	taskEngine.MustInit(context.TODO())
 	return taskEngine, func() {

--- a/agent/engine/engine_windows_integ_test.go
+++ b/agent/engine/engine_windows_integ_test.go
@@ -49,6 +49,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/ec2"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	"github.com/aws/amazon-ecs-agent/agent/engine/execcmd"
+	engineserviceconnect "github.com/aws/amazon-ecs-agent/agent/engine/serviceconnect"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
 	s3factory "github.com/aws/amazon-ecs-agent/agent/s3/factory"
 	"github.com/aws/amazon-ecs-agent/agent/serviceconnect"
@@ -497,7 +498,7 @@ func setupGMSA(cfg *config.Config, state dockerstate.TaskEngineState, t *testing
 
 	taskEngine := NewDockerTaskEngine(cfg, dockerClient, credentialsManager,
 		eventstream.NewEventStream("ENGINEINTEGTEST", context.Background()), imageManager, state, metadataManager,
-		resourceFields, execcmd.NewManager(), serviceconnect.New())
+		resourceFields, execcmd.NewManager(), engineserviceconnect.NewManager(serviceconnect.New()))
 	taskEngine.MustInit(context.TODO())
 	return taskEngine, func() {
 		taskEngine.Shutdown()
@@ -739,7 +740,7 @@ func setupEngineForExecCommandAgent(t *testing.T, hostBinDir string) (TaskEngine
 
 	taskEngine := NewDockerTaskEngine(cfg, dockerClient, credentialsManager,
 		eventstream.NewEventStream("ENGINEINTEGTEST", context.Background()), imageManager, state, metadataManager,
-		nil, execCmdMgr, serviceconnect.New())
+		nil, execCmdMgr, engineserviceconnect.NewManager(serviceconnect.New()))
 	taskEngine.monitorExecAgentsInterval = time.Second
 	taskEngine.MustInit(context.TODO())
 	return taskEngine, func() {

--- a/agent/engine/serviceconnect/manager.go
+++ b/agent/engine/serviceconnect/manager.go
@@ -17,13 +17,11 @@ import (
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	"github.com/aws/amazon-ecs-agent/agent/config"
-	"github.com/aws/amazon-ecs-agent/agent/serviceconnect"
-
 	dockercontainer "github.com/docker/docker/api/types/container"
 )
 
 type Manager interface {
-	AugmentTaskContainer(task *apitask.Task, container *apicontainer.Container, hostConfig *dockercontainer.HostConfig, serviceConnectLoader serviceconnect.Loader) error
-	CreateInstanceTask(config *config.Config, appnetAgentLoader serviceconnect.Loader) (*apitask.Task, error)
+	AugmentTaskContainer(task *apitask.Task, container *apicontainer.Container, hostConfig *dockercontainer.HostConfig) error
+	CreateInstanceTask(config *config.Config) (*apitask.Task, error)
 	AugmentInstanceContainer(task *apitask.Task, container *apicontainer.Container, hostConfig *dockercontainer.HostConfig) error
 }

--- a/agent/engine/serviceconnect/manager_linux_test.go
+++ b/agent/engine/serviceconnect/manager_linux_test.go
@@ -89,7 +89,6 @@ func TestPauseContainerModificationsForServiceConnect(t *testing.T) {
 			testcases = append(testcases, testCase{name: container.Name, container: container, needsImage: container == serviceConnectContainer})
 		}
 	}
-	scManager := NewManager()
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
@@ -105,7 +104,8 @@ func TestPauseContainerModificationsForServiceConnect(t *testing.T) {
 			}
 
 			hostConfig := &dockercontainer.HostConfig{}
-			err := scManager.AugmentTaskContainer(scTask, tc.container, hostConfig, mockLoader)
+			scManager := NewManager(mockLoader)
+			err := scManager.AugmentTaskContainer(scTask, tc.container, hostConfig)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/agent/engine/serviceconnect/manager_linux_test_common.go
+++ b/agent/engine/serviceconnect/manager_linux_test_common.go
@@ -167,22 +167,23 @@ func testAgentContainerModificationsForServiceConnect(t *testing.T, privilegedMo
 		}
 	}
 	scManager := &manager{
-		relayPathContainer:  "/not/var/run",
-		relayPathHost:       filepath.Join(tempDir, "relay"),
-		relayFileName:       "relay_file_of_holiness",
-		endpointENV:         "ReLaYgOeShErE",
-		statusPathContainer: "/some/other/run",
-		statusPathHostRoot:  filepath.Join(tempDir, "status"),
-		statusFileName:      "status_file_of_holiness",
-		statusENV:           "StAtUsGoEsHeRe",
-		adminStatsRequest:   "/give?stats",
-		adminDrainRequest:   "/do?drain",
+		relayPathContainer:   "/not/var/run",
+		relayPathHost:        filepath.Join(tempDir, "relay"),
+		relayFileName:        "relay_file_of_holiness",
+		endpointENV:          "ReLaYgOeShErE",
+		statusPathContainer:  "/some/other/run",
+		statusPathHostRoot:   filepath.Join(tempDir, "status"),
+		statusFileName:       "status_file_of_holiness",
+		statusENV:            "StAtUsGoEsHeRe",
+		adminStatsRequest:    "/give?stats",
+		adminDrainRequest:    "/do?drain",
+		serviceConnectLoader: loader,
 	}
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			hostConfig := &dockercontainer.HostConfig{}
-			err := scManager.AugmentTaskContainer(scTask, tc.container, hostConfig, loader)
+			err := scManager.AugmentTaskContainer(scTask, tc.container, hostConfig)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/agent/engine/serviceconnect/manager_other.go
+++ b/agent/engine/serviceconnect/manager_other.go
@@ -29,14 +29,14 @@ import (
 type manager struct {
 }
 
-func NewManager() Manager {
+func NewManager(serviceConnectLoader serviceconnect.Loader) Manager {
 	return &manager{}
 }
 
-func (m *manager) AugmentTaskContainer(*apitask.Task, *apicontainer.Container, *dockercontainer.HostConfig, serviceconnect.Loader) error {
+func (m *manager) AugmentTaskContainer(*apitask.Task, *apicontainer.Container, *dockercontainer.HostConfig) error {
 	return fmt.Errorf("ServiceConnect is only supported on linux")
 }
-func (m *manager) CreateInstanceTask(config *config.Config, appnetAgentLoader serviceconnect.Loader) (*apitask.Task, error) {
+func (m *manager) CreateInstanceTask(config *config.Config) (*apitask.Task, error) {
 	return nil, fmt.Errorf("ServiceConnect is only supported on linux")
 }
 func (m *manager) AugmentInstanceContainer(*apitask.Task, *apicontainer.Container, *dockercontainer.HostConfig) error {

--- a/agent/engine/serviceconnect/mock/manager.go
+++ b/agent/engine/serviceconnect/mock/manager.go
@@ -24,7 +24,6 @@ import (
 	container "github.com/aws/amazon-ecs-agent/agent/api/container"
 	task "github.com/aws/amazon-ecs-agent/agent/api/task"
 	config "github.com/aws/amazon-ecs-agent/agent/config"
-	serviceconnect "github.com/aws/amazon-ecs-agent/agent/serviceconnect"
 	container0 "github.com/docker/docker/api/types/container"
 	gomock "github.com/golang/mock/gomock"
 )
@@ -67,30 +66,30 @@ func (mr *MockManagerMockRecorder) AugmentInstanceContainer(arg0, arg1, arg2 int
 }
 
 // AugmentTaskContainer mocks base method
-func (m *MockManager) AugmentTaskContainer(arg0 *task.Task, arg1 *container.Container, arg2 *container0.HostConfig, arg3 serviceconnect.Loader) error {
+func (m *MockManager) AugmentTaskContainer(arg0 *task.Task, arg1 *container.Container, arg2 *container0.HostConfig) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AugmentTaskContainer", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "AugmentTaskContainer", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // AugmentTaskContainer indicates an expected call of AugmentTaskContainer
-func (mr *MockManagerMockRecorder) AugmentTaskContainer(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockManagerMockRecorder) AugmentTaskContainer(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AugmentTaskContainer", reflect.TypeOf((*MockManager)(nil).AugmentTaskContainer), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AugmentTaskContainer", reflect.TypeOf((*MockManager)(nil).AugmentTaskContainer), arg0, arg1, arg2)
 }
 
 // CreateInstanceTask mocks base method
-func (m *MockManager) CreateInstanceTask(arg0 *config.Config, arg1 serviceconnect.Loader) (*task.Task, error) {
+func (m *MockManager) CreateInstanceTask(arg0 *config.Config) (*task.Task, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateInstanceTask", arg0, arg1)
+	ret := m.ctrl.Call(m, "CreateInstanceTask", arg0)
 	ret0, _ := ret[0].(*task.Task)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateInstanceTask indicates an expected call of CreateInstanceTask
-func (mr *MockManagerMockRecorder) CreateInstanceTask(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockManagerMockRecorder) CreateInstanceTask(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateInstanceTask", reflect.TypeOf((*MockManager)(nil).CreateInstanceTask), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateInstanceTask", reflect.TypeOf((*MockManager)(nil).CreateInstanceTask), arg0)
 }


### PR DESCRIPTION
### Summary
This change will consolidate what Docker Task Engine is concerned about to only engine/serviceconnect/Manager

### Implementation details
This refactors the service connect loader INTO the manager in anticipation of removing the loader completely.

See:
https://github.com/aws-gibbskt/amazon-ecs-agent/pull/5
https://github.com/aws-gibbskt/amazon-ecs-agent/pull/6
https://github.com/aws-gibbskt/amazon-ecs-agent/pull/7
https://github.com/aws-gibbskt/amazon-ecs-agent/pull/8

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
