### PR TITLE
Move statsEngine initiation from tcs session initialization, and adding channels to statsEngine

### DIFF
--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -59,6 +59,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/stats"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource"
 	tcshandler "github.com/aws/amazon-ecs-agent/agent/tcs/handler"
+	"github.com/aws/amazon-ecs-agent/agent/tcs/model/ecstcs"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 	"github.com/aws/amazon-ecs-agent/agent/utils/loader"
 	"github.com/aws/amazon-ecs-agent/agent/utils/mobypkgwrapper"
@@ -97,6 +98,12 @@ const (
 	inServiceState                 = "InService"
 	asgLifecyclePollWait           = time.Minute
 	asgLifecyclePollMax            = 120 // given each poll cycle waits for about a minute, this gives 2-3 hours before timing out
+
+	// the size of the buffer for the metric/task health/instance health telemetry channels.
+	// By default, TCS (or TACS) will reject metrics that are older than 5 minutes (https://tiny.amazon.com/p6t8axgr).
+	// Since our metrics collection interval is currently set to 20 seconds, setting a buffer size of 15 allows us to
+	// store exactly 5 minutes of metrics in these buffers in the case where we temporarily lose connect to TCS.
+	telemetryChannelDefaultBufferSize = 15
 )
 
 var (
@@ -813,7 +820,7 @@ func (agent *ecsAgent) reregisterContainerInstance(client api.ECSClient, capabil
 	return transientError{err}
 }
 
-// startAsyncRoutines starts all of the background methods
+// startAsyncRoutines starts all background methods
 func (agent *ecsAgent) startAsyncRoutines(
 	containerChangeEventStream *eventstream.EventStream,
 	credentialsManager credentials.Manager,
@@ -840,7 +847,11 @@ func (agent *ecsAgent) startAsyncRoutines(
 	// Agent introspection api
 	go handlers.ServeIntrospectionHTTPEndpoint(agent.ctx, &agent.containerInstanceARN, taskEngine, agent.cfg)
 
-	statsEngine := stats.NewDockerStatsEngine(agent.cfg, agent.dockerClient, containerChangeEventStream)
+	telemetryMessages := make(chan ecstcs.TelemetryMessage, telemetryChannelDefaultBufferSize)
+	healthMessages := make(chan ecstcs.HealthMessage, telemetryChannelDefaultBufferSize)
+	instanceStatusMessages := make(chan ecstcs.InstanceStatusMessage, telemetryChannelDefaultBufferSize)
+
+	statsEngine := stats.NewDockerStatsEngine(agent.cfg, agent.dockerClient, containerChangeEventStream, telemetryMessages, healthMessages, instanceStatusMessages)
 
 	// Start serving the endpoint to fetch IAM Role credentials and other task metadata
 	if agent.cfg.TaskMetadataAZDisabled {
@@ -863,6 +874,12 @@ func (agent *ecsAgent) startAsyncRoutines(
 		TaskEngine:                    taskEngine,
 		StatsEngine:                   statsEngine,
 		Doctor:                        doctor,
+	}
+
+	err := statsEngine.MustInit(agent.ctx, taskEngine, agent.cfg.Cluster, agent.containerInstanceARN)
+	if err != nil {
+		seelog.Warnf("Error initializing metrics engine: %v", err)
+		return
 	}
 
 	// Start metrics session in a go routine

--- a/agent/stats/engine.go
+++ b/agent/stats/engine.go
@@ -99,6 +99,10 @@ type DockerStatsEngine struct {
 	taskToServiceConnectStats           map[string]*ServiceConnectStats
 	publishServiceConnectTickerInterval int32
 	publishMetricsTicker                *time.Ticker
+	// channels to send metrics to TACS Client
+	metricsChannel        chan<- ecstcs.TelemetryMessage
+	healthChannel         chan<- ecstcs.HealthMessage
+	instanceStatusChannel chan<- ecstcs.InstanceStatusMessage
 }
 
 // ResolveTask resolves the api task object, given container id.
@@ -141,7 +145,9 @@ func (resolver *DockerContainerMetadataResolver) ResolveContainer(dockerID strin
 
 // NewDockerStatsEngine creates a new instance of the DockerStatsEngine object.
 // MustInit() must be called to initialize the fields of the new event listener.
-func NewDockerStatsEngine(cfg *config.Config, client dockerapi.DockerClient, containerChangeEventStream *eventstream.EventStream) *DockerStatsEngine {
+func NewDockerStatsEngine(cfg *config.Config, client dockerapi.DockerClient, containerChangeEventStream *eventstream.EventStream,
+	metricsChannel chan<- ecstcs.TelemetryMessage, healthChannel chan<- ecstcs.HealthMessage,
+	instanceStatusChannel chan<- ecstcs.InstanceStatusMessage) *DockerStatsEngine {
 	return &DockerStatsEngine{
 		client:                              client,
 		resolver:                            nil,
@@ -153,6 +159,9 @@ func NewDockerStatsEngine(cfg *config.Config, client dockerapi.DockerClient, con
 		taskToServiceConnectStats:           make(map[string]*ServiceConnectStats),
 		containerChangeEventStream:          containerChangeEventStream,
 		publishServiceConnectTickerInterval: 0,
+		metricsChannel:                      metricsChannel,
+		healthChannel:                       healthChannel,
+		instanceStatusChannel:               instanceStatusChannel,
 	}
 }
 

--- a/agent/tcs/handler/handler.go
+++ b/agent/tcs/handler/handler.go
@@ -57,13 +57,6 @@ func StartMetricsSession(params *TelemetrySessionParams) {
 		return
 	}
 
-	err = params.StatsEngine.MustInit(params.Ctx, params.TaskEngine, params.Cfg.Cluster,
-		params.ContainerInstanceArn)
-	if err != nil {
-		seelog.Warnf("Error initializing metrics engine: %v", err)
-		return
-	}
-
 	err = StartSession(params, params.StatsEngine)
 	if err != nil {
 		seelog.Warnf("Error starting metrics session with backend: %v", err)
@@ -72,7 +65,7 @@ func StartMetricsSession(params *TelemetrySessionParams) {
 
 // StartSession creates a session with the backend and handles requests
 // using the passed in arguments.
-// The engine is expected to initialized and gathering container metrics by
+// The engine is expected to be initialized and gathering container metrics by
 // the time the websocket client starts using it.
 func StartSession(params *TelemetrySessionParams, statsEngine stats.Engine) error {
 	backoff := retry.NewExponentialBackoff(time.Second, 1*time.Minute, 0.2, 2)
@@ -134,7 +127,7 @@ func startSession(
 	}
 	seelog.Info("Connected to TCS endpoint")
 	// start a timer and listens for tcs heartbeats/acks. The timer is reset when
-	// we receive a heartbeat from the server or when a publish metrics message
+	// we receive a heartbeat from the server or when a published metrics message
 	// is acked.
 	timer := time.NewTimer(retry.AddJitter(heartbeatTimeout, heartbeatJitter))
 	defer timer.Stop()

--- a/agent/tcs/model/ecstcs/types.go
+++ b/agent/tcs/model/ecstcs/types.go
@@ -36,3 +36,18 @@ func NewPublishHealthMetricsRequest(metadata *HealthMetadata, healthMetrics []*T
 		Timestamp: aws.Time(time.Now()),
 	}
 }
+
+type TelemetryMessage struct {
+	Metadata    *MetricsMetadata
+	TaskMetrics []*TaskMetric
+}
+
+type HealthMessage struct {
+	Metadata      *MetricsMetadata
+	HealthMetrics []*TaskHealth
+}
+
+type InstanceStatusMessage struct {
+	Metadata *InstanceStatusMetadata
+	Statuses []*InstanceStatus
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
* Move statsEngine initiation out of telemetry session initiation. This helps decoupling statsEngine and telemetry session initiation, make it possible to use a different TACS client interface, as well as establishing channel based communication between statsEngine and TACS Client
* Add task metrics/health metrics/instance status channel
* Updating related metadata

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: N/A

`make release` passed. This is pure metadata changes and not able to be functional tested.

Specifically, `telemetryChannelDefaultBufferSize = 15` will be further tested after channel based communication is implemented. This is currently borrowed from Fargate agent.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Move statsEngine initiation from tcs session initialization, and adding channels to statsEngine

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
