### PR TITLE
Make task not found error message for task protection endpoint consistent with Fargate

### DIFF
--- a/agent/handlers/agentapi/taskprotection/v1/handlers/handlers.go
+++ b/agent/handlers/agentapi/taskprotection/v1/handlers/handlers.go
@@ -47,6 +47,7 @@ const (
 	// must be lower than server write timeout
 	ecsCallTimeout       = 4 * time.Second
 	ecsCallTimedOutError = "Timed out calling ECS Task Protection API"
+	taskNotFoundErrorMsg = "Failed to find a task for the request"
 )
 
 // TaskProtectionPath Returns endpoint path for UpdateTaskProtection API
@@ -330,7 +331,7 @@ func getTaskFromRequest(state dockerstate.TaskEngineState, r *http.Request) (*ap
 		logger.Error("Failed to find task ARN for task protection request", logger.Fields{
 			loggerfield.Error: err,
 		})
-		return nil, http.StatusNotFound, ecs.ErrCodeResourceNotFoundException, errors.New("Invalid request: no task was found")
+		return nil, http.StatusNotFound, ecs.ErrCodeResourceNotFoundException, errors.New(taskNotFoundErrorMsg)
 	}
 
 	task, found := state.TaskByArn(taskARN)
@@ -338,7 +339,7 @@ func getTaskFromRequest(state dockerstate.TaskEngineState, r *http.Request) (*ap
 		logger.Critical("No task was found for taskARN for task protection request", logger.Fields{
 			loggerfield.TaskARN: taskARN,
 		})
-		return nil, http.StatusInternalServerError, ecs.ErrCodeServerException, errors.New("Failed to find a task for the request")
+		return nil, http.StatusInternalServerError, ecs.ErrCodeServerException, errors.New(taskNotFoundErrorMsg)
 	}
 
 	return task, http.StatusOK, "", nil

--- a/agent/handlers/agentapi/taskprotection/v1/handlers/handlers_test.go
+++ b/agent/handlers/agentapi/taskprotection/v1/handlers/handlers_test.go
@@ -190,7 +190,7 @@ func TestUpdateTaskProtectionHandlerTaskARNNotFound(t *testing.T) {
 	expectedResponse := types.TaskProtectionResponse{
 		Error: &types.ErrorResponse{
 			Code:    ecs.ErrCodeResourceNotFoundException,
-			Message: "Invalid request: no task was found",
+			Message: "Failed to find a task for the request",
 		},
 	}
 	testUpdateTaskProtectionHandler(t, mockState, testV3EndpointId, nil, nil, request,
@@ -456,7 +456,7 @@ func TestGetTaskProtectionHandlerTaskARNNotFound(t *testing.T) {
 	expectedResponse := types.TaskProtectionResponse{
 		Error: &types.ErrorResponse{
 			Code:    ecs.ErrCodeResourceNotFoundException,
-			Message: "Invalid request: no task was found",
+			Message: "Failed to find a task for the request",
 		},
 	}
 	testGetTaskProtectionHandler(t, mockState, testV3EndpointId, nil, nil,

--- a/agent/handlers/task_server_setup_test.go
+++ b/agent/handlers/task_server_setup_test.go
@@ -2810,7 +2810,7 @@ func TestGetTaskProtection(t *testing.T) {
 			expectedResponseBody: agentapi.TaskProtectionResponse{
 				Error: &agentapi.ErrorResponse{
 					Code:    ecs.ErrCodeResourceNotFoundException,
-					Message: "Invalid request: no task was found",
+					Message: "Failed to find a task for the request",
 				},
 			},
 		})
@@ -3058,7 +3058,7 @@ func TestUpdateTaskProtection(t *testing.T) {
 		expectedResponseBody: agentapi.TaskProtectionResponse{
 			Error: &agentapi.ErrorResponse{
 				Code:    ecs.ErrCodeResourceNotFoundException,
-				Message: "Invalid request: no task was found",
+				Message: "Failed to find a task for the request",
 			},
 		},
 	}))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Task Protection API on ECS Agent return a different error message on task lookup failure than Fargate Agent. 

ECS Agent -
```
404 Not Found
{
  "error": {
    "Code": "ResourceNotFoundException",
    "Message": "Invalid request: no task was found"  // <------- THIS
  }
}
``` 

Fargate Agent - 
```
404 Not Found
{
  "error": {
    "Code": "ResourceNotFoundException",
    "Message": "Failed to find a task for the request"  // <------- THIS
  }
}
```

To make the experience provide by ECS Agent and Fargate Agent consistent, we are changing ECS Agent's error message to match Fargate Agent. The HTTP status code and error code in the response is not being changed, so customers depending on the codes will not be affected. Error messages are informational only and customers shouldn't be driving logic based on them.

### Implementation details
<!-- How are the changes implemented? -->
* Change the error message string used by task protection handlers when task lookup fails. 
* Update the tests.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
In addition to automated tests, manually invoked GetTaskProtection and UpdateTaskProtection endpoints with an incorrect endpoint ID.

```
$ curl -s -XPUT http://169.254.170.2/api/bad/task-protection/v1/state -d '{"ExpiresInMinutes": 5, "ProtectionEnabled": false}' | jq
{
  "error": {
    "Code": "ResourceNotFoundException",
    "Message": "Failed to find a task for the request"
  }
}
$ curl -s http://169.254.170.2/api/bad/task-protection/v1/state | jq
{
  "error": {
    "Code": "ResourceNotFoundException",
    "Message": "Failed to find a task for the request"
  }
}
```

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Make task not found error message for task protection endpoint consistent with Fargate

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
