### PR TITLE
Remove fallback to Docker for host port ranges assignment

### DIFF
--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -18,7 +18,6 @@ package task
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"reflect"
 	"runtime"
@@ -262,26 +261,6 @@ func TestDockerHostConfigPortBinding(t *testing.T) {
 				Name: "c1",
 				Ports: []apicontainer.PortBinding{
 					{
-						ContainerPortRange: "999-1000",
-						BindIP:             "",
-						Protocol:           apicontainer.TransportProtocolTCP,
-					},
-					{
-						ContainerPortRange: "1-3",
-						BindIP:             "",
-						Protocol:           apicontainer.TransportProtocolUDP,
-					},
-				},
-			},
-		},
-	}
-
-	testTask3 := &Task{
-		Containers: []*apicontainer.Container{
-			{
-				Name: "c1",
-				Ports: []apicontainer.PortBinding{
-					{
 						ContainerPortRange: "55-57",
 						BindIP:             "",
 						Protocol:           apicontainer.TransportProtocolUDP,
@@ -318,30 +297,8 @@ func TestDockerHostConfigPortBinding(t *testing.T) {
 			expectedContainerPortRangeMap: map[string]string{},
 		},
 		{
-			testName: "2 port bindings, each with container port range, 1 found valid host port range, other didn't",
-			testTask: testTask2,
-			getHostPortRange: func(numberOfPorts int, protocol string, dynamicHostPortRange string) (string, error) {
-				if numberOfPorts == 3 {
-					return "", errors.New("couldn't find host ports")
-				}
-				return "99-100", nil
-			},
-			expectedPortBinding: nat.PortMap{
-				nat.Port("999/tcp"):  []nat.PortBinding{{HostPort: "99"}},
-				nat.Port("1000/tcp"): []nat.PortBinding{{HostPort: "100"}},
-			},
-			expectedContainerPortSet: map[int]struct{}{
-				1: {},
-				2: {},
-				3: {},
-			},
-			expectedContainerPortRangeMap: map[string]string{
-				"999-1000": "99-100",
-			},
-		},
-		{
 			testName: "2 port bindings, one with container port range, other with singular container port",
-			testTask: testTask3,
+			testTask: testTask2,
 			getHostPortRange: func(numberOfPorts int, protocol string, dynamicHostPortRange string) (string, error) {
 				return "155-157", nil
 			},


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Starting from ECS Agent version `1.68.0 `, users can specify [containerPortRange](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_PortMapping.html) at ECS task level, and `ECS_DYNAMIC_HOST_PORT_RANGE` at the container instance level to customize 1:1 container-host port mappings for their applications.

With the configured environment variable `ECS_DYNAMIC_HOST_PORT_RANGE`, ECS Agent will try to find a set of contiguous host ports within the given range. As users are expected to have ports to be bound in the customized range, errors should be returned instead of falling back for Docker to process dynamic port assignment if a set of contiguous host ports cannot be found by ECS Agent; therefore, this PR removes the Docker fallback mechanism when a set of contiguous host ports cannot be found by ECS Agent. 

### Issue
Scenario: `ECS_DYNAMIC_HOST_PORT_RANGE` is set, but host ports within the given range are not available for a bridge network mode task to bind it's container ports specified in the `containerPortRange` field.
* __Expected result__: Task failed or a container STOPPED with an error `Reason HostConfigError: error retrieving docker port map: 2 contiguous host ports unavailable`
* __Actual result__: Task succeeded but `networkBindings` is empty, and ecs-agent.log shows `level=error msg="Unable to find contiguous host ports for container, falling back to docker dynamic port assignment" container="xxx" containerPortRange="8085-8086" error="2 contiguous host ports unavailable" task="xxx"`

#### Setup
* ECS-optimized AMI: amzn2-ami-ecs-hvm-2.0.20230127-x86_64-ebs 
* ECS Agent version: 1.68.2
* An ECS cluster with only one registered EC2 instance 
* Userdata
```
#!/bin/bash
echo ECS_DYNAMIC_HOST_PORT_RANGE=100-102 >> /etc/ecs/ecs.config
``` 
* ECS Task definition
```
    {
      "networkMode": "bridge",
      "containerDefinitions": [
        {
          "portMappings": [
            {
              "protocol": "tcp",
              "containerPortRange": "8085-8086"
            }
          ],
          ...
        }
      ]
    }
```
* Ran the first ECS task, the task reached to RUNNING state and the`hostPortRange` returned from [ecs describe-tasks](https://docs.aws.amazon.com/cli/latest/reference/ecs/describe-tasks.html) call is within the given `ECS_DYNAMIC_HOST_PORT_RANGE` value.
```
$ aws ecs describe-tasks --cluster xxx --tasks "xxx" --region xxx
{
            "containers": [
                {
                    "networkBindings": [
                        {
                            "bindIP": "0.0.0.0",
                            "protocol": "tcp",
                            "containerPortRange": "8085-8086",
                            "hostPortRange": "100-101"
                        }
                    ],
                    ...
                }
            ],
}
```
* Ran the same ECS task again, the task reached to RUNNING state but the `hostPortRange` returned from [ecs describe-tasks](https://docs.aws.amazon.com/cli/latest/reference/ecs/describe-tasks.html) call is empty.
```
$ aws ecs describe-tasks --cluster xxx --tasks "xxx" --region xxx
{
            "containers": [
                {
                    "lastStatus": "RUNNING",
                    "networkBindings": [],
                 ...
                }
            ],
}
``` 



### Implementation details
1. agent/api/task/task.go
 - for `containerPortRange` case, return nil as docker port map along with an error in `dockerPortMap()` when a set of contiguous host ports cannot be found by ECS Agent.
2. agent/api/task/task_test.go
- Remove an invalid test after the change made in `dockerPortMap()`

### Testing
1. Replaced the ECS Agent with the fix on the host, run 2 tasks and confirmed the second tasks failed as expected. Details of setup are provided in the __Issue__ section.

```
$ aws ecs describe-tasks --cluster xxx --tasks "xxx" --region xxx
{

            "containers": [
                {
                    "lastStatus": "STOPPED",
                    "reason": "HostConfigError: error retrieving docker port map: 2 contiguous host ports unavailable",
                    "networkInterfaces": [],
                }
}
```

```
ecs-agent.log

level=info time=xxx msg="Creating container" task="xxx" container="xxx"
level=error time=xxx msg="Unable to find contiguous host ports for container" containerPortRange="8085-8086" error="2 contiguous host ports unavailable" task="xxx" container="xxx"
...
level=error time=xxx msg="Error transitioning container" task="xxx" container="xxx" runtimeID="" nextState="CREATED" error="error retrieving docker port map: 2 contiguous host ports unavailable"
...
level=warn time=xxx msg="Error creating container; marking its desired status as STOPPED" task="xxx" container="xxx" error="error retrieving docker port map: 2 contiguous host ports unavailable"
...
```

New tests cover the changes: no

### Description for the changelog
Bug - Remove fallback to Docker for host port ranges assignment

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
