### PR TITLE
Require an HTTP Handler instead of a mux Router in TMDS Config

### DIFF
--- a/agent/handlers/task_server_setup.go
+++ b/agent/handlers/task_server_setup.go
@@ -79,7 +79,7 @@ func taskServerSetup(credentialsManager credentials.Manager,
 	agentAPIV1HandlersSetup(muxRouter, state, credentialsManager, cluster, region, apiEndpoint, acceptInsecureCert)
 
 	return tmds.NewServer(auditLogger,
-		tmds.WithRouter(muxRouter),
+		tmds.WithHandler(muxRouter),
 		tmds.WithListenAddress(tmds.AddressIPv4()),
 		tmds.WithReadTimeout(readTimeout),
 		tmds.WithWriteTimeout(writeTimeout),

--- a/ecs-agent/tmds/server_integ_test.go
+++ b/ecs-agent/tmds/server_integ_test.go
@@ -52,7 +52,7 @@ func TestRequestRateLimiter(t *testing.T) {
 
 	// Setup the server with a low rate limit for testing
 	server, err := NewServer(auditLogger,
-		WithRouter(router),
+		WithHandler(router),
 		WithListenAddress(serverAddress),
 		WithSteadyStateRate(1),
 		WithBurstRate(1),
@@ -91,7 +91,7 @@ func TestRequestWriteTimeout(t *testing.T) {
 
 	// Setup the server with a low write timeout for testing
 	server, err := NewServer(nil,
-		WithRouter(router),
+		WithHandler(router),
 		WithListenAddress(serverAddress),
 		WithWriteTimeout(50*time.Millisecond),
 		WithSteadyStateRate(10),
@@ -126,7 +126,7 @@ func TestRoutes(t *testing.T) {
 	// setup the server
 	serverAddress := "127.0.0.1:3600"
 	server, err := NewServer(nil,
-		WithRouter(router),
+		WithHandler(router),
 		WithListenAddress(serverAddress),
 		WithSteadyStateRate(10),
 		WithBurstRate(10),

--- a/ecs-agent/tmds/server_test.go
+++ b/ecs-agent/tmds/server_test.go
@@ -25,9 +25,9 @@ import (
 )
 
 func TestNewServerErrors(t *testing.T) {
-	t.Run("router is required", func(t *testing.T) {
+	t.Run("handler is required", func(t *testing.T) {
 		_, err := NewServer(nil, WithListenAddress(AddressIPv4()))
-		assert.EqualError(t, err, "router cannot be nil")
+		assert.EqualError(t, err, "handler cannot be nil")
 	})
 }
 
@@ -40,7 +40,7 @@ func TestServerSettings(t *testing.T) {
 
 	server, err := NewServer(nil,
 		WithListenAddress(AddressIPv4()),
-		WithRouter(router),
+		WithHandler(router),
 		WithWriteTimeout(writeTimeout),
 		WithReadTimeout(readTimeout))
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
TMDS initialization function in `ecs-agent` module currently requires a `Router` instance from gorilla/mux library to be passed. Usage of `Router` here is unnecessarily strict and limits the reusability of TMDS to consumers who are using routers from gorilla/mux library. Updating the function to require an `http.Handler` instance instead which would allow greater reuse. `Router` implements `http.Handler` interface.

### Implementation details
* Change `router *mux.Router` field in TMDS initialization config to `handler http.Handler`.
* Update the tests and error messages accordingly.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Require an HTTP Handler instead of a mux Router in TMDS Config to increase the reusability of TMDS.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
