### PR TITLE
Task handler disconnected mode bug fix- Pass context by reference and initialize to nil

### DIFF
--- a/agent/utils/retry/retry_test.go
+++ b/agent/utils/retry/retry_test.go
@@ -84,7 +84,8 @@ func TestRetryWithBackoffCtxForTaskHandler(t *testing.T) {
 
 		t.Run(fmt.Sprintf("retries, disconnected %s", strconv.FormatBool(tc.disconnectModeEnabled)), func(t *testing.T) {
 			counter := 3
-			RetryWithBackoffCtxForTaskHandler(context.TODO(), context.TODO(), cfg, "myArn", NewExponentialBackoff(100*time.Millisecond, 100*time.Millisecond, 0, 1), 200*time.Millisecond, func() error {
+			eventFlwCtx := context.TODO()
+			RetryWithBackoffCtxForTaskHandler(context.TODO(), &eventFlwCtx, cfg, "myArn", NewExponentialBackoff(100*time.Millisecond, 100*time.Millisecond, 0, 1), 200*time.Millisecond, func() error {
 				if counter == 0 {
 					return nil
 				}
@@ -96,7 +97,8 @@ func TestRetryWithBackoffCtxForTaskHandler(t *testing.T) {
 
 		t.Run(fmt.Sprintf("no retries, disconnected %s", strconv.FormatBool(tc.disconnectModeEnabled)), func(t *testing.T) {
 			counter := 3
-			RetryWithBackoffCtxForTaskHandler(context.TODO(), context.TODO(), cfg, "myArn", NewExponentialBackoff(10*time.Second, 20*time.Second, 0, 2), 200*time.Millisecond, func() error {
+			eventFlwCtx := context.TODO()
+			RetryWithBackoffCtxForTaskHandler(context.TODO(), &eventFlwCtx, cfg, "myArn", NewExponentialBackoff(10*time.Second, 20*time.Second, 0, 2), 200*time.Millisecond, func() error {
 				if counter == 0 {
 					return nil
 				}
@@ -114,7 +116,8 @@ func TestRetryWithBackoffCtxForTaskHandler(t *testing.T) {
 		t.Run(fmt.Sprintf("cancel context, disconnected %s", strconv.FormatBool(tc.disconnectModeEnabled)), func(t *testing.T) {
 			counter := 2
 			ctx, cancel := context.WithCancel(context.TODO())
-			RetryWithBackoffCtxForTaskHandler(ctx, context.TODO(), cfg, "myArn", NewExponentialBackoff(100*time.Millisecond, 100*time.Millisecond, 0, 1), 200*time.Millisecond, func() error {
+			eventFlwCtx := context.TODO()
+			RetryWithBackoffCtxForTaskHandler(ctx, &eventFlwCtx, cfg, "myArn", NewExponentialBackoff(100*time.Millisecond, 100*time.Millisecond, 0, 1), 200*time.Millisecond, func() error {
 				counter--
 				if counter == 0 {
 					cancel()
@@ -154,7 +157,7 @@ func TestWaitForDurationWithContext(t *testing.T) {
 					eventFlowCtxCancel()
 				}()
 			}
-			interrupt := WaitForDurationWithContext(eventFlowCtx, tc.delay)
+			interrupt := WaitForDurationWithContext(&eventFlowCtx, tc.delay)
 			assert.True(t, interrupt, "Timer not interrupted")
 		})
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

Fixes the following bugs-

Bug 1:
The `RetryWithBackoffForTaskHandler` method retries task state change events when agent loses network connection. We currently pass a context to `RetryWithBackoffForTaskHandler` to control the retry frequency for task state changes in disconnected mode. Currently, when agent loses network connection, ACS handler starts a timer of 5 minutes and once the timer is completed, agent toggles `disconnectModeEnabled` flag to true and initializes a context. For a task that runs for less than 5 minutes, it is possible that we have invoked `RetryWithBackoffForTaskHandler` before executing `handler.eventFlowCtx, handler.eventFlowCtxCancel = context.WithCancel(handler.ctx)`. Hence, we need to pass the context to `RetryWithBackoffForTaskHandler` by reference and not by value.

Bug 2:
When ACS handler switches to disconnected mode, it does the following steps- 
A1: toggle disconnectModeEnabled to true
A2: initialize context to a specific value derived from parent

The `RetryWithBackoffForTaskHandler` of task handler does the following-
T1: check for disconnectModeEnabled = true
T2: pass initialized context value to `WaitForDurationWithContext`

Our ideal execution sequence for these steps is A1, A2, T1, T2 however it is not guaranteed that it will be so, as the `RetryWithBackoffForTaskHandler` runs asynchrononously. 

If the sequence is A1, T1, T2, A2- we pass a context with cancellation to `WaitForDurationWithContext`. Later we re-initialize the context (and the cancellation function) again, and hence we are unable to cancel the context that `WaitForDurationWithContext` is already receiving on. If we initialize `eventFlwCtx` as `nil`, we can avoid this scenario.

### Implementation details
<!-- How are the changes implemented? -->
1. Pass the address and not the value of handler.eventFlowCtx to `RetryWithBackoffForTaskHandler` (pass by reference).
2. Initialize eventFlwCtx as nil

### Testing
<!-- How was this tested? -->
Ran a task that stops after 5 min and disconnected network connection as soon as task is started. This ensures that we call `RetryWithBackoffForTaskHandler` before executing `handler.eventFlowCtx, handler.eventFlowCtxCancel = context.WithCancel(handler.ctx)`.

<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> Yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
