### PR TITLE
Fix json syntax in release-config

### DIFF
--- a/buildspecs/release-config.yml
+++ b/buildspecs/release-config.yml
@@ -33,7 +33,7 @@ phases:
         {
           "agentReleaseVersion" : "$AGENT_VERSION",
           "releaseDate" : "$RELEASE_DATE",
-          "initStagingConfig" {
+          "initStagingConfig": {
             "release": "1"
           },
           "agentStagingConfig": {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
There was a missing `:` in the release config -- issue discovered during previous release.

### Implementation details
N/A

### Testing
N/A

New tests cover the changes: no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
