### PR TITLE
Common task manifest/stop verification ACK in agent/

### DIFF
--- a/agent/acs/handler/acs_handler.go
+++ b/agent/acs/handler/acs_handler.go
@@ -315,9 +315,12 @@ func (acsSession *session) startACSSession(client wsclient.ClientServer) error {
 
 	client.AddRequestHandler(instanceENIAttachHandler.handlerFunc())
 
+	manifestMessageIDAccessor := &manifestMessageIDAccessor{}
+
 	// Add TaskManifestHandler
 	taskManifestHandler := newTaskManifestHandler(acsSession.ctx, cfg.Cluster, acsSession.containerInstanceARN,
-		client, acsSession.dataClient, acsSession.taskEngine, acsSession.latestSeqNumTaskManifest)
+		client, acsSession.dataClient, acsSession.taskEngine, acsSession.latestSeqNumTaskManifest,
+		manifestMessageIDAccessor)
 
 	defer taskManifestHandler.clearAcks()
 	taskManifestHandler.start()

--- a/agent/acs/handler/task_manifest_common.go
+++ b/agent/acs/handler/task_manifest_common.go
@@ -1,0 +1,23 @@
+package handler
+
+import (
+	"sync"
+)
+
+type manifestMessageIDAccessor struct {
+	messageID string
+	lock      sync.RWMutex
+}
+
+func (mmiAccessor *manifestMessageIDAccessor) GetMessageID() string {
+	mmiAccessor.lock.RLock()
+	defer mmiAccessor.lock.RUnlock()
+	return mmiAccessor.messageID
+}
+
+func (mmiAccessor *manifestMessageIDAccessor) SetMessageID(messageId string) error {
+	mmiAccessor.lock.Lock()
+	defer mmiAccessor.lock.Unlock()
+	mmiAccessor.messageID = messageId
+	return nil
+}

--- a/agent/acs/handler/task_manifest_handler_test.go
+++ b/agent/acs/handler/task_manifest_handler_test.go
@@ -53,9 +53,10 @@ func TestManifestHandlerKillAllTasks(t *testing.T) {
 	mockWSClient := mock_wsclient.NewMockClientServer(ctrl)
 
 	dataClient := newTestDataClient(t)
+	manifestMessageIDAccessor := &manifestMessageIDAccessor{}
 
 	newTaskManifest := newTaskManifestHandler(ctx, cluster, containerInstanceArn, mockWSClient,
-		dataClient, taskEngine, aws.Int64(11))
+		dataClient, taskEngine, aws.Int64(11), manifestMessageIDAccessor)
 
 	ackRequested := &ecsacs.AckRequest{
 		Cluster:           aws.String(cluster),
@@ -147,9 +148,10 @@ func TestManifestHandlerKillFewTasks(t *testing.T) {
 	mockWSClient := mock_wsclient.NewMockClientServer(ctrl)
 
 	dataClient := newTestDataClient(t)
+	manifestMessageIDAccessor := &manifestMessageIDAccessor{}
 
 	newTaskManifest := newTaskManifestHandler(ctx, cluster, containerInstanceArn, mockWSClient,
-		dataClient, taskEngine, aws.Int64(11))
+		dataClient, taskEngine, aws.Int64(11), manifestMessageIDAccessor)
 
 	ackRequested := &ecsacs.AckRequest{
 		Cluster:           aws.String(cluster),
@@ -250,9 +252,10 @@ func TestManifestHandlerKillNoTasks(t *testing.T) {
 	mockWSClient := mock_wsclient.NewMockClientServer(ctrl)
 
 	dataClient := newTestDataClient(t)
+	manifestMessageIDAccessor := &manifestMessageIDAccessor{}
 
 	newTaskManifest := newTaskManifestHandler(ctx, cluster, containerInstanceArn, mockWSClient,
-		dataClient, taskEngine, aws.Int64(11))
+		dataClient, taskEngine, aws.Int64(11), manifestMessageIDAccessor)
 
 	ackRequested := &ecsacs.AckRequest{
 		Cluster:           aws.String(cluster),
@@ -339,9 +342,10 @@ func TestManifestHandlerDifferentTaskLists(t *testing.T) {
 	mockWSClient := mock_wsclient.NewMockClientServer(ctrl)
 
 	dataClient := newTestDataClient(t)
+	manifestMessageIDAccessor := &manifestMessageIDAccessor{}
 
 	newTaskManifest := newTaskManifestHandler(ctx, cluster, containerInstanceArn, mockWSClient,
-		dataClient, taskEngine, aws.Int64(11))
+		dataClient, taskEngine, aws.Int64(11), manifestMessageIDAccessor)
 
 	ackRequested := &ecsacs.AckRequest{
 		Cluster:           aws.String(cluster),
@@ -460,8 +464,10 @@ func TestManifestHandlerSequenceNumbers(t *testing.T) {
 
 			ctx := context.TODO()
 			mockWSClient := mock_wsclient.NewMockClientServer(ctrl)
+			manifestMessageIDAccessor := &manifestMessageIDAccessor{}
+
 			newTaskManifest := newTaskManifestHandler(ctx, cluster, containerInstanceArn, mockWSClient,
-				data.NewNoopClient(), taskEngine, aws.Int64(tc.inputSequenceNumber))
+				data.NewNoopClient(), taskEngine, aws.Int64(tc.inputSequenceNumber), manifestMessageIDAccessor)
 
 			taskList := []*task.Task{
 				{Arn: "arn2", DesiredStatusUnsafe: apitaskstatus.TaskRunning},
@@ -554,8 +560,9 @@ func TestTaskManifestHandlerSendPendingTaskManifestMessageAck(t *testing.T) {
 	taskEngine := mock_engine.NewMockTaskEngine(ctrl)
 	mockWSClient := mock_wsclient.NewMockClientServer(ctrl)
 	mockWSClient.EXPECT().MakeRequest(gomock.Any()).Return(nil).Times(1)
+	manifestMessageIDAccessor := &manifestMessageIDAccessor{}
 	handler := newTaskManifestHandler(ctx, cluster, containerInstanceArn, mockWSClient,
-		data.NewNoopClient(), taskEngine, aws.Int64(testSeqNum))
+		data.NewNoopClient(), taskEngine, aws.Int64(testSeqNum), manifestMessageIDAccessor)
 
 	wg := sync.WaitGroup{}
 	wg.Add(2)
@@ -590,8 +597,9 @@ func TestTaskManifestHandlerHandlePendingTaskStopVerificationAck(t *testing.T) {
 	ctx := context.TODO()
 	taskEngine := mock_engine.NewMockTaskEngine(ctrl)
 	mockWSClient := mock_wsclient.NewMockClientServer(ctrl)
+	manifestMessageIDAccessor := &manifestMessageIDAccessor{}
 	handler := newTaskManifestHandler(ctx, cluster, containerInstanceArn, mockWSClient,
-		data.NewNoopClient(), taskEngine, aws.Int64(testSeqNum))
+		data.NewNoopClient(), taskEngine, aws.Int64(testSeqNum), manifestMessageIDAccessor)
 
 	wg := sync.WaitGroup{}
 	wg.Add(2)

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/acs/session/task_manifest_common.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/acs/session/task_manifest_common.go
@@ -1,0 +1,9 @@
+package session
+
+// ManifestMessageIDAccessor stores the latest message ID that corresponds to the
+// most recently processed task manifest message and is used to determine the
+// validity of a task stop verification ack message.
+type ManifestMessageIDAccessor interface {
+	GetMessageID() string
+	SetMessageID(messageID string) error
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Refactor functionality common to handling/responding to task manifest and task stop verification ACK messages from ACS in `agent/`.

NOTE: For context, logic for handling/responding to task manifest and task stop verification ACK messages from ACS both currently live in a single file `agent/acs/handler/task_manifest_handler.go`. In a future PR, this file will instead be split out into two files, where each file is dedicated to handling/responding to a single specific message type from ACS. This follows the best practice of the single-responsibility principle.

### Implementation details
<!-- How are the changes implemented? -->
Define new `manifestMessageIDAccessor` struct in `agent/acs/handler/task_manifest_common.go` such that `manifestMessageIDAccessor` implements `acssession.ManifestMessageIDAccessor` interface.


Update the following files to make use of `acssession.ManifestMessageIDAccessor` interface and `manifestMessageIDAccessor` struct:
   - `agent/acs/handler/acs_handler.go`
   - `agent/acs/handler/task_manifest_handler.go`
   - `agent/acs/handler/task_manifest_handler_test.go`

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Unit, integration, and functional tests.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Common task manifest/stop verification ACK in agent/

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
