### PR TITLE
[Do not review] Add AL2023 dependency

### DIFF
--- a/scripts/verify-agent-artifacts
+++ b/scripts/verify-agent-artifacts
@@ -84,18 +84,18 @@ ecs-init-${INIT_VERSION}.amzn2.aarch64.rpm
 ecs-init-${INIT_VERSION}.amzn2.aarch64.rpm.asc
 ecs-init-${INIT_VERSION}.amzn2.x86_64.rpm
 ecs-init-${INIT_VERSION}.amzn2.x86_64.rpm.asc
-ecs-init-${INIT_VERSION}.amzn2022.aarch64.rpm
-ecs-init-${INIT_VERSION}.amzn2022.aarch64.rpm.asc
-ecs-init-${INIT_VERSION}.amzn2022.x86_64.rpm
-ecs-init-${INIT_VERSION}.amzn2022.x86_64.rpm.asc
+ecs-init-${INIT_VERSION}.amzn2023.aarch64.rpm
+ecs-init-${INIT_VERSION}.amzn2023.aarch64.rpm.asc
+ecs-init-${INIT_VERSION}.amzn2023.x86_64.rpm
+ecs-init-${INIT_VERSION}.amzn2023.x86_64.rpm.asc
 ecs-init-latest.amzn2.aarch64.rpm
 ecs-init-latest.amzn2.aarch64.rpm.asc
 ecs-init-latest.amzn2.x86_64.rpm
 ecs-init-latest.amzn2.x86_64.rpm.asc
-ecs-init-latest.amzn2022.aarch64.rpm
-ecs-init-latest.amzn2022.aarch64.rpm.asc
-ecs-init-latest.amzn2022.x86_64.rpm
-ecs-init-latest.amzn2022.x86_64.rpm.asc"
+ecs-init-latest.amzn2023.aarch64.rpm
+ecs-init-latest.amzn2023.aarch64.rpm.asc
+ecs-init-latest.amzn2023.x86_64.rpm
+ecs-init-latest.amzn2023.x86_64.rpm.asc"
 
 # verify the files actually exist:
 for f in $files; do


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Update AL2022 to AL2023 

### Implementation details
<!-- How are the changes implemented? -->
In `scripts/verify-agent-artifacts` update AL2022 to AL2023.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

- make release
- GitHub workflow

New tests cover the changes: <!-- yes|no -->: no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
update AL2022 ecs-init agent artifacts to AL2023.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
