### PR TITLE
windows: support special characters in the password for FSx

### DIFF
--- a/agent/taskresource/fsxwindowsfileserver/fsxwindowsfileserver_windows.go
+++ b/agent/taskresource/fsxwindowsfileserver/fsxwindowsfileserver_windows.go
@@ -45,6 +45,7 @@ import (
 )
 
 const (
+	psCredentialCommandFormat = "$(New-Object System.Management.Automation.PSCredential('%s', $(ConvertTo-SecureString '%s' -AsPlainText -Force)))"
 	resourceProvisioningError = "VolumeError: Agent could not create task's volume resources"
 )
 
@@ -548,8 +549,12 @@ func (fv *FSxWindowsFileServerResource) performHostMount(remotePath string, user
 	}
 
 	// formatting to keep powershell happy
-	creds := fmt.Sprintf("-Credential $(New-Object System.Management.Automation.PSCredential(\"%s\", $(ConvertTo-SecureString \"%s\" -AsPlainText -Force)))", username, password)
-	remotePathArg := fmt.Sprintf("-RemotePath \"%s\"", remotePath)
+	// Replace ' with '' so that Powershell would convert it back to '.
+	password = strings.ReplaceAll(password, "'", "''")
+	credsCommand := fmt.Sprintf(psCredentialCommandFormat, username, password)
+	credsArg := fmt.Sprintf("-Credential %s", credsCommand)
+
+	remotePathArg := fmt.Sprintf("-RemotePath '%s'", remotePath)
 
 	// New-SmbGlobalMapping cmdlet creates an SMB mapping between the container instance
 	// and SMB share (FSx for Windows File Server file-system)
@@ -558,7 +563,7 @@ func (fv *FSxWindowsFileServerResource) performHostMount(remotePath string, user
 		"New-SmbGlobalMapping",
 		localPathArg,
 		remotePathArg,
-		creds,
+		credsArg,
 		"-Persistent $true",
 		"-RequirePrivacy $true",
 		"-ErrorAction Stop",

--- a/agent/taskresource/fsxwindowsfileserver/fsxwindowsfileserver_windows_test.go
+++ b/agent/taskresource/fsxwindowsfileserver/fsxwindowsfileserver_windows_test.go
@@ -18,6 +18,7 @@ package fsxwindowsfileserver
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"testing"
@@ -708,5 +709,19 @@ func TestClearFSxWindowsFileServerResource(t *testing.T) {
 	defer func() { execCommand = exec.Command }()
 
 	err := fv.Cleanup()
+	assert.NoError(t, err)
+}
+
+func TestSpecialCharactersInPasswordPSCommand(t *testing.T) {
+	username := "Administrator"
+	password := "AWS@`~!@#$var%^&*()/1asd"
+
+	credsCommand := fmt.Sprintf(psCredentialCommandFormat, username, password)
+
+	// Perform actual exec to determine if the credentials are generated.
+	// Go tests are platform specific and therefore, this would work.
+	cmd := exec.Command("powershell.exe", credsCommand)
+	_, err := cmd.CombinedOutput()
+
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
### Summary
Presently, When a password contains characters that contain escape sequences such as a quotation mark PowerShell fails the command. Reference: https://github.com/aws/amazon-ecs-agent/issues/3270

To mitigate the same and support handling of special characters, we are making the change to use single quoted strings. This means that the password is passed-on to Powershell as it is without any substitutions. Reference: https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_quoting_rules?view=powershell-5.1#single-quoted-strings

### Implementation details
<!-- How are the changes implemented? -->

Instead of using double quotes, we are using single quotes which means that Powershell would be passed-on a value without any substitution.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Created an ECS instance with the custom agent. We used a password which had many special characters.
Tested that the task with FSx volume was running successfully on the instance,


New tests cover the changes: <!-- yes|no -->
Yes
### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
windows: support special characters in the password for FSx
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
