### PR TITLE
Skip sending internal task events to ECS control plane

### DIFF
--- a/agent/eventhandler/task_handler_types.go
+++ b/agent/eventhandler/task_handler_types.go
@@ -79,6 +79,11 @@ func (event *sendableEvent) taskShouldBeSent() bool {
 		return false
 	}
 
+	//  internal task state change does not need to be sent
+	if tevent.Task.IsInternal {
+		return false
+	}
+
 	// Task event should be sent
 	if tevent.Task.GetSentStatus() < tevent.Status {
 		return true

--- a/agent/eventhandler/task_handler_types_test.go
+++ b/agent/eventhandler/task_handler_types_test.go
@@ -62,6 +62,16 @@ func TestShouldTaskEventBeSent(t *testing.T) {
 		shouldBeSent bool
 	}{
 		{
+			// We don't send a task event to backend if it is an internal task
+			event: newSendableTaskEvent(api.TaskStateChange{
+				Status: apitaskstatus.TaskRunning,
+				Task: &apitask.Task{
+					IsInternal: true,
+				},
+			}),
+			shouldBeSent: false,
+		},
+		{
 			// We don't send a task event to backend if task status == NONE
 			event: newSendableTaskEvent(api.TaskStateChange{
 				Status: apitaskstatus.TaskStatusNone,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
---
The internal task events should not be sent to ECS control plane.
  
#### Current behavior
For a container instance that had/has run a [Service Connect](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-connect.html) enabled task, [ecs-agent.log](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/logs.html) will show 
```
level=warn time=xxx msg="Could not submit task state change: [arn:::::/service-connect-relay-xxx-> RUNNING, xxx: InvalidParameterException: Invalid identifier: Identifier is for cluster arn:::::. Your cluster is xxx" module=client.go
level=error time=xxx msg="Unretriable error sending state change to ECS" xxx error="InvalidParameterException: Invalid identifier: Identifier is for cluster arn:::::. Your cluster is xxx"
level=warn time=xxx msg="TaskHandler: Event is sent with invalid parameters; just removing" xxx
```
after ECS Agent is updated/restarted. 

Here, ECS Agent will go though a list with task events, and try to make [SubmitTaskStateChange](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_SubmitTaskStateChange.html) API calls to submit any un-reported events to ECS control plane. As this internal task, which is designed for setting up an AppNet relay container for Service Connect, was not reported previously, ECS Agent will now try to report it to ECS control plane. However, making a STSC call will return an error because this internal task is constructed with mock data.

See how we construct this AppNet relay internal task [here](https://github.com/aws/amazon-ecs-agent/blob/dev/agent/engine/serviceconnect/manager_linux.go#L334-L356).
  
#### After this PR
ECS Agent will not submit internal task events to ECS control plane after it is updated/restarted. Logs shown in the "Current behavior" section will not show up in ecs-agent.log.
    
### Implementation details
---

#### Code path

[startDrainEventsTicker](https://github.com/aws/amazon-ecs-agent/blob/dev/agent/eventhandler/task_handler.go#L121) <- [AddStateChangeEvent](https://github.com/aws/amazon-ecs-agent/blob/dev/agent/eventhandler/task_handler.go#L191) <- [flushBatchUnsafe](https://github.com/aws/amazon-ecs-agent/blob/dev/agent/eventhandler/task_handler.go#L146) <- [sendChange](https://github.com/aws/amazon-ecs-agent/blob/dev/agent/eventhandler/task_handler.go#L294) <- [submitTaskEvents](https://github.com/aws/amazon-ecs-agent/blob/dev/agent/eventhandler/task_handler.go#L375C1-L375C1) <- [submitFirstEvent](https://github.com/aws/amazon-ecs-agent/blob/dev/agent/eventhandler/task_handler.go#L344) <- [taskShouldBeSent](https://github.com/aws/amazon-ecs-agent/blob/dev/agent/eventhandler/task_handler.go#L410)

#### agent/eventhandler/task_handler_types.go
* Add a new if-else statement to avoid sending internal task event.
  
#### agent/eventhandler/task_handler_types_test.go
* Add a new test case to `TestShouldTaskEventBeSent`.
  
### Testing
---
#### Manually testing
1. Registered an EC2 instance launched with the latest ECS optimized AMI `amzn2-ami-ecs-hvm-2.0.20230606-x86_64-ebs`, which has ECS Agent version 1.73.0, to an empty ECS cluster.
2. Ran Service Connect service on the ECS cluster.
3. Downgraded ECS Agent version to `1.71.0` on the same container instance.
4. Updated ECS Agent using the artifact built from this PR on the same container instance.
5. Checked ecs-agent.log, and confirmed there is no error like `level=warn time=xxx msg="Could not submit task state change: [arn:::::/service-connect-relay-xxx ` or `level=error time=xxx msg="Unretriable error sending state change to ECS" xxx error="InvalidParameterException: Invalid identifier: Identifier is for cluster arn:::::. Your cluster is xxx"`

New tests cover the changes: yes
  
### Description for the changelog
---
Skip sending internal task events to ECS control plane
     
### Licensing
---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
