### PR TITLE
Add call to update-version.sh to PR merge codebuild buildspec

### DIFF
--- a/buildspecs/merge-build.yml
+++ b/buildspecs/merge-build.yml
@@ -71,6 +71,18 @@ phases:
 
       # Build agent tar and rpm
       - GO111MODULE=auto
+
+      # Update version.go file
+      - ./scripts/update-version.sh
+      - git add agent/version/version.go
+
+      # Dummy git config to create a commit
+      - git config user.email "you@example.com"
+      - git config user.name "Your Name"
+
+      # Commit required to build agent with updated files
+      - git commit -m "update version"
+
       - make dockerfree-agent-image
       - make generic-rpm-integrated
       - ls

--- a/buildspecs/pr-build.yml
+++ b/buildspecs/pr-build.yml
@@ -60,6 +60,18 @@ phases:
 
       # Building agent tars
       - GO111MODULE=auto
+
+      # Update version.go file
+      - ./scripts/update-version.sh | tee -a $BUILD_LOG
+      - git add agent/version/version.go | tee -a $BUILD_LOG
+
+      # Dummy git config to create a commit
+      - git config user.email "you@example.com" | tee -a $BUILD_LOG
+      - git config user.name "Your Name" | tee -a $BUILD_LOG
+
+      # Commit required to build agent with updated files
+      - git commit -m "update version" | tee -a $BUILD_LOG
+
       - make dockerfree-agent-image 2>&1 | tee -a $BUILD_LOG
       - make generic-rpm-integrated 2>&1 | tee -a $BUILD_LOG
       - ls


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR adds call to ```update-version.sh``` script before building agent artifacts. This fixes a bug causing mismatch between git commit sha in agent/version.go and agent.json/agent artifact suffixes.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Create a test pr against a test base branch and merge to trigger a test (mirror) build codepipeline. Verify commit sha of the artifacts built (checked by ```curl -s 127.0.0.1:51678/v1/metadata | python -mjson.tool```) match against the artifact name suffix/agent.json config file

New tests cover the changes: <!-- yes|no -->
no new tests

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
add call to update-version.sh to dockerfree-agent-image

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
