### PR TITLE
Revert "imageDigest only for ecr"

### DIFF
--- a/agent/engine/docker_image_manager.go
+++ b/agent/engine/docker_image_manager.go
@@ -165,27 +165,20 @@ func (imageManager *dockerImageManager) RecordContainerReference(container *apic
 	return nil
 }
 
-// check whether image pull from ECR
-func (imageManager *dockerImageManager) isImagePullFromECR(container *apicontainer.Container) bool {
-	return container.RegistryAuthentication != nil && container.RegistryAuthentication.ECRAuthData != nil && container.RegistryAuthentication.Type == apicontainer.AuthTypeECR
-}
-
 // The helper function to fetch the RepoImageDigest when inspect the image
 func (imageManager *dockerImageManager) fetchRepoDigest(imageInspected *types.ImageInspect, container *apicontainer.Container) string {
+	imageRepoDigests := imageInspected.RepoDigests
 	resultRepoDigest := ""
-	if imageManager.isImagePullFromECR(container) {
-		imageRepoDigests := imageInspected.RepoDigests
-		imagePrefix := strings.Split(container.Image, "/")[0]
-		for _, imageRepoDigest := range imageRepoDigests {
-			if strings.HasPrefix(imageRepoDigest, imagePrefix) {
-				repoDigestSplitList := strings.Split(imageRepoDigest, "@")
-				if len(repoDigestSplitList) > 1 {
-					resultRepoDigest = repoDigestSplitList[1]
-					return resultRepoDigest
-				} else {
-					seelog.Warnf("ImageRepoDigest doesn't have the right format: %v", imageRepoDigest)
-					return ""
-				}
+	imagePrefix := strings.Split(container.Image, ":")[0]
+	for _, imageRepoDigest := range imageRepoDigests {
+		if strings.HasPrefix(imageRepoDigest, imagePrefix) {
+			repoDigestSplitList := strings.Split(imageRepoDigest, "@")
+			if len(repoDigestSplitList) > 1 {
+				resultRepoDigest = repoDigestSplitList[1]
+				return resultRepoDigest
+			} else {
+				seelog.Warnf("ImageRepoDigest doesn't have the right format: %v", imageRepoDigest)
+				return ""
 			}
 		}
 	}

--- a/agent/engine/docker_image_manager_test.go
+++ b/agent/engine/docker_image_manager_test.go
@@ -307,7 +307,7 @@ func TestFetchRepoDigest(t *testing.T) {
 			container: &apicontainer.Container{
 				Name:        "testContainer1",
 				Image:       "repo1",
-				ImageDigest: "",
+				ImageDigest: "digest1",
 			},
 			imageInspected: &types.ImageInspect{
 				RepoDigests: []string{"repo1@digest1", "repo2@digest2", "repo3@digest3"},
@@ -317,7 +317,7 @@ func TestFetchRepoDigest(t *testing.T) {
 			container: &apicontainer.Container{
 				Name:        "testContainer2",
 				Image:       "repo1:latest",
-				ImageDigest: "",
+				ImageDigest: "digest1",
 			},
 			imageInspected: &types.ImageInspect{
 				RepoDigests: []string{"repo1@digest1", "repo2@digest2", "repo3@digest3"},
@@ -327,7 +327,7 @@ func TestFetchRepoDigest(t *testing.T) {
 			container: &apicontainer.Container{
 				Name:        "testContainer3",
 				Image:       "repo1@sha256:12345",
-				ImageDigest: "",
+				ImageDigest: "sha256:12345",
 			},
 			imageInspected: &types.ImageInspect{
 				RepoDigests: []string{"repo1@sha256:12345", "repo2@digest2", "repo3"},
@@ -351,38 +351,6 @@ func TestFetchRepoDigest(t *testing.T) {
 			},
 			imageInspected: &types.ImageInspect{
 				RepoDigests: []string{"mysql", "repo2@digest2"},
-			},
-		},
-		{
-			container: &apicontainer.Container{
-				Name:        "testContainer6",
-				Image:       "123456781234.dkr.ecr.us-west-2.amazonaws.com/test-rci@sha256:d1c14fcf2e9476ed58ebc4251b211f403f271e96b6c3d9ada0f1c5454ca4d230",
-				ImageDigest: "sha256:d1c14fcf2e9476ed58ebc4251b211f403f271e96b6c3d9ada0f1c5454ca4d230",
-				RegistryAuthentication: &apicontainer.RegistryAuthenticationData{
-					Type: "ecr",
-					ECRAuthData: &apicontainer.ECRAuthData{
-						RegistryID: "123456781234",
-					},
-				},
-			},
-			imageInspected: &types.ImageInspect{
-				RepoDigests: []string{"repo1@digest1", "repo2@digest2", "123456781234.dkr.ecr.us-west-2.amazonaws.com/test-rci@sha256:d1c14fcf2e9476ed58ebc4251b211f403f271e96b6c3d9ada0f1c5454ca4d230"},
-			},
-		},
-		{
-			container: &apicontainer.Container{
-				Name:        "testContainer7",
-				Image:       "123456781234.dkr.ecr.us-west-2.amazonaws.com/ubuntu:trusty",
-				ImageDigest: "sha256:2feffff9eeca4e736f9f8e57813a97fe930554f474f7795ffa5a9261adeaaf44",
-				RegistryAuthentication: &apicontainer.RegistryAuthenticationData{
-					Type: "ecr",
-					ECRAuthData: &apicontainer.ECRAuthData{
-						RegistryID: "123456781234",
-					},
-				},
-			},
-			imageInspected: &types.ImageInspect{
-				RepoDigests: []string{"repo1@digest1", "repo2@digest2", "", "123456781234.dkr.ecr.us-west-2.amazonaws.com/ubuntu@sha256:2feffff9eeca4e736f9f8e57813a97fe930554f474f7795ffa5a9261adeaaf44"},
 			},
 		},
 	}


### PR DESCRIPTION
This reverts commit af54b2fd75e41b7edbc181e1f7539a0409a0771a.

This would address https://github.com/aws/containers-roadmap/issues/1640

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

It was originally decided to supply image digests only for ECR because the image digests we supply do not match the dockerhub UI. This is because the dockerhub UI only shows individual "manifest" image digests for each particular image variant. ECR, on the other hand, displays the "index" digest, which is a single digest shared across all variants of a single image. Somewhat confusingly, the `docker image inspect` command shows the "index" image digest too.

What this means is that `docker image pull` and `docker image inspect` show a different image digest than the dockerhub UI. This is confusing for docker customers and fixing this is one of the most-upvoted feature requests for dockerhub: https://github.com/docker/hub-feedback/issues/1925

Our solution to customer confusion to just simply omit the digest for non-ECR repos was probably not correct. Customers want image digests for all their images. If customers are confused why the docker "index" digest that they see in ecs.DescribeTasks does not match the "manifest" digest they see in dockerhub, then this is a documentation and education issue, not a code issue.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

tested calling ecs.DescribeTasks before and after this change.

Before the change, can see imageDigest field only for private ECR repos:

private ECR (before change):
```
  "image": "XXXX.dkr.ecr.us-west-2.amazonaws.com/XXXX:XXXX",
  "imageDigest": "sha256:eab773b3c3916e73c19232cc854233a17b332754733f07dc75ccb6229a19b766",
```

public ECR (before change):
```
  "image": "public.ecr.aws/docker/library/busybox:latest",
```

dockerhub (before change):
```
  "image": "busybox:latest",
```

After this PR, can see imageDigest field for all images:

private ECR (after change):
```
  "image": "XXXX.dkr.ecr.us-west-2.amazonaws.com/XXXX:XXXX",
  "imageDigest": "sha256:eab773b3c3916e73c19232cc854233a17b332754733f07dc75ccb6229a19b766",
```

public ECR (after change):
```
  "image": "public.ecr.aws/docker/library/busybox:latest",
  "imageDigest": "sha256:7b3ccabffc97de872a30dfd234fd972a66d247c8cfc69b0550f276481852627c",
```

dockerhub (after change):
```
  "image": "busybox:latest",
  "imageDigest": "sha256:7b3ccabffc97de872a30dfd234fd972a66d247c8cfc69b0550f276481852627c",
```

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Enhancement: Provide imageDigest for images from all container repositories

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
