### PR TITLE
Make version generation consistent across build targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ static:
 	./scripts/build
 
 static-with-pause:
-	./scripts/build true "" false true
+	./scripts/build true "" true true
 
 # Cross-platform build target for static checks
 xplatform-build:
@@ -381,7 +381,7 @@ amazon-linux-sources.tgz:
 
 .amazon-linux-rpm-integrated-done: amazon-linux-sources.tgz
 	test -e SOURCES || ln -s . SOURCES
-	rpmbuild --define "%_topdir $(PWD)" -bb ecs-init.spec
+	rpmbuild --define "%_topdir $(PWD)" -bb ecs-agent.spec
 	find RPMS/ -type f -exec cp {} . \;
 	touch .amazon-linux-rpm-integrated-done
 
@@ -404,8 +404,8 @@ generic-rpm-integrated: .generic-rpm-integrated-done
 VERSION = $(shell cat ecs-init/ECSVERSION)
 
 .generic-deb-integrated-done: get-cni-sources
-	mkdir -p BUILDROOT
 	./scripts/update-version.sh
+	mkdir -p BUILDROOT
 	tar -czf ./amazon-ecs-init_${VERSION}.orig.tar.gz ecs-init scripts README.md
 	cp -r packaging/generic-deb-integrated/debian Makefile ecs-init scripts misc agent agent-container amazon-ecs-cni-plugins amazon-vpc-cni-plugins README.md VERSION GO_VERSION BUILDROOT
 	cd BUILDROOT && dpkg-buildpackage -uc -b
@@ -459,16 +459,17 @@ generic-rpm: .generic-rpm-done
 deb: .deb-done
 
 clean:
-	rm -f misc/certs/host-certs.crt &> /dev/null
-	rm -rf misc/pause-container/image/
-	rm -rf misc/pause-container/rootfs/
-	rm -rf misc/plugins/
-	rm -rf out/
-	rm -rf rootfs/
+	-rm -f misc/certs/host-certs.crt &> /dev/null
+	-rm -rf misc/pause-container/image/
+	-rm -rf misc/pause-container/rootfs/
+	-rm -rf misc/plugins/
+	-rm -rf out/
+	-rm -rf rootfs/
 	-$(MAKE) -C $(ECS_CNI_REPOSITORY_SRC_DIR) clean
 	-rm -f .get-deps-stamp
 	-rm -f .builder-image-stamp
 	-rm -f .out-stamp
+	-rm -f ecs-agent.spec
 	-rm -rf $(PWD)/bin
 	-rm -rf cover.out
 	-rm -rf coverprofile.out

--- a/agent/version/formatting.go
+++ b/agent/version/formatting.go
@@ -48,9 +48,7 @@ func String() string {
 	return ret + GitShortHash + ")"
 }
 
+// Don't prepend the dirty (*) in pathwriter path
 func GitHashString() string {
-	if GitDirty {
-		return "*" + GitShortHash
-	}
 	return GitShortHash
 }

--- a/buildspecs/merge-build.yml
+++ b/buildspecs/merge-build.yml
@@ -71,18 +71,6 @@ phases:
 
       # Build agent tar and rpm
       - GO111MODULE=auto
-
-      # Update version.go file
-      - ./scripts/update-version.sh
-      - git add agent/version/version.go
-
-      # Dummy git config to create a commit
-      - git config user.email "you@example.com"
-      - git config user.name "Your Name"
-
-      # Commit required to build agent with updated files
-      - git commit -m "update version"
-
       - make dockerfree-agent-image
       - make generic-rpm-integrated
       - ls

--- a/buildspecs/pr-build.yml
+++ b/buildspecs/pr-build.yml
@@ -60,18 +60,6 @@ phases:
 
       # Building agent tars
       - GO111MODULE=auto
-
-      # Update version.go file
-      - ./scripts/update-version.sh | tee -a $BUILD_LOG
-      - git add agent/version/version.go | tee -a $BUILD_LOG
-
-      # Dummy git config to create a commit
-      - git config user.email "you@example.com" | tee -a $BUILD_LOG
-      - git config user.name "Your Name" | tee -a $BUILD_LOG
-
-      # Commit required to build agent with updated files
-      - git commit -m "update version" | tee -a $BUILD_LOG
-
       - make dockerfree-agent-image 2>&1 | tee -a $BUILD_LOG
       - make generic-rpm-integrated 2>&1 | tee -a $BUILD_LOG
       - ls

--- a/packaging/amazon-linux-ami-integrated/ecs-agent.spec
+++ b/packaging/amazon-linux-ami-integrated/ecs-agent.spec
@@ -161,7 +161,7 @@ required routes among its preparation steps.
 # each of these should build for arm and amd arch
 ./scripts/get-host-certs
 ./scripts/build-cni-plugins
-./scripts/build-integrated true "" false true
+./scripts/build-integrated true "" true true
 ./scripts/build-agent-image
 ./scripts/gobuild.sh %{gobuild_tag}
 

--- a/packaging/generic-rpm-integrated/amazon-ecs-init.spec
+++ b/packaging/generic-rpm-integrated/amazon-ecs-init.spec
@@ -46,7 +46,7 @@ required routes among its preparation steps.
 %build
 ./scripts/get-host-certs
 ./scripts/build-cni-plugins
-./scripts/build-integrated true "" false true
+./scripts/build-integrated true "" true true
 ./scripts/build-agent-image
 ./scripts/gobuild.sh %{gobuild_tag}
 

--- a/scripts/build-integrated
+++ b/scripts/build-integrated
@@ -52,10 +52,10 @@ cd "${SRCPATH}/agent"
 if [[ "${version_gen}" == "true" ]]; then
     # Versioning stuff. We run the generator to setup the version and then always
     # restore ourselves to a clean state
-    cp agent/version/version.go agent/version/_version.go
-    trap "cd \"${ROOT}\"; mv agent/version/_version.go agent/version/version.go" EXIT SIGHUP SIGINT SIGTERM
+    cp ${ROOT}/agent/version/version.go ${ROOT}/agent/version/_version.go
+    trap "cd \"${ROOT}\"; mv ${ROOT}/agent/version/_version.go ${ROOT}/agent/version/version.go" EXIT SIGHUP SIGINT SIGTERM
 
-  cd ./agent/version/
+  cd ${ROOT}/agent/version/
   # Turn off go module here because version-gen.go is a separate program (i.e. "package main")
   # and no dependency needed to be fetched (but if go mod is on it will try to fetch dependency causing
   # this script to fail when we run it in a container with network mode "none").


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Update each of the build processes to use the build-time version rather than the existing version.  Also removing the `*` in our path, but not from the human-readable string.

### Implementation details
Update `build-integrated` to use the buildroot for version file update; update each make target/script/spec file to use the `version_gen=true` path in build-integrated.

also note that this reverts a workaround in our builds https://github.com/aws/amazon-ecs-agent/commit/6e8c9a5167a39c73c47ac352e4c6fe5ec85160d8

### Testing
Tested on AL2 instance
Added a fresh commit then built for each of the following targets to be sure I was picking up the latest:
```
make dockerfree-agent-image
make generic-rpm-integrated
make amazon-linux-rpm-integrated
```
also checked that `make generic-deb-integrated` works, as it calls `make dockerfree-agent-image` to build the agent.
And also note that I tested the koji-built agent and it is consistent already so no work required there:
https://github.com/aws/amazon-ecs-agent/releases/tag/v1.66.2 <- 06008fa
in the koji-built agent:
```
"Version": "Amazon ECS Agent - v1.66.2 (06008fa1)"
```

New tests cover the changes: no

### Description for the changelog
Fix agent short hash version bug

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
