### PR TITLE
Add ServiceName to task

### DIFF
--- a/agent/acs/model/api/api-2.json
+++ b/agent/acs/model/api/api-2.json
@@ -723,7 +723,8 @@
         "pidMode":{"shape":"String"},
         "ipcMode":{"shape":"String"},
         "proxyConfiguration":{"shape":"ProxyConfiguration"},
-        "launchType":{"shape":"String"}
+        "launchType":{"shape":"String"},
+        "serviceName":{"shape":"String"}
       }
     },
     "TaskList":{

--- a/agent/acs/model/ecsacs/api.go
+++ b/agent/acs/model/ecsacs/api.go
@@ -1631,6 +1631,8 @@ type Task struct {
 
 	RoleCredentials *IAMRoleCredentials `locationName:"roleCredentials" type:"structure"`
 
+	ServiceName *string `locationName:"serviceName" type:"string"`
+
 	TaskDefinitionAccountId *string `locationName:"taskDefinitionAccountId" type:"string"`
 
 	Version *string `locationName:"version" type:"string"`

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -161,6 +161,9 @@ type Task struct {
 	Family string
 	// Version is the version of the task definition
 	Version string
+	// ServiceName is the name of the service to which the task belongs.
+	// It is empty if the task does not belong to any service.
+	ServiceName string
 	// Containers are the containers for the task
 	Containers []*apicontainer.Container
 	// Associations are the available associations for the task.

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -1178,6 +1178,7 @@ func TestTaskFromACS(t *testing.T) {
 		DesiredStatus: strptr("RUNNING"),
 		Family:        strptr("myFamily"),
 		Version:       strptr("1"),
+		ServiceName:   strptr("myService"),
 		Containers: []*ecsacs.Container{
 			{
 				Name:        strptr("myName"),
@@ -1273,6 +1274,7 @@ func TestTaskFromACS(t *testing.T) {
 		DesiredStatusUnsafe: apitaskstatus.TaskRunning,
 		Family:              "myFamily",
 		Version:             "1",
+		ServiceName:         "myService",
 		Containers: []*apicontainer.Container{
 			{
 				Name:        "myName",
@@ -3279,6 +3281,16 @@ func TestTaskFromACSPerContainerTimeouts(t *testing.T) {
 
 	assert.Equal(t, task.Containers[0].StartTimeout, expectedTimeout)
 	assert.Equal(t, task.Containers[0].StopTimeout, expectedTimeout)
+}
+
+// Tests that ACS Task to Task translation does not fail when ServiceName is missing.
+// Asserts that Task.ServiceName is empty in such a case.
+func TestTaskFromACSServiceNameMissing(t *testing.T) {
+	taskFromACS := ecsacs.Task{} // No service name
+	seqNum := int64(42)
+	task, err := TaskFromACS(&taskFromACS, &ecsacs.PayloadMessage{SeqNum: &seqNum})
+	assert.Nil(t, err, "Should be able to handle acs task")
+	assert.Equal(t, task.ServiceName, "")
 }
 
 func TestGetContainerIndex(t *testing.T) {

--- a/agent/api/task/taskvolume_test.go
+++ b/agent/api/task/taskvolume_test.go
@@ -91,6 +91,7 @@ func TestMarshalTaskVolumesEFS(t *testing.T) {
 		"Arn": "test",
 		"Family": "",
 		"Version": "",
+		"ServiceName": "",
 		"Containers": null,
 		"associations": null,
 		"resources": null,

--- a/agent/api/task/taskvolume_windows_test.go
+++ b/agent/api/task/taskvolume_windows_test.go
@@ -51,6 +51,7 @@ func TestMarshalTaskVolumeFSxWindowsFileServer(t *testing.T) {
 		"Arn": "test",
 		"Family": "",
 		"Version": "",
+		"ServiceName": "",
 		"Containers": null,
 		"associations": null,
 		"resources": null,	


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
1. Update ACS Client library. ACS now sends `ServiceName` in task payloads.
1. Load `ServiceName` from ACS Task payload into Agent's `Task` type. TMDE will be updated in the future to add `ServiceName` in task responses.

### Testing
Updated unit tests. MACIS functional tests.

New tests cover the changes: yes

### Description for the changelog
Load `ServiceName` from ACS Task Payload.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
