### PR TITLE
Address envFile resource naming defect

### DIFF
--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -3240,7 +3240,7 @@ func (task *Task) initializeEnvfilesResource(config *config.Config, credentialsM
 				return errors.Wrapf(err, "unable to initialize envfiles resource for container %s", container.Name)
 			}
 			task.AddResource(envFiles.ResourceName, envfileResource)
-			container.BuildResourceDependency(envfileResource.GetName(), resourcestatus.ResourceCreated, apicontainerstatus.ContainerCreated)
+			container.BuildResourceDependency(envfileResource.GetName(), resourcestatus.ResourceStatus(envFiles.EnvFileCreated), apicontainerstatus.ContainerCreated)
 		}
 	}
 

--- a/agent/taskresource/envFiles/envfile.go
+++ b/agent/taskresource/envFiles/envfile.go
@@ -202,9 +202,9 @@ func (envfile *EnvironmentFileResource) GetCreatedAt() time.Time {
 	return envfile.createdAtUnsafe
 }
 
-// GetName returns the name fo the resource
+// GetName returns the name of the environment file resource
 func (envfile *EnvironmentFileResource) GetName() string {
-	return ResourceName
+	return ResourceName + "_" + envfile.GetContainerName()
 }
 
 // DesiredTerminal returns true if the resource's desired status is REMOVED


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Address EnvironmentFileResource naming defect which causes a race condition when a task has multiple containers which specify at least one unique environment file.

For further context, please refer to the "Additional Context" section below in this pull request's description.

### Implementation details
<!-- How are the changes implemented? -->
- Modify EnvironmentFileResource `GetName()` method to easily differentiate EnvironmentFileResource objects from one another (i.e., add container name to return value since container name is unique)
- Use `resourcestatus.ResourceStatus(envFiles.EnvFileCreated)` instead of `resourcestatus.ResourceCreated` when building a container's EnvironmentFileResource dependency in the `initializeEnvfilesResource` function
- Update existing unit tests to account for new changes

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
#### Unit testing:
- `make test`

Existing unit test `TestInitializeAndGetEnvfilesResource` has been expanded to cover the changes introduced in this pull request and operates as follows:
1. Creates a task specifying two containers, with each container specifying its own single unique environment file
2. Initializes each containers’ EnvironmentFileResource (which specifies an EnvironmentFileResource dependency for each container)
3. Check that the specified resource dependency for each container is defined as expected
4. Make sure that the resource dependency of the first container is not equal to the resource dependency of the second container

This test will always pass when the fix in this pull request is implemented since the two resource dependencies will never be equal due to each EnvironmentFileResource object’s call to its `GetName()` method returning a unique name. This test will also always fail under the current ECS Agent because the two resource dependencies will always be considered equal due to all calls to EnvironmentFileResource `GetName()` method returning the constant string “envfile”. 

#### Manual testing:
An ECS customer who faced this issue was given a custom ECS Agent with the code changes from this PR built in and validated that they no longer ran into the issue after using that custom ECS Agent.

I was also able to reproduce the issue using the current ECS Agent by taking the following steps:
1. defining a task which has 2 nginx containers where one container specifies a small (<20 KB) environment file and the other container specifies a large (>500 MB) environment file
2. then trying to run 10 such tasks (and subsequently observing some are not able to start due to the race condition coming into play)

Upon using the custom ECS Agent mentioned previously, I could no longer reproduce the issue with the same steps.

New tests cover the changes: no (but existing `TestInitializeAndGetEnvfilesResource`  test has been modified to cover the changes)

### Additional Context
Per the [Amazon ECS Developer Guide](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/taskdef-envfiles.html), each container in a given task can specify up to 10 environment files. If a container specifies 1 or more environment files, then all of its environment files are grouped into a single EnvironmentFileResource. So for each container with 1 or more environment files, an EnvironmentFileResource is created.

A problem arises in the current ECS Agent code when a task has multiple (i.e., more than one) containers which specify at least one unique environment file.

When EnvironmentFileResource objects are initialized in the `initializeEnvfilesResource` function, each EnvironmentFileResource (tied to a unique container in the task) is:

1. added to the task’s ResourcesMap’s slice of task resource objects mapped from “envfile” key
4. added as part of a ResourceDependency for the container it corresponds to, such that the container cannot be transitioned into a “CREATED” status until task resource with resource name “envfile” has KnownStatus “CREATED”

The 2nd point above is problematic. Every EnvironmentFileResource object’s `GetName()` method always returns “envfile”, which means all EnvironmentFileResource objects have the same name. 

Then later, when we check if dependencies for a container are resolved, we pass the slice of task resources returned by `mtask.GetResources()` to the `DependenciesAreResolved` function. 

Diving deeper into `mtask.GetResources()` reveals that it calls `task.getResourcesUnsafe()`, which iterates through the task’s resource map. According to the [Go Programming Language Specification](https://go.dev/ref/spec#For_statements), “the iteration order over maps is not specified and is not guaranteed to be the same from one iteration to the next”. Thus, there is no guarantee as to how the task resources will be ordered in the slice of task resources that we pass to the `DependenciesAreResolved` function.

Recall that all EnvironmentFileResource objects have the same name. Because of this, observe that in the `DependenciesAreResolved` function, only the last EnvironmentFileResource encountered while iterating through the slice of task resources returned by the previous `mtask.GetResources()` call (this EnvironmentFileResource could correspond to any container in the task) will be the one we check if it has KnownStatus CREATED” yet, **regardless of whether or not that EnvironmentFileResource is actually associated with the current container**. That is, only the last EnvironmentFileResource encountered can occupy this map at key value “envfile”.

Thus, even though we have declared EnvironmentFileResource dependencies for containers, there is no guarantee that a container will try to transition to “CREATED” only after its associated environment files have finished downloading and been written to disk.

#### Simplified Example:
Let’s say we have a task that specifies 2 containers, container A and container B where each container specifies its own single unique environment file and the following sequence of events happens:

1. Container A’s EnvironmentFileResource and Container B’s EnvironmentFileResource are initialized
2. Container A’s environment file starts downloading
5. Container B’s environment file starts downloading
6. Container A’s environment file finishes downloading and has been written to disk
7. Container A’s EnvironmentFileResource transitions to KnownStatus “CREATED” since all of its environment files have finished downloading
8. There is a request to transition Container B to “CREATED”, but first Agent must check if Container B’s dependencies are resolved
    1. Get the task’s resources from task’s resource map and store them in a slice (ordering of how task resources get added to the slice NOT guaranteed)
    2. Iterate through the slice above, but only the last EnvironmentFileResource encountered is selected
    4. Let’s say it just so happens the last EnvironmentFileResource encountered is Container A’s EnvironmentFileResource
    5. Agent checks the selected EnvironmentFileResource to see if it has KnownStatus “CREATED”
    6. It sees it has KnownStatus “CREATED”, so the result of this check does not block Container B from transitioning to “CREATED”
9. Agent begins transitioning Container B to “CREATED”
    1. Part of this transition includes reading from Container B’s environment file, which has NOT yet finished downloading yet
10. “Unable to open environment file” error is thrown
11. Container B’s environment file finishes downloading and has been written to disk, but it’s too late already

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Address envFile resource naming defect

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
