### PR TITLE
Programmatically retrieve service connect endpoint

### DIFF
--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -274,6 +274,7 @@ func (agent *ecsAgent) start() int {
 	client := ecsclient.NewECSClient(agent.credentialProvider, agent.cfg, agent.ec2MetadataClient)
 
 	agent.initializeResourceFields(credentialsManager)
+	agent.serviceconnectManager.SetECSClient(client, agent.containerInstanceARN)
 	return agent.doStart(containerChangeEventStream, credentialsManager, state, imageManager, client, execcmd.NewManager())
 }
 

--- a/agent/engine/serviceconnect/manager.go
+++ b/agent/engine/serviceconnect/manager.go
@@ -14,6 +14,7 @@
 package serviceconnect
 
 import (
+	"github.com/aws/amazon-ecs-agent/agent/api"
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	"github.com/aws/amazon-ecs-agent/agent/config"
@@ -28,4 +29,5 @@ type Manager interface {
 	AugmentTaskContainer(task *apitask.Task, container *apicontainer.Container, hostConfig *dockercontainer.HostConfig) error
 	CreateInstanceTask(config *config.Config) (*apitask.Task, error)
 	AugmentInstanceContainer(task *apitask.Task, container *apicontainer.Container, hostConfig *dockercontainer.HostConfig) error
+	SetECSClient(client api.ECSClient, containerInstanceARN string)
 }

--- a/agent/engine/serviceconnect/manager_other.go
+++ b/agent/engine/serviceconnect/manager_other.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"runtime"
 
+	"github.com/aws/amazon-ecs-agent/agent/api"
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	"github.com/aws/amazon-ecs-agent/agent/config"
@@ -58,6 +59,9 @@ func (*manager) IsLoaded(dockerClient dockerapi.DockerClient) (bool, error) {
 	return false, loader.NewUnsupportedPlatformError(fmt.Errorf(
 		"appnetAgent container isloaded: unsupported platform: %s/%s",
 		runtime.GOOS, runtime.GOARCH))
+}
+
+func (m *manager) SetECSClient(api.ECSClient, string) {
 }
 
 func (*manager) GetLoadedImageName() (string, error) {

--- a/agent/engine/serviceconnect/mock/manager.go
+++ b/agent/engine/serviceconnect/mock/manager.go
@@ -22,6 +22,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	api "github.com/aws/amazon-ecs-agent/agent/api"
 	container "github.com/aws/amazon-ecs-agent/agent/api/container"
 	task "github.com/aws/amazon-ecs-agent/agent/api/task"
 	config "github.com/aws/amazon-ecs-agent/agent/config"
@@ -140,4 +141,16 @@ func (m *MockManager) LoadImage(arg0 context.Context, arg1 *config.Config, arg2 
 func (mr *MockManagerMockRecorder) LoadImage(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadImage", reflect.TypeOf((*MockManager)(nil).LoadImage), arg0, arg1, arg2)
+}
+
+// SetECSClient mocks base method
+func (m *MockManager) SetECSClient(arg0 api.ECSClient, arg1 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetECSClient", arg0, arg1)
+}
+
+// SetECSClient indicates an expected call of SetECSClient
+func (mr *MockManagerMockRecorder) SetECSClient(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetECSClient", reflect.TypeOf((*MockManager)(nil).SetECSClient), arg0, arg1)
 }


### PR DESCRIPTION

### Summary
In order to programmatically retrieve the ServiceConnect endpoint, the ECS client must be injected once created.

This allows the service connect manager to get the correct endpoint or fallback to a default if there is an error.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
