### PR TITLE
Upgrade GitHub actions packages to v3

### DIFF
--- a/.github/workflows/gitsecrets.yml
+++ b/.github/workflows/gitsecrets.yml
@@ -8,7 +8,7 @@ jobs:
     name: Git Secrets Scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: src/github.com/aws/amazon-ecs-agent
       - name: Git Secrets Scan Script

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -8,7 +8,7 @@ jobs:
     name: Linux unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: src/github.com/aws/amazon-ecs-agent
       - name: get GO_VERSION
@@ -25,10 +25,10 @@ jobs:
             exit 1
           fi
           echo "::set-output name=GO_VERSION::$go_version"
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: ${{ steps.get-go-version.outputs.GO_VERSION }}
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
           path: src/github.com/aws/amazon-ecs-agent

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -8,7 +8,7 @@ jobs:
     name: Static Analysis
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: src/github.com/aws/amazon-ecs-agent
       - name: get GO_VERSION
@@ -25,10 +25,10 @@ jobs:
             exit 1
           fi
           echo "::set-output name=GO_VERSION::$go_version"
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: ${{ steps.get-go-version.outputs.GO_VERSION }}
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: src/github.com/aws/amazon-ecs-agent
       - name: run static checks
@@ -44,7 +44,7 @@ jobs:
     name: Static Analysis Init
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: src/github.com/aws/amazon-ecs-agent
       - name: get GO_VERSION
@@ -61,10 +61,10 @@ jobs:
             exit 1
           fi
           echo "::set-output name=GO_VERSION::$go_version"
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: ${{ steps.get-go-version.outputs.GO_VERSION }}
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: src/github.com/aws/amazon-ecs-agent
       - name: run static checks
@@ -80,7 +80,7 @@ jobs:
     name: Cross platform build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: src/github.com/aws/amazon-ecs-agent
       - name: get GO_VERSION
@@ -97,10 +97,10 @@ jobs:
             exit 1
           fi
           echo "::set-output name=GO_VERSION::$go_version"
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: ${{ steps.get-go-version.outputs.GO_VERSION }}
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
           path: src/github.com/aws/amazon-ecs-agent

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -8,7 +8,7 @@ jobs:
     name: Windows unit tests
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: src/github.com/aws/amazon-ecs-agent
       - name: get GO_VERSION
@@ -24,10 +24,10 @@ jobs:
             exit 1
           }
           Write-Output "::set-output name=GO_VERSION_WINDOWS::$go_version_win"
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: ${{ steps.get-go-version.outputs.GO_VERSION_WINDOWS }}
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
           path: src/github.com/aws/amazon-ecs-agent


### PR DESCRIPTION
### Summary
This change upgrades actions/checkout and actions/setup-go from v2 to v3.

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

### Implementation details
Upgrade actions packages to v3.

### Testing
GitHub actions should be successful

New tests cover the changes: N/A

### Description for the changelog
CI, changelog entry not needed

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Austin Vazquez <macedonv@amazon.com>
