### PR TITLE
Task state change logging: use logger.Fields instead of plain strings

### DIFF
--- a/agent/eventhandler/task_handler_types.go
+++ b/agent/eventhandler/task_handler_types.go
@@ -15,7 +15,6 @@ package eventhandler
 
 import (
 	"container/list"
-	"fmt"
 	"sync"
 
 	"github.com/aws/amazon-ecs-agent/agent/logger"
@@ -152,27 +151,19 @@ func (event *sendableEvent) send(
 	backoff retry.Backoff,
 	taskEvents *taskSendableEvents) error {
 
-	logger.Info("Sending state change to ECS", logger.Fields{
-		"eventType": eventType,
-		"eventData": event.toString(),
-	})
+	fields := event.toFields()
+	logger.Info("Sending state change to ECS", fields)
 	// Try submitting the change to ECS
 	if err := sendStatusToECS(client, event); err != nil {
-		logger.Error("Unretriable error sending state change to ECS", logger.Fields{
-			"eventType": eventType,
-			"eventData": event.toString(),
-			field.Error: err,
-		})
+		fields[field.Error] = err
+		logger.Error("Unretriable error sending state change to ECS", fields)
 		return err
 	}
 	// submitted; ensure we don't retry it
 	event.setSent()
 	// Mark event as sent
 	setChangeSent(event, dataClient)
-	logger.Debug("Submitted state change to ECS", logger.Fields{
-		"eventType": eventType,
-		"eventData": event.toString(),
-	})
+	logger.Debug("Submitted state change to ECS", fields)
 	taskEvents.events.Remove(eventToSubmit)
 	backoff.Reset()
 	return nil
@@ -234,14 +225,14 @@ func setTaskAttachmentSent(event *sendableEvent, dataClient data.Client) {
 	}
 }
 
-func (event *sendableEvent) toString() string {
+func (event *sendableEvent) toFields() logger.Fields {
 	event.lock.RLock()
 	defer event.lock.RUnlock()
 
 	if event.isContainerEvent {
-		return "ContainerChange: [" + event.containerChange.String() + fmt.Sprintf("] sent: %t", event.containerSent)
+		return event.containerChange.ToFields()
 	} else {
-		return "TaskChange: [" + event.taskChange.String() + fmt.Sprintf("] sent: %t", event.taskSent)
+		return event.taskChange.ToFields()
 	}
 }
 

--- a/agent/eventhandler/task_handler_types_test.go
+++ b/agent/eventhandler/task_handler_types_test.go
@@ -257,7 +257,7 @@ func TestShouldTaskEventBeSent(t *testing.T) {
 			shouldBeSent: false,
 		},
 	} {
-		t.Run(fmt.Sprintf("Event[%s] should be sent[%t]", tc.event.toString(), tc.shouldBeSent), func(t *testing.T) {
+		t.Run(fmt.Sprintf("Event[%v] should be sent[%t]", tc.event.toFields(), tc.shouldBeSent), func(t *testing.T) {
 			assert.Equal(t, tc.shouldBeSent, tc.event.taskShouldBeSent())
 			assert.Equal(t, false, tc.event.containerShouldBeSent())
 			assert.Equal(t, false, tc.event.taskAttachmentShouldBeSent())
@@ -331,8 +331,8 @@ func TestShouldTaskAttachmentEventBeSent(t *testing.T) {
 			taskShouldBeSent:       false,
 		},
 	} {
-		t.Run(fmt.Sprintf("Event[%s] should be sent[attachment=%t;task=%t]",
-			tc.event.toString(), tc.attachmentShouldBeSent, tc.taskShouldBeSent), func(t *testing.T) {
+		t.Run(fmt.Sprintf("Event[%v] should be sent[attachment=%t;task=%t]",
+			tc.event.toFields(), tc.attachmentShouldBeSent, tc.taskShouldBeSent), func(t *testing.T) {
 			assert.Equal(t, tc.attachmentShouldBeSent, tc.event.taskAttachmentShouldBeSent())
 			assert.Equal(t, tc.taskShouldBeSent, tc.event.taskShouldBeSent())
 			assert.Equal(t, false, tc.event.containerShouldBeSent())


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

Refactor log messages for sending state changes to ECS to use logger.Fields and make container state change strings more readable.

In addition to refactoring the format, have also added the container runtime ID(s) and essential status.

from this: 
`
level=info time=2023-05-03T21:47:39Z msg="Sending state change to ECS" eventType="task" eventData="TaskChange: [arn:aws:ecs:us-west-2:039193556298:task/usw2/53669439b60a420dbbf59d2ecaf5206f -> STOPPED, Known Sent: RUNNING, PullStartedAt: 2023-05-03 21:44:48.851603466 +0000 UTC, PullStoppedAt: 2023-05-03 21:44:50.425831882 +0000 UTC, ExecutionStoppedAt: 2023-05-03 21:47:39.738389362 +0000 UTC m=+1.237742685, container change: arn:aws:ecs:us-west-2:039193556298:task/usw2/53669439b60a420dbbf59d2ecaf5206f main -> STOPPED, Exit 137, , Known Sent: RUNNING] sent: false"
`

to this:
`
level=info time=2023-05-04T22:48:12Z msg="Sending state change to ECS" eventType="TaskStateChange" taskStatus="STOPPED" reason="" taskPullStartedAt="2023-05-04T21:56:30Z" taskExecutionStoppedAt="2023-05-04T22:48:12Z" containerChange-0="containerName=main containerStatus=STOPPED containerExitCode=137 containerKnownSentStatus=RUNNING containerRuntimeID=32745980a9121de4a8a39d91ceb35ff74a77737f25ce1de9b8a8dead166306cc containerIsEssential=true" taskArn="arn:aws:ecs:us-west-2:039193556298:task/usw2/8d73d245d6794ff695b1fcf14f8934da" taskKnownSentStatus="RUNNING" taskPullStoppedAt="2023-05-04T21:56:32Z"
`

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

make release

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

NA

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
