### PR TITLE
Fix memory leak while creating multiple httpClient

### DIFF
--- a/agent/stats/service_connect_linux_test.go
+++ b/agent/stats/service_connect_linux_test.go
@@ -24,6 +24,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/aws/amazon-ecs-agent/agent/api/appnet"
 	"github.com/aws/amazon-ecs-agent/agent/api/serviceconnect"
 
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
@@ -136,7 +137,9 @@ func TestRetrieveServiceConnectMetrics(t *testing.T) {
 		ts.Listener = l
 		ts.Start()
 
-		serviceConnectStats := &ServiceConnectStats{}
+		serviceConnectStats := &ServiceConnectStats{
+			appnetClient: appnet.Client(),
+		}
 		serviceConnectStats.retrieveServiceConnectStats(t1)
 
 		sortMetrics(serviceConnectStats.GetStats())


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

Problem Statement: While performance testing ECS agent with 12 tasks, noticed a constantly increasing memory consumption of ECS agent. 

```
go tool pprof heap.pprof
Type: inuse_space
Time: Aug 15, 2022 at 12:51am (UTC)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top10
Showing nodes accounting for 412.59MB, 93.56% of 440.97MB total
Dropped 88 nodes (cum <= 2.20MB)
Showing top 10 nodes out of 50
      flat  flat%   sum%        cum   cum%
  136.53MB 30.96% 30.96%   136.53MB 30.96%  bufio.NewReaderSize (inline)
  123.98MB 28.12% 59.08%   123.98MB 28.12%  bufio.NewWriterSize (inline)
   35.03MB  7.94% 67.02%    35.03MB  7.94%  net/http.(*Transport).queueForIdleConn
   25.52MB  5.79% 72.81%    36.02MB  8.17%  net/http.(*Transport).tryPutIdleConn
   24.01MB  5.44% 78.25%    24.01MB  5.44%  runtime.malg
   20.50MB  4.65% 82.90%   288.51MB 65.43%  net/http.(*Transport).dialConn
   17.02MB  3.86% 86.76%    17.02MB  3.86%  runtime.allocm
      16MB  3.63% 90.39%    58.04MB 13.16%  github.com/aws/amazon-ecs-agent/agent/api/appnet.performAppnetRequest
       7MB  1.59% 91.98%    10.50MB  2.38%  net/http.(*connLRU).add
       7MB  1.59% 93.56%    43.02MB  9.76%  net/http.(*persistConn).readLoop
(pprof) list bufio.NewReaderSize
Total: 440.97MB
ROUTINE ======================== bufio.NewReaderSize in /usr/local/go/src/bufio/bufio.go
  136.53MB   136.53MB (flat, cum) 30.96% of Total
         .          .     51:		return b
         .          .     52:	}
         .          .     53:	if size < minReadBufferSize {
         .          .     54:		size = minReadBufferSize
         .          .     55:	}
    1.50MB     1.50MB     56:	r := new(Reader)
  135.03MB   135.03MB     57:	r.reset(make([]byte, size), rd)
         .          .     58:	return r
         .          .     59:}
         .          .     60:
         .          .     61:// NewReader returns a new Reader whose buffer has the default size.
         .          .     62:func NewReader(rd io.Reader) *Reader {
(pprof
```

```
CONTAINER ID   NAME        CPU %     MEM USAGE / LIMIT     MEM %     NET I/O   BLOCK I/O        PIDS
3f4ff1533ffe   ecs-agent   0.55%     344.1MiB / 246.4GiB   0.14%     0B / 0B   152MB / 14.1MB   72
```
The pprof output indicates that the method performAppnetRequest which calls net.Dial is responsible for 65% of the memory usage of ecs-agent. This was possibly because [https://github.com/golang/go/pull/50799](https://github.com/golang/go/pull/50799/files#diff-f2f92ffe0abe8dd3c833d435c2d859d54380e8e4160af8becab6945395563cfe)
 
This was introduced because, this [https://github.com/aws/amazon-ecs-agent/pull/3332](PR)  was creating http Client for every stats request every minute. Due to this memory leak issue with http.Transport, the memory consumption would continuously increase. Earlier to this PR, the udsHttpClient was common to all appnet Client which would give rise to race conditions when we are running a lot of tasks as stats are collected concurrently. Ref: https://github.com/aws/amazon-ecs-agent/pull/3224

The issue was fixed by making the udshttpClient an attribute of appnet Client. ServiceConnectStats object will store this client as its attribute for every task. So the udsHttpClient is created only once per task for collecting stats

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes

Tested by running 12 tasks with new agent and saw that the GoroutineCount is not exponentially increasing but is constant. The memory usage is also within a constant range after running these tasks for over 12 hrs.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
