### PR TITLE
Add gMSA domainless support

### DIFF
--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -470,7 +470,7 @@ func (task *Task) initializeCredentialSpecResource(config *config.Config, creden
 	resourceFields *taskresource.ResourceFields) error {
 	credspecContainerMapping := task.getAllCredentialSpecRequirements()
 	credentialspecResource, err := credentialspec.NewCredentialSpecResource(task.Arn, config.AWSRegion, task.ExecutionCredentialsID,
-		credentialsManager, resourceFields.SSMClientCreator, resourceFields.S3ClientCreator, credspecContainerMapping)
+		credentialsManager, resourceFields.SSMClientCreator, resourceFields.S3ClientCreator, resourceFields.ASMClientCreator, credspecContainerMapping)
 	if err != nil {
 		return err
 	}

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -36,6 +36,7 @@ import (
 	apieni "github.com/aws/amazon-ecs-agent/agent/api/eni"
 	apitaskstatus "github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/agent/asm"
+	mock_asm_factory "github.com/aws/amazon-ecs-agent/agent/asm/factory/mocks"
 	mock_factory "github.com/aws/amazon-ecs-agent/agent/asm/factory/mocks"
 	mock_secretsmanageriface "github.com/aws/amazon-ecs-agent/agent/asm/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/config"
@@ -4781,12 +4782,14 @@ func TestInitializeAndGetCredentialSpecResource(t *testing.T) {
 	credentialsManager := mock_credentials.NewMockManager(ctrl)
 	ssmClientCreator := mock_ssm_factory.NewMockSSMClientCreator(ctrl)
 	s3ClientCreator := mock_s3_factory.NewMockS3ClientCreator(ctrl)
+	asmClientCreator := mock_asm_factory.NewMockClientCreator(ctrl)
 
 	resFields := &taskresource.ResourceFields{
 		ResourceFieldsCommon: &taskresource.ResourceFieldsCommon{
 			SSMClientCreator:   ssmClientCreator,
 			CredentialsManager: credentialsManager,
 			S3ClientCreator:    s3ClientCreator,
+			ASMClientCreator:   asmClientCreator,
 		},
 	}
 

--- a/agent/engine/docker_task_engine_linux_test.go
+++ b/agent/engine/docker_task_engine_linux_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/api/serviceconnect"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	apitaskstatus "github.com/aws/amazon-ecs-agent/agent/api/task/status"
+	mock_asm_factory "github.com/aws/amazon-ecs-agent/agent/asm/factory/mocks"
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/credentials"
 	"github.com/aws/amazon-ecs-agent/agent/data"
@@ -1489,6 +1490,7 @@ func TestCredentialSpecResourceTaskFile(t *testing.T) {
 
 	ssmClientCreator := mock_ssm_factory.NewMockSSMClientCreator(ctrl)
 	s3ClientCreator := mock_s3_factory.NewMockS3ClientCreator(ctrl)
+	asmClientCreator := mock_asm_factory.NewMockClientCreator(ctrl)
 
 	credentialSpecRes, cerr := credentialspec.NewCredentialSpecResource(
 		testTask.Arn,
@@ -1497,6 +1499,7 @@ func TestCredentialSpecResourceTaskFile(t *testing.T) {
 		credentialsManager,
 		ssmClientCreator,
 		s3ClientCreator,
+		asmClientCreator,
 		nil)
 	assert.NoError(t, cerr)
 

--- a/agent/taskresource/credentialspec/credentialspec.go
+++ b/agent/taskresource/credentialspec/credentialspec.go
@@ -21,6 +21,7 @@ import (
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 	"github.com/aws/amazon-ecs-agent/agent/api/task/status"
+	asmfactory "github.com/aws/amazon-ecs-agent/agent/asm/factory"
 	"github.com/aws/amazon-ecs-agent/agent/credentials"
 	s3factory "github.com/aws/amazon-ecs-agent/agent/s3/factory"
 	ssmfactory "github.com/aws/amazon-ecs-agent/agent/ssm/factory"
@@ -54,6 +55,9 @@ type CredentialSpecResourceCommon struct {
 	// s3ClientCreator is a factory interface that creates new S3 clients. This is
 	// needed mostly for testing.
 	s3ClientCreator s3factory.S3ClientCreator
+	// secretsManagerClientCreator is a factory interface that creates new secret manager clients. This is
+	// needed mostly for testing.
+	secretsmanagerClientCreator asmfactory.ClientCreator
 	// map to transform credentialspec values, key is an input credentialspec
 	// Examples: (windows)
 	// * key := credentialspec:file://credentialspec.json, value := credentialspec=file://credentialspec.json
@@ -80,6 +84,7 @@ func (cs *CredentialSpecResource) Initialize(resourceFields *taskresource.Resour
 	cs.credentialsManager = resourceFields.CredentialsManager
 	cs.ssmClientCreator = resourceFields.SSMClientCreator
 	cs.s3ClientCreator = resourceFields.S3ClientCreator
+	cs.secretsmanagerClientCreator = resourceFields.ASMClientCreator
 	cs.initStatusToTransition()
 }
 

--- a/agent/taskresource/credentialspec/credentialspec_windows.go
+++ b/agent/taskresource/credentialspec/credentialspec_windows.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	asmfactory "github.com/aws/amazon-ecs-agent/agent/asm/factory"
 	"github.com/aws/amazon-ecs-agent/agent/credentials"
 	"github.com/aws/amazon-ecs-agent/agent/s3"
 	s3factory "github.com/aws/amazon-ecs-agent/agent/s3/factory"
@@ -62,6 +63,7 @@ func NewCredentialSpecResource(taskARN, region string,
 	credentialsManager credentials.Manager,
 	ssmClientCreator ssmfactory.SSMClientCreator,
 	s3ClientCreator s3factory.S3ClientCreator,
+	asmClientCreator asmfactory.ClientCreator,
 	credentialSpecContainerMap map[string]string) (*CredentialSpecResource, error) {
 
 	s := &CredentialSpecResource{


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This PR adds the  domainless gMSA support on linux establishing communication with credentials-fetcher daemon and also sharing tickets with application containers

### Implementation details
Added gMSA linux domainless support

### Testing
This was tested through unit tests, as well as manually running the agent on the instance and also verifying the gMSA domainless functionality

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
