### PR TITLE
Allow variables to be set to empty string in envFiles

### DIFF
--- a/agent/taskresource/envFiles/envfile.go
+++ b/agent/taskresource/envFiles/envfile.go
@@ -570,11 +570,11 @@ func (envfile *EnvironmentFileResource) readEnvVarsFromFile(envfilePath string) 
 		// only read the line that has "="
 		if strings.Contains(line, envVariableDelimiter) {
 			variables := strings.SplitN(line, envVariableDelimiter, 2)
-			// verify that there is at least a character on each side
-			if len(variables[0]) > 0 && len(variables[1]) > 0 {
+			// verify that the key is non-empty, the value can be empty
+			if len(variables[0]) > 0 {
 				envVars[variables[0]] = variables[1]
 			} else {
-				seelog.Infof("Not applying line %d of environment file %s, key or value is empty.", lineNum, envfilePath)
+				seelog.Infof("Not applying line %d of environment file %s, key is empty.", lineNum, envfilePath)
 			}
 		}
 	}

--- a/agent/taskresource/envFiles/envfile_test.go
+++ b/agent/taskresource/envFiles/envfile_test.go
@@ -319,6 +319,7 @@ func TestReadEnvVarsFromEnvfiles(t *testing.T) {
 
 	envfileContentLine1 := "key1=value"
 	envFileContentLine2 := "key2=val1=val2"
+	envFileContentLine3 := "key3="
 
 	tempOpen := open
 	open = func(name string) (oswrapper.File, error) {
@@ -333,6 +334,8 @@ func TestReadEnvVarsFromEnvfiles(t *testing.T) {
 		mockScanner.EXPECT().Text().Return(envfileContentLine1),
 		mockScanner.EXPECT().Scan().Return(true),
 		mockScanner.EXPECT().Text().Return(envFileContentLine2),
+		mockScanner.EXPECT().Scan().Return(true),
+		mockScanner.EXPECT().Text().Return(envFileContentLine3),
 		mockScanner.EXPECT().Scan().Return(false),
 		mockScanner.EXPECT().Err().Return(nil),
 	)
@@ -343,6 +346,9 @@ func TestReadEnvVarsFromEnvfiles(t *testing.T) {
 	assert.Equal(t, 1, len(envVarsList))
 	assert.Equal(t, "value", envVarsList[0]["key1"])
 	assert.Equal(t, "val1=val2", envVarsList[0]["key2"])
+	key3Value, ok := envVarsList[0]["key3"]
+	assert.True(t, ok)
+	assert.Equal(t, "", key3Value)
 }
 
 func TestReadEnvVarsCommentFromEnvfiles(t *testing.T) {


### PR DESCRIPTION

### Summary
We currently have environment variables set to empty such as `SIDEKIQ_PRELOAD=` see [issue](https://github.com/sidekiq/sidekiq/issues/4766). This works fine when passing in the variable via task definition but breaks when using environment files.

### Implementation details
No longer ignore variables that have an empty value.

### Testing
Extended existing test to allow empty variables and confirm the variable exists in the returned map when parsing the environment file.
New tests cover the changes: yes

### Description for the changelog
Allow variables to be set to the empty string when using environment files

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
