### PR TITLE
Added new CodeBuild CF template to update and upload agentVersionV2-<branch>.json for AL1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -286,6 +286,7 @@ goimports:
 
 GOPATH=$(shell go env GOPATH)
 .get-deps-stamp:
+	go get golang.org/x/tools/cmd/cover
 	go get github.com/golang/mock/mockgen
 	cd "${GOPATH}/src/github.com/golang/mock/mockgen" && git checkout 1.3.1 && go get ./... && go install ./... && cd -
 	go get golang.org/x/tools/cmd/goimports

--- a/Makefile
+++ b/Makefile
@@ -286,7 +286,6 @@ goimports:
 
 GOPATH=$(shell go env GOPATH)
 .get-deps-stamp:
-	go get golang.org/x/tools/cmd/cover
 	go get github.com/golang/mock/mockgen
 	cd "${GOPATH}/src/github.com/golang/mock/mockgen" && git checkout 1.3.1 && go get ./... && go install ./... && cd -
 	go get golang.org/x/tools/cmd/goimports

--- a/build-infrastructure/al-maintenance-codebuild-stack.yml
+++ b/build-infrastructure/al-maintenance-codebuild-stack.yml
@@ -5,6 +5,7 @@ Parameters:
     GithubFullRepoName:
       Type: String
       Description: Full name of the agent repository to use (e.g. https://github.com/aws/amazon-ecs-agent.git)
+      Default: https://github.com/aws/amazon-ecs-agent.git
     GithubBranchName:
       Type: String
       Description: Name of the base branch to use to build, PRs to which will trigger builds (e.g. refs/heads/AmazonLinuxLegacy)

--- a/build-infrastructure/al-maintenance-codebuild-stack.yml
+++ b/build-infrastructure/al-maintenance-codebuild-stack.yml
@@ -37,8 +37,8 @@ Resources:
             Type: PLAINTEXT
             Value: !Ref ReleaseArtifactsBucketS3Uri
           - Name: GITHUB_SOURCE_BRANCH_NAME
-              Type: PLAINTEXT
-              Value: !Ref GithubSourceBranchName
+            Type: PLAINTEXT
+            Value: !Ref GithubSourceBranchName
       Name: !Ref 'AWS::StackName'
       QueuedTimeoutInMinutes: 60
       ServiceRole: !Ref ServiceRoleArn

--- a/build-infrastructure/al-maintenance-codebuild-stack.yml
+++ b/build-infrastructure/al-maintenance-codebuild-stack.yml
@@ -10,7 +10,7 @@ Parameters:
       Description: Name of the base branch to use to build, PRs to which will trigger builds (e.g. refs/heads/AmazonLinuxLegacy)
     GithubSourceBranchName:
       Type: String
-      Description: Name of the source branch used for the PRs (e.g. refs/heads/al1-patch)
+      Description: Name of the source branch used for the PRs (e.g. al1-patch)
     ReleaseArtifactsBucketS3Uri:
       Type: String
       Description: The URI of the bucket where things land at the end, this is assumed to already exist (e.g. s3://artifacts)
@@ -36,6 +36,9 @@ Resources:
           - Name: RESULTS_BUCKET_URI
             Type: PLAINTEXT
             Value: !Ref ReleaseArtifactsBucketS3Uri
+          - Name: GITHUB_SOURCE_BRANCH_NAME
+              Type: PLAINTEXT
+              Value: !Ref GithubSourceBranchName
       Name: !Ref 'AWS::StackName'
       QueuedTimeoutInMinutes: 60
       ServiceRole: !Ref ServiceRoleArn
@@ -49,8 +52,6 @@ Resources:
         FilterGroups:
           - - Type: EVENT
               Pattern: 'PULL_REQUEST_MERGED'
-            - Type: HEAD_REF
-              Pattern: !Sub '^${GithubSourceBranchName}$'
             - Type: BASE_REF
               Pattern: !Sub '^${GithubBranchName}$'
         Webhook: true

--- a/build-infrastructure/al-maintenance-codebuild-stack.yml
+++ b/build-infrastructure/al-maintenance-codebuild-stack.yml
@@ -1,0 +1,57 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: A template that brings up a code build project that makes release configs for AL versions in maintenance mode
+
+Parameters:
+    GithubFullRepoName:
+      Type: String
+      Description: Full name of the agent repository to use (e.g. https://github.com/aws/amazon-ecs-agent.git)
+    GithubBranchName:
+      Type: String
+      Description: Name of the base branch to use to build, PRs to which will trigger builds (e.g. refs/heads/AmazonLinuxLegacy)
+    GithubSourceBranchName:
+      Type: String
+      Description: Name of the source branch used for the PRs (e.g. refs/heads/al1-patch)
+    ReleaseArtifactsBucketS3Uri:
+      Type: String
+      Description: The URI of the bucket where things land at the end, this is assumed to already exist (e.g. s3://artifacts)
+    ServiceRoleArn:
+      Type: String
+      Description: The ARN of an existing CodeBuild service role
+
+Resources:
+  ModifyAndCopyJSON:
+    Type: 'AWS::CodeBuild::Project'
+    Properties:
+      Artifacts:
+        Type: NO_ARTIFACTS
+      BadgeEnabled: false
+      ConcurrentBuildLimit: 10
+      Description: A CodeBuild project to modify and update the release configs for AL versions in maintenance mode. Builds are triggered by PR merges.
+      Environment:
+        Type: LINUX_CONTAINER
+        ComputeType: BUILD_GENERAL1_SMALL
+        ImagePullCredentialsType: CODEBUILD
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+        EnvironmentVariables:
+          - Name: RESULTS_BUCKET_URI
+            Type: PLAINTEXT
+            Value: !Ref ReleaseArtifactsBucketS3Uri
+      Name: !Ref 'AWS::StackName'
+      QueuedTimeoutInMinutes: 60
+      ServiceRole: !Ref ServiceRoleArn
+      Source:
+        BuildSpec: buildspecs/al-maintenance-release-config.yml
+        Location: !Ref GithubFullRepoName
+        Type: GITHUB
+      TimeoutInMinutes: 60
+      Triggers:
+        BuildType: BUILD
+        FilterGroups:
+          - - Type: EVENT
+              Pattern: 'PULL_REQUEST_MERGED'
+            - Type: HEAD_REF
+              Pattern: !Sub '^${GithubSourceBranchName}$'
+            - Type: BASE_REF
+              Pattern: !Sub '^${GithubBranchName}$'
+        Webhook: true
+      Visibility: PRIVATE

--- a/buildspecs/al-maintenance-release-config.yml
+++ b/buildspecs/al-maintenance-release-config.yml
@@ -3,7 +3,6 @@ version: 0.2
 phases:
   build:
     commands:
-      - GITHUB_SOURCE_BRANCH_NAME=$(echo ${CODEBUILD_WEBHOOK_HEAD_REF} | cut -d "/" -f3-)
       - GITHUB_DEST_BRANCH_NAME=$(echo ${CODEBUILD_WEBHOOK_BASE_REF} | cut -d "/" -f3-)
       - GIT_COMMIT_SHA=$(git rev-parse $GITHUB_DEST_BRANCH_NAME)
       - GIT_COMMIT_SHORT_SHA=$(git rev-parse --short=8 $GITHUB_DEST_BRANCH_NAME)

--- a/buildspecs/al-maintenance-release-config.yml
+++ b/buildspecs/al-maintenance-release-config.yml
@@ -1,47 +1,9 @@
 version: 0.2
 
 phases:
+  pre_build:
+    commands:
+      - sudo yum -y update
   build:
     commands:
-      - GITHUB_DEST_BRANCH_NAME=$(echo ${CODEBUILD_WEBHOOK_BASE_REF} | cut -d "/" -f3-)
-      - GIT_COMMIT_SHA=$(git rev-parse $GITHUB_DEST_BRANCH_NAME)
-      - GIT_COMMIT_SHORT_SHA=$(git rev-parse --short=8 $GITHUB_DEST_BRANCH_NAME)
-      - RELEASE_DATE=$(date +'%Y%m%d')
-      - AGENT_VERSION=$(cat VERSION)
-
-      - |
-        cat << EOF > agent.json
-        {
-          "agentReleaseVersion" : "$AGENT_VERSION",
-          "releaseDate" : "$RELEASE_DATE",
-          "initStagingConfig": {
-            "release": "1"
-          },
-          "agentStagingConfig": {
-            "releaseGitSha": "$GIT_COMMIT_SHA",
-            "releaseGitShortSha": "$GIT_COMMIT_SHORT_SHA",
-            "gitFarmRepoName": "MadisonContainerAgentExternal",
-            "gitHubRepoName": "aws/amazon-ecs-agent",
-            "gitFarmStageBranch": "v${AGENT_VERSION}-stage",
-            "githubReleaseUrl": ""
-          }
-        }
-        EOF
-
-      # Downloading the agentVersionV2-<branch>.json (it is assumed that it already exists)
-      - aws s3 cp ${RESULTS_BUCKET_URI}/agentVersionV2/agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}.json ./agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}.json
-      # Grabbing the new current and release agent version
-      - CURR_VER=$(jq -r '.agentReleaseVersion' agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}.json)
-
-      # Checking to see if there's a new release agent version to be released
-      - |
-        if [[ ! $AGENT_VERSION =~ "${CURR_VER}" ]] ; then
-          # Updating the agentVersionV2-<branch>.json file with new current and release agent versions and copying it to a temp file
-          cat <<< $(jq '.agentReleaseVersion = '\"$AGENT_VERSION\"' | .agentCurrentVersion = '\"$CURR_VER\"'' agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}.json) > agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}-COPY.json
-          # Replace existing agentVersionV2-<branch>.json file with the temp file
-          jq . agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}-COPY.json > agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}.json
-        fi
-
-      # Uploading new agentVersionV2-<branch>.json and agent.json files
-      - aws s3 cp ./agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}.json ${RESULTS_BUCKET_URI}/agentVersionV2/agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}.json
-      - aws s3 cp ./agent.json ${RESULTS_BUCKET_URI}/${GITHUB_SOURCE_BRANCH_NAME}/agent.json
+      - cd scripts && ./release-config.sh

--- a/buildspecs/al-maintenance-release-config.yml
+++ b/buildspecs/al-maintenance-release-config.yml
@@ -32,9 +32,9 @@ phases:
       # Downloading the agentVersionV2-<branch>.json (it is assumed that it already exists)
       - aws s3 cp ${RESULTS_BUCKET_URI}/agentVersionV2/agentVersionV2-${SRC_GITHUB_BRANCH}.json ./agentVersionV2-${SRC_GITHUB_BRANCH}.json
       # Grabbing the new current and release agent version
-      - CURR_VER=$(jq -r '.releaseAgentVersion' agentVersionV2-${SRC_GITHUB_BRANCH}.json)
+      - CURR_VER=$(jq -r '.agentReleaseVersion' agentVersionV2-${SRC_GITHUB_BRANCH}.json)
       # Outputting updated agentVersion-<branch>.json file
-      - cat <<< $(jq '.releaseAgentVersion = '\"$RELEASE_VER\"' | .currentAgentVersion = '\"$CURR_VER\"'' agentVersionV2-${SRC_GITHUB_BRANCH}.json) > agentVersionV2-${SRC_GITHUB_BRANCH}-COPY.json
+      - cat <<< $(jq '.agentReleaseVersion = '\"$RELEASE_VER\"' | .agentCurrentVersion = '\"$CURR_VER\"'' agentVersionV2-${SRC_GITHUB_BRANCH}.json) > agentVersionV2-${SRC_GITHUB_BRANCH}-COPY.json
       # Formatting file by copying over temp file
       - jq . agentVersionV2-${SRC_GITHUB_BRANCH}-COPY.json > agentVersionV2-${SRC_GITHUB_BRANCH}.json
 

--- a/buildspecs/al-maintenance-release-config.yml
+++ b/buildspecs/al-maintenance-release-config.yml
@@ -38,6 +38,13 @@ phases:
       # Formatting file by copying over temp file
       - jq . agentVersionV2-${SRC_GITHUB_BRANCH}-COPY.json > agentVersionV2-${SRC_GITHUB_BRANCH}.json
 
+      # Checking if there's no new agent version
+      - |
+        if [[ $RELEASE_VER =~ "${CURR_VER}" ]] ; then
+          echo "Agent release version ${RELEASE_VER} is the same as the current version ${CURR_VER}, exiting..."
+          exit 1
+        fi
+
       # Uploading new agentVersionV2-<branch>.json and agent.json files
       - aws s3 cp ./agentVersionV2-${SRC_GITHUB_BRANCH}.json ${RESULTS_BUCKET_URI}/agentVersionV2/agentVersionV2-${SRC_GITHUB_BRANCH}.json
       - aws s3 cp ./agent.json ${RESULTS_BUCKET_URI}/${SRC_GITHUB_BRANCH}/agent.json

--- a/buildspecs/al-maintenance-release-config.yml
+++ b/buildspecs/al-maintenance-release-config.yml
@@ -1,0 +1,43 @@
+version: 0.2
+
+phases:
+  build:
+    commands:
+      - SRC_GITHUB_BRANCH=$(echo ${CODEBUILD_WEBHOOK_HEAD_REF} | cut -d "/" -f3-)
+      - DEST_GITHUB_BRANCH=$(echo ${CODEBUILD_WEBHOOK_BASE_REF} | cut -d "/" -f3-)
+      - GIT_COMMIT_SHA=$(git rev-parse $DEST_GITHUB_BRANCH)
+      - GIT_COMMIT_SHORT_SHA=$(git rev-parse --short=8 $DEST_GITHUB_BRANCH)
+      - RELEASE_DATE=$(date +'%Y%m%d')
+      - RELEASE_VER=$(cat VERSION)
+
+      - |
+        cat << EOF > agent.json
+        {
+          "agentReleaseVersion" : "$RELEASE_VER",
+          "releaseDate" : "$RELEASE_DATE",
+          "initStagingConfig": {
+            "release": "1"
+          },
+          "agentStagingConfig": {
+            "releaseGitSha": "$GIT_COMMIT_SHA",
+            "releaseGitShortSha": "$GIT_COMMIT_SHORT_SHA",
+            "gitFarmRepoName": "MadisonContainerAgentExternal",
+            "gitHubRepoName": "aws/amazon-ecs-agent",
+            "gitFarmStageBranch": "v${RELEASE_VER}-stage",
+            "githubReleaseUrl": ""
+          }
+        }
+        EOF
+
+      # Downloading the agentVersionV2-<branch>.json (it is assumed that it already exists)
+      - aws s3 cp ${RESULTS_BUCKET_URI}/agentVersionV2/agentVersionV2-${SRC_GITHUB_BRANCH}.json ./agentVersionV2-${SRC_GITHUB_BRANCH}.json
+      # Grabbing the new current and release agent version
+      - CURR_VER=$(jq -r '.releaseAgentVersion' agentVersionV2-${SRC_GITHUB_BRANCH}.json)
+      # Outputting updated agentVersion-<branch>.json file
+      - cat <<< $(jq '.releaseAgentVersion = '\"$RELEASE_VER\"' | .currentAgentVersion = '\"$CURR_VER\"'' agentVersionV2-${SRC_GITHUB_BRANCH}.json) > agentVersionV2-${SRC_GITHUB_BRANCH}-COPY.json
+      # Formatting file by copying over temp file
+      - jq . agentVersionV2-${SRC_GITHUB_BRANCH}-COPY.json > agentVersionV2-${SRC_GITHUB_BRANCH}.json
+
+      # Uploading new agentVersionV2-<branch>.json and agent.json files
+      - aws s3 cp ./agentVersionV2-${SRC_GITHUB_BRANCH}.json ${RESULTS_BUCKET_URI}/agentVersionV2/agentVersionV2-${SRC_GITHUB_BRANCH}.json
+      - aws s3 cp ./agent.json ${RESULTS_BUCKET_URI}/${SRC_GITHUB_BRANCH}/agent.json

--- a/buildspecs/al-maintenance-release-config.yml
+++ b/buildspecs/al-maintenance-release-config.yml
@@ -3,17 +3,17 @@ version: 0.2
 phases:
   build:
     commands:
-      - SRC_GITHUB_BRANCH=$(echo ${CODEBUILD_WEBHOOK_HEAD_REF} | cut -d "/" -f3-)
-      - DEST_GITHUB_BRANCH=$(echo ${CODEBUILD_WEBHOOK_BASE_REF} | cut -d "/" -f3-)
-      - GIT_COMMIT_SHA=$(git rev-parse $DEST_GITHUB_BRANCH)
-      - GIT_COMMIT_SHORT_SHA=$(git rev-parse --short=8 $DEST_GITHUB_BRANCH)
+      - GITHUB_SOURCE_BRANCH_NAME=$(echo ${CODEBUILD_WEBHOOK_HEAD_REF} | cut -d "/" -f3-)
+      - GITHUB_DEST_BRANCH_NAME=$(echo ${CODEBUILD_WEBHOOK_BASE_REF} | cut -d "/" -f3-)
+      - GIT_COMMIT_SHA=$(git rev-parse $GITHUB_DEST_BRANCH_NAME)
+      - GIT_COMMIT_SHORT_SHA=$(git rev-parse --short=8 $GITHUB_DEST_BRANCH_NAME)
       - RELEASE_DATE=$(date +'%Y%m%d')
-      - RELEASE_VER=$(cat VERSION)
+      - AGENT_VERSION=$(cat VERSION)
 
       - |
         cat << EOF > agent.json
         {
-          "agentReleaseVersion" : "$RELEASE_VER",
+          "agentReleaseVersion" : "$AGENT_VERSION",
           "releaseDate" : "$RELEASE_DATE",
           "initStagingConfig": {
             "release": "1"
@@ -23,28 +23,26 @@ phases:
             "releaseGitShortSha": "$GIT_COMMIT_SHORT_SHA",
             "gitFarmRepoName": "MadisonContainerAgentExternal",
             "gitHubRepoName": "aws/amazon-ecs-agent",
-            "gitFarmStageBranch": "v${RELEASE_VER}-stage",
+            "gitFarmStageBranch": "v${AGENT_VERSION}-stage",
             "githubReleaseUrl": ""
           }
         }
         EOF
 
       # Downloading the agentVersionV2-<branch>.json (it is assumed that it already exists)
-      - aws s3 cp ${RESULTS_BUCKET_URI}/agentVersionV2/agentVersionV2-${SRC_GITHUB_BRANCH}.json ./agentVersionV2-${SRC_GITHUB_BRANCH}.json
+      - aws s3 cp ${RESULTS_BUCKET_URI}/agentVersionV2/agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}.json ./agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}.json
       # Grabbing the new current and release agent version
-      - CURR_VER=$(jq -r '.agentReleaseVersion' agentVersionV2-${SRC_GITHUB_BRANCH}.json)
-      # Outputting updated agentVersion-<branch>.json file
-      - cat <<< $(jq '.agentReleaseVersion = '\"$RELEASE_VER\"' | .agentCurrentVersion = '\"$CURR_VER\"'' agentVersionV2-${SRC_GITHUB_BRANCH}.json) > agentVersionV2-${SRC_GITHUB_BRANCH}-COPY.json
-      # Formatting file by copying over temp file
-      - jq . agentVersionV2-${SRC_GITHUB_BRANCH}-COPY.json > agentVersionV2-${SRC_GITHUB_BRANCH}.json
+      - CURR_VER=$(jq -r '.agentReleaseVersion' agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}.json)
 
-      # Checking if there's no new agent version
+      # Checking to see if there's a new release agent version to be released
       - |
-        if [[ $RELEASE_VER =~ "${CURR_VER}" ]] ; then
-          echo "Agent release version ${RELEASE_VER} is the same as the current version ${CURR_VER}, exiting..."
-          exit 1
+        if [[ ! $AGENT_VERSION =~ "${CURR_VER}" ]] ; then
+          # Updating the agentVersionV2-<branch>.json file with new current and release agent versions and copying it to a temp file
+          cat <<< $(jq '.agentReleaseVersion = '\"$AGENT_VERSION\"' | .agentCurrentVersion = '\"$CURR_VER\"'' agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}.json) > agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}-COPY.json
+          # Replace existing agentVersionV2-<branch>.json file with the temp file
+          jq . agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}-COPY.json > agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}.json
         fi
 
       # Uploading new agentVersionV2-<branch>.json and agent.json files
-      - aws s3 cp ./agentVersionV2-${SRC_GITHUB_BRANCH}.json ${RESULTS_BUCKET_URI}/agentVersionV2/agentVersionV2-${SRC_GITHUB_BRANCH}.json
-      - aws s3 cp ./agent.json ${RESULTS_BUCKET_URI}/${SRC_GITHUB_BRANCH}/agent.json
+      - aws s3 cp ./agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}.json ${RESULTS_BUCKET_URI}/agentVersionV2/agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}.json
+      - aws s3 cp ./agent.json ${RESULTS_BUCKET_URI}/${GITHUB_SOURCE_BRANCH_NAME}/agent.json

--- a/scripts/release-config.sh
+++ b/scripts/release-config.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+GITHUB_DEST_BRANCH_NAME=$(echo ${CODEBUILD_WEBHOOK_BASE_REF} | cut -d "/" -f3-)
+GIT_COMMIT_SHA=$(git rev-parse $GITHUB_DEST_BRANCH_NAME)
+GIT_COMMIT_SHORT_SHA=$(git rev-parse --short=8 $GITHUB_DEST_BRANCH_NAME)
+RELEASE_DATE=$(date +'%Y%m%d')
+AGENT_VERSION=$(cat ../VERSION)
+
+cat << EOF > agent.json
+{
+    "agentReleaseVersion" : "$AGENT_VERSION",
+    "releaseDate" : "$RELEASE_DATE",
+    "initStagingConfig": {
+    "release": "1"
+    },
+    "agentStagingConfig": {
+    "releaseGitSha": "$GIT_COMMIT_SHA",
+    "releaseGitShortSha": "$GIT_COMMIT_SHORT_SHA",
+    "gitFarmRepoName": "MadisonContainerAgentExternal",
+    "gitHubRepoName": "aws/amazon-ecs-agent",
+    "gitFarmStageBranch": "v${AGENT_VERSION}-stage",
+    "githubReleaseUrl": ""
+    }
+}
+EOF
+
+# Downloading the agentVersionV2-<branch>.json (it is assumed that it already exists)
+aws s3 cp ${RESULTS_BUCKET_URI}/agentVersionV2/agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}.json ./agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}.json
+echo "Downloaded agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}.json"
+cat agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}.json
+
+# Grabbing the new current and release agent version
+CURR_VER=$(jq -r '.agentReleaseVersion' agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}.json)
+
+# Checking to see if there's a new release agent version to be released
+if [[ ! $AGENT_VERSION =~ "${CURR_VER}" ]] ; then
+    # Updating the agentVersionV2-<branch>.json file with new current and release agent versions and copying it to a temp file
+    cat <<< $(jq '.agentReleaseVersion = '\"$AGENT_VERSION\"' | .agentCurrentVersion = '\"$CURR_VER\"'' agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}.json) > agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}-COPY.json
+    # Replace existing agentVersionV2-<branch>.json file with the temp file
+    jq . agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}-COPY.json > agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}.json
+fi
+
+# Uploading new agentVersionV2-<branch>.json and agent.json files
+echo "Uploading agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}.json"
+cat agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}.json
+aws s3 cp ./agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}.json ${RESULTS_BUCKET_URI}/agentVersionV2/agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}.json
+
+echo "Uploading agent.json"
+cat agent.json
+aws s3 cp ./agent.json ${RESULTS_BUCKET_URI}/${GITHUB_SOURCE_BRANCH_NAME}/agent.json

--- a/scripts/release-config.sh
+++ b/scripts/release-config.sh
@@ -35,7 +35,7 @@ CURR_VER=$(jq -r '.agentReleaseVersion' agentVersionV2-${GITHUB_SOURCE_BRANCH_NA
 # Checking to see if there's a new release agent version to be released
 if [[ ! $AGENT_VERSION =~ "${CURR_VER}" ]] ; then
     # Updating the agentVersionV2-<branch>.json file with new current and release agent versions and copying it to a temp file
-    cat <<< $(jq '.agentReleaseVersion = '\"$AGENT_VERSION\"' | .agentCurrentVersion = '\"$CURR_VER\"'' agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}.json) > agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}-COPY.json
+    jq ".agentReleaseVersion = \"$AGENT_VERSION\" | .agentCurrentVersion = \"$CURR_VER\"" agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}.json > agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}-COPY.json
     # Replace existing agentVersionV2-<branch>.json file with the temp file
     jq . agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}-COPY.json > agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}.json
 fi


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This PR will introduce a new CodeBuild project which will be kicked off only when a PR has been merged into AmazonLinuxLegacy branch. What this CodeBuild project will do is it'll generate an `agent.json` and `agentVersionV2-<branch>.json` files which will be used as part of our release process. The buildspec file for this CodeBuild project is a bit of a combination of the `release-config.yml` and `copy.yml` buildspec files which is currently being used by our release CodePipeline. 

Note: The agentVersionV2-<branch>.json file for AL1 will need to be manually generated along with the tracking branch (`<branch>` ) for AL1.

### Implementation details
build-infrastructure/al-maintenance-codebuild-stack.yml
- New CF template YAML file
- Similar parameters that's also being used in the release CodePipeline
- New `ServiceRoleArn` parameter which will be referred to as the CodeBuild service role (Will not be creating a new Service Role but instead reusing an existing one)
- Triggered by a `PR_MERGED`
- Using the `AmazonLinuxLegacy` branch as the destination branch (i.e. BASE_REF)

buildspecs/al-maintenance-release-config
- Similar to the `release-config.yml` file in the `dev` branch
- Will also be copying over the generated `agent.json` and new `agentVersionV2-<branch>.json` file over to the same release bucket that our current release CodePipeline is using

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

This CodeBuild CF template file was used in my personal dev account. I've tested the CodeBuild project by cloning the `AmazonLinuxLegacy` branch into my forked repo and used it as the destination branch. I was able to successfully kick off the CodeBuild project each time a PR was merged.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
- Feature: New release CodeBuild project for AL1
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Related PRs:
- https://github.com/aws/amazon-ecs-agent/pull/3611