### PR TITLE
Change JSON key for VPC ID in TMDE v4 TaskResponse from VpcId to VPCID

### DIFF
--- a/agent/handlers/v4/response.go
+++ b/agent/handlers/v4/response.go
@@ -30,7 +30,7 @@ import (
 type TaskResponse struct {
 	*v2.TaskResponse
 	Containers  []ContainerResponse `json:"Containers,omitempty"`
-	VPCID       string              `json:"VpcId,omitempty"`
+	VPCID       string              `json:"VPCID,omitempty"`
 	ServiceName string              `json:"ServiceName,omitempty"`
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Changing the JSON key used for VPC ID field in TMDE v4 TaskResponse from `VpcId` to `VPCID` as suggested by Tech Documentation team. The idea is to use all uppercase for abbreviations.

### Testing
<!-- How was this tested? -->
Tested by sending curl requests to Agent.
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: NA

### Description for the changelog
Change JSON key for VPC ID in TMDE v4 TaskResponse to VPCID
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
