### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -24,7 +24,7 @@ jobs:
             echo "invalid GO version"
             exit 1
           fi
-          echo "::set-output name=GO_VERSION::$go_version"
+          echo "GO_VERSION=$go_version" >> $GITHUB_OUTPUT
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ steps.get-go-version.outputs.GO_VERSION }}
@@ -60,7 +60,7 @@ jobs:
             echo "invalid GO version"
             exit 1
           fi
-          echo "::set-output name=GO_VERSION::$go_version"
+          echo "GO_VERSION=$go_version" >> $GITHUB_OUTPUT
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ steps.get-go-version.outputs.GO_VERSION }}
@@ -96,7 +96,7 @@ jobs:
             echo "invalid GO version"
             exit 1
           fi
-          echo "::set-output name=GO_VERSION::$go_version"
+          echo "GO_VERSION=$go_version" >> $GITHUB_OUTPUT
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ steps.get-go-version.outputs.GO_VERSION }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -23,7 +23,7 @@ jobs:
             echo "invalid GO version"
             exit 1
           }
-          Write-Output "::set-output name=GO_VERSION_WINDOWS::$go_version_win"
+          Write-Output "GO_VERSION_WINDOWS=$go_version_win" >> $env:GITHUB_OUTPUT
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ steps.get-go-version.outputs.GO_VERSION_WINDOWS }}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary

Resolve #3579 

Update workflows to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

### Implementation details

I found the workflow files that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Enhancement - Replace deprecated command with environment file

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
