### PR TITLE
Update amazon-ecs-cni-plugins submodule

### DIFF
--- a/agent/ecscni/plugin_test.go
+++ b/agent/ecscni/plugin_test.go
@@ -29,7 +29,7 @@ import (
 const (
 	// ECSCNIVersion, ECSCNIGitHash, VPCCNIGitHash needs to be updated every time CNI plugin is updated.
 	currentECSCNIVersion = "2020.09.0"
-	currentECSCNIGitHash = "50a9a47e9ca6e11f2498b4cbc6ebcffa537714db"
+	currentECSCNIGitHash = "53a8481891251e66e35847554d52a13fc7c4fd03"
 	currentVPCCNIGitHash = "30b9470e014b65bb8dc7f05f92848910b3f1b3c7"
 )
 


### PR DESCRIPTION
This pulls in a fix for an error that can occur when using awsvpc networking mode where a stale MAC address can cause temporary loss of network connectivity in a container.

Pulls in the following PRs with the fix and comments:

https://github.com/aws/amazon-ecs-cni-plugins/pull/111
https://github.com/aws/amazon-ecs-cni-plugins/pull/112

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

functional tests, verified expected behavior manually

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

Bugfix: awsvpc network mode stale MAC address connectivity issue

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
