### PR TITLE
Add default AES256 encryption and enable versioning for buckets in audit-logs, release-pipeline, and staging-bucket stacks

### DIFF
--- a/build-infrastructure/audit-logs-stack.yml
+++ b/build-infrastructure/audit-logs-stack.yml
@@ -51,6 +51,12 @@ Resources:
     Type: AWS::S3::BucketPolicy
     Properties:
       Bucket: !Sub 'audit-logs-bucket-${AWS::AccountId}'
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      VersioningConfiguration:
+        Status: Enabled
       PolicyDocument:
         Version: 2012-10-17
         Statement:

--- a/build-infrastructure/release-pipeline-stack.yml
+++ b/build-infrastructure/release-pipeline-stack.yml
@@ -117,6 +117,12 @@ Resources:
     Type: AWS::S3::Bucket
     Properties:
       BucketName: !Sub 'codepipeline-${AWS::Region}-${AWS::AccountId}-artifacts'
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      VersioningConfiguration:
+        Status: Enabled
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
         BlockPublicPolicy: true

--- a/build-infrastructure/staging-bucket-stack.yml
+++ b/build-infrastructure/staging-bucket-stack.yml
@@ -16,6 +16,12 @@ Resources:
     Type: AWS::S3::Bucket
     Properties:
       BucketName: !Sub '${StagingBucketNamePrefix}-${AWS::Region}-${AWS::AccountId}'
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      VersioningConfiguration:
+        Status: Enabled
 
   StagingArtifactsBucketPolicy:
     Type: AWS::S3::BucketPolicy


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Add default AES256 encryption and enable versioning for buckets in audit-logs, release-pipeline, and staging-bucket CFN templates. AES256 Encryption is already enabled on the buckets by default so the encryption change in the stack template should be a no-op. Versioning will be enabled when the stack is updated. 

Only the release-pipeline stack actually exists, so we will only update that stack. 

### Implementation details
Update the CFN templates with `BucketEncryption` and `VersioningConfiguration` properties.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Add default AES256 encryption and enable versioning for buckets in audit-logs, release-pipeline, and staging-bucket stacks.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
