### PR TITLE
Remove hardcoded default credential profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,8 +220,6 @@ The agent also supports the following flags:
 
 ## Building and Running from Source
 
-**Running the Amazon ECS Container Agent outside of Amazon EC2 is not supported.**
-
 ### Docker Image (on Linux)
 
 The Amazon ECS Container Agent may be built by typing `make` with the [Docker

--- a/agent/credentials/providers/rotating_shared_credentials_provider.go
+++ b/agent/credentials/providers/rotating_shared_credentials_provider.go
@@ -45,7 +45,7 @@ func NewRotatingSharedCredentialsProvider() *RotatingSharedCredentialsProvider {
 		RotationInterval: defaultRotationInterval,
 		sharedCredentialsProvider: &credentials.SharedCredentialsProvider{
 			Filename: defaultRotatingCredentialsFilename,
-			Profile:  "default",
+			Profile:  "",
 		},
 	}
 }

--- a/agent/credentials/providers/rotating_shared_credentials_provider_test.go
+++ b/agent/credentials/providers/rotating_shared_credentials_provider_test.go
@@ -29,7 +29,7 @@ import (
 func TestNewRotatingSharedCredentialsProvider(t *testing.T) {
 	p := NewRotatingSharedCredentialsProvider()
 	require.Equal(t, time.Minute, p.RotationInterval)
-	require.Equal(t, "default", p.sharedCredentialsProvider.Profile)
+	require.Equal(t, "", p.sharedCredentialsProvider.Profile)
 	require.Equal(t, defaultRotatingCredentialsFilename, p.sharedCredentialsProvider.Filename)
 }
 


### PR DESCRIPTION
Summary
Remove hard-coded "default" profile for credentials. The AWS SDK will already fall back to default if no profile is selected. This allows the customer to specify alternate profiles in their environment.

Implementation details
Remove the hard-coded value and update the unit tests

Testing
Unit tests were successfully run on Ubuntu 20.04 with Golang 1.18

New tests cover the changes: Yes. No new lines were added to the codebase.

Description for the changelog
Enhancement - Remove hard-coded "default" profile for credentials to allow their specification from the environment with fallback to "default".

Licensing
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
