### PR TITLE
Add new AL version in maintenance CodeBuild CF template to update and upload agentVersionV2-<branch>.json for AL1

### DIFF
--- a/build-infrastructure/al-maintenance-codebuild-stack.yml
+++ b/build-infrastructure/al-maintenance-codebuild-stack.yml
@@ -1,0 +1,59 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: A template that brings up a code build project that makes release configs for AL versions in maintenance mode
+
+Parameters:
+    GithubFullRepoName:
+      Type: String
+      Description: Full name of the agent repository to use (e.g. https://github.com/aws/amazon-ecs-agent.git)
+      Default: https://github.com/aws/amazon-ecs-agent.git
+    GithubBranchName:
+      Type: String
+      Description: Name of the base branch to use to build, PRs to which will trigger builds (e.g. refs/heads/AmazonLinuxLegacy)
+    GithubSourceBranchName:
+      Type: String
+      Description: Name of the source branch used for the PRs (e.g. al1-patch)
+    ReleaseArtifactsBucketS3Uri:
+      Type: String
+      Description: The URI of the bucket where things land at the end, this is assumed to already exist (e.g. s3://artifacts)
+    ServiceRoleArn:
+      Type: String
+      Description: The ARN of an existing CodeBuild service role
+
+Resources:
+  ModifyAndCopyJSON:
+    Type: 'AWS::CodeBuild::Project'
+    Properties:
+      Artifacts:
+        Type: NO_ARTIFACTS
+      BadgeEnabled: false
+      ConcurrentBuildLimit: 10
+      Description: A CodeBuild project to modify and update the release configs for AL versions in maintenance mode. Builds are triggered by PR merges.
+      Environment:
+        Type: LINUX_CONTAINER
+        ComputeType: BUILD_GENERAL1_SMALL
+        ImagePullCredentialsType: CODEBUILD
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+        EnvironmentVariables:
+          - Name: RESULTS_BUCKET_URI
+            Type: PLAINTEXT
+            Value: !Ref ReleaseArtifactsBucketS3Uri
+          - Name: GITHUB_SOURCE_BRANCH_NAME
+            Type: PLAINTEXT
+            Value: !Ref GithubSourceBranchName
+      Name: !Ref 'AWS::StackName'
+      QueuedTimeoutInMinutes: 60
+      ServiceRole: !Ref ServiceRoleArn
+      Source:
+        BuildSpec: buildspecs/al-maintenance-release-config.yml
+        Location: !Ref GithubFullRepoName
+        Type: GITHUB
+      TimeoutInMinutes: 60
+      Triggers:
+        BuildType: BUILD
+        FilterGroups:
+          - - Type: EVENT
+              Pattern: 'PULL_REQUEST_MERGED'
+            - Type: BASE_REF
+              Pattern: !Sub '^${GithubBranchName}$'
+        Webhook: true
+      Visibility: PRIVATE

--- a/buildspecs/al-maintenance-release-config.yml
+++ b/buildspecs/al-maintenance-release-config.yml
@@ -1,0 +1,9 @@
+version: 0.2
+
+phases:
+  pre_build:
+    commands:
+      - sudo yum -y update
+  build:
+    commands:
+      - cd scripts && ./release-config.sh

--- a/scripts/release-config.sh
+++ b/scripts/release-config.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+GITHUB_DEST_BRANCH_NAME=$(echo ${CODEBUILD_WEBHOOK_BASE_REF} | cut -d "/" -f3-)
+GIT_COMMIT_SHA=$(git rev-parse $GITHUB_DEST_BRANCH_NAME)
+GIT_COMMIT_SHORT_SHA=$(git rev-parse --short=8 $GITHUB_DEST_BRANCH_NAME)
+RELEASE_DATE=$(date +'%Y%m%d')
+AGENT_VERSION=$(cat ../VERSION)
+
+cat << EOF > agent.json
+{
+    "agentReleaseVersion" : "$AGENT_VERSION",
+    "releaseDate" : "$RELEASE_DATE",
+    "initStagingConfig": {
+    "release": "1"
+    },
+    "agentStagingConfig": {
+    "releaseGitSha": "$GIT_COMMIT_SHA",
+    "releaseGitShortSha": "$GIT_COMMIT_SHORT_SHA",
+    "gitFarmRepoName": "MadisonContainerAgentExternal",
+    "gitHubRepoName": "aws/amazon-ecs-agent",
+    "gitFarmStageBranch": "v${AGENT_VERSION}-stage",
+    "githubReleaseUrl": ""
+    }
+}
+EOF
+
+# Downloading the agentVersionV2-<branch>.json (it is assumed that it already exists)
+aws s3 cp ${RESULTS_BUCKET_URI}/agentVersionV2/agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}.json ./agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}.json
+echo "Downloaded agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}.json"
+cat agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}.json
+
+# Grabbing the new current and release agent version
+CURR_VER=$(jq -r '.agentReleaseVersion' agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}.json)
+
+# Checking to see if there's a new release agent version to be released
+if [[ ! $AGENT_VERSION =~ "${CURR_VER}" ]] ; then
+    # Updating the agentVersionV2-<branch>.json file with new current and release agent versions and copying it to a temp file
+    jq ".agentReleaseVersion = \"$AGENT_VERSION\" | .agentCurrentVersion = \"$CURR_VER\"" agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}.json > agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}-COPY.json
+    # Replace existing agentVersionV2-<branch>.json file with the temp file
+    jq . agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}-COPY.json > agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}.json
+fi
+
+# Uploading new agentVersionV2-<branch>.json and agent.json files
+echo "Uploading agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}.json"
+cat agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}.json
+aws s3 cp ./agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}.json ${RESULTS_BUCKET_URI}/agentVersionV2/agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}.json
+
+echo "Uploading agent.json"
+cat agent.json
+aws s3 cp ./agent.json ${RESULTS_BUCKET_URI}/${GITHUB_SOURCE_BRANCH_NAME}/agent.json


### PR DESCRIPTION
### Summary
This PR will introduce a new CodeBuild project which will be kicked off only when a PR has been merged into AmazonLinuxLegacy branch. What this CodeBuild project will do is it'll generate an `agent.json` and `agentVersionV2-<branch>.json` files which will be used as part of our release process. The buildspec file for this CodeBuild project is a bit of a combination of the `release-config.yml` and `copy.yml` buildspec files which is currently being used by our release CodePipeline. 

### Implementation details
build-infrastructure/al-maintenance-codebuild-stack.yml
- New CF template YAML file
- Similar parameters that's also being used in the release CodePipeline
- New `ServiceRoleArn` parameter which will be referred to as the CodeBuild service role (Will not be creating a new Service Role but instead reusing an existing one)
- Triggered by a `PR_MERGED`
- Using the `AmazonLinuxLegacy` branch as the destination branch (i.e. BASE_REF)

buildspecs/al-maintenance-release-config
- New buildspec YAML file
- Calling a helper script `release-config.sh`

release-config.sh
- Similar to the commands running in the build stage of`release-config.yml` file in the `dev` branch
- Will also be copying over the generated `agent.json` and new `agentVersionV2-<branch>.json` file over to the same release bucket that our current release CodePipeline is using

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

This CodeBuild CF template file was used in my personal dev account. I've tested the CodeBuild project by cloning the `AmazonLinuxLegacy` branch into my forked repo and used it as the destination branch. I was able to successfully kick off the CodeBuild project each time a PR was merged.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
- Feature: New release CodeBuild project for AL1
### Licensing

### Related PRs:
- #3612 
- #3611 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
