### PR TITLE
Endpoint update

### DIFF
--- a/agent/api/container/container.go
+++ b/agent/api/container/container.go
@@ -64,12 +64,12 @@ const (
 	// MetadataURIFormat defines the URI format for v4 metadata endpoint
 	MetadataURIFormatV4 = "http://169.254.170.2/v4/%s"
 
-	// AgentAPIURIEnvVarNameV1 defines the name of the environment
-	// variable injected into containers that contains the Agent API V1 endpoint.
-	AgentAPIURIEnvVarNameV1 = "ECS_AGENT_API_URI_V1"
+	// AgentURIEnvVarName defines the name of the environment variable
+	// injected into containers that contains the Agent endpoints.
+	AgentURIEnvVarName = "ECS_AGENT_URI"
 
-	// AgentAPIURIFormatV1 defines the URI format for v1 Agent API Endpoint
-	AgentAPIURIFormatV1 = "http://169.254.170.2/api/v1/%s"
+	// AgentURIFormat defines the URI format for Agent endpoints
+	AgentURIFormat = "http://169.254.170.2/api/%s"
 
 	// SecretProviderSSM is to show secret provider being SSM
 	SecretProviderSSM = "ssm"
@@ -947,7 +947,7 @@ func (c *Container) InjectV1AgentAPIEndpoint() {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	c.ensureEnvironmentIsInitialized()
-	c.Environment[AgentAPIURIEnvVarNameV1] = fmt.Sprintf(AgentAPIURIFormatV1, c.V3EndpointID)
+	c.Environment[AgentURIEnvVarName] = fmt.Sprintf(AgentURIFormat, c.V3EndpointID)
 }
 
 // Initializes Environment Map if it is nil

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -904,7 +904,7 @@ func TestInitializeContainersV1AgentAPIEndpoint(t *testing.T) {
 		assert.Equal(t, "new-uuid", container.GetV3EndpointID())
 		assert.Equal(t,
 			map[string]string{
-				apicontainer.AgentAPIURIEnvVarNameV1: "http://169.254.170.2/api/v1/new-uuid",
+				apicontainer.AgentURIEnvVarName: "http://169.254.170.2/api/new-uuid",
 			},
 			container.Environment)
 	}

--- a/agent/api/task/task_windows_test.go
+++ b/agent/api/task/task_windows_test.go
@@ -136,7 +136,7 @@ func removeEndpointConfigFromEnvironment(container *apicontainer.Container) {
 	if container.Environment != nil {
 		delete(container.Environment, apicontainer.MetadataURIEnvironmentVariableName)
 		delete(container.Environment, apicontainer.MetadataURIEnvVarNameV4)
-		delete(container.Environment, apicontainer.AgentAPIURIEnvVarNameV1)
+		delete(container.Environment, apicontainer.AgentURIEnvVarName)
 	}
 	if len(container.Environment) == 0 {
 		container.Environment = nil

--- a/agent/engine/common_test.go
+++ b/agent/engine/common_test.go
@@ -174,8 +174,8 @@ func validateContainerRunWorkflow(t *testing.T,
 		dockerConfig.Env = append(dockerConfig.Env, "ECS_CONTAINER_METADATA_URI="+metadataEndpointEnvValue)
 		metadataEndpointEnvValueV4 := fmt.Sprintf(apicontainer.MetadataURIFormatV4, v3EndpointID)
 		dockerConfig.Env = append(dockerConfig.Env, "ECS_CONTAINER_METADATA_URI_V4="+metadataEndpointEnvValueV4)
-		agentAPIEndpointEnvValue := fmt.Sprintf(apicontainer.AgentAPIURIFormatV1, v3EndpointID)
-		dockerConfig.Env = append(dockerConfig.Env, "ECS_AGENT_API_URI_V1="+agentAPIEndpointEnvValue)
+		agentAPIEndpointEnvValue := fmt.Sprintf(apicontainer.AgentURIFormat, v3EndpointID)
+		dockerConfig.Env = append(dockerConfig.Env, "ECS_AGENT_URI="+agentAPIEndpointEnvValue)
 	}
 	// Container config should get updated with this during CreateContainer
 	dockerConfig.Labels["com.amazonaws.ecs.task-arn"] = task.Arn

--- a/agent/handlers/agentapi/v1/taskprotection/handlers/handlers.go
+++ b/agent/handlers/agentapi/v1/taskprotection/handlers/handlers.go
@@ -31,7 +31,7 @@ import (
 // Returns endpoint path for PutTaskProtection API
 func TaskProtectionPath() string {
 	return fmt.Sprintf(
-		"/api/v1/%s/task/protection",
+		"/api/%s/task-protection/v1/state",
 		utils.ConstructMuxVar(v3.V3EndpointIDMuxName, utils.AnythingButSlashRegEx))
 }
 

--- a/agent/handlers/agentapi/v1/taskprotection/handlers/handlers_test.go
+++ b/agent/handlers/agentapi/v1/taskprotection/handlers/handlers_test.go
@@ -33,7 +33,7 @@ import (
 
 // Tests the path for PutTaskProtection API
 func TestTaskProtectionPath(t *testing.T) {
-	assert.Equal(t, "/api/v1/{v3EndpointIDMuxName:[^/]*}/task/protection", TaskProtectionPath())
+	assert.Equal(t, "/api/{v3EndpointIDMuxName:[^/]*}/task-protection/v1/state", TaskProtectionPath())
 }
 
 // Helper function for running tests for PutTaskProtection handler

--- a/agent/handlers/task_server_setup_test.go
+++ b/agent/handlers/task_server_setup_test.go
@@ -1872,7 +1872,7 @@ func testAgentAPIV1TaskProtectionHandler(t *testing.T, requestBody interface{}, 
 
 	// Send request and record response
 	recorder := httptest.NewRecorder()
-	req, _ := http.NewRequest(method, fmt.Sprintf("/api/v1/%s/task/protection", v3EndpointID),
+	req, _ := http.NewRequest(method, fmt.Sprintf("/api/%s/task-protection/v1/state", v3EndpointID),
 		requestReader)
 	server.Handler.ServeHTTP(recorder, req)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Update Task Scale In Protection Endpoint URI and handler to match latest decision.

### Implementation details
<!-- How are the changes implemented? -->
Change environment variable and handler path

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> No

Manual Tests:
```
[ec2-user@ip-172-31-5-32 amazon-ecs-agent]$ docker ps
CONTAINER ID   IMAGE                            COMMAND                CREATED              STATUS                        PORTS     NAMES
4873170a21f5   busybox                          "sh -c 'sleep 3000'"   2 seconds ago        Up 1 second                             ecs-sleeper-2-scratchsleeper-829efde9fd9cf4d7bd01
0a361fc1163c   amazon/amazon-ecs-agent:latest   "/agent"               About a minute ago   Up About a minute (healthy)             ecs-agent
[ec2-user@ip-172-31-5-32 amazon-ecs-agent]$ docker inspect 4873170a21f5
[
    {
        ...
        "Config": {
            ...
            "Env": [
                "AWS_EXECUTION_ENV=AWS_ECS_EC2",
                "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI=/v2/credentials/ce2823c1-23ff-4439-8dd5-1f534425fbc5",
                "ECS_CONTAINER_METADATA_URI=http://169.254.170.2/v3/f118dfa0-e086-4451-986c-6c83d8f30c91",
                "ECS_CONTAINER_METADATA_URI_V4=http://169.254.170.2/v4/f118dfa0-e086-4451-986c-6c83d8f30c91",
                "ECS_AGENT_URI=http://169.254.170.2/api/f118dfa0-e086-4451-986c-6c83d8f30c91",
                "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
            ],
            ...
        }
        ...
    }
]
```
```
[ec2-user@ip-172-31-5-11 amazon-ecs-agent]$ docker exec -it f140bffd9369 /bin/ash
/home # ls
/home # curl
curl: try 'curl --help' for more information
/home # curl -X GET $ECS_AGENT_URI/task-protection/v1/state
"Ok"/home #
/home # curl -X PUT $ECS_AGENT_URI/task-protection/v1/state -d '{"ProtectionEnabled": true, "ExpiresInMinutes": 60}'
"Ok"/home #
```
### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
