### PR TITLE
More structured logging for Task object

### DIFF
--- a/agent/eventhandler/task_handler.go
+++ b/agent/eventhandler/task_handler.go
@@ -184,9 +184,8 @@ func (handler *TaskHandler) startDrainEventsTicker() {
 			// the tasksToContainerStates and tasksToManagedAgentStates maps based on the
 			// task arns of containers and managed agents that haven't been sent to ECS yet.
 			for _, taskEvent := range handler.taskStateChangesToSend() {
-				seelog.Infof(
-					"TaskHandler: Adding a state change event to send batched container/managed agent events: %s",
-					taskEvent.String())
+				logger.Debug("TaskHandler: Adding a state change event to send batched container/managed agent events",
+					taskEvent.ToFields())
 				// Force start the the task state change submission
 				// workflow by calling AddStateChangeEvent method.
 				handler.AddStateChangeEvent(taskEvent, handler.client)


### PR DESCRIPTION
also downgrade log message 'Adding a state change event to send' to DEBUG from INFO, since this log message is redundantly logged twice whenever there is a state change, since we also log the state change when we send it to ECS, like this:

`
level=info time=2023-05-05T22:17:23Z msg="TaskHandler: Adding a state change event to send batched container/managed agent events: arn:aws:ecs:us-west-2:XXX:task/usw2/XXX -> RUNNING, Known Sent: RUNNING, PullStartedAt: 2023-05-05 22:16:44.14108352 +0000 UTC m=+435.253624196, PullStoppedAt: 2023-05-05 22:16:44.3532973 +0000 UTC m=+435.465837967, ExecutionStoppedAt: 0001-01-01 00:00:00 +0000 UTC" module=task_handler.go
`
`
level=info time=2023-05-05T22:17:23Z msg="Sending state change to ECS" taskArn="arn:aws:ecs:us-west-2:XXX:task/usw2/XXX" taskStatus="RUNNING" taskReason="" taskPullStartedAt="2023-05-05T22:16:44Z" eventType="TaskStateChange" taskKnownSentStatus="RUNNING" taskPullStoppedAt="2023-05-05T22:16:44Z" taskExecutionStoppedAt="0001-01-01T00:00:00Z" containerChange-0="containerName=nonessential containerStatus=STOPPED containerExitCode=0 containerKnownSentStatus=RUNNING containerRuntimeID=9bd88a86abd927421788d5aae9c4ec95b42b16e6d98a5b43940f084b60a1a91d containerIsEssential=false"
`

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

make release and run

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

NA

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
