### PR TITLE
Read git hash from RELEASE_COMMIT file if possible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -377,7 +377,7 @@ amazon-linux-sources.tgz:
 	cp packaging/amazon-linux-ami-integrated/amazon-ecs-volume-plugin.conf amazon-ecs-volume-plugin.conf
 	cp packaging/amazon-linux-ami-integrated/amazon-ecs-volume-plugin.service amazon-ecs-volume-plugin.service
 	cp packaging/amazon-linux-ami-integrated/amazon-ecs-volume-plugin.socket amazon-ecs-volume-plugin.socket
-	tar -czf ./sources.tgz ecs-init scripts misc agent amazon-ecs-cni-plugins amazon-vpc-cni-plugins agent-container VERSION
+	tar -czf ./sources.tgz ecs-init scripts misc agent amazon-ecs-cni-plugins amazon-vpc-cni-plugins agent-container VERSION RELEASE_COMMIT
 
 .amazon-linux-rpm-integrated-done: amazon-linux-sources.tgz
 	test -e SOURCES || ln -s . SOURCES


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Read git hash from RELEASE_COMMIT file if possible

### Implementation details
<!-- How are the changes implemented? -->
- Prior to executing `gitHash()` function in `version-gen.go`, try to read hash from `RELEASE_COMMIT` file instead using new `releaseCommitGitHash()` function
- Log relevant information in `gitHash()` and `releaseCommitGitHash()` functions in `version-gen.go`
- Add `RELEASE_COMMIT` file to `amazon-linux-sources.tgz` in `Makefile`
- Use `os.ReadFile` instead of `ioutil.ReadFile` in `version-gen.go` since ioutil package is deprecated as of Go 1.16

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
In the repo root, create a test `RELEASE_COMMIT` file, run version-gen.go, and verify that the correct hash is obtained.
```
$ echo "1a2b3c4d5e6f78901a2b3c4d5e6f78901a2b" > RELEASE_COMMIT
$ cd agent/version 
$ GO111MODULE=off go run gen/version-gen.go
2022/12/07 10:31:04 Successfully retrieved full hash value from RELEASE_COMMIT file, fullHashStr: 1a2b3c4d5e6f78901a2b3c4d5e6f78901a2b
$ cat version.go
// This is an autogenerated file and should not be edited.

// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
//
// Licensed under the Apache License, Version 2.0 (the "License"). You may
// not use this file except in compliance with the License. A copy of the
// License is located at
//
//      http://aws.amazon.com/apache2.0/
//
// or in the "license" file accompanying this file. This file is distributed
// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
// express or implied. See the License for the specific language governing
// permissions and limitations under the License.

// Package version contains constants to indicate the current version of the
// agent. It is autogenerated
package version

// Please DO NOT commit any changes to this file (specifically the hash) except
// for those created by running ./scripts/update-version at the root of the
// repository. Only the 'Version' const should change in checked-in source code

// Version is the version of the Agent
const Version = "1.67.0"

// GitDirty indicates the cleanliness of the git repo when this agent was built
const GitDirty = true

// GitShortHash is the short hash of this agent build
const GitShortHash = "1a2b3c4d"
```

New tests cover the changes: <!-- yes|no -->no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Read git hash from RELEASE_COMMIT file if possible

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
