### PR TITLE
ECS Agent dynamic host port assignment

### DIFF
--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -630,6 +630,7 @@ func (cfg *Config) String() string {
 			"DependentContainersPullUpfront: %v, "+
 			"TaskCPUMemLimit: %v, "+
 			"ShouldExcludeIPv6PortBinding: %v, "+
+			"DynamicHostPortRange: %v"+
 			"%s",
 		cfg.Cluster,
 		cfg.AWSRegion,
@@ -648,6 +649,7 @@ func (cfg *Config) String() string {
 		cfg.DependentContainersPullUpfront,
 		cfg.TaskCPUMemLimit,
 		cfg.ShouldExcludeIPv6PortBinding,
+		cfg.DynamicHostPortRange,
 		cfg.platformString(),
 	)
 }

--- a/agent/utils/ephemeral_ports.go
+++ b/agent/utils/ephemeral_ports.go
@@ -18,6 +18,7 @@ import (
 	"math/rand"
 	"net"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -30,6 +31,11 @@ const (
 	EphemeralPortMin         = 32768
 	EphemeralPortMax         = 60999
 	maxPortSelectionAttempts = 100
+	portUnavailableMsg       = "Port %v is unavailable or an error occurred while listening on the local %v network"
+	portNotFoundErrMsg       = "a host port is unavailable"
+	portsNotFoundErrMsg      = "%v contiguous host ports are unavailable"
+	portRangeErrMsg          = "The host port range: %s found by ECS Agent is not within the expected host port range: %s"
+	portErrMsg               = "The host port: %s found by ECS Agent is not within the expected host port range: %s"
 )
 
 var (
@@ -93,11 +99,50 @@ func (pt *safePortTracker) GetLastAssignedHostPort() int {
 
 var tracker safePortTracker
 
+// ResetTracker resets the last assigned host port to 0.
+func ResetTracker() {
+	tracker.SetLastAssignedHostPort(0)
+}
+
 // GetHostPortRange gets N contiguous host ports from the ephemeral host port range defined on the host.
+// dynamicHostPortRange can be set by customers using ECS Agent environment variable ECS_DYNAMIC_HOST_PORT_RANGE;
+// otherwise, ECS Agent will use the default value returned from GetDynamicHostPortRange() in the utils package.
 func GetHostPortRange(numberOfPorts int, protocol string, dynamicHostPortRange string) (string, error) {
 	portLock.Lock()
 	defer portLock.Unlock()
+	result, err := getNumOfHostPorts(numberOfPorts, protocol, dynamicHostPortRange)
+	if err == nil {
+		// Verify the found host port range is within the given dynamic host port range
+		if isInRange := verifyPortsWithinRange(result, dynamicHostPortRange); !isInRange {
+			errMsg := fmt.Errorf(portRangeErrMsg, result, dynamicHostPortRange)
+			return "", errMsg
+		}
+	}
+	return result, err
+}
 
+// GetHostPort gets 1 host port from the ephemeral host port range defined on the host.
+// dynamicHostPortRange can be set by customers using ECS Agent environment variable ECS_DYNAMIC_HOST_PORT_RANGE;
+// otherwise, ECS Agent will use the default value returned from GetDynamicHostPortRange() in the utils package.
+func GetHostPort(protocol string, dynamicHostPortRange string) (string, error) {
+	portLock.Lock()
+	defer portLock.Unlock()
+	numberOfPorts := 1
+	result, err := getNumOfHostPorts(numberOfPorts, protocol, dynamicHostPortRange)
+	foundHostPort := strings.Split(result, "-")[0]
+	if err == nil {
+		// Verify the found host port is within the given dynamic host port range
+		if isInRange := verifyPortsWithinRange(result, dynamicHostPortRange); !isInRange {
+			errMsg := fmt.Errorf(portErrMsg, foundHostPort, dynamicHostPortRange)
+			return "", errMsg
+		}
+	}
+	return foundHostPort, err
+}
+
+// getNumOfHostPorts returns the requested number of host ports using the given dynamic host port range
+// and protocol. If no host port(s) was/were found, an empty string along with the error message will be returned.
+func getNumOfHostPorts(numberOfPorts int, protocol, dynamicHostPortRange string) (string, error) {
 	// get ephemeral port range, either default or if custom-defined
 	startHostPortRange, endHostPortRange, _ := nat.ParsePortRangeToInt(dynamicHostPortRange)
 	start := startHostPortRange
@@ -127,7 +172,6 @@ func GetHostPortRange(numberOfPorts int, protocol string, dynamicHostPortRange s
 	} else {
 		tracker.SetLastAssignedHostPort(lastCheckedPort)
 	}
-
 	return result, err
 }
 
@@ -157,7 +201,11 @@ func getHostPortRange(numberOfPorts, start, end int, protocol string) (string, i
 	}
 
 	if n != numberOfPorts {
-		return "", resultEndPort, fmt.Errorf("%v contiguous host ports unavailable", numberOfPorts)
+		errMsg := fmt.Errorf(portNotFoundErrMsg)
+		if numberOfPorts > 1 {
+			errMsg = fmt.Errorf(portsNotFoundErrMsg, numberOfPorts)
+		}
+		return "", resultEndPort, errMsg
 	}
 
 	return fmt.Sprintf("%d-%d", resultStartPort, resultEndPort), resultEndPort, nil
@@ -194,4 +242,33 @@ func isPortAvailable(port int, protocol string) (bool, error) {
 	default:
 		return false, errors.New("invalid protocol")
 	}
+}
+
+// PortIsInRange returns true if the given port is within the start-end port range;
+// otherwise, returns false.
+func portIsInRange(port, start, end int) bool {
+	if (port >= start) && (port <= end) {
+		return true
+	}
+	return false
+}
+
+// VerifyPortsWithinRange returns true if the actualPortRange is within the expectedPortRange;
+// otherwise, returns false.
+func verifyPortsWithinRange(actualPortRange, expectedPortRange string) bool {
+	// Get the actual start port and end port
+	aStartPort, aEndPort, _ := nat.ParsePortRangeToInt(actualPortRange)
+	// Get the expected start port and end port
+	eStartPort, eEndPort, _ := nat.ParsePortRangeToInt(expectedPortRange)
+	// Check the actual start port is in the expected range or not
+	aStartIsInRange := portIsInRange(aStartPort, eStartPort, eEndPort)
+	// Check the actual end port is in the expected range or not
+	aEndIsInRange := portIsInRange(aEndPort, eStartPort, eEndPort)
+
+	// Return true if both actual start port and end port are in the expected range
+	if aStartIsInRange && aEndIsInRange {
+		return true
+	}
+
+	return false
 }

--- a/agent/utils/ephemeral_ports_test.go
+++ b/agent/utils/ephemeral_ports_test.go
@@ -130,7 +130,7 @@ func TestGetHostPortRange(t *testing.T) {
 			protocol:                 testTCPProtocol,
 			isPortAvailableFunc:      func(port int, protocol string) (bool, error) { return true, nil },
 			numberOfRequests:         1,
-			expectedError:            errors.New("20 contiguous host ports unavailable"),
+			expectedError:            errors.New("20 contiguous host ports are unavailable"),
 		},
 		{
 			testName:                 "contiguous hostPortRange not found, no ports available on the host",
@@ -139,7 +139,7 @@ func TestGetHostPortRange(t *testing.T) {
 			protocol:                 testTCPProtocol,
 			isPortAvailableFunc:      func(port int, protocol string) (bool, error) { return false, nil },
 			numberOfRequests:         1,
-			expectedError:            errors.New("5 contiguous host ports unavailable"),
+			expectedError:            errors.New("5 contiguous host ports are unavailable"),
 		},
 	}
 
@@ -166,7 +166,7 @@ func TestGetHostPortRange(t *testing.T) {
 					assert.Equal(t, tc.expectedLastAssignedPort[i], actualLastAssignedHostPort)
 				} else {
 					// need to reset the tracker to avoid getting data from previous test cases
-					tracker.SetLastAssignedHostPort(0)
+					ResetTracker()
 
 					hostPortRange, err := GetHostPortRange(tc.numberOfPorts, tc.protocol, tc.testDynamicHostPortRange)
 					assert.Equal(t, tc.expectedError, err)
@@ -175,6 +175,132 @@ func TestGetHostPortRange(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetHostPort(t *testing.T) {
+	numberOfPorts := 1
+	testCases := []struct {
+		testName                  string
+		testDynamicHostPortRange  string
+		protocol                  string
+		numberOfRequests          int
+		resetLastAssignedHostPort bool
+	}{
+		{
+			testName:                  "tcp protocol, a host port found",
+			testDynamicHostPortRange:  "40090-40099",
+			protocol:                  testTCPProtocol,
+			resetLastAssignedHostPort: true,
+			numberOfRequests:          1,
+		},
+		{
+			testName:                  "udp protocol, a host port found",
+			testDynamicHostPortRange:  "40090-40099",
+			protocol:                  testUDPProtocol,
+			resetLastAssignedHostPort: true,
+			numberOfRequests:          1,
+		},
+		{
+			testName:                  "5 requests for host port in succession, success",
+			testDynamicHostPortRange:  "50090-50099",
+			protocol:                  testTCPProtocol,
+			resetLastAssignedHostPort: true,
+			numberOfRequests:          5,
+		},
+		{
+			testName:                  "5 requests for host port in succession, success",
+			testDynamicHostPortRange:  "50090-50099",
+			protocol:                  testUDPProtocol,
+			resetLastAssignedHostPort: false,
+			numberOfRequests:          5,
+		},
+	}
+
+	for _, tc := range testCases {
+		if tc.resetLastAssignedHostPort {
+			// need to reset the tracker to avoid getting data from previous test cases
+			ResetTracker()
+		}
+
+		t.Run(tc.testName, func(t *testing.T) {
+			for i := 0; i < tc.numberOfRequests; i++ {
+				hostPortRange, err := GetHostPort(tc.protocol, tc.testDynamicHostPortRange)
+				assert.NoError(t, err)
+				numberOfHostPorts, err := getPortRangeLength(hostPortRange)
+				assert.NoError(t, err)
+				assert.Equal(t, numberOfPorts, numberOfHostPorts)
+			}
+		})
+	}
+}
+
+func TestPortIsInRange(t *testing.T) {
+	testCases := []struct {
+		testName       string
+		testPort       int
+		testStartPort  int
+		testEndPort    int
+		expectedResult bool
+	}{
+		{
+			testName:       "in the range",
+			testPort:       100,
+			testStartPort:  1,
+			testEndPort:    9999,
+			expectedResult: true,
+		},
+		{
+			testName:       "not in the range",
+			testPort:       10000,
+			testStartPort:  1,
+			testEndPort:    9999,
+			expectedResult: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			result := portIsInRange(tc.testPort, tc.testStartPort, tc.testEndPort)
+			assert.Equal(t, tc.expectedResult, result)
+		})
+	}
+}
+
+func TestVerifyPortsWithinRange(t *testing.T) {
+	testCases := []struct {
+		testName          string
+		testActualRange   string
+		testExpectedRange string
+		expectedResult    bool
+	}{
+		{
+			testName:          "in the expected range",
+			testActualRange:   "1000-1005",
+			testExpectedRange: "900-2000",
+			expectedResult:    true,
+		},
+		{
+			testName:          "not in the expected range",
+			testActualRange:   "1-2",
+			testExpectedRange: "2-100",
+			expectedResult:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			result := verifyPortsWithinRange(tc.testActualRange, tc.testExpectedRange)
+			assert.Equal(t, tc.expectedResult, result)
+		})
+	}
+}
+
+func TestResetTracker(t *testing.T) {
+	tracker.SetLastAssignedHostPort(100)
+	ResetTracker()
+	expectedResetVal := 0
+	actualResult := tracker.GetLastAssignedHostPort()
+	assert.Equal(t, expectedResetVal, actualResult)
 }
 
 func getPortRangeLength(portRange string) (int, error) {


### PR DESCRIPTION
### Summary
This PR is to merge the feature branch [feature/dynamicHostPortAssignment]() into the dev branch.

Following changes, listing from the oldest to the latest, will be introduced to the dev branch after this PR is merged:

1. https://github.com/aws/amazon-ecs-agent/pull/3570
2. https://github.com/aws/amazon-ecs-agent/pull/3584
3. https://github.com/aws/amazon-ecs-agent/pull/3589
4. https://github.com/aws/amazon-ecs-agent/pull/3589
5. https://github.com/aws/amazon-ecs-agent/pull/3600

### Implementation details
Please find details in previous PRs listed in the "Summary" section.

### Testing
Please find details in previous PRs listed in the "Summary" section.

New tests cover the changes: yes

### Description for the changelog
[Enhancement] Support dynamic host port range assignment for singular ports. The dynamic host port range can be configured with `ECS_DYNAMIC_HOST_PORT_RANGE` in ecs.config; if there is no user-specified `ECS_DYNAMIC_HOST_PORT_RANGE`, ECS Agent will assign host ports within the default port range, based on platform and Docker API version, for containers that do not have user-specified host ports in task definitions.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
