### PR TITLE
fix PR git-secret scan workflow

### DIFF
--- a/.github/workflows/gitsecrets.yml
+++ b/.github/workflows/gitsecrets.yml
@@ -13,6 +13,8 @@ jobs:
           path: src/github.com/aws/amazon-ecs-agent
       - name: Git Secrets Scan Script
         run: |
+          # workaround git-secrets requiring the say command: https://github.com/awslabs/git-secrets/pull/221
+          ln -s "$(which echo)" /usr/local/bin/say
           set -ex
           cd $GITHUB_WORKSPACE
           git clone https://github.com/awslabs/git-secrets.git && cd git-secrets


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

There seems to be an issue with git-secrets complaining about not being able to find `say`.
example PR failure: https://github.com/aws/amazon-ecs-agent/actions/runs/3300364593/jobs/5444976040

This adds a workaround until this is fixed upstream: https://github.com/awslabs/git-secrets/pull/221

### Implementation details
<!-- How are the changes implemented? -->

Created a symbolic link between `say` and `echo`. Inspired by how the community is dealing with this, example: https://github.com/determined-ai/determined/pull/5313

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Workaround git-secrets scan issue: https://github.com/awslabs/git-secrets/pull/221

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
