### PR TITLE
add negative integration tests for gmsa on Linux

### DIFF
--- a/agent/engine/engine_sudo_linux_integ_test.go
+++ b/agent/engine/engine_sudo_linux_integ_test.go
@@ -939,6 +939,159 @@ func TestGMSADomainlessTaskFile(t *testing.T) {
 	verifyTaskIsStopped(stateChangeEvents, testTask)
 }
 
+func TestGMSATaskFileS3Err(t *testing.T) {
+	t.Setenv("ECS_GMSA_SUPPORTED", "True")
+	t.Setenv("ZZZ_SKIP_DOMAIN_JOIN_CHECK_NOT_SUPPORTED_IN_PRODUCTION", "True")
+	t.Setenv("ZZZ_SKIP_CREDENTIALS_FETCHER_INVOCATION_CHECK_NOT_SUPPORTED_IN_PRODUCTION", "True")
+
+	cfg := defaultTestConfigIntegTest()
+	cfg.TaskCPUMemLimit.Value = config.ExplicitlyDisabled
+	cfg.TaskCleanupWaitDuration = 3 * time.Second
+	cfg.GMSACapable = config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled}
+	cfg.AWSRegion = "us-west-2"
+
+	taskEngine, done, _ := setupGMSALinux(cfg, nil, t)
+	defer done()
+
+	stateChangeEvents := taskEngine.StateChangeEvents()
+
+	testContainer := createTestContainer()
+	testContainer.Name = "testGMSATaskFile"
+
+	hostConfig := "{\"SecurityOpt\": [\"credentialspec:arn:aws:::s3:testbucket/test-gmsa.json\"]}"
+	testContainer.DockerConfig.HostConfig = &hostConfig
+
+	testTask := &apitask.Task{
+		Arn:                 "testGMSAFileTaskARN",
+		Family:              "family",
+		Version:             "1",
+		DesiredStatusUnsafe: apitaskstatus.TaskRunning,
+		Containers:          []*apicontainer.Container{testContainer},
+	}
+	testTask.Containers[0].TransitionDependenciesMap = make(map[apicontainerstatus.ContainerStatus]apicontainer.TransitionDependencySet)
+	testTask.ResourcesMapUnsafe = make(map[string][]taskresource.TaskResource)
+	testTask.Containers[0].Command = getLongRunningCommand()
+
+	go taskEngine.AddTask(testTask)
+
+	err := verifyTaskIsRunning(stateChangeEvents, testTask)
+	assert.Error(t, err)
+	assert.Error(t, err, "Task went straight to STOPPED without running, task: testGMSAFileTaskARN")
+}
+
+func TestGMSATaskFileSSMErr(t *testing.T) {
+	t.Setenv("ECS_GMSA_SUPPORTED", "True")
+	t.Setenv("ZZZ_SKIP_DOMAIN_JOIN_CHECK_NOT_SUPPORTED_IN_PRODUCTION", "True")
+	t.Setenv("ZZZ_SKIP_CREDENTIALS_FETCHER_INVOCATION_CHECK_NOT_SUPPORTED_IN_PRODUCTION", "True")
+
+	cfg := defaultTestConfigIntegTest()
+	cfg.TaskCPUMemLimit.Value = config.ExplicitlyDisabled
+	cfg.TaskCleanupWaitDuration = 3 * time.Second
+	cfg.GMSACapable = config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled}
+	cfg.AWSRegion = "us-west-2"
+
+	taskEngine, done, _ := setupGMSALinux(cfg, nil, t)
+	defer done()
+
+	stateChangeEvents := taskEngine.StateChangeEvents()
+
+	testContainer := createTestContainer()
+	testContainer.Name = "testGMSATaskFile"
+
+	hostConfig := "{\"SecurityOpt\": [\"credentialspec:aws:arn:ssm:us-west-2:123456789012:document/test-gmsa.json\"]}"
+	testContainer.DockerConfig.HostConfig = &hostConfig
+
+	testTask := &apitask.Task{
+		Arn:                 "testGMSAFileTaskARN",
+		Family:              "family",
+		Version:             "1",
+		DesiredStatusUnsafe: apitaskstatus.TaskRunning,
+		Containers:          []*apicontainer.Container{testContainer},
+	}
+	testTask.Containers[0].TransitionDependenciesMap = make(map[apicontainerstatus.ContainerStatus]apicontainer.TransitionDependencySet)
+	testTask.ResourcesMapUnsafe = make(map[string][]taskresource.TaskResource)
+	testTask.Containers[0].Command = getLongRunningCommand()
+
+	go taskEngine.AddTask(testTask)
+
+	err := verifyTaskIsRunning(stateChangeEvents, testTask)
+	assert.Error(t, err)
+	assert.Error(t, err, "Task went straight to STOPPED without running, task: testGMSAFileTaskARN")
+}
+
+func TestGMSANotRunningErr(t *testing.T) {
+	t.Setenv("ECS_GMSA_SUPPORTED", "True")
+	t.Setenv("ZZZ_SKIP_DOMAIN_JOIN_CHECK_NOT_SUPPORTED_IN_PRODUCTION", "True")
+	t.Setenv("ZZZ_SKIP_CREDENTIALS_FETCHER_INVOCATION_CHECK_NOT_SUPPORTED_IN_PRODUCTION", "False")
+
+	cfg := defaultTestConfigIntegTest()
+	cfg.TaskCPUMemLimit.Value = config.ExplicitlyDisabled
+	cfg.TaskCleanupWaitDuration = 3 * time.Second
+	cfg.GMSACapable = config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled}
+	cfg.AWSRegion = "us-west-2"
+
+	taskEngine, done, _ := setupGMSALinux(cfg, nil, t)
+	defer done()
+
+	stateChangeEvents := taskEngine.StateChangeEvents()
+
+	// Setup test gmsa file
+	credentialSpecDataDir := "/tmp"
+	testFileName := "test-gmsa.json"
+	testCredSpecFilePath := filepath.Join(credentialSpecDataDir, testFileName)
+	_, err := os.Create(testCredSpecFilePath)
+	require.NoError(t, err)
+
+	// add local credentialspec file
+	testCredSpecData := []byte(`{
+    "CmsPlugins":  [
+                       "ActiveDirectory"
+                   ],
+    "DomainJoinConfig":  {
+                             "Sid":  "S-1-5-21-975084816-3050680612-2826754290",
+                             "MachineAccountName":  "gmsa-acct-test",
+                             "Guid":  "92a07e28-bd9f-4bf3-b1f7-0894815a5257",
+                             "DnsTreeName":  "gmsa.test.com",
+                             "DnsName":  "gmsa.test.com",
+                             "NetBiosName":  "gmsa"
+                         },
+    "ActiveDirectoryConfig":  {
+                                  "GroupManagedServiceAccounts":  [
+                                                                      {
+                                                                          "Name":  "gmsa-acct-test",
+                                                                          "Scope":  "gmsa.test.com"
+                                                                      }
+                                                                  ]
+                              }
+}`)
+
+	err = ioutil.WriteFile(testCredSpecFilePath, testCredSpecData, 0755)
+	require.NoError(t, err)
+
+	testContainer := createTestContainer()
+	testContainer.Name = "testGMSATaskFile"
+
+	hostConfig := "{\"SecurityOpt\": [\"credentialspec:file:///tmp/test-gmsa.json\"]}"
+	testContainer.DockerConfig.HostConfig = &hostConfig
+
+	testTask := &apitask.Task{
+		Arn:                 "testGMSAFileTaskARN",
+		Family:              "family",
+		Version:             "1",
+		DesiredStatusUnsafe: apitaskstatus.TaskRunning,
+		Containers:          []*apicontainer.Container{testContainer},
+	}
+	testTask.Containers[0].TransitionDependenciesMap = make(map[apicontainerstatus.ContainerStatus]apicontainer.TransitionDependencySet)
+	testTask.ResourcesMapUnsafe = make(map[string][]taskresource.TaskResource)
+	testTask.Containers[0].Command = getLongRunningCommand()
+
+	go taskEngine.AddTask(testTask)
+
+	err = verifyTaskIsRunning(stateChangeEvents, testTask)
+	assert.Error(t, err)
+	assert.Error(t, err, "Task went straight to STOPPED without running, task: testGMSAFileTaskARN")
+}
+
 func verifyContainerBindMount(client *sdkClient.Client, id, expectedBind string) error {
 	dockerContainer, err := client.ContainerInspect(context.TODO(), id)
 	if err != nil {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR is to add negative integration tests for gMSA on Linux, which covers three cases:
1. gMSA credentialspec file can't be found in S3 bucket
2. gMSA credentialspec file can't be found in SSM documents
3. gMSA Deamon is not running

### Implementation details
<!-- How are the changes implemented? -->
Add integration tests to `agent/engine/engine_sudo_linux_integ_test.go`

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->
YES

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
