### PR TITLE
Add ServiceConnect image to clean-up exclusion list

### DIFF
--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -395,7 +395,11 @@ func (agent *ecsAgent) doStart(containerChangeEventStream *eventstream.EventStre
 		}
 		return exitcodes.ExitTerminal
 	}
-	agent.serviceconnectManager.SetECSClient(client, agent.containerInstanceARN)
+	scManager := agent.serviceconnectManager
+	scManager.SetECSClient(client, agent.containerInstanceARN)
+	if loaded, _ := scManager.IsLoaded(agent.dockerClient); loaded {
+		imageManager.AddImageToCleanUpExclusionList(agent.serviceconnectManager.GetLoadedImageName())
+	}
 
 	// Add container instance ARN to metadata manager
 	if agent.cfg.ContainerMetadataEnabled.Enabled() {

--- a/agent/app/agent_test.go
+++ b/agent/app/agent_test.go
@@ -424,6 +424,8 @@ func testDoStartHappyPathWithConditions(t *testing.T, blackholed bool, warmPools
 	mockServiceConnectManager.EXPECT().GetCapabilitiesForAppnetInterfaceVersion("").AnyTimes()
 	mockServiceConnectManager.EXPECT().SetECSClient(gomock.Any(), gomock.Any()).AnyTimes()
 	mockServiceConnectManager.EXPECT().GetAppnetContainerTarballDir().AnyTimes()
+	mockServiceConnectManager.EXPECT().GetLoadedImageName().Return("service_connect_agent:v1").AnyTimes()
+	imageManager.EXPECT().AddImageToCleanUpExclusionList(gomock.Eq("service_connect_agent:v1")).Times(1)
 	imageManager.EXPECT().StartImageCleanupProcess(gomock.Any()).MaxTimes(1)
 	dockerClient.EXPECT().ListContainers(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		dockerapi.ListContainersResponse{}).AnyTimes()

--- a/agent/app/agent_unix_test.go
+++ b/agent/app/agent_unix_test.go
@@ -113,6 +113,8 @@ func TestDoStartTaskENIHappyPath(t *testing.T) {
 	mockServiceConnectManager.EXPECT().GetCapabilitiesForAppnetInterfaceVersion("").AnyTimes()
 	mockServiceConnectManager.EXPECT().SetECSClient(gomock.Any(), gomock.Any()).AnyTimes()
 	mockServiceConnectManager.EXPECT().GetAppnetContainerTarballDir().AnyTimes()
+	mockServiceConnectManager.EXPECT().GetLoadedImageName().Return("service_connect_agent:v1").AnyTimes()
+	imageManager.EXPECT().AddImageToCleanUpExclusionList(gomock.Eq("service_connect_agent:v1")).Times(1)
 	mockUdevMonitor.EXPECT().Monitor(gomock.Any()).Return(monitoShutdownEvents).AnyTimes()
 
 	gomock.InOrder(
@@ -456,6 +458,8 @@ func TestDoStartCgroupInitHappyPath(t *testing.T) {
 	mockServiceConnectManager.EXPECT().GetCapabilitiesForAppnetInterfaceVersion("").AnyTimes()
 	mockServiceConnectManager.EXPECT().SetECSClient(gomock.Any(), gomock.Any()).AnyTimes()
 	mockServiceConnectManager.EXPECT().GetAppnetContainerTarballDir().AnyTimes()
+	mockServiceConnectManager.EXPECT().GetLoadedImageName().Return("service_connect_agent:v1").AnyTimes()
+	imageManager.EXPECT().AddImageToCleanUpExclusionList(gomock.Eq("service_connect_agent:v1")).Times(1)
 
 	gomock.InOrder(
 		mockControl.EXPECT().Init().Return(nil),
@@ -618,6 +622,8 @@ func TestDoStartGPUManagerHappyPath(t *testing.T) {
 	mockServiceConnectManager.EXPECT().GetCapabilitiesForAppnetInterfaceVersion("").AnyTimes()
 	mockServiceConnectManager.EXPECT().SetECSClient(gomock.Any(), gomock.Any()).AnyTimes()
 	mockServiceConnectManager.EXPECT().GetAppnetContainerTarballDir().AnyTimes()
+	mockServiceConnectManager.EXPECT().GetLoadedImageName().Return("service_connect_agent:v1").AnyTimes()
+	imageManager.EXPECT().AddImageToCleanUpExclusionList(gomock.Eq("service_connect_agent:v1")).Times(1)
 
 	gomock.InOrder(
 		mockGPUManager.EXPECT().Initialize().Return(nil),

--- a/agent/engine/docker_image_manager.go
+++ b/agent/engine/docker_image_manager.go
@@ -49,6 +49,7 @@ type ImageManager interface {
 	GetImageStateFromImageName(containerImageName string) (*image.ImageState, bool)
 	StartImageCleanupProcess(ctx context.Context)
 	SetDataClient(dataClient data.Client)
+	AddImageToCleanUpExclusionList(image string)
 }
 
 // dockerImageManager accounts all the images and their states in the instance.
@@ -110,6 +111,13 @@ func buildImageCleanupExclusionList(cfg *config.Config) []string {
 		})
 	}
 	return excludedImages
+}
+
+func (imageManager *dockerImageManager) AddImageToCleanUpExclusionList(image string) {
+	imageManager.imageCleanupExclusionList = append(imageManager.imageCleanupExclusionList, image)
+	logger.Info("Image excluded from cleanup", logger.Fields{
+		field.Image: image,
+	})
 }
 
 func (imageManager *dockerImageManager) AddAllImageStates(imageStates []*image.ImageState) {

--- a/agent/engine/mocks/engine_mocks.go
+++ b/agent/engine/mocks/engine_mocks.go
@@ -266,6 +266,18 @@ func (mr *MockImageManagerMockRecorder) AddAllImageStates(arg0 interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddAllImageStates", reflect.TypeOf((*MockImageManager)(nil).AddAllImageStates), arg0)
 }
 
+// AddImageToCleanUpExclusionList mocks base method
+func (m *MockImageManager) AddImageToCleanUpExclusionList(arg0 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "AddImageToCleanUpExclusionList", arg0)
+}
+
+// AddImageToCleanUpExclusionList indicates an expected call of AddImageToCleanUpExclusionList
+func (mr *MockImageManagerMockRecorder) AddImageToCleanUpExclusionList(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddImageToCleanUpExclusionList", reflect.TypeOf((*MockImageManager)(nil).AddImageToCleanUpExclusionList), arg0)
+}
+
 // GetImageStateFromImageName mocks base method
 func (m *MockImageManager) GetImageStateFromImageName(arg0 string) (*image.ImageState, bool) {
 	m.ctrl.T.Helper()

--- a/agent/engine/serviceconnect/manager.go
+++ b/agent/engine/serviceconnect/manager.go
@@ -25,7 +25,7 @@ import (
 type Manager interface {
 	loader.Loader
 
-	GetLoadedImageName() (string, error)
+	GetLoadedImageName() string
 	AugmentTaskContainer(task *apitask.Task, container *apicontainer.Container, hostConfig *dockercontainer.HostConfig) error
 	CreateInstanceTask(config *config.Config) (*apitask.Task, error)
 	AugmentInstanceContainer(task *apitask.Task, container *apicontainer.Container, hostConfig *dockercontainer.HostConfig) error

--- a/agent/engine/serviceconnect/manager_linux.go
+++ b/agent/engine/serviceconnect/manager_linux.go
@@ -168,7 +168,7 @@ func (m *manager) augmentAgentContainer(task *apitask.Task, container *apicontai
 	config.DrainRequest = m.adminDrainRequest
 
 	task.PopulateServiceConnectRuntimeConfig(config)
-	container.Image, _ = m.GetLoadedImageName()
+	container.Image = m.GetLoadedImageName()
 	return nil
 }
 
@@ -297,10 +297,7 @@ func (m *manager) AugmentTaskContainer(task *apitask.Task, container *apicontain
 }
 
 func (m *manager) CreateInstanceTask(cfg *config.Config) (*apitask.Task, error) {
-	imageName, err := m.GetLoadedImageName()
-	if err != nil {
-		return nil, err
-	}
+	imageName := m.GetLoadedImageName()
 	containerRunning := apicontainerstatus.ContainerRunning
 	dockerHostConfig := dockercontainer.HostConfig{
 		NetworkMode: apitask.HostNetworkMode,
@@ -404,7 +401,7 @@ func (agent *manager) LoadImage(ctx context.Context, _ *config.Config, dockerCli
 			continue
 		}
 		agent.setLoadedAppnetVerion(supportedAppnetInterfaceVersion)
-		imageName, _ := agent.GetLoadedImageName()
+		imageName := agent.GetLoadedImageName()
 		logger.Info(fmt.Sprintf("Successfully loaded Appnet agent container tarball: %s", agentContainerTarballPath),
 			logger.Fields{
 				field.Image: imageName,
@@ -415,13 +412,12 @@ func (agent *manager) LoadImage(ctx context.Context, _ *config.Config, dockerCli
 }
 
 func (agent *manager) IsLoaded(dockerClient dockerapi.DockerClient) (bool, error) {
-	imageName, _ := agent.GetLoadedImageName()
-	return loader.IsImageLoaded(imageName, dockerClient)
+	return loader.IsImageLoaded(agent.GetLoadedImageName(), dockerClient)
 }
 
-func (agent *manager) GetLoadedImageName() (string, error) {
+func (agent *manager) GetLoadedImageName() string {
 	agent.agentContainerTag = fmt.Sprintf(defaultAgentContainerTagFormat, agent.appnetInterfaceVersion)
-	return fmt.Sprintf("%s:%s", agent.agentContainerImageName, agent.agentContainerTag), nil
+	return fmt.Sprintf("%s:%s", agent.agentContainerImageName, agent.agentContainerTag)
 }
 
 func (agent *manager) GetLoadedAppnetVersion() (string, error) {

--- a/agent/engine/serviceconnect/manager_other.go
+++ b/agent/engine/serviceconnect/manager_other.go
@@ -64,10 +64,8 @@ func (*manager) IsLoaded(dockerClient dockerapi.DockerClient) (bool, error) {
 func (m *manager) SetECSClient(api.ECSClient, string) {
 }
 
-func (*manager) GetLoadedImageName() (string, error) {
-	return "", loader.NewUnsupportedPlatformError(fmt.Errorf(
-		"appnetAgent container get image name: unsupported platform: %s/%s",
-		runtime.GOOS, runtime.GOARCH))
+func (*manager) GetLoadedImageName() string {
+	return ""
 }
 
 func (*manager) GetLoadedAppnetVersion() (string, error) {

--- a/agent/engine/serviceconnect/mock/manager.go
+++ b/agent/engine/serviceconnect/mock/manager.go
@@ -143,12 +143,11 @@ func (mr *MockManagerMockRecorder) GetLoadedAppnetVersion() *gomock.Call {
 }
 
 // GetLoadedImageName mocks base method
-func (m *MockManager) GetLoadedImageName() (string, error) {
+func (m *MockManager) GetLoadedImageName() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLoadedImageName")
 	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	return ret0
 }
 
 // GetLoadedImageName indicates an expected call of GetLoadedImageName


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
ECS Agent periodically cleans up cached docker container images that are not being referenced. There are a few images on the exception list including pause container. We should add Service Connect Agent (aka AppNet Agent) image to this list as well because all SC tasks require cached SC Agent image.

https://github.com/aws/amazon-ecs-agent/issues/3520

### Implementation details
<!-- How are the changes implemented? -->
Added a new function `AddImageToCleanUpExclusionList` to ImageManager, and when ECS Agent bootstrap, we
1. let Service Connect manager load AppNet Agent image (this happens right before instance capability registration), 
2. call the above new function for AppNet image such that it's excluded from clean-up. 

Step 1 has to happen first since the image name might be different depending on the AppNet Agent version installed.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> no

Logs with update ECS Agent:
```
...
level=info time=2022-12-15T17:52:13Z msg="Image excluded from cleanup" image="ecs-service-connect-agent:interface-v1"
...

```

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Add ServiceConnect image to clean-up exclusion list

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
