### PR TITLE
Enumerate port ranges into docker config

### DIFF
--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -1815,11 +1815,15 @@ func (task *Task) dockerExposedPorts(container *apicontainer.Container) (dockerE
 			dockerExposedPorts[dockerPort] = struct{}{}
 		} else if portBinding.ContainerPortRange != "" {
 			// we supply containerPortRange here in case we did not assign a host port range and ask docker to do so
-			dockerPortRange, err := nat.NewPort(protocol, portBinding.ContainerPortRange)
+			startContainerPort, endContainerPort, err := nat.ParsePortRangeToInt(portBinding.ContainerPortRange)
 			if err != nil {
 				return nil, err
 			}
-			dockerExposedPorts[dockerPortRange] = struct{}{}
+
+			for i := startContainerPort; i <= endContainerPort; i++ {
+				dockerPort := nat.Port(strconv.Itoa(i) + "/" + protocol)
+				dockerExposedPorts[dockerPort] = struct{}{}
+			}
 		}
 	}
 	return dockerExposedPorts, nil

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -128,15 +128,32 @@ func TestDockerConfigPortBinding(t *testing.T) {
 	if !ok {
 		t.Fatal("Could not get exposed ports 20/udp")
 	}
-	_, ok = config.ExposedPorts["99-999/tcp"]
-	if !ok {
-		t.Fatal("Could not get exposed ports 99-999/tcp")
-	}
-	_, ok = config.ExposedPorts["121-221/udp"]
-	if !ok {
-		t.Fatal("Could not get exposed ports 121-221/udp")
+
+	startContainerPortTcp, endContainerPortTcp, tcpParseErr := nat.ParsePortRangeToInt("99-999")
+	if tcpParseErr != nil {
+		t.Fatal("Error parsing tcp port range into start and end ints")
 	}
 
+	for i := startContainerPortTcp; i <= endContainerPortTcp; i++ {
+		portProtocol := nat.Port(fmt.Sprintf("%d/tcp", i))
+		_, ok := config.ExposedPorts[portProtocol]
+		if !ok {
+			t.Fatalf("Could not get exposed ports %s", portProtocol)
+		}
+	}
+
+	startContainerPortUdp, endContainerPortUdp, udpParseErr := nat.ParsePortRangeToInt("121-221")
+	if udpParseErr != nil {
+		t.Fatal("Error parsing udp port range into start and end ints")
+	}
+
+	for i := startContainerPortUdp; i <= endContainerPortUdp; i++ {
+		portProtocol := nat.Port(fmt.Sprintf("%d/udp", i))
+		_, ok := config.ExposedPorts[portProtocol]
+		if !ok {
+			t.Fatalf("Could not get exposed ports %s", portProtocol)
+		}
+	}
 }
 
 func TestDockerHostConfigCPUShareZero(t *testing.T) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
When using `docker run` with a port range exposed, Docker enumerates every port within the range into the `Config.ExposedPorts` map but the ECS Agent just puts the range as a string into the config. This becomes a problem when containers themselves aren't exposing ports (the Dockerfile doesn't contain an `EXPOSE` instruction for example) but customers are exposing ports using ECS task definitions and also using dynamic host port binding. 

For example, assume that a container was built without an `EXPOSE` instruction in the Dockerfile but the customer's task definition lists a container port range of 80-90 with the protocol being TCP. Currently, there would be no way of reporting the bound ports since `"80-90/tcp"` gets added to the `Config.ExposedPorts` map and Docker seems to ignore anything that is not a singular port in the above map when it is reporting the host ports bound through the `NetworkSettings.Ports` map. 

### Implementation details
Using [`nat.ParsePortRangeToInt()`](https://pkg.go.dev/github.com/docker/go-connections/nat#ParsePortRangeToInt), we get the start and the end of the port range. Once we have that, we individually build a [`nat.Port`](https://pkg.go.dev/github.com/docker/go-connections/nat#Port) instance for each of the ports in the range and then we add them to the list of Docker exposed ports. 

### Testing

Unit tests were run and manual testing was also done by building the new agent with the changes and then running tasks on the instance with the new agent running. 

<details>
<summary>Manual testing results</summary>

`Config.ExposedPorts` after `$ docker run -d -p 9090 --name dr-sp public.ecr.aws/kulshres/simple-container`

```
$ docker inspect dr-sp | jq '.[0] | .Config | .ExposedPorts'
{
  "8080/tcp": {},
  "9090/tcp": {}
}
```

`Config.ExposedPorts` after `$ docker run -d -p 9090-9095 --name dr-pr public.ecr.aws/kulshres/ranges`

```
$ docker inspect dr-pr | jq '.[0] | .Config | .ExposedPorts'
{
  "8080/tcp": {},
  "8081/tcp": {},
  "8082/tcp": {},
  "8083/tcp": {},
  "8084/tcp": {},
  "8085/tcp": {},
  "9090/tcp": {},
  "9091/tcp": {},
  "9092/tcp": {},
  "9093/tcp": {},
  "9094/tcp": {},
  "9095/tcp": {}
}
```

`Config.ExposedPorts` after running `$ aws ecs run-task --task-definition SimpleContainer --launch-type EC2 --count 1`

```
$ docker inspect ecs-SimpleContainer-3-container-... | jq '.[0] | .Config | .ExposedPorts'
{
  "8080/tcp": {},
  "9090/tcp": {}
}
```

`Config.ExposedPorts` after running `$ aws ecs run-task --task-definition Ranges --launch-type EC2 --count 1`

```
$ docker inspect ecs-Ranges-1-container-... | jq '.[0] | .Config | .ExposedPorts'
{
  "8080/tcp": {},
  "8081/tcp": {},
  "8082/tcp": {},
  "8083/tcp": {},
  "8084/tcp": {},
  "8085/tcp": {},
  "9090-9095/tcp": {}
}
```

`Config.ExposedPorts` after running `$ aws ecs run-task --task-definition SimpleContainer --launch-type EC2 --count 1` and after making the change

```
$ docker inspect ecs-SimpleContainer-3-container-... | jq '.[0] | .Config | .ExposedPorts'
{
  "8080/tcp": {},
  "9090/tcp": {}
}
```

`Config.ExposedPorts` after running `$ aws ecs run-task --task-definition Ranges --launch-type EC2 --count 1` and after making the change

```
$ docker inspect ecs-Ranges-1-container-... | jq '.[0] | .Config | .ExposedPorts'
{
  "8080/tcp": {},
  "8081/tcp": {},
  "8082/tcp": {},
  "8083/tcp": {},
  "8084/tcp": {},
  "8085/tcp": {},
  "9090/tcp": {},
  "9091/tcp": {},
  "9092/tcp": {},
  "9093/tcp": {},
  "9094/tcp": {},
  "9095/tcp": {}
}
```
</details>

New tests cover the changes: yes

### Description for the changelog
Fix: enumerate port ranges into the docker config

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
