### PR TITLE
Client Model changes to parse credentialSpecs

### DIFF
--- a/agent/ecs_client/model/api/api-2.json
+++ b/agent/ecs_client/model/api/api-2.json
@@ -813,6 +813,7 @@
         "dnsSearchDomains":{"shape":"StringList"},
         "extraHosts":{"shape":"HostEntryList"},
         "dockerSecurityOptions":{"shape":"StringList"},
+        "credentialSpecs":{"shape":"StringList"},
         "interactive":{"shape":"BoxedBoolean"},
         "pseudoTerminal":{"shape":"BoxedBoolean"},
         "dockerLabels":{"shape":"DockerLabelsMap"},

--- a/agent/ecs_client/model/ecs/api.go
+++ b/agent/ecs_client/model/ecs/api.go
@@ -4980,6 +4980,8 @@ type ContainerDefinition struct {
 	// of CPU that is described in the task definition.
 	Cpu *int64 `locationName:"cpu" type:"integer"`
 
+	CredentialSpecs []*string `locationName:"credentialSpecs" type:"list"`
+
 	DependsOn []*ContainerDependency `locationName:"dependsOn" type:"list"`
 
 	// When this parameter is true, networking is disabled within the container.
@@ -5442,6 +5444,12 @@ func (s *ContainerDefinition) SetCommand(v []*string) *ContainerDefinition {
 // SetCpu sets the Cpu field's value.
 func (s *ContainerDefinition) SetCpu(v int64) *ContainerDefinition {
 	s.Cpu = &v
+	return s
+}
+
+// SetCredentialSpecs sets the CredentialSpecs field's value.
+func (s *ContainerDefinition) SetCredentialSpecs(v []*string) *ContainerDefinition {
+	s.CredentialSpecs = v
 	return s
 }
 

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/acs/model/ecsacs/api.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/acs/model/ecsacs/api.go
@@ -487,6 +487,8 @@ type Container struct {
 
 	Cpu *int64 `locationName:"cpu" type:"integer"`
 
+	CredentialSpecs []*string `locationName:"credentialSpecs" type:"list"`
+
 	DependsOn []*ContainerDependency `locationName:"dependsOn" type:"list"`
 
 	DockerConfig *DockerConfig `locationName:"dockerConfig" type:"structure"`

--- a/ecs-agent/acs/model/api/api-2.json
+++ b/ecs-agent/acs/model/api/api-2.json
@@ -275,6 +275,7 @@
       "members":{
         "command":{"shape":"StringList"},
         "cpu":{"shape":"Integer"},
+        "credentialSpecs":{"shape":"StringList"},
         "entryPoint":{"shape":"StringList"},
         "environment":{"shape":"EnvironmentVariables"},
         "environmentFiles":{"shape":"EnvironmentFiles"},

--- a/ecs-agent/acs/model/ecsacs/api.go
+++ b/ecs-agent/acs/model/ecsacs/api.go
@@ -487,6 +487,8 @@ type Container struct {
 
 	Cpu *int64 `locationName:"cpu" type:"integer"`
 
+	CredentialSpecs []*string `locationName:"credentialSpecs" type:"list"`
+
 	DependsOn []*ContainerDependency `locationName:"dependsOn" type:"list"`
 
 	DockerConfig *DockerConfig `locationName:"dockerConfig" type:"structure"`


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR changes the acs client models to handle the new credentialSpecs field as part of the container definition

### Implementation details
<!-- How are the changes implemented? -->
The json files are changes, and then the generated go files are checked in. 

### Testing
<!-- How was this tested? -->
The change is manually tested by verifying through log lines that the credentialSpecs field is deserialized properly through ACS. 

<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Client Model changes to parse credentialSpecs

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
