### PR TITLE
bugfix for PR-3522: handle case when env-ECS_DYNAMIC_HOST_PORT_RANGE is not set/ update year to 2023 for make gogenerate

### DIFF
--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -514,6 +514,13 @@ func TestParseDynamicHostPortRange(t *testing.T) {
 			expectedErrorEphemeralHostPortRange: nil,
 		},
 		{
+			testName:                            "Parse DynamicHostPortRange for valid case when config option is not set or is empty",
+			testDynamicHostPortRangeVal:         "",
+			expectedPortRangeVal:                "300-400",
+			expectedErrorDynamicHostPortRange:   nil,
+			expectedErrorEphemeralHostPortRange: nil,
+		},
+		{
 			testName:                            "Parse DynamicHostPortRange for Invalid DynamicHostPortRange value",
 			testDynamicHostPortRangeVal:         "test1",
 			expectedPortRangeVal:                "300-400",
@@ -536,7 +543,7 @@ func TestParseDynamicHostPortRange(t *testing.T) {
 			defer setTestRegion()()
 			defer setTestEnv("ECS_DYNAMIC_HOST_PORT_RANGE", tc.testDynamicHostPortRangeVal)()
 
-			if tc.expectedErrorDynamicHostPortRange != nil {
+			if tc.testDynamicHostPortRangeVal == "" || tc.expectedErrorDynamicHostPortRange != nil {
 				getDynamicHostPortRange = func() (start int, end int, err error) {
 					return 300, 400, nil
 				}

--- a/agent/config/parse.go
+++ b/agent/config/parse.go
@@ -380,16 +380,24 @@ var getDynamicHostPortRange = utils.GetDynamicHostPortRange
 
 func parseDynamicHostPortRange(dynamicHostPortRangeEnv string) string {
 	dynamicHostPortRange := os.Getenv(dynamicHostPortRangeEnv)
-	_, _, err := nat.ParsePortRangeToInt(dynamicHostPortRange)
-	if err != nil {
-		seelog.Warnf("Unable to read the dynamicHostPortRange value: %s", dynamicHostPortRange)
-		startHostPortRange, endHostPortRange, err := getDynamicHostPortRange()
+	if dynamicHostPortRange != "" {
+		_, _, err := nat.ParsePortRangeToInt(dynamicHostPortRange)
 		if err != nil {
-			seelog.Warnf("Unable to read the ephemeral host port range, "+
-				"falling back to the default range: %v-%v", utils.DefaultPortRangeStart, utils.DefaultPortRangeEnd)
-			return fmt.Sprintf("%d-%d", utils.DefaultPortRangeStart, utils.DefaultPortRangeEnd)
+			seelog.Warnf("Invalid dynamicHostPortRange value from config: %s, err: %v", dynamicHostPortRange, err)
+			return getDefaultDynamicHostPortRange()
 		}
-		return fmt.Sprintf("%d-%d", startHostPortRange, endHostPortRange)
+	} else {
+		return getDefaultDynamicHostPortRange()
 	}
 	return dynamicHostPortRange
+}
+
+func getDefaultDynamicHostPortRange() string {
+	startHostPortRange, endHostPortRange, err := getDynamicHostPortRange()
+	if err != nil {
+		seelog.Warnf("Unable to read the ephemeral host port range, "+
+			"falling back to the default range: %v-%v", utils.DefaultPortRangeStart, utils.DefaultPortRangeEnd)
+		return fmt.Sprintf("%d-%d", utils.DefaultPortRangeStart, utils.DefaultPortRangeEnd)
+	}
+	return fmt.Sprintf("%d-%d", startHostPortRange, endHostPortRange)
 }

--- a/ecs-init/cache/dependencies_mocks.go
+++ b/ecs-init/cache/dependencies_mocks.go
@@ -1,4 +1,4 @@
-// Copyright 2015-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/ecs-init/docker/backoff_mocks.go
+++ b/ecs-init/docker/backoff_mocks.go
@@ -1,4 +1,4 @@
-// Copyright 2015-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/ecs-init/docker/dependencies_mocks.go
+++ b/ecs-init/docker/dependencies_mocks.go
@@ -1,4 +1,4 @@
-// Copyright 2015-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/ecs-init/engine/dependencies_mocks.go
+++ b/ecs-init/engine/dependencies_mocks.go
@@ -1,4 +1,4 @@
-// Copyright 2015-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/ecs-init/exec/iptables/cmd_mocks.go
+++ b/ecs-init/exec/iptables/cmd_mocks.go
@@ -1,4 +1,4 @@
-// Copyright 2015-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/ecs-init/exec/iptables/exec_mocks.go
+++ b/ecs-init/exec/iptables/exec_mocks.go
@@ -1,4 +1,4 @@
-// Copyright 2015-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/ecs-init/exec/sysctl/cmd_mocks.go
+++ b/ecs-init/exec/sysctl/cmd_mocks.go
@@ -1,4 +1,4 @@
-// Copyright 2015-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/ecs-init/exec/sysctl/exec_mocks.go
+++ b/ecs-init/exec/sysctl/exec_mocks.go
@@ -1,4 +1,4 @@
-// Copyright 2015-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/ecs-init/gpu/nvidia_gpu_manager_mocks.go
+++ b/ecs-init/gpu/nvidia_gpu_manager_mocks.go
@@ -1,4 +1,4 @@
-// Copyright 2015-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

Identified a bug in PR-3522(to Add new config option for DynamicHostPortRange). When the user does not set the host port range or leave it empty, it does not return any network bindings. 

This is because`nat.ParsePortRangeToInt(dynamicHostPortRange)` would `return 0, 0, nil` if the `len(dynamicHostPortRange)==0`. This update covers both empty and not set cases.

Also updated year to 2023 for failed make gogenerate files.

### Implementation details
<!-- How are the changes implemented? -->
1. Updated `parseDynamicHostPortRange` to handle "" inputs .
2. Updated the `config_test.go` to cover the code changes to `parse.go`.
3. Updated year to 2023 for failed make gogenerate files.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

- All git workflow tests/checks have passed (includes bot/test)

- Ran TaskDefinition against the changes for cases:
  1. ECS_DYNAMIC_HOST_PORT_RANGE is empty
  2. ECS_DYNAMIC_HOST_PORT_RANGE is not set
  3. ECS_DYNAMIC_HOST_PORT_RANGE is invalid
  4. ECS_DYNAMIC_HOST_PORT_RANGE is valid
 


New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
BugFix to cover empty/not set ECS_DYNAMIC_HOST_PORT_RANGE environment variable.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
