### PR TITLE
Filter out metricCount=0 and its corresponding metricValue for service connect metric TargetResponseTime

### DIFF
--- a/agent/stats/service_connect_linux_test.go
+++ b/agent/stats/service_connect_linux_test.go
@@ -94,7 +94,7 @@ func TestRetrieveServiceConnectMetrics(t *testing.T) {
 		{
 			stats: `# TYPE MetricFamily3 histogram
 				MetricFamily3{DimensionX="value1", DimensionY="value2", Direction="egress", le="0.5"} 1
-				MetricFamily3{DimensionX="value1", DimensionY="value2", Direction="egress", le="1"} 2
+				MetricFamily3{DimensionX="value1", DimensionY="value2", Direction="egress", le="1"} 1
 				MetricFamily3{DimensionX="value1", DimensionY="value2", Direction="egress", le="5"} 3
 				`,
 			expectedStats: []*ecstcs.GeneralMetricsWrapper{
@@ -110,13 +110,21 @@ func TestRetrieveServiceConnectMetrics(t *testing.T) {
 						}},
 					GeneralMetrics: []*ecstcs.GeneralMetric{
 						{
-							MetricCounts: []*int64{aws.Int64(1), aws.Int64(1), aws.Int64(1)},
+							MetricCounts: []*int64{aws.Int64(1), aws.Int64(2)},
 							MetricName:   aws.String("MetricFamily3"),
-							MetricValues: []*float64{aws.Float64(0.5), aws.Float64(1), aws.Float64(5)},
+							MetricValues: []*float64{aws.Float64(0.5), aws.Float64(5)},
 						},
 					},
 				},
 			},
+		},
+		{
+			stats: `# TYPE MetricFamily3 histogram
+				MetricFamily3{DimensionX="value1", DimensionY="value2", Direction="egress", le="0.5"} 0
+				MetricFamily3{DimensionX="value1", DimensionY="value2", Direction="egress", le="1"} 0
+				MetricFamily3{DimensionX="value1", DimensionY="value2", Direction="egress", le="5"} 0
+				`,
+			expectedStats: []*ecstcs.GeneralMetricsWrapper{},
 		},
 	}
 


### PR DESCRIPTION
This PR filters out all metric Counts for the histogram metric TargetResponseTime which are 0. We also remove the corresponding metricValues. 
This is because when there is no traffic and metricCount is 0, the dashboards incorrectly show min as 0 and max as 360000.  In this case, there should have been no datapoints. For example,

**Before:** 

**MetricCounts: [8, 0, 3, 0, 0, 0, 1, 0, 0, 0, 0, 0,0,  0,  0,  0,  0,  0,  0 ]
MetricValues: [  0.5,  1,  5,  10,  25,  50,  100,  250,  500,  1000,  2500,  5000,  10000,  30000,  60000,  300000,  600000,  1.8e+06,  3.6e+06 ]}**

![image](https://user-images.githubusercontent.com/43968377/213816671-b45d5be1-6b28-42de-b3dc-ed5e25434049.png)

This Pr correctly sends only non-zero metric counts and now it looks like below.

**After:**


**MetricCounts: [8, 3, 1]
MetricValues: [0.5, 5, 100]}**


![image](https://user-images.githubusercontent.com/43968377/213816815-a3b0fa7b-2358-4687-a521-9d09280e5e75.png)


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes

In the summary the test results are mentioned

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
BugFix: Filter out metricCount=0 and its corresponding metricValue for service connect metric TargetResponseTime

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
