### PR TITLE
Remove set-output GitHub action command

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -24,8 +24,8 @@ jobs:
             echo "invalid GO version"
             exit 1
           fi
-          echo "::set-output name=GO_VERSION::$go_version"
-      - uses: actions/setup-go@v2
+          echo "GO_VERSION=$go_version" >> $GITHUB_OUTPUT
+      - uses: actions/setup-go@v3
         with:
           go-version: ${{ steps.get-go-version.outputs.GO_VERSION }}
       - uses: actions/checkout@v2

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -24,8 +24,8 @@ jobs:
             echo "invalid GO version"
             exit 1
           fi
-          echo "::set-output name=GO_VERSION::$go_version"
-      - uses: actions/setup-go@v2
+          echo "GO_VERSION=$go_version" >> $GITHUB_OUTPUT
+      - uses: actions/setup-go@v3
         with:
           go-version: ${{ steps.get-go-version.outputs.GO_VERSION }}
       - uses: actions/checkout@v2
@@ -60,8 +60,8 @@ jobs:
             echo "invalid GO version"
             exit 1
           fi
-          echo "::set-output name=GO_VERSION::$go_version"
-      - uses: actions/setup-go@v2
+          echo "GO_VERSION=$go_version" >> $GITHUB_OUTPUT
+      - uses: actions/setup-go@v3
         with:
           go-version: ${{ steps.get-go-version.outputs.GO_VERSION }}
       - uses: actions/checkout@v2
@@ -96,8 +96,8 @@ jobs:
             echo "invalid GO version"
             exit 1
           fi
-          echo "::set-output name=GO_VERSION::$go_version"
-      - uses: actions/setup-go@v2
+          echo "GO_VERSION=$go_version" >> $GITHUB_OUTPUT
+      - uses: actions/setup-go@v3
         with:
           go-version: ${{ steps.get-go-version.outputs.GO_VERSION }}
       - uses: actions/checkout@v2

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -23,8 +23,8 @@ jobs:
             echo "invalid GO version"
             exit 1
           }
-          Write-Output "::set-output name=GO_VERSION_WINDOWS::$go_version_win"
-      - uses: actions/setup-go@v2
+          Write-Output "GO_VERSION_WINDOWS=$go_version_win" >> $GITHUB_OUTPUT
+      - uses: actions/setup-go@v3
         with:
           go-version: ${{ steps.get-go-version.outputs.GO_VERSION_WINDOWS }}
       - uses: actions/checkout@v2


### PR DESCRIPTION
### Summary
Removes deprecated set-output GitHub action command.

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

### Implementation details
Updated command references 

### Testing
GitHub actions should pass

New tests cover the changes: N/A

### Description for the changelog
CI - changelog entry not needed

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Austin Vazquez <macedonv@amazon.com>