### PR TITLE
fixing build on mac

### DIFF
--- a/agent/api/task/task_unsupported.go
+++ b/agent/api/task/task_unsupported.go
@@ -82,12 +82,7 @@ func (task *Task) requiresCredentialSpecResource() bool {
 // initializeCredentialSpecResource builds the resource dependency map for the credentialspec resource
 func (task *Task) initializeCredentialSpecResource(config *config.Config, credentialsManager credentials.Manager,
 	resourceFields *taskresource.ResourceFields) error {
-	return errors.New("task credentialspec is only supported on windows")
-}
-
-// GetCredentialSpecResource retrieves credentialspec resource from resource map
-func (task *Task) GetCredentialSpecResource() ([]taskresource.TaskResource, bool) {
-	return []taskresource.TaskResource{}, false
+	return errors.New("unsupported platform")
 }
 
 func enableIPv6SysctlSetting(hostConfig *dockercontainer.HostConfig) {

--- a/agent/ecscni/types.go
+++ b/agent/ecscni/types.go
@@ -33,6 +33,10 @@ const (
 	// present in the output of the '--capabilities' command of a CNI plugin
 	// indicates that the plugin can support the ECS "awsvpc" network mode
 	CapabilityAWSVPCNetworkingMode = "awsvpc-network-mode"
+	// Starting with CNI plugin v0.8.0 (this PR https://github.com/containernetworking/cni/pull/698)
+	// NetworkName has to be non-empty field for network config.
+	// We do not actually make use of the field, hence passing in a placeholder string to fulfill the API spec
+	defaultNetworkName = "network-name"
 )
 
 // Config contains all the information to set up the container namespace using

--- a/agent/ecscni/types_linux.go
+++ b/agent/ecscni/types_linux.go
@@ -48,10 +48,6 @@ const (
 	ECSServiceConnectPluginName = "ecs-serviceconnect"
 	// NetnsFormat is used to construct the path to cotainer network namespace
 	NetnsFormat = "/host/proc/%s/ns/net"
-	// Starting with CNI plugin v0.8.0 (this PR https://github.com/containernetworking/cni/pull/698)
-	// NetworkName has to be non-empty field for network config.
-	// We do not actually make use of the field, hence passing in a placeholder string to fulfill the API spec
-	defaultNetworkName = "network-name"
 )
 
 // IPAMNetworkConfig is the config format accepted by the plugin

--- a/agent/ecscni/types_windows.go
+++ b/agent/ecscni/types_windows.go
@@ -31,10 +31,6 @@ const (
 	TaskHNSNetworkNamePrefix = "task"
 	// ECSBridgeNetworkName is the name of the HNS network used as ecs-bridge.
 	ECSBridgeNetworkName = "nat"
-	// Starting with CNI plugin v0.8.0 (this PR https://github.com/containernetworking/cni/pull/698)
-	// NetworkName has to be non-empty field for network config.
-	// We do not actually make use of the field, hence passing in a placeholder string to fulfill the API spec
-	defaultNetworkName = "network-name"
 	// DefaultENIName is the name of eni interface name in the container namespace
 	DefaultENIName = "eth0"
 )

--- a/agent/engine/docker_task_engine_unsupported.go
+++ b/agent/engine/docker_task_engine_unsupported.go
@@ -22,6 +22,8 @@ import (
 
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
+
+	dockercontainer "github.com/docker/docker/api/types/container"
 )
 
 const (
@@ -54,4 +56,9 @@ func (engine *DockerTaskEngine) reloadAppNetImage() error {
 // restartInstanceTask stop the running internal relay task and starts a new one
 // with updated AppNet image
 func (engine *DockerTaskEngine) restartInstanceTask() {
+}
+
+// updateCredentialSpecMapping is used to map the bind location of kerberos ticket to the target location on the application container
+func (engine *DockerTaskEngine) updateCredentialSpecMapping(taskID string, containerName string, desiredCredSpecInjection string, hostConfig *dockercontainer.HostConfig) {
+	return
 }

--- a/agent/taskresource/credentialspec/credentialspec_unsupported.go
+++ b/agent/taskresource/credentialspec/credentialspec_unsupported.go
@@ -1,0 +1,60 @@
+//go:build !linux && !windows
+// +build !linux,!windows
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package credentialspec
+
+import (
+	"github.com/aws/amazon-ecs-agent/agent/credentials"
+	s3factory "github.com/aws/amazon-ecs-agent/agent/s3/factory"
+	ssmfactory "github.com/aws/amazon-ecs-agent/agent/ssm/factory"
+
+	"github.com/pkg/errors"
+)
+
+// CredentialSpecResource is the abstraction for credentialspec resources
+type CredentialSpecResource struct {
+	*CredentialSpecResourceCommon
+}
+
+// CredentialSpecResourceJSON is the json representation of the credentialspec resource
+type CredentialSpecResourceJSON struct {
+	*CredentialSpecResourceJSONCommon
+}
+
+func NewCredentialSpecResource(taskARN, region string,
+	executionCredentialsID string,
+	credentialsManager credentials.Manager,
+	ssmClientCreator ssmfactory.SSMClientCreator,
+	s3ClientCreator s3factory.S3ClientCreator,
+	credentialSpecContainerMap map[string]string) (*CredentialSpecResource, error) {
+	return nil, errors.New("not supported")
+}
+
+func (cs *CredentialSpecResource) Create() error {
+	return errors.New("not supported")
+}
+
+func (cs *CredentialSpecResource) Cleanup() error {
+	return errors.New("not supported")
+}
+
+func (cs *CredentialSpecResource) MarshallPlatformSpecificFields(credentialSpecResourceJSON *CredentialSpecResourceJSON) {
+	return
+}
+
+func (cs *CredentialSpecResource) UnmarshallPlatformSpecificFields(credentialSpecResourceJSON CredentialSpecResourceJSON) {
+	return
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
When trying to run unit tests locally, the current agent code doesn't compile and prevents me from running tests. This fixes the build on darwin (macOS) and unblocks running tests.

### Implementation details
<!-- How are the changes implemented? -->

Builds on darwin fail due to some objects and methods undeclared. This refactors the missing pieces – moving a few things into common files and refactoring some other into an `_unsupported` file. This follows the existing code convention.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

Verified that I am able to build and run tests locally.

New tests cover the changes: <!-- yes|no --> no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Fix builds on a unix-like system other than linux.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
