### PR TITLE
update package build readmes with new targets

### DIFF
--- a/packaging/generic-deb-integrated/debian/README.source
+++ b/packaging/generic-deb-integrated/debian/README.source
@@ -14,7 +14,7 @@ Steps to build and install package:
     https://docs.aws.amazon.com/efs/latest/ug/installing-amazon-efs-utils.html#installing-other-distro
 
 5. Install the package with
-    sudo apt install -y ./amazon-ecs-init_1.66.2-1_amd64.deb
+    sudo apt install -y ./amazon-ecs-init_${AGENT_VERSION}-1_amd64.deb
 
 6. Install docker and start and enable ecs service
     sudo systemctl enable --now ecs

--- a/packaging/generic-deb-integrated/debian/README.source
+++ b/packaging/generic-deb-integrated/debian/README.source
@@ -1,10 +1,10 @@
 Steps to build and install package:
 
 1. Install build dependencies
-    sudo apt-get update -y && sudo apt-get install -y devscripts build-essential lintian git curl golang-go debhelper
+    sudo apt-get update -y && sudo apt-get install -y make dpkg-dev wget devscripts debhelper
 
 2. Build the package by running
-    make clean deb
+    make clean generic-deb-integrated
 
 3. Install docker
     sudo apt-get install docker.io -y # or via docker repos: https://docs.docker.com/engine/install/
@@ -14,7 +14,7 @@ Steps to build and install package:
     https://docs.aws.amazon.com/efs/latest/ug/installing-amazon-efs-utils.html#installing-other-distro
 
 5. Install the package with
-    sudo apt install -y ./amazon-ecs-init_1.45.0-1_amd64.deb
+    sudo apt install -y ./amazon-ecs-init_1.66.2-1_amd64.deb
 
 6. Install docker and start and enable ecs service
     sudo systemctl enable --now ecs

--- a/packaging/generic-rpm-integrated/README.md
+++ b/packaging/generic-rpm-integrated/README.md
@@ -2,19 +2,11 @@
 
 * Install build and install dependencies
   ```
-  rpm-build make golang-go gcc git wget rpmdevtools 
-  ```
-* Download the latest agent
-  ```
-  curl -O https://s3.amazonaws.com/amazon-ecs-agent/ecs-agent-v${VERSION}.tar
-  ```
-  or
-  ```
-  curl -O https://s3.amazonaws.com/amazon-ecs-agent/ecs-agent-arm64-v${VERSION}.tar
+  rpm-build make gcc git wget rpmdevtools 
   ```
 * Build the package by running 
   ```
-  make generic-rpm
+  make generic-rpm-integrated
   ```
 * Install docker via docker repos: https://docs.docker.com/engine/install/
 * Install the package using built `.rpm` file from previous step
@@ -27,4 +19,3 @@
   ```
   sudo systemctl enable --now amazon-ecs-volume-plugin
   ```
-


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
New packaging and build targets were introduced in the amazon-ecs-agent repository a while ago for building init packages for both deb and rpm type builds (#3234). This PR updates the respective Readme files with instructions to build them.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Tested that following the updated instructions build ```.deb``` and ```.rpm``` files with Ubuntu 20.04 and Amazon Linux 2 instances.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Update packaging Readme files with updated instructions to build init files

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
