### PR TITLE
fix memory resource accounting for multiple containers in single task

### DIFF
--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -3557,10 +3557,11 @@ func (task *Task) ToHostResources() map[string]*ecs.Resource {
 		}
 	} else {
 		containerMEMint64 := int64(0)
-		// To parse memory reservation / soft limit
-		hostConfig := &dockercontainer.HostConfig{}
 
 		for _, c := range task.Containers {
+			// To parse memory reservation / soft limit
+			hostConfig := &dockercontainer.HostConfig{}
+
 			if c.DockerConfig.HostConfig != nil {
 				err := json.Unmarshal([]byte(*c.DockerConfig.HostConfig), hostConfig)
 				if err != nil || hostConfig.MemoryReservation <= 0 {

--- a/agent/api/task/task_test.go
+++ b/agent/api/task/task_test.go
@@ -4894,9 +4894,13 @@ func TestToHostResources(t *testing.T) {
 	// Prepare simple hostConfigs with and without memory reservation field for test cases
 
 	// Host Config with Memory Reservation 400 MiB
-	rawHostConfigMemReservation := "{\"Ulimits\":[],\"MemoryReservation\":419430400,\"NetworkMode\":\"bridge\",\"CapAdd\":[],\"CapDrop\":[]}"
+	rawHostConfigMemReservation400MiB := "{\"Ulimits\":[],\"MemoryReservation\":419430400,\"NetworkMode\":\"bridge\",\"CapAdd\":[],\"CapDrop\":[]}"
+	// Host Config with Memory Reservation 600 MiB
+	rawHostConfigMemReservation600MiB := "{\"Ulimits\":[],\"MemoryReservation\":629145600,\"NetworkMode\":\"bridge\",\"CapAdd\":[],\"CapDrop\":[]}"
 	// Basic host config with a few fields like network mode
-	rawHostConfigNetworkMode := "{\"NetworkMode\":\"bridge\",\"CapAdd\":[],\"CapDrop\":[]}"
+	rawHostConfigBridgeMode := "{\"NetworkMode\":\"bridge\",\"CapAdd\":[],\"CapDrop\":[]}"
+	// Basic host config with a few fields like awsvpc mode
+	rawHostConfigAwsVpcMode := "{\"NetworkMode\":\"awsvpc\",\"CapAdd\":[],\"CapDrop\":[]}"
 
 	// Prefer task level, and check gpu assignment
 	testTask1 := &Task{
@@ -4907,33 +4911,49 @@ func TestToHostResources(t *testing.T) {
 				CPU:    uint(1200),
 				Memory: uint(1200),
 				DockerConfig: apicontainer.DockerConfig{
-					HostConfig: strptr(string(rawHostConfigMemReservation)),
+					HostConfig: strptr(string(rawHostConfigMemReservation400MiB)),
 				},
 				GPUIDs: []string{"gpu1", "gpu2"},
 			},
 		},
 	}
 
-	// If task not set, use container level (MemoryReservation pref)
+	// If task not set, use container level (MemoryReservation pref), verify mem reservation from multiple containers is accounted correctly
 	testTask2 := &Task{
 		Containers: []*apicontainer.Container{
 			{
 				CPU:    uint(1200),
 				Memory: uint(1200),
 				DockerConfig: apicontainer.DockerConfig{
-					HostConfig: strptr(string(rawHostConfigMemReservation)),
+					HostConfig: strptr(string(rawHostConfigMemReservation400MiB)),
+				},
+			},
+			{
+				CPU:    uint(1200),
+				Memory: uint(1200),
+				DockerConfig: apicontainer.DockerConfig{
+					HostConfig: strptr(string(rawHostConfigMemReservation600MiB)),
 				},
 			},
 		},
 	}
 
-	// If task not set, if MemoryReservation not set, use container level hard limit (c.Memory)
+	// If task not set, if MemoryReservation not set, use container level hard limit (c.Memory), verify memory from multiple containers is accounted correclty
 	testTask3 := &Task{
 		Containers: []*apicontainer.Container{
 			{
-				CPU:          uint(1200),
-				Memory:       uint(1200),
-				DockerConfig: apicontainer.DockerConfig{},
+				CPU:    uint(1200),
+				Memory: uint(1200),
+				DockerConfig: apicontainer.DockerConfig{
+					HostConfig: strptr(string(rawHostConfigBridgeMode)),
+				},
+			},
+			{
+				CPU:    uint(1200),
+				Memory: uint(500),
+				DockerConfig: apicontainer.DockerConfig{
+					HostConfig: strptr(string(rawHostConfigBridgeMode)),
+				},
 			},
 		},
 	}
@@ -4947,7 +4967,83 @@ func TestToHostResources(t *testing.T) {
 				CPU:    uint(1200),
 				Memory: uint(1200),
 				DockerConfig: apicontainer.DockerConfig{
-					HostConfig: strptr(string(rawHostConfigMemReservation)),
+					HostConfig: strptr(string(rawHostConfigMemReservation400MiB)),
+				},
+				Ports: []apicontainer.PortBinding{
+					{
+						ContainerPort: 10,
+						HostPort:      10,
+						BindIP:        "",
+						Protocol:      apicontainer.TransportProtocolTCP,
+					},
+					{
+						ContainerPort: 11,
+						HostPort:      11,
+						BindIP:        "",
+						Protocol:      apicontainer.TransportProtocolTCP,
+					},
+					{
+						ContainerPort: 20,
+						HostPort:      20,
+						BindIP:        "",
+						Protocol:      apicontainer.TransportProtocolUDP,
+					},
+					{
+						ContainerPort: 21,
+						HostPort:      21,
+						BindIP:        "",
+						Protocol:      apicontainer.TransportProtocolUDP,
+					},
+					{
+						ContainerPortRange: "99-999",
+						BindIP:             "",
+						Protocol:           apicontainer.TransportProtocolTCP,
+					},
+					{
+						ContainerPortRange: "121-221",
+						BindIP:             "",
+						Protocol:           apicontainer.TransportProtocolUDP,
+					},
+				},
+			},
+		},
+	}
+
+	// A combination of containers with different configs with memory sourcing from different sources
+	testTask5 := &Task{
+		Containers: []*apicontainer.Container{
+			{
+				CPU:    uint(200),
+				Memory: uint(600),
+				// Should get 400 from Docker MemoryReservation field
+				DockerConfig: apicontainer.DockerConfig{
+					HostConfig: strptr(string(rawHostConfigMemReservation400MiB)),
+				},
+			},
+			{
+				CPU:    uint(200),
+				Memory: uint(600),
+				DockerConfig: apicontainer.DockerConfig{
+					HostConfig: strptr(string(rawHostConfigBridgeMode)),
+				},
+			},
+			{
+				CPU:    uint(200),
+				Memory: uint(800),
+			},
+		},
+	}
+
+	// Do not account ports for awsvpc mode
+	testTask6 := &Task{
+		CPU:    1.0,
+		Memory: int64(512),
+		Containers: []*apicontainer.Container{
+			{
+				CPU:    uint(1200),
+				Memory: uint(1200),
+				DockerConfig: apicontainer.DockerConfig{
+					HostConfig: strptr(string(rawHostConfigAwsVpcMode)),
 				},
 				Ports: []apicontainer.PortBinding{
 					{
@@ -4975,35 +5071,11 @@ func TestToHostResources(t *testing.T) {
 				},
 			},
 		},
+		NetworkMode: AWSVPCNetworkMode,
 	}
 
-	// A combination of containers with different configs with memory sourcing from different sources
-	testTask5 := &Task{
-		Containers: []*apicontainer.Container{
-			{
-				CPU:    uint(200),
-				Memory: uint(600),
-				// Should get 400 from Docker MemoryReservation field
-				DockerConfig: apicontainer.DockerConfig{
-					HostConfig: strptr(string(rawHostConfigMemReservation)),
-				},
-			},
-			{
-				CPU:    uint(200),
-				Memory: uint(600),
-				DockerConfig: apicontainer.DockerConfig{
-					HostConfig: strptr(string(rawHostConfigNetworkMode)),
-				},
-			},
-			{
-				CPU:    uint(200),
-				Memory: uint(800),
-			},
-		},
-	}
-
-	portsTCP := []uint16{10}
-	portsUDP := []uint16{20}
+	portsTCP := []uint16{10, 11}
+	portsUDP := []uint16{20, 21}
 
 	testCases := []struct {
 		task              *Task
@@ -5015,11 +5087,11 @@ func TestToHostResources(t *testing.T) {
 		},
 		{
 			task:              testTask2,
-			expectedResources: getTestTaskResourceMap(int64(1200), int64(400), []*string{}, []*string{}, int64(0)),
+			expectedResources: getTestTaskResourceMap(int64(2400), int64(1000), []*string{}, []*string{}, int64(0)),
 		},
 		{
 			task:              testTask3,
-			expectedResources: getTestTaskResourceMap(int64(1200), int64(1200), []*string{}, []*string{}, int64(0)),
+			expectedResources: getTestTaskResourceMap(int64(2400), int64(1700), []*string{}, []*string{}, int64(0)),
 		},
 		{
 			task:              testTask4,
@@ -5028,6 +5100,10 @@ func TestToHostResources(t *testing.T) {
 		{
 			task:              testTask5,
 			expectedResources: getTestTaskResourceMap(int64(600), int64(1800), []*string{}, []*string{}, int64(0)),
+		},
+		{
+			task:              testTask6,
+			expectedResources: getTestTaskResourceMap(int64(1024), int64(512), []*string{}, []*string{}, int64(0)),
 		},
 	}
 


### PR DESCRIPTION
### Summary
This PR fixes how task memory is accounted when task level memory limit is not specified in task definition. The existing implementation fails to account correctly in cases where containers with `MemoryReservation` field present in HostConfig might occur before containers without such field in the `task.Containers` slice. In such cases, `MemoryReservation` of previous container 'persists', as the object into which the HostConfig is being unmarshalled is declared outside of the loop which iterates over the containers.

Main cause of this change is that the ACS payload agent receives has HostConfig like `{\"NetworkMode\":\"bridge\",\"CapAdd\":[],\"CapDrop\":[]}` with missing fields in [HostConfig](https://pkg.go.dev/github.com/docker/docker@v24.0.4+incompatible/api/types/container#HostConfig) struct. That is, if fields like `MemoryReservation` are not specified, they are not present in the payload, and `json.Unmarshal`does not make any changes to the object. Using a new object for every container ensures this persistence does not happen.

### Implementation details
Fix: 
* Define new `&dockercontainer.HostConfig{}` object for each container when mapping task to host resources
* `rawHostConfig*` in related unit tests have been modified to be directly defined using a string instead of marshaling a HostConfig object. This is necessary, because if we use a HostConfig object, it will use the zero value (`int64(0)`) of fields like `MemoryReservation` if they are not specified

### Testing
Verified -
* With manual tests this behavior is consistent
* With manual tests resources allocated in ECS back end are same as ECS Agent for each task
* Added new unit tests with multiple containers and a test with awsvpc network mode
* Verified test with multiple containers - with containers with `MemoryReservation` followed by containers with `memory` fail for existing implementation - and pass with the fix -`testTask5` here

New tests cover the changes: <!-- yes|no -->
Yes

### Description for the changelog
Fix memory resource accounting for multiple containers in single task
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
