### PR TITLE
Add types for task protection handlers

### DIFF
--- a/agent/handlers/agentapi/v1/taskprotection/types/types.go
+++ b/agent/handlers/agentapi/v1/taskprotection/types/types.go
@@ -1,0 +1,55 @@
+package types
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Protection type to set on the task
+type taskProtectionType string
+
+const (
+	TaskProtectionTypeScaleIn  taskProtectionType = "SCALE_IN"
+	TaskProtectionTypeDisabled taskProtectionType = "DISABLED"
+	// TODO Check if DISABLED_PERMANENTLY protection type is to be supported
+)
+
+// Converts a string to taskProtectionType
+func taskProtectionTypeFromString(s string) (taskProtectionType, error) {
+	switch p := strings.ToUpper(s); p {
+	case string(TaskProtectionTypeScaleIn):
+		return TaskProtectionTypeScaleIn, nil
+	case string(TaskProtectionTypeDisabled):
+		return TaskProtectionTypeDisabled, nil
+	default:
+		return "", fmt.Errorf("unknown task protection type: %v", s)
+	}
+}
+
+// Protection for a Task
+type taskProtection struct {
+	protectionType           taskProtectionType
+	protectionTimeoutMinutes *int
+}
+
+// Creates a taskProtection value after validating the arguments
+func NewTaskProtection(protectionType string, timeoutMinutes *int) (*taskProtection, error) {
+	ptype, err := taskProtectionTypeFromString(protectionType)
+	if err != nil {
+		return nil, fmt.Errorf("protection type is invalid: %w", err)
+	}
+
+	if timeoutMinutes != nil && *timeoutMinutes <= 0 {
+		return nil, fmt.Errorf("protection timeout must be greater than zero")
+	}
+
+	return &taskProtection{protectionType: ptype, protectionTimeoutMinutes: timeoutMinutes}, nil
+}
+
+func (taskProtection *taskProtection) GetProtectionType() taskProtectionType {
+	return taskProtection.protectionType
+}
+
+func (taskProtection *taskProtection) GetProtectionTimeoutMinutes() *int {
+	return taskProtection.protectionTimeoutMinutes
+}

--- a/agent/handlers/agentapi/v1/taskprotection/types/types.go
+++ b/agent/handlers/agentapi/v1/taskprotection/types/types.go
@@ -1,3 +1,16 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
 package types
 
 import (

--- a/agent/handlers/agentapi/v1/taskprotection/types/types.go
+++ b/agent/handlers/agentapi/v1/taskprotection/types/types.go
@@ -11,7 +11,6 @@ type taskProtectionType string
 const (
 	TaskProtectionTypeScaleIn  taskProtectionType = "SCALE_IN"
 	TaskProtectionTypeDisabled taskProtectionType = "DISABLED"
-	// TODO Check if DISABLED_PERMANENTLY protection type is to be supported
 )
 
 // Converts a string to taskProtectionType

--- a/agent/handlers/agentapi/v1/taskprotection/types/types_test.go
+++ b/agent/handlers/agentapi/v1/taskprotection/types/types_test.go
@@ -1,0 +1,71 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/aws/amazon-ecs-agent/agent/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+// Helper function for testing taskProtectionTypeFromString
+func testTaskProtectionTypeFromString(t *testing.T, input string, expected taskProtectionType) {
+	output, err := taskProtectionTypeFromString(input)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, output)
+}
+
+func TestTaskProtectionTypeFromStringScaleIn(t *testing.T) {
+	testTaskProtectionTypeFromString(t, "SCALE_IN", TaskProtectionTypeScaleIn)
+}
+
+func TestTaskProtectionTypeFromStringScaleInLower(t *testing.T) {
+	testTaskProtectionTypeFromString(t, "scale_in", TaskProtectionTypeScaleIn)
+}
+
+func TestTaskProtectionTypeFromStringDisabled(t *testing.T) {
+	testTaskProtectionTypeFromString(t, "DISABLED", TaskProtectionTypeDisabled)
+}
+
+func TestTaskProtectionTypeFromStringDisabledLower(t *testing.T) {
+	testTaskProtectionTypeFromString(t, "disabled", TaskProtectionTypeDisabled)
+}
+
+func TestTaskProtectionTypeFromStringError(t *testing.T) {
+	_, err := taskProtectionTypeFromString("unknown")
+	assert.EqualError(t, err, "unknown task protection type: unknown")
+}
+
+// Helper function for testing newTaskProtection
+func testNewTaskProtectionError(t *testing.T, protectionTypeStr string, timeoutMinutes *int, expectedErr string) {
+	protection, err := NewTaskProtection(protectionTypeStr, timeoutMinutes)
+	assert.EqualError(t, err, expectedErr)
+	assert.Nil(t, protection)
+}
+
+// Tests newTaskProtection when protection type is invalid
+func TestNewTaskProtectionTypeInvalid(t *testing.T) {
+	testNewTaskProtectionError(t, "bad", nil,
+		"protection type is invalid: unknown task protection type: bad")
+}
+
+// Tests newTaskProtection when timeout is invalid
+func TestNewTaskProtectionTimeoutInvalid(t *testing.T) {
+	testNewTaskProtectionError(t, string(TaskProtectionTypeScaleIn), utils.IntPtr(-3),
+		"protection timeout must be greater than zero")
+}
+
+// Tests that newTaskProtection can accept nil timeout
+func TestNewTaskProtectionNilTimeout(t *testing.T) {
+	protection, err := NewTaskProtection(string(TaskProtectionTypeScaleIn), nil)
+	assert.NoError(t, err)
+	assert.Equal(t, protection,
+		&taskProtection{protectionType: TaskProtectionTypeScaleIn, protectionTimeoutMinutes: nil})
+}
+
+// Tests newTaskProtection happy path
+func TestNewTaskProtectionHappy(t *testing.T) {
+	protection, err := NewTaskProtection(string(TaskProtectionTypeScaleIn), utils.IntPtr(5))
+	assert.NoError(t, err)
+	assert.Equal(t, protection,
+		&taskProtection{protectionType: TaskProtectionTypeScaleIn, protectionTimeoutMinutes: utils.IntPtr(5)})
+}

--- a/agent/handlers/agentapi/v1/taskprotection/types/types_test.go
+++ b/agent/handlers/agentapi/v1/taskprotection/types/types_test.go
@@ -1,3 +1,16 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
 package types
 
 import (

--- a/agent/utils/utils.go
+++ b/agent/utils/utils.go
@@ -110,6 +110,10 @@ func Strptr(s string) *string {
 	return &s
 }
 
+func IntPtr(i int) *int {
+	return &i
+}
+
 // Uint16SliceToStringSlice converts a slice of type uint16 to a slice of type
 // *string. It uses strconv.Itoa on each element
 func Uint16SliceToStringSlice(slice []uint16) []*string {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Add new types to be used in Task scale-in protection API handlers.

### Implementation details
A couple of new types, their constructors, and getters.

### Testing
Unit tests

New tests cover the changes: yes

### Description for the changelog
Add new types for task scale-in protection API

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
