### PR TITLE
Add metrics interface and corresponding no-ops to ecs-agent/

### DIFF
--- a/ecs-agent/metrics/metrics.go
+++ b/ecs-agent/metrics/metrics.go
@@ -1,0 +1,63 @@
+package metrics
+
+// EntryFactory specifies the factory interface for creating new Metric Entry objects.
+type EntryFactory interface {
+	New(op string) Entry
+	Flush()
+}
+
+// Entry specifies methods that need to be implemented by a metrics entry object.
+type Entry interface {
+	// WithFields allows the caller to set metric metadata. Once an entry object is
+	// created (typically using a meaningful metrics name), its properties can be
+	// manipulated using WithFields. Example:
+	//
+	// m := m.WithFields(map[string]interface{"timestamp": time.Now()})
+	WithFields(f map[string]interface{}) Entry
+	// WithCount allows the caller to set metric counts. This is useful for determining
+	// if a particular operation has occurred or not. Example:
+	//
+	// item, ok := lookup(key)
+	// if ok {
+	//   lookupSuccessMetric = lookupSuccessMetric.WithCount(1)
+	//   // Use item
+	// } else {
+	//   lookupSuccessMetric = lookupSuccessMetric.WithCount(0))
+	// }
+	WithCount(count int) Entry
+	// WithGauge allows the caller to associate a specific value to the metric. This is useful
+	// for reporting numerical values related to any operation, for instance the data transfer
+	// rate for an image pull operation.
+	WithGauge(value interface{}) Entry
+	// Done makes a metric operation as complete. It records the end time of the operation
+	// and returns a function pointer that can be used to flush the metrics to a
+	// persistent store. Callers can optionally defer the function pointer. Example:
+	//
+	// defer lookupMetric.Done(nil) ()
+	Done(err error) func()
+}
+
+// nopEntryFactory implements the EntryFactory interface with no-ops.
+type nopEntryFactory struct{}
+
+// NewNopEntryFactory creates a metric log entry factory that doesn't log any metrics.
+func NewNopEntryFactory() EntryFactory {
+	return &nopEntryFactory{}
+}
+
+func (*nopEntryFactory) New(op string) Entry {
+	return newNopEntry(op)
+}
+
+func (f *nopEntryFactory) Flush() {}
+
+type nopEntry struct{}
+
+func newNopEntry(op string) Entry {
+	return &nopEntry{}
+}
+
+func (e *nopEntry) WithFields(f map[string]interface{}) Entry { return e }
+func (e *nopEntry) WithCount(count int) Entry                 { return e }
+func (e *nopEntry) WithGauge(value interface{}) Entry         { return e }
+func (e *nopEntry) Done(err error) func()                     { return func() {} }


### PR DESCRIPTION
### Summary
<!-- What does this pull request do? -->
Moving the metrics-related interfaces as well as their no-op implementations to the `ecs-agent` directory. No-op metrics will be integrated as a part of incoming efforts. 

### Implementation details
<!-- How are the changes implemented? -->
- `EntryFactory` and `Entry` interfaces included in the metrics package.
- `nopEntryFactory` is the no-op implementation of the `EntryFactory` interface.
- `nopEntry` is the no-op implementation of the `Entry` interface.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Existing unit and integ tests.
The changes do not involve any integration to cause changes to the Agent. The no-op implementations are too low-level and do not have observable side effects to add unit tests for.

New tests cover the changes: no 

### Description for the changelog

Add metrics interface and corresponding no-ops to ecs-agent/

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
