### PR TITLE
Change reconcile/container update order on init and waitForHostResources/emitCurrentStatus order

### DIFF
--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -3617,8 +3617,8 @@ func (task *Task) ToHostResources() map[string]*ecs.Resource {
 		"taskArn":   task.Arn,
 		"CPU":       *resources["CPU"].IntegerValue,
 		"MEMORY":    *resources["MEMORY"].IntegerValue,
-		"PORTS_TCP": resources["PORTS_TCP"].StringSetValue,
-		"PORTS_UDP": resources["PORTS_UDP"].StringSetValue,
+		"PORTS_TCP": aws.StringValueSlice(resources["PORTS_TCP"].StringSetValue),
+		"PORTS_UDP": aws.StringValueSlice(resources["PORTS_UDP"].StringSetValue),
 		"GPU":       *resources["GPU"].IntegerValue,
 	})
 	return resources

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -597,11 +597,13 @@ func (engine *DockerTaskEngine) synchronizeState() {
 	}
 
 	tasks := engine.state.AllTasks()
-	// Pre-consume resources for tasks have progressed beyond resource check (waitingTaskQueue) stage.
+	// For normal task progress, overseeTask 'consume's resources through waitForHostResources in host_resource_manager before progressing
+	// For agent restarts (state restore), we pre-consume resources for tasks that had progressed beyond waitForHostResources stage -
+	// so these tasks do not wait during 'waitForHostResources' call again - do not go through queuing again
+	//
 	// Call reconcileHostResources before
-	// - filterTasksToStartUnsafe which will reconcile container statuses
-	// for the duration the agent was stopped
-	// - starting managedTask goroutines
+	// - filterTasksToStartUnsafe which will reconcile container statuses for the duration the agent was stopped
+	// - starting managedTask's overseeTask goroutines
 	engine.reconcileHostResources()
 	tasksToStart := engine.filterTasksToStartUnsafe(tasks)
 	for _, task := range tasks {

--- a/agent/engine/host_resource_manager.go
+++ b/agent/engine/host_resource_manager.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/amazon-ecs-agent/agent/utils"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
 	"github.com/aws/amazon-ecs-agent/ecs-agent/logger/field"
+	"github.com/aws/aws-sdk-go/aws"
 )
 
 const (
@@ -67,25 +68,13 @@ func (e *ResourceIsNilForTask) Error() string {
 	return fmt.Sprintf("resource %s is nil in task resources", e.resource)
 }
 
-func toStringSlice(s []*string) []string {
-	var t []string
-	for _, ptr := range s {
-		if ptr == nil {
-			t = append(t, "nil")
-		} else {
-			t = append(t, *ptr)
-		}
-	}
-	return t
-}
-
 func (h *HostResourceManager) logResources(msg string, taskArn string) {
 	logger.Debug(msg, logger.Fields{
 		"taskArn":   taskArn,
 		"CPU":       *h.consumedResource[CPU].IntegerValue,
 		"MEMORY":    *h.consumedResource[MEMORY].IntegerValue,
-		"PORTS_TCP": toStringSlice(h.consumedResource[PORTSTCP].StringSetValue),
-		"PORTS_UDP": toStringSlice(h.consumedResource[PORTSUDP].StringSetValue),
+		"PORTS_TCP": aws.StringValueSlice(h.consumedResource[PORTSTCP].StringSetValue),
+		"PORTS_UDP": aws.StringValueSlice(h.consumedResource[PORTSUDP].StringSetValue),
 		"GPU":       *h.consumedResource[GPU].IntegerValue,
 	})
 }

--- a/agent/engine/host_resource_manager.go
+++ b/agent/engine/host_resource_manager.go
@@ -67,13 +67,25 @@ func (e *ResourceIsNilForTask) Error() string {
 	return fmt.Sprintf("resource %s is nil in task resources", e.resource)
 }
 
+func toStringSlice(s []*string) []string {
+	var t []string
+	for _, ptr := range s {
+		if ptr == nil {
+			t = append(t, "nil")
+		} else {
+			t = append(t, *ptr)
+		}
+	}
+	return t
+}
+
 func (h *HostResourceManager) logResources(msg string, taskArn string) {
 	logger.Debug(msg, logger.Fields{
 		"taskArn":   taskArn,
 		"CPU":       *h.consumedResource[CPU].IntegerValue,
 		"MEMORY":    *h.consumedResource[MEMORY].IntegerValue,
-		"PORTS_TCP": h.consumedResource[PORTSTCP].StringSetValue,
-		"PORTS_UDP": h.consumedResource[PORTSUDP].StringSetValue,
+		"PORTS_TCP": toStringSlice(h.consumedResource[PORTSTCP].StringSetValue),
+		"PORTS_UDP": toStringSlice(h.consumedResource[PORTSUDP].StringSetValue),
 		"GPU":       *h.consumedResource[GPU].IntegerValue,
 	})
 }

--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -203,6 +203,7 @@ func (mtask *managedTask) overseeTask() {
 	// Wait here until enough resources are available on host for the task to progress
 	// - Waits until host resource manager succesfully 'consume's task resources and returns
 	// - For tasks which have crossed this stage before (on agent restarts), resources are pre-consumed - returns immediately
+	// - If the task is already stopped (knownStatus is STOPPED), does not attempt to consume resources - returns immediately
 	// (resources are later 'release'd on Stopped task emitTaskEvent call)
 	mtask.waitForHostResources()
 
@@ -276,6 +277,13 @@ func (mtask *managedTask) emitCurrentStatus() {
 // the task. It will wait for event on this task's consumedHostResourceEvent
 // channel from monitorQueuedTasks routine to wake up
 func (mtask *managedTask) waitForHostResources() {
+	if mtask.GetKnownStatus().Terminal() {
+		// Task's known status is STOPPED. No need to wait in this case and proceed to cleanup
+		// This is relevant when agent restarts and a task has stopped - do not attempt
+		// to consume resources in host resource manager
+		return
+	}
+
 	if !mtask.IsInternal && !mtask.engine.hostResourceManager.checkTaskConsumed(mtask.Arn) {
 		// Internal tasks are started right away as their resources are not accounted for
 		mtask.engine.enqueueTask(mtask)

--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -199,11 +199,15 @@ func (mtask *managedTask) overseeTask() {
 	// `desiredstatus`es which are a construct of the engine used only here,
 	// not present on the backend
 	mtask.UpdateStatus()
+
+	// Wait here until enough resources are available on host for the task to progress
+	// - Waits until host resource manager succesfully 'consume's task resources and returns
+	// - For tasks which have crossed this stage before (on agent restarts), resources are pre-consumed - returns immediately
+	// (resources are later 'release'd on Stopped task emitTaskEvent call)
+	mtask.waitForHostResources()
+
 	// If this was a 'state restore', send all unsent statuses
 	mtask.emitCurrentStatus()
-
-	// Wait for host resources required by this task to become available
-	mtask.waitForHostResources()
 
 	// Main infinite loop. This is where we receive messages and dispatch work.
 	for {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR fixes a bug figured out in task resource accounting on Agent Restarts. The issue is when Agent is down. a container stops (repro by `docker stop <container_id>`) and agent comes back up, task resources are not released by host resource manager.

Problems in current orders of calls are :
- `reconcileHostResources` (see #3723) is being called after stopped containers are accounted for in task engine. So if a container stops while the agent is stopped, reconcileHostResources may not pre-'consume' resources for a task, because it's overseeTask would still need to be run for cleanup if it's status has changed to stop.  As a result, `reconcileHostResources` should be called before `filterTasksToStartUnsafe` which updates the container and task statuses. This order is updated with comments.
- In overseeTask, `emitCurrentStatus` also does an `emitTaskEvent` call - which releases 'consumed' resources in host resource manager (see `Management of host resources` in summary in #3723). And `waitForHostResources()` again re-allocates resources, leading to persistent accounted for resources in host resource manager in these cases (when tasks stop when agent is down). Changing it's order after `waitForHostResources()` call and updating comments.


This PR also makes a change in `host_resource_manager` and `ToHostResources` in `task.go` to dereference ports from `[]*string` to `[]string` during logging for more understandable debug logging. This change results in outputting actual port values instead of lvalues of the ports which might not be always relevant. See PORTS_TCP and PORTS_UDP after the change here
`[Debug] logger=structured msg="Consumed resources after task consume call" CPU=512 MEMORY=768 PORTS_TCP=[22 23] PORTS_UDP=[1000 1001] GPU=
1 taskArn="arn:aws:ecs:us-east-1:<aws_account_id>:task/cluster-name/11111"`

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
With debug logs, verified agent restarts function properly and resources are accounted and released properly for following scenarios :
- Tasks are running while agent restarts
- Tasks stop while agent restarts - agent picks up stopped tasks, emits change of status and host resource manager releases resources
- Instance reboots - agent picks up stopped tasks, emits change of status and host resource manager releases resources

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Fix Agent restarts and ports logging with task resource accounting
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
