### PR TITLE
periodically disconnect from acs

### DIFF
--- a/agent/acs/handler/heartbeat_handler.go
+++ b/agent/acs/handler/heartbeat_handler.go
@@ -103,6 +103,18 @@ func (heartbeatHandler *heartbeatHandler) sendHeartbeatAck() {
 	}
 }
 
+// sendPendingHeartbeatAck sends all pending heartbeat acks to ACS before closing the connection
+func (heartbeatHandler *heartbeatHandler) sendPendingHeartbeatAck() {
+	for {
+		select {
+		case ack := <-heartbeatHandler.heartbeatAckMessageBuffer:
+			heartbeatHandler.sendSingleHeartbeatAck(ack)
+		default:
+			return
+		}
+	}
+}
+
 func (heartbeatHandler *heartbeatHandler) sendSingleHeartbeatAck(ack *ecsacs.HeartbeatAckRequest) {
 	err := heartbeatHandler.acsClient.MakeRequest(ack)
 	if err != nil {

--- a/agent/acs/handler/payload_handler.go
+++ b/agent/acs/handler/payload_handler.go
@@ -122,6 +122,18 @@ func (payloadHandler *payloadRequestHandler) sendAcks() {
 	}
 }
 
+// sendPendingAcks sends ack requests to ACS before closing the connection
+func (payloadHandler *payloadRequestHandler) sendPendingAcks() {
+	for {
+		select {
+		case mid := <-payloadHandler.ackRequest:
+			payloadHandler.ackMessageId(mid)
+		default:
+			return
+		}
+	}
+}
+
 // ackMessageId sends an AckRequest for a message id
 func (payloadHandler *payloadRequestHandler) ackMessageId(messageID string) {
 	seelog.Debugf("Acking payload message id: %s", messageID)

--- a/agent/acs/handler/refresh_credentials_handler.go
+++ b/agent/acs/handler/refresh_credentials_handler.go
@@ -92,6 +92,18 @@ func (refreshHandler *refreshCredentialsHandler) sendAcks() {
 	}
 }
 
+// sendPendingAcks sends pending acks to ACS before closing the connection
+func (refreshHandler *refreshCredentialsHandler) sendPendingAcks() {
+	for {
+		select {
+		case ack := <-refreshHandler.ackRequest:
+			refreshHandler.ackMessage(ack)
+		default:
+			return
+		}
+	}
+}
+
 // ackMessageId sends an IAMRoleCredentialsAckRequest to the backend
 func (refreshHandler *refreshCredentialsHandler) ackMessage(ack *ecsacs.IAMRoleCredentialsAckRequest) {
 	err := refreshHandler.acsClient.MakeRequest(ack)

--- a/agent/wsclient/mock/client.go
+++ b/agent/wsclient/mock/client.go
@@ -188,6 +188,20 @@ func (mr *MockClientServerMockRecorder) SetReadDeadline(arg0 interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetReadDeadline", reflect.TypeOf((*MockClientServer)(nil).SetReadDeadline), arg0)
 }
 
+// WriteCloseMessage mocks base method
+func (m *MockClientServer) WriteCloseMessage() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WriteCloseMessage")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WriteCloseMessage indicates an expected call of WriteCloseMessage
+func (mr *MockClientServerMockRecorder) WriteCloseMessage() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteCloseMessage", reflect.TypeOf((*MockClientServer)(nil).WriteCloseMessage))
+}
+
 // WriteMessage mocks base method
 func (m *MockClientServer) WriteMessage(arg0 []byte) error {
 	m.ctrl.T.Helper()

--- a/agent/wsclient/wsconn/conn.go
+++ b/agent/wsclient/wsconn/conn.go
@@ -19,6 +19,7 @@ import "time"
 // connection's methods that this client uses.
 type WebsocketConn interface {
 	WriteMessage(messageType int, data []byte) error
+	WriteControl(messageType int, data []byte, deadline time.Time) error
 	ReadMessage() (messageType int, data []byte, err error)
 	Close() error
 	SetWriteDeadline(t time.Time) error

--- a/agent/wsclient/wsconn/mock/conn.go
+++ b/agent/wsclient/wsconn/mock/conn.go
@@ -106,6 +106,20 @@ func (mr *MockWebsocketConnMockRecorder) SetWriteDeadline(arg0 interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetWriteDeadline", reflect.TypeOf((*MockWebsocketConn)(nil).SetWriteDeadline), arg0)
 }
 
+// WriteControl mocks base method
+func (m *MockWebsocketConn) WriteControl(arg0 int, arg1 []byte, arg2 time.Time) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WriteControl", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WriteControl indicates an expected call of WriteControl
+func (mr *MockWebsocketConnMockRecorder) WriteControl(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteControl", reflect.TypeOf((*MockWebsocketConn)(nil).WriteControl), arg0, arg1, arg2)
+}
+
 // WriteMessage mocks base method
 func (m *MockWebsocketConn) WriteMessage(arg0 int, arg1 []byte) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR introduces a connection time property to the ACS session object. With this change, the agent will periodically disconnect from ACS (every 15-45 minutes).

Currently we rely on ACS to periodically disconnect from the agent, unless the agent stops receiving heartbeats from ACS. About every ~1-2 minutes, if the agent does not receive any heartbeats and if no activity occurs, the agent closes its connection to ACS. 

If an ACS host is unhealthy (i.e. it looses track of its active connections and doesn't disconnect periodically anymore) and that we can no longer rely on heartbeats, the agent will be stuck with a stale connection. This may lead to task credentials not being refreshed or no task payload being served by this container instance. With this change, we would no longer have a single point of failure (i.e. unhealthy ACS host) and we let the agent control its fate.

### Implementation details
<!-- How are the changes implemented? -->
- A new `connectionTimer` is started when the ACS websocket connection is established. 
- When this timer is up, the agent sends all pending acks to ACS and writes a close message on the connection using websocket [Control Messages](https://pkg.go.dev/github.com/gorilla/websocket#hdr-Control_Messages). The agent sends a message of type [websocket.CloseMessage](https://github.com/gorilla/websocket/blob/9111bb834a68b893cebbbaed5060bdbc1d9ab7d2/conn.go#L74) with status code [NormalClosure](https://github.com/gorilla/websocket/blob/9111bb834a68b893cebbbaed5060bdbc1d9ab7d2/conn.go#L46).
- The close message is sent to ACS which then is echoed back to the agent. This close message is added to the message queue. This ensures that the agent reads and handles unread messages first, before closing the connection. [Reference](https://www.rfc-editor.org/rfc/rfc6455#section-5.5.1)
- When agent detects the close message, it returns an `io.EOF` back to the parent go routine that started the ACS session. This is in-line with how it returns an `io.EOF` when ACS initiates the connection close. [Reference](https://github.com/aws/amazon-ecs-agent/blob/4943e4d853a84cf4d76b9d1241ee1f4f189b9c4a/agent/wsclient/client.go#L390-L392)
- Upon `io.EOF`, the websocket connection is established immediately without backoff.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
- Updated unit tests.
- Built a test AMI with these changes and launched a container instance that disconnects to ACS every minute (for testing purposes). The connection is re-established in < ~1 second.
- Let this container instance run for about 2 days to monitor the agent, upon frequent disconnection.
- Created an ECS service and ran a small test that increments the service's desired task count by 1 every 25 seconds, upto 50 tasks.
- Checked ECS agent logs to verify that the disconnection workflow works as expected and that all tasks get served as requested.
```
level=info msg="Closing ACS websocket connection after 1 minutes" module=acs_handler.go
level=debug msg="Connection closed for a valid reason: websocket: close 1000 (normal): ConnectionExpired: Reconnect to continue" module=client.go
level=info msg="ACS Websocket connection closed for a valid reason" module=acs_handler.go
level=info msg="ACS Websocket connection closed for a valid reason: EOF" module=acs_handler.go
level=debug msg="Received connect to ACS message" module=acs_handler.go
level=info msg="Establishing a Websocket connection ..."
level=debug msg="Established a Websocket connection to ..."
level=info msg="Connected to ACS endpoint"
```
- Checked ACS logs and verified the sequence of operations that is executed when agent closes the connection.

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Enhancement: periodically disconnect from ACS

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
