### PR TITLE
Move credentials endpoints to ecs-agent module

### DIFF
--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -27,6 +27,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient"
 	"github.com/aws/amazon-ecs-agent/agent/ec2"
 	"github.com/aws/amazon-ecs-agent/agent/utils"
+	commonutils "github.com/aws/amazon-ecs-agent/ecs-agent/utils"
 	"github.com/cihub/seelog"
 )
 
@@ -204,7 +205,7 @@ func (cfg *Config) Merge(rhs Config) *Config {
 				leftField.Set(reflect.ValueOf(right.Field(i).Interface()))
 			}
 		default:
-			if utils.ZeroOrNil(leftField.Interface()) {
+			if commonutils.ZeroOrNil(leftField.Interface()) {
 				leftField.Set(reflect.ValueOf(right.Field(i).Interface()))
 			}
 		}
@@ -395,7 +396,7 @@ func (cfg *Config) checkMissingAndDepreciated() error {
 	fatalFields := []string{}
 	for i := 0; i < cfgElem.NumField(); i++ {
 		cfgField := cfgElem.Field(i)
-		if utils.ZeroOrNil(cfgField.Interface()) {
+		if commonutils.ZeroOrNil(cfgField.Interface()) {
 			missingTag := cfgStructField.Field(i).Tag.Get("missing")
 			if len(missingTag) == 0 {
 				continue
@@ -429,7 +430,7 @@ func (cfg *Config) complete() bool {
 	cfgElem := reflect.ValueOf(cfg).Elem()
 
 	for i := 0; i < cfgElem.NumField(); i++ {
-		if utils.ZeroOrNil(cfgElem.Field(i).Interface()) {
+		if commonutils.ZeroOrNil(cfgElem.Field(i).Interface()) {
 			return false
 		}
 	}
@@ -464,7 +465,7 @@ func fileConfig() (Config, error) {
 	}
 
 	// Handle any deprecated keys correctly here
-	if utils.ZeroOrNil(cfg.Cluster) && !utils.ZeroOrNil(cfg.ClusterArn) {
+	if commonutils.ZeroOrNil(cfg.Cluster) && !commonutils.ZeroOrNil(cfg.ClusterArn) {
 		cfg.Cluster = cfg.ClusterArn
 	}
 	return cfg, nil

--- a/agent/handlers/task_server_setup.go
+++ b/agent/handlers/task_server_setup.go
@@ -22,7 +22,6 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	agentAPITaskProtectionV1 "github.com/aws/amazon-ecs-agent/agent/handlers/agentapi/taskprotection/v1/handlers"
-	v1 "github.com/aws/amazon-ecs-agent/agent/handlers/v1"
 	v2 "github.com/aws/amazon-ecs-agent/agent/handlers/v2"
 	v3 "github.com/aws/amazon-ecs-agent/agent/handlers/v3"
 	v4 "github.com/aws/amazon-ecs-agent/agent/handlers/v4"
@@ -32,6 +31,8 @@ import (
 	"github.com/aws/amazon-ecs-agent/ecs-agent/credentials"
 	auditinterface "github.com/aws/amazon-ecs-agent/ecs-agent/logger/audit"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/tmds"
+	tmdsv1 "github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v1"
+	tmdsv2 "github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v2"
 	"github.com/cihub/seelog"
 	"github.com/gorilla/mux"
 )
@@ -67,8 +68,8 @@ func taskServerSetup(credentialsManager credentials.Manager,
 	// to permanently redirect(301) to "/v3/metadata/task" handler
 	muxRouter.SkipClean(false)
 
-	muxRouter.HandleFunc(v1.CredentialsPath,
-		v1.CredentialsHandler(credentialsManager, auditLogger))
+	muxRouter.HandleFunc(tmdsv1.CredentialsPath,
+		tmdsv1.CredentialsHandler(credentialsManager, auditLogger))
 
 	v2HandlersSetup(muxRouter, state, ecsClient, statsEngine, cluster, credentialsManager, auditLogger, availabilityZone, containerInstanceArn)
 
@@ -97,7 +98,7 @@ func v2HandlersSetup(muxRouter *mux.Router,
 	auditLogger auditinterface.AuditLogger,
 	availabilityZone string,
 	containerInstanceArn string) {
-	muxRouter.HandleFunc(v2.CredentialsPath, v2.CredentialsHandler(credentialsManager, auditLogger))
+	muxRouter.HandleFunc(tmdsv2.CredentialsPath, tmdsv2.CredentialsHandler(credentialsManager, auditLogger))
 	muxRouter.HandleFunc(v2.ContainerMetadataPath, v2.TaskContainerMetadataHandler(state, ecsClient, cluster, availabilityZone, containerInstanceArn, false))
 	muxRouter.HandleFunc(v2.TaskMetadataPath, v2.TaskContainerMetadataHandler(state, ecsClient, cluster, availabilityZone, containerInstanceArn, false))
 	muxRouter.HandleFunc(v2.TaskWithTagsMetadataPath, v2.TaskContainerMetadataHandler(state, ecsClient, cluster, availabilityZone, containerInstanceArn, true))

--- a/agent/handlers/task_server_setup_test.go
+++ b/agent/handlers/task_server_setup_test.go
@@ -51,6 +51,7 @@ import (
 	mock_credentials "github.com/aws/amazon-ecs-agent/ecs-agent/credentials/mocks"
 	mock_audit "github.com/aws/amazon-ecs-agent/ecs-agent/logger/audit/mocks"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/utils"
+	tmdsv1 "github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v1"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/docker/docker/api/types"
 	"github.com/golang/mock/gomock"
@@ -535,7 +536,7 @@ func TestInvalidPath(t *testing.T) {
 // query parameters are not specified for the credentials endpoint.
 func TestCredentialsV1RequestWithNoArguments(t *testing.T) {
 	msg := &utils.ErrorMessage{
-		Code:          v1.ErrNoIDInRequest,
+		Code:          tmdsv1.ErrNoIDInRequest,
 		Message:       "CredentialsV1Request: No ID in the request",
 		HTTPErrorCode: http.StatusBadRequest,
 	}
@@ -546,7 +547,7 @@ func TestCredentialsV1RequestWithNoArguments(t *testing.T) {
 // query parameters are not specified for the credentials endpoint.
 func TestCredentialsV2RequestWithNoArguments(t *testing.T) {
 	msg := &utils.ErrorMessage{
-		Code:          v1.ErrNoIDInRequest,
+		Code:          tmdsv1.ErrNoIDInRequest,
 		Message:       "CredentialsV2Request: No ID in the request",
 		HTTPErrorCode: http.StatusBadRequest,
 	}
@@ -557,7 +558,7 @@ func TestCredentialsV2RequestWithNoArguments(t *testing.T) {
 // the credentials manager does not contain the credentials id specified in the query.
 func TestCredentialsV1RequestWhenCredentialsIdNotFound(t *testing.T) {
 	expectedErrorMessage := &utils.ErrorMessage{
-		Code:          v1.ErrInvalidIDInRequest,
+		Code:          tmdsv1.ErrInvalidIDInRequest,
 		Message:       fmt.Sprintf("CredentialsV1Request: Credentials not found"),
 		HTTPErrorCode: http.StatusBadRequest,
 	}
@@ -571,7 +572,7 @@ func TestCredentialsV1RequestWhenCredentialsIdNotFound(t *testing.T) {
 // the credentials manager does not contain the credentials id specified in the query.
 func TestCredentialsV2RequestWhenCredentialsIdNotFound(t *testing.T) {
 	expectedErrorMessage := &utils.ErrorMessage{
-		Code:          v1.ErrInvalidIDInRequest,
+		Code:          tmdsv1.ErrInvalidIDInRequest,
 		Message:       fmt.Sprintf("CredentialsV2Request: Credentials not found"),
 		HTTPErrorCode: http.StatusBadRequest,
 	}
@@ -585,7 +586,7 @@ func TestCredentialsV2RequestWhenCredentialsIdNotFound(t *testing.T) {
 // the credentials manager returns empty credentials.
 func TestCredentialsV1RequestWhenCredentialsUninitialized(t *testing.T) {
 	expectedErrorMessage := &utils.ErrorMessage{
-		Code:          v1.ErrCredentialsUninitialized,
+		Code:          tmdsv1.ErrCredentialsUninitialized,
 		Message:       fmt.Sprintf("CredentialsV1Request: Credentials uninitialized for ID"),
 		HTTPErrorCode: http.StatusServiceUnavailable,
 	}
@@ -599,7 +600,7 @@ func TestCredentialsV1RequestWhenCredentialsUninitialized(t *testing.T) {
 // the credentials manager returns empty credentials.
 func TestCredentialsV2RequestWhenCredentialsUninitialized(t *testing.T) {
 	expectedErrorMessage := &utils.ErrorMessage{
-		Code:          v1.ErrCredentialsUninitialized,
+		Code:          tmdsv1.ErrCredentialsUninitialized,
 		Message:       fmt.Sprintf("CredentialsV2Request: Credentials uninitialized for ID"),
 		HTTPErrorCode: http.StatusServiceUnavailable,
 	}

--- a/agent/logger/audit/audit_log_test.go
+++ b/agent/logger/audit/audit_log_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/config"
 	mock_infologger "github.com/aws/amazon-ecs-agent/agent/logger/audit/mocks"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/credentials"
+	auditinterface "github.com/aws/amazon-ecs-agent/ecs-agent/logger/audit"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/audit/request"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -77,7 +78,8 @@ func TestWritingToAuditLog(t *testing.T) {
 		verifyAuditLogEntryResult(logLine, taskARN, dummyURLPath, t)
 	})
 
-	auditLogger.Log(request.LogRequest{Request: req, ARN: taskARN}, dummyResponseCode, GetCredentialsEventType(dummyRoleType))
+	auditLogger.Log(request.LogRequest{Request: req, ARN: taskARN}, dummyResponseCode,
+		auditinterface.GetCredentialsEventTypeFromRoleType(dummyRoleType))
 }
 
 func TestWritingToAuditLogV2(t *testing.T) {
@@ -108,7 +110,8 @@ func TestWritingToAuditLogV2(t *testing.T) {
 		verifyAuditLogEntryResult(logLine, taskARN, credentials.V2CredentialsPath, t)
 	})
 
-	auditLogger.Log(request.LogRequest{Request: req, ARN: taskARN}, dummyResponseCode, GetCredentialsEventType(dummyRoleType))
+	auditLogger.Log(request.LogRequest{Request: req, ARN: taskARN}, dummyResponseCode,
+		auditinterface.GetCredentialsEventTypeFromRoleType(dummyRoleType))
 }
 
 func TestWritingErrorsToAuditLog(t *testing.T) {
@@ -139,7 +142,8 @@ func TestWritingErrorsToAuditLog(t *testing.T) {
 		verifyAuditLogEntryResult(logLine, "-", dummyURLPath, t)
 	})
 
-	auditLogger.Log(request.LogRequest{Request: req, ARN: ""}, dummyResponseCode, GetCredentialsEventType(dummyRoleType))
+	auditLogger.Log(request.LogRequest{Request: req, ARN: ""}, dummyResponseCode,
+		auditinterface.GetCredentialsEventTypeFromRoleType(dummyRoleType))
 }
 
 func TestWritingToAuditLogWhenDisabled(t *testing.T) {
@@ -162,7 +166,8 @@ func TestWritingToAuditLogWhenDisabled(t *testing.T) {
 
 	mockInfoLogger.EXPECT().Info(gomock.Any()).Times(0)
 
-	auditLogger.Log(request.LogRequest{Request: req, ARN: taskARN}, dummyResponseCode, GetCredentialsEventType(dummyRoleType))
+	auditLogger.Log(request.LogRequest{Request: req, ARN: taskARN}, dummyResponseCode,
+		auditinterface.GetCredentialsEventTypeFromRoleType(dummyRoleType))
 }
 
 func TestConstructCommonAuditLogEntryFields(t *testing.T) {
@@ -181,7 +186,8 @@ func TestConstructCommonAuditLogEntryFields(t *testing.T) {
 }
 
 func TestConstructAuditLogEntryByTypeGetCredentials(t *testing.T) {
-	result := constructAuditLogEntryByType(GetCredentialsEventType(dummyRoleType), dummyCluster,
+	result := constructAuditLogEntryByType(
+		auditinterface.GetCredentialsEventTypeFromRoleType(dummyRoleType), dummyCluster,
 		dummyContainerInstanceArn)
 	verifyConstructAuditLogEntryGetCredentialsResult(result, t)
 }
@@ -209,7 +215,8 @@ func verifyConstructAuditLogEntryGetCredentialsResult(result string, t *testing.
 	tokens := strings.Split(result, " ")
 
 	assert.Equal(t, getCredentialsEntryFieldCount, len(tokens), "Incorrect number of tokens in GetCredentials audit log entry")
-	assert.Equal(t, GetCredentialsEventType(dummyRoleType), tokens[0], "event type does not match")
+	assert.Equal(t, auditinterface.GetCredentialsEventTypeFromRoleType(dummyRoleType),
+		tokens[0], "event type does not match")
 
 	auditLogVersion, _ := strconv.Atoi(tokens[1])
 	assert.Equal(t, getCredentialsAuditLogVersion, auditLogVersion, "version does not match")

--- a/agent/logger/audit/entry_types.go
+++ b/agent/logger/audit/entry_types.go
@@ -19,15 +19,12 @@ import (
 	"time"
 
 	"github.com/aws/amazon-ecs-agent/ecs-agent/credentials"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/audit"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/audit/request"
 	log "github.com/cihub/seelog"
 )
 
 const (
-	getCredentialsEventType                = "GetCredentials"
-	getCredentialsTaskExecutionEventType   = "GetCredentialsExecutionRole"
-	getCredentialsInvalidRoleTypeEventType = "GetCredentialsInvalidRoleType"
-
 	// getCredentialsAuditLogVersion is the version of the audit log
 	// Version '1', the fields are:
 	// 1. event time
@@ -54,18 +51,6 @@ type commonAuditLogEntryFields struct {
 	theURL       string
 	userAgent    string
 	arn          string
-}
-
-// GetCredentialsEventType is the type for a GetCredentials request
-func GetCredentialsEventType(roleType string) string {
-	switch roleType {
-	case credentials.ApplicationRoleType:
-		return getCredentialsEventType
-	case credentials.ExecutionRoleType:
-		return getCredentialsTaskExecutionEventType
-	default:
-		return getCredentialsInvalidRoleTypeEventType
-	}
 }
 
 func (c *commonAuditLogEntryFields) string() string {
@@ -103,7 +88,7 @@ func constructCommonAuditLogEntryFields(r request.LogRequest, httpResponseCode i
 
 func constructAuditLogEntryByType(eventType string, cluster string, containerInstanceArn string) string {
 	switch eventType {
-	case getCredentialsEventType:
+	case audit.GetCredentialsEventType:
 		fields := &getCredentialsAuditLogEntryFields{
 			eventType:            eventType,
 			version:              getCredentialsAuditLogVersion,
@@ -111,7 +96,7 @@ func constructAuditLogEntryByType(eventType string, cluster string, containerIns
 			containerInstanceArn: populateField(containerInstanceArn),
 		}
 		return fields.string()
-	case getCredentialsTaskExecutionEventType:
+	case audit.GetCredentialsTaskExecutionEventType:
 		fields := &getCredentialsAuditLogEntryFields{
 			eventType:            eventType,
 			version:              getCredentialsAuditLogVersion,

--- a/agent/utils/utils.go
+++ b/agent/utils/utils.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
 	"github.com/aws/amazon-ecs-agent/agent/utils/httpproxy"
+	commonutils "github.com/aws/amazon-ecs-agent/ecs-agent/utils"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -42,28 +43,6 @@ func DefaultIfBlank(str string, default_value string) string {
 		return default_value
 	}
 	return str
-}
-
-func ZeroOrNil(obj interface{}) bool {
-	value := reflect.ValueOf(obj)
-	if !value.IsValid() {
-		return true
-	}
-	if obj == nil {
-		return true
-	}
-	switch value.Kind() {
-	case reflect.Slice, reflect.Array, reflect.Map:
-		return value.Len() == 0
-	}
-	zero := reflect.Zero(reflect.TypeOf(obj))
-	if !value.Type().Comparable() {
-		return false
-	}
-	if obj == zero.Interface() {
-		return true
-	}
-	return false
 }
 
 // SlicesDeepEqual checks if slice1 and slice2 are equal, disregarding order.
@@ -216,7 +195,7 @@ func SearchStrInDir(dir, filePrefix, content string) error {
 	for _, file := range logfiles {
 		if strings.HasPrefix(file.Name(), filePrefix) {
 			desiredFile = file.Name()
-			if ZeroOrNil(desiredFile) {
+			if commonutils.ZeroOrNil(desiredFile) {
 				return fmt.Errorf("File with prefix: %v does not exist", filePrefix)
 			}
 

--- a/agent/utils/utils_test.go
+++ b/agent/utils/utils_test.go
@@ -17,7 +17,6 @@
 package utils
 
 import (
-	"encoding/json"
 	"errors"
 	"sort"
 	"testing"
@@ -37,52 +36,6 @@ func TestDefaultIfBlank(t *testing.T) {
 
 	result = DefaultIfBlank("", defaultValue)
 	assert.Equal(t, defaultValue, result)
-}
-
-type dummyStruct struct {
-	// no contents
-}
-
-func (d dummyStruct) MarshalJSON([]byte, error) {
-	json.Marshal(nil)
-}
-
-func TestZeroOrNil(t *testing.T) {
-	type ZeroTest struct {
-		testInt     int
-		TestStr     string
-		testNilJson dummyStruct
-	}
-
-	var strMap map[string]string
-
-	testCases := []struct {
-		param    interface{}
-		expected bool
-		name     string
-	}{
-		{nil, true, "Nil is nil"},
-		{0, true, "0 is 0"},
-		{"", true, "\"\" is the string zerovalue"},
-		{ZeroTest{}, true, "ZeroTest zero-value should be zero"},
-		{ZeroTest{TestStr: "asdf"}, false, "ZeroTest with a field populated isn't zero"},
-		{ZeroTest{testNilJson: dummyStruct{}}, true, "nil is nil"},
-		{1, false, "1 is not 0"},
-		{[]uint16{1, 2, 3}, false, "[1,2,3] is not zero"},
-		{[]uint16{}, true, "[] is zero"},
-		{struct{ uncomparable []uint16 }{uncomparable: []uint16{1, 2, 3}}, false, "Uncomparable structs are never zero"},
-		{struct{ uncomparable []uint16 }{uncomparable: nil}, false, "Uncomparable structs are never zero"},
-		{strMap, true, "map[string]string is zero or nil"},
-		{make(map[string]string), true, "empty map[string]string is zero or nil"},
-		{map[string]string{"foo": "bar"}, false, "map[string]string{foo:bar} is not zero or nil"},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.expected, ZeroOrNil(tc.param), tc.name)
-		})
-	}
-
 }
 
 func TestSlicesDeepEqual(t *testing.T) {

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/acs/session/task_manifest_common.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/acs/session/task_manifest_common.go
@@ -1,0 +1,9 @@
+package session
+
+// ManifestMessageIDAccessor stores the latest message ID that corresponds to the
+// most recently processed task manifest message and is used to determine the
+// validity of a task stop verification ack message.
+type ManifestMessageIDAccessor interface {
+	GetMessageID() string
+	SetMessageID(messageID string) error
+}

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/logger/audit/audit_log.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/logger/audit/audit_log.go
@@ -15,10 +15,31 @@
 
 package audit
 
-import "github.com/aws/amazon-ecs-agent/ecs-agent/logger/audit/request"
+import (
+	"github.com/aws/amazon-ecs-agent/ecs-agent/credentials"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/audit/request"
+)
+
+const (
+	GetCredentialsEventType                = "GetCredentials"
+	GetCredentialsTaskExecutionEventType   = "GetCredentialsExecutionRole"
+	GetCredentialsInvalidRoleTypeEventType = "GetCredentialsInvalidRoleType"
+)
 
 type AuditLogger interface {
 	Log(r request.LogRequest, httpResponseCode int, eventType string)
 	GetContainerInstanceArn() string
 	GetCluster() string
+}
+
+// Returns a suitable audit log event type for the credentials role type
+func GetCredentialsEventTypeFromRoleType(roleType string) string {
+	switch roleType {
+	case credentials.ApplicationRoleType:
+		return GetCredentialsEventType
+	case credentials.ExecutionRoleType:
+		return GetCredentialsTaskExecutionEventType
+	default:
+		return GetCredentialsInvalidRoleTypeEventType
+	}
 }

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v2/credentials_handler.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v2/credentials_handler.go
@@ -17,10 +17,10 @@ import (
 	"fmt"
 	"net/http"
 
-	v1 "github.com/aws/amazon-ecs-agent/agent/handlers/v1"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/credentials"
 	auditinterface "github.com/aws/amazon-ecs-agent/ecs-agent/logger/audit"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/utils"
+	v1 "github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v1"
 	"github.com/gorilla/mux"
 )
 

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/utils/utils.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/utils/utils.go
@@ -1,0 +1,37 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+package utils
+
+import "reflect"
+
+func ZeroOrNil(obj interface{}) bool {
+	value := reflect.ValueOf(obj)
+	if !value.IsValid() {
+		return true
+	}
+	if obj == nil {
+		return true
+	}
+	switch value.Kind() {
+	case reflect.Slice, reflect.Array, reflect.Map:
+		return value.Len() == 0
+	}
+	zero := reflect.Zero(reflect.TypeOf(obj))
+	if !value.Type().Comparable() {
+		return false
+	}
+	if obj == zero.Interface() {
+		return true
+	}
+	return false
+}

--- a/agent/vendor/modules.txt
+++ b/agent/vendor/modules.txt
@@ -22,8 +22,11 @@ github.com/aws/amazon-ecs-agent/ecs-agent/logger/audit/request
 github.com/aws/amazon-ecs-agent/ecs-agent/logger/field
 github.com/aws/amazon-ecs-agent/ecs-agent/tmds
 github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/utils
+github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v1
+github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v2
 github.com/aws/amazon-ecs-agent/ecs-agent/tmds/logging
 github.com/aws/amazon-ecs-agent/ecs-agent/tmds/utils/mux
+github.com/aws/amazon-ecs-agent/ecs-agent/utils
 github.com/aws/amazon-ecs-agent/ecs-agent/utils/arn
 github.com/aws/amazon-ecs-agent/ecs-agent/utils/ttime
 github.com/aws/amazon-ecs-agent/ecs-agent/utils/ttime/mocks

--- a/ecs-agent/logger/audit/audit_log.go
+++ b/ecs-agent/logger/audit/audit_log.go
@@ -15,10 +15,31 @@
 
 package audit
 
-import "github.com/aws/amazon-ecs-agent/ecs-agent/logger/audit/request"
+import (
+	"github.com/aws/amazon-ecs-agent/ecs-agent/credentials"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/audit/request"
+)
+
+const (
+	GetCredentialsEventType                = "GetCredentials"
+	GetCredentialsTaskExecutionEventType   = "GetCredentialsExecutionRole"
+	GetCredentialsInvalidRoleTypeEventType = "GetCredentialsInvalidRoleType"
+)
 
 type AuditLogger interface {
 	Log(r request.LogRequest, httpResponseCode int, eventType string)
 	GetContainerInstanceArn() string
 	GetCluster() string
+}
+
+// Returns a suitable audit log event type for the credentials role type
+func GetCredentialsEventTypeFromRoleType(roleType string) string {
+	switch roleType {
+	case credentials.ApplicationRoleType:
+		return GetCredentialsEventType
+	case credentials.ExecutionRoleType:
+		return GetCredentialsTaskExecutionEventType
+	default:
+		return GetCredentialsInvalidRoleTypeEventType
+	}
 }

--- a/ecs-agent/tmds/handlers/credentials_handler_test.go
+++ b/ecs-agent/tmds/handlers/credentials_handler_test.go
@@ -1,0 +1,314 @@
+//go:build unit
+// +build unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+package v1
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/amazon-ecs-agent/ecs-agent/credentials"
+	mock_credentials "github.com/aws/amazon-ecs-agent/ecs-agent/credentials/mocks"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/audit"
+	mock_audit "github.com/aws/amazon-ecs-agent/ecs-agent/logger/audit/mocks"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/utils"
+	v1 "github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v1"
+	v2 "github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v2"
+	"github.com/gorilla/mux"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Function to make a URL path for credentials request
+type MakePath = func(credsId string) string
+
+// A function that creates a credentialse HTTP handler
+type GetCredentialsHandler = func(credentials.Manager, audit.AuditLogger) http.Handler
+
+// A structure representing a test case for credentials endpoint error handling tests.
+type CredentialsErrorTestCase struct {
+	Name               string
+	Path               string
+	GetHandler         func(*mock_credentials.MockManager, *mock_audit.MockAuditLogger) http.Handler
+	ExpectedStatusCode int
+	ExpectedResponse   utils.ErrorMessage
+}
+
+// MakePath function for credentials endpoint v1
+var makePathV1 MakePath = func(credsId string) string {
+	if credsId == "" {
+		return "/credentials"
+	}
+	return "/credentials?id=" + credsId
+}
+
+// MakePath function for credentials endpoint v2
+var makePathV2 MakePath = func(credsId string) string {
+	return fmt.Sprintf("%s/%s", credentials.V2CredentialsPath, credsId)
+}
+
+// GetCredentialsHandler function for v1
+var getCredentialsHandlerV1 GetCredentialsHandler = func(
+	credManager credentials.Manager,
+	auditLogger audit.AuditLogger,
+) http.Handler {
+	return http.HandlerFunc(v1.CredentialsHandler(credManager, auditLogger))
+}
+
+// GetCredentialsHandler function for v2
+var getCredentialsHandlerV2 GetCredentialsHandler = func(
+	credManager credentials.Manager,
+	auditLogger audit.AuditLogger,
+) http.Handler {
+	router := mux.NewRouter()
+	router.HandleFunc(v2.CredentialsPath, v2.CredentialsHandler(credManager, auditLogger))
+	return router
+}
+
+// Creates a test case for "no credentials ID in request" error
+func noCredentialsIDCase(
+	makePath MakePath,
+	makeHandler GetCredentialsHandler,
+	errorPrefix string,
+) CredentialsErrorTestCase {
+	return CredentialsErrorTestCase{
+		Name: "no credentials ID in the requeest",
+		Path: makePath(""),
+		GetHandler: func(
+			credManager *mock_credentials.MockManager,
+			auditLogger *mock_audit.MockAuditLogger,
+		) http.Handler {
+			auditLogger.EXPECT().Log(
+				gomock.Any(),
+				http.StatusBadRequest,
+				audit.GetCredentialsInvalidRoleTypeEventType)
+
+			return makeHandler(credManager, auditLogger)
+		},
+		ExpectedStatusCode: http.StatusBadRequest,
+		ExpectedResponse: utils.ErrorMessage{
+			Code:          v1.ErrNoIDInRequest,
+			Message:       errorPrefix + ": No Credential ID in the request",
+			HTTPErrorCode: http.StatusBadRequest,
+		},
+	}
+}
+
+// Creates a test case for "credentials not found" error
+func credentialsNotFoundCase(
+	makePath MakePath,
+	makeHandler GetCredentialsHandler,
+	errorPrefix string,
+) CredentialsErrorTestCase {
+	return CredentialsErrorTestCase{
+		Name: "credentials not found",
+		Path: makePath("credsid"),
+		GetHandler: func(
+			credManager *mock_credentials.MockManager,
+			auditLogger *mock_audit.MockAuditLogger,
+		) http.Handler {
+			auditLogger.EXPECT().Log(
+				gomock.Any(),
+				http.StatusBadRequest,
+				audit.GetCredentialsInvalidRoleTypeEventType)
+			credManager.EXPECT().GetTaskCredentials("credsid").
+				Return(credentials.TaskIAMRoleCredentials{}, false)
+
+			return makeHandler(credManager, auditLogger)
+		},
+		ExpectedStatusCode: http.StatusBadRequest,
+		ExpectedResponse: utils.ErrorMessage{
+			Code:          v1.ErrInvalidIDInRequest,
+			Message:       errorPrefix + ": Credentials not found",
+			HTTPErrorCode: http.StatusBadRequest,
+		},
+	}
+}
+
+// Creates a test case for "credentials uninitialized" error
+func credentialsUninitializedCase(
+	makePath MakePath,
+	makeHandler GetCredentialsHandler,
+	errorPrefix string,
+) CredentialsErrorTestCase {
+	return CredentialsErrorTestCase{
+		Name: "credentials uninitialized",
+		Path: makePath("credsid"),
+		GetHandler: func(
+			credManager *mock_credentials.MockManager,
+			auditLogger *mock_audit.MockAuditLogger,
+		) http.Handler {
+			auditLogger.EXPECT().Log(
+				gomock.Any(),
+				http.StatusServiceUnavailable,
+				audit.GetCredentialsInvalidRoleTypeEventType)
+			credManager.EXPECT().GetTaskCredentials("credsid").
+				Return(credentials.TaskIAMRoleCredentials{}, true)
+
+			return makeHandler(credManager, auditLogger)
+		},
+		ExpectedStatusCode: http.StatusServiceUnavailable,
+		ExpectedResponse: utils.ErrorMessage{
+			Code:          v1.ErrCredentialsUninitialized,
+			Message:       errorPrefix + ": Credentials uninitialized for ID",
+			HTTPErrorCode: http.StatusServiceUnavailable,
+		},
+	}
+}
+
+// Tests error cases for credentials endpoint v1
+func TestCredentialsHandlerErrorV1(t *testing.T) {
+	errorPrefix := "CredentialsV1Request"
+	tcs := []CredentialsErrorTestCase{
+		noCredentialsIDCase(makePathV1, getCredentialsHandlerV1, errorPrefix),
+		credentialsNotFoundCase(makePathV1, getCredentialsHandlerV1, errorPrefix),
+		credentialsUninitializedCase(makePathV1, getCredentialsHandlerV1, errorPrefix),
+	}
+	for _, tc := range tcs {
+		t.Run(tc.Name, func(t *testing.T) {
+			testCredentialsHandlerError(t, tc)
+		})
+	}
+}
+
+// Tests error cases for credentials endpoint v2
+func TestCredentialsHandlerErrorV2(t *testing.T) {
+	errorPrefix := "CredentialsV2Request"
+	tcs := []CredentialsErrorTestCase{
+		noCredentialsIDCase(makePathV2, getCredentialsHandlerV2, errorPrefix),
+		credentialsNotFoundCase(makePathV2, getCredentialsHandlerV2, errorPrefix),
+		credentialsUninitializedCase(makePathV2, getCredentialsHandlerV2, errorPrefix),
+	}
+	for _, tc := range tcs {
+		t.Run(tc.Name, func(t *testing.T) {
+			testCredentialsHandlerError(t, tc)
+		})
+	}
+}
+
+// Tests error handling of credentials endpoint for a given test case.
+// This function works by sending a test request to the
+// handler and asserting on the response code and response body.
+// This function also creates mocks for credentials manager and audit logger interfaces
+// which are passed to the provided test case. The test case is responsible for setting up
+// expectations on the mocks.
+func testCredentialsHandlerError(
+	t *testing.T,
+	tc CredentialsErrorTestCase,
+) {
+	// Set up mocks
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	auditLogger := mock_audit.NewMockAuditLogger(ctrl)
+	credManager := mock_credentials.NewMockManager(ctrl)
+
+	// Create request handler using a function provided by the test case.
+	// The test case is responsible for setting up expectations on the mocks.
+	handler := tc.GetHandler(credManager, auditLogger)
+
+	// Create a test reqeust
+	req, err := http.NewRequest("GET", tc.Path, nil)
+	if err != nil {
+		require.NoError(t, err)
+	}
+	recorder := httptest.NewRecorder()
+
+	// Serve the request and read the response
+	handler.ServeHTTP(recorder, req)
+	var response utils.ErrorMessage
+	err = json.Unmarshal(recorder.Body.Bytes(), &response)
+	require.NoError(t, err)
+
+	// Assert on response status code and body
+	assert.Equal(t, tc.ExpectedStatusCode, recorder.Code)
+	assert.Equal(t, tc.ExpectedResponse, response)
+}
+
+// Tests happy case for credentials endpoint v1
+func TestCredentialsHandlerV1Success(t *testing.T) {
+	testCredentialsHandlerSuccess(t, makePathV1, getCredentialsHandlerV1)
+}
+
+// Tests happy case for credentials endpoint v2
+func TestCredentialsHandlerV2Success(t *testing.T) {
+	testCredentialsHandlerSuccess(t, makePathV2, getCredentialsHandlerV2)
+}
+
+// Tests happy case for credentials endpoint by sending a request to the handler and
+// asserting that 200-OK response is received with credentials in the body.
+func testCredentialsHandlerSuccess(t *testing.T, makePath MakePath, makeHandler GetCredentialsHandler) {
+	// Create mocks
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	auditLogger := mock_audit.NewMockAuditLogger(ctrl)
+	credManager := mock_credentials.NewMockManager(ctrl)
+
+	// Some variables
+	credsId := "credsid"
+	taskArn := "taskArn"
+	path := makePath(credsId)
+
+	// Credentials that will be found by the credential manager
+	creds := credentials.IAMRoleCredentials{
+		CredentialsID:   credsId,
+		RoleArn:         "rolearn",
+		AccessKeyID:     "access_key_id",
+		SecretAccessKey: "secret_access_key",
+		SessionToken:    "session_token",
+		Expiration:      "expiration",
+		RoleType:        credentials.ApplicationRoleType,
+	}
+
+	// Expected response - not all credentials fields are sent in the response
+	expectedCreds := credentials.IAMRoleCredentials{
+		RoleArn:         "rolearn",
+		AccessKeyID:     "access_key_id",
+		SecretAccessKey: "secret_access_key",
+		SessionToken:    "session_token",
+		Expiration:      "expiration",
+	}
+
+	auditLogger.EXPECT().Log(
+		gomock.Any(),
+		http.StatusOK,
+		audit.GetCredentialsEventType)
+	credManager.EXPECT().GetTaskCredentials(credsId).Return(
+		credentials.TaskIAMRoleCredentials{ARN: taskArn, IAMRoleCredentials: creds}, true)
+
+	// Prepare and send a request
+	req, err := http.NewRequest("GET", path, nil)
+	if err != nil {
+		require.NoError(t, err)
+	}
+	recorder := httptest.NewRecorder()
+	handler := makeHandler(credManager, auditLogger)
+	handler.ServeHTTP(recorder, req)
+
+	// Read the response
+	var response credentials.IAMRoleCredentials
+	err = json.Unmarshal(recorder.Body.Bytes(), &response)
+	require.NoError(t, err)
+
+	// Assert on status code and body
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	assert.Equal(t, expectedCreds, response)
+}

--- a/ecs-agent/tmds/handlers/v1/credentials_handler.go
+++ b/ecs-agent/tmds/handlers/v1/credentials_handler.go
@@ -1,0 +1,181 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package v1
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/aws/amazon-ecs-agent/ecs-agent/credentials"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/audit"
+	auditinterface "github.com/aws/amazon-ecs-agent/ecs-agent/logger/audit"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/audit/request"
+	handlersutils "github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/utils"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/utils"
+	"github.com/cihub/seelog"
+)
+
+const (
+	// Error Types
+
+	// ErrNoIDInRequest is the error code indicating that no ID was specified
+	ErrNoIDInRequest = "NoIdInRequest"
+
+	// ErrInvalidIDInRequest is the error code indicating that the ID was invalid
+	ErrInvalidIDInRequest = "InvalidIdInRequest"
+
+	// ErrNoCredentialsAssociated is the error code indicating no credentials are
+	// associated with the specified ID
+	ErrNoCredentialsAssociated = "NoCredentialsAssociated"
+
+	// ErrCredentialsUninitialized is the error code indicating that credentials were
+	// not properly initialized.  This may happen immediately after the agent is
+	// started, before it has completed state reconciliation.
+	ErrCredentialsUninitialized = "CredentialsUninitialized"
+
+	// ErrInternalServer is the error indicating something generic went wrong
+	ErrInternalServer = "InternalServerError"
+
+	// Credentials API version.
+	apiVersion = 1
+
+	// CredentialsPath specifies the relative URI path for serving task IAM credentials
+	CredentialsPath = credentials.V1CredentialsPath
+)
+
+// CredentialsHandler creates response for the 'v1/credentials' API. It returns a JSON response
+// containing credentials when found. The HTTP status code of 400 is returned otherwise.
+func CredentialsHandler(
+	credentialsManager credentials.Manager,
+	auditLogger auditinterface.AuditLogger,
+) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		credentialsID := getCredentialsID(r)
+		errPrefix := fmt.Sprintf("CredentialsV%dRequest: ", apiVersion)
+		CredentialsHandlerImpl(w, r, auditLogger, credentialsManager, credentialsID, errPrefix)
+	}
+}
+
+// CredentialsHandlerImpl is the major logic in CredentialsHandler, abstract this out
+// because v2.CredentialsHandler also uses the same logic.
+func CredentialsHandlerImpl(
+	w http.ResponseWriter,
+	r *http.Request,
+	auditLogger auditinterface.AuditLogger,
+	credentialsManager credentials.Manager,
+	credentialsID string,
+	errPrefix string,
+) {
+	responseJSON, arn, roleType, errorMessage, err := processCredentialsRequest(
+		credentialsManager, r, credentialsID, errPrefix)
+	if err != nil {
+		errResponseJSON, err := json.Marshal(errorMessage)
+		if e := handlersutils.WriteResponseIfMarshalError(w, err); e != nil {
+			return
+		}
+		writeCredentialsRequestResponse(w, r, errorMessage.HTTPErrorCode,
+			audit.GetCredentialsEventTypeFromRoleType(roleType), arn, auditLogger, errResponseJSON)
+		return
+	}
+
+	writeCredentialsRequestResponse(w, r, http.StatusOK,
+		audit.GetCredentialsEventTypeFromRoleType(roleType), arn, auditLogger, responseJSON)
+}
+
+// processCredentialsRequest returns the response json containing credentials for the
+// credentials id in the request
+func processCredentialsRequest(
+	credentialsManager credentials.Manager,
+	r *http.Request,
+	credentialsID string,
+	errPrefix string,
+) ([]byte, string, string, *handlersutils.ErrorMessage, error) {
+	if credentialsID == "" {
+		errText := errPrefix + "No Credential ID in the request"
+		seelog.Errorf("Error processing credential request: %s", errText)
+		msg := &handlersutils.ErrorMessage{
+			Code:          ErrNoIDInRequest,
+			Message:       errText,
+			HTTPErrorCode: http.StatusBadRequest,
+		}
+		return nil, "", "", msg, errors.New(errText)
+	}
+
+	credentials, ok := credentialsManager.GetTaskCredentials(credentialsID)
+	if !ok {
+		errText := errPrefix + "Credentials not found"
+		seelog.Errorf("Error processing credential request: %s", errText)
+		msg := &handlersutils.ErrorMessage{
+			Code:          ErrInvalidIDInRequest,
+			Message:       errText,
+			HTTPErrorCode: http.StatusBadRequest,
+		}
+		return nil, "", "", msg, errors.New(errText)
+	}
+
+	seelog.Infof("Processing credential request, credentialType=%s taskARN=%s",
+		credentials.IAMRoleCredentials.RoleType, credentials.ARN)
+
+	if utils.ZeroOrNil(credentials.ARN) && utils.ZeroOrNil(credentials.IAMRoleCredentials) {
+		// This can happen when the agent is restarted and is reconciling its state.
+		errText := errPrefix + "Credentials uninitialized for ID"
+		seelog.Errorf("Error processing credential request credentialType=%s taskARN=%s: %s",
+			credentials.IAMRoleCredentials.RoleType, credentials.ARN, errText)
+		msg := &handlersutils.ErrorMessage{
+			Code:          ErrCredentialsUninitialized,
+			Message:       errText,
+			HTTPErrorCode: http.StatusServiceUnavailable,
+		}
+		return nil, "", "", msg, errors.New(errText)
+	}
+
+	credentialsJSON, err := json.Marshal(credentials.IAMRoleCredentials)
+	if err != nil {
+		errText := errPrefix + "Error marshaling credentials"
+		seelog.Errorf("Error processing credential request credentialType=%s taskARN=%s: %s",
+			credentials.IAMRoleCredentials.RoleType, credentials.ARN, errText)
+		msg := &handlersutils.ErrorMessage{
+			Code:          ErrInternalServer,
+			Message:       "Internal server error",
+			HTTPErrorCode: http.StatusInternalServerError,
+		}
+		return nil, "", "", msg, errors.New(errText)
+	}
+
+	// Success
+	return credentialsJSON, credentials.ARN, credentials.IAMRoleCredentials.RoleType, nil, nil
+}
+
+func writeCredentialsRequestResponse(
+	w http.ResponseWriter,
+	r *http.Request,
+	httpStatusCode int,
+	eventType string,
+	arn string,
+	auditLogger auditinterface.AuditLogger,
+	message []byte,
+) {
+	auditLogger.Log(request.LogRequest{Request: r, ARN: arn}, httpStatusCode, eventType)
+	handlersutils.WriteJSONToResponse(w, httpStatusCode, message, handlersutils.RequestTypeCreds)
+}
+
+func getCredentialsID(r *http.Request) string {
+	credentialsID, ok := handlersutils.ValueFromRequest(r, credentials.CredentialsIDQueryParameterName)
+	if ok {
+		return credentialsID
+	}
+	return ""
+}

--- a/ecs-agent/tmds/handlers/v2/credentials_handler.go
+++ b/ecs-agent/tmds/handlers/v2/credentials_handler.go
@@ -1,0 +1,54 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package v2
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/aws/amazon-ecs-agent/ecs-agent/credentials"
+	auditinterface "github.com/aws/amazon-ecs-agent/ecs-agent/logger/audit"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/utils"
+	v1 "github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v1"
+	"github.com/gorilla/mux"
+)
+
+const (
+	// Credentials API version.
+	apiVersion = 2
+
+	// credentialsIDMuxName is the key that's used in gorilla/mux to get the credentials ID.
+	credentialsIDMuxName = "credentialsIDMuxName"
+)
+
+// CredentialsPath specifies the relative URI path for serving task IAM credentials.
+// Use "AnythingRegEx" regex to handle the case where the "credentialsIDMuxName" is
+// empty, this is because the name that's used to extract dynamic value in gorilla cannot
+// be empty by default. If we don't do this, we will get 404 error when we access "/v2/credentials/",
+// but it should be 400 error.
+var CredentialsPath = credentials.V2CredentialsPath + "/" + utils.ConstructMuxVar(credentialsIDMuxName, utils.AnythingRegEx)
+
+// CredentialsHandler creates response for the 'v2/credentials' API.
+func CredentialsHandler(credentialsManager credentials.Manager, auditLogger auditinterface.AuditLogger) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		credentialsID := getCredentialsID(r)
+		errPrefix := fmt.Sprintf("CredentialsV%dRequest: ", apiVersion)
+		v1.CredentialsHandlerImpl(w, r, auditLogger, credentialsManager, credentialsID, errPrefix)
+	}
+}
+
+func getCredentialsID(r *http.Request) string {
+	vars := mux.Vars(r)
+	return vars[credentialsIDMuxName]
+}

--- a/ecs-agent/utils/utils.go
+++ b/ecs-agent/utils/utils.go
@@ -1,0 +1,37 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+package utils
+
+import "reflect"
+
+func ZeroOrNil(obj interface{}) bool {
+	value := reflect.ValueOf(obj)
+	if !value.IsValid() {
+		return true
+	}
+	if obj == nil {
+		return true
+	}
+	switch value.Kind() {
+	case reflect.Slice, reflect.Array, reflect.Map:
+		return value.Len() == 0
+	}
+	zero := reflect.Zero(reflect.TypeOf(obj))
+	if !value.Type().Comparable() {
+		return false
+	}
+	if obj == zero.Interface() {
+		return true
+	}
+	return false
+}

--- a/ecs-agent/utils/utils_test.go
+++ b/ecs-agent/utils/utils_test.go
@@ -1,0 +1,61 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type dummyStruct struct {
+	// no contents
+}
+
+func TestZeroOrNil(t *testing.T) {
+	type ZeroTest struct {
+		testInt     int
+		TestStr     string
+		testNilJson dummyStruct
+	}
+
+	var strMap map[string]string
+
+	testCases := []struct {
+		param    interface{}
+		expected bool
+		name     string
+	}{
+		{nil, true, "Nil is nil"},
+		{0, true, "0 is 0"},
+		{"", true, "\"\" is the string zerovalue"},
+		{ZeroTest{}, true, "ZeroTest zero-value should be zero"},
+		{ZeroTest{TestStr: "asdf"}, false, "ZeroTest with a field populated isn't zero"},
+		{ZeroTest{testNilJson: dummyStruct{}}, true, "nil is nil"},
+		{1, false, "1 is not 0"},
+		{[]uint16{1, 2, 3}, false, "[1,2,3] is not zero"},
+		{[]uint16{}, true, "[] is zero"},
+		{struct{ uncomparable []uint16 }{uncomparable: []uint16{1, 2, 3}}, false, "Uncomparable structs are never zero"},
+		{struct{ uncomparable []uint16 }{uncomparable: nil}, false, "Uncomparable structs are never zero"},
+		{strMap, true, "map[string]string is zero or nil"},
+		{make(map[string]string), true, "empty map[string]string is zero or nil"},
+		{map[string]string{"foo": "bar"}, false, "map[string]string{foo:bar} is not zero or nil"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, ZeroOrNil(tc.param), tc.name)
+		})
+	}
+
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Move v1 and v2 TMDS credentials endpoint handlers from agent module to ecs-agent module.

### Implementation details
<!-- How are the changes implemented? -->
* Moved v1 and v2 credentials endpoint handlers from agent module to ecs-agent module. 
    * `agent/handlers/v1/credentials_handler.go` to `ecs-agent/tmds/handlers/v1/credentials_handler.go`.
    * `agent/handlers/v2/credentials_handler.go` to `ecs-agent/tmds/handlers/v2/credentials_handler.go`.
* Added new unit tests to ecs-agent module for both credentials endpoint handlers. Although agent module has TMDS tests covering these endpoints, we want to have unit tests in ecs-agent module that exclusively cover these handlers too.
* Moved `GetCredentialsEventType` function from `agent/logger/audit/entry_types.go` to `ecs-agent/logger/audit/audit_log.go`. This function returns an appropriate audit log event type for the provided role type (task role or execution role) and is used by credentials endpoint handlers too. Also moved the corresponding audit log event type constants that this function returns. 
* Moved `ZeroOrNil` util function from `agent/utils/utils.go` to `ecs-agent/utils/utils.go` as it is used by credentials handlers.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
In addition to new unit tests, also performed manual stress testing for the two changed endpoints. There is no obvious change in performance seen. 

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Move v1 and v2 TMDS credentials endpoints to ecs-agent module.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
