### PR TITLE
Use debug instead of error log for skipped events for internal task/container

### DIFF
--- a/agent/api/statechange.go
+++ b/agent/api/statechange.go
@@ -101,12 +101,20 @@ type AttachmentStateChange struct {
 	Attachment *apieni.ENIAttachment
 }
 
+type ErrShouldNotSendEvent struct {
+	resourceId string
+}
+
+func (e ErrShouldNotSendEvent) Error() string {
+	return fmt.Sprintf("should not send events for internal tasks or containers: %s", e.resourceId)
+}
+
 // NewTaskStateChangeEvent creates a new task state change event
 // returns error if the state change doesn't need to be sent to the ECS backend.
 func NewTaskStateChangeEvent(task *apitask.Task, reason string) (TaskStateChange, error) {
 	var event TaskStateChange
 	if task.IsInternal {
-		return event, errors.Errorf("skip creating task stage change event for internal task %v", task.Arn)
+		return event, ErrShouldNotSendEvent{task.Arn}
 	}
 	taskKnownStatus := task.GetKnownStatus()
 	if !taskKnownStatus.BackendRecognized() {
@@ -160,9 +168,7 @@ func NewContainerStateChangeEvent(task *apitask.Task, cont *apicontainer.Contain
 func newUncheckedContainerStateChangeEvent(task *apitask.Task, cont *apicontainer.Container, reason string) (ContainerStateChange, error) {
 	var event ContainerStateChange
 	if cont.IsInternal() {
-		return event, errors.Errorf(
-			"create container state change event api: internal container: %s",
-			cont.Name)
+		return event, ErrShouldNotSendEvent{cont.Name}
 	}
 	portBindings := cont.GetKnownPortBindings()
 	if task.IsServiceConnectEnabled() && task.IsNetworkModeBridge() {

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -784,10 +784,14 @@ func (engine *DockerTaskEngine) deleteTask(task *apitask.Task) {
 func (engine *DockerTaskEngine) emitTaskEvent(task *apitask.Task, reason string) {
 	event, err := api.NewTaskStateChangeEvent(task, reason)
 	if err != nil {
-		logger.Error("Unable to create task state change event", logger.Fields{
-			field.TaskID: task.GetID(),
-			field.Error:  err,
-		})
+		if _, ok := err.(api.ErrShouldNotSendEvent); ok {
+			logger.Debug(err.Error())
+		} else {
+			logger.Error("Unable to create task state change event", logger.Fields{
+				field.TaskID: task.GetID(),
+				field.Error:  err,
+			})
+		}
 		return
 	}
 	logger.Info("Preparing to send change event", logger.Fields{

--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -615,11 +615,15 @@ func (mtask *managedTask) emitTaskEvent(task *apitask.Task, reason string) {
 	}
 	event, err := api.NewTaskStateChangeEvent(task, reason)
 	if err != nil {
-		logger.Error("Skipping emitting event for task due to error", logger.Fields{
-			field.TaskID: mtask.GetID(),
-			field.Reason: reason,
-			field.Error:  err,
-		})
+		if _, ok := err.(api.ErrShouldNotSendEvent); ok {
+			logger.Debug(err.Error())
+		} else {
+			logger.Error("Skipping emitting event for task due to error", logger.Fields{
+				field.TaskID: mtask.GetID(),
+				field.Reason: reason,
+				field.Error:  err,
+			})
+		}
 		return
 	}
 	logger.Debug("Sending task change event", logger.Fields{
@@ -680,11 +684,15 @@ func (mtask *managedTask) emitManagedAgentEvent(task *apitask.Task, cont *apicon
 func (mtask *managedTask) emitContainerEvent(task *apitask.Task, cont *apicontainer.Container, reason string) {
 	event, err := api.NewContainerStateChangeEvent(task, cont, reason)
 	if err != nil {
-		logger.Debug("Skipping emitting event for container", logger.Fields{
-			field.TaskID:    mtask.GetID(),
-			field.Container: cont.Name,
-			field.Error:     err,
-		})
+		if _, ok := err.(api.ErrShouldNotSendEvent); ok {
+			logger.Debug(err.Error())
+		} else {
+			logger.Error("Skipping emitting event for container due to error", logger.Fields{
+				field.TaskID:    mtask.GetID(),
+				field.Container: cont.Name,
+				field.Error:     err,
+			})
+		}
 		return
 	}
 	mtask.doEmitContainerEvent(event)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
For internal tasks (e.g. service connect relay) or internal containers (e.g. pause containers), we do not wish to publish any state change events for them. Currently we log an error message when we encounter such task/container while constructing the events. But that could be noisy and misleading since this is not a real error but rather designed behavior. This PR updates all such error messages to be debug messages.

### Implementation details
<!-- How are the changes implemented? -->
Created new error type `ErrShouldNotSendEvent`. This error will be returned for internal task/containers when constructing a state change event. Caller will discern this error, and log a debug instead of error message in that case.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
* Ran `make test`
* Tested updated ECS Agent with service connect task, observed debug logs below
```
level=debug time=2023-02-06T21:01:52Z msg="Should not send events for internal tasks or containers: ~internal~ecs~pause-server"
level=debug time=2023-02-06T21:01:52Z msg="Should not send events for internal tasks or containers: ~internal~ecs~pause-ecs-service-connect-ciCxr"
level=debug time=2023-02-06T21:01:52Z msg="Should not send events for internal tasks or containers: instance-service-connect-relay"
```

New tests cover the changes: <!-- yes|no --> no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Use debug instead of error log for skipped events for internal task/container

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
