### PR TITLE
Channel based docker stats engine implementation (DockerStatsEngine -> TCSClient)

### DIFF
--- a/agent/app/agent.go
+++ b/agent/app/agent.go
@@ -100,9 +100,11 @@ const (
 	asgLifecyclePollMax            = 120 // given each poll cycle waits for about a minute, this gives 2-3 hours before timing out
 
 	// By default, TCS (or TACS) will reject metrics that are older than 5 minutes. Since our metrics collection interval
-	// is currently set to 20 seconds, setting a buffer size of 15 for each task and targeting at 1000 tasks (currently known maximum ~500)
-	// allows us to store exactly 5 minutes of metrics in these buffers in the case where we temporarily lose connect to TCS.
-	telemetryChannelDefaultBufferSize = 15000
+	// is currently set to 20 seconds, setting a buffer size of 15 allows us to store exactly 5 minutes of metrics in
+	// these buffers in the case where we temporarily lose connect to TCS. This value does not change with task number,
+	// as the number of messages in the channel is equal to the number of times we call `getInstanceMetrics`, which collects
+	// metrics from all tasks and containers and put them into one TelemetryMessage object.
+	telemetryChannelDefaultBufferSize = 15
 )
 
 var (

--- a/agent/stats/engine.go
+++ b/agent/stats/engine.go
@@ -48,6 +48,15 @@ const (
 	queueResetThreshold    = 2 * dockerclient.StatsInactivityTimeout
 	hostNetworkMode        = "host"
 	noneNetworkMode        = "none"
+	// defaultPublishServiceConnectTicker is every 3rd time service connect metrics will be sent to the backend
+	// Task metrics are published at 20s interval, thus task's service metrics will be published 60s.
+	defaultPublishServiceConnectTicker = 3
+	// publishMetricsTimeout is the duration that we wait for metrics/health info to be
+	// pushed to the TCS channels. In theory, this timeout should never be hit since
+	// the TCS handler should be continually reading from the channels and pushing to
+	// TCS, but when we lose connection to TCS, these channels back up. In case this
+	// happens, we need to have a timeout to prevent statsEngine channels from blocking.
+	publishMetricsTimeout = 1 * time.Second
 )
 
 var (
@@ -100,9 +109,8 @@ type DockerStatsEngine struct {
 	publishServiceConnectTickerInterval int32
 	publishMetricsTicker                *time.Ticker
 	// channels to send metrics to TACS Client
-	metricsChannel        chan<- ecstcs.TelemetryMessage
-	healthChannel         chan<- ecstcs.HealthMessage
-	instanceStatusChannel chan<- ecstcs.InstanceStatusMessage
+	metricsChannel chan<- ecstcs.TelemetryMessage
+	healthChannel  chan<- ecstcs.HealthMessage
 }
 
 // ResolveTask resolves the api task object, given container id.
@@ -146,8 +154,7 @@ func (resolver *DockerContainerMetadataResolver) ResolveContainer(dockerID strin
 // NewDockerStatsEngine creates a new instance of the DockerStatsEngine object.
 // MustInit() must be called to initialize the fields of the new event listener.
 func NewDockerStatsEngine(cfg *config.Config, client dockerapi.DockerClient, containerChangeEventStream *eventstream.EventStream,
-	metricsChannel chan<- ecstcs.TelemetryMessage, healthChannel chan<- ecstcs.HealthMessage,
-	instanceStatusChannel chan<- ecstcs.InstanceStatusMessage) *DockerStatsEngine {
+	metricsChannel chan<- ecstcs.TelemetryMessage, healthChannel chan<- ecstcs.HealthMessage) *DockerStatsEngine {
 	return &DockerStatsEngine{
 		client:                              client,
 		resolver:                            nil,
@@ -161,7 +168,6 @@ func NewDockerStatsEngine(cfg *config.Config, client dockerapi.DockerClient, con
 		publishServiceConnectTickerInterval: 0,
 		metricsChannel:                      metricsChannel,
 		healthChannel:                       healthChannel,
-		instanceStatusChannel:               instanceStatusChannel,
 	}
 }
 
@@ -428,6 +434,77 @@ func (engine *DockerStatsEngine) addToStatsContainerMapUnsafe(
 	taskToContainerMap[taskARN][containerID] = statsContainer
 
 	return true
+}
+
+// StartMetricsPublish starts to collect and publish task and health metrics
+func (engine *DockerStatsEngine) StartMetricsPublish() {
+	if engine.publishMetricsTicker == nil {
+		seelog.Debug("Skipping reporting metrics through channel. Publish ticker is uninitialized")
+		return
+	}
+
+	// Publish metrics immediately after we start the loop and wait for ticks. This makes sure TACS side has correct
+	// TaskCount metrics in CX account (especially for short living tasks)
+	engine.publishMetrics(false)
+	engine.publishHealth()
+
+	for {
+		var includeServiceConnectStats bool
+		metricCounter := engine.GetPublishServiceConnectTickerInterval()
+		metricCounter++
+		if metricCounter == defaultPublishServiceConnectTicker {
+			includeServiceConnectStats = true
+			metricCounter = 0
+		}
+		engine.SetPublishServiceConnectTickerInterval(metricCounter)
+		select {
+		case <-engine.publishMetricsTicker.C:
+			seelog.Debugf("publishMetricsTicker triggered. Sending telemetry messages to tcsClient through channel")
+			go engine.publishMetrics(includeServiceConnectStats)
+			go engine.publishHealth()
+		case <-engine.ctx.Done():
+			return
+		}
+	}
+}
+
+func (engine *DockerStatsEngine) publishMetrics(includeServiceConnectStats bool) {
+	publishMetricsCtx, cancel := context.WithTimeout(engine.ctx, publishMetricsTimeout)
+	defer cancel()
+	metricsMetadata, taskMetrics, metricsErr := engine.GetInstanceMetrics(includeServiceConnectStats)
+	if metricsErr == nil {
+		select {
+		case engine.metricsChannel <- ecstcs.TelemetryMessage{
+			Metadata:                   metricsMetadata,
+			TaskMetrics:                taskMetrics,
+			IncludeServiceConnectStats: includeServiceConnectStats,
+		}:
+			seelog.Debugf("sent telemetry message")
+		case <-publishMetricsCtx.Done():
+			seelog.Errorf("timeout sending telemetry message, discarding metrics")
+		}
+	} else {
+		seelog.Warnf("Error collecting task metrics: %v", metricsErr)
+	}
+}
+
+func (engine *DockerStatsEngine) publishHealth() {
+	publishHealthCtx, cancel := context.WithTimeout(engine.ctx, publishMetricsTimeout)
+	defer cancel()
+	healthMetadata, taskHealthMetrics, healthErr := engine.GetTaskHealthMetrics()
+	if healthErr == nil {
+		select {
+		case engine.healthChannel <- ecstcs.HealthMessage{
+			Metadata:      healthMetadata,
+			HealthMetrics: taskHealthMetrics,
+		}:
+			seelog.Debugf("sent health message")
+		case <-publishHealthCtx.Done():
+			seelog.Errorf("timeout sending health message, discarding metrics")
+		}
+	} else {
+		seelog.Warnf("Error collecting health metrics: %v", healthErr)
+	}
 }
 
 // GetInstanceMetrics gets all task metrics and instance metadata from stats engine.

--- a/agent/stats/engine.go
+++ b/agent/stats/engine.go
@@ -473,13 +473,14 @@ func (engine *DockerStatsEngine) publishMetrics(includeServiceConnectStats bool)
 	defer cancel()
 	metricsMetadata, taskMetrics, metricsErr := engine.GetInstanceMetrics(includeServiceConnectStats)
 	if metricsErr == nil {
-		select {
-		case engine.metricsChannel <- ecstcs.TelemetryMessage{
+		metricsMessage := ecstcs.TelemetryMessage{
 			Metadata:                   metricsMetadata,
 			TaskMetrics:                taskMetrics,
 			IncludeServiceConnectStats: includeServiceConnectStats,
-		}:
-			seelog.Debugf("sent telemetry message")
+		}
+		select {
+		case engine.metricsChannel <- metricsMessage:
+			seelog.Debugf("sent telemetry message: %v", metricsMessage)
 		case <-publishMetricsCtx.Done():
 			seelog.Errorf("timeout sending telemetry message, discarding metrics")
 		}
@@ -493,12 +494,13 @@ func (engine *DockerStatsEngine) publishHealth() {
 	defer cancel()
 	healthMetadata, taskHealthMetrics, healthErr := engine.GetTaskHealthMetrics()
 	if healthErr == nil {
-		select {
-		case engine.healthChannel <- ecstcs.HealthMessage{
+		healthMessage := ecstcs.HealthMessage{
 			Metadata:      healthMetadata,
 			HealthMetrics: taskHealthMetrics,
-		}:
-			seelog.Debugf("sent health message")
+		}
+		select {
+		case engine.healthChannel <- healthMessage:
+			seelog.Debugf("sent health message: %v", healthMessage)
 		case <-publishHealthCtx.Done():
 			seelog.Errorf("timeout sending health message, discarding metrics")
 		}

--- a/agent/stats/engine_integ_test.go
+++ b/agent/stats/engine_integ_test.go
@@ -62,7 +62,7 @@ func createRunningTask(networkMode string) *apitask.Task {
 
 func TestStatsEngineWithExistingContainersWithoutHealth(t *testing.T) {
 	// Create a new docker stats engine
-	engine := NewDockerStatsEngine(&cfg, dockerClient, eventStream("TestStatsEngineWithExistingContainersWithoutHealth"), nil, nil, nil)
+	engine := NewDockerStatsEngine(&cfg, dockerClient, eventStream("TestStatsEngineWithExistingContainersWithoutHealth"), nil, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 
@@ -127,7 +127,7 @@ func TestStatsEngineWithExistingContainersWithoutHealth(t *testing.T) {
 
 func TestStatsEngineWithNewContainersWithoutHealth(t *testing.T) {
 	// Create a new docker stats engine
-	engine := NewDockerStatsEngine(&cfg, dockerClient, eventStream("TestStatsEngineWithNewContainers"), nil, nil, nil)
+	engine := NewDockerStatsEngine(&cfg, dockerClient, eventStream("TestStatsEngineWithNewContainers"), nil, nil)
 	defer engine.removeAll()
 
 	// Assign ContainerStop timeout to addressable variable
@@ -199,7 +199,7 @@ func TestStatsEngineWithNewContainersWithoutHealth(t *testing.T) {
 
 func TestStatsEngineWithExistingContainers(t *testing.T) {
 	// Create a new docker stats engine
-	engine := NewDockerStatsEngine(&cfg, dockerClient, eventStream("TestStatsEngineWithExistingContainers"), nil, nil, nil)
+	engine := NewDockerStatsEngine(&cfg, dockerClient, eventStream("TestStatsEngineWithExistingContainers"), nil, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 
@@ -270,7 +270,7 @@ func TestStatsEngineWithExistingContainers(t *testing.T) {
 
 func TestStatsEngineWithNewContainers(t *testing.T) {
 	// Create a new docker stats engine
-	engine := NewDockerStatsEngine(&cfg, dockerClient, eventStream("TestStatsEngineWithNewContainers"), nil, nil, nil)
+	engine := NewDockerStatsEngine(&cfg, dockerClient, eventStream("TestStatsEngineWithNewContainers"), nil, nil)
 	defer engine.removeAll()
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
@@ -352,7 +352,7 @@ func TestStatsEngineWithNewContainersWithPolling(t *testing.T) {
 	// Create a new docker client with new config
 	dockerClientForNewContainersWithPolling, _ := dockerapi.NewDockerGoClient(sdkClientFactory, &cfg, ctx)
 	// Create a new docker stats engine
-	engine := NewDockerStatsEngine(&cfg, dockerClientForNewContainersWithPolling, eventStream("TestStatsEngineWithNewContainers"), nil, nil, nil)
+	engine := NewDockerStatsEngine(&cfg, dockerClientForNewContainersWithPolling, eventStream("TestStatsEngineWithNewContainers"), nil, nil)
 	defer engine.removeAll()
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
@@ -459,7 +459,7 @@ func TestStatsEngineWithDockerTaskEngine(t *testing.T) {
 		testTask)
 
 	// Create a new docker stats engine
-	statsEngine := NewDockerStatsEngine(&cfg, dockerClient, containerChangeEventStream, nil, nil, nil)
+	statsEngine := NewDockerStatsEngine(&cfg, dockerClient, containerChangeEventStream, nil, nil)
 	err = statsEngine.MustInit(ctx, taskEngine, defaultCluster, defaultContainerInstance)
 	require.NoError(t, err, "initializing stats engine failed")
 	defer statsEngine.removeAll()
@@ -542,7 +542,7 @@ func TestStatsEngineWithDockerTaskEngineMissingRemoveEvent(t *testing.T) {
 		testTask)
 
 	// Create a new docker stats engine
-	statsEngine := NewDockerStatsEngine(&cfg, dockerClient, containerChangeEventStream, nil, nil, nil)
+	statsEngine := NewDockerStatsEngine(&cfg, dockerClient, containerChangeEventStream, nil, nil)
 	err = statsEngine.MustInit(ctx, taskEngine, defaultCluster, defaultContainerInstance)
 	require.NoError(t, err, "initializing stats engine failed")
 	defer statsEngine.removeAll()
@@ -571,9 +571,8 @@ func TestStatsEngineWithDockerTaskEngineMissingRemoveEvent(t *testing.T) {
 
 	time.Sleep(checkPointSleep)
 
-	// Simulate tcs client invoking GetInstanceMetrics.
 	_, _, err = statsEngine.GetInstanceMetrics(false)
-	assert.Error(t, err, "expect error 'no task metrics tp report' when getting instance metrics")
+	assert.Error(t, err, "expect error 'no task metrics to report' when getting instance metrics")
 
 	// Should not contain any metrics after cleanup.
 	validateIdleContainerMetrics(t, statsEngine)
@@ -586,7 +585,7 @@ func TestStatsEngineWithNetworkStatsDefaultMode(t *testing.T) {
 
 func testNetworkModeStatsInteg(t *testing.T, networkMode string, statsEmpty bool) {
 	// Create a new docker stats engine
-	engine := NewDockerStatsEngine(&cfg, dockerClient, eventStream("TestStatsEngineWithNetworkStats"), nil, nil, nil)
+	engine := NewDockerStatsEngine(&cfg, dockerClient, eventStream("TestStatsEngineWithNetworkStats"), nil, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 
@@ -667,7 +666,7 @@ func testNetworkModeStatsInteg(t *testing.T, networkMode string, statsEmpty bool
 
 func TestStorageStats(t *testing.T) {
 	// Create a new docker stats engine
-	engine := NewDockerStatsEngine(&cfg, dockerClient, eventStream("TestStatsEngineWithStorageStats"), nil, nil, nil)
+	engine := NewDockerStatsEngine(&cfg, dockerClient, eventStream("TestStatsEngineWithStorageStats"), nil, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 

--- a/agent/stats/engine_test.go
+++ b/agent/stats/engine_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	mock_dockerapi "github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi/mocks"
 	mock_resolver "github.com/aws/amazon-ecs-agent/agent/stats/resolver/mock"
+	"github.com/aws/amazon-ecs-agent/agent/tcs/model/ecstcs"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/docker/docker/api/types"
@@ -41,9 +42,12 @@ import (
 )
 
 const (
-	DefaultNetworkMode = "default"
-	BridgeNetworkMode  = "bridge"
-	SCContainerName    = "service-connect"
+	DefaultNetworkMode                           = "default"
+	BridgeNetworkMode                            = "bridge"
+	SCContainerName                              = "service-connect"
+	testTelemetryChannelDefaultBufferSize        = 5000
+	testTelemetryChannelBufferSizeForChannelFull = 1
+	testPublishMetricsInterval                   = 5 * time.Second
 )
 
 func TestStatsEngineAddRemoveContainers(t *testing.T) {
@@ -71,8 +75,7 @@ func TestStatsEngineAddRemoveContainers(t *testing.T) {
 	mockStatsChannel := make(chan *types.StatsJSON)
 	defer close(mockStatsChannel)
 	mockDockerClient.EXPECT().Stats(gomock.Any(), gomock.Any(), gomock.Any()).Return(mockStatsChannel, nil).AnyTimes()
-
-	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestStatsEngineAddRemoveContainers"), nil, nil, nil)
+	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestStatsEngineAddRemoveContainers"), nil, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	engine.ctx = ctx
@@ -222,7 +225,7 @@ func TestStatsEngineMetadataInStatsSets(t *testing.T) {
 	mockDockerClient.EXPECT().Stats(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 	resolver.EXPECT().ResolveTaskByARN(gomock.Any()).Return(t1, nil).AnyTimes()
 
-	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestStatsEngineMetadataInStatsSets"), nil, nil, nil)
+	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestStatsEngineMetadataInStatsSets"), nil, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	engine.ctx = ctx
@@ -272,7 +275,7 @@ func TestStatsEngineMetadataInStatsSets(t *testing.T) {
 }
 
 func TestStatsEngineInvalidTaskEngine(t *testing.T) {
-	statsEngine := NewDockerStatsEngine(&cfg, nil, eventStream("TestStatsEngineInvalidTaskEngine"), nil, nil, nil)
+	statsEngine := NewDockerStatsEngine(&cfg, nil, eventStream("TestStatsEngineInvalidTaskEngine"), nil, nil)
 	taskEngine := &MockTaskEngine{}
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
@@ -283,7 +286,7 @@ func TestStatsEngineInvalidTaskEngine(t *testing.T) {
 }
 
 func TestStatsEngineUninitialized(t *testing.T) {
-	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestStatsEngineUninitialized"), nil, nil, nil)
+	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestStatsEngineUninitialized"), nil, nil)
 	defer engine.removeAll()
 
 	engine.resolver = &DockerContainerMetadataResolver{}
@@ -302,7 +305,7 @@ func TestStatsEngineTerminalTask(t *testing.T) {
 		KnownStatusUnsafe: apitaskstatus.TaskStopped,
 		Family:            "f1",
 	}, nil)
-	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestStatsEngineTerminalTask"), nil, nil, nil)
+	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestStatsEngineTerminalTask"), nil, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	engine.ctx = ctx
@@ -314,6 +317,221 @@ func TestStatsEngineTerminalTask(t *testing.T) {
 
 	engine.addAndStartStatsContainer("c1")
 	validateIdleContainerMetrics(t, engine)
+}
+
+func TestStartMetricsPublish(t *testing.T) {
+	testcases := []struct {
+		name                       string
+		hasPublishTicker           bool
+		expectedInstanceMessageNum int
+		expectedHealthMessageNum   int
+		expectedNonEmptyMetricsMsg bool
+		serviceConnectEnabled      bool
+		disableMetrics             bool
+		channelSize                int
+	}{
+		{
+			name:                       "NoPublishTicker",
+			hasPublishTicker:           false,
+			expectedInstanceMessageNum: 0,
+			expectedHealthMessageNum:   0,
+			expectedNonEmptyMetricsMsg: false,
+			serviceConnectEnabled:      false,
+			disableMetrics:             false,
+			channelSize:                testTelemetryChannelDefaultBufferSize,
+		},
+		{
+			name:                       "HappyCase",
+			hasPublishTicker:           true,
+			expectedInstanceMessageNum: 2, // 1 for immediate metrics publish, 1 for metrics publish after ticker
+			expectedHealthMessageNum:   2,
+			expectedNonEmptyMetricsMsg: true,
+			serviceConnectEnabled:      false,
+			disableMetrics:             false,
+			channelSize:                testTelemetryChannelDefaultBufferSize,
+		},
+		{
+			name:                       "MetricsDisabled",
+			hasPublishTicker:           true,
+			expectedInstanceMessageNum: 2,
+			expectedHealthMessageNum:   2,
+			expectedNonEmptyMetricsMsg: false,
+			serviceConnectEnabled:      false,
+			disableMetrics:             true,
+			channelSize:                testTelemetryChannelDefaultBufferSize,
+		},
+		{
+			name:                       "ChannelFull",
+			hasPublishTicker:           true,
+			expectedInstanceMessageNum: 1, // expecting discarding messages after channel is full
+			expectedHealthMessageNum:   1,
+			expectedNonEmptyMetricsMsg: true,
+			serviceConnectEnabled:      false,
+			disableMetrics:             false,
+			channelSize:                testTelemetryChannelBufferSizeForChannelFull,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			publishMetricsCfg := cfg
+			if tc.disableMetrics {
+				publishMetricsCfg.DisableMetrics = config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled}
+			}
+
+			containerID := "c1"
+			t1 := &apitask.Task{
+				Arn:               "t1",
+				Family:            "f1",
+				KnownStatusUnsafe: apitaskstatus.TaskRunning,
+				Containers: []*apicontainer.Container{
+					{Name: containerID},
+				},
+			}
+
+			mockDockerClient := mock_dockerapi.NewMockDockerClient(mockCtrl)
+			resolver := mock_resolver.NewMockContainerMetadataResolver(mockCtrl)
+
+			mockDockerClient.EXPECT().Stats(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+			mockDockerClient.EXPECT().InspectContainer(gomock.Any(), gomock.Any(), gomock.Any()).Return(&types.ContainerJSON{
+				ContainerJSONBase: &types.ContainerJSONBase{
+					ID:    containerID,
+					State: &types.ContainerState{Pid: 23},
+				},
+			}, nil).AnyTimes()
+
+			resolver.EXPECT().ResolveTask(containerID).AnyTimes().Return(t1, nil)
+			resolver.EXPECT().ResolveTaskByARN(gomock.Any()).Return(t1, nil).AnyTimes()
+			resolver.EXPECT().ResolveContainer(containerID).Return(&apicontainer.DockerContainer{
+				DockerID: containerID,
+				Container: &apicontainer.Container{
+					KnownStatusUnsafe: apicontainerstatus.ContainerRunning,
+					HealthCheckType:   "docker",
+					Health: apicontainer.HealthStatus{
+						Status: apicontainerstatus.ContainerHealthy,
+						Since:  aws.Time(time.Now()),
+					},
+				},
+			}, nil).AnyTimes()
+
+			telemetryMessages := make(chan ecstcs.TelemetryMessage, tc.channelSize)
+			healthMessages := make(chan ecstcs.HealthMessage, tc.channelSize)
+
+			engine := NewDockerStatsEngine(&publishMetricsCfg, nil, eventStream("TestStartMetricsPublish"), telemetryMessages, healthMessages)
+			ctx, cancel := context.WithCancel(context.TODO())
+			engine.ctx = ctx
+			engine.resolver = resolver
+			engine.cluster = defaultCluster
+			engine.containerInstanceArn = defaultContainerInstance
+			engine.client = mockDockerClient
+			ticker := time.NewTicker(testPublishMetricsInterval)
+			if !tc.hasPublishTicker {
+				ticker = nil
+			}
+			engine.publishMetricsTicker = ticker
+
+			engine.addAndStartStatsContainer(containerID)
+			ts1 := parseNanoTime("2015-02-12T21:22:05.131117533Z")
+
+			containerStats := createFakeContainerStats()
+			dockerStats := []*types.StatsJSON{{}, {}}
+			dockerStats[0].Read = ts1
+			containers, _ := engine.tasksToContainers["t1"]
+
+			// Two docker stats sample can be one CW stats.
+			for _, statsContainer := range containers {
+				for i := 0; i < 2; i++ {
+					statsContainer.statsQueue.add(containerStats[i])
+					statsContainer.statsQueue.setLastStat(dockerStats[i])
+				}
+			}
+
+			go engine.StartMetricsPublish()
+
+			// wait 1s for first set of metrics sent (immediately), and then add a second set of stats
+			time.Sleep(time.Second)
+			for _, statsContainer := range containers {
+				for i := 0; i < 2; i++ {
+					statsContainer.statsQueue.add(containerStats[i])
+					statsContainer.statsQueue.setLastStat(dockerStats[i])
+				}
+			}
+
+			time.Sleep(testPublishMetricsInterval + time.Second)
+
+			assert.Len(t, telemetryMessages, tc.expectedInstanceMessageNum)
+			assert.Len(t, healthMessages, tc.expectedHealthMessageNum)
+
+			if tc.expectedInstanceMessageNum > 0 {
+				telemetryMessage := <-telemetryMessages
+				if tc.expectedNonEmptyMetricsMsg {
+					assert.NotEmpty(t, telemetryMessage.TaskMetrics)
+					assert.NotZero(t, *telemetryMessage.TaskMetrics[0].ContainerMetrics[0].StorageStatsSet.ReadSizeBytes.Sum)
+				} else {
+					assert.Empty(t, telemetryMessage.TaskMetrics)
+				}
+			}
+			if tc.expectedHealthMessageNum > 0 {
+				healthMessage := <-healthMessages
+				assert.NotEmpty(t, healthMessage.HealthMetrics)
+			}
+
+			// verify full channel behavior: the message is dropped
+			if tc.channelSize == testTelemetryChannelBufferSizeForChannelFull {
+
+				// add a third set of metrics. This time, change storageReadBytes to 0 to verify that the 2nd set of metrics
+				// are dropped as expected.
+				containerStats[0].storageReadBytes = uint64(0)
+				containerStats[1].storageReadBytes = uint64(0)
+				for _, statsContainer := range containers {
+					for i := 0; i < 2; i++ {
+						statsContainer.statsQueue.add(containerStats[i])
+						statsContainer.statsQueue.setLastStat(dockerStats[i])
+					}
+				}
+
+				telemetryMessage := <-telemetryMessages
+				healthMessage := <-healthMessages
+				assert.NotEmpty(t, telemetryMessage.TaskMetrics)
+				assert.NotEmpty(t, healthMessage.HealthMetrics)
+				assert.Zero(t, *telemetryMessage.TaskMetrics[0].ContainerMetrics[0].StorageStatsSet.ReadSizeBytes.Sum)
+			}
+
+			cancel()
+			if ticker != nil {
+				ticker.Stop()
+			}
+			close(telemetryMessages)
+			close(healthMessages)
+		})
+	}
+}
+
+func TestGetInstanceMetricsNonIdleEmptyError(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	resolver := mock_resolver.NewMockContainerMetadataResolver(mockCtrl)
+	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestGetInstanceMetrics"), nil, nil)
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	engine.ctx = ctx
+	engine.containerInstanceArn = "container_instance"
+
+	var err error
+	engine.tasksToContainers["t1"] = nil
+	engine.tasksToDefinitions["t1"] = &taskDefinition{
+		family:  "f1",
+		version: "1",
+	}
+
+	engine.resolver = resolver
+	_, taskMetric, err := engine.GetInstanceMetrics(false)
+	assert.Len(t, taskMetric, 0)
+	assert.Equal(t, err, EmptyMetricsError)
 }
 
 func TestGetTaskHealthMetrics(t *testing.T) {
@@ -334,7 +552,7 @@ func TestGetTaskHealthMetrics(t *testing.T) {
 		},
 	}, nil).Times(3)
 
-	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestGetTaskHealthMetrics"), nil, nil, nil)
+	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestGetTaskHealthMetrics"), nil, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	engine.ctx = ctx
@@ -378,7 +596,7 @@ func TestGetTaskHealthMetricsStoppedContainer(t *testing.T) {
 		},
 	}, nil).Times(2)
 
-	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestGetTaskHealthMetrics"), nil, nil, nil)
+	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestGetTaskHealthMetrics"), nil, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	engine.ctx = ctx
@@ -397,6 +615,30 @@ func TestGetTaskHealthMetricsStoppedContainer(t *testing.T) {
 	engine.resolver = resolver
 	_, _, err = engine.GetTaskHealthMetrics()
 	assert.Error(t, err, "empty metrics should cause an error")
+}
+
+func TestGetTaskHealthMetricsEmptyError(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	resolver := mock_resolver.NewMockContainerMetadataResolver(mockCtrl)
+	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestGetTaskHealthMetrics"), nil, nil)
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	engine.ctx = ctx
+	engine.containerInstanceArn = "container_instance"
+
+	var err error
+	engine.tasksToHealthCheckContainers["t1"] = nil
+	engine.tasksToDefinitions["t1"] = &taskDefinition{
+		family:  "f1",
+		version: "1",
+	}
+
+	engine.resolver = resolver
+	_, taskHealth, err := engine.GetTaskHealthMetrics()
+	assert.Len(t, taskHealth, 0)
+	assert.Equal(t, err, EmptyHealthMetricsError)
 }
 
 // TestMetricsDisabled tests container won't call docker api to collect stats
@@ -421,7 +663,7 @@ func TestMetricsDisabled(t *testing.T) {
 		},
 	}, nil).Times(2)
 
-	engine := NewDockerStatsEngine(&disableMetricsConfig, nil, eventStream("TestMetricsDisabled"), nil, nil, nil)
+	engine := NewDockerStatsEngine(&disableMetricsConfig, nil, eventStream("TestMetricsDisabled"), nil, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	engine.ctx = ctx
@@ -442,7 +684,7 @@ func TestSynchronizeOnRestart(t *testing.T) {
 	client := mock_dockerapi.NewMockDockerClient(ctrl)
 	resolver := mock_resolver.NewMockContainerMetadataResolver(ctrl)
 
-	engine := NewDockerStatsEngine(&cfg, client, eventStream("TestSynchronizeOnRestart"), nil, nil, nil)
+	engine := NewDockerStatsEngine(&cfg, client, eventStream("TestSynchronizeOnRestart"), nil, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	engine.ctx = ctx
@@ -541,7 +783,7 @@ func testNetworkModeStats(t *testing.T, netMode string, enis []*apieni.ENI, serv
 			State: &types.ContainerState{Pid: 23},
 		},
 	}, nil).AnyTimes()
-	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestTaskNetworkStatsSet"), nil, nil, nil)
+	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestTaskNetworkStatsSet"), nil, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	engine.ctx = ctx

--- a/agent/stats/engine_test.go
+++ b/agent/stats/engine_test.go
@@ -45,7 +45,7 @@ const (
 	DefaultNetworkMode                           = "default"
 	BridgeNetworkMode                            = "bridge"
 	SCContainerName                              = "service-connect"
-	testTelemetryChannelDefaultBufferSize        = 5000
+	testTelemetryChannelDefaultBufferSize        = 10
 	testTelemetryChannelBufferSizeForChannelFull = 1
 	testPublishMetricsInterval                   = 5 * time.Second
 )

--- a/agent/stats/engine_unix_integ_test.go
+++ b/agent/stats/engine_unix_integ_test.go
@@ -89,7 +89,7 @@ func TestStatsEngineWithServiceConnectMetrics(t *testing.T) {
 			}
 
 			// Create a new docker stats engine
-			engine := NewDockerStatsEngine(&testConfig, dockerClient, eventStream("TestStatsEngineWithServiceConnectMetrics"), nil, nil, nil)
+			engine := NewDockerStatsEngine(&testConfig, dockerClient, eventStream("TestStatsEngineWithServiceConnectMetrics"), nil, nil)
 			ctx, cancel := context.WithCancel(context.TODO())
 			defer cancel()
 

--- a/agent/stats/engine_unix_test.go
+++ b/agent/stats/engine_unix_test.go
@@ -94,7 +94,7 @@ func TestNetworkModeStatsAWSVPCMode(t *testing.T) {
 			State: &types.ContainerState{Pid: 23},
 		},
 	}, nil).AnyTimes()
-	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestTaskNetworkStatsSet"), nil, nil, nil)
+	engine := NewDockerStatsEngine(&cfg, nil, eventStream("TestTaskNetworkStatsSet"), nil, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	engine.ctx = ctx
@@ -155,7 +155,7 @@ func TestServiceConnectWithDisabledMetrics(t *testing.T) {
 		Container: &container,
 	}, nil).Times(2)
 
-	engine := NewDockerStatsEngine(&disableMetricsConfig, nil, eventStream("TestServiceConnectWithDisabledMetrics"), nil, nil, nil)
+	engine := NewDockerStatsEngine(&disableMetricsConfig, nil, eventStream("TestServiceConnectWithDisabledMetrics"), nil, nil)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	engine.ctx = ctx

--- a/agent/tcs/client/client_test.go
+++ b/agent/tcs/client/client_test.go
@@ -23,7 +23,6 @@
 package tcsclient
 
 import (
-	"context"
 	"fmt"
 	"math/rand"
 	"strconv"
@@ -46,12 +45,15 @@ import (
 )
 
 const (
-	testPublishMetricsInterval        = 1 * time.Second
-	testMessageId                     = "testMessageId"
-	testCluster                       = "default"
-	testContainerInstance             = "containerInstance"
-	rwTimeout                         = time.Second
-	testPublishMetricRequestSizeLimit = 1024
+	testPublishMetricsInterval            = 1 * time.Second
+	testMessageId                         = "testMessageId"
+	testCluster                           = "default"
+	testContainerInstance                 = "containerInstance"
+	rwTimeout                             = time.Second
+	testPublishMetricRequestSizeLimit     = 1024
+	testTelemetryChannelDefaultBufferSize = 5000
+	testIncludeScStats                    = true
+	testNotIncludeScStats                 = false
 )
 
 const (
@@ -384,22 +386,18 @@ func TestPublishMetricsRequest(t *testing.T) {
 	}
 }
 
-func TestPublishMetricsOnceEmptyStatsError(t *testing.T) {
-	cs := clientServer{
-		statsEngine: &emptyStatsEngine{},
-	}
-	err := cs.publishMetricsOnce(false)
-
-	assert.Error(t, err, "Failed: expecting publishMerticOnce return err ")
-}
-
 func TestPublishOnceIdleStatsEngine(t *testing.T) {
 	cs := clientServer{
 		statsEngine: &idleStatsEngine{},
 	}
-	requests, err := cs.metricsToPublishMetricRequests(false)
+	metadata, taskMetrics, _ := cs.statsEngine.GetInstanceMetrics(testNotIncludeScStats)
+	requests, err := cs.metricsToPublishMetricRequests(ecstcs.TelemetryMessage{
+		Metadata:                   metadata,
+		TaskMetrics:                taskMetrics,
+		IncludeServiceConnectStats: testNotIncludeScStats,
+	})
 	if err != nil {
-		t.Fatal("Error creating publishmetricrequests: ", err)
+		t.Fatal("Error creating publishMetricRequests: ", err)
 	}
 	if len(requests) != 1 {
 		t.Errorf("Expected %d requests, got %d", 1, len(requests))
@@ -412,15 +410,20 @@ func TestPublishOnceIdleStatsEngine(t *testing.T) {
 
 func TestPublishOnceNonIdleStatsEngine(t *testing.T) {
 	expectedRequests := 3
-	// Cretes 21 task metrics, which translate to 3 batches,
+	// Creates 21 task metrics, which translate to 3 batches,
 	// {[Task1, Task2, ...Task10], [Task11, Task12, ...Task20], [Task21]}
 	numTasks := (tasksInMetricMessage * (expectedRequests - 1)) + 1
 	cs := clientServer{
 		statsEngine: newNonIdleStatsEngine(numTasks),
 	}
-	requests, err := cs.metricsToPublishMetricRequests(false)
+	metadata, taskMetrics, err := cs.statsEngine.GetInstanceMetrics(testNotIncludeScStats)
+	requests, err := cs.metricsToPublishMetricRequests(ecstcs.TelemetryMessage{
+		Metadata:                   metadata,
+		TaskMetrics:                taskMetrics,
+		IncludeServiceConnectStats: testNotIncludeScStats,
+	})
 	if err != nil {
-		t.Fatal("Error creating publishmetricrequests: ", err)
+		t.Fatal("Error creating publishMetricRequests: ", err)
 	}
 	taskArns := make(map[string]bool)
 	for _, request := range requests {
@@ -476,9 +479,14 @@ func TestPublishServiceConnectStatsEngine(t *testing.T) {
 			cs := clientServer{
 				statsEngine: newServiceConnectStatsEngine(tc.numTasks),
 			}
-			requests, err := cs.metricsToPublishMetricRequests(true)
+			metadata, taskMetrics, _ := cs.statsEngine.GetInstanceMetrics(testIncludeScStats)
+			requests, err := cs.metricsToPublishMetricRequests(ecstcs.TelemetryMessage{
+				Metadata:                   metadata,
+				TaskMetrics:                taskMetrics,
+				IncludeServiceConnectStats: testIncludeScStats,
+			})
 			if err != nil {
-				t.Fatal("Error creating publishmetricrequests: ", err)
+				t.Fatal("Error creating publishMetricRequests: ", err)
 			}
 
 			taskArns := make(map[string]bool)
@@ -513,7 +521,7 @@ func testCS(conn *mock_wsconn.MockWebsocketConn) wsclient.ClientServer {
 		AWSRegion:          "us-east-1",
 		AcceptInsecureCert: true,
 	}
-	cs := New("https://aws.amazon.com/ecs", cfg, testCreds, &mockStatsEngine{},
+	cs := New("https://aws.amazon.com/ecs", cfg, testCreds, &mockStatsEngine{}, nil, nil,
 		testPublishMetricsInterval, rwTimeout, false, emptyDoctor).(*clientServer)
 	cs.SetConnection(conn)
 	return cs
@@ -571,76 +579,6 @@ func TestAckPublishHealthHandlerCalled(t *testing.T) {
 	<-handledPayload
 }
 
-// TestMetricsDisabled tests that if metrics is disabled, only health metrics will be sent
-func TestMetricsDisabled(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	ctx, cancel := context.WithCancel(context.TODO())
-	conn := mock_wsconn.NewMockWebsocketConn(ctrl)
-	mockStatsEngine := mock_stats.NewMockEngine(ctrl)
-
-	cfg := config.DefaultConfig()
-
-	cs := New("", &cfg, testCreds, mockStatsEngine, testPublishMetricsInterval, rwTimeout, true, emptyDoctor)
-	cs.SetConnection(conn)
-
-	published := make(chan struct{})
-	read := make(chan struct{})
-
-	// stats engine should only be called for getting health metrics
-	mockStatsEngine.EXPECT().GetPublishMetricsTicker().Do(func() {
-		cancel()
-	}).Return(time.NewTicker(config.DefaultContainerMetricsPublishInterval)).Times(1)
-	mockStatsEngine.EXPECT().GetTaskHealthMetrics().Return(&ecstcs.HealthMetadata{
-		Cluster:           aws.String("TestMetricsDisabled"),
-		ContainerInstance: aws.String("container_instance"),
-		Fin:               aws.Bool(true),
-		MessageId:         aws.String("message_id"),
-	}, []*ecstcs.TaskHealth{{}}, nil).MinTimes(1)
-	conn.EXPECT().SetReadDeadline(gomock.Any()).Return(nil).MinTimes(1)
-	conn.EXPECT().ReadMessage().Do(func() {
-		read <- struct{}{}
-	}).Return(1, nil, nil).MinTimes(1)
-	conn.EXPECT().SetWriteDeadline(gomock.Any()).Return(nil).MinTimes(1)
-	conn.EXPECT().WriteMessage(gomock.Any(), gomock.Any()).Do(func(messageType int, data []byte) {
-		published <- struct{}{}
-	}).Return(nil).MinTimes(1)
-
-	go func() {
-		err := cs.Serve()
-		assert.NoError(t, err)
-	}()
-	<-published
-	<-read
-
-	// Wait for the context to be cancelled. This ensures that the publishMetrics() go routine started by cs.Serve()
-	// always runs and GetPublishMetricsTicker mock call is triggered.
-	select {
-	case <-ctx.Done():
-	}
-}
-
-func TestCreatePublishHealthRequestsEmpty(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	conn := mock_wsconn.NewMockWebsocketConn(ctrl)
-	mockStatsEngine := mock_stats.NewMockEngine(ctrl)
-	cfg := config.DefaultConfig()
-
-	cs := New("", &cfg, testCreds, mockStatsEngine, testPublishMetricsInterval, rwTimeout, true, emptyDoctor)
-	cs.SetConnection(conn)
-
-	mockStatsEngine.EXPECT().GetTaskHealthMetrics().Return(nil, nil, stats.EmptyHealthMetricsError)
-	_, err := cs.(*clientServer).createPublishHealthRequests()
-	assert.Equal(t, err, stats.EmptyHealthMetricsError)
-
-	mockStatsEngine.EXPECT().GetTaskHealthMetrics().Return(nil, nil, nil)
-	_, err = cs.(*clientServer).createPublishHealthRequests()
-	assert.NoError(t, err)
-}
-
 func TestCreatePublishHealthRequests(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -649,7 +587,7 @@ func TestCreatePublishHealthRequests(t *testing.T) {
 	mockStatsEngine := mock_stats.NewMockEngine(ctrl)
 	cfg := config.DefaultConfig()
 
-	cs := New("", &cfg, testCreds, mockStatsEngine, testPublishMetricsInterval, rwTimeout, true, emptyDoctor)
+	cs := New("", &cfg, testCreds, mockStatsEngine, nil, nil, testPublishMetricsInterval, rwTimeout, true, emptyDoctor)
 	cs.SetConnection(conn)
 
 	testMetadata := &ecstcs.HealthMetadata{
@@ -687,7 +625,11 @@ func TestCreatePublishHealthRequests(t *testing.T) {
 	}
 
 	mockStatsEngine.EXPECT().GetTaskHealthMetrics().Return(testMetadata, testHealthMetrics, nil)
-	request, err := cs.(*clientServer).createPublishHealthRequests()
+	metadata, healthMetrics, _ := mockStatsEngine.GetTaskHealthMetrics()
+	request, err := cs.(*clientServer).createPublishHealthRequests(ecstcs.HealthMessage{
+		Metadata:      metadata,
+		HealthMetrics: healthMetrics,
+	})
 
 	assert.NoError(t, err)
 	assert.Len(t, request, 1)

--- a/agent/tcs/client/client_test.go
+++ b/agent/tcs/client/client_test.go
@@ -51,7 +51,7 @@ const (
 	testContainerInstance                 = "containerInstance"
 	rwTimeout                             = time.Second
 	testPublishMetricRequestSizeLimit     = 1024
-	testTelemetryChannelDefaultBufferSize = 5000
+	testTelemetryChannelDefaultBufferSize = 10
 	testIncludeScStats                    = true
 	testNotIncludeScStats                 = false
 )

--- a/agent/tcs/handler/handler.go
+++ b/agent/tcs/handler/handler.go
@@ -94,9 +94,9 @@ func startTelemetrySession(params *TelemetrySessionParams, statsEngine stats.Eng
 		return err
 	}
 	url := formatURL(tcsEndpoint, params.Cfg.Cluster, params.ContainerInstanceArn, params.TaskEngine)
-	return startSession(params.Ctx, url, params.Cfg, params.CredentialProvider, statsEngine,
-		defaultHeartbeatTimeout, defaultHeartbeatJitter, config.DefaultContainerMetricsPublishInterval,
-		params.DeregisterInstanceEventStream, params.Doctor)
+	return startSession(params.Ctx, url, params.Cfg, params.CredentialProvider, statsEngine, params.MetricsChannel,
+		params.HealthChannel, defaultHeartbeatTimeout, defaultHeartbeatJitter,
+		config.DefaultContainerMetricsPublishInterval, params.DeregisterInstanceEventStream, params.Doctor)
 }
 
 func startSession(
@@ -105,12 +105,14 @@ func startSession(
 	cfg *config.Config,
 	credentialProvider *credentials.Credentials,
 	statsEngine stats.Engine,
+	metricsChannel <-chan ecstcs.TelemetryMessage,
+	healthChannel <-chan ecstcs.HealthMessage,
 	heartbeatTimeout, heartbeatJitter,
 	publishMetricsInterval time.Duration,
 	deregisterInstanceEventStream *eventstream.EventStream,
 	doctor *doctor.Doctor,
 ) error {
-	client := tcsclient.New(url, cfg, credentialProvider, statsEngine,
+	client := tcsclient.New(url, cfg, credentialProvider, statsEngine, metricsChannel, healthChannel,
 		publishMetricsInterval, wsRWTimeout, cfg.DisableMetrics.Enabled(), doctor)
 	defer client.Close()
 

--- a/agent/tcs/handler/handler_test.go
+++ b/agent/tcs/handler/handler_test.go
@@ -56,7 +56,7 @@ const (
 	testMessageId                         = "testMessageId"
 	testPublishMetricsInterval            = 1 * time.Second
 	testSendMetricsToChannelWaitTime      = 100 * time.Millisecond
-	testTelemetryChannelDefaultBufferSize = 5000
+	testTelemetryChannelDefaultBufferSize = 10
 )
 
 type mockStatsEngine struct {

--- a/agent/tcs/handler/handler_test.go
+++ b/agent/tcs/handler/handler_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/version"
 	"github.com/aws/amazon-ecs-agent/agent/wsclient"
 	wsmock "github.com/aws/amazon-ecs-agent/agent/wsclient/mock/utils"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/docker/docker/api/types"
 	"github.com/golang/mock/gomock"
@@ -48,15 +49,21 @@ import (
 )
 
 const (
-	testTaskArn                = "arn:aws:ecs:us-east-1:123:task/def"
-	testTaskDefinitionFamily   = "task-def"
-	testClusterArn             = "arn:aws:ecs:us-east-1:123:cluster/default"
-	testInstanceArn            = "arn:aws:ecs:us-east-1:123:container-instance/abc"
-	testMessageId              = "testMessageId"
-	testPublishMetricsInterval = 1 * time.Millisecond
+	testTaskArn                           = "arn:aws:ecs:us-east-1:123:task/def"
+	testTaskDefinitionFamily              = "task-def"
+	testClusterArn                        = "arn:aws:ecs:us-east-1:123:cluster/default"
+	testInstanceArn                       = "arn:aws:ecs:us-east-1:123:container-instance/abc"
+	testMessageId                         = "testMessageId"
+	testPublishMetricsInterval            = 1 * time.Second
+	testSendMetricsToChannelWaitTime      = 100 * time.Millisecond
+	testTelemetryChannelDefaultBufferSize = 5000
 )
 
-type mockStatsEngine struct{}
+type mockStatsEngine struct {
+	metricsChannel       chan<- ecstcs.TelemetryMessage
+	healthChannel        chan<- ecstcs.HealthMessage
+	publishMetricsTicker *time.Ticker
+}
 
 var testCreds = credentials.NewStaticCredentials("test-id", "test-secret", "test-token")
 
@@ -88,8 +95,43 @@ func (*mockStatsEngine) SetPublishServiceConnectTickerInterval(counter int32) {
 	return
 }
 
-func (*mockStatsEngine) GetPublishMetricsTicker() *time.Ticker {
-	return time.NewTicker(config.DefaultContainerMetricsPublishInterval)
+func (engine *mockStatsEngine) GetPublishMetricsTicker() *time.Ticker {
+	return engine.publishMetricsTicker
+}
+
+// SimulateMetricsPublishToChannel simulates the behavior of `StartMetricsPublish` in DockerStatsEngine, which feeds metrics
+// to channel to TCS Client. There has to be at least one valid metrics sent, otherwise no request will be made to mockServer
+// in TestStartSession, specifically blocking `request := <-requestChan`
+func (engine *mockStatsEngine) SimulateMetricsPublishToChannel(ctx context.Context) {
+	engine.publishMetricsTicker = time.NewTicker(testPublishMetricsInterval)
+	for {
+		select {
+		case <-engine.publishMetricsTicker.C:
+			engine.metricsChannel <- ecstcs.TelemetryMessage{
+				Metadata: &ecstcs.MetricsMetadata{
+					Cluster:           aws.String(testClusterArn),
+					ContainerInstance: aws.String(testInstanceArn),
+					Fin:               aws.Bool(false),
+					Idle:              aws.Bool(false),
+					MessageId:         aws.String(testMessageId),
+				},
+				TaskMetrics: []*ecstcs.TaskMetric{
+					&ecstcs.TaskMetric{},
+				},
+				IncludeServiceConnectStats: false,
+			}
+
+			engine.healthChannel <- ecstcs.HealthMessage{
+				Metadata:      &ecstcs.HealthMetadata{},
+				HealthMetrics: []*ecstcs.TaskHealth{},
+			}
+
+		case <-ctx.Done():
+			defer close(engine.metricsChannel)
+			defer close(engine.healthChannel)
+			return
+		}
+	}
 }
 
 // TestDisableMetrics tests the StartMetricsSession will return immediately if
@@ -132,6 +174,10 @@ func TestStartSession(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	telemetryMessages := make(chan ecstcs.TelemetryMessage, testTelemetryChannelDefaultBufferSize)
+	healthMessages := make(chan ecstcs.HealthMessage, testTelemetryChannelDefaultBufferSize)
+
 	wait := &sync.WaitGroup{}
 	ctx, cancel := context.WithCancel(context.Background())
 	wait.Add(1)
@@ -149,19 +195,27 @@ func TestStartSession(t *testing.T) {
 	}()
 
 	deregisterInstanceEventStream := eventstream.NewEventStream("Deregister_Instance", context.Background())
+
+	mockEngine := &mockStatsEngine{
+		metricsChannel: telemetryMessages,
+		healthChannel:  healthMessages,
+	}
+
 	// Start a session with the test server.
-	go startSession(ctx, server.URL, testCfg, testCreds, &mockStatsEngine{},
+	go startSession(ctx, server.URL, testCfg, testCreds, mockEngine, telemetryMessages, healthMessages,
 		defaultHeartbeatTimeout, defaultHeartbeatJitter,
 		testPublishMetricsInterval, deregisterInstanceEventStream, emptyDoctor)
+	// Wait for 100 ms to make sure the session is ready to receive message from channel
+	time.Sleep(testSendMetricsToChannelWaitTime)
+	go mockEngine.SimulateMetricsPublishToChannel(ctx)
 
-	// startSession internally starts publishing metrics from the mockStatsEngine object.
-	time.Sleep(testPublishMetricsInterval)
+	// startSession internally starts publishing metrics from the mockStatsEngine object (poll msg out of channel).
+	time.Sleep(testPublishMetricsInterval * 2)
 
 	// Read request channel to get the metric data published to the server.
 	request := <-requestChan
 	cancel()
 	wait.Wait()
-
 	go func() {
 		for {
 			select {
@@ -213,8 +267,14 @@ func TestSessionConnectionClosedByRemote(t *testing.T) {
 	deregisterInstanceEventStream.StartListening()
 	defer cancel()
 
+	telemetryMessages := make(chan ecstcs.TelemetryMessage, testTelemetryChannelDefaultBufferSize)
+	healthMessages := make(chan ecstcs.HealthMessage, testTelemetryChannelDefaultBufferSize)
+
 	// Start a session with the test server.
-	err = startSession(ctx, server.URL, testCfg, testCreds, &mockStatsEngine{},
+	err = startSession(ctx, server.URL, testCfg, testCreds, &mockStatsEngine{
+		metricsChannel: telemetryMessages,
+		healthChannel:  healthMessages,
+	}, telemetryMessages, healthMessages,
 		defaultHeartbeatTimeout, defaultHeartbeatJitter,
 		testPublishMetricsInterval, deregisterInstanceEventStream, emptyDoctor)
 
@@ -250,8 +310,15 @@ func TestConnectionInactiveTimeout(t *testing.T) {
 	deregisterInstanceEventStream := eventstream.NewEventStream("Deregister_Instance", ctx)
 	deregisterInstanceEventStream.StartListening()
 	defer cancel()
+
+	telemetryMessages := make(chan ecstcs.TelemetryMessage, testTelemetryChannelDefaultBufferSize)
+	healthMessages := make(chan ecstcs.HealthMessage, testTelemetryChannelDefaultBufferSize)
+
 	// Start a session with the test server.
-	err = startSession(ctx, server.URL, testCfg, testCreds, &mockStatsEngine{},
+	err = startSession(ctx, server.URL, testCfg, testCreds, &mockStatsEngine{
+		metricsChannel: telemetryMessages,
+		healthChannel:  healthMessages,
+	}, telemetryMessages, healthMessages,
 		50*time.Millisecond, 100*time.Millisecond,
 		testPublishMetricsInterval, deregisterInstanceEventStream, emptyDoctor)
 	// if we are not blocked here, then the test pass as it will reconnect in StartSession

--- a/agent/tcs/handler/types.go
+++ b/agent/tcs/handler/types.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/engine"
 	"github.com/aws/amazon-ecs-agent/agent/eventstream"
 	"github.com/aws/amazon-ecs-agent/agent/stats"
+	"github.com/aws/amazon-ecs-agent/agent/tcs/model/ecstcs"
 	"github.com/aws/amazon-ecs-agent/agent/utils/ttime"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/pkg/errors"
@@ -40,6 +41,8 @@ type TelemetrySessionParams struct {
 	ECSClient                     api.ECSClient
 	TaskEngine                    engine.TaskEngine
 	StatsEngine                   *stats.DockerStatsEngine
+	MetricsChannel                <-chan ecstcs.TelemetryMessage
+	HealthChannel                 <-chan ecstcs.HealthMessage
 	Doctor                        *doctor.Doctor
 	_time                         ttime.Time
 	_timeOnce                     sync.Once

--- a/agent/tcs/model/ecstcs/types.go
+++ b/agent/tcs/model/ecstcs/types.go
@@ -38,16 +38,12 @@ func NewPublishHealthMetricsRequest(metadata *HealthMetadata, healthMetrics []*T
 }
 
 type TelemetryMessage struct {
-	Metadata    *MetricsMetadata
-	TaskMetrics []*TaskMetric
+	Metadata                   *MetricsMetadata
+	TaskMetrics                []*TaskMetric
+	IncludeServiceConnectStats bool
 }
 
 type HealthMessage struct {
-	Metadata      *MetricsMetadata
+	Metadata      *HealthMetadata
 	HealthMetrics []*TaskHealth
-}
-
-type InstanceStatusMessage struct {
-	Metadata *InstanceStatusMetadata
-	Statuses []*InstanceStatus
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
- Pulls in latest changes in dev branch to feature branch
- Change the interaction between dockerStatsEngine and tcsClient from
  - TCS Client calls dockerStatsEngine methods based on ticker to get metrics directly, to
  - TCS Client has two go routines to poll messages from channels, while dockerStatsEngine publishes telemetry messages to channels based on publish ticker

### Implementation details
<!-- How are the changes implemented? -->
- Move logics of getting `includeServiceConnectMetrics` from `tcs/client` to `stats/engine`
  - Corresponding unit test changes for this move
- Change the ticker for publish method from `tcs/client` to `stats/engine`
- Keep the collect metrics logics isolated in statsEngine, and change communication between tcsClient and statsEngine from function call to channel
- Unit test to test channel behavior
- StartSession test to test full end to end message send/receive behavior

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes.

- New unit tests included to test changed behavior and channel behaviors. 
- Removed some tests that are no longer providing value (mostly in tcs/client_test) and replaced them with tests in engine_test, as handling is now happening on the statsEngine side, before telemetry messages are sent through the channel. Specifically
  - TestPublishMetricsOnceEmptyStatsError removed because now there will be no error since when metrics are empty it is an empty channel. Similar functionality will be tested in engine_test.go TestGetInstanceMetricsNonIdleEmptyError
  - TestCreatePublishHealthRequestsEmpty removed because now there will be no error since when metrics are empty it is an empty channel. Similar functionality will be tested in engine_test.go TestGetTaskHealthMetricsEmptyError
- The log entries in unit test can validate the channel full behavior, which drops the metrics sent after the channel full with 1 second timeout
```
=== RUN   TestStartMetricsPublish/ChannelFull
1684729831247602895 [Info] Event stream TestStartMetricsPublish start listening...
1684729831247629573 [Debug] Adding container to stats watch list, id: c1, task: t1
1684729831247722891 [Debug] Adding container to stats health check watch list, id: c1, task: t1
1684729831247777701 [Debug] Collecting stats for container c1
1684729831247965705 [Debug] sent telemetry message
1684729831248038708 [Debug] sent health message
1684729832247929304 [Error] Received a docker stat object with duplicate timestamp
1684729836247743258 [Debug] publishMetricsTicker triggered. Sending telemetry messages to tcsClient through channel
1684729837247949612 [Error] timeout sending health message, discarding metrics
1684729837248047981 [Error] timeout sending telemetry message, discarding metrics
1684729838249034600 [Error] Received a docker stat object with duplicate timestamp
1684729841247732249 [Debug] publishMetricsTicker triggered. Sending telemetry messages to tcsClient through channel
1684729841247991130 [Debug] sent telemetry message
1684729841248113612 [Debug] sent health message
```
- Run a manual test with 45 tasks on the instance without service connect setup and without container health metrics setup. Seen following information (with some extra debug log)
```
level=debug time=2023-05-08T21:12:32Z msg="HH: publishMetricsTicker trigger. Sending Messages" module=engine.go
level=debug time=2023-05-08T21:12:32Z msg="HH: Sent telemetry message" module=engine.go
level=debug time=2023-05-08T21:12:32Z msg="HH: Sent health message" module=engine.go
level=debug time=2023-05-08T21:12:32Z msg="HH: received message in metricsChannel. Trying" module=client.go
level=debug time=2023-05-08T21:12:32Z msg="HH: make metric request attempt" module=client.go
level=debug time=2023-05-08T21:12:32Z msg="HH: make metric request attempt" module=client.go
level=debug time=2023-05-08T21:12:32Z msg="HH: make metric request attempt" module=client.go
level=debug time=2023-05-08T21:12:32Z msg="HH: make metric request attempt" module=client.go
level=debug time=2023-05-08T21:12:32Z msg="HH: make metric request attempt" module=client.go
level=debug time=2023-05-08T21:12:32Z msg="HH: received message in healthChannel. Trying" module=client.go
level=debug time=2023-05-08T21:12:32Z msg="No container health metrics to report" module=client.go
level=debug time=2023-05-08T21:12:32Z msg="Received message of type: AckPublishMetric" module=client.go
level=debug time=2023-05-08T21:12:32Z msg="Received AckPublishMetric from tcs" module=handler.go
level=debug time=2023-05-08T21:12:32Z msg="Received message of type: AckPublishMetric" module=client.go
level=debug time=2023-05-08T21:12:32Z msg="Received AckPublishMetric from tcs" module=handler.go
level=debug time=2023-05-08T21:12:32Z msg="Received message of type: AckPublishMetric" module=client.go
level=debug time=2023-05-08T21:12:32Z msg="Received AckPublishMetric from tcs" module=handler.go
level=debug time=2023-05-08T21:12:32Z msg="Received message of type: AckPublishMetric" module=client.go
level=debug time=2023-05-08T21:12:32Z msg="Received AckPublishMetric from tcs" module=handler.go
level=debug time=2023-05-08T21:12:32Z msg="Received message of type: AckPublishMetric" module=client.go
level=debug time=2023-05-08T21:12:32Z msg="Received AckPublishMetric from tcs" module=handler.go
level=debug time=2023-05-08T21:12:45Z msg="Skipping publishing container instance status message that was already sent" module=client.go
level=debug time=2023-05-08T21:12:49Z msg="Received message of type: HeartbeatMessage" module=client.go
level=debug time=2023-05-08T21:12:49Z msg="ACS activity occurred" module=acs_handler.go
level=debug time=2023-05-08T21:12:49Z msg="instance healthcheck result: OK" module=doctor.go
level=debug time=2023-05-08T21:12:52Z msg="HH: publishMetricsTicker trigger. Sending Messages" module=engine.go
level=debug time=2023-05-08T21:12:52Z msg="HH: Sent telemetry message" module=engine.go
level=debug time=2023-05-08T21:12:52Z msg="HH: Sent health message" module=engine.go
level=debug time=2023-05-08T21:12:52Z msg="HH: received message in metricsChannel. Trying" module=client.go
level=debug time=2023-05-08T21:12:52Z msg="HH: make metric request attempt" module=client.go
level=debug time=2023-05-08T21:12:52Z msg="HH: make metric request attempt" module=client.go
level=debug time=2023-05-08T21:12:52Z msg="HH: make metric request attempt" module=client.go
level=debug time=2023-05-08T21:12:52Z msg="HH: make metric request attempt" module=client.go
level=debug time=2023-05-08T21:12:52Z msg="HH: make metric request attempt" module=client.go
level=debug time=2023-05-08T21:12:52Z msg="HH: received message in healthChannel. Trying" module=client.go
level=debug time=2023-05-08T21:12:52Z msg="No container health metrics to report" module=client.go
level=debug time=2023-05-08T21:12:52Z msg="Received message of type: AckPublishMetric" module=client.go
level=debug time=2023-05-08T21:12:52Z msg="Received AckPublishMetric from tcs" module=handler.go
level=debug time=2023-05-08T21:12:52Z msg="Received message of type: AckPublishMetric" module=client.go
level=debug time=2023-05-08T21:12:52Z msg="Received AckPublishMetric from tcs" module=handler.go
level=debug time=2023-05-08T21:12:52Z msg="Received message of type: AckPublishMetric" module=client.go
level=debug time=2023-05-08T21:12:52Z msg="Received AckPublishMetric from tcs" module=handler.go
level=debug time=2023-05-08T21:12:52Z msg="Received message of type: AckPublishMetric" module=client.go
level=debug time=2023-05-08T21:12:52Z msg="Received AckPublishMetric from tcs" module=handler.go
level=debug time=2023-05-08T21:12:52Z msg="Received message of type: AckPublishMetric" module=client.go
level=debug time=2023-05-08T21:12:52Z msg="Received AckPublishMetric from tcs" module=handler.go
```
   We see it is separated to 5 request and everything looks normal.
- Existing integ/functional tests on metrics and health metrics passed.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Channel based dockerStatsEngine implementation

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
