### PR TITLE
make expiration optional for task protection

### DIFF
--- a/agent/handlers/agentapi/v1/taskprotection/types/types.go
+++ b/agent/handlers/agentapi/v1/taskprotection/types/types.go
@@ -15,7 +15,6 @@ package types
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 )
 
@@ -44,14 +43,8 @@ func (taskProtection *taskProtection) MarshalJSON() ([]byte, error) {
 
 // Creates a taskProtection value after validating the arguments
 func NewTaskProtection(protectionEnabled bool, expiresInMinutes *int) (*taskProtection, error) {
-	if protectionEnabled {
-		if expiresInMinutes == nil {
-			return nil, errors.New("expiration duration is required for enabled task protection")
-		}
-
-		if *expiresInMinutes <= 0 {
-			return nil, fmt.Errorf("expiration duration must be greater than zero minutes for enabled task protection")
-		}
+	if protectionEnabled && expiresInMinutes != nil && *expiresInMinutes <= 0 {
+		return nil, fmt.Errorf("expiration duration must be greater than zero minutes for enabled task protection")
 	}
 
 	return &taskProtection{

--- a/agent/handlers/agentapi/v1/taskprotection/types/types_test.go
+++ b/agent/handlers/agentapi/v1/taskprotection/types/types_test.go
@@ -35,9 +35,9 @@ func TestNewTaskProtection(t *testing.T) {
 			err:               utils.Strptr("expiration duration must be greater than zero minutes for enabled task protection"),
 		},
 		{
-			name:              "nil timeout not allowed for enabled protection",
+			name:              "nil timeout allowed for enabled protection",
 			protectionEnabled: true,
-			err:               utils.Strptr("expiration duration is required for enabled task protection"),
+			expected:          &taskProtection{protectionEnabled: true},
 		},
 		{
 			name:              "nil timeout allowed for disabled protection",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Mark `ExpiresInMinutes` in UpdateTaskProtection request as optional

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Before:
```
[ec2-user@ip-172-31-5-11 amazon-ecs-agent]$ docker exec -it c246572b0dbc /bin/ash
/home # curl -X PUT $ECS_AGENT_URI/task-protection/v1/state -d '{"ProtectionEnabled": true}'
"Invalid request: expiration duration is required for enabled task protection"/home #
```
After: 
```
[ec2-user@ip-172-31-5-11 amazon-ecs-agent]$ docker exec -it 96ac204e9eb6 /bin/ash
/home # curl -X PUT $ECS_AGENT_URI/task-protection/v1/state -d '{"ProtectionEnabled": true}'
"Ok"/home #
```

New tests cover the changes: <!-- yes|no --> No

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
