### PR TITLE
Add string method to TaskProtection type

### DIFF
--- a/agent/handlers/agentapi/taskprotection/v1/types/types.go
+++ b/agent/handlers/agentapi/taskprotection/v1/types/types.go
@@ -64,7 +64,7 @@ func (taskProtection *taskProtection) GetExpiresInMinutes() *int {
 func (taskProtection *taskProtection) String() string {
 	jsonBytes, err := taskProtection.MarshalJSON()
 	if err != nil {
-		return fmt.Sprintf("failed to get String representation of taskProtection type: %v", err)
+		return fmt.Sprintf("failed to get string representation of taskProtection type: %v", err)
 	}
 	return string(jsonBytes)
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
`TaskProtection` type is missing a `String` method which makes logs including it appear weird because by default the memory address of `expiresInMinutes` field is printed by Go. Fixing this by adding a dedicated `String` method to `TaskProtection`. 

### Implementation details
The implementation relies on JSON marshaling of `TaskProtection` type so that new fields are supported automatically. 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Created some instances of the `TaskProtection` struct and printed them with `fmt.Printf`. Outputs shown below.
```
{"ProtectionEnabled":true,"ExpiresInMinutes":null}
{"ProtectionEnabled":false,"ExpiresInMinutes":null}
{"ProtectionEnabled":true,"ExpiresInMinutes":3}
```

New tests cover the changes: <!-- yes|no --> no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Add String method to TaskProtection type.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
