### PR TITLE
Inject Agent API V1 endpoint path into containers as an environment v…

### DIFF
--- a/agent/api/container/container.go
+++ b/agent/api/container/container.go
@@ -64,6 +64,13 @@ const (
 	// MetadataURIFormat defines the URI format for v4 metadata endpoint
 	MetadataURIFormatV4 = "http://169.254.170.2/v4/%s"
 
+	// AgentAPIURIEnvVarNameV1 defines the name of the environment
+	// variable injected into containers that contains the Agent API V1 endpoint.
+	AgentAPIURIEnvVarNameV1 = "ECS_AGENT_API_URI_V1"
+
+	// AgentAPIURIFormatV1 defines the URI format for v1 Agent API Endpoint
+	AgentAPIURIFormatV1 = "http://169.254.170.2/api/v1/%s"
+
 	// SecretProviderSSM is to show secret provider being SSM
 	SecretProviderSSM = "ssm"
 
@@ -932,6 +939,22 @@ func (c *Container) InjectV4MetadataEndpoint() {
 
 	c.Environment[MetadataURIEnvVarNameV4] =
 		fmt.Sprintf(MetadataURIFormatV4, c.V3EndpointID)
+}
+
+// InjectV1AgentAPIEndpoint injects the v1 Agent API endpoint into the container
+// as an environment variable.
+func (c *Container) InjectV1AgentAPIEndpoint() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.ensureEnvironmentIsInitialized()
+	c.Environment[AgentAPIURIEnvVarNameV1] = fmt.Sprintf(AgentAPIURIFormatV1, c.V3EndpointID)
+}
+
+// Initializes Environment Map if it is nil
+func (c *Container) ensureEnvironmentIsInitialized() {
+	if c.Environment == nil {
+		c.Environment = make(map[string]string)
+	}
 }
 
 // ShouldCreateWithSSMSecret returns true if this container needs to get secret

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -880,6 +880,35 @@ func TestInitializeContainersV4MetadataEndpoint(t *testing.T) {
 		fmt.Sprintf(apicontainer.MetadataURIFormatV4, "new-uuid"))
 }
 
+// Tests that task.initializeContainersV1AgentAPIEndpoint method initializes
+// V3EndpointID for all containers of the task and injects v1 Agent API Endpoint
+// as an environment variable into each container.
+func TestInitializeContainersV1AgentAPIEndpoint(t *testing.T) {
+	// Create a dummy task
+	task := Task{
+		Containers: []*apicontainer.Container{
+			{
+				Name: "c1",
+			},
+			{
+				Name: "c2",
+			},
+		},
+	}
+
+	// Call the method
+	task.initializeContainersV1AgentAPIEndpoint(utils.NewStaticUUIDProvider("new-uuid"))
+
+	// Assert that v3 endpoint id is set and the endpoint is injected to env of each container
+	for _, container := range task.Containers {
+		assert.Equal(t, container.GetV3EndpointID(), "new-uuid")
+		assert.Equal(t, container.Environment,
+			map[string]string{
+				apicontainer.AgentAPIURIEnvVarNameV1: "http://169.254.170.2/api/v1/new-uuid",
+			})
+	}
+}
+
 func TestPostUnmarshalTaskWithLocalVolumes(t *testing.T) {
 	// Constants used here are defined in task_unix_test.go and task_windows_test.go
 	taskFromACS := ecsacs.Task{

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -901,11 +901,12 @@ func TestInitializeContainersV1AgentAPIEndpoint(t *testing.T) {
 
 	// Assert that v3 endpoint id is set and the endpoint is injected to env of each container
 	for _, container := range task.Containers {
-		assert.Equal(t, container.GetV3EndpointID(), "new-uuid")
-		assert.Equal(t, container.Environment,
+		assert.Equal(t, "new-uuid", container.GetV3EndpointID())
+		assert.Equal(t,
 			map[string]string{
 				apicontainer.AgentAPIURIEnvVarNameV1: "http://169.254.170.2/api/v1/new-uuid",
-			})
+			},
+			container.Environment)
 	}
 }
 

--- a/agent/api/task/task_windows_test.go
+++ b/agent/api/task/task_windows_test.go
@@ -123,19 +123,20 @@ func TestPostUnmarshalWindowsCanonicalPaths(t *testing.T) {
 	task.PostUnmarshalTask(&cfg, nil, nil, nil, nil)
 
 	for _, container := range task.Containers { // remove v3 endpoint from each container because it's randomly generated
-		removeV3andV4EndpointConfig(container)
+		removeEndpointConfigFromEnvironment(container)
 	}
 	assert.Equal(t, expectedTask.Containers, task.Containers, "Containers should be equal")
 	assert.Equal(t, expectedTask.Volumes, task.Volumes, "Volumes should be equal")
 }
 
-// removeV3EndpointConfig removes the v3 endpoint id and the injected env for a container
+// removeEndpointConfigFromEnvironment removes the v3 endpoint id and the injected env for a container
 // so that checking all other fields can be easier
-func removeV3andV4EndpointConfig(container *apicontainer.Container) {
+func removeEndpointConfigFromEnvironment(container *apicontainer.Container) {
 	container.SetV3EndpointID("")
 	if container.Environment != nil {
 		delete(container.Environment, apicontainer.MetadataURIEnvironmentVariableName)
 		delete(container.Environment, apicontainer.MetadataURIEnvVarNameV4)
+		delete(container.Environment, apicontainer.AgentAPIURIEnvVarNameV1)
 	}
 	if len(container.Environment) == 0 {
 		container.Environment = nil

--- a/agent/engine/common_test.go
+++ b/agent/engine/common_test.go
@@ -174,6 +174,8 @@ func validateContainerRunWorkflow(t *testing.T,
 		dockerConfig.Env = append(dockerConfig.Env, "ECS_CONTAINER_METADATA_URI="+metadataEndpointEnvValue)
 		metadataEndpointEnvValueV4 := fmt.Sprintf(apicontainer.MetadataURIFormatV4, v3EndpointID)
 		dockerConfig.Env = append(dockerConfig.Env, "ECS_CONTAINER_METADATA_URI_V4="+metadataEndpointEnvValueV4)
+		agentAPIEndpointEnvValue := fmt.Sprintf(apicontainer.AgentAPIURIFormatV1, v3EndpointID)
+		dockerConfig.Env = append(dockerConfig.Env, "ECS_AGENT_API_URI_V1="+agentAPIEndpointEnvValue)
 	}
 	// Container config should get updated with this during CreateContainer
 	dockerConfig.Labels["com.amazonaws.ecs.task-arn"] = task.Arn


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->
*Merging to feature branch*

### Summary
This change adds a new environment variable `ECS_AGENT_API_URI_V1` to all containers started by the Agent. This variable contains the path of Agent API V1 endpoint that we will add in an upcoming PR. Agent API V1 endpoint will contain handlers for `PutTaskProtection` and `GetTaskProtection` APIs. 

The endpoint path reuses and includes v3 endpoint ID used by v3 and v4 Task Metadata endpoints. V3 Endpoint ID is a unique identifier that maps to task ARN.

### Implementation details
Changes mirror the environment variable setup for TMDE v3 and v4. 
1. V3 Endpoint ID is initialized as a random UUID for all containers of a task when it is initialized. 
2. V3 Endpoint ID is used to generate the value for `ECS_AGENT_API_URI_V1` environment variable and which is added to the container's `Environment` Map that is used to inject environment variables into the docker container that is created later.

### Testing
New unit tests are added that test if a task's containers are updated to have `ECS_AGENT_API_URI_V1` environment variable with the expected value after initialization. 

Manual testing was done by building agent from source and deploying it to a test EC2 container instance. It was verified that the new environment variable is available to the container containing the expected value. An example is shown below.

```
ECS_AGENT_API_URI_V1=http://169.254.170.2/api/v1/7500ca5f-9461-471e-bf23-fe78c8717142
```

<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

### Description for the changelog
Add `ECS_AGENT_API_URI_V1` environment variable containing endpoint path for Agent API V1 to containers.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
