### PR TITLE
Fix Windows issue resolving LinkName

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -31,4 +31,4 @@ jobs:
           gcc --version
           $env:ZZZ_SKIP_WINDOWS_SERVER_VERSION_CHECK_NOT_SUPPORTED_IN_PRODUCTION = 'true'
           $packages=go list .\... | Where-Object {$_ -NotMatch 'vendor'}
-          go test -v -tags unit -timeout=40s $packages
+          go test -v -tags unit -timeout=120s $packages

--- a/agent/api/task/task_test_utils.go
+++ b/agent/api/task/task_test_utils.go
@@ -38,7 +38,7 @@ const (
 	ipv4              = "10.0.0.2"
 	ipv4Block         = "/24"
 	ipv4Gateway       = "10.0.0.1"
-	mac               = "1.2.3.4"
+	mac               = "00:00:00:00:00:00"
 	ipv6              = "f0:234:23"
 	ipv6Block         = "/64"
 	ignoredUID        = "1337"

--- a/agent/engine/docker_task_engine_test.go
+++ b/agent/engine/docker_task_engine_test.go
@@ -81,7 +81,7 @@ const (
 	credentialsID               = "credsid"
 	ipv4                        = "10.0.0.1"
 	gatewayIPv4                 = "10.0.0.2/20"
-	mac                         = "1.2.3.4"
+	mac                         = "00:00:00:00:00:00"
 	ipv6                        = "f0:234:23"
 	dockerContainerName         = "docker-container-name"
 	containerPid                = 123


### PR DESCRIPTION
### Summary

1. Fixes an issue in Windows when iphelper api is failing
that can cause resolution of the interface LinkName to return
an empty string. In this case the CNI will fail to move the
task interface because it is not found.

2. Fixes an issue when using Get-NetAdapter to only return -Physical
addresses that avoids the duplicate vEthernet virtual address created
by CNI which can cause the wrong LinkName to be returned if the
vEthernet address is returned before the Physical address in the list.

3. Fixes an issue when using Get-NetAdapter that if a single element
is returned PowerShell ConvertTo-Json does not return the JSON as
an array which can cause a failure to unmarshal.

4. Fixes an issue when comparing MAC addresses that we compare them
as strict hardware bytes instead of strings to avoid match issues
between '-' and ':' between sets.

Signed-off-by: Justin Terry <jlterry@amazon.com>

### Testing

I have verified the code changes by running ECS Windows Tasks on ECS Clusters with iphelper completely disabled. This forces the use of the net interface wrapper (Get-NetAdapter callout) in all cases and verifies the functionality.

New tests cover the changes: <!-- yes|no -->
- Existing tests cover the cases already.

### Description for the changelog
Fixes bugs associated with Windows task networking resolution failing due to an invalid LinkName of `""` (empty string).

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
