### PR TITLE
make TestGetHostPortRange unit test deterministic

### DIFF
--- a/agent/utils/ephemeral_ports_test.go
+++ b/agent/utils/ephemeral_ports_test.go
@@ -79,6 +79,7 @@ func TestGetHostPortRange(t *testing.T) {
 		testDynamicHostPortRange string
 		protocol                 string
 		expectedLastAssignedPort []int
+		isPortAvailableFunc      func(port int, protocol string) (bool, error)
 		numberOfRequests         int
 		expectedError            error
 	}{
@@ -88,6 +89,7 @@ func TestGetHostPortRange(t *testing.T) {
 			testDynamicHostPortRange: "40001-40080",
 			protocol:                 testTCPProtocol,
 			expectedLastAssignedPort: []int{40010},
+			isPortAvailableFunc:      func(port int, protocol string) (bool, error) { return true, nil },
 			numberOfRequests:         1,
 			expectedError:            nil,
 		},
@@ -97,6 +99,7 @@ func TestGetHostPortRange(t *testing.T) {
 			testDynamicHostPortRange: "40001-40080",
 			protocol:                 testUDPProtocol,
 			expectedLastAssignedPort: []int{40040},
+			isPortAvailableFunc:      func(port int, protocol string) (bool, error) { return true, nil },
 			numberOfRequests:         1,
 			expectedError:            nil,
 		},
@@ -106,6 +109,7 @@ func TestGetHostPortRange(t *testing.T) {
 			testDynamicHostPortRange: "40001-40080",
 			protocol:                 testTCPProtocol,
 			expectedLastAssignedPort: []int{40060, 40000},
+			isPortAvailableFunc:      func(port int, protocol string) (bool, error) { return true, nil },
 			numberOfRequests:         2,
 			expectedError:            nil,
 		},
@@ -115,24 +119,42 @@ func TestGetHostPortRange(t *testing.T) {
 			testDynamicHostPortRange: "40001-40080",
 			protocol:                 testUDPProtocol,
 			expectedLastAssignedPort: []int{40015},
+			isPortAvailableFunc:      func(port int, protocol string) (bool, error) { return true, nil },
 			numberOfRequests:         1,
 			expectedError:            nil,
 		},
 		{
-			testName:                 "contiguous hostPortRange not found",
+			testName:                 "contiguous hostPortRange not found, numberOfPorts more than available",
 			numberOfPorts:            20,
 			testDynamicHostPortRange: "40001-40005",
 			protocol:                 testTCPProtocol,
+			isPortAvailableFunc:      func(port int, protocol string) (bool, error) { return true, nil },
 			numberOfRequests:         1,
 			expectedError:            errors.New("20 contiguous host ports unavailable"),
 		},
+		{
+			testName:                 "contiguous hostPortRange not found, no ports available on the host",
+			numberOfPorts:            5,
+			testDynamicHostPortRange: "40001-40005",
+			protocol:                 testTCPProtocol,
+			isPortAvailableFunc:      func(port int, protocol string) (bool, error) { return false, nil },
+			numberOfRequests:         1,
+			expectedError:            errors.New("5 contiguous host ports unavailable"),
+		},
 	}
+
+	// mock isPortAvailable() for unit test
+	// this ensures that the test doesn't rely on the runtime port availability on the host
+	isPortAvailableFuncTmp := isPortAvailableFunc
+	defer func() {
+		isPortAvailableFunc = isPortAvailableFuncTmp
+	}()
 
 	for _, tc := range testCases {
 		t.Run(tc.testName, func(t *testing.T) {
 			for i := 0; i < tc.numberOfRequests; i++ {
+				isPortAvailableFunc = tc.isPortAvailableFunc
 				if tc.expectedError == nil {
-
 					hostPortRange, err := GetHostPortRange(tc.numberOfPorts, tc.protocol, tc.testDynamicHostPortRange)
 					assert.NoError(t, err)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
make TestGetHostPortRange unit test deterministic

I noticed that the `TestGetHostPortRange` unit test relies on the underlying host's port availability. [example failure](https://github.com/aws/amazon-ecs-agent/actions/runs/4240931060/jobs/7370520811)

```
2023-02-22T08:49:37.6412749Z === RUN   TestGetHostPortRange/tcp_protocol,_contiguous_hostPortRange_found
2023-02-22T08:49:37.6412935Z     ephemeral_ports_test.go:144: 
2023-02-22T08:49:37.6413203Z         	Error Trace:	ephemeral_ports_test.go:144
2023-02-22T08:49:37.6413427Z         	Error:      	Not equal: 
2023-02-22T08:49:37.6413669Z         	            	expected: 40010
2023-02-22T08:49:37.6413896Z         	            	actual  : 40012
2023-02-22T08:49:37.6414282Z         	Test:       	
```

The `getHostPortRange` method does a `net.Listen`/`net.ListenPacket` calls on the host to check if a port is available. In the unit test, we check if the assigned ports matches an expected set of ports. This leads to it occasionally failing on PRs GH workflow, depending on whether a port is available at that point in time.

### Implementation details
<!-- How are the changes implemented? -->
This PR refactors the `getHostPortRange` method and mocks the part where we do the port check on the host, in the unit test.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

Existing unit tests succeed.

New tests cover the changes: <!-- yes|no --> no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

make TestGetHostPortRange unit test deterministic

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
