### PR TITLE
Update Release CodePipeline to update and upload agentVersionV2-<branch>.json file

### DIFF
--- a/build-infrastructure/release-pipeline-stack.yml
+++ b/build-infrastructure/release-pipeline-stack.yml
@@ -95,6 +95,9 @@ Parameters:
   GithubBranchName:
     Type: String
     Description: The name of the branch to use to build (e.g. mainline, dev)
+  GithubSourceBranchName:
+    Type: String
+    Description: The name of the source branch (e.g. dev, featureBranch)
   SecretKeyArn:
     Type: String
     Description: The ARN of the secret key
@@ -673,6 +676,12 @@ Resources:
                   - s3:GetObjectVersion
                   - s3:GetBucketAcl
                   - s3:GetBucketLocation
+              - Sid: ResultsBucketAccess
+                Effect: Allow
+                Resource:
+                  - !Ref ReleaseArtifactsBucketArn
+                  - !Sub '${ReleaseArtifactsBucketArn}/*'
+                Action: s3:*
               - Sid: CodeBuildCreateReportAccess
                 Effect: Allow
                 Resource:
@@ -698,6 +707,13 @@ Resources:
         ComputeType: BUILD_GENERAL1_SMALL
         ImagePullCredentialsType: CODEBUILD
         Image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+        EnvironmentVariables:
+          - Name: RESULTS_BUCKET_URI
+            Type: PLAINTEXT
+            Value: !Ref ReleaseArtifactsBucketS3Uri
+          - Name: GITHUB_SOURCE_BRANCH_NAME
+            Type: PLAINTEXT
+            Value: !Ref GithubSourceBranchName
       Source:
         BuildSpec: buildspecs/release-config.yml
         Type: CODEPIPELINE
@@ -779,6 +795,9 @@ Resources:
           - Name: RESULTS_BUCKET_URI
             Type: PLAINTEXT
             Value: !Ref ReleaseArtifactsBucketS3Uri
+          - Name: GITHUB_SOURCE_BRANCH_NAME
+            Type: PLAINTEXT
+            Value: !Ref GithubSourceBranchName
       Source:
         BuildSpec: buildspecs/copy.yml
         Type: CODEPIPELINE

--- a/buildspecs/copy.yml
+++ b/buildspecs/copy.yml
@@ -9,6 +9,8 @@ phases:
     commands:
       # Copy release config
       - aws s3 cp $CODEBUILD_SRC_DIR_JSONArtifact/agent.json "$RESULTS_BUCKET_URI/$GIT_COMMIT_SHA/agent.json"
+      # Copy the updated agentVersionV2-<branch>.json file
+      - aws s3 cp $CODEBUILD_SRC_DIR_JSONArtifact/agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}.json "$RESULTS_BUCKET_URI/agentVersionV2/agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}.json"
       
       # since the buildspecs are the primary artifacts, we need to change directory
       - cd $CODEBUILD_SRC_DIR_SignedArtifact

--- a/buildspecs/release-config.yml
+++ b/buildspecs/release-config.yml
@@ -57,6 +57,21 @@ phases:
         }
         EOF
 
+      # Copying over the existing agentVersionV2-<branch>.json file
+      - aws s3 cp ${RESULTS_BUCKET_URI}/agentVersionV2/agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}.json ./agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}.json
+      # Grabbing the old release agent version (will be the new current agent version)
+      - CURR_VER=$(jq -r '.agentReleaseVersion' agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}.json)
+
+      # Checking to see if there's a new release agent version to be released
+      - |
+        if [[ ! $AGENT_VERSION =~ "${CURR_VER}" ]] ; then
+          # Updating the agentVersionV2-<branch>.json file with new current and release agent versions and copying it to a temp file
+          cat <<< $(jq '.agentReleaseVersion = '\"$AGENT_VERSION\"' | .agentCurrentVersion = '\"$CURR_VER\"'' agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}.json) > agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}-COPY.json
+          # Replace existing agentVersionV2-<branch>.json file with the temp file
+          jq . agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}-COPY.json > agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}.json
+        fi
+
 artifacts:
   files:
     - agent.json
+    - agentVersionV2-${GITHUB_SOURCE_BRANCH_NAME}.json


### PR DESCRIPTION
### Summary
This PR will modify our current release CodePipeline project to generate and copy over a new release config file called agentVersionV2-.json file which will be used in our release process in the near future. The `<branch>` refers to the tracking branch that will be used. (e.g. `agentVersionV2-featureBranch.json`), in this case it'll be `dev`. 

(Note: This duplicates PR #3611 which has already been approved and merged. We'll have to manually update the CodePipeline project )

### Implementation details
build-infrastructure/release-pipeline-stack.yml
- Added a new parameter called GithubSourceBranchName which will be passed in as an environment variable for the MakeJSON and Copy stages in order to refer to the tracking branch
- Updated the policy for the MakeJSON CodeBuild service role to have permission to access the release bucket

buildspecs/copy.yml
- Copying over the new agentVersionV2-.json file along with the rest of the configs/artifacts

buildspecs/release-config.yml
- Grabbing an existing/older version of agentVersionv2-.json file from the release bucket (Note: Will need to manually create one first)
- Updating the agentVersionv2-.json file only if there's a new agent release version

(Note: These changes will need to be manually applied to the CodePipeline project)

### Testing

The release CodePipeline was replicated within my personal dev account along with these changes applied to it. No issues occurred while kicking off the release CodePipeline.

### Description for the changelog

- Feature: Add new release config file called agentVersionV2-.json to our release CodePipeline project
### Licensing

### Related PR
- https://github.com/aws/amazon-ecs-agent/pull/3611

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
