### PR TITLE
[DHPA] Refactor buildPortMapWithSCIngressConfig() in task.go

### DIFF
--- a/agent/utils/ephemeral_ports_test.go
+++ b/agent/utils/ephemeral_ports_test.go
@@ -139,7 +139,7 @@ func TestGetHostPortRange(t *testing.T) {
 			protocol:                 testTCPProtocol,
 			isPortAvailableFunc:      func(port int, protocol string) (bool, error) { return false, nil },
 			numberOfRequests:         1,
-			expectedError:            errors.New("5 contiguous host ports unavailable"),
+			expectedError:            errors.New("5 contiguous host ports are unavailable"),
 		},
 	}
 


### PR DESCRIPTION
### Summary
DHPA - Dynamic Host Port Assignment

__The target branch of this PR is [feature/dynamicHostPortAssignment](https://github.com/aws/amazon-ecs-agent/tree/feature/dynamicHostPortAssignment)__.

This PR has following 2 changes
* Refactored `buildPortMapWithSCIngressConfig()` in task.go, and add some service connect testing results in the later testing section.
* Fixed a unit test case in `TestGetHostPortRange` by adding the missing "are" in the expected error message.

### Implementation details
__agent/api/task/task.go__
* Remove `containerPortSet` from one of the return values from `buildPortMapWithSCIngressConfig()` since this value is only meaningful for service connect AppNet containers. We will update the container port set for the service connect AppNet container in this function instead of returning it back. 
* (Note that, every service connect enabled task will have a associated service connect AppNet container. For example, if there are 5 service connect enabled tasks placed on the same container instance, there will be 5 task-associated service connect AppNet containers running in the container instance.) 

### Testing
Find more details for ECS service connect via this AWS ECS documentation [[here]](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-connect.html).

#### Setup for manual testing
1. Launched an ECS cluster with a namespace
2. Launched an EC2 instance with ECS optimized AL2 AMI
3. Registered this EC2 instance to the testing ECS cluster
4. Replaced ECS Agent built from this PR on the container instance
5. Registered different `bridge network mode` task definitions for each test case
6. Created service connect services with different task definitions and service connect configurations based on test cases
7. Ran [ecs describe-tasks](https://docs.aws.amazon.com/cli/latest/reference/ecs/describe-tasks.html) to get the actual [networkBindings](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_NetworkBinding.html) of the task containers, including service connect AppNet containers.

#### Sample task definition
```
{
    "networkMode": "bridge",
    "containerDefinitions": [
        {
        "name": "webServer1",
        "portMappings": [
            {
		"name": "webServer1",
                "containerPort": <containerPort>,
                "hostPort": <hostPort>,
                "appProtocol": "http"
            }
        ],
    },
    {
        "name": "webServer2",
        "portMappings": [
            {
		"name": "webServer2",
                "containerPort": <containerPort>,
                "hostPort": <hostPort>,
                "appProtocol": "http"
            }
        ],
    }
}
```
#### Example service connect configuration
```
    "serviceConnectConfiguration": {
        "enabled": true,
        "namespace": "xxx",
        "services": [
            {
                "portName": "webServer1",
                "discoveryName": "xxx",
                "ingressPortOverride": <ingressPortOverride>,
                "clientAliases": [...]
            },
            {
                "portName": "webServer2",
                "discoveryName": "xxx",
                "ingressPortOverride": <ingressPortOverride>,
                "clientAliases": [...]
            }
        ],
    }, 
``` 

#### Test cases
| Case   |      ECS_DYNAMIC_HOST_PORT_RANGE      |  Service connect config | Port mappings in task def - webServer1 | Port mappings in task def - webServer2 |
|:------|:-------|:------|:------|:------|
| 1 |  52000-52100 | ingressPortOverride: 15000 for port name webServer1 | with user-specified containerPort | with user-specified containerPort | 

__Network bindings result__
* Service connect AppNet container has one ingress listener port bound to user-specified host port `15000`, and one ingress listener port bound to a host port within dynamic host port range `52000-52100`.
* WebServer1 and webServer2 containers' container port both bound to host ports within dynamic host port range `52000-52100`.
* In this case, 3 host ports are assigned by ECS Agent.
  
---
  
  
| Case   |      ECS_DYNAMIC_HOST_PORT_RANGE      |  Service connect config | Port mappings in task def - webServer1 | Port mappings in task def - webServer2 |
|:------|:-------|:------|:------|:------|
| 2|  52000-52100 | ingressPortOverride: 15000 for port name webServer1 | with user-specified containerPort and hostPort | with user-specified containerPort and hostPort| 

__Network bindings result__
* Service connect AppNet container has one ingress listener port bound to user-specified host port `15000`, and one ingress listener port bound to a host port within dynamic host port range `52000-52100`.
* WebServer1 and webServer2 containers' container port both bound to user-specified host ports.
* In this case, 1 host port is assigned by ECS Agent.
   
---
  
| Case   |      ECS_DYNAMIC_HOST_PORT_RANGE      |  Service connect config | Port mappings in task def - webServer1 | Port mappings in task def - webServer2 |
|:------|:-------|:------|:------|:------|
| 3 |  52000-52100 | ingressPortOverride: 15000 for port name webServer1 and ingressPortOverride: 25000 for port name webServer2 | with user-specified containerPort and hostPort | with user-specified containerPort and hostPort| 

__Network bindings result__
* Service connect AppNet container has one ingress listener port bound to user-specified host port `15000`, and one ingress listener port bound to user-specified host port `25000`.
* WebServer1 and webServer2 containers' container port both bound to user-specified host ports.
* In this case, 0 host port is assigned by ECS Agent.
  
---
  
| Case   |      ECS_DYNAMIC_HOST_PORT_RANGE      |  Service connect config | Port mappings in task def - webServer1 | Port mappings in task def - webServer2 |
|:------|:-------|:------|:------|:------|
| 4 |  52000-52100 | no ingressPortOverride | with user-specified containerPort  | with user-specified containerPort | 

__Network bindings result__
* Service connect AppNet container has both ingress listener ports bound to host ports within dynamic host port range `52000-52100`.
* WebServer1 and webServer2 containers' container port both bound to host ports within dynamic host port range `52000-52100`.
* In this case, 4 host port is assigned by ECS Agent.
  
---  
| Case   |      ECS_DYNAMIC_HOST_PORT_RANGE      |  Service connect config | Port mappings in task def - webServer1 | Port mappings in task def - webServer2 |
|:------|:-------|:------|:------|:------|
| 5 |  52000-52000 | no ingressPortOverride | with user-specified containerPort and hostPort | with user-specified containerPort and hostPort| 

__Network bindings result__
* Service connect AppNet container failed to be created as the given dynamic port range is not enough to cover the required number of host ports, causing it's associated pause container failed to start.

```
level=error time=xxx msg="Error transitioning container" task="xxx" container="~internal~ecs~pause-ecs-service-connect-xxx" runtimeID="xxx" nextState="RUNNING" error="Error response from daemon: driver failed programming external connectivity on endpoint xxx(xxx): Bind for 0.0.0.0:52000 failed: port is already allocated"
```
* Task stayed in pending as service connect AppNet container failed to reach to healthy state.

New tests cover the changes: no

### Description for the changelog
N/A

### Related PRs
1. https://github.com/aws/amazon-ecs-agent/pull/3522
2. https://github.com/aws/amazon-ecs-agent/pull/3569
3. https://github.com/aws/amazon-ecs-agent/pull/3570
4. https://github.com/aws/amazon-ecs-agent/pull/3584
5. https://github.com/aws/amazon-ecs-agent/pull/3585
7. https://github.com/aws/amazon-ecs-agent/pull/3589

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
