### PR TITLE
Create TCS Handler in ecs-agent model

### DIFF
--- a/agent/stats/reporter/reporter.go
+++ b/agent/stats/reporter/reporter.go
@@ -1,0 +1,140 @@
+package reporter
+
+import (
+	"context"
+	"errors"
+	"io"
+	"time"
+
+	"github.com/aws/amazon-ecs-agent/agent/api"
+	"github.com/aws/amazon-ecs-agent/agent/config"
+	"github.com/aws/amazon-ecs-agent/agent/engine"
+	"github.com/aws/amazon-ecs-agent/agent/version"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/doctor"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/eventstream"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
+	tcshandler "github.com/aws/amazon-ecs-agent/ecs-agent/tcs/handler"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/tcs/model/ecstcs"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/retry"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/wsclient"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/cihub/seelog"
+)
+
+const (
+	// The maximum time to wait between heartbeats without disconnecting
+	defaultHeartbeatTimeout = 1 * time.Minute
+	defaultHeartbeatJitter  = 1 * time.Minute
+	// Default websocket client disconnection timeout initiated by agent
+	defaultDisconnectionTimeout = 15 * time.Minute
+	defaultDisconnectionJitter  = 30 * time.Minute
+)
+
+type DockerTelemetrySession struct {
+	s                    tcshandler.TelemetrySession
+	ecsClient            api.ECSClient
+	containerInstanceArn string
+}
+
+func (session *DockerTelemetrySession) Start(ctx context.Context) error {
+	backoff := retry.NewExponentialBackoff(time.Second, 1*time.Minute, 0.2, 2)
+	for {
+		endpoint, tcsError := discoverPollEndpoint(session.containerInstanceArn, session.ecsClient)
+		if tcsError == nil {
+			tcsError = session.s.StartTelemetrySession(ctx, endpoint)
+		}
+		switch tcsError {
+		case context.Canceled, context.DeadlineExceeded:
+			return tcsError
+		case io.EOF, nil:
+			logger.Info("TCS Websocket connection closed for a valid reason")
+			backoff.Reset()
+		default:
+			seelog.Errorf("Error: lost websocket connection with ECS Telemetry service (TCS): %v", tcsError)
+			time.Sleep(backoff.Duration())
+		}
+	}
+}
+
+func NewDockerTelemetrySession(
+	containerInstanceArn string,
+	credentialProvider *credentials.Credentials,
+	cfg *config.Config,
+	deregisterInstanceEventStream *eventstream.EventStream,
+	ecsClient api.ECSClient,
+	taskEngine engine.TaskEngine,
+	metricsChannel <-chan ecstcs.TelemetryMessage,
+	healthChannel <-chan ecstcs.HealthMessage,
+	doctor *doctor.Doctor) *DockerTelemetrySession {
+	ok, cfgParseErr := isContainerHealthMetricsDisabled(cfg)
+	if cfgParseErr != nil {
+		seelog.Warnf("Error starting metrics session: %v", cfgParseErr)
+		return nil
+	}
+	if ok {
+		seelog.Warnf("Metrics were disabled, not starting the telemetry session")
+		return nil
+	}
+
+	agentVersion, agentHash, containerRuntimeVersion := generateVersionInfo(taskEngine)
+	if cfg == nil {
+		logger.Error("Config is empty in the tcs session parameter")
+		return nil
+	}
+
+	session := tcshandler.NewTelemetrySession(
+		containerInstanceArn,
+		cfg.Cluster,
+		agentVersion,
+		agentHash,
+		containerRuntimeVersion,
+		"", // this will be overridden by DockerTelemetrySession.Start()
+		cfg.DisableMetrics.Enabled() && cfg.DisableDockerHealthCheck.Enabled(),
+		credentialProvider,
+		&wsclient.WSClientMinAgentConfig{
+			AWSRegion:          cfg.AWSRegion,
+			AcceptInsecureCert: cfg.AcceptInsecureCert,
+			DockerEndpoint:     cfg.DockerEndpoint,
+			IsDocker:           true,
+		},
+		deregisterInstanceEventStream,
+		defaultHeartbeatTimeout,
+		defaultHeartbeatJitter,
+		defaultDisconnectionTimeout,
+		defaultDisconnectionJitter,
+		nil,
+		metricsChannel,
+		healthChannel,
+		doctor,
+	)
+	return &DockerTelemetrySession{session, ecsClient, containerInstanceArn}
+}
+
+func generateVersionInfo(taskEngine engine.TaskEngine) (string, string, string) {
+	agentVersion := version.Version
+	agentHash := version.GitHashString()
+	var containerRuntimeVersion string
+	if dockerVersion, getVersionErr := taskEngine.Version(); getVersionErr == nil {
+		containerRuntimeVersion = dockerVersion
+	}
+
+	return agentVersion, agentHash, containerRuntimeVersion
+}
+
+func discoverPollEndpoint(containerInstanceArn string, ecsClient api.ECSClient) (string, error) {
+	tcsEndpoint, err := ecsClient.DiscoverTelemetryEndpoint(containerInstanceArn)
+	if err != nil {
+		logger.Error("tcs: unable to discover poll endpoint", logger.Fields{
+			field.Error: err,
+		})
+	}
+	return tcsEndpoint, err
+}
+
+func isContainerHealthMetricsDisabled(cfg *config.Config) (bool, error) {
+	if cfg != nil {
+		return cfg.DisableMetrics.Enabled() && cfg.DisableDockerHealthCheck.Enabled(), nil
+	}
+	return false, errors.New("config is empty in the tcs session parameter")
+}

--- a/agent/stats/reporter/reporter.go
+++ b/agent/stats/reporter/reporter.go
@@ -72,7 +72,7 @@ func NewDockerTelemetrySession(
 		agentHash,
 		containerRuntimeVersion,
 		"", // this will be overridden by DockerTelemetrySession.Start()
-		cfg.DisableMetrics.Enabled() && cfg.DisableDockerHealthCheck.Enabled(),
+		cfg.DisableMetrics.Enabled(),
 		credentialProvider,
 		&wsclient.WSClientMinAgentConfig{
 			AWSRegion:          cfg.AWSRegion,

--- a/agent/tcs/handler/types.go
+++ b/agent/tcs/handler/types.go
@@ -37,7 +37,6 @@ type TelemetrySessionParams struct {
 	CredentialProvider            *credentials.Credentials
 	Cfg                           *config.Config
 	DeregisterInstanceEventStream *eventstream.EventStream
-	AcceptInvalidCert             bool
 	ECSClient                     api.ECSClient
 	TaskEngine                    engine.TaskEngine
 	StatsEngine                   *stats.DockerStatsEngine

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tcs/handler/handler.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tcs/handler/handler.go
@@ -1,0 +1,258 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+//lint:file-ignore U1000 Ignore unused metricsFactory field as it is only used by Fargate
+
+package tcshandler
+
+import (
+	"context"
+	"io"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/aws/amazon-ecs-agent/ecs-agent/doctor"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/eventstream"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/metrics"
+	tcsclient "github.com/aws/amazon-ecs-agent/ecs-agent/tcs/client"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/tcs/model/ecstcs"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/retry"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/wsclient"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/cihub/seelog"
+)
+
+const (
+	// wsRWTimeout is the duration of read and write deadline for the websocket connection
+	deregisterContainerInstanceHandler = "TCSDeregisterContainerInstanceHandler"
+	ContainerRuntimeDocker             = "Docker"
+)
+
+// TelemetrySession defines an interface for handler's long-lived connection with TCS.
+type TelemetrySession interface {
+	StartTelemetrySession(context.Context, string) error
+	Start(context.Context) error
+}
+
+// telemetrySession is the base session params type which contains all the parameters required to start a tcs session
+type telemetrySession struct {
+	containerInstanceArn          string
+	cluster                       string
+	agentVersion                  string
+	agentHash                     string
+	containerRuntimeVersion       string
+	endpoint                      string
+	disableContainerHealthMetrics bool
+	credentialsProvider           *credentials.Credentials
+	cfg                           *wsclient.WSClientMinAgentConfig
+	deregisterInstanceEventStream *eventstream.EventStream
+	heartbeatTimeout              time.Duration
+	heartbeatJitterMax            time.Duration
+	disconnectTimeout             time.Duration
+	disconnectJitterMax           time.Duration
+	metricsFactory                metrics.EntryFactory
+	metricsChannel                <-chan ecstcs.TelemetryMessage
+	healthChannel                 <-chan ecstcs.HealthMessage
+	doctor                        *doctor.Doctor
+}
+
+func NewTelemetrySession(
+	containerInstanceArn string,
+	cluster string,
+	agentVersion string,
+	agentHash string,
+	containerRuntimeVersion string,
+	endpoint string,
+	disableContainerHealthMetrics bool,
+	credentialsProvider *credentials.Credentials,
+	cfg *wsclient.WSClientMinAgentConfig,
+	deregisterInstanceEventStream *eventstream.EventStream,
+	heartbeatTimeout time.Duration,
+	heartbeatJitterMax time.Duration,
+	disconnectTimeout time.Duration,
+	disconnectJitterMax time.Duration,
+	metricsFactory metrics.EntryFactory,
+	metricsChannel <-chan ecstcs.TelemetryMessage,
+	healthChannel <-chan ecstcs.HealthMessage,
+	doctor *doctor.Doctor,
+) TelemetrySession {
+	return &telemetrySession{
+		containerInstanceArn:          containerInstanceArn,
+		cluster:                       cluster,
+		agentVersion:                  agentVersion,
+		agentHash:                     agentHash,
+		containerRuntimeVersion:       containerRuntimeVersion,
+		endpoint:                      endpoint,
+		disableContainerHealthMetrics: disableContainerHealthMetrics,
+		credentialsProvider:           credentialsProvider,
+		cfg:                           cfg,
+		deregisterInstanceEventStream: deregisterInstanceEventStream,
+		metricsChannel:                metricsChannel,
+		healthChannel:                 healthChannel,
+		heartbeatTimeout:              heartbeatTimeout,
+		heartbeatJitterMax:            heartbeatJitterMax,
+		disconnectTimeout:             disconnectTimeout,
+		disconnectJitterMax:           disconnectJitterMax,
+		metricsFactory:                metricsFactory,
+		doctor:                        doctor,
+	}
+}
+
+// Start runs in for loop to start telemetry session with exponential backoff
+func (session *telemetrySession) Start(ctx context.Context) error {
+	backoff := retry.NewExponentialBackoff(time.Second, 1*time.Minute, 0.2, 2)
+	for {
+		tcsError := session.StartTelemetrySession(ctx, session.endpoint)
+		switch tcsError {
+		case context.Canceled, context.DeadlineExceeded:
+			return tcsError
+		case io.EOF, nil:
+			logger.Info("TCS Websocket connection closed for a valid reason")
+			backoff.Reset()
+		default:
+			seelog.Errorf("Error: lost websocket connection with ECS Telemetry service (TCS): %v", tcsError)
+			time.Sleep(backoff.Duration())
+		}
+	}
+}
+
+// StartTelemetrySession creates a session with the backend and handles requests.
+func (session *telemetrySession) StartTelemetrySession(ctx context.Context, endpoint string) error {
+	if session.disableContainerHealthMetrics {
+		logger.Warn("Metrics were disabled, not starting the telemetry session")
+		return nil
+	}
+
+	wsRWTimeout := 2*session.heartbeatTimeout + session.heartbeatJitterMax
+
+	var containerRuntime string
+	if session.cfg.IsDocker {
+		containerRuntime = ContainerRuntimeDocker
+	}
+
+	tcsEndpointUrl := formatURL(endpoint, session.cluster, session.containerInstanceArn, session.agentVersion,
+		session.agentHash, containerRuntime, session.containerRuntimeVersion)
+	client := tcsclient.New(tcsEndpointUrl, session.cfg, session.doctor, session.disableContainerHealthMetrics, tcsclient.DefaultContainerMetricsPublishInterval,
+		session.credentialsProvider, wsRWTimeout, session.metricsChannel, session.healthChannel)
+	defer client.Close()
+
+	if session.deregisterInstanceEventStream != nil {
+		err := session.deregisterInstanceEventStream.Subscribe(deregisterContainerInstanceHandler, client.Disconnect)
+		if err != nil {
+			return err
+		}
+		defer session.deregisterInstanceEventStream.Unsubscribe(deregisterContainerInstanceHandler)
+	}
+	err := client.Connect()
+	if err != nil {
+		logger.Error("Error connecting to TCS", logger.Fields{
+			field.Error: err,
+		})
+		return err
+	}
+	logger.Info("Connected to TCS endpoint")
+	// start a timer and listens for tcs heartbeats/acks. The timer is reset when
+	// we receive a heartbeat from the server or when a published metrics message
+	// is acked.
+	timer := time.NewTimer(retry.AddJitter(session.heartbeatTimeout, session.heartbeatJitterMax))
+	defer timer.Stop()
+	client.AddRequestHandler(heartbeatHandler(timer, session.heartbeatTimeout, session.heartbeatJitterMax))
+	client.AddRequestHandler(ackPublishMetricHandler(timer, session.heartbeatTimeout, session.heartbeatJitterMax))
+	client.AddRequestHandler(ackPublishHealthMetricHandler(timer, session.heartbeatTimeout, session.heartbeatJitterMax))
+	client.AddRequestHandler(ackPublishInstanceStatusHandler(timer, session.heartbeatTimeout, session.heartbeatJitterMax))
+	client.SetAnyRequestHandler(anyMessageHandler(client, wsRWTimeout))
+	serveC := make(chan error, 1)
+	go func() {
+		serveC <- client.Serve(ctx)
+	}()
+	select {
+	case <-ctx.Done():
+		// outer context done, agent is exiting
+		client.Disconnect()
+	case <-timer.C:
+		seelog.Info("TCS Connection hasn't had any activity for too long; disconnecting")
+		client.Disconnect()
+	case err := <-serveC:
+		return err
+	}
+	return nil
+}
+
+// heartbeatHandler resets the heartbeat timer when HeartbeatMessage message is received from tcs.
+func heartbeatHandler(timer *time.Timer, heartbeatTimeout, heartbeatJitter time.Duration) func(*ecstcs.HeartbeatMessage) {
+	return func(*ecstcs.HeartbeatMessage) {
+		logger.Debug("Received HeartbeatMessage from tcs")
+		timer.Reset(retry.AddJitter(heartbeatTimeout, heartbeatJitter))
+	}
+}
+
+// ackPublishMetricHandler consumes the ack message from the backend. THe backend sends
+// the ack each time it processes a metric message.
+func ackPublishMetricHandler(timer *time.Timer, heartbeatTimeout, heartbeatJitter time.Duration) func(*ecstcs.AckPublishMetric) {
+	return func(*ecstcs.AckPublishMetric) {
+		logger.Debug("Received AckPublishMetric from tcs")
+		timer.Reset(retry.AddJitter(heartbeatTimeout, heartbeatJitter))
+	}
+}
+
+// ackPublishHealthMetricHandler consumes the ack message from backend. The backend sends
+// the ack each time it processes a health message
+func ackPublishHealthMetricHandler(timer *time.Timer, heartbeatTimeout, heartbeatJitter time.Duration) func(*ecstcs.AckPublishHealth) {
+	return func(*ecstcs.AckPublishHealth) {
+		logger.Debug("Received ACKPublishHealth from tcs")
+		timer.Reset(retry.AddJitter(heartbeatTimeout, heartbeatJitter))
+	}
+}
+
+// ackPublishInstanceStatusHandler consumes the ack message from backend. The backend sends
+// the ack each time it processes a health message
+func ackPublishInstanceStatusHandler(timer *time.Timer, heartbeatTimeout, heartbeatJitter time.Duration) func(*ecstcs.AckPublishInstanceStatus) {
+	return func(*ecstcs.AckPublishInstanceStatus) {
+		logger.Debug("Received AckPublishInstanceStatus from tcs")
+		timer.Reset(retry.AddJitter(heartbeatTimeout, heartbeatJitter))
+	}
+}
+
+// anyMessageHandler handles any server message. Any server message means the
+// connection is active
+func anyMessageHandler(client wsclient.ClientServer, wsRWTimeout time.Duration) func(interface{}) {
+	return func(interface{}) {
+		logger.Trace("TCS activity occurred")
+		// Reset read deadline as there's activity on the channel
+		if err := client.SetReadDeadline(time.Now().Add(wsRWTimeout)); err != nil {
+			logger.Warn("Unable to extend read deadline for TCS connection", logger.Fields{
+				field.Error: err,
+			})
+		}
+	}
+}
+
+// formatURL returns formatted url for tcs endpoint.
+func formatURL(endpoint, cluster, containerInstance, agentVersion, agentHash, containerRuntime, containerRuntimeVersion string) string {
+	tcsURL := endpoint
+	if !strings.HasSuffix(tcsURL, "/") {
+		tcsURL += "/"
+	}
+	query := url.Values{}
+	query.Set("cluster", cluster)
+	query.Set("containerInstance", containerInstance)
+	query.Set("agentVersion", agentVersion)
+	query.Set("agentHash", agentHash)
+	if containerRuntime == ContainerRuntimeDocker && containerRuntimeVersion != "" {
+		query.Set("dockerVersion", containerRuntimeVersion)
+	}
+	return tcsURL + "ws?" + query.Encode()
+}

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tcs/handler/handler.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/tcs/handler/handler.go
@@ -36,7 +36,6 @@ import (
 )
 
 const (
-	// wsRWTimeout is the duration of read and write deadline for the websocket connection
 	deregisterContainerInstanceHandler = "TCSDeregisterContainerInstanceHandler"
 	ContainerRuntimeDocker             = "Docker"
 )

--- a/agent/vendor/modules.txt
+++ b/agent/vendor/modules.txt
@@ -27,6 +27,7 @@ github.com/aws/amazon-ecs-agent/ecs-agent/logger/audit/request
 github.com/aws/amazon-ecs-agent/ecs-agent/logger/field
 github.com/aws/amazon-ecs-agent/ecs-agent/metrics
 github.com/aws/amazon-ecs-agent/ecs-agent/tcs/client
+github.com/aws/amazon-ecs-agent/ecs-agent/tcs/handler
 github.com/aws/amazon-ecs-agent/ecs-agent/tcs/model/ecstcs
 github.com/aws/amazon-ecs-agent/ecs-agent/tmds
 github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/response

--- a/ecs-agent/tcs/handler/handler.go
+++ b/ecs-agent/tcs/handler/handler.go
@@ -54,7 +54,7 @@ type telemetrySession struct {
 	agentHash                     string
 	containerRuntimeVersion       string
 	endpoint                      string
-	disableContainerHealthMetrics bool
+	disableMetrics                bool
 	credentialsProvider           *credentials.Credentials
 	cfg                           *wsclient.WSClientMinAgentConfig
 	deregisterInstanceEventStream *eventstream.EventStream
@@ -75,7 +75,7 @@ func NewTelemetrySession(
 	agentHash string,
 	containerRuntimeVersion string,
 	endpoint string,
-	disableContainerHealthMetrics bool,
+	disableMetrics bool,
 	credentialsProvider *credentials.Credentials,
 	cfg *wsclient.WSClientMinAgentConfig,
 	deregisterInstanceEventStream *eventstream.EventStream,
@@ -95,7 +95,7 @@ func NewTelemetrySession(
 		agentHash:                     agentHash,
 		containerRuntimeVersion:       containerRuntimeVersion,
 		endpoint:                      endpoint,
-		disableContainerHealthMetrics: disableContainerHealthMetrics,
+		disableMetrics:                disableMetrics,
 		credentialsProvider:           credentialsProvider,
 		cfg:                           cfg,
 		deregisterInstanceEventStream: deregisterInstanceEventStream,
@@ -130,11 +130,6 @@ func (session *telemetrySession) Start(ctx context.Context) error {
 
 // StartTelemetrySession creates a session with the backend and handles requests.
 func (session *telemetrySession) StartTelemetrySession(ctx context.Context, endpoint string) error {
-	if session.disableContainerHealthMetrics {
-		logger.Warn("Metrics were disabled, not starting the telemetry session")
-		return nil
-	}
-
 	wsRWTimeout := 2*session.heartbeatTimeout + session.heartbeatJitterMax
 
 	var containerRuntime string
@@ -144,7 +139,7 @@ func (session *telemetrySession) StartTelemetrySession(ctx context.Context, endp
 
 	tcsEndpointUrl := formatURL(endpoint, session.cluster, session.containerInstanceArn, session.agentVersion,
 		session.agentHash, containerRuntime, session.containerRuntimeVersion)
-	client := tcsclient.New(tcsEndpointUrl, session.cfg, session.doctor, session.disableContainerHealthMetrics, tcsclient.DefaultContainerMetricsPublishInterval,
+	client := tcsclient.New(tcsEndpointUrl, session.cfg, session.doctor, session.disableMetrics, tcsclient.DefaultContainerMetricsPublishInterval,
 		session.credentialsProvider, wsRWTimeout, session.metricsChannel, session.healthChannel)
 	defer client.Close()
 

--- a/ecs-agent/tcs/handler/handler.go
+++ b/ecs-agent/tcs/handler/handler.go
@@ -1,0 +1,258 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+//lint:file-ignore U1000 Ignore unused metricsFactory field as it is only used by Fargate
+
+package tcshandler
+
+import (
+	"context"
+	"io"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/aws/amazon-ecs-agent/ecs-agent/doctor"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/eventstream"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/metrics"
+	tcsclient "github.com/aws/amazon-ecs-agent/ecs-agent/tcs/client"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/tcs/model/ecstcs"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/utils/retry"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/wsclient"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/cihub/seelog"
+)
+
+const (
+	// wsRWTimeout is the duration of read and write deadline for the websocket connection
+	deregisterContainerInstanceHandler = "TCSDeregisterContainerInstanceHandler"
+	ContainerRuntimeDocker             = "Docker"
+)
+
+// TelemetrySession defines an interface for handler's long-lived connection with TCS.
+type TelemetrySession interface {
+	StartTelemetrySession(context.Context, string) error
+	Start(context.Context) error
+}
+
+// telemetrySession is the base session params type which contains all the parameters required to start a tcs session
+type telemetrySession struct {
+	containerInstanceArn          string
+	cluster                       string
+	agentVersion                  string
+	agentHash                     string
+	containerRuntimeVersion       string
+	endpoint                      string
+	disableContainerHealthMetrics bool
+	credentialsProvider           *credentials.Credentials
+	cfg                           *wsclient.WSClientMinAgentConfig
+	deregisterInstanceEventStream *eventstream.EventStream
+	heartbeatTimeout              time.Duration
+	heartbeatJitterMax            time.Duration
+	disconnectTimeout             time.Duration
+	disconnectJitterMax           time.Duration
+	metricsFactory                metrics.EntryFactory
+	metricsChannel                <-chan ecstcs.TelemetryMessage
+	healthChannel                 <-chan ecstcs.HealthMessage
+	doctor                        *doctor.Doctor
+}
+
+func NewTelemetrySession(
+	containerInstanceArn string,
+	cluster string,
+	agentVersion string,
+	agentHash string,
+	containerRuntimeVersion string,
+	endpoint string,
+	disableContainerHealthMetrics bool,
+	credentialsProvider *credentials.Credentials,
+	cfg *wsclient.WSClientMinAgentConfig,
+	deregisterInstanceEventStream *eventstream.EventStream,
+	heartbeatTimeout time.Duration,
+	heartbeatJitterMax time.Duration,
+	disconnectTimeout time.Duration,
+	disconnectJitterMax time.Duration,
+	metricsFactory metrics.EntryFactory,
+	metricsChannel <-chan ecstcs.TelemetryMessage,
+	healthChannel <-chan ecstcs.HealthMessage,
+	doctor *doctor.Doctor,
+) TelemetrySession {
+	return &telemetrySession{
+		containerInstanceArn:          containerInstanceArn,
+		cluster:                       cluster,
+		agentVersion:                  agentVersion,
+		agentHash:                     agentHash,
+		containerRuntimeVersion:       containerRuntimeVersion,
+		endpoint:                      endpoint,
+		disableContainerHealthMetrics: disableContainerHealthMetrics,
+		credentialsProvider:           credentialsProvider,
+		cfg:                           cfg,
+		deregisterInstanceEventStream: deregisterInstanceEventStream,
+		metricsChannel:                metricsChannel,
+		healthChannel:                 healthChannel,
+		heartbeatTimeout:              heartbeatTimeout,
+		heartbeatJitterMax:            heartbeatJitterMax,
+		disconnectTimeout:             disconnectTimeout,
+		disconnectJitterMax:           disconnectJitterMax,
+		metricsFactory:                metricsFactory,
+		doctor:                        doctor,
+	}
+}
+
+// Start runs in for loop to start telemetry session with exponential backoff
+func (session *telemetrySession) Start(ctx context.Context) error {
+	backoff := retry.NewExponentialBackoff(time.Second, 1*time.Minute, 0.2, 2)
+	for {
+		tcsError := session.StartTelemetrySession(ctx, session.endpoint)
+		switch tcsError {
+		case context.Canceled, context.DeadlineExceeded:
+			return tcsError
+		case io.EOF, nil:
+			logger.Info("TCS Websocket connection closed for a valid reason")
+			backoff.Reset()
+		default:
+			seelog.Errorf("Error: lost websocket connection with ECS Telemetry service (TCS): %v", tcsError)
+			time.Sleep(backoff.Duration())
+		}
+	}
+}
+
+// StartTelemetrySession creates a session with the backend and handles requests.
+func (session *telemetrySession) StartTelemetrySession(ctx context.Context, endpoint string) error {
+	if session.disableContainerHealthMetrics {
+		logger.Warn("Metrics were disabled, not starting the telemetry session")
+		return nil
+	}
+
+	wsRWTimeout := 2*session.heartbeatTimeout + session.heartbeatJitterMax
+
+	var containerRuntime string
+	if session.cfg.IsDocker {
+		containerRuntime = ContainerRuntimeDocker
+	}
+
+	tcsEndpointUrl := formatURL(endpoint, session.cluster, session.containerInstanceArn, session.agentVersion,
+		session.agentHash, containerRuntime, session.containerRuntimeVersion)
+	client := tcsclient.New(tcsEndpointUrl, session.cfg, session.doctor, session.disableContainerHealthMetrics, tcsclient.DefaultContainerMetricsPublishInterval,
+		session.credentialsProvider, wsRWTimeout, session.metricsChannel, session.healthChannel)
+	defer client.Close()
+
+	if session.deregisterInstanceEventStream != nil {
+		err := session.deregisterInstanceEventStream.Subscribe(deregisterContainerInstanceHandler, client.Disconnect)
+		if err != nil {
+			return err
+		}
+		defer session.deregisterInstanceEventStream.Unsubscribe(deregisterContainerInstanceHandler)
+	}
+	err := client.Connect()
+	if err != nil {
+		logger.Error("Error connecting to TCS", logger.Fields{
+			field.Error: err,
+		})
+		return err
+	}
+	logger.Info("Connected to TCS endpoint")
+	// start a timer and listens for tcs heartbeats/acks. The timer is reset when
+	// we receive a heartbeat from the server or when a published metrics message
+	// is acked.
+	timer := time.NewTimer(retry.AddJitter(session.heartbeatTimeout, session.heartbeatJitterMax))
+	defer timer.Stop()
+	client.AddRequestHandler(heartbeatHandler(timer, session.heartbeatTimeout, session.heartbeatJitterMax))
+	client.AddRequestHandler(ackPublishMetricHandler(timer, session.heartbeatTimeout, session.heartbeatJitterMax))
+	client.AddRequestHandler(ackPublishHealthMetricHandler(timer, session.heartbeatTimeout, session.heartbeatJitterMax))
+	client.AddRequestHandler(ackPublishInstanceStatusHandler(timer, session.heartbeatTimeout, session.heartbeatJitterMax))
+	client.SetAnyRequestHandler(anyMessageHandler(client, wsRWTimeout))
+	serveC := make(chan error, 1)
+	go func() {
+		serveC <- client.Serve(ctx)
+	}()
+	select {
+	case <-ctx.Done():
+		// outer context done, agent is exiting
+		client.Disconnect()
+	case <-timer.C:
+		seelog.Info("TCS Connection hasn't had any activity for too long; disconnecting")
+		client.Disconnect()
+	case err := <-serveC:
+		return err
+	}
+	return nil
+}
+
+// heartbeatHandler resets the heartbeat timer when HeartbeatMessage message is received from tcs.
+func heartbeatHandler(timer *time.Timer, heartbeatTimeout, heartbeatJitter time.Duration) func(*ecstcs.HeartbeatMessage) {
+	return func(*ecstcs.HeartbeatMessage) {
+		logger.Debug("Received HeartbeatMessage from tcs")
+		timer.Reset(retry.AddJitter(heartbeatTimeout, heartbeatJitter))
+	}
+}
+
+// ackPublishMetricHandler consumes the ack message from the backend. THe backend sends
+// the ack each time it processes a metric message.
+func ackPublishMetricHandler(timer *time.Timer, heartbeatTimeout, heartbeatJitter time.Duration) func(*ecstcs.AckPublishMetric) {
+	return func(*ecstcs.AckPublishMetric) {
+		logger.Debug("Received AckPublishMetric from tcs")
+		timer.Reset(retry.AddJitter(heartbeatTimeout, heartbeatJitter))
+	}
+}
+
+// ackPublishHealthMetricHandler consumes the ack message from backend. The backend sends
+// the ack each time it processes a health message
+func ackPublishHealthMetricHandler(timer *time.Timer, heartbeatTimeout, heartbeatJitter time.Duration) func(*ecstcs.AckPublishHealth) {
+	return func(*ecstcs.AckPublishHealth) {
+		logger.Debug("Received ACKPublishHealth from tcs")
+		timer.Reset(retry.AddJitter(heartbeatTimeout, heartbeatJitter))
+	}
+}
+
+// ackPublishInstanceStatusHandler consumes the ack message from backend. The backend sends
+// the ack each time it processes a health message
+func ackPublishInstanceStatusHandler(timer *time.Timer, heartbeatTimeout, heartbeatJitter time.Duration) func(*ecstcs.AckPublishInstanceStatus) {
+	return func(*ecstcs.AckPublishInstanceStatus) {
+		logger.Debug("Received AckPublishInstanceStatus from tcs")
+		timer.Reset(retry.AddJitter(heartbeatTimeout, heartbeatJitter))
+	}
+}
+
+// anyMessageHandler handles any server message. Any server message means the
+// connection is active
+func anyMessageHandler(client wsclient.ClientServer, wsRWTimeout time.Duration) func(interface{}) {
+	return func(interface{}) {
+		logger.Trace("TCS activity occurred")
+		// Reset read deadline as there's activity on the channel
+		if err := client.SetReadDeadline(time.Now().Add(wsRWTimeout)); err != nil {
+			logger.Warn("Unable to extend read deadline for TCS connection", logger.Fields{
+				field.Error: err,
+			})
+		}
+	}
+}
+
+// formatURL returns formatted url for tcs endpoint.
+func formatURL(endpoint, cluster, containerInstance, agentVersion, agentHash, containerRuntime, containerRuntimeVersion string) string {
+	tcsURL := endpoint
+	if !strings.HasSuffix(tcsURL, "/") {
+		tcsURL += "/"
+	}
+	query := url.Values{}
+	query.Set("cluster", cluster)
+	query.Set("containerInstance", containerInstance)
+	query.Set("agentVersion", agentVersion)
+	query.Set("agentHash", agentHash)
+	if containerRuntime == ContainerRuntimeDocker && containerRuntimeVersion != "" {
+		query.Set("dockerVersion", containerRuntimeVersion)
+	}
+	return tcsURL + "ws?" + query.Encode()
+}

--- a/ecs-agent/tcs/handler/handler.go
+++ b/ecs-agent/tcs/handler/handler.go
@@ -36,7 +36,6 @@ import (
 )
 
 const (
-	// wsRWTimeout is the duration of read and write deadline for the websocket connection
 	deregisterContainerInstanceHandler = "TCSDeregisterContainerInstanceHandler"
 	ContainerRuntimeDocker             = "Docker"
 )

--- a/ecs-agent/tcs/handler/handler_test.go
+++ b/ecs-agent/tcs/handler/handler_test.go
@@ -132,33 +132,6 @@ func (Source *mockStatsSource) SimulateMetricsPublishToChannel(ctx context.Conte
 	}
 }
 
-// TestDisableMetrics tests the StartTelemetrySession will return immediately if
-// the metrics was disabled
-func TestDisableMetrics(t *testing.T) {
-	ctx, _ := context.WithCancel(context.Background())
-	session := NewTelemetrySession(
-		testInstanceArn,
-		testClusterArn,
-		testAgentVersion,
-		testAgentHash,
-		testContainerRuntimeVersion,
-		"",
-		true,
-		nil,
-		nil,
-		nil,
-		testHeartbeatTimeout,
-		testHeartbeatJitter,
-		testDisconnectionTimeout,
-		testDisconnectionJitter,
-		nil,
-		nil,
-		nil,
-		nil)
-
-	session.StartTelemetrySession(ctx, "")
-}
-
 func TestFormatURL(t *testing.T) {
 	endpoint := "http://127.0.0.0.1/"
 	ctrl := gomock.NewController(t)

--- a/ecs-agent/tcs/handler/handler_test.go
+++ b/ecs-agent/tcs/handler/handler_test.go
@@ -1,0 +1,517 @@
+//go:build unit
+// +build unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package tcshandler
+
+import (
+	"errors"
+	"io"
+	"math/rand"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"context"
+
+	"github.com/aws/amazon-ecs-agent/ecs-agent/doctor"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/eventstream"
+	tcsclient "github.com/aws/amazon-ecs-agent/ecs-agent/tcs/client"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/tcs/model/ecstcs"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/wsclient"
+	wsmock "github.com/aws/amazon-ecs-agent/ecs-agent/wsclient/mock/utils"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/golang/mock/gomock"
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testTaskArn                           = "arn:aws:ecs:us-east-1:123:task/def"
+	testTaskDefinitionFamily              = "task-def"
+	testClusterArn                        = "arn:aws:ecs:us-east-1:123:cluster/default"
+	testInstanceArn                       = "arn:aws:ecs:us-east-1:123:container-instance/abc"
+	testMessageId                         = "testMessageId"
+	testPublishMetricsInterval            = 1 * time.Second
+	testSendMetricsToChannelWaitTime      = 100 * time.Millisecond
+	testTelemetryChannelDefaultBufferSize = 10
+	testDockerEndpoint                    = "testEndpoint"
+	testAgentVersion                      = "testAgentVersion"
+	testAgentHash                         = "testAgentHash"
+	testContainerRuntimeVersion           = "testContainerRuntimeVersion"
+	testHeartbeatTimeout                  = 1 * time.Minute
+	testHeartbeatJitter                   = 1 * time.Minute
+	testDisconnectionTimeout              = 15 * time.Minute
+	testDisconnectionJitter               = 30 * time.Minute
+)
+
+type mockStatsSource struct {
+	metricsChannel       chan<- ecstcs.TelemetryMessage
+	healthChannel        chan<- ecstcs.HealthMessage
+	publishMetricsTicker *time.Ticker
+}
+
+var testCreds = credentials.NewStaticCredentials("test-id", "test-secret", "test-token")
+
+var testCfg = &wsclient.WSClientMinAgentConfig{
+	AWSRegion:          "us-east-1",
+	AcceptInsecureCert: true,
+	DockerEndpoint:     testDockerEndpoint,
+	IsDocker:           true,
+}
+
+var emptyDoctor, _ = doctor.NewDoctor([]doctor.Healthcheck{}, "test-cluster", "this:is:an:instance:arn")
+
+func (*mockStatsSource) GetInstanceMetrics(includeServiceConnectStats bool) (*ecstcs.MetricsMetadata, []*ecstcs.TaskMetric, error) {
+	req := createPublishMetricsRequest()
+	return req.Metadata, req.TaskMetrics, nil
+}
+
+func (*mockStatsSource) GetTaskHealthMetrics() (*ecstcs.HealthMetadata, []*ecstcs.TaskHealth, error) {
+	return nil, nil, nil
+}
+
+func (*mockStatsSource) GetPublishServiceConnectTickerInterval() int32 {
+	return 0
+}
+
+func (*mockStatsSource) SetPublishServiceConnectTickerInterval(counter int32) {
+	return
+}
+
+func (Source *mockStatsSource) GetPublishMetricsTicker() *time.Ticker {
+	return Source.publishMetricsTicker
+}
+
+// SimulateMetricsPublishToChannel simulates the behavior of `StartMetricsPublish` in DockerStatsSource, which feeds metrics
+// to channel to TCS Client. There has to be at least one valid metrics sent, otherwise no request will be made to mockServer
+// in TestStartTelemetrySession, specifically blocking `request := <-requestChan`
+func (Source *mockStatsSource) SimulateMetricsPublishToChannel(ctx context.Context) {
+	Source.publishMetricsTicker = time.NewTicker(testPublishMetricsInterval)
+	for {
+		select {
+		case <-Source.publishMetricsTicker.C:
+			Source.metricsChannel <- ecstcs.TelemetryMessage{
+				Metadata: &ecstcs.MetricsMetadata{
+					Cluster:           aws.String(testClusterArn),
+					ContainerInstance: aws.String(testInstanceArn),
+					Fin:               aws.Bool(false),
+					Idle:              aws.Bool(false),
+					MessageId:         aws.String(testMessageId),
+				},
+				TaskMetrics: []*ecstcs.TaskMetric{
+					&ecstcs.TaskMetric{},
+				},
+			}
+
+			Source.healthChannel <- ecstcs.HealthMessage{
+				Metadata:      &ecstcs.HealthMetadata{},
+				HealthMetrics: []*ecstcs.TaskHealth{},
+			}
+
+		case <-ctx.Done():
+			defer close(Source.metricsChannel)
+			defer close(Source.healthChannel)
+			return
+		}
+	}
+}
+
+// TestDisableMetrics tests the StartTelemetrySession will return immediately if
+// the metrics was disabled
+func TestDisableMetrics(t *testing.T) {
+	ctx, _ := context.WithCancel(context.Background())
+	session := NewTelemetrySession(
+		testInstanceArn,
+		testClusterArn,
+		testAgentVersion,
+		testAgentHash,
+		testContainerRuntimeVersion,
+		"",
+		true,
+		nil,
+		nil,
+		nil,
+		testHeartbeatTimeout,
+		testHeartbeatJitter,
+		testDisconnectionTimeout,
+		testDisconnectionJitter,
+		nil,
+		nil,
+		nil,
+		nil)
+
+	session.StartTelemetrySession(ctx, "")
+}
+
+func TestFormatURL(t *testing.T) {
+	endpoint := "http://127.0.0.0.1/"
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	wsurl := formatURL(endpoint, testClusterArn, testInstanceArn, testAgentVersion, testAgentHash,
+		ContainerRuntimeDocker, testContainerRuntimeVersion)
+	parsed, err := url.Parse(wsurl)
+	assert.NoError(t, err, "should be able to parse URL")
+	assert.Equal(t, "/ws", parsed.Path, "wrong path")
+	assert.Equal(t, testClusterArn, parsed.Query().Get("cluster"), "wrong cluster")
+	assert.Equal(t, testInstanceArn, parsed.Query().Get("containerInstance"), "wrong container instance")
+	assert.Equal(t, testAgentVersion, parsed.Query().Get("agentVersion"), "wrong agent version")
+	assert.Equal(t, testAgentHash, parsed.Query().Get("agentHash"), "wrong agent hash")
+	assert.Equal(t, testContainerRuntimeVersion, parsed.Query().Get("dockerVersion"), "wrong docker version")
+}
+
+func TestStartTelemetrySession(t *testing.T) {
+	// Start test server.
+	closeWS := make(chan []byte)
+	server, serverChan, requestChan, serverErr, err := wsmock.GetMockServer(closeWS)
+	server.StartTLS()
+	defer server.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	telemetryMessages := make(chan ecstcs.TelemetryMessage, testTelemetryChannelDefaultBufferSize)
+	healthMessages := make(chan ecstcs.HealthMessage, testTelemetryChannelDefaultBufferSize)
+
+	wait := &sync.WaitGroup{}
+	ctx, cancel := context.WithCancel(context.Background())
+	wait.Add(1)
+	go func() {
+		select {
+		case sErr := <-serverErr:
+			t.Error(sErr)
+		case <-ctx.Done():
+		}
+		wait.Done()
+	}()
+	defer func() {
+		closeSocket(closeWS)
+		close(serverChan)
+	}()
+
+	deregisterInstanceEventStream := eventstream.NewEventStream("Deregister_Instance", context.Background())
+
+	mockSource := &mockStatsSource{
+		metricsChannel: telemetryMessages,
+		healthChannel:  healthMessages,
+	}
+
+	session := NewTelemetrySession(
+		testInstanceArn,
+		testClusterArn,
+		testAgentVersion,
+		testAgentHash,
+		testContainerRuntimeVersion,
+		server.URL,
+		false,
+		testCreds,
+		testCfg,
+		deregisterInstanceEventStream,
+		testHeartbeatTimeout,
+		testHeartbeatJitter,
+		testDisconnectionTimeout,
+		testDisconnectionJitter,
+		nil,
+		telemetryMessages,
+		healthMessages,
+		emptyDoctor,
+	)
+
+	// Start a session with the test server.
+	go session.StartTelemetrySession(ctx, server.URL)
+
+	// Wait for 100 ms to make sure the session is ready to receive message from channel
+	time.Sleep(testSendMetricsToChannelWaitTime)
+	go mockSource.SimulateMetricsPublishToChannel(ctx)
+
+	// startTelemetrySession internally starts publishing metrics from the mockStatsSource object (poll msg out of channel).
+	time.Sleep(testPublishMetricsInterval * 2)
+
+	// Read request channel to get the metric data published to the server.
+	request := <-requestChan
+	cancel()
+	wait.Wait()
+	go func() {
+		for {
+			select {
+			case <-requestChan:
+			}
+		}
+	}()
+
+	// Decode and verify the metric data.
+	payload, err := getPayloadFromRequest(request)
+	if err != nil {
+		t.Fatal("Error decoding payload: ", err)
+	}
+
+	// Decode and verify the metric data.
+	_, responseType, err := wsclient.DecodeData([]byte(payload), tcsclient.NewTCSDecoder())
+	if err != nil {
+		t.Fatal("error decoding data: ", err)
+	}
+	if responseType != "PublishMetricsRequest" {
+		t.Fatal("Unexpected responseType: ", responseType)
+	}
+}
+
+func TestSessionConnectionClosedByRemote(t *testing.T) {
+	// Start test server.
+	closeWS := make(chan []byte)
+	server, serverChan, _, serverErr, err := wsmock.GetMockServer(closeWS)
+	server.StartTLS()
+	defer server.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		serr := <-serverErr
+		if !websocket.IsCloseError(serr, websocket.CloseNormalClosure) {
+			t.Error(serr)
+		}
+	}()
+	sleepBeforeClose := 10 * time.Millisecond
+	go func() {
+		time.Sleep(sleepBeforeClose)
+		closeSocket(closeWS)
+		close(serverChan)
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	deregisterInstanceEventStream := eventstream.NewEventStream("Deregister_Instance", ctx)
+	deregisterInstanceEventStream.StartListening()
+	defer cancel()
+
+	telemetryMessages := make(chan ecstcs.TelemetryMessage, testTelemetryChannelDefaultBufferSize)
+	healthMessages := make(chan ecstcs.HealthMessage, testTelemetryChannelDefaultBufferSize)
+
+	session := NewTelemetrySession(
+		testInstanceArn,
+		testClusterArn,
+		testAgentVersion,
+		testAgentHash,
+		testContainerRuntimeVersion,
+		server.URL,
+		false,
+		testCreds,
+		testCfg,
+		deregisterInstanceEventStream,
+		testHeartbeatTimeout,
+		testHeartbeatJitter,
+		testDisconnectionTimeout,
+		testDisconnectionJitter,
+		nil,
+		telemetryMessages,
+		healthMessages,
+		emptyDoctor,
+	)
+
+	// Start a session with the test server.
+	err = session.StartTelemetrySession(ctx, server.URL)
+
+	if err == nil {
+		t.Error("Expected io.EOF on closed connection")
+	}
+	if err != io.EOF {
+		t.Error("Expected io.EOF on closed connection, got: ", err)
+	}
+}
+
+// TestConnectionInactiveTimeout tests the tcs client reconnect when it loses network
+// connection, or it's inactive for too long
+func TestConnectionInactiveTimeout(t *testing.T) {
+	// Start test server.
+	closeWS := make(chan []byte)
+	server, _, requestChan, serverErr, err := wsmock.GetMockServer(closeWS)
+	server.StartTLS()
+	defer server.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	go func() {
+		for {
+			select {
+			case <-requestChan:
+			}
+		}
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	deregisterInstanceEventStream := eventstream.NewEventStream("Deregister_Instance", ctx)
+	deregisterInstanceEventStream.StartListening()
+	defer cancel()
+
+	telemetryMessages := make(chan ecstcs.TelemetryMessage, testTelemetryChannelDefaultBufferSize)
+	healthMessages := make(chan ecstcs.HealthMessage, testTelemetryChannelDefaultBufferSize)
+
+	session := NewTelemetrySession(
+		testInstanceArn,
+		testClusterArn,
+		testAgentVersion,
+		testAgentHash,
+		testContainerRuntimeVersion,
+		server.URL,
+		false,
+		testCreds,
+		testCfg,
+		deregisterInstanceEventStream,
+		50*time.Millisecond,
+		100*time.Millisecond,
+		testDisconnectionTimeout,
+		testDisconnectionJitter,
+		nil,
+		telemetryMessages,
+		healthMessages,
+		emptyDoctor,
+	)
+
+	// Start a session with the test server.
+	err = session.StartTelemetrySession(ctx, server.URL)
+
+	assert.NoError(t, err, "Close the connection should cause the tcs client return error")
+
+	assert.True(t, websocket.IsCloseError(<-serverErr, websocket.CloseAbnormalClosure),
+		"Read from closed connection should produce an io.EOF error")
+
+	closeSocket(closeWS)
+}
+
+func getPayloadFromRequest(request string) (string, error) {
+	lines := strings.Split(request, "\r\n")
+	if len(lines) > 0 {
+		return lines[len(lines)-1], nil
+	}
+
+	return "", errors.New("Could not get payload")
+}
+
+// closeSocket tells the server to send a close frame. This lets us test
+// what happens if the connection is closed by the remote server.
+func closeSocket(ws chan<- []byte) {
+	ws <- websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")
+	close(ws)
+}
+
+func createPublishMetricsRequest() *ecstcs.PublishMetricsRequest {
+	cluster := testClusterArn
+	ci := testInstanceArn
+	taskArn := testTaskArn
+	taskDefinitionFamily := testTaskDefinitionFamily
+	var fval float64
+	fval = rand.Float64()
+	var ival int64
+	ival = rand.Int63n(10)
+	ts := time.Now()
+	idle := false
+	messageId := testMessageId
+	return &ecstcs.PublishMetricsRequest{
+		Metadata: &ecstcs.MetricsMetadata{
+			Cluster:           &cluster,
+			ContainerInstance: &ci,
+			Idle:              &idle,
+			MessageId:         &messageId,
+		},
+		TaskMetrics: []*ecstcs.TaskMetric{
+			{
+				ContainerMetrics: []*ecstcs.ContainerMetric{
+					{
+						CpuStatsSet: &ecstcs.CWStatsSet{
+							Max:         &fval,
+							Min:         &fval,
+							SampleCount: &ival,
+							Sum:         &fval,
+						},
+						MemoryStatsSet: &ecstcs.CWStatsSet{
+							Max:         &fval,
+							Min:         &fval,
+							SampleCount: &ival,
+							Sum:         &fval,
+						},
+					},
+				},
+				TaskArn:              &taskArn,
+				TaskDefinitionFamily: &taskDefinitionFamily,
+			},
+		},
+		Timestamp: &ts,
+	}
+}
+
+func TestStartTelemetrySessionMetricsChannelPauseWhenClientClosed(t *testing.T) {
+	telemetryMessages := make(chan ecstcs.TelemetryMessage, testTelemetryChannelDefaultBufferSize)
+	healthMessages := make(chan ecstcs.HealthMessage, testTelemetryChannelDefaultBufferSize)
+
+	// Start test server.
+	closeWS := make(chan []byte)
+	server, _, _, _, _ := wsmock.GetMockServer(closeWS)
+	server.StartTLS()
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	deregisterInstanceEventStream := eventstream.NewEventStream("Deregister_Instance", context.Background())
+	deregisterInstanceEventStream.StartListening()
+
+	session := NewTelemetrySession(
+		testInstanceArn,
+		testClusterArn,
+		testAgentVersion,
+		testAgentHash,
+		testContainerRuntimeVersion,
+		server.URL,
+		false,
+		testCreds,
+		testCfg,
+		deregisterInstanceEventStream,
+		testHeartbeatTimeout,
+		testHeartbeatJitter,
+		testDisconnectionTimeout,
+		testDisconnectionJitter,
+		nil,
+		telemetryMessages,
+		healthMessages,
+		emptyDoctor,
+	)
+
+	go session.StartTelemetrySession(ctx, server.URL)
+	telemetryMessages <- ecstcs.TelemetryMessage{}
+	for len(telemetryMessages) != 0 {
+		time.Sleep(1 * time.Second)
+	} // wait till tcs client is up and is polling message
+
+	cancel()
+	time.Sleep(5 * time.Second) // wait till tcs client is stopped (returned from StartTelemetrySession)
+
+	// Send message while TCS Client is closed and verify the message is not polled but stays in the channel
+	for it := 0; it < testTelemetryChannelDefaultBufferSize; it++ {
+		telemetryMessages <- ecstcs.TelemetryMessage{}
+	}
+
+	// check messages filled the channel
+	assert.Len(t, telemetryMessages, testTelemetryChannelDefaultBufferSize)
+	// check after channel is full, message will be dropped
+
+	// simulating retry after backoff
+	newCtx, _ := context.WithCancel(context.Background())
+	go session.StartTelemetrySession(newCtx, server.URL)
+	for len(telemetryMessages) != 0 {
+		time.Sleep(1 * time.Second)
+	} // test will time out if after tcs client startup, message does not resume flowing
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Create TCS Handler in ecs-agent module and corresponding agent component to integrate with this change. Also add some tests to TCS Client and TCS Handler in ecs-agent module.

### Implementation details
<!-- How are the changes implemented? -->
- `ecs-agent/tcs/handler`
  - Change the implementation to have a `TelemetrySession` interface and an implementation 
  - Add a test to verify channel message persists while TCS connection dced, and resume to flow when TCS connection is recovered
- `ecs-agent/tcs/client`
  - Switch from default seelog interface to structured log
  - Add a test to verify generating publish metrics from telemetry message can be paginated properly based on metric size (this case should not happen based on current metrics size)
  - Add a test to verify the telemetry message channels are non blocking
  - Add a test to verify if an invalid telemetry message is sent to channel, no problematic request will be sent (this theoretically should not happen)
  - Some naming changes
- `stats/reporter`
  - Add function to generates agentVersion information (for generating TACS endpoint url), this was originally in `agent/tcs/handler`
  - Add function to get TCS endpoint using `discoverTelemetryEndpoint` API. This was originally in `agent/tcs/handler`
  - Embed `ecs-agent/tcs/handler`'s `TelemetrySession` interface to "override" `Start` function, so that `discoverPollEndpoint` can also be part of the retry and backoff, while avoiding moving too many code (some of those are agent module specific) to ecs-agent module 

A follow up PR will remove the `agent/tcs/handler` as well as wire in the new TCS Handler (use session definition in reporter in `agent.go`)

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes

- Testing workflow in github passed.
- Manually verified the normal TCS workflow and TCS connect/disconnect/reconnect behavior is working fine from ecs-agent.log after using agent wired in the handler changes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Create TCS Handler in ecs-agent model

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
