### PR TITLE
add RPMs and Anywhere scripts to validation

### DIFF
--- a/scripts/verify-agent-artifacts
+++ b/scripts/verify-agent-artifacts
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 AGENT_VERSION="${1:-}"
+INIT_VERSION="${AGENT_VERSION}-1"
 BUCKET_NAME="${2:-}"
 SHA=$(git rev-parse --short=8 HEAD)
 
@@ -66,7 +67,35 @@ ecs-agent-arm64-v${AGENT_VERSION}.tar.asc
 ecs-agent-arm64-${SHA}.tar
 ecs-agent-arm64-${SHA}.tar.md5
 ecs-agent-arm64-${SHA}.tar.json
-ecs-agent-arm64-${SHA}.tar.asc"
+ecs-agent-arm64-${SHA}.tar.asc
+ecs-anywhere-install-latest.sh
+ecs-anywhere-install-latest.sh.asc
+ecs-anywhere-install-${INIT_VERSION}.sh
+ecs-anywhere-install-${INIT_VERSION}.sh.asc
+amazon-ecs-init-${INIT_VERSION}.x86_64.rpm
+amazon-ecs-init-${INIT_VERSION}.x86_64.rpm.asc
+amazon-ecs-init-${INIT_VERSION}.aarch64.rpm
+amazon-ecs-init-${INIT_VERSION}.aarch64.rpm.asc
+amazon-ecs-init-${INIT_VERSION}.amd64.deb
+amazon-ecs-init-${INIT_VERSION}.amd64.deb.asc
+amazon-ecs-init-${INIT_VERSION}.arm64.deb
+amazon-ecs-init-${INIT_VERSION}.arm64.deb.asc
+ecs-init-${INIT_VERSION}.amzn2.aarch64.rpm
+ecs-init-${INIT_VERSION}.amzn2.aarch64.rpm.asc
+ecs-init-${INIT_VERSION}.amzn2.x86_64.rpm
+ecs-init-${INIT_VERSION}.amzn2.x86_64.rpm.asc
+ecs-init-${INIT_VERSION}.amzn2022.aarch64.rpm
+ecs-init-${INIT_VERSION}.amzn2022.aarch64.rpm.asc
+ecs-init-${INIT_VERSION}.amzn2022.x86_64.rpm
+ecs-init-${INIT_VERSION}.amzn2022.x86_64.rpm.asc
+ecs-init-latest.amzn2.aarch64.rpm
+ecs-init-latest.amzn2.aarch64.rpm.asc
+ecs-init-latest.amzn2.x86_64.rpm
+ecs-init-latest.amzn2.x86_64.rpm.asc
+ecs-init-latest.amzn2022.aarch64.rpm
+ecs-init-latest.amzn2022.aarch64.rpm.asc
+ecs-init-latest.amzn2022.x86_64.rpm
+ecs-init-latest.amzn2022.x86_64.rpm.asc"
 
 # verify the files actually exist:
 for f in $files; do


### PR DESCRIPTION
### Summary
This is a little change to add a more complete set of release artifacts to our validation script.

### Implementation details
Updated to add anywhere rpms/debs and Koji-built rpms and also anywhere install scripts.
The only gaps are in configuration (agent.json and agentVersion.json) which live in a separate account.

### Testing
Tested manually against latest available artifacts and saw that all artifacts are available/readable after most recent release
```
./verify-agent-artifacts 1.62.2 ${RELEASE_S3_BUCKET}
```
New tests cover the changes: no

Description for the changelog
Update validation script with more comprehensive set of files.

Licensing
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.