### PR TITLE
Prevent resetting valid agent state db when IMDS fails on startup

### DIFF
--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -87,7 +87,7 @@ const (
 	instanceIdBackoffMax      = time.Second * 5
 	instanceIdBackoffJitter   = 0.2
 	instanceIdBackoffMultiple = 1.3
-	instanceIdMaxRetryCount   = 3
+	instanceIdMaxRetryCount   = 5
 
 	targetLifecycleBackoffMin      = time.Second
 	targetLifecycleBackoffMax      = time.Second * 5
@@ -536,6 +536,10 @@ func (agent *ecsAgent) newTaskEngine(containerChangeEventStream *eventstream.Eve
 	}
 
 	currentEC2InstanceID := agent.getEC2InstanceID()
+	if currentEC2InstanceID == "" {
+		currentEC2InstanceID = savedData.ec2InstanceID
+		seelog.Warnf("Not able to get EC2 Instance ID from IMDS, using EC2 Instance ID from saved state: '%s'", currentEC2InstanceID)
+	}
 	if savedData.ec2InstanceID != "" && savedData.ec2InstanceID != currentEC2InstanceID {
 		seelog.Warnf(instanceIDMismatchErrorFormat,
 			savedData.ec2InstanceID, currentEC2InstanceID)

--- a/agent/app/agent_compatibility_linux_test.go
+++ b/agent/app/agent_compatibility_linux_test.go
@@ -89,6 +89,7 @@ func TestCompatibilityNotSetFail(t *testing.T) {
 		require.NoError(t, dataClient.SaveTask(task))
 	}
 
+	cfg.Cluster = "test-cluster"
 	agent := &ecsAgent{
 		cfg:                   &cfg,
 		dataClient:            dataClient,

--- a/agent/app/agent_test.go
+++ b/agent/app/agent_test.go
@@ -892,6 +892,8 @@ func TestGetEC2InstanceIDIIDError(t *testing.T) {
 	ec2MetadataClient.EXPECT().InstanceID().Return("", errors.New("error"))
 	ec2MetadataClient.EXPECT().InstanceID().Return("", errors.New("error"))
 	ec2MetadataClient.EXPECT().InstanceID().Return("", errors.New("error"))
+	ec2MetadataClient.EXPECT().InstanceID().Return("", errors.New("error"))
+	ec2MetadataClient.EXPECT().InstanceID().Return("", errors.New("error"))
 	assert.Equal(t, "", agent.getEC2InstanceID())
 }
 

--- a/agent/tcs/client/client_test.go
+++ b/agent/tcs/client/client_test.go
@@ -602,7 +602,10 @@ func TestMetricsDisabled(t *testing.T) {
 		published <- struct{}{}
 	}).Return(nil).MinTimes(1)
 
-	go cs.Serve()
+	go func() {
+		err := cs.Serve()
+		assert.NoError(t, err)
+	}()
 	<-published
 	<-readed
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This is a followup to https://github.com/aws/amazon-ecs-agent/pull/2861

In the rare occasion that IMDS fails multiple times (also bumping this multiple from 3 to 5), then we should try to avoid resetting the agent state db if we have an existing agent state.

This is to prevent a situation like this from occurring, since resetting the state db will result in a duplicate container instance on the same ec2 instance id, and will also result in some tasks being dropped by the agent.

```
level=warn time=2022-11-23T15:43:00Z msg="Unable to access EC2 Metadata service to determine EC2 ID: RequestError: send request failed\ncaused by: Get \"http://169.254.169.254/latest/meta-data/instance-id\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)" module=agent.go
level=warn time=2022-11-23T15:45:47Z msg="Data mismatch; saved InstanceID 'i-030e42d5588188300' does not match current InstanceID ''. Overwriting old datafile" module=agent.go
```

### Implementation details
<!-- How are the changes implemented? -->

`currentEC2InstanceID` will fallback to the instance ID saved in agent's state db if IMDS fails to return an ec2 instance id.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: no

existing functional tests

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Bugfix: Prevent resetting valid agent state db when IMDS fails on startup

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
