### PR TITLE
Use Ubuntu 20.04 for linux GH Unit tests

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -6,7 +6,7 @@ permissions: read-all
 jobs:
   unit-tests:
     name: Linux unit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Github actions moved ```ubuntu-latest``` to use Ubuntu 22.04 by default which uses cgroups v2 by default. ECS Agent has some unit tests incompatible when running on cgroups v2 support. This PR temporarily fixes this by enforcing GH Actions to use ```ubuntu-20.04``` which is still supported.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Use Ubuntu 20.04 for linux GH Unit tests

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
