### PR TITLE
Support firelens for bridge mode ServiceConnect task

### DIFF
--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -3443,6 +3443,10 @@ func (task *Task) IsServiceConnectEnabled() bool {
 	return task.GetServiceConnectContainer() != nil
 }
 
+func (task *Task) IsServiceConnectBridgeModeApplicationContainer(container *apicontainer.Container) bool {
+	return container.GetNetworkModeFromHostConfig() == "container" && task.IsServiceConnectEnabled()
+}
+
 // PopulateServiceConnectContainerMappingEnvVar populates APPNET_CONTAINER_IP_MAPPING env var for AppNet Agent container
 // aka SC container
 func (task *Task) PopulateServiceConnectContainerMappingEnvVar() error {

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -1386,8 +1386,8 @@ func (engine *DockerTaskEngine) createContainer(task *apitask.Task, container *a
 				targetContainer, err = task.GetBridgeModePauseContainerForTaskContainer(targetContainer)
 				if err != nil {
 					return dockerapi.DockerContainerMetadata{
-						Error: dockerapi.CannotStartContainerError{FromError: errors.New(fmt.Sprintf("failed to start firelens"+
-							"container: %v", err))},
+						Error: dockerapi.CannotStartContainerError{FromError: errors.New(fmt.Sprintf(
+							"failed to start firelens container: %v", err))},
 					}
 				}
 			}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Currently, if a task is ServiceConnect-enabled, and runs in bridge network mode, then it won't be able to use `awsfirelens` log driver. 
This PR makes `awsfirelens` compatible with SC-enabled, bridge mode tasks.

### Implementation details
<!-- How are the changes implemented? -->
ECS Agent is responsible for injecting `FLUENT_HOST` environment variable to application containers. The variable contains the IP address assigned to the FireLens container. See public [doc](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_firelens.html). So far, ECS Agent resolves the container IP by directly querying the container network info from docker inspect. This becomes an issue with ServiceConnect bridge mode tasks, because we are launching pause containers for each application container (for network namespace configuration). In that case, the application container will not have the expected network info, as the info is now associated with its pause container.

This PR makes changes in two places - 
1. When resolving container IP for FireLens container itself
2. When resolving FireLens container IP for other application containers

In both cases, we now retrieve the container IP from the FireLens pause container instead, using the readily available `GetBridgeModePauseContainerForTaskContainer` function.

### Testing
* Added unit test for `CreateContainer` and `StartContainer` for both SC and non-SC bridge mode tasks.
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

* E2E test by running a bridge task with SC enabled that also use `awsfirelens` log driver - verified that 1) task is able to run, and 2) application log was successfully delivered to my fluentd destination (an S3 bucket)


### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Support firelens for bridge mode ServiceConnect task

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
