### PR TITLE
Restart AppNet Relay on failure

### DIFF
--- a/agent/engine/serviceconnect/manager_linux.go
+++ b/agent/engine/serviceconnect/manager_linux.go
@@ -302,7 +302,15 @@ func (m *manager) CreateInstanceTask(cfg *config.Config) (*apitask.Task, error) 
 		return nil, err
 	}
 	containerRunning := apicontainerstatus.ContainerRunning
-	dockerHostConfig := dockercontainer.HostConfig{NetworkMode: apitask.HostNetworkMode}
+	dockerHostConfig := dockercontainer.HostConfig{
+		NetworkMode: apitask.HostNetworkMode,
+		// do not restart relay if it's stopped manually.
+		// the default value of 0 for MaximumRetryCount means that we will not enforce a maximum count
+		RestartPolicy: dockercontainer.RestartPolicy{
+			Name:              "on-failure",
+			MaximumRetryCount: 0,
+		},
+	}
 	rawHostConfig, err := json.Marshal(&dockerHostConfig)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Restart AppNet Relay on failure

### Implementation details
Configure Docker restart policy for AppNet Relay container so that it will be restarted by docker if it exits due to an error.
`MaximumRetryCount` is set to 0 to indicate that we are not enforcing a maximum count ([reference](https://github.com/moby/moby/blob/7b9275c0da707b030e62c96b679a976f31f929d3/restartmanager/restartmanager.go#L91))
### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> no

Tested with new ECS Agent and verified that AppNet Relay has correct restart policy configured
```
$ docker inspect 805d395608a5 | jq .[0].HostConfig.RestartPolicy
{
  "Name": "on-failure",
  "MaximumRetryCount": 0
}
```

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Restart AppNet Relay on failure

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
