### PR TITLE
Update debian recipe to use system golang version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,9 @@ all: docker
 gobuild:
 	./scripts/build false
 
+gobuild-init-deb:
+	./scripts/gobuild.sh debian
+
 # create output directories
 .out-stamp:
 	mkdir -p ./out/test-artifacts ./out/cni-plugins ./out/amazon-ecs-cni-plugins ./out/amazon-vpc-cni-plugins
@@ -338,6 +341,10 @@ goimports:
 	goimports -w $(GOFMTFILES)
 
 GOPATH=$(shell go env GOPATH)
+
+install-golang:
+	./scripts/install-golang.sh
+
 .get-deps-stamp:
 	go get golang.org/x/tools/cmd/cover
 	go get github.com/golang/mock/mockgen
@@ -396,8 +403,8 @@ VERSION = $(shell cat ecs-init/ECSVERSION)
 	mkdir -p BUILDROOT
 	./scripts/update-version.sh
 	tar -czf ./amazon-ecs-init_${VERSION}.orig.tar.gz ecs-init scripts README.md
-	cp -r packaging/generic-deb-integrated/debian ecs-init scripts misc agent agent-container amazon-ecs-cni-plugins amazon-vpc-cni-plugins README.md VERSION BUILDROOT
-	cd BUILDROOT && debuild -uc -us --lintian-opts --suppress-tags bad-distribution-in-changes-file,file-in-unusual-dir
+	cp -r packaging/generic-deb-integrated/debian Makefile ecs-init scripts misc agent agent-container amazon-ecs-cni-plugins amazon-vpc-cni-plugins README.md VERSION GO_VERSION BUILDROOT
+	cd BUILDROOT && dpkg-buildpackage -uc -b
 	touch .generic-deb-integrated-done
 
 generic-deb-integrated: .generic-deb-integrated-done
@@ -481,7 +488,7 @@ clean:
 	-rm -rf ./BUILDROOT BUILD RPMS SRPMS SOURCES SPECS
 	-rm -rf ./x86_64
 	-rm -f ./amazon-ecs-init_${VERSION}*
-	-rm -f .srpm-done .rpm-done .generic-rpm-done
+	-rm -f .srpm-done .rpm-done .generic-rpm-done .generic-deb-integrated-done
 	-rm -f .deb-done
 	-rm -f .amazon-linux-rpm-integrated-done
 	-rm -f .generic-rpm-integrated-done

--- a/buildspecs/merge-build-ubuntu.yml
+++ b/buildspecs/merge-build-ubuntu.yml
@@ -35,7 +35,6 @@ phases:
       - GITHUBUSERNAME=$(ls)
       - mkdir -p src/github.com/
       - mv $GITHUBUSERNAME src/github.com/aws
-      - export GOPATH=$GOPATH:$(pwd)
       - cd src/github.com/aws/amazon-ecs-agent
 
       # Build agent tars
@@ -43,9 +42,7 @@ phases:
       - DEBIAN_FRONTEND=noninteractive
 
       - apt-get update -y
-      - apt-get install -y make dpkg-dev devscripts debhelper golang
-      - which go
-      - go version
+      - apt-get install -y make dpkg-dev devscripts debhelper
       - make generic-deb-integrated
       - mv amazon-ecs-init_${AGENT_VERSION}-1_${architecture}.deb $ECS_AGENT_DEB
 

--- a/buildspecs/pr-build-ubuntu.yml
+++ b/buildspecs/pr-build-ubuntu.yml
@@ -31,7 +31,6 @@ phases:
 
       # Path readjustment for codebuild testing with fork and setting GOPATH appropriately
       - cd ../../../..
-      - export GOPATH=$GOPATH:$(pwd)
       - cd src/github.com
       - |
         if [[ $GITHUBUSERNAME != "aws" ]] ; then
@@ -44,9 +43,7 @@ phases:
       - DEBIAN_FRONTEND=noninteractive
         
       - apt-get update -y | tee -a $BUILD_LOG
-      - apt-get install -y make dpkg-dev devscripts debhelper golang | tee -a $BUILD_LOG
-      - which go
-      - go version
+      - apt-get install -y make dpkg-dev wget devscripts debhelper | tee -a $BUILD_LOG
       - make generic-deb-integrated 2>&1 | tee -a $BUILD_LOG
       - ls | tee -a $BUILD_LOG
 

--- a/packaging/generic-deb-integrated/debian/control
+++ b/packaging/generic-deb-integrated/debian/control
@@ -2,7 +2,7 @@ Source: amazon-ecs-init
 Section: misc
 Priority: optional
 Maintainer: ecs-agent-dev <ecs-agent-dev@amazon.com>
-Build-Depends: debhelper (>= 9.20160709~), golang-go (>= 1.7)
+Build-Depends: debhelper (>= 9.20160709~), wget, ca-certificates
 Standards-Version: 4.3.0
 Homepage: https://aws.amazon.com/ecs
 Vcs-Git: git://github.com/aws/amazon-ecs-agent.git

--- a/packaging/generic-deb-integrated/debian/rules
+++ b/packaging/generic-deb-integrated/debian/rules
@@ -11,20 +11,16 @@ export DH_VERBOSE=1
 %:
 	dh $@
 
+override_dh_auto_clean:
+override_dh_auto_test:
 override_dh_auto_build:
-	./scripts/get-host-certs
-	./scripts/build-cni-plugins
-	./scripts/build-integrated true "" false true
-	./scripts/build-agent-image
-	./scripts/gobuild.sh debian
-
-clean:
-	dh $@
-	rm -f amazon-ecs-init
-
 override_dh_auto_install:
+	make dockerfree-agent-image
+	make gobuild-init-deb
 	cp ./ecs-agent-v${AGENT_VERSION}.tar debian/amazon-ecs-init/var/cache/ecs/ecs-agent-v${VERSION}.tar
 	echo "2" >debian/amazon-ecs-init/var/cache/ecs/state
 	ln -s "/var/cache/ecs/ecs-agent-v${VERSION}.tar" debian/amazon-ecs-init/var/cache/ecs/ecs-agent.tar
 	dh_installsystemd --no-start --no-enable --name=ecs
 	dh_installsystemd --no-start --no-enable --name=amazon-ecs-volume-plugin
+override_dh_gencontrol:
+	dh_gencontrol -- -v$(VERSION)

--- a/packaging/generic-deb-integrated/debian/source/options
+++ b/packaging/generic-deb-integrated/debian/source/options
@@ -1,4 +1,0 @@
-# Automatically add upstream changes to the quilt overlay.
-# http://manpages.ubuntu.com/manpages/trusty/man1/dpkg-source.1.html
-# This supports reusing the orig.tar.gz for debian increments.
-auto-commit

--- a/scripts/build
+++ b/scripts/build
@@ -35,22 +35,40 @@ PAUSE_CONTAINER_TARBALL="amazon-ecs-pause.tar"
 ROOT=$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )
 cd "${ROOT}"
 
+# we need to make sure we've got the correct golang version installed
+# if it's already installed the script will set env vars and exit
+source ./scripts/install-golang.sh
+
 # Set TARGET_OS from GOOS if it is not set
 if [[ "${TARGET_OS}" == "" && "${GOOS}" != "" ]]; then
-  TARGET_OS="${GOOS}"
+    TARGET_OS="${GOOS}"
 fi
 
+# setup temporary build directory
+export TOPWD="$(pwd)"
+export BUILDDIR="$(mktemp -d)"
+export GOPATH="${BUILDDIR}"
+export SRCPATH="${BUILDDIR}/src/github.com/aws"
+mkdir -p "${SRCPATH}"
+
+# create a gopath-friendly symlink to the BUILDROOT
+# codebuild's path is TOPWD=/codebuild/output/src381519807/src/github.com/aws/amazon-ecs-agent/BUILDROOT
+cd "${SRCPATH}"
+ln -s "${TOPWD}" "amazon-ecs-agent"
+
+# run build from our temporary linked srcpath
+cd ${SRCPATH}/amazon-ecs-agent
 if [[ "${version_gen}" == "true" ]]; then
-    # Versioning stuff. We run the generator to setup the version and then always
-    # restore ourselves to a clean state
+    # We run the generator to setup the version and then always restore ourselves to a clean state
     cp agent/version/version.go agent/version/_version.go
     trap "cd \"${ROOT}\"; mv agent/version/_version.go agent/version/version.go" EXIT SIGHUP SIGINT SIGTERM
 
-  cd ./agent/version/
-  # Turn off go module here because version-gen.go is a separate program (i.e. "package main")
-  # and no dependency needed to be fetched (but if go mod is on it will try to fetch dependency causing
-  # this script to fail when we run it in a container with network mode "none").
-  GO111MODULE=off go run gen/version-gen.go
+    cd ./agent/version/
+    # Turn off go module here because version-gen.go is a separate program (i.e. "package main")
+    # and no dependency needed to be fetched (but if go mod is on it will try to fetch dependency causing
+    # this script to fail when we run it in a container with network mode "none").
+    echo "running version gen"
+    GO111MODULE=off go run gen/version-gen.go
 fi
 
 if [[ "${with_pause}" == "true" ]]; then
@@ -59,21 +77,25 @@ fi
 
 if [ "${TARGET_OS}" == "windows" ]; then
     unset static
-    build_exe="out/amazon-ecs-agent.exe"
+    build_artifact="out/amazon-ecs-agent.exe"
     export GOOS=windows
 else
-    build_exe="out/amazon-ecs-agent"
+    build_artifact="out/amazon-ecs-agent"
 fi
 
-cd "${ROOT}"
+# run build from our temporary linked srcpath
+cd ${SRCPATH}/amazon-ecs-agent
 if [[ "${TARGET_OS}" == "windows" ]]; then
-    go build -ldflags "${LDFLAGS} -s" -o $build_exe ./agent/
+    go build -ldflags "${LDFLAGS} -s" -o $build_artifact ./agent/
 elif [[ "${static}" == "true" ]]; then
-    GO111MODULE=auto CGO_ENABLED=0 go build -installsuffix cgo -a -ldflags "${LDFLAGS} -s" -o $build_exe ./agent/
+    GO111MODULE=auto CGO_ENABLED=0 go build -installsuffix cgo -a -ldflags "${LDFLAGS} -s" -o $build_artifact ./agent/
 else
-    GO111MODULE=auto go build -o $build_exe ./agent/
+    GO111MODULE=auto go build -o $build_artifact ./agent/
 fi
 
 if [[ -n "${output_directory}" ]]; then
-    mv $build_exe "${output_directory}"
+    mv $build_artifact "${output_directory}"
 fi
+
+# finally, we'll clean up builddir
+rm -r "${BUILDDIR}"

--- a/scripts/build-cni-plugins
+++ b/scripts/build-cni-plugins
@@ -37,11 +37,15 @@ esac
 if [ "$architecture" == "amd64" ]; then export GOARCH=amd64; fi
 if [ "$architecture" == "arm64" ]; then export GOARCH=arm64; fi
 
-goversion=`go version | cut -d' ' -f3 | cut -c 3-`
-
 # this script assumes we've run the get-cni-sources make target to update the cni submodules
 ROOT=$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )
 cd "${ROOT}"
+
+# we need to make sure we've got the correct golang version installed
+# if it's already installed the script will set env vars and exit
+source ./scripts/install-golang.sh
+
+goversion=`go version | cut -d' ' -f3 | cut -c 3-`
 
 export BUILDDIR="$(mktemp -d)"
 export GITPATH="${BUILDDIR}/src/github.com/aws"

--- a/scripts/gobuild.sh
+++ b/scripts/gobuild.sh
@@ -20,6 +20,10 @@ export SRCPATH="${BUILDDIR}/src/github.com/aws/amazon-ecs-agent"
 export GOPATH="${TOPWD}:${BUILDDIR}"
 export GO111MODULE="auto"
 
+# we need to make sure we've got the correct golang version installed
+# if it's already installed the script will set env vars and exit
+source ./scripts/install-golang.sh
+
 if [ -d "${TOPWD}/.git" ]; then
     version=$(cat "${TOPWD}/ecs-init/ECSVERSION")
     git_hash=$(git rev-parse --short=8 HEAD)

--- a/scripts/install-golang.sh
+++ b/scripts/install-golang.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the
+# "License"). You may not use this file except in compliance
+#  with the License. A copy of the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+
+architecture=""
+case $(uname -m) in
+    x86_64)
+        architecture="amd64"
+        ;;
+    arm64)
+        architecture="arm64"
+        ;;
+    aarch64)
+        architecture="arm64"
+        ;;
+    *)
+        echo $"Unknown architecture $0"
+        exit 1
+esac
+
+if [ "$architecture" == "amd64" ]; then export GOARCH=amd64; fi
+if [ "$architecture" == "arm64" ]; then export GOARCH=arm64; fi
+
+# if golang isn't installed then we'll install it
+go_bin_path="none"
+if which go; then
+    export go_bin_path=$(which go)
+fi
+if [ $go_bin_path == "/usr/bin/go" ]; then
+    # rpm installs golang to the go_bin_path
+    echo "golang exists on /usr/bin/go, using system golang version"
+elif [ ${go_bin_path:0:10} == "/usr/local" ]; then
+    # using existing installed golang; re-export path to be sure it's there
+    export GOROOT=/usr/local/go
+    export PATH=$PATH:$GOROOT/bin
+    echo "$GOROOT exists. Using installed golang version"
+else
+    # install golang defined in GO_VERSION file
+    echo "$GOROOT doesn't exist, installing $(cat ./GO_VERSION)"
+    GO_VERSION=$(cat ./GO_VERSION)
+    tmpdir=$(mktemp -d)
+    GOLANG_TAR="go${GO_VERSION}.linux-${GOARCH}.tar.gz"
+    wget -O ${tmpdir}/${GOLANG_TAR} https://storage.googleapis.com/golang/${GOLANG_TAR}
+    # only use sudo if it's available
+    if ! sudo true; then
+        tar -C /usr/local -xzf ${tmpdir}/${GOLANG_TAR}
+    else
+	sudo tar -C /usr/local -xzf ${tmpdir}/${GOLANG_TAR}
+    fi
+    export GOROOT=/usr/local/go
+    export PATH=$PATH:$GOROOT/bin
+    # confirm installation
+    which go
+    go version
+fi


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This updates the static build process to use the golang version specified in GO_VERSION.  It also updates the Debian repo build process to use the Makefile targets and skip the extra linting and internal change tracking.

### Implementation details
For the Debian builds, the main changes are to use `dpkg-buildpackage` rather than `debuild` (the latter calls the former but adds a bunch of extra steps that we don't need).  It also removes the dependency on Debian-managed golang and updates the build targets to prefer either the pre-existing system golang installed at `/usr/local/go` or else install the GO_VERSION via wget and use that.  This allows our builds to work with the latest golang version (currently 1.19.1).

This also updates our builds to use a symlinked tmpdir as our buildroot and sets our GOPATH to temp buildroot to override any issues with build systems that build in non-standard paths (like our CodeBuild environment).

### Testing
Built locally using all Make targets on Ubuntu 20.04.4 and also built via CodeBuild (see github action tests below).

New tests cover the changes: no

### Description for the changelog
Update static build golang version and refine Debian builds. 

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
