### PR TITLE
Add APPNET_SUPPORTED_IP_FAMILIES to support dual stack

### DIFF
--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -1857,7 +1857,7 @@ func (task *Task) dockerHostConfig(container *apicontainer.Container, dockerCont
 				hostConfig.ExtraHosts = append(hostConfig.ExtraHosts, hosts...)
 			}
 
-			if task.shouldEnableIPv6() {
+			if task.ShouldEnableIPv6() {
 				// By default, the disable ipv6 setting is turned on, so need to turn it off to enable it.
 				enableIPv6SysctlSetting(hostConfig)
 			}
@@ -2081,7 +2081,7 @@ func (task *Task) generateENIExtraHosts() []string {
 	return extraHosts
 }
 
-func (task *Task) shouldEnableIPv4() bool {
+func (task *Task) ShouldEnableIPv4() bool {
 	eni := task.GetPrimaryENI()
 	if eni == nil {
 		return false
@@ -2089,7 +2089,7 @@ func (task *Task) shouldEnableIPv4() bool {
 	return len(eni.GetIPV4Addresses()) > 0
 }
 
-func (task *Task) shouldEnableIPv6() bool {
+func (task *Task) ShouldEnableIPv6() bool {
 	eni := task.GetPrimaryENI()
 	if eni == nil {
 		return false

--- a/agent/api/task/task_linux.go
+++ b/agent/api/task/task_linux.go
@@ -341,8 +341,8 @@ func (task *Task) BuildCNIConfigAwsvpc(includeIPAMConfig bool, cniConfig *ecscni
 			task.ServiceConnectConfig,
 			ecscni.NAT,
 			false,
-			task.shouldEnableIPv4(),
-			task.shouldEnableIPv6(),
+			task.ShouldEnableIPv4(),
+			task.ShouldEnableIPv6(),
 			cniConfig)
 		if err != nil {
 			return nil, err

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -3666,9 +3666,9 @@ func TestShouldEnableIPv6(t *testing.T) {
 	task := &Task{
 		ENIs: []*apieni.ENI{getTestENI()},
 	}
-	assert.True(t, task.shouldEnableIPv6())
+	assert.True(t, task.ShouldEnableIPv6())
 	task.ENIs[0].IPV6Addresses = nil
-	assert.False(t, task.shouldEnableIPv6())
+	assert.False(t, task.ShouldEnableIPv6())
 }
 
 func getTestENI() *apieni.ENI {

--- a/agent/engine/serviceconnect/manager_linux_test_common.go
+++ b/agent/engine/serviceconnect/manager_linux_test_common.go
@@ -134,6 +134,7 @@ func testAgentContainerModificationsForServiceConnect(t *testing.T, privilegedMo
 		"StAtUsGoEsHeRe":                "/some/other/run/status_file_of_holiness",
 		"APPNET_AGENT_ADMIN_MODE":       "uds",
 		"ENVOY_ENABLE_IAM_AUTH_FOR_XDS": "0",
+		"APPNET_SUPPORTED_IP_FAMILIES":  "ALL",
 	}
 
 	type testCase struct {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Add APPNET_SUPPORTED_IP_FAMILIES to support dual stack for Service Connect

### Implementation details
<!-- How are the changes implemented? -->
Pass `APPNET_SUPPORTED_IP_FAMILIES` to AppNet Agent container together with the other required ENVs. For bridge mode tasks, we support only IPv4. For awsvpc tasks, we determine the supported IP families based on the task ENI by checking whether the task ENI has IPv4 or IPv6 address present.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
`make test`

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Add APPNET_SUPPORTED_IP_FAMILIES to support dual stack for Service Connect

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
