### PR TITLE
fix gmsa,fsx capability bug

### DIFF
--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -312,7 +312,7 @@ func (agent *ecsAgent) appendDockerDependentCapabilities(capabilities []*ecs.Att
 }
 
 func (agent *ecsAgent) appendGMSACapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
-	if agent.cfg.GMSACapable {
+	if agent.cfg.GMSACapable.Enabled() {
 		return appendNameOnlyAttribute(capabilities, attributePrefix+capabilityGMSA)
 	}
 

--- a/agent/app/agent_capability_test.go
+++ b/agent/app/agent_capability_test.go
@@ -1432,7 +1432,7 @@ func TestAppendGMSACapabilities(t *testing.T) {
 
 	agent := &ecsAgent{
 		cfg: &config.Config{
-			GMSACapable: true,
+			GMSACapable: config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled},
 		},
 	}
 

--- a/agent/app/agent_capability_windows.go
+++ b/agent/app/agent_capability_windows.go
@@ -109,7 +109,7 @@ func (agent *ecsAgent) appendIPv6Capability(capabilities []*ecs.Attribute) []*ec
 }
 
 func (agent *ecsAgent) appendFSxWindowsFileServerCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
-	if agent.cfg.FSxWindowsFileServerCapable {
+	if agent.cfg.FSxWindowsFileServerCapable.Enabled() {
 		return appendNameOnlyAttribute(capabilities, attributePrefix+capabilityFSxWindowsFileServer)
 	}
 

--- a/agent/app/agent_capability_windows_test.go
+++ b/agent/app/agent_capability_windows_test.go
@@ -236,7 +236,7 @@ func TestAppendGMSACapabilitiesFalse(t *testing.T) {
 
 	agent := &ecsAgent{
 		cfg: &config.Config{
-			GMSACapable: false,
+			GMSACapable: config.BooleanDefaultFalse{Value: config.ExplicitlyDisabled},
 		},
 	}
 
@@ -258,7 +258,7 @@ func TestAppendFSxWindowsFileServerCapabilities(t *testing.T) {
 
 	agent := &ecsAgent{
 		cfg: &config.Config{
-			FSxWindowsFileServerCapable: true,
+			FSxWindowsFileServerCapable: config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled},
 		},
 	}
 
@@ -280,7 +280,7 @@ func TestAppendFSxWindowsFileServerCapabilitiesFalse(t *testing.T) {
 
 	agent := &ecsAgent{
 		cfg: &config.Config{
-			FSxWindowsFileServerCapable: false,
+			FSxWindowsFileServerCapable: config.BooleanDefaultFalse{Value: config.ExplicitlyDisabled},
 		},
 	}
 

--- a/agent/config/config_unix.go
+++ b/agent/config/config_unix.go
@@ -101,7 +101,7 @@ func DefaultConfig() Config {
 		NvidiaRuntime:                       DefaultNvidiaRuntime,
 		CgroupCPUPeriod:                     defaultCgroupCPUPeriod,
 		GMSACapable:                         parseGMSACapability(),
-		FSxWindowsFileServerCapable:         false,
+		FSxWindowsFileServerCapable:         BooleanDefaultFalse{Value: ExplicitlyDisabled},
 		RuntimeStatsLogFile:                 defaultRuntimeStatsLogFile,
 		EnableRuntimeStats:                  BooleanDefaultFalse{Value: NotSet},
 		ShouldExcludeIPv6PortBinding:        BooleanDefaultTrue{Value: ExplicitlyEnabled},

--- a/agent/config/config_windows.go
+++ b/agent/config/config_windows.go
@@ -142,8 +142,8 @@ func DefaultConfig() Config {
 		SharedVolumeMatchFullConfig:         BooleanDefaultFalse{Value: ExplicitlyDisabled}, //only requiring shared volumes to match on name, which is default docker behavior
 		PollMetrics:                         BooleanDefaultFalse{Value: NotSet},
 		PollingMetricsWaitDuration:          DefaultPollingMetricsWaitDuration,
-		GMSACapable:                         true,
-		FSxWindowsFileServerCapable:         true,
+		GMSACapable:                         BooleanDefaultFalse{Value: ExplicitlyDisabled},
+		FSxWindowsFileServerCapable:         BooleanDefaultFalse{Value: ExplicitlyDisabled},
 		PauseContainerImageName:             DefaultPauseContainerImageName,
 		PauseContainerTag:                   DefaultPauseContainerTag,
 		CNIPluginsPath:                      filepath.Join(ecsBinaryDir, defaultCNIPluginDirName),

--- a/agent/config/parse_linux_test.go
+++ b/agent/config/parse_linux_test.go
@@ -27,25 +27,25 @@ func TestParseGMSACapabilitySupported(t *testing.T) {
 	t.Setenv("ECS_DOMAIN_JOINED_LINUX_INSTANCE", "True")
 	t.Setenv("CREDENTIALS_FETCHER_HOST_DIR", "/var/run")
 
-	assert.True(t, parseGMSACapability())
+	assert.True(t, parseGMSACapability().Enabled())
 }
 
 func TestParseGMSACapabilityNonDomainJoined(t *testing.T) {
 	t.Setenv("ECS_GMSA_SUPPORTED", "True")
 	t.Setenv("ECS_DOMAIN_JOINED_LINUX_INSTANCE", "False")
 
-	assert.False(t, parseGMSACapability())
+	assert.False(t, parseGMSACapability().Enabled())
 }
 
 func TestParseGMSACapabilityUnsupported(t *testing.T) {
 	t.Setenv("ECS_GMSA_SUPPORTED", "False")
 
-	assert.False(t, parseGMSACapability())
+	assert.False(t, parseGMSACapability().Enabled())
 }
 
 func TestSkipDomainJoinCheckParseGMSACapability(t *testing.T) {
 	t.Setenv("ECS_GMSA_SUPPORTED", "True")
 	t.Setenv("ZZZ_SKIP_DOMAIN_JOIN_CHECK_NOT_SUPPORTED_IN_PRODUCTION", "True")
 
-	assert.True(t, parseGMSACapability())
+	assert.True(t, parseGMSACapability().Enabled())
 }

--- a/agent/config/parse_unsupported_test.go
+++ b/agent/config/parse_unsupported_test.go
@@ -17,23 +17,15 @@
 package config
 
 import (
-	"errors"
-	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
-func parseGMSACapability() BooleanDefaultFalse {
-	return BooleanDefaultFalse{Value: ExplicitlyDisabled}
+func TestParseGMSACapabilitySupported(t *testing.T) {
+	assert.False(t, parseGMSACapability().Enabled())
 }
 
-func parseFSxWindowsFileServerCapability() BooleanDefaultFalse {
-	return BooleanDefaultFalse{Value: ExplicitlyDisabled}
-}
-
-var IsWindows2016 = func() (bool, error) {
-	return false, errors.New("unsupported platform")
-}
-
-// GetOSFamily returns "UNSUPPORTED" as operating system family for non-windows based ecs instances.
-func GetOSFamily() string {
-	return strings.ToUpper(OSType)
+func TestParseFSxWindowsFileServerCapability(t *testing.T) {
+	assert.False(t, parseGMSACapability().Enabled())
 }

--- a/agent/config/parse_windows_test.go
+++ b/agent/config/parse_windows_test.go
@@ -27,7 +27,7 @@ func TestParseGMSACapability(t *testing.T) {
 	os.Setenv("ECS_GMSA_SUPPORTED", "False")
 	defer os.Unsetenv("ECS_GMSA_SUPPORTED")
 
-	assert.False(t, parseGMSACapability())
+	assert.False(t, parseGMSACapability().Enabled())
 }
 
 func TestParseBooleanEnvVar(t *testing.T) {
@@ -49,5 +49,5 @@ func TestParseFSxWindowsFileServerCapability(t *testing.T) {
 	os.Setenv("ECS_FSX_WINDOWS_FILE_SERVER_SUPPORTED", "False")
 	defer os.Unsetenv("ECS_FSX_WINDOWS_FILE_SERVER_SUPPORTED")
 
-	assert.False(t, parseFSxWindowsFileServerCapability())
+	assert.False(t, parseFSxWindowsFileServerCapability().Enabled())
 }

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -329,14 +329,14 @@ type Config struct {
 
 	// GMSACapable is the config option to indicate if gMSA is supported.
 	// It should be enabled by default only if the container instance is part of a valid active directory domain.
-	GMSACapable bool
+	GMSACapable BooleanDefaultFalse
 
 	// VolumePluginCapabilities specifies the capabilities of the ecs volume plugin.
 	VolumePluginCapabilities []string
 
 	// FSxWindowsFileServerCapable is the config option to indicate if fsxWindowsFileServer is supported.
 	// It should be enabled by default only if the container instance is part of a valid active directory domain.
-	FSxWindowsFileServerCapable bool
+	FSxWindowsFileServerCapable BooleanDefaultFalse
 
 	// External specifies whether agent is running on external compute capacity (i.e. outside of aws).
 	External BooleanDefaultFalse

--- a/agent/engine/engine_sudo_linux_integ_test.go
+++ b/agent/engine/engine_sudo_linux_integ_test.go
@@ -767,7 +767,7 @@ func TestGMSATaskFile(t *testing.T) {
 	cfg := defaultTestConfigIntegTest()
 	cfg.TaskCPUMemLimit.Value = config.ExplicitlyDisabled
 	cfg.TaskCleanupWaitDuration = 3 * time.Second
-	cfg.GMSACapable = true
+	cfg.GMSACapable = config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled}
 	cfg.AWSRegion = "us-west-2"
 
 	taskEngine, done, _ := setupGMSALinux(cfg, nil, t)

--- a/agent/engine/engine_windows_integ_test.go
+++ b/agent/engine/engine_windows_integ_test.go
@@ -455,7 +455,7 @@ func defaultTestConfigIntegTestGMSA() *config.Config {
 	cfg.TaskCPUMemLimit.Value = config.ExplicitlyDisabled
 	cfg.ImagePullBehavior = config.ImagePullPreferCachedBehavior
 
-	cfg.GMSACapable = true
+	cfg.GMSACapable = config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled}
 	cfg.AWSRegion = "us-west-2"
 
 	return cfg


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This pull request fixes how the Agent determines whether it is gMSA and fsx capable. Currently when either of these capabilities are set to false, the `config.mergeDefaultConfig(errs)` line will set these back to true on Windows since the lhs is the boolean false and the default config (rhs) contains the boolean true. 


### Implementation details
<!-- How are the changes implemented? -->
This fix is done by changing the native `boolean` to now use `BooleanDefaultFalse`

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

This change was tested both by using unit tests and a custom ecs agent installed on a windows ec2 instance which was connected to a cluster. The logs were viewed to see what capabilities were advertised upon agent startup. 

New tests cover the changes: <!-- yes|no -->
yes
### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Bug - Fixed a bug that incorrectly advertised the gMSA and fsx capability 

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
