### PR TITLE
Add task manifest/stop verification ACK common interface to ecs-agent/

### DIFF
--- a/ecs-agent/acs/session/task_manifest_common.go
+++ b/ecs-agent/acs/session/task_manifest_common.go
@@ -1,0 +1,9 @@
+package session
+
+// ManifestMessageIDAccessor stores the latest message ID that corresponds to the
+// most recently processed task manifest message and is used to determine the
+// validity of a task stop verification ack message.
+type ManifestMessageIDAccessor interface {
+	GetMessageID() string
+	SetMessageID(messageID string) error
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Add a common interface for task manifest/stop verification ACK responders to `ecs-agent/`

### Implementation details
<!-- How are the changes implemented? -->
- Create interface inside of `ecs-agent/acs/session/task_manifest_common.go`

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: N/A

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Add task manifest/stop verification ACK common interface ecs-agent/

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
