### PR TITLE
Add timeout to ecs calls

### DIFF
--- a/agent/api/interface.go
+++ b/agent/api/interface.go
@@ -16,6 +16,8 @@ package api
 import (
 	"github.com/aws/amazon-ecs-agent/agent/api/serviceconnect"
 	"github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
 	prometheus "github.com/prometheus/client_model/go"
 )
 
@@ -88,5 +90,9 @@ type AppnetClient interface {
 // implements the UpdateTaskProtection and GetTaskProtection
 type ECSTaskProtectionSDK interface {
 	UpdateTaskProtection(input *ecs.UpdateTaskProtectionInput) (*ecs.UpdateTaskProtectionOutput, error)
+	UpdateTaskProtectionWithContext(ctx aws.Context, input *ecs.UpdateTaskProtectionInput,
+		opts ...request.Option) (*ecs.UpdateTaskProtectionOutput, error)
 	GetTaskProtection(input *ecs.GetTaskProtectionInput) (*ecs.GetTaskProtectionOutput, error)
+	GetTaskProtectionWithContext(ctx aws.Context, input *ecs.GetTaskProtectionInput,
+		opts ...request.Option) (*ecs.GetTaskProtectionOutput, error)
 }

--- a/agent/api/mocks/api_mocks.go
+++ b/agent/api/mocks/api_mocks.go
@@ -19,11 +19,13 @@
 package mock_api
 
 import (
+	context "context"
 	reflect "reflect"
 
 	api "github.com/aws/amazon-ecs-agent/agent/api"
 	serviceconnect "github.com/aws/amazon-ecs-agent/agent/api/serviceconnect"
 	ecs "github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
+	request "github.com/aws/aws-sdk-go/aws/request"
 	gomock "github.com/golang/mock/gomock"
 	go0 "github.com/prometheus/client_model/go"
 )
@@ -439,6 +441,26 @@ func (mr *MockECSTaskProtectionSDKMockRecorder) GetTaskProtection(arg0 interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTaskProtection", reflect.TypeOf((*MockECSTaskProtectionSDK)(nil).GetTaskProtection), arg0)
 }
 
+// GetTaskProtectionWithContext mocks base method
+func (m *MockECSTaskProtectionSDK) GetTaskProtectionWithContext(arg0 context.Context, arg1 *ecs.GetTaskProtectionInput, arg2 ...request.Option) (*ecs.GetTaskProtectionOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetTaskProtectionWithContext", varargs...)
+	ret0, _ := ret[0].(*ecs.GetTaskProtectionOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTaskProtectionWithContext indicates an expected call of GetTaskProtectionWithContext
+func (mr *MockECSTaskProtectionSDKMockRecorder) GetTaskProtectionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTaskProtectionWithContext", reflect.TypeOf((*MockECSTaskProtectionSDK)(nil).GetTaskProtectionWithContext), varargs...)
+}
+
 // UpdateTaskProtection mocks base method
 func (m *MockECSTaskProtectionSDK) UpdateTaskProtection(arg0 *ecs.UpdateTaskProtectionInput) (*ecs.UpdateTaskProtectionOutput, error) {
 	m.ctrl.T.Helper()
@@ -452,4 +474,24 @@ func (m *MockECSTaskProtectionSDK) UpdateTaskProtection(arg0 *ecs.UpdateTaskProt
 func (mr *MockECSTaskProtectionSDKMockRecorder) UpdateTaskProtection(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTaskProtection", reflect.TypeOf((*MockECSTaskProtectionSDK)(nil).UpdateTaskProtection), arg0)
+}
+
+// UpdateTaskProtectionWithContext mocks base method
+func (m *MockECSTaskProtectionSDK) UpdateTaskProtectionWithContext(arg0 context.Context, arg1 *ecs.UpdateTaskProtectionInput, arg2 ...request.Option) (*ecs.UpdateTaskProtectionOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "UpdateTaskProtectionWithContext", varargs...)
+	ret0, _ := ret[0].(*ecs.UpdateTaskProtectionOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateTaskProtectionWithContext indicates an expected call of UpdateTaskProtectionWithContext
+func (mr *MockECSTaskProtectionSDKMockRecorder) UpdateTaskProtectionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTaskProtectionWithContext", reflect.TypeOf((*MockECSTaskProtectionSDK)(nil).UpdateTaskProtectionWithContext), varargs...)
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Use a timeout when calling ECS SDK Task Protection functions in Agent Task Protection handlers. 

Agent TMDE server (that hosts the task protection endpoints) has a hard-coded write timeout of 5 seconds. This puts an upper bound timeout of 5 seconds on all HTTP handlers registered on the server. This means that if a handler takes longer than 5 seconds to process a request the the server will kill the customer task's connection before the handler gets a chance to write a response to it. This leads to an undesirable EOF or empty response error on customer task's end. 

ECS SDK calls that Agent Task Protection handlers make can take longer than 5 seconds for a variety of reasons such that the SDK retrying requests failed with a recoverable failure or ECS taking longer than usual to respond. 

In fact, with default ECS request throttling limits in place, Agent is able to support a request rate of 30 rps only for task protection calls because of ECS throttling the requests and the SDK performing retries. Over this request rate customer's HTTP connections start getting killed without a response. 

The change proposed in this PR restricts ECS SDK calls to take at most 4 seconds (1 second less than the server write timeout) which allows Agent to support a sustained request rate of 200rps for task protection calls with default ECS throttling limits. 

If ECS SDK calls made by the agent timeout then a HTTP 504 Gateway Timeout response is sent back to the client to notify them of Agent timing out waiting for another resource to respond (ECS in this case).

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Load tested task protection API with [vegeta](https://github.com/tsenart/vegeta) and ensured that it is able to support 200rps consistently for task protection calls without killing any connections.

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Make task protection ECS calls with a timeout of 4 seconds to make sure requests to Agent task protection endpoints finish before Agent TMDE server's write timeout of 5 seconds.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
