### PR TITLE
Move v4 metadata models to ecs-agent module

### DIFF
--- a/agent/handlers/task_server_setup_test.go
+++ b/agent/handlers/task_server_setup_test.go
@@ -39,7 +39,6 @@ import (
 	mock_dockerstate "github.com/aws/amazon-ecs-agent/agent/engine/dockerstate/mocks"
 	task_protection_v1 "github.com/aws/amazon-ecs-agent/agent/handlers/agentapi/taskprotection/v1/handlers"
 	v3 "github.com/aws/amazon-ecs-agent/agent/handlers/v3"
-	v4 "github.com/aws/amazon-ecs-agent/agent/handlers/v4"
 	"github.com/aws/amazon-ecs-agent/agent/stats"
 	mock_stats "github.com/aws/amazon-ecs-agent/agent/stats/mock"
 	agentutils "github.com/aws/amazon-ecs-agent/agent/utils"
@@ -51,6 +50,8 @@ import (
 	"github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/utils"
 	tmdsv1 "github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v1"
 	v2 "github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v2"
+	v4 "github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v4/state"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/docker/docker/api/types"
 	"github.com/golang/mock/gomock"

--- a/agent/handlers/v4/container_metadata_handler.go
+++ b/agent/handlers/v4/container_metadata_handler.go
@@ -22,6 +22,8 @@ import (
 	v3 "github.com/aws/amazon-ecs-agent/agent/handlers/v3"
 	tmdsresponse "github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/response"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/utils"
+	tmdsv4 "github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v4/state"
+
 	"github.com/cihub/seelog"
 	"github.com/pkg/errors"
 )
@@ -62,7 +64,7 @@ func ContainerMetadataHandler(state dockerstate.TaskEngineState) func(http.Respo
 }
 
 // GetContainerResponse gets container response for v4 metadata
-func GetContainerResponse(containerID string, state dockerstate.TaskEngineState) (*ContainerResponse, error) {
+func GetContainerResponse(containerID string, state dockerstate.TaskEngineState) (*tmdsv4.ContainerResponse, error) {
 	containerResponse, err := NewContainerResponse(containerID, state)
 	if err != nil {
 		seelog.Errorf("Unable to get container metadata for container '%s'", containerID)
@@ -79,7 +81,7 @@ func GetContainerResponse(containerID string, state dockerstate.TaskEngineState)
 }
 
 // GetContainerNetworkMetadata returns the network metadata for the container
-func GetContainerNetworkMetadata(containerID string, state dockerstate.TaskEngineState) ([]Network, error) {
+func GetContainerNetworkMetadata(containerID string, state dockerstate.TaskEngineState) ([]tmdsv4.Network, error) {
 	dockerContainer, ok := state.ContainerByID(containerID)
 	if !ok {
 		return nil, errors.Errorf("unable to find container '%s'", containerID)
@@ -98,17 +100,17 @@ func GetContainerNetworkMetadata(containerID string, state dockerstate.TaskEngin
 
 	// Extensive Network information is not available for Docker API versions 1.17-1.20
 	// Instead we only get the details of the first network
-	networks := make([]Network, 0)
+	networks := make([]tmdsv4.Network, 0)
 	if len(settings.Networks) > 0 {
 		for modeFromSettings, containerNetwork := range settings.Networks {
 			networkMode := modeFromSettings
 			ipv4Addresses := []string{containerNetwork.IPAddress}
-			network := Network{Network: tmdsresponse.Network{NetworkMode: networkMode, IPv4Addresses: ipv4Addresses}}
+			network := tmdsv4.Network{Network: tmdsresponse.Network{NetworkMode: networkMode, IPv4Addresses: ipv4Addresses}}
 			networks = append(networks, network)
 		}
 	} else {
 		ipv4Addresses := []string{ipv4AddressFromSettings}
-		network := Network{Network: tmdsresponse.Network{NetworkMode: networkModeFromHostConfig, IPv4Addresses: ipv4Addresses}}
+		network := tmdsv4.Network{Network: tmdsresponse.Network{NetworkMode: networkModeFromHostConfig, IPv4Addresses: ipv4Addresses}}
 		networks = append(networks, network)
 	}
 	return networks, nil

--- a/agent/handlers/v4/task_metadata_handler.go
+++ b/agent/handlers/v4/task_metadata_handler.go
@@ -22,6 +22,8 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
 	v3 "github.com/aws/amazon-ecs-agent/agent/handlers/v3"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/utils"
+	tmdsv4 "github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v4/state"
+
 	"github.com/cihub/seelog"
 )
 
@@ -70,7 +72,7 @@ func TaskMetadataHandler(state dockerstate.TaskEngineState, ecsClient api.ECSCli
 		// for non-awsvpc task mode
 		if !task.IsNetworkModeAWSVPC() {
 			// fill in non-awsvpc network details for container responses here
-			responses := make([]ContainerResponse, 0)
+			responses := make([]tmdsv4.ContainerResponse, 0)
 			for _, containerResponse := range taskResponse.Containers {
 				networks, err := GetContainerNetworkMetadata(containerResponse.ID, state)
 				if err != nil {

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v4/state/response.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v4/state/response.go
@@ -1,0 +1,69 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+package state
+
+import (
+	"github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/response"
+	v2 "github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v2"
+)
+
+// TaskResponse is the v4 Task response. It augments the v4 Container response
+// with the v2 task response object.
+type TaskResponse struct {
+	*v2.TaskResponse
+	Containers  []ContainerResponse `json:"Containers,omitempty"`
+	VPCID       string              `json:"VPCID,omitempty"`
+	ServiceName string              `json:"ServiceName,omitempty"`
+}
+
+// ContainerResponse is the v4 Container response. It augments the v4 Network response
+// with the v2 container response object.
+type ContainerResponse struct {
+	*v2.ContainerResponse
+	Networks []Network `json:"Networks,omitempty"`
+}
+
+// Network is the v4 Network response. It adds a bunch of information about network
+// interface(s) on top of what is supported by v4.
+// See `NetworkInterfaceProperties` for more details.
+type Network struct {
+	response.Network
+	// NetworkInterfaceProperties specifies additional properties of the network
+	// of the network interface that are exposed via the metadata server.
+	// We currently populate this only for the `awsvpc` networking mode.
+	NetworkInterfaceProperties
+}
+
+// NetworkInterfaceProperties represents additional properties we may want to expose via
+// task metadata about the network interface that's attached to the container/task. We
+// mostly use this to populate data about ENIs for tasks launched with `awsvpc` mode.
+type NetworkInterfaceProperties struct {
+	// AttachmentIndex reflects the `index` specified by the customer (if any)
+	// while creating the task with `awsvpc` mode.
+	AttachmentIndex *int `json:"AttachmentIndex,omitempty"`
+	// MACAddress is the MAC address of the network interface.
+	MACAddress string `json:"MACAddress,omitempty"`
+	// IPv4SubnetCIDRBlock is the IPv4 CIDR address block associated with the interface's subnet.
+	IPV4SubnetCIDRBlock string `json:"IPv4SubnetCIDRBlock,omitempty"`
+	// IPv6SubnetCIDRBlock is the IPv6 CIDR address block associated with the interface's subnet.
+	IPv6SubnetCIDRBlock string `json:"IPv6SubnetCIDRBlock,omitempty"`
+	// DomainNameServers specifies the nameserver IP addresses for the network interface.
+	DomainNameServers []string `json:"DomainNameServers,omitempty"`
+	// DomainNameSearchList specifies the search list for the domain name lookup for
+	// the network interface.
+	DomainNameSearchList []string `json:"DomainNameSearchList,omitempty"`
+	// PrivateDNSName is the dns name assigned to this network interface.
+	PrivateDNSName string `json:"PrivateDNSName,omitempty"`
+	// SubnetGatewayIPV4Address is the IPv4 gateway address for the network interface.
+	SubnetGatewayIPV4Address string `json:"SubnetGatewayIpv4Address,omitempty"`
+}

--- a/agent/vendor/modules.txt
+++ b/agent/vendor/modules.txt
@@ -25,6 +25,7 @@ github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/response
 github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/utils
 github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v1
 github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v2
+github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v4/state
 github.com/aws/amazon-ecs-agent/ecs-agent/tmds/logging
 github.com/aws/amazon-ecs-agent/ecs-agent/tmds/utils/mux
 github.com/aws/amazon-ecs-agent/ecs-agent/utils

--- a/ecs-agent/tmds/handlers/v4/state/response.go
+++ b/ecs-agent/tmds/handlers/v4/state/response.go
@@ -1,0 +1,69 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+package state
+
+import (
+	"github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/response"
+	v2 "github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/v2"
+)
+
+// TaskResponse is the v4 Task response. It augments the v4 Container response
+// with the v2 task response object.
+type TaskResponse struct {
+	*v2.TaskResponse
+	Containers  []ContainerResponse `json:"Containers,omitempty"`
+	VPCID       string              `json:"VPCID,omitempty"`
+	ServiceName string              `json:"ServiceName,omitempty"`
+}
+
+// ContainerResponse is the v4 Container response. It augments the v4 Network response
+// with the v2 container response object.
+type ContainerResponse struct {
+	*v2.ContainerResponse
+	Networks []Network `json:"Networks,omitempty"`
+}
+
+// Network is the v4 Network response. It adds a bunch of information about network
+// interface(s) on top of what is supported by v4.
+// See `NetworkInterfaceProperties` for more details.
+type Network struct {
+	response.Network
+	// NetworkInterfaceProperties specifies additional properties of the network
+	// of the network interface that are exposed via the metadata server.
+	// We currently populate this only for the `awsvpc` networking mode.
+	NetworkInterfaceProperties
+}
+
+// NetworkInterfaceProperties represents additional properties we may want to expose via
+// task metadata about the network interface that's attached to the container/task. We
+// mostly use this to populate data about ENIs for tasks launched with `awsvpc` mode.
+type NetworkInterfaceProperties struct {
+	// AttachmentIndex reflects the `index` specified by the customer (if any)
+	// while creating the task with `awsvpc` mode.
+	AttachmentIndex *int `json:"AttachmentIndex,omitempty"`
+	// MACAddress is the MAC address of the network interface.
+	MACAddress string `json:"MACAddress,omitempty"`
+	// IPv4SubnetCIDRBlock is the IPv4 CIDR address block associated with the interface's subnet.
+	IPV4SubnetCIDRBlock string `json:"IPv4SubnetCIDRBlock,omitempty"`
+	// IPv6SubnetCIDRBlock is the IPv6 CIDR address block associated with the interface's subnet.
+	IPv6SubnetCIDRBlock string `json:"IPv6SubnetCIDRBlock,omitempty"`
+	// DomainNameServers specifies the nameserver IP addresses for the network interface.
+	DomainNameServers []string `json:"DomainNameServers,omitempty"`
+	// DomainNameSearchList specifies the search list for the domain name lookup for
+	// the network interface.
+	DomainNameSearchList []string `json:"DomainNameSearchList,omitempty"`
+	// PrivateDNSName is the dns name assigned to this network interface.
+	PrivateDNSName string `json:"PrivateDNSName,omitempty"`
+	// SubnetGatewayIPV4Address is the IPv4 gateway address for the network interface.
+	SubnetGatewayIPV4Address string `json:"SubnetGatewayIpv4Address,omitempty"`
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Move v4 task and container metadata model structs to ecs-agent module. The structs will be used in upcoming PRs for ecs-agent module.

### Implementation details
<!-- How are the changes implemented? -->
* Move `TaskMetadata` and `ContainerMetadata` from agent to ecs-agent module. 
* Update agent module to consume the models from ecs-agent.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Automated tests only.

New tests cover the changes: <!-- yes|no --> no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Move v4 metadata models to ecs-agent module

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
