### PR TITLE
Add ecs-init build tag argument in integrated spec files

### DIFF
--- a/packaging/amazon-linux-ami-integrated/ecs-agent.spec
+++ b/packaging/amazon-linux-ami-integrated/ecs-agent.spec
@@ -163,7 +163,7 @@ required routes among its preparation steps.
 ./scripts/build-cni-plugins
 ./scripts/build-integrated true "" false true
 ./scripts/build-agent-image
-./scripts/gobuild.sh
+./scripts/gobuild.sh %{gobuild_tag}
 
 %install
 install -D amazon-ecs-init %{buildroot}%{_libexecdir}/amazon-ecs-init

--- a/packaging/generic-rpm-integrated/amazon-ecs-init.spec
+++ b/packaging/generic-rpm-integrated/amazon-ecs-init.spec
@@ -48,7 +48,7 @@ required routes among its preparation steps.
 ./scripts/build-cni-plugins
 ./scripts/build-integrated true "" false true
 ./scripts/build-agent-image
-./scripts/gobuild.sh
+./scripts/gobuild.sh %{gobuild_tag}
 
 %install
 install -D amazon-ecs-init %{buildroot}%{_libexecdir}/amazon-ecs-init


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This adds the build tag to the ecs-init gobuild.sh script, which will point to the correct ecs-init config
https://github.com/aws/amazon-ecs-init/blob/5f7f9336bc3c5314206aefd212e9ebbfc3bdab60/ecs-init/config/config_al2.go#L1

### Implementation details
the tags are already defined in the spec files, this was just a miss in our setup/testing.

### Testing
Built using `make generic-rpm-integrated` on a fresh instance of latest ecs-optimized AMI. 
```
sudo systemctl stop ecs
sudo rpm -e <old rpm file>
sudo rpm -i <built rpm file>
sudo systemctl start ecs
```
then a docker inspect of the launched agent container to be sure we see:
```
            {
                "Type": "bind",
                "Source": "/sys/fs/cgroup",
                "Destination": "/sys/fs/cgroup",
                "Mode": "",
                "RW": true,
                "Propagation": "rprivate"
            },
```

### Description for the changelog
Fix ecs-init build tag bug for integrated builds.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
