### PR TITLE
Explicitly set ENVOY_ADMIN_MODE for AppNet Relay

### DIFF
--- a/agent/engine/serviceconnect/manager_linux.go
+++ b/agent/engine/serviceconnect/manager_linux.go
@@ -61,6 +61,8 @@ const (
 	agentAuthOff   = "0"
 	agentModeENV   = "APPNET_AGENT_ADMIN_MODE"
 	agentModeValue = "uds"
+	envoyModeENV   = "ENVOY_ADMIN_MODE"
+	envoyModeValue = "uds"
 
 	containerInstanceArnENV = "ECS_CONTAINER_INSTANCE_ARN"
 
@@ -222,6 +224,7 @@ func (m *manager) initRelayEnvironment(config *config.Config, container *apicont
 		upstreamENV:    filepath.Join(m.relayPathContainer, m.relayFileName),
 		regionENV:      config.AWSRegion,
 		agentModeENV:   agentModeValue,
+		envoyModeENV:   envoyModeValue,
 		relayEnableENV: relayEnableOn,
 		m.endpointENV:  endpoint,
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
AppNet requested that we now explicitly set `ENVOY_ADMIN_MODE` Env variable to `uds` (they used to assume it from `APPNET_AGENT_ADMIN_MODE` Env) 

For AppNet Agent container, the Env will come down as part of container definition. But for Relay we need to add it explicitly.




### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> no

`make test`

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Explicitly set ENVOY_ADMIN_MODE for AppNet Relay

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
