### PR TITLE
 [DHPA] Upudate dockerPortMap() in task.go with dynamic host port range support - part 2

### DIFF
--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -630,6 +630,7 @@ func (cfg *Config) String() string {
 			"DependentContainersPullUpfront: %v, "+
 			"TaskCPUMemLimit: %v, "+
 			"ShouldExcludeIPv6PortBinding: %v, "+
+			"DynamicHostPortRange: %v"+
 			"%s",
 		cfg.Cluster,
 		cfg.AWSRegion,
@@ -648,6 +649,7 @@ func (cfg *Config) String() string {
 		cfg.DependentContainersPullUpfront,
 		cfg.TaskCPUMemLimit,
 		cfg.ShouldExcludeIPv6PortBinding,
+		cfg.DynamicHostPortRange,
 		cfg.platformString(),
 	)
 }

--- a/agent/utils/ephemeral_ports.go
+++ b/agent/utils/ephemeral_ports.go
@@ -214,3 +214,32 @@ func getHostPortRange(numberOfPorts, start, end int, protocol string) (string, i
 
 	return fmt.Sprintf("%d-%d", resultStartPort, resultEndPort), resultEndPort, nil
 }
+
+// PortIsInRange returns true if the given port is within the start-end port range;
+// otherwise, returns false.
+func PortIsInRange(port, start, end int) bool {
+	if (port >= start) && (port <= end) {
+		return true
+	}
+	return false
+}
+
+// VerifyPortsWithinRange returns true if the actualPortRange is within the expectedPortRange;
+// otherwise, returns false.
+func VerifyPortsWithinRange(actualPortRange, expectedPortRange string) bool {
+	// Get the actual start port and end port
+	aStartPort, aEndPort, _ := nat.ParsePortRangeToInt(actualPortRange)
+	// Get the expected start port and end port
+	eStartPort, eEndPort, _ := nat.ParsePortRangeToInt(expectedPortRange)
+	// Check the actual start port is in the expected range or not
+	aStartIsInRange := PortIsInRange(aStartPort, eStartPort, eEndPort)
+	// Check the actual end port is in the expected range or not
+	aEndIsInRange := PortIsInRange(aEndPort, eStartPort, eEndPort)
+
+	// Return true if both actual start port and end port are in the expected range
+	if aStartIsInRange && aEndIsInRange {
+		return true
+	}
+
+	return false
+}

--- a/agent/utils/ephemeral_ports.go
+++ b/agent/utils/ephemeral_ports.go
@@ -96,6 +96,11 @@ func (pt *safePortTracker) GetLastAssignedHostPort() int {
 
 var tracker safePortTracker
 
+// ResetTracker resets the last assigned host port to 0.
+func ResetTracker() {
+	tracker.SetLastAssignedHostPort(0)
+}
+
 // GetHostPortRange gets N contiguous host ports from the ephemeral host port range defined on the host.
 // dynamicHostPortRange can be set by customers using ECS Agent environment variable ECS_DYNAMIC_HOST_PORT_RANGE;
 // otherwise, ECS Agent will use the default value returned from GetDynamicHostPortRange() in the utils package.

--- a/agent/utils/ephemeral_ports_test.go
+++ b/agent/utils/ephemeral_ports_test.go
@@ -144,7 +144,7 @@ func TestGetHostPortRange(t *testing.T) {
 					assert.Equal(t, tc.expectedLastAssignedPort[i], actualLastAssignedHostPort)
 				} else {
 					// need to reset the tracker to avoid getting data from previous test cases
-					tracker.SetLastAssignedHostPort(0)
+					ResetTracker()
 
 					hostPortRange, err := GetHostPortRange(tc.numberOfPorts, tc.protocol, tc.testDynamicHostPortRange)
 					assert.Equal(t, tc.expectedError, err)
@@ -196,7 +196,8 @@ func TestGetHostPort(t *testing.T) {
 
 	for _, tc := range testCases {
 		if tc.resetLastAssignedHostPort {
-			tracker.SetLastAssignedHostPort(0)
+			// need to reset the tracker to avoid getting data from previous test cases
+			ResetTracker()
 		}
 
 		t.Run(tc.testName, func(t *testing.T) {
@@ -273,6 +274,14 @@ func TestVerifyPortsWithinRange(t *testing.T) {
 			assert.Equal(t, tc.expectedResult, result)
 		})
 	}
+}
+
+func TestResetTracker(t *testing.T) {
+	tracker.SetLastAssignedHostPort(100)
+	ResetTracker()
+	expectedResetVal := 0
+	actualResult := tracker.GetLastAssignedHostPort()
+	assert.Equal(t, expectedResetVal, actualResult)
 }
 
 func getPortRangeLength(portRange string) (int, error) {

--- a/agent/utils/ephemeral_ports_test.go
+++ b/agent/utils/ephemeral_ports_test.go
@@ -207,9 +207,70 @@ func TestGetHostPort(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Equal(t, numberOfPorts, numberOfHostPorts)
 
-				actualResult := verifyPortsWithinRange(hostPortRange, tc.testDynamicHostPortRange)
+				actualResult := VerifyPortsWithinRange(hostPortRange, tc.testDynamicHostPortRange)
 				assert.True(t, actualResult)
 			}
+		})
+	}
+}
+
+func TestPortIsInRange(t *testing.T) {
+	testCases := []struct {
+		testName       string
+		testPort       int
+		testStartPort  int
+		testEndPort    int
+		expectedResult bool
+	}{
+		{
+			testName:       "in the range",
+			testPort:       100,
+			testStartPort:  1,
+			testEndPort:    9999,
+			expectedResult: true,
+		},
+		{
+			testName:       "not in the range",
+			testPort:       10000,
+			testStartPort:  1,
+			testEndPort:    9999,
+			expectedResult: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			result := PortIsInRange(tc.testPort, tc.testStartPort, tc.testEndPort)
+			assert.Equal(t, tc.expectedResult, result)
+		})
+	}
+}
+
+func TestVerifyPortsWithinRange(t *testing.T) {
+	testCases := []struct {
+		testName          string
+		testActualRange   string
+		testExpectedRange string
+		expectedResult    bool
+	}{
+		{
+			testName:          "in the expected range",
+			testActualRange:   "1000-1005",
+			testExpectedRange: "900-2000",
+			expectedResult:    true,
+		},
+		{
+			testName:          "not in the expected range",
+			testActualRange:   "1-2",
+			testExpectedRange: "2-100",
+			expectedResult:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			result := VerifyPortsWithinRange(tc.testActualRange, tc.testExpectedRange)
+			assert.Equal(t, tc.expectedResult, result)
 		})
 	}
 }
@@ -220,32 +281,4 @@ func getPortRangeLength(portRange string) (int, error) {
 		return 0, err
 	}
 	return endPort - startPort + 1, nil
-}
-
-// verifyPortsWithinRange returns true if the actualPortRange is within the expectedPortRange;
-// otherwise, returns false.
-func verifyPortsWithinRange(actualPortRange, expectedPortRange string) bool {
-	// get the actual start port and end port
-	aStartPort, aEndPort, _ := nat.ParsePortRangeToInt(actualPortRange)
-	// get the expected start port and end port
-	eStartPort, eEndPort, _ := nat.ParsePortRangeToInt(expectedPortRange)
-	// check the actual start port is in the expected range or not
-	aStartIsInRange := portIsInRange(aStartPort, eStartPort, eEndPort)
-	// check the actual end port is in the expected range or not
-	aEndIsInRange := portIsInRange(aEndPort, eStartPort, eEndPort)
-
-	// return true if both actual start port and end port are in the expected range
-	if aStartIsInRange && aEndIsInRange {
-		return true
-	}
-
-	return false
-}
-
-// portIsInRange checks the given port is within the start-end range
-func portIsInRange(port, start, end int) bool {
-	if (port >= start) && (port <= end) {
-		return true
-	}
-	return false
 }


### PR DESCRIPTION
### Summary
DHPA - Dynamic Host Port Assignment

__The target branch of this PR is [feature/dynamicHostPortAssignment](https://github.com/aws/amazon-ecs-agent/tree/feature/dynamicHostPortAssignment)__.

This is a follow-up PR for [Upudate dockerPortMap() in task.go with dynamic host port range support - part 1](https://github.com/aws/amazon-ecs-agent/pull/3584) to implement dynamic host port assignment for default bridge mode service connect ingress listener ports in `dockerPortMap()`. 

*** __For a better view of diffs between these 2 PR, please take a look on this [PR](https://github.com/chienhanlin/amazon-ecs-agent/pull/39).__ ***

Comparing to the current [Upudate dockerPortMap() in task.go with dynamic host port range support - part 1](https://github.com/aws/amazon-ecs-agent/pull/3584) PR, main changes in this PR include:

1. Add function `buildPortMapWithSCIngressConfig()` to build a dockerPortMap and a containerPortSet for ingress listener ports under two service connect bridge mode cases:  

 * Case 1.  __Non-default bridge mode__ service connect experience: customers specify host ports (ingressPortOverride) for listeners in the ingress config.
```
"serviceConnectConfiguration": {
        "enabled": true,
        "namespace": "<Namespace>",
        "services": [
            {
                "portName": "webserver",
                "discoveryName": "<DiscoveryName>",
                "ingressPortOverride": 15000,
                "clientAliases": [
                    {
                        "port": <Client Port>,
                        "dnsName": "<Client DNS>"
                    }
                ]
            }
        ],
}               
   ```
 * Case 2. __Default bridge mode__ service connect experience: customers do not specify host ports for listeners in the ingress config. Instead, ECS Agent finds host ports within the given dynamic host port range. If ECS Agent cannot find an available host port within the range, an error will be returned.

2. Update comments for function `dockerPortMap()` to include service connect ingress listener ports info
3. Refactor how we create port bindings for service connect ingress listener ports in function `dockerPortMap()`
4. Add a new function `ResetTracker()` in ephemeral_ports.go to reset the last assigned host port to 0. This function will be used in unit tests `TestGetHostPort`, `TestGetHostPortRange` and `TestDockerHostConfigSCBridgeMode`. 
5. Update `TestDockerHostConfigSCBridgeMode` to test changes made in this PR.

> Note that `dynamicHostPortRange` can be configured by customers using ECS Agent environment variable [ECS_DYNAMIC_HOST_PORT_RANGE](https://github.com/aws/amazon-ecs-agent/search?q=ECS_DYNAMIC_HOST_PORT_RANGE); if the customized value is not provided, ECS Agent will use the default value returned from [GetDynamicHostPortRange()](https://github.com/aws/amazon-ecs-agent/search?q=GetDynamicHostPortRange).

### Implementation details
__agent/api/task/task.go__
 * Add function `buildPortMapWithSCIngressConfig()` to build a dockerPortMap and a containerPortSet for ingress listener ports 
 * Refactor how we create port bindings for service connect ingress listener ports and update comments for function `dockerPortMap()`

__agent/api/task/task_test.go__
 * Update test cases in `TestDockerHostConfigSCBridgeMode` to test changes

__agent/utils/ephemeral_ports.go__
 * Add  `ResetTracker()` and use it in `TestGetHostPort` and `TestGetHostPortRange`

__agent/utils/ephemeral_ports_test.go__
 *  Use `ResetTracker()` in `TestGetHostPort` and `TestGetHostPortRange`
 *  Add `TestResetTracker`

### Testing
New tests cover the changes: yes

#### Unit test
#### TestDockerHostConfigSCBridgeMode
```
--- PASS: TestDockerHostConfigSCBridgeMode (0.00s)
    --- PASS: TestDockerHostConfigSCBridgeMode/with_default_dynamic_host_port_range (0.00s)
    --- PASS: TestDockerHostConfigSCBridgeMode/with_user-specified_dynamic_host_port_range (0.00s)
    --- PASS: TestDockerHostConfigSCBridgeMode/with_user-specified_dynamic_host_port_range_but_no_available_host_port (0.00s)
```
#### TestResetTracker
```
--- PASS: TestResetTracker (0.00s)
```

#### Manual test
See [Upudate dockerPortMap() in task.go with dynamic host port range support - part 1](https://github.com/aws/amazon-ecs-agent/pull/3584) for container port and container port range testing results.

### Description for the changelog
[Enhancement] Support user-specified dynamic host port range for a singular port and default bridge mode service connect ingress listener port.

### Related PRs
1. https://github.com/aws/amazon-ecs-agent/pull/3570
2. https://github.com/aws/amazon-ecs-agent/pull/3569
3. https://github.com/aws/amazon-ecs-agent/pull/3522
4. https://github.com/aws/amazon-ecs-agent/pull/3584

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.