### PR TITLE
Add ecs-serviceconnect to CNI and Agent build scripts

### DIFF
--- a/scripts/build-agent-image
+++ b/scripts/build-agent-image
@@ -48,6 +48,7 @@ cp ./misc/plugins/ecs-bridge rootfs/amazon-ecs-cni-plugins/ecs-bridge
 cp ./misc/plugins/ecs-eni rootfs/amazon-ecs-cni-plugins/ecs-eni
 cp ./misc/plugins/ecs-ipam rootfs/amazon-ecs-cni-plugins/ecs-ipam
 cp ./misc/plugins/vpc-branch-eni rootfs/amazon-ecs-cni-plugins/vpc-branch-eni
+cp ./misc/plugins/ecs-serviceconnect rootfs/amazon-ecs-cni-plugins/ecs-serviceconnect
 
 # add certs
 mkdir -p rootfs/etc/ssl/certs/

--- a/scripts/build-cni-plugins
+++ b/scripts/build-cni-plugins
@@ -61,9 +61,9 @@ make clean
 
 # buildvcs=false excludes version control information in golang >= 1.18. This is required for compiling agent with included repositories
 if [[ $goversion < "1.18" ]]; then
-	cd ${GITPATH}/amazon-vpc-cni-plugins && GO111MODULE=on GOFLAGS="-mod=vendor" make aws-appmesh vpc-branch-eni
+	cd ${GITPATH}/amazon-vpc-cni-plugins && GO111MODULE=on GOFLAGS="-mod=vendor" make aws-appmesh vpc-branch-eni ecs-serviceconnect
 else
-	cd ${GITPATH}/amazon-vpc-cni-plugins && GO111MODULE=on GOFLAGS="-mod=vendor -buildvcs=false" make aws-appmesh vpc-branch-eni
+	cd ${GITPATH}/amazon-vpc-cni-plugins && GO111MODULE=on GOFLAGS="-mod=vendor -buildvcs=false" make aws-appmesh vpc-branch-eni ecs-serviceconnect
 fi
 cp -a ./build/linux_${GOARCH}/. ${ROOT}/misc/plugins/
 make clean


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Add ecs-serviceconnect to CNI and Agent build scripts invoked by make target `dockerfree-agent-image`. 

We are seeing below error when running SC:
```
error="add network failed: failed to find plugin \"ecs-serviceconnect\" in path [/amazon-ecs-cni-plugins]"
```

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> no

```
% sudo make dockerfree-agent-image
...
Built ecs-serviceconnect plugin.
...
+ cp ./misc/plugins/ecs-serviceconnect rootfs/amazon-ecs-cni-plugins/ecs-serviceconnect
...
```
Using the generated ECS Agent image, I replaced the ECS Agent on an existing ECS Optimized AMI;

Before replacing, `ecs-serviceconnect` binary is missing
```
$ docker ps
CONTAINER ID   IMAGE                            COMMAND    CREATED          STATUS                    PORTS     NAMES
5f4144ccd269   amazon/amazon-ecs-agent:latest   "/agent"   47 minutes ago   Up 47 minutes (healthy)             ecs-agent
[ec2-user@ip-172-31-3-30 ~]$ docker export 5f4144ccd269 | tar -tf - | grep plugins
amazon-ecs-cni-plugins/
amazon-ecs-cni-plugins/aws-appmesh
amazon-ecs-cni-plugins/ecs-bridge
amazon-ecs-cni-plugins/ecs-eni
amazon-ecs-cni-plugins/ecs-ipam
amazon-ecs-cni-plugins/vpc-branch-eni
etc/docker/plugins/
run/docker/plugins/
```
After replacing, `ecs-serviceconnect` is now present
```
$ docker ps
CONTAINER ID   IMAGE                            COMMAND    CREATED         STATUS                            PORTS     NAMES
4fd68939ffba   amazon/amazon-ecs-agent:latest   "/agent"   3 seconds ago   Up 2 seconds (health: starting)             ecs-agent
[ec2-user@ip-172-31-3-30 ~]$ docker export 4fd68939ffba | tar -tf - | grep plugins
amazon-ecs-cni-plugins/
amazon-ecs-cni-plugins/aws-appmesh
amazon-ecs-cni-plugins/ecs-bridge
amazon-ecs-cni-plugins/ecs-eni
amazon-ecs-cni-plugins/ecs-ipam
amazon-ecs-cni-plugins/ecs-serviceconnect
amazon-ecs-cni-plugins/vpc-branch-eni
etc/docker/plugins/
run/docker/plugins/

```



### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Add ecs-serviceconnect to CNI and Agent build scripts

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
