### PR TITLE
adding container metadata to the introspection response

### DIFF
--- a/agent/handlers/v1/response.go
+++ b/agent/handlers/v1/response.go
@@ -14,6 +14,8 @@
 package v1
 
 import (
+	"time"
+
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
@@ -49,6 +51,10 @@ type ContainerResponse struct {
 	DockerID   string                        `json:"DockerId"`
 	DockerName string                        `json:"DockerName"`
 	Name       string                        `json:"Name"`
+	Image      string                        `json:"Image"`
+	ImageID    string                        `json:"ImageID"`
+	CreatedAt  *time.Time                    `json:"CreatedAt,omitempty"`
+	StartedAt  *time.Time                    `json:"StartedAt,omitempty"`
 	Ports      []tmdsresponse.PortResponse   `json:"Ports,omitempty"`
 	Networks   []tmdsresponse.Network        `json:"Networks,omitempty"`
 	Volumes    []tmdsresponse.VolumeResponse `json:"Volumes,omitempty"`
@@ -89,6 +95,8 @@ func NewContainerResponse(dockerContainer *apicontainer.DockerContainer, eni *ap
 	container := dockerContainer.Container
 	resp := ContainerResponse{
 		Name:       container.Name,
+		Image:      container.Image,
+		ImageID:    container.ImageID,
 		DockerID:   dockerContainer.DockerID,
 		DockerName: dockerContainer.DockerName,
 	}
@@ -104,6 +112,14 @@ func NewContainerResponse(dockerContainer *apicontainer.DockerContainer, eni *ap
 				IPv6Addresses: eni.GetIPV6Addresses(),
 			},
 		}
+	}
+	if createdAt := container.GetCreatedAt(); !createdAt.IsZero() {
+		createdAt = createdAt.UTC()
+		resp.CreatedAt = &createdAt
+	}
+	if startedAt := container.GetStartedAt(); !startedAt.IsZero() {
+		startedAt = startedAt.UTC()
+		resp.StartedAt = &startedAt
 	}
 	return resp
 }

--- a/agent/handlers/v1/response_test.go
+++ b/agent/handlers/v1/response_test.go
@@ -19,11 +19,13 @@ package v1
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
 	apitaskstatus "github.com/aws/amazon-ecs-agent/agent/api/task/status"
 	apieni "github.com/aws/amazon-ecs-agent/ecs-agent/api/eni"
+	"github.com/aws/amazon-ecs-agent/ecs-agent/tmds/handlers/response"
 
 	"github.com/docker/docker/api/types"
 	"github.com/stretchr/testify/assert"
@@ -33,53 +35,68 @@ const (
 	taskARN        = "t1"
 	family         = "sleep"
 	version        = "1"
+	status         = "RUNNING"
 	containerID    = "cid"
 	containerName  = "sleepy"
+	imageName      = "busybox"
+	imageID        = "busyboxID"
+	networkMode    = "awsvpc"
 	eniIPv4Address = "10.0.0.2"
+	port           = 80
+	protocol       = "tcp"
 	volName        = "volume1"
 	volSource      = "/var/lib/volume1"
 	volDestination = "/volume"
 )
 
-func TestTaskResponse(t *testing.T) {
-	expectedTaskResponseMap := map[string]interface{}{
-		"Arn":           "t1",
-		"DesiredStatus": "RUNNING",
-		"KnownStatus":   "RUNNING",
-		"Family":        "sleep",
-		"Version":       "1",
-		"Containers": []interface{}{
-			map[string]interface{}{
-				"DockerId":   "cid",
-				"DockerName": "sleepy",
-				"Name":       "sleepy",
-				"Ports": []interface{}{
-					map[string]interface{}{
-						// The number should be float here, because when we unmarshal
-						// something and we don't specify the number type, it will be
-						// set to float.
-						"ContainerPort": float64(80),
-						"Protocol":      "tcp",
-						"HostPort":      float64(80),
-					},
-				},
-				"Networks": []interface{}{
-					map[string]interface{}{
-						"NetworkMode":   "awsvpc",
-						"IPv4Addresses": []interface{}{"10.0.0.2"},
-					},
-				},
-				"Volumes": []interface{}{
-					map[string]interface{}{
-						"DockerName":  volName,
-						"Source":      volSource,
-						"Destination": volDestination,
-					},
-				},
-			},
+var (
+	containerTime        = time.Now()
+	containerTimeUTC     = containerTime.UTC()
+	expectedPortResponse = response.PortResponse{
+		ContainerPort: port,
+		Protocol:      protocol,
+		HostPort:      port,
+	}
+	expectedNetworkResponse = response.Network{
+		NetworkMode:   networkMode,
+		IPv4Addresses: []string{eniIPv4Address},
+	}
+	expectedVolumeResponse = response.VolumeResponse{
+		DockerName:  volName,
+		Source:      volSource,
+		Destination: volDestination,
+	}
+	expectedContainerResponse = ContainerResponse{
+		DockerID:   containerID,
+		DockerName: containerName,
+		Name:       containerName,
+		Image:      imageName,
+		ImageID:    imageID,
+		CreatedAt:  &containerTimeUTC,
+		StartedAt:  &containerTimeUTC,
+		Ports: []response.PortResponse{
+			expectedPortResponse,
+		},
+		Networks: []response.Network{
+			expectedNetworkResponse,
+		},
+		Volumes: []response.VolumeResponse{
+			expectedVolumeResponse,
 		},
 	}
+	expectedTaskResponse = TaskResponse{
+		Arn:           taskARN,
+		DesiredStatus: status,
+		KnownStatus:   status,
+		Family:        family,
+		Version:       version,
+		Containers: []ContainerResponse{
+			expectedContainerResponse,
+		},
+	}
+)
 
+func TestTaskResponse(t *testing.T) {
 	task := &apitask.Task{
 		Arn:                 taskARN,
 		Family:              family,
@@ -98,7 +115,9 @@ func TestTaskResponse(t *testing.T) {
 	}
 
 	container := &apicontainer.Container{
-		Name: containerName,
+		Name:    containerName,
+		Image:   imageName,
+		ImageID: imageID,
 		Ports: []apicontainer.PortBinding{
 			{
 				ContainerPort: 80,
@@ -113,6 +132,9 @@ func TestTaskResponse(t *testing.T) {
 			},
 		},
 	}
+
+	container.SetCreatedAt(containerTime)
+	container.SetStartedAt(containerTime)
 
 	containerNameToDockerContainer := map[string]*apicontainer.DockerContainer{
 		taskARN: {
@@ -124,45 +146,17 @@ func TestTaskResponse(t *testing.T) {
 
 	taskResponse := NewTaskResponse(task, containerNameToDockerContainer)
 
-	taskResponseJSON, err := json.Marshal(taskResponse)
+	_, err := json.Marshal(taskResponse)
 	assert.NoError(t, err)
 
-	taskResponseMap := make(map[string]interface{})
-
-	json.Unmarshal(taskResponseJSON, &taskResponseMap)
-
-	assert.Equal(t, expectedTaskResponseMap, taskResponseMap)
+	assert.Equal(t, expectedTaskResponse, *taskResponse)
 }
 
 func TestContainerResponse(t *testing.T) {
-	expectedContainerResponseMap := map[string]interface{}{
-		"DockerId":   "cid",
-		"DockerName": "sleepy",
-		"Name":       "sleepy",
-		"Ports": []interface{}{
-			map[string]interface{}{
-				"ContainerPort": float64(80),
-				"Protocol":      "tcp",
-				"HostPort":      float64(80),
-			},
-		},
-		"Networks": []interface{}{
-			map[string]interface{}{
-				"NetworkMode":   "awsvpc",
-				"IPv4Addresses": []interface{}{"10.0.0.2"},
-			},
-		},
-		"Volumes": []interface{}{
-			map[string]interface{}{
-				"DockerName":  volName,
-				"Source":      volSource,
-				"Destination": volDestination,
-			},
-		},
-	}
-
 	container := &apicontainer.Container{
-		Name: containerName,
+		Name:    containerName,
+		Image:   imageName,
+		ImageID: imageID,
 		Ports: []apicontainer.PortBinding{
 			{
 				ContainerPort: 80,
@@ -177,6 +171,9 @@ func TestContainerResponse(t *testing.T) {
 			},
 		},
 	}
+
+	container.SetCreatedAt(containerTime)
+	container.SetStartedAt(containerTime)
 
 	dockerContainer := &apicontainer.DockerContainer{
 		DockerID:   containerID,
@@ -194,14 +191,10 @@ func TestContainerResponse(t *testing.T) {
 
 	containerResponse := NewContainerResponse(dockerContainer, eni)
 
-	containerResponseJSON, err := json.Marshal(containerResponse)
+	_, err := json.Marshal(containerResponse)
 	assert.NoError(t, err)
 
-	containerResponseMap := make(map[string]interface{})
-
-	json.Unmarshal(containerResponseJSON, &containerResponseMap)
-
-	assert.Equal(t, expectedContainerResponseMap, containerResponseMap)
+	assert.Equal(t, expectedContainerResponse, containerResponse)
 }
 
 func TestPortBindingsResponse(t *testing.T) {
@@ -221,10 +214,7 @@ func TestPortBindingsResponse(t *testing.T) {
 	}
 
 	PortBindingsResponse := NewPortBindingsResponse(dockerContainer, nil)
-
-	assert.Equal(t, uint16(80), PortBindingsResponse[0].ContainerPort)
-	assert.Equal(t, uint16(80), PortBindingsResponse[0].HostPort)
-	assert.Equal(t, "tcp", PortBindingsResponse[0].Protocol)
+	assert.Equal(t, expectedPortResponse, PortBindingsResponse[0])
 }
 
 func TestVolumesResponse(t *testing.T) {
@@ -244,8 +234,5 @@ func TestVolumesResponse(t *testing.T) {
 	}
 
 	VolumesResponse := NewVolumesResponse(dockerContainer)
-
-	assert.Equal(t, volName, VolumesResponse[0].DockerName)
-	assert.Equal(t, volSource, VolumesResponse[0].Source)
-	assert.Equal(t, volDestination, VolumesResponse[0].Destination)
+	assert.Equal(t, expectedVolumeResponse, VolumesResponse[0])
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR adds the following container metadata to the introspection response:
- Container ImageName
- Container ImageID
- Container CreatedAt
- Container StartedAt

The above metadata is available via task metadata endpoint. This change fills the gap in the introspection response. 

### Implementation details
<!-- How are the changes implemented? -->
Updated the v1 handler container response. Note that this doesn't alter task metadata endpoint v1 since that has been moved to the ecs-agent directory.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

- Updated the unit tests for task and container response.
- Tested a custom ECS agent build and verified that the introspection response now has the new metadata. 

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

enhancement: adding new container metadata to the introspection response

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
