### PR TITLE
[DHPA] Upudate dockerPortMap() in task.go with dynamic host port range support - part 1

### DIFF
--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -630,6 +630,7 @@ func (cfg *Config) String() string {
 			"DependentContainersPullUpfront: %v, "+
 			"TaskCPUMemLimit: %v, "+
 			"ShouldExcludeIPv6PortBinding: %v, "+
+			"DynamicHostPortRange: %v"+
 			"%s",
 		cfg.Cluster,
 		cfg.AWSRegion,
@@ -648,6 +649,7 @@ func (cfg *Config) String() string {
 		cfg.DependentContainersPullUpfront,
 		cfg.TaskCPUMemLimit,
 		cfg.ShouldExcludeIPv6PortBinding,
+		cfg.DynamicHostPortRange,
 		cfg.platformString(),
 	)
 }

--- a/agent/utils/ephemeral_ports.go
+++ b/agent/utils/ephemeral_ports.go
@@ -214,3 +214,32 @@ func getHostPortRange(numberOfPorts, start, end int, protocol string) (string, i
 
 	return fmt.Sprintf("%d-%d", resultStartPort, resultEndPort), resultEndPort, nil
 }
+
+// PortIsInRange returns true if the given port is within the start-end port range;
+// otherwise, returns false.
+func PortIsInRange(port, start, end int) bool {
+	if (port >= start) && (port <= end) {
+		return true
+	}
+	return false
+}
+
+// VerifyPortsWithinRange returns true if the actualPortRange is within the expectedPortRange;
+// otherwise, returns false.
+func VerifyPortsWithinRange(actualPortRange, expectedPortRange string) bool {
+	// Get the actual start port and end port
+	aStartPort, aEndPort, _ := nat.ParsePortRangeToInt(actualPortRange)
+	// Get the expected start port and end port
+	eStartPort, eEndPort, _ := nat.ParsePortRangeToInt(expectedPortRange)
+	// Check the actual start port is in the expected range or not
+	aStartIsInRange := PortIsInRange(aStartPort, eStartPort, eEndPort)
+	// Check the actual end port is in the expected range or not
+	aEndIsInRange := PortIsInRange(aEndPort, eStartPort, eEndPort)
+
+	// Return true if both actual start port and end port are in the expected range
+	if aStartIsInRange && aEndIsInRange {
+		return true
+	}
+
+	return false
+}

--- a/agent/utils/ephemeral_ports_test.go
+++ b/agent/utils/ephemeral_ports_test.go
@@ -207,9 +207,70 @@ func TestGetHostPort(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Equal(t, numberOfPorts, numberOfHostPorts)
 
-				actualResult := verifyPortsWithinRange(hostPortRange, tc.testDynamicHostPortRange)
+				actualResult := VerifyPortsWithinRange(hostPortRange, tc.testDynamicHostPortRange)
 				assert.True(t, actualResult)
 			}
+		})
+	}
+}
+
+func TestPortIsInRange(t *testing.T) {
+	testCases := []struct {
+		testName       string
+		testPort       int
+		testStartPort  int
+		testEndPort    int
+		expectedResult bool
+	}{
+		{
+			testName:       "in the range",
+			testPort:       100,
+			testStartPort:  1,
+			testEndPort:    9999,
+			expectedResult: true,
+		},
+		{
+			testName:       "not in the range",
+			testPort:       10000,
+			testStartPort:  1,
+			testEndPort:    9999,
+			expectedResult: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			result := PortIsInRange(tc.testPort, tc.testStartPort, tc.testEndPort)
+			assert.Equal(t, tc.expectedResult, result)
+		})
+	}
+}
+
+func TestVerifyPortsWithinRange(t *testing.T) {
+	testCases := []struct {
+		testName          string
+		testActualRange   string
+		testExpectedRange string
+		expectedResult    bool
+	}{
+		{
+			testName:          "in the expected range",
+			testActualRange:   "1000-1005",
+			testExpectedRange: "900-2000",
+			expectedResult:    true,
+		},
+		{
+			testName:          "not in the expected range",
+			testActualRange:   "1-2",
+			testExpectedRange: "2-100",
+			expectedResult:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			result := VerifyPortsWithinRange(tc.testActualRange, tc.testExpectedRange)
+			assert.Equal(t, tc.expectedResult, result)
 		})
 	}
 }
@@ -220,32 +281,4 @@ func getPortRangeLength(portRange string) (int, error) {
 		return 0, err
 	}
 	return endPort - startPort + 1, nil
-}
-
-// verifyPortsWithinRange returns true if the actualPortRange is within the expectedPortRange;
-// otherwise, returns false.
-func verifyPortsWithinRange(actualPortRange, expectedPortRange string) bool {
-	// get the actual start port and end port
-	aStartPort, aEndPort, _ := nat.ParsePortRangeToInt(actualPortRange)
-	// get the expected start port and end port
-	eStartPort, eEndPort, _ := nat.ParsePortRangeToInt(expectedPortRange)
-	// check the actual start port is in the expected range or not
-	aStartIsInRange := portIsInRange(aStartPort, eStartPort, eEndPort)
-	// check the actual end port is in the expected range or not
-	aEndIsInRange := portIsInRange(aEndPort, eStartPort, eEndPort)
-
-	// return true if both actual start port and end port are in the expected range
-	if aStartIsInRange && aEndIsInRange {
-		return true
-	}
-
-	return false
-}
-
-// portIsInRange checks the given port is within the start-end range
-func portIsInRange(port, start, end int) bool {
-	if (port >= start) && (port <= end) {
-		return true
-	}
-	return false
 }


### PR DESCRIPTION
### Summary
DHPA - Dynamic Host Port Assignment

__The target branch of this PR is [feature/dynamicHostPortAssignment](https://github.com/aws/amazon-ecs-agent/tree/feature/dynamicHostPortAssignment)__.

This is a follow-up PR for [ [DHPA] Add GetHostPort() and update unit tests](https://github.com/aws/amazon-ecs-agent/pull/3570) to utilize function `GetHostPort()` in `dockerPortMap()` to construct a docker port map for an application container with the user-specified container port but without an user-defined host port running in bridge network mode.

Comparing to the current [dockerPortMap()](https://github.com/aws/amazon-ecs-agent/blob/master/agent/api/task/task.go#L2341-L2449), main changes in this PR include:

1. Use `GetHostPort()` to get a host port from the given `dynamicHostPortRange` when (a) it's a bridge network mode task and (b) there is the defined container port but no defined host in the port mapping configured by customers. With this change, ECS Agent will be the single source of truth for host port assignment. We will not fall back to Docker dynamic host port assignment if no host port can be found by ECS Agent within the given `dynamicHostPortRange`.
```
{
  "networkMode": "bridge",
  "containerDefinitions": [
    {
      "portMappings": [
        {
          "protocol": "tcp",
          "containerPort": 100,  
        }
      ],
      "image": "...",
      "name": "..."
    }
  ]
}
```
> Note that `dynamicHostPortRange` can be configured by customers using ECS Agent environment variable [ECS_DYNAMIC_HOST_PORT_RANGE](https://github.com/aws/amazon-ecs-agent/search?q=ECS_DYNAMIC_HOST_PORT_RANGE); if the customized value is not provided, ECS Agent will use the default value returned from [GetDynamicHostPortRange()](https://github.com/aws/amazon-ecs-agent/search?q=GetDynamicHostPortRange).
2. Update test cases in `TestDockerHostConfigPortBinding` to validate changes made in this PR
3. Make function `PortIsInRange()` and `VerifyPortsWithinRange()` public
4. Add  `dynamicHostPortRange` to `String()`  for Agent config.go

### Implementation details
__agent/api/task/task.go__
 * Update `dockerPortMap()` to include ECS Agent dynamic host port assignment for a singular port case
 * Update comments for the function

__agent/api/task/task_test.go__
 * Update test cases in `TestDockerHostConfigPortBinding` to test changes

__agent/utils/ephemeral_ports.go__
 * Move  `VerifyPortsWithinRange()` and `PortIsInRange()` from the test file and make them public for reusing them in task_test.go

__agent/utils/ephemeral_ports_test.go__
 *  Add unit tests for `VerifyPortsWithinRange()` and `PortIsInRange()` 

__agent/config/config.go__
 *  Add `dynamicHostPortRange` to function `String()`
```
level=debug time=xxx msg="Loaded config: Cluster: default,  ..., DynamicHostPortRange: 50000-50010, PauseContainerImageName: amazon/amazon-ecs-pause, PauseContainerTag: 0.1.0" module=agent.go
```

### Testing
New tests cover the changes: yes

#### Unit test
#### TestDockerHostConfigPortBinding
```
--- PASS: TestDockerHostConfigPortBinding (0.00s)
    --- PASS: TestDockerHostConfigPortBinding/user-specified_container_ports_and_host_ports (0.00s)
    --- PASS: TestDockerHostConfigPortBinding/user-specified_container_ports_with_a_ideal_dynamicHostPortRange (0.00s)
    --- PASS: TestDockerHostConfigPortBinding/user-specified_container_ports_with_a_bad_dynamicHostPortRange (0.00s)
    --- PASS: TestDockerHostConfigPortBinding/user-specified_container_port_and_container_port_range_with_a_ideal_dynamicHostPortRange (0.00s)
    --- PASS: TestDockerHostConfigPortBinding/user-specified_container_port_and_container_port_range_with_a_bad_user-specified_dynamicHostPortRange (0.00s)
```
#### TestPortIsInRange
```
--- PASS: TestPortIsInRange (0.00s)
    --- PASS: TestPortIsInRange/in_the_range (0.00s)
    --- PASS: TestPortIsInRange/not_in_the_range (0.00s)
```
#### TestVerifyPortsWithinRange
```
--- PASS: TestVerifyPortsWithinRange (0.00s)
    --- PASS: TestVerifyPortsWithinRange/in_the_expected_range (0.00s)
    --- PASS: TestVerifyPortsWithinRange/not_in_the_expected_range (0.00s)
```

#### Manual test
##### Setup
* An ECS cluster with only one registered EC2 instance, which is launched with ECS optimized AMI: amzn2-ami-ecs-hvm-2.0.20230127-x86_64-ebs
* Install AWS CLI version `aws-cli/2.10.0 Python/3.9.11 Linux/4.14.301-224.520.amzn2.x86_64 exe/x86_64.amzn.2 prompt/off` on the host
* Run [ecs describe-tasks](https://docs.aws.amazon.com/cli/latest/reference/ecs/describe-tasks.html) to get the actual [networkBindings](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_NetworkBinding.html) of the task container
* Check the default ephemeral port range for Docker version 1.6.0 and later listed on the instance under /proc/sys/net/ipv4/ip_local_port_range
```
[ec2-user@ip-xxx]$ cat /proc/sys/net/ipv4/ip_local_port_range
32768   60999
```
##### Test cases

| Case   |      ECS_DYNAMIC_HOST_PORT_RANGE      |  Port mappings in task def | Result | Note | 
|:----------|:-------------|:------|:------|:------|
| 1 |  no user-specified value | containerPortRange 8080-8084 | hostPortRange 332768-32772 | bound to host ports in default range |
| 2 |  invalid value | containerPortRange 8080-8084 | hostPortRange 32768-32772 | bound to host ports in default range |
| 3 |  50000-50010 | containerPortRange 8080-8084 | hostPortRange 50000-50004 | bound to host ports in user-specified range |
| 4 |  50000-50001 | containerPortRange 8080-8084 | HostConfigError: error retrieving docker port map 5 contiguous host ports are unavailable | the user-specified dynamic host port range is not enough to cover required # of host ports |
| 5 |  no user-specified value | containerPort 8080  | hostPort 32768 | bound to a host port in default range |
| 6 |  invalid value | containerPort 8080  | hostPort 32768 | bound to a host port in default range |
| 7 |  50000-50010 | containerPort 8080 | hostPort 50005 | bound to a host port in user-specified range |
| 8 |  50000-50001 | containerPort 8080 | HostConfigError: error retrieving docker port map: a host port is unavailable | host port 50000 and 50001 were both unavailable |
| 9 |  no user-specified value | containerPort 8080 and hostPort 9000 | hostPort 9000 | bound to the user-specified host port |
| 10 |  50000-50010 | containerPort 8080 and hostPort 9000 | hostPort 9000 | bound to the user-specified host port |


### Description for the changelog
[Enhancement] Support user-specified dynamic host port range for a singular port - part 1

### Related PRs
1. https://github.com/aws/amazon-ecs-agent/pull/3570
2. https://github.com/aws/amazon-ecs-agent/pull/3569
3. https://github.com/aws/amazon-ecs-agent/pull/3522
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.