### PR TITLE
Update GitHub Actions checkout package in CI

### DIFF
--- a/.github/workflows/gitsecrets.yml
+++ b/.github/workflows/gitsecrets.yml
@@ -8,7 +8,7 @@ jobs:
     name: Git Secrets Scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: src/github.com/aws/amazon-ecs-agent
       - name: Git Secrets Scan Script

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -8,7 +8,7 @@ jobs:
     name: Linux unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
           path: src/github.com/aws/amazon-ecs-agent

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -8,7 +8,7 @@ jobs:
     name: Static Analysis
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: src/github.com/aws/amazon-ecs-agent
       - name: get GO_VERSION
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: ${{ steps.get-go-version.outputs.GO_VERSION }}
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: src/github.com/aws/amazon-ecs-agent
       - name: run static checks
@@ -44,7 +44,7 @@ jobs:
     name: Static Analysis Init
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: src/github.com/aws/amazon-ecs-agent
       - name: get GO_VERSION
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: ${{ steps.get-go-version.outputs.GO_VERSION }}
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: src/github.com/aws/amazon-ecs-agent
       - name: run static checks
@@ -80,7 +80,7 @@ jobs:
     name: Cross platform build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: src/github.com/aws/amazon-ecs-agent
       - name: get GO_VERSION
@@ -100,7 +100,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: ${{ steps.get-go-version.outputs.GO_VERSION }}
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
           path: src/github.com/aws/amazon-ecs-agent

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -8,7 +8,7 @@ jobs:
     name: Windows unit tests
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: src/github.com/aws/amazon-ecs-agent
       - name: get GO_VERSION
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: ${{ steps.get-go-version.outputs.GO_VERSION_WINDOWS }}
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
           path: src/github.com/aws/amazon-ecs-agent


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Resolve NodeJS 12 deprecation warnings in CI workflows.

### Implementation details
<!-- How are the changes implemented? --> Move actions/checkout package from v2 to v3.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> n/a

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Resolve CI NodeJS 12 deprecation warnings for actions/checkout

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
