### PR TITLE
Reduce the flakiness of a windows integration test TestExecCommandAgent

### DIFF
--- a/agent/engine/engine_windows_integ_test.go
+++ b/agent/engine/engine_windows_integ_test.go
@@ -889,5 +889,5 @@ func killMockExecCommandAgent(t *testing.T, client *sdkClient.Client, containerI
 	require.NoError(t, err)
 
 	// Windows docker exec takes longer than Linux
-	time.Sleep(4 * time.Second)
+	time.Sleep(8 * time.Second)
 }

--- a/agent/engine/engine_windows_integ_test.go
+++ b/agent/engine/engine_windows_integ_test.go
@@ -837,7 +837,10 @@ func verifyMockExecCommandAgentStatus(t *testing.T, client *sdkClient.Client, co
 			require.NotEqual(t, -1, pidPos, "PID title not found in the container top response")
 			for _, proc := range top.Processes {
 				matched, _ := regexp.MatchString(execCmdAgentProcessRegex, proc[cmdPos])
-				if matched {
+				// Process we are checking to be stopped might still be running.
+				// expectedPid matches the pid of the process in that case, so wait if that's
+				// the case.
+				if matched && (checkIsRunning || expectedPid != proc[pidPos]) {
 					res <- proc[pidPos]
 					return
 				}
@@ -846,7 +849,7 @@ func verifyMockExecCommandAgentStatus(t *testing.T, client *sdkClient.Client, co
 			select {
 			case <-ctx.Done():
 				return
-			case <-time.After(time.Second * 4):
+			case <-time.After(time.Second * 1):
 			}
 		}
 	}()
@@ -887,7 +890,4 @@ func killMockExecCommandAgent(t *testing.T, client *sdkClient.Client, containerI
 		Detach: true,
 	})
 	require.NoError(t, err)
-
-	// Windows docker exec takes longer than Linux
-	time.Sleep(8 * time.Second)
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
`TestExecCommandAgent` currently issues a kill command for a process running inside a container and sleeps for 4 seconds hoping for the process to be killed. This test has been failing lately because the process to be killed is still running for some time after 4 seconds. 

This change replaces the 4 second sleep with a loop that checks every second if the process was killed. The loop timeouts after 15 seconds. 

### Testing
Tested by running the test on a Windows EC2 instance. Also the test is run as a part of PR checks.
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: NA

### Description for the changelog
Reduce the flakiness of TestExecCommandAgent.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
