### PR TITLE
Run AppNet Relay as non-root and remove it from introspection response; fix AppNet container pull error

### DIFF
--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -292,6 +292,8 @@ type Task struct {
 	ServiceConnectConnectionDrainingUnsafe bool `json:"ServiceConnectConnectionDraining,omitempty"`
 
 	NetworkMode string `json:"NetworkMode,omitempty"`
+
+	IsInternal bool `json:"IsInternal,omitempty"`
 }
 
 // TaskFromACS translates ecsacs.Task to apitask.Task by first marshaling the received

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -1693,7 +1693,8 @@ func (task *Task) dockerConfig(container *apicontainer.Container, apiVersion doc
 	}
 
 	// TODO [SC] - Move this as well as 'dockerExposedPorts' SC-specific logic into a separate file
-	if task.IsServiceConnectEnabled() && container == task.GetServiceConnectContainer() {
+	if (task.IsServiceConnectEnabled() && container == task.GetServiceConnectContainer()) ||
+		container.Type == apicontainer.ContainerServiceConnectRelay {
 		containerConfig.User = strconv.Itoa(serviceconnect.AppNetUID)
 	}
 

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -1015,8 +1015,12 @@ func (engine *DockerTaskEngine) GetTaskByArn(arn string) (*apitask.Task, bool) {
 
 func (engine *DockerTaskEngine) pullContainer(task *apitask.Task, container *apicontainer.Container) dockerapi.DockerContainerMetadata {
 	switch container.Type {
-	case apicontainer.ContainerCNIPause, apicontainer.ContainerNamespacePause:
-		// pause images are managed at startup
+	case apicontainer.ContainerCNIPause, apicontainer.ContainerNamespacePause, apicontainer.ContainerServiceConnectRelay:
+		// pause images and AppNet relay image are managed at startup
+		return dockerapi.DockerContainerMetadata{}
+	}
+	// AppNet Agent container image is also managed at start up (it uses the same image as AppNet Relay container)
+	if task.IsServiceConnectEnabled() && container == task.GetServiceConnectContainer() {
 		return dockerapi.DockerContainerMetadata{}
 	}
 

--- a/agent/engine/docker_task_engine_linux_test.go
+++ b/agent/engine/docker_task_engine_linux_test.go
@@ -1000,9 +1000,9 @@ func TestContainersWithServiceConnect(t *testing.T) {
 
 	// For the other container
 	imageManager.EXPECT().AddAllImageStates(gomock.Any()).AnyTimes()
-	dockerClient.EXPECT().PullImage(gomock.Any(), gomock.Any(), nil, gomock.Any()).Return(dockerapi.DockerContainerMetadata{}).Times(3)
-	imageManager.EXPECT().RecordContainerReference(gomock.Any()).Return(nil).Times(3)
-	imageManager.EXPECT().GetImageStateFromImageName(gomock.Any()).Return(nil, false).Times(3)
+	dockerClient.EXPECT().PullImage(gomock.Any(), gomock.Any(), nil, gomock.Any()).Return(dockerapi.DockerContainerMetadata{}).Times(2)
+	imageManager.EXPECT().RecordContainerReference(gomock.Any()).Return(nil).Times(2)
+	imageManager.EXPECT().GetImageStateFromImageName(gomock.Any()).Return(nil, false).Times(2)
 	dockerClient.EXPECT().APIVersion().Return(defaultDockerClientAPIVersion, nil).Times(4)
 
 	serviceConnectCreate, _, scStop := setupMockSCTaskContainer("service-connect", sleepTask.Containers[2], scContainerID, 1337, containerNetNS, serviceConnectManager, dockerClient, nil)
@@ -1195,10 +1195,11 @@ func TestContainersWithServiceConnect_BridgeMode(t *testing.T) {
 	cniClient.EXPECT().CleanupNS(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(2)
 
 	// For SC and sleep container - those calls can happen in parallel
+	// Note that SC container won't trigger image-related calls as AppNet container images are cached and managed by Agent
 	imageManager.EXPECT().AddAllImageStates(gomock.Any()).AnyTimes()
-	dockerClient.EXPECT().PullImage(gomock.Any(), gomock.Any(), nil, gomock.Any()).Return(dockerapi.DockerContainerMetadata{}).Times(2)
-	imageManager.EXPECT().RecordContainerReference(gomock.Any()).Return(nil).Times(2)
-	imageManager.EXPECT().GetImageStateFromImageName(gomock.Any()).Return(nil, false).Times(2)
+	dockerClient.EXPECT().PullImage(gomock.Any(), gomock.Any(), nil, gomock.Any()).Return(dockerapi.DockerContainerMetadata{}).Times(1)
+	imageManager.EXPECT().RecordContainerReference(gomock.Any()).Return(nil).Times(1)
+	imageManager.EXPECT().GetImageStateFromImageName(gomock.Any()).Return(nil, false).Times(1)
 	dockerClient.EXPECT().APIVersion().Return(defaultDockerClientAPIVersion, nil).Times(2)
 
 	cleanup := make(chan time.Time)

--- a/agent/engine/dockerstate/docker_task_engine_state.go
+++ b/agent/engine/dockerstate/docker_task_engine_state.go
@@ -151,10 +151,26 @@ func (state *DockerTaskEngineState) AllTasks() []*apitask.Task {
 	state.lock.RLock()
 	defer state.lock.RUnlock()
 
-	return state.allTasksUnsafe(false)
+	return state.allTasksUnsafe()
 }
 
-func (state *DockerTaskEngineState) allTasksUnsafe(excludeInternal bool) []*apitask.Task {
+func (state *DockerTaskEngineState) allTasksUnsafe() []*apitask.Task {
+	return state.getFilteredTasksUnsafe(false)
+}
+
+// AllExternalTasks returns all tasks with IsInternal==false (i.e. all customer-initiated tasks)
+func (state *DockerTaskEngineState) AllExternalTasks() []*apitask.Task {
+	state.lock.RLock()
+	defer state.lock.RUnlock()
+
+	return state.allExternalTasksUnsafe()
+}
+
+func (state *DockerTaskEngineState) allExternalTasksUnsafe() []*apitask.Task {
+	return state.getFilteredTasksUnsafe(true)
+}
+
+func (state *DockerTaskEngineState) getFilteredTasksUnsafe(excludeInternal bool) []*apitask.Task {
 	ret := make([]*apitask.Task, len(state.tasks))
 	ndx := 0
 	for _, task := range state.tasks {
@@ -165,14 +181,6 @@ func (state *DockerTaskEngineState) allTasksUnsafe(excludeInternal bool) []*apit
 		ndx++
 	}
 	return ret[:ndx]
-}
-
-// AllExternalTasks returns all tasks with IsInternal==false (i.e. all customer-initiated tasks)
-func (state *DockerTaskEngineState) AllExternalTasks() []*apitask.Task {
-	state.lock.RLock()
-	defer state.lock.RUnlock()
-
-	return state.allTasksUnsafe(true)
 }
 
 // AllImageStates returns all of the image.ImageStates

--- a/agent/engine/dockerstate/json.go
+++ b/agent/engine/dockerstate/json.go
@@ -38,7 +38,7 @@ func (state *DockerTaskEngineState) MarshalJSON() ([]byte, error) {
 	state.lock.RLock()
 	defer state.lock.RUnlock()
 	toSave := savedState{
-		Tasks:          state.allTasksUnsafe(false),
+		Tasks:          state.allTasksUnsafe(),
 		IdToContainer:  state.idToContainer,
 		IdToTask:       state.idToTask,
 		ImageStates:    state.allImageStatesUnsafe(),

--- a/agent/engine/dockerstate/json.go
+++ b/agent/engine/dockerstate/json.go
@@ -38,7 +38,7 @@ func (state *DockerTaskEngineState) MarshalJSON() ([]byte, error) {
 	state.lock.RLock()
 	defer state.lock.RUnlock()
 	toSave := savedState{
-		Tasks:          state.allTasksUnsafe(),
+		Tasks:          state.allTasksUnsafe(false),
 		IdToContainer:  state.idToContainer,
 		IdToTask:       state.idToTask,
 		ImageStates:    state.allImageStatesUnsafe(),

--- a/agent/engine/dockerstate/mocks/dockerstate_mocks.go
+++ b/agent/engine/dockerstate/mocks/dockerstate_mocks.go
@@ -137,7 +137,7 @@ func (mr *MockTaskEngineStateMockRecorder) AllENIAttachments() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllENIAttachments", reflect.TypeOf((*MockTaskEngineState)(nil).AllENIAttachments))
 }
 
-// AllExternalTasks mocks base method.
+// AllExternalTasks mocks base method
 func (m *MockTaskEngineState) AllExternalTasks() []*task.Task {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllExternalTasks")
@@ -145,7 +145,7 @@ func (m *MockTaskEngineState) AllExternalTasks() []*task.Task {
 	return ret0
 }
 
-// AllExternalTasks indicates an expected call of AllExternalTasks.
+// AllExternalTasks indicates an expected call of AllExternalTasks
 func (mr *MockTaskEngineStateMockRecorder) AllExternalTasks() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllExternalTasks", reflect.TypeOf((*MockTaskEngineState)(nil).AllExternalTasks))

--- a/agent/engine/dockerstate/mocks/dockerstate_mocks.go
+++ b/agent/engine/dockerstate/mocks/dockerstate_mocks.go
@@ -137,6 +137,20 @@ func (mr *MockTaskEngineStateMockRecorder) AllENIAttachments() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllENIAttachments", reflect.TypeOf((*MockTaskEngineState)(nil).AllENIAttachments))
 }
 
+// AllExternalTasks mocks base method.
+func (m *MockTaskEngineState) AllExternalTasks() []*task.Task {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AllExternalTasks")
+	ret0, _ := ret[0].([]*task.Task)
+	return ret0
+}
+
+// AllExternalTasks indicates an expected call of AllExternalTasks.
+func (mr *MockTaskEngineStateMockRecorder) AllExternalTasks() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllExternalTasks", reflect.TypeOf((*MockTaskEngineState)(nil).AllExternalTasks))
+}
+
 // AllImageStates mocks base method
 func (m *MockTaskEngineState) AllImageStates() []*image.ImageState {
 	m.ctrl.T.Helper()

--- a/agent/engine/serviceconnect/manager_linux.go
+++ b/agent/engine/serviceconnect/manager_linux.go
@@ -281,6 +281,7 @@ func (m *manager) CreateInstanceTask(cfg *config.Config) (*apitask.Task, error) 
 		LaunchType:         "EC2",
 		NetworkMode:        apitask.HostNetworkMode,
 		ResourcesMapUnsafe: make(map[string][]taskresource.TaskResource),
+		IsInternal:         true,
 	}
 	m.initRelayEnvironment(cfg, task.Containers[0])
 

--- a/agent/handlers/v1/response.go
+++ b/agent/handlers/v1/response.go
@@ -175,7 +175,7 @@ func NewVolumesResponse(dockerContainer *apicontainer.DockerContainer) []VolumeR
 
 // NewTasksResponse creates TasksResponse for all the tasks.
 func NewTasksResponse(state dockerstate.TaskEngineState) *TasksResponse {
-	allTasks := state.AllTasks()
+	allTasks := state.AllExternalTasks()
 	taskResponses := make([]*TaskResponse, len(allTasks))
 	for ndx, task := range allTasks {
 		containerMap, _ := state.ContainerMapByArn(task.Arn)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
1. Run AppNet Relay container as non-privileged user 1337, same as task AppNet container. 
2. We've modeled AppNet Relay as an internal ECS task in a previous [PR](https://github.com/aws/amazon-ecs-agent/pull/3280) to leverage the existing task/container lifecycle management mechanism. In this PR we take this task out from introspection endpoint (http://localhost:51678/v1/tasks) response as it should be kept invisible to customers. We do this by introducing an `IsInternal` field to task model, and setting it to true for AppNet relay indicating that it's an internally managed task (not initiated by customer). Upon receiving request to list all tasks with Introspection API, we filter out internal tasks. 
3. Do not try to pull container images for AppNet relay or task container, as the images are loaded by ECS Agent locally.


<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

Tested new Agent with Service Connect task and verified that
1. Task is able to start with Relay running as non-privileged user, and task AppNet container able to retrieve cluster config
2. AppNet relay task is removed from introspection response from `curl http://localhost:51678/v1/tasks`
3. No longer seeing image pull errors for AppNet containers.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Run AppNet Relay as non-root; Remove it from introspection response; Fix AppNet container pull error.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
