### PR TITLE
windows: explicitly provide the network name override to nat when using bridge network mode

### DIFF
--- a/agent/api/task/task_windows.go
+++ b/agent/api/task/task_windows.go
@@ -43,6 +43,10 @@ const (
 	cpuSharesPerCore  = 1024
 	percentageFactor  = 100
 	minimumCPUPercent = 1
+
+	// windowsDefaultNetworkName is the name of the docker network to which the containers in
+	// default mode are attached to.
+	windowsDefaultNetworkName = "nat"
 )
 
 // PlatformFields consists of fields specific to Windows for a task
@@ -103,6 +107,13 @@ func (task *Task) platformHostConfigOverride(hostConfig *dockercontainer.HostCon
 		// As of version  17.06.2-ee-6 of docker. MemoryReservation is not supported on windows. This ensures that
 		// this parameter is not passed, allowing to launch a container without a hard limit.
 		hostConfig.MemoryReservation = 0
+	}
+
+	// On Windows, bridge mode equivalent for Linux is "default" or "nat" network.
+	// We need to perform explicit conversion for the same.
+	networkMode := hostConfig.NetworkMode.NetworkName()
+	if networkMode == BridgeNetworkMode {
+		hostConfig.NetworkMode = windowsDefaultNetworkName
 	}
 
 	return nil

--- a/agent/api/task/task_windows_test.go
+++ b/agent/api/task/task_windows_test.go
@@ -142,6 +142,7 @@ func removeEndpointConfigFromEnvironment(container *apicontainer.Container) {
 func TestWindowsPlatformHostConfigOverride(t *testing.T) {
 	// Testing Windows platform override for HostConfig.
 	// Expects MemorySwappiness option to be set to -1
+	// Expects NetworkMode to be set as nat only when the network mode is bridge.
 
 	task := &Task{}
 
@@ -155,6 +156,14 @@ func TestWindowsPlatformHostConfigOverride(t *testing.T) {
 	task.platformHostConfigOverride(hostConfig)
 	assert.Equal(t, int64(minimumCPUPercent), hostConfig.CPUPercent)
 	assert.Empty(t, hostConfig.CPUShares)
+
+	hostConfig = &dockercontainer.HostConfig{NetworkMode: BridgeNetworkMode}
+	task.platformHostConfigOverride(hostConfig)
+	assert.Equal(t, windowsDefaultNetworkName, hostConfig.NetworkMode.NetworkName())
+
+	hostConfig = &dockercontainer.HostConfig{NetworkMode: AWSVPCNetworkMode}
+	task.platformHostConfigOverride(hostConfig)
+	assert.Equal(t, AWSVPCNetworkMode, hostConfig.NetworkMode.NetworkName())
 }
 
 func TestDockerHostConfigRawConfigMerging(t *testing.T) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
On Linux, the default network mode is `bridge` wherein all the containers are attached to a common docker bridge network. On Windows, this default mode translates to `nat` or `default` docker network.

When we use `bridge` as the network mode, then docker daemon errors out due to `bridge` network not present itself. Therefore, we need to do an override for Windows such that whenever `bridge` mode is specified in HostConfig, we would translate it to `nat` network.

This PR adds support for the same.
### Implementation details
<!-- How are the changes implemented? -->
We already have a method named `platformHostConfigOverride` in `task_windows.go` which performs platform specific overrides in the HostConfig. We have added the translation logic in the same method.


### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

A custom binary of the agent was built and was tested out.
Ran a bunch of tasks with both `bridge` and `default` mode.

New tests cover the changes: <!-- yes|no --> Yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
windows: explicitly provide the network name override to nat when using bridge network mode
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
