### PR TITLE
bugfix: send network bindings for default network mode

### DIFF
--- a/agent/api/ecsclient/client.go
+++ b/agent/api/ecsclient/client.go
@@ -50,8 +50,6 @@ const (
 	osTypeAttrName              = "ecs.os-type"
 	osFamilyAttrName            = "ecs.os-family"
 	RoundtripTimeout            = 5 * time.Second
-	// networkModeBridge specifies the bridge network mode.
-	networkModeBridge = "bridge"
 	// ecsMaxNetworkBindingsLength is the maximum length of the ecs.NetworkBindings list sent as part of the
 	// container state change payload. Currently, this is enforced only when containerPortRanges are requested.
 	ecsMaxNetworkBindingsLength = 100
@@ -526,10 +524,6 @@ type ProtocolBindIP struct {
 // getNetworkBindings returns the list of networkingBindings, sent to ECS as part of the container state change payload
 func getNetworkBindings(change api.ContainerStateChange, shouldExcludeIPv6PortBinding bool) []*ecs.NetworkBinding {
 	networkBindings := []*ecs.NetworkBinding{}
-	// we return network bindings for bridge network mode tasks only
-	if change.Container.GetNetworkMode() != networkModeBridge {
-		return networkBindings
-	}
 	// hostPortToProtocolBindIPMap is a map to store protocol and bindIP information associated to host ports
 	// that belong to a range. This is used in case when there are multiple protocol/bindIP combinations associated to a
 	// port binding. example: when both IPv4 and IPv6 bindIPs are populated by docker and shouldExcludeIPv6PortBinding is false.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
bugfix: send network bindings for default network mode

### Implementation details
<!-- How are the changes implemented? -->
This PR removes the network mode check during network bindings generation. We need network bindings when the network mode is "default" as well.

Simply removing this check because non-bridge/non-nat/non-default modes, network bindings is not generated anyways. Also, we dont have this check for singular port mappings, so keeping things consistent.

verification:

`networkBinding` for default and bridge mode:
```
"networkBindings": [
                        {
                            "bindIP": "0.0.0.0",
                            "protocol": "tcp",
                            "containerPortRange": "8080-8085",
                            "hostPortRange": "32780-32785"
                        }
                    ],
```


for others:
```
 "networkBindings": [],
```


### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->
Manually tested on a test instance that now sends network bindings for both default and bridge network mode. and that it doesn't for other network modes (like it doesn't today).

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
