### PR TITLE
Fix unit tests for cgroup v2

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -6,7 +6,7 @@ permissions: read-all
 jobs:
   unit-tests:
     name: Linux unit tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:

--- a/agent/taskresource/cgroup/cgroup_test.go
+++ b/agent/taskresource/cgroup/cgroup_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/amazon-ecs-agent/agent/config"
 	cgroup "github.com/aws/amazon-ecs-agent/agent/taskresource/cgroup/control"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/cgroup/control/mock_control"
 	resourcestatus "github.com/aws/amazon-ecs-agent/agent/taskresource/status"
@@ -42,6 +43,9 @@ const (
 )
 
 func TestCreateHappyPath(t *testing.T) {
+	if config.CgroupV2 {
+		t.Skip("Skipping TestCreateHappyPath for CgroupV2 as memory.use_hierarchy is not created when cgroupV2=true")
+	}
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -68,6 +72,9 @@ func TestCreateCgroupPathExists(t *testing.T) {
 	mockIO := mock_ioutilwrapper.NewMockIOUtil(ctrl)
 
 	cgroupRoot := fmt.Sprintf("/ecs/%s", taskID)
+	if config.CgroupV2 {
+		cgroupRoot = fmt.Sprintf("ecstasks-%s.slice", taskID)
+	}
 
 	gomock.InOrder(
 		mockControl.EXPECT().Exists(gomock.Any()).Return(true),
@@ -85,6 +92,9 @@ func TestCreateCgroupError(t *testing.T) {
 	mockIO := mock_ioutilwrapper.NewMockIOUtil(ctrl)
 
 	cgroupRoot := fmt.Sprintf("/ecs/%s", taskID)
+	if config.CgroupV2 {
+		cgroupRoot = fmt.Sprintf("ecstasks-%s.slice", taskID)
+	}
 
 	gomock.InOrder(
 		mockControl.EXPECT().Exists(gomock.Any()).Return(false),
@@ -101,6 +111,9 @@ func TestCleanupHappyPath(t *testing.T) {
 
 	mockControl := mock_control.NewMockControl(ctrl)
 	cgroupRoot := fmt.Sprintf("/ecs/%s", taskID)
+	if config.CgroupV2 {
+		cgroupRoot = fmt.Sprintf("ecstasks-%s.slice", taskID)
+	}
 
 	mockControl.EXPECT().Remove(cgroupRoot).Return(nil)
 
@@ -114,6 +127,9 @@ func TestCleanupRemoveError(t *testing.T) {
 
 	mockControl := mock_control.NewMockControl(ctrl)
 	cgroupRoot := fmt.Sprintf("/ecs/%s", taskID)
+	if config.CgroupV2 {
+		cgroupRoot = fmt.Sprintf("ecstasks-%s.slice", taskID)
+	}
 
 	mockControl.EXPECT().Remove(gomock.Any()).Return(errors.New("cgroup remove error"))
 
@@ -127,6 +143,9 @@ func TestCleanupCgroupDeletedError(t *testing.T) {
 
 	mockControl := mock_control.NewMockControl(ctrl)
 	cgroupRoot := fmt.Sprintf("/ecs/%s", taskID)
+	if config.CgroupV2 {
+		cgroupRoot = fmt.Sprintf("ecstasks-%s.slice", taskID)
+	}
 
 	err := cgroups.ErrCgroupDeleted
 	wrappedErr := fmt.Errorf("cgroup remove: unable to obtain controller: %w", err)
@@ -144,6 +163,11 @@ func TestMarshal(t *testing.T) {
 		"\"createdAt\":\"0001-01-01T00:00:00Z\",\"desiredStatus\":\"CREATED\",\"knownStatus\":\"NONE\",\"resourceSpec\":{}}"
 
 	cgroupRoot := "/ecs/taskid"
+	if config.CgroupV2 {
+		cgroupRoot = fmt.Sprintf("ecstasks-%s.slice", "taskid")
+		cgroupStr = "{\"cgroupRoot\":\"ecstasks-taskid.slice\",\"cgroupMountPath\":\"/sys/fs/cgroup\"," +
+			"\"createdAt\":\"0001-01-01T00:00:00Z\",\"desiredStatus\":\"CREATED\",\"knownStatus\":\"NONE\",\"resourceSpec\":{}}"
+	}
 	cgroupMountPath := "/sys/fs/cgroup"
 
 	cgroup := NewCgroupResource("", cgroup.New(), nil, cgroupRoot, cgroupMountPath, specs.LinuxResources{})
@@ -160,6 +184,14 @@ func TestUnmarshal(t *testing.T) {
 	cgroupMountPath := "/sys/fs/cgroup"
 	bytes := []byte("{\"CgroupRoot\":\"/ecs/taskid\",\"CgroupMountPath\":\"/sys/fs/cgroup\"," +
 		"\"CreatedAt\":\"0001-01-01T00:00:00Z\",\"DesiredStatus\":\"CREATED\",\"KnownStatus\":\"NONE\"}")
+
+	if config.CgroupV2 {
+		cgroupRoot = fmt.Sprintf("ecstasks-%s.slice", "taskid")
+		bytes = []byte("{\"CgroupRoot\":\"ecstasks-taskid.slice\",\"CgroupMountPath\":\"/sys/fs/cgroup\"," +
+			"\"CreatedAt\":\"0001-01-01T00:00:00Z\",\"DesiredStatus\":\"CREATED\",\"KnownStatus\":\"NONE\"}")
+
+	}
+
 	unmarshalledCgroup := &CgroupResource{}
 	err := unmarshalledCgroup.UnmarshalJSON(bytes)
 	assert.NoError(t, err)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
* ECS Agent already supports cgroupv2, but some unit tests failed to work with cgroupv2 support. This PR makes due changes to the tests by checking for the cgroup version support running and verifying the correct addresses/values depending on the support. 
* Additionally, also this PR also changes the GH Actions tests to run on ```ubuntu-latest``` which now points to ubuntu 22.04 to keep up with the latest OS.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Verified the following commands succeeded for cgroupv1 and cgroupv2 support on ubuntu 20.04 and ubuntu 22.04
```make test-silent```
```make test-init```
New tests cover the changes: <!-- yes|no -->
yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Fix unit tests for cgroup v2
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
