### PR TITLE
Add more v2, v3, and v4 task metadata tests

### DIFF
--- a/agent/handlers/task_server_setup_test.go
+++ b/agent/handlers/task_server_setup_test.go
@@ -463,7 +463,7 @@ func v4ContainerResponseFromV2(
 	}
 }
 
-// Returns a standard v4 task response. This getter fucntion protects against tests mutating
+// Returns a standard v4 task response. This getter function protects against tests mutating
 // the response.
 func expectedV4TaskResponse() v4.TaskResponse {
 	return v4TaskResponseFromV2(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
* Add more tests for v2, v3, and v4 task metadata endpoints. Currently there are some error cases that are not covered by existing tests. This change fills that gap in coverage. 
* General improvements to the test file. 
    * Replace some global variables for expected responses with getter functions so that tests are free to mutate the expected responses if needed without affecting other tests. 
    * Consolidate all cases for v2, v3, and v4 task metadata endpoints into one test each to promote code reuse and improve readability and maintainability. 

### Implementation details
<!-- How are the changes implemented? -->
* Add `TestV2TaskMetadata`, `TestV3TaskMetadata`, and `TestV4TaskMetadata` functions for testing v2, v3, and v4 task metadata endpoints, respectively. These test functions include all happy and error cases. Remove existing tests for these endpoints as they are covered in the new test functions. 
* Replace some global variables with getter functions for better test isolation (tests are free to mutate the values returned by the getter functions without affecting other tests).

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Add more v2, v3, and v4 task metadata tests

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
