### PR TITLE
update v3 metadata to return network despite nil

### DIFF
--- a/agent/handlers/v3/task_metadata_handler.go
+++ b/agent/handlers/v3/task_metadata_handler.go
@@ -68,12 +68,7 @@ func TaskMetadataHandler(state dockerstate.TaskEngineState, ecsClient api.ECSCli
 			for _, containerResponse := range taskResponse.Containers {
 				networks, err := GetContainerNetworkMetadata(containerResponse.ID, state)
 				if err != nil {
-					errResponseJSON, err := json.Marshal(err.Error())
-					if e := utils.WriteResponseIfMarshalError(w, err); e != nil {
-						return
-					}
-					utils.WriteJSONToResponse(w, http.StatusInternalServerError, errResponseJSON, utils.RequestTypeContainerMetadata)
-					return
+					seelog.Warnf("Error retrieving network metadata for container %s - %s", containerResponse.ID, err)
 				}
 				containerResponse.Networks = networks
 				responses = append(responses, containerResponse)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This updates the v3 metadata endpoint to return network metadata for all available. Previously we threw a `http.StatusInternalServerError` (500) in the case of any container in the task not having available network metadata.

Related changes to v4: https://github.com/aws/amazon-ecs-agent/pull/2719, https://github.com/aws/amazon-ecs-agent/pull/2747

### Implementation details
<!-- How are the changes implemented? -->
removed error cases for individual missing metadata and added a warn log level entry.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Enhancement - Allow task metadata endpoint v3 to return metadata for task when some of the container does not have network metadata

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
