### PR TITLE
Add test cases for GetTaskProtection API to TMDS tests

### DIFF
--- a/agent/handlers/agentapi/taskprotection/v1/handlers/handlers.go
+++ b/agent/handlers/agentapi/taskprotection/v1/handlers/handlers.go
@@ -125,7 +125,7 @@ func UpdateTaskProtectionHandler(state dockerstate.TaskEngineState, credentialsM
 				updateTaskProtectionRequestType)
 			return
 		}
-		ecsClient := factory.newTaskProtectionClient(taskRoleCredential)
+		ecsClient := factory.NewTaskProtectionClient(taskRoleCredential)
 
 		ctx, cancel := context.WithTimeout(r.Context(), ecsCallTimeout)
 		defer cancel()
@@ -221,7 +221,7 @@ func GetTaskProtectionHandler(state dockerstate.TaskEngineState, credentialsMana
 			return
 		}
 
-		ecsClient := factory.newTaskProtectionClient(taskRoleCredential)
+		ecsClient := factory.NewTaskProtectionClient(taskRoleCredential)
 
 		ctx, cancel := context.WithTimeout(r.Context(), ecsCallTimeout)
 		defer cancel()
@@ -286,7 +286,7 @@ func GetTaskProtectionHandler(state dockerstate.TaskEngineState, credentialsMana
 }
 
 // Helper function for retrieving credential from credentials manager and create ecs client
-func (factory TaskProtectionClientFactory) newTaskProtectionClient(taskRoleCredential credentials.TaskIAMRoleCredentials) api.ECSTaskProtectionSDK {
+func (factory TaskProtectionClientFactory) NewTaskProtectionClient(taskRoleCredential credentials.TaskIAMRoleCredentials) api.ECSTaskProtectionSDK {
 	taskCredential := taskRoleCredential.GetIAMRoleCredentials()
 	cfg := aws.NewConfig().
 		WithCredentials(awscreds.NewStaticCredentials(taskCredential.AccessKeyID,

--- a/agent/handlers/agentapi/taskprotection/v1/handlers/handlers_mocks.go
+++ b/agent/handlers/agentapi/taskprotection/v1/handlers/handlers_mocks.go
@@ -49,16 +49,16 @@ func (m *MockTaskProtectionClientFactoryInterface) EXPECT() *MockTaskProtectionC
 	return m.recorder
 }
 
-// newTaskProtectionClient mocks base method.
-func (m *MockTaskProtectionClientFactoryInterface) newTaskProtectionClient(arg0 credentials.TaskIAMRoleCredentials) api.ECSTaskProtectionSDK {
+// NewTaskProtectionClient mocks base method.
+func (m *MockTaskProtectionClientFactoryInterface) NewTaskProtectionClient(arg0 credentials.TaskIAMRoleCredentials) api.ECSTaskProtectionSDK {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "newTaskProtectionClient", arg0)
+	ret := m.ctrl.Call(m, "NewTaskProtectionClient", arg0)
 	ret0, _ := ret[0].(api.ECSTaskProtectionSDK)
 	return ret0
 }
 
-// newTaskProtectionClient indicates an expected call of newTaskProtectionClient.
-func (mr *MockTaskProtectionClientFactoryInterfaceMockRecorder) newTaskProtectionClient(arg0 interface{}) *gomock.Call {
+// NewTaskProtectionClient indicates an expected call of NewTaskProtectionClient.
+func (mr *MockTaskProtectionClientFactoryInterfaceMockRecorder) NewTaskProtectionClient(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "newTaskProtectionClient", reflect.TypeOf((*MockTaskProtectionClientFactoryInterface)(nil).newTaskProtectionClient), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewTaskProtectionClient", reflect.TypeOf((*MockTaskProtectionClientFactoryInterface)(nil).NewTaskProtectionClient), arg0)
 }

--- a/agent/handlers/agentapi/taskprotection/v1/handlers/handlers_test.go
+++ b/agent/handlers/agentapi/taskprotection/v1/handlers/handlers_test.go
@@ -86,7 +86,7 @@ func TestGetECSClientHappyCase(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	ret := factory.newTaskProtectionClient(testIAMRoleCredentials)
+	ret := factory.NewTaskProtectionClient(testIAMRoleCredentials)
 	_, ok := ret.(api.ECSTaskProtectionSDK)
 
 	// Assert response
@@ -405,7 +405,7 @@ func TestUpdateTaskProtectionHandler_PostCall(t *testing.T) {
 			mockState.EXPECT().TaskARNByV3EndpointID(gomock.Eq(testV3EndpointId)).Return(testTaskArn, true)
 			mockState.EXPECT().TaskByArn(gomock.Eq(testTaskArn)).Return(&testTask, true)
 			mockManager.EXPECT().GetTaskCredentials(gomock.Eq(testTaskCredentialsId)).Return(credentials.TaskIAMRoleCredentials{}, true)
-			mockFactory.EXPECT().newTaskProtectionClient(gomock.Eq(credentials.TaskIAMRoleCredentials{})).Return(mockECSClient)
+			mockFactory.EXPECT().NewTaskProtectionClient(gomock.Eq(credentials.TaskIAMRoleCredentials{})).Return(mockECSClient)
 			mockECSClient.EXPECT().
 				UpdateTaskProtectionWithContext(gomock.Any(), gomock.Any()).
 				Return(tc.ecsResponse, tc.ecsError)
@@ -644,7 +644,7 @@ func TestGetTaskProtectionHandler_PostCall(t *testing.T) {
 			mockState.EXPECT().TaskARNByV3EndpointID(gomock.Eq(testV3EndpointId)).Return(testTaskArn, true)
 			mockState.EXPECT().TaskByArn(gomock.Eq(testTaskArn)).Return(&testTask, true)
 			mockManager.EXPECT().GetTaskCredentials(gomock.Eq(testTaskCredentialsId)).Return(credentials.TaskIAMRoleCredentials{}, true)
-			mockFactory.EXPECT().newTaskProtectionClient(gomock.Eq(credentials.TaskIAMRoleCredentials{})).Return(mockECSClient)
+			mockFactory.EXPECT().NewTaskProtectionClient(gomock.Eq(credentials.TaskIAMRoleCredentials{})).Return(mockECSClient)
 			mockECSClient.EXPECT().
 				GetTaskProtectionWithContext(gomock.Any(), gomock.Any()).
 				Return(tc.ecsResponse, tc.ecsError)

--- a/agent/handlers/agentapi/taskprotection/v1/handlers/interface.go
+++ b/agent/handlers/agentapi/taskprotection/v1/handlers/interface.go
@@ -6,5 +6,5 @@ import (
 )
 
 type TaskProtectionClientFactoryInterface interface {
-	newTaskProtectionClient(taskRoleCredential credentials.TaskIAMRoleCredentials) api.ECSTaskProtectionSDK
+	NewTaskProtectionClient(taskRoleCredential credentials.TaskIAMRoleCredentials) api.ECSTaskProtectionSDK
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Add comprehensive unit tests for GetTaskProtection API to Task Metadata Server (TMDS) tests. These test cases are already covered by handler-level unit tests for GetTaskProtection handler, however, we will be moving the handler to ecs-agent module in upcoming PRs and having the API tested by TMDS tests will help gain confidence in the move.

This change is a part of a series of similar changes we have been making for many TMDS endpoints. See #3729, #3722, and #3708 that did the same for taskWithTags, task metadata, and container metadata endpoints, respectively.

### Implementation details
<!-- How are the changes implemented? -->
* Export `NewTaskProtectionClient` method of `TaskProtectionClientFactoryInterface` interface so that it can be mocked. This interface is used by task protection handlers to initialize ECS clients with the right permissions to make ECS task protection calls for the tasks.
* Update TMDS setup in `agent/handlers/task_server_setup.go` to use dependency injection for `TaskProtectionClientFactoryInterface`.
* Add `TestAgentAPIV1GetTaskProtectionHandler` function to TMDS test file. This function contains tests for GetTaskProtection API.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> NA

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Add test cases for GetTaskProtection API to TMDS tests

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
