### PR TITLE
Task scale in handlers

### DIFF
--- a/agent/handlers/agentapi/v1/taskprotection/handlers/handlers.go
+++ b/agent/handlers/agentapi/v1/taskprotection/handlers/handlers.go
@@ -1,0 +1,105 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
+	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
+	"github.com/aws/amazon-ecs-agent/agent/handlers/agentapi/v1/taskprotection/types"
+	"github.com/aws/amazon-ecs-agent/agent/handlers/utils"
+	v3 "github.com/aws/amazon-ecs-agent/agent/handlers/v3"
+	"github.com/cihub/seelog"
+)
+
+const (
+	putTaskProtectionRequestType = "v1/PutTaskProtection"
+)
+
+// Returns endpoint path for PutTaskProtection API
+func PutTaskProtectionPath() string {
+	return fmt.Sprintf(
+		"/api/v1/%s/task/protection",
+		utils.ConstructMuxVar(v3.V3EndpointIDMuxName, utils.AnythingButSlashRegEx))
+}
+
+// Task protection request received from customers pending validation
+type taskProtectionRequest struct {
+	ProtectionType           string
+	ProtectionTimeoutMinutes *int
+}
+
+// PutTaskProtectionHandler returns an HTTP request handler function for
+// PutTaskProtection API
+func PutTaskProtectionHandler(state dockerstate.TaskEngineState,
+	cluster string) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var request taskProtectionRequest
+		jsonDecoder := json.NewDecoder(r.Body)
+		jsonDecoder.DisallowUnknownFields()
+		if err := jsonDecoder.Decode(&request); err != nil {
+			seelog.Errorf("PutTaskProtection: failed to decode request: %v", err)
+			writeJSONResponse(w, http.StatusBadRequest,
+				"Failed to decode request", putTaskProtectionRequestType)
+			return
+		}
+
+		if request.ProtectionType == "" {
+			writeJSONResponse(w, http.StatusBadRequest,
+				"Invalid request: protection type is missing or empty",
+				putTaskProtectionRequestType)
+			return
+		}
+
+		taskProtection, err := types.NewTaskProtection(request.ProtectionType, request.ProtectionTimeoutMinutes)
+		if err != nil {
+			writeJSONResponse(w, http.StatusBadRequest,
+				fmt.Sprintf("Invalid request: %v", err),
+				putTaskProtectionRequestType)
+			return
+		}
+
+		task, err := getTaskFromRequest(state, r)
+		if err != nil {
+			writeJSONResponse(w, http.StatusInternalServerError,
+				fmt.Sprintf("Failed to find task: %v", err), putTaskProtectionRequestType)
+			return
+		}
+
+		// TODO: Call ECS
+		seelog.Infof("Would have called ECS.PutTaskProtection(%s, %s, %s, %s, %v)\n",
+			cluster, task.ServiceName, task.Arn, taskProtection.GetProtectionType(),
+			taskProtection.GetProtectionTimeoutMinutes())
+		writeJSONResponse(w, http.StatusOK, "Ok", putTaskProtectionRequestType)
+	}
+}
+
+// Helper function for finding task for the request
+func getTaskFromRequest(state dockerstate.TaskEngineState, r *http.Request) (*apitask.Task, error) {
+	taskARN, err := v3.GetTaskARNByRequest(r, state)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get task ARN from request: %w", err)
+	}
+
+	task, found := state.TaskByArn(taskARN)
+	if !found {
+		return nil, fmt.Errorf("could not find task from task ARN '%v'", taskARN)
+	}
+
+	return task, nil
+}
+
+// Writes the provided response to the ResponseWriter and handles any errors
+func writeJSONResponse(w http.ResponseWriter, responseCode int, response interface{},
+	requestType string) {
+	bytes, err := json.Marshal(response)
+	if err != nil {
+		seelog.Errorf("Agent API V1 failed to marshal response '%v' as JSON: %v",
+			response, err)
+		utils.WriteJSONToResponse(w, http.StatusInternalServerError, []byte(`{}`),
+			requestType)
+	} else {
+		utils.WriteJSONToResponse(w, responseCode, bytes, requestType)
+	}
+}

--- a/agent/handlers/agentapi/v1/taskprotection/handlers/handlers.go
+++ b/agent/handlers/agentapi/v1/taskprotection/handlers/handlers.go
@@ -13,12 +13,8 @@ import (
 	"github.com/cihub/seelog"
 )
 
-const (
-	putTaskProtectionRequestType = "v1/PutTaskProtection"
-)
-
 // Returns endpoint path for PutTaskProtection API
-func PutTaskProtectionPath() string {
+func TaskProtectionPath() string {
 	return fmt.Sprintf(
 		"/api/v1/%s/task/protection",
 		utils.ConstructMuxVar(v3.V3EndpointIDMuxName, utils.AnythingButSlashRegEx))
@@ -35,6 +31,8 @@ type taskProtectionRequest struct {
 func PutTaskProtectionHandler(state dockerstate.TaskEngineState,
 	cluster string) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
+		putTaskProtectionRequestType := "v1/PutTaskProtection"
+
 		var request taskProtectionRequest
 		jsonDecoder := json.NewDecoder(r.Body)
 		jsonDecoder.DisallowUnknownFields()
@@ -88,6 +86,26 @@ func getTaskFromRequest(state dockerstate.TaskEngineState, r *http.Request) (*ap
 	}
 
 	return task, nil
+}
+
+// GetTaskProtectionHandler returns a handler function for GetTaskProtection API
+func GetTaskProtectionHandler(state dockerstate.TaskEngineState,
+	cluster string) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		getTaskProtectionRequestType := "api/v1/GetTaskProtection"
+
+		task, err := getTaskFromRequest(state, r)
+		if err != nil {
+			writeJSONResponse(w, http.StatusInternalServerError,
+				fmt.Sprintf("Failed to find task: %v", err), getTaskProtectionRequestType)
+			return
+		}
+
+		// TODO: Call ECS
+		seelog.Infof("Would have called ECS.GetTaskProtection(%s, %s, %s)",
+			cluster, task.ServiceName, task)
+		writeJSONResponse(w, http.StatusOK, "Ok", getTaskProtectionRequestType)
+	}
 }
 
 // Writes the provided response to the ResponseWriter and handles any errors

--- a/agent/handlers/agentapi/v1/taskprotection/handlers/handlers.go
+++ b/agent/handlers/agentapi/v1/taskprotection/handlers/handlers.go
@@ -34,7 +34,7 @@ func TaskProtectionPath() string {
 }
 
 // Task protection request received from customers pending validation
-type taskProtectionRequest struct {
+type TaskProtectionRequest struct {
 	ProtectionType           string
 	ProtectionTimeoutMinutes *int
 }
@@ -46,7 +46,7 @@ func PutTaskProtectionHandler(state dockerstate.TaskEngineState,
 	return func(w http.ResponseWriter, r *http.Request) {
 		putTaskProtectionRequestType := "api/v1/PutTaskProtection"
 
-		var request taskProtectionRequest
+		var request TaskProtectionRequest
 		jsonDecoder := json.NewDecoder(r.Body)
 		jsonDecoder.DisallowUnknownFields()
 		if err := jsonDecoder.Decode(&request); err != nil {

--- a/agent/handlers/agentapi/v1/taskprotection/handlers/handlers.go
+++ b/agent/handlers/agentapi/v1/taskprotection/handlers/handlers.go
@@ -1,3 +1,16 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
 package handlers
 
 import (

--- a/agent/handlers/agentapi/v1/taskprotection/handlers/handlers.go
+++ b/agent/handlers/agentapi/v1/taskprotection/handlers/handlers.go
@@ -35,8 +35,8 @@ func TaskProtectionPath() string {
 
 // Task protection request received from customers pending validation
 type taskProtectionRequest struct {
-	protectionType           string
-	protectionTimeoutMinutes *int
+	ProtectionType           string
+	ProtectionTimeoutMinutes *int
 }
 
 // PutTaskProtectionHandler returns an HTTP request handler function for
@@ -56,14 +56,14 @@ func PutTaskProtectionHandler(state dockerstate.TaskEngineState,
 			return
 		}
 
-		if request.protectionType == "" {
+		if request.ProtectionType == "" {
 			writeJSONResponse(w, http.StatusBadRequest,
 				"Invalid request: protection type is missing or empty",
 				putTaskProtectionRequestType)
 			return
 		}
 
-		taskProtection, err := types.NewTaskProtection(request.protectionType, request.protectionTimeoutMinutes)
+		taskProtection, err := types.NewTaskProtection(request.ProtectionType, request.ProtectionTimeoutMinutes)
 		if err != nil {
 			writeJSONResponse(w, http.StatusBadRequest,
 				fmt.Sprintf("Invalid request: %v", err),

--- a/agent/handlers/agentapi/v1/taskprotection/handlers/handlers.go
+++ b/agent/handlers/agentapi/v1/taskprotection/handlers/handlers.go
@@ -44,7 +44,7 @@ type taskProtectionRequest struct {
 func PutTaskProtectionHandler(state dockerstate.TaskEngineState,
 	cluster string) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		putTaskProtectionRequestType := "v1/PutTaskProtection"
+		putTaskProtectionRequestType := "api/v1/PutTaskProtection"
 
 		var request taskProtectionRequest
 		jsonDecoder := json.NewDecoder(r.Body)

--- a/agent/handlers/agentapi/v1/taskprotection/handlers/handlers.go
+++ b/agent/handlers/agentapi/v1/taskprotection/handlers/handlers.go
@@ -35,8 +35,8 @@ func TaskProtectionPath() string {
 
 // Task protection request received from customers pending validation
 type taskProtectionRequest struct {
-	ProtectionType           string
-	ProtectionTimeoutMinutes *int
+	protectionType           string
+	protectionTimeoutMinutes *int
 }
 
 // PutTaskProtectionHandler returns an HTTP request handler function for
@@ -56,14 +56,14 @@ func PutTaskProtectionHandler(state dockerstate.TaskEngineState,
 			return
 		}
 
-		if request.ProtectionType == "" {
+		if request.protectionType == "" {
 			writeJSONResponse(w, http.StatusBadRequest,
 				"Invalid request: protection type is missing or empty",
 				putTaskProtectionRequestType)
 			return
 		}
 
-		taskProtection, err := types.NewTaskProtection(request.ProtectionType, request.ProtectionTimeoutMinutes)
+		taskProtection, err := types.NewTaskProtection(request.protectionType, request.protectionTimeoutMinutes)
 		if err != nil {
 			writeJSONResponse(w, http.StatusBadRequest,
 				fmt.Sprintf("Invalid request: %v", err),

--- a/agent/handlers/agentapi/v1/taskprotection/handlers/handlers_test.go
+++ b/agent/handlers/agentapi/v1/taskprotection/handlers/handlers_test.go
@@ -1,0 +1,172 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/amazon-ecs-agent/agent/api/task"
+	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
+	mock_dockerstate "github.com/aws/amazon-ecs-agent/agent/engine/dockerstate/mocks"
+	"github.com/aws/amazon-ecs-agent/agent/handlers/agentapi/v1/taskprotection/types"
+	v3 "github.com/aws/amazon-ecs-agent/agent/handlers/v3"
+	"github.com/golang/mock/gomock"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+)
+
+// Tests the path for PutTaskProtection API
+func TestPutTaskProtectionPath(t *testing.T) {
+	assert.Equal(t, "/api/v1/{v3EndpointIDMuxName:[^/]*}/task/protection", PutTaskProtectionPath())
+}
+
+// Helper function for running tests for PutTaskProtection handler
+func testPutTaskProtectionHandler(t *testing.T, state dockerstate.TaskEngineState,
+	v3EndpointID string,
+	request interface{}, expectedResponse interface{}, expectedResponseCode int) {
+	// Prepare request
+	requestBytes, err := json.Marshal(request)
+	assert.NoError(t, err)
+	bodyReader := bytes.NewReader(requestBytes)
+	req, err := http.NewRequest("PUT", "", bodyReader)
+	assert.NoError(t, err)
+	req = mux.SetURLVars(req, map[string]string{v3.V3EndpointIDMuxName: v3EndpointID})
+
+	// Call handler
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(PutTaskProtectionHandler(state, "cluster"))
+	handler.ServeHTTP(rr, req)
+
+	expectedResponseJSON, err := json.Marshal(expectedResponse)
+	assert.NoError(t, err, "Expected response must be JSON encodable")
+
+	// Assert response
+	assert.Equal(t, expectedResponseCode, rr.Code)
+	responseBody, err := io.ReadAll(rr.Body)
+	assert.NoError(t, err, "Failed to read response body")
+	assert.Equal(t, string(expectedResponseJSON), string(responseBody))
+}
+
+// TestPutTaskProtectionHandlerInvalidRequest tests PutTaskProtection handler
+// with a bad HTTP request
+func TestPutTaskProtectionHandlerInvalidRequest(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	request := taskProtectionRequest{ProtectionType: "badProtectionType"}
+	testPutTaskProtectionHandler(t, mock_dockerstate.NewMockTaskEngineState(ctrl),
+		"endpointID", request,
+		"Invalid request: protection type is invalid: unknown task protection type: badProtectionType",
+		http.StatusBadRequest)
+}
+
+// TestPutTaskProtectionHandlerInvalidJSONRequest tests PutTaskProtection handler
+// with a bad ProtectionTimeoutMinutes type
+func TestPutTaskProtectionHandlerInvalidTimeoutType(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	testPutTaskProtectionHandler(t, mock_dockerstate.NewMockTaskEngineState(ctrl),
+		"endpointID",
+		map[string]string{
+			"ProtectionType":           string(types.TaskProtectionTypeScaleIn),
+			"ProtectionTimeoutMinutes": "badType",
+		},
+		"Failed to decode request",
+		http.StatusBadRequest)
+}
+
+// TestPutTaskProtectionHandlerInvalidJSONRequest tests PutTaskProtection handler
+// with a bad JSON in request body
+func TestPutTaskProtectionHandlerInvalidJSONRequest(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	testPutTaskProtectionHandler(t, mock_dockerstate.NewMockTaskEngineState(ctrl),
+		"endpointID", "", "Failed to decode request", http.StatusBadRequest)
+}
+
+// TestPutTaskProtectionHandlerNoBody tests that PutTaskProtection handler returns an
+// appropriate error if protection type is missing in the request
+func TestPutTaskProtectionHandlerNoBody(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	testPutTaskProtectionHandler(t, mock_dockerstate.NewMockTaskEngineState(ctrl),
+		"endpointID", nil, "Invalid request: protection type is missing or empty", http.StatusBadRequest)
+}
+
+// TestPutTaskProtectionHandlerUnknownFieldsInRequest tests that PutTaskProtection handler
+// returns bad request error when the reqeust JSON contains an unknown field.
+func TestPutTaskProtectionHandlerUnknownFieldsInRequest(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	request := taskProtectionRequest{ProtectionType: string(types.TaskProtectionTypeScaleIn)}
+	requestJSON, err := json.Marshal(request)
+	assert.NoError(t, err)
+
+	var rawRequest map[string]interface{}
+	err = json.Unmarshal(requestJSON, &rawRequest)
+	assert.NoError(t, err)
+	rawRequest["UnknownField"] = 5
+
+	testPutTaskProtectionHandler(t, mock_dockerstate.NewMockTaskEngineState(ctrl),
+		"endpointID", rawRequest, "Failed to decode request", http.StatusBadRequest)
+}
+
+// TestPutTaskProtectionHandlerTaskARNNotFound tests PutTaskProtection handler's
+// behavior when task ARN was not found for the request.
+func TestPutTaskProtectionHandlerTaskARNNotFound(t *testing.T) {
+	muxVars := make(map[string]string)
+	muxVars[v3.V3EndpointIDMuxName] = "endpointID"
+	request := taskProtectionRequest{ProtectionType: string(types.TaskProtectionTypeDisabled)}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockState := mock_dockerstate.NewMockTaskEngineState(ctrl)
+	mockState.EXPECT().TaskARNByV3EndpointID(gomock.Eq("endpointID")).Return("", false)
+
+	testPutTaskProtectionHandler(t, mockState, "endpointID", request,
+		"Failed to find task: unable to get task ARN from request: unable to get task Arn from v3 endpoint ID: endpointID",
+		http.StatusInternalServerError)
+}
+
+// TestPutTaskProtectionHandlerTaskNotFound tests PutTaskProtection handler's
+// behavior when task ARN was not found for the request.
+func TestPutTaskProtectionHandlerTaskNotFound(t *testing.T) {
+	request := taskProtectionRequest{ProtectionType: string(types.TaskProtectionTypeDisabled)}
+	muxVars := make(map[string]string)
+	muxVars[v3.V3EndpointIDMuxName] = "endpointID"
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockState := mock_dockerstate.NewMockTaskEngineState(ctrl)
+	mockState.EXPECT().TaskARNByV3EndpointID(gomock.Eq("endpointID")).Return("taskARN", true)
+	mockState.EXPECT().TaskByArn(gomock.Eq("taskARN")).Return(nil, false)
+
+	testPutTaskProtectionHandler(t, mockState, "endpointID", request,
+		"Failed to find task: could not find task from task ARN 'taskARN'",
+		http.StatusInternalServerError)
+}
+
+// TestPutTaskProtectionHandlerHappy tests PutTaskProtection handler's
+// behavior when request and state both are good.
+func TestPutTaskProtectionHandlerHappy(t *testing.T) {
+	request := taskProtectionRequest{ProtectionType: string(types.TaskProtectionTypeDisabled)}
+	muxVars := make(map[string]string)
+	muxVars[v3.V3EndpointIDMuxName] = "endpointID"
+
+	taskARN := "taskARN"
+	task := task.Task{
+		Arn:         taskARN,
+		ServiceName: "myService",
+	}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockState := mock_dockerstate.NewMockTaskEngineState(ctrl)
+	mockState.EXPECT().TaskARNByV3EndpointID(gomock.Eq("endpointID")).Return(taskARN, true)
+	mockState.EXPECT().TaskByArn(gomock.Eq(taskARN)).Return(&task, true)
+
+	testPutTaskProtectionHandler(t, mockState, "endpointID", request, "Ok", http.StatusOK)
+}

--- a/agent/handlers/agentapi/v1/taskprotection/handlers/handlers_test.go
+++ b/agent/handlers/agentapi/v1/taskprotection/handlers/handlers_test.go
@@ -19,8 +19,8 @@ import (
 )
 
 // Tests the path for PutTaskProtection API
-func TestPutTaskProtectionPath(t *testing.T) {
-	assert.Equal(t, "/api/v1/{v3EndpointIDMuxName:[^/]*}/task/protection", PutTaskProtectionPath())
+func TestTaskProtectionPath(t *testing.T) {
+	assert.Equal(t, "/api/v1/{v3EndpointIDMuxName:[^/]*}/task/protection", TaskProtectionPath())
 }
 
 // Helper function for running tests for PutTaskProtection handler
@@ -169,4 +169,82 @@ func TestPutTaskProtectionHandlerHappy(t *testing.T) {
 	mockState.EXPECT().TaskByArn(gomock.Eq(taskARN)).Return(&task, true)
 
 	testPutTaskProtectionHandler(t, mockState, "endpointID", request, "Ok", http.StatusOK)
+}
+
+// Helper function for running tests for GetTaskProtection handler
+func testGetTaskProtectionHandler(t *testing.T, state dockerstate.TaskEngineState,
+	v3EndpointID string, expectedResponse interface{}, expectedResponseCode int) {
+	// Prepare request
+	bodyReader := bytes.NewReader([]byte{})
+	req, err := http.NewRequest("GET", "", bodyReader)
+	assert.NoError(t, err)
+	req = mux.SetURLVars(req, map[string]string{v3.V3EndpointIDMuxName: v3EndpointID})
+
+	// Call handler
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(GetTaskProtectionHandler(state, "cluster"))
+	handler.ServeHTTP(rr, req)
+
+	expectedResponseJSON, err := json.Marshal(expectedResponse)
+	assert.NoError(t, err, "Expected response must be JSON encodable")
+
+	// Assert response
+	assert.Equal(t, expectedResponseCode, rr.Code)
+	responseBody, err := io.ReadAll(rr.Body)
+	assert.NoError(t, err, "Failed to read response body")
+	assert.Equal(t, string(expectedResponseJSON), string(responseBody))
+}
+
+// TestGetTaskProtectionHandlerTaskARNNotFound tests GetTaskProtection handler's
+// behavior when task ARN was not found for the request.
+func TestGetTaskProtectionHandlerTaskARNNotFound(t *testing.T) {
+	muxVars := make(map[string]string)
+	muxVars[v3.V3EndpointIDMuxName] = "endpointID"
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockState := mock_dockerstate.NewMockTaskEngineState(ctrl)
+	mockState.EXPECT().TaskARNByV3EndpointID(gomock.Eq("endpointID")).Return("", false)
+
+	testGetTaskProtectionHandler(t, mockState, "endpointID",
+		"Failed to find task: unable to get task ARN from request: unable to get task Arn from v3 endpoint ID: endpointID",
+		http.StatusInternalServerError)
+}
+
+// TestGetTaskProtectionHandlerTaskNotFound tests GetTaskProtection handler's
+// behavior when task ARN was not found for the request.
+func TestGetTaskProtectionHandlerTaskNotFound(t *testing.T) {
+	muxVars := make(map[string]string)
+	muxVars[v3.V3EndpointIDMuxName] = "endpointID"
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockState := mock_dockerstate.NewMockTaskEngineState(ctrl)
+	mockState.EXPECT().TaskARNByV3EndpointID(gomock.Eq("endpointID")).Return("taskARN", true)
+	mockState.EXPECT().TaskByArn(gomock.Eq("taskARN")).Return(nil, false)
+
+	testGetTaskProtectionHandler(t, mockState, "endpointID",
+		"Failed to find task: could not find task from task ARN 'taskARN'",
+		http.StatusInternalServerError)
+}
+
+// TestGetTaskProtectionHandlerHappy tests GetTaskProtection handler's
+// behavior when request and state both are good.
+func TestGetTaskProtectionHandlerHappy(t *testing.T) {
+	muxVars := make(map[string]string)
+	muxVars[v3.V3EndpointIDMuxName] = "endpointID"
+
+	taskARN := "taskARN"
+	task := task.Task{
+		Arn:         taskARN,
+		ServiceName: "myService",
+	}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockState := mock_dockerstate.NewMockTaskEngineState(ctrl)
+	mockState.EXPECT().TaskARNByV3EndpointID(gomock.Eq("endpointID")).Return(taskARN, true)
+	mockState.EXPECT().TaskByArn(gomock.Eq(taskARN)).Return(&task, true)
+
+	testGetTaskProtectionHandler(t, mockState, "endpointID", "Ok", http.StatusOK)
 }

--- a/agent/handlers/agentapi/v1/taskprotection/handlers/handlers_test.go
+++ b/agent/handlers/agentapi/v1/taskprotection/handlers/handlers_test.go
@@ -69,7 +69,7 @@ func testPutTaskProtectionHandler(t *testing.T, state dockerstate.TaskEngineStat
 func TestPutTaskProtectionHandlerInvalidRequest(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
-	request := taskProtectionRequest{ProtectionType: "badProtectionType"}
+	request := taskProtectionRequest{protectionType: "badProtectionType"}
 	testPutTaskProtectionHandler(t, mock_dockerstate.NewMockTaskEngineState(ctrl),
 		"endpointID", request,
 		"Invalid request: protection type is invalid: unknown task protection type: badProtectionType",
@@ -115,7 +115,7 @@ func TestPutTaskProtectionHandlerUnknownFieldsInRequest(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	request := taskProtectionRequest{ProtectionType: string(types.TaskProtectionTypeScaleIn)}
+	request := taskProtectionRequest{protectionType: string(types.TaskProtectionTypeScaleIn)}
 	requestJSON, err := json.Marshal(request)
 	assert.NoError(t, err)
 
@@ -131,7 +131,7 @@ func TestPutTaskProtectionHandlerUnknownFieldsInRequest(t *testing.T) {
 // TestPutTaskProtectionHandlerTaskARNNotFound tests PutTaskProtection handler's
 // behavior when task ARN was not found for the request.
 func TestPutTaskProtectionHandlerTaskARNNotFound(t *testing.T) {
-	request := taskProtectionRequest{ProtectionType: string(types.TaskProtectionTypeDisabled)}
+	request := taskProtectionRequest{protectionType: string(types.TaskProtectionTypeDisabled)}
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -146,7 +146,7 @@ func TestPutTaskProtectionHandlerTaskARNNotFound(t *testing.T) {
 // TestPutTaskProtectionHandlerTaskNotFound tests PutTaskProtection handler's
 // behavior when task ARN was not found for the request.
 func TestPutTaskProtectionHandlerTaskNotFound(t *testing.T) {
-	request := taskProtectionRequest{ProtectionType: string(types.TaskProtectionTypeDisabled)}
+	request := taskProtectionRequest{protectionType: string(types.TaskProtectionTypeDisabled)}
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -162,7 +162,7 @@ func TestPutTaskProtectionHandlerTaskNotFound(t *testing.T) {
 // TestPutTaskProtectionHandlerHappy tests PutTaskProtection handler's
 // behavior when request and state both are good.
 func TestPutTaskProtectionHandlerHappy(t *testing.T) {
-	request := taskProtectionRequest{ProtectionType: string(types.TaskProtectionTypeDisabled)}
+	request := taskProtectionRequest{protectionType: string(types.TaskProtectionTypeDisabled)}
 
 	taskARN := "taskARN"
 	task := task.Task{

--- a/agent/handlers/agentapi/v1/taskprotection/handlers/handlers_test.go
+++ b/agent/handlers/agentapi/v1/taskprotection/handlers/handlers_test.go
@@ -1,3 +1,16 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
 package handlers
 
 import (
@@ -44,6 +57,7 @@ func testPutTaskProtectionHandler(t *testing.T, state dockerstate.TaskEngineStat
 	assert.NoError(t, err, "Expected response must be JSON encodable")
 
 	// Assert response
+	assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
 	assert.Equal(t, expectedResponseCode, rr.Code)
 	responseBody, err := io.ReadAll(rr.Body)
 	assert.NoError(t, err, "Failed to read response body")
@@ -117,8 +131,6 @@ func TestPutTaskProtectionHandlerUnknownFieldsInRequest(t *testing.T) {
 // TestPutTaskProtectionHandlerTaskARNNotFound tests PutTaskProtection handler's
 // behavior when task ARN was not found for the request.
 func TestPutTaskProtectionHandlerTaskARNNotFound(t *testing.T) {
-	muxVars := make(map[string]string)
-	muxVars[v3.V3EndpointIDMuxName] = "endpointID"
 	request := taskProtectionRequest{ProtectionType: string(types.TaskProtectionTypeDisabled)}
 
 	ctrl := gomock.NewController(t)
@@ -135,8 +147,6 @@ func TestPutTaskProtectionHandlerTaskARNNotFound(t *testing.T) {
 // behavior when task ARN was not found for the request.
 func TestPutTaskProtectionHandlerTaskNotFound(t *testing.T) {
 	request := taskProtectionRequest{ProtectionType: string(types.TaskProtectionTypeDisabled)}
-	muxVars := make(map[string]string)
-	muxVars[v3.V3EndpointIDMuxName] = "endpointID"
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -153,8 +163,6 @@ func TestPutTaskProtectionHandlerTaskNotFound(t *testing.T) {
 // behavior when request and state both are good.
 func TestPutTaskProtectionHandlerHappy(t *testing.T) {
 	request := taskProtectionRequest{ProtectionType: string(types.TaskProtectionTypeDisabled)}
-	muxVars := make(map[string]string)
-	muxVars[v3.V3EndpointIDMuxName] = "endpointID"
 
 	taskARN := "taskARN"
 	task := task.Task{
@@ -198,9 +206,6 @@ func testGetTaskProtectionHandler(t *testing.T, state dockerstate.TaskEngineStat
 // TestGetTaskProtectionHandlerTaskARNNotFound tests GetTaskProtection handler's
 // behavior when task ARN was not found for the request.
 func TestGetTaskProtectionHandlerTaskARNNotFound(t *testing.T) {
-	muxVars := make(map[string]string)
-	muxVars[v3.V3EndpointIDMuxName] = "endpointID"
-
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockState := mock_dockerstate.NewMockTaskEngineState(ctrl)
@@ -214,9 +219,6 @@ func TestGetTaskProtectionHandlerTaskARNNotFound(t *testing.T) {
 // TestGetTaskProtectionHandlerTaskNotFound tests GetTaskProtection handler's
 // behavior when task ARN was not found for the request.
 func TestGetTaskProtectionHandlerTaskNotFound(t *testing.T) {
-	muxVars := make(map[string]string)
-	muxVars[v3.V3EndpointIDMuxName] = "endpointID"
-
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockState := mock_dockerstate.NewMockTaskEngineState(ctrl)
@@ -231,9 +233,6 @@ func TestGetTaskProtectionHandlerTaskNotFound(t *testing.T) {
 // TestGetTaskProtectionHandlerHappy tests GetTaskProtection handler's
 // behavior when request and state both are good.
 func TestGetTaskProtectionHandlerHappy(t *testing.T) {
-	muxVars := make(map[string]string)
-	muxVars[v3.V3EndpointIDMuxName] = "endpointID"
-
 	taskARN := "taskARN"
 	task := task.Task{
 		Arn:         taskARN,

--- a/agent/handlers/agentapi/v1/taskprotection/handlers/handlers_test.go
+++ b/agent/handlers/agentapi/v1/taskprotection/handlers/handlers_test.go
@@ -69,7 +69,7 @@ func testPutTaskProtectionHandler(t *testing.T, state dockerstate.TaskEngineStat
 func TestPutTaskProtectionHandlerInvalidRequest(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
-	request := taskProtectionRequest{protectionType: "badProtectionType"}
+	request := taskProtectionRequest{ProtectionType: "badProtectionType"}
 	testPutTaskProtectionHandler(t, mock_dockerstate.NewMockTaskEngineState(ctrl),
 		"endpointID", request,
 		"Invalid request: protection type is invalid: unknown task protection type: badProtectionType",
@@ -115,7 +115,7 @@ func TestPutTaskProtectionHandlerUnknownFieldsInRequest(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	request := taskProtectionRequest{protectionType: string(types.TaskProtectionTypeScaleIn)}
+	request := taskProtectionRequest{ProtectionType: string(types.TaskProtectionTypeScaleIn)}
 	requestJSON, err := json.Marshal(request)
 	assert.NoError(t, err)
 
@@ -131,7 +131,7 @@ func TestPutTaskProtectionHandlerUnknownFieldsInRequest(t *testing.T) {
 // TestPutTaskProtectionHandlerTaskARNNotFound tests PutTaskProtection handler's
 // behavior when task ARN was not found for the request.
 func TestPutTaskProtectionHandlerTaskARNNotFound(t *testing.T) {
-	request := taskProtectionRequest{protectionType: string(types.TaskProtectionTypeDisabled)}
+	request := taskProtectionRequest{ProtectionType: string(types.TaskProtectionTypeDisabled)}
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -146,7 +146,7 @@ func TestPutTaskProtectionHandlerTaskARNNotFound(t *testing.T) {
 // TestPutTaskProtectionHandlerTaskNotFound tests PutTaskProtection handler's
 // behavior when task ARN was not found for the request.
 func TestPutTaskProtectionHandlerTaskNotFound(t *testing.T) {
-	request := taskProtectionRequest{protectionType: string(types.TaskProtectionTypeDisabled)}
+	request := taskProtectionRequest{ProtectionType: string(types.TaskProtectionTypeDisabled)}
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -162,7 +162,7 @@ func TestPutTaskProtectionHandlerTaskNotFound(t *testing.T) {
 // TestPutTaskProtectionHandlerHappy tests PutTaskProtection handler's
 // behavior when request and state both are good.
 func TestPutTaskProtectionHandlerHappy(t *testing.T) {
-	request := taskProtectionRequest{protectionType: string(types.TaskProtectionTypeDisabled)}
+	request := taskProtectionRequest{ProtectionType: string(types.TaskProtectionTypeDisabled)}
 
 	taskARN := "taskARN"
 	task := task.Task{

--- a/agent/handlers/agentapi/v1/taskprotection/handlers/handlers_test.go
+++ b/agent/handlers/agentapi/v1/taskprotection/handlers/handlers_test.go
@@ -69,7 +69,7 @@ func testPutTaskProtectionHandler(t *testing.T, state dockerstate.TaskEngineStat
 func TestPutTaskProtectionHandlerInvalidRequest(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
-	request := taskProtectionRequest{ProtectionType: "badProtectionType"}
+	request := TaskProtectionRequest{ProtectionType: "badProtectionType"}
 	testPutTaskProtectionHandler(t, mock_dockerstate.NewMockTaskEngineState(ctrl),
 		"endpointID", request,
 		"Invalid request: protection type is invalid: unknown task protection type: badProtectionType",
@@ -115,7 +115,7 @@ func TestPutTaskProtectionHandlerUnknownFieldsInRequest(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	request := taskProtectionRequest{ProtectionType: string(types.TaskProtectionTypeScaleIn)}
+	request := TaskProtectionRequest{ProtectionType: string(types.TaskProtectionTypeScaleIn)}
 	requestJSON, err := json.Marshal(request)
 	assert.NoError(t, err)
 
@@ -131,7 +131,7 @@ func TestPutTaskProtectionHandlerUnknownFieldsInRequest(t *testing.T) {
 // TestPutTaskProtectionHandlerTaskARNNotFound tests PutTaskProtection handler's
 // behavior when task ARN was not found for the request.
 func TestPutTaskProtectionHandlerTaskARNNotFound(t *testing.T) {
-	request := taskProtectionRequest{ProtectionType: string(types.TaskProtectionTypeDisabled)}
+	request := TaskProtectionRequest{ProtectionType: string(types.TaskProtectionTypeDisabled)}
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -146,7 +146,7 @@ func TestPutTaskProtectionHandlerTaskARNNotFound(t *testing.T) {
 // TestPutTaskProtectionHandlerTaskNotFound tests PutTaskProtection handler's
 // behavior when task ARN was not found for the request.
 func TestPutTaskProtectionHandlerTaskNotFound(t *testing.T) {
-	request := taskProtectionRequest{ProtectionType: string(types.TaskProtectionTypeDisabled)}
+	request := TaskProtectionRequest{ProtectionType: string(types.TaskProtectionTypeDisabled)}
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -162,7 +162,7 @@ func TestPutTaskProtectionHandlerTaskNotFound(t *testing.T) {
 // TestPutTaskProtectionHandlerHappy tests PutTaskProtection handler's
 // behavior when request and state both are good.
 func TestPutTaskProtectionHandlerHappy(t *testing.T) {
-	request := taskProtectionRequest{ProtectionType: string(types.TaskProtectionTypeDisabled)}
+	request := TaskProtectionRequest{ProtectionType: string(types.TaskProtectionTypeDisabled)}
 
 	taskARN := "taskARN"
 	task := task.Task{

--- a/agent/handlers/task_server_setup.go
+++ b/agent/handlers/task_server_setup.go
@@ -159,9 +159,14 @@ func v4HandlersSetup(muxRouter *mux.Router,
 func v1AgentAPIHandlersSetup(muxRouter *mux.Router, state dockerstate.TaskEngineState, cluster string) {
 	muxRouter.
 		HandleFunc(
-			agentAPIV1TaskProtection.PutTaskProtectionPath(),
+			agentAPIV1TaskProtection.TaskProtectionPath(),
 			agentAPIV1TaskProtection.PutTaskProtectionHandler(state, cluster)).
 		Methods("PUT")
+	muxRouter.
+		HandleFunc(
+			agentAPIV1TaskProtection.TaskProtectionPath(),
+			agentAPIV1TaskProtection.GetTaskProtectionHandler(state, cluster)).
+		Methods("GET")
 }
 
 // ServeTaskHTTPEndpoint serves task/container metadata, task/container stats, and IAM Role Credentials

--- a/agent/handlers/task_server_setup.go
+++ b/agent/handlers/task_server_setup.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/credentials"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
+	agentAPIV1TaskProtection "github.com/aws/amazon-ecs-agent/agent/handlers/agentapi/v1/taskprotection/handlers"
 	handlersutils "github.com/aws/amazon-ecs-agent/agent/handlers/utils"
 	v1 "github.com/aws/amazon-ecs-agent/agent/handlers/v1"
 	v2 "github.com/aws/amazon-ecs-agent/agent/handlers/v2"
@@ -70,6 +71,8 @@ func taskServerSetup(credentialsManager credentials.Manager,
 	v3HandlersSetup(muxRouter, state, ecsClient, statsEngine, cluster, availabilityZone, containerInstanceArn)
 
 	v4HandlersSetup(muxRouter, state, ecsClient, statsEngine, cluster, availabilityZone, containerInstanceArn)
+
+	v1AgentAPIHandlersSetup(muxRouter, state, cluster)
 
 	limiter := tollbooth.NewLimiter(int64(steadyStateRate), nil)
 	limiter.SetOnLimitReached(handlersutils.LimitReachedHandler(auditLogger))
@@ -150,6 +153,15 @@ func v4HandlersSetup(muxRouter *mux.Router,
 	muxRouter.HandleFunc(v4.ContainerAssociationsPath, v4.ContainerAssociationsHandler(state))
 	muxRouter.HandleFunc(v4.ContainerAssociationPathWithSlash, v4.ContainerAssociationHandler(state))
 	muxRouter.HandleFunc(v4.ContainerAssociationPath, v4.ContainerAssociationHandler(state))
+}
+
+// v1AgentAPIHandlersSetup adds handlers for Agent API V1
+func v1AgentAPIHandlersSetup(muxRouter *mux.Router, state dockerstate.TaskEngineState, cluster string) {
+	muxRouter.
+		HandleFunc(
+			agentAPIV1TaskProtection.PutTaskProtectionPath(),
+			agentAPIV1TaskProtection.PutTaskProtectionHandler(state, cluster)).
+		Methods("PUT")
 }
 
 // ServeTaskHTTPEndpoint serves task/container metadata, task/container stats, and IAM Role Credentials

--- a/agent/handlers/task_server_setup_test.go
+++ b/agent/handlers/task_server_setup_test.go
@@ -1870,6 +1870,11 @@ func testAgentAPIV1TaskProtectionHandler(t *testing.T, requestBody interface{}, 
 	assert.Equal(t, http.StatusOK, recorder.Code)
 }
 
+// Tests that Agent API v1 GetTaskProtection handler is registered correctly
+func TestAgentAPIV1GetTaskProtectionHandler(t *testing.T) {
+	testAgentAPIV1TaskProtectionHandler(t, nil, "GET")
+}
+
 // Tests that Agent API v1 PutTaskProtection handler is registered successfully
 func TestAgentAPIV1PutTaskProtectionHandler(t *testing.T) {
 	requestBody := map[string]interface{}{"protectionType": "SCALE_IN"}

--- a/agent/handlers/task_server_setup_test.go
+++ b/agent/handlers/task_server_setup_test.go
@@ -40,8 +40,8 @@ import (
 	mock_credentials "github.com/aws/amazon-ecs-agent/agent/credentials/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
 	mock_dockerstate "github.com/aws/amazon-ecs-agent/agent/engine/dockerstate/mocks"
-	agentAPIV1 "github.com/aws/amazon-ecs-agent/agent/handlers/agentapi/v1/taskprotection/handlers"
-	agentAPIV1Types "github.com/aws/amazon-ecs-agent/agent/handlers/agentapi/v1/taskprotection/types"
+	v1_task_protection "github.com/aws/amazon-ecs-agent/agent/handlers/agentapi/v1/taskprotection/handlers"
+	v1_task_protection_types "github.com/aws/amazon-ecs-agent/agent/handlers/agentapi/v1/taskprotection/types"
 	"github.com/aws/amazon-ecs-agent/agent/handlers/utils"
 	v1 "github.com/aws/amazon-ecs-agent/agent/handlers/v1"
 	v2 "github.com/aws/amazon-ecs-agent/agent/handlers/v2"
@@ -1883,8 +1883,8 @@ func TestAgentAPIV1GetTaskProtectionHandler(t *testing.T) {
 
 // Tests that Agent API v1 PutTaskProtection handler is registered correctly
 func TestAgentAPIV1PutTaskProtectionHandler(t *testing.T) {
-	requestBody := agentAPIV1.TaskProtectionRequest{
-		ProtectionType: string(agentAPIV1Types.TaskProtectionTypeScaleIn),
+	requestBody := v1_task_protection.TaskProtectionRequest{
+		ProtectionType: string(v1_task_protection_types.TaskProtectionTypeScaleIn),
 	}
 	testAgentAPIV1TaskProtectionHandler(t, requestBody, "PUT")
 }

--- a/agent/handlers/task_server_setup_test.go
+++ b/agent/handlers/task_server_setup_test.go
@@ -40,6 +40,8 @@ import (
 	mock_credentials "github.com/aws/amazon-ecs-agent/agent/credentials/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
 	mock_dockerstate "github.com/aws/amazon-ecs-agent/agent/engine/dockerstate/mocks"
+	agentAPIV1 "github.com/aws/amazon-ecs-agent/agent/handlers/agentapi/v1/taskprotection/handlers"
+	agentAPIV1Types "github.com/aws/amazon-ecs-agent/agent/handlers/agentapi/v1/taskprotection/types"
 	"github.com/aws/amazon-ecs-agent/agent/handlers/utils"
 	v1 "github.com/aws/amazon-ecs-agent/agent/handlers/v1"
 	v2 "github.com/aws/amazon-ecs-agent/agent/handlers/v2"
@@ -1881,6 +1883,8 @@ func TestAgentAPIV1GetTaskProtectionHandler(t *testing.T) {
 
 // Tests that Agent API v1 PutTaskProtection handler is registered correctly
 func TestAgentAPIV1PutTaskProtectionHandler(t *testing.T) {
-	requestBody := map[string]interface{}{"protectionType": "SCALE_IN"}
+	requestBody := agentAPIV1.TaskProtectionRequest{
+		ProtectionType: string(agentAPIV1Types.TaskProtectionTypeScaleIn),
+	}
 	testAgentAPIV1TaskProtectionHandler(t, requestBody, "PUT")
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This change adds a new HTTP endpoint to agent with the following two handlers. 

| Endpoint path | Method | Description |
| ------------- | -------- | ----------- |
| /api/v1/{v3EndpointID}/task/protection | PUT | Update protection status of a task |
| /api/v1/{v3EndpointID}/task/protection | GET | Get the protection status of a task |

The endpoint path `/api/v1/{v3EndpointID}` is exposed to customer containers as an environment variable. Changes for this have already been merged to the feature branch.

ECS Client has not yet been updated with `PutTaskProtection` and `GetTaskProtection` APIs, so the handlers do not do anything meaningful. Once the ECS client libraries are updated, the handlers will be updated to call the corresponding ECS APIs. This will be done in a future PR. TODOs have been added to the handlers to capture this requirement. For this reason the new handlers simply respond with "Ok" on success for now, the response will be made richer when the handlers are updated to call ECS.

### Implementation details
Handler functions are added for PUT and GET methods of the endpoint. The handlers lookup task for the request using the V3 Endpoint ID passed in the request URL and perform the required validations. 

### Testing
1. New unit tests have been added to test the new handlers and their registration to the agent HTTP server. 
2. Agent was built using the source of this PR on an AL2 EC2 instance and PUT and GET requests were sent to it on the new endpoint being added. The requests were handled by the agent as expected.

```
root@5006c649e9d2:/# curl -X GET $ECS_AGENT_API_URI_V1/task/protection                                      
"Ok"root@5006c649e9d2:/#                                                                                    
root@5006c649e9d2:/# curl -X PUT $ECS_AGENT_API_URI_V1/task/protection -d '{"protectionType": "scale_in"}'  
"Ok"root@5006c649e9d2:/#                                                                                    
root@5006c649e9d2:/#                                                                                        
root@5006c649e9d2:/# curl -X PUT $ECS_AGENT_API_URI_V1/task/protection -d '{"protectionType": "invalid"}'   
"Invalid request: protection type is invalid: unknown task protection type: invalid"root@5006c649e9d2:/#    
```

<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: yes

### Description for the changelog
Add PutTaskProtection and GetTaskProtection APIs.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
