### PR TITLE
Get task protection

### DIFF
--- a/agent/handlers/agentapi/taskprotection/v1/handlers/handlers.go
+++ b/agent/handlers/agentapi/taskprotection/v1/handlers/handlers.go
@@ -239,7 +239,10 @@ func GetTaskProtectionHandler(state dockerstate.TaskEngineState, credentialsMana
 
 		if err != nil {
 			exceptionType, statusCode := getExceptionTypeAndStatusCode(err)
-			logger.Error(fmt.Sprintf("ECS throws an exception with type %s", exceptionType))
+			logger.Error("ECS throws an exception.", logger.Fields{
+				"ExceptionType":   exceptionType,
+				loggerfield.Error: err,
+			})
 			writeJSONResponse(w, statusCode, err.Error(), getTaskProtectionRequestType)
 			return
 		}
@@ -275,8 +278,8 @@ func writeJSONResponse(w http.ResponseWriter, responseCode int, response interfa
 	bytes, err := json.Marshal(response)
 	if err != nil {
 		logger.Error("Agent API Task Protection V1: failed to marshal response as JSON", logger.Fields{
-			"response": response,
-			"error":    err,
+			"response":        response,
+			loggerfield.Error: err,
 		})
 		utils.WriteJSONToResponse(w, http.StatusInternalServerError, []byte(`{}`),
 			requestType)

--- a/agent/handlers/agentapi/taskprotection/v1/handlers/handlers.go
+++ b/agent/handlers/agentapi/taskprotection/v1/handlers/handlers.go
@@ -122,7 +122,10 @@ func UpdateTaskProtectionHandler(state dockerstate.TaskEngineState, credentialsM
 
 		if err != nil {
 			exceptionType, statusCode := getExceptionTypeAndStatusCode(err)
-			logger.Error(fmt.Sprintf("ECS throws an exception with type %s", exceptionType))
+			logger.Error("Got an exception when calling UpdateTaskProtection.", logger.Fields{
+				"ExceptionType":   exceptionType,
+				loggerfield.Error: err,
+			})
 			writeJSONResponse(w, statusCode, err.Error(), updateTaskProtectionRequestType)
 			return
 		}
@@ -239,7 +242,7 @@ func GetTaskProtectionHandler(state dockerstate.TaskEngineState, credentialsMana
 
 		if err != nil {
 			exceptionType, statusCode := getExceptionTypeAndStatusCode(err)
-			logger.Error("ECS throws an exception.", logger.Fields{
+			logger.Error("Got an exception when calling GetTaskProtection.", logger.Fields{
 				"ExceptionType":   exceptionType,
 				loggerfield.Error: err,
 			})
@@ -258,11 +261,6 @@ func GetTaskProtectionHandler(state dockerstate.TaskEngineState, credentialsMana
 			return
 		}
 
-		// there are no exceptions but there are failures when setting protection in scheduler
-		if len(response.ProtectedTasks) > 0 {
-			writeJSONResponse(w, http.StatusOK, response.ProtectedTasks[0], getTaskProtectionRequestType)
-			return
-		}
 		if len(response.ProtectedTasks) != ExpectedProtectionResponseLength {
 			logger.Error(fmt.Sprintf("expect %v protectedTask in response, get %v", ExpectedProtectionResponseLength, len(response.ProtectedTasks)))
 			writeJSONResponse(w, http.StatusInternalServerError, "An unexpected failure occurred.", getTaskProtectionRequestType)

--- a/agent/handlers/agentapi/taskprotection/v1/handlers/handlers.go
+++ b/agent/handlers/agentapi/taskprotection/v1/handlers/handlers.go
@@ -150,7 +150,7 @@ func UpdateTaskProtectionHandler(state dockerstate.TaskEngineState, credentialsM
 func (factory TaskProtectionClientFactory) newTaskProtectionClient(credentialsManager credentials.Manager, task *apitask.Task) (api.ECSTaskProtectionSDK, int, error) {
 	taskRoleCredential, ok := credentialsManager.GetTaskCredentials(task.GetCredentialsID())
 	if !ok {
-		return nil, http.StatusBadRequest, errors.New("invalid Request: no task IAM role credentials available for task")
+		return nil, http.StatusBadRequest, errors.New("Invalid Request: no task IAM role credentials available for task")
 	}
 	taskCredential := taskRoleCredential.GetIAMRoleCredentials()
 	cfg := aws.NewConfig().
@@ -195,7 +195,7 @@ func getTaskFromRequest(state dockerstate.TaskEngineState, r *http.Request) (*ap
 		logger.Error("Failed to find task ARN for task protection request", logger.Fields{
 			loggerfield.Error: err,
 		})
-		return nil, http.StatusBadRequest, errors.New("invalid request: no task was found")
+		return nil, http.StatusBadRequest, errors.New("Invalid request: no task was found")
 	}
 
 	task, found := state.TaskByArn(taskARN)
@@ -203,7 +203,7 @@ func getTaskFromRequest(state dockerstate.TaskEngineState, r *http.Request) (*ap
 		logger.Critical("No task was found for taskARN for task protection request", logger.Fields{
 			loggerfield.TaskARN: taskARN,
 		})
-		return nil, http.StatusInternalServerError, errors.New("failed to find a task for the request")
+		return nil, http.StatusInternalServerError, errors.New("Failed to find a task for the request")
 	}
 
 	return task, http.StatusOK, nil

--- a/agent/handlers/agentapi/taskprotection/v1/handlers/handlers_test.go
+++ b/agent/handlers/agentapi/taskprotection/v1/handlers/handlers_test.go
@@ -63,7 +63,7 @@ func TestTaskProtectionPath(t *testing.T) {
 }
 
 // TestGetECSClientHappyCase tests newTaskProtectionClient uses credential in credentials manager and
-// returns a ECS client with correct status code and error
+// returns an ECS client with correct status code and error
 func TestGetECSClientHappyCase(t *testing.T) {
 	testTask := task.Task{
 		Arn:         testTaskArn,
@@ -480,27 +480,14 @@ func TestGetTaskProtectionHandler_PostCall(t *testing.T) {
 			ecsResponse: &ecs.GetTaskProtectionOutput{
 				Failures: []*ecs.Failure{},
 				ProtectedTasks: []*ecs.ProtectedTask{{
-					ProtectionEnabled: aws.Bool(true),
-					ExpirationDate:    aws.Time(time.UnixMilli(0)),
+					ProtectionEnabled: aws.Bool(false),
+					ExpirationDate:    nil,
 					TaskArn:           aws.String(testTaskArn),
 				}},
 			},
 			expectedResponse: ecs.ProtectedTask{
-				ProtectionEnabled: aws.Bool(true),
-				ExpirationDate:    aws.Time(time.UnixMilli(0)),
-				TaskArn:           aws.String(testTaskArn),
-			},
-			expectedStatusCode: http.StatusOK,
-		},
-		{
-			name:     "SuccessWithNoProtectionTasks",
-			ecsError: nil,
-			ecsResponse: &ecs.GetTaskProtectionOutput{
-				Failures:       []*ecs.Failure{},
-				ProtectedTasks: []*ecs.ProtectedTask{},
-			},
-			expectedResponse: ecs.ProtectedTask{
 				ProtectionEnabled: aws.Bool(false),
+				ExpirationDate:    nil,
 				TaskArn:           aws.String(testTaskArn),
 			},
 			expectedStatusCode: http.StatusOK,

--- a/agent/handlers/agentapi/taskprotection/v1/handlers/handlers_test.go
+++ b/agent/handlers/agentapi/taskprotection/v1/handlers/handlers_test.go
@@ -340,9 +340,8 @@ func TestUpdateTaskProtectionHandler_PostCall(t *testing.T) {
 	}
 }
 
-// Helper function for running tests for GetTaskProtection handler
 func testGetTaskProtectionHandler(t *testing.T, state dockerstate.TaskEngineState,
-	v3EndpointID string, expectedResponse interface{}, expectedResponseCode int) {
+	v3EndpointID string, credentialsManager credentials.Manager, factory TaskProtectionClientFactoryInterface, expectedResponse interface{}, expectedResponseCode int) {
 	// Prepare request
 	bodyReader := bytes.NewReader([]byte{})
 	req, err := http.NewRequest("GET", "", bodyReader)
@@ -351,7 +350,7 @@ func testGetTaskProtectionHandler(t *testing.T, state dockerstate.TaskEngineStat
 
 	// Call handler
 	rr := httptest.NewRecorder()
-	handler := http.HandlerFunc(GetTaskProtectionHandler(state, nil, testCluster, testRegion))
+	handler := http.HandlerFunc(GetTaskProtectionHandler(state, credentialsManager, factory, testCluster))
 	handler.ServeHTTP(rr, req)
 
 	expectedResponseJSON, err := json.Marshal(expectedResponse)
@@ -372,7 +371,7 @@ func TestGetTaskProtectionHandlerTaskARNNotFound(t *testing.T) {
 	mockState := mock_dockerstate.NewMockTaskEngineState(ctrl)
 	mockState.EXPECT().TaskARNByV3EndpointID(gomock.Eq(testV3EndpointId)).Return("", false)
 
-	testGetTaskProtectionHandler(t, mockState, testV3EndpointId,
+	testGetTaskProtectionHandler(t, mockState, testV3EndpointId, nil, nil,
 		"invalid request: no task was found",
 		http.StatusBadRequest)
 }
@@ -386,24 +385,151 @@ func TestGetTaskProtectionHandlerTaskNotFound(t *testing.T) {
 	mockState.EXPECT().TaskARNByV3EndpointID(gomock.Eq(testV3EndpointId)).Return(testTaskArn, true)
 	mockState.EXPECT().TaskByArn(gomock.Eq(testTaskArn)).Return(nil, false)
 
-	testGetTaskProtectionHandler(t, mockState, testV3EndpointId,
+	testGetTaskProtectionHandler(t, mockState, testV3EndpointId, nil, nil,
 		"failed to find a task for the request",
 		http.StatusInternalServerError)
 }
 
-// TestGetTaskProtectionHandlerHappy tests GetTaskProtection handler's
-// behavior when request and state both are good.
-func TestGetTaskProtectionHandlerHappy(t *testing.T) {
+// TestGetTaskProtectionHandlerTaskRoleCredentialsNotFound tests GetTaskProtection handler's
+// behavior when task IAM role credential is not found for the request.
+func TestGetTaskProtectionHandlerTaskRoleCredentialsNotFound(t *testing.T) {
 	testTask := task.Task{
 		Arn:         testTaskArn,
 		ServiceName: testServiceName,
+	}
+	testTask.SetCredentialsID(testTaskCredentialsId)
+
+	factory := TaskProtectionClientFactory{
+		Region: testRegion, Endpoint: testEndpoint, AcceptInsecureCert: testAcceptInsecureCert,
 	}
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockState := mock_dockerstate.NewMockTaskEngineState(ctrl)
+	mockManager := mock_credentials.NewMockManager(ctrl)
 	mockState.EXPECT().TaskARNByV3EndpointID(gomock.Eq(testV3EndpointId)).Return(testTaskArn, true)
 	mockState.EXPECT().TaskByArn(gomock.Eq(testTaskArn)).Return(&testTask, true)
+	mockManager.EXPECT().GetTaskCredentials(gomock.Eq(testTaskCredentialsId)).Return(credentials.TaskIAMRoleCredentials{}, false)
 
-	testGetTaskProtectionHandler(t, mockState, testV3EndpointId, "Ok", http.StatusOK)
+	testGetTaskProtectionHandler(t, mockState, testV3EndpointId, mockManager, factory,
+		"invalid Request: no task IAM role credentials available for task", http.StatusBadRequest)
+}
+
+// TestGetTaskProtectionHandler_PostCall tests GetTaskProtection handler's
+// behavior when request successfully reached ECS and get response
+func TestGetTaskProtectionHandler_PostCall(t *testing.T) {
+	testCases := []struct {
+		name               string
+		ecsError           error
+		ecsResponse        *ecs.GetTaskProtectionOutput
+		expectedResponse   interface{}
+		expectedStatusCode int
+		time               time.Time
+	}{
+		{
+			name:               "ServerException",
+			ecsError:           awserr.New(ecs.ErrCodeServerException, "error message", nil),
+			ecsResponse:        &ecs.GetTaskProtectionOutput{},
+			expectedResponse:   "ServerException: error message",
+			expectedStatusCode: http.StatusInternalServerError,
+		},
+		{
+			name:               "OtherExceptions",
+			ecsError:           awserr.New(ecs.ErrCodeAccessDeniedException, "error message", nil),
+			ecsResponse:        &ecs.GetTaskProtectionOutput{},
+			expectedResponse:   "AccessDeniedException: error message",
+			expectedStatusCode: http.StatusBadRequest,
+		},
+		{
+			name:     "Failure",
+			ecsError: nil,
+			ecsResponse: &ecs.GetTaskProtectionOutput{
+				Failures: []*ecs.Failure{{
+					Arn:    aws.String(testTaskArn),
+					Reason: aws.String("Failure Reason"),
+				}},
+				ProtectedTasks: []*ecs.ProtectedTask{},
+			},
+			expectedResponse: ecs.Failure{
+				Arn:    aws.String(testTaskArn),
+				Reason: aws.String("Failure Reason"),
+			},
+			expectedStatusCode: http.StatusBadRequest,
+		},
+		{
+			name:     "SuccessProtected",
+			ecsError: nil,
+			ecsResponse: &ecs.GetTaskProtectionOutput{
+				Failures: []*ecs.Failure{},
+				ProtectedTasks: []*ecs.ProtectedTask{{
+					ProtectionEnabled: aws.Bool(true),
+					ExpirationDate:    aws.Time(time.UnixMilli(0)),
+					TaskArn:           aws.String(testTaskArn),
+				}},
+			},
+			expectedResponse: ecs.ProtectedTask{
+				ProtectionEnabled: aws.Bool(true),
+				ExpirationDate:    aws.Time(time.UnixMilli(0)),
+				TaskArn:           aws.String(testTaskArn),
+			},
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:     "SuccessNotProtected",
+			ecsError: nil,
+			ecsResponse: &ecs.GetTaskProtectionOutput{
+				Failures: []*ecs.Failure{},
+				ProtectedTasks: []*ecs.ProtectedTask{{
+					ProtectionEnabled: aws.Bool(true),
+					ExpirationDate:    aws.Time(time.UnixMilli(0)),
+					TaskArn:           aws.String(testTaskArn),
+				}},
+			},
+			expectedResponse: ecs.ProtectedTask{
+				ProtectionEnabled: aws.Bool(true),
+				ExpirationDate:    aws.Time(time.UnixMilli(0)),
+				TaskArn:           aws.String(testTaskArn),
+			},
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:     "SuccessWithNoProtectionTasks",
+			ecsError: nil,
+			ecsResponse: &ecs.GetTaskProtectionOutput{
+				Failures:       []*ecs.Failure{},
+				ProtectedTasks: []*ecs.ProtectedTask{},
+			},
+			expectedResponse: ecs.ProtectedTask{
+				ProtectionEnabled: aws.Bool(false),
+				TaskArn:           aws.String(testTaskArn),
+			},
+			expectedStatusCode: http.StatusOK,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			testTask := task.Task{
+				Arn:         testTaskArn,
+				ServiceName: testServiceName,
+			}
+			testTask.SetCredentialsID(testTaskCredentialsId)
+
+			mockState := mock_dockerstate.NewMockTaskEngineState(ctrl)
+			mockManager := mock_credentials.NewMockManager(ctrl)
+			mockFactory := NewMockTaskProtectionClientFactoryInterface(ctrl)
+			mockECSClient := mock_api.NewMockECSTaskProtectionSDK(ctrl)
+
+			mockState.EXPECT().TaskARNByV3EndpointID(gomock.Eq(testV3EndpointId)).Return(testTaskArn, true)
+			mockState.EXPECT().TaskByArn(gomock.Eq(testTaskArn)).Return(&testTask, true)
+			mockFactory.EXPECT().newTaskProtectionClient(mockManager, &testTask).Return(
+				mockECSClient, http.StatusOK, nil)
+			mockECSClient.EXPECT().GetTaskProtection(gomock.Any()).Return(tc.ecsResponse, tc.ecsError)
+
+			testGetTaskProtectionHandler(t, mockState, testV3EndpointId, mockManager, mockFactory, tc.expectedResponse, tc.expectedStatusCode)
+		})
+	}
 }

--- a/agent/handlers/agentapi/taskprotection/v1/handlers/handlers_test.go
+++ b/agent/handlers/agentapi/taskprotection/v1/handlers/handlers_test.go
@@ -199,7 +199,7 @@ func TestUpdateTaskProtectionHandlerTaskARNNotFound(t *testing.T) {
 	mockState.EXPECT().TaskARNByV3EndpointID(gomock.Eq(testV3EndpointId)).Return("", false)
 
 	testUpdateTaskProtectionHandler(t, mockState, testV3EndpointId, nil, nil, request,
-		"invalid request: no task was found",
+		"Invalid request: no task was found",
 		http.StatusBadRequest)
 }
 
@@ -215,7 +215,7 @@ func TestUpdateTaskProtectionHandlerTaskNotFound(t *testing.T) {
 	mockState.EXPECT().TaskByArn(gomock.Eq(testTaskArn)).Return(nil, false)
 
 	testUpdateTaskProtectionHandler(t, mockState, testV3EndpointId, nil, nil, request,
-		"failed to find a task for the request",
+		"Failed to find a task for the request",
 		http.StatusInternalServerError)
 }
 
@@ -245,7 +245,7 @@ func TestUpdateTaskProtectionHandlerTaskRoleCredentialsNotFound(t *testing.T) {
 	mockManager.EXPECT().GetTaskCredentials(gomock.Eq(testTaskCredentialsId)).Return(credentials.TaskIAMRoleCredentials{}, false)
 
 	testUpdateTaskProtectionHandler(t, mockState, testV3EndpointId, mockManager, factory, request,
-		"invalid Request: no task IAM role credentials available for task", http.StatusBadRequest)
+		"Invalid Request: no task IAM role credentials available for task", http.StatusBadRequest)
 }
 
 // TestUpdateTaskProtectionHandler_PostCall tests UpdateTaskProtection handler's
@@ -372,7 +372,7 @@ func TestGetTaskProtectionHandlerTaskARNNotFound(t *testing.T) {
 	mockState.EXPECT().TaskARNByV3EndpointID(gomock.Eq(testV3EndpointId)).Return("", false)
 
 	testGetTaskProtectionHandler(t, mockState, testV3EndpointId, nil, nil,
-		"invalid request: no task was found",
+		"Invalid request: no task was found",
 		http.StatusBadRequest)
 }
 
@@ -386,7 +386,7 @@ func TestGetTaskProtectionHandlerTaskNotFound(t *testing.T) {
 	mockState.EXPECT().TaskByArn(gomock.Eq(testTaskArn)).Return(nil, false)
 
 	testGetTaskProtectionHandler(t, mockState, testV3EndpointId, nil, nil,
-		"failed to find a task for the request",
+		"Failed to find a task for the request",
 		http.StatusInternalServerError)
 }
 
@@ -412,7 +412,7 @@ func TestGetTaskProtectionHandlerTaskRoleCredentialsNotFound(t *testing.T) {
 	mockManager.EXPECT().GetTaskCredentials(gomock.Eq(testTaskCredentialsId)).Return(credentials.TaskIAMRoleCredentials{}, false)
 
 	testGetTaskProtectionHandler(t, mockState, testV3EndpointId, mockManager, factory,
-		"invalid Request: no task IAM role credentials available for task", http.StatusBadRequest)
+		"Invalid Request: no task IAM role credentials available for task", http.StatusBadRequest)
 }
 
 // TestGetTaskProtectionHandler_PostCall tests GetTaskProtection handler's

--- a/agent/handlers/task_server_setup.go
+++ b/agent/handlers/task_server_setup.go
@@ -173,7 +173,7 @@ func agentAPIV1HandlersSetup(muxRouter *mux.Router, state dockerstate.TaskEngine
 	muxRouter.
 		HandleFunc(
 			agentAPITaskProtectionV1.TaskProtectionPath(),
-			agentAPITaskProtectionV1.GetTaskProtectionHandler(state, credentialsManager, cluster, region)).
+			agentAPITaskProtectionV1.GetTaskProtectionHandler(state, credentialsManager, factory, cluster)).
 		Methods("GET")
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Implement UpdateTaskProtection Call.

### Implementation details
<!-- How are the changes implemented? -->
Use ECS Task Protection Client created in https://github.com/aws/amazon-ecs-agent/pull/3397 to call ECS API.
(This PR is based on https://github.com/aws/amazon-ecs-agent/pull/3397, and diff will look different when that PR is merged)

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> Yes.

Manual Tests:
* IAM Role doesn't have proper access (Control Plane validation fails) - other Control Plane validations and Agent validations are similar to tests done in https://github.com/aws/amazon-ecs-agent/pull/3397, skipping those.
    * Command
        ```
        curl $ECS_AGENT_URI/task-protection/v1/state -v
        ```
    * Result
        ```
        *   Trying 169.254.170.2:80...
        * Connected to 169.254.170.2 (169.254.170.2) port 80 (#0)
        > GET /api/dd09c1a0-46b2-438a-b852-9725501d4f9b/task-protection/v1/state HTTP/1.1
        > Host: 169.254.170.2
        > User-Agent: curl/7.81.0
        > Accept: */*
        >
        * Mark bundle as not supporting multiuse
        < HTTP/1.1 400 Bad Request
        < Content-Type: application/json
        < X-Rate-Limit-Duration: 1
        < X-Rate-Limit-Limit: 40
        < X-Rate-Limit-Request-Forwarded-For:
        < X-Rate-Limit-Request-Remote-Addr: 172.17.0.2:50178
        < Date: Thu, 22 Sep 2022 18:42:51 GMT
        < Content-Length: 339
        <
        * Connection #0 to host 169.254.170.2 left intact
        "AccessDeniedException: User: arn:aws:sts::922673882694:assumed-role/ecsTaskRole/005f35b294fd48a29d74c660bffe7d30 is not authorized to perform: ecs:GetTaskProtection on resource: arn:aws:ecs:us-west-2:922673882694:task/gamma-default/005f35b294fd48a29d74c660bffe7d30 because no identity-based policy allows the ecs:GetTaskProtection action"
        ```
    * Log
        ```
        level=debug time=2022-09-22T18:42:20Z msg="Handling http requestmethodGETfrom172.17.0.2:42612" module=logging_handler.go
        level=info time=2022-09-22T18:42:20Z msg="GetTaskProtection endpoint was called" cluster="gamma-default" taskARN="arn:aws:ecs:us-west-2:922673882694:task/gamma-default/005f35b294fd48a29d74c660bffe7d30"
        level=debug time=2022-09-22T18:42:20Z msg="getTaskProtection response:" TaskProtection=[] error="AccessDeniedException: User: arn:aws:sts::922673882694:assumed-role/ecsTaskRole/005f35b294fd48a29d74c660bffe7d30 is not authorized to perform: ecs:GetTaskProtection on resource: arn:aws:ecs:us-west-2:922673882694:task/gamma-default/005f35b294fd48a29d74c660bffe7d30 because no identity-based policy allows the ecs:GetTaskProtection action" reason=[]
        level=info time=2022-09-22T18:42:20Z msg="ECS throws an exception with type AccessDeniedException"
        level=error time=2022-09-22T18:42:20Z msg="HTTP response status code is '400', request type is: api/GetTaskProtection/v1, and response in JSON is \"AccessDeniedException: User: arn:aws:sts::922673882694:assumed-role/ecsTaskRole/005f35b294fd48a29d74c660bffe7d30 is not authorized to perform: ecs:GetTaskProtection on resource: arn:aws:ecs:us-west-2:922673882694:task/gamma-default/005f35b294fd48a29d74c660bffe7d30 because no identity-based policy allows the ecs:GetTaskProtection action\"" module=helpers.go
        ```
* Happy Case: Task is protected
    * Command
        ```
        /home # curl -X PUT $ECS_AGENT_URI/task-protection/v1/state -d '{"ProtectionEnabled": true, "ExpiresInMinutes": 5}' -v
        /home # curl $ECS_AGENT_URI/task-protection/v1/state -v
        ```
    * Result
        ```
        *   Trying 169.254.170.2:80...
        * Connected to 169.254.170.2 (169.254.170.2) port 80 (#0)
        > GET /api/dd09c1a0-46b2-438a-b852-9725501d4f9b/task-protection/v1/state HTTP/1.1
        > Host: 169.254.170.2
        > User-Agent: curl/7.81.0
        > Accept: */*
        >
        * Mark bundle as not supporting multiuse
        < HTTP/1.1 200 OK
        < Content-Type: application/json
        < X-Rate-Limit-Duration: 1
        < X-Rate-Limit-Limit: 40
        < X-Rate-Limit-Request-Forwarded-For:
        < X-Rate-Limit-Request-Remote-Addr: 172.17.0.2:38622
        < Date: Thu, 22 Sep 2022 18:50:36 GMT
        < Content-Length: 151
        <
        * Connection #0 to host 169.254.170.2 left intact
        {"ExpirationDate":"2022-09-22T18:55:30Z","ProtectionEnabled":true,"TaskArn":"arn:aws:ecs:us-west-2:922673882694:task/005f35b294fd48a29d74c660bffe7d30"}
        ```
    * Log
        ```
        level=debug time=2022-09-22T18:50:36Z msg="Handling http requestmethodGETfrom172.17.0.2:38622" module=logging_handler.go
        level=info time=2022-09-22T18:50:36Z msg="GetTaskProtection endpoint was called" cluster="gamma-default" taskARN="arn:aws:ecs:us-west-2:922673882694:task/gamma-default/005f35b294fd48a29d74c660bffe7d30"
        level=debug time=2022-09-22T18:50:36Z msg="getTaskProtection response:" TaskProtection=[{
        ExpirationDate: 2022-09-22 18:55:30 +0000 UTC,
        ProtectionEnabled: true,
        TaskArn: "arn:aws:ecs:us-west-2:922673882694:task/005f35b294fd48a29d74c660bffe7d30"
        }] error=<nil> reason=[]
        ```
* Happy Case: Task is not protected
    * Command
        ```
        /home #  curl $ECS_AGENT_URI/task-protection/v1/state -v
        ```
    * Result
        ```
        *   Trying 169.254.170.2:80...
        * Connected to 169.254.170.2 (169.254.170.2) port 80 (#0)
        > GET /api/dd09c1a0-46b2-438a-b852-9725501d4f9b/task-protection/v1/state HTTP/1.1
        > Host: 169.254.170.2
        > User-Agent: curl/7.81.0
        > Accept: */*
        >
        * Mark bundle as not supporting multiuse
        < HTTP/1.1 200 OK
        < Content-Type: application/json
        < X-Rate-Limit-Duration: 1
        < X-Rate-Limit-Limit: 40
        < X-Rate-Limit-Request-Forwarded-For:
        < X-Rate-Limit-Request-Remote-Addr: 172.17.0.2:35818
        < Date: Thu, 22 Sep 2022 19:05:00 GMT
        < Content-Length: 134
        <
        * Connection #0 to host 169.254.170.2 left intact
        {"ExpirationDate":null,"ProtectionEnabled":false,"TaskArn":"arn:aws:ecs:us-west-2:922673882694:task/005f35b294fd48a29d74c660bffe7d30"}
        ```
    * Log - Protection is not enabled.
        ```
        level=info time=2022-09-22T19:13:56Z msg="GetTaskProtection endpoint was called" cluster="gamma-default" taskARN="arn:aws:ecs:us-west-2:922673882694:task/gamma-default/196f9acd78f94ae0911832c905fa0f85"
        level=debug time=2022-09-22T19:13:56Z msg="getTaskProtection response:" TaskProtection=[{
        ProtectionEnabled: false,
        TaskArn: "arn:aws:ecs:us-west-2:922673882694:task/196f9acd78f94ae0911832c905fa0f85"
        }] error=<nil> reason=[]
        ```
    * ~~Log - Protection is never set, or is unset by customer using UpdateTaskProtection API.~~
        ```
        level=info time=2022-09-22T19:10:04Z msg="GetTaskProtection endpoint was called" cluster="gamma-default" taskARN="arn:aws:ecs:us-west-2:922673882694:task/gamma-default/196f9acd78f94ae0911832c905fa0f85"
        level=debug time=2022-09-22T19:10:04Z msg="getTaskProtection response:" TaskProtection=[] error=<nil> reason=[]
        ```
    * ~~Log - Protection is expired.~~
        ```
        level=info time=2022-09-22T19:13:56Z msg="GetTaskProtection endpoint was called" cluster="gamma-default" taskARN="arn:aws:ecs:us-west-2:922673882694:task/gamma-default/196f9acd78f94ae0911832c905fa0f85"
        level=debug time=2022-09-22T19:13:56Z msg="getTaskProtection response:" TaskProtection=[{
        ProtectionEnabled: false,
        TaskArn: "arn:aws:ecs:us-west-2:922673882694:task/196f9acd78f94ae0911832c905fa0f85"
        }] error=<nil> reason=[]
        ```

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Implement GetTaskProtection Call

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
