### PR TITLE
Upgrade github.com/golang/mock and mockgen from 1.3.x to 1.6.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,11 +121,10 @@ misc/certs/ca-certificates.crt:
 	docker run "amazon/amazon-ecs-agent-cert-source:make" cat /etc/ssl/certs/ca-certificates.crt > misc/certs/ca-certificates.crt
 
 gogenerate:
-	go generate -x ./agent/...
 	$(MAKE) goimports
 
 gogenerate-init:
-	PATH=$(PATH):$(shell pwd)/scripts go generate -x ./ecs-init/...
+	PATH=$(PATH):$(shell pwd)/scripts go generate -x ./agent/... ./ecs-init/...
 	$(MAKE) goimports
 
 # 'go' may not be on the $PATH for sudo tests
@@ -349,9 +348,8 @@ install-golang:
 	./scripts/install-golang.sh
 
 .get-deps-stamp:
-	go get github.com/golang/mock/mockgen
-	cd "${GOPATH}/src/github.com/golang/mock/mockgen" && git checkout 1.3.1 && go get ./... && go install ./... && cd -
-	go get golang.org/x/tools/cmd/goimports
+	go install github.com/golang/mock/mockgen@v1.6.0
+	go install golang.org/x/tools/cmd/goimports@v0.2.0
 	GO111MODULE=on go install github.com/fzipp/gocyclo/cmd/gocyclo@v0.3.1
 	GO111MODULE=on go install honnef.co/go/tools/cmd/staticcheck@v0.3.2
 	touch .get-deps-stamp
@@ -359,10 +357,9 @@ install-golang:
 get-deps: .get-deps-stamp
 
 get-deps-init:
-	go get github.com/golang/mock/mockgen
-	cd "${GOPATH}/src/github.com/golang/mock/mockgen" && git checkout 1.3.1 && go get ./... && go install ./... && cd -
+	go install github.com/golang/mock/mockgen@v1.6.0
+	go install golang.org/x/tools/cmd/goimports@v0.2.0
 	GO111MODULE=on go install github.com/fzipp/gocyclo/cmd/gocyclo@v0.3.1
-	go get golang.org/x/tools/cmd/goimports
 	GO111MODULE=on go install honnef.co/go/tools/cmd/staticcheck@v0.3.2
 
 amazon-linux-sources.tgz:

--- a/agent/api/mocks/api_mocks.go
+++ b/agent/api/mocks/api_mocks.go
@@ -27,33 +27,33 @@ import (
 	ecs "github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
 	request "github.com/aws/aws-sdk-go/aws/request"
 	gomock "github.com/golang/mock/gomock"
-	go0 "github.com/prometheus/client_model/go"
+	io_prometheus_client "github.com/prometheus/client_model/go"
 )
 
-// MockECSSDK is a mock of ECSSDK interface
+// MockECSSDK is a mock of ECSSDK interface.
 type MockECSSDK struct {
 	ctrl     *gomock.Controller
 	recorder *MockECSSDKMockRecorder
 }
 
-// MockECSSDKMockRecorder is the mock recorder for MockECSSDK
+// MockECSSDKMockRecorder is the mock recorder for MockECSSDK.
 type MockECSSDKMockRecorder struct {
 	mock *MockECSSDK
 }
 
-// NewMockECSSDK creates a new mock instance
+// NewMockECSSDK creates a new mock instance.
 func NewMockECSSDK(ctrl *gomock.Controller) *MockECSSDK {
 	mock := &MockECSSDK{ctrl: ctrl}
 	mock.recorder = &MockECSSDKMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockECSSDK) EXPECT() *MockECSSDKMockRecorder {
 	return m.recorder
 }
 
-// CreateCluster mocks base method
+// CreateCluster mocks base method.
 func (m *MockECSSDK) CreateCluster(arg0 *ecs.CreateClusterInput) (*ecs.CreateClusterOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateCluster", arg0)
@@ -62,13 +62,13 @@ func (m *MockECSSDK) CreateCluster(arg0 *ecs.CreateClusterInput) (*ecs.CreateClu
 	return ret0, ret1
 }
 
-// CreateCluster indicates an expected call of CreateCluster
+// CreateCluster indicates an expected call of CreateCluster.
 func (mr *MockECSSDKMockRecorder) CreateCluster(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCluster", reflect.TypeOf((*MockECSSDK)(nil).CreateCluster), arg0)
 }
 
-// DiscoverPollEndpoint mocks base method
+// DiscoverPollEndpoint mocks base method.
 func (m *MockECSSDK) DiscoverPollEndpoint(arg0 *ecs.DiscoverPollEndpointInput) (*ecs.DiscoverPollEndpointOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DiscoverPollEndpoint", arg0)
@@ -77,13 +77,13 @@ func (m *MockECSSDK) DiscoverPollEndpoint(arg0 *ecs.DiscoverPollEndpointInput) (
 	return ret0, ret1
 }
 
-// DiscoverPollEndpoint indicates an expected call of DiscoverPollEndpoint
+// DiscoverPollEndpoint indicates an expected call of DiscoverPollEndpoint.
 func (mr *MockECSSDKMockRecorder) DiscoverPollEndpoint(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DiscoverPollEndpoint", reflect.TypeOf((*MockECSSDK)(nil).DiscoverPollEndpoint), arg0)
 }
 
-// ListTagsForResource mocks base method
+// ListTagsForResource mocks base method.
 func (m *MockECSSDK) ListTagsForResource(arg0 *ecs.ListTagsForResourceInput) (*ecs.ListTagsForResourceOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListTagsForResource", arg0)
@@ -92,13 +92,13 @@ func (m *MockECSSDK) ListTagsForResource(arg0 *ecs.ListTagsForResourceInput) (*e
 	return ret0, ret1
 }
 
-// ListTagsForResource indicates an expected call of ListTagsForResource
+// ListTagsForResource indicates an expected call of ListTagsForResource.
 func (mr *MockECSSDKMockRecorder) ListTagsForResource(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTagsForResource", reflect.TypeOf((*MockECSSDK)(nil).ListTagsForResource), arg0)
 }
 
-// RegisterContainerInstance mocks base method
+// RegisterContainerInstance mocks base method.
 func (m *MockECSSDK) RegisterContainerInstance(arg0 *ecs.RegisterContainerInstanceInput) (*ecs.RegisterContainerInstanceOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RegisterContainerInstance", arg0)
@@ -107,13 +107,13 @@ func (m *MockECSSDK) RegisterContainerInstance(arg0 *ecs.RegisterContainerInstan
 	return ret0, ret1
 }
 
-// RegisterContainerInstance indicates an expected call of RegisterContainerInstance
+// RegisterContainerInstance indicates an expected call of RegisterContainerInstance.
 func (mr *MockECSSDKMockRecorder) RegisterContainerInstance(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterContainerInstance", reflect.TypeOf((*MockECSSDK)(nil).RegisterContainerInstance), arg0)
 }
 
-// UpdateContainerInstancesState mocks base method
+// UpdateContainerInstancesState mocks base method.
 func (m *MockECSSDK) UpdateContainerInstancesState(arg0 *ecs.UpdateContainerInstancesStateInput) (*ecs.UpdateContainerInstancesStateOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateContainerInstancesState", arg0)
@@ -122,36 +122,36 @@ func (m *MockECSSDK) UpdateContainerInstancesState(arg0 *ecs.UpdateContainerInst
 	return ret0, ret1
 }
 
-// UpdateContainerInstancesState indicates an expected call of UpdateContainerInstancesState
+// UpdateContainerInstancesState indicates an expected call of UpdateContainerInstancesState.
 func (mr *MockECSSDKMockRecorder) UpdateContainerInstancesState(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateContainerInstancesState", reflect.TypeOf((*MockECSSDK)(nil).UpdateContainerInstancesState), arg0)
 }
 
-// MockECSSubmitStateSDK is a mock of ECSSubmitStateSDK interface
+// MockECSSubmitStateSDK is a mock of ECSSubmitStateSDK interface.
 type MockECSSubmitStateSDK struct {
 	ctrl     *gomock.Controller
 	recorder *MockECSSubmitStateSDKMockRecorder
 }
 
-// MockECSSubmitStateSDKMockRecorder is the mock recorder for MockECSSubmitStateSDK
+// MockECSSubmitStateSDKMockRecorder is the mock recorder for MockECSSubmitStateSDK.
 type MockECSSubmitStateSDKMockRecorder struct {
 	mock *MockECSSubmitStateSDK
 }
 
-// NewMockECSSubmitStateSDK creates a new mock instance
+// NewMockECSSubmitStateSDK creates a new mock instance.
 func NewMockECSSubmitStateSDK(ctrl *gomock.Controller) *MockECSSubmitStateSDK {
 	mock := &MockECSSubmitStateSDK{ctrl: ctrl}
 	mock.recorder = &MockECSSubmitStateSDKMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockECSSubmitStateSDK) EXPECT() *MockECSSubmitStateSDKMockRecorder {
 	return m.recorder
 }
 
-// SubmitAttachmentStateChanges mocks base method
+// SubmitAttachmentStateChanges mocks base method.
 func (m *MockECSSubmitStateSDK) SubmitAttachmentStateChanges(arg0 *ecs.SubmitAttachmentStateChangesInput) (*ecs.SubmitAttachmentStateChangesOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SubmitAttachmentStateChanges", arg0)
@@ -160,13 +160,13 @@ func (m *MockECSSubmitStateSDK) SubmitAttachmentStateChanges(arg0 *ecs.SubmitAtt
 	return ret0, ret1
 }
 
-// SubmitAttachmentStateChanges indicates an expected call of SubmitAttachmentStateChanges
+// SubmitAttachmentStateChanges indicates an expected call of SubmitAttachmentStateChanges.
 func (mr *MockECSSubmitStateSDKMockRecorder) SubmitAttachmentStateChanges(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitAttachmentStateChanges", reflect.TypeOf((*MockECSSubmitStateSDK)(nil).SubmitAttachmentStateChanges), arg0)
 }
 
-// SubmitContainerStateChange mocks base method
+// SubmitContainerStateChange mocks base method.
 func (m *MockECSSubmitStateSDK) SubmitContainerStateChange(arg0 *ecs.SubmitContainerStateChangeInput) (*ecs.SubmitContainerStateChangeOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SubmitContainerStateChange", arg0)
@@ -175,13 +175,13 @@ func (m *MockECSSubmitStateSDK) SubmitContainerStateChange(arg0 *ecs.SubmitConta
 	return ret0, ret1
 }
 
-// SubmitContainerStateChange indicates an expected call of SubmitContainerStateChange
+// SubmitContainerStateChange indicates an expected call of SubmitContainerStateChange.
 func (mr *MockECSSubmitStateSDKMockRecorder) SubmitContainerStateChange(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitContainerStateChange", reflect.TypeOf((*MockECSSubmitStateSDK)(nil).SubmitContainerStateChange), arg0)
 }
 
-// SubmitTaskStateChange mocks base method
+// SubmitTaskStateChange mocks base method.
 func (m *MockECSSubmitStateSDK) SubmitTaskStateChange(arg0 *ecs.SubmitTaskStateChangeInput) (*ecs.SubmitTaskStateChangeOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SubmitTaskStateChange", arg0)
@@ -190,36 +190,36 @@ func (m *MockECSSubmitStateSDK) SubmitTaskStateChange(arg0 *ecs.SubmitTaskStateC
 	return ret0, ret1
 }
 
-// SubmitTaskStateChange indicates an expected call of SubmitTaskStateChange
+// SubmitTaskStateChange indicates an expected call of SubmitTaskStateChange.
 func (mr *MockECSSubmitStateSDKMockRecorder) SubmitTaskStateChange(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitTaskStateChange", reflect.TypeOf((*MockECSSubmitStateSDK)(nil).SubmitTaskStateChange), arg0)
 }
 
-// MockECSClient is a mock of ECSClient interface
+// MockECSClient is a mock of ECSClient interface.
 type MockECSClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockECSClientMockRecorder
 }
 
-// MockECSClientMockRecorder is the mock recorder for MockECSClient
+// MockECSClientMockRecorder is the mock recorder for MockECSClient.
 type MockECSClientMockRecorder struct {
 	mock *MockECSClient
 }
 
-// NewMockECSClient creates a new mock instance
+// NewMockECSClient creates a new mock instance.
 func NewMockECSClient(ctrl *gomock.Controller) *MockECSClient {
 	mock := &MockECSClient{ctrl: ctrl}
 	mock.recorder = &MockECSClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockECSClient) EXPECT() *MockECSClientMockRecorder {
 	return m.recorder
 }
 
-// DiscoverPollEndpoint mocks base method
+// DiscoverPollEndpoint mocks base method.
 func (m *MockECSClient) DiscoverPollEndpoint(arg0 string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DiscoverPollEndpoint", arg0)
@@ -228,13 +228,13 @@ func (m *MockECSClient) DiscoverPollEndpoint(arg0 string) (string, error) {
 	return ret0, ret1
 }
 
-// DiscoverPollEndpoint indicates an expected call of DiscoverPollEndpoint
+// DiscoverPollEndpoint indicates an expected call of DiscoverPollEndpoint.
 func (mr *MockECSClientMockRecorder) DiscoverPollEndpoint(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DiscoverPollEndpoint", reflect.TypeOf((*MockECSClient)(nil).DiscoverPollEndpoint), arg0)
 }
 
-// DiscoverServiceConnectEndpoint mocks base method
+// DiscoverServiceConnectEndpoint mocks base method.
 func (m *MockECSClient) DiscoverServiceConnectEndpoint(arg0 string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DiscoverServiceConnectEndpoint", arg0)
@@ -243,13 +243,13 @@ func (m *MockECSClient) DiscoverServiceConnectEndpoint(arg0 string) (string, err
 	return ret0, ret1
 }
 
-// DiscoverServiceConnectEndpoint indicates an expected call of DiscoverServiceConnectEndpoint
+// DiscoverServiceConnectEndpoint indicates an expected call of DiscoverServiceConnectEndpoint.
 func (mr *MockECSClientMockRecorder) DiscoverServiceConnectEndpoint(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DiscoverServiceConnectEndpoint", reflect.TypeOf((*MockECSClient)(nil).DiscoverServiceConnectEndpoint), arg0)
 }
 
-// DiscoverTelemetryEndpoint mocks base method
+// DiscoverTelemetryEndpoint mocks base method.
 func (m *MockECSClient) DiscoverTelemetryEndpoint(arg0 string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DiscoverTelemetryEndpoint", arg0)
@@ -258,13 +258,13 @@ func (m *MockECSClient) DiscoverTelemetryEndpoint(arg0 string) (string, error) {
 	return ret0, ret1
 }
 
-// DiscoverTelemetryEndpoint indicates an expected call of DiscoverTelemetryEndpoint
+// DiscoverTelemetryEndpoint indicates an expected call of DiscoverTelemetryEndpoint.
 func (mr *MockECSClientMockRecorder) DiscoverTelemetryEndpoint(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DiscoverTelemetryEndpoint", reflect.TypeOf((*MockECSClient)(nil).DiscoverTelemetryEndpoint), arg0)
 }
 
-// GetResourceTags mocks base method
+// GetResourceTags mocks base method.
 func (m *MockECSClient) GetResourceTags(arg0 string) ([]*ecs.Tag, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetResourceTags", arg0)
@@ -273,13 +273,13 @@ func (m *MockECSClient) GetResourceTags(arg0 string) ([]*ecs.Tag, error) {
 	return ret0, ret1
 }
 
-// GetResourceTags indicates an expected call of GetResourceTags
+// GetResourceTags indicates an expected call of GetResourceTags.
 func (mr *MockECSClientMockRecorder) GetResourceTags(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResourceTags", reflect.TypeOf((*MockECSClient)(nil).GetResourceTags), arg0)
 }
 
-// RegisterContainerInstance mocks base method
+// RegisterContainerInstance mocks base method.
 func (m *MockECSClient) RegisterContainerInstance(arg0 string, arg1 []*ecs.Attribute, arg2 []*ecs.Tag, arg3 string, arg4 []*ecs.PlatformDevice, arg5 string) (string, string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RegisterContainerInstance", arg0, arg1, arg2, arg3, arg4, arg5)
@@ -289,13 +289,13 @@ func (m *MockECSClient) RegisterContainerInstance(arg0 string, arg1 []*ecs.Attri
 	return ret0, ret1, ret2
 }
 
-// RegisterContainerInstance indicates an expected call of RegisterContainerInstance
+// RegisterContainerInstance indicates an expected call of RegisterContainerInstance.
 func (mr *MockECSClientMockRecorder) RegisterContainerInstance(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterContainerInstance", reflect.TypeOf((*MockECSClient)(nil).RegisterContainerInstance), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
-// SubmitAttachmentStateChange mocks base method
+// SubmitAttachmentStateChange mocks base method.
 func (m *MockECSClient) SubmitAttachmentStateChange(arg0 api.AttachmentStateChange) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SubmitAttachmentStateChange", arg0)
@@ -303,13 +303,13 @@ func (m *MockECSClient) SubmitAttachmentStateChange(arg0 api.AttachmentStateChan
 	return ret0
 }
 
-// SubmitAttachmentStateChange indicates an expected call of SubmitAttachmentStateChange
+// SubmitAttachmentStateChange indicates an expected call of SubmitAttachmentStateChange.
 func (mr *MockECSClientMockRecorder) SubmitAttachmentStateChange(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitAttachmentStateChange", reflect.TypeOf((*MockECSClient)(nil).SubmitAttachmentStateChange), arg0)
 }
 
-// SubmitContainerStateChange mocks base method
+// SubmitContainerStateChange mocks base method.
 func (m *MockECSClient) SubmitContainerStateChange(arg0 api.ContainerStateChange) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SubmitContainerStateChange", arg0)
@@ -317,13 +317,13 @@ func (m *MockECSClient) SubmitContainerStateChange(arg0 api.ContainerStateChange
 	return ret0
 }
 
-// SubmitContainerStateChange indicates an expected call of SubmitContainerStateChange
+// SubmitContainerStateChange indicates an expected call of SubmitContainerStateChange.
 func (mr *MockECSClientMockRecorder) SubmitContainerStateChange(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitContainerStateChange", reflect.TypeOf((*MockECSClient)(nil).SubmitContainerStateChange), arg0)
 }
 
-// SubmitTaskStateChange mocks base method
+// SubmitTaskStateChange mocks base method.
 func (m *MockECSClient) SubmitTaskStateChange(arg0 api.TaskStateChange) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SubmitTaskStateChange", arg0)
@@ -331,13 +331,13 @@ func (m *MockECSClient) SubmitTaskStateChange(arg0 api.TaskStateChange) error {
 	return ret0
 }
 
-// SubmitTaskStateChange indicates an expected call of SubmitTaskStateChange
+// SubmitTaskStateChange indicates an expected call of SubmitTaskStateChange.
 func (mr *MockECSClientMockRecorder) SubmitTaskStateChange(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitTaskStateChange", reflect.TypeOf((*MockECSClient)(nil).SubmitTaskStateChange), arg0)
 }
 
-// UpdateContainerInstancesState mocks base method
+// UpdateContainerInstancesState mocks base method.
 func (m *MockECSClient) UpdateContainerInstancesState(arg0, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateContainerInstancesState", arg0, arg1)
@@ -345,36 +345,36 @@ func (m *MockECSClient) UpdateContainerInstancesState(arg0, arg1 string) error {
 	return ret0
 }
 
-// UpdateContainerInstancesState indicates an expected call of UpdateContainerInstancesState
+// UpdateContainerInstancesState indicates an expected call of UpdateContainerInstancesState.
 func (mr *MockECSClientMockRecorder) UpdateContainerInstancesState(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateContainerInstancesState", reflect.TypeOf((*MockECSClient)(nil).UpdateContainerInstancesState), arg0, arg1)
 }
 
-// MockAppnetClient is a mock of AppnetClient interface
+// MockAppnetClient is a mock of AppnetClient interface.
 type MockAppnetClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockAppnetClientMockRecorder
 }
 
-// MockAppnetClientMockRecorder is the mock recorder for MockAppnetClient
+// MockAppnetClientMockRecorder is the mock recorder for MockAppnetClient.
 type MockAppnetClientMockRecorder struct {
 	mock *MockAppnetClient
 }
 
-// NewMockAppnetClient creates a new mock instance
+// NewMockAppnetClient creates a new mock instance.
 func NewMockAppnetClient(ctrl *gomock.Controller) *MockAppnetClient {
 	mock := &MockAppnetClient{ctrl: ctrl}
 	mock.recorder = &MockAppnetClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockAppnetClient) EXPECT() *MockAppnetClientMockRecorder {
 	return m.recorder
 }
 
-// DrainInboundConnections mocks base method
+// DrainInboundConnections mocks base method.
 func (m *MockAppnetClient) DrainInboundConnections(arg0 serviceconnect.RuntimeConfig) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DrainInboundConnections", arg0)
@@ -382,51 +382,51 @@ func (m *MockAppnetClient) DrainInboundConnections(arg0 serviceconnect.RuntimeCo
 	return ret0
 }
 
-// DrainInboundConnections indicates an expected call of DrainInboundConnections
+// DrainInboundConnections indicates an expected call of DrainInboundConnections.
 func (mr *MockAppnetClientMockRecorder) DrainInboundConnections(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DrainInboundConnections", reflect.TypeOf((*MockAppnetClient)(nil).DrainInboundConnections), arg0)
 }
 
-// GetStats mocks base method
-func (m *MockAppnetClient) GetStats(arg0 serviceconnect.RuntimeConfig) (map[string]*go0.MetricFamily, error) {
+// GetStats mocks base method.
+func (m *MockAppnetClient) GetStats(arg0 serviceconnect.RuntimeConfig) (map[string]*io_prometheus_client.MetricFamily, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetStats", arg0)
-	ret0, _ := ret[0].(map[string]*go0.MetricFamily)
+	ret0, _ := ret[0].(map[string]*io_prometheus_client.MetricFamily)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetStats indicates an expected call of GetStats
+// GetStats indicates an expected call of GetStats.
 func (mr *MockAppnetClientMockRecorder) GetStats(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStats", reflect.TypeOf((*MockAppnetClient)(nil).GetStats), arg0)
 }
 
-// MockECSTaskProtectionSDK is a mock of ECSTaskProtectionSDK interface
+// MockECSTaskProtectionSDK is a mock of ECSTaskProtectionSDK interface.
 type MockECSTaskProtectionSDK struct {
 	ctrl     *gomock.Controller
 	recorder *MockECSTaskProtectionSDKMockRecorder
 }
 
-// MockECSTaskProtectionSDKMockRecorder is the mock recorder for MockECSTaskProtectionSDK
+// MockECSTaskProtectionSDKMockRecorder is the mock recorder for MockECSTaskProtectionSDK.
 type MockECSTaskProtectionSDKMockRecorder struct {
 	mock *MockECSTaskProtectionSDK
 }
 
-// NewMockECSTaskProtectionSDK creates a new mock instance
+// NewMockECSTaskProtectionSDK creates a new mock instance.
 func NewMockECSTaskProtectionSDK(ctrl *gomock.Controller) *MockECSTaskProtectionSDK {
 	mock := &MockECSTaskProtectionSDK{ctrl: ctrl}
 	mock.recorder = &MockECSTaskProtectionSDKMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockECSTaskProtectionSDK) EXPECT() *MockECSTaskProtectionSDKMockRecorder {
 	return m.recorder
 }
 
-// GetTaskProtection mocks base method
+// GetTaskProtection mocks base method.
 func (m *MockECSTaskProtectionSDK) GetTaskProtection(arg0 *ecs.GetTaskProtectionInput) (*ecs.GetTaskProtectionOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTaskProtection", arg0)
@@ -435,13 +435,13 @@ func (m *MockECSTaskProtectionSDK) GetTaskProtection(arg0 *ecs.GetTaskProtection
 	return ret0, ret1
 }
 
-// GetTaskProtection indicates an expected call of GetTaskProtection
+// GetTaskProtection indicates an expected call of GetTaskProtection.
 func (mr *MockECSTaskProtectionSDKMockRecorder) GetTaskProtection(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTaskProtection", reflect.TypeOf((*MockECSTaskProtectionSDK)(nil).GetTaskProtection), arg0)
 }
 
-// GetTaskProtectionWithContext mocks base method
+// GetTaskProtectionWithContext mocks base method.
 func (m *MockECSTaskProtectionSDK) GetTaskProtectionWithContext(arg0 context.Context, arg1 *ecs.GetTaskProtectionInput, arg2 ...request.Option) (*ecs.GetTaskProtectionOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
@@ -454,14 +454,14 @@ func (m *MockECSTaskProtectionSDK) GetTaskProtectionWithContext(arg0 context.Con
 	return ret0, ret1
 }
 
-// GetTaskProtectionWithContext indicates an expected call of GetTaskProtectionWithContext
+// GetTaskProtectionWithContext indicates an expected call of GetTaskProtectionWithContext.
 func (mr *MockECSTaskProtectionSDKMockRecorder) GetTaskProtectionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTaskProtectionWithContext", reflect.TypeOf((*MockECSTaskProtectionSDK)(nil).GetTaskProtectionWithContext), varargs...)
 }
 
-// UpdateTaskProtection mocks base method
+// UpdateTaskProtection mocks base method.
 func (m *MockECSTaskProtectionSDK) UpdateTaskProtection(arg0 *ecs.UpdateTaskProtectionInput) (*ecs.UpdateTaskProtectionOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateTaskProtection", arg0)
@@ -470,13 +470,13 @@ func (m *MockECSTaskProtectionSDK) UpdateTaskProtection(arg0 *ecs.UpdateTaskProt
 	return ret0, ret1
 }
 
-// UpdateTaskProtection indicates an expected call of UpdateTaskProtection
+// UpdateTaskProtection indicates an expected call of UpdateTaskProtection.
 func (mr *MockECSTaskProtectionSDKMockRecorder) UpdateTaskProtection(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTaskProtection", reflect.TypeOf((*MockECSTaskProtectionSDK)(nil).UpdateTaskProtection), arg0)
 }
 
-// UpdateTaskProtectionWithContext mocks base method
+// UpdateTaskProtectionWithContext mocks base method.
 func (m *MockECSTaskProtectionSDK) UpdateTaskProtectionWithContext(arg0 context.Context, arg1 *ecs.UpdateTaskProtectionInput, arg2 ...request.Option) (*ecs.UpdateTaskProtectionOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
@@ -489,7 +489,7 @@ func (m *MockECSTaskProtectionSDK) UpdateTaskProtectionWithContext(arg0 context.
 	return ret0, ret1
 }
 
-// UpdateTaskProtectionWithContext indicates an expected call of UpdateTaskProtectionWithContext
+// UpdateTaskProtectionWithContext indicates an expected call of UpdateTaskProtectionWithContext.
 func (mr *MockECSTaskProtectionSDKMockRecorder) UpdateTaskProtectionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)

--- a/agent/app/factory/mocks/factory_mocks.go
+++ b/agent/app/factory/mocks/factory_mocks.go
@@ -26,30 +26,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockStateManager is a mock of StateManager interface
+// MockStateManager is a mock of StateManager interface.
 type MockStateManager struct {
 	ctrl     *gomock.Controller
 	recorder *MockStateManagerMockRecorder
 }
 
-// MockStateManagerMockRecorder is the mock recorder for MockStateManager
+// MockStateManagerMockRecorder is the mock recorder for MockStateManager.
 type MockStateManagerMockRecorder struct {
 	mock *MockStateManager
 }
 
-// NewMockStateManager creates a new mock instance
+// NewMockStateManager creates a new mock instance.
 func NewMockStateManager(ctrl *gomock.Controller) *MockStateManager {
 	mock := &MockStateManager{ctrl: ctrl}
 	mock.recorder = &MockStateManagerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockStateManager) EXPECT() *MockStateManagerMockRecorder {
 	return m.recorder
 }
 
-// NewStateManager mocks base method
+// NewStateManager mocks base method.
 func (m *MockStateManager) NewStateManager(arg0 *config.Config, arg1 ...statemanager.Option) (statemanager.StateManager, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
@@ -62,37 +62,37 @@ func (m *MockStateManager) NewStateManager(arg0 *config.Config, arg1 ...stateman
 	return ret0, ret1
 }
 
-// NewStateManager indicates an expected call of NewStateManager
+// NewStateManager indicates an expected call of NewStateManager.
 func (mr *MockStateManagerMockRecorder) NewStateManager(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewStateManager", reflect.TypeOf((*MockStateManager)(nil).NewStateManager), varargs...)
 }
 
-// MockSaveableOption is a mock of SaveableOption interface
+// MockSaveableOption is a mock of SaveableOption interface.
 type MockSaveableOption struct {
 	ctrl     *gomock.Controller
 	recorder *MockSaveableOptionMockRecorder
 }
 
-// MockSaveableOptionMockRecorder is the mock recorder for MockSaveableOption
+// MockSaveableOptionMockRecorder is the mock recorder for MockSaveableOption.
 type MockSaveableOptionMockRecorder struct {
 	mock *MockSaveableOption
 }
 
-// NewMockSaveableOption creates a new mock instance
+// NewMockSaveableOption creates a new mock instance.
 func NewMockSaveableOption(ctrl *gomock.Controller) *MockSaveableOption {
 	mock := &MockSaveableOption{ctrl: ctrl}
 	mock.recorder = &MockSaveableOptionMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSaveableOption) EXPECT() *MockSaveableOptionMockRecorder {
 	return m.recorder
 }
 
-// AddSaveable mocks base method
+// AddSaveable mocks base method.
 func (m *MockSaveableOption) AddSaveable(arg0 string, arg1 statemanager.Saveable) statemanager.Option {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddSaveable", arg0, arg1)
@@ -100,7 +100,7 @@ func (m *MockSaveableOption) AddSaveable(arg0 string, arg1 statemanager.Saveable
 	return ret0
 }
 
-// AddSaveable indicates an expected call of AddSaveable
+// AddSaveable indicates an expected call of AddSaveable.
 func (mr *MockSaveableOptionMockRecorder) AddSaveable(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddSaveable", reflect.TypeOf((*MockSaveableOption)(nil).AddSaveable), arg0, arg1)

--- a/agent/app/mocks/credentials_mocks.go
+++ b/agent/app/mocks/credentials_mocks.go
@@ -25,30 +25,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockProvider is a mock of Provider interface
+// MockProvider is a mock of Provider interface.
 type MockProvider struct {
 	ctrl     *gomock.Controller
 	recorder *MockProviderMockRecorder
 }
 
-// MockProviderMockRecorder is the mock recorder for MockProvider
+// MockProviderMockRecorder is the mock recorder for MockProvider.
 type MockProviderMockRecorder struct {
 	mock *MockProvider
 }
 
-// NewMockProvider creates a new mock instance
+// NewMockProvider creates a new mock instance.
 func NewMockProvider(ctrl *gomock.Controller) *MockProvider {
 	mock := &MockProvider{ctrl: ctrl}
 	mock.recorder = &MockProviderMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockProvider) EXPECT() *MockProviderMockRecorder {
 	return m.recorder
 }
 
-// IsExpired mocks base method
+// IsExpired mocks base method.
 func (m *MockProvider) IsExpired() bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsExpired")
@@ -56,13 +56,13 @@ func (m *MockProvider) IsExpired() bool {
 	return ret0
 }
 
-// IsExpired indicates an expected call of IsExpired
+// IsExpired indicates an expected call of IsExpired.
 func (mr *MockProviderMockRecorder) IsExpired() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsExpired", reflect.TypeOf((*MockProvider)(nil).IsExpired))
 }
 
-// Retrieve mocks base method
+// Retrieve mocks base method.
 func (m *MockProvider) Retrieve() (credentials.Value, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Retrieve")
@@ -71,7 +71,7 @@ func (m *MockProvider) Retrieve() (credentials.Value, error) {
 	return ret0, ret1
 }
 
-// Retrieve indicates an expected call of Retrieve
+// Retrieve indicates an expected call of Retrieve.
 func (mr *MockProviderMockRecorder) Retrieve() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Retrieve", reflect.TypeOf((*MockProvider)(nil).Retrieve))

--- a/agent/asm/factory/mocks/factory_mocks.go
+++ b/agent/asm/factory/mocks/factory_mocks.go
@@ -26,30 +26,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockClientCreator is a mock of ClientCreator interface
+// MockClientCreator is a mock of ClientCreator interface.
 type MockClientCreator struct {
 	ctrl     *gomock.Controller
 	recorder *MockClientCreatorMockRecorder
 }
 
-// MockClientCreatorMockRecorder is the mock recorder for MockClientCreator
+// MockClientCreatorMockRecorder is the mock recorder for MockClientCreator.
 type MockClientCreatorMockRecorder struct {
 	mock *MockClientCreator
 }
 
-// NewMockClientCreator creates a new mock instance
+// NewMockClientCreator creates a new mock instance.
 func NewMockClientCreator(ctrl *gomock.Controller) *MockClientCreator {
 	mock := &MockClientCreator{ctrl: ctrl}
 	mock.recorder = &MockClientCreatorMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockClientCreator) EXPECT() *MockClientCreatorMockRecorder {
 	return m.recorder
 }
 
-// NewASMClient mocks base method
+// NewASMClient mocks base method.
 func (m *MockClientCreator) NewASMClient(arg0 string, arg1 credentials.IAMRoleCredentials) secretsmanageriface.SecretsManagerAPI {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewASMClient", arg0, arg1)
@@ -57,7 +57,7 @@ func (m *MockClientCreator) NewASMClient(arg0 string, arg1 credentials.IAMRoleCr
 	return ret0
 }
 
-// NewASMClient indicates an expected call of NewASMClient
+// NewASMClient indicates an expected call of NewASMClient.
 func (mr *MockClientCreatorMockRecorder) NewASMClient(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewASMClient", reflect.TypeOf((*MockClientCreator)(nil).NewASMClient), arg0, arg1)

--- a/agent/asm/mocks/secretsmanagerapi_mocks.go
+++ b/agent/asm/mocks/secretsmanagerapi_mocks.go
@@ -27,30 +27,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockSecretsManagerAPI is a mock of SecretsManagerAPI interface
+// MockSecretsManagerAPI is a mock of SecretsManagerAPI interface.
 type MockSecretsManagerAPI struct {
 	ctrl     *gomock.Controller
 	recorder *MockSecretsManagerAPIMockRecorder
 }
 
-// MockSecretsManagerAPIMockRecorder is the mock recorder for MockSecretsManagerAPI
+// MockSecretsManagerAPIMockRecorder is the mock recorder for MockSecretsManagerAPI.
 type MockSecretsManagerAPIMockRecorder struct {
 	mock *MockSecretsManagerAPI
 }
 
-// NewMockSecretsManagerAPI creates a new mock instance
+// NewMockSecretsManagerAPI creates a new mock instance.
 func NewMockSecretsManagerAPI(ctrl *gomock.Controller) *MockSecretsManagerAPI {
 	mock := &MockSecretsManagerAPI{ctrl: ctrl}
 	mock.recorder = &MockSecretsManagerAPIMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSecretsManagerAPI) EXPECT() *MockSecretsManagerAPIMockRecorder {
 	return m.recorder
 }
 
-// CancelRotateSecret mocks base method
+// CancelRotateSecret mocks base method.
 func (m *MockSecretsManagerAPI) CancelRotateSecret(arg0 *secretsmanager.CancelRotateSecretInput) (*secretsmanager.CancelRotateSecretOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CancelRotateSecret", arg0)
@@ -59,13 +59,13 @@ func (m *MockSecretsManagerAPI) CancelRotateSecret(arg0 *secretsmanager.CancelRo
 	return ret0, ret1
 }
 
-// CancelRotateSecret indicates an expected call of CancelRotateSecret
+// CancelRotateSecret indicates an expected call of CancelRotateSecret.
 func (mr *MockSecretsManagerAPIMockRecorder) CancelRotateSecret(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelRotateSecret", reflect.TypeOf((*MockSecretsManagerAPI)(nil).CancelRotateSecret), arg0)
 }
 
-// CancelRotateSecretRequest mocks base method
+// CancelRotateSecretRequest mocks base method.
 func (m *MockSecretsManagerAPI) CancelRotateSecretRequest(arg0 *secretsmanager.CancelRotateSecretInput) (*request.Request, *secretsmanager.CancelRotateSecretOutput) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CancelRotateSecretRequest", arg0)
@@ -74,13 +74,13 @@ func (m *MockSecretsManagerAPI) CancelRotateSecretRequest(arg0 *secretsmanager.C
 	return ret0, ret1
 }
 
-// CancelRotateSecretRequest indicates an expected call of CancelRotateSecretRequest
+// CancelRotateSecretRequest indicates an expected call of CancelRotateSecretRequest.
 func (mr *MockSecretsManagerAPIMockRecorder) CancelRotateSecretRequest(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelRotateSecretRequest", reflect.TypeOf((*MockSecretsManagerAPI)(nil).CancelRotateSecretRequest), arg0)
 }
 
-// CancelRotateSecretWithContext mocks base method
+// CancelRotateSecretWithContext mocks base method.
 func (m *MockSecretsManagerAPI) CancelRotateSecretWithContext(arg0 context.Context, arg1 *secretsmanager.CancelRotateSecretInput, arg2 ...request.Option) (*secretsmanager.CancelRotateSecretOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
@@ -93,14 +93,14 @@ func (m *MockSecretsManagerAPI) CancelRotateSecretWithContext(arg0 context.Conte
 	return ret0, ret1
 }
 
-// CancelRotateSecretWithContext indicates an expected call of CancelRotateSecretWithContext
+// CancelRotateSecretWithContext indicates an expected call of CancelRotateSecretWithContext.
 func (mr *MockSecretsManagerAPIMockRecorder) CancelRotateSecretWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelRotateSecretWithContext", reflect.TypeOf((*MockSecretsManagerAPI)(nil).CancelRotateSecretWithContext), varargs...)
 }
 
-// CreateSecret mocks base method
+// CreateSecret mocks base method.
 func (m *MockSecretsManagerAPI) CreateSecret(arg0 *secretsmanager.CreateSecretInput) (*secretsmanager.CreateSecretOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateSecret", arg0)
@@ -109,13 +109,13 @@ func (m *MockSecretsManagerAPI) CreateSecret(arg0 *secretsmanager.CreateSecretIn
 	return ret0, ret1
 }
 
-// CreateSecret indicates an expected call of CreateSecret
+// CreateSecret indicates an expected call of CreateSecret.
 func (mr *MockSecretsManagerAPIMockRecorder) CreateSecret(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSecret", reflect.TypeOf((*MockSecretsManagerAPI)(nil).CreateSecret), arg0)
 }
 
-// CreateSecretRequest mocks base method
+// CreateSecretRequest mocks base method.
 func (m *MockSecretsManagerAPI) CreateSecretRequest(arg0 *secretsmanager.CreateSecretInput) (*request.Request, *secretsmanager.CreateSecretOutput) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateSecretRequest", arg0)
@@ -124,13 +124,13 @@ func (m *MockSecretsManagerAPI) CreateSecretRequest(arg0 *secretsmanager.CreateS
 	return ret0, ret1
 }
 
-// CreateSecretRequest indicates an expected call of CreateSecretRequest
+// CreateSecretRequest indicates an expected call of CreateSecretRequest.
 func (mr *MockSecretsManagerAPIMockRecorder) CreateSecretRequest(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSecretRequest", reflect.TypeOf((*MockSecretsManagerAPI)(nil).CreateSecretRequest), arg0)
 }
 
-// CreateSecretWithContext mocks base method
+// CreateSecretWithContext mocks base method.
 func (m *MockSecretsManagerAPI) CreateSecretWithContext(arg0 context.Context, arg1 *secretsmanager.CreateSecretInput, arg2 ...request.Option) (*secretsmanager.CreateSecretOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
@@ -143,14 +143,14 @@ func (m *MockSecretsManagerAPI) CreateSecretWithContext(arg0 context.Context, ar
 	return ret0, ret1
 }
 
-// CreateSecretWithContext indicates an expected call of CreateSecretWithContext
+// CreateSecretWithContext indicates an expected call of CreateSecretWithContext.
 func (mr *MockSecretsManagerAPIMockRecorder) CreateSecretWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSecretWithContext", reflect.TypeOf((*MockSecretsManagerAPI)(nil).CreateSecretWithContext), varargs...)
 }
 
-// DeleteResourcePolicy mocks base method
+// DeleteResourcePolicy mocks base method.
 func (m *MockSecretsManagerAPI) DeleteResourcePolicy(arg0 *secretsmanager.DeleteResourcePolicyInput) (*secretsmanager.DeleteResourcePolicyOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteResourcePolicy", arg0)
@@ -159,13 +159,13 @@ func (m *MockSecretsManagerAPI) DeleteResourcePolicy(arg0 *secretsmanager.Delete
 	return ret0, ret1
 }
 
-// DeleteResourcePolicy indicates an expected call of DeleteResourcePolicy
+// DeleteResourcePolicy indicates an expected call of DeleteResourcePolicy.
 func (mr *MockSecretsManagerAPIMockRecorder) DeleteResourcePolicy(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteResourcePolicy", reflect.TypeOf((*MockSecretsManagerAPI)(nil).DeleteResourcePolicy), arg0)
 }
 
-// DeleteResourcePolicyRequest mocks base method
+// DeleteResourcePolicyRequest mocks base method.
 func (m *MockSecretsManagerAPI) DeleteResourcePolicyRequest(arg0 *secretsmanager.DeleteResourcePolicyInput) (*request.Request, *secretsmanager.DeleteResourcePolicyOutput) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteResourcePolicyRequest", arg0)
@@ -174,13 +174,13 @@ func (m *MockSecretsManagerAPI) DeleteResourcePolicyRequest(arg0 *secretsmanager
 	return ret0, ret1
 }
 
-// DeleteResourcePolicyRequest indicates an expected call of DeleteResourcePolicyRequest
+// DeleteResourcePolicyRequest indicates an expected call of DeleteResourcePolicyRequest.
 func (mr *MockSecretsManagerAPIMockRecorder) DeleteResourcePolicyRequest(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteResourcePolicyRequest", reflect.TypeOf((*MockSecretsManagerAPI)(nil).DeleteResourcePolicyRequest), arg0)
 }
 
-// DeleteResourcePolicyWithContext mocks base method
+// DeleteResourcePolicyWithContext mocks base method.
 func (m *MockSecretsManagerAPI) DeleteResourcePolicyWithContext(arg0 context.Context, arg1 *secretsmanager.DeleteResourcePolicyInput, arg2 ...request.Option) (*secretsmanager.DeleteResourcePolicyOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
@@ -193,14 +193,14 @@ func (m *MockSecretsManagerAPI) DeleteResourcePolicyWithContext(arg0 context.Con
 	return ret0, ret1
 }
 
-// DeleteResourcePolicyWithContext indicates an expected call of DeleteResourcePolicyWithContext
+// DeleteResourcePolicyWithContext indicates an expected call of DeleteResourcePolicyWithContext.
 func (mr *MockSecretsManagerAPIMockRecorder) DeleteResourcePolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteResourcePolicyWithContext", reflect.TypeOf((*MockSecretsManagerAPI)(nil).DeleteResourcePolicyWithContext), varargs...)
 }
 
-// DeleteSecret mocks base method
+// DeleteSecret mocks base method.
 func (m *MockSecretsManagerAPI) DeleteSecret(arg0 *secretsmanager.DeleteSecretInput) (*secretsmanager.DeleteSecretOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteSecret", arg0)
@@ -209,13 +209,13 @@ func (m *MockSecretsManagerAPI) DeleteSecret(arg0 *secretsmanager.DeleteSecretIn
 	return ret0, ret1
 }
 
-// DeleteSecret indicates an expected call of DeleteSecret
+// DeleteSecret indicates an expected call of DeleteSecret.
 func (mr *MockSecretsManagerAPIMockRecorder) DeleteSecret(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSecret", reflect.TypeOf((*MockSecretsManagerAPI)(nil).DeleteSecret), arg0)
 }
 
-// DeleteSecretRequest mocks base method
+// DeleteSecretRequest mocks base method.
 func (m *MockSecretsManagerAPI) DeleteSecretRequest(arg0 *secretsmanager.DeleteSecretInput) (*request.Request, *secretsmanager.DeleteSecretOutput) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteSecretRequest", arg0)
@@ -224,13 +224,13 @@ func (m *MockSecretsManagerAPI) DeleteSecretRequest(arg0 *secretsmanager.DeleteS
 	return ret0, ret1
 }
 
-// DeleteSecretRequest indicates an expected call of DeleteSecretRequest
+// DeleteSecretRequest indicates an expected call of DeleteSecretRequest.
 func (mr *MockSecretsManagerAPIMockRecorder) DeleteSecretRequest(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSecretRequest", reflect.TypeOf((*MockSecretsManagerAPI)(nil).DeleteSecretRequest), arg0)
 }
 
-// DeleteSecretWithContext mocks base method
+// DeleteSecretWithContext mocks base method.
 func (m *MockSecretsManagerAPI) DeleteSecretWithContext(arg0 context.Context, arg1 *secretsmanager.DeleteSecretInput, arg2 ...request.Option) (*secretsmanager.DeleteSecretOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
@@ -243,14 +243,14 @@ func (m *MockSecretsManagerAPI) DeleteSecretWithContext(arg0 context.Context, ar
 	return ret0, ret1
 }
 
-// DeleteSecretWithContext indicates an expected call of DeleteSecretWithContext
+// DeleteSecretWithContext indicates an expected call of DeleteSecretWithContext.
 func (mr *MockSecretsManagerAPIMockRecorder) DeleteSecretWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSecretWithContext", reflect.TypeOf((*MockSecretsManagerAPI)(nil).DeleteSecretWithContext), varargs...)
 }
 
-// DescribeSecret mocks base method
+// DescribeSecret mocks base method.
 func (m *MockSecretsManagerAPI) DescribeSecret(arg0 *secretsmanager.DescribeSecretInput) (*secretsmanager.DescribeSecretOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeSecret", arg0)
@@ -259,13 +259,13 @@ func (m *MockSecretsManagerAPI) DescribeSecret(arg0 *secretsmanager.DescribeSecr
 	return ret0, ret1
 }
 
-// DescribeSecret indicates an expected call of DescribeSecret
+// DescribeSecret indicates an expected call of DescribeSecret.
 func (mr *MockSecretsManagerAPIMockRecorder) DescribeSecret(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSecret", reflect.TypeOf((*MockSecretsManagerAPI)(nil).DescribeSecret), arg0)
 }
 
-// DescribeSecretRequest mocks base method
+// DescribeSecretRequest mocks base method.
 func (m *MockSecretsManagerAPI) DescribeSecretRequest(arg0 *secretsmanager.DescribeSecretInput) (*request.Request, *secretsmanager.DescribeSecretOutput) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeSecretRequest", arg0)
@@ -274,13 +274,13 @@ func (m *MockSecretsManagerAPI) DescribeSecretRequest(arg0 *secretsmanager.Descr
 	return ret0, ret1
 }
 
-// DescribeSecretRequest indicates an expected call of DescribeSecretRequest
+// DescribeSecretRequest indicates an expected call of DescribeSecretRequest.
 func (mr *MockSecretsManagerAPIMockRecorder) DescribeSecretRequest(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSecretRequest", reflect.TypeOf((*MockSecretsManagerAPI)(nil).DescribeSecretRequest), arg0)
 }
 
-// DescribeSecretWithContext mocks base method
+// DescribeSecretWithContext mocks base method.
 func (m *MockSecretsManagerAPI) DescribeSecretWithContext(arg0 context.Context, arg1 *secretsmanager.DescribeSecretInput, arg2 ...request.Option) (*secretsmanager.DescribeSecretOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
@@ -293,14 +293,14 @@ func (m *MockSecretsManagerAPI) DescribeSecretWithContext(arg0 context.Context, 
 	return ret0, ret1
 }
 
-// DescribeSecretWithContext indicates an expected call of DescribeSecretWithContext
+// DescribeSecretWithContext indicates an expected call of DescribeSecretWithContext.
 func (mr *MockSecretsManagerAPIMockRecorder) DescribeSecretWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSecretWithContext", reflect.TypeOf((*MockSecretsManagerAPI)(nil).DescribeSecretWithContext), varargs...)
 }
 
-// GetRandomPassword mocks base method
+// GetRandomPassword mocks base method.
 func (m *MockSecretsManagerAPI) GetRandomPassword(arg0 *secretsmanager.GetRandomPasswordInput) (*secretsmanager.GetRandomPasswordOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRandomPassword", arg0)
@@ -309,13 +309,13 @@ func (m *MockSecretsManagerAPI) GetRandomPassword(arg0 *secretsmanager.GetRandom
 	return ret0, ret1
 }
 
-// GetRandomPassword indicates an expected call of GetRandomPassword
+// GetRandomPassword indicates an expected call of GetRandomPassword.
 func (mr *MockSecretsManagerAPIMockRecorder) GetRandomPassword(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRandomPassword", reflect.TypeOf((*MockSecretsManagerAPI)(nil).GetRandomPassword), arg0)
 }
 
-// GetRandomPasswordRequest mocks base method
+// GetRandomPasswordRequest mocks base method.
 func (m *MockSecretsManagerAPI) GetRandomPasswordRequest(arg0 *secretsmanager.GetRandomPasswordInput) (*request.Request, *secretsmanager.GetRandomPasswordOutput) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRandomPasswordRequest", arg0)
@@ -324,13 +324,13 @@ func (m *MockSecretsManagerAPI) GetRandomPasswordRequest(arg0 *secretsmanager.Ge
 	return ret0, ret1
 }
 
-// GetRandomPasswordRequest indicates an expected call of GetRandomPasswordRequest
+// GetRandomPasswordRequest indicates an expected call of GetRandomPasswordRequest.
 func (mr *MockSecretsManagerAPIMockRecorder) GetRandomPasswordRequest(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRandomPasswordRequest", reflect.TypeOf((*MockSecretsManagerAPI)(nil).GetRandomPasswordRequest), arg0)
 }
 
-// GetRandomPasswordWithContext mocks base method
+// GetRandomPasswordWithContext mocks base method.
 func (m *MockSecretsManagerAPI) GetRandomPasswordWithContext(arg0 context.Context, arg1 *secretsmanager.GetRandomPasswordInput, arg2 ...request.Option) (*secretsmanager.GetRandomPasswordOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
@@ -343,14 +343,14 @@ func (m *MockSecretsManagerAPI) GetRandomPasswordWithContext(arg0 context.Contex
 	return ret0, ret1
 }
 
-// GetRandomPasswordWithContext indicates an expected call of GetRandomPasswordWithContext
+// GetRandomPasswordWithContext indicates an expected call of GetRandomPasswordWithContext.
 func (mr *MockSecretsManagerAPIMockRecorder) GetRandomPasswordWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRandomPasswordWithContext", reflect.TypeOf((*MockSecretsManagerAPI)(nil).GetRandomPasswordWithContext), varargs...)
 }
 
-// GetResourcePolicy mocks base method
+// GetResourcePolicy mocks base method.
 func (m *MockSecretsManagerAPI) GetResourcePolicy(arg0 *secretsmanager.GetResourcePolicyInput) (*secretsmanager.GetResourcePolicyOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetResourcePolicy", arg0)
@@ -359,13 +359,13 @@ func (m *MockSecretsManagerAPI) GetResourcePolicy(arg0 *secretsmanager.GetResour
 	return ret0, ret1
 }
 
-// GetResourcePolicy indicates an expected call of GetResourcePolicy
+// GetResourcePolicy indicates an expected call of GetResourcePolicy.
 func (mr *MockSecretsManagerAPIMockRecorder) GetResourcePolicy(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResourcePolicy", reflect.TypeOf((*MockSecretsManagerAPI)(nil).GetResourcePolicy), arg0)
 }
 
-// GetResourcePolicyRequest mocks base method
+// GetResourcePolicyRequest mocks base method.
 func (m *MockSecretsManagerAPI) GetResourcePolicyRequest(arg0 *secretsmanager.GetResourcePolicyInput) (*request.Request, *secretsmanager.GetResourcePolicyOutput) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetResourcePolicyRequest", arg0)
@@ -374,13 +374,13 @@ func (m *MockSecretsManagerAPI) GetResourcePolicyRequest(arg0 *secretsmanager.Ge
 	return ret0, ret1
 }
 
-// GetResourcePolicyRequest indicates an expected call of GetResourcePolicyRequest
+// GetResourcePolicyRequest indicates an expected call of GetResourcePolicyRequest.
 func (mr *MockSecretsManagerAPIMockRecorder) GetResourcePolicyRequest(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResourcePolicyRequest", reflect.TypeOf((*MockSecretsManagerAPI)(nil).GetResourcePolicyRequest), arg0)
 }
 
-// GetResourcePolicyWithContext mocks base method
+// GetResourcePolicyWithContext mocks base method.
 func (m *MockSecretsManagerAPI) GetResourcePolicyWithContext(arg0 context.Context, arg1 *secretsmanager.GetResourcePolicyInput, arg2 ...request.Option) (*secretsmanager.GetResourcePolicyOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
@@ -393,14 +393,14 @@ func (m *MockSecretsManagerAPI) GetResourcePolicyWithContext(arg0 context.Contex
 	return ret0, ret1
 }
 
-// GetResourcePolicyWithContext indicates an expected call of GetResourcePolicyWithContext
+// GetResourcePolicyWithContext indicates an expected call of GetResourcePolicyWithContext.
 func (mr *MockSecretsManagerAPIMockRecorder) GetResourcePolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResourcePolicyWithContext", reflect.TypeOf((*MockSecretsManagerAPI)(nil).GetResourcePolicyWithContext), varargs...)
 }
 
-// GetSecretValue mocks base method
+// GetSecretValue mocks base method.
 func (m *MockSecretsManagerAPI) GetSecretValue(arg0 *secretsmanager.GetSecretValueInput) (*secretsmanager.GetSecretValueOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSecretValue", arg0)
@@ -409,13 +409,13 @@ func (m *MockSecretsManagerAPI) GetSecretValue(arg0 *secretsmanager.GetSecretVal
 	return ret0, ret1
 }
 
-// GetSecretValue indicates an expected call of GetSecretValue
+// GetSecretValue indicates an expected call of GetSecretValue.
 func (mr *MockSecretsManagerAPIMockRecorder) GetSecretValue(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecretValue", reflect.TypeOf((*MockSecretsManagerAPI)(nil).GetSecretValue), arg0)
 }
 
-// GetSecretValueRequest mocks base method
+// GetSecretValueRequest mocks base method.
 func (m *MockSecretsManagerAPI) GetSecretValueRequest(arg0 *secretsmanager.GetSecretValueInput) (*request.Request, *secretsmanager.GetSecretValueOutput) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSecretValueRequest", arg0)
@@ -424,13 +424,13 @@ func (m *MockSecretsManagerAPI) GetSecretValueRequest(arg0 *secretsmanager.GetSe
 	return ret0, ret1
 }
 
-// GetSecretValueRequest indicates an expected call of GetSecretValueRequest
+// GetSecretValueRequest indicates an expected call of GetSecretValueRequest.
 func (mr *MockSecretsManagerAPIMockRecorder) GetSecretValueRequest(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecretValueRequest", reflect.TypeOf((*MockSecretsManagerAPI)(nil).GetSecretValueRequest), arg0)
 }
 
-// GetSecretValueWithContext mocks base method
+// GetSecretValueWithContext mocks base method.
 func (m *MockSecretsManagerAPI) GetSecretValueWithContext(arg0 context.Context, arg1 *secretsmanager.GetSecretValueInput, arg2 ...request.Option) (*secretsmanager.GetSecretValueOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
@@ -443,14 +443,14 @@ func (m *MockSecretsManagerAPI) GetSecretValueWithContext(arg0 context.Context, 
 	return ret0, ret1
 }
 
-// GetSecretValueWithContext indicates an expected call of GetSecretValueWithContext
+// GetSecretValueWithContext indicates an expected call of GetSecretValueWithContext.
 func (mr *MockSecretsManagerAPIMockRecorder) GetSecretValueWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecretValueWithContext", reflect.TypeOf((*MockSecretsManagerAPI)(nil).GetSecretValueWithContext), varargs...)
 }
 
-// ListSecretVersionIds mocks base method
+// ListSecretVersionIds mocks base method.
 func (m *MockSecretsManagerAPI) ListSecretVersionIds(arg0 *secretsmanager.ListSecretVersionIdsInput) (*secretsmanager.ListSecretVersionIdsOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListSecretVersionIds", arg0)
@@ -459,13 +459,13 @@ func (m *MockSecretsManagerAPI) ListSecretVersionIds(arg0 *secretsmanager.ListSe
 	return ret0, ret1
 }
 
-// ListSecretVersionIds indicates an expected call of ListSecretVersionIds
+// ListSecretVersionIds indicates an expected call of ListSecretVersionIds.
 func (mr *MockSecretsManagerAPIMockRecorder) ListSecretVersionIds(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSecretVersionIds", reflect.TypeOf((*MockSecretsManagerAPI)(nil).ListSecretVersionIds), arg0)
 }
 
-// ListSecretVersionIdsPages mocks base method
+// ListSecretVersionIdsPages mocks base method.
 func (m *MockSecretsManagerAPI) ListSecretVersionIdsPages(arg0 *secretsmanager.ListSecretVersionIdsInput, arg1 func(*secretsmanager.ListSecretVersionIdsOutput, bool) bool) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListSecretVersionIdsPages", arg0, arg1)
@@ -473,13 +473,13 @@ func (m *MockSecretsManagerAPI) ListSecretVersionIdsPages(arg0 *secretsmanager.L
 	return ret0
 }
 
-// ListSecretVersionIdsPages indicates an expected call of ListSecretVersionIdsPages
+// ListSecretVersionIdsPages indicates an expected call of ListSecretVersionIdsPages.
 func (mr *MockSecretsManagerAPIMockRecorder) ListSecretVersionIdsPages(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSecretVersionIdsPages", reflect.TypeOf((*MockSecretsManagerAPI)(nil).ListSecretVersionIdsPages), arg0, arg1)
 }
 
-// ListSecretVersionIdsPagesWithContext mocks base method
+// ListSecretVersionIdsPagesWithContext mocks base method.
 func (m *MockSecretsManagerAPI) ListSecretVersionIdsPagesWithContext(arg0 context.Context, arg1 *secretsmanager.ListSecretVersionIdsInput, arg2 func(*secretsmanager.ListSecretVersionIdsOutput, bool) bool, arg3 ...request.Option) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
@@ -491,14 +491,14 @@ func (m *MockSecretsManagerAPI) ListSecretVersionIdsPagesWithContext(arg0 contex
 	return ret0
 }
 
-// ListSecretVersionIdsPagesWithContext indicates an expected call of ListSecretVersionIdsPagesWithContext
+// ListSecretVersionIdsPagesWithContext indicates an expected call of ListSecretVersionIdsPagesWithContext.
 func (mr *MockSecretsManagerAPIMockRecorder) ListSecretVersionIdsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSecretVersionIdsPagesWithContext", reflect.TypeOf((*MockSecretsManagerAPI)(nil).ListSecretVersionIdsPagesWithContext), varargs...)
 }
 
-// ListSecretVersionIdsRequest mocks base method
+// ListSecretVersionIdsRequest mocks base method.
 func (m *MockSecretsManagerAPI) ListSecretVersionIdsRequest(arg0 *secretsmanager.ListSecretVersionIdsInput) (*request.Request, *secretsmanager.ListSecretVersionIdsOutput) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListSecretVersionIdsRequest", arg0)
@@ -507,13 +507,13 @@ func (m *MockSecretsManagerAPI) ListSecretVersionIdsRequest(arg0 *secretsmanager
 	return ret0, ret1
 }
 
-// ListSecretVersionIdsRequest indicates an expected call of ListSecretVersionIdsRequest
+// ListSecretVersionIdsRequest indicates an expected call of ListSecretVersionIdsRequest.
 func (mr *MockSecretsManagerAPIMockRecorder) ListSecretVersionIdsRequest(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSecretVersionIdsRequest", reflect.TypeOf((*MockSecretsManagerAPI)(nil).ListSecretVersionIdsRequest), arg0)
 }
 
-// ListSecretVersionIdsWithContext mocks base method
+// ListSecretVersionIdsWithContext mocks base method.
 func (m *MockSecretsManagerAPI) ListSecretVersionIdsWithContext(arg0 context.Context, arg1 *secretsmanager.ListSecretVersionIdsInput, arg2 ...request.Option) (*secretsmanager.ListSecretVersionIdsOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
@@ -526,14 +526,14 @@ func (m *MockSecretsManagerAPI) ListSecretVersionIdsWithContext(arg0 context.Con
 	return ret0, ret1
 }
 
-// ListSecretVersionIdsWithContext indicates an expected call of ListSecretVersionIdsWithContext
+// ListSecretVersionIdsWithContext indicates an expected call of ListSecretVersionIdsWithContext.
 func (mr *MockSecretsManagerAPIMockRecorder) ListSecretVersionIdsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSecretVersionIdsWithContext", reflect.TypeOf((*MockSecretsManagerAPI)(nil).ListSecretVersionIdsWithContext), varargs...)
 }
 
-// ListSecrets mocks base method
+// ListSecrets mocks base method.
 func (m *MockSecretsManagerAPI) ListSecrets(arg0 *secretsmanager.ListSecretsInput) (*secretsmanager.ListSecretsOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListSecrets", arg0)
@@ -542,13 +542,13 @@ func (m *MockSecretsManagerAPI) ListSecrets(arg0 *secretsmanager.ListSecretsInpu
 	return ret0, ret1
 }
 
-// ListSecrets indicates an expected call of ListSecrets
+// ListSecrets indicates an expected call of ListSecrets.
 func (mr *MockSecretsManagerAPIMockRecorder) ListSecrets(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSecrets", reflect.TypeOf((*MockSecretsManagerAPI)(nil).ListSecrets), arg0)
 }
 
-// ListSecretsPages mocks base method
+// ListSecretsPages mocks base method.
 func (m *MockSecretsManagerAPI) ListSecretsPages(arg0 *secretsmanager.ListSecretsInput, arg1 func(*secretsmanager.ListSecretsOutput, bool) bool) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListSecretsPages", arg0, arg1)
@@ -556,13 +556,13 @@ func (m *MockSecretsManagerAPI) ListSecretsPages(arg0 *secretsmanager.ListSecret
 	return ret0
 }
 
-// ListSecretsPages indicates an expected call of ListSecretsPages
+// ListSecretsPages indicates an expected call of ListSecretsPages.
 func (mr *MockSecretsManagerAPIMockRecorder) ListSecretsPages(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSecretsPages", reflect.TypeOf((*MockSecretsManagerAPI)(nil).ListSecretsPages), arg0, arg1)
 }
 
-// ListSecretsPagesWithContext mocks base method
+// ListSecretsPagesWithContext mocks base method.
 func (m *MockSecretsManagerAPI) ListSecretsPagesWithContext(arg0 context.Context, arg1 *secretsmanager.ListSecretsInput, arg2 func(*secretsmanager.ListSecretsOutput, bool) bool, arg3 ...request.Option) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
@@ -574,14 +574,14 @@ func (m *MockSecretsManagerAPI) ListSecretsPagesWithContext(arg0 context.Context
 	return ret0
 }
 
-// ListSecretsPagesWithContext indicates an expected call of ListSecretsPagesWithContext
+// ListSecretsPagesWithContext indicates an expected call of ListSecretsPagesWithContext.
 func (mr *MockSecretsManagerAPIMockRecorder) ListSecretsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSecretsPagesWithContext", reflect.TypeOf((*MockSecretsManagerAPI)(nil).ListSecretsPagesWithContext), varargs...)
 }
 
-// ListSecretsRequest mocks base method
+// ListSecretsRequest mocks base method.
 func (m *MockSecretsManagerAPI) ListSecretsRequest(arg0 *secretsmanager.ListSecretsInput) (*request.Request, *secretsmanager.ListSecretsOutput) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListSecretsRequest", arg0)
@@ -590,13 +590,13 @@ func (m *MockSecretsManagerAPI) ListSecretsRequest(arg0 *secretsmanager.ListSecr
 	return ret0, ret1
 }
 
-// ListSecretsRequest indicates an expected call of ListSecretsRequest
+// ListSecretsRequest indicates an expected call of ListSecretsRequest.
 func (mr *MockSecretsManagerAPIMockRecorder) ListSecretsRequest(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSecretsRequest", reflect.TypeOf((*MockSecretsManagerAPI)(nil).ListSecretsRequest), arg0)
 }
 
-// ListSecretsWithContext mocks base method
+// ListSecretsWithContext mocks base method.
 func (m *MockSecretsManagerAPI) ListSecretsWithContext(arg0 context.Context, arg1 *secretsmanager.ListSecretsInput, arg2 ...request.Option) (*secretsmanager.ListSecretsOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
@@ -609,14 +609,14 @@ func (m *MockSecretsManagerAPI) ListSecretsWithContext(arg0 context.Context, arg
 	return ret0, ret1
 }
 
-// ListSecretsWithContext indicates an expected call of ListSecretsWithContext
+// ListSecretsWithContext indicates an expected call of ListSecretsWithContext.
 func (mr *MockSecretsManagerAPIMockRecorder) ListSecretsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSecretsWithContext", reflect.TypeOf((*MockSecretsManagerAPI)(nil).ListSecretsWithContext), varargs...)
 }
 
-// PutResourcePolicy mocks base method
+// PutResourcePolicy mocks base method.
 func (m *MockSecretsManagerAPI) PutResourcePolicy(arg0 *secretsmanager.PutResourcePolicyInput) (*secretsmanager.PutResourcePolicyOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutResourcePolicy", arg0)
@@ -625,13 +625,13 @@ func (m *MockSecretsManagerAPI) PutResourcePolicy(arg0 *secretsmanager.PutResour
 	return ret0, ret1
 }
 
-// PutResourcePolicy indicates an expected call of PutResourcePolicy
+// PutResourcePolicy indicates an expected call of PutResourcePolicy.
 func (mr *MockSecretsManagerAPIMockRecorder) PutResourcePolicy(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutResourcePolicy", reflect.TypeOf((*MockSecretsManagerAPI)(nil).PutResourcePolicy), arg0)
 }
 
-// PutResourcePolicyRequest mocks base method
+// PutResourcePolicyRequest mocks base method.
 func (m *MockSecretsManagerAPI) PutResourcePolicyRequest(arg0 *secretsmanager.PutResourcePolicyInput) (*request.Request, *secretsmanager.PutResourcePolicyOutput) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutResourcePolicyRequest", arg0)
@@ -640,13 +640,13 @@ func (m *MockSecretsManagerAPI) PutResourcePolicyRequest(arg0 *secretsmanager.Pu
 	return ret0, ret1
 }
 
-// PutResourcePolicyRequest indicates an expected call of PutResourcePolicyRequest
+// PutResourcePolicyRequest indicates an expected call of PutResourcePolicyRequest.
 func (mr *MockSecretsManagerAPIMockRecorder) PutResourcePolicyRequest(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutResourcePolicyRequest", reflect.TypeOf((*MockSecretsManagerAPI)(nil).PutResourcePolicyRequest), arg0)
 }
 
-// PutResourcePolicyWithContext mocks base method
+// PutResourcePolicyWithContext mocks base method.
 func (m *MockSecretsManagerAPI) PutResourcePolicyWithContext(arg0 context.Context, arg1 *secretsmanager.PutResourcePolicyInput, arg2 ...request.Option) (*secretsmanager.PutResourcePolicyOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
@@ -659,14 +659,14 @@ func (m *MockSecretsManagerAPI) PutResourcePolicyWithContext(arg0 context.Contex
 	return ret0, ret1
 }
 
-// PutResourcePolicyWithContext indicates an expected call of PutResourcePolicyWithContext
+// PutResourcePolicyWithContext indicates an expected call of PutResourcePolicyWithContext.
 func (mr *MockSecretsManagerAPIMockRecorder) PutResourcePolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutResourcePolicyWithContext", reflect.TypeOf((*MockSecretsManagerAPI)(nil).PutResourcePolicyWithContext), varargs...)
 }
 
-// PutSecretValue mocks base method
+// PutSecretValue mocks base method.
 func (m *MockSecretsManagerAPI) PutSecretValue(arg0 *secretsmanager.PutSecretValueInput) (*secretsmanager.PutSecretValueOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutSecretValue", arg0)
@@ -675,13 +675,13 @@ func (m *MockSecretsManagerAPI) PutSecretValue(arg0 *secretsmanager.PutSecretVal
 	return ret0, ret1
 }
 
-// PutSecretValue indicates an expected call of PutSecretValue
+// PutSecretValue indicates an expected call of PutSecretValue.
 func (mr *MockSecretsManagerAPIMockRecorder) PutSecretValue(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutSecretValue", reflect.TypeOf((*MockSecretsManagerAPI)(nil).PutSecretValue), arg0)
 }
 
-// PutSecretValueRequest mocks base method
+// PutSecretValueRequest mocks base method.
 func (m *MockSecretsManagerAPI) PutSecretValueRequest(arg0 *secretsmanager.PutSecretValueInput) (*request.Request, *secretsmanager.PutSecretValueOutput) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutSecretValueRequest", arg0)
@@ -690,13 +690,13 @@ func (m *MockSecretsManagerAPI) PutSecretValueRequest(arg0 *secretsmanager.PutSe
 	return ret0, ret1
 }
 
-// PutSecretValueRequest indicates an expected call of PutSecretValueRequest
+// PutSecretValueRequest indicates an expected call of PutSecretValueRequest.
 func (mr *MockSecretsManagerAPIMockRecorder) PutSecretValueRequest(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutSecretValueRequest", reflect.TypeOf((*MockSecretsManagerAPI)(nil).PutSecretValueRequest), arg0)
 }
 
-// PutSecretValueWithContext mocks base method
+// PutSecretValueWithContext mocks base method.
 func (m *MockSecretsManagerAPI) PutSecretValueWithContext(arg0 context.Context, arg1 *secretsmanager.PutSecretValueInput, arg2 ...request.Option) (*secretsmanager.PutSecretValueOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
@@ -709,14 +709,14 @@ func (m *MockSecretsManagerAPI) PutSecretValueWithContext(arg0 context.Context, 
 	return ret0, ret1
 }
 
-// PutSecretValueWithContext indicates an expected call of PutSecretValueWithContext
+// PutSecretValueWithContext indicates an expected call of PutSecretValueWithContext.
 func (mr *MockSecretsManagerAPIMockRecorder) PutSecretValueWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutSecretValueWithContext", reflect.TypeOf((*MockSecretsManagerAPI)(nil).PutSecretValueWithContext), varargs...)
 }
 
-// RestoreSecret mocks base method
+// RestoreSecret mocks base method.
 func (m *MockSecretsManagerAPI) RestoreSecret(arg0 *secretsmanager.RestoreSecretInput) (*secretsmanager.RestoreSecretOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RestoreSecret", arg0)
@@ -725,13 +725,13 @@ func (m *MockSecretsManagerAPI) RestoreSecret(arg0 *secretsmanager.RestoreSecret
 	return ret0, ret1
 }
 
-// RestoreSecret indicates an expected call of RestoreSecret
+// RestoreSecret indicates an expected call of RestoreSecret.
 func (mr *MockSecretsManagerAPIMockRecorder) RestoreSecret(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestoreSecret", reflect.TypeOf((*MockSecretsManagerAPI)(nil).RestoreSecret), arg0)
 }
 
-// RestoreSecretRequest mocks base method
+// RestoreSecretRequest mocks base method.
 func (m *MockSecretsManagerAPI) RestoreSecretRequest(arg0 *secretsmanager.RestoreSecretInput) (*request.Request, *secretsmanager.RestoreSecretOutput) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RestoreSecretRequest", arg0)
@@ -740,13 +740,13 @@ func (m *MockSecretsManagerAPI) RestoreSecretRequest(arg0 *secretsmanager.Restor
 	return ret0, ret1
 }
 
-// RestoreSecretRequest indicates an expected call of RestoreSecretRequest
+// RestoreSecretRequest indicates an expected call of RestoreSecretRequest.
 func (mr *MockSecretsManagerAPIMockRecorder) RestoreSecretRequest(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestoreSecretRequest", reflect.TypeOf((*MockSecretsManagerAPI)(nil).RestoreSecretRequest), arg0)
 }
 
-// RestoreSecretWithContext mocks base method
+// RestoreSecretWithContext mocks base method.
 func (m *MockSecretsManagerAPI) RestoreSecretWithContext(arg0 context.Context, arg1 *secretsmanager.RestoreSecretInput, arg2 ...request.Option) (*secretsmanager.RestoreSecretOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
@@ -759,14 +759,14 @@ func (m *MockSecretsManagerAPI) RestoreSecretWithContext(arg0 context.Context, a
 	return ret0, ret1
 }
 
-// RestoreSecretWithContext indicates an expected call of RestoreSecretWithContext
+// RestoreSecretWithContext indicates an expected call of RestoreSecretWithContext.
 func (mr *MockSecretsManagerAPIMockRecorder) RestoreSecretWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestoreSecretWithContext", reflect.TypeOf((*MockSecretsManagerAPI)(nil).RestoreSecretWithContext), varargs...)
 }
 
-// RotateSecret mocks base method
+// RotateSecret mocks base method.
 func (m *MockSecretsManagerAPI) RotateSecret(arg0 *secretsmanager.RotateSecretInput) (*secretsmanager.RotateSecretOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RotateSecret", arg0)
@@ -775,13 +775,13 @@ func (m *MockSecretsManagerAPI) RotateSecret(arg0 *secretsmanager.RotateSecretIn
 	return ret0, ret1
 }
 
-// RotateSecret indicates an expected call of RotateSecret
+// RotateSecret indicates an expected call of RotateSecret.
 func (mr *MockSecretsManagerAPIMockRecorder) RotateSecret(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RotateSecret", reflect.TypeOf((*MockSecretsManagerAPI)(nil).RotateSecret), arg0)
 }
 
-// RotateSecretRequest mocks base method
+// RotateSecretRequest mocks base method.
 func (m *MockSecretsManagerAPI) RotateSecretRequest(arg0 *secretsmanager.RotateSecretInput) (*request.Request, *secretsmanager.RotateSecretOutput) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RotateSecretRequest", arg0)
@@ -790,13 +790,13 @@ func (m *MockSecretsManagerAPI) RotateSecretRequest(arg0 *secretsmanager.RotateS
 	return ret0, ret1
 }
 
-// RotateSecretRequest indicates an expected call of RotateSecretRequest
+// RotateSecretRequest indicates an expected call of RotateSecretRequest.
 func (mr *MockSecretsManagerAPIMockRecorder) RotateSecretRequest(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RotateSecretRequest", reflect.TypeOf((*MockSecretsManagerAPI)(nil).RotateSecretRequest), arg0)
 }
 
-// RotateSecretWithContext mocks base method
+// RotateSecretWithContext mocks base method.
 func (m *MockSecretsManagerAPI) RotateSecretWithContext(arg0 context.Context, arg1 *secretsmanager.RotateSecretInput, arg2 ...request.Option) (*secretsmanager.RotateSecretOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
@@ -809,14 +809,14 @@ func (m *MockSecretsManagerAPI) RotateSecretWithContext(arg0 context.Context, ar
 	return ret0, ret1
 }
 
-// RotateSecretWithContext indicates an expected call of RotateSecretWithContext
+// RotateSecretWithContext indicates an expected call of RotateSecretWithContext.
 func (mr *MockSecretsManagerAPIMockRecorder) RotateSecretWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RotateSecretWithContext", reflect.TypeOf((*MockSecretsManagerAPI)(nil).RotateSecretWithContext), varargs...)
 }
 
-// TagResource mocks base method
+// TagResource mocks base method.
 func (m *MockSecretsManagerAPI) TagResource(arg0 *secretsmanager.TagResourceInput) (*secretsmanager.TagResourceOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TagResource", arg0)
@@ -825,13 +825,13 @@ func (m *MockSecretsManagerAPI) TagResource(arg0 *secretsmanager.TagResourceInpu
 	return ret0, ret1
 }
 
-// TagResource indicates an expected call of TagResource
+// TagResource indicates an expected call of TagResource.
 func (mr *MockSecretsManagerAPIMockRecorder) TagResource(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TagResource", reflect.TypeOf((*MockSecretsManagerAPI)(nil).TagResource), arg0)
 }
 
-// TagResourceRequest mocks base method
+// TagResourceRequest mocks base method.
 func (m *MockSecretsManagerAPI) TagResourceRequest(arg0 *secretsmanager.TagResourceInput) (*request.Request, *secretsmanager.TagResourceOutput) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TagResourceRequest", arg0)
@@ -840,13 +840,13 @@ func (m *MockSecretsManagerAPI) TagResourceRequest(arg0 *secretsmanager.TagResou
 	return ret0, ret1
 }
 
-// TagResourceRequest indicates an expected call of TagResourceRequest
+// TagResourceRequest indicates an expected call of TagResourceRequest.
 func (mr *MockSecretsManagerAPIMockRecorder) TagResourceRequest(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TagResourceRequest", reflect.TypeOf((*MockSecretsManagerAPI)(nil).TagResourceRequest), arg0)
 }
 
-// TagResourceWithContext mocks base method
+// TagResourceWithContext mocks base method.
 func (m *MockSecretsManagerAPI) TagResourceWithContext(arg0 context.Context, arg1 *secretsmanager.TagResourceInput, arg2 ...request.Option) (*secretsmanager.TagResourceOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
@@ -859,14 +859,14 @@ func (m *MockSecretsManagerAPI) TagResourceWithContext(arg0 context.Context, arg
 	return ret0, ret1
 }
 
-// TagResourceWithContext indicates an expected call of TagResourceWithContext
+// TagResourceWithContext indicates an expected call of TagResourceWithContext.
 func (mr *MockSecretsManagerAPIMockRecorder) TagResourceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TagResourceWithContext", reflect.TypeOf((*MockSecretsManagerAPI)(nil).TagResourceWithContext), varargs...)
 }
 
-// UntagResource mocks base method
+// UntagResource mocks base method.
 func (m *MockSecretsManagerAPI) UntagResource(arg0 *secretsmanager.UntagResourceInput) (*secretsmanager.UntagResourceOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UntagResource", arg0)
@@ -875,13 +875,13 @@ func (m *MockSecretsManagerAPI) UntagResource(arg0 *secretsmanager.UntagResource
 	return ret0, ret1
 }
 
-// UntagResource indicates an expected call of UntagResource
+// UntagResource indicates an expected call of UntagResource.
 func (mr *MockSecretsManagerAPIMockRecorder) UntagResource(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UntagResource", reflect.TypeOf((*MockSecretsManagerAPI)(nil).UntagResource), arg0)
 }
 
-// UntagResourceRequest mocks base method
+// UntagResourceRequest mocks base method.
 func (m *MockSecretsManagerAPI) UntagResourceRequest(arg0 *secretsmanager.UntagResourceInput) (*request.Request, *secretsmanager.UntagResourceOutput) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UntagResourceRequest", arg0)
@@ -890,13 +890,13 @@ func (m *MockSecretsManagerAPI) UntagResourceRequest(arg0 *secretsmanager.UntagR
 	return ret0, ret1
 }
 
-// UntagResourceRequest indicates an expected call of UntagResourceRequest
+// UntagResourceRequest indicates an expected call of UntagResourceRequest.
 func (mr *MockSecretsManagerAPIMockRecorder) UntagResourceRequest(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UntagResourceRequest", reflect.TypeOf((*MockSecretsManagerAPI)(nil).UntagResourceRequest), arg0)
 }
 
-// UntagResourceWithContext mocks base method
+// UntagResourceWithContext mocks base method.
 func (m *MockSecretsManagerAPI) UntagResourceWithContext(arg0 context.Context, arg1 *secretsmanager.UntagResourceInput, arg2 ...request.Option) (*secretsmanager.UntagResourceOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
@@ -909,14 +909,14 @@ func (m *MockSecretsManagerAPI) UntagResourceWithContext(arg0 context.Context, a
 	return ret0, ret1
 }
 
-// UntagResourceWithContext indicates an expected call of UntagResourceWithContext
+// UntagResourceWithContext indicates an expected call of UntagResourceWithContext.
 func (mr *MockSecretsManagerAPIMockRecorder) UntagResourceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UntagResourceWithContext", reflect.TypeOf((*MockSecretsManagerAPI)(nil).UntagResourceWithContext), varargs...)
 }
 
-// UpdateSecret mocks base method
+// UpdateSecret mocks base method.
 func (m *MockSecretsManagerAPI) UpdateSecret(arg0 *secretsmanager.UpdateSecretInput) (*secretsmanager.UpdateSecretOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateSecret", arg0)
@@ -925,13 +925,13 @@ func (m *MockSecretsManagerAPI) UpdateSecret(arg0 *secretsmanager.UpdateSecretIn
 	return ret0, ret1
 }
 
-// UpdateSecret indicates an expected call of UpdateSecret
+// UpdateSecret indicates an expected call of UpdateSecret.
 func (mr *MockSecretsManagerAPIMockRecorder) UpdateSecret(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSecret", reflect.TypeOf((*MockSecretsManagerAPI)(nil).UpdateSecret), arg0)
 }
 
-// UpdateSecretRequest mocks base method
+// UpdateSecretRequest mocks base method.
 func (m *MockSecretsManagerAPI) UpdateSecretRequest(arg0 *secretsmanager.UpdateSecretInput) (*request.Request, *secretsmanager.UpdateSecretOutput) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateSecretRequest", arg0)
@@ -940,13 +940,13 @@ func (m *MockSecretsManagerAPI) UpdateSecretRequest(arg0 *secretsmanager.UpdateS
 	return ret0, ret1
 }
 
-// UpdateSecretRequest indicates an expected call of UpdateSecretRequest
+// UpdateSecretRequest indicates an expected call of UpdateSecretRequest.
 func (mr *MockSecretsManagerAPIMockRecorder) UpdateSecretRequest(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSecretRequest", reflect.TypeOf((*MockSecretsManagerAPI)(nil).UpdateSecretRequest), arg0)
 }
 
-// UpdateSecretVersionStage mocks base method
+// UpdateSecretVersionStage mocks base method.
 func (m *MockSecretsManagerAPI) UpdateSecretVersionStage(arg0 *secretsmanager.UpdateSecretVersionStageInput) (*secretsmanager.UpdateSecretVersionStageOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateSecretVersionStage", arg0)
@@ -955,13 +955,13 @@ func (m *MockSecretsManagerAPI) UpdateSecretVersionStage(arg0 *secretsmanager.Up
 	return ret0, ret1
 }
 
-// UpdateSecretVersionStage indicates an expected call of UpdateSecretVersionStage
+// UpdateSecretVersionStage indicates an expected call of UpdateSecretVersionStage.
 func (mr *MockSecretsManagerAPIMockRecorder) UpdateSecretVersionStage(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSecretVersionStage", reflect.TypeOf((*MockSecretsManagerAPI)(nil).UpdateSecretVersionStage), arg0)
 }
 
-// UpdateSecretVersionStageRequest mocks base method
+// UpdateSecretVersionStageRequest mocks base method.
 func (m *MockSecretsManagerAPI) UpdateSecretVersionStageRequest(arg0 *secretsmanager.UpdateSecretVersionStageInput) (*request.Request, *secretsmanager.UpdateSecretVersionStageOutput) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateSecretVersionStageRequest", arg0)
@@ -970,13 +970,13 @@ func (m *MockSecretsManagerAPI) UpdateSecretVersionStageRequest(arg0 *secretsman
 	return ret0, ret1
 }
 
-// UpdateSecretVersionStageRequest indicates an expected call of UpdateSecretVersionStageRequest
+// UpdateSecretVersionStageRequest indicates an expected call of UpdateSecretVersionStageRequest.
 func (mr *MockSecretsManagerAPIMockRecorder) UpdateSecretVersionStageRequest(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSecretVersionStageRequest", reflect.TypeOf((*MockSecretsManagerAPI)(nil).UpdateSecretVersionStageRequest), arg0)
 }
 
-// UpdateSecretVersionStageWithContext mocks base method
+// UpdateSecretVersionStageWithContext mocks base method.
 func (m *MockSecretsManagerAPI) UpdateSecretVersionStageWithContext(arg0 context.Context, arg1 *secretsmanager.UpdateSecretVersionStageInput, arg2 ...request.Option) (*secretsmanager.UpdateSecretVersionStageOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
@@ -989,14 +989,14 @@ func (m *MockSecretsManagerAPI) UpdateSecretVersionStageWithContext(arg0 context
 	return ret0, ret1
 }
 
-// UpdateSecretVersionStageWithContext indicates an expected call of UpdateSecretVersionStageWithContext
+// UpdateSecretVersionStageWithContext indicates an expected call of UpdateSecretVersionStageWithContext.
 func (mr *MockSecretsManagerAPIMockRecorder) UpdateSecretVersionStageWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSecretVersionStageWithContext", reflect.TypeOf((*MockSecretsManagerAPI)(nil).UpdateSecretVersionStageWithContext), varargs...)
 }
 
-// UpdateSecretWithContext mocks base method
+// UpdateSecretWithContext mocks base method.
 func (m *MockSecretsManagerAPI) UpdateSecretWithContext(arg0 context.Context, arg1 *secretsmanager.UpdateSecretInput, arg2 ...request.Option) (*secretsmanager.UpdateSecretOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
@@ -1009,14 +1009,14 @@ func (m *MockSecretsManagerAPI) UpdateSecretWithContext(arg0 context.Context, ar
 	return ret0, ret1
 }
 
-// UpdateSecretWithContext indicates an expected call of UpdateSecretWithContext
+// UpdateSecretWithContext indicates an expected call of UpdateSecretWithContext.
 func (mr *MockSecretsManagerAPIMockRecorder) UpdateSecretWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSecretWithContext", reflect.TypeOf((*MockSecretsManagerAPI)(nil).UpdateSecretWithContext), varargs...)
 }
 
-// ValidateResourcePolicy mocks base method
+// ValidateResourcePolicy mocks base method.
 func (m *MockSecretsManagerAPI) ValidateResourcePolicy(arg0 *secretsmanager.ValidateResourcePolicyInput) (*secretsmanager.ValidateResourcePolicyOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ValidateResourcePolicy", arg0)
@@ -1025,13 +1025,13 @@ func (m *MockSecretsManagerAPI) ValidateResourcePolicy(arg0 *secretsmanager.Vali
 	return ret0, ret1
 }
 
-// ValidateResourcePolicy indicates an expected call of ValidateResourcePolicy
+// ValidateResourcePolicy indicates an expected call of ValidateResourcePolicy.
 func (mr *MockSecretsManagerAPIMockRecorder) ValidateResourcePolicy(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateResourcePolicy", reflect.TypeOf((*MockSecretsManagerAPI)(nil).ValidateResourcePolicy), arg0)
 }
 
-// ValidateResourcePolicyRequest mocks base method
+// ValidateResourcePolicyRequest mocks base method.
 func (m *MockSecretsManagerAPI) ValidateResourcePolicyRequest(arg0 *secretsmanager.ValidateResourcePolicyInput) (*request.Request, *secretsmanager.ValidateResourcePolicyOutput) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ValidateResourcePolicyRequest", arg0)
@@ -1040,13 +1040,13 @@ func (m *MockSecretsManagerAPI) ValidateResourcePolicyRequest(arg0 *secretsmanag
 	return ret0, ret1
 }
 
-// ValidateResourcePolicyRequest indicates an expected call of ValidateResourcePolicyRequest
+// ValidateResourcePolicyRequest indicates an expected call of ValidateResourcePolicyRequest.
 func (mr *MockSecretsManagerAPIMockRecorder) ValidateResourcePolicyRequest(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateResourcePolicyRequest", reflect.TypeOf((*MockSecretsManagerAPI)(nil).ValidateResourcePolicyRequest), arg0)
 }
 
-// ValidateResourcePolicyWithContext mocks base method
+// ValidateResourcePolicyWithContext mocks base method.
 func (m *MockSecretsManagerAPI) ValidateResourcePolicyWithContext(arg0 context.Context, arg1 *secretsmanager.ValidateResourcePolicyInput, arg2 ...request.Option) (*secretsmanager.ValidateResourcePolicyOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
@@ -1059,7 +1059,7 @@ func (m *MockSecretsManagerAPI) ValidateResourcePolicyWithContext(arg0 context.C
 	return ret0, ret1
 }
 
-// ValidateResourcePolicyWithContext indicates an expected call of ValidateResourcePolicyWithContext
+// ValidateResourcePolicyWithContext indicates an expected call of ValidateResourcePolicyWithContext.
 func (mr *MockSecretsManagerAPIMockRecorder) ValidateResourcePolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)

--- a/agent/async/mocks/async_mocks.go
+++ b/agent/async/mocks/async_mocks.go
@@ -25,42 +25,42 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockCache is a mock of Cache interface
+// MockCache is a mock of Cache interface.
 type MockCache struct {
 	ctrl     *gomock.Controller
 	recorder *MockCacheMockRecorder
 }
 
-// MockCacheMockRecorder is the mock recorder for MockCache
+// MockCacheMockRecorder is the mock recorder for MockCache.
 type MockCacheMockRecorder struct {
 	mock *MockCache
 }
 
-// NewMockCache creates a new mock instance
+// NewMockCache creates a new mock instance.
 func NewMockCache(ctrl *gomock.Controller) *MockCache {
 	mock := &MockCache{ctrl: ctrl}
 	mock.recorder = &MockCacheMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockCache) EXPECT() *MockCacheMockRecorder {
 	return m.recorder
 }
 
-// Delete mocks base method
+// Delete mocks base method.
 func (m *MockCache) Delete(arg0 string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Delete", arg0)
 }
 
-// Delete indicates an expected call of Delete
+// Delete indicates an expected call of Delete.
 func (mr *MockCacheMockRecorder) Delete(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockCache)(nil).Delete), arg0)
 }
 
-// Get mocks base method
+// Get mocks base method.
 func (m *MockCache) Get(arg0 string) (async.Value, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", arg0)
@@ -69,60 +69,60 @@ func (m *MockCache) Get(arg0 string) (async.Value, bool) {
 	return ret0, ret1
 }
 
-// Get indicates an expected call of Get
+// Get indicates an expected call of Get.
 func (mr *MockCacheMockRecorder) Get(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockCache)(nil).Get), arg0)
 }
 
-// Set mocks base method
+// Set mocks base method.
 func (m *MockCache) Set(arg0 string, arg1 async.Value) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Set", arg0, arg1)
 }
 
-// Set indicates an expected call of Set
+// Set indicates an expected call of Set.
 func (mr *MockCacheMockRecorder) Set(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Set", reflect.TypeOf((*MockCache)(nil).Set), arg0, arg1)
 }
 
-// MockTTLCache is a mock of TTLCache interface
+// MockTTLCache is a mock of TTLCache interface.
 type MockTTLCache struct {
 	ctrl     *gomock.Controller
 	recorder *MockTTLCacheMockRecorder
 }
 
-// MockTTLCacheMockRecorder is the mock recorder for MockTTLCache
+// MockTTLCacheMockRecorder is the mock recorder for MockTTLCache.
 type MockTTLCacheMockRecorder struct {
 	mock *MockTTLCache
 }
 
-// NewMockTTLCache creates a new mock instance
+// NewMockTTLCache creates a new mock instance.
 func NewMockTTLCache(ctrl *gomock.Controller) *MockTTLCache {
 	mock := &MockTTLCache{ctrl: ctrl}
 	mock.recorder = &MockTTLCacheMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockTTLCache) EXPECT() *MockTTLCacheMockRecorder {
 	return m.recorder
 }
 
-// Delete mocks base method
+// Delete mocks base method.
 func (m *MockTTLCache) Delete(arg0 string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Delete", arg0)
 }
 
-// Delete indicates an expected call of Delete
+// Delete indicates an expected call of Delete.
 func (mr *MockTTLCacheMockRecorder) Delete(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockTTLCache)(nil).Delete), arg0)
 }
 
-// Get mocks base method
+// Get mocks base method.
 func (m *MockTTLCache) Get(arg0 string) (interface{}, bool, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", arg0)
@@ -132,19 +132,19 @@ func (m *MockTTLCache) Get(arg0 string) (interface{}, bool, bool) {
 	return ret0, ret1, ret2
 }
 
-// Get indicates an expected call of Get
+// Get indicates an expected call of Get.
 func (mr *MockTTLCacheMockRecorder) Get(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockTTLCache)(nil).Get), arg0)
 }
 
-// Set mocks base method
+// Set mocks base method.
 func (m *MockTTLCache) Set(arg0 string, arg1 interface{}) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Set", arg0, arg1)
 }
 
-// Set indicates an expected call of Set
+// Set indicates an expected call of Set.
 func (mr *MockTTLCacheMockRecorder) Set(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Set", reflect.TypeOf((*MockTTLCache)(nil).Set), arg0, arg1)

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -88,7 +88,6 @@ func TestBrokenEC2MetadataEndpoint(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockEc2Metadata := mock_ec2.NewMockEC2MetadataClient(ctrl)
 
-	mockEc2Metadata.EXPECT().InstanceIdentityDocument().Return(ec2metadata.EC2InstanceIdentityDocument{}, errors.New("err"))
 	mockEc2Metadata.EXPECT().GetUserData()
 
 	config, err := NewConfig(mockEc2Metadata)

--- a/agent/containermetadata/mocks/containermetadata_mocks.go
+++ b/agent/containermetadata/mocks/containermetadata_mocks.go
@@ -29,30 +29,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockManager is a mock of Manager interface
+// MockManager is a mock of Manager interface.
 type MockManager struct {
 	ctrl     *gomock.Controller
 	recorder *MockManagerMockRecorder
 }
 
-// MockManagerMockRecorder is the mock recorder for MockManager
+// MockManagerMockRecorder is the mock recorder for MockManager.
 type MockManagerMockRecorder struct {
 	mock *MockManager
 }
 
-// NewMockManager creates a new mock instance
+// NewMockManager creates a new mock instance.
 func NewMockManager(ctrl *gomock.Controller) *MockManager {
 	mock := &MockManager{ctrl: ctrl}
 	mock.recorder = &MockManagerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockManager) EXPECT() *MockManagerMockRecorder {
 	return m.recorder
 }
 
-// Clean mocks base method
+// Clean mocks base method.
 func (m *MockManager) Clean(arg0 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Clean", arg0)
@@ -60,13 +60,13 @@ func (m *MockManager) Clean(arg0 string) error {
 	return ret0
 }
 
-// Clean indicates an expected call of Clean
+// Clean indicates an expected call of Clean.
 func (mr *MockManagerMockRecorder) Clean(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Clean", reflect.TypeOf((*MockManager)(nil).Clean), arg0)
 }
 
-// Create mocks base method
+// Create mocks base method.
 func (m *MockManager) Create(arg0 *container.Config, arg1 *container.HostConfig, arg2 *task.Task, arg3 string, arg4 []string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create", arg0, arg1, arg2, arg3, arg4)
@@ -74,61 +74,61 @@ func (m *MockManager) Create(arg0 *container.Config, arg1 *container.HostConfig,
 	return ret0
 }
 
-// Create indicates an expected call of Create
+// Create indicates an expected call of Create.
 func (mr *MockManagerMockRecorder) Create(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockManager)(nil).Create), arg0, arg1, arg2, arg3, arg4)
 }
 
-// SetAvailabilityZone mocks base method
+// SetAvailabilityZone mocks base method.
 func (m *MockManager) SetAvailabilityZone(arg0 string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetAvailabilityZone", arg0)
 }
 
-// SetAvailabilityZone indicates an expected call of SetAvailabilityZone
+// SetAvailabilityZone indicates an expected call of SetAvailabilityZone.
 func (mr *MockManagerMockRecorder) SetAvailabilityZone(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAvailabilityZone", reflect.TypeOf((*MockManager)(nil).SetAvailabilityZone), arg0)
 }
 
-// SetContainerInstanceARN mocks base method
+// SetContainerInstanceARN mocks base method.
 func (m *MockManager) SetContainerInstanceARN(arg0 string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetContainerInstanceARN", arg0)
 }
 
-// SetContainerInstanceARN indicates an expected call of SetContainerInstanceARN
+// SetContainerInstanceARN indicates an expected call of SetContainerInstanceARN.
 func (mr *MockManagerMockRecorder) SetContainerInstanceARN(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetContainerInstanceARN", reflect.TypeOf((*MockManager)(nil).SetContainerInstanceARN), arg0)
 }
 
-// SetHostPrivateIPv4Address mocks base method
+// SetHostPrivateIPv4Address mocks base method.
 func (m *MockManager) SetHostPrivateIPv4Address(arg0 string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetHostPrivateIPv4Address", arg0)
 }
 
-// SetHostPrivateIPv4Address indicates an expected call of SetHostPrivateIPv4Address
+// SetHostPrivateIPv4Address indicates an expected call of SetHostPrivateIPv4Address.
 func (mr *MockManagerMockRecorder) SetHostPrivateIPv4Address(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetHostPrivateIPv4Address", reflect.TypeOf((*MockManager)(nil).SetHostPrivateIPv4Address), arg0)
 }
 
-// SetHostPublicIPv4Address mocks base method
+// SetHostPublicIPv4Address mocks base method.
 func (m *MockManager) SetHostPublicIPv4Address(arg0 string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetHostPublicIPv4Address", arg0)
 }
 
-// SetHostPublicIPv4Address indicates an expected call of SetHostPublicIPv4Address
+// SetHostPublicIPv4Address indicates an expected call of SetHostPublicIPv4Address.
 func (mr *MockManagerMockRecorder) SetHostPublicIPv4Address(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetHostPublicIPv4Address", reflect.TypeOf((*MockManager)(nil).SetHostPublicIPv4Address), arg0)
 }
 
-// Update mocks base method
+// Update mocks base method.
 func (m *MockManager) Update(arg0 context.Context, arg1 string, arg2 *task.Task, arg3 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Update", arg0, arg1, arg2, arg3)
@@ -136,36 +136,36 @@ func (m *MockManager) Update(arg0 context.Context, arg1 string, arg2 *task.Task,
 	return ret0
 }
 
-// Update indicates an expected call of Update
+// Update indicates an expected call of Update.
 func (mr *MockManagerMockRecorder) Update(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockManager)(nil).Update), arg0, arg1, arg2, arg3)
 }
 
-// MockDockerMetadataClient is a mock of DockerMetadataClient interface
+// MockDockerMetadataClient is a mock of DockerMetadataClient interface.
 type MockDockerMetadataClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockDockerMetadataClientMockRecorder
 }
 
-// MockDockerMetadataClientMockRecorder is the mock recorder for MockDockerMetadataClient
+// MockDockerMetadataClientMockRecorder is the mock recorder for MockDockerMetadataClient.
 type MockDockerMetadataClientMockRecorder struct {
 	mock *MockDockerMetadataClient
 }
 
-// NewMockDockerMetadataClient creates a new mock instance
+// NewMockDockerMetadataClient creates a new mock instance.
 func NewMockDockerMetadataClient(ctrl *gomock.Controller) *MockDockerMetadataClient {
 	mock := &MockDockerMetadataClient{ctrl: ctrl}
 	mock.recorder = &MockDockerMetadataClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockDockerMetadataClient) EXPECT() *MockDockerMetadataClientMockRecorder {
 	return m.recorder
 }
 
-// InspectContainer mocks base method
+// InspectContainer mocks base method.
 func (m *MockDockerMetadataClient) InspectContainer(arg0 context.Context, arg1 string, arg2 time.Duration) (*types.ContainerJSON, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InspectContainer", arg0, arg1, arg2)
@@ -174,7 +174,7 @@ func (m *MockDockerMetadataClient) InspectContainer(arg0 context.Context, arg1 s
 	return ret0, ret1
 }
 
-// InspectContainer indicates an expected call of InspectContainer
+// InspectContainer indicates an expected call of InspectContainer.
 func (mr *MockDockerMetadataClientMockRecorder) InspectContainer(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InspectContainer", reflect.TypeOf((*MockDockerMetadataClient)(nil).InspectContainer), arg0, arg1, arg2)

--- a/agent/credentials/mocks/credentials_mocks.go
+++ b/agent/credentials/mocks/credentials_mocks.go
@@ -25,30 +25,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockManager is a mock of Manager interface
+// MockManager is a mock of Manager interface.
 type MockManager struct {
 	ctrl     *gomock.Controller
 	recorder *MockManagerMockRecorder
 }
 
-// MockManagerMockRecorder is the mock recorder for MockManager
+// MockManagerMockRecorder is the mock recorder for MockManager.
 type MockManagerMockRecorder struct {
 	mock *MockManager
 }
 
-// NewMockManager creates a new mock instance
+// NewMockManager creates a new mock instance.
 func NewMockManager(ctrl *gomock.Controller) *MockManager {
 	mock := &MockManager{ctrl: ctrl}
 	mock.recorder = &MockManagerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockManager) EXPECT() *MockManagerMockRecorder {
 	return m.recorder
 }
 
-// GetTaskCredentials mocks base method
+// GetTaskCredentials mocks base method.
 func (m *MockManager) GetTaskCredentials(arg0 string) (credentials.TaskIAMRoleCredentials, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTaskCredentials", arg0)
@@ -57,25 +57,25 @@ func (m *MockManager) GetTaskCredentials(arg0 string) (credentials.TaskIAMRoleCr
 	return ret0, ret1
 }
 
-// GetTaskCredentials indicates an expected call of GetTaskCredentials
+// GetTaskCredentials indicates an expected call of GetTaskCredentials.
 func (mr *MockManagerMockRecorder) GetTaskCredentials(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTaskCredentials", reflect.TypeOf((*MockManager)(nil).GetTaskCredentials), arg0)
 }
 
-// RemoveCredentials mocks base method
+// RemoveCredentials mocks base method.
 func (m *MockManager) RemoveCredentials(arg0 string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "RemoveCredentials", arg0)
 }
 
-// RemoveCredentials indicates an expected call of RemoveCredentials
+// RemoveCredentials indicates an expected call of RemoveCredentials.
 func (mr *MockManagerMockRecorder) RemoveCredentials(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveCredentials", reflect.TypeOf((*MockManager)(nil).RemoveCredentials), arg0)
 }
 
-// SetTaskCredentials mocks base method
+// SetTaskCredentials mocks base method.
 func (m *MockManager) SetTaskCredentials(arg0 *credentials.TaskIAMRoleCredentials) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetTaskCredentials", arg0)
@@ -83,7 +83,7 @@ func (m *MockManager) SetTaskCredentials(arg0 *credentials.TaskIAMRoleCredential
 	return ret0
 }
 
-// SetTaskCredentials indicates an expected call of SetTaskCredentials
+// SetTaskCredentials indicates an expected call of SetTaskCredentials.
 func (mr *MockManagerMockRecorder) SetTaskCredentials(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTaskCredentials", reflect.TypeOf((*MockManager)(nil).SetTaskCredentials), arg0)

--- a/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
+++ b/agent/dockerclient/dockerapi/mocks/dockerapi_mocks.go
@@ -34,30 +34,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockDockerClient is a mock of DockerClient interface
+// MockDockerClient is a mock of DockerClient interface.
 type MockDockerClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockDockerClientMockRecorder
 }
 
-// MockDockerClientMockRecorder is the mock recorder for MockDockerClient
+// MockDockerClientMockRecorder is the mock recorder for MockDockerClient.
 type MockDockerClientMockRecorder struct {
 	mock *MockDockerClient
 }
 
-// NewMockDockerClient creates a new mock instance
+// NewMockDockerClient creates a new mock instance.
 func NewMockDockerClient(ctrl *gomock.Controller) *MockDockerClient {
 	mock := &MockDockerClient{ctrl: ctrl}
 	mock.recorder = &MockDockerClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockDockerClient) EXPECT() *MockDockerClientMockRecorder {
 	return m.recorder
 }
 
-// APIVersion mocks base method
+// APIVersion mocks base method.
 func (m *MockDockerClient) APIVersion() (dockerclient.DockerVersion, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "APIVersion")
@@ -66,13 +66,13 @@ func (m *MockDockerClient) APIVersion() (dockerclient.DockerVersion, error) {
 	return ret0, ret1
 }
 
-// APIVersion indicates an expected call of APIVersion
+// APIVersion indicates an expected call of APIVersion.
 func (mr *MockDockerClientMockRecorder) APIVersion() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIVersion", reflect.TypeOf((*MockDockerClient)(nil).APIVersion))
 }
 
-// ContainerEvents mocks base method
+// ContainerEvents mocks base method.
 func (m *MockDockerClient) ContainerEvents(arg0 context.Context) (<-chan dockerapi.DockerContainerChangeEvent, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContainerEvents", arg0)
@@ -81,13 +81,13 @@ func (m *MockDockerClient) ContainerEvents(arg0 context.Context) (<-chan dockera
 	return ret0, ret1
 }
 
-// ContainerEvents indicates an expected call of ContainerEvents
+// ContainerEvents indicates an expected call of ContainerEvents.
 func (mr *MockDockerClientMockRecorder) ContainerEvents(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerEvents", reflect.TypeOf((*MockDockerClient)(nil).ContainerEvents), arg0)
 }
 
-// CreateContainer mocks base method
+// CreateContainer mocks base method.
 func (m *MockDockerClient) CreateContainer(arg0 context.Context, arg1 *container0.Config, arg2 *container0.HostConfig, arg3 string, arg4 time.Duration) dockerapi.DockerContainerMetadata {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateContainer", arg0, arg1, arg2, arg3, arg4)
@@ -95,13 +95,13 @@ func (m *MockDockerClient) CreateContainer(arg0 context.Context, arg1 *container
 	return ret0
 }
 
-// CreateContainer indicates an expected call of CreateContainer
+// CreateContainer indicates an expected call of CreateContainer.
 func (mr *MockDockerClientMockRecorder) CreateContainer(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateContainer", reflect.TypeOf((*MockDockerClient)(nil).CreateContainer), arg0, arg1, arg2, arg3, arg4)
 }
 
-// CreateContainerExec mocks base method
+// CreateContainerExec mocks base method.
 func (m *MockDockerClient) CreateContainerExec(arg0 context.Context, arg1 string, arg2 types.ExecConfig, arg3 time.Duration) (*types.IDResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateContainerExec", arg0, arg1, arg2, arg3)
@@ -110,13 +110,13 @@ func (m *MockDockerClient) CreateContainerExec(arg0 context.Context, arg1 string
 	return ret0, ret1
 }
 
-// CreateContainerExec indicates an expected call of CreateContainerExec
+// CreateContainerExec indicates an expected call of CreateContainerExec.
 func (mr *MockDockerClientMockRecorder) CreateContainerExec(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateContainerExec", reflect.TypeOf((*MockDockerClient)(nil).CreateContainerExec), arg0, arg1, arg2, arg3)
 }
 
-// CreateVolume mocks base method
+// CreateVolume mocks base method.
 func (m *MockDockerClient) CreateVolume(arg0 context.Context, arg1, arg2 string, arg3, arg4 map[string]string, arg5 time.Duration) dockerapi.SDKVolumeResponse {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateVolume", arg0, arg1, arg2, arg3, arg4, arg5)
@@ -124,13 +124,13 @@ func (m *MockDockerClient) CreateVolume(arg0 context.Context, arg1, arg2 string,
 	return ret0
 }
 
-// CreateVolume indicates an expected call of CreateVolume
+// CreateVolume indicates an expected call of CreateVolume.
 func (mr *MockDockerClientMockRecorder) CreateVolume(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVolume", reflect.TypeOf((*MockDockerClient)(nil).CreateVolume), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
-// DescribeContainer mocks base method
+// DescribeContainer mocks base method.
 func (m *MockDockerClient) DescribeContainer(arg0 context.Context, arg1 string) (status.ContainerStatus, dockerapi.DockerContainerMetadata) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeContainer", arg0, arg1)
@@ -139,13 +139,13 @@ func (m *MockDockerClient) DescribeContainer(arg0 context.Context, arg1 string) 
 	return ret0, ret1
 }
 
-// DescribeContainer indicates an expected call of DescribeContainer
+// DescribeContainer indicates an expected call of DescribeContainer.
 func (mr *MockDockerClientMockRecorder) DescribeContainer(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeContainer", reflect.TypeOf((*MockDockerClient)(nil).DescribeContainer), arg0, arg1)
 }
 
-// Info mocks base method
+// Info mocks base method.
 func (m *MockDockerClient) Info(arg0 context.Context, arg1 time.Duration) (types.Info, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Info", arg0, arg1)
@@ -154,13 +154,13 @@ func (m *MockDockerClient) Info(arg0 context.Context, arg1 time.Duration) (types
 	return ret0, ret1
 }
 
-// Info indicates an expected call of Info
+// Info indicates an expected call of Info.
 func (mr *MockDockerClientMockRecorder) Info(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Info", reflect.TypeOf((*MockDockerClient)(nil).Info), arg0, arg1)
 }
 
-// InspectContainer mocks base method
+// InspectContainer mocks base method.
 func (m *MockDockerClient) InspectContainer(arg0 context.Context, arg1 string, arg2 time.Duration) (*types.ContainerJSON, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InspectContainer", arg0, arg1, arg2)
@@ -169,13 +169,13 @@ func (m *MockDockerClient) InspectContainer(arg0 context.Context, arg1 string, a
 	return ret0, ret1
 }
 
-// InspectContainer indicates an expected call of InspectContainer
+// InspectContainer indicates an expected call of InspectContainer.
 func (mr *MockDockerClientMockRecorder) InspectContainer(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InspectContainer", reflect.TypeOf((*MockDockerClient)(nil).InspectContainer), arg0, arg1, arg2)
 }
 
-// InspectContainerExec mocks base method
+// InspectContainerExec mocks base method.
 func (m *MockDockerClient) InspectContainerExec(arg0 context.Context, arg1 string, arg2 time.Duration) (*types.ContainerExecInspect, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InspectContainerExec", arg0, arg1, arg2)
@@ -184,13 +184,13 @@ func (m *MockDockerClient) InspectContainerExec(arg0 context.Context, arg1 strin
 	return ret0, ret1
 }
 
-// InspectContainerExec indicates an expected call of InspectContainerExec
+// InspectContainerExec indicates an expected call of InspectContainerExec.
 func (mr *MockDockerClientMockRecorder) InspectContainerExec(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InspectContainerExec", reflect.TypeOf((*MockDockerClient)(nil).InspectContainerExec), arg0, arg1, arg2)
 }
 
-// InspectImage mocks base method
+// InspectImage mocks base method.
 func (m *MockDockerClient) InspectImage(arg0 string) (*types.ImageInspect, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InspectImage", arg0)
@@ -199,13 +199,13 @@ func (m *MockDockerClient) InspectImage(arg0 string) (*types.ImageInspect, error
 	return ret0, ret1
 }
 
-// InspectImage indicates an expected call of InspectImage
+// InspectImage indicates an expected call of InspectImage.
 func (mr *MockDockerClientMockRecorder) InspectImage(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InspectImage", reflect.TypeOf((*MockDockerClient)(nil).InspectImage), arg0)
 }
 
-// InspectVolume mocks base method
+// InspectVolume mocks base method.
 func (m *MockDockerClient) InspectVolume(arg0 context.Context, arg1 string, arg2 time.Duration) dockerapi.SDKVolumeResponse {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InspectVolume", arg0, arg1, arg2)
@@ -213,13 +213,13 @@ func (m *MockDockerClient) InspectVolume(arg0 context.Context, arg1 string, arg2
 	return ret0
 }
 
-// InspectVolume indicates an expected call of InspectVolume
+// InspectVolume indicates an expected call of InspectVolume.
 func (mr *MockDockerClientMockRecorder) InspectVolume(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InspectVolume", reflect.TypeOf((*MockDockerClient)(nil).InspectVolume), arg0, arg1, arg2)
 }
 
-// KnownVersions mocks base method
+// KnownVersions mocks base method.
 func (m *MockDockerClient) KnownVersions() []dockerclient.DockerVersion {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "KnownVersions")
@@ -227,13 +227,13 @@ func (m *MockDockerClient) KnownVersions() []dockerclient.DockerVersion {
 	return ret0
 }
 
-// KnownVersions indicates an expected call of KnownVersions
+// KnownVersions indicates an expected call of KnownVersions.
 func (mr *MockDockerClientMockRecorder) KnownVersions() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KnownVersions", reflect.TypeOf((*MockDockerClient)(nil).KnownVersions))
 }
 
-// ListContainers mocks base method
+// ListContainers mocks base method.
 func (m *MockDockerClient) ListContainers(arg0 context.Context, arg1 bool, arg2 time.Duration) dockerapi.ListContainersResponse {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListContainers", arg0, arg1, arg2)
@@ -241,13 +241,13 @@ func (m *MockDockerClient) ListContainers(arg0 context.Context, arg1 bool, arg2 
 	return ret0
 }
 
-// ListContainers indicates an expected call of ListContainers
+// ListContainers indicates an expected call of ListContainers.
 func (mr *MockDockerClientMockRecorder) ListContainers(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListContainers", reflect.TypeOf((*MockDockerClient)(nil).ListContainers), arg0, arg1, arg2)
 }
 
-// ListImages mocks base method
+// ListImages mocks base method.
 func (m *MockDockerClient) ListImages(arg0 context.Context, arg1 time.Duration) dockerapi.ListImagesResponse {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListImages", arg0, arg1)
@@ -255,13 +255,13 @@ func (m *MockDockerClient) ListImages(arg0 context.Context, arg1 time.Duration) 
 	return ret0
 }
 
-// ListImages indicates an expected call of ListImages
+// ListImages indicates an expected call of ListImages.
 func (mr *MockDockerClientMockRecorder) ListImages(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListImages", reflect.TypeOf((*MockDockerClient)(nil).ListImages), arg0, arg1)
 }
 
-// ListPlugins mocks base method
+// ListPlugins mocks base method.
 func (m *MockDockerClient) ListPlugins(arg0 context.Context, arg1 time.Duration, arg2 filters.Args) dockerapi.ListPluginsResponse {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListPlugins", arg0, arg1, arg2)
@@ -269,13 +269,13 @@ func (m *MockDockerClient) ListPlugins(arg0 context.Context, arg1 time.Duration,
 	return ret0
 }
 
-// ListPlugins indicates an expected call of ListPlugins
+// ListPlugins indicates an expected call of ListPlugins.
 func (mr *MockDockerClientMockRecorder) ListPlugins(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPlugins", reflect.TypeOf((*MockDockerClient)(nil).ListPlugins), arg0, arg1, arg2)
 }
 
-// ListPluginsWithFilters mocks base method
+// ListPluginsWithFilters mocks base method.
 func (m *MockDockerClient) ListPluginsWithFilters(arg0 context.Context, arg1 bool, arg2 []string, arg3 time.Duration) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListPluginsWithFilters", arg0, arg1, arg2, arg3)
@@ -284,13 +284,13 @@ func (m *MockDockerClient) ListPluginsWithFilters(arg0 context.Context, arg1 boo
 	return ret0, ret1
 }
 
-// ListPluginsWithFilters indicates an expected call of ListPluginsWithFilters
+// ListPluginsWithFilters indicates an expected call of ListPluginsWithFilters.
 func (mr *MockDockerClientMockRecorder) ListPluginsWithFilters(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPluginsWithFilters", reflect.TypeOf((*MockDockerClient)(nil).ListPluginsWithFilters), arg0, arg1, arg2, arg3)
 }
 
-// LoadImage mocks base method
+// LoadImage mocks base method.
 func (m *MockDockerClient) LoadImage(arg0 context.Context, arg1 io.Reader, arg2 time.Duration) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LoadImage", arg0, arg1, arg2)
@@ -298,13 +298,13 @@ func (m *MockDockerClient) LoadImage(arg0 context.Context, arg1 io.Reader, arg2 
 	return ret0
 }
 
-// LoadImage indicates an expected call of LoadImage
+// LoadImage indicates an expected call of LoadImage.
 func (mr *MockDockerClientMockRecorder) LoadImage(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadImage", reflect.TypeOf((*MockDockerClient)(nil).LoadImage), arg0, arg1, arg2)
 }
 
-// PullImage mocks base method
+// PullImage mocks base method.
 func (m *MockDockerClient) PullImage(arg0 context.Context, arg1 string, arg2 *container.RegistryAuthenticationData, arg3 time.Duration) dockerapi.DockerContainerMetadata {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PullImage", arg0, arg1, arg2, arg3)
@@ -312,13 +312,13 @@ func (m *MockDockerClient) PullImage(arg0 context.Context, arg1 string, arg2 *co
 	return ret0
 }
 
-// PullImage indicates an expected call of PullImage
+// PullImage indicates an expected call of PullImage.
 func (mr *MockDockerClientMockRecorder) PullImage(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PullImage", reflect.TypeOf((*MockDockerClient)(nil).PullImage), arg0, arg1, arg2, arg3)
 }
 
-// RemoveContainer mocks base method
+// RemoveContainer mocks base method.
 func (m *MockDockerClient) RemoveContainer(arg0 context.Context, arg1 string, arg2 time.Duration) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveContainer", arg0, arg1, arg2)
@@ -326,13 +326,13 @@ func (m *MockDockerClient) RemoveContainer(arg0 context.Context, arg1 string, ar
 	return ret0
 }
 
-// RemoveContainer indicates an expected call of RemoveContainer
+// RemoveContainer indicates an expected call of RemoveContainer.
 func (mr *MockDockerClientMockRecorder) RemoveContainer(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveContainer", reflect.TypeOf((*MockDockerClient)(nil).RemoveContainer), arg0, arg1, arg2)
 }
 
-// RemoveImage mocks base method
+// RemoveImage mocks base method.
 func (m *MockDockerClient) RemoveImage(arg0 context.Context, arg1 string, arg2 time.Duration) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveImage", arg0, arg1, arg2)
@@ -340,13 +340,13 @@ func (m *MockDockerClient) RemoveImage(arg0 context.Context, arg1 string, arg2 t
 	return ret0
 }
 
-// RemoveImage indicates an expected call of RemoveImage
+// RemoveImage indicates an expected call of RemoveImage.
 func (mr *MockDockerClientMockRecorder) RemoveImage(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveImage", reflect.TypeOf((*MockDockerClient)(nil).RemoveImage), arg0, arg1, arg2)
 }
 
-// RemoveVolume mocks base method
+// RemoveVolume mocks base method.
 func (m *MockDockerClient) RemoveVolume(arg0 context.Context, arg1 string, arg2 time.Duration) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveVolume", arg0, arg1, arg2)
@@ -354,13 +354,13 @@ func (m *MockDockerClient) RemoveVolume(arg0 context.Context, arg1 string, arg2 
 	return ret0
 }
 
-// RemoveVolume indicates an expected call of RemoveVolume
+// RemoveVolume indicates an expected call of RemoveVolume.
 func (mr *MockDockerClientMockRecorder) RemoveVolume(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveVolume", reflect.TypeOf((*MockDockerClient)(nil).RemoveVolume), arg0, arg1, arg2)
 }
 
-// StartContainer mocks base method
+// StartContainer mocks base method.
 func (m *MockDockerClient) StartContainer(arg0 context.Context, arg1 string, arg2 time.Duration) dockerapi.DockerContainerMetadata {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartContainer", arg0, arg1, arg2)
@@ -368,13 +368,13 @@ func (m *MockDockerClient) StartContainer(arg0 context.Context, arg1 string, arg
 	return ret0
 }
 
-// StartContainer indicates an expected call of StartContainer
+// StartContainer indicates an expected call of StartContainer.
 func (mr *MockDockerClientMockRecorder) StartContainer(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartContainer", reflect.TypeOf((*MockDockerClient)(nil).StartContainer), arg0, arg1, arg2)
 }
 
-// StartContainerExec mocks base method
+// StartContainerExec mocks base method.
 func (m *MockDockerClient) StartContainerExec(arg0 context.Context, arg1 string, arg2 types.ExecStartCheck, arg3 time.Duration) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartContainerExec", arg0, arg1, arg2, arg3)
@@ -382,13 +382,13 @@ func (m *MockDockerClient) StartContainerExec(arg0 context.Context, arg1 string,
 	return ret0
 }
 
-// StartContainerExec indicates an expected call of StartContainerExec
+// StartContainerExec indicates an expected call of StartContainerExec.
 func (mr *MockDockerClientMockRecorder) StartContainerExec(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartContainerExec", reflect.TypeOf((*MockDockerClient)(nil).StartContainerExec), arg0, arg1, arg2, arg3)
 }
 
-// Stats mocks base method
+// Stats mocks base method.
 func (m *MockDockerClient) Stats(arg0 context.Context, arg1 string, arg2 time.Duration) (<-chan *types.StatsJSON, <-chan error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Stats", arg0, arg1, arg2)
@@ -397,13 +397,13 @@ func (m *MockDockerClient) Stats(arg0 context.Context, arg1 string, arg2 time.Du
 	return ret0, ret1
 }
 
-// Stats indicates an expected call of Stats
+// Stats indicates an expected call of Stats.
 func (mr *MockDockerClientMockRecorder) Stats(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stats", reflect.TypeOf((*MockDockerClient)(nil).Stats), arg0, arg1, arg2)
 }
 
-// StopContainer mocks base method
+// StopContainer mocks base method.
 func (m *MockDockerClient) StopContainer(arg0 context.Context, arg1 string, arg2 time.Duration) dockerapi.DockerContainerMetadata {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StopContainer", arg0, arg1, arg2)
@@ -411,13 +411,13 @@ func (m *MockDockerClient) StopContainer(arg0 context.Context, arg1 string, arg2
 	return ret0
 }
 
-// StopContainer indicates an expected call of StopContainer
+// StopContainer indicates an expected call of StopContainer.
 func (mr *MockDockerClientMockRecorder) StopContainer(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopContainer", reflect.TypeOf((*MockDockerClient)(nil).StopContainer), arg0, arg1, arg2)
 }
 
-// SupportedVersions mocks base method
+// SupportedVersions mocks base method.
 func (m *MockDockerClient) SupportedVersions() []dockerclient.DockerVersion {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SupportedVersions")
@@ -425,13 +425,13 @@ func (m *MockDockerClient) SupportedVersions() []dockerclient.DockerVersion {
 	return ret0
 }
 
-// SupportedVersions indicates an expected call of SupportedVersions
+// SupportedVersions indicates an expected call of SupportedVersions.
 func (mr *MockDockerClientMockRecorder) SupportedVersions() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SupportedVersions", reflect.TypeOf((*MockDockerClient)(nil).SupportedVersions))
 }
 
-// SystemPing mocks base method
+// SystemPing mocks base method.
 func (m *MockDockerClient) SystemPing(arg0 context.Context, arg1 time.Duration) dockerapi.PingResponse {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SystemPing", arg0, arg1)
@@ -439,13 +439,13 @@ func (m *MockDockerClient) SystemPing(arg0 context.Context, arg1 time.Duration) 
 	return ret0
 }
 
-// SystemPing indicates an expected call of SystemPing
+// SystemPing indicates an expected call of SystemPing.
 func (mr *MockDockerClientMockRecorder) SystemPing(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SystemPing", reflect.TypeOf((*MockDockerClient)(nil).SystemPing), arg0, arg1)
 }
 
-// Version mocks base method
+// Version mocks base method.
 func (m *MockDockerClient) Version(arg0 context.Context, arg1 time.Duration) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Version", arg0, arg1)
@@ -454,13 +454,13 @@ func (m *MockDockerClient) Version(arg0 context.Context, arg1 time.Duration) (st
 	return ret0, ret1
 }
 
-// Version indicates an expected call of Version
+// Version indicates an expected call of Version.
 func (mr *MockDockerClientMockRecorder) Version(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Version", reflect.TypeOf((*MockDockerClient)(nil).Version), arg0, arg1)
 }
 
-// WithVersion mocks base method
+// WithVersion mocks base method.
 func (m *MockDockerClient) WithVersion(arg0 dockerclient.DockerVersion) dockerapi.DockerClient {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WithVersion", arg0)
@@ -468,7 +468,7 @@ func (m *MockDockerClient) WithVersion(arg0 dockerclient.DockerVersion) dockerap
 	return ret0
 }
 
-// WithVersion indicates an expected call of WithVersion
+// WithVersion indicates an expected call of WithVersion.
 func (mr *MockDockerClientMockRecorder) WithVersion(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithVersion", reflect.TypeOf((*MockDockerClient)(nil).WithVersion), arg0)

--- a/agent/dockerclient/sdkclient/mocks/sdkclient_mocks.go
+++ b/agent/dockerclient/sdkclient/mocks/sdkclient_mocks.go
@@ -34,30 +34,30 @@ import (
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-// MockClient is a mock of Client interface
+// MockClient is a mock of Client interface.
 type MockClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockClientMockRecorder
 }
 
-// MockClientMockRecorder is the mock recorder for MockClient
+// MockClientMockRecorder is the mock recorder for MockClient.
 type MockClientMockRecorder struct {
 	mock *MockClient
 }
 
-// NewMockClient creates a new mock instance
+// NewMockClient creates a new mock instance.
 func NewMockClient(ctrl *gomock.Controller) *MockClient {
 	mock := &MockClient{ctrl: ctrl}
 	mock.recorder = &MockClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
-// ClientVersion mocks base method
+// ClientVersion mocks base method.
 func (m *MockClient) ClientVersion() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ClientVersion")
@@ -65,13 +65,13 @@ func (m *MockClient) ClientVersion() string {
 	return ret0
 }
 
-// ClientVersion indicates an expected call of ClientVersion
+// ClientVersion indicates an expected call of ClientVersion.
 func (mr *MockClientMockRecorder) ClientVersion() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClientVersion", reflect.TypeOf((*MockClient)(nil).ClientVersion))
 }
 
-// ContainerCreate mocks base method
+// ContainerCreate mocks base method.
 func (m *MockClient) ContainerCreate(arg0 context.Context, arg1 *container.Config, arg2 *container.HostConfig, arg3 *network.NetworkingConfig, arg4 *v1.Platform, arg5 string) (container.ContainerCreateCreatedBody, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContainerCreate", arg0, arg1, arg2, arg3, arg4, arg5)
@@ -80,13 +80,13 @@ func (m *MockClient) ContainerCreate(arg0 context.Context, arg1 *container.Confi
 	return ret0, ret1
 }
 
-// ContainerCreate indicates an expected call of ContainerCreate
+// ContainerCreate indicates an expected call of ContainerCreate.
 func (mr *MockClientMockRecorder) ContainerCreate(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerCreate", reflect.TypeOf((*MockClient)(nil).ContainerCreate), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
-// ContainerExecCreate mocks base method
+// ContainerExecCreate mocks base method.
 func (m *MockClient) ContainerExecCreate(arg0 context.Context, arg1 string, arg2 types.ExecConfig) (types.IDResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContainerExecCreate", arg0, arg1, arg2)
@@ -95,13 +95,13 @@ func (m *MockClient) ContainerExecCreate(arg0 context.Context, arg1 string, arg2
 	return ret0, ret1
 }
 
-// ContainerExecCreate indicates an expected call of ContainerExecCreate
+// ContainerExecCreate indicates an expected call of ContainerExecCreate.
 func (mr *MockClientMockRecorder) ContainerExecCreate(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerExecCreate", reflect.TypeOf((*MockClient)(nil).ContainerExecCreate), arg0, arg1, arg2)
 }
 
-// ContainerExecInspect mocks base method
+// ContainerExecInspect mocks base method.
 func (m *MockClient) ContainerExecInspect(arg0 context.Context, arg1 string) (types.ContainerExecInspect, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContainerExecInspect", arg0, arg1)
@@ -110,13 +110,13 @@ func (m *MockClient) ContainerExecInspect(arg0 context.Context, arg1 string) (ty
 	return ret0, ret1
 }
 
-// ContainerExecInspect indicates an expected call of ContainerExecInspect
+// ContainerExecInspect indicates an expected call of ContainerExecInspect.
 func (mr *MockClientMockRecorder) ContainerExecInspect(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerExecInspect", reflect.TypeOf((*MockClient)(nil).ContainerExecInspect), arg0, arg1)
 }
 
-// ContainerExecStart mocks base method
+// ContainerExecStart mocks base method.
 func (m *MockClient) ContainerExecStart(arg0 context.Context, arg1 string, arg2 types.ExecStartCheck) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContainerExecStart", arg0, arg1, arg2)
@@ -124,13 +124,13 @@ func (m *MockClient) ContainerExecStart(arg0 context.Context, arg1 string, arg2 
 	return ret0
 }
 
-// ContainerExecStart indicates an expected call of ContainerExecStart
+// ContainerExecStart indicates an expected call of ContainerExecStart.
 func (mr *MockClientMockRecorder) ContainerExecStart(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerExecStart", reflect.TypeOf((*MockClient)(nil).ContainerExecStart), arg0, arg1, arg2)
 }
 
-// ContainerInspect mocks base method
+// ContainerInspect mocks base method.
 func (m *MockClient) ContainerInspect(arg0 context.Context, arg1 string) (types.ContainerJSON, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContainerInspect", arg0, arg1)
@@ -139,13 +139,13 @@ func (m *MockClient) ContainerInspect(arg0 context.Context, arg1 string) (types.
 	return ret0, ret1
 }
 
-// ContainerInspect indicates an expected call of ContainerInspect
+// ContainerInspect indicates an expected call of ContainerInspect.
 func (mr *MockClientMockRecorder) ContainerInspect(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerInspect", reflect.TypeOf((*MockClient)(nil).ContainerInspect), arg0, arg1)
 }
 
-// ContainerList mocks base method
+// ContainerList mocks base method.
 func (m *MockClient) ContainerList(arg0 context.Context, arg1 types.ContainerListOptions) ([]types.Container, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContainerList", arg0, arg1)
@@ -154,13 +154,13 @@ func (m *MockClient) ContainerList(arg0 context.Context, arg1 types.ContainerLis
 	return ret0, ret1
 }
 
-// ContainerList indicates an expected call of ContainerList
+// ContainerList indicates an expected call of ContainerList.
 func (mr *MockClientMockRecorder) ContainerList(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerList", reflect.TypeOf((*MockClient)(nil).ContainerList), arg0, arg1)
 }
 
-// ContainerRemove mocks base method
+// ContainerRemove mocks base method.
 func (m *MockClient) ContainerRemove(arg0 context.Context, arg1 string, arg2 types.ContainerRemoveOptions) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContainerRemove", arg0, arg1, arg2)
@@ -168,13 +168,13 @@ func (m *MockClient) ContainerRemove(arg0 context.Context, arg1 string, arg2 typ
 	return ret0
 }
 
-// ContainerRemove indicates an expected call of ContainerRemove
+// ContainerRemove indicates an expected call of ContainerRemove.
 func (mr *MockClientMockRecorder) ContainerRemove(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerRemove", reflect.TypeOf((*MockClient)(nil).ContainerRemove), arg0, arg1, arg2)
 }
 
-// ContainerStart mocks base method
+// ContainerStart mocks base method.
 func (m *MockClient) ContainerStart(arg0 context.Context, arg1 string, arg2 types.ContainerStartOptions) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContainerStart", arg0, arg1, arg2)
@@ -182,13 +182,13 @@ func (m *MockClient) ContainerStart(arg0 context.Context, arg1 string, arg2 type
 	return ret0
 }
 
-// ContainerStart indicates an expected call of ContainerStart
+// ContainerStart indicates an expected call of ContainerStart.
 func (mr *MockClientMockRecorder) ContainerStart(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerStart", reflect.TypeOf((*MockClient)(nil).ContainerStart), arg0, arg1, arg2)
 }
 
-// ContainerStats mocks base method
+// ContainerStats mocks base method.
 func (m *MockClient) ContainerStats(arg0 context.Context, arg1 string, arg2 bool) (types.ContainerStats, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContainerStats", arg0, arg1, arg2)
@@ -197,13 +197,13 @@ func (m *MockClient) ContainerStats(arg0 context.Context, arg1 string, arg2 bool
 	return ret0, ret1
 }
 
-// ContainerStats indicates an expected call of ContainerStats
+// ContainerStats indicates an expected call of ContainerStats.
 func (mr *MockClientMockRecorder) ContainerStats(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerStats", reflect.TypeOf((*MockClient)(nil).ContainerStats), arg0, arg1, arg2)
 }
 
-// ContainerStop mocks base method
+// ContainerStop mocks base method.
 func (m *MockClient) ContainerStop(arg0 context.Context, arg1 string, arg2 *time.Duration) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContainerStop", arg0, arg1, arg2)
@@ -211,13 +211,13 @@ func (m *MockClient) ContainerStop(arg0 context.Context, arg1 string, arg2 *time
 	return ret0
 }
 
-// ContainerStop indicates an expected call of ContainerStop
+// ContainerStop indicates an expected call of ContainerStop.
 func (mr *MockClientMockRecorder) ContainerStop(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerStop", reflect.TypeOf((*MockClient)(nil).ContainerStop), arg0, arg1, arg2)
 }
 
-// ContainerTop mocks base method
+// ContainerTop mocks base method.
 func (m *MockClient) ContainerTop(arg0 context.Context, arg1 string, arg2 []string) (container.ContainerTopOKBody, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContainerTop", arg0, arg1, arg2)
@@ -226,13 +226,13 @@ func (m *MockClient) ContainerTop(arg0 context.Context, arg1 string, arg2 []stri
 	return ret0, ret1
 }
 
-// ContainerTop indicates an expected call of ContainerTop
+// ContainerTop indicates an expected call of ContainerTop.
 func (mr *MockClientMockRecorder) ContainerTop(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerTop", reflect.TypeOf((*MockClient)(nil).ContainerTop), arg0, arg1, arg2)
 }
 
-// Events mocks base method
+// Events mocks base method.
 func (m *MockClient) Events(arg0 context.Context, arg1 types.EventsOptions) (<-chan events.Message, <-chan error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Events", arg0, arg1)
@@ -241,13 +241,13 @@ func (m *MockClient) Events(arg0 context.Context, arg1 types.EventsOptions) (<-c
 	return ret0, ret1
 }
 
-// Events indicates an expected call of Events
+// Events indicates an expected call of Events.
 func (mr *MockClientMockRecorder) Events(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Events", reflect.TypeOf((*MockClient)(nil).Events), arg0, arg1)
 }
 
-// ImageImport mocks base method
+// ImageImport mocks base method.
 func (m *MockClient) ImageImport(arg0 context.Context, arg1 types.ImageImportSource, arg2 string, arg3 types.ImageImportOptions) (io.ReadCloser, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ImageImport", arg0, arg1, arg2, arg3)
@@ -256,13 +256,13 @@ func (m *MockClient) ImageImport(arg0 context.Context, arg1 types.ImageImportSou
 	return ret0, ret1
 }
 
-// ImageImport indicates an expected call of ImageImport
+// ImageImport indicates an expected call of ImageImport.
 func (mr *MockClientMockRecorder) ImageImport(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImageImport", reflect.TypeOf((*MockClient)(nil).ImageImport), arg0, arg1, arg2, arg3)
 }
 
-// ImageInspectWithRaw mocks base method
+// ImageInspectWithRaw mocks base method.
 func (m *MockClient) ImageInspectWithRaw(arg0 context.Context, arg1 string) (types.ImageInspect, []byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ImageInspectWithRaw", arg0, arg1)
@@ -272,13 +272,13 @@ func (m *MockClient) ImageInspectWithRaw(arg0 context.Context, arg1 string) (typ
 	return ret0, ret1, ret2
 }
 
-// ImageInspectWithRaw indicates an expected call of ImageInspectWithRaw
+// ImageInspectWithRaw indicates an expected call of ImageInspectWithRaw.
 func (mr *MockClientMockRecorder) ImageInspectWithRaw(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImageInspectWithRaw", reflect.TypeOf((*MockClient)(nil).ImageInspectWithRaw), arg0, arg1)
 }
 
-// ImageList mocks base method
+// ImageList mocks base method.
 func (m *MockClient) ImageList(arg0 context.Context, arg1 types.ImageListOptions) ([]types.ImageSummary, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ImageList", arg0, arg1)
@@ -287,13 +287,13 @@ func (m *MockClient) ImageList(arg0 context.Context, arg1 types.ImageListOptions
 	return ret0, ret1
 }
 
-// ImageList indicates an expected call of ImageList
+// ImageList indicates an expected call of ImageList.
 func (mr *MockClientMockRecorder) ImageList(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImageList", reflect.TypeOf((*MockClient)(nil).ImageList), arg0, arg1)
 }
 
-// ImageLoad mocks base method
+// ImageLoad mocks base method.
 func (m *MockClient) ImageLoad(arg0 context.Context, arg1 io.Reader, arg2 bool) (types.ImageLoadResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ImageLoad", arg0, arg1, arg2)
@@ -302,13 +302,13 @@ func (m *MockClient) ImageLoad(arg0 context.Context, arg1 io.Reader, arg2 bool) 
 	return ret0, ret1
 }
 
-// ImageLoad indicates an expected call of ImageLoad
+// ImageLoad indicates an expected call of ImageLoad.
 func (mr *MockClientMockRecorder) ImageLoad(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImageLoad", reflect.TypeOf((*MockClient)(nil).ImageLoad), arg0, arg1, arg2)
 }
 
-// ImagePull mocks base method
+// ImagePull mocks base method.
 func (m *MockClient) ImagePull(arg0 context.Context, arg1 string, arg2 types.ImagePullOptions) (io.ReadCloser, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ImagePull", arg0, arg1, arg2)
@@ -317,13 +317,13 @@ func (m *MockClient) ImagePull(arg0 context.Context, arg1 string, arg2 types.Ima
 	return ret0, ret1
 }
 
-// ImagePull indicates an expected call of ImagePull
+// ImagePull indicates an expected call of ImagePull.
 func (mr *MockClientMockRecorder) ImagePull(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImagePull", reflect.TypeOf((*MockClient)(nil).ImagePull), arg0, arg1, arg2)
 }
 
-// ImageRemove mocks base method
+// ImageRemove mocks base method.
 func (m *MockClient) ImageRemove(arg0 context.Context, arg1 string, arg2 types.ImageRemoveOptions) ([]types.ImageDeleteResponseItem, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ImageRemove", arg0, arg1, arg2)
@@ -332,13 +332,13 @@ func (m *MockClient) ImageRemove(arg0 context.Context, arg1 string, arg2 types.I
 	return ret0, ret1
 }
 
-// ImageRemove indicates an expected call of ImageRemove
+// ImageRemove indicates an expected call of ImageRemove.
 func (mr *MockClientMockRecorder) ImageRemove(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImageRemove", reflect.TypeOf((*MockClient)(nil).ImageRemove), arg0, arg1, arg2)
 }
 
-// Info mocks base method
+// Info mocks base method.
 func (m *MockClient) Info(arg0 context.Context) (types.Info, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Info", arg0)
@@ -347,13 +347,13 @@ func (m *MockClient) Info(arg0 context.Context) (types.Info, error) {
 	return ret0, ret1
 }
 
-// Info indicates an expected call of Info
+// Info indicates an expected call of Info.
 func (mr *MockClientMockRecorder) Info(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Info", reflect.TypeOf((*MockClient)(nil).Info), arg0)
 }
 
-// Ping mocks base method
+// Ping mocks base method.
 func (m *MockClient) Ping(arg0 context.Context) (types.Ping, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Ping", arg0)
@@ -362,13 +362,13 @@ func (m *MockClient) Ping(arg0 context.Context) (types.Ping, error) {
 	return ret0, ret1
 }
 
-// Ping indicates an expected call of Ping
+// Ping indicates an expected call of Ping.
 func (mr *MockClientMockRecorder) Ping(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ping", reflect.TypeOf((*MockClient)(nil).Ping), arg0)
 }
 
-// PluginList mocks base method
+// PluginList mocks base method.
 func (m *MockClient) PluginList(arg0 context.Context, arg1 filters.Args) (types.PluginsListResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PluginList", arg0, arg1)
@@ -377,13 +377,13 @@ func (m *MockClient) PluginList(arg0 context.Context, arg1 filters.Args) (types.
 	return ret0, ret1
 }
 
-// PluginList indicates an expected call of PluginList
+// PluginList indicates an expected call of PluginList.
 func (mr *MockClientMockRecorder) PluginList(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PluginList", reflect.TypeOf((*MockClient)(nil).PluginList), arg0, arg1)
 }
 
-// ServerVersion mocks base method
+// ServerVersion mocks base method.
 func (m *MockClient) ServerVersion(arg0 context.Context) (types.Version, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ServerVersion", arg0)
@@ -392,13 +392,13 @@ func (m *MockClient) ServerVersion(arg0 context.Context) (types.Version, error) 
 	return ret0, ret1
 }
 
-// ServerVersion indicates an expected call of ServerVersion
+// ServerVersion indicates an expected call of ServerVersion.
 func (mr *MockClientMockRecorder) ServerVersion(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServerVersion", reflect.TypeOf((*MockClient)(nil).ServerVersion), arg0)
 }
 
-// VolumeCreate mocks base method
+// VolumeCreate mocks base method.
 func (m *MockClient) VolumeCreate(arg0 context.Context, arg1 volume.VolumeCreateBody) (types.Volume, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "VolumeCreate", arg0, arg1)
@@ -407,13 +407,13 @@ func (m *MockClient) VolumeCreate(arg0 context.Context, arg1 volume.VolumeCreate
 	return ret0, ret1
 }
 
-// VolumeCreate indicates an expected call of VolumeCreate
+// VolumeCreate indicates an expected call of VolumeCreate.
 func (mr *MockClientMockRecorder) VolumeCreate(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VolumeCreate", reflect.TypeOf((*MockClient)(nil).VolumeCreate), arg0, arg1)
 }
 
-// VolumeInspect mocks base method
+// VolumeInspect mocks base method.
 func (m *MockClient) VolumeInspect(arg0 context.Context, arg1 string) (types.Volume, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "VolumeInspect", arg0, arg1)
@@ -422,13 +422,13 @@ func (m *MockClient) VolumeInspect(arg0 context.Context, arg1 string) (types.Vol
 	return ret0, ret1
 }
 
-// VolumeInspect indicates an expected call of VolumeInspect
+// VolumeInspect indicates an expected call of VolumeInspect.
 func (mr *MockClientMockRecorder) VolumeInspect(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VolumeInspect", reflect.TypeOf((*MockClient)(nil).VolumeInspect), arg0, arg1)
 }
 
-// VolumeRemove mocks base method
+// VolumeRemove mocks base method.
 func (m *MockClient) VolumeRemove(arg0 context.Context, arg1 string, arg2 bool) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "VolumeRemove", arg0, arg1, arg2)
@@ -436,7 +436,7 @@ func (m *MockClient) VolumeRemove(arg0 context.Context, arg1 string, arg2 bool) 
 	return ret0
 }
 
-// VolumeRemove indicates an expected call of VolumeRemove
+// VolumeRemove indicates an expected call of VolumeRemove.
 func (mr *MockClientMockRecorder) VolumeRemove(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VolumeRemove", reflect.TypeOf((*MockClient)(nil).VolumeRemove), arg0, arg1, arg2)

--- a/agent/dockerclient/sdkclientfactory/mocks/sdkclientfactory_mocks.go
+++ b/agent/dockerclient/sdkclientfactory/mocks/sdkclientfactory_mocks.go
@@ -26,30 +26,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockFactory is a mock of Factory interface
+// MockFactory is a mock of Factory interface.
 type MockFactory struct {
 	ctrl     *gomock.Controller
 	recorder *MockFactoryMockRecorder
 }
 
-// MockFactoryMockRecorder is the mock recorder for MockFactory
+// MockFactoryMockRecorder is the mock recorder for MockFactory.
 type MockFactoryMockRecorder struct {
 	mock *MockFactory
 }
 
-// NewMockFactory creates a new mock instance
+// NewMockFactory creates a new mock instance.
 func NewMockFactory(ctrl *gomock.Controller) *MockFactory {
 	mock := &MockFactory{ctrl: ctrl}
 	mock.recorder = &MockFactoryMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockFactory) EXPECT() *MockFactoryMockRecorder {
 	return m.recorder
 }
 
-// FindClientAPIVersion mocks base method
+// FindClientAPIVersion mocks base method.
 func (m *MockFactory) FindClientAPIVersion(arg0 sdkclient.Client) dockerclient.DockerVersion {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FindClientAPIVersion", arg0)
@@ -57,13 +57,13 @@ func (m *MockFactory) FindClientAPIVersion(arg0 sdkclient.Client) dockerclient.D
 	return ret0
 }
 
-// FindClientAPIVersion indicates an expected call of FindClientAPIVersion
+// FindClientAPIVersion indicates an expected call of FindClientAPIVersion.
 func (mr *MockFactoryMockRecorder) FindClientAPIVersion(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindClientAPIVersion", reflect.TypeOf((*MockFactory)(nil).FindClientAPIVersion), arg0)
 }
 
-// FindKnownAPIVersions mocks base method
+// FindKnownAPIVersions mocks base method.
 func (m *MockFactory) FindKnownAPIVersions() []dockerclient.DockerVersion {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FindKnownAPIVersions")
@@ -71,13 +71,13 @@ func (m *MockFactory) FindKnownAPIVersions() []dockerclient.DockerVersion {
 	return ret0
 }
 
-// FindKnownAPIVersions indicates an expected call of FindKnownAPIVersions
+// FindKnownAPIVersions indicates an expected call of FindKnownAPIVersions.
 func (mr *MockFactoryMockRecorder) FindKnownAPIVersions() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindKnownAPIVersions", reflect.TypeOf((*MockFactory)(nil).FindKnownAPIVersions))
 }
 
-// FindSupportedAPIVersions mocks base method
+// FindSupportedAPIVersions mocks base method.
 func (m *MockFactory) FindSupportedAPIVersions() []dockerclient.DockerVersion {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FindSupportedAPIVersions")
@@ -85,13 +85,13 @@ func (m *MockFactory) FindSupportedAPIVersions() []dockerclient.DockerVersion {
 	return ret0
 }
 
-// FindSupportedAPIVersions indicates an expected call of FindSupportedAPIVersions
+// FindSupportedAPIVersions indicates an expected call of FindSupportedAPIVersions.
 func (mr *MockFactoryMockRecorder) FindSupportedAPIVersions() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindSupportedAPIVersions", reflect.TypeOf((*MockFactory)(nil).FindSupportedAPIVersions))
 }
 
-// GetClient mocks base method
+// GetClient mocks base method.
 func (m *MockFactory) GetClient(arg0 dockerclient.DockerVersion) (sdkclient.Client, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetClient", arg0)
@@ -100,13 +100,13 @@ func (m *MockFactory) GetClient(arg0 dockerclient.DockerVersion) (sdkclient.Clie
 	return ret0, ret1
 }
 
-// GetClient indicates an expected call of GetClient
+// GetClient indicates an expected call of GetClient.
 func (mr *MockFactoryMockRecorder) GetClient(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClient", reflect.TypeOf((*MockFactory)(nil).GetClient), arg0)
 }
 
-// GetDefaultClient mocks base method
+// GetDefaultClient mocks base method.
 func (m *MockFactory) GetDefaultClient() (sdkclient.Client, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDefaultClient")
@@ -115,7 +115,7 @@ func (m *MockFactory) GetDefaultClient() (sdkclient.Client, error) {
 	return ret0, ret1
 }
 
-// GetDefaultClient indicates an expected call of GetDefaultClient
+// GetDefaultClient indicates an expected call of GetDefaultClient.
 func (mr *MockFactoryMockRecorder) GetDefaultClient() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDefaultClient", reflect.TypeOf((*MockFactory)(nil).GetDefaultClient))

--- a/agent/ec2/http/mocks/http_mocks.go
+++ b/agent/ec2/http/mocks/http_mocks.go
@@ -25,30 +25,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockClient is a mock of Client interface
+// MockClient is a mock of Client interface.
 type MockClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockClientMockRecorder
 }
 
-// MockClientMockRecorder is the mock recorder for MockClient
+// MockClientMockRecorder is the mock recorder for MockClient.
 type MockClientMockRecorder struct {
 	mock *MockClient
 }
 
-// NewMockClient creates a new mock instance
+// NewMockClient creates a new mock instance.
 func NewMockClient(ctrl *gomock.Controller) *MockClient {
 	mock := &MockClient{ctrl: ctrl}
 	mock.recorder = &MockClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
-// Get mocks base method
+// Get mocks base method.
 func (m *MockClient) Get(arg0 string) (*http.Response, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", arg0)
@@ -57,7 +57,7 @@ func (m *MockClient) Get(arg0 string) (*http.Response, error) {
 	return ret0, ret1
 }
 
-// Get indicates an expected call of Get
+// Get indicates an expected call of Get.
 func (mr *MockClientMockRecorder) Get(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockClient)(nil).Get), arg0)

--- a/agent/ec2/mocks/ec2_mocks.go
+++ b/agent/ec2/mocks/ec2_mocks.go
@@ -28,30 +28,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockEC2MetadataClient is a mock of EC2MetadataClient interface
+// MockEC2MetadataClient is a mock of EC2MetadataClient interface.
 type MockEC2MetadataClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockEC2MetadataClientMockRecorder
 }
 
-// MockEC2MetadataClientMockRecorder is the mock recorder for MockEC2MetadataClient
+// MockEC2MetadataClientMockRecorder is the mock recorder for MockEC2MetadataClient.
 type MockEC2MetadataClientMockRecorder struct {
 	mock *MockEC2MetadataClient
 }
 
-// NewMockEC2MetadataClient creates a new mock instance
+// NewMockEC2MetadataClient creates a new mock instance.
 func NewMockEC2MetadataClient(ctrl *gomock.Controller) *MockEC2MetadataClient {
 	mock := &MockEC2MetadataClient{ctrl: ctrl}
 	mock.recorder = &MockEC2MetadataClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockEC2MetadataClient) EXPECT() *MockEC2MetadataClientMockRecorder {
 	return m.recorder
 }
 
-// AllENIMacs mocks base method
+// AllENIMacs mocks base method.
 func (m *MockEC2MetadataClient) AllENIMacs() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllENIMacs")
@@ -60,13 +60,13 @@ func (m *MockEC2MetadataClient) AllENIMacs() (string, error) {
 	return ret0, ret1
 }
 
-// AllENIMacs indicates an expected call of AllENIMacs
+// AllENIMacs indicates an expected call of AllENIMacs.
 func (mr *MockEC2MetadataClientMockRecorder) AllENIMacs() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllENIMacs", reflect.TypeOf((*MockEC2MetadataClient)(nil).AllENIMacs))
 }
 
-// DefaultCredentials mocks base method
+// DefaultCredentials mocks base method.
 func (m *MockEC2MetadataClient) DefaultCredentials() (*ec2.RoleCredentials, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DefaultCredentials")
@@ -75,13 +75,13 @@ func (m *MockEC2MetadataClient) DefaultCredentials() (*ec2.RoleCredentials, erro
 	return ret0, ret1
 }
 
-// DefaultCredentials indicates an expected call of DefaultCredentials
+// DefaultCredentials indicates an expected call of DefaultCredentials.
 func (mr *MockEC2MetadataClientMockRecorder) DefaultCredentials() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DefaultCredentials", reflect.TypeOf((*MockEC2MetadataClient)(nil).DefaultCredentials))
 }
 
-// GetDynamicData mocks base method
+// GetDynamicData mocks base method.
 func (m *MockEC2MetadataClient) GetDynamicData(arg0 string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDynamicData", arg0)
@@ -90,13 +90,13 @@ func (m *MockEC2MetadataClient) GetDynamicData(arg0 string) (string, error) {
 	return ret0, ret1
 }
 
-// GetDynamicData indicates an expected call of GetDynamicData
+// GetDynamicData indicates an expected call of GetDynamicData.
 func (mr *MockEC2MetadataClientMockRecorder) GetDynamicData(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDynamicData", reflect.TypeOf((*MockEC2MetadataClient)(nil).GetDynamicData), arg0)
 }
 
-// GetMetadata mocks base method
+// GetMetadata mocks base method.
 func (m *MockEC2MetadataClient) GetMetadata(arg0 string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMetadata", arg0)
@@ -105,13 +105,13 @@ func (m *MockEC2MetadataClient) GetMetadata(arg0 string) (string, error) {
 	return ret0, ret1
 }
 
-// GetMetadata indicates an expected call of GetMetadata
+// GetMetadata indicates an expected call of GetMetadata.
 func (mr *MockEC2MetadataClientMockRecorder) GetMetadata(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetadata", reflect.TypeOf((*MockEC2MetadataClient)(nil).GetMetadata), arg0)
 }
 
-// GetUserData mocks base method
+// GetUserData mocks base method.
 func (m *MockEC2MetadataClient) GetUserData() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetUserData")
@@ -120,13 +120,13 @@ func (m *MockEC2MetadataClient) GetUserData() (string, error) {
 	return ret0, ret1
 }
 
-// GetUserData indicates an expected call of GetUserData
+// GetUserData indicates an expected call of GetUserData.
 func (mr *MockEC2MetadataClientMockRecorder) GetUserData() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserData", reflect.TypeOf((*MockEC2MetadataClient)(nil).GetUserData))
 }
 
-// InstanceID mocks base method
+// InstanceID mocks base method.
 func (m *MockEC2MetadataClient) InstanceID() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceID")
@@ -135,13 +135,13 @@ func (m *MockEC2MetadataClient) InstanceID() (string, error) {
 	return ret0, ret1
 }
 
-// InstanceID indicates an expected call of InstanceID
+// InstanceID indicates an expected call of InstanceID.
 func (mr *MockEC2MetadataClientMockRecorder) InstanceID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceID", reflect.TypeOf((*MockEC2MetadataClient)(nil).InstanceID))
 }
 
-// InstanceIdentityDocument mocks base method
+// InstanceIdentityDocument mocks base method.
 func (m *MockEC2MetadataClient) InstanceIdentityDocument() (ec2metadata.EC2InstanceIdentityDocument, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceIdentityDocument")
@@ -150,13 +150,13 @@ func (m *MockEC2MetadataClient) InstanceIdentityDocument() (ec2metadata.EC2Insta
 	return ret0, ret1
 }
 
-// InstanceIdentityDocument indicates an expected call of InstanceIdentityDocument
+// InstanceIdentityDocument indicates an expected call of InstanceIdentityDocument.
 func (mr *MockEC2MetadataClientMockRecorder) InstanceIdentityDocument() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceIdentityDocument", reflect.TypeOf((*MockEC2MetadataClient)(nil).InstanceIdentityDocument))
 }
 
-// OutpostARN mocks base method
+// OutpostARN mocks base method.
 func (m *MockEC2MetadataClient) OutpostARN() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "OutpostARN")
@@ -165,13 +165,13 @@ func (m *MockEC2MetadataClient) OutpostARN() (string, error) {
 	return ret0, ret1
 }
 
-// OutpostARN indicates an expected call of OutpostARN
+// OutpostARN indicates an expected call of OutpostARN.
 func (mr *MockEC2MetadataClientMockRecorder) OutpostARN() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OutpostARN", reflect.TypeOf((*MockEC2MetadataClient)(nil).OutpostARN))
 }
 
-// PrimaryENIMAC mocks base method
+// PrimaryENIMAC mocks base method.
 func (m *MockEC2MetadataClient) PrimaryENIMAC() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PrimaryENIMAC")
@@ -180,13 +180,13 @@ func (m *MockEC2MetadataClient) PrimaryENIMAC() (string, error) {
 	return ret0, ret1
 }
 
-// PrimaryENIMAC indicates an expected call of PrimaryENIMAC
+// PrimaryENIMAC indicates an expected call of PrimaryENIMAC.
 func (mr *MockEC2MetadataClientMockRecorder) PrimaryENIMAC() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrimaryENIMAC", reflect.TypeOf((*MockEC2MetadataClient)(nil).PrimaryENIMAC))
 }
 
-// PrivateIPv4Address mocks base method
+// PrivateIPv4Address mocks base method.
 func (m *MockEC2MetadataClient) PrivateIPv4Address() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PrivateIPv4Address")
@@ -195,13 +195,13 @@ func (m *MockEC2MetadataClient) PrivateIPv4Address() (string, error) {
 	return ret0, ret1
 }
 
-// PrivateIPv4Address indicates an expected call of PrivateIPv4Address
+// PrivateIPv4Address indicates an expected call of PrivateIPv4Address.
 func (mr *MockEC2MetadataClientMockRecorder) PrivateIPv4Address() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrivateIPv4Address", reflect.TypeOf((*MockEC2MetadataClient)(nil).PrivateIPv4Address))
 }
 
-// PublicIPv4Address mocks base method
+// PublicIPv4Address mocks base method.
 func (m *MockEC2MetadataClient) PublicIPv4Address() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PublicIPv4Address")
@@ -210,13 +210,13 @@ func (m *MockEC2MetadataClient) PublicIPv4Address() (string, error) {
 	return ret0, ret1
 }
 
-// PublicIPv4Address indicates an expected call of PublicIPv4Address
+// PublicIPv4Address indicates an expected call of PublicIPv4Address.
 func (mr *MockEC2MetadataClientMockRecorder) PublicIPv4Address() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublicIPv4Address", reflect.TypeOf((*MockEC2MetadataClient)(nil).PublicIPv4Address))
 }
 
-// Region mocks base method
+// Region mocks base method.
 func (m *MockEC2MetadataClient) Region() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Region")
@@ -225,13 +225,13 @@ func (m *MockEC2MetadataClient) Region() (string, error) {
 	return ret0, ret1
 }
 
-// Region indicates an expected call of Region
+// Region indicates an expected call of Region.
 func (mr *MockEC2MetadataClientMockRecorder) Region() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Region", reflect.TypeOf((*MockEC2MetadataClient)(nil).Region))
 }
 
-// SpotInstanceAction mocks base method
+// SpotInstanceAction mocks base method.
 func (m *MockEC2MetadataClient) SpotInstanceAction() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SpotInstanceAction")
@@ -240,13 +240,13 @@ func (m *MockEC2MetadataClient) SpotInstanceAction() (string, error) {
 	return ret0, ret1
 }
 
-// SpotInstanceAction indicates an expected call of SpotInstanceAction
+// SpotInstanceAction indicates an expected call of SpotInstanceAction.
 func (mr *MockEC2MetadataClientMockRecorder) SpotInstanceAction() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SpotInstanceAction", reflect.TypeOf((*MockEC2MetadataClient)(nil).SpotInstanceAction))
 }
 
-// SubnetID mocks base method
+// SubnetID mocks base method.
 func (m *MockEC2MetadataClient) SubnetID(arg0 string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SubnetID", arg0)
@@ -255,13 +255,13 @@ func (m *MockEC2MetadataClient) SubnetID(arg0 string) (string, error) {
 	return ret0, ret1
 }
 
-// SubnetID indicates an expected call of SubnetID
+// SubnetID indicates an expected call of SubnetID.
 func (mr *MockEC2MetadataClientMockRecorder) SubnetID(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubnetID", reflect.TypeOf((*MockEC2MetadataClient)(nil).SubnetID), arg0)
 }
 
-// TargetLifecycleState mocks base method
+// TargetLifecycleState mocks base method.
 func (m *MockEC2MetadataClient) TargetLifecycleState() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TargetLifecycleState")
@@ -270,13 +270,13 @@ func (m *MockEC2MetadataClient) TargetLifecycleState() (string, error) {
 	return ret0, ret1
 }
 
-// TargetLifecycleState indicates an expected call of TargetLifecycleState
+// TargetLifecycleState indicates an expected call of TargetLifecycleState.
 func (mr *MockEC2MetadataClientMockRecorder) TargetLifecycleState() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TargetLifecycleState", reflect.TypeOf((*MockEC2MetadataClient)(nil).TargetLifecycleState))
 }
 
-// VPCID mocks base method
+// VPCID mocks base method.
 func (m *MockEC2MetadataClient) VPCID(arg0 string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "VPCID", arg0)
@@ -285,36 +285,36 @@ func (m *MockEC2MetadataClient) VPCID(arg0 string) (string, error) {
 	return ret0, ret1
 }
 
-// VPCID indicates an expected call of VPCID
+// VPCID indicates an expected call of VPCID.
 func (mr *MockEC2MetadataClientMockRecorder) VPCID(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VPCID", reflect.TypeOf((*MockEC2MetadataClient)(nil).VPCID), arg0)
 }
 
-// MockHttpClient is a mock of HttpClient interface
+// MockHttpClient is a mock of HttpClient interface.
 type MockHttpClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockHttpClientMockRecorder
 }
 
-// MockHttpClientMockRecorder is the mock recorder for MockHttpClient
+// MockHttpClientMockRecorder is the mock recorder for MockHttpClient.
 type MockHttpClientMockRecorder struct {
 	mock *MockHttpClient
 }
 
-// NewMockHttpClient creates a new mock instance
+// NewMockHttpClient creates a new mock instance.
 func NewMockHttpClient(ctrl *gomock.Controller) *MockHttpClient {
 	mock := &MockHttpClient{ctrl: ctrl}
 	mock.recorder = &MockHttpClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockHttpClient) EXPECT() *MockHttpClientMockRecorder {
 	return m.recorder
 }
 
-// GetDynamicData mocks base method
+// GetDynamicData mocks base method.
 func (m *MockHttpClient) GetDynamicData(arg0 string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDynamicData", arg0)
@@ -323,13 +323,13 @@ func (m *MockHttpClient) GetDynamicData(arg0 string) (string, error) {
 	return ret0, ret1
 }
 
-// GetDynamicData indicates an expected call of GetDynamicData
+// GetDynamicData indicates an expected call of GetDynamicData.
 func (mr *MockHttpClientMockRecorder) GetDynamicData(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDynamicData", reflect.TypeOf((*MockHttpClient)(nil).GetDynamicData), arg0)
 }
 
-// GetInstanceIdentityDocument mocks base method
+// GetInstanceIdentityDocument mocks base method.
 func (m *MockHttpClient) GetInstanceIdentityDocument() (ec2metadata.EC2InstanceIdentityDocument, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetInstanceIdentityDocument")
@@ -338,13 +338,13 @@ func (m *MockHttpClient) GetInstanceIdentityDocument() (ec2metadata.EC2InstanceI
 	return ret0, ret1
 }
 
-// GetInstanceIdentityDocument indicates an expected call of GetInstanceIdentityDocument
+// GetInstanceIdentityDocument indicates an expected call of GetInstanceIdentityDocument.
 func (mr *MockHttpClientMockRecorder) GetInstanceIdentityDocument() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstanceIdentityDocument", reflect.TypeOf((*MockHttpClient)(nil).GetInstanceIdentityDocument))
 }
 
-// GetMetadata mocks base method
+// GetMetadata mocks base method.
 func (m *MockHttpClient) GetMetadata(arg0 string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMetadata", arg0)
@@ -353,13 +353,13 @@ func (m *MockHttpClient) GetMetadata(arg0 string) (string, error) {
 	return ret0, ret1
 }
 
-// GetMetadata indicates an expected call of GetMetadata
+// GetMetadata indicates an expected call of GetMetadata.
 func (mr *MockHttpClientMockRecorder) GetMetadata(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetadata", reflect.TypeOf((*MockHttpClient)(nil).GetMetadata), arg0)
 }
 
-// GetUserData mocks base method
+// GetUserData mocks base method.
 func (m *MockHttpClient) GetUserData() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetUserData")
@@ -368,13 +368,13 @@ func (m *MockHttpClient) GetUserData() (string, error) {
 	return ret0, ret1
 }
 
-// GetUserData indicates an expected call of GetUserData
+// GetUserData indicates an expected call of GetUserData.
 func (mr *MockHttpClientMockRecorder) GetUserData() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserData", reflect.TypeOf((*MockHttpClient)(nil).GetUserData))
 }
 
-// Region mocks base method
+// Region mocks base method.
 func (m *MockHttpClient) Region() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Region")
@@ -383,36 +383,36 @@ func (m *MockHttpClient) Region() (string, error) {
 	return ret0, ret1
 }
 
-// Region indicates an expected call of Region
+// Region indicates an expected call of Region.
 func (mr *MockHttpClientMockRecorder) Region() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Region", reflect.TypeOf((*MockHttpClient)(nil).Region))
 }
 
-// MockClient is a mock of Client interface
+// MockClient is a mock of Client interface.
 type MockClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockClientMockRecorder
 }
 
-// MockClientMockRecorder is the mock recorder for MockClient
+// MockClientMockRecorder is the mock recorder for MockClient.
 type MockClientMockRecorder struct {
 	mock *MockClient
 }
 
-// NewMockClient creates a new mock instance
+// NewMockClient creates a new mock instance.
 func NewMockClient(ctrl *gomock.Controller) *MockClient {
 	mock := &MockClient{ctrl: ctrl}
 	mock.recorder = &MockClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
-// CreateTags mocks base method
+// CreateTags mocks base method.
 func (m *MockClient) CreateTags(arg0 *ec20.CreateTagsInput) (*ec20.CreateTagsOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateTags", arg0)
@@ -421,13 +421,13 @@ func (m *MockClient) CreateTags(arg0 *ec20.CreateTagsInput) (*ec20.CreateTagsOut
 	return ret0, ret1
 }
 
-// CreateTags indicates an expected call of CreateTags
+// CreateTags indicates an expected call of CreateTags.
 func (mr *MockClientMockRecorder) CreateTags(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTags", reflect.TypeOf((*MockClient)(nil).CreateTags), arg0)
 }
 
-// DescribeECSTagsForInstance mocks base method
+// DescribeECSTagsForInstance mocks base method.
 func (m *MockClient) DescribeECSTagsForInstance(arg0 string) ([]*ecs.Tag, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeECSTagsForInstance", arg0)
@@ -436,36 +436,36 @@ func (m *MockClient) DescribeECSTagsForInstance(arg0 string) ([]*ecs.Tag, error)
 	return ret0, ret1
 }
 
-// DescribeECSTagsForInstance indicates an expected call of DescribeECSTagsForInstance
+// DescribeECSTagsForInstance indicates an expected call of DescribeECSTagsForInstance.
 func (mr *MockClientMockRecorder) DescribeECSTagsForInstance(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeECSTagsForInstance", reflect.TypeOf((*MockClient)(nil).DescribeECSTagsForInstance), arg0)
 }
 
-// MockClientSDK is a mock of ClientSDK interface
+// MockClientSDK is a mock of ClientSDK interface.
 type MockClientSDK struct {
 	ctrl     *gomock.Controller
 	recorder *MockClientSDKMockRecorder
 }
 
-// MockClientSDKMockRecorder is the mock recorder for MockClientSDK
+// MockClientSDKMockRecorder is the mock recorder for MockClientSDK.
 type MockClientSDKMockRecorder struct {
 	mock *MockClientSDK
 }
 
-// NewMockClientSDK creates a new mock instance
+// NewMockClientSDK creates a new mock instance.
 func NewMockClientSDK(ctrl *gomock.Controller) *MockClientSDK {
 	mock := &MockClientSDK{ctrl: ctrl}
 	mock.recorder = &MockClientSDKMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockClientSDK) EXPECT() *MockClientSDKMockRecorder {
 	return m.recorder
 }
 
-// CreateTags mocks base method
+// CreateTags mocks base method.
 func (m *MockClientSDK) CreateTags(arg0 *ec20.CreateTagsInput) (*ec20.CreateTagsOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateTags", arg0)
@@ -474,13 +474,13 @@ func (m *MockClientSDK) CreateTags(arg0 *ec20.CreateTagsInput) (*ec20.CreateTags
 	return ret0, ret1
 }
 
-// CreateTags indicates an expected call of CreateTags
+// CreateTags indicates an expected call of CreateTags.
 func (mr *MockClientSDKMockRecorder) CreateTags(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTags", reflect.TypeOf((*MockClientSDK)(nil).CreateTags), arg0)
 }
 
-// DescribeTags mocks base method
+// DescribeTags mocks base method.
 func (m *MockClientSDK) DescribeTags(arg0 *ec20.DescribeTagsInput) (*ec20.DescribeTagsOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeTags", arg0)
@@ -489,7 +489,7 @@ func (m *MockClientSDK) DescribeTags(arg0 *ec20.DescribeTagsInput) (*ec20.Descri
 	return ret0, ret1
 }
 
-// DescribeTags indicates an expected call of DescribeTags
+// DescribeTags indicates an expected call of DescribeTags.
 func (mr *MockClientSDKMockRecorder) DescribeTags(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTags", reflect.TypeOf((*MockClientSDK)(nil).DescribeTags), arg0)

--- a/agent/ecr/mocks/ecr_mocks.go
+++ b/agent/ecr/mocks/ecr_mocks.go
@@ -27,30 +27,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockECRSDK is a mock of ECRSDK interface
+// MockECRSDK is a mock of ECRSDK interface.
 type MockECRSDK struct {
 	ctrl     *gomock.Controller
 	recorder *MockECRSDKMockRecorder
 }
 
-// MockECRSDKMockRecorder is the mock recorder for MockECRSDK
+// MockECRSDKMockRecorder is the mock recorder for MockECRSDK.
 type MockECRSDKMockRecorder struct {
 	mock *MockECRSDK
 }
 
-// NewMockECRSDK creates a new mock instance
+// NewMockECRSDK creates a new mock instance.
 func NewMockECRSDK(ctrl *gomock.Controller) *MockECRSDK {
 	mock := &MockECRSDK{ctrl: ctrl}
 	mock.recorder = &MockECRSDKMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockECRSDK) EXPECT() *MockECRSDKMockRecorder {
 	return m.recorder
 }
 
-// GetAuthorizationToken mocks base method
+// GetAuthorizationToken mocks base method.
 func (m *MockECRSDK) GetAuthorizationToken(arg0 *ecr0.GetAuthorizationTokenInput) (*ecr0.GetAuthorizationTokenOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAuthorizationToken", arg0)
@@ -59,36 +59,36 @@ func (m *MockECRSDK) GetAuthorizationToken(arg0 *ecr0.GetAuthorizationTokenInput
 	return ret0, ret1
 }
 
-// GetAuthorizationToken indicates an expected call of GetAuthorizationToken
+// GetAuthorizationToken indicates an expected call of GetAuthorizationToken.
 func (mr *MockECRSDKMockRecorder) GetAuthorizationToken(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAuthorizationToken", reflect.TypeOf((*MockECRSDK)(nil).GetAuthorizationToken), arg0)
 }
 
-// MockECRFactory is a mock of ECRFactory interface
+// MockECRFactory is a mock of ECRFactory interface.
 type MockECRFactory struct {
 	ctrl     *gomock.Controller
 	recorder *MockECRFactoryMockRecorder
 }
 
-// MockECRFactoryMockRecorder is the mock recorder for MockECRFactory
+// MockECRFactoryMockRecorder is the mock recorder for MockECRFactory.
 type MockECRFactoryMockRecorder struct {
 	mock *MockECRFactory
 }
 
-// NewMockECRFactory creates a new mock instance
+// NewMockECRFactory creates a new mock instance.
 func NewMockECRFactory(ctrl *gomock.Controller) *MockECRFactory {
 	mock := &MockECRFactory{ctrl: ctrl}
 	mock.recorder = &MockECRFactoryMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockECRFactory) EXPECT() *MockECRFactoryMockRecorder {
 	return m.recorder
 }
 
-// GetClient mocks base method
+// GetClient mocks base method.
 func (m *MockECRFactory) GetClient(arg0 *container.ECRAuthData) (ecr.ECRClient, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetClient", arg0)
@@ -97,36 +97,36 @@ func (m *MockECRFactory) GetClient(arg0 *container.ECRAuthData) (ecr.ECRClient, 
 	return ret0, ret1
 }
 
-// GetClient indicates an expected call of GetClient
+// GetClient indicates an expected call of GetClient.
 func (mr *MockECRFactoryMockRecorder) GetClient(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClient", reflect.TypeOf((*MockECRFactory)(nil).GetClient), arg0)
 }
 
-// MockECRClient is a mock of ECRClient interface
+// MockECRClient is a mock of ECRClient interface.
 type MockECRClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockECRClientMockRecorder
 }
 
-// MockECRClientMockRecorder is the mock recorder for MockECRClient
+// MockECRClientMockRecorder is the mock recorder for MockECRClient.
 type MockECRClientMockRecorder struct {
 	mock *MockECRClient
 }
 
-// NewMockECRClient creates a new mock instance
+// NewMockECRClient creates a new mock instance.
 func NewMockECRClient(ctrl *gomock.Controller) *MockECRClient {
 	mock := &MockECRClient{ctrl: ctrl}
 	mock.recorder = &MockECRClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockECRClient) EXPECT() *MockECRClientMockRecorder {
 	return m.recorder
 }
 
-// GetAuthorizationToken mocks base method
+// GetAuthorizationToken mocks base method.
 func (m *MockECRClient) GetAuthorizationToken(arg0 string) (*ecr0.AuthorizationData, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAuthorizationToken", arg0)
@@ -135,7 +135,7 @@ func (m *MockECRClient) GetAuthorizationToken(arg0 string) (*ecr0.AuthorizationD
 	return ret0, ret1
 }
 
-// GetAuthorizationToken indicates an expected call of GetAuthorizationToken
+// GetAuthorizationToken indicates an expected call of GetAuthorizationToken.
 func (mr *MockECRClientMockRecorder) GetAuthorizationToken(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAuthorizationToken", reflect.TypeOf((*MockECRClient)(nil).GetAuthorizationToken), arg0)

--- a/agent/ecscni/mocks/ecscni_mocks.go
+++ b/agent/ecscni/mocks/ecscni_mocks.go
@@ -28,30 +28,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockCNIClient is a mock of CNIClient interface
+// MockCNIClient is a mock of CNIClient interface.
 type MockCNIClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockCNIClientMockRecorder
 }
 
-// MockCNIClientMockRecorder is the mock recorder for MockCNIClient
+// MockCNIClientMockRecorder is the mock recorder for MockCNIClient.
 type MockCNIClientMockRecorder struct {
 	mock *MockCNIClient
 }
 
-// NewMockCNIClient creates a new mock instance
+// NewMockCNIClient creates a new mock instance.
 func NewMockCNIClient(ctrl *gomock.Controller) *MockCNIClient {
 	mock := &MockCNIClient{ctrl: ctrl}
 	mock.recorder = &MockCNIClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockCNIClient) EXPECT() *MockCNIClientMockRecorder {
 	return m.recorder
 }
 
-// Capabilities mocks base method
+// Capabilities mocks base method.
 func (m *MockCNIClient) Capabilities(arg0 string) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Capabilities", arg0)
@@ -60,13 +60,13 @@ func (m *MockCNIClient) Capabilities(arg0 string) ([]string, error) {
 	return ret0, ret1
 }
 
-// Capabilities indicates an expected call of Capabilities
+// Capabilities indicates an expected call of Capabilities.
 func (mr *MockCNIClientMockRecorder) Capabilities(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Capabilities", reflect.TypeOf((*MockCNIClient)(nil).Capabilities), arg0)
 }
 
-// CleanupNS mocks base method
+// CleanupNS mocks base method.
 func (m *MockCNIClient) CleanupNS(arg0 context.Context, arg1 *ecscni.Config, arg2 time.Duration) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CleanupNS", arg0, arg1, arg2)
@@ -74,13 +74,13 @@ func (m *MockCNIClient) CleanupNS(arg0 context.Context, arg1 *ecscni.Config, arg
 	return ret0
 }
 
-// CleanupNS indicates an expected call of CleanupNS
+// CleanupNS indicates an expected call of CleanupNS.
 func (mr *MockCNIClientMockRecorder) CleanupNS(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanupNS", reflect.TypeOf((*MockCNIClient)(nil).CleanupNS), arg0, arg1, arg2)
 }
 
-// ReleaseIPResource mocks base method
+// ReleaseIPResource mocks base method.
 func (m *MockCNIClient) ReleaseIPResource(arg0 context.Context, arg1 *ecscni.Config, arg2 time.Duration) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReleaseIPResource", arg0, arg1, arg2)
@@ -88,13 +88,13 @@ func (m *MockCNIClient) ReleaseIPResource(arg0 context.Context, arg1 *ecscni.Con
 	return ret0
 }
 
-// ReleaseIPResource indicates an expected call of ReleaseIPResource
+// ReleaseIPResource indicates an expected call of ReleaseIPResource.
 func (mr *MockCNIClientMockRecorder) ReleaseIPResource(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReleaseIPResource", reflect.TypeOf((*MockCNIClient)(nil).ReleaseIPResource), arg0, arg1, arg2)
 }
 
-// SetupNS mocks base method
+// SetupNS mocks base method.
 func (m *MockCNIClient) SetupNS(arg0 context.Context, arg1 *ecscni.Config, arg2 time.Duration) (*current.Result, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetupNS", arg0, arg1, arg2)
@@ -103,13 +103,13 @@ func (m *MockCNIClient) SetupNS(arg0 context.Context, arg1 *ecscni.Config, arg2 
 	return ret0, ret1
 }
 
-// SetupNS indicates an expected call of SetupNS
+// SetupNS indicates an expected call of SetupNS.
 func (mr *MockCNIClientMockRecorder) SetupNS(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetupNS", reflect.TypeOf((*MockCNIClient)(nil).SetupNS), arg0, arg1, arg2)
 }
 
-// Version mocks base method
+// Version mocks base method.
 func (m *MockCNIClient) Version(arg0 string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Version", arg0)
@@ -118,7 +118,7 @@ func (m *MockCNIClient) Version(arg0 string) (string, error) {
 	return ret0, ret1
 }
 
-// Version indicates an expected call of Version
+// Version indicates an expected call of Version.
 func (mr *MockCNIClientMockRecorder) Version(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Version", reflect.TypeOf((*MockCNIClient)(nil).Version), arg0)

--- a/agent/ecscni/mocks/namespace_helper_mocks.go
+++ b/agent/ecscni/mocks/namespace_helper_mocks.go
@@ -28,30 +28,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockNamespaceHelper is a mock of NamespaceHelper interface
+// MockNamespaceHelper is a mock of NamespaceHelper interface.
 type MockNamespaceHelper struct {
 	ctrl     *gomock.Controller
 	recorder *MockNamespaceHelperMockRecorder
 }
 
-// MockNamespaceHelperMockRecorder is the mock recorder for MockNamespaceHelper
+// MockNamespaceHelperMockRecorder is the mock recorder for MockNamespaceHelper.
 type MockNamespaceHelperMockRecorder struct {
 	mock *MockNamespaceHelper
 }
 
-// NewMockNamespaceHelper creates a new mock instance
+// NewMockNamespaceHelper creates a new mock instance.
 func NewMockNamespaceHelper(ctrl *gomock.Controller) *MockNamespaceHelper {
 	mock := &MockNamespaceHelper{ctrl: ctrl}
 	mock.recorder = &MockNamespaceHelperMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockNamespaceHelper) EXPECT() *MockNamespaceHelperMockRecorder {
 	return m.recorder
 }
 
-// ConfigureTaskNamespaceRouting mocks base method
+// ConfigureTaskNamespaceRouting mocks base method.
 func (m *MockNamespaceHelper) ConfigureTaskNamespaceRouting(arg0 context.Context, arg1 *eni.ENI, arg2 *ecscni.Config, arg3 *current.Result) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConfigureTaskNamespaceRouting", arg0, arg1, arg2, arg3)
@@ -59,7 +59,7 @@ func (m *MockNamespaceHelper) ConfigureTaskNamespaceRouting(arg0 context.Context
 	return ret0
 }
 
-// ConfigureTaskNamespaceRouting indicates an expected call of ConfigureTaskNamespaceRouting
+// ConfigureTaskNamespaceRouting indicates an expected call of ConfigureTaskNamespaceRouting.
 func (mr *MockNamespaceHelperMockRecorder) ConfigureTaskNamespaceRouting(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfigureTaskNamespaceRouting", reflect.TypeOf((*MockNamespaceHelper)(nil).ConfigureTaskNamespaceRouting), arg0, arg1, arg2, arg3)

--- a/agent/ecscni/mocks_cnitypes/result_mocks.go
+++ b/agent/ecscni/mocks_cnitypes/result_mocks.go
@@ -26,30 +26,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockResult is a mock of Result interface
+// MockResult is a mock of Result interface.
 type MockResult struct {
 	ctrl     *gomock.Controller
 	recorder *MockResultMockRecorder
 }
 
-// MockResultMockRecorder is the mock recorder for MockResult
+// MockResultMockRecorder is the mock recorder for MockResult.
 type MockResultMockRecorder struct {
 	mock *MockResult
 }
 
-// NewMockResult creates a new mock instance
+// NewMockResult creates a new mock instance.
 func NewMockResult(ctrl *gomock.Controller) *MockResult {
 	mock := &MockResult{ctrl: ctrl}
 	mock.recorder = &MockResultMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockResult) EXPECT() *MockResultMockRecorder {
 	return m.recorder
 }
 
-// GetAsVersion mocks base method
+// GetAsVersion mocks base method.
 func (m *MockResult) GetAsVersion(arg0 string) (types.Result, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAsVersion", arg0)
@@ -58,13 +58,13 @@ func (m *MockResult) GetAsVersion(arg0 string) (types.Result, error) {
 	return ret0, ret1
 }
 
-// GetAsVersion indicates an expected call of GetAsVersion
+// GetAsVersion indicates an expected call of GetAsVersion.
 func (mr *MockResultMockRecorder) GetAsVersion(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAsVersion", reflect.TypeOf((*MockResult)(nil).GetAsVersion), arg0)
 }
 
-// Print mocks base method
+// Print mocks base method.
 func (m *MockResult) Print() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Print")
@@ -72,13 +72,13 @@ func (m *MockResult) Print() error {
 	return ret0
 }
 
-// Print indicates an expected call of Print
+// Print indicates an expected call of Print.
 func (mr *MockResultMockRecorder) Print() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Print", reflect.TypeOf((*MockResult)(nil).Print))
 }
 
-// PrintTo mocks base method
+// PrintTo mocks base method.
 func (m *MockResult) PrintTo(arg0 io.Writer) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PrintTo", arg0)
@@ -86,13 +86,13 @@ func (m *MockResult) PrintTo(arg0 io.Writer) error {
 	return ret0
 }
 
-// PrintTo indicates an expected call of PrintTo
+// PrintTo indicates an expected call of PrintTo.
 func (mr *MockResultMockRecorder) PrintTo(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrintTo", reflect.TypeOf((*MockResult)(nil).PrintTo), arg0)
 }
 
-// Version mocks base method
+// Version mocks base method.
 func (m *MockResult) Version() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Version")
@@ -100,7 +100,7 @@ func (m *MockResult) Version() string {
 	return ret0
 }
 
-// Version indicates an expected call of Version
+// Version indicates an expected call of Version.
 func (mr *MockResultMockRecorder) Version() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Version", reflect.TypeOf((*MockResult)(nil).Version))

--- a/agent/ecscni/mocks_libcni/libcni_mocks.go
+++ b/agent/ecscni/mocks_libcni/libcni_mocks.go
@@ -27,30 +27,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockCNI is a mock of CNI interface
+// MockCNI is a mock of CNI interface.
 type MockCNI struct {
 	ctrl     *gomock.Controller
 	recorder *MockCNIMockRecorder
 }
 
-// MockCNIMockRecorder is the mock recorder for MockCNI
+// MockCNIMockRecorder is the mock recorder for MockCNI.
 type MockCNIMockRecorder struct {
 	mock *MockCNI
 }
 
-// NewMockCNI creates a new mock instance
+// NewMockCNI creates a new mock instance.
 func NewMockCNI(ctrl *gomock.Controller) *MockCNI {
 	mock := &MockCNI{ctrl: ctrl}
 	mock.recorder = &MockCNIMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockCNI) EXPECT() *MockCNIMockRecorder {
 	return m.recorder
 }
 
-// AddNetwork mocks base method
+// AddNetwork mocks base method.
 func (m *MockCNI) AddNetwork(arg0 context.Context, arg1 *libcni.NetworkConfig, arg2 *libcni.RuntimeConf) (types.Result, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddNetwork", arg0, arg1, arg2)
@@ -59,13 +59,13 @@ func (m *MockCNI) AddNetwork(arg0 context.Context, arg1 *libcni.NetworkConfig, a
 	return ret0, ret1
 }
 
-// AddNetwork indicates an expected call of AddNetwork
+// AddNetwork indicates an expected call of AddNetwork.
 func (mr *MockCNIMockRecorder) AddNetwork(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddNetwork", reflect.TypeOf((*MockCNI)(nil).AddNetwork), arg0, arg1, arg2)
 }
 
-// AddNetworkList mocks base method
+// AddNetworkList mocks base method.
 func (m *MockCNI) AddNetworkList(arg0 context.Context, arg1 *libcni.NetworkConfigList, arg2 *libcni.RuntimeConf) (types.Result, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddNetworkList", arg0, arg1, arg2)
@@ -74,13 +74,13 @@ func (m *MockCNI) AddNetworkList(arg0 context.Context, arg1 *libcni.NetworkConfi
 	return ret0, ret1
 }
 
-// AddNetworkList indicates an expected call of AddNetworkList
+// AddNetworkList indicates an expected call of AddNetworkList.
 func (mr *MockCNIMockRecorder) AddNetworkList(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddNetworkList", reflect.TypeOf((*MockCNI)(nil).AddNetworkList), arg0, arg1, arg2)
 }
 
-// CheckNetwork mocks base method
+// CheckNetwork mocks base method.
 func (m *MockCNI) CheckNetwork(arg0 context.Context, arg1 *libcni.NetworkConfig, arg2 *libcni.RuntimeConf) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CheckNetwork", arg0, arg1, arg2)
@@ -88,13 +88,13 @@ func (m *MockCNI) CheckNetwork(arg0 context.Context, arg1 *libcni.NetworkConfig,
 	return ret0
 }
 
-// CheckNetwork indicates an expected call of CheckNetwork
+// CheckNetwork indicates an expected call of CheckNetwork.
 func (mr *MockCNIMockRecorder) CheckNetwork(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckNetwork", reflect.TypeOf((*MockCNI)(nil).CheckNetwork), arg0, arg1, arg2)
 }
 
-// CheckNetworkList mocks base method
+// CheckNetworkList mocks base method.
 func (m *MockCNI) CheckNetworkList(arg0 context.Context, arg1 *libcni.NetworkConfigList, arg2 *libcni.RuntimeConf) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CheckNetworkList", arg0, arg1, arg2)
@@ -102,13 +102,13 @@ func (m *MockCNI) CheckNetworkList(arg0 context.Context, arg1 *libcni.NetworkCon
 	return ret0
 }
 
-// CheckNetworkList indicates an expected call of CheckNetworkList
+// CheckNetworkList indicates an expected call of CheckNetworkList.
 func (mr *MockCNIMockRecorder) CheckNetworkList(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckNetworkList", reflect.TypeOf((*MockCNI)(nil).CheckNetworkList), arg0, arg1, arg2)
 }
 
-// DelNetwork mocks base method
+// DelNetwork mocks base method.
 func (m *MockCNI) DelNetwork(arg0 context.Context, arg1 *libcni.NetworkConfig, arg2 *libcni.RuntimeConf) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DelNetwork", arg0, arg1, arg2)
@@ -116,13 +116,13 @@ func (m *MockCNI) DelNetwork(arg0 context.Context, arg1 *libcni.NetworkConfig, a
 	return ret0
 }
 
-// DelNetwork indicates an expected call of DelNetwork
+// DelNetwork indicates an expected call of DelNetwork.
 func (mr *MockCNIMockRecorder) DelNetwork(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DelNetwork", reflect.TypeOf((*MockCNI)(nil).DelNetwork), arg0, arg1, arg2)
 }
 
-// DelNetworkList mocks base method
+// DelNetworkList mocks base method.
 func (m *MockCNI) DelNetworkList(arg0 context.Context, arg1 *libcni.NetworkConfigList, arg2 *libcni.RuntimeConf) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DelNetworkList", arg0, arg1, arg2)
@@ -130,13 +130,13 @@ func (m *MockCNI) DelNetworkList(arg0 context.Context, arg1 *libcni.NetworkConfi
 	return ret0
 }
 
-// DelNetworkList indicates an expected call of DelNetworkList
+// DelNetworkList indicates an expected call of DelNetworkList.
 func (mr *MockCNIMockRecorder) DelNetworkList(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DelNetworkList", reflect.TypeOf((*MockCNI)(nil).DelNetworkList), arg0, arg1, arg2)
 }
 
-// GetNetworkCachedConfig mocks base method
+// GetNetworkCachedConfig mocks base method.
 func (m *MockCNI) GetNetworkCachedConfig(arg0 *libcni.NetworkConfig, arg1 *libcni.RuntimeConf) ([]byte, *libcni.RuntimeConf, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetNetworkCachedConfig", arg0, arg1)
@@ -146,13 +146,13 @@ func (m *MockCNI) GetNetworkCachedConfig(arg0 *libcni.NetworkConfig, arg1 *libcn
 	return ret0, ret1, ret2
 }
 
-// GetNetworkCachedConfig indicates an expected call of GetNetworkCachedConfig
+// GetNetworkCachedConfig indicates an expected call of GetNetworkCachedConfig.
 func (mr *MockCNIMockRecorder) GetNetworkCachedConfig(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNetworkCachedConfig", reflect.TypeOf((*MockCNI)(nil).GetNetworkCachedConfig), arg0, arg1)
 }
 
-// GetNetworkCachedResult mocks base method
+// GetNetworkCachedResult mocks base method.
 func (m *MockCNI) GetNetworkCachedResult(arg0 *libcni.NetworkConfig, arg1 *libcni.RuntimeConf) (types.Result, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetNetworkCachedResult", arg0, arg1)
@@ -161,13 +161,13 @@ func (m *MockCNI) GetNetworkCachedResult(arg0 *libcni.NetworkConfig, arg1 *libcn
 	return ret0, ret1
 }
 
-// GetNetworkCachedResult indicates an expected call of GetNetworkCachedResult
+// GetNetworkCachedResult indicates an expected call of GetNetworkCachedResult.
 func (mr *MockCNIMockRecorder) GetNetworkCachedResult(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNetworkCachedResult", reflect.TypeOf((*MockCNI)(nil).GetNetworkCachedResult), arg0, arg1)
 }
 
-// GetNetworkListCachedConfig mocks base method
+// GetNetworkListCachedConfig mocks base method.
 func (m *MockCNI) GetNetworkListCachedConfig(arg0 *libcni.NetworkConfigList, arg1 *libcni.RuntimeConf) ([]byte, *libcni.RuntimeConf, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetNetworkListCachedConfig", arg0, arg1)
@@ -177,13 +177,13 @@ func (m *MockCNI) GetNetworkListCachedConfig(arg0 *libcni.NetworkConfigList, arg
 	return ret0, ret1, ret2
 }
 
-// GetNetworkListCachedConfig indicates an expected call of GetNetworkListCachedConfig
+// GetNetworkListCachedConfig indicates an expected call of GetNetworkListCachedConfig.
 func (mr *MockCNIMockRecorder) GetNetworkListCachedConfig(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNetworkListCachedConfig", reflect.TypeOf((*MockCNI)(nil).GetNetworkListCachedConfig), arg0, arg1)
 }
 
-// GetNetworkListCachedResult mocks base method
+// GetNetworkListCachedResult mocks base method.
 func (m *MockCNI) GetNetworkListCachedResult(arg0 *libcni.NetworkConfigList, arg1 *libcni.RuntimeConf) (types.Result, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetNetworkListCachedResult", arg0, arg1)
@@ -192,13 +192,13 @@ func (m *MockCNI) GetNetworkListCachedResult(arg0 *libcni.NetworkConfigList, arg
 	return ret0, ret1
 }
 
-// GetNetworkListCachedResult indicates an expected call of GetNetworkListCachedResult
+// GetNetworkListCachedResult indicates an expected call of GetNetworkListCachedResult.
 func (mr *MockCNIMockRecorder) GetNetworkListCachedResult(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNetworkListCachedResult", reflect.TypeOf((*MockCNI)(nil).GetNetworkListCachedResult), arg0, arg1)
 }
 
-// ValidateNetwork mocks base method
+// ValidateNetwork mocks base method.
 func (m *MockCNI) ValidateNetwork(arg0 context.Context, arg1 *libcni.NetworkConfig) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ValidateNetwork", arg0, arg1)
@@ -207,13 +207,13 @@ func (m *MockCNI) ValidateNetwork(arg0 context.Context, arg1 *libcni.NetworkConf
 	return ret0, ret1
 }
 
-// ValidateNetwork indicates an expected call of ValidateNetwork
+// ValidateNetwork indicates an expected call of ValidateNetwork.
 func (mr *MockCNIMockRecorder) ValidateNetwork(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateNetwork", reflect.TypeOf((*MockCNI)(nil).ValidateNetwork), arg0, arg1)
 }
 
-// ValidateNetworkList mocks base method
+// ValidateNetworkList mocks base method.
 func (m *MockCNI) ValidateNetworkList(arg0 context.Context, arg1 *libcni.NetworkConfigList) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ValidateNetworkList", arg0, arg1)
@@ -222,7 +222,7 @@ func (m *MockCNI) ValidateNetworkList(arg0 context.Context, arg1 *libcni.Network
 	return ret0, ret1
 }
 
-// ValidateNetworkList indicates an expected call of ValidateNetworkList
+// ValidateNetworkList indicates an expected call of ValidateNetworkList.
 func (mr *MockCNIMockRecorder) ValidateNetworkList(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateNetworkList", reflect.TypeOf((*MockCNI)(nil).ValidateNetworkList), arg0, arg1)

--- a/agent/engine/dockerstate/mocks/dockerstate_mocks.go
+++ b/agent/engine/dockerstate/mocks/dockerstate_mocks.go
@@ -28,102 +28,102 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockTaskEngineState is a mock of TaskEngineState interface
+// MockTaskEngineState is a mock of TaskEngineState interface.
 type MockTaskEngineState struct {
 	ctrl     *gomock.Controller
 	recorder *MockTaskEngineStateMockRecorder
 }
 
-// MockTaskEngineStateMockRecorder is the mock recorder for MockTaskEngineState
+// MockTaskEngineStateMockRecorder is the mock recorder for MockTaskEngineState.
 type MockTaskEngineStateMockRecorder struct {
 	mock *MockTaskEngineState
 }
 
-// NewMockTaskEngineState creates a new mock instance
+// NewMockTaskEngineState creates a new mock instance.
 func NewMockTaskEngineState(ctrl *gomock.Controller) *MockTaskEngineState {
 	mock := &MockTaskEngineState{ctrl: ctrl}
 	mock.recorder = &MockTaskEngineStateMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockTaskEngineState) EXPECT() *MockTaskEngineStateMockRecorder {
 	return m.recorder
 }
 
-// AddContainer mocks base method
+// AddContainer mocks base method.
 func (m *MockTaskEngineState) AddContainer(arg0 *container.DockerContainer, arg1 *task.Task) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AddContainer", arg0, arg1)
 }
 
-// AddContainer indicates an expected call of AddContainer
+// AddContainer indicates an expected call of AddContainer.
 func (mr *MockTaskEngineStateMockRecorder) AddContainer(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddContainer", reflect.TypeOf((*MockTaskEngineState)(nil).AddContainer), arg0, arg1)
 }
 
-// AddENIAttachment mocks base method
+// AddENIAttachment mocks base method.
 func (m *MockTaskEngineState) AddENIAttachment(arg0 *eni.ENIAttachment) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AddENIAttachment", arg0)
 }
 
-// AddENIAttachment indicates an expected call of AddENIAttachment
+// AddENIAttachment indicates an expected call of AddENIAttachment.
 func (mr *MockTaskEngineStateMockRecorder) AddENIAttachment(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddENIAttachment", reflect.TypeOf((*MockTaskEngineState)(nil).AddENIAttachment), arg0)
 }
 
-// AddImageState mocks base method
+// AddImageState mocks base method.
 func (m *MockTaskEngineState) AddImageState(arg0 *image.ImageState) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AddImageState", arg0)
 }
 
-// AddImageState indicates an expected call of AddImageState
+// AddImageState indicates an expected call of AddImageState.
 func (mr *MockTaskEngineStateMockRecorder) AddImageState(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddImageState", reflect.TypeOf((*MockTaskEngineState)(nil).AddImageState), arg0)
 }
 
-// AddPulledContainer mocks base method
+// AddPulledContainer mocks base method.
 func (m *MockTaskEngineState) AddPulledContainer(arg0 *container.DockerContainer, arg1 *task.Task) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AddPulledContainer", arg0, arg1)
 }
 
-// AddPulledContainer indicates an expected call of AddPulledContainer
+// AddPulledContainer indicates an expected call of AddPulledContainer.
 func (mr *MockTaskEngineStateMockRecorder) AddPulledContainer(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddPulledContainer", reflect.TypeOf((*MockTaskEngineState)(nil).AddPulledContainer), arg0, arg1)
 }
 
-// AddTask mocks base method
+// AddTask mocks base method.
 func (m *MockTaskEngineState) AddTask(arg0 *task.Task) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AddTask", arg0)
 }
 
-// AddTask indicates an expected call of AddTask
+// AddTask indicates an expected call of AddTask.
 func (mr *MockTaskEngineStateMockRecorder) AddTask(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddTask", reflect.TypeOf((*MockTaskEngineState)(nil).AddTask), arg0)
 }
 
-// AddTaskIPAddress mocks base method
+// AddTaskIPAddress mocks base method.
 func (m *MockTaskEngineState) AddTaskIPAddress(arg0, arg1 string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AddTaskIPAddress", arg0, arg1)
 }
 
-// AddTaskIPAddress indicates an expected call of AddTaskIPAddress
+// AddTaskIPAddress indicates an expected call of AddTaskIPAddress.
 func (mr *MockTaskEngineStateMockRecorder) AddTaskIPAddress(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddTaskIPAddress", reflect.TypeOf((*MockTaskEngineState)(nil).AddTaskIPAddress), arg0, arg1)
 }
 
-// AllENIAttachments mocks base method
+// AllENIAttachments mocks base method.
 func (m *MockTaskEngineState) AllENIAttachments() []*eni.ENIAttachment {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllENIAttachments")
@@ -131,13 +131,13 @@ func (m *MockTaskEngineState) AllENIAttachments() []*eni.ENIAttachment {
 	return ret0
 }
 
-// AllENIAttachments indicates an expected call of AllENIAttachments
+// AllENIAttachments indicates an expected call of AllENIAttachments.
 func (mr *MockTaskEngineStateMockRecorder) AllENIAttachments() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllENIAttachments", reflect.TypeOf((*MockTaskEngineState)(nil).AllENIAttachments))
 }
 
-// AllExternalTasks mocks base method
+// AllExternalTasks mocks base method.
 func (m *MockTaskEngineState) AllExternalTasks() []*task.Task {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllExternalTasks")
@@ -145,13 +145,13 @@ func (m *MockTaskEngineState) AllExternalTasks() []*task.Task {
 	return ret0
 }
 
-// AllExternalTasks indicates an expected call of AllExternalTasks
+// AllExternalTasks indicates an expected call of AllExternalTasks.
 func (mr *MockTaskEngineStateMockRecorder) AllExternalTasks() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllExternalTasks", reflect.TypeOf((*MockTaskEngineState)(nil).AllExternalTasks))
 }
 
-// AllImageStates mocks base method
+// AllImageStates mocks base method.
 func (m *MockTaskEngineState) AllImageStates() []*image.ImageState {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllImageStates")
@@ -159,13 +159,13 @@ func (m *MockTaskEngineState) AllImageStates() []*image.ImageState {
 	return ret0
 }
 
-// AllImageStates indicates an expected call of AllImageStates
+// AllImageStates indicates an expected call of AllImageStates.
 func (mr *MockTaskEngineStateMockRecorder) AllImageStates() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllImageStates", reflect.TypeOf((*MockTaskEngineState)(nil).AllImageStates))
 }
 
-// AllTasks mocks base method
+// AllTasks mocks base method.
 func (m *MockTaskEngineState) AllTasks() []*task.Task {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllTasks")
@@ -173,13 +173,13 @@ func (m *MockTaskEngineState) AllTasks() []*task.Task {
 	return ret0
 }
 
-// AllTasks indicates an expected call of AllTasks
+// AllTasks indicates an expected call of AllTasks.
 func (mr *MockTaskEngineStateMockRecorder) AllTasks() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllTasks", reflect.TypeOf((*MockTaskEngineState)(nil).AllTasks))
 }
 
-// ContainerByID mocks base method
+// ContainerByID mocks base method.
 func (m *MockTaskEngineState) ContainerByID(arg0 string) (*container.DockerContainer, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContainerByID", arg0)
@@ -188,13 +188,13 @@ func (m *MockTaskEngineState) ContainerByID(arg0 string) (*container.DockerConta
 	return ret0, ret1
 }
 
-// ContainerByID indicates an expected call of ContainerByID
+// ContainerByID indicates an expected call of ContainerByID.
 func (mr *MockTaskEngineStateMockRecorder) ContainerByID(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerByID", reflect.TypeOf((*MockTaskEngineState)(nil).ContainerByID), arg0)
 }
 
-// ContainerMapByArn mocks base method
+// ContainerMapByArn mocks base method.
 func (m *MockTaskEngineState) ContainerMapByArn(arg0 string) (map[string]*container.DockerContainer, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContainerMapByArn", arg0)
@@ -203,13 +203,13 @@ func (m *MockTaskEngineState) ContainerMapByArn(arg0 string) (map[string]*contai
 	return ret0, ret1
 }
 
-// ContainerMapByArn indicates an expected call of ContainerMapByArn
+// ContainerMapByArn indicates an expected call of ContainerMapByArn.
 func (mr *MockTaskEngineStateMockRecorder) ContainerMapByArn(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerMapByArn", reflect.TypeOf((*MockTaskEngineState)(nil).ContainerMapByArn), arg0)
 }
 
-// DockerIDByV3EndpointID mocks base method
+// DockerIDByV3EndpointID mocks base method.
 func (m *MockTaskEngineState) DockerIDByV3EndpointID(arg0 string) (string, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DockerIDByV3EndpointID", arg0)
@@ -218,13 +218,13 @@ func (m *MockTaskEngineState) DockerIDByV3EndpointID(arg0 string) (string, bool)
 	return ret0, ret1
 }
 
-// DockerIDByV3EndpointID indicates an expected call of DockerIDByV3EndpointID
+// DockerIDByV3EndpointID indicates an expected call of DockerIDByV3EndpointID.
 func (mr *MockTaskEngineStateMockRecorder) DockerIDByV3EndpointID(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DockerIDByV3EndpointID", reflect.TypeOf((*MockTaskEngineState)(nil).DockerIDByV3EndpointID), arg0)
 }
 
-// ENIByMac mocks base method
+// ENIByMac mocks base method.
 func (m *MockTaskEngineState) ENIByMac(arg0 string) (*eni.ENIAttachment, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ENIByMac", arg0)
@@ -233,13 +233,13 @@ func (m *MockTaskEngineState) ENIByMac(arg0 string) (*eni.ENIAttachment, bool) {
 	return ret0, ret1
 }
 
-// ENIByMac indicates an expected call of ENIByMac
+// ENIByMac indicates an expected call of ENIByMac.
 func (mr *MockTaskEngineStateMockRecorder) ENIByMac(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ENIByMac", reflect.TypeOf((*MockTaskEngineState)(nil).ENIByMac), arg0)
 }
 
-// GetAllContainerIDs mocks base method
+// GetAllContainerIDs mocks base method.
 func (m *MockTaskEngineState) GetAllContainerIDs() []string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAllContainerIDs")
@@ -247,13 +247,13 @@ func (m *MockTaskEngineState) GetAllContainerIDs() []string {
 	return ret0
 }
 
-// GetAllContainerIDs indicates an expected call of GetAllContainerIDs
+// GetAllContainerIDs indicates an expected call of GetAllContainerIDs.
 func (mr *MockTaskEngineStateMockRecorder) GetAllContainerIDs() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllContainerIDs", reflect.TypeOf((*MockTaskEngineState)(nil).GetAllContainerIDs))
 }
 
-// GetIPAddressByTaskARN mocks base method
+// GetIPAddressByTaskARN mocks base method.
 func (m *MockTaskEngineState) GetIPAddressByTaskARN(arg0 string) (string, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetIPAddressByTaskARN", arg0)
@@ -262,13 +262,13 @@ func (m *MockTaskEngineState) GetIPAddressByTaskARN(arg0 string) (string, bool) 
 	return ret0, ret1
 }
 
-// GetIPAddressByTaskARN indicates an expected call of GetIPAddressByTaskARN
+// GetIPAddressByTaskARN indicates an expected call of GetIPAddressByTaskARN.
 func (mr *MockTaskEngineStateMockRecorder) GetIPAddressByTaskARN(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIPAddressByTaskARN", reflect.TypeOf((*MockTaskEngineState)(nil).GetIPAddressByTaskARN), arg0)
 }
 
-// GetTaskByIPAddress mocks base method
+// GetTaskByIPAddress mocks base method.
 func (m *MockTaskEngineState) GetTaskByIPAddress(arg0 string) (string, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTaskByIPAddress", arg0)
@@ -277,13 +277,13 @@ func (m *MockTaskEngineState) GetTaskByIPAddress(arg0 string) (string, bool) {
 	return ret0, ret1
 }
 
-// GetTaskByIPAddress indicates an expected call of GetTaskByIPAddress
+// GetTaskByIPAddress indicates an expected call of GetTaskByIPAddress.
 func (mr *MockTaskEngineStateMockRecorder) GetTaskByIPAddress(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTaskByIPAddress", reflect.TypeOf((*MockTaskEngineState)(nil).GetTaskByIPAddress), arg0)
 }
 
-// MarshalJSON mocks base method
+// MarshalJSON mocks base method.
 func (m *MockTaskEngineState) MarshalJSON() ([]byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MarshalJSON")
@@ -292,13 +292,13 @@ func (m *MockTaskEngineState) MarshalJSON() ([]byte, error) {
 	return ret0, ret1
 }
 
-// MarshalJSON indicates an expected call of MarshalJSON
+// MarshalJSON indicates an expected call of MarshalJSON.
 func (mr *MockTaskEngineStateMockRecorder) MarshalJSON() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarshalJSON", reflect.TypeOf((*MockTaskEngineState)(nil).MarshalJSON))
 }
 
-// PulledContainerMapByArn mocks base method
+// PulledContainerMapByArn mocks base method.
 func (m *MockTaskEngineState) PulledContainerMapByArn(arg0 string) (map[string]*container.DockerContainer, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PulledContainerMapByArn", arg0)
@@ -307,61 +307,61 @@ func (m *MockTaskEngineState) PulledContainerMapByArn(arg0 string) (map[string]*
 	return ret0, ret1
 }
 
-// PulledContainerMapByArn indicates an expected call of PulledContainerMapByArn
+// PulledContainerMapByArn indicates an expected call of PulledContainerMapByArn.
 func (mr *MockTaskEngineStateMockRecorder) PulledContainerMapByArn(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PulledContainerMapByArn", reflect.TypeOf((*MockTaskEngineState)(nil).PulledContainerMapByArn), arg0)
 }
 
-// RemoveENIAttachment mocks base method
+// RemoveENIAttachment mocks base method.
 func (m *MockTaskEngineState) RemoveENIAttachment(arg0 string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "RemoveENIAttachment", arg0)
 }
 
-// RemoveENIAttachment indicates an expected call of RemoveENIAttachment
+// RemoveENIAttachment indicates an expected call of RemoveENIAttachment.
 func (mr *MockTaskEngineStateMockRecorder) RemoveENIAttachment(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveENIAttachment", reflect.TypeOf((*MockTaskEngineState)(nil).RemoveENIAttachment), arg0)
 }
 
-// RemoveImageState mocks base method
+// RemoveImageState mocks base method.
 func (m *MockTaskEngineState) RemoveImageState(arg0 *image.ImageState) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "RemoveImageState", arg0)
 }
 
-// RemoveImageState indicates an expected call of RemoveImageState
+// RemoveImageState indicates an expected call of RemoveImageState.
 func (mr *MockTaskEngineStateMockRecorder) RemoveImageState(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveImageState", reflect.TypeOf((*MockTaskEngineState)(nil).RemoveImageState), arg0)
 }
 
-// RemoveTask mocks base method
+// RemoveTask mocks base method.
 func (m *MockTaskEngineState) RemoveTask(arg0 *task.Task) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "RemoveTask", arg0)
 }
 
-// RemoveTask indicates an expected call of RemoveTask
+// RemoveTask indicates an expected call of RemoveTask.
 func (mr *MockTaskEngineStateMockRecorder) RemoveTask(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveTask", reflect.TypeOf((*MockTaskEngineState)(nil).RemoveTask), arg0)
 }
 
-// Reset mocks base method
+// Reset mocks base method.
 func (m *MockTaskEngineState) Reset() {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Reset")
 }
 
-// Reset indicates an expected call of Reset
+// Reset indicates an expected call of Reset.
 func (mr *MockTaskEngineStateMockRecorder) Reset() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reset", reflect.TypeOf((*MockTaskEngineState)(nil).Reset))
 }
 
-// TaskARNByV3EndpointID mocks base method
+// TaskARNByV3EndpointID mocks base method.
 func (m *MockTaskEngineState) TaskARNByV3EndpointID(arg0 string) (string, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TaskARNByV3EndpointID", arg0)
@@ -370,13 +370,13 @@ func (m *MockTaskEngineState) TaskARNByV3EndpointID(arg0 string) (string, bool) 
 	return ret0, ret1
 }
 
-// TaskARNByV3EndpointID indicates an expected call of TaskARNByV3EndpointID
+// TaskARNByV3EndpointID indicates an expected call of TaskARNByV3EndpointID.
 func (mr *MockTaskEngineStateMockRecorder) TaskARNByV3EndpointID(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TaskARNByV3EndpointID", reflect.TypeOf((*MockTaskEngineState)(nil).TaskARNByV3EndpointID), arg0)
 }
 
-// TaskByArn mocks base method
+// TaskByArn mocks base method.
 func (m *MockTaskEngineState) TaskByArn(arg0 string) (*task.Task, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TaskByArn", arg0)
@@ -385,13 +385,13 @@ func (m *MockTaskEngineState) TaskByArn(arg0 string) (*task.Task, bool) {
 	return ret0, ret1
 }
 
-// TaskByArn indicates an expected call of TaskByArn
+// TaskByArn indicates an expected call of TaskByArn.
 func (mr *MockTaskEngineStateMockRecorder) TaskByArn(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TaskByArn", reflect.TypeOf((*MockTaskEngineState)(nil).TaskByArn), arg0)
 }
 
-// TaskByID mocks base method
+// TaskByID mocks base method.
 func (m *MockTaskEngineState) TaskByID(arg0 string) (*task.Task, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TaskByID", arg0)
@@ -400,13 +400,13 @@ func (m *MockTaskEngineState) TaskByID(arg0 string) (*task.Task, bool) {
 	return ret0, ret1
 }
 
-// TaskByID indicates an expected call of TaskByID
+// TaskByID indicates an expected call of TaskByID.
 func (mr *MockTaskEngineStateMockRecorder) TaskByID(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TaskByID", reflect.TypeOf((*MockTaskEngineState)(nil).TaskByID), arg0)
 }
 
-// TaskByShortID mocks base method
+// TaskByShortID mocks base method.
 func (m *MockTaskEngineState) TaskByShortID(arg0 string) ([]*task.Task, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TaskByShortID", arg0)
@@ -415,13 +415,13 @@ func (m *MockTaskEngineState) TaskByShortID(arg0 string) ([]*task.Task, bool) {
 	return ret0, ret1
 }
 
-// TaskByShortID indicates an expected call of TaskByShortID
+// TaskByShortID indicates an expected call of TaskByShortID.
 func (mr *MockTaskEngineStateMockRecorder) TaskByShortID(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TaskByShortID", reflect.TypeOf((*MockTaskEngineState)(nil).TaskByShortID), arg0)
 }
 
-// UnmarshalJSON mocks base method
+// UnmarshalJSON mocks base method.
 func (m *MockTaskEngineState) UnmarshalJSON(arg0 []byte) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UnmarshalJSON", arg0)
@@ -429,7 +429,7 @@ func (m *MockTaskEngineState) UnmarshalJSON(arg0 []byte) error {
 	return ret0
 }
 
-// UnmarshalJSON indicates an expected call of UnmarshalJSON
+// UnmarshalJSON indicates an expected call of UnmarshalJSON.
 func (mr *MockTaskEngineStateMockRecorder) UnmarshalJSON(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnmarshalJSON", reflect.TypeOf((*MockTaskEngineState)(nil).UnmarshalJSON), arg0)

--- a/agent/engine/execcmd/mocks/execcmd_mocks.go
+++ b/agent/engine/execcmd/mocks/execcmd_mocks.go
@@ -30,30 +30,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockManager is a mock of Manager interface
+// MockManager is a mock of Manager interface.
 type MockManager struct {
 	ctrl     *gomock.Controller
 	recorder *MockManagerMockRecorder
 }
 
-// MockManagerMockRecorder is the mock recorder for MockManager
+// MockManagerMockRecorder is the mock recorder for MockManager.
 type MockManagerMockRecorder struct {
 	mock *MockManager
 }
 
-// NewMockManager creates a new mock instance
+// NewMockManager creates a new mock instance.
 func NewMockManager(ctrl *gomock.Controller) *MockManager {
 	mock := &MockManager{ctrl: ctrl}
 	mock.recorder = &MockManagerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockManager) EXPECT() *MockManagerMockRecorder {
 	return m.recorder
 }
 
-// InitializeContainer mocks base method
+// InitializeContainer mocks base method.
 func (m *MockManager) InitializeContainer(arg0 string, arg1 *container.Container, arg2 *container0.HostConfig) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InitializeContainer", arg0, arg1, arg2)
@@ -61,13 +61,13 @@ func (m *MockManager) InitializeContainer(arg0 string, arg1 *container.Container
 	return ret0
 }
 
-// InitializeContainer indicates an expected call of InitializeContainer
+// InitializeContainer indicates an expected call of InitializeContainer.
 func (mr *MockManagerMockRecorder) InitializeContainer(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitializeContainer", reflect.TypeOf((*MockManager)(nil).InitializeContainer), arg0, arg1, arg2)
 }
 
-// RestartAgentIfStopped mocks base method
+// RestartAgentIfStopped mocks base method.
 func (m *MockManager) RestartAgentIfStopped(arg0 context.Context, arg1 dockerapi.DockerClient, arg2 *task.Task, arg3 *container.Container, arg4 string) (execcmd.RestartStatus, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RestartAgentIfStopped", arg0, arg1, arg2, arg3, arg4)
@@ -76,13 +76,13 @@ func (m *MockManager) RestartAgentIfStopped(arg0 context.Context, arg1 dockerapi
 	return ret0, ret1
 }
 
-// RestartAgentIfStopped indicates an expected call of RestartAgentIfStopped
+// RestartAgentIfStopped indicates an expected call of RestartAgentIfStopped.
 func (mr *MockManagerMockRecorder) RestartAgentIfStopped(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestartAgentIfStopped", reflect.TypeOf((*MockManager)(nil).RestartAgentIfStopped), arg0, arg1, arg2, arg3, arg4)
 }
 
-// StartAgent mocks base method
+// StartAgent mocks base method.
 func (m *MockManager) StartAgent(arg0 context.Context, arg1 dockerapi.DockerClient, arg2 *task.Task, arg3 *container.Container, arg4 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartAgent", arg0, arg1, arg2, arg3, arg4)
@@ -90,7 +90,7 @@ func (m *MockManager) StartAgent(arg0 context.Context, arg1 dockerapi.DockerClie
 	return ret0
 }
 
-// StartAgent indicates an expected call of StartAgent
+// StartAgent indicates an expected call of StartAgent.
 func (mr *MockManagerMockRecorder) StartAgent(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartAgent", reflect.TypeOf((*MockManager)(nil).StartAgent), arg0, arg1, arg2, arg3, arg4)

--- a/agent/engine/mocks/engine_mocks.go
+++ b/agent/engine/mocks/engine_mocks.go
@@ -30,54 +30,54 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockTaskEngine is a mock of TaskEngine interface
+// MockTaskEngine is a mock of TaskEngine interface.
 type MockTaskEngine struct {
 	ctrl     *gomock.Controller
 	recorder *MockTaskEngineMockRecorder
 }
 
-// MockTaskEngineMockRecorder is the mock recorder for MockTaskEngine
+// MockTaskEngineMockRecorder is the mock recorder for MockTaskEngine.
 type MockTaskEngineMockRecorder struct {
 	mock *MockTaskEngine
 }
 
-// NewMockTaskEngine creates a new mock instance
+// NewMockTaskEngine creates a new mock instance.
 func NewMockTaskEngine(ctrl *gomock.Controller) *MockTaskEngine {
 	mock := &MockTaskEngine{ctrl: ctrl}
 	mock.recorder = &MockTaskEngineMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockTaskEngine) EXPECT() *MockTaskEngineMockRecorder {
 	return m.recorder
 }
 
-// AddTask mocks base method
+// AddTask mocks base method.
 func (m *MockTaskEngine) AddTask(arg0 *task.Task) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AddTask", arg0)
 }
 
-// AddTask indicates an expected call of AddTask
+// AddTask indicates an expected call of AddTask.
 func (mr *MockTaskEngineMockRecorder) AddTask(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddTask", reflect.TypeOf((*MockTaskEngine)(nil).AddTask), arg0)
 }
 
-// Disable mocks base method
+// Disable mocks base method.
 func (m *MockTaskEngine) Disable() {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Disable")
 }
 
-// Disable indicates an expected call of Disable
+// Disable indicates an expected call of Disable.
 func (mr *MockTaskEngineMockRecorder) Disable() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Disable", reflect.TypeOf((*MockTaskEngine)(nil).Disable))
 }
 
-// GetTaskByArn mocks base method
+// GetTaskByArn mocks base method.
 func (m *MockTaskEngine) GetTaskByArn(arg0 string) (*task.Task, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTaskByArn", arg0)
@@ -86,13 +86,13 @@ func (m *MockTaskEngine) GetTaskByArn(arg0 string) (*task.Task, bool) {
 	return ret0, ret1
 }
 
-// GetTaskByArn indicates an expected call of GetTaskByArn
+// GetTaskByArn indicates an expected call of GetTaskByArn.
 func (mr *MockTaskEngineMockRecorder) GetTaskByArn(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTaskByArn", reflect.TypeOf((*MockTaskEngine)(nil).GetTaskByArn), arg0)
 }
 
-// Init mocks base method
+// Init mocks base method.
 func (m *MockTaskEngine) Init(arg0 context.Context) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Init", arg0)
@@ -100,13 +100,13 @@ func (m *MockTaskEngine) Init(arg0 context.Context) error {
 	return ret0
 }
 
-// Init indicates an expected call of Init
+// Init indicates an expected call of Init.
 func (mr *MockTaskEngineMockRecorder) Init(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Init", reflect.TypeOf((*MockTaskEngine)(nil).Init), arg0)
 }
 
-// ListTasks mocks base method
+// ListTasks mocks base method.
 func (m *MockTaskEngine) ListTasks() ([]*task.Task, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListTasks")
@@ -115,13 +115,13 @@ func (m *MockTaskEngine) ListTasks() ([]*task.Task, error) {
 	return ret0, ret1
 }
 
-// ListTasks indicates an expected call of ListTasks
+// ListTasks indicates an expected call of ListTasks.
 func (mr *MockTaskEngineMockRecorder) ListTasks() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTasks", reflect.TypeOf((*MockTaskEngine)(nil).ListTasks))
 }
 
-// LoadState mocks base method
+// LoadState mocks base method.
 func (m *MockTaskEngine) LoadState() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LoadState")
@@ -129,13 +129,13 @@ func (m *MockTaskEngine) LoadState() error {
 	return ret0
 }
 
-// LoadState indicates an expected call of LoadState
+// LoadState indicates an expected call of LoadState.
 func (mr *MockTaskEngineMockRecorder) LoadState() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadState", reflect.TypeOf((*MockTaskEngine)(nil).LoadState))
 }
 
-// MarshalJSON mocks base method
+// MarshalJSON mocks base method.
 func (m *MockTaskEngine) MarshalJSON() ([]byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MarshalJSON")
@@ -144,25 +144,25 @@ func (m *MockTaskEngine) MarshalJSON() ([]byte, error) {
 	return ret0, ret1
 }
 
-// MarshalJSON indicates an expected call of MarshalJSON
+// MarshalJSON indicates an expected call of MarshalJSON.
 func (mr *MockTaskEngineMockRecorder) MarshalJSON() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarshalJSON", reflect.TypeOf((*MockTaskEngine)(nil).MarshalJSON))
 }
 
-// MustInit mocks base method
+// MustInit mocks base method.
 func (m *MockTaskEngine) MustInit(arg0 context.Context) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "MustInit", arg0)
 }
 
-// MustInit indicates an expected call of MustInit
+// MustInit indicates an expected call of MustInit.
 func (mr *MockTaskEngineMockRecorder) MustInit(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MustInit", reflect.TypeOf((*MockTaskEngine)(nil).MustInit), arg0)
 }
 
-// SaveState mocks base method
+// SaveState mocks base method.
 func (m *MockTaskEngine) SaveState() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SaveState")
@@ -170,25 +170,25 @@ func (m *MockTaskEngine) SaveState() error {
 	return ret0
 }
 
-// SaveState indicates an expected call of SaveState
+// SaveState indicates an expected call of SaveState.
 func (mr *MockTaskEngineMockRecorder) SaveState() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveState", reflect.TypeOf((*MockTaskEngine)(nil).SaveState))
 }
 
-// SetDataClient mocks base method
+// SetDataClient mocks base method.
 func (m *MockTaskEngine) SetDataClient(arg0 data.Client) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetDataClient", arg0)
 }
 
-// SetDataClient indicates an expected call of SetDataClient
+// SetDataClient indicates an expected call of SetDataClient.
 func (mr *MockTaskEngineMockRecorder) SetDataClient(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDataClient", reflect.TypeOf((*MockTaskEngine)(nil).SetDataClient), arg0)
 }
 
-// StateChangeEvents mocks base method
+// StateChangeEvents mocks base method.
 func (m *MockTaskEngine) StateChangeEvents() chan statechange.Event {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StateChangeEvents")
@@ -196,13 +196,13 @@ func (m *MockTaskEngine) StateChangeEvents() chan statechange.Event {
 	return ret0
 }
 
-// StateChangeEvents indicates an expected call of StateChangeEvents
+// StateChangeEvents indicates an expected call of StateChangeEvents.
 func (mr *MockTaskEngineMockRecorder) StateChangeEvents() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateChangeEvents", reflect.TypeOf((*MockTaskEngine)(nil).StateChangeEvents))
 }
 
-// UnmarshalJSON mocks base method
+// UnmarshalJSON mocks base method.
 func (m *MockTaskEngine) UnmarshalJSON(arg0 []byte) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UnmarshalJSON", arg0)
@@ -210,13 +210,13 @@ func (m *MockTaskEngine) UnmarshalJSON(arg0 []byte) error {
 	return ret0
 }
 
-// UnmarshalJSON indicates an expected call of UnmarshalJSON
+// UnmarshalJSON indicates an expected call of UnmarshalJSON.
 func (mr *MockTaskEngineMockRecorder) UnmarshalJSON(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnmarshalJSON", reflect.TypeOf((*MockTaskEngine)(nil).UnmarshalJSON), arg0)
 }
 
-// Version mocks base method
+// Version mocks base method.
 func (m *MockTaskEngine) Version() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Version")
@@ -225,60 +225,60 @@ func (m *MockTaskEngine) Version() (string, error) {
 	return ret0, ret1
 }
 
-// Version indicates an expected call of Version
+// Version indicates an expected call of Version.
 func (mr *MockTaskEngineMockRecorder) Version() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Version", reflect.TypeOf((*MockTaskEngine)(nil).Version))
 }
 
-// MockImageManager is a mock of ImageManager interface
+// MockImageManager is a mock of ImageManager interface.
 type MockImageManager struct {
 	ctrl     *gomock.Controller
 	recorder *MockImageManagerMockRecorder
 }
 
-// MockImageManagerMockRecorder is the mock recorder for MockImageManager
+// MockImageManagerMockRecorder is the mock recorder for MockImageManager.
 type MockImageManagerMockRecorder struct {
 	mock *MockImageManager
 }
 
-// NewMockImageManager creates a new mock instance
+// NewMockImageManager creates a new mock instance.
 func NewMockImageManager(ctrl *gomock.Controller) *MockImageManager {
 	mock := &MockImageManager{ctrl: ctrl}
 	mock.recorder = &MockImageManagerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockImageManager) EXPECT() *MockImageManagerMockRecorder {
 	return m.recorder
 }
 
-// AddAllImageStates mocks base method
+// AddAllImageStates mocks base method.
 func (m *MockImageManager) AddAllImageStates(arg0 []*image.ImageState) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AddAllImageStates", arg0)
 }
 
-// AddAllImageStates indicates an expected call of AddAllImageStates
+// AddAllImageStates indicates an expected call of AddAllImageStates.
 func (mr *MockImageManagerMockRecorder) AddAllImageStates(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddAllImageStates", reflect.TypeOf((*MockImageManager)(nil).AddAllImageStates), arg0)
 }
 
-// AddImageToCleanUpExclusionList mocks base method
+// AddImageToCleanUpExclusionList mocks base method.
 func (m *MockImageManager) AddImageToCleanUpExclusionList(arg0 string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AddImageToCleanUpExclusionList", arg0)
 }
 
-// AddImageToCleanUpExclusionList indicates an expected call of AddImageToCleanUpExclusionList
+// AddImageToCleanUpExclusionList indicates an expected call of AddImageToCleanUpExclusionList.
 func (mr *MockImageManagerMockRecorder) AddImageToCleanUpExclusionList(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddImageToCleanUpExclusionList", reflect.TypeOf((*MockImageManager)(nil).AddImageToCleanUpExclusionList), arg0)
 }
 
-// GetImageStateFromImageName mocks base method
+// GetImageStateFromImageName mocks base method.
 func (m *MockImageManager) GetImageStateFromImageName(arg0 string) (*image.ImageState, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetImageStateFromImageName", arg0)
@@ -287,13 +287,13 @@ func (m *MockImageManager) GetImageStateFromImageName(arg0 string) (*image.Image
 	return ret0, ret1
 }
 
-// GetImageStateFromImageName indicates an expected call of GetImageStateFromImageName
+// GetImageStateFromImageName indicates an expected call of GetImageStateFromImageName.
 func (mr *MockImageManagerMockRecorder) GetImageStateFromImageName(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImageStateFromImageName", reflect.TypeOf((*MockImageManager)(nil).GetImageStateFromImageName), arg0)
 }
 
-// RecordContainerReference mocks base method
+// RecordContainerReference mocks base method.
 func (m *MockImageManager) RecordContainerReference(arg0 *container.Container) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RecordContainerReference", arg0)
@@ -301,13 +301,13 @@ func (m *MockImageManager) RecordContainerReference(arg0 *container.Container) e
 	return ret0
 }
 
-// RecordContainerReference indicates an expected call of RecordContainerReference
+// RecordContainerReference indicates an expected call of RecordContainerReference.
 func (mr *MockImageManagerMockRecorder) RecordContainerReference(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecordContainerReference", reflect.TypeOf((*MockImageManager)(nil).RecordContainerReference), arg0)
 }
 
-// RemoveContainerReferenceFromImageState mocks base method
+// RemoveContainerReferenceFromImageState mocks base method.
 func (m *MockImageManager) RemoveContainerReferenceFromImageState(arg0 *container.Container) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveContainerReferenceFromImageState", arg0)
@@ -315,31 +315,31 @@ func (m *MockImageManager) RemoveContainerReferenceFromImageState(arg0 *containe
 	return ret0
 }
 
-// RemoveContainerReferenceFromImageState indicates an expected call of RemoveContainerReferenceFromImageState
+// RemoveContainerReferenceFromImageState indicates an expected call of RemoveContainerReferenceFromImageState.
 func (mr *MockImageManagerMockRecorder) RemoveContainerReferenceFromImageState(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveContainerReferenceFromImageState", reflect.TypeOf((*MockImageManager)(nil).RemoveContainerReferenceFromImageState), arg0)
 }
 
-// SetDataClient mocks base method
+// SetDataClient mocks base method.
 func (m *MockImageManager) SetDataClient(arg0 data.Client) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetDataClient", arg0)
 }
 
-// SetDataClient indicates an expected call of SetDataClient
+// SetDataClient indicates an expected call of SetDataClient.
 func (mr *MockImageManagerMockRecorder) SetDataClient(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDataClient", reflect.TypeOf((*MockImageManager)(nil).SetDataClient), arg0)
 }
 
-// StartImageCleanupProcess mocks base method
+// StartImageCleanupProcess mocks base method.
 func (m *MockImageManager) StartImageCleanupProcess(arg0 context.Context) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "StartImageCleanupProcess", arg0)
 }
 
-// StartImageCleanupProcess indicates an expected call of StartImageCleanupProcess
+// StartImageCleanupProcess indicates an expected call of StartImageCleanupProcess.
 func (mr *MockImageManagerMockRecorder) StartImageCleanupProcess(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartImageCleanupProcess", reflect.TypeOf((*MockImageManager)(nil).StartImageCleanupProcess), arg0)

--- a/agent/engine/serviceconnect/mock/manager.go
+++ b/agent/engine/serviceconnect/mock/manager.go
@@ -32,30 +32,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockManager is a mock of Manager interface
+// MockManager is a mock of Manager interface.
 type MockManager struct {
 	ctrl     *gomock.Controller
 	recorder *MockManagerMockRecorder
 }
 
-// MockManagerMockRecorder is the mock recorder for MockManager
+// MockManagerMockRecorder is the mock recorder for MockManager.
 type MockManagerMockRecorder struct {
 	mock *MockManager
 }
 
-// NewMockManager creates a new mock instance
+// NewMockManager creates a new mock instance.
 func NewMockManager(ctrl *gomock.Controller) *MockManager {
 	mock := &MockManager{ctrl: ctrl}
 	mock.recorder = &MockManagerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockManager) EXPECT() *MockManagerMockRecorder {
 	return m.recorder
 }
 
-// AugmentInstanceContainer mocks base method
+// AugmentInstanceContainer mocks base method.
 func (m *MockManager) AugmentInstanceContainer(arg0 *task.Task, arg1 *container.Container, arg2 *container0.HostConfig) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AugmentInstanceContainer", arg0, arg1, arg2)
@@ -63,13 +63,13 @@ func (m *MockManager) AugmentInstanceContainer(arg0 *task.Task, arg1 *container.
 	return ret0
 }
 
-// AugmentInstanceContainer indicates an expected call of AugmentInstanceContainer
+// AugmentInstanceContainer indicates an expected call of AugmentInstanceContainer.
 func (mr *MockManagerMockRecorder) AugmentInstanceContainer(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AugmentInstanceContainer", reflect.TypeOf((*MockManager)(nil).AugmentInstanceContainer), arg0, arg1, arg2)
 }
 
-// AugmentTaskContainer mocks base method
+// AugmentTaskContainer mocks base method.
 func (m *MockManager) AugmentTaskContainer(arg0 *task.Task, arg1 *container.Container, arg2 *container0.HostConfig) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AugmentTaskContainer", arg0, arg1, arg2)
@@ -77,13 +77,13 @@ func (m *MockManager) AugmentTaskContainer(arg0 *task.Task, arg1 *container.Cont
 	return ret0
 }
 
-// AugmentTaskContainer indicates an expected call of AugmentTaskContainer
+// AugmentTaskContainer indicates an expected call of AugmentTaskContainer.
 func (mr *MockManagerMockRecorder) AugmentTaskContainer(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AugmentTaskContainer", reflect.TypeOf((*MockManager)(nil).AugmentTaskContainer), arg0, arg1, arg2)
 }
 
-// CreateInstanceTask mocks base method
+// CreateInstanceTask mocks base method.
 func (m *MockManager) CreateInstanceTask(arg0 *config.Config) (*task.Task, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateInstanceTask", arg0)
@@ -92,13 +92,13 @@ func (m *MockManager) CreateInstanceTask(arg0 *config.Config) (*task.Task, error
 	return ret0, ret1
 }
 
-// CreateInstanceTask indicates an expected call of CreateInstanceTask
+// CreateInstanceTask indicates an expected call of CreateInstanceTask.
 func (mr *MockManagerMockRecorder) CreateInstanceTask(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateInstanceTask", reflect.TypeOf((*MockManager)(nil).CreateInstanceTask), arg0)
 }
 
-// GetAppnetContainerTarballDir mocks base method
+// GetAppnetContainerTarballDir mocks base method.
 func (m *MockManager) GetAppnetContainerTarballDir() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAppnetContainerTarballDir")
@@ -106,13 +106,13 @@ func (m *MockManager) GetAppnetContainerTarballDir() string {
 	return ret0
 }
 
-// GetAppnetContainerTarballDir indicates an expected call of GetAppnetContainerTarballDir
+// GetAppnetContainerTarballDir indicates an expected call of GetAppnetContainerTarballDir.
 func (mr *MockManagerMockRecorder) GetAppnetContainerTarballDir() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAppnetContainerTarballDir", reflect.TypeOf((*MockManager)(nil).GetAppnetContainerTarballDir))
 }
 
-// GetCapabilitiesForAppnetInterfaceVersion mocks base method
+// GetCapabilitiesForAppnetInterfaceVersion mocks base method.
 func (m *MockManager) GetCapabilitiesForAppnetInterfaceVersion(arg0 string) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCapabilitiesForAppnetInterfaceVersion", arg0)
@@ -121,13 +121,13 @@ func (m *MockManager) GetCapabilitiesForAppnetInterfaceVersion(arg0 string) ([]s
 	return ret0, ret1
 }
 
-// GetCapabilitiesForAppnetInterfaceVersion indicates an expected call of GetCapabilitiesForAppnetInterfaceVersion
+// GetCapabilitiesForAppnetInterfaceVersion indicates an expected call of GetCapabilitiesForAppnetInterfaceVersion.
 func (mr *MockManagerMockRecorder) GetCapabilitiesForAppnetInterfaceVersion(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCapabilitiesForAppnetInterfaceVersion", reflect.TypeOf((*MockManager)(nil).GetCapabilitiesForAppnetInterfaceVersion), arg0)
 }
 
-// GetLoadedAppnetVersion mocks base method
+// GetLoadedAppnetVersion mocks base method.
 func (m *MockManager) GetLoadedAppnetVersion() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLoadedAppnetVersion")
@@ -136,13 +136,13 @@ func (m *MockManager) GetLoadedAppnetVersion() (string, error) {
 	return ret0, ret1
 }
 
-// GetLoadedAppnetVersion indicates an expected call of GetLoadedAppnetVersion
+// GetLoadedAppnetVersion indicates an expected call of GetLoadedAppnetVersion.
 func (mr *MockManagerMockRecorder) GetLoadedAppnetVersion() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLoadedAppnetVersion", reflect.TypeOf((*MockManager)(nil).GetLoadedAppnetVersion))
 }
 
-// GetLoadedImageName mocks base method
+// GetLoadedImageName mocks base method.
 func (m *MockManager) GetLoadedImageName() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLoadedImageName")
@@ -150,13 +150,13 @@ func (m *MockManager) GetLoadedImageName() string {
 	return ret0
 }
 
-// GetLoadedImageName indicates an expected call of GetLoadedImageName
+// GetLoadedImageName indicates an expected call of GetLoadedImageName.
 func (mr *MockManagerMockRecorder) GetLoadedImageName() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLoadedImageName", reflect.TypeOf((*MockManager)(nil).GetLoadedImageName))
 }
 
-// IsLoaded mocks base method
+// IsLoaded mocks base method.
 func (m *MockManager) IsLoaded(arg0 dockerapi.DockerClient) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsLoaded", arg0)
@@ -165,13 +165,13 @@ func (m *MockManager) IsLoaded(arg0 dockerapi.DockerClient) (bool, error) {
 	return ret0, ret1
 }
 
-// IsLoaded indicates an expected call of IsLoaded
+// IsLoaded indicates an expected call of IsLoaded.
 func (mr *MockManagerMockRecorder) IsLoaded(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsLoaded", reflect.TypeOf((*MockManager)(nil).IsLoaded), arg0)
 }
 
-// LoadImage mocks base method
+// LoadImage mocks base method.
 func (m *MockManager) LoadImage(arg0 context.Context, arg1 *config.Config, arg2 dockerapi.DockerClient) (*types.ImageInspect, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LoadImage", arg0, arg1, arg2)
@@ -180,19 +180,19 @@ func (m *MockManager) LoadImage(arg0 context.Context, arg1 *config.Config, arg2 
 	return ret0, ret1
 }
 
-// LoadImage indicates an expected call of LoadImage
+// LoadImage indicates an expected call of LoadImage.
 func (mr *MockManagerMockRecorder) LoadImage(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadImage", reflect.TypeOf((*MockManager)(nil).LoadImage), arg0, arg1, arg2)
 }
 
-// SetECSClient mocks base method
+// SetECSClient mocks base method.
 func (m *MockManager) SetECSClient(arg0 api.ECSClient, arg1 string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetECSClient", arg0, arg1)
 }
 
-// SetECSClient indicates an expected call of SetECSClient
+// SetECSClient indicates an expected call of SetECSClient.
 func (mr *MockManagerMockRecorder) SetECSClient(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetECSClient", reflect.TypeOf((*MockManager)(nil).SetECSClient), arg0, arg1)

--- a/agent/engine/task_manager_test.go
+++ b/agent/engine/task_manager_test.go
@@ -1414,9 +1414,6 @@ func TestTaskWaitForExecutionCredentials(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(fmt.Sprintf("%v", tc.errs), func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			mockTime := mock_ttime.NewMockTime(ctrl)
-			mockTimer := mock_ttime.NewMockTimer(ctrl)
 			ctx, cancel := context.WithCancel(context.TODO())
 			defer cancel()
 			task := &managedTask{
@@ -1425,12 +1422,9 @@ func TestTaskWaitForExecutionCredentials(t *testing.T) {
 					KnownStatusUnsafe:   apitaskstatus.TaskRunning,
 					DesiredStatusUnsafe: apitaskstatus.TaskRunning,
 				},
-				_time:       mockTime,
 				acsMessages: make(chan acsTransition),
 			}
 			if tc.result {
-				mockTime.EXPECT().AfterFunc(gomock.Any(), gomock.Any()).Return(mockTimer)
-				mockTimer.EXPECT().Stop()
 				go func() { task.acsMessages <- acsTransition{desiredStatus: apitaskstatus.TaskRunning} }()
 			}
 

--- a/agent/eni/netlinkwrapper/mocks/mock_netlinkwrapper_linux.go
+++ b/agent/eni/netlinkwrapper/mocks/mock_netlinkwrapper_linux.go
@@ -25,30 +25,30 @@ import (
 	netlink "github.com/vishvananda/netlink"
 )
 
-// MockNetLink is a mock of NetLink interface
+// MockNetLink is a mock of NetLink interface.
 type MockNetLink struct {
 	ctrl     *gomock.Controller
 	recorder *MockNetLinkMockRecorder
 }
 
-// MockNetLinkMockRecorder is the mock recorder for MockNetLink
+// MockNetLinkMockRecorder is the mock recorder for MockNetLink.
 type MockNetLinkMockRecorder struct {
 	mock *MockNetLink
 }
 
-// NewMockNetLink creates a new mock instance
+// NewMockNetLink creates a new mock instance.
 func NewMockNetLink(ctrl *gomock.Controller) *MockNetLink {
 	mock := &MockNetLink{ctrl: ctrl}
 	mock.recorder = &MockNetLinkMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockNetLink) EXPECT() *MockNetLinkMockRecorder {
 	return m.recorder
 }
 
-// LinkByName mocks base method
+// LinkByName mocks base method.
 func (m *MockNetLink) LinkByName(arg0 string) (netlink.Link, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LinkByName", arg0)
@@ -57,13 +57,13 @@ func (m *MockNetLink) LinkByName(arg0 string) (netlink.Link, error) {
 	return ret0, ret1
 }
 
-// LinkByName indicates an expected call of LinkByName
+// LinkByName indicates an expected call of LinkByName.
 func (mr *MockNetLinkMockRecorder) LinkByName(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LinkByName", reflect.TypeOf((*MockNetLink)(nil).LinkByName), arg0)
 }
 
-// LinkList mocks base method
+// LinkList mocks base method.
 func (m *MockNetLink) LinkList() ([]netlink.Link, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LinkList")
@@ -72,7 +72,7 @@ func (m *MockNetLink) LinkList() ([]netlink.Link, error) {
 	return ret0, ret1
 }
 
-// LinkList indicates an expected call of LinkList
+// LinkList indicates an expected call of LinkList.
 func (mr *MockNetLinkMockRecorder) LinkList() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LinkList", reflect.TypeOf((*MockNetLink)(nil).LinkList))

--- a/agent/eni/netwrapper/mocks/mock_netwrapper.go
+++ b/agent/eni/netwrapper/mocks/mock_netwrapper.go
@@ -25,30 +25,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockNetWrapper is a mock of NetWrapper interface
+// MockNetWrapper is a mock of NetWrapper interface.
 type MockNetWrapper struct {
 	ctrl     *gomock.Controller
 	recorder *MockNetWrapperMockRecorder
 }
 
-// MockNetWrapperMockRecorder is the mock recorder for MockNetWrapper
+// MockNetWrapperMockRecorder is the mock recorder for MockNetWrapper.
 type MockNetWrapperMockRecorder struct {
 	mock *MockNetWrapper
 }
 
-// NewMockNetWrapper creates a new mock instance
+// NewMockNetWrapper creates a new mock instance.
 func NewMockNetWrapper(ctrl *gomock.Controller) *MockNetWrapper {
 	mock := &MockNetWrapper{ctrl: ctrl}
 	mock.recorder = &MockNetWrapperMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockNetWrapper) EXPECT() *MockNetWrapperMockRecorder {
 	return m.recorder
 }
 
-// FindInterfaceByIndex mocks base method
+// FindInterfaceByIndex mocks base method.
 func (m *MockNetWrapper) FindInterfaceByIndex(arg0 int) (*net.Interface, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FindInterfaceByIndex", arg0)
@@ -57,13 +57,13 @@ func (m *MockNetWrapper) FindInterfaceByIndex(arg0 int) (*net.Interface, error) 
 	return ret0, ret1
 }
 
-// FindInterfaceByIndex indicates an expected call of FindInterfaceByIndex
+// FindInterfaceByIndex indicates an expected call of FindInterfaceByIndex.
 func (mr *MockNetWrapperMockRecorder) FindInterfaceByIndex(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindInterfaceByIndex", reflect.TypeOf((*MockNetWrapper)(nil).FindInterfaceByIndex), arg0)
 }
 
-// GetAllNetworkInterfaces mocks base method
+// GetAllNetworkInterfaces mocks base method.
 func (m *MockNetWrapper) GetAllNetworkInterfaces() ([]net.Interface, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAllNetworkInterfaces")
@@ -72,7 +72,7 @@ func (m *MockNetWrapper) GetAllNetworkInterfaces() ([]net.Interface, error) {
 	return ret0, ret1
 }
 
-// GetAllNetworkInterfaces indicates an expected call of GetAllNetworkInterfaces
+// GetAllNetworkInterfaces indicates an expected call of GetAllNetworkInterfaces.
 func (mr *MockNetWrapperMockRecorder) GetAllNetworkInterfaces() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllNetworkInterfaces", reflect.TypeOf((*MockNetWrapper)(nil).GetAllNetworkInterfaces))

--- a/agent/eni/udevwrapper/mocks/mock_udevwrapper_linux.go
+++ b/agent/eni/udevwrapper/mocks/mock_udevwrapper_linux.go
@@ -25,30 +25,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockUdev is a mock of Udev interface
+// MockUdev is a mock of Udev interface.
 type MockUdev struct {
 	ctrl     *gomock.Controller
 	recorder *MockUdevMockRecorder
 }
 
-// MockUdevMockRecorder is the mock recorder for MockUdev
+// MockUdevMockRecorder is the mock recorder for MockUdev.
 type MockUdevMockRecorder struct {
 	mock *MockUdev
 }
 
-// NewMockUdev creates a new mock instance
+// NewMockUdev creates a new mock instance.
 func NewMockUdev(ctrl *gomock.Controller) *MockUdev {
 	mock := &MockUdev{ctrl: ctrl}
 	mock.recorder = &MockUdevMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockUdev) EXPECT() *MockUdevMockRecorder {
 	return m.recorder
 }
 
-// Close mocks base method
+// Close mocks base method.
 func (m *MockUdev) Close() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Close")
@@ -56,13 +56,13 @@ func (m *MockUdev) Close() error {
 	return ret0
 }
 
-// Close indicates an expected call of Close
+// Close indicates an expected call of Close.
 func (mr *MockUdevMockRecorder) Close() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockUdev)(nil).Close))
 }
 
-// Monitor mocks base method
+// Monitor mocks base method.
 func (m *MockUdev) Monitor(arg0 chan *udev.UEvent) chan bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Monitor", arg0)
@@ -70,7 +70,7 @@ func (m *MockUdev) Monitor(arg0 chan *udev.UEvent) chan bool {
 	return ret0
 }
 
-// Monitor indicates an expected call of Monitor
+// Monitor indicates an expected call of Monitor.
 func (mr *MockUdevMockRecorder) Monitor(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Monitor", reflect.TypeOf((*MockUdev)(nil).Monitor), arg0)

--- a/agent/fsx/factory/mocks/factory_mocks.go
+++ b/agent/fsx/factory/mocks/factory_mocks.go
@@ -26,30 +26,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockFSxClientCreator is a mock of FSxClientCreator interface
+// MockFSxClientCreator is a mock of FSxClientCreator interface.
 type MockFSxClientCreator struct {
 	ctrl     *gomock.Controller
 	recorder *MockFSxClientCreatorMockRecorder
 }
 
-// MockFSxClientCreatorMockRecorder is the mock recorder for MockFSxClientCreator
+// MockFSxClientCreatorMockRecorder is the mock recorder for MockFSxClientCreator.
 type MockFSxClientCreatorMockRecorder struct {
 	mock *MockFSxClientCreator
 }
 
-// NewMockFSxClientCreator creates a new mock instance
+// NewMockFSxClientCreator creates a new mock instance.
 func NewMockFSxClientCreator(ctrl *gomock.Controller) *MockFSxClientCreator {
 	mock := &MockFSxClientCreator{ctrl: ctrl}
 	mock.recorder = &MockFSxClientCreatorMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockFSxClientCreator) EXPECT() *MockFSxClientCreatorMockRecorder {
 	return m.recorder
 }
 
-// NewFSxClient mocks base method
+// NewFSxClient mocks base method.
 func (m *MockFSxClientCreator) NewFSxClient(arg0 string, arg1 credentials.IAMRoleCredentials) fsx.FSxClient {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewFSxClient", arg0, arg1)
@@ -57,7 +57,7 @@ func (m *MockFSxClientCreator) NewFSxClient(arg0 string, arg1 credentials.IAMRol
 	return ret0
 }
 
-// NewFSxClient indicates an expected call of NewFSxClient
+// NewFSxClient indicates an expected call of NewFSxClient.
 func (mr *MockFSxClientCreatorMockRecorder) NewFSxClient(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewFSxClient", reflect.TypeOf((*MockFSxClientCreator)(nil).NewFSxClient), arg0, arg1)

--- a/agent/fsx/mocks/fsx_mocks.go
+++ b/agent/fsx/mocks/fsx_mocks.go
@@ -25,30 +25,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockFSxClient is a mock of FSxClient interface
+// MockFSxClient is a mock of FSxClient interface.
 type MockFSxClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockFSxClientMockRecorder
 }
 
-// MockFSxClientMockRecorder is the mock recorder for MockFSxClient
+// MockFSxClientMockRecorder is the mock recorder for MockFSxClient.
 type MockFSxClientMockRecorder struct {
 	mock *MockFSxClient
 }
 
-// NewMockFSxClient creates a new mock instance
+// NewMockFSxClient creates a new mock instance.
 func NewMockFSxClient(ctrl *gomock.Controller) *MockFSxClient {
 	mock := &MockFSxClient{ctrl: ctrl}
 	mock.recorder = &MockFSxClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockFSxClient) EXPECT() *MockFSxClientMockRecorder {
 	return m.recorder
 }
 
-// DescribeFileSystems mocks base method
+// DescribeFileSystems mocks base method.
 func (m *MockFSxClient) DescribeFileSystems(arg0 *fsx.DescribeFileSystemsInput) (*fsx.DescribeFileSystemsOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeFileSystems", arg0)
@@ -57,7 +57,7 @@ func (m *MockFSxClient) DescribeFileSystems(arg0 *fsx.DescribeFileSystemsInput) 
 	return ret0, ret1
 }
 
-// DescribeFileSystems indicates an expected call of DescribeFileSystems
+// DescribeFileSystems indicates an expected call of DescribeFileSystems.
 func (mr *MockFSxClientMockRecorder) DescribeFileSystems(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeFileSystems", reflect.TypeOf((*MockFSxClient)(nil).DescribeFileSystems), arg0)

--- a/agent/gpu/mocks/gpu_manager_mocks.go
+++ b/agent/gpu/mocks/gpu_manager_mocks.go
@@ -25,30 +25,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockGPUManager is a mock of GPUManager interface
+// MockGPUManager is a mock of GPUManager interface.
 type MockGPUManager struct {
 	ctrl     *gomock.Controller
 	recorder *MockGPUManagerMockRecorder
 }
 
-// MockGPUManagerMockRecorder is the mock recorder for MockGPUManager
+// MockGPUManagerMockRecorder is the mock recorder for MockGPUManager.
 type MockGPUManagerMockRecorder struct {
 	mock *MockGPUManager
 }
 
-// NewMockGPUManager creates a new mock instance
+// NewMockGPUManager creates a new mock instance.
 func NewMockGPUManager(ctrl *gomock.Controller) *MockGPUManager {
 	mock := &MockGPUManager{ctrl: ctrl}
 	mock.recorder = &MockGPUManagerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockGPUManager) EXPECT() *MockGPUManagerMockRecorder {
 	return m.recorder
 }
 
-// GetDevices mocks base method
+// GetDevices mocks base method.
 func (m *MockGPUManager) GetDevices() []*ecs.PlatformDevice {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDevices")
@@ -56,13 +56,13 @@ func (m *MockGPUManager) GetDevices() []*ecs.PlatformDevice {
 	return ret0
 }
 
-// GetDevices indicates an expected call of GetDevices
+// GetDevices indicates an expected call of GetDevices.
 func (mr *MockGPUManagerMockRecorder) GetDevices() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDevices", reflect.TypeOf((*MockGPUManager)(nil).GetDevices))
 }
 
-// GetDriverVersion mocks base method
+// GetDriverVersion mocks base method.
 func (m *MockGPUManager) GetDriverVersion() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDriverVersion")
@@ -70,13 +70,13 @@ func (m *MockGPUManager) GetDriverVersion() string {
 	return ret0
 }
 
-// GetDriverVersion indicates an expected call of GetDriverVersion
+// GetDriverVersion indicates an expected call of GetDriverVersion.
 func (mr *MockGPUManagerMockRecorder) GetDriverVersion() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDriverVersion", reflect.TypeOf((*MockGPUManager)(nil).GetDriverVersion))
 }
 
-// GetGPUIDsUnsafe mocks base method
+// GetGPUIDsUnsafe mocks base method.
 func (m *MockGPUManager) GetGPUIDsUnsafe() []string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetGPUIDsUnsafe")
@@ -84,13 +84,13 @@ func (m *MockGPUManager) GetGPUIDsUnsafe() []string {
 	return ret0
 }
 
-// GetGPUIDsUnsafe indicates an expected call of GetGPUIDsUnsafe
+// GetGPUIDsUnsafe indicates an expected call of GetGPUIDsUnsafe.
 func (mr *MockGPUManagerMockRecorder) GetGPUIDsUnsafe() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGPUIDsUnsafe", reflect.TypeOf((*MockGPUManager)(nil).GetGPUIDsUnsafe))
 }
 
-// Initialize mocks base method
+// Initialize mocks base method.
 func (m *MockGPUManager) Initialize() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Initialize")
@@ -98,43 +98,43 @@ func (m *MockGPUManager) Initialize() error {
 	return ret0
 }
 
-// Initialize indicates an expected call of Initialize
+// Initialize indicates an expected call of Initialize.
 func (mr *MockGPUManagerMockRecorder) Initialize() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Initialize", reflect.TypeOf((*MockGPUManager)(nil).Initialize))
 }
 
-// SetDevices mocks base method
+// SetDevices mocks base method.
 func (m *MockGPUManager) SetDevices() {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetDevices")
 }
 
-// SetDevices indicates an expected call of SetDevices
+// SetDevices indicates an expected call of SetDevices.
 func (mr *MockGPUManagerMockRecorder) SetDevices() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDevices", reflect.TypeOf((*MockGPUManager)(nil).SetDevices))
 }
 
-// SetDriverVersion mocks base method
+// SetDriverVersion mocks base method.
 func (m *MockGPUManager) SetDriverVersion(arg0 string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetDriverVersion", arg0)
 }
 
-// SetDriverVersion indicates an expected call of SetDriverVersion
+// SetDriverVersion indicates an expected call of SetDriverVersion.
 func (mr *MockGPUManagerMockRecorder) SetDriverVersion(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDriverVersion", reflect.TypeOf((*MockGPUManager)(nil).SetDriverVersion), arg0)
 }
 
-// SetGPUIDs mocks base method
+// SetGPUIDs mocks base method.
 func (m *MockGPUManager) SetGPUIDs(arg0 []string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetGPUIDs", arg0)
 }
 
-// SetGPUIDs indicates an expected call of SetGPUIDs
+// SetGPUIDs indicates an expected call of SetGPUIDs.
 func (mr *MockGPUManagerMockRecorder) SetGPUIDs(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetGPUIDs", reflect.TypeOf((*MockGPUManager)(nil).SetGPUIDs), arg0)

--- a/agent/handlers/agentapi/taskprotection/v1/handlers/handlers_mocks.go
+++ b/agent/handlers/agentapi/taskprotection/v1/handlers/handlers_mocks.go
@@ -26,30 +26,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockTaskProtectionClientFactoryInterface is a mock of TaskProtectionClientFactoryInterface interface
+// MockTaskProtectionClientFactoryInterface is a mock of TaskProtectionClientFactoryInterface interface.
 type MockTaskProtectionClientFactoryInterface struct {
 	ctrl     *gomock.Controller
 	recorder *MockTaskProtectionClientFactoryInterfaceMockRecorder
 }
 
-// MockTaskProtectionClientFactoryInterfaceMockRecorder is the mock recorder for MockTaskProtectionClientFactoryInterface
+// MockTaskProtectionClientFactoryInterfaceMockRecorder is the mock recorder for MockTaskProtectionClientFactoryInterface.
 type MockTaskProtectionClientFactoryInterfaceMockRecorder struct {
 	mock *MockTaskProtectionClientFactoryInterface
 }
 
-// NewMockTaskProtectionClientFactoryInterface creates a new mock instance
+// NewMockTaskProtectionClientFactoryInterface creates a new mock instance.
 func NewMockTaskProtectionClientFactoryInterface(ctrl *gomock.Controller) *MockTaskProtectionClientFactoryInterface {
 	mock := &MockTaskProtectionClientFactoryInterface{ctrl: ctrl}
 	mock.recorder = &MockTaskProtectionClientFactoryInterfaceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockTaskProtectionClientFactoryInterface) EXPECT() *MockTaskProtectionClientFactoryInterfaceMockRecorder {
 	return m.recorder
 }
 
-// newTaskProtectionClient mocks base method
+// newTaskProtectionClient mocks base method.
 func (m *MockTaskProtectionClientFactoryInterface) newTaskProtectionClient(arg0 credentials.TaskIAMRoleCredentials) api.ECSTaskProtectionSDK {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "newTaskProtectionClient", arg0)
@@ -57,7 +57,7 @@ func (m *MockTaskProtectionClientFactoryInterface) newTaskProtectionClient(arg0 
 	return ret0
 }
 
-// newTaskProtectionClient indicates an expected call of newTaskProtectionClient
+// newTaskProtectionClient indicates an expected call of newTaskProtectionClient.
 func (mr *MockTaskProtectionClientFactoryInterfaceMockRecorder) newTaskProtectionClient(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "newTaskProtectionClient", reflect.TypeOf((*MockTaskProtectionClientFactoryInterface)(nil).newTaskProtectionClient), arg0)

--- a/agent/handlers/mocks/handlers_mocks.go
+++ b/agent/handlers/mocks/handlers_mocks.go
@@ -25,30 +25,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockDockerStateResolver is a mock of DockerStateResolver interface
+// MockDockerStateResolver is a mock of DockerStateResolver interface.
 type MockDockerStateResolver struct {
 	ctrl     *gomock.Controller
 	recorder *MockDockerStateResolverMockRecorder
 }
 
-// MockDockerStateResolverMockRecorder is the mock recorder for MockDockerStateResolver
+// MockDockerStateResolverMockRecorder is the mock recorder for MockDockerStateResolver.
 type MockDockerStateResolverMockRecorder struct {
 	mock *MockDockerStateResolver
 }
 
-// NewMockDockerStateResolver creates a new mock instance
+// NewMockDockerStateResolver creates a new mock instance.
 func NewMockDockerStateResolver(ctrl *gomock.Controller) *MockDockerStateResolver {
 	mock := &MockDockerStateResolver{ctrl: ctrl}
 	mock.recorder = &MockDockerStateResolverMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockDockerStateResolver) EXPECT() *MockDockerStateResolverMockRecorder {
 	return m.recorder
 }
 
-// State mocks base method
+// State mocks base method.
 func (m *MockDockerStateResolver) State() dockerstate.TaskEngineState {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "State")
@@ -56,7 +56,7 @@ func (m *MockDockerStateResolver) State() dockerstate.TaskEngineState {
 	return ret0
 }
 
-// State indicates an expected call of State
+// State indicates an expected call of State.
 func (mr *MockDockerStateResolverMockRecorder) State() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "State", reflect.TypeOf((*MockDockerStateResolver)(nil).State))

--- a/agent/handlers/mocks/http/handlers_mocks.go
+++ b/agent/handlers/mocks/http/handlers_mocks.go
@@ -25,30 +25,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockResponseWriter is a mock of ResponseWriter interface
+// MockResponseWriter is a mock of ResponseWriter interface.
 type MockResponseWriter struct {
 	ctrl     *gomock.Controller
 	recorder *MockResponseWriterMockRecorder
 }
 
-// MockResponseWriterMockRecorder is the mock recorder for MockResponseWriter
+// MockResponseWriterMockRecorder is the mock recorder for MockResponseWriter.
 type MockResponseWriterMockRecorder struct {
 	mock *MockResponseWriter
 }
 
-// NewMockResponseWriter creates a new mock instance
+// NewMockResponseWriter creates a new mock instance.
 func NewMockResponseWriter(ctrl *gomock.Controller) *MockResponseWriter {
 	mock := &MockResponseWriter{ctrl: ctrl}
 	mock.recorder = &MockResponseWriterMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockResponseWriter) EXPECT() *MockResponseWriterMockRecorder {
 	return m.recorder
 }
 
-// Header mocks base method
+// Header mocks base method.
 func (m *MockResponseWriter) Header() http.Header {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Header")
@@ -56,13 +56,13 @@ func (m *MockResponseWriter) Header() http.Header {
 	return ret0
 }
 
-// Header indicates an expected call of Header
+// Header indicates an expected call of Header.
 func (mr *MockResponseWriterMockRecorder) Header() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Header", reflect.TypeOf((*MockResponseWriter)(nil).Header))
 }
 
-// Write mocks base method
+// Write mocks base method.
 func (m *MockResponseWriter) Write(arg0 []byte) (int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Write", arg0)
@@ -71,19 +71,19 @@ func (m *MockResponseWriter) Write(arg0 []byte) (int, error) {
 	return ret0, ret1
 }
 
-// Write indicates an expected call of Write
+// Write indicates an expected call of Write.
 func (mr *MockResponseWriterMockRecorder) Write(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Write", reflect.TypeOf((*MockResponseWriter)(nil).Write), arg0)
 }
 
-// WriteHeader mocks base method
+// WriteHeader mocks base method.
 func (m *MockResponseWriter) WriteHeader(arg0 int) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "WriteHeader", arg0)
 }
 
-// WriteHeader indicates an expected call of WriteHeader
+// WriteHeader indicates an expected call of WriteHeader.
 func (mr *MockResponseWriterMockRecorder) WriteHeader(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteHeader", reflect.TypeOf((*MockResponseWriter)(nil).WriteHeader), arg0)

--- a/agent/httpclient/mock/httpclient.go
+++ b/agent/httpclient/mock/httpclient.go
@@ -25,30 +25,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockRoundTripper is a mock of RoundTripper interface
+// MockRoundTripper is a mock of RoundTripper interface.
 type MockRoundTripper struct {
 	ctrl     *gomock.Controller
 	recorder *MockRoundTripperMockRecorder
 }
 
-// MockRoundTripperMockRecorder is the mock recorder for MockRoundTripper
+// MockRoundTripperMockRecorder is the mock recorder for MockRoundTripper.
 type MockRoundTripperMockRecorder struct {
 	mock *MockRoundTripper
 }
 
-// NewMockRoundTripper creates a new mock instance
+// NewMockRoundTripper creates a new mock instance.
 func NewMockRoundTripper(ctrl *gomock.Controller) *MockRoundTripper {
 	mock := &MockRoundTripper{ctrl: ctrl}
 	mock.recorder = &MockRoundTripperMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockRoundTripper) EXPECT() *MockRoundTripperMockRecorder {
 	return m.recorder
 }
 
-// RoundTrip mocks base method
+// RoundTrip mocks base method.
 func (m *MockRoundTripper) RoundTrip(arg0 *http.Request) (*http.Response, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RoundTrip", arg0)
@@ -57,7 +57,7 @@ func (m *MockRoundTripper) RoundTrip(arg0 *http.Request) (*http.Response, error)
 	return ret0, ret1
 }
 
-// RoundTrip indicates an expected call of RoundTrip
+// RoundTrip indicates an expected call of RoundTrip.
 func (mr *MockRoundTripperMockRecorder) RoundTrip(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RoundTrip", reflect.TypeOf((*MockRoundTripper)(nil).RoundTrip), arg0)

--- a/agent/logger/audit/mocks/audit_log_mocks.go
+++ b/agent/logger/audit/mocks/audit_log_mocks.go
@@ -25,30 +25,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockAuditLogger is a mock of AuditLogger interface
+// MockAuditLogger is a mock of AuditLogger interface.
 type MockAuditLogger struct {
 	ctrl     *gomock.Controller
 	recorder *MockAuditLoggerMockRecorder
 }
 
-// MockAuditLoggerMockRecorder is the mock recorder for MockAuditLogger
+// MockAuditLoggerMockRecorder is the mock recorder for MockAuditLogger.
 type MockAuditLoggerMockRecorder struct {
 	mock *MockAuditLogger
 }
 
-// NewMockAuditLogger creates a new mock instance
+// NewMockAuditLogger creates a new mock instance.
 func NewMockAuditLogger(ctrl *gomock.Controller) *MockAuditLogger {
 	mock := &MockAuditLogger{ctrl: ctrl}
 	mock.recorder = &MockAuditLoggerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockAuditLogger) EXPECT() *MockAuditLoggerMockRecorder {
 	return m.recorder
 }
 
-// GetCluster mocks base method
+// GetCluster mocks base method.
 func (m *MockAuditLogger) GetCluster() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCluster")
@@ -56,13 +56,13 @@ func (m *MockAuditLogger) GetCluster() string {
 	return ret0
 }
 
-// GetCluster indicates an expected call of GetCluster
+// GetCluster indicates an expected call of GetCluster.
 func (mr *MockAuditLoggerMockRecorder) GetCluster() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCluster", reflect.TypeOf((*MockAuditLogger)(nil).GetCluster))
 }
 
-// GetContainerInstanceArn mocks base method
+// GetContainerInstanceArn mocks base method.
 func (m *MockAuditLogger) GetContainerInstanceArn() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetContainerInstanceArn")
@@ -70,48 +70,48 @@ func (m *MockAuditLogger) GetContainerInstanceArn() string {
 	return ret0
 }
 
-// GetContainerInstanceArn indicates an expected call of GetContainerInstanceArn
+// GetContainerInstanceArn indicates an expected call of GetContainerInstanceArn.
 func (mr *MockAuditLoggerMockRecorder) GetContainerInstanceArn() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContainerInstanceArn", reflect.TypeOf((*MockAuditLogger)(nil).GetContainerInstanceArn))
 }
 
-// Log mocks base method
+// Log mocks base method.
 func (m *MockAuditLogger) Log(arg0 request.LogRequest, arg1 int, arg2 string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Log", arg0, arg1, arg2)
 }
 
-// Log indicates an expected call of Log
+// Log indicates an expected call of Log.
 func (mr *MockAuditLoggerMockRecorder) Log(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Log", reflect.TypeOf((*MockAuditLogger)(nil).Log), arg0, arg1, arg2)
 }
 
-// MockInfoLogger is a mock of InfoLogger interface
+// MockInfoLogger is a mock of InfoLogger interface.
 type MockInfoLogger struct {
 	ctrl     *gomock.Controller
 	recorder *MockInfoLoggerMockRecorder
 }
 
-// MockInfoLoggerMockRecorder is the mock recorder for MockInfoLogger
+// MockInfoLoggerMockRecorder is the mock recorder for MockInfoLogger.
 type MockInfoLoggerMockRecorder struct {
 	mock *MockInfoLogger
 }
 
-// NewMockInfoLogger creates a new mock instance
+// NewMockInfoLogger creates a new mock instance.
 func NewMockInfoLogger(ctrl *gomock.Controller) *MockInfoLogger {
 	mock := &MockInfoLogger{ctrl: ctrl}
 	mock.recorder = &MockInfoLoggerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockInfoLogger) EXPECT() *MockInfoLoggerMockRecorder {
 	return m.recorder
 }
 
-// Info mocks base method
+// Info mocks base method.
 func (m *MockInfoLogger) Info(arg0 ...interface{}) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{}
@@ -121,7 +121,7 @@ func (m *MockInfoLogger) Info(arg0 ...interface{}) {
 	m.ctrl.Call(m, "Info", varargs...)
 }
 
-// Info indicates an expected call of Info
+// Info indicates an expected call of Info.
 func (mr *MockInfoLoggerMockRecorder) Info(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Info", reflect.TypeOf((*MockInfoLogger)(nil).Info), arg0...)

--- a/agent/logger/mocks/logger_mocks.go
+++ b/agent/logger/mocks/logger_mocks.go
@@ -25,30 +25,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockCustomReceiver is a mock of CustomReceiver interface
+// MockCustomReceiver is a mock of CustomReceiver interface.
 type MockCustomReceiver struct {
 	ctrl     *gomock.Controller
 	recorder *MockCustomReceiverMockRecorder
 }
 
-// MockCustomReceiverMockRecorder is the mock recorder for MockCustomReceiver
+// MockCustomReceiverMockRecorder is the mock recorder for MockCustomReceiver.
 type MockCustomReceiverMockRecorder struct {
 	mock *MockCustomReceiver
 }
 
-// NewMockCustomReceiver creates a new mock instance
+// NewMockCustomReceiver creates a new mock instance.
 func NewMockCustomReceiver(ctrl *gomock.Controller) *MockCustomReceiver {
 	mock := &MockCustomReceiver{ctrl: ctrl}
 	mock.recorder = &MockCustomReceiverMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockCustomReceiver) EXPECT() *MockCustomReceiverMockRecorder {
 	return m.recorder
 }
 
-// AfterParse mocks base method
+// AfterParse mocks base method.
 func (m *MockCustomReceiver) AfterParse(arg0 seelog.CustomReceiverInitArgs) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AfterParse", arg0)
@@ -56,13 +56,13 @@ func (m *MockCustomReceiver) AfterParse(arg0 seelog.CustomReceiverInitArgs) erro
 	return ret0
 }
 
-// AfterParse indicates an expected call of AfterParse
+// AfterParse indicates an expected call of AfterParse.
 func (mr *MockCustomReceiverMockRecorder) AfterParse(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AfterParse", reflect.TypeOf((*MockCustomReceiver)(nil).AfterParse), arg0)
 }
 
-// Close mocks base method
+// Close mocks base method.
 func (m *MockCustomReceiver) Close() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Close")
@@ -70,25 +70,25 @@ func (m *MockCustomReceiver) Close() error {
 	return ret0
 }
 
-// Close indicates an expected call of Close
+// Close indicates an expected call of Close.
 func (mr *MockCustomReceiverMockRecorder) Close() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockCustomReceiver)(nil).Close))
 }
 
-// Flush mocks base method
+// Flush mocks base method.
 func (m *MockCustomReceiver) Flush() {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Flush")
 }
 
-// Flush indicates an expected call of Flush
+// Flush indicates an expected call of Flush.
 func (mr *MockCustomReceiverMockRecorder) Flush() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Flush", reflect.TypeOf((*MockCustomReceiver)(nil).Flush))
 }
 
-// ReceiveMessage mocks base method
+// ReceiveMessage mocks base method.
 func (m *MockCustomReceiver) ReceiveMessage(arg0 string, arg1 seelog.LogLevel, arg2 seelog.LogContextInterface) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReceiveMessage", arg0, arg1, arg2)
@@ -96,7 +96,7 @@ func (m *MockCustomReceiver) ReceiveMessage(arg0 string, arg1 seelog.LogLevel, a
 	return ret0
 }
 
-// ReceiveMessage indicates an expected call of ReceiveMessage
+// ReceiveMessage indicates an expected call of ReceiveMessage.
 func (mr *MockCustomReceiverMockRecorder) ReceiveMessage(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReceiveMessage", reflect.TypeOf((*MockCustomReceiver)(nil).ReceiveMessage), arg0, arg1, arg2)

--- a/agent/s3/factory/mocks/factory_mocks.go
+++ b/agent/s3/factory/mocks/factory_mocks.go
@@ -26,30 +26,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockS3ClientCreator is a mock of S3ClientCreator interface
+// MockS3ClientCreator is a mock of S3ClientCreator interface.
 type MockS3ClientCreator struct {
 	ctrl     *gomock.Controller
 	recorder *MockS3ClientCreatorMockRecorder
 }
 
-// MockS3ClientCreatorMockRecorder is the mock recorder for MockS3ClientCreator
+// MockS3ClientCreatorMockRecorder is the mock recorder for MockS3ClientCreator.
 type MockS3ClientCreatorMockRecorder struct {
 	mock *MockS3ClientCreator
 }
 
-// NewMockS3ClientCreator creates a new mock instance
+// NewMockS3ClientCreator creates a new mock instance.
 func NewMockS3ClientCreator(ctrl *gomock.Controller) *MockS3ClientCreator {
 	mock := &MockS3ClientCreator{ctrl: ctrl}
 	mock.recorder = &MockS3ClientCreatorMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockS3ClientCreator) EXPECT() *MockS3ClientCreatorMockRecorder {
 	return m.recorder
 }
 
-// NewS3Client mocks base method
+// NewS3Client mocks base method.
 func (m *MockS3ClientCreator) NewS3Client(arg0 string, arg1 credentials.IAMRoleCredentials) s3.S3Client {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewS3Client", arg0, arg1)
@@ -57,13 +57,13 @@ func (m *MockS3ClientCreator) NewS3Client(arg0 string, arg1 credentials.IAMRoleC
 	return ret0
 }
 
-// NewS3Client indicates an expected call of NewS3Client
+// NewS3Client indicates an expected call of NewS3Client.
 func (mr *MockS3ClientCreatorMockRecorder) NewS3Client(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewS3Client", reflect.TypeOf((*MockS3ClientCreator)(nil).NewS3Client), arg0, arg1)
 }
 
-// NewS3ManagerClient mocks base method
+// NewS3ManagerClient mocks base method.
 func (m *MockS3ClientCreator) NewS3ManagerClient(arg0, arg1 string, arg2 credentials.IAMRoleCredentials) (s3.S3ManagerClient, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewS3ManagerClient", arg0, arg1, arg2)
@@ -72,7 +72,7 @@ func (m *MockS3ClientCreator) NewS3ManagerClient(arg0, arg1 string, arg2 credent
 	return ret0, ret1
 }
 
-// NewS3ManagerClient indicates an expected call of NewS3ManagerClient
+// NewS3ManagerClient indicates an expected call of NewS3ManagerClient.
 func (mr *MockS3ClientCreatorMockRecorder) NewS3ManagerClient(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewS3ManagerClient", reflect.TypeOf((*MockS3ClientCreator)(nil).NewS3ManagerClient), arg0, arg1, arg2)

--- a/agent/s3/mocks/s3_mocks.go
+++ b/agent/s3/mocks/s3_mocks.go
@@ -25,30 +25,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockS3Client is a mock of S3Client interface
+// MockS3Client is a mock of S3Client interface.
 type MockS3Client struct {
 	ctrl     *gomock.Controller
 	recorder *MockS3ClientMockRecorder
 }
 
-// MockS3ClientMockRecorder is the mock recorder for MockS3Client
+// MockS3ClientMockRecorder is the mock recorder for MockS3Client.
 type MockS3ClientMockRecorder struct {
 	mock *MockS3Client
 }
 
-// NewMockS3Client creates a new mock instance
+// NewMockS3Client creates a new mock instance.
 func NewMockS3Client(ctrl *gomock.Controller) *MockS3Client {
 	mock := &MockS3Client{ctrl: ctrl}
 	mock.recorder = &MockS3ClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockS3Client) EXPECT() *MockS3ClientMockRecorder {
 	return m.recorder
 }
 
-// GetObject mocks base method
+// GetObject mocks base method.
 func (m *MockS3Client) GetObject(arg0 *s3.GetObjectInput) (*s3.GetObjectOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetObject", arg0)
@@ -57,7 +57,7 @@ func (m *MockS3Client) GetObject(arg0 *s3.GetObjectInput) (*s3.GetObjectOutput, 
 	return ret0, ret1
 }
 
-// GetObject indicates an expected call of GetObject
+// GetObject indicates an expected call of GetObject.
 func (mr *MockS3ClientMockRecorder) GetObject(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetObject", reflect.TypeOf((*MockS3Client)(nil).GetObject), arg0)

--- a/agent/s3/mocks/s3manager/s3_mocks.go
+++ b/agent/s3/mocks/s3manager/s3_mocks.go
@@ -28,30 +28,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockS3ManagerClient is a mock of S3ManagerClient interface
+// MockS3ManagerClient is a mock of S3ManagerClient interface.
 type MockS3ManagerClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockS3ManagerClientMockRecorder
 }
 
-// MockS3ManagerClientMockRecorder is the mock recorder for MockS3ManagerClient
+// MockS3ManagerClientMockRecorder is the mock recorder for MockS3ManagerClient.
 type MockS3ManagerClientMockRecorder struct {
 	mock *MockS3ManagerClient
 }
 
-// NewMockS3ManagerClient creates a new mock instance
+// NewMockS3ManagerClient creates a new mock instance.
 func NewMockS3ManagerClient(ctrl *gomock.Controller) *MockS3ManagerClient {
 	mock := &MockS3ManagerClient{ctrl: ctrl}
 	mock.recorder = &MockS3ManagerClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockS3ManagerClient) EXPECT() *MockS3ManagerClientMockRecorder {
 	return m.recorder
 }
 
-// DownloadWithContext mocks base method
+// DownloadWithContext mocks base method.
 func (m *MockS3ManagerClient) DownloadWithContext(arg0 context.Context, arg1 io.WriterAt, arg2 *s3.GetObjectInput, arg3 ...func(*s3manager.Downloader)) (int64, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
@@ -64,7 +64,7 @@ func (m *MockS3ManagerClient) DownloadWithContext(arg0 context.Context, arg1 io.
 	return ret0, ret1
 }
 
-// DownloadWithContext indicates an expected call of DownloadWithContext
+// DownloadWithContext indicates an expected call of DownloadWithContext.
 func (mr *MockS3ManagerClientMockRecorder) DownloadWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)

--- a/agent/s3/s3_test.go
+++ b/agent/s3/s3_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	s3sdk "github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
@@ -46,8 +47,9 @@ func TestDownloadFile(t *testing.T) {
 	mockFile := mock_oswrapper.NewMockFile()
 	mockS3ManagerClient := mock_s3manager.NewMockS3ManagerClient(ctrl)
 
-	mockS3ManagerClient.EXPECT().DownloadWithContext(gomock.Any(), mockFile, gomock.Any()).Do(func(ctx aws.Context,
-		w io.WriterAt, input *s3sdk.GetObjectInput) {
+	mockS3ManagerClient.EXPECT().DownloadWithContext(
+		gomock.Any(), mockFile, gomock.Any(), gomock.Any(),
+	).Do(func(ctx aws.Context, w io.WriterAt, input *s3sdk.GetObjectInput, options ...func(*s3manager.Downloader)) {
 		assert.Equal(t, testBucket, aws.StringValue(input.Bucket))
 		assert.Equal(t, testKey, aws.StringValue(input.Key))
 	})

--- a/agent/ssm/factory/mocks/factory_mocks.go
+++ b/agent/ssm/factory/mocks/factory_mocks.go
@@ -26,30 +26,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockSSMClientCreator is a mock of SSMClientCreator interface
+// MockSSMClientCreator is a mock of SSMClientCreator interface.
 type MockSSMClientCreator struct {
 	ctrl     *gomock.Controller
 	recorder *MockSSMClientCreatorMockRecorder
 }
 
-// MockSSMClientCreatorMockRecorder is the mock recorder for MockSSMClientCreator
+// MockSSMClientCreatorMockRecorder is the mock recorder for MockSSMClientCreator.
 type MockSSMClientCreatorMockRecorder struct {
 	mock *MockSSMClientCreator
 }
 
-// NewMockSSMClientCreator creates a new mock instance
+// NewMockSSMClientCreator creates a new mock instance.
 func NewMockSSMClientCreator(ctrl *gomock.Controller) *MockSSMClientCreator {
 	mock := &MockSSMClientCreator{ctrl: ctrl}
 	mock.recorder = &MockSSMClientCreatorMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSSMClientCreator) EXPECT() *MockSSMClientCreatorMockRecorder {
 	return m.recorder
 }
 
-// NewSSMClient mocks base method
+// NewSSMClient mocks base method.
 func (m *MockSSMClientCreator) NewSSMClient(arg0 string, arg1 credentials.IAMRoleCredentials) ssm.SSMClient {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewSSMClient", arg0, arg1)
@@ -57,7 +57,7 @@ func (m *MockSSMClientCreator) NewSSMClient(arg0 string, arg1 credentials.IAMRol
 	return ret0
 }
 
-// NewSSMClient indicates an expected call of NewSSMClient
+// NewSSMClient indicates an expected call of NewSSMClient.
 func (mr *MockSSMClientCreatorMockRecorder) NewSSMClient(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewSSMClient", reflect.TypeOf((*MockSSMClientCreator)(nil).NewSSMClient), arg0, arg1)

--- a/agent/ssm/mocks/ssm_mocks.go
+++ b/agent/ssm/mocks/ssm_mocks.go
@@ -25,30 +25,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockSSMClient is a mock of SSMClient interface
+// MockSSMClient is a mock of SSMClient interface.
 type MockSSMClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockSSMClientMockRecorder
 }
 
-// MockSSMClientMockRecorder is the mock recorder for MockSSMClient
+// MockSSMClientMockRecorder is the mock recorder for MockSSMClient.
 type MockSSMClientMockRecorder struct {
 	mock *MockSSMClient
 }
 
-// NewMockSSMClient creates a new mock instance
+// NewMockSSMClient creates a new mock instance.
 func NewMockSSMClient(ctrl *gomock.Controller) *MockSSMClient {
 	mock := &MockSSMClient{ctrl: ctrl}
 	mock.recorder = &MockSSMClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSSMClient) EXPECT() *MockSSMClientMockRecorder {
 	return m.recorder
 }
 
-// GetParameters mocks base method
+// GetParameters mocks base method.
 func (m *MockSSMClient) GetParameters(arg0 *ssm.GetParametersInput) (*ssm.GetParametersOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetParameters", arg0)
@@ -57,7 +57,7 @@ func (m *MockSSMClient) GetParameters(arg0 *ssm.GetParametersInput) (*ssm.GetPar
 	return ret0, ret1
 }
 
-// GetParameters indicates an expected call of GetParameters
+// GetParameters indicates an expected call of GetParameters.
 func (mr *MockSSMClientMockRecorder) GetParameters(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetParameters", reflect.TypeOf((*MockSSMClient)(nil).GetParameters), arg0)

--- a/agent/statemanager/mocks/statemanager_mocks.go
+++ b/agent/statemanager/mocks/statemanager_mocks.go
@@ -24,30 +24,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockStateManager is a mock of StateManager interface
+// MockStateManager is a mock of StateManager interface.
 type MockStateManager struct {
 	ctrl     *gomock.Controller
 	recorder *MockStateManagerMockRecorder
 }
 
-// MockStateManagerMockRecorder is the mock recorder for MockStateManager
+// MockStateManagerMockRecorder is the mock recorder for MockStateManager.
 type MockStateManagerMockRecorder struct {
 	mock *MockStateManager
 }
 
-// NewMockStateManager creates a new mock instance
+// NewMockStateManager creates a new mock instance.
 func NewMockStateManager(ctrl *gomock.Controller) *MockStateManager {
 	mock := &MockStateManager{ctrl: ctrl}
 	mock.recorder = &MockStateManagerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockStateManager) EXPECT() *MockStateManagerMockRecorder {
 	return m.recorder
 }
 
-// ForceSave mocks base method
+// ForceSave mocks base method.
 func (m *MockStateManager) ForceSave() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ForceSave")
@@ -55,13 +55,13 @@ func (m *MockStateManager) ForceSave() error {
 	return ret0
 }
 
-// ForceSave indicates an expected call of ForceSave
+// ForceSave indicates an expected call of ForceSave.
 func (mr *MockStateManagerMockRecorder) ForceSave() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForceSave", reflect.TypeOf((*MockStateManager)(nil).ForceSave))
 }
 
-// Load mocks base method
+// Load mocks base method.
 func (m *MockStateManager) Load() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Load")
@@ -69,13 +69,13 @@ func (m *MockStateManager) Load() error {
 	return ret0
 }
 
-// Load indicates an expected call of Load
+// Load indicates an expected call of Load.
 func (mr *MockStateManagerMockRecorder) Load() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Load", reflect.TypeOf((*MockStateManager)(nil).Load))
 }
 
-// Save mocks base method
+// Save mocks base method.
 func (m *MockStateManager) Save() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Save")
@@ -83,7 +83,7 @@ func (m *MockStateManager) Save() error {
 	return ret0
 }
 
-// Save indicates an expected call of Save
+// Save indicates an expected call of Save.
 func (mr *MockStateManagerMockRecorder) Save() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Save", reflect.TypeOf((*MockStateManager)(nil).Save))

--- a/agent/stats/mock/engine.go
+++ b/agent/stats/mock/engine.go
@@ -28,30 +28,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockEngine is a mock of Engine interface
+// MockEngine is a mock of Engine interface.
 type MockEngine struct {
 	ctrl     *gomock.Controller
 	recorder *MockEngineMockRecorder
 }
 
-// MockEngineMockRecorder is the mock recorder for MockEngine
+// MockEngineMockRecorder is the mock recorder for MockEngine.
 type MockEngineMockRecorder struct {
 	mock *MockEngine
 }
 
-// NewMockEngine creates a new mock instance
+// NewMockEngine creates a new mock instance.
 func NewMockEngine(ctrl *gomock.Controller) *MockEngine {
 	mock := &MockEngine{ctrl: ctrl}
 	mock.recorder = &MockEngineMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockEngine) EXPECT() *MockEngineMockRecorder {
 	return m.recorder
 }
 
-// ContainerDockerStats mocks base method
+// ContainerDockerStats mocks base method.
 func (m *MockEngine) ContainerDockerStats(arg0, arg1 string) (*types.StatsJSON, *stats.NetworkStatsPerSec, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContainerDockerStats", arg0, arg1)
@@ -61,13 +61,13 @@ func (m *MockEngine) ContainerDockerStats(arg0, arg1 string) (*types.StatsJSON, 
 	return ret0, ret1, ret2
 }
 
-// ContainerDockerStats indicates an expected call of ContainerDockerStats
+// ContainerDockerStats indicates an expected call of ContainerDockerStats.
 func (mr *MockEngineMockRecorder) ContainerDockerStats(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerDockerStats", reflect.TypeOf((*MockEngine)(nil).ContainerDockerStats), arg0, arg1)
 }
 
-// GetInstanceMetrics mocks base method
+// GetInstanceMetrics mocks base method.
 func (m *MockEngine) GetInstanceMetrics(arg0 bool) (*ecstcs.MetricsMetadata, []*ecstcs.TaskMetric, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetInstanceMetrics", arg0)
@@ -77,13 +77,13 @@ func (m *MockEngine) GetInstanceMetrics(arg0 bool) (*ecstcs.MetricsMetadata, []*
 	return ret0, ret1, ret2
 }
 
-// GetInstanceMetrics indicates an expected call of GetInstanceMetrics
+// GetInstanceMetrics indicates an expected call of GetInstanceMetrics.
 func (mr *MockEngineMockRecorder) GetInstanceMetrics(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstanceMetrics", reflect.TypeOf((*MockEngine)(nil).GetInstanceMetrics), arg0)
 }
 
-// GetPublishMetricsTicker mocks base method
+// GetPublishMetricsTicker mocks base method.
 func (m *MockEngine) GetPublishMetricsTicker() *time.Ticker {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPublishMetricsTicker")
@@ -91,13 +91,13 @@ func (m *MockEngine) GetPublishMetricsTicker() *time.Ticker {
 	return ret0
 }
 
-// GetPublishMetricsTicker indicates an expected call of GetPublishMetricsTicker
+// GetPublishMetricsTicker indicates an expected call of GetPublishMetricsTicker.
 func (mr *MockEngineMockRecorder) GetPublishMetricsTicker() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPublishMetricsTicker", reflect.TypeOf((*MockEngine)(nil).GetPublishMetricsTicker))
 }
 
-// GetPublishServiceConnectTickerInterval mocks base method
+// GetPublishServiceConnectTickerInterval mocks base method.
 func (m *MockEngine) GetPublishServiceConnectTickerInterval() int32 {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPublishServiceConnectTickerInterval")
@@ -105,13 +105,13 @@ func (m *MockEngine) GetPublishServiceConnectTickerInterval() int32 {
 	return ret0
 }
 
-// GetPublishServiceConnectTickerInterval indicates an expected call of GetPublishServiceConnectTickerInterval
+// GetPublishServiceConnectTickerInterval indicates an expected call of GetPublishServiceConnectTickerInterval.
 func (mr *MockEngineMockRecorder) GetPublishServiceConnectTickerInterval() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPublishServiceConnectTickerInterval", reflect.TypeOf((*MockEngine)(nil).GetPublishServiceConnectTickerInterval))
 }
 
-// GetTaskHealthMetrics mocks base method
+// GetTaskHealthMetrics mocks base method.
 func (m *MockEngine) GetTaskHealthMetrics() (*ecstcs.HealthMetadata, []*ecstcs.TaskHealth, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTaskHealthMetrics")
@@ -121,19 +121,19 @@ func (m *MockEngine) GetTaskHealthMetrics() (*ecstcs.HealthMetadata, []*ecstcs.T
 	return ret0, ret1, ret2
 }
 
-// GetTaskHealthMetrics indicates an expected call of GetTaskHealthMetrics
+// GetTaskHealthMetrics indicates an expected call of GetTaskHealthMetrics.
 func (mr *MockEngineMockRecorder) GetTaskHealthMetrics() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTaskHealthMetrics", reflect.TypeOf((*MockEngine)(nil).GetTaskHealthMetrics))
 }
 
-// SetPublishServiceConnectTickerInterval mocks base method
+// SetPublishServiceConnectTickerInterval mocks base method.
 func (m *MockEngine) SetPublishServiceConnectTickerInterval(arg0 int32) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetPublishServiceConnectTickerInterval", arg0)
 }
 
-// SetPublishServiceConnectTickerInterval indicates an expected call of SetPublishServiceConnectTickerInterval
+// SetPublishServiceConnectTickerInterval indicates an expected call of SetPublishServiceConnectTickerInterval.
 func (mr *MockEngineMockRecorder) SetPublishServiceConnectTickerInterval(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetPublishServiceConnectTickerInterval", reflect.TypeOf((*MockEngine)(nil).SetPublishServiceConnectTickerInterval), arg0)

--- a/agent/stats/resolver/mock/resolver.go
+++ b/agent/stats/resolver/mock/resolver.go
@@ -26,30 +26,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockContainerMetadataResolver is a mock of ContainerMetadataResolver interface
+// MockContainerMetadataResolver is a mock of ContainerMetadataResolver interface.
 type MockContainerMetadataResolver struct {
 	ctrl     *gomock.Controller
 	recorder *MockContainerMetadataResolverMockRecorder
 }
 
-// MockContainerMetadataResolverMockRecorder is the mock recorder for MockContainerMetadataResolver
+// MockContainerMetadataResolverMockRecorder is the mock recorder for MockContainerMetadataResolver.
 type MockContainerMetadataResolverMockRecorder struct {
 	mock *MockContainerMetadataResolver
 }
 
-// NewMockContainerMetadataResolver creates a new mock instance
+// NewMockContainerMetadataResolver creates a new mock instance.
 func NewMockContainerMetadataResolver(ctrl *gomock.Controller) *MockContainerMetadataResolver {
 	mock := &MockContainerMetadataResolver{ctrl: ctrl}
 	mock.recorder = &MockContainerMetadataResolverMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockContainerMetadataResolver) EXPECT() *MockContainerMetadataResolverMockRecorder {
 	return m.recorder
 }
 
-// ResolveContainer mocks base method
+// ResolveContainer mocks base method.
 func (m *MockContainerMetadataResolver) ResolveContainer(arg0 string) (*container.DockerContainer, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResolveContainer", arg0)
@@ -58,13 +58,13 @@ func (m *MockContainerMetadataResolver) ResolveContainer(arg0 string) (*containe
 	return ret0, ret1
 }
 
-// ResolveContainer indicates an expected call of ResolveContainer
+// ResolveContainer indicates an expected call of ResolveContainer.
 func (mr *MockContainerMetadataResolverMockRecorder) ResolveContainer(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveContainer", reflect.TypeOf((*MockContainerMetadataResolver)(nil).ResolveContainer), arg0)
 }
 
-// ResolveTask mocks base method
+// ResolveTask mocks base method.
 func (m *MockContainerMetadataResolver) ResolveTask(arg0 string) (*task.Task, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResolveTask", arg0)
@@ -73,13 +73,13 @@ func (m *MockContainerMetadataResolver) ResolveTask(arg0 string) (*task.Task, er
 	return ret0, ret1
 }
 
-// ResolveTask indicates an expected call of ResolveTask
+// ResolveTask indicates an expected call of ResolveTask.
 func (mr *MockContainerMetadataResolverMockRecorder) ResolveTask(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveTask", reflect.TypeOf((*MockContainerMetadataResolver)(nil).ResolveTask), arg0)
 }
 
-// ResolveTaskByARN mocks base method
+// ResolveTaskByARN mocks base method.
 func (m *MockContainerMetadataResolver) ResolveTaskByARN(arg0 string) (*task.Task, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResolveTaskByARN", arg0)
@@ -88,7 +88,7 @@ func (m *MockContainerMetadataResolver) ResolveTaskByARN(arg0 string) (*task.Tas
 	return ret0, ret1
 }
 
-// ResolveTaskByARN indicates an expected call of ResolveTaskByARN
+// ResolveTaskByARN indicates an expected call of ResolveTaskByARN.
 func (mr *MockContainerMetadataResolverMockRecorder) ResolveTaskByARN(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveTaskByARN", reflect.TypeOf((*MockContainerMetadataResolver)(nil).ResolveTaskByARN), arg0)

--- a/agent/taskresource/cgroup/control/factory/mock/mock_cgroups_linux.go
+++ b/agent/taskresource/cgroup/control/factory/mock/mock_cgroups_linux.go
@@ -24,33 +24,33 @@ import (
 	cgroups "github.com/containerd/cgroups"
 	v1 "github.com/containerd/cgroups/stats/v1"
 	gomock "github.com/golang/mock/gomock"
-	specs_go "github.com/opencontainers/runtime-spec/specs-go"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
-// MockCgroup is a mock of Cgroup interface
+// MockCgroup is a mock of Cgroup interface.
 type MockCgroup struct {
 	ctrl     *gomock.Controller
 	recorder *MockCgroupMockRecorder
 }
 
-// MockCgroupMockRecorder is the mock recorder for MockCgroup
+// MockCgroupMockRecorder is the mock recorder for MockCgroup.
 type MockCgroupMockRecorder struct {
 	mock *MockCgroup
 }
 
-// NewMockCgroup creates a new mock instance
+// NewMockCgroup creates a new mock instance.
 func NewMockCgroup(ctrl *gomock.Controller) *MockCgroup {
 	mock := &MockCgroup{ctrl: ctrl}
 	mock.recorder = &MockCgroupMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockCgroup) EXPECT() *MockCgroupMockRecorder {
 	return m.recorder
 }
 
-// Add mocks base method
+// Add mocks base method.
 func (m *MockCgroup) Add(arg0 cgroups.Process, arg1 ...cgroups.Name) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
@@ -62,14 +62,14 @@ func (m *MockCgroup) Add(arg0 cgroups.Process, arg1 ...cgroups.Name) error {
 	return ret0
 }
 
-// Add indicates an expected call of Add
+// Add indicates an expected call of Add.
 func (mr *MockCgroupMockRecorder) Add(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Add", reflect.TypeOf((*MockCgroup)(nil).Add), varargs...)
 }
 
-// AddProc mocks base method
+// AddProc mocks base method.
 func (m *MockCgroup) AddProc(arg0 uint64, arg1 ...cgroups.Name) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
@@ -81,14 +81,14 @@ func (m *MockCgroup) AddProc(arg0 uint64, arg1 ...cgroups.Name) error {
 	return ret0
 }
 
-// AddProc indicates an expected call of AddProc
+// AddProc indicates an expected call of AddProc.
 func (mr *MockCgroupMockRecorder) AddProc(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddProc", reflect.TypeOf((*MockCgroup)(nil).AddProc), varargs...)
 }
 
-// AddTask mocks base method
+// AddTask mocks base method.
 func (m *MockCgroup) AddTask(arg0 cgroups.Process, arg1 ...cgroups.Name) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
@@ -100,14 +100,14 @@ func (m *MockCgroup) AddTask(arg0 cgroups.Process, arg1 ...cgroups.Name) error {
 	return ret0
 }
 
-// AddTask indicates an expected call of AddTask
+// AddTask indicates an expected call of AddTask.
 func (mr *MockCgroupMockRecorder) AddTask(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddTask", reflect.TypeOf((*MockCgroup)(nil).AddTask), varargs...)
 }
 
-// Delete mocks base method
+// Delete mocks base method.
 func (m *MockCgroup) Delete() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Delete")
@@ -115,13 +115,13 @@ func (m *MockCgroup) Delete() error {
 	return ret0
 }
 
-// Delete indicates an expected call of Delete
+// Delete indicates an expected call of Delete.
 func (mr *MockCgroupMockRecorder) Delete() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockCgroup)(nil).Delete))
 }
 
-// Freeze mocks base method
+// Freeze mocks base method.
 func (m *MockCgroup) Freeze() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Freeze")
@@ -129,13 +129,13 @@ func (m *MockCgroup) Freeze() error {
 	return ret0
 }
 
-// Freeze indicates an expected call of Freeze
+// Freeze indicates an expected call of Freeze.
 func (mr *MockCgroupMockRecorder) Freeze() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Freeze", reflect.TypeOf((*MockCgroup)(nil).Freeze))
 }
 
-// MoveTo mocks base method
+// MoveTo mocks base method.
 func (m *MockCgroup) MoveTo(arg0 cgroups.Cgroup) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MoveTo", arg0)
@@ -143,14 +143,14 @@ func (m *MockCgroup) MoveTo(arg0 cgroups.Cgroup) error {
 	return ret0
 }
 
-// MoveTo indicates an expected call of MoveTo
+// MoveTo indicates an expected call of MoveTo.
 func (mr *MockCgroupMockRecorder) MoveTo(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MoveTo", reflect.TypeOf((*MockCgroup)(nil).MoveTo), arg0)
 }
 
-// New mocks base method
-func (m *MockCgroup) New(arg0 string, arg1 *specs_go.LinuxResources) (cgroups.Cgroup, error) {
+// New mocks base method.
+func (m *MockCgroup) New(arg0 string, arg1 *specs.LinuxResources) (cgroups.Cgroup, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "New", arg0, arg1)
 	ret0, _ := ret[0].(cgroups.Cgroup)
@@ -158,13 +158,13 @@ func (m *MockCgroup) New(arg0 string, arg1 *specs_go.LinuxResources) (cgroups.Cg
 	return ret0, ret1
 }
 
-// New indicates an expected call of New
+// New indicates an expected call of New.
 func (mr *MockCgroupMockRecorder) New(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "New", reflect.TypeOf((*MockCgroup)(nil).New), arg0, arg1)
 }
 
-// OOMEventFD mocks base method
+// OOMEventFD mocks base method.
 func (m *MockCgroup) OOMEventFD() (uintptr, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "OOMEventFD")
@@ -173,13 +173,13 @@ func (m *MockCgroup) OOMEventFD() (uintptr, error) {
 	return ret0, ret1
 }
 
-// OOMEventFD indicates an expected call of OOMEventFD
+// OOMEventFD indicates an expected call of OOMEventFD.
 func (mr *MockCgroupMockRecorder) OOMEventFD() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OOMEventFD", reflect.TypeOf((*MockCgroup)(nil).OOMEventFD))
 }
 
-// Processes mocks base method
+// Processes mocks base method.
 func (m *MockCgroup) Processes(arg0 cgroups.Name, arg1 bool) ([]cgroups.Process, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Processes", arg0, arg1)
@@ -188,13 +188,13 @@ func (m *MockCgroup) Processes(arg0 cgroups.Name, arg1 bool) ([]cgroups.Process,
 	return ret0, ret1
 }
 
-// Processes indicates an expected call of Processes
+// Processes indicates an expected call of Processes.
 func (mr *MockCgroupMockRecorder) Processes(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Processes", reflect.TypeOf((*MockCgroup)(nil).Processes), arg0, arg1)
 }
 
-// RegisterMemoryEvent mocks base method
+// RegisterMemoryEvent mocks base method.
 func (m *MockCgroup) RegisterMemoryEvent(arg0 cgroups.MemoryEvent) (uintptr, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RegisterMemoryEvent", arg0)
@@ -203,13 +203,13 @@ func (m *MockCgroup) RegisterMemoryEvent(arg0 cgroups.MemoryEvent) (uintptr, err
 	return ret0, ret1
 }
 
-// RegisterMemoryEvent indicates an expected call of RegisterMemoryEvent
+// RegisterMemoryEvent indicates an expected call of RegisterMemoryEvent.
 func (mr *MockCgroupMockRecorder) RegisterMemoryEvent(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterMemoryEvent", reflect.TypeOf((*MockCgroup)(nil).RegisterMemoryEvent), arg0)
 }
 
-// Stat mocks base method
+// Stat mocks base method.
 func (m *MockCgroup) Stat(arg0 ...cgroups.ErrorHandler) (*v1.Metrics, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{}
@@ -222,13 +222,13 @@ func (m *MockCgroup) Stat(arg0 ...cgroups.ErrorHandler) (*v1.Metrics, error) {
 	return ret0, ret1
 }
 
-// Stat indicates an expected call of Stat
+// Stat indicates an expected call of Stat.
 func (mr *MockCgroupMockRecorder) Stat(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stat", reflect.TypeOf((*MockCgroup)(nil).Stat), arg0...)
 }
 
-// State mocks base method
+// State mocks base method.
 func (m *MockCgroup) State() cgroups.State {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "State")
@@ -236,13 +236,13 @@ func (m *MockCgroup) State() cgroups.State {
 	return ret0
 }
 
-// State indicates an expected call of State
+// State indicates an expected call of State.
 func (mr *MockCgroupMockRecorder) State() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "State", reflect.TypeOf((*MockCgroup)(nil).State))
 }
 
-// Subsystems mocks base method
+// Subsystems mocks base method.
 func (m *MockCgroup) Subsystems() []cgroups.Subsystem {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Subsystems")
@@ -250,13 +250,13 @@ func (m *MockCgroup) Subsystems() []cgroups.Subsystem {
 	return ret0
 }
 
-// Subsystems indicates an expected call of Subsystems
+// Subsystems indicates an expected call of Subsystems.
 func (mr *MockCgroupMockRecorder) Subsystems() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subsystems", reflect.TypeOf((*MockCgroup)(nil).Subsystems))
 }
 
-// Tasks mocks base method
+// Tasks mocks base method.
 func (m *MockCgroup) Tasks(arg0 cgroups.Name, arg1 bool) ([]cgroups.Process, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Tasks", arg0, arg1)
@@ -265,13 +265,13 @@ func (m *MockCgroup) Tasks(arg0 cgroups.Name, arg1 bool) ([]cgroups.Process, err
 	return ret0, ret1
 }
 
-// Tasks indicates an expected call of Tasks
+// Tasks indicates an expected call of Tasks.
 func (mr *MockCgroupMockRecorder) Tasks(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tasks", reflect.TypeOf((*MockCgroup)(nil).Tasks), arg0, arg1)
 }
 
-// Thaw mocks base method
+// Thaw mocks base method.
 func (m *MockCgroup) Thaw() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Thaw")
@@ -279,21 +279,21 @@ func (m *MockCgroup) Thaw() error {
 	return ret0
 }
 
-// Thaw indicates an expected call of Thaw
+// Thaw indicates an expected call of Thaw.
 func (mr *MockCgroupMockRecorder) Thaw() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Thaw", reflect.TypeOf((*MockCgroup)(nil).Thaw))
 }
 
-// Update mocks base method
-func (m *MockCgroup) Update(arg0 *specs_go.LinuxResources) error {
+// Update mocks base method.
+func (m *MockCgroup) Update(arg0 *specs.LinuxResources) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Update", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// Update indicates an expected call of Update
+// Update indicates an expected call of Update.
 func (mr *MockCgroupMockRecorder) Update(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockCgroup)(nil).Update), arg0)

--- a/agent/taskresource/cgroup/control/factory/mock_factory/mock_cgroup_factory_linux.go
+++ b/agent/taskresource/cgroup/control/factory/mock_factory/mock_cgroup_factory_linux.go
@@ -23,33 +23,33 @@ import (
 
 	cgroups "github.com/containerd/cgroups"
 	gomock "github.com/golang/mock/gomock"
-	specs_go "github.com/opencontainers/runtime-spec/specs-go"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
-// MockCgroupFactory is a mock of CgroupFactory interface
+// MockCgroupFactory is a mock of CgroupFactory interface.
 type MockCgroupFactory struct {
 	ctrl     *gomock.Controller
 	recorder *MockCgroupFactoryMockRecorder
 }
 
-// MockCgroupFactoryMockRecorder is the mock recorder for MockCgroupFactory
+// MockCgroupFactoryMockRecorder is the mock recorder for MockCgroupFactory.
 type MockCgroupFactoryMockRecorder struct {
 	mock *MockCgroupFactory
 }
 
-// NewMockCgroupFactory creates a new mock instance
+// NewMockCgroupFactory creates a new mock instance.
 func NewMockCgroupFactory(ctrl *gomock.Controller) *MockCgroupFactory {
 	mock := &MockCgroupFactory{ctrl: ctrl}
 	mock.recorder = &MockCgroupFactoryMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockCgroupFactory) EXPECT() *MockCgroupFactoryMockRecorder {
 	return m.recorder
 }
 
-// Load mocks base method
+// Load mocks base method.
 func (m *MockCgroupFactory) Load(arg0 cgroups.Hierarchy, arg1 cgroups.Path) (cgroups.Cgroup, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Load", arg0, arg1)
@@ -58,14 +58,14 @@ func (m *MockCgroupFactory) Load(arg0 cgroups.Hierarchy, arg1 cgroups.Path) (cgr
 	return ret0, ret1
 }
 
-// Load indicates an expected call of Load
+// Load indicates an expected call of Load.
 func (mr *MockCgroupFactoryMockRecorder) Load(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Load", reflect.TypeOf((*MockCgroupFactory)(nil).Load), arg0, arg1)
 }
 
-// New mocks base method
-func (m *MockCgroupFactory) New(arg0 cgroups.Hierarchy, arg1 cgroups.Path, arg2 *specs_go.LinuxResources) (cgroups.Cgroup, error) {
+// New mocks base method.
+func (m *MockCgroupFactory) New(arg0 cgroups.Hierarchy, arg1 cgroups.Path, arg2 *specs.LinuxResources) (cgroups.Cgroup, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "New", arg0, arg1, arg2)
 	ret0, _ := ret[0].(cgroups.Cgroup)
@@ -73,7 +73,7 @@ func (m *MockCgroupFactory) New(arg0 cgroups.Hierarchy, arg1 cgroups.Path, arg2 
 	return ret0, ret1
 }
 
-// New indicates an expected call of New
+// New indicates an expected call of New.
 func (mr *MockCgroupFactoryMockRecorder) New(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "New", reflect.TypeOf((*MockCgroupFactory)(nil).New), arg0, arg1, arg2)

--- a/agent/taskresource/cgroup/control/mock_control/mock_cgroup_control_linux.go
+++ b/agent/taskresource/cgroup/control/mock_control/mock_cgroup_control_linux.go
@@ -25,30 +25,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockControl is a mock of Control interface
+// MockControl is a mock of Control interface.
 type MockControl struct {
 	ctrl     *gomock.Controller
 	recorder *MockControlMockRecorder
 }
 
-// MockControlMockRecorder is the mock recorder for MockControl
+// MockControlMockRecorder is the mock recorder for MockControl.
 type MockControlMockRecorder struct {
 	mock *MockControl
 }
 
-// NewMockControl creates a new mock instance
+// NewMockControl creates a new mock instance.
 func NewMockControl(ctrl *gomock.Controller) *MockControl {
 	mock := &MockControl{ctrl: ctrl}
 	mock.recorder = &MockControlMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockControl) EXPECT() *MockControlMockRecorder {
 	return m.recorder
 }
 
-// Create mocks base method
+// Create mocks base method.
 func (m *MockControl) Create(arg0 *control.Spec) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create", arg0)
@@ -56,13 +56,13 @@ func (m *MockControl) Create(arg0 *control.Spec) error {
 	return ret0
 }
 
-// Create indicates an expected call of Create
+// Create indicates an expected call of Create.
 func (mr *MockControlMockRecorder) Create(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockControl)(nil).Create), arg0)
 }
 
-// Exists mocks base method
+// Exists mocks base method.
 func (m *MockControl) Exists(arg0 string) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Exists", arg0)
@@ -70,13 +70,13 @@ func (m *MockControl) Exists(arg0 string) bool {
 	return ret0
 }
 
-// Exists indicates an expected call of Exists
+// Exists indicates an expected call of Exists.
 func (mr *MockControlMockRecorder) Exists(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exists", reflect.TypeOf((*MockControl)(nil).Exists), arg0)
 }
 
-// Init mocks base method
+// Init mocks base method.
 func (m *MockControl) Init() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Init")
@@ -84,13 +84,13 @@ func (m *MockControl) Init() error {
 	return ret0
 }
 
-// Init indicates an expected call of Init
+// Init indicates an expected call of Init.
 func (mr *MockControlMockRecorder) Init() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Init", reflect.TypeOf((*MockControl)(nil).Init))
 }
 
-// Remove mocks base method
+// Remove mocks base method.
 func (m *MockControl) Remove(arg0 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Remove", arg0)
@@ -98,7 +98,7 @@ func (m *MockControl) Remove(arg0 string) error {
 	return ret0
 }
 
-// Remove indicates an expected call of Remove
+// Remove indicates an expected call of Remove.
 func (mr *MockControlMockRecorder) Remove(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Remove", reflect.TypeOf((*MockControl)(nil).Remove), arg0)

--- a/agent/taskresource/envFiles/envfile_test.go
+++ b/agent/taskresource/envFiles/envfile_test.go
@@ -37,6 +37,7 @@ import (
 	mock_oswrapper "github.com/aws/amazon-ecs-agent/agent/utils/oswrapper/mocks"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 )
@@ -141,8 +142,10 @@ func TestCreateWithEnvVarFile(t *testing.T) {
 		mockCredentialsManager.EXPECT().GetTaskCredentials(executionCredentialsID).Return(creds, true),
 		mockS3ClientCreator.EXPECT().NewS3ManagerClient(s3Bucket, region, creds.IAMRoleCredentials).Return(mockS3Client, nil),
 		mockIOUtil.EXPECT().TempFile(resourceDir, gomock.Any()).Return(mockFile, nil),
-		mockS3Client.EXPECT().DownloadWithContext(gomock.Any(), mockFile, gomock.Any()).Do(
-			func(ctx aws.Context, w io.WriterAt, input *s3.GetObjectInput) {
+		mockS3Client.EXPECT().DownloadWithContext(
+			gomock.Any(), mockFile, gomock.Any(), gomock.Any(),
+		).Do(
+			func(ctx aws.Context, w io.WriterAt, input *s3.GetObjectInput, options ...func(*s3manager.Downloader)) {
 				assert.Equal(t, s3Bucket, aws.StringValue(input.Bucket))
 				assert.Equal(t, s3Key, aws.StringValue(input.Key))
 			}).Return(int64(0), nil),

--- a/agent/taskresource/firelens/firelens_unix_test.go
+++ b/agent/taskresource/firelens/firelens_unix_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/golang/mock/gomock"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -366,8 +367,8 @@ func TestCreateFirelensResourceWithS3Config(t *testing.T) {
 		mockS3ClientCreator.EXPECT().NewS3ManagerClient("bucket", testRegion, creds.IAMRoleCredentials).Return(mockS3Client, nil),
 		// write external config file downloaded from s3
 		mockIOUtil.EXPECT().TempFile(testResourceDir, tempFile).Return(mockFile, nil),
-		mockS3Client.EXPECT().DownloadWithContext(gomock.Any(), mockFile, gomock.Any()).Do(
-			func(ctx aws.Context, w io.WriterAt, input *s3.GetObjectInput) {
+		mockS3Client.EXPECT().DownloadWithContext(gomock.Any(), mockFile, gomock.Any(), gomock.Any()).Do(
+			func(ctx aws.Context, w io.WriterAt, input *s3.GetObjectInput, options ...func(*s3manager.Downloader)) {
 				assert.Equal(t, "bucket", aws.StringValue(input.Bucket))
 				assert.Equal(t, "key", aws.StringValue(input.Key))
 			}).Return(int64(0), nil),

--- a/agent/taskresource/mocks/taskresource_mocks.go
+++ b/agent/taskresource/mocks/taskresource_mocks.go
@@ -30,30 +30,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockTaskResource is a mock of TaskResource interface
+// MockTaskResource is a mock of TaskResource interface.
 type MockTaskResource struct {
 	ctrl     *gomock.Controller
 	recorder *MockTaskResourceMockRecorder
 }
 
-// MockTaskResourceMockRecorder is the mock recorder for MockTaskResource
+// MockTaskResourceMockRecorder is the mock recorder for MockTaskResource.
 type MockTaskResourceMockRecorder struct {
 	mock *MockTaskResource
 }
 
-// NewMockTaskResource creates a new mock instance
+// NewMockTaskResource creates a new mock instance.
 func NewMockTaskResource(ctrl *gomock.Controller) *MockTaskResource {
 	mock := &MockTaskResource{ctrl: ctrl}
 	mock.recorder = &MockTaskResourceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockTaskResource) EXPECT() *MockTaskResourceMockRecorder {
 	return m.recorder
 }
 
-// ApplyTransition mocks base method
+// ApplyTransition mocks base method.
 func (m *MockTaskResource) ApplyTransition(arg0 status1.ResourceStatus) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ApplyTransition", arg0)
@@ -61,25 +61,25 @@ func (m *MockTaskResource) ApplyTransition(arg0 status1.ResourceStatus) error {
 	return ret0
 }
 
-// ApplyTransition indicates an expected call of ApplyTransition
+// ApplyTransition indicates an expected call of ApplyTransition.
 func (mr *MockTaskResourceMockRecorder) ApplyTransition(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyTransition", reflect.TypeOf((*MockTaskResource)(nil).ApplyTransition), arg0)
 }
 
-// BuildContainerDependency mocks base method
+// BuildContainerDependency mocks base method.
 func (m *MockTaskResource) BuildContainerDependency(arg0 string, arg1 status.ContainerStatus, arg2 status1.ResourceStatus) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "BuildContainerDependency", arg0, arg1, arg2)
 }
 
-// BuildContainerDependency indicates an expected call of BuildContainerDependency
+// BuildContainerDependency indicates an expected call of BuildContainerDependency.
 func (mr *MockTaskResourceMockRecorder) BuildContainerDependency(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildContainerDependency", reflect.TypeOf((*MockTaskResource)(nil).BuildContainerDependency), arg0, arg1, arg2)
 }
 
-// Cleanup mocks base method
+// Cleanup mocks base method.
 func (m *MockTaskResource) Cleanup() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Cleanup")
@@ -87,13 +87,13 @@ func (m *MockTaskResource) Cleanup() error {
 	return ret0
 }
 
-// Cleanup indicates an expected call of Cleanup
+// Cleanup indicates an expected call of Cleanup.
 func (mr *MockTaskResourceMockRecorder) Cleanup() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Cleanup", reflect.TypeOf((*MockTaskResource)(nil).Cleanup))
 }
 
-// Create mocks base method
+// Create mocks base method.
 func (m *MockTaskResource) Create() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create")
@@ -101,13 +101,13 @@ func (m *MockTaskResource) Create() error {
 	return ret0
 }
 
-// Create indicates an expected call of Create
+// Create indicates an expected call of Create.
 func (mr *MockTaskResourceMockRecorder) Create() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockTaskResource)(nil).Create))
 }
 
-// DependOnTaskNetwork mocks base method
+// DependOnTaskNetwork mocks base method.
 func (m *MockTaskResource) DependOnTaskNetwork() bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DependOnTaskNetwork")
@@ -115,13 +115,13 @@ func (m *MockTaskResource) DependOnTaskNetwork() bool {
 	return ret0
 }
 
-// DependOnTaskNetwork indicates an expected call of DependOnTaskNetwork
+// DependOnTaskNetwork indicates an expected call of DependOnTaskNetwork.
 func (mr *MockTaskResourceMockRecorder) DependOnTaskNetwork() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DependOnTaskNetwork", reflect.TypeOf((*MockTaskResource)(nil).DependOnTaskNetwork))
 }
 
-// DesiredTerminal mocks base method
+// DesiredTerminal mocks base method.
 func (m *MockTaskResource) DesiredTerminal() bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DesiredTerminal")
@@ -129,13 +129,13 @@ func (m *MockTaskResource) DesiredTerminal() bool {
 	return ret0
 }
 
-// DesiredTerminal indicates an expected call of DesiredTerminal
+// DesiredTerminal indicates an expected call of DesiredTerminal.
 func (mr *MockTaskResourceMockRecorder) DesiredTerminal() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DesiredTerminal", reflect.TypeOf((*MockTaskResource)(nil).DesiredTerminal))
 }
 
-// GetAppliedStatus mocks base method
+// GetAppliedStatus mocks base method.
 func (m *MockTaskResource) GetAppliedStatus() status1.ResourceStatus {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAppliedStatus")
@@ -143,13 +143,13 @@ func (m *MockTaskResource) GetAppliedStatus() status1.ResourceStatus {
 	return ret0
 }
 
-// GetAppliedStatus indicates an expected call of GetAppliedStatus
+// GetAppliedStatus indicates an expected call of GetAppliedStatus.
 func (mr *MockTaskResourceMockRecorder) GetAppliedStatus() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAppliedStatus", reflect.TypeOf((*MockTaskResource)(nil).GetAppliedStatus))
 }
 
-// GetContainerDependencies mocks base method
+// GetContainerDependencies mocks base method.
 func (m *MockTaskResource) GetContainerDependencies(arg0 status1.ResourceStatus) []container.ContainerDependency {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetContainerDependencies", arg0)
@@ -157,13 +157,13 @@ func (m *MockTaskResource) GetContainerDependencies(arg0 status1.ResourceStatus)
 	return ret0
 }
 
-// GetContainerDependencies indicates an expected call of GetContainerDependencies
+// GetContainerDependencies indicates an expected call of GetContainerDependencies.
 func (mr *MockTaskResourceMockRecorder) GetContainerDependencies(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContainerDependencies", reflect.TypeOf((*MockTaskResource)(nil).GetContainerDependencies), arg0)
 }
 
-// GetCreatedAt mocks base method
+// GetCreatedAt mocks base method.
 func (m *MockTaskResource) GetCreatedAt() time.Time {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCreatedAt")
@@ -171,13 +171,13 @@ func (m *MockTaskResource) GetCreatedAt() time.Time {
 	return ret0
 }
 
-// GetCreatedAt indicates an expected call of GetCreatedAt
+// GetCreatedAt indicates an expected call of GetCreatedAt.
 func (mr *MockTaskResourceMockRecorder) GetCreatedAt() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCreatedAt", reflect.TypeOf((*MockTaskResource)(nil).GetCreatedAt))
 }
 
-// GetDesiredStatus mocks base method
+// GetDesiredStatus mocks base method.
 func (m *MockTaskResource) GetDesiredStatus() status1.ResourceStatus {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDesiredStatus")
@@ -185,13 +185,13 @@ func (m *MockTaskResource) GetDesiredStatus() status1.ResourceStatus {
 	return ret0
 }
 
-// GetDesiredStatus indicates an expected call of GetDesiredStatus
+// GetDesiredStatus indicates an expected call of GetDesiredStatus.
 func (mr *MockTaskResourceMockRecorder) GetDesiredStatus() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDesiredStatus", reflect.TypeOf((*MockTaskResource)(nil).GetDesiredStatus))
 }
 
-// GetKnownStatus mocks base method
+// GetKnownStatus mocks base method.
 func (m *MockTaskResource) GetKnownStatus() status1.ResourceStatus {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetKnownStatus")
@@ -199,13 +199,13 @@ func (m *MockTaskResource) GetKnownStatus() status1.ResourceStatus {
 	return ret0
 }
 
-// GetKnownStatus indicates an expected call of GetKnownStatus
+// GetKnownStatus indicates an expected call of GetKnownStatus.
 func (mr *MockTaskResourceMockRecorder) GetKnownStatus() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKnownStatus", reflect.TypeOf((*MockTaskResource)(nil).GetKnownStatus))
 }
 
-// GetName mocks base method
+// GetName mocks base method.
 func (m *MockTaskResource) GetName() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetName")
@@ -213,13 +213,13 @@ func (m *MockTaskResource) GetName() string {
 	return ret0
 }
 
-// GetName indicates an expected call of GetName
+// GetName indicates an expected call of GetName.
 func (mr *MockTaskResourceMockRecorder) GetName() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetName", reflect.TypeOf((*MockTaskResource)(nil).GetName))
 }
 
-// GetTerminalReason mocks base method
+// GetTerminalReason mocks base method.
 func (m *MockTaskResource) GetTerminalReason() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTerminalReason")
@@ -227,25 +227,25 @@ func (m *MockTaskResource) GetTerminalReason() string {
 	return ret0
 }
 
-// GetTerminalReason indicates an expected call of GetTerminalReason
+// GetTerminalReason indicates an expected call of GetTerminalReason.
 func (mr *MockTaskResourceMockRecorder) GetTerminalReason() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTerminalReason", reflect.TypeOf((*MockTaskResource)(nil).GetTerminalReason))
 }
 
-// Initialize mocks base method
+// Initialize mocks base method.
 func (m *MockTaskResource) Initialize(arg0 *taskresource.ResourceFields, arg1, arg2 status0.TaskStatus) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Initialize", arg0, arg1, arg2)
 }
 
-// Initialize indicates an expected call of Initialize
+// Initialize indicates an expected call of Initialize.
 func (mr *MockTaskResourceMockRecorder) Initialize(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Initialize", reflect.TypeOf((*MockTaskResource)(nil).Initialize), arg0, arg1, arg2)
 }
 
-// KnownCreated mocks base method
+// KnownCreated mocks base method.
 func (m *MockTaskResource) KnownCreated() bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "KnownCreated")
@@ -253,13 +253,13 @@ func (m *MockTaskResource) KnownCreated() bool {
 	return ret0
 }
 
-// KnownCreated indicates an expected call of KnownCreated
+// KnownCreated indicates an expected call of KnownCreated.
 func (mr *MockTaskResourceMockRecorder) KnownCreated() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KnownCreated", reflect.TypeOf((*MockTaskResource)(nil).KnownCreated))
 }
 
-// MarshalJSON mocks base method
+// MarshalJSON mocks base method.
 func (m *MockTaskResource) MarshalJSON() ([]byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MarshalJSON")
@@ -268,13 +268,13 @@ func (m *MockTaskResource) MarshalJSON() ([]byte, error) {
 	return ret0, ret1
 }
 
-// MarshalJSON indicates an expected call of MarshalJSON
+// MarshalJSON indicates an expected call of MarshalJSON.
 func (mr *MockTaskResourceMockRecorder) MarshalJSON() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarshalJSON", reflect.TypeOf((*MockTaskResource)(nil).MarshalJSON))
 }
 
-// NextKnownState mocks base method
+// NextKnownState mocks base method.
 func (m *MockTaskResource) NextKnownState() status1.ResourceStatus {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NextKnownState")
@@ -282,13 +282,13 @@ func (m *MockTaskResource) NextKnownState() status1.ResourceStatus {
 	return ret0
 }
 
-// NextKnownState indicates an expected call of NextKnownState
+// NextKnownState indicates an expected call of NextKnownState.
 func (mr *MockTaskResourceMockRecorder) NextKnownState() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NextKnownState", reflect.TypeOf((*MockTaskResource)(nil).NextKnownState))
 }
 
-// SetAppliedStatus mocks base method
+// SetAppliedStatus mocks base method.
 func (m *MockTaskResource) SetAppliedStatus(arg0 status1.ResourceStatus) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetAppliedStatus", arg0)
@@ -296,49 +296,49 @@ func (m *MockTaskResource) SetAppliedStatus(arg0 status1.ResourceStatus) bool {
 	return ret0
 }
 
-// SetAppliedStatus indicates an expected call of SetAppliedStatus
+// SetAppliedStatus indicates an expected call of SetAppliedStatus.
 func (mr *MockTaskResourceMockRecorder) SetAppliedStatus(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAppliedStatus", reflect.TypeOf((*MockTaskResource)(nil).SetAppliedStatus), arg0)
 }
 
-// SetCreatedAt mocks base method
+// SetCreatedAt mocks base method.
 func (m *MockTaskResource) SetCreatedAt(arg0 time.Time) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetCreatedAt", arg0)
 }
 
-// SetCreatedAt indicates an expected call of SetCreatedAt
+// SetCreatedAt indicates an expected call of SetCreatedAt.
 func (mr *MockTaskResourceMockRecorder) SetCreatedAt(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCreatedAt", reflect.TypeOf((*MockTaskResource)(nil).SetCreatedAt), arg0)
 }
 
-// SetDesiredStatus mocks base method
+// SetDesiredStatus mocks base method.
 func (m *MockTaskResource) SetDesiredStatus(arg0 status1.ResourceStatus) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetDesiredStatus", arg0)
 }
 
-// SetDesiredStatus indicates an expected call of SetDesiredStatus
+// SetDesiredStatus indicates an expected call of SetDesiredStatus.
 func (mr *MockTaskResourceMockRecorder) SetDesiredStatus(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDesiredStatus", reflect.TypeOf((*MockTaskResource)(nil).SetDesiredStatus), arg0)
 }
 
-// SetKnownStatus mocks base method
+// SetKnownStatus mocks base method.
 func (m *MockTaskResource) SetKnownStatus(arg0 status1.ResourceStatus) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetKnownStatus", arg0)
 }
 
-// SetKnownStatus indicates an expected call of SetKnownStatus
+// SetKnownStatus indicates an expected call of SetKnownStatus.
 func (mr *MockTaskResourceMockRecorder) SetKnownStatus(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetKnownStatus", reflect.TypeOf((*MockTaskResource)(nil).SetKnownStatus), arg0)
 }
 
-// StatusString mocks base method
+// StatusString mocks base method.
 func (m *MockTaskResource) StatusString(arg0 status1.ResourceStatus) string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StatusString", arg0)
@@ -346,13 +346,13 @@ func (m *MockTaskResource) StatusString(arg0 status1.ResourceStatus) string {
 	return ret0
 }
 
-// StatusString indicates an expected call of StatusString
+// StatusString indicates an expected call of StatusString.
 func (mr *MockTaskResourceMockRecorder) StatusString(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StatusString", reflect.TypeOf((*MockTaskResource)(nil).StatusString), arg0)
 }
 
-// SteadyState mocks base method
+// SteadyState mocks base method.
 func (m *MockTaskResource) SteadyState() status1.ResourceStatus {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SteadyState")
@@ -360,13 +360,13 @@ func (m *MockTaskResource) SteadyState() status1.ResourceStatus {
 	return ret0
 }
 
-// SteadyState indicates an expected call of SteadyState
+// SteadyState indicates an expected call of SteadyState.
 func (mr *MockTaskResourceMockRecorder) SteadyState() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SteadyState", reflect.TypeOf((*MockTaskResource)(nil).SteadyState))
 }
 
-// TerminalStatus mocks base method
+// TerminalStatus mocks base method.
 func (m *MockTaskResource) TerminalStatus() status1.ResourceStatus {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TerminalStatus")
@@ -374,13 +374,13 @@ func (m *MockTaskResource) TerminalStatus() status1.ResourceStatus {
 	return ret0
 }
 
-// TerminalStatus indicates an expected call of TerminalStatus
+// TerminalStatus indicates an expected call of TerminalStatus.
 func (mr *MockTaskResourceMockRecorder) TerminalStatus() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TerminalStatus", reflect.TypeOf((*MockTaskResource)(nil).TerminalStatus))
 }
 
-// UnmarshalJSON mocks base method
+// UnmarshalJSON mocks base method.
 func (m *MockTaskResource) UnmarshalJSON(arg0 []byte) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UnmarshalJSON", arg0)
@@ -388,7 +388,7 @@ func (m *MockTaskResource) UnmarshalJSON(arg0 []byte) error {
 	return ret0
 }
 
-// UnmarshalJSON indicates an expected call of UnmarshalJSON
+// UnmarshalJSON indicates an expected call of UnmarshalJSON.
 func (mr *MockTaskResourceMockRecorder) UnmarshalJSON(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnmarshalJSON", reflect.TypeOf((*MockTaskResource)(nil).UnmarshalJSON), arg0)

--- a/agent/utils/bufiowrapper/mocks/bufiowrapper_mocks.go
+++ b/agent/utils/bufiowrapper/mocks/bufiowrapper_mocks.go
@@ -26,30 +26,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockBufio is a mock of Bufio interface
+// MockBufio is a mock of Bufio interface.
 type MockBufio struct {
 	ctrl     *gomock.Controller
 	recorder *MockBufioMockRecorder
 }
 
-// MockBufioMockRecorder is the mock recorder for MockBufio
+// MockBufioMockRecorder is the mock recorder for MockBufio.
 type MockBufioMockRecorder struct {
 	mock *MockBufio
 }
 
-// NewMockBufio creates a new mock instance
+// NewMockBufio creates a new mock instance.
 func NewMockBufio(ctrl *gomock.Controller) *MockBufio {
 	mock := &MockBufio{ctrl: ctrl}
 	mock.recorder = &MockBufioMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockBufio) EXPECT() *MockBufioMockRecorder {
 	return m.recorder
 }
 
-// NewScanner mocks base method
+// NewScanner mocks base method.
 func (m *MockBufio) NewScanner(arg0 io.Reader) bufiowrapper.Scanner {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewScanner", arg0)
@@ -57,36 +57,36 @@ func (m *MockBufio) NewScanner(arg0 io.Reader) bufiowrapper.Scanner {
 	return ret0
 }
 
-// NewScanner indicates an expected call of NewScanner
+// NewScanner indicates an expected call of NewScanner.
 func (mr *MockBufioMockRecorder) NewScanner(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewScanner", reflect.TypeOf((*MockBufio)(nil).NewScanner), arg0)
 }
 
-// MockScanner is a mock of Scanner interface
+// MockScanner is a mock of Scanner interface.
 type MockScanner struct {
 	ctrl     *gomock.Controller
 	recorder *MockScannerMockRecorder
 }
 
-// MockScannerMockRecorder is the mock recorder for MockScanner
+// MockScannerMockRecorder is the mock recorder for MockScanner.
 type MockScannerMockRecorder struct {
 	mock *MockScanner
 }
 
-// NewMockScanner creates a new mock instance
+// NewMockScanner creates a new mock instance.
 func NewMockScanner(ctrl *gomock.Controller) *MockScanner {
 	mock := &MockScanner{ctrl: ctrl}
 	mock.recorder = &MockScannerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockScanner) EXPECT() *MockScannerMockRecorder {
 	return m.recorder
 }
 
-// Err mocks base method
+// Err mocks base method.
 func (m *MockScanner) Err() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Err")
@@ -94,13 +94,13 @@ func (m *MockScanner) Err() error {
 	return ret0
 }
 
-// Err indicates an expected call of Err
+// Err indicates an expected call of Err.
 func (mr *MockScannerMockRecorder) Err() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Err", reflect.TypeOf((*MockScanner)(nil).Err))
 }
 
-// Scan mocks base method
+// Scan mocks base method.
 func (m *MockScanner) Scan() bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Scan")
@@ -108,13 +108,13 @@ func (m *MockScanner) Scan() bool {
 	return ret0
 }
 
-// Scan indicates an expected call of Scan
+// Scan indicates an expected call of Scan.
 func (mr *MockScannerMockRecorder) Scan() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Scan", reflect.TypeOf((*MockScanner)(nil).Scan))
 }
 
-// Text mocks base method
+// Text mocks base method.
 func (m *MockScanner) Text() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Text")
@@ -122,7 +122,7 @@ func (m *MockScanner) Text() string {
 	return ret0
 }
 
-// Text indicates an expected call of Text
+// Text indicates an expected call of Text.
 func (mr *MockScannerMockRecorder) Text() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Text", reflect.TypeOf((*MockScanner)(nil).Text))

--- a/agent/utils/ioutilwrapper/mocks/ioutilwrapper_mocks.go
+++ b/agent/utils/ioutilwrapper/mocks/ioutilwrapper_mocks.go
@@ -26,30 +26,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockIOUtil is a mock of IOUtil interface
+// MockIOUtil is a mock of IOUtil interface.
 type MockIOUtil struct {
 	ctrl     *gomock.Controller
 	recorder *MockIOUtilMockRecorder
 }
 
-// MockIOUtilMockRecorder is the mock recorder for MockIOUtil
+// MockIOUtilMockRecorder is the mock recorder for MockIOUtil.
 type MockIOUtilMockRecorder struct {
 	mock *MockIOUtil
 }
 
-// NewMockIOUtil creates a new mock instance
+// NewMockIOUtil creates a new mock instance.
 func NewMockIOUtil(ctrl *gomock.Controller) *MockIOUtil {
 	mock := &MockIOUtil{ctrl: ctrl}
 	mock.recorder = &MockIOUtilMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockIOUtil) EXPECT() *MockIOUtilMockRecorder {
 	return m.recorder
 }
 
-// TempFile mocks base method
+// TempFile mocks base method.
 func (m *MockIOUtil) TempFile(arg0, arg1 string) (oswrapper.File, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TempFile", arg0, arg1)
@@ -58,13 +58,13 @@ func (m *MockIOUtil) TempFile(arg0, arg1 string) (oswrapper.File, error) {
 	return ret0, ret1
 }
 
-// TempFile indicates an expected call of TempFile
+// TempFile indicates an expected call of TempFile.
 func (mr *MockIOUtilMockRecorder) TempFile(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TempFile", reflect.TypeOf((*MockIOUtil)(nil).TempFile), arg0, arg1)
 }
 
-// WriteFile mocks base method
+// WriteFile mocks base method.
 func (m *MockIOUtil) WriteFile(arg0 string, arg1 []byte, arg2 fs.FileMode) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WriteFile", arg0, arg1, arg2)
@@ -72,7 +72,7 @@ func (m *MockIOUtil) WriteFile(arg0 string, arg1 []byte, arg2 fs.FileMode) error
 	return ret0
 }
 
-// WriteFile indicates an expected call of WriteFile
+// WriteFile indicates an expected call of WriteFile.
 func (mr *MockIOUtilMockRecorder) WriteFile(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteFile", reflect.TypeOf((*MockIOUtil)(nil).WriteFile), arg0, arg1, arg2)

--- a/agent/utils/loader/mocks/load_mocks.go
+++ b/agent/utils/loader/mocks/load_mocks.go
@@ -28,30 +28,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockLoader is a mock of Loader interface
+// MockLoader is a mock of Loader interface.
 type MockLoader struct {
 	ctrl     *gomock.Controller
 	recorder *MockLoaderMockRecorder
 }
 
-// MockLoaderMockRecorder is the mock recorder for MockLoader
+// MockLoaderMockRecorder is the mock recorder for MockLoader.
 type MockLoaderMockRecorder struct {
 	mock *MockLoader
 }
 
-// NewMockLoader creates a new mock instance
+// NewMockLoader creates a new mock instance.
 func NewMockLoader(ctrl *gomock.Controller) *MockLoader {
 	mock := &MockLoader{ctrl: ctrl}
 	mock.recorder = &MockLoaderMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockLoader) EXPECT() *MockLoaderMockRecorder {
 	return m.recorder
 }
 
-// IsLoaded mocks base method
+// IsLoaded mocks base method.
 func (m *MockLoader) IsLoaded(arg0 dockerapi.DockerClient) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsLoaded", arg0)
@@ -60,13 +60,13 @@ func (m *MockLoader) IsLoaded(arg0 dockerapi.DockerClient) (bool, error) {
 	return ret0, ret1
 }
 
-// IsLoaded indicates an expected call of IsLoaded
+// IsLoaded indicates an expected call of IsLoaded.
 func (mr *MockLoaderMockRecorder) IsLoaded(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsLoaded", reflect.TypeOf((*MockLoader)(nil).IsLoaded), arg0)
 }
 
-// LoadImage mocks base method
+// LoadImage mocks base method.
 func (m *MockLoader) LoadImage(arg0 context.Context, arg1 *config.Config, arg2 dockerapi.DockerClient) (*types.ImageInspect, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LoadImage", arg0, arg1, arg2)
@@ -75,7 +75,7 @@ func (m *MockLoader) LoadImage(arg0 context.Context, arg1 *config.Config, arg2 d
 	return ret0, ret1
 }
 
-// LoadImage indicates an expected call of LoadImage
+// LoadImage indicates an expected call of LoadImage.
 func (mr *MockLoaderMockRecorder) LoadImage(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadImage", reflect.TypeOf((*MockLoader)(nil).LoadImage), arg0, arg1, arg2)

--- a/agent/utils/mobypkgwrapper/mocks/pluginswrapper_mocks.go
+++ b/agent/utils/mobypkgwrapper/mocks/pluginswrapper_mocks.go
@@ -24,30 +24,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockPlugins is a mock of Plugins interface
+// MockPlugins is a mock of Plugins interface.
 type MockPlugins struct {
 	ctrl     *gomock.Controller
 	recorder *MockPluginsMockRecorder
 }
 
-// MockPluginsMockRecorder is the mock recorder for MockPlugins
+// MockPluginsMockRecorder is the mock recorder for MockPlugins.
 type MockPluginsMockRecorder struct {
 	mock *MockPlugins
 }
 
-// NewMockPlugins creates a new mock instance
+// NewMockPlugins creates a new mock instance.
 func NewMockPlugins(ctrl *gomock.Controller) *MockPlugins {
 	mock := &MockPlugins{ctrl: ctrl}
 	mock.recorder = &MockPluginsMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockPlugins) EXPECT() *MockPluginsMockRecorder {
 	return m.recorder
 }
 
-// Scan mocks base method
+// Scan mocks base method.
 func (m *MockPlugins) Scan() ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Scan")
@@ -56,7 +56,7 @@ func (m *MockPlugins) Scan() ([]string, error) {
 	return ret0, ret1
 }
 
-// Scan indicates an expected call of Scan
+// Scan indicates an expected call of Scan.
 func (mr *MockPluginsMockRecorder) Scan() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Scan", reflect.TypeOf((*MockPlugins)(nil).Scan))

--- a/agent/utils/mocks/utils_mocks.go
+++ b/agent/utils/mocks/utils_mocks.go
@@ -24,30 +24,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockLicenseProvider is a mock of LicenseProvider interface
+// MockLicenseProvider is a mock of LicenseProvider interface.
 type MockLicenseProvider struct {
 	ctrl     *gomock.Controller
 	recorder *MockLicenseProviderMockRecorder
 }
 
-// MockLicenseProviderMockRecorder is the mock recorder for MockLicenseProvider
+// MockLicenseProviderMockRecorder is the mock recorder for MockLicenseProvider.
 type MockLicenseProviderMockRecorder struct {
 	mock *MockLicenseProvider
 }
 
-// NewMockLicenseProvider creates a new mock instance
+// NewMockLicenseProvider creates a new mock instance.
 func NewMockLicenseProvider(ctrl *gomock.Controller) *MockLicenseProvider {
 	mock := &MockLicenseProvider{ctrl: ctrl}
 	mock.recorder = &MockLicenseProviderMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockLicenseProvider) EXPECT() *MockLicenseProviderMockRecorder {
 	return m.recorder
 }
 
-// GetText mocks base method
+// GetText mocks base method.
 func (m *MockLicenseProvider) GetText() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetText")
@@ -56,7 +56,7 @@ func (m *MockLicenseProvider) GetText() (string, error) {
 	return ret0, ret1
 }
 
-// GetText indicates an expected call of GetText
+// GetText indicates an expected call of GetText.
 func (mr *MockLicenseProviderMockRecorder) GetText() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetText", reflect.TypeOf((*MockLicenseProvider)(nil).GetText))

--- a/agent/utils/nswrapper/mocks/nswrapper_mocks_linux.go
+++ b/agent/utils/nswrapper/mocks/nswrapper_mocks_linux.go
@@ -25,30 +25,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockNS is a mock of NS interface
+// MockNS is a mock of NS interface.
 type MockNS struct {
 	ctrl     *gomock.Controller
 	recorder *MockNSMockRecorder
 }
 
-// MockNSMockRecorder is the mock recorder for MockNS
+// MockNSMockRecorder is the mock recorder for MockNS.
 type MockNSMockRecorder struct {
 	mock *MockNS
 }
 
-// NewMockNS creates a new mock instance
+// NewMockNS creates a new mock instance.
 func NewMockNS(ctrl *gomock.Controller) *MockNS {
 	mock := &MockNS{ctrl: ctrl}
 	mock.recorder = &MockNSMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockNS) EXPECT() *MockNSMockRecorder {
 	return m.recorder
 }
 
-// GetNS mocks base method
+// GetNS mocks base method.
 func (m *MockNS) GetNS(arg0 string) (ns.NetNS, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetNS", arg0)
@@ -57,13 +57,13 @@ func (m *MockNS) GetNS(arg0 string) (ns.NetNS, error) {
 	return ret0, ret1
 }
 
-// GetNS indicates an expected call of GetNS
+// GetNS indicates an expected call of GetNS.
 func (mr *MockNSMockRecorder) GetNS(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNS", reflect.TypeOf((*MockNS)(nil).GetNS), arg0)
 }
 
-// WithNetNSPath mocks base method
+// WithNetNSPath mocks base method.
 func (m *MockNS) WithNetNSPath(arg0 string, arg1 func(ns.NetNS) error) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WithNetNSPath", arg0, arg1)
@@ -71,7 +71,7 @@ func (m *MockNS) WithNetNSPath(arg0 string, arg1 func(ns.NetNS) error) error {
 	return ret0
 }
 
-// WithNetNSPath indicates an expected call of WithNetNSPath
+// WithNetNSPath indicates an expected call of WithNetNSPath.
 func (mr *MockNSMockRecorder) WithNetNSPath(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithNetNSPath", reflect.TypeOf((*MockNS)(nil).WithNetNSPath), arg0, arg1)

--- a/agent/utils/retry/mock/retry_mocks.go
+++ b/agent/utils/retry/mock/retry_mocks.go
@@ -25,30 +25,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockBackoff is a mock of Backoff interface
+// MockBackoff is a mock of Backoff interface.
 type MockBackoff struct {
 	ctrl     *gomock.Controller
 	recorder *MockBackoffMockRecorder
 }
 
-// MockBackoffMockRecorder is the mock recorder for MockBackoff
+// MockBackoffMockRecorder is the mock recorder for MockBackoff.
 type MockBackoffMockRecorder struct {
 	mock *MockBackoff
 }
 
-// NewMockBackoff creates a new mock instance
+// NewMockBackoff creates a new mock instance.
 func NewMockBackoff(ctrl *gomock.Controller) *MockBackoff {
 	mock := &MockBackoff{ctrl: ctrl}
 	mock.recorder = &MockBackoffMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockBackoff) EXPECT() *MockBackoffMockRecorder {
 	return m.recorder
 }
 
-// Duration mocks base method
+// Duration mocks base method.
 func (m *MockBackoff) Duration() time.Duration {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Duration")
@@ -56,19 +56,19 @@ func (m *MockBackoff) Duration() time.Duration {
 	return ret0
 }
 
-// Duration indicates an expected call of Duration
+// Duration indicates an expected call of Duration.
 func (mr *MockBackoffMockRecorder) Duration() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Duration", reflect.TypeOf((*MockBackoff)(nil).Duration))
 }
 
-// Reset mocks base method
+// Reset mocks base method.
 func (m *MockBackoff) Reset() {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Reset")
 }
 
-// Reset indicates an expected call of Reset
+// Reset indicates an expected call of Reset.
 func (mr *MockBackoffMockRecorder) Reset() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reset", reflect.TypeOf((*MockBackoff)(nil).Reset))

--- a/agent/utils/ttime/mocks/time_mocks.go
+++ b/agent/utils/ttime/mocks/time_mocks.go
@@ -26,30 +26,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockTime is a mock of Time interface
+// MockTime is a mock of Time interface.
 type MockTime struct {
 	ctrl     *gomock.Controller
 	recorder *MockTimeMockRecorder
 }
 
-// MockTimeMockRecorder is the mock recorder for MockTime
+// MockTimeMockRecorder is the mock recorder for MockTime.
 type MockTimeMockRecorder struct {
 	mock *MockTime
 }
 
-// NewMockTime creates a new mock instance
+// NewMockTime creates a new mock instance.
 func NewMockTime(ctrl *gomock.Controller) *MockTime {
 	mock := &MockTime{ctrl: ctrl}
 	mock.recorder = &MockTimeMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockTime) EXPECT() *MockTimeMockRecorder {
 	return m.recorder
 }
 
-// After mocks base method
+// After mocks base method.
 func (m *MockTime) After(arg0 time.Duration) <-chan time.Time {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "After", arg0)
@@ -57,13 +57,13 @@ func (m *MockTime) After(arg0 time.Duration) <-chan time.Time {
 	return ret0
 }
 
-// After indicates an expected call of After
+// After indicates an expected call of After.
 func (mr *MockTimeMockRecorder) After(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "After", reflect.TypeOf((*MockTime)(nil).After), arg0)
 }
 
-// AfterFunc mocks base method
+// AfterFunc mocks base method.
 func (m *MockTime) AfterFunc(arg0 time.Duration, arg1 func()) ttime.Timer {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AfterFunc", arg0, arg1)
@@ -71,13 +71,13 @@ func (m *MockTime) AfterFunc(arg0 time.Duration, arg1 func()) ttime.Timer {
 	return ret0
 }
 
-// AfterFunc indicates an expected call of AfterFunc
+// AfterFunc indicates an expected call of AfterFunc.
 func (mr *MockTimeMockRecorder) AfterFunc(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AfterFunc", reflect.TypeOf((*MockTime)(nil).AfterFunc), arg0, arg1)
 }
 
-// Now mocks base method
+// Now mocks base method.
 func (m *MockTime) Now() time.Time {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Now")
@@ -85,48 +85,48 @@ func (m *MockTime) Now() time.Time {
 	return ret0
 }
 
-// Now indicates an expected call of Now
+// Now indicates an expected call of Now.
 func (mr *MockTimeMockRecorder) Now() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Now", reflect.TypeOf((*MockTime)(nil).Now))
 }
 
-// Sleep mocks base method
+// Sleep mocks base method.
 func (m *MockTime) Sleep(arg0 time.Duration) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Sleep", arg0)
 }
 
-// Sleep indicates an expected call of Sleep
+// Sleep indicates an expected call of Sleep.
 func (mr *MockTimeMockRecorder) Sleep(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sleep", reflect.TypeOf((*MockTime)(nil).Sleep), arg0)
 }
 
-// MockTimer is a mock of Timer interface
+// MockTimer is a mock of Timer interface.
 type MockTimer struct {
 	ctrl     *gomock.Controller
 	recorder *MockTimerMockRecorder
 }
 
-// MockTimerMockRecorder is the mock recorder for MockTimer
+// MockTimerMockRecorder is the mock recorder for MockTimer.
 type MockTimerMockRecorder struct {
 	mock *MockTimer
 }
 
-// NewMockTimer creates a new mock instance
+// NewMockTimer creates a new mock instance.
 func NewMockTimer(ctrl *gomock.Controller) *MockTimer {
 	mock := &MockTimer{ctrl: ctrl}
 	mock.recorder = &MockTimerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockTimer) EXPECT() *MockTimerMockRecorder {
 	return m.recorder
 }
 
-// Reset mocks base method
+// Reset mocks base method.
 func (m *MockTimer) Reset(arg0 time.Duration) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Reset", arg0)
@@ -134,13 +134,13 @@ func (m *MockTimer) Reset(arg0 time.Duration) bool {
 	return ret0
 }
 
-// Reset indicates an expected call of Reset
+// Reset indicates an expected call of Reset.
 func (mr *MockTimerMockRecorder) Reset(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reset", reflect.TypeOf((*MockTimer)(nil).Reset), arg0)
 }
 
-// Stop mocks base method
+// Stop mocks base method.
 func (m *MockTimer) Stop() bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Stop")
@@ -148,7 +148,7 @@ func (m *MockTimer) Stop() bool {
 	return ret0
 }
 
-// Stop indicates an expected call of Stop
+// Stop indicates an expected call of Stop.
 func (mr *MockTimerMockRecorder) Stop() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockTimer)(nil).Stop))

--- a/agent/vendor/github.com/golang/mock/gomock/call.go
+++ b/agent/vendor/github.com/golang/mock/gomock/call.go
@@ -50,19 +50,22 @@ func newCall(t TestHelper, receiver interface{}, method string, methodType refle
 	t.Helper()
 
 	// TODO: check arity, types.
-	margs := make([]Matcher, len(args))
+	mArgs := make([]Matcher, len(args))
 	for i, arg := range args {
 		if m, ok := arg.(Matcher); ok {
-			margs[i] = m
+			mArgs[i] = m
 		} else if arg == nil {
 			// Handle nil specially so that passing a nil interface value
 			// will match the typed nils of concrete args.
-			margs[i] = Nil()
+			mArgs[i] = Nil()
 		} else {
-			margs[i] = Eq(arg)
+			mArgs[i] = Eq(arg)
 		}
 	}
 
+	// callerInfo's skip should be updated if the number of calls between the user's test
+	// and this line changes, i.e. this code is wrapped in another anonymous function.
+	// 0 is us, 1 is RecordCallWithMethodType(), 2 is the generated recorder, and 3 is the user's test.
 	origin := callerInfo(3)
 	actions := []func([]interface{}) []interface{}{func([]interface{}) []interface{} {
 		// Synthesize the zero value for each of the return args' types.
@@ -73,7 +76,7 @@ func newCall(t TestHelper, receiver interface{}, method string, methodType refle
 		return rets
 	}}
 	return &Call{t: t, receiver: receiver, method: method, methodType: methodType,
-		args: margs, origin: origin, minCalls: 1, maxCalls: 1, actions: actions}
+		args: mArgs, origin: origin, minCalls: 1, maxCalls: 1, actions: actions}
 }
 
 // AnyTimes allows the expectation to be called 0 or more times
@@ -110,19 +113,25 @@ func (c *Call) DoAndReturn(f interface{}) *Call {
 	v := reflect.ValueOf(f)
 
 	c.addAction(func(args []interface{}) []interface{} {
-		vargs := make([]reflect.Value, len(args))
+		c.t.Helper()
+		vArgs := make([]reflect.Value, len(args))
 		ft := v.Type()
+		if c.methodType.NumIn() != ft.NumIn() {
+			c.t.Fatalf("wrong number of arguments in DoAndReturn func for %T.%v: got %d, want %d [%s]",
+				c.receiver, c.method, ft.NumIn(), c.methodType.NumIn(), c.origin)
+			return nil
+		}
 		for i := 0; i < len(args); i++ {
 			if args[i] != nil {
-				vargs[i] = reflect.ValueOf(args[i])
+				vArgs[i] = reflect.ValueOf(args[i])
 			} else {
 				// Use the zero value for the arg.
-				vargs[i] = reflect.Zero(ft.In(i))
+				vArgs[i] = reflect.Zero(ft.In(i))
 			}
 		}
-		vrets := v.Call(vargs)
-		rets := make([]interface{}, len(vrets))
-		for i, ret := range vrets {
+		vRets := v.Call(vArgs)
+		rets := make([]interface{}, len(vRets))
+		for i, ret := range vRets {
 			rets[i] = ret.Interface()
 		}
 		return rets
@@ -139,17 +148,23 @@ func (c *Call) Do(f interface{}) *Call {
 	v := reflect.ValueOf(f)
 
 	c.addAction(func(args []interface{}) []interface{} {
-		vargs := make([]reflect.Value, len(args))
+		c.t.Helper()
+		if c.methodType.NumIn() != v.Type().NumIn() {
+			c.t.Fatalf("wrong number of arguments in Do func for %T.%v: got %d, want %d [%s]",
+				c.receiver, c.method, v.Type().NumIn(), c.methodType.NumIn(), c.origin)
+			return nil
+		}
+		vArgs := make([]reflect.Value, len(args))
 		ft := v.Type()
 		for i := 0; i < len(args); i++ {
 			if args[i] != nil {
-				vargs[i] = reflect.ValueOf(args[i])
+				vArgs[i] = reflect.ValueOf(args[i])
 			} else {
 				// Use the zero value for the arg.
-				vargs[i] = reflect.Zero(ft.In(i))
+				vArgs[i] = reflect.Zero(ft.In(i))
 			}
 		}
-		v.Call(vargs)
+		v.Call(vArgs)
 		return nil
 	})
 	return c
@@ -301,14 +316,9 @@ func (c *Call) matches(args []interface{}) error {
 
 		for i, m := range c.args {
 			if !m.Matches(args[i]) {
-				got := fmt.Sprintf("%v", args[i])
-				if gs, ok := m.(GotFormatter); ok {
-					got = gs.Got(args[i])
-				}
-
 				return fmt.Errorf(
 					"expected call at %s doesn't match the argument at index %d.\nGot: %v\nWant: %v",
-					c.origin, i, got, m,
+					c.origin, i, formatGottenArg(m, args[i]), m,
 				)
 			}
 		}
@@ -331,7 +341,7 @@ func (c *Call) matches(args []interface{}) error {
 				// Non-variadic args
 				if !m.Matches(args[i]) {
 					return fmt.Errorf("expected call at %s doesn't match the argument at index %s.\nGot: %v\nWant: %v",
-						c.origin, strconv.Itoa(i), args[i], m)
+						c.origin, strconv.Itoa(i), formatGottenArg(m, args[i]), m)
 				}
 				continue
 			}
@@ -355,12 +365,12 @@ func (c *Call) matches(args []interface{}) error {
 			// matches all the remaining arguments or the lack of any.
 			// Convert the remaining arguments, if any, into a slice of the
 			// expected type.
-			vargsType := c.methodType.In(c.methodType.NumIn() - 1)
-			vargs := reflect.MakeSlice(vargsType, 0, len(args)-i)
+			vArgsType := c.methodType.In(c.methodType.NumIn() - 1)
+			vArgs := reflect.MakeSlice(vArgsType, 0, len(args)-i)
 			for _, arg := range args[i:] {
-				vargs = reflect.Append(vargs, reflect.ValueOf(arg))
+				vArgs = reflect.Append(vArgs, reflect.ValueOf(arg))
 			}
-			if m.Matches(vargs.Interface()) {
+			if m.Matches(vArgs.Interface()) {
 				// Got Foo(a, b, c, d, e) want Foo(matcherA, matcherB, gomock.Any())
 				// Got Foo(a, b, c, d, e) want Foo(matcherA, matcherB, someSliceMatcher)
 				// Got Foo(a, b) want Foo(matcherA, matcherB, gomock.Any())
@@ -373,16 +383,16 @@ func (c *Call) matches(args []interface{}) error {
 			// Got Foo(a, b, c, d) want Foo(matcherA, matcherB, matcherC, matcherD, matcherE)
 			// Got Foo(a, b, c, d, e) want Foo(matcherA, matcherB, matcherC, matcherD)
 			// Got Foo(a, b, c) want Foo(matcherA, matcherB)
-			return fmt.Errorf("Expected call at %s doesn't match the argument at index %s.\nGot: %v\nWant: %v",
-				c.origin, strconv.Itoa(i), args[i:], c.args[i])
 
+			return fmt.Errorf("expected call at %s doesn't match the argument at index %s.\nGot: %v\nWant: %v",
+				c.origin, strconv.Itoa(i), formatGottenArg(m, args[i:]), c.args[i])
 		}
 	}
 
 	// Check that all prerequisite calls have been satisfied.
 	for _, preReqCall := range c.preReqs {
 		if !preReqCall.satisfied() {
-			return fmt.Errorf("Expected call at %s doesn't have a prerequisite call satisfied:\n%v\nshould be called before:\n%v",
+			return fmt.Errorf("expected call at %s doesn't have a prerequisite call satisfied:\n%v\nshould be called before:\n%v",
 				c.origin, preReqCall, c)
 		}
 	}
@@ -424,4 +434,12 @@ func setSlice(arg interface{}, v reflect.Value) {
 
 func (c *Call) addAction(action func([]interface{}) []interface{}) {
 	c.actions = append(c.actions, action)
+}
+
+func formatGottenArg(m Matcher, arg interface{}) string {
+	got := fmt.Sprintf("%v (%T)", arg, arg)
+	if gs, ok := m.(GotFormatter); ok {
+		got = gs.Got(arg)
+	}
+	return got
 }

--- a/agent/vendor/github.com/golang/mock/gomock/callset.go
+++ b/agent/vendor/github.com/golang/mock/gomock/callset.go
@@ -16,6 +16,7 @@ package gomock
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 )
 
@@ -84,14 +85,18 @@ func (cs callSet) FindMatch(receiver interface{}, method string, args []interfac
 	for _, call := range exhausted {
 		if err := call.matches(args); err != nil {
 			_, _ = fmt.Fprintf(&callsErrors, "\n%v", err)
+			continue
 		}
+		_, _ = fmt.Fprintf(
+			&callsErrors, "all expected calls for method %q have been exhausted", method,
+		)
 	}
 
 	if len(expected)+len(exhausted) == 0 {
 		_, _ = fmt.Fprintf(&callsErrors, "there are no expected calls of the method %q for that receiver", method)
 	}
 
-	return nil, fmt.Errorf(callsErrors.String())
+	return nil, errors.New(callsErrors.String())
 }
 
 // Failures returns the calls that are not satisfied.

--- a/agent/vendor/github.com/golang/mock/gomock/controller.go
+++ b/agent/vendor/github.com/golang/mock/gomock/controller.go
@@ -50,9 +50,6 @@
 //         mockObj.EXPECT().SomeMethod(2, "second"),
 //         mockObj.EXPECT().SomeMethod(3, "third"),
 //     )
-//
-// TODO:
-//	- Handle different argument/return types (e.g. ..., chan, map, interface).
 package gomock
 
 import (
@@ -75,6 +72,15 @@ type TestReporter interface {
 type TestHelper interface {
 	TestReporter
 	Helper()
+}
+
+// cleanuper is used to check if TestHelper also has the `Cleanup` method. A
+// common pattern is to pass in a `*testing.T` to
+// `NewController(t TestReporter)`. In Go 1.14+, `*testing.T` has a cleanup
+// method. This can be utilized to call `Finish()` so the caller of this library
+// does not have to.
+type cleanuper interface {
+	Cleanup(func())
 }
 
 // A Controller represents the top-level control of a mock ecosystem.  It
@@ -115,29 +121,43 @@ type Controller struct {
 
 // NewController returns a new Controller. It is the preferred way to create a
 // Controller.
+//
+// New in go1.14+, if you are passing a *testing.T into this function you no
+// longer need to call ctrl.Finish() in your test methods.
 func NewController(t TestReporter) *Controller {
 	h, ok := t.(TestHelper)
 	if !ok {
-		h = nopTestHelper{t}
+		h = &nopTestHelper{t}
 	}
-
-	return &Controller{
+	ctrl := &Controller{
 		T:             h,
 		expectedCalls: newCallSet(),
 	}
+	if c, ok := isCleanuper(ctrl.T); ok {
+		c.Cleanup(func() {
+			ctrl.T.Helper()
+			ctrl.finish(true, nil)
+		})
+	}
+
+	return ctrl
 }
 
 type cancelReporter struct {
-	TestHelper
+	t      TestHelper
 	cancel func()
 }
 
 func (r *cancelReporter) Errorf(format string, args ...interface{}) {
-	r.TestHelper.Errorf(format, args...)
+	r.t.Errorf(format, args...)
 }
 func (r *cancelReporter) Fatalf(format string, args ...interface{}) {
 	defer r.cancel()
-	r.TestHelper.Fatalf(format, args...)
+	r.t.Fatalf(format, args...)
+}
+
+func (r *cancelReporter) Helper() {
+	r.t.Helper()
 }
 
 // WithContext returns a new Controller and a Context, which is cancelled on any
@@ -145,15 +165,22 @@ func (r *cancelReporter) Fatalf(format string, args ...interface{}) {
 func WithContext(ctx context.Context, t TestReporter) (*Controller, context.Context) {
 	h, ok := t.(TestHelper)
 	if !ok {
-		h = nopTestHelper{t}
+		h = &nopTestHelper{t: t}
 	}
 
 	ctx, cancel := context.WithCancel(ctx)
-	return NewController(&cancelReporter{h, cancel}), ctx
+	return NewController(&cancelReporter{t: h, cancel: cancel}), ctx
 }
 
 type nopTestHelper struct {
-	TestReporter
+	t TestReporter
+}
+
+func (h *nopTestHelper) Errorf(format string, args ...interface{}) {
+	h.t.Errorf(format, args...)
+}
+func (h *nopTestHelper) Fatalf(format string, args ...interface{}) {
+	h.t.Fatalf(format, args...)
 }
 
 func (h nopTestHelper) Helper() {}
@@ -197,7 +224,10 @@ func (ctrl *Controller) Call(receiver interface{}, method string, args ...interf
 
 		expected, err := ctrl.expectedCalls.FindMatch(receiver, method, args)
 		if err != nil {
-			origin := callerInfo(2)
+			// callerInfo's skip should be updated if the number of calls between the user's test
+			// and this line changes, i.e. this code is wrapped in another anonymous function.
+			// 0 is us, 1 is controller.Call(), 2 is the generated mock, and 3 is the user's test.
+			origin := callerInfo(3)
 			ctrl.T.Fatalf("Unexpected call to %T.%v(%v) at %s because: %s", receiver, method, args, origin, err)
 		}
 
@@ -229,21 +259,33 @@ func (ctrl *Controller) Call(receiver interface{}, method string, args ...interf
 // Finish checks to see if all the methods that were expected to be called
 // were called. It should be invoked for each Controller. It is not idempotent
 // and therefore can only be invoked once.
+//
+// New in go1.14+, if you are passing a *testing.T into NewController function you no
+// longer need to call ctrl.Finish() in your test methods.
 func (ctrl *Controller) Finish() {
+	// If we're currently panicking, probably because this is a deferred call.
+	// This must be recovered in the deferred function.
+	err := recover()
+	ctrl.finish(false, err)
+}
+
+func (ctrl *Controller) finish(cleanup bool, panicErr interface{}) {
 	ctrl.T.Helper()
 
 	ctrl.mu.Lock()
 	defer ctrl.mu.Unlock()
 
 	if ctrl.finished {
-		ctrl.T.Fatalf("Controller.Finish was called more than once. It has to be called exactly once.")
+		if _, ok := isCleanuper(ctrl.T); !ok {
+			ctrl.T.Fatalf("Controller.Finish was called more than once. It has to be called exactly once.")
+		}
+		return
 	}
 	ctrl.finished = true
 
-	// If we're currently panicking, probably because this is a deferred call,
-	// pass through the panic.
-	if err := recover(); err != nil {
-		panic(err)
+	// Short-circuit, pass through the panic.
+	if panicErr != nil {
+		panic(panicErr)
 	}
 
 	// Check that all remaining expected calls are satisfied.
@@ -252,13 +294,43 @@ func (ctrl *Controller) Finish() {
 		ctrl.T.Errorf("missing call(s) to %v", call)
 	}
 	if len(failures) != 0 {
-		ctrl.T.Fatalf("aborting test due to missing call(s)")
+		if !cleanup {
+			ctrl.T.Fatalf("aborting test due to missing call(s)")
+			return
+		}
+		ctrl.T.Errorf("aborting test due to missing call(s)")
 	}
 }
 
+// callerInfo returns the file:line of the call site. skip is the number
+// of stack frames to skip when reporting. 0 is callerInfo's call site.
 func callerInfo(skip int) string {
 	if _, file, line, ok := runtime.Caller(skip + 1); ok {
 		return fmt.Sprintf("%s:%d", file, line)
 	}
 	return "unknown file"
+}
+
+// isCleanuper checks it if t's base TestReporter has a Cleanup method.
+func isCleanuper(t TestReporter) (cleanuper, bool) {
+	tr := unwrapTestReporter(t)
+	c, ok := tr.(cleanuper)
+	return c, ok
+}
+
+// unwrapTestReporter unwraps TestReporter to the base implementation.
+func unwrapTestReporter(t TestReporter) TestReporter {
+	tr := t
+	switch nt := t.(type) {
+	case *cancelReporter:
+		tr = nt.t
+		if h, check := tr.(*nopTestHelper); check {
+			tr = h.t
+		}
+	case *nopTestHelper:
+		tr = nt.t
+	default:
+		// not wrapped
+	}
+	return tr
 }

--- a/agent/vendor/github.com/golang/mock/mockgen/model/model.go
+++ b/agent/vendor/github.com/golang/mock/mockgen/model/model.go
@@ -71,6 +71,16 @@ func (intf *Interface) addImports(im map[string]bool) {
 	}
 }
 
+// AddMethod adds a new method, de-duplicating by method name.
+func (intf *Interface) AddMethod(m *Method) {
+	for _, me := range intf.Methods {
+		if me.Name == m.Name {
+			return
+		}
+	}
+	intf.Methods = append(intf.Methods, m)
+}
+
 // Method is a single method of an interface.
 type Method struct {
 	Name     string
@@ -250,11 +260,10 @@ func (mt *MapType) addImports(im map[string]bool) {
 // NamedType is an exported type in a package.
 type NamedType struct {
 	Package string // may be empty
-	Type    string // TODO: should this be typed Type?
+	Type    string
 }
 
 func (nt *NamedType) String(pm map[string]string, pkgOverride string) string {
-	// TODO: is this right?
 	if pkgOverride == nt.Package {
 		return nt.Type
 	}
@@ -311,7 +320,7 @@ func InterfaceFromInterfaceType(it reflect.Type) (*Interface, error) {
 			return nil, err
 		}
 
-		intf.Methods = append(intf.Methods, m)
+		intf.AddMethod(m)
 	}
 
 	return intf, nil
@@ -467,4 +476,20 @@ func impPath(imp string) string {
 		imp = imp[i+len("/vendor/"):]
 	}
 	return imp
+}
+
+// ErrorInterface represent built-in error interface.
+var ErrorInterface = Interface{
+	Name: "error",
+	Methods: []*Method{
+		{
+			Name: "Error",
+			Out: []*Parameter{
+				{
+					Name: "",
+					Type: PredeclaredType("string"),
+				},
+			},
+		},
+	},
 }

--- a/agent/wsclient/mock/client.go
+++ b/agent/wsclient/mock/client.go
@@ -27,42 +27,42 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockClientServer is a mock of ClientServer interface
+// MockClientServer is a mock of ClientServer interface.
 type MockClientServer struct {
 	ctrl     *gomock.Controller
 	recorder *MockClientServerMockRecorder
 }
 
-// MockClientServerMockRecorder is the mock recorder for MockClientServer
+// MockClientServerMockRecorder is the mock recorder for MockClientServer.
 type MockClientServerMockRecorder struct {
 	mock *MockClientServer
 }
 
-// NewMockClientServer creates a new mock instance
+// NewMockClientServer creates a new mock instance.
 func NewMockClientServer(ctrl *gomock.Controller) *MockClientServer {
 	mock := &MockClientServer{ctrl: ctrl}
 	mock.recorder = &MockClientServerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockClientServer) EXPECT() *MockClientServerMockRecorder {
 	return m.recorder
 }
 
-// AddRequestHandler mocks base method
+// AddRequestHandler mocks base method.
 func (m *MockClientServer) AddRequestHandler(arg0 wsclient.RequestHandler) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AddRequestHandler", arg0)
 }
 
-// AddRequestHandler indicates an expected call of AddRequestHandler
+// AddRequestHandler indicates an expected call of AddRequestHandler.
 func (mr *MockClientServerMockRecorder) AddRequestHandler(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddRequestHandler", reflect.TypeOf((*MockClientServer)(nil).AddRequestHandler), arg0)
 }
 
-// Close mocks base method
+// Close mocks base method.
 func (m *MockClientServer) Close() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Close")
@@ -70,13 +70,13 @@ func (m *MockClientServer) Close() error {
 	return ret0
 }
 
-// Close indicates an expected call of Close
+// Close indicates an expected call of Close.
 func (mr *MockClientServerMockRecorder) Close() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockClientServer)(nil).Close))
 }
 
-// Connect mocks base method
+// Connect mocks base method.
 func (m *MockClientServer) Connect() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Connect")
@@ -84,13 +84,13 @@ func (m *MockClientServer) Connect() error {
 	return ret0
 }
 
-// Connect indicates an expected call of Connect
+// Connect indicates an expected call of Connect.
 func (mr *MockClientServerMockRecorder) Connect() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Connect", reflect.TypeOf((*MockClientServer)(nil).Connect))
 }
 
-// Disconnect mocks base method
+// Disconnect mocks base method.
 func (m *MockClientServer) Disconnect(arg0 ...interface{}) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{}
@@ -102,13 +102,13 @@ func (m *MockClientServer) Disconnect(arg0 ...interface{}) error {
 	return ret0
 }
 
-// Disconnect indicates an expected call of Disconnect
+// Disconnect indicates an expected call of Disconnect.
 func (mr *MockClientServerMockRecorder) Disconnect(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Disconnect", reflect.TypeOf((*MockClientServer)(nil).Disconnect), arg0...)
 }
 
-// IsConnected mocks base method
+// IsConnected mocks base method.
 func (m *MockClientServer) IsConnected() bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsConnected")
@@ -116,13 +116,13 @@ func (m *MockClientServer) IsConnected() bool {
 	return ret0
 }
 
-// IsConnected indicates an expected call of IsConnected
+// IsConnected indicates an expected call of IsConnected.
 func (mr *MockClientServerMockRecorder) IsConnected() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsConnected", reflect.TypeOf((*MockClientServer)(nil).IsConnected))
 }
 
-// MakeRequest mocks base method
+// MakeRequest mocks base method.
 func (m *MockClientServer) MakeRequest(arg0 interface{}) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MakeRequest", arg0)
@@ -130,13 +130,13 @@ func (m *MockClientServer) MakeRequest(arg0 interface{}) error {
 	return ret0
 }
 
-// MakeRequest indicates an expected call of MakeRequest
+// MakeRequest indicates an expected call of MakeRequest.
 func (mr *MockClientServerMockRecorder) MakeRequest(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeRequest", reflect.TypeOf((*MockClientServer)(nil).MakeRequest), arg0)
 }
 
-// Serve mocks base method
+// Serve mocks base method.
 func (m *MockClientServer) Serve() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Serve")
@@ -144,37 +144,37 @@ func (m *MockClientServer) Serve() error {
 	return ret0
 }
 
-// Serve indicates an expected call of Serve
+// Serve indicates an expected call of Serve.
 func (mr *MockClientServerMockRecorder) Serve() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Serve", reflect.TypeOf((*MockClientServer)(nil).Serve))
 }
 
-// SetAnyRequestHandler mocks base method
+// SetAnyRequestHandler mocks base method.
 func (m *MockClientServer) SetAnyRequestHandler(arg0 wsclient.RequestHandler) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetAnyRequestHandler", arg0)
 }
 
-// SetAnyRequestHandler indicates an expected call of SetAnyRequestHandler
+// SetAnyRequestHandler indicates an expected call of SetAnyRequestHandler.
 func (mr *MockClientServerMockRecorder) SetAnyRequestHandler(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAnyRequestHandler", reflect.TypeOf((*MockClientServer)(nil).SetAnyRequestHandler), arg0)
 }
 
-// SetConnection mocks base method
+// SetConnection mocks base method.
 func (m *MockClientServer) SetConnection(arg0 wsconn.WebsocketConn) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetConnection", arg0)
 }
 
-// SetConnection indicates an expected call of SetConnection
+// SetConnection indicates an expected call of SetConnection.
 func (mr *MockClientServerMockRecorder) SetConnection(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConnection", reflect.TypeOf((*MockClientServer)(nil).SetConnection), arg0)
 }
 
-// SetReadDeadline mocks base method
+// SetReadDeadline mocks base method.
 func (m *MockClientServer) SetReadDeadline(arg0 time.Time) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetReadDeadline", arg0)
@@ -182,13 +182,13 @@ func (m *MockClientServer) SetReadDeadline(arg0 time.Time) error {
 	return ret0
 }
 
-// SetReadDeadline indicates an expected call of SetReadDeadline
+// SetReadDeadline indicates an expected call of SetReadDeadline.
 func (mr *MockClientServerMockRecorder) SetReadDeadline(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetReadDeadline", reflect.TypeOf((*MockClientServer)(nil).SetReadDeadline), arg0)
 }
 
-// WriteCloseMessage mocks base method
+// WriteCloseMessage mocks base method.
 func (m *MockClientServer) WriteCloseMessage() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WriteCloseMessage")
@@ -196,13 +196,13 @@ func (m *MockClientServer) WriteCloseMessage() error {
 	return ret0
 }
 
-// WriteCloseMessage indicates an expected call of WriteCloseMessage
+// WriteCloseMessage indicates an expected call of WriteCloseMessage.
 func (mr *MockClientServerMockRecorder) WriteCloseMessage() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteCloseMessage", reflect.TypeOf((*MockClientServer)(nil).WriteCloseMessage))
 }
 
-// WriteMessage mocks base method
+// WriteMessage mocks base method.
 func (m *MockClientServer) WriteMessage(arg0 []byte) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WriteMessage", arg0)
@@ -210,7 +210,7 @@ func (m *MockClientServer) WriteMessage(arg0 []byte) error {
 	return ret0
 }
 
-// WriteMessage indicates an expected call of WriteMessage
+// WriteMessage indicates an expected call of WriteMessage.
 func (mr *MockClientServerMockRecorder) WriteMessage(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteMessage", reflect.TypeOf((*MockClientServer)(nil).WriteMessage), arg0)

--- a/agent/wsclient/wsconn/mock/conn.go
+++ b/agent/wsclient/wsconn/mock/conn.go
@@ -25,30 +25,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockWebsocketConn is a mock of WebsocketConn interface
+// MockWebsocketConn is a mock of WebsocketConn interface.
 type MockWebsocketConn struct {
 	ctrl     *gomock.Controller
 	recorder *MockWebsocketConnMockRecorder
 }
 
-// MockWebsocketConnMockRecorder is the mock recorder for MockWebsocketConn
+// MockWebsocketConnMockRecorder is the mock recorder for MockWebsocketConn.
 type MockWebsocketConnMockRecorder struct {
 	mock *MockWebsocketConn
 }
 
-// NewMockWebsocketConn creates a new mock instance
+// NewMockWebsocketConn creates a new mock instance.
 func NewMockWebsocketConn(ctrl *gomock.Controller) *MockWebsocketConn {
 	mock := &MockWebsocketConn{ctrl: ctrl}
 	mock.recorder = &MockWebsocketConnMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockWebsocketConn) EXPECT() *MockWebsocketConnMockRecorder {
 	return m.recorder
 }
 
-// Close mocks base method
+// Close mocks base method.
 func (m *MockWebsocketConn) Close() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Close")
@@ -56,13 +56,13 @@ func (m *MockWebsocketConn) Close() error {
 	return ret0
 }
 
-// Close indicates an expected call of Close
+// Close indicates an expected call of Close.
 func (mr *MockWebsocketConnMockRecorder) Close() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockWebsocketConn)(nil).Close))
 }
 
-// ReadMessage mocks base method
+// ReadMessage mocks base method.
 func (m *MockWebsocketConn) ReadMessage() (int, []byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReadMessage")
@@ -72,13 +72,13 @@ func (m *MockWebsocketConn) ReadMessage() (int, []byte, error) {
 	return ret0, ret1, ret2
 }
 
-// ReadMessage indicates an expected call of ReadMessage
+// ReadMessage indicates an expected call of ReadMessage.
 func (mr *MockWebsocketConnMockRecorder) ReadMessage() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadMessage", reflect.TypeOf((*MockWebsocketConn)(nil).ReadMessage))
 }
 
-// SetReadDeadline mocks base method
+// SetReadDeadline mocks base method.
 func (m *MockWebsocketConn) SetReadDeadline(arg0 time.Time) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetReadDeadline", arg0)
@@ -86,13 +86,13 @@ func (m *MockWebsocketConn) SetReadDeadline(arg0 time.Time) error {
 	return ret0
 }
 
-// SetReadDeadline indicates an expected call of SetReadDeadline
+// SetReadDeadline indicates an expected call of SetReadDeadline.
 func (mr *MockWebsocketConnMockRecorder) SetReadDeadline(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetReadDeadline", reflect.TypeOf((*MockWebsocketConn)(nil).SetReadDeadline), arg0)
 }
 
-// SetWriteDeadline mocks base method
+// SetWriteDeadline mocks base method.
 func (m *MockWebsocketConn) SetWriteDeadline(arg0 time.Time) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetWriteDeadline", arg0)
@@ -100,13 +100,13 @@ func (m *MockWebsocketConn) SetWriteDeadline(arg0 time.Time) error {
 	return ret0
 }
 
-// SetWriteDeadline indicates an expected call of SetWriteDeadline
+// SetWriteDeadline indicates an expected call of SetWriteDeadline.
 func (mr *MockWebsocketConnMockRecorder) SetWriteDeadline(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetWriteDeadline", reflect.TypeOf((*MockWebsocketConn)(nil).SetWriteDeadline), arg0)
 }
 
-// WriteControl mocks base method
+// WriteControl mocks base method.
 func (m *MockWebsocketConn) WriteControl(arg0 int, arg1 []byte, arg2 time.Time) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WriteControl", arg0, arg1, arg2)
@@ -114,13 +114,13 @@ func (m *MockWebsocketConn) WriteControl(arg0 int, arg1 []byte, arg2 time.Time) 
 	return ret0
 }
 
-// WriteControl indicates an expected call of WriteControl
+// WriteControl indicates an expected call of WriteControl.
 func (mr *MockWebsocketConnMockRecorder) WriteControl(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteControl", reflect.TypeOf((*MockWebsocketConn)(nil).WriteControl), arg0, arg1, arg2)
 }
 
-// WriteMessage mocks base method
+// WriteMessage mocks base method.
 func (m *MockWebsocketConn) WriteMessage(arg0 int, arg1 []byte) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WriteMessage", arg0, arg1)
@@ -128,7 +128,7 @@ func (m *MockWebsocketConn) WriteMessage(arg0 int, arg1 []byte) error {
 	return ret0
 }
 
-// WriteMessage indicates an expected call of WriteMessage
+// WriteMessage indicates an expected call of WriteMessage.
 func (mr *MockWebsocketConnMockRecorder) WriteMessage(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteMessage", reflect.TypeOf((*MockWebsocketConn)(nil).WriteMessage), arg0, arg1)

--- a/ecs-init/cache/dependencies_mocks.go
+++ b/ecs-init/cache/dependencies_mocks.go
@@ -27,30 +27,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// Mocks3API is a mock of s3API interface
+// Mocks3API is a mock of s3API interface.
 type Mocks3API struct {
 	ctrl     *gomock.Controller
 	recorder *Mocks3APIMockRecorder
 }
 
-// Mocks3APIMockRecorder is the mock recorder for Mocks3API
+// Mocks3APIMockRecorder is the mock recorder for Mocks3API.
 type Mocks3APIMockRecorder struct {
 	mock *Mocks3API
 }
 
-// NewMocks3API creates a new mock instance
+// NewMocks3API creates a new mock instance.
 func NewMocks3API(ctrl *gomock.Controller) *Mocks3API {
 	mock := &Mocks3API{ctrl: ctrl}
 	mock.recorder = &Mocks3APIMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *Mocks3API) EXPECT() *Mocks3APIMockRecorder {
 	return m.recorder
 }
 
-// Download mocks base method
+// Download mocks base method.
 func (m *Mocks3API) Download(w io.WriterAt, input *s3.GetObjectInput, options ...func(*s3manager.Downloader)) (int64, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{w, input}
@@ -63,49 +63,49 @@ func (m *Mocks3API) Download(w io.WriterAt, input *s3.GetObjectInput, options ..
 	return ret0, ret1
 }
 
-// Download indicates an expected call of Download
+// Download indicates an expected call of Download.
 func (mr *Mocks3APIMockRecorder) Download(w, input interface{}, options ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{w, input}, options...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Download", reflect.TypeOf((*Mocks3API)(nil).Download), varargs...)
 }
 
-// Mocks3DownloaderAPI is a mock of s3DownloaderAPI interface
+// Mocks3DownloaderAPI is a mock of s3DownloaderAPI interface.
 type Mocks3DownloaderAPI struct {
 	ctrl     *gomock.Controller
 	recorder *Mocks3DownloaderAPIMockRecorder
 }
 
-// Mocks3DownloaderAPIMockRecorder is the mock recorder for Mocks3DownloaderAPI
+// Mocks3DownloaderAPIMockRecorder is the mock recorder for Mocks3DownloaderAPI.
 type Mocks3DownloaderAPIMockRecorder struct {
 	mock *Mocks3DownloaderAPI
 }
 
-// NewMocks3DownloaderAPI creates a new mock instance
+// NewMocks3DownloaderAPI creates a new mock instance.
 func NewMocks3DownloaderAPI(ctrl *gomock.Controller) *Mocks3DownloaderAPI {
 	mock := &Mocks3DownloaderAPI{ctrl: ctrl}
 	mock.recorder = &Mocks3DownloaderAPIMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *Mocks3DownloaderAPI) EXPECT() *Mocks3DownloaderAPIMockRecorder {
 	return m.recorder
 }
 
-// addBucketDownloader mocks base method
+// addBucketDownloader mocks base method.
 func (m *Mocks3DownloaderAPI) addBucketDownloader(bucketDownloader *s3BucketDownloader) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "addBucketDownloader", bucketDownloader)
 }
 
-// addBucketDownloader indicates an expected call of addBucketDownloader
+// addBucketDownloader indicates an expected call of addBucketDownloader.
 func (mr *Mocks3DownloaderAPIMockRecorder) addBucketDownloader(bucketDownloader interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "addBucketDownloader", reflect.TypeOf((*Mocks3DownloaderAPI)(nil).addBucketDownloader), bucketDownloader)
 }
 
-// downloadFile mocks base method
+// downloadFile mocks base method.
 func (m *Mocks3DownloaderAPI) downloadFile(fileName string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "downloadFile", fileName)
@@ -114,91 +114,50 @@ func (m *Mocks3DownloaderAPI) downloadFile(fileName string) (string, error) {
 	return ret0, ret1
 }
 
-// downloadFile indicates an expected call of downloadFile
+// downloadFile indicates an expected call of downloadFile.
 func (mr *Mocks3DownloaderAPIMockRecorder) downloadFile(fileName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "downloadFile", reflect.TypeOf((*Mocks3DownloaderAPI)(nil).downloadFile), fileName)
 }
 
-// MockfileSystem is a mock of fileSystem interface
+// MockfileSystem is a mock of fileSystem interface.
 type MockfileSystem struct {
 	ctrl     *gomock.Controller
 	recorder *MockfileSystemMockRecorder
 }
 
-// MockfileSystemMockRecorder is the mock recorder for MockfileSystem
+// MockfileSystemMockRecorder is the mock recorder for MockfileSystem.
 type MockfileSystemMockRecorder struct {
 	mock *MockfileSystem
 }
 
-// NewMockfileSystem creates a new mock instance
+// NewMockfileSystem creates a new mock instance.
 func NewMockfileSystem(ctrl *gomock.Controller) *MockfileSystem {
 	mock := &MockfileSystem{ctrl: ctrl}
 	mock.recorder = &MockfileSystemMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockfileSystem) EXPECT() *MockfileSystemMockRecorder {
 	return m.recorder
 }
 
-// MkdirAll mocks base method
-func (m *MockfileSystem) MkdirAll(path string, perm os.FileMode) error {
+// Base mocks base method.
+func (m *MockfileSystem) Base(path string) string {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MkdirAll", path, perm)
-	ret0, _ := ret[0].(error)
+	ret := m.ctrl.Call(m, "Base", path)
+	ret0, _ := ret[0].(string)
 	return ret0
 }
 
-// MkdirAll indicates an expected call of MkdirAll
-func (mr *MockfileSystemMockRecorder) MkdirAll(path, perm interface{}) *gomock.Call {
+// Base indicates an expected call of Base.
+func (mr *MockfileSystemMockRecorder) Base(path interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MkdirAll", reflect.TypeOf((*MockfileSystem)(nil).MkdirAll), path, perm)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Base", reflect.TypeOf((*MockfileSystem)(nil).Base), path)
 }
 
-// TempFile mocks base method
-func (m *MockfileSystem) TempFile(dir, prefix string) (*os.File, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TempFile", dir, prefix)
-	ret0, _ := ret[0].(*os.File)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// TempFile indicates an expected call of TempFile
-func (mr *MockfileSystemMockRecorder) TempFile(dir, prefix interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TempFile", reflect.TypeOf((*MockfileSystem)(nil).TempFile), dir, prefix)
-}
-
-// Remove mocks base method
-func (m *MockfileSystem) Remove(path string) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Remove", path)
-}
-
-// Remove indicates an expected call of Remove
-func (mr *MockfileSystemMockRecorder) Remove(path interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Remove", reflect.TypeOf((*MockfileSystem)(nil).Remove), path)
-}
-
-// TeeReader mocks base method
-func (m *MockfileSystem) TeeReader(r io.Reader, w io.Writer) io.Reader {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TeeReader", r, w)
-	ret0, _ := ret[0].(io.Reader)
-	return ret0
-}
-
-// TeeReader indicates an expected call of TeeReader
-func (mr *MockfileSystemMockRecorder) TeeReader(r, w interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TeeReader", reflect.TypeOf((*MockfileSystem)(nil).TeeReader), r, w)
-}
-
-// Copy mocks base method
+// Copy mocks base method.
 func (m *MockfileSystem) Copy(dst io.Writer, src io.Reader) (int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Copy", dst, src)
@@ -207,42 +166,27 @@ func (m *MockfileSystem) Copy(dst io.Writer, src io.Reader) (int64, error) {
 	return ret0, ret1
 }
 
-// Copy indicates an expected call of Copy
+// Copy indicates an expected call of Copy.
 func (mr *MockfileSystemMockRecorder) Copy(dst, src interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Copy", reflect.TypeOf((*MockfileSystem)(nil).Copy), dst, src)
 }
 
-// Rename mocks base method
-func (m *MockfileSystem) Rename(oldpath, newpath string) error {
+// MkdirAll mocks base method.
+func (m *MockfileSystem) MkdirAll(path string, perm os.FileMode) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Rename", oldpath, newpath)
+	ret := m.ctrl.Call(m, "MkdirAll", path, perm)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// Rename indicates an expected call of Rename
-func (mr *MockfileSystemMockRecorder) Rename(oldpath, newpath interface{}) *gomock.Call {
+// MkdirAll indicates an expected call of MkdirAll.
+func (mr *MockfileSystemMockRecorder) MkdirAll(path, perm interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Rename", reflect.TypeOf((*MockfileSystem)(nil).Rename), oldpath, newpath)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MkdirAll", reflect.TypeOf((*MockfileSystem)(nil).MkdirAll), path, perm)
 }
 
-// ReadAll mocks base method
-func (m *MockfileSystem) ReadAll(r io.Reader) ([]byte, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadAll", r)
-	ret0, _ := ret[0].([]byte)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ReadAll indicates an expected call of ReadAll
-func (mr *MockfileSystemMockRecorder) ReadAll(r interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadAll", reflect.TypeOf((*MockfileSystem)(nil).ReadAll), r)
-}
-
-// Open mocks base method
+// Open mocks base method.
 func (m *MockfileSystem) Open(name string) (io.ReadCloser, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Open", name)
@@ -251,13 +195,54 @@ func (m *MockfileSystem) Open(name string) (io.ReadCloser, error) {
 	return ret0, ret1
 }
 
-// Open indicates an expected call of Open
+// Open indicates an expected call of Open.
 func (mr *MockfileSystemMockRecorder) Open(name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Open", reflect.TypeOf((*MockfileSystem)(nil).Open), name)
 }
 
-// Stat mocks base method
+// ReadAll mocks base method.
+func (m *MockfileSystem) ReadAll(r io.Reader) ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReadAll", r)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReadAll indicates an expected call of ReadAll.
+func (mr *MockfileSystemMockRecorder) ReadAll(r interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadAll", reflect.TypeOf((*MockfileSystem)(nil).ReadAll), r)
+}
+
+// Remove mocks base method.
+func (m *MockfileSystem) Remove(path string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Remove", path)
+}
+
+// Remove indicates an expected call of Remove.
+func (mr *MockfileSystemMockRecorder) Remove(path interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Remove", reflect.TypeOf((*MockfileSystem)(nil).Remove), path)
+}
+
+// Rename mocks base method.
+func (m *MockfileSystem) Rename(oldpath, newpath string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Rename", oldpath, newpath)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Rename indicates an expected call of Rename.
+func (mr *MockfileSystemMockRecorder) Rename(oldpath, newpath interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Rename", reflect.TypeOf((*MockfileSystem)(nil).Rename), oldpath, newpath)
+}
+
+// Stat mocks base method.
 func (m *MockfileSystem) Stat(name string) (fileSizeInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Stat", name)
@@ -266,27 +251,42 @@ func (m *MockfileSystem) Stat(name string) (fileSizeInfo, error) {
 	return ret0, ret1
 }
 
-// Stat indicates an expected call of Stat
+// Stat indicates an expected call of Stat.
 func (mr *MockfileSystemMockRecorder) Stat(name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stat", reflect.TypeOf((*MockfileSystem)(nil).Stat), name)
 }
 
-// Base mocks base method
-func (m *MockfileSystem) Base(path string) string {
+// TeeReader mocks base method.
+func (m *MockfileSystem) TeeReader(r io.Reader, w io.Writer) io.Reader {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Base", path)
-	ret0, _ := ret[0].(string)
+	ret := m.ctrl.Call(m, "TeeReader", r, w)
+	ret0, _ := ret[0].(io.Reader)
 	return ret0
 }
 
-// Base indicates an expected call of Base
-func (mr *MockfileSystemMockRecorder) Base(path interface{}) *gomock.Call {
+// TeeReader indicates an expected call of TeeReader.
+func (mr *MockfileSystemMockRecorder) TeeReader(r, w interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Base", reflect.TypeOf((*MockfileSystem)(nil).Base), path)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TeeReader", reflect.TypeOf((*MockfileSystem)(nil).TeeReader), r, w)
 }
 
-// WriteFile mocks base method
+// TempFile mocks base method.
+func (m *MockfileSystem) TempFile(dir, prefix string) (*os.File, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TempFile", dir, prefix)
+	ret0, _ := ret[0].(*os.File)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// TempFile indicates an expected call of TempFile.
+func (mr *MockfileSystemMockRecorder) TempFile(dir, prefix interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TempFile", reflect.TypeOf((*MockfileSystem)(nil).TempFile), dir, prefix)
+}
+
+// WriteFile mocks base method.
 func (m *MockfileSystem) WriteFile(filename string, data []byte, perm os.FileMode) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WriteFile", filename, data, perm)
@@ -294,36 +294,36 @@ func (m *MockfileSystem) WriteFile(filename string, data []byte, perm os.FileMod
 	return ret0
 }
 
-// WriteFile indicates an expected call of WriteFile
+// WriteFile indicates an expected call of WriteFile.
 func (mr *MockfileSystemMockRecorder) WriteFile(filename, data, perm interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteFile", reflect.TypeOf((*MockfileSystem)(nil).WriteFile), filename, data, perm)
 }
 
-// MockfileSizeInfo is a mock of fileSizeInfo interface
+// MockfileSizeInfo is a mock of fileSizeInfo interface.
 type MockfileSizeInfo struct {
 	ctrl     *gomock.Controller
 	recorder *MockfileSizeInfoMockRecorder
 }
 
-// MockfileSizeInfoMockRecorder is the mock recorder for MockfileSizeInfo
+// MockfileSizeInfoMockRecorder is the mock recorder for MockfileSizeInfo.
 type MockfileSizeInfoMockRecorder struct {
 	mock *MockfileSizeInfo
 }
 
-// NewMockfileSizeInfo creates a new mock instance
+// NewMockfileSizeInfo creates a new mock instance.
 func NewMockfileSizeInfo(ctrl *gomock.Controller) *MockfileSizeInfo {
 	mock := &MockfileSizeInfo{ctrl: ctrl}
 	mock.recorder = &MockfileSizeInfoMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockfileSizeInfo) EXPECT() *MockfileSizeInfoMockRecorder {
 	return m.recorder
 }
 
-// Size mocks base method
+// Size mocks base method.
 func (m *MockfileSizeInfo) Size() int64 {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Size")
@@ -331,36 +331,36 @@ func (m *MockfileSizeInfo) Size() int64 {
 	return ret0
 }
 
-// Size indicates an expected call of Size
+// Size indicates an expected call of Size.
 func (mr *MockfileSizeInfoMockRecorder) Size() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Size", reflect.TypeOf((*MockfileSizeInfo)(nil).Size))
 }
 
-// MockinstanceMetadata is a mock of instanceMetadata interface
+// MockinstanceMetadata is a mock of instanceMetadata interface.
 type MockinstanceMetadata struct {
 	ctrl     *gomock.Controller
 	recorder *MockinstanceMetadataMockRecorder
 }
 
-// MockinstanceMetadataMockRecorder is the mock recorder for MockinstanceMetadata
+// MockinstanceMetadataMockRecorder is the mock recorder for MockinstanceMetadata.
 type MockinstanceMetadataMockRecorder struct {
 	mock *MockinstanceMetadata
 }
 
-// NewMockinstanceMetadata creates a new mock instance
+// NewMockinstanceMetadata creates a new mock instance.
 func NewMockinstanceMetadata(ctrl *gomock.Controller) *MockinstanceMetadata {
 	mock := &MockinstanceMetadata{ctrl: ctrl}
 	mock.recorder = &MockinstanceMetadataMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockinstanceMetadata) EXPECT() *MockinstanceMetadataMockRecorder {
 	return m.recorder
 }
 
-// Region mocks base method
+// Region mocks base method.
 func (m *MockinstanceMetadata) Region() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Region")
@@ -369,7 +369,7 @@ func (m *MockinstanceMetadata) Region() (string, error) {
 	return ret0, ret1
 }
 
-// Region indicates an expected call of Region
+// Region indicates an expected call of Region.
 func (mr *MockinstanceMetadataMockRecorder) Region() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Region", reflect.TypeOf((*MockinstanceMetadata)(nil).Region))

--- a/ecs-init/docker/backoff_mocks.go
+++ b/ecs-init/docker/backoff_mocks.go
@@ -24,30 +24,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockBackoff is a mock of Backoff interface
+// MockBackoff is a mock of Backoff interface.
 type MockBackoff struct {
 	ctrl     *gomock.Controller
 	recorder *MockBackoffMockRecorder
 }
 
-// MockBackoffMockRecorder is the mock recorder for MockBackoff
+// MockBackoffMockRecorder is the mock recorder for MockBackoff.
 type MockBackoffMockRecorder struct {
 	mock *MockBackoff
 }
 
-// NewMockBackoff creates a new mock instance
+// NewMockBackoff creates a new mock instance.
 func NewMockBackoff(ctrl *gomock.Controller) *MockBackoff {
 	mock := &MockBackoff{ctrl: ctrl}
 	mock.recorder = &MockBackoffMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockBackoff) EXPECT() *MockBackoffMockRecorder {
 	return m.recorder
 }
 
-// Duration mocks base method
+// Duration mocks base method.
 func (m *MockBackoff) Duration() time.Duration {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Duration")
@@ -55,13 +55,13 @@ func (m *MockBackoff) Duration() time.Duration {
 	return ret0
 }
 
-// Duration indicates an expected call of Duration
+// Duration indicates an expected call of Duration.
 func (mr *MockBackoffMockRecorder) Duration() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Duration", reflect.TypeOf((*MockBackoff)(nil).Duration))
 }
 
-// ShouldRetry mocks base method
+// ShouldRetry mocks base method.
 func (m *MockBackoff) ShouldRetry() bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ShouldRetry")
@@ -69,7 +69,7 @@ func (m *MockBackoff) ShouldRetry() bool {
 	return ret0
 }
 
-// ShouldRetry indicates an expected call of ShouldRetry
+// ShouldRetry indicates an expected call of ShouldRetry.
 func (mr *MockBackoffMockRecorder) ShouldRetry() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShouldRetry", reflect.TypeOf((*MockBackoff)(nil).ShouldRetry))

--- a/ecs-init/docker/dependencies_mocks.go
+++ b/ecs-init/docker/dependencies_mocks.go
@@ -20,135 +20,163 @@ package docker
 import (
 	reflect "reflect"
 
-	go_dockerclient "github.com/fsouza/go-dockerclient"
+	docker "github.com/fsouza/go-dockerclient"
 	gomock "github.com/golang/mock/gomock"
 )
 
-// Mockdockerclient is a mock of dockerclient interface
+// Mockdockerclient is a mock of dockerclient interface.
 type Mockdockerclient struct {
 	ctrl     *gomock.Controller
 	recorder *MockdockerclientMockRecorder
 }
 
-// MockdockerclientMockRecorder is the mock recorder for Mockdockerclient
+// MockdockerclientMockRecorder is the mock recorder for Mockdockerclient.
 type MockdockerclientMockRecorder struct {
 	mock *Mockdockerclient
 }
 
-// NewMockdockerclient creates a new mock instance
+// NewMockdockerclient creates a new mock instance.
 func NewMockdockerclient(ctrl *gomock.Controller) *Mockdockerclient {
 	mock := &Mockdockerclient{ctrl: ctrl}
 	mock.recorder = &MockdockerclientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *Mockdockerclient) EXPECT() *MockdockerclientMockRecorder {
 	return m.recorder
 }
 
-// ListImages mocks base method
-func (m *Mockdockerclient) ListImages(opts go_dockerclient.ListImagesOptions) ([]go_dockerclient.APIImages, error) {
+// CreateContainer mocks base method.
+func (m *Mockdockerclient) CreateContainer(opts docker.CreateContainerOptions) (*docker.Container, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListImages", opts)
-	ret0, _ := ret[0].([]go_dockerclient.APIImages)
+	ret := m.ctrl.Call(m, "CreateContainer", opts)
+	ret0, _ := ret[0].(*docker.Container)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListImages indicates an expected call of ListImages
+// CreateContainer indicates an expected call of CreateContainer.
+func (mr *MockdockerclientMockRecorder) CreateContainer(opts interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateContainer", reflect.TypeOf((*Mockdockerclient)(nil).CreateContainer), opts)
+}
+
+// ListContainers mocks base method.
+func (m *Mockdockerclient) ListContainers(opts docker.ListContainersOptions) ([]docker.APIContainers, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListContainers", opts)
+	ret0, _ := ret[0].([]docker.APIContainers)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListContainers indicates an expected call of ListContainers.
+func (mr *MockdockerclientMockRecorder) ListContainers(opts interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListContainers", reflect.TypeOf((*Mockdockerclient)(nil).ListContainers), opts)
+}
+
+// ListImages mocks base method.
+func (m *Mockdockerclient) ListImages(opts docker.ListImagesOptions) ([]docker.APIImages, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListImages", opts)
+	ret0, _ := ret[0].([]docker.APIImages)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListImages indicates an expected call of ListImages.
 func (mr *MockdockerclientMockRecorder) ListImages(opts interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListImages", reflect.TypeOf((*Mockdockerclient)(nil).ListImages), opts)
 }
 
-// LoadImage mocks base method
-func (m *Mockdockerclient) LoadImage(opts go_dockerclient.LoadImageOptions) error {
+// LoadImage mocks base method.
+func (m *Mockdockerclient) LoadImage(opts docker.LoadImageOptions) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LoadImage", opts)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// LoadImage indicates an expected call of LoadImage
+// LoadImage indicates an expected call of LoadImage.
 func (mr *MockdockerclientMockRecorder) LoadImage(opts interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadImage", reflect.TypeOf((*Mockdockerclient)(nil).LoadImage), opts)
 }
 
-// Logs mocks base method
-func (m *Mockdockerclient) Logs(opts go_dockerclient.LogsOptions) error {
+// Logs mocks base method.
+func (m *Mockdockerclient) Logs(opts docker.LogsOptions) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Logs", opts)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// Logs indicates an expected call of Logs
+// Logs indicates an expected call of Logs.
 func (mr *MockdockerclientMockRecorder) Logs(opts interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Logs", reflect.TypeOf((*Mockdockerclient)(nil).Logs), opts)
 }
 
-// ListContainers mocks base method
-func (m *Mockdockerclient) ListContainers(opts go_dockerclient.ListContainersOptions) ([]go_dockerclient.APIContainers, error) {
+// Ping mocks base method.
+func (m *Mockdockerclient) Ping() error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListContainers", opts)
-	ret0, _ := ret[0].([]go_dockerclient.APIContainers)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret := m.ctrl.Call(m, "Ping")
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-// ListContainers indicates an expected call of ListContainers
-func (mr *MockdockerclientMockRecorder) ListContainers(opts interface{}) *gomock.Call {
+// Ping indicates an expected call of Ping.
+func (mr *MockdockerclientMockRecorder) Ping() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListContainers", reflect.TypeOf((*Mockdockerclient)(nil).ListContainers), opts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ping", reflect.TypeOf((*Mockdockerclient)(nil).Ping))
 }
 
-// RemoveContainer mocks base method
-func (m *Mockdockerclient) RemoveContainer(opts go_dockerclient.RemoveContainerOptions) error {
+// RemoveContainer mocks base method.
+func (m *Mockdockerclient) RemoveContainer(opts docker.RemoveContainerOptions) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveContainer", opts)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// RemoveContainer indicates an expected call of RemoveContainer
+// RemoveContainer indicates an expected call of RemoveContainer.
 func (mr *MockdockerclientMockRecorder) RemoveContainer(opts interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveContainer", reflect.TypeOf((*Mockdockerclient)(nil).RemoveContainer), opts)
 }
 
-// CreateContainer mocks base method
-func (m *Mockdockerclient) CreateContainer(opts go_dockerclient.CreateContainerOptions) (*go_dockerclient.Container, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateContainer", opts)
-	ret0, _ := ret[0].(*go_dockerclient.Container)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CreateContainer indicates an expected call of CreateContainer
-func (mr *MockdockerclientMockRecorder) CreateContainer(opts interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateContainer", reflect.TypeOf((*Mockdockerclient)(nil).CreateContainer), opts)
-}
-
-// StartContainer mocks base method
-func (m *Mockdockerclient) StartContainer(id string, hostConfig *go_dockerclient.HostConfig) error {
+// StartContainer mocks base method.
+func (m *Mockdockerclient) StartContainer(id string, hostConfig *docker.HostConfig) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartContainer", id, hostConfig)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// StartContainer indicates an expected call of StartContainer
+// StartContainer indicates an expected call of StartContainer.
 func (mr *MockdockerclientMockRecorder) StartContainer(id, hostConfig interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartContainer", reflect.TypeOf((*Mockdockerclient)(nil).StartContainer), id, hostConfig)
 }
 
-// WaitContainer mocks base method
+// StopContainer mocks base method.
+func (m *Mockdockerclient) StopContainer(id string, timeout uint) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StopContainer", id, timeout)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// StopContainer indicates an expected call of StopContainer.
+func (mr *MockdockerclientMockRecorder) StopContainer(id, timeout interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopContainer", reflect.TypeOf((*Mockdockerclient)(nil).StopContainer), id, timeout)
+}
+
+// WaitContainer mocks base method.
 func (m *Mockdockerclient) WaitContainer(id string) (int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitContainer", id)
@@ -157,64 +185,36 @@ func (m *Mockdockerclient) WaitContainer(id string) (int, error) {
 	return ret0, ret1
 }
 
-// WaitContainer indicates an expected call of WaitContainer
+// WaitContainer indicates an expected call of WaitContainer.
 func (mr *MockdockerclientMockRecorder) WaitContainer(id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitContainer", reflect.TypeOf((*Mockdockerclient)(nil).WaitContainer), id)
 }
 
-// StopContainer mocks base method
-func (m *Mockdockerclient) StopContainer(id string, timeout uint) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StopContainer", id, timeout)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// StopContainer indicates an expected call of StopContainer
-func (mr *MockdockerclientMockRecorder) StopContainer(id, timeout interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopContainer", reflect.TypeOf((*Mockdockerclient)(nil).StopContainer), id, timeout)
-}
-
-// Ping mocks base method
-func (m *Mockdockerclient) Ping() error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Ping")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Ping indicates an expected call of Ping
-func (mr *MockdockerclientMockRecorder) Ping() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ping", reflect.TypeOf((*Mockdockerclient)(nil).Ping))
-}
-
-// MockdockerClientFactory is a mock of dockerClientFactory interface
+// MockdockerClientFactory is a mock of dockerClientFactory interface.
 type MockdockerClientFactory struct {
 	ctrl     *gomock.Controller
 	recorder *MockdockerClientFactoryMockRecorder
 }
 
-// MockdockerClientFactoryMockRecorder is the mock recorder for MockdockerClientFactory
+// MockdockerClientFactoryMockRecorder is the mock recorder for MockdockerClientFactory.
 type MockdockerClientFactoryMockRecorder struct {
 	mock *MockdockerClientFactory
 }
 
-// NewMockdockerClientFactory creates a new mock instance
+// NewMockdockerClientFactory creates a new mock instance.
 func NewMockdockerClientFactory(ctrl *gomock.Controller) *MockdockerClientFactory {
 	mock := &MockdockerClientFactory{ctrl: ctrl}
 	mock.recorder = &MockdockerClientFactoryMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockdockerClientFactory) EXPECT() *MockdockerClientFactoryMockRecorder {
 	return m.recorder
 }
 
-// NewVersionedClient mocks base method
+// NewVersionedClient mocks base method.
 func (m *MockdockerClientFactory) NewVersionedClient(endpoint, apiVersionString string) (dockerclient, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewVersionedClient", endpoint, apiVersionString)
@@ -223,36 +223,36 @@ func (m *MockdockerClientFactory) NewVersionedClient(endpoint, apiVersionString 
 	return ret0, ret1
 }
 
-// NewVersionedClient indicates an expected call of NewVersionedClient
+// NewVersionedClient indicates an expected call of NewVersionedClient.
 func (mr *MockdockerClientFactoryMockRecorder) NewVersionedClient(endpoint, apiVersionString interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewVersionedClient", reflect.TypeOf((*MockdockerClientFactory)(nil).NewVersionedClient), endpoint, apiVersionString)
 }
 
-// MockfileSystem is a mock of fileSystem interface
+// MockfileSystem is a mock of fileSystem interface.
 type MockfileSystem struct {
 	ctrl     *gomock.Controller
 	recorder *MockfileSystemMockRecorder
 }
 
-// MockfileSystemMockRecorder is the mock recorder for MockfileSystem
+// MockfileSystemMockRecorder is the mock recorder for MockfileSystem.
 type MockfileSystemMockRecorder struct {
 	mock *MockfileSystem
 }
 
-// NewMockfileSystem creates a new mock instance
+// NewMockfileSystem creates a new mock instance.
 func NewMockfileSystem(ctrl *gomock.Controller) *MockfileSystem {
 	mock := &MockfileSystem{ctrl: ctrl}
 	mock.recorder = &MockfileSystemMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockfileSystem) EXPECT() *MockfileSystemMockRecorder {
 	return m.recorder
 }
 
-// ReadFile mocks base method
+// ReadFile mocks base method.
 func (m *MockfileSystem) ReadFile(filename string) ([]byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReadFile", filename)
@@ -261,7 +261,7 @@ func (m *MockfileSystem) ReadFile(filename string) ([]byte, error) {
 	return ret0, ret1
 }
 
-// ReadFile indicates an expected call of ReadFile
+// ReadFile indicates an expected call of ReadFile.
 func (mr *MockfileSystemMockRecorder) ReadFile(filename interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadFile", reflect.TypeOf((*MockfileSystem)(nil).ReadFile), filename)

--- a/ecs-init/engine/dependencies_mocks.go
+++ b/ecs-init/engine/dependencies_mocks.go
@@ -25,44 +25,44 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// Mockdownloader is a mock of downloader interface
+// Mockdownloader is a mock of downloader interface.
 type Mockdownloader struct {
 	ctrl     *gomock.Controller
 	recorder *MockdownloaderMockRecorder
 }
 
-// MockdownloaderMockRecorder is the mock recorder for Mockdownloader
+// MockdownloaderMockRecorder is the mock recorder for Mockdownloader.
 type MockdownloaderMockRecorder struct {
 	mock *Mockdownloader
 }
 
-// NewMockdownloader creates a new mock instance
+// NewMockdownloader creates a new mock instance.
 func NewMockdownloader(ctrl *gomock.Controller) *Mockdownloader {
 	mock := &Mockdownloader{ctrl: ctrl}
 	mock.recorder = &MockdownloaderMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *Mockdownloader) EXPECT() *MockdownloaderMockRecorder {
 	return m.recorder
 }
 
-// IsAgentCached mocks base method
-func (m *Mockdownloader) IsAgentCached() bool {
+// AgentCacheStatus mocks base method.
+func (m *Mockdownloader) AgentCacheStatus() cache.CacheStatus {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsAgentCached")
-	ret0, _ := ret[0].(bool)
+	ret := m.ctrl.Call(m, "AgentCacheStatus")
+	ret0, _ := ret[0].(cache.CacheStatus)
 	return ret0
 }
 
-// IsAgentCached indicates an expected call of IsAgentCached
-func (mr *MockdownloaderMockRecorder) IsAgentCached() *gomock.Call {
+// AgentCacheStatus indicates an expected call of AgentCacheStatus.
+func (mr *MockdownloaderMockRecorder) AgentCacheStatus() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsAgentCached", reflect.TypeOf((*Mockdownloader)(nil).IsAgentCached))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AgentCacheStatus", reflect.TypeOf((*Mockdownloader)(nil).AgentCacheStatus))
 }
 
-// DownloadAgent mocks base method
+// DownloadAgent mocks base method.
 func (m *Mockdownloader) DownloadAgent() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DownloadAgent")
@@ -70,13 +70,27 @@ func (m *Mockdownloader) DownloadAgent() error {
 	return ret0
 }
 
-// DownloadAgent indicates an expected call of DownloadAgent
+// DownloadAgent indicates an expected call of DownloadAgent.
 func (mr *MockdownloaderMockRecorder) DownloadAgent() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadAgent", reflect.TypeOf((*Mockdownloader)(nil).DownloadAgent))
 }
 
-// LoadCachedAgent mocks base method
+// IsAgentCached mocks base method.
+func (m *Mockdownloader) IsAgentCached() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsAgentCached")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsAgentCached indicates an expected call of IsAgentCached.
+func (mr *MockdownloaderMockRecorder) IsAgentCached() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsAgentCached", reflect.TypeOf((*Mockdownloader)(nil).IsAgentCached))
+}
+
+// LoadCachedAgent mocks base method.
 func (m *Mockdownloader) LoadCachedAgent() (io.ReadCloser, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LoadCachedAgent")
@@ -85,13 +99,13 @@ func (m *Mockdownloader) LoadCachedAgent() (io.ReadCloser, error) {
 	return ret0, ret1
 }
 
-// LoadCachedAgent indicates an expected call of LoadCachedAgent
+// LoadCachedAgent indicates an expected call of LoadCachedAgent.
 func (mr *MockdownloaderMockRecorder) LoadCachedAgent() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadCachedAgent", reflect.TypeOf((*Mockdownloader)(nil).LoadCachedAgent))
 }
 
-// LoadDesiredAgent mocks base method
+// LoadDesiredAgent mocks base method.
 func (m *Mockdownloader) LoadDesiredAgent() (io.ReadCloser, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LoadDesiredAgent")
@@ -100,13 +114,13 @@ func (m *Mockdownloader) LoadDesiredAgent() (io.ReadCloser, error) {
 	return ret0, ret1
 }
 
-// LoadDesiredAgent indicates an expected call of LoadDesiredAgent
+// LoadDesiredAgent indicates an expected call of LoadDesiredAgent.
 func (mr *MockdownloaderMockRecorder) LoadDesiredAgent() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadDesiredAgent", reflect.TypeOf((*Mockdownloader)(nil).LoadDesiredAgent))
 }
 
-// RecordCachedAgent mocks base method
+// RecordCachedAgent mocks base method.
 func (m *Mockdownloader) RecordCachedAgent() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RecordCachedAgent")
@@ -114,50 +128,36 @@ func (m *Mockdownloader) RecordCachedAgent() error {
 	return ret0
 }
 
-// RecordCachedAgent indicates an expected call of RecordCachedAgent
+// RecordCachedAgent indicates an expected call of RecordCachedAgent.
 func (mr *MockdownloaderMockRecorder) RecordCachedAgent() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecordCachedAgent", reflect.TypeOf((*Mockdownloader)(nil).RecordCachedAgent))
 }
 
-// AgentCacheStatus mocks base method
-func (m *Mockdownloader) AgentCacheStatus() cache.CacheStatus {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AgentCacheStatus")
-	ret0, _ := ret[0].(cache.CacheStatus)
-	return ret0
-}
-
-// AgentCacheStatus indicates an expected call of AgentCacheStatus
-func (mr *MockdownloaderMockRecorder) AgentCacheStatus() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AgentCacheStatus", reflect.TypeOf((*Mockdownloader)(nil).AgentCacheStatus))
-}
-
-// MockdockerClient is a mock of dockerClient interface
+// MockdockerClient is a mock of dockerClient interface.
 type MockdockerClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockdockerClientMockRecorder
 }
 
-// MockdockerClientMockRecorder is the mock recorder for MockdockerClient
+// MockdockerClientMockRecorder is the mock recorder for MockdockerClient.
 type MockdockerClientMockRecorder struct {
 	mock *MockdockerClient
 }
 
-// NewMockdockerClient creates a new mock instance
+// NewMockdockerClient creates a new mock instance.
 func NewMockdockerClient(ctrl *gomock.Controller) *MockdockerClient {
 	mock := &MockdockerClient{ctrl: ctrl}
 	mock.recorder = &MockdockerClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockdockerClient) EXPECT() *MockdockerClientMockRecorder {
 	return m.recorder
 }
 
-// GetContainerLogTail mocks base method
+// GetContainerLogTail mocks base method.
 func (m *MockdockerClient) GetContainerLogTail(logWindowSize string) string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetContainerLogTail", logWindowSize)
@@ -165,13 +165,13 @@ func (m *MockdockerClient) GetContainerLogTail(logWindowSize string) string {
 	return ret0
 }
 
-// GetContainerLogTail indicates an expected call of GetContainerLogTail
+// GetContainerLogTail indicates an expected call of GetContainerLogTail.
 func (mr *MockdockerClientMockRecorder) GetContainerLogTail(logWindowSize interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContainerLogTail", reflect.TypeOf((*MockdockerClient)(nil).GetContainerLogTail), logWindowSize)
 }
 
-// IsAgentImageLoaded mocks base method
+// IsAgentImageLoaded mocks base method.
 func (m *MockdockerClient) IsAgentImageLoaded() (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsAgentImageLoaded")
@@ -180,13 +180,27 @@ func (m *MockdockerClient) IsAgentImageLoaded() (bool, error) {
 	return ret0, ret1
 }
 
-// IsAgentImageLoaded indicates an expected call of IsAgentImageLoaded
+// IsAgentImageLoaded indicates an expected call of IsAgentImageLoaded.
 func (mr *MockdockerClientMockRecorder) IsAgentImageLoaded() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsAgentImageLoaded", reflect.TypeOf((*MockdockerClient)(nil).IsAgentImageLoaded))
 }
 
-// LoadImage mocks base method
+// LoadEnvVars mocks base method.
+func (m *MockdockerClient) LoadEnvVars() map[string]string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LoadEnvVars")
+	ret0, _ := ret[0].(map[string]string)
+	return ret0
+}
+
+// LoadEnvVars indicates an expected call of LoadEnvVars.
+func (mr *MockdockerClientMockRecorder) LoadEnvVars() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadEnvVars", reflect.TypeOf((*MockdockerClient)(nil).LoadEnvVars))
+}
+
+// LoadImage mocks base method.
 func (m *MockdockerClient) LoadImage(image io.Reader) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LoadImage", image)
@@ -194,13 +208,13 @@ func (m *MockdockerClient) LoadImage(image io.Reader) error {
 	return ret0
 }
 
-// LoadImage indicates an expected call of LoadImage
+// LoadImage indicates an expected call of LoadImage.
 func (mr *MockdockerClientMockRecorder) LoadImage(image interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadImage", reflect.TypeOf((*MockdockerClient)(nil).LoadImage), image)
 }
 
-// RemoveExistingAgentContainer mocks base method
+// RemoveExistingAgentContainer mocks base method.
 func (m *MockdockerClient) RemoveExistingAgentContainer() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveExistingAgentContainer")
@@ -208,13 +222,13 @@ func (m *MockdockerClient) RemoveExistingAgentContainer() error {
 	return ret0
 }
 
-// RemoveExistingAgentContainer indicates an expected call of RemoveExistingAgentContainer
+// RemoveExistingAgentContainer indicates an expected call of RemoveExistingAgentContainer.
 func (mr *MockdockerClientMockRecorder) RemoveExistingAgentContainer() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveExistingAgentContainer", reflect.TypeOf((*MockdockerClient)(nil).RemoveExistingAgentContainer))
 }
 
-// StartAgent mocks base method
+// StartAgent mocks base method.
 func (m *MockdockerClient) StartAgent() (int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartAgent")
@@ -223,13 +237,13 @@ func (m *MockdockerClient) StartAgent() (int, error) {
 	return ret0, ret1
 }
 
-// StartAgent indicates an expected call of StartAgent
+// StartAgent indicates an expected call of StartAgent.
 func (mr *MockdockerClientMockRecorder) StartAgent() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartAgent", reflect.TypeOf((*MockdockerClient)(nil).StartAgent))
 }
 
-// StopAgent mocks base method
+// StopAgent mocks base method.
 func (m *MockdockerClient) StopAgent() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StopAgent")
@@ -237,50 +251,36 @@ func (m *MockdockerClient) StopAgent() error {
 	return ret0
 }
 
-// StopAgent indicates an expected call of StopAgent
+// StopAgent indicates an expected call of StopAgent.
 func (mr *MockdockerClientMockRecorder) StopAgent() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopAgent", reflect.TypeOf((*MockdockerClient)(nil).StopAgent))
 }
 
-// LoadEnvVars mocks base method
-func (m *MockdockerClient) LoadEnvVars() map[string]string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LoadEnvVars")
-	ret0, _ := ret[0].(map[string]string)
-	return ret0
-}
-
-// LoadEnvVars indicates an expected call of LoadEnvVars
-func (mr *MockdockerClientMockRecorder) LoadEnvVars() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadEnvVars", reflect.TypeOf((*MockdockerClient)(nil).LoadEnvVars))
-}
-
-// MockloopbackRouting is a mock of loopbackRouting interface
+// MockloopbackRouting is a mock of loopbackRouting interface.
 type MockloopbackRouting struct {
 	ctrl     *gomock.Controller
 	recorder *MockloopbackRoutingMockRecorder
 }
 
-// MockloopbackRoutingMockRecorder is the mock recorder for MockloopbackRouting
+// MockloopbackRoutingMockRecorder is the mock recorder for MockloopbackRouting.
 type MockloopbackRoutingMockRecorder struct {
 	mock *MockloopbackRouting
 }
 
-// NewMockloopbackRouting creates a new mock instance
+// NewMockloopbackRouting creates a new mock instance.
 func NewMockloopbackRouting(ctrl *gomock.Controller) *MockloopbackRouting {
 	mock := &MockloopbackRouting{ctrl: ctrl}
 	mock.recorder = &MockloopbackRoutingMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockloopbackRouting) EXPECT() *MockloopbackRoutingMockRecorder {
 	return m.recorder
 }
 
-// Enable mocks base method
+// Enable mocks base method.
 func (m *MockloopbackRouting) Enable() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Enable")
@@ -288,13 +288,13 @@ func (m *MockloopbackRouting) Enable() error {
 	return ret0
 }
 
-// Enable indicates an expected call of Enable
+// Enable indicates an expected call of Enable.
 func (mr *MockloopbackRoutingMockRecorder) Enable() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Enable", reflect.TypeOf((*MockloopbackRouting)(nil).Enable))
 }
 
-// RestoreDefault mocks base method
+// RestoreDefault mocks base method.
 func (m *MockloopbackRouting) RestoreDefault() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RestoreDefault")
@@ -302,36 +302,36 @@ func (m *MockloopbackRouting) RestoreDefault() error {
 	return ret0
 }
 
-// RestoreDefault indicates an expected call of RestoreDefault
+// RestoreDefault indicates an expected call of RestoreDefault.
 func (mr *MockloopbackRoutingMockRecorder) RestoreDefault() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestoreDefault", reflect.TypeOf((*MockloopbackRouting)(nil).RestoreDefault))
 }
 
-// MockcredentialsProxyRoute is a mock of credentialsProxyRoute interface
+// MockcredentialsProxyRoute is a mock of credentialsProxyRoute interface.
 type MockcredentialsProxyRoute struct {
 	ctrl     *gomock.Controller
 	recorder *MockcredentialsProxyRouteMockRecorder
 }
 
-// MockcredentialsProxyRouteMockRecorder is the mock recorder for MockcredentialsProxyRoute
+// MockcredentialsProxyRouteMockRecorder is the mock recorder for MockcredentialsProxyRoute.
 type MockcredentialsProxyRouteMockRecorder struct {
 	mock *MockcredentialsProxyRoute
 }
 
-// NewMockcredentialsProxyRoute creates a new mock instance
+// NewMockcredentialsProxyRoute creates a new mock instance.
 func NewMockcredentialsProxyRoute(ctrl *gomock.Controller) *MockcredentialsProxyRoute {
 	mock := &MockcredentialsProxyRoute{ctrl: ctrl}
 	mock.recorder = &MockcredentialsProxyRouteMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockcredentialsProxyRoute) EXPECT() *MockcredentialsProxyRouteMockRecorder {
 	return m.recorder
 }
 
-// Create mocks base method
+// Create mocks base method.
 func (m *MockcredentialsProxyRoute) Create() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create")
@@ -339,13 +339,13 @@ func (m *MockcredentialsProxyRoute) Create() error {
 	return ret0
 }
 
-// Create indicates an expected call of Create
+// Create indicates an expected call of Create.
 func (mr *MockcredentialsProxyRouteMockRecorder) Create() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockcredentialsProxyRoute)(nil).Create))
 }
 
-// Remove mocks base method
+// Remove mocks base method.
 func (m *MockcredentialsProxyRoute) Remove() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Remove")
@@ -353,36 +353,36 @@ func (m *MockcredentialsProxyRoute) Remove() error {
 	return ret0
 }
 
-// Remove indicates an expected call of Remove
+// Remove indicates an expected call of Remove.
 func (mr *MockcredentialsProxyRouteMockRecorder) Remove() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Remove", reflect.TypeOf((*MockcredentialsProxyRoute)(nil).Remove))
 }
 
-// Mockipv6RouterAdvertisements is a mock of ipv6RouterAdvertisements interface
+// Mockipv6RouterAdvertisements is a mock of ipv6RouterAdvertisements interface.
 type Mockipv6RouterAdvertisements struct {
 	ctrl     *gomock.Controller
 	recorder *Mockipv6RouterAdvertisementsMockRecorder
 }
 
-// Mockipv6RouterAdvertisementsMockRecorder is the mock recorder for Mockipv6RouterAdvertisements
+// Mockipv6RouterAdvertisementsMockRecorder is the mock recorder for Mockipv6RouterAdvertisements.
 type Mockipv6RouterAdvertisementsMockRecorder struct {
 	mock *Mockipv6RouterAdvertisements
 }
 
-// NewMockipv6RouterAdvertisements creates a new mock instance
+// NewMockipv6RouterAdvertisements creates a new mock instance.
 func NewMockipv6RouterAdvertisements(ctrl *gomock.Controller) *Mockipv6RouterAdvertisements {
 	mock := &Mockipv6RouterAdvertisements{ctrl: ctrl}
 	mock.recorder = &Mockipv6RouterAdvertisementsMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *Mockipv6RouterAdvertisements) EXPECT() *Mockipv6RouterAdvertisementsMockRecorder {
 	return m.recorder
 }
 
-// Disable mocks base method
+// Disable mocks base method.
 func (m *Mockipv6RouterAdvertisements) Disable() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Disable")
@@ -390,7 +390,7 @@ func (m *Mockipv6RouterAdvertisements) Disable() error {
 	return ret0
 }
 
-// Disable indicates an expected call of Disable
+// Disable indicates an expected call of Disable.
 func (mr *Mockipv6RouterAdvertisementsMockRecorder) Disable() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Disable", reflect.TypeOf((*Mockipv6RouterAdvertisements)(nil).Disable))

--- a/ecs-init/exec/iptables/cmd_mocks.go
+++ b/ecs-init/exec/iptables/cmd_mocks.go
@@ -23,30 +23,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockCmd is a mock of Cmd interface
+// MockCmd is a mock of Cmd interface.
 type MockCmd struct {
 	ctrl     *gomock.Controller
 	recorder *MockCmdMockRecorder
 }
 
-// MockCmdMockRecorder is the mock recorder for MockCmd
+// MockCmdMockRecorder is the mock recorder for MockCmd.
 type MockCmdMockRecorder struct {
 	mock *MockCmd
 }
 
-// NewMockCmd creates a new mock instance
+// NewMockCmd creates a new mock instance.
 func NewMockCmd(ctrl *gomock.Controller) *MockCmd {
 	mock := &MockCmd{ctrl: ctrl}
 	mock.recorder = &MockCmdMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockCmd) EXPECT() *MockCmdMockRecorder {
 	return m.recorder
 }
 
-// CombinedOutput mocks base method
+// CombinedOutput mocks base method.
 func (m *MockCmd) CombinedOutput() ([]byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CombinedOutput")
@@ -55,13 +55,13 @@ func (m *MockCmd) CombinedOutput() ([]byte, error) {
 	return ret0, ret1
 }
 
-// CombinedOutput indicates an expected call of CombinedOutput
+// CombinedOutput indicates an expected call of CombinedOutput.
 func (mr *MockCmdMockRecorder) CombinedOutput() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CombinedOutput", reflect.TypeOf((*MockCmd)(nil).CombinedOutput))
 }
 
-// Output mocks base method
+// Output mocks base method.
 func (m *MockCmd) Output() ([]byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Output")
@@ -70,7 +70,7 @@ func (m *MockCmd) Output() ([]byte, error) {
 	return ret0, ret1
 }
 
-// Output indicates an expected call of Output
+// Output indicates an expected call of Output.
 func (mr *MockCmdMockRecorder) Output() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Output", reflect.TypeOf((*MockCmd)(nil).Output))

--- a/ecs-init/exec/iptables/exec_mocks.go
+++ b/ecs-init/exec/iptables/exec_mocks.go
@@ -24,45 +24,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockExec is a mock of Exec interface
+// MockExec is a mock of Exec interface.
 type MockExec struct {
 	ctrl     *gomock.Controller
 	recorder *MockExecMockRecorder
 }
 
-// MockExecMockRecorder is the mock recorder for MockExec
+// MockExecMockRecorder is the mock recorder for MockExec.
 type MockExecMockRecorder struct {
 	mock *MockExec
 }
 
-// NewMockExec creates a new mock instance
+// NewMockExec creates a new mock instance.
 func NewMockExec(ctrl *gomock.Controller) *MockExec {
 	mock := &MockExec{ctrl: ctrl}
 	mock.recorder = &MockExecMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockExec) EXPECT() *MockExecMockRecorder {
 	return m.recorder
 }
 
-// LookPath mocks base method
-func (m *MockExec) LookPath(file string) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LookPath", file)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// LookPath indicates an expected call of LookPath
-func (mr *MockExecMockRecorder) LookPath(file interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LookPath", reflect.TypeOf((*MockExec)(nil).LookPath), file)
-}
-
-// Command mocks base method
+// Command mocks base method.
 func (m *MockExec) Command(name string, arg ...string) cmd.Cmd {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{name}
@@ -74,9 +59,24 @@ func (m *MockExec) Command(name string, arg ...string) cmd.Cmd {
 	return ret0
 }
 
-// Command indicates an expected call of Command
+// Command indicates an expected call of Command.
 func (mr *MockExecMockRecorder) Command(name interface{}, arg ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{name}, arg...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Command", reflect.TypeOf((*MockExec)(nil).Command), varargs...)
+}
+
+// LookPath mocks base method.
+func (m *MockExec) LookPath(file string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LookPath", file)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// LookPath indicates an expected call of LookPath.
+func (mr *MockExecMockRecorder) LookPath(file interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LookPath", reflect.TypeOf((*MockExec)(nil).LookPath), file)
 }

--- a/ecs-init/exec/sysctl/cmd_mocks.go
+++ b/ecs-init/exec/sysctl/cmd_mocks.go
@@ -23,30 +23,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockCmd is a mock of Cmd interface
+// MockCmd is a mock of Cmd interface.
 type MockCmd struct {
 	ctrl     *gomock.Controller
 	recorder *MockCmdMockRecorder
 }
 
-// MockCmdMockRecorder is the mock recorder for MockCmd
+// MockCmdMockRecorder is the mock recorder for MockCmd.
 type MockCmdMockRecorder struct {
 	mock *MockCmd
 }
 
-// NewMockCmd creates a new mock instance
+// NewMockCmd creates a new mock instance.
 func NewMockCmd(ctrl *gomock.Controller) *MockCmd {
 	mock := &MockCmd{ctrl: ctrl}
 	mock.recorder = &MockCmdMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockCmd) EXPECT() *MockCmdMockRecorder {
 	return m.recorder
 }
 
-// CombinedOutput mocks base method
+// CombinedOutput mocks base method.
 func (m *MockCmd) CombinedOutput() ([]byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CombinedOutput")
@@ -55,13 +55,13 @@ func (m *MockCmd) CombinedOutput() ([]byte, error) {
 	return ret0, ret1
 }
 
-// CombinedOutput indicates an expected call of CombinedOutput
+// CombinedOutput indicates an expected call of CombinedOutput.
 func (mr *MockCmdMockRecorder) CombinedOutput() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CombinedOutput", reflect.TypeOf((*MockCmd)(nil).CombinedOutput))
 }
 
-// Output mocks base method
+// Output mocks base method.
 func (m *MockCmd) Output() ([]byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Output")
@@ -70,7 +70,7 @@ func (m *MockCmd) Output() ([]byte, error) {
 	return ret0, ret1
 }
 
-// Output indicates an expected call of Output
+// Output indicates an expected call of Output.
 func (mr *MockCmdMockRecorder) Output() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Output", reflect.TypeOf((*MockCmd)(nil).Output))

--- a/ecs-init/exec/sysctl/exec_mocks.go
+++ b/ecs-init/exec/sysctl/exec_mocks.go
@@ -24,45 +24,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockExec is a mock of Exec interface
+// MockExec is a mock of Exec interface.
 type MockExec struct {
 	ctrl     *gomock.Controller
 	recorder *MockExecMockRecorder
 }
 
-// MockExecMockRecorder is the mock recorder for MockExec
+// MockExecMockRecorder is the mock recorder for MockExec.
 type MockExecMockRecorder struct {
 	mock *MockExec
 }
 
-// NewMockExec creates a new mock instance
+// NewMockExec creates a new mock instance.
 func NewMockExec(ctrl *gomock.Controller) *MockExec {
 	mock := &MockExec{ctrl: ctrl}
 	mock.recorder = &MockExecMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockExec) EXPECT() *MockExecMockRecorder {
 	return m.recorder
 }
 
-// LookPath mocks base method
-func (m *MockExec) LookPath(file string) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LookPath", file)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// LookPath indicates an expected call of LookPath
-func (mr *MockExecMockRecorder) LookPath(file interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LookPath", reflect.TypeOf((*MockExec)(nil).LookPath), file)
-}
-
-// Command mocks base method
+// Command mocks base method.
 func (m *MockExec) Command(name string, arg ...string) cmd.Cmd {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{name}
@@ -74,9 +59,24 @@ func (m *MockExec) Command(name string, arg ...string) cmd.Cmd {
 	return ret0
 }
 
-// Command indicates an expected call of Command
+// Command indicates an expected call of Command.
 func (mr *MockExecMockRecorder) Command(name interface{}, arg ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{name}, arg...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Command", reflect.TypeOf((*MockExec)(nil).Command), varargs...)
+}
+
+// LookPath mocks base method.
+func (m *MockExec) LookPath(file string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LookPath", file)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// LookPath indicates an expected call of LookPath.
+func (mr *MockExecMockRecorder) LookPath(file interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LookPath", reflect.TypeOf((*MockExec)(nil).LookPath), file)
 }

--- a/ecs-init/gpu/nvidia_gpu_manager_mocks.go
+++ b/ecs-init/gpu/nvidia_gpu_manager_mocks.go
@@ -23,87 +23,44 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockGPUManager is a mock of GPUManager interface
+// MockGPUManager is a mock of GPUManager interface.
 type MockGPUManager struct {
 	ctrl     *gomock.Controller
 	recorder *MockGPUManagerMockRecorder
 }
 
-// MockGPUManagerMockRecorder is the mock recorder for MockGPUManager
+// MockGPUManagerMockRecorder is the mock recorder for MockGPUManager.
 type MockGPUManagerMockRecorder struct {
 	mock *MockGPUManager
 }
 
-// NewMockGPUManager creates a new mock instance
+// NewMockGPUManager creates a new mock instance.
 func NewMockGPUManager(ctrl *gomock.Controller) *MockGPUManager {
 	mock := &MockGPUManager{ctrl: ctrl}
 	mock.recorder = &MockGPUManagerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockGPUManager) EXPECT() *MockGPUManagerMockRecorder {
 	return m.recorder
 }
 
-// Setup mocks base method
-func (m *MockGPUManager) Setup() error {
+// DetectGPUDevices mocks base method.
+func (m *MockGPUManager) DetectGPUDevices() error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Setup")
+	ret := m.ctrl.Call(m, "DetectGPUDevices")
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// Setup indicates an expected call of Setup
-func (mr *MockGPUManagerMockRecorder) Setup() *gomock.Call {
+// DetectGPUDevices indicates an expected call of DetectGPUDevices.
+func (mr *MockGPUManagerMockRecorder) DetectGPUDevices() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Setup", reflect.TypeOf((*MockGPUManager)(nil).Setup))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetectGPUDevices", reflect.TypeOf((*MockGPUManager)(nil).DetectGPUDevices))
 }
 
-// Initialize mocks base method
-func (m *MockGPUManager) Initialize() error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Initialize")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Initialize indicates an expected call of Initialize
-func (mr *MockGPUManagerMockRecorder) Initialize() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Initialize", reflect.TypeOf((*MockGPUManager)(nil).Initialize))
-}
-
-// Shutdown mocks base method
-func (m *MockGPUManager) Shutdown() error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Shutdown")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Shutdown indicates an expected call of Shutdown
-func (mr *MockGPUManagerMockRecorder) Shutdown() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Shutdown", reflect.TypeOf((*MockGPUManager)(nil).Shutdown))
-}
-
-// GetGPUDeviceIDs mocks base method
-func (m *MockGPUManager) GetGPUDeviceIDs() ([]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetGPUDeviceIDs")
-	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetGPUDeviceIDs indicates an expected call of GetGPUDeviceIDs
-func (mr *MockGPUManagerMockRecorder) GetGPUDeviceIDs() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGPUDeviceIDs", reflect.TypeOf((*MockGPUManager)(nil).GetGPUDeviceIDs))
-}
-
-// GetDriverVersion mocks base method
+// GetDriverVersion mocks base method.
 func (m *MockGPUManager) GetDriverVersion() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDriverVersion")
@@ -112,27 +69,42 @@ func (m *MockGPUManager) GetDriverVersion() (string, error) {
 	return ret0, ret1
 }
 
-// GetDriverVersion indicates an expected call of GetDriverVersion
+// GetDriverVersion indicates an expected call of GetDriverVersion.
 func (mr *MockGPUManagerMockRecorder) GetDriverVersion() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDriverVersion", reflect.TypeOf((*MockGPUManager)(nil).GetDriverVersion))
 }
 
-// DetectGPUDevices mocks base method
-func (m *MockGPUManager) DetectGPUDevices() error {
+// GetGPUDeviceIDs mocks base method.
+func (m *MockGPUManager) GetGPUDeviceIDs() ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DetectGPUDevices")
+	ret := m.ctrl.Call(m, "GetGPUDeviceIDs")
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetGPUDeviceIDs indicates an expected call of GetGPUDeviceIDs.
+func (mr *MockGPUManagerMockRecorder) GetGPUDeviceIDs() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGPUDeviceIDs", reflect.TypeOf((*MockGPUManager)(nil).GetGPUDeviceIDs))
+}
+
+// Initialize mocks base method.
+func (m *MockGPUManager) Initialize() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Initialize")
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// DetectGPUDevices indicates an expected call of DetectGPUDevices
-func (mr *MockGPUManagerMockRecorder) DetectGPUDevices() *gomock.Call {
+// Initialize indicates an expected call of Initialize.
+func (mr *MockGPUManagerMockRecorder) Initialize() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetectGPUDevices", reflect.TypeOf((*MockGPUManager)(nil).DetectGPUDevices))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Initialize", reflect.TypeOf((*MockGPUManager)(nil).Initialize))
 }
 
-// SaveGPUState mocks base method
+// SaveGPUState mocks base method.
 func (m *MockGPUManager) SaveGPUState() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SaveGPUState")
@@ -140,8 +112,36 @@ func (m *MockGPUManager) SaveGPUState() error {
 	return ret0
 }
 
-// SaveGPUState indicates an expected call of SaveGPUState
+// SaveGPUState indicates an expected call of SaveGPUState.
 func (mr *MockGPUManagerMockRecorder) SaveGPUState() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveGPUState", reflect.TypeOf((*MockGPUManager)(nil).SaveGPUState))
+}
+
+// Setup mocks base method.
+func (m *MockGPUManager) Setup() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Setup")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Setup indicates an expected call of Setup.
+func (mr *MockGPUManagerMockRecorder) Setup() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Setup", reflect.TypeOf((*MockGPUManager)(nil).Setup))
+}
+
+// Shutdown mocks base method.
+func (m *MockGPUManager) Shutdown() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Shutdown")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Shutdown indicates an expected call of Shutdown.
+func (mr *MockGPUManagerMockRecorder) Shutdown() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Shutdown", reflect.TypeOf((*MockGPUManager)(nil).Shutdown))
 }


### PR DESCRIPTION
Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

Upgrade github.com/golang/mock and mockgen from 1.3.x to 1.6.0.

### Implementation details
<!-- How are the changes implemented? -->

The first commit upgrades github.com/golang/mock and mockgen. The second commit fixes test failures due to the upgrade.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
