### PR TITLE
SC bugfix: generate network bindings for SC containers 

### DIFF
--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -2338,6 +2338,8 @@ func (task *Task) dockerPortMap(container *apicontainer.Container) (nat.PortMap,
 	dockerPortMap := nat.PortMap{}
 	scContainer := task.GetServiceConnectContainer()
 	containerToCheck := container
+	containerPortSet := make(map[int]struct{})
+	containerPortRangeMap := make(map[string]string)
 	if task.IsServiceConnectEnabled() && task.IsNetworkModeBridge() {
 		if container.Type == apicontainer.ContainerCNIPause {
 			// we will create bindings for task containers (including both customer containers and SC Appnet container)
@@ -2352,12 +2354,17 @@ func (task *Task) dockerPortMap(container *apicontainer.Container) (nat.PortMap,
 				// create bindings for all ingress listener ports
 				// no need to create binding for egress listener port as it won't be access from host level or from outside
 				for _, ic := range task.ServiceConnectConfig.IngressConfig {
-					dockerPort := nat.Port(strconv.Itoa(int(ic.ListenerPort))) + "/tcp"
+					listenerPortInt := int(ic.ListenerPort)
+					dockerPort := nat.Port(strconv.Itoa(listenerPortInt)) + "/tcp"
 					hostPort := 0           // default bridge-mode SC experience - host port will be an ephemeral port assigned by docker
 					if ic.HostPort != nil { // non-default bridge-mode SC experience - host port specified by customer
 						hostPort = int(*ic.HostPort)
 					}
 					dockerPortMap[dockerPort] = append(dockerPortMap[dockerPort], nat.PortBinding{HostPort: strconv.Itoa(hostPort)})
+					// append non-range, singular container port to the containerPortSet
+					containerPortSet[listenerPortInt] = struct{}{}
+					// set taskContainer.ContainerPortSet to be used during network binding creation
+					taskContainer.SetContainerPortSet(containerPortSet)
 				}
 				return dockerPortMap, nil
 			}
@@ -2370,8 +2377,6 @@ func (task *Task) dockerPortMap(container *apicontainer.Container) (nat.PortMap,
 		}
 	}
 
-	containerPortSet := make(map[int]struct{})
-	containerPortRangeMap := make(map[string]string)
 	for _, portBinding := range containerToCheck.Ports {
 		// for each port binding config, either one of containerPort or containerPortRange is set
 		if portBinding.ContainerPort != 0 {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->
 
### Summary
<!-- What does this pull request do? -->
bug-fix: generate network bindings for SC containers

### Implementation details
<!-- How are the changes implemented? -->

With port range mapping project, we changed the way network bindings are generated for a container.
We generate a port set that stores singular ports for a container, while giving `dockerPortMap` to Docker.

The fix here is to update this set for a SC container too. This ensures that we generate network bindings related to a SC container as well, in addition to application container.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

Built an ecs-agent manually and ran SC tasks to verify that network bindings for SC container are now populated as expected. We're also working on running the functional tests related to service connect.

New tests cover the changes: <!-- yes|no --> no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

bug-fix: generate network bindings for SC containers

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
