### PR TITLE
Advertise Domainless gMSA capability on Windows

### DIFF
--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -66,6 +66,7 @@ const (
 	capabilityFirelensConfigS3                             = "firelens.options.config.s3"
 	capabilityFullTaskSync                                 = "full-sync"
 	capabilityGMSA                                         = "gmsa"
+	capabilityGMSADomainless                               = "gmsa-domainless"
 	capabilityEFS                                          = "efs"
 	capabilityEFSAuth                                      = "efsAuth"
 	capabilityEnvFilesS3                                   = "env-files.s3"
@@ -271,6 +272,9 @@ func (agent *ecsAgent) capabilities() ([]*ecs.Attribute, error) {
 	// support GMSA capabilities
 	capabilities = agent.appendGMSACapabilities(capabilities)
 
+	// support GMSA domainless capabilities
+	capabilities = agent.appendGMSADomainlessCapabilities(capabilities)
+
 	// support efs auth on ecs capabilities
 	for _, cap := range agent.cfg.VolumePluginCapabilities {
 		capabilities = agent.appendEFSVolumePluginCapabilities(capabilities, cap)
@@ -314,6 +318,14 @@ func (agent *ecsAgent) appendDockerDependentCapabilities(capabilities []*ecs.Att
 func (agent *ecsAgent) appendGMSACapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
 	if agent.cfg.GMSACapable.Enabled() {
 		return appendNameOnlyAttribute(capabilities, attributePrefix+capabilityGMSA)
+	}
+
+	return capabilities
+}
+
+func (agent *ecsAgent) appendGMSADomainlessCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
+	if agent.cfg.GMSADomainlessCapable.Enabled() {
+		return appendNameOnlyAttribute(capabilities, attributePrefix+capabilityGMSADomainless)
 	}
 
 	return capabilities

--- a/agent/app/agent_capability_test.go
+++ b/agent/app/agent_capability_test.go
@@ -1433,3 +1433,47 @@ func TestAppendGMSACapabilities(t *testing.T) {
 		assert.Equal(t, aws.StringValue(expected.Value), aws.StringValue(capabilities[i].Value))
 	}
 }
+
+func TestAppendGMSADomainlessCapabilities(t *testing.T) {
+	var inputCapabilities []*ecs.Attribute
+	var expectedCapabilities []*ecs.Attribute
+
+	expectedCapabilities = append(expectedCapabilities,
+		[]*ecs.Attribute{
+			{
+				Name: aws.String(attributePrefix + capabilityGMSADomainless),
+			},
+		}...)
+
+	agent := &ecsAgent{
+		cfg: &config.Config{
+			GMSADomainlessCapable: config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled},
+		},
+	}
+
+	capabilities := agent.appendGMSADomainlessCapabilities(inputCapabilities)
+
+	assert.Equal(t, len(expectedCapabilities), len(capabilities))
+	for i, expected := range expectedCapabilities {
+		assert.Equal(t, aws.StringValue(expected.Name), aws.StringValue(capabilities[i].Name))
+		assert.Equal(t, aws.StringValue(expected.Value), aws.StringValue(capabilities[i].Value))
+	}
+}
+
+func TestAppendGMSADomainlessCapabilitiesFalse(t *testing.T) {
+	var inputCapabilities []*ecs.Attribute
+	var expectedCapabilities []*ecs.Attribute
+
+	expectedCapabilities = append(expectedCapabilities,
+		[]*ecs.Attribute{}...)
+
+	agent := &ecsAgent{
+		cfg: &config.Config{
+			GMSADomainlessCapable: config.BooleanDefaultFalse{Value: config.ExplicitlyDisabled},
+		},
+	}
+
+	capabilities := agent.appendGMSADomainlessCapabilities(inputCapabilities)
+
+	assert.Equal(t, len(expectedCapabilities), len(capabilities))
+}

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -587,6 +587,7 @@ func environmentConfig() (Config, error) {
 		CgroupCPUPeriod:                     parseCgroupCPUPeriod(),
 		SpotInstanceDrainingEnabled:         parseBooleanDefaultFalseConfig("ECS_ENABLE_SPOT_INSTANCE_DRAINING"),
 		GMSACapable:                         parseGMSACapability(),
+		GMSADomainlessCapable:               parseGMSADomainlessCapability(),
 		VolumePluginCapabilities:            parseVolumePluginCapabilities(),
 		FSxWindowsFileServerCapable:         parseFSxWindowsFileServerCapability(),
 		External:                            parseBooleanDefaultFalseConfig("ECS_EXTERNAL"),

--- a/agent/config/config_unix.go
+++ b/agent/config/config_unix.go
@@ -102,6 +102,7 @@ func DefaultConfig() Config {
 		NvidiaRuntime:                       DefaultNvidiaRuntime,
 		CgroupCPUPeriod:                     defaultCgroupCPUPeriod,
 		GMSACapable:                         parseGMSACapability(),
+		GMSADomainlessCapable:               parseGMSADomainlessCapability(),
 		FSxWindowsFileServerCapable:         BooleanDefaultFalse{Value: ExplicitlyDisabled},
 		RuntimeStatsLogFile:                 defaultRuntimeStatsLogFile,
 		EnableRuntimeStats:                  BooleanDefaultFalse{Value: NotSet},

--- a/agent/config/config_windows.go
+++ b/agent/config/config_windows.go
@@ -144,6 +144,7 @@ func DefaultConfig() Config {
 		PollMetrics:                         BooleanDefaultFalse{Value: NotSet},
 		PollingMetricsWaitDuration:          DefaultPollingMetricsWaitDuration,
 		GMSACapable:                         BooleanDefaultFalse{Value: ExplicitlyDisabled},
+		GMSADomainlessCapable:               BooleanDefaultFalse{Value: ExplicitlyDisabled},
 		FSxWindowsFileServerCapable:         BooleanDefaultFalse{Value: ExplicitlyDisabled},
 		PauseContainerImageName:             DefaultPauseContainerImageName,
 		PauseContainerTag:                   DefaultPauseContainerTag,

--- a/agent/config/parse_linux.go
+++ b/agent/config/parse_linux.go
@@ -72,6 +72,10 @@ func parseFSxWindowsFileServerCapability() BooleanDefaultFalse {
 	return BooleanDefaultFalse{Value: ExplicitlyDisabled}
 }
 
+func parseGMSADomainlessCapability() BooleanDefaultFalse {
+	return BooleanDefaultFalse{Value: ExplicitlyDisabled}
+}
+
 var IsWindows2016 = func() (bool, error) {
 	return false, errors.New("unsupported platform")
 }

--- a/agent/config/parse_unsupported.go
+++ b/agent/config/parse_unsupported.go
@@ -29,6 +29,10 @@ func parseFSxWindowsFileServerCapability() BooleanDefaultFalse {
 	return BooleanDefaultFalse{Value: ExplicitlyDisabled}
 }
 
+func parseGMSADomainlessCapability() BooleanDefaultFalse {
+	return BooleanDefaultFalse{Value: ExplicitlyDisabled}
+}
+
 var IsWindows2016 = func() (bool, error) {
 	return false, errors.New("unsupported platform")
 }

--- a/agent/config/parse_windows.go
+++ b/agent/config/parse_windows.go
@@ -24,7 +24,9 @@ import (
 	"unsafe"
 
 	"github.com/aws/amazon-ecs-agent/agent/utils"
+
 	"github.com/cihub/seelog"
+	"golang.org/x/sys/windows/registry"
 )
 
 const (
@@ -32,12 +34,37 @@ const (
 	// to skip the windows server version check. This is useful for testing and
 	// should not be set for any non-test use-case.
 	envSkipWindowsServerVersionCheck = "ZZZ_SKIP_WINDOWS_SERVER_VERSION_CHECK_NOT_SUPPORTED_IN_PRODUCTION"
+	gmsaPluginGUID                   = "{859E1386-BDB4-49E8-85C7-3070B13920E1}"
+)
+
+var (
+	fnQueryDomainlessGmsaPluginSubKeys = queryDomainlessGmsaPluginSubKeys
 )
 
 // parseGMSACapability is used to determine if gMSA support can be enabled
 func parseGMSACapability() BooleanDefaultFalse {
 	envStatus := utils.ParseBool(os.Getenv("ECS_GMSA_SUPPORTED"), true)
 	return checkDomainJoinWithEnvOverride(envStatus)
+}
+
+// parseGMSADomainlessCapability is used to determine if gMSA domainless support can be enabled
+func parseGMSADomainlessCapability() BooleanDefaultFalse {
+	envStatus := utils.ParseBool(os.Getenv("ECS_GMSA_SUPPORTED"), false)
+	if envStatus {
+		// gmsaDomainless is not supported on Windows 2016
+		isWindows2016, err := IsWindows2016()
+		if err != nil || isWindows2016 {
+			return BooleanDefaultFalse{Value: ExplicitlyDisabled}
+		}
+
+		// gmsaDomainless is not supported if the plugin is not installed on the instance
+		installed, err := isDomainlessGmsaPluginInstalled()
+		if err != nil || !installed {
+			return BooleanDefaultFalse{Value: ExplicitlyDisabled}
+		}
+		return BooleanDefaultFalse{Value: ExplicitlyEnabled}
+	}
+	return BooleanDefaultFalse{Value: ExplicitlyDisabled}
 }
 
 // parseFSxWindowsFileServerCapability is used to determine if fsxWindowsFileServer support can be enabled
@@ -113,4 +140,43 @@ var IsWindows2016 = func() (bool, error) {
 	isWS2016 := strings.Contains(str, "Microsoft Windows Server 2016 Datacenter")
 
 	return isWS2016, nil
+}
+
+var queryDomainlessGmsaPluginSubKeys = func() ([]string, error) {
+	k, err := registry.OpenKey(registry.LOCAL_MACHINE, `SYSTEM\CurrentControlSet\Control\CCG\COMClasses\`, registry.READ)
+	if err != nil {
+		seelog.Errorf("Failed to open registry key SYSTEM\\CurrentControlSet\\Control\\CCG\\COMClasses with error: %v", err)
+		return nil, err
+	}
+	defer k.Close()
+	stat, err := k.Stat()
+	if err != nil {
+		seelog.Errorf("Failed to stat registry key SYSTEM\\CurrentControlSet\\Control\\CCG\\COMClasses with error: %v", err)
+		return nil, err
+	}
+	subKeys, err := k.ReadSubKeyNames(int(stat.SubKeyCount))
+	if err != nil {
+		seelog.Errorf("Failed to read subkeys of SYSTEM\\CurrentControlSet\\Control\\CCG\\COMClasses with error: %v", err)
+		return nil, err
+	}
+
+	seelog.Debugf("gMSA Subkeys are %+v", subKeys)
+	return subKeys, nil
+}
+
+// This function queries all gmsa plugin subkeys to check whether the Amazon ECS Plugin GUID is present.
+func isDomainlessGmsaPluginInstalled() (bool, error) {
+	subKeys, err := fnQueryDomainlessGmsaPluginSubKeys()
+	if err != nil {
+		seelog.Errorf("Failed to query gmsa plugin subkeys")
+		return false, err
+	}
+
+	for _, subKey := range subKeys {
+		if subKey == gmsaPluginGUID {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }

--- a/agent/config/parse_windows_test.go
+++ b/agent/config/parse_windows_test.go
@@ -51,3 +51,63 @@ func TestParseFSxWindowsFileServerCapability(t *testing.T) {
 
 	assert.False(t, parseFSxWindowsFileServerCapability().Enabled())
 }
+
+func TestParseDomainlessgMSACapabilityFalseOnW2016(t *testing.T) {
+	IsWindows2016 = func() (bool, error) {
+		return true, nil
+	}
+
+	os.Setenv("ECS_GMSA_SUPPORTED", "True")
+	defer os.Unsetenv("ECS_GMSA_SUPPORTED")
+
+	fnQueryDomainlessGmsaPluginSubKeys = func() ([]string, error) {
+		return []string{}, nil
+	}
+
+	assert.False(t, parseGMSADomainlessCapability().Enabled())
+}
+
+func TestParseDomainlessgMSACapabilityFalsePluginNoEnv(t *testing.T) {
+	IsWindows2016 = func() (bool, error) {
+		return false, nil
+	}
+
+	os.Setenv("ECS_GMSA_SUPPORTED", "False")
+	defer os.Unsetenv("ECS_GMSA_SUPPORTED")
+
+	fnQueryDomainlessGmsaPluginSubKeys = func() ([]string, error) {
+		return []string{"{859E1386-BDB4-49E8-85C7-3070B13920E1}"}, nil
+	}
+
+	assert.False(t, parseGMSADomainlessCapability().Enabled())
+}
+
+func TestParseDomainlessgMSACapabilityFalseNoPlugin(t *testing.T) {
+	IsWindows2016 = func() (bool, error) {
+		return false, nil
+	}
+
+	os.Setenv("ECS_GMSA_SUPPORTED", "True")
+	defer os.Unsetenv("ECS_GMSA_SUPPORTED")
+
+	fnQueryDomainlessGmsaPluginSubKeys = func() ([]string, error) {
+		return []string{}, nil
+	}
+
+	assert.False(t, parseGMSADomainlessCapability().Enabled())
+}
+
+func TestParseDomainlessgMSACapabilityTrue(t *testing.T) {
+	IsWindows2016 = func() (bool, error) {
+		return false, nil
+	}
+
+	os.Setenv("ECS_GMSA_SUPPORTED", "True")
+	defer os.Unsetenv("ECS_GMSA_SUPPORTED")
+
+	fnQueryDomainlessGmsaPluginSubKeys = func() ([]string, error) {
+		return []string{"{859E1386-BDB4-49E8-85C7-3070B13920E1}"}, nil
+	}
+
+	assert.True(t, parseGMSADomainlessCapability().Enabled())
+}

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -331,6 +331,10 @@ type Config struct {
 	// It should be enabled by default only if the container instance is part of a valid active directory domain.
 	GMSACapable BooleanDefaultFalse
 
+	// GMSADomainlessCapable is the config option to indicate if gMSA domainless is supported.
+	// It should be enabled by if the container instance has a plugin to support active directory authentication.
+	GMSADomainlessCapable BooleanDefaultFalse
+
 	// VolumePluginCapabilities specifies the capabilities of the ecs volume plugin.
 	VolumePluginCapabilities []string
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This PR is advertises the new domainless gmsa capability on the Windows ECS agent. The Linux agent will be coming in a followup PR. 

### Implementation details
<!-- How are the changes implemented? -->
The Windows agent will advertise the gmsa capability only under the following 3 conditions

1. Environment variable is set 
2. The windows instance must not be 2016
3. The domainless gMSA plugin must be installed 

### Testing
<!-- How was this tested? -->

<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
This change was unit tested as well as tested on a Windows EC2 instance and describe-container-instance was called to ensure that the capability was correctly advertised. It was also run on an old Windows EC2 instance to ensure the capability was not advertised. 

New tests cover the changes: <!-- yes --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Advertise gmsa domainless capability on Windows Agent
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
