### PR TITLE
adding util methods to get ephemeral host port range [part 2 of container-port-range support]

### DIFF
--- a/agent/utils/ephemeral_ports_linux.go
+++ b/agent/utils/ephemeral_ports_linux.go
@@ -1,0 +1,52 @@
+//go:build linux
+// +build linux
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package utils
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+const (
+	// defaultPortRangeStart indicates the first port in ephemeral port range
+	defaultPortRangeStart = 49153
+	// defaultPortRangeEnd indicates the last port in ephemeral port range
+	defaultPortRangeEnd = 65535
+	// portRangeKernelParam is a kernel parameter that defines the ephemeral port range
+	portRangeKernelParam = "/proc/sys/net/ipv4/ip_local_port_range"
+)
+
+// getDynamicHostPortRange returns the ephemeral port range defined by the "/proc/sys/net/ipv4/ip_local_port_range"
+// kernel parameter. Ref: https://github.com/moby/moby/blob/master/libnetwork/portallocator/portallocator_linux.go
+func getDynamicHostPortRange() (start int, end int, err error) {
+	file, err := os.Open(portRangeKernelParam)
+	if err != nil {
+		return 0, 0, err
+	}
+	defer file.Close()
+
+	n, err := fmt.Fscanf(bufio.NewReader(file), "%d\t%d", &start, &end)
+	if n != 2 || err != nil {
+		if err == nil {
+			err = fmt.Errorf("unexpected count of parsed numbers (%d)", n)
+		}
+		return 0, 0, fmt.Errorf("failed to parse ephemeral port range from %s: %v",
+			portRangeKernelParam, err)
+	}
+	return start, end, nil
+}

--- a/agent/utils/ephemeral_ports_test.go
+++ b/agent/utils/ephemeral_ports_test.go
@@ -1,11 +1,32 @@
 package utils
 
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
 import (
+	"errors"
 	"math/rand"
 	"testing"
 	"time"
 
+	"github.com/docker/go-connections/nat"
+
 	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testTCPProtocol = "tcp"
+	testUDPProtocol = "udp"
 )
 
 func TestGenerateEphemeralPortNumbers(t *testing.T) {
@@ -49,4 +70,65 @@ func TestGenerateEphemeralPortNumbers_CollisionError(t *testing.T) {
 	assert.Nil(t, ports)
 	assert.Error(t, err)
 	assert.Equal(t, "maximum number of attempts to generate unique ports reached", err.Error())
+}
+
+func TestGetHostPortRange(t *testing.T) {
+	testCases := []struct {
+		testName      string
+		numberOfPorts int
+		protocol      string
+		expectedError error
+	}{
+		{
+			testName:      "tcp protocol, contiguous hostPortRange found",
+			numberOfPorts: 10,
+			protocol:      testTCPProtocol,
+			expectedError: nil,
+		},
+		{
+			testName:      "udp protocol, contiguous hostPortRange found",
+			numberOfPorts: 500,
+			protocol:      testUDPProtocol,
+			expectedError: nil,
+		},
+		{
+			testName:      "contiguous hostPortRange not found",
+			numberOfPorts: 20,
+			protocol:      testTCPProtocol,
+			expectedError: errors.New("20 contiguous host ports unavailable"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			hostPortRange, err := GetHostPortRange(tc.numberOfPorts, tc.protocol)
+			if tc.expectedError == nil {
+				assert.NoError(t, err)
+
+				numberOfHostPorts, err := getPortRangeLength(hostPortRange)
+				assert.NoError(t, err)
+				assert.Equal(t, tc.numberOfPorts, numberOfHostPorts)
+			} else {
+				defer func() {
+					dynamicHostPortRange = getDynamicHostPortRange
+				}()
+
+				dynamicHostPortRange = func() (start int, end int, err error) {
+					return 1, 2, nil
+				}
+				hostPortRange, err := GetHostPortRange(tc.numberOfPorts, tc.protocol)
+				assert.Equal(t, tc.expectedError, err)
+				assert.Equal(t, "", hostPortRange)
+			}
+
+		})
+	}
+}
+
+func getPortRangeLength(portRange string) (int, error) {
+	startPort, endPort, err := nat.ParsePortRangeToInt(portRange)
+	if err != nil {
+		return 0, err
+	}
+	return endPort - startPort + 1, nil
 }

--- a/agent/utils/ephemeral_ports_unsupported.go
+++ b/agent/utils/ephemeral_ports_unsupported.go
@@ -1,0 +1,29 @@
+//go:build !linux && !windows
+// +build !linux,!windows
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package utils
+
+const (
+	// defaultPortRangeStart indicates the first port in ephemeral port range
+	defaultPortRangeStart = 49153
+	// defaultPortRangeEnd indicates the last port in ephemeral port range
+	defaultPortRangeEnd = 65535
+)
+
+// getDynamicHostPortRange returns the default ephemeral port range
+func getDynamicHostPortRange() (start int, end int, err error) {
+	return defaultPortRangeStart, defaultPortRangeEnd, nil
+}

--- a/agent/utils/ephemeral_ports_windows.go
+++ b/agent/utils/ephemeral_ports_windows.go
@@ -1,0 +1,18 @@
+//go:build windows
+// +build windows
+
+package utils
+
+const (
+	// Ref: https://learn.microsoft.com/en-US/troubleshoot/windows-server/networking/default-dynamic-port-range-tcpip-chang
+	// defaultPortRangeStart indicates the first port in ephemeral port range
+	defaultPortRangeStart = 49152
+	// defaultPortRangeEnd indicates the last port in ephemeral port range
+	defaultPortRangeEnd = 65535
+)
+
+// getDynamicHostPortRange returns the default ephemeral port range on Windows.
+// TODO: instead of sticking to defaults, run netsh commands on the host to get the ranges.
+func getDynamicHostPortRange() (start int, end int, err error) {
+	return defaultPortRangeStart, defaultPortRangeEnd, nil
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR follows after https://github.com/aws/amazon-ecs-agent/pull/3473
It adds helper util methods to get contiguous host ports from the ephemeral port range.

To follow in next PR, 
Supply docker with port ranges, using the helper method added in this PR.

### Implementation details
<!-- How are the changes implemented? -->
The agent would query host property and get the ephemeral port range. It would loop over the ephemeral range and get N contiguous host ports where N = number of container ports in `containerPortRange`.

If it is unable to read host property, the agent would stick to a defined default ephemeral range.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
