### PR TITLE
Plumb credentialSpecs field into container

### DIFF
--- a/agent/api/container/container.go
+++ b/agent/api/container/container.go
@@ -87,6 +87,10 @@ const (
 
 	// neuronVisibleDevicesEnvVar is the env which indicates that the container wants to use inferentia devices.
 	neuronVisibleDevicesEnvVar = "AWS_NEURON_VISIBLE_DEVICES"
+
+	credentialSpecPrefix = "credentialspec"
+
+	credentialSpecDomainlessPrefix = credentialSpecPrefix + "domainless"
 )
 
 var (
@@ -199,6 +203,8 @@ type Container struct {
 	Overrides ContainerOverrides `json:"overrides"`
 	// DockerConfig is the configuration used to create the container
 	DockerConfig DockerConfig `json:"dockerConfig"`
+	// CredentialSpecs is the configuration used for configuring gMSA authentication for the container
+	CredentialSpecs []string `json:"credentialSpecs,omitempty"`
 	// RegistryAuthentication is the auth data used to pull image
 	RegistryAuthentication *RegistryAuthenticationData `json:"registryAuthentication"`
 	// HealthCheckType is the mechanism to use for the container health check
@@ -1350,6 +1356,22 @@ func (c *Container) GetCredentialSpec() (string, error) {
 }
 
 func (c *Container) getCredentialSpec() (string, error) {
+	credSpecHostConfig, err := c.getCredentialSpecFromHostConfig()
+	credSpecCredentialSpecsContainerField, err2 := c.getCredentialSpecFromCredentialSpecsContainerField()
+
+	// Prefer to use CredentialSpecsContainerField because of the upcoming docker runtime deprecation
+	if err2 == nil {
+		return credSpecCredentialSpecsContainerField, nil
+	}
+
+	if err == nil {
+		return credSpecHostConfig, nil
+	}
+
+	return "", errors.New("unable to obtain credentialspec from both hostConfig and credentialSpecs")
+}
+
+func (c *Container) getCredentialSpecFromHostConfig() (string, error) {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 
@@ -1364,12 +1386,29 @@ func (c *Container) getCredentialSpec() (string, error) {
 	}
 
 	for _, opt := range hostConfig.SecurityOpt {
-		if strings.HasPrefix(opt, "credentialspec") {
+		if strings.HasPrefix(opt, credentialSpecPrefix) {
 			return opt, nil
 		}
 	}
 
 	return "", errors.New("unable to obtain credentialspec")
+}
+
+func (c *Container) getCredentialSpecFromCredentialSpecsContainerField() (string, error) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	if c.CredentialSpecs == nil || len(c.CredentialSpecs) == 0 {
+		return "", errors.New("empty container credentialSpecs")
+	}
+
+	for _, credentialSpec := range c.CredentialSpecs {
+		if strings.HasPrefix(credentialSpec, credentialSpecPrefix) || strings.HasPrefix(credentialSpec, credentialSpecDomainlessPrefix) {
+			return credentialSpec, nil
+		}
+	}
+
+	return "", errors.New("credentialspec not found in CredentialSpecs field")
 }
 
 func (c *Container) GetManagedAgentStatus(agentName string) apicontainerstatus.ManagedAgentStatus {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR adds the credentialSpecs field into the agent container object, and then modifies the getCredentialSpec function to look in the credentialSpecs field when attempting to retrieve any credentialSpecs associated with the container. 
### Implementation details

<!-- How are the changes implemented? -->
The changes to getCredentialSpec() are implemented in the following

1. First check the container credentialSpecs field for the credentialSpec
2. Then check the docker HostConfig field for the credentialSpec 
3. If none are found in both locations, throw error

### Testing
<!-- How was this tested? -->
This was tested through unit tests, as well as manually running the agent on the instance, calling run-task with a domainless gMSA task, and printing out the contents of the container object. 

<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Plumb credentialSpecs field into container

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
