### PR TITLE
Refresh Windows Domainless gMSA plugin credentials

### DIFF
--- a/agent/acs/handler/refresh_credentials_handler.go
+++ b/agent/acs/handler/refresh_credentials_handler.go
@@ -13,9 +13,8 @@
 package handler
 
 import (
-	"fmt"
-
 	"context"
+	"fmt"
 
 	"github.com/aws/amazon-ecs-agent/agent/engine"
 	"github.com/aws/amazon-ecs-agent/agent/wsclient"
@@ -23,6 +22,13 @@ import (
 	"github.com/aws/amazon-ecs-agent/ecs-agent/credentials"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/cihub/seelog"
+
+	"github.com/pkg/errors"
+)
+
+var (
+	// For ease of unit testing
+	checkAndSetDomainlessGMSATaskExecutionRoleCredentialsImpl = checkAndSetDomainlessGMSATaskExecutionRoleCredentials
 )
 
 // refreshCredentialsHandler represents the refresh credentials operation for the ACS client
@@ -145,10 +151,11 @@ func (refreshHandler *refreshCredentialsHandler) handleSingleMessage(message *ec
 	if !validRoleType(roleType) {
 		seelog.Errorf("Unknown RoleType for task in credentials message, roleType: %s arn: %s, messageId: %s", roleType, taskArn, messageId)
 	} else {
+		iamRoleCredentials := credentials.IAMRoleCredentialsFromACS(message.RoleCredentials, roleType)
 		err = refreshHandler.credentialsManager.SetTaskCredentials(
 			&(credentials.TaskIAMRoleCredentials{
 				ARN:                taskArn,
-				IAMRoleCredentials: credentials.IAMRoleCredentialsFromACS(message.RoleCredentials, roleType),
+				IAMRoleCredentials: iamRoleCredentials,
 			}))
 		if err != nil {
 			seelog.Errorf("Unable to update credentials for task, err: %v messageId: %s", err, messageId)
@@ -160,6 +167,12 @@ func (refreshHandler *refreshCredentialsHandler) handleSingleMessage(message *ec
 		}
 		if roleType == credentials.ExecutionRoleType {
 			task.SetExecutionRoleCredentialsID(aws.StringValue(message.RoleCredentials.CredentialsId))
+			// Refresh domainless gMSA plugin credentials if needed
+			err = checkAndSetDomainlessGMSATaskExecutionRoleCredentialsImpl(iamRoleCredentials, task)
+			if err != nil {
+				seelog.Errorf("Unable to SetDomainlessGMSATaskExecutionRoleCredentials for task %s, err: %v messageId: %s", taskArn, err, messageId)
+				return errors.Wrap(err, "unable to SetDomainlessGMSATaskExecutionRoleCredentials")
+			}
 		}
 	}
 

--- a/agent/acs/handler/refresh_credentials_handler_linux.go
+++ b/agent/acs/handler/refresh_credentials_handler_linux.go
@@ -1,0 +1,30 @@
+//go:build linux
+// +build linux
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package handler
+
+import (
+	"github.com/aws/amazon-ecs-agent/agent/api/task"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/credentials"
+)
+
+func checkAndSetDomainlessGMSATaskExecutionRoleCredentials(iamRoleCredentials credentials.IAMRoleCredentials, task *task.Task) error {
+	// exit early if the task does not need domainless gMSA
+	if !task.RequiresDomainlessCredentialSpecResource() {
+		return nil
+	}
+	return nil
+}

--- a/agent/acs/handler/refresh_credentials_handler_windows.go
+++ b/agent/acs/handler/refresh_credentials_handler_windows.go
@@ -1,0 +1,33 @@
+//go:build windows
+// +build windows
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package handler
+
+import (
+	"github.com/aws/amazon-ecs-agent/agent/api/task"
+	"github.com/aws/amazon-ecs-agent/agent/taskresource/credentialspec"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/credentials"
+)
+
+// setDomainlessGMSATaskExecutionRoleCredentials sets the taskExecutionRoleCredentials to a Windows Registry Key so that
+// the domainless gMSA plugin can use these credentials to retrieve the customer Active Directory credential
+func checkAndSetDomainlessGMSATaskExecutionRoleCredentials(iamRoleCredentials credentials.IAMRoleCredentials, task *task.Task) error {
+	// exit early if the task does not need domainless gMSA
+	if !task.RequiresDomainlessCredentialSpecResource() {
+		return nil
+	}
+	return credentialspec.SetTaskExecutionCredentialsRegKeys(iamRoleCredentials, task.Arn)
+}

--- a/agent/api/container/container.go
+++ b/agent/api/container/container.go
@@ -1356,14 +1356,24 @@ func (c *Container) UpdateManagedAgentSentStatus(agentName string, status apicon
 	return false
 }
 
-// RequiresCredentialSpec checks if container needs a credentialspec resource
-func (c *Container) RequiresCredentialSpec() bool {
+// RequiresAnyCredentialSpec checks if container needs a credentialspec resource (domain-joined or domainless)
+func (c *Container) RequiresAnyCredentialSpec() bool {
 	credSpec, err := c.getCredentialSpec()
 	if err != nil || credSpec == "" {
 		return false
 	}
 
 	return true
+}
+
+// RequiresDomainlessCredentialSpec checks if container needs a domainless credentialspec resource
+func (c *Container) RequiresDomainlessCredentialSpec() bool {
+	credSpec, err := c.getCredentialSpec()
+	if err != nil || credSpec == "" {
+		return false
+	}
+
+	return strings.HasPrefix(credSpec, credentialSpecDomainlessPrefix)
 }
 
 // GetCredentialSpec is used to retrieve the current credentialspec resource

--- a/agent/api/task/task_unsupported.go
+++ b/agent/api/task/task_unsupported.go
@@ -73,9 +73,9 @@ func (task *Task) dockerCPUShares(containerCPU uint) int64 {
 	return int64(containerCPU)
 }
 
-// requiresCredentialSpecResource returns true if at least one container in the task
+// requiresAnyCredentialSpecResource returns true if at least one container in the task
 // needs a valid credentialspec resource
-func (task *Task) requiresCredentialSpecResource() bool {
+func (task *Task) requiresAnyCredentialSpecResource() bool {
 	return false
 }
 

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -1402,7 +1402,7 @@ func (engine *DockerTaskEngine) createContainer(task *apitask.Task, container *a
 	}
 
 	// Populate credentialspec resource
-	if container.RequiresCredentialSpec() {
+	if container.RequiresAnyCredentialSpec() {
 		logger.Debug("Obtained container with credentialspec resource requirement for task", logger.Fields{
 			field.TaskID:    task.GetID(),
 			field.Container: container.Name,

--- a/agent/taskresource/credentialspec/credentialspec_windows.go
+++ b/agent/taskresource/credentialspec/credentialspec_windows.go
@@ -66,7 +66,7 @@ var (
 	readCredentialSpecImpl                    = readCredentialSpec
 	writeCredentialSpecImpl                   = writeCredentialSpec
 	readWriteDomainlessCredentialSpecImpl     = readWriteDomainlessCredentialSpec
-	setTaskExecutionCredentialsRegKeysImpl    = setTaskExecutionCredentialsRegKeys
+	setTaskExecutionCredentialsRegKeysImpl    = SetTaskExecutionCredentialsRegKeys
 	handleNonFileDomainlessGMSACredSpecImpl   = handleNonFileDomainlessGMSACredSpec
 	deleteTaskExecutionCredentialsRegKeysImpl = deleteTaskExecutionCredentialsRegKeys
 )
@@ -496,7 +496,7 @@ func (cs *CredentialSpecResource) UnmarshallPlatformSpecificFields(credentialSpe
 // setTaskExecutionCredentialsRegKeys stores the taskExecutionRole IAM credentials to the task registry key
 // so that the domainless gMSA plugin may use these credentials to access the customer Active Directory authentication
 // information.
-func setTaskExecutionCredentialsRegKeys(taskCredentials credentials.IAMRoleCredentials, taskArn string) error {
+func SetTaskExecutionCredentialsRegKeys(taskCredentials credentials.IAMRoleCredentials, taskArn string) error {
 	if taskCredentials == (credentials.IAMRoleCredentials{}) {
 		err := errors.New("Unable to find execution role credentials while setting registry key for task " + taskArn)
 		return err
@@ -529,6 +529,7 @@ func setTaskExecutionCredentialsRegKeys(taskCredentials credentials.IAMRoleCrede
 		return errors.Wrapf(err, errMsg)
 	}
 
+	seelog.Infof("Successfully SetTaskExecutionCredentialsRegKeys for task %s", taskArn)
 	return nil
 }
 

--- a/agent/taskresource/credentialspec/credentialspec_windows_test.go
+++ b/agent/taskresource/credentialspec/credentialspec_windows_test.go
@@ -1150,7 +1150,7 @@ func TestGetTargetMappingErr(t *testing.T) {
 
 func TestSetTaskExecutionCredentialsRegKeysErr(t *testing.T) {
 	var iamCredentials credentials.IAMRoleCredentials
-	err := setTaskExecutionCredentialsRegKeys(iamCredentials, "12345678")
+	err := SetTaskExecutionCredentialsRegKeys(iamCredentials, "12345678")
 	assert.EqualError(t, err, "Unable to find execution role credentials while setting registry key for task 12345678")
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
The domainless gMSA plugin requires taskExecutionRole IAM credentials to access customer resources. These credentials are populated once at the beginning of task start, but they need to be updated each time the credentials are vended down to the agent. 

### Implementation details
<!-- How are the changes implemented? -->
This change is primarily implemented in the refresh handler. Everytime an execution role gets vended down, the refresh handler should populate the Windows registry key where the plugin credentials are stored. 

### Testing
<!-- How was this tested? -->
This change was unit tested

I have also let a task run for 2 days and then checked out the instance logs and I do see that the credentials are being set correctly after a refresh from ACS (have logs I can send) 
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->
yes
### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Refresh Windows Domainless gMSA plugin credentials
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
