### PR TITLE
Update defaultServiceConnectIfName to work with new CNI API spec

### DIFF
--- a/agent/ecscni/types_linux.go
+++ b/agent/ecscni/types_linux.go
@@ -32,7 +32,8 @@ const (
 	// defaultServiceConnectIfName is the default ifname used for invoking ServiceConnect CNI plugin.
 	// Even though the actual SC netns configuration does not require IfName, we still need to pass in a placeholder
 	// value because IfName is a mandatory field to invoke any CNI plugin.
-	defaultServiceConnectIfName = "ecs-serviceconnect"
+	// Additionally, the API spec requires that ifName length to be <= 15 chars.
+	defaultServiceConnectIfName = "ecs-sc"
 	// ECSIPAMPluginName is the binary of the ipam plugin
 	ECSIPAMPluginName = "ecs-ipam"
 	// ECSBridgePluginName is the binary of the bridge plugin


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
CNI API spec now requires `ifname` length to be <= 15 characters (https://github.com/containernetworking/cni/pull/712). Update `defaultServiceConnectIfName` to conform to the spec. 



### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> no

Ran E2E test with test AMI and verified ingress and egress traffic for both awsvpc and bridge mode Service Connect tasks.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Update defaultServiceConnectIfName to work with new CNI API spec
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
