### PR TITLE
Set AppNet UID to 20000; Add ECS_CONTAINER_INSTANCE_ARN Env

### DIFF
--- a/agent/api/serviceconnect/service_connect.go
+++ b/agent/api/serviceconnect/service_connect.go
@@ -13,7 +13,7 @@
 
 package serviceconnect
 
-const AppNetUID = 20000
+const AppNetUID = 20000 // arbitrarily selected
 
 // Config represents the Service Connect configuration for a task.
 type Config struct {

--- a/agent/api/serviceconnect/service_connect.go
+++ b/agent/api/serviceconnect/service_connect.go
@@ -13,7 +13,7 @@
 
 package serviceconnect
 
-const AppNetUID = 1337
+const AppNetUID = 20000
 
 // Config represents the Service Connect configuration for a task.
 type Config struct {

--- a/agent/engine/serviceconnect/manager_linux.go
+++ b/agent/engine/serviceconnect/manager_linux.go
@@ -60,6 +60,8 @@ const (
 	agentModeENV   = "APPNET_AGENT_ADMIN_MODE"
 	agentModeValue = "uds"
 
+	containerInstanceArnENV = "ECS_CONTAINER_INSTANCE_ARN"
+
 	unixRequestPrefix        = "unix://"
 	httpRequestPrefix        = "http://localhost"
 	defaultAdminStatsRequest = httpRequestPrefix + "/stats/prometheus?usedonly&filter=metrics_extension&delta"
@@ -189,10 +191,11 @@ func (m *manager) initAgentDirectoryMounts(taskId string, container *apicontaine
 
 func (m *manager) initAgentEnvironment(container *apicontainer.Container) {
 	scEnv := map[string]string{
-		m.endpointENV: unixRequestPrefix + filepath.Join(m.relayPathContainer, m.relayFileName),
-		m.statusENV:   filepath.Join(m.statusPathContainer, m.statusFileName),
-		agentModeENV:  agentModeValue,
-		agentAuthENV:  agentAuthOff,
+		m.endpointENV:           unixRequestPrefix + filepath.Join(m.relayPathContainer, m.relayFileName),
+		m.statusENV:             filepath.Join(m.statusPathContainer, m.statusFileName),
+		agentModeENV:            agentModeValue,
+		agentAuthENV:            agentAuthOff,
+		containerInstanceArnENV: m.containerInstanceARN,
 	}
 
 	container.MergeEnvironmentVariables(scEnv)

--- a/agent/engine/serviceconnect/manager_linux_test_common.go
+++ b/agent/engine/serviceconnect/manager_linux_test_common.go
@@ -134,6 +134,7 @@ func testAgentContainerModificationsForServiceConnect(t *testing.T, privilegedMo
 		"StAtUsGoEsHeRe":                "/some/other/run/status_file_of_holiness",
 		"APPNET_AGENT_ADMIN_MODE":       "uds",
 		"ENVOY_ENABLE_IAM_AUTH_FOR_XDS": "0",
+		"ECS_CONTAINER_INSTANCE_ARN":    "fake_container_instance",
 	}
 
 	type testCase struct {
@@ -174,6 +175,8 @@ func testAgentContainerModificationsForServiceConnect(t *testing.T, privilegedMo
 
 		AgentContainerImageName: "container",
 		AgentContainerTag:       "tag",
+
+		containerInstanceARN: "fake_container_instance",
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Set AppNet UID to 20000; Add ECS_CONTAINER_INSTANCE_ARN Env.

### Implementation details
<!-- How are the changes implemented? -->
1. Update AppNet UID from `1337` to `20000` (arbitrarily selected) - `1337` is known to be associated with hacker activities and may raise customer suspicion. 
2. Add `ECS_CONTAINER_INSTANCE_ARN` Env for AppNet Agent container.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
`make test`

New tests cover the changes: <!-- yes|no --> no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Set AppNet UID to 20000; Add ECS_CONTAINER_INSTANCE_ARN Env

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
