### PR TITLE
Skip sending STSC events for internal tasks

### DIFF
--- a/agent/api/statechange.go
+++ b/agent/api/statechange.go
@@ -105,6 +105,9 @@ type AttachmentStateChange struct {
 // returns error if the state change doesn't need to be sent to the ECS backend.
 func NewTaskStateChangeEvent(task *apitask.Task, reason string) (TaskStateChange, error) {
 	var event TaskStateChange
+	if task.IsInternal {
+		return event, errors.Errorf("skip creating task stage change event for internal task %v", task.Arn)
+	}
 	taskKnownStatus := task.GetKnownStatus()
 	if !taskKnownStatus.BackendRecognized() {
 		return event, errors.Errorf(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
We are currently sending STSC events for AppNet relay task. This task is initiated and managed by ECS Agent to support Service Connect feature, and not meant to be exposed to customers. Therefore, we should not be sending STSC events for it.

### Implementation details
Adding a condition check to skip creating STSC events for internal tasks. 

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

* make test
* tested updated Agent with SC task, observed following log message
```
level=error time=2023-01-24T18:04:42Z msg="Skipping emitting event for task due to error" task="service-connect-relay-935909be-9c11-11ed-92a6-0a2da05dafe1" reason="" error="skip creating task stage change event for internal task arn:::::/service-connect-relay-935909be-9c11-11ed-92a6-0a2da05dafe1"

```

New tests cover the changes: <!-- yes|no --> no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Skip sending STSC events for internal tasks

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
