### PR TITLE
ecs-init: Add ISO partition for downloading agent appropriately

### DIFF
--- a/ecs-init/config/common.go
+++ b/ecs-init/config/common.go
@@ -112,6 +112,8 @@ var partitionBucketRegion = map[string]string{
 	endpoints.AwsPartitionID:      endpoints.UsEast1RegionID,
 	endpoints.AwsCnPartitionID:    endpoints.CnNorth1RegionID,
 	endpoints.AwsUsGovPartitionID: endpoints.UsGovWest1RegionID,
+	endpoints.AwsIsoPartitionID:   endpoints.UsIsoEast1RegionID,
+	endpoints.AwsIsoBPartitionID:  endpoints.UsIsobEast1RegionID,
 }
 
 // goarch is an injectable GOARCH runtime string. This controls the


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR adds the ISO partition ID and the region to the `partitionBucketRegion` mapping. ECS init goes looking for where to download ecs agent from, but fails for ISO regions. With this change, it should now be able to look in the right place.

### Implementation details
<!-- How are the changes implemented? -->
We use the identifier defined in aws-sdk: https://github.com/aws/amazon-ecs-agent/blob/7060c3f945eaf3c24dc544dc8c204c36272aa652/ecs-init/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go#L10-L16

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Fix: Add ISO partition for downloading agent appropriately
 
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
