### PR TITLE
increase wait timeout for TestFirelensFluentbit

### DIFF
--- a/agent/engine/engine_sudo_linux_integ_test.go
+++ b/agent/engine/engine_sudo_linux_integ_test.go
@@ -377,8 +377,8 @@ func createFirelensTask(t *testing.T) *apitask.Task {
 }
 
 func waitCloudwatchLogs(client *cloudwatchlogs.CloudWatchLogs, params *cloudwatchlogs.GetLogEventsInput) (*cloudwatchlogs.GetLogEventsOutput, error) {
-	// The test could fail for timing issue, so retry for 30 seconds to make this test more stable
-	for i := 0; i < 30; i++ {
+	// The test could fail for timing issue, so retry for 60 seconds to make this test more stable
+	for i := 0; i < 60; i++ {
 		resp, err := client.GetLogEvents(params)
 		if err != nil {
 			awsError, ok := err.(awserr.Error)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
`TestFirelensFluentbit` integ tests have been failing for AL platforms on recent PRs like:


- https://github.com/aws/amazon-ecs-agent/pull/3452
- https://github.com/aws/amazon-ecs-agent/pull/3449

The test creates a new go routine to execute `engine.AddTask` workflow. It transitions a task from start to stop, by starting a `logsender` container and a `firelens` container.

It checks for CW log events every second, for a maximum of 30 seconds: https://github.com/aws/amazon-ecs-agent/blob/7b2c24dda23b6aba56ca5504c5aa336467f55060/agent/engine/engine_sudo_linux_integ_test.go#L379

Increasing the timeout from 30 seconds to 60 seconds seems to resolve the test failure. I am unclear on why this issue is only visible recently in dev branch, with no change in test code, setup.

Increasing this timeout is safe to do because the `waitCloudwatchLogs` method checks for log events every second (not at the end of 30s).
### Implementation details
<!-- How are the changes implemented? -->

increasing wait timeout for `TestFirelensFluentbit`

### Testing
<!-- How was this tested? --> 
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
