### PR TITLE
Update wsclient RequestResponder interface

### DIFF
--- a/ecs-agent/wsclient/client.go
+++ b/ecs-agent/wsclient/client.go
@@ -99,6 +99,10 @@ type RequestHandler interface{}
 //	    respond  func(interface{}) error
 //	    dispatcher actor.Dispatcher
 //	}
+//	func(d *payloadmessagedispatcher) RegisterResponder(respond func(interface{}) error) error {
+//	    d.respond = respond
+//	    return nil
+//	}
 //	func(d *payloadmessagedispatcher) HandlerFunc() RequestHandler {
 //	    return func(payload *ecsacs.PayloadMessage) {
 //	        message := &actor.DispatcherMessage{
@@ -114,6 +118,9 @@ type RequestHandler interface{}
 type RequestResponder interface {
 	// Name returns the name of the responder. This is used mostly for logging.
 	Name() string
+	// RegisterResponder registers a function that can be invoked in response
+	// to receiving and processing a websocket request message.
+	RegisterResponder(RespondFunc)
 	// HandlerFunc returns the RequestHandler callback for a particular
 	// websocket request message type.
 	HandlerFunc() RequestHandler

--- a/ecs-agent/wsclient/mock/client.go
+++ b/ecs-agent/wsclient/mock/client.go
@@ -269,6 +269,18 @@ func (mr *MockRequestResponderMockRecorder) Name() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockRequestResponder)(nil).Name))
 }
 
+// RegisterResponder mocks base method.
+func (m *MockRequestResponder) RegisterResponder(arg0 wsclient.RespondFunc) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "RegisterResponder", arg0)
+}
+
+// RegisterResponder indicates an expected call of RegisterResponder.
+func (mr *MockRequestResponderMockRecorder) RegisterResponder(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterResponder", reflect.TypeOf((*MockRequestResponder)(nil).RegisterResponder), arg0)
+}
+
 // MockClientFactory is a mock of ClientFactory interface.
 type MockClientFactory struct {
 	ctrl     *gomock.Controller


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Add the RegisterResponder method in the wsclient RequestResponder interface

### Implementation details
<!-- How are the changes implemented? -->
Included new method and regenerated the mock file.

### Testing
<!-- How was this tested? -->
Existing tests
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Add the RegisterResponder method in the wsclient RequestResponder interface

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
