### PR TITLE
Write AppNet logs to /var/log/ecs/ if no logging driver configured

### DIFF
--- a/agent/engine/serviceconnect/manager_linux_test_common.go
+++ b/agent/engine/serviceconnect/manager_linux_test_common.go
@@ -128,6 +128,7 @@ func testAgentContainerModificationsForServiceConnect(t *testing.T, privilegedMo
 	expectedBinds := []string{
 		fmt.Sprintf("%s/status/%s:%s", tempDir, scTask.GetID(), "/some/other/run"),
 		fmt.Sprintf("%s/relay:%s", tempDir, "/not/var/run"),
+		fmt.Sprintf("%s/log/%s:%s", tempDir, scTask.GetID(), "/some/other/log"),
 	}
 	expectedENVs := map[string]string{
 		"ReLaYgOeShErE":                 "unix:///not/var/run/relay_file_of_holiness",
@@ -135,6 +136,7 @@ func testAgentContainerModificationsForServiceConnect(t *testing.T, privilegedMo
 		"APPNET_AGENT_ADMIN_MODE":       "uds",
 		"ENVOY_ENABLE_IAM_AUTH_FOR_XDS": "0",
 		"ECS_CONTAINER_INSTANCE_ARN":    "fake_container_instance",
+		"APPNET_ENVOY_LOG_DESTINATION":  "/some/other/log",
 	}
 
 	type testCase struct {
@@ -177,6 +179,8 @@ func testAgentContainerModificationsForServiceConnect(t *testing.T, privilegedMo
 		AgentContainerTag:       "tag",
 
 		containerInstanceARN: "fake_container_instance",
+		logPathContainer:     "/some/other/log",
+		logPathHostRoot:      filepath.Join(tempDir, "log"),
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Write AppNet logs to host `/var/log/ecs/service_connect/` if no logging driver configured, for visibility and troubleshooting purposes.

That will always be the case for AppNet Relay container as they are not configurable by customer.

For AppNet Agent container, customer may set up logging driver within `ServiceConnectConfiguration` when creating or updating a service. If none specified, we then let AppNet write the logs to file. 

### Implementation details
<!-- How are the changes implemented? -->
We first check if a logging driver is present for AppNet relay/agent.

 If logging driver is unspecified, we will pass `APPNET_ENVOY_LOG_DESTINATION` ENV and use `/var/log/` (the container path) for both Relay and Agent containers.

We then create host directories `/var/log/ecs/service_connect/relay/` and `/var/log/ecs/service_connect/$task-id` for Relay and Agent respectively, as well as bind mounts to their container `/var/log/` path. 

We do NOT specify following log configurations, but rather use AppNet default values:
- log file name (`appnet_envoy.log`)
- max log file size (1Mb)
- retention count (5) 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

* added unit test
* ran e2e test and verified 
  *  when no logging driver specified, local log files are created at the correct locations for both relay and agent
  * when logging driver is configured for appnet agent, it's no longer writing to file on disk, and relay still is. Also checked that appnet agent log is streamed to cloudwatch (I tested with awslogs driver)

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Write AppNet logs to /var/log/ecs/ if no logging driver configured

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
