### PR TITLE
Batch Size to Send Task Updates

### DIFF
--- a/agent/acs/handler/acs_handler.go
+++ b/agent/acs/handler/acs_handler.go
@@ -257,7 +257,7 @@ func (acsSession *session) Start() error {
 						sendEmptyMessageOnChannel(connectToACS)
 					}
 				} else {
-					acsSession.startDisconnectMode()
+					acsSession.startDisconnectMode(connectToACS)
 				}
 			} else {
 				// Disconnected unexpectedly from ACS, compute backoff duration to
@@ -288,8 +288,8 @@ func (acsSession *session) Start() error {
 
 // startDisconnectMode contains the logic necessary to turn disconnectModeEnabled on if the instance
 // has DisconnectMode capability, and network connection has been lost.
-func (acsSession *session) startDisconnectMode() {
-	connectToACS := make(chan struct{}, 1)
+func (acsSession *session) startDisconnectMode(connectToACS chan<- struct{}) {
+	// connectToACS := make(chan struct{}, 1)
 	cfg := acsSession.agentConfig
 	if acsSession.disconnectionTimer != nil {
 		timerCompleted := acsSession.checkDisconnectionTimer()
@@ -443,6 +443,7 @@ func (acsSession *session) startACSSession(client wsclient.ClientServer) error {
 			// Once ACS successfully reconnects, set disconnectModeEnabled to FALSE
 			logger.Debug("Turning DisconnectModeEnabled off after successful reconnection.")
 			cfg.SetDisconnectModeEnabled(false)
+			acsSession.taskHandler.ResumeEventsFlow()
 		} else if acsSession.disconnectionTimer != nil {
 			// If reconnection is successful when the disconnection timer has already started,
 			// then terminate the timer. This way the timer can be re-initalized when connection


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
1. Creates a `taskCount` variable to keep track of how many task updates are sent in one minute (which is counted by the `taskCountTimer`) and sleeps for one minute after the `throttlingLimit` (for token refills) as defined [here](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/request-throttling.html) for API agent modify actions is reached. 
2. Passes the `connectToACS` channel into the `startDisconnectMode()` in order to successfully reconnect to ACS after `disconnectModeEnabled `is turned on (bug fix).
### Implementation details
<!-- How are the changes implemented? -->
1. In taskHandler.go, there are two new struct variables (the taskCount and taskCountTimer) in order to keep track of task updates being sent. The logic to update the taskCount according to the timer is in the function `submitTaskEvents`.
2. The logic to sleep after the limit has been reached is in the function`submitFirstEvent`. 
3. `connectToACS` is passed into `startDisconnectMode()` as a channel argument, allowing the original function and channel to be referenced from the newer function.

### Testing
The new feature was tested manually by checking log statements, but in this case the `throttlingLimit` was set to 2, for readability: 
```
level=debug time=2022-07-26T00:11:32Z msg="Starting taskCountTimer here."
level=debug time=2022-07-26T00:11:32Z msg="Increasing taskCount by 1" taskCount=1
level=debug time=2022-07-26T00:11:32Z msg="Checking TaskCount Timer"
level=debug time=2022-07-26T00:11:32Z msg="Increasing taskCount by 1" taskCount=2
level=debug time=2022-07-26T00:11:32Z msg="Checking TaskCount Timer"
level=debug time=2022-07-26T00:11:32Z msg="Reached throttling limit for sending task events, starting sleep for one minute"

```

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Feature - sending task state change events in batches

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
