### PR TITLE
Update changelog generation script to add amazon-linux-ami-integrated

### DIFF
--- a/packaging/amazon-linux-ami-integrated/ecs-agent.spec
+++ b/packaging/amazon-linux-ami-integrated/ecs-agent.spec
@@ -284,6 +284,9 @@ fi
 * Wed Jun 15 2022 Mythri Garaga Manjunatha <mythr@amazon.com> - 1.61.3-1
 - Cache Agent version 1.61.3
 
+* Wed Jun 01 2022 Utsa Bhattacharjya <utsa@amazon.com> - 1.61.2-1
+- Cache Agent version 1.61.2
+
 * Tue May 03 2022 Anuj Singh <singholt@amazon.com> - 1.61.1-1
 - Cache Agent version 1.61.1
 - Install script no longer fails on systems using cgroups v2
@@ -737,3 +740,4 @@ fi
 
 * Mon Dec 15 2014 Samuel Karp <skarp@amazon.com> - 0.2-1
 - Naive update functionality
+

--- a/packaging/amazon-linux-ami/ecs-agent.spec
+++ b/packaging/amazon-linux-ami/ecs-agent.spec
@@ -291,6 +291,9 @@ fi
 * Wed Jun 15 2022 Mythri Garaga Manjunatha <mythr@amazon.com> - 1.61.3-1
 - Cache Agent version 1.61.3
 
+* Wed Jun 01 2022 Utsa Bhattacharjya <utsa@amazon.com> - 1.61.2-1
+- Cache Agent version 1.61.2
+
 * Tue May 03 2022 Anuj Singh <singholt@amazon.com> - 1.61.1-1
 - Cache Agent version 1.61.1
 - Install script no longer fails on systems using cgroups v2
@@ -744,3 +747,4 @@ fi
 
 * Mon Dec 15 2014 Samuel Karp <skarp@amazon.com> - 0.2-1
 - Naive update functionality
+

--- a/packaging/generic-deb-integrated/debian/changelog
+++ b/packaging/generic-deb-integrated/debian/changelog
@@ -22,6 +22,12 @@ amazon-ecs-init (1.61.3-1) stable; urgency=medium
 
  -- Mythri Garaga Manjunatha <mythr@amazon.com>  Wed, 15 Jun 2022 18:00:00 +0000
 
+amazon-ecs-init (1.61.2-1) stable; urgency=medium
+
+  * Cache Agent version 1.61.2
+
+ -- Utsa Bhattacharjya <utsa@amazon.com>  Wed, 01 Jun 2022 18:00:00 +0000
+
 amazon-ecs-init (1.61.1-1) stable; urgency=medium
 
   * Cache Agent version 1.61.1

--- a/packaging/generic-deb/debian/changelog
+++ b/packaging/generic-deb/debian/changelog
@@ -22,6 +22,12 @@ amazon-ecs-init (1.61.3-1) stable; urgency=medium
 
  -- Mythri Garaga Manjunatha <mythr@amazon.com>  Wed, 15 Jun 2022 18:00:00 +0000
 
+amazon-ecs-init (1.61.2-1) stable; urgency=medium
+
+  * Cache Agent version 1.61.2
+
+ -- Utsa Bhattacharjya <utsa@amazon.com>  Wed, 01 Jun 2022 18:00:00 +0000
+
 amazon-ecs-init (1.61.1-1) stable; urgency=medium
 
   * Cache Agent version 1.61.1

--- a/packaging/generic-rpm-integrated/amazon-ecs-init.spec
+++ b/packaging/generic-rpm-integrated/amazon-ecs-init.spec
@@ -107,6 +107,9 @@ ln -sf %{basename:%{agent_image}} %{_cachedir}/ecs/ecs-agent.tar
 * Wed Jun 15 2022 Mythri Garaga Manjunatha <mythr@amazon.com> - 1.61.3-1
 - Cache Agent version 1.61.3
 
+* Wed Jun 01 2022 Utsa Bhattacharjya <utsa@amazon.com> - 1.61.2-1
+- Cache Agent version 1.61.2
+
 * Tue May 03 2022 Anuj Singh <singholt@amazon.com> - 1.61.1-1
 - Cache Agent version 1.61.1
 - Install script no longer fails on systems using cgroups v2
@@ -560,3 +563,4 @@ ln -sf %{basename:%{agent_image}} %{_cachedir}/ecs/ecs-agent.tar
 
 * Mon Dec 15 2014 Samuel Karp <skarp@amazon.com> - 0.2-1
 - Naive update functionality
+

--- a/packaging/generic-rpm/amazon-ecs-init.spec
+++ b/packaging/generic-rpm/amazon-ecs-init.spec
@@ -117,6 +117,9 @@ ln -sf %{basename:%{agent_image}} %{_cachedir}/ecs/ecs-agent.tar
 * Wed Jun 15 2022 Mythri Garaga Manjunatha <mythr@amazon.com> - 1.61.3-1
 - Cache Agent version 1.61.3
 
+* Wed Jun 01 2022 Utsa Bhattacharjya <utsa@amazon.com> - 1.61.2-1
+- Cache Agent version 1.61.2
+
 * Tue May 03 2022 Anuj Singh <singholt@amazon.com> - 1.61.1-1
 - Cache Agent version 1.61.1
 - Install script no longer fails on systems using cgroups v2
@@ -570,3 +573,4 @@ ln -sf %{basename:%{agent_image}} %{_cachedir}/ecs/ecs-agent.tar
 
 * Mon Dec 15 2014 Samuel Karp <skarp@amazon.com> - 0.2-1
 - Naive update functionality
+

--- a/packaging/suse/amazon-ecs-init.changes
+++ b/packaging/suse/amazon-ecs-init.changes
@@ -15,6 +15,10 @@ Wed Jun 15, 18:00:00 UTC 2022 - mythr@amazon.com - 1.61.3-1
 
 - Cache Agent version 1.61.3
 -------------------------------------------------------------------
+Wed Jun 01, 18:00:00 UTC 2022 - utsa@amazon.com - 1.61.2-1
+
+- Cache Agent version 1.61.2
+-------------------------------------------------------------------
 Tue May 03, 18:00:00 UTC 2022 - singholt@amazon.com - 1.61.1-1
 
 - Cache Agent version 1.61.1

--- a/scripts/changelog/changelog.go
+++ b/scripts/changelog/changelog.go
@@ -16,14 +16,15 @@ type Change struct {
 }
 
 const (
-	CHANGE_TEMPLATE  = "./CHANGELOG_MASTER"
-	TOP_LEVEL        = "../../CHANGELOG.md"
-	AMAZON_LINUX_RPM = "../../packaging/amazon-linux-ami/ecs-agent.spec"
-	GENERIC_RPM      = "../../packaging/generic-rpm/amazon-ecs-init.spec"
-	GENERIC_RPM_INT  = "../../packaging/generic-rpm-integrated/amazon-ecs-init.spec"
-	SUSE             = "../../packaging/suse/amazon-ecs-init.changes"
-	UBUNTU           = "../../packaging/generic-deb/debian/changelog"
-	GENERIC_DEB_INT  = "../../packaging/generic-deb-integrated/debian/changelog"
+	CHANGE_TEMPLATE      = "./CHANGELOG_MASTER"
+	TOP_LEVEL            = "../../CHANGELOG.md"
+	AMAZON_LINUX_RPM     = "../../packaging/amazon-linux-ami/ecs-agent.spec"
+	AMAZON_LINUX_RPM_INT = "../../packaging/amazon-linux-ami-integrated/ecs-agent.spec"
+	GENERIC_RPM          = "../../packaging/generic-rpm/amazon-ecs-init.spec"
+	GENERIC_RPM_INT      = "../../packaging/generic-rpm-integrated/amazon-ecs-init.spec"
+	SUSE                 = "../../packaging/suse/amazon-ecs-init.changes"
+	UBUNTU               = "../../packaging/generic-deb/debian/changelog"
+	GENERIC_DEB_INT      = "../../packaging/generic-deb-integrated/debian/changelog"
 
 	AMAZON_LINUX_TIME_FMT = "Mon Jan 02 2006"
 	DEBIAN_TIME_FMT       = "Mon, 02 Jan 2006 15:04:05 -0700"
@@ -79,7 +80,7 @@ func main() {
 	rewriteChangelog(GENERIC_DEB_INT, ubuntuChangeString)
 	rewriteChangelog(SUSE, suseChangeString)
 
-	rpmSpecs := []string{AMAZON_LINUX_RPM, GENERIC_RPM, GENERIC_RPM_INT}
+	rpmSpecs := []string{AMAZON_LINUX_RPM, AMAZON_LINUX_RPM_INT, GENERIC_RPM, GENERIC_RPM_INT}
 	for _, spec := range rpmSpecs {
 		// Get everything before the %changelog section, so that the change logs
 		// in rpmChangeString are appended after it.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This adds amazon-linux-integrated to the set of specfiles which have their changelog updated automatically by the changelog generation script.

### Implementation details
Added the ecs-agent.spec file to the array of files to update

### Testing
Tested by locally running the script (which picked up a change that was added only to the external init package.

### Description for the changelog
Update changelog generation to add missing spec file.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
