### PR TITLE
Remove telemetry message logging to avoid polluting debug log too much

### DIFF
--- a/agent/stats/engine.go
+++ b/agent/stats/engine.go
@@ -480,7 +480,7 @@ func (engine *DockerStatsEngine) publishMetrics(includeServiceConnectStats bool)
 		}
 		select {
 		case engine.metricsChannel <- metricsMessage:
-			seelog.Debugf("sent telemetry message: %v", metricsMessage)
+			seelog.Debugf("sent telemetry message")
 		case <-publishMetricsCtx.Done():
 			seelog.Errorf("timeout sending telemetry message, discarding metrics")
 		}
@@ -500,7 +500,7 @@ func (engine *DockerStatsEngine) publishHealth() {
 		}
 		select {
 		case engine.healthChannel <- healthMessage:
-			seelog.Debugf("sent health message: %v", healthMessage)
+			seelog.Debugf("sent health message")
 		case <-publishHealthCtx.Done():
 			seelog.Errorf("timeout sending health message, discarding metrics")
 		}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Remove the logging of the telemetry messages sent through channel. Since telemetry messages are a single object and can't be formatted properly, having those logged will pollute the debug log, making it very messy.

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> N/A

Github workflow passed.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Remove telemetry message logging when communicate using channel.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
