### PR TITLE
Add ServiceName to TMDE v4 TaskResponse

### DIFF
--- a/agent/handlers/task_server_setup_test.go
+++ b/agent/handlers/task_server_setup_test.go
@@ -1471,8 +1471,8 @@ func TestV4BridgeTaskMetadata(t *testing.T) {
 	gomock.InOrder(
 		state.EXPECT().TaskARNByV3EndpointID(v3EndpointID).Return(taskARN, true),
 		state.EXPECT().TaskByArn(taskARN).Return(bridgeTask, true),
-		state.EXPECT().ContainerMapByArn(taskARN).Return(containerNameToBridgeContainer, true),
 		state.EXPECT().TaskByArn(taskARN).Return(bridgeTask, true),
+		state.EXPECT().ContainerMapByArn(taskARN).Return(containerNameToBridgeContainer, true),
 		state.EXPECT().ContainerByID(containerID).Return(bridgeContainer, true),
 		state.EXPECT().PulledContainerMapByArn(taskARN).Return(nil, true),
 	)
@@ -1506,8 +1506,8 @@ func TestV4BridgeTaskMetadataAllowMissingContainerNetwork(t *testing.T) {
 	gomock.InOrder(
 		state.EXPECT().TaskARNByV3EndpointID(v3EndpointID).Return(taskARN, true),
 		state.EXPECT().TaskByArn(taskARN).Return(bridgeTask, true),
-		state.EXPECT().ContainerMapByArn(taskARN).Return(containerNameToBridgeContainer, true),
 		state.EXPECT().TaskByArn(taskARN).Return(bridgeTask, true),
+		state.EXPECT().ContainerMapByArn(taskARN).Return(containerNameToBridgeContainer, true),
 		state.EXPECT().ContainerByID(containerID).Return(nil, false),
 		state.EXPECT().PulledContainerMapByArn(taskARN).Return(nil, true),
 	)

--- a/agent/handlers/v4/response.go
+++ b/agent/handlers/v4/response.go
@@ -31,6 +31,7 @@ type TaskResponse struct {
 	*v2.TaskResponse
 	Containers []ContainerResponse `json:"Containers,omitempty"`
 	VPCID      string              `json:"VpcId,omitempty"`
+	ServiceName string              `json:"ServiceName,omitempty"`
 }
 
 // ContainerResponse is the v4 Container response. It augments the v4 Network response
@@ -85,6 +86,7 @@ func NewTaskResponse(
 	az string,
 	vpcID string,
 	containerInstanceARN string,
+	serviceName string,
 	propagateTags bool,
 ) (*TaskResponse, error) {
 	// Construct the v2 response first.
@@ -112,6 +114,7 @@ func NewTaskResponse(
 		TaskResponse: v2Resp,
 		Containers:   containers,
 		VPCID:        vpcID,
+		ServiceName:  serviceName,
 	}, nil
 }
 

--- a/agent/handlers/v4/response.go
+++ b/agent/handlers/v4/response.go
@@ -29,8 +29,8 @@ import (
 // with the v2 task response object.
 type TaskResponse struct {
 	*v2.TaskResponse
-	Containers []ContainerResponse `json:"Containers,omitempty"`
-	VPCID      string              `json:"VpcId,omitempty"`
+	Containers  []ContainerResponse `json:"Containers,omitempty"`
+	VPCID       string              `json:"VpcId,omitempty"`
 	ServiceName string              `json:"ServiceName,omitempty"`
 }
 

--- a/agent/handlers/v4/response_test.go
+++ b/agent/handlers/v4/response_test.go
@@ -39,6 +39,7 @@ const (
 	cluster                  = "default"
 	family                   = "sleep"
 	version                  = "1"
+	serviceName              = "someService"
 	containerID              = "cid"
 	containerName            = "sleepy"
 	imageName                = "busybox"
@@ -69,6 +70,7 @@ func TestNewTaskContainerResponses(t *testing.T) {
 		Arn:                 taskARN,
 		Family:              family,
 		Version:             version,
+		ServiceName:         serviceName,
 		DesiredStatusUnsafe: apitaskstatus.TaskRunning,
 		KnownStatusUnsafe:   apitaskstatus.TaskRunning,
 		ENIs: []*apieni.ENI{
@@ -135,7 +137,8 @@ func TestNewTaskContainerResponses(t *testing.T) {
 		state.EXPECT().TaskByArn(taskARN).Return(task, true),
 	)
 
-	taskResponse, err := NewTaskResponse(taskARN, state, ecsClient, cluster, availabilityZone, vpcID, containerInstanceArn, false)
+	taskResponse, err := NewTaskResponse(taskARN, state, ecsClient, cluster,
+		availabilityZone, vpcID, containerInstanceArn, task.ServiceName, false)
 	require.NoError(t, err)
 	_, err = json.Marshal(taskResponse)
 	require.NoError(t, err)
@@ -144,6 +147,7 @@ func TestNewTaskContainerResponses(t *testing.T) {
 	assert.Equal(t, eniIPv6Address, taskResponse.Containers[0].Networks[0].IPv6Addresses[0])
 	assert.Equal(t, ipv6SubnetCIDRBlock, taskResponse.Containers[0].Networks[0].IPv6SubnetCIDRBlock)
 	assert.Equal(t, subnetGatewayIPV4Address, taskResponse.Containers[0].Networks[0].SubnetGatewayIPV4Address)
+	assert.Equal(t, serviceName, taskResponse.ServiceName)
 
 	gomock.InOrder(
 		state.EXPECT().ContainerByID(containerID).Return(dockerContainer, true),


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Add `ServiceName` field to TMDE v4 task responses.

### Implementation details
`ServiceName` field is available in `Task`, so just copying it to TMDE v4 `TaskResponse` type.

### Testing
Tested on an EC2 instance registered under a Gamma cluster. `ServiceName` field has not yet been added to ACS Task Payload in Production, so the tests have been performed against Gamma environment.

Only v4 Task Responses included `ServiceName`, v3 responses did not.
```
[ec2-user@ip-172-31-10-152 amazon-ecs-agent]$ curl http://169.254.170.2/v4/ef23daaf-d681-4cc9-a6df-3f047e25e2fe/task | jq '.ServiceName'                                                                                                                  
"nginx"                                                                                                                      
[ec2-user@ip-172-31-10-152 amazon-ecs-agent]$ curl http://169.254.170.2/v4/ef23daaf-d681-4cc9-a6df-3f047e25e2fe/taskWithTags | jq '.ServiceName'                                                                                                          
"nginx"                                                                        
[ec2-user@ip-172-31-10-152 amazon-ecs-agent]$ curl http://169.254.170.2/v3/ef23daaf-d681-4cc9-a6df-3f047e25e2fe/task | jq '.ServiceName'                                                                                                                  
null                                                                                                                         
[ec2-user@ip-172-31-10-152 amazon-ecs-agent]$ curl http://169.254.170.2/v3/ef23daaf-d681-4cc9-a6df-3f047e25e2fe/taskWithTags | jq '.ServiceName'                                                                                                          
null                                                                                                                         
[ec2-user@ip-172-31-10-152 amazon-ecs-agent]$                                                                                
```
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: Yes

### Description for the changelog
Add ServiceName to TMDE v4 Task Responses.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
