### PR TITLE
[WIP][DHPA] Update dockerPortMap() to include ECS Agent host port assignment logic

### DIFF
--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -240,13 +240,13 @@ func TestDockerHostConfigPortBinding(t *testing.T) {
 				Ports: []apicontainer.PortBinding{
 					{
 						ContainerPort: 10,
-						HostPort:      10,
+						HostPort:      20,
 						BindIP:        "",
 						Protocol:      apicontainer.TransportProtocolTCP,
 					},
 					{
 						ContainerPort: 20,
-						HostPort:      20,
+						HostPort:      30,
 						BindIP:        "",
 						Protocol:      apicontainer.TransportProtocolUDP,
 					},
@@ -256,6 +256,31 @@ func TestDockerHostConfigPortBinding(t *testing.T) {
 	}
 
 	testTask2 := &Task{
+		Containers: []*apicontainer.Container{
+			{
+				Name: "c1",
+				Ports: []apicontainer.PortBinding{
+					{
+						ContainerPort: 10,
+						BindIP:        "",
+						Protocol:      apicontainer.TransportProtocolTCP,
+					},
+					{
+						ContainerPort: 20,
+						BindIP:        "",
+						Protocol:      apicontainer.TransportProtocolUDP,
+					},
+					{
+						ContainerPort: 30,
+						BindIP:        "",
+						Protocol:      apicontainer.TransportProtocolUDP,
+					},
+				},
+			},
+		},
+	}
+
+	testTask3 := &Task{
 		Containers: []*apicontainer.Container{
 			{
 				Name: "c1",
@@ -278,17 +303,20 @@ func TestDockerHostConfigPortBinding(t *testing.T) {
 	testCases := []struct {
 		testName                      string
 		testTask                      *Task
-		getHostPortRange              func(numberOfPorts int, protocol string, dynamicHostPortRange string) (string, error)
+		testDynamicHostPortRange      string
+		testContainerPortRange        string
 		expectedPortBinding           nat.PortMap
 		expectedContainerPortSet      map[int]struct{}
 		expectedContainerPortRangeMap map[string]string
+		expectedError                 bool
 	}{
 		{
-			testName: "2 port bindings, each with singular container port - host port",
-			testTask: testTask1,
+			testName:                 "user-specified container ports and host ports",
+			testTask:                 testTask1,
+			testDynamicHostPortRange: "40000-60000",
 			expectedPortBinding: nat.PortMap{
-				nat.Port("10/tcp"): []nat.PortBinding{{HostPort: "10"}},
-				nat.Port("20/udp"): []nat.PortBinding{{HostPort: "20"}},
+				nat.Port("10/tcp"): []nat.PortBinding{{HostPort: "20"}},
+				nat.Port("20/udp"): []nat.PortBinding{{HostPort: "30"}},
 			},
 			expectedContainerPortSet: map[int]struct{}{
 				10: {},
@@ -297,23 +325,37 @@ func TestDockerHostConfigPortBinding(t *testing.T) {
 			expectedContainerPortRangeMap: map[string]string{},
 		},
 		{
-			testName: "2 port bindings, one with container port range, other with singular container port",
-			testTask: testTask2,
-			getHostPortRange: func(numberOfPorts int, protocol string, dynamicHostPortRange string) (string, error) {
-				return "155-157", nil
+			testName:                 "user-specified container ports with a ideal dynamicHostPortRange",
+			testTask:                 testTask2,
+			testDynamicHostPortRange: "40000-60000",
+			expectedContainerPortSet: map[int]struct{}{
+				10: {},
+				20: {},
+				30: {},
 			},
-			expectedPortBinding: nat.PortMap{
-				nat.Port("55/udp"): []nat.PortBinding{{HostPort: "155"}},
-				nat.Port("56/udp"): []nat.PortBinding{{HostPort: "156"}},
-				nat.Port("57/udp"): []nat.PortBinding{{HostPort: "157"}},
-				nat.Port("80/tcp"): []nat.PortBinding{{HostPort: "0"}},
-			},
+			expectedContainerPortRangeMap: map[string]string{},
+		},
+		{
+			testName:                 "user-specified container ports with a bad dynamicHostPortRange",
+			testTask:                 testTask2,
+			testDynamicHostPortRange: "100-101",
+			expectedError:            true,
+		},
+		{
+			testName:                 "user-specified container port and container port range with a ideal dynamicHostPortRange",
+			testTask:                 testTask3,
+			testDynamicHostPortRange: "40000-60000",
+			testContainerPortRange:   "55-57",
 			expectedContainerPortSet: map[int]struct{}{
 				80: {},
 			},
-			expectedContainerPortRangeMap: map[string]string{
-				"55-57": "155-157",
-			},
+		},
+		{
+			testName:                 "user-specified container port and container port range with a bad user-specified dynamicHostPortRange",
+			testTask:                 testTask3,
+			testDynamicHostPortRange: "40000-40001",
+			testContainerPortRange:   "55-57",
+			expectedError:            true,
 		},
 	}
 
@@ -322,22 +364,51 @@ func TestDockerHostConfigPortBinding(t *testing.T) {
 			defer func() {
 				getHostPortRange = utils.GetHostPortRange
 			}()
-			getHostPortRange = tc.getHostPortRange
 
-			config, err := tc.testTask.DockerHostConfig(tc.testTask.Containers[0], dockerMap(tc.testTask), defaultDockerClientAPIVersion,
-				&config.Config{})
-			assert.Nil(t, err)
+			// get the Docker host config for the task container
+			config, err := tc.testTask.DockerHostConfig(tc.testTask.Containers[0], dockerMap(tc.testTask),
+				defaultDockerClientAPIVersion, &config.Config{DynamicHostPortRange: tc.testDynamicHostPortRange})
+			if !tc.expectedError {
+				assert.Nil(t, err)
 
-			if !reflect.DeepEqual(config.PortBindings, tc.expectedPortBinding) {
-				t.Error("Expected port bindings to be resolved, was: ", config.PortBindings)
-			}
+				// verify PortBindings
+				if tc.expectedPortBinding != nil {
+					if !reflect.DeepEqual(config.PortBindings, tc.expectedPortBinding) {
+						t.Error("Expected port bindings to be resolved, was: ", config.PortBindings)
+					}
+				} else {
+					// verify ECS Agent assigned host ports are within the dynamic host port range
+					eStartPort, eEndPort, _ := nat.ParsePortRangeToInt(tc.testDynamicHostPortRange)
+					for _, hostPortBinding := range config.PortBindings {
+						hostPort, _ := strconv.Atoi(hostPortBinding[0].HostPort)
+						result := utils.PortIsInRange(hostPort, eStartPort, eEndPort)
+						if !result {
+							t.Error("Actual host port is not in the dynamicHostPortRange: ", hostPort)
+							break
+						}
+					}
+				}
 
-			if !reflect.DeepEqual(tc.testTask.Containers[0].ContainerPortSet, tc.expectedContainerPortSet) {
-				t.Error("Expected container port set to be resolved, was: ", tc.testTask.Containers[0].GetContainerPortSet())
-			}
+				// verify ContainerPortSet
+				if !reflect.DeepEqual(tc.testTask.Containers[0].ContainerPortSet, tc.expectedContainerPortSet) {
+					t.Error("Expected container port set to be resolved, was: ", tc.testTask.Containers[0].GetContainerPortSet())
+				}
 
-			if !reflect.DeepEqual(tc.testTask.Containers[0].ContainerPortRangeMap, tc.expectedContainerPortRangeMap) {
-				t.Error("Expected container port range map to be resolved, was: ", tc.testTask.Containers[0].GetContainerPortRangeMap())
+				// verify ContainerPortRangeMap
+				if tc.expectedContainerPortRangeMap != nil {
+					if !reflect.DeepEqual(tc.testTask.Containers[0].ContainerPortRangeMap, tc.expectedContainerPortRangeMap) {
+						t.Error("Expected container port range map to be resolved, was: ", tc.testTask.Containers[0].GetContainerPortRangeMap())
+					}
+				} else {
+					// verify ECS Agent assigned host port range are within the dynamic host port range
+					hostPortRange := tc.testTask.Containers[0].ContainerPortRangeMap[tc.testContainerPortRange]
+					result := utils.VerifyPortsWithinRange(hostPortRange, tc.testDynamicHostPortRange)
+					if !result {
+						t.Error("Expected host port range should be in the dynamicHostPortRange, but the actual host port range is: ", hostPortRange)
+					}
+				}
+			} else {
+				assert.NotNil(t, err)
 			}
 		})
 	}

--- a/agent/utils/ephemeral_ports.go
+++ b/agent/utils/ephemeral_ports.go
@@ -214,3 +214,31 @@ func getHostPortRange(numberOfPorts, start, end int, protocol string) (string, i
 
 	return fmt.Sprintf("%d-%d", resultStartPort, resultEndPort), resultEndPort, nil
 }
+
+// PortIsInRange checks the given port is within the start-end range
+func PortIsInRange(port, start, end int) bool {
+	if (port >= start) && (port <= end) {
+		return true
+	}
+	return false
+}
+
+// VerifyPortsWithinRange returns true if the actualPortRange is within the expectedPortRange;
+// otherwise, returns false.
+func VerifyPortsWithinRange(actualPortRange, expectedPortRange string) bool {
+	// get the actual start port and end port
+	aStartPort, aEndPort, _ := nat.ParsePortRangeToInt(actualPortRange)
+	// get the expected start port and end port
+	eStartPort, eEndPort, _ := nat.ParsePortRangeToInt(expectedPortRange)
+	// check the actual start port is in the expected range or not
+	aStartIsInRange := PortIsInRange(aStartPort, eStartPort, eEndPort)
+	// check the actual end port is in the expected range or not
+	aEndIsInRange := PortIsInRange(aEndPort, eStartPort, eEndPort)
+
+	// return true if both actual start port and end port are in the expected range
+	if aStartIsInRange && aEndIsInRange {
+		return true
+	}
+
+	return false
+}

--- a/agent/utils/ephemeral_ports_test.go
+++ b/agent/utils/ephemeral_ports_test.go
@@ -207,9 +207,70 @@ func TestGetHostPort(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Equal(t, numberOfPorts, numberOfHostPorts)
 
-				actualResult := verifyPortsWithinRange(hostPortRange, tc.testDynamicHostPortRange)
+				actualResult := VerifyPortsWithinRange(hostPortRange, tc.testDynamicHostPortRange)
 				assert.True(t, actualResult)
 			}
+		})
+	}
+}
+
+func TestPortIsInRange(t *testing.T) {
+	testCases := []struct {
+		testName       string
+		testPort       int
+		testStartPort  int
+		testEndPort    int
+		expectedResult bool
+	}{
+		{
+			testName:       "in the range",
+			testPort:       100,
+			testStartPort:  1,
+			testEndPort:    9999,
+			expectedResult: true,
+		},
+		{
+			testName:       "not in the range",
+			testPort:       10000,
+			testStartPort:  1,
+			testEndPort:    9999,
+			expectedResult: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			result := PortIsInRange(tc.testPort, tc.testStartPort, tc.testEndPort)
+			assert.Equal(t, tc.expectedResult, result)
+		})
+	}
+}
+
+func TestVerifyPortsWithinRange(t *testing.T) {
+	testCases := []struct {
+		testName          string
+		testActualRange   string
+		testExpectedRange string
+		expectedResult    bool
+	}{
+		{
+			testName:          "in the expected range",
+			testActualRange:   "1000-1005",
+			testExpectedRange: "900-2000",
+			expectedResult:    true,
+		},
+		{
+			testName:          "not in the expected range",
+			testActualRange:   "1-2",
+			testExpectedRange: "2-100",
+			expectedResult:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			result := VerifyPortsWithinRange(tc.testActualRange, tc.testExpectedRange)
+			assert.Equal(t, tc.expectedResult, result)
 		})
 	}
 }
@@ -220,32 +281,4 @@ func getPortRangeLength(portRange string) (int, error) {
 		return 0, err
 	}
 	return endPort - startPort + 1, nil
-}
-
-// verifyPortsWithinRange returns true if the actualPortRange is within the expectedPortRange;
-// otherwise, returns false.
-func verifyPortsWithinRange(actualPortRange, expectedPortRange string) bool {
-	// get the actual start port and end port
-	aStartPort, aEndPort, _ := nat.ParsePortRangeToInt(actualPortRange)
-	// get the expected start port and end port
-	eStartPort, eEndPort, _ := nat.ParsePortRangeToInt(expectedPortRange)
-	// check the actual start port is in the expected range or not
-	aStartIsInRange := portIsInRange(aStartPort, eStartPort, eEndPort)
-	// check the actual end port is in the expected range or not
-	aEndIsInRange := portIsInRange(aEndPort, eStartPort, eEndPort)
-
-	// return true if both actual start port and end port are in the expected range
-	if aStartIsInRange && aEndIsInRange {
-		return true
-	}
-
-	return false
-}
-
-// portIsInRange checks the given port is within the start-end range
-func portIsInRange(port, start, end int) bool {
-	if (port >= start) && (port <= end) {
-		return true
-	}
-	return false
 }


### PR DESCRIPTION
### Summary
DHPA - Dynamic Host Port Assignment

__The target branch of this PR is [feature/dynamicHostPortAssignment](https://github.com/aws/amazon-ecs-agent/tree/feature/dynamicHostPortAssignment)__.

This is a follow-up PR for [ [DHPA] Add GetHostPort() and update unit tests](https://github.com/aws/amazon-ecs-agent/pull/3570) to utilize function `GetHostPort()` in `dockerPortMap()` to construct port bindings for a task container in task.go.

In `dockerPortMap()`, we create port bindings for service connect ingress listeners, update the docker port map, update the container port set, update the container port range and assign them to the corresponding task container based on each case. 

Comparing to the current [dockerPortMap()](https://github.com/aws/amazon-ecs-agent/blob/master/agent/api/task/task.go#L2341-L2449), main changes made for this function in this PR includes:

1. Add a new function called `updatePortMapWithSCIngressConfig()` to handle creating port bindings for service connect ingress config
2. Use `GetHostPort()` to get host port from the given `dynamicHostPortRange` when it's a default bridge mode service connect experience or there is no user-specified host port in the bridge mode task.

Note that `dynamicHostPortRange` can be configured by users using ECS Agent environment variable [ECS_DYNAMIC_HOST_PORT_RANGE](https://github.com/aws/amazon-ecs-agent/search?q=ECS_DYNAMIC_HOST_PORT_RANGE); if the customized value is not provided, ECS Agent will use the default value returned from [GetDynamicHostPortRange()](https://github.com/aws/amazon-ecs-agent/search?q=GetDynamicHostPortRange) in the utilizes package.

### Implementation details
__agent/api/task/task.go__
 * Add a new function `updatePortMapWithSCIngressConfig()` 
 * Update `dockerPortMap()` to include ECS Agent dynamic host port assignment for a singular port case
 * Add comments to each function

__agent/api/task/task_test.go__
 * Update test cases in `TestDockerHostConfigPortBinding` to test changes

__agent/utils/ephemeral_ports.go__
 * Move  `VerifyPortsWithinRange()` and `PortIsInRange()` from the test file and make them public for reusing them in task_test.go

__agent/utils/ephemeral_ports_test.go__
 *  Add unit tests for `VerifyPortsWithinRange()` and `PortIsInRange()` 

### Testing
New tests cover the changes: yes

#### Unit test
```
--- PASS: TestDockerHostConfigPortBinding (0.00s)
    --- PASS: TestDockerHostConfigPortBinding/user-specified_container_ports_and_host_ports (0.00s)
    --- PASS: TestDockerHostConfigPortBinding/user-specified_container_ports_with_a_ideal_dynamicHostPortRange (0.00s)
    --- PASS: TestDockerHostConfigPortBinding/user-specified_container_ports_with_a_bad_dynamicHostPortRange (0.00s)
    --- PASS: TestDockerHostConfigPortBinding/user-specified_container_port_and_container_port_range_with_a_ideal_dynamicHostPortRange (0.00s)
    --- PASS: TestDockerHostConfigPortBinding/user-specified_container_port_and_container_port_range_with_a_bad_user-specified_dynamicHostPortRange (0.00s)
```

#### Manual test
##### Setup
* An ECS cluster with only one registered EC2 instance, which is launched with ECS optimized AMI: amzn2-ami-ecs-hvm-2.0.20230127-x86_64-ebs
* Install AWS CLI version `aws-cli/2.10.0 Python/3.9.11 Linux/4.14.301-224.520.amzn2.x86_64 exe/x86_64.amzn.2 prompt/off` on the host
* Run [ecs describe-tasks](https://docs.aws.amazon.com/cli/latest/reference/ecs/describe-tasks.html) to get the actual [networkBindings](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_NetworkBinding.html) of the task container
* Check the default ephemeral port range for Docker version 1.6.0 and later listed on the instance under /proc/sys/net/ipv4/ip_local_port_range
```
[ec2-user@ip-xxx]$ cat /proc/sys/net/ipv4/ip_local_port_range
32768   60999
```
##### Test cases

| Case   |      ECS_DYNAMIC_HOST_PORT_RANGE      |  Port mappings in task def | Result | Note | 
|:----------:|:-------------:|:------:|:------:|:------:|
| 1 |  no user-specificed value | containerPortRange 8080-8084 | hostPortRange 32773-32777 | ports in default range |
| 2 |  user-specificed invalid value | containerPortRange 8080-8084 | hostPortRange 32768-32772 | fall back to use default range |
| 3 |  user-specificed 50000-50010 | containerPortRange 8080-8084 | hostPortRange 50000-50004 | ports in user-specificed range |
| 4 |  user-specificed 50000-50001 | containerPortRange 8080-8084 | HostConfigError: error retrieving docker port map 5 contiguous host ports are unavailable | the range is not enough to cover required # of ports |
| 5 |  no user-specificed value | containerPort 8080  | hostPort 32768 | ports in default range |
| 6 |  user-specificed invalid value | containerPort 8080  | hostPort 32768 | fall back to use default range |
| 7 |  user-specificed 50000-50010 | containerPort 8080 | hostPort 50005 | ports in user-specificed range |
| 8 |  user-specificed 50000-50001 | containerPort 8080 | HostConfigError: error retrieving docker port map: a host port is unavailablee | port 50000 and 50001 were occupied by other tasks |
| 9 |  user-specificed 50000-50010 | containerPort 8080 hostPort 9000 | hostPort 9000 | bound to user-specificed hostPort |


### Description for the changelog
[Enhancement] Support user-specified dynamic host port range for a singular port.

### Related PRs
1. https://github.com/aws/amazon-ecs-agent/pull/3570
2. https://github.com/aws/amazon-ecs-agent/pull/3569
3. https://github.com/aws/amazon-ecs-agent/pull/3522
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.