### PR TITLE
swapped the impl of GetAllNetworkInterfaces from Golang net pkg to pwsh cmdlet

### DIFF
--- a/agent/eni/netwrapper/netwrapper.go
+++ b/agent/eni/netwrapper/netwrapper.go
@@ -36,5 +36,5 @@ func (utils *utils) FindInterfaceByIndex(index int) (*net.Interface, error) {
 }
 
 func (utils *utils) GetAllNetworkInterfaces() ([]net.Interface, error) {
-	return net.Interfaces()
+	return utils.getAllNetworkInterfaces()
 }

--- a/agent/eni/netwrapper/netwrapper_linux.go
+++ b/agent/eni/netwrapper/netwrapper_linux.go
@@ -1,0 +1,24 @@
+//go:build linux
+// +build linux
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package netwrapper
+
+import "net"
+
+// getAllNetworkInterfaces returns all the network adapters.
+func (utils *utils) getAllNetworkInterfaces() ([]net.Interface, error) {
+	return net.Interfaces()
+}

--- a/agent/eni/netwrapper/netwrapper_windows.go
+++ b/agent/eni/netwrapper/netwrapper_windows.go
@@ -1,0 +1,90 @@
+//go:build windows
+// +build windows
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package netwrapper
+
+import (
+	"encoding/json"
+	"net"
+	"os/exec"
+
+	log "github.com/cihub/seelog"
+	"github.com/pkg/errors"
+)
+
+type windowsNetworkAdapter struct {
+	Name       string `json:"ifAlias"`
+	MacAddress string `json:"MacAddress"`
+	IfIndex    int    `json:"ifIndex"`
+	MTU        int    `json:"ActiveMaximumTransmissionUnit"`
+}
+
+type winAdapters []windowsNetworkAdapter
+
+// Making it visible for unit testing
+var execCommand = exec.Command
+
+// getAllNetworkInterfaces returns all the network adapters.
+// Unfortunately, as of August 2022, the Win32 IPHelper API seems to be flaky wherein
+// the same stops responding in few intermittent cases. Therefore, to avoid failures
+// in such cases, we have switched to using Powershell cmdlet for fetching all the interfaces.
+func (utils *utils) getAllNetworkInterfaces() ([]net.Interface, error) {
+	log.Info("Running Powershell command to fetch all the network adapters")
+
+	// This command returns a JSON array of all the network interfaces on the instance.
+	cmd := "Get-NetAdapter | select ifAlias, ifIndex, MacAddress, ActiveMaximumTransmissionUnit | ConvertTo-Json"
+	out, err := execCommand("Powershell", "-C", cmd).Output()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to execute Get-NetAdapter for retrieving all interfaces")
+	}
+	log.Debugf("Output of Get-NetAdapters Powershell command execution: %s", out)
+
+	// Convert the obtained JSON array into an array of structs.
+	var data winAdapters
+	err = json.Unmarshal(out, &data)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to unmarshal the json of network adapters")
+	}
+
+	// This is an error condition since the instance would have at least 1 ENI.
+	if len(data) == 0 {
+		return nil, errors.Errorf("invalid number of network adapters found on the instance")
+	}
+	log.Debugf("Unmarshalled Powershell output into an array of structs")
+
+	// Convert the data into an array of net.Interface
+	var ifaces []net.Interface
+	for _, adapter := range data {
+		mac, err := net.ParseMAC(adapter.MacAddress)
+		if err != nil {
+			// Log the error and continue to get as many adapters as possible.
+			log.Errorf("unable to parse mac address: %v", err)
+			continue
+		}
+
+		iface := net.Interface{
+			Index:        adapter.IfIndex,
+			MTU:          adapter.MTU,
+			Name:         adapter.Name,
+			HardwareAddr: mac,
+		}
+
+		ifaces = append(ifaces, iface)
+	}
+	log.Debugf("All the interfaces found using Get-NetAdapters are: %v", ifaces)
+
+	return ifaces, nil
+}

--- a/agent/eni/netwrapper/netwrapper_windows_test.go
+++ b/agent/eni/netwrapper/netwrapper_windows_test.go
@@ -1,0 +1,155 @@
+//go:build windows
+// +build windows
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package netwrapper
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	dummyIfAlias              = "Ethernet 2"
+	dummyIfIndex              = 9
+	dummyMAC                  = "06-34-BB-C8-64-C5"
+	networkAdapterValidResult = `[
+  {
+    "ifAlias": "%s",
+    "ifIndex": %d,
+    "MacAddress": "%s",
+    "ActiveMaximumTransmissionUnit": 1500
+  }
+]`
+	networkAdapterExpectedValidResult []net.Interface
+	networkAdapterInvalidResult       = ""
+)
+
+func init() {
+	networkAdapterValidResult = fmt.Sprintf(networkAdapterValidResult, dummyIfAlias, dummyIfIndex, dummyMAC)
+
+	parsedMAC, _ := net.ParseMAC(dummyMAC)
+	networkAdapterExpectedValidResult = []net.Interface{
+		{
+			Index:        dummyIfIndex,
+			MTU:          1500,
+			Name:         dummyIfAlias,
+			HardwareAddr: parsedMAC,
+		},
+	}
+
+}
+
+// Supporting methods for testing getAllNetworkInterfaces method.
+// mockExecCommandForNetworkAdaptersSuccess returns a valid output from exec cmd.
+func mockExecCommandForNetworkAdaptersSuccess(command string, args ...string) *exec.Cmd {
+	cs := []string{"-test.run=TestNetworkAdaptersProcessSuccess", "--", command}
+	cs = append(cs, args...)
+	cmd := exec.Command(os.Args[0], cs...)
+	cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1"}
+	return cmd
+}
+
+// TestNetworkAdaptersProcessSuccess is invoked from mockExecCommandForNetworkAdaptersSuccess
+// to return the network adapter information.
+func TestNetworkAdaptersProcessSuccess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	fmt.Fprintf(os.Stdout, networkAdapterValidResult)
+	os.Exit(0)
+}
+
+// mockExecCommandForNetworkAdaptersInvalidOutput returns an invalid output from exec cmd.
+func mockExecCommandForNetworkAdaptersInvalidOutput(command string, args ...string) *exec.Cmd {
+	cs := []string{"-test.run=TestNetworkAdaptersProcessInvalidOutput", "--", command}
+	cs = append(cs, args...)
+	cmd := exec.Command(os.Args[0], cs...)
+	cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1"}
+	return cmd
+}
+
+// TestNetworkAdaptersProcessInvalidOutput is invoked from mockExecCommandForNetworkAdaptersInvalidOutput
+// to return invalid network adapter information.
+func TestNetworkAdaptersProcessInvalidOutput(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	fmt.Fprintf(os.Stdout, networkAdapterInvalidResult)
+	os.Exit(0)
+}
+
+// mockExecCommandForNetworkAdaptersCommandError returns an error during command execution.
+func mockExecCommandForNetworkAdaptersCommandError(command string, args ...string) *exec.Cmd {
+	cs := []string{"-test.run=TestNetworkAdaptersProcessCommandError", "--", command}
+	cs = append(cs, args...)
+	cmd := exec.Command(os.Args[0], cs...)
+	cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1"}
+	return cmd
+}
+
+// TestNetworkAdaptersProcessCommandError is invoked from mockExecCommandForNetworkAdaptersCommandError
+// to return an error during command execution.
+func TestNetworkAdaptersProcessCommandError(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "error during execution")
+	os.Exit(1)
+}
+
+func TestGetAllWindowsNetworkInterfaces(t *testing.T) {
+	var tests = []struct {
+		name                string
+		execCmd             func(string, ...string) *exec.Cmd
+		expectedOutput      []net.Interface
+		expectedErrorString string
+	}{
+		{
+			name:                "TestGetAllWindowsNetworkInterfacesSuccess",
+			execCmd:             mockExecCommandForNetworkAdaptersSuccess,
+			expectedOutput:      networkAdapterExpectedValidResult,
+			expectedErrorString: "",
+		},
+		{
+			name:                "TestGetAllWindowsNetworkInterfacesInvalidOutput",
+			execCmd:             mockExecCommandForNetworkAdaptersInvalidOutput,
+			expectedOutput:      nil,
+			expectedErrorString: "failed to unmarshal the json of network adapters: unexpected end of JSON input",
+		},
+		{
+			name:                "TestGetAllWindowsNetworkInterfacesCommandError",
+			execCmd:             mockExecCommandForNetworkAdaptersCommandError,
+			expectedOutput:      nil,
+			expectedErrorString: "failed to execute Get-NetAdapter for retrieving all interfaces: exit status 1",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			execCommand = test.execCmd
+			out, err := New().GetAllNetworkInterfaces()
+			assert.Equal(t, test.expectedOutput, out)
+			if test.expectedErrorString != "" {
+				assert.EqualError(t, err, test.expectedErrorString)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

As of August 2022, Windows instances are facing an issue wherein Win32 APIs are not working as expected in intermittent cases. Essentially, the callbacks for `NotifyIpInterfaceChange API` are not working as well as `GetAdaptersAddresses API` is not returning all the network interfaces on the instance. The second issue leads to `net.Interfaces()` failing as well.

 In order to ensure that tasks using `awsvpc network mode` continue working on Windows nodes, we are swapping the existing mechanism for periodic reconciliation to an alternate mechanism wherein a Powershell cmdlet is being executed to fetch all the network interfaces on the instance. Therefore, in the happy path, Win32 NotifyIpInterfaceChange API callback would be invoked and the ENI would be acknowledged promptly.

However, in the scenario wherein WIN32 IP Helper APIs fail to work as expected, we would rely upon the periodic reconciliation which happens every 30 seconds. Since the actual ENI timeout is much greater than this reconciliation period, the ENI timeout would be prevented.

### Implementation details
<!-- How are the changes implemented? -->

We have a `netwrapper` package which presently abstracts Golang's net package. This in turn is used in netutils and then in watcher packages.
For the implementation change suggested above, we are swapping the generic `net.Interfaces()` call with platform specific implementation.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
New unit tests have been added to validate this implementation.
From functional testing viewpoint, a new agent was built and deployed on `Windows Server 2019 Full` and `Windows Server 2022 Full` instances. In this process, we disabled the callbacks so that the actual scenario was replicated.
We then launched tasks (4-6 simultaneously on same node) over a period of 5 hours.

New tests cover the changes: <!-- yes|no -->
Yes
### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
windows: swapped the impl of GetAllNetworkInterfaces from Golang net pkg to pwsh cmdlet
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
