### PR TITLE
Move common metadata models to ecs-agent module

### DIFF
--- a/agent/containermetadata/parse_metadata.go
+++ b/agent/containermetadata/parse_metadata.go
@@ -19,6 +19,7 @@ import (
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 
+	tmdsresponse "github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/response"
 	"github.com/cihub/seelog"
 	"github.com/docker/docker/api/types"
 	dockercontainer "github.com/docker/docker/api/types/container"
@@ -142,17 +143,17 @@ func parseNetworkMetadata(settings *types.NetworkSettings, hostConfig *dockercon
 
 	// Extensive Network information is not available for Docker API versions 1.17-1.20
 	// Instead we only get the details of the first network
-	networkList := make([]Network, 0)
+	networkList := make([]tmdsresponse.Network, 0)
 	if len(settings.Networks) > 0 {
 		for modeFromSettings, containerNetwork := range settings.Networks {
 			networkMode := modeFromSettings
 			ipv4Addresses := []string{containerNetwork.IPAddress}
-			network := Network{NetworkMode: networkMode, IPv4Addresses: ipv4Addresses}
+			network := tmdsresponse.Network{NetworkMode: networkMode, IPv4Addresses: ipv4Addresses}
 			networkList = append(networkList, network)
 		}
 	} else {
 		ipv4Addresses := []string{ipv4AddressFromSettings}
-		network := Network{NetworkMode: networkModeFromHostConfig, IPv4Addresses: ipv4Addresses}
+		network := tmdsresponse.Network{NetworkMode: networkModeFromHostConfig, IPv4Addresses: ipv4Addresses}
 		networkList = append(networkList, network)
 	}
 

--- a/agent/containermetadata/types.go
+++ b/agent/containermetadata/types.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	tmdsresponse "github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/response"
 	"github.com/docker/docker/api/types"
 )
 
@@ -82,19 +83,12 @@ type DockerMetadataClient interface {
 	InspectContainer(context.Context, string, time.Duration) (*types.ContainerJSON, error)
 }
 
-// Network is a struct that keeps track of metadata of a network interface
-type Network struct {
-	NetworkMode   string   `json:"NetworkMode,omitempty"`
-	IPv4Addresses []string `json:"IPv4Addresses,omitempty"`
-	IPv6Addresses []string `json:"IPv6Addresses,omitempty"`
-}
-
 // NetworkMetadata keeps track of the data we parse from the Network Settings
 // in docker containers. While most information is redundant with the internal
 // Network struct, we keeps this wrapper in case we wish to add data specifically
 // from the NetworkSettings
 type NetworkMetadata struct {
-	networks []Network
+	networks []tmdsresponse.Network
 }
 
 // DockerContainerMetadata keeps track of all metadata acquired from Docker inspection
@@ -147,7 +141,7 @@ type metadataSerializer struct {
 	ImageID                string                     `json:"ImageID,omitempty"`
 	ImageName              string                     `json:"ImageName,omitempty"`
 	Ports                  []apicontainer.PortBinding `json:"PortMappings,omitempty"`
-	Networks               []Network                  `json:"Networks,omitempty"`
+	Networks               []tmdsresponse.Network     `json:"Networks,omitempty"`
 	MetadataFileStatus     MetadataStatus             `json:"MetadataFileStatus,omitempty"`
 	AvailabilityZone       string                     `json:"AvailabilityZone,omitempty"`
 	HostPrivateIPv4Address string                     `json:"HostPrivateIPv4Address,omitempty"`

--- a/agent/handlers/task_server_setup_test.go
+++ b/agent/handlers/task_server_setup_test.go
@@ -35,11 +35,9 @@ import (
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	apitaskstatus "github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	"github.com/aws/amazon-ecs-agent/agent/config"
-	"github.com/aws/amazon-ecs-agent/agent/containermetadata"
 	"github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
 	mock_dockerstate "github.com/aws/amazon-ecs-agent/agent/engine/dockerstate/mocks"
 	task_protection_v1 "github.com/aws/amazon-ecs-agent/agent/handlers/agentapi/taskprotection/v1/handlers"
-	v1 "github.com/aws/amazon-ecs-agent/agent/handlers/v1"
 	v2 "github.com/aws/amazon-ecs-agent/agent/handlers/v2"
 	v3 "github.com/aws/amazon-ecs-agent/agent/handlers/v3"
 	v4 "github.com/aws/amazon-ecs-agent/agent/handlers/v4"
@@ -50,6 +48,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/ecs-agent/credentials"
 	mock_credentials "github.com/aws/amazon-ecs-agent/ecs-agent/credentials/mocks"
 	mock_audit "github.com/aws/amazon-ecs-agent/ecs-agent/logger/audit/mocks"
+	tmdsresponse "github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/response"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/utils"
 	tmdsv1 "github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v1"
 	"github.com/aws/aws-sdk-go/aws"
@@ -242,14 +241,14 @@ var (
 		},
 		Type:   containerType,
 		Labels: labels,
-		Ports: []v1.PortResponse{
+		Ports: []tmdsresponse.PortResponse{
 			{
 				ContainerPort: containerPort,
 				Protocol:      containerPortProtocol,
 				HostPort:      containerPort,
 			},
 		},
-		Networks: []containermetadata.Network{
+		Networks: []tmdsresponse.Network{
 			{
 				NetworkMode:   utils.NetworkModeAWSVPC,
 				IPv4Addresses: []string{eniIPv4Address},
@@ -348,13 +347,13 @@ var (
 		},
 		Type:   containerType,
 		Labels: labels,
-		Ports: []v1.PortResponse{
+		Ports: []tmdsresponse.PortResponse{
 			{
 				ContainerPort: containerPort,
 				Protocol:      containerPortProtocol,
 			},
 		},
-		Networks: []containermetadata.Network{
+		Networks: []tmdsresponse.Network{
 			{
 				NetworkMode:   bridgeMode,
 				IPv4Addresses: []string{bridgeIPAddr},
@@ -395,14 +394,14 @@ var (
 			},
 			Type:   containerType,
 			Labels: labels,
-			Ports: []v1.PortResponse{
+			Ports: []tmdsresponse.PortResponse{
 				{
 					ContainerPort: containerPort,
 					Protocol:      containerPortProtocol,
 					HostPort:      containerPort,
 				},
 			},
-			Networks: []containermetadata.Network{
+			Networks: []tmdsresponse.Network{
 				{
 					NetworkMode:   utils.NetworkModeAWSVPC,
 					IPv4Addresses: []string{eniIPv4Address},
@@ -410,7 +409,7 @@ var (
 			},
 		},
 		Networks: []v4.Network{{
-			Network: containermetadata.Network{
+			Network: tmdsresponse.Network{
 				NetworkMode:   utils.NetworkModeAWSVPC,
 				IPv4Addresses: []string{eniIPv4Address},
 			},
@@ -485,7 +484,7 @@ var (
 	expectedV4BridgeContainerResponse = v4.ContainerResponse{
 		ContainerResponse: &expectedBridgeContainerResponse,
 		Networks: []v4.Network{{
-			Network: containermetadata.Network{
+			Network: tmdsresponse.Network{
 				NetworkMode:   bridgeMode,
 				IPv4Addresses: []string{bridgeIPAddr},
 			},

--- a/agent/handlers/v1/response.go
+++ b/agent/handlers/v1/response.go
@@ -16,9 +16,9 @@ package v1
 import (
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
-	"github.com/aws/amazon-ecs-agent/agent/containermetadata"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
+	tmdsresponse "github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/response"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/utils"
 )
 
@@ -46,28 +46,12 @@ type TasksResponse struct {
 
 // ContainerResponse is the schema for the container response JSON object
 type ContainerResponse struct {
-	DockerID   string                      `json:"DockerId"`
-	DockerName string                      `json:"DockerName"`
-	Name       string                      `json:"Name"`
-	Ports      []PortResponse              `json:"Ports,omitempty"`
-	Networks   []containermetadata.Network `json:"Networks,omitempty"`
-	Volumes    []VolumeResponse            `json:"Volumes,omitempty"`
-}
-
-// VolumeResponse is the schema for the volume response JSON object
-type VolumeResponse struct {
-	DockerName  string `json:"DockerName,omitempty"`
-	Source      string `json:"Source,omitempty"`
-	Destination string `json:"Destination,omitempty"`
-}
-
-// PortResponse defines the schema for portmapping response JSON
-// object.
-type PortResponse struct {
-	ContainerPort uint16 `json:"ContainerPort,omitempty"`
-	Protocol      string `json:"Protocol,omitempty"`
-	HostPort      uint16 `json:"HostPort,omitempty"`
-	HostIp        string `json:"HostIp,omitempty"`
+	DockerID   string                        `json:"DockerId"`
+	DockerName string                        `json:"DockerName"`
+	Name       string                        `json:"Name"`
+	Ports      []tmdsresponse.PortResponse   `json:"Ports,omitempty"`
+	Networks   []tmdsresponse.Network        `json:"Networks,omitempty"`
+	Volumes    []tmdsresponse.VolumeResponse `json:"Volumes,omitempty"`
 }
 
 // NewTaskResponse creates a TaskResponse for a task.
@@ -113,7 +97,7 @@ func NewContainerResponse(dockerContainer *apicontainer.DockerContainer, eni *ap
 	resp.Volumes = NewVolumesResponse(dockerContainer)
 
 	if eni != nil {
-		resp.Networks = []containermetadata.Network{
+		resp.Networks = []tmdsresponse.Network{
 			{
 				NetworkMode:   utils.NetworkModeAWSVPC,
 				IPv4Addresses: eni.GetIPV4Addresses(),
@@ -125,9 +109,9 @@ func NewContainerResponse(dockerContainer *apicontainer.DockerContainer, eni *ap
 }
 
 // NewPortBindingsResponse creates PortResponse for a container.
-func NewPortBindingsResponse(dockerContainer *apicontainer.DockerContainer, eni *apieni.ENI) []PortResponse {
+func NewPortBindingsResponse(dockerContainer *apicontainer.DockerContainer, eni *apieni.ENI) []tmdsresponse.PortResponse {
 	container := dockerContainer.Container
-	resp := []PortResponse{}
+	resp := []tmdsresponse.PortResponse{}
 
 	bindings := container.GetKnownPortBindings()
 
@@ -138,7 +122,7 @@ func NewPortBindingsResponse(dockerContainer *apicontainer.DockerContainer, eni 
 	}
 
 	for _, binding := range bindings {
-		port := PortResponse{
+		port := tmdsresponse.PortResponse{
 			ContainerPort: binding.ContainerPort,
 			Protocol:      binding.Protocol.String(),
 		}
@@ -155,14 +139,14 @@ func NewPortBindingsResponse(dockerContainer *apicontainer.DockerContainer, eni 
 }
 
 // NewVolumesResponse creates VolumeResponse for a container
-func NewVolumesResponse(dockerContainer *apicontainer.DockerContainer) []VolumeResponse {
+func NewVolumesResponse(dockerContainer *apicontainer.DockerContainer) []tmdsresponse.VolumeResponse {
 	container := dockerContainer.Container
-	var resp []VolumeResponse
+	var resp []tmdsresponse.VolumeResponse
 
 	volumes := container.GetVolumes()
 
 	for _, volume := range volumes {
-		volResp := VolumeResponse{
+		volResp := tmdsresponse.VolumeResponse{
 			DockerName:  volume.Name,
 			Source:      volume.Source,
 			Destination: volume.Destination,

--- a/agent/handlers/v2/response.go
+++ b/agent/handlers/v2/response.go
@@ -20,10 +20,10 @@ import (
 
 	"github.com/aws/amazon-ecs-agent/agent/api"
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
-	"github.com/aws/amazon-ecs-agent/agent/containermetadata"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	v1 "github.com/aws/amazon-ecs-agent/agent/handlers/v1"
 	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
+	tmdsresponse "github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/response"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/utils"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/cihub/seelog"
@@ -53,27 +53,27 @@ type TaskResponse struct {
 // ContainerResponse defines the schema for the container response
 // JSON object
 type ContainerResponse struct {
-	ID            string                      `json:"DockerId"`
-	Name          string                      `json:"Name"`
-	DockerName    string                      `json:"DockerName"`
-	Image         string                      `json:"Image"`
-	ImageID       string                      `json:"ImageID"`
-	Ports         []v1.PortResponse           `json:"Ports,omitempty"`
-	Labels        map[string]string           `json:"Labels,omitempty"`
-	DesiredStatus string                      `json:"DesiredStatus"`
-	KnownStatus   string                      `json:"KnownStatus"`
-	ExitCode      *int                        `json:"ExitCode,omitempty"`
-	Limits        LimitsResponse              `json:"Limits"`
-	CreatedAt     *time.Time                  `json:"CreatedAt,omitempty"`
-	StartedAt     *time.Time                  `json:"StartedAt,omitempty"`
-	FinishedAt    *time.Time                  `json:"FinishedAt,omitempty"`
-	Type          string                      `json:"Type"`
-	Networks      []containermetadata.Network `json:"Networks,omitempty"`
-	Health        *apicontainer.HealthStatus  `json:"Health,omitempty"`
-	Volumes       []v1.VolumeResponse         `json:"Volumes,omitempty"`
-	LogDriver     string                      `json:"LogDriver,omitempty"`
-	LogOptions    map[string]string           `json:"LogOptions,omitempty"`
-	ContainerARN  string                      `json:"ContainerARN,omitempty"`
+	ID            string                        `json:"DockerId"`
+	Name          string                        `json:"Name"`
+	DockerName    string                        `json:"DockerName"`
+	Image         string                        `json:"Image"`
+	ImageID       string                        `json:"ImageID"`
+	Ports         []tmdsresponse.PortResponse   `json:"Ports,omitempty"`
+	Labels        map[string]string             `json:"Labels,omitempty"`
+	DesiredStatus string                        `json:"DesiredStatus"`
+	KnownStatus   string                        `json:"KnownStatus"`
+	ExitCode      *int                          `json:"ExitCode,omitempty"`
+	Limits        LimitsResponse                `json:"Limits"`
+	CreatedAt     *time.Time                    `json:"CreatedAt,omitempty"`
+	StartedAt     *time.Time                    `json:"StartedAt,omitempty"`
+	FinishedAt    *time.Time                    `json:"FinishedAt,omitempty"`
+	Type          string                        `json:"Type"`
+	Networks      []tmdsresponse.Network        `json:"Networks,omitempty"`
+	Health        *apicontainer.HealthStatus    `json:"Health,omitempty"`
+	Volumes       []tmdsresponse.VolumeResponse `json:"Volumes,omitempty"`
+	LogDriver     string                        `json:"LogDriver,omitempty"`
+	LogOptions    map[string]string             `json:"LogOptions,omitempty"`
+	ContainerARN  string                        `json:"ContainerARN,omitempty"`
 }
 
 // LimitsResponse defines the schema for task/cpu limits response
@@ -272,7 +272,7 @@ func NewContainerResponse(
 	}
 
 	for _, binding := range container.GetKnownPortBindings() {
-		port := v1.PortResponse{
+		port := tmdsresponse.PortResponse{
 			ContainerPort: binding.ContainerPort,
 			Protocol:      binding.Protocol.String(),
 		}
@@ -289,7 +289,7 @@ func NewContainerResponse(
 	}
 
 	if eni != nil {
-		resp.Networks = []containermetadata.Network{
+		resp.Networks = []tmdsresponse.Network{
 			{
 				NetworkMode:   utils.NetworkModeAWSVPC,
 				IPv4Addresses: eni.GetIPV4Addresses(),

--- a/agent/handlers/v3/container_metadata_handler.go
+++ b/agent/handlers/v3/container_metadata_handler.go
@@ -18,9 +18,9 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/aws/amazon-ecs-agent/agent/containermetadata"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	v2 "github.com/aws/amazon-ecs-agent/agent/handlers/v2"
+	tmdsresponse "github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/response"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/utils"
 	"github.com/cihub/seelog"
 	"github.com/pkg/errors"
@@ -78,7 +78,7 @@ func GetContainerResponse(containerID string, state dockerstate.TaskEngineState)
 }
 
 // GetContainerNetworkMetadata returns the network metadata for the container
-func GetContainerNetworkMetadata(containerID string, state dockerstate.TaskEngineState) ([]containermetadata.Network, error) {
+func GetContainerNetworkMetadata(containerID string, state dockerstate.TaskEngineState) ([]tmdsresponse.Network, error) {
 	dockerContainer, ok := state.ContainerByID(containerID)
 	if !ok {
 		return nil, errors.Errorf("Unable to find container '%s'", containerID)
@@ -98,17 +98,17 @@ func GetContainerNetworkMetadata(containerID string, state dockerstate.TaskEngin
 
 	// Extensive Network information is not available for Docker API versions 1.17-1.20
 	// Instead we only get the details of the first network
-	networks := make([]containermetadata.Network, 0)
+	networks := make([]tmdsresponse.Network, 0)
 	if len(settings.Networks) > 0 {
 		for modeFromSettings, containerNetwork := range settings.Networks {
 			networkMode := modeFromSettings
 			ipv4Addresses := []string{containerNetwork.IPAddress}
-			network := containermetadata.Network{NetworkMode: networkMode, IPv4Addresses: ipv4Addresses}
+			network := tmdsresponse.Network{NetworkMode: networkMode, IPv4Addresses: ipv4Addresses}
 			networks = append(networks, network)
 		}
 	} else {
 		ipv4Addresses := []string{ipv4AddressFromSettings}
-		network := containermetadata.Network{NetworkMode: networkModeFromHostConfig, IPv4Addresses: ipv4Addresses}
+		network := tmdsresponse.Network{NetworkMode: networkModeFromHostConfig, IPv4Addresses: ipv4Addresses}
 		networks = append(networks, network)
 	}
 	return networks, nil

--- a/agent/handlers/v4/container_metadata_handler.go
+++ b/agent/handlers/v4/container_metadata_handler.go
@@ -18,9 +18,9 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/aws/amazon-ecs-agent/agent/containermetadata"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	v3 "github.com/aws/amazon-ecs-agent/agent/handlers/v3"
+	tmdsresponse "github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/response"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/utils"
 	"github.com/cihub/seelog"
 	"github.com/pkg/errors"
@@ -103,12 +103,12 @@ func GetContainerNetworkMetadata(containerID string, state dockerstate.TaskEngin
 		for modeFromSettings, containerNetwork := range settings.Networks {
 			networkMode := modeFromSettings
 			ipv4Addresses := []string{containerNetwork.IPAddress}
-			network := Network{Network: containermetadata.Network{NetworkMode: networkMode, IPv4Addresses: ipv4Addresses}}
+			network := Network{Network: tmdsresponse.Network{NetworkMode: networkMode, IPv4Addresses: ipv4Addresses}}
 			networks = append(networks, network)
 		}
 	} else {
 		ipv4Addresses := []string{ipv4AddressFromSettings}
-		network := Network{Network: containermetadata.Network{NetworkMode: networkModeFromHostConfig, IPv4Addresses: ipv4Addresses}}
+		network := Network{Network: tmdsresponse.Network{NetworkMode: networkModeFromHostConfig, IPv4Addresses: ipv4Addresses}}
 		networks = append(networks, network)
 	}
 	return networks, nil

--- a/agent/handlers/v4/response.go
+++ b/agent/handlers/v4/response.go
@@ -17,10 +17,10 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/api"
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
-	"github.com/aws/amazon-ecs-agent/agent/containermetadata"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	v2 "github.com/aws/amazon-ecs-agent/agent/handlers/v2"
 	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
+	tmdsresponse "github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/response"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/utils"
 	"github.com/pkg/errors"
 )
@@ -45,7 +45,7 @@ type ContainerResponse struct {
 // interface(s) on top of what is supported by v4.
 // See `NetworkInterfaceProperties` for more details.
 type Network struct {
-	containermetadata.Network
+	tmdsresponse.Network
 	// NetworkInterfaceProperties specifies additional properties of the network
 	// of the network interface that are exposed via the metadata server.
 	// We currently populate this only for the `awsvpc` networking mode.
@@ -147,7 +147,7 @@ func NewContainerResponse(
 // look up the task information in the local state based on the id, which could be
 // either task arn or contianer id.
 func toV4NetworkResponse(
-	networks []containermetadata.Network,
+	networks []tmdsresponse.Network,
 	lookup func() (*apitask.Task, bool),
 ) ([]Network, error) {
 	var resp []Network

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/response/response.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/response/response.go
@@ -1,0 +1,38 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// This package defines some common types used by all task metadata functions
+package response
+
+// VolumeResponse is the schema for the volume response JSON object
+type VolumeResponse struct {
+	DockerName  string `json:"DockerName,omitempty"`
+	Source      string `json:"Source,omitempty"`
+	Destination string `json:"Destination,omitempty"`
+}
+
+// PortResponse defines the schema for portmapping response JSON
+// object.
+type PortResponse struct {
+	ContainerPort uint16 `json:"ContainerPort,omitempty"`
+	Protocol      string `json:"Protocol,omitempty"`
+	HostPort      uint16 `json:"HostPort,omitempty"`
+	HostIp        string `json:"HostIp,omitempty"`
+}
+
+// Network is a struct that keeps track of metadata of a network interface
+type Network struct {
+	NetworkMode   string   `json:"NetworkMode,omitempty"`
+	IPv4Addresses []string `json:"IPv4Addresses,omitempty"`
+	IPv6Addresses []string `json:"IPv6Addresses,omitempty"`
+}

--- a/agent/vendor/modules.txt
+++ b/agent/vendor/modules.txt
@@ -21,6 +21,7 @@ github.com/aws/amazon-ecs-agent/ecs-agent/logger/audit/mocks
 github.com/aws/amazon-ecs-agent/ecs-agent/logger/audit/request
 github.com/aws/amazon-ecs-agent/ecs-agent/logger/field
 github.com/aws/amazon-ecs-agent/ecs-agent/tmds
+github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/response
 github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/utils
 github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v1
 github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v2

--- a/ecs-agent/tmds/handlers/response/response.go
+++ b/ecs-agent/tmds/handlers/response/response.go
@@ -1,0 +1,38 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// This package defines some common types used by all task metadata functions
+package response
+
+// VolumeResponse is the schema for the volume response JSON object
+type VolumeResponse struct {
+	DockerName  string `json:"DockerName,omitempty"`
+	Source      string `json:"Source,omitempty"`
+	Destination string `json:"Destination,omitempty"`
+}
+
+// PortResponse defines the schema for portmapping response JSON
+// object.
+type PortResponse struct {
+	ContainerPort uint16 `json:"ContainerPort,omitempty"`
+	Protocol      string `json:"Protocol,omitempty"`
+	HostPort      uint16 `json:"HostPort,omitempty"`
+	HostIp        string `json:"HostIp,omitempty"`
+}
+
+// Network is a struct that keeps track of metadata of a network interface
+type Network struct {
+	NetworkMode   string   `json:"NetworkMode,omitempty"`
+	IPv4Addresses []string `json:"IPv4Addresses,omitempty"`
+	IPv6Addresses []string `json:"IPv6Addresses,omitempty"`
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Move the following metadata models to `ecs-agent` module. 
* `PortResponse` and `VolumeResponse` models that are common to v1-v4 metadata endpoints 
*  `Network` model that is common to v1-v4 metadata endpoints and file-based container metadata feature.

These changes will be handy when more metadata models will be moved to ecs-agent in future PRs.

### Implementation details
<!-- How are the changes implemented? -->
* Move `PortResponse` and `VolumeResponse` structs from `agent/handlers/v1/response.go` to `ecs-agent/tmds/handlers/response.go`.
* Move `Network` struct from `agent/containermetadata/types.go` to `ecs-agent/tmds/handlers/response.go`.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
In addition to automated tests, performed manual tests to ensure that there is no change in networks, ports, and volumes metadata generated by container metadata file and TMDS.

Container metadata file before -
```
❯ docker exec $(docker ps --filter "ancestor=nginx" -q) bash -c 'cat $ECS_CONTAINER_METADATA_FILE' | jq '{PortMappings, NetworkBindings}'
{
  "PortMappings": [
    {
      "ContainerPort": 80,
      "ContainerPortRange": "",
      "HostPort": 32768,
      "BindIp": "0.0.0.0",
      "Protocol": "tcp"
    },
    {
      "ContainerPort": 80,
      "ContainerPortRange": "",
      "HostPort": 32768,
      "BindIp": "::",
      "Protocol": "tcp"
    }
  ],
  "Networks": [
    {
      "NetworkMode": "bridge",
      "IPv4Addresses": [
        "172.17.0.2"
      ]
    }
  ]
}
```

Container metadata file after -
```
❯ docker exec $(docker ps --filter "ancestor=nginx" -q) bash -c 'cat $ECS_CONTAINER_METADATA_FILE' | jq '{PortMappings, NetworkBindings}'
{
  "PortMappings": [
    {
      "ContainerPort": 80,
      "ContainerPortRange": "",
      "HostPort": 32768,
      "BindIp": "0.0.0.0",
      "Protocol": "tcp"
    },
    {
      "ContainerPort": 80,
      "ContainerPortRange": "",
      "HostPort": 32768,
      "BindIp": "::",
      "Protocol": "tcp"
    }
  ],
  "Networks": [
    {
      "NetworkMode": "bridge",
      "IPv4Addresses": [
        "172.17.0.2"
      ]
    }
  ]
}
```

v3 metadata before - 
```
❯ docker exec $(docker ps --filter "ancestor=nginx" -q) bash -c 'curl $ECS_CONTAINER_METADATA_URI' | jq '{Ports, Networks, Volumes}'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2451    0  2451    0     0  2393k      0 --:--:-- --:--:-- --:--:-- 2393k
{
  "Ports": [
    {
      "ContainerPort": 80,
      "Protocol": "tcp",
      "HostPort": 32768
    },
    {
      "ContainerPort": 80,
      "Protocol": "tcp",
      "HostPort": 32768
    }
  ],
  "Networks": [
    {
      "NetworkMode": "bridge",
      "IPv4Addresses": [
        "172.17.0.2"
      ]
    }
  ],
  "Volumes": [
    {
      "Source": "/tmp",
      "Destination": "/volume/shared"
    },
    {
      "Source": "/var/lib/ecs/data/metadata/test/a0293b9e29174d9fa7beee14e6f12106/web",
      "Destination": "/opt/ecs/metadata/d18aea79-5cf9-49a9-9247-afb7c5480e1b"
    }
  ]
}
```

v3 metadata after - 
```
❯ docker exec $(docker ps --filter "ancestor=nginx" -q) bash -c 'curl $ECS_CONTAINER_METADATA_URI' | jq '{Ports, Networks, Volumes}'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2526    0  2526    0     0  2466k      0 --:--:-- --:--:-- --:--:-- 2466k
{
  "Ports": [
    {
      "ContainerPort": 80,
      "Protocol": "tcp",
      "HostPort": 32768
    },
    {
      "ContainerPort": 80,
      "Protocol": "tcp",
      "HostPort": 32768
    }
  ],
  "Networks": [
    {
      "NetworkMode": "bridge",
      "IPv4Addresses": [
        "172.17.0.2"
      ]
    }
  ],
  "Volumes": [
    {
      "Source": "/tmp",
      "Destination": "/volume/shared"
    },
    {
      "Source": "/var/lib/ecs/data/metadata/test/b9a1aec39a4f40de9764bc218cac1247/web",
      "Destination": "/opt/ecs/metadata/852e304d-2e03-4d4a-a38d-b893e14e7f48"
    }
  ]
}
```

v4 metadata  before - 
```
❯ docker exec $(docker ps --filter "ancestor=nginx" -q) bash -c 'curl $ECS_CONTAINER_METADATA_URI_V4' | jq '{Ports, Networks, Volumes}'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2645    0  2645    0     0  2583k      0 --:--:-- --:--:-- --:--:-- 2583k
{
  "Ports": [
    {
      "ContainerPort": 80,
      "Protocol": "tcp",
      "HostPort": 32768,
      "HostIp": "0.0.0.0"
    },
    {
      "ContainerPort": 80,
      "Protocol": "tcp",
      "HostPort": 32768,
      "HostIp": "::"
    }
  ],
  "Networks": [
    {
      "NetworkMode": "bridge",
      "IPv4Addresses": [
        "172.17.0.2"
      ]
    }
  ],
  "Volumes": [
    {
      "Source": "/tmp",
      "Destination": "/volume/shared"
    },
    {
      "Source": "/var/lib/ecs/data/metadata/test/a0293b9e29174d9fa7beee14e6f12106/web",
      "Destination": "/opt/ecs/metadata/d18aea79-5cf9-49a9-9247-afb7c5480e1b"
    }
  ]
}
```

v4 metadata after - 
```
❯ docker exec $(docker ps --filter "ancestor=nginx" -q) bash -c 'curl $ECS_CONTAINER_METADATA_URI_V4' | jq '{Ports, Networks, Volumes}'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2720    0  2720    0     0  2656k      0 --:--:-- --:--:-- --:--:-- 2656k
{
  "Ports": [
    {
      "ContainerPort": 80,
      "Protocol": "tcp",
      "HostPort": 32768,
      "HostIp": "0.0.0.0"
    },
    {
      "ContainerPort": 80,
      "Protocol": "tcp",
      "HostPort": 32768,
      "HostIp": "::"
    }
  ],
  "Networks": [
    {
      "NetworkMode": "bridge",
      "IPv4Addresses": [
        "172.17.0.2"
      ]
    }
  ],
  "Volumes": [
    {
      "Source": "/tmp",
      "Destination": "/volume/shared"
    },
    {
      "Source": "/var/lib/ecs/data/metadata/test/b9a1aec39a4f40de9764bc218cac1247/web",
      "Destination": "/opt/ecs/metadata/852e304d-2e03-4d4a-a38d-b893e14e7f48"
    }
  ]
}
```


New tests cover the changes: <!-- yes|no --> no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Move common metadata models to ecs-agent module.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
