### PR TITLE
Update service connect config validator

### DIFF
--- a/agent/api/serviceconnect/service_connect_validator_test.go
+++ b/agent/api/serviceconnect/service_connect_validator_test.go
@@ -253,25 +253,16 @@ func TestValidateServiceConnectConfigWithEmptyConfig(t *testing.T) {
 		testName                 string
 		testEgressConfigIsEmpty  bool
 		testIngressConfigIsEmpty bool
-		shouldError              bool
 	}{
 		{
 			testName:                 "AWSVPC default case with the empty egress config and dns config",
 			testEgressConfigIsEmpty:  true,
 			testIngressConfigIsEmpty: false,
-			shouldError:              false,
 		},
 		{
 			testName:                 "AWSVPC default case with the empty ingress config",
 			testEgressConfigIsEmpty:  false,
 			testIngressConfigIsEmpty: true,
-			shouldError:              false,
-		},
-		{
-			testName:                 "AWSVPC default case with the empty ingress config and engress config",
-			testEgressConfigIsEmpty:  true,
-			testIngressConfigIsEmpty: true,
-			shouldError:              true,
 		},
 	}
 
@@ -298,11 +289,7 @@ func TestValidateServiceConnectConfigWithEmptyConfig(t *testing.T) {
 				testIngressConfig,
 			)
 			err := ValidateServiceConnectConfig(testServiceConnectConfig, testTaskContainers, AWSVPCNetworkMode, false)
-			if tc.shouldError {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-			}
+			assert.NoError(t, err)
 		})
 	}
 }
@@ -345,24 +332,6 @@ func TestValidateServiceConnectConfigWithError(t *testing.T) {
 			testIngressConfigEntry: getTestIngressConfigEntry(AWSVPCNetworkMode, testInboundListenerName, false, uint16(0), testAwsVpcDefaultInterceptPort, aws.Uint16(0)),
 		},
 		{
-			testName:               "AWSVPC default case with no IPv4 CIDR in the egress config when Ipv6 is not enabled",
-			testNetworkMode:        AWSVPCNetworkMode,
-			testIsIPv6Enabled:      false,
-			testContainerName:      testServiceConnectContainerName,
-			testEgressConfig:       getTestEgressConfig(testOutboundListenerName, "", ""),
-			testDnsConfigEntry:     getTestDnsConfigEntry(testHostName, testIPv4Address),
-			testIngressConfigEntry: getTestIngressConfigEntry(AWSVPCNetworkMode, testInboundListenerName, false, uint16(0), testAwsVpcDefaultInterceptPort, aws.Uint16(0)),
-		},
-		{
-			testName:               "AWSVPC default case with no IPv6 CIDR in the egress config when IPv6 is enabled",
-			testNetworkMode:        AWSVPCNetworkMode,
-			testIsIPv6Enabled:      true,
-			testContainerName:      testServiceConnectContainerName,
-			testEgressConfig:       getTestEgressConfig(testOutboundListenerName, testIPv4Cidr, ""),
-			testDnsConfigEntry:     getTestDnsConfigEntry(testHostName, testIPv6Address),
-			testIngressConfigEntry: getTestIngressConfigEntry(AWSVPCNetworkMode, testInboundListenerName, false, uint16(0), testAwsVpcDefaultInterceptPort, aws.Uint16(0)),
-		},
-		{
 			testName:               "AWSVPC override case with the invalid IPv4 CIDR in the egress config",
 			testNetworkMode:        AWSVPCNetworkMode,
 			testIsIPv6Enabled:      false,
@@ -379,15 +348,6 @@ func TestValidateServiceConnectConfigWithError(t *testing.T) {
 			testEgressConfig:       getTestEgressConfig(testOutboundListenerName, testIPv4Cidr, "999999999"),
 			testDnsConfigEntry:     getTestDnsConfigEntry(testHostName, testIPv6Address),
 			testIngressConfigEntry: getTestIngressConfigEntry(AWSVPCNetworkMode, "", true, testListenerPort, aws.Uint16(0), aws.Uint16(0)),
-		},
-		{
-			testName:               "Bridge default case with the egress config but no dns config",
-			testNetworkMode:        BridgeNetworkMode,
-			testIsIPv6Enabled:      false,
-			testContainerName:      testServiceConnectContainerName,
-			testEgressConfig:       getTestEgressConfig(testOutboundListenerName, "", testIPv6Cidr),
-			testDnsConfigEntry:     DNSConfigEntry{},
-			testIngressConfigEntry: getTestIngressConfigEntry(BridgeNetworkMode, "", false, testBridgeDefaultListenerPort, aws.Uint16(0), aws.Uint16(0)),
 		},
 		{
 			testName:               "Bridge override case with no the invalid address in dns config when IPv6 is enabled",

--- a/agent/api/task/task_attachment_handler_test.go
+++ b/agent/api/task/task_attachment_handler_test.go
@@ -115,7 +115,7 @@ func TestHandleTaskAttachmentsWithServiceConnectAttachment(t *testing.T) {
 			testName: "AWSVPC IPv6 enabled with error",
 			testServiceConnectConfig: constructTestServiceConnectConfig(
 				testIngressPort,
-				testInboundListener,
+				"",
 				testOutboundListener,
 				"",
 				testIPv6CIDR,


### PR DESCRIPTION
### Summary
As service connect config  will be validated in ECS control plane before streaming down to Agent, Agent will only validate service connect configurations when 
1. fields consumed and proceeded by ECS Agent
2. fields with a global standard, e.g. CIDR format 

### Implementation details
1. service_connect_validator.go
 *  **Main change**: remove both nil egress config and empty ingress config validation
 * **Main change**: remove non-empty IPV4CIDR validation and non-empty IPV6CIDR validation
 * **Main change**: remove DNS config must exist when egress config us not nil validation
 * Refactor error messages into constants
 * Update variable naming and format 
2. service_connect_validator_test.go
 * Remove following tests as corresponding validations are removed from service_connect_validator.go
   * "AWSVPC default case with the empty ingress config and engress config" test
   * "AWSVPC default case with no IPv4 CIDR in the egress config when Ipv6 is not enabled" test
   * "AWSVPC default case with no IPv6 CIDR in the egress config when IPv6 is enabled" test 
   * "Bridge default case with the egress config but no dns config" test
3. agent/api/task/task_attachment_handler_test.go
* Update "AWSVPC IPv6 enabled with error" test as an empty IPv4CIDR validation is removed from service_connect_validator.go 
   
### Testing
New tests cover the changes: no

### Description for the changelog
Update service connect config validator to validate fields with a global standard, or consumed and proceeded by ECS Agent

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.