### PR TITLE
broadcast FSx capability by default for Windows

### DIFF
--- a/agent/app/agent_capability_windows_test.go
+++ b/agent/app/agent_capability_windows_test.go
@@ -258,7 +258,7 @@ func TestAppendFSxWindowsFileServerCapabilities(t *testing.T) {
 
 	agent := &ecsAgent{
 		cfg: &config.Config{
-			FSxWindowsFileServerCapable: config.BooleanDefaultFalse{Value: config.ExplicitlyEnabled},
+			FSxWindowsFileServerCapable: config.BooleanDefaultTrue{Value: config.ExplicitlyEnabled},
 		},
 	}
 
@@ -280,7 +280,7 @@ func TestAppendFSxWindowsFileServerCapabilitiesFalse(t *testing.T) {
 
 	agent := &ecsAgent{
 		cfg: &config.Config{
-			FSxWindowsFileServerCapable: config.BooleanDefaultFalse{Value: config.ExplicitlyDisabled},
+			FSxWindowsFileServerCapable: config.BooleanDefaultTrue{Value: config.ExplicitlyDisabled},
 		},
 	}
 

--- a/agent/config/config_unix.go
+++ b/agent/config/config_unix.go
@@ -103,7 +103,7 @@ func DefaultConfig() Config {
 		CgroupCPUPeriod:                     defaultCgroupCPUPeriod,
 		GMSACapable:                         parseGMSACapability(),
 		GMSADomainlessCapable:               parseGMSADomainlessCapability(),
-		FSxWindowsFileServerCapable:         BooleanDefaultFalse{Value: ExplicitlyDisabled},
+		FSxWindowsFileServerCapable:         BooleanDefaultTrue{Value: ExplicitlyDisabled},
 		RuntimeStatsLogFile:                 defaultRuntimeStatsLogFile,
 		EnableRuntimeStats:                  BooleanDefaultFalse{Value: NotSet},
 		ShouldExcludeIPv6PortBinding:        BooleanDefaultTrue{Value: ExplicitlyEnabled},

--- a/agent/config/config_unix_test.go
+++ b/agent/config/config_unix_test.go
@@ -75,6 +75,7 @@ func TestConfigDefault(t *testing.T) {
 	assert.False(t, cfg.PollMetrics.Enabled(), "ECS_POLL_METRICS default should be false")
 	assert.False(t, cfg.EnableRuntimeStats.Enabled(), "Default EnableRuntimeStats set incorrectly")
 	assert.True(t, cfg.ShouldExcludeIPv6PortBinding.Enabled(), "Default ShouldExcludeIPv6PortBinding set incorrectly")
+	assert.False(t, cfg.FSxWindowsFileServerCapable.Enabled(), "Default FSxWindowsFileServerCapable set incorrectly")
 }
 
 // TestConfigFromFile tests the configuration can be read from file

--- a/agent/config/config_windows.go
+++ b/agent/config/config_windows.go
@@ -145,7 +145,7 @@ func DefaultConfig() Config {
 		PollingMetricsWaitDuration:          DefaultPollingMetricsWaitDuration,
 		GMSACapable:                         BooleanDefaultFalse{Value: ExplicitlyDisabled},
 		GMSADomainlessCapable:               BooleanDefaultFalse{Value: ExplicitlyDisabled},
-		FSxWindowsFileServerCapable:         BooleanDefaultFalse{Value: ExplicitlyDisabled},
+		FSxWindowsFileServerCapable:         BooleanDefaultTrue{Value: NotSet},
 		PauseContainerImageName:             DefaultPauseContainerImageName,
 		PauseContainerTag:                   DefaultPauseContainerTag,
 		CNIPluginsPath:                      filepath.Join(ecsBinaryDir, defaultCNIPluginDirName),

--- a/agent/config/config_windows_test.go
+++ b/agent/config/config_windows_test.go
@@ -72,6 +72,7 @@ func TestConfigDefault(t *testing.T) {
 	assert.False(t, cfg.DependentContainersPullUpfront.Enabled(), "Default DependentContainersPullUpfront set incorrectly")
 	assert.False(t, cfg.EnableRuntimeStats.Enabled(), "Default EnableRuntimeStats set incorrectly")
 	assert.True(t, cfg.ShouldExcludeIPv6PortBinding.Enabled(), "Default ShouldExcludeIPv6PortBinding set incorrectly")
+	assert.True(t, cfg.FSxWindowsFileServerCapable.Enabled(), "Default FSxWindowsFileServerCapable set incorrectly")
 }
 
 func TestConfigIAMTaskRolesReserves80(t *testing.T) {

--- a/agent/config/parse_linux.go
+++ b/agent/config/parse_linux.go
@@ -69,8 +69,8 @@ func parseGMSACapability() BooleanDefaultFalse {
 	return BooleanDefaultFalse{Value: ExplicitlyDisabled}
 }
 
-func parseFSxWindowsFileServerCapability() BooleanDefaultFalse {
-	return BooleanDefaultFalse{Value: ExplicitlyDisabled}
+func parseFSxWindowsFileServerCapability() BooleanDefaultTrue {
+	return BooleanDefaultTrue{Value: ExplicitlyDisabled}
 }
 
 // parseGMSADomainlessCapability is used to determine if gMSA domainless support can be enabled

--- a/agent/config/parse_linux_test.go
+++ b/agent/config/parse_linux_test.go
@@ -43,6 +43,16 @@ func TestParseGMSACapabilityUnsupported(t *testing.T) {
 	assert.False(t, parseGMSACapability().Enabled())
 }
 
+func TestParseFSxWindowsFileServerCapabilityUsingEnv(t *testing.T) {
+	t.Setenv("ECS_FSX_WINDOWS_FILE_SERVER_SUPPORTED", "True")
+
+	assert.False(t, parseFSxWindowsFileServerCapability().Enabled())
+}
+
+func TestParseFSxWindowsFileServerCapabilityDefault(t *testing.T) {
+	assert.False(t, parseFSxWindowsFileServerCapability().Enabled())
+}
+
 func TestSkipDomainJoinCheckParseGMSACapability(t *testing.T) {
 	t.Setenv("ECS_GMSA_SUPPORTED", "True")
 	t.Setenv("ZZZ_SKIP_DOMAIN_JOIN_CHECK_NOT_SUPPORTED_IN_PRODUCTION", "True")

--- a/agent/config/parse_unsupported.go
+++ b/agent/config/parse_unsupported.go
@@ -25,8 +25,8 @@ func parseGMSACapability() BooleanDefaultFalse {
 	return BooleanDefaultFalse{Value: ExplicitlyDisabled}
 }
 
-func parseFSxWindowsFileServerCapability() BooleanDefaultFalse {
-	return BooleanDefaultFalse{Value: ExplicitlyDisabled}
+func parseFSxWindowsFileServerCapability() BooleanDefaultTrue {
+	return BooleanDefaultTrue{Value: ExplicitlyDisabled}
 }
 
 func parseGMSADomainlessCapability() BooleanDefaultFalse {

--- a/agent/config/parse_windows.go
+++ b/agent/config/parse_windows.go
@@ -68,15 +68,17 @@ func parseGMSADomainlessCapability() BooleanDefaultFalse {
 }
 
 // parseFSxWindowsFileServerCapability is used to determine if fsxWindowsFileServer support can be enabled
-func parseFSxWindowsFileServerCapability() BooleanDefaultFalse {
-	// fsxwindowsfileserver is not supported on Windows 2016 and non-domain-joined container instances
+func parseFSxWindowsFileServerCapability() BooleanDefaultTrue {
+	// fsxwindowsfileserver is not supported on Windows 2016.
 	status, err := IsWindows2016()
 	if err != nil || status == true {
-		return BooleanDefaultFalse{Value: ExplicitlyDisabled}
+		return BooleanDefaultTrue{Value: ExplicitlyDisabled}
 	}
 
-	envStatus := utils.ParseBool(os.Getenv("ECS_FSX_WINDOWS_FILE_SERVER_SUPPORTED"), true)
-	return checkDomainJoinWithEnvOverride(envStatus)
+	// By default, or if ECS_FSX_WINDOWS_FILE_SERVER_SUPPORTED is set as true, agent will
+	// broadcast the FSx capability. Only when ECS_FSX_WINDOWS_FILE_SERVER_SUPPORTED is
+	// explicitly set as false, the instance will not broadcast FSx capability.
+	return parseBooleanDefaultTrueConfig("ECS_FSX_WINDOWS_FILE_SERVER_SUPPORTED")
 }
 
 func checkDomainJoinWithEnvOverride(envStatus bool) BooleanDefaultFalse {

--- a/agent/config/parse_windows_test.go
+++ b/agent/config/parse_windows_test.go
@@ -52,6 +52,14 @@ func TestParseFSxWindowsFileServerCapability(t *testing.T) {
 	assert.False(t, parseFSxWindowsFileServerCapability().Enabled())
 }
 
+func TestParseFSxWindowsFileServerCapabilityDefault(t *testing.T) {
+	IsWindows2016 = func() (bool, error) {
+		return false, nil
+	}
+
+	assert.True(t, parseFSxWindowsFileServerCapability().Enabled())
+}
+
 func TestParseDomainlessgMSACapabilityFalseOnW2016(t *testing.T) {
 	IsWindows2016 = func() (bool, error) {
 		return true, nil

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -340,8 +340,8 @@ type Config struct {
 	VolumePluginCapabilities []string
 
 	// FSxWindowsFileServerCapable is the config option to indicate if fsxWindowsFileServer is supported.
-	// It should be enabled by default only if the container instance is part of a valid active directory domain.
-	FSxWindowsFileServerCapable BooleanDefaultFalse
+	// It is enabled by default on Windows and can be overridden by the ECS_FSX_WINDOWS_FILE_SERVER_SUPPORTED environment variable.
+	FSxWindowsFileServerCapable BooleanDefaultTrue
 
 	// External specifies whether agent is running on external compute capacity (i.e. outside of aws).
 	External BooleanDefaultFalse


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Presently, the logic for enabling FSx on the instance requires the instance to be domain joined with the AD. This behaviour was fixed in https://github.com/aws/amazon-ecs-agent/pull/3540.

However, this is not needed for enabling just FSx capability. If a customer has setup their DHCP option set for their AD, then FSx can work on their instances even without a domain join. Reference- https://docs.aws.amazon.com/directoryservice/latest/admin-guide/dhcp_options_set.html

Therefore, we will enable FSx capability by default. The customer can explicitly disable it by setting `ECS_FSX_WINDOWS_FILE_SERVER_SUPPORTED` as false.

### Implementation details
<!-- How are the changes implemented? -->
Removed the dependency of FSx capability on instance domain join.


### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->
Created a custom agent and ran a FSx enabled task without domain join of the instance.
New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
enable FSx capability by default for Windows
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
