### PR TITLE
Add log message for task CNI setup, and other log mods 

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -40,4 +40,4 @@ jobs:
           gcc --version
           $env:ZZZ_SKIP_WINDOWS_SERVER_VERSION_CHECK_NOT_SUPPORTED_IN_PRODUCTION = 'true'
           $packages=go list .\... | Where-Object {$_ -NotMatch 'vendor'}
-          go test -v -tags unit -timeout=40s $packages
+          go test -v -tags unit -timeout=120s $packages

--- a/Makefile
+++ b/Makefile
@@ -254,7 +254,7 @@ dockerfree-cni-plugins:
 release-agent-internal: dockerfree-certs dockerfree-cni-plugins static
 	./scripts/build-agent-image
 
-# Default Agent target to build. Pulls cni plugins, builds agent image and save it to disk 
+# Default Agent target to build. Pulls cni plugins, builds agent image and save it to disk
 release-agent: get-cni-sources
 	$(MAKE) release-agent-internal
 
@@ -350,7 +350,7 @@ install-golang:
 .get-deps-stamp:
 	go install github.com/golang/mock/mockgen@v1.6.0
 	go install golang.org/x/tools/cmd/goimports@v0.2.0
-	GO111MODULE=on go install github.com/fzipp/gocyclo/cmd/gocyclo@v0.3.1
+	GO111MODULE=on go install github.com/fzipp/gocyclo/cmd/gocyclo@v0.6.0
 	GO111MODULE=on go install honnef.co/go/tools/cmd/staticcheck@v0.3.2
 	touch .get-deps-stamp
 
@@ -359,7 +359,7 @@ get-deps: .get-deps-stamp
 get-deps-init:
 	go install github.com/golang/mock/mockgen@v1.6.0
 	go install golang.org/x/tools/cmd/goimports@v0.2.0
-	GO111MODULE=on go install github.com/fzipp/gocyclo/cmd/gocyclo@v0.3.1
+	GO111MODULE=on go install github.com/fzipp/gocyclo/cmd/gocyclo@v0.6.0
 	GO111MODULE=on go install honnef.co/go/tools/cmd/staticcheck@v0.3.2
 
 amazon-linux-sources.tgz:

--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ ifneq (${BUILD_PLATFORM},aarch64)
 endif
 
 test:
-	cd agent && GO111MODULE=on ${GOTEST} ${VERBOSE} -tags unit -mod vendor -coverprofile ../cover.out -timeout=60s ./... && cd ..
+	cd agent && GO111MODULE=on ${GOTEST} ${VERBOSE} -tags unit -mod vendor -coverprofile ../cover.out -timeout=120s ./... && cd ..
 	go tool cover -func cover.out > coverprofile.out
 
 test-init:
@@ -153,7 +153,7 @@ test-init:
 	go tool cover -func cover.out > coverprofile-init.out
 
 test-silent:
-	cd agent && GO111MODULE=on ${GOTEST} -tags unit -mod vendor -coverprofile ../cover.out -timeout=60s ./... && cd ..
+	cd agent && GO111MODULE=on ${GOTEST} -tags unit -mod vendor -coverprofile ../cover.out -timeout=120s ./... && cd ..
 	go tool cover -func cover.out > coverprofile.out
 
 .PHONY: analyze-cover-profile

--- a/agent/acs/handler/payload_handler_test.go
+++ b/agent/acs/handler/payload_handler_test.go
@@ -217,7 +217,6 @@ func TestHandlePayloadMessageSaveDataError(t *testing.T) {
 		ResourcesMapUnsafe:  make(map[string][]taskresource.TaskResource),
 		NetworkMode:         apitask.BridgeNetworkMode,
 	}
-	expectedTask.GetID() // to set the task setIdOnce (sync.Once) property
 
 	assert.Equal(t, expectedTask, addedTask, "added task is not expected")
 }
@@ -279,7 +278,6 @@ func TestHandlePayloadMessageAckedWhenTaskAdded(t *testing.T) {
 		ResourcesMapUnsafe: make(map[string][]taskresource.TaskResource),
 		NetworkMode:        apitask.BridgeNetworkMode,
 	}
-	expectedTask.GetID() // to set the task setIdOnce (sync.Once) property
 	assert.Equal(t, expectedTask, addedTask, "received task is not expected")
 }
 
@@ -458,7 +456,6 @@ func TestPayloadBufferHandler(t *testing.T) {
 		ResourcesMapUnsafe: make(map[string][]taskresource.TaskResource),
 		NetworkMode:        apitask.BridgeNetworkMode,
 	}
-	expectedTask.GetID() // to set the task setIdOnce (sync.Once) property
 	assert.Equal(t, expectedTask, addedTask, "received task is not expected")
 }
 
@@ -693,7 +690,6 @@ func validateTaskAndCredentials(taskCredentialsAck, expectedCredentialsAckForTas
 		NetworkMode:        apitask.BridgeNetworkMode,
 	}
 	expectedTask.SetCredentialsID(expectedTaskCredentials.CredentialsID)
-	expectedTask.GetID() // to set the task setIdOnce (sync.Once) property
 
 	if !reflect.DeepEqual(addedTask, expectedTask) {
 		return fmt.Errorf("Mismatch between expected and added tasks, expected: %v, added: %v", expectedTask, addedTask)

--- a/agent/api/statechange.go
+++ b/agent/api/statechange.go
@@ -149,14 +149,14 @@ func NewContainerStateChangeEvent(task *apitask.Task, cont *apicontainer.Contain
 	}
 	contKnownStatus := cont.GetKnownStatus()
 	if !contKnownStatus.ShouldReportToBackend(cont.GetSteadyStateStatus()) {
-		return event, errors.Errorf(
+		return event, ErrShouldNotSendEvent{fmt.Sprintf(
 			"create container state change event api: status not recognized by ECS: %v",
-			contKnownStatus)
+			contKnownStatus)}
 	}
 	if cont.GetSentStatus() >= contKnownStatus {
-		return event, errors.Errorf(
+		return event, ErrShouldNotSendEvent{fmt.Sprintf(
 			"create container state change event api: status [%s] already sent for container %s, task %s",
-			contKnownStatus.String(), cont.Name, task.Arn)
+			contKnownStatus.String(), cont.Name, task.Arn)}
 	}
 	if reason == "" && cont.ApplyingError != nil {
 		reason = cont.ApplyingError.Error()

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -508,10 +508,6 @@ func (task *Task) initNetworkMode(acsTaskNetworkMode *string) {
 			field.NetworkMode: aws.StringValue(acsTaskNetworkMode),
 		})
 	}
-	logger.Info("Task network mode initialized", logger.Fields{
-		field.TaskID:      task.GetID(),
-		field.NetworkMode: task.NetworkMode,
-	})
 }
 
 func (task *Task) initServiceConnectResources() error {

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -1864,7 +1864,6 @@ func TestTaskFromACS(t *testing.T) {
 		Memory:              512,
 		ResourcesMapUnsafe:  make(map[string][]taskresource.TaskResource),
 	}
-	expectedTask.GetID() // to set the task setIdOnce (sync.Once) property
 
 	seqNum := int64(42)
 	task, err := TaskFromACS(&taskFromAcs, &ecsacs.PayloadMessage{SeqNum: &seqNum})

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -1752,6 +1752,15 @@ func (engine *DockerTaskEngine) provisionContainerResourcesAwsvpc(task *apitask.
 		}
 	}
 
+	logger.Info("Setting up CNI config for task", logger.Fields{
+		field.TaskID:        task.GetID(),
+		"cniContainerID":    cniConfig.ContainerID,
+		"cniPluginPath":     cniConfig.PluginsPath,
+		"cniID":             cniConfig.ID,
+		"cniBridgeName":     cniConfig.BridgeName,
+		"cniContainerNetNs": cniConfig.ContainerNetNS,
+	})
+
 	// Invoke the libcni to config the network namespace for the container
 	result, err := engine.cniClient.SetupNS(engine.ctx, cniConfig, cniSetupTimeout)
 	if err != nil {

--- a/agent/sighandlers/termination_handler.go
+++ b/agent/sighandlers/termination_handler.go
@@ -87,11 +87,11 @@ func FinalSave(state dockerstate.TaskEngineState, dataClient data.Client, taskEn
 	disableErr := <-engineDisabled
 
 	stateSaved := make(chan error)
-	saveTimer := time.AfterFunc(finalSaveTimeout, func() {
-		stateSaved <- errors.New("final save: timed out trying to save to disk")
-	})
 	go func() {
 		seelog.Debug("Saving state before shutting down")
+		saveTimer := time.AfterFunc(finalSaveTimeout, func() {
+			stateSaved <- errors.New("final save: timed out trying to save to disk")
+		})
 		saveStateAll(state, dataClient)
 		saveTimer.Stop()
 		stateSaved <- nil

--- a/agent/stats/container.go
+++ b/agent/stats/container.go
@@ -39,6 +39,7 @@ func newStatsContainer(dockerID string, client dockerapi.DockerClient, resolver 
 			DockerID:    dockerID,
 			Name:        dockerContainer.Container.Name,
 			NetworkMode: dockerContainer.Container.GetNetworkMode(),
+			StartedAt:   dockerContainer.Container.GetStartedAt(),
 		},
 		ctx:      ctx,
 		cancel:   cancel,

--- a/agent/stats/queue.go
+++ b/agent/stats/queue.go
@@ -169,62 +169,72 @@ func (queue *Queue) GetMemoryStatsSet() (*ecstcs.CWStatsSet, error) {
 func (queue *Queue) GetStorageStatsSet() (*ecstcs.StorageStatsSet, error) {
 	storageStatsSet := &ecstcs.StorageStatsSet{}
 	var err error
+	var errStr string
 	storageStatsSet.ReadSizeBytes, err = queue.getULongStatsSet(getStorageReadBytes)
 	if err != nil {
-		seelog.Warnf("Error getting storage read size bytes: %v", err)
+		errStr += fmt.Sprintf("error getting storage read size bytes: %v - ", err)
 	}
 	storageStatsSet.WriteSizeBytes, err = queue.getULongStatsSet(getStorageWriteBytes)
 	if err != nil {
-		seelog.Warnf("Error getting storage write size bytes: %v", err)
+		errStr += fmt.Sprintf("error getting storage write size bytes: %v - ", err)
 	}
-	return storageStatsSet, err
+	var errOut error
+	if len(errStr) > 0 {
+		errOut = fmt.Errorf(errStr)
+	}
+	return storageStatsSet, errOut
 }
 
 // GetNetworkStatsSet gets the stats set for network metrics.
 func (queue *Queue) GetNetworkStatsSet() (*ecstcs.NetworkStatsSet, error) {
 	networkStatsSet := &ecstcs.NetworkStatsSet{}
 	var err error
+	var errStr string
 	networkStatsSet.RxBytes, err = queue.getULongStatsSet(getNetworkRxBytes)
 	if err != nil {
-		seelog.Warnf("Error getting network rx bytes: %v", err)
+		errStr += fmt.Sprintf("error getting network rx bytes: %v - ", err)
 	}
 	networkStatsSet.RxDropped, err = queue.getULongStatsSet(getNetworkRxDropped)
 	if err != nil {
-		seelog.Warnf("Error getting network rx dropped: %v", err)
+		errStr += fmt.Sprintf("error getting network rx dropped: %v - ", err)
 	}
 	networkStatsSet.RxErrors, err = queue.getULongStatsSet(getNetworkRxErrors)
 	if err != nil {
-		seelog.Warnf("Error getting network rx errors: %v", err)
+		errStr += fmt.Sprintf("error getting network rx errors: %v - ", err)
 	}
 	networkStatsSet.RxPackets, err = queue.getULongStatsSet(getNetworkRxPackets)
 	if err != nil {
-		seelog.Warnf("Error getting network rx packets: %v", err)
+		errStr += fmt.Sprintf("error getting network rx packets: %v - ", err)
 	}
 	networkStatsSet.TxBytes, err = queue.getULongStatsSet(getNetworkTxBytes)
 	if err != nil {
-		seelog.Warnf("Error getting network tx bytes: %v", err)
+		errStr += fmt.Sprintf("error getting network tx bytes: %v - ", err)
 	}
 	networkStatsSet.TxDropped, err = queue.getULongStatsSet(getNetworkTxDropped)
 	if err != nil {
-		seelog.Warnf("Error getting network tx dropped: %v", err)
+		errStr += fmt.Sprintf("error getting network tx dropped: %v - ", err)
 	}
 	networkStatsSet.TxErrors, err = queue.getULongStatsSet(getNetworkTxErrors)
 	if err != nil {
-		seelog.Warnf("Error getting network tx errors: %v", err)
+		errStr += fmt.Sprintf("error getting network tx errors: %v - ", err)
 	}
 	networkStatsSet.TxPackets, err = queue.getULongStatsSet(getNetworkTxPackets)
 	if err != nil {
-		seelog.Warnf("Error getting network tx packets: %v", err)
+		errStr += fmt.Sprintf("error getting network tx packets: %v - ", err)
 	}
 	networkStatsSet.RxBytesPerSecond, err = queue.getUDoubleCWStatsSet(getNetworkRxPacketsPerSecond)
 	if err != nil {
-		seelog.Warnf("Error getting network rx bytes per second: %v", err)
+		errStr += fmt.Sprintf("error getting network rx bytes per second: %v - ", err)
 	}
 	networkStatsSet.TxBytesPerSecond, err = queue.getUDoubleCWStatsSet(getNetworkTxPacketsPerSecond)
 	if err != nil {
-		seelog.Warnf("Error getting network tx bytes per second: %v", err)
+		errStr += fmt.Sprintf("error getting network tx bytes per second: %v - ", err)
 	}
-	return networkStatsSet, err
+	var errOut error
+	if len(errStr) > 0 {
+		errOut = fmt.Errorf(errStr)
+	}
+	return networkStatsSet, errOut
 }
 
 func getNetworkRxBytes(s *UsageStats) uint64 {

--- a/agent/stats/types.go
+++ b/agent/stats/types.go
@@ -62,9 +62,10 @@ type UsageStats struct {
 
 // ContainerMetadata contains meta-data information for a container.
 type ContainerMetadata struct {
-	DockerID    string `json:"-"`
-	Name        string `json:"-"`
-	NetworkMode string `json:"-"`
+	DockerID    string    `json:"-"`
+	Name        string    `json:"-"`
+	NetworkMode string    `json:"-"`
+	StartedAt   time.Time `json:"-"`
 }
 
 // TaskMetadata contains meta-data information for a task.

--- a/scripts/run-unit-tests.ps1
+++ b/scripts/run-unit-tests.ps1
@@ -16,7 +16,7 @@ $cwd = (pwd).Path
 try {
     cd $cwd
     $packages=go list .\agent\... | Where-Object {$_ -NotMatch 'vendor'}
-    go test -v -tags unit -timeout=40s $packages
+    go test -v -tags unit -timeout=120s $packages
     $testsExitCode = $LastExitCode
 } finally {
     cd "$cwd"


### PR DESCRIPTION
### Summary
<!-- What does this pull request do? -->

Agent logs are very verbose and log quite a lot of red herring warning and error log messages. In some cases it is also logging irrelevant and duplicate messages.

In this change there is also the addition of a log message for when we are setting up the CNI config for a task.

Overall these log messages represent around 16-25% of an agent logfile (higher percent on instances with higher numbers of tasks).

Changes to logging:

- add a grace period for cloudwatch metrics warnings
- remove unnecessary stat warns/errors when a task is or has exited
- remove unnecessary (and somewhat misleading) "network mode initialized" log messages
- dont log errors for "skippable" docker events

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Enhancement - logging cleanup for unnecessary warn/error messages

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
