### PR TITLE
Cherry pick Extend the mounting and Add the CAP_CHOWN capability commit from amazon-ecs-init repo

### DIFF
--- a/ecs-init/docker/docker.go
+++ b/ecs-init/docker/docker.go
@@ -79,6 +79,11 @@ const (
 	// For more information on setns, please read this manpage:
 	// http://man7.org/linux/man-pages/man2/setns.2.html
 	CapSysAdmin = "SYS_ADMIN"
+	// CapChown to start agent with CAP_CHOWN capability
+	// This is needed for the ECS Agent to invoke the chown call when
+	// configuring the files for configuration or administration.
+	// http://man7.org/linux/man-pages/man2/chown.2.html
+	CapChown = "CAP_CHOWN"
 	// DefaultCgroupMountpoint is the default mount point for the cgroup subsystem
 	DefaultCgroupMountpoint = "/sys/fs/cgroup"
 	// pluginSocketFilesDir specifies the location of UNIX domain socket files of

--- a/ecs-init/docker/docker_config.go
+++ b/ecs-init/docker/docker_config.go
@@ -49,7 +49,7 @@ func createHostConfig(binds []string) *godocker.HostConfig {
 		// CapNetAdmin and CapSysAdmin are needed for running task in awsvpc network mode.
 		// This network mode is (at least currently) not supported in external environment,
 		// hence not adding them in that case.
-		caps = []string{CapNetAdmin, CapSysAdmin}
+		caps = []string{CapNetAdmin, CapSysAdmin, CapChown}
 	}
 
 	hostConfig := &godocker.HostConfig{

--- a/ecs-init/docker/docker_test.go
+++ b/ecs-init/docker/docker_test.go
@@ -35,7 +35,7 @@ import (
 const (
 	testTempDirPrefix = "init-docker-test-"
 
-	expectedAgentBindsUnspecifiedPlatform = 21
+	expectedAgentBindsUnspecifiedPlatform = 20
 	expectedAgentBindsSuseUbuntuPlatform  = 18
 )
 
@@ -829,21 +829,13 @@ func TestStartAgentWithExecBinds(t *testing.T) {
 	hostCapabilityExecResourcesDir := filepath.Join(hostResourcesRootDir, execCapabilityName)
 	containerCapabilityExecResourcesDir := filepath.Join(containerResourcesRootDir, execCapabilityName)
 
-	// binaries
-	hostBinDir := filepath.Join(hostCapabilityExecResourcesDir, execBinRelativePath)
-	containerBinDir := filepath.Join(containerCapabilityExecResourcesDir, execBinRelativePath)
-
 	// config
 	hostConfigDir := filepath.Join(hostCapabilityExecResourcesDir, execConfigRelativePath)
 	containerConfigDir := filepath.Join(containerCapabilityExecResourcesDir, execConfigRelativePath)
 
-	// certs
-	hostCertsDir := filepath.Join(hostCapabilityExecResourcesDir, execCertsRelativePath)
-	containerCertsDir := filepath.Join(containerCapabilityExecResourcesDir, execCertsRelativePath)
-
 	expectedExecBinds := []string{
-		hostBinDir + ":" + containerBinDir + readOnly,
-		hostCertsDir + ":" + containerCertsDir + readOnly,
+		hostResourcesRootDir + ":" + containerResourcesRootDir + readOnly,
+		hostConfigDir + ":" + containerConfigDir,
 	}
 	expectedAgentBinds += len(expectedExecBinds)
 
@@ -886,17 +878,9 @@ func TestGetCapabilityExecBinds(t *testing.T) {
 	hostCapabilityExecResourcesDir := filepath.Join(hostResourcesRootDir, execCapabilityName)
 	containerCapabilityExecResourcesDir := filepath.Join(containerResourcesRootDir, execCapabilityName)
 
-	// binaries
-	hostBinDir := filepath.Join(hostCapabilityExecResourcesDir, execBinRelativePath)
-	containerBinDir := filepath.Join(containerCapabilityExecResourcesDir, execBinRelativePath)
-
 	// config
 	hostConfigDir := filepath.Join(hostCapabilityExecResourcesDir, execConfigRelativePath)
 	containerConfigDir := filepath.Join(containerCapabilityExecResourcesDir, execConfigRelativePath)
-
-	// certs
-	hostCertsDir := filepath.Join(hostCapabilityExecResourcesDir, execCertsRelativePath)
-	containerCertsDir := filepath.Join(containerCapabilityExecResourcesDir, execCertsRelativePath)
 
 	testCases := []struct {
 		name            string
@@ -909,19 +893,17 @@ func TestGetCapabilityExecBinds(t *testing.T) {
 				return true
 			},
 			expectedBinds: []string{
-				hostBinDir + ":" + containerBinDir + readOnly,
+				hostResourcesRootDir + ":" + containerResourcesRootDir + readOnly,
 				hostConfigDir + ":" + containerConfigDir,
-				hostCertsDir + ":" + containerCertsDir + readOnly,
 			},
 		},
 		{
-			name: "only ssm-agent bin path valid",
+			name: "managed-agents path valid, no execute-command",
 			testIsPathValid: func(path string, isDir bool) bool {
-				return path == hostBinDir
+				return path == hostResourcesRootDir
 			},
 			expectedBinds: []string{
-				hostBinDir + ":" + containerBinDir + readOnly,
-				hostConfigDir + ":" + containerConfigDir,
+				hostResourcesRootDir + ":" + containerResourcesRootDir + readOnly,
 			},
 		},
 		{
@@ -929,15 +911,13 @@ func TestGetCapabilityExecBinds(t *testing.T) {
 			testIsPathValid: func(path string, isDir bool) bool {
 				return false
 			},
-			expectedBinds: []string{
-				hostConfigDir + ":" + containerConfigDir,
-			},
+			expectedBinds: []string{},
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			isPathValid = tc.testIsPathValid
-			binds := getCapabilityExecBinds()
+			binds := getCapabilityBinds()
 			assert.Equal(t, tc.expectedBinds, binds)
 		})
 	}

--- a/ecs-init/docker/docker_test.go
+++ b/ecs-init/docker/docker_test.go
@@ -290,7 +290,7 @@ func validateCommonCreateContainerOptions(opts godocker.CreateContainerOptions, 
 		t.Errorf("Expected network mode to be %s, got %s", networkMode, hostCfg.NetworkMode)
 	}
 
-	if len(hostCfg.CapAdd) != 2 {
+	if len(hostCfg.CapAdd) != 3 {
 		t.Error("Mismatch detected in added host config capabilities")
 	}
 


### PR DESCRIPTION
### Summary
This PR cherry-picks two commits from the https://github.com/aws/amazon-ecs-init repo.

*  Extend the mounting to include all dependencies [#508](https://github.com/aws/amazon-ecs-init/pull/508) 
*  Add the CAP_CHOWN capability to support running rootless [#511](https://github.com/aws/amazon-ecs-init/pull/511) 
  
### Implementation details
N/A

### Testing
New tests cover the changes: no

### Description for the changelog
Extend the mounting to include all dependencies and add the CAP_CHOWN capability to support running rootless.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
