### PR TITLE
Dont consume host resources for tasks getting STOPPED while waiting in waitingTasksQueue

### DIFF
--- a/agent/engine/task_manager.go
+++ b/agent/engine/task_manager.go
@@ -204,6 +204,7 @@ func (mtask *managedTask) overseeTask() {
 	// - Waits until host resource manager succesfully 'consume's task resources and returns
 	// - For tasks which have crossed this stage before (on agent restarts), resources are pre-consumed - returns immediately
 	// - If the task is already stopped (knownStatus is STOPPED), does not attempt to consume resources - returns immediately
+	// - If an ACS StopTask arrives, host resources manager returns immediately. Host resource manager does not consume resources
 	// (resources are later 'release'd on Stopped task emitTaskEvent call)
 	mtask.waitForHostResources()
 
@@ -386,6 +387,14 @@ func (mtask *managedTask) waitEvent(stopWaiting <-chan struct{}) bool {
 func (mtask *managedTask) handleDesiredStatusChange(desiredStatus apitaskstatus.TaskStatus, seqnum int64) {
 	// Handle acs message changes this task's desired status to whatever
 	// acs says it should be if it is compatible
+
+	// Isolate change of desired status updates from monitorQueuedTasks processing to prevent
+	// unexpected updates to host resource manager when tasks are being processed by monitorQueuedTasks
+	// For example when ACS StopTask event updates arrives and simultaneously monitorQueuedTasks
+	// could be processing
+	mtask.engine.monitorQueuedTasksLock.Lock()
+	defer mtask.engine.monitorQueuedTasksLock.Unlock()
+
 	logger.Info("New acs transition", logger.Fields{
 		field.TaskID:        mtask.GetID(),
 		field.DesiredStatus: desiredStatus.String(),
@@ -1454,6 +1463,9 @@ func (mtask *managedTask) time() ttime.Time {
 }
 
 func (mtask *managedTask) cleanupTask(taskStoppedDuration time.Duration) {
+	// In case waitForHostResources returns on an event other than task's consumedHostResourceEvent
+	// release resources from host_resource_manager
+	go mtask.discardConsumedHostResourceEvents()
 	taskExecutionCredentialsID := mtask.GetExecutionCredentialsID()
 	cleanupTimeDuration := mtask.GetKnownStatusTime().Add(taskStoppedDuration).Sub(ttime.Now())
 	cleanupTime := make(<-chan time.Time)
@@ -1514,6 +1526,22 @@ func (mtask *managedTask) discardEvents() {
 		case <-mtask.dockerMessages:
 		case <-mtask.acsMessages:
 		case <-mtask.resourceStateChangeEvent:
+		case <-mtask.ctx.Done():
+			return
+		}
+	}
+}
+
+func (mtask *managedTask) discardConsumedHostResourceEvents() {
+	for {
+		select {
+		case <-mtask.consumedHostResourceEvent:
+			logger.Info("Releasing resources in cleanup", logger.Fields{field.TaskARN: mtask.Arn})
+			resourcesToRelease := mtask.ToHostResources()
+			err := mtask.engine.hostResourceManager.release(mtask.Arn, resourcesToRelease)
+			if err != nil {
+				logger.Critical("Failed to release resources in discardConsumedHostResourceEvents", logger.Fields{field.TaskARN: mtask.Arn})
+			}
 		case <-mtask.ctx.Done():
 			return
 		}

--- a/agent/engine/task_manager_test.go
+++ b/agent/engine/task_manager_test.go
@@ -1420,7 +1420,8 @@ func TestTaskWaitForExecutionCredentials(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.TODO())
 			defer cancel()
 			task := &managedTask{
-				ctx: ctx,
+				ctx:    ctx,
+				engine: &DockerTaskEngine{},
 				Task: &apitask.Task{
 					KnownStatusUnsafe:   apitaskstatus.TaskRunning,
 					DesiredStatusUnsafe: apitaskstatus.TaskRunning,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Context: Task Resource Accounting feature implements queuing (`monitorQueuedTasks`) for tasks to go through where each task waits to 'consume' resources in `host_resource_manager`. `host_resource_manager` keeps an account of each task which has acquired resources to progress for task creation/running.

If a ACS `StopTask` request arrives at Agent while the task is still in this queue, overseeTask - waiting in `waitForHostResources`, falls through and does not wait for the event from `monitorQueuedTasks`, ends up calling 'host_resource_manager.release()` during emitTaskEvent.

But if these `STOPPED` tasks are dequeued later (in docker_task_engine), they just write to the channel with no listeners after the `host_resource_manager.consume()` call in `docker_task_engine`, and the resources persist in host_resource_manager.

This PR fixes this by not calling `host_resource_manager.consume()` for tasks in `monitorQueuedTasks` whose desired status has changed to `STOPPED`. Some cautionary implementation steps have been taken to isolate working of `monitorQueuedTasks` as described in implementation

### Implementation
* Added a `monitorQueuedTasksLock` for the main body of the loop in `monitorQueuedTasks`. This is to synchronize the processing of the topTask in `monitorQueuedTasks` and any parallel update to its desired status - say from ACS updates
* The main body of this processing in `monitorQueuedTasks` has been moved to a method `tryDequeueWaitingTasks` - to put into this critical section of `monitorQueuedTasksLock`
* `monitorQueuedTasksLock` is also used in `handleDesiredStatusChange` which updates the desired status of a managed task
* Adds an integ test `TestHostResourceManagerStopTaskNotBlockWaitingTasks` to test this behavior
* Made container names unique in existing test `TestHostResourceManagerResourceUtilization` for easier debugging

### As a result of this implementation, consider the scenarios
1. StopTask arrives and is processed when the task is not yet processed by `monitorQueuedTasks`
 - This is safe because when task is dequeued, it's desired status is read as `STOPPED` and queue returns on `consumedHostResourceEvent` without consuming resources

2. StopTask arrives while the task is being processed by `monitorQueuedTasks`
 - Due to critical sections put in place, desired status will be updated after `monitorQueuedTasks` is done processing. Resources will be consumed, and released in `emitTaskEvent`

3. StopTask arrives and is processed any time after `monitorQueuedTasks` is done processing
 - Desired status will be updated after `monitorQueuedTasks` is done processing. Resources will be consumed and released in `emitTaskEvent`


### Related Containers Roadmap Issue
https://github.com/aws/containers-roadmap/issues/325

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

Verified by
- Starting and stopping a task with `stopTimeout` of 300s. Starting another same task and stopped it. This task goes to the waiting queue and also returns in overseeTask goroutine. Later this task does not call consume and checked debug logs
```
level=info time=2023-06-15T07:22:18Z msg="Task desired status STOPPED while waiting for host resources, not consuming" taskARN="arn:aws:ecs:us-west-2:<account_id>task/taskAccounting/aa77bc7083d9401b8f4aac32424abed2"
```
- Added an integ test `TestHostResourceManagerStopTaskNotBlockWaitingTasks` and verified it succeeds. This test simulates ACS stopTask for a tasks stuck in `waitingTasksQueue` and verifies the resources are released in host_resource_manager

New tests cover the changes: <!-- yes|no -->
Yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Dont consume host resources for tasks getting STOPPED while waiting 
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
