### PR TITLE
fix ecs-init logging

### DIFF
--- a/ecs-init/cache/cache.go
+++ b/ecs-init/cache/cache.go
@@ -183,7 +183,7 @@ func (d *Downloader) getRegion() string {
 
 	region, err := d.metadata.Region()
 	if err != nil {
-		log.Warn("Could not retrieve the region from EC2 Instance Metadata. Error: %s", err.Error())
+		log.Warnf("Could not retrieve the region from EC2 Instance Metadata. Error: %s", err.Error())
 		region = defaultRegion
 	}
 	d.region = region


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

fix ecs-init log message.

### Implementation details
<!-- How are the changes implemented? -->

using format log method with format string.
currently message shows format string  `%s`.
```
2023-02-114T01:02:00Z [WARN] Could not retrieve the region from EC2 Instance Metadata. Error: %sEC2MetadataRequestError: .....
```

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
*  fix ecs-init log message

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
